### PR TITLE
fix(landing-page): surface HTML to PPT in nav and footer, move Tools last

### DIFF
--- a/apps/landing-page/app/_components/header.tsx
+++ b/apps/landing-page/app/_components/header.tsx
@@ -70,6 +70,7 @@ const TOOL_ENTRIES: ReadonlyArray<{ href: string; key: SolutionPageKey }> = [
   { href: '/solutions/design-to-code/', key: 'designToCode' },
   { href: '/solutions/figma-to-code/', key: 'figmaToCode' },
   { href: '/solutions/screenshot-to-code/', key: 'screenshotToCode' },
+  { href: '/solutions/html-to-ppt/', key: 'htmlToPpt' },
 ];
 
 // Agent column — the coding agents with a dedicated long-form design page
@@ -271,20 +272,6 @@ export function Header({
               >
                 <li className='nav-dropdown-group'>
                   <span className='nav-dropdown-group-label'>
-                    {productMenuCopy.tools}
-                  </span>
-                </li>
-                {TOOL_ENTRIES.map(({ href: toolHref, key }) => (
-                  <li key={key}>
-                    <a href={href(toolHref)}>
-                      <span className='dropdown-name'>
-                        {getSolutionPageCopy(locale, key).breadcrumb}
-                      </span>
-                    </a>
-                  </li>
-                ))}
-                <li className='nav-dropdown-group'>
-                  <span className='nav-dropdown-group-label'>
                     {productMenuCopy.useCases}
                   </span>
                 </li>
@@ -304,6 +291,20 @@ export function Header({
                   <li key={name}>
                     <a href={href(ROLE_HREFS[index]!)}>
                       <span className='dropdown-name'>{name}</span>
+                    </a>
+                  </li>
+                ))}
+                <li className='nav-dropdown-group'>
+                  <span className='nav-dropdown-group-label'>
+                    {productMenuCopy.tools}
+                  </span>
+                </li>
+                {TOOL_ENTRIES.map(({ href: toolHref, key }) => (
+                  <li key={key}>
+                    <a href={href(toolHref)}>
+                      <span className='dropdown-name'>
+                        {getSolutionPageCopy(locale, key).breadcrumb}
+                      </span>
                     </a>
                   </li>
                 ))}

--- a/apps/landing-page/app/_components/site-footer.astro
+++ b/apps/landing-page/app/_components/site-footer.astro
@@ -9,6 +9,7 @@ import {
   localizedHref,
 } from '../i18n';
 import { getFooterLegalCopy } from '../footer-legal-i18n';
+import { getSolutionPageCopy, type SolutionPageKey } from '../solution-pages-i18n';
 
 interface Props {
   counts: HeaderProps['counts'];
@@ -37,6 +38,21 @@ const USE_CASE_HREFS = [
   '/solutions/image/',
   '/solutions/video/',
   '/solutions/design-system/',
+] as const;
+
+// Solution → Tools. Kept in lockstep with header.tsx's TOOL_ENTRIES; labels
+// reuse each tool page's own breadcrumb so footer, nav, and hub cards share a
+// single translation source. Rendered at the bottom of the Solution column,
+// mirroring the nav dropdown order (use cases → tools).
+const TOOL_ENTRIES: ReadonlyArray<{ href: string; key: SolutionPageKey }> = [
+  { href: '/solutions/ai-wireframe-generator/', key: 'aiWireframeGenerator' },
+  { href: '/solutions/ai-ui-generator/', key: 'aiUiGenerator' },
+  { href: '/solutions/ai-prototype-generator/', key: 'aiPrototypeGenerator' },
+  { href: '/solutions/ai-landing-page-generator/', key: 'aiLandingPageGenerator' },
+  { href: '/solutions/design-to-code/', key: 'designToCode' },
+  { href: '/solutions/figma-to-code/', key: 'figmaToCode' },
+  { href: '/solutions/screenshot-to-code/', key: 'screenshotToCode' },
+  { href: '/solutions/html-to-ppt/', key: 'htmlToPpt' },
 ] as const;
 
 // A short, recognisable subset of the agent roster for the footer; the
@@ -71,6 +87,12 @@ const l = getFooterLegalCopy(locale);
         <ul>
           {menu.useCaseItems.map((name, i) => (
             <li><a href={href(USE_CASE_HREFS[i]!)}>{name}</a></li>
+          ))}
+        </ul>
+        <h6 class='sub-footer-subhead'>{menu.tools}</h6>
+        <ul>
+          {TOOL_ENTRIES.map(({ href: toolHref, key }) => (
+            <li><a href={href(toolHref)}>{getSolutionPageCopy(locale, key).breadcrumb}</a></li>
           ))}
         </ul>
       </div>
@@ -223,6 +245,17 @@ const l = getFooterLegalCopy(locale);
     }
     .foot-social a:hover {
       color: var(--ink, #262626);
+    }
+    /* Secondary "Tools" heading inside the Solution column — reuses the h5
+       eyebrow look but sits below the use-case list, so it needs top spacing. */
+    .sub-footer-subhead {
+      font-family: var(--mono);
+      font-size: 10px;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      color: var(--ink-mute);
+      font-weight: 500;
+      margin: 20px 0 14px;
     }
   </style>
 </footer>


### PR DESCRIPTION
## Why

While reviewing the live Solution ▸ Tools dropdown I noticed the HTML to PPT tool page was missing from it. The `/solutions/html-to-ppt/` page has been live since #5387, but that PR only wired it into the `/solutions` hub — the top-nav dropdown and the footer never linked it, so it was effectively undiscoverable from navigation. This fixes that gap and, while there, tidies the dropdown ordering so the AI generator tools sit below the use-case and role links instead of on top.

## What users will see

- The Solution ▸ Tools dropdown now lists **HTML to PPT** (previously only reachable via the `/solutions` hub or a direct URL).
- In that dropdown, the **Tools** group now appears at the bottom — order is **Use cases → Roles → Tools** (it used to lead with Tools).
- The footer's **Solution** column now has a **Tools** sub-section listing all the AI generator tools (including HTML to PPT), under the use-case links.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [x] **UI (landing-page)** — top-nav Solution dropdown + site footer link changes
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — no new keys; tool labels reuse each tool page's existing breadcrumb
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — landing-page navigation/footer wiring only, no product runtime change

## Preview

Shareable staging preview (available once CI publishes it):
**https://pr-5636.open-design-landing-staging.pages.dev/solutions/html-to-ppt/**

- Homepage (see reordered Solution dropdown): https://pr-5636.open-design-landing-staging.pages.dev/
- Any page footer now shows the Tools sub-section under Solution.

## Screenshots

Solution ▸ Tools dropdown now ends with **HTML to PPT**; footer Solution column gains a **Tools** sub-section. (See preview links above.)

## Bug fix verification

Not a code-logic bug — this is a navigation-wiring gap. Verified by rendering the dropdown and footer locally (see Validation).

## Validation

- `astro check` → **0 errors** (371 files)
- `astro dev` render check:
  - Home nav: DOM order confirmed **use cases → roles → tools**, with `/solutions/html-to-ppt/` as the last tool.
  - Footer: `Tools` subhead + `/solutions/html-to-ppt/` link render in the Solution column on sub-pages.
- Labels resolve from each tool page's `breadcrumb` (single source shared by nav / footer / hub — cannot drift).
