### PR TITLE
fix(web): hide native caret while composer placeholder carousel runs

### DIFF
--- a/apps/web/src/styles/chat.css
+++ b/apps/web/src/styles/chat.css
@@ -1244,6 +1244,17 @@
   caret-color: var(--accent);
   -webkit-user-modify: read-write-plaintext-only; /* paste-as-plain-text guard */
 }
+/* While the empty composer runs the placeholder typewriter carousel, the
+   carousel draws its own decorative caret trailing the animated text. Suppress
+   the native caret (which sits at offset 0) so the two don't blink at once
+   (#5373). Keyed off the carousel being a later sibling of the editor, so it
+   covers both the chat composer (.composer-input-wrap) and the home hero
+   (.home-hero__prompt-editor) without depending on the wrapper class. The
+   carousel unmounts as soon as the field has text, which restores the native
+   caret automatically. */
+.composer-input-editor:has(~ .home-hero__carousel) [contenteditable='true'] {
+  caret-color: transparent;
+}
 .composer.composer-active-file-mode .composer-input-editor [contenteditable='true'],
 .composer.composer-active-file-mode .composer-input-editor .composer-editable {
   min-height: clamp(150px, 20vh, 210px);


### PR DESCRIPTION
## Summary

An empty, focused composer runs a placeholder typewriter carousel that draws its own decorative caret trailing the animated text. The native browser caret also blinks at offset 0, so two carets show at once (#5373).

## Fix

Suppress the native caret while the carousel is mounted; it reverts automatically the moment the field has text.

Keyed off the carousel being a sibling of the editor (`:has(~ .home-hero__carousel)`), so it covers both the chat composer (`.composer-input-wrap`) and the home hero (`.home-hero__prompt-editor`) without depending on the wrapper class.

## Validation

- Chat composer: `composer-input-editor` and `PlaceholderCarousel` are siblings inside `composer-input-wrap` ✅
- Home hero: same sibling structure inside `home-hero__prompt-editor` ✅
- The `:has` selector targets the carousel via its `.home-hero__carousel` class — a sibling beyond which the carousel always appears when mounted
- Carousel unmounts when `active=false` (non-empty field), restoring native caret automatically
- No JS changes — pure CSS

Closes #5373