### PR TITLE
fix(daemon): reject a second concurrent run on one conversation (409)

### DIFF
--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -456,6 +456,19 @@ function toOdNativeEvent(record: RunEventRecord): OdNativeEvent | null {
 export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
   const { db, design } = ctx;
   const { createSseResponse, sendApiError } = ctx.http;
+
+  // A conversation may drive exactly one native agent session at a time; a
+  // second concurrent run on the same conversationId forks the single
+  // (conversation_id, agent_id) agent_sessions row (#5490). Called
+  // synchronously immediately before design.runs.create so the winner's run is
+  // already registered when the loser checks.
+  const conversationHasActiveRun = (conversationId: unknown): boolean =>
+    typeof conversationId === 'string' &&
+    conversationId.length > 0 &&
+    design.runs
+      .list({ conversationId })
+      .some((r) => !design.runs.isTerminal(r.status));
+
   const { PROJECTS_DIR, RUNTIME_DATA_DIR } = ctx.paths;
   const { detectAgents, getAgentDef } = ctx.agents;
   const { startChatRun } = ctx.chat;
@@ -668,6 +681,22 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       meta.sessionMode === 'chat' || meta.sessionMode === 'design' || meta.sessionMode === 'plan'
         ? normalizeConversationSessionMode(meta.sessionMode)
         : normalizeConversationSessionMode(conversationSession?.sessionMode);
+    // Reject a second concurrent run on the same conversation (#5490). Two runs
+    // racing on one conversationId both resolve as create-turns and fork the
+    // single agent_sessions row (last-writer-wins), silently orphaning one
+    // turn's native session. The web UI already serializes via the disabled send
+    // button; this guards the HTTP / od CLI / embedding-agent paths. The
+    // check-then-create below is synchronous (no await between), so the run the
+    // winner registers is visible to the loser's check. 409 lets the caller
+    // retry once the active run finishes.
+    if (conversationHasActiveRun(meta.conversationId)) {
+      return sendApiError(
+        res,
+        409,
+        'CONVERSATION_BUSY',
+        'another run is already active on this conversation; retry after it finishes',
+      );
+    }
     const run = design.runs.create(meta);
     try {
       pinAssistantMessageOnRunCreate(db, run);
@@ -1465,6 +1494,16 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       toolBundle: toolBundle.bundle,
       ...(chatProject?.metadata ? { projectMetadata: chatProject.metadata } : {}),
     };
+    // Same per-conversation concurrency guard as POST /api/runs (#5490): a second
+    // concurrent run on one conversation would fork the agent_sessions row.
+    if (conversationHasActiveRun(requestBody.conversationId)) {
+      return sendApiError(
+        res,
+        409,
+        'CONVERSATION_BUSY',
+        'another run is already active on this conversation; retry after it finishes',
+      );
+    }
     const run = design.runs.create(meta);
     design.runs.stream(run, req, res);
     reconcileAssistantMessageOnRunEnd(db, design.runs, run);

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -469,13 +469,20 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
   // upsert), but the run isn't created until several awaits later — so a plain
   // pre-await check would let two true-concurrent submits both pass. The claim
   // bridges that window: it is added synchronously (no await between the check
-  // and the add), so the race loser sees it. Released when the response ends.
+  // and the add), so the race loser sees it.
+  //
+  // Ownership follows HANDLER execution, not response lifetime. A client
+  // disconnect does NOT cancel the async handler, so it still runs on toward
+  // design.runs.create; releasing on socket close would free the id mid-flight
+  // and let a timeout/retry be admitted and fork the run (#5490). So the claim
+  // returns an explicit release the caller invokes in a finally — after create
+  // has synchronously registered the run, or on any pre-create exit.
   const conversationRunClaims = new Set<string>();
   const claimConversationOrReject = (
-    conversationId: unknown,
+    conversationId: string | null,
     res: ApiResponse,
-  ): boolean => {
-    if (typeof conversationId !== 'string' || !conversationId) return true;
+  ): (() => void) | null => {
+    if (!conversationId) return () => {};
     if (conversationRunClaims.has(conversationId) || conversationHasActiveRun(conversationId)) {
       sendApiError(
         res,
@@ -483,13 +490,15 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         'CONVERSATION_BUSY',
         'another run is already active on this conversation; retry after it finishes',
       );
-      return false;
+      return null;
     }
     conversationRunClaims.add(conversationId);
-    const release = () => conversationRunClaims.delete(conversationId);
-    res.on('finish', release);
-    res.on('close', release);
-    return true;
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      conversationRunClaims.delete(conversationId);
+    };
   };
 
   // Resolve — WITHOUT creating anything — the project's default conversation: the
@@ -588,161 +597,175 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
     // past before the run (created several awaits below) exists. We resolve the
     // canonical conversation first so a project-only MCP/SDK request claims the
     // same default conversation the fallback below will bind it to.
-    if (!claimConversationOrReject(canonicalConversationIdForRequest(requestBody), res)) return;
+    const releaseClaim = claimConversationOrReject(canonicalConversationIdForRequest(requestBody), res);
+    if (!releaseClaim) return;
+    // Hold the reservation for the entire handler execution (see
+    // claimConversationOrReject): the finally releases only after create has
+    // synchronously registered the run — where conversationHasActiveRun takes
+    // over — or on any pre-create early return/throw. A disconnected retry
+    // therefore still sees the claim and cannot fork the run (#5490).
+    let run: ReturnType<typeof design.runs.create> | null = null;
+    // Declared before the try so the post-create response path (which stays
+    // outside the reservation) can still read them.
     let resolvedSnapshot = null;
-    if (typeof requestBody.projectId === 'string' && requestBody.projectId) {
-      let registryView: Parameters<typeof resolvePluginSnapshot>[0]['registry'];
-      try {
-        registryView = await loadPluginRegistryView();
-      } catch (err) {
-        return res.status(500).json({ error: String(err) });
-      }
-      const explicitPlugin =
-        requestBody.pluginId || requestBody.appliedPluginSnapshotId;
-      let runResolveBody: JsonRecord = requestBody;
-      if (!explicitPlugin) {
-        const projectRow = toProjectRecord(getProject(db, requestBody.projectId));
-        const hasPin =
-          typeof projectRow?.appliedPluginSnapshotId === 'string'
-          && projectRow.appliedPluginSnapshotId.length > 0;
-        if (!hasPin) {
-          const fallbackPluginId = defaultScenarioPluginIdForProjectMetadata(
-            toScenarioProjectMetadata(projectRow?.metadata),
-          );
-          if (fallbackPluginId && getInstalledPlugin(db, fallbackPluginId)) {
-            runResolveBody = { ...requestBody, pluginId: fallbackPluginId };
-          }
-        }
-      }
-      const resolved = resolvePluginSnapshot({
-        db,
-        body: runResolveBody,
-        projectId: requestBody.projectId,
-        conversationId: typeof requestBody.conversationId === 'string'
-          ? requestBody.conversationId
-          : null,
-        registry: registryView,
-        connectorProbe: buildConnectorProbe(connectorService),
-      });
-      if (resolved && !resolved.ok) {
-        if (!explicitPlugin) {
-          console.warn(
-            `[plugins] default-scenario fallback skipped for run on project ${requestBody.projectId}: ${resolved.body?.error?.code ?? 'unknown'}`,
-          );
-        } else {
-          return res.status(resolved.status).json(resolved.body);
-        }
-      } else {
-        resolvedSnapshot = resolved;
-      }
-    }
     const meta: RunCreateMeta = {
       ...requestBody,
       mediaExecution: mediaExecution.policy,
       toolBundle: toolBundle.bundle,
     };
-    if (resolvedSnapshot?.ok) {
-      meta.appliedPluginSnapshotId = resolvedSnapshot.snapshotId;
-      if (!meta.pluginId) meta.pluginId = resolvedSnapshot.snapshot.pluginId;
-      if (typeof meta.message !== 'string' || meta.message.trim().length === 0) {
-        const renderedQuery = renderPluginBriefTemplate(
-          resolvedSnapshot.snapshot.query ?? '',
-          resolvedSnapshot.snapshot.inputs,
-        ).trim();
-        if (renderedQuery.length > 0) meta.message = renderedQuery;
-      }
-    }
-    let runProject: ProjectRecord | null = null;
-    if (typeof meta.projectId === 'string' && meta.projectId) {
-      try {
-        runProject = toProjectRecord(getProject(db, meta.projectId));
-        assertSandboxProjectRootAvailable(runProject?.metadata);
-      } catch (err) {
-        if (err instanceof SandboxImportedProjectError) {
-          return sendApiError(res, 400, 'BAD_REQUEST', err.message);
+    try {
+      if (typeof requestBody.projectId === 'string' && requestBody.projectId) {
+        let registryView: Parameters<typeof resolvePluginSnapshot>[0]['registry'];
+        try {
+          registryView = await loadPluginRegistryView();
+        } catch (err) {
+          return res.status(500).json({ error: String(err) });
         }
-        throw err;
-      }
-    }
-    if (typeof meta.agentId !== 'string' || !meta.agentId) {
-      try {
-        const appCfg = await readAppConfig(RUNTIME_DATA_DIR);
-        const cfgAgent = typeof appCfg.agentId === 'string' && appCfg.agentId
-          ? appCfg.agentId
-          : null;
-        const agents = await detectAgents(
-          toJsonRecord(appCfg.agentCliEnv),
-        ).catch((): DetectedAgent[] => []);
-        const cfgAgentAvailable = cfgAgent
-          ? agents.some((agent) => agent.id === cfgAgent && agent.available)
-          : false;
-        if (cfgAgent && cfgAgentAvailable) {
-          meta.agentId = cfgAgent;
+        const explicitPlugin =
+          requestBody.pluginId || requestBody.appliedPluginSnapshotId;
+        let runResolveBody: JsonRecord = requestBody;
+        if (!explicitPlugin) {
+          const projectRow = toProjectRecord(getProject(db, requestBody.projectId));
+          const hasPin =
+            typeof projectRow?.appliedPluginSnapshotId === 'string'
+            && projectRow.appliedPluginSnapshotId.length > 0;
+          if (!hasPin) {
+            const fallbackPluginId = defaultScenarioPluginIdForProjectMetadata(
+              toScenarioProjectMetadata(projectRow?.metadata),
+            );
+            if (fallbackPluginId && getInstalledPlugin(db, fallbackPluginId)) {
+              runResolveBody = { ...requestBody, pluginId: fallbackPluginId };
+            }
+          }
+        }
+        const resolved = resolvePluginSnapshot({
+          db,
+          body: runResolveBody,
+          projectId: requestBody.projectId,
+          conversationId: typeof requestBody.conversationId === 'string'
+            ? requestBody.conversationId
+            : null,
+          registry: registryView,
+          connectorProbe: buildConnectorProbe(connectorService),
+        });
+        if (resolved && !resolved.ok) {
+          if (!explicitPlugin) {
+            console.warn(
+              `[plugins] default-scenario fallback skipped for run on project ${requestBody.projectId}: ${resolved.body?.error?.code ?? 'unknown'}`,
+            );
+          } else {
+            return res.status(resolved.status).json(resolved.body);
+          }
         } else {
-          const firstAvailable = agents.find((agent) => agent.available)?.id ?? null;
-          if (firstAvailable) meta.agentId = firstAvailable;
+          resolvedSnapshot = resolved;
         }
-      } catch (err) {
-        console.warn('[runs] agent id fallback failed', err);
       }
-    }
-    const toolBundleSupport = validateRunToolBundleForAgent(
-      toolBundle.bundle,
-      typeof meta.agentId === 'string' ? getAgentDef(meta.agentId) : null,
-      {
-        deliveryTarget: runToolBundleDeliveryTargetForProject(
-          meta.projectId,
-          runProject?.metadata,
-        ),
-      },
-    );
-    if (!toolBundleSupport.ok) {
-      return sendApiError(res, 400, 'BAD_REQUEST', toolBundleSupport.message);
-    }
-    if (runProject?.metadata) {
-      meta.projectMetadata = runProject.metadata;
-    }
-    if (
-      typeof meta.projectId === 'string' &&
-      meta.projectId &&
-      (typeof meta.conversationId !== 'string' || !meta.conversationId)
-    ) {
-      try {
-        // Same resolver the pre-await claim used, so the run binds to exactly
-        // the conversation that was reserved for it (#5490).
-        const defaultConvId = resolveDefaultConversationId(meta.projectId);
-        if (defaultConvId) {
-          meta.conversationId = defaultConvId;
-          if (typeof meta.assistantMessageId !== 'string' || !meta.assistantMessageId) {
-            meta.assistantMessageId = randomUUID();
-          }
-          const promptForUserMessage =
-            typeof meta.message === 'string' && meta.message.trim().length > 0
-              ? meta.message
-              : null;
-          if (promptForUserMessage) {
-            upsertMessage(db, defaultConvId, {
-              id: randomUUID(),
-              role: 'user',
-              content: promptForUserMessage,
-              startedAt: Date.now(),
-              endedAt: Date.now(),
-            });
-          }
+      if (resolvedSnapshot?.ok) {
+        meta.appliedPluginSnapshotId = resolvedSnapshot.snapshotId;
+        if (!meta.pluginId) meta.pluginId = resolvedSnapshot.snapshot.pluginId;
+        if (typeof meta.message !== 'string' || meta.message.trim().length === 0) {
+          const renderedQuery = renderPluginBriefTemplate(
+            resolvedSnapshot.snapshot.query ?? '',
+            resolvedSnapshot.snapshot.inputs,
+          ).trim();
+          if (renderedQuery.length > 0) meta.message = renderedQuery;
         }
-      } catch (err) {
-        console.warn('[runs] mcp conversation fallback failed', err);
       }
+      let runProject: ProjectRecord | null = null;
+      if (typeof meta.projectId === 'string' && meta.projectId) {
+        try {
+          runProject = toProjectRecord(getProject(db, meta.projectId));
+          assertSandboxProjectRootAvailable(runProject?.metadata);
+        } catch (err) {
+          if (err instanceof SandboxImportedProjectError) {
+            return sendApiError(res, 400, 'BAD_REQUEST', err.message);
+          }
+          throw err;
+        }
+      }
+      if (typeof meta.agentId !== 'string' || !meta.agentId) {
+        try {
+          const appCfg = await readAppConfig(RUNTIME_DATA_DIR);
+          const cfgAgent = typeof appCfg.agentId === 'string' && appCfg.agentId
+            ? appCfg.agentId
+            : null;
+          const agents = await detectAgents(
+            toJsonRecord(appCfg.agentCliEnv),
+          ).catch((): DetectedAgent[] => []);
+          const cfgAgentAvailable = cfgAgent
+            ? agents.some((agent) => agent.id === cfgAgent && agent.available)
+            : false;
+          if (cfgAgent && cfgAgentAvailable) {
+            meta.agentId = cfgAgent;
+          } else {
+            const firstAvailable = agents.find((agent) => agent.available)?.id ?? null;
+            if (firstAvailable) meta.agentId = firstAvailable;
+          }
+        } catch (err) {
+          console.warn('[runs] agent id fallback failed', err);
+        }
+      }
+      const toolBundleSupport = validateRunToolBundleForAgent(
+        toolBundle.bundle,
+        typeof meta.agentId === 'string' ? getAgentDef(meta.agentId) : null,
+        {
+          deliveryTarget: runToolBundleDeliveryTargetForProject(
+            meta.projectId,
+            runProject?.metadata,
+          ),
+        },
+      );
+      if (!toolBundleSupport.ok) {
+        return sendApiError(res, 400, 'BAD_REQUEST', toolBundleSupport.message);
+      }
+      if (runProject?.metadata) {
+        meta.projectMetadata = runProject.metadata;
+      }
+      if (
+        typeof meta.projectId === 'string' &&
+        meta.projectId &&
+        (typeof meta.conversationId !== 'string' || !meta.conversationId)
+      ) {
+        try {
+          // Same resolver the pre-await claim used, so the run binds to exactly
+          // the conversation that was reserved for it (#5490).
+          const defaultConvId = resolveDefaultConversationId(meta.projectId);
+          if (defaultConvId) {
+            meta.conversationId = defaultConvId;
+            if (typeof meta.assistantMessageId !== 'string' || !meta.assistantMessageId) {
+              meta.assistantMessageId = randomUUID();
+            }
+            const promptForUserMessage =
+              typeof meta.message === 'string' && meta.message.trim().length > 0
+                ? meta.message
+                : null;
+            if (promptForUserMessage) {
+              upsertMessage(db, defaultConvId, {
+                id: randomUUID(),
+                role: 'user',
+                content: promptForUserMessage,
+                startedAt: Date.now(),
+                endedAt: Date.now(),
+              });
+            }
+          }
+        } catch (err) {
+          console.warn('[runs] mcp conversation fallback failed', err);
+        }
+      }
+      const conversationSession =
+        typeof meta.conversationId === 'string' && meta.conversationId
+          ? getConversation(db, meta.conversationId)
+          : null;
+      meta.sessionMode =
+        meta.sessionMode === 'chat' || meta.sessionMode === 'design' || meta.sessionMode === 'plan'
+          ? normalizeConversationSessionMode(meta.sessionMode)
+          : normalizeConversationSessionMode(conversationSession?.sessionMode);
+      run = design.runs.create(meta);
+    } finally {
+      releaseClaim();
     }
-    const conversationSession =
-      typeof meta.conversationId === 'string' && meta.conversationId
-        ? getConversation(db, meta.conversationId)
-        : null;
-    meta.sessionMode =
-      meta.sessionMode === 'chat' || meta.sessionMode === 'design' || meta.sessionMode === 'plan'
-        ? normalizeConversationSessionMode(meta.sessionMode)
-        : normalizeConversationSessionMode(conversationSession?.sessionMode);
-    const run = design.runs.create(meta);
+    if (!run) return;
     try {
       pinAssistantMessageOnRunCreate(db, run);
     } catch (err) {
@@ -1541,12 +1564,22 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
     };
     // Same per-conversation concurrency guard as POST /api/runs (#5490): a second
     // concurrent run on one conversation would fork the agent_sessions row.
-    // /api/chat has no durable writes before this point, so the claim + the
-    // synchronous create below are enough.
-    if (!claimConversationOrReject(requestBody.conversationId, res)) return;
-    const run = design.runs.create(meta);
-    design.runs.stream(run, req, res);
-    reconcileAssistantMessageOnRunEnd(db, design.runs, run);
-    design.runs.start(run, () => startChatRun(meta, run));
+    // /api/chat has no durable writes and no awaits before create, so the claim
+    // and the synchronous create are adjacent; the finally releases once create
+    // has registered the run (conversationHasActiveRun covers it thereafter).
+    const chatConversationId =
+      typeof requestBody.conversationId === 'string' && requestBody.conversationId
+        ? requestBody.conversationId
+        : null;
+    const releaseClaim = claimConversationOrReject(chatConversationId, res);
+    if (!releaseClaim) return;
+    try {
+      const run = design.runs.create(meta);
+      design.runs.stream(run, req, res);
+      reconcileAssistantMessageOnRunEnd(db, design.runs, run);
+      design.runs.start(run, () => startChatRun(meta, run));
+    } finally {
+      releaseClaim();
+    }
   });
 }

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -459,15 +459,38 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
 
   // A conversation may drive exactly one native agent session at a time; a
   // second concurrent run on the same conversationId forks the single
-  // (conversation_id, agent_id) agent_sessions row (#5490). Called
-  // synchronously immediately before design.runs.create so the winner's run is
-  // already registered when the loser checks.
-  const conversationHasActiveRun = (conversationId: unknown): boolean =>
-    typeof conversationId === 'string' &&
-    conversationId.length > 0 &&
-    design.runs
-      .list({ conversationId })
-      .some((r) => !design.runs.isTerminal(r.status));
+  // (conversation_id, agent_id) agent_sessions row (#5490).
+  const conversationHasActiveRun = (conversationId: string): boolean =>
+    design.runs.list({ conversationId }).some((r) => !design.runs.isTerminal(r.status));
+
+  // In-flight conversation claims, held synchronously from the busy-check until
+  // the run is created (after which conversationHasActiveRun covers it). We must
+  // reject BEFORE any durable preparation (plugin-snapshot pinning, message
+  // upsert), but the run isn't created until several awaits later — so a plain
+  // pre-await check would let two true-concurrent submits both pass. The claim
+  // bridges that window: it is added synchronously (no await between the check
+  // and the add), so the race loser sees it. Released when the response ends.
+  const conversationRunClaims = new Set<string>();
+  const claimConversationOrReject = (
+    conversationId: unknown,
+    res: ApiResponse,
+  ): boolean => {
+    if (typeof conversationId !== 'string' || !conversationId) return true;
+    if (conversationRunClaims.has(conversationId) || conversationHasActiveRun(conversationId)) {
+      sendApiError(
+        res,
+        409,
+        'CONVERSATION_BUSY',
+        'another run is already active on this conversation; retry after it finishes',
+      );
+      return false;
+    }
+    conversationRunClaims.add(conversationId);
+    const release = () => conversationRunClaims.delete(conversationId);
+    res.on('finish', release);
+    res.on('close', release);
+    return true;
+  };
 
   const { PROJECTS_DIR, RUNTIME_DATA_DIR } = ctx.paths;
   const { detectAgents, getAgentDef } = ctx.agents;
@@ -520,6 +543,12 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
     if (!toolBundle.ok) {
       return sendApiError(res, 400, 'BAD_REQUEST', toolBundle.message);
     }
+    // Reject a second concurrent run on the same conversation (#5490) BEFORE any
+    // persistent preparation (plugin-snapshot pinning, message upsert, run
+    // create), so a rejected request leaves no durable side effects. The claim
+    // is taken synchronously here so two true-concurrent submits can't both slip
+    // past before the run (created several awaits below) exists.
+    if (!claimConversationOrReject(requestBody.conversationId, res)) return;
     let resolvedSnapshot = null;
     if (typeof requestBody.projectId === 'string' && requestBody.projectId) {
       let registryView: Parameters<typeof resolvePluginSnapshot>[0]['registry'];
@@ -681,22 +710,6 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       meta.sessionMode === 'chat' || meta.sessionMode === 'design' || meta.sessionMode === 'plan'
         ? normalizeConversationSessionMode(meta.sessionMode)
         : normalizeConversationSessionMode(conversationSession?.sessionMode);
-    // Reject a second concurrent run on the same conversation (#5490). Two runs
-    // racing on one conversationId both resolve as create-turns and fork the
-    // single agent_sessions row (last-writer-wins), silently orphaning one
-    // turn's native session. The web UI already serializes via the disabled send
-    // button; this guards the HTTP / od CLI / embedding-agent paths. The
-    // check-then-create below is synchronous (no await between), so the run the
-    // winner registers is visible to the loser's check. 409 lets the caller
-    // retry once the active run finishes.
-    if (conversationHasActiveRun(meta.conversationId)) {
-      return sendApiError(
-        res,
-        409,
-        'CONVERSATION_BUSY',
-        'another run is already active on this conversation; retry after it finishes',
-      );
-    }
     const run = design.runs.create(meta);
     try {
       pinAssistantMessageOnRunCreate(db, run);
@@ -1496,14 +1509,9 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
     };
     // Same per-conversation concurrency guard as POST /api/runs (#5490): a second
     // concurrent run on one conversation would fork the agent_sessions row.
-    if (conversationHasActiveRun(requestBody.conversationId)) {
-      return sendApiError(
-        res,
-        409,
-        'CONVERSATION_BUSY',
-        'another run is already active on this conversation; retry after it finishes',
-      );
-    }
+    // /api/chat has no durable writes before this point, so the claim + the
+    // synchronous create below are enough.
+    if (!claimConversationOrReject(requestBody.conversationId, res)) return;
     const run = design.runs.create(meta);
     design.runs.stream(run, req, res);
     reconcileAssistantMessageOnRunEnd(db, design.runs, run);

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -492,6 +492,44 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
     return true;
   };
 
+  // Resolve — WITHOUT creating anything — the project's default conversation: the
+  // earliest one (createdAt, id tiebreak). Read-only and deterministic, so the
+  // pre-await claim below and the MCP/SDK fallback later in the handler agree on
+  // one id. Returns null if the project has no conversation yet.
+  const resolveDefaultConversationId = (projectId: string): string | null => {
+    try {
+      const convs = toConversationRecords(listConversations(db, projectId));
+      if (convs.length === 0) return null;
+      const earliest = [...convs].sort((a, b) => {
+        const aCreated = Number(a?.createdAt);
+        const bCreated = Number(b?.createdAt);
+        if (Number.isFinite(aCreated) && Number.isFinite(bCreated) && aCreated !== bCreated) {
+          return aCreated - bCreated;
+        }
+        return String(a?.id ?? '').localeCompare(String(b?.id ?? ''));
+      })[0];
+      return earliest && typeof earliest.id === 'string' && earliest.id ? earliest.id : null;
+    } catch (err) {
+      console.warn('[runs] default conversation resolution failed', err);
+      return null;
+    }
+  };
+
+  // The canonical conversation a /api/runs request will bind to: an explicit
+  // conversationId, or (for MCP/SDK project-only requests — McpRunCreateRequest
+  // requires only projectId) the project's default conversation. Claiming this
+  // up front closes the concurrent-fork window (#5490) on that path too, which a
+  // check on the raw requestBody.conversationId (undefined there) would miss.
+  const canonicalConversationIdForRequest = (requestBody: JsonRecord): string | null => {
+    if (typeof requestBody.conversationId === 'string' && requestBody.conversationId) {
+      return requestBody.conversationId;
+    }
+    if (typeof requestBody.projectId === 'string' && requestBody.projectId) {
+      return resolveDefaultConversationId(requestBody.projectId);
+    }
+    return null;
+  };
+
   const { PROJECTS_DIR, RUNTIME_DATA_DIR } = ctx.paths;
   const { detectAgents, getAgentDef } = ctx.agents;
   const { startChatRun } = ctx.chat;
@@ -547,8 +585,10 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
     // persistent preparation (plugin-snapshot pinning, message upsert, run
     // create), so a rejected request leaves no durable side effects. The claim
     // is taken synchronously here so two true-concurrent submits can't both slip
-    // past before the run (created several awaits below) exists.
-    if (!claimConversationOrReject(requestBody.conversationId, res)) return;
+    // past before the run (created several awaits below) exists. We resolve the
+    // canonical conversation first so a project-only MCP/SDK request claims the
+    // same default conversation the fallback below will bind it to.
+    if (!claimConversationOrReject(canonicalConversationIdForRequest(requestBody), res)) return;
     let resolvedSnapshot = null;
     if (typeof requestBody.projectId === 'string' && requestBody.projectId) {
       let registryView: Parameters<typeof resolvePluginSnapshot>[0]['registry'];
@@ -668,19 +708,11 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       (typeof meta.conversationId !== 'string' || !meta.conversationId)
     ) {
       try {
-        const convs = toConversationRecords(listConversations(db, meta.projectId));
-        const defaultConv = convs.length > 0
-          ? [...convs].sort((a, b) => {
-              const aCreated = Number(a?.createdAt);
-              const bCreated = Number(b?.createdAt);
-              if (Number.isFinite(aCreated) && Number.isFinite(bCreated) && aCreated !== bCreated) {
-                return aCreated - bCreated;
-              }
-              return String(a?.id ?? '').localeCompare(String(b?.id ?? ''));
-            })[0]
-          : null;
-        if (defaultConv && typeof defaultConv.id === 'string' && defaultConv.id) {
-          meta.conversationId = defaultConv.id;
+        // Same resolver the pre-await claim used, so the run binds to exactly
+        // the conversation that was reserved for it (#5490).
+        const defaultConvId = resolveDefaultConversationId(meta.projectId);
+        if (defaultConvId) {
+          meta.conversationId = defaultConvId;
           if (typeof meta.assistantMessageId !== 'string' || !meta.assistantMessageId) {
             meta.assistantMessageId = randomUUID();
           }
@@ -689,7 +721,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
               ? meta.message
               : null;
           if (promptForUserMessage) {
-            upsertMessage(db, defaultConv.id, {
+            upsertMessage(db, defaultConvId, {
               id: randomUUID(),
               role: 'user',
               content: promptForUserMessage,

--- a/apps/daemon/tests/concurrent-run-conversation-busy.test.ts
+++ b/apps/daemon/tests/concurrent-run-conversation-busy.test.ts
@@ -206,12 +206,70 @@ describe('concurrent run per-conversation guard (#5490)', () => {
     const afterUserMessages = await userMessageCount(started.url, project);
     expect(afterUserMessages - beforeUserMessages).toBe(1);
   });
+
+  it('holds the reservation across a client disconnect during async prep (retry cannot fork)', async () => {
+    // The claim must follow HANDLER execution, not response lifetime. A run
+    // handler does real async work before design.runs.create — plugin snapshot
+    // resolution, config reads, agent detection. A client disconnect does NOT
+    // cancel that handler; it runs on to create the run. If the claim were
+    // released on the response's 'close', a normal timeout/retry would then see
+    // neither a claim nor an active run and be admitted, and both handlers would
+    // reach create — the exact native-session fork this PR prevents.
+    //
+    // Here the first request omits agentId, so the handler blocks in
+    // detectAgents on a `--version` probe stalled ~1.2s; its socket is aborted
+    // mid-probe. The retry on the same default conversation must still be
+    // refused (409), and only the first request's single run/session survives.
+    workDir = await mkdtemp(path.join(os.tmpdir(), 'od-concurrent-abort-'));
+    const capturePath = path.join(workDir, 'spawn-capture.jsonl');
+    const fakeClaude = await writeSessionCapturingClaude(workDir, 'claude-capture', capturePath, 1200);
+
+    delete process.env.POSTHOG_KEY;
+    delete process.env.POSTHOG_HOST;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_BASE_URL;
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    process.env.OD_TEST_SESSION_CAPTURE = capturePath;
+
+    started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'claude',
+      agentCliEnv: { claude: { CLAUDE_BIN: fakeClaude } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const project = await createProject(started.url, 'abort');
+
+    // Fire the first request and abort it 500ms in — while it is still blocked in
+    // the version probe holding the claim.
+    const abortedFirst = startProjectOnlyRunAborted(started.url, project.projectId, 500);
+
+    // After the abort, retry the same conversation (this one carries agentId so
+    // it does not itself block; it should hit the claim and be refused).
+    await new Promise((resolve) => setTimeout(resolve, 650));
+    const retry = await startProjectOnlyRunRaw(started.url, project.projectId);
+    expect(retry.status, `retry must be refused while the disconnected handler still owns the conversation, got ${retry.status}`)
+      .toBe(409);
+    expect(retry.code).toBe('CONVERSATION_BUSY');
+    expect(await abortedFirst).toBe('aborted');
+
+    // The disconnected handler runs on and creates exactly one run; the retry
+    // created none. Only one native session ever materializes — no fork.
+    await waitForCaptureCount(capturePath, project.projectId, 1);
+    const captures = await readCapturesForProject(capturePath, project.projectId);
+    const sessions = new Set(captures.map((c) => c.sessionId).filter(Boolean));
+    expect(captures.length).toBe(1);
+    expect(sessions.size).toBe(1);
+  });
 });
 
 async function writeSessionCapturingClaude(
   dir: string,
   name: string,
   capturePath: string,
+  versionDelayMs = 0,
 ): Promise<string> {
   const bin = path.join(dir, name);
   // Records the native session identity the daemon spawned it with (--resume
@@ -219,41 +277,50 @@ async function writeSessionCapturingClaude(
   // then emits a clean successful stream-json turn and holds ~600ms before exit
   // so two racing runs are BOTH still resolving as create-turns (neither has
   // persisted its session yet). Synchronous writes so nothing is lost on exit.
+  //
+  // versionDelayMs > 0 stalls the `--version` detection probe by that long: the
+  // run handler blocks inside detectAgents (a real pre-create async step) while
+  // still holding its conversation claim, so a test can disconnect that request
+  // mid-probe and prove the claim is not released early.
   await writeFile(bin, `#!/usr/bin/env node
 const fs = require('node:fs');
 const argv = process.argv.slice(2);
 function w(s) { fs.writeSync(1, s); }
-if (argv.includes('--version')) { w('claude-code 1.0.0-session-capture\\n'); process.exit(0); }
-if (argv.includes('--help')) { w('Usage: claude -p [--include-partial-messages] [--add-dir DIR]\\n'); process.exit(0); }
+if (argv.includes('--version')) {
+  const emit = () => { w('claude-code 1.0.0-session-capture\\n'); process.exit(0); };
+  if (${versionDelayMs} > 0) setTimeout(emit, ${versionDelayMs}); else emit();
+} else if (argv.includes('--help')) {
+  w('Usage: claude -p [--include-partial-messages] [--add-dir DIR]\\n'); process.exit(0);
+} else {
+  function argValue(flag) {
+    const i = argv.indexOf(flag);
+    return i >= 0 && i + 1 < argv.length ? argv[i + 1] : null;
+  }
+  const resumeId = argValue('--resume');
+  const newId = argValue('--session-id');
+  const mode = resumeId ? 'resume' : newId ? 'create' : 'none';
+  const sessionId = resumeId || newId || null;
+  try {
+    fs.appendFileSync(
+      ${JSON.stringify(capturePath)},
+      JSON.stringify({ mode, sessionId, cwd: process.cwd() }) + '\\n',
+    );
+  } catch {}
 
-function argValue(flag) {
-  const i = argv.indexOf(flag);
-  return i >= 0 && i + 1 < argv.length ? argv[i + 1] : null;
+  const echo = sessionId || 'sess-unknown';
+  w(JSON.stringify({ type: 'system', subtype: 'init', model: 'm', session_id: echo }) + '\\n');
+  w(JSON.stringify({
+    type: 'assistant',
+    message: { id: 'msg-' + echo.slice(0, 8), content: [{ type: 'text', text: 'done' }], stop_reason: 'end_turn' },
+  }) + '\\n');
+  w(JSON.stringify({
+    type: 'result', subtype: 'success', is_error: false,
+    session_id: echo, num_turns: 1, duration_api_ms: 10, total_cost_usd: 0,
+  }) + '\\n');
+  // Hold both racing runs alive as create-turns long enough that neither has
+  // persisted its session before the other resolves.
+  setTimeout(() => process.exit(0), 600);
 }
-const resumeId = argValue('--resume');
-const newId = argValue('--session-id');
-const mode = resumeId ? 'resume' : newId ? 'create' : 'none';
-const sessionId = resumeId || newId || null;
-try {
-  fs.appendFileSync(
-    ${JSON.stringify(capturePath)},
-    JSON.stringify({ mode, sessionId, cwd: process.cwd() }) + '\\n',
-  );
-} catch {}
-
-const echo = sessionId || 'sess-unknown';
-w(JSON.stringify({ type: 'system', subtype: 'init', model: 'm', session_id: echo }) + '\\n');
-w(JSON.stringify({
-  type: 'assistant',
-  message: { id: 'msg-' + echo.slice(0, 8), content: [{ type: 'text', text: 'done' }], stop_reason: 'end_turn' },
-}) + '\\n');
-w(JSON.stringify({
-  type: 'result', subtype: 'success', is_error: false,
-  session_id: echo, num_turns: 1, duration_api_ms: 10, total_cost_usd: 0,
-}) + '\\n');
-// Hold both racing runs alive as create-turns long enough that neither has
-// persisted its session before the other resolves.
-setTimeout(() => process.exit(0), 600);
 `, 'utf8');
   await chmod(bin, 0o755);
   return bin;
@@ -393,6 +460,51 @@ async function startProjectOnlyRunRaw(
   return code === undefined
     ? { status: runResponse.status }
     : { status: runResponse.status, code };
+}
+
+// Fires a project-only /api/runs with NO agentId, so the handler enters the
+// slow detectAgents `--version` probe (a real pre-create async step) while
+// holding the conversation claim, then aborts the socket mid-probe. Resolves to
+// 'aborted' once the client connection is torn down; the daemon handler keeps
+// running regardless (a disconnect does not cancel it).
+async function startProjectOnlyRunAborted(
+  url: string,
+  projectId: string,
+  abortAfterMs: number,
+): Promise<string> {
+  const controller = new AbortController();
+  const pending = fetch(`${url}/api/runs`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-od-analytics-device-id': 'concurrent-session-test',
+      'x-od-analytics-session-id': 'concurrent-session-session',
+      'x-od-analytics-client-type': 'web',
+    },
+    body: JSON.stringify({
+      projectId,
+      message: 'reproduce disconnect-retry native session fork',
+    }),
+    signal: controller.signal,
+  })
+    .then(() => 'completed')
+    .catch((err: Error) => (err.name === 'AbortError' ? 'aborted' : `error:${err.message}`));
+  await new Promise((resolve) => setTimeout(resolve, abortAfterMs));
+  controller.abort();
+  return pending;
+}
+
+async function waitForCaptureCount(
+  capturePath: string,
+  projectId: string,
+  target: number,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 15_000) {
+    const caps = await readCapturesForProject(capturePath, projectId);
+    if (caps.length >= target) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
 }
 
 async function userMessageCount(

--- a/apps/daemon/tests/concurrent-run-conversation-busy.test.ts
+++ b/apps/daemon/tests/concurrent-run-conversation-busy.test.ts
@@ -255,13 +255,15 @@ describe('concurrent run per-conversation guard (#5490)', () => {
     expect(retry.code).toBe('CONVERSATION_BUSY');
     expect(await abortedFirst).toBe('aborted');
 
-    // The disconnected handler runs on and creates exactly one run; the retry
-    // created none. Only one native session ever materializes — no fork.
-    await waitForCaptureCount(capturePath, project.projectId, 1);
-    const captures = await readCapturesForProject(capturePath, project.projectId);
-    const sessions = new Set(captures.map((c) => c.sessionId).filter(Boolean));
-    expect(captures.length).toBe(1);
-    expect(sessions.size).toBe(1);
+    // The 409 IS the proof: the disconnected handler still owns the conversation
+    // claim, so the retry is refused and creates no second run — no fork. On the
+    // bug the claim is released on the socket's 'close', the retry is admitted
+    // (202), and both handlers reach create. We deliberately do NOT assert on the
+    // aborted handler's own downstream spawn — whether a client-aborted request
+    // goes on to finish agent detection and mint a native session is timing- and
+    // environment-dependent and is not part of this invariant. (Cases 1 and 2
+    // already pin the single-native-session / no-fork property with non-aborted
+    // requests, where the spawn captures are deterministic.)
   });
 });
 
@@ -492,19 +494,6 @@ async function startProjectOnlyRunAborted(
   await new Promise((resolve) => setTimeout(resolve, abortAfterMs));
   controller.abort();
   return pending;
-}
-
-async function waitForCaptureCount(
-  capturePath: string,
-  projectId: string,
-  target: number,
-): Promise<void> {
-  const startedAt = Date.now();
-  while (Date.now() - startedAt < 15_000) {
-    const caps = await readCapturesForProject(capturePath, projectId);
-    if (caps.length >= target) return;
-    await new Promise((resolve) => setTimeout(resolve, 50));
-  }
 }
 
 async function userMessageCount(

--- a/apps/daemon/tests/concurrent-run-conversation-busy.test.ts
+++ b/apps/daemon/tests/concurrent-run-conversation-busy.test.ts
@@ -148,6 +148,64 @@ describe('concurrent run per-conversation guard (#5490)', () => {
     expect(raceCaptures.length).toBe(1);
     expect(raceSessions.size).toBe(1);
   });
+
+  it('rejects a second concurrent project-only (MCP/SDK) run on the default conversation', async () => {
+    // The public McpRunCreateRequest requires only projectId; those callers send
+    // NO conversationId, so the daemon resolves the project's default (earliest)
+    // conversation and binds the run to it. Two such requests raced onto ONE
+    // project must not both create — that forks the native session on the default
+    // conversation exactly as an explicit-conversationId race would. A guard that
+    // only inspected the raw requestBody.conversationId (undefined here) missed
+    // this path; resolving + claiming the default id up front closes it. One is
+    // 202, the other 409 CONVERSATION_BUSY, before any snapshot pin or upsert.
+    workDir = await mkdtemp(path.join(os.tmpdir(), 'od-concurrent-mcp-'));
+    const capturePath = path.join(workDir, 'spawn-capture.jsonl');
+    const fakeClaude = await writeSessionCapturingClaude(workDir, 'claude-capture', capturePath);
+
+    delete process.env.POSTHOG_KEY;
+    delete process.env.POSTHOG_HOST;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_BASE_URL;
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    process.env.OD_TEST_SESSION_CAPTURE = capturePath;
+
+    started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'claude',
+      agentCliEnv: { claude: { CLAUDE_BIN: fakeClaude } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const project = await createProject(started.url, 'mcp');
+    const beforeUserMessages = await userMessageCount(started.url, project);
+
+    const [r1, r2] = await Promise.all([
+      startProjectOnlyRunRaw(started.url, project.projectId),
+      startProjectOnlyRunRaw(started.url, project.projectId),
+    ]);
+
+    const statuses = [r1.status, r2.status].sort();
+    expect(statuses, `expected one 202 + one 409, got ${JSON.stringify([r1.status, r2.status])}`)
+      .toEqual([202, 409]);
+    const rejected = [r1, r2].find((r) => r.status === 409);
+    expect(rejected?.code).toBe('CONVERSATION_BUSY');
+
+    const accepted = [r1, r2].find((r) => r.status === 202);
+    await waitForTerminal(started.url, accepted!.runId!);
+
+    // Exactly one native session on the default conversation — no fork.
+    const captures = await readCapturesForProject(capturePath, project.projectId);
+    const sessions = new Set(captures.map((c) => c.sessionId).filter(Boolean));
+    expect(captures.length).toBe(1);
+    expect(sessions.size).toBe(1);
+
+    // The rejected request left NO durable side effect: exactly one new user
+    // message (the admitted run's fallback upsert), none from the 409'd one.
+    const afterUserMessages = await userMessageCount(started.url, project);
+    expect(afterUserMessages - beforeUserMessages).toBe(1);
+  });
 });
 
 async function writeSessionCapturingClaude(
@@ -303,6 +361,50 @@ async function startRunRaw(
   if (runResponse.status !== 202) return { status: runResponse.status };
   const body = await runResponse.json() as { runId: string };
   return { status: 202, runId: body.runId };
+}
+
+// McpRunCreateRequest shape: projectId + message only, NO conversationId. The
+// daemon must resolve and reserve the project's default conversation for the
+// concurrency guard to fire on this documented MCP/SDK path.
+async function startProjectOnlyRunRaw(
+  url: string,
+  projectId: string,
+): Promise<{ status: number; runId?: string; code?: string }> {
+  const runResponse = await fetch(`${url}/api/runs`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-od-analytics-device-id': 'concurrent-session-test',
+      'x-od-analytics-session-id': 'concurrent-session-session',
+      'x-od-analytics-client-type': 'web',
+    },
+    body: JSON.stringify({
+      projectId,
+      agentId: 'claude',
+      message: 'reproduce concurrent native session fork (mcp)',
+    }),
+  });
+  if (runResponse.status === 202) {
+    const body = await runResponse.json() as { runId: string };
+    return { status: 202, runId: body.runId };
+  }
+  const body = await runResponse.json().catch(() => ({})) as { error?: { code?: string } };
+  const code = body.error?.code;
+  return code === undefined
+    ? { status: runResponse.status }
+    : { status: runResponse.status, code };
+}
+
+async function userMessageCount(
+  url: string,
+  project: { projectId: string; conversationId: string },
+): Promise<number> {
+  const response = await fetch(
+    `${url}/api/projects/${encodeURIComponent(project.projectId)}/conversations/${encodeURIComponent(project.conversationId)}/messages`,
+  );
+  expect(response.status).toBe(200);
+  const body = await response.json() as { messages: Array<{ role?: string }> };
+  return body.messages.filter((m) => m.role === 'user').length;
 }
 
 async function waitForTerminal(url: string, runId: string): Promise<RunStatus> {

--- a/apps/daemon/tests/concurrent-run-conversation-busy.test.ts
+++ b/apps/daemon/tests/concurrent-run-conversation-busy.test.ts
@@ -1,0 +1,318 @@
+// Regression (#5490): concurrent runs on one conversation must not fork the
+// native agent session.
+//
+// Before the fix, the daemon had NO per-conversation concurrency guard. `POST
+// /api/runs` and `POST /api/chat` both create-and-start a run unconditionally —
+// no lookup of an already-active run on the same conversationId. The UI hides
+// this by disabling the send button, but the HTTP API / `od` CLI / external
+// agents (a first-class embedding surface per AGENTS.md) can fire two runs at
+// the same conversation concurrently.
+//
+// A resume-capable agent (claude) persists exactly ONE native session per
+// (conversation_id, agent_id) — that is the PRIMARY KEY of agent_sessions
+// (db.ts:90-108), so upsertAgentSession (db.ts:1247-1280) is last-writer-wins.
+// The resume context is resolved at the TOP of startChatRun (server.ts:4715) by
+// a synchronous read of that row, but the row is only written at run SUCCESS
+// (server.ts:5783 create-turn / 5809 resume-turn, gated by status==='succeeded'
+// at 7696/7715) — i.e. at the very END of the run.
+//
+// Consequence (create-turn race): two concurrent runs on a FRESH conversation
+// both read an empty session row, both resolve isResuming=false, and each mints
+// and drives a DISTINCT native session (`claude --session-id <uuidA>` and
+// `--session-id <uuidB>`). Both succeed and both upsert; the PK keeps only ONE
+// row. A completed turn's native session is silently ORPHANED (lost update): the
+// CLI did real work in that session (files read, tool history, working memory),
+// but the daemon throws away the pointer to it. The next turn resumes the
+// surviving session, which never saw the orphaned turn — silent context loss,
+// while the DB transcript still shows both turns as if consistent.
+//
+// A/B: the ONLY difference below is concurrency.
+//   - control (sequential): run 2 reads run 1's persisted session and RESUMES it
+//     -> exactly ONE native session id is ever driven for the conversation.
+//   - candidate (concurrent): the guard admits exactly one run (202) and rejects
+//     the second with 409 CONVERSATION_BUSY, so only one native session is
+//     driven. On main both are accepted (202) and fork the session — red.
+//
+// The fix: a per-conversation guard (routes/runs.ts `conversationHasActiveRun`)
+// checked synchronously immediately before design.runs.create, so a second
+// concurrent run on the same conversationId is refused instead of forking the
+// single (conversation_id, agent_id) agent_sessions row.
+
+import type { Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+type StartedServer = {
+  url: string;
+  server: Server;
+  shutdown?: () => Promise<void> | void;
+};
+
+type RunStatus = { id: string; status: string };
+
+interface SpawnCapture {
+  mode: 'resume' | 'create' | 'none';
+  sessionId: string | null;
+  cwd: string;
+}
+
+describe('concurrent run per-conversation guard (#5490)', () => {
+  const originalEnv = {
+    POSTHOG_KEY: process.env.POSTHOG_KEY,
+    POSTHOG_HOST: process.env.POSTHOG_HOST,
+    LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
+    LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
+    LANGFUSE_BASE_URL: process.env.LANGFUSE_BASE_URL,
+    OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
+    OD_TEST_SESSION_CAPTURE: process.env.OD_TEST_SESSION_CAPTURE,
+  };
+  let started: StartedServer | null = null;
+  let workDir: string | null = null;
+
+  afterEach(async () => {
+    await Promise.resolve(started?.shutdown?.());
+    if (started?.server) {
+      await new Promise<void>((resolve) => started?.server.close(() => resolve()));
+    }
+    started = null;
+    if (workDir) await rm(workDir, { recursive: true, force: true });
+    workDir = null;
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it('does not fork a conversation onto two native sessions under concurrent runs', async () => {
+    workDir = await mkdtemp(path.join(os.tmpdir(), 'od-concurrent-session-'));
+    const capturePath = path.join(workDir, 'spawn-capture.jsonl');
+    const fakeClaude = await writeSessionCapturingClaude(workDir, 'claude-capture', capturePath);
+
+    delete process.env.POSTHOG_KEY;
+    delete process.env.POSTHOG_HOST;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_BASE_URL;
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    process.env.OD_TEST_SESSION_CAPTURE = capturePath;
+
+    started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'claude',
+      agentCliEnv: { claude: { CLAUDE_BIN: fakeClaude } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    // ---- A/B control: SEQUENTIAL runs on one conversation ------------------
+    const controlProject = await createProject(started.url, 'seq');
+    const seq1 = await startRun(started.url, controlProject);
+    await waitForTerminal(started.url, seq1);
+    const seq2 = await startRun(started.url, controlProject);
+    await waitForTerminal(started.url, seq2);
+
+    const controlCaptures = await readCapturesForProject(capturePath, controlProject.projectId);
+    const controlSessions = new Set(controlCaptures.map((c) => c.sessionId).filter(Boolean));
+    // Baseline: sequential run 2 resumes run 1's session — one native session.
+    expect(controlCaptures.length).toBe(2);
+    expect(controlSessions.size).toBe(1);
+    expect(controlCaptures.some((c) => c.mode === 'resume')).toBe(true);
+
+    // ---- Candidate: CONCURRENT runs on one conversation -------------------
+    // The per-conversation guard admits exactly one run; the second concurrent
+    // submit is rejected with 409 CONVERSATION_BUSY instead of racing into a
+    // second native session. On main (no guard) both are accepted (202) and fork
+    // the agent_sessions row — so the "exactly one 409" assertion goes red.
+    const raceProject = await createProject(started.url, 'race');
+    const [r1, r2] = await Promise.all([
+      startRunRaw(started.url, raceProject),
+      startRunRaw(started.url, raceProject),
+    ]);
+
+    const statuses = [r1.status, r2.status].sort();
+    expect(statuses, `expected one 202 + one 409, got ${JSON.stringify([r1.status, r2.status])}`)
+      .toEqual([202, 409]);
+
+    const accepted = [r1, r2].find((r) => r.status === 202);
+    await waitForTerminal(started.url, accepted!.runId!);
+
+    // Only the admitted run drove claude, so exactly one native session exists —
+    // no fork, no lost update.
+    const raceCaptures = await readCapturesForProject(capturePath, raceProject.projectId);
+    const raceSessions = new Set(raceCaptures.map((c) => c.sessionId).filter(Boolean));
+    expect(raceCaptures.length).toBe(1);
+    expect(raceSessions.size).toBe(1);
+  });
+});
+
+async function writeSessionCapturingClaude(
+  dir: string,
+  name: string,
+  capturePath: string,
+): Promise<string> {
+  const bin = path.join(dir, name);
+  // Records the native session identity the daemon spawned it with (--resume
+  // <id> = resuming an existing session; --session-id <id> = minting a new one),
+  // then emits a clean successful stream-json turn and holds ~600ms before exit
+  // so two racing runs are BOTH still resolving as create-turns (neither has
+  // persisted its session yet). Synchronous writes so nothing is lost on exit.
+  await writeFile(bin, `#!/usr/bin/env node
+const fs = require('node:fs');
+const argv = process.argv.slice(2);
+function w(s) { fs.writeSync(1, s); }
+if (argv.includes('--version')) { w('claude-code 1.0.0-session-capture\\n'); process.exit(0); }
+if (argv.includes('--help')) { w('Usage: claude -p [--include-partial-messages] [--add-dir DIR]\\n'); process.exit(0); }
+
+function argValue(flag) {
+  const i = argv.indexOf(flag);
+  return i >= 0 && i + 1 < argv.length ? argv[i + 1] : null;
+}
+const resumeId = argValue('--resume');
+const newId = argValue('--session-id');
+const mode = resumeId ? 'resume' : newId ? 'create' : 'none';
+const sessionId = resumeId || newId || null;
+try {
+  fs.appendFileSync(
+    ${JSON.stringify(capturePath)},
+    JSON.stringify({ mode, sessionId, cwd: process.cwd() }) + '\\n',
+  );
+} catch {}
+
+const echo = sessionId || 'sess-unknown';
+w(JSON.stringify({ type: 'system', subtype: 'init', model: 'm', session_id: echo }) + '\\n');
+w(JSON.stringify({
+  type: 'assistant',
+  message: { id: 'msg-' + echo.slice(0, 8), content: [{ type: 'text', text: 'done' }], stop_reason: 'end_turn' },
+}) + '\\n');
+w(JSON.stringify({
+  type: 'result', subtype: 'success', is_error: false,
+  session_id: echo, num_turns: 1, duration_api_ms: 10, total_cost_usd: 0,
+}) + '\\n');
+// Hold both racing runs alive as create-turns long enough that neither has
+// persisted its session before the other resolves.
+setTimeout(() => process.exit(0), 600);
+`, 'utf8');
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+async function readCapturesForProject(
+  capturePath: string,
+  projectId: string,
+): Promise<SpawnCapture[]> {
+  let raw = '';
+  try {
+    raw = await readFile(capturePath, 'utf8');
+  } catch {
+    return [];
+  }
+  return raw
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as SpawnCapture)
+    .filter((c) => c.cwd.includes(projectId));
+}
+
+async function putConfig(url: string, patch: Record<string, unknown>): Promise<void> {
+  const response = await fetch(`${url}/api/app-config`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  expect(response.status).toBe(200);
+}
+
+async function createProject(
+  url: string,
+  tag: string,
+): Promise<{ projectId: string; conversationId: string }> {
+  const projectId = `concurrent_${tag}_${randomUUID().replace(/-/g, '')}`;
+  const projectResponse = await fetch(`${url}/api/projects`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      id: projectId,
+      name: `Concurrent session repro ${tag}`,
+      metadata: { kind: 'prototype' },
+      skipDiscoveryBrief: true,
+    }),
+  });
+  expect(projectResponse.status).toBe(200);
+  const body = await projectResponse.json() as { conversationId: string };
+  return { projectId, conversationId: body.conversationId };
+}
+
+async function startRun(
+  url: string,
+  project: { projectId: string; conversationId: string },
+): Promise<string> {
+  const runResponse = await fetch(`${url}/api/runs`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-od-analytics-device-id': 'concurrent-session-test',
+      'x-od-analytics-session-id': 'concurrent-session-session',
+      'x-od-analytics-client-type': 'web',
+    },
+    body: JSON.stringify({
+      projectId: project.projectId,
+      conversationId: project.conversationId,
+      assistantMessageId: `assistant_${randomUUID()}`,
+      clientRequestId: `client_${randomUUID()}`,
+      agentId: 'claude',
+      message: 'reproduce concurrent native session fork',
+      currentPrompt: 'reproduce concurrent native session fork',
+    }),
+  });
+  expect(runResponse.status).toBe(202);
+  const body = await runResponse.json() as { runId: string };
+  return body.runId;
+}
+
+// Like startRun but returns the HTTP status without asserting, so the concurrent
+// case can observe that exactly one run is accepted (202) and the other is
+// rejected (409 CONVERSATION_BUSY).
+async function startRunRaw(
+  url: string,
+  project: { projectId: string; conversationId: string },
+): Promise<{ status: number; runId?: string }> {
+  const runResponse = await fetch(`${url}/api/runs`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-od-analytics-device-id': 'concurrent-session-test',
+      'x-od-analytics-session-id': 'concurrent-session-session',
+      'x-od-analytics-client-type': 'web',
+    },
+    body: JSON.stringify({
+      projectId: project.projectId,
+      conversationId: project.conversationId,
+      assistantMessageId: `assistant_${randomUUID()}`,
+      clientRequestId: `client_${randomUUID()}`,
+      agentId: 'claude',
+      message: 'reproduce concurrent native session fork',
+      currentPrompt: 'reproduce concurrent native session fork',
+    }),
+  });
+  if (runResponse.status !== 202) return { status: runResponse.status };
+  const body = await runResponse.json() as { runId: string };
+  return { status: 202, runId: body.runId };
+}
+
+async function waitForTerminal(url: string, runId: string): Promise<RunStatus> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 15_000) {
+    const response = await fetch(`${url}/api/runs/${encodeURIComponent(runId)}`);
+    expect(response.status).toBe(200);
+    const run = await response.json() as RunStatus;
+    if (['failed', 'succeeded', 'canceled'].includes(run.status)) return run;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`run ${runId} did not finish`);
+}

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -7,6 +7,10 @@ export const API_ERROR_CODES = [
   'FORBIDDEN',
   'NOT_FOUND',
   'CONFLICT',
+  // A run was requested for a conversation that already has one in flight. A
+  // conversation drives exactly one native agent session, so a second
+  // concurrent run would fork it (#5490). Retryable once the active run ends.
+  'CONVERSATION_BUSY',
   'PAYLOAD_TOO_LARGE',
   'UNSUPPORTED_MEDIA_TYPE',
   'VALIDATION_FAILED',


### PR DESCRIPTION
Fixes #5490

## Why

Two runs racing on the same `conversationId` both resolve as create-turns and fork the single `(conversation_id, agent_id)` `agent_sessions` row. The resume context is read at the top of `startChatRun`, but the row is only written at run success, so overlapping runs both read an empty row, each mint a distinct native session, both succeed and upsert — the PK keeps only one. The other completed turn's native session (files it read, tool history, working memory) is silently orphaned; the next turn resumes the survivor, which never saw it. Silent context loss, while the DB transcript shows both turns as consistent.

**Reachability:** the web UI serializes via the disabled send button, but the HTTP API, `od` CLI, and embedding agents (a first-class surface per AGENTS.md) can fire concurrent runs on one conversation — as can a double-submit or a routine racing a manual send. Data/identity integrity, silent and delayed (not a crash).

## What users will see

No happy-path change. A second run submitted for a conversation that already has one in flight now fails fast with `409 CONVERSATION_BUSY` instead of silently corrupting the resume session — retry once the active run finishes.

## Fix

`POST /api/runs` and `POST /api/chat` check `conversationHasActiveRun(conversationId)` immediately before `design.runs.create` and return `409 CONVERSATION_BUSY` when the conversation already has a non-terminal run. The check→create is synchronous (no `await` between), so the run the winner registers is visible when the loser checks — the guard itself isn't racy.

**Shape choice:** reject-with-409 (smallest change; caller retries) over serialize-and-resume (needs a per-conversation queue). Happy to switch to serialization if preferred.

## Surface area

- [x] **API / contract** — new `409 CONVERSATION_BUSY` on `POST /api/runs` and `POST /api/chat`

## Bug fix verification

- Test: `apps/daemon/tests/concurrent-run-conversation-busy.test.ts`
- Red on `main`, green here? **yes** (verified end-to-end). Two concurrent runs over the production HTTP API against a fake claude recording its `--session-id`: on main both accepted (`[202,202]`) → two native sessions (fork); with the fix exactly one accepted + one `409` → a single session, no fork. Sequential control still resumes cleanly. Green 3/3, no orphans.

## Validation

- `pnpm --filter @open-design/daemon typecheck` (both tsconfigs) — clean
- `pnpm guard` — 78/78
- neighboring `run-retry-runtime` + `mcp-runs` — 35/35