### PR TITLE
fix(daemon): ingest call-prefixed Codex images

### DIFF
--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -1046,7 +1046,7 @@ function codexImagegenMissingOutputError(threadDir: string, stdout: string): Err
     );
   }
   return new Error(
-    `Codex imagegen completed but did not write an ig_* image under ${threadDir}. Use an API-backed image provider or a Codex CLI build that writes generated_images output.${suffix}`,
+    `Codex imagegen completed but did not write an ig_* or call_* image under ${threadDir}. Use an API-backed image provider or a Codex CLI build that writes generated_images output.${suffix}`,
   );
 }
 
@@ -1065,9 +1065,13 @@ async function readCodexGeneratedImage(
     }
     throw err;
   }
+  const supportedImagePattern = /\.(?:png|jpe?g|webp)$/i;
   const match = entries
-    .filter((name) => /^ig_.*\.(?:png|jpe?g|webp)$/i.test(name))
-    .sort()[0];
+    .filter((name) => /^ig_/i.test(name) && supportedImagePattern.test(name))
+    .sort()[0]
+    ?? entries
+      .filter((name) => /^call_/i.test(name) && supportedImagePattern.test(name))
+      .sort()[0];
   if (!match) {
     throw codexImagegenMissingOutputError(threadDir, stdout);
   }

--- a/apps/daemon/tests/media/openai-compatible-providers.test.ts
+++ b/apps/daemon/tests/media/openai-compatible-providers.test.ts
@@ -121,6 +121,7 @@ describe('OpenAI-compatible media providers', () => {
       expectedConfigExcludes?: string;
       expectedArgsIncludes?: string;
       expectedArgsExcludes?: string;
+      outputFileName?: string;
     } = {},
   ) {
     const codexBin = path.join(root, `${threadId}.mjs`);
@@ -133,6 +134,7 @@ const expectedConfigIncludes = ${JSON.stringify(options.expectedConfigIncludes ?
 const expectedConfigExcludes = ${JSON.stringify(options.expectedConfigExcludes ?? '')};
 const expectedArgsIncludes = ${JSON.stringify(options.expectedArgsIncludes ?? '')};
 const expectedArgsExcludes = ${JSON.stringify(options.expectedArgsExcludes ?? '')};
+const outputFileName = ${JSON.stringify(options.outputFileName ?? 'ig_0001.png')};
 const args = process.argv.slice(2);
 const addDirIndex = args.indexOf('--add-dir');
 const generatedRoot = addDirIndex >= 0 ? args[addDirIndex + 1] : '';
@@ -162,7 +164,7 @@ process.stdin.on('end', () => {
   if (!stdin.includes('$imagegen') || !generatedRoot) process.exit(7);
   const outDir = path.join(generatedRoot, '${threadId}');
   mkdirSync(outDir, { recursive: true });
-  writeFileSync(path.join(outDir, 'ig_0001.png'), Buffer.from(pngBase64, 'base64'));
+  writeFileSync(path.join(outDir, outputFileName), Buffer.from(pngBase64, 'base64'));
   process.stdout.write(JSON.stringify({ type: 'thread.started', thread_id: '${threadId}' }) + '\\n');
 });
 `, 'utf8');
@@ -529,6 +531,52 @@ process.stdin.on('end', () => {
     expect(fetchMock).not.toHaveBeenCalled();
     const bytes = await readFile(path.join(projectsRoot, 'project-1', 'subscription-default.png'));
     expect(bytes.length).toBeGreaterThan(0);
+  });
+
+  it('ingests call-prefixed Codex subscription image output', async () => {
+    const generatedHome = path.join(root, 'call-prefixed-codex-home');
+    await writeCodexAuth(generatedHome, {
+      auth_mode: 'chatgpt',
+      OPENAI_API_KEY: null,
+    });
+    await installFakeCodex(generatedHome, 'call-prefixed-codex-thread', {
+      outputFileName: 'call_Er2KDML8Fof5QcOXdSovI85V.png',
+    });
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'gpt-image-2',
+      prompt: 'A compact purple cat icon',
+      output: 'call-prefixed.png',
+    });
+
+    expect(result.providerId).toBe('codex');
+    const bytes = await readFile(path.join(projectsRoot, 'project-1', 'call-prefixed.png'));
+    expect(bytes.length).toBeGreaterThan(0);
+  });
+
+  it('ignores unrelated image files in the Codex generated thread directory', async () => {
+    const generatedHome = path.join(root, 'unrelated-image-codex-home');
+    await writeCodexAuth(generatedHome, {
+      auth_mode: 'chatgpt',
+      OPENAI_API_KEY: null,
+    });
+    await installFakeCodex(generatedHome, 'unrelated-image-codex-thread', {
+      outputFileName: 'preview.png',
+    });
+
+    await expect(generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'gpt-image-2',
+      prompt: 'A compact purple cat icon',
+      output: 'unrelated-image.png',
+    })).rejects.toThrow(/did not write an ig_\* or call_\* image/i);
   });
 
   it('prefers the Codex subscription path for gpt-image-2 even when an OpenAI key is configured', async () => {


### PR DESCRIPTION
Fixes #5527

## Why

The P0 runtime report in #5527 showed Codex imagegen writing a valid `call_*.png` under the expected per-thread `generated_images` directory while the daemon still returned its generic “did not write an `ig_*` image” failure.

I reproduced that exact mismatch on current `main` at `d954bee`: the existing fake-Codex media harness wrote `call_Er2KDML8Fof5QcOXdSovI85V.png`, and `readCodexGeneratedImage()` rejected it at the `^ig_` candidate filter before `readFile()`.

## What users will see

Codex/OpenAI subscription image generation can complete successfully when current Codex writes a supported `call_*` image. Existing `ig_*` output remains the preferred match, and unrelated files such as `preview.png` remain excluded.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this changes daemon media-result ingestion and has no UI changes.

## Bug fix verification

- Test path: `apps/daemon/tests/media/openai-compatible-providers.test.ts`
- RED on `d954bee`: the focused `call_Er2KDML8Fof5QcOXdSovI85V.png` case failed with `Codex imagegen completed but did not write an ig_* image` from `readCodexGeneratedImage()`.
- GREEN on this branch: the fake Codex `call_*` output is ingested, existing `ig_*` cases remain green, preview-only behavior remains green, and an unrelated `preview.png` is still rejected.

## Validation

- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/media/openai-compatible-providers.test.ts` — 19/19
- `pnpm --filter @open-design/daemon build`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard` — 78/78
- `git diff --check`

All authoritative commands above were rerun in the isolated worktree on Node `v24.18.0`. A broad local daemon-suite attempt exceeded the 600-second runner limit after unrelated local Node ABI/AMR environment failures, so I am not claiming a full daemon-suite pass here; the changed media scope and repository-required gates above are green.
