### PR TITLE
fix(web): align fullscreen settings controls

### DIFF
--- a/apps/web/src/styles/workspace/mention-home.css
+++ b/apps/web/src/styles/workspace/mention-home.css
@@ -687,8 +687,8 @@
    save settles. */
 .settings-chrome {
   position: absolute;
-  top: 18px;
-  right: 18px;
+  top: 24px;
+  right: 24px;
   z-index: 10;
   display: flex;
   align-items: center;


### PR DESCRIPTION
Fixes #5513

## Why

The fullscreen Settings view positions the fullscreen/restore and close controls closer to the window edge than the rest of the layout. This makes the controls feel visually misaligned with the fullscreen container, which already uses a 24px viewport inset.

This PR aligns the controls with the existing fullscreen spacing to make the Settings surface feel more consistent.

## What users will see

When opening Settings in fullscreen mode, the fullscreen/restore and close controls are aligned with the rest of the Settings layout instead of appearing cramped against the top-right edge.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Before and after screenshots of the fullscreen Settings view showing the updated alignment of the top-right controls.

## Bug fix verification

- Test path that reproduces the bug:
  - Open **Settings**.
  - Enter fullscreen mode.
  - Observe the top-right fullscreen/restore and close controls.
- A new automated test was not added because this is a visual CSS alignment change.
- Verified manually that the controls align with the existing 24px fullscreen inset and remain correctly positioned in fullscreen mode.

## Validation

- Ran the application locally.
- Verified the Settings dialog in normal and fullscreen modes.
- Confirmed the top-right controls align with the fullscreen container spacing.