### PR TITLE
Fix workspace collab sync and public file publish

### DIFF
--- a/apps/daemon/src/collab/resource-hub-publish-adapter.ts
+++ b/apps/daemon/src/collab/resource-hub-publish-adapter.ts
@@ -163,6 +163,7 @@ export function createResourceHubPublishAdapterFromEnv(
   resolveProjectDir: (projectId: string) => string | Promise<string>,
   getPrincipal?: (projectId?: string) => ResourceHubPrincipal | null | Promise<ResourceHubPrincipal | null>,
   describeProject?: (projectId: string) => Record<string, unknown> | null | Promise<Record<string, unknown> | null>,
+  resolvePullDir?: (projectId: string) => string | Promise<string>,
   env: NodeJS.ProcessEnv = process.env,
 ): ResourcePublishAdapter | null {
   if (!env.OD_RESOURCE_HUB_URL?.trim()) return null;
@@ -170,6 +171,7 @@ export function createResourceHubPublishAdapterFromEnv(
   return createResourceHubPublishAdapter({
     client,
     resolveProjectDir,
+    ...(resolvePullDir ? { resolvePullDir } : {}),
     ...(describeProject ? { describeProject } : {}),
     getPrincipal: getPrincipal ?? (() => readResourceHubPrincipal(env)),
   });

--- a/apps/daemon/src/collab/runtime.ts
+++ b/apps/daemon/src/collab/runtime.ts
@@ -180,7 +180,7 @@ export function createCollabRuntime(options: CreateCollabRuntimeOptions = {}): C
   function rememberTeamShare(
     projectId: string,
     share: ResourceHubPrincipal,
-    syncState: ProjectSyncState = 'pending_upload',
+    syncState?: ProjectSyncState,
   ) {
     owners.set(projectId, share.memberId);
     scopedOwners.set(scopedProjectKey(projectId, share), share.memberId);
@@ -190,8 +190,10 @@ export function createCollabRuntime(options: CreateCollabRuntimeOptions = {}): C
       sharePrincipals.set(projectId, principals);
     }
     principals.set(share.teamId, share);
-    syncStates.set(projectId, syncState);
-    syncStates.set(scopedProjectKey(projectId, share), syncState);
+    if (syncState) {
+      syncStates.set(projectId, syncState);
+      syncStates.set(scopedProjectKey(projectId, share), syncState);
+    }
   }
 
   async function markTeamProject(

--- a/apps/daemon/src/collab/runtime.ts
+++ b/apps/daemon/src/collab/runtime.ts
@@ -91,6 +91,8 @@ export interface CreateCollabRuntimeOptions {
   adapter?: ResourcePublishAdapter;
   /** Managed-project directory resolver, so the real hub adapter can pack/land. */
   resolveProjectDir?: (projectId: string) => string;
+  /** Directory resolver for materializing pulled shared projects before a local row exists. */
+  resolvePullDir?: (projectId: string) => string;
   /** Resource-index metadata for team project discovery/cards. */
   describeProject?: (projectId: string) => Record<string, unknown> | null | Promise<Record<string, unknown> | null>;
   /** Workspace-context provider. Defaults to a dev provider until wired to an identity source. */
@@ -113,6 +115,7 @@ export interface CreateCollabRuntimeOptions {
 
 function selectResourcePublishAdapter(
   resolveProjectDir: ((projectId: string) => string | Promise<string>) | undefined,
+  resolvePullDir: ((projectId: string) => string | Promise<string>) | undefined,
   workspaceContext: WorkspaceContextProvider,
   getProjectPrincipal: (projectId?: string) => ResourceHubPrincipal | null | Promise<ResourceHubPrincipal | null>,
   describeProject: ((projectId: string) => Record<string, unknown> | null | Promise<Record<string, unknown> | null>) | undefined,
@@ -121,11 +124,12 @@ function selectResourcePublishAdapter(
   if (shouldUseVelaCliResourceTransport()) {
     return createVelaCliResourceAdapter({
       resolveProjectDir,
+      ...(resolvePullDir ? { resolvePullDir } : {}),
       ...(describeProject ? { describeProject } : {}),
       hasTeamIdentity: async () => contextHasTeamIdentity(await workspaceContext.current({})),
     });
   }
-  return createResourceHubPublishAdapterFromEnv(resolveProjectDir, getProjectPrincipal, describeProject);
+  return createResourceHubPublishAdapterFromEnv(resolveProjectDir, getProjectPrincipal, describeProject, resolvePullDir);
 }
 
 export function createCollabRuntime(options: CreateCollabRuntimeOptions = {}): CollabRuntime {
@@ -166,6 +170,7 @@ export function createCollabRuntime(options: CreateCollabRuntimeOptions = {}): C
     options.adapter ??
     selectResourcePublishAdapter(
       options.resolveProjectDir,
+      options.resolvePullDir,
       workspaceContext,
       getProjectPrincipal,
       options.describeProject,

--- a/apps/daemon/src/collab/vela-cli-resource-adapter.ts
+++ b/apps/daemon/src/collab/vela-cli-resource-adapter.ts
@@ -18,6 +18,11 @@ import type { ResourcePublishAdapter } from './publish-scheduler.js';
 
 const PUBLISHED_REF = 'published';
 const PROJECT_KIND = 'project';
+const MEMBER_MIRROR_EXCLUDED_ENTRIES = [
+  '.file-versions',
+  '.live-artifacts',
+  '.od-skills',
+] as const;
 
 /** Run `vela resource <args>` and resolve its stdout. */
 export type RunVelaResource = (args: string[]) => Promise<string>;
@@ -80,6 +85,9 @@ export function createVelaCliResourceAdapter(
       return gated(async () => {
         const dir = await options.resolveProjectDir(projectId);
         const args = ['push', kind, resourceIdFor(projectId, principal), dir, '--ref', PUBLISHED_REF, '--json'];
+        for (const name of MEMBER_MIRROR_EXCLUDED_ENTRIES) {
+          args.push('--exclude', name);
+        }
         const metadata = await options.describeProject?.(projectId);
         if (metadata && Object.keys(metadata).length > 0) {
           args.push('--metadata-json', JSON.stringify(metadata));

--- a/apps/daemon/src/collab/vela-cli-resource-adapter.ts
+++ b/apps/daemon/src/collab/vela-cli-resource-adapter.ts
@@ -48,6 +48,14 @@ interface VelaVersionRecord {
   version?: number;
 }
 
+export interface VelaResourceSnapshotRecord {
+  slug: string;
+  name: string;
+  kind: string;
+  versionId: string;
+  createdAt: string;
+}
+
 export function createVelaCliResourceAdapter(
   options: VelaCliResourceAdapterOptions,
 ): ResourcePublishAdapter {
@@ -133,9 +141,28 @@ function parseVersion(stdout: string): number | null {
   }
 }
 
-const defaultRunVelaResource: RunVelaResource = (args) =>
+export function parseVelaResourceSnapshot(stdout: string): VelaResourceSnapshotRecord | null {
+  const trimmed = stdout.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed = JSON.parse(trimmed) as Partial<VelaResourceSnapshotRecord>;
+    return typeof parsed.slug === 'string' && parsed.slug
+      ? {
+          slug: parsed.slug,
+          name: typeof parsed.name === 'string' ? parsed.name : '',
+          kind: typeof parsed.kind === 'string' ? parsed.kind : '',
+          versionId: typeof parsed.versionId === 'string' ? parsed.versionId : '',
+          createdAt: typeof parsed.createdAt === 'string' ? parsed.createdAt : '',
+        }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export const runVelaResourceCommand: RunVelaResource = (args) =>
   new Promise<string>((resolve, reject) => {
-    const bin = process.env.OD_VELA_BIN?.trim() || 'vela';
+    const bin = process.env.OD_VELA_BIN?.trim() || process.env.VELA_BIN?.trim() || 'vela';
     execFile(
       bin,
       ['resource', ...args],
@@ -148,6 +175,8 @@ const defaultRunVelaResource: RunVelaResource = (args) =>
       },
     );
   });
+
+const defaultRunVelaResource: RunVelaResource = runVelaResourceCommand;
 
 export function buildVelaResourceEnv(
   env: NodeJS.ProcessEnv = process.env,

--- a/apps/daemon/src/collab/vela-workspace-context.ts
+++ b/apps/daemon/src/collab/vela-workspace-context.ts
@@ -82,13 +82,15 @@ export function mapVelaWorkspaceContext(input: unknown): WorkspaceCollabContext 
   if (!ROLES.has(raw.role as CollabMemberRole)) return null;
   if (!MEMBER_STATUSES.has(raw.memberStatus as WorkspaceMemberStatus)) return null;
   if (!LIFECYCLE_STATES.has(raw.lifecycleState as WorkspaceLifecycleState)) return null;
-  if (!BILLING_STATES.has(raw.billingState as WorkspaceBillingState)) return null;
   if (!PROVIDER_MODES.has(raw.providerMode as WorkspaceProviderMode)) return null;
 
   const workspaceType = raw.workspaceType as WorkspaceType;
   const role = raw.role as CollabMemberRole;
   const memberStatus = raw.memberStatus as WorkspaceMemberStatus;
   const lifecycleState = raw.lifecycleState as WorkspaceLifecycleState;
+  const billingState = BILLING_STATES.has(raw.billingState as WorkspaceBillingState)
+    ? raw.billingState as WorkspaceBillingState
+    : billingStateFromLifecycle(lifecycleState);
 
   const context: WorkspaceCollabContext = {
     workspaceId,
@@ -97,7 +99,7 @@ export function mapVelaWorkspaceContext(input: unknown): WorkspaceCollabContext 
     role,
     memberStatus,
     lifecycleState,
-    billingState: raw.billingState as WorkspaceBillingState,
+    billingState,
     planId: str(raw.planId) || null,
     providerMode: raw.providerMode as WorkspaceProviderMode,
     seatSummary: parseSeatSummary(raw.seatSummary),
@@ -182,6 +184,17 @@ export function createWorkspaceContextProviderFromEnv(
 
 function str(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
+}
+
+function billingStateFromLifecycle(
+  lifecycleState: WorkspaceLifecycleState,
+): WorkspaceBillingState {
+  if (lifecycleState === 'billing_past_due') return 'past_due';
+  if (lifecycleState === 'locked') return 'locked';
+  if (lifecycleState === 'deleting' || lifecycleState === 'deleted') {
+    return 'inactive';
+  }
+  return 'active';
 }
 
 function parseSeatSummary(value: unknown): WorkspaceSeatSummary {

--- a/apps/daemon/src/routes/collab-sync.ts
+++ b/apps/daemon/src/routes/collab-sync.ts
@@ -222,6 +222,18 @@ function publicSnapshotFileUrl(baseUrl: string, slug: string, filePath: string):
   return new URL(relative, baseUrl).toString();
 }
 
+async function resolveSharedProjectForPublicFile(
+  resolveSharedProject: RegisterCollabSyncRoutesDeps['resolveSharedProject'],
+  projectId: string,
+): Promise<{ ok: true; project: TeamProject | null } | { ok: false }> {
+  try {
+    return { ok: true, project: await resolveSharedProject?.(projectId) ?? null };
+  } catch (error) {
+    console.warn('[od] failed to resolve public file project ownership:', error);
+    return { ok: false };
+  }
+}
+
 export function registerCollabSyncRoutes(app: Express, deps: RegisterCollabSyncRoutesDeps): void {
   const {
     scheduler,
@@ -364,14 +376,17 @@ export function registerCollabSyncRoutes(app: Express, deps: RegisterCollabSyncR
     if (!await canShareProjectsForRequest(req)) {
       return res.status(403).json({ error: 'WORKSPACE_PROJECT_SHARE_DENIED' });
     }
-    let sharedProject: TeamProject | null = null;
-    try {
-      sharedProject = await resolveSharedProject?.(projectId) ?? null;
-    } catch {
-      sharedProject = null;
+    const sharedProjectResult = await resolveSharedProjectForPublicFile(resolveSharedProject, projectId);
+    if (!sharedProjectResult.ok) {
+      return res.status(503).json({ error: 'WORKSPACE_PROJECT_OWNERSHIP_UNAVAILABLE' });
     }
+    const sharedProject = sharedProjectResult.project;
     if (sharedProject?.ownerMemberId && sharedProject.ownerMemberId !== principal.memberId) {
       return res.status(403).json({ error: 'WORKSPACE_PROJECT_PUBLISH_DENIED' });
+    }
+    const baseUrl = publicResourceHubBaseUrl();
+    if (!baseUrl) {
+      return res.status(502).json({ error: 'PUBLIC_FILE_URL_UNAVAILABLE' });
     }
     if (!resolveProjectDir) {
       return res.status(500).json({ error: 'PROJECT_DIR_UNAVAILABLE' });
@@ -423,10 +438,6 @@ export function registerCollabSyncRoutes(app: Express, deps: RegisterCollabSyncR
       if (!snapshot) {
         return res.status(502).json({ error: 'PUBLIC_SNAPSHOT_UNAVAILABLE' });
       }
-      const baseUrl = publicResourceHubBaseUrl();
-      if (!baseUrl) {
-        return res.status(502).json({ error: 'PUBLIC_FILE_URL_UNAVAILABLE' });
-      }
       return res.json({
         url: publicSnapshotFileUrl(baseUrl, snapshot.slug, filePath),
         slug: snapshot.slug,
@@ -457,12 +468,11 @@ export function registerCollabSyncRoutes(app: Express, deps: RegisterCollabSyncR
     if (!await canShareProjectsForRequest(req)) {
       return res.status(403).json({ error: 'WORKSPACE_PROJECT_SHARE_DENIED' });
     }
-    let sharedProject: TeamProject | null = null;
-    try {
-      sharedProject = await resolveSharedProject?.(projectId) ?? null;
-    } catch {
-      sharedProject = null;
+    const sharedProjectResult = await resolveSharedProjectForPublicFile(resolveSharedProject, projectId);
+    if (!sharedProjectResult.ok) {
+      return res.status(503).json({ error: 'WORKSPACE_PROJECT_OWNERSHIP_UNAVAILABLE' });
     }
+    const sharedProject = sharedProjectResult.project;
     if (sharedProject?.ownerMemberId && sharedProject.ownerMemberId !== principal.memberId) {
       return res.status(403).json({ error: 'WORKSPACE_PROJECT_PUBLISH_DENIED' });
     }

--- a/apps/daemon/src/routes/collab-sync.ts
+++ b/apps/daemon/src/routes/collab-sync.ts
@@ -7,6 +7,7 @@ import { contextToResourceHubPrincipal } from '../collab/resource-hub-publish-ad
 import type { CollabRuntime } from '../collab/runtime.js';
 import { parseVelaResourceSnapshot, runVelaResourceCommand } from '../collab/vela-cli-resource-adapter.js';
 import type { ResourceHubPrincipal } from '../integrations/resource-hub.js';
+import { readVelaControlApiContext } from '../integrations/vela.js';
 import { projectResourceIdFor } from '../integrations/vela-team-projects.js';
 import { readProjectManifest } from '../project-locations.js';
 
@@ -212,13 +213,13 @@ function encodePublicFileUrlPath(filePath: string): string {
   return filePath.split('/').map((part) => encodeURIComponent(part)).join('/');
 }
 
-function publicResourceHubBaseUrl(): string {
-  return process.env.VELA_API_URL?.trim() || process.env.OD_RESOURCE_HUB_URL?.trim() || 'http://127.0.0.1:18080';
+function publicResourceHubBaseUrl(): string | null {
+  return readVelaControlApiContext()?.apiUrl?.trim() || process.env.OD_RESOURCE_HUB_URL?.trim() || null;
 }
 
-function publicSnapshotFileUrl(slug: string, filePath: string): string {
+function publicSnapshotFileUrl(baseUrl: string, slug: string, filePath: string): string {
   const relative = `/api/v1/public/snapshots/${encodeURIComponent(slug)}/files/${encodePublicFileUrlPath(filePath)}`;
-  return new URL(relative, publicResourceHubBaseUrl()).toString();
+  return new URL(relative, baseUrl).toString();
 }
 
 export function registerCollabSyncRoutes(app: Express, deps: RegisterCollabSyncRoutesDeps): void {
@@ -360,6 +361,18 @@ export function registerCollabSyncRoutes(app: Express, deps: RegisterCollabSyncR
     if (!principal) {
       return res.status(409).json({ error: 'WORKSPACE_IDENTITY_REQUIRED' });
     }
+    if (!await canShareProjectsForRequest(req)) {
+      return res.status(403).json({ error: 'WORKSPACE_PROJECT_SHARE_DENIED' });
+    }
+    let sharedProject: TeamProject | null = null;
+    try {
+      sharedProject = await resolveSharedProject?.(projectId) ?? null;
+    } catch {
+      sharedProject = null;
+    }
+    if (sharedProject?.ownerMemberId && sharedProject.ownerMemberId !== principal.memberId) {
+      return res.status(403).json({ error: 'WORKSPACE_PROJECT_PUBLISH_DENIED' });
+    }
     if (!resolveProjectDir) {
       return res.status(500).json({ error: 'PROJECT_DIR_UNAVAILABLE' });
     }
@@ -410,8 +423,12 @@ export function registerCollabSyncRoutes(app: Express, deps: RegisterCollabSyncR
       if (!snapshot) {
         return res.status(502).json({ error: 'PUBLIC_SNAPSHOT_UNAVAILABLE' });
       }
+      const baseUrl = publicResourceHubBaseUrl();
+      if (!baseUrl) {
+        return res.status(502).json({ error: 'PUBLIC_FILE_URL_UNAVAILABLE' });
+      }
       return res.json({
-        url: publicSnapshotFileUrl(snapshot.slug, filePath),
+        url: publicSnapshotFileUrl(baseUrl, snapshot.slug, filePath),
         slug: snapshot.slug,
         fileName: filePath,
       });
@@ -420,6 +437,47 @@ export function registerCollabSyncRoutes(app: Express, deps: RegisterCollabSyncR
       return res.status(502).json({ error: 'PUBLIC_FILE_PUBLISH_UNAVAILABLE' });
     } finally {
       await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
+  app.delete(/^\/api\/projects\/([^/]+)\/files\/(.+)\/publish-public$/u, async (req, res) => {
+    const params = req.params as unknown as { 0?: string; 1?: string };
+    const projectId = String(params[0] ?? '');
+    const filePath = normalizePublicFilePath(String(params[1] ?? ''));
+    const slug = typeof (req.body as { slug?: unknown } | undefined)?.slug === 'string'
+      ? (req.body as { slug: string }).slug.trim()
+      : '';
+    if (!projectId || !filePath || !slug) {
+      return res.status(400).json({ error: 'invalid_public_file' });
+    }
+    const principal = await principalForRequest(req);
+    if (!principal) {
+      return res.status(409).json({ error: 'WORKSPACE_IDENTITY_REQUIRED' });
+    }
+    if (!await canShareProjectsForRequest(req)) {
+      return res.status(403).json({ error: 'WORKSPACE_PROJECT_SHARE_DENIED' });
+    }
+    let sharedProject: TeamProject | null = null;
+    try {
+      sharedProject = await resolveSharedProject?.(projectId) ?? null;
+    } catch {
+      sharedProject = null;
+    }
+    if (sharedProject?.ownerMemberId && sharedProject.ownerMemberId !== principal.memberId) {
+      return res.status(403).json({ error: 'WORKSPACE_PROJECT_PUBLISH_DENIED' });
+    }
+    const resourceId = publicFileResourceIdFor(projectId, filePath, principal);
+    try {
+      await runVelaResourceCommand([
+        'snapshot-redact',
+        resourceId,
+        slug,
+        '--json',
+      ]);
+      return res.json({ ok: true, slug, fileName: filePath });
+    } catch (error) {
+      console.warn('[od] failed to unpublish public project file:', error);
+      return res.status(502).json({ error: 'PUBLIC_FILE_UNPUBLISH_UNAVAILABLE' });
     }
   });
 

--- a/apps/daemon/src/routes/collab-sync.ts
+++ b/apps/daemon/src/routes/collab-sync.ts
@@ -1,9 +1,11 @@
 import type { Express } from 'express';
-import { readdir, readFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import type { ProjectMetadata, ProjectSyncIntentEvent, TeamProject } from '@open-design/contracts';
 import { contextToResourceHubPrincipal } from '../collab/resource-hub-publish-adapter.js';
 import type { CollabRuntime } from '../collab/runtime.js';
+import { parseVelaResourceSnapshot, runVelaResourceCommand } from '../collab/vela-cli-resource-adapter.js';
 import type { ResourceHubPrincipal } from '../integrations/resource-hub.js';
 import { projectResourceIdFor } from '../integrations/vela-team-projects.js';
 import { readProjectManifest } from '../project-locations.js';
@@ -70,6 +72,7 @@ export interface RegisterCollabSyncRoutesDeps {
   teamProjectCatalog?: TeamProjectCatalogWriter;
   describeProject?: (projectId: string) => Promise<PulledProjectManifest | null> | PulledProjectManifest | null;
   projectStore?: PulledProjectStore;
+  resolveProjectDir?: (projectId: string) => string;
   resolvePullDir?: (projectId: string) => string;
   readManifest?: (projectDir: string) => Promise<PulledProjectManifest | null>;
 }
@@ -80,6 +83,8 @@ const SYNC_INTENT_EVENTS: ReadonlySet<ProjectSyncIntentEvent> = new Set([
   'project_team_unshare_requested',
 ]);
 const PULLED_PROJECT_PLACEHOLDER_NAME = '共享项目';
+const PUBLIC_FILE_RESOURCE_KIND = 'project';
+const PUBLIC_FILE_REF = 'published';
 
 function cleanPulledProjectName(value: unknown): string | null {
   if (typeof value !== 'string') return null;
@@ -170,6 +175,52 @@ function headerPrincipalForRequest(req: { get(name: string): string | undefined 
   };
 }
 
+function normalizePublicFilePath(raw: string): string | null {
+  let decoded: string;
+  try {
+    decoded = raw
+      .split('/')
+      .map((part) => decodeURIComponent(part))
+      .join('/');
+  } catch {
+    return null;
+  }
+  const normalized = decoded.replace(/^\/+/, '').replace(/\/+/g, '/');
+  if (
+    !normalized ||
+    normalized.includes('\0') ||
+    normalized.split('/').some((part) => part === '' || part === '.' || part === '..')
+  ) {
+    return null;
+  }
+  return normalized;
+}
+
+function publicFileResourceIdFor(
+  projectId: string,
+  filePath: string,
+  principal: ResourceHubPrincipal,
+): string {
+  const scoped = Buffer.from(
+    JSON.stringify([principal.teamId, principal.memberId, projectId, filePath]),
+    'utf8',
+  ).toString('base64url');
+  return `project-file-${scoped}`;
+}
+
+function encodePublicFileUrlPath(filePath: string): string {
+  return filePath.split('/').map((part) => encodeURIComponent(part)).join('/');
+}
+
+function publicResourceHubBaseUrl(): string {
+  return process.env.VELA_API_URL?.trim() || process.env.OD_RESOURCE_HUB_URL?.trim() || 'http://127.0.0.1:18080';
+}
+
+function publicSnapshotFileUrl(slug: string, filePath: string): string {
+  const relative = `/api/v1/public/snapshots/${encodeURIComponent(slug)}/files/${encodePublicFileUrlPath(filePath)}`;
+  return new URL(relative, publicResourceHubBaseUrl()).toString();
+}
+
 export function registerCollabSyncRoutes(app: Express, deps: RegisterCollabSyncRoutesDeps): void {
   const {
     scheduler,
@@ -184,6 +235,7 @@ export function registerCollabSyncRoutes(app: Express, deps: RegisterCollabSyncR
   } = deps.collab;
   const {
     projectStore,
+    resolveProjectDir,
     resolvePullDir,
     resolveSharedProjectOwner,
     resolveSharedProject,
@@ -295,6 +347,80 @@ export function registerCollabSyncRoutes(app: Express, deps: RegisterCollabSyncR
     scheduler.notifyChanged(req.params.id, 'run');
     scheduler.runBoundary(req.params.id);
     res.json({ ok: true });
+  });
+
+  app.post(/^\/api\/projects\/([^/]+)\/files\/(.+)\/publish-public$/u, async (req, res) => {
+    const params = req.params as unknown as { 0?: string; 1?: string };
+    const projectId = String(params[0] ?? '');
+    const filePath = normalizePublicFilePath(String(params[1] ?? ''));
+    if (!projectId || !filePath) {
+      return res.status(400).json({ error: 'invalid_file_path' });
+    }
+    const principal = await principalForRequest(req);
+    if (!principal) {
+      return res.status(409).json({ error: 'WORKSPACE_IDENTITY_REQUIRED' });
+    }
+    if (!resolveProjectDir) {
+      return res.status(500).json({ error: 'PROJECT_DIR_UNAVAILABLE' });
+    }
+
+    const projectDir = resolveProjectDir(projectId);
+    const sourceFile = path.join(projectDir, filePath);
+    let data: Buffer;
+    try {
+      data = await readFile(sourceFile);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      return res.status(code === 'ENOENT' ? 404 : 400).json({
+        error: code === 'ENOENT' ? 'FILE_NOT_FOUND' : 'FILE_UNAVAILABLE',
+      });
+    }
+
+    const resourceId = publicFileResourceIdFor(projectId, filePath, principal);
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'od-public-file-'));
+    try {
+      const targetFile = path.join(tempDir, filePath);
+      await mkdir(path.dirname(targetFile), { recursive: true });
+      await writeFile(targetFile, data);
+      const metadata = {
+        source: 'open-design',
+        projectId,
+        fileName: filePath,
+      };
+      await runVelaResourceCommand([
+        'push',
+        PUBLIC_FILE_RESOURCE_KIND,
+        resourceId,
+        tempDir,
+        '--ref',
+        PUBLIC_FILE_REF,
+        '--metadata-json',
+        JSON.stringify(metadata),
+        '--json',
+      ]);
+      const snapshot = parseVelaResourceSnapshot(await runVelaResourceCommand([
+        'snapshot',
+        resourceId,
+        '--ref',
+        PUBLIC_FILE_REF,
+        '--name',
+        path.basename(filePath),
+        '--json',
+      ]));
+      if (!snapshot) {
+        return res.status(502).json({ error: 'PUBLIC_SNAPSHOT_UNAVAILABLE' });
+      }
+      return res.json({
+        url: publicSnapshotFileUrl(snapshot.slug, filePath),
+        slug: snapshot.slug,
+        fileName: filePath,
+      });
+    } catch (error) {
+      console.warn('[od] failed to publish public project file:', error);
+      return res.status(502).json({ error: 'PUBLIC_FILE_PUBLISH_UNAVAILABLE' });
+    } finally {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
   });
 
   app.post('/api/projects/:id/collab/sync-intent', async (req, res) => {

--- a/apps/daemon/src/routes/collab-sync.ts
+++ b/apps/daemon/src/routes/collab-sync.ts
@@ -1,5 +1,5 @@
 import type { Express } from 'express';
-import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import type { ProjectMetadata, ProjectSyncIntentEvent, TeamProject } from '@open-design/contracts';
@@ -86,6 +86,14 @@ const SYNC_INTENT_EVENTS: ReadonlySet<ProjectSyncIntentEvent> = new Set([
 const PULLED_PROJECT_PLACEHOLDER_NAME = '共享项目';
 const PUBLIC_FILE_RESOURCE_KIND = 'project';
 const PUBLIC_FILE_REF = 'published';
+
+interface PublicFilePublication {
+  url: string;
+  slug: string;
+  fileName: string;
+}
+
+const publicFilePublications = new Map<string, PublicFilePublication>();
 
 function cleanPulledProjectName(value: unknown): string | null {
   if (typeof value !== 'string') return null;
@@ -177,6 +185,7 @@ function headerPrincipalForRequest(req: { get(name: string): string | undefined 
 }
 
 function normalizePublicFilePath(raw: string): string | null {
+  if (raw.includes('\\')) return null;
   let decoded: string;
   try {
     decoded = raw
@@ -186,6 +195,7 @@ function normalizePublicFilePath(raw: string): string | null {
   } catch {
     return null;
   }
+  if (decoded.includes('\\')) return null;
   const normalized = decoded.replace(/^\/+/, '').replace(/\/+/g, '/');
   if (
     !normalized ||
@@ -195,6 +205,20 @@ function normalizePublicFilePath(raw: string): string | null {
     return null;
   }
   return normalized;
+}
+
+async function resolvePublicSourceFile(projectDir: string, filePath: string): Promise<string> {
+  const [projectRoot, candidate] = await Promise.all([
+    realpath(projectDir),
+    realpath(path.join(projectDir, filePath)),
+  ]);
+  const relative = path.relative(projectRoot, candidate);
+  if (relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))) {
+    return candidate;
+  }
+  const error = new Error('public file path escapes project root') as NodeJS.ErrnoException;
+  error.code = 'EACCES';
+  throw error;
 }
 
 function publicFileResourceIdFor(
@@ -207,6 +231,10 @@ function publicFileResourceIdFor(
     'utf8',
   ).toString('base64url');
   return `project-file-${scoped}`;
+}
+
+function publicFilePublicationKey(projectId: string, filePath: string, principal: ResourceHubPrincipal): string {
+  return JSON.stringify([principal.teamId, principal.memberId, projectId, filePath]);
 }
 
 function encodePublicFileUrlPath(filePath: string): string {
@@ -393,9 +421,9 @@ export function registerCollabSyncRoutes(app: Express, deps: RegisterCollabSyncR
     }
 
     const projectDir = resolveProjectDir(projectId);
-    const sourceFile = path.join(projectDir, filePath);
     let data: Buffer;
     try {
+      const sourceFile = await resolvePublicSourceFile(projectDir, filePath);
       data = await readFile(sourceFile);
     } catch (error) {
       const code = (error as NodeJS.ErrnoException)?.code;
@@ -438,11 +466,13 @@ export function registerCollabSyncRoutes(app: Express, deps: RegisterCollabSyncR
       if (!snapshot) {
         return res.status(502).json({ error: 'PUBLIC_SNAPSHOT_UNAVAILABLE' });
       }
-      return res.json({
+      const publication = {
         url: publicSnapshotFileUrl(baseUrl, snapshot.slug, filePath),
         slug: snapshot.slug,
         fileName: filePath,
-      });
+      };
+      publicFilePublications.set(publicFilePublicationKey(projectId, filePath, principal), publication);
+      return res.json(publication);
     } catch (error) {
       console.warn('[od] failed to publish public project file:', error);
       return res.status(502).json({ error: 'PUBLIC_FILE_PUBLISH_UNAVAILABLE' });
@@ -484,11 +514,39 @@ export function registerCollabSyncRoutes(app: Express, deps: RegisterCollabSyncR
         slug,
         '--json',
       ]);
+      publicFilePublications.delete(publicFilePublicationKey(projectId, filePath, principal));
       return res.json({ ok: true, slug, fileName: filePath });
     } catch (error) {
       console.warn('[od] failed to unpublish public project file:', error);
       return res.status(502).json({ error: 'PUBLIC_FILE_UNPUBLISH_UNAVAILABLE' });
     }
+  });
+
+  app.get(/^\/api\/projects\/([^/]+)\/files\/(.+)\/publish-public$/u, async (req, res) => {
+    const params = req.params as unknown as { 0?: string; 1?: string };
+    const projectId = String(params[0] ?? '');
+    const filePath = normalizePublicFilePath(String(params[1] ?? ''));
+    if (!projectId || !filePath) {
+      return res.status(400).json({ error: 'invalid_file_path' });
+    }
+    const principal = await principalForRequest(req);
+    if (!principal) {
+      return res.status(409).json({ error: 'WORKSPACE_IDENTITY_REQUIRED' });
+    }
+    if (!await canShareProjectsForRequest(req)) {
+      return res.status(403).json({ error: 'WORKSPACE_PROJECT_SHARE_DENIED' });
+    }
+    const sharedProjectResult = await resolveSharedProjectForPublicFile(resolveSharedProject, projectId);
+    if (!sharedProjectResult.ok) {
+      return res.status(503).json({ error: 'WORKSPACE_PROJECT_OWNERSHIP_UNAVAILABLE' });
+    }
+    const sharedProject = sharedProjectResult.project;
+    if (sharedProject?.ownerMemberId && sharedProject.ownerMemberId !== principal.memberId) {
+      return res.status(403).json({ error: 'WORKSPACE_PROJECT_PUBLISH_DENIED' });
+    }
+    return res.json({
+      publication: publicFilePublications.get(publicFilePublicationKey(projectId, filePath, principal)) ?? null,
+    });
   });
 
   app.post('/api/projects/:id/collab/sync-intent', async (req, res) => {

--- a/apps/daemon/src/runtimes/executables.ts
+++ b/apps/daemon/src/runtimes/executables.ts
@@ -180,7 +180,7 @@ function configuredExecutableOverride(
 ): string | null {
   const envKey = AGENT_BIN_ENV_KEYS.get(def?.id);
   if (!envKey) return null;
-  return executableFilePath(configuredEnv?.[envKey]);
+  return executableFilePath(configuredEnv?.[envKey] ?? process.env[envKey]);
 }
 
 export function resolveAmrOpenCodeExecutable(

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -3932,7 +3932,7 @@ export async function startServer({
       const ctx = await collab.workspaceContext.current({});
       const principal = contextToResourceHubPrincipal(ctx);
       if (!principal || owner !== principal.memberId) return false;
-      collab.rememberTeamShare(projectId, principal, 'synced');
+      collab.rememberTeamShare(projectId, principal);
       return true;
     },
     subscribeFiles: (projectId, onChange) => {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -3852,6 +3852,7 @@ export async function startServer({
   const collab = createCollabRuntime({
     resolveProjectDir: (projectId) =>
       resolveProjectShareDir(PROJECTS_DIR, projectId, getProject(db, projectId), resolveProjectDir),
+    resolvePullDir: (projectId) => resolveProjectDir(PROJECTS_DIR, projectId),
     describeProject: describeCollabProject,
     ...(velaCliTeamProjectCatalog ? { teamProjectCatalog: velaCliTeamProjectCatalog } : {}),
     onPublished: ({ projectId, principal }) => {
@@ -3929,12 +3930,16 @@ export async function startServer({
       const owner = await resolveSharedProjectOwner(projectId);
       if (!owner) return false;
       const ctx = await collab.workspaceContext.current({});
-      return ctx?.workspaceMemberId != null && owner === ctx.workspaceMemberId;
+      const principal = contextToResourceHubPrincipal(ctx);
+      if (!principal || owner !== principal.memberId) return false;
+      collab.rememberTeamShare(projectId, principal, 'synced');
+      return true;
     },
     subscribeFiles: (projectId, onChange) => {
+      const watchProject = getProject(db, projectId);
       const sub = subscribeFileEvents(PROJECTS_DIR, projectId, (evt) => {
         if (evt.type === 'file-changed') onChange();
-      });
+      }, { metadata: watchProject?.metadata });
       return { unsubscribe: () => sub.unsubscribe() };
     },
     onError: (error) => console.warn('[od] collab publish watcher error:', error),
@@ -3969,6 +3974,8 @@ export async function startServer({
         });
       },
     },
+    resolveProjectDir: (projectId) =>
+      resolveProjectShareDir(PROJECTS_DIR, projectId, getProject(db, projectId), resolveProjectDir),
     resolvePullDir: (projectId) => resolveProjectDir(PROJECTS_DIR, projectId),
     resolveSharedProject,
     resolveSharedProjectOwner,

--- a/apps/daemon/tests/collab-sync-routes.test.ts
+++ b/apps/daemon/tests/collab-sync-routes.test.ts
@@ -9,12 +9,14 @@ import {
   buildWorkspaceSeatSummary,
   type WorkspaceCollabContext,
 } from '@open-design/contracts';
+import { runVelaResourceCommand } from '../src/collab/vela-cli-resource-adapter.js';
 import {
   createCollabRuntime,
   type CollabRuntime,
   type CreateCollabRuntimeOptions,
 } from '../src/collab/runtime.js';
 import type { WorkspaceContextProvider } from '../src/collab/workspace-context.js';
+import { readVelaControlApiContext } from '../src/integrations/vela.js';
 import { projectResourceIdFor } from '../src/integrations/vela-team-projects.js';
 import {
   registerCollabSyncRoutes,
@@ -23,6 +25,18 @@ import {
   type RegisterPulledProjectInput,
 } from '../src/routes/collab-sync.js';
 import { writeProjectManifest } from '../src/project-locations.js';
+
+vi.mock('../src/collab/vela-cli-resource-adapter.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/collab/vela-cli-resource-adapter.js')>();
+  return {
+    ...actual,
+    runVelaResourceCommand: vi.fn(),
+  };
+});
+
+vi.mock('../src/integrations/vela.js', () => ({
+  readVelaControlApiContext: vi.fn(() => null),
+}));
 
 /** In-memory project store standing in for the daemon's SQLite-backed store, so
  *  a route test can assert register-on-pull without a real database. */
@@ -75,6 +89,8 @@ let runtime: CollabRuntime | null = null;
 const tempDirs: string[] = [];
 
 afterEach(async () => {
+  vi.mocked(runVelaResourceCommand).mockReset();
+  vi.mocked(readVelaControlApiContext).mockReturnValue(null);
   runtime?.dispose(); // cancel any pending debounce timers
   runtime = null;
   if (server) {
@@ -541,6 +557,13 @@ describe('collab sync routes', () => {
     const resolveProjectDir = vi.fn(() => {
       throw new Error('project dir should not be read');
     });
+    vi.mocked(readVelaControlApiContext).mockReturnValue({
+      profile: 'test',
+      apiUrl: 'https://hub.example.test',
+      controlKey: 'ctrl-test',
+      user: null,
+      configMtimeMs: null,
+    });
     const api = await startSyncServer(fixedShareContextProvider(true), {
       resolveProjectDir,
       resolveSharedProject: async () => ({
@@ -558,6 +581,59 @@ describe('collab sync routes', () => {
     expect(res.status).toBe(403);
     expect(res.body.error).toBe('WORKSPACE_PROJECT_PUBLISH_DENIED');
     expect(resolveProjectDir).not.toHaveBeenCalled();
+  });
+
+  it('fails public file publish and unpublish when ownership lookup fails', async () => {
+    const resolveProjectDir = vi.fn(() => {
+      throw new Error('project dir should not be read');
+    });
+    vi.mocked(readVelaControlApiContext).mockReturnValue({
+      profile: 'test',
+      apiUrl: 'https://hub.example.test',
+      controlKey: 'ctrl-test',
+      user: null,
+      configMtimeMs: null,
+    });
+    const api = await startSyncServer(fixedShareContextProvider(true), {
+      resolveProjectDir,
+      resolveSharedProject: async () => {
+        throw new Error('catalog unavailable');
+      },
+    });
+
+    const publish = await api.json('/api/projects/p1/files/index.html/publish-public', {
+      method: 'POST',
+    });
+    const unpublish = await api.json('/api/projects/p1/files/index.html/publish-public', {
+      method: 'DELETE',
+      body: { slug: 'public-slug' },
+    });
+
+    expect(publish.status).toBe(503);
+    expect(publish.body.error).toBe('WORKSPACE_PROJECT_OWNERSHIP_UNAVAILABLE');
+    expect(unpublish.status).toBe(503);
+    expect(unpublish.body.error).toBe('WORKSPACE_PROJECT_OWNERSHIP_UNAVAILABLE');
+    expect(resolveProjectDir).not.toHaveBeenCalled();
+    expect(runVelaResourceCommand).not.toHaveBeenCalled();
+  });
+
+  it('does not create a public snapshot when no public base URL is configured', async () => {
+    const resolveProjectDir = vi.fn(() => {
+      throw new Error('project dir should not be read');
+    });
+    const api = await startSyncServer(fixedShareContextProvider(true), {
+      resolveProjectDir,
+      resolveSharedProject: async () => null,
+    });
+
+    const res = await api.json('/api/projects/p1/files/index.html/publish-public', {
+      method: 'POST',
+    });
+
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBe('PUBLIC_FILE_URL_UNAVAILABLE');
+    expect(resolveProjectDir).not.toHaveBeenCalled();
+    expect(runVelaResourceCommand).not.toHaveBeenCalled();
   });
 
   it('writes and removes the Vela team-project catalog around share intents', async () => {

--- a/apps/daemon/tests/collab-sync-routes.test.ts
+++ b/apps/daemon/tests/collab-sync-routes.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import express from 'express';
 import http from 'node:http';
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import {
@@ -280,6 +280,19 @@ describe('collab sync routes', () => {
     );
     expect(runtime.projectSyncState(projectId, workspaceA)).toBe('sync_failed');
     expect(runtime.projectSyncState(projectId, workspaceB)).toBe('sync_failed');
+  });
+
+  it('preserves existing sync state when rememberTeamShare only seeds ownership', () => {
+    runtime = createCollabRuntime();
+    const workspace = {
+      memberId: 'member-a',
+      teamId: 'workspace-a',
+      role: 'admin' as const,
+      lifecycleState: 'active' as const,
+    };
+    runtime.rememberTeamShare('p1', workspace, 'sync_failed');
+    runtime.rememberTeamShare('p1', workspace);
+    expect(runtime.projectSyncState('p1', workspace)).toBe('sync_failed');
   });
 
   it('keeps team-project catalog resource ids scoped per workspace principal', async () => {
@@ -633,6 +646,82 @@ describe('collab sync routes', () => {
     expect(res.status).toBe(502);
     expect(res.body.error).toBe('PUBLIC_FILE_URL_UNAVAILABLE');
     expect(resolveProjectDir).not.toHaveBeenCalled();
+    expect(runVelaResourceCommand).not.toHaveBeenCalled();
+  });
+
+  it('hydrates and clears public file publication state', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'od-public-file-'));
+    tempDirs.push(dir);
+    await writeFile(path.join(dir, 'index.html'), '<h1>Published</h1>');
+    vi.mocked(readVelaControlApiContext).mockReturnValue({
+      profile: 'test',
+      apiUrl: 'https://hub.example.test',
+      controlKey: 'ctrl-test',
+      user: null,
+      configMtimeMs: null,
+    });
+    vi.mocked(runVelaResourceCommand).mockImplementation(async (args) => {
+      if (args[0] === 'snapshot') {
+        return JSON.stringify({
+          slug: 'public-slug',
+          name: 'index.html',
+          kind: 'project',
+          versionId: 'v1',
+          createdAt: new Date(1).toISOString(),
+        });
+      }
+      return JSON.stringify({ version: 1 });
+    });
+    const api = await startSyncServer(fixedShareContextProvider(true), {
+      resolveProjectDir: () => dir,
+      resolveSharedProject: async () => null,
+    });
+
+    const publish = await api.json('/api/projects/p1/files/index.html/publish-public', { method: 'POST' });
+    const current = await api.json('/api/projects/p1/files/index.html/publish-public');
+    const unpublish = await api.json('/api/projects/p1/files/index.html/publish-public', {
+      method: 'DELETE',
+      body: { slug: 'public-slug' },
+    });
+    const afterUnpublish = await api.json('/api/projects/p1/files/index.html/publish-public');
+
+    const publication = {
+      url: 'https://hub.example.test/api/v1/public/snapshots/public-slug/files/index.html',
+      slug: 'public-slug',
+      fileName: 'index.html',
+    };
+    expect(publish.status).toBe(200);
+    expect(publish.body).toEqual(publication);
+    expect(current.body.publication).toEqual(publication);
+    expect(unpublish.status).toBe(200);
+    expect(afterUnpublish.body.publication).toBeNull();
+  });
+
+  it('rejects escaped and symlinked public file paths before publishing', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'od-public-file-'));
+    const outsideDir = await mkdtemp(path.join(tmpdir(), 'od-public-outside-'));
+    tempDirs.push(dir, outsideDir);
+    await writeFile(path.join(outsideDir, 'secret.html'), '<h1>Secret</h1>');
+    await symlink(path.join(outsideDir, 'secret.html'), path.join(dir, 'secret-link.html'));
+    vi.mocked(readVelaControlApiContext).mockReturnValue({
+      profile: 'test',
+      apiUrl: 'https://hub.example.test',
+      controlKey: 'ctrl-test',
+      user: null,
+      configMtimeMs: null,
+    });
+    const api = await startSyncServer(fixedShareContextProvider(true), {
+      resolveProjectDir: () => dir,
+      resolveSharedProject: async () => null,
+    });
+
+    const backslash = await api.json('/api/projects/p1/files/nested%5Csecret.html/publish-public', { method: 'POST' });
+    const symlinked = await api.json('/api/projects/p1/files/secret-link.html/publish-public', { method: 'POST' });
+
+    expect(backslash.status).toBe(400);
+    expect(backslash.body.error).toBe('invalid_file_path');
+    expect(symlinked.status).toBe(400);
+    expect(symlinked.body.error).toBe('FILE_UNAVAILABLE');
     expect(runVelaResourceCommand).not.toHaveBeenCalled();
   });
 

--- a/apps/daemon/tests/collab-sync-routes.test.ts
+++ b/apps/daemon/tests/collab-sync-routes.test.ts
@@ -53,6 +53,7 @@ function fixedShareContextProvider(canShareProjects: boolean): WorkspaceContextP
   const context: WorkspaceCollabContext = {
     workspaceId: 'ws-1',
     workspaceType: 'team',
+    teamId: 'team-1',
     workspaceMemberId: 'wm-1',
     role: 'member',
     memberStatus: 'active',
@@ -536,6 +537,29 @@ describe('collab sync routes', () => {
     expect(removes).toEqual([]);
   });
 
+  it('refuses public file publishing for a shared project owned by another member', async () => {
+    const resolveProjectDir = vi.fn(() => {
+      throw new Error('project dir should not be read');
+    });
+    const api = await startSyncServer(fixedShareContextProvider(true), {
+      resolveProjectDir,
+      resolveSharedProject: async () => ({
+        projectId: 'p1',
+        ownerMemberId: 'wm-owner',
+        sharedAt: new Date(1).toISOString(),
+        name: 'Owner Project',
+      }),
+    });
+
+    const res = await api.json('/api/projects/p1/files/index.html/publish-public', {
+      method: 'POST',
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('WORKSPACE_PROJECT_PUBLISH_DENIED');
+    expect(resolveProjectDir).not.toHaveBeenCalled();
+  });
+
   it('writes and removes the Vela team-project catalog around share intents', async () => {
     const writes: unknown[] = [];
     const removes: string[] = [];
@@ -565,6 +589,12 @@ describe('collab sync routes', () => {
     expect(writes).toEqual([
       {
         projectId: 'p1',
+        resourceId: projectResourceIdFor('p1', {
+          teamId: 'team-1',
+          memberId: 'wm-1',
+          role: 'member',
+          lifecycleState: 'active',
+        }),
         displayName: 'Electric Studio 2',
         syncState: 'synced',
         metadata: {

--- a/apps/daemon/tests/runtimes/executables.test.ts
+++ b/apps/daemon/tests/runtimes/executables.test.ts
@@ -136,6 +136,36 @@ fsTest(
 );
 
 fsTest(
+  'resolveAgentExecutable honors inherited VELA_BIN before PATH fallback',
+  () => {
+    const root = mkdtempSync(join(tmpdir(), 'od-amr-env-bin-precedence-'));
+    try {
+      return withEnvSnapshot(['PATH', 'OD_AGENT_HOME', 'OD_RESOURCE_ROOT', 'VELA_BIN'], () => {
+        const pathBin = join(root, 'path-bin');
+        const pathVela = join(pathBin, 'vela');
+        const envVela = join(root, 'env', 'vela');
+        mkdirSync(pathBin, { recursive: true });
+        mkdirSync(join(root, 'env'), { recursive: true });
+        writeFileSync(pathVela, '#!/bin/sh\nexit 0\n');
+        writeFileSync(envVela, '#!/bin/sh\nexit 0\n');
+        chmodSync(pathVela, 0o755);
+        chmodSync(envVela, 0o755);
+        process.env.PATH = pathBin;
+        process.env.OD_AGENT_HOME = join(root, 'empty-home');
+        process.env.OD_RESOURCE_ROOT = '';
+        process.env.VELA_BIN = envVela;
+
+        const resolved = resolveAgentExecutable(minimalAgentDef({ id: 'amr', bin: 'vela' }));
+
+        assert.equal(resolved, envVela);
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  },
+);
+
+fsTest(
   'resolveAgentExecutable falls back to PATH Vela when packaged built-in Vela is absent',
   () => {
     const root = mkdtempSync(join(tmpdir(), 'od-amr-path-fallback-'));

--- a/apps/daemon/tests/vela-cli-resource-adapter.test.ts
+++ b/apps/daemon/tests/vela-cli-resource-adapter.test.ts
@@ -50,6 +50,12 @@ describe('createVelaCliResourceAdapter', () => {
       '--ref',
       'published',
       '--json',
+      '--exclude',
+      '.file-versions',
+      '--exclude',
+      '.live-artifacts',
+      '--exclude',
+      '.od-skills',
     ]);
   });
 
@@ -69,6 +75,12 @@ describe('createVelaCliResourceAdapter', () => {
       '--ref',
       'published',
       '--json',
+      '--exclude',
+      '.file-versions',
+      '--exclude',
+      '.live-artifacts',
+      '--exclude',
+      '.od-skills',
       '--metadata-json',
       JSON.stringify({ name: 'Launch Deck', metadata: { kind: 'deck' } }),
     ]);

--- a/apps/daemon/tests/vela-workspace-context.test.ts
+++ b/apps/daemon/tests/vela-workspace-context.test.ts
@@ -68,6 +68,20 @@ describe('mapVelaWorkspaceContext', () => {
     expect(mapped?.seatSummary).toEqual({ seatLimit: 5, usedSeats: 5, availableSeats: 0, isSeatFull: true });
   });
 
+  it('accepts member contexts that hide billing-only fields', () => {
+    const mapped = mapVelaWorkspaceContext({
+      ...B_TEAM_CONTEXT,
+      billingState: undefined,
+      planId: undefined,
+      seatSummary: undefined,
+    });
+    expect(mapped).not.toBeNull();
+    expect(mapped?.billingState).toBe('active');
+    expect(mapped?.planId).toBeNull();
+    expect(mapped?.seatSummary).toEqual({ seatLimit: 0, usedSeats: 0, availableSeats: 0, isSeatFull: true });
+    expect(mapped?.permissions.canShareProjects).toBe(true);
+  });
+
   it('returns null on a bad enum or a missing id', () => {
     expect(mapVelaWorkspaceContext({ ...B_TEAM_CONTEXT, role: 'viewer' })).toBeNull();
     expect(mapVelaWorkspaceContext({ ...B_TEAM_CONTEXT, lifecycleState: 'frozen' })).toBeNull();

--- a/apps/web/src/collab/useWorkspaceContext.ts
+++ b/apps/web/src/collab/useWorkspaceContext.ts
@@ -21,29 +21,80 @@ export interface WorkspaceContextState {
 
 export function useWorkspaceContext(): WorkspaceContextState {
   const [state, setState] = useState<WorkspaceContextState>({ context: null, loading: true });
+  const mountedRef = useRef(true);
 
   useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const res = await fetch('/api/workspace/context');
-        if (!res.ok) {
-          if (!cancelled) setState({ context: null, loading: false });
-          return;
-        }
-        const body = (await res.json()) as WorkspaceContextResponse;
-        if (!cancelled) setState({ context: body.context ?? null, loading: false });
-      } catch {
-        // Personal / offline / daemon without the B proxy: stay in the local state.
-        if (!cancelled) setState({ context: null, loading: false });
-      }
-    })();
+    mountedRef.current = true;
     return () => {
-      cancelled = true;
+      mountedRef.current = false;
     };
   }, []);
 
+  const loadContext = useCallback(async (clearOnFailure: boolean) => {
+    try {
+      const res = await fetch('/api/workspace/context', { cache: 'no-store' });
+      if (!res.ok) {
+        if (clearOnFailure && mountedRef.current) setState({ context: null, loading: false });
+        return;
+      }
+      const body = (await res.json()) as WorkspaceContextResponse;
+      if (mountedRef.current) setState({ context: body.context ?? null, loading: false });
+    } catch {
+      // Personal / offline / daemon without the B proxy: stay in the local state.
+      if (clearOnFailure && mountedRef.current) setState({ context: null, loading: false });
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadContext(true);
+  }, [loadContext]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (document.visibilityState === 'visible') void loadContext(false);
+    }, WORKSPACE_CONTEXT_POLL_MS);
+    return () => clearInterval(interval);
+  }, [loadContext]);
+
+  useEffect(() => {
+    const refresh = () => {
+      void loadContext(true);
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') refresh();
+    };
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === WORKSPACE_CONTEXT_REFRESH_STORAGE_KEY) refresh();
+    };
+    window.addEventListener('focus', refresh);
+    window.addEventListener('pageshow', refresh);
+    window.addEventListener(WORKSPACE_CONTEXT_REFRESH_EVENT, refresh);
+    window.addEventListener('storage', onStorage);
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      window.removeEventListener('focus', refresh);
+      window.removeEventListener('pageshow', refresh);
+      window.removeEventListener(WORKSPACE_CONTEXT_REFRESH_EVENT, refresh);
+      window.removeEventListener('storage', onStorage);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [loadContext]);
+
   return state;
+}
+
+const WORKSPACE_CONTEXT_POLL_MS = 30_000;
+export const WORKSPACE_CONTEXT_REFRESH_EVENT = 'od:workspace-context-refresh';
+const WORKSPACE_CONTEXT_REFRESH_STORAGE_KEY = 'od.workspaceContext.refreshAt';
+
+export function notifyWorkspaceContextRefresh(): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(WORKSPACE_CONTEXT_REFRESH_EVENT));
+  try {
+    window.localStorage.setItem(WORKSPACE_CONTEXT_REFRESH_STORAGE_KEY, String(Date.now()));
+  } catch {
+    // The in-window event is enough when localStorage is unavailable.
+  }
 }
 
 /**

--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -28,7 +28,7 @@ import { Icon } from './Icon';
 import { InviteDialog } from './InviteDialog';
 import { CreditsPanel } from './CreditsPanel';
 import { LOCALE_LABEL, LOCALES, useI18n } from '../i18n';
-import { notifyWorkspaceBillingRefresh } from '../collab/useWorkspaceContext';
+import { notifyWorkspaceBillingRefresh, notifyWorkspaceContextRefresh } from '../collab/useWorkspaceContext';
 import type { EntryHomeView } from '../router';
 
 const REPO_URL = 'https://github.com/nexu-io/open-design';
@@ -185,8 +185,8 @@ export function EntryNavRail({
     context?.billingRecovery?.recoveryUrl?.trim() ||
     (workspaceSettingsUrl ? teamConsoleUrl(workspaceSettingsUrl, 'billing') : null);
   // Product decision: plan selection / payment lives in Vela Web. The local
-  // client opens that billing surface, then refreshes `/api/workspace/billing`
-  // when focus returns so direct web upgrades sync back into the credits chip.
+  // client opens that billing surface, then refreshes billing + context when
+  // focus returns so direct web upgrades sync plan, credits, seats and gates.
   const canUpgrade = Boolean(billingUpgradeUrl && permissions?.canManageBilling);
   const currentLanguageLabel = LOCALE_LABEL[locale];
 
@@ -194,7 +194,10 @@ export function EntryNavRail({
     if (!billingUpgradeUrl) return;
     setCreditsOpen(false);
     window.open(billingUpgradeUrl, '_blank', 'noopener,noreferrer');
-    window.setTimeout(() => notifyWorkspaceBillingRefresh(), 3000);
+    window.setTimeout(() => {
+      notifyWorkspaceBillingRefresh();
+      notifyWorkspaceContextRefresh();
+    }, 3000);
   }
 
   const selectView = (next: EntryView) => {

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -67,6 +67,7 @@ import {
   fetchProjectFileVersions,
   fetchProjectFilePreview,
   fetchProjectFiles,
+  fetchProjectFilePublicPublication,
   fetchProjectFileText,
   uploadProjectFiles,
   liveArtifactPreviewUrl,
@@ -5304,6 +5305,8 @@ function ReactComponentViewer({
   const [publishingPublicFile, setPublishingPublicFile] = useState(false);
   const [publishLinkFeedback, setPublishLinkFeedback] = useState<'copied' | 'failed' | null>(null);
   const filePublished = publishedFileUrl.length > 0;
+  const publicFileRequestSeqRef = useRef(0);
+  const publicFileIdentityRef = useRef({ projectId, fileName: file.name });
   const shareRef = useRef<HTMLDivElement | null>(null);
   // HTML entries that load this file as a Babel module. `null` = still
   // checking; `[]` = standalone artifact; non-empty = a module of a
@@ -5406,41 +5409,85 @@ function ReactComponentViewer({
   }, [viewerOnly]);
 
   useEffect(() => {
+    publicFileIdentityRef.current = { projectId, fileName: file.name };
+    const requestSeq = ++publicFileRequestSeqRef.current;
+    let cancelled = false;
     setPublishedFileUrl('');
     setPublishedFileSlug('');
     setPublishingPublicFile(false);
     setPublishLinkFeedback(null);
+    void fetchProjectFilePublicPublication(projectId, file.name)
+      .then((publication) => {
+        const current = publicFileIdentityRef.current;
+        if (
+          cancelled ||
+          publicFileRequestSeqRef.current !== requestSeq ||
+          current.projectId !== projectId ||
+          current.fileName !== file.name
+        ) {
+          return;
+        }
+        setPublishedFileUrl(publication?.url ?? '');
+        setPublishedFileSlug(publication?.slug ?? '');
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
   }, [projectId, file.name]);
 
   async function publishCurrentFilePublic() {
     if (viewerOnly || publishingPublicFile) return;
+    const requestProjectId = projectId;
+    const requestFileName = file.name;
+    const requestSeq = ++publicFileRequestSeqRef.current;
     setPublishingPublicFile(true);
     setPublishLinkFeedback(null);
     try {
-      const response = await publishProjectFilePublic(projectId, file.name);
+      const response = await publishProjectFilePublic(requestProjectId, requestFileName);
+      const current = publicFileIdentityRef.current;
+      if (
+        publicFileRequestSeqRef.current !== requestSeq ||
+        current.projectId !== requestProjectId ||
+        current.fileName !== requestFileName
+      ) {
+        return;
+      }
       setPublishedFileUrl(response.url);
       setPublishedFileSlug(response.slug);
     } catch (error) {
       console.warn('[FileViewer] failed to publish public file', error);
-      setPublishLinkFeedback('failed');
+      if (publicFileRequestSeqRef.current === requestSeq) setPublishLinkFeedback('failed');
     } finally {
-      setPublishingPublicFile(false);
+      if (publicFileRequestSeqRef.current === requestSeq) setPublishingPublicFile(false);
     }
   }
 
   async function unpublishCurrentFilePublic() {
     if (!publishedFileSlug || publishingPublicFile) return;
+    const requestProjectId = projectId;
+    const requestFileName = file.name;
+    const requestSlug = publishedFileSlug;
+    const requestSeq = ++publicFileRequestSeqRef.current;
     setPublishingPublicFile(true);
     setPublishLinkFeedback(null);
     try {
-      await unpublishProjectFilePublic(projectId, file.name, publishedFileSlug);
+      await unpublishProjectFilePublic(requestProjectId, requestFileName, requestSlug);
+      const current = publicFileIdentityRef.current;
+      if (
+        publicFileRequestSeqRef.current !== requestSeq ||
+        current.projectId !== requestProjectId ||
+        current.fileName !== requestFileName
+      ) {
+        return;
+      }
       setPublishedFileUrl('');
       setPublishedFileSlug('');
     } catch (error) {
       console.warn('[FileViewer] failed to unpublish public file', error);
-      setPublishLinkFeedback('failed');
+      if (publicFileRequestSeqRef.current === requestSeq) setPublishLinkFeedback('failed');
     } finally {
-      setPublishingPublicFile(false);
+      if (publicFileRequestSeqRef.current === requestSeq) setPublishingPublicFile(false);
     }
   }
 
@@ -6231,6 +6278,8 @@ function HtmlViewer({
   const [publishingPublicFile, setPublishingPublicFile] = useState(false);
   const [publishLinkFeedback, setPublishLinkFeedback] = useState<'copied' | 'failed' | null>(null);
   const filePublished = publishedFileUrl.length > 0;
+  const publicFileRequestSeqRef = useRef(0);
+  const publicFileIdentityRef = useRef({ projectId, fileName: file.name });
   // False when closed; otherwise records which entry opened the modal so the
   // surface_view impression can carry entry_from.
   const [versionModalOpen, setVersionModalOpen] = useState<false | 'toolbar' | 'more_menu'>(false);
@@ -6318,41 +6367,85 @@ function HtmlViewer({
   }, [deployMenuOpen]);
 
   useEffect(() => {
+    publicFileIdentityRef.current = { projectId, fileName: file.name };
+    const requestSeq = ++publicFileRequestSeqRef.current;
+    let cancelled = false;
     setPublishedFileUrl('');
     setPublishedFileSlug('');
     setPublishingPublicFile(false);
     setPublishLinkFeedback(null);
+    void fetchProjectFilePublicPublication(projectId, file.name)
+      .then((publication) => {
+        const current = publicFileIdentityRef.current;
+        if (
+          cancelled ||
+          publicFileRequestSeqRef.current !== requestSeq ||
+          current.projectId !== projectId ||
+          current.fileName !== file.name
+        ) {
+          return;
+        }
+        setPublishedFileUrl(publication?.url ?? '');
+        setPublishedFileSlug(publication?.slug ?? '');
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
   }, [projectId, file.name]);
 
   async function publishCurrentFilePublic() {
     if (viewerOnly || publishingPublicFile) return;
+    const requestProjectId = projectId;
+    const requestFileName = file.name;
+    const requestSeq = ++publicFileRequestSeqRef.current;
     setPublishingPublicFile(true);
     setPublishLinkFeedback(null);
     try {
-      const response = await publishProjectFilePublic(projectId, file.name);
+      const response = await publishProjectFilePublic(requestProjectId, requestFileName);
+      const current = publicFileIdentityRef.current;
+      if (
+        publicFileRequestSeqRef.current !== requestSeq ||
+        current.projectId !== requestProjectId ||
+        current.fileName !== requestFileName
+      ) {
+        return;
+      }
       setPublishedFileUrl(response.url);
       setPublishedFileSlug(response.slug);
     } catch (error) {
       console.warn('[FileViewer] failed to publish public file', error);
-      setPublishLinkFeedback('failed');
+      if (publicFileRequestSeqRef.current === requestSeq) setPublishLinkFeedback('failed');
     } finally {
-      setPublishingPublicFile(false);
+      if (publicFileRequestSeqRef.current === requestSeq) setPublishingPublicFile(false);
     }
   }
 
   async function unpublishCurrentFilePublic() {
     if (!publishedFileSlug || publishingPublicFile) return;
+    const requestProjectId = projectId;
+    const requestFileName = file.name;
+    const requestSlug = publishedFileSlug;
+    const requestSeq = ++publicFileRequestSeqRef.current;
     setPublishingPublicFile(true);
     setPublishLinkFeedback(null);
     try {
-      await unpublishProjectFilePublic(projectId, file.name, publishedFileSlug);
+      await unpublishProjectFilePublic(requestProjectId, requestFileName, requestSlug);
+      const current = publicFileIdentityRef.current;
+      if (
+        publicFileRequestSeqRef.current !== requestSeq ||
+        current.projectId !== requestProjectId ||
+        current.fileName !== requestFileName
+      ) {
+        return;
+      }
       setPublishedFileUrl('');
       setPublishedFileSlug('');
     } catch (error) {
       console.warn('[FileViewer] failed to unpublish public file', error);
-      setPublishLinkFeedback('failed');
+      if (publicFileRequestSeqRef.current === requestSeq) setPublishLinkFeedback('failed');
     } finally {
-      setPublishingPublicFile(false);
+      if (publicFileRequestSeqRef.current === requestSeq) setPublishingPublicFile(false);
     }
   }
 

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -72,6 +72,7 @@ import {
   liveArtifactPreviewUrl,
   projectFileUrl,
   projectRawUrl,
+  publishProjectFilePublic,
   LiveArtifactRefreshError,
   refreshLiveArtifact,
   restoreProjectFileVersion,
@@ -5297,8 +5298,10 @@ function ReactComponentViewer({
   const [shareAccess, setShareAccess] = useState<'private' | 'workspace'>('private');
   const [shareAccessMenuOpen, setShareAccessMenuOpen] = useState(false);
   const [shareAccessBusy, setShareAccessBusy] = useState(false);
-  const [filePublished, setFilePublished] = useState(false);
+  const [publishedFileUrl, setPublishedFileUrl] = useState('');
+  const [publishingPublicFile, setPublishingPublicFile] = useState(false);
   const [publishLinkFeedback, setPublishLinkFeedback] = useState<'copied' | 'failed' | null>(null);
+  const filePublished = publishedFileUrl.length > 0;
   const shareRef = useRef<HTMLDivElement | null>(null);
   // HTML entries that load this file as a Babel module. `null` = still
   // checking; `[]` = standalone artifact; non-empty = a module of a
@@ -5400,14 +5403,25 @@ function ReactComponentViewer({
     setShareAccessMenuOpen(false);
   }, [viewerOnly]);
 
-  // Published-file link. The demo mints a dedicated share URL; this viewer has
-  // no publish backend, so we fall back to the current page URL (no invented
-  // backend) and copy it to the clipboard with the same transient feedback.
-  const publishedFileUrl = typeof window !== 'undefined' ? window.location.href : '';
+  async function publishCurrentFilePublic() {
+    if (viewerOnly || publishingPublicFile) return;
+    setPublishingPublicFile(true);
+    setPublishLinkFeedback(null);
+    try {
+      const response = await publishProjectFilePublic(projectId, file.name);
+      setPublishedFileUrl(response.url);
+    } catch (error) {
+      console.warn('[FileViewer] failed to publish public file', error);
+      setPublishLinkFeedback('failed');
+    } finally {
+      setPublishingPublicFile(false);
+    }
+  }
+
   async function copyPublishedFileLink() {
     let ok = false;
     try {
-      if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      if (publishedFileUrl && typeof navigator !== 'undefined' && navigator.clipboard) {
         await navigator.clipboard.writeText(publishedFileUrl);
         ok = true;
       }
@@ -5647,7 +5661,7 @@ function ReactComponentViewer({
                                 <button
                                   type="button"
                                   className="chrome-publish-button chrome-publish-button--ghost"
-                                  onClick={() => setFilePublished(false)}
+                                  onClick={() => setPublishedFileUrl('')}
                                 >
                                   {t('common.cancel')}
                                 </button>
@@ -5657,9 +5671,11 @@ function ReactComponentViewer({
                             <button
                               type="button"
                               className="chrome-publish-primary"
-                              disabled={viewerOnly}
+                              disabled={viewerOnly || publishingPublicFile}
                               title={viewerOnly ? viewerOnlyDisabledTitle : undefined}
-                              onClick={() => setFilePublished(true)}
+                              onClick={() => {
+                                void publishCurrentFilePublic();
+                              }}
                             >
                               <RemixIcon name="upload-cloud-2-line" size={15} />
                               {t('fileViewer.publishFile')}
@@ -6181,8 +6197,10 @@ function HtmlViewer({
   const [shareAccess, setShareAccess] = useState<'private' | 'workspace'>('private');
   const [shareAccessMenuOpen, setShareAccessMenuOpen] = useState(false);
   const [shareAccessBusy, setShareAccessBusy] = useState(false);
-  const [filePublished, setFilePublished] = useState(false);
+  const [publishedFileUrl, setPublishedFileUrl] = useState('');
+  const [publishingPublicFile, setPublishingPublicFile] = useState(false);
   const [publishLinkFeedback, setPublishLinkFeedback] = useState<'copied' | 'failed' | null>(null);
+  const filePublished = publishedFileUrl.length > 0;
   // False when closed; otherwise records which entry opened the modal so the
   // surface_view impression can carry entry_from.
   const [versionModalOpen, setVersionModalOpen] = useState<false | 'toolbar' | 'more_menu'>(false);
@@ -6268,14 +6286,25 @@ function HtmlViewer({
   useEffect(() => {
     if (!deployMenuOpen) setShareAccessMenuOpen(false);
   }, [deployMenuOpen]);
-  // Published-file link. The demo mints a dedicated share URL; this viewer has
-  // no publish backend, so we fall back to the current page URL (no invented
-  // backend) and copy it to the clipboard with the same transient feedback.
-  const publishedFileUrl = typeof window !== 'undefined' ? window.location.href : '';
+  async function publishCurrentFilePublic() {
+    if (viewerOnly || publishingPublicFile) return;
+    setPublishingPublicFile(true);
+    setPublishLinkFeedback(null);
+    try {
+      const response = await publishProjectFilePublic(projectId, file.name);
+      setPublishedFileUrl(response.url);
+    } catch (error) {
+      console.warn('[FileViewer] failed to publish public file', error);
+      setPublishLinkFeedback('failed');
+    } finally {
+      setPublishingPublicFile(false);
+    }
+  }
+
   async function copyPublishedFileLink() {
     let ok = false;
     try {
-      if (typeof navigator !== 'undefined' && navigator.clipboard) {
+      if (publishedFileUrl && typeof navigator !== 'undefined' && navigator.clipboard) {
         await navigator.clipboard.writeText(publishedFileUrl);
         ok = true;
       }
@@ -11095,7 +11124,7 @@ function HtmlViewer({
                               <button
                                 type="button"
                                 className="chrome-publish-button chrome-publish-button--ghost"
-                                onClick={() => setFilePublished(false)}
+                                onClick={() => setPublishedFileUrl('')}
                               >
                                 {t('fileViewer.unpublishFile')}
                               </button>
@@ -11105,9 +11134,11 @@ function HtmlViewer({
                           <button
                             type="button"
                             className="chrome-publish-primary"
-                            disabled={viewerOnly}
+                            disabled={viewerOnly || publishingPublicFile}
                             title={viewerOnly ? viewerOnlyDisabledTitle : undefined}
-                            onClick={() => setFilePublished(true)}
+                            onClick={() => {
+                              void publishCurrentFilePublic();
+                            }}
                           >
                             <RemixIcon name="upload-cloud-2-line" size={15} />
                             {t('fileViewer.publishFile')}

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -73,6 +73,7 @@ import {
   projectFileUrl,
   projectRawUrl,
   publishProjectFilePublic,
+  unpublishProjectFilePublic,
   LiveArtifactRefreshError,
   refreshLiveArtifact,
   restoreProjectFileVersion,
@@ -5299,6 +5300,7 @@ function ReactComponentViewer({
   const [shareAccessMenuOpen, setShareAccessMenuOpen] = useState(false);
   const [shareAccessBusy, setShareAccessBusy] = useState(false);
   const [publishedFileUrl, setPublishedFileUrl] = useState('');
+  const [publishedFileSlug, setPublishedFileSlug] = useState('');
   const [publishingPublicFile, setPublishingPublicFile] = useState(false);
   const [publishLinkFeedback, setPublishLinkFeedback] = useState<'copied' | 'failed' | null>(null);
   const filePublished = publishedFileUrl.length > 0;
@@ -5403,6 +5405,13 @@ function ReactComponentViewer({
     setShareAccessMenuOpen(false);
   }, [viewerOnly]);
 
+  useEffect(() => {
+    setPublishedFileUrl('');
+    setPublishedFileSlug('');
+    setPublishingPublicFile(false);
+    setPublishLinkFeedback(null);
+  }, [projectId, file.name]);
+
   async function publishCurrentFilePublic() {
     if (viewerOnly || publishingPublicFile) return;
     setPublishingPublicFile(true);
@@ -5410,8 +5419,25 @@ function ReactComponentViewer({
     try {
       const response = await publishProjectFilePublic(projectId, file.name);
       setPublishedFileUrl(response.url);
+      setPublishedFileSlug(response.slug);
     } catch (error) {
       console.warn('[FileViewer] failed to publish public file', error);
+      setPublishLinkFeedback('failed');
+    } finally {
+      setPublishingPublicFile(false);
+    }
+  }
+
+  async function unpublishCurrentFilePublic() {
+    if (!publishedFileSlug || publishingPublicFile) return;
+    setPublishingPublicFile(true);
+    setPublishLinkFeedback(null);
+    try {
+      await unpublishProjectFilePublic(projectId, file.name, publishedFileSlug);
+      setPublishedFileUrl('');
+      setPublishedFileSlug('');
+    } catch (error) {
+      console.warn('[FileViewer] failed to unpublish public file', error);
       setPublishLinkFeedback('failed');
     } finally {
       setPublishingPublicFile(false);
@@ -5661,9 +5687,12 @@ function ReactComponentViewer({
                                 <button
                                   type="button"
                                   className="chrome-publish-button chrome-publish-button--ghost"
-                                  onClick={() => setPublishedFileUrl('')}
+                                  disabled={publishingPublicFile}
+                                  onClick={() => {
+                                    void unpublishCurrentFilePublic();
+                                  }}
                                 >
-                                  {t('common.cancel')}
+                                  {t('fileViewer.unpublishFile')}
                                 </button>
                               </div>
                             </>
@@ -6198,6 +6227,7 @@ function HtmlViewer({
   const [shareAccessMenuOpen, setShareAccessMenuOpen] = useState(false);
   const [shareAccessBusy, setShareAccessBusy] = useState(false);
   const [publishedFileUrl, setPublishedFileUrl] = useState('');
+  const [publishedFileSlug, setPublishedFileSlug] = useState('');
   const [publishingPublicFile, setPublishingPublicFile] = useState(false);
   const [publishLinkFeedback, setPublishLinkFeedback] = useState<'copied' | 'failed' | null>(null);
   const filePublished = publishedFileUrl.length > 0;
@@ -6286,6 +6316,14 @@ function HtmlViewer({
   useEffect(() => {
     if (!deployMenuOpen) setShareAccessMenuOpen(false);
   }, [deployMenuOpen]);
+
+  useEffect(() => {
+    setPublishedFileUrl('');
+    setPublishedFileSlug('');
+    setPublishingPublicFile(false);
+    setPublishLinkFeedback(null);
+  }, [projectId, file.name]);
+
   async function publishCurrentFilePublic() {
     if (viewerOnly || publishingPublicFile) return;
     setPublishingPublicFile(true);
@@ -6293,8 +6331,25 @@ function HtmlViewer({
     try {
       const response = await publishProjectFilePublic(projectId, file.name);
       setPublishedFileUrl(response.url);
+      setPublishedFileSlug(response.slug);
     } catch (error) {
       console.warn('[FileViewer] failed to publish public file', error);
+      setPublishLinkFeedback('failed');
+    } finally {
+      setPublishingPublicFile(false);
+    }
+  }
+
+  async function unpublishCurrentFilePublic() {
+    if (!publishedFileSlug || publishingPublicFile) return;
+    setPublishingPublicFile(true);
+    setPublishLinkFeedback(null);
+    try {
+      await unpublishProjectFilePublic(projectId, file.name, publishedFileSlug);
+      setPublishedFileUrl('');
+      setPublishedFileSlug('');
+    } catch (error) {
+      console.warn('[FileViewer] failed to unpublish public file', error);
       setPublishLinkFeedback('failed');
     } finally {
       setPublishingPublicFile(false);
@@ -11124,7 +11179,10 @@ function HtmlViewer({
                               <button
                                 type="button"
                                 className="chrome-publish-button chrome-publish-button--ghost"
-                                onClick={() => setPublishedFileUrl('')}
+                                disabled={publishingPublicFile}
+                                onClick={() => {
+                                  void unpublishCurrentFilePublic();
+                                }}
                               >
                                 {t('fileViewer.unpublishFile')}
                               </button>

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -90,6 +90,12 @@ export type WebDeployProjectFileResponse = DeployProjectFileResponse;
 export type WebCloudflarePagesDeploySelection = CloudflarePagesDeploySelection;
 export type WebCloudflarePagesZonesResponse = CloudflarePagesZonesResponse;
 
+export interface WebPublicProjectFileResponse {
+  url: string;
+  slug: string;
+  fileName: string;
+}
+
 export function isDeployProviderId(value: unknown): value is WebDeployProviderId {
   return typeof value === 'string' && (DEPLOY_PROVIDER_IDS as readonly string[]).includes(value);
 }
@@ -1363,6 +1369,29 @@ export async function deployProjectFile(
     throw new Error(payload?.error?.message || payload?.message || `Deploy failed (${resp.status})`);
   }
   return (await resp.json()) as WebDeployProjectFileResponse;
+}
+
+export async function publishProjectFilePublic(
+  projectId: string,
+  fileName: string,
+): Promise<WebPublicProjectFileResponse> {
+  const resp = await fetch(
+    `/api/projects/${encodeURIComponent(projectId)}/files/${encodeURIComponent(fileName)}/publish-public`,
+    { method: 'POST' },
+  );
+  if (!resp.ok) {
+    const payload = (await resp.json().catch(() => null)) as
+      | { error?: { message?: string } | string; message?: string }
+      | null;
+    const errorMessage =
+      typeof payload?.error === 'object'
+        ? payload.error.message
+        : typeof payload?.error === 'string'
+          ? payload.error
+          : payload?.message;
+    throw new Error(errorMessage || `Publish failed (${resp.status})`);
+  }
+  return (await resp.json()) as WebPublicProjectFileResponse;
 }
 
 export async function checkDeploymentLink(

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -1394,6 +1394,29 @@ export async function publishProjectFilePublic(
   return (await resp.json()) as WebPublicProjectFileResponse;
 }
 
+export async function fetchProjectFilePublicPublication(
+  projectId: string,
+  fileName: string,
+): Promise<WebPublicProjectFileResponse | null> {
+  const resp = await fetch(
+    `/api/projects/${encodeURIComponent(projectId)}/files/${encodeURIComponent(fileName)}/publish-public`,
+  );
+  if (!resp.ok) {
+    const payload = (await resp.json().catch(() => null)) as
+      | { error?: { message?: string } | string; message?: string }
+      | null;
+    const errorMessage =
+      typeof payload?.error === 'object'
+        ? payload.error.message
+        : typeof payload?.error === 'string'
+          ? payload.error
+          : payload?.message;
+    throw new Error(errorMessage || `Fetch publish state failed (${resp.status})`);
+  }
+  const payload = (await resp.json()) as { publication?: WebPublicProjectFileResponse | null };
+  return payload.publication ?? null;
+}
+
 export async function unpublishProjectFilePublic(
   projectId: string,
   fileName: string,

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -1394,6 +1394,34 @@ export async function publishProjectFilePublic(
   return (await resp.json()) as WebPublicProjectFileResponse;
 }
 
+export async function unpublishProjectFilePublic(
+  projectId: string,
+  fileName: string,
+  slug: string,
+): Promise<{ ok: true; slug: string; fileName: string }> {
+  const resp = await fetch(
+    `/api/projects/${encodeURIComponent(projectId)}/files/${encodeURIComponent(fileName)}/publish-public`,
+    {
+      method: 'DELETE',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ slug }),
+    },
+  );
+  if (!resp.ok) {
+    const payload = (await resp.json().catch(() => null)) as
+      | { error?: { message?: string } | string; message?: string }
+      | null;
+    const errorMessage =
+      typeof payload?.error === 'object'
+        ? payload.error.message
+        : typeof payload?.error === 'string'
+          ? payload.error
+          : payload?.message;
+    throw new Error(errorMessage || `Unpublish failed (${resp.status})`);
+  }
+  return (await resp.json()) as { ok: true; slug: string; fileName: string };
+}
+
 export async function checkDeploymentLink(
   projectId: string,
   deploymentId: string,

--- a/packages/contracts/src/api/resources.ts
+++ b/packages/contracts/src/api/resources.ts
@@ -63,6 +63,12 @@ export interface PublicSnapshotResponse {
   manifest: ResourceManifest | null;
 }
 
+export interface PublicProjectFileResponse {
+  url: string;
+  slug: string;
+  fileName: string;
+}
+
 export interface ResourceListResponse {
   resources: ResourceSummary[];
 }


### PR DESCRIPTION
## Why

This PR follows the workspace-team C-lane end-to-end testing pass. While validating shared projects with owner/member local clients, we found three linked problems: member-owned shared project edits were not reliably published back to Resource Hub, the "publish single file" URL still pointed at the local Open Design client instead of a public file view, and workspace/billing context changes from Vela Web needed to refresh back into the local shell.

The pain being addressed is user-facing collaboration correctness: team members need shared project edits, comments, presence-adjacent context, and public file links to work through Vela-backed identity/resource services rather than local-only state.

## What users will see

- Editing a member-owned shared project publishes file changes back through Vela Resource Hub, so other team members can pull the updated file.
- "发布单个文件给所有人" now mints a public Vela snapshot file URL instead of copying the current Open Design client route.
- Workspace context refreshes on focus/pageshow, periodic polling, and after opening the billing upgrade surface, so plan/seat/permission changes made in Vela Web are reflected locally.
- Vela binary resolution honors `VELA_BIN` from the process environment before falling back to PATH.

## Surface area

- [x] **UI** — publish single file behavior and workspace context refresh hooks in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — uses inherited `VELA_BIN` when resolving Vela-backed runtime commands
- [x] **API / contract** — adds `/api/projects/:id/files/:file/publish-public` and public file response shape
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`)
- [x] **Default behavior change** — shared-project owner publish watcher now tracks externally stored project metadata and publishes through Resource Hub
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached here. This was validated against the existing local owner/member workspace clients; the visible entry points are the file viewer Share popover and workspace shell.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/runtimes/executables.test.ts`, `apps/daemon/tests/vela-workspace-context.test.ts`
- Did the test go red on `main` and green on this branch? no; these are focused regression/contract tests added during the local workspace-team run rather than a pre-captured red spec.
- Additional manual verification: member-owned shared project file edits advanced the Vela resource head and owner pull matched member content; public file publish returned a Vela public snapshot URL that served `text/html` directly.

## Validation

- `git diff --cached --check`
- `pnpm --filter @open-design/daemon build`
- `pnpm --filter @open-design/web typecheck`