### PR TITLE
fix(web): paint the update-ready prompt above the raised home composer

### DIFF
--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -760,7 +760,13 @@
   background: var(--bg);
   isolation: isolate;
 }
-.entry-main__topbar:has(.entry-settings-menu__popover) {
+/* The topbar is an isolated sticky stacking context at z-index 10, so a
+   child popover's own z-index cannot escape it. While a topbar popover or
+   the updater's "update ready" prompt is open, lift the whole topbar above
+   raised page surfaces (e.g. the home composer card at z-index 1700 when
+   its agent picker is open) so the prompt paints on top. */
+.entry-main__topbar:has(.entry-settings-menu__popover),
+.entry-main__topbar:has(.updater-popup) {
   z-index: 1900;
 }
 .entry-main__topbar::before {

--- a/e2e/ui/updater-popup-stacking.test.ts
+++ b/e2e/ui/updater-popup-stacking.test.ts
@@ -1,0 +1,183 @@
+import { expect, test } from '@/playwright/suite';
+import { applyStandardMocks } from '@/playwright/mock-factory';
+import { T } from '@/timeouts';
+
+// Recent-project fixtures give the home page enough height to scroll the
+// composer card up under the sticky topbar, matching the reported window
+// state (the user had scrolled; the hero heading was off-screen).
+const RECENT_PROJECTS = Array.from({ length: 6 }, (_, i) => ({
+  id: `proj-${i}`,
+  name: `Project ${i}`,
+  skillId: null,
+  designSystemId: null,
+  createdAt: 1700000000000 + i,
+  updatedAt: 1700000000000 + i,
+}));
+
+// Regression: the desktop "update ready" prompt (`.updater-popup`) rendered
+// BELOW the home composer. The popup lives inside `.entry-main__topbar`,
+// which is `position: sticky; z-index: 10; isolation: isolate` — a sealed
+// stacking context — so the popup's own `z-index: 80` cannot escape it.
+// Meanwhile `.home-hero__input-card:has(.inline-switcher__popover)` raises
+// the composer card to `z-index: 1700`, painting the card (and its agent
+// picker) over the update prompt. The fix mirrors the settings-menu
+// precedent: `.entry-main__topbar:has(.updater-popup)` lifts the topbar's
+// stacking context while the prompt is open.
+
+test.beforeEach(async ({ page }) => {
+  await applyStandardMocks(page);
+  await page.route('**/api/projects', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({ json: { projects: RECENT_PROJECTS } });
+  });
+  // Fake the packaged-desktop host bridge with a fully-downloaded update so
+  // the topbar shows the updater indicator and its ready prompt.
+  await page.addInitScript(() => {
+    const downloadedStatus = {
+      arch: 'arm64',
+      availableVersion: '0.14.1-prerelease.2',
+      capabilities: {
+        canApplyInPlace: false,
+        canDownload: true,
+        canOpenInstaller: true,
+        requiresManualInstall: true,
+      },
+      channel: 'prerelease',
+      currentVersion: '0.14.1-prerelease.1',
+      downloadPath: '/tmp/open-design-update.dmg',
+      enabled: true,
+      mode: 'package-launcher',
+      platform: 'darwin',
+      state: 'downloaded',
+      supported: true,
+    };
+    (window as unknown as { __od__?: unknown }).__od__ = {
+      version: 2,
+      client: { type: 'desktop', platform: 'darwin', osLocale: 'en-US' },
+      browser: { clearData: async () => ({ ok: true }) },
+      capture: { page: async () => ({ ok: false, reason: 'not mocked' }) },
+      pdf: { print: async () => ({ ok: true }) },
+      pet: { setVisible: () => {} },
+      project: {
+        pickAndImport: async () => ({ ok: false, canceled: true }),
+        pickAndReplaceWorkingDir: async () => ({ ok: false, canceled: true }),
+      },
+      shell: {
+        openExternal: async () => ({ ok: true }),
+        openPath: async () => ({ ok: true }),
+      },
+      updater: {
+        status: async () => downloadedStatus,
+        check: async () => downloadedStatus,
+        download: async () => downloadedStatus,
+        install: async () => downloadedStatus,
+        quit: async () => ({ ok: true }),
+        subscribe: () => () => {},
+      },
+    };
+  });
+});
+
+test('[P1] update ready prompt paints above the composer and its agent picker', async ({ page }) => {
+  // Match the reported desktop window shape (1280x900 logical). The prompt
+  // anchors to the sticky topbar, so it stays pinned to the viewport top.
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.getByText('Loading Open Design…').waitFor({ state: 'hidden', timeout: T.long });
+  await expect(page.getByTestId('home-hero')).toBeVisible();
+
+  // Scroll the entry main pane until the composer card sits at the viewport
+  // top, as in the bug report: the user had scrolled the home page, so the
+  // in-flow composer card slid up under the sticky-topbar prompt. Wait for
+  // the recent-projects fixtures to give the pane scroll room first.
+  await page.waitForFunction(() => {
+    const scroller = document.querySelector('.entry-main--scroll');
+    return scroller != null && scroller.scrollHeight > scroller.clientHeight + 400;
+  }, undefined, { timeout: T.long });
+  // Scroll-and-verify inside one poll step: late-loading home sections can
+  // reset the pane's scroll position, so re-issue the scroll until the card
+  // actually holds near the top.
+  await expect
+    .poll(async () =>
+      page.evaluate(() => {
+        const scroller = document.querySelector('.entry-main--scroll');
+        const card = document.querySelector('.home-hero__input-card');
+        if (scroller == null || card == null) return Number.NaN;
+        const top = card.getBoundingClientRect().top;
+        if (top > 80) scroller.scrollBy(0, top - 24);
+        return card.getBoundingClientRect().top;
+      }),
+    )
+    .toBeLessThan(80);
+
+  await page.getByTestId('entry-nav-updater').click();
+  const popup = page.getByTestId('updater-popup');
+  await expect(popup).toBeVisible();
+
+  // Open the composer's agent picker with the keyboard. The prompt dismisses
+  // on outside MOUSEDOWN only, so keyboard activation keeps both surfaces
+  // open at once — the state users hit when the prompt is up (e.g. while an
+  // install is in flight) and they interact with the composer.
+  const chip = page.getByTestId('inline-model-switcher-chip');
+  await chip.focus();
+  await page.keyboard.press('Enter');
+  await expect(page.getByTestId('inline-model-switcher-popover')).toBeVisible();
+  await expect(popup).toBeVisible();
+
+  // The prompt is a dialog: it must be the topmost element wherever the
+  // raised composer card or its agent-picker popover overlaps it. With the
+  // stacking bug, `elementFromPoint` resolves to composer/picker content
+  // instead of the prompt.
+  const probe = await page.evaluate(() => {
+    const popupEl = document.querySelector('[data-testid="updater-popup"]');
+    const overlays = [
+      document.querySelector('.home-hero__input-card'),
+      document.querySelector('[data-testid="inline-model-switcher-popover"]'),
+    ];
+    if (popupEl == null || overlays.some((el) => el == null)) {
+      return { ready: false, overlapArea: 0, samples: [] };
+    }
+    const p = popupEl.getBoundingClientRect();
+    let overlapArea = 0;
+    const samples: { x: number; y: number; insidePopup: boolean; hit: string }[] = [];
+    for (const overlay of overlays) {
+      const r = (overlay as Element).getBoundingClientRect();
+      const left = Math.max(p.left, r.left);
+      const right = Math.min(p.right, r.right);
+      const top = Math.max(p.top, r.top);
+      const bottom = Math.min(p.bottom, r.bottom);
+      if (right - left < 4 || bottom - top < 4) continue;
+      overlapArea += (right - left) * (bottom - top);
+      for (const fx of [0.25, 0.5, 0.75]) {
+        for (const fy of [0.25, 0.5, 0.75]) {
+          const x = Math.round(left + (right - left) * fx);
+          const y = Math.round(top + (bottom - top) * fy);
+          const hit = document.elementFromPoint(x, y);
+          samples.push({
+            x,
+            y,
+            insidePopup: hit?.closest('[data-testid="updater-popup"]') != null,
+            hit:
+              hit instanceof HTMLElement
+                ? hit.className.toString().slice(0, 60) || hit.tagName
+                : (hit?.tagName ?? 'null'),
+          });
+        }
+      }
+    }
+    return { ready: true, overlapArea, samples };
+  });
+
+  expect(probe.ready, 'popup, composer card, and agent picker must all be present').toBe(true);
+  // Geometry precondition: the composer surfaces actually reach under the
+  // prompt — otherwise this test would pass without exercising the stack.
+  expect(probe.overlapArea, 'composer must overlap the prompt area').toBeGreaterThan(0);
+  const leaks = probe.samples.filter((sample) => !sample.insidePopup);
+  expect(
+    leaks,
+    `Composer content paints over the update prompt at: ${JSON.stringify(leaks)}`,
+  ).toEqual([]);
+});


### PR DESCRIPTION
Bug source (external tracker, Plane): https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/716a0ab5-e410-4170-bd7a-799aeb3839c8

## Why

0.14.1 acceptance found the desktop auto-update "update ready" prompt rendering **below** the home composer: on a scrolled home window, opening the composer's agent picker painted the composer card and its popover over the prompt, hiding its icon and left edge (see the Plane issue screenshot). An update prompt is the highest-intent surface on screen — installing may quit the app — so anything painting over it is a real UX bug.

Root cause, not symptom: the prompt lives inside `.entry-main__topbar`, which is `position: sticky; z-index: 10; isolation: isolate` — a sealed stacking context. The prompt's own `z-index: 80` cannot escape it, while `.home-hero__input-card:has(.inline-switcher__popover)` (and the other composer-popover variants) raise the composer card to `z-index: 1700`, above the whole topbar. The repo already solves this exact shape for the settings menu (`.entry-main__topbar:has(.entry-settings-menu__popover)` → `z-index: 1900`); this PR extends that same lift to `:has(.updater-popup)`.

## What users will see

When the "Update ready" prompt is open in the top-right corner, it now always paints on top of the home composer and its agent/model picker, even on a scrolled home page. No layout or interaction changes — only paint order while the prompt is open.

## Surface area

- [x] **UI** — stacking/paint-order fix for the updater prompt in `apps/web` (desktop packaged runtime surface)
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var** — not applicable: purely a visual stacking fix in web CSS; there is no CLI-reachable behavior in this change
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

The before state is the screenshot attached to the Plane issue (composer + agent picker covering the prompt's left half). I reproduced exactly that state in a mocked packaged-desktop web runtime and verified after the fix that the prompt paints fully above both surfaces; the regression test below asserts this with `document.elementFromPoint` sampling across the overlap region (18 sample points, all must resolve inside the prompt), so the paint order is pinned by CI rather than by eyeballing.

## Bug fix verification

- Test path that reproduces the bug: `e2e/ui/updater-popup-stacking.test.ts`
- Red on the pre-fix tree (identical to `main` — the CSS edit is this PR's only source change) with all 18 overlap samples resolving to composer/picker content; green on this branch (3/3 repeat runs). (yes)
- The test mocks the packaged-desktop `window.__od__` bridge with a downloaded update, seeds recent-project fixtures so the home pane can scroll, scrolls the composer under the sticky-topbar prompt (the reported window state), opens the prompt plus the agent picker, and asserts the prompt is topmost wherever they overlap — with a geometry precondition (`overlapArea > 0`) so the test cannot silently pass without exercising the stack.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass (workspace) and `pnpm --filter @open-design/e2e typecheck` — pass
- `pnpm -C e2e exec playwright test ui/updater-popup-stacking.test.ts --repeat-each=3` — 3/3 pass (red before the CSS fix, green after)

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>