### PR TITLE
fix(web): keep loaded config when re-persisting a downgraded protocol fails

### DIFF
--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -755,7 +755,15 @@ export function loadConfig(): AppConfig {
     }
 
     if (migratedConfig || downgradedUnsupportedChatProtocol) {
-      saveConfig(merged);
+      // Best-effort re-persist of the migrated / downgraded config. A localStorage
+      // write failure here (quota exceeded, private-mode storage disabled) must not
+      // fall through to the outer catch and discard the valid config we just
+      // parsed — that would silently reset the user to defaults for the session.
+      try {
+        saveConfig(merged);
+      } catch {
+        // keep the parsed config even if it could not be written back
+      }
     }
 
     return merged;

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -1012,6 +1012,37 @@ describe('loadConfig', () => {
     expect(config.configMigrationVersion).toBe(2);
   });
 
+  it('keeps the parsed config when re-persisting a downgraded protocol fails', () => {
+    // A stored `bedrock` protocol is downgraded on load, which re-persists via
+    // saveConfig(). If that localStorage write throws (quota / private mode),
+    // the valid parsed config must survive rather than being reset to defaults.
+    const persisted: Partial<AppConfig> = {
+      mode: 'api',
+      apiProtocol: 'bedrock',
+      apiKey: 'sk-secret',
+      baseUrl: 'https://bedrock-runtime.us-east-1.amazonaws.com',
+      model: 'anthropic.claude-3',
+      configMigrationVersion: 1,
+      agentId: null,
+      skillId: null,
+      designSystemId: null,
+    };
+    store.set('open-design:config', JSON.stringify(persisted));
+    const setItem = vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+      throw new DOMException('exceeded', 'QuotaExceededError');
+    });
+    try {
+      const config = loadConfig();
+      // the unsupported protocol was still downgraded ...
+      expect(config.apiProtocol).toBe(DEFAULT_CONFIG.apiProtocol);
+      // ... but the rest of the user's config was NOT discarded to defaults
+      expect(config.mode).toBe('api');
+    } finally {
+      setItem.mockRestore();
+    }
+  });
+
+
   it('backfills the fixed-origin base URL for AIHubMix when persisted empty', () => {
     // AIHubMix hides the Base URL field, so older configs persisted an empty
     // baseUrl. An empty base URL blocks the live model-list fetch, so loadConfig


### PR DESCRIPTION
## Why

Scratching an itch found while auditing the web client's local-state persistence. `loadConfig()` can silently reset a user's whole saved configuration to defaults for the session when a `localStorage` write fails — a data-loss papercut that is invisible until the user notices their settings reverted.

## What users will see

Users whose browser rejects a `localStorage` write (storage quota exceeded, or private-mode storage disabled) no longer have their saved settings silently reset to defaults after a Bedrock-protocol config is auto-downgraded on load. The config is preserved for the session instead.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/state/config.test.ts` → "keeps the parsed config when re-persisting a downgraded protocol fails"
- Did the test go red on `main` and green on this branch? **yes** — red: the stored config resets so `mode` becomes the default `daemon`; green: `mode` stays `api`.

## Validation

- `pnpm --filter @open-design/web test` for `tests/state/config.test.ts` (56/56 green) plus `tsc` on the changed file. Full `pnpm guard` / `pnpm typecheck` left to CI (workspace deps only partially installed locally).

---

`loadConfig()` wraps its whole body in a `try/catch` that returns `DEFAULT_CONFIG`. When a stored config carries an unsupported chat protocol (Bedrock), the loader downgrades it and re-persists the result inline via `saveConfig(merged)` — still inside that `try`. If the `localStorage` write throws, the exception fell through to the outer `catch` and the user's valid, already-parsed config was discarded and reset to defaults. The inline `saveConfig(merged)` is now wrapped in its own `try/catch`, so a best-effort re-persist failure no longer takes the parsed config down with it — the downgrade still applies in memory, it just may not be written back.
