### PR TITLE
fix(web): use baked previews for slide presets

### DIFF
--- a/apps/web/src/components/HomeHero.tsx
+++ b/apps/web/src/components/HomeHero.tsx
@@ -2384,6 +2384,7 @@ function PluginPromptPresetCard({
             pluginId={record.id}
             pluginTitle={title}
             preview={preview}
+            eager={odMode === 'deck'}
           />
           {active ? (
             <span className="home-hero__plugin-preset-check" aria-hidden>

--- a/apps/web/src/components/plugins-home/preview.ts
+++ b/apps/web/src/components/plugins-home/preview.ts
@@ -114,10 +114,6 @@ function readBakedPreview(
   return { poster, video, holdMs: typeof holdMs === 'number' ? holdMs : null };
 }
 
-function shouldPreferLivePreview(record: InstalledPluginRecord): boolean {
-  return (record.manifest?.tags ?? []).some((tag) => tag === 'commercial-slide-agent');
-}
-
 function readExamples(record: InstalledPluginRecord): ExampleOutputEntry[] {
   const od = record.manifest?.od as
     | { useCase?: { exampleOutputs?: unknown } }
@@ -192,7 +188,7 @@ export function inferPluginPreview(
   // the daemon has attached one. Everything else — crucially the detail modal —
   // falls through to the real `od.preview`, so opening a plugin still shows the
   // live, interactive page rather than the baked video.
-  if (opts?.preferBaked && !shouldPreferLivePreview(record)) {
+  if (opts?.preferBaked) {
     const baked = readBakedPreview(record);
     if (baked) {
       return {

--- a/apps/web/tests/components/plugins-home-preview-surface.test.tsx
+++ b/apps/web/tests/components/plugins-home-preview-surface.test.tsx
@@ -21,8 +21,12 @@ vi.mock('../../src/components/plugins-home/cards/MediaSurface', () => ({
 }));
 
 vi.mock('../../src/components/plugins-home/cards/HtmlSurface', () => ({
-  HtmlSurface: ({ inView }: { inView: boolean }) => (
-    <div data-testid="html-surface" data-in-view={String(inView)} />
+  HtmlSurface: ({ eager, inView }: { eager?: boolean; inView: boolean }) => (
+    <div
+      data-testid="html-surface"
+      data-eager={String(Boolean(eager))}
+      data-in-view={String(inView)}
+    />
   ),
 }));
 
@@ -112,5 +116,18 @@ describe('PreviewSurface media visibility gates', () => {
       />,
     );
     expect(screen.getByTestId('design-surface').dataset.inView).toBe('false');
+  });
+
+  it('passes eager through to html surfaces', () => {
+    visibilityQueue.splice(0, visibilityQueue.length, true, true, true, true);
+    render(
+      <PreviewSurface
+        pluginId="sample"
+        pluginTitle="Sample"
+        preview={{ kind: 'html', src: '/preview', label: 'preview', source: 'preview' }}
+        eager
+      />,
+    );
+    expect(screen.getByTestId('html-surface').dataset.eager).toBe('true');
   });
 });

--- a/apps/web/tests/components/plugins-home-preview.test.ts
+++ b/apps/web/tests/components/plugins-home-preview.test.ts
@@ -141,15 +141,32 @@ describe('inferPluginPreview', () => {
     expect(gallery.loopHoldMs).toBe(2500);
   });
 
-  it('keeps commercial slide templates on live HTML even when a stale baked preview exists', () => {
+  it('uses baked previews for commercial slide templates when available', () => {
     const record = make({
       id: 'commercial-deck',
       tags: ['commercial-slide-agent'],
       preview: { type: 'html', entry: './example.html' },
       bakedPreview: {
-        poster: '/api/plugin-previews/commercial-deck/old/poster.jpg',
-        video: '/api/plugin-previews/commercial-deck/old/preview.mp4',
+        poster: '/api/plugin-previews/commercial-deck/current/poster.jpg',
+        video: '/api/plugin-previews/commercial-deck/current/preview.mp4',
+        holdMs: 2500,
       },
+    });
+
+    const gallery = inferPluginPreview(record, { preferBaked: true });
+    expect(gallery.kind).toBe('media');
+    if (gallery.kind !== 'media') return;
+    expect(gallery.mediaType).toBe('video');
+    expect(gallery.poster).toBe('/api/plugin-previews/commercial-deck/current/poster.jpg');
+    expect(gallery.videoUrl).toBe('/api/plugin-previews/commercial-deck/current/preview.mp4');
+    expect(gallery.loopHoldMs).toBe(2500);
+  });
+
+  it('falls back to live HTML for commercial slide templates without a baked preview', () => {
+    const record = make({
+      id: 'commercial-deck',
+      tags: ['commercial-slide-agent'],
+      preview: { type: 'html', entry: './example.html' },
     });
 
     const gallery = inferPluginPreview(record, { preferBaked: true });


### PR DESCRIPTION
## Why

QA reported that slideshow template preset cards on the Home page rendered blank cover areas on latest `origin/main`. The affected deck presets already have baked preview clips in `data/plugin-previews/manifest.json`, but `commercial-slide-agent` records were explicitly forced back to live HTML iframe previews, bypassing those baked assets and exposing the blank iframe-loading path.

This PR restores the intended gallery behavior: use the cheap baked preview when the daemon has attached one, and keep live HTML as the fallback when no baked clip exists.

## What users will see

Home page slideshow template preset cards show their baked preview cover/clip instead of blank iframe placeholders. Deck templates without a baked clip still render through the live HTML preview path, with eager mounting for the Home preset row fallback.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Manual local acceptance was done against `pnpm tools-dev run web --namespace template-preview-fix --daemon-port 48510 --web-port 48511`; the Home page deck preset row was verified after the fix.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/plugins-home-preview.test.ts`
- Did the test go red on `main` and green on this branch? The updated commercial-slide baked-preview assertion is the inverse of `main`'s `shouldPreferLivePreview` behavior and is green on this branch.
- Additional coverage: `apps/web/tests/components/plugins-home-preview-surface.test.tsx` covers passing the eager fallback through to HTML surfaces.

## Validation

- `pnpm exec vitest run -c vitest.config.ts --maxWorkers=2 tests/components/plugins-home-preview.test.ts tests/components/plugins-home-preview-surface.test.tsx` (from `apps/web`)
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm install`
- `pnpm typecheck`
