### PR TITLE
fix(daemon): allow Grok Build headless edits

### DIFF
--- a/apps/daemon/src/runtimes/defs/grok-build.ts
+++ b/apps/daemon/src/runtimes/defs/grok-build.ts
@@ -74,12 +74,19 @@ export const grokBuildAgentDef = {
   ],
   // Grok Build CLI v0.1.212+ enforces `-p, --single <PROMPT>` as value-
   // required, while normal OD composed prompts exceed safe argv budgets.
-  // Use the CLI's explicit prompt-file transport instead.
+  // Use the CLI's explicit prompt-file transport instead. Headless runs also
+  // need plan mode disabled and tool calls auto-approved: otherwise a write
+  // request is permission-cancelled while the CLI still exits successfully.
   buildArgs: (_prompt, _imagePaths, _extra = [], options = {}, runtimeContext = {}) => {
     if (!runtimeContext.promptFilePath) {
       throw new Error('grok-build requires runtimeContext.promptFilePath');
     }
-    const args = ['--prompt-file', runtimeContext.promptFilePath];
+    const args = [
+      '--prompt-file',
+      runtimeContext.promptFilePath,
+      '--no-plan',
+      '--always-approve',
+    ];
     if (options.model && options.model !== DEFAULT_MODEL_OPTION.id) {
       args.push('--model', options.model);
     }

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -839,6 +839,8 @@ test('grok-build uses --prompt-file and never embeds the prompt in argv or stdin
   assert.deepEqual(args, [
     '--prompt-file',
     promptFilePath,
+    '--no-plan',
+    '--always-approve',
     '--model',
     'grok-4.3',
   ]);
@@ -847,6 +849,13 @@ test('grok-build uses --prompt-file and never embeds the prompt in argv or stdin
   assert.equal(args.includes('-p'), false);
   assert.equal(args.includes('--single'), false);
   assert.equal(args.filter((entry) => entry === '--prompt-file').length, 1);
+});
+
+test('grok-build disables plan mode and auto-approves headless tool calls (issue #5507)', () => {
+  const promptFilePath = '/tmp/od-grok-prompt/prompt.md';
+  const args = grokBuild.buildArgs('', [], [], { model: 'grok-build' }, { promptFilePath });
+
+  assert.deepEqual(args.slice(2, 4), ['--no-plan', '--always-approve']);
 });
 
 test('grok-build omits effort for default/build models but keeps it for reasoning models', () => {
@@ -861,6 +870,8 @@ test('grok-build omits effort for default/build models but keeps it for reasonin
   assert.deepEqual(reasoningArgs, [
     '--prompt-file',
     promptFilePath,
+    '--no-plan',
+    '--always-approve',
     '--model',
     'grok-4.20-reasoning',
     '--effort',


### PR DESCRIPTION
Fixes #5507

## Why

Grok Build headless runs can narrate a file edit, exit 0, and leave the target unchanged. Grok's structured output identifies the turn as `PermissionCancelled`, but the current plain-stream adapter sees only the successful process exit and marks the Open Design run as succeeded.

The Grok CLI needs plan mode disabled for unattended implementation turns, and its documented headless approval flag enabled. Without both controls, tool execution can stop at an approval boundary that Open Design cannot answer.

## What users will see

Grok Build runs that request project edits now apply those edits instead of finishing as a successful no-op at an unattended plan or permission boundary. There is no new UI or setting.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## What changed

- pass `--no-plan` to prevent unattended runs from stopping at plan approval
- pass `--always-approve` so headless tool calls do not wait for an interactive prompt
- add regression coverage pinning both flags in the Grok Build argv contract

## Screenshots

N/A — no UI changes.

## Bug fix verification

- Test path: `apps/daemon/tests/runtimes/agent-args.test.ts`
- RED: the new regression test failed on `main` because the adapter emitted `--model grok-build` where `--no-plan --always-approve` were required.
- GREEN: the focused test passes on this branch with all 44 assertions green.
- Direct Grok CLI 0.2.93 repro: adapter-equivalent invocation left `BEFORE` unchanged; adding `--no-plan --always-approve` changed it to `AFTER`.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/runtimes/agent-args.test.ts` — 44 passed
- `pnpm typecheck` — passed
- CI workflow #29216450262 — all 19 jobs passed or were intentionally skipped by scope detection