### PR TITLE
fix(packaged): widen win32 daemon status-wait budget + back off polling

### DIFF
--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -149,25 +149,49 @@ async function openLog(path: string): Promise<FileHandle> {
 }
 
 const DAEMON_STATUS_TIMEOUT_MS = 35_000;
+// Windows first launches routinely blow past the 35s POSIX budget: Defender
+// real-time scanning of the freshly-written packaged binaries inflates the
+// daemon cold start (native better-sqlite3 load + first SQLite open/migrate +
+// status-pipe bind) well past 35s. PostHog on the packaged_runtime_failed
+// status-timeout bucket showed ~90% of affected devices DID open the app on a
+// later launch — the daemon was merely slow, not dead — so a wider win32 budget
+// lets that first launch succeed instead of failing to a recovery screen and
+// forcing a manual relaunch.
+const WIN32_STATUS_TIMEOUT_MS = 90_000;
 const DAEMON_MIGRATION_STATUS_TIMEOUT_MS = 30 * 60 * 1000;
 
+// Poll cadence for waitForStatus: start tight so a fast daemon is detected
+// promptly, then back off geometrically (capped) so a not-yet-bound pipe is not
+// hammered with connect attempts that add CPU/AV contention to an already-slow
+// cold start.
+const STATUS_POLL_INITIAL_MS = 150;
+const STATUS_POLL_MAX_MS = 1500;
+
+// Baseline status wait budget by platform, before the daemon-only legacy
+// migration override. win32 gets the wider AV-scan headroom; every other OS
+// keeps the 35s baseline.
+function baseStatusTimeoutMs(platform: NodeJS.Platform = process.platform): number {
+  return platform === "win32" ? WIN32_STATUS_TIMEOUT_MS : DAEMON_STATUS_TIMEOUT_MS;
+}
+
 /**
- * Daemon status wait budget. The default 35s is fine for normal cold
- * boots, but the OD_LEGACY_DATA_DIR one-shot recovery flow can synch-
- * copy a multi-GB legacy `.od/` payload before SQLite even opens, and
- * killing the child mid-migration can leave dataDir half-promoted.
- * When the env var is set, use a 30-minute budget so the parent will
- * not tear the daemon down before the migration can complete.
+ * Daemon status wait budget. The platform baseline (35s, or 90s on win32 for
+ * AV-scan headroom) is fine for normal cold boots, but the OD_LEGACY_DATA_DIR
+ * one-shot recovery flow can synch-copy a multi-GB legacy `.od/` payload before
+ * SQLite even opens, and killing the child mid-migration can leave dataDir
+ * half-promoted. When the env var is set, use a 30-minute budget so the parent
+ * will not tear the daemon down before the migration can complete.
  *
  * @see apps/daemon/src/legacy-data-migrator.ts
  * @see https://github.com/nexu-io/open-design/issues/710
  */
 export function resolveDaemonStatusTimeoutMs(
   env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
 ): number {
   const raw = env.OD_LEGACY_DATA_DIR;
   if (raw != null && raw.length > 0) return DAEMON_MIGRATION_STATUS_TIMEOUT_MS;
-  return DAEMON_STATUS_TIMEOUT_MS;
+  return baseStatusTimeoutMs(platform);
 }
 
 /**
@@ -190,6 +214,7 @@ export async function waitForStatus<T>(
 ): Promise<T> {
   const startedAt = Date.now();
   let lastError: unknown;
+  let pollDelayMs = STATUS_POLL_INITIAL_MS;
   let childExited: { code: number | null; signal: NodeJS.Signals | null } | null = null;
 
   // Cover the race between spawn-resolved and now: if the child has
@@ -223,12 +248,12 @@ export async function waitForStatus<T>(
         if (watch?.child.pid != null) {
           if (statusPid == null) {
             lastError = new Error(`sidecar status did not include pid for spawned pid ${watch.child.pid}`);
-            await sleep(150);
+            await sleep(STATUS_POLL_INITIAL_MS);
             continue;
           }
           if (statusPid !== watch.child.pid) {
             lastError = new Error(`sidecar status pid ${statusPid} did not match spawned pid ${watch.child.pid}`);
-            await sleep(150);
+            await sleep(STATUS_POLL_INITIAL_MS);
             continue;
           }
         }
@@ -236,7 +261,8 @@ export async function waitForStatus<T>(
       } catch (error) {
         lastError = error;
       }
-      await sleep(150);
+      await sleep(pollDelayMs);
+      pollDelayMs = Math.min(pollDelayMs * 2, STATUS_POLL_MAX_MS);
     }
 
     throw new Error(
@@ -595,7 +621,10 @@ export async function startPackagedSidecars(
     const webStatus = await waitForStatus<WebStatusSnapshot>(
       web.ipcPath,
       (status) => status.url != null,
-      DAEMON_STATUS_TIMEOUT_MS,
+      // Web has no legacy-migration path, so it uses the plain platform
+      // baseline (still widened on win32, where AV scanning can also slow the
+      // web sidecar's first bind) rather than resolveDaemonStatusTimeoutMs.
+      baseStatusTimeoutMs(),
       { child: web.child, logPath: logPathFor(paths, APP_KEYS.WEB) },
     );
     if (webStatus.url == null) throw new Error("web did not report a URL");

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -261,7 +261,13 @@ export async function waitForStatus<T>(
       } catch (error) {
         lastError = error;
       }
-      await sleep(pollDelayMs);
+      // Keep timeoutMs a hard-ish upper bound: never sleep past the deadline, so
+      // the widened win32 budget can't be overshot by a full backoff interval on
+      // a slow/dead sidecar. The in-flight requestJsonIpc timeout is the only
+      // residual overshoot; the while-condition re-checks the deadline next tick.
+      const remaining = timeoutMs - (Date.now() - startedAt);
+      if (remaining <= 0) break;
+      await sleep(Math.min(pollDelayMs, remaining));
       pollDelayMs = Math.min(pollDelayMs * 2, STATUS_POLL_MAX_MS);
     }
 

--- a/apps/packaged/src/startup-telemetry.ts
+++ b/apps/packaged/src/startup-telemetry.ts
@@ -86,6 +86,7 @@ export type StartupFailureKind =
   | "daemon-start"
   | "web-start"
   | "path-access"
+  | "status-timeout"
   | "unknown";
 
 export interface StartupFailureClassification {
@@ -102,6 +103,12 @@ export interface StartupFailureClassification {
 const EXIT_RE =
   /exited before reporting status \(code=(.*?), signal=(.*?)\); see (.*?) for details/;
 
+// `waitForStatus` (apps/packaged/src/sidecars.ts) throws this when the wait
+// budget expires with the child still ALIVE — the daemon/web pipe never bound in
+// time (the win32 first-launch AV-scan case), as opposed to EXIT_RE's dead
+// child. There is no daemon log path in this message, so no log tail is read.
+const STATUS_TIMEOUT_RE = /^timed out waiting for sidecar status at /;
+
 export function classifyStartupFailure(
   error: unknown,
   isPathAccess: boolean,
@@ -112,6 +119,12 @@ export function classifyStartupFailure(
   const message = error instanceof Error ? error.message : String(error ?? "");
   const match = EXIT_RE.exec(message);
   if (!match) {
+    // Distinguish a slow-but-alive sidecar (budget exhausted) from a truly
+    // opaque failure so the status-timeout bucket is measurable on its own —
+    // it is the signal for whether the win32 budget raise drained these.
+    if (STATUS_TIMEOUT_RE.test(message)) {
+      return { failureKind: "status-timeout", exitCode: null, signal: null, logPath: null };
+    }
     return { failureKind: "unknown", exitCode: null, signal: null, logPath: null };
   }
   const rawCode = match[1];

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -39,12 +39,21 @@ function slashPath(value: string): string {
 }
 
 describe('resolveDaemonStatusTimeoutMs', () => {
-  it('uses the default 35-second budget for normal cold boots', () => {
-    expect(resolveDaemonStatusTimeoutMs({})).toBe(35_000);
+  it('uses the 35-second baseline budget on non-win32 for normal cold boots', () => {
+    expect(resolveDaemonStatusTimeoutMs({}, 'linux')).toBe(35_000);
+    expect(resolveDaemonStatusTimeoutMs({}, 'darwin')).toBe(35_000);
+  });
+
+  it('widens the baseline to 90 seconds on win32 for AV-scan-slow first launches', () => {
+    // Windows Defender scanning freshly-written packaged binaries inflates the
+    // daemon cold start (native better-sqlite3 load + first SQLite open + pipe
+    // bind) past 35s; PostHog showed ~90% of the status-timeout devices did open
+    // on a later launch, so the wider budget lets the first launch succeed.
+    expect(resolveDaemonStatusTimeoutMs({}, 'win32')).toBe(90_000);
   });
 
   it('treats an empty OD_LEGACY_DATA_DIR as unset', () => {
-    expect(resolveDaemonStatusTimeoutMs({ OD_LEGACY_DATA_DIR: '' })).toBe(35_000);
+    expect(resolveDaemonStatusTimeoutMs({ OD_LEGACY_DATA_DIR: '' }, 'linux')).toBe(35_000);
   });
 
   it('extends the budget to 30 minutes when OD_LEGACY_DATA_DIR is set', () => {
@@ -53,18 +62,22 @@ describe('resolveDaemonStatusTimeoutMs', () => {
     // minutes was historically observed to time out on real installs.
     const value = resolveDaemonStatusTimeoutMs({
       OD_LEGACY_DATA_DIR: '/path/to/old/.od',
-    });
+    }, 'linux');
     expect(value).toBeGreaterThanOrEqual(10 * 60 * 1000);
     expect(value).toBe(30 * 60 * 1000);
+    // The migration override beats the widened win32 baseline too.
+    expect(
+      resolveDaemonStatusTimeoutMs({ OD_LEGACY_DATA_DIR: '/path/to/old/.od' }, 'win32'),
+    ).toBe(30 * 60 * 1000);
   });
 
   it('falls back to process.env when called with no argument', () => {
     const original = process.env.OD_LEGACY_DATA_DIR;
     try {
       delete process.env.OD_LEGACY_DATA_DIR;
-      expect(resolveDaemonStatusTimeoutMs()).toBe(35_000);
+      expect(resolveDaemonStatusTimeoutMs(undefined, 'linux')).toBe(35_000);
       process.env.OD_LEGACY_DATA_DIR = '/some/legacy/path';
-      expect(resolveDaemonStatusTimeoutMs()).toBe(30 * 60 * 1000);
+      expect(resolveDaemonStatusTimeoutMs(undefined, 'linux')).toBe(30 * 60 * 1000);
     } finally {
       if (original == null) delete process.env.OD_LEGACY_DATA_DIR;
       else process.env.OD_LEGACY_DATA_DIR = original;

--- a/apps/packaged/tests/startup-telemetry.test.ts
+++ b/apps/packaged/tests/startup-telemetry.test.ts
@@ -87,6 +87,20 @@ describe('classifyStartupFailure', () => {
   it('falls back to unknown for an unrecognized error', () => {
     expect(classifyStartupFailure(new Error('boom'), false).failureKind).toBe('unknown');
   });
+
+  it('classifies a status-wait timeout as status-timeout, not unknown', () => {
+    // waitForStatus throws this when the budget expires with the child still
+    // ALIVE (the win32 first-launch AV-scan case) — the pipe never bound in
+    // time, so there is no exit code, signal, or daemon log to read. Splitting
+    // it out of `unknown` is what makes the win32 budget-raise measurable.
+    const winPipe =
+      'timed out waiting for sidecar status at \\\\.\\pipe\\open-design-release-stable-win-daemon (connect ENOENT \\\\.\\pipe\\open-design-release-stable-win-daemon)';
+    const c = classifyStartupFailure(new Error(winPipe), false);
+    expect(c.failureKind).toBe('status-timeout');
+    expect(c.exitCode).toBeNull();
+    expect(c.signal).toBeNull();
+    expect(c.logPath).toBeNull();
+  });
 });
 
 describe('scrubUserPaths', () => {

--- a/packages/contracts/src/analytics/events/result-events.ts
+++ b/packages/contracts/src/analytics/events/result-events.ts
@@ -695,6 +695,11 @@ export type PackagedStartupFailureKind =
   | 'daemon-start'
   | 'web-start'
   | 'path-access'
+  // A sidecar that never reported ready within the status-wait budget — the
+  // pipe/socket never bound in time (e.g. win32 first-launch AV scanning slowing
+  // the daemon cold start), as opposed to a sidecar that exited (`daemon-start` /
+  // `web-start`). Split out so this bucket stops hiding inside `unknown`.
+  | 'status-timeout'
   | 'unknown';
 
 // Event-specific props for `packaged_runtime_failed`. Emitted by the packaged


### PR DESCRIPTION
## Why

Triaging the daily stability digest, `packaged_runtime_failed` was up ~31% and Windows dominated it. Slicing PostHog with the correct props (`platform` / `failure_kind` / `exit_code`) showed the single biggest startup-crash bucket is **win32 status-wait timeouts: ~178 events / 61 devices per day**, all `failure_kind=unknown` with **no exit code, no signal, no error code, no daemon log** — the daemon never reported ready before the wait budget expired.

Two follow-up queries proved this is **transient**, not a dead daemon:
- Events-per-device: **214 devices hit it exactly once**, 72 twice/thrice, tapering off — not a chronic fleet fault.
- **90% (289/318) of the affected devices later produced a `$pageview`** — the app *did* open on a subsequent launch.

So the daemon isn't broken; it's **slow on first launch**. Windows Defender real-time scanning of the freshly-written packaged binaries inflates the daemon cold start (native `better-sqlite3` load + first SQLite open/migrate + status-pipe bind) past the fixed **35s** wait budget. The user hits a recovery/failure screen, relaunches, and it works — but that first-launch failure is avoidable.

## What users will see

Windows users whose first launch is slowed by AV scanning now get the app to **open on that first launch** instead of failing to a recovery screen and having to relaunch. No visible change on machines that already start within 35s, and no change on macOS/Linux.

Trade-off: on a genuinely-dead daemon (never starts), a win32 user now waits up to **90s** (behind the splash) before the failure screen, instead of 35s. That is the deliberate cost of rescuing the ~90% transient-slow majority; the budget is a single constant if we want to tune it.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var** — n/a. Internal packaged startup-reliability behavior (the status-wait budget), not a user-invokable capability — same category as the existing timeout logic, so the UI/CLI dual-track rule doesn't apply.
- [x] **API / contract** — adds one value (`status-timeout`) to `PackagedStartupFailureKind` in `packages/contracts`. Additive enum widening on an existing required field; no shape change, so `EVENT_SCHEMA_VERSION` is not bumped.
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — win32 daemon/web status-wait budget 35s → 90s; poll cadence between connects backs off geometrically instead of flat 150ms.
- [ ] **None**

## How it works

- **`resolveDaemonStatusTimeoutMs` is now platform-aware** (`apps/packaged/src/sidecars.ts`): win32 → 90s of AV-scan headroom, other OSes keep 35s. The `OD_LEGACY_DATA_DIR` migration override (30 min) still takes precedence on every platform. The web sidecar wait uses the same widened baseline (`baseStatusTimeoutMs()`) since it has no legacy-migration path.
- **`waitForStatus` backs off geometrically** (150ms → 1.5s cap) between connect polls instead of a flat 150ms, so a not-yet-bound pipe isn't hammered with connect attempts that add CPU/AV contention to an already-slow cold start. The child-exit fast-fail race and the pid-match retries are unchanged (a *dead* daemon still surfaces immediately).
- **`classifyStartupFailure` tags the timeout message as `status-timeout`** (`apps/packaged/src/startup-telemetry.ts`) instead of letting it fall into `unknown`. This is the measurement that closes the loop: after this ships we can slice `packaged_runtime_failed WHERE failure_kind='status-timeout'` and watch the bucket drain (or not) as the budget change reaches devices.

## Bug fix verification

Encoded as falsifiable red specs at the two changed boundaries:

- `apps/packaged/tests/sidecars.test.ts` — `resolveDaemonStatusTimeoutMs({}, 'win32')` → **90_000** (red on `main`: the function ignored platform and always returned 35_000); migration override still wins on win32; existing 35s assertions pinned to an explicit non-win32 platform so they're host-independent.
- `apps/packaged/tests/startup-telemetry.test.ts` — a real win32 pipe timeout message classifies as **`status-timeout`** with null exit/signal/log (red on `main`: it returned `unknown`).

## Validation

- `pnpm guard` — 78/78 pass
- `pnpm --filter @open-design/packaged --filter @open-design/contracts typecheck` — clean
- `pnpm --filter @open-design/packaged test` — **166 pass (14 files)**; the two new specs confirmed executing (not skipped) via a name filter.

### Follow-ups (not in this PR)
- Split the `status-timeout` bucket into daemon-vs-web by carrying the IPC app segment (the win pipe name already encodes it) — deferred to avoid a new telemetry field here.
- The mac `better-sqlite3` `ERR_MODULE_NOT_FOUND` bucket and the daemon-side `env=development` mislabel are separate fixes tracked independently.
