### PR TITLE
docs: clarify Docker build resource requirements

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -43,6 +43,23 @@ Defaults:
 - Node heap cap: `--max-old-space-size=192`
 - Compose memory cap: `384m` (`OPEN_DESIGN_MEM_LIMIT=256m` to override)
 
+### Runtime limits vs local image builds
+
+The memory defaults above apply to the already-built runtime container. They do
+not describe the host resources needed to build the Docker image from source. A
+source build runs TypeScript compilation, the Next.js production build, package
+deployment, and dependency cleanup before the runtime container exists. That
+build path can need substantially more memory than the running service.
+
+If `docker compose pull` cannot fetch `ghcr.io/nexu-io/od:latest`, do not assume
+that a small VPS which can run the published image can also build it locally. Use
+a larger temporary build host, a CI runner, or another machine with enough memory
+to build and push a private image, then run that image on the smaller runtime
+server.
+
+To avoid accidental local builds while installing on a small server, keep using
+`docker compose up -d --no-build` after a successful pull.
+
 Do not publish the daemon directly on a public or shared LAN interface. The API is
 unauthenticated for non-browser clients, so remote deployments should keep Compose
 bound to localhost and put an authenticated reverse proxy, SSH tunnel, or VPN in

--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -60,7 +60,15 @@ Memory limit [384m]:
 | **Docker image** | `ghcr.io/nexu-io/od:latest` | Use `:latest` for the newest stable image, `:<version>` for a pinned release, or `@sha256:<digest>` for reproducibility |
 | **Port** | `7456` | The port the daemon listens on. Must not be in use. |
 | **Allowed origins** | _(empty)_ | CORS origins for reverse-proxy setups. See [`network-security.md`](network-security.md). Leave empty for localhost-only use. |
-| **Memory limit** | `384m` | Container memory cap. Raise for large concurrent agent runs. |
+| **Memory limit** | `384m` | Runtime container memory cap. This is not a Docker image build-host requirement. Raise for large concurrent agent runs. |
+
+> **Runtime vs build resources:** The installer is designed to pull a prebuilt
+> image and start it with `docker compose up -d --no-build`. The `384m` memory
+> default limits the running container only. If the image pull is unavailable and
+> you choose to build from source instead, the build host needs enough memory for
+> TypeScript compilation, the Next.js production build, package deployment, and
+> dependency cleanup. A small VPS that can run the prebuilt image may still run
+> out of memory while building it locally.
 
 After you confirm, the installer:
 
@@ -189,6 +197,8 @@ The container always binds `127.0.0.1:<port>:7456` — the daemon is never direc
 | `Docker daemon is not running` | Docker Desktop not started | Open Docker Desktop or run `sudo systemctl start docker` |
 | `Port 7456 is already in use` | Another service on that port | Re-run with `--port 8080` |
 | Health check times out | Image pull slow or daemon slow to start | Wait and check `docker compose -f deploy/docker-compose.yml logs` |
+| Image pull fails for `ghcr.io/nexu-io/od:latest` | Registry access, tag availability, or authentication issue | Check the image reference and registry access before falling back to a local build. If you build from source, use a larger build host or CI runner; the runtime memory limit does not size the build. |
+| Local Docker build is killed or exits with out-of-memory errors | Build host is too small for TypeScript/Next.js production build steps | Build on a larger temporary machine or CI runner, push the resulting image, then deploy that image to the smaller runtime host with `--no-build`. |
 | `Permission denied` on install.sh | Script not executable | Run `chmod +x deploy/scripts/install.sh` |
 | systemd unit not created | `systemd` not found | Omit `--no-systemd` if systemd is available, or manage via Docker CLI |
 | `.env` has wrong port after re-install | Old backup not restored | Edit `deploy/.env` directly or delete it and re-run |


### PR DESCRIPTION
## Summary
- Clarifies that the documented Node heap and Compose memory limits apply to the runtime container, not source image builds
- Warns small-VPS self-hosters that fallback local builds can need substantially more memory than the running service
- Adds troubleshooting entries for GHCR pull failures and local Docker build OOMs

## Surface area
- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — docs update only

## Validation
- [x] Reviewed the Markdown diff locally
- [x] Ran `git diff --check`
- [x] Verified GitHub PR checks are passing: `approve`, `label`
- [ ] `pnpm lint:craft` not run locally because `pnpm` is not installed on this host

Closes #5568
