### PR TITLE
feat(daemon): route Langfuse telemetry through Vela when logged in

### DIFF
--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -53,6 +53,71 @@ export function closeDatabase() {
   dbFile = null;
 }
 
+/**
+ * Ensure run_telemetry_accepted_anchors has conversation ownership and prune
+ * rows that no longer belong to a live conversation.
+ *
+ * Early revisions of this table were keyed only by run_id. Without an owner,
+ * conversation/project deletes left accepted-body metadata (and Vela identity
+ * fingerprints) behind forever. Rebuild when conversation_id is missing, then
+ * delete anchors that cannot be attributed to any remaining conversation.
+ */
+function migrateRunTelemetryAcceptedAnchors(db: SqliteDb): void {
+  const cols = db
+    .prepare(`PRAGMA table_info(run_telemetry_accepted_anchors)`)
+    .all() as DbRow[];
+  if (cols.length === 0) return;
+
+  if (!cols.some((c: DbRow) => c.name === 'conversation_id')) {
+    db.exec(`
+      CREATE TABLE run_telemetry_accepted_anchors__new (
+        run_id TEXT PRIMARY KEY,
+        conversation_id TEXT,
+        accepted_body_id TEXT NOT NULL,
+        report_trigger TEXT NOT NULL,
+        delivery_channel TEXT,
+        vela_identity TEXT,
+        updated_at INTEGER NOT NULL,
+        FOREIGN KEY(conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+      );
+      INSERT INTO run_telemetry_accepted_anchors__new (
+        run_id, conversation_id, accepted_body_id, report_trigger,
+        delivery_channel, vela_identity, updated_at
+      )
+      SELECT a.run_id,
+             (
+               SELECT m.conversation_id
+                 FROM messages m
+                WHERE m.run_id = a.run_id
+                ORDER BY m.position DESC
+                LIMIT 1
+             ),
+             a.accepted_body_id,
+             a.report_trigger,
+             a.delivery_channel,
+             a.vela_identity,
+             a.updated_at
+        FROM run_telemetry_accepted_anchors a;
+      DROP TABLE run_telemetry_accepted_anchors;
+      ALTER TABLE run_telemetry_accepted_anchors__new
+        RENAME TO run_telemetry_accepted_anchors;
+    `);
+  }
+
+  // Drop true orphans: no owning conversation, or conversation already gone.
+  // Rebinding survivors that still belong to a live conversation keep their
+  // conversation_id and are retained until that conversation is deleted.
+  db.exec(`
+    DELETE FROM run_telemetry_accepted_anchors
+     WHERE conversation_id IS NULL
+        OR conversation_id NOT IN (SELECT id FROM conversations);
+  `);
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_run_telemetry_accepted_anchors_conversation
+      ON run_telemetry_accepted_anchors(conversation_id);
+  `);
+}
+
 function migrate(db: SqliteDb): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS projects (
@@ -325,16 +390,22 @@ function migrate(db: SqliteDb): void {
   // columns alone are insufficient: when failed run A schedules
   // terminal_fallback and upsert rebinds the only assistant row to run B, the
   // delayed accepted write for A would find no run_id=A row.
+  // conversation_id owns lifecycle: project/conversation delete cascades here
+  // (and delete paths also prune explicitly so rebinding orphans leave with the
+  // conversation even when no messages still carry the original run_id).
   db.exec(`
     CREATE TABLE IF NOT EXISTS run_telemetry_accepted_anchors (
       run_id TEXT PRIMARY KEY,
+      conversation_id TEXT,
       accepted_body_id TEXT NOT NULL,
       report_trigger TEXT NOT NULL,
       delivery_channel TEXT,
       vela_identity TEXT,
-      updated_at INTEGER NOT NULL
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY(conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
     );
   `);
+  migrateRunTelemetryAcceptedAnchors(db);
   const routineRunCols = db.prepare(`PRAGMA table_info(routine_runs)`).all() as DbRow[];
   if (!routineRunCols.some((c: DbRow) => c.name === 'error_code')) {
     db.exec(`ALTER TABLE routine_runs ADD COLUMN error_code TEXT`);
@@ -892,7 +963,26 @@ export function updateProject(db: SqliteDb, id: string, patch: DbRow) {
 }
 
 export function deleteProject(db: SqliteDb, id: string) {
-  db.prepare(`DELETE FROM projects WHERE id = ?`).run(id);
+  const tx = db.transaction(() => {
+    // Prune run-keyed anchors before cascading conversation/message deletes so
+    // rebinding survivors (no live messages.run_id) still leave with the project.
+    db.prepare(
+      `DELETE FROM run_telemetry_accepted_anchors
+        WHERE conversation_id IN (
+          SELECT id FROM conversations WHERE project_id = ?
+        )
+           OR run_id IN (
+             SELECT m.run_id
+               FROM messages m
+               INNER JOIN conversations c ON c.id = m.conversation_id
+              WHERE c.project_id = ?
+                AND m.run_id IS NOT NULL
+                AND TRIM(m.run_id) != ''
+           )`,
+    ).run(id, id);
+    db.prepare(`DELETE FROM projects WHERE id = ?`).run(id);
+  });
+  tx();
 }
 
 function normalizeProject(row: DbRow) {
@@ -1270,7 +1360,22 @@ export function updateConversation(db: SqliteDb, id: string, patch: DbRow) {
 }
 
 export function deleteConversation(db: SqliteDb, id: string) {
-  db.prepare(`DELETE FROM conversations WHERE id = ?`).run(id);
+  const tx = db.transaction(() => {
+    // Explicit prune covers ownership by conversation_id (rebinding orphans)
+    // and current message run_ids (legacy rows without conversation_id).
+    db.prepare(
+      `DELETE FROM run_telemetry_accepted_anchors
+        WHERE conversation_id = ?
+           OR run_id IN (
+             SELECT run_id FROM messages
+              WHERE conversation_id = ?
+                AND run_id IS NOT NULL
+                AND TRIM(run_id) != ''
+           )`,
+    ).run(id, id);
+    db.prepare(`DELETE FROM conversations WHERE id = ?`).run(id);
+  });
+  tx();
 }
 
 // ---------- agent sessions ----------
@@ -1794,11 +1899,67 @@ function mergeFeedbackTelemetryAnchor(
  * cannot later attach via a different backend. `velaIdentity` fingerprints the
  * accepting Vela profile/key so scores cannot follow a later account switch.
  */
+function resolveConversationIdForRunAnchor(
+  db: SqliteDb,
+  runId: string,
+  assistantMessageId?: string | null,
+  explicitConversationId?: string | null,
+): string | null {
+  const explicit =
+    typeof explicitConversationId === 'string' ? explicitConversationId.trim() : '';
+  if (explicit) {
+    const exists = db
+      .prepare(`SELECT 1 AS ok FROM conversations WHERE id = ?`)
+      .get(explicit) as DbRow | undefined;
+    if (exists) return explicit;
+  }
+
+  const assistantId =
+    typeof assistantMessageId === 'string' ? assistantMessageId.trim() : '';
+  // Prefer the assistant message id: after rebinding, run_id no longer matches
+  // but the row still carries the owning conversation.
+  if (assistantId) {
+    const byMessage = db
+      .prepare(
+        `SELECT conversation_id AS conversationId
+           FROM messages
+          WHERE id = ?`,
+      )
+      .get(assistantId) as DbRow | undefined;
+    if (
+      byMessage &&
+      typeof byMessage.conversationId === 'string' &&
+      byMessage.conversationId.trim()
+    ) {
+      return byMessage.conversationId.trim();
+    }
+  }
+
+  const byRun = db
+    .prepare(
+      `SELECT conversation_id AS conversationId
+         FROM messages
+        WHERE run_id = ?
+        ORDER BY position DESC
+        LIMIT 1`,
+    )
+    .get(runId) as DbRow | undefined;
+  if (
+    byRun &&
+    typeof byRun.conversationId === 'string' &&
+    byRun.conversationId.trim()
+  ) {
+    return byRun.conversationId.trim();
+  }
+  return null;
+}
+
 export function setRunTelemetryAcceptedAnchor(
   db: SqliteDb,
   opts: {
     runId: string;
     assistantMessageId?: string | null;
+    conversationId?: string | null;
     bodyId: string;
     reportTrigger: TelemetryAcceptedReportTrigger;
     deliveryChannel?: TelemetryAcceptedDeliveryChannel | null;
@@ -1825,19 +1986,35 @@ export function setRunTelemetryAcceptedAnchor(
     return false;
   }
 
+  const conversationId = resolveConversationIdForRunAnchor(
+    db,
+    runId,
+    opts.assistantMessageId,
+    opts.conversationId,
+  );
+
   const now = Date.now();
   db.prepare(
     `INSERT INTO run_telemetry_accepted_anchors (
-        run_id, accepted_body_id, report_trigger, delivery_channel,
+        run_id, conversation_id, accepted_body_id, report_trigger, delivery_channel,
         vela_identity, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(run_id) DO UPDATE SET
+        conversation_id = COALESCE(excluded.conversation_id, run_telemetry_accepted_anchors.conversation_id),
         accepted_body_id = excluded.accepted_body_id,
         report_trigger = excluded.report_trigger,
         delivery_channel = excluded.delivery_channel,
         vela_identity = excluded.vela_identity,
         updated_at = excluded.updated_at`,
-  ).run(runId, bodyId, reportTrigger, deliveryChannel, velaIdentity, now);
+  ).run(
+    runId,
+    conversationId,
+    bodyId,
+    reportTrigger,
+    deliveryChannel,
+    velaIdentity,
+    now,
+  );
 
   // Best-effort dual-write onto the current assistant row when it still belongs
   // to this run. Failure to find a row is not an error — run-keyed storage is
@@ -2028,7 +2205,20 @@ export function appendMessageAgentEvent(db: SqliteDb, messageId: string, event: 
 }
 
 export function deleteMessage(db: SqliteDb, id: string) {
-  db.prepare(`DELETE FROM messages WHERE id = ?`).run(id);
+  const tx = db.transaction(() => {
+    const row = db
+      .prepare(`SELECT run_id AS runId FROM messages WHERE id = ?`)
+      .get(id) as DbRow | undefined;
+    const runId =
+      typeof row?.runId === 'string' && row.runId.trim() ? row.runId.trim() : null;
+    if (runId) {
+      db.prepare(
+        `DELETE FROM run_telemetry_accepted_anchors WHERE run_id = ?`,
+      ).run(runId);
+    }
+    db.prepare(`DELETE FROM messages WHERE id = ?`).run(id);
+  });
+  tx();
 }
 
 // ---------- preview comments ----------

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -1579,14 +1579,40 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
   return row ? normalizeMessage(row) : null;
 }
 
-export function getMessageTelemetryFinalizationState(db: SqliteDb, messageId: string) {
-  const row = db
-    .prepare(
-      `SELECT telemetry_finalized_at AS telemetryFinalizedAt
-         FROM messages
-        WHERE id = ?`,
-    )
-    .get(messageId) as DbRow | undefined;
+/**
+ * Read the assistant message's telemetry finalization gate.
+ *
+ * When `runId` is provided, the lookup is run-scoped (`id` + `run_id`). The
+ * delayed terminal_fallback timer must pass the run that scheduled it: after
+ * a side-chat retry rebinds the same assistant row to a newer run, the old
+ * run's timer must not observe the new run's `telemetry_finalized_at` and
+ * skip reporting.
+ */
+export function getMessageTelemetryFinalizationState(
+  db: SqliteDb,
+  messageId: string,
+  runId?: string | null,
+) {
+  const normalizedRunId =
+    typeof runId === 'string' && runId.trim() ? runId.trim() : null;
+  const row = (
+    normalizedRunId
+      ? db
+          .prepare(
+            `SELECT telemetry_finalized_at AS telemetryFinalizedAt
+               FROM messages
+              WHERE id = ?
+                AND run_id = ?`,
+          )
+          .get(messageId, normalizedRunId)
+      : db
+          .prepare(
+            `SELECT telemetry_finalized_at AS telemetryFinalizedAt
+               FROM messages
+              WHERE id = ?`,
+          )
+          .get(messageId)
+  ) as DbRow | undefined;
   if (!row) {
     return {
       exists: false,

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -128,6 +128,7 @@ function migrate(db: SqliteDb): void {
       telemetry_finalized_at INTEGER,
       telemetry_accepted_body_id TEXT,
       telemetry_accepted_report_trigger TEXT,
+      telemetry_accepted_delivery_channel TEXT,
       started_at INTEGER,
       ended_at INTEGER,
       position INTEGER NOT NULL,
@@ -316,6 +317,9 @@ function migrate(db: SqliteDb): void {
   }
   if (!messageCols.some((c: DbRow) => c.name === 'telemetry_accepted_report_trigger')) {
     db.exec(`ALTER TABLE messages ADD COLUMN telemetry_accepted_report_trigger TEXT`);
+  }
+  if (!messageCols.some((c: DbRow) => c.name === 'telemetry_accepted_delivery_channel')) {
+    db.exec(`ALTER TABLE messages ADD COLUMN telemetry_accepted_delivery_channel TEXT`);
   }
   const routineRunCols = db.prepare(`PRAGMA table_info(routine_runs)`).all() as DbRow[];
   if (!routineRunCols.some((c: DbRow) => c.name === 'error_code')) {
@@ -1464,6 +1468,10 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
                 WHEN ? THEN NULL
                 ELSE telemetry_accepted_report_trigger
               END,
+              telemetry_accepted_delivery_channel = CASE
+                WHEN ? THEN NULL
+                ELSE telemetry_accepted_delivery_channel
+              END,
               started_at = ?, ended_at = ?
         WHERE id = ?`,
     ).run(
@@ -1491,6 +1499,7 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
       m.telemetryFinalized === true ? now : null,
       m.telemetryFinalized === true ? 1 : 0,
       now,
+      clearAcceptedTelemetryAnchor ? 1 : 0,
       clearAcceptedTelemetryAnchor ? 1 : 0,
       clearAcceptedTelemetryAnchor ? 1 : 0,
       m.startedAt ?? null,
@@ -1627,6 +1636,7 @@ export function getMessageTelemetryFinalizationState(
 }
 
 type TelemetryAcceptedReportTrigger = 'final_message' | 'terminal_fallback';
+type TelemetryAcceptedDeliveryChannel = 'vela' | 'relay' | 'langfuse';
 
 function normalizeTelemetryAcceptedReportTrigger(
   value: unknown,
@@ -1636,11 +1646,20 @@ function normalizeTelemetryAcceptedReportTrigger(
     : null;
 }
 
+function normalizeTelemetryAcceptedDeliveryChannel(
+  value: unknown,
+): TelemetryAcceptedDeliveryChannel | null {
+  return value === 'vela' || value === 'relay' || value === 'langfuse'
+    ? value
+    : null;
+}
+
 function rowToFeedbackTelemetryAnchor(row: DbRow): {
   runStatus: string | null;
   telemetryFinalized: boolean;
   acceptedTraceBodyId: string | null;
   acceptedReportTrigger: TelemetryAcceptedReportTrigger | null;
+  acceptedDeliveryChannel: TelemetryAcceptedDeliveryChannel | null;
 } {
   const acceptedTraceBodyId =
     typeof row.acceptedTraceBodyId === 'string' && row.acceptedTraceBodyId.trim()
@@ -1652,6 +1671,9 @@ function rowToFeedbackTelemetryAnchor(row: DbRow): {
     acceptedTraceBodyId,
     acceptedReportTrigger: normalizeTelemetryAcceptedReportTrigger(
       row.acceptedReportTrigger,
+    ),
+    acceptedDeliveryChannel: normalizeTelemetryAcceptedDeliveryChannel(
+      row.acceptedDeliveryChannel,
     ),
   };
 }
@@ -1665,6 +1687,10 @@ function rowToFeedbackTelemetryAnchor(row: DbRow): {
  *
  * Preference matches process-local memory: an accepted final_message is never
  * demoted by a later terminal_fallback write.
+ *
+ * `deliveryChannel` records the transport that accepted the body (especially
+ * `vela`, which scopes/hashes ids) so feedback cannot later attach via an
+ * anonymous relay to a raw body id that never received the run.
  */
 export function setRunTelemetryAcceptedAnchor(
   db: SqliteDb,
@@ -1673,11 +1699,15 @@ export function setRunTelemetryAcceptedAnchor(
     assistantMessageId?: string | null;
     bodyId: string;
     reportTrigger: TelemetryAcceptedReportTrigger;
+    deliveryChannel?: TelemetryAcceptedDeliveryChannel | null;
   },
 ): boolean {
   const runId = typeof opts.runId === 'string' ? opts.runId.trim() : '';
   const bodyId = typeof opts.bodyId === 'string' ? opts.bodyId.trim() : '';
   const reportTrigger = normalizeTelemetryAcceptedReportTrigger(opts.reportTrigger);
+  const deliveryChannel = normalizeTelemetryAcceptedDeliveryChannel(
+    opts.deliveryChannel,
+  );
   if (!runId || !bodyId || !reportTrigger) return false;
 
   let messageId: string | null = null;
@@ -1737,10 +1767,11 @@ export function setRunTelemetryAcceptedAnchor(
     .prepare(
       `UPDATE messages
           SET telemetry_accepted_body_id = ?,
-              telemetry_accepted_report_trigger = ?
+              telemetry_accepted_report_trigger = ?,
+              telemetry_accepted_delivery_channel = ?
         WHERE id = ?`,
     )
-    .run(bodyId, reportTrigger, messageId);
+    .run(bodyId, reportTrigger, deliveryChannel, messageId);
   return Number(result.changes ?? 0) > 0;
 }
 
@@ -1766,6 +1797,7 @@ export function getRunFeedbackTelemetryAnchor(
   telemetryFinalized: boolean;
   acceptedTraceBodyId: string | null;
   acceptedReportTrigger: TelemetryAcceptedReportTrigger | null;
+  acceptedDeliveryChannel: TelemetryAcceptedDeliveryChannel | null;
 } | null {
   const normalizedRunId = typeof runId === 'string' ? runId.trim() : '';
   if (!normalizedRunId) return null;
@@ -1776,7 +1808,8 @@ export function getRunFeedbackTelemetryAnchor(
         `SELECT run_status AS runStatus,
                 telemetry_finalized_at AS telemetryFinalizedAt,
                 telemetry_accepted_body_id AS acceptedTraceBodyId,
-                telemetry_accepted_report_trigger AS acceptedReportTrigger
+                telemetry_accepted_report_trigger AS acceptedReportTrigger,
+                telemetry_accepted_delivery_channel AS acceptedDeliveryChannel
            FROM messages
           WHERE id = ?
             AND run_id = ?
@@ -1793,7 +1826,8 @@ export function getRunFeedbackTelemetryAnchor(
       `SELECT run_status AS runStatus,
               telemetry_finalized_at AS telemetryFinalizedAt,
               telemetry_accepted_body_id AS acceptedTraceBodyId,
-              telemetry_accepted_report_trigger AS acceptedReportTrigger
+              telemetry_accepted_report_trigger AS acceptedReportTrigger,
+              telemetry_accepted_delivery_channel AS acceptedDeliveryChannel
          FROM messages
         WHERE run_id = ?
           AND role = 'assistant'

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -194,6 +194,7 @@ function migrate(db: SqliteDb): void {
       telemetry_accepted_body_id TEXT,
       telemetry_accepted_report_trigger TEXT,
       telemetry_accepted_delivery_channel TEXT,
+      telemetry_accepted_vela_identity TEXT,
       started_at INTEGER,
       ended_at INTEGER,
       position INTEGER NOT NULL,
@@ -385,6 +386,9 @@ function migrate(db: SqliteDb): void {
   }
   if (!messageCols.some((c: DbRow) => c.name === 'telemetry_accepted_delivery_channel')) {
     db.exec(`ALTER TABLE messages ADD COLUMN telemetry_accepted_delivery_channel TEXT`);
+  }
+  if (!messageCols.some((c: DbRow) => c.name === 'telemetry_accepted_vela_identity')) {
+    db.exec(`ALTER TABLE messages ADD COLUMN telemetry_accepted_vela_identity TEXT`);
   }
   // Run-keyed accepted telemetry anchors survive assistant-row reuse. Message
   // columns alone are insufficient: when failed run A schedules
@@ -1591,6 +1595,10 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
                 WHEN ? THEN NULL
                 ELSE telemetry_accepted_delivery_channel
               END,
+              telemetry_accepted_vela_identity = CASE
+                WHEN ? THEN NULL
+                ELSE telemetry_accepted_vela_identity
+              END,
               started_at = ?, ended_at = ?
         WHERE id = ?`,
     ).run(
@@ -1618,6 +1626,7 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
       m.telemetryFinalized === true ? now : null,
       m.telemetryFinalized === true ? 1 : 0,
       now,
+      clearAcceptedTelemetryAnchor ? 1 : 0,
       clearAcceptedTelemetryAnchor ? 1 : 0,
       clearAcceptedTelemetryAnchor ? 1 : 0,
       clearAcceptedTelemetryAnchor ? 1 : 0,
@@ -2089,9 +2098,10 @@ export function setRunTelemetryAcceptedAnchor(
       `UPDATE messages
           SET telemetry_accepted_body_id = ?,
               telemetry_accepted_report_trigger = ?,
-              telemetry_accepted_delivery_channel = ?
+              telemetry_accepted_delivery_channel = ?,
+              telemetry_accepted_vela_identity = ?
         WHERE id = ?`,
-    ).run(bodyId, reportTrigger, deliveryChannel, messageId);
+    ).run(bodyId, reportTrigger, deliveryChannel, velaIdentity, messageId);
   }
   return true;
 }
@@ -2145,7 +2155,8 @@ export function getRunFeedbackTelemetryAnchor(
                 telemetry_finalized_at AS telemetryFinalizedAt,
                 telemetry_accepted_body_id AS acceptedTraceBodyId,
                 telemetry_accepted_report_trigger AS acceptedReportTrigger,
-                telemetry_accepted_delivery_channel AS acceptedDeliveryChannel
+                telemetry_accepted_delivery_channel AS acceptedDeliveryChannel,
+                telemetry_accepted_vela_identity AS acceptedVelaIdentity
            FROM messages
           WHERE id = ?
             AND run_id = ?
@@ -2163,7 +2174,8 @@ export function getRunFeedbackTelemetryAnchor(
               telemetry_finalized_at AS telemetryFinalizedAt,
               telemetry_accepted_body_id AS acceptedTraceBodyId,
               telemetry_accepted_report_trigger AS acceptedReportTrigger,
-              telemetry_accepted_delivery_channel AS acceptedDeliveryChannel
+              telemetry_accepted_delivery_channel AS acceptedDeliveryChannel,
+              telemetry_accepted_vela_identity AS acceptedVelaIdentity
          FROM messages
         WHERE run_id = ?
           AND role = 'assistant'

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -1564,6 +1564,53 @@ export function getMessageTelemetryFinalizationState(db: SqliteDb, messageId: st
   };
 }
 
+/**
+ * Best-effort anchor for feedback → Langfuse score attachment: run status and
+ * whether the assistant message was telemetry-finalized. Used to derive the
+ * terminal_fallback body id (`runId:tf`) when no final_message was delivered.
+ */
+export function getRunFeedbackTelemetryAnchor(
+  db: SqliteDb,
+  runId: string,
+  assistantMessageId?: string | null,
+): {
+  runStatus: string | null;
+  telemetryFinalized: boolean;
+} | null {
+  if (typeof assistantMessageId === 'string' && assistantMessageId.trim()) {
+    const byId = db
+      .prepare(
+        `SELECT run_status AS runStatus,
+                telemetry_finalized_at AS telemetryFinalizedAt
+           FROM messages
+          WHERE id = ?`,
+      )
+      .get(assistantMessageId.trim()) as DbRow | undefined;
+    if (byId) {
+      return {
+        runStatus: typeof byId.runStatus === 'string' ? byId.runStatus : null,
+        telemetryFinalized:
+          typeof byId.telemetryFinalizedAt === 'number',
+      };
+    }
+  }
+  const byRun = db
+    .prepare(
+      `SELECT run_status AS runStatus,
+              telemetry_finalized_at AS telemetryFinalizedAt
+         FROM messages
+        WHERE run_id = ?
+        ORDER BY position DESC
+        LIMIT 1`,
+    )
+    .get(runId) as DbRow | undefined;
+  if (!byRun) return null;
+  return {
+    runStatus: typeof byRun.runStatus === 'string' ? byRun.runStatus : null,
+    telemetryFinalized: typeof byRun.telemetryFinalizedAt === 'number',
+  };
+}
+
 export function appendMessageStatusEvent(db: SqliteDb, messageId: string, event: DbRow) {
   const label = typeof event?.label === 'string' ? event.label.trim() : '';
   const detail = typeof event?.detail === 'string' ? event.detail.trim() : '';

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -1917,6 +1917,14 @@ export function setRunTelemetryAcceptedAnchor(
  * delayed terminal_fallback acceptance for run A still resolves after the
  * assistant row was rebound to run B.
  *
+ * Before that acceptance, this helper can return `null` for run A once the
+ * only assistant row has been rebound to run B (no run_id=A message row and
+ * no accepted anchor yet). Mid-window feedback must still defer via the
+ * process-local run-scoped awaiting token registered when terminal_fallback
+ * is scheduled (`markRunAwaitingFinalAcceptance(runId)`), not via message-row
+ * status — otherwise scores ship on canonical `runId` and detach from a later
+ * accepted `runId:tf` body.
+ *
  * An explicit `assistantMessageId` is only trusted when it is the terminal
  * assistant row for the URL `runId`. Stale or foreign ids (user messages,
  * other runs, non-terminal placeholders) fall through to the run lookup so

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -1431,8 +1431,11 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
   const now = Date.now();
   if (existing) {
     // Side-chat retry reuses the failed assistant message id with a new
-    // run_id. Drop accepted-telemetry anchors from the previous run so
-    // early feedback cannot score the old `${oldRunId}:tf` body.
+    // run_id. Drop accepted-telemetry anchors and the finalization gate from
+    // the previous run so early feedback cannot score the old
+    // `${oldRunId}:tf` body and terminal-fallback telemetry is not skipped
+    // for the new run (reportRunCompletionTelemetryFallback checks
+    // finalizedAt !== null).
     const prevRunId =
       typeof existing.runId === 'string' && existing.runId.trim()
         ? existing.runId.trim()
@@ -1449,6 +1452,7 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
               pre_turn_file_names_json = ?,
               session_mode = ?, run_context_json = ?, applied_plugin_snapshot_json = ?,
               telemetry_finalized_at = CASE
+                WHEN ? THEN ?
                 WHEN ? THEN COALESCE(telemetry_finalized_at, ?)
                 ELSE telemetry_finalized_at
               END,
@@ -1481,6 +1485,10 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
       normalizeMessageSessionModeForStorage(m.sessionMode),
       m.runContext ? JSON.stringify(m.runContext) : null,
       m.appliedPluginSnapshot ? JSON.stringify(m.appliedPluginSnapshot) : null,
+      // New run_id: start with a clean finalization gate (or stamp now if this
+      // write itself finalizes). Same run_id: preserve / coalesce as before.
+      clearAcceptedTelemetryAnchor ? 1 : 0,
+      m.telemetryFinalized === true ? now : null,
       m.telemetryFinalized === true ? 1 : 0,
       now,
       clearAcceptedTelemetryAnchor ? 1 : 0,

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -321,6 +321,20 @@ function migrate(db: SqliteDb): void {
   if (!messageCols.some((c: DbRow) => c.name === 'telemetry_accepted_delivery_channel')) {
     db.exec(`ALTER TABLE messages ADD COLUMN telemetry_accepted_delivery_channel TEXT`);
   }
+  // Run-keyed accepted telemetry anchors survive assistant-row reuse. Message
+  // columns alone are insufficient: when failed run A schedules
+  // terminal_fallback and upsert rebinds the only assistant row to run B, the
+  // delayed accepted write for A would find no run_id=A row.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS run_telemetry_accepted_anchors (
+      run_id TEXT PRIMARY KEY,
+      accepted_body_id TEXT NOT NULL,
+      report_trigger TEXT NOT NULL,
+      delivery_channel TEXT,
+      vela_identity TEXT,
+      updated_at INTEGER NOT NULL
+    );
+  `);
   const routineRunCols = db.prepare(`PRAGMA table_info(routine_runs)`).all() as DbRow[];
   if (!routineRunCols.some((c: DbRow) => c.name === 'error_code')) {
     db.exec(`ALTER TABLE routine_runs ADD COLUMN error_code TEXT`);
@@ -1654,12 +1668,19 @@ function normalizeTelemetryAcceptedDeliveryChannel(
     : null;
 }
 
+function normalizeTelemetryAcceptedVelaIdentity(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
 function rowToFeedbackTelemetryAnchor(row: DbRow): {
   runStatus: string | null;
   telemetryFinalized: boolean;
   acceptedTraceBodyId: string | null;
   acceptedReportTrigger: TelemetryAcceptedReportTrigger | null;
   acceptedDeliveryChannel: TelemetryAcceptedDeliveryChannel | null;
+  acceptedVelaIdentity: string | null;
 } {
   const acceptedTraceBodyId =
     typeof row.acceptedTraceBodyId === 'string' && row.acceptedTraceBodyId.trim()
@@ -1675,22 +1696,103 @@ function rowToFeedbackTelemetryAnchor(row: DbRow): {
     acceptedDeliveryChannel: normalizeTelemetryAcceptedDeliveryChannel(
       row.acceptedDeliveryChannel,
     ),
+    acceptedVelaIdentity: normalizeTelemetryAcceptedVelaIdentity(
+      row.acceptedVelaIdentity,
+    ),
+  };
+}
+
+type RunKeyedAcceptedAnchor = {
+  acceptedTraceBodyId: string;
+  acceptedReportTrigger: TelemetryAcceptedReportTrigger;
+  acceptedDeliveryChannel: TelemetryAcceptedDeliveryChannel | null;
+  acceptedVelaIdentity: string | null;
+};
+
+function readRunKeyedAcceptedAnchor(
+  db: SqliteDb,
+  runId: string,
+): RunKeyedAcceptedAnchor | null {
+  const row = db
+    .prepare(
+      `SELECT accepted_body_id AS acceptedTraceBodyId,
+              report_trigger AS acceptedReportTrigger,
+              delivery_channel AS acceptedDeliveryChannel,
+              vela_identity AS acceptedVelaIdentity
+         FROM run_telemetry_accepted_anchors
+        WHERE run_id = ?`,
+    )
+    .get(runId) as DbRow | undefined;
+  if (!row) return null;
+  const acceptedTraceBodyId =
+    typeof row.acceptedTraceBodyId === 'string' && row.acceptedTraceBodyId.trim()
+      ? row.acceptedTraceBodyId.trim()
+      : '';
+  const acceptedReportTrigger = normalizeTelemetryAcceptedReportTrigger(
+    row.acceptedReportTrigger,
+  );
+  if (!acceptedTraceBodyId || !acceptedReportTrigger) return null;
+  return {
+    acceptedTraceBodyId,
+    acceptedReportTrigger,
+    acceptedDeliveryChannel: normalizeTelemetryAcceptedDeliveryChannel(
+      row.acceptedDeliveryChannel,
+    ),
+    acceptedVelaIdentity: normalizeTelemetryAcceptedVelaIdentity(
+      row.acceptedVelaIdentity,
+    ),
+  };
+}
+
+function mergeFeedbackTelemetryAnchor(
+  messageRow: DbRow | null,
+  runKeyed: RunKeyedAcceptedAnchor | null,
+): {
+  runStatus: string | null;
+  telemetryFinalized: boolean;
+  acceptedTraceBodyId: string | null;
+  acceptedReportTrigger: TelemetryAcceptedReportTrigger | null;
+  acceptedDeliveryChannel: TelemetryAcceptedDeliveryChannel | null;
+  acceptedVelaIdentity: string | null;
+} | null {
+  if (!messageRow && !runKeyed) return null;
+  const fromMessage = messageRow ? rowToFeedbackTelemetryAnchor(messageRow) : null;
+  // Run-keyed storage is authoritative for accepted fields: it survives
+  // assistant-row reuse. Message columns remain a legacy fallback.
+  return {
+    runStatus: fromMessage?.runStatus ?? null,
+    telemetryFinalized: fromMessage?.telemetryFinalized ?? false,
+    acceptedTraceBodyId:
+      runKeyed?.acceptedTraceBodyId ?? fromMessage?.acceptedTraceBodyId ?? null,
+    acceptedReportTrigger:
+      runKeyed?.acceptedReportTrigger ??
+      fromMessage?.acceptedReportTrigger ??
+      null,
+    acceptedDeliveryChannel:
+      runKeyed?.acceptedDeliveryChannel ??
+      fromMessage?.acceptedDeliveryChannel ??
+      null,
+    acceptedVelaIdentity:
+      runKeyed?.acceptedVelaIdentity ??
+      fromMessage?.acceptedVelaIdentity ??
+      null,
   };
 }
 
 /**
  * Persist the accepted final-purpose Langfuse body id for feedback attachment.
  *
- * Survives daemon restart so scores still target the body that Langfuse/Vela
- * actually accepted (e.g. `runId:tf` after terminal_fallback) even when a later
- * final_message delivery fails and process-local memory is cold.
+ * Primary storage is the run-keyed `run_telemetry_accepted_anchors` table so
+ * anchors survive assistant-row reuse (failed run A → row rebound to B → A's
+ * delayed terminal_fallback acceptance still has a restart-safe home). Message
+ * columns are dual-written when a matching assistant row still exists.
  *
  * Preference matches process-local memory: an accepted final_message is never
  * demoted by a later terminal_fallback write.
  *
- * `deliveryChannel` records the transport that accepted the body (especially
- * `vela`, which scopes/hashes ids) so feedback cannot later attach via an
- * anonymous relay to a raw body id that never received the run.
+ * `deliveryChannel` records the transport that accepted the body so feedback
+ * cannot later attach via a different backend. `velaIdentity` fingerprints the
+ * accepting Vela profile/key so scores cannot follow a later account switch.
  */
 export function setRunTelemetryAcceptedAnchor(
   db: SqliteDb,
@@ -1700,6 +1802,7 @@ export function setRunTelemetryAcceptedAnchor(
     bodyId: string;
     reportTrigger: TelemetryAcceptedReportTrigger;
     deliveryChannel?: TelemetryAcceptedDeliveryChannel | null;
+    velaIdentity?: string | null;
   },
 ): boolean {
   const runId = typeof opts.runId === 'string' ? opts.runId.trim() : '';
@@ -1708,10 +1811,39 @@ export function setRunTelemetryAcceptedAnchor(
   const deliveryChannel = normalizeTelemetryAcceptedDeliveryChannel(
     opts.deliveryChannel,
   );
+  const velaIdentity =
+    deliveryChannel === 'vela'
+      ? normalizeTelemetryAcceptedVelaIdentity(opts.velaIdentity)
+      : null;
   if (!runId || !bodyId || !reportTrigger) return false;
 
+  const existingRunKeyed = readRunKeyedAcceptedAnchor(db, runId);
+  if (
+    existingRunKeyed?.acceptedReportTrigger === 'final_message' &&
+    reportTrigger === 'terminal_fallback'
+  ) {
+    return false;
+  }
+
+  const now = Date.now();
+  db.prepare(
+    `INSERT INTO run_telemetry_accepted_anchors (
+        run_id, accepted_body_id, report_trigger, delivery_channel,
+        vela_identity, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?)
+      ON CONFLICT(run_id) DO UPDATE SET
+        accepted_body_id = excluded.accepted_body_id,
+        report_trigger = excluded.report_trigger,
+        delivery_channel = excluded.delivery_channel,
+        vela_identity = excluded.vela_identity,
+        updated_at = excluded.updated_at`,
+  ).run(runId, bodyId, reportTrigger, deliveryChannel, velaIdentity, now);
+
+  // Best-effort dual-write onto the current assistant row when it still belongs
+  // to this run. Failure to find a row is not an error — run-keyed storage is
+  // the restart-safe source of truth.
   let messageId: string | null = null;
-  let existingTrigger: TelemetryAcceptedReportTrigger | null = null;
+  let existingMessageTrigger: TelemetryAcceptedReportTrigger | null = null;
   const assistantMessageId =
     typeof opts.assistantMessageId === 'string'
       ? opts.assistantMessageId.trim()
@@ -1731,7 +1863,7 @@ export function setRunTelemetryAcceptedAnchor(
       .get(assistantMessageId, runId) as DbRow | undefined;
     if (byId && typeof byId.id === 'string') {
       messageId = byId.id;
-      existingTrigger = normalizeTelemetryAcceptedReportTrigger(
+      existingMessageTrigger = normalizeTelemetryAcceptedReportTrigger(
         byId.acceptedReportTrigger,
       );
     }
@@ -1750,29 +1882,27 @@ export function setRunTelemetryAcceptedAnchor(
       .get(runId) as DbRow | undefined;
     if (byRun && typeof byRun.id === 'string') {
       messageId = byRun.id;
-      existingTrigger = normalizeTelemetryAcceptedReportTrigger(
+      existingMessageTrigger = normalizeTelemetryAcceptedReportTrigger(
         byRun.acceptedReportTrigger,
       );
     }
   }
-  if (!messageId) return false;
   if (
-    existingTrigger === 'final_message' &&
-    reportTrigger === 'terminal_fallback'
+    messageId &&
+    !(
+      existingMessageTrigger === 'final_message' &&
+      reportTrigger === 'terminal_fallback'
+    )
   ) {
-    return false;
-  }
-
-  const result = db
-    .prepare(
+    db.prepare(
       `UPDATE messages
           SET telemetry_accepted_body_id = ?,
               telemetry_accepted_report_trigger = ?,
               telemetry_accepted_delivery_channel = ?
         WHERE id = ?`,
-    )
-    .run(bodyId, reportTrigger, deliveryChannel, messageId);
-  return Number(result.changes ?? 0) > 0;
+    ).run(bodyId, reportTrigger, deliveryChannel, messageId);
+  }
+  return true;
 }
 
 /**
@@ -1782,6 +1912,10 @@ export function setRunTelemetryAcceptedAnchor(
  *
  * Prefer the accepted body id over raw finalization when resolving the score
  * target — finalization alone does not mean a final_message body was accepted.
+ *
+ * Accepted body / channel / Vela identity prefer the run-keyed table so a
+ * delayed terminal_fallback acceptance for run A still resolves after the
+ * assistant row was rebound to run B.
  *
  * An explicit `assistantMessageId` is only trusted when it is the terminal
  * assistant row for the URL `runId`. Stale or foreign ids (user messages,
@@ -1798,9 +1932,12 @@ export function getRunFeedbackTelemetryAnchor(
   acceptedTraceBodyId: string | null;
   acceptedReportTrigger: TelemetryAcceptedReportTrigger | null;
   acceptedDeliveryChannel: TelemetryAcceptedDeliveryChannel | null;
+  acceptedVelaIdentity: string | null;
 } | null {
   const normalizedRunId = typeof runId === 'string' ? runId.trim() : '';
   if (!normalizedRunId) return null;
+
+  const runKeyed = readRunKeyedAcceptedAnchor(db, normalizedRunId);
 
   if (typeof assistantMessageId === 'string' && assistantMessageId.trim()) {
     const byId = db
@@ -1818,7 +1955,7 @@ export function getRunFeedbackTelemetryAnchor(
       )
       .get(assistantMessageId.trim(), normalizedRunId) as DbRow | undefined;
     if (byId) {
-      return rowToFeedbackTelemetryAnchor(byId);
+      return mergeFeedbackTelemetryAnchor(byId, runKeyed);
     }
   }
   const byRun = db
@@ -1835,8 +1972,7 @@ export function getRunFeedbackTelemetryAnchor(
         LIMIT 1`,
     )
     .get(normalizedRunId) as DbRow | undefined;
-  if (!byRun) return null;
-  return rowToFeedbackTelemetryAnchor(byRun);
+  return mergeFeedbackTelemetryAnchor(byRun ?? null, runKeyed);
 }
 
 export function appendMessageStatusEvent(db: SqliteDb, messageId: string, event: DbRow) {

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -1992,6 +1992,20 @@ export function setRunTelemetryAcceptedAnchor(
     opts.assistantMessageId,
     opts.conversationId,
   );
+  // Delayed terminal_fallback can accept after the user already deleted the
+  // conversation/project. Delete hooks have already run; a null owner cannot
+  // cascade, so never insert an unowned accepted-body / Vela-identity row.
+  if (!conversationId) {
+    db.prepare(
+      `DELETE FROM run_telemetry_accepted_anchors
+        WHERE run_id = ?
+          AND (
+            conversation_id IS NULL
+            OR conversation_id NOT IN (SELECT id FROM conversations)
+          )`,
+    ).run(runId);
+    return false;
+  }
 
   const now = Date.now();
   db.prepare(

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -1701,7 +1701,7 @@ export function setRunTelemetryAcceptedAnchor(
  * An explicit `assistantMessageId` is only trusted when it is the terminal
  * assistant row for the URL `runId`. Stale or foreign ids (user messages,
  * other runs, non-terminal placeholders) fall through to the run lookup so
- * their null/foreign `run_status` cannot steer `resolveFeedbackTraceId`.
+ * their null/foreign accepted body id cannot mis-anchor feedback.
  */
 export function getRunFeedbackTelemetryAnchor(
   db: SqliteDb,

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -1963,6 +1963,34 @@ function resolveConversationIdForRunAnchor(
   return null;
 }
 
+/**
+ * True when a run still has a live conversation owner that can cascade
+ * accepted-anchor lifecycle (conversation row present via explicit id,
+ * assistant message, or current run_id message lookup).
+ *
+ * Used by deferred feedback flush gates so a late terminal_fallback accept
+ * after conversation/project delete does not ship queued custom reasons.
+ */
+export function runHasLiveTelemetryOwner(
+  db: SqliteDb,
+  opts: {
+    runId: string;
+    assistantMessageId?: string | null;
+    conversationId?: string | null;
+  },
+): boolean {
+  const runId = typeof opts.runId === 'string' ? opts.runId.trim() : '';
+  if (!runId) return false;
+  return (
+    resolveConversationIdForRunAnchor(
+      db,
+      runId,
+      opts.assistantMessageId,
+      opts.conversationId,
+    ) != null
+  );
+}
+
 export function setRunTelemetryAcceptedAnchor(
   db: SqliteDb,
   opts: {

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -1633,14 +1633,18 @@ export function setRunTelemetryAcceptedAnchor(
       ? opts.assistantMessageId.trim()
       : '';
   if (assistantMessageId) {
+    // Only trust an explicit message id when it belongs to this run's
+    // assistant row; stale/foreign ids fall through to the run_id lookup.
     const byId = db
       .prepare(
         `SELECT id,
                 telemetry_accepted_report_trigger AS acceptedReportTrigger
            FROM messages
-          WHERE id = ?`,
+          WHERE id = ?
+            AND run_id = ?
+            AND role = 'assistant'`,
       )
-      .get(assistantMessageId) as DbRow | undefined;
+      .get(assistantMessageId, runId) as DbRow | undefined;
     if (byId && typeof byId.id === 'string') {
       messageId = byId.id;
       existingTrigger = normalizeTelemetryAcceptedReportTrigger(
@@ -1655,6 +1659,7 @@ export function setRunTelemetryAcceptedAnchor(
                 telemetry_accepted_report_trigger AS acceptedReportTrigger
            FROM messages
           WHERE run_id = ?
+            AND role = 'assistant'
           ORDER BY position DESC
           LIMIT 1`,
       )
@@ -1721,6 +1726,7 @@ export function getRunFeedbackTelemetryAnchor(
            FROM messages
           WHERE id = ?
             AND run_id = ?
+            AND role = 'assistant'
             AND run_status IN ('succeeded', 'failed', 'canceled')`,
       )
       .get(assistantMessageId.trim(), normalizedRunId) as DbRow | undefined;
@@ -1736,6 +1742,7 @@ export function getRunFeedbackTelemetryAnchor(
               telemetry_accepted_report_trigger AS acceptedReportTrigger
          FROM messages
         WHERE run_id = ?
+          AND role = 'assistant'
         ORDER BY position DESC
         LIMIT 1`,
     )

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -1426,10 +1426,20 @@ export function listMessages(db: SqliteDb, conversationId: string) {
 
 export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
   const existing = db
-    .prepare(`SELECT position FROM messages WHERE id = ?`)
+    .prepare(`SELECT position, run_id AS runId FROM messages WHERE id = ?`)
     .get(m.id) as DbRow | undefined;
   const now = Date.now();
   if (existing) {
+    // Side-chat retry reuses the failed assistant message id with a new
+    // run_id. Drop accepted-telemetry anchors from the previous run so
+    // early feedback cannot score the old `${oldRunId}:tf` body.
+    const prevRunId =
+      typeof existing.runId === 'string' && existing.runId.trim()
+        ? existing.runId.trim()
+        : null;
+    const nextRunId =
+      typeof m.runId === 'string' && m.runId.trim() ? m.runId.trim() : null;
+    const clearAcceptedTelemetryAnchor = prevRunId !== nextRunId;
     db.prepare(
       `UPDATE messages
           SET role = ?, content = ?, agent_id = ?, agent_name = ?,
@@ -1441,6 +1451,14 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
               telemetry_finalized_at = CASE
                 WHEN ? THEN COALESCE(telemetry_finalized_at, ?)
                 ELSE telemetry_finalized_at
+              END,
+              telemetry_accepted_body_id = CASE
+                WHEN ? THEN NULL
+                ELSE telemetry_accepted_body_id
+              END,
+              telemetry_accepted_report_trigger = CASE
+                WHEN ? THEN NULL
+                ELSE telemetry_accepted_report_trigger
               END,
               started_at = ?, ended_at = ?
         WHERE id = ?`,
@@ -1465,6 +1483,8 @@ export function upsertMessage(db: SqliteDb, conversationId: string, m: DbRow) {
       m.appliedPluginSnapshot ? JSON.stringify(m.appliedPluginSnapshot) : null,
       m.telemetryFinalized === true ? 1 : 0,
       now,
+      clearAcceptedTelemetryAnchor ? 1 : 0,
+      clearAcceptedTelemetryAnchor ? 1 : 0,
       m.startedAt ?? null,
       m.endedAt ?? null,
       m.id,

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -1692,6 +1692,11 @@ export function setRunTelemetryAcceptedAnchor(
  *
  * Prefer the accepted body id over raw finalization when resolving the score
  * target — finalization alone does not mean a final_message body was accepted.
+ *
+ * An explicit `assistantMessageId` is only trusted when it is the terminal
+ * assistant row for the URL `runId`. Stale or foreign ids (user messages,
+ * other runs, non-terminal placeholders) fall through to the run lookup so
+ * their null/foreign `run_status` cannot steer `resolveFeedbackTraceId`.
  */
 export function getRunFeedbackTelemetryAnchor(
   db: SqliteDb,
@@ -1703,6 +1708,9 @@ export function getRunFeedbackTelemetryAnchor(
   acceptedTraceBodyId: string | null;
   acceptedReportTrigger: TelemetryAcceptedReportTrigger | null;
 } | null {
+  const normalizedRunId = typeof runId === 'string' ? runId.trim() : '';
+  if (!normalizedRunId) return null;
+
   if (typeof assistantMessageId === 'string' && assistantMessageId.trim()) {
     const byId = db
       .prepare(
@@ -1711,9 +1719,11 @@ export function getRunFeedbackTelemetryAnchor(
                 telemetry_accepted_body_id AS acceptedTraceBodyId,
                 telemetry_accepted_report_trigger AS acceptedReportTrigger
            FROM messages
-          WHERE id = ?`,
+          WHERE id = ?
+            AND run_id = ?
+            AND run_status IN ('succeeded', 'failed', 'canceled')`,
       )
-      .get(assistantMessageId.trim()) as DbRow | undefined;
+      .get(assistantMessageId.trim(), normalizedRunId) as DbRow | undefined;
     if (byId) {
       return rowToFeedbackTelemetryAnchor(byId);
     }
@@ -1729,7 +1739,7 @@ export function getRunFeedbackTelemetryAnchor(
         ORDER BY position DESC
         LIMIT 1`,
     )
-    .get(runId) as DbRow | undefined;
+    .get(normalizedRunId) as DbRow | undefined;
   if (!byRun) return null;
   return rowToFeedbackTelemetryAnchor(byRun);
 }

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -126,6 +126,8 @@ function migrate(db: SqliteDb): void {
       run_context_json TEXT,
       applied_plugin_snapshot_json TEXT,
       telemetry_finalized_at INTEGER,
+      telemetry_accepted_body_id TEXT,
+      telemetry_accepted_report_trigger TEXT,
       started_at INTEGER,
       ended_at INTEGER,
       position INTEGER NOT NULL,
@@ -308,6 +310,12 @@ function migrate(db: SqliteDb): void {
   }
   if (!messageCols.some((c: DbRow) => c.name === 'telemetry_finalized_at')) {
     db.exec(`ALTER TABLE messages ADD COLUMN telemetry_finalized_at INTEGER`);
+  }
+  if (!messageCols.some((c: DbRow) => c.name === 'telemetry_accepted_body_id')) {
+    db.exec(`ALTER TABLE messages ADD COLUMN telemetry_accepted_body_id TEXT`);
+  }
+  if (!messageCols.some((c: DbRow) => c.name === 'telemetry_accepted_report_trigger')) {
+    db.exec(`ALTER TABLE messages ADD COLUMN telemetry_accepted_report_trigger TEXT`);
   }
   const routineRunCols = db.prepare(`PRAGMA table_info(routine_runs)`).all() as DbRow[];
   if (!routineRunCols.some((c: DbRow) => c.name === 'error_code')) {
@@ -1564,10 +1572,126 @@ export function getMessageTelemetryFinalizationState(db: SqliteDb, messageId: st
   };
 }
 
+type TelemetryAcceptedReportTrigger = 'final_message' | 'terminal_fallback';
+
+function normalizeTelemetryAcceptedReportTrigger(
+  value: unknown,
+): TelemetryAcceptedReportTrigger | null {
+  return value === 'final_message' || value === 'terminal_fallback'
+    ? value
+    : null;
+}
+
+function rowToFeedbackTelemetryAnchor(row: DbRow): {
+  runStatus: string | null;
+  telemetryFinalized: boolean;
+  acceptedTraceBodyId: string | null;
+  acceptedReportTrigger: TelemetryAcceptedReportTrigger | null;
+} {
+  const acceptedTraceBodyId =
+    typeof row.acceptedTraceBodyId === 'string' && row.acceptedTraceBodyId.trim()
+      ? row.acceptedTraceBodyId.trim()
+      : null;
+  return {
+    runStatus: typeof row.runStatus === 'string' ? row.runStatus : null,
+    telemetryFinalized: typeof row.telemetryFinalizedAt === 'number',
+    acceptedTraceBodyId,
+    acceptedReportTrigger: normalizeTelemetryAcceptedReportTrigger(
+      row.acceptedReportTrigger,
+    ),
+  };
+}
+
 /**
- * Best-effort anchor for feedback → Langfuse score attachment: run status and
- * whether the assistant message was telemetry-finalized. Used to derive the
- * terminal_fallback body id (`runId:tf`) when no final_message was delivered.
+ * Persist the accepted final-purpose Langfuse body id for feedback attachment.
+ *
+ * Survives daemon restart so scores still target the body that Langfuse/Vela
+ * actually accepted (e.g. `runId:tf` after terminal_fallback) even when a later
+ * final_message delivery fails and process-local memory is cold.
+ *
+ * Preference matches process-local memory: an accepted final_message is never
+ * demoted by a later terminal_fallback write.
+ */
+export function setRunTelemetryAcceptedAnchor(
+  db: SqliteDb,
+  opts: {
+    runId: string;
+    assistantMessageId?: string | null;
+    bodyId: string;
+    reportTrigger: TelemetryAcceptedReportTrigger;
+  },
+): boolean {
+  const runId = typeof opts.runId === 'string' ? opts.runId.trim() : '';
+  const bodyId = typeof opts.bodyId === 'string' ? opts.bodyId.trim() : '';
+  const reportTrigger = normalizeTelemetryAcceptedReportTrigger(opts.reportTrigger);
+  if (!runId || !bodyId || !reportTrigger) return false;
+
+  let messageId: string | null = null;
+  let existingTrigger: TelemetryAcceptedReportTrigger | null = null;
+  const assistantMessageId =
+    typeof opts.assistantMessageId === 'string'
+      ? opts.assistantMessageId.trim()
+      : '';
+  if (assistantMessageId) {
+    const byId = db
+      .prepare(
+        `SELECT id,
+                telemetry_accepted_report_trigger AS acceptedReportTrigger
+           FROM messages
+          WHERE id = ?`,
+      )
+      .get(assistantMessageId) as DbRow | undefined;
+    if (byId && typeof byId.id === 'string') {
+      messageId = byId.id;
+      existingTrigger = normalizeTelemetryAcceptedReportTrigger(
+        byId.acceptedReportTrigger,
+      );
+    }
+  }
+  if (!messageId) {
+    const byRun = db
+      .prepare(
+        `SELECT id,
+                telemetry_accepted_report_trigger AS acceptedReportTrigger
+           FROM messages
+          WHERE run_id = ?
+          ORDER BY position DESC
+          LIMIT 1`,
+      )
+      .get(runId) as DbRow | undefined;
+    if (byRun && typeof byRun.id === 'string') {
+      messageId = byRun.id;
+      existingTrigger = normalizeTelemetryAcceptedReportTrigger(
+        byRun.acceptedReportTrigger,
+      );
+    }
+  }
+  if (!messageId) return false;
+  if (
+    existingTrigger === 'final_message' &&
+    reportTrigger === 'terminal_fallback'
+  ) {
+    return false;
+  }
+
+  const result = db
+    .prepare(
+      `UPDATE messages
+          SET telemetry_accepted_body_id = ?,
+              telemetry_accepted_report_trigger = ?
+        WHERE id = ?`,
+    )
+    .run(bodyId, reportTrigger, messageId);
+  return Number(result.changes ?? 0) > 0;
+}
+
+/**
+ * Best-effort anchor for feedback → Langfuse score attachment: run status,
+ * whether the assistant message was telemetry-finalized, and any accepted
+ * final-purpose body id persisted after a successful telemetry delivery.
+ *
+ * Prefer the accepted body id over raw finalization when resolving the score
+ * target — finalization alone does not mean a final_message body was accepted.
  */
 export function getRunFeedbackTelemetryAnchor(
   db: SqliteDb,
@@ -1576,28 +1700,30 @@ export function getRunFeedbackTelemetryAnchor(
 ): {
   runStatus: string | null;
   telemetryFinalized: boolean;
+  acceptedTraceBodyId: string | null;
+  acceptedReportTrigger: TelemetryAcceptedReportTrigger | null;
 } | null {
   if (typeof assistantMessageId === 'string' && assistantMessageId.trim()) {
     const byId = db
       .prepare(
         `SELECT run_status AS runStatus,
-                telemetry_finalized_at AS telemetryFinalizedAt
+                telemetry_finalized_at AS telemetryFinalizedAt,
+                telemetry_accepted_body_id AS acceptedTraceBodyId,
+                telemetry_accepted_report_trigger AS acceptedReportTrigger
            FROM messages
           WHERE id = ?`,
       )
       .get(assistantMessageId.trim()) as DbRow | undefined;
     if (byId) {
-      return {
-        runStatus: typeof byId.runStatus === 'string' ? byId.runStatus : null,
-        telemetryFinalized:
-          typeof byId.telemetryFinalizedAt === 'number',
-      };
+      return rowToFeedbackTelemetryAnchor(byId);
     }
   }
   const byRun = db
     .prepare(
       `SELECT run_status AS runStatus,
-              telemetry_finalized_at AS telemetryFinalizedAt
+              telemetry_finalized_at AS telemetryFinalizedAt,
+              telemetry_accepted_body_id AS acceptedTraceBodyId,
+              telemetry_accepted_report_trigger AS acceptedReportTrigger
          FROM messages
         WHERE run_id = ?
         ORDER BY position DESC
@@ -1605,10 +1731,7 @@ export function getRunFeedbackTelemetryAnchor(
     )
     .get(runId) as DbRow | undefined;
   if (!byRun) return null;
-  return {
-    runStatus: typeof byRun.runStatus === 'string' ? byRun.runStatus : null,
-    telemetryFinalized: typeof byRun.telemetryFinalizedAt === 'number',
-  };
+  return rowToFeedbackTelemetryAnchor(byRun);
 }
 
 export function appendMessageStatusEvent(db: SqliteDb, messageId: string, event: DbRow) {

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -18,6 +18,7 @@ import { agentCliEnvForAgent, readAppConfig } from './app-config.js';
 import type { AppVersionInfo } from './app-version.js';
 import { listMessages } from './db.js';
 import {
+  canDeliverRunFeedback,
   deriveLangfuseDeliveryState,
   readTelemetrySinkConfig,
   reportRunCompleted,
@@ -1188,15 +1189,17 @@ export async function reportRunFeedbackFromDaemon(
   }
   // Pre-resolve the sink before claiming `accepted`. Avoids advertising a
   // successful enqueue to callers when there's no Langfuse endpoint
-  // configured to ship the score to.
+  // configured to ship the score to. Share eligibility with reportRunFeedback:
+  // a Vela sink still needs installationId (or an anonymous fallback).
   const configuredEnv = agentCliEnvForAgent(cfg.agentCliEnv, 'amr');
   const sink = readTelemetrySinkConfig(process.env, configuredEnv);
-  if (!sink) {
+  const installationId = cfg.installationId ?? null;
+  if (!canDeliverRunFeedback(sink, installationId)) {
     return { status: 'skipped_no_sink' };
   }
   const ctx: FeedbackReportContext = {
     runId: opts.runId,
-    installationId: cfg.installationId ?? null,
+    installationId,
     prefs,
     rating: opts.rating,
     reasonCodes: opts.reasonCodes,

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -973,7 +973,14 @@ export async function reportRunCompletedFromDaemon(
           (x) => x.id === run.assistantMessageId,
         );
         const m = assistantIndex >= 0 ? allMessages[assistantIndex] : undefined;
-        if (m) {
+        // Only trust message-derived content/manifests when the row still
+        // belongs to this run. Delayed terminal_fallback for run A can fire
+        // after a side-chat retry rebinds the same assistantMessageId to run
+        // B; id-only reload would otherwise publish B's content under A's
+        // failed trace.
+        const messageRunId =
+          m && typeof m.runId === 'string' ? m.runId.trim() : '';
+        if (m && (!messageRunId || messageRunId === run.id)) {
           messageContent = typeof m.content === 'string' ? m.content : '';
           // listMessages returns producedFiles already parsed (db.ts:965).
           producedFilesRaw = m.producedFiles;
@@ -1243,6 +1250,7 @@ export async function reportRunFeedbackFromDaemon(
   let runStatus: string | null | undefined;
   let telemetryFinalized: boolean | undefined;
   let acceptedTraceBodyId: string | null | undefined;
+  let acceptedReportTrigger: 'final_message' | 'terminal_fallback' | null | undefined;
   let acceptedDeliveryChannel:
     | 'vela'
     | 'relay'
@@ -1260,6 +1268,7 @@ export async function reportRunFeedbackFromDaemon(
         runStatus = anchor.runStatus;
         telemetryFinalized = anchor.telemetryFinalized;
         acceptedTraceBodyId = anchor.acceptedTraceBodyId;
+        acceptedReportTrigger = anchor.acceptedReportTrigger;
         acceptedDeliveryChannel = anchor.acceptedDeliveryChannel;
       }
     } catch (err) {
@@ -1288,6 +1297,9 @@ export async function reportRunFeedbackFromDaemon(
   // Do not pin a provisional canonical runId while terminal_fallback may still
   // become the only accepted body — reportRunFeedback will defer until
   // rememberAcceptedFinalTraceBodyId flushes onto the accepted id.
+  // When the accepted trigger is still terminal_fallback, pin for immediate
+  // `:tf` delivery but also pass acceptedReportTrigger so reportRunFeedback
+  // refreshes the deferred queue for a later final_message replay.
   const deferFeedback = shouldDeferRunFeedback(resolveInput);
   const ctx: FeedbackReportContext = {
     runId: opts.runId,
@@ -1296,6 +1308,9 @@ export async function reportRunFeedbackFromDaemon(
       : { traceId: resolveFeedbackTraceId(resolveInput) }),
     ...(runStatus !== undefined ? { runStatus } : {}),
     ...(telemetryFinalized !== undefined ? { telemetryFinalized } : {}),
+    ...(acceptedReportTrigger !== undefined
+      ? { acceptedReportTrigger }
+      : {}),
     ...(acceptedDeliveryChannel !== undefined
       ? { acceptedDeliveryChannel }
       : {}),

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -1154,8 +1154,9 @@ export async function reportRunCompletedFromDaemon(
         ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
       },
     );
-    // Persist the accepted final-purpose body id so feedback can still attach
-    // after a daemon restart when process-local memory is cold.
+    // Persist the accepted final-purpose body id + delivery channel so feedback
+    // can still attach after a daemon restart when process-local memory is cold,
+    // and so Vela-scoped traces never get anonymous raw-id scores later.
     if (delivery.langfuse_delivery_status === 'accepted') {
       try {
         setRunTelemetryAcceptedAnchor(db as Parameters<typeof setRunTelemetryAcceptedAnchor>[0], {
@@ -1163,6 +1164,7 @@ export async function reportRunCompletedFromDaemon(
           assistantMessageId: run.assistantMessageId ?? null,
           bodyId: scopedTelemetryBodyId(run.id, 'final', reportTrigger),
           reportTrigger,
+          deliveryChannel: delivery.langfuse_delivery_channel ?? null,
         });
       } catch (err) {
         console.warn(
@@ -1228,13 +1230,11 @@ export async function reportRunFeedbackFromDaemon(
   // Pre-resolve the sink before claiming `accepted`. Avoids advertising a
   // successful enqueue to callers when there's no Langfuse endpoint
   // configured to ship the score to. Share eligibility with reportRunFeedback:
-  // a Vela sink still needs installationId (or an anonymous fallback).
+  // a Vela sink still needs installationId (or an anonymous fallback) unless
+  // the accepted final body was Vela-scoped (anonymous must not misattach).
   const configuredEnv = agentCliEnvForAgent(cfg.agentCliEnv, 'amr');
   const sink = readTelemetrySinkConfig(process.env, configuredEnv);
   const installationId = cfg.installationId ?? null;
-  if (!canDeliverRunFeedback(sink, installationId)) {
-    return { status: 'skipped_no_sink' };
-  }
   const assistantMessageId =
     opts.scoreMetadata &&
     typeof opts.scoreMetadata.assistantMessageId === 'string'
@@ -1243,6 +1243,12 @@ export async function reportRunFeedbackFromDaemon(
   let runStatus: string | null | undefined;
   let telemetryFinalized: boolean | undefined;
   let acceptedTraceBodyId: string | null | undefined;
+  let acceptedDeliveryChannel:
+    | 'vela'
+    | 'relay'
+    | 'langfuse'
+    | null
+    | undefined;
   if (opts.db) {
     try {
       const anchor = getRunFeedbackTelemetryAnchor(
@@ -1254,6 +1260,7 @@ export async function reportRunFeedbackFromDaemon(
         runStatus = anchor.runStatus;
         telemetryFinalized = anchor.telemetryFinalized;
         acceptedTraceBodyId = anchor.acceptedTraceBodyId;
+        acceptedDeliveryChannel = anchor.acceptedDeliveryChannel;
       }
     } catch (err) {
       console.warn(
@@ -1261,6 +1268,14 @@ export async function reportRunFeedbackFromDaemon(
         String(err),
       );
     }
+  }
+  if (
+    !canDeliverRunFeedback(sink, installationId, process.env, {
+      requireChannel:
+        acceptedDeliveryChannel === 'vela' ? 'vela' : null,
+    })
+  ) {
+    return { status: 'skipped_no_sink' };
   }
   const resolveInput = {
     runId: opts.runId,
@@ -1281,6 +1296,9 @@ export async function reportRunFeedbackFromDaemon(
       : { traceId: resolveFeedbackTraceId(resolveInput) }),
     ...(runStatus !== undefined ? { runStatus } : {}),
     ...(telemetryFinalized !== undefined ? { telemetryFinalized } : {}),
+    ...(acceptedDeliveryChannel !== undefined
+      ? { acceptedDeliveryChannel }
+      : {}),
     installationId,
     prefs,
     rating: opts.rating,

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -16,13 +16,14 @@ import { modelIdForTracking } from '@open-design/contracts/analytics';
 
 import { agentCliEnvForAgent, readAppConfig } from './app-config.js';
 import type { AppVersionInfo } from './app-version.js';
-import { listMessages } from './db.js';
+import { getRunFeedbackTelemetryAnchor, listMessages } from './db.js';
 import {
   canDeliverRunFeedback,
   deriveLangfuseDeliveryState,
   readTelemetrySinkConfig,
   reportRunCompleted,
   reportRunFeedback,
+  resolveFeedbackTraceId,
   type AgentEventSummary,
   type ArtifactManifestEntry,
   type ArtifactSummary,
@@ -1166,6 +1167,11 @@ export interface ReportRunFeedbackFromDaemonOpts {
   customReason: string;
   /** Extra context for Langfuse score metadata (projectId / conversationId / assistantMessageId). */
   scoreMetadata?: Record<string, unknown>;
+  /**
+   * Optional SQLite handle so feedback can derive the accepted final-purpose
+   * body id (canonical vs terminal_fallback `:tf`) from message finalization.
+   */
+  db?: unknown;
   fetchImpl?: typeof fetch;
 }
 
@@ -1204,8 +1210,41 @@ export async function reportRunFeedbackFromDaemon(
   if (!canDeliverRunFeedback(sink, installationId)) {
     return { status: 'skipped_no_sink' };
   }
+  const assistantMessageId =
+    opts.scoreMetadata &&
+    typeof opts.scoreMetadata.assistantMessageId === 'string'
+      ? opts.scoreMetadata.assistantMessageId
+      : null;
+  let runStatus: string | null | undefined;
+  let telemetryFinalized: boolean | undefined;
+  if (opts.db) {
+    try {
+      const anchor = getRunFeedbackTelemetryAnchor(
+        opts.db as Parameters<typeof getRunFeedbackTelemetryAnchor>[0],
+        opts.runId,
+        assistantMessageId,
+      );
+      if (anchor) {
+        runStatus = anchor.runStatus;
+        telemetryFinalized = anchor.telemetryFinalized;
+      }
+    } catch (err) {
+      console.warn(
+        '[langfuse-bridge] feedback telemetry anchor lookup failed:',
+        String(err),
+      );
+    }
+  }
+  const traceId = resolveFeedbackTraceId({
+    runId: opts.runId,
+    ...(runStatus !== undefined ? { runStatus } : {}),
+    ...(telemetryFinalized !== undefined ? { telemetryFinalized } : {}),
+  });
   const ctx: FeedbackReportContext = {
     runId: opts.runId,
+    traceId,
+    ...(runStatus !== undefined ? { runStatus } : {}),
+    ...(telemetryFinalized !== undefined ? { telemetryFinalized } : {}),
     installationId,
     prefs,
     rating: opts.rating,

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -1170,6 +1170,7 @@ export async function reportRunCompletedFromDaemon(
         setRunTelemetryAcceptedAnchor(db as Parameters<typeof setRunTelemetryAcceptedAnchor>[0], {
           runId: run.id,
           assistantMessageId: run.assistantMessageId ?? null,
+          conversationId: run.conversationId ?? null,
           bodyId: scopedTelemetryBodyId(run.id, 'final', reportTrigger),
           reportTrigger,
           deliveryChannel: delivery.langfuse_delivery_channel ?? null,

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -1297,14 +1297,14 @@ export async function reportRunFeedbackFromDaemon(
   // after a later login would score a different namespace than the already-
   // accepted anonymous trace.
   //
-  // Only rows with a *persisted* accepted body (and no channel) are legacy.
-  // `telemetryFinalized` alone is not enough: createFinalizedMessageTelemetryReporter
+  // Only rows with a *persisted* accepted body (and no channel) are legacy-
+  // anonymous for sink selection. `telemetryFinalized` alone is not enough to
+  // choose legacy-anonymous sinks: createFinalizedMessageTelemetryReporter
   // marks the assistant message finalized before async reportRunCompleted
-  // records an accepted anchor, so a just-finished successful run can briefly
-  // look "finalized" with null body/channel. Treat that window as live
-  // finalization (global sink preflight + shouldDeferRunFeedback queue) rather
-  // than legacy-anonymous, which would skip Vela-only installs or mis-attach
-  // scores when both backends exist.
+  // records an accepted anchor. The live race is gated by
+  // markRunAwaitingFinalAcceptance + shouldDeferRunFeedback; cold finalized
+  // rows with no accepted body (and no in-flight mark) ship on the canonical
+  // body via the global sink preflight instead of queueing forever.
   //
   // When both relay and direct Langfuse are viable, the original backend is
   // ambiguous — skip rather than relay-first guess (see

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -24,7 +24,7 @@ import {
 import {
   canDeliverRunFeedback,
   deriveLangfuseDeliveryState,
-  readTelemetrySinkConfig,
+  readTelemetrySinkConfigForChannel,
   reportRunCompleted,
   reportRunFeedback,
   resolveFeedbackTraceId,
@@ -1240,8 +1240,9 @@ export async function reportRunFeedbackFromDaemon(
   // configured to ship the score to. Share eligibility with reportRunFeedback:
   // a Vela sink still needs installationId (or an anonymous fallback) unless
   // the accepted final body was Vela-scoped (anonymous must not misattach).
+  // Load the accepted-channel anchor first so sink selection sticks to that
+  // transport instead of the global Vela → relay → langfuse preference.
   const configuredEnv = agentCliEnvForAgent(cfg.agentCliEnv, 'amr');
-  const sink = readTelemetrySinkConfig(process.env, configuredEnv);
   const installationId = cfg.installationId ?? null;
   const assistantMessageId =
     opts.scoreMetadata &&
@@ -1289,6 +1290,11 @@ export async function reportRunFeedbackFromDaemon(
     acceptedDeliveryChannel === 'langfuse'
       ? acceptedDeliveryChannel
       : null;
+  const sink = readTelemetrySinkConfigForChannel(
+    requireChannel,
+    process.env,
+    configuredEnv,
+  );
   if (
     !canDeliverRunFeedback(sink, installationId, process.env, {
       requireChannel,

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -24,6 +24,7 @@ import {
 import {
   canDeliverRunFeedback,
   deriveLangfuseDeliveryState,
+  isLateFinalFeedbackHandoffOpen,
   readLegacyAnonymousAcceptedSinkConfig,
   readTelemetrySinkConfigForChannel,
   reportRunCompleted,
@@ -1322,13 +1323,18 @@ export async function reportRunFeedbackFromDaemon(
         process.env,
         configuredEnv,
       );
-  if (
-    !canDeliverRunFeedback(sink, installationId, process.env, {
-      requireChannel,
-      requireVelaIdentity:
-        requireChannel === 'vela' ? (acceptedVelaIdentity ?? null) : null,
-    })
-  ) {
+  const canDeliver = canDeliverRunFeedback(sink, installationId, process.env, {
+    requireChannel,
+    requireVelaIdentity:
+      requireChannel === 'vela' ? (acceptedVelaIdentity ?? null) : null,
+  });
+  // When the sticky accepted channel cannot deliver (e.g. Vela profile switch
+  // or logout during the late-final window), still refresh the deferred queue
+  // so a later final_message under a new identity can replay the latest score.
+  // Only suppress the immediate network send; do not return skipped_no_sink
+  // while the late-final handoff is open.
+  const lateFinalOpen = isLateFinalFeedbackHandoffOpen(opts.runId);
+  if (!canDeliver && !lateFinalOpen) {
     return { status: 'skipped_no_sink' };
   }
   const resolveInput = {
@@ -1376,11 +1382,14 @@ export async function reportRunFeedbackFromDaemon(
   // telemetry, not a client-facing signal. Deferred feedback is still
   // `accepted` from the caller's perspective — it ships when the run's
   // final-purpose body is accepted.
-  // Pass the preflight-resolved sink so reportRunFeedback does not re-run
-  // global priority selection and potentially diverge from the sticky channel
-  // that just passed canDeliverRunFeedback.
+  // When canDeliver is false, omit the sticky sink config so reportRunFeedback
+  // only refreshes the deferred queue (immediate send remains suppressed) and
+  // a later final_message flush re-resolves from live env/identity.
+  // When canDeliver is true, pass the preflight-resolved sink so reportRunFeedback
+  // does not re-run global priority selection and potentially diverge from the
+  // sticky channel that just passed canDeliverRunFeedback.
   void reportRunFeedback(ctx, {
-    config: sink,
+    ...(canDeliver ? { config: sink } : {}),
     configuredEnv,
     ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
   }).catch((err) => {

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -16,7 +16,11 @@ import { modelIdForTracking } from '@open-design/contracts/analytics';
 
 import { agentCliEnvForAgent, readAppConfig } from './app-config.js';
 import type { AppVersionInfo } from './app-version.js';
-import { getRunFeedbackTelemetryAnchor, listMessages } from './db.js';
+import {
+  getRunFeedbackTelemetryAnchor,
+  listMessages,
+  setRunTelemetryAcceptedAnchor,
+} from './db.js';
 import {
   canDeliverRunFeedback,
   deriveLangfuseDeliveryState,
@@ -24,6 +28,7 @@ import {
   reportRunCompleted,
   reportRunFeedback,
   resolveFeedbackTraceId,
+  scopedTelemetryBodyId,
   type AgentEventSummary,
   type ArtifactManifestEntry,
   type ArtifactSummary,
@@ -1135,18 +1140,37 @@ export async function reportRunCompletedFromDaemon(
 
     const uploadedManifests = await buildTraceObjectManifests(objectManifestOptions);
     const finalManifests = mergeTraceSafeManifests(manifests, uploadedManifests);
-    return await reportRunCompleted(
+    const reportTrigger = opts.reportTrigger ?? 'final_message';
+    const delivery = await reportRunCompleted(
       buildContext(finalManifests, buildTraceObjectSummary({
         traceObjectFilesRaw,
         ...(uploadedManifests ? { uploaded: uploadedManifests } : {}),
       })),
       {
         deliveryPurpose: 'final',
-        reportTrigger: opts.reportTrigger ?? 'final_message',
+        reportTrigger,
         configuredEnv,
         ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
       },
     );
+    // Persist the accepted final-purpose body id so feedback can still attach
+    // after a daemon restart when process-local memory is cold.
+    if (delivery.langfuse_delivery_status === 'accepted') {
+      try {
+        setRunTelemetryAcceptedAnchor(db as Parameters<typeof setRunTelemetryAcceptedAnchor>[0], {
+          runId: run.id,
+          assistantMessageId: run.assistantMessageId ?? null,
+          bodyId: scopedTelemetryBodyId(run.id, 'final', reportTrigger),
+          reportTrigger,
+        });
+      } catch (err) {
+        console.warn(
+          '[langfuse-bridge] failed to persist accepted telemetry anchor:',
+          String(err),
+        );
+      }
+    }
+    return delivery;
   } catch (err) {
     console.warn('[langfuse-bridge] report failed:', String(err));
     return {
@@ -1217,6 +1241,7 @@ export async function reportRunFeedbackFromDaemon(
       : null;
   let runStatus: string | null | undefined;
   let telemetryFinalized: boolean | undefined;
+  let acceptedTraceBodyId: string | null | undefined;
   if (opts.db) {
     try {
       const anchor = getRunFeedbackTelemetryAnchor(
@@ -1227,6 +1252,7 @@ export async function reportRunFeedbackFromDaemon(
       if (anchor) {
         runStatus = anchor.runStatus;
         telemetryFinalized = anchor.telemetryFinalized;
+        acceptedTraceBodyId = anchor.acceptedTraceBodyId;
       }
     } catch (err) {
       console.warn(
@@ -1239,6 +1265,9 @@ export async function reportRunFeedbackFromDaemon(
     runId: opts.runId,
     ...(runStatus !== undefined ? { runStatus } : {}),
     ...(telemetryFinalized !== undefined ? { telemetryFinalized } : {}),
+    ...(acceptedTraceBodyId !== undefined
+      ? { acceptedTraceBodyId }
+      : {}),
   });
   const ctx: FeedbackReportContext = {
     runId: opts.runId,

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -1301,10 +1301,11 @@ export async function reportRunFeedbackFromDaemon(
   // anonymous for sink selection. `telemetryFinalized` alone is not enough to
   // choose legacy-anonymous sinks: createFinalizedMessageTelemetryReporter
   // marks the assistant message finalized before async reportRunCompleted
-  // records an accepted anchor. The live race is gated by
-  // markRunAwaitingFinalAcceptance + shouldDeferRunFeedback; cold finalized
-  // rows with no accepted body (and no in-flight mark) ship on the canonical
-  // body via the global sink preflight instead of queueing forever.
+  // records an accepted anchor. The live race (and terminal_fallback delay)
+  // is gated by markRunAwaitingFinalAcceptance + shouldDeferRunFeedback; cold
+  // finalized/failed rows with no accepted body (and no in-flight mark) ship
+  // on the canonical body via the global sink preflight instead of queueing
+  // forever.
   //
   // When both relay and direct Langfuse are viable, the original backend is
   // ambiguous — skip rather than relay-first guess (see

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -14,7 +14,7 @@ import path from 'node:path';
 
 import { modelIdForTracking } from '@open-design/contracts/analytics';
 
-import { readAppConfig } from './app-config.js';
+import { agentCliEnvForAgent, readAppConfig } from './app-config.js';
 import type { AppVersionInfo } from './app-version.js';
 import { listMessages } from './db.js';
 import {
@@ -1105,15 +1105,21 @@ export async function reportRunCompletedFromDaemon(
       ...(run.promptTelemetry ? { promptTelemetry: run.promptTelemetry } : {}),
     });
 
+    const configuredEnv = agentCliEnvForAgent(cfg.agentCliEnv, 'amr');
     const registrationManifests = await buildTraceObjectManifests({
       ...objectManifestOptions,
       uploadMode: 'manifest-only',
     });
     if (registrationManifests) {
+      // Always anonymous relay + distinct delivery purpose. Object scope is
+      // keyed by installationId + original runId; Vela would hash body.id and
+      // break authorize/upload. Registration also omits turn content.
       await reportRunCompleted(
         buildContext(mergeTraceSafeManifests(manifests, registrationManifests)),
         {
           config: objectRegistrationTelemetryConfig(),
+          deliveryPurpose: 'object-registration',
+          configuredEnv,
           ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
         },
       );
@@ -1126,7 +1132,11 @@ export async function reportRunCompletedFromDaemon(
         traceObjectFilesRaw,
         ...(uploadedManifests ? { uploaded: uploadedManifests } : {}),
       })),
-      opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {},
+      {
+        deliveryPurpose: 'final',
+        configuredEnv,
+        ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+      },
     );
   } catch (err) {
     console.warn('[langfuse-bridge] report failed:', String(err));
@@ -1179,7 +1189,8 @@ export async function reportRunFeedbackFromDaemon(
   // Pre-resolve the sink before claiming `accepted`. Avoids advertising a
   // successful enqueue to callers when there's no Langfuse endpoint
   // configured to ship the score to.
-  const sink = readTelemetrySinkConfig();
+  const configuredEnv = agentCliEnvForAgent(cfg.agentCliEnv, 'amr');
+  const sink = readTelemetrySinkConfig(process.env, configuredEnv);
   if (!sink) {
     return { status: 'skipped_no_sink' };
   }
@@ -1197,10 +1208,10 @@ export async function reportRunFeedbackFromDaemon(
   // immediately. The handler's response already encodes the consent +
   // sink-presence outcome above; failures inside the send are operational
   // telemetry, not a client-facing signal.
-  void reportRunFeedback(
-    ctx,
-    opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {},
-  ).catch((err) => {
+  void reportRunFeedback(ctx, {
+    configuredEnv,
+    ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+  }).catch((err) => {
     console.warn('[langfuse-bridge] feedback report failed:', String(err));
   });
   return { status: 'accepted' };

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -1328,15 +1328,6 @@ export async function reportRunFeedbackFromDaemon(
     requireVelaIdentity:
       requireChannel === 'vela' ? (acceptedVelaIdentity ?? null) : null,
   });
-  // When the sticky accepted channel cannot deliver (e.g. Vela profile switch
-  // or logout during the late-final window), still refresh the deferred queue
-  // so a later final_message under a new identity can replay the latest score.
-  // Only suppress the immediate network send; do not return skipped_no_sink
-  // while the late-final handoff is open.
-  const lateFinalOpen = isLateFinalFeedbackHandoffOpen(opts.runId);
-  if (!canDeliver && !lateFinalOpen) {
-    return { status: 'skipped_no_sink' };
-  }
   const resolveInput = {
     runId: opts.runId,
     ...(runStatus !== undefined ? { runStatus } : {}),
@@ -1352,6 +1343,18 @@ export async function reportRunFeedbackFromDaemon(
   // `:tf` delivery but also pass acceptedReportTrigger so reportRunFeedback
   // refreshes the deferred queue for a later final_message replay.
   const deferFeedback = shouldDeferRunFeedback(resolveInput);
+  // When the sticky accepted channel cannot deliver (e.g. Vela profile switch
+  // or logout during the late-final window), still refresh the deferred queue
+  // so a later final_message under a new identity can replay the latest score.
+  // Same for the *live* final-acceptance window before any body is accepted:
+  // a missing sink must not return skipped_no_sink while
+  // markRunAwaitingFinalAcceptance is open — the user may log in / add a
+  // relay before the delayed fallback or final_message accepts. Only suppress
+  // the immediate network send; enqueue without a submit-time sink config.
+  const lateFinalOpen = isLateFinalFeedbackHandoffOpen(opts.runId);
+  if (!canDeliver && !lateFinalOpen && !deferFeedback) {
+    return { status: 'skipped_no_sink' };
+  }
   const ctx: FeedbackReportContext = {
     runId: opts.runId,
     ...(deferFeedback

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -35,6 +35,7 @@ import {
   type MessageSummary,
   type ReportContext,
   type RuntimeInfo,
+  type TelemetryReportTrigger,
   type TelemetrySinkConfig,
   type TraceObjectSummary,
   type ToolCallSummary,
@@ -121,6 +122,11 @@ export interface ReportRunCompletedFromDaemonOpts {
   persistedEndedAt?: number;
   /** App version info — collected once at daemon startup and reused. */
   appVersion?: AppVersionInfo | null;
+  /**
+   * Logical final-delivery trigger. Terminal fallback vs finalized message
+   * must produce distinct stable telemetry ids for the same run.
+   */
+  reportTrigger?: TelemetryReportTrigger;
   fetchImpl?: typeof fetch;
 }
 
@@ -1135,6 +1141,7 @@ export async function reportRunCompletedFromDaemon(
       })),
       {
         deliveryPurpose: 'final',
+        reportTrigger: opts.reportTrigger ?? 'final_message',
         configuredEnv,
         ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
       },

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -1349,7 +1349,11 @@ export async function reportRunFeedbackFromDaemon(
   // telemetry, not a client-facing signal. Deferred feedback is still
   // `accepted` from the caller's perspective — it ships when the run's
   // final-purpose body is accepted.
+  // Pass the preflight-resolved sink so reportRunFeedback does not re-run
+  // global priority selection and potentially diverge from the sticky channel
+  // that just passed canDeliverRunFeedback.
   void reportRunFeedback(ctx, {
+    config: sink,
     configuredEnv,
     ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
   }).catch((err) => {

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -24,7 +24,7 @@ import {
 import {
   canDeliverRunFeedback,
   deriveLangfuseDeliveryState,
-  readAnonymousTelemetrySinkConfig,
+  readLegacyAnonymousAcceptedSinkConfig,
   readTelemetrySinkConfigForChannel,
   reportRunCompleted,
   reportRunFeedback,
@@ -1296,13 +1296,17 @@ export async function reportRunFeedbackFromDaemon(
   // completed on the anonymous relay/Langfuse path; falling forward to the
   // global Vela-first preference after a later login would score a different
   // namespace than the already-accepted anonymous trace.
+  //
+  // When both relay and direct Langfuse are viable, the original backend is
+  // ambiguous — skip rather than relay-first guess (see
+  // readLegacyAnonymousAcceptedSinkConfig).
   const legacyAnonymousAccepted =
     requireChannel == null &&
     (telemetryFinalized === true ||
       (typeof acceptedTraceBodyId === 'string' &&
         acceptedTraceBodyId.trim().length > 0));
   const sink = legacyAnonymousAccepted
-    ? readAnonymousTelemetrySinkConfig(process.env)
+    ? readLegacyAnonymousAcceptedSinkConfig(process.env)
     : readTelemetrySinkConfigForChannel(
         requireChannel,
         process.env,

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -24,6 +24,7 @@ import {
 import {
   canDeliverRunFeedback,
   deriveLangfuseDeliveryState,
+  readAnonymousTelemetrySinkConfig,
   readTelemetrySinkConfigForChannel,
   reportRunCompleted,
   reportRunFeedback,
@@ -1290,11 +1291,23 @@ export async function reportRunFeedbackFromDaemon(
     acceptedDeliveryChannel === 'langfuse'
       ? acceptedDeliveryChannel
       : null;
-  const sink = readTelemetrySinkConfigForChannel(
-    requireChannel,
-    process.env,
-    configuredEnv,
-  );
+  // Pre-migration accepted anchors may still have telemetryFinalized /
+  // acceptedTraceBodyId while acceptedDeliveryChannel is null. Those runs
+  // completed on the anonymous relay/Langfuse path; falling forward to the
+  // global Vela-first preference after a later login would score a different
+  // namespace than the already-accepted anonymous trace.
+  const legacyAnonymousAccepted =
+    requireChannel == null &&
+    (telemetryFinalized === true ||
+      (typeof acceptedTraceBodyId === 'string' &&
+        acceptedTraceBodyId.trim().length > 0));
+  const sink = legacyAnonymousAccepted
+    ? readAnonymousTelemetrySinkConfig(process.env)
+    : readTelemetrySinkConfigForChannel(
+        requireChannel,
+        process.env,
+        configuredEnv,
+      );
   if (
     !canDeliverRunFeedback(sink, installationId, process.env, {
       requireChannel,

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -1172,6 +1172,7 @@ export async function reportRunCompletedFromDaemon(
           bodyId: scopedTelemetryBodyId(run.id, 'final', reportTrigger),
           reportTrigger,
           deliveryChannel: delivery.langfuse_delivery_channel ?? null,
+          velaIdentity: delivery.langfuse_vela_identity ?? null,
         });
       } catch (err) {
         console.warn(
@@ -1257,6 +1258,7 @@ export async function reportRunFeedbackFromDaemon(
     | 'langfuse'
     | null
     | undefined;
+  let acceptedVelaIdentity: string | null | undefined;
   if (opts.db) {
     try {
       const anchor = getRunFeedbackTelemetryAnchor(
@@ -1270,6 +1272,7 @@ export async function reportRunFeedbackFromDaemon(
         acceptedTraceBodyId = anchor.acceptedTraceBodyId;
         acceptedReportTrigger = anchor.acceptedReportTrigger;
         acceptedDeliveryChannel = anchor.acceptedDeliveryChannel;
+        acceptedVelaIdentity = anchor.acceptedVelaIdentity;
       }
     } catch (err) {
       console.warn(
@@ -1278,10 +1281,19 @@ export async function reportRunFeedbackFromDaemon(
       );
     }
   }
+  // Exact channel stickiness for every accepted transport, not only Vela —
+  // relay/langfuse/vela body-id namespaces are not interchangeable.
+  const requireChannel =
+    acceptedDeliveryChannel === 'vela' ||
+    acceptedDeliveryChannel === 'relay' ||
+    acceptedDeliveryChannel === 'langfuse'
+      ? acceptedDeliveryChannel
+      : null;
   if (
     !canDeliverRunFeedback(sink, installationId, process.env, {
-      requireChannel:
-        acceptedDeliveryChannel === 'vela' ? 'vela' : null,
+      requireChannel,
+      requireVelaIdentity:
+        requireChannel === 'vela' ? (acceptedVelaIdentity ?? null) : null,
     })
   ) {
     return { status: 'skipped_no_sink' };
@@ -1313,6 +1325,9 @@ export async function reportRunFeedbackFromDaemon(
       : {}),
     ...(acceptedDeliveryChannel !== undefined
       ? { acceptedDeliveryChannel }
+      : {}),
+    ...(acceptedVelaIdentity !== undefined
+      ? { acceptedVelaIdentity }
       : {}),
     installationId,
     prefs,

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -29,6 +29,7 @@ import {
   reportRunFeedback,
   resolveFeedbackTraceId,
   scopedTelemetryBodyId,
+  shouldDeferRunFeedback,
   type AgentEventSummary,
   type ArtifactManifestEntry,
   type ArtifactSummary,
@@ -1261,17 +1262,23 @@ export async function reportRunFeedbackFromDaemon(
       );
     }
   }
-  const traceId = resolveFeedbackTraceId({
+  const resolveInput = {
     runId: opts.runId,
     ...(runStatus !== undefined ? { runStatus } : {}),
     ...(telemetryFinalized !== undefined ? { telemetryFinalized } : {}),
     ...(acceptedTraceBodyId !== undefined
       ? { acceptedTraceBodyId }
       : {}),
-  });
+  };
+  // Do not pin a provisional canonical runId while terminal_fallback may still
+  // become the only accepted body — reportRunFeedback will defer until
+  // rememberAcceptedFinalTraceBodyId flushes onto the accepted id.
+  const deferFeedback = shouldDeferRunFeedback(resolveInput);
   const ctx: FeedbackReportContext = {
     runId: opts.runId,
-    traceId,
+    ...(deferFeedback
+      ? {}
+      : { traceId: resolveFeedbackTraceId(resolveInput) }),
     ...(runStatus !== undefined ? { runStatus } : {}),
     ...(telemetryFinalized !== undefined ? { telemetryFinalized } : {}),
     installationId,
@@ -1285,7 +1292,9 @@ export async function reportRunFeedbackFromDaemon(
   // Fire-and-forget the actual network send so the route can respond
   // immediately. The handler's response already encodes the consent +
   // sink-presence outcome above; failures inside the send are operational
-  // telemetry, not a client-facing signal.
+  // telemetry, not a client-facing signal. Deferred feedback is still
+  // `accepted` from the caller's perspective — it ships when the run's
+  // final-purpose body is accepted.
   void reportRunFeedback(ctx, {
     configuredEnv,
     ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -1291,20 +1291,28 @@ export async function reportRunFeedbackFromDaemon(
     acceptedDeliveryChannel === 'langfuse'
       ? acceptedDeliveryChannel
       : null;
-  // Pre-migration accepted anchors may still have telemetryFinalized /
-  // acceptedTraceBodyId while acceptedDeliveryChannel is null. Those runs
-  // completed on the anonymous relay/Langfuse path; falling forward to the
-  // global Vela-first preference after a later login would score a different
-  // namespace than the already-accepted anonymous trace.
+  // Pre-migration accepted anchors may still have acceptedTraceBodyId while
+  // acceptedDeliveryChannel is null. Those runs completed on the anonymous
+  // relay/Langfuse path; falling forward to the global Vela-first preference
+  // after a later login would score a different namespace than the already-
+  // accepted anonymous trace.
+  //
+  // Only rows with a *persisted* accepted body (and no channel) are legacy.
+  // `telemetryFinalized` alone is not enough: createFinalizedMessageTelemetryReporter
+  // marks the assistant message finalized before async reportRunCompleted
+  // records an accepted anchor, so a just-finished successful run can briefly
+  // look "finalized" with null body/channel. Treat that window as live
+  // finalization (global sink preflight + shouldDeferRunFeedback queue) rather
+  // than legacy-anonymous, which would skip Vela-only installs or mis-attach
+  // scores when both backends exist.
   //
   // When both relay and direct Langfuse are viable, the original backend is
   // ambiguous — skip rather than relay-first guess (see
   // readLegacyAnonymousAcceptedSinkConfig).
   const legacyAnonymousAccepted =
     requireChannel == null &&
-    (telemetryFinalized === true ||
-      (typeof acceptedTraceBodyId === 'string' &&
-        acceptedTraceBodyId.trim().length > 0));
+    typeof acceptedTraceBodyId === 'string' &&
+    acceptedTraceBodyId.trim().length > 0;
   const sink = legacyAnonymousAccepted
     ? readLegacyAnonymousAcceptedSinkConfig(process.env)
     : readTelemetrySinkConfigForChannel(

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -26,7 +26,7 @@
 
 import { createHash } from 'node:crypto';
 
-import type { TelemetryPrefs } from './app-config.js';
+import { readAppConfigSync, type TelemetryPrefs } from './app-config.js';
 import { readVelaControlApiContext } from './integrations/vela.js';
 import {
   buildPromptStackFlatMetadata,
@@ -261,9 +261,14 @@ export function clearRunAwaitingFinalAcceptance(
   const pending = pendingRunFeedbackByRunId.get(key);
   if (!pending) return;
   pendingRunFeedbackByRunId.delete(key);
+  // Same privacy gate as flushPendingRunFeedback: do not ship a delayed
+  // custom reason if live consent flipped off while waiting.
+  const flushPrefs = prefsForDeferredFeedbackFlush(pending.ctx.prefs);
+  if (flushPrefs == null) return;
   void reportRunFeedback(
     {
       ...pending.ctx,
+      prefs: flushPrefs,
       // Never invent `:tf` without acceptance; canonical is the legacy target.
       traceId: key,
     },
@@ -557,6 +562,69 @@ function flushReportOpts(
   return opts;
 }
 
+/**
+ * Optional test override for re-reading telemetry prefs at deferred-flush time.
+ * `undefined` means use the production reader (`OD_DATA_DIR` + app-config).
+ */
+let liveTelemetryPrefsReaderForTests:
+  | (() => TelemetryPrefs | null)
+  | undefined;
+
+/**
+ * Test-only: inject live telemetry prefs for deferred feedback flush gates.
+ * Pass `undefined` to restore the production `OD_DATA_DIR` reader.
+ */
+export function setLiveTelemetryPrefsReaderForTests(
+  reader: (() => TelemetryPrefs | null) | undefined,
+): void {
+  liveTelemetryPrefsReaderForTests = reader;
+}
+
+/**
+ * Re-read current telemetry prefs for a deferred feedback flush.
+ *
+ * Production uses the same sync app-config path as spawn-env consent checks
+ * (`OD_DATA_DIR` + `readAppConfigSync`). When no data dir is available (unit
+ * tests that never set one), returns null so the caller can fall back to the
+ * queued snapshot.
+ */
+function readLiveTelemetryPrefsForFlush(): TelemetryPrefs | null {
+  if (liveTelemetryPrefsReaderForTests !== undefined) {
+    return liveTelemetryPrefsReaderForTests();
+  }
+  const dataDir = process.env.OD_DATA_DIR?.trim();
+  if (!dataDir) return null;
+  try {
+    const cfg = readAppConfigSync(dataDir);
+    return cfg.telemetry ?? {};
+  } catch {
+    // Unreadable config during a delayed content send: fail closed.
+    return { metrics: false, content: false };
+  }
+}
+
+/**
+ * Prefs to ship with a deferred feedback flush.
+ *
+ * The queue captures prefs at submit time. Consent can flip off during the
+ * terminal-fallback / late-final window; re-check live prefs before the
+ * network send so a revoked opt-in does not leak custom reasons. Returns
+ * null when current consent is off (caller must drop without sending).
+ */
+function prefsForDeferredFeedbackFlush(
+  queued: TelemetryPrefs,
+): TelemetryPrefs | null {
+  let live: TelemetryPrefs | null;
+  try {
+    live = readLiveTelemetryPrefsForFlush();
+  } catch {
+    return null;
+  }
+  const effective = live ?? queued;
+  if (effective.metrics !== true || effective.content !== true) return null;
+  return effective;
+}
+
 function flushPendingRunFeedback(
   runId: string,
   acceptedBodyId: string,
@@ -569,6 +637,17 @@ function flushPendingRunFeedback(
   if (!key || !bodyId) return;
   const pending = pendingRunFeedbackByRunId.get(key);
   if (!pending) return;
+
+  // Privacy: re-check consent at flush time. Queued prefs can be stale after
+  // the terminal-fallback delay; a mid-window opt-out must not ship the raw
+  // custom reason (or retain it for a later final_message re-attach).
+  const flushPrefs = prefsForDeferredFeedbackFlush(pending.ctx.prefs);
+  if (flushPrefs == null) {
+    pendingRunFeedbackByRunId.delete(key);
+    cancelPendingTerminalFallbackQueueDrop(key);
+    return;
+  }
+
   // final_message owns the anchor: drop immediately. terminal_fallback keeps
   // the entry so a later final_message can re-attach onto the canonical body,
   // but only for a bounded late-final window (see
@@ -583,6 +662,7 @@ function flushPendingRunFeedback(
   void reportRunFeedback(
     {
       ...pending.ctx,
+      prefs: flushPrefs,
       traceId: bodyId,
       ...(deliveryChannel
         ? { acceptedDeliveryChannel: deliveryChannel }
@@ -607,6 +687,7 @@ export function resetPendingRunFeedbackForTests(): void {
   pendingRunFeedbackByRunId.clear();
   runsAwaitingFinalAcceptance.clear();
   awaitingFinalAcceptanceTokenSeq = 0;
+  liveTelemetryPrefsReaderForTests = undefined;
 }
 
 /** Test-only: whether deferred feedback is still queued for a run. */

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -119,11 +119,37 @@ export type TelemetryDeliveryPurpose = 'object-registration' | 'final';
  *
  * Failed/canceled runs may emit a synthetic `terminal_fallback` report first,
  * then a later `final_message` once the assistant message is telemetry-finalized.
- * Those two deliveries must not share ingestion event ids / Vela idempotency
- * keys, or the complete report is treated as a retry of the partial fallback.
- * True transport retries for the same trigger stay stable.
+ * Those two deliveries must not share Langfuse body ids, ingestion event ids,
+ * or Vela idempotency keys: a slow out-of-order fallback would otherwise
+ * overwrite the canonical finalized trace for the same run. True transport
+ * retries for the same trigger stay stable.
  */
 export type TelemetryReportTrigger = 'final_message' | 'terminal_fallback';
+
+/**
+ * Scope Langfuse observation/trace body ids for a delivery.
+ *
+ * Terminal-fallback writes into a distinct entity namespace (`:tf`) so a late
+ * partial fallback cannot clobber the canonical finalized observations that
+ * share the original run-scoped ids. Object-registration keeps original ids
+ * so object authority stays keyed by installation + runId.
+ */
+export function scopedTelemetryBodyId(
+  baseId: string,
+  deliveryPurpose: TelemetryDeliveryPurpose = 'final',
+  reportTrigger: TelemetryReportTrigger = 'final_message',
+): string {
+  if (deliveryPurpose !== 'final' || reportTrigger !== 'terminal_fallback') {
+    return baseId;
+  }
+  const trimmed = baseId.trim() || 'body-unknown';
+  if (trimmed.endsWith(':tf')) return trimmed;
+  const candidate = `${trimmed}:tf`;
+  if (candidate.length <= 200) return candidate;
+  const digest = createHash('sha256').update(candidate).digest('hex').slice(0, 16);
+  const keep = 200 - 1 - digest.length;
+  return `${candidate.slice(0, Math.max(1, keep))}-${digest}`;
+}
 
 export type TelemetrySinkConfig =
   | {
@@ -1525,15 +1551,21 @@ export function buildTracePayload(
   const performanceDiagnostics = buildPerformanceDiagnostics(ctx);
 
   const success = ctx.run.status === 'succeeded';
-  const traceId = ctx.run.runId;
+  // Canonical run id stays in metadata for correlation; Langfuse entity body
+  // ids may be remapped for terminal_fallback so late partials cannot overwrite
+  // a completed final_message delivery for the same run.
+  const canonicalTraceId = ctx.run.runId;
+  const scopeBodyId = (baseId: string) =>
+    scopedTelemetryBodyId(baseId, deliveryPurpose, idReportTrigger);
+  const traceId = scopeBodyId(canonicalTraceId);
   const langfuseDelivery =
     ctx.langfuse ?? deriveLangfuseDeliveryState(ctx.prefs, readTelemetrySinkConfig());
-  const agentSpanId = `${ctx.run.runId}-agent`;
-  const generationId = `${ctx.run.runId}-gen`;
+  const agentSpanId = scopeBodyId(`${ctx.run.runId}-agent`);
+  const generationId = scopeBodyId(`${ctx.run.runId}-gen`);
   const createGeneration = shouldCreateGenerationObservation(ctx);
   const operationSpanId = createGeneration
     ? generationId
-    : `${ctx.run.runId}-runtime`;
+    : scopeBodyId(`${ctx.run.runId}-runtime`);
   const promptStack = ctx.promptTelemetry
     ? wantsTextContent
       ? ctx.promptTelemetry
@@ -1563,7 +1595,7 @@ export function buildTracePayload(
     status: ctx.run.status,
     error: ctx.run.error ?? undefined,
     error_code: ctx.run.errorCode,
-    langfuse_trace_id: traceId,
+    langfuse_trace_id: canonicalTraceId,
     identity_type: 'anonymous_installation',
     installation_id: ctx.installationId ?? undefined,
     ...langfuseDelivery,
@@ -1620,14 +1652,21 @@ export function buildTracePayload(
   // shows them in the dedicated Model Parameters card and filters work.
   const modelParameters: Record<string, unknown> | undefined =
     ctx.turn?.reasoning ? { reasoning: ctx.turn.reasoning } : undefined;
+  // Build phase spans with canonical run-scoped ids, then remap body ids into
+  // the delivery namespace so terminal_fallback gets `…:tf` suffixes (not
+  // `run:tf-phase-…` mid-string infixes).
   const timingSpanBodies = buildTimingSpanBodies(ctx, operationSpanId, {
     modelCallName: createGeneration ? 'agent-call' : 'runtime-call',
     ...(promptStack ? { promptStack } : {}),
-  });
+  }).map((span) => ({
+    ...span,
+    id: scopeBodyId(String(span.id)),
+    traceId,
+  }));
   const toolParentObservationId = timingSpanBodies.some(
     (span) => span.name === 'agent-call',
   )
-    ? `${ctx.run.runId}-phase-agent-call`
+    ? scopeBodyId(`${ctx.run.runId}-phase-agent-call`)
     : agentSpanId;
   const agentEventParentObservationId = toolParentObservationId;
 
@@ -1763,7 +1802,7 @@ export function buildTracePayload(
 
   if (ctx.agentEvents?.length) {
     for (const event of ctx.agentEvents) {
-      const eventBodyId = `${ctx.run.runId}-agent-event-${event.id}`;
+      const eventBodyId = scopeBodyId(`${ctx.run.runId}-agent-event-${event.id}`);
       batch.push({
         id: stableIngestionEventId(eventBodyId, deliveryPurpose, idReportTrigger),
         type: 'event-create',
@@ -1786,7 +1825,7 @@ export function buildTracePayload(
 
   if (ctx.tools?.length) {
     for (const tool of ctx.tools) {
-      const toolSpanId = `${ctx.run.runId}-tool-${tool.id}`;
+      const toolSpanId = scopeBodyId(`${ctx.run.runId}-tool-${tool.id}`);
       const toolStartedAt = new Date(tool.startedAt).toISOString();
       const toolEndedAt = new Date(tool.endedAt).toISOString();
       const toolDurationMs = durationMs(tool.startedAt, tool.endedAt);
@@ -1833,7 +1872,7 @@ export function buildTracePayload(
   }
 
   if (artifactsList && (artifactsList.length > 0 || artifactsTruncated)) {
-    const artifactsEventId = `${ctx.run.runId}-artifacts`;
+    const artifactsEventId = scopeBodyId(`${ctx.run.runId}-artifacts`);
     batch.push({
       id: stableIngestionEventId(artifactsEventId, deliveryPurpose, idReportTrigger),
       type: 'event-create',
@@ -1866,7 +1905,7 @@ export function buildTracePayload(
   }
 
   if (!success || ctx.eventsSummary.errors > 0) {
-    const errorEventId = `${ctx.run.runId}-error`;
+    const errorEventId = scopeBodyId(`${ctx.run.runId}-error`);
     batch.push({
       id: stableIngestionEventId(errorEventId, deliveryPurpose, idReportTrigger),
       type: 'event-create',
@@ -1892,22 +1931,17 @@ export function buildTracePayload(
 
 /**
  * Stable ingestion event id so retries reuse the same Langfuse/Vela event ids.
- * Distinct suffixes keep object-registration, terminal-fallback, and finalized
- * final deliveries from being treated as retries of each other.
+ * Object-registration uses a `:reg` suffix so it is not deduped against final
+ * delivery (same body ids). Terminal-fallback uniqueness comes from scoped
+ * body ids (`:tf`); this helper does not re-suffix those.
  */
 export function stableIngestionEventId(
   bodyId: string,
   deliveryPurpose: TelemetryDeliveryPurpose = 'final',
-  reportTrigger: TelemetryReportTrigger = 'final_message',
+  _reportTrigger: TelemetryReportTrigger = 'final_message',
 ): string {
   const trimmed = bodyId.trim() || 'ingest-unknown';
-  let suffix = '';
-  if (deliveryPurpose === 'object-registration') {
-    suffix = ':reg';
-  } else if (reportTrigger === 'terminal_fallback') {
-    // Late final_message for the same run must not reuse fallback event ids.
-    suffix = ':tf';
-  }
+  const suffix = deliveryPurpose === 'object-registration' ? ':reg' : '';
   const candidate = `${trimmed}${suffix}`;
   if (candidate.length <= 200) return candidate;
   // Preserve uniqueness when truncating long body ids.

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -493,8 +493,8 @@ function readVelaTelemetrySinkConfig(
   const authSource: 'env' | 'file' = envControlKey ? 'env' : 'file';
   const context = readVelaControlApiContext(env, configuredEnv);
   const controlKey = context?.controlKey?.trim() ?? '';
-  if (!controlKey) return null;
-  const apiUrl = (context?.apiUrl?.trim() || 'https://amr-api.open-design.ai').replace(
+  if (!context || !controlKey) return null;
+  const apiUrl = (context.apiUrl?.trim() || 'https://amr-api.open-design.ai').replace(
     /\/+$/,
     '',
   );

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -183,7 +183,9 @@ export function rememberAcceptedFinalTraceBodyId(
   });
   // Replay any feedback that arrived during the terminal_fallback delay (or
   // before final_message acceptance) onto the body that was actually accepted.
-  flushPendingRunFeedback(key, acceptedBodyId);
+  // Keep the queue after terminal_fallback so a later final_message can re-
+  // attach the same score to the canonical body when it wins the anchor.
+  flushPendingRunFeedback(key, acceptedBodyId, reportTrigger);
 }
 
 /** Test-only: clear the accepted-final-trace registry between cases. */
@@ -242,13 +244,23 @@ export function queuePendingRunFeedback(
   pendingRunFeedbackByRunId.set(key, { ctx, opts });
 }
 
-function flushPendingRunFeedback(runId: string, acceptedBodyId: string): void {
+function flushPendingRunFeedback(
+  runId: string,
+  acceptedBodyId: string,
+  reportTrigger: TelemetryReportTrigger,
+): void {
   const key = runId.trim();
   const bodyId = acceptedBodyId.trim();
   if (!key || !bodyId) return;
   const pending = pendingRunFeedbackByRunId.get(key);
   if (!pending) return;
-  pendingRunFeedbackByRunId.delete(key);
+  // Drop the queue only once final_message owns the anchor. A terminal_fallback
+  // acceptance may be followed by a later final_message that prefers the
+  // canonical body; deleting here would permanently leave the only score on
+  // `runId:tf`.
+  if (reportTrigger === 'final_message') {
+    pendingRunFeedbackByRunId.delete(key);
+  }
   void reportRunFeedback(
     {
       ...pending.ctx,
@@ -2978,6 +2990,22 @@ export async function reportRunFeedback(
   ) {
     queuePendingRunFeedback(ctx, opts);
     return;
+  }
+
+  // After terminal_fallback is accepted, live re-ratings ship immediately onto
+  // `:tf` but must also refresh the deferred queue so a later final_message
+  // re-attach uses the latest score (not a stale pre-fallback rating).
+  // Skip when the caller already pinned a body id (flush path) — those
+  // deliveries must not overwrite the unpinned deferred entry.
+  const runKey = typeof ctx.runId === 'string' ? ctx.runId.trim() : '';
+  const explicitTrace =
+    typeof ctx.traceId === 'string' ? ctx.traceId.trim() : '';
+  if (
+    runKey &&
+    !explicitTrace &&
+    acceptedFinalTraceBodyIds.get(runKey)?.reportTrigger === 'terminal_fallback'
+  ) {
+    queuePendingRunFeedback(ctx, opts);
   }
 
   let batch: unknown[];

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -182,6 +182,59 @@ const acceptedFinalTraceBodyIds = new Map<
 >();
 
 /**
+ * Process-local set of runs whose final-purpose telemetry delivery is still
+ * in flight. createFinalizedMessageTelemetryReporter marks the message
+ * `telemetry_finalized` before reportRunCompleted can call
+ * rememberAcceptedFinalTraceBodyId; feedback during that window must wait.
+ *
+ * Absent from this set means there is no completer that will flush a deferred
+ * score (cold start, pre-migration row, or delivery already finished without
+ * an accepted anchor) — do not queue forever on those rows.
+ */
+const runsAwaitingFinalAcceptance = new Set<string>();
+
+/**
+ * Mark a run as having a final-purpose telemetry delivery in flight so
+ * feedback can defer until rememberAcceptedFinalTraceBodyId (or clear).
+ */
+export function markRunAwaitingFinalAcceptance(runId: string): void {
+  const key = typeof runId === 'string' ? runId.trim() : '';
+  if (key) runsAwaitingFinalAcceptance.add(key);
+}
+
+/**
+ * End the live finalization wait for a run.
+ *
+ * When an accepted body was never recorded, any deferred feedback is released
+ * onto the canonical runId (legacy cold / failed-finalization path) instead of
+ * remaining in pendingRunFeedbackByRunId until process exit.
+ */
+export function clearRunAwaitingFinalAcceptance(runId: string): void {
+  const key = typeof runId === 'string' ? runId.trim() : '';
+  if (!key) return;
+  if (!runsAwaitingFinalAcceptance.delete(key)) return;
+  // Accepted anchors already flushed via rememberAcceptedFinalTraceBodyId
+  // (which clears this set first). Remaining queue entries have no completer.
+  if (acceptedFinalTraceBodyIds.has(key)) return;
+  const pending = pendingRunFeedbackByRunId.get(key);
+  if (!pending) return;
+  pendingRunFeedbackByRunId.delete(key);
+  void reportRunFeedback(
+    {
+      ...pending.ctx,
+      // Never invent `:tf` without acceptance; canonical is the legacy target.
+      traceId: key,
+    },
+    pending.opts,
+  ).catch((err) => {
+    console.warn(
+      '[langfuse-trace] legacy/canonical deferred feedback flush failed:',
+      String(err),
+    );
+  });
+}
+
+/**
  * Stable fingerprint for the Vela account that accepted a final-purpose body.
  * Profile name + truncated Control Key hash (never the raw key).
  */
@@ -231,6 +284,9 @@ export function rememberAcceptedFinalTraceBodyId(
     ...(channel ? { deliveryChannel: channel } : {}),
     ...(identity ? { velaIdentity: identity } : {}),
   });
+  // End the live-finalization wait before flushing so a concurrent clear does
+  // not double-ship the same deferred score on the canonical body.
+  runsAwaitingFinalAcceptance.delete(key);
   // Replay any feedback that arrived during the terminal_fallback delay (or
   // before final_message acceptance) onto the body that was actually accepted.
   // Keep the queue after terminal_fallback so a later final_message can re-
@@ -262,6 +318,7 @@ export function getAcceptedFinalVelaIdentity(runId: string): string | null {
 /** Test-only: clear the accepted-final-trace registry between cases. */
 export function resetAcceptedFinalTraceBodyIdsForTests(): void {
   acceptedFinalTraceBodyIds.clear();
+  runsAwaitingFinalAcceptance.clear();
 }
 
 type PendingRunFeedbackEntry = {
@@ -283,9 +340,16 @@ const pendingRunFeedbackByRunId = new Map<string, PendingRunFeedbackEntry>();
  * Defer when no accepted body is known yet (process-local or persisted) and
  * either:
  * - the run failed/canceled (terminal_fallback delay window), or
- * - the message is already telemetry-finalized (live finalization race:
- *   createFinalizedMessageTelemetryReporter marks finalized before
- *   reportRunCompleted / rememberAcceptedFinalTraceBodyId records the anchor).
+ * - the message is telemetry-finalized *and* this process still has a final-
+ *   purpose delivery in flight (`markRunAwaitingFinalAcceptance`): the live
+ *   race where createFinalizedMessageTelemetryReporter marks finalized before
+ *   reportRunCompleted / rememberAcceptedFinalTraceBodyId records the anchor.
+ *
+ * Cold finalized rows with no accepted body (pre-migration, never-persisted
+ * anchors, or delivery already finished without accept) are NOT deferred —
+ * there is no completer to flush a queue, so scores ship on the canonical
+ * runId (or skip via sink eligibility) instead of sitting in
+ * pendingRunFeedbackByRunId until process exit.
  *
  * Once any body has been accepted — or the caller already pinned an explicit
  * `traceId` — send now so scores attach to the known body/channel.
@@ -307,9 +371,12 @@ export function shouldDeferRunFeedback(input: {
       ? input.acceptedTraceBodyId.trim()
       : '';
   if (accepted) return false;
-  // Finalized-without-accepted is the live finalization race, not "safe to
-  // ship on a guessed channel". Queue until rememberAcceptedFinalTraceBodyId.
-  if (input.telemetryFinalized === true) return true;
+  // Finalized-without-accepted is only the live finalization race while a
+  // completer is still in flight. Cold/legacy finalized rows have no pending
+  // rememberAcceptedFinalTraceBodyId — do not queue them forever.
+  if (input.telemetryFinalized === true) {
+    return runsAwaitingFinalAcceptance.has(runId);
+  }
   return input.runStatus === 'failed' || input.runStatus === 'canceled';
 }
 
@@ -412,6 +479,7 @@ function flushPendingRunFeedback(
 /** Test-only: clear deferred feedback between cases. */
 export function resetPendingRunFeedbackForTests(): void {
   pendingRunFeedbackByRunId.clear();
+  runsAwaitingFinalAcceptance.clear();
 }
 
 /**

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -151,6 +151,76 @@ export function scopedTelemetryBodyId(
   return `${candidate.slice(0, Math.max(1, keep))}-${digest}`;
 }
 
+/**
+ * Process-local map of the last accepted final-purpose Langfuse body id per run.
+ * Prefer final_message over terminal_fallback so a later finalized delivery
+ * becomes the feedback anchor when both fire in the same process.
+ */
+const acceptedFinalTraceBodyIds = new Map<
+  string,
+  { bodyId: string; reportTrigger: TelemetryReportTrigger }
+>();
+
+/**
+ * Remember the body id of an accepted final-purpose delivery so feedback
+ * scores can attach to the same Langfuse/Vela trace (including `:tf`).
+ */
+export function rememberAcceptedFinalTraceBodyId(
+  runId: string,
+  bodyId: string,
+  reportTrigger: TelemetryReportTrigger,
+): void {
+  const key = runId.trim();
+  if (!key || !bodyId.trim()) return;
+  const existing = acceptedFinalTraceBodyIds.get(key);
+  if (existing?.reportTrigger === 'final_message' && reportTrigger === 'terminal_fallback') {
+    return;
+  }
+  acceptedFinalTraceBodyIds.set(key, {
+    bodyId: bodyId.trim(),
+    reportTrigger,
+  });
+}
+
+/** Test-only: clear the accepted-final-trace registry between cases. */
+export function resetAcceptedFinalTraceBodyIdsForTests(): void {
+  acceptedFinalTraceBodyIds.clear();
+}
+
+/**
+ * Resolve the Langfuse body id feedback scores should target for a run.
+ *
+ * Priority:
+ * 1. Explicit override (`traceId`)
+ * 2. Process-local accepted final delivery body id
+ * 3. Derive from run status + message finalization (mirrors terminal_fallback rules)
+ * 4. Canonical runId
+ */
+export function resolveFeedbackTraceId(input: {
+  runId: string;
+  /** Explicit override (e.g. caller already resolved the anchor). */
+  traceId?: string | null;
+  runStatus?: string | null;
+  /** True when the assistant message was telemetry-finalized (final_message path). */
+  telemetryFinalized?: boolean;
+}): string {
+  const runId = typeof input.runId === 'string' ? input.runId.trim() : '';
+  if (!runId) return typeof input.runId === 'string' ? input.runId : '';
+  const explicit = typeof input.traceId === 'string' ? input.traceId.trim() : '';
+  if (explicit) return explicit;
+  const remembered = acceptedFinalTraceBodyIds.get(runId);
+  if (remembered?.bodyId) return remembered.bodyId;
+  // Failed/canceled runs that never reach a telemetry-finalized final_message
+  // only have the terminal_fallback body namespace in Langfuse/Vela.
+  if (
+    input.telemetryFinalized !== true &&
+    (input.runStatus === 'failed' || input.runStatus === 'canceled')
+  ) {
+    return scopedTelemetryBodyId(runId, 'final', 'terminal_fallback');
+  }
+  return runId;
+}
+
 export type TelemetrySinkConfig =
   | {
       kind: 'vela';
@@ -442,15 +512,22 @@ export interface ReportRunOpts {
 /**
  * Payload sent to Langfuse when a user thumbs-up/down's an assistant turn.
  *
- * The `runId` doubles as the Langfuse trace id (same convention used by
- * buildTracePayload), so the score lands on the existing trace if the run
- * was previously reported. If the run wasn't reported (e.g. content
- * consent was off at run completion, then turned on before the user
- * scored), Langfuse will accept the score anyway and the trace will
- * materialize when/if the daemon backfills it.
+ * Scores attach to the accepted final-purpose body id for the run (canonical
+ * `runId` after final_message, or `${runId}:tf` for terminal_fallback-only
+ * completions). Callers may pass an explicit `traceId`, or supply run status +
+ * finalization so resolveFeedbackTraceId can derive the anchor.
  */
 export interface FeedbackReportContext {
   runId: string;
+  /**
+   * Langfuse body id the score should attach to. When omitted, derived via
+   * resolveFeedbackTraceId from accepted-delivery memory and/or run status.
+   */
+  traceId?: string;
+  /** Terminal run status; used to derive the fallback `:tf` body id. */
+  runStatus?: string | null;
+  /** True when the assistant message was telemetry-finalized. */
+  telemetryFinalized?: boolean;
   installationId: string | null;
   prefs: TelemetryPrefs;
   rating: 'positive' | 'negative';
@@ -595,9 +672,26 @@ export function canDeliverRunFeedback(
   return true;
 }
 
+/**
+ * Whether a resolved sink can actually deliver a final run report.
+ * Same Vela + installationId + anonymous-fallback rule as reportRunCompleted
+ * and canDeliverRunFeedback.
+ */
+export function canDeliverRunTelemetry(
+  sink: TelemetrySinkConfig | null,
+  installationId: string | null | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): sink is TelemetrySinkConfig {
+  return canDeliverRunFeedback(sink, installationId, env);
+}
+
 export function deriveLangfuseDeliveryState(
   prefs: TelemetryPrefs,
   sink: TelemetrySinkConfig | null,
+  opts: {
+    installationId?: string | null;
+    env?: NodeJS.ProcessEnv;
+  } = {},
 ): LangfuseDeliveryState {
   if (prefs.metrics !== true) {
     return {
@@ -617,6 +711,16 @@ export function deriveLangfuseDeliveryState(
     return {
       langfuse_expected: false,
       langfuse_delivery_status: 'not_expected',
+      langfuse_drop_reason: 'missing_sink_config',
+    };
+  }
+  // Match reportRunCompleted: a resolved Vela sink still needs installationId
+  // (or anonymous fallback). Otherwise delivery fails immediately as
+  // missing_sink_config — run_finished must not claim `queued`.
+  if (!canDeliverRunTelemetry(sink, opts.installationId, opts.env ?? process.env)) {
+    return {
+      langfuse_expected: true,
+      langfuse_delivery_status: 'failed',
       langfuse_drop_reason: 'missing_sink_config',
     };
   }
@@ -2490,7 +2594,9 @@ export async function reportRunCompleted(
   if (ctx.prefs.content !== true) return notExpected;
 
   const config = resolveReportConfig(opts);
-  const langfuseDelivery = deriveLangfuseDeliveryState(ctx.prefs, config);
+  const langfuseDelivery = deriveLangfuseDeliveryState(ctx.prefs, config, {
+    installationId: ctx.installationId,
+  });
   if (!config) {
     if (!missingTelemetrySinkWarned) {
       // Warn once per daemon process; packaged config is loaded at process
@@ -2500,6 +2606,11 @@ export async function reportRunCompleted(
         '[langfuse-trace] Telemetry metrics are enabled but no Vela Control Key, relay, or Langfuse credentials are configured',
       );
     }
+    return langfuseDelivery;
+  }
+  // Pre-send eligibility matches run_finished analytics: undeliverable Vela
+  // configs (no installationId, no anonymous fallback) fail immediately.
+  if (langfuseDelivery.langfuse_delivery_status === 'failed') {
     return langfuseDelivery;
   }
 
@@ -2539,6 +2650,19 @@ export async function reportRunCompleted(
 
   const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
   const configuredEnv = opts.configuredEnv ?? {};
+  const noteAcceptedFinalTrace = (state: LangfuseDeliveryState): LangfuseDeliveryState => {
+    if (
+      deliveryPurpose === 'final' &&
+      state.langfuse_delivery_status === 'accepted'
+    ) {
+      rememberAcceptedFinalTraceBodyId(
+        ctx.run.runId,
+        scopedTelemetryBodyId(ctx.run.runId, deliveryPurpose, reportTrigger),
+        reportTrigger,
+      );
+    }
+    return state;
+  };
   if (config.kind === 'vela') {
     // Object-registration must stay on the anonymous relay so object scope is
     // keyed by the original runId (Vela scopes/hashes body.id for Langfuse).
@@ -2551,7 +2675,9 @@ export async function reportRunCompleted(
           langfuse_drop_reason: 'missing_sink_config',
         };
       }
-      return postAnonymousBatch(fallback, batch, serialized, fetchImpl);
+      return noteAcceptedFinalTrace(
+        await postAnonymousBatch(fallback, batch, serialized, fetchImpl),
+      );
     }
     const installationId = ctx.installationId?.trim() ?? '';
     if (!installationId) {
@@ -2565,18 +2691,26 @@ export async function reportRunCompleted(
           langfuse_drop_reason: 'missing_sink_config',
         };
       }
-      return postAnonymousBatch(fallback, batch, serialized, fetchImpl);
+      return noteAcceptedFinalTrace(
+        await postAnonymousBatch(fallback, batch, serialized, fetchImpl),
+      );
     }
-    return postVelaBatch(config, batch, installationId, fetchImpl, {
-      configuredEnv,
-      deliveryPurpose,
-      reportTrigger,
-    });
+    return noteAcceptedFinalTrace(
+      await postVelaBatch(config, batch, installationId, fetchImpl, {
+        configuredEnv,
+        deliveryPurpose,
+        reportTrigger,
+      }),
+    );
   }
   if (config.kind === 'relay') {
-    return postRelayBatch(config, serialized, fetchImpl);
+    return noteAcceptedFinalTrace(
+      await postRelayBatch(config, serialized, fetchImpl),
+    );
   }
-  return postLangfuseBatch(config, batch, fetchImpl);
+  return noteAcceptedFinalTrace(
+    await postLangfuseBatch(config, batch, fetchImpl),
+  );
 }
 
 // Build a Langfuse `score-create` batch for a user-supplied turn rating.
@@ -2615,7 +2749,17 @@ export function feedbackIngestionRevision(ctx: FeedbackReportContext): string {
 }
 
 export function buildFeedbackPayload(ctx: FeedbackReportContext): unknown[] {
-  const traceId = ctx.runId;
+  // Attach scores to the same body id final-purpose delivery used (canonical
+  // runId or the terminal_fallback `:tf` namespace) — never invent a second
+  // canonical trace when only the fallback was sent.
+  const traceId = resolveFeedbackTraceId({
+    runId: ctx.runId,
+    ...(ctx.traceId !== undefined ? { traceId: ctx.traceId } : {}),
+    ...(ctx.runStatus !== undefined ? { runStatus: ctx.runStatus } : {}),
+    ...(ctx.telemetryFinalized !== undefined
+      ? { telemetryFinalized: ctx.telemetryFinalized }
+      : {}),
+  });
   const nowIso = new Date().toISOString();
   const batch: unknown[] = [];
   const revision = feedbackIngestionRevision(ctx);

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -95,10 +95,21 @@ export type LangfuseDropReason =
   | 'timeout'
   | 'network_error';
 
+/**
+ * Transport that actually accepted a final-purpose telemetry batch.
+ *
+ * Vela scopes/hashes submitted body ids before writing Langfuse, so feedback
+ * must stay on the same channel. Anonymous relay/direct Langfuse write the
+ * raw body id and must not receive scores for Vela-accepted runs.
+ */
+export type TelemetryDeliveryChannel = 'vela' | 'relay' | 'langfuse';
+
 export interface LangfuseDeliveryState {
   langfuse_expected: boolean;
   langfuse_delivery_status: LangfuseDeliveryStatus;
   langfuse_drop_reason?: LangfuseDropReason;
+  /** Set on accepted deliveries so feedback can pin the same transport. */
+  langfuse_delivery_channel?: TelemetryDeliveryChannel;
 }
 
 export type AnonymousTelemetrySinkConfig =
@@ -158,7 +169,11 @@ export function scopedTelemetryBodyId(
  */
 const acceptedFinalTraceBodyIds = new Map<
   string,
-  { bodyId: string; reportTrigger: TelemetryReportTrigger }
+  {
+    bodyId: string;
+    reportTrigger: TelemetryReportTrigger;
+    deliveryChannel?: TelemetryDeliveryChannel;
+  }
 >();
 
 /**
@@ -169,6 +184,7 @@ export function rememberAcceptedFinalTraceBodyId(
   runId: string,
   bodyId: string,
   reportTrigger: TelemetryReportTrigger,
+  deliveryChannel?: TelemetryDeliveryChannel | null,
 ): void {
   const key = runId.trim();
   if (!key || !bodyId.trim()) return;
@@ -177,15 +193,34 @@ export function rememberAcceptedFinalTraceBodyId(
     return;
   }
   const acceptedBodyId = bodyId.trim();
+  const channel =
+    deliveryChannel === 'vela' ||
+    deliveryChannel === 'relay' ||
+    deliveryChannel === 'langfuse'
+      ? deliveryChannel
+      : undefined;
   acceptedFinalTraceBodyIds.set(key, {
     bodyId: acceptedBodyId,
     reportTrigger,
+    ...(channel ? { deliveryChannel: channel } : {}),
   });
   // Replay any feedback that arrived during the terminal_fallback delay (or
   // before final_message acceptance) onto the body that was actually accepted.
   // Keep the queue after terminal_fallback so a later final_message can re-
   // attach the same score to the canonical body when it wins the anchor.
-  flushPendingRunFeedback(key, acceptedBodyId, reportTrigger);
+  flushPendingRunFeedback(key, acceptedBodyId, reportTrigger, channel);
+}
+
+/**
+ * Process-local accepted delivery channel for a run, if any.
+ * Used to keep feedback on the same transport after Vela acceptance.
+ */
+export function getAcceptedFinalDeliveryChannel(
+  runId: string,
+): TelemetryDeliveryChannel | null {
+  const key = typeof runId === 'string' ? runId.trim() : '';
+  if (!key) return null;
+  return acceptedFinalTraceBodyIds.get(key)?.deliveryChannel ?? null;
 }
 
 /** Test-only: clear the accepted-final-trace registry between cases. */
@@ -248,6 +283,7 @@ function flushPendingRunFeedback(
   runId: string,
   acceptedBodyId: string,
   reportTrigger: TelemetryReportTrigger,
+  deliveryChannel?: TelemetryDeliveryChannel,
 ): void {
   const key = runId.trim();
   const bodyId = acceptedBodyId.trim();
@@ -265,6 +301,9 @@ function flushPendingRunFeedback(
     {
       ...pending.ctx,
       traceId: bodyId,
+      ...(deliveryChannel
+        ? { acceptedDeliveryChannel: deliveryChannel }
+        : {}),
     },
     pending.opts,
   ).catch((err) => {
@@ -642,6 +681,12 @@ export interface FeedbackReportContext {
   runStatus?: string | null;
   /** True when the assistant message was telemetry-finalized. */
   telemetryFinalized?: boolean;
+  /**
+   * Transport that accepted the final-purpose body this score attaches to.
+   * When `vela`, feedback must not fall back to anonymous relay/Langfuse —
+   * Vela scopes body ids, so raw-id anonymous scores would misattach.
+   */
+  acceptedDeliveryChannel?: TelemetryDeliveryChannel | null;
   installationId: string | null;
   prefs: TelemetryPrefs;
   rating: 'positive' | 'negative';
@@ -771,13 +816,21 @@ export function readTelemetrySinkConfig(
  * a resolved Vela sink still requires a non-empty installationId, otherwise
  * delivery falls back to the anonymous sink (or is undeliverable when that
  * is also missing).
+ *
+ * When `requireChannel` is `vela`, anonymous fallback is suppressed: the
+ * accepted final body lives under Vela-scoped ids and must not receive
+ * raw-id scores on the anonymous relay.
  */
 export function canDeliverRunFeedback(
   sink: TelemetrySinkConfig | null,
   installationId: string | null | undefined,
   env: NodeJS.ProcessEnv = process.env,
+  opts: { requireChannel?: TelemetryDeliveryChannel | null } = {},
 ): sink is TelemetrySinkConfig {
   if (!sink) return false;
+  if (opts.requireChannel === 'vela') {
+    return sink.kind === 'vela' && Boolean(installationId?.trim());
+  }
   if (sink.kind === 'vela') {
     const id = installationId?.trim() ?? '';
     if (id) return true;
@@ -2344,12 +2397,18 @@ async function postVelaBatch(
     configuredEnv?: Record<string, string>;
     deliveryPurpose?: TelemetryDeliveryPurpose;
     reportTrigger?: TelemetryReportTrigger;
+    /**
+     * When false, 401/403 does not fall back to the anonymous relay. Required
+     * for feedback scores that must stay on a Vela-scoped body id.
+     */
+    allowAnonymousFallback?: boolean;
   } = {},
 ): Promise<LangfuseDeliveryState> {
   const env = opts.env ?? process.env;
   const configuredEnv = opts.configuredEnv ?? {};
   const deliveryPurpose = opts.deliveryPurpose ?? 'final';
   const reportTrigger = opts.reportTrigger ?? 'final_message';
+  const allowAnonymousFallback = opts.allowAnonymousFallback !== false;
   const typedBatch = asLangfuseIngestionBatch(batch);
   const envelope = toVelaTelemetryEnvelope(typedBatch, installationId);
   const traceId =
@@ -2400,6 +2459,7 @@ async function postVelaBatch(
         return {
           langfuse_expected: true,
           langfuse_delivery_status: 'accepted',
+          langfuse_delivery_channel: 'vela',
         };
       }
 
@@ -2409,9 +2469,20 @@ async function postVelaBatch(
       // Auth failures: optionally clear matching local login and allow a
       // one-shot anonymous fallback. Do not anonymous-fallback on 400 / 429 /
       // 5xx / timeout — that can overwrite an authenticated identity if Vela
-      // already accepted the batch.
+      // already accepted the batch. Feedback for Vela-scoped bodies also
+      // suppresses anonymous fallback so scores cannot attach to raw ids.
       if (response.status === 401 || response.status === 403) {
         maybeForgetVelaLoginOnAuthFailure(config, env, configuredEnv);
+        if (!allowAnonymousFallback) {
+          console.warn(
+            `[langfuse-trace] Vela telemetry auth failed status=${response.status}; anonymous fallback suppressed`,
+          );
+          return {
+            langfuse_expected: true,
+            langfuse_delivery_status: 'failed',
+            langfuse_drop_reason: response.status === 401 ? 'vela_401' : 'vela_403',
+          };
+        }
         console.warn(
           `[langfuse-trace] Vela telemetry auth failed status=${response.status}; falling back to anonymous sink`,
         );
@@ -2532,6 +2603,7 @@ async function postLangfuseBatch(
       return {
         langfuse_expected: true,
         langfuse_delivery_status: 'accepted',
+        langfuse_delivery_channel: 'langfuse',
       };
     } catch (error) {
       if (attempt < attempts) {
@@ -2609,6 +2681,7 @@ async function postRelayBatch(
       return {
         langfuse_expected: true,
         langfuse_delivery_status: 'accepted',
+        langfuse_delivery_channel: 'relay',
       };
     } catch (error) {
       if (attempt < attempts) {
@@ -2808,6 +2881,7 @@ export async function reportRunCompleted(
         ctx.run.runId,
         scopedTelemetryBodyId(ctx.run.runId, deliveryPurpose, reportTrigger),
         reportTrigger,
+        state.langfuse_delivery_channel,
       );
     }
     return state;
@@ -2972,9 +3046,20 @@ export async function reportRunFeedback(
   if (ctx.prefs.content !== true) return;
 
   const config = resolveReportConfig(opts);
+  const requireChannel =
+    ctx.acceptedDeliveryChannel === 'vela'
+      ? 'vela'
+      : getAcceptedFinalDeliveryChannel(ctx.runId) === 'vela'
+        ? 'vela'
+        : null;
   // Same eligibility as reportRunFeedbackFromDaemon preflight: Vela without
-  // installationId only ships when an anonymous sink is available.
-  if (!canDeliverRunFeedback(config, ctx.installationId)) return;
+  // installationId only ships when an anonymous sink is available — unless
+  // the accepted final body was Vela-scoped, in which case anonymous is off.
+  if (!canDeliverRunFeedback(config, ctx.installationId, process.env, {
+    requireChannel,
+  })) {
+    return;
+  }
 
   // Failed/canceled runs may still be waiting on terminal_fallback acceptance.
   // Queue until rememberAcceptedFinalTraceBodyId flushes onto the accepted body.
@@ -3030,6 +3115,8 @@ export async function reportRunFeedback(
   if (config.kind === 'vela') {
     const installationId = ctx.installationId?.trim() ?? '';
     if (!installationId) {
+      // Vela-scoped anchors never fall back; canDeliver already gated this.
+      if (requireChannel === 'vela') return;
       // canDeliverRunFeedback already verified anonymous fallback exists.
       const fallback = readAnonymousTelemetrySinkConfig();
       if (!fallback) return;
@@ -3039,9 +3126,13 @@ export async function reportRunFeedback(
     await postVelaBatch(config, batch, installationId, fetchImpl, {
       configuredEnv,
       deliveryPurpose: opts.deliveryPurpose ?? 'final',
+      // Keep scores on the Vela-scoped body when that is what was accepted.
+      allowAnonymousFallback: requireChannel !== 'vela',
     });
     return;
   }
+  // Non-Vela sink cannot attach to a Vela-scoped body (ids diverge).
+  if (requireChannel === 'vela') return;
   if (config.kind === 'relay') {
     await postRelayBatch(config, serialized, fetchImpl);
     return;

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -687,6 +687,13 @@ export interface FeedbackReportContext {
    * Vela scopes body ids, so raw-id anonymous scores would misattach.
    */
   acceptedDeliveryChannel?: TelemetryDeliveryChannel | null;
+  /**
+   * Report trigger that owns the accepted final-purpose body (from process
+   * memory or the persisted DB anchor). When still `terminal_fallback`, live
+   * re-ratings must refresh the deferred queue so a later final_message can
+   * re-attach the latest score.
+   */
+  acceptedReportTrigger?: TelemetryReportTrigger | null;
   installationId: string | null;
   prefs: TelemetryPrefs;
   rating: 'positive' | 'negative';
@@ -3080,17 +3087,23 @@ export async function reportRunFeedback(
   // After terminal_fallback is accepted, live re-ratings ship immediately onto
   // `:tf` but must also refresh the deferred queue so a later final_message
   // re-attach uses the latest score (not a stale pre-fallback rating).
-  // Skip when the caller already pinned a body id (flush path) — those
-  // deliveries must not overwrite the unpinned deferred entry.
+  // The bridge pins an explicit `:tf` body id once the DB/process anchor is
+  // accepted, so we must refresh even when `traceId` is present — otherwise
+  // mid-window re-ratings leave the queue on a stale pre-fallback payload.
+  // final_message flush deletes the queue before shipping, so it never
+  // re-enters here after the canonical body wins.
   const runKey = typeof ctx.runId === 'string' ? ctx.runId.trim() : '';
-  const explicitTrace =
-    typeof ctx.traceId === 'string' ? ctx.traceId.trim() : '';
-  if (
-    runKey &&
-    !explicitTrace &&
-    acceptedFinalTraceBodyIds.get(runKey)?.reportTrigger === 'terminal_fallback'
-  ) {
-    queuePendingRunFeedback(ctx, opts);
+  const acceptedTrigger =
+    acceptedFinalTraceBodyIds.get(runKey)?.reportTrigger ??
+    (ctx.acceptedReportTrigger === 'terminal_fallback' ||
+    ctx.acceptedReportTrigger === 'final_message'
+      ? ctx.acceptedReportTrigger
+      : null);
+  if (runKey && acceptedTrigger === 'terminal_fallback') {
+    // Keep the deferred entry unpinned so final_message flush can re-target
+    // the canonical body via rememberAcceptedFinalTraceBodyId.
+    const { traceId: _pinnedTraceId, ...unpinnedCtx } = ctx;
+    queuePendingRunFeedback(unpinnedCtx, opts);
   }
 
   let batch: unknown[];

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -530,6 +530,28 @@ export function readTelemetrySinkConfig(
   );
 }
 
+/**
+ * Whether feedback telemetry can actually be delivered for this sink +
+ * installation. Shared by the daemon preflight (`accepted` vs
+ * `skipped_no_sink`) and `reportRunFeedback` so both use the same rule:
+ * a resolved Vela sink still requires a non-empty installationId, otherwise
+ * delivery falls back to the anonymous sink (or is undeliverable when that
+ * is also missing).
+ */
+export function canDeliverRunFeedback(
+  sink: TelemetrySinkConfig | null,
+  installationId: string | null | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): sink is TelemetrySinkConfig {
+  if (!sink) return false;
+  if (sink.kind === 'vela') {
+    const id = installationId?.trim() ?? '';
+    if (id) return true;
+    return readAnonymousTelemetrySinkConfig(env) != null;
+  }
+  return true;
+}
+
 export function deriveLangfuseDeliveryState(
   prefs: TelemetryPrefs,
   sink: TelemetrySinkConfig | null,
@@ -2570,7 +2592,9 @@ export async function reportRunFeedback(
   if (ctx.prefs.content !== true) return;
 
   const config = resolveReportConfig(opts);
-  if (!config) return;
+  // Same eligibility as reportRunFeedbackFromDaemon preflight: Vela without
+  // installationId only ships when an anonymous sink is available.
+  if (!canDeliverRunFeedback(config, ctx.installationId)) return;
 
   let batch: unknown[];
   try {
@@ -2594,6 +2618,7 @@ export async function reportRunFeedback(
   if (config.kind === 'vela') {
     const installationId = ctx.installationId?.trim() ?? '';
     if (!installationId) {
+      // canDeliverRunFeedback already verified anonymous fallback exists.
       const fallback = readAnonymousTelemetrySinkConfig();
       if (!fallback) return;
       await postAnonymousBatch(fallback, batch, serialized, fetchImpl);

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -330,10 +330,19 @@ export function rememberAcceptedFinalTraceBodyId(
   // not double-ship the same deferred score on the canonical body. Acceptance
   // supersedes all in-flight tokens for this run.
   runsAwaitingFinalAcceptance.delete(key);
+  // Open the late-final re-attach window as soon as terminal_fallback wins so
+  // mid-window live re-ratings can refresh the deferred queue even when no
+  // pre-acceptance feedback was pending. final_message cancels this timer.
+  if (reportTrigger === 'terminal_fallback') {
+    schedulePendingTerminalFallbackQueueDrop(key);
+  } else if (reportTrigger === 'final_message') {
+    cancelPendingTerminalFallbackQueueDrop(key);
+  }
   // Replay any feedback that arrived during the terminal_fallback delay (or
   // before final_message acceptance) onto the body that was actually accepted.
   // Keep the queue after terminal_fallback so a later final_message can re-
-  // attach the same score to the canonical body when it wins the anchor.
+  // attach the same score to the canonical body when it wins the anchor —
+  // bounded by TERMINAL_FALLBACK_LATE_FINAL_FEEDBACK_MS for TF-only runs.
   flushPendingRunFeedback(key, acceptedBodyId, reportTrigger, channel, identity);
 }
 
@@ -376,6 +385,71 @@ type PendingRunFeedbackEntry = {
  * detaches the score from the only body that eventually exists (`runId:tf`).
  */
 const pendingRunFeedbackByRunId = new Map<string, PendingRunFeedbackEntry>();
+
+/**
+ * How long deferred feedback may remain after a `terminal_fallback` acceptance
+ * so a later `final_message` can re-attach the same score to the canonical body.
+ *
+ * Terminal-fallback-only runs never get that late final: without a bound the
+ * map would retain custom reasons and `opts.config` (including a Vela Control
+ * Key from the submit-time sink) until daemon exit. Concurrent final-purpose
+ * flights that finish inside this window still re-flush from the queue.
+ */
+export const TERMINAL_FALLBACK_LATE_FINAL_FEEDBACK_MS = 30_000;
+
+/**
+ * One-shot timers that drop `pendingRunFeedbackByRunId` after terminal_fallback
+ * when no late final_message claims the queue. Keyed by run id.
+ */
+const pendingTerminalFallbackQueueDropTimers = new Map<
+  string,
+  ReturnType<typeof setTimeout>
+>();
+
+function cancelPendingTerminalFallbackQueueDrop(runId: string): void {
+  const key = typeof runId === 'string' ? runId.trim() : '';
+  if (!key) return;
+  const timer = pendingTerminalFallbackQueueDropTimers.get(key);
+  if (!timer) return;
+  clearTimeout(timer);
+  pendingTerminalFallbackQueueDropTimers.delete(key);
+}
+
+/**
+ * Schedule a bounded drop of deferred feedback retained after terminal_fallback.
+ * Idempotent per run: the first schedule wins so re-ratings refresh the payload
+ * without extending secret retention indefinitely.
+ */
+function schedulePendingTerminalFallbackQueueDrop(runId: string): void {
+  const key = typeof runId === 'string' ? runId.trim() : '';
+  if (!key) return;
+  if (pendingTerminalFallbackQueueDropTimers.has(key)) return;
+  const timer = setTimeout(() => {
+    pendingTerminalFallbackQueueDropTimers.delete(key);
+    // A concurrent final-purpose attempt may still accept and re-flush; keep
+    // the queue and re-arm until that attempt ends without acceptance.
+    if (awaitingFinalAcceptanceCount(key) > 0) {
+      schedulePendingTerminalFallbackQueueDrop(key);
+      return;
+    }
+    // final_message already owns the anchor and deleted the queue on flush.
+    if (acceptedFinalTraceBodyIds.get(key)?.reportTrigger === 'final_message') {
+      pendingRunFeedbackByRunId.delete(key);
+      return;
+    }
+    // Terminal-fallback-only (or late final never came): drop retained secrets.
+    pendingRunFeedbackByRunId.delete(key);
+  }, TERMINAL_FALLBACK_LATE_FINAL_FEEDBACK_MS);
+  timer.unref?.();
+  pendingTerminalFallbackQueueDropTimers.set(key, timer);
+}
+
+/** True while the late-final re-attach window is still open for a run. */
+function hasPendingTerminalFallbackQueueRetention(runId: string): boolean {
+  const key = typeof runId === 'string' ? runId.trim() : '';
+  if (!key) return false;
+  return pendingTerminalFallbackQueueDropTimers.has(key);
+}
 
 /**
  * True when feedback should wait for an accepted final-purpose body id.
@@ -495,12 +569,16 @@ function flushPendingRunFeedback(
   if (!key || !bodyId) return;
   const pending = pendingRunFeedbackByRunId.get(key);
   if (!pending) return;
-  // Drop the queue only once final_message owns the anchor. A terminal_fallback
-  // acceptance may be followed by a later final_message that prefers the
-  // canonical body; deleting here would permanently leave the only score on
-  // `runId:tf`.
+  // final_message owns the anchor: drop immediately. terminal_fallback keeps
+  // the entry so a later final_message can re-attach onto the canonical body,
+  // but only for a bounded late-final window (see
+  // TERMINAL_FALLBACK_LATE_FINAL_FEEDBACK_MS) so TF-only runs do not retain
+  // custom reasons / opts.config (Vela Control Keys) until process exit.
   if (reportTrigger === 'final_message') {
     pendingRunFeedbackByRunId.delete(key);
+    cancelPendingTerminalFallbackQueueDrop(key);
+  } else if (reportTrigger === 'terminal_fallback') {
+    schedulePendingTerminalFallbackQueueDrop(key);
   }
   void reportRunFeedback(
     {
@@ -522,9 +600,20 @@ function flushPendingRunFeedback(
 
 /** Test-only: clear deferred feedback between cases. */
 export function resetPendingRunFeedbackForTests(): void {
+  for (const timer of pendingTerminalFallbackQueueDropTimers.values()) {
+    clearTimeout(timer);
+  }
+  pendingTerminalFallbackQueueDropTimers.clear();
   pendingRunFeedbackByRunId.clear();
   runsAwaitingFinalAcceptance.clear();
   awaitingFinalAcceptanceTokenSeq = 0;
+}
+
+/** Test-only: whether deferred feedback is still queued for a run. */
+export function hasPendingRunFeedbackForTests(runId: string): boolean {
+  const key = typeof runId === 'string' ? runId.trim() : '';
+  if (!key) return false;
+  return pendingRunFeedbackByRunId.has(key);
 }
 
 /**
@@ -3375,8 +3464,10 @@ export async function reportRunFeedback(
   // The bridge pins an explicit `:tf` body id once the DB/process anchor is
   // accepted, so we must refresh even when `traceId` is present — otherwise
   // mid-window re-ratings leave the queue on a stale pre-fallback payload.
-  // final_message flush deletes the queue before shipping, so it never
-  // re-enters here after the canonical body wins.
+  // Only retain while the late-final window is open or a final-purpose attempt
+  // is still in flight — re-queuing after the window would leak secrets again
+  // with no completer to clear them. final_message flush deletes the queue
+  // before shipping, so it never re-enters here after the canonical body wins.
   const runKey = typeof ctx.runId === 'string' ? ctx.runId.trim() : '';
   const acceptedTrigger =
     acceptedFinalTraceBodyIds.get(runKey)?.reportTrigger ??
@@ -3384,11 +3475,19 @@ export async function reportRunFeedback(
     ctx.acceptedReportTrigger === 'final_message'
       ? ctx.acceptedReportTrigger
       : null);
-  if (runKey && acceptedTrigger === 'terminal_fallback') {
+  if (
+    runKey &&
+    acceptedTrigger === 'terminal_fallback' &&
+    (hasPendingTerminalFallbackQueueRetention(runKey) ||
+      awaitingFinalAcceptanceCount(runKey) > 0)
+  ) {
     // Keep the deferred entry unpinned so final_message flush can re-target
     // the canonical body via rememberAcceptedFinalTraceBodyId.
     const { traceId: _pinnedTraceId, ...unpinnedCtx } = ctx;
     queuePendingRunFeedback(unpinnedCtx, opts);
+    // Ensure a drop is scheduled when retention came only from an in-flight
+    // final attempt (no prior TF flush scheduled a timer yet).
+    schedulePendingTerminalFallbackQueueDrop(runKey);
   }
 
   let batch: unknown[];

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -182,39 +182,81 @@ const acceptedFinalTraceBodyIds = new Map<
 >();
 
 /**
- * Process-local set of runs whose final-purpose telemetry delivery is still
- * in flight. createFinalizedMessageTelemetryReporter marks the message
- * `telemetry_finalized` before reportRunCompleted can call
- * rememberAcceptedFinalTraceBodyId; feedback during that window must wait.
+ * Process-local in-flight final-purpose telemetry deliveries, keyed by run id.
  *
- * Absent from this set means there is no completer that will flush a deferred
- * score (cold start, pre-migration row, or delivery already finished without
- * an accepted anchor) — do not queue forever on those rows.
+ * Each `markRunAwaitingFinalAcceptance` returns a token; only that token's
+ * matching clear (or a full clear on acceptance) ends that attempt. A boolean
+ * set is insufficient: `terminal_fallback` and `final_message` can both be in
+ * flight for the same run, and clearing on the first failure must not flush
+ * deferred feedback while the other delivery can still accept a sticky body.
+ *
+ * The schedule-time token for terminal_fallback delay is also run-scoped (not
+ * message-row-scoped), so after assistant-row reuse feedback for the old run
+ * still defers until that run's accepted body is known.
+ *
+ * Empty token set means there is no completer that will flush a deferred score
+ * (cold start, pre-migration row, or delivery already finished without an
+ * accepted anchor) — do not queue forever on those rows.
  */
-const runsAwaitingFinalAcceptance = new Set<string>();
+const runsAwaitingFinalAcceptance = new Map<string, Set<string>>();
+let awaitingFinalAcceptanceTokenSeq = 0;
+
+function awaitingFinalAcceptanceCount(runId: string): number {
+  return runsAwaitingFinalAcceptance.get(runId)?.size ?? 0;
+}
 
 /**
  * Mark a run as having a final-purpose telemetry delivery in flight so
  * feedback can defer until rememberAcceptedFinalTraceBodyId (or clear).
+ *
+ * Returns a token that must be passed to `clearRunAwaitingFinalAcceptance` for
+ * that attempt. Empty string means the run id was invalid and nothing was
+ * registered.
  */
-export function markRunAwaitingFinalAcceptance(runId: string): void {
+export function markRunAwaitingFinalAcceptance(runId: string): string {
   const key = typeof runId === 'string' ? runId.trim() : '';
-  if (key) runsAwaitingFinalAcceptance.add(key);
+  if (!key) return '';
+  let tokens = runsAwaitingFinalAcceptance.get(key);
+  if (!tokens) {
+    tokens = new Set();
+    runsAwaitingFinalAcceptance.set(key, tokens);
+  }
+  const token = `${key}:${++awaitingFinalAcceptanceTokenSeq}`;
+  tokens.add(token);
+  return token;
 }
 
 /**
- * End the live finalization wait for a run.
+ * End one (or all) live finalization wait(s) for a run.
  *
- * When an accepted body was never recorded, any deferred feedback is released
- * onto the canonical runId (legacy cold / failed-finalization path) instead of
- * remaining in pendingRunFeedbackByRunId until process exit.
+ * When `token` is provided, only that in-flight attempt is released. When
+ * omitted, every remaining attempt is cleared (used when an accepted body is
+ * already known or a path never obtained a token).
+ *
+ * Deferred feedback is released onto the canonical runId only when the last
+ * attempt ends without an accepted body (legacy cold / failed-finalization
+ * path) instead of remaining in pendingRunFeedbackByRunId until process exit.
  */
-export function clearRunAwaitingFinalAcceptance(runId: string): void {
+export function clearRunAwaitingFinalAcceptance(
+  runId: string,
+  token?: string | null,
+): void {
   const key = typeof runId === 'string' ? runId.trim() : '';
   if (!key) return;
-  if (!runsAwaitingFinalAcceptance.delete(key)) return;
+  const tokens = runsAwaitingFinalAcceptance.get(key);
+  if (!tokens || tokens.size === 0) return;
+
+  if (typeof token === 'string' && token) {
+    if (!tokens.delete(token)) return;
+  } else {
+    tokens.clear();
+  }
+
+  if (tokens.size > 0) return;
+  runsAwaitingFinalAcceptance.delete(key);
+
   // Accepted anchors already flushed via rememberAcceptedFinalTraceBodyId
-  // (which clears this set first). Remaining queue entries have no completer.
+  // (which clears tokens first). Remaining queue entries have no completer.
   if (acceptedFinalTraceBodyIds.has(key)) return;
   const pending = pendingRunFeedbackByRunId.get(key);
   if (!pending) return;
@@ -284,8 +326,9 @@ export function rememberAcceptedFinalTraceBodyId(
     ...(channel ? { deliveryChannel: channel } : {}),
     ...(identity ? { velaIdentity: identity } : {}),
   });
-  // End the live-finalization wait before flushing so a concurrent clear does
-  // not double-ship the same deferred score on the canonical body.
+  // End every live-finalization wait before flushing so a concurrent clear does
+  // not double-ship the same deferred score on the canonical body. Acceptance
+  // supersedes all in-flight tokens for this run.
   runsAwaitingFinalAcceptance.delete(key);
   // Replay any feedback that arrived during the terminal_fallback delay (or
   // before final_message acceptance) onto the body that was actually accepted.
@@ -372,10 +415,13 @@ export function shouldDeferRunFeedback(input: {
       ? input.acceptedTraceBodyId.trim()
       : '';
   if (accepted) return false;
-  // Live completer only. Cold failed/canceled/finalized rows have no pending
-  // rememberAcceptedFinalTraceBodyId / clearRunAwaitingFinalAcceptance — do
-  // not queue them forever on status or finalized flags alone.
-  return runsAwaitingFinalAcceptance.has(runId);
+  // Live completer only (schedule-time terminal_fallback token and/or in-flight
+  // final-purpose report tokens). Cold failed/canceled/finalized rows have no
+  // pending rememberAcceptedFinalTraceBodyId / clearRunAwaitingFinalAcceptance
+  // — do not queue them forever on status or finalized flags alone.
+  // Run-id tokens survive assistant-row reuse: getRunFeedbackTelemetryAnchor
+  // may return null for the old run while its delayed fallback is still open.
+  return awaitingFinalAcceptanceCount(runId) > 0;
 }
 
 export function queuePendingRunFeedback(
@@ -478,6 +524,7 @@ function flushPendingRunFeedback(
 export function resetPendingRunFeedbackForTests(): void {
   pendingRunFeedbackByRunId.clear();
   runsAwaitingFinalAcceptance.clear();
+  awaitingFinalAcceptanceTokenSeq = 0;
 }
 
 /**

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -889,7 +889,9 @@ export function canDeliverRunFeedback(
   const requireChannel = opts.requireChannel ?? null;
   if (requireChannel) {
     if (sink.kind !== requireChannel) return false;
-    if (requireChannel === 'vela') {
+    // Narrow on sink.kind (not requireChannel): TS does not refine a union
+    // through equality with a separate variable of the same string-literal union.
+    if (sink.kind === 'vela') {
       if (!installationId?.trim()) return false;
       const requiredIdentity =
         typeof opts.requireVelaIdentity === 'string'

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -114,6 +114,17 @@ export type AnonymousTelemetrySinkConfig =
 
 export type TelemetryDeliveryPurpose = 'object-registration' | 'final';
 
+/**
+ * Logical final-delivery trigger for a completed run.
+ *
+ * Failed/canceled runs may emit a synthetic `terminal_fallback` report first,
+ * then a later `final_message` once the assistant message is telemetry-finalized.
+ * Those two deliveries must not share ingestion event ids / Vela idempotency
+ * keys, or the complete report is treated as a retry of the partial fallback.
+ * True transport retries for the same trigger stay stable.
+ */
+export type TelemetryReportTrigger = 'final_message' | 'terminal_fallback';
+
 export type TelemetrySinkConfig =
   | {
       kind: 'vela';
@@ -389,6 +400,12 @@ export interface ReportRunOpts {
    * deduped.
    */
   deliveryPurpose?: TelemetryDeliveryPurpose;
+  /**
+   * Distinguishes terminal-fallback vs finalized-message final deliveries for
+   * the same run so late-complete reports are not Vela-deduped against an
+   * earlier partial/empty fallback. Ignored for object-registration.
+   */
+  reportTrigger?: TelemetryReportTrigger;
   /**
    * App-config AMR env (`agentCliEnv.amr`), e.g. OPEN_DESIGN_AMR_PROFILE /
    * VELA_API_URL. Merged into Vela Control Key resolution.
@@ -1425,6 +1442,7 @@ function shouldCreateGenerationObservation(ctx: ReportContext): boolean {
 export function buildTracePayload(
   ctx: ReportContext,
   deliveryPurpose: TelemetryDeliveryPurpose = 'final',
+  reportTrigger: TelemetryReportTrigger = 'final_message',
 ): unknown[] {
   // Object-registration needs manifests for upload authority but must not
   // double-write turn text when the final delivery goes through Vela.
@@ -1434,6 +1452,10 @@ export function buildTracePayload(
     ctx.prefs.metrics === true && ctx.prefs.content === true;
   const wantsTextContent = deliveryPurpose === 'final' && consentOn;
   const wantsArtifacts = consentOn;
+  // Object-registration is its own logical delivery; only final deliveries
+  // further split by report trigger (terminal fallback vs finalized message).
+  const idReportTrigger =
+    deliveryPurpose === 'object-registration' ? 'final_message' : reportTrigger;
 
   const sessionId =
     ctx.conversationId.length <= SESSION_ID_MAX ? ctx.conversationId : undefined;
@@ -1611,7 +1633,7 @@ export function buildTracePayload(
 
   const batch: LangfuseIngestionEvent[] = [
     {
-      id: stableIngestionEventId(traceId, deliveryPurpose),
+      id: stableIngestionEventId(traceId, deliveryPurpose, idReportTrigger),
       type: 'trace-create',
       timestamp: nowIso,
       body: {
@@ -1627,12 +1649,15 @@ export function buildTracePayload(
         metadata: {
           ...traceMetadata,
           telemetry_delivery_purpose: deliveryPurpose,
+          ...(deliveryPurpose === 'final'
+            ? { telemetry_report_trigger: idReportTrigger }
+            : {}),
         },
         timestamp: startTimeIso,
       },
     },
     {
-      id: stableIngestionEventId(agentSpanId, deliveryPurpose),
+      id: stableIngestionEventId(agentSpanId, deliveryPurpose, idReportTrigger),
       type: 'span-create',
       timestamp: nowIso,
       body: {
@@ -1661,7 +1686,7 @@ export function buildTracePayload(
 
   if (createGeneration) {
     batch.push({
-      id: stableIngestionEventId(generationId, deliveryPurpose),
+      id: stableIngestionEventId(generationId, deliveryPurpose, idReportTrigger),
       type: 'generation-create',
       timestamp: nowIso,
       body: {
@@ -1696,7 +1721,7 @@ export function buildTracePayload(
     });
   } else {
     batch.push({
-      id: stableIngestionEventId(operationSpanId, deliveryPurpose),
+      id: stableIngestionEventId(operationSpanId, deliveryPurpose, idReportTrigger),
       type: 'span-create',
       timestamp: nowIso,
       body: {
@@ -1729,7 +1754,7 @@ export function buildTracePayload(
   for (const span of timingSpanBodies) {
     const spanId = typeof span.id === 'string' ? span.id : `${traceId}-phase`;
     batch.push({
-      id: stableIngestionEventId(spanId, deliveryPurpose),
+      id: stableIngestionEventId(spanId, deliveryPurpose, idReportTrigger),
       type: 'span-create',
       timestamp: nowIso,
       body: span,
@@ -1740,7 +1765,7 @@ export function buildTracePayload(
     for (const event of ctx.agentEvents) {
       const eventBodyId = `${ctx.run.runId}-agent-event-${event.id}`;
       batch.push({
-        id: stableIngestionEventId(eventBodyId, deliveryPurpose),
+        id: stableIngestionEventId(eventBodyId, deliveryPurpose, idReportTrigger),
         type: 'event-create',
         timestamp: nowIso,
         body: {
@@ -1778,7 +1803,7 @@ export function buildTracePayload(
           )
         : undefined;
       batch.push({
-        id: stableIngestionEventId(toolSpanId, deliveryPurpose),
+        id: stableIngestionEventId(toolSpanId, deliveryPurpose, idReportTrigger),
         type: 'span-create',
         timestamp: nowIso,
         body: {
@@ -1810,7 +1835,7 @@ export function buildTracePayload(
   if (artifactsList && (artifactsList.length > 0 || artifactsTruncated)) {
     const artifactsEventId = `${ctx.run.runId}-artifacts`;
     batch.push({
-      id: stableIngestionEventId(artifactsEventId, deliveryPurpose),
+      id: stableIngestionEventId(artifactsEventId, deliveryPurpose, idReportTrigger),
       type: 'event-create',
       timestamp: nowIso,
       body: {
@@ -1843,7 +1868,7 @@ export function buildTracePayload(
   if (!success || ctx.eventsSummary.errors > 0) {
     const errorEventId = `${ctx.run.runId}-error`;
     batch.push({
-      id: stableIngestionEventId(errorEventId, deliveryPurpose),
+      id: stableIngestionEventId(errorEventId, deliveryPurpose, idReportTrigger),
       type: 'event-create',
       timestamp: nowIso,
       body: {
@@ -1867,15 +1892,22 @@ export function buildTracePayload(
 
 /**
  * Stable ingestion event id so retries reuse the same Langfuse/Vela event ids.
- * Object-registration and final deliveries use distinct suffixes so the
- * two-stage object-upload flow is not deduped.
+ * Distinct suffixes keep object-registration, terminal-fallback, and finalized
+ * final deliveries from being treated as retries of each other.
  */
 export function stableIngestionEventId(
   bodyId: string,
   deliveryPurpose: TelemetryDeliveryPurpose = 'final',
+  reportTrigger: TelemetryReportTrigger = 'final_message',
 ): string {
   const trimmed = bodyId.trim() || 'ingest-unknown';
-  const suffix = deliveryPurpose === 'object-registration' ? ':reg' : '';
+  let suffix = '';
+  if (deliveryPurpose === 'object-registration') {
+    suffix = ':reg';
+  } else if (reportTrigger === 'terminal_fallback') {
+    // Late final_message for the same run must not reuse fallback event ids.
+    suffix = ':tf';
+  }
   const candidate = `${trimmed}${suffix}`;
   if (candidate.length <= 200) return candidate;
   // Preserve uniqueness when truncating long body ids.
@@ -1886,19 +1918,24 @@ export function stableIngestionEventId(
 
 /**
  * Stable idempotency key for one complete events envelope.
- * sha256(purpose + traceId + sorted ingestion event ids), prefixed for the Vela key pattern.
+ * sha256(purpose + trigger + traceId + sorted ingestion event ids), prefixed for the Vela key pattern.
  */
 export function buildTelemetryIdempotencyKey(
   batch: Array<{ id: string }>,
   traceId: string,
   deliveryPurpose: TelemetryDeliveryPurpose = 'final',
+  reportTrigger: TelemetryReportTrigger = 'final_message',
 ): string {
   const sortedIds = batch
     .map((event) => event.id)
     .filter((id) => typeof id === 'string' && id.length > 0)
     .sort();
+  const idReportTrigger =
+    deliveryPurpose === 'object-registration' ? 'final_message' : reportTrigger;
   const digest = createHash('sha256')
-    .update(`${deliveryPurpose}\0${traceId}\0${sortedIds.join('\0')}`)
+    .update(
+      `${deliveryPurpose}\0${idReportTrigger}\0${traceId}\0${sortedIds.join('\0')}`,
+    )
     .digest('hex');
   return `od-telemetry-${digest}`;
 }
@@ -2012,11 +2049,13 @@ async function postVelaBatch(
     env?: NodeJS.ProcessEnv;
     configuredEnv?: Record<string, string>;
     deliveryPurpose?: TelemetryDeliveryPurpose;
+    reportTrigger?: TelemetryReportTrigger;
   } = {},
 ): Promise<LangfuseDeliveryState> {
   const env = opts.env ?? process.env;
   const configuredEnv = opts.configuredEnv ?? {};
   const deliveryPurpose = opts.deliveryPurpose ?? 'final';
+  const reportTrigger = opts.reportTrigger ?? 'final_message';
   const typedBatch = asLangfuseIngestionBatch(batch);
   const envelope = toVelaTelemetryEnvelope(typedBatch, installationId);
   const traceId =
@@ -2030,6 +2069,7 @@ async function postVelaBatch(
     typedBatch,
     traceId,
     deliveryPurpose,
+    reportTrigger,
   );
   const body = JSON.stringify(envelope);
   const bodyBytes = Buffer.byteLength(body, 'utf8');
@@ -2423,9 +2463,14 @@ export async function reportRunCompleted(
   }
 
   const deliveryPurpose = opts.deliveryPurpose ?? 'final';
+  const reportTrigger = opts.reportTrigger ?? 'final_message';
   let batch: unknown[];
   try {
-    batch = buildTracePayload({ ...ctx, langfuse: langfuseDelivery }, deliveryPurpose);
+    batch = buildTracePayload(
+      { ...ctx, langfuse: langfuseDelivery },
+      deliveryPurpose,
+      reportTrigger,
+    );
   } catch (error) {
     console.warn(`[langfuse-trace] Payload build error: ${String(error)}`);
     return {
@@ -2484,6 +2529,7 @@ export async function reportRunCompleted(
     return postVelaBatch(config, batch, installationId, fetchImpl, {
       configuredEnv,
       deliveryPurpose,
+      reportTrigger,
     });
   }
   if (config.kind === 'relay') {

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -283,9 +283,15 @@ const pendingRunFeedbackByRunId = new Map<string, PendingRunFeedbackEntry>();
 /**
  * True when feedback should wait for an accepted final-purpose body id.
  *
- * Defer only for failed/canceled runs that are not yet telemetry-finalized and
- * have no accepted body (process-local or persisted). Once final_message owns
- * the delivery (telemetryFinalized) or any body has been accepted, send now.
+ * Defer when no accepted body is known yet (process-local or persisted) and
+ * either:
+ * - the run failed/canceled (terminal_fallback delay window), or
+ * - the message is already telemetry-finalized (live finalization race:
+ *   createFinalizedMessageTelemetryReporter marks finalized before
+ *   reportRunCompleted / rememberAcceptedFinalTraceBodyId records the anchor).
+ *
+ * Once any body has been accepted — or the caller already pinned an explicit
+ * `traceId` — send now so scores attach to the known body/channel.
  */
 export function shouldDeferRunFeedback(input: {
   runId: string;
@@ -304,7 +310,9 @@ export function shouldDeferRunFeedback(input: {
       ? input.acceptedTraceBodyId.trim()
       : '';
   if (accepted) return false;
-  if (input.telemetryFinalized === true) return false;
+  // Finalized-without-accepted is the live finalization race, not "safe to
+  // ship on a guessed channel". Queue until rememberAcceptedFinalTraceBodyId.
+  if (input.telemetryFinalized === true) return true;
   return input.runStatus === 'failed' || input.runStatus === 'canceled';
 }
 

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -1593,12 +1593,22 @@ export function buildTracePayload(
   // Object-registration needs manifests for upload authority but must not
   // double-write turn text when the final delivery goes through Vela.
   // `wantsTextContent` gates prompt/output/tool I/O and stream-tail metadata
-  // (stderr/stdout/diagnostics); `wantsArtifacts` gates object manifests used
-  // by the worker object-scope registry.
+  // (stderr/stdout/diagnostics). Agent/runtime error strings (`error` /
+  // `statusMessage`) are additionally stripped for object-registration so the
+  // anonymous relay never receives turn/error text before final Vela delivery.
+  // `wantsArtifacts` gates object manifests used by the worker object-scope
+  // registry.
   const consentOn =
     ctx.prefs.metrics === true && ctx.prefs.content === true;
   const wantsTextContent = deliveryPurpose === 'final' && consentOn;
   const wantsArtifacts = consentOn;
+  // Keep free-text error strings on final deliveries (including content-
+  // consent-off) so Langfuse still classifies failures; omit them only from
+  // the object-registration anonymous relay pass.
+  const errorText =
+    deliveryPurpose === 'object-registration'
+      ? undefined
+      : (ctx.run.error ?? undefined);
   // Object-registration is its own logical delivery; only final deliveries
   // further split by report trigger (terminal fallback vs finalized message).
   const idReportTrigger =
@@ -1714,7 +1724,7 @@ export function buildTracePayload(
     success,
     env: readTelemetryEnvironment(),
     status: ctx.run.status,
-    error: ctx.run.error ?? undefined,
+    error: errorText,
     error_code: ctx.run.errorCode,
     langfuse_trace_id: canonicalTraceId,
     identity_type: 'anonymous_installation',
@@ -1839,7 +1849,7 @@ export function buildTracePayload(
         input: inputText,
         output: outputText,
         level: success ? 'DEFAULT' : 'ERROR',
-        statusMessage: ctx.run.error ?? undefined,
+        statusMessage: errorText,
         metadata: {
           status: ctx.run.status,
           messageId: ctx.message.messageId || undefined,
@@ -1874,7 +1884,7 @@ export function buildTracePayload(
         input: generationInput,
         output: outputText,
         level: success ? 'DEFAULT' : 'ERROR',
-        statusMessage: ctx.run.error ?? undefined,
+        statusMessage: errorText,
         usage,
         metadata: {
           durationMs: ctx.eventsSummary.durationMs,
@@ -1904,7 +1914,7 @@ export function buildTracePayload(
         input: generationInput,
         output: outputText,
         level: 'ERROR',
-        statusMessage: ctx.run.error ?? undefined,
+        statusMessage: errorText,
         metadata: {
           durationMs: ctx.eventsSummary.durationMs,
           cost_usd: costBreakdown.cost_usd,
@@ -2048,7 +2058,7 @@ export function buildTracePayload(
         name: success ? 'error-summary' : 'run-error',
         startTime: endTimeIso,
         level: 'ERROR',
-        statusMessage: ctx.run.error ?? undefined,
+        statusMessage: errorText,
         metadata: {
           status: ctx.run.status,
           errors: ctx.eventsSummary.errors,

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -331,23 +331,28 @@ export function rememberAcceptedFinalTraceBodyId(
     ...(channel ? { deliveryChannel: channel } : {}),
     ...(identity ? { velaIdentity: identity } : {}),
   });
-  // End every live-finalization wait before flushing so a concurrent clear does
-  // not double-ship the same deferred score on the canonical body. Acceptance
-  // supersedes all in-flight tokens for this run.
-  runsAwaitingFinalAcceptance.delete(key);
-  // Open the late-final re-attach window as soon as terminal_fallback wins so
-  // mid-window live re-ratings can refresh the deferred queue even when no
-  // pre-acceptance feedback was pending. final_message cancels this timer.
-  if (reportTrigger === 'terminal_fallback') {
-    schedulePendingTerminalFallbackQueueDrop(key);
-  } else if (reportTrigger === 'final_message') {
+  // final_message owns the anchor: drop every in-flight token. terminal_fallback
+  // must NOT clear unrelated tokens — a concurrent final_message attempt can
+  // still accept after TERMINAL_FALLBACK_LATE_FINAL_FEEDBACK_MS, and the drop
+  // timer re-arms while awaitingFinalAcceptanceCount > 0. Callers release their
+  // own token via clearRunAwaitingFinalAcceptance; clear skips deferred flush
+  // when an accepted body already exists, so preserving tokens cannot double-
+  // ship onto the canonical body.
+  if (reportTrigger === 'final_message') {
+    runsAwaitingFinalAcceptance.delete(key);
     cancelPendingTerminalFallbackQueueDrop(key);
+  } else if (reportTrigger === 'terminal_fallback') {
+    // Open the late-final re-attach window as soon as terminal_fallback wins so
+    // mid-window live re-ratings can refresh the deferred queue even when no
+    // pre-acceptance feedback was pending.
+    schedulePendingTerminalFallbackQueueDrop(key);
   }
   // Replay any feedback that arrived during the terminal_fallback delay (or
   // before final_message acceptance) onto the body that was actually accepted.
   // Keep the queue after terminal_fallback so a later final_message can re-
   // attach the same score to the canonical body when it wins the anchor —
-  // bounded by TERMINAL_FALLBACK_LATE_FINAL_FEEDBACK_MS for TF-only runs.
+  // bounded by TERMINAL_FALLBACK_LATE_FINAL_FEEDBACK_MS for TF-only runs, or
+  // until the last concurrent final-purpose attempt clears.
   flushPendingRunFeedback(key, acceptedBodyId, reportTrigger, channel, identity);
 }
 
@@ -457,6 +462,23 @@ function hasPendingTerminalFallbackQueueRetention(runId: string): boolean {
 }
 
 /**
+ * True while a terminal_fallback acceptance still allows late-final feedback
+ * handoff: either the bounded retention timer is armed, or a concurrent
+ * final-purpose delivery is still in flight (so a slow final_message can
+ * still re-attach the deferred score after the first 30s window).
+ */
+export function isLateFinalFeedbackHandoffOpen(runId: string): boolean {
+  const key = typeof runId === 'string' ? runId.trim() : '';
+  if (!key) return false;
+  const accepted = acceptedFinalTraceBodyIds.get(key);
+  if (!accepted || accepted.reportTrigger !== 'terminal_fallback') return false;
+  return (
+    hasPendingTerminalFallbackQueueRetention(key) ||
+    awaitingFinalAcceptanceCount(key) > 0
+  );
+}
+
+/**
  * True when feedback should wait for an accepted final-purpose body id.
  *
  * Defer only while this process still has a live final-purpose completer
@@ -563,16 +585,37 @@ function flushReportOpts(
 }
 
 /**
+ * Authoritative daemon data root for deferred-feedback consent re-checks.
+ *
+ * Prefer this over raw `process.env.OD_DATA_DIR`: server.ts resolves
+ * `RUNTIME_DATA_DIR` once at startup and does not always write it back into
+ * the environment. Wired via `configureDeferredFeedbackDataDir`.
+ */
+let deferredFeedbackDataDir: string | null = null;
+
+/**
  * Optional test override for re-reading telemetry prefs at deferred-flush time.
- * `undefined` means use the production reader (`OD_DATA_DIR` + app-config).
+ * `undefined` means use the production reader (configured data dir / app-config).
  */
 let liveTelemetryPrefsReaderForTests:
   | (() => TelemetryPrefs | null)
   | undefined;
 
 /**
+ * Pin the resolved daemon data directory used when re-reading telemetry
+ * prefs before a deferred feedback flush. Call once from server bootstrap
+ * with `RUNTIME_DATA_DIR`.
+ */
+export function configureDeferredFeedbackDataDir(
+  dataDir: string | null | undefined,
+): void {
+  const trimmed = typeof dataDir === 'string' ? dataDir.trim() : '';
+  deferredFeedbackDataDir = trimmed || null;
+}
+
+/**
  * Test-only: inject live telemetry prefs for deferred feedback flush gates.
- * Pass `undefined` to restore the production `OD_DATA_DIR` reader.
+ * Pass `undefined` to restore the production data-dir reader.
  */
 export function setLiveTelemetryPrefsReaderForTests(
   reader: (() => TelemetryPrefs | null) | undefined,
@@ -583,17 +626,24 @@ export function setLiveTelemetryPrefsReaderForTests(
 /**
  * Re-read current telemetry prefs for a deferred feedback flush.
  *
- * Production uses the same sync app-config path as spawn-env consent checks
- * (`OD_DATA_DIR` + `readAppConfigSync`). When no data dir is available (unit
- * tests that never set one), returns null so the caller can fall back to the
- * queued snapshot.
+ * Production uses the configured daemon data root (`configureDeferredFeedbackDataDir`
+ * / `RUNTIME_DATA_DIR`) with `readAppConfigSync`, falling back to
+ * `process.env.OD_DATA_DIR` only when the configured root was never set.
+ * When no data dir is available or config is unreadable, fail closed
+ * (metrics/content off) so a mid-window opt-out cannot be skipped by falling
+ * back to the queued submit-time snapshot.
  */
-function readLiveTelemetryPrefsForFlush(): TelemetryPrefs | null {
+function readLiveTelemetryPrefsForFlush(): TelemetryPrefs {
   if (liveTelemetryPrefsReaderForTests !== undefined) {
-    return liveTelemetryPrefsReaderForTests();
+    const injected = liveTelemetryPrefsReaderForTests();
+    // Treat a null test injection as fail-closed (same as missing data dir).
+    return injected ?? { metrics: false, content: false };
   }
-  const dataDir = process.env.OD_DATA_DIR?.trim();
-  if (!dataDir) return null;
+  const dataDir =
+    deferredFeedbackDataDir ?? process.env.OD_DATA_DIR?.trim() ?? '';
+  if (!dataDir) {
+    return { metrics: false, content: false };
+  }
   try {
     const cfg = readAppConfigSync(dataDir);
     return cfg.telemetry ?? {};
@@ -610,19 +660,19 @@ function readLiveTelemetryPrefsForFlush(): TelemetryPrefs | null {
  * terminal-fallback / late-final window; re-check live prefs before the
  * network send so a revoked opt-in does not leak custom reasons. Returns
  * null when current consent is off (caller must drop without sending).
+ * Live prefs always win — never fall back to the queued snapshot.
  */
 function prefsForDeferredFeedbackFlush(
-  queued: TelemetryPrefs,
+  _queued: TelemetryPrefs,
 ): TelemetryPrefs | null {
-  let live: TelemetryPrefs | null;
+  let live: TelemetryPrefs;
   try {
     live = readLiveTelemetryPrefsForFlush();
   } catch {
     return null;
   }
-  const effective = live ?? queued;
-  if (effective.metrics !== true || effective.content !== true) return null;
-  return effective;
+  if (live.metrics !== true || live.content !== true) return null;
+  return live;
 }
 
 function flushPendingRunFeedback(
@@ -688,6 +738,7 @@ export function resetPendingRunFeedbackForTests(): void {
   runsAwaitingFinalAcceptance.clear();
   awaitingFinalAcceptanceTokenSeq = 0;
   liveTelemetryPrefsReaderForTests = undefined;
+  deferredFeedbackDataDir = null;
 }
 
 /** Test-only: whether deferred feedback is still queued for a run. */
@@ -3513,18 +3564,12 @@ export async function reportRunFeedback(
           : getAcceptedFinalVelaIdentity(ctx.runId))
       : null;
   const config = resolveReportConfig(opts, requireChannel);
-  // Same eligibility as reportRunFeedbackFromDaemon preflight: exact channel
-  // match when an accepted anchor exists; Vela also needs installationId +
-  // matching accepting-account fingerprint when known.
-  if (!canDeliverRunFeedback(config, ctx.installationId, process.env, {
-    requireChannel,
-    requireVelaIdentity,
-  })) {
-    return;
-  }
 
   // Failed/canceled runs may still be waiting on terminal_fallback acceptance.
   // Queue until rememberAcceptedFinalTraceBodyId flushes onto the accepted body.
+  // Do this before the sticky-sink delivery gate so a mid-window re-rate that
+  // cannot deliver on the old accepted channel still refreshes the deferred
+  // queue for a later final_message (e.g. after an AMR profile switch).
   if (
     shouldDeferRunFeedback({
       runId: ctx.runId,
@@ -3540,8 +3585,11 @@ export async function reportRunFeedback(
   }
 
   // After terminal_fallback is accepted, live re-ratings ship immediately onto
-  // `:tf` but must also refresh the deferred queue so a later final_message
-  // re-attach uses the latest score (not a stale pre-fallback rating).
+  // `:tf` when the sticky sink can still deliver, but must also refresh the
+  // deferred queue so a later final_message re-attach uses the latest score
+  // (not a stale pre-fallback rating). Refresh even when the immediate send is
+  // suppressed (Vela account switched / logged out) — only the network path is
+  // gated by canDeliverRunFeedback below.
   // The bridge pins an explicit `:tf` body id once the DB/process anchor is
   // accepted, so we must refresh even when `traceId` is present — otherwise
   // mid-window re-ratings leave the queue on a stale pre-fallback payload.
@@ -3550,18 +3598,8 @@ export async function reportRunFeedback(
   // with no completer to clear them. final_message flush deletes the queue
   // before shipping, so it never re-enters here after the canonical body wins.
   const runKey = typeof ctx.runId === 'string' ? ctx.runId.trim() : '';
-  const acceptedTrigger =
-    acceptedFinalTraceBodyIds.get(runKey)?.reportTrigger ??
-    (ctx.acceptedReportTrigger === 'terminal_fallback' ||
-    ctx.acceptedReportTrigger === 'final_message'
-      ? ctx.acceptedReportTrigger
-      : null);
-  if (
-    runKey &&
-    acceptedTrigger === 'terminal_fallback' &&
-    (hasPendingTerminalFallbackQueueRetention(runKey) ||
-      awaitingFinalAcceptanceCount(runKey) > 0)
-  ) {
+  const lateFinalOpen = isLateFinalFeedbackHandoffOpen(runKey);
+  if (lateFinalOpen) {
     // Keep the deferred entry unpinned so final_message flush can re-target
     // the canonical body via rememberAcceptedFinalTraceBodyId.
     const { traceId: _pinnedTraceId, ...unpinnedCtx } = ctx;
@@ -3569,6 +3607,17 @@ export async function reportRunFeedback(
     // Ensure a drop is scheduled when retention came only from an in-flight
     // final attempt (no prior TF flush scheduled a timer yet).
     schedulePendingTerminalFallbackQueueDrop(runKey);
+  }
+
+  // Same eligibility as reportRunFeedbackFromDaemon preflight: exact channel
+  // match when an accepted anchor exists; Vela also needs installationId +
+  // matching accepting-account fingerprint when known. Applies only to the
+  // immediate network send — deferred queue refresh above already ran.
+  if (!canDeliverRunFeedback(config, ctx.installationId, process.env, {
+    requireChannel,
+    requireVelaIdentity,
+  })) {
+    return;
   }
 
   let batch: unknown[];

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -1,11 +1,13 @@
 // Langfuse trace forwarding for completed agent runs.
 //
 // This module is intentionally dependency-free (no `langfuse` SDK). It builds
-// Langfuse ingestion batches for completed runs and sends them either to the
-// official Open Design telemetry relay or, for local smoke tests, directly to
-// Langfuse. Without OPEN_DESIGN_TELEMETRY_RELAY_URL or LANGFUSE_PUBLIC_KEY /
-// LANGFUSE_SECRET_KEY in the env, every entry point becomes a no-op so that
-// dev runs and forks of this open-source repo do not accidentally report.
+// Langfuse ingestion batches for completed runs and sends them either through
+// the Vela authenticated telemetry entry (when a Control Key is present), the
+// official Open Design telemetry relay (anonymous installation identity), or,
+// for local smoke tests, directly to Langfuse. Without a Vela Control Key,
+// OPEN_DESIGN_TELEMETRY_RELAY_URL, or LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY
+// in the env, every entry point becomes a no-op so that dev runs and forks of
+// this open-source repo do not accidentally report.
 //
 // Privacy gates are layered: `prefs.metrics` is the master switch, and
 // `prefs.content` is required for Langfuse traces because this sink is used
@@ -14,11 +16,21 @@
 // content are both enabled, Langfuse receives the trace and associated object
 // references. If either is off, no network call is made.
 //
+// Identity trust boundary:
+// - daemon submits installationId + redacted batch only
+// - Vela server injects app_user_id / email from Control Key auth
+// - anonymous path keeps userId = installationId and never claims app identity
+//
 // See: specs/change/20260507-langfuse-telemetry/spec.md
+// See: docs/LANGFUSE_VELA_ACCOUNT_INTEGRATION_PLAN.md (open-design-evals)
 
-import { randomUUID } from 'node:crypto';
+import { createHash } from 'node:crypto';
 
 import type { TelemetryPrefs } from './app-config.js';
+import {
+  forgetVelaLogin,
+  readVelaControlApiContext,
+} from './integrations/vela.js';
 import {
   buildPromptStackFlatMetadata,
   promptStackWithoutContent,
@@ -74,6 +86,12 @@ export type LangfuseDropReason =
   | 'relay_5xx'
   | 'langfuse_4xx'
   | 'langfuse_5xx'
+  | 'vela_400'
+  | 'vela_401'
+  | 'vela_403'
+  | 'vela_413'
+  | 'vela_429'
+  | 'vela_5xx'
   | 'network_error';
 
 export interface LangfuseDeliveryState {
@@ -82,7 +100,7 @@ export interface LangfuseDeliveryState {
   langfuse_drop_reason?: LangfuseDropReason;
 }
 
-export type TelemetrySinkConfig =
+export type AnonymousTelemetrySinkConfig =
   | {
       kind: 'relay';
       relayUrl: string;
@@ -92,6 +110,56 @@ export type TelemetrySinkConfig =
   | ({
       kind: 'langfuse';
     } & LangfuseConfig);
+
+export type TelemetryDeliveryPurpose = 'object-registration' | 'final';
+
+export type TelemetrySinkConfig =
+  | {
+      kind: 'vela';
+      apiUrl: string;
+      controlKey: string;
+      timeoutMs: number;
+      retries: number;
+      /** AMR profile used to resolve this sink (for stale-auth cleanup). */
+      profile: string;
+      /** Whether the Control Key came from process/app env or ~/.amr config. */
+      authSource: 'env' | 'file';
+      /**
+       * When true, a 401/403 may clear the matching local file login.
+       * Explicit test/config sinks leave this false so they cannot log out
+       * an unrelated real account.
+       */
+      clearLoginOnAuthFailure: boolean;
+    }
+  | AnonymousTelemetrySinkConfig;
+
+const LANGFUSE_TYPE_TO_ENVELOPE_KIND = {
+  'trace-create': 'trace',
+  'span-create': 'span',
+  'generation-create': 'generation',
+  'event-create': 'event',
+  'score-create': 'score',
+} as const;
+
+type LangfuseIngestionType = keyof typeof LANGFUSE_TYPE_TO_ENVELOPE_KIND;
+
+interface LangfuseIngestionEvent {
+  id: string;
+  type: LangfuseIngestionType;
+  timestamp: string;
+  body: Record<string, unknown>;
+}
+
+export interface VelaTelemetryEnvelope {
+  version: 1;
+  installationId: string;
+  events: Array<{
+    id: string;
+    kind: (typeof LANGFUSE_TYPE_TO_ENVELOPE_KIND)[LangfuseIngestionType];
+    timestamp: string;
+    data: Record<string, unknown>;
+  }>;
+}
 
 export interface RunSummary {
   runId: string;
@@ -312,6 +380,19 @@ export interface ReportContext {
 export interface ReportRunOpts {
   config?: TelemetrySinkConfig | LangfuseConfig | null;
   fetchImpl?: typeof fetch;
+  /**
+   * Distinguishes the pre-upload object-scope registration pass from the
+   * final delivery. Registration keeps original run IDs on the anonymous
+   * relay (object authority is keyed by installation + original runId) and
+   * uses distinct stable ingestion event IDs so the final batch is not
+   * deduped.
+   */
+  deliveryPurpose?: TelemetryDeliveryPurpose;
+  /**
+   * App-config AMR env (`agentCliEnv.amr`), e.g. OPEN_DESIGN_AMR_PROFILE /
+   * VELA_API_URL. Merged into Vela Control Key resolution.
+   */
+  configuredEnv?: Record<string, string>;
 }
 
 /**
@@ -361,31 +442,91 @@ export function readLangfuseConfig(
   };
 }
 
+function isVelaTelemetryEnabled(env: NodeJS.ProcessEnv): boolean {
+  const raw = env.OPEN_DESIGN_VELA_TELEMETRY?.trim().toLowerCase();
+  if (!raw) return true;
+  return raw !== '0' && raw !== 'false' && raw !== 'off' && raw !== 'no';
+}
+
+function readTelemetryTimeoutMs(env: NodeJS.ProcessEnv): number {
+  return parsePositiveInt(
+    env.OPEN_DESIGN_TELEMETRY_TIMEOUT_MS ?? env.LANGFUSE_TIMEOUT_MS,
+    DEFAULT_FETCH_TIMEOUT_MS,
+  );
+}
+
+function readTelemetryRetries(env: NodeJS.ProcessEnv): number {
+  return parseNonNegativeInt(
+    env.OPEN_DESIGN_TELEMETRY_RETRIES ?? env.LANGFUSE_RETRIES,
+    DEFAULT_FETCH_RETRIES,
+  );
+}
+
 /**
- * Resolve telemetry delivery in release-safe order: hosted relay first,
- * direct Langfuse credentials second for local smoke tests, disabled last.
+ * Anonymous sinks only: hosted relay first, direct Langfuse second.
+ * Used when no Vela Control Key is available, and as the 401/403 fallback.
  */
-export function readTelemetrySinkConfig(
+export function readAnonymousTelemetrySinkConfig(
   env: NodeJS.ProcessEnv = process.env,
-): TelemetrySinkConfig | null {
+): AnonymousTelemetrySinkConfig | null {
   const relayUrl = env.OPEN_DESIGN_TELEMETRY_RELAY_URL?.trim();
   if (relayUrl) {
     return {
       kind: 'relay',
       relayUrl: relayUrl.replace(/\/+$/, ''),
-      timeoutMs: parsePositiveInt(
-        env.OPEN_DESIGN_TELEMETRY_TIMEOUT_MS ?? env.LANGFUSE_TIMEOUT_MS,
-        DEFAULT_FETCH_TIMEOUT_MS,
-      ),
-      retries: parseNonNegativeInt(
-        env.OPEN_DESIGN_TELEMETRY_RETRIES ?? env.LANGFUSE_RETRIES,
-        DEFAULT_FETCH_RETRIES,
-      ),
+      timeoutMs: readTelemetryTimeoutMs(env),
+      retries: readTelemetryRetries(env),
     };
   }
 
   const config = readLangfuseConfig(env);
   return config == null ? null : { kind: 'langfuse', ...config };
+}
+
+function readVelaTelemetrySinkConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  configuredEnv: Record<string, string> = {},
+): Extract<TelemetrySinkConfig, { kind: 'vela' }> | null {
+  if (!isVelaTelemetryEnabled(env)) return null;
+  const mergedForAuthSource = { ...env, ...configuredEnv };
+  const envControlKey = mergedForAuthSource.VELA_CONTROL_KEY?.trim() ?? '';
+  const authSource: 'env' | 'file' = envControlKey ? 'env' : 'file';
+  const context = readVelaControlApiContext(env, configuredEnv);
+  const controlKey = context?.controlKey?.trim() ?? '';
+  if (!controlKey) return null;
+  const apiUrl = (context?.apiUrl?.trim() || 'https://amr-api.open-design.ai').replace(
+    /\/+$/,
+    '',
+  );
+  return {
+    kind: 'vela',
+    apiUrl,
+    controlKey,
+    timeoutMs: readTelemetryTimeoutMs(env),
+    retries: readTelemetryRetries(env),
+    profile: context.profile,
+    authSource,
+    // Only file-backed logins can be cleared, and only when we resolved the
+    // live sink ourselves (not an explicit test/config override).
+    clearLoginOnAuthFailure: authSource === 'file',
+  };
+}
+
+/**
+ * Resolve telemetry delivery in release-safe order:
+ * 1. Vela authenticated sink when a Control Key is present
+ * 2. hosted anonymous relay
+ * 3. direct Langfuse credentials for local smoke tests
+ * 4. disabled
+ */
+export function readTelemetrySinkConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  configuredEnv: Record<string, string> = {},
+): TelemetrySinkConfig | null {
+  return (
+    readVelaTelemetrySinkConfig(env, configuredEnv) ??
+    readAnonymousTelemetrySinkConfig(env)
+  );
 }
 
 export function deriveLangfuseDeliveryState(
@@ -1258,9 +1399,18 @@ function shouldCreateGenerationObservation(ctx: ReportContext): boolean {
   return ctx.run.failure?.failure_stage !== 'session_init';
 }
 
-export function buildTracePayload(ctx: ReportContext): unknown[] {
-  const wantsContent = ctx.prefs.metrics === true && ctx.prefs.content === true;
-  const wantsArtifacts = wantsContent;
+export function buildTracePayload(
+  ctx: ReportContext,
+  deliveryPurpose: TelemetryDeliveryPurpose = 'final',
+): unknown[] {
+  // Object-registration needs manifests for upload authority but must not
+  // double-write turn text when the final delivery goes through Vela.
+  // `wantsTextContent` gates prompt/output/tool I/O; `wantsArtifacts` gates
+  // object manifests used by the worker object-scope registry.
+  const consentOn =
+    ctx.prefs.metrics === true && ctx.prefs.content === true;
+  const wantsTextContent = deliveryPurpose === 'final' && consentOn;
+  const wantsArtifacts = consentOn;
 
   const sessionId =
     ctx.conversationId.length <= SESSION_ID_MAX ? ctx.conversationId : undefined;
@@ -1269,10 +1419,10 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
   const endTimeIso = new Date(ctx.run.endedAt).toISOString();
   const nowIso = new Date().toISOString();
 
-  const inputText = wantsContent
+  const inputText = wantsTextContent
     ? truncate(ctx.message.prompt, INPUT_MAX_BYTES)
     : undefined;
-  const outputText = wantsContent
+  const outputText = wantsTextContent
     ? truncate(redactArtifactBlocks(ctx.message.output), OUTPUT_MAX_BYTES)
     : undefined;
 
@@ -1295,10 +1445,10 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
   const artifactManifestTruncated = wantsArtifacts
     ? manifestTruncated(ctx.artifactManifest)
     : undefined;
-  const inputTextSnapshotManifest = wantsArtifacts && wantsContent
+  const inputTextSnapshotManifest = wantsArtifacts
     ? cappedManifestEntries(ctx.inputTextSnapshotManifest)
     : undefined;
-  const inputTextSnapshotManifestTruncated = wantsArtifacts && wantsContent
+  const inputTextSnapshotManifestTruncated = wantsArtifacts
     ? manifestTruncated(ctx.inputTextSnapshotManifest)
     : undefined;
 
@@ -1340,7 +1490,7 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
     ? generationId
     : `${ctx.run.runId}-runtime`;
   const promptStack = ctx.promptTelemetry
-    ? wantsContent
+    ? wantsTextContent
       ? ctx.promptTelemetry
       : promptStackWithoutContent(ctx.promptTelemetry)
     : undefined;
@@ -1359,7 +1509,9 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
   // Trace metadata is the queryable + exportable fact-sheet for each turn.
   // Anything we want to slice on for evals or dataset construction lives
   // here. Fields are flat (Langfuse stores it as JSON but indexes shallow
-  // keys best). All entries are anonymous — no PII, no credentials.
+  // keys best). Daemon only asserts installation identity; Vela overwrites
+  // identity_type / app_user_id / user_email for authenticated deliveries.
+  // Never put client-claimed email or app_user_id here as trusted identity.
   const traceMetadata: Record<string, unknown> = {
     success,
     env: readTelemetryEnvironment(),
@@ -1367,6 +1519,8 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
     error: ctx.run.error ?? undefined,
     error_code: ctx.run.errorCode,
     langfuse_trace_id: traceId,
+    identity_type: 'anonymous_installation',
+    installation_id: ctx.installationId ?? undefined,
     ...langfuseDelivery,
     ...(ctx.run.failure ?? {}),
     ...(ctx.run.timings ?? {}),
@@ -1432,25 +1586,30 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
     : agentSpanId;
   const agentEventParentObservationId = toolParentObservationId;
 
-  const batch: unknown[] = [
+  const batch: LangfuseIngestionEvent[] = [
     {
-      id: randomUUID(),
+      id: stableIngestionEventId(traceId, deliveryPurpose),
       type: 'trace-create',
       timestamp: nowIso,
       body: {
         id: traceId,
         name: 'open-design-turn',
         sessionId,
+        // Anonymous / pre-auth identity. Vela overwrites userId for
+        // authenticated deliveries; never send client-claimed app ids here.
         userId: ctx.installationId ?? undefined,
         tags: buildTagList(ctx),
         input: inputText,
         output: outputText,
-        metadata: traceMetadata,
+        metadata: {
+          ...traceMetadata,
+          telemetry_delivery_purpose: deliveryPurpose,
+        },
         timestamp: startTimeIso,
       },
     },
     {
-      id: randomUUID(),
+      id: stableIngestionEventId(agentSpanId, deliveryPurpose),
       type: 'span-create',
       timestamp: nowIso,
       body: {
@@ -1479,7 +1638,7 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
 
   if (createGeneration) {
     batch.push({
-      id: randomUUID(),
+      id: stableIngestionEventId(generationId, deliveryPurpose),
       type: 'generation-create',
       timestamp: nowIso,
       body: {
@@ -1514,7 +1673,7 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
     });
   } else {
     batch.push({
-      id: randomUUID(),
+      id: stableIngestionEventId(operationSpanId, deliveryPurpose),
       type: 'span-create',
       timestamp: nowIso,
       body: {
@@ -1545,8 +1704,9 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
   }
 
   for (const span of timingSpanBodies) {
+    const spanId = typeof span.id === 'string' ? span.id : `${traceId}-phase`;
     batch.push({
-      id: randomUUID(),
+      id: stableIngestionEventId(spanId, deliveryPurpose),
       type: 'span-create',
       timestamp: nowIso,
       body: span,
@@ -1555,12 +1715,13 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
 
   if (ctx.agentEvents?.length) {
     for (const event of ctx.agentEvents) {
+      const eventBodyId = `${ctx.run.runId}-agent-event-${event.id}`;
       batch.push({
-        id: randomUUID(),
+        id: stableIngestionEventId(eventBodyId, deliveryPurpose),
         type: 'event-create',
         timestamp: nowIso,
         body: {
-          id: `${ctx.run.runId}-agent-event-${event.id}`,
+          id: eventBodyId,
           traceId,
           parentObservationId: agentEventParentObservationId,
           name: event.name,
@@ -1581,20 +1742,20 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
       const toolStartedAt = new Date(tool.startedAt).toISOString();
       const toolEndedAt = new Date(tool.endedAt).toISOString();
       const toolDurationMs = durationMs(tool.startedAt, tool.endedAt);
-      const toolInput = wantsContent
+      const toolInput = wantsTextContent
         ? truncate(
             traceSafeToolPayload(tool.name, 'input', tool.input),
             TOOL_INPUT_MAX_BYTES,
           )
         : undefined;
-      const toolOutput = wantsContent
+      const toolOutput = wantsTextContent
         ? truncate(
             traceSafeToolPayload(tool.name, 'output', tool.output),
             TOOL_OUTPUT_MAX_BYTES,
           )
         : undefined;
       batch.push({
-        id: randomUUID(),
+        id: stableIngestionEventId(toolSpanId, deliveryPurpose),
         type: 'span-create',
         timestamp: nowIso,
         body: {
@@ -1624,12 +1785,13 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
   }
 
   if (artifactsList && (artifactsList.length > 0 || artifactsTruncated)) {
+    const artifactsEventId = `${ctx.run.runId}-artifacts`;
     batch.push({
-      id: randomUUID(),
+      id: stableIngestionEventId(artifactsEventId, deliveryPurpose),
       type: 'event-create',
       timestamp: nowIso,
       body: {
-        id: `${ctx.run.runId}-artifacts`,
+        id: artifactsEventId,
         traceId,
         parentObservationId: agentSpanId,
         name: 'artifact-summary',
@@ -1656,12 +1818,13 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
   }
 
   if (!success || ctx.eventsSummary.errors > 0) {
+    const errorEventId = `${ctx.run.runId}-error`;
     batch.push({
-      id: randomUUID(),
+      id: stableIngestionEventId(errorEventId, deliveryPurpose),
       type: 'event-create',
       timestamp: nowIso,
       body: {
-        id: `${ctx.run.runId}-error`,
+        id: errorEventId,
         traceId,
         parentObservationId: agentSpanId,
         name: success ? 'error-summary' : 'run-error',
@@ -1677,6 +1840,283 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
   }
 
   return batch;
+}
+
+/**
+ * Stable ingestion event id so retries reuse the same Langfuse/Vela event ids.
+ * Object-registration and final deliveries use distinct suffixes so the
+ * two-stage object-upload flow is not deduped.
+ */
+export function stableIngestionEventId(
+  bodyId: string,
+  deliveryPurpose: TelemetryDeliveryPurpose = 'final',
+): string {
+  const trimmed = bodyId.trim() || 'ingest-unknown';
+  const suffix = deliveryPurpose === 'object-registration' ? ':reg' : '';
+  const candidate = `${trimmed}${suffix}`;
+  if (candidate.length <= 200) return candidate;
+  // Preserve uniqueness when truncating long body ids.
+  const digest = createHash('sha256').update(candidate).digest('hex').slice(0, 16);
+  const keep = 200 - 1 - digest.length;
+  return `${candidate.slice(0, Math.max(1, keep))}-${digest}`;
+}
+
+/**
+ * Stable idempotency key for one complete events envelope.
+ * sha256(purpose + traceId + sorted ingestion event ids), prefixed for the Vela key pattern.
+ */
+export function buildTelemetryIdempotencyKey(
+  batch: Array<{ id: string }>,
+  traceId: string,
+  deliveryPurpose: TelemetryDeliveryPurpose = 'final',
+): string {
+  const sortedIds = batch
+    .map((event) => event.id)
+    .filter((id) => typeof id === 'string' && id.length > 0)
+    .sort();
+  const digest = createHash('sha256')
+    .update(`${deliveryPurpose}\0${traceId}\0${sortedIds.join('\0')}`)
+    .digest('hex');
+  return `od-telemetry-${digest}`;
+}
+
+function classifyFetchError(error: unknown): 'timeout' | 'network_error' {
+  if (!error || typeof error !== 'object') return 'network_error';
+  const name = 'name' in error ? String((error as { name?: unknown }).name ?? '') : '';
+  if (name === 'TimeoutError' || name === 'AbortError') return 'timeout';
+  const message =
+    'message' in error ? String((error as { message?: unknown }).message ?? '') : '';
+  if (/timeout|aborted|AbortError/i.test(message)) return 'timeout';
+  return 'network_error';
+}
+
+/**
+ * Clear local login only when the failed request still matches the currently
+ * stored file-backed Control Key for the same profile. Prevents a late 401
+ * from account A from logging out account B after a switch.
+ */
+function maybeForgetVelaLoginOnAuthFailure(
+  config: Extract<TelemetrySinkConfig, { kind: 'vela' }>,
+  env: NodeJS.ProcessEnv,
+  configuredEnv: Record<string, string>,
+): void {
+  if (!config.clearLoginOnAuthFailure) return;
+  if (config.authSource !== 'file') return;
+  try {
+    const current = readVelaControlApiContext(env, configuredEnv);
+    if (!current) return;
+    if (current.profile !== config.profile) return;
+    if (current.controlKey !== config.controlKey) return;
+    // Pass profile selection through env so forgetVelaLogin targets the same profile.
+    const profileEnv: NodeJS.ProcessEnv = {
+      ...env,
+      ...configuredEnv,
+      OPEN_DESIGN_AMR_PROFILE: config.profile,
+    };
+    forgetVelaLogin(profileEnv);
+  } catch {
+    // Best-effort cleanup only.
+  }
+}
+
+/** Convert a Langfuse ingestion batch into the vendor-neutral Vela envelope. */
+export function toVelaTelemetryEnvelope(
+  batch: unknown[],
+  installationId: string,
+): VelaTelemetryEnvelope {
+  const events: VelaTelemetryEnvelope['events'] = [];
+  for (const item of batch) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
+    const event = item as Partial<LangfuseIngestionEvent>;
+    if (typeof event.id !== 'string' || !event.id.trim()) continue;
+    if (typeof event.type !== 'string') continue;
+    if (!(event.type in LANGFUSE_TYPE_TO_ENVELOPE_KIND)) continue;
+    if (typeof event.timestamp !== 'string' || !event.timestamp.trim()) continue;
+    if (!event.body || typeof event.body !== 'object' || Array.isArray(event.body)) {
+      continue;
+    }
+    events.push({
+      id: stableIngestionEventId(event.id),
+      kind: LANGFUSE_TYPE_TO_ENVELOPE_KIND[event.type as LangfuseIngestionType],
+      timestamp: event.timestamp,
+      data: event.body,
+    });
+  }
+  if (events.length === 0) {
+    throw new Error('vela telemetry envelope has no convertible events');
+  }
+  return {
+    version: 1,
+    installationId,
+    events,
+  };
+}
+
+function asLangfuseIngestionBatch(batch: unknown[]): LangfuseIngestionEvent[] {
+  return batch.filter((item): item is LangfuseIngestionEvent => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) return false;
+    const event = item as Partial<LangfuseIngestionEvent>;
+    return (
+      typeof event.id === 'string' &&
+      typeof event.type === 'string' &&
+      event.type in LANGFUSE_TYPE_TO_ENVELOPE_KIND &&
+      typeof event.timestamp === 'string' &&
+      !!event.body &&
+      typeof event.body === 'object' &&
+      !Array.isArray(event.body)
+    );
+  });
+}
+
+async function postAnonymousBatch(
+  config: AnonymousTelemetrySinkConfig,
+  batch: unknown[],
+  serializedLangfuseBody: string,
+  fetchImpl: typeof fetch,
+): Promise<LangfuseDeliveryState> {
+  if (config.kind === 'relay') {
+    return postRelayBatch(config, serializedLangfuseBody, fetchImpl);
+  }
+  return postLangfuseBatch(config, batch, fetchImpl);
+}
+
+async function postVelaBatch(
+  config: Extract<TelemetrySinkConfig, { kind: 'vela' }>,
+  batch: unknown[],
+  installationId: string,
+  fetchImpl: typeof fetch,
+  opts: {
+    env?: NodeJS.ProcessEnv;
+    configuredEnv?: Record<string, string>;
+    deliveryPurpose?: TelemetryDeliveryPurpose;
+  } = {},
+): Promise<LangfuseDeliveryState> {
+  const env = opts.env ?? process.env;
+  const configuredEnv = opts.configuredEnv ?? {};
+  const deliveryPurpose = opts.deliveryPurpose ?? 'final';
+  const typedBatch = asLangfuseIngestionBatch(batch);
+  const envelope = toVelaTelemetryEnvelope(typedBatch, installationId);
+  const traceId =
+    typeof typedBatch.find((event) => event.type === 'trace-create')?.body.id ===
+    'string'
+      ? String(typedBatch.find((event) => event.type === 'trace-create')!.body.id)
+      : typedBatch[0]?.body.id
+        ? String(typedBatch[0].body.id)
+        : typedBatch[0]?.id ?? 'unknown-trace';
+  const idempotencyKey = buildTelemetryIdempotencyKey(
+    typedBatch,
+    traceId,
+    deliveryPurpose,
+  );
+  const body = JSON.stringify(envelope);
+  const bodyBytes = Buffer.byteLength(body, 'utf8');
+  if (bodyBytes > HARD_BATCH_MAX_BYTES) {
+    console.warn(
+      `[langfuse-trace] Vela telemetry envelope too large (${bodyBytes}B > ${HARD_BATCH_MAX_BYTES}B)`,
+    );
+    return {
+      langfuse_expected: true,
+      langfuse_delivery_status: 'failed',
+      langfuse_drop_reason: 'payload_too_large',
+    };
+  }
+  const attempts = config.retries + 1;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const response = await fetchImpl(
+        `${config.apiUrl}/api/v1/open-design/telemetry`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${config.controlKey}`,
+            'Content-Type': 'application/json',
+            'Idempotency-Key': idempotencyKey,
+          },
+          signal: AbortSignal.timeout(config.timeoutMs),
+          body,
+        },
+      );
+
+      // Vela contract is 202 Accepted. Do not treat other 2xx as success.
+      if (response.status === 202) {
+        return {
+          langfuse_expected: true,
+          langfuse_delivery_status: 'accepted',
+        };
+      }
+
+      // Drain body without logging it (may contain reflected payload / PII).
+      await response.text().catch(() => '');
+
+      // Auth failures: optionally clear matching local login and allow a
+      // one-shot anonymous fallback. Do not anonymous-fallback on 400 / 429 /
+      // 5xx / timeout — that can overwrite an authenticated identity if Vela
+      // already accepted the batch.
+      if (response.status === 401 || response.status === 403) {
+        maybeForgetVelaLoginOnAuthFailure(config, env, configuredEnv);
+        console.warn(
+          `[langfuse-trace] Vela telemetry auth failed status=${response.status}; falling back to anonymous sink`,
+        );
+        const fallback = readAnonymousTelemetrySinkConfig(env);
+        if (!fallback) {
+          return {
+            langfuse_expected: true,
+            langfuse_delivery_status: 'failed',
+            langfuse_drop_reason: response.status === 401 ? 'vela_401' : 'vela_403',
+          };
+        }
+        const serialized = JSON.stringify({ batch });
+        return postAnonymousBatch(fallback, batch, serialized, fetchImpl);
+      }
+
+      if (response.status === 400) {
+        console.warn('[langfuse-trace] Vela telemetry rejected payload status=400');
+        return {
+          langfuse_expected: true,
+          langfuse_delivery_status: 'failed',
+          langfuse_drop_reason: 'vela_400',
+        };
+      }
+
+      if (
+        attempt < attempts &&
+        (response.status === 429 || response.status >= 500)
+      ) {
+        await waitBeforeRetry(attempt);
+        continue;
+      }
+
+      console.warn(
+        `[langfuse-trace] Vela telemetry failed status=${response.status}`,
+      );
+      return {
+        langfuse_expected: true,
+        langfuse_delivery_status: 'failed',
+        langfuse_drop_reason: ingestionDropReasonFromStatus(response.status, 'vela'),
+      };
+    } catch (error) {
+      if (attempt < attempts) {
+        await waitBeforeRetry(attempt);
+        continue;
+      }
+      // Network/timeout after retries: do NOT anonymous-fallback. Vela may have
+      // already accepted the batch; anonymous write could overwrite identity.
+      const errorKind = classifyFetchError(error);
+      console.warn(`[langfuse-trace] Vela telemetry fetch error: ${errorKind}`);
+      return {
+        langfuse_expected: true,
+        langfuse_delivery_status: 'failed',
+        langfuse_drop_reason: 'network_error',
+      };
+    }
+  }
+
+  return {
+    langfuse_expected: true,
+    langfuse_delivery_status: 'failed',
+    langfuse_drop_reason: 'network_error',
+  };
 }
 
 async function postLangfuseBatch(
@@ -1840,14 +2280,27 @@ function waitBeforeRetry(attempt: number): Promise<void> {
 function normalizeTelemetrySinkConfig(
   config: TelemetrySinkConfig | LangfuseConfig,
 ): TelemetrySinkConfig {
-  if ('kind' in config) return config;
+  if ('kind' in config) {
+    if (config.kind === 'vela') {
+      return {
+        ...config,
+        profile: config.profile || 'prod',
+        authSource: config.authSource ?? 'env',
+        // Explicit sinks never clear an unrelated local login by default.
+        clearLoginOnAuthFailure: config.clearLoginOnAuthFailure ?? false,
+      };
+    }
+    return config;
+  }
   return { kind: 'langfuse', ...config };
 }
 
 function resolveReportConfig(
   opts: ReportRunOpts,
 ): TelemetrySinkConfig | null {
-  if (opts.config === undefined) return readTelemetrySinkConfig();
+  if (opts.config === undefined) {
+    return readTelemetrySinkConfig(process.env, opts.configuredEnv ?? {});
+  }
   if (opts.config == null) return null;
   return normalizeTelemetrySinkConfig(opts.config);
 }
@@ -1856,6 +2309,15 @@ function ingestionDropReasonFromStatus(
   status: number,
   sinkKind: TelemetrySinkConfig['kind'],
 ): LangfuseDropReason {
+  if (sinkKind === 'vela') {
+    if (status === 401) return 'vela_401';
+    if (status === 403) return 'vela_403';
+    if (status === 400) return 'vela_400';
+    if (status === 413) return 'vela_413';
+    if (status === 429) return 'vela_429';
+    if (status >= 500) return 'vela_5xx';
+    return 'vela_400';
+  }
   if (sinkKind === 'relay') {
     if (status === 429) return 'relay_429';
     if (status === 413) return 'relay_413';
@@ -1868,7 +2330,7 @@ function ingestionDropReasonFromStatus(
 
 function dropReasonFromPerEventErrors(
   responseBody: string,
-  sinkKind: TelemetrySinkConfig['kind'],
+  sinkKind: Exclude<TelemetrySinkConfig['kind'], 'vela'>,
 ): LangfuseDropReason {
   let parsed: unknown;
   try {
@@ -1929,15 +2391,16 @@ export async function reportRunCompleted(
       // start, so repeated run-level warnings would only add noise.
       missingTelemetrySinkWarned = true;
       console.warn(
-        '[langfuse-trace] Telemetry metrics are enabled but no relay or Langfuse credentials are configured',
+        '[langfuse-trace] Telemetry metrics are enabled but no Vela Control Key, relay, or Langfuse credentials are configured',
       );
     }
     return langfuseDelivery;
   }
 
+  const deliveryPurpose = opts.deliveryPurpose ?? 'final';
   let batch: unknown[];
   try {
-    batch = buildTracePayload({ ...ctx, langfuse: langfuseDelivery });
+    batch = buildTracePayload({ ...ctx, langfuse: langfuseDelivery }, deliveryPurpose);
   } catch (error) {
     console.warn(`[langfuse-trace] Payload build error: ${String(error)}`);
     return {
@@ -1964,6 +2427,40 @@ export async function reportRunCompleted(
   }
 
   const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  const configuredEnv = opts.configuredEnv ?? {};
+  if (config.kind === 'vela') {
+    // Object-registration must stay on the anonymous relay so object scope is
+    // keyed by the original runId (Vela scopes/hashes body.id for Langfuse).
+    if (deliveryPurpose === 'object-registration') {
+      const fallback = readAnonymousTelemetrySinkConfig();
+      if (!fallback) {
+        return {
+          langfuse_expected: true,
+          langfuse_delivery_status: 'failed',
+          langfuse_drop_reason: 'missing_sink_config',
+        };
+      }
+      return postAnonymousBatch(fallback, batch, serialized, fetchImpl);
+    }
+    const installationId = ctx.installationId?.trim() ?? '';
+    if (!installationId) {
+      // Vela schema requires installationId; fall back to anonymous without
+      // claiming a Vela account identity.
+      const fallback = readAnonymousTelemetrySinkConfig();
+      if (!fallback) {
+        return {
+          langfuse_expected: true,
+          langfuse_delivery_status: 'failed',
+          langfuse_drop_reason: 'missing_sink_config',
+        };
+      }
+      return postAnonymousBatch(fallback, batch, serialized, fetchImpl);
+    }
+    return postVelaBatch(config, batch, installationId, fetchImpl, {
+      configuredEnv,
+      deliveryPurpose,
+    });
+  }
   if (config.kind === 'relay') {
     return postRelayBatch(config, serialized, fetchImpl);
   }
@@ -1999,12 +2496,13 @@ export function buildFeedbackPayload(ctx: FeedbackReportContext): unknown[] {
     ...(ctx.metadata ?? {}),
   };
 
+  const ratingScoreId = `${traceId}-rating`;
   batch.push({
-    id: randomUUID(),
+    id: stableIngestionEventId(ratingScoreId),
     type: 'score-create',
     timestamp: nowIso,
     body: {
-      id: `${traceId}-rating`,
+      id: ratingScoreId,
       traceId,
       name: 'user_rating',
       value: ctx.rating === 'positive' ? 1 : -1,
@@ -2015,13 +2513,14 @@ export function buildFeedbackPayload(ctx: FeedbackReportContext): unknown[] {
   });
 
   for (const code of ctx.reasonCodes) {
+    // Stable per (run, code) so re-submission overwrites cleanly.
+    const reasonScoreId = `${traceId}-reason-${code}`;
     batch.push({
-      id: randomUUID(),
+      id: stableIngestionEventId(reasonScoreId),
       type: 'score-create',
       timestamp: nowIso,
       body: {
-        // Stable per (run, code) so re-submission overwrites cleanly.
-        id: `${traceId}-reason-${code}`,
+        id: reasonScoreId,
         traceId,
         name: 'user_rating_reason',
         value: code,
@@ -2065,6 +2564,21 @@ export async function reportRunFeedback(
   }
 
   const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  const configuredEnv = opts.configuredEnv ?? {};
+  if (config.kind === 'vela') {
+    const installationId = ctx.installationId?.trim() ?? '';
+    if (!installationId) {
+      const fallback = readAnonymousTelemetrySinkConfig();
+      if (!fallback) return;
+      await postAnonymousBatch(fallback, batch, serialized, fetchImpl);
+      return;
+    }
+    await postVelaBatch(config, batch, installationId, fetchImpl, {
+      configuredEnv,
+      deliveryPurpose: opts.deliveryPurpose ?? 'final',
+    });
+    return;
+  }
   if (config.kind === 'relay') {
     await postRelayBatch(config, serialized, fetchImpl);
     return;

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -1592,10 +1592,12 @@ export function buildTracePayload(
 ): unknown[] {
   // Object-registration needs manifests for upload authority but must not
   // double-write turn text when the final delivery goes through Vela.
-  // `wantsTextContent` gates prompt/output/tool I/O and stream-tail metadata
-  // (stderr/stdout/diagnostics). Agent/runtime error strings (`error` /
-  // `statusMessage`) are additionally stripped for object-registration so the
-  // anonymous relay never receives turn/error text before final Vela delivery.
+  // `wantsTextContent` gates prompt/output/tool I/O, stream-tail metadata
+  // (stderr/stdout/diagnostics), and agent-event payloads (`output` /
+  // `statusMessage`, including diagnostic messages). Agent/runtime error
+  // strings (`error` / span `statusMessage`) are additionally stripped for
+  // object-registration so the anonymous relay never receives turn/error text
+  // before final Vela delivery.
   // `wantsArtifacts` gates object manifests used by the worker object-scope
   // registry.
   const consentOn =
@@ -1954,10 +1956,13 @@ export function buildTracePayload(
           parentObservationId: agentEventParentObservationId,
           name: event.name,
           startTime: new Date(event.timestamp).toISOString(),
+          // Keep structural input (event_type/source) for both deliveries;
+          // free-text diagnostic/runtime payloads stay on final only so the
+          // object-registration anonymous relay never sees turn/error text.
           input: event.input,
-          output: event.output,
+          output: wantsTextContent ? event.output : undefined,
           level: event.level ?? 'DEFAULT',
-          statusMessage: event.statusMessage,
+          statusMessage: wantsTextContent ? event.statusMessage : undefined,
           metadata: event.metadata,
         },
       });

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -2476,15 +2476,37 @@ export async function reportRunCompleted(
 // user opted into telemetry.content; the consent gate lives in
 // reportRunFeedback below, so this builder stays content-agnostic.
 //
-// Limitation: stable score ids (`${traceId}-rating`, `${traceId}-reason-${code}`)
-// mean re-submission overwrites cleanly, but reason codes the user removes
-// in a follow-up submission do not get a tombstone. A future change can
-// thread `removedReasonCodes` through and emit overwriting "cleared"
-// scores for them; not done here to keep this PR scoped to the bridge.
+// Limitation: stable score body ids (`${traceId}-rating`,
+// `${traceId}-reason-${code}`) mean re-submission overwrites cleanly, but
+// reason codes the user removes in a follow-up submission do not get a
+// tombstone. A future change can thread `removedReasonCodes` through and
+// emit overwriting "cleared" scores for them; not done here to keep this
+// PR scoped to the bridge.
+//
+// Ingestion event ids intentionally include a payload revision so Vela's
+// Idempotency-Key (derived from event ids) changes when the user edits
+// feedback. Score body.id stays stable for Langfuse overwrite semantics.
+/**
+ * Short digest of mutable feedback fields. Identical re-submissions keep the
+ * same revision (true retries); edits (rating flip, reason codes, custom
+ * text) produce a new revision so ingestion event ids — and therefore the
+ * Vela Idempotency-Key — differ from the previous submission.
+ */
+export function feedbackIngestionRevision(ctx: FeedbackReportContext): string {
+  const material = [
+    ctx.rating,
+    [...ctx.reasonCodes].sort().join('\0'),
+    ctx.hasCustomReason ? '1' : '0',
+    ctx.customReason ?? '',
+  ].join('\n');
+  return createHash('sha256').update(material).digest('hex').slice(0, 16);
+}
+
 export function buildFeedbackPayload(ctx: FeedbackReportContext): unknown[] {
   const traceId = ctx.runId;
   const nowIso = new Date().toISOString();
   const batch: unknown[] = [];
+  const revision = feedbackIngestionRevision(ctx);
 
   const ratingMetadata: Record<string, unknown> = {
     reasonCodes: ctx.reasonCodes,
@@ -2498,7 +2520,7 @@ export function buildFeedbackPayload(ctx: FeedbackReportContext): unknown[] {
 
   const ratingScoreId = `${traceId}-rating`;
   batch.push({
-    id: stableIngestionEventId(ratingScoreId),
+    id: stableIngestionEventId(`${ratingScoreId}:${revision}`),
     type: 'score-create',
     timestamp: nowIso,
     body: {
@@ -2513,10 +2535,11 @@ export function buildFeedbackPayload(ctx: FeedbackReportContext): unknown[] {
   });
 
   for (const code of ctx.reasonCodes) {
-    // Stable per (run, code) so re-submission overwrites cleanly.
+    // body.id stable per (run, code) so re-submission overwrites cleanly;
+    // event id includes revision so rating flips are not treated as retries.
     const reasonScoreId = `${traceId}-reason-${code}`;
     batch.push({
-      id: stableIngestionEventId(reasonScoreId),
+      id: stableIngestionEventId(`${reasonScoreId}:${revision}`),
       type: 'score-create',
       timestamp: nowIso,
       body: {

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -176,15 +176,96 @@ export function rememberAcceptedFinalTraceBodyId(
   if (existing?.reportTrigger === 'final_message' && reportTrigger === 'terminal_fallback') {
     return;
   }
+  const acceptedBodyId = bodyId.trim();
   acceptedFinalTraceBodyIds.set(key, {
-    bodyId: bodyId.trim(),
+    bodyId: acceptedBodyId,
     reportTrigger,
   });
+  // Replay any feedback that arrived during the terminal_fallback delay (or
+  // before final_message acceptance) onto the body that was actually accepted.
+  flushPendingRunFeedback(key, acceptedBodyId);
 }
 
 /** Test-only: clear the accepted-final-trace registry between cases. */
 export function resetAcceptedFinalTraceBodyIdsForTests(): void {
   acceptedFinalTraceBodyIds.clear();
+}
+
+type PendingRunFeedbackEntry = {
+  ctx: FeedbackReportContext;
+  opts: ReportRunOpts;
+};
+
+/**
+ * Process-local queue of feedback submitted before any final-purpose body was
+ * accepted. Failed/canceled runs often sit in the terminal_fallback delay with
+ * no accepted body yet; scoring onto the canonical runId then permanently
+ * detaches the score from the only body that eventually exists (`runId:tf`).
+ */
+const pendingRunFeedbackByRunId = new Map<string, PendingRunFeedbackEntry>();
+
+/**
+ * True when feedback should wait for an accepted final-purpose body id.
+ *
+ * Defer only for failed/canceled runs that are not yet telemetry-finalized and
+ * have no accepted body (process-local or persisted). Once final_message owns
+ * the delivery (telemetryFinalized) or any body has been accepted, send now.
+ */
+export function shouldDeferRunFeedback(input: {
+  runId: string;
+  /** Explicit body override — never defer when the caller already pinned a target. */
+  traceId?: string | null;
+  runStatus?: string | null;
+  telemetryFinalized?: boolean;
+  acceptedTraceBodyId?: string | null;
+}): boolean {
+  if (typeof input.traceId === 'string' && input.traceId.trim()) return false;
+  const runId = typeof input.runId === 'string' ? input.runId.trim() : '';
+  if (!runId) return false;
+  if (acceptedFinalTraceBodyIds.has(runId)) return false;
+  const accepted =
+    typeof input.acceptedTraceBodyId === 'string'
+      ? input.acceptedTraceBodyId.trim()
+      : '';
+  if (accepted) return false;
+  if (input.telemetryFinalized === true) return false;
+  return input.runStatus === 'failed' || input.runStatus === 'canceled';
+}
+
+export function queuePendingRunFeedback(
+  ctx: FeedbackReportContext,
+  opts: ReportRunOpts = {},
+): void {
+  const key = typeof ctx.runId === 'string' ? ctx.runId.trim() : '';
+  if (!key) return;
+  // Keep the latest submission only; thumbs can flip during the delay window.
+  pendingRunFeedbackByRunId.set(key, { ctx, opts });
+}
+
+function flushPendingRunFeedback(runId: string, acceptedBodyId: string): void {
+  const key = runId.trim();
+  const bodyId = acceptedBodyId.trim();
+  if (!key || !bodyId) return;
+  const pending = pendingRunFeedbackByRunId.get(key);
+  if (!pending) return;
+  pendingRunFeedbackByRunId.delete(key);
+  void reportRunFeedback(
+    {
+      ...pending.ctx,
+      traceId: bodyId,
+    },
+    pending.opts,
+  ).catch((err) => {
+    console.warn(
+      '[langfuse-trace] deferred feedback flush failed:',
+      String(err),
+    );
+  });
+}
+
+/** Test-only: clear deferred feedback between cases. */
+export function resetPendingRunFeedbackForTests(): void {
+  pendingRunFeedbackByRunId.clear();
 }
 
 /**
@@ -1198,6 +1279,7 @@ function buildToolPerformanceDiagnostics(
 
 function buildArtifactWriteDiagnostics(
   ctx: ReportContext,
+  opts: { includeArtifactFilenames?: boolean } = {},
 ): Record<string, unknown> {
   const writeTools = (ctx.tools ?? []).filter((tool) => tool.name === 'Write');
   const totalArtifactSizeBytes = ctx.artifacts.reduce(
@@ -1208,6 +1290,7 @@ function buildArtifactWriteDiagnostics(
     (sum, tool) => sum + durationMs(tool.startedAt, tool.endedAt),
     0,
   );
+  const includeArtifactFilenames = opts.includeArtifactFilenames !== false;
   return {
     artifact_count: ctx.artifacts.length,
     total_artifact_size_bytes: totalArtifactSizeBytes,
@@ -1225,11 +1308,16 @@ function buildArtifactWriteDiagnostics(
       ctx.artifacts.length > 0 && writeTools.length > 0
         ? undefined
         : 'artifact files are not yet linked to individual Write tool ids',
-    artifacts: ctx.artifacts.map((artifact) => ({
-      slug: artifact.slug,
-      type: artifact.type,
-      size_bytes: artifact.sizeBytes,
-    })),
+    // Filename/slug lists can encode user content; omit on non-final deliveries.
+    ...(includeArtifactFilenames
+      ? {
+          artifacts: ctx.artifacts.map((artifact) => ({
+            slug: artifact.slug,
+            type: artifact.type,
+            size_bytes: artifact.sizeBytes,
+          })),
+        }
+      : {}),
   };
 }
 
@@ -1279,11 +1367,14 @@ function buildSemanticPhaseDiagnostics(ctx: ReportContext): Record<string, unkno
   };
 }
 
-function buildPerformanceDiagnostics(ctx: ReportContext): Record<string, unknown> {
+function buildPerformanceDiagnostics(
+  ctx: ReportContext,
+  opts: { includeArtifactFilenames?: boolean } = {},
+): Record<string, unknown> {
   return {
     timings: ctx.run.timings,
     tool_performance: buildToolPerformanceDiagnostics(ctx.tools),
-    artifact_write: buildArtifactWriteDiagnostics(ctx),
+    artifact_write: buildArtifactWriteDiagnostics(ctx, opts),
     preview_verify: {
       status: 'not_instrumented',
       screenshot_check: 'not_reported',
@@ -1603,12 +1694,16 @@ export function buildTracePayload(
   // strings (`error` / span `statusMessage`) are additionally stripped for
   // object-registration so the anonymous relay never receives turn/error text
   // before final Vela delivery.
-  // `wantsArtifacts` gates object manifests used by the worker object-scope
-  // registry.
+  // `wantsManifests` gates object manifests used by the worker object-scope
+  // registry (kept on registration). `wantsArtifactSummaries` gates
+  // filename/slug-bearing artifact lists and diagnostic filename arrays —
+  // final delivery only, so the anonymous registration relay cannot leak
+  // content-derived names before authenticated Vela delivery.
   const consentOn =
     ctx.prefs.metrics === true && ctx.prefs.content === true;
   const wantsTextContent = deliveryPurpose === 'final' && consentOn;
-  const wantsArtifacts = consentOn;
+  const wantsManifests = consentOn;
+  const wantsArtifactSummaries = deliveryPurpose === 'final' && consentOn;
   // Keep free-text error strings on final deliveries (including content-
   // consent-off) so Langfuse still classifies failures; omit them only from
   // the object-registration anonymous relay pass.
@@ -1635,29 +1730,29 @@ export function buildTracePayload(
     ? truncate(redactArtifactBlocks(ctx.message.output), OUTPUT_MAX_BYTES)
     : undefined;
 
-  const artifactsList = wantsArtifacts
+  const artifactsList = wantsArtifactSummaries
     ? ctx.artifacts.slice(0, ARTIFACTS_MAX_ITEMS)
     : undefined;
   const artifactsTruncated =
-    wantsArtifacts && ctx.artifacts.length > ARTIFACTS_MAX_ITEMS
+    wantsArtifactSummaries && ctx.artifacts.length > ARTIFACTS_MAX_ITEMS
       ? true
       : undefined;
-  const attachmentManifest = wantsArtifacts
+  const attachmentManifest = wantsManifests
     ? cappedManifestEntries(ctx.attachmentManifest)
     : undefined;
-  const attachmentManifestTruncated = wantsArtifacts
+  const attachmentManifestTruncated = wantsManifests
     ? manifestTruncated(ctx.attachmentManifest)
     : undefined;
-  const artifactManifest = wantsArtifacts
+  const artifactManifest = wantsManifests
     ? cappedManifestEntries(ctx.artifactManifest)
     : undefined;
-  const artifactManifestTruncated = wantsArtifacts
+  const artifactManifestTruncated = wantsManifests
     ? manifestTruncated(ctx.artifactManifest)
     : undefined;
-  const inputTextSnapshotManifest = wantsArtifacts
+  const inputTextSnapshotManifest = wantsManifests
     ? cappedManifestEntries(ctx.inputTextSnapshotManifest)
     : undefined;
-  const inputTextSnapshotManifestTruncated = wantsArtifacts
+  const inputTextSnapshotManifestTruncated = wantsManifests
     ? manifestTruncated(ctx.inputTextSnapshotManifest)
     : undefined;
 
@@ -1686,7 +1781,9 @@ export function buildTracePayload(
       }
     : undefined;
   const costBreakdown = buildCostBreakdown(ctx);
-  const performanceDiagnostics = buildPerformanceDiagnostics(ctx);
+  const performanceDiagnostics = buildPerformanceDiagnostics(ctx, {
+    includeArtifactFilenames: wantsArtifactSummaries,
+  });
 
   const success = ctx.run.status === 'succeeded';
   // Canonical run id stays in metadata for correlation; Langfuse entity body
@@ -1763,7 +1860,7 @@ export function buildTracePayload(
     input_text_snapshot_manifest: inputTextSnapshotManifest,
     input_text_snapshot_manifest_truncated: inputTextSnapshotManifestTruncated,
     trace_object_summary: ctx.traceObjectSummary,
-    manifest_completeness: wantsArtifacts
+    manifest_completeness: wantsManifests
       ? (ctx.manifestCompleteness ?? 'unavailable')
       : undefined,
     projectId: ctx.projectId || undefined,
@@ -2037,12 +2134,12 @@ export function buildTracePayload(
         input: {
           source: 'agent_generated_artifacts',
           artifact_count: artifactsList.length,
-          artifact_manifest_enabled: wantsArtifacts,
+          artifact_manifest_enabled: wantsManifests,
         },
         output: {
           artifacts: artifactsList,
           artifactsTruncated,
-          manifest_completeness: wantsArtifacts
+          manifest_completeness: wantsManifests
             ? (ctx.manifestCompleteness ?? 'unavailable')
             : 'off',
         },
@@ -2866,6 +2963,22 @@ export async function reportRunFeedback(
   // Same eligibility as reportRunFeedbackFromDaemon preflight: Vela without
   // installationId only ships when an anonymous sink is available.
   if (!canDeliverRunFeedback(config, ctx.installationId)) return;
+
+  // Failed/canceled runs may still be waiting on terminal_fallback acceptance.
+  // Queue until rememberAcceptedFinalTraceBodyId flushes onto the accepted body.
+  if (
+    shouldDeferRunFeedback({
+      runId: ctx.runId,
+      ...(ctx.traceId !== undefined ? { traceId: ctx.traceId } : {}),
+      ...(ctx.runStatus !== undefined ? { runStatus: ctx.runStatus } : {}),
+      ...(ctx.telemetryFinalized !== undefined
+        ? { telemetryFinalized: ctx.telemetryFinalized }
+        : {}),
+    })
+  ) {
+    queuePendingRunFeedback(ctx, opts);
+    return;
+  }
 
   let batch: unknown[];
   try {

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -324,22 +324,47 @@ export function queuePendingRunFeedback(
  * Feedback queued at submit time may carry `opts.config` from the live sink
  * then (`reportRunFeedbackFromDaemon` passes `config: sink`). The body that
  * is later accepted can land on a different channel (Vela 401/403 → relay, or
- * login/logout during the delay). `resolveReportConfig` prefers explicit
- * `opts.config` over sticky `acceptedDeliveryChannel`, so a stale sink would
- * fail `canDeliverRunFeedback` and drop the score. Keep a matching explicit
- * config; strip mismatch so sticky channel re-resolves from env.
+ * login/logout during the delay), or stay on `vela` but with a different
+ * Control Key / profile after an AMR switch. `resolveReportConfig` prefers
+ * explicit `opts.config` over sticky `acceptedDeliveryChannel`, so a stale
+ * sink would fail `canDeliverRunFeedback` and drop the score. Keep a matching
+ * explicit config (same channel, and for Vela the same accepting-account
+ * fingerprint); strip mismatch so sticky channel re-resolves from env.
  */
 function flushReportOpts(
   opts: ReportRunOpts,
   deliveryChannel?: TelemetryDeliveryChannel,
+  acceptedVelaIdentity?: string,
 ): ReportRunOpts {
   if (!deliveryChannel) return opts;
   if (opts.config === undefined || opts.config == null) return opts;
   const pendingKind =
     'kind' in opts.config ? opts.config.kind : ('langfuse' as const);
-  if (pendingKind === deliveryChannel) return opts;
-  const { config: _staleConfig, ...rest } = opts;
-  return rest;
+  if (pendingKind !== deliveryChannel) {
+    const { config: _staleConfig, ...rest } = opts;
+    return rest;
+  }
+  // Same channel, but Vela account may have changed during the delay window.
+  // Kind-only equality would keep the submit-time Control Key; the flush then
+  // passes the new acceptedVelaIdentity and canDeliverRunFeedback rejects it.
+  if (deliveryChannel === 'vela' && pendingKind === 'vela') {
+    const required =
+      typeof acceptedVelaIdentity === 'string' ? acceptedVelaIdentity.trim() : '';
+    if (required) {
+      const config = opts.config;
+      if (config && 'kind' in config && config.kind === 'vela') {
+        const current = velaSinkIdentityFingerprint(
+          config.profile,
+          config.controlKey,
+        );
+        if (!current || current !== required) {
+          const { config: _staleConfig, ...rest } = opts;
+          return rest;
+        }
+      }
+    }
+  }
+  return opts;
 }
 
 function flushPendingRunFeedback(
@@ -370,7 +395,7 @@ function flushPendingRunFeedback(
         : {}),
       ...(velaIdentity ? { acceptedVelaIdentity: velaIdentity } : {}),
     },
-    flushReportOpts(pending.opts, deliveryChannel),
+    flushReportOpts(pending.opts, deliveryChannel, velaIdentity),
   ).catch((err) => {
     console.warn(
       '[langfuse-trace] deferred feedback flush failed:',

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -265,6 +265,9 @@ export function clearRunAwaitingFinalAcceptance(
   // custom reason if live consent flipped off while waiting.
   const flushPrefs = prefsForDeferredFeedbackFlush(pending.ctx.prefs);
   if (flushPrefs == null) return;
+  // Same owner gate as flushPendingRunFeedback: conversation/project may
+  // have been deleted during the terminal-fallback / awaiting window.
+  if (!liveDeferredFeedbackOwnerExists(pending.ctx)) return;
   // Submit-time opts may pin a Vela Control Key / profile. Logout or AMR
   // switch during the awaiting window must not reuse that stale sink on the
   // canonical fallback path — strip config so resolveReportConfig re-reads
@@ -607,6 +610,28 @@ let liveTelemetryPrefsReaderForTests:
   | undefined;
 
 /**
+ * Live conversation-owner check for deferred feedback flushes.
+ *
+ * Wired from server bootstrap with SQLite (`runHasLiveTelemetryOwner`) so a
+ * terminal_fallback accept after conversation/project delete does not ship
+ * queued custom reasons. `undefined` means "assume live" (unit tests that do
+ * not model ownership); production always configures a real check.
+ */
+export type DeferredFeedbackOwnerCheckInput = {
+  runId: string;
+  conversationId?: string | null;
+  assistantMessageId?: string | null;
+};
+export type DeferredFeedbackOwnerCheck = (
+  input: DeferredFeedbackOwnerCheckInput,
+) => boolean;
+
+let deferredFeedbackOwnerCheck: DeferredFeedbackOwnerCheck | undefined;
+let liveDeferredFeedbackOwnerCheckForTests:
+  | DeferredFeedbackOwnerCheck
+  | undefined;
+
+/**
  * Pin the resolved daemon data directory used when re-reading telemetry
  * prefs before a deferred feedback flush. Call once from server bootstrap
  * with `RUNTIME_DATA_DIR`.
@@ -619,6 +644,16 @@ export function configureDeferredFeedbackDataDir(
 }
 
 /**
+ * Pin the live conversation-owner check used before deferred feedback flushes.
+ * Call once from server bootstrap after SQLite is open.
+ */
+export function configureDeferredFeedbackOwnerCheck(
+  check: DeferredFeedbackOwnerCheck | null | undefined,
+): void {
+  deferredFeedbackOwnerCheck = check ?? undefined;
+}
+
+/**
  * Test-only: inject live telemetry prefs for deferred feedback flush gates.
  * Pass `undefined` to restore the production data-dir reader.
  */
@@ -626,6 +661,16 @@ export function setLiveTelemetryPrefsReaderForTests(
   reader: (() => TelemetryPrefs | null) | undefined,
 ): void {
   liveTelemetryPrefsReaderForTests = reader;
+}
+
+/**
+ * Test-only: inject live conversation-owner existence for deferred flushes.
+ * Pass `undefined` to restore the production configured check (or default-live).
+ */
+export function setLiveDeferredFeedbackOwnerCheckForTests(
+  check: DeferredFeedbackOwnerCheck | undefined,
+): void {
+  liveDeferredFeedbackOwnerCheckForTests = check;
 }
 
 /**
@@ -680,6 +725,46 @@ function prefsForDeferredFeedbackFlush(
   return live;
 }
 
+function stringMetaField(
+  metadata: Record<string, unknown> | undefined,
+  key: string,
+): string | null {
+  if (!metadata) return null;
+  const value = metadata[key];
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+/**
+ * Whether the conversation/project owner for queued feedback still exists.
+ *
+ * `setRunTelemetryAcceptedAnchor` refuses unowned rows after delete; this
+ * gate runs earlier (inside rememberAcceptedFinalTraceBodyId) so pending
+ * custom reasons are not flushed before that DB check can reject.
+ */
+function liveDeferredFeedbackOwnerExists(ctx: FeedbackReportContext): boolean {
+  const input: DeferredFeedbackOwnerCheckInput = {
+    runId: typeof ctx.runId === 'string' ? ctx.runId.trim() : '',
+    conversationId: stringMetaField(ctx.metadata, 'conversationId'),
+    assistantMessageId: stringMetaField(ctx.metadata, 'assistantMessageId'),
+  };
+  if (!input.runId) return false;
+  const check =
+    liveDeferredFeedbackOwnerCheckForTests ?? deferredFeedbackOwnerCheck;
+  if (!check) {
+    // Unit tests without a configured owner model treat the owner as live.
+    // Production always wires configureDeferredFeedbackOwnerCheck after DB open.
+    return true;
+  }
+  try {
+    return check(input) === true;
+  } catch {
+    // Unreadable owner state during a delayed content send: fail closed.
+    return false;
+  }
+}
+
 function flushPendingRunFeedback(
   runId: string,
   acceptedBodyId: string,
@@ -698,6 +783,16 @@ function flushPendingRunFeedback(
   // custom reason (or retain it for a later final_message re-attach).
   const flushPrefs = prefsForDeferredFeedbackFlush(pending.ctx.prefs);
   if (flushPrefs == null) {
+    pendingRunFeedbackByRunId.delete(key);
+    cancelPendingTerminalFallbackQueueDrop(key);
+    return;
+  }
+
+  // Privacy: re-check live conversation/project owner. Delete can land during
+  // the terminal_fallback delay; setRunTelemetryAcceptedAnchor later refuses
+  // the unowned row, but this flush runs first and would still ship the
+  // queued custom reason without this gate.
+  if (!liveDeferredFeedbackOwnerExists(pending.ctx)) {
     pendingRunFeedbackByRunId.delete(key);
     cancelPendingTerminalFallbackQueueDrop(key);
     return;
@@ -743,7 +838,9 @@ export function resetPendingRunFeedbackForTests(): void {
   runsAwaitingFinalAcceptance.clear();
   awaitingFinalAcceptanceTokenSeq = 0;
   liveTelemetryPrefsReaderForTests = undefined;
+  liveDeferredFeedbackOwnerCheckForTests = undefined;
   deferredFeedbackDataDir = null;
+  deferredFeedbackOwnerCheck = undefined;
 }
 
 /** Test-only: whether deferred feedback is still queued for a run. */

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -110,6 +110,12 @@ export interface LangfuseDeliveryState {
   langfuse_drop_reason?: LangfuseDropReason;
   /** Set on accepted deliveries so feedback can pin the same transport. */
   langfuse_delivery_channel?: TelemetryDeliveryChannel;
+  /**
+   * Fingerprint of the Vela profile + Control Key that accepted the body.
+   * Feedback must match this identity so scores are not written under a
+   * different account after an AMR profile/key switch.
+   */
+  langfuse_vela_identity?: string;
 }
 
 export type AnonymousTelemetrySinkConfig =
@@ -173,8 +179,26 @@ const acceptedFinalTraceBodyIds = new Map<
     bodyId: string;
     reportTrigger: TelemetryReportTrigger;
     deliveryChannel?: TelemetryDeliveryChannel;
+    /** Vela profile+key fingerprint when deliveryChannel is `vela`. */
+    velaIdentity?: string;
   }
 >();
+
+/**
+ * Stable fingerprint for the Vela account that accepted a final-purpose body.
+ * Profile name + truncated Control Key hash (never the raw key).
+ */
+export function velaSinkIdentityFingerprint(
+  profile: string | null | undefined,
+  controlKey: string | null | undefined,
+): string | null {
+  const key = typeof controlKey === 'string' ? controlKey.trim() : '';
+  if (!key) return null;
+  const profileName =
+    typeof profile === 'string' && profile.trim() ? profile.trim() : 'default';
+  const keyHash = createHash('sha256').update(key, 'utf8').digest('hex').slice(0, 16);
+  return `${profileName}:${keyHash}`;
+}
 
 /**
  * Remember the body id of an accepted final-purpose delivery so feedback
@@ -185,6 +209,7 @@ export function rememberAcceptedFinalTraceBodyId(
   bodyId: string,
   reportTrigger: TelemetryReportTrigger,
   deliveryChannel?: TelemetryDeliveryChannel | null,
+  velaIdentity?: string | null,
 ): void {
   const key = runId.trim();
   if (!key || !bodyId.trim()) return;
@@ -199,21 +224,26 @@ export function rememberAcceptedFinalTraceBodyId(
     deliveryChannel === 'langfuse'
       ? deliveryChannel
       : undefined;
+  const identity =
+    channel === 'vela' && typeof velaIdentity === 'string' && velaIdentity.trim()
+      ? velaIdentity.trim()
+      : undefined;
   acceptedFinalTraceBodyIds.set(key, {
     bodyId: acceptedBodyId,
     reportTrigger,
     ...(channel ? { deliveryChannel: channel } : {}),
+    ...(identity ? { velaIdentity: identity } : {}),
   });
   // Replay any feedback that arrived during the terminal_fallback delay (or
   // before final_message acceptance) onto the body that was actually accepted.
   // Keep the queue after terminal_fallback so a later final_message can re-
   // attach the same score to the canonical body when it wins the anchor.
-  flushPendingRunFeedback(key, acceptedBodyId, reportTrigger, channel);
+  flushPendingRunFeedback(key, acceptedBodyId, reportTrigger, channel, identity);
 }
 
 /**
  * Process-local accepted delivery channel for a run, if any.
- * Used to keep feedback on the same transport after Vela acceptance.
+ * Used to keep feedback on the same transport after any channel acceptance.
  */
 export function getAcceptedFinalDeliveryChannel(
   runId: string,
@@ -221,6 +251,15 @@ export function getAcceptedFinalDeliveryChannel(
   const key = typeof runId === 'string' ? runId.trim() : '';
   if (!key) return null;
   return acceptedFinalTraceBodyIds.get(key)?.deliveryChannel ?? null;
+}
+
+/**
+ * Process-local Vela identity fingerprint for a run accepted on Vela, if any.
+ */
+export function getAcceptedFinalVelaIdentity(runId: string): string | null {
+  const key = typeof runId === 'string' ? runId.trim() : '';
+  if (!key) return null;
+  return acceptedFinalTraceBodyIds.get(key)?.velaIdentity ?? null;
 }
 
 /** Test-only: clear the accepted-final-trace registry between cases. */
@@ -284,6 +323,7 @@ function flushPendingRunFeedback(
   acceptedBodyId: string,
   reportTrigger: TelemetryReportTrigger,
   deliveryChannel?: TelemetryDeliveryChannel,
+  velaIdentity?: string,
 ): void {
   const key = runId.trim();
   const bodyId = acceptedBodyId.trim();
@@ -304,6 +344,7 @@ function flushPendingRunFeedback(
       ...(deliveryChannel
         ? { acceptedDeliveryChannel: deliveryChannel }
         : {}),
+      ...(velaIdentity ? { acceptedVelaIdentity: velaIdentity } : {}),
     },
     pending.opts,
   ).catch((err) => {
@@ -683,10 +724,16 @@ export interface FeedbackReportContext {
   telemetryFinalized?: boolean;
   /**
    * Transport that accepted the final-purpose body this score attaches to.
-   * When `vela`, feedback must not fall back to anonymous relay/Langfuse —
-   * Vela scopes body ids, so raw-id anonymous scores would misattach.
+   * Feedback must use the same channel — cross-channel writes do not attach
+   * to the same Langfuse/Vela trace (Vela scopes/hashes body ids).
    */
   acceptedDeliveryChannel?: TelemetryDeliveryChannel | null;
+  /**
+   * Fingerprint of the accepting Vela profile/key when
+   * `acceptedDeliveryChannel` is `vela`. Mismatch suppresses delivery so
+   * scores cannot follow an AMR account switch.
+   */
+  acceptedVelaIdentity?: string | null;
   /**
    * Report trigger that owns the accepted final-purpose body (from process
    * memory or the persisted DB anchor). When still `terminal_fallback`, live
@@ -824,19 +871,36 @@ export function readTelemetrySinkConfig(
  * delivery falls back to the anonymous sink (or is undeliverable when that
  * is also missing).
  *
- * When `requireChannel` is `vela`, anonymous fallback is suppressed: the
- * accepted final body lives under Vela-scoped ids and must not receive
- * raw-id scores on the anonymous relay.
+ * When `requireChannel` is set, the live sink must be exactly that channel.
+ * Cross-channel writes do not attach to the same Langfuse/Vela trace.
+ * For `vela`, also require installationId and (when provided) a matching
+ * accepting-account fingerprint so profile/key switches cannot misattribute.
  */
 export function canDeliverRunFeedback(
   sink: TelemetrySinkConfig | null,
   installationId: string | null | undefined,
   env: NodeJS.ProcessEnv = process.env,
-  opts: { requireChannel?: TelemetryDeliveryChannel | null } = {},
+  opts: {
+    requireChannel?: TelemetryDeliveryChannel | null;
+    requireVelaIdentity?: string | null;
+  } = {},
 ): sink is TelemetrySinkConfig {
   if (!sink) return false;
-  if (opts.requireChannel === 'vela') {
-    return sink.kind === 'vela' && Boolean(installationId?.trim());
+  const requireChannel = opts.requireChannel ?? null;
+  if (requireChannel) {
+    if (sink.kind !== requireChannel) return false;
+    if (requireChannel === 'vela') {
+      if (!installationId?.trim()) return false;
+      const requiredIdentity =
+        typeof opts.requireVelaIdentity === 'string'
+          ? opts.requireVelaIdentity.trim()
+          : '';
+      if (requiredIdentity) {
+        const current = velaSinkIdentityFingerprint(sink.profile, sink.controlKey);
+        if (!current || current !== requiredIdentity) return false;
+      }
+    }
+    return true;
   }
   if (sink.kind === 'vela') {
     const id = installationId?.trim() ?? '';
@@ -2463,10 +2527,15 @@ async function postVelaBatch(
 
       // Vela contract is 202 Accepted. Do not treat other 2xx as success.
       if (response.status === 202) {
+        const identity = velaSinkIdentityFingerprint(
+          config.profile,
+          config.controlKey,
+        );
         return {
           langfuse_expected: true,
           langfuse_delivery_status: 'accepted',
           langfuse_delivery_channel: 'vela',
+          ...(identity ? { langfuse_vela_identity: identity } : {}),
         };
       }
 
@@ -2889,6 +2958,7 @@ export async function reportRunCompleted(
         scopedTelemetryBodyId(ctx.run.runId, deliveryPurpose, reportTrigger),
         reportTrigger,
         state.langfuse_delivery_channel,
+        state.langfuse_vela_identity,
       );
     }
     return state;
@@ -3053,17 +3123,27 @@ export async function reportRunFeedback(
   if (ctx.prefs.content !== true) return;
 
   const config = resolveReportConfig(opts);
-  const requireChannel =
-    ctx.acceptedDeliveryChannel === 'vela'
-      ? 'vela'
-      : getAcceptedFinalDeliveryChannel(ctx.runId) === 'vela'
-        ? 'vela'
-        : null;
-  // Same eligibility as reportRunFeedbackFromDaemon preflight: Vela without
-  // installationId only ships when an anonymous sink is available — unless
-  // the accepted final body was Vela-scoped, in which case anonymous is off.
+  // Sticky exact channel: once a final body was accepted on relay/langfuse/vela,
+  // feedback must stay on that same transport (body id namespaces diverge).
+  const requireChannel: TelemetryDeliveryChannel | null =
+    ctx.acceptedDeliveryChannel === 'vela' ||
+    ctx.acceptedDeliveryChannel === 'relay' ||
+    ctx.acceptedDeliveryChannel === 'langfuse'
+      ? ctx.acceptedDeliveryChannel
+      : getAcceptedFinalDeliveryChannel(ctx.runId);
+  const requireVelaIdentity =
+    requireChannel === 'vela'
+      ? (typeof ctx.acceptedVelaIdentity === 'string' &&
+        ctx.acceptedVelaIdentity.trim()
+          ? ctx.acceptedVelaIdentity.trim()
+          : getAcceptedFinalVelaIdentity(ctx.runId))
+      : null;
+  // Same eligibility as reportRunFeedbackFromDaemon preflight: exact channel
+  // match when an accepted anchor exists; Vela also needs installationId +
+  // matching accepting-account fingerprint when known.
   if (!canDeliverRunFeedback(config, ctx.installationId, process.env, {
     requireChannel,
+    requireVelaIdentity,
   })) {
     return;
   }
@@ -3125,11 +3205,13 @@ export async function reportRunFeedback(
 
   const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
   const configuredEnv = opts.configuredEnv ?? {};
+  // When an accepted channel is sticky, never fall back to a different sink.
+  const stickyChannel = requireChannel != null;
   if (config.kind === 'vela') {
     const installationId = ctx.installationId?.trim() ?? '';
     if (!installationId) {
-      // Vela-scoped anchors never fall back; canDeliver already gated this.
-      if (requireChannel === 'vela') return;
+      // Sticky anchors never fall back; canDeliver already gated this.
+      if (stickyChannel) return;
       // canDeliverRunFeedback already verified anonymous fallback exists.
       const fallback = readAnonymousTelemetrySinkConfig();
       if (!fallback) return;
@@ -3139,13 +3221,13 @@ export async function reportRunFeedback(
     await postVelaBatch(config, batch, installationId, fetchImpl, {
       configuredEnv,
       deliveryPurpose: opts.deliveryPurpose ?? 'final',
-      // Keep scores on the Vela-scoped body when that is what was accepted.
-      allowAnonymousFallback: requireChannel !== 'vela',
+      // Keep scores on the accepted channel; never anonymous-overwrite sticky.
+      allowAnonymousFallback: !stickyChannel,
     });
     return;
   }
-  // Non-Vela sink cannot attach to a Vela-scoped body (ids diverge).
-  if (requireChannel === 'vela') return;
+  // Sticky channel already enforced by canDeliver; safety for divergent sinks.
+  if (stickyChannel && config.kind !== requireChannel) return;
   if (config.kind === 'relay') {
     await postRelayBatch(config, serialized, fetchImpl);
     return;

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -318,6 +318,30 @@ export function queuePendingRunFeedback(
   pendingRunFeedbackByRunId.set(key, { ctx, opts });
 }
 
+/**
+ * Report opts for flushing deferred feedback onto an accepted final body.
+ *
+ * Feedback queued at submit time may carry `opts.config` from the live sink
+ * then (`reportRunFeedbackFromDaemon` passes `config: sink`). The body that
+ * is later accepted can land on a different channel (Vela 401/403 → relay, or
+ * login/logout during the delay). `resolveReportConfig` prefers explicit
+ * `opts.config` over sticky `acceptedDeliveryChannel`, so a stale sink would
+ * fail `canDeliverRunFeedback` and drop the score. Keep a matching explicit
+ * config; strip mismatch so sticky channel re-resolves from env.
+ */
+function flushReportOpts(
+  opts: ReportRunOpts,
+  deliveryChannel?: TelemetryDeliveryChannel,
+): ReportRunOpts {
+  if (!deliveryChannel) return opts;
+  if (opts.config === undefined || opts.config == null) return opts;
+  const pendingKind =
+    'kind' in opts.config ? opts.config.kind : ('langfuse' as const);
+  if (pendingKind === deliveryChannel) return opts;
+  const { config: _staleConfig, ...rest } = opts;
+  return rest;
+}
+
 function flushPendingRunFeedback(
   runId: string,
   acceptedBodyId: string,
@@ -346,7 +370,7 @@ function flushPendingRunFeedback(
         : {}),
       ...(velaIdentity ? { acceptedVelaIdentity: velaIdentity } : {}),
     },
-    pending.opts,
+    flushReportOpts(pending.opts, deliveryChannel),
   ).catch((err) => {
     console.warn(
       '[langfuse-trace] deferred feedback flush failed:',

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -1655,10 +1655,17 @@ export function buildTracePayload(
   // Build phase spans with canonical run-scoped ids, then remap body ids into
   // the delivery namespace so terminal_fallback gets `…:tf` suffixes (not
   // `run:tf-phase-…` mid-string infixes).
-  const timingSpanBodies = buildTimingSpanBodies(ctx, operationSpanId, {
-    modelCallName: createGeneration ? 'agent-call' : 'runtime-call',
-    ...(promptStack ? { promptStack } : {}),
-  }).map((span) => ({
+  // Explicit Record return type: spreading Record<string, unknown> into an
+  // object literal would otherwise infer only { id, traceId } and lose
+  // indexed access to span.name below.
+  const timingSpanBodies: Record<string, unknown>[] = buildTimingSpanBodies(
+    ctx,
+    operationSpanId,
+    {
+      modelCallName: createGeneration ? 'agent-call' : 'runtime-call',
+      ...(promptStack ? { promptStack } : {}),
+    },
+  ).map((span) => ({
     ...span,
     id: scopeBodyId(String(span.id)),
     traceId,

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -337,19 +337,20 @@ const pendingRunFeedbackByRunId = new Map<string, PendingRunFeedbackEntry>();
 /**
  * True when feedback should wait for an accepted final-purpose body id.
  *
- * Defer when no accepted body is known yet (process-local or persisted) and
- * either:
- * - the run failed/canceled (terminal_fallback delay window), or
- * - the message is telemetry-finalized *and* this process still has a final-
- *   purpose delivery in flight (`markRunAwaitingFinalAcceptance`): the live
- *   race where createFinalizedMessageTelemetryReporter marks finalized before
- *   reportRunCompleted / rememberAcceptedFinalTraceBodyId records the anchor.
+ * Defer only while this process still has a live final-purpose completer
+ * (`markRunAwaitingFinalAcceptance`): the terminal_fallback delay window
+ * (marked when the fallback timer is scheduled), the in-flight
+ * reportRunCompleted after that timer, or the live finalization race where
+ * createFinalizedMessageTelemetryReporter marks finalized before
+ * rememberAcceptedFinalTraceBodyId records the anchor.
  *
- * Cold finalized rows with no accepted body (pre-migration, never-persisted
- * anchors, or delivery already finished without accept) are NOT deferred —
- * there is no completer to flush a queue, so scores ship on the canonical
- * runId (or skip via sink eligibility) instead of sitting in
- * pendingRunFeedbackByRunId until process exit.
+ * Cold rows with no accepted body (daemon restart, pre-migration, never-
+ * persisted anchors, or delivery already finished/cleared without accept)
+ * are NOT deferred — there is no completer to flush a queue, so scores ship
+ * on the canonical runId (or skip via sink eligibility) instead of sitting
+ * in pendingRunFeedbackByRunId until process exit. Status-only or
+ * finalized-only signals are not enough; without the process-local awaiting
+ * marker a failed/canceled row would queue forever after restart.
  *
  * Once any body has been accepted — or the caller already pinned an explicit
  * `traceId` — send now so scores attach to the known body/channel.
@@ -371,13 +372,10 @@ export function shouldDeferRunFeedback(input: {
       ? input.acceptedTraceBodyId.trim()
       : '';
   if (accepted) return false;
-  // Finalized-without-accepted is only the live finalization race while a
-  // completer is still in flight. Cold/legacy finalized rows have no pending
-  // rememberAcceptedFinalTraceBodyId — do not queue them forever.
-  if (input.telemetryFinalized === true) {
-    return runsAwaitingFinalAcceptance.has(runId);
-  }
-  return input.runStatus === 'failed' || input.runStatus === 'canceled';
+  // Live completer only. Cold failed/canceled/finalized rows have no pending
+  // rememberAcceptedFinalTraceBodyId / clearRunAwaitingFinalAcceptance — do
+  // not queue them forever on status or finalized flags alone.
+  return runsAwaitingFinalAcceptance.has(runId);
 }
 
 export function queuePendingRunFeedback(

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -841,6 +841,39 @@ export function readAnonymousTelemetrySinkConfig(
   return config == null ? null : { kind: 'langfuse', ...config };
 }
 
+/**
+ * Sink selection for pre-migration accepted anchors that lack
+ * `acceptedDeliveryChannel` (null channel).
+ *
+ * Relay and direct Langfuse are non-interchangeable body-id namespaces. The
+ * normal anonymous resolver is relay-first, which would re-route a run that
+ * originally accepted on direct Langfuse onto the relay once a relay URL is
+ * added later. When both anonymous backends are viable we treat the legacy
+ * channel as ambiguous and return null so feedback is skipped rather than
+ * detached from the accepted trace. When only one is configured, use it.
+ */
+export function readLegacyAnonymousAcceptedSinkConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): AnonymousTelemetrySinkConfig | null {
+  const relayUrl = env.OPEN_DESIGN_TELEMETRY_RELAY_URL?.trim();
+  const hasRelay = Boolean(relayUrl);
+  const langfuse = readLangfuseConfig(env);
+  const hasLangfuse = langfuse != null;
+  if (hasRelay && hasLangfuse) return null;
+  if (hasRelay && relayUrl) {
+    return {
+      kind: 'relay',
+      relayUrl: relayUrl.replace(/\/+$/, ''),
+      timeoutMs: readTelemetryTimeoutMs(env),
+      retries: readTelemetryRetries(env),
+    };
+  }
+  if (hasLangfuse && langfuse) {
+    return { kind: 'langfuse', ...langfuse };
+  }
+  return null;
+}
+
 function readVelaTelemetrySinkConfig(
   env: NodeJS.ProcessEnv = process.env,
   configuredEnv: Record<string, string> = {},

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -27,10 +27,7 @@
 import { createHash } from 'node:crypto';
 
 import type { TelemetryPrefs } from './app-config.js';
-import {
-  forgetVelaLogin,
-  readVelaControlApiContext,
-} from './integrations/vela.js';
+import { readVelaControlApiContext } from './integrations/vela.js';
 import {
   buildPromptStackFlatMetadata,
   promptStackWithoutContent,
@@ -478,16 +475,10 @@ export type TelemetrySinkConfig =
       controlKey: string;
       timeoutMs: number;
       retries: number;
-      /** AMR profile used to resolve this sink (for stale-auth cleanup). */
+      /** AMR profile used to resolve this sink. */
       profile: string;
       /** Whether the Control Key came from process/app env or ~/.amr config. */
       authSource: 'env' | 'file';
-      /**
-       * When true, a 401/403 may clear the matching local file login.
-       * Explicit test/config sinks leave this false so they cannot log out
-       * an unrelated real account.
-       */
-      clearLoginOnAuthFailure: boolean;
     }
   | AnonymousTelemetrySinkConfig;
 
@@ -930,9 +921,6 @@ function readVelaTelemetrySinkConfig(
     retries: readTelemetryRetries(env),
     profile: context.profile,
     authSource,
-    // Only file-backed logins can be cleared, and only when we resolved the
-    // live sink ourselves (not an explicit test/config override).
-    clearLoginOnAuthFailure: authSource === 'file',
   };
 }
 
@@ -2498,35 +2486,6 @@ function classifyFetchError(error: unknown): 'timeout' | 'network_error' {
   return 'network_error';
 }
 
-/**
- * Clear local login only when the failed request still matches the currently
- * stored file-backed Control Key for the same profile. Prevents a late 401
- * from account A from logging out account B after a switch.
- */
-function maybeForgetVelaLoginOnAuthFailure(
-  config: Extract<TelemetrySinkConfig, { kind: 'vela' }>,
-  env: NodeJS.ProcessEnv,
-  configuredEnv: Record<string, string>,
-): void {
-  if (!config.clearLoginOnAuthFailure) return;
-  if (config.authSource !== 'file') return;
-  try {
-    const current = readVelaControlApiContext(env, configuredEnv);
-    if (!current) return;
-    if (current.profile !== config.profile) return;
-    if (current.controlKey !== config.controlKey) return;
-    // Pass profile selection through env so forgetVelaLogin targets the same profile.
-    const profileEnv: NodeJS.ProcessEnv = {
-      ...env,
-      ...configuredEnv,
-      OPEN_DESIGN_AMR_PROFILE: config.profile,
-    };
-    forgetVelaLogin(profileEnv);
-  } catch {
-    // Best-effort cleanup only.
-  }
-}
-
 /** Convert a Langfuse ingestion batch into the vendor-neutral Vela envelope. */
 export function toVelaTelemetryEnvelope(
   batch: unknown[],
@@ -2595,7 +2554,6 @@ async function postVelaBatch(
   fetchImpl: typeof fetch,
   opts: {
     env?: NodeJS.ProcessEnv;
-    configuredEnv?: Record<string, string>;
     deliveryPurpose?: TelemetryDeliveryPurpose;
     reportTrigger?: TelemetryReportTrigger;
     /**
@@ -2606,7 +2564,6 @@ async function postVelaBatch(
   } = {},
 ): Promise<LangfuseDeliveryState> {
   const env = opts.env ?? process.env;
-  const configuredEnv = opts.configuredEnv ?? {};
   const deliveryPurpose = opts.deliveryPurpose ?? 'final';
   const reportTrigger = opts.reportTrigger ?? 'final_message';
   const allowAnonymousFallback = opts.allowAnonymousFallback !== false;
@@ -2672,13 +2629,14 @@ async function postVelaBatch(
       // Drain body without logging it (may contain reflected payload / PII).
       await response.text().catch(() => '');
 
-      // Auth failures: optionally clear matching local login and allow a
-      // one-shot anonymous fallback. Do not anonymous-fallback on 400 / 429 /
-      // 5xx / timeout — that can overwrite an authenticated identity if Vela
-      // already accepted the batch. Feedback for Vela-scoped bodies also
-      // suppresses anonymous fallback so scores cannot attach to raw ids.
+      // Auth failures: report drop reason and allow a one-shot anonymous
+      // fallback. Telemetry must not mutate AMR login state — login
+      // invalidation belongs to explicit Vela auth flows only.
+      // Do not anonymous-fallback on 400 / 429 / 5xx / timeout — that can
+      // overwrite an authenticated identity if Vela already accepted the
+      // batch. Feedback for Vela-scoped bodies also suppresses anonymous
+      // fallback so scores cannot attach to raw ids.
       if (response.status === 401 || response.status === 403) {
-        maybeForgetVelaLoginOnAuthFailure(config, env, configuredEnv);
         if (!allowAnonymousFallback) {
           console.warn(
             `[langfuse-trace] Vela telemetry auth failed status=${response.status}; anonymous fallback suppressed`,
@@ -2924,8 +2882,6 @@ function normalizeTelemetrySinkConfig(
         ...config,
         profile: config.profile || 'prod',
         authSource: config.authSource ?? 'env',
-        // Explicit sinks never clear an unrelated local login by default.
-        clearLoginOnAuthFailure: config.clearLoginOnAuthFailure ?? false,
       };
     }
     return config;
@@ -3084,7 +3040,6 @@ export async function reportRunCompleted(
   }
 
   const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
-  const configuredEnv = opts.configuredEnv ?? {};
   const noteAcceptedFinalTrace = (state: LangfuseDeliveryState): LangfuseDeliveryState => {
     if (
       deliveryPurpose === 'final' &&
@@ -3134,7 +3089,6 @@ export async function reportRunCompleted(
     }
     return noteAcceptedFinalTrace(
       await postVelaBatch(config, batch, installationId, fetchImpl, {
-        configuredEnv,
         deliveryPurpose,
         reportTrigger,
       }),
@@ -3342,7 +3296,6 @@ export async function reportRunFeedback(
   }
 
   const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
-  const configuredEnv = opts.configuredEnv ?? {};
   // When an accepted channel is sticky, never fall back to a different sink.
   const stickyChannel = requireChannel != null;
   if (config.kind === 'vela') {
@@ -3357,7 +3310,6 @@ export async function reportRunFeedback(
       return;
     }
     await postVelaBatch(config, batch, installationId, fetchImpl, {
-      configuredEnv,
       deliveryPurpose: opts.deliveryPurpose ?? 'final',
       // Keep scores on the accepted channel; never anonymous-overwrite sticky.
       allowAnonymousFallback: !stickyChannel,

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -265,6 +265,11 @@ export function clearRunAwaitingFinalAcceptance(
   // custom reason if live consent flipped off while waiting.
   const flushPrefs = prefsForDeferredFeedbackFlush(pending.ctx.prefs);
   if (flushPrefs == null) return;
+  // Submit-time opts may pin a Vela Control Key / profile. Logout or AMR
+  // switch during the awaiting window must not reuse that stale sink on the
+  // canonical fallback path — strip config so resolveReportConfig re-reads
+  // the live env (same idea as flushReportOpts on accepted-body flush).
+  const { config: _staleSubmitConfig, ...canonicalFlushOpts } = pending.opts;
   void reportRunFeedback(
     {
       ...pending.ctx,
@@ -272,7 +277,7 @@ export function clearRunAwaitingFinalAcceptance(
       // Never invent `:tf` without acceptance; canonical is the legacy target.
       traceId: key,
     },
-    pending.opts,
+    canonicalFlushOpts,
   ).catch((err) => {
     console.warn(
       '[langfuse-trace] legacy/canonical deferred feedback flush failed:',

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -194,20 +194,28 @@ export function resetAcceptedFinalTraceBodyIdsForTests(): void {
  * 1. Explicit override (`traceId`)
  * 2. Process-local accepted final delivery body id
  * 3. Persisted accepted final-purpose body id (survives daemon restart)
- * 4. Derive from run status + message finalization (mirrors terminal_fallback rules)
- * 5. Canonical runId
+ * 4. Canonical runId
  *
- * Prefer accepted delivery memory/persistence over raw `telemetry_finalized_at`:
- * a failed/canceled run may accept `terminal_fallback`, later finalize a
- * message, then fail `final_message` delivery. Feedback must still target the
- * accepted `:tf` body rather than a never-accepted canonical id.
+ * Never invent a `:tf` body id from run status alone. Immediate feedback after
+ * a failed/canceled run can arrive before `terminal_fallback` is accepted (or
+ * while a late `final_message` still cancels the fallback timer). Scoring onto
+ * a not-yet-accepted `:tf` id permanently detaches feedback from the real
+ * trace. Prefer accepted delivery memory/persistence so feedback attaches only
+ * to a body that was actually accepted.
+ *
+ * `runStatus` / `telemetryFinalized` remain accepted inputs for callers that
+ * already load them from the DB anchor, but they do not rewrite the body id.
  */
 export function resolveFeedbackTraceId(input: {
   runId: string;
   /** Explicit override (e.g. caller already resolved the anchor). */
   traceId?: string | null;
+  /** Terminal run status from the feedback anchor (informational; not used to invent `:tf`). */
   runStatus?: string | null;
-  /** True when the assistant message was telemetry-finalized (final_message path). */
+  /**
+   * True when the assistant message was telemetry-finalized (final_message path).
+   * Informational for callers; not used to invent a body id.
+   */
   telemetryFinalized?: boolean;
   /**
    * Accepted final-purpose body id persisted on the message row. Used when
@@ -226,14 +234,10 @@ export function resolveFeedbackTraceId(input: {
       ? input.acceptedTraceBodyId.trim()
       : '';
   if (accepted) return accepted;
-  // Failed/canceled runs that never reach a telemetry-finalized final_message
-  // only have the terminal_fallback body namespace in Langfuse/Vela.
-  if (
-    input.telemetryFinalized !== true &&
-    (input.runStatus === 'failed' || input.runStatus === 'canceled')
-  ) {
-    return scopedTelemetryBodyId(runId, 'final', 'terminal_fallback');
-  }
+  // Keep the canonical id until an accepted final-purpose body is known.
+  // Status-based `:tf` rewrite would attach scores to a nonexistent trace when
+  // feedback arrives before terminal_fallback acceptance (or when late
+  // finalization cancels the fallback and only publishes runId).
   return runId;
 }
 
@@ -529,18 +533,19 @@ export interface ReportRunOpts {
  * Payload sent to Langfuse when a user thumbs-up/down's an assistant turn.
  *
  * Scores attach to the accepted final-purpose body id for the run (canonical
- * `runId` after final_message, or `${runId}:tf` for terminal_fallback-only
- * completions). Callers may pass an explicit `traceId`, or supply run status +
- * finalization so resolveFeedbackTraceId can derive the anchor.
+ * `runId` after final_message, or `${runId}:tf` after an accepted
+ * terminal_fallback). Callers may pass an explicit `traceId`, or rely on
+ * resolveFeedbackTraceId accepted-delivery memory / persisted anchor.
  */
 export interface FeedbackReportContext {
   runId: string;
   /**
    * Langfuse body id the score should attach to. When omitted, derived via
-   * resolveFeedbackTraceId from accepted-delivery memory and/or run status.
+   * resolveFeedbackTraceId from accepted-delivery memory (process-local or
+   * persisted). Without an accepted anchor, defaults to the canonical runId.
    */
   traceId?: string;
-  /** Terminal run status; used to derive the fallback `:tf` body id. */
+  /** Terminal run status from the feedback anchor (optional context). */
   runStatus?: string | null;
   /** True when the assistant message was telemetry-finalized. */
   telemetryFinalized?: boolean;

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -92,6 +92,7 @@ export type LangfuseDropReason =
   | 'vela_413'
   | 'vela_429'
   | 'vela_5xx'
+  | 'timeout'
   | 'network_error';
 
 export interface LangfuseDeliveryState {
@@ -2102,12 +2103,14 @@ async function postVelaBatch(
       }
       // Network/timeout after retries: do NOT anonymous-fallback. Vela may have
       // already accepted the batch; anonymous write could overwrite identity.
+      // Surface timeout separately from network_error so telemetry can tell
+      // upstream slowness apart from transport failures.
       const errorKind = classifyFetchError(error);
       console.warn(`[langfuse-trace] Vela telemetry fetch error: ${errorKind}`);
       return {
         langfuse_expected: true,
         langfuse_delivery_status: 'failed',
-        langfuse_drop_reason: 'network_error',
+        langfuse_drop_reason: errorKind,
       };
     }
   }

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -193,8 +193,14 @@ export function resetAcceptedFinalTraceBodyIdsForTests(): void {
  * Priority:
  * 1. Explicit override (`traceId`)
  * 2. Process-local accepted final delivery body id
- * 3. Derive from run status + message finalization (mirrors terminal_fallback rules)
- * 4. Canonical runId
+ * 3. Persisted accepted final-purpose body id (survives daemon restart)
+ * 4. Derive from run status + message finalization (mirrors terminal_fallback rules)
+ * 5. Canonical runId
+ *
+ * Prefer accepted delivery memory/persistence over raw `telemetry_finalized_at`:
+ * a failed/canceled run may accept `terminal_fallback`, later finalize a
+ * message, then fail `final_message` delivery. Feedback must still target the
+ * accepted `:tf` body rather than a never-accepted canonical id.
  */
 export function resolveFeedbackTraceId(input: {
   runId: string;
@@ -203,6 +209,11 @@ export function resolveFeedbackTraceId(input: {
   runStatus?: string | null;
   /** True when the assistant message was telemetry-finalized (final_message path). */
   telemetryFinalized?: boolean;
+  /**
+   * Accepted final-purpose body id persisted on the message row. Used when
+   * process-local memory is cold after a daemon restart.
+   */
+  acceptedTraceBodyId?: string | null;
 }): string {
   const runId = typeof input.runId === 'string' ? input.runId.trim() : '';
   if (!runId) return typeof input.runId === 'string' ? input.runId : '';
@@ -210,6 +221,11 @@ export function resolveFeedbackTraceId(input: {
   if (explicit) return explicit;
   const remembered = acceptedFinalTraceBodyIds.get(runId);
   if (remembered?.bodyId) return remembered.bodyId;
+  const accepted =
+    typeof input.acceptedTraceBodyId === 'string'
+      ? input.acceptedTraceBodyId.trim()
+      : '';
+  if (accepted) return accepted;
   // Failed/canceled runs that never reach a telemetry-finalized final_message
   // only have the terminal_fallback body namespace in Langfuse/Vela.
   if (
@@ -1576,8 +1592,9 @@ export function buildTracePayload(
 ): unknown[] {
   // Object-registration needs manifests for upload authority but must not
   // double-write turn text when the final delivery goes through Vela.
-  // `wantsTextContent` gates prompt/output/tool I/O; `wantsArtifacts` gates
-  // object manifests used by the worker object-scope registry.
+  // `wantsTextContent` gates prompt/output/tool I/O and stream-tail metadata
+  // (stderr/stdout/diagnostics); `wantsArtifacts` gates object manifests used
+  // by the worker object-scope registry.
   const consentOn =
     ctx.prefs.metrics === true && ctx.prefs.content === true;
   const wantsTextContent = deliveryPurpose === 'final' && consentOn;
@@ -1705,9 +1722,12 @@ export function buildTracePayload(
     ...langfuseDelivery,
     ...(ctx.run.failure ?? {}),
     ...(ctx.run.timings ?? {}),
-    stderr: ctx.run.stderr,
-    stdout: ctx.run.stdout,
-    diagnostics: ctx.run.diagnostics,
+    // Stream tails and run diagnostics can contain raw CLI output after secret
+    // redaction. Keep them off object-registration so the anonymous relay never
+    // double-writes turn content that the final Vela delivery owns.
+    stderr: wantsTextContent ? ctx.run.stderr : undefined,
+    stdout: wantsTextContent ? ctx.run.stdout : undefined,
+    diagnostics: wantsTextContent ? ctx.run.diagnostics : undefined,
     eventsSummary: ctx.eventsSummary,
     tokens,
     cost_usd: costBreakdown.cost_usd,

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -864,6 +864,41 @@ export function readTelemetrySinkConfig(
 }
 
 /**
+ * Resolve the sink for a sticky accepted delivery channel.
+ *
+ * Feedback scores must attach to the same transport that accepted the final
+ * body. Preferring the global Vela → relay → langfuse order would skip a still-
+ * available lower-priority channel when a higher one appears later (login,
+ * env change) and fail sticky delivery with `skipped_no_sink`.
+ *
+ * When `channel` is null/undefined, falls back to {@link readTelemetrySinkConfig}.
+ */
+export function readTelemetrySinkConfigForChannel(
+  channel: TelemetryDeliveryChannel | null | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+  configuredEnv: Record<string, string> = {},
+): TelemetrySinkConfig | null {
+  if (channel === 'vela') {
+    return readVelaTelemetrySinkConfig(env, configuredEnv);
+  }
+  if (channel === 'relay') {
+    const relayUrl = env.OPEN_DESIGN_TELEMETRY_RELAY_URL?.trim();
+    if (!relayUrl) return null;
+    return {
+      kind: 'relay',
+      relayUrl: relayUrl.replace(/\/+$/, ''),
+      timeoutMs: readTelemetryTimeoutMs(env),
+      retries: readTelemetryRetries(env),
+    };
+  }
+  if (channel === 'langfuse') {
+    const config = readLangfuseConfig(env);
+    return config == null ? null : { kind: 'langfuse', ...config };
+  }
+  return readTelemetrySinkConfig(env, configuredEnv);
+}
+
+/**
  * Whether feedback telemetry can actually be delivered for this sink +
  * installation. Shared by the daemon preflight (`accepted` vs
  * `skipped_no_sink`) and `reportRunFeedback` so both use the same rule:
@@ -889,18 +924,21 @@ export function canDeliverRunFeedback(
   const requireChannel = opts.requireChannel ?? null;
   if (requireChannel) {
     if (sink.kind !== requireChannel) return false;
-    // Narrow on sink.kind (not requireChannel): TS does not refine a union
-    // through equality with a separate variable of the same string-literal union.
-    if (sink.kind === 'vela') {
-      if (!installationId?.trim()) return false;
-      const requiredIdentity =
-        typeof opts.requireVelaIdentity === 'string'
-          ? opts.requireVelaIdentity.trim()
-          : '';
-      if (requiredIdentity) {
-        const current = velaSinkIdentityFingerprint(sink.profile, sink.controlKey);
-        if (!current || current !== requiredIdentity) return false;
-      }
+    // Explicit early return so TS narrows to the Vela variant before we read
+    // profile/controlKey (requireChannel equality alone does not narrow sink).
+    if (sink.kind !== 'vela') return true;
+    const velaSink: Extract<TelemetrySinkConfig, { kind: 'vela' }> = sink;
+    if (!installationId?.trim()) return false;
+    const requiredIdentity =
+      typeof opts.requireVelaIdentity === 'string'
+        ? opts.requireVelaIdentity.trim()
+        : '';
+    if (requiredIdentity) {
+      const current = velaSinkIdentityFingerprint(
+        velaSink.profile,
+        velaSink.controlKey,
+      );
+      if (!current || current !== requiredIdentity) return false;
     }
     return true;
   }
@@ -2807,9 +2845,16 @@ function normalizeTelemetrySinkConfig(
 
 function resolveReportConfig(
   opts: ReportRunOpts,
+  stickyChannel: TelemetryDeliveryChannel | null = null,
 ): TelemetrySinkConfig | null {
   if (opts.config === undefined) {
-    return readTelemetrySinkConfig(process.env, opts.configuredEnv ?? {});
+    // Honor sticky accepted channel so feedback does not jump to a higher-
+    // priority sink that appeared after the final body was accepted.
+    return readTelemetrySinkConfigForChannel(
+      stickyChannel,
+      process.env,
+      opts.configuredEnv ?? {},
+    );
   }
   if (opts.config == null) return null;
   return normalizeTelemetrySinkConfig(opts.config);
@@ -3124,9 +3169,9 @@ export async function reportRunFeedback(
   if (ctx.prefs.metrics !== true) return;
   if (ctx.prefs.content !== true) return;
 
-  const config = resolveReportConfig(opts);
   // Sticky exact channel: once a final body was accepted on relay/langfuse/vela,
   // feedback must stay on that same transport (body id namespaces diverge).
+  // Resolve the channel first so sink selection honors it over global priority.
   const requireChannel: TelemetryDeliveryChannel | null =
     ctx.acceptedDeliveryChannel === 'vela' ||
     ctx.acceptedDeliveryChannel === 'relay' ||
@@ -3140,6 +3185,7 @@ export async function reportRunFeedback(
           ? ctx.acceptedVelaIdentity.trim()
           : getAcceptedFinalVelaIdentity(ctx.runId))
       : null;
+  const config = resolveReportConfig(opts, requireChannel);
   // Same eligibility as reportRunFeedbackFromDaemon preflight: exact channel
   // match when an accepted anchor exists; Vela also needs installationId +
   // matching accepting-account fingerprint when known.

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -1002,9 +1002,16 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         const appCfgAtFinish = await readAppConfig(RUNTIME_DATA_DIR).catch(
           () => ({} as Record<string, unknown>),
         );
+        // Match langfuse-bridge delivery: Settings AMR profile env must reach
+        // sink resolution so run_finished delivery metrics stay consistent with
+        // the actual Vela/anonymous path for non-default profiles.
+        const configuredAmrEnvAtFinish = agentCliEnvForAgent(
+          (appCfgAtFinish as { agentCliEnv?: AgentCliEnv }).agentCliEnv,
+          'amr',
+        );
         const langfuseDeliveryForAnalytics = deriveLangfuseDeliveryState(
           (appCfgAtFinish as { telemetry?: Record<string, unknown> }).telemetry ?? {},
-          readTelemetrySinkConfig(),
+          readTelemetrySinkConfig(process.env, configuredAmrEnvAtFinish),
         );
         const result = runResultFromStatus(status.status);
         const errorCode = deriveRunErrorCode(status);

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -1009,9 +1009,17 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
           (appCfgAtFinish as { agentCliEnv?: AgentCliEnv }).agentCliEnv,
           'amr',
         );
+        const installationIdAtFinish =
+          typeof (appCfgAtFinish as { installationId?: unknown }).installationId ===
+          'string'
+            ? (appCfgAtFinish as { installationId: string }).installationId
+            : null;
+        // Same eligibility as reportRunCompleted: Vela without installationId
+        // (and without anonymous fallback) is not `queued`.
         const langfuseDeliveryForAnalytics = deriveLangfuseDeliveryState(
           (appCfgAtFinish as { telemetry?: Record<string, unknown> }).telemetry ?? {},
           readTelemetrySinkConfig(process.env, configuredAmrEnvAtFinish),
+          { installationId: installationIdAtFinish },
         );
         const result = runResultFromStatus(status.status);
         const errorCode = deriveRunErrorCode(status);

--- a/apps/daemon/src/routes/telemetry.ts
+++ b/apps/daemon/src/routes/telemetry.ts
@@ -26,10 +26,12 @@ export interface DaemonTelemetry {
 export interface RegisterTelemetryRoutesDeps {
   dataDir: string;
   readAppConfig: typeof readAppConfig;
+  /** Optional SQLite handle for feedback → accepted-trace-id derivation. */
+  db?: unknown;
 }
 
 export function registerTelemetryRoutes(app: Express, deps: RegisterTelemetryRoutesDeps): DaemonTelemetry {
-  const { dataDir } = deps;
+  const { dataDir, db } = deps;
   const analyticsService = createAnalyticsService({ dataDir });
   let cachedAppVersion: any = null;
 
@@ -119,6 +121,7 @@ export function registerTelemetryRoutes(app: Express, deps: RegisterTelemetryRou
     reportFeedback: (req) =>
       reportRunFeedbackFromDaemon({
         dataDir,
+        ...(db ? { db } : {}),
         ...req,
       }),
   };

--- a/apps/daemon/src/runtimes/chat-run-messages.ts
+++ b/apps/daemon/src/runtimes/chat-run-messages.ts
@@ -357,6 +357,10 @@ export function pinAssistantMessageOnRunCreate(db: SqliteDb, run: ChatRunMessage
               telemetry_accepted_delivery_channel = CASE
                 WHEN ? THEN NULL
                 ELSE telemetry_accepted_delivery_channel
+              END,
+              telemetry_accepted_vela_identity = CASE
+                WHEN ? THEN NULL
+                ELSE telemetry_accepted_vela_identity
               END
         WHERE id = ?`,
     ).run(
@@ -373,6 +377,7 @@ export function pinAssistantMessageOnRunCreate(db: SqliteDb, run: ChatRunMessage
       clearAcceptedTelemetryAnchor ? 1 : 0,
       run.createdAt,
       run.createdAt,
+      clearAcceptedTelemetryAnchor ? 1 : 0,
       clearAcceptedTelemetryAnchor ? 1 : 0,
       clearAcceptedTelemetryAnchor ? 1 : 0,
       clearAcceptedTelemetryAnchor ? 1 : 0,

--- a/apps/daemon/src/runtimes/chat-run-messages.ts
+++ b/apps/daemon/src/runtimes/chat-run-messages.ts
@@ -281,9 +281,20 @@ function liveArtifactRefreshPhase(value: unknown): 'started' | 'succeeded' | 'fa
 export function pinAssistantMessageOnRunCreate(db: SqliteDb, run: ChatRunMessageState): void {
   if (!run.conversationId || !run.assistantMessageId) return;
   const existing = db
-    .prepare(`SELECT id FROM messages WHERE id = ?`)
-    .get(run.assistantMessageId);
+    .prepare(`SELECT id, run_id AS runId FROM messages WHERE id = ?`)
+    .get(run.assistantMessageId) as { id: string; runId?: string | null } | undefined;
   if (existing) {
+    // Side-chat retry reuses the failed assistant message id with a new
+    // run_id via this raw pin path (not upsertMessage). Drop accepted-
+    // telemetry anchors from the previous run so early feedback cannot
+    // score the old `${oldRunId}:tf` body.
+    const prevRunId =
+      typeof existing.runId === 'string' && existing.runId.trim()
+        ? existing.runId.trim()
+        : null;
+    const nextRunId =
+      typeof run.id === 'string' && run.id.trim() ? run.id.trim() : null;
+    const clearAcceptedTelemetryAnchor = prevRunId !== nextRunId;
     db.prepare(
       `UPDATE messages
           SET run_id = ?,
@@ -293,7 +304,15 @@ export function pinAssistantMessageOnRunCreate(db: SqliteDb, run: ChatRunMessage
               END,
               session_mode = ?,
               run_context_json = ?,
-              started_at = COALESCE(started_at, ?)
+              started_at = COALESCE(started_at, ?),
+              telemetry_accepted_body_id = CASE
+                WHEN ? THEN NULL
+                ELSE telemetry_accepted_body_id
+              END,
+              telemetry_accepted_report_trigger = CASE
+                WHEN ? THEN NULL
+                ELSE telemetry_accepted_report_trigger
+              END
         WHERE id = ?`,
     ).run(
       run.id,
@@ -301,6 +320,8 @@ export function pinAssistantMessageOnRunCreate(db: SqliteDb, run: ChatRunMessage
       run.sessionMode ?? null,
       run.context ? JSON.stringify(run.context) : null,
       run.createdAt,
+      clearAcceptedTelemetryAnchor ? 1 : 0,
+      clearAcceptedTelemetryAnchor ? 1 : 0,
       run.assistantMessageId,
     );
     return;

--- a/apps/daemon/src/runtimes/chat-run-messages.ts
+++ b/apps/daemon/src/runtimes/chat-run-messages.ts
@@ -317,6 +317,10 @@ export function pinAssistantMessageOnRunCreate(db: SqliteDb, run: ChatRunMessage
               telemetry_accepted_report_trigger = CASE
                 WHEN ? THEN NULL
                 ELSE telemetry_accepted_report_trigger
+              END,
+              telemetry_accepted_delivery_channel = CASE
+                WHEN ? THEN NULL
+                ELSE telemetry_accepted_delivery_channel
               END
         WHERE id = ?`,
     ).run(
@@ -325,6 +329,7 @@ export function pinAssistantMessageOnRunCreate(db: SqliteDb, run: ChatRunMessage
       run.sessionMode ?? null,
       run.context ? JSON.stringify(run.context) : null,
       run.createdAt,
+      clearAcceptedTelemetryAnchor ? 1 : 0,
       clearAcceptedTelemetryAnchor ? 1 : 0,
       clearAcceptedTelemetryAnchor ? 1 : 0,
       clearAcceptedTelemetryAnchor ? 1 : 0,

--- a/apps/daemon/src/runtimes/chat-run-messages.ts
+++ b/apps/daemon/src/runtimes/chat-run-messages.ts
@@ -286,8 +286,9 @@ export function pinAssistantMessageOnRunCreate(db: SqliteDb, run: ChatRunMessage
   if (existing) {
     // Side-chat retry reuses the failed assistant message id with a new
     // run_id via this raw pin path (not upsertMessage). Drop accepted-
-    // telemetry anchors from the previous run so early feedback cannot
-    // score the old `${oldRunId}:tf` body.
+    // telemetry anchors and the finalization gate from the previous run so
+    // early feedback cannot score the old `${oldRunId}:tf` body and
+    // terminal-fallback telemetry is not skipped for the new run.
     const prevRunId =
       typeof existing.runId === 'string' && existing.runId.trim()
         ? existing.runId.trim()
@@ -305,6 +306,10 @@ export function pinAssistantMessageOnRunCreate(db: SqliteDb, run: ChatRunMessage
               session_mode = ?,
               run_context_json = ?,
               started_at = COALESCE(started_at, ?),
+              telemetry_finalized_at = CASE
+                WHEN ? THEN NULL
+                ELSE telemetry_finalized_at
+              END,
               telemetry_accepted_body_id = CASE
                 WHEN ? THEN NULL
                 ELSE telemetry_accepted_body_id
@@ -320,6 +325,7 @@ export function pinAssistantMessageOnRunCreate(db: SqliteDb, run: ChatRunMessage
       run.sessionMode ?? null,
       run.context ? JSON.stringify(run.context) : null,
       run.createdAt,
+      clearAcceptedTelemetryAnchor ? 1 : 0,
       clearAcceptedTelemetryAnchor ? 1 : 0,
       clearAcceptedTelemetryAnchor ? 1 : 0,
       run.assistantMessageId,

--- a/apps/daemon/src/runtimes/chat-run-messages.ts
+++ b/apps/daemon/src/runtimes/chat-run-messages.ts
@@ -303,7 +303,11 @@ export function pinAssistantMessageOnRunCreate(db: SqliteDb, run: ChatRunMessage
     // or started_at/ended_at from run A would mark run B as already
     // delivery_failed/no_result and leak stale duration into conversation
     // summaries (conversationRunSummaryFromRow trusts any finite pair).
-    // Same-run re-pins still preserve terminal status and timestamps.
+    // Also clear assistant payload columns (content / produced_files /
+    // trace_object_files): reportRunCompletedFromDaemon trusts any row whose
+    // runId === run.id, so a fail-before-upsert for run B would otherwise
+    // publish run A's stale output and manifests under B's trace.
+    // Same-run re-pins still preserve terminal status, timestamps, and payload.
     db.prepare(
       `UPDATE messages
           SET run_id = ?,
@@ -315,6 +319,18 @@ export function pinAssistantMessageOnRunCreate(db: SqliteDb, run: ChatRunMessage
               result_delivery_state = CASE
                 WHEN ? THEN NULL
                 ELSE result_delivery_state
+              END,
+              content = CASE
+                WHEN ? THEN ''
+                ELSE content
+              END,
+              produced_files_json = CASE
+                WHEN ? THEN NULL
+                ELSE produced_files_json
+              END,
+              trace_object_files_json = CASE
+                WHEN ? THEN NULL
+                ELSE trace_object_files_json
               END,
               session_mode = ?,
               run_context_json = ?,
@@ -348,6 +364,9 @@ export function pinAssistantMessageOnRunCreate(db: SqliteDb, run: ChatRunMessage
       clearAcceptedTelemetryAnchor ? 1 : 0,
       run.status,
       run.status,
+      clearAcceptedTelemetryAnchor ? 1 : 0,
+      clearAcceptedTelemetryAnchor ? 1 : 0,
+      clearAcceptedTelemetryAnchor ? 1 : 0,
       clearAcceptedTelemetryAnchor ? 1 : 0,
       run.sessionMode ?? null,
       run.context ? JSON.stringify(run.context) : null,

--- a/apps/daemon/src/runtimes/chat-run-messages.ts
+++ b/apps/daemon/src/runtimes/chat-run-messages.ts
@@ -296,10 +296,17 @@ export function pinAssistantMessageOnRunCreate(db: SqliteDb, run: ChatRunMessage
     const nextRunId =
       typeof run.id === 'string' && run.id.trim() ? run.id.trim() : null;
     const clearAcceptedTelemetryAnchor = prevRunId !== nextRunId;
+    // Ownership change (retry reusing the assistant id under a new run_id)
+    // must write the new run's status. Preserving a prior terminal
+    // run_status would make a fresh retry look completed until the next
+    // message upsert, so feedback and other terminal-state logic can
+    // observe run B as failed/succeeded/canceled before it produces output.
+    // Same-run re-pins still preserve an already-terminal status.
     db.prepare(
       `UPDATE messages
           SET run_id = ?,
               run_status = CASE
+                WHEN ? THEN ?
                 WHEN run_status IN ('succeeded', 'failed', 'canceled') THEN run_status
                 ELSE ?
               END,
@@ -325,6 +332,8 @@ export function pinAssistantMessageOnRunCreate(db: SqliteDb, run: ChatRunMessage
         WHERE id = ?`,
     ).run(
       run.id,
+      clearAcceptedTelemetryAnchor ? 1 : 0,
+      run.status,
       run.status,
       run.sessionMode ?? null,
       run.context ? JSON.stringify(run.context) : null,

--- a/apps/daemon/src/runtimes/chat-run-messages.ts
+++ b/apps/daemon/src/runtimes/chat-run-messages.ts
@@ -297,11 +297,13 @@ export function pinAssistantMessageOnRunCreate(db: SqliteDb, run: ChatRunMessage
       typeof run.id === 'string' && run.id.trim() ? run.id.trim() : null;
     const clearAcceptedTelemetryAnchor = prevRunId !== nextRunId;
     // Ownership change (retry reusing the assistant id under a new run_id)
-    // must write the new run's status. Preserving a prior terminal
-    // run_status would make a fresh retry look completed until the next
-    // message upsert, so feedback and other terminal-state logic can
-    // observe run B as failed/succeeded/canceled before it produces output.
-    // Same-run re-pins still preserve an already-terminal status.
+    // must write the new run's status and clear run-owned terminal metadata.
+    // Preserving a prior terminal run_status would make a fresh retry look
+    // completed until the next message upsert; leaving result_delivery_state
+    // or started_at/ended_at from run A would mark run B as already
+    // delivery_failed/no_result and leak stale duration into conversation
+    // summaries (conversationRunSummaryFromRow trusts any finite pair).
+    // Same-run re-pins still preserve terminal status and timestamps.
     db.prepare(
       `UPDATE messages
           SET run_id = ?,
@@ -310,9 +312,20 @@ export function pinAssistantMessageOnRunCreate(db: SqliteDb, run: ChatRunMessage
                 WHEN run_status IN ('succeeded', 'failed', 'canceled') THEN run_status
                 ELSE ?
               END,
+              result_delivery_state = CASE
+                WHEN ? THEN NULL
+                ELSE result_delivery_state
+              END,
               session_mode = ?,
               run_context_json = ?,
-              started_at = COALESCE(started_at, ?),
+              started_at = CASE
+                WHEN ? THEN ?
+                ELSE COALESCE(started_at, ?)
+              END,
+              ended_at = CASE
+                WHEN ? THEN NULL
+                ELSE ended_at
+              END,
               telemetry_finalized_at = CASE
                 WHEN ? THEN NULL
                 ELSE telemetry_finalized_at
@@ -335,9 +348,13 @@ export function pinAssistantMessageOnRunCreate(db: SqliteDb, run: ChatRunMessage
       clearAcceptedTelemetryAnchor ? 1 : 0,
       run.status,
       run.status,
+      clearAcceptedTelemetryAnchor ? 1 : 0,
       run.sessionMode ?? null,
       run.context ? JSON.stringify(run.context) : null,
+      clearAcceptedTelemetryAnchor ? 1 : 0,
       run.createdAt,
+      run.createdAt,
+      clearAcceptedTelemetryAnchor ? 1 : 0,
       clearAcceptedTelemetryAnchor ? 1 : 0,
       clearAcceptedTelemetryAnchor ? 1 : 0,
       clearAcceptedTelemetryAnchor ? 1 : 0,

--- a/apps/daemon/src/server-context.ts
+++ b/apps/daemon/src/server-context.ts
@@ -75,6 +75,11 @@ export interface TelemetryDeps {
       projectId?: string;
       conversationId?: string;
       reportTrigger?: 'final_message' | 'terminal_fallback';
+      /**
+       * Schedule-time awaiting token from markRunAwaitingFinalAcceptance so the
+       * terminal_fallback delay and report share one in-flight attempt.
+       */
+      awaitingToken?: string;
     },
   ) => void;
   /**

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -385,7 +385,11 @@ import {
   snapshotAiHtmlVersionsForRun,
 } from './run-html-version-snapshots.js';
 import { reportRunCompletedFromDaemon } from './langfuse-bridge.js';
-import { scopedTelemetryBodyId } from './langfuse-trace.js';
+import {
+  clearRunAwaitingFinalAcceptance,
+  markRunAwaitingFinalAcceptance,
+  scopedTelemetryBodyId,
+} from './langfuse-trace.js';
 import { buildPromptStackTelemetry } from './prompt-telemetry.js';
 import { readAnalyticsContext } from './analytics.js';
 import {
@@ -1541,40 +1545,52 @@ export function createFinalizedMessageTelemetryReporter({
     if (reportTrigger !== 'terminal_fallback') {
       reportedRuns.add(run.id);
     }
+    // Cover the live finalization race: message is already telemetry_finalized
+    // before async reportRunCompleted can rememberAcceptedFinalTraceBodyId.
+    // Feedback during this window defers; cold finalized/no-anchor rows without
+    // this mark ship on the canonical body instead of queueing forever.
+    markRunAwaitingFinalAcceptance(run.id);
     void (async () => {
       const start = Date.now();
-      const delivery = await report({
-        db,
-        dataDir,
-        run,
-        persistedRunStatus: saved.runStatus,
-        persistedEndedAt: saved.endedAt,
-        appVersion: getAppVersion(),
-        reportTrigger,
-      });
-      const state = delivery ?? {
-        langfuse_expected: true,
-        langfuse_delivery_status: 'accepted',
-      };
-      captureResult({
-        analyticsContext: options.analyticsContext,
-        conversationId: options.conversationId ?? saved.conversationId,
-        delivery: state,
-        durationMs: Date.now() - start,
-        projectId: options.projectId,
-        reportTrigger,
-        reportResult: state.langfuse_expected === false
-          ? 'skipped'
-          : state.langfuse_delivery_status === 'accepted'
-            ? 'accepted'
-            : state.langfuse_delivery_status === 'failed'
-              ? 'failed'
-              : 'skipped',
-        run,
-        runId: run.id,
-        skipReason: state.langfuse_expected === false ? 'not_expected' : undefined,
-        status: saved.runStatus,
-      });
+      try {
+        const delivery = await report({
+          db,
+          dataDir,
+          run,
+          persistedRunStatus: saved.runStatus,
+          persistedEndedAt: saved.endedAt,
+          appVersion: getAppVersion(),
+          reportTrigger,
+        });
+        const state = delivery ?? {
+          langfuse_expected: true,
+          langfuse_delivery_status: 'accepted',
+        };
+        captureResult({
+          analyticsContext: options.analyticsContext,
+          conversationId: options.conversationId ?? saved.conversationId,
+          delivery: state,
+          durationMs: Date.now() - start,
+          projectId: options.projectId,
+          reportTrigger,
+          reportResult: state.langfuse_expected === false
+            ? 'skipped'
+            : state.langfuse_delivery_status === 'accepted'
+              ? 'accepted'
+              : state.langfuse_delivery_status === 'failed'
+                ? 'failed'
+                : 'skipped',
+          run,
+          runId: run.id,
+          skipReason: state.langfuse_expected === false ? 'not_expected' : undefined,
+          status: saved.runStatus,
+        });
+      } finally {
+        // On accept, rememberAcceptedFinalTraceBodyId already cleared the mark
+        // and flushed deferred scores. On failure/skip, release any queue onto
+        // the canonical body so scores are not stranded until process exit.
+        clearRunAwaitingFinalAcceptance(run.id);
+      }
     })();
   };
 }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -2519,7 +2519,14 @@ export async function startServer({
     const timer = setTimeout(() => {
       if (reportedRuns.has(run.id)) return;
       if (run.assistantMessageId) {
-        const messageTelemetry = getMessageTelemetryFinalizationState(db, run.assistantMessageId);
+        // Run-scoped: a later run may reuse this assistant row and finalize
+        // before our delayed fallback fires. Message-id-only lookup would see
+        // the new run's finalized_at and drop this run's terminal_fallback.
+        const messageTelemetry = getMessageTelemetryFinalizationState(
+          db,
+          run.assistantMessageId,
+          run.id,
+        );
         if (messageTelemetry.finalizedAt !== null) return;
       }
       reportFinalizedMessage(

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -2467,6 +2467,7 @@ export async function startServer({
   const telemetry = registerTelemetryRoutes(app, {
     dataDir: RUNTIME_DATA_DIR,
     readAppConfig,
+    db,
   });
   const { analyticsService } = telemetry;
   const design = {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -385,6 +385,7 @@ import {
   snapshotAiHtmlVersionsForRun,
 } from './run-html-version-snapshots.js';
 import { reportRunCompletedFromDaemon } from './langfuse-bridge.js';
+import { scopedTelemetryBodyId } from './langfuse-trace.js';
 import { buildPromptStackTelemetry } from './prompt-telemetry.js';
 import { readAnalyticsContext } from './analytics.js';
 import {
@@ -1475,7 +1476,9 @@ export function createFinalizedMessageTelemetryReporter({
         project_id: run?.projectId ?? projectId ?? null,
         conversation_id: run?.conversationId ?? conversationId ?? null,
         run_id: runId,
-        langfuse_trace_id: runId,
+        // Correlate analytics to the body id that was actually written
+        // (terminal_fallback uses runId:tf; final_message keeps runId).
+        langfuse_trace_id: scopedTelemetryBodyId(runId, 'final', reportTrigger),
         langfuse_expected: delivery.langfuse_expected,
         langfuse_delivery_status: delivery.langfuse_delivery_status,
         ...(delivery.langfuse_drop_reason

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -388,6 +388,7 @@ import { reportRunCompletedFromDaemon } from './langfuse-bridge.js';
 import {
   clearRunAwaitingFinalAcceptance,
   configureDeferredFeedbackDataDir,
+  configureDeferredFeedbackOwnerCheck,
   markRunAwaitingFinalAcceptance,
   scopedTelemetryBodyId,
 } from './langfuse-trace.js';
@@ -544,6 +545,7 @@ import {
   normalizeConversationSessionMode,
   deleteRoutine as dbDeleteRoutine,
   openDatabase,
+  runHasLiveTelemetryOwner,
   setTabs,
   updateConversation,
   updatePreviewCommentStatus,
@@ -2295,6 +2297,13 @@ export async function startServer({
     next();
   });
   const db = openDatabase(PROJECT_ROOT, { dataDir: RUNTIME_DATA_DIR });
+  // Deferred feedback flushes re-check live conversation ownership so a late
+  // terminal_fallback accept after conversation/project delete cannot ship
+  // queued custom reasons (setRunTelemetryAcceptedAnchor already refuses the
+  // unowned DB row, but process-local flush runs earlier).
+  configureDeferredFeedbackOwnerCheck((input) =>
+    runHasLiveTelemetryOwner(db, input),
+  );
   // Restore paired browser-extension origins into the in-memory allowlist the
   // /api origin middleware above consults, so a paired clipper survives daemon
   // restarts without re-pairing.

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1501,7 +1501,12 @@ export function createFinalizedMessageTelemetryReporter({
     });
   };
   return (saved, body = {}, options = {}) => {
-    if (!shouldReportRunCompletedFromMessage(saved, body)) return;
+    if (!shouldReportRunCompletedFromMessage(saved, body)) {
+      // terminal_fallback may have marked at timer schedule; release if this
+      // path never starts a report that would clear in finally.
+      if (saved?.runId) clearRunAwaitingFinalAcceptance(saved.runId);
+      return;
+    }
     const runId = saved.runId;
     const run = design.runs.get(runId);
     if (!run) {
@@ -1520,6 +1525,8 @@ export function createFinalizedMessageTelemetryReporter({
         skipReason: 'run_not_found',
         status: saved.runStatus,
       });
+      // Schedule-only awaiting mark must not outlive a skipped report.
+      clearRunAwaitingFinalAcceptance(runId);
       return;
     }
     const reportTrigger = options.reportTrigger ?? 'final_message';
@@ -1540,6 +1547,7 @@ export function createFinalizedMessageTelemetryReporter({
         skipReason: 'duplicate_run',
         status: saved.runStatus,
       });
+      // In-flight final_message owns the mark; do not clear here.
       return;
     }
     if (reportTrigger !== 'terminal_fallback') {
@@ -2535,8 +2543,15 @@ export async function startServer({
     status: string;
   }) => {
     if (!shouldReportRunCompletionTelemetryFallbackStatus(status)) return;
+    // Cover the whole terminal_fallback delay + report flight so mid-window
+    // feedback defers onto `:tf` (or flushes on clear). Cold restarts have no
+    // mark, so failed/canceled feedback must not queue forever on status alone.
+    markRunAwaitingFinalAcceptance(run.id);
     const timer = setTimeout(() => {
-      if (reportedRuns.has(run.id)) return;
+      if (reportedRuns.has(run.id)) {
+        // final_message claimed the run and owns the awaiting-mark lifecycle.
+        return;
+      }
       if (run.assistantMessageId) {
         // Run-scoped: a later run may reuse this assistant row and finalize
         // before our delayed fallback fires. Message-id-only lookup would see
@@ -2546,7 +2561,12 @@ export async function startServer({
           run.assistantMessageId,
           run.id,
         );
-        if (messageTelemetry.finalizedAt !== null) return;
+        if (messageTelemetry.finalizedAt !== null) {
+          // Finalized without claiming reportedRuns (e.g. run already gone) —
+          // release the schedule-only mark so scores are not stranded.
+          clearRunAwaitingFinalAcceptance(run.id);
+          return;
+        }
       }
       reportFinalizedMessage(
         {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -387,6 +387,7 @@ import {
 import { reportRunCompletedFromDaemon } from './langfuse-bridge.js';
 import {
   clearRunAwaitingFinalAcceptance,
+  configureDeferredFeedbackDataDir,
   markRunAwaitingFinalAcceptance,
   scopedTelemetryBodyId,
 } from './langfuse-trace.js';
@@ -809,6 +810,10 @@ const SANDBOX_MODE_ENABLED = isSandboxModeEnabled(process.env);
 const RUNTIME_DATA_DIR = resolveDataDir(process.env.OD_DATA_DIR, PROJECT_ROOT, {
   requireExplicit: SANDBOX_MODE_ENABLED,
 });
+// Deferred feedback consent re-checks must use the resolved data root, not
+// raw process.env.OD_DATA_DIR (which may be unset when the default path is
+// used). See prefsForDeferredFeedbackFlush in langfuse-trace.ts.
+configureDeferredFeedbackDataDir(RUNTIME_DATA_DIR);
 const SANDBOX_RUNTIME = resolveSandboxRuntimeConfig(SANDBOX_MODE_ENABLED, RUNTIME_DATA_DIR);
 ensureSandboxRuntimeDirs(SANDBOX_RUNTIME);
 const PLUGIN_LOCKFILE_PATH = path.join(RUNTIME_DATA_DIR, 'od-plugin-lock.json');
@@ -1613,9 +1618,11 @@ export function createFinalizedMessageTelemetryReporter({
           status: saved.runStatus,
         });
       } finally {
-        // On accept, rememberAcceptedFinalTraceBodyId already cleared all tokens
-        // and flushed deferred scores. On failure/skip, release only this
-        // attempt; other in-flight final-purpose deliveries may still accept.
+        // On final_message accept, rememberAcceptedFinalTraceBodyId clears all
+        // tokens and flushes deferred scores. On terminal_fallback accept,
+        // unrelated in-flight tokens are preserved so a slow final_message can
+        // still re-attach; this finally releases only this attempt's token.
+        // On failure/skip, the same per-token clear applies.
         clearRunAwaitingFinalAcceptance(run.id, awaitingToken || undefined);
       }
     })();

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1509,13 +1509,13 @@ export function createFinalizedMessageTelemetryReporter({
         ? options.awaitingToken.trim()
         : '';
     if (!shouldReportRunCompletedFromMessage(saved, body)) {
-      // terminal_fallback may have marked at timer schedule; release only that
-      // attempt (or all tokens if this path never received one).
-      if (saved?.runId) {
-        clearRunAwaitingFinalAcceptance(
-          saved.runId,
-          reusedAwaitingToken || undefined,
-        );
+      // terminal_fallback may have marked at timer schedule; release only when
+      // this invocation actually received that schedule token. Generic non-final
+      // message writes (e.g. thumbs via PUT /messages/:id) pass no token —
+      // clearing with undefined would wipe every awaiting attempt and flush
+      // deferred feedback off the eventual runId:tf anchor.
+      if (saved?.runId && reusedAwaitingToken) {
+        clearRunAwaitingFinalAcceptance(saved.runId, reusedAwaitingToken);
       }
       return;
     }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1501,10 +1501,22 @@ export function createFinalizedMessageTelemetryReporter({
     });
   };
   return (saved, body = {}, options = {}) => {
+    // Optional schedule-time token for terminal_fallback: reuse it as this
+    // report's in-flight token so delay + report share one attempt and dual
+    // terminal_fallback/final_message flights keep independent counts.
+    const reusedAwaitingToken =
+      typeof options.awaitingToken === 'string' && options.awaitingToken.trim()
+        ? options.awaitingToken.trim()
+        : '';
     if (!shouldReportRunCompletedFromMessage(saved, body)) {
-      // terminal_fallback may have marked at timer schedule; release if this
-      // path never starts a report that would clear in finally.
-      if (saved?.runId) clearRunAwaitingFinalAcceptance(saved.runId);
+      // terminal_fallback may have marked at timer schedule; release only that
+      // attempt (or all tokens if this path never received one).
+      if (saved?.runId) {
+        clearRunAwaitingFinalAcceptance(
+          saved.runId,
+          reusedAwaitingToken || undefined,
+        );
+      }
       return;
     }
     const runId = saved.runId;
@@ -1526,7 +1538,7 @@ export function createFinalizedMessageTelemetryReporter({
         status: saved.runStatus,
       });
       // Schedule-only awaiting mark must not outlive a skipped report.
-      clearRunAwaitingFinalAcceptance(runId);
+      clearRunAwaitingFinalAcceptance(runId, reusedAwaitingToken || undefined);
       return;
     }
     const reportTrigger = options.reportTrigger ?? 'final_message';
@@ -1547,7 +1559,11 @@ export function createFinalizedMessageTelemetryReporter({
         skipReason: 'duplicate_run',
         status: saved.runStatus,
       });
-      // In-flight final_message owns the mark; do not clear here.
+      // In-flight final_message owns its mark; release only a reused schedule
+      // token so this duplicate path does not strand delay-window deferral.
+      if (reusedAwaitingToken) {
+        clearRunAwaitingFinalAcceptance(run.id, reusedAwaitingToken);
+      }
       return;
     }
     if (reportTrigger !== 'terminal_fallback') {
@@ -1557,7 +1573,10 @@ export function createFinalizedMessageTelemetryReporter({
     // before async reportRunCompleted can rememberAcceptedFinalTraceBodyId.
     // Feedback during this window defers; cold finalized/no-anchor rows without
     // this mark ship on the canonical body instead of queueing forever.
-    markRunAwaitingFinalAcceptance(run.id);
+    // Reuse the schedule-time terminal_fallback token when provided so one
+    // attempt spans delay + report and dual flights stay independently counted.
+    const awaitingToken =
+      reusedAwaitingToken || markRunAwaitingFinalAcceptance(run.id);
     void (async () => {
       const start = Date.now();
       try {
@@ -1594,10 +1613,10 @@ export function createFinalizedMessageTelemetryReporter({
           status: saved.runStatus,
         });
       } finally {
-        // On accept, rememberAcceptedFinalTraceBodyId already cleared the mark
-        // and flushed deferred scores. On failure/skip, release any queue onto
-        // the canonical body so scores are not stranded until process exit.
-        clearRunAwaitingFinalAcceptance(run.id);
+        // On accept, rememberAcceptedFinalTraceBodyId already cleared all tokens
+        // and flushed deferred scores. On failure/skip, release only this
+        // attempt; other in-flight final-purpose deliveries may still accept.
+        clearRunAwaitingFinalAcceptance(run.id, awaitingToken || undefined);
       }
     })();
   };
@@ -2544,12 +2563,16 @@ export async function startServer({
   }) => {
     if (!shouldReportRunCompletionTelemetryFallbackStatus(status)) return;
     // Cover the whole terminal_fallback delay + report flight so mid-window
-    // feedback defers onto `:tf` (or flushes on clear). Cold restarts have no
-    // mark, so failed/canceled feedback must not queue forever on status alone.
-    markRunAwaitingFinalAcceptance(run.id);
+    // feedback defers onto `:tf` (or flushes on clear). Token is keyed by
+    // immutable run.id so assistant-row reuse cannot drop deferral for this
+    // run. Cold restarts have no mark, so failed/canceled feedback must not
+    // queue forever on status alone.
+    const awaitingToken = markRunAwaitingFinalAcceptance(run.id);
     const timer = setTimeout(() => {
       if (reportedRuns.has(run.id)) {
-        // final_message claimed the run and owns the awaiting-mark lifecycle.
+        // final_message claimed the run and owns its own awaiting token —
+        // release this schedule-only token so scores are not stranded.
+        clearRunAwaitingFinalAcceptance(run.id, awaitingToken);
         return;
       }
       if (run.assistantMessageId) {
@@ -2564,7 +2587,7 @@ export async function startServer({
         if (messageTelemetry.finalizedAt !== null) {
           // Finalized without claiming reportedRuns (e.g. run already gone) —
           // release the schedule-only mark so scores are not stranded.
-          clearRunAwaitingFinalAcceptance(run.id);
+          clearRunAwaitingFinalAcceptance(run.id, awaitingToken);
           return;
         }
       }
@@ -2583,6 +2606,8 @@ export async function startServer({
           conversationId: run.conversationId,
           projectId: run.projectId,
           reportTrigger: 'terminal_fallback',
+          // Reuse the schedule token as this report's in-flight attempt.
+          awaitingToken,
         },
       );
     }, LANGFUSE_TERMINAL_FALLBACK_DELAY_MS);

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1547,6 +1547,7 @@ export function createFinalizedMessageTelemetryReporter({
         persistedRunStatus: saved.runStatus,
         persistedEndedAt: saved.endedAt,
         appVersion: getAppVersion(),
+        reportTrigger,
       });
       const state = delivery ?? {
         langfuse_expected: true,

--- a/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
+++ b/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
@@ -499,6 +499,78 @@ describe('persisted telemetry accepted anchor', () => {
     });
   });
 
+  it('run-scoped finalization lookup keeps failed run A eligible after row reuse + B finalize', () => {
+    // Overlapping sequence the message-id-only gate misses:
+    // failed A schedules terminal_fallback → same assistant row rebinds to B →
+    // B finalizes before A's timer fires. A's delayed check must pass run.id
+    // so it does not observe B's telemetry_finalized_at and skip reporting.
+    const oldRunId = 'run-a-failed-pending-fallback';
+    const newRunId = 'run-b-reused-and-finalized';
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const now = Date.now();
+    insertProject(db, {
+      id: 'proj-1',
+      name: 'Telemetry project',
+      createdAt: now,
+      updatedAt: now,
+    });
+    insertConversation(db, {
+      id: 'conv-1',
+      projectId: 'proj-1',
+      title: 'Telemetry run',
+      createdAt: now,
+      updatedAt: now,
+    });
+    // A failed without finalization yet (fallback delay still open).
+    upsertMessage(db, 'conv-1', {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: 'partial A',
+      runId: oldRunId,
+      runStatus: 'failed',
+      telemetryFinalized: false,
+      endedAt: now,
+    });
+    expect(
+      getMessageTelemetryFinalizationState(db, 'assistant-1', oldRunId),
+    ).toEqual({
+      exists: true,
+      finalizedAt: null,
+    });
+
+    // Rebind the same assistant row to B and finalize B.
+    pinAssistantMessageOnRunCreate(db, {
+      id: newRunId,
+      conversationId: 'conv-1',
+      assistantMessageId: 'assistant-1',
+      status: 'running',
+      createdAt: now + 1,
+    });
+    upsertMessage(db, 'conv-1', {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: 'final B',
+      runId: newRunId,
+      runStatus: 'succeeded',
+      telemetryFinalized: true,
+      endedAt: now + 2,
+    });
+
+    // Message-id-only lookup sees B's finalized_at (the bug surface).
+    expect(getMessageTelemetryFinalizationState(db, 'assistant-1').finalizedAt).not.toBeNull();
+    // Run-scoped A no longer owns the row → gate open for A's delayed fallback.
+    expect(
+      getMessageTelemetryFinalizationState(db, 'assistant-1', oldRunId),
+    ).toEqual({
+      exists: false,
+      finalizedAt: null,
+    });
+    // Run-scoped B correctly sees finalization and would skip a redundant fallback.
+    expect(
+      getMessageTelemetryFinalizationState(db, 'assistant-1', newRunId).finalizedAt,
+    ).not.toBeNull();
+  });
+
   it('accepted write with stale assistantMessageId still lands on the run row after restart', () => {
     const runId = 'run-stale-write';
     const otherRunId = 'run-other-stale-write';

--- a/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
+++ b/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
@@ -5,6 +5,9 @@ import path from 'node:path';
 
 import {
   closeDatabase,
+  deleteConversation,
+  deleteMessage,
+  deleteProject,
   getMessageTelemetryFinalizationState,
   getRunFeedbackTelemetryAnchor,
   insertConversation,
@@ -812,5 +815,140 @@ describe('persisted telemetry accepted anchor', () => {
         acceptedTraceBodyId: anchor!.acceptedTraceBodyId,
       }),
     ).toBe(expectedBodyId);
+  });
+
+  it('deletes run-keyed anchors with conversation/project/message delete paths', () => {
+    const runId = 'run-delete-with-owner';
+    const bodyId = scopedTelemetryBodyId(runId, 'final', 'final_message');
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    seedFailedAssistant(db, runId);
+    expect(
+      setRunTelemetryAcceptedAnchor(db, {
+        runId,
+        assistantMessageId: 'assistant-1',
+        conversationId: 'conv-1',
+        bodyId,
+        reportTrigger: 'final_message',
+        deliveryChannel: 'vela',
+        velaIdentity: 'prod:abcdef0123456789',
+      }),
+    ).toBe(true);
+    expect(getRunFeedbackTelemetryAnchor(db, runId)?.acceptedTraceBodyId).toBe(bodyId);
+
+    // Message delete removes the matching run-keyed anchor.
+    deleteMessage(db, 'assistant-1');
+    expect(getRunFeedbackTelemetryAnchor(db, runId)).toBeNull();
+    expect(
+      db
+        .prepare(
+          `SELECT COUNT(*) AS n FROM run_telemetry_accepted_anchors WHERE run_id = ?`,
+        )
+        .get(runId) as { n: number },
+    ).toEqual({ n: 0 });
+
+    // Recreate message + anchor, then conversation delete must prune ownership.
+    upsertMessage(db, 'conv-1', {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: 'partial',
+      runId,
+      runStatus: 'failed',
+      telemetryFinalized: true,
+      endedAt: Date.now(),
+    });
+    expect(
+      setRunTelemetryAcceptedAnchor(db, {
+        runId,
+        assistantMessageId: 'assistant-1',
+        conversationId: 'conv-1',
+        bodyId,
+        reportTrigger: 'final_message',
+        deliveryChannel: 'vela',
+        velaIdentity: 'prod:abcdef0123456789',
+      }),
+    ).toBe(true);
+    deleteConversation(db, 'conv-1');
+    expect(
+      db
+        .prepare(
+          `SELECT COUNT(*) AS n FROM run_telemetry_accepted_anchors WHERE run_id = ?`,
+        )
+        .get(runId) as { n: number },
+    ).toEqual({ n: 0 });
+
+    // Project delete also prunes anchors owned by its conversations.
+    insertConversation(db, {
+      id: 'conv-2',
+      projectId: 'proj-1',
+      title: 'Second',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+    const runId2 = 'run-delete-with-project';
+    upsertMessage(db, 'conv-2', {
+      id: 'assistant-2',
+      role: 'assistant',
+      content: 'partial',
+      runId: runId2,
+      runStatus: 'succeeded',
+      telemetryFinalized: true,
+      endedAt: Date.now(),
+    });
+    expect(
+      setRunTelemetryAcceptedAnchor(db, {
+        runId: runId2,
+        assistantMessageId: 'assistant-2',
+        conversationId: 'conv-2',
+        bodyId: runId2,
+        reportTrigger: 'final_message',
+      }),
+    ).toBe(true);
+    deleteProject(db, 'proj-1');
+    expect(
+      db
+        .prepare(`SELECT COUNT(*) AS n FROM run_telemetry_accepted_anchors`)
+        .get() as { n: number },
+    ).toEqual({ n: 0 });
+  });
+
+  it('conversation delete removes rebinding orphan anchors with no live run_id row', () => {
+    const oldRunId = 'run-rebinding-orphan';
+    const newRunId = 'run-rebinding-current';
+    const staleBodyId = scopedTelemetryBodyId(oldRunId, 'final', 'terminal_fallback');
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    seedFailedAssistant(db, oldRunId);
+    expect(
+      setRunTelemetryAcceptedAnchor(db, {
+        runId: oldRunId,
+        assistantMessageId: 'assistant-1',
+        conversationId: 'conv-1',
+        bodyId: staleBodyId,
+        reportTrigger: 'terminal_fallback',
+      }),
+    ).toBe(true);
+
+    // Side-chat retry rebinds the assistant row; run-keyed A remains intentional
+    // while the conversation lives.
+    upsertMessage(db, 'conv-1', {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: '',
+      runId: newRunId,
+      runStatus: null,
+      telemetryFinalized: false,
+    });
+    expect(getRunFeedbackTelemetryAnchor(db, oldRunId)?.acceptedTraceBodyId).toBe(
+      staleBodyId,
+    );
+
+    // Deleting the conversation must not leave the orphaned run-keyed row behind.
+    deleteConversation(db, 'conv-1');
+    expect(
+      db
+        .prepare(
+          `SELECT COUNT(*) AS n FROM run_telemetry_accepted_anchors WHERE run_id = ?`,
+        )
+        .get(oldRunId) as { n: number },
+    ).toEqual({ n: 0 });
   });
 });

--- a/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
+++ b/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
@@ -17,6 +17,7 @@ import {
   resetAcceptedFinalTraceBodyIdsForTests,
   scopedTelemetryBodyId,
 } from '../src/langfuse-trace.js';
+import { pinAssistantMessageOnRunCreate } from '../src/runtimes/chat-run-messages.js';
 
 describe('persisted telemetry accepted anchor', () => {
   let tempDir: string;
@@ -352,6 +353,78 @@ describe('persisted telemetry accepted anchor', () => {
     });
     expect(getRunFeedbackTelemetryAnchor(db, newRunId, 'assistant-1')).toEqual({
       runStatus: 'succeeded',
+      telemetryFinalized: true,
+      acceptedTraceBodyId: newRunId,
+      acceptedReportTrigger: 'final_message',
+    });
+  });
+
+  it('clears accepted telemetry anchors when run-pin reuses a message for a new run_id', () => {
+    const oldRunId = 'run-failed-pin-original';
+    const newRunId = 'run-retry-via-pin';
+    const staleBodyId = scopedTelemetryBodyId(oldRunId, 'final', 'terminal_fallback');
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    seedFailedAssistant(db, oldRunId);
+    expect(
+      setRunTelemetryAcceptedAnchor(db, {
+        runId: oldRunId,
+        assistantMessageId: 'assistant-1',
+        bodyId: staleBodyId,
+        reportTrigger: 'terminal_fallback',
+      }),
+    ).toBe(true);
+    expect(getRunFeedbackTelemetryAnchor(db, oldRunId, 'assistant-1')).toEqual({
+      runStatus: 'failed',
+      telemetryFinalized: true,
+      acceptedTraceBodyId: staleBodyId,
+      acceptedReportTrigger: 'terminal_fallback',
+    });
+
+    // Run creation pins existing assistant rows through a raw UPDATE, not
+    // upsertMessage — that path must also drop the previous :tf anchor.
+    pinAssistantMessageOnRunCreate(db, {
+      id: newRunId,
+      conversationId: 'conv-1',
+      assistantMessageId: 'assistant-1',
+      status: 'running',
+      createdAt: Date.now(),
+    });
+
+    expect(getRunFeedbackTelemetryAnchor(db, oldRunId, 'assistant-1')).toBeNull();
+    expect(getRunFeedbackTelemetryAnchor(db, newRunId, 'assistant-1')).toEqual({
+      // Terminal run_status is preserved by the pin CASE expression.
+      runStatus: 'failed',
+      telemetryFinalized: true,
+      acceptedTraceBodyId: null,
+      acceptedReportTrigger: null,
+    });
+    expect(
+      resolveFeedbackTraceId({
+        runId: newRunId,
+        runStatus: 'failed',
+        telemetryFinalized: true,
+        acceptedTraceBodyId: null,
+      }),
+    ).toBe(newRunId);
+
+    // Same run_id pin keeps an accepted anchor (idempotent re-pin).
+    expect(
+      setRunTelemetryAcceptedAnchor(db, {
+        runId: newRunId,
+        assistantMessageId: 'assistant-1',
+        bodyId: newRunId,
+        reportTrigger: 'final_message',
+      }),
+    ).toBe(true);
+    pinAssistantMessageOnRunCreate(db, {
+      id: newRunId,
+      conversationId: 'conv-1',
+      assistantMessageId: 'assistant-1',
+      status: 'running',
+      createdAt: Date.now(),
+    });
+    expect(getRunFeedbackTelemetryAnchor(db, newRunId, 'assistant-1')).toEqual({
+      runStatus: 'failed',
       telemetryFinalized: true,
       acceptedTraceBodyId: newRunId,
       acceptedReportTrigger: 'final_message',

--- a/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
+++ b/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
@@ -141,6 +141,49 @@ describe('persisted telemetry accepted anchor', () => {
     });
   });
 
+  it('dual-writes Vela identity onto the message row so message-only fallback cannot cross accounts', () => {
+    const runId = 'run-vela-message-fallback';
+    const velaIdentity = 'prod:fedcba9876543210';
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    seedFailedAssistant(db, runId);
+    expect(
+      setRunTelemetryAcceptedAnchor(db, {
+        runId,
+        assistantMessageId: 'assistant-1',
+        bodyId: runId,
+        reportTrigger: 'final_message',
+        deliveryChannel: 'vela',
+        velaIdentity,
+      }),
+    ).toBe(true);
+
+    // Drop the primary run-keyed row so only the message dual-write remains.
+    db.prepare(`DELETE FROM run_telemetry_accepted_anchors WHERE run_id = ?`).run(
+      runId,
+    );
+    const messageRow = db
+      .prepare(
+        `SELECT telemetry_accepted_delivery_channel AS channel,
+                telemetry_accepted_vela_identity AS identity
+           FROM messages
+          WHERE id = ?`,
+      )
+      .get('assistant-1') as { channel: string | null; identity: string | null };
+    expect(messageRow).toEqual({
+      channel: 'vela',
+      identity: velaIdentity,
+    });
+
+    expect(getRunFeedbackTelemetryAnchor(db, runId, 'assistant-1')).toEqual({
+      runStatus: 'failed',
+      telemetryFinalized: true,
+      acceptedTraceBodyId: runId,
+      acceptedReportTrigger: 'final_message',
+      acceptedDeliveryChannel: 'vela',
+      acceptedVelaIdentity: velaIdentity,
+    });
+  });
+
   it('does not demote an accepted final_message anchor with a later terminal_fallback write', () => {
     const runId = 'run-final-wins';
     const db = openDatabase(tempDir, { dataDir: tempDir });
@@ -973,7 +1016,8 @@ describe('persisted telemetry accepted anchor', () => {
           `UPDATE messages
               SET telemetry_accepted_body_id = NULL,
                   telemetry_accepted_report_trigger = NULL,
-                  telemetry_accepted_delivery_channel = NULL
+                  telemetry_accepted_delivery_channel = NULL,
+                  telemetry_accepted_vela_identity = NULL
             WHERE run_id = ?`,
         )
         .run(runId);

--- a/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
+++ b/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
@@ -72,6 +72,7 @@ describe('persisted telemetry accepted anchor', () => {
         assistantMessageId: 'assistant-1',
         bodyId: expectedBodyId,
         reportTrigger: 'terminal_fallback',
+        deliveryChannel: 'relay',
       }),
     ).toBe(true);
     // Simulate final_message failure: process memory cleared, no final accepted write.
@@ -85,6 +86,7 @@ describe('persisted telemetry accepted anchor', () => {
       telemetryFinalized: true,
       acceptedTraceBodyId: expectedBodyId,
       acceptedReportTrigger: 'terminal_fallback',
+      acceptedDeliveryChannel: 'relay',
     });
     expect(
       resolveFeedbackTraceId({
@@ -102,6 +104,32 @@ describe('persisted telemetry accepted anchor', () => {
         telemetryFinalized: true,
       }),
     ).toBe(runId);
+  });
+
+  it('persists Vela delivery channel so feedback can refuse anonymous misattach', () => {
+    const runId = 'run-vela-accepted-channel';
+    const db1 = openDatabase(tempDir, { dataDir: tempDir });
+    seedFailedAssistant(db1, runId);
+    expect(
+      setRunTelemetryAcceptedAnchor(db1, {
+        runId,
+        assistantMessageId: 'assistant-1',
+        bodyId: runId,
+        reportTrigger: 'final_message',
+        deliveryChannel: 'vela',
+      }),
+    ).toBe(true);
+    closeDatabase();
+    resetAcceptedFinalTraceBodyIdsForTests();
+
+    const db2 = openDatabase(tempDir, { dataDir: tempDir });
+    expect(getRunFeedbackTelemetryAnchor(db2, runId, 'assistant-1')).toEqual({
+      runStatus: 'failed',
+      telemetryFinalized: true,
+      acceptedTraceBodyId: runId,
+      acceptedReportTrigger: 'final_message',
+      acceptedDeliveryChannel: 'vela',
+    });
   });
 
   it('does not demote an accepted final_message anchor with a later terminal_fallback write', () => {
@@ -190,6 +218,7 @@ describe('persisted telemetry accepted anchor', () => {
         telemetryFinalized: false,
         acceptedTraceBodyId: expectedBodyId,
         acceptedReportTrigger: 'terminal_fallback',
+        acceptedDeliveryChannel: null,
       });
       expect(
         resolveFeedbackTraceId({
@@ -207,6 +236,7 @@ describe('persisted telemetry accepted anchor', () => {
       telemetryFinalized: false,
       acceptedTraceBodyId: expectedBodyId,
       acceptedReportTrigger: 'terminal_fallback',
+      acceptedDeliveryChannel: null,
     });
   });
 
@@ -263,12 +293,14 @@ describe('persisted telemetry accepted anchor', () => {
       telemetryFinalized: false,
       acceptedTraceBodyId: expectedBodyId,
       acceptedReportTrigger: 'terminal_fallback',
+      acceptedDeliveryChannel: null,
     });
     expect(getRunFeedbackTelemetryAnchor(db, otherRunId, 'assistant-foreign')).toEqual({
       runStatus: 'succeeded',
       telemetryFinalized: true,
       acceptedTraceBodyId: null,
       acceptedReportTrigger: null,
+      acceptedDeliveryChannel: null,
     });
 
     // Matching id still writes the intended row.
@@ -305,6 +337,7 @@ describe('persisted telemetry accepted anchor', () => {
       telemetryFinalized: true,
       acceptedTraceBodyId: staleBodyId,
       acceptedReportTrigger: 'terminal_fallback',
+      acceptedDeliveryChannel: null,
     });
 
     // Side-chat retry reuses the failed assistant message id with a new run.
@@ -325,6 +358,7 @@ describe('persisted telemetry accepted anchor', () => {
       telemetryFinalized: false,
       acceptedTraceBodyId: null,
       acceptedReportTrigger: null,
+      acceptedDeliveryChannel: null,
     });
     expect(getMessageTelemetryFinalizationState(db, 'assistant-1')).toEqual({
       exists: true,
@@ -362,6 +396,7 @@ describe('persisted telemetry accepted anchor', () => {
       telemetryFinalized: true,
       acceptedTraceBodyId: newRunId,
       acceptedReportTrigger: 'final_message',
+      acceptedDeliveryChannel: null,
     });
   });
 
@@ -384,6 +419,7 @@ describe('persisted telemetry accepted anchor', () => {
       telemetryFinalized: true,
       acceptedTraceBodyId: staleBodyId,
       acceptedReportTrigger: 'terminal_fallback',
+      acceptedDeliveryChannel: null,
     });
 
     // Run creation pins existing assistant rows through a raw UPDATE, not
@@ -404,6 +440,7 @@ describe('persisted telemetry accepted anchor', () => {
       telemetryFinalized: false,
       acceptedTraceBodyId: null,
       acceptedReportTrigger: null,
+      acceptedDeliveryChannel: null,
     });
     expect(getMessageTelemetryFinalizationState(db, 'assistant-1')).toEqual({
       exists: true,
@@ -440,6 +477,7 @@ describe('persisted telemetry accepted anchor', () => {
       telemetryFinalized: false,
       acceptedTraceBodyId: newRunId,
       acceptedReportTrigger: 'final_message',
+      acceptedDeliveryChannel: null,
     });
   });
 
@@ -496,6 +534,7 @@ describe('persisted telemetry accepted anchor', () => {
       telemetryFinalized: false,
       acceptedTraceBodyId: null,
       acceptedReportTrigger: null,
+      acceptedDeliveryChannel: null,
     });
   });
 
@@ -623,7 +662,8 @@ describe('persisted telemetry accepted anchor', () => {
         .prepare(
           `UPDATE messages
               SET telemetry_accepted_body_id = NULL,
-                  telemetry_accepted_report_trigger = NULL
+                  telemetry_accepted_report_trigger = NULL,
+                  telemetry_accepted_delivery_channel = NULL
             WHERE run_id = ?`,
         )
         .run(runId);
@@ -641,6 +681,7 @@ describe('persisted telemetry accepted anchor', () => {
         telemetryFinalized: true,
         acceptedTraceBodyId: expectedBodyId,
         acceptedReportTrigger: 'terminal_fallback',
+        acceptedDeliveryChannel: null,
       });
       expect(
         getRunFeedbackTelemetryAnchor(db1, otherRunId, 'assistant-foreign')
@@ -660,6 +701,7 @@ describe('persisted telemetry accepted anchor', () => {
       telemetryFinalized: true,
       acceptedTraceBodyId: expectedBodyId,
       acceptedReportTrigger: 'terminal_fallback',
+      acceptedDeliveryChannel: null,
     });
     expect(
       resolveFeedbackTraceId({

--- a/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
+++ b/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
@@ -427,6 +427,13 @@ describe('persisted telemetry accepted anchor', () => {
     const staleBodyId = scopedTelemetryBodyId(oldRunId, 'final', 'terminal_fallback');
     const db = openDatabase(tempDir, { dataDir: tempDir });
     seedFailedAssistant(db, oldRunId);
+    // Seed terminal delivery metadata from the failed run so ownership change
+    // must clear it (otherwise a fresh running retry stays delivery_failed).
+    db.prepare(
+      `UPDATE messages
+          SET result_delivery_state = ?, started_at = ?, ended_at = ?
+        WHERE id = ?`,
+    ).run('delivery_failed', 1_700_000_000_000, 1_700_000_001_000, 'assistant-1');
     expect(
       setRunTelemetryAcceptedAnchor(db, {
         runId: oldRunId,
@@ -446,12 +453,13 @@ describe('persisted telemetry accepted anchor', () => {
 
     // Run creation pins existing assistant rows through a raw UPDATE, not
     // upsertMessage — message columns clear for B, run-keyed A stays.
+    const retryCreatedAt = 1_700_000_100_000;
     pinAssistantMessageOnRunCreate(db, {
       id: newRunId,
       conversationId: 'conv-1',
       assistantMessageId: 'assistant-1',
       status: 'running',
-      createdAt: Date.now(),
+      createdAt: retryCreatedAt,
     });
 
     expect(getRunFeedbackTelemetryAnchor(db, oldRunId, 'assistant-1')).toEqual({
@@ -471,6 +479,26 @@ describe('persisted telemetry accepted anchor', () => {
       acceptedReportTrigger: null,
       acceptedDeliveryChannel: null,
       acceptedVelaIdentity: null,
+    });
+    // Run-owned terminal fields must reset so conversation summaries and
+    // delivery state do not inherit the previous run.
+    expect(
+      db
+        .prepare(
+          `SELECT result_delivery_state AS resultDeliveryState,
+                  started_at AS startedAt,
+                  ended_at AS endedAt
+             FROM messages WHERE id = ?`,
+        )
+        .get('assistant-1') as {
+        resultDeliveryState: string | null;
+        startedAt: number | null;
+        endedAt: number | null;
+      },
+    ).toEqual({
+      resultDeliveryState: null,
+      startedAt: retryCreatedAt,
+      endedAt: null,
     });
     expect(getMessageTelemetryFinalizationState(db, 'assistant-1')).toEqual({
       exists: true,
@@ -502,7 +530,7 @@ describe('persisted telemetry accepted anchor', () => {
       conversationId: 'conv-1',
       assistantMessageId: 'assistant-1',
       status: 'running',
-      createdAt: Date.now(),
+      createdAt: retryCreatedAt + 1,
     });
     expect(getRunFeedbackTelemetryAnchor(db, newRunId, 'assistant-1')).toEqual({
       runStatus: 'running',
@@ -511,6 +539,26 @@ describe('persisted telemetry accepted anchor', () => {
       acceptedReportTrigger: 'final_message',
       acceptedDeliveryChannel: null,
       acceptedVelaIdentity: null,
+    });
+    // Same-run re-pin must keep the ownership-change started_at (COALESCE)
+    // and leave ended_at / result_delivery_state cleared.
+    expect(
+      db
+        .prepare(
+          `SELECT result_delivery_state AS resultDeliveryState,
+                  started_at AS startedAt,
+                  ended_at AS endedAt
+             FROM messages WHERE id = ?`,
+        )
+        .get('assistant-1') as {
+        resultDeliveryState: string | null;
+        startedAt: number | null;
+        endedAt: number | null;
+      },
+    ).toEqual({
+      resultDeliveryState: null,
+      startedAt: retryCreatedAt,
+      endedAt: null,
     });
   });
 

--- a/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
+++ b/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
@@ -87,6 +87,7 @@ describe('persisted telemetry accepted anchor', () => {
       acceptedTraceBodyId: expectedBodyId,
       acceptedReportTrigger: 'terminal_fallback',
       acceptedDeliveryChannel: 'relay',
+      acceptedVelaIdentity: null,
     });
     expect(
       resolveFeedbackTraceId({
@@ -106,8 +107,9 @@ describe('persisted telemetry accepted anchor', () => {
     ).toBe(runId);
   });
 
-  it('persists Vela delivery channel so feedback can refuse anonymous misattach', () => {
+  it('persists Vela delivery channel + identity so feedback can refuse anonymous/misaccount attach', () => {
     const runId = 'run-vela-accepted-channel';
+    const velaIdentity = 'prod:abcdef0123456789';
     const db1 = openDatabase(tempDir, { dataDir: tempDir });
     seedFailedAssistant(db1, runId);
     expect(
@@ -117,6 +119,7 @@ describe('persisted telemetry accepted anchor', () => {
         bodyId: runId,
         reportTrigger: 'final_message',
         deliveryChannel: 'vela',
+        velaIdentity,
       }),
     ).toBe(true);
     closeDatabase();
@@ -129,6 +132,7 @@ describe('persisted telemetry accepted anchor', () => {
       acceptedTraceBodyId: runId,
       acceptedReportTrigger: 'final_message',
       acceptedDeliveryChannel: 'vela',
+      acceptedVelaIdentity: velaIdentity,
     });
   });
 
@@ -219,6 +223,7 @@ describe('persisted telemetry accepted anchor', () => {
         acceptedTraceBodyId: expectedBodyId,
         acceptedReportTrigger: 'terminal_fallback',
         acceptedDeliveryChannel: null,
+        acceptedVelaIdentity: null,
       });
       expect(
         resolveFeedbackTraceId({
@@ -237,6 +242,7 @@ describe('persisted telemetry accepted anchor', () => {
       acceptedTraceBodyId: expectedBodyId,
       acceptedReportTrigger: 'terminal_fallback',
       acceptedDeliveryChannel: null,
+      acceptedVelaIdentity: null,
     });
   });
 
@@ -294,6 +300,7 @@ describe('persisted telemetry accepted anchor', () => {
       acceptedTraceBodyId: expectedBodyId,
       acceptedReportTrigger: 'terminal_fallback',
       acceptedDeliveryChannel: null,
+      acceptedVelaIdentity: null,
     });
     expect(getRunFeedbackTelemetryAnchor(db, otherRunId, 'assistant-foreign')).toEqual({
       runStatus: 'succeeded',
@@ -301,6 +308,7 @@ describe('persisted telemetry accepted anchor', () => {
       acceptedTraceBodyId: null,
       acceptedReportTrigger: null,
       acceptedDeliveryChannel: null,
+      acceptedVelaIdentity: null,
     });
 
     // Matching id still writes the intended row.
@@ -318,7 +326,7 @@ describe('persisted telemetry accepted anchor', () => {
     ).toBe(foreignBodyId);
   });
 
-  it('clears accepted telemetry anchors when upsert reuses a message for a new run_id', () => {
+  it('keeps run-keyed accepted anchors when upsert reuses a message for a new run_id', () => {
     const oldRunId = 'run-failed-original';
     const newRunId = 'run-retry';
     const staleBodyId = scopedTelemetryBodyId(oldRunId, 'final', 'terminal_fallback');
@@ -338,6 +346,7 @@ describe('persisted telemetry accepted anchor', () => {
       acceptedTraceBodyId: staleBodyId,
       acceptedReportTrigger: 'terminal_fallback',
       acceptedDeliveryChannel: null,
+      acceptedVelaIdentity: null,
     });
 
     // Side-chat retry reuses the failed assistant message id with a new run.
@@ -350,15 +359,23 @@ describe('persisted telemetry accepted anchor', () => {
       telemetryFinalized: false,
     });
 
-    // Old run row is gone; new run must not inherit the previous :tf anchor
-    // or the previous finalization gate (fallback skip checks finalizedAt).
-    expect(getRunFeedbackTelemetryAnchor(db, oldRunId, 'assistant-1')).toBeNull();
+    // Message columns for the reused row are cleared for B, but run-keyed
+    // storage keeps A's accepted :tf anchor so late feedback still attaches.
+    expect(getRunFeedbackTelemetryAnchor(db, oldRunId, 'assistant-1')).toEqual({
+      runStatus: null,
+      telemetryFinalized: false,
+      acceptedTraceBodyId: staleBodyId,
+      acceptedReportTrigger: 'terminal_fallback',
+      acceptedDeliveryChannel: null,
+      acceptedVelaIdentity: null,
+    });
     expect(getRunFeedbackTelemetryAnchor(db, newRunId, 'assistant-1')).toEqual({
       runStatus: null,
       telemetryFinalized: false,
       acceptedTraceBodyId: null,
       acceptedReportTrigger: null,
       acceptedDeliveryChannel: null,
+      acceptedVelaIdentity: null,
     });
     expect(getMessageTelemetryFinalizationState(db, 'assistant-1')).toEqual({
       exists: true,
@@ -397,10 +414,11 @@ describe('persisted telemetry accepted anchor', () => {
       acceptedTraceBodyId: newRunId,
       acceptedReportTrigger: 'final_message',
       acceptedDeliveryChannel: null,
+      acceptedVelaIdentity: null,
     });
   });
 
-  it('clears accepted telemetry anchors when run-pin reuses a message for a new run_id', () => {
+  it('keeps run-keyed accepted anchors when run-pin reuses a message for a new run_id', () => {
     const oldRunId = 'run-failed-pin-original';
     const newRunId = 'run-retry-via-pin';
     const staleBodyId = scopedTelemetryBodyId(oldRunId, 'final', 'terminal_fallback');
@@ -420,11 +438,11 @@ describe('persisted telemetry accepted anchor', () => {
       acceptedTraceBodyId: staleBodyId,
       acceptedReportTrigger: 'terminal_fallback',
       acceptedDeliveryChannel: null,
+      acceptedVelaIdentity: null,
     });
 
     // Run creation pins existing assistant rows through a raw UPDATE, not
-    // upsertMessage — that path must also drop the previous :tf anchor and
-    // finalization gate.
+    // upsertMessage — message columns clear for B, run-keyed A stays.
     pinAssistantMessageOnRunCreate(db, {
       id: newRunId,
       conversationId: 'conv-1',
@@ -433,7 +451,14 @@ describe('persisted telemetry accepted anchor', () => {
       createdAt: Date.now(),
     });
 
-    expect(getRunFeedbackTelemetryAnchor(db, oldRunId, 'assistant-1')).toBeNull();
+    expect(getRunFeedbackTelemetryAnchor(db, oldRunId, 'assistant-1')).toEqual({
+      runStatus: null,
+      telemetryFinalized: false,
+      acceptedTraceBodyId: staleBodyId,
+      acceptedReportTrigger: 'terminal_fallback',
+      acceptedDeliveryChannel: null,
+      acceptedVelaIdentity: null,
+    });
     expect(getRunFeedbackTelemetryAnchor(db, newRunId, 'assistant-1')).toEqual({
       // Terminal run_status is preserved by the pin CASE expression.
       runStatus: 'failed',
@@ -441,6 +466,7 @@ describe('persisted telemetry accepted anchor', () => {
       acceptedTraceBodyId: null,
       acceptedReportTrigger: null,
       acceptedDeliveryChannel: null,
+      acceptedVelaIdentity: null,
     });
     expect(getMessageTelemetryFinalizationState(db, 'assistant-1')).toEqual({
       exists: true,
@@ -478,7 +504,79 @@ describe('persisted telemetry accepted anchor', () => {
       acceptedTraceBodyId: newRunId,
       acceptedReportTrigger: 'final_message',
       acceptedDeliveryChannel: null,
+      acceptedVelaIdentity: null,
     });
+  });
+
+  it('A fails → row reused by B → A fallback accepted → restart still resolves A:tf', () => {
+    // Review regression: delayed terminal_fallback acceptance for A must not
+    // require a live messages row with run_id=A. After B reuses the assistant
+    // row, the accepted write still lands in run-keyed storage and survives
+    // restart so feedback targets A:tf instead of canonical A.
+    const oldRunId = 'run-a-fallback-after-reuse';
+    const newRunId = 'run-b-reused-row';
+    const expectedBodyId = scopedTelemetryBodyId(
+      oldRunId,
+      'final',
+      'terminal_fallback',
+    );
+    const db1 = openDatabase(tempDir, { dataDir: tempDir });
+    seedFailedAssistant(db1, oldRunId);
+
+    // Rebind the only assistant row to B before A's fallback delivery lands.
+    upsertMessage(db1, 'conv-1', {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: 'B running',
+      runId: newRunId,
+      runStatus: 'running',
+      telemetryFinalized: false,
+    });
+    expect(getRunFeedbackTelemetryAnchor(db1, oldRunId, 'assistant-1')).toBeNull();
+
+    // Delayed A acceptance: no run_id=A message remains, but run-keyed write
+    // still succeeds.
+    expect(
+      setRunTelemetryAcceptedAnchor(db1, {
+        runId: oldRunId,
+        assistantMessageId: 'assistant-1',
+        bodyId: expectedBodyId,
+        reportTrigger: 'terminal_fallback',
+        deliveryChannel: 'relay',
+      }),
+    ).toBe(true);
+    expect(getRunFeedbackTelemetryAnchor(db1, oldRunId)).toEqual({
+      runStatus: null,
+      telemetryFinalized: false,
+      acceptedTraceBodyId: expectedBodyId,
+      acceptedReportTrigger: 'terminal_fallback',
+      acceptedDeliveryChannel: 'relay',
+      acceptedVelaIdentity: null,
+    });
+    // B must not inherit A's anchor via the shared message row.
+    expect(
+      getRunFeedbackTelemetryAnchor(db1, newRunId, 'assistant-1')?.acceptedTraceBodyId,
+    ).toBeNull();
+
+    closeDatabase();
+    resetAcceptedFinalTraceBodyIdsForTests();
+
+    const db2 = openDatabase(tempDir, { dataDir: tempDir });
+    const anchor = getRunFeedbackTelemetryAnchor(db2, oldRunId);
+    expect(anchor).toEqual({
+      runStatus: null,
+      telemetryFinalized: false,
+      acceptedTraceBodyId: expectedBodyId,
+      acceptedReportTrigger: 'terminal_fallback',
+      acceptedDeliveryChannel: 'relay',
+      acceptedVelaIdentity: null,
+    });
+    expect(
+      resolveFeedbackTraceId({
+        runId: oldRunId,
+        acceptedTraceBodyId: anchor!.acceptedTraceBodyId,
+      }),
+    ).toBe(expectedBodyId);
   });
 
   it('reused assistant row after failed retry keeps finalization gate open for terminal fallback', () => {
@@ -535,6 +633,7 @@ describe('persisted telemetry accepted anchor', () => {
       acceptedTraceBodyId: null,
       acceptedReportTrigger: null,
       acceptedDeliveryChannel: null,
+      acceptedVelaIdentity: null,
     });
   });
 
@@ -682,6 +781,7 @@ describe('persisted telemetry accepted anchor', () => {
         acceptedTraceBodyId: expectedBodyId,
         acceptedReportTrigger: 'terminal_fallback',
         acceptedDeliveryChannel: null,
+        acceptedVelaIdentity: null,
       });
       expect(
         getRunFeedbackTelemetryAnchor(db1, otherRunId, 'assistant-foreign')
@@ -702,6 +802,7 @@ describe('persisted telemetry accepted anchor', () => {
       acceptedTraceBodyId: expectedBodyId,
       acceptedReportTrigger: 'terminal_fallback',
       acceptedDeliveryChannel: null,
+      acceptedVelaIdentity: null,
     });
     expect(
       resolveFeedbackTraceId({

--- a/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
+++ b/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
@@ -951,4 +951,34 @@ describe('persisted telemetry accepted anchor', () => {
         .get(oldRunId) as { n: number },
     ).toEqual({ n: 0 });
   });
+
+  it('skips accepted-anchor writes when the conversation owner is already gone', () => {
+    const runId = 'run-late-accept-after-delete';
+    const bodyId = scopedTelemetryBodyId(runId, 'final', 'terminal_fallback');
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    seedFailedAssistant(db, runId);
+
+    // Owner deleted while terminal_fallback was still delayed.
+    deleteConversation(db, 'conv-1');
+
+    expect(
+      setRunTelemetryAcceptedAnchor(db, {
+        runId,
+        assistantMessageId: 'assistant-1',
+        conversationId: 'conv-1',
+        bodyId,
+        reportTrigger: 'terminal_fallback',
+        deliveryChannel: 'vela',
+        velaIdentity: 'prod:abcdef0123456789',
+      }),
+    ).toBe(false);
+    expect(
+      db
+        .prepare(
+          `SELECT COUNT(*) AS n FROM run_telemetry_accepted_anchors WHERE run_id = ?`,
+        )
+        .get(runId) as { n: number },
+    ).toEqual({ n: 0 });
+    expect(getRunFeedbackTelemetryAnchor(db, runId)).toBeNull();
+  });
 });

--- a/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
+++ b/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
@@ -207,4 +207,80 @@ describe('persisted telemetry accepted anchor', () => {
       acceptedReportTrigger: 'terminal_fallback',
     });
   });
+
+  it('setRunTelemetryAcceptedAnchor ignores foreign message ids and writes the run row', () => {
+    const runId = 'run-target-write';
+    const otherRunId = 'run-other-write';
+    const expectedBodyId = scopedTelemetryBodyId(runId, 'final', 'terminal_fallback');
+    const foreignBodyId = scopedTelemetryBodyId(otherRunId, 'final', 'final_message');
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const now = Date.now();
+    insertProject(db, {
+      id: 'proj-1',
+      name: 'Telemetry project',
+      createdAt: now,
+      updatedAt: now,
+    });
+    insertConversation(db, {
+      id: 'conv-1',
+      projectId: 'proj-1',
+      title: 'Telemetry run',
+      createdAt: now,
+      updatedAt: now,
+    });
+    upsertMessage(db, 'conv-1', {
+      id: 'assistant-foreign',
+      role: 'assistant',
+      content: 'other run',
+      runId: otherRunId,
+      runStatus: 'succeeded',
+      telemetryFinalized: true,
+      endedAt: now,
+    });
+    upsertMessage(db, 'conv-1', {
+      id: 'assistant-target',
+      role: 'assistant',
+      content: 'partial',
+      runId,
+      runStatus: 'failed',
+      telemetryFinalized: false,
+      endedAt: now,
+    });
+
+    // Foreign id must not write the anchor onto the other run's row.
+    expect(
+      setRunTelemetryAcceptedAnchor(db, {
+        runId,
+        assistantMessageId: 'assistant-foreign',
+        bodyId: expectedBodyId,
+        reportTrigger: 'terminal_fallback',
+      }),
+    ).toBe(true);
+    expect(getRunFeedbackTelemetryAnchor(db, runId)).toEqual({
+      runStatus: 'failed',
+      telemetryFinalized: false,
+      acceptedTraceBodyId: expectedBodyId,
+      acceptedReportTrigger: 'terminal_fallback',
+    });
+    expect(getRunFeedbackTelemetryAnchor(db, otherRunId, 'assistant-foreign')).toEqual({
+      runStatus: 'succeeded',
+      telemetryFinalized: true,
+      acceptedTraceBodyId: null,
+      acceptedReportTrigger: null,
+    });
+
+    // Matching id still writes the intended row.
+    expect(
+      setRunTelemetryAcceptedAnchor(db, {
+        runId: otherRunId,
+        assistantMessageId: 'assistant-foreign',
+        bodyId: foreignBodyId,
+        reportTrigger: 'final_message',
+      }),
+    ).toBe(true);
+    expect(
+      getRunFeedbackTelemetryAnchor(db, otherRunId, 'assistant-foreign')
+        ?.acceptedTraceBodyId,
+    ).toBe(foreignBodyId);
+  });
 });

--- a/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
+++ b/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
@@ -283,4 +283,104 @@ describe('persisted telemetry accepted anchor', () => {
         ?.acceptedTraceBodyId,
     ).toBe(foreignBodyId);
   });
+
+  it('accepted write with stale assistantMessageId still lands on the run row after restart', () => {
+    const runId = 'run-stale-write';
+    const otherRunId = 'run-other-stale-write';
+    const expectedBodyId = scopedTelemetryBodyId(runId, 'final', 'terminal_fallback');
+    const now = Date.now();
+
+    const db1 = openDatabase(tempDir, { dataDir: tempDir });
+    insertProject(db1, {
+      id: 'proj-1',
+      name: 'Telemetry project',
+      createdAt: now,
+      updatedAt: now,
+    });
+    insertConversation(db1, {
+      id: 'conv-1',
+      projectId: 'proj-1',
+      title: 'Telemetry run',
+      createdAt: now,
+      updatedAt: now,
+    });
+    // Foreign assistant (other run) and a user message act as stale client ids.
+    upsertMessage(db1, 'conv-1', {
+      id: 'assistant-foreign',
+      role: 'assistant',
+      content: 'other run',
+      runId: otherRunId,
+      runStatus: 'succeeded',
+      telemetryFinalized: true,
+      endedAt: now,
+    });
+    upsertMessage(db1, 'conv-1', {
+      id: 'user-1',
+      role: 'user',
+      content: 'prompt',
+    });
+    // Real terminal assistant for the run that accepted terminal_fallback.
+    upsertMessage(db1, 'conv-1', {
+      id: 'assistant-target',
+      role: 'assistant',
+      content: 'partial',
+      runId,
+      runStatus: 'failed',
+      telemetryFinalized: true,
+      endedAt: now,
+    });
+
+    for (const staleId of ['assistant-foreign', 'user-1', 'missing-id'] as const) {
+      // Clear any prior anchor so each stale id is exercised independently.
+      db1
+        .prepare(
+          `UPDATE messages
+              SET telemetry_accepted_body_id = NULL,
+                  telemetry_accepted_report_trigger = NULL
+            WHERE run_id = ?`,
+        )
+        .run(runId);
+      expect(
+        setRunTelemetryAcceptedAnchor(db1, {
+          runId,
+          assistantMessageId: staleId,
+          bodyId: expectedBodyId,
+          reportTrigger: 'terminal_fallback',
+        }),
+      ).toBe(true);
+      // Anchor must land on the run-owned assistant row, not the stale id.
+      expect(getRunFeedbackTelemetryAnchor(db1, runId, 'assistant-target')).toEqual({
+        runStatus: 'failed',
+        telemetryFinalized: true,
+        acceptedTraceBodyId: expectedBodyId,
+        acceptedReportTrigger: 'terminal_fallback',
+      });
+      expect(
+        getRunFeedbackTelemetryAnchor(db1, otherRunId, 'assistant-foreign')
+          ?.acceptedTraceBodyId,
+      ).toBeNull();
+    }
+
+    closeDatabase();
+    resetAcceptedFinalTraceBodyIdsForTests();
+
+    // After restart, feedback still targets :tf even though the accepted write
+    // was invoked with a stale/foreign assistantMessageId.
+    const db2 = openDatabase(tempDir, { dataDir: tempDir });
+    const anchor = getRunFeedbackTelemetryAnchor(db2, runId, 'assistant-foreign');
+    expect(anchor).toEqual({
+      runStatus: 'failed',
+      telemetryFinalized: true,
+      acceptedTraceBodyId: expectedBodyId,
+      acceptedReportTrigger: 'terminal_fallback',
+    });
+    expect(
+      resolveFeedbackTraceId({
+        runId,
+        runStatus: anchor!.runStatus,
+        telemetryFinalized: anchor!.telemetryFinalized,
+        acceptedTraceBodyId: anchor!.acceptedTraceBodyId,
+      }),
+    ).toBe(expectedBodyId);
+  });
 });

--- a/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
+++ b/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 
 import {
   closeDatabase,
+  getMessageTelemetryFinalizationState,
   getRunFeedbackTelemetryAnchor,
   insertConversation,
   insertProject,
@@ -316,13 +317,18 @@ describe('persisted telemetry accepted anchor', () => {
       telemetryFinalized: false,
     });
 
-    // Old run row is gone; new run must not inherit the previous :tf anchor.
+    // Old run row is gone; new run must not inherit the previous :tf anchor
+    // or the previous finalization gate (fallback skip checks finalizedAt).
     expect(getRunFeedbackTelemetryAnchor(db, oldRunId, 'assistant-1')).toBeNull();
     expect(getRunFeedbackTelemetryAnchor(db, newRunId, 'assistant-1')).toEqual({
       runStatus: null,
-      telemetryFinalized: true,
+      telemetryFinalized: false,
       acceptedTraceBodyId: null,
       acceptedReportTrigger: null,
+    });
+    expect(getMessageTelemetryFinalizationState(db, 'assistant-1')).toEqual({
+      exists: true,
+      finalizedAt: null,
     });
     expect(
       resolveFeedbackTraceId({
@@ -381,7 +387,8 @@ describe('persisted telemetry accepted anchor', () => {
     });
 
     // Run creation pins existing assistant rows through a raw UPDATE, not
-    // upsertMessage — that path must also drop the previous :tf anchor.
+    // upsertMessage — that path must also drop the previous :tf anchor and
+    // finalization gate.
     pinAssistantMessageOnRunCreate(db, {
       id: newRunId,
       conversationId: 'conv-1',
@@ -394,9 +401,13 @@ describe('persisted telemetry accepted anchor', () => {
     expect(getRunFeedbackTelemetryAnchor(db, newRunId, 'assistant-1')).toEqual({
       // Terminal run_status is preserved by the pin CASE expression.
       runStatus: 'failed',
-      telemetryFinalized: true,
+      telemetryFinalized: false,
       acceptedTraceBodyId: null,
       acceptedReportTrigger: null,
+    });
+    expect(getMessageTelemetryFinalizationState(db, 'assistant-1')).toEqual({
+      exists: true,
+      finalizedAt: null,
     });
     expect(
       resolveFeedbackTraceId({
@@ -407,7 +418,8 @@ describe('persisted telemetry accepted anchor', () => {
       }),
     ).toBe(newRunId);
 
-    // Same run_id pin keeps an accepted anchor (idempotent re-pin).
+    // Same run_id pin keeps an accepted anchor (idempotent re-pin) without
+    // re-opening the finalization gate (anchor write does not finalize).
     expect(
       setRunTelemetryAcceptedAnchor(db, {
         runId: newRunId,
@@ -425,9 +437,65 @@ describe('persisted telemetry accepted anchor', () => {
     });
     expect(getRunFeedbackTelemetryAnchor(db, newRunId, 'assistant-1')).toEqual({
       runStatus: 'failed',
-      telemetryFinalized: true,
+      telemetryFinalized: false,
       acceptedTraceBodyId: newRunId,
       acceptedReportTrigger: 'final_message',
+    });
+  });
+
+  it('reused assistant row after failed retry keeps finalization gate open for terminal fallback', () => {
+    // Mirrors reportRunCompletionTelemetryFallback: it skips the send when
+    // getMessageTelemetryFinalizationState(...).finalizedAt !== null. A side-
+    // chat retry that reuses the assistant message id must not inherit the
+    // previous run's finalized_at, or a failed/canceled retry drops telemetry.
+    const oldRunId = 'run-failed-then-retry';
+    const retryRunId = 'run-retry-then-fail';
+    const oldBodyId = scopedTelemetryBodyId(oldRunId, 'final', 'terminal_fallback');
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    seedFailedAssistant(db, oldRunId);
+    expect(
+      setRunTelemetryAcceptedAnchor(db, {
+        runId: oldRunId,
+        assistantMessageId: 'assistant-1',
+        bodyId: oldBodyId,
+        reportTrigger: 'terminal_fallback',
+      }),
+    ).toBe(true);
+    expect(getMessageTelemetryFinalizationState(db, 'assistant-1').finalizedAt).not.toBeNull();
+
+    // Pin path used on run create, then upsert path used when the retry fails.
+    pinAssistantMessageOnRunCreate(db, {
+      id: retryRunId,
+      conversationId: 'conv-1',
+      assistantMessageId: 'assistant-1',
+      status: 'running',
+      createdAt: Date.now(),
+    });
+    expect(getMessageTelemetryFinalizationState(db, 'assistant-1')).toEqual({
+      exists: true,
+      finalizedAt: null,
+    });
+
+    upsertMessage(db, 'conv-1', {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: 'retry partial',
+      runId: retryRunId,
+      runStatus: 'failed',
+      telemetryFinalized: false,
+      endedAt: Date.now(),
+    });
+
+    // Gate still open → terminal-fallback would not skip on finalizedAt.
+    expect(getMessageTelemetryFinalizationState(db, 'assistant-1')).toEqual({
+      exists: true,
+      finalizedAt: null,
+    });
+    expect(getRunFeedbackTelemetryAnchor(db, retryRunId, 'assistant-1')).toEqual({
+      runStatus: 'failed',
+      telemetryFinalized: false,
+      acceptedTraceBodyId: null,
+      acceptedReportTrigger: null,
     });
   });
 

--- a/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
+++ b/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
@@ -463,8 +463,9 @@ describe('persisted telemetry accepted anchor', () => {
       acceptedVelaIdentity: null,
     });
     expect(getRunFeedbackTelemetryAnchor(db, newRunId, 'assistant-1')).toEqual({
-      // Terminal run_status is preserved by the pin CASE expression.
-      runStatus: 'failed',
+      // Ownership change must take the new run's non-terminal status so a
+      // fresh retry is not observed as already completed.
+      runStatus: 'running',
       telemetryFinalized: false,
       acceptedTraceBodyId: null,
       acceptedReportTrigger: null,
@@ -486,6 +487,8 @@ describe('persisted telemetry accepted anchor', () => {
 
     // Same run_id pin keeps an accepted anchor (idempotent re-pin) without
     // re-opening the finalization gate (anchor write does not finalize).
+    // Terminal status is preserved only on same-run pins; after ownership
+    // change the row is still non-terminal here.
     expect(
       setRunTelemetryAcceptedAnchor(db, {
         runId: newRunId,
@@ -502,7 +505,7 @@ describe('persisted telemetry accepted anchor', () => {
       createdAt: Date.now(),
     });
     expect(getRunFeedbackTelemetryAnchor(db, newRunId, 'assistant-1')).toEqual({
-      runStatus: 'failed',
+      runStatus: 'running',
       telemetryFinalized: false,
       acceptedTraceBodyId: newRunId,
       acceptedReportTrigger: 'final_message',

--- a/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
+++ b/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -12,10 +12,12 @@ import {
   getRunFeedbackTelemetryAnchor,
   insertConversation,
   insertProject,
+  listMessages,
   openDatabase,
   setRunTelemetryAcceptedAnchor,
   upsertMessage,
 } from '../src/db.js';
+import { reportRunCompletedFromDaemon } from '../src/langfuse-bridge.js';
 import {
   resolveFeedbackTraceId,
   resetAcceptedFinalTraceBodyIdsForTests,
@@ -431,9 +433,17 @@ describe('persisted telemetry accepted anchor', () => {
     // must clear it (otherwise a fresh running retry stays delivery_failed).
     db.prepare(
       `UPDATE messages
-          SET result_delivery_state = ?, started_at = ?, ended_at = ?
+          SET result_delivery_state = ?, started_at = ?, ended_at = ?,
+              produced_files_json = ?, trace_object_files_json = ?
         WHERE id = ?`,
-    ).run('delivery_failed', 1_700_000_000_000, 1_700_000_001_000, 'assistant-1');
+    ).run(
+      'delivery_failed',
+      1_700_000_000_000,
+      1_700_000_001_000,
+      JSON.stringify([{ name: 'stale-a.html', kind: 'html', size: 12 }]),
+      JSON.stringify([{ name: 'stale-a.html', kind: 'html', size: 12 }]),
+      'assistant-1',
+    );
     expect(
       setRunTelemetryAcceptedAnchor(db, {
         runId: oldRunId,
@@ -487,18 +497,29 @@ describe('persisted telemetry accepted anchor', () => {
         .prepare(
           `SELECT result_delivery_state AS resultDeliveryState,
                   started_at AS startedAt,
-                  ended_at AS endedAt
+                  ended_at AS endedAt,
+                  content,
+                  produced_files_json AS producedFilesJson,
+                  trace_object_files_json AS traceObjectFilesJson
              FROM messages WHERE id = ?`,
         )
         .get('assistant-1') as {
         resultDeliveryState: string | null;
         startedAt: number | null;
         endedAt: number | null;
+        content: string;
+        producedFilesJson: string | null;
+        traceObjectFilesJson: string | null;
       },
     ).toEqual({
       resultDeliveryState: null,
       startedAt: retryCreatedAt,
       endedAt: null,
+      // Ownership change must drop prior payload so fail-before-upsert for B
+      // cannot publish A's content/manifests under B's run_id.
+      content: '',
+      producedFilesJson: null,
+      traceObjectFilesJson: null,
     });
     expect(getMessageTelemetryFinalizationState(db, 'assistant-1')).toEqual({
       exists: true,
@@ -525,6 +546,18 @@ describe('persisted telemetry accepted anchor', () => {
         reportTrigger: 'final_message',
       }),
     ).toBe(true);
+    // Same-run re-pin must also preserve any in-flight payload written after
+    // the ownership change (not wipe content again).
+    upsertMessage(db, 'conv-1', {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: 'retry partial B',
+      runId: newRunId,
+      runStatus: 'running',
+      startedAt: retryCreatedAt,
+      producedFiles: [{ name: 'b-partial.html', kind: 'html', size: 3 }],
+      traceObjectFiles: [{ name: 'b-partial.html', kind: 'html', size: 3 }],
+    });
     pinAssistantMessageOnRunCreate(db, {
       id: newRunId,
       conversationId: 'conv-1',
@@ -541,25 +574,149 @@ describe('persisted telemetry accepted anchor', () => {
       acceptedVelaIdentity: null,
     });
     // Same-run re-pin must keep the ownership-change started_at (COALESCE)
-    // and leave ended_at / result_delivery_state cleared.
+    // and leave ended_at / result_delivery_state cleared, and keep payload.
     expect(
       db
         .prepare(
           `SELECT result_delivery_state AS resultDeliveryState,
                   started_at AS startedAt,
-                  ended_at AS endedAt
+                  ended_at AS endedAt,
+                  content,
+                  produced_files_json AS producedFilesJson,
+                  trace_object_files_json AS traceObjectFilesJson
              FROM messages WHERE id = ?`,
         )
         .get('assistant-1') as {
         resultDeliveryState: string | null;
         startedAt: number | null;
         endedAt: number | null;
+        content: string;
+        producedFilesJson: string | null;
+        traceObjectFilesJson: string | null;
       },
     ).toEqual({
       resultDeliveryState: null,
       startedAt: retryCreatedAt,
       endedAt: null,
+      content: 'retry partial B',
+      producedFilesJson: JSON.stringify([
+        { name: 'b-partial.html', kind: 'html', size: 3 },
+      ]),
+      traceObjectFilesJson: JSON.stringify([
+        { name: 'b-partial.html', kind: 'html', size: 3 },
+      ]),
     });
+  });
+
+  it('pin ownership change clears payload so early B telemetry cannot publish A', async () => {
+    // Review regression: side-chat retry reuses assistant id under a new
+    // run_id via pinAssistantMessageOnRunCreate. reportRunCompletedFromDaemon
+    // trusts any row with runId === run.id and reloads content/manifests from
+    // listMessages. If B fails before the next message upsert, B must not
+    // inherit A's stale body.
+    const oldRunId = 'run-a-stale-payload';
+    const newRunId = 'run-b-fail-before-upsert';
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const now = Date.now();
+    insertProject(db, {
+      id: 'proj-1',
+      name: 'Telemetry project',
+      createdAt: now,
+      updatedAt: now,
+    });
+    insertConversation(db, {
+      id: 'conv-1',
+      projectId: 'proj-1',
+      title: 'Telemetry run',
+      createdAt: now,
+      updatedAt: now,
+    });
+    upsertMessage(db, 'conv-1', {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: 'final A — must not appear on run B',
+      runId: oldRunId,
+      runStatus: 'failed',
+      telemetryFinalized: true,
+      endedAt: now,
+      producedFiles: [{ name: 'a-only.html', kind: 'html', size: 42 }],
+      traceObjectFiles: [{ name: 'a-only.html', kind: 'html', size: 42 }],
+    });
+
+    pinAssistantMessageOnRunCreate(db, {
+      id: newRunId,
+      conversationId: 'conv-1',
+      assistantMessageId: 'assistant-1',
+      status: 'running',
+      createdAt: now + 1,
+    });
+
+    const pinned = listMessages(db, 'conv-1').find((m) => m.id === 'assistant-1') as {
+      content?: string;
+      runId?: string | null;
+      producedFiles?: unknown;
+      traceObjectFiles?: unknown;
+    };
+    expect(pinned.runId).toBe(newRunId);
+    expect(pinned.content).toBe('');
+    expect(pinned.producedFiles ?? null).toBeNull();
+    expect(pinned.traceObjectFiles ?? null).toBeNull();
+
+    writeFileSync(
+      path.join(tempDir, 'app-config.json'),
+      JSON.stringify({
+        installationId: 'install-pin-payload',
+        telemetry: { metrics: true, content: true, artifactManifest: true },
+      }),
+    );
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk';
+    process.env.LANGFUSE_SECRET_KEY = 'sk';
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(new Response('{}', { status: 207 }));
+    try {
+      // Immediate report after repin — no intervening upsert for B.
+      await reportRunCompletedFromDaemon({
+        db,
+        dataDir: tempDir,
+        run: {
+          id: newRunId,
+          projectId: 'proj-1',
+          conversationId: 'conv-1',
+          assistantMessageId: 'assistant-1',
+          agentId: 'claude',
+          status: 'failed',
+          createdAt: now + 1,
+          updatedAt: now + 2,
+          events: [],
+          userPrompt: 'prompt for run B',
+        } as any,
+        persistedRunStatus: 'failed',
+        reportTrigger: 'terminal_fallback',
+        fetchImpl: fetchSpy as any,
+      });
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const batch = JSON.parse(
+        (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+      ).batch as Array<{ type: string; body: Record<string, any> }>;
+      const trace = batch.find((item) => item.type === 'trace-create')?.body;
+      expect(trace?.id).toBe(`${newRunId}:tf`);
+      expect(trace?.input).toBe('prompt for run B');
+      expect(trace?.output ?? '').toBe('');
+      expect(String(trace?.output ?? '')).not.toContain('final A');
+      const artifacts = batch.find(
+        (item) =>
+          item.type === 'event-create' && item.body?.name === 'artifact-summary',
+      )?.body;
+      expect(artifacts?.output?.artifacts ?? []).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ slug: 'a-only.html' }),
+        ]),
+      );
+    } finally {
+      delete process.env.LANGFUSE_PUBLIC_KEY;
+      delete process.env.LANGFUSE_SECRET_KEY;
+    }
   });
 
   it('A fails → row reused by B → A fallback accepted → restart still resolves A:tf', () => {

--- a/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
+++ b/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
@@ -126,4 +126,85 @@ describe('persisted telemetry accepted anchor', () => {
     expect(anchor?.acceptedTraceBodyId).toBe(runId);
     expect(anchor?.acceptedReportTrigger).toBe('final_message');
   });
+
+  it('ignores a stale or foreign assistantMessageId and falls back to the run row', () => {
+    const runId = 'run-target';
+    const otherRunId = 'run-other';
+    const expectedBodyId = scopedTelemetryBodyId(runId, 'final', 'terminal_fallback');
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const now = Date.now();
+    insertProject(db, {
+      id: 'proj-1',
+      name: 'Telemetry project',
+      createdAt: now,
+      updatedAt: now,
+    });
+    insertConversation(db, {
+      id: 'conv-1',
+      projectId: 'proj-1',
+      title: 'Telemetry run',
+      createdAt: now,
+      updatedAt: now,
+    });
+    // Foreign terminal assistant (different run) — must not steer the URL run.
+    upsertMessage(db, 'conv-1', {
+      id: 'assistant-foreign',
+      role: 'assistant',
+      content: 'other run',
+      runId: otherRunId,
+      runStatus: 'succeeded',
+      telemetryFinalized: true,
+      endedAt: now,
+    });
+    // User message id (no terminal run_status) — same trap as a stale client id.
+    upsertMessage(db, 'conv-1', {
+      id: 'user-1',
+      role: 'user',
+      content: 'prompt',
+    });
+    // Canonical terminal assistant for the feedback URL run.
+    upsertMessage(db, 'conv-1', {
+      id: 'assistant-target',
+      role: 'assistant',
+      content: 'partial',
+      runId,
+      runStatus: 'failed',
+      telemetryFinalized: false,
+      endedAt: now,
+    });
+    expect(
+      setRunTelemetryAcceptedAnchor(db, {
+        runId,
+        assistantMessageId: 'assistant-target',
+        bodyId: expectedBodyId,
+        reportTrigger: 'terminal_fallback',
+      }),
+    ).toBe(true);
+
+    for (const staleId of ['assistant-foreign', 'user-1', 'missing-id'] as const) {
+      const anchor = getRunFeedbackTelemetryAnchor(db, runId, staleId);
+      expect(anchor).toEqual({
+        runStatus: 'failed',
+        telemetryFinalized: false,
+        acceptedTraceBodyId: expectedBodyId,
+        acceptedReportTrigger: 'terminal_fallback',
+      });
+      expect(
+        resolveFeedbackTraceId({
+          runId,
+          runStatus: anchor!.runStatus,
+          telemetryFinalized: anchor!.telemetryFinalized,
+          acceptedTraceBodyId: anchor!.acceptedTraceBodyId,
+        }),
+      ).toBe(expectedBodyId);
+    }
+
+    // Matching id + run_id + terminal status still wins.
+    expect(getRunFeedbackTelemetryAnchor(db, runId, 'assistant-target')).toEqual({
+      runStatus: 'failed',
+      telemetryFinalized: false,
+      acceptedTraceBodyId: expectedBodyId,
+      acceptedReportTrigger: 'terminal_fallback',
+    });
+  });
 });

--- a/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
+++ b/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
@@ -284,6 +284,80 @@ describe('persisted telemetry accepted anchor', () => {
     ).toBe(foreignBodyId);
   });
 
+  it('clears accepted telemetry anchors when upsert reuses a message for a new run_id', () => {
+    const oldRunId = 'run-failed-original';
+    const newRunId = 'run-retry';
+    const staleBodyId = scopedTelemetryBodyId(oldRunId, 'final', 'terminal_fallback');
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    seedFailedAssistant(db, oldRunId);
+    expect(
+      setRunTelemetryAcceptedAnchor(db, {
+        runId: oldRunId,
+        assistantMessageId: 'assistant-1',
+        bodyId: staleBodyId,
+        reportTrigger: 'terminal_fallback',
+      }),
+    ).toBe(true);
+    expect(getRunFeedbackTelemetryAnchor(db, oldRunId, 'assistant-1')).toEqual({
+      runStatus: 'failed',
+      telemetryFinalized: true,
+      acceptedTraceBodyId: staleBodyId,
+      acceptedReportTrigger: 'terminal_fallback',
+    });
+
+    // Side-chat retry reuses the failed assistant message id with a new run.
+    upsertMessage(db, 'conv-1', {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: '',
+      runId: newRunId,
+      runStatus: null,
+      telemetryFinalized: false,
+    });
+
+    // Old run row is gone; new run must not inherit the previous :tf anchor.
+    expect(getRunFeedbackTelemetryAnchor(db, oldRunId, 'assistant-1')).toBeNull();
+    expect(getRunFeedbackTelemetryAnchor(db, newRunId, 'assistant-1')).toEqual({
+      runStatus: null,
+      telemetryFinalized: true,
+      acceptedTraceBodyId: null,
+      acceptedReportTrigger: null,
+    });
+    expect(
+      resolveFeedbackTraceId({
+        runId: newRunId,
+        runStatus: 'failed',
+        telemetryFinalized: true,
+        acceptedTraceBodyId: null,
+      }),
+    ).toBe(newRunId);
+
+    // Same run_id updates keep an accepted anchor (mid-stream / finalize path).
+    expect(
+      setRunTelemetryAcceptedAnchor(db, {
+        runId: newRunId,
+        assistantMessageId: 'assistant-1',
+        bodyId: newRunId,
+        reportTrigger: 'final_message',
+      }),
+    ).toBe(true);
+    upsertMessage(db, 'conv-1', {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: 'retry reply',
+      runId: newRunId,
+      runStatus: 'succeeded',
+      telemetryFinalized: true,
+      endedAt: Date.now(),
+    });
+    expect(getRunFeedbackTelemetryAnchor(db, newRunId, 'assistant-1')).toEqual({
+      runStatus: 'succeeded',
+      telemetryFinalized: true,
+      acceptedTraceBodyId: newRunId,
+      acceptedReportTrigger: 'final_message',
+    });
+  });
+
   it('accepted write with stale assistantMessageId still lands on the run row after restart', () => {
     const runId = 'run-stale-write';
     const otherRunId = 'run-other-stale-write';

--- a/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
+++ b/apps/daemon/tests/db-telemetry-accepted-anchor.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  closeDatabase,
+  getRunFeedbackTelemetryAnchor,
+  insertConversation,
+  insertProject,
+  openDatabase,
+  setRunTelemetryAcceptedAnchor,
+  upsertMessage,
+} from '../src/db.js';
+import {
+  resolveFeedbackTraceId,
+  resetAcceptedFinalTraceBodyIdsForTests,
+  scopedTelemetryBodyId,
+} from '../src/langfuse-trace.js';
+
+describe('persisted telemetry accepted anchor', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'od-db-telemetry-anchor-'));
+    resetAcceptedFinalTraceBodyIdsForTests();
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+    resetAcceptedFinalTraceBodyIdsForTests();
+  });
+
+  function seedFailedAssistant(db: ReturnType<typeof openDatabase>, runId: string) {
+    const now = Date.now();
+    insertProject(db, {
+      id: 'proj-1',
+      name: 'Telemetry project',
+      createdAt: now,
+      updatedAt: now,
+    });
+    insertConversation(db, {
+      id: 'conv-1',
+      projectId: 'proj-1',
+      title: 'Telemetry run',
+      createdAt: now,
+      updatedAt: now,
+    });
+    upsertMessage(db, 'conv-1', {
+      id: 'assistant-1',
+      role: 'assistant',
+      content: 'partial',
+      runId,
+      runStatus: 'failed',
+      telemetryFinalized: true,
+      endedAt: now,
+    });
+  }
+
+  it('survives restart: fallback accepted, final_message failed, feedback still targets runId:tf', () => {
+    const runId = 'run-fallback-then-final-fail';
+    const expectedBodyId = scopedTelemetryBodyId(runId, 'final', 'terminal_fallback');
+
+    const db1 = openDatabase(tempDir, { dataDir: tempDir });
+    seedFailedAssistant(db1, runId);
+    expect(
+      setRunTelemetryAcceptedAnchor(db1, {
+        runId,
+        assistantMessageId: 'assistant-1',
+        bodyId: expectedBodyId,
+        reportTrigger: 'terminal_fallback',
+      }),
+    ).toBe(true);
+    // Simulate final_message failure: process memory cleared, no final accepted write.
+    closeDatabase();
+    resetAcceptedFinalTraceBodyIdsForTests();
+
+    const db2 = openDatabase(tempDir, { dataDir: tempDir });
+    const anchor = getRunFeedbackTelemetryAnchor(db2, runId, 'assistant-1');
+    expect(anchor).toEqual({
+      runStatus: 'failed',
+      telemetryFinalized: true,
+      acceptedTraceBodyId: expectedBodyId,
+      acceptedReportTrigger: 'terminal_fallback',
+    });
+    expect(
+      resolveFeedbackTraceId({
+        runId,
+        runStatus: anchor!.runStatus,
+        telemetryFinalized: anchor!.telemetryFinalized,
+        acceptedTraceBodyId: anchor!.acceptedTraceBodyId,
+      }),
+    ).toBe(expectedBodyId);
+    // Without the persisted anchor, finalization alone would wrongly pick canonical runId.
+    expect(
+      resolveFeedbackTraceId({
+        runId,
+        runStatus: 'failed',
+        telemetryFinalized: true,
+      }),
+    ).toBe(runId);
+  });
+
+  it('does not demote an accepted final_message anchor with a later terminal_fallback write', () => {
+    const runId = 'run-final-wins';
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    seedFailedAssistant(db, runId);
+    expect(
+      setRunTelemetryAcceptedAnchor(db, {
+        runId,
+        assistantMessageId: 'assistant-1',
+        bodyId: runId,
+        reportTrigger: 'final_message',
+      }),
+    ).toBe(true);
+    expect(
+      setRunTelemetryAcceptedAnchor(db, {
+        runId,
+        assistantMessageId: 'assistant-1',
+        bodyId: `${runId}:tf`,
+        reportTrigger: 'terminal_fallback',
+      }),
+    ).toBe(false);
+    const anchor = getRunFeedbackTelemetryAnchor(db, runId, 'assistant-1');
+    expect(anchor?.acceptedTraceBodyId).toBe(runId);
+    expect(anchor?.acceptedReportTrigger).toBe('final_message');
+  });
+});

--- a/apps/daemon/tests/langfuse-bridge-nonblocking.test.ts
+++ b/apps/daemon/tests/langfuse-bridge-nonblocking.test.ts
@@ -6,6 +6,7 @@ const reportRunCompletedMock = vi.fn();
 
 vi.mock('../src/app-config.js', () => ({
   readAppConfig: readAppConfigMock,
+  agentCliEnvForAgent: () => ({}),
 }));
 
 vi.mock('../src/db.js', () => ({

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -2557,9 +2557,11 @@ describe('langfuse-bridge.reportRunFeedbackFromDaemon', () => {
     expect(String(fetchSpy.mock.calls[0]![0])).toContain(
       '/api/v1/open-design/telemetry',
     );
-    expect(String(fetchSpy.mock.calls[0]![1].headers?.Authorization ?? '')).toBe(
-      'Bearer ck_logged_in_later',
-    );
+    expect(
+      String(
+        (fetchSpy.mock.calls[0]![1].headers as Record<string, string>)?.Authorization ?? '',
+      ),
+    ).toBe('Bearer ck_logged_in_later');
   });
 
   it('ships cold finalized/no-anchor feedback on the canonical body (no indefinite defer)', async () => {

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -8,6 +8,7 @@ import {
   reportRunFeedbackFromDaemon,
 } from '../src/langfuse-bridge.js';
 import {
+  markRunAwaitingFinalAcceptance,
   rememberAcceptedFinalTraceBodyId,
   reportRunCompleted,
   resetAcceptedFinalTraceBodyIdsForTests,
@@ -2425,6 +2426,8 @@ describe('langfuse-bridge.reportRunFeedbackFromDaemon', () => {
     // reportRunCompleted persists an accepted body/channel. Immediate thumbs
     // on a just-finished successful final_message must not take the legacy
     // anonymous path (Vela-only → skipped_no_sink) or ship on a guessed sink.
+    // markRunAwaitingFinalAcceptance is what distinguishes this live race from
+    // cold finalized/no-anchor rows that must not queue forever.
     await writeAppCfg({
       installationId: 'install-uuid-1',
       telemetry: { metrics: true, content: true },
@@ -2434,6 +2437,7 @@ describe('langfuse-bridge.reportRunFeedbackFromDaemon', () => {
     // Vela-only: no relay / direct Langfuse.
     const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
     const runId = 'run-live-finalization-race';
+    markRunAwaitingFinalAcceptance(runId);
     const db = {
       prepare: (sql: string) => {
         if (
@@ -2477,6 +2481,59 @@ describe('langfuse-bridge.reportRunFeedbackFromDaemon', () => {
     expect(String(fetchSpy.mock.calls[0]![0])).toContain(
       '/api/v1/open-design/telemetry',
     );
+  });
+
+  it('ships cold finalized/no-anchor feedback on the canonical body (no indefinite defer)', async () => {
+    // Pre-migration or never-accepted rows: telemetry_finalized_at set, no
+    // accepted body/channel, and no in-flight markRunAwaitingFinalAcceptance.
+    // Must not sit in pendingRunFeedbackByRunId until process exit.
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true },
+    });
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk';
+    process.env.LANGFUSE_SECRET_KEY = 'sk';
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 }),
+      );
+    const runId = 'run-cold-finalized-no-anchor';
+    const db = {
+      prepare: (sql: string) => {
+        if (
+          sql.includes('telemetry_accepted_body_id') ||
+          sql.includes('run_telemetry_accepted_anchors')
+        ) {
+          return {
+            get: () => ({
+              runStatus: 'succeeded',
+              telemetryFinalizedAt: Date.now() - 60_000,
+              acceptedTraceBodyId: null,
+              acceptedReportTrigger: null,
+              acceptedDeliveryChannel: null,
+            }),
+          };
+        }
+        return { get: () => undefined, run: () => ({ changes: 0 }), all: () => [] };
+      },
+    };
+    const outcome = await reportRunFeedbackFromDaemon({
+      dataDir,
+      runId,
+      rating: 'positive',
+      reasonCodes: [],
+      hasCustomReason: false,
+      customReason: '',
+      db,
+      fetchImpl: fetchSpy as any,
+    });
+    expect(outcome).toEqual({ status: 'accepted' });
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
+    expect(body.batch[0].body.traceId).toBe(runId);
   });
 
   it('replays the latest mid-window re-rating onto final_message after terminal_fallback', async () => {

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -7,12 +7,21 @@ import {
   reportRunCompletedFromDaemon,
   reportRunFeedbackFromDaemon,
 } from '../src/langfuse-bridge.js';
+import {
+  rememberAcceptedFinalTraceBodyId,
+  reportRunCompleted,
+  resetAcceptedFinalTraceBodyIdsForTests,
+  resetPendingRunFeedbackForTests,
+  scopedTelemetryBodyId,
+} from '../src/langfuse-trace.js';
 import { buildPromptStackTelemetry } from '../src/prompt-telemetry.js';
 
 interface FakeMessage {
   id: string;
   role: 'user' | 'assistant';
   content: string;
+  /** Owning run id when known; foreign ownership must not be published. */
+  runId?: string | null;
   attachments?: Array<Record<string, unknown>>;
   producedFiles?: Array<Record<string, unknown>>;
   traceObjectFiles?: Array<Record<string, unknown>>;
@@ -139,6 +148,107 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
       fetchImpl: fetchSpy as any,
     });
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not publish reused assistant-row content under a prior run id', async () => {
+    // A -> B reuse: delayed terminal_fallback for failed run A still holds
+    // assistantMessageId, but the row now belongs to succeeded run B. Emitting
+    // B's content/files under A's failed trace is cross-run corruption.
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true, artifactManifest: true },
+    });
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(new Response('{}', { status: 207 }));
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk';
+    process.env.LANGFUSE_SECRET_KEY = 'sk';
+    try {
+      await reportRunCompletedFromDaemon({
+        db: makeDbWithListMessages({
+          'conv-1': [
+            {
+              id: 'assistant-1',
+              role: 'assistant',
+              content: 'final B — must not appear on run A',
+              runId: 'run-b-reused',
+              producedFiles: [
+                {
+                  name: 'b-only.html',
+                  kind: 'html',
+                  size: 42,
+                },
+              ],
+            },
+          ],
+        }),
+        dataDir,
+        run: makeRun({
+          id: 'run-a-failed-pending-fallback',
+          assistantMessageId: 'assistant-1',
+          status: 'failed',
+          userPrompt: 'prompt for run A',
+        }) as any,
+        persistedRunStatus: 'failed',
+        reportTrigger: 'terminal_fallback',
+        fetchImpl: fetchSpy as any,
+      });
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const batch = JSON.parse(
+        (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+      ).batch as Array<{ type: string; body: Record<string, any> }>;
+      const trace = batch.find((item) => item.type === 'trace-create')?.body;
+      expect(trace?.id).toBe('run-a-failed-pending-fallback:tf');
+      expect(trace?.input).toBe('prompt for run A');
+      // Foreign row content and artifact inventory must not leak onto run A.
+      // Empty assistant output is omitted from the payload (undefined), not "".
+      expect(trace?.output ?? '').toBe('');
+      expect(String(trace?.output ?? '')).not.toContain('final B');
+      const artifacts = batch.find(
+        (item) =>
+          item.type === 'event-create' && item.body?.name === 'artifact-summary',
+      )?.body;
+      expect(artifacts?.output?.artifacts ?? []).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ slug: 'b-only.html' }),
+        ]),
+      );
+
+      // Positive control: matching run ownership still ships content.
+      fetchSpy.mockClear();
+      await reportRunCompletedFromDaemon({
+        db: makeDbWithListMessages({
+          'conv-1': [
+            {
+              id: 'assistant-1',
+              role: 'assistant',
+              content: 'owned by run B',
+              runId: 'run-b-reused',
+              producedFiles: [{ name: 'b-only.html', kind: 'html', size: 42 }],
+            },
+          ],
+        }),
+        dataDir,
+        run: makeRun({
+          id: 'run-b-reused',
+          assistantMessageId: 'assistant-1',
+          status: 'succeeded',
+          userPrompt: 'prompt for run B',
+        }) as any,
+        fetchImpl: fetchSpy as any,
+      });
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const ownedBatch = JSON.parse(
+        (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+      ).batch as Array<{ type: string; body: Record<string, any> }>;
+      const ownedTrace = ownedBatch.find(
+        (item) => item.type === 'trace-create',
+      )?.body;
+      expect(ownedTrace?.output).toBe('owned by run B');
+    } finally {
+      delete process.env.LANGFUSE_PUBLIC_KEY;
+      delete process.env.LANGFUSE_SECRET_KEY;
+    }
   });
 
   it('does nothing when conversation/tool content reporting is off', async () => {
@@ -1871,11 +1981,15 @@ describe('langfuse-bridge.reportRunFeedbackFromDaemon', () => {
 
   beforeEach(async () => {
     dataDir = await mkdtemp(path.join(tmpdir(), 'od-bridge-feedback-'));
+    resetAcceptedFinalTraceBodyIdsForTests();
+    resetPendingRunFeedbackForTests();
   });
 
   afterEach(async () => {
     await rm(dataDir, { recursive: true, force: true });
     vi.restoreAllMocks();
+    resetAcceptedFinalTraceBodyIdsForTests();
+    resetPendingRunFeedbackForTests();
     delete process.env.VELA_CONTROL_KEY;
     delete process.env.VELA_API_URL;
     delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
@@ -2000,6 +2114,141 @@ describe('langfuse-bridge.reportRunFeedbackFromDaemon', () => {
     expect(outcome).toEqual({ status: 'skipped_no_sink' });
     expect(fetchSpy).not.toHaveBeenCalled();
   });
+
+  it('replays the latest mid-window re-rating onto final_message after terminal_fallback', async () => {
+    // terminal_fallback accepted → bridge pins :tf → user flips rating →
+    // final_message wins. Canonical replay must use the edited rating, not a
+    // stale pre-fallback / first-tf payload.
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true },
+    });
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk';
+    process.env.LANGFUSE_SECRET_KEY = 'sk';
+    const runId = 'run-bridge-tf-rerate';
+    const fallbackBodyId = scopedTelemetryBodyId(runId, 'final', 'terminal_fallback');
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 }),
+      );
+    const langfuseConfig = {
+      kind: 'langfuse' as const,
+      authHeader: 'Basic dGVzdA==',
+      baseUrl: 'https://langfuse.example',
+      timeoutMs: 5_000,
+      retries: 0,
+    };
+
+    // Seed process-local + DB-shaped anchor the way terminal_fallback acceptance does.
+    rememberAcceptedFinalTraceBodyId(runId, fallbackBodyId, 'terminal_fallback', 'langfuse');
+    const db = {
+      prepare: (sql: string) => {
+        if (sql.includes('telemetry_accepted_body_id')) {
+          return {
+            get: () => ({
+              runStatus: 'failed',
+              telemetryFinalizedAt: null,
+              acceptedTraceBodyId: fallbackBodyId,
+              acceptedReportTrigger: 'terminal_fallback',
+              acceptedDeliveryChannel: 'langfuse',
+            }),
+          };
+        }
+        return { get: () => undefined, run: () => ({ changes: 0 }), all: () => [] };
+      },
+    };
+
+    try {
+      const first = await reportRunFeedbackFromDaemon({
+        dataDir,
+        runId,
+        rating: 'positive',
+        reasonCodes: [],
+        hasCustomReason: false,
+        customReason: '',
+        db,
+        fetchImpl: fetchSpy as any,
+      });
+      expect(first).toEqual({ status: 'accepted' });
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+      });
+      const firstScore = JSON.parse(
+        (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+      );
+      expect(firstScore.batch[0].body.traceId).toBe(fallbackBodyId);
+      expect(firstScore.batch[0].body.value).toBe(1);
+
+      // User flips rating while only :tf is accepted.
+      const second = await reportRunFeedbackFromDaemon({
+        dataDir,
+        runId,
+        rating: 'negative',
+        reasonCodes: ['matched_request'],
+        hasCustomReason: false,
+        customReason: '',
+        db,
+        fetchImpl: fetchSpy as any,
+      });
+      expect(second).toEqual({ status: 'accepted' });
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+      });
+      const secondScore = JSON.parse(
+        (fetchSpy.mock.calls[1]![1] as RequestInit).body as string,
+      );
+      expect(secondScore.batch[0].body.traceId).toBe(fallbackBodyId);
+      expect(secondScore.batch[0].body.value).toBe(-1);
+
+      // Later final_message wins the anchor; deferred queue must re-attach the
+      // latest (negative) score onto the canonical body.
+      const finalCompleted = await reportRunCompleted(
+        {
+          installationId: 'install-uuid-1',
+          projectId: 'proj-1',
+          conversationId: 'conv-1',
+          agentId: 'claude',
+          run: {
+            runId,
+            status: 'failed',
+            startedAt: 1_700_000_000_000,
+            endedAt: 1_700_000_002_000,
+          },
+          message: {
+            messageId: 'assistant-1',
+            prompt: 'prompt',
+            output: 'partial',
+          },
+          artifacts: [],
+          tools: [],
+          agentEvents: [],
+          eventsSummary: { toolCalls: 0, errors: 0, durationMs: 2000 },
+          prefs: { metrics: true, content: true, artifactManifest: false },
+        },
+        {
+          config: langfuseConfig,
+          fetchImpl: fetchSpy as any,
+          reportTrigger: 'final_message',
+        },
+      );
+      expect(finalCompleted.langfuse_delivery_status).toBe('accepted');
+      await vi.waitFor(() => {
+        expect(fetchSpy.mock.calls.length).toBeGreaterThanOrEqual(4);
+      });
+      const finalScoreBody = JSON.parse(
+        (fetchSpy.mock.calls[fetchSpy.mock.calls.length - 1]![1] as RequestInit)
+          .body as string,
+      );
+      expect(finalScoreBody.batch[0].type).toBe('score-create');
+      expect(finalScoreBody.batch[0].body.traceId).toBe(runId);
+      expect(finalScoreBody.batch[0].body.value).toBe(-1);
+      expect(finalScoreBody.batch[0].body.comment).toBe('negative');
+    } finally {
+      delete process.env.LANGFUSE_PUBLIC_KEY;
+      delete process.env.LANGFUSE_SECRET_KEY;
+    }
+  });
 });
 
 // listMessages reads from a `prepare(...).all(cid)` call against
@@ -2020,7 +2269,7 @@ function makeDbWithListMessages(messagesByConvo: Record<string, FakeMessage[]>) 
             content: m.content,
             agentId: null,
             agentName: null,
-            runId: null,
+            runId: m.runId ?? null,
             runStatus: null,
             lastRunEventId: null,
             eventsJson: null,

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -1959,6 +1959,47 @@ describe('langfuse-bridge.reportRunFeedbackFromDaemon', () => {
       expect(fetchSpy).toHaveBeenCalled();
     });
   });
+
+  it('returns skipped_no_sink for Vela-accepted anchors when only anonymous relay remains', async () => {
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true },
+    });
+    // Logged out of Vela; only the anonymous relay is available.
+    delete process.env.VELA_CONTROL_KEY;
+    delete process.env.VELA_API_URL;
+    process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL =
+      'https://telemetry.open-design.ai/api/langfuse';
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 207 }));
+    const db = {
+      prepare: (sql: string) => {
+        if (sql.includes('telemetry_accepted_body_id')) {
+          return {
+            get: () => ({
+              runStatus: 'succeeded',
+              telemetryFinalizedAt: Date.now(),
+              acceptedTraceBodyId: 'run-vela-anchor',
+              acceptedReportTrigger: 'final_message',
+              acceptedDeliveryChannel: 'vela',
+            }),
+          };
+        }
+        return { get: () => undefined, run: () => ({ changes: 0 }), all: () => [] };
+      },
+    };
+    const outcome = await reportRunFeedbackFromDaemon({
+      dataDir,
+      runId: 'run-vela-anchor',
+      rating: 'positive',
+      reasonCodes: [],
+      hasCustomReason: false,
+      customReason: '',
+      db,
+      fetchImpl: fetchSpy as any,
+    });
+    expect(outcome).toEqual({ status: 'skipped_no_sink' });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
 });
 
 // listMessages reads from a `prepare(...).all(cid)` call against

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -3,7 +3,10 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { reportRunCompletedFromDaemon } from '../src/langfuse-bridge.js';
+import {
+  reportRunCompletedFromDaemon,
+  reportRunFeedbackFromDaemon,
+} from '../src/langfuse-bridge.js';
 import { buildPromptStackTelemetry } from '../src/prompt-telemetry.js';
 
 interface FakeMessage {
@@ -1860,6 +1863,101 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     expect(trace.metadata.eventsSummary.durationMs).toBe(2500);
     expect(span.metadata.status).toBe('canceled');
     expect(span.endTime).toBe(new Date(run.createdAt + 2500).toISOString());
+  });
+});
+
+describe('langfuse-bridge.reportRunFeedbackFromDaemon', () => {
+  let dataDir: string;
+
+  beforeEach(async () => {
+    dataDir = await mkdtemp(path.join(tmpdir(), 'od-bridge-feedback-'));
+  });
+
+  afterEach(async () => {
+    await rm(dataDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+    delete process.env.VELA_CONTROL_KEY;
+    delete process.env.VELA_API_URL;
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.OPEN_DESIGN_VELA_TELEMETRY;
+  });
+
+  async function writeAppCfg(cfg: Record<string, unknown>) {
+    await writeFile(path.join(dataDir, 'app-config.json'), JSON.stringify(cfg));
+  }
+
+  it('returns skipped_no_sink when Vela is configured but installationId is missing and no anonymous sink exists', async () => {
+    await writeAppCfg({
+      // Missing / null installationId is legitimate; Vela cannot ship without it.
+      installationId: null,
+      telemetry: { metrics: true, content: true },
+    });
+    process.env.VELA_CONTROL_KEY = 'ck_test_key';
+    process.env.VELA_API_URL = 'https://amr-api.example.com';
+    // No OPEN_DESIGN_TELEMETRY_RELAY_URL / LANGFUSE_* → anonymous fallback absent.
+    const fetchSpy = vi.fn();
+    const outcome = await reportRunFeedbackFromDaemon({
+      dataDir,
+      runId: 'run-feedback-1',
+      rating: 'positive',
+      reasonCodes: [],
+      hasCustomReason: false,
+      customReason: '',
+      fetchImpl: fetchSpy as any,
+    });
+    expect(outcome).toEqual({ status: 'skipped_no_sink' });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns accepted when Vela has installationId', async () => {
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true },
+    });
+    process.env.VELA_CONTROL_KEY = 'ck_test_key';
+    process.env.VELA_API_URL = 'https://amr-api.example.com';
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
+    const outcome = await reportRunFeedbackFromDaemon({
+      dataDir,
+      runId: 'run-feedback-1',
+      rating: 'positive',
+      reasonCodes: [],
+      hasCustomReason: false,
+      customReason: '',
+      fetchImpl: fetchSpy as any,
+    });
+    expect(outcome).toEqual({ status: 'accepted' });
+    // Fire-and-forget send may race the assertion; give the microtask a tick.
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+  });
+
+  it('returns accepted for Vela without installationId when anonymous fallback is configured', async () => {
+    await writeAppCfg({
+      installationId: null,
+      telemetry: { metrics: true, content: true },
+    });
+    process.env.VELA_CONTROL_KEY = 'ck_test_key';
+    process.env.VELA_API_URL = 'https://amr-api.example.com';
+    process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL =
+      'https://telemetry.open-design.ai/api/langfuse';
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 207 }));
+    const outcome = await reportRunFeedbackFromDaemon({
+      dataDir,
+      runId: 'run-feedback-1',
+      rating: 'negative',
+      reasonCodes: ['matched_request'],
+      hasCustomReason: false,
+      customReason: '',
+      fetchImpl: fetchSpy as any,
+    });
+    expect(outcome).toEqual({ status: 'accepted' });
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
   });
 });
 

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -2163,13 +2163,15 @@ describe('langfuse-bridge.reportRunFeedbackFromDaemon', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it('returns skipped_no_sink when relay-accepted feedback would ship through Vela', async () => {
+  it('returns skipped_no_sink when relay-accepted feedback has no relay endpoint left', async () => {
     await writeAppCfg({
       installationId: 'install-uuid-1',
       telemetry: { metrics: true, content: true },
     });
+    // Only Vela remains — sticky relay cannot fall forward onto Vela.
     process.env.VELA_CONTROL_KEY = 'ck_test_key';
     process.env.VELA_API_URL = 'https://amr-api.example.com';
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
     const fetchSpy = vi.fn();
     const db = {
       prepare: (sql: string) => {
@@ -2202,6 +2204,57 @@ describe('langfuse-bridge.reportRunFeedbackFromDaemon', () => {
     });
     expect(outcome).toEqual({ status: 'skipped_no_sink' });
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('ships relay-accepted feedback through relay when Vela is also configured', async () => {
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true },
+    });
+    process.env.VELA_CONTROL_KEY = 'ck_test_key';
+    process.env.VELA_API_URL = 'https://amr-api.example.com';
+    process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL =
+      'https://telemetry.open-design.ai/api/langfuse';
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 207 }));
+    const db = {
+      prepare: (sql: string) => {
+        if (
+          sql.includes('telemetry_accepted_body_id') ||
+          sql.includes('run_telemetry_accepted_anchors')
+        ) {
+          return {
+            get: () => ({
+              runStatus: 'succeeded',
+              telemetryFinalizedAt: Date.now(),
+              acceptedTraceBodyId: 'run-relay-sticky',
+              acceptedReportTrigger: 'final_message',
+              acceptedDeliveryChannel: 'relay',
+            }),
+          };
+        }
+        return { get: () => undefined, run: () => ({ changes: 0 }), all: () => [] };
+      },
+    };
+    const outcome = await reportRunFeedbackFromDaemon({
+      dataDir,
+      runId: 'run-relay-sticky',
+      rating: 'positive',
+      reasonCodes: [],
+      hasCustomReason: false,
+      customReason: '',
+      db,
+      fetchImpl: fetchSpy as any,
+    });
+    expect(outcome).toEqual({ status: 'accepted' });
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+    expect(String(fetchSpy.mock.calls[0]![0])).toBe(
+      'https://telemetry.open-design.ai/api/langfuse',
+    );
+    expect(String(fetchSpy.mock.calls[0]![0])).not.toContain(
+      '/api/v1/open-design/telemetry',
+    );
   });
 
   it('replays the latest mid-window re-rating onto final_message after terminal_fallback', async () => {

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -13,6 +13,7 @@ import {
   resetAcceptedFinalTraceBodyIdsForTests,
   resetPendingRunFeedbackForTests,
   scopedTelemetryBodyId,
+  velaSinkIdentityFingerprint,
 } from '../src/langfuse-trace.js';
 import { buildPromptStackTelemetry } from '../src/prompt-telemetry.js';
 
@@ -2087,7 +2088,10 @@ describe('langfuse-bridge.reportRunFeedbackFromDaemon', () => {
     const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 207 }));
     const db = {
       prepare: (sql: string) => {
-        if (sql.includes('telemetry_accepted_body_id')) {
+        if (
+          sql.includes('telemetry_accepted_body_id') ||
+          sql.includes('run_telemetry_accepted_anchors')
+        ) {
           return {
             get: () => ({
               runStatus: 'succeeded',
@@ -2095,6 +2099,7 @@ describe('langfuse-bridge.reportRunFeedbackFromDaemon', () => {
               acceptedTraceBodyId: 'run-vela-anchor',
               acceptedReportTrigger: 'final_message',
               acceptedDeliveryChannel: 'vela',
+              acceptedVelaIdentity: velaSinkIdentityFingerprint('prod', 'ck_old'),
             }),
           };
         }
@@ -2104,6 +2109,90 @@ describe('langfuse-bridge.reportRunFeedbackFromDaemon', () => {
     const outcome = await reportRunFeedbackFromDaemon({
       dataDir,
       runId: 'run-vela-anchor',
+      rating: 'positive',
+      reasonCodes: [],
+      hasCustomReason: false,
+      customReason: '',
+      db,
+      fetchImpl: fetchSpy as any,
+    });
+    expect(outcome).toEqual({ status: 'skipped_no_sink' });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns skipped_no_sink when the live Vela account differs from the accepting one', async () => {
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true },
+    });
+    process.env.VELA_CONTROL_KEY = 'ck_switched_account';
+    process.env.VELA_API_URL = 'https://amr-api.example.com';
+    const fetchSpy = vi.fn();
+    const acceptingIdentity = velaSinkIdentityFingerprint('prod', 'ck_accepted');
+    const db = {
+      prepare: (sql: string) => {
+        if (
+          sql.includes('telemetry_accepted_body_id') ||
+          sql.includes('run_telemetry_accepted_anchors')
+        ) {
+          return {
+            get: () => ({
+              runStatus: 'succeeded',
+              telemetryFinalizedAt: Date.now(),
+              acceptedTraceBodyId: 'run-vela-account',
+              acceptedReportTrigger: 'final_message',
+              acceptedDeliveryChannel: 'vela',
+              acceptedVelaIdentity: acceptingIdentity,
+            }),
+          };
+        }
+        return { get: () => undefined, run: () => ({ changes: 0 }), all: () => [] };
+      },
+    };
+    const outcome = await reportRunFeedbackFromDaemon({
+      dataDir,
+      runId: 'run-vela-account',
+      rating: 'positive',
+      reasonCodes: [],
+      hasCustomReason: false,
+      customReason: '',
+      db,
+      fetchImpl: fetchSpy as any,
+    });
+    expect(outcome).toEqual({ status: 'skipped_no_sink' });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns skipped_no_sink when relay-accepted feedback would ship through Vela', async () => {
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true },
+    });
+    process.env.VELA_CONTROL_KEY = 'ck_test_key';
+    process.env.VELA_API_URL = 'https://amr-api.example.com';
+    const fetchSpy = vi.fn();
+    const db = {
+      prepare: (sql: string) => {
+        if (
+          sql.includes('telemetry_accepted_body_id') ||
+          sql.includes('run_telemetry_accepted_anchors')
+        ) {
+          return {
+            get: () => ({
+              runStatus: 'succeeded',
+              telemetryFinalizedAt: Date.now(),
+              acceptedTraceBodyId: 'run-relay-anchor',
+              acceptedReportTrigger: 'final_message',
+              acceptedDeliveryChannel: 'relay',
+            }),
+          };
+        }
+        return { get: () => undefined, run: () => ({ changes: 0 }), all: () => [] };
+      },
+    };
+    const outcome = await reportRunFeedbackFromDaemon({
+      dataDir,
+      runId: 'run-relay-anchor',
       rating: 'positive',
       reasonCodes: [],
       hasCustomReason: false,

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -2260,6 +2260,7 @@ describe('langfuse-bridge.reportRunFeedbackFromDaemon', () => {
   it('keeps legacy null-channel accepted anchors on anonymous relay when Vela is configured', async () => {
     // Pre-migration rows: finalized/accepted body with no delivery_channel.
     // Later Vela login must not re-route feedback onto a different namespace.
+    // Only relay is configured among anonymous backends → unambiguous.
     await writeAppCfg({
       installationId: 'install-uuid-1',
       telemetry: { metrics: true, content: true },
@@ -2308,6 +2309,115 @@ describe('langfuse-bridge.reportRunFeedbackFromDaemon', () => {
     expect(String(fetchSpy.mock.calls[0]![0])).not.toContain(
       '/api/v1/open-design/telemetry',
     );
+  });
+
+  it('keeps legacy null-channel accepted anchors on direct Langfuse when only Langfuse is configured', async () => {
+    // Mirror of the relay-only legacy case: null channel + only direct
+    // Langfuse among anonymous backends must not fall forward onto Vela.
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true },
+    });
+    process.env.VELA_CONTROL_KEY = 'ck_test_key';
+    process.env.VELA_API_URL = 'https://amr-api.example.com';
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk';
+    process.env.LANGFUSE_SECRET_KEY = 'sk';
+    process.env.LANGFUSE_BASE_URL = 'https://langfuse.example';
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 }),
+      );
+    const db = {
+      prepare: (sql: string) => {
+        if (
+          sql.includes('telemetry_accepted_body_id') ||
+          sql.includes('run_telemetry_accepted_anchors')
+        ) {
+          return {
+            get: () => ({
+              runStatus: 'succeeded',
+              telemetryFinalizedAt: Date.now(),
+              acceptedTraceBodyId: 'run-legacy-null-langfuse',
+              acceptedReportTrigger: 'final_message',
+              acceptedDeliveryChannel: null,
+            }),
+          };
+        }
+        return { get: () => undefined, run: () => ({ changes: 0 }), all: () => [] };
+      },
+    };
+    try {
+      const outcome = await reportRunFeedbackFromDaemon({
+        dataDir,
+        runId: 'run-legacy-null-langfuse',
+        rating: 'positive',
+        reasonCodes: [],
+        hasCustomReason: false,
+        customReason: '',
+        db,
+        fetchImpl: fetchSpy as any,
+      });
+      expect(outcome).toEqual({ status: 'accepted' });
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalled();
+      });
+      expect(String(fetchSpy.mock.calls[0]![0])).toBe(
+        'https://langfuse.example/api/public/ingestion',
+      );
+      expect(String(fetchSpy.mock.calls[0]![0])).not.toContain(
+        '/api/v1/open-design/telemetry',
+      );
+    } finally {
+      delete process.env.LANGFUSE_BASE_URL;
+    }
+  });
+
+  it('skips legacy null-channel feedback when both relay and direct Langfuse are viable', async () => {
+    // Ambiguous migration path: original accept channel unknown; do not
+    // relay-first and detach scores from a direct-Langfuse accepted trace.
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true },
+    });
+    process.env.VELA_CONTROL_KEY = 'ck_test_key';
+    process.env.VELA_API_URL = 'https://amr-api.example.com';
+    process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL =
+      'https://telemetry.open-design.ai/api/langfuse';
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk';
+    process.env.LANGFUSE_SECRET_KEY = 'sk';
+    const fetchSpy = vi.fn();
+    const db = {
+      prepare: (sql: string) => {
+        if (
+          sql.includes('telemetry_accepted_body_id') ||
+          sql.includes('run_telemetry_accepted_anchors')
+        ) {
+          return {
+            get: () => ({
+              runStatus: 'succeeded',
+              telemetryFinalizedAt: Date.now(),
+              acceptedTraceBodyId: 'run-legacy-ambiguous',
+              acceptedReportTrigger: 'final_message',
+              acceptedDeliveryChannel: null,
+            }),
+          };
+        }
+        return { get: () => undefined, run: () => ({ changes: 0 }), all: () => [] };
+      },
+    };
+    const outcome = await reportRunFeedbackFromDaemon({
+      dataDir,
+      runId: 'run-legacy-ambiguous',
+      rating: 'positive',
+      reasonCodes: [],
+      hasCustomReason: false,
+      customReason: '',
+      db,
+      fetchImpl: fetchSpy as any,
+    });
+    expect(outcome).toEqual({ status: 'skipped_no_sink' });
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it('replays the latest mid-window re-rating onto final_message after terminal_fallback', async () => {

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -2536,6 +2536,58 @@ describe('langfuse-bridge.reportRunFeedbackFromDaemon', () => {
     expect(body.batch[0].body.traceId).toBe(runId);
   });
 
+  it('ships cold failed/no-anchor feedback on the canonical body (no indefinite defer)', async () => {
+    // Daemon restart / fallback already cleared: failed run, no accepted body,
+    // no markRunAwaitingFinalAcceptance. Status alone must not queue forever.
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true },
+    });
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk';
+    process.env.LANGFUSE_SECRET_KEY = 'sk';
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 }),
+      );
+    const runId = 'run-cold-failed-no-anchor';
+    const db = {
+      prepare: (sql: string) => {
+        if (
+          sql.includes('telemetry_accepted_body_id') ||
+          sql.includes('run_telemetry_accepted_anchors')
+        ) {
+          return {
+            get: () => ({
+              runStatus: 'failed',
+              telemetryFinalizedAt: null,
+              acceptedTraceBodyId: null,
+              acceptedReportTrigger: null,
+              acceptedDeliveryChannel: null,
+            }),
+          };
+        }
+        return { get: () => undefined, run: () => ({ changes: 0 }), all: () => [] };
+      },
+    };
+    const outcome = await reportRunFeedbackFromDaemon({
+      dataDir,
+      runId,
+      rating: 'negative',
+      reasonCodes: [],
+      hasCustomReason: false,
+      customReason: '',
+      db,
+      fetchImpl: fetchSpy as any,
+    });
+    expect(outcome).toEqual({ status: 'accepted' });
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
+    expect(body.batch[0].body.traceId).toBe(runId);
+  });
+
   it('replays the latest mid-window re-rating onto final_message after terminal_fallback', async () => {
     // terminal_fallback accepted → bridge pins :tf → user flips rating →
     // final_message wins. Canonical replay must use the edited rating, not a

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -2257,6 +2257,59 @@ describe('langfuse-bridge.reportRunFeedbackFromDaemon', () => {
     );
   });
 
+  it('keeps legacy null-channel accepted anchors on anonymous relay when Vela is configured', async () => {
+    // Pre-migration rows: finalized/accepted body with no delivery_channel.
+    // Later Vela login must not re-route feedback onto a different namespace.
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true },
+    });
+    process.env.VELA_CONTROL_KEY = 'ck_test_key';
+    process.env.VELA_API_URL = 'https://amr-api.example.com';
+    process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL =
+      'https://telemetry.open-design.ai/api/langfuse';
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 207 }));
+    const db = {
+      prepare: (sql: string) => {
+        if (
+          sql.includes('telemetry_accepted_body_id') ||
+          sql.includes('run_telemetry_accepted_anchors')
+        ) {
+          return {
+            get: () => ({
+              runStatus: 'succeeded',
+              telemetryFinalizedAt: Date.now(),
+              acceptedTraceBodyId: 'run-legacy-null-channel',
+              acceptedReportTrigger: 'final_message',
+              acceptedDeliveryChannel: null,
+            }),
+          };
+        }
+        return { get: () => undefined, run: () => ({ changes: 0 }), all: () => [] };
+      },
+    };
+    const outcome = await reportRunFeedbackFromDaemon({
+      dataDir,
+      runId: 'run-legacy-null-channel',
+      rating: 'positive',
+      reasonCodes: [],
+      hasCustomReason: false,
+      customReason: '',
+      db,
+      fetchImpl: fetchSpy as any,
+    });
+    expect(outcome).toEqual({ status: 'accepted' });
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+    expect(String(fetchSpy.mock.calls[0]![0])).toBe(
+      'https://telemetry.open-design.ai/api/langfuse',
+    );
+    expect(String(fetchSpy.mock.calls[0]![0])).not.toContain(
+      '/api/v1/open-design/telemetry',
+    );
+  });
+
   it('replays the latest mid-window re-rating onto final_message after terminal_fallback', async () => {
     // terminal_fallback accepted → bridge pins :tf → user flips rating →
     // final_message wins. Canonical replay must use the edited rating, not a

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -1999,6 +1999,15 @@ function makeDbWithListMessages(messagesByConvo: Record<string, FakeMessage[]>) 
             position: 0,
           }));
         },
+        // Accepted-telemetry-anchor writes use prepare().get/.run after a
+        // successful final delivery. These unit tests use a stub DB; return
+        // empty so setRunTelemetryAcceptedAnchor no-ops without throwing.
+        get() {
+          return undefined;
+        },
+        run() {
+          return { changes: 0 };
+        },
       };
     },
   };

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -2489,6 +2489,79 @@ describe('langfuse-bridge.reportRunFeedbackFromDaemon', () => {
     );
   });
 
+  it('queues feedback during live awaiting window when no sink is configured yet', async () => {
+    // terminal_fallback / final_message is in flight (awaiting mark set) but
+    // the user has not logged into Vela and has no relay/Langfuse. lateFinalOpen
+    // is false (no accepted terminal_fallback body). Feedback must still enqueue
+    // without a stale sink config so a later login + accept can flush the score
+    // — not return skipped_no_sink and drop it permanently.
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true },
+    });
+    // No Vela / relay / Langfuse at submit time.
+    delete process.env.VELA_CONTROL_KEY;
+    delete process.env.VELA_API_URL;
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
+    const runId = 'run-awaiting-no-sink-yet';
+    markRunAwaitingFinalAcceptance(runId);
+    const db = {
+      prepare: (sql: string) => {
+        if (
+          sql.includes('telemetry_accepted_body_id') ||
+          sql.includes('run_telemetry_accepted_anchors')
+        ) {
+          return {
+            get: () => ({
+              runStatus: 'failed',
+              telemetryFinalizedAt: null,
+              acceptedTraceBodyId: null,
+              acceptedReportTrigger: null,
+              acceptedDeliveryChannel: null,
+            }),
+          };
+        }
+        return { get: () => undefined, run: () => ({ changes: 0 }), all: () => [] };
+      },
+    };
+    const outcome = await reportRunFeedbackFromDaemon({
+      dataDir,
+      runId,
+      rating: 'negative',
+      reasonCodes: ['matched_request'],
+      hasCustomReason: false,
+      customReason: '',
+      db,
+      fetchImpl: fetchSpy as any,
+    });
+    expect(outcome).toEqual({ status: 'accepted' });
+    expect(hasPendingRunFeedbackForTests(runId)).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    // User logs into Vela before the delayed final-purpose report accepts.
+    process.env.VELA_CONTROL_KEY = 'ck_logged_in_later';
+    process.env.VELA_API_URL = 'https://amr-api.example.com';
+    rememberAcceptedFinalTraceBodyId(
+      runId,
+      scopedTelemetryBodyId(runId, 'final', 'terminal_fallback'),
+      'terminal_fallback',
+      'vela',
+      velaSinkIdentityFingerprint('prod', 'ck_logged_in_later'),
+    );
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      '/api/v1/open-design/telemetry',
+    );
+    expect(String(fetchSpy.mock.calls[0]![1].headers?.Authorization ?? '')).toBe(
+      'Bearer ck_logged_in_later',
+    );
+  });
+
   it('ships cold finalized/no-anchor feedback on the canonical body (no indefinite defer)', async () => {
     // Pre-migration or never-accepted rows: telemetry_finalized_at set, no
     // accepted body/channel, and no in-flight markRunAwaitingFinalAcceptance.

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -2420,6 +2420,65 @@ describe('langfuse-bridge.reportRunFeedbackFromDaemon', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it('queues feedback during live finalization race on Vela-only (finalized, no accepted anchor yet)', async () => {
+    // createFinalizedMessageTelemetryReporter marks telemetryFinalized before
+    // reportRunCompleted persists an accepted body/channel. Immediate thumbs
+    // on a just-finished successful final_message must not take the legacy
+    // anonymous path (Vela-only → skipped_no_sink) or ship on a guessed sink.
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true },
+    });
+    process.env.VELA_CONTROL_KEY = 'ck_test_key';
+    process.env.VELA_API_URL = 'https://amr-api.example.com';
+    // Vela-only: no relay / direct Langfuse.
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
+    const runId = 'run-live-finalization-race';
+    const db = {
+      prepare: (sql: string) => {
+        if (
+          sql.includes('telemetry_accepted_body_id') ||
+          sql.includes('run_telemetry_accepted_anchors')
+        ) {
+          return {
+            get: () => ({
+              runStatus: 'succeeded',
+              telemetryFinalizedAt: Date.now(),
+              acceptedTraceBodyId: null,
+              acceptedReportTrigger: null,
+              acceptedDeliveryChannel: null,
+            }),
+          };
+        }
+        return { get: () => undefined, run: () => ({ changes: 0 }), all: () => [] };
+      },
+    };
+    const outcome = await reportRunFeedbackFromDaemon({
+      dataDir,
+      runId,
+      rating: 'positive',
+      reasonCodes: [],
+      hasCustomReason: false,
+      customReason: '',
+      db,
+      fetchImpl: fetchSpy as any,
+    });
+    // Enqueued for later flush — not skipped_no_sink from a false legacy path.
+    expect(outcome).toEqual({ status: 'accepted' });
+    // Still waiting on rememberAcceptedFinalTraceBodyId; nothing shipped yet.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    // final_message acceptance records the Vela body/channel and flushes.
+    rememberAcceptedFinalTraceBodyId(runId, runId, 'final_message', 'vela');
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      '/api/v1/open-design/telemetry',
+    );
+  });
+
   it('replays the latest mid-window re-rating onto final_message after terminal_fallback', async () => {
     // terminal_fallback accepted → bridge pins :tf → user flips rating →
     // final_message wins. Canonical replay must use the edited rating, not a

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -8,12 +8,14 @@ import {
   reportRunFeedbackFromDaemon,
 } from '../src/langfuse-bridge.js';
 import {
+  hasPendingRunFeedbackForTests,
   markRunAwaitingFinalAcceptance,
   rememberAcceptedFinalTraceBodyId,
   reportRunCompleted,
   resetAcceptedFinalTraceBodyIdsForTests,
   resetPendingRunFeedbackForTests,
   scopedTelemetryBodyId,
+  setLiveTelemetryPrefsReaderForTests,
   velaSinkIdentityFingerprint,
 } from '../src/langfuse-trace.js';
 import { buildPromptStackTelemetry } from '../src/prompt-telemetry.js';
@@ -1985,6 +1987,10 @@ describe('langfuse-bridge.reportRunFeedbackFromDaemon', () => {
     dataDir = await mkdtemp(path.join(tmpdir(), 'od-bridge-feedback-'));
     resetAcceptedFinalTraceBodyIdsForTests();
     resetPendingRunFeedbackForTests();
+    setLiveTelemetryPrefsReaderForTests(() => ({
+      metrics: true,
+      content: true,
+    }));
   });
 
   afterEach(async () => {
@@ -2721,6 +2727,100 @@ describe('langfuse-bridge.reportRunFeedbackFromDaemon', () => {
       delete process.env.LANGFUSE_PUBLIC_KEY;
       delete process.env.LANGFUSE_SECRET_KEY;
     }
+  });
+
+  it('queues a re-rate after Vela profile switch during late-final without skipping', async () => {
+    // terminal_fallback accepted on Vela identity A. User switches AMR profile
+    // (live key B) and re-rates: sticky canDeliver fails, but the deferred
+    // queue must still refresh so final_message under B can replay the latest
+    // score instead of a stale queued rating (or none).
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true },
+    });
+    process.env.VELA_CONTROL_KEY = 'ck_new_profile';
+    process.env.VELA_API_URL = 'https://amr-api.example.com';
+    const runId = 'run-bridge-vela-switch-rerate';
+    const oldIdentity = velaSinkIdentityFingerprint('prod', 'ck_old_profile');
+    const newIdentity = velaSinkIdentityFingerprint('prod', 'ck_new_profile');
+    const fallbackBodyId = scopedTelemetryBodyId(runId, 'final', 'terminal_fallback');
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
+
+    // Process-local + DB-shaped sticky anchor under the old Vela identity.
+    rememberAcceptedFinalTraceBodyId(
+      runId,
+      fallbackBodyId,
+      'terminal_fallback',
+      'vela',
+      oldIdentity,
+    );
+    const db = {
+      prepare: (sql: string) => {
+        if (
+          sql.includes('run_telemetry_accepted_anchors') ||
+          sql.includes('telemetry_accepted_body_id')
+        ) {
+          return {
+            get: () => ({
+              runStatus: 'failed',
+              telemetryFinalizedAt: null,
+              acceptedTraceBodyId: fallbackBodyId,
+              acceptedReportTrigger: 'terminal_fallback',
+              acceptedDeliveryChannel: 'vela',
+              acceptedVelaIdentity: oldIdentity,
+            }),
+          };
+        }
+        return { get: () => undefined, run: () => ({ changes: 0 }), all: () => [] };
+      },
+    };
+
+    const rerate = await reportRunFeedbackFromDaemon({
+      dataDir,
+      runId,
+      rating: 'negative',
+      reasonCodes: ['matched_request'],
+      hasCustomReason: false,
+      customReason: '',
+      db,
+      fetchImpl: fetchSpy as any,
+    });
+    expect(rerate).toEqual({ status: 'accepted' });
+    // Sticky old identity cannot deliver; immediate send suppressed.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(hasPendingRunFeedbackForTests(runId)).toBe(true);
+
+    // final_message under the new Vela identity replays the re-rated score.
+    rememberAcceptedFinalTraceBodyId(
+      runId,
+      runId,
+      'final_message',
+      'vela',
+      newIdentity,
+    );
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+    const envelope = JSON.parse(
+      (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+    );
+    expect(envelope.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'score',
+          data: expect.objectContaining({
+            name: 'user_rating',
+            value: -1,
+            traceId: runId,
+          }),
+        }),
+      ]),
+    );
+    const auth = String(
+      (fetchSpy.mock.calls[0]![1] as { headers?: Record<string, string> }).headers
+        ?.Authorization ?? '',
+    );
+    expect(auth).toBe('Bearer ck_new_profile');
   });
 });
 

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -7,14 +7,18 @@ import {
   buildFeedbackPayload,
   buildTelemetryIdempotencyKey,
   canDeliverRunFeedback,
+  canDeliverRunTelemetry,
   feedbackIngestionRevision,
   buildTracePayload,
   deriveLangfuseDeliveryState,
   readAnonymousTelemetrySinkConfig,
   readLangfuseConfig,
   readTelemetrySinkConfig,
+  rememberAcceptedFinalTraceBodyId,
   reportRunCompleted,
   reportRunFeedback,
+  resetAcceptedFinalTraceBodyIdsForTests,
+  resolveFeedbackTraceId,
   scopedTelemetryBodyId,
   stableIngestionEventId,
   toVelaTelemetryEnvelope,
@@ -372,6 +376,99 @@ describe('deriveLangfuseDeliveryState', () => {
       langfuse_expected: true,
       langfuse_delivery_status: 'queued',
     });
+  });
+
+  it('marks Vela without installationId and no anonymous fallback as failed missing_sink_config', () => {
+    const velaSink: TelemetrySinkConfig = {
+      kind: 'vela',
+      apiUrl: 'https://amr-api.example.com',
+      controlKey: 'ck_test_key',
+      timeoutMs: 20_000,
+      retries: 1,
+      profile: 'prod',
+      authSource: 'env',
+      clearLoginOnAuthFailure: false,
+    };
+    expect(
+      deriveLangfuseDeliveryState(
+        { metrics: true, content: true, artifactManifest: true },
+        velaSink,
+        { installationId: null, env: {} },
+      ),
+    ).toEqual({
+      langfuse_expected: true,
+      langfuse_delivery_status: 'failed',
+      langfuse_drop_reason: 'missing_sink_config',
+    });
+    expect(canDeliverRunTelemetry(velaSink, null, {})).toBe(false);
+  });
+
+  it('keeps Vela queued when installationId is present', () => {
+    const velaSink: TelemetrySinkConfig = {
+      kind: 'vela',
+      apiUrl: 'https://amr-api.example.com',
+      controlKey: 'ck_test_key',
+      timeoutMs: 20_000,
+      retries: 1,
+      profile: 'prod',
+      authSource: 'env',
+      clearLoginOnAuthFailure: false,
+    };
+    expect(
+      deriveLangfuseDeliveryState(
+        { metrics: true, content: true, artifactManifest: true },
+        velaSink,
+        { installationId: 'install-1', env: {} },
+      ),
+    ).toEqual({
+      langfuse_expected: true,
+      langfuse_delivery_status: 'queued',
+    });
+  });
+});
+
+describe('resolveFeedbackTraceId', () => {
+  afterEach(() => {
+    resetAcceptedFinalTraceBodyIdsForTests();
+  });
+
+  it('defaults to the canonical runId', () => {
+    expect(resolveFeedbackTraceId({ runId: 'run-a' })).toBe('run-a');
+  });
+
+  it('derives the terminal_fallback body id for failed/canceled non-finalized runs', () => {
+    expect(
+      resolveFeedbackTraceId({
+        runId: 'run-failed',
+        runStatus: 'failed',
+        telemetryFinalized: false,
+      }),
+    ).toBe(scopedTelemetryBodyId('run-failed', 'final', 'terminal_fallback'));
+    expect(
+      resolveFeedbackTraceId({
+        runId: 'run-canceled',
+        runStatus: 'canceled',
+      }),
+    ).toBe('run-canceled:tf');
+  });
+
+  it('keeps the canonical id when the message was telemetry-finalized', () => {
+    expect(
+      resolveFeedbackTraceId({
+        runId: 'run-finalized',
+        runStatus: 'failed',
+        telemetryFinalized: true,
+      }),
+    ).toBe('run-finalized');
+  });
+
+  it('prefers the accepted final_message body id over a prior terminal_fallback memory', () => {
+    rememberAcceptedFinalTraceBodyId('run-mem', 'run-mem:tf', 'terminal_fallback');
+    rememberAcceptedFinalTraceBodyId('run-mem', 'run-mem', 'final_message');
+    expect(resolveFeedbackTraceId({ runId: 'run-mem' })).toBe('run-mem');
+    // Late fallback must not demote the canonical anchor.
+    rememberAcceptedFinalTraceBodyId('run-mem', 'run-mem:tf', 'terminal_fallback');
+    expect(resolveFeedbackTraceId({ runId: 'run-mem' })).toBe('run-mem');
   });
 });
 
@@ -3068,6 +3165,10 @@ function makeFeedbackCtx(
 }
 
 describe('buildFeedbackPayload', () => {
+  afterEach(() => {
+    resetAcceptedFinalTraceBodyIdsForTests();
+  });
+
   it('emits a numeric user_rating score plus per-reason categorical scores', () => {
     const batch = buildFeedbackPayload(
       makeFeedbackCtx({
@@ -3098,6 +3199,35 @@ describe('buildFeedbackPayload', () => {
     }
     expect(batch[1]!.body.value).toBe('missed_request');
     expect(batch[2]!.body.value).toBe('weak_visual');
+  });
+
+  it('attaches scores to the terminal_fallback body id for fallback-only runs', () => {
+    const batch = buildFeedbackPayload(
+      makeFeedbackCtx({
+        runId: 'run-fallback-only',
+        runStatus: 'failed',
+        telemetryFinalized: false,
+      }),
+    ) as Array<Record<string, any>>;
+    const expectedTraceId = scopedTelemetryBodyId(
+      'run-fallback-only',
+      'final',
+      'terminal_fallback',
+    );
+    expect(batch[0]!.body.traceId).toBe(expectedTraceId);
+    expect(batch[0]!.body.id).toBe(`${expectedTraceId}-rating`);
+  });
+
+  it('uses the remembered accepted body id when present', () => {
+    rememberAcceptedFinalTraceBodyId(
+      'run-remembered',
+      'run-remembered:tf',
+      'terminal_fallback',
+    );
+    const batch = buildFeedbackPayload(
+      makeFeedbackCtx({ runId: 'run-remembered' }),
+    ) as Array<Record<string, any>>;
+    expect(batch[0]!.body.traceId).toBe('run-remembered:tf');
   });
 
   it('does not emit reason scores when no codes were submitted', () => {

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   buildFeedbackPayload,
   buildTelemetryIdempotencyKey,
+  canDeliverRunFeedback,
   feedbackIngestionRevision,
   buildTracePayload,
   deriveLangfuseDeliveryState,
@@ -269,6 +270,51 @@ describe('readTelemetrySinkConfig', () => {
       OPEN_DESIGN_TELEMETRY_RELAY_URL: 'https://telemetry.open-design.ai/api/langfuse',
     });
     expect(cfg).toMatchObject({ kind: 'relay' });
+  });
+});
+
+describe('canDeliverRunFeedback', () => {
+  const velaSink: TelemetrySinkConfig = {
+    kind: 'vela',
+    apiUrl: 'https://amr-api.example.com',
+    controlKey: 'ck_test_key',
+    timeoutMs: 20_000,
+    retries: 1,
+    profile: 'prod',
+    authSource: 'env',
+    clearLoginOnAuthFailure: false,
+  };
+  const relaySink: TelemetrySinkConfig = {
+    kind: 'relay',
+    relayUrl: 'https://telemetry.open-design.ai/api/langfuse',
+    timeoutMs: 20_000,
+    retries: 1,
+  };
+
+  it('rejects a null sink', () => {
+    expect(canDeliverRunFeedback(null, 'install-1')).toBe(false);
+  });
+
+  it('accepts anonymous sinks without an installation id', () => {
+    expect(canDeliverRunFeedback(relaySink, null)).toBe(true);
+    expect(canDeliverRunFeedback(relaySink, undefined)).toBe(true);
+  });
+
+  it('accepts Vela when installationId is present', () => {
+    expect(canDeliverRunFeedback(velaSink, 'install-1', {})).toBe(true);
+  });
+
+  it('rejects Vela without installationId when no anonymous sink exists', () => {
+    expect(canDeliverRunFeedback(velaSink, null, {})).toBe(false);
+    expect(canDeliverRunFeedback(velaSink, '   ', {})).toBe(false);
+  });
+
+  it('accepts Vela without installationId when anonymous fallback exists', () => {
+    expect(
+      canDeliverRunFeedback(velaSink, null, {
+        OPEN_DESIGN_TELEMETRY_RELAY_URL: 'https://telemetry.open-design.ai/api/langfuse',
+      }),
+    ).toBe(true);
   });
 });
 

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -15,6 +15,7 @@ import {
   readTelemetrySinkConfig,
   reportRunCompleted,
   reportRunFeedback,
+  scopedTelemetryBodyId,
   stableIngestionEventId,
   toVelaTelemetryEnvelope,
   type FeedbackReportContext,
@@ -1734,7 +1735,7 @@ describe('buildTracePayload', () => {
     expect(finalBatch[0]!.body.input).toBe('Make a landing page for a coffee shop.');
   });
 
-  it('uses distinct stable ids for terminal_fallback vs final_message late finalization', () => {
+  it('uses distinct body and event ids for terminal_fallback vs final_message', () => {
     const ctx = makeCtx({
       prefs: { metrics: true, content: true, artifactManifest: false },
     });
@@ -1742,24 +1743,38 @@ describe('buildTracePayload', () => {
       ctx,
       'final',
       'terminal_fallback',
-    ) as Array<{ id: string; body: Record<string, any> }>;
+    ) as Array<{ id: string; type: string; body: Record<string, any> }>;
     const finalizedBatch = buildTracePayload(
       ctx,
       'final',
       'final_message',
-    ) as Array<{ id: string; body: Record<string, any> }>;
+    ) as Array<{ id: string; type: string; body: Record<string, any> }>;
     const fallbackRetry = buildTracePayload(
       ctx,
       'final',
       'terminal_fallback',
-    ) as Array<{ id: string }>;
+    ) as Array<{ id: string; body: { id: string } }>;
 
-    // Body ids stay run-scoped so Langfuse can overwrite the same observations.
-    expect(fallbackBatch[0]!.body.id).toBe(finalizedBatch[0]!.body.id);
-    // Ingestion event ids must differ so Vela does not dedupe the late final.
-    expect(fallbackBatch[0]!.id).toBe(
-      stableIngestionEventId(fallbackBatch[0]!.body.id, 'final', 'terminal_fallback'),
+    // Body ids must differ so a late fallback cannot overwrite the canonical
+    // finalized Langfuse entities for the same run.
+    expect(fallbackBatch[0]!.body.id).toBe(
+      scopedTelemetryBodyId(String(finalizedBatch[0]!.body.id), 'final', 'terminal_fallback'),
     );
+    expect(fallbackBatch[0]!.body.id).toBe(`${finalizedBatch[0]!.body.id}:tf`);
+    expect(fallbackBatch[0]!.body.id).not.toBe(finalizedBatch[0]!.body.id);
+    // Correlation metadata still points at the original run id.
+    expect(fallbackBatch[0]!.body.metadata.langfuse_trace_id).toBe(ctx.run.runId);
+    expect(finalizedBatch[0]!.body.metadata.langfuse_trace_id).toBe(ctx.run.runId);
+
+    for (const event of fallbackBatch) {
+      expect(String(event.body.id)).toMatch(/:tf$/);
+      if ('traceId' in event.body) {
+        expect(event.body.traceId).toBe(fallbackBatch[0]!.body.id);
+      }
+      expect(event.id).toBe(
+        stableIngestionEventId(event.body.id, 'final', 'terminal_fallback'),
+      );
+    }
     expect(fallbackBatch[0]!.id).toBe(`${finalizedBatch[0]!.id}:tf`);
     expect(fallbackBatch.map((event) => event.id)).not.toEqual(
       finalizedBatch.map((event) => event.id),
@@ -1767,6 +1782,9 @@ describe('buildTracePayload', () => {
     // True transport retries of the same logical delivery stay stable.
     expect(fallbackRetry.map((event) => event.id)).toEqual(
       fallbackBatch.map((event) => event.id),
+    );
+    expect(fallbackRetry.map((event) => event.body.id)).toEqual(
+      fallbackBatch.map((event) => event.body.id),
     );
     expect(fallbackBatch[0]!.body.metadata.telemetry_report_trigger).toBe(
       'terminal_fallback',
@@ -2249,7 +2267,7 @@ describe('reportRunCompleted', () => {
     expect(key1['Idempotency-Key']).toBe(key2['Idempotency-Key']);
   });
 
-  it('uses distinct Vela event ids and idempotency keys for terminal_fallback vs final_message', async () => {
+  it('uses distinct Vela body ids, event ids, and idempotency keys for terminal_fallback vs final_message', async () => {
     const velaConfig = velaSink();
     const ctx = makeCtx({
       prefs: { metrics: true, content: true, artifactManifest: false },
@@ -2300,8 +2318,80 @@ describe('reportRunCompleted', () => {
     expect(fallbackBody.events[0].id).toMatch(/:tf$/);
     expect(finalizedBody.events[0].id).not.toMatch(/:tf$/);
     expect(fallbackBody.events[0].id).not.toBe(finalizedBody.events[0].id);
-    // Observation body ids remain stable for Langfuse overwrite semantics.
-    expect(fallbackBody.events[0].data.id).toBe(finalizedBody.events[0].data.id);
+    // Distinct Langfuse body ids so out-of-order fallback cannot clobber final.
+    expect(fallbackBody.events[0].data.id).toBe(`${finalizedBody.events[0].data.id}:tf`);
+    expect(fallbackBody.events[0].data.id).not.toBe(finalizedBody.events[0].data.id);
+  });
+
+  it('keeps finalized Langfuse body ids winning when fallback transport finishes later', async () => {
+    const ctx = makeCtx({
+      prefs: { metrics: true, content: true, artifactManifest: false },
+    });
+    let releaseFallback!: () => void;
+    const fallbackGate = new Promise<void>((resolve) => {
+      releaseFallback = resolve;
+    });
+    const posted: Array<{ reportTrigger: 'terminal_fallback' | 'final_message'; body: any }> =
+      [];
+
+    const fetchSpy = vi.fn(async (_url: string, init: RequestInit) => {
+      const payload = JSON.parse(String(init.body));
+      const firstBodyId = String(payload.batch?.[0]?.body?.id ?? '');
+      const isFallback = firstBodyId.endsWith(':tf');
+      if (isFallback) {
+        await fallbackGate;
+      }
+      posted.push({
+        reportTrigger: isFallback ? 'terminal_fallback' : 'final_message',
+        body: payload,
+      });
+      return new Response(JSON.stringify({ successes: [], errors: [] }), {
+        status: 200,
+      });
+    });
+
+    const fallbackPromise = reportRunCompleted(ctx, {
+      config: TEST_CONFIG,
+      fetchImpl: fetchSpy as any,
+      deliveryPurpose: 'final',
+      reportTrigger: 'terminal_fallback',
+    });
+    // Let the fallback request reach its delayed transport gate.
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+
+    const finalizedResult = await reportRunCompleted(ctx, {
+      config: TEST_CONFIG,
+      fetchImpl: fetchSpy as any,
+      deliveryPurpose: 'final',
+      reportTrigger: 'final_message',
+    });
+    expect(finalizedResult.langfuse_delivery_status).toBe('accepted');
+    // Finalized payload has already been delivered while fallback is still gated.
+    expect(posted).toHaveLength(1);
+    expect(posted[0]!.reportTrigger).toBe('final_message');
+    expect(posted[0]!.body.batch[0].body.id).toBe(ctx.run.runId);
+    expect(posted[0]!.body.batch[0].body.output).toBe(
+      'Here is a landing page draft …',
+    );
+
+    releaseFallback();
+    const fallbackResult = await fallbackPromise;
+    expect(fallbackResult.langfuse_delivery_status).toBe('accepted');
+    expect(posted).toHaveLength(2);
+    expect(posted[1]!.reportTrigger).toBe('terminal_fallback');
+    // Late fallback writes a separate entity namespace and cannot replace the
+    // canonical run-scoped observations that final_message already sent.
+    expect(posted[1]!.body.batch[0].body.id).toBe(`${ctx.run.runId}:tf`);
+    expect(posted[1]!.body.batch[0].body.id).not.toBe(
+      posted[0]!.body.batch[0].body.id,
+    );
+    // Canonical finalized record still holds the completed payload.
+    expect(posted[0]!.body.batch[0].body.id).toBe(ctx.run.runId);
+    expect(posted[0]!.body.batch[0].body.output).toBe(
+      'Here is a landing page draft …',
+    );
   });
 
   it('does not anonymous-fallback on Vela 429/5xx or network errors', async () => {

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -26,6 +26,7 @@ import {
   resetPendingRunFeedbackForTests,
   resolveFeedbackTraceId,
   scopedTelemetryBodyId,
+  setLiveTelemetryPrefsReaderForTests,
   shouldDeferRunFeedback,
   stableIngestionEventId,
   TERMINAL_FALLBACK_LATE_FINAL_FEEDBACK_MS,
@@ -4407,6 +4408,61 @@ describe('reportRunFeedback', () => {
         if (value === undefined) delete process.env[key];
         else process.env[key] = value;
       }
+    }
+  });
+
+  it('drops deferred feedback when live telemetry consent is revoked before flush', async () => {
+    // Queued while metrics+content were on; user opts out before terminal_fallback
+    // accepts. Flush must re-check live prefs and drop without shipping the
+    // custom reason (stale submit-time prefs alone would still send).
+    resetAcceptedFinalTraceBodyIdsForTests();
+    resetPendingRunFeedbackForTests();
+    const runId = 'run-deferred-consent-revoked';
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 }),
+    );
+
+    try {
+      setLiveTelemetryPrefsReaderForTests(() => ({
+        metrics: true,
+        content: true,
+      }));
+      markRunAwaitingFinalAcceptance(runId);
+      await reportRunFeedback(
+        makeFeedbackCtx({
+          runId,
+          runStatus: 'failed',
+          telemetryFinalized: false,
+          rating: 'negative',
+          reasonCodes: [],
+          hasCustomReason: true,
+          customReason: 'secret free-text reason',
+        }),
+        { config: TEST_CONFIG, fetchImpl: fetchSpy as any },
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(hasPendingRunFeedbackForTests(runId)).toBe(true);
+
+      // Consent revoked during the terminal-fallback delay window.
+      setLiveTelemetryPrefsReaderForTests(() => ({
+        metrics: false,
+        content: false,
+      }));
+
+      rememberAcceptedFinalTraceBodyId(
+        runId,
+        scopedTelemetryBodyId(runId, 'final', 'terminal_fallback'),
+        'terminal_fallback',
+        'langfuse',
+      );
+
+      // Allow any async flush attempt to settle; network must stay silent.
+      await vi.waitFor(() => {
+        expect(hasPendingRunFeedbackForTests(runId)).toBe(false);
+      });
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      resetPendingRunFeedbackForTests();
     }
   });
 });

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -16,6 +16,7 @@ import {
   readLegacyAnonymousAcceptedSinkConfig,
   readTelemetrySinkConfig,
   readTelemetrySinkConfigForChannel,
+  markRunAwaitingFinalAcceptance,
   rememberAcceptedFinalTraceBodyId,
   reportRunCompleted,
   reportRunFeedback,
@@ -3831,9 +3832,11 @@ describe('reportRunFeedback', () => {
 
   it('defers feedback when telemetryFinalized without an accepted anchor yet', () => {
     // Live finalization race: message row is finalized before reportRunCompleted
-    // persists acceptedTraceBodyId / acceptedDeliveryChannel.
+    // persists acceptedTraceBodyId / acceptedDeliveryChannel — only while this
+    // process still has a final-purpose delivery in flight.
     resetAcceptedFinalTraceBodyIdsForTests();
     resetPendingRunFeedbackForTests();
+    markRunAwaitingFinalAcceptance('run-finalized-no-anchor');
     expect(
       shouldDeferRunFeedback({
         runId: 'run-finalized-no-anchor',
@@ -3847,6 +3850,14 @@ describe('reportRunFeedback', () => {
         runStatus: 'succeeded',
         telemetryFinalized: true,
         acceptedTraceBodyId: 'run-finalized-with-body',
+      }),
+    ).toBe(false);
+    // Cold finalized/no-anchor (no in-flight completer) must not queue forever.
+    expect(
+      shouldDeferRunFeedback({
+        runId: 'run-cold-finalized-no-anchor',
+        runStatus: 'succeeded',
+        telemetryFinalized: true,
       }),
     ).toBe(false);
     // Unscoped feedback (no status / finalized signal) still ships immediately.

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -3689,4 +3689,95 @@ describe('reportRunFeedback', () => {
     expect(feedbackBody.batch[0].body.id).toBe(`${expectedTraceId}-rating`);
     expect(feedbackBody.batch[0].body.traceId).not.toBe(runId);
   });
+
+  it('replays deferred feedback onto final_message after terminal_fallback was accepted first', async () => {
+    // feedback during delay → terminal_fallback accepted → final_message accepted.
+    // The score must re-attach to the canonical body once final_message wins;
+    // flushing (and deleting) only on the first acceptance would leave it on :tf.
+    resetAcceptedFinalTraceBodyIdsForTests();
+    resetPendingRunFeedbackForTests();
+    const runId = 'run-feedback-tf-then-final';
+    const fallbackTraceId = scopedTelemetryBodyId(runId, 'final', 'terminal_fallback');
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 }),
+    );
+
+    expect(
+      shouldDeferRunFeedback({
+        runId,
+        runStatus: 'failed',
+        telemetryFinalized: false,
+      }),
+    ).toBe(true);
+    await reportRunFeedback(
+      makeFeedbackCtx({
+        runId,
+        runStatus: 'failed',
+        telemetryFinalized: false,
+        reasonCodes: [],
+      }),
+      { config: TEST_CONFIG, fetchImpl: fetchSpy as any },
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    const fallbackCompleted = await reportRunCompleted(
+      makeCtx({
+        prefs: { metrics: true, content: true, artifactManifest: false },
+        run: {
+          runId,
+          status: 'failed',
+          startedAt: 1_700_000_000_000,
+          endedAt: 1_700_000_001_000,
+        },
+      }),
+      {
+        config: TEST_CONFIG,
+        fetchImpl: fetchSpy as any,
+        reportTrigger: 'terminal_fallback',
+      },
+    );
+    expect(fallbackCompleted).toEqual({
+      langfuse_expected: true,
+      langfuse_delivery_status: 'accepted',
+    });
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+    const afterFallbackScore = JSON.parse(
+      fetchSpy.mock.calls[1]![1].body as string,
+    );
+    expect(afterFallbackScore.batch[0].body.traceId).toBe(fallbackTraceId);
+
+    const finalCompleted = await reportRunCompleted(
+      makeCtx({
+        prefs: { metrics: true, content: true, artifactManifest: false },
+        run: {
+          runId,
+          status: 'failed',
+          startedAt: 1_700_000_000_000,
+          endedAt: 1_700_000_002_000,
+        },
+      }),
+      {
+        config: TEST_CONFIG,
+        fetchImpl: fetchSpy as any,
+        reportTrigger: 'final_message',
+      },
+    );
+    expect(finalCompleted).toEqual({
+      langfuse_expected: true,
+      langfuse_delivery_status: 'accepted',
+    });
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledTimes(4);
+    });
+
+    const finalScoreBody = JSON.parse(fetchSpy.mock.calls[3]![1].body as string);
+    expect(finalScoreBody.batch).toHaveLength(1);
+    expect(finalScoreBody.batch[0].type).toBe('score-create');
+    expect(finalScoreBody.batch[0].body.traceId).toBe(runId);
+    expect(finalScoreBody.batch[0].body.id).toBe(`${runId}-rating`);
+    expect(finalScoreBody.batch[0].body.traceId).not.toBe(fallbackTraceId);
+    expect(resolveFeedbackTraceId({ runId })).toBe(runId);
+  });
 });

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -4081,7 +4081,8 @@ describe('reportRunFeedback', () => {
         '/api/v1/open-design/telemetry',
       );
       const auth = String(
-        (fetchSpy.mock.calls[0]![1] as RequestInit).headers?.Authorization ?? '',
+        ((fetchSpy.mock.calls[0]![1] as RequestInit).headers as Record<string, string>)
+          ?.Authorization ?? '',
       );
       expect(auth).not.toContain('ck_stale_profile_a');
       const body = JSON.parse(
@@ -4505,9 +4506,11 @@ describe('reportRunFeedback', () => {
         '/api/v1/open-design/telemetry',
       );
       // Live env key B — not the stale submit-time key A.
-      expect(String(fetchSpy.mock.calls[0]![1].headers?.Authorization ?? '')).toBe(
-        'Bearer ck_accepted_after_switch',
-      );
+      expect(
+        String(
+          (fetchSpy.mock.calls[0]![1].headers as Record<string, string>)?.Authorization ?? '',
+        ),
+      ).toBe('Bearer ck_accepted_after_switch');
       const envelope = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
       expect(envelope.version).toBe(1);
       expect(envelope.installationId).toBe('install-uuid-1');
@@ -4840,9 +4843,11 @@ describe('reportRunFeedback', () => {
           }),
         ]),
       );
-      expect(String(fetchSpy.mock.calls[0]![1].headers?.Authorization ?? '')).toBe(
-        'Bearer ck_new_after_switch',
-      );
+      expect(
+        String(
+          (fetchSpy.mock.calls[0]![1].headers as Record<string, string>)?.Authorization ?? '',
+        ),
+      ).toBe('Bearer ck_new_after_switch');
     } finally {
       for (const [key, value] of Object.entries(previous)) {
         if (value === undefined) delete process.env[key];

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -326,6 +326,25 @@ describe('canDeliverRunFeedback', () => {
       }),
     ).toBe(true);
   });
+
+  it('rejects anonymous fallback when the accepted channel is Vela', () => {
+    expect(
+      canDeliverRunFeedback(
+        relaySink,
+        'install-1',
+        {},
+        { requireChannel: 'vela' },
+      ),
+    ).toBe(false);
+    expect(
+      canDeliverRunFeedback(velaSink, null, {
+        OPEN_DESIGN_TELEMETRY_RELAY_URL: 'https://telemetry.open-design.ai/api/langfuse',
+      }, { requireChannel: 'vela' }),
+    ).toBe(false);
+    expect(
+      canDeliverRunFeedback(velaSink, 'install-1', {}, { requireChannel: 'vela' }),
+    ).toBe(true);
+  });
 });
 
 describe('deriveLangfuseDeliveryState', () => {
@@ -2306,6 +2325,7 @@ describe('reportRunCompleted', () => {
     expect(result).toEqual({
       langfuse_expected: true,
       langfuse_delivery_status: 'accepted',
+      langfuse_delivery_channel: 'langfuse',
     });
   });
 
@@ -2346,6 +2366,7 @@ describe('reportRunCompleted', () => {
     expect(result).toEqual({
       langfuse_expected: true,
       langfuse_delivery_status: 'accepted',
+      langfuse_delivery_channel: 'langfuse',
     });
   });
 
@@ -2416,6 +2437,7 @@ describe('reportRunCompleted', () => {
     expect(result).toEqual({
       langfuse_expected: true,
       langfuse_delivery_status: 'accepted',
+      langfuse_delivery_channel: 'relay',
     });
   });
 
@@ -2557,6 +2579,7 @@ describe('reportRunCompleted', () => {
     expect(result).toEqual({
       langfuse_expected: true,
       langfuse_delivery_status: 'accepted',
+      langfuse_delivery_channel: 'vela',
     });
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     const [url, init] = fetchSpy.mock.calls[0]!;
@@ -2857,6 +2880,8 @@ describe('reportRunCompleted', () => {
       expect(result).toEqual({
         langfuse_expected: true,
         langfuse_delivery_status: 'accepted',
+        // Vela auth failure fell back to anonymous relay.
+        langfuse_delivery_channel: 'relay',
       });
       expect(fetchSpy).toHaveBeenCalledTimes(2);
       expect(String(fetchSpy.mock.calls[0]![0])).toContain('/api/v1/open-design/telemetry');
@@ -2995,6 +3020,8 @@ describe('reportRunCompleted', () => {
           expect(result).toEqual({
             langfuse_expected: true,
             langfuse_delivery_status: 'accepted',
+            // Vela auth failure fell back to anonymous relay.
+            langfuse_delivery_channel: 'relay',
           });
           expect(fetchSpy).toHaveBeenCalledTimes(2);
           expect(String(fetchSpy.mock.calls[0]![0])).toContain(
@@ -3286,6 +3313,7 @@ describe('reportRunCompleted', () => {
     expect(result).toEqual({
       langfuse_expected: true,
       langfuse_delivery_status: 'accepted',
+      langfuse_delivery_channel: 'langfuse',
     });
   });
 
@@ -3376,6 +3404,7 @@ describe('reportRunCompleted', () => {
     expect(result).toEqual({
       langfuse_expected: true,
       langfuse_delivery_status: 'accepted',
+      langfuse_delivery_channel: 'langfuse',
     });
   });
 });
@@ -3568,6 +3597,47 @@ describe('reportRunFeedback', () => {
     expect(body.batch[0].body.value).toBe(1);
   });
 
+  it('does not post feedback to anonymous sinks when the accepted channel is Vela', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 }),
+    );
+    await reportRunFeedback(
+      makeFeedbackCtx({
+        runId: 'run-vela-scoped',
+        acceptedDeliveryChannel: 'vela',
+        reasonCodes: [],
+      }),
+      { config: TEST_CONFIG, fetchImpl: fetchSpy as any },
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('posts feedback through Vela when the accepted channel is Vela', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
+    const velaConfig: TelemetrySinkConfig = {
+      kind: 'vela',
+      apiUrl: 'https://amr-api.example.com',
+      controlKey: 'ck_test_key',
+      timeoutMs: 20_000,
+      retries: 0,
+      profile: 'prod',
+      authSource: 'env',
+      clearLoginOnAuthFailure: false,
+    };
+    await reportRunFeedback(
+      makeFeedbackCtx({
+        runId: 'run-vela-scoped',
+        acceptedDeliveryChannel: 'vela',
+        reasonCodes: [],
+      }),
+      { config: velaConfig, fetchImpl: fetchSpy as any },
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+      '/api/v1/open-design/telemetry',
+    );
+  });
+
   it('attaches feedback to the terminal_fallback :tf body after a fallback-only completion', async () => {
     resetAcceptedFinalTraceBodyIdsForTests();
     resetPendingRunFeedbackForTests();
@@ -3597,6 +3667,7 @@ describe('reportRunFeedback', () => {
     expect(completed).toEqual({
       langfuse_expected: true,
       langfuse_delivery_status: 'accepted',
+      langfuse_delivery_channel: 'langfuse',
     });
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     const completionBody = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
@@ -3671,6 +3742,7 @@ describe('reportRunFeedback', () => {
     expect(completed).toEqual({
       langfuse_expected: true,
       langfuse_delivery_status: 'accepted',
+      langfuse_delivery_channel: 'langfuse',
     });
 
     await vi.waitFor(() => {
@@ -3739,6 +3811,7 @@ describe('reportRunFeedback', () => {
     expect(fallbackCompleted).toEqual({
       langfuse_expected: true,
       langfuse_delivery_status: 'accepted',
+      langfuse_delivery_channel: 'langfuse',
     });
     await vi.waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledTimes(2);
@@ -3767,6 +3840,7 @@ describe('reportRunFeedback', () => {
     expect(finalCompleted).toEqual({
       langfuse_expected: true,
       langfuse_delivery_status: 'accepted',
+      langfuse_delivery_channel: 'langfuse',
     });
     await vi.waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledTimes(4);

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -27,6 +27,7 @@ import {
   resetPendingRunFeedbackForTests,
   resolveFeedbackTraceId,
   scopedTelemetryBodyId,
+  setLiveDeferredFeedbackOwnerCheckForTests,
   setLiveTelemetryPrefsReaderForTests,
   shouldDeferRunFeedback,
   stableIngestionEventId,
@@ -4588,6 +4589,130 @@ describe('reportRunFeedback', () => {
       });
       expect(fetchSpy).not.toHaveBeenCalled();
     } finally {
+      resetPendingRunFeedbackForTests();
+    }
+  });
+
+  it('drops deferred feedback when conversation owner is deleted before flush', async () => {
+    // Queued during terminal_fallback delay; user deletes the conversation
+    // before the delayed report accepts. rememberAcceptedFinalTraceBodyId
+    // flushes before setRunTelemetryAcceptedAnchor's DB owner check, so the
+    // flush path must re-check live ownership and drop custom reasons.
+    resetAcceptedFinalTraceBodyIdsForTests();
+    resetPendingRunFeedbackForTests();
+    const runId = 'run-deferred-owner-deleted';
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 }),
+    );
+    let ownerLive = true;
+
+    try {
+      setLiveTelemetryPrefsReaderForTests(() => ({
+        metrics: true,
+        content: true,
+      }));
+      setLiveDeferredFeedbackOwnerCheckForTests(() => ownerLive);
+      markRunAwaitingFinalAcceptance(runId);
+      await reportRunFeedback(
+        makeFeedbackCtx({
+          runId,
+          runStatus: 'failed',
+          telemetryFinalized: false,
+          rating: 'negative',
+          reasonCodes: [],
+          hasCustomReason: true,
+          customReason: 'secret free-text for deleted conversation',
+          metadata: {
+            conversationId: 'conv-deleted-mid-window',
+            assistantMessageId: 'assistant-deleted-mid-window',
+          },
+        }),
+        { config: TEST_CONFIG, fetchImpl: fetchSpy as any },
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(hasPendingRunFeedbackForTests(runId)).toBe(true);
+
+      // Owner deleted during the terminal-fallback delay window.
+      ownerLive = false;
+
+      rememberAcceptedFinalTraceBodyId(
+        runId,
+        scopedTelemetryBodyId(runId, 'final', 'terminal_fallback'),
+        'terminal_fallback',
+        'langfuse',
+      );
+
+      await vi.waitFor(() => {
+        expect(hasPendingRunFeedbackForTests(runId)).toBe(false);
+      });
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      resetPendingRunFeedbackForTests();
+    }
+  });
+
+  it('drops deferred feedback on canonical fallback when owner is deleted before last attempt clears', async () => {
+    // All in-flight final-purpose attempts fail after conversation delete.
+    // clearRunAwaitingFinalAcceptance must not ship the queued custom reason
+    // onto the canonical body when the owner no longer exists.
+    resetAcceptedFinalTraceBodyIdsForTests();
+    resetPendingRunFeedbackForTests();
+    setLiveTelemetryPrefsReaderForTests(() => ({
+      metrics: true,
+      content: true,
+    }));
+    const runId = 'run-canonical-owner-deleted';
+    const previous = {
+      LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
+      LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
+      LANGFUSE_BASE_URL: process.env.LANGFUSE_BASE_URL,
+      OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
+      VELA_CONTROL_KEY: process.env.VELA_CONTROL_KEY,
+      VELA_API_URL: process.env.VELA_API_URL,
+    };
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk';
+    process.env.LANGFUSE_SECRET_KEY = 'sk';
+    process.env.LANGFUSE_BASE_URL = 'https://us.cloud.langfuse.com';
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    delete process.env.VELA_CONTROL_KEY;
+    delete process.env.VELA_API_URL;
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 }),
+    );
+    let ownerLive = true;
+
+    try {
+      setLiveDeferredFeedbackOwnerCheckForTests(() => ownerLive);
+      const token = markRunAwaitingFinalAcceptance(runId);
+      await reportRunFeedback(
+        makeFeedbackCtx({
+          runId,
+          runStatus: 'failed',
+          telemetryFinalized: false,
+          rating: 'negative',
+          reasonCodes: [],
+          hasCustomReason: true,
+          customReason: 'canonical flush must not leak after delete',
+          metadata: { conversationId: 'conv-gone' },
+        }),
+        { config: TEST_CONFIG, fetchImpl: fetchSpy as any },
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(hasPendingRunFeedbackForTests(runId)).toBe(true);
+
+      ownerLive = false;
+      clearRunAwaitingFinalAcceptance(runId, token);
+
+      // Queue entry is consumed; network must stay silent.
+      expect(hasPendingRunFeedbackForTests(runId)).toBe(false);
+      // Give any accidental async send a chance to fire.
+      await Promise.resolve();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
       resetPendingRunFeedbackForTests();
     }
   });

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -1842,10 +1842,28 @@ describe('buildTracePayload', () => {
       },
       diagnostics: { stage: 'agent_stream', raw: 'turn content' },
     };
+    const agentEvents = [
+      {
+        id: 'diagnostic-plain_stream_artifacts_persist_failed-0',
+        name: 'agent-diagnostic:plain_stream_artifacts_persist_failed',
+        timestamp: 1_700_000_003_000,
+        input: { source: 'daemon-run-finalize', event_type: 'diagnostic' },
+        output: {
+          name: 'plain_stream_artifacts_persist_failed',
+          message: 'Failed to persist plain-stream artifact(s): disk full',
+        },
+        statusMessage: 'Failed to persist plain-stream artifact(s): disk full',
+        level: 'ERROR' as const,
+        metadata: {
+          diagnostic_name: 'plain_stream_artifacts_persist_failed',
+        },
+      },
+    ];
     const finalBatch = buildTracePayload(
       makeCtx({
         prefs: { metrics: true, content: true, artifactManifest: false },
         run: streamRun,
+        agentEvents,
       }),
       'final',
     ) as Array<{ id: string; body: Record<string, any> }>;
@@ -1853,6 +1871,7 @@ describe('buildTracePayload', () => {
       makeCtx({
         prefs: { metrics: true, content: true, artifactManifest: false },
         run: streamRun,
+        agentEvents,
       }),
       'object-registration',
     ) as Array<{ id: string; body: Record<string, any> }>;
@@ -1879,6 +1898,25 @@ describe('buildTracePayload', () => {
     expect(
       regBatch.find((e) => e.body?.name === 'run-error')?.body.statusMessage,
     ).toBeUndefined();
+    // Agent-event diagnostic payloads (output/statusMessage) must not leak
+    // into the anonymous registration relay either.
+    const regAgentDiagnostic = regBatch.find(
+      (e) => e.body?.name === 'agent-diagnostic:plain_stream_artifacts_persist_failed',
+    );
+    expect(regAgentDiagnostic).toBeDefined();
+    expect(regAgentDiagnostic!.body.output).toBeUndefined();
+    expect(regAgentDiagnostic!.body.statusMessage).toBeUndefined();
+    expect(regAgentDiagnostic!.body.input).toEqual({
+      source: 'daemon-run-finalize',
+      event_type: 'diagnostic',
+    });
+    const finalAgentDiagnostic = finalBatch.find(
+      (e) => e.body?.name === 'agent-diagnostic:plain_stream_artifacts_persist_failed',
+    );
+    expect(finalAgentDiagnostic!.body.output).toEqual(agentEvents[0]!.output);
+    expect(finalAgentDiagnostic!.body.statusMessage).toBe(
+      agentEvents[0]!.statusMessage,
+    );
     expect(finalBatch[0]!.body.input).toBe('Make a landing page for a coffee shop.');
     expect(finalBatch[0]!.body.metadata.error).toBe('provider failed');
     expect(finalBatch[0]!.body.metadata.stderr).toEqual(streamRun.stderr);

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -2,12 +2,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   buildFeedbackPayload,
+  buildTelemetryIdempotencyKey,
   buildTracePayload,
   deriveLangfuseDeliveryState,
+  readAnonymousTelemetrySinkConfig,
   readLangfuseConfig,
   readTelemetrySinkConfig,
   reportRunCompleted,
   reportRunFeedback,
+  stableIngestionEventId,
+  toVelaTelemetryEnvelope,
   type FeedbackReportContext,
   type LangfuseConfig,
   type ReportContext,
@@ -157,8 +161,67 @@ describe('readLangfuseConfig', () => {
 });
 
 describe('readTelemetrySinkConfig', () => {
+  it('prefers the Vela authenticated sink when a Control Key is present', () => {
+    const cfg = readTelemetrySinkConfig({
+      VELA_CONTROL_KEY: 'ck_test_key',
+      VELA_API_URL: 'https://amr-api.example.com//',
+      OPEN_DESIGN_TELEMETRY_RELAY_URL: 'https://telemetry.open-design.ai/api/langfuse',
+      LANGFUSE_PUBLIC_KEY: 'pk',
+      LANGFUSE_SECRET_KEY: 'sk',
+    });
+    expect(cfg).toEqual({
+      kind: 'vela',
+      apiUrl: 'https://amr-api.example.com',
+      controlKey: 'ck_test_key',
+      timeoutMs: 20_000,
+      retries: 1,
+      profile: 'prod',
+      authSource: 'env',
+      clearLoginOnAuthFailure: false,
+    });
+  });
+
+  it('uses app-config AMR profile/API URL when resolving the Vela sink', () => {
+    const cfg = readTelemetrySinkConfig(
+      {
+        OPEN_DESIGN_TELEMETRY_RELAY_URL: 'https://telemetry.open-design.ai/api/langfuse',
+      },
+      {
+        OPEN_DESIGN_AMR_PROFILE: 'test',
+        VELA_CONTROL_KEY: 'ck_from_app_config',
+        VELA_API_URL: 'https://amr-api-test.example.com//',
+      },
+    );
+    expect(cfg).toEqual({
+      kind: 'vela',
+      apiUrl: 'https://amr-api-test.example.com',
+      controlKey: 'ck_from_app_config',
+      timeoutMs: 20_000,
+      retries: 1,
+      profile: 'test',
+      authSource: 'env',
+      clearLoginOnAuthFailure: false,
+    });
+  });
+
+  it('can disable the Vela sink for gray rollback', () => {
+    const cfg = readTelemetrySinkConfig({
+      OPEN_DESIGN_VELA_TELEMETRY: '0',
+      VELA_CONTROL_KEY: 'ck_test_key',
+      OPEN_DESIGN_TELEMETRY_RELAY_URL: 'https://telemetry.open-design.ai/api/langfuse//',
+    });
+    expect(cfg).toEqual({
+      kind: 'relay',
+      relayUrl: 'https://telemetry.open-design.ai/api/langfuse',
+      timeoutMs: 20_000,
+      retries: 1,
+    });
+  });
+
   it('prefers the Open Design telemetry relay when configured', () => {
     const cfg = readTelemetrySinkConfig({
+      // Force anonymous path even if the developer machine has a local Control Key.
+      OPEN_DESIGN_VELA_TELEMETRY: '0',
       OPEN_DESIGN_TELEMETRY_RELAY_URL: 'https://telemetry.open-design.ai/api/langfuse//',
       LANGFUSE_PUBLIC_KEY: 'pk',
       LANGFUSE_SECRET_KEY: 'sk',
@@ -173,6 +236,7 @@ describe('readTelemetrySinkConfig', () => {
 
   it('uses relay-specific timeout and retry tuning when present', () => {
     const cfg = readTelemetrySinkConfig({
+      OPEN_DESIGN_VELA_TELEMETRY: '0',
       OPEN_DESIGN_TELEMETRY_RELAY_URL: 'https://telemetry.open-design.ai/api/langfuse',
       OPEN_DESIGN_TELEMETRY_TIMEOUT_MS: '30000',
       OPEN_DESIGN_TELEMETRY_RETRIES: '3',
@@ -188,6 +252,7 @@ describe('readTelemetrySinkConfig', () => {
 
   it('falls back to direct Langfuse config for local smoke tests', () => {
     const cfg = readTelemetrySinkConfig({
+      OPEN_DESIGN_VELA_TELEMETRY: '0',
       LANGFUSE_PUBLIC_KEY: 'pk',
       LANGFUSE_SECRET_KEY: 'sk',
     });
@@ -195,6 +260,14 @@ describe('readTelemetrySinkConfig', () => {
       kind: 'langfuse',
       baseUrl: 'https://us.cloud.langfuse.com',
     });
+  });
+
+  it('exposes an anonymous-only resolver that never returns Vela', () => {
+    const cfg = readAnonymousTelemetrySinkConfig({
+      VELA_CONTROL_KEY: 'ck_test_key',
+      OPEN_DESIGN_TELEMETRY_RELAY_URL: 'https://telemetry.open-design.ai/api/langfuse',
+    });
+    expect(cfg).toMatchObject({ kind: 'relay' });
   });
 });
 
@@ -1556,6 +1629,103 @@ describe('buildTracePayload', () => {
     const batch = buildTracePayload(makeCtx({ installationId: null }));
     expect((batch[0] as any).body.userId).toBeUndefined();
   });
+
+  it('stamps anonymous installation identity metadata without client-claimed account fields', () => {
+    const batch = buildTracePayload(
+      makeCtx({
+        installationId: 'install-uuid-1',
+        prefs: { metrics: true, content: true, artifactManifest: false },
+      }),
+    );
+    const trace = bodyOf(batch, 'trace-create');
+    expect(trace.userId).toBe('install-uuid-1');
+    expect(trace.metadata.identity_type).toBe('anonymous_installation');
+    expect(trace.metadata.installation_id).toBe('install-uuid-1');
+    expect(trace.metadata.app_user_id).toBeUndefined();
+    expect(trace.metadata.user_email).toBeUndefined();
+  });
+
+  it('uses stable ingestion event ids derived from body ids', () => {
+    const batch = buildTracePayload(
+      makeCtx({
+        prefs: { metrics: true, content: true, artifactManifest: false },
+      }),
+    ) as Array<{ id: string; body: { id: string } }>;
+    for (const event of batch) {
+      expect(event.id).toBe(stableIngestionEventId(event.body.id, 'final'));
+    }
+    const again = buildTracePayload(
+      makeCtx({
+        prefs: { metrics: true, content: true, artifactManifest: false },
+      }),
+    ) as Array<{ id: string }>;
+    expect(again.map((event) => event.id)).toEqual(batch.map((event) => event.id));
+  });
+
+  it('uses distinct stable ids and omits turn content for object-registration', () => {
+    const finalBatch = buildTracePayload(
+      makeCtx({
+        prefs: { metrics: true, content: true, artifactManifest: false },
+      }),
+      'final',
+    ) as Array<{ id: string; body: Record<string, any> }>;
+    const regBatch = buildTracePayload(
+      makeCtx({
+        prefs: { metrics: true, content: true, artifactManifest: false },
+      }),
+      'object-registration',
+    ) as Array<{ id: string; body: Record<string, any> }>;
+    expect(regBatch[0]!.id).toBe(`${finalBatch[0]!.id}:reg`);
+    expect(regBatch[0]!.body.input).toBeUndefined();
+    expect(regBatch[0]!.body.output).toBeUndefined();
+    expect(regBatch[0]!.body.metadata.telemetry_delivery_purpose).toBe(
+      'object-registration',
+    );
+    expect(finalBatch[0]!.body.input).toBe('Make a landing page for a coffee shop.');
+  });
+});
+
+describe('vela telemetry envelope helpers', () => {
+  it('builds a stable idempotency key from trace id + sorted event ids', () => {
+    const keyA = buildTelemetryIdempotencyKey(
+      [{ id: 'b' }, { id: 'a' }],
+      'run-1',
+    );
+    const keyB = buildTelemetryIdempotencyKey(
+      [{ id: 'a' }, { id: 'b' }],
+      'run-1',
+    );
+    const keyC = buildTelemetryIdempotencyKey(
+      [{ id: 'a' }, { id: 'b' }],
+      'run-2',
+    );
+    expect(keyA).toBe(keyB);
+    expect(keyA).toMatch(/^od-telemetry-[a-f0-9]{64}$/);
+    expect(keyA).not.toBe(keyC);
+  });
+
+  it('converts Langfuse batch events into the vendor-neutral Vela envelope', () => {
+    const batch = buildTracePayload(
+      makeCtx({
+        prefs: { metrics: true, content: true, artifactManifest: false },
+      }),
+    );
+    const envelope = toVelaTelemetryEnvelope(batch, 'install-uuid-1');
+    expect(envelope.version).toBe(1);
+    expect(envelope.installationId).toBe('install-uuid-1');
+    expect(envelope.events.length).toBeGreaterThan(0);
+    expect(envelope.events[0]).toMatchObject({
+      kind: 'trace',
+      data: {
+        id: 'run-1',
+        name: 'open-design-turn',
+        userId: 'install-uuid-1',
+      },
+    });
+    expect(envelope.events.some((event) => event.kind === 'generation')).toBe(true);
+    expect(JSON.stringify(envelope)).not.toContain('user_email');
+    expect(JSON.stringify(envelope)).not.toContain('app_user_id');
+  });
 });
 
 describe('reportRunCompleted', () => {
@@ -1870,6 +2040,218 @@ describe('reportRunCompleted', () => {
       langfuse_delivery_status: 'failed',
       langfuse_drop_reason: 'langfuse_5xx',
     });
+  });
+
+  function velaSink(
+    overrides: Partial<Extract<TelemetrySinkConfig, { kind: 'vela' }>> = {},
+  ): Extract<TelemetrySinkConfig, { kind: 'vela' }> {
+    return {
+      kind: 'vela',
+      apiUrl: 'https://amr-api.example.com',
+      controlKey: 'ck_test_key',
+      timeoutMs: 20_000,
+      retries: 0,
+      profile: 'prod',
+      authSource: 'env',
+      clearLoginOnAuthFailure: false,
+      ...overrides,
+    };
+  }
+
+  it('POSTs the vendor-neutral envelope to Vela with Control Key + idempotency key', async () => {
+    const velaConfig = velaSink();
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 202 }),
+    );
+    const result = await reportRunCompleted(
+      makeCtx({
+        prefs: { metrics: true, content: true, artifactManifest: false },
+      }),
+      {
+        config: velaConfig,
+        fetchImpl: fetchSpy as any,
+      },
+    );
+    expect(result).toEqual({
+      langfuse_expected: true,
+      langfuse_delivery_status: 'accepted',
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe('https://amr-api.example.com/api/v1/open-design/telemetry');
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer ck_test_key');
+    expect(headers['Idempotency-Key']).toMatch(/^od-telemetry-[a-f0-9]{64}$/);
+    const body = JSON.parse(init.body as string);
+    expect(body.version).toBe(1);
+    expect(body.installationId).toBe('install-uuid-1');
+    expect(Array.isArray(body.events)).toBe(true);
+    expect(body.events[0].kind).toBe('trace');
+    expect(body.events[0].data.metadata.identity_type).toBe('anonymous_installation');
+    expect(JSON.stringify(body)).not.toContain('user@');
+  });
+
+  it('reuses the same Vela idempotency key across retries', async () => {
+    const velaConfig = velaSink({ retries: 1 });
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('busy', { status: 503 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 202 }));
+    const result = await reportRunCompleted(
+      makeCtx({
+        prefs: { metrics: true, content: true, artifactManifest: false },
+      }),
+      {
+        config: velaConfig,
+        fetchImpl: fetchSpy as any,
+      },
+    );
+    expect(result.langfuse_delivery_status).toBe('accepted');
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const key1 = (fetchSpy.mock.calls[0]![1] as RequestInit).headers as Record<string, string>;
+    const key2 = (fetchSpy.mock.calls[1]![1] as RequestInit).headers as Record<string, string>;
+    expect(key1['Idempotency-Key']).toBe(key2['Idempotency-Key']);
+  });
+
+  it('does not anonymous-fallback on Vela 429/5xx or network errors', async () => {
+    const velaConfig = velaSink();
+    const prevRelay = process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL =
+      'https://telemetry.open-design.ai/api/langfuse';
+    try {
+      const fetchSpy = vi.fn().mockResolvedValue(new Response('nope', { status: 503 }));
+      const result = await reportRunCompleted(
+        makeCtx({
+          prefs: { metrics: true, content: true, artifactManifest: false },
+        }),
+        {
+          config: velaConfig,
+          fetchImpl: fetchSpy as any,
+        },
+      );
+      expect(result).toEqual({
+        langfuse_expected: true,
+        langfuse_delivery_status: 'failed',
+        langfuse_drop_reason: 'vela_5xx',
+      });
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(String(fetchSpy.mock.calls[0]![0])).toContain('/api/v1/open-design/telemetry');
+    } finally {
+      if (prevRelay === undefined) delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+      else process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL = prevRelay;
+    }
+  });
+
+  it('does not anonymous-fallback on Vela 400 protocol errors', async () => {
+    const velaConfig = velaSink();
+    const prevRelay = process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL =
+      'https://telemetry.open-design.ai/api/langfuse';
+    try {
+      const fetchSpy = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: 'invalid_open_design_telemetry_payload' }), {
+          status: 400,
+        }),
+      );
+      const result = await reportRunCompleted(
+        makeCtx({
+          prefs: { metrics: true, content: true, artifactManifest: false },
+        }),
+        {
+          config: velaConfig,
+          fetchImpl: fetchSpy as any,
+        },
+      );
+      expect(result).toEqual({
+        langfuse_expected: true,
+        langfuse_delivery_status: 'failed',
+        langfuse_drop_reason: 'vela_400',
+      });
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      if (prevRelay === undefined) delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+      else process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL = prevRelay;
+    }
+  });
+
+  it('falls back to anonymous relay on Vela 401/403', async () => {
+    const velaConfig = velaSink({ controlKey: 'ck_expired' });
+    const prevRelay = process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    const prevVela = process.env.OPEN_DESIGN_VELA_TELEMETRY;
+    process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL =
+      'https://telemetry.open-design.ai/api/langfuse';
+    process.env.OPEN_DESIGN_VELA_TELEMETRY = '0';
+    const velaModule = await import('../src/integrations/vela.js');
+    const forgetSpy = vi
+      .spyOn(velaModule, 'forgetVelaLogin')
+      .mockImplementation(() => undefined);
+    try {
+      const fetchSpy = vi
+        .fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify({ error: 'unauthenticated' }), { status: 401 }))
+        .mockResolvedValueOnce(new Response('{}', { status: 200 }));
+      const result = await reportRunCompleted(
+        makeCtx({
+          prefs: { metrics: true, content: true, artifactManifest: false },
+        }),
+        {
+          config: velaConfig,
+          fetchImpl: fetchSpy as any,
+        },
+      );
+      expect(result).toEqual({
+        langfuse_expected: true,
+        langfuse_delivery_status: 'accepted',
+      });
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(String(fetchSpy.mock.calls[0]![0])).toContain('/api/v1/open-design/telemetry');
+      expect(String(fetchSpy.mock.calls[1]![0])).toBe(
+        'https://telemetry.open-design.ai/api/langfuse',
+      );
+      const relayHeaders = fetchSpy.mock.calls[1]![1].headers as Record<string, string>;
+      expect(relayHeaders['X-Open-Design-Telemetry']).toBe('langfuse-ingestion-v1');
+      // Explicit sinks must not clear an unrelated local login.
+      expect(forgetSpy).not.toHaveBeenCalled();
+    } finally {
+      forgetSpy.mockRestore();
+      if (prevRelay === undefined) delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+      else process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL = prevRelay;
+      if (prevVela === undefined) delete process.env.OPEN_DESIGN_VELA_TELEMETRY;
+      else process.env.OPEN_DESIGN_VELA_TELEMETRY = prevVela;
+    }
+  });
+
+  it('forces object-registration onto the anonymous relay even when Vela is configured', async () => {
+    const prevRelay = process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL =
+      'https://telemetry.open-design.ai/api/langfuse';
+    try {
+      const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+      const result = await reportRunCompleted(
+        makeCtx({
+          prefs: { metrics: true, content: true, artifactManifest: false },
+        }),
+        {
+          config: velaSink(),
+          deliveryPurpose: 'object-registration',
+          fetchImpl: fetchSpy as any,
+        },
+      );
+      expect(result.langfuse_delivery_status).toBe('accepted');
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(String(fetchSpy.mock.calls[0]![0])).toBe(
+        'https://telemetry.open-design.ai/api/langfuse',
+      );
+      const body = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
+      expect(body.batch[0].id).toMatch(/:reg$/);
+      expect(body.batch[0].body.input).toBeUndefined();
+      expect(body.batch[0].body.metadata.telemetry_delivery_purpose).toBe(
+        'object-registration',
+      );
+    } finally {
+      if (prevRelay === undefined) delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+      else process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL = prevRelay;
+    }
   });
 
   it('classifies relay per-event 429s separately from generic 4xx', async () => {

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -1987,6 +1987,7 @@ describe('buildTracePayload', () => {
           sensitivity: 'private',
           source: 'agent_generated',
           expires_at: null,
+          approved_by: null,
         },
       ],
       attachmentManifest: [

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -1867,10 +1867,29 @@ describe('buildTracePayload', () => {
     expect(regBatch[0]!.body.metadata.stderr).toBeUndefined();
     expect(regBatch[0]!.body.metadata.stdout).toBeUndefined();
     expect(regBatch[0]!.body.metadata.diagnostics).toBeUndefined();
+    // Agent/runtime error text must also stay off the anonymous registration
+    // relay (metadata.error + statusMessage on spans / run-error event).
+    expect(regBatch[0]!.body.metadata.error).toBeUndefined();
+    expect(
+      regBatch.find((e) => e.body?.name === 'agent-run')?.body.statusMessage,
+    ).toBeUndefined();
+    expect(
+      regBatch.find((e) => e.body?.name === 'llm')?.body.statusMessage,
+    ).toBeUndefined();
+    expect(
+      regBatch.find((e) => e.body?.name === 'run-error')?.body.statusMessage,
+    ).toBeUndefined();
     expect(finalBatch[0]!.body.input).toBe('Make a landing page for a coffee shop.');
+    expect(finalBatch[0]!.body.metadata.error).toBe('provider failed');
     expect(finalBatch[0]!.body.metadata.stderr).toEqual(streamRun.stderr);
     expect(finalBatch[0]!.body.metadata.stdout).toEqual(streamRun.stdout);
     expect(finalBatch[0]!.body.metadata.diagnostics).toEqual(streamRun.diagnostics);
+    expect(
+      finalBatch.find((e) => e.body?.name === 'agent-run')?.body.statusMessage,
+    ).toBe('provider failed');
+    expect(
+      finalBatch.find((e) => e.body?.name === 'run-error')?.body.statusMessage,
+    ).toBe('provider failed');
   });
 
   it('uses distinct body and event ids for terminal_fallback vs final_message', () => {

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -18,8 +18,10 @@ import {
   reportRunCompleted,
   reportRunFeedback,
   resetAcceptedFinalTraceBodyIdsForTests,
+  resetPendingRunFeedbackForTests,
   resolveFeedbackTraceId,
   scopedTelemetryBodyId,
+  shouldDeferRunFeedback,
   stableIngestionEventId,
   toVelaTelemetryEnvelope,
   type FeedbackReportContext,
@@ -430,6 +432,7 @@ describe('deriveLangfuseDeliveryState', () => {
 describe('resolveFeedbackTraceId', () => {
   afterEach(() => {
     resetAcceptedFinalTraceBodyIdsForTests();
+    resetPendingRunFeedbackForTests();
   });
 
   it('defaults to the canonical runId', () => {
@@ -1955,6 +1958,110 @@ describe('buildTracePayload', () => {
     ).toBe('provider failed');
   });
 
+  it('keeps authority manifests on object-registration but omits artifact filename summaries', () => {
+    const artifactSlug = 'prompt-derived-landing-page.html';
+    const ctx = makeCtx({
+      prefs: { metrics: true, content: true, artifactManifest: true },
+      artifacts: [
+        { slug: artifactSlug, type: 'html', sizeBytes: 2048 },
+      ],
+      artifactManifest: [
+        {
+          artifact_id: 'art-1',
+          object_class: 'artifact',
+          type: 'html',
+          storage_ref:
+            'od://objects/workspaces/unknown/projects/proj-1/runs/run-1/artifact/art-1',
+          status: 'ok',
+          project_id: 'proj-1',
+          run_id: 'run-1',
+          workspace_id: null,
+          build_status: 'complete',
+          preview_status: 'unavailable',
+          export_status: 'available',
+          redacted: false,
+          truncated: false,
+          stored_in_open_design: true,
+          retention_policy: 'project_lifetime',
+          access_scope: 'project',
+          sensitivity: 'private',
+          source: 'agent_generated',
+          expires_at: null,
+        },
+      ],
+      attachmentManifest: [
+        {
+          attachment_id: 'att-1',
+          object_class: 'attachment',
+          storage_ref:
+            'od://objects/workspaces/unknown/projects/proj-1/runs/run-1/attachment/att-1',
+          status: 'ok',
+          project_id: 'proj-1',
+          run_id: 'run-1',
+          workspace_id: null,
+          size_bytes: 128,
+          sha256: 'sha256:abc',
+          mime_type: 'application/pdf',
+          extension: 'pdf',
+          redacted: false,
+          truncated: false,
+          stored_in_open_design: true,
+          retention_policy: 'project_lifetime',
+          access_scope: 'project',
+          sensitivity: 'private',
+          source: 'user_upload',
+          expires_at: null,
+          approved_by: null,
+        },
+      ],
+      manifestCompleteness: 'complete',
+    });
+    const regBatch = buildTracePayload(ctx, 'object-registration') as Array<{
+      type: string;
+      body: Record<string, any>;
+    }>;
+    const finalBatch = buildTracePayload(ctx, 'final') as Array<{
+      type: string;
+      body: Record<string, any>;
+    }>;
+    const regTrace = regBatch.find((e) => e.type === 'trace-create')!.body;
+    const finalTrace = finalBatch.find((e) => e.type === 'trace-create')!.body;
+
+    // Authority manifests stay on registration for object-scope upload.
+    expect(regTrace.metadata.artifact_manifest).toEqual(
+      finalTrace.metadata.artifact_manifest,
+    );
+    expect(regTrace.metadata.attachment_manifest).toEqual(
+      finalTrace.metadata.attachment_manifest,
+    );
+    expect(regTrace.metadata.manifest_completeness).toBe('complete');
+
+    // Filename/slug summaries must not leak on the anonymous registration pass.
+    expect(regTrace.metadata.artifacts).toBeUndefined();
+    expect(
+      regTrace.metadata.performance_diagnostics?.artifact_write?.artifacts,
+    ).toBeUndefined();
+    expect(
+      regTrace.metadata.performance_diagnostics?.artifact_write?.artifact_count,
+    ).toBe(1);
+    expect(
+      regBatch.find((e) => e.body?.name === 'artifact-summary'),
+    ).toBeUndefined();
+
+    // Final delivery still carries the content-bearing summaries.
+    expect(finalTrace.metadata.artifacts).toEqual([
+      { slug: artifactSlug, type: 'html', sizeBytes: 2048 },
+    ]);
+    expect(
+      finalTrace.metadata.performance_diagnostics?.artifact_write?.artifacts,
+    ).toEqual([
+      { slug: artifactSlug, type: 'html', size_bytes: 2048 },
+    ]);
+    expect(
+      finalBatch.find((e) => e.body?.name === 'artifact-summary'),
+    ).toBeDefined();
+  });
+
   it('uses distinct body and event ids for terminal_fallback vs final_message', () => {
     const ctx = makeCtx({
       prefs: { metrics: true, content: true, artifactManifest: false },
@@ -3462,6 +3569,7 @@ describe('reportRunFeedback', () => {
 
   it('attaches feedback to the terminal_fallback :tf body after a fallback-only completion', async () => {
     resetAcceptedFinalTraceBodyIdsForTests();
+    resetPendingRunFeedbackForTests();
     const runId = 'run-fallback-feedback-e2e';
     const expectedTraceId = scopedTelemetryBodyId(runId, 'final', 'terminal_fallback');
     const fetchSpy = vi.fn().mockResolvedValue(
@@ -3505,6 +3613,74 @@ describe('reportRunFeedback', () => {
       { config: TEST_CONFIG, fetchImpl: fetchSpy as any },
     );
     expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const feedbackBody = JSON.parse(fetchSpy.mock.calls[1]![1].body as string);
+    expect(feedbackBody.batch).toHaveLength(1);
+    expect(feedbackBody.batch[0].type).toBe('score-create');
+    expect(feedbackBody.batch[0].body.traceId).toBe(expectedTraceId);
+    expect(feedbackBody.batch[0].body.id).toBe(`${expectedTraceId}-rating`);
+    expect(feedbackBody.batch[0].body.traceId).not.toBe(runId);
+  });
+
+  it('defers feedback submitted before terminal_fallback acceptance onto runId:tf', async () => {
+    resetAcceptedFinalTraceBodyIdsForTests();
+    resetPendingRunFeedbackForTests();
+    const runId = 'run-feedback-before-tf';
+    const expectedTraceId = scopedTelemetryBodyId(runId, 'final', 'terminal_fallback');
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 }),
+    );
+
+    // User rates during the fallback delay: no accepted body yet.
+    expect(
+      shouldDeferRunFeedback({
+        runId,
+        runStatus: 'failed',
+        telemetryFinalized: false,
+      }),
+    ).toBe(true);
+    await reportRunFeedback(
+      makeFeedbackCtx({
+        runId,
+        runStatus: 'failed',
+        telemetryFinalized: false,
+        reasonCodes: [],
+      }),
+      { config: TEST_CONFIG, fetchImpl: fetchSpy as any },
+    );
+    // Deferred — nothing shipped onto the provisional canonical runId.
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    // Later terminal_fallback is accepted; deferred score must land on :tf.
+    const completed = await reportRunCompleted(
+      makeCtx({
+        prefs: { metrics: true, content: true, artifactManifest: false },
+        run: {
+          runId,
+          status: 'failed',
+          startedAt: 1_700_000_000_000,
+          endedAt: 1_700_000_001_000,
+        },
+      }),
+      {
+        config: TEST_CONFIG,
+        fetchImpl: fetchSpy as any,
+        reportTrigger: 'terminal_fallback',
+      },
+    );
+    expect(completed).toEqual({
+      langfuse_expected: true,
+      langfuse_delivery_status: 'accepted',
+    });
+
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+    const completionBody = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
+    const completionTrace = completionBody.batch.find(
+      (item: { type: string }) => item.type === 'trace-create',
+    );
+    expect(completionTrace?.body?.id).toBe(expectedTraceId);
+
     const feedbackBody = JSON.parse(fetchSpy.mock.calls[1]![1].body as string);
     expect(feedbackBody.batch).toHaveLength(1);
     expect(feedbackBody.batch[0].type).toBe('score-create');

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -4202,4 +4202,104 @@ describe('reportRunFeedback', () => {
       }
     }
   });
+
+  it('re-resolves a stale submit-time Vela key when deferred feedback flushes on the same channel', async () => {
+    // Queued under Control Key A; user switches AMR profile before the final
+    // body is accepted. Acceptance is still `vela` but with key B. Kind-only
+    // flush opts would keep key A, fail canDeliverRunFeedback on the accepted
+    // identity, and drop the score even though the live Vela sink matches.
+    resetAcceptedFinalTraceBodyIdsForTests();
+    resetPendingRunFeedbackForTests();
+    const runId = 'run-deferred-vela-identity-switch';
+    const previous = {
+      VELA_CONTROL_KEY: process.env.VELA_CONTROL_KEY,
+      VELA_API_URL: process.env.VELA_API_URL,
+      OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
+      LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
+      LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
+    };
+    process.env.VELA_CONTROL_KEY = 'ck_accepted_after_switch';
+    process.env.VELA_API_URL = 'https://amr-api.example.com';
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+
+    const velaAtSubmit: TelemetrySinkConfig = {
+      kind: 'vela',
+      apiUrl: 'https://amr-api.example.com',
+      controlKey: 'ck_stale_submit',
+      timeoutMs: 20_000,
+      retries: 0,
+      profile: 'prod',
+      authSource: 'env',
+      clearLoginOnAuthFailure: false,
+    };
+    const acceptingIdentity = velaSinkIdentityFingerprint(
+      'prod',
+      'ck_accepted_after_switch',
+    );
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
+
+    try {
+      expect(
+        shouldDeferRunFeedback({
+          runId,
+          runStatus: 'failed',
+          telemetryFinalized: false,
+        }),
+      ).toBe(true);
+      await reportRunFeedback(
+        makeFeedbackCtx({
+          runId,
+          runStatus: 'failed',
+          telemetryFinalized: false,
+          reasonCodes: [],
+        }),
+        { config: velaAtSubmit, fetchImpl: fetchSpy as any },
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
+
+      rememberAcceptedFinalTraceBodyId(
+        runId,
+        scopedTelemetryBodyId(runId, 'final', 'terminal_fallback'),
+        'terminal_fallback',
+        'vela',
+        acceptingIdentity,
+      );
+
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+      });
+      expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+        '/api/v1/open-design/telemetry',
+      );
+      // Live env key B — not the stale submit-time key A.
+      expect(String(fetchSpy.mock.calls[0]![1].headers?.Authorization ?? '')).toBe(
+        'Bearer ck_accepted_after_switch',
+      );
+      const envelope = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
+      expect(envelope.version).toBe(1);
+      expect(envelope.installationId).toBe('install-uuid-1');
+      expect(envelope.events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: 'score',
+            data: expect.objectContaining({
+              name: 'user_rating',
+              traceId: scopedTelemetryBodyId(
+                runId,
+                'final',
+                'terminal_fallback',
+              ),
+            }),
+          }),
+        ]),
+      );
+    } finally {
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  });
 });

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -2453,6 +2456,262 @@ describe('reportRunCompleted', () => {
       if (prevVela === undefined) delete process.env.OPEN_DESIGN_VELA_TELEMETRY;
       else process.env.OPEN_DESIGN_VELA_TELEMETRY = prevVela;
     }
+  });
+
+  /**
+   * File-backed login cleanup on Vela 401/403: only a matching profile/key
+   * may be cleared. These cases resolve the live sink via
+   * `readTelemetrySinkConfig()` against a seeded `~/.amr` profile (not an
+   * explicit env-backed override), so `clearLoginOnAuthFailure` is true.
+   */
+  async function withSeededAmrHome<T>(
+    profiles: Record<string, Record<string, unknown>>,
+    run: (helpers: {
+      configPath: string;
+      readProfiles: () => Record<string, Record<string, unknown>>;
+      writeProfiles: (next: Record<string, Record<string, unknown>>) => void;
+    }) => Promise<T>,
+  ): Promise<T> {
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+    const originalAmrProfile = process.env.OPEN_DESIGN_AMR_PROFILE;
+    const originalVelaControlKey = process.env.VELA_CONTROL_KEY;
+    const originalVelaApiUrl = process.env.VELA_API_URL;
+    const originalVelaTelemetry = process.env.OPEN_DESIGN_VELA_TELEMETRY;
+    const originalRelay = process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    const tmpHome = mkdtempSync(path.join(tmpdir(), 'od-langfuse-amr-'));
+    const configDir = path.join(tmpHome, '.amr');
+    const configPath = path.join(configDir, 'config.json');
+    mkdirSync(configDir, { recursive: true });
+    const writeProfiles = (next: Record<string, Record<string, unknown>>) => {
+      writeFileSync(
+        configPath,
+        JSON.stringify({ version: 1, profiles: next }, null, 2),
+        'utf8',
+      );
+    };
+    const readProfiles = (): Record<string, Record<string, unknown>> => {
+      const parsed = JSON.parse(readFileSync(configPath, 'utf8')) as {
+        profiles?: Record<string, Record<string, unknown>>;
+      };
+      return parsed.profiles ?? {};
+    };
+    writeProfiles(profiles);
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+    delete process.env.VELA_CONTROL_KEY;
+    delete process.env.VELA_API_URL;
+    delete process.env.OPEN_DESIGN_VELA_TELEMETRY;
+    process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL =
+      'https://telemetry.open-design.ai/api/langfuse';
+    try {
+      return await run({ configPath, readProfiles, writeProfiles });
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = originalUserProfile;
+      if (originalAmrProfile === undefined) delete process.env.OPEN_DESIGN_AMR_PROFILE;
+      else process.env.OPEN_DESIGN_AMR_PROFILE = originalAmrProfile;
+      if (originalVelaControlKey === undefined) delete process.env.VELA_CONTROL_KEY;
+      else process.env.VELA_CONTROL_KEY = originalVelaControlKey;
+      if (originalVelaApiUrl === undefined) delete process.env.VELA_API_URL;
+      else process.env.VELA_API_URL = originalVelaApiUrl;
+      if (originalVelaTelemetry === undefined) delete process.env.OPEN_DESIGN_VELA_TELEMETRY;
+      else process.env.OPEN_DESIGN_VELA_TELEMETRY = originalVelaTelemetry;
+      if (originalRelay === undefined) delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+      else process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL = originalRelay;
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }
+
+  it.each([401, 403] as const)(
+    'clears matching file-backed login and falls back anonymously on Vela %s',
+    async (status) => {
+      await withSeededAmrHome(
+        {
+          local: {
+            controlKey: 'ck_local_expired',
+            runtimeKey: 'rt_local',
+            apiUrl: 'https://amr-api.example.com',
+            user: { id: 'u-local', email: 'local@example.com' },
+          },
+          prod: {
+            controlKey: 'ck_prod_keep',
+            runtimeKey: 'rt_prod',
+            user: { id: 'u-prod', email: 'prod@example.com' },
+          },
+        },
+        async ({ readProfiles }) => {
+          process.env.OPEN_DESIGN_AMR_PROFILE = 'local';
+          const sink = readTelemetrySinkConfig(process.env);
+          expect(sink).toMatchObject({
+            kind: 'vela',
+            authSource: 'file',
+            profile: 'local',
+            controlKey: 'ck_local_expired',
+            clearLoginOnAuthFailure: true,
+          });
+
+          const fetchSpy = vi
+            .fn()
+            .mockResolvedValueOnce(
+              new Response(JSON.stringify({ error: status === 401 ? 'unauthenticated' : 'forbidden' }), {
+                status,
+              }),
+            )
+            .mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+          const result = await reportRunCompleted(
+            makeCtx({
+              prefs: { metrics: true, content: true, artifactManifest: false },
+            }),
+            {
+              // Leave config undefined so delivery re-resolves via
+              // readTelemetrySinkConfig() (file-backed path under test).
+              fetchImpl: fetchSpy as any,
+              configuredEnv: { OPEN_DESIGN_AMR_PROFILE: 'local' },
+            },
+          );
+
+          expect(result).toEqual({
+            langfuse_expected: true,
+            langfuse_delivery_status: 'accepted',
+          });
+          expect(fetchSpy).toHaveBeenCalledTimes(2);
+          expect(String(fetchSpy.mock.calls[0]![0])).toContain(
+            '/api/v1/open-design/telemetry',
+          );
+          expect(String(fetchSpy.mock.calls[1]![0])).toBe(
+            'https://telemetry.open-design.ai/api/langfuse',
+          );
+
+          const profiles = readProfiles();
+          // Matching profile/key is cleared; other profiles stay intact.
+          expect(profiles.local?.controlKey).toBeUndefined();
+          expect(profiles.local?.runtimeKey).toBeUndefined();
+          expect(profiles.local?.user).toBeUndefined();
+          expect(profiles.local?.apiUrl).toBe('https://amr-api.example.com');
+          expect(profiles.prod?.controlKey).toBe('ck_prod_keep');
+          expect(profiles.prod?.runtimeKey).toBe('rt_prod');
+        },
+      );
+    },
+  );
+
+  it('does not clear file-backed login when the stored control key no longer matches', async () => {
+    await withSeededAmrHome(
+      {
+        local: {
+          controlKey: 'ck_request_key',
+          runtimeKey: 'rt_local',
+          user: { id: 'u-local', email: 'local@example.com' },
+        },
+      },
+      async ({ readProfiles, writeProfiles }) => {
+        process.env.OPEN_DESIGN_AMR_PROFILE = 'local';
+        const sink = readTelemetrySinkConfig(process.env);
+        expect(sink).toMatchObject({
+          kind: 'vela',
+          authSource: 'file',
+          profile: 'local',
+          controlKey: 'ck_request_key',
+          clearLoginOnAuthFailure: true,
+        });
+
+        // Simulate account switch after the sink was resolved: live file key
+        // no longer matches the in-flight request key.
+        writeProfiles({
+          local: {
+            controlKey: 'ck_switched_account',
+            runtimeKey: 'rt_switched',
+            user: { id: 'u-switched', email: 'switched@example.com' },
+          },
+        });
+
+        const fetchSpy = vi
+          .fn()
+          .mockResolvedValueOnce(
+            new Response(JSON.stringify({ error: 'unauthenticated' }), { status: 401 }),
+          )
+          .mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+        const result = await reportRunCompleted(
+          makeCtx({
+            prefs: { metrics: true, content: true, artifactManifest: false },
+          }),
+          {
+            config: sink!,
+            fetchImpl: fetchSpy as any,
+            configuredEnv: { OPEN_DESIGN_AMR_PROFILE: 'local' },
+          },
+        );
+
+        expect(result.langfuse_delivery_status).toBe('accepted');
+        const profiles = readProfiles();
+        expect(profiles.local?.controlKey).toBe('ck_switched_account');
+        expect(profiles.local?.runtimeKey).toBe('rt_switched');
+        expect(profiles.local?.user).toEqual({
+          id: 'u-switched',
+          email: 'switched@example.com',
+        });
+      },
+    );
+  });
+
+  it('does not clear a different AMR profile on Vela auth failure', async () => {
+    await withSeededAmrHome(
+      {
+        local: {
+          controlKey: 'ck_local',
+          runtimeKey: 'rt_local',
+          user: { id: 'u-local', email: 'local@example.com' },
+        },
+        prod: {
+          controlKey: 'ck_prod',
+          runtimeKey: 'rt_prod',
+          user: { id: 'u-prod', email: 'prod@example.com' },
+        },
+      },
+      async ({ readProfiles }) => {
+        process.env.OPEN_DESIGN_AMR_PROFILE = 'local';
+        const sink = readTelemetrySinkConfig(process.env);
+        expect(sink).toMatchObject({
+          kind: 'vela',
+          authSource: 'file',
+          profile: 'local',
+          controlKey: 'ck_local',
+          clearLoginOnAuthFailure: true,
+        });
+
+        const fetchSpy = vi
+          .fn()
+          .mockResolvedValueOnce(
+            new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 }),
+          )
+          .mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+        // Live re-read uses the switched profile selection; the in-flight sink
+        // still targets `local`, so cleanup must not touch either profile.
+        const result = await reportRunCompleted(
+          makeCtx({
+            prefs: { metrics: true, content: true, artifactManifest: false },
+          }),
+          {
+            config: sink!,
+            fetchImpl: fetchSpy as any,
+            configuredEnv: { OPEN_DESIGN_AMR_PROFILE: 'prod' },
+          },
+        );
+
+        expect(result.langfuse_delivery_status).toBe('accepted');
+        const profiles = readProfiles();
+        expect(profiles.local?.controlKey).toBe('ck_local');
+        expect(profiles.local?.runtimeKey).toBe('rt_local');
+        expect(profiles.prod?.controlKey).toBe('ck_prod');
+        expect(profiles.prod?.runtimeKey).toBe('rt_prod');
+      },
+    );
   });
 
   it('forces object-registration onto the anonymous relay even when Vela is configured', async () => {

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -192,7 +192,6 @@ describe('readTelemetrySinkConfig', () => {
       retries: 1,
       profile: 'prod',
       authSource: 'env',
-      clearLoginOnAuthFailure: false,
     });
   });
 
@@ -215,7 +214,6 @@ describe('readTelemetrySinkConfig', () => {
       retries: 1,
       profile: 'test',
       authSource: 'env',
-      clearLoginOnAuthFailure: false,
     });
   });
 
@@ -396,7 +394,6 @@ describe('canDeliverRunFeedback', () => {
     retries: 1,
     profile: 'prod',
     authSource: 'env',
-    clearLoginOnAuthFailure: false,
   };
   const relaySink: TelemetrySinkConfig = {
     kind: 'relay',
@@ -577,7 +574,6 @@ describe('deriveLangfuseDeliveryState', () => {
       retries: 1,
       profile: 'prod',
       authSource: 'env',
-      clearLoginOnAuthFailure: false,
     };
     expect(
       deriveLangfuseDeliveryState(
@@ -602,7 +598,6 @@ describe('deriveLangfuseDeliveryState', () => {
       retries: 1,
       profile: 'prod',
       authSource: 'env',
-      clearLoginOnAuthFailure: false,
     };
     expect(
       deriveLangfuseDeliveryState(
@@ -2730,7 +2725,6 @@ describe('reportRunCompleted', () => {
       retries: 0,
       profile: 'prod',
       authSource: 'env',
-      clearLoginOnAuthFailure: false,
       ...overrides,
     };
   }
@@ -3036,10 +3030,6 @@ describe('reportRunCompleted', () => {
     process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL =
       'https://telemetry.open-design.ai/api/langfuse';
     process.env.OPEN_DESIGN_VELA_TELEMETRY = '0';
-    const velaModule = await import('../src/integrations/vela.js');
-    const forgetSpy = vi
-      .spyOn(velaModule, 'forgetVelaLogin')
-      .mockImplementation(() => undefined);
     try {
       const fetchSpy = vi
         .fn()
@@ -3067,10 +3057,7 @@ describe('reportRunCompleted', () => {
       );
       const relayHeaders = fetchSpy.mock.calls[1]![1].headers as Record<string, string>;
       expect(relayHeaders['X-Open-Design-Telemetry']).toBe('langfuse-ingestion-v1');
-      // Explicit sinks must not clear an unrelated local login.
-      expect(forgetSpy).not.toHaveBeenCalled();
     } finally {
-      forgetSpy.mockRestore();
       if (prevRelay === undefined) delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
       else process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL = prevRelay;
       if (prevVela === undefined) delete process.env.OPEN_DESIGN_VELA_TELEMETRY;
@@ -3079,10 +3066,9 @@ describe('reportRunCompleted', () => {
   });
 
   /**
-   * File-backed login cleanup on Vela 401/403: only a matching profile/key
-   * may be cleared. These cases resolve the live sink via
-   * `readTelemetrySinkConfig()` against a seeded `~/.amr` profile (not an
-   * explicit env-backed override), so `clearLoginOnAuthFailure` is true.
+   * File-backed Vela sink fixtures: resolve the live sink via
+   * `readTelemetrySinkConfig()` against a seeded `~/.amr` profile.
+   * Telemetry 401/403 must fall back anonymously without mutating login.
    */
   async function withSeededAmrHome<T>(
     profiles: Record<string, Record<string, unknown>>,
@@ -3146,7 +3132,7 @@ describe('reportRunCompleted', () => {
   }
 
   it.each([401, 403] as const)(
-    'clears matching file-backed login and falls back anonymously on Vela %s',
+    'preserves file-backed login and falls back anonymously on Vela %s',
     async (status) => {
       await withSeededAmrHome(
         {
@@ -3170,7 +3156,6 @@ describe('reportRunCompleted', () => {
             authSource: 'file',
             profile: 'local',
             controlKey: 'ck_local_expired',
-            clearLoginOnAuthFailure: true,
           });
 
           const fetchSpy = vi
@@ -3209,10 +3194,13 @@ describe('reportRunCompleted', () => {
           );
 
           const profiles = readProfiles();
-          // Matching profile/key is cleared; other profiles stay intact.
-          expect(profiles.local?.controlKey).toBeUndefined();
-          expect(profiles.local?.runtimeKey).toBeUndefined();
-          expect(profiles.local?.user).toBeUndefined();
+          // Telemetry auth failure must not revoke product credentials.
+          expect(profiles.local?.controlKey).toBe('ck_local_expired');
+          expect(profiles.local?.runtimeKey).toBe('rt_local');
+          expect(profiles.local?.user).toEqual({
+            id: 'u-local',
+            email: 'local@example.com',
+          });
           expect(profiles.local?.apiUrl).toBe('https://amr-api.example.com');
           expect(profiles.prod?.controlKey).toBe('ck_prod_keep');
           expect(profiles.prod?.runtimeKey).toBe('rt_prod');
@@ -3220,121 +3208,6 @@ describe('reportRunCompleted', () => {
       );
     },
   );
-
-  it('does not clear file-backed login when the stored control key no longer matches', async () => {
-    await withSeededAmrHome(
-      {
-        local: {
-          controlKey: 'ck_request_key',
-          runtimeKey: 'rt_local',
-          user: { id: 'u-local', email: 'local@example.com' },
-        },
-      },
-      async ({ readProfiles, writeProfiles }) => {
-        process.env.OPEN_DESIGN_AMR_PROFILE = 'local';
-        const sink = readTelemetrySinkConfig(process.env);
-        expect(sink).toMatchObject({
-          kind: 'vela',
-          authSource: 'file',
-          profile: 'local',
-          controlKey: 'ck_request_key',
-          clearLoginOnAuthFailure: true,
-        });
-
-        // Simulate account switch after the sink was resolved: live file key
-        // no longer matches the in-flight request key.
-        writeProfiles({
-          local: {
-            controlKey: 'ck_switched_account',
-            runtimeKey: 'rt_switched',
-            user: { id: 'u-switched', email: 'switched@example.com' },
-          },
-        });
-
-        const fetchSpy = vi
-          .fn()
-          .mockResolvedValueOnce(
-            new Response(JSON.stringify({ error: 'unauthenticated' }), { status: 401 }),
-          )
-          .mockResolvedValueOnce(new Response('{}', { status: 200 }));
-
-        const result = await reportRunCompleted(
-          makeCtx({
-            prefs: { metrics: true, content: true, artifactManifest: false },
-          }),
-          {
-            config: sink!,
-            fetchImpl: fetchSpy as any,
-            configuredEnv: { OPEN_DESIGN_AMR_PROFILE: 'local' },
-          },
-        );
-
-        expect(result.langfuse_delivery_status).toBe('accepted');
-        const profiles = readProfiles();
-        expect(profiles.local?.controlKey).toBe('ck_switched_account');
-        expect(profiles.local?.runtimeKey).toBe('rt_switched');
-        expect(profiles.local?.user).toEqual({
-          id: 'u-switched',
-          email: 'switched@example.com',
-        });
-      },
-    );
-  });
-
-  it('does not clear a different AMR profile on Vela auth failure', async () => {
-    await withSeededAmrHome(
-      {
-        local: {
-          controlKey: 'ck_local',
-          runtimeKey: 'rt_local',
-          user: { id: 'u-local', email: 'local@example.com' },
-        },
-        prod: {
-          controlKey: 'ck_prod',
-          runtimeKey: 'rt_prod',
-          user: { id: 'u-prod', email: 'prod@example.com' },
-        },
-      },
-      async ({ readProfiles }) => {
-        process.env.OPEN_DESIGN_AMR_PROFILE = 'local';
-        const sink = readTelemetrySinkConfig(process.env);
-        expect(sink).toMatchObject({
-          kind: 'vela',
-          authSource: 'file',
-          profile: 'local',
-          controlKey: 'ck_local',
-          clearLoginOnAuthFailure: true,
-        });
-
-        const fetchSpy = vi
-          .fn()
-          .mockResolvedValueOnce(
-            new Response(JSON.stringify({ error: 'forbidden' }), { status: 403 }),
-          )
-          .mockResolvedValueOnce(new Response('{}', { status: 200 }));
-
-        // Live re-read uses the switched profile selection; the in-flight sink
-        // still targets `local`, so cleanup must not touch either profile.
-        const result = await reportRunCompleted(
-          makeCtx({
-            prefs: { metrics: true, content: true, artifactManifest: false },
-          }),
-          {
-            config: sink!,
-            fetchImpl: fetchSpy as any,
-            configuredEnv: { OPEN_DESIGN_AMR_PROFILE: 'prod' },
-          },
-        );
-
-        expect(result.langfuse_delivery_status).toBe('accepted');
-        const profiles = readProfiles();
-        expect(profiles.local?.controlKey).toBe('ck_local');
-        expect(profiles.local?.runtimeKey).toBe('rt_local');
-        expect(profiles.prod?.controlKey).toBe('ck_prod');
-        expect(profiles.prod?.runtimeKey).toBe('rt_prod');
-      },
-    );
-  });
 
   it('forces object-registration onto the anonymous relay even when Vela is configured', async () => {
     const prevRelay = process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
@@ -3799,7 +3672,6 @@ describe('reportRunFeedback', () => {
       retries: 0,
       profile: 'prod',
       authSource: 'env',
-      clearLoginOnAuthFailure: false,
     };
     await reportRunFeedback(
       makeFeedbackCtx({
@@ -3863,7 +3735,6 @@ describe('reportRunFeedback', () => {
       retries: 0,
       profile: 'prod',
       authSource: 'env',
-      clearLoginOnAuthFailure: false,
     };
     await reportRunFeedback(
       makeFeedbackCtx({
@@ -3887,7 +3758,6 @@ describe('reportRunFeedback', () => {
       retries: 0,
       profile: 'prod',
       authSource: 'env',
-      clearLoginOnAuthFailure: false,
     };
     await reportRunFeedback(
       makeFeedbackCtx({
@@ -4178,7 +4048,6 @@ describe('reportRunFeedback', () => {
       retries: 0,
       profile: 'prod',
       authSource: 'env',
-      clearLoginOnAuthFailure: false,
     };
     const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 207 }));
 
@@ -4260,7 +4129,6 @@ describe('reportRunFeedback', () => {
       retries: 0,
       profile: 'prod',
       authSource: 'env',
-      clearLoginOnAuthFailure: false,
     };
     const acceptingIdentity = velaSinkIdentityFingerprint(
       'prod',

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -1570,6 +1570,8 @@ describe('buildTracePayload', () => {
   it('nests agent status and usage events under agent-call', () => {
     const batch = buildTracePayload(
       makeCtx({
+        // Content consent required for agent-event free-text `output`.
+        prefs: { metrics: true, content: true, artifactManifest: false },
         run: {
           runId: 'run-agent-events',
           status: 'succeeded',
@@ -1648,6 +1650,8 @@ describe('buildTracePayload', () => {
   it('nests agent diagnostics under agent-call without requiring message content', () => {
     const batch = buildTracePayload(
       makeCtx({
+        // Content consent required for diagnostic free-text `output` payloads.
+        prefs: { metrics: true, content: true, artifactManifest: false },
         run: {
           runId: 'run-agent-diagnostics',
           status: 'succeeded',

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -17,6 +17,7 @@ import {
   readTelemetrySinkConfig,
   readTelemetrySinkConfigForChannel,
   clearRunAwaitingFinalAcceptance,
+  configureDeferredFeedbackDataDir,
   hasPendingRunFeedbackForTests,
   markRunAwaitingFinalAcceptance,
   rememberAcceptedFinalTraceBodyId,
@@ -3610,10 +3611,18 @@ describe('reportRunFeedback', () => {
   beforeEach(() => {
     vi.useRealTimers();
     resetAcceptedFinalTraceBodyIdsForTests();
+    resetPendingRunFeedbackForTests();
+    // Default live consent on so deferred flushes are not fail-closed when
+    // no OD_DATA_DIR / configured data root is present in unit tests.
+    setLiveTelemetryPrefsReaderForTests(() => ({
+      metrics: true,
+      content: true,
+    }));
   });
 
   afterEach(() => {
     resetAcceptedFinalTraceBodyIdsForTests();
+    resetPendingRunFeedbackForTests();
   });
 
   it('skips when metrics consent is off', async () => {
@@ -4161,7 +4170,7 @@ describe('reportRunFeedback', () => {
         new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 }),
       );
 
-      markRunAwaitingFinalAcceptance(runId);
+      const tfToken = markRunAwaitingFinalAcceptance(runId);
       await reportRunFeedback(
         makeFeedbackCtx({
           runId,
@@ -4181,6 +4190,8 @@ describe('reportRunFeedback', () => {
         'terminal_fallback',
         'langfuse',
       );
+      // Production finally releases the TF attempt token after acceptance.
+      clearRunAwaitingFinalAcceptance(runId, tfToken);
 
       // Immediate flush onto :tf; queue retained for a possible late final.
       await vi.waitFor(() => {
@@ -4462,6 +4473,269 @@ describe('reportRunFeedback', () => {
       });
       expect(fetchSpy).not.toHaveBeenCalled();
     } finally {
+      resetPendingRunFeedbackForTests();
+    }
+  });
+
+  it('fails closed on deferred flush when OD_DATA_DIR is unset and consent flipped via configured data root', async () => {
+    // Production resolves RUNTIME_DATA_DIR even when OD_DATA_DIR is absent.
+    // Consent re-check must read that root — not fall back to the queued
+    // submit-time snapshot when process.env.OD_DATA_DIR is empty.
+    resetAcceptedFinalTraceBodyIdsForTests();
+    resetPendingRunFeedbackForTests();
+    const runId = 'run-deferred-consent-via-data-dir';
+    const dataDir = mkdtempSync(path.join(tmpdir(), 'od-deferred-consent-'));
+    const previousOdDataDir = process.env.OD_DATA_DIR;
+    delete process.env.OD_DATA_DIR;
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 }),
+    );
+
+    try {
+      // No test reader: production path only.
+      setLiveTelemetryPrefsReaderForTests(undefined);
+      configureDeferredFeedbackDataDir(dataDir);
+      writeFileSync(
+        path.join(dataDir, 'app-config.json'),
+        JSON.stringify({ telemetry: { metrics: true, content: true } }),
+      );
+
+      markRunAwaitingFinalAcceptance(runId);
+      await reportRunFeedback(
+        makeFeedbackCtx({
+          runId,
+          runStatus: 'failed',
+          telemetryFinalized: false,
+          rating: 'negative',
+          reasonCodes: [],
+          hasCustomReason: true,
+          customReason: 'queued custom reason',
+        }),
+        { config: TEST_CONFIG, fetchImpl: fetchSpy as any },
+      );
+      expect(hasPendingRunFeedbackForTests(runId)).toBe(true);
+
+      // Opt out after queueing; live config must win over queued prefs.
+      writeFileSync(
+        path.join(dataDir, 'app-config.json'),
+        JSON.stringify({ telemetry: { metrics: false, content: false } }),
+      );
+
+      rememberAcceptedFinalTraceBodyId(
+        runId,
+        scopedTelemetryBodyId(runId, 'final', 'terminal_fallback'),
+        'terminal_fallback',
+        'langfuse',
+      );
+
+      await vi.waitFor(() => {
+        expect(hasPendingRunFeedbackForTests(runId)).toBe(false);
+      });
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      if (previousOdDataDir === undefined) delete process.env.OD_DATA_DIR;
+      else process.env.OD_DATA_DIR = previousOdDataDir;
+      rmSync(dataDir, { recursive: true, force: true });
+      resetPendingRunFeedbackForTests();
+    }
+  });
+
+  it('keeps the deferred queue past the late-final window while final_message is still in flight', async () => {
+    // terminal_fallback accepts first and would schedule a 30s drop, but a
+    // concurrent final_message can take ~40s (20s timeout + 1 retry). Tokens
+    // must survive TF accept so the drop timer re-arms until FM completes.
+    vi.useFakeTimers();
+    try {
+      resetAcceptedFinalTraceBodyIdsForTests();
+      resetPendingRunFeedbackForTests();
+      setLiveTelemetryPrefsReaderForTests(() => ({
+        metrics: true,
+        content: true,
+      }));
+      const runId = 'run-tf-then-slow-final';
+      const fallbackTraceId = scopedTelemetryBodyId(
+        runId,
+        'final',
+        'terminal_fallback',
+      );
+      const fetchSpy = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 }),
+      );
+
+      const tokenTf = markRunAwaitingFinalAcceptance(runId);
+      const tokenFinal = markRunAwaitingFinalAcceptance(runId);
+
+      await reportRunFeedback(
+        makeFeedbackCtx({
+          runId,
+          runStatus: 'failed',
+          telemetryFinalized: false,
+          rating: 'positive',
+          reasonCodes: [],
+        }),
+        { config: TEST_CONFIG, fetchImpl: fetchSpy as any },
+      );
+      expect(hasPendingRunFeedbackForTests(runId)).toBe(true);
+
+      // TF accepts first; preserve the final_message token.
+      rememberAcceptedFinalTraceBodyId(
+        runId,
+        fallbackTraceId,
+        'terminal_fallback',
+        'langfuse',
+      );
+      clearRunAwaitingFinalAcceptance(runId, tokenTf);
+
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+      });
+      expect(hasPendingRunFeedbackForTests(runId)).toBe(true);
+
+      // Mid-window re-rate while only :tf is accepted.
+      await reportRunFeedback(
+        makeFeedbackCtx({
+          runId,
+          runStatus: 'failed',
+          telemetryFinalized: false,
+          rating: 'negative',
+          reasonCodes: ['matched_request'],
+          acceptedReportTrigger: 'terminal_fallback',
+          acceptedDeliveryChannel: 'langfuse',
+          traceId: fallbackTraceId,
+        }),
+        { config: TEST_CONFIG, fetchImpl: fetchSpy as any },
+      );
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+      });
+
+      // Past the default 30s late-final window; queue must still be held
+      // because final_message is still in flight.
+      await vi.advanceTimersByTimeAsync(TERMINAL_FALLBACK_LATE_FINAL_FEEDBACK_MS + 5_000);
+      expect(hasPendingRunFeedbackForTests(runId)).toBe(true);
+
+      // Slow final_message accepts after ~40s of Vela timeout/retry budget.
+      rememberAcceptedFinalTraceBodyId(runId, runId, 'final_message', 'langfuse');
+      clearRunAwaitingFinalAcceptance(runId, tokenFinal);
+
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledTimes(3);
+      });
+      const finalScore = JSON.parse(fetchSpy.mock.calls[2]![1].body as string);
+      expect(finalScore.batch[0].type).toBe('score-create');
+      expect(finalScore.batch[0].body.traceId).toBe(runId);
+      expect(finalScore.batch[0].body.value).toBe(-1);
+      expect(hasPendingRunFeedbackForTests(runId)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+      resetPendingRunFeedbackForTests();
+    }
+  });
+
+  it('refreshes deferred queue on re-rate even when sticky Vela identity cannot deliver', async () => {
+    // TF accepted under Vela identity A; user switches profile before re-rating.
+    // Immediate send is suppressed, but the deferred queue must still take the
+    // new score so final_message under identity B can replay it.
+    resetAcceptedFinalTraceBodyIdsForTests();
+    resetPendingRunFeedbackForTests();
+    setLiveTelemetryPrefsReaderForTests(() => ({
+      metrics: true,
+      content: true,
+    }));
+    const runId = 'run-tf-vela-identity-rerate-queue';
+    const previous = {
+      VELA_CONTROL_KEY: process.env.VELA_CONTROL_KEY,
+      VELA_API_URL: process.env.VELA_API_URL,
+      OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
+      LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
+      LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
+    };
+    process.env.VELA_CONTROL_KEY = 'ck_new_after_switch';
+    process.env.VELA_API_URL = 'https://amr-api.example.com';
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+
+    const oldIdentity = velaSinkIdentityFingerprint('prod', 'ck_old_accepted');
+    const newIdentity = velaSinkIdentityFingerprint('prod', 'ck_new_after_switch');
+    const fallbackBodyId = scopedTelemetryBodyId(
+      runId,
+      'final',
+      'terminal_fallback',
+    );
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
+
+    try {
+      markRunAwaitingFinalAcceptance(runId);
+      rememberAcceptedFinalTraceBodyId(
+        runId,
+        fallbackBodyId,
+        'terminal_fallback',
+        'vela',
+        oldIdentity,
+      );
+
+      // Live sink after profile switch (new key). Sticky accepted identity is
+      // still the old fingerprint, so canDeliverRunFeedback rejects the send.
+      const liveVela: TelemetrySinkConfig = {
+        kind: 'vela',
+        apiUrl: 'https://amr-api.example.com',
+        controlKey: 'ck_new_after_switch',
+        timeoutMs: 20_000,
+        retries: 0,
+        profile: 'prod',
+        authSource: 'env',
+      };
+      await reportRunFeedback(
+        makeFeedbackCtx({
+          runId,
+          rating: 'negative',
+          reasonCodes: ['matched_request'],
+          acceptedReportTrigger: 'terminal_fallback',
+          acceptedDeliveryChannel: 'vela',
+          acceptedVelaIdentity: oldIdentity,
+          traceId: fallbackBodyId,
+        }),
+        { config: liveVela, fetchImpl: fetchSpy as any },
+      );
+      // Immediate send suppressed.
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(hasPendingRunFeedbackForTests(runId)).toBe(true);
+
+      // final_message accepts under the new Vela identity and must replay the
+      // re-rated (negative) score — not drop for lack of a refreshed queue.
+      rememberAcceptedFinalTraceBodyId(
+        runId,
+        runId,
+        'final_message',
+        'vela',
+        newIdentity,
+      );
+
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalled();
+      });
+      const envelope = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
+      expect(envelope.events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: 'score',
+            data: expect.objectContaining({
+              name: 'user_rating',
+              value: -1,
+              traceId: runId,
+            }),
+          }),
+        ]),
+      );
+      expect(String(fetchSpy.mock.calls[0]![1].headers?.Authorization ?? '')).toBe(
+        'Bearer ck_new_after_switch',
+      );
+    } finally {
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
       resetPendingRunFeedbackForTests();
     }
   });

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -14,6 +14,7 @@ import {
   readAnonymousTelemetrySinkConfig,
   readLangfuseConfig,
   readTelemetrySinkConfig,
+  readTelemetrySinkConfigForChannel,
   rememberAcceptedFinalTraceBodyId,
   reportRunCompleted,
   reportRunFeedback,
@@ -281,6 +282,59 @@ describe('readTelemetrySinkConfig', () => {
       OPEN_DESIGN_TELEMETRY_RELAY_URL: 'https://telemetry.open-design.ai/api/langfuse',
     });
     expect(cfg).toMatchObject({ kind: 'relay' });
+  });
+});
+
+describe('readTelemetrySinkConfigForChannel', () => {
+  const bothSinksEnv = {
+    VELA_CONTROL_KEY: 'ck_test_key',
+    VELA_API_URL: 'https://amr-api.example.com',
+    OPEN_DESIGN_TELEMETRY_RELAY_URL: 'https://telemetry.open-design.ai/api/langfuse',
+    LANGFUSE_PUBLIC_KEY: 'pk',
+    LANGFUSE_SECRET_KEY: 'sk',
+  } as const;
+
+  it('returns the preferred sink when no sticky channel is set', () => {
+    expect(readTelemetrySinkConfigForChannel(null, bothSinksEnv)).toMatchObject({
+      kind: 'vela',
+    });
+  });
+
+  it('selects relay even when Vela is preferred globally', () => {
+    expect(readTelemetrySinkConfigForChannel('relay', bothSinksEnv)).toEqual({
+      kind: 'relay',
+      relayUrl: 'https://telemetry.open-design.ai/api/langfuse',
+      timeoutMs: 20_000,
+      retries: 1,
+    });
+  });
+
+  it('selects direct Langfuse even when relay is preferred anonymously', () => {
+    expect(readTelemetrySinkConfigForChannel('langfuse', bothSinksEnv)).toMatchObject({
+      kind: 'langfuse',
+      baseUrl: 'https://us.cloud.langfuse.com',
+    });
+  });
+
+  it('selects Vela when the sticky channel is Vela', () => {
+    expect(readTelemetrySinkConfigForChannel('vela', bothSinksEnv)).toMatchObject({
+      kind: 'vela',
+      controlKey: 'ck_test_key',
+    });
+  });
+
+  it('returns null when the sticky channel is unavailable', () => {
+    expect(
+      readTelemetrySinkConfigForChannel('relay', {
+        VELA_CONTROL_KEY: 'ck_test_key',
+      }),
+    ).toBeNull();
+    expect(
+      readTelemetrySinkConfigForChannel('langfuse', {
+        OPEN_DESIGN_TELEMETRY_RELAY_URL:
+          'https://telemetry.open-design.ai/api/langfuse',
+      }),
+    ).toBeNull();
   });
 });
 
@@ -3707,6 +3761,46 @@ describe('reportRunFeedback', () => {
       { config: velaConfig, fetchImpl: fetchSpy as any },
     );
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('posts relay-accepted feedback through relay when Vela is also configured', async () => {
+    const previous = {
+      VELA_CONTROL_KEY: process.env.VELA_CONTROL_KEY,
+      VELA_API_URL: process.env.VELA_API_URL,
+      OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
+      LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
+      LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
+    };
+    process.env.VELA_CONTROL_KEY = 'ck_test_key';
+    process.env.VELA_API_URL = 'https://amr-api.example.com';
+    process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL =
+      'https://telemetry.open-design.ai/api/langfuse';
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 207 }));
+    try {
+      // No explicit config: env resolution would prefer Vela unless sticky.
+      await reportRunFeedback(
+        makeFeedbackCtx({
+          runId: 'run-relay-sticky-with-vela',
+          acceptedDeliveryChannel: 'relay',
+          reasonCodes: [],
+        }),
+        { fetchImpl: fetchSpy as any },
+      );
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(String(fetchSpy.mock.calls[0]![0])).toBe(
+        'https://telemetry.open-design.ai/api/langfuse',
+      );
+      expect(String(fetchSpy.mock.calls[0]![0])).not.toContain(
+        '/api/v1/open-design/telemetry',
+      );
+    } finally {
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
   });
 
   it('does not post feedback through a different Vela account than the accepting one', async () => {

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -3956,35 +3956,147 @@ describe('reportRunFeedback', () => {
   });
 
   it('flushes deferred feedback to canonical only after the last in-flight attempt fails', async () => {
+    // Canonical flush strips submit-time opts.config and re-resolves the live
+    // sink (logout / profile switch safety). Seed env so re-resolution works.
     resetAcceptedFinalTraceBodyIdsForTests();
     resetPendingRunFeedbackForTests();
+    setLiveTelemetryPrefsReaderForTests(() => ({
+      metrics: true,
+      content: true,
+    }));
     const runId = 'run-dual-inflight-both-fail';
+    const previous = {
+      LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
+      LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
+      LANGFUSE_BASE_URL: process.env.LANGFUSE_BASE_URL,
+      OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
+      VELA_CONTROL_KEY: process.env.VELA_CONTROL_KEY,
+      VELA_API_URL: process.env.VELA_API_URL,
+    };
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk';
+    process.env.LANGFUSE_SECRET_KEY = 'sk';
+    process.env.LANGFUSE_BASE_URL = 'https://us.cloud.langfuse.com';
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    delete process.env.VELA_CONTROL_KEY;
+    delete process.env.VELA_API_URL;
     const fetchSpy = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 }),
     );
 
-    const tokenTf = markRunAwaitingFinalAcceptance(runId);
-    const tokenFinal = markRunAwaitingFinalAcceptance(runId);
-    await reportRunFeedback(
-      makeFeedbackCtx({
-        runId,
-        runStatus: 'failed',
-        telemetryFinalized: false,
-        reasonCodes: [],
-      }),
-      { config: TEST_CONFIG, fetchImpl: fetchSpy as any },
-    );
-    expect(fetchSpy).not.toHaveBeenCalled();
+    try {
+      const tokenTf = markRunAwaitingFinalAcceptance(runId);
+      const tokenFinal = markRunAwaitingFinalAcceptance(runId);
+      await reportRunFeedback(
+        makeFeedbackCtx({
+          runId,
+          runStatus: 'failed',
+          telemetryFinalized: false,
+          reasonCodes: [],
+        }),
+        { config: TEST_CONFIG, fetchImpl: fetchSpy as any },
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
 
-    clearRunAwaitingFinalAcceptance(runId, tokenTf);
-    expect(fetchSpy).not.toHaveBeenCalled();
+      clearRunAwaitingFinalAcceptance(runId, tokenTf);
+      expect(fetchSpy).not.toHaveBeenCalled();
 
-    clearRunAwaitingFinalAcceptance(runId, tokenFinal);
-    await vi.waitFor(() => {
-      expect(fetchSpy).toHaveBeenCalled();
-    });
-    const body = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
-    expect(body.batch[0].body.traceId).toBe(runId);
+      clearRunAwaitingFinalAcceptance(runId, tokenFinal);
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalled();
+      });
+      const body = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
+      expect(body.batch[0].body.traceId).toBe(runId);
+    } finally {
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      resetPendingRunFeedbackForTests();
+    }
+  });
+
+  it('re-resolves live sink when clearRunAwaitingFinalAcceptance flushes after Vela logout/profile switch', async () => {
+    // Queued under Control Key A while a final-purpose attempt is open. User
+    // logs out / switches AMR before every attempt ends without acceptance.
+    // clearRunAwaitingFinalAcceptance must not replay with pending.opts.config
+    // (stale key A) — strip and re-resolve so the canonical score lands on the
+    // live anonymous path (or key B), never the previous Vela account.
+    resetAcceptedFinalTraceBodyIdsForTests();
+    resetPendingRunFeedbackForTests();
+    setLiveTelemetryPrefsReaderForTests(() => ({
+      metrics: true,
+      content: true,
+    }));
+    const runId = 'run-clear-awaiting-stale-vela-config';
+    const previous = {
+      VELA_CONTROL_KEY: process.env.VELA_CONTROL_KEY,
+      VELA_API_URL: process.env.VELA_API_URL,
+      OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
+      LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
+      LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
+    };
+    process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL =
+      'https://telemetry.open-design.ai/api/langfuse';
+    delete process.env.VELA_CONTROL_KEY;
+    delete process.env.VELA_API_URL;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+
+    const velaAtSubmit: TelemetrySinkConfig = {
+      kind: 'vela',
+      apiUrl: 'https://amr-api.example.com',
+      controlKey: 'ck_stale_profile_a',
+      timeoutMs: 20_000,
+      retries: 0,
+      profile: 'prod',
+      authSource: 'env',
+    };
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 207 }));
+
+    try {
+      const token = markRunAwaitingFinalAcceptance(runId);
+      await reportRunFeedback(
+        makeFeedbackCtx({
+          runId,
+          runStatus: 'failed',
+          telemetryFinalized: false,
+          reasonCodes: [],
+        }),
+        { config: velaAtSubmit, fetchImpl: fetchSpy as any },
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(hasPendingRunFeedbackForTests(runId)).toBe(true);
+
+      // Logout / profile switch: live env has only the anonymous relay.
+      // Last final-purpose attempt ends without acceptance → canonical flush.
+      clearRunAwaitingFinalAcceptance(runId, token);
+
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+      });
+      expect(String(fetchSpy.mock.calls[0]![0])).toBe(
+        'https://telemetry.open-design.ai/api/langfuse',
+      );
+      expect(String(fetchSpy.mock.calls[0]![0])).not.toContain(
+        '/api/v1/open-design/telemetry',
+      );
+      const auth = String(
+        (fetchSpy.mock.calls[0]![1] as RequestInit).headers?.Authorization ?? '',
+      );
+      expect(auth).not.toContain('ck_stale_profile_a');
+      const body = JSON.parse(
+        (fetchSpy.mock.calls[0]![1] as RequestInit).body as string,
+      );
+      expect(body.batch[0].type).toBe('score-create');
+      expect(body.batch[0].body.traceId).toBe(runId);
+      expect(hasPendingRunFeedbackForTests(runId)).toBe(false);
+    } finally {
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      resetPendingRunFeedbackForTests();
+    }
   });
 
   it('defers feedback submitted before terminal_fallback acceptance onto runId:tf', async () => {

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -436,20 +436,23 @@ describe('resolveFeedbackTraceId', () => {
     expect(resolveFeedbackTraceId({ runId: 'run-a' })).toBe('run-a');
   });
 
-  it('derives the terminal_fallback body id for failed/canceled non-finalized runs', () => {
+  it('keeps the canonical id when failed/canceled but no accepted fallback anchor exists', () => {
+    // Immediate thumbs-up/down after a failed run must not invent runId:tf
+    // before terminal_fallback is accepted (or while late finalization may
+    // still cancel the fallback and publish only the canonical trace).
     expect(
       resolveFeedbackTraceId({
         runId: 'run-failed',
         runStatus: 'failed',
         telemetryFinalized: false,
       }),
-    ).toBe(scopedTelemetryBodyId('run-failed', 'final', 'terminal_fallback'));
+    ).toBe('run-failed');
     expect(
       resolveFeedbackTraceId({
         runId: 'run-canceled',
         runStatus: 'canceled',
       }),
-    ).toBe('run-canceled:tf');
+    ).toBe('run-canceled');
   });
 
   it('keeps the canonical id when the message was telemetry-finalized', () => {
@@ -460,6 +463,28 @@ describe('resolveFeedbackTraceId', () => {
         telemetryFinalized: true,
       }),
     ).toBe('run-finalized');
+  });
+
+  it('uses a remembered terminal_fallback body id only after acceptance', () => {
+    expect(
+      resolveFeedbackTraceId({
+        runId: 'run-tf-accept',
+        runStatus: 'failed',
+        telemetryFinalized: false,
+      }),
+    ).toBe('run-tf-accept');
+    rememberAcceptedFinalTraceBodyId(
+      'run-tf-accept',
+      'run-tf-accept:tf',
+      'terminal_fallback',
+    );
+    expect(
+      resolveFeedbackTraceId({
+        runId: 'run-tf-accept',
+        runStatus: 'failed',
+        telemetryFinalized: false,
+      }),
+    ).toBe('run-tf-accept:tf');
   });
 
   it('prefers the accepted final_message body id over a prior terminal_fallback memory', () => {
@@ -3299,7 +3324,7 @@ describe('buildFeedbackPayload', () => {
     expect(batch[2]!.body.value).toBe('weak_visual');
   });
 
-  it('attaches scores to the terminal_fallback body id for fallback-only runs', () => {
+  it('keeps scores on the canonical id for failed runs without an accepted fallback anchor', () => {
     const batch = buildFeedbackPayload(
       makeFeedbackCtx({
         runId: 'run-fallback-only',
@@ -3307,13 +3332,9 @@ describe('buildFeedbackPayload', () => {
         telemetryFinalized: false,
       }),
     ) as Array<Record<string, any>>;
-    const expectedTraceId = scopedTelemetryBodyId(
-      'run-fallback-only',
-      'final',
-      'terminal_fallback',
-    );
-    expect(batch[0]!.body.traceId).toBe(expectedTraceId);
-    expect(batch[0]!.body.id).toBe(`${expectedTraceId}-rating`);
+    // Status alone must not invent :tf; only accepted delivery memory does.
+    expect(batch[0]!.body.traceId).toBe('run-fallback-only');
+    expect(batch[0]!.body.id).toBe('run-fallback-only-rating');
   });
 
   it('uses the remembered accepted body id when present', () => {

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   buildFeedbackPayload,
   buildTelemetryIdempotencyKey,
+  feedbackIngestionRevision,
   buildTracePayload,
   deriveLangfuseDeliveryState,
   readAnonymousTelemetrySinkConfig,
@@ -2524,6 +2525,54 @@ describe('buildFeedbackPayload', () => {
     expect(batch).toHaveLength(1);
     expect(batch[0]!.body.name).toBe('user_rating');
     expect(batch[0]!.body.value).toBe(1);
+  });
+
+  it('keeps score body.id stable but changes event ids when feedback payload edits', () => {
+    const positive = makeFeedbackCtx({
+      rating: 'positive',
+      reasonCodes: ['matched_request'],
+    });
+    const negative = makeFeedbackCtx({
+      rating: 'negative',
+      reasonCodes: ['matched_request'],
+    });
+    const positiveBatch = buildFeedbackPayload(positive) as Array<Record<string, any>>;
+    const negativeBatch = buildFeedbackPayload(negative) as Array<Record<string, any>>;
+    const positiveRetry = buildFeedbackPayload(positive) as Array<Record<string, any>>;
+
+    expect(positiveBatch[0]!.body.id).toBe('run-feedback-1-rating');
+    expect(negativeBatch[0]!.body.id).toBe('run-feedback-1-rating');
+    expect(positiveBatch[1]!.body.id).toBe('run-feedback-1-reason-matched_request');
+    expect(negativeBatch[1]!.body.id).toBe('run-feedback-1-reason-matched_request');
+
+    expect(positiveBatch[0]!.id).not.toBe(negativeBatch[0]!.id);
+    expect(positiveBatch[1]!.id).not.toBe(negativeBatch[1]!.id);
+    expect(positiveBatch[0]!.id).toBe(positiveRetry[0]!.id);
+
+    const revisionPos = feedbackIngestionRevision(positive);
+    const revisionNeg = feedbackIngestionRevision(negative);
+    expect(revisionPos).not.toBe(revisionNeg);
+    expect(positiveBatch[0]!.id).toBe(
+      stableIngestionEventId(`run-feedback-1-rating:${revisionPos}`),
+    );
+    expect(negativeBatch[0]!.id).toBe(
+      stableIngestionEventId(`run-feedback-1-rating:${revisionNeg}`),
+    );
+
+    const keyPos = buildTelemetryIdempotencyKey(
+      positiveBatch as Array<{ id: string }>,
+      'run-feedback-1',
+    );
+    const keyNeg = buildTelemetryIdempotencyKey(
+      negativeBatch as Array<{ id: string }>,
+      'run-feedback-1',
+    );
+    const keyRetry = buildTelemetryIdempotencyKey(
+      positiveRetry as Array<{ id: string }>,
+      'run-feedback-1',
+    );
+    expect(keyPos).not.toBe(keyNeg);
+    expect(keyPos).toBe(keyRetry);
   });
 });
 

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -17,6 +17,7 @@ import {
   readTelemetrySinkConfig,
   readTelemetrySinkConfigForChannel,
   clearRunAwaitingFinalAcceptance,
+  hasPendingRunFeedbackForTests,
   markRunAwaitingFinalAcceptance,
   rememberAcceptedFinalTraceBodyId,
   reportRunCompleted,
@@ -27,6 +28,7 @@ import {
   scopedTelemetryBodyId,
   shouldDeferRunFeedback,
   stableIngestionEventId,
+  TERMINAL_FALLBACK_LATE_FINAL_FEEDBACK_MS,
   toVelaTelemetryEnvelope,
   velaSinkIdentityFingerprint,
   type FeedbackReportContext,
@@ -4139,6 +4141,91 @@ describe('reportRunFeedback', () => {
     expect(finalScoreBody.batch[0].body.id).toBe(`${runId}-rating`);
     expect(finalScoreBody.batch[0].body.traceId).not.toBe(fallbackTraceId);
     expect(resolveFeedbackTraceId({ runId })).toBe(runId);
+  });
+
+  it('drops terminal-fallback-only deferred feedback after the late-final window', async () => {
+    // TF-only runs never get a final_message; the deferred queue must not keep
+    // custom reasons / opts.config (Control Keys) until daemon exit.
+    vi.useFakeTimers();
+    try {
+      resetAcceptedFinalTraceBodyIdsForTests();
+      resetPendingRunFeedbackForTests();
+      const runId = 'run-feedback-tf-only-drop';
+      const fallbackTraceId = scopedTelemetryBodyId(
+        runId,
+        'final',
+        'terminal_fallback',
+      );
+      const fetchSpy = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 }),
+      );
+
+      markRunAwaitingFinalAcceptance(runId);
+      await reportRunFeedback(
+        makeFeedbackCtx({
+          runId,
+          runStatus: 'failed',
+          telemetryFinalized: false,
+          reasonCodes: ['other'],
+          customReason: 'leaky-custom-reason',
+        }),
+        { config: TEST_CONFIG, fetchImpl: fetchSpy as any },
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(hasPendingRunFeedbackForTests(runId)).toBe(true);
+
+      rememberAcceptedFinalTraceBodyId(
+        runId,
+        fallbackTraceId,
+        'terminal_fallback',
+        'langfuse',
+      );
+
+      // Immediate flush onto :tf; queue retained for a possible late final.
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+      });
+      const flushed = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
+      expect(flushed.batch[0].body.traceId).toBe(fallbackTraceId);
+      expect(hasPendingRunFeedbackForTests(runId)).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(TERMINAL_FALLBACK_LATE_FINAL_FEEDBACK_MS);
+      expect(hasPendingRunFeedbackForTests(runId)).toBe(false);
+
+      // A final_message after the window must not re-ship the dropped payload.
+      const finalCompleted = await reportRunCompleted(
+        makeCtx({
+          prefs: { metrics: true, content: true, artifactManifest: false },
+          run: {
+            runId,
+            status: 'failed',
+            startedAt: 1_700_000_000_000,
+            endedAt: 1_700_000_002_000,
+          },
+        }),
+        {
+          config: TEST_CONFIG,
+          fetchImpl: fetchSpy as any,
+          reportTrigger: 'final_message',
+        },
+      );
+      expect(finalCompleted).toEqual({
+        langfuse_expected: true,
+        langfuse_delivery_status: 'accepted',
+        langfuse_delivery_channel: 'langfuse',
+      });
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+      });
+      const finalBody = JSON.parse(fetchSpy.mock.calls[1]![1].body as string);
+      expect(
+        finalBody.batch.some((item: { type: string }) => item.type === 'score-create'),
+      ).toBe(false);
+      expect(hasPendingRunFeedbackForTests(runId)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+      resetPendingRunFeedbackForTests();
+    }
   });
 
   it('re-resolves a stale submit-time sink when deferred feedback flushes on a different channel', async () => {

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -4071,4 +4071,86 @@ describe('reportRunFeedback', () => {
     expect(finalScoreBody.batch[0].body.traceId).not.toBe(fallbackTraceId);
     expect(resolveFeedbackTraceId({ runId })).toBe(runId);
   });
+
+  it('re-resolves a stale submit-time sink when deferred feedback flushes on a different channel', async () => {
+    // Queued while Vela was selected; final body accepted on relay (e.g. Vela
+    // 401/403 fallback). Flush must not keep the Vela opts.config — that would
+    // fail canDeliverRunFeedback and drop the score silently.
+    resetAcceptedFinalTraceBodyIdsForTests();
+    resetPendingRunFeedbackForTests();
+    const runId = 'run-deferred-channel-switch';
+    const previous = {
+      VELA_CONTROL_KEY: process.env.VELA_CONTROL_KEY,
+      VELA_API_URL: process.env.VELA_API_URL,
+      OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
+      LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
+      LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
+    };
+    process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL =
+      'https://telemetry.open-design.ai/api/langfuse';
+    delete process.env.VELA_CONTROL_KEY;
+    delete process.env.VELA_API_URL;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+
+    const velaAtSubmit: TelemetrySinkConfig = {
+      kind: 'vela',
+      apiUrl: 'https://amr-api.example.com',
+      controlKey: 'ck_stale_submit',
+      timeoutMs: 20_000,
+      retries: 0,
+      profile: 'prod',
+      authSource: 'env',
+      clearLoginOnAuthFailure: false,
+    };
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 207 }));
+
+    try {
+      expect(
+        shouldDeferRunFeedback({
+          runId,
+          runStatus: 'failed',
+          telemetryFinalized: false,
+        }),
+      ).toBe(true);
+      await reportRunFeedback(
+        makeFeedbackCtx({
+          runId,
+          runStatus: 'failed',
+          telemetryFinalized: false,
+          reasonCodes: [],
+        }),
+        { config: velaAtSubmit, fetchImpl: fetchSpy as any },
+      );
+      expect(fetchSpy).not.toHaveBeenCalled();
+
+      // Accepted body landed on relay (not the Vela sink queued at submit).
+      rememberAcceptedFinalTraceBodyId(
+        runId,
+        scopedTelemetryBodyId(runId, 'final', 'terminal_fallback'),
+        'terminal_fallback',
+        'relay',
+      );
+
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+      });
+      expect(String(fetchSpy.mock.calls[0]![0])).toBe(
+        'https://telemetry.open-design.ai/api/langfuse',
+      );
+      expect(String(fetchSpy.mock.calls[0]![0])).not.toContain(
+        '/api/v1/open-design/telemetry',
+      );
+      const feedbackBody = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
+      expect(feedbackBody.batch[0].type).toBe('score-create');
+      expect(feedbackBody.batch[0].body.traceId).toBe(
+        scopedTelemetryBodyId(runId, 'final', 'terminal_fallback'),
+      );
+    } finally {
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  });
 });

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -24,6 +24,7 @@ import {
   shouldDeferRunFeedback,
   stableIngestionEventId,
   toVelaTelemetryEnvelope,
+  velaSinkIdentityFingerprint,
   type FeedbackReportContext,
   type LangfuseConfig,
   type ReportContext,
@@ -344,6 +345,71 @@ describe('canDeliverRunFeedback', () => {
     expect(
       canDeliverRunFeedback(velaSink, 'install-1', {}, { requireChannel: 'vela' }),
     ).toBe(true);
+  });
+
+  it('requires exact channel match for every accepted delivery channel', () => {
+    const langfuseSink: TelemetrySinkConfig = {
+      kind: 'langfuse',
+      authHeader: 'Basic dGVzdA==',
+      baseUrl: 'https://langfuse.example',
+      timeoutMs: 1_000,
+      retries: 0,
+    };
+    // Accepted relay must not post through Vela or direct Langfuse.
+    expect(
+      canDeliverRunFeedback(velaSink, 'install-1', {}, { requireChannel: 'relay' }),
+    ).toBe(false);
+    expect(
+      canDeliverRunFeedback(langfuseSink, 'install-1', {}, { requireChannel: 'relay' }),
+    ).toBe(false);
+    expect(
+      canDeliverRunFeedback(relaySink, null, {}, { requireChannel: 'relay' }),
+    ).toBe(true);
+    // Accepted langfuse must not post through relay/vela.
+    expect(
+      canDeliverRunFeedback(relaySink, null, {}, { requireChannel: 'langfuse' }),
+    ).toBe(false);
+    expect(
+      canDeliverRunFeedback(velaSink, 'install-1', {}, { requireChannel: 'langfuse' }),
+    ).toBe(false);
+    expect(
+      canDeliverRunFeedback(langfuseSink, null, {}, { requireChannel: 'langfuse' }),
+    ).toBe(true);
+    // Accepted vela must not post through relay/langfuse.
+    expect(
+      canDeliverRunFeedback(relaySink, 'install-1', {}, { requireChannel: 'vela' }),
+    ).toBe(false);
+    expect(
+      canDeliverRunFeedback(langfuseSink, 'install-1', {}, { requireChannel: 'vela' }),
+    ).toBe(false);
+  });
+
+  it('rejects Vela feedback when the accepting account fingerprint mismatches', () => {
+    const identity = velaSinkIdentityFingerprint('prod', 'ck_test_key');
+    expect(identity).toBeTruthy();
+    expect(
+      canDeliverRunFeedback(velaSink, 'install-1', {}, {
+        requireChannel: 'vela',
+        requireVelaIdentity: identity,
+      }),
+    ).toBe(true);
+    expect(
+      canDeliverRunFeedback(velaSink, 'install-1', {}, {
+        requireChannel: 'vela',
+        requireVelaIdentity: 'prod:deadbeefdeadbeef',
+      }),
+    ).toBe(false);
+    const otherKeySink: TelemetrySinkConfig = {
+      ...velaSink,
+      controlKey: 'ck_other_account',
+      profile: 'prod',
+    };
+    expect(
+      canDeliverRunFeedback(otherKeySink, 'install-1', {}, {
+        requireChannel: 'vela',
+        requireVelaIdentity: identity,
+      }),
+    ).toBe(false);
   });
 });
 
@@ -2580,6 +2646,10 @@ describe('reportRunCompleted', () => {
       langfuse_expected: true,
       langfuse_delivery_status: 'accepted',
       langfuse_delivery_channel: 'vela',
+      langfuse_vela_identity: velaSinkIdentityFingerprint(
+        velaConfig.profile,
+        velaConfig.controlKey,
+      ),
     });
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     const [url, init] = fetchSpy.mock.calls[0]!;
@@ -3612,6 +3682,54 @@ describe('reportRunFeedback', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it('does not post feedback through Vela when the accepted channel is relay', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
+    const velaConfig: TelemetrySinkConfig = {
+      kind: 'vela',
+      apiUrl: 'https://amr-api.example.com',
+      controlKey: 'ck_test_key',
+      timeoutMs: 20_000,
+      retries: 0,
+      profile: 'prod',
+      authSource: 'env',
+      clearLoginOnAuthFailure: false,
+    };
+    await reportRunFeedback(
+      makeFeedbackCtx({
+        runId: 'run-relay-scoped',
+        acceptedDeliveryChannel: 'relay',
+        reasonCodes: [],
+      }),
+      { config: velaConfig, fetchImpl: fetchSpy as any },
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not post feedback through a different Vela account than the accepting one', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
+    const acceptingIdentity = velaSinkIdentityFingerprint('prod', 'ck_accepted');
+    const liveConfig: TelemetrySinkConfig = {
+      kind: 'vela',
+      apiUrl: 'https://amr-api.example.com',
+      controlKey: 'ck_switched_account',
+      timeoutMs: 20_000,
+      retries: 0,
+      profile: 'prod',
+      authSource: 'env',
+      clearLoginOnAuthFailure: false,
+    };
+    await reportRunFeedback(
+      makeFeedbackCtx({
+        runId: 'run-vela-account-switch',
+        acceptedDeliveryChannel: 'vela',
+        acceptedVelaIdentity: acceptingIdentity,
+        reasonCodes: [],
+      }),
+      { config: liveConfig, fetchImpl: fetchSpy as any },
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it('posts feedback through Vela when the accepted channel is Vela', async () => {
     const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
     const velaConfig: TelemetrySinkConfig = {
@@ -3628,6 +3746,7 @@ describe('reportRunFeedback', () => {
       makeFeedbackCtx({
         runId: 'run-vela-scoped',
         acceptedDeliveryChannel: 'vela',
+        acceptedVelaIdentity: velaSinkIdentityFingerprint('prod', 'ck_test_key'),
         reasonCodes: [],
       }),
       { config: velaConfig, fetchImpl: fetchSpy as any },

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -470,6 +470,19 @@ describe('resolveFeedbackTraceId', () => {
     rememberAcceptedFinalTraceBodyId('run-mem', 'run-mem:tf', 'terminal_fallback');
     expect(resolveFeedbackTraceId({ runId: 'run-mem' })).toBe('run-mem');
   });
+
+  it('prefers a persisted accepted :tf body over telemetry_finalized after cold start', () => {
+    // Simulates daemon restart: process-local memory empty, but DB recorded that
+    // terminal_fallback was accepted while a later final_message failed.
+    expect(
+      resolveFeedbackTraceId({
+        runId: 'run-restart',
+        runStatus: 'failed',
+        telemetryFinalized: true,
+        acceptedTraceBodyId: 'run-restart:tf',
+      }),
+    ).toBe('run-restart:tf');
+  });
 });
 
 describe('buildTracePayload', () => {
@@ -1811,15 +1824,35 @@ describe('buildTracePayload', () => {
   });
 
   it('uses distinct stable ids and omits turn content for object-registration', () => {
+    const streamRun = {
+      runId: 'run-1',
+      status: 'failed' as const,
+      startedAt: 1_700_000_000_000,
+      endedAt: 1_700_000_004_500,
+      error: 'provider failed',
+      stderr: {
+        tail: 'CLI stream tail with secret-redacted provider noise',
+        lineCount: 8,
+        truncated: true,
+      },
+      stdout: {
+        tail: 'partial assistant stream text',
+        lineCount: 3,
+        truncated: false,
+      },
+      diagnostics: { stage: 'agent_stream', raw: 'turn content' },
+    };
     const finalBatch = buildTracePayload(
       makeCtx({
         prefs: { metrics: true, content: true, artifactManifest: false },
+        run: streamRun,
       }),
       'final',
     ) as Array<{ id: string; body: Record<string, any> }>;
     const regBatch = buildTracePayload(
       makeCtx({
         prefs: { metrics: true, content: true, artifactManifest: false },
+        run: streamRun,
       }),
       'object-registration',
     ) as Array<{ id: string; body: Record<string, any> }>;
@@ -1829,7 +1862,15 @@ describe('buildTracePayload', () => {
     expect(regBatch[0]!.body.metadata.telemetry_delivery_purpose).toBe(
       'object-registration',
     );
+    // Object-registration must not carry stream tails / diagnostics either —
+    // those are turn content the final Vela path owns.
+    expect(regBatch[0]!.body.metadata.stderr).toBeUndefined();
+    expect(regBatch[0]!.body.metadata.stdout).toBeUndefined();
+    expect(regBatch[0]!.body.metadata.diagnostics).toBeUndefined();
     expect(finalBatch[0]!.body.input).toBe('Make a landing page for a coffee shop.');
+    expect(finalBatch[0]!.body.metadata.stderr).toEqual(streamRun.stderr);
+    expect(finalBatch[0]!.body.metadata.stdout).toEqual(streamRun.stdout);
+    expect(finalBatch[0]!.body.metadata.diagnostics).toEqual(streamRun.diagnostics);
   });
 
   it('uses distinct body and event ids for terminal_fallback vs final_message', () => {

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -1730,6 +1730,69 @@ describe('buildTracePayload', () => {
     );
     expect(finalBatch[0]!.body.input).toBe('Make a landing page for a coffee shop.');
   });
+
+  it('uses distinct stable ids for terminal_fallback vs final_message late finalization', () => {
+    const ctx = makeCtx({
+      prefs: { metrics: true, content: true, artifactManifest: false },
+    });
+    const fallbackBatch = buildTracePayload(
+      ctx,
+      'final',
+      'terminal_fallback',
+    ) as Array<{ id: string; body: Record<string, any> }>;
+    const finalizedBatch = buildTracePayload(
+      ctx,
+      'final',
+      'final_message',
+    ) as Array<{ id: string; body: Record<string, any> }>;
+    const fallbackRetry = buildTracePayload(
+      ctx,
+      'final',
+      'terminal_fallback',
+    ) as Array<{ id: string }>;
+
+    // Body ids stay run-scoped so Langfuse can overwrite the same observations.
+    expect(fallbackBatch[0]!.body.id).toBe(finalizedBatch[0]!.body.id);
+    // Ingestion event ids must differ so Vela does not dedupe the late final.
+    expect(fallbackBatch[0]!.id).toBe(
+      stableIngestionEventId(fallbackBatch[0]!.body.id, 'final', 'terminal_fallback'),
+    );
+    expect(fallbackBatch[0]!.id).toBe(`${finalizedBatch[0]!.id}:tf`);
+    expect(fallbackBatch.map((event) => event.id)).not.toEqual(
+      finalizedBatch.map((event) => event.id),
+    );
+    // True transport retries of the same logical delivery stay stable.
+    expect(fallbackRetry.map((event) => event.id)).toEqual(
+      fallbackBatch.map((event) => event.id),
+    );
+    expect(fallbackBatch[0]!.body.metadata.telemetry_report_trigger).toBe(
+      'terminal_fallback',
+    );
+    expect(finalizedBatch[0]!.body.metadata.telemetry_report_trigger).toBe(
+      'final_message',
+    );
+
+    const fallbackKey = buildTelemetryIdempotencyKey(
+      fallbackBatch,
+      String(fallbackBatch[0]!.body.id),
+      'final',
+      'terminal_fallback',
+    );
+    const finalizedKey = buildTelemetryIdempotencyKey(
+      finalizedBatch,
+      String(finalizedBatch[0]!.body.id),
+      'final',
+      'final_message',
+    );
+    const fallbackRetryKey = buildTelemetryIdempotencyKey(
+      fallbackRetry,
+      String(fallbackBatch[0]!.body.id),
+      'final',
+      'terminal_fallback',
+    );
+    expect(fallbackKey).not.toBe(finalizedKey);
+    expect(fallbackKey).toBe(fallbackRetryKey);
+  });
 });
 
 describe('vela telemetry envelope helpers', () => {
@@ -1749,6 +1812,29 @@ describe('vela telemetry envelope helpers', () => {
     expect(keyA).toBe(keyB);
     expect(keyA).toMatch(/^od-telemetry-[a-f0-9]{64}$/);
     expect(keyA).not.toBe(keyC);
+  });
+
+  it('includes report trigger so terminal_fallback and final_message keys differ', () => {
+    const keyFallback = buildTelemetryIdempotencyKey(
+      [{ id: 'run-1:tf' }],
+      'run-1',
+      'final',
+      'terminal_fallback',
+    );
+    const keyFinal = buildTelemetryIdempotencyKey(
+      [{ id: 'run-1' }],
+      'run-1',
+      'final',
+      'final_message',
+    );
+    const keyFallbackRetry = buildTelemetryIdempotencyKey(
+      [{ id: 'run-1:tf' }],
+      'run-1',
+      'final',
+      'terminal_fallback',
+    );
+    expect(keyFallback).not.toBe(keyFinal);
+    expect(keyFallback).toBe(keyFallbackRetry);
   });
 
   it('converts Langfuse batch events into the vendor-neutral Vela envelope', () => {
@@ -2158,6 +2244,61 @@ describe('reportRunCompleted', () => {
     const key1 = (fetchSpy.mock.calls[0]![1] as RequestInit).headers as Record<string, string>;
     const key2 = (fetchSpy.mock.calls[1]![1] as RequestInit).headers as Record<string, string>;
     expect(key1['Idempotency-Key']).toBe(key2['Idempotency-Key']);
+  });
+
+  it('uses distinct Vela event ids and idempotency keys for terminal_fallback vs final_message', async () => {
+    const velaConfig = velaSink();
+    const ctx = makeCtx({
+      prefs: { metrics: true, content: true, artifactManifest: false },
+    });
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 202 }),
+    );
+
+    const fallbackResult = await reportRunCompleted(ctx, {
+      config: velaConfig,
+      fetchImpl: fetchSpy as any,
+      deliveryPurpose: 'final',
+      reportTrigger: 'terminal_fallback',
+    });
+    const finalizedResult = await reportRunCompleted(ctx, {
+      config: velaConfig,
+      fetchImpl: fetchSpy as any,
+      deliveryPurpose: 'final',
+      reportTrigger: 'final_message',
+    });
+    // Same logical delivery re-posted (transport retry) keeps the final key.
+    const finalizedRetry = await reportRunCompleted(ctx, {
+      config: velaConfig,
+      fetchImpl: fetchSpy as any,
+      deliveryPurpose: 'final',
+      reportTrigger: 'final_message',
+    });
+
+    expect(fallbackResult.langfuse_delivery_status).toBe('accepted');
+    expect(finalizedResult.langfuse_delivery_status).toBe('accepted');
+    expect(finalizedRetry.langfuse_delivery_status).toBe('accepted');
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
+
+    const fallbackInit = fetchSpy.mock.calls[0]![1] as RequestInit;
+    const finalizedInit = fetchSpy.mock.calls[1]![1] as RequestInit;
+    const retryInit = fetchSpy.mock.calls[2]![1] as RequestInit;
+    const fallbackHeaders = fallbackInit.headers as Record<string, string>;
+    const finalizedHeaders = finalizedInit.headers as Record<string, string>;
+    const retryHeaders = retryInit.headers as Record<string, string>;
+
+    expect(fallbackHeaders['Idempotency-Key']).not.toBe(
+      finalizedHeaders['Idempotency-Key'],
+    );
+    expect(finalizedHeaders['Idempotency-Key']).toBe(retryHeaders['Idempotency-Key']);
+
+    const fallbackBody = JSON.parse(String(fallbackInit.body));
+    const finalizedBody = JSON.parse(String(finalizedInit.body));
+    expect(fallbackBody.events[0].id).toMatch(/:tf$/);
+    expect(finalizedBody.events[0].id).not.toMatch(/:tf$/);
+    expect(fallbackBody.events[0].id).not.toBe(finalizedBody.events[0].id);
+    // Observation body ids remain stable for Langfuse overwrite semantics.
+    expect(fallbackBody.events[0].data.id).toBe(finalizedBody.events[0].data.id);
   });
 
   it('does not anonymous-fallback on Vela 429/5xx or network errors', async () => {

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -2175,6 +2175,52 @@ describe('reportRunCompleted', () => {
     }
   });
 
+  it('reports timeout drop reason when Vela fetch aborts after retries', async () => {
+    const velaConfig = velaSink({ retries: 0 });
+    const timeoutError = new Error('The operation was aborted due to timeout');
+    timeoutError.name = 'TimeoutError';
+    const fetchSpy = vi.fn().mockRejectedValue(timeoutError);
+    const result = await reportRunCompleted(
+      makeCtx({
+        prefs: { metrics: true, content: true, artifactManifest: false },
+      }),
+      {
+        config: velaConfig,
+        fetchImpl: fetchSpy as any,
+      },
+    );
+    expect(result).toEqual({
+      langfuse_expected: true,
+      langfuse_delivery_status: 'failed',
+      langfuse_drop_reason: 'timeout',
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Vela telemetry fetch error: timeout'),
+    );
+  });
+
+  it('reports network_error drop reason for non-timeout Vela fetch failures', async () => {
+    const velaConfig = velaSink({ retries: 0 });
+    const fetchSpy = vi.fn().mockRejectedValue(new Error('ECONNRESET'));
+    const result = await reportRunCompleted(
+      makeCtx({
+        prefs: { metrics: true, content: true, artifactManifest: false },
+      }),
+      {
+        config: velaConfig,
+        fetchImpl: fetchSpy as any,
+      },
+    );
+    expect(result).toEqual({
+      langfuse_expected: true,
+      langfuse_delivery_status: 'failed',
+      langfuse_drop_reason: 'network_error',
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Vela telemetry fetch error: network_error'),
+    );
+  });
+
   it('falls back to anonymous relay on Vela 401/403', async () => {
     const velaConfig = velaSink({ controlKey: 'ck_expired' });
     const prevRelay = process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -16,6 +16,7 @@ import {
   readLegacyAnonymousAcceptedSinkConfig,
   readTelemetrySinkConfig,
   readTelemetrySinkConfigForChannel,
+  clearRunAwaitingFinalAcceptance,
   markRunAwaitingFinalAcceptance,
   rememberAcceptedFinalTraceBodyId,
   reportRunCompleted,
@@ -3875,12 +3876,103 @@ describe('reportRunFeedback', () => {
         runStatus: 'canceled',
       }),
     ).toBe(false);
-    // Unscoped feedback (no status / finalized signal) still ships immediately.
+    // Unscoped feedback (no status / finalized signal) still ships immediately
+    // when no run-scoped awaiting token exists (cold / no completer).
     expect(
       shouldDeferRunFeedback({
         runId: 'run-no-context',
       }),
     ).toBe(false);
+  });
+
+  it('defers unscoped feedback while a run-scoped terminal_fallback token is open (row-reuse window)', () => {
+    // After assistant-row reuse, getRunFeedbackTelemetryAnchor(run A) returns
+    // null until A:tf is accepted — resolveInput is only { runId }. The
+    // schedule-time awaiting token is keyed by immutable run_id so feedback
+    // still defers instead of shipping on canonical runId.
+    resetAcceptedFinalTraceBodyIdsForTests();
+    resetPendingRunFeedbackForTests();
+    const runId = 'run-a-null-anchor-pending-tf';
+    markRunAwaitingFinalAcceptance(runId);
+    expect(shouldDeferRunFeedback({ runId })).toBe(true);
+    clearRunAwaitingFinalAcceptance(runId);
+    expect(shouldDeferRunFeedback({ runId })).toBe(false);
+  });
+
+  it('keeps deferral until the last in-flight final-purpose attempt clears without accept', async () => {
+    // terminal_fallback + final_message can both be in flight. The first
+    // clear must not flush deferred feedback onto canonical runId while the
+    // other delivery can still accept a sticky body (e.g. runId:tf).
+    resetAcceptedFinalTraceBodyIdsForTests();
+    resetPendingRunFeedbackForTests();
+    const runId = 'run-dual-inflight-final';
+    const expectedTf = scopedTelemetryBodyId(runId, 'final', 'terminal_fallback');
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 }),
+    );
+
+    const tokenTf = markRunAwaitingFinalAcceptance(runId);
+    const tokenFinal = markRunAwaitingFinalAcceptance(runId);
+    expect(shouldDeferRunFeedback({ runId })).toBe(true);
+
+    await reportRunFeedback(
+      makeFeedbackCtx({
+        runId,
+        runStatus: 'failed',
+        telemetryFinalized: false,
+        reasonCodes: [],
+      }),
+      { config: TEST_CONFIG, fetchImpl: fetchSpy as any },
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    // First attempt fails/ends — other delivery still pending.
+    clearRunAwaitingFinalAcceptance(runId, tokenTf);
+    expect(shouldDeferRunFeedback({ runId })).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    // Second attempt accepts sticky :tf and flushes the deferred score there.
+    rememberAcceptedFinalTraceBodyId(runId, expectedTf, 'terminal_fallback', 'langfuse');
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
+    expect(body.batch[0].body.traceId).toBe(expectedTf);
+    // Stale clear of the already-superseded token must not re-flush canonical.
+    clearRunAwaitingFinalAcceptance(runId, tokenFinal);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('flushes deferred feedback to canonical only after the last in-flight attempt fails', async () => {
+    resetAcceptedFinalTraceBodyIdsForTests();
+    resetPendingRunFeedbackForTests();
+    const runId = 'run-dual-inflight-both-fail';
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 }),
+    );
+
+    const tokenTf = markRunAwaitingFinalAcceptance(runId);
+    const tokenFinal = markRunAwaitingFinalAcceptance(runId);
+    await reportRunFeedback(
+      makeFeedbackCtx({
+        runId,
+        runStatus: 'failed',
+        telemetryFinalized: false,
+        reasonCodes: [],
+      }),
+      { config: TEST_CONFIG, fetchImpl: fetchSpy as any },
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    clearRunAwaitingFinalAcceptance(runId, tokenTf);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    clearRunAwaitingFinalAcceptance(runId, tokenFinal);
+    await vi.waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
+    expect(body.batch[0].body.traceId).toBe(runId);
   });
 
   it('defers feedback submitted before terminal_fallback acceptance onto runId:tf', async () => {

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -13,6 +13,7 @@ import {
   deriveLangfuseDeliveryState,
   readAnonymousTelemetrySinkConfig,
   readLangfuseConfig,
+  readLegacyAnonymousAcceptedSinkConfig,
   readTelemetrySinkConfig,
   readTelemetrySinkConfigForChannel,
   rememberAcceptedFinalTraceBodyId,
@@ -282,6 +283,54 @@ describe('readTelemetrySinkConfig', () => {
       OPEN_DESIGN_TELEMETRY_RELAY_URL: 'https://telemetry.open-design.ai/api/langfuse',
     });
     expect(cfg).toMatchObject({ kind: 'relay' });
+  });
+});
+
+describe('readLegacyAnonymousAcceptedSinkConfig', () => {
+  it('returns null when both relay and direct Langfuse are viable', () => {
+    // Ambiguous pre-migration channel: cannot know which backend accepted.
+    expect(
+      readLegacyAnonymousAcceptedSinkConfig({
+        OPEN_DESIGN_TELEMETRY_RELAY_URL:
+          'https://telemetry.open-design.ai/api/langfuse',
+        LANGFUSE_PUBLIC_KEY: 'pk',
+        LANGFUSE_SECRET_KEY: 'sk',
+      }),
+    ).toBeNull();
+  });
+
+  it('selects relay when only the relay is configured', () => {
+    expect(
+      readLegacyAnonymousAcceptedSinkConfig({
+        OPEN_DESIGN_TELEMETRY_RELAY_URL:
+          'https://telemetry.open-design.ai/api/langfuse',
+        VELA_CONTROL_KEY: 'ck_test_key',
+      }),
+    ).toMatchObject({
+      kind: 'relay',
+      relayUrl: 'https://telemetry.open-design.ai/api/langfuse',
+    });
+  });
+
+  it('selects direct Langfuse when only Langfuse credentials are configured', () => {
+    expect(
+      readLegacyAnonymousAcceptedSinkConfig({
+        LANGFUSE_PUBLIC_KEY: 'pk',
+        LANGFUSE_SECRET_KEY: 'sk',
+        VELA_CONTROL_KEY: 'ck_test_key',
+      }),
+    ).toMatchObject({
+      kind: 'langfuse',
+      baseUrl: 'https://us.cloud.langfuse.com',
+    });
+  });
+
+  it('returns null when neither anonymous backend is configured', () => {
+    expect(
+      readLegacyAnonymousAcceptedSinkConfig({
+        VELA_CONTROL_KEY: 'ck_test_key',
+      }),
+    ).toBeNull();
   });
 });
 

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -3959,6 +3959,34 @@ describe('reportRunFeedback', () => {
     expect(feedbackBody.batch[0].body.traceId).not.toBe(runId);
   });
 
+  it('defers feedback when telemetryFinalized without an accepted anchor yet', () => {
+    // Live finalization race: message row is finalized before reportRunCompleted
+    // persists acceptedTraceBodyId / acceptedDeliveryChannel.
+    resetAcceptedFinalTraceBodyIdsForTests();
+    resetPendingRunFeedbackForTests();
+    expect(
+      shouldDeferRunFeedback({
+        runId: 'run-finalized-no-anchor',
+        runStatus: 'succeeded',
+        telemetryFinalized: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldDeferRunFeedback({
+        runId: 'run-finalized-with-body',
+        runStatus: 'succeeded',
+        telemetryFinalized: true,
+        acceptedTraceBodyId: 'run-finalized-with-body',
+      }),
+    ).toBe(false);
+    // Unscoped feedback (no status / finalized signal) still ships immediately.
+    expect(
+      shouldDeferRunFeedback({
+        runId: 'run-no-context',
+      }),
+    ).toBe(false);
+  });
+
   it('defers feedback submitted before terminal_fallback acceptance onto runId:tf', async () => {
     resetAcceptedFinalTraceBodyIdsForTests();
     resetPendingRunFeedbackForTests();

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -3860,6 +3860,21 @@ describe('reportRunFeedback', () => {
         telemetryFinalized: true,
       }),
     ).toBe(false);
+    // Cold failed/canceled after restart (or after fallback cleared) with no
+    // awaiting mark must not queue forever on status alone.
+    expect(
+      shouldDeferRunFeedback({
+        runId: 'run-cold-failed-no-anchor',
+        runStatus: 'failed',
+        telemetryFinalized: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldDeferRunFeedback({
+        runId: 'run-cold-canceled-no-anchor',
+        runStatus: 'canceled',
+      }),
+    ).toBe(false);
     // Unscoped feedback (no status / finalized signal) still ships immediately.
     expect(
       shouldDeferRunFeedback({
@@ -3877,6 +3892,9 @@ describe('reportRunFeedback', () => {
       new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 }),
     );
 
+    // Live terminal_fallback delay/report window: awaiting mark is set when the
+    // fallback timer is scheduled (or when report starts).
+    markRunAwaitingFinalAcceptance(runId);
     // User rates during the fallback delay: no accepted body yet.
     expect(
       shouldDeferRunFeedback({
@@ -3949,6 +3967,7 @@ describe('reportRunFeedback', () => {
       new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 }),
     );
 
+    markRunAwaitingFinalAcceptance(runId);
     expect(
       shouldDeferRunFeedback({
         runId,
@@ -4063,6 +4082,7 @@ describe('reportRunFeedback', () => {
     const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 207 }));
 
     try {
+      markRunAwaitingFinalAcceptance(runId);
       expect(
         shouldDeferRunFeedback({
           runId,
@@ -4148,6 +4168,7 @@ describe('reportRunFeedback', () => {
     const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
 
     try {
+      markRunAwaitingFinalAcceptance(runId);
       expect(
         shouldDeferRunFeedback({
           runId,

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -3298,6 +3298,11 @@ describe('reportRunFeedback', () => {
 
   beforeEach(() => {
     vi.useRealTimers();
+    resetAcceptedFinalTraceBodyIdsForTests();
+  });
+
+  afterEach(() => {
+    resetAcceptedFinalTraceBodyIdsForTests();
   });
 
   it('skips when metrics consent is off', async () => {
@@ -3334,5 +3339,58 @@ describe('reportRunFeedback', () => {
     expect(body.batch).toHaveLength(2);
     expect(body.batch[0].type).toBe('score-create');
     expect(body.batch[0].body.value).toBe(1);
+  });
+
+  it('attaches feedback to the terminal_fallback :tf body after a fallback-only completion', async () => {
+    resetAcceptedFinalTraceBodyIdsForTests();
+    const runId = 'run-fallback-feedback-e2e';
+    const expectedTraceId = scopedTelemetryBodyId(runId, 'final', 'terminal_fallback');
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ successes: [], errors: [] }), { status: 207 }),
+    );
+
+    // Fallback-only completion (failed run, no later telemetry-finalized message).
+    const completed = await reportRunCompleted(
+      makeCtx({
+        prefs: { metrics: true, content: true, artifactManifest: false },
+        run: {
+          runId,
+          status: 'failed',
+          startedAt: 1_700_000_000_000,
+          endedAt: 1_700_000_001_000,
+        },
+      }),
+      {
+        config: TEST_CONFIG,
+        fetchImpl: fetchSpy as any,
+        reportTrigger: 'terminal_fallback',
+      },
+    );
+    expect(completed).toEqual({
+      langfuse_expected: true,
+      langfuse_delivery_status: 'accepted',
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const completionBody = JSON.parse(fetchSpy.mock.calls[0]![1].body as string);
+    const completionTrace = completionBody.batch.find(
+      (item: { type: string }) => item.type === 'trace-create',
+    );
+    expect(completionTrace?.body?.id).toBe(expectedTraceId);
+
+    // User rates the failed run; scores must target the same :tf body id.
+    await reportRunFeedback(
+      makeFeedbackCtx({
+        runId,
+        reasonCodes: [],
+      }),
+      { config: TEST_CONFIG, fetchImpl: fetchSpy as any },
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const feedbackBody = JSON.parse(fetchSpy.mock.calls[1]![1].body as string);
+    expect(feedbackBody.batch).toHaveLength(1);
+    expect(feedbackBody.batch[0].type).toBe('score-create');
+    expect(feedbackBody.batch[0].body.traceId).toBe(expectedTraceId);
+    expect(feedbackBody.batch[0].body.id).toBe(`${expectedTraceId}-rating`);
+    expect(feedbackBody.batch[0].body.traceId).not.toBe(runId);
   });
 });

--- a/apps/daemon/tests/telemetry-message-finalization.test.ts
+++ b/apps/daemon/tests/telemetry-message-finalization.test.ts
@@ -484,6 +484,8 @@ describe('Langfuse message finalization gate', () => {
         insertId: 'run-accepted-headerless-finalize-langfuse-report-final_message-accepted',
         properties: expect.objectContaining({
           run_id: 'run-accepted-headerless-finalize',
+          // final_message keeps the canonical runId; only terminal_fallback scopes to :tf.
+          langfuse_trace_id: 'run-accepted-headerless-finalize',
           langfuse_delivery_status: 'accepted',
           langfuse_report_result: 'accepted',
           langfuse_report_trigger: 'final_message',

--- a/apps/daemon/tests/telemetry-message-finalization.test.ts
+++ b/apps/daemon/tests/telemetry-message-finalization.test.ts
@@ -269,6 +269,7 @@ describe('Langfuse message finalization gate', () => {
       persistedRunStatus: 'succeeded',
       persistedEndedAt: 1234,
       appVersion: { version: '0.7.0', channel: 'beta', packaged: true },
+      reportTrigger: 'final_message',
     });
   });
 
@@ -348,6 +349,12 @@ describe('Langfuse message finalization gate', () => {
     expect(report.mock.calls.map(([call]) => call.persistedEndedAt)).toEqual([
       1234,
       1235,
+    ]);
+    // Late-finalization path must thread distinct report triggers so Vela
+    // ingestion ids / Idempotency-Key do not collide between fallback and final.
+    expect(report.mock.calls.map(([call]) => call.reportTrigger)).toEqual([
+      'terminal_fallback',
+      'final_message',
     ]);
     expect(capture).toHaveBeenCalledTimes(3);
     expect(capture.mock.calls.map(([call]) => call.insertId)).toEqual(expect.arrayContaining([

--- a/apps/daemon/tests/telemetry-message-finalization.test.ts
+++ b/apps/daemon/tests/telemetry-message-finalization.test.ts
@@ -419,7 +419,7 @@ describe('Langfuse message finalization gate', () => {
         insertId: 'run-accepted-langfuse-report-terminal_fallback-accepted',
         properties: expect.objectContaining({
           run_id: 'run-accepted',
-          langfuse_trace_id: 'run-accepted',
+          langfuse_trace_id: 'run-accepted:tf',
           langfuse_expected: true,
           langfuse_delivery_status: 'accepted',
           langfuse_report_result: 'accepted',

--- a/apps/daemon/tests/telemetry-message-finalization.test.ts
+++ b/apps/daemon/tests/telemetry-message-finalization.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  clearRunAwaitingFinalAcceptance,
+  markRunAwaitingFinalAcceptance,
+  resetPendingRunFeedbackForTests,
+  shouldDeferRunFeedback,
+} from '../src/langfuse-trace.js';
+import {
   FORM_ANSWERED_GENERIC_OVERRIDE,
   composeChatUserRequestForAgent,
   createFinalizedMessageTelemetryReporter,
@@ -538,5 +544,76 @@ describe('Langfuse message finalization gate', () => {
         }),
       }),
     );
+  });
+
+  it('does not clear terminal_fallback awaiting tokens on ordinary non-final message writes', () => {
+    // During the failed/canceled terminal_fallback delay, web thumbs feedback
+    // may PUT /messages/:id without telemetryFinalized. That path must leave
+    // the schedule-time awaiting token intact so deferred scores still attach
+    // to the eventual runId:tf body instead of flushing on canonical runId.
+    resetPendingRunFeedbackForTests();
+    const runId = 'run-tf-delay-message-write';
+    markRunAwaitingFinalAcceptance(runId);
+    expect(shouldDeferRunFeedback({ runId })).toBe(true);
+
+    const report = vi.fn();
+    const reporter = createFinalizedMessageTelemetryReporter({
+      design: { runs: { get: vi.fn(() => undefined) } },
+      db: 'db',
+      dataDir: '/tmp/od-data',
+      reportedRuns: new Set<string>(),
+      report,
+    });
+
+    reporter(
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'partial',
+        runId,
+        runStatus: 'failed',
+      },
+      // Ordinary message update — no telemetryFinalized, no awaitingToken.
+      { content: 'partial with thumbs metadata' },
+    );
+
+    expect(report).not.toHaveBeenCalled();
+    expect(shouldDeferRunFeedback({ runId })).toBe(true);
+
+    clearRunAwaitingFinalAcceptance(runId);
+    expect(shouldDeferRunFeedback({ runId })).toBe(false);
+  });
+
+  it('releases only the provided schedule token when a non-final write cancels that attempt', () => {
+    resetPendingRunFeedbackForTests();
+    const runId = 'run-tf-cancel-specific-token';
+    const tokenTf = markRunAwaitingFinalAcceptance(runId);
+    const tokenOther = markRunAwaitingFinalAcceptance(runId);
+    expect(shouldDeferRunFeedback({ runId })).toBe(true);
+
+    const reporter = createFinalizedMessageTelemetryReporter({
+      design: { runs: { get: vi.fn(() => undefined) } },
+      db: 'db',
+      dataDir: '/tmp/od-data',
+      reportedRuns: new Set<string>(),
+      report: vi.fn(),
+    });
+
+    // Non-final path with the schedule token still releases only that attempt.
+    reporter(
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        content: 'still waiting',
+        runId,
+        runStatus: 'failed',
+      },
+      {},
+      { awaitingToken: tokenTf },
+    );
+
+    expect(shouldDeferRunFeedback({ runId })).toBe(true);
+    clearRunAwaitingFinalAcceptance(runId, tokenOther);
+    expect(shouldDeferRunFeedback({ runId })).toBe(false);
   });
 });

--- a/packages/contracts/src/analytics/events/shared-enums.ts
+++ b/packages/contracts/src/analytics/events/shared-enums.ts
@@ -361,6 +361,16 @@ export type TrackingLangfuseDropReason =
   | 'relay_5xx'
   | 'langfuse_4xx'
   | 'langfuse_5xx'
+  // Vela authenticated telemetry sink (daemon → Vela Control API).
+  | 'vela_400'
+  | 'vela_401'
+  | 'vela_403'
+  | 'vela_413'
+  | 'vela_429'
+  | 'vela_5xx'
+  // Transport failures: distinguish abort/timeout from other network errors
+  // so dashboards can separate upstream slowness from connectivity issues.
+  | 'timeout'
   | 'network_error';
 export type TrackingLangfuseReportResult =
   | 'accepted'

--- a/packages/contracts/tests/analytics-run-finished-contract.test.ts
+++ b/packages/contracts/tests/analytics-run-finished-contract.test.ts
@@ -168,4 +168,41 @@ describe('analytics run_finished contract', () => {
     expect(payload.props.langfuse_report_result).toBe('failed');
     expect(payload.props.langfuse_delivery_status).toBe('failed');
   });
+
+  it('accepts Vela sink and timeout langfuse_drop_reason values', () => {
+    const velaFailed = {
+      event: 'langfuse_report_result',
+      props: {
+        page_name: 'chat_panel',
+        area: 'chat_panel',
+        project_id: 'proj-1',
+        conversation_id: 'conv-1',
+        run_id: 'run-1',
+        langfuse_trace_id: 'run-1',
+        langfuse_expected: true,
+        langfuse_delivery_status: 'failed',
+        langfuse_drop_reason: 'vela_5xx',
+        langfuse_report_result: 'failed',
+        langfuse_report_trigger: 'terminal_fallback',
+        report_duration_ms: 50,
+        result: 'failed',
+        error_code: 'AGENT_EXECUTION_FAILED',
+        agent_provider_id: 'codex_cli',
+        model_id: 'default',
+      },
+    } satisfies Extract<AnalyticsEventPayload, { event: 'langfuse_report_result' }>;
+
+    const timedOut = {
+      event: 'run_finished',
+      props: {
+        ...makeBaseRunFinishedProps(),
+        langfuse_expected: true,
+        langfuse_delivery_status: 'failed',
+        langfuse_drop_reason: 'timeout',
+      },
+    } satisfies Extract<AnalyticsEventPayload, { event: 'run_finished' }>;
+
+    expect(velaFailed.props.langfuse_drop_reason).toBe('vela_5xx');
+    expect(timedOut.props.langfuse_drop_reason).toBe('timeout');
+  });
 });


### PR DESCRIPTION
## Summary

Implements Phase 3 of the Langfuse × Vela account integration for the Open Design daemon:

- When a Vela Control Key is present, completed-run / feedback telemetry posts the vendor-neutral envelope to `POST /api/v1/open-design/telemetry` (Bearer Control Key + stable Idempotency-Key).
- Without a Control Key, keep the existing anonymous telemetry relay / direct Langfuse path.
- Gray rollback: `OPEN_DESIGN_VELA_TELEMETRY=0|false|off|no`.
- Daemon only asserts installation identity (`identity_type=anonymous_installation`, `installation_id`); Vela injects trusted `app_user_id` / email server-side.
- Object-registration stays on the anonymous relay with distinct stable event IDs (`:reg`) so original `runId` object scope still works and final delivery is not deduped; registration omits turn text content.
- Threads app-config AMR env (`agentCliEnv.amr`) into sink selection.
- 401/403 may clear only a matching file-backed login for the same profile/key; explicit sinks never clear local login.
- Do not log Vela response bodies; classify fetch failures as `timeout` / `network_error`.

## Fallback rules

| Case | Behavior |
|---|---|
| No Control Key | Anonymous relay / Langfuse |
| Vela 401/403 | Clear matching file login (if applicable) + anonymous fallback |
| Vela 400 | Fail, no anonymous fallback |
| Vela 429/5xx / timeout | Retry Vela only (no anonymous overwrite) |
| Vela 202 | Accepted |

## Test plan

- [x] `apps/daemon` vitest: `langfuse-trace.test.ts` + `langfuse-bridge*.test.ts` (114 passed)
- [ ] Manual: logged-in AMR run → Langfuse trace has Vela-injected identity metadata
- [ ] Manual: logged-out run → anonymous installation identity still works
- [ ] Manual: object upload (attachments/artifacts) still succeeds when logged in
- [ ] Manual: `OPEN_DESIGN_VELA_TELEMETRY=0` forces anonymous path while logged in