### PR TITLE
fix(download): preserve target isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - [Fixed] Long speaker notes are now scrollable inside the presenter view instead of being clipped when notes push the layout past the viewport. (#6271)
+- [Fixed] Managed downloads preserve unrelated cache entries during recovery and respect live target locks during removal. (#5643)
 
 ## [0.9.0] - 2026-05-29
 

--- a/packages/download/src/remove.ts
+++ b/packages/download/src/remove.ts
@@ -18,6 +18,7 @@ import { removePathBestEffort } from "@open-design/platform";
 
 import { MANAGED_DOWNLOAD_ERROR_CODES, ManagedDownloadError } from "./errors.js";
 import { pathExists } from "./fs-io.js";
+import { acquireLock, releaseLock } from "./lock.js";
 import { readManifest } from "./manifest.js";
 import { activeTargets, targetActiveKey } from "./registry.js";
 import { ensureManagedBase } from "./store.js";
@@ -67,14 +68,18 @@ export async function removeManagedDownload(options: RemoveManagedDownloadOption
     throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.TARGET_LOCKED, `download target is active: ${target.bucket}/${target.fileName}`);
   }
   await ensureManagedBase(target.basePath);
-  await Promise.all([
-    removePathBestEffort(target.finalPath),
-    removePathBestEffort(target.partialPath, { recursive: false }),
-    removePathBestEffort(target.manifestPath, { recursive: false }),
-    removePathBestEffort(target.lockPath, { recursive: false }),
-  ]);
-  const bucketPath = join(target.basePath, target.bucket);
-  const entries = await readdir(bucketPath).catch(() => null);
-  if (entries != null && entries.length === 0) await rm(bucketPath, { force: true, recursive: true }).catch(() => undefined);
-  return { removed: true };
+  const lock = await acquireLock(target);
+  try {
+    await Promise.all([
+      removePathBestEffort(target.finalPath),
+      removePathBestEffort(target.partialPath, { recursive: false }),
+      removePathBestEffort(target.manifestPath, { recursive: false }),
+    ]);
+    const bucketPath = join(target.basePath, target.bucket);
+    const entries = await readdir(bucketPath).catch(() => null);
+    if (entries != null && entries.length === 0) await rm(bucketPath, { force: true, recursive: true }).catch(() => undefined);
+    return { removed: true };
+  } finally {
+    await releaseLock(lock);
+  }
 }

--- a/packages/download/src/run.ts
+++ b/packages/download/src/run.ts
@@ -2,7 +2,7 @@
  * @module run
  *
  * Single managed-download execution. Detects reusable state (a verified complete
- * file or a resumable partial), resets suspicious/corrupt bases, then acquires the
+ * file or a resumable partial), clears suspicious/corrupt target state, then acquires the
  * lock, prunes, transfers, verifies the checksum, and atomically promotes the
  * partial to its final path — emitting the final result. This is the orchestration
  * kernel behind the public `managedDownload`. Depends on the store, manifest, lock,
@@ -17,7 +17,7 @@ import { hashFile, pathExists, statFileSize, writeJson } from "./fs-io.js";
 import { acquireLock, type AcquiredLock, releaseLock } from "./lock.js";
 import { createManifest, manifestMatchesTarget, readManifest } from "./manifest.js";
 import { pruneManagedDownloads } from "./prune.js";
-import { ensureManagedBase, resetOwnedBase } from "./store.js";
+import { ensureManagedBase } from "./store.js";
 import type { NormalizedTarget } from "./target.js";
 import { downloadWithRetries } from "./transfer.js";
 import type { DownloadManifest } from "./manifest.js";
@@ -25,26 +25,35 @@ import type { ManagedDownloadProgress, ManagedDownloadResult } from "./types.js"
 
 /**
  * @internal Snapshot of reusable state resolved before a transfer: an existing
- * complete result, a resumable partial manifest, or a signal that the base was
- * reset because its state was suspicious.
+ * complete result or a resumable partial manifest.
  */
 type ReusableState = {
   manifest: DownloadManifest | null;
-  reset?: boolean;
   result?: ManagedDownloadResult;
 };
 
 /**
- * @internal Reset the owned base and report that a suspicious state was cleared.
+ * @internal Clear one target's result and scratch state while retaining its lock.
+ */
+async function clearTargetState(target: NormalizedTarget): Promise<void> {
+  await Promise.all([
+    rm(target.finalPath, { force: true, recursive: true }),
+    rm(target.partialPath, { force: true, recursive: true }),
+    rm(target.manifestPath, { force: true, recursive: true }),
+  ]);
+}
+
+/**
+ * @internal Clear suspicious target state before starting a fresh download.
  */
 async function suspiciousReset(target: NormalizedTarget): Promise<ReusableState> {
-  await resetOwnedBase(target.basePath);
-  return { manifest: null, reset: true };
+  await clearTargetState(target);
+  return { manifest: null };
 }
 
 /**
  * @internal Resolve whether an existing complete file can be reused, a partial
- * can be resumed, or the base must be reset.
+ * can be resumed, or target state must be cleared.
  * @returns The resolved reusable state.
  */
 async function loadReusableState(target: NormalizedTarget): Promise<ReusableState> {
@@ -106,25 +115,12 @@ export async function runManagedDownload(
   try {
     let state = await loadReusableState(target);
     if (state.result != null) return state.result;
-    if (state.reset === true) {
-      // A reset removes the lock as part of the managed base cleanup, so
-      // reacquire it before writing the fresh target state.
-      await releaseLock(lock);
-      lock = null;
-      await ensureManagedBase(target.basePath);
-      lock = await acquireLock(target);
-      state = await loadReusableState(target);
-      if (state.result != null) return state.result;
-      if (state.reset === true) {
-        throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.STORE_CORRUPT, "download state kept resetting after base cleanup");
-      }
-    }
     const download = await downloadWithRetries(target, state.manifest, options);
     const actual = await hashFile(target.partialPath, target.checksum.algorithm).catch((error: unknown) => {
       throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.STORE_CORRUPT, `downloaded partial could not be hashed: ${errorMessage(error)}`);
     });
     if (actual !== target.checksum.value) {
-      await resetOwnedBase(target.basePath).catch(() => undefined);
+      await clearTargetState(target).catch(() => undefined);
       throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.CHECKSUM_MISMATCH, "downloaded file checksum did not match requested payload", {
         actual,
         expected: target.checksum.value,
@@ -135,7 +131,7 @@ export async function runManagedDownload(
     if (await pathExists(target.finalPath)) {
       const existing = await hashFile(target.finalPath, target.checksum.algorithm).catch(() => null);
       if (existing !== target.checksum.value) {
-        await resetOwnedBase(target.basePath).catch(() => undefined);
+        await clearTargetState(target).catch(() => undefined);
         throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.STORE_CORRUPT, "existing complete file did not match requested payload");
       }
       await rm(target.partialPath, { force: true }).catch(() => undefined);

--- a/packages/download/src/store.ts
+++ b/packages/download/src/store.ts
@@ -4,11 +4,11 @@
  * Managed-download root ownership and directory lifecycle. Reads/writes the
  * ownership sentinel that marks a base directory as Open Design-owned, refuses to
  * take over foreign/non-empty directories, ensures the `.state`/`.partial`/`.locks`
- * scratch layout exists, and resets an owned base by clearing its contents.
+ * scratch layout exists, and refuses to take over a foreign/non-empty base.
  * Depends on constants, errors, and the fs-io primitives.
  */
 
-import { lstat, mkdir, readdir, rm } from "node:fs/promises";
+import { lstat, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 
 import { LOCK_DIR, PARTIAL_DIR, STATE_DIR, STORE_KIND, STORE_SCHEMA_VERSION, STORE_SENTINEL } from "./constants.js";
@@ -42,23 +42,6 @@ async function writeSentinel(basePath: string): Promise<void> {
     kind: STORE_KIND,
     schemaVersion: STORE_SCHEMA_VERSION,
   } satisfies StoreSentinel);
-}
-
-/**
- * Clear all contents of an owned base and re-establish the sentinel and scratch
- * directories. Refuses to touch a base that is not owned.
- */
-export async function resetOwnedBase(basePath: string): Promise<void> {
-  const sentinel = await readJson<unknown>(join(basePath, STORE_SENTINEL));
-  if (!isStoreSentinel(sentinel)) {
-    throw new ManagedDownloadError(MANAGED_DOWNLOAD_ERROR_CODES.STORE_NOT_OWNED, `download base is not owned: ${basePath}`);
-  }
-  const entries = await readdir(basePath).catch(() => []);
-  for (const entry of entries) {
-    await rm(join(basePath, entry), { force: true, recursive: true }).catch(() => undefined);
-  }
-  await writeSentinel(basePath);
-  await ensureStoreDirs(basePath);
 }
 
 /**

--- a/packages/download/tests/index.test.ts
+++ b/packages/download/tests/index.test.ts
@@ -200,7 +200,7 @@ describe("managed download package", () => {
     }
   });
 
-  it("quick-fails a checksum mismatch after resetting owned state", async () => {
+  it("quick-fails a checksum mismatch after clearing target state", async () => {
     const fixture = await startFixture("wrong bytes");
     const root = tmpRoot("checksum-mismatch");
     await expect(
@@ -390,6 +390,34 @@ describe("managed download package", () => {
     }
   });
 
+  it("does not remove a target held by a live external lock", async () => {
+    const body = "locked remove payload";
+    const fixture = await startFixture(body);
+    const root = tmpRoot("remove-live-lock");
+    const basePath = join(root, "downloads");
+    try {
+      const result = await managedDownload({
+        basePath,
+        bucket: "updates",
+        fileName: "installer.bin",
+        payload: { checksum: { algorithm: "sha256", value: sha256(body) }, url: fixture.url },
+      });
+      const targetLockPath = lockPath(basePath, "updates", "installer.bin");
+      writeFileSync(targetLockPath, JSON.stringify({
+        createdAt: new Date().toISOString(),
+        pid: process.pid,
+      }));
+
+      await expect(removeManagedDownload({ basePath, bucket: "updates", fileName: "installer.bin" })).rejects.toMatchObject({
+        code: MANAGED_DOWNLOAD_ERROR_CODES.TARGET_LOCKED,
+      });
+      expect(readFileSync(result.path, "utf8")).toBe(body);
+      expect(existsSync(targetLockPath)).toBe(true);
+    } finally {
+      await fixture.close();
+    }
+  });
+
   it("prunes managed data older than the default one-day window", async () => {
     const body = "old payload";
     const fixture = await startFixture(body);
@@ -437,6 +465,43 @@ describe("managed download package", () => {
       expect(fixture.requests.length).toBeGreaterThanOrEqual(2);
     } finally {
       await fixture.close();
+    }
+  });
+
+  it("preserves other targets when repairing corrupt state", async () => {
+    const firstBody = "first payload";
+    const secondBody = "second payload";
+    const firstFixture = await startFixture(firstBody);
+    const secondFixture = await startFixture(secondBody);
+    const root = tmpRoot("target-reset");
+    const basePath = join(root, "downloads");
+    try {
+      const first = await managedDownload({
+        basePath,
+        bucket: "cache",
+        fileName: "first.bin",
+        payload: { checksum: { algorithm: "sha256", value: sha256(firstBody) }, url: firstFixture.url },
+      });
+      const second = await managedDownload({
+        basePath,
+        bucket: "cache",
+        fileName: "second.bin",
+        payload: { checksum: { algorithm: "sha256", value: sha256(secondBody) }, url: secondFixture.url },
+      });
+      writeFileSync(first.path, "tampered bytes");
+
+      await managedDownload({
+        basePath,
+        bucket: "cache",
+        fileName: "first.bin",
+        payload: { checksum: { algorithm: "sha256", value: sha256(firstBody) }, url: firstFixture.url },
+      });
+
+      expect(readFileSync(second.path, "utf8")).toBe(secondBody);
+      expect(secondFixture.requests).toHaveLength(1);
+    } finally {
+      await firstFixture.close();
+      await secondFixture.close();
     }
   });
 });


### PR DESCRIPTION
## Why

Recovering one damaged managed download deleted the entire shared cache root, including unrelated completed downloads and locks. Removal also relied only on in-process state, so it could delete a file being handled by another process.

## What users will see

Retrying a damaged download preserves other cached downloads. Removing a download now reports that the target is locked when another process owns it instead of deleting its data.

## Surface area

- [x] **Default behavior change** — recovery and removal now preserve managed-download target isolation

## Screenshots

Not applicable; this is a download lifecycle fix.

## Bug fix verification

- Test path that reproduces the bugs: `packages/download/tests/index.test.ts`
- Did the test go red on `main` and green on this branch? yes
- Added coverage for corrupt-target recovery preserving a second target and removal refusing a live external lock.

## Validation

- `pnpm --filter @open-design/download test`
- `pnpm --filter @open-design/download typecheck`
- `pnpm --filter @open-design/download build`
- `pnpm guard`
- `pnpm typecheck`
