### PR TITLE
fix(web): reveal rendered deck thumbnails

### DIFF
--- a/apps/web/src/components/DeckThumbnailRail.tsx
+++ b/apps/web/src/components/DeckThumbnailRail.tsx
@@ -121,13 +121,21 @@ const DeckThumbnailItem = memo(function DeckThumbnailItem({
   const [shadowFailed, setShadowFailed] = useState(false);
   useEffect(() => setShadowFailed(false), [parsedDeck, index]);
   const useShadow = parsedDeck !== null && !shadowFailed;
-  const [thumbnailReady, setThumbnailReady] = useState(false);
+  // Tie readiness to the renderer currently mounted in this item. Resetting a
+  // boolean from an effect races the shadow child's layout effect: the child
+  // can report ready first, then the parent's effect writes `false` and leaves
+  // the loading cover over an otherwise-rendered slide forever. A source key
+  // makes a new deck/fallback synchronously not-ready during render, while a
+  // ready callback can only mark the source it belongs to.
+  const thumbnailSource = useShadow ? parsedDeck : getSrcDoc;
+  const [readySource, setReadySource] = useState<typeof thumbnailSource | null>(null);
+  const thumbnailReady = mounted && readySource === thumbnailSource;
   useEffect(() => {
-    setThumbnailReady(false);
-  }, [mounted, useShadow, parsedDeck, index]);
-  const handleThumbnailReady = useCallback(() => setThumbnailReady(true), []);
+    if (!mounted) setReadySource(null);
+  }, [mounted]);
+  const handleThumbnailReady = useCallback(() => setReadySource(thumbnailSource), [thumbnailSource]);
   const handleShadowError = useCallback(() => {
-    setThumbnailReady(false);
+    setReadySource(null);
     setShadowFailed(true);
   }, []);
 

--- a/apps/web/tests/components/deck-thumbnail-rail.test.tsx
+++ b/apps/web/tests/components/deck-thumbnail-rail.test.tsx
@@ -132,4 +132,30 @@ describe('DeckThumbnailRail', () => {
     fireEvent.click(buttons[2]!);
     expect(onSelect).toHaveBeenCalledWith(2);
   });
+
+  it('removes the loading cover after a shadow thumbnail is ready', () => {
+    const width = vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(160);
+    const height = vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(90);
+    try {
+      const deck = `<!doctype html><html><head><style>
+        :root { --slide-bg: #fff; }
+        .deck-stage { width: 1920px; height: 1080px; }
+        .slide { background: var(--slide-bg); }
+      </style></head><body><div class="deck-stage" id="deck-stage">
+        <section class="slide active" data-screen-label="01">Visible slide</section>
+      </div></body></html>`;
+      const parsedDeck = parseDeckThumbnails(deck);
+      expect(parsedDeck.renderable).toBe(true);
+
+      const { container } = render(
+        <DeckThumbnailRail {...railProps({ count: 1, labelTotal: 1, parsedDeck })} />,
+      );
+
+      expect(container.querySelector('.deck-thumbnail-shadow-host')).toBeTruthy();
+      expect(container.querySelector('.deck-thumbnail-loading')).toBeNull();
+    } finally {
+      width.mockRestore();
+      height.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
## Why

A generated HTML slide deck rendered correctly in the main stage, but every miniature in the left thumbnail rail remained covered by the dark loading shimmer. This was reported while validating a real generated graduation-defense deck and made slide navigation look broken even though the deck itself had finished rendering.

The shadow thumbnail child reported readiness from its layout effect, then the parent item's passive reset effect wrote `thumbnailReady = false` afterward. The slide content existed underneath, but the loading cover stayed mounted forever.

## What users will see

Generated slide decks show the actual miniature for every mounted page after it is ready. The dark loading shimmer disappears instead of permanently covering the slide content.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Before: the reported deck showed a correctly rendered main slide while every left-rail thumbnail stayed behind the dark loading cover. The original report screenshot will be attached in the PR conversation because the GitHub API does not accept local image attachments in the PR body.

After: the regression test verifies that a ready shadow thumbnail contains its slide and no longer has a `.deck-thumbnail-loading` cover.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/deck-thumbnail-rail.test.tsx`
- Did the test go red on `main` and green on this branch? **Yes.** On `main`, the ready shadow thumbnail still retained `.deck-thumbnail-loading`; on this branch the cover is removed.

## Validation

- `corepack pnpm exec vitest run -c vitest.config.ts tests/components/deck-thumbnail-rail.test.tsx tests/components/deck-slide-thumbnail.test.tsx tests/runtime/deck-thumbnail-parser.test.ts --maxWorkers=2` — 25 passed
- `corepack pnpm test` in `apps/web` — 4,391 passed, 7 skipped
- `corepack pnpm guard`
- `corepack pnpm typecheck`
