### PR TITLE
fix(web): use current logo on home entry surfaces

### DIFF
--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -116,7 +116,7 @@ export function EntryNavRail({
             data-testid="entry-nav-logo"
           >
             <img
-              src="/app-icon.svg"
+              src="/logo.svg"
               alt=""
               className="entry-nav-rail__logo-img"
               draggable={false}

--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -1226,7 +1226,7 @@ export const HomeHero = forwardRef<HomeHeroHandle, Props>(function HomeHero(
     <section ref={homeHeroRef} className="home-hero" data-testid="home-hero">
       <div className="home-hero__brand" aria-hidden>
         <span className="home-hero__brand-mark">
-          <img src="/app-icon.svg" alt="" draggable={false} />
+          <img src="/logo.svg" alt="" draggable={false} />
         </span>
         <span className="home-hero__brand-name">Open Design</span>
       </div>

--- a/apps/web/tests/components/home-logo-assets.test.ts
+++ b/apps/web/tests/components/home-logo-assets.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const homeHeroSource = readFileSync(
+  new URL('../../src/components/HomeHero.tsx', import.meta.url),
+  'utf8',
+);
+const entryNavRailSource = readFileSync(
+  new URL('../../src/components/EntryNavRail.tsx', import.meta.url),
+  'utf8',
+);
+
+describe('Home logo assets', () => {
+  it('uses the current Open Design logo glyph on both Home entry surfaces', () => {
+    // Home hero brand mark (next to "Open Design" wordmark)
+    expect(homeHeroSource).toContain('src="/logo.svg"');
+    expect(homeHeroSource).not.toContain('src="/app-icon.svg"');
+
+    // Left navigation rail logo
+    expect(entryNavRailSource).toContain('src="/logo.svg"');
+    expect(entryNavRailSource).not.toContain('src="/app-icon.svg"');
+  });
+});


### PR DESCRIPTION
## Summary

Issue #5365 — the Home page shows the old logo on two surfaces: the left navigation rail and the brand mark next to the `Open Design` wordmark in the hero area. Both reference `/app-icon.svg` (the old icon) instead of `/logo.svg` (the current brand glyph).

## Fix

Swap both `src` attributes from `/app-icon.svg` to `/logo.svg`:

- `apps/web/src/components/EntryNavRail.tsx` — nav rail logo
- `apps/web/src/components/HomeHero.tsx` — hero brand mark

## Validation

- Focused regression test (`home-logo-assets.test.ts`) pins both source references to guard against future regression
- Visual DOM inspection confirms both placements resolve to `/logo.svg`
- The old `/app-icon.svg` asset remains in `public/` — only swapped in the two Home surfaces

Closes #5365