### PR TITLE
fix(web): restore silent update checkbox geometry

### DIFF
--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -503,15 +503,23 @@
 .settings-about-silent-updates {
   align-items: center;
 }
-.settings-about-toggle {
+.settings-about-diagnostics > .settings-about-toggle {
   display: flex;
+  flex-direction: row;
   align-items: flex-start;
   gap: 10px;
   min-width: 0;
 }
 .settings-about-toggle input {
-  flex: 0 0 auto;
-  margin-top: 2px;
+  appearance: auto;
+  width: 14px;
+  height: 14px;
+  flex: none;
+  padding: 0;
+  border: none;
+  background: none;
+  accent-color: var(--accent);
+  margin: 2px 0 0;
 }
 .settings-about-toggle-copy {
   display: flex;

--- a/apps/web/tests/styles/settings-polish.test.ts
+++ b/apps/web/tests/styles/settings-polish.test.ts
@@ -6,6 +6,7 @@ import { readExpandedIndexCss } from '../helpers/read-expanded-css';
 const indexCss = readFileSync(new URL('../../src/index.css', import.meta.url), 'utf8');
 const expandedIndexCss = readExpandedIndexCss();
 const mentionHomeCss = readFileSync(new URL('../../src/styles/workspace/mention-home.css', import.meta.url), 'utf8');
+const artifactsCss = readFileSync(new URL('../../src/styles/workspace/artifacts.css', import.meta.url), 'utf8');
 
 function cssBlock(css: string, selector: string): string {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -52,5 +53,18 @@ describe('settings polish CSS', () => {
     expect(ruleValue(head, 'background')).toBe('var(--bg-elevated)');
     expect(ruleValue(content, 'position')).toBe('relative');
     expect(ruleValue(content, 'z-index')).toBe('1');
+  });
+
+  it('keeps the silent-update checkbox native-sized and aligned horizontally', () => {
+    const row = cssBlock(artifactsCss, '.settings-about-diagnostics > .settings-about-toggle');
+    const checkbox = cssBlock(artifactsCss, '.settings-about-toggle input');
+
+    expect(ruleValue(row, 'flex-direction')).toBe('row');
+    expect(ruleValue(row, 'gap')).toBe('10px');
+    expect(ruleValue(checkbox, 'appearance')).toBe('auto');
+    expect(ruleValue(checkbox, 'width')).toBe('14px');
+    expect(ruleValue(checkbox, 'height')).toBe('14px');
+    expect(ruleValue(checkbox, 'padding')).toBe('0');
+    expect(ruleValue(checkbox, 'margin')).toBe('2px 0 0');
   });
 });


### PR DESCRIPTION
## Why

While validating the silent-update preference introduced by #5071 in a real packaged build, the checkbox in Settings > About rendered as a full-width input above its copy instead of a compact native control beside it.

The settings row was being overridden by broader modal styles: `.modal label` forced a column layout, while shared input geometry stretched the checkbox. This patch gives the existing setting a narrowly scoped row layout and restores native checkbox geometry without changing updater behavior.

## What users will see

Settings > About keeps **Allow silent updates** as a compact native checkbox on the left, vertically aligned with its label and description. The preference, default value, and update workflow are unchanged.

## Surface area

- [x] **UI** — fixes the existing silent-update setting geometry in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Real packaged `0.14.1-beta.2101`, Settings > About entry point:

![Settings About page with the compact Allow silent updates checkbox aligned to the left of its copy](https://raw.githubusercontent.com/nexu-io/open-design/e54ba9333fe5d58bc8688666854d44c39cf54725/pr5547-silent-update-checkbox.png)

## Bug fix verification

- Test path: `apps/web/tests/styles/settings-polish.test.ts`
- Red on `main`: yes — the focused test failed with `Missing CSS block for .settings-about-diagnostics > .settings-about-toggle`.
- Green on this branch: yes — the same focused test passes all 4 cases.
- Runtime check: inspected Settings > About in packaged `0.14.1-beta.2101`; the checkbox renders as an unchecked native control at approximately `13.72 x 13.72px`, in a horizontal row with a `10px` gap and zero input padding.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/styles/settings-polish.test.ts` — 4/4 passed
- `pnpm --filter @open-design/web typecheck` — passed
- `pnpm guard` — passed (78 guard tests)
- `pnpm typecheck` — passed
- `git diff --check` — passed
- Real packaged-build visual inspection — passed
