### PR TITLE
fix(skills): pin the data-report wide-table date column under horizontal scroll

### DIFF
--- a/e2e/tests/skills/data-report.test.ts
+++ b/e2e/tests/skills/data-report.test.ts
@@ -1,0 +1,69 @@
+// The data-report template ships twice: skills/data-report/ (the skill the
+// agent reads mid-task) and plugins/_official/examples/data-report/ (the
+// Community gallery mirror). The two copies must stay byte-for-byte identical
+// for SKILL.md and example.html — the migration generator must NOT be re-run
+// to sync them, because it rebuilds open-design.json and drops the mirror's
+// hand-added i18n fields.
+//
+// example.html is also the visual anchor for the wide-table pinned-column
+// contract (issue nexu-io/open-design#417, internal #691): a horizontal
+// scroll container, a sticky first column with a z-index ladder, and opaque
+// td-level zebra backgrounds. The load-bearing properties must live in the
+// example's own <style> block (not only in CDN Tailwind classes) so the
+// contract survives offline. The behavioral proof lives in
+// e2e/ui/data-report-sticky-column.test.ts; this spec pins the static shape
+// against future drift.
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
+const skillDir = path.join(repoRoot, 'skills', 'data-report');
+const mirrorDir = path.join(repoRoot, 'plugins', '_official', 'examples', 'data-report');
+
+describe('data-report template', () => {
+  it('[P2] skills/ and plugins/ mirror copies are byte-for-byte identical', async () => {
+    for (const file of ['SKILL.md', 'example.html']) {
+      const [skill, mirror] = await Promise.all([
+        readFile(path.join(skillDir, file), 'utf8'),
+        readFile(path.join(mirrorDir, file), 'utf8'),
+      ]);
+      expect(mirror, `${file} drifted between skills/data-report and plugins mirror`).toBe(skill);
+    }
+  });
+
+  it('[P2] example.html carries the pinned-column contract in its own <style> block', async () => {
+    const html = await readFile(path.join(skillDir, 'example.html'), 'utf8');
+    const styleBlock = html.match(/<style>([\s\S]*?)<\/style>/)?.[1];
+    expect(styleBlock, 'example.html must have an inline <style> block').toBeTruthy();
+    const css = styleBlock ?? '';
+
+    // Horizontal scroll container (not overflow:hidden clipping).
+    expect(css).toMatch(/\.table-scroll\s*\{[^}]*overflow-x\s*:\s*auto/);
+    // Sticky pinned first column with its z-index step above dynamic cells.
+    expect(css).toMatch(/th:first-child,\s*td:first-child\s*\{[^}]*position\s*:\s*sticky/);
+    expect(css).toMatch(/tbody td:first-child\s*\{[^}]*z-index\s*:\s*1/);
+    // Header above data cells; top-left crossing cell above everything.
+    expect(css).toMatch(/thead th\s*\{[^}]*z-index\s*:\s*2/);
+    expect(css).toMatch(/thead th:first-child\s*\{[^}]*z-index\s*:\s*3/);
+    // Opaque td-level backgrounds: base, zebra stripe, and hover must target
+    // td (row-level backgrounds do not participate in sticky layering).
+    expect(css).toMatch(/tbody td\s*\{[^}]*background\s*:\s*#/);
+    expect(css).toMatch(/tbody tr:nth-child\(even\)\s+td\s*\{[^}]*background/);
+    expect(css).toMatch(/tbody tr:hover\s+td\s*\{[^}]*background/);
+
+    // The detail table must be wired through the scroll container.
+    expect(html).toContain('class="table-scroll"');
+  });
+
+  it('[P2] SKILL.md spells out the wide-table pinned-column contract', async () => {
+    const skillMd = await readFile(path.join(skillDir, 'SKILL.md'), 'utf8');
+    expect(skillMd).toContain('overflow-x:auto');
+    expect(skillMd).toContain('position:sticky; left:0;');
+    expect(skillMd).toContain('z-index:3');
+    expect(skillMd).toContain('tbody tr:nth-child(even) td');
+  });
+});

--- a/e2e/ui/data-report-sticky-column.test.ts
+++ b/e2e/ui/data-report-sticky-column.test.ts
@@ -1,0 +1,195 @@
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '@/playwright/suite';
+
+// Regression for the data-report template (skills/data-report/example.html):
+// when a report table grows enough columns to scroll horizontally, the pinned
+// date (first) column must stay visible. On main the example table had no
+// horizontal-scroll story at all (5 columns inside an `overflow-hidden` card),
+// and its base styles carried two latent bugs that agent-generated wide tables
+// inherited: sticky cells without a z-index ladder (dynamic columns paint over
+// the pinned column) and zebra/hover backgrounds on the `tr` row level (row
+// backgrounds do not participate in sticky layering, so scrolled content
+// bleeds through the transparent pinned cells).
+//
+// Issue: nexu-io/open-design#417 (internal #691).
+//
+// Shape:
+// 1. Scenario guard — the example's detail table actually scrolls
+//    horizontally (red on main, where the table cannot scroll).
+// 2. Symptom assertion — after scrolling to the middle, hit-testing inside
+//    the pinned column's slot must resolve to a first-column cell with a
+//    fully opaque background.
+// 3. Known-bad controls — fixed fixtures reproducing the pre-fix styles keep
+//    proving the symptom assertion can detect both failure modes (takeover by
+//    dynamic columns, and row-background bleed-through), so a green run is
+//    never vacuous.
+
+const repoRoot = fileURLToPath(new URL('../../', import.meta.url));
+const exampleHtmlPath = path.join(repoRoot, 'skills', 'data-report', 'example.html');
+
+type FirstColumnProbe = {
+  scrollable: boolean;
+  scrolled: boolean;
+  hitCellIndex: number | null;
+  hitBackgroundAlpha: number | null;
+  hitDescription: string;
+};
+
+// Scrolls the `.table-scroll` container to its horizontal midpoint, then
+// hit-tests a point inside the pinned first column's slot (left edge of the
+// scroll viewport) on the given tbody row. Reports which column the topmost
+// element belongs to and how opaque its cell background is.
+async function probeFirstColumnAfterHorizontalScroll(
+  page: Page,
+  rowIndex: number,
+): Promise<FirstColumnProbe> {
+  return await page.evaluate(async (nthRow: number) => {
+    const scroller = document.querySelector('.table-scroll');
+    if (!(scroller instanceof HTMLElement)) {
+      throw new Error('missing .table-scroll horizontal scroll container');
+    }
+    const scrollable = scroller.scrollWidth > scroller.clientWidth;
+    scroller.scrollLeft = (scroller.scrollWidth - scroller.clientWidth) / 2;
+
+    const row = scroller.querySelector(`tbody tr:nth-child(${nthRow})`);
+    if (!row) throw new Error(`missing probe row tbody tr:nth-child(${nthRow})`);
+    // The detail table sits below the fold in the real example page;
+    // elementFromPoint only hit-tests inside the viewport.
+    row.scrollIntoView({ block: 'center' });
+    await new Promise((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve(null))),
+    );
+    const rowRect = row.getBoundingClientRect();
+    const scrollerRect = scroller.getBoundingClientRect();
+    // 24px inside the scroll viewport's left edge — well within the pinned
+    // column's extent (its padding alone is 14px), regardless of column width.
+    const x = scrollerRect.left + 24;
+    const y = rowRect.top + rowRect.height / 2;
+    const hit = document.elementFromPoint(x, y);
+    const cell = hit?.closest('td, th') ?? null;
+
+    let alpha: number | null = null;
+    if (cell) {
+      const background = getComputedStyle(cell).backgroundColor;
+      const channels = background.match(/rgba?\(([^)]+)\)/);
+      if (channels?.[1]) {
+        const parts = channels[1].split(',').map((value) => Number.parseFloat(value));
+        alpha = parts.length >= 4 ? (parts[3] ?? 0) : 1;
+      } else {
+        alpha = 0;
+      }
+    }
+
+    return {
+      scrollable,
+      scrolled: scroller.scrollLeft > 0,
+      hitCellIndex: cell instanceof HTMLTableCellElement ? cell.cellIndex : null,
+      hitBackgroundAlpha: alpha,
+      hitDescription: hit instanceof HTMLElement ? `${hit.tagName}.${hit.className}` : 'null',
+    };
+  }, rowIndex);
+}
+
+// The pre-fix table styles from skills/data-report/example.html as they were
+// on main, applied to a wide table. main's card was `overflow-hidden` (the
+// wide table could not scroll at all), so the fixture adds only the scroll
+// container + min-width needed to reach the scrolling scenario — the
+// layering/background rules under test are byte-for-byte the main-era ones.
+const MAIN_ERA_TABLE_CSS = `
+  .table-scroll { overflow-x:auto; }
+  table { border-collapse:collapse; width:100%; min-width:1280px; font-size:13px; }
+  thead th { background:#f4f1ec; text-align:left; padding:10px 14px; position:sticky; top:0; }
+  tbody td { padding:10px 14px; border-bottom:1px solid #e7e5e0; }
+  tbody tr:nth-child(even) { background:#fbfaf7; }
+  tbody tr:hover { background:#f4f1ec; }
+`;
+
+function buildWideTableDocument(extraCss: string): string {
+  const columns = ['月份', ...Array.from({ length: 9 }, (_, i) => `指标 ${i + 1}`)];
+  const head = `<tr>${columns.map((label) => `<th>${label}</th>`).join('')}</tr>`;
+  const rows = Array.from({ length: 6 }, (_, r) => {
+    const cells = columns
+      .map((_, c) => `<td>${c === 0 ? `2025-0${r + 1}` : `v${r + 1}.${c}`}</td>`)
+      .join('');
+    return `<tr>${cells}</tr>`;
+  }).join('');
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"><style>${MAIN_ERA_TABLE_CSS}${extraCss}</style></head><body><div class="table-scroll"><table><thead>${head}</thead><tbody>${rows}</tbody></table></div></body></html>`;
+}
+
+test.beforeEach(async ({ page }) => {
+  // Narrow enough that the 1280px-min-width table must scroll horizontally.
+  await page.setViewportSize({ width: 1000, height: 800 });
+  // The pinned-column contract must hold without any CDN (Tailwind, fonts,
+  // Chart.js): every load-bearing property lives in the example's own
+  // <style> block, so all external requests are refused.
+  await page.route(/^https?:\/\//, (route) => route.abort());
+});
+
+test('[P2] data-report example keeps the pinned date column visible and opaque under horizontal scroll', async ({
+  page,
+}) => {
+  await page.goto(pathToFileURL(exampleHtmlPath).href);
+  // The detail rows are rendered by the example's inline script.
+  await expect(page.locator('#rows tr')).toHaveCount(9);
+
+  // Row 1 exercises the base (white) row background, row 2 the zebra stripe —
+  // both must be opaque at the td level for the pinned column to mask
+  // scrolled-under content.
+  for (const rowIndex of [1, 2]) {
+    const probe = await probeFirstColumnAfterHorizontalScroll(page, rowIndex);
+    expect(
+      probe.scrollable,
+      'scenario guard: the detail table must overflow its scroll container horizontally',
+    ).toBe(true);
+    expect(probe.scrolled, 'scenario guard: the container must actually scroll').toBe(true);
+    expect(
+      probe.hitCellIndex,
+      `row ${rowIndex}: the pinned column slot is covered by ${probe.hitDescription}`,
+    ).toBe(0);
+    expect(
+      probe.hitBackgroundAlpha,
+      `row ${rowIndex}: the pinned cell background must be fully opaque, got ${JSON.stringify(probe)}`,
+    ).toBe(1);
+  }
+});
+
+test('[P2] known-bad control: main-era styles without a pinned column let dynamic columns take the date slot', async ({
+  page,
+}) => {
+  await page.setContent(buildWideTableDocument(''));
+
+  const probe = await probeFirstColumnAfterHorizontalScroll(page, 2);
+  expect(probe.scrollable).toBe(true);
+  expect(probe.scrolled).toBe(true);
+  // Detection power: with no sticky first column the date column scrolls away
+  // and a dynamic column occupies its slot. If this ever reports cell 0, the
+  // symptom assertion above has gone vacuous.
+  expect(probe.hitCellIndex, `expected a dynamic column, got ${probe.hitDescription}`).not.toBe(0);
+  expect(probe.hitCellIndex).not.toBeNull();
+});
+
+test('[P2] known-bad control: naive sticky column over row-level zebra bleeds scrolled content through', async ({
+  page,
+}) => {
+  // What an agent following the old SKILL.md got by adding only
+  // `position:sticky; left:0` — no z-index ladder, no opaque td background.
+  await page.setContent(
+    buildWideTableDocument('th:first-child, td:first-child { position:sticky; left:0; }'),
+  );
+
+  // Row 2 carries the zebra stripe on the tr level: the sticky td itself is
+  // transparent, so the row background (and anything scrolled underneath)
+  // shows through the pinned cell.
+  const probe = await probeFirstColumnAfterHorizontalScroll(page, 2);
+  expect(probe.scrollable).toBe(true);
+  expect(probe.scrolled).toBe(true);
+  expect(probe.hitCellIndex).toBe(0);
+  expect(
+    probe.hitBackgroundAlpha,
+    'detection power: the naive sticky cell must read as transparent',
+  ).toBeLessThan(1);
+});

--- a/plugins/_official/examples/data-report/SKILL.md
+++ b/plugins/_official/examples/data-report/SKILL.md
@@ -39,6 +39,10 @@ od:
 - 主图表区: 至少 2 个图表 (柱状 / 折线 / 饼 / 散点), 使用 Chart.js 或 ECharts (jsdelivr CDN 引入), 数据从用户输入解析得到。
 - **图表容器必须有固定高度**: 每个 `<canvas>` 外层包一个 `<div style="position:relative;height:NNNpx">` (KPI 迷你图 ~40px, 主图表 ~240–280px)。Chart.js 用 `responsive:true, maintainAspectRatio:false` 时若父容器没有显式高度, 会陷入 ResizeObserver 死循环, 图表无限增高直至卡死浏览器。**绝对不要**直接给 canvas 写 `height=` 属性当布局, 那个只是初始值。
 - 数据表格: 用户原始数据节选, 使用 `<table>` + 现代化样式 (zebra stripe, hover, sticky header)。
+- **宽表必须横向滚动 + 固定首列**: 列数多 (约 ≥6 列或含长文本列) 时, 把 `<table>` 包进 `overflow-x:auto` 的滚动容器里。**不要**把 overflow 写在 `<table>` 自身上, 也**不要**用 `overflow:hidden` 把宽表裁掉。首列 (日期/主键列) 钉住: `th:first-child, td:first-child { position:sticky; left:0; }`。注意 `position:sticky` 只相对最近的滚动容器生效——表格包进 overflow 容器后, `thead th { top:0 }` 钉的是容器内部的垂直滚动, 不再相对页面滚动。
+- **固定列 z-index 阶梯** (否则横向滚动时动态列会盖住固定列): 普通数据单元格不设 z-index (auto); 固定列 `tbody td:first-child` 用 `z-index:1` 压过滚动的动态列; 表头 `thead th` 用 `z-index:2` 压过所有数据单元格; 左上交叉单元格 `thead th:first-child` 用 `left:0; z-index:3` 同时钉住两个方向、压过一切。
+- **sticky 单元格必须有自身的不透明背景色**: zebra 条纹和 hover 背景必须落在 `td` 级 (`tbody tr:nth-child(even) td { … }`、`tbody tr:hover td { … }`), **不要**只写在 `tr` 行级——行背景不参与 sticky 分层, 横向滚动时滚过的内容会从固定列底下透出来。
+- 固定列右缘建议用 `box-shadow` (如 `2px 0 4px rgba(0,0,0,0.06)`) 提示"后面还有列"; `border-collapse:collapse` 下 sticky 单元格的边框滚动时会丢失, 需要边框跟随时改用 `border-collapse:separate; border-spacing:0`。
 - 洞察块: 3-5 条文字洞察, 用 emoji 开头, 像产品周报。
 - 底部"方法论"折叠区。
 - 配色克制专业: 主色 1 + 中性色阶, 图表用调色板。

--- a/plugins/_official/examples/data-report/example.html
+++ b/plugins/_official/examples/data-report/example.html
@@ -10,11 +10,17 @@
   body { background:#fafaf7; font-family:'Inter','Noto Sans SC',sans-serif; color:#15140f; -webkit-font-smoothing:antialiased; }
   .num { font-family:'Inter',sans-serif; font-feature-settings:'tnum' on; letter-spacing:-0.02em; }
   .section h2 { font-size:11px; font-weight:700; letter-spacing:0.18em; text-transform:uppercase; color:#5a564e; margin:0 0 16px; }
-  table { border-collapse:collapse; width:100%; font-size:13px; }
-  thead th { background:#f4f1ec; text-align:left; padding:10px 14px; font-size:11px; font-weight:700; letter-spacing:0.08em; text-transform:uppercase; color:#5a564e; position:sticky; top:0; }
-  tbody td { padding:10px 14px; border-bottom:1px solid #e7e5e0; }
-  tbody tr:nth-child(even) { background:#fbfaf7; }
-  tbody tr:hover { background:#f4f1ec; }
+  /* 宽表契约: 横向滚动容器 + sticky 固定首列 + z-index 阶梯 + td 级不透明背景。
+     这些承重属性必须写在这里 (或内联 style), 不能只用 Tailwind 工具类——CDN 失效时契约仍需成立。 */
+  .table-scroll { overflow-x:auto; }
+  table { border-collapse:separate; border-spacing:0; width:100%; min-width:1280px; font-size:13px; }
+  thead th { background:#f4f1ec; text-align:left; padding:10px 14px; font-size:11px; font-weight:700; letter-spacing:0.08em; text-transform:uppercase; color:#5a564e; position:sticky; top:0; z-index:2; white-space:nowrap; }
+  tbody td { padding:10px 14px; border-bottom:1px solid #e7e5e0; background:#ffffff; white-space:nowrap; }
+  tbody tr:nth-child(even) td { background:#fbfaf7; }
+  tbody tr:hover td { background:#f4f1ec; }
+  th:first-child, td:first-child { position:sticky; left:0; box-shadow:2px 0 4px rgba(0,0,0,0.06); }
+  tbody td:first-child { z-index:1; }
+  thead th:first-child { z-index:3; }
   .delta-up { color:#1f7a3a; font-weight:600; }
   .delta-down { color:#9c2a25; font-weight:600; }
 </style>
@@ -84,10 +90,25 @@
   <section class="section mb-10">
     <h2>明细 · Raw data</h2>
     <div class="rounded-2xl border border-[#e7e5e0] overflow-hidden bg-white">
-      <table>
-        <thead><tr><th>月份</th><th class="text-right">MAU</th><th class="text-right">新增</th><th class="text-right">付费</th><th class="text-right">流失率</th></tr></thead>
-        <tbody id="rows"></tbody>
-      </table>
+      <div class="table-scroll">
+        <!-- 内联 border-collapse: Tailwind CDN 的 preflight 带 table { border-collapse:collapse },
+             注入顺序不可控; collapse 模式下 sticky 单元格的边框滚动时会丢失, 内联保证 separate 恒生效。 -->
+        <table style="border-collapse:separate;border-spacing:0">
+          <thead><tr>
+            <th>月份</th>
+            <th class="text-right">MAU</th>
+            <th class="text-right">MAU 环比</th>
+            <th class="text-right">净增 MAU</th>
+            <th class="text-right">新增</th>
+            <th class="text-right">新增环比</th>
+            <th class="text-right">付费</th>
+            <th class="text-right">付费环比</th>
+            <th class="text-right">付费率</th>
+            <th class="text-right">流失率</th>
+          </tr></thead>
+          <tbody id="rows"></tbody>
+        </table>
+      </div>
     </div>
   </section>
 
@@ -136,15 +157,28 @@ const data = [
   {month:'2025-05', mau:23950, signups:4250, paying:2418, churn:0.018},
 ];
 
-document.getElementById('rows').innerHTML = data.map(d => `
+// 派生列全部由 data 纯计算得出 (环比 = 与上一行比较, 首行无上月记 "—")
+const growthPct = (cur, prev) => prev == null ? null : (cur - prev) / prev * 100;
+const fmtGrowth = (v) => v == null
+  ? '<span class="text-[#5a564e]">—</span>'
+  : `<span class="${v >= 0 ? 'delta-up' : 'delta-down'}">${v >= 0 ? '▲' : '▼'} ${Math.abs(v).toFixed(1)}%</span>`;
+
+document.getElementById('rows').innerHTML = data.map((d, i) => {
+  const prev = i > 0 ? data[i - 1] : null;
+  return `
   <tr>
     <td class="font-mono text-xs">${d.month}</td>
     <td class="text-right num">${d.mau.toLocaleString()}</td>
+    <td class="text-right num">${fmtGrowth(growthPct(d.mau, prev?.mau))}</td>
+    <td class="text-right num">${prev ? '+' + (d.mau - prev.mau).toLocaleString() : '<span class="text-[#5a564e]">—</span>'}</td>
     <td class="text-right num">${d.signups.toLocaleString()}</td>
+    <td class="text-right num">${fmtGrowth(growthPct(d.signups, prev?.signups))}</td>
     <td class="text-right num">${d.paying.toLocaleString()}</td>
+    <td class="text-right num">${fmtGrowth(growthPct(d.paying, prev?.paying))}</td>
+    <td class="text-right num">${(d.paying / d.mau * 100).toFixed(1)}%</td>
     <td class="text-right num">${(d.churn*100).toFixed(1)}%</td>
-  </tr>
-`).join('');
+  </tr>`;
+}).join('');
 
 const sparkOpts = { responsive:true, maintainAspectRatio:false, plugins:{legend:{display:false},tooltip:{enabled:false}}, scales:{x:{display:false},y:{display:false}}, elements:{point:{radius:0},line:{tension:0.4,borderWidth:2}} };
 new Chart(document.getElementById('kpi1'), { type:'line', data:{labels:data.map(d=>d.month), datasets:[{data:data.map(d=>d.mau), borderColor:'#c96442', fill:false}]}, options:sparkOpts });

--- a/skills/data-report/SKILL.md
+++ b/skills/data-report/SKILL.md
@@ -39,6 +39,10 @@ od:
 - 主图表区: 至少 2 个图表 (柱状 / 折线 / 饼 / 散点), 使用 Chart.js 或 ECharts (jsdelivr CDN 引入), 数据从用户输入解析得到。
 - **图表容器必须有固定高度**: 每个 `<canvas>` 外层包一个 `<div style="position:relative;height:NNNpx">` (KPI 迷你图 ~40px, 主图表 ~240–280px)。Chart.js 用 `responsive:true, maintainAspectRatio:false` 时若父容器没有显式高度, 会陷入 ResizeObserver 死循环, 图表无限增高直至卡死浏览器。**绝对不要**直接给 canvas 写 `height=` 属性当布局, 那个只是初始值。
 - 数据表格: 用户原始数据节选, 使用 `<table>` + 现代化样式 (zebra stripe, hover, sticky header)。
+- **宽表必须横向滚动 + 固定首列**: 列数多 (约 ≥6 列或含长文本列) 时, 把 `<table>` 包进 `overflow-x:auto` 的滚动容器里。**不要**把 overflow 写在 `<table>` 自身上, 也**不要**用 `overflow:hidden` 把宽表裁掉。首列 (日期/主键列) 钉住: `th:first-child, td:first-child { position:sticky; left:0; }`。注意 `position:sticky` 只相对最近的滚动容器生效——表格包进 overflow 容器后, `thead th { top:0 }` 钉的是容器内部的垂直滚动, 不再相对页面滚动。
+- **固定列 z-index 阶梯** (否则横向滚动时动态列会盖住固定列): 普通数据单元格不设 z-index (auto); 固定列 `tbody td:first-child` 用 `z-index:1` 压过滚动的动态列; 表头 `thead th` 用 `z-index:2` 压过所有数据单元格; 左上交叉单元格 `thead th:first-child` 用 `left:0; z-index:3` 同时钉住两个方向、压过一切。
+- **sticky 单元格必须有自身的不透明背景色**: zebra 条纹和 hover 背景必须落在 `td` 级 (`tbody tr:nth-child(even) td { … }`、`tbody tr:hover td { … }`), **不要**只写在 `tr` 行级——行背景不参与 sticky 分层, 横向滚动时滚过的内容会从固定列底下透出来。
+- 固定列右缘建议用 `box-shadow` (如 `2px 0 4px rgba(0,0,0,0.06)`) 提示"后面还有列"; `border-collapse:collapse` 下 sticky 单元格的边框滚动时会丢失, 需要边框跟随时改用 `border-collapse:separate; border-spacing:0`。
 - 洞察块: 3-5 条文字洞察, 用 emoji 开头, 像产品周报。
 - 底部"方法论"折叠区。
 - 配色克制专业: 主色 1 + 中性色阶, 图表用调色板。

--- a/skills/data-report/example.html
+++ b/skills/data-report/example.html
@@ -10,11 +10,17 @@
   body { background:#fafaf7; font-family:'Inter','Noto Sans SC',sans-serif; color:#15140f; -webkit-font-smoothing:antialiased; }
   .num { font-family:'Inter',sans-serif; font-feature-settings:'tnum' on; letter-spacing:-0.02em; }
   .section h2 { font-size:11px; font-weight:700; letter-spacing:0.18em; text-transform:uppercase; color:#5a564e; margin:0 0 16px; }
-  table { border-collapse:collapse; width:100%; font-size:13px; }
-  thead th { background:#f4f1ec; text-align:left; padding:10px 14px; font-size:11px; font-weight:700; letter-spacing:0.08em; text-transform:uppercase; color:#5a564e; position:sticky; top:0; }
-  tbody td { padding:10px 14px; border-bottom:1px solid #e7e5e0; }
-  tbody tr:nth-child(even) { background:#fbfaf7; }
-  tbody tr:hover { background:#f4f1ec; }
+  /* 宽表契约: 横向滚动容器 + sticky 固定首列 + z-index 阶梯 + td 级不透明背景。
+     这些承重属性必须写在这里 (或内联 style), 不能只用 Tailwind 工具类——CDN 失效时契约仍需成立。 */
+  .table-scroll { overflow-x:auto; }
+  table { border-collapse:separate; border-spacing:0; width:100%; min-width:1280px; font-size:13px; }
+  thead th { background:#f4f1ec; text-align:left; padding:10px 14px; font-size:11px; font-weight:700; letter-spacing:0.08em; text-transform:uppercase; color:#5a564e; position:sticky; top:0; z-index:2; white-space:nowrap; }
+  tbody td { padding:10px 14px; border-bottom:1px solid #e7e5e0; background:#ffffff; white-space:nowrap; }
+  tbody tr:nth-child(even) td { background:#fbfaf7; }
+  tbody tr:hover td { background:#f4f1ec; }
+  th:first-child, td:first-child { position:sticky; left:0; box-shadow:2px 0 4px rgba(0,0,0,0.06); }
+  tbody td:first-child { z-index:1; }
+  thead th:first-child { z-index:3; }
   .delta-up { color:#1f7a3a; font-weight:600; }
   .delta-down { color:#9c2a25; font-weight:600; }
 </style>
@@ -84,10 +90,25 @@
   <section class="section mb-10">
     <h2>明细 · Raw data</h2>
     <div class="rounded-2xl border border-[#e7e5e0] overflow-hidden bg-white">
-      <table>
-        <thead><tr><th>月份</th><th class="text-right">MAU</th><th class="text-right">新增</th><th class="text-right">付费</th><th class="text-right">流失率</th></tr></thead>
-        <tbody id="rows"></tbody>
-      </table>
+      <div class="table-scroll">
+        <!-- 内联 border-collapse: Tailwind CDN 的 preflight 带 table { border-collapse:collapse },
+             注入顺序不可控; collapse 模式下 sticky 单元格的边框滚动时会丢失, 内联保证 separate 恒生效。 -->
+        <table style="border-collapse:separate;border-spacing:0">
+          <thead><tr>
+            <th>月份</th>
+            <th class="text-right">MAU</th>
+            <th class="text-right">MAU 环比</th>
+            <th class="text-right">净增 MAU</th>
+            <th class="text-right">新增</th>
+            <th class="text-right">新增环比</th>
+            <th class="text-right">付费</th>
+            <th class="text-right">付费环比</th>
+            <th class="text-right">付费率</th>
+            <th class="text-right">流失率</th>
+          </tr></thead>
+          <tbody id="rows"></tbody>
+        </table>
+      </div>
     </div>
   </section>
 
@@ -136,15 +157,28 @@ const data = [
   {month:'2025-05', mau:23950, signups:4250, paying:2418, churn:0.018},
 ];
 
-document.getElementById('rows').innerHTML = data.map(d => `
+// 派生列全部由 data 纯计算得出 (环比 = 与上一行比较, 首行无上月记 "—")
+const growthPct = (cur, prev) => prev == null ? null : (cur - prev) / prev * 100;
+const fmtGrowth = (v) => v == null
+  ? '<span class="text-[#5a564e]">—</span>'
+  : `<span class="${v >= 0 ? 'delta-up' : 'delta-down'}">${v >= 0 ? '▲' : '▼'} ${Math.abs(v).toFixed(1)}%</span>`;
+
+document.getElementById('rows').innerHTML = data.map((d, i) => {
+  const prev = i > 0 ? data[i - 1] : null;
+  return `
   <tr>
     <td class="font-mono text-xs">${d.month}</td>
     <td class="text-right num">${d.mau.toLocaleString()}</td>
+    <td class="text-right num">${fmtGrowth(growthPct(d.mau, prev?.mau))}</td>
+    <td class="text-right num">${prev ? '+' + (d.mau - prev.mau).toLocaleString() : '<span class="text-[#5a564e]">—</span>'}</td>
     <td class="text-right num">${d.signups.toLocaleString()}</td>
+    <td class="text-right num">${fmtGrowth(growthPct(d.signups, prev?.signups))}</td>
     <td class="text-right num">${d.paying.toLocaleString()}</td>
+    <td class="text-right num">${fmtGrowth(growthPct(d.paying, prev?.paying))}</td>
+    <td class="text-right num">${(d.paying / d.mau * 100).toFixed(1)}%</td>
     <td class="text-right num">${(d.churn*100).toFixed(1)}%</td>
-  </tr>
-`).join('');
+  </tr>`;
+}).join('');
 
 const sparkOpts = { responsive:true, maintainAspectRatio:false, plugins:{legend:{display:false},tooltip:{enabled:false}}, scales:{x:{display:false},y:{display:false}}, elements:{point:{radius:0},line:{tension:0.4,borderWidth:2}} };
 new Chart(document.getElementById('kpi1'), { type:'line', data:{labels:data.map(d=>d.month), datasets:[{data:data.map(d=>d.mau), borderColor:'#c96442', fill:false}]}, options:sparkOpts });


### PR DESCRIPTION
> External tracker (Plane, not a GitHub issue — no auto-close reference on purpose): https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/da9f159a-c5a6-4818-8dd8-7ef9b0c7c319 (internal #691, dispatched as nexu-io/open-design#417)

## Why

A user (黄月, 2026-07-01) reported that data-report tables with many columns break under horizontal scroll: the dynamic columns paint over the pinned date column, and the table's zebra/hover background bleeds through it, so rows can no longer be matched to their dates — the JTBD ("keep the date column visible while browsing wide data") fails outright.

There is no first-party report-table component in `apps/web`; "创建数据报表" is the agent generating an HTML report from the **`skills/data-report`** template, rendered in the FileViewer iframe. The host app cannot reach into the artifact's CSS, so the fix belongs in the template layer. The template itself planted the bug: `SKILL.md` asked only for "zebra stripe, hover, sticky header" with no wide-table layering contract, and `example.html` shipped a sticky header without z-index, zebra/hover on the `tr` row level (row backgrounds don't participate in sticky layering), and an `overflow-hidden` card that clips wide tables instead of scrolling. Any agent following that anchor reproduced the issue on wide tables.

## What users will see

- Newly generated data reports with wide detail tables scroll horizontally inside the card, with the date (first) column pinned on the left, always on top of the scrolling columns, with an opaque background and a subtle right-edge shadow — dates stay readable at any scroll position.
- The bundled data-report example (skill preview and Community gallery mirror) now demonstrates exactly this: its detail table grew from 5 to 10 columns (MoM growth for MAU/signups/paying, net MAU adds, paying rate — all derived purely from the existing data array, no invented data) so the pinned-column recipe is visible in the anchor itself.
- Existing, already-generated report HTML files do not self-heal (template fixes only affect new generations). Users can regenerate or ask the agent to patch an existing file per the new contract — worth noting back to the reporter on the Plane issue.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — change under `skills/` (`skills/data-report` + its byte-identical `plugins/_official/examples/data-report` mirror)
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

No UI surface in `apps/web`/`apps/desktop` is touched, hence no CLI counterpart applies — this is a template + test change.

## Screenshots

No `apps/web` UI changed, so no entry-point screenshot applies. For the template's visual acceptance: open `skills/data-report/example.html` in a browser and scroll the 明细 table horizontally — the month column stays pinned, opaque, above the scrolling columns (verified with the CDN active AND with all http(s) blocked; the load-bearing CSS is inline). The "before" overlay cannot be reproduced from main's example (5 columns never scroll); the two known-bad control tests in the red spec rebuild the main-era styles on a wide table and demonstrate both failure modes (column takeover + background bleed-through).

## Bug fix verification

- Red spec: `e2e/ui/data-report-sticky-column.test.ts` — offline (`page.route` aborts every http(s) request), loads the repo's `example.html` via `file://`, then (1) scenario guard: the detail table must overflow its scroll container horizontally, (2) symptom assertion: after scrolling to the middle, `document.elementFromPoint` inside the pinned column slot must resolve to a first-column cell whose computed background is fully opaque.
- Red on `main`, green on this branch: **yes** — verified by checking out main's `example.html` against this branch's test: the scenario guard fails (`missing .table-scroll horizontal scroll container`; main's 5-column table sits in `overflow-hidden` and cannot scroll). With this branch's template all 3 cases pass.
- Detection power stays proven: two known-bad controls embed the main-era styles on a wide fixture table — one without a pinned column (a dynamic column takes the date slot, `cellIndex ≠ 0`) and one with a naive `position:sticky; left:0` only (the pinned cell reads transparent, row zebra bleeds through). They keep the symptom assertion from ever going vacuous.
- Static drift guard: `e2e/tests/skills/data-report.test.ts` pins skills/plugins mirror byte-equality and the contract shape (`overflow-x` container, sticky + z-index ladder, td-level zebra) in `example.html`'s own `<style>` block.

## Validation

- `pnpm guard` — pass (fail 0)
- `pnpm typecheck` — pass (all packages)
- `pnpm --dir e2e typecheck` — pass
- `pnpm --dir e2e test tests/skills/data-report.test.ts` — 3 passed
- `pnpm --dir e2e exec playwright test ui/data-report-sticky-column.test.ts` — 3 passed (and the example case verified red against main's `example.html`)
- Mirror sync: `diff -q skills/data-report/{SKILL.md,example.html}` vs `plugins/_official/examples/data-report/` — identical (mirror synced by copy, NOT by re-running the migration generator, which would rebuild `open-design.json` and drop its hand-added 18-locale i18n fields; `open-design.json` untouched)
- Online-mode acceptance probe (CDN active): Tailwind injected, computed `border-collapse` stays `separate` (inline style beats Play-CDN preflight — this is why the table carries an inline `border-collapse:separate;border-spacing:0`), pinned cell hit-test passes with opaque zebra background

## Implementation decisions (for review course-correction)

- The `SKILL.md` contract uses the same bold-imperative phrasing as the existing chart-height rule (line 40), which has proven effective at steering generations.
- Derived columns exclude ARPU (no revenue field in the example data; adding it would violate the template's "must parse actual data, never invent" rule) and land on 10 columns — enough to force horizontal scroll at the example's content width.
- Spec OQ-1 (whether the reporter meant a baked dashboard plugin instead of this template) is left open deliberately: `skills/data-report` is the only first-party "创建数据报表" path found in the repo, and the contract/recipe would transfer unchanged if another surface is later confirmed.

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>