### PR TITLE
fix(web): hold the next-step card while a question form awaits answers

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -28,6 +28,7 @@ import {
   type TrackingProjectKind,
 } from "@open-design/contracts/analytics";
 import {
+  hasUnterminatedQuestionForm,
   splitOnQuestionForms,
   stripTrailingOpenQuestionForm,
   type QuestionForm,
@@ -752,13 +753,30 @@ function AssistantMessageImpl({
             : !!onToolboxAction ||
               !!onNextStepCreateDesignSystem ||
               (!!nextStepArtifactName && (!!onArtifactShare || !!onArtifactDownload));
+  // A clarification turn terminates its run while the emitted <question-form>
+  // is still waiting for the user in the Questions tab. Until the immediate
+  // user reply submits that form's answers (skip-all submits through the same
+  // path), the turn is mid-handshake, not settled. Suppressed direction forms
+  // render as a locked pill the user cannot answer, so they don't hold the
+  // card back.
+  const hasPendingQuestionForm = useMemo(() => {
+    if (hasUnterminatedQuestionForm(message.content)) return true;
+    return splitOnQuestionForms(message.content).some(
+      (seg) =>
+        seg.kind === "form" &&
+        !(suppressDirectionForms && isDirectionForm(seg.form)) &&
+        (!nextUserContent || !parseSubmittedAnswers(seg.form, nextUserContent)),
+    );
+  }, [message.content, nextUserContent, suppressDirectionForms]);
   // Terminal turns should leave the user with an actionable path, including
   // canceled/failed/no-artifact turns. Artifact-backed cards still wire Share
   // and Download to the chosen file; incomplete cards fall back to composer
-  // prompts or toolbox actions.
+  // prompts or toolbox actions. A turn still waiting on question-form answers
+  // is the exception: the next step IS answering the form.
   const showNextStepActions =
     !streaming &&
     runTerminal &&
+    !hasPendingQuestionForm &&
     ((!!isLast && hasNextStepPrimary) || showOpenDesignSubmission);
   // Pre-output vs working: before any real content (text / thinking / tools /
   // files) the footer shimmers "Preparing…"; the moment content lands it

--- a/apps/web/tests/components/AssistantMessage.nextStep.test.tsx
+++ b/apps/web/tests/components/AssistantMessage.nextStep.test.tsx
@@ -291,3 +291,87 @@ describe('AssistantMessage next-step affordance', () => {
     expect(screen.getByTestId('next-step-actions')).toBeTruthy();
   });
 });
+
+// A clarification turn ends the run while its <question-form> is still waiting
+// for the user in the Questions tab; the next-step card must hold back until
+// the answers (or a skip-all, which submits through the same path) arrive as
+// the following user message.
+describe('AssistantMessage next-step affordance during the question phase', () => {
+  const QUESTION_FORM_CONTENT = [
+    'Got it — a couple of quick questions first.',
+    '',
+    '<question-form id="discovery" title="Brief">',
+    '{"questions":[{"id":"studio","label":"Studio name","type":"text","required":true}]}',
+    '</question-form>',
+  ].join('\n');
+
+  function questionFormMessage(content = QUESTION_FORM_CONTENT): ChatMessage {
+    return baseMessage({
+      content,
+      events: [{ kind: 'text', text: content } as NonNullable<ChatMessage['events']>[number]],
+    });
+  }
+
+  it('does not render while the question form is still unanswered', () => {
+    render(
+      <AssistantMessage
+        message={questionFormMessage()}
+        streaming={false}
+        projectId="proj-1"
+        isLast
+        {...handlers()}
+      />,
+    );
+    expect(screen.getByTestId('questions-banner')).toBeTruthy();
+    expect(screen.queryByTestId('next-step-actions')).toBeNull();
+  });
+
+  it('does not render while an unterminated question form is pending', () => {
+    const content = 'Quick brief first.\n\n<question-form id="discovery" title="Brief">\n{"questions":[';
+    render(
+      <AssistantMessage
+        message={questionFormMessage(content)}
+        streaming={false}
+        projectId="proj-1"
+        isLast
+        {...handlers()}
+      />,
+    );
+    expect(screen.queryByTestId('next-step-actions')).toBeNull();
+  });
+
+  it('renders once the next user message submits the form answers', () => {
+    render(
+      <AssistantMessage
+        message={questionFormMessage()}
+        streaming={false}
+        projectId="proj-1"
+        isLast
+        nextUserContent={'[form answers — discovery]\n- Studio name: Cobalt Studio'}
+        {...handlers()}
+      />,
+    );
+    expect(screen.getByTestId('next-step-actions')).toBeTruthy();
+  });
+
+  it('ignores a suppressed direction form (locked design system) when gating', () => {
+    const content = [
+      'Pick a direction.',
+      '',
+      '<question-form id="direction" title="Visual direction">',
+      '{"questions":[{"id":"dir","label":"Direction","type":"direction-cards","options":["A","B"]}]}',
+      '</question-form>',
+    ].join('\n');
+    render(
+      <AssistantMessage
+        message={questionFormMessage(content)}
+        streaming={false}
+        projectId="proj-1"
+        isLast
+        suppressDirectionForms
+        {...handlers()}
+      />,
+    );
+    expect(screen.getByTestId('next-step-actions')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Source issue (external tracker): https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/840587b4-ce0e-4d51-a776-8f24566e4bed

## Why

0.15.0 acceptance P0: during the question / clarification phase — while the Brief `<question-form>` was still unanswered in the right-hand Questions tab (countdown running) — the left chat pane already rendered the NEXT STEP card (Continue working / Generate artifact / More).

Root cause: a clarification turn terminates its run (`runStatus` goes terminal) the moment the form is emitted, and `showNextStepActions` in `AssistantMessage.tsx` gated only on `!streaming && runTerminal && isLast`. Nothing distinguished "turn settled" from "turn parked mid-handshake waiting on form answers", so the terminal-turn card appeared while the form was still pending.

## What users will see

When the agent asks clarifying questions, the chat shows only the Questions banner; the NEXT STEP card no longer appears alongside the unanswered form. Once the user submits the form (or skips it — Skip all and the countdown submit through the same answers path), the card renders as before. Suppressed direction forms (already-locked design system) don't hold the card back, since users cannot answer them.

## How

`AssistantMessage.tsx` computes `hasPendingQuestionForm` from the message content: any complete `<question-form>` whose answers are not found in the immediate next user message (via the existing `parseSubmittedAnswers` reverse of `formatFormAnswers`), or an unterminated form tag, marks the turn as mid-handshake and holds `showNextStepActions` back.

## Surface area

- [x] **UI** — behavior/timing fix for the next-step card in `apps/web` chat pane (no new entry point)
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Bug screenshot is attached to the tracker issue: the NEXT STEP card visible on the left while the Brief form on the right is unanswered with the auto-skip countdown still running. After this fix that state renders without the card; it appears only after the answers (or skip) land as the next user message.

## Bug fix verification

- Test path: `apps/web/tests/components/AssistantMessage.nextStep.test.tsx` — new describe "AssistantMessage next-step affordance during the question phase" (4 cases: pending form holds the card, unterminated form holds the card, submitted answers release it, suppressed direction forms are ignored).
- Red on `main`, green on this branch: **yes** — without the source change the two gating cases fail (full web suite: 2 failed / 4344 passed), with it the affected files pass (40/40).
- Also ran `pnpm guard` and `pnpm typecheck` (clean).

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>