### PR TITLE
fix daemon MCP prompt on native session resume

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1402,11 +1402,16 @@ export function composeChatUserRequestForAgent(
   // of what the upstream CLI already has in memory — and the embedded
   // copy carries the literal `<question-form>` markup the agent emitted
   // on turn 1, which the model then re-emits on turn 2. Send only the
-  // latest user turn (`currentPrompt`) in that case; the upstream
-  // session memory provides the rest. See
+  // latest user turn (`currentPrompt`) in that case; legacy and MCP
+  // callers only provide `message`, so fall back to it when needed. The
+  // upstream session memory provides the rest. See
   // `RuntimeAgentDef.resumesSessionViaCli`.
   const skip = options.skipTranscript === true;
-  const bodySource = skip ? currentPrompt : message;
+  const resumedTurn =
+    typeof currentPrompt === 'string' && currentPrompt.trim()
+      ? currentPrompt
+      : message;
+  const bodySource = skip ? resumedTurn : message;
   const body =
     typeof bodySource === 'string' && bodySource.trim()
       ? bodySource

--- a/apps/daemon/tests/telemetry-message-finalization.test.ts
+++ b/apps/daemon/tests/telemetry-message-finalization.test.ts
@@ -231,6 +231,14 @@ describe('Langfuse message finalization gate', () => {
     expect(kept).toBe(transcript);
   });
 
+  it('falls back to message for a resumed turn without currentPrompt', () => {
+    expect(
+      composeChatUserRequestForAgent('MCP follow-up prompt', undefined, {
+        skipTranscript: true,
+      }),
+    ).toBe('MCP follow-up prompt');
+  });
+
   it('invokes Langfuse reporting once when the final message write is marked', () => {
     const run = {
       id: 'run-1',


### PR DESCRIPTION
Fixes #5532

## Why

I picked this up from the confirmed community issue because MCP `start_run` follow-ups can silently succeed without applying the requested change when OpenCode resumes an existing native session.

MCP sends the latest instruction in `message`, while the native-session resume path previously read only `currentPrompt`. That mismatch replaced a valid follow-up with `(No extra typed instruction.)`, so the agent could return a successful no-op.

## What users will see

Follow-up prompts sent through MCP now reach a resumed OpenCode session. Existing Studio continuations still prefer `currentPrompt`, and other agents keep their existing transcript behavior.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this changes daemon prompt delivery and has no UI surface.

## Bug fix verification

- Test path: `apps/daemon/tests/telemetry-message-finalization.test.ts`
- The regression test went red before the source change: expected `MCP follow-up prompt`, received `(No extra typed instruction.)`.
- The same test went green after the fallback was added.

## Validation

- `apps/daemon/node_modules/.bin/vitest run -c vitest.config.ts tests/telemetry-message-finalization.test.ts tests/mcp-runs.test.ts` — 52 passed
- `apps/daemon/node_modules/.bin/vitest run -c vitest.config.ts tests/opencode-session-resume.test.ts` — 3 passed
- `pnpm --filter @open-design/daemon typecheck` — passed
- `git diff --check` — passed
- `pnpm guard` could not complete in the sparse checkout because the unmodified `design-systems/_schema/manifest.schema.ts` file was not present; CI will run it against the full checkout.
