### PR TITLE
fix(web): anchor browser-assist guide and workspace snapshot toasts to their panes

### DIFF
--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -3668,24 +3668,32 @@ export function FileWorkspace({
           onClose={() => setLauncherOpen(false)}
         />
       ) : null}
+      {/* Workspace-owned toasts anchor to this pane's bottom-center instead of
+          the viewport's: a bare fixed .od-toast centers across the whole
+          window, drifting over the chat pane and covering the composer send
+          area in split view. */}
       {browserSnapshotToast ? (
-        <Toast
-          message={browserSnapshotToast.message}
-          details={browserSnapshotToast.details}
-          actionLabel={browserSnapshotToast.actionLabel}
-          className={browserSnapshotToast.className}
-          onAction={browserSnapshotToast.onAction}
-          role={browserSnapshotToast.role}
-          tone={browserSnapshotToast.tone}
-          ttlMs={browserSnapshotToast.ttlMs}
-          onDismiss={() => setBrowserSnapshotToast(null)}
-        />
+        <div className="workspace-toast-anchor">
+          <Toast
+            message={browserSnapshotToast.message}
+            details={browserSnapshotToast.details}
+            actionLabel={browserSnapshotToast.actionLabel}
+            className={browserSnapshotToast.className}
+            onAction={browserSnapshotToast.onAction}
+            role={browserSnapshotToast.role}
+            tone={browserSnapshotToast.tone}
+            ttlMs={browserSnapshotToast.ttlMs}
+            onDismiss={() => setBrowserSnapshotToast(null)}
+          />
+        </div>
       ) : launcherToast ? (
-        <Toast
-          message={launcherToast}
-          role="alert"
-          onDismiss={() => setLauncherToast(null)}
-        />
+        <div className="workspace-toast-anchor">
+          <Toast
+            message={launcherToast}
+            role="alert"
+            onDismiss={() => setLauncherToast(null)}
+          />
+        </div>
       ) : null}
       <div className="ws-body">
         {/* Banner moved into DesignFilesPanel for the Design Files tab so

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -7956,6 +7956,7 @@ export function ProjectView({
             details: null,
             tone: 'error',
             ttlMs: 7000,
+            scope: 'chat-pane',
           });
           return { status: 'handled' };
         }
@@ -7978,6 +7979,7 @@ export function ProjectView({
             details: null,
             tone: 'error',
             ttlMs: 6000,
+            scope: 'chat-pane',
           });
           return { status: 'handled' };
         }
@@ -8007,6 +8009,7 @@ export function ProjectView({
             details: null,
             tone: 'error',
             ttlMs: 5000,
+            scope: 'chat-pane',
           });
           return;
         }
@@ -8055,6 +8058,7 @@ export function ProjectView({
         details: t('chat.brandBrowserAssistDownloadGuideDetails'),
         tone: 'error',
         ttlMs: 7000,
+        scope: 'chat-pane',
       });
     })()
       .catch((err) => {
@@ -8064,6 +8068,7 @@ export function ProjectView({
           details: null,
           tone: 'error',
           ttlMs: 5000,
+          scope: 'chat-pane',
         });
       })
       .finally(() => {

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -163,6 +163,35 @@
 .project-actions-toast-anchor .od-toast.leaving {
   animation: none;
 }
+/* Workspace-owned toasts (Download Page snapshot progress/result, tab
+   launcher errors) anchor to the workspace pane's bottom-center instead of
+   the viewport's, so they never drift over the chat pane or the composer
+   send area in split view. Requires `.workspace` to be the
+   containing block — see `position: relative` in workspace/drawer.css. */
+.workspace-toast-anchor {
+  position: absolute;
+  inset: auto 24px 24px;
+  display: flex;
+  justify-content: center;
+  z-index: 60;
+  pointer-events: none;
+}
+.workspace-toast-anchor .od-toast {
+  /* Relative (not static) so the absolutely-positioned close/action controls
+     keep the toast itself as their containing block. */
+  position: relative;
+  inset: auto;
+  transform: none;
+  animation: none;
+  pointer-events: auto;
+}
+.workspace-toast-anchor .od-toast.od-toast-browser-snapshot {
+  width: min(460px, 100%);
+  max-width: 100%;
+}
+.workspace-toast-anchor .od-toast.leaving {
+  animation: none;
+}
 .od-toast.tone-success {
   border: 1px solid color-mix(in srgb, var(--success, #2da44e) 42%, var(--border));
   background: color-mix(in srgb, var(--success, #2da44e) 14%, var(--bg));

--- a/apps/web/src/styles/workspace/drawer.css
+++ b/apps/web/src/styles/workspace/drawer.css
@@ -1361,6 +1361,9 @@
    File workspace — tabs + viewer
    ============================================================ */
 .workspace {
+  /* Containing block for .workspace-toast-anchor (viewer/routines.css), which
+     pins workspace-owned toasts to this pane instead of the viewport. */
+  position: relative;
   display: flex;
   flex-direction: column;
   min-height: 0;

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -1432,6 +1432,47 @@ describe('FileWorkspace launcher tab creation', () => {
     );
   });
 
+  it('anchors the browser snapshot toast inside the workspace pane', async () => {
+    // The Download Page progress/result toast is workspace-owned UI. Rendered
+    // as a bare fixed .od-toast it centers on the whole viewport, drifting
+    // over the chat pane and covering the composer send area in split view;
+    // the anchor scopes it to the workspace pane instead.
+    const browserTab = {
+      id: '__browser__:1',
+      insertAfter: '__design_files__',
+      label: 'Browser',
+      title: 'Example',
+      url: 'https://example.com',
+    };
+
+    render(
+      <FileWorkspace
+        projectId="project-1"
+        projectKind="prototype"
+        files={[]}
+        liveArtifacts={[]}
+        onRefreshFiles={vi.fn()}
+        isDeck={false}
+        tabsState={{
+          tabs: [],
+          active: '__browser__:1',
+          browserTabs: [browserTab],
+        }}
+        onTabsStateChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('emit-browser-snapshot-success'));
+
+    const toast = await waitFor(() => {
+      const node = document.querySelector<HTMLElement>('.od-toast');
+      expect(node?.textContent).toContain('Saved page snapshot');
+      return node as HTMLElement;
+    });
+    expect(toast.closest('.workspace-toast-anchor')).toBeTruthy();
+    expect(toast.closest('[data-testid="file-workspace"]')).toBeTruthy();
+  });
+
   it('anchors a new browser after the visible tab tail', async () => {
     const onTabsStateChange = vi.fn();
     const rootBrowserTab = {

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -17,6 +17,10 @@ import {
   shouldClearActiveRunRefs,
   shouldReplayTerminalRunMessage,
 } from '../../src/components/ProjectView';
+import {
+  BRAND_BROWSER_TAB_ID,
+  registerBrandBrowser,
+} from '../../src/runtime/brand-browser-bridge';
 import type { Artifact, ChatMessage, ProjectFile } from '../../src/types';
 
 const listConversations = vi.fn();
@@ -41,7 +45,9 @@ const patchProject = vi.fn();
 const patchPreviewCommentStatus = vi.fn();
 const saveTabs = vi.fn();
 const writeProjectTextFile = vi.fn();
+const fetchProjectFileText = vi.fn();
 const cancelBrandExtraction = vi.fn();
+const continueBrandExtraction = vi.fn();
 const originalFetch = globalThis.fetch;
 
 const replayArtifact: Artifact = {
@@ -136,6 +142,7 @@ vi.mock('../../src/providers/registry', () => ({
   fetchProjectDesignSystemPackageAudit: (...args: unknown[]) => fetchProjectDesignSystemPackageAudit(...args),
   fetchLiveArtifacts: (...args: unknown[]) => fetchLiveArtifacts(...args),
   fetchProjectFiles: (...args: unknown[]) => fetchProjectFiles(...args),
+  fetchProjectFileText: (...args: unknown[]) => fetchProjectFileText(...args),
   fetchSkill: (...args: unknown[]) => fetchSkill(...args),
   patchPreviewCommentStatus: (...args: unknown[]) => patchPreviewCommentStatus(...args),
   upsertPreviewComment: vi.fn(),
@@ -151,6 +158,7 @@ vi.mock('../../src/runtime/brands', async () => {
   return {
     ...actual,
     cancelBrandExtraction: (...args: unknown[]) => cancelBrandExtraction(...args),
+    continueBrandExtraction: (...args: unknown[]) => continueBrandExtraction(...args),
   };
 });
 
@@ -220,6 +228,7 @@ async function waitForReadyChatPaneProps() {
       reason?: string;
       url?: string;
     }) => Promise<{ ok: boolean; action?: string; message?: string } | void> | { ok: boolean; action?: string; message?: string } | void;
+    onContinueBrandExtraction?: () => void;
     onSend?: (prompt: string, attachments: unknown[], comments: unknown[]) => Promise<void>;
     initialDraft?: string;
   };
@@ -1056,6 +1065,97 @@ describe('ProjectView daemon cleanup', () => {
     expect(toast.closest('.project-actions-toast-anchor')).toBeTruthy();
     expect(toast.closest('.split-chat-slot')).toBeTruthy();
     expect(toast.closest('.chat-log-wrap')?.className).toContain('has-chat-log-tray');
+  });
+
+  it('anchors the continue-extraction download-page guide in the chat pane too', async () => {
+    // The "Download Page" guide that fires when Continue extraction cannot
+    // read any snapshot must anchor between the transcript and the composer,
+    // exactly like the browser-assist confirm guide above. Rendering it
+    // through the viewport-fixed fallback floats it bottom-center across
+    // both panes, covering the composer send area.
+    listConversations.mockResolvedValue([{ id: 'conv-brand', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+    streamViaDaemon.mockResolvedValue(undefined);
+    // No saved page archive on disk…
+    fetchProjectFileText.mockResolvedValue(null);
+    // …and the daemon cannot finish programmatically either.
+    continueBrandExtraction.mockResolvedValue({ ok: false, error: 'still walled' });
+
+    // A mounted desktop Browser tab whose live DOM and page-snapshot download
+    // both fail, so the flow lands on the "Download Page" guide toast.
+    registerBrandBrowser('brand-project', BRAND_BROWSER_TAB_ID, {
+      executeJavaScript: () => null,
+      downloadPageSnapshot: async () => ({ ok: false, message: 'snapshot save failed' }),
+      getURL: () => 'https://refly.ai/',
+      isDesktopWebview: true,
+    });
+
+    chatPaneSpy.mockClear();
+    fileWorkspaceSpy.mockClear();
+
+    try {
+      render(
+        <ProjectView
+          project={{
+            id: 'brand-project',
+            name: 'Refly Design System',
+            skillId: null,
+            designSystemId: null,
+            metadata: {
+              kind: 'brand',
+              importedFrom: 'brand-extraction',
+              brandId: 'refly-ai',
+              brandSourceUrl: 'https://refly.ai/',
+            },
+            createdAt: 1,
+            updatedAt: 1,
+          } as never}
+          routeFileName={null}
+          config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
+          agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
+          skills={[]}
+          designTemplates={[]}
+          designSystems={[]}
+          daemonLive
+          onModeChange={() => {}}
+          onAgentChange={() => {}}
+          onAgentModelChange={() => {}}
+          onRefreshAgents={() => {}}
+          onOpenSettings={() => {}}
+          onBack={() => {}}
+          onClearPendingPrompt={() => {}}
+          onTouchProject={() => {}}
+          onProjectChange={() => {}}
+          onProjectsRefresh={() => {}}
+        />,
+      );
+
+      const chatProps = await waitForReadyChatPaneProps();
+      expect(chatProps.onContinueBrandExtraction).toBeTypeOf('function');
+
+      await act(async () => {
+        chatProps.onContinueBrandExtraction?.();
+      });
+
+      const toast = await waitFor(() => {
+        const node = document.querySelector('.od-toast');
+        expect(node?.textContent).toContain('chat.brandBrowserAssistDownloadGuideDetails');
+        return node as HTMLElement;
+      });
+      expect(toast.closest('.project-actions-toast-anchor')).toBeTruthy();
+      expect(toast.closest('.split-chat-slot')).toBeTruthy();
+      expect(toast.closest('.chat-log-wrap')?.className).toContain('has-chat-log-tray');
+    } finally {
+      registerBrandBrowser('brand-project', BRAND_BROWSER_TAB_ID, null);
+    }
   });
 
   it('waits for pendingPrompt hydration before consuming an auto-send flag', async () => {


### PR DESCRIPTION
Tracker: [提取网页，打开浏览器辅助，下载网页弹窗层级不对 (0.14.1 验收)](https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/e3cee6a6-36d7-44b4-b052-761a151e1764)

## Why

0.14.1 acceptance reported that during web-page brand extraction, the "open browser assist" / "download page" guide popups float at the bottom-center of the whole window, drift across the chat/workspace split, cover the composer send area, and get visually clipped by the composer chrome.

#5403 already fixed one instance of this (the browser-assist **confirm** guide) by anchoring `scope: 'chat-pane'` toasts between the transcript and the composer. Two instances of the same defect remained:

1. **The "Download Page" guide toast** shown when *Continue extraction* cannot read any snapshot (`ProjectView.tsx`) — plus the other error toasts in that same continue-extraction flow — never got `scope: 'chat-pane'`, so they still rendered through the viewport-fixed fallback (`.od-toast { position: fixed; bottom: 24px; left: 50% }`), landing across both panes and over the send button.
2. **The workspace-owned Download Page snapshot progress/result toast** (and tab-launcher errors) in `FileWorkspace.tsx` rendered as a bare fixed `.od-toast` too, so a workspace action produced a toast centered on the whole window instead of the workspace pane.

## What users will see

- When *Continue extraction* fails to read a page snapshot, the "Download Page" step-by-step guide now appears inside the chat pane, right above the input box — it no longer floats mid-window or covers the send button.
- When saving a page snapshot from the Browser tab (More → Download Page), the progress/success/error toast now appears at the bottom-center of the **workspace pane** (where the action happened), never over the chat composer.

## Surface area

- [x] **UI** — positioning/layering fix for existing toasts in `apps/web` (no new UI elements)
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [ ] None

## Screenshots

The bug screenshot lives in the tracker item (guide toast floating bottom-center across the split, partially hidden behind the send button). Fix verified in a real browser against the production stylesheets (`apps/web/src/index.css` cascade) with the exact DOM structure the app renders: the chat-pane guide anchors above the composer inside the left pane; the workspace snapshot toast pins to the workspace pane's bottom-center with its close button inside the toast.

## Bug fix verification

- Test paths that reproduce the bug:
  - `apps/web/tests/components/ProjectView.run-cleanup.test.tsx` → "anchors the continue-extraction download-page guide in the chat pane too"
  - `apps/web/tests/components/FileWorkspace.test.tsx` → "anchors the browser snapshot toast inside the workspace pane"
- Did the tests go red before the source change and green after? **yes** (both failed on the unmodified sources at the anchor-containment assertion, i.e. the toast rendered through the viewport-fixed path; green after the fix)

## Implementation notes / decisions

- Followed the pattern #5403 established rather than inventing a new one: `scope: 'chat-pane'` for chat-flow toasts, plus a new `.workspace-toast-anchor` mirroring `.project-actions-toast-anchor` for workspace-owned toasts.
- All five toasts in the brand continue-extraction flow got `scope: 'chat-pane'` (not just the guide) — they fire from the same gesture and had the same composer-overlap defect. When the chat pane is hidden (workspace focus mode, comment inspector), the scoped toasts still fall back to the fixed position, which is safe because no composer is visible there.
- `.workspace` gained `position: relative` as the anchor's containing block. Audited the workspace subtree for regressions: panel content absolutes resolve to `.ws-body` (already `position: relative`) and the tab-bar menus are `position: fixed`, so nothing re-anchors.
- Inside the anchor the toast keeps `position: relative` (not `static`) so its absolutely-positioned close/action buttons keep the toast as their containing block.

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>