### PR TITLE
fix(web): keep lock icons visible for long model names

### DIFF
--- a/apps/web/src/components/modelOptions.tsx
+++ b/apps/web/src/components/modelOptions.tsx
@@ -354,24 +354,6 @@ export const SearchableModelSelect = forwardRef<
                       <span className="model-select-searchable__option-copy">
                         <span className="model-select-searchable__option-label">
                           <span id={optionLabelId}>{option.label}</span>
-                          {showUpgradeLock ? (
-                            <button
-                              type="button"
-                              className="model-select-searchable__option-lock-inline od-tooltip"
-                              data-testid="model-option-upgrade-lock"
-                              id={optionDisabledId}
-                              data-tooltip={disabledHint ?? undefined}
-                              data-tooltip-placement="top"
-                              title={disabledHint ?? undefined}
-                              aria-label={disabledHint ?? undefined}
-                              onClick={(event) => {
-                                event.stopPropagation();
-                                onDisabledOptionUpgrade?.(option);
-                              }}
-                            >
-                              <Icon name="lock" size={13} />
-                            </button>
-                          ) : null}
                         </span>
                         {costLabel ? (
                           <span
@@ -390,13 +372,35 @@ export const SearchableModelSelect = forwardRef<
                           </span>
                         ) : null}
                       </span>
-                      {tagLabel ? (
-                        <span
-                          className="model-select-searchable__option-badge"
-                          data-tag={tag}
-                          id={optionTagId}
-                        >
-                          {tagLabel}
+                      {showUpgradeLock || tagLabel ? (
+                        <span className="model-select-searchable__option-affordances">
+                          {showUpgradeLock ? (
+                            <button
+                              type="button"
+                              className="model-select-searchable__option-lock-inline od-tooltip"
+                              data-testid="model-option-upgrade-lock"
+                              id={optionDisabledId}
+                              data-tooltip={disabledHint ?? undefined}
+                              data-tooltip-placement="top"
+                              title={disabledHint ?? undefined}
+                              aria-label={disabledHint ?? undefined}
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                onDisabledOptionUpgrade?.(option);
+                              }}
+                            >
+                              <Icon name="lock" size={13} />
+                            </button>
+                          ) : null}
+                          {tagLabel ? (
+                            <span
+                              className="model-select-searchable__option-badge"
+                              data-tag={tag}
+                              id={optionTagId}
+                            >
+                              {tagLabel}
+                            </span>
+                          ) : null}
                         </span>
                       ) : null}
                     </span>

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -1792,6 +1792,12 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.model-select-searchable__option-label > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .model-select-searchable__value-badge,
 .model-select-searchable__option-badge {
   --model-tag-color: var(--text-muted);
@@ -1842,6 +1848,12 @@
 .model-select-searchable__option.is-active .model-select-searchable__option-meta {
   color: color-mix(in srgb, var(--accent-strong) 60%, var(--text-muted));
 }
+.model-select-searchable__option-affordances {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 4px;
+  flex: 0 0 auto;
+}
 .model-select-searchable__option-lock-inline {
   display: inline-flex;
   align-items: center;
@@ -1856,7 +1868,6 @@
   color: var(--text-muted);
   cursor: pointer;
   vertical-align: middle;
-  margin-left: 6px;
   transition:
     color 160ms cubic-bezier(0.23, 1, 0.32, 1),
     background 160ms cubic-bezier(0.23, 1, 0.32, 1);

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -2233,6 +2233,12 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.model-select-searchable__option-label > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .model-select-searchable__value-badge,
 .model-select-searchable__option-badge {
   --model-tag-color: var(--text-muted);
@@ -2283,6 +2289,12 @@
 .model-select-searchable__option.is-active .model-select-searchable__option-meta {
   color: color-mix(in srgb, var(--accent-strong) 60%, var(--text-muted));
 }
+.model-select-searchable__option-affordances {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 4px;
+  flex: 0 0 auto;
+}
 .model-select-searchable__option-lock-inline {
   display: inline-flex;
   align-items: center;
@@ -2297,7 +2309,6 @@
   color: var(--text-muted);
   cursor: pointer;
   vertical-align: middle;
-  margin-left: 6px;
   transition:
     color 160ms cubic-bezier(0.23, 1, 0.32, 1),
     background 160ms cubic-bezier(0.23, 1, 0.32, 1);

--- a/apps/web/tests/components/modelOptions.test.tsx
+++ b/apps/web/tests/components/modelOptions.test.tsx
@@ -197,4 +197,47 @@ describe('SearchableModelSelect', () => {
     );
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it('keeps upgrade affordances outside the truncating model label', async () => {
+    const longModelLabel = 'gemini-3-flash-preview-with-an-extra-long-provider-suffix';
+
+    render(
+      <SearchableModelSelect
+        models={[
+          { id: 'deepseek-v4-flash', label: 'deepseek-v4-flash', default: true },
+          {
+            id: 'google/gemini-3-flash-preview',
+            label: longModelLabel,
+            enabled: false,
+            metadata: { capability: 'standard' },
+          },
+        ]}
+        value="deepseek-v4-flash"
+        onChange={vi.fn()}
+        searchPlaceholder="Search models"
+        disabledOptionHint={(option) =>
+          option.enabled === false ? 'Upgrade to use' : null
+        }
+        onDisabledOptionUpgrade={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('combobox'));
+
+    const disabledOption = await screen.findByRole('option', {
+      name: longModelLabel,
+    });
+    const label = disabledOption.querySelector('.model-select-searchable__option-label');
+    const affordances = disabledOption.querySelector(
+      '.model-select-searchable__option-affordances',
+    );
+    const lock = screen.getByTestId('model-option-upgrade-lock');
+    const badge = disabledOption.querySelector('.model-select-searchable__option-badge');
+
+    expect(label?.textContent).toBe(longModelLabel);
+    expect(label?.contains(lock)).toBe(false);
+    expect(affordances?.contains(lock)).toBe(true);
+    expect(affordances?.contains(badge)).toBe(true);
+    expect(disabledOption).toHaveAccessibleName(longModelLabel);
+  });
 });

--- a/apps/web/tests/styles/model-option-lock-layout.test.ts
+++ b/apps/web/tests/styles/model-option-lock-layout.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const mirroredModelPickerStyles = [
+  ['home', new URL('../../src/styles/home/entry-layout.css', import.meta.url)],
+  ['workspace', new URL('../../src/styles/workspace/artifacts.css', import.meta.url)],
+] as const;
+
+function declarationBlock(css: string, selector: string): string {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return css.match(new RegExp(`${escapedSelector}\\s*\\{([^}]*)\\}`))?.[1] ?? '';
+}
+
+describe.each(mirroredModelPickerStyles)('%s model picker layout', (_surface, stylesheet) => {
+  const css = readFileSync(stylesheet, 'utf8');
+
+  it('reserves a non-shrinking lane for lock and tier affordances', () => {
+    const declarations = declarationBlock(
+      css,
+      '.model-select-searchable__option-affordances',
+    );
+
+    expect(declarations).toContain('display: inline-flex;');
+    expect(declarations).toContain('flex: 0 0 auto;');
+  });
+
+  it('allows the long model label text to truncate before the affordances', () => {
+    const declarations = declarationBlock(
+      css,
+      '.model-select-searchable__option-label > span',
+    );
+
+    expect(declarations).toContain('min-width: 0;');
+    expect(declarations).toContain('overflow: hidden;');
+    expect(declarations).toContain('text-overflow: ellipsis;');
+    expect(declarations).toContain('white-space: nowrap;');
+  });
+});


### PR DESCRIPTION
Fixes #5514

## Why

Free-tier users can see unavailable models in the Home model picker, but long model names consumed the same nowrap row as the inline upgrade lock. The label could overflow past the option while the lock was clipped outside the row, making the unavailable state look broken and harder to understand.

## What users will see

Long unavailable model names now truncate with an ellipsis before a stable trailing affordance lane. The upgrade lock and tier badge remain fully visible and independently aligned, while the option keeps the complete model name as its accessible name.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

### Home entry point

| Before | After |
| --- | --- |
| <img src="https://gist.githubusercontent.com/roian6/f0f814696e335848fa1b8fe2d4c13134/raw/31e8faa99f0de80c2bb42acc02979c59441907c8/before-model-picker-full.png" width="640" alt="Home model picker before the fix, with the lock clipped for a long unavailable model name"> | <img src="https://gist.githubusercontent.com/roian6/f0f814696e335848fa1b8fe2d4c13134/raw/72d7293d221cb9018a76a1bba415b840bd1b6634/after-model-picker-full.png" width="640" alt="Home model picker after the fix, with the long name truncated and lock visible"> |

### Picker detail

| Before | After |
| --- | --- |
| <img src="https://gist.githubusercontent.com/roian6/f0f814696e335848fa1b8fe2d4c13134/raw/36abdb2978431831a09a9527d99d4c0547abe647/before-model-picker-popover.png" width="295" alt="Before: long model label overflows and the lock is clipped outside the option"> | <img src="https://gist.githubusercontent.com/roian6/f0f814696e335848fa1b8fe2d4c13134/raw/bea069c8f63c81995d273abe3857c59e00f73a36/after-model-picker-popover.png" width="295" alt="After: label truncates while the lock and Standard badge remain fully visible"> |

## Bug fix verification

- Test paths:
  - `apps/web/tests/components/modelOptions.test.tsx`
  - `apps/web/tests/styles/model-option-lock-layout.test.ts`
- Red on `main`: yes. The component regression failed because the lock remained inside the truncating label and no trailing affordance lane existed; the mirrored style contract failed because neither surface reserved that lane or constrained the label text.
- Green on this branch: yes, 15/15 focused tests pass.
- Browser reproduction at 1440×1000:
  - Before: the option ended at `x=950.4`, while the lock ended at `x=1020.8`; the 312px label did not truncate.
  - After: the label truncates from 312px to 137px, and the 22×22 lock plus tier badge both remain inside the option.
  - The full long model name remains the option's accessible name; console, page, and HTTP error counts were all zero.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/modelOptions.test.tsx tests/styles/model-option-lock-layout.test.ts --maxWorkers=2` — 15/15 passed
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard` — 78/78 passed
- `git diff --check`
- Changed-lines secret pattern scan — no findings
- Deterministic Playwright before/after visual and bounding-box verification in the Home free-tier picker
