### PR TITLE
feat(daemon): expose per-run failure diagnostics — od run inspect + endpoint (slice 1 of #5489)

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -5997,6 +5997,8 @@ async function runRun(args) {
   od run continue <runId> [--follow]        Continue a resumable failed run.
   od run list   [--project <id>]            List recent runs.
   od run info   <runId>                     One run's status.
+  od run inspect <runId> [--json]           Failure diagnostics: why it failed,
+                                            retryable, suggested action.
   od run result-package <runId> [--json]    Inspect run outputs and workspace
                                             provenance without applying them.
 
@@ -6034,6 +6036,30 @@ Common options:
       if (!resp.ok) return structuredHttpFailure(resp, 'run-not-found');
       const data = await resp.json();
       process.stdout.write(JSON.stringify(data, null, 2) + '\n');
+      return;
+    }
+    case 'inspect': {
+      // Surface the daemon's per-run failure diagnostics (#5489): why it
+      // failed, whether it is safe to retry, and the suggested action.
+      const id = rest.find((a) => !a.startsWith('-'));
+      if (!id) {
+        console.error('Usage: od run inspect <runId> [--json]');
+        process.exit(2);
+      }
+      const resp = await fetch(`${base}/api/runs/${encodeURIComponent(id)}/diagnostics`);
+      if (!resp.ok) return structuredHttpFailure(resp, 'run-not-found');
+      const data = await resp.json();
+      if (flags.json) return process.stdout.write(JSON.stringify(data, null, 2) + '\n');
+      console.log(`${data?.runId ?? id} — ${data?.status ?? '-'}`);
+      const failure = data?.failure ?? null;
+      if (!failure) {
+        console.log('failure: (none)');
+        return;
+      }
+      const stage = failure.stage ? `   (stage: ${failure.stage})` : '';
+      console.log(`failure: ${failure.category ?? '-'} / ${failure.detail ?? '-'}${stage}`);
+      console.log(`retryable: ${failure.retryable === null ? '-' : failure.retryable ? 'yes' : 'no'}`);
+      console.log(`suggested action: ${failure.userAction ?? '-'}`);
       return;
     }
     case 'result-package': {

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -10,6 +10,11 @@ import {
   type ChatRunStatus,
   type ChatRunStatusResponse,
   type ProjectMetadata as ContractProjectMetadata,
+  type RunDiagnosticsResponse,
+  type RunFailureCategory,
+  type RunFailureDetail,
+  type RunFailureStage,
+  type RunFailureUserAction,
   type RunResultPackageResponse,
 } from '@open-design/contracts';
 import {
@@ -145,6 +150,13 @@ interface ChatRun {
   signal?: string | null;
   error?: string | null;
   errorCode?: string | null;
+  // Finalize-time failure classification the daemon computes for retry-policy +
+  // telemetry (#5489). Surfaced through GET /api/runs/:id/diagnostics.
+  failureCategory?: RunFailureCategory | null;
+  failureDetail?: RunFailureDetail | null;
+  failureStage?: RunFailureStage | null;
+  failureRetryable?: boolean | null;
+  failureUserAction?: RunFailureUserAction | null;
   projectMetadata?: ProjectMetadata;
   appliedPluginSnapshotId?: string | null;
   pluginId?: string | null;
@@ -1352,6 +1364,36 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
     const run = design.runs.get(runId);
     if (!run) return sendApiError(res, 404, 'NOT_FOUND', 'run not found');
     res.json(design.runs.statusBody(run));
+  });
+
+  // Per-run reliability diagnostics (#5489). Surfaces the full failure
+  // classification the daemon already computes at finalize-time — stage,
+  // retryable, and user_action in addition to the category/detail the status
+  // endpoint carries — so local users and external agents (`od run inspect`)
+  // can see why a run failed and whether to retry, without reading telemetry.
+  // A dedicated sub-resource so GET /api/runs/:id stays lean. `failure` is null
+  // for a run that did not fail. Availability matches GET /api/runs/:id (the
+  // live run registry); durable/timing/token slices are deferred.
+  app.get('/api/runs/:id/diagnostics', (req: ApiRequest, res: ApiResponse) => {
+    const runId = routeParamId(req);
+    if (!runId) return sendApiError(res, 400, 'BAD_REQUEST', 'run id missing');
+    const run = design.runs.get(runId);
+    if (!run) return sendApiError(res, 404, 'NOT_FOUND', 'run not found');
+    const failed = run.status === 'failed';
+    const body: RunDiagnosticsResponse = {
+      runId: run.id,
+      status: run.status,
+      failure: failed
+        ? {
+            category: run.failureCategory ?? null,
+            detail: run.failureDetail ?? null,
+            stage: run.failureStage ?? null,
+            retryable: run.failureRetryable ?? null,
+            userAction: run.failureUserAction ?? null,
+          }
+        : null,
+    };
+    res.json(body);
   });
 
   app.get('/api/runs/:id/events', (req: ApiRequest, res: ApiResponse) => {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5241,6 +5241,13 @@ export async function startServer({
       // failure type + fix. Only meaningful on a failed result.
       run.failureCategory = result === 'failed' ? failure?.failure_category ?? null : null;
       run.failureDetail = result === 'failed' ? failure?.failure_detail ?? null : null;
+      // Carry the remaining already-computed classification fields on the run so
+      // the diagnostics endpoint + `od run inspect` can surface them (#5489).
+      // Same source object as failureCategory/Detail above; only meaningful on a
+      // failed result.
+      run.failureStage = result === 'failed' ? failure?.failure_stage ?? null : null;
+      run.failureRetryable = result === 'failed' ? failure?.retryable ?? null : null;
+      run.failureUserAction = result === 'failed' ? failure?.user_action ?? null : null;
       // Stamp the classification onto the persisted assistant message too, so a
       // reload (or any daemon-side persistence without the live web error
       // handler) keeps the specific failure guidance instead of the coarse

--- a/apps/daemon/tests/run-diagnostics-endpoint.test.ts
+++ b/apps/daemon/tests/run-diagnostics-endpoint.test.ts
@@ -1,0 +1,114 @@
+// Feature (#5489, slice 1): GET /api/runs/:id/diagnostics + `od run inspect`
+// expose the full failure classification the daemon already computes at
+// finalize-time. Before this, only failureCategory / failureDetail reached the
+// API; failureStage / retryable / userAction were telemetry-only. This spec
+// drives a real daemon over the production HTTP API, fails a run through a fake
+// claude CLI, and asserts the diagnostics endpoint now carries all five fields.
+
+import type { Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+type StartedServer = { url: string; server: Server; shutdown?: () => Promise<void> | void };
+
+describe('run diagnostics endpoint (#5489)', () => {
+  const savedEnv: Record<string, string | undefined> = {};
+  for (const k of ['POSTHOG_KEY', 'POSTHOG_HOST', 'LANGFUSE_PUBLIC_KEY', 'LANGFUSE_SECRET_KEY', 'LANGFUSE_BASE_URL', 'OPEN_DESIGN_TELEMETRY_RELAY_URL']) {
+    savedEnv[k] = process.env[k];
+  }
+  let started: StartedServer | null = null;
+  let binDir: string | null = null;
+
+  afterEach(async () => {
+    await Promise.resolve(started?.shutdown?.());
+    if (started?.server) await new Promise<void>((r) => started?.server.close(() => r()));
+    started = null;
+    if (binDir) await rm(binDir, { recursive: true, force: true });
+    binDir = null;
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k]; else process.env[k] = v;
+    }
+  });
+
+  it('exposes stage / retryable / userAction for a failed run, not just category/detail', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-run-diag-'));
+    const bin = await writeFailingClaude(binDir, 'claude-fail');
+    for (const k of Object.keys(savedEnv)) delete process.env[k];
+    started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'claude',
+      agentCliEnv: { claude: { CLAUDE_BIN: bin } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const runId = await createAndWaitForFailure(started.url);
+
+    // The diagnostics endpoint carries the full classification.
+    const diag = await (await fetch(`${started.url}/api/runs/${encodeURIComponent(runId)}/diagnostics`)).json() as {
+      runId: string;
+      status: string;
+      failure: { category: unknown; detail: unknown; stage: unknown; retryable: unknown; userAction: unknown } | null;
+    };
+    expect(diag.runId).toBe(runId);
+    expect(diag.status).toBe('failed');
+    expect(diag.failure, 'a failed run must carry a failure object').not.toBeNull();
+    // The three fields this slice newly exposes must be present (the whole point).
+    expect(diag.failure).toHaveProperty('stage');
+    expect(diag.failure).toHaveProperty('retryable');
+    expect(diag.failure).toHaveProperty('userAction');
+    expect(typeof diag.failure!.retryable === 'boolean' || diag.failure!.retryable === null).toBe(true);
+
+    // Control: the plain status endpoint still does NOT carry the new fields,
+    // proving the diagnostics resource is what adds them.
+    const status = await (await fetch(`${started.url}/api/runs/${encodeURIComponent(runId)}`)).json() as Record<string, unknown>;
+    expect(status).not.toHaveProperty('failureStage');
+    expect(status).not.toHaveProperty('failureUserAction');
+  });
+});
+
+async function writeFailingClaude(dir: string, name: string): Promise<string> {
+  const bin = path.join(dir, name);
+  await writeFile(bin, `#!/usr/bin/env node
+const fs = require('node:fs');
+if (process.argv.includes('--version')) { fs.writeSync(1, 'claude-code 1.0.0-diag-test\\n'); process.exit(0); }
+if (process.argv.includes('--help')) { fs.writeSync(1, 'Usage: claude -p\\n'); process.exit(0); }
+fs.writeSync(1, JSON.stringify({ type: 'system', subtype: 'init', model: 'claude-diag-test' }) + '\\n');
+// Fail with an authentication error so the classifier produces a concrete
+// stage/retryable/user_action (not just a generic process_exit).
+fs.writeSync(2, 'Error: authentication required. Please sign in again.\\n');
+process.exit(1);
+`, 'utf8');
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+async function putConfig(url: string, patch: Record<string, unknown>): Promise<void> {
+  const r = await fetch(`${url}/api/app-config`, { method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify(patch) });
+  expect(r.status).toBe(200);
+}
+
+async function createAndWaitForFailure(url: string): Promise<string> {
+  const projectId = `run_diag_${randomUUID()}`;
+  const p = await fetch(`${url}/api/projects`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ id: projectId, name: 'Run diagnostics', metadata: { kind: 'prototype' }, skipDiscoveryBrief: true }) });
+  expect(p.status).toBe(200);
+  const { conversationId } = await p.json() as { conversationId: string };
+  const r = await fetch(`${url}/api/runs`, { method: 'POST', headers: { 'content-type': 'application/json', 'x-od-analytics-device-id': 'd', 'x-od-analytics-session-id': 's', 'x-od-analytics-client-type': 'web' }, body: JSON.stringify({ projectId, conversationId, assistantMessageId: `a_${randomUUID()}`, clientRequestId: `c_${randomUUID()}`, agentId: 'claude', message: 'x', currentPrompt: 'x' }) });
+  expect(r.status).toBe(202);
+  const { runId } = await r.json() as { runId: string };
+  const start = Date.now();
+  while (Date.now() - start < 10_000) {
+    const run = await (await fetch(`${url}/api/runs/${encodeURIComponent(runId)}`)).json() as { status: string };
+    if (['failed', 'succeeded', 'canceled'].includes(run.status)) {
+      expect(run.status).toBe('failed');
+      return runId;
+    }
+    await new Promise((res) => setTimeout(res, 100));
+  }
+  throw new Error(`run ${runId} did not finish`);
+}

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -17,6 +17,8 @@ import type { TrackingRuntimeType } from '../analytics/public-params.js';
 import type {
   TrackingRunFailureCategory,
   TrackingRunFailureDetail,
+  TrackingRunFailureStage,
+  TrackingRunFailureUserAction,
 } from '../analytics/events.js';
 
 // The daemon's run-failure taxonomy, re-exported under product-facing names so
@@ -26,6 +28,13 @@ import type {
 // producer and consumer can't drift.
 export type RunFailureCategory = TrackingRunFailureCategory;
 export type RunFailureDetail = TrackingRunFailureDetail;
+// The remaining classification fields the daemon already computes at
+// finalize-time but has not exposed on the API surface until now (#5489): the
+// pipeline stage the failure landed in, whether it is safe to retry, and the
+// suggested user action. Re-exported here so `od run inspect` and the
+// diagnostics endpoint carry the same union the daemon and analytics use.
+export type RunFailureStage = TrackingRunFailureStage;
+export type RunFailureUserAction = TrackingRunFailureUserAction;
 
 export type ChatRole = 'user' | 'assistant';
 export type ChatSessionMode = 'design' | 'chat' | 'plan';
@@ -501,6 +510,39 @@ export interface ChatRunStatusResponse {
 }
 
 export type ChatRunResultPackageResponse = RunResultPackageResponse;
+
+/**
+ * Per-run reliability diagnostics (#5489). The daemon already computes the full
+ * failure classification at finalize-time for retry-policy + telemetry, but the
+ * status surface only carried `failureCategory` / `failureDetail`. This exposes
+ * the remaining classification fields to local users and external agents
+ * (`GET /api/runs/:id/diagnostics`, `od run inspect`) so they can see *why* a
+ * run failed, whether it is safe to retry, and what action to take — without
+ * reading PostHog/Langfuse. Slice 1 covers the bounded failure classification;
+ * timing-segment and token/cache breakdowns follow once their storage story is
+ * settled (they are fire-and-forget into telemetry today).
+ *
+ * `failure` is null when the run did not fail. Availability matches
+ * `GET /api/runs/:id`: the live run registry (recent runs). Durable
+ * cross-restart persistence is deferred with the timing/token slice.
+ */
+export interface RunDiagnosticsResponse {
+  runId: string;
+  status: ChatRunStatus;
+  failure: {
+    category: RunFailureCategory | null;
+    detail: RunFailureDetail | null;
+    /** Pipeline stage the failure landed in (spawn, first_token_wait,
+     *  tool_execution, finalize, …). */
+    stage: RunFailureStage | null;
+    /** True when a same-run retry is safe (transient upstream/rate-limit),
+     *  false for terminal causes (auth, hard quota, user cancellation). */
+    retryable: boolean | null;
+    /** Suggested next action (retry, login, recharge, upgrade,
+     *  switch_model, reduce_context, install_cli, fix_config, none). */
+    userAction: RunFailureUserAction | null;
+  } | null;
+}
 
 export interface ChatRunListResponse {
   runs: ChatRunStatusResponse[];


### PR DESCRIPTION
Refs #5489. **Draft — a concrete reference implementation of the slice-1 shape @lefarcen and I converged on in the proposal, posted to make the product-direction review easier. Not asking to merge ahead of that direction.**

## Why

Per #5489: the daemon already computes the full failure classification at finalize-time (for retry-policy + telemetry), but the API surface only carried `failureCategory` / `failureDetail`. `failureStage`, `retryable`, and `user_action` were telemetry-only — so a self-hoster, or an external agent driving Open Design through `od`, could not see *why* a run failed, *whether it is safe to retry*, or *what action to take* without reading PostHog/Langfuse. That breaks the UI+CLI dual-track rule and the CLI-as-embeddability-contract principle in AGENTS.md.

## What this slice does (backbone: contracts + daemon + CLI + test)

- Carries `failureStage` / `failureRetryable` / `failureUserAction` on the run (same source object as the existing category/detail, `server.ts`).
- **`GET /api/runs/:id/diagnostics`** — a dedicated sub-resource so `GET /api/runs/:id` stays lean; returns `RunDiagnosticsResponse` with the full classification (`failure` is `null` for a run that did not fail).
- **`od run inspect <runId> [--json]`**.
- Contracts: `RunDiagnosticsResponse` + re-export `RunFailureStage` / `RunFailureUserAction` (mirrors the existing `RunFailureCategory` / `RunFailureDetail` re-exports).

```
$ od run inspect run_abc
run_abc — failed
failure: auth / invalid_api_key   (stage: first_token_wait)
retryable: no
suggested action: login
```

## The 2/5 → 5/5 split (per the proposal thread)

This carries the **bounded failure classification** only. Availability matches `GET /api/runs/:id` (the live run registry), so it sidesteps the persistence seam entirely. The heavier **timing-segment + token/cache** breakdown — which is fire-and-forget into telemetry today and needs the storage decision (persist to SQLite under the `RUNTIME_DATA_DIR` contract vs in-memory only) — is deliberately **not** in this slice.

## Deliberately deferred (call these out for review)

- **Web diagnostics panel** (+ its i18n across 18 locales): held until the shape is blessed, so the panel and the timing/token fields land together rather than churning the UI twice. The dual-track intent is met by `od run inspect` here + the panel in the follow-up.
- **Durable / timing / token slice**: separate PR, gated on the storage decision.

## Scope boundaries

Pure exposure — no new computation, no change to classification logic (stays out of the accuracy-tuning lane #4966 / #5223 / #5356). Complementary to #5321 (which surfaces category/detail as chat guidance), not a duplicate.

## Validation

- `pnpm --filter @open-design/daemon typecheck` (both tsconfigs) — clean
- `pnpm guard` — 78/78
- `apps/daemon/tests/run-diagnostics-endpoint.test.ts` — green 3/3: fails a run through a fake claude over the production HTTP API, asserts `/diagnostics` now carries `stage` / `retryable` / `userAction` (control: the plain status endpoint does not).

Happy to adjust the endpoint shape, field names, or the persistence/UI phasing once the product direction lands.

## Surface area

- [x] **CLI** — `od run inspect`
- [x] **API / contract** — `GET /api/runs/:id/diagnostics` + `RunDiagnosticsResponse`
- [ ] UI — deferred to the follow-up (see above)