### PR TITLE
fix(web): stop silent-updates settings toggle from crashing the page

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -5668,13 +5668,19 @@ export function SettingsDialog({
                 <label className="settings-about-toggle">
                   <input
                     checked={cfg.allowSilentUpdates === true}
+                    data-testid="settings-allow-silent-updates"
                     type="checkbox"
-                    onChange={(event) =>
+                    onChange={(event) => {
+                      // Capture before setState: React clears event.currentTarget
+                      // after the handler returns, and the functional updater can
+                      // run later when SettingsDialog already has pending lanes
+                      // (about-updater status, autosave indicator, etc.).
+                      const allowSilentUpdates = event.currentTarget.checked;
                       setCfg((current) => ({
                         ...current,
-                        allowSilentUpdates: event.currentTarget.checked,
-                      }))
-                    }
+                        allowSilentUpdates,
+                      }));
+                    }}
                   />
                   <span className="settings-about-toggle-copy">
                     <span>{t('settings.allowSilentUpdates')}</span>

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -5063,4 +5063,67 @@ describe('SettingsDialog about interactions', () => {
     });
     expect(install).toHaveBeenCalledTimes(1);
   });
+
+  it('toggles allowSilentUpdates on the about page and autosaves without crashing', async () => {
+    const { onPersist } = renderSettingsDialog(
+      { mode: 'daemon', agentId: 'codex', allowSilentUpdates: false },
+      {
+        initialSection: 'about',
+        appVersionInfo: {
+          version: '0.14.1',
+          channel: 'beta',
+          packaged: true,
+          platform: 'darwin',
+          arch: 'arm64',
+        },
+      },
+    );
+
+    const checkbox = screen.getByTestId('settings-allow-silent-updates') as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+
+    // Concurrent sibling updates (about-updater status subscription, autosave
+    // status) can defer the functional setCfg updater until after React has
+    // cleared event.currentTarget. Toggle twice to cover on → off.
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(true);
+    expect(screen.getByTestId('settings-allow-silent-updates')).toBeTruthy();
+
+    await waitFor(() => {
+      expect(onPersist).toHaveBeenCalledWith(
+        expect.objectContaining({ allowSilentUpdates: true }),
+        expect.anything(),
+      );
+    });
+
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(false);
+    expect(screen.getByTestId('settings-allow-silent-updates')).toBeTruthy();
+
+    await waitFor(() => {
+      expect(onPersist).toHaveBeenCalledWith(
+        expect.objectContaining({ allowSilentUpdates: false }),
+        expect.anything(),
+      );
+    });
+  });
+
+  it('does not read event.currentTarget inside the silent-updates setCfg updater', async () => {
+    // Source invariant: functional updaters must not close over event.currentTarget
+    // (null after the native/React event handler returns under pending lanes).
+    const { readFile } = await import('node:fs/promises');
+    const { join } = await import('node:path');
+    const source = await readFile(
+      join(process.cwd(), 'src/components/SettingsDialog.tsx'),
+      'utf8',
+    );
+    const silentToggleBlock = source.match(
+      /data-testid="settings-allow-silent-updates"[\s\S]*?<\/label>/,
+    )?.[0];
+    expect(silentToggleBlock).toBeTruthy();
+    expect(silentToggleBlock).not.toMatch(
+      /setCfg\(\s*\(\s*current\s*\)\s*=>\s*\(\{[\s\S]*?event\.currentTarget\.checked/,
+    );
+    expect(silentToggleBlock).toMatch(/const allowSilentUpdates = event\.currentTarget\.checked/);
+  });
 });

--- a/apps/web/tests/components/silent-updates-currentTarget.race.test.tsx
+++ b/apps/web/tests/components/silent-updates-currentTarget.race.test.tsx
@@ -94,7 +94,7 @@ describe('silent updates currentTarget race', () => {
     event.currentTarget = null;
     try {
       // Same expression SettingsDialog used inside setCfg(current => ...)
-      void (event.currentTarget as HTMLInputElement).checked;
+      void (event.currentTarget as unknown as HTMLInputElement).checked;
     } catch (error) {
       thrown = error;
     }

--- a/apps/web/tests/components/silent-updates-currentTarget.race.test.tsx
+++ b/apps/web/tests/components/silent-updates-currentTarget.race.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+/**
+ * Documents the React event.currentTarget + functional setState race that
+ * crashed Settings → About "Allow silent updates" under pending sibling
+ * updates (about-updater status, autosave indicator).
+ *
+ * React clears `event.currentTarget` after the native handler returns. When
+ * the fiber already has pending lanes, useState skips eager evaluation and
+ * runs the functional updater later — reading `event.currentTarget.checked`
+ * then throws TypeError and tears down the tree (error page, needs reload).
+ */
+import React, { useEffect, useState } from 'react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});
+
+function BadSilentToggle({ forcePendingLanes }: { forcePendingLanes: boolean }) {
+  const [allowSilentUpdates, setAllowSilentUpdates] = useState(false);
+  const [, setBump] = useState(0);
+
+  useEffect(() => {
+    if (!forcePendingLanes) return;
+    // Keep this fiber "busy" so subsequent setState may skip eager evaluation.
+    const id = window.setInterval(() => setBump((n) => n + 1), 0);
+    return () => window.clearInterval(id);
+  }, [forcePendingLanes]);
+
+  return (
+    <label>
+      <input
+        type="checkbox"
+        checked={allowSilentUpdates}
+        data-testid="bad-silent-toggle"
+        onChange={(event) => {
+          // Intentionally BAD pattern (what SettingsDialog used before the fix).
+          setAllowSilentUpdates(() => event.currentTarget.checked);
+        }}
+      />
+      Allow silent updates
+    </label>
+  );
+}
+
+function GoodSilentToggle({ forcePendingLanes }: { forcePendingLanes: boolean }) {
+  const [allowSilentUpdates, setAllowSilentUpdates] = useState(false);
+  const [, setBump] = useState(0);
+
+  useEffect(() => {
+    if (!forcePendingLanes) return;
+    const id = window.setInterval(() => setBump((n) => n + 1), 0);
+    return () => window.clearInterval(id);
+  }, [forcePendingLanes]);
+
+  return (
+    <label>
+      <input
+        type="checkbox"
+        checked={allowSilentUpdates}
+        data-testid="good-silent-toggle"
+        onChange={(event) => {
+          const next = event.currentTarget.checked;
+          setAllowSilentUpdates(() => next);
+        }}
+      />
+      Allow silent updates
+    </label>
+  );
+}
+
+describe('silent updates currentTarget race', () => {
+  it('good pattern survives pending lanes on the same fiber', async () => {
+    render(<GoodSilentToggle forcePendingLanes />);
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 15));
+    });
+    const checkbox = screen.getByTestId('good-silent-toggle') as HTMLInputElement;
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(true);
+    fireEvent.click(checkbox);
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it('bad pattern can throw when currentTarget is read after the handler', async () => {
+    // Direct unit of the failure mode: if the functional updater runs after
+    // React nulls currentTarget, accessing .checked throws.
+    let thrown: unknown = null;
+    const event = {
+      currentTarget: null as HTMLInputElement | null,
+    };
+    // Simulate "handler returned; React cleared currentTarget"
+    event.currentTarget = null;
+    try {
+      // Same expression SettingsDialog used inside setCfg(current => ...)
+      void (event.currentTarget as HTMLInputElement).checked;
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(TypeError);
+    expect(String(thrown)).toMatch(/null|undefined|checked/i);
+
+    // And the fixed capture pattern does not throw even when the event is cleared later.
+    const live = { currentTarget: { checked: true } as HTMLInputElement };
+    const captured = live.currentTarget.checked;
+    live.currentTarget = null as unknown as HTMLInputElement;
+    expect(captured).toBe(true);
+  });
+
+  it('renders the bad toggle under pending lanes without requiring a green path', async () => {
+    // Environment-dependent: some React schedules still eager-evaluate and
+    // never hit the throw. We still mount the bad component to keep the
+    // race harness available when debugging future regressions.
+    render(<BadSilentToggle forcePendingLanes />);
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 15));
+    });
+    expect(screen.getByTestId('bad-silent-toggle')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Why

QA reported that toggling **Settings → About → Allow silent updates** dropped the app into the reload error page (`This page couldn't load` / need Reload). While validating silent updates on tools-dev we hit the same crash on the first click under the buggy pattern.

**Pain:** a one-click preference control took down the whole web shell and forced a reload, so users could not enable/disable silent updates from Settings.

## What users will see

- Toggling **Allow silent updates** in Settings → About no longer crashes the page.
- Preference still autosaves as before; no change to silent-update apply semantics at startup.

## Surface area

- [x] **UI** — settings checkbox handler in `apps/web` (About section)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Behavior fix (no visual change). Reproduced on tools-dev:

| Build | Result |
|-------|--------|
| Before (read `event.currentTarget.checked` inside functional `setCfg`) | First click → `TypeError: Cannot read properties of null (reading 'checked')` → reload error page |
| After (capture `checked` before `setState`) | 16 rapid toggles; settings dialog stays mounted; no pageerror |

## Bug fix verification

- Test path that reproduces the bug:
  - `apps/web/tests/components/SettingsDialog.execution.test.tsx` — toggles About checkbox + autosave + source invariant
  - `apps/web/tests/components/silent-updates-currentTarget.race.test.tsx` — documents the `currentTarget`/deferred updater failure mode
- Did the test go red on `main` and green on this branch? **Source invariant is red on the old pattern** (functional updater closed over `event.currentTarget.checked`). Full-page crash was **red on tools-dev with the old handler** and **green with this fix** (A/B Playwright against `http://127.0.0.1:17573`).
- Root cause: React clears `event.currentTarget` after the change handler returns. When `SettingsDialog` already has pending lanes (about-updater status, autosave indicator), `useState` defers the functional updater and reading `.checked` throws.

## Validation

```bash
cd apps/web && pnpm exec vitest run -c vitest.config.ts \
  tests/components/SettingsDialog.execution.test.tsx \
  tests/components/silent-updates-currentTarget.race.test.tsx \
  -t "silent|allowSilent"
# 6 passed

# tools-dev A/B (Settings → About → toggle Allow silent updates)
# broken handler: crash on toggle #1 + reload page
# fixed handler: 16 toggles, settingsAlive=true, pageErrors=0
```