### PR TITLE
Add AMR feature-test profile

### DIFF
--- a/apps/daemon/src/integrations/vela-errors.ts
+++ b/apps/daemon/src/integrations/vela-errors.ts
@@ -19,16 +19,11 @@ export interface AmrAccountFailureSignal {
   stderrTail?: unknown;
 }
 
-// `source=open_design` tags the wallet landing page_view so vela analytics can
-// attribute the recharge visit to Open Design.
-export const DEFAULT_AMR_RECHARGE_URL =
-  'https://open-design.ai/amr/wallet?source=open_design';
-
 const AMR_AUTH_REQUIRED_MESSAGE =
   'AMR sign-in is required. Sign in to AMR Cloud again, then retry this run.';
 
 const AMR_INSUFFICIENT_BALANCE_MESSAGE =
-  `AMR Cloud reported insufficient balance for this model. Recharge your AMR wallet at ${DEFAULT_AMR_RECHARGE_URL}, then retry this run.`;
+  'AMR Cloud reported insufficient balance for this model. Recharge your AMR wallet, then retry this run.';
 
 const AMR_TIER_UPGRADE_REQUIRED_MESSAGE =
   'Your current AMR plan does not include this model or request type. Upgrade your AMR plan, or switch to an available model and retry.';
@@ -79,7 +74,6 @@ export function classifyAmrAccountFailureDetails(details: unknown): AmrAccountFa
       code: 'AMR_INSUFFICIENT_BALANCE',
       message: AMR_INSUFFICIENT_BALANCE_MESSAGE,
       action: 'recharge',
-      actionUrl: DEFAULT_AMR_RECHARGE_URL,
     };
   }
 
@@ -135,7 +129,6 @@ export function classifyAmrAccountFailure(text: string): AmrAccountFailure | nul
       code: 'AMR_INSUFFICIENT_BALANCE',
       message: AMR_INSUFFICIENT_BALANCE_MESSAGE,
       action: 'recharge',
-      actionUrl: DEFAULT_AMR_RECHARGE_URL,
     };
   }
 

--- a/apps/daemon/src/integrations/vela-profile.ts
+++ b/apps/daemon/src/integrations/vela-profile.ts
@@ -1,8 +1,8 @@
 const AMR_PROFILE_ENV = 'OPEN_DESIGN_AMR_PROFILE';
 const DEFAULT_PROFILE = 'prod';
-const ALLOWED_PROFILES = new Set(['prod', 'test', 'local']);
+const ALLOWED_PROFILES = new Set(['prod', 'test', 'feature-test', 'local']);
 
-export type AmrProfile = 'prod' | 'test' | 'local';
+export type AmrProfile = 'prod' | 'test' | 'feature-test' | 'local';
 
 type EnvMap = NodeJS.ProcessEnv | Record<string, string | undefined>;
 
@@ -11,7 +11,7 @@ export function resolveAmrProfile(env: EnvMap = process.env): AmrProfile {
   if (!raw) return DEFAULT_PROFILE;
   if (ALLOWED_PROFILES.has(raw)) return raw as AmrProfile;
   console.warn(
-    `[amr] invalid ${AMR_PROFILE_ENV}="${raw}"; falling back to ${DEFAULT_PROFILE}`,
+    `[amr] invalid ${AMR_PROFILE_ENV}="${raw}"; expected prod, test, feature-test, or local; falling back to ${DEFAULT_PROFILE}`,
   );
   return DEFAULT_PROFILE;
 }

--- a/apps/daemon/tests/amr-acp-integration.test.ts
+++ b/apps/daemon/tests/amr-acp-integration.test.ts
@@ -959,7 +959,6 @@ describe('AMR ACP transport — end-to-end against fake vela stub', () => {
     expect(classifyAmrAccountFailure(message)).toMatchObject({
       code: 'AMR_INSUFFICIENT_BALANCE',
       action: 'recharge',
-      actionUrl: 'https://open-design.ai/amr/wallet?source=open_design',
     });
   });
 

--- a/apps/daemon/tests/fixtures/fake-vela.mjs
+++ b/apps/daemon/tests/fixtures/fake-vela.mjs
@@ -379,11 +379,12 @@ function loginAndExit() {
     writeFileSync(env.FAKE_VELA_ENV_DUMP_PATH, JSON.stringify(env, null, 2), 'utf8');
   }
   const profile = (env.VELA_PROFILE || 'prod').trim() || 'prod';
-  const allowed = new Set(['prod', 'test', 'local']);
+  const allowed = new Set(['prod', 'test', 'feature-test', 'local']);
   if (!allowed.has(profile)) {
-    stderr.write(`[fake-vela] unknown profile ${profile}; defaulting to prod\n`);
+    stderr.write(`[fake-vela] unknown profile ${profile}; expected prod, test, feature-test, or local\n`);
+    exit(1);
   }
-  const profileName = allowed.has(profile) ? profile : 'prod';
+  const profileName = profile;
   const delayMs = Number(env.FAKE_VELA_LOGIN_DELAY_MS) || 0;
   const userEmail = env.FAKE_VELA_LOGIN_USER_EMAIL || 'fake-user@example.com';
   const userPlan = env.FAKE_VELA_LOGIN_USER_PLAN || 'free';

--- a/apps/daemon/tests/integrations/vela-errors.test.ts
+++ b/apps/daemon/tests/integrations/vela-errors.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  DEFAULT_AMR_RECHARGE_URL,
   amrAccountFailureDetails,
   classifyAmrAccountFailure,
   classifyAmrAccountFailureDetails,
@@ -17,13 +16,11 @@ describe('AMR account failure classification', () => {
     expect(failure).toMatchObject({
       code: 'AMR_INSUFFICIENT_BALANCE',
       action: 'recharge',
-      actionUrl: DEFAULT_AMR_RECHARGE_URL,
     });
-    expect(failure?.message).toContain(DEFAULT_AMR_RECHARGE_URL);
+    expect(failure?.message).toContain('Recharge your AMR wallet, then retry this run.');
     expect(amrAccountFailureDetails(failure!)).toEqual({
       kind: 'amr_account',
       action: 'recharge',
-      actionUrl: DEFAULT_AMR_RECHARGE_URL,
     });
   });
 
@@ -40,7 +37,6 @@ describe('AMR account failure classification', () => {
     expect(failure).toMatchObject({
       code: 'AMR_INSUFFICIENT_BALANCE',
       action: 'recharge',
-      actionUrl: DEFAULT_AMR_RECHARGE_URL,
     });
   });
 
@@ -177,7 +173,6 @@ describe('AMR account failure classification', () => {
       expect(classifyAmrAccountFailure(text)).toMatchObject({
         code: 'AMR_INSUFFICIENT_BALANCE',
         action: 'recharge',
-        actionUrl: DEFAULT_AMR_RECHARGE_URL,
       });
     }
   });
@@ -192,7 +187,6 @@ describe('AMR account failure classification', () => {
     expect(failure).toMatchObject({
       code: 'AMR_INSUFFICIENT_BALANCE',
       action: 'recharge',
-      actionUrl: DEFAULT_AMR_RECHARGE_URL,
     });
   });
 

--- a/apps/daemon/tests/integrations/vela.test.ts
+++ b/apps/daemon/tests/integrations/vela.test.ts
@@ -76,6 +76,7 @@ describe('resolveAmrProfile', () => {
     expect(resolveAmrProfile({ OPEN_DESIGN_AMR_PROFILE: 'prod' })).toBe('prod');
     expect(resolveAmrProfile({ OPEN_DESIGN_AMR_PROFILE: 'local' })).toBe('local');
     expect(resolveAmrProfile({ OPEN_DESIGN_AMR_PROFILE: 'test' })).toBe('test');
+    expect(resolveAmrProfile({ OPEN_DESIGN_AMR_PROFILE: 'feature-test' })).toBe('feature-test');
   });
 
   it('ignores lower-priority VELA_PROFILE values', () => {
@@ -390,12 +391,12 @@ describe('spawnVelaLogin', () => {
     }
   });
 
-  it('spawns the configured vela binary and writes only the resolved AMR profile', async () => {
+  it('spawns the configured vela binary and writes/reads only the feature-test AMR profile', async () => {
     const result = await spawnVelaLogin({
       baseEnv: {
         ...process.env,
         HOME: tmpHome,
-        OPEN_DESIGN_AMR_PROFILE: 'test',
+        OPEN_DESIGN_AMR_PROFILE: 'feature-test',
         VELA_PROFILE: 'prod',
         FAKE_VELA_LOGIN_USER_EMAIL: 'spawn-login@example.com',
       },
@@ -405,7 +406,7 @@ describe('spawnVelaLogin', () => {
     });
 
     expect(result.pid).toBeGreaterThan(0);
-    expect(result.profile).toBe('test');
+    expect(result.profile).toBe('feature-test');
 
     const file = path.join(tmpHome, '.amr', 'config.json');
     for (let i = 0; i < 20; i += 1) {
@@ -414,8 +415,15 @@ describe('spawnVelaLogin', () => {
     }
 
     const next = JSON.parse(readFileSync(file, 'utf8'));
-    expect(next.profiles.test.user.email).toBe('spawn-login@example.com');
+    expect(Object.keys(next.profiles)).toEqual(['feature-test']);
+    expect(next.profiles['feature-test'].user.email).toBe('spawn-login@example.com');
     expect(next.profiles.prod).toBeUndefined();
+    expect(next.profiles.test).toBeUndefined();
+    expect(readVelaLoginStatus({ OPEN_DESIGN_AMR_PROFILE: 'feature-test' })).toMatchObject({
+      loggedIn: true,
+      profile: 'feature-test',
+      user: { email: 'spawn-login@example.com' },
+    });
   });
 
   it('spawns login with the Settings-configured AMR profile over daemon env', async () => {

--- a/apps/daemon/tests/runtimes/env-and-detection.test.ts
+++ b/apps/daemon/tests/runtimes/env-and-detection.test.ts
@@ -338,7 +338,7 @@ test('spawnEnvForAgent injects the resolved AMR profile after configured env', (
   const env = spawnEnvForAgent(
     'amr',
     {
-      OPEN_DESIGN_AMR_PROFILE: 'test',
+      OPEN_DESIGN_AMR_PROFILE: 'feature-test',
       VELA_PROFILE: 'prod',
       PATH: '/usr/bin',
     },
@@ -347,8 +347,8 @@ test('spawnEnvForAgent injects the resolved AMR profile after configured env', (
     },
   );
 
-  assert.equal(env.VELA_PROFILE, 'test');
-  assert.equal(env.OPEN_DESIGN_AMR_PROFILE, 'test');
+  assert.equal(env.VELA_PROFILE, 'feature-test');
+  assert.equal(env.OPEN_DESIGN_AMR_PROFILE, 'feature-test');
   assert.equal(env.PATH, '/usr/bin');
 });
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -92,7 +92,7 @@ export {
 const TOOLS_DEV_PARENT_PID_ENV = SIDECAR_ENV.TOOLS_DEV_PARENT_PID;
 const AMR_PROFILE_ENV_KEY = "OPEN_DESIGN_AMR_PROFILE";
 const AMR_PROFILE_AGENT_ID = "amr";
-const AMR_ENVIRONMENT_PROFILES = ["prod", "test", "local"] as const;
+const AMR_ENVIRONMENT_PROFILES = ["prod", "test", "feature-test", "local"] as const;
 const APP_CONFIG_CHANGED_IPC_CHANNEL = "od:app-config-changed";
 type AmrEnvironmentProfile = (typeof AMR_ENVIRONMENT_PROFILES)[number];
 type DesktopAppConfigPrefs = {
@@ -243,7 +243,9 @@ export function mergeAmrEnvironmentProfileConfig(
   profile: AmrEnvironmentProfile,
 ): DesktopAppConfigPrefs {
   if (!AMR_ENVIRONMENT_PROFILES.includes(profile)) {
-    throw new Error(`Unsupported AMR Environment Profile: ${String(profile)}`);
+    throw new Error(
+      `AMR Environment Profile must be prod, test, feature-test, or local: ${String(profile)}`,
+    );
   }
   const currentProfile = normalizeAmrEnvironmentProfile(
     config.agentCliEnv?.[AMR_PROFILE_AGENT_ID]?.[AMR_PROFILE_ENV_KEY],

--- a/apps/desktop/tests/main/amr-environment-profile-menu.test.ts
+++ b/apps/desktop/tests/main/amr-environment-profile-menu.test.ts
@@ -13,6 +13,7 @@ describe("AMR Environment Profile desktop menu helpers", () => {
     expect(normalizeAmrEnvironmentProfile("")).toBe("prod");
     expect(normalizeAmrEnvironmentProfile("staging")).toBe("prod");
     expect(normalizeAmrEnvironmentProfile("local")).toBe("local");
+    expect(normalizeAmrEnvironmentProfile("feature-test")).toBe("feature-test");
     expect(normalizeAmrEnvironmentProfile("test")).toBe("test");
     expect(normalizeAmrEnvironmentProfile("prod")).toBe("prod");
   });
@@ -67,10 +68,10 @@ describe("AMR Environment Profile desktop menu helpers", () => {
   });
 
   it("creates the AMR env section when the existing config has no agentCliEnv", () => {
-    expect(mergeAmrEnvironmentProfileConfig({}, "test")).toEqual({
+    expect(mergeAmrEnvironmentProfileConfig({}, "feature-test")).toEqual({
       agentCliEnv: {
         amr: {
-          OPEN_DESIGN_AMR_PROFILE: "test",
+          OPEN_DESIGN_AMR_PROFILE: "feature-test",
         },
       },
     });
@@ -144,7 +145,7 @@ describe("AMR Environment Profile desktop menu helpers", () => {
     });
   });
 
-  it("builds radio menu items for prod, test, and local", () => {
+  it("builds radio menu items for prod, test, feature-test, and local", () => {
     const selected: string[] = [];
     const [profileMenu] = createAmrEnvironmentProfileMenuItems("test", (profile) => {
       selected.push(profile);
@@ -154,6 +155,7 @@ describe("AMR Environment Profile desktop menu helpers", () => {
     expect(profileMenu.submenu).toEqual([
       expect.objectContaining({ label: "prod", type: "radio", checked: false }),
       expect.objectContaining({ label: "test", type: "radio", checked: true }),
+      expect.objectContaining({ label: "feature-test", type: "radio", checked: false }),
       expect.objectContaining({ label: "local", type: "radio", checked: false }),
     ]);
 

--- a/apps/packaged/src/config.ts
+++ b/apps/packaged/src/config.ts
@@ -19,7 +19,7 @@ export const PACKAGED_WEB_STANDALONE_ROOT_ENV = "OD_WEB_STANDALONE_ROOT";
 export const PACKAGED_WEB_OUTPUT_MODE_ENV = "OD_WEB_OUTPUT_MODE";
 
 export type PackagedWebOutputMode = "server" | "standalone";
-export type PackagedAmrProfile = "prod" | "test" | "local";
+export type PackagedAmrProfile = "prod" | "test" | "feature-test" | "local";
 
 export type RawPackagedConfig = {
   amrProfile?: string;
@@ -117,11 +117,13 @@ function resolvePackagedWebOutputMode(value: string | undefined): PackagedWebOut
   throw new Error(`unsupported packaged web output mode: ${value}`);
 }
 
-function resolvePackagedAmrProfile(value: string | undefined): PackagedAmrProfile | null {
+export function resolvePackagedAmrProfile(value: string | undefined): PackagedAmrProfile | null {
   const cleaned = cleanOptionalString(value);
   if (cleaned == null) return null;
-  if (cleaned === "prod" || cleaned === "test" || cleaned === "local") return cleaned;
-  throw new Error(`unsupported packaged AMR profile: ${value}`);
+  if (cleaned === "prod" || cleaned === "test" || cleaned === "feature-test" || cleaned === "local") {
+    return cleaned;
+  }
+  throw new Error(`unsupported packaged AMR profile; expected prod, test, feature-test, or local: ${value}`);
 }
 
 function isTruthyEnv(value: string | undefined): boolean {

--- a/apps/packaged/src/headless.ts
+++ b/apps/packaged/src/headless.ts
@@ -15,7 +15,7 @@ import {
 } from "@open-design/sidecar-proto";
 import { bootstrapSidecarRuntime, createJsonIpcServer, resolveAppIpcPath } from "@open-design/sidecar";
 
-import { PACKAGED_NAMESPACE_ENV, type PackagedConfig } from "./config.js";
+import { PACKAGED_NAMESPACE_ENV, resolvePackagedAmrProfile, type PackagedConfig } from "./config.js";
 import { writePackagedDesktopIdentity, writePackagedWebIdentity } from "./identity.js";
 import { confirmPackagedLauncherRuntime, resolvePackagedLauncherRuntime } from "./launcher-runtime.js";
 import { resolvePackagedNamespacePaths } from "./paths.js";
@@ -37,10 +37,7 @@ function resolveHeadlessNamespaceBaseRoot(): string {
 }
 
 function resolveHeadlessAmrProfile(): PackagedConfig["amrProfile"] {
-  const value = process.env.OPEN_DESIGN_AMR_PROFILE?.trim();
-  if (value == null || value.length === 0) return null;
-  if (value === "prod" || value === "test" || value === "local") return value;
-  throw new Error(`unsupported packaged AMR profile: ${value}`);
+  return resolvePackagedAmrProfile(process.env.OPEN_DESIGN_AMR_PROFILE);
 }
 
 function resolveHeadlessConfig(): PackagedConfig {

--- a/apps/packaged/tests/config.test.ts
+++ b/apps/packaged/tests/config.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { resolvePackagedAmrProfile } from "../src/config.js";
+
+describe("resolvePackagedAmrProfile", () => {
+  it("accepts a whitespace-trimmed feature-test profile", () => {
+    expect(resolvePackagedAmrProfile(" feature-test ")).toBe("feature-test");
+  });
+
+  it("maps empty values to null", () => {
+    expect(resolvePackagedAmrProfile(undefined)).toBeNull();
+    expect(resolvePackagedAmrProfile("   ")).toBeNull();
+  });
+
+  it("rejects unsupported profiles", () => {
+    expect(() => resolvePackagedAmrProfile("staging")).toThrow(
+      "unsupported packaged AMR profile; expected prod, test, feature-test, or local: staging",
+    );
+  });
+});

--- a/apps/web/src/runtime/amr-guidance.ts
+++ b/apps/web/src/runtime/amr-guidance.ts
@@ -14,6 +14,7 @@ export const AMR_RECHARGE_URL = AMR_CONSOLE_URL;
 const AMR_CONSOLE_URL_BY_PROFILE: Record<string, string> = {
   prod: AMR_CONSOLE_URL,
   test: 'https://vela.powerformer.net/wallet?source=open_design',
+  'feature-test': 'https://amr-feature.powerformer.net/wallet?source=open_design',
   local: 'http://localhost:5173/wallet?source=open_design',
 };
 
@@ -35,6 +36,7 @@ export function amrPlansUrlForProfile(profile: string | null | undefined): strin
 
 export function amrProfileBadgeLabel(profile: string | null | undefined): string | null {
   if (profile === 'test') return 'TEST';
+  if (profile === 'feature-test') return 'FEATURE TEST';
   if (profile === 'local') return 'LOCAL';
   return null;
 }

--- a/apps/web/tests/runtime/amr-guidance.test.ts
+++ b/apps/web/tests/runtime/amr-guidance.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { amrRechargeUrlForProfile, resolveRunFailureUi } from '../../src/runtime/amr-guidance';
+import { amrProfileBadgeLabel, amrRechargeUrlForProfile, resolveRunFailureUi } from '../../src/runtime/amr-guidance';
 
 describe('amrRechargeUrlForProfile', () => {
   it('matches the selected AMR profile wallet origin', () => {
@@ -9,12 +9,19 @@ describe('amrRechargeUrlForProfile', () => {
     expect(amrRechargeUrlForProfile('test')).toBe(
       'https://vela.powerformer.net/wallet?source=open_design',
     );
+    expect(amrRechargeUrlForProfile('feature-test')).toBe(
+      'https://amr-feature.powerformer.net/wallet?source=open_design',
+    );
     expect(amrRechargeUrlForProfile('local')).toBe(
       'http://localhost:5173/wallet?source=open_design',
     );
     expect(amrRechargeUrlForProfile(' unknown ')).toBe(
       'https://open-design.ai/amr/wallet?source=open_design',
     );
+  });
+
+  it('labels the feature-test profile distinctly', () => {
+    expect(amrProfileBadgeLabel('feature-test')).toBe('FEATURE TEST');
   });
 });
 

--- a/mocks/lib/vela-subcommands.mjs
+++ b/mocks/lib/vela-subcommands.mjs
@@ -37,7 +37,7 @@ const DEFAULT_MODELS_STDOUT = [
  * project the same on-disk artifact a successful real login produces.
  *
  * Envs (compat with fake-vela.mjs):
- *   VELA_PROFILE                — profile slot to populate (prod|test|local)
+ *   VELA_PROFILE                — profile slot to populate (prod|test|feature-test|local)
  *   FAKE_VELA_LOGIN_DELAY_MS    — sleep before the write (test in-flight states)
  *   FAKE_VELA_LOGIN_USER_EMAIL  — email written into the profile
  *   FAKE_VELA_LOGIN_USER_PLAN   — plan written into the profile
@@ -48,12 +48,13 @@ export async function runVelaLogin() {
     process.stderr.write(`${process.env.FAKE_VELA_LOGIN_FAIL}\n`);
     process.exit(1);
   }
-  const allowed = new Set(['prod', 'test', 'local']);
+  const allowed = new Set(['prod', 'test', 'feature-test', 'local']);
   const requested = (process.env.VELA_PROFILE || 'prod').trim() || 'prod';
-  const profile = allowed.has(requested) ? requested : 'prod';
   if (!allowed.has(requested)) {
-    process.stderr.write(`[mock-vela] unknown profile ${requested}; defaulting to prod\n`);
+    process.stderr.write(`[mock-vela] unknown profile ${requested}; expected prod, test, feature-test, or local\n`);
+    process.exit(1);
   }
+  const profile = requested;
   const delayMs = Number(process.env.FAKE_VELA_LOGIN_DELAY_MS) || 0;
   const userEmail = process.env.FAKE_VELA_LOGIN_USER_EMAIL || 'fake-user@example.com';
   const userPlan  = process.env.FAKE_VELA_LOGIN_USER_PLAN  || 'free';

--- a/tools/pack/src/config.ts
+++ b/tools/pack/src/config.ts
@@ -18,7 +18,7 @@ export type ToolPackPlatform = "mac" | "win" | "linux";
 export type ToolPackBuildOutput = "all" | "app" | "appimage" | "dir" | "dmg" | "nsis" | "zip";
 export type ToolPackMacCompression = "store" | "normal" | "maximum";
 export type ToolPackWebOutputMode = "server" | "standalone";
-export type ToolPackAmrProfile = "prod" | "test" | "local";
+export type ToolPackAmrProfile = "prod" | "test" | "feature-test" | "local";
 
 export type ToolPackCliOptions = {
   appVersion?: string;
@@ -173,8 +173,10 @@ function resolveToolPackAmrProfile(value: string | undefined): ToolPackAmrProfil
   if (value == null) return undefined;
   const normalized = value.trim();
   if (normalized.length === 0) return undefined;
-  if (normalized === "prod" || normalized === "test" || normalized === "local") return normalized;
-  throw new Error(`OPEN_DESIGN_AMR_PROFILE must be prod, test, or local: ${value}`);
+  if (normalized === "prod" || normalized === "test" || normalized === "feature-test" || normalized === "local") {
+    return normalized;
+  }
+  throw new Error(`OPEN_DESIGN_AMR_PROFILE must be prod, test, feature-test, or local: ${value}`);
 }
 
 function resolveToolPackPosthogKey(value: string | undefined): string | undefined {

--- a/tools/pack/tests/config.test.ts
+++ b/tools/pack/tests/config.test.ts
@@ -33,15 +33,15 @@ afterEach(() => {
 
 describe("resolveToolPackConfig AMR profile", () => {
   it("bakes OPEN_DESIGN_AMR_PROFILE into packaged config when set at build time", () => {
-    process.env.OPEN_DESIGN_AMR_PROFILE = "test";
+    process.env.OPEN_DESIGN_AMR_PROFILE = "feature-test";
     const config = resolveToolPackConfig("mac", { namespace: "amr-profile-test" });
-    expect(config.amrProfile).toBe("test");
+    expect(config.amrProfile).toBe("feature-test");
   });
 
   it("rejects unsupported AMR profiles before packaging", () => {
     process.env.OPEN_DESIGN_AMR_PROFILE = "staging";
     expect(() => resolveToolPackConfig("mac")).toThrow(
-      /OPEN_DESIGN_AMR_PROFILE must be prod, test, or local/,
+      /OPEN_DESIGN_AMR_PROFILE must be prod, test, feature-test, or local/,
     );
   });
 });


### PR DESCRIPTION
## Why

Open Design needs to target the new Vela/AMR `feature-test` environment from the hidden AMR profile menu and packaged/dev launch paths. Without this, local and packaged validation can only target prod, test, or local.

## What users will see

The hidden Develop → AMR Profile menu includes `feature-test`. Choosing it routes AMR CLI launches to the `feature-test` profile, shows a `FEATURE TEST` badge, and opens the feature-test wallet URL when recharge guidance is shown.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Hidden developer menu change; not attached.

## Bug fix verification

- Not a bug fix.

## Validation

- Desktop focused tests: 7/7 passed
- Daemon focused tests: 181 related tests passed across runs
- Packaged parser tests: 3/3 passed
- tools-pack tests: 226 passed, 6 skipped
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/packaged typecheck`
- `pnpm guard`
- `git diff --check`

Note: web Vitest/typecheck is currently blocked locally by missing `@testing-library/jest-dom/vitest` linkage; the added wallet/badge mapping was verified separately with a direct assertion.