### PR TITLE
docs(agent-adapters): describe the data-oriented RuntimeAgentDef registry (not a class interface)

### DIFF
--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -12,63 +12,99 @@ If you're adding a new ACP-backed runtime, start with [`new-agent-runtime-acp.md
 
 ---
 
-## 1. Adapter interface (TypeScript)
+## 1. Adapter contract: a data spec, not a class
 
-Every adapter implements this interface. The current adapter implementation lives in [`apps/daemon/src/agents.ts`](../apps/daemon/src/agents.ts).
+An adapter is **not** a class that implements the agent loop. It is a **plain data object** — one `RuntimeAgentDef` object literal per CLI — that declares *how to talk to* that CLI: which binary to probe, how to build its argv, how it streams, what it can do. A **generic engine** reads those fields and does the detecting, launching, invoking, and stream-parsing for every agent uniformly. There is no per-agent subclass and no `run()` / `cancel()` method to implement.
+
+Where the pieces live (all under `apps/daemon/src/`):
+
+- **The contract (the data spec):** [`runtimes/types.ts`](../apps/daemon/src/runtimes/types.ts) — the `RuntimeAgentDef` type.
+- **One def per CLI:** [`runtimes/defs/*.ts`](../apps/daemon/src/runtimes/defs) — `claude.ts`, `codex.ts`, `gemini.ts`, `devin.ts`, … each exports a single object literal.
+- **The registry (a unique-id array):** [`runtimes/registry.ts`](../apps/daemon/src/runtimes/registry.ts) — `BASE_AGENT_DEFS` collects every def into `AGENT_DEFS`; a boot-time loop throws on any duplicate `id`.
+- **The generic engine (zero per-agent code):** `detection.ts`, `capabilities.ts`, `executables.ts` / `resolution.ts`, `launch.ts`, `invocation.ts`, `env.ts`, `mcp.ts`, `models.ts`, `prompt-budget.ts` under `runtimes/`, plus the stream dispatch in [`server.ts`](../apps/daemon/src/server.ts) that routes each def's `streamFormat` / `eventParser` to the matching `*-stream.ts` parser.
+- **The public barrel:** [`agents.ts`](../apps/daemon/src/agents.ts) re-exports `AGENT_DEFS`, `getAgentDef`, `detectAgents`, `resolveAgentLaunch`, … from `runtimes/`. It defines nothing itself — import from it for convenience, but read `runtimes/` for the contract.
+
+> **Adding a CLI is a one-file change.** Drop a new `runtimes/defs/<cli>.ts` exporting one `RuntimeAgentDef`, add it to the `BASE_AGENT_DEFS` array in `registry.ts`, and the engine detects, launches, invokes, and (for an existing `streamFormat`) streams it — **no engine edits, no new class, no method overrides.** The def is config; the loop is shared. A genuinely new wire format is the only case that also adds an engine file (a new `*-stream.ts` and a `streamFormat` value).
+
+### The data spec (`RuntimeAgentDef`, abbreviated)
+
+The full type lives in `runtimes/types.ts`; the load-bearing fields:
 
 ```ts
-interface AgentAdapter {
-  readonly id: string;                      // "claude-code" | "codex" | …
-  readonly displayName: string;
+type RuntimeAgentDef = {
+  id: string;                 // unique key, e.g. "claude" | "codex" — the registry dedupes on it
+  name: string;               // display name
+  bin: string;                // CLI executable to probe on PATH
+  fallbackBins?: string[];    // alternate executable names
+  versionArgs: string[];      // args for the version / detection probe
+  fallbackModels: RuntimeModelOption[];
 
-  // -- discovery --------------------------------------------------
-  detect(): Promise<AgentDetection | null>; // null if not installed
+  // How to invoke: build the argv for one turn from the composed prompt.
+  buildArgs: (
+    prompt: string,
+    imagePaths: string[],
+    extraAllowedDirs?: string[],
+    options?: RuntimeBuildOptions,
+    runtimeContext?: RuntimeContext,
+  ) => string[];
 
-  // -- capability negotiation ------------------------------------
-  capabilities(): AgentCapabilities;
+  // How it talks back: the engine dispatches these to the matching parser.
+  streamFormat: string;               // e.g. "stream-json" | "acp-json-rpc" | "text"
+  eventParser?: string;               // named parser, e.g. "claude-stream" | "qoder-stream"
 
-  // -- execution -------------------------------------------------
-  run(params: AgentRunParams): AsyncIterable<AgentEvent>;
-  cancel(runId: string): Promise<void>;
-  resume?(runId: string, message: string): AsyncIterable<AgentEvent>;
-}
+  // How the prompt is delivered.
+  promptViaStdin?: boolean;
+  promptViaFile?: boolean;
+  promptInputFormat?: 'text' | 'stream-json';
 
-interface AgentDetection {
-  executablePath: string;                   // absolute path to CLI
-  version: string;
-  configDir?: string;                       // e.g. ~/.claude
-  skillsDir?: string;                       // e.g. ~/.claude/skills
-  authState: "ok" | "missing" | "expired";
-}
-
-interface AgentCapabilities {
-  surgicalEdit: boolean;                    // can edit a targeted region without rewriting file
-  nativeSkillLoading: boolean;              // picks up ~/.<agent>/skills/ automatically
-  streaming: boolean;                       // emits tool calls in real time
-  resume: boolean;                          // can continue an interrupted run
-  permissionMode: "strict" | "permissive" | "none";
-  contextWindowHint?: number;               // in tokens
-}
-
-interface AgentRunParams {
-  runId: string;
-  cwd: string;                              // absolute path — artifact dir
-  systemPrompt: string;                     // skill's SKILL.md body + DESIGN.md excerpt
-  userPrompt: string;
-  skillDir?: string;                        // if set, adapter should make skill files available
-  allowedTools?: string[];                  // for agents that support it
-  timeoutMs?: number;
-}
-
-type AgentEvent =
-  | { type: "thinking"; text: string }
-  | { type: "tool_call"; name: string; input: unknown; id: string }
-  | { type: "tool_result"; id: string; output: unknown }
-  | { type: "text_delta"; text: string }
-  | { type: "file_write"; path: string }   // synthesized by adapter if agent doesn't emit natively
-  | { type: "error"; error: string }
-  | { type: "done"; reason: "completed" | "cancelled" | "error" };
+  // Optional capability / integration declarations (all data, no behavior).
+  supportsImagePaths?: boolean;
+  externalMcpInjection?: 'claude-mcp-json' | 'acp-merge' | 'opencode-env-content';
+  authProbe?: { args: string[]; timeoutMs?: number };
+  listModels?: RuntimeListModels;     // dynamic model discovery
+  // …~30 more optional fields, every one data or a pure arg-builder.
+};
 ```
+
+Every field is **data or a pure arg-builder** — there is no `run()`, no `cancel()`, no subclass. Capabilities, detection, cancellation, and streaming are the engine's job, driven off these declarations, which is why a new agent needs only a new object rather than a new code path.
+
+### A concrete def (shape)
+
+```ts
+// runtimes/defs/gemini.ts (illustrative)
+export const geminiAgentDef: RuntimeAgentDef = {
+  id: 'gemini',
+  name: 'Gemini CLI',
+  bin: 'gemini',
+  versionArgs: ['--version'],
+  fallbackModels: [{ id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' }],
+  streamFormat: 'stream-json',
+  promptViaStdin: true,
+  buildArgs: (prompt, imagePaths, extraDirs, opts) => [
+    '--output-format', 'stream-json',
+    /* … */
+  ],
+};
+```
+
+### The registry (a unique-id array)
+
+```ts
+// runtimes/registry.ts
+const BASE_AGENT_DEFS: RuntimeAgentDef[] = [
+  claudeAgentDef, codexAgentDef, devinAgentDef, geminiAgentDef,
+  /* … one entry per CLI (roughly two dozen today) … */
+];
+
+// boot-time invariant: no two defs may share an id
+const ids = new Set<string>();
+for (const def of AGENT_DEFS) {
+  if (ids.has(def.id)) throw new Error(`Duplicate agent definition id: ${def.id}`);
+  ids.add(def.id);
+}
+```
+
+`AGENT_DEFS` = `BASE_AGENT_DEFS` plus any user-defined local profiles (`readLocalAgentProfileDefs`), and `getAgentDef(id)` is the lookup the rest of the daemon uses. The event set the `*-stream.ts` parsers emit onto the UI stream (thinking / tool-call / tool-result / text-delta / file-write / error / done) is defined by those parsers, not by the def — see §11 for where they live and `server.ts` for the dispatch.
 
 ## 2. Detection strategy
 
@@ -195,7 +231,6 @@ The adapter declares which strategy to use via `capabilities().nativeSkillLoadin
 ### 5.7 OpenCode / OpenClaw
 
 - Less-matured CLIs. Targeting P2. Expect bumps; adapter implementations will likely be the thinnest possible "shell out, parse output, synthesize events" approach.
-- OpenCode runs as `opencode run --format json` with the prompt on stdin. Newer OpenCode builds that advertise `--dangerously-skip-permissions` from `opencode run --help` receive that flag so headless runs do not stop on edit approval prompts; older builds keep the 1.3-compatible argv.
 
 ### 5.8 GitHub Copilot CLI
 
@@ -243,28 +278,6 @@ The adapter declares which strategy to use via `capabilities().nativeSkillLoadin
 - Prompt delivery: positional argv (no stdin sentinel; clap declares `prompt: String` as a required field). This means very large composed prompts can hit Windows' ~32 KB `CreateProcess` limit; for typical chat prompts this is non-issue. Upstream support for a `-` stdin sentinel would let us flip this to `promptViaStdin: true` like the other adapters. To avoid surfacing oversized prompts as a generic `spawn ENAMETOOLONG` / `E2BIG`, the adapter declares `maxPromptArgBytes` (currently 30,000) and `/api/chat` enforces it through three complementary guards: a fast pre-bin-resolution `checkPromptArgvBudget` against the raw composed prompt bytes, a post-`buildArgs` `checkWindowsCmdShimCommandLineBudget` that — when the resolved binary is a Windows `.cmd` / `.bat` shim — recomputes the would-be `cmd.exe /d /s /c "<inner>"` command line using the same per-arg quote-doubling the platform layer applies on Windows, and a sibling `checkWindowsDirectExeCommandLineBudget` that — when the resolved binary is a non-shim Windows install (e.g. a cargo-built `deepseek.exe`) — recomputes the same command line using libuv's `quote_cmd_arg` rules (every `"` becomes `\"`, backslashes adjacent to a quote are doubled). The two Windows guards are mutually exclusive on a given resolution: the cmd-shim guard owns `.cmd`/`.bat`, the direct-exe guard owns everything else. Together they catch quote-heavy prompts (code blocks, JSON-shaped skill seeds) that fit under the raw byte budget but expand past CreateProcess's 32_767-char `lpCommandLine` cap on either install path. All three guards emit the same actionable `AGENT_PROMPT_TOO_LARGE` SSE error telling the user to reduce skills/design-system context, shorten the conversation, or pick an adapter with stdin support, and all three are unit-tested (oversized + short-prompt branches, quote-heavy regressions for both Windows paths, and a mutual-exclusivity check) so the guards can't silently regress.
 - Models: ships `deepseek-v4-pro` and `deepseek-v4-flash` as fallback hints (1M-token context windows, native thinking-mode streaming). Users can paste any other id (e.g. `nvidia-nim/deepseek-v4-pro`, `fireworks/deepseek-v4-flash`) via the Settings dialog's custom-model input.
 - **Gotcha — auth state is not auto-detected.** DeepSeek TUI reads its API key from `~/.deepseek/config.toml` or `DEEPSEEK_API_KEY`. If the user hasn't run `deepseek auth set --provider deepseek` (or set the env var), the first run errors out with a non-actionable message. Detection currently only reports `available: true` based on the binary being on PATH; surface auth state via `deepseek doctor --json` in a follow-up.
-
-### 5.13 Plain stream artifact handoff
-
-Adapters with `streamFormat: 'plain'` do not expose structured file-write tool calls to the daemon. Their stdout is still a valid artifact handoff when the model emits Anthropic-style source blocks:
-
-```html
-<artifact identifier="landing-page" type="text/html" title="Landing page">
-<!doctype html>
-<html>...</html>
-</artifact>
-```
-
-At run completion, the daemon scans the captured plain stdout for `<artifact>` blocks with supported text types and writes them through the normal project artifact path:
-
-| Artifact type | Project file |
-|---|---|
-| `text/html` or `html` | `<identifier>.html` |
-| `text/css` or `css` | `<identifier>.css` |
-| `image/svg+xml` or `svg` | `<identifier>.svg` |
-| `text/markdown`, `text/x-markdown`, `markdown`, or `md` | `<identifier>.md` |
-
-The identifier is slugged before use, collisions receive `-2`, `-3`, etc., and outputs without a supported `<artifact>` block are left unchanged. This daemon-side extraction keeps headless runs and web-attached runs aligned: the project file exists even when no browser is present to parse the chat stream.
 
 ## 6. Capability-driven UI
 
@@ -333,25 +346,39 @@ The daemon never grants more authority to an agent than it had on its own. We do
 
 ## 11. Adapter source layout
 
+The contract and the per-CLI defs live under `apps/daemon/src/runtimes/`; the streaming parsers and the spawn/dispatch glue live beside them in `apps/daemon/src/`.
+
 ```
-apps/daemon/
-├── base.ts                 # shared interface + utility helpers
-├── claude-code/
-│   ├── adapter.ts
-│   ├── stream-parser.ts    # JSON-lines → AgentEvent
-│   └── detect.ts
-├── api-fallback/
-│   ├── adapter.ts
-│   ├── tool-loop.ts        # the minimal tool-use loop
-│   └── tools.ts            # Read/Write/Edit implementations
-├── codex/                  # Phase 1
-├── cursor-agent/           # Phase 1
-├── gemini-cli/             # Phase 2
-├── opencode/               # Phase 2
-└── openclaw/               # Phase 2
+apps/daemon/src/
+├── agents.ts               # public barrel — re-exports AGENT_DEFS / getAgentDef / detectAgents / … from runtimes/ (defines nothing)
+├── runtimes/
+│   ├── types.ts            # the RuntimeAgentDef contract (the data spec) + shared runtime types
+│   ├── registry.ts         # BASE_AGENT_DEFS array → AGENT_DEFS + unique-id guard + getAgentDef()
+│   ├── defs/               # one object literal per CLI — the file you add for a new agent
+│   │   ├── claude.ts
+│   │   ├── codex.ts
+│   │   ├── gemini.ts
+│   │   ├── devin.ts
+│   │   ├── …               # ~two dozen defs (opencode, hermes, cursor-agent, qoder, copilot,
+│   │   │                   #   amp, pi, kiro, kilo, vibe, deepseek, aider, antigravity, qwen,
+│   │   │                   #   grok-build, kimi, reasonix, codebuddy, trae-cli, …)
+│   │   └── shared.ts       # helpers reused across defs (not a registered agent)
+│   ├── detection.ts        # generic PATH-scan + config-probe over every def (detectAgents / …Stream)
+│   ├── capabilities.ts     # derives the UI capability map from def fields
+│   ├── executables.ts      # PATH resolution     · resolution.ts — bin resolution
+│   ├── launch.ts           # generic launch descriptor (resolveAgentLaunch / applyAgentLaunchEnv)
+│   ├── invocation.ts       # generic argv/prompt invocation from a def's buildArgs
+│   ├── env.ts              # per-agent spawn env  · mcp.ts — external-MCP injection per def
+│   ├── models.ts           # live/fallback models · prompt-budget.ts — argv size guards
+│   └── local-profiles.ts   # user-defined local agent profiles merged into AGENT_DEFS
+├── claude-stream.ts        # eventParser="claude-stream": JSONL → UI events
+├── qoder-stream.ts         # eventParser="qoder-stream"   · copilot-stream.ts · json-event-stream.ts
+├── pi-rpc.ts               # pi's JSON-RPC transport
+├── acp.ts                  # shared ACP JSON-RPC transport (devin / kimi / kilo / kiro / vibe / hermes)
+└── server.ts               # spawn pipeline + stream dispatch: routes def.streamFormat/eventParser to a parser
 ```
 
-Each adapter is a separate module so community contributions can add new ones without touching core daemon code.
+The engine is agent-agnostic: it iterates `AGENT_DEFS` and reads fields. A community contribution adds a new agent by dropping one `runtimes/defs/<cli>.ts` and appending it to `BASE_AGENT_DEFS` — detection, launch, invocation, and (for an existing `streamFormat`) parsing come for free, with no change to core daemon code.
 
 ## 12. Open questions
 

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -19,7 +19,7 @@ An adapter is **not** a class that implements the agent loop. It is a **plain da
 Where the pieces live (all under `apps/daemon/src/`):
 
 - **The contract (the data spec):** [`runtimes/types.ts`](../apps/daemon/src/runtimes/types.ts) — the `RuntimeAgentDef` type.
-- **One def per CLI:** [`runtimes/defs/*.ts`](../apps/daemon/src/runtimes/defs) — `claude.ts`, `codex.ts`, `gemini.ts`, `devin.ts`, … each exports a single object literal.
+- **One def per CLI:** [`runtimes/defs/*.ts`](../apps/daemon/src/runtimes/defs) — `claude.ts`, `codex.ts`, `cursor-agent.ts`, `devin.ts`, … each exports a single object literal.
 - **The registry (a unique-id array):** [`runtimes/registry.ts`](../apps/daemon/src/runtimes/registry.ts) — `BASE_AGENT_DEFS` collects every def into `AGENT_DEFS`; a boot-time loop throws on any duplicate `id`.
 - **The generic engine (zero per-agent code):** `detection.ts`, `capabilities.ts`, `executables.ts` / `resolution.ts`, `launch.ts`, `invocation.ts`, `env.ts`, `mcp.ts`, `models.ts`, `prompt-budget.ts` under `runtimes/`, plus the stream dispatch in [`server.ts`](../apps/daemon/src/server.ts) that routes each def's `streamFormat` / `eventParser` to the matching `*-stream.ts` parser.
 - **The public barrel:** [`agents.ts`](../apps/daemon/src/agents.ts) re-exports `AGENT_DEFS`, `getAgentDef`, `detectAgents`, `resolveAgentLaunch`, … from `runtimes/`. It defines nothing itself — import from it for convenience, but read `runtimes/` for the contract.
@@ -49,8 +49,8 @@ type RuntimeAgentDef = {
   ) => string[];
 
   // How it talks back: the engine dispatches these to the matching parser.
-  streamFormat: string;               // e.g. "stream-json" | "acp-json-rpc" | "text"
-  eventParser?: string;               // named parser, e.g. "claude-stream" | "qoder-stream"
+  streamFormat: string;               // e.g. "claude-stream-json" | "acp-json-rpc" | "plain"
+  eventParser?: string;               // named parser, e.g. "codex" | "cursor-agent" | "opencode"
 
   // How the prompt is delivered.
   promptViaStdin?: boolean;
@@ -71,14 +71,14 @@ Every field is **data or a pure arg-builder** — there is no `run()`, no `cance
 ### A concrete def (shape)
 
 ```ts
-// runtimes/defs/gemini.ts (illustrative)
-export const geminiAgentDef: RuntimeAgentDef = {
-  id: 'gemini',
-  name: 'Gemini CLI',
-  bin: 'gemini',
+// runtimes/defs/acme.ts (illustrative — a made-up CLI, not a shipped def)
+export const acmeAgentDef: RuntimeAgentDef = {
+  id: 'acme',
+  name: 'Acme CLI',
+  bin: 'acme',
   versionArgs: ['--version'],
-  fallbackModels: [{ id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' }],
-  streamFormat: 'stream-json',
+  fallbackModels: [{ id: 'acme-pro', label: 'Acme Pro' }],
+  streamFormat: 'claude-stream-json',   // reuse an existing parser — no engine change
   promptViaStdin: true,
   buildArgs: (prompt, imagePaths, extraDirs, opts) => [
     '--output-format', 'stream-json',
@@ -92,7 +92,7 @@ export const geminiAgentDef: RuntimeAgentDef = {
 ```ts
 // runtimes/registry.ts
 const BASE_AGENT_DEFS: RuntimeAgentDef[] = [
-  claudeAgentDef, codexAgentDef, devinAgentDef, geminiAgentDef,
+  claudeAgentDef, codexAgentDef, devinAgentDef, cursorAgentDef,
   /* … one entry per CLI (roughly two dozen today) … */
 ];
 
@@ -380,9 +380,9 @@ apps/daemon/src/
 │   ├── defs/               # one object literal per CLI — the file you add for a new agent
 │   │   ├── claude.ts
 │   │   ├── codex.ts
-│   │   ├── gemini.ts
+│   │   ├── cursor-agent.ts
 │   │   ├── devin.ts
-│   │   ├── …               # ~two dozen defs (opencode, hermes, cursor-agent, qoder, copilot,
+│   │   ├── …               # ~two dozen defs (opencode, hermes, qoder, copilot,
 │   │   │                   #   amp, pi, kiro, kilo, vibe, deepseek, aider, antigravity, qwen,
 │   │   │                   #   grok-build, kimi, reasonix, codebuddy, trae-cli, …)
 │   │   └── shared.ts       # helpers reused across defs (not a registered agent)

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -231,6 +231,7 @@ The adapter declares which strategy to use via `capabilities().nativeSkillLoadin
 ### 5.7 OpenCode / OpenClaw
 
 - Less-matured CLIs. Targeting P2. Expect bumps; adapter implementations will likely be the thinnest possible "shell out, parse output, synthesize events" approach.
+- OpenCode runs as `opencode run --format json` with the prompt on stdin. Newer OpenCode builds that advertise `--dangerously-skip-permissions` from `opencode run --help` receive that flag so headless runs do not stop on edit approval prompts; older builds keep the 1.3-compatible argv.
 
 ### 5.8 GitHub Copilot CLI
 
@@ -278,6 +279,28 @@ The adapter declares which strategy to use via `capabilities().nativeSkillLoadin
 - Prompt delivery: positional argv (no stdin sentinel; clap declares `prompt: String` as a required field). This means very large composed prompts can hit Windows' ~32 KB `CreateProcess` limit; for typical chat prompts this is non-issue. Upstream support for a `-` stdin sentinel would let us flip this to `promptViaStdin: true` like the other adapters. To avoid surfacing oversized prompts as a generic `spawn ENAMETOOLONG` / `E2BIG`, the adapter declares `maxPromptArgBytes` (currently 30,000) and `/api/chat` enforces it through three complementary guards: a fast pre-bin-resolution `checkPromptArgvBudget` against the raw composed prompt bytes, a post-`buildArgs` `checkWindowsCmdShimCommandLineBudget` that — when the resolved binary is a Windows `.cmd` / `.bat` shim — recomputes the would-be `cmd.exe /d /s /c "<inner>"` command line using the same per-arg quote-doubling the platform layer applies on Windows, and a sibling `checkWindowsDirectExeCommandLineBudget` that — when the resolved binary is a non-shim Windows install (e.g. a cargo-built `deepseek.exe`) — recomputes the same command line using libuv's `quote_cmd_arg` rules (every `"` becomes `\"`, backslashes adjacent to a quote are doubled). The two Windows guards are mutually exclusive on a given resolution: the cmd-shim guard owns `.cmd`/`.bat`, the direct-exe guard owns everything else. Together they catch quote-heavy prompts (code blocks, JSON-shaped skill seeds) that fit under the raw byte budget but expand past CreateProcess's 32_767-char `lpCommandLine` cap on either install path. All three guards emit the same actionable `AGENT_PROMPT_TOO_LARGE` SSE error telling the user to reduce skills/design-system context, shorten the conversation, or pick an adapter with stdin support, and all three are unit-tested (oversized + short-prompt branches, quote-heavy regressions for both Windows paths, and a mutual-exclusivity check) so the guards can't silently regress.
 - Models: ships `deepseek-v4-pro` and `deepseek-v4-flash` as fallback hints (1M-token context windows, native thinking-mode streaming). Users can paste any other id (e.g. `nvidia-nim/deepseek-v4-pro`, `fireworks/deepseek-v4-flash`) via the Settings dialog's custom-model input.
 - **Gotcha — auth state is not auto-detected.** DeepSeek TUI reads its API key from `~/.deepseek/config.toml` or `DEEPSEEK_API_KEY`. If the user hasn't run `deepseek auth set --provider deepseek` (or set the env var), the first run errors out with a non-actionable message. Detection currently only reports `available: true` based on the binary being on PATH; surface auth state via `deepseek doctor --json` in a follow-up.
+
+### 5.13 Plain stream artifact handoff
+
+Adapters with `streamFormat: 'plain'` do not expose structured file-write tool calls to the daemon. Their stdout is still a valid artifact handoff when the model emits Anthropic-style source blocks:
+
+```html
+<artifact identifier="landing-page" type="text/html" title="Landing page">
+<!doctype html>
+<html>...</html>
+</artifact>
+```
+
+At run completion, the daemon scans the captured plain stdout for `<artifact>` blocks with supported text types and writes them through the normal project artifact path:
+
+| Artifact type | Project file |
+|---|---|
+| `text/html` or `html` | `<identifier>.html` |
+| `text/css` or `css` | `<identifier>.css` |
+| `image/svg+xml` or `svg` | `<identifier>.svg` |
+| `text/markdown`, `text/x-markdown`, `markdown`, or `md` | `<identifier>.md` |
+
+The identifier is slugged before use, collisions receive `-2`, `-3`, etc., and outputs without a supported `<artifact>` block are left unchanged. This daemon-side extraction keeps headless runs and web-attached runs aligned: the project file exists even when no browser is present to parse the chat stream.
 
 ## 6. Capability-driven UI
 
@@ -346,7 +369,7 @@ The daemon never grants more authority to an agent than it had on its own. We do
 
 ## 11. Adapter source layout
 
-The contract and the per-CLI defs live under `apps/daemon/src/runtimes/`; the streaming parsers and the spawn/dispatch glue live beside them in `apps/daemon/src/`.
+The contract, the per-CLI defs, and the stream parsers live under `apps/daemon/src/runtimes/`; the JSON-RPC transports live under `apps/daemon/src/agent-protocol/`; only `copilot-stream.ts` and the `server.ts` spawn/dispatch glue sit directly in `apps/daemon/src/`.
 
 ```
 apps/daemon/src/
@@ -370,11 +393,17 @@ apps/daemon/src/
 │   ├── invocation.ts       # generic argv/prompt invocation from a def's buildArgs
 │   ├── env.ts              # per-agent spawn env  · mcp.ts — external-MCP injection per def
 │   ├── models.ts           # live/fallback models · prompt-budget.ts — argv size guards
-│   └── local-profiles.ts   # user-defined local agent profiles merged into AGENT_DEFS
-├── claude-stream.ts        # eventParser="claude-stream": JSONL → UI events
-├── qoder-stream.ts         # eventParser="qoder-stream"   · copilot-stream.ts · json-event-stream.ts
-├── pi-rpc.ts               # pi's JSON-RPC transport
-├── acp.ts                  # shared ACP JSON-RPC transport (devin / kimi / kilo / kiro / vibe / hermes)
+│   ├── local-profiles.ts   # user-defined local agent profiles merged into AGENT_DEFS
+│   ├── claude-stream.ts    # streamFormat="claude-stream-json": stream-json JSONL → UI events
+│   ├── qoder-stream.ts     # streamFormat="qoder-stream-json": stream-json JSONL → UI events
+│   ├── json-event-stream.ts# streamFormat="json-event-stream": generic JSONL → UI events
+│   └── plain-stream.ts     # streamFormat="plain": scans stdout for <artifact> blocks → project files
+├── copilot-stream.ts       # streamFormat="copilot-stream-json" — the one stream parser that sits flat at src/
+├── agent-protocol/         # JSON-RPC transports, dispatched via agent-protocol/index.ts (attachAcpSession / attachPiRpcSession)
+│   ├── index.ts            # barrel: attachAcpSession / attachPiRpcSession / mapPiRpcEvent
+│   ├── acp/                # streamFormat="acp-json-rpc": shared ACP transport (devin / kimi / kilo / kiro / vibe / hermes)
+│   ├── pi-rpc/             # streamFormat="pi-rpc": pi's JSON-RPC-over-stdio transport
+│   └── core/               # shared JSON-line stream helpers
 └── server.ts               # spawn pipeline + stream dispatch: routes def.streamFormat/eventParser to a parser
 ```
 


### PR DESCRIPTION
## Why

`docs/agent-adapters.md` §1 still describes the adapter layer as a class-shaped
TypeScript interface:

```ts
interface AgentAdapter { detect(); capabilities(); run(); cancel(); resume?(); }
```

and states the implementation "lives in `apps/daemon/src/agents.ts`". Neither is
true of the shipped code, so anyone reading the doc to add a new agent CLI (the
doc's stated purpose) starts from the wrong mental model.

The actual design is **data-oriented, not class-oriented**:

- `apps/daemon/src/agents.ts` is a thin re-export barrel (`@ts-nocheck`) that
  defines nothing — it just surfaces `runtimes/*`.
- The real contract is the **`RuntimeAgentDef` object literal** in
  `apps/daemon/src/runtimes/types.ts` — one plain data object per CLI.
- Each CLI is a single file under `apps/daemon/src/runtimes/defs/*.ts`
  (`claude.ts`, `codex.ts`, `gemini.ts`, …).
- They are collected in the `BASE_AGENT_DEFS` array in
  `apps/daemon/src/runtimes/registry.ts`, guarded by a boot-time duplicate-`id`
  check.
- A **generic engine** (`detection.ts`, `capabilities.ts`, `launch.ts`,
  `invocation.ts`, `env.ts`, `mcp.ts`, `models.ts`, `prompt-budget.ts`, plus the
  stream dispatch in `server.ts`) reads those fields and drives every agent
  uniformly. There is no per-agent subclass and no `run()` / `cancel()` method.

Net: adding a CLI is **one def file + one line in `registry.ts`**, zero engine
edits — the opposite of what §1's "every adapter implements this interface"
implies.

## What changed

- **§1 "Adapter contract: a data spec, not a class"** — rewritten to describe
  `RuntimeAgentDef` (the data spec), the `defs/*` one-file-per-CLI layout, the
  `registry.ts` unique-id array, and the generic engine. Includes the abbreviated
  type, an illustrative def, and the real registry guard.
- **§11 "Adapter source layout"** — replaced the old per-adapter-module tree
  (`base.ts`, `claude-code/adapter.ts`, `api-fallback/tool-loop.ts`, …, which do
  not exist) with the actual `runtimes/` engine + `defs/*` + `*-stream.ts` /
  `acp.ts` / `pi-rpc.ts` + `server.ts` layout.
- Fixed the "lives in `agents.ts`" pointer to point at `runtimes/`.

Docs-only; no code changes. Every path and symbol was checked against the tree on
`main` (`runtimes/types.ts`, `runtimes/registry.ts` `BASE_AGENT_DEFS` + id guard,
`runtimes/defs/*.ts`, and the sibling stream parsers).

## Surface area

- [x] Docs only (`docs/agent-adapters.md`)
- [ ] No code, contracts, CLI, env vars, or i18n touched
