### PR TITLE
test(e2e): cover uploaded root-relative image preview

### DIFF
--- a/e2e/resources/playwright.ts
+++ b/e2e/resources/playwright.ts
@@ -541,7 +541,7 @@ export const playwrightUiScenarios: UiScenario[] = [
   },
   {
     id: 'uploaded-image-renders-in-preview',
-    title: 'Uploaded reference images render correctly in generated deck preview',
+    title: 'Uploaded reference images render correctly in generated page preview',
     kind: 'workspace',
     flow: 'uploaded-image-renders-in-preview',
     automated: true,
@@ -551,7 +551,7 @@ export const playwrightUiScenarios: UiScenario[] = [
       projectName: 'Uploaded image preview render',
       tab: 'prototype',
     },
-    prompt: 'Use uploaded brand images inside a generated deck preview',
+    prompt: 'Use uploaded brand images inside a generated page preview',
     expectedFiles: [
       {
         name: 'brand.png',
@@ -565,7 +565,7 @@ export const playwrightUiScenarios: UiScenario[] = [
     ],
     expectedPreviewText: 'Image Preview',
     notes: [
-      'Seeds an image plus relative HTML reference and asserts the preview iframe loads the image.',
+      'Uploads an image through the real Design Files control, references it by generated root-relative HTML path, and asserts the preview iframe decodes it.',
     ],
   },
   {

--- a/e2e/ui/app-design-files.test.ts
+++ b/e2e/ui/app-design-files.test.ts
@@ -372,15 +372,34 @@ function escapeRegExp(value: string): string {
 
 async function runUploadedImageRendersInPreviewFlow(page: Page, entry: UiScenario) {
   const { projectId } = await getCurrentProjectContext(page);
-  const pngBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5W6McAAAAASUVORK5CYII=';
-  await seedProjectFile(page, projectId, 'brand.png', pngBase64, 'base64');
+  const pngBytes = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5W6McAAAAASUVORK5CYII=',
+    'base64',
+  );
+  await page.getByTestId('design-files-upload-input').setInputFiles({
+    name: 'brand.png',
+    mimeType: 'image/png',
+    buffer: pngBytes,
+  });
+  await expect(page.getByRole('tab', { name: /brand\.png/i })).toBeVisible();
+
+  const uploadedImage = await page.request.get(
+    `/api/projects/${encodeURIComponent(projectId)}/raw/brand.png`,
+  );
+  expect(uploadedImage.ok(), `uploaded image: ${await uploadedImage.text()}`).toBeTruthy();
+  expect(uploadedImage.headers()['content-type']).toContain('image/png');
+
   await seedHtmlArtifact(
     page,
     projectId,
     'image-preview.html',
-    '<!doctype html><html><body><main><h1>Image Preview</h1><img alt="Brand logo" src="brand.png"></main></body></html>',
+    // Generated pages commonly use site-root paths. Before the preview asset
+    // normalization fix, this resolved against the Open Design app origin and
+    // left the uploaded image broken even though its project raw URL was valid.
+    '<!doctype html><html><body><main><h1>Image Preview</h1><img alt="Brand logo" src="/brand.png"></main></body></html>',
   );
   await page.reload();
+  await expectWorkspaceReady(page);
   await openDesignFile(page, 'image-preview.html');
 
   const image = page.frameLocator('[data-testid="artifact-preview-frame"]').getByRole('img', { name: 'Brand logo' });


### PR DESCRIPTION
## Why

Plane demand #694 reported that a PNG uploaded through Design Files could not be displayed from a generated page preview. The existing regression scenario seeded the image through the API and referenced it with a relative path, so it did not exercise the user upload flow or the root-relative path shape that triggered the original failure.

This PR adds coverage for that exact chain so the existing preview asset normalization fix cannot regress unnoticed.

## What users will see

No new UI or behavior change on current `main`. The regression test now verifies that a PNG uploaded through Design Files remains visible when a generated HTML page references it as `/brand.png`.

## Surface area

- [ ] UI (`apps/web`, `packages/components`, styles, interactions)
- [ ] Daemon / API (`apps/daemon`, contracts, routes)
- [ ] Desktop / packaged runtime
- [ ] Agent runtime / adapters / prompts
- [ ] Skills / design systems / design templates / craft
- [ ] CLI flags or commands
- [ ] Environment variables
- [ ] i18n keys
- [ ] Root dependencies (`package.json`)
- [x] None — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — this is test-only regression coverage with no UI changes.

## Bug fix verification

- Red spec: `e2e/ui/app-design-files.test.ts`, scenario `[P1] uploaded-image-renders-in-preview`.
- Confirmed red twice at `57386e4ef1`, the parent of the preview asset normalization fix: the iframe image completed with `naturalWidth === 0`.
- Confirmed green on this branch against current `main`, including two consecutive runs.
- Current `main` already contains the product fix; this PR strengthens its regression coverage rather than duplicating product code.

## Validation

- `corepack pnpm exec playwright test -c playwright.config.ts ui/app-design-files.test.ts --grep uploaded-image-renders-in-preview --workers=1 --repeat-each=2`
- `corepack pnpm exec playwright test -c playwright.config.ts ui/app-design-files.test.ts --grep uploaded-image-renders-in-preview --workers=1` (after rebasing onto latest `origin/main`)
- `corepack pnpm guard`
- `corepack pnpm typecheck`
