### PR TITLE
fix(web): keep the split resize handle hitbox off the chat scrollbar gutter

### DIFF
--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -1506,8 +1506,11 @@ a.avatar-item:visited {
   position: absolute;
   top: 0;
   bottom: 0;
-  left: -2px;
-  right: -10px;
+  /* Invariant: the extended hitbox must never cross the inline-start edge —
+     the chat panel's scrollbar gutter sits flush against it (LTR and RTL).
+     Extra grab room is allowed on the workspace (inline-end) side only. */
+  inset-inline-start: 0;
+  inset-inline-end: -8px;
   cursor: col-resize;
 }
 .split-resize-handle::after {

--- a/e2e/ui/split-resize-scrollbar-hitbox.test.ts
+++ b/e2e/ui/split-resize-scrollbar-hitbox.test.ts
@@ -1,0 +1,204 @@
+import { expect, test } from '@/playwright/suite';
+import { openNewProjectModal } from '@/playwright/rail';
+import type { Locator, Page } from '@playwright/test';
+import { applyStandardMocks } from '@/playwright/mock-factory';
+
+// Red spec for issue #548 (Plane): the split resize handle's extended hitbox
+// (`.split-resize-handle::before`) must never cross the handle's inline-start
+// edge, because the chat panel's scrollbar gutter sits flush against it. When
+// it does, clicks aimed at the scrollbar start a panel resize instead, and
+// hovering the scrollbar shows the col-resize posture.
+//
+// Hit-testing note: pseudo-element hit areas are attributed to their host
+// element, so `document.elementFromPoint` returns `.split-resize-handle`
+// whenever a point falls inside the ::before overhang.
+
+test.beforeEach(async ({ page }) => {
+  await applyStandardMocks(page);
+});
+
+test('[P1] chat scrollbar gutter edge belongs to the chat panel, not the resize handle', async ({ page }) => {
+  await gotoEntryHome(page);
+  await createProject(page, 'Scrollbar hitbox LTR');
+  await expectWorkspaceReady(page);
+
+  const chatLog = page.locator('.chat-log');
+  const box = await requireBoundingBox(chatLog);
+  const y = box.y + box.height / 2;
+
+  // Red probe: 1px inside the chat-log edge that faces the handle. On main
+  // the handle's ::before overhangs 2px into the scrollbar gutter, so this
+  // point hit-tests to the handle (red); after the fix it belongs to the
+  // chat panel (green).
+  const redProbe = await probeHit(page, box.x + box.width - 1, y);
+  expect(redProbe.hitHandle, `expected chat panel at 1px probe, hit <${redProbe.tag} class="${redProbe.className}">`).toBe(false);
+  expect(redProbe.insideChatLog).toBe(true);
+
+  // Control probe: 3px inside — beyond main's 2px overhang, so it must hit
+  // the chat panel before AND after the fix. Guards against over-shrinking
+  // the handle or introducing a new overlay on the gutter.
+  const controlProbe = await probeHit(page, box.x + box.width - 3, y);
+  expect(controlProbe.hitHandle).toBe(false);
+  expect(controlProbe.insideChatLog).toBe(true);
+});
+
+test('[P1] hovering and dragging on the scrollbar gutter does not enter resize posture', async ({ page }) => {
+  await gotoEntryHome(page);
+  await createProject(page, 'Scrollbar hover posture');
+  await expectWorkspaceReady(page);
+
+  const chatLog = page.locator('.chat-log');
+  const handle = page.locator('.split-resize-handle');
+  const box = await requireBoundingBox(chatLog);
+  const x = box.x + box.width - 1;
+  const y = box.y + box.height / 2;
+
+  await page.mouse.move(x, y);
+  const hover = await probeHit(page, x, y);
+  expect(hover.cursor).not.toBe('col-resize');
+  // The highlight posture is purely :hover-driven (::after restyle), so
+  // asserting :hover does not match asserts the highlight never shows.
+  expect(await handle.evaluate((el) => el.matches(':hover'))).toBe(false);
+
+  const widthBefore = await readChatPanelWidth(handle);
+  await page.mouse.down();
+  await page.mouse.move(x + 40, y, { steps: 5 });
+  await expect(page.locator('.split')).not.toHaveClass(/is-resizing-chat/);
+  await page.mouse.up();
+
+  expect(await readChatPanelWidth(handle)).toBe(widthBefore);
+});
+
+test('[P1] resize handle body still drags the chat panel width', async ({ page }) => {
+  await gotoEntryHome(page);
+  await createProject(page, 'Handle drag regression guard');
+  await expectWorkspaceReady(page);
+
+  const handle = page.locator('.split-resize-handle');
+  const handleBox = await requireBoundingBox(handle);
+  const x = handleBox.x + handleBox.width / 2;
+  const y = handleBox.y + handleBox.height / 2;
+
+  const widthBefore = await readChatPanelWidth(handle);
+  await page.mouse.move(x, y);
+  await page.mouse.down();
+  // Drag toward the chat panel (narrower): the default width sits well above
+  // aria-valuemin, so a 60px pull is never clamped away.
+  await page.mouse.move(x - 60, y, { steps: 6 });
+  await page.mouse.up();
+
+  const widthAfter = await readChatPanelWidth(handle);
+  expect(widthAfter).not.toBe(widthBefore);
+  const min = Number(await handle.getAttribute('aria-valuemin'));
+  const max = Number(await handle.getAttribute('aria-valuemax'));
+  expect(widthAfter).toBeGreaterThanOrEqual(min);
+  expect(widthAfter).toBeLessThanOrEqual(max);
+});
+
+test('[P1] RTL: chat scrollbar gutter is not covered by the resize handle', async ({ page }) => {
+  await gotoEntryHome(page);
+  await createProject(page, 'Scrollbar hitbox RTL');
+  await expectWorkspaceReady(page);
+  // Switch to Arabic through the in-project settings UI. Seeding the locale
+  // via localStorage before navigation is unreliable here: the initial-locale
+  // detection can transiently lose a persisted manual locale during the hard
+  // navigation that project creation performs (adjacent issue, not part of
+  // this fix). setLocale from the settings dialog applies synchronously.
+  await switchLocaleToArabic(page);
+  await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+
+  const chatLog = page.locator('.chat-log');
+  const box = await requireBoundingBox(chatLog);
+  const y = box.y + box.height / 2;
+
+  // RTL: the chat panel is the grid's first column (visually right), the
+  // handle sits at its LEFT edge, and the scrollbar renders on the chat-log's
+  // left edge. On main the physical `right: -10px` overhang covers the whole
+  // 8px gutter, so BOTH probes hit the handle (no green baseline for the
+  // control probe in RTL); after the logical-property fix both are green.
+  for (const inset of [1, 3]) {
+    const probe = await probeHit(page, box.x + inset, y);
+    expect(probe.hitHandle, `expected chat panel at ${inset}px probe, hit <${probe.tag} class="${probe.className}">`).toBe(false);
+    expect(probe.insideChatLog).toBe(true);
+  }
+});
+
+interface HitProbe {
+  hitHandle: boolean;
+  insideChatLog: boolean;
+  tag: string;
+  className: string;
+  cursor: string;
+}
+
+async function probeHit(page: Page, x: number, y: number): Promise<HitProbe> {
+  return page.evaluate(([px, py]) => {
+    const el = document.elementFromPoint(px, py) as HTMLElement | null;
+    return {
+      hitHandle: !!el?.closest('.split-resize-handle'),
+      insideChatLog: !!el?.closest('.chat-log'),
+      tag: el?.tagName ?? '<none>',
+      className: typeof el?.className === 'string' ? el.className : '',
+      cursor: el ? window.getComputedStyle(el).cursor : '',
+    };
+  }, [x, y] as const);
+}
+
+async function requireBoundingBox(locator: Locator) {
+  await expect(locator).toBeVisible();
+  const box = await locator.boundingBox();
+  expect(box).toBeTruthy();
+  return box!;
+}
+
+async function readChatPanelWidth(handle: Locator): Promise<number> {
+  const raw = await handle.getAttribute('aria-valuenow');
+  const parsed = Number.parseInt(raw ?? '', 10);
+  expect(Number.isFinite(parsed)).toBeTruthy();
+  return parsed;
+}
+
+// Switch the app language to Arabic from inside the project view: avatar
+// menu → full settings → Language section → the tile whose code is "ar".
+// All selectors are class/testid based so they survive the locale change.
+async function switchLocaleToArabic(page: Page) {
+  await page.locator('.avatar-agent-trigger').click();
+  await page.locator('.avatar-item--execution-settings').click();
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await dialog.locator('.settings-nav-item', { hasText: 'Language' }).click();
+  await dialog
+    .locator('.settings-language-tile')
+    .filter({ has: page.locator('.settings-language-tile-code:text-is("ar")') })
+    .click();
+  await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+  await page.keyboard.press('Escape');
+  await expect(dialog).toBeHidden();
+}
+
+async function gotoEntryHome(page: Page) {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.getByText('Loading Open Design…').waitFor({ state: 'detached', timeout: 10_000 }).catch(() => {});
+  const privacyDialog = page.getByRole('dialog').filter({ hasText: 'Help us improve Open Design' });
+  if (await privacyDialog.isVisible()) {
+    await privacyDialog.getByRole('button', { name: /I get it|not now|got it|don't share/i }).click();
+    await expect(privacyDialog).toHaveCount(0);
+  }
+  await expect(page.getByTestId('home-hero')).toBeVisible();
+  await expect(page.getByTestId('home-hero-input')).toBeVisible();
+}
+
+async function createProject(page: Page, projectName: string) {
+  await openNewProjectModal(page);
+  await page.getByTestId('new-project-tab-prototype').click();
+  await page.getByTestId('new-project-name').fill(projectName);
+  await page.getByTestId('create-project').click();
+}
+
+async function expectWorkspaceReady(page: Page) {
+  await expect(page).toHaveURL(/\/projects\//);
+  await expect(page.getByText('Loading Open Design…')).toHaveCount(0);
+  await expect(page.getByTestId('chat-composer')).toBeVisible();
+  await expect(page.getByTestId('chat-composer-input')).toBeVisible();
+  await expect(page.getByTestId('file-workspace')).toBeVisible();
+}


### PR DESCRIPTION
## Why

Paid-insight report (Plane issue #548, KANO must-have): while scrolling the chat pane in the project workspace, clicks aimed at the scrollbar are misrecognized and hovering near it flips the UI into an unexpected resize posture. Users dragging the scrollbar end up widening the chat panel instead of scrolling, and the canvas iframe momentarily loses pointer events (`is-resizing-chat`), which reads as "the workspace froze mid-scroll".

Root cause is a single geometry defect: the split resize handle's extended hitbox (`.split-resize-handle::before`, `left: -2px; right: -10px`) overlaps the chat-log's 8px scrollbar gutter. The 2px chat-side overhang covers the outer edge of the gutter exactly where users aim at the ~4px visible thumb. Because the offsets are physical, RTL (`ar`/`fa`) is worse: `right: -10px` lands on the chat side and covers the **entire** gutter, making the scrollbar nearly unclickable.

Source: https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/5c505d35-42e9-40e7-ab07-ba6e3bbfb2ee

## What users will see

- Clicking and dragging anywhere on the chat pane's scrollbar — including its outermost 2px — scrolls the chat instead of resizing the panel.
- Hovering the scrollbar no longer shows the `col-resize` cursor or the divider highlight; the resize posture only appears inside the handle's own hit area.
- In Arabic/Farsi (RTL), the chat scrollbar becomes fully clickable again.
- The handle itself is unchanged: pointer drag and keyboard resize (←/→/Home/End) behave exactly as before, with a 16px effective grab width (8px body + 8px workspace-side overhang).

## Implementation notes

- The fix is CSS-only, in `apps/web/src/styles/shell.css`: the `::before` overhang moves from physical `left: -2px; right: -10px` to logical `inset-inline-start: 0; inset-inline-end: -8px`, with a comment stating the invariant (the hitbox must never cross the inline-start edge, where the scrollbar gutter sits in both LTR and RTL).
- The issue's suggested "separate hover from resize event logic" resolves here without any JS: hover posture and resize both key off the same hit geometry, so fixing the geometry fixes both. `handleChatResizePointerDown`, pointer capture, RTL delta math, and width persistence are untouched.
- `routines.css`'s `.app .split-resize-handle` override restates width/background only and never touches `::before`, so the fix applies there automatically.
- Build spot-check: the production bundle keeps the logical properties (minified to the equivalent `inset-inline: 0 -8px` shorthand) — no directionless `left`/`right` downgrade.

## Surface area

- [x] **UI** — behavior fix to the chat/workspace split handle hit area in `apps/web` (no new page/dialog/setting)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

CLI surface is genuinely not applicable: this is a pointer-geometry bug fix inside the web workspace; there is no capability to mirror as an `od` subcommand.

## Screenshots

The change is invisible hit-test geometry — a screenshot cannot show the hitbox, and the cursor is not captured in screenshots. Reviewable evidence is the Playwright probe spec below (`document.elementFromPoint` on the gutter edge, red on main / green here, LTR + RTL). For eyes-on verification: hover the chat scrollbar — on `main` the divider highlights and the cursor flips to `col-resize`; on this branch it does not.

## Bug fix verification

- Test path: `e2e/ui/split-resize-scrollbar-hitbox.test.ts`
- Red on `main`, green on this branch? **yes** — with the CSS fix stashed (main baseline), 3 of 4 tests fail exactly as designed: the LTR gutter probe, the hover/drag posture test, and the RTL probe. The fourth (drag-the-handle regression guard) passes on both, as intended. With the fix applied, all 4 pass.

## Validation

- `pnpm guard` ✅
- `pnpm typecheck` ✅
- `pnpm --filter @open-design/web typecheck` ✅
- `pnpm --filter @open-design/web build` ✅ + bundle spot-check: `.split-resize-handle:before{...inset-inline:0 -8px}` (logical properties preserved)
- `playwright test ui/split-resize-scrollbar-hitbox.test.ts` — 4/4 green on this branch; 3 red / 1 green with the fix stashed (main baseline)
- `playwright test ui/workspace-keyboard-flows.test.ts` — the resize-related case (`keyboard chat panel resize persists after reload`) passes; 5 quick-switcher cases fail in this environment, and a baseline re-run **with the fix stashed** shows the same 5 failures, so they are pre-existing environment flakes unrelated to this change (all failures are artifact-list timing in the mock-run flow, no overlap with the handle hitbox).
- Local Playwright runs used the config-supported `OD_PLAYWRIGHT_WORKERS=1` / `OD_PLAYWRIGHT_TIMEOUT` knobs because this machine's cold `next dev` compile (23–44s) starves the default 45s test timeout with parallel workers; no committed config was changed.

## Adjacent issues (not addressed here)

- `.entry-side-resizer` (`apps/web/src/styles/viewer/composio.css`) uses the same physical-offset overhang pattern (`right: -3px; width: 6px`) and has the same latent RTL/scrollbar defect if that sidebar ever scrolls; it should get the same inline-start/inline-end invariant in a follow-up.
- `routines.css` references `var(--chat-panel-width, 460px)`, a variable never set anywhere in web source (the real source of truth is the inline `gridTemplateColumns` / `--project-chat-panel-width`); dead rule worth a cleanup issue.

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>