### PR TITLE
fix(daemon): pin data-chart discipline into the deck framework prompt

### DIFF
--- a/apps/daemon/src/prompts/deck-framework.ts
+++ b/apps/daemon/src/prompts/deck-framework.ts
@@ -424,6 +424,35 @@ Rules — non-negotiable:
 3. **Body slides: ≤ 3 paragraphs, ≤ 56ch lead text width, ≤ 12 words per line.**
 4. **One idea per slide.** Two ideas = two slides.
 
+## Data chart discipline (hand-written bar charts)
+
+Hand-written div/CSS charts fail in two ways users report as "the chart is lying": bar lengths eyeballed as magic numbers that don't match the data, and value labels clipped away inside fixed-height bars. If the active template family ships a chart reference (e.g. the \`html-ppt\` family's Chart.js \`chart-bar.html\` template), prefer it over a hand-written div chart. When you do hand-write a bar chart (horizontal or vertical), build it from this skeleton:
+
+\`\`\`html
+<div class="chart" style="--max: 5.0">
+  <div class="bar-row">
+    <span class="bar-label">2024</span>
+    <div class="bar-track"><div class="bar" style="--v: 5.0"></div></div>
+    <span class="bar-value">5.0 万亿</span>
+  </div>
+  <!-- one .bar-row per data point; put the REAL numeric value in --v -->
+</div>
+\`\`\`
+
+\`\`\`css
+.bar { width: calc(var(--v) / var(--max) * 100%); }
+\`\`\`
+
+Rules — same weight as the density rules above:
+
+1. **Bar lengths are computed, never eyeballed.** Every bar carries its value as an inline \`--v\`; declare \`--max\` ONCE on the chart container so all bars share one baseline. \`--v\` / \`--max\` must be unitless numbers — \`calc()\` division needs a plain number, so units ("万亿", "%", "$") live only in the \`.bar-value\` text. Vertical variant: \`.bar { height: calc(var(--v) / var(--max) * 100%); }\`, and give \`.bar-track\` an explicit height (a percentage height inside an auto-height parent computes to 0 and every bar collapses).
+2. **Every data point gets a visible category label AND value label.** Render the value in its own element outside the bar (like \`.bar-value\` above), never inside a fixed-height \`overflow: hidden\` bar where a short bar clips it away.
+
+- ❌ Don't hand-write eyeballed \`height: 62%\` / \`width: 45%\` magic numbers on bars.
+- ❌ Don't let bars in the same chart imply different baselines — one \`--max\` per chart.
+- ❌ Don't nest value labels inside a clipping fixed-height bar.
+- ❌ Don't omit any data point's label, however short its bar.
+
 ## Pre-handoff self-check — run this BEFORE the final file summary
 
 For every \`<section class="slide">\`, mentally render at 1920×1080 and answer:
@@ -432,6 +461,8 @@ For every \`<section class="slide">\`, mentally render at 1920×1080 and answer:
 - [ ] If there's an absolutely-positioned footer/header, does flow content stop before the footer's reserved band? (See Rule 2 above.)
 - [ ] Is the display headline ≤ 140px and ≤ 8 words?
 - [ ] Does the slide carry ≤ one big idea? (No mashed-together masthead + display headline + subtitle + absolute footer + sidebar.)
+- [ ] If the slide has a chart: does every data point show a visible category label and value label?
+- [ ] Are bar lengths computed from \`--v\` / \`--max\` so proportions match the data? (Mentally spot-check two bars.)
 
 If any answer is "no", redesign the slide BEFORE handoff. Decks that overflow are the most common single failure mode reported by users; the user has rejected one before and will reject one again.
 

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -325,6 +325,15 @@ describe('composeSystemPrompt', () => {
     expect(prompt).not.toContain('## Media generation contract');
   });
 
+  it('pins the data chart discipline inside the deck framework (#907)', () => {
+    const prompt = composeSystemPrompt({ skillMode: 'deck' });
+
+    expect(prompt).toContain('## Data chart discipline');
+    expect(prompt).toContain('calc(var(--v) / var(--max)');
+    expect(prompt).toContain('visible category label AND value label');
+    expect(prompt).toContain('Mentally spot-check two bars');
+  });
+
   it('resolves a non-media primary surface ahead of composed media mentions', () => {
     expect(resolveExclusiveSurface({
       skillMode: 'deck',

--- a/packages/contracts/src/prompts/deck-framework.ts
+++ b/packages/contracts/src/prompts/deck-framework.ts
@@ -397,6 +397,35 @@ Rules — non-negotiable:
 3. **Body slides: ≤ 3 paragraphs, ≤ 56ch lead text width, ≤ 12 words per line.**
 4. **One idea per slide.** Two ideas = two slides.
 
+## Data chart discipline (hand-written bar charts)
+
+Hand-written div/CSS charts fail in two ways users report as "the chart is lying": bar lengths eyeballed as magic numbers that don't match the data, and value labels clipped away inside fixed-height bars. If the active template family ships a chart reference (e.g. the \`html-ppt\` family's Chart.js \`chart-bar.html\` template), prefer it over a hand-written div chart. When you do hand-write a bar chart (horizontal or vertical), build it from this skeleton:
+
+\`\`\`html
+<div class="chart" style="--max: 5.0">
+  <div class="bar-row">
+    <span class="bar-label">2024</span>
+    <div class="bar-track"><div class="bar" style="--v: 5.0"></div></div>
+    <span class="bar-value">5.0 万亿</span>
+  </div>
+  <!-- one .bar-row per data point; put the REAL numeric value in --v -->
+</div>
+\`\`\`
+
+\`\`\`css
+.bar { width: calc(var(--v) / var(--max) * 100%); }
+\`\`\`
+
+Rules — same weight as the density rules above:
+
+1. **Bar lengths are computed, never eyeballed.** Every bar carries its value as an inline \`--v\`; declare \`--max\` ONCE on the chart container so all bars share one baseline. \`--v\` / \`--max\` must be unitless numbers — \`calc()\` division needs a plain number, so units ("万亿", "%", "$") live only in the \`.bar-value\` text. Vertical variant: \`.bar { height: calc(var(--v) / var(--max) * 100%); }\`, and give \`.bar-track\` an explicit height (a percentage height inside an auto-height parent computes to 0 and every bar collapses).
+2. **Every data point gets a visible category label AND value label.** Render the value in its own element outside the bar (like \`.bar-value\` above), never inside a fixed-height \`overflow: hidden\` bar where a short bar clips it away.
+
+- ❌ Don't hand-write eyeballed \`height: 62%\` / \`width: 45%\` magic numbers on bars.
+- ❌ Don't let bars in the same chart imply different baselines — one \`--max\` per chart.
+- ❌ Don't nest value labels inside a clipping fixed-height bar.
+- ❌ Don't omit any data point's label, however short its bar.
+
 ## Pre-emit self-check — run this BEFORE writing the \`<artifact>\` tag
 
 For every \`<section class="slide">\`, mentally render at 1920×1080 and answer:
@@ -405,6 +434,8 @@ For every \`<section class="slide">\`, mentally render at 1920×1080 and answer:
 - [ ] If there's an absolutely-positioned footer/header, does flow content stop before the footer's reserved band? (See Rule 2 above.)
 - [ ] Is the display headline ≤ 140px and ≤ 8 words?
 - [ ] Does the slide carry ≤ one big idea? (No mashed-together masthead + display headline + subtitle + absolute footer + sidebar.)
+- [ ] If the slide has a chart: does every data point show a visible category label and value label?
+- [ ] Are bar lengths computed from \`--v\` / \`--max\` so proportions match the data? (Mentally spot-check two bars.)
 
 If any answer is "no", redesign the slide BEFORE emitting. Decks that overflow are the most common single failure mode reported by users; the user has rejected one before and will reject one again.
 

--- a/packages/contracts/tests/system-prompt.test.ts
+++ b/packages/contracts/tests/system-prompt.test.ts
@@ -116,6 +116,15 @@ describe('DISCOVERY_AND_PHILOSOPHY (contracts copy) — prompt routing parity', 
     expect(prompt).not.toContain('Copy the canonical skeleton below as index.html');
     expect(prompt).toContain('semantically named deck HTML file');
   });
+
+  it('pins the data chart discipline inside the deck framework (#907)', () => {
+    const prompt = composeSystemPrompt({ skillMode: 'deck' });
+
+    expect(prompt).toContain('## Data chart discipline');
+    expect(prompt).toContain('calc(var(--v) / var(--max)');
+    expect(prompt).toContain('visible category label AND value label');
+    expect(prompt).toContain('Mentally spot-check two bars');
+  });
 });
 
 describe('composeSystemPrompt', () => {


### PR DESCRIPTION
Implements Plane issue [open-design #839 / #907](https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/34ed7e1b-5676-48d6-8195-a4be71124ad4) (提出者：黄月 · P2). This is an external-tracker task, so there is no GitHub issue to auto-close.

## Why

A user generating a pension-themed PPT (deck project) got a bar-chart slide with two quality defects that make the chart *lie*: some bars had no visible label, and bar lengths did not track the underlying values (a 3× value difference rendered as near-equal bars). For finance/pension content, where data credibility is the whole point, this is a correctness defect in the output, not a cosmetic one.

Root cause: chat-generated decks that fall through to `DECK_FRAMEWORK_DIRECTIVE` — no-skill-seed deck projects, plus the freeform "if this brief is a slide deck…" path (both gated by `!hasSkillSeed` in `system.ts`) — get hard rules for nav/zoom/print/density but **zero guidance for data charts**. With no chart skeleton to copy, the model hand-writes div/CSS bar charts and reliably hits two failure modes that exactly match the reported symptoms:

1. **Eyeballed bar lengths** — `height: 62%` magic numbers written by eye instead of computed from the data, with no shared max baseline across bars → proportions don't match values.
2. **Clipped labels** — value labels nested inside fixed-height `overflow: hidden` bars (short bars clip the label away), or labels only written for some bars → labels partially missing.

The framework's own design philosophy already resolved the density/overflow failure mode the same way — a paste-ready skeleton plus a ban list plus a self-check beats abstract rules — so charts get the same treatment. This also mirrors the existing brand-deck `funnel-label-clipped` guard (`qa/deck-layout.ts`), which already encodes "don't inline value labels in a fixed-height track."

## What users will see

Decks generated through the general deck framework (deck projects with no skill/design-template bound, and the freeform slide-deck path) now produce hand-written bar charts where **every data point shows a visible category + value label** and **bar lengths are computed from the data** (`calc(--v / --max)` with one shared baseline per chart), so a 5.0 bar is genuinely ~4× a 1.2 bar. No new UI, setting, or command — the improvement shows up in the generated deck output itself.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — generated deck output changes for all users on the covered paths: hand-written bar charts now follow the computed-proportion + always-labeled discipline. No model/setting/schema/network default changed; this is a system-prompt quality guardrail, not a config change.
- [ ] **None**

The change is prompt-string + anchor-test only (`apps/daemon/src/prompts/deck-framework.ts`, its `packages/contracts` mirror, and the two composition tests). The contracts edit is to a prompt constant, not a DTO/endpoint/SSE shape, so it is not an API/contract change. The `packages/contracts` mirror keeps BYOK/API mode covered — landing both mirrors in one PR avoids a protection gap.

## Screenshots

N/A — no UI surface. See "Manual acceptance" below for the reviewer-driven buggy-vs-fix comparison.

## Bug fix verification

- Test paths that reproduce the bug (prompt-composition anchor layer — the cheapest falsifiable layer, since the model's own output can't be deterministically red-tested):
  - `apps/daemon/tests/prompts/system.test.ts` → `pins the data chart discipline inside the deck framework (#907)`
  - `packages/contracts/tests/system-prompt.test.ts` → `pins the data chart discipline inside the deck framework (#907)`
- Did the tests go red on `main` and green on this branch? **yes** — the asserted markers (`## Data chart discipline`, `calc(var(--v) / var(--max)`, `visible category label AND value label`, `Mentally spot-check two bars`) are absent from the directive at `HEAD`/`main` (verified via `git show HEAD:…deck-framework.ts`), so both tests fail on `main` and pass here.
- Assertions target semantic markers (the `--v` / `--max` skeleton, the label rule, the self-check item), not a full-text snapshot, so they stay robust to future directive rewrites.

**Manual acceptance (reviewer, per spec §5.3 — visible defect needs an eye):** the deterministic anchor above is the red→green proof; the probabilistic model behavior is confirmed by generation. Stand up two namespace-isolated dev runtimes (`OD_DATA_DIR`-separated), one on `main` and one on this branch, create a deck project **with no skill/design-template bound**, and generate ≥3 pension decks with a fixed dataset (e.g. "2020–2024 结余：1.2 / 1.8 / 2.1 / 4.2 / 5.0 万亿"). On this branch every counted chart slide should show all category+value labels and, measured in devtools, pairwise `.bar` render lengths matching the data ratios within ±2%. Regenerate (don't count) any turn that produced a table instead of a hand-written chart.

## Validation

- `pnpm guard` — pass (78/78)
- `pnpm --filter @open-design/daemon typecheck` — pass
- `pnpm --filter @open-design/contracts typecheck` — pass
- `pnpm --filter @open-design/daemon test` (`tests/prompts/system.test.ts`) — 48 pass, new anchor green
- `pnpm --filter @open-design/contracts test` (`system-prompt`) — 56 pass, new anchor green

## Scope notes & adjacent issues

- **Coverage boundary (spec §2/§4, open question Q1):** this fix only reaches paths that inject `DECK_FRAMEWORK_DIRECTIVE`. Deck skills/design-templates that ship an `assets/template.html` seed (simple-deck, guizang-ppt, replit-deck, ib-pitch-book, html-ppt-pitch-deck…) bypass the directive entirely and are **not** covered. The original Plane #839 attachment (which would identify the exact generation path) was not reachable from the repo; per the spec's decision rule I implemented the general-framework path (its primary scope) and note the assumption here. If the original artifact turns out to be a seeded-skill product, the equivalent chart discipline for that skill's guide is a required follow-up.
- **Not in scope (spec §4):** wrapping a chart library as a runtime dep; a post-generation hard QA gate for chat decks (`analyseDeckLayout` is brand-deck-only today); PPTX export fidelity; line/pie chart discipline; and the **pre-existing** daemon↔contracts `deck-framework.ts` copy drift (chrome show/hide, extra shortcuts) — this PR only keeps the *new* section identical on both sides. Each is a follow-up, not this PR's scope.

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>