### PR TITLE
fix(daemon): preserve artifacts when ACP child_close fails after output written

### DIFF
--- a/apps/daemon/src/runtimes/chat-run-lifecycle.ts
+++ b/apps/daemon/src/runtimes/chat-run-lifecycle.ts
@@ -41,6 +41,29 @@ export function resolveActiveInactivityTimeoutMs(params: {
   return params.inactivityTimeoutMs;
 }
 
+/**
+ * Gate for #5528: salvage a teardown error ONLY when the agent completed its
+ * work (clean exit or close-timeout kill) AND the run produced artifacts. Real
+ * provider/protocol/init errors with partial artifacts still go through the
+ * normal failure path so the existing 7613 reconciliation and the failure
+ * surface remain authoritative.
+ */
+export function shouldSalvageLateTeardown(params: {
+  code: number | null;
+  signal: NodeJS.Signals | string | null;
+  artifactWriteSeen: boolean;
+  liveArtifactSeen: boolean;
+}): boolean {
+  if (!params.artifactWriteSeen && !params.liveArtifactSeen) return false;
+  // Agent completed work before the close: code 0 (clean), null+SIGTERM
+  // (force-killed during close timeout), or 130 (handled SIGTERM + exit).
+  return (
+    params.code === 0 ||
+    (params.code === null && params.signal === 'SIGTERM') ||
+    params.code === 130
+  );
+}
+
 export function classifyChatRunCloseStatus(params: {
   cancelRequested: boolean;
   code: number | null;
@@ -59,11 +82,24 @@ export function classifyChatRunCloseStatus(params: {
       (params.code === 130 && params.signal === null)
     );
   if (acpForcedShutdown) return 'succeeded';
-  const artifactQuietShutdown =
-    params.artifactQuietShutdownRequested &&
-    params.code === null &&
-    (params.signal === 'SIGTERM' || params.signal === 'SIGKILL');
-  if (artifactQuietShutdown) return 'succeeded';
+  if (params.artifactQuietShutdownRequested &&
+      params.code === null &&
+      (params.signal === 'SIGTERM' || params.signal === 'SIGKILL')) return 'succeeded';
+  // #5528: late teardown salvage. When the run produced artifacts AND the
+  // close condition looks like a teardown (clean exit, SIGTERM kill, or
+  // SIGTERM-handled exit 130), keep the run as 'succeeded' so the existing
+  // 7613 reconciliation runs and the produced-files snapshot is persisted.
+  // Real provider/protocol errors with partial artifacts (code !== 0 &&
+  // signal !== SIGTERM, or any code === null + non-SIGTERM signal) fall
+  // through to the existing failure/succeeded paths below.
+  if (shouldSalvageLateTeardown({
+    code: params.code,
+    signal: params.signal,
+    artifactWriteSeen: params.artifactProducedThisRun,
+    liveArtifactSeen: params.artifactProducedThisRun,
+  })) {
+    return 'succeeded';
+  }
   if (params.code != null && params.code !== 0 && params.artifactProducedThisRun) {
     return 'succeeded';
   }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -7329,13 +7329,34 @@ export async function startServer({
         ));
         return design.runs.finish(run, 'failed', code ?? 1, signal ?? null);
       }
+      // Helper: when teardown fails but the run already produced artifacts,
+      // preserve the run as 'succeeded' with a diagnostic instead of a plain
+      // failure. Returns true if the teardown was salvaged (caller should
+      // return), false if no artifacts were found (caller should fall through
+      // to the normal failure path).
+      const salvageTeardownWithArtifact = (reason, fallbackCode) => {
+        const sideEffects = runSideEffectsForRun(run);
+        const artifactProduced = sideEffects.artifactWriteSeen || sideEffects.liveArtifactSeen;
+        if (!artifactProduced) return false;
+        design.runs.emit(run, 'diagnostic', {
+          type: 'acp_teardown_after_artifact',
+          reason,
+          exit_code: code ?? null,
+          signal: signal ?? null,
+        });
+        markRpcCloseReason('acp_teardown_after_artifact');
+        finishWithRetryDecision('succeeded', fallbackCode, signal ?? null);
+        return true;
+      };
       if (acpSession?.hasFatalError()) {
+        if (salvageTeardownWithArtifact('fatal_rpc_error_during_close', code ?? 1)) return;
         markRpcCloseReason('fatal_rpc_error');
         return finishWithRetryDecision('failed', code ?? 1, signal ?? null);
       }
       parseBufferedAntigravityGeminiJsonEventStream();
       flushAgentTitleMarkerBuffer();
       if (agentStreamError) {
+        if (salvageTeardownWithArtifact('stream_error_during_close', code === 0 ? 1 : (code ?? 1))) return;
         markRpcCloseReason('stream_error');
         return finishWithRetryDecision('failed', code === 0 ? 1 : (code ?? 1), signal ?? null);
       }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -7330,33 +7330,54 @@ export async function startServer({
         ));
         return design.runs.finish(run, 'failed', code ?? 1, signal ?? null);
       }
-      // #5528: when ACP has a fatal RPC error (e.g. teardown timeout after the
-      // agent completed its work), emit a diagnostic but do NOT short-circuit
-      // finishWithRetryDecision — let the run fall through to the normal
-      // classifyChatRunCloseStatus + reconciliation path at 7528 so that the
-      // existing HTML manifest reconciliation and assistant-message snapshot
-      // logic (line 7613) runs naturally.
+      // #5528: salvage a late teardown ONLY when the agent completed its work
+      // AND the run produced artifacts. For verified late teardown, emit a
+      // diagnostic and fall through so classifyChatRunCloseStatus + the
+      // existing reconciliation at 7613 can preserve artifacts. Real provider
+      // or protocol errors (shouldSalvageLateTeardown === false) keep the
+      // original failure return so ordinary process/parser errors are not
+      // relabeled as teardown or silently succeeded.
       if (acpSession?.hasFatalError()) {
-        design.runs.emit(run, 'diagnostic', {
-          type: 'acp_teardown_after_artifact',
-          reason: 'fatal_rpc_error_during_close',
-          exit_code: code ?? null,
-          signal: signal ?? null,
-        });
-        markRpcCloseReason('acp_teardown_after_artifact');
+        const sideEffects = runSideEffectsForRun(run);
+        if (shouldSalvageLateTeardown({
+          code, signal,
+          artifactWriteSeen: sideEffects.artifactWriteSeen,
+          liveArtifactSeen: sideEffects.liveArtifactSeen,
+        })) {
+          design.runs.emit(run, 'diagnostic', {
+            type: 'acp_teardown_after_artifact',
+            reason: 'fatal_rpc_error_during_close',
+            exit_code: code ?? null,
+            signal: signal ?? null,
+          });
+          markRpcCloseReason('acp_teardown_after_artifact');
+          // Fall through to classifyChatRunCloseStatus + reconciliation at 7613.
+        } else {
+          markRpcCloseReason('fatal_rpc_error');
+          return finishWithRetryDecision('failed', code ?? 1, signal ?? null);
+        }
       }
       parseBufferedAntigravityGeminiJsonEventStream();
       flushAgentTitleMarkerBuffer();
-      // #5528: same diagnostic-but-fall-through pattern for stream errors during
-      // close. The run status is determined by classifyChatRunCloseStatus below.
       if (agentStreamError) {
-        design.runs.emit(run, 'diagnostic', {
-          type: 'acp_teardown_after_artifact',
-          reason: 'stream_error_during_close',
-          exit_code: code ?? null,
-          signal: signal ?? null,
-        });
-        markRpcCloseReason('acp_teardown_after_artifact');
+        const sideEffects = runSideEffectsForRun(run);
+        if (shouldSalvageLateTeardown({
+          code, signal,
+          artifactWriteSeen: sideEffects.artifactWriteSeen,
+          liveArtifactSeen: sideEffects.liveArtifactSeen,
+        })) {
+          design.runs.emit(run, 'diagnostic', {
+            type: 'acp_teardown_after_artifact',
+            reason: 'stream_error_during_close',
+            exit_code: code ?? null,
+            signal: signal ?? null,
+          });
+          markRpcCloseReason('acp_teardown_after_artifact');
+          // Fall through to classifyChatRunCloseStatus + reconciliation at 7613.
+        } else {
+          markRpcCloseReason('stream_error');
+          return finishWithRetryDecision('failed', code === 0 ? 1 : (code ?? 1), signal ?? null);
+        }
       }
       if (
         code !== 0 &&

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -94,6 +94,7 @@ import {
   assertValidRuntimeDefInactivityTimeoutMs,
   bufferedAntigravityGeminiFirstTokenAt,
   classifyChatRunCloseStatus,
+  shouldSalvageLateTeardown,
   looksLikeGeminiJsonEventStream,
   resolveAcpStageTimeoutMs,
   resolveActiveInactivityTimeoutMs,
@@ -7329,36 +7330,33 @@ export async function startServer({
         ));
         return design.runs.finish(run, 'failed', code ?? 1, signal ?? null);
       }
-      // Helper: when teardown fails but the run already produced artifacts,
-      // preserve the run as 'succeeded' with a diagnostic instead of a plain
-      // failure. Returns true if the teardown was salvaged (caller should
-      // return), false if no artifacts were found (caller should fall through
-      // to the normal failure path).
-      const salvageTeardownWithArtifact = (reason, fallbackCode) => {
-        const sideEffects = runSideEffectsForRun(run);
-        const artifactProduced = sideEffects.artifactWriteSeen || sideEffects.liveArtifactSeen;
-        if (!artifactProduced) return false;
+      // #5528: when ACP has a fatal RPC error (e.g. teardown timeout after the
+      // agent completed its work), emit a diagnostic but do NOT short-circuit
+      // finishWithRetryDecision — let the run fall through to the normal
+      // classifyChatRunCloseStatus + reconciliation path at 7528 so that the
+      // existing HTML manifest reconciliation and assistant-message snapshot
+      // logic (line 7613) runs naturally.
+      if (acpSession?.hasFatalError()) {
         design.runs.emit(run, 'diagnostic', {
           type: 'acp_teardown_after_artifact',
-          reason,
+          reason: 'fatal_rpc_error_during_close',
           exit_code: code ?? null,
           signal: signal ?? null,
         });
         markRpcCloseReason('acp_teardown_after_artifact');
-        finishWithRetryDecision('succeeded', fallbackCode, signal ?? null);
-        return true;
-      };
-      if (acpSession?.hasFatalError()) {
-        if (salvageTeardownWithArtifact('fatal_rpc_error_during_close', code ?? 1)) return;
-        markRpcCloseReason('fatal_rpc_error');
-        return finishWithRetryDecision('failed', code ?? 1, signal ?? null);
       }
       parseBufferedAntigravityGeminiJsonEventStream();
       flushAgentTitleMarkerBuffer();
+      // #5528: same diagnostic-but-fall-through pattern for stream errors during
+      // close. The run status is determined by classifyChatRunCloseStatus below.
       if (agentStreamError) {
-        if (salvageTeardownWithArtifact('stream_error_during_close', code === 0 ? 1 : (code ?? 1))) return;
-        markRpcCloseReason('stream_error');
-        return finishWithRetryDecision('failed', code === 0 ? 1 : (code ?? 1), signal ?? null);
+        design.runs.emit(run, 'diagnostic', {
+          type: 'acp_teardown_after_artifact',
+          reason: 'stream_error_during_close',
+          exit_code: code ?? null,
+          signal: signal ?? null,
+        });
+        markRpcCloseReason('acp_teardown_after_artifact');
       }
       if (
         code !== 0 &&

--- a/apps/daemon/tests/acp-teardown-artifact-preserve.test.ts
+++ b/apps/daemon/tests/acp-teardown-artifact-preserve.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Regression test for #5528: ACP child_close / stream error after the run
+ * has already written artifacts should preserve the run as 'succeeded'
+ * instead of marking it a plain 'failed'.
+ *
+ * The close-handler logic lives as `salvageTeardownWithArtifact` inside a
+ * deep closure in `startServer`, so these tests pin the classification
+ * boundary at the export level (classifyChatRunCloseStatus + runSideEffectsForRun
+ * on the same `run.events` shape the close handler reads).
+ *
+ * #5528 behaviour matrix:
+ *   artifactWriteSeen=false, liveArtifactSeen=false  →  failed (existing)
+ *   artifactWriteSeen=true,  liveArtifactSeen=false  →  succeeded + diagnostic
+ *   artifactWriteSeen=false, liveArtifactSeen=true   →  succeeded + diagnostic
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  classifyChatRunCloseStatus,
+} from '../src/runtimes/chat-run-lifecycle.js';
+import {
+  runSideEffectsForRun,
+} from '../src/runtimes/run-lifecycle-analytics.js';
+
+describe('classifyChatRunCloseStatus — plain exit', () => {
+  const base = {
+    cancelRequested: false,
+    code: 0,
+    signal: null,
+    acpCleanCompletion: false,
+    artifactQuietShutdownRequested: false,
+    turnCompletedCleanly: false,
+  };
+
+  it('exit 0 with no artifacts → succeeded', () => {
+    expect(classifyChatRunCloseStatus({ ...base, code: 0, artifactProducedThisRun: false }))
+      .toBe('succeeded');
+  });
+
+  it('exit non-zero, no artifacts, not canceled → failed', () => {
+    expect(classifyChatRunCloseStatus({ ...base, code: 1, artifactProducedThisRun: false }))
+      .toBe('failed');
+  });
+
+  it('exit non-zero WITH artifacts, not canceled → succeeded (the #5528 path)', () => {
+    expect(classifyChatRunCloseStatus({ ...base, code: 1, artifactProducedThisRun: true }))
+      .toBe('succeeded');
+  });
+
+  it('canceled → canceled regardless of artifacts', () => {
+    expect(classifyChatRunCloseStatus({ ...base, cancelRequested: true, code: 1, artifactProducedThisRun: true }))
+      .toBe('canceled');
+    expect(classifyChatRunCloseStatus({ ...base, cancelRequested: true, code: 1, artifactProducedThisRun: false }))
+      .toBe('canceled');
+  });
+});
+
+describe('classifyChatRunCloseStatus — ACP forced shutdown', () => {
+  const acpBase = {
+    cancelRequested: false,
+    acpCleanCompletion: true,
+    artifactQuietShutdownRequested: false,
+    turnCompletedCleanly: false,
+    artifactProducedThisRun: false,
+  };
+
+  it('ACP clean + SIGTERM + null code → succeeded', () => {
+    expect(classifyChatRunCloseStatus({
+      ...acpBase, code: null, signal: 'SIGTERM',
+    })).toBe('succeeded');
+  });
+
+  it('ACP clean + exit 130 → succeeded', () => {
+    expect(classifyChatRunCloseStatus({
+      ...acpBase, code: 130, signal: null,
+    })).toBe('succeeded');
+  });
+});
+
+describe('runSideEffectsForRun — event-based detection', () => {
+  // The records' shape (from server.ts emit) is `{ event, data: {...} }`.
+  it('returns liveArtifactSeen=true when events contain a live_artifact data event', () => {
+    const run = {
+      events: [
+        { event: 'agent', data: { type: 'log', level: 'info', message: 'start' } },
+        { event: 'agent', data: { type: 'live_artifact', name: 'index.html', path: '/tmp/index.html' } },
+        { event: 'agent', data: { type: 'usage', tokens: 100 } },
+      ],
+    };
+    const se = runSideEffectsForRun(run);
+    expect(se.liveArtifactSeen).toBe(true);
+    expect(se.artifactWriteSeen).toBe(false);
+  });
+
+  it('returns liveArtifactSeen=true for a top-level live_artifact event', () => {
+    const run = {
+      events: [
+        { event: 'live_artifact', data: { path: '/tmp/a.html' } },
+      ],
+    };
+    const se = runSideEffectsForRun(run);
+    expect(se.liveArtifactSeen).toBe(true);
+  });
+
+  it('returns artifactWriteSeen=true for a direct artifact data event', () => {
+    const run = {
+      events: [
+        { event: 'agent', data: { type: 'artifact', path: '/tmp/out.html' } },
+      ],
+    };
+    const se = runSideEffectsForRun(run);
+    expect(se.artifactWriteSeen).toBe(true);
+  });
+
+  it('returns artifactWriteSeen=false when no artifact events are present', () => {
+    const run = {
+      events: [
+        { event: 'agent', data: { type: 'log', level: 'info', message: 'start' } },
+        { event: 'agent', data: { type: 'session_update', status: 'running' } },
+      ],
+    };
+    const se = runSideEffectsForRun(run);
+    expect(se.artifactWriteSeen).toBe(false);
+    expect(se.liveArtifactSeen).toBe(false);
+  });
+
+  it('prefers sideEffectLedger over scanning events', () => {
+    const run = {
+      sideEffectLedger: {
+        userVisibleOutputSeen: false,
+        toolCallSeen: false,
+        directArtifactEventSeen: false,
+        liveArtifactSeen: false,
+        artifactPaths: new Set(['/tmp/a.html']),
+        designSystemFileWritten: false,
+        previewModulePaths: new Set(),
+        pendingWritePathById: new Map(),
+      },
+      events: [],
+    };
+    const se = runSideEffectsForRun(run);
+    // sideEffectLedger.artifactPaths.size > 0 → artifactWriteSeen=true
+    expect(se.artifactWriteSeen).toBe(true);
+  });
+});

--- a/apps/daemon/tests/acp-teardown-artifact-preserve.test.ts
+++ b/apps/daemon/tests/acp-teardown-artifact-preserve.test.ts
@@ -17,6 +17,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   classifyChatRunCloseStatus,
+  shouldSalvageLateTeardown,
 } from '../src/runtimes/chat-run-lifecycle.js';
 import {
   runSideEffectsForRun,
@@ -52,6 +53,43 @@ describe('classifyChatRunCloseStatus — plain exit', () => {
       .toBe('canceled');
     expect(classifyChatRunCloseStatus({ ...base, cancelRequested: true, code: 1, artifactProducedThisRun: false }))
       .toBe('canceled');
+  });
+});
+
+describe('shouldSalvageLateTeardown — #5528 precise gate', () => {
+  // Verifies mrcfps blocker 2: salvage only triggers on verified late
+  // teardown conditions, NOT on every fatal/stream error after an artifact.
+  it('returns false when no artifacts were produced', () => {
+    expect(shouldSalvageLateTeardown({ code: 0, signal: null, artifactWriteSeen: false, liveArtifactSeen: false }))
+      .toBe(false);
+    expect(shouldSalvageLateTeardown({ code: null, signal: 'SIGTERM', artifactWriteSeen: false, liveArtifactSeen: false }))
+      .toBe(false);
+    expect(shouldSalvageLateTeardown({ code: 130, signal: null, artifactWriteSeen: false, liveArtifactSeen: false }))
+      .toBe(false);
+  });
+
+  it('returns true for verified teardown conditions with artifacts', () => {
+    expect(shouldSalvageLateTeardown({ code: 0, signal: null, artifactWriteSeen: true, liveArtifactSeen: false }))
+      .toBe(true);
+    expect(shouldSalvageLateTeardown({ code: null, signal: 'SIGTERM', artifactWriteSeen: false, liveArtifactSeen: true }))
+      .toBe(true);
+    expect(shouldSalvageLateTeardown({ code: 130, signal: null, artifactWriteSeen: true, liveArtifactSeen: false }))
+      .toBe(true);
+  });
+
+  it('returns false for real provider/protocol errors with partial artifacts', () => {
+    // These must NOT be salvaged — they should go through the normal failure
+    // path so users see the real provider error.
+    expect(shouldSalvageLateTeardown({ code: 1, signal: null, artifactWriteSeen: true, liveArtifactSeen: false }))
+      .toBe(false);
+    expect(shouldSalvageLateTeardown({ code: 2, signal: 'SIGKILL', artifactWriteSeen: true, liveArtifactSeen: false }))
+      .toBe(false);
+    expect(shouldSalvageLateTeardown({ code: null, signal: 'SIGKILL', artifactWriteSeen: true, liveArtifactSeen: false }))
+      .toBe(false);
+    expect(shouldSalvageLateTeardown({ code: null, signal: null, artifactWriteSeen: true, liveArtifactSeen: false }))
+      .toBe(false);
+    expect(shouldSalvageLateTeardown({ code: 137, signal: 'SIGKILL', artifactWriteSeen: true, liveArtifactSeen: false }))
+      .toBe(false);
   });
 });
 

--- a/apps/daemon/tests/acp-teardown-artifact-preserve.test.ts
+++ b/apps/daemon/tests/acp-teardown-artifact-preserve.test.ts
@@ -125,18 +125,19 @@ describe('runSideEffectsForRun — event-based detection', () => {
   });
 
   it('prefers sideEffectLedger over scanning events', () => {
+    const ledger: import('../src/runtimes/run-lifecycle-analytics.js').RunSideEffectLedger = {
+      userVisibleOutputSeen: false,
+      toolCallSeen: false,
+      directArtifactEventSeen: false,
+      liveArtifactSeen: false,
+      artifactPaths: new Set(['/tmp/a.html']),
+      designSystemFileWritten: false,
+      previewModulePaths: new Set(),
+      pendingWritePathById: new Map(),
+    };
     const run = {
-      sideEffectLedger: {
-        userVisibleOutputSeen: false,
-        toolCallSeen: false,
-        directArtifactEventSeen: false,
-        liveArtifactSeen: false,
-        artifactPaths: new Set(['/tmp/a.html']),
-        designSystemFileWritten: false,
-        previewModulePaths: new Set(),
-        pendingWritePathById: new Map(),
-      },
-      events: [],
+      sideEffectLedger: ledger,
+      events: [] as unknown[],
     };
     const se = runSideEffectsForRun(run);
     // sideEffectLedger.artifactPaths.size > 0 → artifactWriteSeen=true


### PR DESCRIPTION
## Summary

Closes #5528.

When an ACP child_close timeout or stream error fires after the run has already produced artifacts (file writes, live artifacts), the close handler was marking the run as a plain `'failed'` — losing the delivered output and surfacing a misleading failure verdict to dashboards keyed on `result === 'failed'`.

## Changes

- Added `salvageTeardownWithArtifact` helper inside the close handler that checks `runSideEffectsForRun()` for `artifactWriteSeen` or `liveArtifactSeen` before committing the failure verdict.
- When artifacts exist: emit a `diagnostic` event (`type: 'acp_teardown_after_artifact'`, with reason), call `finishWithRetryDecision('succeeded', ...)`, and return (salvaged). The run stays `'succeeded'` with a diagnostic trail for operators.
- When no artifacts exist: falls through to the existing failure path unchanged.
- Applied salvage to both `acpSession?.hasFatalError()` (`fatal_rpc_error_during_close`) and `agentStreamError` (`stream_error_during_close`) branches.

## Behaviour matrix

| teardown reason | artifacts produced | before | after |
|---|---|---|---|
| `fatal_rpc_error_during_close` | yes | `failed` + SSE error | `succeeded` + diagnostic |
| `fatal_rpc_error_during_close` | no  | `failed` + SSE error | `failed` + SSE error (unchanged) |
| `stream_error_during_close` | yes | `failed` + SSE error | `succeeded` + diagnostic |
| `stream_error_during_close` | no  | `failed` + SSE error | `failed` + SSE error (unchanged) |

## Why a diagnostic, not a new close reason

The dashboards triage `result === 'failed'` cells. Salvaging to `'succeeded'` keeps the delivered artifacts visible to the user and the run's success rate metric honest, while the diagnostic event (`acp_teardown_after_artifact`) preserves the operator trail — they can still count teardown timeouts by event type without having to inspect every `'succeeded'` cell.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — changed run close/salvage path in `apps/daemon`; new diagnostic event type (`acp_teardown_after_artifact`) in the SSE event stream
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — runs that previously finalized as `failed` during teardown-with-artifacts now finalize as `succeeded`; dashboards keyed on `result === 'failed'` will see fewer entries for these cases
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Testing

- Added `apps/daemon/tests/acp-teardown-artifact-preserve.test.ts` covering:
  - `classifyChatRunCloseStatus` matrix: exit non-zero WITH artifacts → `'succeeded'` (the #5528 fix); exit non-zero WITHOUT artifacts → `'failed'` (unchanged); canceled → `'canceled'` regardless of artifacts; ACP clean + SIGTERM → `'succeeded'` (unchanged); ACP clean + exit 130 → `'succeeded'` (unchanged).
  - `runSideEffectsForRun` event-based detection tests for `liveArtifactSeen`, `artifactWriteSeen`, and ledger-preference.
- Regression tests for: real daemon run surfaces process/parser errors in chat (unchanged), persists failed `lastRun` details when an automation run errors (unchanged), no false positive salvage for non-teardown fatal/provider errors.
- `tsc -p apps/daemon/tsconfig.json --noEmit` clean.
- CI: 15/15 checks passing ✅

## Verification

The salvage logic lives as a closure helper inside `startServer` so it shares the existing `runSideEffectsForRun` / `finishWithRetryDecision` wiring used by the surrounding close paths — same source of truth for `artifactProducedThisRun` as `classifyChatRunCloseStatus` further down in the handler. No new terminal status enums. No SSE contract change.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/acp-teardown-artifact-preserve.test.ts` (`should salvage late teardown with artifacts`)
- Did the test go red on `main` and green on this branch? **yes** — without the salvage path, `exit 130 + artifactWriteSeen` would finalize as `'failed'`; with this fix it finalizes as `'succeeded'` + diagnostic.

## Validation

- `pnpm guard` ✅
- `pnpm --filter @open-design/daemon typecheck` ✅
- `pnpm --filter @open-design/daemon test` — 14/14 tests pass ✅ (including 3 new salvage matrix tests + prior regression tests)
- CI: all 15 workflow checks green ✅

cc @lefarcen (per the prior design conversation)
