### PR TITLE
fix(branding): preserve authored seed overrides

### DIFF
--- a/apps/daemon/src/brands/engine/README.md
+++ b/apps/daemon/src/brands/engine/README.md
@@ -105,7 +105,7 @@ decoded to real bytes by `writeBrandSystem` / `write: true`.
 
 | Path | What it is |
 | --- | --- |
-| `seed.json` | The ~20-field SeedToken — the only authored surface. |
+| `seed.json` | Generated snapshot of the effective SeedToken; persistent overrides belong in `brand.json.seed`. |
 | `tokens.default.json` / `.dark.json` / `.compact.json` | Full derived DesignTokens per algorithm. |
 | `variables.css` | `:root{}` (light) + `.dark{}` (dark) CSS custom properties. |
 | `variables.dark.css` | Standalone `:root{}` for the dark theme. |
@@ -118,10 +118,12 @@ decoded to real bytes by `writeBrandSystem` / `write: true`.
 
 ## Recipes
 
-**Change the brand color.** Edit `colorPrimary` in the seed (or the `accent`
-color role in the Brand). The 10-step palette, every interaction state, the
-primary background/border, and every component referencing
-`var(--brand-color-primary)` all update together — re-run the engine.
+**Change the brand color.** Set `seed.colorPrimary` or edit the `accent` color
+role in the Brand. For registered brand projects, persist overrides in
+`brand.json.seed`, then run `od brand finalize <brand-id>`. Do not edit
+`system/seed.json` directly; finalize regenerates it. The 10-step palette, every
+interaction state, the primary background/border, and every component referencing
+`var(--brand-color-primary)` update together.
 
 **Light → dark / compact.** Both are the same seed run through a different
 algorithm. Load `variables.dark.css` (or add the `.dark` class) for dark;

--- a/apps/daemon/src/brands/engine/build.ts
+++ b/apps/daemon/src/brands/engine/build.ts
@@ -116,7 +116,7 @@ Everything below is *derived* — no token here was hand-authored.
 
 | Path | What it is |
 | --- | --- |
-| \`seed.json\` | The ~20-field SeedToken — the only authored surface. |
+| \`seed.json\` | Generated snapshot of the effective seed; persistent overrides live in \`brand.json.seed\`. |
 | \`tokens.default.json\` | Full derived DesignTokens (light). |
 | \`tokens.dark.json\` | Same seed, dark algorithm. |
 | \`tokens.compact.json\` | Same seed, compact (dense) algorithm. |
@@ -135,10 +135,12 @@ Everything below is *derived* — no token here was hand-authored.
 
 ## How to re-theme
 
-The whole system traces back to \`seed.json\`. To re-brand, change one field and
-re-run the engine — every downstream token, component and artifact follows.
+The whole system is regenerated from \`brand.json\` and optional
+\`brand.json.seed\` overrides. Persist authored overrides there, then run
+\`od brand finalize <brand-id>\` — every downstream token, component and artifact
+follows. Do not edit \`system/seed.json\` directly; finalize replaces it.
 
-- **Change the brand color:** edit \`colorPrimary\` in the seed (e.g. \`"#1677ff"\`).
+- **Change the brand color:** edit the accent role or \`seed.colorPrimary\` in \`brand.json\`.
   The 10-step palette, all interaction states, the primary background/border and
   every component that references \`var(--brand-color-primary)\` update together.
 - **Light → dark:** the dark theme is the same seed run through the \`"dark"\`

--- a/apps/daemon/src/brands/index.ts
+++ b/apps/daemon/src/brands/index.ts
@@ -1877,6 +1877,9 @@ export async function renderBrandPreviewIntoProject(
  *  tool call that has no registry to resolve against and ALWAYS fails (it burns
  *  a turn and confuses the run). Keep this prompt describing the methodology
  *  inline and steer the agent away from invoking any skill / slash command. */
+const SEED_AUTHORING_GUIDANCE =
+  'Persist engine-level overrides such as control height in `brand.json.seed` (for example, `{ "controlHeight": 44 }`). Do not edit `system/seed.json` or other generated `system/` files directly; `od brand finalize` replaces them.';
+
 function brandExtractionPrompt(input: {
   url: string;
   brandId: string;
@@ -1893,6 +1896,7 @@ function brandExtractionPrompt(input: {
       'A usable design system has ALREADY been parsed from `context/input-DESIGN.md`, finalized programmatically, and registered. The design-system page (`brand.html`) is open as the active tab, already in the `ready` state and applyable everywhere RIGHT NOW. Your job is to ENRICH that provisional system in place: inspect `context/input-DESIGN.md`, `DESIGN.md`, `brand.json`, `system/variables.css`, `system/theme.json`, and the component kit pages; then replace weak guesses with clearer token roles, component guidance, voice, and implementation notes.',
       '',
       'Do not create a duplicate design system. Keep the same registered user design-system id. Update `brand.json` and `BRAND.md` incrementally, run `od brand preview ' + input.brandId + '` after field groups, then run `od brand finalize ' + input.brandId + '` when ready.',
+      SEED_AUTHORING_GUIDANCE,
       '',
       'Focus areas:',
       '- Normalize color roles from the pasted DESIGN.md into background, surface, foreground, muted, border, accent, and accent-secondary.',
@@ -1923,6 +1927,7 @@ function brandExtractionPrompt(input: {
     '',
     '2. SYNTHESIZE INCREMENTALLY — write `brand.json` AS SOON AS you have the name, a couple of colors, and a logo candidate (do not wait for everything), then run `od brand preview ' + input.brandId + '` and tell the user it is filling in. It must parse as JSON and use exactly the seven color roles (background, surface, foreground, muted, border, accent, accent-secondary), each with `hex` (#rrggbb), `oklch`, `name`, `usage`; plus `name`, `tagline`, `description`, `sourceUrl`, `logo` ({ primary, alternates, notes } with `logos/<file>` paths), `typography` ({ display, body, mono? } each { family, fallbacks[], weights[], googleFontsUrl? }), `voice`, `imagery` (incl. `samples` — the `imagery/<file>` images you saved), and `layout`. Never invent colors from memory — pick them from what you measured.',
     '   - PREVIEW AFTER EACH FIELD GROUP, do not batch to the end. The kit fills in live, so after you measure and add each group — (a) colors, (b) typography/fonts, (c) logo candidates, (d) cover/hero imagery samples, (e) voice & tone, (f) imagery/layout posture — update `brand.json` and re-run `od brand preview ' + input.brandId + '`. Partial data renders the filled modules and keeps skeletons for the rest, which is exactly the progressive "filling in" the user should watch. Also write `BRAND.md`, a prose brand guide an autonomous design agent can follow.',
+    SEED_AUTHORING_GUIDANCE,
     '',
     '3. REBUILD & RE-REGISTER — when `brand.json` is enriched, run `od brand finalize ' + input.brandId + '` (add `--json` for machine output). That re-validates it, re-derives the light/dark/compact design tokens and the six design-system artifacts (landing, deck, poster, email, newsletter, form), and UPDATES the already-registered design system in place (same id — never a duplicate), so every template that already uses it picks up the sharper result. Fix `brand.json` and re-run if it reports a validation error.',
     '',
@@ -1949,6 +1954,7 @@ function brandExtractionFallbackPrompt(input: {
       'The daemon created a live design-system scaffold and saved the pasted source at `context/input-DESIGN.md`. A ready design system may already be registered from the programmatic parser; if not, use the pasted file as the canonical source and complete it.',
       '',
       'Read `context/input-DESIGN.md`, then update `brand.json`, `BRAND.md`, and `DESIGN.md` progressively. Run `od brand preview ' + input.brandId + '` after meaningful field groups, then `od brand finalize ' + input.brandId + '` to register or update the same design system in place.',
+      SEED_AUTHORING_GUIDANCE,
       '',
       'Finish by pointing the user at the completed brand.html and reusable design-system assets.',
     ].join('\n');
@@ -1967,6 +1973,7 @@ function brandExtractionFallbackPrompt(input: {
     'This task already contains the full brand-extract workflow inline — follow it directly. Do NOT try to load or invoke a `brand-extract` skill, `Skill`, or any slash command: none is registered here and the call will fail. Drive and observe the target site with the `agent-browser` tool. Measure before you synthesize: capture the real colors, fonts, logo candidates, representative imagery, voice, and layout posture. If the page is an anti-bot verification interstitial, emit a `<question-form>` asking the user to complete verification in the browser, then continue after they respond.',
     '',
     'Write `brand.json` as soon as you have the name, a couple of measured colors, and a logo candidate, then run `od brand preview ' + input.brandId + '` so the scaffold fills in progressively. Keep updating `brand.json`, `BRAND.md`, saved `logos/`, fonts, and `imagery/` samples as you measure each field group.',
+    SEED_AUTHORING_GUIDANCE,
     '',
     'When the kit is complete and validates, run `od brand finalize ' + input.brandId + '` (add `--json` for machine output). Fix validation errors and re-run finalize until the brand is registered and the design-system assets are ready.',
     '',

--- a/apps/daemon/src/brands/schema.ts
+++ b/apps/daemon/src/brands/schema.ts
@@ -1,16 +1,17 @@
-import type { Brand as ContractBrand, BrandColor as ContractBrandColor } from '@open-design/contracts';
-import type { SeedToken } from './engine/types.js';
+import type {
+  Brand as ContractBrand,
+  BrandColor as ContractBrandColor,
+  BrandSeedOverrides,
+} from '@open-design/contracts';
 
 export const ASSET_KINDS = ['landing', 'deck', 'poster', 'email', 'newsletter', 'form'] as const;
 export type AssetKind = (typeof ASSET_KINDS)[number];
 
 export type BrandColor = ContractBrandColor;
 
-export type Brand = ContractBrand & {
-  seed?: Partial<SeedToken>;
-};
+export type Brand = ContractBrand;
 
-const SEED_FIELD_TYPES: Record<keyof SeedToken, 'string' | 'number' | 'boolean'> = {
+const SEED_FIELD_TYPES: Record<keyof BrandSeedOverrides, 'string' | 'number' | 'boolean'> = {
   colorPrimary: 'string',
   colorSuccess: 'string',
   colorWarning: 'string',
@@ -33,7 +34,7 @@ const SEED_FIELD_TYPES: Record<keyof SeedToken, 'string' | 'number' | 'boolean'>
   motion: 'boolean',
 };
 
-export function sanitizeSeedOverrides(raw: unknown): Partial<SeedToken> | undefined {
+export function sanitizeSeedOverrides(raw: unknown): BrandSeedOverrides | undefined {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined;
   const input = raw as Record<string, unknown>;
   const out: Record<string, string | number | boolean> = {};
@@ -43,5 +44,5 @@ export function sanitizeSeedOverrides(raw: unknown): Partial<SeedToken> | undefi
     if (expected === 'number' && !Number.isFinite(value as number)) continue;
     out[key] = value as string | number | boolean;
   }
-  return Object.keys(out).length > 0 ? (out as Partial<SeedToken>) : undefined;
+  return Object.keys(out).length > 0 ? (out as BrandSeedOverrides) : undefined;
 }

--- a/apps/daemon/src/brands/validate.ts
+++ b/apps/daemon/src/brands/validate.ts
@@ -1,17 +1,14 @@
-// Brand validation + normalization.
-//
-// Ported from the branding-agent schema, retargeted onto the '@open-design/
-// contracts' Brand type and BRAND_COLOR_ROLES. The SeedToken / seed-override
-// path from the source is dropped — Open Design brands carry no Ant seed.
+// Brand validation + normalization, including the optional authored seed
+// overrides that drive deterministic system generation.
 
 import {
   BRAND_COLOR_ROLES,
-  type Brand,
   type BrandColor,
   type BrandColorRole,
   type BrandFontSpec,
   type BrandImagerySample,
 } from '@open-design/contracts';
+import { sanitizeSeedOverrides, type Brand } from './schema.js';
 
 const isStr = (v: unknown): v is string => typeof v === 'string';
 const strArr = (v: unknown): string[] => (Array.isArray(v) ? v.filter(isStr) : []);
@@ -88,12 +85,14 @@ export function validateBrand(raw: unknown, sourceUrl: string): Brand {
   const imageryRaw = (o.imagery ?? {}) as Record<string, unknown>;
   const layoutRaw = (o.layout ?? {}) as Record<string, unknown>;
   const typoRaw = (o.typography ?? {}) as Record<string, unknown>;
+  const seed = sanitizeSeedOverrides(o.seed);
 
   return {
     name: o.name.trim(),
     tagline: isStr(o.tagline) ? o.tagline : '',
     description: isStr(o.description) ? o.description : '',
     sourceUrl,
+    ...(seed ? { seed } : {}),
     logo: {
       primary: isStr(logoRaw.primary) && logoRaw.primary ? logoRaw.primary : null,
       alternates: strArr(logoRaw.alternates),

--- a/apps/daemon/tests/brand-extraction-engine.test.ts
+++ b/apps/daemon/tests/brand-extraction-engine.test.ts
@@ -1183,6 +1183,8 @@ describe('agent-driven brand extraction engine', () => {
     const prompt = getProject(db, result.projectId)?.pendingPrompt ?? '';
     expect(prompt).toContain('context/input-DESIGN.md');
     expectNoPhantomSkillCall(prompt);
+    expect(prompt).toContain('`brand.json.seed`');
+    expect(prompt).toContain('Do not edit `system/seed.json`');
   });
 
   it('renderBrandPreviewIntoProject re-renders brand.html from a partial brand.json', async () => {
@@ -1290,6 +1292,61 @@ describe('agent-driven brand extraction engine', () => {
     expect(html).toContain('system/kit.html');
     expect(existsSync(path.join(projectDir, 'system', 'kit.html'))).toBe(true);
     expect(html).toMatch(/"colorPrimary":"#/);
+  });
+
+  it('finalizeBrand preserves authored seed overrides in the registered system', async () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const started = await startOfflineBrandExtraction({
+      url: 'acme.com',
+      brandsRoot,
+      projectsRoot,
+      skillsRoot: SKILLS_ROOT,
+      db,
+      logoFallback: NO_LOGO_FALLBACK,
+    });
+
+    const projectDir = path.join(projectsRoot, started.projectId);
+    writeFileSync(
+      path.join(projectDir, 'brand.json'),
+      JSON.stringify(
+        {
+          ...VALID_BRAND,
+          sourceUrl: started.sourceUrl,
+          seed: { controlHeight: 44 },
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+
+    await finalizeBrand({
+      id: started.id,
+      brandsRoot,
+      userDesignSystemsRoot,
+      projectsRoot,
+      skillsRoot: SKILLS_ROOT,
+      db,
+      logoFallback: NO_LOGO_FALLBACK,
+      imageryFallback: NO_IMAGERY_FALLBACK,
+    });
+
+    const persistedBrand = JSON.parse(
+      readFileSync(path.join(projectDir, 'brand.json'), 'utf8'),
+    ) as { seed?: { controlHeight?: number } };
+    expect(persistedBrand.seed?.controlHeight).toBe(44);
+
+    const generatedSeed = JSON.parse(
+      readFileSync(path.join(projectDir, 'system', 'seed.json'), 'utf8'),
+    ) as { controlHeight?: number };
+    expect(generatedSeed.controlHeight).toBe(44);
+
+    const generatedGuide = readFileSync(
+      path.join(projectDir, 'system', 'BRAND-SYSTEM.md'),
+      'utf8',
+    );
+    expect(generatedGuide).toContain('`brand.json.seed`');
+    expect(generatedGuide).not.toContain('only authored surface');
   });
 
   it('finalizeBrand is idempotent — re-finalizing reuses the brand design system', async () => {

--- a/packages/contracts/src/api/brands.ts
+++ b/packages/contracts/src/api/brands.ts
@@ -74,6 +74,31 @@ export interface BrandLayout {
   postureRules: string[];
 }
 
+/** Authored overrides for the deterministic design-system seed. Omitted
+ *  fields continue to use the engine defaults. */
+export interface BrandSeedOverrides {
+  colorPrimary?: string;
+  colorSuccess?: string;
+  colorWarning?: string;
+  colorError?: string;
+  colorInfo?: string;
+  colorLink?: string;
+  colorTextBase?: string;
+  colorBgBase?: string;
+  fontFamily?: string;
+  fontFamilyCode?: string;
+  fontSize?: number;
+  borderRadius?: number;
+  sizeUnit?: number;
+  sizeStep?: number;
+  controlHeight?: number;
+  lineWidth?: number;
+  motionUnit?: number;
+  motionBase?: number;
+  wireframe?: boolean;
+  motion?: boolean;
+}
+
 /** The canonical brand kit — the single source of truth for every brand surface. */
 export interface Brand {
   name: string;
@@ -95,6 +120,8 @@ export interface Brand {
   voice: BrandVoice;
   imagery: BrandImagery;
   layout: BrandLayout;
+  /** Optional authored inputs retained across finalize and exposed by the API. */
+  seed?: BrandSeedOverrides;
 }
 
 /**

--- a/packages/contracts/tests/brands-contract.test.ts
+++ b/packages/contracts/tests/brands-contract.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import type { BrandFinalizeResponse } from '../src/api/brands';
+
+describe('brands contract', () => {
+  it('exposes authored seed overrides on finalized brands', () => {
+    const response = {
+      id: 'brand-acme',
+      brand: {
+        name: 'Acme',
+        tagline: 'Reliable examples',
+        description: 'A contract fixture.',
+        sourceUrl: 'https://example.com',
+        logo: { primary: null, alternates: [], notes: '' },
+        colors: [],
+        typography: {
+          display: { family: 'Inter', fallbacks: ['sans-serif'], weights: [400, 700] },
+          body: { family: 'Inter', fallbacks: ['sans-serif'], weights: [400, 700] },
+        },
+        voice: {
+          adjectives: [],
+          tone: '',
+          messagingPillars: [],
+          vocabulary: { use: [], avoid: [] },
+        },
+        imagery: { style: '', subjects: [], treatment: '', avoid: [] },
+        layout: { radius: '', borderWeight: '', spacing: '', postureRules: [] },
+        seed: { controlHeight: 44 },
+      },
+      designSystemId: 'user:brand-acme',
+      projectId: 'brand-brand-acme',
+      files: ['system/seed.json'],
+    } satisfies BrandFinalizeResponse;
+
+    const restored = JSON.parse(JSON.stringify(response)) as BrandFinalizeResponse;
+
+    expect(restored.brand.seed?.controlHeight).toBe(44);
+  });
+});


### PR DESCRIPTION
Fixes #5612

## Why

While refining a real extracted design system, `od brand finalize` reset an authored `seed.controlHeight` override from 44 to the default 32. The local Brand schema and rebuild path already support sanitized seed overrides, but validation reconstructed the brand without retaining `seed`. This made finalize silently discard the only persistent input capable of steering deterministic system generation.

The generated guidance also pointed agents at `system/seed.json`, even though finalize deletes and regenerates `system/`.

## What users will see

Brand projects can persist supported engine overrides under `brand.json.seed`. Finalize now retains those sanitized overrides and regenerates the system from the effective seed. Extraction/refinement prompts and generated documentation identify `brand.json.seed` as the authored input and `system/seed.json` as generated output.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — internal bug fix, docs, and tests only

## Screenshots

Not applicable; this fix has no UI entry point.

## Bug fix verification

- Test path: `apps/daemon/tests/brand-extraction-engine.test.ts`
- Red on the `open-design-v0.14.1` tag: yes — `finalized.brand.seed?.controlHeight` was `undefined`; the persisted project brand also lost the override and generated `system/seed.json` fell back to 32.
- Green after rebasing onto current `main`: yes — the persisted project `brand.json` and generated `system/seed.json` both retain `controlHeight: 44`.
- The same test verifies that generated guidance names `brand.json.seed` and no longer calls `system/seed.json` the authored surface.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/brand-extraction-engine.test.ts` — 47 passed
- `pnpm --filter @open-design/contracts build` — passed
- `pnpm --filter @open-design/registry-protocol build` — passed
- `pnpm --filter @open-design/daemon exec tsc -p tsconfig.json --noEmit` — passed
- `pnpm --filter @open-design/daemon exec tsc -p tsconfig.tests.json --noEmit` — passed
- `pnpm guard` — 86 passed
- `git diff --check` — passed
