### PR TITLE
fix(web): keep the sticky home topbar above the popover-elevated composer card

### DIFF
--- a/apps/web/src/styles/home/home-hero.css
+++ b/apps/web/src/styles/home/home-hero.css
@@ -430,11 +430,21 @@
   margin-top: 0;
   transition: border-color 120ms var(--ease-out), box-shadow 120ms var(--ease-out);
 }
+/* While one of the composer's popovers is open, the whole card (a stacking
+   context) is lifted so the popover escapes above the static home content
+   below it (recent projects, plugin tiles — their contexts top out at 8).
+   The lift must stay BELOW `.entry-main__topbar` (z-index 10): the sticky
+   topbar is opaque chrome and the card scrolling under it must never cover
+   the chip cluster. It must also stay below the fixed modal family
+   (`.home-hero-confirm__backdrop` 80, `.plus-menu__popup` 90,
+   `.plugins-import-modal__backdrop` 100, `.use-everywhere-modal-backdrop`
+   920). Popover z-indexes inside the card (1503/1701/…) are local to the
+   card's stacking context and only order its own children. */
 .home-hero__input-card:has(.inline-switcher__popover),
 .home-hero__input-card:has(.session-mode-toggle__popover),
 .home-hero__input-card:has(.home-hero__plugin-picker),
 .home-hero__input-card:has(.home-hero__template-menu) {
-  z-index: 1700;
+  z-index: 9;
   overflow: visible;
 }
 .home-hero__input-card--compact-authoring {

--- a/e2e/ui/home-composer-topbar-stacking.test.ts
+++ b/e2e/ui/home-composer-topbar-stacking.test.ts
@@ -1,0 +1,192 @@
+import { expect, test } from '@/playwright/suite';
+import type { Page } from '@playwright/test';
+import { routeAgents } from '@/playwright/mock-factory';
+import { T } from '@/timeouts';
+
+// Regression (0.14.1 acceptance): scroll the home view so the composer card
+// slides under the sticky topbar strip, then open the composer's agent/model
+// switcher. Opening any composer popover elevated the whole input card to
+// z-index 1700 — far above the topbar's z-index 10 — so the card body painted
+// over the topbar chips (GitHub star, Teams, Discord, settings). The sticky
+// topbar is opaque chrome: content scrolling underneath must stay behind it
+// in every composer state, while the composer's popovers still need to paint
+// above the static home content below the card.
+
+test.describe.configure({ timeout: T.xlong });
+
+const STORAGE_KEY = 'open-design:config';
+
+const HOME_CONFIG = {
+  mode: 'daemon',
+  apiKey: '',
+  baseUrl: 'https://api.anthropic.com',
+  model: 'default',
+  agentId: 'codex',
+  skillId: null,
+  designSystemId: null,
+  onboardingCompleted: true,
+  agentModels: { codex: { model: 'default' } },
+  privacyDecisionAt: 1,
+  telemetry: { metrics: false, content: false, artifactManifest: false },
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(
+    ({ key, value }) => {
+      window.localStorage.clear();
+      window.sessionStorage.clear();
+      window.localStorage.setItem(key, JSON.stringify(value));
+    },
+    { key: STORAGE_KEY, value: HOME_CONFIG },
+  );
+
+  await page.route('**/api/github/open-design', async (route) => {
+    await route.fulfill({ json: { stargazers_count: 51600 } });
+  });
+
+  await routeAgents(page, [
+    {
+      id: 'codex',
+      name: 'Codex CLI',
+      bin: 'codex',
+      available: true,
+      version: '0.80.0',
+      models: [{ id: 'default', label: 'Default' }],
+    },
+  ]);
+
+  await page.route('**/api/app-config', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({ json: { config: HOME_CONFIG } });
+  });
+
+  await page.route('**/api/projects', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({ json: { projects: [] } });
+      return;
+    }
+    await route.continue();
+  });
+});
+
+test('[P1] sticky topbar chips stay above the composer card while its switcher popover is open', async ({
+  page,
+}) => {
+  // Narrow enough that the centered 720px composer card horizontally overlaps
+  // the right-aligned topbar chip cluster; short enough that the home view
+  // scrolls. Keep width above the 900px compact-topbar breakpoint so the chip
+  // cluster stays visible.
+  await page.setViewportSize({ width: 1120, height: 640 });
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.getByText('Loading Open Design…').waitFor({ state: 'hidden', timeout: 15_000 });
+  await expect(page.getByTestId('entry-star-badge')).toBeVisible();
+  await expect(page.getByTestId('home-hero-input')).toBeVisible();
+
+  // Reveal the community templates section (first-run gesture) so the scroll
+  // container has enough content height to slide the composer under the
+  // sticky topbar strip.
+  await page.mouse.wheel(0, 500);
+
+  // Scroll the entry main container until the composer card's top edge sits
+  // inside the sticky topbar strip, vertically overlapping the chip row.
+  await scrollComposerUnderTopbar(page);
+
+  // Open the composer's agent/model switcher — this is the state that
+  // elevates the input card's stacking context.
+  await page.getByTestId('inline-model-switcher-chip').click();
+  const popover = page.getByTestId('inline-model-switcher-popover');
+  await expect(popover).toBeVisible();
+
+  const probe = await page.evaluate(() => {
+    const badge = document.querySelector('[data-testid="entry-star-badge"]');
+    const card = document.querySelector('.home-hero__input-card');
+    if (!badge || !card) return { overlap: false, hits: [] as never[] };
+    const b = badge.getBoundingClientRect();
+    const c = card.getBoundingClientRect();
+    const left = Math.max(b.left, c.left);
+    const right = Math.min(b.right, c.right);
+    const top = Math.max(b.top, c.top);
+    const bottom = Math.min(b.bottom, c.bottom);
+    const overlap = right - left > 2 && bottom - top > 2;
+    const fractions = [0.3, 0.7];
+    const hits = overlap
+      ? fractions.map((f) => {
+          const x = Math.round(left + (right - left) * f);
+          const y = Math.round(top + (bottom - top) * 0.5);
+          const el = document.elementFromPoint(x, y);
+          return {
+            x,
+            y,
+            inTopbar: !!el?.closest('.entry-main__topbar'),
+            hitClass:
+              el instanceof HTMLElement
+                ? el.className.toString().slice(0, 60) || el.tagName
+                : (el?.tagName ?? 'null'),
+          };
+        })
+      : [];
+    return { overlap, hits };
+  });
+
+  expect(
+    probe.overlap,
+    'test setup: the composer card should overlap the GitHub star chip after scrolling',
+  ).toBe(true);
+  const covered = probe.hits.filter((h) => !h.inTopbar);
+  expect(
+    covered,
+    `composer card paints over the sticky topbar chips at: ${JSON.stringify(covered)}`,
+  ).toEqual([]);
+
+  // Guard the other side of the layering contract: the switcher popover must
+  // still paint above the static home content below the card.
+  const popoverProbe = await popover.evaluate((el: Element) => {
+    const rect = el.getBoundingClientRect();
+    const x = Math.round(rect.left + rect.width * 0.5);
+    return [0.35, 0.6].map((f) => {
+      const y = Math.round(rect.top + rect.height * f);
+      const hit = document.elementFromPoint(x, y);
+      return {
+        f,
+        insidePopover: !!hit?.closest('.inline-switcher__popover'),
+        hitClass:
+          hit instanceof HTMLElement
+            ? hit.className.toString().slice(0, 60) || hit.tagName
+            : (hit?.tagName ?? 'null'),
+      };
+    });
+  });
+  const leaks = popoverProbe.filter((p) => !p.insidePopover);
+  expect(
+    leaks,
+    `home content bleeds through the open switcher popover at: ${JSON.stringify(leaks)}`,
+  ).toEqual([]);
+});
+
+// Scrolls `.entry-main--scroll` so the composer card's top edge lands inside
+// the sticky topbar strip (which stays pinned at the container's top). Fails
+// loudly when the container cannot scroll far enough to create the overlap.
+async function scrollComposerUnderTopbar(page: Page) {
+  const result = await page.evaluate(() => {
+    const scroller = document.querySelector('.entry-main--scroll');
+    const card = document.querySelector('.home-hero__input-card');
+    const topbar = document.querySelector('.entry-main__topbar');
+    if (!scroller || !card || !topbar) return { ok: false, reason: 'missing nodes' };
+    const topbarRect = topbar.getBoundingClientRect();
+    // Land the card's top edge in the middle of the topbar strip.
+    const targetTop = topbarRect.top + topbarRect.height * 0.5;
+    const cardTop = card.getBoundingClientRect().top;
+    scroller.scrollTop += cardTop - targetTop;
+    const after = card.getBoundingClientRect().top;
+    return {
+      ok: after <= topbarRect.bottom - 4,
+      reason: `card top ${Math.round(after)} vs topbar bottom ${Math.round(topbarRect.bottom)}`,
+    };
+  });
+  expect(result.ok, `test setup: could not scroll the composer under the topbar (${result.reason})`).toBe(
+    true,
+  );
+}


### PR DESCRIPTION
## Why

0.14.1 acceptance bug from the external tracker: [会话窗层级不对](https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/928fae75-d660-426f-be8e-f98ed4eb88e1). With the home view scrolled so the composer (session input) card slides under the sticky topbar strip, opening the composer's agent/model switcher made the card body paint **over** the topbar chips — the GitHub Star chip was partially covered in the acceptance screenshot.

Root cause: `.home-hero__input-card:has(<any composer popover>)` lifted the whole card to `z-index: 1700` so its popovers could escape above the home content below. But 1700 also out-stacked the sticky topbar (`.entry-main__topbar`, z-index 10) — whose own comment promises that content scrolling underneath "stays clipped behind it" — and the fixed modal family (`.automation-modal-backdrop` 80, `.plus-menu__popup` 90, `.plugins-import-modal__backdrop` 100, `.use-everywhere-modal-backdrop` 920).

## What users will see

When the home page is scrolled and a composer popover (agent/model switcher, mode toggle, template menu, plugin picker) is open, the top-right chips (GitHub Star, Teams, Discord, settings) now stay visible and clickable above the composer card instead of being covered by it. The popovers still paint above the recent projects / community content below the card.

## Decision taken

The elevated card only needs to beat the *static* home content below the hero, whose stacking contexts top out at `z-index: 8` — so the lift is now `9` (content 8 < card 9 < topbar 10 < fixed modals 80+). The alternative — raising the topbar above 1700 — was rejected because several full-screen fixed modals sit at z-index 80–920 and would be pierced by the chrome. Popover z-indexes *inside* the card (1503/1701/…) are local to the card's stacking context and are unaffected.

## Surface area

- [x] **UI** — stacking fix in `apps/web` home view (no new surface)
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [ ] None

## Screenshots

The red run's failure artifact reproduces the acceptance screenshot (composer card covering the Star chip with the switcher popover open); after the fix the same scenario shows the chips painting above the card. Verified interactively via `tools-dev run web` + browser probe (`document.elementFromPoint` over the chip/card overlap resolves to the star badge after the fix). This automated environment has no image-upload channel, so the before/after evidence is encoded in the spec below instead.

## Bug fix verification

- Test path that reproduces the bug: `e2e/ui/home-composer-topbar-stacking.test.ts` — scrolls the composer under the sticky topbar, opens the agent/model switcher, and asserts via `document.elementFromPoint` that (1) the topbar chips win the chip/card overlap and (2) the popover still paints above the home content.
- Red on the unfixed tree, green on this branch: **yes** (red: probe resolved to `composer-editor-paragraph`; green after the one-line z-index change).

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass (only a pre-existing `apps/landing-page` deprecation warning, 0 errors)
- `cd e2e && pnpm typecheck` — pass
- `e2e/ui/home-composer-topbar-stacking.test.ts` — red before / green after
- Adjacent suites `e2e/ui/home-hero-rail.test.ts` + `e2e/ui/entry-topbar.test.ts` — no new failures vs baseline: 7 failures reproduce identically with the fix stashed (pre-existing), and the one differing case (`entry-topbar.test.ts:180`) passes 3/3 with the fix applied (flaky).

## Adjacent issues (not touched)

- `.entry-main__topbar:has(.entry-settings-menu__popover) { z-index: 1900 }` (entry-layout.css) was a counter-patch against the card's old 1700 lift; it is now redundant and keeps the topbar above fixed modals while the settings popover is open. Left as-is to hold this fix's scope.
- The pre-existing failures in `home-hero-rail.test.ts` (example presets not updating the composer input) and `entry-topbar.test.ts:141/:166` reproduce on the baseline without this change.

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>