### PR TITLE
fix daemon Antigravity prompt delivery after agy 1.1.1

### DIFF
--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -572,33 +572,56 @@ When you write or edit an HTML file in the project folder through the native fil
 - After the final self-check, briefly name the written file and summarize the result instead.
 - A filesystem run that emits a source-code \`<artifact>\` is treated as an unexpected fallback by the host.`;
 
-export function buildExamplePromptOverride(
+type PromptPartWriter = (part: string) => void;
+
+function appendExamplePromptOverride(
+  pushPromptPart: PromptPartWriter,
+  pushVerbatimPromptPart: PromptPartWriter,
   title?: string | null,
   brief?: Record<string, string> | null,
-): string {
-  let text = `# Example prompt mode — full-quality direct generation
+): void {
+  pushPromptPart(`# Example prompt mode — full-quality direct generation
 
-The user selected a curated example prompt from the gallery and sent it without modification. This prompt is a complete, self-contained creative brief that has been carefully designed to produce a showcase-quality artifact.`;
+The user selected a curated example prompt from the gallery and sent it without modification. This prompt is a complete, self-contained creative brief that has been carefully designed to produce a showcase-quality artifact.`);
 
   if (title) {
-    text += `\n\nSelected example: "${title}"`;
+    pushPromptPart('\n\nSelected example: "');
+    pushVerbatimPromptPart(title);
+    pushPromptPart('"');
   }
 
   if (brief && Object.keys(brief).length > 0) {
-    text += `\n\nPre-filled creative brief (treat as if the user already answered all discovery questions):`;
+    pushPromptPart(
+      '\n\nPre-filled creative brief (treat as if the user already answered all discovery questions):',
+    );
     for (const [key, value] of Object.entries(brief)) {
-      text += `\n- ${key.replace(/_/g, ' ')}: ${value}`;
+      pushPromptPart('\n- ');
+      pushVerbatimPromptPart(key.replace(/_/g, ' '));
+      pushPromptPart(': ');
+      pushVerbatimPromptPart(value);
     }
   }
 
-  text += `\n\nRules:
+  pushPromptPart(`\n\nRules:
 1. Do NOT emit \`<question-form id="discovery">\`, do NOT show "Quick brief — 30 seconds", and do NOT ask any clarifying questions.
 2. Treat the user's message as the FULL specification — it contains all visual direction, content themes, and structural intent needed.
 3. Generate the artifact at your absolute highest quality. This is a showcase piece — match or exceed the standard of a hand-crafted design.
 4. Infer any unspecified details (copy, layout choices, imagery descriptions) in a way that is maximally coherent with the stated creative direction.
-5. Proceed directly to planning and building. Output your TodoWrite plan and then the artifact immediately.`;
+5. Proceed directly to planning and building. Output your TodoWrite plan and then the artifact immediately.`);
+}
 
-  return text;
+export function buildExamplePromptOverride(
+  title?: string | null,
+  brief?: Record<string, string> | null,
+): string {
+  const parts: string[] = [];
+  appendExamplePromptOverride(
+    (part) => parts.push(part),
+    (part) => parts.push(part),
+    title,
+    brief,
+  );
+  return parts.join('');
 }
 
 const ACTIVE_DESIGN_SYSTEM_VISUAL_DIRECTION_OVERRIDE = `
@@ -952,6 +975,19 @@ export function composeSystemPrompt({
   if (isSlimCharterHead && streamFormat === 'claude-stream-json') {
     parts.push(CLAUDE_PLAN_TOOL_NOTE, '\n\n---\n\n');
   }
+  const verbatimPromptPartIndexes = new Set<number>();
+  const pushVerbatimPromptPart = (part: string): void => {
+    verbatimPromptPartIndexes.add(parts.length);
+    parts.push(part);
+  };
+  const pushPromptSectionHeading = (heading: string, name?: string): void => {
+    parts.push(`\n\n## ${heading}`);
+    if (name) {
+      parts.push(' — ');
+      pushVerbatimPromptPart(name);
+    }
+    parts.push('\n\n');
+  };
   const activeDesignSystemBody = designSystemBody?.trim();
   const activeSkillModes = new Set(
     Array.isArray(skillModes)
@@ -1007,7 +1043,12 @@ export function composeSystemPrompt({
   // and LLM inference time. The MEDIA_GENERATION_CONTRACT (pushed below) is
   // the sole workflow authority for these surfaces.
   if (metadata?.examplePrompt === true) {
-    parts.push(buildExamplePromptOverride(metadata.examplePromptTitle, metadata.examplePromptBrief));
+    appendExamplePromptOverride(
+      (part) => parts.push(part),
+      pushVerbatimPromptPart,
+      metadata.examplePromptTitle,
+      metadata.examplePromptBrief,
+    );
     parts.push('\n\n---\n\n');
   } else if (metadata?.skipDiscoveryBrief === true) {
     parts.push(SKIP_DISCOVERY_BRIEF_OVERRIDE);
@@ -1104,8 +1145,9 @@ export function composeSystemPrompt({
     // repeated rationale prose cut. The classic wording below stays
     // byte-stable for the classic stack.
     parts.push(
-      `\n\n## Personal memory (auto-extracted from past chats)\n\nPreferences and context sedimented from this user's previous conversations — authoritative for tone, terminology, and what they already told you; never re-ask what is captured here. On conflict the active design system wins tokens and the active skill wins workflow (see Precedence). Use memory to silently expand short asks into a full internal brief before acting; ask a clarifying question only when a critical target, permission, or conflict cannot be resolved from the request plus memory.\n\n${memoryBody.trim()}`,
+      `\n\n## Personal memory (auto-extracted from past chats)\n\nPreferences and context sedimented from this user's previous conversations — authoritative for tone, terminology, and what they already told you; never re-ask what is captured here. On conflict the active design system wins tokens and the active skill wins workflow (see Precedence). Use memory to silently expand short asks into a full internal brief before acting; ask a clarifying question only when a critical target, permission, or conflict cannot be resolved from the request plus memory.\n\n`,
     );
+    pushVerbatimPromptPart(memoryBody.trim());
     if ((memoryHooks?.rewrite ?? true)) {
       parts.push(
         `\n\n## Intent gateway — turn short asks into a brief\n\nWhen memory lets you expand a short or underspecified request into a clear brief, surface it as ONE collapsed card at the very start of your reply, then continue working without waiting for confirmation:\n\n<od-card type="task-brief">\n{ "summary": "<one line restating the expanded intent>", "fields": [ {"label": "Audience", "value": "…"}, {"label": "Deliverable", "value": "…"}, {"label": "Done means", "value": "…"} ] }\n</od-card>\n\nAt most one per turn; skip it when the request is already explicit or trivial (you may emit one compact chip instead: <od-card type="memory-applied">{ "summary": "Applied your profile and 2 rules", "used": [ {"type": "profile", "name": "Work profile"} ] }</od-card>). The card replaces the turn-1 discovery form when intent is already clear — it never replaces TodoWrite or the pre-ship self-check, and never appears as prose.`,
@@ -1123,8 +1165,9 @@ export function composeSystemPrompt({
 
   if (!isSlimCore && memoryBody && memoryBody.trim().length > 0) {
     parts.push(
-      `\n\n## Personal memory (auto-extracted from past chats)\n\nThe following facts have been sedimented from this user's previous conversations and edited in the settings panel. Treat them as preferences and context, NOT hard rules: when they collide with the active design system tokens, the brand wins; when they collide with the active skill's workflow, the skill wins. They are still authoritative for tone, voice, terminology, and what the user already told you about themselves and their goals — never re-ask the user about something already captured here.\n\nUse memory as a task-intent gateway. When the user's request is short or underspecified, silently expand it into an internal task brief before acting: infer the task type, user/profile background, project/artifact context, delivery preferences, known feedback meanings, constraints, and validation/finish line. Proceed from that richer brief so the user does not need to repeat setup. Ask a clarifying question only when a critical target, permission, or conflict cannot be resolved from the current request plus memory. Do not dump the full internal brief unless the user asks to inspect it. Expanding intent this way changes only WHAT you know going in; it never shortcuts the standard build flow — you still plan with TodoWrite and still run the anti-slop / brand self-check on every artifact-producing turn.\n\n${memoryBody.trim()}`,
+      `\n\n## Personal memory (auto-extracted from past chats)\n\nThe following facts have been sedimented from this user's previous conversations and edited in the settings panel. Treat them as preferences and context, NOT hard rules: when they collide with the active design system tokens, the brand wins; when they collide with the active skill's workflow, the skill wins. They are still authoritative for tone, voice, terminology, and what the user already told you about themselves and their goals — never re-ask the user about something already captured here.\n\nUse memory as a task-intent gateway. When the user's request is short or underspecified, silently expand it into an internal task brief before acting: infer the task type, user/profile background, project/artifact context, delivery preferences, known feedback meanings, constraints, and validation/finish line. Proceed from that richer brief so the user does not need to repeat setup. Ask a clarifying question only when a critical target, permission, or conflict cannot be resolved from the current request plus memory. Do not dump the full internal brief unless the user asks to inspect it. Expanding intent this way changes only WHAT you know going in; it never shortcuts the standard build flow — you still plan with TodoWrite and still run the anti-slop / brand self-check on every artifact-producing turn.\n\n`,
     );
+    pushVerbatimPromptPart(memoryBody.trim());
 
     // Two-loop memory instruction blocks. These pair with the memory body
     // above (Workstream 1A renders a `### Profile` first and a
@@ -1151,34 +1194,36 @@ export function composeSystemPrompt({
 
   if (userInstructions && userInstructions.trim().length > 0) {
     parts.push(
-      `\n\n## Custom instructions (user-level)\n\nThe user has set the following persistent instructions. Apply them as defaults to every project. When a project-level instruction below contradicts a point here, the project-level version wins.\n\n${userInstructions.trim()}`,
+      `\n\n## Custom instructions (user-level)\n\nThe user has set the following persistent instructions. Apply them as defaults to every project. When a project-level instruction below contradicts a point here, the project-level version wins.\n\n`,
     );
+    pushVerbatimPromptPart(userInstructions.trim());
   }
 
   if (projectInstructions && projectInstructions.trim().length > 0) {
     parts.push(
-      `\n\n## Custom instructions (project-level)\n\nThe user has set the following instructions for this specific project. They take precedence over user-level custom instructions whenever both address the same topic (e.g. if user-level says "use spaces" but project-level says "use tabs", use tabs).\n\n${projectInstructions.trim()}`,
+      `\n\n## Custom instructions (project-level)\n\nThe user has set the following instructions for this specific project. They take precedence over user-level custom instructions whenever both address the same topic (e.g. if user-level says "use spaces" but project-level says "use tabs", use tabs).\n\n`,
     );
+    pushVerbatimPromptPart(projectInstructions.trim());
   }
 
   if (activeDesignSystemBody && activeDesignSystemBody.length > 0) {
-    const usageBlock =
-      designSystemUsageMd && designSystemUsageMd.trim().length > 0
-        ? designSystemUsageMd.trim()
-        : DEFAULT_DESIGN_SYSTEM_USAGE;
-    parts.push(
-      `\n\n## How to use this design system${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\n${usageBlock}`,
-    );
+    pushPromptSectionHeading('How to use this design system', designSystemTitle);
+    if (designSystemUsageMd && designSystemUsageMd.trim().length > 0) {
+      pushVerbatimPromptPart(designSystemUsageMd.trim());
+    } else {
+      parts.push(DEFAULT_DESIGN_SYSTEM_USAGE);
+    }
 
+    pushPromptSectionHeading('Active design system', designSystemTitle);
     parts.push(
-      `\n\n## Active design system${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\nTreat the following DESIGN.md as authoritative for color, typography, spacing, and component rules. Do not invent tokens outside this palette. When you copy the active skill's seed template, bind these tokens into its \`:root\` block before generating any layout.\n\n${activeDesignSystemBody}`,
+      "Treat the following DESIGN.md as authoritative for color, typography, spacing, and component rules. Do not invent tokens outside this palette. When you copy the active skill's seed template, bind these tokens into its `:root` block before generating any layout.\n\n",
     );
+    pushVerbatimPromptPart(activeDesignSystemBody);
 
     const importModeGuidance = renderDesignSystemImportModeGuidance(designSystemImportMode);
     if (importModeGuidance) {
-      parts.push(
-        `\n\n## Design system import mode${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\n${importModeGuidance}`,
-      );
+      pushPromptSectionHeading('Design system import mode', designSystemTitle);
+      parts.push(importModeGuidance);
     }
   }
 
@@ -1193,42 +1238,56 @@ export function composeSystemPrompt({
   // individually gated: missing files skip silently, preserving the
   // legacy DESIGN.md-only behaviour for prose-only brands.
   if (designSystemTokensCss && designSystemTokensCss.trim().length > 0) {
+    pushPromptSectionHeading('Active design system tokens', designSystemTitle);
     parts.push(
-      `\n\n## Active design system tokens${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\nThe block below is this brand's tokens.css contract — every \`:root\` custom property and any scoped override (e.g. \`:root[lang=...]\`) the brand defines. **Paste the unscoped \`:root { ... }\` block verbatim into the artifact's first \`<style>\`** so every \`var(--*)\` reference resolves at runtime.\n\nDo not invent new tokens. Do not redefine these values. Do not write raw hex outside this :root block. The DESIGN.md above is prose; this is the binding contract.\n\n\`\`\`css\n${designSystemTokensCss.trim()}\n\`\`\``,
+      `The block below is this brand's tokens.css contract — every \`:root\` custom property and any scoped override (e.g. \`:root[lang=...]\`) the brand defines. **Paste the unscoped \`:root { ... }\` block verbatim into the artifact's first \`<style>\`** so every \`var(--*)\` reference resolves at runtime.\n\nDo not invent new tokens. Do not redefine these values. Do not write raw hex outside this :root block. The DESIGN.md above is prose; this is the binding contract.\n\n\`\`\`css\n`,
     );
+    pushVerbatimPromptPart(designSystemTokensCss.trim());
+    parts.push('\n```');
   }
 
   if (designSystemComponentsManifest && designSystemComponentsManifest.trim().length > 0) {
+    pushPromptSectionHeading('Reference component manifest', designSystemTitle);
     parts.push(
-      `\n\n## Reference component manifest${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\nA compact structured summary derived from this brand's components.html fixture. Use it as the component inventory for generated artifacts: match the listed selectors, component groups, class names, token references, focus behavior, and spacing cadence. Prefer these manifest entries over inventing new component shapes.\n\n\`\`\`text\n${designSystemComponentsManifest.trim()}\n\`\`\``,
+      `A compact structured summary derived from this brand's components.html fixture. Use it as the component inventory for generated artifacts: match the listed selectors, component groups, class names, token references, focus behavior, and spacing cadence. Prefer these manifest entries over inventing new component shapes.\n\n\`\`\`text\n`,
     );
+    pushVerbatimPromptPart(designSystemComponentsManifest.trim());
+    parts.push('\n```');
   } else if (designSystemFixtureHtml && designSystemFixtureHtml.trim().length > 0) {
+    pushPromptSectionHeading('Reference fixture', designSystemTitle);
     parts.push(
-      `\n\n## Reference fixture${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\nA self-contained worked artifact in this design system. Match its component shapes (button structure, card structure, type-scale rhythm, focus ring, spacing cadence) when generating new artifacts. Copying fragments is encouraged as long as you keep the \`var(--*)\` references intact — they are already wired to the tokens above.\n\n\`\`\`html\n${designSystemFixtureHtml.trim()}\n\`\`\``,
+      `A self-contained worked artifact in this design system. Match its component shapes (button structure, card structure, type-scale rhythm, focus ring, spacing cadence) when generating new artifacts. Copying fragments is encouraged as long as you keep the \`var(--*)\` references intact — they are already wired to the tokens above.\n\n\`\`\`html\n`,
     );
+    pushVerbatimPromptPart(designSystemFixtureHtml.trim());
+    parts.push('\n```');
   }
 
   if (designSystemPullIndex && designSystemPullIndex.trim().length > 0) {
+    pushPromptSectionHeading('Pull-layer files available on demand', designSystemTitle);
     parts.push(
-      `\n\n## Pull-layer files available on demand${designSystemTitle ? ` — ${designSystemTitle}` : ''}\n\nThis design-system package declares richer files for inspection, source evidence, or human preview. Keep the push prompt light: use the index below to decide what to read later. When the runtime tool environment is available, read a listed path with \`\"$OD_NODE_BIN\" \"$OD_BIN\" tools design-systems read --path <path>\`; the daemon will reject paths outside this manifest allowlist.\n\n\`\`\`text\n${designSystemPullIndex.trim()}\n\`\`\``,
+      `This design-system package declares richer files for inspection, source evidence, or human preview. Keep the push prompt light: use the index below to decide what to read later. When the runtime tool environment is available, read a listed path with \`"$OD_NODE_BIN" "$OD_BIN" tools design-systems read --path <path>\`; the daemon will reject paths outside this manifest allowlist.\n\n\`\`\`text\n`,
     );
+    pushVerbatimPromptPart(designSystemPullIndex.trim());
+    parts.push('\n```');
   }
 
   if (craftBody && craftBody.trim().length > 0) {
-    const sectionLabel =
-      Array.isArray(craftSections) && craftSections.length > 0
-        ? ` — ${craftSections.join(', ')}`
-        : '';
+    parts.push('\n\n## Active craft references');
+    if (Array.isArray(craftSections) && craftSections.length > 0) {
+      parts.push(' — ');
+      pushVerbatimPromptPart(craftSections.join(', '));
+    }
     parts.push(
-      `\n\n## Active craft references${sectionLabel}\n\nThe following craft rules are universal — they apply on top of the active design system above, regardless of brand. The DESIGN.md decides *which* tokens to use; craft rules decide *how* to use them. On any conflict between a craft rule and a brand DESIGN.md, the brand wins for token values; craft rules still apply to anything the brand does not override (letter-spacing, accent overuse caps, anti-slop patterns).\n\n${craftBody.trim()}`,
+      '\n\nThe following craft rules are universal — they apply on top of the active design system above, regardless of brand. The DESIGN.md decides *which* tokens to use; craft rules decide *how* to use them. On any conflict between a craft rule and a brand DESIGN.md, the brand wins for token values; craft rules still apply to anything the brand does not override (letter-spacing, accent overuse caps, anti-slop patterns).\n\n',
     );
+    pushVerbatimPromptPart(craftBody.trim());
   }
 
   if (skillBody && skillBody.trim().length > 0) {
     const preflight = derivePreflight(skillBody);
-    parts.push(
-      `\n\n## Active skill${skillName ? ` — ${skillName}` : ''}\n\nFollow this skill's workflow exactly.${preflight}\n\n${skillBody.trim()}`,
-    );
+    pushPromptSectionHeading('Active skill', skillName);
+    parts.push(`Follow this skill's workflow exactly.${preflight}\n\n`);
+    pushVerbatimPromptPart(skillBody.trim());
   }
 
   if (!isAskMode) {
@@ -1236,7 +1295,7 @@ export function composeSystemPrompt({
   }
 
   if (pluginBlock && pluginBlock.trim().length > 0) {
-    parts.push(pluginBlock);
+    pushVerbatimPromptPart(pluginBlock);
   }
 
   // Plan §3.L2 / spec §23.4 — splice per-stage atom blocks immediately
@@ -1248,7 +1307,7 @@ export function composeSystemPrompt({
   if (Array.isArray(activeStageBlocks) && activeStageBlocks.length > 0) {
     for (const block of activeStageBlocks) {
       if (typeof block === 'string' && block.trim().length > 0) {
-        parts.push(block);
+        pushVerbatimPromptPart(block);
       }
     }
   }
@@ -1261,7 +1320,7 @@ export function composeSystemPrompt({
     mediaExecution,
     isSlimCore ? 'facts' : 'classic',
   );
-  if (metaBlock) parts.push(metaBlock);
+  if (metaBlock) pushVerbatimPromptPart(metaBlock);
 
   // Decks have a load-bearing framework (nav, counter, scroll JS, print
   // stylesheet for PDF stitching). Pin it last so it overrides any softer
@@ -1349,7 +1408,7 @@ export function composeSystemPrompt({
   // lands.
   const cfg = critique ?? defaultCritiqueConfig();
   if (cfg.enabled && critiqueBrand && critiqueSkill && !isMediaSurface && !isAskMode) {
-    parts.push('\n\n' + renderPanelPrompt({ cfg, brand: critiqueBrand, skill: critiqueSkill }));
+    pushVerbatimPromptPart('\n\n' + renderPanelPrompt({ cfg, brand: critiqueBrand, skill: critiqueSkill }));
   }
 
   // The three tail overrides below exist to re-assert rules the classic
@@ -1399,10 +1458,13 @@ export function composeSystemPrompt({
     "stop and ask the user a real question instead.",
   );
 
-  const prompt = parts.join('');
-  return promptToolVocabulary === 'native'
-    ? neutralizeOpenDesignToolNames(prompt)
-    : prompt;
+  return parts
+    .map((part, index) =>
+      promptToolVocabulary === 'native' && !verbatimPromptPartIndexes.has(index)
+        ? neutralizeOpenDesignToolNames(part)
+        : part,
+    )
+    .join('');
 }
 
 /**

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -847,6 +847,8 @@ export function composeSystemPrompt({
     metadata?.kind === 'video' ||
     metadata?.kind === 'audio';
   const isSlimCharterHead = isSlimCore && !isAskModeEarly && !isMediaSurfaceEarly;
+  const resolvedExecutionProfile =
+    executionProfile ?? executionProfileFromStreamFormat(streamFormat);
 
   // Head ordering differs by variant, following prompt-caching prefix rules
   // (stable content first — see shared prompt-caching guidance):
@@ -860,25 +862,26 @@ export function composeSystemPrompt({
   // turn — with the security section reading as its first subsection, so the
   // ask document keeps the same identity-first H1 > H2 hierarchy as design
   // mode. Both blocks are static, so the swap is cache-neutral.
-  // Plain-stream (BYOK/API) slim runs put the API-mode override BEFORE the
+  // Tool-less text-artifact slim runs put the API-mode override BEFORE the
   // charter: its "every later instruction … is overridden" scope must cover
-  // the charter's TodoWrite/render instructions, which classic guaranteed by
-  // always composing the override first. Cache-neutral — plain runs use the
-  // text_artifact charter variant and form their own prefix family anyway.
+  // the charter's planning/render instructions, matching classic's authority
+  // order. Native filesystem runs keep their own capabilities and skip it.
   const parts: string[] = isSlimCharterHead
     ? [
-        ...(streamFormat === 'plain' ? [API_MODE_OVERRIDE, '\n\n---\n\n'] : []),
-        renderSlimCoreCharter(
-          executionProfile ?? executionProfileFromStreamFormat(streamFormat),
-        ),
+        ...(resolvedExecutionProfile === 'text_artifact'
+          ? [API_MODE_OVERRIDE, '\n\n---\n\n']
+          : []),
+        renderSlimCoreCharter(resolvedExecutionProfile),
         '\n\n---\n\n',
       ]
     : isSlimCore && isAskModeEarly
       ? [
-          // Ask mode on a plain stream still leads with the API override so
-          // its "overrides every rule below" scope covers the chat charter,
-          // matching classic's authority order (API before CHAT).
-          ...(streamFormat === 'plain' ? [API_MODE_OVERRIDE, '\n\n---\n\n'] : []),
+          // Ask mode on a tool-less text-artifact profile still leads with the
+          // API override so its scope covers the chat charter, matching
+          // classic's authority order (API before CHAT).
+          ...(resolvedExecutionProfile === 'text_artifact'
+            ? [API_MODE_OVERRIDE, '\n\n---\n\n']
+            : []),
           CHAT_MODE_OVERRIDE,
           '\n\n---\n\n',
           PROMPT_INJECTION_RESISTANCE,
@@ -890,8 +893,10 @@ export function composeSystemPrompt({
             // either — CHAT_MODE_OVERRIDE forbids creating media, which would
             // contradict the media-generation contract appended below as the
             // sole workflow authority. Keep classic's skeleton: API override
-            // first on plain streams, then injection resistance.
-            ...(streamFormat === 'plain' ? [API_MODE_OVERRIDE, '\n\n---\n\n'] : []),
+            // first on text-artifact profiles, then injection resistance.
+            ...(resolvedExecutionProfile === 'text_artifact'
+              ? [API_MODE_OVERRIDE, '\n\n---\n\n']
+              : []),
             PROMPT_INJECTION_RESISTANCE,
             '\n\n---\n\n',
           ]
@@ -914,12 +919,9 @@ export function composeSystemPrompt({
         : [],
   );
   const resolvedExclusiveSurface = resolveExclusiveSurface({ metadata, skillMode, skillModes });
-  const resolvedExecutionProfile =
-    executionProfile ?? executionProfileFromStreamFormat(streamFormat);
 
-  // API/BYOK mode (streamFormat === 'plain'): mirrors the same fix from
-  // `@open-design/contracts`'s composer. The daemon hits this path for
-  // any plain-stream adapter (e.g. DeepSeek), so without pinning the
+  // Tool-less text-artifact mode mirrors the API/BYOK fix from
+  // `@open-design/contracts`'s composer. Without pinning the
   // override above DISCOVERY_AND_PHILOSOPHY here too, those daemon
   // agents still emit the `<todo-list>` / `[读取 X]` pseudo-tool
   // markup described in #313. Keep the wording byte-identical to the
@@ -930,7 +932,7 @@ export function composeSystemPrompt({
   // mid-conversation only invalidates the cached suffix, not the whole prompt.
   const slimTurnVariableParts: string[] = [];
 
-  if (streamFormat === 'plain' && !isSlimCore) {
+  if (resolvedExecutionProfile === 'text_artifact' && !isSlimCore) {
     // Slim runs (charter head AND ask head) already composed this first.
     parts.push(API_MODE_OVERRIDE);
     parts.push('\n\n---\n\n');

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -50,6 +50,7 @@ import {
   type MediaExecutionPolicy,
   type MediaSurface,
 } from '@open-design/contracts';
+import type { RuntimePromptToolVocabulary } from '../runtimes/types.js';
 
 // Prepended first in every composed prompt so it wins precedence over all
 // later sections, including skill bodies and user/project instructions.
@@ -631,6 +632,37 @@ function renderDesignSystemImportModeGuidance(
   return undefined;
 }
 
+const NATIVE_TOOL_VOCABULARY_OVERRIDE = `# Native runtime tools (read first — overrides named-tool instructions below)
+
+This runtime owns its tool names and exposes its own filesystem and shell capabilities. Treat every later instruction to inspect, create, change, search, or validate project files as an outcome to complete with whatever native capabilities are available. Treat planning and progress instructions the same way: use a native task-list feature when one exists; otherwise keep a concise prose plan and continue.
+
+Never emit, simulate, or narrate a tool call. The Open Design host only needs the resulting project files, progress text, and final summary.`;
+
+const OPEN_DESIGN_TOOL_NAME_REPLACEMENTS = {
+  TodoWrite: 'task list',
+  WebFetch: 'web fetch',
+  WebSearch: 'web search',
+  Read: 'read',
+  Write: 'write',
+  Edit: 'edit',
+  Bash: 'shell',
+  Glob: 'file search',
+  Grep: 'text search',
+} as const;
+
+const OPEN_DESIGN_TOOL_NAME_PATTERN =
+  /\b(?:TodoWrite|WebFetch|WebSearch|Read|Write|Edit|Bash|Glob|Grep)\b/g;
+
+function neutralizeOpenDesignToolNames(prompt: string): string {
+  return prompt.replace(
+    OPEN_DESIGN_TOOL_NAME_PATTERN,
+    (toolName) =>
+      OPEN_DESIGN_TOOL_NAME_REPLACEMENTS[
+        toolName as keyof typeof OPEN_DESIGN_TOOL_NAME_REPLACEMENTS
+      ],
+  );
+}
+
 export interface ComposeInput {
   agentId?: string | null | undefined;
   includeCodexImagegenOverride?: boolean | undefined;
@@ -786,6 +818,8 @@ export interface ComposeInput {
   // `detectPlatformIntentSignal`). ORed with the metadata-based platform
   // gate for PLATFORM_CONTRACTS_BLOCK under slim; absent = metadata only.
   platformHintSignal?: boolean | undefined;
+  // Native-tool runtimes receive outcome-oriented instructions without OD tool names.
+  promptToolVocabulary?: RuntimePromptToolVocabulary | undefined;
 }
 
 export function composeSystemPrompt({
@@ -828,6 +862,7 @@ export function composeSystemPrompt({
   promptCoreVariant,
   mediaHintSignal,
   platformHintSignal,
+  promptToolVocabulary,
 }: ComposeInput): string {
   // Slim core collapses the discovery layer + designer charter + their tail
   // overrides into one charter document; the classic stack keeps the legacy
@@ -849,6 +884,10 @@ export function composeSystemPrompt({
   const isSlimCharterHead = isSlimCore && !isAskModeEarly && !isMediaSurfaceEarly;
   const resolvedExecutionProfile =
     executionProfile ?? executionProfileFromStreamFormat(streamFormat);
+  const nativeToolVocabularyParts =
+    promptToolVocabulary === 'native'
+      ? [NATIVE_TOOL_VOCABULARY_OVERRIDE, '\n\n---\n\n']
+      : [];
 
   // Head ordering differs by variant, following prompt-caching prefix rules
   // (stable content first — see shared prompt-caching guidance):
@@ -871,6 +910,7 @@ export function composeSystemPrompt({
         ...(resolvedExecutionProfile === 'text_artifact'
           ? [API_MODE_OVERRIDE, '\n\n---\n\n']
           : []),
+        ...nativeToolVocabularyParts,
         renderSlimCoreCharter(resolvedExecutionProfile),
         '\n\n---\n\n',
       ]
@@ -882,6 +922,7 @@ export function composeSystemPrompt({
           ...(resolvedExecutionProfile === 'text_artifact'
             ? [API_MODE_OVERRIDE, '\n\n---\n\n']
             : []),
+          ...nativeToolVocabularyParts,
           CHAT_MODE_OVERRIDE,
           '\n\n---\n\n',
           PROMPT_INJECTION_RESISTANCE,
@@ -897,10 +938,11 @@ export function composeSystemPrompt({
             ...(resolvedExecutionProfile === 'text_artifact'
               ? [API_MODE_OVERRIDE, '\n\n---\n\n']
               : []),
+            ...nativeToolVocabularyParts,
             PROMPT_INJECTION_RESISTANCE,
             '\n\n---\n\n',
           ]
-        : [PROMPT_INJECTION_RESISTANCE, '\n\n---\n\n'];
+        : [PROMPT_INJECTION_RESISTANCE, '\n\n---\n\n', ...nativeToolVocabularyParts];
   // The slim charter's plan step is deliberately generic ("use your runtime's
   // plan/todo tool, else a numbered list") so it works on codex / opencode /
   // ACP agents that have no such tool. Claude-family runs (streamFormat
@@ -1357,7 +1399,10 @@ export function composeSystemPrompt({
     "stop and ask the user a real question instead.",
   );
 
-  return parts.join('');
+  const prompt = parts.join('');
+  return promptToolVocabulary === 'native'
+    ? neutralizeOpenDesignToolNames(prompt)
+    : prompt;
 }
 
 /**

--- a/apps/daemon/src/runtimes/defs/antigravity.ts
+++ b/apps/daemon/src/runtimes/defs/antigravity.ts
@@ -234,6 +234,7 @@ export const antigravityAgentDef = {
   promptViaStdin: true,
   streamFormat: 'plain',
   executionProfile: 'filesystem',
+  promptToolVocabulary: 'native',
   installUrl: 'https://antigravity.google/cli',
   docsUrl: 'https://antigravity.google/docs/cli-overview',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/antigravity.ts
+++ b/apps/daemon/src/runtimes/defs/antigravity.ts
@@ -215,18 +215,8 @@ export const antigravityAgentDef = {
         runtimeContext.antigravitySettingsPath,
       );
     }
-    // We invoke agy via `-p -` (print mode + stdin sentinel), NOT
-    // `chat -`. Verified against `agy --help` on v1.0.3 — the
-    // `Available subcommands` list is `changelog / help / install /
-    // plugin / update`, and `chat` is NOT among them. `-p` is the
-    // documented print-mode flag (`Short alias for --print`) and
-    // `agy -p -` reads the prompt from stdin. The looper reviewer
-    // bot's environment runs a different agy build that may have
-    // renamed the entry point; until upstream confirms a stable
-    // headless subcommand (see google-antigravity/antigravity-cli#119)
-    // and the change actually ships in the auto-update channel that
-    // packaged OD users get, `-p -` is the contract that actually
-    // produces a print-mode reply on the installed CLI.
+    // `agy` 1.1.1 consumes piped stdin only when no prompt value is supplied.
+    // Passing `-p -` treats `-` as the literal prompt and ignores stdin.
     const args: string[] = [];
     // Always opt into `--log-file` when the daemon supplied a path so
     // it can post-exit grep for the actual upstream failure shape
@@ -235,20 +225,15 @@ export const antigravityAgentDef = {
     // never echoes those errors on stdout. See server.ts empty-output
     // guard for the consumer.
     //
-    // Flag order is load-bearing on agy v1.0.3: `agy -p --log-file
-    // /tmp/x -` runs successfully but leaves /tmp/x empty, while `agy
-    // --log-file /tmp/x -p -` captures the diagnostic log, including
-    // `Propagating selected model override to backend: label="<model>"`
-    // and auth/quota failures.
+    // `--log-file` remains compatible with stdin-driven headless mode.
     if (runtimeContext.agentLogFilePath) {
       args.push('--log-file', runtimeContext.agentLogFilePath);
     }
-    args.push('-p');
-    args.push('-');
     return args;
   },
   promptViaStdin: true,
   streamFormat: 'plain',
+  executionProfile: 'filesystem',
   installUrl: 'https://antigravity.google/cli',
   docsUrl: 'https://antigravity.google/docs/cli-overview',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/detection.ts
+++ b/apps/daemon/src/runtimes/detection.ts
@@ -270,12 +270,12 @@ function stripFns(
   // Drop the buildArgs / listModels closures but keep declarative metadata
   // (reasoningOptions, streamFormat, name, bin, etc.). `models` is
   // populated separately by `fetchModels`, so we strip the static
-  // `fallbackModels` slot here too. `helpArgs` / `capabilityFlags` /
-  // `fallbackBins` / `maxPromptArgBytes` / `env` are probe-or-spawn-only
-  // metadata and shouldn't bleed into the API response either.
-  // `inactivityTimeoutMs` is a spawn-time hint for the chat-run watchdog
-  // and is not part of the public AgentInfo contract — strip it here so
-  // the runtime registry stays the only consumer.
+  // `fallbackModels`, execution metadata, and probe-or-spawn-only settings
+  // (`helpArgs` / `capabilityFlags` / `fallbackBins` / `maxPromptArgBytes` /
+  // `env`) shouldn't bleed into the API response either. `inactivityTimeoutMs`
+  // is a spawn-time hint for the chat-run watchdog and is not part of the
+  // public AgentInfo contract — strip it here so the runtime registry stays
+  // the only consumer.
   const {
     buildArgs,
     listModels,
@@ -287,6 +287,8 @@ function stripFns(
     versionProbeTimeoutMs,
     maxPromptArgBytes,
     env,
+    executionProfile,
+    promptToolVocabulary,
     inactivityTimeoutMs,
     authProbe,
     ...rest

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -95,6 +95,8 @@ export type RuntimePromptBudgetError = {
   limit: number;
 };
 
+export type RuntimePromptToolVocabulary = 'open-design' | 'native';
+
 export type RuntimeAgentDef = {
   id: string;
   name: string;
@@ -111,6 +113,8 @@ export type RuntimeAgentDef = {
   streamFormat: string;
   // Plain stdout does not necessarily mean the runtime lacks filesystem tools.
   executionProfile?: ExecutionProfile;
+  // Native-tool CLIs own their tool names; avoid OD-managed tool tokens in prompts.
+  promptToolVocabulary?: RuntimePromptToolVocabulary;
   fallbackBins?: string[];
   versionProbeTimeoutMs?: number;
   helpArgs?: string[];

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -274,6 +274,8 @@ export type DetectedAgent = Omit<
   // shared web/CLI shape — agents pick it up by reading the runtime
   // def directly, the registry payload stays unchanged.
   | 'inactivityTimeoutMs'
+  | 'executionProfile'
+  | 'promptToolVocabulary'
   | 'authProbe'
 > & {
   models: RuntimeModelOption[];

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -1,5 +1,5 @@
 import type { ExecFileOptions } from 'node:child_process';
-import type { AgentDiagnostic, ModelMetadata } from '@open-design/contracts';
+import type { AgentDiagnostic, ExecutionProfile, ModelMetadata } from '@open-design/contracts';
 
 export type { AgentDiagnostic } from '@open-design/contracts';
 
@@ -109,6 +109,8 @@ export type RuntimeAgentDef = {
     runtimeContext?: RuntimeContext,
   ) => string[];
   streamFormat: string;
+  // Plain stdout does not necessarily mean the runtime lacks filesystem tools.
+  executionProfile?: ExecutionProfile;
   fallbackBins?: string[];
   versionProbeTimeoutMs?: number;
   helpArgs?: string[];

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4026,6 +4026,7 @@ export async function startServer({
       }
     }
 
+    const promptAgentDef = getAgentDef(agentId);
     const prompt = composeSystemPrompt({
       agentId,
       includeCodexImagegenOverride: false,
@@ -4067,7 +4068,8 @@ export async function startServer({
       byokMediaDefaults,
       streamFormat,
       executionProfile:
-        getAgentDef(agentId)?.executionProfile ?? executionProfileFromStreamFormat(streamFormat),
+        promptAgentDef?.executionProfile ?? executionProfileFromStreamFormat(streamFormat),
+      promptToolVocabulary: promptAgentDef?.promptToolVocabulary,
       ...(pluginBlock ? { pluginBlock } : {}),
       ...(activeStageBlocks ? { activeStageBlocks } : {}),
       userInstructions,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -4066,7 +4066,8 @@ export async function startServer({
       mediaExecution,
       byokMediaDefaults,
       streamFormat,
-      executionProfile: executionProfileFromStreamFormat(streamFormat),
+      executionProfile:
+        getAgentDef(agentId)?.executionProfile ?? executionProfileFromStreamFormat(streamFormat),
       ...(pluginBlock ? { pluginBlock } : {}),
       ...(activeStageBlocks ? { activeStageBlocks } : {}),
       userInstructions,
@@ -5082,7 +5083,8 @@ export async function startServer({
     lifecycle.mark('prompt_build_end');
     lifecycle.mark('launch_preflight_start');
     // (model resolution + AMR concretization hoisted above the resume guard)
-    const executionProfile = executionProfileFromStreamFormat(def.streamFormat);
+    const executionProfile =
+      def.executionProfile ?? executionProfileFromStreamFormat(def.streamFormat);
     // Accumulates the agent's visible text this run so the close handler can
     // tell whether the turn ended on a clarifying question form. The
     // `od-plugin-authoring` plugin's turn-1 flow is to emit a

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -3952,8 +3952,10 @@ export async function startServer({
     //
     // Non-plain adapters (claude-stream-json, copilot-stream-json,
     // json-event-stream, acp-json-rpc, pi-rpc) emit their own wrapper
-    // protocol; the v1 critique parser only understands plain stdout. The
-    // spawn path falls through to legacy generation for those, so the
+    // protocol; the v1 critique parser only understands plain stdout. Plain
+    // filesystem profiles also skip it because their canonical output is a
+    // project file, not the stdout artifact envelope the parser consumes.
+    // The spawn path falls through to legacy generation for those, so the
     // panel addendum has to be suppressed here too: otherwise the model
     // is instructed to emit Critique Theater tags that no orchestrator
     // consumes.
@@ -3967,11 +3969,17 @@ export async function startServer({
       || resolvedExclusiveSurface === 'video'
       || resolvedExclusiveSurface === 'audio';
     const isPlainAdapter = (streamFormat ?? 'plain') === 'plain';
+    const promptAgentDef = getAgentDef(agentId);
+    const promptExecutionProfile =
+      promptAgentDef?.executionProfile ?? executionProfileFromStreamFormat(streamFormat);
     const critiqueShouldRun = critiqueEnabledForRun
       && critiqueBrand !== undefined
       && critiqueSkill !== undefined
       && !isMediaSurface
-      && isPlainAdapter;
+      && isPlainAdapter
+      // Critique Theater v1 consumes stdout artifacts. Filesystem profiles
+      // write canonical project files instead, even when their stream is plain.
+      && promptExecutionProfile === 'text_artifact';
     // Only thread the critique fields when the run is actually eligible;
     // otherwise the composer's own internal eligibility check (cfg.enabled
     // && brand && skill && !isMediaSurface) might still fire on
@@ -4026,7 +4034,6 @@ export async function startServer({
       }
     }
 
-    const promptAgentDef = getAgentDef(agentId);
     const prompt = composeSystemPrompt({
       agentId,
       includeCodexImagegenOverride: false,
@@ -4067,8 +4074,7 @@ export async function startServer({
       mediaExecution,
       byokMediaDefaults,
       streamFormat,
-      executionProfile:
-        promptAgentDef?.executionProfile ?? executionProfileFromStreamFormat(streamFormat),
+      executionProfile: promptExecutionProfile,
       promptToolVocabulary: promptAgentDef?.promptToolVocabulary,
       ...(pluginBlock ? { pluginBlock } : {}),
       ...(activeStageBlocks ? { activeStageBlocks } : {}),
@@ -6479,6 +6485,46 @@ export async function startServer({
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
 
+    const deliverPromptToChildStdin = () => {
+      const stdin = child.stdin;
+      if (!writePromptToChildStdin || !stdin) return;
+
+      writePromptToChildStdin = false;
+      const promptInputFormat = def.promptInputFormat ?? 'text';
+      lifecycle.mark('model_call_start');
+      lifecycle.mark('stdin_write_start');
+      const markStdinWriteEnd = (err?: Error | null) => {
+        if (err) return;
+        lifecycle.mark('stdin_write_end');
+      };
+      if (promptInputFormat === 'stream-json') {
+        // Wrap the prompt as an Anthropic user message and write it as one
+        // JSONL line. Do NOT close stdin: claude-code keeps reading further
+        // messages until EOF, which is what lets the daemon stream more user
+        // messages into the same turn. The stdin is closed on a clean terminal
+        // turn (see applyClaudeStreamJsonRunBookkeeping) or when the child
+        // exits (run terminates, user cancels).
+        const userMessage = JSON.stringify({
+          type: 'user',
+          message: {
+            role: 'user',
+            content: [{ type: 'text', text: composed }],
+          },
+        });
+        try {
+          stdin.write(`${userMessage}\n`, 'utf8', markStdinWriteEnd);
+        } catch (err) {
+          // Swallow EPIPE here for the same reason as the listener above —
+          // a fast-exiting child has already routed its failure through
+          // stderr / exit handlers.
+          if (err && err.code !== 'EPIPE') throw err;
+        }
+        run.stdinOpen = true;
+      } else {
+        stdin.end(composed, 'utf8', markStdinWriteEnd);
+      }
+    };
+
     // Reset the inactivity watchdog on every raw stdout byte so that
     // structured adapters that buffer partial lines (Codex item.completed,
     // pi-rpc session/prompt, ACP agent messages) and models that spend a
@@ -6581,13 +6627,12 @@ export async function startServer({
     });
 
     // Critique Theater branch (M0 dark launch, default disabled).
-    // Only plain-stream adapters are routed through runOrchestrator in v1.
-    // Adapters that emit structured wrappers (claude-stream-json,
-    // qoder-stream-json, copilot-stream-json, json-event-stream,
-    // acp-json-rpc, pi-rpc) fall
-    // through to the legacy single-pass code path below with a one-time
-    // stderr warning so the parser never sees wrapper bytes. Per-format
-    // decoding into the orchestrator is a v2 concern.
+    // Only plain-stream text-artifact adapters are routed through
+    // runOrchestrator in v1. Adapters that emit structured wrappers
+    // (claude-stream-json, qoder-stream-json, copilot-stream-json,
+    // json-event-stream, acp-json-rpc, pi-rpc) and plain filesystem
+    // adapters fall through to the legacy single-pass code path below.
+    // Per-format decoding and filesystem-artifact orchestration are v2 concerns.
     //
     // Use critiqueShouldRun (computed in the prompt builder) instead of
     // just the env var or the rollout resolver so the orchestrator gate
@@ -6694,6 +6739,9 @@ export async function startServer({
             resolve({ code, signal });
           });
         });
+        // Prompt-via-stdin plain adapters cannot produce the critique stream
+        // until stdin closes, so deliver before the orchestrator awaits stdout.
+        deliverPromptToChildStdin();
         try {
           const orchestratorResult = await runOrchestrator({
             runId: critiqueRunId,
@@ -7956,41 +8004,7 @@ export async function startServer({
         cleanupPromptFile();
       }
     });
-    if (writePromptToChildStdin && child.stdin) {
-      const promptInputFormat = def.promptInputFormat ?? 'text';
-      lifecycle.mark('model_call_start');
-      lifecycle.mark('stdin_write_start');
-      const markStdinWriteEnd = (err?: Error | null) => {
-        if (err) return;
-        lifecycle.mark('stdin_write_end');
-      };
-      if (promptInputFormat === 'stream-json') {
-        // Wrap the prompt as an Anthropic user message and write it as one
-        // JSONL line. Do NOT close stdin: claude-code keeps reading further
-        // messages until EOF, which is what lets the daemon stream more user
-        // messages into the same turn. The stdin is closed on a clean terminal
-        // turn (see applyClaudeStreamJsonRunBookkeeping) or when the child
-        // exits (run terminates, user cancels).
-        const userMessage = JSON.stringify({
-          type: 'user',
-          message: {
-            role: 'user',
-            content: [{ type: 'text', text: composed }],
-          },
-        });
-        try {
-          child.stdin.write(`${userMessage}\n`, 'utf8', markStdinWriteEnd);
-        } catch (err) {
-          // Swallow EPIPE here for the same reason as the listener above —
-          // a fast-exiting child has already routed its failure through
-          // stderr / exit handlers.
-          if (err && err.code !== 'EPIPE') throw err;
-        }
-        run.stdinOpen = true;
-      } else {
-        child.stdin.end(composed, 'utf8', markStdinWriteEnd);
-      }
-    }
+    deliverPromptToChildStdin();
   };
 
   orbitService.setRunHandler(async ({

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -1855,6 +1855,204 @@ process.stdin.on('end', () => {
     }
   });
 
+  it('keeps Critique Theater active for plain text-artifact runtimes', async () => {
+    if (!process.env.OD_DATA_DIR) {
+      throw new Error('OD_DATA_DIR is required for text-artifact critique tests');
+    }
+
+    const projectId = `critique-text-artifact-project-${randomUUID()}`;
+    const skillId = `critique-text-artifact-${randomUUID()}`;
+    const skillDir = resolve(process.env.OD_DATA_DIR, 'skills', skillId);
+    const originalCritiqueEnabled = process.env.OD_CRITIQUE_ENABLED;
+
+    const createProjectResponse = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: projectId,
+        name: 'Text-artifact critique eligibility fixture',
+        designSystemId: 'default',
+      }),
+    });
+    expect(createProjectResponse.ok).toBe(true);
+
+    await fsp.mkdir(skillDir, { recursive: true });
+    await fsp.writeFile(
+      resolve(skillDir, 'SKILL.md'),
+      `---
+name: ${skillId}
+description: Text-artifact critique eligibility regression fixture.
+---
+
+# Text-artifact critique fixture
+
+This skill supplies the context needed to make critique eligible.
+`,
+      'utf8',
+    );
+
+    process.env.OD_CRITIQUE_ENABLED = 'true';
+
+    try {
+      await withFakeAgent(
+        'qwen',
+        `
+const args = process.argv.slice(2);
+if (args[0] === '--version') {
+  console.log('1.0.0-test');
+  process.exit(0);
+}
+let prompt = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  prompt += chunk;
+});
+process.stdin.on('end', () => {
+  if (!prompt.includes('<CRITIQUE_RUN')) {
+    process.stdout.write('missing-critique-panel\\n');
+    process.exit(0);
+  }
+  process.stdout.write([
+    '<CRITIQUE_RUN version="1" maxRounds="3" threshold="8.0" scale="10">',
+    '  <ROUND n="1">',
+    '    <PANELIST role="designer">',
+    '      <NOTES>v1</NOTES>',
+    '      <ARTIFACT mime="text/html"><![CDATA[<html><body>draft</body></html>]]></ARTIFACT>',
+    '    </PANELIST>',
+    '    <PANELIST role="critic" score="9.0"><DIM name="hierarchy" score="9">ok</DIM></PANELIST>',
+    '    <PANELIST role="brand" score="9.0"><DIM name="voice" score="9">ok</DIM></PANELIST>',
+    '    <PANELIST role="a11y" score="9.0"><DIM name="contrast" score="9">ok</DIM></PANELIST>',
+    '    <PANELIST role="copy" score="9.0"><DIM name="clarity" score="9">ok</DIM></PANELIST>',
+    '    <ROUND_END n="1" composite="9.0" must_fix="0" decision="ship">',
+    '      <REASON>Ship on round 1.</REASON>',
+    '    </ROUND_END>',
+    '  </ROUND>',
+    '  <SHIP round="1" composite="9.0" status="shipped">',
+    '    <ARTIFACT mime="text/html"><![CDATA[<html><body>final</body></html>]]></ARTIFACT>',
+    '    <SUMMARY>Text-artifact route remained critique-eligible.</SUMMARY>',
+    '  </SHIP>',
+    '</CRITIQUE_RUN>',
+  ].join('\\n') + '\\n');
+  process.exit(0);
+});
+`,
+        async () => {
+          const response = await fetch(`${baseUrl}/api/chat`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              agentId: 'qwen',
+              projectId,
+              designSystemId: 'default',
+              message: 'draft a text artifact with critique orchestration',
+              skillIds: [skillId],
+            }),
+          });
+          const body = await response.text();
+
+          expect(response.ok).toBe(true);
+          expect(body).toContain('event: critique.run_started');
+          expect(body).toContain('event: critique.ship');
+          expect(body).toContain('Text-artifact route remained critique-eligible.');
+          expect(body).toContain('"status":"shipped"');
+          expect(body).not.toContain('missing-critique-panel');
+        },
+      );
+    } finally {
+      if (originalCritiqueEnabled == null) {
+        delete process.env.OD_CRITIQUE_ENABLED;
+      } else {
+        process.env.OD_CRITIQUE_ENABLED = originalCritiqueEnabled;
+      }
+      await fsp.rm(skillDir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips Critique Theater for plain filesystem runtimes', async () => {
+    if (!process.env.OD_DATA_DIR) {
+      throw new Error('OD_DATA_DIR is required for filesystem critique tests');
+    }
+
+    const skillId = `critique-filesystem-${randomUUID()}`;
+    const skillDir = resolve(process.env.OD_DATA_DIR, 'skills', skillId);
+    const originalCritiqueEnabled = process.env.OD_CRITIQUE_ENABLED;
+
+    await fsp.mkdir(skillDir, { recursive: true });
+    await fsp.writeFile(
+      resolve(skillDir, 'SKILL.md'),
+      `---
+name: ${skillId}
+description: Filesystem critique eligibility regression fixture.
+---
+
+# Filesystem critique fixture
+
+This skill supplies the context needed to make critique otherwise eligible.
+`,
+      'utf8',
+    );
+
+    process.env.OD_CRITIQUE_ENABLED = 'true';
+
+    try {
+      await withFakeAgent(
+        'agy',
+        `
+const args = process.argv.slice(2);
+if (args[0] === '--version') {
+  console.log('1.1.1-test');
+  process.exit(0);
+}
+let prompt = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  prompt += chunk;
+});
+process.stdin.on('end', () => {
+  const hasFilesystemHandoff =
+    prompt.includes('## Filesystem handoff') ||
+    prompt.includes('You work in a filesystem-backed project');
+  const checks = [
+    hasFilesystemHandoff ? 'filesystem-handoff-enabled' : 'missing-filesystem-handoff',
+    prompt.includes('API mode — no tools available') ? 'unexpected-api-mode' : 'api-mode-disabled-for-filesystem',
+    prompt.includes('<CRITIQUE_RUN') ? 'unexpected-critique-panel' : 'critique-panel-disabled-for-filesystem',
+  ];
+  process.stdout.write(checks.join('\\n') + '\\n');
+  process.exit(0);
+});
+`,
+        async () => {
+          const response = await fetch(`${baseUrl}/api/chat`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              agentId: 'antigravity',
+              designSystemId: 'default',
+              message: 'draft a filesystem artifact without critique orchestration',
+              skillIds: [skillId],
+            }),
+          });
+          const body = await response.text();
+
+          expect(response.ok).toBe(true);
+          expect(body).toContain('filesystem-handoff-enabled');
+          expect(body).toContain('critique-panel-disabled-for-filesystem');
+          expect(body).toContain('api-mode-disabled-for-filesystem');
+          expect(body).not.toContain('missing-filesystem-handoff');
+          expect(body).not.toContain('unexpected-critique-panel');
+          expect(body).not.toContain('unexpected-api-mode');
+        },
+      );
+    } finally {
+      if (originalCritiqueEnabled == null) {
+        delete process.env.OD_CRITIQUE_ENABLED;
+      } else {
+        process.env.OD_CRITIQUE_ENABLED = originalCritiqueEnabled;
+      }
+      await fsp.rm(skillDir, { recursive: true, force: true });
+    }
+  });
+
   it('preserves plugin-local and composed @-mention skills in plugin-bound runs', async () => {
     const pluginId = `plugin-local-${randomUUID()}`;
     const pluginFixtureDir = await createPluginFixture({

--- a/apps/daemon/tests/prompts/api-mode-override.test.ts
+++ b/apps/daemon/tests/prompts/api-mode-override.test.ts
@@ -113,5 +113,107 @@ describe('daemon composeSystemPrompt — API mode (#313)', () => {
       expect(prompt).toContain("runtime's native tool-call interface");
       expect(prompt).toContain('This runtime owns its tool names');
     });
+
+    it('keeps native filesystem semantics in the slim charter', () => {
+      const prompt = composeSystemPrompt({
+        streamFormat: antigravityAgentDef.streamFormat,
+        executionProfile: antigravityAgentDef.executionProfile,
+        promptToolVocabulary: antigravityAgentDef.promptToolVocabulary,
+        promptCoreVariant: 'slim',
+      });
+      const nativeToolsIdx = prompt.indexOf('# Native runtime tools');
+      const charterIdx = prompt.indexOf('# Open Design charter');
+
+      expect(prompt).not.toMatch(/API mode — no tools available/i);
+      expect(nativeToolsIdx).toBeGreaterThanOrEqual(0);
+      expect(charterIdx).toBeGreaterThan(nativeToolsIdx);
+      expect(prompt).toContain('filesystem-backed project');
+      for (const toolName of ['TodoWrite', 'Read', 'Write', 'Edit', 'Bash', 'Glob', 'Grep']) {
+        expect(prompt).not.toMatch(new RegExp(`\\b${toolName}\\b`));
+      }
+    });
+
+    it('preserves injected memory copy in the slim native prompt', () => {
+      const injectedCopy = 'Pre-Read: Read, Write, Edit, Bash, and Grep.';
+      const prompt = composeSystemPrompt({
+        streamFormat: antigravityAgentDef.streamFormat,
+        executionProfile: antigravityAgentDef.executionProfile,
+        promptToolVocabulary: antigravityAgentDef.promptToolVocabulary,
+        promptCoreVariant: 'slim',
+        memoryBody: `MEMORY ${injectedCopy}`,
+      });
+
+      expect(prompt).toContain(`MEMORY ${injectedCopy}`);
+    });
+
+    it('preserves injected copy while neutralizing only Open Design core instructions', () => {
+      const injectedCopy = 'Pre-Read: Read, Write, Edit, Bash, and Grep.';
+      const prompt = composeSystemPrompt({
+        streamFormat: antigravityAgentDef.streamFormat,
+        executionProfile: antigravityAgentDef.executionProfile,
+        promptToolVocabulary: antigravityAgentDef.promptToolVocabulary,
+        memoryBody: `MEMORY ${injectedCopy}`,
+        userInstructions: `USER ${injectedCopy}`,
+        projectInstructions: `PROJECT ${injectedCopy}`,
+        designSystemTitle: `DESIGN TITLE ${injectedCopy}`,
+        designSystemUsageMd: `DESIGN USAGE ${injectedCopy}`,
+        designSystemBody: `DESIGN BODY ${injectedCopy}`,
+        designSystemTokensCss: `:root { --copy: "${injectedCopy}"; }`,
+        designSystemComponentsManifest: `MANIFEST ${injectedCopy}`,
+        designSystemPullIndex: `PULL INDEX ${injectedCopy}`,
+        craftSections: [`CRAFT SECTION ${injectedCopy}`],
+        craftBody: `CRAFT BODY ${injectedCopy}`,
+        skillName: `SKILL NAME ${injectedCopy}`,
+        skillBody: `SKILL BODY ${injectedCopy}\nassets/template.html`,
+        pluginBlock: `PLUGIN ${injectedCopy}`,
+        activeStageBlocks: [`STAGE ${injectedCopy}`],
+        metadata: {
+          kind: 'template',
+          examplePrompt: true,
+          examplePromptTitle: `EXAMPLE TITLE ${injectedCopy}`,
+          examplePromptBrief: { brief: `EXAMPLE BRIEF ${injectedCopy}` },
+        },
+        template: {
+          name: `TEMPLATE ${injectedCopy}`,
+          description: `TEMPLATE DESCRIPTION ${injectedCopy}`,
+          files: [{ name: 'index.html', content: `<h1>${injectedCopy}</h1>` }],
+        },
+      });
+
+      for (const expected of [
+        `MEMORY ${injectedCopy}`,
+        `USER ${injectedCopy}`,
+        `PROJECT ${injectedCopy}`,
+        `DESIGN TITLE ${injectedCopy}`,
+        `DESIGN USAGE ${injectedCopy}`,
+        `DESIGN BODY ${injectedCopy}`,
+        `MANIFEST ${injectedCopy}`,
+        `PULL INDEX ${injectedCopy}`,
+        `CRAFT SECTION ${injectedCopy}`,
+        `CRAFT BODY ${injectedCopy}`,
+        `SKILL NAME ${injectedCopy}`,
+        `SKILL BODY ${injectedCopy}`,
+        `PLUGIN ${injectedCopy}`,
+        `STAGE ${injectedCopy}`,
+        `EXAMPLE TITLE ${injectedCopy}`,
+        `EXAMPLE BRIEF ${injectedCopy}`,
+        `TEMPLATE ${injectedCopy}`,
+        `TEMPLATE DESCRIPTION ${injectedCopy}`,
+        `<h1>${injectedCopy}</h1>`,
+      ]) {
+        expect(prompt).toContain(expected);
+      }
+      expect(prompt).toContain(':root { --copy: "Pre-Read: Read, Write, Edit, Bash, and Grep."; }');
+      expect(prompt).toContain(
+        '**Pre-flight (do this before any other tool):** read `assets/template.html`',
+      );
+      expect(prompt).not.toContain(
+        '**Pre-flight (do this before any other tool):** Read `assets/template.html`',
+      );
+      expect(prompt).toContain('Output your task list plan and then the artifact immediately.');
+      expect(prompt).not.toContain('Output your TodoWrite plan and then the artifact immediately.');
+      expect(prompt).toContain('you still plan with task list');
+      expect(prompt).not.toContain('you still plan with TodoWrite');
+    });
   });
 });

--- a/apps/daemon/tests/prompts/api-mode-override.test.ts
+++ b/apps/daemon/tests/prompts/api-mode-override.test.ts
@@ -133,25 +133,19 @@ describe('daemon composeSystemPrompt — API mode (#313)', () => {
       }
     });
 
-    it('preserves injected memory copy in the slim native prompt', () => {
+
+    it.each([
+      ['classic', undefined],
+      ['slim', 'slim'],
+    ] as const)(
+      'preserves injected copy while neutralizing only Open Design core instructions (%s)',
+      (_variant, promptCoreVariant) => {
       const injectedCopy = 'Pre-Read: Read, Write, Edit, Bash, and Grep.';
       const prompt = composeSystemPrompt({
         streamFormat: antigravityAgentDef.streamFormat,
         executionProfile: antigravityAgentDef.executionProfile,
         promptToolVocabulary: antigravityAgentDef.promptToolVocabulary,
-        promptCoreVariant: 'slim',
-        memoryBody: `MEMORY ${injectedCopy}`,
-      });
-
-      expect(prompt).toContain(`MEMORY ${injectedCopy}`);
-    });
-
-    it('preserves injected copy while neutralizing only Open Design core instructions', () => {
-      const injectedCopy = 'Pre-Read: Read, Write, Edit, Bash, and Grep.';
-      const prompt = composeSystemPrompt({
-        streamFormat: antigravityAgentDef.streamFormat,
-        executionProfile: antigravityAgentDef.executionProfile,
-        promptToolVocabulary: antigravityAgentDef.promptToolVocabulary,
+        promptCoreVariant,
         memoryBody: `MEMORY ${injectedCopy}`,
         userInstructions: `USER ${injectedCopy}`,
         projectInstructions: `PROJECT ${injectedCopy}`,
@@ -212,8 +206,11 @@ describe('daemon composeSystemPrompt — API mode (#313)', () => {
       );
       expect(prompt).toContain('Output your task list plan and then the artifact immediately.');
       expect(prompt).not.toContain('Output your TodoWrite plan and then the artifact immediately.');
-      expect(prompt).toContain('you still plan with task list');
-      expect(prompt).not.toContain('you still plan with TodoWrite');
-    });
+      if (promptCoreVariant !== 'slim') {
+        expect(prompt).toContain('you still plan with task list');
+        expect(prompt).not.toContain('you still plan with TodoWrite');
+      }
+      },
+    );
   });
 });

--- a/apps/daemon/tests/prompts/api-mode-override.test.ts
+++ b/apps/daemon/tests/prompts/api-mode-override.test.ts
@@ -79,5 +79,13 @@ describe('daemon composeSystemPrompt — API mode (#313)', () => {
       const prompt = composeSystemPrompt({ streamFormat: 'plain' });
       expect(prompt).toMatch(/<artifact>/);
     });
+
+    it('omits the API-mode override for filesystem-capable plain runtimes', () => {
+      const prompt = composeSystemPrompt({
+        streamFormat: 'plain',
+        executionProfile: 'filesystem',
+      });
+      expect(prompt).not.toMatch(/API mode — no tools available/i);
+    });
   });
 });

--- a/apps/daemon/tests/prompts/api-mode-override.test.ts
+++ b/apps/daemon/tests/prompts/api-mode-override.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { composeSystemPrompt } from '../../src/prompts/system.js';
+import { antigravityAgentDef } from '../../src/runtimes/defs/antigravity.js';
 
 /**
  * Daemon-side mirror of the API-mode override fix for #313.
@@ -86,6 +87,31 @@ describe('daemon composeSystemPrompt — API mode (#313)', () => {
         executionProfile: 'filesystem',
       });
       expect(prompt).not.toMatch(/API mode — no tools available/i);
+    });
+
+    it('uses native tool vocabulary for the Antigravity filesystem path', () => {
+      const prompt = composeSystemPrompt({
+        streamFormat: antigravityAgentDef.streamFormat,
+        executionProfile: antigravityAgentDef.executionProfile,
+        promptToolVocabulary: antigravityAgentDef.promptToolVocabulary,
+      });
+      expect(prompt).not.toMatch(/API mode — no tools available/i);
+      for (const toolName of [
+        'TodoWrite',
+        'Read',
+        'Write',
+        'Edit',
+        'Bash',
+        'Glob',
+        'Grep',
+        'WebFetch',
+        'WebSearch',
+      ]) {
+        expect(prompt).not.toMatch(new RegExp(`\\b${toolName}\\b`));
+      }
+      expect(prompt).toContain('filesystem-backed project');
+      expect(prompt).toContain("runtime's native tool-call interface");
+      expect(prompt).toContain('This runtime owns its tool names');
     });
   });
 });

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -532,6 +532,7 @@ test('antigravity pipes prompt via stdin without a prompt flag', () => {
   assert.equal(antigravity.streamFormat, 'plain');
   assert.equal(antigravity.promptViaStdin, true);
   assert.equal(antigravity.executionProfile, 'filesystem');
+  assert.equal(antigravity.promptToolVocabulary, 'native');
 
   const args = antigravity.buildArgs('write hello world', [], [], {}, {});
   assert.deepEqual(args, []);

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -525,27 +525,21 @@ test('qwen args check promptViaStdin, base args, model args and exclude `-` sent
   assert.equal(withModel.includes('-'), false);
 });
 
-// `agy` exposes `-p` (print mode, alias for `--print`) plus `-` as
-// the stdin sentinel — confirmed against `agy --help` on v1.0.3, where
-// `Available subcommands` is `changelog / help / install / plugin /
-// update` (no `chat`). Earlier review iterations pinned `['chat', '-']`
-// based on a different agy build the looper reviewer environment uses;
-// the installed CLI does not recognise it, exits 0 with no stdout, and
-// the daemon would render the resulting empty reply as a "successful"
-// agent response — exactly the failure mode the auth/quota guard at
-// server.ts ~12090 is meant to catch but for the wrong reason.
-test('antigravity pipes prompt via stdin via -p flag (print mode)', () => {
+// `agy` 1.1.1 reads piped stdin only when no prompt value is supplied.
+// Passing `-p -` treats `-` as the literal prompt and ignores stdin.
+test('antigravity pipes prompt via stdin without a prompt flag', () => {
   assert.equal(antigravity.bin, 'agy');
   assert.equal(antigravity.streamFormat, 'plain');
   assert.equal(antigravity.promptViaStdin, true);
+  assert.equal(antigravity.executionProfile, 'filesystem');
 
   const args = antigravity.buildArgs('write hello world', [], [], {}, {});
-  assert.deepEqual(args, ['-p', '-']);
+  assert.deepEqual(args, []);
 
   const argsWithLog = antigravity.buildArgs('write hello world', [], [], {}, {
     agentLogFilePath: '/tmp/od-agy-test.log',
   });
-  assert.deepEqual(argsWithLog, ['--log-file', '/tmp/od-agy-test.log', '-p', '-']);
+  assert.deepEqual(argsWithLog, ['--log-file', '/tmp/od-agy-test.log']);
 
   // No `--model` flag exists upstream, so buildArgs argv must stay the
   // same regardless of which label the user picks.
@@ -560,7 +554,7 @@ test('antigravity pipes prompt via stdin via -p flag (print mode)', () => {
       antigravitySettingsPath: join(settingsDir, 'settings.json'),
     });
     assert.equal(withModel.includes('--model'), false);
-    assert.deepEqual(withModel, ['--log-file', '/tmp/od-agy-test.log', '-p', '-']);
+    assert.deepEqual(withModel, ['--log-file', '/tmp/od-agy-test.log']);
   } finally {
     rmSync(settingsDir, { recursive: true, force: true });
   }
@@ -576,13 +570,12 @@ test('antigravity pipes prompt via stdin via -p flag (print mode)', () => {
   const followUp = antigravity.buildArgs('next message', [], [], {}, {
     hasPriorAssistantTurn: true,
   });
-  assert.deepEqual(followUp, ['-p', '-']);
-  assert.equal(followUp.includes('-c'), false);
+  assert.deepEqual(followUp, []);
 
   const firstTurn = antigravity.buildArgs('first', [], [], {}, {
     hasPriorAssistantTurn: false,
   });
-  assert.deepEqual(firstTurn, ['-p', '-']);
+  assert.deepEqual(firstTurn, []);
   assert.equal(antigravity.resumesSessionViaCli, undefined);
 
   assert.equal(antigravity.maxPromptArgBytes, undefined);

--- a/apps/daemon/tests/runtimes/registry-and-args.test.ts
+++ b/apps/daemon/tests/runtimes/registry-and-args.test.ts
@@ -367,6 +367,28 @@ test('codex model picker includes current OpenAI choices in priority order', asy
   }
 });
 
+test('Antigravity detection omits execution metadata from the public record', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-agents-antigravity-public-metadata-'));
+  try {
+    await withEnvSnapshot(['PATH', 'OD_AGENT_HOME'], async () => {
+      const agyBin = join(dir, 'agy');
+      writeFileSync(agyBin, '#!/bin/sh\nif [ "$1" = "--version" ]; then echo "agy 1.1.1"; exit 0; fi\nexit 0\n');
+      chmodSync(agyBin, 0o755);
+      process.env.OD_AGENT_HOME = dir;
+      process.env.PATH = dir;
+
+      const agents = await detectAgents();
+      const detected = agents.find((agent) => agent.id === 'antigravity');
+
+      assert.ok(detected);
+      assert.equal(Object.hasOwn(detected, 'executionProfile'), false);
+      assert.equal(Object.hasOwn(detected, 'promptToolVocabulary'), false);
+    });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('claude probes auth status so rescans reflect CLI auth changes', async () => {
   assert.deepEqual(claude.authProbe, {
     args: ['auth', 'status'],


### PR DESCRIPTION
Fixes #4597
Fixes #5448
Fixes #5495

## Why

I hit this while validating the Antigravity adapter against current `agy` releases after updating a downstream Open Design build.

`agy` 1.1.1 intentionally stopped reading stdin whenever a prompt value is supplied. Open Design still launched the CLI as `agy -p -`, so current releases treat `-` as the prompt and ignore the composed Open Design request. That produces the empty / single-dash replies reported in #5448 and #5495.

The adapter also declares `streamFormat: 'plain'`. Open Design previously treated every plain stream as a tool-less API run and injected the `API mode — no tools available` override, even though Antigravity has native filesystem tools. That mismatch produces the guardrail refusal reported in #4597.

This PR keeps the existing stdin transport, removes the prompt argument entirely, gives runtime definitions an explicit execution profile, and adds a native prompt-tool vocabulary so filesystem handoff stays active without naming Open Design-managed tools that Antigravity does not expose. The current no-prompt-flag stdin behavior and the 1.1.1 change are discussed upstream: https://github.com/google-antigravity/antigravity-cli/issues/582. That stdin path remains undocumented.

## What users will see

Selecting **Local CLI → Antigravity** now delivers the full Open Design prompt to current `agy` releases. Antigravity can follow the design brief and write project files instead of responding to an empty / `-` prompt or rejecting Open Design's no-tools preamble.

Existing model selection and `--log-file` diagnostics remain unchanged. The filesystem handoff remains active, but Antigravity now receives native-capability language instead of `TodoWrite` / `Read` / `Write` / `Edit` / `Bash` / `WebFetch` instructions.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — no UI surface changed.

## Bug fix verification

- Test paths:
  - `apps/daemon/tests/runtimes/agent-args.test.ts`
  - `apps/daemon/tests/prompts/api-mode-override.test.ts`
- Red on `main`: yes — the original branch tests produced 2 failures against `d954bee80` (Antigravity had no filesystem execution profile, and the API-mode override was still present).
- Review regression red on `bf270a26e`: yes — the Antigravity prompt still exposed OD-managed tool names and the runtime definition had no native vocabulary marker.
- Green on this branch: yes — 56/56 prompt/argv tests plus the focused filesystem-critique route regression pass.
- Runtime reproduction:
  - verified `agy` 1.1.1 and 1.1.2 read piped prompts when no prompt flag is supplied;
  - verified `agy -p -` does not consume the piped prompt on the affected releases;
  - on Windows, installed `agy` 1.1.4 (`C:\Users\btf\AppData\Local\agy\bin\agy.exe`) exited 0 and returned exactly `SEQ_BARE_114` for a piped `Return exactly SEQ_BARE_114` prompt with bare `agy`; `agy -p -` exited 0 but returned a generic greeting instead. This stdin path remains undocumented (https://github.com/google-antigravity/antigravity-cli/issues/582);
  - verified a 114,735-byte stdin prompt with a tail marker and `--log-file` returned the expected tail response without truncation;
  - ran Open Design through `tools-dev`, selected Antigravity in onboarding, then completed a real Design-mode run that created `antigravity-smoke.html` containing `ANTIGRAVITY_SMOKE_OK`;
  - after the first review fix, ran a second isolated `tools-dev` Antigravity flow that created `antigravity-native-final.html` containing `ANTIGRAVITY NATIVE PROMPT FINAL OK`;
  - after scoping native vocabulary neutralization, ran an isolated Antigravity flow whose generated HTML retained the exact `COPY_PROBE[Pre-Read: Read, Write, Edit, Bash, and Grep.]` marker;
  - with Critique Theater forced on, the focused `/api/chat` regression confirmed Antigravity keeps filesystem handoff and receives no `<CRITIQUE_RUN>` panel protocol.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/agent-args.test.ts tests/prompts/api-mode-override.test.ts` — 56 passed
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/chat-route.test.ts -t "skips Critique Theater for plain filesystem runtimes"` — 1 passed
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon build`
- `pnpm guard` — 78 guard tests passed
- `pnpm typecheck` — 0 errors (existing Astro hints only)
- `git diff --check upstream/main...HEAD`
- Browser smoke through `pnpm tools-dev` with an isolated daemon data root and Antigravity 1.1.2
- Direct Windows runtime probe with installed `agy` 1.1.4: bare `agy` returned exact `SEQ_BARE_114` from the piped prompt, while `agy -p -` returned a generic greeting; the working no-prompt-flag stdin path is undocumented (https://github.com/google-antigravity/antigravity-cli/issues/582).