### PR TITLE
docs: disclose PostHog as a telemetry recipient in PRIVACY.md

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -74,11 +74,25 @@ sent to PostHog **even when telemetry is turned off**, so that stability problem
 stay visible to the team — including crashes that happen before the app is
 healthy enough to report anything else.
 
-These reports carry the exception type and message, scrubbed stack frames and
-file paths, the path of the page you were on, your anonymous installation ID, the
-app version, and a session ID. They are not a copy of your conversations or your
-project files, and the redaction described above still applies — API keys, tokens,
-and other secrets are stripped before anything is sent.
+**What a report contains depends on the event.** Every one of them carries your
+anonymous installation ID, the app version, and which build environment you are
+on. Beyond that:
+
+- **Crashes and unhandled errors** in the app window also include the exception
+  type and message, a scrubbed stack trace, the path of the page you were on, and
+  a session ID.
+- **Reliability events** — white screens, stuck runs, long tasks — include the
+  path of the page you were on and details of the event itself, but **no**
+  exception message and **no** stack trace.
+- **Startup failures** in the desktop app include a scrubbed error message and
+  stack trace, the log-file path, and which native module failed to load. Because
+  the app never got far enough to open a window, these carry **no** page path and
+  **no** session ID.
+
+Free-form error text and every file path are scrubbed to strip your home directory
+before send, and the redaction described above still applies — API keys, tokens,
+and other secrets are removed. These reports are not a copy of your conversations
+or your project files.
 
 ## Your anonymous ID
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -44,12 +44,22 @@ team. Each category is independently controllable in Settings.
 
 ## How telemetry is sent
 
-Redacted telemetry batches are sent to a Cloudflare Worker relay operated by
-the Open Design team, which forwards them to [Langfuse](https://langfuse.com)
-for analysis. The relay holds the Langfuse write credentials server-side, so
-packaged clients only ever ship a public relay URL — no secret keys. If the
-relay is unavailable the app retries quietly and keeps working; telemetry
-never blocks your workflow.
+Telemetry reaches us over two separate paths, depending on the category.
+
+**Anonymous metrics and stability events** are sent to
+[PostHog](https://posthog.com) (`https://us.i.posthog.com`), a third-party
+product-analytics provider, using a public project key. The web app, the local
+daemon, and the packaged desktop app each send these directly to PostHog rather
+than through the relay described below.
+
+**Conversation and tool content**, when that category is enabled, is sent as
+redacted batches to a Cloudflare Worker relay operated by the Open Design team,
+which forwards them to [Langfuse](https://langfuse.com) for analysis. The relay
+holds the Langfuse write credentials server-side, so packaged clients only ever
+ship a public relay URL — no secret keys.
+
+If either endpoint is unavailable the app retries quietly and keeps working;
+telemetry never blocks your workflow.
 
 ## Your anonymous ID
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -40,7 +40,9 @@ team. Each category is independently controllable in Settings.
 - The contents of your generated artifact files.
 - Your BYOK API keys, tokens, or other secrets — these are redacted before
   send and are never part of telemetry.
-- Anything at all while telemetry is turned off.
+- Anything at all while telemetry is turned off — with one exception, described
+  under [Stability and crash diagnostics](#stability-and-crash-diagnostics)
+  below.
 
 ## How telemetry is sent
 
@@ -52,14 +54,31 @@ product-analytics provider, using a public project key. The web app, the local
 daemon, and the packaged desktop app each send these directly to PostHog rather
 than through the relay described below.
 
-**Conversation and tool content**, when that category is enabled, is sent as
-redacted batches to a Cloudflare Worker relay operated by the Open Design team,
-which forwards them to [Langfuse](https://langfuse.com) for analysis. The relay
-holds the Langfuse write credentials server-side, so packaged clients only ever
-ship a public relay URL — no secret keys.
+**Conversation and tool content** is sent as redacted batches to a Cloudflare
+Worker relay operated by the Open Design team, which forwards them to
+[Langfuse](https://langfuse.com) for analysis. This path is used only when
+**both** *Anonymous metrics* **and** *Conversation and tool content* are enabled
+in **Settings → Privacy** — if metrics are turned off, no content is sent to
+Langfuse even when the content toggle is left on. The relay holds the Langfuse
+write credentials server-side, so packaged clients only ever ship a public relay
+URL — no secret keys.
 
 If either endpoint is unavailable the app retries quietly and keeps working;
 telemetry never blocks your workflow.
+
+## Stability and crash diagnostics
+
+One narrow category is deliberately **not** covered by the telemetry toggle.
+Exception reports, white screens, stuck or dropped runs, and startup failures are
+sent to PostHog **even when telemetry is turned off**, so that stability problems
+stay visible to the team — including crashes that happen before the app is
+healthy enough to report anything else.
+
+These reports carry the exception type and message, scrubbed stack frames and
+file paths, the path of the page you were on, your anonymous installation ID, the
+app version, and a session ID. They are not a copy of your conversations or your
+project files, and the redaction described above still applies — API keys, tokens,
+and other secrets are stripped before anything is sent.
 
 ## Your anonymous ID
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -74,9 +74,11 @@ sent to PostHog **even when telemetry is turned off**, so that stability problem
 stay visible to the team — including crashes that happen before the app is
 healthy enough to report anything else.
 
-**What a report contains depends on the event.** Every one of them carries your
-anonymous installation ID, the app version, and which build environment you are
-on. Beyond that:
+**What a report contains depends on the event.** They all carry an anonymous
+identifier, the app version, and which build environment you are on. That
+identifier is normally your anonymous installation ID; if it has not been written
+yet — on a first launch, or when a startup fails before the app can read it — a
+synthetic stand-in is used instead. Beyond that:
 
 - **Crashes and unhandled errors** in the app window also include the exception
   type and message, a scrubbed stack trace, the path of the page you were on, and


### PR DESCRIPTION
Closes #5540.

## Why

`PRIVACY.md` says it *"documents the behavior shipped in the app"*, but its "How telemetry is sent" section described only one destination — the Cloudflare Worker relay that forwards to Langfuse — and stated that *"packaged clients only ever ship a public relay URL."*

Anonymous metrics and stability events actually go **directly to PostHog**, which the page never mentioned (`grep -ci posthog PRIVACY.md` → `0`):

| what | where |
| --- | --- |
| `DEFAULT_HOST = 'https://us.i.posthog.com'` | `apps/daemon/src/analytics.ts:29` |
| `DEFAULT_HOST = "https://us.i.posthog.com"` | `apps/packaged/src/startup-telemetry.ts:37` |
| `posthog-js` `1.374.2` / `posthog-node` `5.34.6` | `apps/web/package.json:52`, `apps/daemon/package.json:57` |
| *"PostHog / Langfuse telemetry endpoints. `metrics` and `content`…"* | `apps/web/src/types.ts:454` |

So someone reading the page to find out which third parties receive their data got an incomplete answer.

## What users will see

The privacy page now names PostHog alongside the Langfuse relay, states the real condition under which content reaches Langfuse, and adds a short **Stability and crash diagnostics** section explaining the one category that keeps flowing after telemetry is turned off. No UI, no behavior change.

## Surface area

**Docs only — `PRIVACY.md`.** No code, no config, no schema, no dependencies. (+36 / −7, one file.)

## Validation

Docs-only, cross-checked against the current telemetry code at `4b4c7f4`:

- **PostHog is the recipient** — `us.i.posthog.com` in `apps/daemon/src/analytics.ts:29` and `apps/packaged/src/startup-telemetry.ts:37`; `grep -ci posthog PRIVACY.md` was `0` before this change.
- **The Langfuse gate** — `deriveLangfuseDeliveryState` (`apps/daemon/src/langfuse-trace.ts:391`) returns `not_expected` with `drop_reason: 'metrics_consent_off'` when `prefs.metrics !== true`, and `'content_consent_off'` when `prefs.content !== true`. Their own test asserts it: *"marks traces not expected when metrics consent is off"* with `{ metrics: false, content: true }` (`apps/daemon/tests/langfuse-trace.test.ts:202`).
- **The stability exception** — `apps/web/src/analytics/provider.tsx:186-189` (*"This runs regardless of the user's analytics consent toggle — error reports are intentionally not gated by it"*) and `apps/packaged/src/startup-telemetry.ts:21-24`.

## Changes since first push (addressing review)

Thanks @nettee — both points were right, and I've verified each against the source rather than just taking the note:

1. **The Langfuse condition was wrong.** I'd written *"when that category is enabled"*. The shipped gate requires **both** `metrics` **and** `content` to be on — with `metrics` off, content is dropped (`metrics_consent_off`) even if the content toggle is on. Reworded to say exactly that. Good catch; as written it would have been a factual regression.

2. **Naming stability events sharpened the contradiction with the opt-out claim.** You offered two paths: disclose the exception in this PR, or drop "stability events" until the consent-language fix lands. I took the **disclose** path, because dropping the mention would have made the page *less* accurate in order to look more consistent — the wrong trade for a privacy page. So this now also amends the *"Anything at all while telemetry is turned off"* line and adds a **Stability and crash diagnostics** section.

**A flag on that second one:** it means this PR now touches the area of #4708, which I had deliberately avoided, and which you said has an internal fix coming. That's a decision for you, not me. If it collides, I'm happy to revert to the narrow version (PostHog disclosure only, no mention of stability events) — just say the word and I'll push it. And of course, please rewrite any of this wording in your own voice; it's your privacy page, and it should sound like you.

<sub>I used an AI assistant to trace the telemetry paths and draft this; it's credited in the commit trailer rather than hidden. Every file:line above I read and verified myself.</sub>
