### PR TITLE
fix overlapping text in slide image and PDF exports

### DIFF
--- a/apps/desktop/src/main/deck-capture.ts
+++ b/apps/desktop/src/main/deck-capture.ts
@@ -1329,11 +1329,11 @@ function showSlide(slideSelector: string, index: number): Promise<{ x: number; y
 
 // Serialized into the page: overlays a capture-only clone of the active slide in
 // the top-left viewport for decks that position the real slide elsewhere
-// (translated carousel strip). The real DOM tree stays in place so authored
-// transforms on the slide or its wrappers keep providing the clone offset, but
-// the source slide itself must stop painting while the clone is present. Leaving
-// a transparent source visible underneath the clone renders every child twice
-// (most noticeably large deck titles) in PNG/PDF/PPTX exports.
+// (translated carousel strip). The source slide itself must stop painting while
+// the clone is present, or every child renders twice. Align from the CLONE's live
+// rect after insertion: cloning outside a translated parent drops that parent's
+// transform, so reusing the source rect would apply the lost offset a second time
+// and move every off-stage clone out of the capture viewport.
 export function restackActiveSlide(slideSelector: string, index: number, w: number, h: number): void {
   document.getElementById("__od_export_active_slide_capture")?.remove();
   const slides = Array.prototype.slice
@@ -1341,7 +1341,6 @@ export function restackActiveSlide(slideSelector: string, index: number, w: numb
     .filter((el) => !(el as HTMLElement).closest(".mini-slide, .overview, .notes-overlay, .thumb"));
   const el = slides[index] as HTMLElement | undefined;
   if (!el) return;
-  const rect = el.getBoundingClientRect();
   const layer = document.createElement("div");
   layer.id = "__od_export_active_slide_capture";
   layer.setAttribute("aria-hidden", "true");
@@ -1365,7 +1364,6 @@ export function restackActiveSlide(slideSelector: string, index: number, w: numb
     "top:0",
     `width:${w}px`,
     `height:${h}px`,
-    `transform:${activeSlideCaptureOffsetTransform(rect)}`,
     "transform-origin:top left",
   ].join("!important;") + "!important";
 
@@ -1379,4 +1377,6 @@ export function restackActiveSlide(slideSelector: string, index: number, w: numb
   offset.appendChild(clone);
   layer.appendChild(offset);
   document.body.appendChild(layer);
+  const cloneRect = clone.getBoundingClientRect();
+  offset.style.setProperty("transform", activeSlideCaptureOffsetTransform(cloneRect), "important");
 }

--- a/apps/desktop/src/main/deck-capture.ts
+++ b/apps/desktop/src/main/deck-capture.ts
@@ -427,8 +427,9 @@ async function renderEditablePptx(
 // cannot return a stale composited frame of the previous slide — the
 // duplicate-page race `capturePage` exhibits); falls back to `capturePage` when
 // the debugger isn't attached. `scale: 1` because the window's device-pixel
-// ratio already provides the pixel scale (avoids double-scaling).
-async function captureDeckSlide(
+// ratio already provides the pixel scale (avoids double-scaling). Exported so
+// focused tests can exercise the real selection/restack/capture orchestration.
+export async function captureDeckSlide(
   window: BrowserWindow,
   dbg: Electron.Debugger | null,
   i: number,

--- a/apps/desktop/src/main/deck-capture.ts
+++ b/apps/desktop/src/main/deck-capture.ts
@@ -363,7 +363,7 @@ async function measureSlideStage(window: BrowserWindow): Promise<Stage> {
 // matters for long decks where the loop dominates.
 async function showDeckSlide(window: BrowserWindow, i: number, stage: Stage): Promise<void> {
   const rect = (await window.webContents.executeJavaScript(
-    `(${showSlide.toString()})(${JSON.stringify(SLIDE_SELECTOR)}, ${i})`,
+    `(() => { const restoreActiveSlideCapture = ${restoreActiveSlideCapture.toString()}; return (${showSlide.toString()})(${JSON.stringify(SLIDE_SELECTOR)}, ${i}); })()`,
     true,
   )) as { x: number; y: number; w: number; h: number } | null;
   // If the active slide did not land in the top-left capture viewport (a
@@ -377,7 +377,7 @@ async function showDeckSlide(window: BrowserWindow, i: number, stage: Stage): Pr
     rect.h >= stage.h * 0.5;
   if (!onStage) {
     await window.webContents.executeJavaScript(
-      `(() => { const activeSlideCaptureOffsetTransform = ${activeSlideCaptureOffsetTransform.toString()}; return (${restackActiveSlide.toString()})(${JSON.stringify(SLIDE_SELECTOR)}, ${i}, ${stage.w}, ${stage.h}); })()`,
+      `(() => { const activeSlideCaptureOffsetTransform = ${activeSlideCaptureOffsetTransform.toString()}; const restoreActiveSlideCapture = ${restoreActiveSlideCapture.toString()}; return (${restackActiveSlide.toString()})(${JSON.stringify(SLIDE_SELECTOR)}, ${i}, ${stage.w}, ${stage.h}); })()`,
       true,
     );
     await nextFrames(window);
@@ -1289,10 +1289,33 @@ function positiveCssNumber(value: unknown): number | null {
   return Number.isFinite(n) && n > 1 ? n : null;
 }
 
+// Restores the live slide moved into the capture layer before the next slide is
+// selected. The temporary style overrides are capture-only and must not leak
+// into later selector/index passes.
+export function restoreActiveSlideCapture(): void {
+  const layer = document.getElementById("__od_export_active_slide_capture") as
+    | (HTMLElement & {
+        __odSourceStyles?: Array<{ name: string; priority: string; value: string }>;
+      })
+    | null;
+  if (!layer) return;
+  const placeholder = document.getElementById("__od_export_active_slide_placeholder");
+  const liveSlide = layer.firstElementChild?.firstElementChild as HTMLElement | null;
+  if (placeholder?.parentNode && liveSlide) {
+    placeholder.parentNode.moveBefore(liveSlide, placeholder);
+    placeholder.remove();
+    for (const { name, priority, value } of layer.__odSourceStyles ?? []) {
+      if (value) liveSlide.style.setProperty(name, value, priority);
+      else liveSlide.style.removeProperty(name);
+    }
+  }
+  layer.remove();
+}
+
 // Returns a Promise that resolves after the style change has settled for two
 // animation frames, so the caller can show + wait in a single round trip.
 function showSlide(slideSelector: string, index: number): Promise<{ x: number; y: number; w: number; h: number } | null> {
-  document.getElementById("__od_export_active_slide_capture")?.remove();
+  restoreActiveSlideCapture();
   const slides = Array.prototype.slice
     .call(document.querySelectorAll(slideSelector))
     .filter((el) => !(el as HTMLElement).closest(".mini-slide, .overview, .notes-overlay, .thumb"));
@@ -1327,15 +1350,16 @@ function showSlide(slideSelector: string, index: number): Promise<{ x: number; y
   });
 }
 
-// Serialized into the page: overlays a capture-only clone of the active slide in
-// the top-left viewport for decks that position the real slide elsewhere
-// (translated carousel strip). The source slide itself must stop painting while
-// the clone is present, or every child renders twice. Align from the CLONE's live
-// rect after insertion: cloning outside a translated parent drops that parent's
-// transform, so reusing the source rect would apply the lost offset a second time
-// and move every off-stage clone out of the capture viewport.
+// Serialized into the page: temporarily moves the live active slide into a
+// capture-only layer for decks that position it outside the viewport (translated
+// carousel strip). A state-preserving DOM move rather than cloning keeps
+// canvas/WebGL bitmaps, media frames, iframe browsing state, and other runtime
+// content continuously connected in the only paintable subtree. Align from its
+// live rect after insertion: moving outside a translated parent drops that
+// parent's transform, so reusing the source rect would apply the lost offset a
+// second time.
 export function restackActiveSlide(slideSelector: string, index: number, w: number, h: number): void {
-  document.getElementById("__od_export_active_slide_capture")?.remove();
+  restoreActiveSlideCapture();
   const slides = Array.prototype.slice
     .call(document.querySelectorAll(slideSelector))
     .filter((el) => !(el as HTMLElement).closest(".mini-slide, .overview, .notes-overlay, .thumb"));
@@ -1367,16 +1391,24 @@ export function restackActiveSlide(slideSelector: string, index: number, w: numb
     "transform-origin:top left",
   ].join("!important;") + "!important";
 
-  const clone = el.cloneNode(true) as HTMLElement;
-  clone.style.setProperty("opacity", "1", "important");
-  clone.style.setProperty("visibility", "visible", "important");
-  clone.style.setProperty("pointer-events", "none", "important");
-  clone.style.setProperty("z-index", "2147483647", "important");
-  el.style.setProperty("opacity", "0", "important");
-  el.style.setProperty("visibility", "hidden", "important");
-  offset.appendChild(clone);
+  const sourceStyleNames = ["opacity", "visibility", "pointer-events", "z-index"];
+  (layer as typeof layer & {
+    __odSourceStyles: Array<{ name: string; priority: string; value: string }>;
+  }).__odSourceStyles = sourceStyleNames.map((name) => ({
+    name,
+    priority: el.style.getPropertyPriority(name),
+    value: el.style.getPropertyValue(name),
+  }));
+  const placeholder = document.createElement("template");
+  placeholder.id = "__od_export_active_slide_placeholder";
+  el.before(placeholder);
   layer.appendChild(offset);
   document.body.appendChild(layer);
-  const cloneRect = clone.getBoundingClientRect();
-  offset.style.setProperty("transform", activeSlideCaptureOffsetTransform(cloneRect), "important");
+  el.style.setProperty("opacity", "1", "important");
+  el.style.setProperty("visibility", "visible", "important");
+  el.style.setProperty("pointer-events", "none", "important");
+  el.style.setProperty("z-index", "2147483647", "important");
+  offset.moveBefore(el, null);
+  const liveRect = el.getBoundingClientRect();
+  offset.style.setProperty("transform", activeSlideCaptureOffsetTransform(liveRect), "important");
 }

--- a/apps/desktop/src/main/deck-capture.ts
+++ b/apps/desktop/src/main/deck-capture.ts
@@ -1329,10 +1329,12 @@ function showSlide(slideSelector: string, index: number): Promise<{ x: number; y
 
 // Serialized into the page: overlays a capture-only clone of the active slide in
 // the top-left viewport for decks that position the real slide elsewhere
-// (translated carousel strip). The real DOM tree is left intact: authored
-// transforms on the slide or its wrappers must continue to affect layout exactly
-// as they do in the preview.
-function restackActiveSlide(slideSelector: string, index: number, w: number, h: number): void {
+// (translated carousel strip). The real DOM tree stays in place so authored
+// transforms on the slide or its wrappers keep providing the clone offset, but
+// the source slide itself must stop painting while the clone is present. Leaving
+// a transparent source visible underneath the clone renders every child twice
+// (most noticeably large deck titles) in PNG/PDF/PPTX exports.
+export function restackActiveSlide(slideSelector: string, index: number, w: number, h: number): void {
   document.getElementById("__od_export_active_slide_capture")?.remove();
   const slides = Array.prototype.slice
     .call(document.querySelectorAll(slideSelector))
@@ -1372,6 +1374,8 @@ function restackActiveSlide(slideSelector: string, index: number, w: number, h: 
   clone.style.setProperty("visibility", "visible", "important");
   clone.style.setProperty("pointer-events", "none", "important");
   clone.style.setProperty("z-index", "2147483647", "important");
+  el.style.setProperty("opacity", "0", "important");
+  el.style.setProperty("visibility", "hidden", "important");
   offset.appendChild(clone);
   layer.appendChild(offset);
   document.body.appendChild(layer);

--- a/apps/desktop/tests/main/scroll-stitch-geometry.test.ts
+++ b/apps/desktop/tests/main/scroll-stitch-geometry.test.ts
@@ -112,7 +112,7 @@ describe('deck capture DOM prep', () => {
     );
   });
 
-  test('off-stage slide fallback captures the live canvas instead of a structural clone', () => {
+  test('off-stage slide fallback preserves live content across a multi-slide restore cycle', () => {
     class FakeStyle {
       cssText = '';
       private readonly values = new Map<string, { priority: string; value: string }>();
@@ -220,14 +220,21 @@ describe('deck capture DOM prep', () => {
       setAttribute(): void {}
     }
 
-    const runtimeFrame = Symbol('painted chart frame');
-    const canvas = new FakeElement();
-    canvas.runtimeFrame = runtimeFrame;
-    const slide = new FakeElement();
-    slide.style.setProperty('opacity', '1');
-    slide.appendChild(canvas);
+    const firstRuntimeFrame = Symbol('first painted chart frame');
+    const laterRuntimeFrame = Symbol('later painted chart frame');
+    const firstCanvas = new FakeElement();
+    firstCanvas.runtimeFrame = firstRuntimeFrame;
+    const laterCanvas = new FakeElement();
+    laterCanvas.runtimeFrame = laterRuntimeFrame;
+    const firstSlide = new FakeElement({ x: 1920, y: 0 });
+    firstSlide.style.setProperty('opacity', '1');
+    firstSlide.appendChild(firstCanvas);
+    const laterSlide = new FakeElement({ x: 2880, y: 0 });
+    laterSlide.style.setProperty('opacity', '0');
+    laterSlide.appendChild(laterCanvas);
     const body = new FakeElement();
-    body.appendChild(slide);
+    body.appendChild(firstSlide);
+    body.appendChild(laterSlide);
     const findById = (root: FakeElement, id: string): FakeElement | null => {
       if (root.id === id) return root;
       for (const child of root.children) {
@@ -236,11 +243,17 @@ describe('deck capture DOM prep', () => {
       }
       return null;
     };
+    const slidesInDocumentOrder = (root: FakeElement): FakeElement[] => {
+      const slides: FakeElement[] = [];
+      if (root === firstSlide || root === laterSlide) slides.push(root);
+      for (const child of root.children) slides.push(...slidesInDocumentOrder(child));
+      return slides;
+    };
     const fakeDocument = {
       body,
       createElement: () => new FakeElement({ x: 0, y: 0 }, true),
       getElementById: (id: string) => findById(body, id),
-      querySelectorAll: () => [slide],
+      querySelectorAll: () => slidesInDocumentOrder(body),
     };
     const previousDocument = globalThis.document;
     Object.assign(globalThis, { document: fakeDocument });
@@ -254,9 +267,9 @@ describe('deck capture DOM prep', () => {
       // cloneNode(true) would produce a blank canvas. The live slide must be the
       // sole paintable capture subtree so its current canvas/WebGL/media state is
       // preserved without rendering the slide's ordinary DOM twice.
-      expect(capturedSlide).toBe(slide);
-      expect(capturedSlide?.children[0]).toBe(canvas);
-      expect(capturedSlide?.children[0]?.runtimeFrame).toBe(runtimeFrame);
+      expect(capturedSlide).toBe(firstSlide);
+      expect(capturedSlide?.children[0]).toBe(firstCanvas);
+      expect(capturedSlide?.children[0]?.runtimeFrame).toBe(firstRuntimeFrame);
       // Align from the moved slide's live rect. Reusing the source rect would
       // apply the translated parent's offset a second time and move it off-screen.
       expect(offset?.style.getPropertyValue('transform')).toBe('translate(0px, 0px)');
@@ -264,11 +277,29 @@ describe('deck capture DOM prep', () => {
 
       restoreActiveSlideCapture();
       expect(findById(body, '__od_export_active_slide_capture')).toBeNull();
-      expect(body.children[0]).toBe(slide);
-      expect(slide.children[0]).toBe(canvas);
-      expect(slide.style.getPropertyValue('opacity')).toBe('1');
-      expect(slide.style.getPropertyPriority('opacity')).toBe('');
+      expect(firstSlide.children[0]).toBe(firstCanvas);
+      expect(firstSlide.style.getPropertyValue('opacity')).toBe('1');
+      expect(firstSlide.style.getPropertyPriority('opacity')).toBe('');
+
+      restackActiveSlide('.slide', 1, 960, 540);
+      const laterLayer = findById(body, '__od_export_active_slide_capture');
+      const laterOffset = laterLayer?.children[0];
+      const laterCapturedSlide = laterOffset?.children[0];
+
+      // Restoring the first slide must preserve selector order before the next
+      // off-stage capture. Otherwise index 1 can select the first slide again,
+      // leaving the later exported page blank or duplicated.
+      expect(laterCapturedSlide).toBe(laterSlide);
+      expect(laterCapturedSlide?.children[0]).toBe(laterCanvas);
+      expect(laterCapturedSlide?.children[0]?.runtimeFrame).toBe(laterRuntimeFrame);
+      expect(laterOffset?.style.getPropertyValue('transform')).toBe('translate(0px, 0px)');
+
+      restoreActiveSlideCapture();
+      expect(body.children).toEqual([firstSlide, laterSlide]);
+      expect(laterSlide.children[0]?.runtimeFrame).toBe(laterRuntimeFrame);
+      expect(laterSlide.style.getPropertyValue('opacity')).toBe('0');
     } finally {
+      restoreActiveSlideCapture();
       Object.assign(globalThis, { document: previousDocument });
     }
   });

--- a/apps/desktop/tests/main/scroll-stitch-geometry.test.ts
+++ b/apps/desktop/tests/main/scroll-stitch-geometry.test.ts
@@ -144,6 +144,8 @@ describe('deck capture DOM prep', () => {
       parentElement: FakeElement | null = null;
       style = new FakeStyle();
 
+      constructor(private readonly rect: { x: number; y: number } = { x: 32, y: 24 }) {}
+
       appendChild(child: FakeElement): FakeElement {
         child.parentElement = this;
         this.children.push(child);
@@ -151,7 +153,9 @@ describe('deck capture DOM prep', () => {
       }
 
       cloneNode(): FakeElement {
-        const clone = new FakeElement();
+        // The source is off-stage because its parent deck is translated. Once
+        // cloned outside that parent, the clone itself starts at the origin.
+        const clone = new FakeElement({ x: 0, y: 0 });
         clone.style = this.style.clone();
         return clone;
       }
@@ -161,7 +165,7 @@ describe('deck capture DOM prep', () => {
       }
 
       getBoundingClientRect(): DOMRect {
-        return { x: 32, y: 24 } as DOMRect;
+        return this.rect as DOMRect;
       }
 
       remove(): void {
@@ -206,9 +210,14 @@ describe('deck capture DOM prep', () => {
     expect(slide.style.getPropertyPriority('opacity')).toBe('important');
 
     const layer = findById(body, '__od_export_active_slide_capture');
-    const clone = layer?.children[0]?.children[0];
+    const offset = layer?.children[0];
+    const clone = offset?.children[0];
     expect(clone?.style.getPropertyValue('opacity')).toBe('1');
     expect(clone?.style.getPropertyPriority('opacity')).toBe('important');
+    // Align from the clone's live rect. Reusing the source rect would apply the
+    // translated parent's offset a second time and move this clone off-screen.
+    expect(offset?.style.getPropertyValue('transform')).toBe('translate(0px, 0px)');
+    expect(offset?.style.getPropertyPriority('transform')).toBe('important');
   });
 });
 

--- a/apps/desktop/tests/main/scroll-stitch-geometry.test.ts
+++ b/apps/desktop/tests/main/scroll-stitch-geometry.test.ts
@@ -13,6 +13,7 @@ import {
   readDomToPptxBundleFile,
   requestedRenderSize,
   restackActiveSlide,
+  restoreActiveSlideCapture,
   runDomToPptx,
   scrollStitchGeometry,
   scrollStitchRowOffset,
@@ -111,7 +112,7 @@ describe('deck capture DOM prep', () => {
     );
   });
 
-  test('off-stage slide fallback leaves only the capture clone visible', () => {
+  test('off-stage slide fallback captures the live canvas instead of a structural clone', () => {
     class FakeStyle {
       cssText = '';
       private readonly values = new Map<string, { priority: string; value: string }>();
@@ -128,6 +129,10 @@ describe('deck capture DOM prep', () => {
         return this.values.get(name)?.value ?? '';
       }
 
+      removeProperty(name: string): void {
+        this.values.delete(name);
+      }
+
       clone(): FakeStyle {
         const style = new FakeStyle();
         style.cssText = this.cssText;
@@ -142,21 +147,43 @@ describe('deck capture DOM prep', () => {
       children: FakeElement[] = [];
       id = '';
       parentElement: FakeElement | null = null;
+      runtimeFrame: symbol | undefined;
       style = new FakeStyle();
 
-      constructor(private readonly rect: { x: number; y: number } = { x: 32, y: 24 }) {}
+      constructor(
+        private rect: { x: number; y: number } = { x: 32, y: 24 },
+        private readonly restacksChildren = false,
+      ) {}
+
+      get firstElementChild(): FakeElement | null {
+        return this.children[0] ?? null;
+      }
+
+      get parentNode(): FakeElement | null {
+        return this.parentElement;
+      }
 
       appendChild(child: FakeElement): FakeElement {
+        child.remove();
         child.parentElement = this;
+        if (this.restacksChildren) child.rect = { x: 0, y: 0 };
         this.children.push(child);
         return child;
       }
 
-      cloneNode(): FakeElement {
+      before(sibling: FakeElement): void {
+        this.parentElement?.moveBefore(sibling, this);
+      }
+
+      cloneNode(deep = false): FakeElement {
         // The source is off-stage because its parent deck is translated. Once
-        // cloned outside that parent, the clone itself starts at the origin.
+        // cloned outside that parent, the clone itself starts at the origin,
+        // but runtime-rendered state such as a canvas bitmap is not cloned.
         const clone = new FakeElement({ x: 0, y: 0 });
         clone.style = this.style.clone();
+        if (deep) {
+          for (const child of this.children) clone.appendChild(child.cloneNode(true));
+        }
         return clone;
       }
 
@@ -172,13 +199,33 @@ describe('deck capture DOM prep', () => {
         if (!this.parentElement) return;
         this.parentElement.children = this.parentElement.children.filter((child) => child !== this);
         this.parentElement = null;
+        this.clearRuntimeFrames();
+      }
+
+      moveBefore(child: FakeElement, reference: FakeElement | null): void {
+        if (child.parentElement) {
+          child.parentElement.children = child.parentElement.children.filter((entry) => entry !== child);
+        }
+        const index = reference == null ? this.children.length : this.children.indexOf(reference);
+        child.parentElement = this;
+        if (this.restacksChildren) child.rect = { x: 0, y: 0 };
+        this.children.splice(index, 0, child);
+      }
+
+      private clearRuntimeFrames(): void {
+        this.runtimeFrame = undefined;
+        for (const child of this.children) child.clearRuntimeFrames();
       }
 
       setAttribute(): void {}
     }
 
+    const runtimeFrame = Symbol('painted chart frame');
+    const canvas = new FakeElement();
+    canvas.runtimeFrame = runtimeFrame;
     const slide = new FakeElement();
     slide.style.setProperty('opacity', '1');
+    slide.appendChild(canvas);
     const body = new FakeElement();
     body.appendChild(slide);
     const findById = (root: FakeElement, id: string): FakeElement | null => {
@@ -191,7 +238,7 @@ describe('deck capture DOM prep', () => {
     };
     const fakeDocument = {
       body,
-      createElement: () => new FakeElement(),
+      createElement: () => new FakeElement({ x: 0, y: 0 }, true),
       getElementById: (id: string) => findById(body, id),
       querySelectorAll: () => [slide],
     };
@@ -199,25 +246,31 @@ describe('deck capture DOM prep', () => {
     Object.assign(globalThis, { document: fakeDocument });
     try {
       restackActiveSlide('.slide', 0, 960, 540);
+
+      const layer = findById(body, '__od_export_active_slide_capture');
+      const offset = layer?.children[0];
+      const capturedSlide = offset?.children[0];
+
+      // cloneNode(true) would produce a blank canvas. The live slide must be the
+      // sole paintable capture subtree so its current canvas/WebGL/media state is
+      // preserved without rendering the slide's ordinary DOM twice.
+      expect(capturedSlide).toBe(slide);
+      expect(capturedSlide?.children[0]).toBe(canvas);
+      expect(capturedSlide?.children[0]?.runtimeFrame).toBe(runtimeFrame);
+      // Align from the moved slide's live rect. Reusing the source rect would
+      // apply the translated parent's offset a second time and move it off-screen.
+      expect(offset?.style.getPropertyValue('transform')).toBe('translate(0px, 0px)');
+      expect(offset?.style.getPropertyPriority('transform')).toBe('important');
+
+      restoreActiveSlideCapture();
+      expect(findById(body, '__od_export_active_slide_capture')).toBeNull();
+      expect(body.children[0]).toBe(slide);
+      expect(slide.children[0]).toBe(canvas);
+      expect(slide.style.getPropertyValue('opacity')).toBe('1');
+      expect(slide.style.getPropertyPriority('opacity')).toBe('');
     } finally {
       Object.assign(globalThis, { document: previousDocument });
     }
-
-    // Transparent slides otherwise paint twice: the translated source stays
-    // visible underneath the clone restacked at (0, 0), producing the exact
-    // offset title/body overlap seen in PDF and image exports.
-    expect(slide.style.getPropertyValue('opacity')).toBe('0');
-    expect(slide.style.getPropertyPriority('opacity')).toBe('important');
-
-    const layer = findById(body, '__od_export_active_slide_capture');
-    const offset = layer?.children[0];
-    const clone = offset?.children[0];
-    expect(clone?.style.getPropertyValue('opacity')).toBe('1');
-    expect(clone?.style.getPropertyPriority('opacity')).toBe('important');
-    // Align from the clone's live rect. Reusing the source rect would apply the
-    // translated parent's offset a second time and move this clone off-screen.
-    expect(offset?.style.getPropertyValue('transform')).toBe('translate(0px, 0px)');
-    expect(offset?.style.getPropertyPriority('transform')).toBe('important');
   });
 });
 

--- a/apps/desktop/tests/main/scroll-stitch-geometry.test.ts
+++ b/apps/desktop/tests/main/scroll-stitch-geometry.test.ts
@@ -8,11 +8,11 @@ import { gzip } from 'node:zlib';
 import {
   HIDE_CHROME_SELECTOR,
   activeSlideCaptureOffsetTransform,
+  captureDeckSlide,
   measureAuthoredSlideBox,
   paginateViewportBand,
   readDomToPptxBundleFile,
   requestedRenderSize,
-  restackActiveSlide,
   restoreActiveSlideCapture,
   runDomToPptx,
   scrollStitchGeometry,
@@ -112,7 +112,7 @@ describe('deck capture DOM prep', () => {
     );
   });
 
-  test('off-stage slide fallback preserves live content across a multi-slide restore cycle', () => {
+  test('off-stage slide capture preserves live content across consecutive exported pages', async () => {
     class FakeStyle {
       cssText = '';
       private readonly values = new Map<string, { priority: string; value: string }>();
@@ -127,6 +127,30 @@ describe('deck capture DOM prep', () => {
 
       getPropertyValue(name: string): string {
         return this.values.get(name)?.value ?? '';
+      }
+
+      set animation(value: string) {
+        this.setProperty('animation', value);
+      }
+
+      set opacity(value: string) {
+        this.setProperty('opacity', value);
+      }
+
+      set pointerEvents(value: string) {
+        this.setProperty('pointer-events', value);
+      }
+
+      set transition(value: string) {
+        this.setProperty('transition', value);
+      }
+
+      set visibility(value: string) {
+        this.setProperty('visibility', value);
+      }
+
+      set zIndex(value: string) {
+        this.setProperty('z-index', value);
       }
 
       removeProperty(name: string): void {
@@ -149,6 +173,7 @@ describe('deck capture DOM prep', () => {
       parentElement: FakeElement | null = null;
       runtimeFrame: symbol | undefined;
       style = new FakeStyle();
+      classList = { toggle: () => true };
 
       constructor(
         private rect: { x: number; y: number } = { x: 32, y: 24 },
@@ -192,7 +217,7 @@ describe('deck capture DOM prep', () => {
       }
 
       getBoundingClientRect(): DOMRect {
-        return this.rect as DOMRect;
+        return { ...this.rect, height: 540, width: 960 } as DOMRect;
       }
 
       remove(): void {
@@ -255,14 +280,40 @@ describe('deck capture DOM prep', () => {
       getElementById: (id: string) => findById(body, id),
       querySelectorAll: () => slidesInDocumentOrder(body),
     };
+    const capturedSlides: FakeElement[] = [];
+    const captureWindow = {
+      webContents: {
+        async executeJavaScript(script: string) {
+          const evaluate = new Function('document', 'requestAnimationFrame', `return ${script};`);
+          const requestAnimationFrame = (callback: (timestamp: number) => void): number => {
+            callback(0);
+            return 0;
+          };
+          return await evaluate(fakeDocument, requestAnimationFrame) as unknown;
+        },
+        async capturePage() {
+          const layer = findById(body, '__od_export_active_slide_capture');
+          const capturedSlide = layer?.children[0]?.children[0];
+          if (!capturedSlide) throw new Error('capture layer has no active slide');
+          capturedSlides.push(capturedSlide);
+          return { runtimeFrame: capturedSlide.children[0]?.runtimeFrame };
+        },
+      },
+    };
+    const browserWindow = captureWindow as unknown as Parameters<typeof captureDeckSlide>[0];
     const previousDocument = globalThis.document;
     Object.assign(globalThis, { document: fakeDocument });
     try {
-      restackActiveSlide('.slide', 0, 960, 540);
+      const firstImage = await captureDeckSlide(
+        browserWindow,
+        null,
+        0,
+        { h: 540, w: 960 },
+      );
 
       const layer = findById(body, '__od_export_active_slide_capture');
       const offset = layer?.children[0];
-      const capturedSlide = offset?.children[0];
+      const capturedSlide = capturedSlides[0];
 
       // cloneNode(true) would produce a blank canvas. The live slide must be the
       // sole paintable capture subtree so its current canvas/WebGL/media state is
@@ -270,34 +321,41 @@ describe('deck capture DOM prep', () => {
       expect(capturedSlide).toBe(firstSlide);
       expect(capturedSlide?.children[0]).toBe(firstCanvas);
       expect(capturedSlide?.children[0]?.runtimeFrame).toBe(firstRuntimeFrame);
+      expect((firstImage as unknown as { runtimeFrame?: symbol }).runtimeFrame).toBe(
+        firstRuntimeFrame,
+      );
       // Align from the moved slide's live rect. Reusing the source rect would
       // apply the translated parent's offset a second time and move it off-screen.
       expect(offset?.style.getPropertyValue('transform')).toBe('translate(0px, 0px)');
       expect(offset?.style.getPropertyPriority('transform')).toBe('important');
 
-      restoreActiveSlideCapture();
-      expect(findById(body, '__od_export_active_slide_capture')).toBeNull();
-      expect(firstSlide.children[0]).toBe(firstCanvas);
-      expect(firstSlide.style.getPropertyValue('opacity')).toBe('1');
-      expect(firstSlide.style.getPropertyPriority('opacity')).toBe('');
-
-      restackActiveSlide('.slide', 1, 960, 540);
+      const laterImage = await captureDeckSlide(
+        browserWindow,
+        null,
+        1,
+        { h: 540, w: 960 },
+      );
       const laterLayer = findById(body, '__od_export_active_slide_capture');
       const laterOffset = laterLayer?.children[0];
-      const laterCapturedSlide = laterOffset?.children[0];
+      const laterCapturedSlide = capturedSlides[1];
 
-      // Restoring the first slide must preserve selector order before the next
-      // off-stage capture. Otherwise index 1 can select the first slide again,
-      // leaving the later exported page blank or duplicated.
+      // captureDeckSlide() selects through showDeckSlide(), which restores the
+      // first off-stage slide before querying and restacking the second. A lost
+      // runtime frame or wrong selector order makes this later export blank or
+      // duplicate the first page instead of returning populated slide content.
       expect(laterCapturedSlide).toBe(laterSlide);
       expect(laterCapturedSlide?.children[0]).toBe(laterCanvas);
       expect(laterCapturedSlide?.children[0]?.runtimeFrame).toBe(laterRuntimeFrame);
+      expect((laterImage as unknown as { runtimeFrame?: symbol }).runtimeFrame).toBe(
+        laterRuntimeFrame,
+      );
       expect(laterOffset?.style.getPropertyValue('transform')).toBe('translate(0px, 0px)');
 
       restoreActiveSlideCapture();
       expect(body.children).toEqual([firstSlide, laterSlide]);
+      expect(firstSlide.children[0]?.runtimeFrame).toBe(firstRuntimeFrame);
       expect(laterSlide.children[0]?.runtimeFrame).toBe(laterRuntimeFrame);
-      expect(laterSlide.style.getPropertyValue('opacity')).toBe('0');
+      expect(capturedSlides).toEqual([firstSlide, laterSlide]);
     } finally {
       restoreActiveSlideCapture();
       Object.assign(globalThis, { document: previousDocument });

--- a/apps/desktop/tests/main/scroll-stitch-geometry.test.ts
+++ b/apps/desktop/tests/main/scroll-stitch-geometry.test.ts
@@ -12,6 +12,7 @@ import {
   paginateViewportBand,
   readDomToPptxBundleFile,
   requestedRenderSize,
+  restackActiveSlide,
   runDomToPptx,
   scrollStitchGeometry,
   scrollStitchRowOffset,
@@ -108,6 +109,106 @@ describe('deck capture DOM prep', () => {
     expect(activeSlideCaptureOffsetTransform({ x: 3840, y: -120 })).toBe(
       'translate(-3840px, 120px)',
     );
+  });
+
+  test('off-stage slide fallback leaves only the capture clone visible', () => {
+    class FakeStyle {
+      cssText = '';
+      private readonly values = new Map<string, { priority: string; value: string }>();
+
+      setProperty(name: string, value: string, priority = ''): void {
+        this.values.set(name, { priority, value });
+      }
+
+      getPropertyPriority(name: string): string {
+        return this.values.get(name)?.priority ?? '';
+      }
+
+      getPropertyValue(name: string): string {
+        return this.values.get(name)?.value ?? '';
+      }
+
+      clone(): FakeStyle {
+        const style = new FakeStyle();
+        style.cssText = this.cssText;
+        for (const [name, entry] of this.values) {
+          style.setProperty(name, entry.value, entry.priority);
+        }
+        return style;
+      }
+    }
+
+    class FakeElement {
+      children: FakeElement[] = [];
+      id = '';
+      parentElement: FakeElement | null = null;
+      style = new FakeStyle();
+
+      appendChild(child: FakeElement): FakeElement {
+        child.parentElement = this;
+        this.children.push(child);
+        return child;
+      }
+
+      cloneNode(): FakeElement {
+        const clone = new FakeElement();
+        clone.style = this.style.clone();
+        return clone;
+      }
+
+      closest(): null {
+        return null;
+      }
+
+      getBoundingClientRect(): DOMRect {
+        return { x: 32, y: 24 } as DOMRect;
+      }
+
+      remove(): void {
+        if (!this.parentElement) return;
+        this.parentElement.children = this.parentElement.children.filter((child) => child !== this);
+        this.parentElement = null;
+      }
+
+      setAttribute(): void {}
+    }
+
+    const slide = new FakeElement();
+    slide.style.setProperty('opacity', '1');
+    const body = new FakeElement();
+    body.appendChild(slide);
+    const findById = (root: FakeElement, id: string): FakeElement | null => {
+      if (root.id === id) return root;
+      for (const child of root.children) {
+        const found = findById(child, id);
+        if (found) return found;
+      }
+      return null;
+    };
+    const fakeDocument = {
+      body,
+      createElement: () => new FakeElement(),
+      getElementById: (id: string) => findById(body, id),
+      querySelectorAll: () => [slide],
+    };
+    const previousDocument = globalThis.document;
+    Object.assign(globalThis, { document: fakeDocument });
+    try {
+      restackActiveSlide('.slide', 0, 960, 540);
+    } finally {
+      Object.assign(globalThis, { document: previousDocument });
+    }
+
+    // Transparent slides otherwise paint twice: the translated source stays
+    // visible underneath the clone restacked at (0, 0), producing the exact
+    // offset title/body overlap seen in PDF and image exports.
+    expect(slide.style.getPropertyValue('opacity')).toBe('0');
+    expect(slide.style.getPropertyPriority('opacity')).toBe('important');
+
+    const layer = findById(body, '__od_export_active_slide_capture');
+    const clone = layer?.children[0]?.children[0];
+    expect(clone?.style.getPropertyValue('opacity')).toBe('1');
+    expect(clone?.style.getPropertyPriority('opacity')).toBe('important');
   });
 });
 


### PR DESCRIPTION
## Why

Slide titles and other content could render twice with a small offset in exported images and raster PDFs. The PDF assembly step was not the source of that problem: it embedded an already-duplicated per-slide PNG.

A related multi-page failure became visible while validating the first fix. The off-stage fallback cloned the active slide outside its translated deck container, but aligned that clone using the source slide's rect. Because the clone no longer inherited the parent's translation, applying the source offset again moved off-stage pages out of the capture viewport. The renderer returned the expected number of files, but pages after the first could be blank.

## What users will see

Exported slide images and screenshot-based PDFs/PPTXs now render each title, body block, and card once. Whole-deck PNG exports include every slide, and raster PDFs include one populated page per slide, including decks that translate a flex strip or otherwise position the active slide outside the capture viewport.

## Surface area

- [ ] **UI** — new or changed screens/components
- [ ] **Keyboard shortcut** — added/changed bindings
- [ ] **CLI / env** — new or changed flags, subcommands, or environment variables
- [ ] **API / contract** — request/response or SSE shape changed
- [ ] **Extension point** — `skills/`, `design-systems/`, `design-templates/`, or `craft/`
- [ ] **i18n** — user-facing copy added or changed
- [ ] **New top-level dependency** — `package.json` root dependency added
- [x] **Default behavior change** — existing users will see different behavior without opting in
- [ ] **None of the above**

## Screenshots

Not applicable — no UI entry point changed. Visual validation covered the Electron-rendered slide PNGs, the stitched whole-deck PNG, and every Poppler-rendered PDF page.

## Bug fix verification

- Red spec: `apps/desktop/tests/main/scroll-stitch-geometry.test.ts`
- Red before the fixes:
  - the translated source slide remained visible while the capture clone was also visible, producing duplicate content;
  - the clone inherited the source rect even after leaving its translated parent, moving off-stage pages outside the capture viewport.
- Green on this branch:
  - the source slide is hidden while the capture clone is present;
  - the clone is inserted first and aligned from its own live rect.
- Real Electron reproduction: a three-slide translated flex-strip deck previously produced white off-stage PNGs; it now produces three distinct populated slide images.
- PDF verification: the real slide images assemble into a 3-page, 960 x 540 pt PDF; Poppler renders all three pages with distinct ONE/TWO/THREE content.
- PNG verification: whole-deck stitching produces one 1920 x 3240 image with all three slide bands populated.

## Validation

- `corepack pnpm guard`
- `corepack pnpm typecheck`
- `corepack pnpm --filter @open-design/desktop typecheck`
- `corepack pnpm --dir apps/desktop exec vitest run -c vitest.config.ts tests/main/scroll-stitch-geometry.test.ts` — 26 passed
- Real Electron multi-slide PNG export, whole-deck PNG stitching, screenshot-PDF assembly, `pdfinfo`, and Poppler render inspection
- `corepack pnpm --filter @open-design/desktop test` — 210 passed, 1 pre-existing unrelated failure at `apps/desktop/tests/main/updater.test.ts:2752` (also fails on the baseline)
