### PR TITLE
fix(daemon): pin mermaid dark-theme discipline into the deck framework prompt

### DIFF
--- a/apps/daemon/src/prompts/deck-framework.ts
+++ b/apps/daemon/src/prompts/deck-framework.ts
@@ -453,6 +453,46 @@ Rules — same weight as the density rules above:
 - ❌ Don't nest value labels inside a clipping fixed-height bar.
 - ❌ Don't omit any data point's label, however short its bar.
 
+## Mermaid diagram theme discipline (dark decks)
+
+Mermaid's default theme is built for white pages: near-black labels (\`#333\`), pale node fills, black strokes, and a TRANSPARENT svg background. Embedded in a dark-themed deck it produces the failure users report as "the diagram text is unreadable in dark mode": dark labels sitting directly on the dark slide background. Prefer a hand-written HTML/CSS/SVG diagram styled with the deck's own tokens (\`--bg\`, \`--fg\`, \`--accent\`) — it never drifts from the theme and needs no external JS. When you do embed Mermaid, pick the theme from the slide background at initialize time — never leave the default (light) theme on a dark deck:
+
+\`\`\`html
+<script>
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'dark',        // dark slide background
+    // theme: 'default',  // light slide background
+  });
+</script>
+\`\`\`
+
+For brand fidelity, \`theme: 'base'\` + \`themeVariables\` reuses the deck palette — pass concrete color values (Mermaid cannot resolve CSS \`var()\` references). \`darkMode: true\` alone does NOT darken node fills — \`base\` keeps its cream \`primaryColor\` default, so always set \`primaryColor\` to a dark surface tone alongside the light text:
+
+\`\`\`js
+mermaid.initialize({
+  startOnLoad: true,
+  theme: 'base',
+  themeVariables: {
+    darkMode: true,                 // match the slide background
+    background: '#101014',          // the deck's --bg value, as a literal
+    primaryColor: '#1c1c24',        // node fill — dark surface tone, NOT the cream default
+    primaryTextColor: '#e8e8ec',    // the deck's --fg value, as a literal
+    primaryBorderColor: '#8a8a94',
+    lineColor: '#8a8a94',
+  },
+});
+\`\`\`
+
+Rules — same weight as the density rules above:
+
+1. **Diagram text color follows the slide background, not Mermaid's default.** Dark background → \`theme: 'dark'\` or \`base\` + dark \`themeVariables\`; light background → the default is fine.
+2. **Never rely on the SVG bringing its own backdrop.** Mermaid emits a transparent-background SVG, so every label sits directly on the slide. If the diagram cannot be themed, give its container an explicit light plate (e.g. \`background: #fff\`, padding, radius) instead of shipping unreadable labels.
+
+- ❌ Don't call \`mermaid.initialize()\` without a \`theme\` on a dark deck.
+- ❌ Don't pass \`var(--fg)\` strings into \`themeVariables\` — Mermaid needs literal colors.
+- ❌ Don't hand-recolor a single label to "fix" contrast; theme the whole diagram.
+
 ## Pre-handoff self-check — run this BEFORE the final file summary
 
 For every \`<section class="slide">\`, mentally render at 1920×1080 and answer:
@@ -463,6 +503,7 @@ For every \`<section class="slide">\`, mentally render at 1920×1080 and answer:
 - [ ] Does the slide carry ≤ one big idea? (No mashed-together masthead + display headline + subtitle + absolute footer + sidebar.)
 - [ ] If the slide has a chart: does every data point show a visible category label and value label?
 - [ ] Are bar lengths computed from \`--v\` / \`--max\` so proportions match the data? (Mentally spot-check two bars.)
+- [ ] If the slide embeds a Mermaid diagram: is \`mermaid.initialize\` themed to the slide background (dark background → \`dark\`/\`base\` theme), leaving no dark-on-dark labels?
 
 If any answer is "no", redesign the slide BEFORE handoff. Decks that overflow are the most common single failure mode reported by users; the user has rejected one before and will reject one again.
 

--- a/apps/daemon/tests/prompts/system.test.ts
+++ b/apps/daemon/tests/prompts/system.test.ts
@@ -334,6 +334,15 @@ describe('composeSystemPrompt', () => {
     expect(prompt).toContain('Mentally spot-check two bars');
   });
 
+  it('pins the mermaid theme discipline inside the deck framework (dark decks)', () => {
+    const prompt = composeSystemPrompt({ skillMode: 'deck' });
+
+    expect(prompt).toContain('## Mermaid diagram theme discipline');
+    expect(prompt).toContain("theme: 'dark'");
+    expect(prompt).toContain('themeVariables');
+    expect(prompt).toContain('no dark-on-dark labels');
+  });
+
   it('resolves a non-media primary surface ahead of composed media mentions', () => {
     expect(resolveExclusiveSurface({
       skillMode: 'deck',

--- a/packages/contracts/src/prompts/deck-framework.ts
+++ b/packages/contracts/src/prompts/deck-framework.ts
@@ -426,6 +426,46 @@ Rules — same weight as the density rules above:
 - ❌ Don't nest value labels inside a clipping fixed-height bar.
 - ❌ Don't omit any data point's label, however short its bar.
 
+## Mermaid diagram theme discipline (dark decks)
+
+Mermaid's default theme is built for white pages: near-black labels (\`#333\`), pale node fills, black strokes, and a TRANSPARENT svg background. Embedded in a dark-themed deck it produces the failure users report as "the diagram text is unreadable in dark mode": dark labels sitting directly on the dark slide background. Prefer a hand-written HTML/CSS/SVG diagram styled with the deck's own tokens (\`--bg\`, \`--fg\`, \`--accent\`) — it never drifts from the theme and needs no external JS. When you do embed Mermaid, pick the theme from the slide background at initialize time — never leave the default (light) theme on a dark deck:
+
+\`\`\`html
+<script>
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'dark',        // dark slide background
+    // theme: 'default',  // light slide background
+  });
+</script>
+\`\`\`
+
+For brand fidelity, \`theme: 'base'\` + \`themeVariables\` reuses the deck palette — pass concrete color values (Mermaid cannot resolve CSS \`var()\` references). \`darkMode: true\` alone does NOT darken node fills — \`base\` keeps its cream \`primaryColor\` default, so always set \`primaryColor\` to a dark surface tone alongside the light text:
+
+\`\`\`js
+mermaid.initialize({
+  startOnLoad: true,
+  theme: 'base',
+  themeVariables: {
+    darkMode: true,                 // match the slide background
+    background: '#101014',          // the deck's --bg value, as a literal
+    primaryColor: '#1c1c24',        // node fill — dark surface tone, NOT the cream default
+    primaryTextColor: '#e8e8ec',    // the deck's --fg value, as a literal
+    primaryBorderColor: '#8a8a94',
+    lineColor: '#8a8a94',
+  },
+});
+\`\`\`
+
+Rules — same weight as the density rules above:
+
+1. **Diagram text color follows the slide background, not Mermaid's default.** Dark background → \`theme: 'dark'\` or \`base\` + dark \`themeVariables\`; light background → the default is fine.
+2. **Never rely on the SVG bringing its own backdrop.** Mermaid emits a transparent-background SVG, so every label sits directly on the slide. If the diagram cannot be themed, give its container an explicit light plate (e.g. \`background: #fff\`, padding, radius) instead of shipping unreadable labels.
+
+- ❌ Don't call \`mermaid.initialize()\` without a \`theme\` on a dark deck.
+- ❌ Don't pass \`var(--fg)\` strings into \`themeVariables\` — Mermaid needs literal colors.
+- ❌ Don't hand-recolor a single label to "fix" contrast; theme the whole diagram.
+
 ## Pre-emit self-check — run this BEFORE writing the \`<artifact>\` tag
 
 For every \`<section class="slide">\`, mentally render at 1920×1080 and answer:
@@ -436,6 +476,7 @@ For every \`<section class="slide">\`, mentally render at 1920×1080 and answer:
 - [ ] Does the slide carry ≤ one big idea? (No mashed-together masthead + display headline + subtitle + absolute footer + sidebar.)
 - [ ] If the slide has a chart: does every data point show a visible category label and value label?
 - [ ] Are bar lengths computed from \`--v\` / \`--max\` so proportions match the data? (Mentally spot-check two bars.)
+- [ ] If the slide embeds a Mermaid diagram: is \`mermaid.initialize\` themed to the slide background (dark background → \`dark\`/\`base\` theme), leaving no dark-on-dark labels?
 
 If any answer is "no", redesign the slide BEFORE emitting. Decks that overflow are the most common single failure mode reported by users; the user has rejected one before and will reject one again.
 

--- a/packages/contracts/tests/system-prompt.test.ts
+++ b/packages/contracts/tests/system-prompt.test.ts
@@ -125,6 +125,15 @@ describe('DISCOVERY_AND_PHILOSOPHY (contracts copy) — prompt routing parity', 
     expect(prompt).toContain('visible category label AND value label');
     expect(prompt).toContain('Mentally spot-check two bars');
   });
+
+  it('pins the mermaid theme discipline inside the deck framework (dark decks)', () => {
+    const prompt = composeSystemPrompt({ skillMode: 'deck' });
+
+    expect(prompt).toContain('## Mermaid diagram theme discipline');
+    expect(prompt).toContain("theme: 'dark'");
+    expect(prompt).toContain('themeVariables');
+    expect(prompt).toContain('no dark-on-dark labels');
+  });
 });
 
 describe('composeSystemPrompt', () => {


### PR DESCRIPTION
> Source (external tracker, not a GitHub issue): https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/9cd2904d-e52c-4813-9e4f-e7a3512aaa12

## Why

0.14.1 acceptance reported: 暗黑模式下 mermaid 图表的文字与背景对比度不足、看不清,需让 mermaid 文字颜色随主题(暗色)自适应 (no screenshot; the screen recording missed the scene).

**Where the bug actually lives.** I swept every mermaid surface in the product before touching anything. The in-app surfaces are already dark-safe on `main`: the sketch editor's "Mermaid to Excalidraw" dialog and canvas render through Excalidraw's theme filter; SVG/image artifact previews sit on a forced white backdrop (`.image-body img { background: white }`); HTML preview iframes get Chromium's opaque canvas when the app's `color-scheme: dark` mismatches light artifact content; chat code fences are shiki theme-aware. None of them reproduces the report.

What does reproduce it — trivially — is **generated content**: a dark-themed deck/page (the product's own example prompts push dark dashboards, and several `html-ppt-*` template families are dark) where the model embeds a Mermaid diagram with the default (light) theme. Mermaid's default theme assumes a white page: near-black edge labels, black strokes, and a **transparent svg background**, so everything sits directly on the dark slide background. Measured on a dark slide (`--bg #101014`): edge labels ~**3.3:1** contrast (below WCAG AA 4.5:1), connector lines ~**1.9:1** (nearly invisible). That matches the report word for word, and the deck framework prompt had zero guidance on diagram theming — the exact same gap #5542 just closed for hand-written data charts, from the same acceptance batch and the same Plane project.

**The fix** follows #5542's shape: pin a compact "Mermaid diagram theme discipline" section into `DECK_FRAMEWORK_DIRECTIVE` (daemon copy + identical mirror in the contracts copy so API/BYOK mode is covered):

- Prefer deck-token-styled HTML/CSS/SVG diagrams (the direction the official `ve-*` example plugins already took when they removed mermaid).
- When embedding Mermaid, derive the theme from the slide background at initialize time: dark background → `theme: 'dark'`, or `theme: 'base'` + `themeVariables` with concrete palette values. The skeleton explicitly sets a dark `primaryColor` because `darkMode: true` alone keeps `base`'s cream node fill (verified: light text on cream nodes is the failure mode of the naive config).
- Never rely on the svg bringing its own backdrop; ban list (`initialize()` without a theme on a dark deck, CSS `var()` strings in `themeVariables`, hand-recoloring single labels).
- One new pre-handoff / pre-emit self-check item on each side, keeping each side's self-check heading intact.

With the disciplined init the same dark slide renders at **≥7.9:1** (edge labels) and **10.5:1** (node text).

**Why prompt discipline and not app code:** the unreadable pixels live inside model-generated artifacts, not in any app rendering path; there is no app-side hook that can retheme an already-baked diagram inside user HTML. This is the same reasoning the repo accepted for #5542.

## What users will see

No UI change. When the agent generates a dark-themed deck or page that includes a Mermaid diagram, the diagram's text, lines, and node fills now follow the design's dark background instead of shipping Mermaid's light default — labels are readable instead of dark-on-dark.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — prompt directive + tests only (`apps/daemon/src/prompts/deck-framework.ts`, `packages/contracts/src/prompts/deck-framework.ts`, and their prompt-composition tests)

## Screenshots

Not a UI change (verification was done against a live dark deck slide in the viewer; contrast figures in "Why" are measured from those screenshots).

## Bug fix verification

- Test paths that reproduce the gap:
  - `apps/daemon/tests/prompts/system.test.ts` → "pins the mermaid theme discipline inside the deck framework (dark decks)"
  - `packages/contracts/tests/system-prompt.test.ts` → same assertion for the API/BYOK prompt copy
- Red on `main`, green on this branch: **yes** (both sides; run before and after the source change).
- Symptom-level verification: reproduced the reported failure on a dark deck slide embedding a default-theme Mermaid flowchart in the running web app (edge labels ~3.3:1, lines ~1.9:1), then re-rendered the same slide with the discipline's `base` + dark `themeVariables` skeleton → ≥7.9:1 / 10.5:1, everything readable.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/contracts test` — 240/240 pass
- `apps/daemon` `vitest run tests/prompts/system.test.ts` — 49/49 pass
- Full `pnpm --filter @open-design/daemon test`: 5632 passed, 4 failed — the same 4 tests (`chat-route`, `connection-test`, `vela.routes`) fail identically on a clean `main` checkout in this environment (verified via `git stash` baseline run), so they are pre-existing and unrelated to this change.

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>