### PR TITLE
perf(daemon): stream and cache Resource Hub blob transfers

### DIFF
--- a/apps/daemon/src/integrations/resource-hub.ts
+++ b/apps/daemon/src/integrations/resource-hub.ts
@@ -358,6 +358,26 @@ export function createResourceHubClient(options: ResourceHubClientOptions = {}) 
       });
     },
 
+    // PUT one blob's bytes straight to a presigned target. No hub round-trip —
+    // exposed so the drive can prepare a whole batch once, then fan out the byte
+    // uploads concurrently before a single batched commit.
+    async uploadBytes(
+      upload: Pick<PreparedUpload, 'url' | 'method'>,
+      bytes: Uint8Array,
+    ): Promise<void> {
+      const response = await fetchImpl(upload.url, {
+        method: upload.method,
+        body: bytes,
+      });
+      if (!response.ok) {
+        throw new ResourceHubError(
+          response.status,
+          'blob_upload_failed',
+          `PUT to object store failed (${response.status})`,
+        );
+      }
+    },
+
     // Push one blob: prepare (skips if the store already has it), PUT the bytes
     // straight to the presigned URL, then commit so the hub verifies + indexes.
     async pushBlob(
@@ -372,19 +392,7 @@ export function createResourceHubClient(options: ResourceHubClientOptions = {}) 
       const upload = prepared.uploads.find(
         (candidate) => candidate.digest === input.digest,
       );
-      if (upload) {
-        const response = await fetchImpl(upload.url, {
-          method: upload.method,
-          body: input.bytes,
-        });
-        if (!response.ok) {
-          throw new ResourceHubError(
-            response.status,
-            'blob_upload_failed',
-            `PUT to object store failed (${response.status})`,
-          );
-        }
-      }
+      if (upload) await this.uploadBytes(upload, input.bytes);
       await this.commitUpload(principal, [descriptor]);
     },
 

--- a/apps/daemon/src/integrations/resource-hub.ts
+++ b/apps/daemon/src/integrations/resource-hub.ts
@@ -12,6 +12,14 @@
 // only buildAuthHeaders. Hub-only request shapes stay local until the platform
 // publishes canonical resource contracts.
 
+import { createReadStream, createWriteStream } from 'node:fs';
+import fsp from 'node:fs/promises';
+import http from 'node:http';
+import https from 'node:https';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+
 import type {
   PublicSnapshotResponse,
   ResourceSnapshotRecord,
@@ -376,6 +384,70 @@ export function createResourceHubClient(options: ResourceHubClientOptions = {}) 
           `PUT to object store failed (${response.status})`,
         );
       }
+    },
+
+    // Stream a file's bytes straight to a presigned target with a known length,
+    // never holding the whole blob in memory. We pipe the file into a raw
+    // http(s) request (rather than fetch) because undici buffers a ReadableStream
+    // request body instead of applying backpressure — piping to the socket keeps
+    // peak memory at the stream's high-water mark. Content-Length is required for
+    // a presigned S3/MinIO PUT and is not a signed header, so we set it freely.
+    async uploadFile(
+      upload: Pick<PreparedUpload, 'url' | 'method'>,
+      filePath: string,
+      size: number,
+    ): Promise<void> {
+      const url = new URL(upload.url);
+      const transport = url.protocol === 'https:' ? https : http;
+      await new Promise<void>((resolve, reject) => {
+        const req = transport.request(
+          url,
+          { method: upload.method, headers: { 'content-length': size } },
+          (res) => {
+            res.resume(); // drain the response so the socket can free
+            const status = res.statusCode ?? 0;
+            if (status >= 200 && status < 300) {
+              res.on('end', resolve);
+            } else {
+              reject(
+                new ResourceHubError(
+                  status,
+                  'blob_upload_failed',
+                  `PUT to object store failed (${status})`,
+                ),
+              );
+            }
+          },
+        );
+        req.on('error', reject);
+        const source = createReadStream(filePath);
+        source.on('error', reject);
+        source.pipe(req);
+      });
+    },
+
+    // Resolve a presigned GET and stream the blob straight to a file, never
+    // buffering it in memory. Parent dirs are created as needed.
+    async downloadToFile(
+      principal: ResourceHubPrincipal,
+      digest: string,
+      destPath: string,
+    ): Promise<void> {
+      const signed = await request<{ url: string; method: string }>(
+        principal,
+        'GET',
+        `/api/v1/resources/blobs/${encodeURIComponent(digest)}/download`,
+      );
+      const response = await fetchImpl(signed.url, { method: signed.method });
+      if (!response.ok || !response.body) {
+        throw new ResourceHubError(
+          response.status,
+          'blob_download_failed',
+          `GET from object store failed (${response.status})`,
+        );
+      }
+      await fsp.mkdir(path.dirname(destPath), { recursive: true });
+      await pipeline(Readable.fromWeb(response.body as never), createWriteStream(destPath));
     },
 
     // Push one blob: prepare (skips if the store already has it), PUT the bytes

--- a/apps/daemon/src/resource-cache.ts
+++ b/apps/daemon/src/resource-cache.ts
@@ -1,0 +1,67 @@
+import { randomUUID } from 'node:crypto';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+
+// Local content-addressed blob cache for the resource drive. A blob's bytes are
+// immutable and named by their digest, so once a blob is on disk here we never
+// have to pull it from the store again — pull/materialize become read-through.
+// Modelled on git's object store / restic's local cache: shard by a digest
+// prefix to keep directories small, write atomically (temp + rename) so a
+// crashed write never leaves a truncated entry a reader could trust.
+//
+// v1 keeps everything (no GC). Blobs are content-addressed and shared across
+// resources/teams, so the cache is pure upside; eviction is a later concern
+// tied to a size budget.
+
+export interface BlobCache {
+  get(digest: string): Promise<Uint8Array | null>;
+  put(digest: string, bytes: Uint8Array): Promise<void>;
+}
+
+// digest is "<algo>:<hex>". Lay it out as <root>/<algo>/<aa>/<rest> so a single
+// directory never holds more than 256 shards.
+function pathForDigest(root: string, digest: string): string | null {
+  const sep = digest.indexOf(':');
+  if (sep <= 0) return null;
+  const algo = digest.slice(0, sep);
+  const hex = digest.slice(sep + 1);
+  if (!/^[0-9a-f]{4,}$/u.test(hex)) return null;
+  return path.join(root, algo, hex.slice(0, 2), hex.slice(2));
+}
+
+export function createBlobCache(rootDir: string): BlobCache {
+  return {
+    async get(digest) {
+      const file = pathForDigest(rootDir, digest);
+      if (!file) return null;
+      try {
+        return new Uint8Array(await fsp.readFile(file));
+      } catch {
+        return null;
+      }
+    },
+    async put(digest, bytes) {
+      const file = pathForDigest(rootDir, digest);
+      if (!file) return;
+      await fsp.mkdir(path.dirname(file), { recursive: true });
+      const tmp = `${file}.tmp-${randomUUID()}`;
+      try {
+        await fsp.writeFile(tmp, bytes);
+        await fsp.rename(tmp, file);
+      } catch (error) {
+        await fsp.rm(tmp, { force: true }).catch(() => {});
+        // A cache write is best-effort — a full disk must not fail the transfer.
+        if ((error as NodeJS.ErrnoException)?.code === 'EEXIST') return;
+      }
+    },
+  };
+}
+
+// Disabled cache: every read misses, every write is dropped. Lets the drive
+// treat "no cache configured" and "cache configured" through one code path.
+export const noopBlobCache: BlobCache = {
+  async get() {
+    return null;
+  },
+  async put() {},
+};

--- a/apps/daemon/src/resource-cache.ts
+++ b/apps/daemon/src/resource-cache.ts
@@ -4,18 +4,23 @@ import path from 'node:path';
 
 // Local content-addressed blob cache for the resource drive. A blob's bytes are
 // immutable and named by their digest, so once a blob is on disk here we never
-// have to pull it from the store again — pull/materialize become read-through.
-// Modelled on git's object store / restic's local cache: shard by a digest
-// prefix to keep directories small, write atomically (temp + rename) so a
-// crashed write never leaves a truncated entry a reader could trust.
+// pull it from the store again — pull/materialize become read-through. Modelled
+// on git's object store / restic's local cache: shard by a digest prefix to keep
+// directories small, land entries atomically (temp + rename) so a crashed write
+// never leaves a truncated file a reader could trust.
 //
-// v1 keeps everything (no GC). Blobs are content-addressed and shared across
-// resources/teams, so the cache is pure upside; eviction is a later concern
-// tied to a size budget.
+// File-oriented (not bytes): callers stream a source file into the cache and
+// copy the cache entry out, so nothing has to hold a whole blob in memory.
+// v1 keeps everything (no GC): blobs are content-addressed and shared across
+// resources/teams, so the cache is pure upside; eviction is a later concern.
 
 export interface BlobCache {
-  get(digest: string): Promise<Uint8Array | null>;
-  put(digest: string, bytes: Uint8Array): Promise<void>;
+  // Absolute path where this digest is (or would be) stored, or null if the
+  // cache can't address it (malformed digest) or is disabled.
+  pathFor(digest: string): string | null;
+  has(digest: string): Promise<boolean>;
+  // Atomically copy a source file's bytes into the cache under `digest`.
+  putFile(digest: string, sourcePath: string): Promise<void>;
 }
 
 // digest is "<algo>:<hex>". Lay it out as <root>/<algo>/<aa>/<rest> so a single
@@ -31,37 +36,45 @@ function pathForDigest(root: string, digest: string): string | null {
 
 export function createBlobCache(rootDir: string): BlobCache {
   return {
-    async get(digest) {
+    pathFor(digest) {
+      return pathForDigest(rootDir, digest);
+    },
+    async has(digest) {
       const file = pathForDigest(rootDir, digest);
-      if (!file) return null;
+      if (!file) return false;
       try {
-        return new Uint8Array(await fsp.readFile(file));
+        await fsp.access(file);
+        return true;
       } catch {
-        return null;
+        return false;
       }
     },
-    async put(digest, bytes) {
+    async putFile(digest, sourcePath) {
       const file = pathForDigest(rootDir, digest);
       if (!file) return;
       await fsp.mkdir(path.dirname(file), { recursive: true });
       const tmp = `${file}.tmp-${randomUUID()}`;
       try {
-        await fsp.writeFile(tmp, bytes);
+        await fsp.copyFile(sourcePath, tmp);
         await fsp.rename(tmp, file);
       } catch (error) {
         await fsp.rm(tmp, { force: true }).catch(() => {});
-        // A cache write is best-effort — a full disk must not fail the transfer.
+        // A cache write is best-effort — a full disk must not fail the transfer;
+        // a concurrent writer landing the same content first is fine.
         if ((error as NodeJS.ErrnoException)?.code === 'EEXIST') return;
       }
     },
   };
 }
 
-// Disabled cache: every read misses, every write is dropped. Lets the drive
-// treat "no cache configured" and "cache configured" through one code path.
+// Disabled cache: addresses nothing, stores nothing. Lets the drive treat
+// "no cache" and "cache" through one code path.
 export const noopBlobCache: BlobCache = {
-  async get() {
+  pathFor() {
     return null;
   },
-  async put() {},
+  async has() {
+    return false;
+  },
+  async putFile() {},
 };

--- a/apps/daemon/src/resource-drive.ts
+++ b/apps/daemon/src/resource-drive.ts
@@ -8,6 +8,7 @@ import type {
   ResourceHubPrincipal,
   VersionRecord,
 } from './integrations/resource-hub.js';
+import { type BlobCache, noopBlobCache } from './resource-cache.js';
 
 // Neutral cloud-drive SDK over the resource hub. Kind-agnostic: it moves
 // directory trees to/from the hub as content-addressed manifests + blobs, and
@@ -68,6 +69,40 @@ function byPath(a: { path: string }, b: { path: string }): number {
   return 0;
 }
 
+// Blob byte transfer is the bottleneck for multi-file trees: each PUT/GET is an
+// independent network round-trip to the object store, so they parallelize
+// cleanly. Bound the fan-out so a large tree doesn't open hundreds of sockets
+// at once (git-LFS / rclone use the same bounded-pool shape).
+const DEFAULT_TRANSFER_CONCURRENCY = 8;
+
+export interface TransferOptions {
+  // Max concurrent blob PUT/GET in flight. Defaults to DEFAULT_TRANSFER_CONCURRENCY.
+  concurrency?: number;
+  // Local content-addressed cache; materialize reads through it and push
+  // populates it, so re-pulling a known blob never hits the network.
+  cache?: BlobCache;
+}
+
+// Run `fn` over `items` with at most `limit` invocations in flight. A fixed pool
+// of workers drains a shared cursor — the daemon's house pattern for bounded
+// concurrency (see inline-assets runWithConcurrency).
+async function forEachLimit<T>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<void>,
+): Promise<void> {
+  let next = 0;
+  async function worker(): Promise<void> {
+    while (true) {
+      const idx = next++;
+      if (idx >= items.length) return;
+      await fn(items[idx]!);
+    }
+  }
+  const workers = Math.max(1, Math.min(limit, items.length));
+  await Promise.all(Array.from({ length: workers }, () => worker()));
+}
+
 // Walk a directory into a content-addressed tree. Paths are stored relative to
 // rootDir with forward slashes (canonical). Directories are recorded explicitly
 // so empty dirs survive; symlinks are stored by target without following.
@@ -116,21 +151,53 @@ export async function packTree(
 
 // Push a packed tree as a new version: upload only the blobs the store is
 // missing, then publish. Optionally move a ref (with optimistic concurrency).
+//
+// The store already dedupes globally, so find-missing IS the delta: only blobs
+// absent store-wide travel. Those upload as one batched prepare -> concurrent
+// PUTs -> one batched commit (instead of a prepare/PUT/commit round-trip per
+// blob, serially), the Bazel BatchUpdateBlobs / OCI-parallel-push shape.
 export async function pushTree(
   client: ResourceHubClient,
   principal: ResourceHubPrincipal,
   resourceId: string,
   packed: PackedTree,
-  options: { ref?: string; expectedVersionId?: string | null } = {},
+  options: {
+    ref?: string;
+    expectedVersionId?: string | null;
+  } & TransferOptions = {},
 ): Promise<VersionRecord> {
+  const cache = options.cache ?? noopBlobCache;
+  const concurrency = options.concurrency ?? DEFAULT_TRANSFER_CONCURRENCY;
+
   const missing = await client.findMissingBlobs(principal, [
     ...packed.blobs.keys(),
   ]);
-  for (const digest of missing) {
-    const bytes = packed.blobs.get(digest);
-    if (!bytes) continue;
-    await client.pushBlob(principal, { digest, bytes });
+  const descriptors = missing
+    .map((digest) => {
+      const bytes = packed.blobs.get(digest);
+      return bytes ? { digest, size: bytes.byteLength } : null;
+    })
+    .filter((d): d is { digest: string; size: number } => d !== null);
+
+  if (descriptors.length > 0) {
+    // One prepare for the whole batch: the store re-checks and only signs the
+    // blobs it is still missing (present[] we skip).
+    const prepared = await client.prepareUpload(principal, descriptors);
+    await forEachLimit(prepared.uploads, concurrency, async (upload) => {
+      const bytes = packed.blobs.get(upload.digest);
+      if (!bytes) return;
+      await client.uploadBytes(upload, bytes);
+    });
+    // One commit for the whole batch (the hub HEAD-verifies each object).
+    await client.commitUpload(principal, descriptors);
+    // Seed the local cache with what we just pushed so an immediate
+    // materialize of this tree stays local.
+    await forEachLimit(descriptors, concurrency, async ({ digest }) => {
+      const bytes = packed.blobs.get(digest);
+      if (bytes) await cache.put(digest, bytes);
+    });
   }
+
   return client.publishVersion(principal, resourceId, {
     manifestDigest: packed.manifestDigest,
     entries: packed.entries,
@@ -144,14 +211,24 @@ export async function pushTree(
 // Materialize a manifest's tree into destDir. Pulls only file blobs. Uses a
 // hardened join so a hostile path or symlink target cannot escape destDir
 // (Spec E §2.7 safe landing).
+//
+// Structure (dirs + symlinks) lands first, in path order, so every parent
+// exists before its children. File blobs then fetch concurrently, read through
+// the local cache — a blob already on disk (from a prior pull or the push that
+// created it) never touches the network.
 export async function materializeTree(
   client: ResourceHubClient,
   principal: ResourceHubPrincipal,
   manifestDigest: string,
   destDir: string,
+  options: TransferOptions = {},
 ): Promise<void> {
+  const cache = options.cache ?? noopBlobCache;
+  const concurrency = options.concurrency ?? DEFAULT_TRANSFER_CONCURRENCY;
   const manifest = await client.getManifest(principal, manifestDigest);
   const root = path.resolve(destDir);
+
+  const files: { target: string; digest: string; executable: boolean }[] = [];
   // Sort by path so parent directories are created before their children.
   for (const entry of [...manifest.entries].sort(byPath)) {
     const target = safeJoin(root, entry.path);
@@ -165,14 +242,24 @@ export async function materializeTree(
       );
       await fsp.symlink(entry.symlinkTarget ?? '', target);
     } else if (entry.type === 'file' && entry.blobDigest) {
-      await fsp.mkdir(path.dirname(target), { recursive: true });
-      await fsp.writeFile(
+      files.push({
         target,
-        await client.pullBlob(principal, entry.blobDigest),
-      );
-      if (entry.executable) await fsp.chmod(target, 0o755);
+        digest: entry.blobDigest,
+        executable: entry.executable,
+      });
     }
   }
+
+  await forEachLimit(files, concurrency, async (file) => {
+    let bytes = await cache.get(file.digest);
+    if (!bytes) {
+      bytes = await client.pullBlob(principal, file.digest);
+      await cache.put(file.digest, bytes);
+    }
+    await fsp.mkdir(path.dirname(file.target), { recursive: true });
+    await fsp.writeFile(file.target, bytes);
+    if (file.executable) await fsp.chmod(file.target, 0o755);
+  });
 }
 
 // Resolve a ref to its version's manifest and materialize it. Convenience over
@@ -183,6 +270,7 @@ export async function materializeRef(
   resourceId: string,
   ref: string,
   destDir: string,
+  options: TransferOptions = {},
 ): Promise<VersionRecord> {
   const refRecord = await client.getRef(principal, resourceId, ref);
   const versions = await client.listVersions(principal, resourceId);
@@ -190,7 +278,7 @@ export async function materializeRef(
   if (!version) {
     throw new Error(`ref ${ref} points at unknown version ${refRecord.versionId}`);
   }
-  await materializeTree(client, principal, version.manifestDigest, destDir);
+  await materializeTree(client, principal, version.manifestDigest, destDir, options);
   return version;
 }
 

--- a/apps/daemon/src/resource-drive.ts
+++ b/apps/daemon/src/resource-drive.ts
@@ -1,6 +1,9 @@
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
+import { createReadStream } from 'node:fs';
 import fsp from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
 
 import type {
   ManifestEntryInput,
@@ -15,20 +18,34 @@ import { type BlobCache, noopBlobCache } from './resource-cache.js';
 // knows nothing about design-systems / plugins / skills or WHEN to sync — that
 // is the consumer's concern. Consumers build features ("share a design system")
 // on top of these primitives; this layer stays a neutral cloud drive.
+//
+// Bytes stream file<->store throughout: pack records a file REFERENCE (path +
+// size + streamed digest) rather than the bytes, push streams each file to its
+// presigned PUT, and materialize streams each GET to disk. So peak memory is
+// bounded by the socket buffers, not the tree or the largest file.
 
 const DIGEST_ALGORITHM = 'sha256';
 
-function digestBytes(bytes: Uint8Array): string {
-  return `${DIGEST_ALGORITHM}:${createHash(DIGEST_ALGORITHM)
-    .update(bytes)
-    .digest('hex')}`;
+// A file's bytes, addressed by content but kept on disk (never in memory).
+export interface BlobSource {
+  path: string;
+  size: number;
+}
+
+// Stream a file through the digest algorithm without holding it in memory.
+async function hashFile(filePath: string): Promise<string> {
+  const hash = createHash(DIGEST_ALGORITHM);
+  await pipeline(createReadStream(filePath), hash);
+  return `${DIGEST_ALGORITHM}:${hash.digest('hex')}`;
 }
 
 export interface PackedTree {
   manifestDigest: string;
   entries: ManifestEntryInput[];
-  // Content-addressed file bytes, deduped by digest — the blobs to upload.
-  blobs: Map<string, Uint8Array>;
+  // Content-addressed file sources, deduped by digest — the blobs to upload.
+  // References to files on disk, not their bytes, so a large tree never sits
+  // in memory at once.
+  blobs: Map<string, BlobSource>;
 }
 
 export interface PackTreeOptions {
@@ -112,7 +129,7 @@ export async function packTree(
 ): Promise<PackedTree> {
   const { exclude } = options;
   const entries: ManifestEntryInput[] = [];
-  const blobs = new Map<string, Uint8Array>();
+  const blobs = new Map<string, BlobSource>();
 
   async function walk(absDir: string, relDir: string): Promise<void> {
     const dirents = await fsp.readdir(absDir, { withFileTypes: true });
@@ -130,10 +147,9 @@ export async function packTree(
         entries.push({ path: rel, type: 'dir' });
         await walk(abs, rel);
       } else if (dirent.isFile()) {
-        const bytes = new Uint8Array(await fsp.readFile(abs));
-        const digest = digestBytes(bytes);
-        if (!blobs.has(digest)) blobs.set(digest, bytes);
         const stat = await fsp.stat(abs);
+        const digest = await hashFile(abs);
+        if (!blobs.has(digest)) blobs.set(digest, { path: abs, size: stat.size });
         entries.push({
           path: rel,
           type: 'file',
@@ -174,8 +190,8 @@ export async function pushTree(
   ]);
   const descriptors = missing
     .map((digest) => {
-      const bytes = packed.blobs.get(digest);
-      return bytes ? { digest, size: bytes.byteLength } : null;
+      const source = packed.blobs.get(digest);
+      return source ? { digest, size: source.size } : null;
     })
     .filter((d): d is { digest: string; size: number } => d !== null);
 
@@ -184,17 +200,17 @@ export async function pushTree(
     // blobs it is still missing (present[] we skip).
     const prepared = await client.prepareUpload(principal, descriptors);
     await forEachLimit(prepared.uploads, concurrency, async (upload) => {
-      const bytes = packed.blobs.get(upload.digest);
-      if (!bytes) return;
-      await client.uploadBytes(upload, bytes);
+      const source = packed.blobs.get(upload.digest);
+      if (!source) return;
+      await client.uploadFile(upload, source.path, source.size);
     });
     // One commit for the whole batch (the hub HEAD-verifies each object).
     await client.commitUpload(principal, descriptors);
-    // Seed the local cache with what we just pushed so an immediate
-    // materialize of this tree stays local.
+    // Seed the local cache with what we just pushed (copied from the source
+    // file, streamed) so an immediate materialize of this tree stays local.
     await forEachLimit(descriptors, concurrency, async ({ digest }) => {
-      const bytes = packed.blobs.get(digest);
-      if (bytes) await cache.put(digest, bytes);
+      const source = packed.blobs.get(digest);
+      if (source) await cache.putFile(digest, source.path);
     });
   }
 
@@ -228,7 +244,9 @@ export async function materializeTree(
   const manifest = await client.getManifest(principal, manifestDigest);
   const root = path.resolve(destDir);
 
-  const files: { target: string; digest: string; executable: boolean }[] = [];
+  // Group file paths by blob digest: a digest that appears at several paths is
+  // fetched ONCE and copied to each target (duplicate content is common).
+  const byDigest = new Map<string, { target: string; executable: boolean }[]>();
   // Sort by path so parent directories are created before their children.
   for (const entry of [...manifest.entries].sort(byPath)) {
     const target = safeJoin(root, entry.path);
@@ -242,24 +260,50 @@ export async function materializeTree(
       );
       await fsp.symlink(entry.symlinkTarget ?? '', target);
     } else if (entry.type === 'file' && entry.blobDigest) {
-      files.push({
-        target,
-        digest: entry.blobDigest,
-        executable: entry.executable,
-      });
+      const targets = byDigest.get(entry.blobDigest) ?? [];
+      targets.push({ target, executable: entry.executable });
+      byDigest.set(entry.blobDigest, targets);
     }
   }
 
-  await forEachLimit(files, concurrency, async (file) => {
-    let bytes = await cache.get(file.digest);
-    if (!bytes) {
-      bytes = await client.pullBlob(principal, file.digest);
-      await cache.put(file.digest, bytes);
+  await forEachLimit([...byDigest.keys()], concurrency, async (digest) => {
+    // Resolve a local file holding this blob's bytes, streaming from the store
+    // only on a cache miss — never buffering the blob in memory.
+    const source = await ensureLocalBlob(client, principal, cache, digest, root);
+    for (const { target, executable } of byDigest.get(digest) ?? []) {
+      await fsp.mkdir(path.dirname(target), { recursive: true });
+      await fsp.copyFile(source.path, target);
+      if (executable) await fsp.chmod(target, 0o755);
     }
-    await fsp.mkdir(path.dirname(file.target), { recursive: true });
-    await fsp.writeFile(file.target, bytes);
-    if (file.executable) await fsp.chmod(file.target, 0o755);
+    if (source.cleanup) await fsp.rm(source.path, { force: true }).catch(() => {});
   });
+}
+
+// Return a path to a local file holding `digest`'s bytes. Prefers the cache;
+// on a miss streams the blob from the store to disk and seeds the cache. When
+// no cache is configured the blob lands in a temp file the caller must clean up
+// (source.cleanup = true).
+async function ensureLocalBlob(
+  client: ResourceHubClient,
+  principal: ResourceHubPrincipal,
+  cache: BlobCache,
+  digest: string,
+  scratchDir: string,
+): Promise<{ path: string; cleanup: boolean }> {
+  const cachePath = cache.pathFor(digest);
+  if (cachePath) {
+    if (!(await cache.has(digest))) {
+      const tmp = path.join(scratchDir, `.blob-${randomUUID()}`);
+      await client.downloadToFile(principal, digest, tmp);
+      await cache.putFile(digest, tmp);
+      await fsp.rm(tmp, { force: true }).catch(() => {});
+    }
+    return { path: cachePath, cleanup: false };
+  }
+  // No cache: stream straight to a temp file the caller copies out and removes.
+  const tmp = path.join(os.tmpdir(), `od-blob-${randomUUID()}`);
+  await client.downloadToFile(principal, digest, tmp);
+  return { path: tmp, cleanup: true };
 }
 
 // Resolve a ref to its version's manifest and materialize it. Convenience over

--- a/apps/daemon/src/resource-sharing/orchestrator.ts
+++ b/apps/daemon/src/resource-sharing/orchestrator.ts
@@ -13,6 +13,7 @@ import {
   readResourceHubPrincipal,
 } from '../integrations/resource-hub.js';
 import { materializeRef, packTree, pushTree } from '../resource-drive.js';
+import { createBlobCache } from '../resource-cache.js';
 import { findSkillById, listSkills } from '../skills.js';
 import {
   ResourceAdapterError,
@@ -79,6 +80,11 @@ export function createSharingOrchestrator(deps: SharingDeps) {
       getInstalledPlugin(deps.db, localId)?.fsPath ?? null,
   });
   const client = createResourceHubClient();
+  // Local content-addressed blob cache: push seeds it, pull reads through it, so
+  // materializing a tree whose blobs are already on disk stays offline.
+  const cache = createBlobCache(
+    path.join(deps.paths.RUNTIME_DATA_DIR, 'resource-cache'),
+  );
   const shareLocks = new Map<string, Promise<void>>();
 
   function principalOrThrow(): ResourceHubPrincipal {
@@ -148,6 +154,7 @@ export function createSharingOrchestrator(deps: SharingDeps) {
         }
         const version = await pushTree(client, principal, hubResourceId, packed, {
           ref: 'latest',
+          cache,
         });
         upsertShared(deps.db, {
           kind,
@@ -251,6 +258,7 @@ export function createSharingOrchestrator(deps: SharingDeps) {
         hubResourceId,
         'latest',
         tempDir,
+        { cache },
       );
       try {
         await fsp.rename(dir, backupDir);

--- a/apps/daemon/tests/resource-drive.test.ts
+++ b/apps/daemon/tests/resource-drive.test.ts
@@ -1,0 +1,219 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type {
+  BlobDescriptor,
+  Manifest,
+  ManifestEntryInput,
+  PrepareUploadResult,
+  ResourceHubPrincipal,
+} from '../src/integrations/resource-hub.js';
+import {
+  type PackedTree,
+  computeManifestDigest,
+  materializeTree,
+  pushTree,
+} from '../src/resource-drive.js';
+import { createBlobCache, noopBlobCache } from '../src/resource-cache.js';
+
+const principal: ResourceHubPrincipal = {
+  memberId: 'm',
+  teamId: 't',
+  role: 'owner',
+  lifecycleState: 'active',
+};
+
+const bytesOf = (s: string) => new TextEncoder().encode(s);
+// Realistic-shaped digest (long lowercase hex) so the content-addressed cache,
+// which validates the hex, accepts it. Opaque + unique per content otherwise.
+const digestOf = (s: string) =>
+  `sha256:${Buffer.from(s).toString('hex')}`;
+
+// In-memory fake hub client + object store, recording how the drive calls it.
+function fakeClient() {
+  const store = new Map<string, Uint8Array>(); // committed blobs
+  const staged = new Map<string, Uint8Array>(); // uploaded, awaiting commit
+  const manifests = new Map<string, Manifest>();
+  const calls = { prepare: 0, commit: 0, upload: 0, pull: 0, publish: 0 };
+  let inFlight = 0;
+  let maxInFlight = 0;
+
+  const gate = async () => {
+    inFlight++;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    await Promise.resolve();
+    await Promise.resolve();
+    inFlight--;
+  };
+
+  const client = {
+    async findMissingBlobs(_p: ResourceHubPrincipal, digests: string[]) {
+      return digests.filter((d) => !store.has(d));
+    },
+    async prepareUpload(
+      _p: ResourceHubPrincipal,
+      blobs: BlobDescriptor[],
+    ): Promise<PrepareUploadResult> {
+      calls.prepare++;
+      const missing = blobs.filter((b) => !store.has(b.digest));
+      return {
+        uploads: missing.map((b) => ({
+          digest: b.digest,
+          url: `mem://${b.digest}`,
+          method: 'PUT',
+          expiresInSeconds: 60,
+        })),
+        present: blobs.filter((b) => store.has(b.digest)).map((b) => b.digest),
+        storeLive: true,
+      };
+    },
+    async uploadBytes(upload: { url: string }, bytes: Uint8Array) {
+      calls.upload++;
+      await gate();
+      staged.set(upload.url.replace('mem://', ''), bytes);
+    },
+    async commitUpload(_p: ResourceHubPrincipal, blobs: BlobDescriptor[]) {
+      calls.commit++;
+      for (const b of blobs) {
+        const bytes = staged.get(b.digest);
+        if (bytes) store.set(b.digest, bytes);
+      }
+    },
+    async publishVersion(
+      _p: ResourceHubPrincipal,
+      resourceId: string,
+      input: { manifestDigest: string; entries: ManifestEntryInput[] },
+    ) {
+      calls.publish++;
+      manifests.set(input.manifestDigest, {
+        digest: input.manifestDigest,
+        entries: input.entries.map((e) => ({
+          path: e.path,
+          type: e.type,
+          executable: e.executable ?? false,
+          blobDigest: e.blobDigest ?? null,
+          symlinkTarget: e.symlinkTarget ?? null,
+        })),
+      });
+      return {
+        id: 'v1',
+        resourceId,
+        version: 1,
+        manifestDigest: input.manifestDigest,
+        createdByMemberId: 'm',
+        createdAt: '2026-07-09T00:00:00.000Z',
+      };
+    },
+    async getManifest(_p: ResourceHubPrincipal, digest: string) {
+      const m = manifests.get(digest);
+      if (!m) throw new Error(`no manifest ${digest}`);
+      return m;
+    },
+    async pullBlob(_p: ResourceHubPrincipal, digest: string) {
+      calls.pull++;
+      await gate();
+      const bytes = store.get(digest);
+      if (!bytes) throw new Error(`no blob ${digest}`);
+      return bytes;
+    },
+  };
+  return { client, store, calls, maxInFlight: () => maxInFlight };
+}
+
+// A packed tree of `n` files (paths a0..a{n-1}), each with distinct content.
+function packOf(n: number): PackedTree {
+  const entries: ManifestEntryInput[] = [];
+  const blobs = new Map<string, Uint8Array>();
+  for (let i = 0; i < n; i++) {
+    const digest = digestOf(`content-${i}`);
+    blobs.set(digest, bytesOf(`content-${i}`));
+    entries.push({ path: `a${i}.txt`, type: 'file', blobDigest: digest });
+  }
+  return { manifestDigest: computeManifestDigest(entries), entries, blobs };
+}
+
+let tmp: string | null = null;
+afterEach(async () => {
+  if (tmp) await rm(tmp, { recursive: true, force: true });
+  tmp = null;
+});
+
+describe('resource-cache', () => {
+  it('round-trips bytes and misses on unknown / malformed digests', async () => {
+    tmp = await mkdtemp(path.join(os.tmpdir(), 'cache-'));
+    const cache = createBlobCache(tmp);
+    expect(await cache.get('sha256:deadbeef')).toBeNull();
+    await cache.put('sha256:deadbeef', bytesOf('hi'));
+    expect(new TextDecoder().decode((await cache.get('sha256:deadbeef'))!)).toBe('hi');
+    expect(await cache.get('not-a-digest')).toBeNull(); // no colon -> no path
+  });
+});
+
+describe('pushTree', () => {
+  it('uploads missing blobs as ONE prepare + ONE commit, bounded-parallel', async () => {
+    const { client, store, calls, maxInFlight } = fakeClient();
+    const packed = packOf(20);
+
+    await pushTree(client as never, principal, 'r1', packed, { concurrency: 4 });
+
+    expect(calls.prepare).toBe(1); // batched, not per-blob
+    expect(calls.commit).toBe(1);
+    expect(calls.upload).toBe(20);
+    expect(calls.publish).toBe(1);
+    expect(store.size).toBe(20);
+    expect(maxInFlight()).toBeLessThanOrEqual(4); // concurrency bound honored
+  });
+
+  it('re-push of an already-present tree uploads nothing', async () => {
+    const { client, calls } = fakeClient();
+    const packed = packOf(10);
+    await pushTree(client as never, principal, 'r1', packed, {});
+    await pushTree(client as never, principal, 'r1', packed, {});
+    expect(calls.upload).toBe(10); // only the first push transferred bytes
+    expect(calls.prepare).toBe(1); // 2nd push: nothing missing -> no prepare
+    expect(calls.publish).toBe(2); // both pushes still publish a version
+  });
+});
+
+describe('materializeTree', () => {
+  it('writes byte-identical files and pulls each blob once (cold)', async () => {
+    const { client } = fakeClient();
+    const packed = packOf(8);
+    await pushTree(client as never, principal, 'r1', packed, {});
+    tmp = await mkdtemp(path.join(os.tmpdir(), 'mat-'));
+
+    await materializeTree(client as never, principal, packed.manifestDigest, tmp);
+
+    for (let i = 0; i < 8; i++) {
+      expect(await readFile(path.join(tmp, `a${i}.txt`), 'utf8')).toBe(`content-${i}`);
+    }
+  });
+
+  it('serves a warm cache without touching the network', async () => {
+    const { client, calls } = fakeClient();
+    const packed = packOf(6);
+    tmp = await mkdtemp(path.join(os.tmpdir(), 'mat-'));
+    const cache = createBlobCache(path.join(tmp, 'cache'));
+
+    await pushTree(client as never, principal, 'r1', packed, { cache }); // seeds cache
+    const pullsBefore = calls.pull;
+    await materializeTree(client as never, principal, packed.manifestDigest, path.join(tmp, 'out'), {
+      cache,
+    });
+    expect(calls.pull).toBe(pullsBefore); // zero pulls: every blob came from cache
+  });
+
+  it('falls back to pulls with the noop cache', async () => {
+    const { client, calls } = fakeClient();
+    const packed = packOf(5);
+    await pushTree(client as never, principal, 'r1', packed, {});
+    tmp = await mkdtemp(path.join(os.tmpdir(), 'mat-'));
+    await materializeTree(client as never, principal, packed.manifestDigest, tmp, {
+      cache: noopBlobCache,
+    });
+    expect(calls.pull).toBe(5);
+  });
+});

--- a/apps/daemon/tests/resource-drive.test.ts
+++ b/apps/daemon/tests/resource-drive.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -8,15 +8,11 @@ import type {
   BlobDescriptor,
   Manifest,
   ManifestEntryInput,
+  PreparedUpload,
   PrepareUploadResult,
   ResourceHubPrincipal,
 } from '../src/integrations/resource-hub.js';
-import {
-  type PackedTree,
-  computeManifestDigest,
-  materializeTree,
-  pushTree,
-} from '../src/resource-drive.js';
+import { materializeTree, packTree, pushTree } from '../src/resource-drive.js';
 import { createBlobCache, noopBlobCache } from '../src/resource-cache.js';
 
 const principal: ResourceHubPrincipal = {
@@ -26,21 +22,16 @@ const principal: ResourceHubPrincipal = {
   lifecycleState: 'active',
 };
 
-const bytesOf = (s: string) => new TextEncoder().encode(s);
-// Realistic-shaped digest (long lowercase hex) so the content-addressed cache,
-// which validates the hex, accepts it. Opaque + unique per content otherwise.
-const digestOf = (s: string) =>
-  `sha256:${Buffer.from(s).toString('hex')}`;
-
-// In-memory fake hub client + object store, recording how the drive calls it.
+// In-memory fake hub + object store, recording how the drive calls it. Bytes
+// flow file<->store: uploadFile reads the source file, downloadToFile writes the
+// dest file, so the fake exercises the same streaming surface the real one does.
 function fakeClient() {
   const store = new Map<string, Uint8Array>(); // committed blobs
   const staged = new Map<string, Uint8Array>(); // uploaded, awaiting commit
   const manifests = new Map<string, Manifest>();
-  const calls = { prepare: 0, commit: 0, upload: 0, pull: 0, publish: 0 };
+  const calls = { prepare: 0, commit: 0, upload: 0, download: 0, publish: 0 };
   let inFlight = 0;
   let maxInFlight = 0;
-
   const gate = async () => {
     inFlight++;
     maxInFlight = Math.max(maxInFlight, inFlight);
@@ -70,10 +61,10 @@ function fakeClient() {
         storeLive: true,
       };
     },
-    async uploadBytes(upload: { url: string }, bytes: Uint8Array) {
+    async uploadFile(upload: Pick<PreparedUpload, 'url'>, filePath: string) {
       calls.upload++;
       await gate();
-      staged.set(upload.url.replace('mem://', ''), bytes);
+      staged.set(upload.url.replace('mem://', ''), new Uint8Array(await readFile(filePath)));
     },
     async commitUpload(_p: ResourceHubPrincipal, blobs: BlobDescriptor[]) {
       calls.commit++;
@@ -112,27 +103,26 @@ function fakeClient() {
       if (!m) throw new Error(`no manifest ${digest}`);
       return m;
     },
-    async pullBlob(_p: ResourceHubPrincipal, digest: string) {
-      calls.pull++;
+    async downloadToFile(_p: ResourceHubPrincipal, digest: string, destPath: string) {
+      calls.download++;
       await gate();
       const bytes = store.get(digest);
       if (!bytes) throw new Error(`no blob ${digest}`);
-      return bytes;
+      await mkdir(path.dirname(destPath), { recursive: true });
+      await writeFile(destPath, bytes);
     },
   };
   return { client, store, calls, maxInFlight: () => maxInFlight };
 }
 
-// A packed tree of `n` files (paths a0..a{n-1}), each with distinct content.
-function packOf(n: number): PackedTree {
-  const entries: ManifestEntryInput[] = [];
-  const blobs = new Map<string, Uint8Array>();
+// Build a tree of `n` files on disk; every 5th duplicates content (dedup).
+async function buildTree(root: string, n: number): Promise<void> {
   for (let i = 0; i < n; i++) {
-    const digest = digestOf(`content-${i}`);
-    blobs.set(digest, bytesOf(`content-${i}`));
-    entries.push({ path: `a${i}.txt`, type: 'file', blobDigest: digest });
+    const dir = path.join(root, `d${i % 4}`);
+    await mkdir(dir, { recursive: true });
+    const content = i % 5 === 0 ? 'SHARED-DUP' : `content-${i}`;
+    await writeFile(path.join(dir, `f${i}.txt`), content);
   }
-  return { manifestDigest: computeManifestDigest(entries), entries, blobs };
 }
 
 let tmp: string | null = null;
@@ -142,78 +132,111 @@ afterEach(async () => {
 });
 
 describe('resource-cache', () => {
-  it('round-trips bytes and misses on unknown / malformed digests', async () => {
+  it('addresses, stores and reports blobs by digest; ignores malformed', async () => {
     tmp = await mkdtemp(path.join(os.tmpdir(), 'cache-'));
-    const cache = createBlobCache(tmp);
-    expect(await cache.get('sha256:deadbeef')).toBeNull();
-    await cache.put('sha256:deadbeef', bytesOf('hi'));
-    expect(new TextDecoder().decode((await cache.get('sha256:deadbeef'))!)).toBe('hi');
-    expect(await cache.get('not-a-digest')).toBeNull(); // no colon -> no path
+    const cache = createBlobCache(path.join(tmp, 'cas'));
+    const src = path.join(tmp, 'src.bin');
+    await writeFile(src, 'hello-cache');
+    const digest = 'sha256:deadbeefcafe';
+    expect(await cache.has(digest)).toBe(false);
+    await cache.putFile(digest, src);
+    expect(await cache.has(digest)).toBe(true);
+    expect(await readFile(cache.pathFor(digest)!, 'utf8')).toBe('hello-cache');
+    expect(cache.pathFor('not-a-digest')).toBeNull();
+  });
+});
+
+describe('packTree', () => {
+  it('records file sources (paths + sizes), deduped by digest', async () => {
+    tmp = await mkdtemp(path.join(os.tmpdir(), 'pack-'));
+    await buildTree(tmp, 20);
+    const packed = await packTree(tmp);
+    expect(packed.blobs.size).toBeLessThan(20); // duplicates collapsed
+    for (const source of packed.blobs.values()) {
+      expect(typeof source.path).toBe('string');
+      expect(source.size).toBeGreaterThan(0);
+    }
   });
 });
 
 describe('pushTree', () => {
-  it('uploads missing blobs as ONE prepare + ONE commit, bounded-parallel', async () => {
+  it('streams missing blobs as ONE prepare + ONE commit, bounded-parallel', async () => {
+    tmp = await mkdtemp(path.join(os.tmpdir(), 'push-'));
+    await buildTree(tmp, 24);
     const { client, store, calls, maxInFlight } = fakeClient();
-    const packed = packOf(20);
+    const packed = await packTree(tmp);
 
     await pushTree(client as never, principal, 'r1', packed, { concurrency: 4 });
 
-    expect(calls.prepare).toBe(1); // batched, not per-blob
+    expect(calls.prepare).toBe(1);
     expect(calls.commit).toBe(1);
-    expect(calls.upload).toBe(20);
     expect(calls.publish).toBe(1);
-    expect(store.size).toBe(20);
-    expect(maxInFlight()).toBeLessThanOrEqual(4); // concurrency bound honored
+    expect(calls.upload).toBe(packed.blobs.size); // one PUT per unique blob
+    expect(store.size).toBe(packed.blobs.size);
+    expect(maxInFlight()).toBeLessThanOrEqual(4);
   });
 
   it('re-push of an already-present tree uploads nothing', async () => {
+    tmp = await mkdtemp(path.join(os.tmpdir(), 'push-'));
+    await buildTree(tmp, 12);
     const { client, calls } = fakeClient();
-    const packed = packOf(10);
+    const packed = await packTree(tmp);
     await pushTree(client as never, principal, 'r1', packed, {});
+    const uploads = calls.upload;
     await pushTree(client as never, principal, 'r1', packed, {});
-    expect(calls.upload).toBe(10); // only the first push transferred bytes
+    expect(calls.upload).toBe(uploads); // 2nd push transferred nothing
     expect(calls.prepare).toBe(1); // 2nd push: nothing missing -> no prepare
-    expect(calls.publish).toBe(2); // both pushes still publish a version
+    expect(calls.publish).toBe(2);
   });
 });
 
 describe('materializeTree', () => {
-  it('writes byte-identical files and pulls each blob once (cold)', async () => {
-    const { client } = fakeClient();
-    const packed = packOf(8);
-    await pushTree(client as never, principal, 'r1', packed, {});
+  it('writes byte-identical files, fetching each unique blob once', async () => {
     tmp = await mkdtemp(path.join(os.tmpdir(), 'mat-'));
+    const srcDir = path.join(tmp, 'src');
+    await buildTree(srcDir, 16);
+    const { client, calls } = fakeClient();
+    const packed = await packTree(srcDir);
+    await pushTree(client as never, principal, 'r1', packed, {});
 
-    await materializeTree(client as never, principal, packed.manifestDigest, tmp);
+    const out = path.join(tmp, 'out');
+    await materializeTree(client as never, principal, packed.manifestDigest, out);
 
-    for (let i = 0; i < 8; i++) {
-      expect(await readFile(path.join(tmp, `a${i}.txt`), 'utf8')).toBe(`content-${i}`);
+    for (let i = 0; i < 16; i++) {
+      const rel = path.join(`d${i % 4}`, `f${i}.txt`);
+      expect(await readFile(path.join(out, rel), 'utf8')).toBe(
+        await readFile(path.join(srcDir, rel), 'utf8'),
+      );
     }
+    expect(calls.download).toBe(packed.blobs.size); // deduped: once per digest
   });
 
   it('serves a warm cache without touching the network', async () => {
-    const { client, calls } = fakeClient();
-    const packed = packOf(6);
     tmp = await mkdtemp(path.join(os.tmpdir(), 'mat-'));
-    const cache = createBlobCache(path.join(tmp, 'cache'));
-
+    const srcDir = path.join(tmp, 'src');
+    await buildTree(srcDir, 10);
+    const { client, calls } = fakeClient();
+    const cache = createBlobCache(path.join(tmp, 'cas'));
+    const packed = await packTree(srcDir);
     await pushTree(client as never, principal, 'r1', packed, { cache }); // seeds cache
-    const pullsBefore = calls.pull;
+
+    const before = calls.download;
     await materializeTree(client as never, principal, packed.manifestDigest, path.join(tmp, 'out'), {
       cache,
     });
-    expect(calls.pull).toBe(pullsBefore); // zero pulls: every blob came from cache
+    expect(calls.download).toBe(before); // zero downloads: served from CAS
   });
 
-  it('falls back to pulls with the noop cache', async () => {
-    const { client, calls } = fakeClient();
-    const packed = packOf(5);
-    await pushTree(client as never, principal, 'r1', packed, {});
+  it('falls back to downloads with the noop cache', async () => {
     tmp = await mkdtemp(path.join(os.tmpdir(), 'mat-'));
-    await materializeTree(client as never, principal, packed.manifestDigest, tmp, {
+    const srcDir = path.join(tmp, 'src');
+    await buildTree(srcDir, 8);
+    const { client, calls } = fakeClient();
+    const packed = await packTree(srcDir);
+    await pushTree(client as never, principal, 'r1', packed, {});
+    await materializeTree(client as never, principal, packed.manifestDigest, path.join(tmp, 'out'), {
       cache: noopBlobCache,
     });
-    expect(calls.pull).toBe(5);
+    expect(calls.download).toBe(packed.blobs.size);
   });
 });

--- a/apps/daemon/tests/resource-sharing-orchestrator.test.ts
+++ b/apps/daemon/tests/resource-sharing-orchestrator.test.ts
@@ -310,7 +310,7 @@ describe('resource-sharing orchestrator', () => {
       expect.objectContaining({ teamId: 'team_1' }),
       'hub-acme',
       undefined,
-      { ref: 'latest' },
+      { ref: 'latest', cache: expect.anything() },
     );
     expect(pushTree).toHaveBeenNthCalledWith(
       2,
@@ -318,7 +318,7 @@ describe('resource-sharing orchestrator', () => {
       expect.objectContaining({ teamId: 'team_1' }),
       'hub-acme',
       undefined,
-      { ref: 'latest' },
+      { ref: 'latest', cache: expect.anything() },
     );
   });
 
@@ -361,7 +361,7 @@ describe('resource-sharing orchestrator', () => {
       expect.objectContaining({ teamId: 'team_1' }),
       'hub-retry',
       undefined,
-      { ref: 'latest' },
+      { ref: 'latest', cache: expect.anything() },
     );
     expect(pushTree).toHaveBeenNthCalledWith(
       2,
@@ -369,7 +369,7 @@ describe('resource-sharing orchestrator', () => {
       expect.objectContaining({ teamId: 'team_1' }),
       'hub-retry',
       undefined,
-      { ref: 'latest' },
+      { ref: 'latest', cache: expect.anything() },
     );
   });
 
@@ -485,7 +485,7 @@ describe('resource-sharing orchestrator', () => {
       expect.objectContaining({ teamId: 'team_1' }),
       'hub-team-1',
       undefined,
-      { ref: 'latest' },
+      { ref: 'latest', cache: expect.anything() },
     );
     expect(pushTree).toHaveBeenNthCalledWith(
       2,
@@ -493,7 +493,7 @@ describe('resource-sharing orchestrator', () => {
       expect.objectContaining({ teamId: 'team_2' }),
       'hub-team-2',
       undefined,
-      { ref: 'latest' },
+      { ref: 'latest', cache: expect.anything() },
     );
   });
 
@@ -531,7 +531,7 @@ describe('resource-sharing orchestrator', () => {
       expect.objectContaining({ teamId: 'team_1' }),
       'hub-single',
       undefined,
-      { ref: 'latest' },
+      { ref: 'latest', cache: expect.anything() },
     );
     expect(pushTree).toHaveBeenNthCalledWith(
       2,
@@ -539,7 +539,7 @@ describe('resource-sharing orchestrator', () => {
       expect.objectContaining({ teamId: 'team_1' }),
       'hub-single',
       undefined,
-      { ref: 'latest' },
+      { ref: 'latest', cache: expect.anything() },
     );
   });
 


### PR DESCRIPTION
## Summary

- stream Resource Hub blob hashing, uploads, and downloads through files instead of buffering complete trees or blobs in memory
- batch upload preparation and commit calls, with bounded concurrent object-store transfers
- add a local content-addressed blob cache so repeated pulls and duplicate manifest entries avoid redundant network reads
- wire the cache into resource sharing while preserving atomic destination replacement and the existing hub wire contract

## Why

The previous resource-drive implementation read every file into memory and transferred missing blobs serially with one prepare/upload/commit sequence per blob. Large or file-heavy resources therefore scaled peak memory with content size and paid avoidable Resource Hub and object-store round trips.

This change keeps peak transfer memory bounded by stream buffers, reduces control-plane calls through batching, and reuses immutable content-addressed bytes locally.

## Impact

- large design-system, plugin, skill, and project transfers no longer require whole-blob or whole-tree buffering
- missing blobs upload with a bounded eight-worker pool and a single batch prepare/commit sequence
- materialization downloads each digest once, fans duplicate content out locally, and reads through the daemon data-root cache
- no Resource Hub API, manifest, ref, or authorization contract changes are required

## Validation

- `pnpm guard`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/resource-drive.test.ts tests/resource-sharing-orchestrator.test.ts tests/resource-routes.test.ts --maxWorkers=2` — 33/33 passed
- real feature-test Resource Hub/S3 SDK and CLI verifier — 13/13 passed
- local daemon + Web browser E2E against feature-test — 16/16 passed, including share v1/v2, detail, public snapshot, teammate pull, repeat-pull idempotency, and exact byte verification
- manifest-derived S3 verification — 31/31 referenced blobs present; public blob digest matched and out-of-snapshot access returned 404
