### PR TITLE
fix(daemon): support Azure GPT-5.6 Responses API

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -736,6 +736,9 @@ function appendVersionedApiPath(baseUrl: string, suffix: string): string {
     : `${pathname}/v1${suffix}`;
   return url.toString();
 }
+export function requiresAzureResponsesApi(model: string): boolean {
+  return /^gpt-5\.6(?:[-_]|$)/i.test(model.trim());
+}
 
 function truncateSample(text: unknown): string {
   if (typeof text !== 'string') return '';
@@ -798,6 +801,14 @@ function inspectProviderCompletion(
   if (!obj) return { valid: false };
 
   if (protocol === 'openai' || protocol === 'azure' || protocol === 'senseaudio' || protocol === 'aihubmix') {
+    if (
+      protocol === 'azure' &&
+      !Array.isArray(obj.choices) &&
+      (typeof (obj as { output_text?: unknown }).output_text === 'string' ||
+        Array.isArray((obj as { output?: unknown }).output))
+    ) {
+      return { valid: true, sample: 'valid completion' };
+    }
     const responseModel = typeof obj.model === 'string' ? obj.model : '';
     if (
       // AIHubMix is omitted from the strict response-model check (like Azure):
@@ -1230,6 +1241,33 @@ function buildProviderCall(input: ProviderTestRequest): ProviderCallShape {
           : usesVersionedOpenAIPath
             ? ''
             : '2024-10-21';
+
+      if (requiresAzureResponsesApi(model)) {
+        url.pathname = usesVersionedOpenAIPath
+          ? `${basePath}/responses`
+          : `${basePath}/openai/deployments/${encodeURIComponent(model)}/responses`;
+        if (usesVersionedOpenAIPath && !apiVersion) {
+          url.searchParams.delete('api-version');
+        }
+        if (apiVersion) {
+          url.searchParams.set('api-version', apiVersion);
+        }
+        return {
+          url: url.toString(),
+          headers: {
+            'content-type': 'application/json',
+            'api-key': apiKey,
+          },
+          body: {
+            ...(usesVersionedOpenAIPath ? { model } : {}),
+            input: SMOKE_PROMPT,
+            max_output_tokens: PROVIDER_MAX_TOKENS,
+            stream: false,
+          },
+          extractText: extractAzureResponsesText,
+        };
+      }
+
       url.pathname = usesVersionedOpenAIPath
         ? `${basePath}/chat/completions`
         : `${basePath}/openai/deployments/${encodeURIComponent(model)}/chat/completions`;
@@ -1330,6 +1368,27 @@ function extractOpenAIMessageText(data: unknown): string {
     | undefined;
   if (typeof first?.message?.content === 'string') return first.message.content;
   if (typeof first?.text === 'string') return first.text;
+  return '';
+}
+function extractAzureResponsesText(data: unknown): string {
+  const obj = data as { output_text?: unknown; output?: unknown };
+  if (typeof obj.output_text === 'string') return obj.output_text;
+  const output = obj.output;
+  if (Array.isArray(output)) {
+    for (const item of output) {
+      const content = (item as { content?: unknown })?.content;
+      if (!Array.isArray(content)) continue;
+      for (const block of content) {
+        if (
+          block &&
+          typeof block === 'object' &&
+          typeof (block as { text?: unknown }).text === 'string'
+        ) {
+          return (block as { text: string }).text;
+        }
+      }
+    }
+  }
   return '';
 }
 

--- a/apps/daemon/src/routes/chat.ts
+++ b/apps/daemon/src/routes/chat.ts
@@ -32,7 +32,7 @@ import {
 } from '../integrations/aihubmix.js';
 import { isSafeId as isSafeProjectId } from '../projects.js';
 import { projectKindToTracking } from '@open-design/contracts/analytics';
-import { proxyDispatcherRequestInit, validateUserProviderBaseUrl } from '../connectionTest.js';
+import { proxyDispatcherRequestInit, validateUserProviderBaseUrl, requiresAzureResponsesApi } from '../connectionTest.js';
 import { googleStreamGenerateContentUrl } from '../integrations/google-models.js';
 import { createRoleMarkerGuard } from '../role-marker-guard.js';
 import { authorizeReasoningEgress, sendReasoningEgressDenial } from '../reasoning-egress.js';
@@ -558,6 +558,19 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
     const first = choices[0];
     if (typeof first?.delta?.content === 'string') return first.delta.content;
     if (typeof first?.text === 'string') return first.text;
+    return '';
+  };
+  const extractAzureResponsesDeltaText = (data: any) => {
+    return data?.type === 'response.output_text.delta' && typeof data?.delta === 'string'
+      ? data.delta
+      : '';
+  };
+
+  const extractAzureResponsesErrorMessage = (data: any) => {
+    if (data?.type !== 'response.error' && data?.type !== 'error') return '';
+    const err = data?.error ?? data;
+    if (typeof err === 'string') return err;
+    if (typeof err?.message === 'string') return err.message;
     return '';
   };
 
@@ -1126,9 +1139,10 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
         : usesVersionedOpenAIPath
           ? ''
           : '2024-10-21';
+    const useResponsesApi = requiresAzureResponsesApi(model);
     url.pathname = usesVersionedOpenAIPath
-      ? `${basePath}/chat/completions`
-      : `${basePath}/openai/deployments/${encodeURIComponent(model)}/chat/completions`;
+      ? `${basePath}/${useResponsesApi ? 'responses' : 'chat/completions'}`
+      : `${basePath}/openai/deployments/${encodeURIComponent(model)}/${useResponsesApi ? 'responses' : 'chat/completions'}`;
     if (usesVersionedOpenAIPath && !version) {
       url.searchParams.delete('api-version');
     }
@@ -1136,7 +1150,7 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
       url.searchParams.set('api-version', version);
     }
     console.log(
-      `[proxy:azure] ${req.method} ${validated.parsed!.hostname} deployment=${model} api-version=${version || 'omitted'}`,
+      `[proxy:azure] ${req.method} ${validated.parsed!.hostname} deployment=${model} api-version=${version || 'omitted'} api=${useResponsesApi ? 'responses' : 'chat_completions'}`,
     );
 
     const payloadMessages = Array.isArray(messages) ? [...messages] : [];
@@ -1146,12 +1160,22 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
 
     const effectiveMaxTokens =
       typeof maxTokens === 'number' && maxTokens > 0 ? maxTokens : 8192;
-    const payload = {
-      ...(usesVersionedOpenAIPath ? { model } : {}),
-      messages: payloadMessages,
-      ...buildLegacyMaxTokensParam(effectiveMaxTokens),
-      stream: true,
-    };
+    const payload: any = useResponsesApi
+      ? {
+          ...(usesVersionedOpenAIPath ? { model } : {}),
+          input: payloadMessages.map((m: any) => ({
+            role: m.role === 'assistant' ? 'assistant' : m.role === 'system' ? 'system' : 'user',
+            content: m.content,
+          })),
+          max_output_tokens: effectiveMaxTokens,
+          stream: true,
+        }
+      : {
+          ...(usesVersionedOpenAIPath ? { model } : {}),
+          messages: payloadMessages,
+          ...buildLegacyMaxTokensParam(effectiveMaxTokens),
+          stream: true,
+        };
     const retryPayload = {
       ...(usesVersionedOpenAIPath ? { model } : {}),
       messages: payloadMessages,
@@ -1183,6 +1207,7 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
       if (!response.ok) {
         let errorText = await response.text();
         if (
+          !useResponsesApi &&
           response.status === 400 &&
           isUnsupportedMaxTokensError(errorText)
         ) {
@@ -1212,34 +1237,63 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
         }
       }
 
-      let ended = false;
+     let ended = false;
       const guard = createDeltaGuard(sse);
-      await streamUpstreamSse(response, ({ payload: ssePayload, data }: any) => {
-        if (ssePayload === '[DONE]') {
-          sse.send('end', {});
-          ended = true;
-          return true;
-        }
-        if (!data) return false;
-        const streamError = extractStreamErrorMessage(data);
-        if (streamError) {
-          sendProxyError(sse, `Azure error: ${streamError}`, { details: data });
-          ended = true;
-          return true;
-        }
-        const delta = extractOpenAIText(data);
-        if (delta) { guard.sendDelta(delta); 
-          if (guard.contaminated) { 
-            sse.send('end', {}); 
-            ended = true; 
-            return true; 
-          } 
-        }
-        return false;
-      });
+      if (useResponsesApi) {
+        await streamUpstreamSse(response, ({ data }: any) => {
+          if (!data) return false;
+          const streamError = extractAzureResponsesErrorMessage(data);
+          if (streamError) {
+            sendProxyError(sse, `Azure error: ${streamError}`, { details: data });
+            ended = true;
+            return true;
+          }
+          const delta = extractAzureResponsesDeltaText(data);
+          if (delta) {
+            guard.sendDelta(delta);
+            if (guard.contaminated) {
+              sse.send('end', {});
+              ended = true;
+              return true;
+            }
+          }
+          if (data?.type === 'response.completed' || data?.type === 'response.incomplete') {
+            sse.send('end', {});
+            ended = true;
+            return true;
+          }
+          return false;
+        });
+      } else {
+        await streamUpstreamSse(response, ({ payload: ssePayload, data }: any) => {
+          if (ssePayload === '[DONE]') {
+            sse.send('end', {});
+            ended = true;
+            return true;
+          }
+          if (!data) return false;
+          const streamError = extractStreamErrorMessage(data);
+          if (streamError) {
+            sendProxyError(sse, `Azure error: ${streamError}`, { details: data });
+            ended = true;
+            return true;
+          }
+          const delta = extractOpenAIText(data);
+          if (delta) { guard.sendDelta(delta); 
+            if (guard.contaminated) { 
+              sse.send('end', {}); 
+              ended = true; 
+              return true; 
+            } 
+          }
+          return false;
+        });
+      }
       if (!ended) sse.send('end', {});
       sse.end();
-    } catch (err: any) {
+        } 
+        
+      catch (err: any) {
       console.error(`[proxy:azure] internal error: ${err.message}`);
       sendProxyError(sse, err.message, { code: 'INTERNAL_ERROR' });
       sse.end();


### PR DESCRIPTION
Fixes #5574

## Why

Azure OpenAI GPT-5.6 deployments (Sol, Terra, and Luna) use the Responses API instead of the Chat Completions API. The current Azure BYOK implementation continues to use the Chat Completions endpoint during connection testing and agent execution, causing agent execution to fail even though the connection test succeeds.

This change adds Azure GPT-5.6 detection and routes supported requests through the Responses API while preserving the existing Chat Completions flow for other Azure models.

## What users will see

Users configuring Azure OpenAI BYOK with GPT-5.6 deployments should be able to execute prompts successfully instead of receiving a "Resource not found" or unsupported Chat Completions error.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — Azure GPT-5.6 BYOK requests are routed to the Responses API instead of the Chat Completions API.
- [ ] **None**

## Screenshots

Not applicable.

## Bug fix verification

- Test path that reproduces the bug:
  1. Configure Azure OpenAI BYOK with a GPT-5.6 deployment.
  2. Verify the connection test succeeds.
  3. Execute a prompt.
- A new automated regression test was not added.
- This change was implemented based on the reported Azure GPT-5.6 Responses API requirements and existing Azure request flow.

## Validation

- [ ] `pnpm guard`
- [ ] `pnpm typecheck`