### PR TITLE
fix(web): reset entry scroll on route changes

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -596,6 +596,12 @@ export function EntryShell({
   // §7.1). Cleared as soon as the user takes any concrete entry (spec §7.4).
   const [onboardingRec, setOnboardingRec] = useState<Recommendation | null>(null);
   const entryMainScrollRef = useRef<HTMLElement | null>(null);
+  // Entry views share this element, so route changes must not inherit the previous view's offset.
+  useLayoutEffect(() => {
+    const scrollContainer = entryMainScrollRef.current;
+    if (!scrollContainer) return;
+    scrollContainer.scrollTop = 0;
+  }, [view]);
   const analytics = useAnalytics();
   const discordOnlineLabel = discordPresence
     ? t('entry.discordOnlineLabel', {

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -354,6 +354,49 @@ describe('EntryShell design systems view', () => {
   });
 });
 
+describe('EntryShell route scroll isolation', () => {
+  afterEach(() => {
+    window.localStorage.removeItem('od.entry.railOpen');
+  });
+
+  function entryScrollContainer(): HTMLElement {
+    const scrollContainer = document.querySelector('.entry-main--scroll');
+    expect(scrollContainer).toBeInstanceOf(HTMLElement);
+    if (!(scrollContainer instanceof HTMLElement)) {
+      throw new Error('entry scroll container not found');
+    }
+    return scrollContainer;
+  }
+
+  it('resets the shared scroll offset when navigating from Home to Projects', async () => {
+    window.localStorage.setItem('od.entry.railOpen', 'true');
+    renderHome();
+
+    const scrollContainer = entryScrollContainer();
+    scrollContainer.scrollTop = 280;
+    fireEvent.click(screen.getByTestId('entry-nav-projects'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('entry-view-projects').getAttribute('data-active')).toBe('true');
+    });
+    expect(scrollContainer.scrollTop).toBe(0);
+  });
+
+  it('resets the shared scroll offset when navigating from Projects to Home', async () => {
+    window.localStorage.setItem('od.entry.railOpen', 'true');
+    renderHome({}, '/projects');
+
+    const scrollContainer = entryScrollContainer();
+    scrollContainer.scrollTop = 360;
+    fireEvent.click(screen.getByTestId('entry-nav-home'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('entry-view-home').getAttribute('data-active')).toBe('true');
+    });
+    expect(scrollContainer.scrollTop).toBe(0);
+  });
+});
+
 describe('EntryShell new project rail', () => {
   it('creates a blank project directly from the rail plus', async () => {
     window.localStorage.setItem('od.entry.railOpen', 'false');


### PR DESCRIPTION
Fixes #2709

## Why

I picked this up from #2709 after reproducing the scroll leak on current `main`. Home and the other entry routes keep their content mounted inside the same `.entry-main--scroll` element, so changing routes preserved the previous route's vertical offset. That could land users midway through an unrelated page and hide its heading and primary controls.

## What users will see

Switching between Home and Projects now opens the destination at the top instead of inheriting the previous page's scroll position. The reset runs before paint, so there is no intermediate flash at the stale offset.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

The original visual report is attached to #2709. A deterministic Chromium probe at the same 1280×640 viewport and with the same 12-project fixture produced these route-transition measurements:

| Transition | `main` | This PR |
| --- | ---: | ---: |
| Home (320 px) → Projects | 236 px inherited (clamped to the page maximum) | 0 px |
| Projects (236 px) → Home | 236 px inherited | 0 px |

Product console, page, and HTTP error counts were all zero in the fixed run.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/EntryShell.onboarding.test.tsx`
- Did the test go red on `main` and green on this branch? **Yes.** The two direction-specific tests failed on `main` with retained offsets of 280 px and 360 px, then passed with destination offsets of 0 px after the source change.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web build`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/EntryShell.onboarding.test.tsx --maxWorkers=2` — 35/35 passed
- `pnpm --filter @open-design/web test` — 414 files passed; 4,341 tests passed, 7 skipped
- Deterministic Chromium before/after probe for Home → Projects and Projects → Home — both destination offsets 0 px; no product console/page/HTTP errors
