### PR TITLE
fix(web): keep Mark tool annotations painting after a mid-gesture tool switch

### DIFF
--- a/apps/web/src/components/PreviewDrawOverlay.tsx
+++ b/apps/web/src/components/PreviewDrawOverlay.tsx
@@ -145,6 +145,13 @@ export function PreviewDrawOverlay({
   const strokesRef = useRef<Stroke[]>([]);
   const undoneStrokesRef = useRef<Stroke[]>([]);
   const drawingRef = useRef<Stroke | null>(null);
+  // The pointer that owns the in-flight ink gesture. Pointer capture keeps
+  // routing an abandoned pointer's events here after a mid-gesture tool
+  // switch (touch: finger 1 drags, finger 2 switches tools, finger 3 starts
+  // the new stroke before finger 1 lifts), so move/up/cancel from any other
+  // pointer must be ignored or finger 1's late pointerup would commit-and-
+  // clear the stroke finger 3 is still drawing.
+  const gesturePointerIdRef = useRef<number | null>(null);
   // Box-select accumulates: each drag commits another region, so the user can
   // mark several areas in one pass instead of one box replacing the last.
   const selectionBoxesRef = useRef<NormalizedRect[]>([]);
@@ -355,6 +362,7 @@ export function PreviewDrawOverlay({
   // never appears on screen), and a hanging pen stroke keeps growing from
   // bare hover moves — both read as "annotations stop updating" (issue #549).
   function cancelActiveGesture() {
+    gesturePointerIdRef.current = null;
     if (!boxDraftRef.current && !drawingRef.current) return;
     commitInkMutation(() => {
       boxDraftRef.current = null;
@@ -449,6 +457,18 @@ export function PreviewDrawOverlay({
       setEditingTextId(id);
       return;
     }
+    // First pointer down owns the gesture; a second finger landing while a
+    // draft/stroke is in flight must not hijack and restart it. Ownership is
+    // stale once nothing is in flight (e.g. undo discarded the draft), so a
+    // fresh pointer may then claim it even if the old owner never lifted.
+    if (
+      gesturePointerIdRef.current !== null &&
+      gesturePointerIdRef.current !== e.pointerId &&
+      (boxDraftRef.current || drawingRef.current)
+    ) {
+      return;
+    }
+    gesturePointerIdRef.current = e.pointerId;
     (e.target as Element).setPointerCapture?.(e.pointerId);
     const point = pointFromEvent(e);
     if (markTool === 'box') {
@@ -466,6 +486,7 @@ export function PreviewDrawOverlay({
     if (!active) return;
     e.preventDefault();
     if (sending) return;
+    if (gesturePointerIdRef.current !== e.pointerId) return;
     if (boxDraftRef.current) {
       const draft = boxDraftRef.current;
       commitInkMutation(() => {
@@ -483,6 +504,8 @@ export function PreviewDrawOverlay({
     if (!active) return;
     e.preventDefault();
     if (sending) return;
+    if (gesturePointerIdRef.current !== e.pointerId) return;
+    gesturePointerIdRef.current = null;
     if (boxDraftRef.current) {
       const draft = boxDraftRef.current;
       commitInkMutation(() => {

--- a/apps/web/src/components/PreviewDrawOverlay.tsx
+++ b/apps/web/src/components/PreviewDrawOverlay.tsx
@@ -326,6 +326,42 @@ export function PreviewDrawOverlay({
     setRedoCount(undoneStrokesRef.current.length);
   }
 
+  // The single commit path for every ink-data mutation (strokes, boxes, and
+  // their in-flight gesture state). Invariant: by the time this returns, the
+  // canvas pixels, the toolbar's derived state (hasInk/hasBox/hasText/undo/
+  // redo), and the floating dock position all agree with the refs — no caller
+  // has to remember the redraw/sync/bump choreography itself. `coalesce` is
+  // for the pointermove hot path only: it repaints at most once per animation
+  // frame and defers the derived-state refresh to the gesture's commit point.
+  // One-shot mutations repaint synchronously and drop any pending coalesced
+  // frame so no redundant repaint outlives them.
+  function commitInkMutation(mutate: () => void, opts?: { coalesce?: boolean }) {
+    mutate();
+    if (opts?.coalesce) {
+      scheduleRedraw();
+      return;
+    }
+    if (redrawFrameRef.current !== null) {
+      cancelAnimationFrame(redrawFrameRef.current);
+      redrawFrameRef.current = null;
+    }
+    syncHistoryState();
+    redraw();
+    bumpLayoutRevision();
+  }
+
+  // Switching mark tools must never leave a half-finished gesture behind: a
+  // hanging box draft swallows the next pen stroke's pointermoves (the new ink
+  // never appears on screen), and a hanging pen stroke keeps growing from
+  // bare hover moves — both read as "annotations stop updating" (issue #549).
+  function cancelActiveGesture() {
+    if (!boxDraftRef.current && !drawingRef.current) return;
+    commitInkMutation(() => {
+      boxDraftRef.current = null;
+      drawingRef.current = null;
+    });
+  }
+
   // Text marks live in React state (they render DOM textareas) with a ref mirror
   // for the async capture read. Route every mutation through here so the two
   // never drift, then refresh the derived history flags.
@@ -417,58 +453,58 @@ export function PreviewDrawOverlay({
     const point = pointFromEvent(e);
     if (markTool === 'box') {
       // Start a fresh draft on top of any already-committed boxes.
-      boxDraftRef.current = { start: point, current: point };
-      syncHistoryState();
-      redraw();
+      commitInkMutation(() => {
+        boxDraftRef.current = { start: point, current: point };
+      });
       return;
     }
-    drawingRef.current = { points: [point] };
-    redraw();
+    commitInkMutation(() => {
+      drawingRef.current = { points: [point] };
+    });
   }
   function onPointerMove(e: PointerEvent) {
     if (!active) return;
     e.preventDefault();
     if (sending) return;
     if (boxDraftRef.current) {
-      boxDraftRef.current.current = pointFromEvent(e);
-      scheduleRedraw();
+      const draft = boxDraftRef.current;
+      commitInkMutation(() => {
+        draft.current = pointFromEvent(e);
+      }, { coalesce: true });
       return;
     }
     if (!drawingRef.current) return;
-    drawingRef.current.points.push(pointFromEvent(e));
-    scheduleRedraw();
+    const drawing = drawingRef.current;
+    commitInkMutation(() => {
+      drawing.points.push(pointFromEvent(e));
+    }, { coalesce: true });
   }
   function onPointerUp(e: PointerEvent) {
     if (!active) return;
     e.preventDefault();
     if (sending) return;
-    // A final synchronous redraw follows; drop any pending move-frame.
-    if (redrawFrameRef.current !== null) {
-      cancelAnimationFrame(redrawFrameRef.current);
-      redrawFrameRef.current = null;
-    }
     if (boxDraftRef.current) {
-      boxDraftRef.current.current = pointFromEvent(e);
-      const next = normalizedRectFromPoints(boxDraftRef.current.start, boxDraftRef.current.current);
-      boxDraftRef.current = null;
-      // Commit the drawn region; ignore accidental micro-drags (click without move).
-      if (next.width >= 0.006 && next.height >= 0.006) {
-        selectionBoxesRef.current = [...selectionBoxesRef.current, next];
-        bumpLayoutRevision();
-      }
-      syncHistoryState();
-      redraw();
+      const draft = boxDraftRef.current;
+      commitInkMutation(() => {
+        draft.current = pointFromEvent(e);
+        const next = normalizedRectFromPoints(draft.start, draft.current);
+        boxDraftRef.current = null;
+        // Commit the drawn region; ignore accidental micro-drags (click without move).
+        if (next.width >= 0.006 && next.height >= 0.006) {
+          selectionBoxesRef.current = [...selectionBoxesRef.current, next];
+        }
+      });
       return;
     }
     if (!drawingRef.current) return;
-    if (drawingRef.current.points.length > 1) {
-      strokesRef.current.push(drawingRef.current);
-      undoneStrokesRef.current = [];
-      bumpLayoutRevision();
-      syncHistoryState();
-    }
-    drawingRef.current = null;
-    redraw();
+    const drawing = drawingRef.current;
+    commitInkMutation(() => {
+      if (drawing.points.length > 1) {
+        strokesRef.current.push(drawing);
+        undoneStrokesRef.current = [];
+      }
+      drawingRef.current = null;
+    });
   }
 
   function onCanvasWheel(e: WheelEvent<HTMLCanvasElement>) {
@@ -481,16 +517,15 @@ export function PreviewDrawOverlay({
   }
 
   function clearInk() {
-    strokesRef.current = [];
-    undoneStrokesRef.current = [];
-    drawingRef.current = null;
-    selectionBoxesRef.current = [];
-    boxDraftRef.current = null;
     resetTextEditingState();
     commitTextMarks([]);
-    syncHistoryState();
-    redraw();
-    bumpLayoutRevision();
+    commitInkMutation(() => {
+      strokesRef.current = [];
+      undoneStrokesRef.current = [];
+      drawingRef.current = null;
+      selectionBoxesRef.current = [];
+      boxDraftRef.current = null;
+    });
   }
 
   function resetTextEditingState() {
@@ -633,6 +668,7 @@ export function PreviewDrawOverlay({
 
   function selectMarkTool(nextTool: MarkTool) {
     onToolbarClick?.(nextTool === 'box' ? 'rect' : nextTool === 'text' ? 'text' : 'pen');
+    cancelActiveGesture();
     setMarkTool(nextTool);
     setMarkToolMenuOpen(false);
   }
@@ -710,41 +746,39 @@ export function PreviewDrawOverlay({
     // Discard an in-progress draft first, then pop committed boxes one at a
     // time (most recent first) before falling back to freehand strokes.
     if (boxDraftRef.current) {
-      boxDraftRef.current = null;
-      syncHistoryState();
-      redraw();
-      bumpLayoutRevision();
+      commitInkMutation(() => {
+        boxDraftRef.current = null;
+      });
       onToolbarClick?.('undo');
       return;
     }
     if (selectionBoxesRef.current.length > 0) {
-      selectionBoxesRef.current = selectionBoxesRef.current.slice(0, -1);
-      syncHistoryState();
-      redraw();
-      bumpLayoutRevision();
+      commitInkMutation(() => {
+        selectionBoxesRef.current = selectionBoxesRef.current.slice(0, -1);
+      });
       onToolbarClick?.('undo');
       return;
     }
-    const stroke = strokesRef.current.pop();
+    const stroke = strokesRef.current.at(-1);
     if (!stroke) return;
     onToolbarClick?.('undo');
-    undoneStrokesRef.current.push(stroke);
-    drawingRef.current = null;
-    syncHistoryState();
-    redraw();
-    bumpLayoutRevision();
+    commitInkMutation(() => {
+      strokesRef.current.pop();
+      undoneStrokesRef.current.push(stroke);
+      drawingRef.current = null;
+    });
   }
 
   function redoStroke() {
     if (sending) return;
-    const stroke = undoneStrokesRef.current.pop();
+    const stroke = undoneStrokesRef.current.at(-1);
     if (!stroke) return;
     onToolbarClick?.('redo');
-    strokesRef.current.push(stroke);
-    drawingRef.current = null;
-    syncHistoryState();
-    redraw();
-    bumpLayoutRevision();
+    commitInkMutation(() => {
+      undoneStrokesRef.current.pop();
+      strokesRef.current.push(stroke);
+      drawingRef.current = null;
+    });
   }
 
   function closeOverlay() {
@@ -753,18 +787,17 @@ export function PreviewDrawOverlay({
 
   useEffect(() => {
     if (active) return;
-    strokesRef.current = [];
-    undoneStrokesRef.current = [];
-    drawingRef.current = null;
-    selectionBoxesRef.current = [];
-    boxDraftRef.current = null;
     resetTextEditingState();
     commitTextMarks([]);
     setExtraFiles([]);
     setPreviewIndex(null);
-    syncHistoryState();
-    redraw();
-    bumpLayoutRevision();
+    commitInkMutation(() => {
+      strokesRef.current = [];
+      undoneStrokesRef.current = [];
+      drawingRef.current = null;
+      selectionBoxesRef.current = [];
+      boxDraftRef.current = null;
+    });
   }, [active, redraw]);
 
   function normalizedRectToCanvasRect(box: NormalizedRect): Rect | null {

--- a/apps/web/tests/components/PreviewDrawOverlay.redraw-sync.test.tsx
+++ b/apps/web/tests/components/PreviewDrawOverlay.redraw-sync.test.tsx
@@ -157,6 +157,35 @@ describe('PreviewDrawOverlay redraw sync (issue #549)', () => {
     expect(frame!.strokePaths[0]!.segments).toBeGreaterThan(0);
   });
 
+  it('ignores the abandoned pointer’s pointerup while a new pointer is mid-stroke (multi-touch)', () => {
+    const { canvas, paint, getByRole } = renderOverlay();
+
+    // Finger 1 starts a box drag; finger 2 taps the toolbar and switches to
+    // Pen (clearing the draft); finger 3 begins the new pen stroke while
+    // finger 1 is still down.
+    fireEvent.pointerDown(canvas, { clientX: 20, clientY: 20, pointerId: 1 });
+    fireEvent.pointerMove(canvas, { clientX: 80, clientY: 80, pointerId: 1 });
+    switchMarkTool(getByRole, 'Box select', 'Pen');
+    fireEvent.pointerDown(canvas, { clientX: 100, clientY: 100, pointerId: 3 });
+
+    // Finger 1 finally lifts. Pointer capture routes its pointerup here; it
+    // must not commit-and-clear the stroke finger 3 is still drawing.
+    fireEvent.pointerUp(canvas, { clientX: 80, clientY: 80, pointerId: 1 });
+
+    fireEvent.pointerMove(canvas, { clientX: 130, clientY: 130, pointerId: 3 });
+    fireEvent.pointerMove(canvas, { clientX: 160, clientY: 160, pointerId: 3 });
+    fireEvent.pointerUp(canvas, { clientX: 160, clientY: 160, pointerId: 3 });
+    flushAnimationFrames();
+
+    // The full stroke (down + both moves) survives as one committed path; the
+    // abandoned drag leaves no box behind.
+    const frame = paint.lastFrame();
+    expect(frame).not.toBeNull();
+    expect(frame!.boxes).toBe(0);
+    expect(frame!.strokePaths).toHaveLength(1);
+    expect(frame!.strokePaths[0]!.segments).toBe(2);
+  });
+
   it('does not grow ghost ink from hover moves after a pen stroke was abandoned by a tool switch', () => {
     const { canvas, paint, getByRole } = renderOverlay();
     switchMarkTool(getByRole, 'Box select', 'Pen');

--- a/apps/web/tests/components/PreviewDrawOverlay.redraw-sync.test.tsx
+++ b/apps/web/tests/components/PreviewDrawOverlay.redraw-sync.test.tsx
@@ -1,0 +1,216 @@
+// @vitest-environment jsdom
+
+// Red spec for issue #549: "annotation display does not update in the Mark
+// tool". The reproduction matrix pinned the failure to cross-tool paths:
+// switching the mark tool mid-gesture leaves the interrupted gesture's state
+// (`boxDraftRef` / `drawingRef`) hanging, and every later pointer interaction
+// is misrouted through that stale gesture — the new annotation never shows up
+// on the canvas while a ghost of the abandoned one keeps repainting.
+//
+// These tests observe the actual painted canvas frames (not just the refs)
+// through a recording 2D context, per the jsdom caveats in the tech spec:
+// redraw() bails out unless `window.CanvasRenderingContext2D` is defined, so
+// the stub must exist before the overlay renders.
+
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PreviewDrawOverlay } from '../../src/components/PreviewDrawOverlay';
+
+class FakeCanvasRenderingContext2D {}
+
+// Deterministic rAF: scheduleRedraw()'s coalesced frames land in this queue
+// and only run when the test flushes them, so "did the canvas repaint" is
+// never timing-dependent.
+let rafQueue = new Map<number, FrameRequestCallback>();
+let nextRafId = 1;
+
+function flushAnimationFrames() {
+  const batch = [...rafQueue.values()];
+  rafQueue.clear();
+  for (const cb of batch) cb(0);
+}
+
+beforeEach(() => {
+  rafQueue = new Map();
+  nextRafId = 1;
+  vi.stubGlobal('CanvasRenderingContext2D', FakeCanvasRenderingContext2D);
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    const id = nextRafId;
+    nextRafId += 1;
+    rafQueue.set(id, cb);
+    return id;
+  });
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+    rafQueue.delete(id);
+  });
+  // Uninstrumented canvases (jsdom has no real 2D context) return null instead
+  // of throwing "not implemented" noise; instrumented ones shadow this at the
+  // instance level.
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation((() => null) as never);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+interface PaintedFrame {
+  boxes: number;
+  strokePaths: Array<{ segments: number }>;
+}
+
+// Record what redraw() actually paints. Every clearRect() starts a new frame;
+// strokeRect() marks a box (committed or draft), and each beginPath/lineTo/
+// stroke sequence marks one freehand path with its segment count — a hanging
+// single-point stroke paints zero segments, a real drawn line paints >= 1.
+function instrumentCanvas(canvas: HTMLCanvasElement) {
+  const frames: PaintedFrame[] = [];
+  let current: PaintedFrame | null = null;
+  let pendingPath: { segments: number } | null = null;
+  const ctx = {
+    clearRect: () => {
+      current = { boxes: 0, strokePaths: [] };
+      frames.push(current);
+    },
+    strokeRect: () => {
+      if (current) current.boxes += 1;
+    },
+    beginPath: () => {
+      pendingPath = { segments: 0 };
+    },
+    lineTo: () => {
+      if (pendingPath) pendingPath.segments += 1;
+    },
+    stroke: () => {
+      if (current && pendingPath) current.strokePaths.push(pendingPath);
+      pendingPath = null;
+    },
+    moveTo: () => {},
+    fillRect: () => {},
+    fillText: () => {},
+    setLineDash: () => {},
+    save: () => {},
+    restore: () => {},
+    measureText: () => ({ width: 0 }),
+    lineWidth: 1,
+    lineCap: 'round',
+    lineJoin: 'round',
+    strokeStyle: '',
+    fillStyle: '',
+    font: '',
+  };
+  canvas.getContext = (() => ctx) as unknown as HTMLCanvasElement['getContext'];
+  canvas.getBoundingClientRect = () =>
+    ({
+      x: 0, y: 0, left: 0, top: 0, right: 200, bottom: 200, width: 200, height: 200,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  return {
+    lastFrame: () => frames.at(-1) ?? null,
+    frameCount: () => frames.length,
+  };
+}
+
+function renderOverlay() {
+  const utils = render(
+    <PreviewDrawOverlay active>
+      <div style={{ width: 320, height: 200 }} />
+    </PreviewDrawOverlay>,
+  );
+  const canvas = utils.container.querySelector<HTMLCanvasElement>('canvas')!;
+  const paint = instrumentCanvas(canvas);
+  return { ...utils, canvas, paint };
+}
+
+function switchMarkTool(
+  getByRole: ReturnType<typeof render>['getByRole'],
+  from: string,
+  to: string,
+) {
+  fireEvent.click(getByRole('button', { name: from }));
+  fireEvent.click(getByRole('menuitemradio', { name: to }));
+}
+
+describe('PreviewDrawOverlay redraw sync (issue #549)', () => {
+  it('paints the pen stroke drawn after a box drag was abandoned by a tool switch', () => {
+    const { canvas, paint, getByRole } = renderOverlay();
+
+    // Start a box drag; before it ends, a second pointer (touch, or a pointer
+    // whose pointerup the canvas never saw) switches the tool from the menu.
+    fireEvent.pointerDown(canvas, { clientX: 20, clientY: 20, pointerId: 1 });
+    fireEvent.pointerMove(canvas, { clientX: 80, clientY: 80, pointerId: 1 });
+    switchMarkTool(getByRole, 'Box select', 'Pen');
+
+    // Draw a pen stroke with a fresh pointer. Its ink must appear, and the
+    // abandoned drag must not resurface as a ghost rectangle.
+    fireEvent.pointerDown(canvas, { clientX: 100, clientY: 100, pointerId: 2 });
+    fireEvent.pointerMove(canvas, { clientX: 140, clientY: 140, pointerId: 2 });
+    fireEvent.pointerUp(canvas, { clientX: 140, clientY: 140, pointerId: 2 });
+    flushAnimationFrames();
+
+    const frame = paint.lastFrame();
+    expect(frame).not.toBeNull();
+    expect(frame!.boxes).toBe(0);
+    expect(frame!.strokePaths).toHaveLength(1);
+    expect(frame!.strokePaths[0]!.segments).toBeGreaterThan(0);
+  });
+
+  it('does not grow ghost ink from hover moves after a pen stroke was abandoned by a tool switch', () => {
+    const { canvas, paint, getByRole } = renderOverlay();
+    switchMarkTool(getByRole, 'Box select', 'Pen');
+
+    // Start a pen stroke, then switch tools mid-stroke; the gesture never gets
+    // its pointerup on the canvas.
+    fireEvent.pointerDown(canvas, { clientX: 20, clientY: 20, pointerId: 1 });
+    fireEvent.pointerMove(canvas, { clientX: 40, clientY: 40, pointerId: 1 });
+    switchMarkTool(getByRole, 'Pen', 'Box select');
+
+    // Later the mouse merely hovers the canvas (no button pressed). No ink may
+    // appear from those moves.
+    fireEvent.pointerMove(canvas, { clientX: 120, clientY: 120, pointerId: 3 });
+    fireEvent.pointerMove(canvas, { clientX: 160, clientY: 160, pointerId: 3 });
+    flushAnimationFrames();
+
+    const frame = paint.lastFrame();
+    expect(frame).not.toBeNull();
+    expect(frame!.strokePaths).toHaveLength(0);
+  });
+
+  it('does not resurrect the abandoned box draft while placing a text label', () => {
+    const { canvas, paint, getByRole } = renderOverlay();
+
+    // Interrupted box drag, then the user switches to the text tool.
+    fireEvent.pointerDown(canvas, { clientX: 20, clientY: 20, pointerId: 1 });
+    fireEvent.pointerMove(canvas, { clientX: 80, clientY: 80, pointerId: 1 });
+    switchMarkTool(getByRole, 'Box select', 'Text');
+
+    // Dropping a label and moving the pointer must not repaint (or resize) the
+    // abandoned rectangle.
+    fireEvent.pointerDown(canvas, { clientX: 100, clientY: 100, pointerId: 2 });
+    fireEvent.pointerMove(canvas, { clientX: 150, clientY: 150, pointerId: 2 });
+    flushAnimationFrames();
+
+    const frame = paint.lastFrame();
+    expect(frame).not.toBeNull();
+    expect(frame!.boxes).toBe(0);
+  });
+
+  it('keeps coalescing pointermove repaints into a single animation frame', () => {
+    const { canvas, paint, getByRole } = renderOverlay();
+    switchMarkTool(getByRole, 'Box select', 'Pen');
+
+    fireEvent.pointerDown(canvas, { clientX: 20, clientY: 20, pointerId: 1 });
+    const framesAfterDown = paint.frameCount();
+
+    // A high-Hz pointer burst schedules at most one pending repaint.
+    fireEvent.pointerMove(canvas, { clientX: 30, clientY: 30, pointerId: 1 });
+    fireEvent.pointerMove(canvas, { clientX: 40, clientY: 40, pointerId: 1 });
+    fireEvent.pointerMove(canvas, { clientX: 50, clientY: 50, pointerId: 1 });
+    expect(paint.frameCount()).toBe(framesAfterDown);
+
+    flushAnimationFrames();
+    expect(paint.frameCount()).toBe(framesAfterDown + 1);
+  });
+});


### PR DESCRIPTION
Source: [Plane 工作项 #769 / repo issue #549](https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/c42d0639-0b4b-413f-a126-3701f49c8421) — 用户报告 Mark 工具"标注项显示不更新"（付费洞察，二手转述，无复现步骤）。

## Why

A paid-insight report (issue #549 / Plane #769) said annotations in the Mark tool stop updating on screen — the core annotate-and-preview loop reads as broken. The report came second-hand with no repro steps, so per the planning spec the first deliverable was a reproduction matrix that pins a falsifiable failing scenario before touching source.

The matrix confirmed the spec's root-cause candidate 1 (cross-tool paths): `selectMarkTool` switches the tool **without cancelling the in-flight gesture**, leaving `boxDraftRef` / `drawingRef` hanging. Every later pointer event is then misrouted through that stale gesture:

- an abandoned **box draft** swallows all of the next pen stroke's pointermoves — the user draws and **no ink ever appears** (the literal reported symptom);
- the abandoned draft keeps resizing under the cursor and gets **committed as a rectangle the user never drew**;
- an abandoned **pen stroke** keeps growing from bare hover moves (no button pressed), painting ghost ink;
- with the text tool, dropping a label also resurrects the hanging draft rectangle.

A mid-gesture tool switch is a real interaction: on touch, finger 1 is drawing while finger 2 taps the tool menu; the same hang also occurs whenever the canvas misses a gesture's pointerup.

## What users will see

No new UI. In the Mark tool (artifact preview and Design Browser — the fix is inside the shared component, both mounts benefit):

- Switching between box / pen / text mid-gesture now cleanly discards the half-finished drag or stroke; the next annotation paints immediately.
- No more ghost rectangles that resize while hovering, no self-drawing ink after a tool switch, and no phantom box silently added to the submitted screenshot.

**Implementation decision (flagging for review):** a tool switch **discards** the in-flight gesture rather than committing it. Discarding matches the existing undo semantics for drafts (an uncommitted draft is not a mark) and never fabricates a mark the user didn't finish; if product prefers commit-on-switch, it's a one-line change inside `cancelActiveGesture`.

Structurally, per the spec's "let the fix read as an invariant" requirement, the scattered `syncHistoryState()` / `redraw()` / `bumpLayoutRevision()` choreography is converged into a single commit path `commitInkMutation(mutate, opts)` whose docblock states the invariant: when it returns, canvas pixels, toolbar derived state, and dock position agree with the refs. All 13 one-shot mutation sites now route through it; the pointermove hot path keeps rAF coalescing via `{ coalesce: true }` (guarded by a dedicated test), so the high-Hz pointer performance characteristic is preserved. One-shot commits also cancel any pending coalesced frame — that removes redundant repaints (the previously inline special case in `onPointerUp`), not a "stale frame overwrites new pixels" hazard, since `redraw()` always reads the latest refs.

## Surface area

- [ ] **UI** — no new page / dialog / panel / menu item / setting (behavior fix inside the existing Mark overlay)
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — single-component bug fix (`apps/web/src/components/PreviewDrawOverlay.tsx`) + tests; no new surface, no HTTP/contracts/CLI change, so the UI/CLI dual-track closure does not apply (no new capability)

## Screenshots

This run is headless, so no screen recording is attached. Reviewer repro (before/after, ~30s each) — per the repo playbook, stage two namespaced runtimes (`main` vs this branch) and walk the same steps:

1. Open any artifact preview → toolbar **Mark** button.
2. Box tool: press and drag on the canvas, and **while still dragging** (or after the canvas missed the pointerup, e.g. second touch finger) switch the mark tool to **Pen**.
3. Draw with the pen.
   - `main`: no ink appears while drawing; a ghost rectangle follows the cursor and a box you never drew is committed.
   - this branch: the pen stroke paints live; no ghost rectangle.
4. Reverse direction (pen mid-stroke → switch to box, then just hover): `main` grows ink from hover moves; this branch doesn't.

## Bug fix verification

- Test path: `apps/web/tests/components/PreviewDrawOverlay.redraw-sync.test.tsx` — observes actually-painted canvas frames via a recording 2D context (defines `window.CanvasRenderingContext2D` so `redraw()` doesn't bail in jsdom, per the spec's testing caveat; asserts per-canvas so the composite pipeline's offscreen canvas can't pollute counts).
- Red on `main`, green on this branch? **yes** — the three regression rows fail on the unmodified source exactly as analyzed (`boxes: 1` ghost rectangle painted; hover-grown stroke `{ segments: 3 }` painted; resurrected draft while placing a text label), and pass with the fix. The fourth row (pointermove repaints coalesce into one animation frame) is a perf guard that is green on both sides by design.

Reproduction-matrix conclusions for the other spec candidates (all left out of this PR, see Adjacent issues): single-branch missed-sync calls — not found (matches the spec's static walkthrough); rAF-starvation (candidate 2) — not reproducible as a user-visible failure (pending frames resume on visibility; `onPointerUp` already repaints synchronously), so the spec's conditional `visibilitychange` fallback was **not** added; resize-race (candidate 3) — `resize()` always ends in a synchronous `redraw()`, no lost paint found; candidates 4/5/6 — out of scope by the spec (product decisions).

## Validation

- `pnpm guard` ✅
- `pnpm typecheck` ✅
- `pnpm --filter @open-design/web test` ✅ — 412 files, 4300 passed / 7 skipped, no new failures vs baseline (branch differs from `main` only by this commit; the three overlay suites `PreviewDrawOverlay.test.tsx`, `capture-fallback`, `send-disabled` all green)

## Adjacent issues

Out-of-scope defects confirmed while walking the matrix (per the Bug follow-up workflow, each needs its own red spec / decision, not this PR):

1. **Global Cmd/Ctrl+Z interception from inactive mounts** — the overlay's keyboard effect (`PreviewDrawOverlay.tsx`, keydown listener) is not gated on `active`; the two static shell mounts in `FileViewer.tsx` `preventDefault` native undo everywhere the viewer is open.
2. **`sending` window silently drops pointer input (spec candidate 6)** — during a submit, pointerdown/move/up and undo/redo early-return with no visible feedback; if the submit's pointerup was swallowed and the send then *fails*, the un-terminated draft is left hanging (same ghost family as this fix, different trigger). Needs the product decision recorded in the spec's open question 3.
3. **Viewport-anchored marks vs content scroll / srcDoc remount (spec candidates 4/5)** — annotations don't follow scrolled or refreshed content; anchoring semantics are a product call, spec'd as a separate issue.

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>