### PR TITLE
fix web powered previews behind reverse proxies

### DIFF
--- a/apps/web/src/runtime/powered-preview.ts
+++ b/apps/web/src/runtime/powered-preview.ts
@@ -61,6 +61,19 @@ export function swapLoopbackHost(origin: string): string {
   }
 }
 
+function isRemoteHttpOrigin(origin: string): boolean {
+  try {
+    const url = new URL(origin);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+    return url.hostname !== '127.0.0.1'
+      && url.hostname !== 'localhost'
+      && url.hostname !== '[::1]'
+      && url.hostname !== '::1';
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Resolve the origin to load the powered iframe from, given the daemon's
  * reported base. The result must be the loopback host-swapped variant, because
@@ -70,6 +83,10 @@ export function swapLoopbackHost(origin: string): string {
  */
 export function resolvePoweredBaseOrigin(baseOrigin: string): string | null {
   const appOrigin = typeof window !== 'undefined' ? window.location.origin : '';
+  // A loopback URL reported through a reverse proxy points at the browser's
+  // machine, not the remote daemon. Fall back to the same-origin raw preview
+  // instead of leaking an unreachable localhost iframe URL.
+  if (isRemoteHttpOrigin(appOrigin)) return null;
   let normalized: string;
   try {
     normalized = new URL(baseOrigin).origin;

--- a/apps/web/tests/runtime/powered-preview.test.ts
+++ b/apps/web/tests/runtime/powered-preview.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { buildProjectPoweredFileUrl } from '@open-design/contracts';
 import {
   resolvePoweredBaseOrigin,
   swapLoopbackHost,
 } from '../../src/runtime/powered-preview';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('swapLoopbackHost', () => {
   it('swaps 127.0.0.1 <-> localhost, preserving scheme and port', () => {
@@ -24,7 +28,14 @@ describe('swapLoopbackHost', () => {
 
 describe('resolvePoweredBaseOrigin', () => {
   it('returns the host-swapped loopback origin for powered previews', () => {
+    vi.stubGlobal('window', {
+      location: { origin: 'http://127.0.0.1:17456' },
+    });
+
     expect(resolvePoweredBaseOrigin('http://127.0.0.1:17456')).toBe('http://localhost:17456');
+    vi.stubGlobal('window', {
+      location: { origin: 'http://localhost:17456' },
+    });
     expect(resolvePoweredBaseOrigin('http://localhost:17456')).toBe('http://127.0.0.1:17456');
   });
 
@@ -35,6 +46,22 @@ describe('resolvePoweredBaseOrigin', () => {
   it('returns null when no preview-only host swap exists', () => {
     expect(resolvePoweredBaseOrigin('http://192.168.1.20:17456')).toBeNull();
     expect(resolvePoweredBaseOrigin('https://example.com')).toBeNull();
+  });
+
+  it('does not send a reverse-proxied app shell to the browser loopback interface', () => {
+    vi.stubGlobal('window', {
+      location: { origin: 'https://design.example.com' },
+    });
+
+    expect(resolvePoweredBaseOrigin('http://127.0.0.1:17456')).toBeNull();
+  });
+
+  it('keeps powered previews available to the packaged app custom protocol', () => {
+    vi.stubGlobal('window', {
+      location: { origin: 'od://app' },
+    });
+
+    expect(resolvePoweredBaseOrigin('http://127.0.0.1:17456')).toBe('http://localhost:17456');
   });
 
   it('returns null for an unparseable base', () => {


### PR DESCRIPTION
## Why

When Open Design is accessed through a remote hostname or reverse proxy, the daemon still reports its loopback address as the powered-preview base origin. The browser then points the iframe at `localhost` on the viewer's own machine, so WebGL pages fail to load and expose an unreachable local daemon port in the page's requests.

Deployments should not need to pin an external hostname, intercept the isolation API response, or expose the daemon's internal port to the browser. The web client already has a raw-preview fallback, so remote HTTP(S) app shells should use that safe path instead.

## What users will see

When a project is opened through a remote hostname or reverse proxy, HTML files that request powered preview no longer try to reach the browser's `localhost`. They fall back to the same-origin raw preview instead. Local HTTP(S) access and the desktop app's `od://` protocol continue to use the isolated powered preview.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this change does not add or alter UI.

## Bug fix verification

- Test path: `apps/web/tests/runtime/powered-preview.test.ts`
- The new regression case fails on `main`: a remote HTTPS app shell resolves the preview to `http://localhost:<daemon-port>`. It passes after the fix by returning `null` and activating the existing raw-preview fallback.
- The same test suite covers local HTTP and the desktop `od://` protocol to confirm that both still retain powered preview.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web test` (414 test files passed; 4,339 tests passed and 7 skipped)
- `pnpm --filter @open-design/web build`
- `git diff --check`
- Upstream CI passed, including workspace tests, web tests, E2E Vitest, UI P0, and visual suites.

Known limitation: reverse-proxied remote pages use raw preview, so artifacts that depend on SharedArrayBuffer, same-origin Workers, or other cross-origin-isolation capabilities will still need a separately protected preview origin in a future change. This fix prioritizes preventing default remote deployments from navigating to the browser's own loopback interface.
