### PR TITLE
fix(web): sandbox the speaker-notes presenter deck iframes

### DIFF
--- a/apps/web/src/runtime/speaker-notes.ts
+++ b/apps/web/src/runtime/speaker-notes.ts
@@ -244,15 +244,15 @@ export function buildSpeakerNotesPresenterHtml(options: {
       <button type="button" id="reset"></button>
       <div class="counter" id="counter"></div>
     </div>
-    <div class="current"><iframe id="current" title="Current slide"></iframe></div>
+    <div class="current"><iframe id="current" title="Current slide" sandbox="allow-scripts"></iframe></div>
     <div class="filmstrip">
       <section id="previous-section">
         <div class="thumb-label" id="previous-label"></div>
-        <div class="thumb-frame"><iframe id="previous" title="Previous slide"></iframe></div>
+        <div class="thumb-frame"><iframe id="previous" title="Previous slide" sandbox="allow-scripts"></iframe></div>
       </section>
       <section id="next-section">
         <div class="thumb-label" id="next-label"></div>
-        <div class="thumb-frame"><iframe id="next" title="Next slide"></iframe></div>
+        <div class="thumb-frame"><iframe id="next" title="Next slide" sandbox="allow-scripts"></iframe></div>
       </section>
     </div>
   </main>

--- a/apps/web/tests/runtime/speaker-notes.test.ts
+++ b/apps/web/tests/runtime/speaker-notes.test.ts
@@ -372,4 +372,36 @@ describe('speaker notes HTML helpers', () => {
     expect(html).toContain('window.resizeTo(nextWidth, nextHeight)');
     expect(html).toContain("window.addEventListener('resize', scheduleMinimumWindowSize)");
   });
+
+  it('sandboxes the presenter slide iframes to an opaque origin', () => {
+    const html = buildSpeakerNotesPresenterHtml({
+      previewHtml: '<section class="slide">One</section>',
+      title: 'Deck',
+      projectId: 'project-1',
+      fileName: 'deck.html',
+      notes: ['Intro'],
+      initialSlideIndex: 0,
+      slideCount: 1,
+      labels: {
+        title: 'Speaker notes',
+        edit: 'Edit',
+        save: 'Save notes',
+        pause: 'Pause',
+        resume: 'Resume',
+        reset: 'Reset',
+        previous: 'Previous',
+        next: 'Next',
+        empty: 'Empty',
+        slide: 'Slide {current} / {total}',
+      },
+    });
+    // The srcdoc loaded into each frame is the full, untrusted deck (scripts
+    // included); the frames must run it in an opaque origin so it cannot reach
+    // the app's storage or daemon.
+    for (const id of ['current', 'previous', 'next']) {
+      const tag = html.match(new RegExp(`<iframe id="${id}"[^>]*>`))?.[0] ?? '';
+      expect(tag).toContain('sandbox="allow-scripts"');
+      expect(tag).not.toContain('allow-same-origin');
+    }
+  });
 });


### PR DESCRIPTION
## Why

Scratching an itch found while auditing how the app renders untrusted deck HTML. The speaker-notes presenter window loaded each slide's full deck HTML — scripts included — into `<iframe>`s that had no `sandbox` attribute. Because the presenter window is opened same-origin (via `document.write`), those frames ran the deck same-origin as the app, giving deck scripts access to app storage (API keys/tokens) and the local daemon. Every other deck/artifact preview path in the app already sandboxes this content; the presenter was the one path that did not.

## What users will see

No visible change. Presenter mode looks and behaves the same — slide navigation (driven by `postMessage`) is unaffected; the deck slides just run in an isolated (opaque) origin now, matching the rest of the app's deck previews.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/runtime/speaker-notes.test.ts` → "sandboxes the presenter slide iframes to an opaque origin"
- Did the test go red on `main` and green on this branch? **yes** — red: the generated iframes have no `sandbox` attribute; green: all three carry `sandbox="allow-scripts"` (without `allow-same-origin`).

## Validation

- `pnpm --filter @open-design/web test` for `tests/runtime/speaker-notes.test.ts` (green) plus `tsc` on the changed file. Full `pnpm guard` / `pnpm typecheck` left to CI.

---

The presenter's `#current` / `#previous` / `#next` slide `<iframe>`s now carry `sandbox="allow-scripts"` (deliberately without `allow-same-origin`), so the untrusted deck runs in an opaque origin and can no longer read the app's cookies/localStorage or reach the daemon. `allow-scripts` alone preserves the deck's own scripts and the presenter's `postMessage`-driven slide navigation.
