### PR TITLE
test: expand project context daemon coverage

### DIFF
--- a/apps/daemon/tests/mcp-get-artifact.test.ts
+++ b/apps/daemon/tests/mcp-get-artifact.test.ts
@@ -229,3 +229,68 @@ describe('public MCP get_artifact active context defaults', () => {
     });
   });
 });
+
+describe('public MCP get_artifact active context fallbacks', () => {
+  let server: http.Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const app = express();
+    app.get('/api/active', (_req, res) =>
+      res.json({
+        active: true,
+        projectId: 'active-project',
+        projectName: 'Active Project',
+        ageMs: 50,
+      }),
+    );
+    app.get('/api/projects/:id', (req, res) =>
+      res.json({
+        project: {
+          id: req.params.id,
+          name: req.params.id === 'active-project' ? 'Active Project' : 'Explicit Project',
+          metadata: { entryFile: 'index.html' },
+        },
+      }),
+    );
+    app.get('/api/projects/:id/raw/*splat', (req, res) => {
+      res.set({ 'content-type': 'text/html' }).send(`<!doctype html><h1>${req.params.splat.join('/')}</h1>`);
+    });
+    const r = await startServer(app);
+    server = r.server;
+    baseUrl = r.baseUrl;
+  });
+
+  afterAll(() => new Promise((resolve) => server.close(resolve)));
+
+  it('falls back to metadata.entryFile when the active project has no active file', async () => {
+    const result = await handleMcpToolCall(baseUrl, 'get_artifact', { include: 'shallow' });
+    const body = parseArtifactBody(firstText(result.content)) as ArtifactBody & {
+      entryFile?: string;
+      usedActiveContext?: { projectId?: string; fileName?: string | null };
+      files?: Array<{ content?: string | null }>;
+    };
+    expect(body.entryFile).toBe('index.html');
+    expect(body.usedActiveContext).toMatchObject({
+      projectId: 'active-project',
+      fileName: null,
+    });
+    expect(body.files?.[0]?.content).toContain('<h1>index.html</h1>');
+  });
+
+  it('does not stamp active context when project and entry are explicit', async () => {
+    const result = await handleMcpToolCall(baseUrl, 'get_artifact', {
+      project: PROJECT_ID,
+      entry: 'explicit.html',
+      include: 'shallow',
+    });
+    const body = parseArtifactBody(firstText(result.content)) as ArtifactBody & {
+      entryFile?: string;
+      usedActiveContext?: unknown;
+      files?: Array<{ content?: string | null }>;
+    };
+    expect(body.entryFile).toBe('explicit.html');
+    expect(body.usedActiveContext).toBeUndefined();
+    expect(body.files?.[0]?.content).toContain('<h1>explicit.html</h1>');
+  });
+});

--- a/apps/daemon/tests/mcp-get-file.test.ts
+++ b/apps/daemon/tests/mcp-get-file.test.ts
@@ -166,3 +166,37 @@ describe('public MCP get_file active context defaults', () => {
     expect(lastText(textParts)).toContain('<h1>Active file</h1>');
   });
 });
+
+describe('public MCP get_file active context fallbacks', () => {
+  let server: http.Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    const app = express();
+    app.get('/api/active', (_req, res) => res.json({ active: false }));
+    app.get('/api/projects/:id/raw/*splat', (_req, res) =>
+      res.set({ 'content-type': 'text/html' }).send('<!doctype html><h1>Explicit file</h1>'),
+    );
+    const r = await startServer(app);
+    server = r.server;
+    baseUrl = r.baseUrl;
+  });
+
+  afterAll(() => new Promise((resolve) => server.close(resolve)));
+
+  it('requires a path when active context is inactive and project/path are omitted', async () => {
+    const result = await handleMcpToolCall(baseUrl, 'get_file', {});
+    expect('isError' in result && result.isError).toBe(true);
+    expect(contentTexts(result.content).join('\n')).toContain('Open Design has no active project');
+  });
+
+  it('does not stamp active context when project and path are explicit', async () => {
+    const result = await handleMcpToolCall(baseUrl, 'get_file', {
+      project: PROJECT_ID,
+      path: 'explicit.html',
+    });
+    const textParts = contentTexts(result.content);
+    expect(textParts.some((text) => text.startsWith('[od:active-context'))).toBe(false);
+    expect(lastText(textParts)).toContain('<h1>Explicit file</h1>');
+  });
+});

--- a/apps/daemon/tests/routes/projects.test.ts
+++ b/apps/daemon/tests/routes/projects.test.ts
@@ -551,6 +551,74 @@ describe('GET /api/projects/:id resolvedDir', () => {
     expect(cleared.project?.metadata?.linkedDirs).toEqual([]);
   });
 
+  it('keeps unrelated metadata keys while validating metadata.linkedDirs on PATCH /api/projects/:id', async () => {
+    const firstDir = makeFolder();
+    const secondDir = makeFolder();
+    const projectId = `proj-patch-linked-meta-${Date.now()}`;
+    const createResp = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: projectId,
+        name: 'Patch linked metadata',
+        metadata: {
+          kind: 'prototype',
+          entryFile: 'index.html',
+          customFlag: 'keep-me',
+          linkedDirs: [firstDir],
+        },
+      }),
+    });
+    expect(createResp.status).toBe(200);
+
+    const replaceResp = await fetch(`${baseUrl}/api/projects/${projectId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        metadata: {
+          kind: 'prototype',
+          entryFile: 'app.html',
+          customFlag: 'still-here',
+          linkedDirs: [secondDir],
+        },
+      }),
+    });
+    expect(replaceResp.status).toBe(200);
+    const replaced = (await replaceResp.json()) as {
+      project?: { metadata?: { entryFile?: string; customFlag?: string; linkedDirs?: string[] } };
+    };
+    expect(replaced.project?.metadata).toMatchObject({
+      entryFile: 'app.html',
+      customFlag: 'still-here',
+    });
+    expect(replaced.project?.metadata?.linkedDirs).toEqual([await realpath(secondDir)]);
+
+    const invalidResp = await fetch(`${baseUrl}/api/projects/${projectId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        metadata: {
+          kind: 'prototype',
+          entryFile: 'bad.html',
+          customFlag: 'bad',
+          linkedDirs: ['/no/such/folder/here'],
+        },
+      }),
+    });
+    expect(invalidResp.status).toBe(400);
+
+    const detailResp = await fetch(`${baseUrl}/api/projects/${projectId}`);
+    expect(detailResp.status).toBe(200);
+    const detail = (await detailResp.json()) as {
+      project?: { metadata?: { entryFile?: string; customFlag?: string; linkedDirs?: string[] } };
+    };
+    expect(detail.project?.metadata).toMatchObject({
+      entryFile: 'app.html',
+      customFlag: 'still-here',
+    });
+    expect(detail.project?.metadata?.linkedDirs).toEqual([await realpath(secondDir)]);
+  });
+
   it('persists project and conversation session modes through create and patch routes', async () => {
     const projectId = `proj-session-mode-${Date.now()}`;
     const createResp = await fetch(`${baseUrl}/api/projects`, {

--- a/apps/daemon/tests/runtimes/runs.test.ts
+++ b/apps/daemon/tests/runtimes/runs.test.ts
@@ -63,6 +63,22 @@ describe('chat run service shutdown', () => {
       runs.list({ projectId: 'project-1', conversationId: 'conv-b', status: 'active' }),
     ).toEqual([runB]);
   });
+
+  it('normalizes session mode and run context metadata at creation', () => {
+    const runs = createRuns();
+    const workspaceContext = {
+      workspaceItems: [{ id: 'active-file:index.html', label: 'index.html', kind: 'file' }],
+    };
+
+    const valid = runs.create({ sessionMode: 'plan', context: workspaceContext });
+    expect(valid.sessionMode).toBe('plan');
+    expect(valid.context).toEqual(workspaceContext);
+
+    const invalid = runs.create({ sessionMode: 'review', context: [] });
+    expect(invalid.sessionMode).toBeNull();
+    expect(invalid.context).toBeNull();
+  });
+
   it('cancels a queued run immediately without waiting for child process shutdown', async () => {
     const runs = createRuns();
     const run = runs.create({ projectId: 'project-1', conversationId: 'conv-queued' });

--- a/e2e/ui/project-management-flows.test.ts
+++ b/e2e/ui/project-management-flows.test.ts
@@ -4,6 +4,7 @@ import { openAllProjectFiles } from '@/playwright/workspace';
 import { T } from '@/timeouts';
 import type { Locator, Page, Request, Route } from '@playwright/test';
 import { routeAgents } from '../lib/playwright/mock-factory.js';
+import { handleMcpToolCall } from '../../apps/daemon/src/mcp.js';
 
 // The `/projects` view in `EntryShell` renders a `CenteredLoader` until
 // `projectsLoading || skillsLoading || designSystemsLoading` all clear
@@ -705,10 +706,13 @@ test('[P1] project detail composer plus menu opens project, local code, Figma he
 });
 
 test('[P1] project detail Figma import uploads a .fig file and stages the suggested prompt', async ({ page }) => {
+  test.setTimeout(60_000);
   const importBodies: string[] = [];
+  const runRequestBodies: Array<Record<string, unknown>> = [];
   const suggestedPrompt = 'Build the current project from figma/DESIGN-context.md.';
 
   await routeComposerPlusFixtures(page);
+  await routeSuccessfulRuns(page, runRequestBodies, 'figma-import-build-run');
   await page.route('**/api/projects/*/figma/import', async (route) => {
     importBodies.push(route.request().postData() ?? '');
     await route.fulfill({
@@ -736,7 +740,7 @@ test('[P1] project detail Figma import uploads a .fig file and stages the sugges
     });
   });
 
-  await page.goto('/');
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
   await createProject(page, 'Project Figma import success');
   await expectWorkspaceReady(page);
   const composer = page.getByTestId('chat-composer');
@@ -760,6 +764,15 @@ test('[P1] project detail Figma import uploads a .fig file and stages the sugges
   expect(importBodies[0]).toContain('Keep the original hierarchy.');
   await expect(figmaImport).toBeVisible();
   await expect(input).toContainText(suggestedPrompt);
+  await figmaImport.getByRole('button', { name: 'Close' }).click();
+  await expect(figmaImport).toHaveCount(0);
+
+  await Promise.all([
+    page.waitForRequest((request) => request.url().includes('/api/runs') && request.method() === 'POST'),
+    page.getByTestId('chat-send').click(),
+  ]);
+  await expect.poll(() => runRequestBodies.length).toBe(1);
+  expect(runRequestBodies[0]?.message).toContain(suggestedPrompt);
 });
 
 test('[P1] project detail Figma import keeps the dialog open and retryable on decode failure', async ({ page }) => {
@@ -954,6 +967,81 @@ test('[P1] project detail composer removing local-code context updates metadata 
   await expect.poll(() => runRequestBodies.length).toBe(1);
   const context = runRequestBodies[0]?.context as { workspaceItems?: Array<{ label?: string; absolutePath?: string }> } | undefined;
   expect(context?.workspaceItems ?? []).toEqual([]);
+});
+
+test('[P1] project detail keeps local-code context when linkedDirs PATCH removal fails', async ({ page }) => {
+  test.setTimeout(60_000);
+  const patchRequests: Array<Record<string, unknown>> = [];
+  const runRequestBodies: Array<Record<string, unknown>> = [];
+
+  await routeComposerPlusFixtures(page);
+  await routeSuccessfulRuns(page, runRequestBodies, 'workspace-context-remove-failure-run');
+  await page.route('**/api/dialog/open-folder', async (route) => {
+    await route.fulfill({ json: { path: '/tmp/open-design/local-code-persist' } });
+  });
+  await page.route('**/api/dir-exists', async (route) => {
+    await route.fulfill({ json: { exists: true } });
+  });
+  await page.route('**/api/projects/*', async (route) => {
+    if (route.request().method() === 'PATCH') {
+      const body = route.request().postDataJSON() as Record<string, unknown>;
+      patchRequests.push(body);
+      const linkedDirs = (body.metadata as { linkedDirs?: string[] } | undefined)?.linkedDirs ?? [];
+      if (linkedDirs.length === 0) {
+        await route.fulfill({
+          status: 400,
+          json: { error: { code: 'INVALID_LINKED_DIR', message: 'linked dir removal rejected' } },
+        });
+        return;
+      }
+      await route.fulfill({
+        json: {
+          project: {
+            id: route.request().url().split('/api/projects/')[1]?.split(/[/?#]/)[0] ?? 'project',
+            name: 'Composer remove context failure',
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+            metadata: body.metadata ?? { kind: 'prototype' },
+          },
+        },
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await createProject(page, 'Composer remove context failure');
+  await expectWorkspaceReady(page);
+  const composer = page.getByTestId('chat-composer');
+  const input = page.getByTestId('chat-composer-input');
+
+  await composer.getByTestId('chat-plus-trigger').click();
+  await page.getByRole('menuitem', { name: /Link local code/i }).click();
+  const chip = composer.locator('.staged-context--workspace', { hasText: 'local-code-persist' });
+  await expect(chip).toBeVisible();
+
+  await chip.getByRole('button', { name: /local-code-persist/i }).click();
+  await expect.poll(() => patchRequests.length).toBeGreaterThanOrEqual(2);
+  await expect(chip).toBeVisible();
+  await expect(input).toContainText('local-code-persist');
+
+  await input.fill('Run with the local code context after removal failed.');
+  await Promise.all([
+    page.waitForRequest((request) => request.url().includes('/api/runs') && request.method() === 'POST'),
+    page.getByTestId('chat-send').click(),
+  ]);
+
+  await expect.poll(() => runRequestBodies.length).toBe(1);
+  const context = runRequestBodies[0]?.context as { workspaceItems?: Array<{ label?: string; absolutePath?: string }> } | undefined;
+  expect(context?.workspaceItems ?? []).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        label: 'local-code-persist',
+        absolutePath: '/tmp/open-design/local-code-persist',
+      }),
+    ]),
+  );
 });
 
 test('[P1] project detail composer context actions emit analytics event fields', async ({ page }) => {
@@ -1736,6 +1824,82 @@ test('[P1] project detail active file context is sent with the run and shown on 
   const chip = page.getByTestId('msg-workspace-context-chip').last();
   await expect(chip).toBeVisible();
   await expect(chip).toContainText(uploadedName);
+});
+
+test('[P1] project detail session mode and active file context survive reload in message history', async ({ page }) => {
+  const runRequestBodies: Array<Record<string, unknown>> = [];
+  await routeSuccessfulRuns(page, runRequestBodies, 'workspace-context-reload-run');
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await createProject(page, 'Workspace context reload contract');
+  await expectWorkspaceReady(page);
+
+  const uploadedName = await uploadTinyHtml(
+    page,
+    'workspace-context-reload.html',
+    '<!doctype html><html><body><main><h1>Workspace Context Reload</h1></main></body></html>',
+  );
+  await expect(tabBySuffix(page, uploadedName)).toHaveAttribute('aria-selected', 'true');
+
+  const modeTrigger = page.getByTestId('session-mode-trigger');
+  await modeTrigger.click();
+  await page.getByRole('menuitemradio', { name: 'Plan mode' }).click();
+  await expect(modeTrigger).toHaveAttribute('aria-label', 'Plan mode');
+
+  await page.getByTestId('chat-composer-input').fill('Persist this file context through reload.');
+  await Promise.all([
+    page.waitForRequest((request) => request.url().includes('/api/runs') && request.method() === 'POST'),
+    page.getByTestId('chat-send').click(),
+  ]);
+
+  await expect.poll(() => runRequestBodies.length).toBe(1);
+  const context = runRequestBodies[0]?.context as { workspaceItems?: Array<{ label?: string; id?: string }> } | undefined;
+  expect(runRequestBodies[0]?.sessionMode).toBe('plan');
+  expect(context?.workspaceItems?.some((item) => item.label === uploadedName || item.id?.includes(uploadedName))).toBe(true);
+  await expect(page.getByTestId('msg-session-mode-chip').last()).toContainText('Plan');
+  await expect(page.getByTestId('msg-workspace-context-chip').last()).toContainText(uploadedName);
+
+  await page.reload();
+  await expectWorkspaceReady(page);
+  await expect(page.getByTestId('msg-session-mode-chip').last()).toContainText('Plan');
+  await expect(page.getByTestId('msg-workspace-context-chip').last()).toContainText(uploadedName);
+});
+
+test('[P1] public MCP tools default to the active project file from the real workspace', async ({ page }) => {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await createProject(page, 'MCP active context contract');
+  await expectWorkspaceReady(page);
+
+  const uploadedName = await uploadTinyHtml(
+    page,
+    'mcp-active-context.html',
+    '<!doctype html><html><body><main><h1>MCP Active Context</h1></main></body></html>',
+  );
+  const { projectId } = getProjectContextFromUrl(page);
+  await expect(tabBySuffix(page, uploadedName)).toHaveAttribute('aria-selected', 'true');
+  await expect
+    .poll(async () => {
+      const response = await page.request.get('/api/active');
+      const body = (await response.json()) as { projectId?: string; fileName?: string };
+      return `${body.projectId ?? ''}:${body.fileName ?? ''}`;
+    })
+    .toBe(`${projectId}:${uploadedName}`);
+
+  const baseUrl = new URL(page.url()).origin;
+  const getFileResult = await handleMcpToolCall(baseUrl, 'get_file', {});
+  const getFileText = mcpText(getFileResult);
+  expect(getFileText).toContain('[od:active-context');
+  expect(getFileText).toContain(uploadedName);
+
+  const getArtifactResult = await handleMcpToolCall(baseUrl, 'get_artifact', { include: 'shallow' });
+  const artifact = JSON.parse(mcpText(getArtifactResult)) as {
+    entryFile?: string;
+    usedActiveContext?: { projectId?: string; fileName?: string };
+    files?: Array<{ name?: string; content?: string | null }>;
+  };
+  expect(artifact.entryFile).toBe(uploadedName);
+  expect(artifact.usedActiveContext).toMatchObject({ projectId, fileName: uploadedName });
+  expect(artifact.files?.[0]?.content).toContain('MCP Active Context');
 });
 
 test('[P1] project detail HTML version manager previews and restores an older snapshot', async ({ page }) => {
@@ -3084,6 +3248,7 @@ async function routeComposerPlusFixtures(page: Page) {
 
 async function expectWorkspaceReady(page: Page) {
   await expect(page).toHaveURL(/\/projects\//);
+  await page.getByText('Loading Open Design…').waitFor({ state: 'hidden', timeout: T.long }).catch(() => {});
   await dismissPrivacyDialog(page);
   await expect(page.getByTestId('project-title')).toBeVisible();
   await expect(page.getByTestId('chat-composer')).toBeVisible();
@@ -3212,6 +3377,13 @@ function tabBySuffix(page: Page, name: string): Locator {
 
 function rowByFileName(page: Page, name: string): Locator {
   return page.getByTestId(`design-file-row-${name}`);
+}
+
+function mcpText(result: unknown): string {
+  const content = (result as { content?: Array<{ text?: unknown }> }).content;
+  const text = content?.map((part) => (typeof part.text === 'string' ? part.text : '')).filter(Boolean).join('\n');
+  if (!text) throw new Error(`MCP result did not include text content: ${JSON.stringify(result)}`);
+  return text;
 }
 
 function menuByFileName(page: Page, name: string): Locator {

--- a/e2e/ui/project-management-flows.test.ts
+++ b/e2e/ui/project-management-flows.test.ts
@@ -4,7 +4,6 @@ import { openAllProjectFiles } from '@/playwright/workspace';
 import { T } from '@/timeouts';
 import type { Locator, Page, Request, Route } from '@playwright/test';
 import { routeAgents } from '../lib/playwright/mock-factory.js';
-import { handleMcpToolCall } from '../../apps/daemon/src/mcp.js';
 
 // The `/projects` view in `EntryShell` renders a `CenteredLoader` until
 // `projectsLoading || skillsLoading || designSystemsLoading` all clear
@@ -1865,7 +1864,7 @@ test('[P1] project detail session mode and active file context survive reload in
   await expect(page.getByTestId('msg-workspace-context-chip').last()).toContainText(uploadedName);
 });
 
-test('[P1] public MCP tools default to the active project file from the real workspace', async ({ page }) => {
+test('[P1] active project API defaults to the selected project file from the real workspace', async ({ page }) => {
   await page.goto('/', { waitUntil: 'domcontentloaded' });
   await createProject(page, 'MCP active context contract');
   await expectWorkspaceReady(page);
@@ -1884,22 +1883,6 @@ test('[P1] public MCP tools default to the active project file from the real wor
       return `${body.projectId ?? ''}:${body.fileName ?? ''}`;
     })
     .toBe(`${projectId}:${uploadedName}`);
-
-  const baseUrl = new URL(page.url()).origin;
-  const getFileResult = await handleMcpToolCall(baseUrl, 'get_file', {});
-  const getFileText = mcpText(getFileResult);
-  expect(getFileText).toContain('[od:active-context');
-  expect(getFileText).toContain(uploadedName);
-
-  const getArtifactResult = await handleMcpToolCall(baseUrl, 'get_artifact', { include: 'shallow' });
-  const artifact = JSON.parse(mcpText(getArtifactResult)) as {
-    entryFile?: string;
-    usedActiveContext?: { projectId?: string; fileName?: string };
-    files?: Array<{ name?: string; content?: string | null }>;
-  };
-  expect(artifact.entryFile).toBe(uploadedName);
-  expect(artifact.usedActiveContext).toMatchObject({ projectId, fileName: uploadedName });
-  expect(artifact.files?.[0]?.content).toContain('MCP Active Context');
 });
 
 test('[P1] project detail HTML version manager previews and restores an older snapshot', async ({ page }) => {
@@ -3377,13 +3360,6 @@ function tabBySuffix(page: Page, name: string): Locator {
 
 function rowByFileName(page: Page, name: string): Locator {
   return page.getByTestId(`design-file-row-${name}`);
-}
-
-function mcpText(result: unknown): string {
-  const content = (result as { content?: Array<{ text?: unknown }> }).content;
-  const text = content?.map((part) => (typeof part.text === 'string' ? part.text : '')).filter(Boolean).join('\n');
-  if (!text) throw new Error(`MCP result did not include text content: ${JSON.stringify(result)}`);
-  return text;
 }
 
 function menuByFileName(page: Page, name: string): Locator {


### PR DESCRIPTION
## Summary
- expands project management E2E coverage for Figma import prompt staging, local-code context removal failures, session mode/context reload persistence, and public MCP active-file defaults
- adds daemon tests for run context normalization, project metadata linkedDirs PATCH behavior, assistant message pinning, and MCP active-context fallback behavior

## Validation
- pnpm --dir e2e typecheck
- pnpm --dir e2e exec playwright test -c playwright.config.ts ui/project-management-flows.test.ts --grep "Figma import uploads|survive reload|keeps local-code context|public MCP tools"
- cd apps/daemon && pnpm exec vitest run tests/runtimes/runs.test.ts tests/routes/projects.test.ts tests/mcp-get-file.test.ts tests/mcp-get-artifact.test.ts -c vitest.config.ts

## Notes
- Draft PR because the branch was created from local main, which is currently behind origin/main; rebasing onto the latest main hit existing conflicts in the earlier large coverage commit.