### PR TITLE
fix(daemon): read Pi model list from stdout

### DIFF
--- a/apps/daemon/src/runtimes/defs/pi.ts
+++ b/apps/daemon/src/runtimes/defs/pi.ts
@@ -12,16 +12,15 @@ export const piAgentDef = {
     // every spawn). The default 3s version-probe timeout is too tight; raise it
     // so detection doesn't silently abort before reaching fetchModels.
     versionProbeTimeoutMs: 15_000,
-    // `pi --list-models` prints a TSV table to stderr (not stdout),
-    // so we use a custom fetchModels that reads stderr.
+    // `pi --list-models` prints its TSV table to stdout.
     fetchModels: async (resolvedBin, env) => {
       try {
-        const { stderr } = await execAgentFile(resolvedBin, ['--list-models'], {
+        const { stdout } = await execAgentFile(resolvedBin, ['--list-models'], {
           env,
           timeout: 60_000, // Windows: 20s exceeded under parallel detection load
           maxBuffer: 8 * 1024 * 1024,
         });
-        const parsed = parsePiModels(stderr);
+        const parsed = parsePiModels(stdout);
         if (!parsed || parsed.length === 0) return null;
         return parsed;
       } catch {

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -269,6 +269,38 @@ test('pi args use rpc mode without --no-session and append model/thinking option
   ]);
 });
 
+test('pi fetchModels reads the model table from stdout', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-pi-models-'));
+  try {
+    const bin = join(dir, process.platform === 'win32' ? 'pi.cmd' : 'pi');
+    if (process.platform === 'win32') {
+      writeFileSync(
+        bin,
+        '@echo off\r\nif "%~1"=="--list-models" (\r\n  echo provider model context max-out thinking images\r\n  echo anthropic claude-sonnet-4-5 200K 64K yes yes\r\n  exit /b 0\r\n)\r\nexit /b 1\r\n',
+      );
+    } else {
+      writeFileSync(
+        bin,
+        '#!/bin/sh\nif [ "$1" = "--list-models" ]; then\n  printf \'%s\\n\' \\\n    \'provider model context max-out thinking images\' \\\n    \'anthropic claude-sonnet-4-5 200K 64K yes yes\'\n  exit 0\nfi\nexit 1\n',
+      );
+      chmodSync(bin, 0o755);
+    }
+
+    assert.ok(pi.fetchModels, 'pi must define fetchModels');
+    const models = await pi.fetchModels(bin, {});
+
+    assert.deepEqual(models, [
+      { id: 'default', label: 'Default (CLI config)' },
+      {
+        id: 'anthropic/claude-sonnet-4-5',
+        label: 'anthropic/claude-sonnet-4-5',
+      },
+    ]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('pi args forward extraAllowedDirs as --append-system-prompt flags', () => {
   const args = pi.buildArgs(
     '',


### PR DESCRIPTION
Fixes #5632

## Why

I picked up the confirmed community bug in #5632 after claiming it. Pi writes the `--list-models` table to stdout, but the daemon read stderr, so successful discovery was discarded and users only received fallback models.

## What users will see

After rescanning agents, Pi users will see the models returned by their local `pi --list-models` command in the existing model picker instead of only the fallback list.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — this adds no UI surface; it corrects the model data supplied to the existing picker.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/runtimes/agent-args.test.ts`
- Did the test go red on `main` and green on this branch? **Yes.** The regression test received `null` before the source change and the parsed Pi models afterward.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/daemon build`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/agent-args.test.ts` (45 passed)

All commands ran with Node 24.13.1 and pnpm 10.33.2.
