### PR TITLE
add liquid-glass-card skill

### DIFF
--- a/skills/liquid-glass-card/SKILL.md
+++ b/skills/liquid-glass-card/SKILL.md
@@ -19,6 +19,7 @@ od:
   platform: desktop
   scenario: design
   upstream: "https://kokonutui.com/docs/cards/liquid-glass-card"
+  example_prompt: "Build a liquid-glass 'now playing' card over a warm sunset-gradient background: a frosted glass panel with a track title, artist, a progress slider, and a pill-shaped play button, so the gradient visibly bends through the glass. Then re-tokenize the --lg-* variables to my brand and verify it against references/checklist.md."
   preview:
     type: html
     entry: index.html
@@ -29,6 +30,7 @@ od:
 # liquid-glass-card
 
 > Adapted from KokonutUI (MIT, @dorianbaffier) — https://kokonutui.com/docs/cards/liquid-glass-card
+> Full MIT license and attribution: [`references/LICENSE`](references/LICENSE).
 
 ## What it does
 
@@ -59,6 +61,15 @@ Buttons use the same recipe with `border-radius: 999px` and a stronger displacem
   shadcn/ui `Button` + `Card`, `cn`, `cva`, `lucide-react`, Tailwind v4, and
   `next/image` (swap for `<img>` outside Next). Install via
   `bunx shadcn@latest add @kokonutui/liquid-glass-card` in real app repos.
+
+## Before emitting (required gate)
+
+Before you emit the artifact, run **every P0 gate** in
+[`references/checklist.md`](references/checklist.md): distortion visible over a
+non-flat background, isolated stacking context on each glass root, non-Chromium
+fallback wired, WCAG-AA contrast against the effective backdrop, and `--lg-*`
+tokenized to the active brand. If any P0 gate fails, fix the output and re-check —
+do not ship a glass surface that fails one.
 
 ## Constraints
 

--- a/skills/liquid-glass-card/SKILL.md
+++ b/skills/liquid-glass-card/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: liquid-glass-card
+description: |
+  Apple-style "liquid glass" card and pill-button treatment from KokonutUI: an SVG
+  feTurbulence + feDisplacementMap filter applied as a backdrop-filter so the content
+  behind the surface bends like liquid, plus a layered inset-shadow stack for the
+  glass edge highlights and a soft 2px backdrop blur. Ships a dependency-free
+  HTML/CSS reference (example.html) and the original React/shadcn source
+  (liquid-glass-card.tsx).
+triggers:
+  - "liquid glass"
+  - "glass card"
+  - "glassmorphism card"
+  - "apple glass effect"
+  - "frosted glass button"
+  - "kokonutui"
+od:
+  mode: prototype
+  platform: desktop
+  scenario: design
+  upstream: "https://kokonutui.com/docs/cards/liquid-glass-card"
+  preview:
+    type: html
+    entry: index.html
+  design_system:
+    requires: false
+---
+
+# liquid-glass-card
+
+> Adapted from KokonutUI (MIT, @dorianbaffier) — https://kokonutui.com/docs/cards/liquid-glass-card
+
+## What it does
+
+Gives any card, button, dock, or panel the Apple-style **liquid glass** look. Three
+stacked ingredients, all in `example.html`:
+
+1. **Liquid distortion** — a hidden SVG filter (`feTurbulence → feGaussianBlur →
+   feDisplacementMap scale 30 → feGaussianBlur`) applied to a full-bleed layer via
+   `backdrop-filter: url(#liquid-glass-filter)`. This displaces whatever renders
+   *behind* the surface, which is what reads as "liquid".
+2. **Glass edge** — a pointer-events-none overlay carrying the layered inset
+   box-shadow stack (thin bright inner rims top-left/bottom-right, wide soft inner
+   glow, faint outer drop shadow).
+3. **Frost** — `backdrop-filter: blur(2px) saturate(1.15)` plus a ~6% white surface
+   tint on the element itself.
+
+Buttons use the same recipe with `border-radius: 999px` and a stronger displacement
+(`scale 70`, `#liquid-glass-filter-strong`).
+
+## How to use
+
+- **In any HTML artifact**: copy the `<svg>` filter defs once into the document, then
+  apply the `.liquid-glass` / `.liquid-glass-btn` pattern from `example.html`.
+  Re-tokenize the `--lg-*` custom properties to the active design system (canvas,
+  foreground, accent, radius) — do NOT keep the demo's NIX-flavored defaults on
+  other brands.
+- **In React projects**: use `liquid-glass-card.tsx` (original source). It expects
+  shadcn/ui `Button` + `Card`, `cn`, `cva`, `lucide-react`, Tailwind v4, and
+  `next/image` (swap for `<img>` outside Next). Install via
+  `bunx shadcn@latest add @kokonutui/liquid-glass-card` in real app repos.
+
+## Constraints
+
+- The effect only reads on **busy or gradient backgrounds** — over a flat solid
+  color the displacement is invisible. Place glass surfaces over imagery, auras,
+  or gradients.
+- `backdrop-filter: url(#…)` is **Chromium-only**; Safari/Firefox get the graceful
+  fallback (blur + saturate + edge shadows) already wired in `example.html`. Never
+  rely on the distortion alone to convey information.
+- Keep one shared filter def per document; per-element filters at high `scale`
+  are GPU-costly. Avoid animating the filter itself.
+- The inset-shadow stack above is the dark-canvas variant. On light canvases use
+  the light stack from the TSX (`GLASS_SHADOW_LIGHT`, black-based insets).

--- a/skills/liquid-glass-card/example.html
+++ b/skills/liquid-glass-card/example.html
@@ -1,0 +1,152 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Liquid Glass Card — reference implementation</title>
+<style>
+  :root {
+    /* Swap these for the active design system's tokens */
+    --lg-canvas: #0a0e0c;
+    --lg-fg: #fffaea;
+    --lg-fg-muted: #aab5a9;
+    --lg-accent: #fe9730;
+    --lg-radius: 20px;
+    --lg-surface-tint: rgba(255, 255, 255, 0.06);
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    font-family: Geist, Inter, system-ui, -apple-system, sans-serif;
+    color: var(--lg-fg);
+    background:
+      radial-gradient(60% 50% at 20% 10%, rgba(254, 151, 48, 0.35), transparent 60%),
+      radial-gradient(50% 45% at 85% 25%, rgba(100, 245, 163, 0.18), transparent 60%),
+      radial-gradient(70% 60% at 60% 90%, rgba(253, 251, 121, 0.12), transparent 55%),
+      var(--lg-canvas);
+  }
+
+  .stage { display: grid; gap: 28px; padding: 48px 24px; justify-items: center; }
+
+  /* ── Liquid glass card ─────────────────────────────────────────────── */
+  .liquid-glass {
+    position: relative;
+    overflow: hidden;
+    isolation: isolate;
+    border-radius: var(--lg-radius);
+    padding: 28px;
+    max-width: 380px;
+    background: var(--lg-surface-tint);
+    -webkit-backdrop-filter: blur(2px) saturate(1.15); /* Safari/Firefox fallback */
+    backdrop-filter: blur(2px) saturate(1.15);
+    transition: transform 0.3s ease;
+  }
+  /* Layer 1: the liquid distortion (Chromium honors url() backdrop-filters) */
+  .liquid-glass::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    border-radius: inherit;
+    -webkit-backdrop-filter: url(#liquid-glass-filter);
+    backdrop-filter: url(#liquid-glass-filter);
+    pointer-events: none;
+  }
+  /* Layer 2: the layered inset "glass edge" shadow stack (from KokonutUI) */
+  .liquid-glass::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    box-shadow:
+      0 0 8px rgba(0, 0, 0, 0.03),
+      0 2px 6px rgba(0, 0, 0, 0.08),
+      inset 3px 3px 0.5px -3.5px rgba(255, 255, 255, 0.09),
+      inset -3px -3px 0.5px -3.5px rgba(255, 255, 255, 0.85),
+      inset 1px 1px 1px -0.5px rgba(255, 255, 255, 0.6),
+      inset -1px -1px 1px -0.5px rgba(255, 255, 255, 0.6),
+      inset 0 0 6px 6px rgba(255, 255, 255, 0.12),
+      inset 0 0 2px 2px rgba(255, 255, 255, 0.06),
+      0 0 12px rgba(0, 0, 0, 0.15);
+  }
+  .liquid-glass:hover { transform: translateY(-2px); }
+
+  /* ── Liquid glass pill button ──────────────────────────────────────── */
+  .liquid-glass-btn {
+    position: relative;
+    overflow: hidden;
+    isolation: isolate;
+    border: 0;
+    border-radius: 999px;
+    padding: 12px 26px;
+    font: inherit;
+    font-weight: 600;
+    color: var(--lg-fg);
+    background: var(--lg-surface-tint);
+    cursor: pointer;
+    -webkit-backdrop-filter: blur(2px);
+    backdrop-filter: blur(2px);
+    transition: transform 0.3s ease;
+    box-shadow:
+      inset 2px 2px 0.5px -2px rgba(255, 255, 255, 0.5),
+      inset -2px -2px 0.5px -2px rgba(255, 255, 255, 0.5),
+      inset 0 0 6px 4px rgba(255, 255, 255, 0.1),
+      0 0 12px rgba(0, 0, 0, 0.2);
+  }
+  .liquid-glass-btn::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    border-radius: inherit;
+    -webkit-backdrop-filter: url(#liquid-glass-filter-strong);
+    backdrop-filter: url(#liquid-glass-filter-strong);
+    pointer-events: none;
+  }
+  .liquid-glass-btn:hover { transform: scale(1.05); }
+  .liquid-glass-btn.accent { color: #1a1206; background: color-mix(in srgb, var(--lg-accent) 82%, transparent); }
+
+  .liquid-glass h2 { margin: 0 0 8px; font-size: 20px; }
+  .liquid-glass p { margin: 0 0 20px; color: var(--lg-fg-muted); font-size: 14px; line-height: 1.6; }
+  .row { display: flex; gap: 12px; }
+</style>
+</head>
+<body>
+  <!-- The liquid distortion filter (shared; one per document is enough).
+       feTurbulence noise displaces whatever is BEHIND the element via
+       backdrop-filter: url(#id) — that displacement is the "liquid" look. -->
+  <svg aria-hidden="true" style="position:absolute;width:0;height:0">
+    <defs>
+      <filter id="liquid-glass-filter" color-interpolation-filters="sRGB" x="-50%" y="-50%" width="200%" height="200%">
+        <feTurbulence type="fractalNoise" baseFrequency="0.05 0.05" numOctaves="1" seed="1" result="turbulence"/>
+        <feGaussianBlur in="turbulence" stdDeviation="2" result="blurredNoise"/>
+        <feDisplacementMap in="SourceGraphic" in2="blurredNoise" scale="30" xChannelSelector="R" yChannelSelector="B" result="displaced"/>
+        <feGaussianBlur in="displaced" stdDeviation="4" result="finalBlur"/>
+        <feComposite in="finalBlur" in2="finalBlur" operator="over"/>
+      </filter>
+      <filter id="liquid-glass-filter-strong" color-interpolation-filters="sRGB" x="-50%" y="-50%" width="200%" height="200%">
+        <feTurbulence type="fractalNoise" baseFrequency="0.05 0.05" numOctaves="1" seed="1" result="turbulence"/>
+        <feGaussianBlur in="turbulence" stdDeviation="2" result="blurredNoise"/>
+        <feDisplacementMap in="SourceGraphic" in2="blurredNoise" scale="70" xChannelSelector="R" yChannelSelector="B" result="displaced"/>
+        <feGaussianBlur in="displaced" stdDeviation="4" result="finalBlur"/>
+        <feComposite in="finalBlur" in2="finalBlur" operator="over"/>
+      </filter>
+    </defs>
+  </svg>
+
+  <div class="stage">
+    <div class="liquid-glass">
+      <h2>Liquid Glass</h2>
+      <p>Apple-style glass card: turbulence-displaced backdrop, layered inset edge highlights, and a soft blur. Everything behind this card bends like liquid.</p>
+      <div class="row">
+        <button class="liquid-glass-btn accent" type="button">Primary</button>
+        <button class="liquid-glass-btn" type="button">Secondary</button>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/skills/liquid-glass-card/liquid-glass-card.tsx
+++ b/skills/liquid-glass-card/liquid-glass-card.tsx
@@ -1,0 +1,420 @@
+"use client";
+
+/**
+ * @author: @dorianbaffier
+ * @description: Liquid Glass Card - Optimized with Shadcn UI
+ * @version: 2.0.0
+ * @date: 2025-10-11
+ * @license: MIT
+ * @website: https://kokonutui.com
+ * @github: https://github.com/kokonut-labs/kokonutui
+ */
+
+import { cva, type VariantProps } from "class-variance-authority";
+import { ArrowLeft, ArrowRight, Pause, Play } from "lucide-react";
+import Image from "next/image";
+import React from "react";
+import { Button, type ButtonProps } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+// Constants for better maintainability
+const GLASS_SHADOW_LIGHT =
+  "shadow-[0_0_6px_rgba(0,0,0,0.03),0_2px_6px_rgba(0,0,0,0.08),inset_3px_3px_0.5px_-3px_rgba(0,0,0,0.9),inset_-3px_-3px_0.5px_-3px_rgba(0,0,0,0.85),inset_1px_1px_1px_-0.5px_rgba(0,0,0,0.6),inset_-1px_-1px_1px_-0.5px_rgba(0,0,0,0.6),inset_0_0_6px_6px_rgba(0,0,0,0.12),inset_0_0_2px_2px_rgba(0,0,0,0.06),0_0_12px_rgba(255,255,255,0.15)]";
+
+const GLASS_SHADOW_DARK =
+  "dark:shadow-[0_0_8px_rgba(0,0,0,0.03),0_2px_6px_rgba(0,0,0,0.08),inset_3px_3px_0.5px_-3.5px_rgba(255,255,255,0.09),inset_-3px_-3px_0.5px_-3.5px_rgba(255,255,255,0.85),inset_1px_1px_1px_-0.5px_rgba(255,255,255,0.6),inset_-1px_-1px_1px_-0.5px_rgba(255,255,255,0.6),inset_0_0_6px_6px_rgba(255,255,255,0.12),inset_0_0_2px_2px_rgba(255,255,255,0.06),0_0_12px_rgba(0,0,0,0.15)]";
+
+const GLASS_SHADOW = `${GLASS_SHADOW_LIGHT} ${GLASS_SHADOW_DARK}`;
+
+const DEFAULT_GLASS_FILTER_SCALE = 30;
+const BUTTON_GLASS_FILTER_SCALE = 70;
+
+// Shared glass filter component
+interface GlassFilterProps {
+  id: string;
+  scale?: number;
+}
+
+const GlassFilter = React.memo(
+  ({ id, scale = DEFAULT_GLASS_FILTER_SCALE }: GlassFilterProps) => (
+    <svg className="hidden">
+      <title>Glass Effect Filter</title>
+      <defs>
+        <filter
+          colorInterpolationFilters="sRGB"
+          height="200%"
+          id={id}
+          width="200%"
+          x="-50%"
+          y="-50%"
+        >
+          <feTurbulence
+            baseFrequency="0.05 0.05"
+            numOctaves="1"
+            result="turbulence"
+            seed="1"
+            type="fractalNoise"
+          />
+          <feGaussianBlur
+            in="turbulence"
+            result="blurredNoise"
+            stdDeviation="2"
+          />
+          <feDisplacementMap
+            in="SourceGraphic"
+            in2="blurredNoise"
+            result="displaced"
+            scale={scale}
+            xChannelSelector="R"
+            yChannelSelector="B"
+          />
+          <feGaussianBlur in="displaced" result="finalBlur" stdDeviation="4" />
+          <feComposite in="finalBlur" in2="finalBlur" operator="over" />
+        </filter>
+      </defs>
+    </svg>
+  )
+);
+GlassFilter.displayName = "GlassFilter";
+
+// Liquid Button - extends shadcn Button with glass effect
+const liquidButtonVariants = cva("relative transition-transform duration-300", {
+  variants: {
+    liquidVariant: {
+      default: "hover:scale-105",
+      none: "",
+    },
+  },
+  defaultVariants: {
+    liquidVariant: "default",
+  },
+});
+
+export type LiquidButtonProps = ButtonProps & {
+  liquidVariant?: "default" | "none";
+};
+
+function LiquidButton({
+  className,
+  liquidVariant = "default",
+  children,
+  ...props
+}: LiquidButtonProps) {
+  const filterId = React.useId();
+
+  return (
+    <>
+      <Button
+        className={cn(liquidButtonVariants({ liquidVariant }), className)}
+        {...props}
+      >
+        <div
+          className={cn(
+            "pointer-events-none absolute inset-0 rounded-full transition-all",
+            GLASS_SHADOW
+          )}
+        />
+        <div
+          className="pointer-events-none absolute inset-0 isolate -z-10 overflow-hidden rounded-md"
+          style={{ backdropFilter: `url("#${filterId}")` }}
+        />
+        <span className="relative z-10">{children}</span>
+      </Button>
+      <GlassFilter id={filterId} scale={BUTTON_GLASS_FILTER_SCALE} />
+    </>
+  );
+}
+
+// Liquid Glass Card - extends shadcn Card with glass effect
+const liquidGlassCardVariants = cva(
+  "group relative overflow-hidden bg-background/20 backdrop-blur-[2px] transition-all duration-300",
+  {
+    variants: {
+      glassSize: {
+        sm: "p-4",
+        default: "p-6",
+        lg: "p-8",
+      },
+    },
+    defaultVariants: {
+      glassSize: "default",
+    },
+  }
+);
+
+export type LiquidGlassCardProps = React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof liquidGlassCardVariants> & {
+    glassEffect?: boolean;
+  };
+
+function LiquidGlassCard({
+  className,
+  glassSize,
+  glassEffect = true,
+  children,
+  ...props
+}: LiquidGlassCardProps) {
+  const filterId = React.useId();
+
+  return (
+    <Card
+      className={cn(liquidGlassCardVariants({ glassSize }), className)}
+      {...props}
+    >
+      <div
+        className={cn(
+          "pointer-events-none absolute inset-0 rounded-lg transition-all",
+          GLASS_SHADOW
+        )}
+      />
+
+      {glassEffect && (
+        <>
+          <div
+            className="pointer-events-none absolute inset-0 -z-10 overflow-hidden rounded-lg"
+            style={{ backdropFilter: `url("#${filterId}")` }}
+          />
+          <GlassFilter id={filterId} scale={DEFAULT_GLASS_FILTER_SCALE} />
+        </>
+      )}
+
+      <div className="relative z-10">{children}</div>
+
+      <div className="pointer-events-none absolute inset-0 z-20 rounded-lg bg-gradient-to-r from-transparent via-black/5 to-transparent opacity-0 transition-opacity duration-200 group-hover:opacity-100 dark:via-white/5" />
+    </Card>
+  );
+}
+
+// Demo: Music Player Card
+const TOTAL_DURATION = 45;
+const VOLUME_BAR_COUNT = 8;
+const SEEK_JUMP_SECONDS = 5;
+const TIMER_INTERVAL_MS = 1000;
+const STATIC_BAR_HEIGHT = "6px";
+const MIN_TIME = 0;
+const BAR_DELAY_INCREMENT = 0.1;
+const PROGRESS_PERCENTAGE_MULTIPLIER = 100;
+
+const formatTime = (timeInSeconds: number): string => {
+  const minutes = Math.floor(timeInSeconds / 60);
+  const seconds = Math.floor(timeInSeconds % 60);
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+};
+
+interface VolumeBarsProps {
+  isPlaying: boolean;
+}
+
+const VolumeBars = React.memo(({ isPlaying }: VolumeBarsProps) => {
+  const bars = Array.from({ length: VOLUME_BAR_COUNT }, (_, i) => ({
+    id: `bar-${i}`,
+    delay: i * BAR_DELAY_INCREMENT,
+  }));
+
+  return (
+    <div className="pointer-events-none flex h-8 w-10 items-end gap-0.5">
+      {bars.map((bar) => (
+        <div
+          className={cn(
+            "w-[3px] rounded-sm",
+            isPlaying && "animate-bounce-music"
+          )}
+          key={bar.id}
+          style={{
+            height: isPlaying ? undefined : STATIC_BAR_HEIGHT,
+            animationDelay: `${bar.delay}s`,
+            background: "linear-gradient(to top, #FF2E55, #FF6B88)",
+          }}
+        />
+      ))}
+    </div>
+  );
+});
+VolumeBars.displayName = "VolumeBars";
+
+interface ProgressBarProps {
+  currentTime: number;
+  totalDuration: number;
+  onSeek: (newTime: number) => void;
+}
+
+const ProgressBar = React.memo(
+  ({ currentTime, totalDuration, onSeek }: ProgressBarProps) => {
+    const progress =
+      (currentTime / totalDuration) * PROGRESS_PERCENTAGE_MULTIPLIER;
+
+    const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+      const bar = e.currentTarget;
+      const rect = bar.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const percent = x / rect.width;
+      const newTime = Math.min(
+        Math.max(MIN_TIME, percent * totalDuration),
+        totalDuration
+      );
+      onSeek(newTime);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        const newTime = Math.min(
+          currentTime + SEEK_JUMP_SECONDS,
+          totalDuration
+        );
+        onSeek(newTime);
+      }
+    };
+
+    return (
+      <>
+        <div className="flex justify-between font-medium text-xs text-zinc-500 dark:text-zinc-400">
+          <span className="tabular-nums">{formatTime(currentTime)}</span>
+          <span className="tabular-nums">{formatTime(totalDuration)}</span>
+        </div>
+        <div
+          aria-label="Seek progress bar"
+          aria-valuemax={totalDuration}
+          aria-valuemin={MIN_TIME}
+          aria-valuenow={currentTime}
+          className="relative z-10 h-1 w-full cursor-pointer overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-800"
+          onClick={handleClick}
+          onKeyDown={handleKeyDown}
+          role="slider"
+          tabIndex={0}
+        >
+          <div
+            className="h-full bg-gradient-to-r from-[#FF2E55] to-[#FF6B88] transition-all duration-200"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      </>
+    );
+  }
+);
+ProgressBar.displayName = "ProgressBar";
+
+export function NotificationCenter() {
+  const [isPlaying, setIsPlaying] = React.useState(true);
+  const [currentTime, setCurrentTime] = React.useState(MIN_TIME);
+
+  React.useEffect(() => {
+    if (!isPlaying || currentTime >= TOTAL_DURATION) {
+      return;
+    }
+
+    const intervalId = setInterval(() => {
+      setCurrentTime((prev) => {
+        if (prev >= TOTAL_DURATION) {
+          setIsPlaying(false);
+          return TOTAL_DURATION;
+        }
+        return prev + 1;
+      });
+    }, TIMER_INTERVAL_MS);
+
+    return () => clearInterval(intervalId);
+  }, [isPlaying, currentTime]);
+
+  const handlePlayPause = () => {
+    setIsPlaying((prev) => !prev);
+  };
+
+  const handleSeek = (newTime: number) => {
+    setCurrentTime(newTime);
+    if (newTime < TOTAL_DURATION && !isPlaying) {
+      setIsPlaying(true);
+    }
+  };
+
+  return (
+    <div className="w-full max-w-sm">
+      <LiquidGlassCard className="gap-3.5 rounded-3xl border border-zinc-200/60 bg-gradient-to-br from-zinc-50 to-zinc-100 p-4 shadow-xl dark:border-zinc-700/60 dark:from-zinc-900 dark:to-black">
+        <div className="flex items-center gap-3">
+          <div className="relative mr-2 mb-4 h-16 w-16 shrink-0 overflow-hidden rounded-2xl bg-gradient-to-br from-pink-400 via-pink-300 to-rose-200 shadow-lg ring-1 ring-black/5 dark:shadow-xl">
+            <Image
+              alt="Album Art for Glow by Echo"
+              className="h-full w-full object-cover"
+              height={64}
+              src="https://ferf1mheo22r9ira.public.blob.vercel-storage.com/portrait2-x5MjJSaQ9ed0HZrewEhH7TkZwjZ66K.jpeg"
+              width={64}
+            />
+          </div>
+
+          <div className="flex-1 overflow-hidden">
+            <h3 className="overflow-hidden text-ellipsis whitespace-nowrap font-semibold text-lg text-zinc-900 dark:text-white">
+              Glow
+            </h3>
+            <p className="mt-0.5 text-sm text-zinc-600 dark:text-zinc-400">
+              Echo
+            </p>
+          </div>
+
+          <VolumeBars isPlaying={isPlaying} />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <ProgressBar
+            currentTime={currentTime}
+            onSeek={handleSeek}
+            totalDuration={TOTAL_DURATION}
+          />
+
+          <div className="mt-1 flex items-center justify-between">
+            <div className="flex items-center justify-center gap-2">
+              <LiquidButton
+                aria-label="Previous track"
+                className="h-10 w-10 rounded-full bg-transparent text-zinc-700 transition-colors hover:bg-zinc-200/80 dark:text-zinc-300 dark:hover:bg-zinc-800/80"
+                size="icon"
+                variant="ghost"
+              >
+                <ArrowLeft className="size-4" />
+              </LiquidButton>
+              <LiquidButton
+                aria-label={isPlaying ? "Pause" : "Play"}
+                className="h-11 w-11 rounded-full bg-transparent text-zinc-700 transition-colors hover:bg-zinc-200/80 dark:text-zinc-300 dark:hover:bg-zinc-800/80"
+                onClick={handlePlayPause}
+                size="icon"
+                variant="ghost"
+              >
+                {isPlaying ? (
+                  <Pause className="size-5" />
+                ) : (
+                  <Play className="size-5" />
+                )}
+              </LiquidButton>
+              <LiquidButton
+                aria-label="Next track"
+                className="h-10 w-10 rounded-full bg-transparent text-zinc-700 transition-colors hover:bg-zinc-200/80 dark:text-zinc-300 dark:hover:bg-zinc-800/80"
+                size="icon"
+                variant="ghost"
+              >
+                <ArrowRight className="size-4" />
+              </LiquidButton>
+            </div>
+            <LiquidButton
+              aria-label="More options"
+              className="h-10 w-10 rounded-full bg-transparent text-zinc-700 transition-colors hover:bg-zinc-200/80 dark:text-zinc-300 dark:hover:bg-zinc-800/80"
+              size="icon"
+              variant="ghost"
+            >
+              <svg
+                className="size-4"
+                fill="currentColor"
+                viewBox="0 0 16 16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <title>Options</title>
+                <path d="M6.634 1.135A7 7 0 0 1 15 8a.5.5 0 0 1-1 0 6 6 0 1 0-6.5 5.98v-1.005A5 5 0 1 1 13 8a.5.5 0 0 1-1 0 4 4 0 1 0-4.5 3.969v-1.011A2.999 2.999 0 1 1 11 8a.5.5 0 0 1-1 0 2 2 0 1 0-2.5 1.936v-1.07a1 1 0 1 1 1 0V15.5a.5.5 0 0 1-1 0v-.518a7 7 0 0 1-.866-13.847" />
+              </svg>
+            </LiquidButton>
+          </div>
+        </div>
+      </LiquidGlassCard>
+    </div>
+  );
+}
+
+export { LiquidButton, LiquidGlassCard };
+export default NotificationCenter;

--- a/skills/liquid-glass-card/liquid-glass-card.tsx
+++ b/skills/liquid-glass-card/liquid-glass-card.tsx
@@ -79,7 +79,7 @@ const GlassFilter = React.memo(
 GlassFilter.displayName = "GlassFilter";
 
 // Liquid Button - extends shadcn Button with glass effect
-const liquidButtonVariants = cva("relative transition-transform duration-300", {
+const liquidButtonVariants = cva("relative isolate transition-transform duration-300", {
   variants: {
     liquidVariant: {
       default: "hover:scale-105",
@@ -128,7 +128,7 @@ function LiquidButton({
 
 // Liquid Glass Card - extends shadcn Card with glass effect
 const liquidGlassCardVariants = cva(
-  "group relative overflow-hidden bg-background/20 backdrop-blur-[2px] transition-all duration-300",
+  "group relative isolate overflow-hidden bg-background/20 backdrop-blur-[2px] transition-all duration-300",
   {
     variants: {
       glassSize: {
@@ -257,14 +257,33 @@ const ProgressBar = React.memo(
     };
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
-        const newTime = Math.min(
-          currentTime + SEEK_JUMP_SECONDS,
-          totalDuration
-        );
-        onSeek(newTime);
+      const clamp = (t: number) =>
+        Math.min(Math.max(MIN_TIME, t), totalDuration);
+      let next: number | null = null;
+      switch (e.key) {
+        case "ArrowRight":
+        case "ArrowUp":
+          next = clamp(currentTime + SEEK_JUMP_SECONDS);
+          break;
+        case "ArrowLeft":
+        case "ArrowDown":
+          next = clamp(currentTime - SEEK_JUMP_SECONDS);
+          break;
+        case "Home":
+          next = MIN_TIME;
+          break;
+        case "End":
+          next = totalDuration;
+          break;
+        case "Enter":
+        case " ":
+          next = clamp(currentTime + SEEK_JUMP_SECONDS);
+          break;
+        default:
+          return;
       }
+      e.preventDefault();
+      onSeek(next);
     };
 
     return (
@@ -278,6 +297,7 @@ const ProgressBar = React.memo(
           aria-valuemax={totalDuration}
           aria-valuemin={MIN_TIME}
           aria-valuenow={currentTime}
+          aria-valuetext={`${formatTime(currentTime)} of ${formatTime(totalDuration)}`}
           className="relative z-10 h-1 w-full cursor-pointer overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-800"
           onClick={handleClick}
           onKeyDown={handleKeyDown}
@@ -306,7 +326,11 @@ export function NotificationCenter() {
 
     const intervalId = setInterval(() => {
       setCurrentTime((prev) => {
-        if (prev >= TOTAL_DURATION) {
+        // Pause on the tick that REACHES the end. Guarding on `>= TOTAL_DURATION`
+        // never fires: the 44→45 tick returns 45, the effect guard then early-
+        // returns and clears the interval before another tick can run, leaving
+        // the UI stuck on "Pause". Detect the final tick one step early.
+        if (prev >= TOTAL_DURATION - 1) {
           setIsPlaying(false);
           return TOTAL_DURATION;
         }

--- a/skills/liquid-glass-card/references/LICENSE
+++ b/skills/liquid-glass-card/references/LICENSE
@@ -1,0 +1,30 @@
+MIT License
+
+Copyright (c) 2025 kokonutUI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+This skill vendors the Liquid Glass Card component from KokonutUI
+(https://kokonutui.com/docs/cards/liquid-glass-card, https://github.com/kokonut-labs/kokonutui),
+authored by @dorianbaffier, under the MIT license reproduced above. The
+`liquid-glass-card.tsx` source retains its original attribution header. The
+`example.html` reference implementation in this folder is an original,
+dependency-free re-expression of the same technique.

--- a/skills/liquid-glass-card/references/checklist.md
+++ b/skills/liquid-glass-card/references/checklist.md
@@ -1,0 +1,34 @@
+# Liquid-glass — pre-emit checklist (P0 gates)
+
+Run every gate below **before** emitting the artifact. Each is a hard gate: if
+it fails, fix the output and re-check — do not ship a glass surface that fails
+any P0 item.
+
+## P0 — must pass
+
+1. **Distortion is visible.** The glass surface sits over imagery, an aura, or a
+   gradient — never a flat solid fill (over a flat color the `feDisplacementMap`
+   has nothing to bend and the effect reads as a plain blurred box).
+2. **Stacking context is isolated.** Every glass root sets `isolate` (or an
+   equivalent non-negative layering) so the `-z-10` distortion layer paints
+   over the container background, not behind it or an ancestor.
+3. **Fallback is wired.** A non-Chromium fallback is present: `backdrop-filter:
+   blur() saturate()` plus the inset edge-shadow stack render a legible glass
+   surface even when `backdrop-filter: url(#…)` is unsupported (Safari/Firefox).
+   No information is conveyed by the distortion alone.
+4. **Contrast holds.** Foreground text on the glass surface meets WCAG AA (4.5:1
+   for body, 3:1 for large text) against the *effective* backdrop, not just the
+   tint. Verify against the busiest region of the background behind the card.
+5. **Tokenized to the active brand.** The `--lg-*` custom properties (canvas,
+   foreground, accent, radius) are set from the active DESIGN.md — the demo's
+   NIX-flavored defaults are not shipped on another brand.
+
+## P1 — should pass
+
+6. **Responsive.** The surface holds at mobile widths (≤380px): padding, radius,
+   and any control row reflow without clipping; touch targets ≥44px.
+7. **Interactive controls are accessible.** Any slider/button carries correct
+   ARIA and full keyboard support (a `role="slider"` handles Arrow/Home/End,
+   not just Enter/Space) — or is a native control.
+8. **Motion restraint.** The filter itself is not animated (GPU-costly); one
+   shared `<filter>` def per document, referenced by id.


### PR DESCRIPTION
## Why

I built this while working on dark-first design systems in OD and kept wanting an Apple-style "liquid glass" surface for cards and CTAs. It's a genuinely reusable technique (the glass distortion + edge-highlight recipe is fiddly to get right by hand), so it seemed worth contributing as a skill rather than re-deriving it each time. Adapted from KokonutUI (MIT, credited in `SKILL.md` and in the source header).

## What users will see

A new **liquid-glass-card** entry in Settings → Skills (mode `prototype`). Triggers on "liquid glass", "glass card", "glassmorphism card", "apple glass effect", etc. When invoked, the agent gets the recipe plus a live `example.html` preview: a glass card and pill buttons distorting the gradient behind them. The skill body documents re-tokenizing the effect to the active DESIGN.md rather than keeping the demo palette.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [x] **Extension point** — new `skills/liquid-glass-card/` entry (functional skill, `od.mode: prototype`, self-contained `example.html`, `design_system.requires: false`).
- [ ] **i18n keys** — none needed; skill display copy falls back to English (verified `apps/web` `content.test.ts` still green).
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

The skill's own `example.html` is the preview — it renders live in Settings → Skills (`/api/skills/liquid-glass-card/example`). It shows a frosted glass card with two pill buttons over a warm gradient; on Chromium the backdrop visibly bends (SVG `url()` filter), and Safari/Firefox fall back to a blur + edge-shadow treatment.

## Notes for reviewers

- **Attribution / license**: adapted from [KokonutUI](https://kokonutui.com/docs/cards/liquid-glass-card) (MIT, @dorianbaffier). Credit is in `SKILL.md` and the `liquid-glass-card.tsx` header is preserved intact.
- **Two files ship alongside `SKILL.md`**: `example.html` (dependency-free HTML/CSS, the OD-facing artifact) and `liquid-glass-card.tsx` (the original React/shadcn source, for real app repos — not executed by OD).
- **Conformed to the catalogue schema**: `od.mode: prototype`, `preview: {type: html, entry: index.html}`, `design_system.requires: false`; passes the skill-submission validator and `pnpm guard`.
- Totally understand if a vendored-component skill isn't the direction you want for the catalogue vs. a stub pointing at KokonutUI — happy to convert it to a lightweight stub if you'd prefer.


## Validation

- `bash scripts/validate-skill-submission.sh skills/liquid-glass-card` — all PASS (SKILL.md, frontmatter `name`/`description`, all relative refs resolve inside the folder — now including `references/LICENSE` and `references/checklist.md`).
- `pnpm guard` — clean.
- Daemon `/api/skills` parses the entry as `mode: prototype` with `examplePrompt` populated; `/api/skills/liquid-glass-card/example` serves `200` (the preview renders).

## Update — review follow-up (@nettee)

- **License (blocking):** added `references/LICENSE` with the full upstream MIT text (`Copyright (c) 2025 kokonutUI`) and linked it from `SKILL.md`; the `.tsx` retains its attribution header.
- **Packaging (blocking):** added `references/checklist.md` (P0 pre-emit gates), a required **Before emitting** step in `SKILL.md` that routes the workflow through it, and a concrete `od.example_prompt`.
- **Stacking context (blocking):** added `isolate` to both glass roots (`liquidGlassCardVariants`, `liquidButtonVariants`) so the `-z-10` distortion layer paints over the card background, matching the working `example.html`.
- **Music player (non-blocking):** now pauses on the tick that reaches the end (`prev >= TOTAL_DURATION - 1`).
- **Slider a11y (non-blocking):** implemented the full slider key contract (Arrow/Home/End, kept Enter/Space) with clamped values + `aria-valuetext`.

Note on the two non-blocking items: `skills/` is content (not covered by the daemon/web test suites), so there's no existing harness for a fake-timer/RTL regression test on the vendored `.tsx`. Happy to add one if you'd like a test-infra path for skill components, but I didn't want to introduce a new toolchain under `skills/` unprompted.
