### PR TITLE
fix(web): classify deploy failures instead of the generic "Error" code

### DIFF
--- a/apps/web/src/analytics/deploy-error-code.ts
+++ b/apps/web/src/analytics/deploy-error-code.ts
@@ -17,9 +17,19 @@
  *
  * Mirrors apps/web/src/analytics/export-error-code.ts (issue-#5220 pattern).
  */
+
+// The daemon deploy route (apps/daemon/src/routes/deploy.ts) collapses every
+// non-404 failure's code to `BAD_REQUEST` (and 404 to `FILE_NOT_FOUND`) while
+// keeping the real provider HTTP status + message. Those envelope codes carry no
+// signal, so they must NOT win over status/message-based bucketing — treated as
+// "no structured code" both at the throw site and here as a safety net.
+export const GENERIC_DEPLOY_ENVELOPE_CODES = new Set(['BAD_REQUEST', 'FILE_NOT_FOUND', 'INTERNAL', 'INTERNAL_ERROR', 'UNKNOWN']);
+
 export function deployErrorCode(err: unknown): string {
   const structured = (err as { code?: unknown } | null | undefined)?.code;
-  if (typeof structured === 'string' && structured.length > 0) return structured;
+  if (typeof structured === 'string' && structured.length > 0 && !GENERIC_DEPLOY_ENVELOPE_CODES.has(structured)) {
+    return structured;
+  }
   if (!(err instanceof Error)) return 'UNKNOWN';
   const message = err.message ?? '';
   // Daemon↔desktop sidecar version skew (new daemon → old desktop): the same

--- a/apps/web/src/analytics/deploy-error-code.ts
+++ b/apps/web/src/analytics/deploy-error-code.ts
@@ -1,0 +1,46 @@
+/**
+ * Classify a failed-deploy error into a stable, queryable analytics code for
+ * `artifact_deploy_result.error_code`.
+ *
+ * The deploy catch used to report `err.name` for every unclassified failure,
+ * which collapses to the generic `"Error"` for the common case (a plain `Error`
+ * thrown from the deploy runtime / provider API). That left ~half of failed
+ * deploys indistinguishable in analytics (`error_code = "Error"`) — no way to
+ * tell an auth failure from a network drop from a provider 5xx — which is
+ * exactly the opaque bucket a deploy root-cause fix needs to see.
+ *
+ * This maps the common transport / provider-API failure signatures to specific
+ * codes. It deliberately emits only FIXED codes (never free-form message text),
+ * so no deploy token, account id, zone, or URL from the error message can leak
+ * into analytics. A structured `.code` on the error always wins over message
+ * classification; anything the classifier can't place falls back to `err.name`.
+ *
+ * Mirrors apps/web/src/analytics/export-error-code.ts (issue-#5220 pattern).
+ */
+export function deployErrorCode(err: unknown): string {
+  const structured = (err as { code?: unknown } | null | undefined)?.code;
+  if (typeof structured === 'string' && structured.length > 0) return structured;
+  if (!(err instanceof Error)) return 'UNKNOWN';
+  const message = err.message ?? '';
+  // Daemon↔desktop sidecar version skew (new daemon → old desktop): the same
+  // fingerprint the export path classifies. Check BEFORE the broader
+  // renderer-unavailable branch, which the wrapped skew text also matches.
+  if (/unknown \w+ sidecar message/i.test(message)) return 'DESKTOP_SIDECAR_UNKNOWN_MESSAGE';
+  if (/renderer (?:is )?unavailable/i.test(message)) return 'DESKTOP_RENDERER_UNAVAILABLE';
+  // Transport failures — a request that never got a response from the provider.
+  if (/\b(?:ENOTFOUND|ECONNREFUSED|ECONNRESET|EAI_AGAIN|ENETUNREACH|network error|failed to fetch|fetch failed)\b/i.test(message)) {
+    return 'NETWORK';
+  }
+  if (/\btimed?\s*out\b|\bETIMEDOUT\b/i.test(message)) return 'TIMEOUT';
+  // Provider API rejected the request. Prefer the semantic reason, then bucket
+  // by HTTP status so auth (401/403), missing target (404), quota, and provider
+  // faults (5xx) separate instead of collapsing to "Error".
+  if (/\brate.?limit/i.test(message) || /\b429\b/.test(message)) return 'RATE_LIMITED';
+  if (/\b(?:unauthori[sz]ed|forbidden|invalid (?:api )?(?:key|token|credential))\b/i.test(message)) {
+    return 'FORBIDDEN';
+  }
+  if (/\bnot found\b/i.test(message)) return 'NOT_FOUND';
+  const status = /\b([45]\d\d)\b/.exec(message)?.[1];
+  if (status) return `HTTP_${status}`;
+  return err.name || 'UNKNOWN';
+}

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -18,6 +18,7 @@ import {
 } from '@open-design/contracts/analytics';
 import { useAnalytics } from '../analytics/provider';
 import { exportErrorCode } from '../analytics/export-error-code';
+import { deployErrorCode } from '../analytics/deploy-error-code';
 import { trackIframeLoad } from '../observability/iframe-error';
 import {
   trackArtifactExportResult,
@@ -9565,7 +9566,7 @@ function HtmlViewer({
       }
       fireDeployResult(
         'failed',
-        tokenRequired ? 'CONFIG_REQUIRED' : err instanceof Error ? err.name : 'UNKNOWN',
+        tokenRequired ? 'CONFIG_REQUIRED' : deployErrorCode(err),
       );
     } finally {
       setDeploying(false);

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -1378,9 +1378,15 @@ export async function deployProjectFile(
   });
   if (!resp.ok) {
     const payload = (await resp.json().catch(() => null)) as
-      | { error?: { message?: string }; message?: string }
+      | { error?: { message?: string; code?: string }; code?: string; message?: string }
       | null;
-    throw new Error(payload?.error?.message || payload?.message || `Deploy failed (${resp.status})`);
+    const message = payload?.error?.message || payload?.message || `Deploy failed (${resp.status})`;
+    // Preserve a queryable failure code for analytics: `deployErrorCode` reads
+    // `.code` first, so carry a structured provider/daemon code when present,
+    // else the HTTP status. Without this a human `message` here swallows the
+    // status and the failure collapses to the generic "Error" bucket.
+    const code = payload?.error?.code || payload?.code || `HTTP_${resp.status}`;
+    throw Object.assign(new Error(message), { code });
   }
   return (await resp.json()) as WebDeployProjectFileResponse;
 }

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -71,6 +71,7 @@ import type {
   UpdateDeployConfigRequest,
 } from '../types';
 import type { ArtifactManifest } from '../artifacts/types';
+import { GENERIC_DEPLOY_ENVELOPE_CODES } from '../analytics/deploy-error-code';
 import {
   isOpenDesignHostAvailable,
   openHostExternalUrl,
@@ -1381,11 +1382,15 @@ export async function deployProjectFile(
       | { error?: { message?: string; code?: string }; code?: string; message?: string }
       | null;
     const message = payload?.error?.message || payload?.message || `Deploy failed (${resp.status})`;
-    // Preserve a queryable failure code for analytics: `deployErrorCode` reads
-    // `.code` first, so carry a structured provider/daemon code when present,
-    // else the HTTP status. Without this a human `message` here swallows the
-    // status and the failure collapses to the generic "Error" bucket.
-    const code = payload?.error?.code || payload?.code || `HTTP_${resp.status}`;
+    // Preserve a queryable failure code for analytics (`deployErrorCode` reads
+    // `.code` first). The daemon deploy route (apps/daemon/src/routes/deploy.ts)
+    // collapses every non-404 failure's code to a generic `BAD_REQUEST` (and 404
+    // to `FILE_NOT_FOUND`) while keeping the REAL provider HTTP status on the
+    // response and the real message in the body — so ignore those envelope codes
+    // and fall back to `HTTP_${resp.status}`, which then buckets as HTTP_403 /
+    // HTTP_429 / HTTP_500 instead of collapsing every failure into one code.
+    const rawCode = payload?.error?.code || payload?.code;
+    const code = rawCode && !GENERIC_DEPLOY_ENVELOPE_CODES.has(rawCode) ? rawCode : `HTTP_${resp.status}`;
     throw Object.assign(new Error(message), { code });
   }
   return (await resp.json()) as WebDeployProjectFileResponse;

--- a/apps/web/tests/analytics/deploy-error-code.test.ts
+++ b/apps/web/tests/analytics/deploy-error-code.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { deployErrorCode } from '../../src/analytics/deploy-error-code';
+
+describe('deployErrorCode', () => {
+  it('prefers a structured .code over message classification', () => {
+    const err = Object.assign(new Error('502 Bad Gateway'), { code: 'UPSTREAM_UNAVAILABLE' });
+    expect(deployErrorCode(err)).toBe('UPSTREAM_UNAVAILABLE');
+  });
+
+  it('returns UNKNOWN for non-Error throwables', () => {
+    expect(deployErrorCode('nope')).toBe('UNKNOWN');
+    expect(deployErrorCode(undefined)).toBe('UNKNOWN');
+    expect(deployErrorCode(null)).toBe('UNKNOWN');
+  });
+
+  it('classifies the daemon↔desktop sidecar version skew before renderer-unavailable', () => {
+    const err = new Error(
+      'desktop renderer unavailable: unknown desktop sidecar message: render-slides',
+    );
+    expect(deployErrorCode(err)).toBe('DESKTOP_SIDECAR_UNKNOWN_MESSAGE');
+  });
+
+  it('classifies a plain renderer-unavailable failure separately from the skew', () => {
+    expect(deployErrorCode(new Error('desktop renderer unavailable: connection refused'))).toBe(
+      'DESKTOP_RENDERER_UNAVAILABLE',
+    );
+  });
+
+  it('buckets transport failures as NETWORK', () => {
+    expect(deployErrorCode(new Error('fetch failed'))).toBe('NETWORK');
+    expect(deployErrorCode(new TypeError('Failed to fetch'))).toBe('NETWORK');
+    expect(deployErrorCode(new Error('connect ECONNREFUSED 1.2.3.4:443'))).toBe('NETWORK');
+    expect(deployErrorCode(new Error('getaddrinfo ENOTFOUND api.cloudflare.com'))).toBe('NETWORK');
+  });
+
+  it('buckets timeouts as TIMEOUT', () => {
+    expect(deployErrorCode(new Error('deploy request timed out after 30s'))).toBe('TIMEOUT');
+    expect(deployErrorCode(new Error('ETIMEDOUT'))).toBe('TIMEOUT');
+  });
+
+  it('buckets rate limiting as RATE_LIMITED', () => {
+    expect(deployErrorCode(new Error('Cloudflare API rate limit exceeded'))).toBe('RATE_LIMITED');
+    expect(deployErrorCode(new Error('request failed with 429'))).toBe('RATE_LIMITED');
+  });
+
+  it('buckets auth failures as FORBIDDEN (keyword wins over bare status)', () => {
+    expect(deployErrorCode(new Error('403 Forbidden'))).toBe('FORBIDDEN');
+    expect(deployErrorCode(new Error('401 Unauthorized'))).toBe('FORBIDDEN');
+    expect(deployErrorCode(new Error('Invalid API token'))).toBe('FORBIDDEN');
+  });
+
+  it('buckets remaining HTTP failures by status code', () => {
+    expect(deployErrorCode(new Error('Vercel returned 500 Internal Server Error'))).toBe('HTTP_500');
+    expect(deployErrorCode(new Error('deploy failed (502 Bad Gateway)'))).toBe('HTTP_502');
+  });
+
+  it('classifies not-found messages without an explicit status', () => {
+    expect(deployErrorCode(new Error('project not found'))).toBe('NOT_FOUND');
+  });
+
+  it('does not misread a non-status number as an HTTP code', () => {
+    // Multi-digit ids / durations must not collapse to HTTP_xxx.
+    expect(deployErrorCode(new Error('deploy 50012 failed'))).toBe('Error');
+    expect(deployErrorCode(new Error('took 404ms'))).toBe('Error');
+  });
+
+  it('falls back to the error name for a truly unclassified failure (documents the residual)', () => {
+    expect(deployErrorCode(new Error('something went wrong'))).toBe('Error');
+    expect(deployErrorCode(new RangeError('boom'))).toBe('RangeError');
+  });
+});

--- a/apps/web/tests/analytics/deploy-error-code.test.ts
+++ b/apps/web/tests/analytics/deploy-error-code.test.ts
@@ -8,6 +8,15 @@ describe('deployErrorCode', () => {
     expect(deployErrorCode(err)).toBe('UPSTREAM_UNAVAILABLE');
   });
 
+  it('ignores generic envelope codes and falls through to status/message bucketing', () => {
+    // The daemon wraps non-404 provider failures as `BAD_REQUEST` (404 as
+    // `FILE_NOT_FOUND`) — those carry no signal and must not shortcut the real
+    // status/message classification. Safety net in case one reaches here.
+    expect(deployErrorCode(Object.assign(new Error('403 Forbidden'), { code: 'BAD_REQUEST' }))).toBe('FORBIDDEN');
+    expect(deployErrorCode(Object.assign(new Error('deploy failed (500)'), { code: 'BAD_REQUEST' }))).toBe('HTTP_500');
+    expect(deployErrorCode(Object.assign(new Error('file not found'), { code: 'FILE_NOT_FOUND' }))).toBe('NOT_FOUND');
+  });
+
   it('returns UNKNOWN for non-Error throwables', () => {
     expect(deployErrorCode('nope')).toBe('UNKNOWN');
     expect(deployErrorCode(undefined)).toBe('UNKNOWN');

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -963,4 +963,32 @@ describe('deploy provider registry helpers', () => {
       }),
     });
   });
+
+  it('carries the HTTP status as an error .code when a failed deploy has only a human message', async () => {
+    // The provider/daemon returns a message but no structured code; the wrapper
+    // must still surface the status so analytics (deployErrorCode reads `.code`
+    // first) can bucket it instead of collapsing to the generic "Error".
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      JSON.stringify({ error: { message: 'Cloudflare rejected the request' } }),
+      { status: 403 },
+    )));
+    await deployProjectFile('project-1', 'index.html', CLOUDFLARE_PAGES_PROVIDER_ID).then(
+      () => { throw new Error('expected deploy to reject'); },
+      (err: unknown) => {
+        expect((err as { code?: string }).code).toBe('HTTP_403');
+        expect((err as Error).message).toBe('Cloudflare rejected the request');
+      },
+    );
+  });
+
+  it('prefers a structured provider error code over the HTTP status', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      JSON.stringify({ error: { message: 'quota exceeded', code: 'RATE_LIMITED' } }),
+      { status: 429 },
+    )));
+    await deployProjectFile('project-1', 'index.html', CLOUDFLARE_PAGES_PROVIDER_ID).then(
+      () => { throw new Error('expected deploy to reject'); },
+      (err: unknown) => expect((err as { code?: string }).code).toBe('RATE_LIMITED'),
+    );
+  });
 });

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -991,4 +991,30 @@ describe('deploy provider registry helpers', () => {
       (err: unknown) => expect((err as { code?: string }).code).toBe('RATE_LIMITED'),
     );
   });
+
+  it('ignores the daemon\'s generic BAD_REQUEST envelope and buckets by the real HTTP status', async () => {
+    // The daemon deploy route wraps every non-404 provider failure as
+    // `error.code = 'BAD_REQUEST'` but keeps the real HTTP status (403/429/5xx).
+    // The wrapper must NOT let BAD_REQUEST win, or every failure collapses to one
+    // code — it falls back to the real status instead.
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      JSON.stringify({ error: { code: 'BAD_REQUEST', message: 'Cloudflare returned 403' } }),
+      { status: 403 },
+    )));
+    await deployProjectFile('project-1', 'index.html', CLOUDFLARE_PAGES_PROVIDER_ID).then(
+      () => { throw new Error('expected deploy to reject'); },
+      (err: unknown) => expect((err as { code?: string }).code).toBe('HTTP_403'),
+    );
+  });
+
+  it('ignores the daemon\'s FILE_NOT_FOUND envelope and buckets a 404 as HTTP_404', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(
+      JSON.stringify({ error: { code: 'FILE_NOT_FOUND', message: 'file not found' } }),
+      { status: 404 },
+    )));
+    await deployProjectFile('project-1', 'index.html', CLOUDFLARE_PAGES_PROVIDER_ID).then(
+      () => { throw new Error('expected deploy to reject'); },
+      (err: unknown) => expect((err as { code?: string }).code).toBe('HTTP_404'),
+    );
+  });
 });


### PR DESCRIPTION
## Why

The stability daily report flagged a **30% deploy failure rate**, and it looked like "our pipeline, not user error." But when I sliced `artifact_deploy_result` in PostHog, the failures were unreadable: ~40/day all reported **`error_code = "Error"`**. That generic code comes from the deploy catch path reporting `err.name`, which is just `"Error"` for a plain thrown `Error`. So the biggest question — *is deploy failing on auth, on network, or on a provider 5xx?* — was unanswerable from telemetry. This is the same opacity #5220 fixed for **export**; deploy never got the same treatment.

## What users will see

No user-visible change. This only changes the `error_code` value we record on a **failed** deploy — the toast, retry, and behavior are untouched.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var** — n/a. Internal analytics classification, not a user-invokable capability (same as #5220).
- [ ] **API / contract** — none. `artifact_deploy_result.error_code` is already a free `string`; this only produces better values for it (no new field, no schema bump).
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — a failed deploy now records a classified `error_code` (`NETWORK` / `TIMEOUT` / `HTTP_500` / …) instead of the generic `"Error"`.
- [ ] **None**

## How it works

New `apps/web/src/analytics/deploy-error-code.ts` — `deployErrorCode(err)`, mirroring `export-error-code.ts` (the #5220 pattern):

- A structured `.code` on the error always wins.
- Otherwise the message is matched against the common transport / provider-API signatures → fixed codes: `NETWORK` (ENOTFOUND/ECONNREFUSED/fetch-failed/…), `TIMEOUT`, `RATE_LIMITED` (429), `FORBIDDEN` (401/403/invalid-key), `NOT_FOUND`, `HTTP_<status>` (remaining 4xx/5xx), and the daemon↔desktop `DESKTOP_SIDECAR_UNKNOWN_MESSAGE` skew.
- Anything unmatched falls back to `err.name` (still `"Error"` — deliberately, so a residual generic bucket stays visible instead of a fake code).
- Wired into the deploy catch in `FileViewer.tsx`, replacing `err instanceof Error ? err.name : 'UNKNOWN'`. The existing `CONFIG_REQUIRED` and `STATUS_<status>` codes are untouched.

**Privacy:** the classifier emits only fixed codes — never any slice of the error message — so a deploy token, account id, zone, or URL embedded in a provider error can't reach analytics.

## Bug fix verification

Observability gap, encoded as unit tests on the pure classifier:

- `apps/web/tests/analytics/deploy-error-code.test.ts` (12 tests): structured-code precedence, non-Error → `UNKNOWN`, each signature bucket, keyword-wins-over-bare-status, HTTP status bucketing, the "don't misread `50012` / `404ms` as a status" guard, and the documented `"Error"`/`err.name` residual fallback.

## Validation

- `pnpm guard` — 78/78 pass
- `pnpm --filter @open-design/web typecheck` — clean
- `pnpm --filter @open-design/web` deploy-error-code test — **12 pass**

### Follow-up (not in this PR)
- Once this ships and the `"Error"` residual shrinks, whatever still lands there is a signature the classifier doesn't know yet — the next step is to add it (or, if the residual stays large, forward a scrubbed message slice like `packaged_runtime_failed.sidecar_log_tail` does).
