### PR TITLE
fix(desktop): keep CJK typefaces intact in editable PPTX export

### DIFF
--- a/apps/desktop/src/main/deck-capture.ts
+++ b/apps/desktop/src/main/deck-capture.ts
@@ -1132,17 +1132,24 @@ export async function runDomToPptx(slideSelector: string): Promise<{ b64?: strin
   // the Latin webfont that leads our template stacks) before dom-to-pptx reads it,
   // so PowerPoint/WPS/Keynote all resolve the same real font. See
   // cjkPromotedFontFamily for the why. Keyed on the element that directly owns the
-  // text so a container that only holds Latin markup is never rewritten.
+  // text so a container that only holds Latin markup is never rewritten. Decide on
+  // the element's COMBINED direct text: bilingual markup often splits one element
+  // across text nodes (`Product Launch<br>产品发布`, `Welcome <strong>…</strong> 欢迎`),
+  // so a later CJK chunk must still win even when a Latin chunk comes first.
   function promoteCjkTypefaces(slides: HTMLElement[]): void {
     const touched = new Set<HTMLElement>();
     for (const slide of slides) {
       const walker = document.createTreeWalker(slide, NodeFilter.SHOW_TEXT);
       for (let node = walker.nextNode(); node; node = walker.nextNode()) {
-        const value = node.nodeValue || "";
         const el = node.parentElement;
-        if (!el || touched.has(el) || !value.trim()) continue;
+        if (!el || touched.has(el)) continue;
         touched.add(el);
-        const promoted = cjkPromotedFontFamily(getComputedStyle(el).fontFamily, value);
+        let combined = "";
+        for (const child of el.childNodes) {
+          if (child.nodeType === Node.TEXT_NODE) combined += child.nodeValue || "";
+        }
+        if (!combined.trim()) continue;
+        const promoted = cjkPromotedFontFamily(getComputedStyle(el).fontFamily, combined);
         if (promoted) el.style.setProperty("font-family", promoted, "important");
       }
     }

--- a/apps/desktop/src/main/deck-capture.ts
+++ b/apps/desktop/src/main/deck-capture.ts
@@ -400,8 +400,10 @@ async function renderEditablePptx(
   );
   await nextFrames(window);
   await window.webContents.executeJavaScript(await loadDomToPptxBundle(), true);
+  // runDomToPptx calls cjkPromotedFontFamily by name; define it in the same scope
+  // as the serialized body so the reference resolves inside the render window.
   const out = (await window.webContents.executeJavaScript(
-    `(${runDomToPptx.toString()})(${JSON.stringify(SLIDE_SELECTOR)})`,
+    `(() => { const cjkPromotedFontFamily = ${cjkPromotedFontFamily.toString()}; return (${runDomToPptx.toString()})(${JSON.stringify(SLIDE_SELECTOR)}); })()`,
     true,
   )) as { b64?: string; error?: string };
   if (!out || out.error || !out.b64) {
@@ -956,6 +958,46 @@ function showAllSlides(slideSelector: string): number {
   return slides.length;
 }
 
+// Picks the typeface the exported PPTX should name for a run of `text`, given its
+// CSS `font-family` stack. dom-to-pptx names ONE typeface per run — the first
+// family in the stack — and writes it to the PowerPoint `<a:latin>`, `<a:ea>`
+// (East-Asian) and `<a:cs>` slots alike. Our deck templates lead every stack
+// with a Latin-only webfont (e.g. `'Inter','Noto Sans SC',…`): the browser then
+// renders CJK glyphs with the later CJK family via per-glyph fallback, but the
+// export mislabels those runs with the Latin font — which has no CJK glyphs — so
+// PowerPoint, WPS, and Keynote each substitute a DIFFERENT fallback and the
+// Chinese/Japanese/Korean text renders wrong and inconsistently ("字体错乱").
+//
+// When `text` contains East-Asian characters and the stack carries a CJK-capable
+// family further down, return the stack reordered so that family leads (the whole
+// stack is preserved so the browser keeps its own per-glyph fallback). Returns
+// `null` when nothing needs to change (Latin-only text, no CJK family in the
+// stack, or a CJK family already leads) so callers can skip the element. Kept
+// pure and self-contained so it can be both unit-tested and serialized into the
+// export render window.
+export function cjkPromotedFontFamily(fontFamily: string, text: string): string | null {
+  // CJK symbols/punctuation, Hiragana, Katakana, CJK Unified Ideographs (+ Ext-A),
+  // Yi, Hangul syllables, CJK compatibility ideographs, and half/fullwidth forms.
+  const cjkText =
+    /[\u2E80-\u2FDF\u3000-\u303F\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uA000-\uA4CF\uAC00-\uD7AF\uF900-\uFAFF\uFF00-\uFFEF]/;
+  // Family names that carry CJK glyph coverage: the Noto SC/TC/JP/KR webfonts the
+  // html-ppt templates ship, plus common system CJK faces an authored deck may
+  // name, so a promoted typeface resolves to a real CJK font across the office
+  // suites instead of each app's arbitrary fallback.
+  const cjkFamily =
+    /noto\s*(sans|serif)\s*(sc|tc|hk|jp|kr|cjk)|source\s*han|pingfang|hiragino|heiti|songti|kaiti|fangsong|microsoft\s*(yahei|jhenghei)|yahei|simsun|simhei|mingliu|meiryo|ms\s*(gothic|mincho)|malgun|nanum|gulim|batang|dotum|思源|苹方|黑体|宋体|楷体|仿宋|微软雅黑|明體|明朝|ゴシック/i;
+  if (!fontFamily || !cjkText.test(text || "")) return null;
+  const families = fontFamily
+    .split(",")
+    .map((f) => f.trim())
+    .filter(Boolean);
+  if (families.length < 2) return null;
+  const firstCjk = families.findIndex((f) => cjkFamily.test(f.replace(/^["']|["']$/g, "").trim()));
+  // No CJK family to promote, or one already leads the stack.
+  if (firstCjk <= 0) return null;
+  return [families[firstCjk], ...families.filter((_, i) => i !== firstCjk)].join(", ");
+}
+
 // Serialized into the page: runs the injected dom-to-pptx engine over every real
 // slide and returns the .pptx bytes as base64 (or an error). Fonts are
 // auto-detected + embedded; SVGs stay vector (editable in PowerPoint).
@@ -1086,6 +1128,26 @@ export async function runDomToPptx(slideSelector: string): Promise<{ b64?: strin
     }
   }
 
+  // Reorder each text run's font-family so CJK runs name their CJK typeface (not
+  // the Latin webfont that leads our template stacks) before dom-to-pptx reads it,
+  // so PowerPoint/WPS/Keynote all resolve the same real font. See
+  // cjkPromotedFontFamily for the why. Keyed on the element that directly owns the
+  // text so a container that only holds Latin markup is never rewritten.
+  function promoteCjkTypefaces(slides: HTMLElement[]): void {
+    const touched = new Set<HTMLElement>();
+    for (const slide of slides) {
+      const walker = document.createTreeWalker(slide, NodeFilter.SHOW_TEXT);
+      for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+        const value = node.nodeValue || "";
+        const el = node.parentElement;
+        if (!el || touched.has(el) || !value.trim()) continue;
+        touched.add(el);
+        const promoted = cjkPromotedFontFamily(getComputedStyle(el).fontFamily, value);
+        if (promoted) el.style.setProperty("font-family", promoted, "important");
+      }
+    }
+  }
+
   try {
     const w = window as unknown as {
       domToPptx?: { exportToPptx: (target: unknown, options: unknown) => Promise<Blob> };
@@ -1099,6 +1161,7 @@ export async function runDomToPptx(slideSelector: string): Promise<{ b64?: strin
     if (slides.length === 0) return { error: "no slides to export" };
     ensureExplicitSlideBackgrounds(slides as HTMLElement[]);
     stabilizeLargeSingleLineText(slides as HTMLElement[]);
+    promoteCjkTypefaces(slides as HTMLElement[]);
     // dom-to-pptx assumes `node.className` is a string, but SVG elements expose
     // an SVGAnimatedString, so its DOM walk throws on decks containing inline SVG.
     // Normalize those to a plain string in this throwaway render window.

--- a/apps/desktop/tests/main/pptx-cjk-typeface.test.ts
+++ b/apps/desktop/tests/main/pptx-cjk-typeface.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'vitest';
+
+import { cjkPromotedFontFamily, runDomToPptx } from '../../src/main/deck-capture.js';
+
+// Reproduction for the "editable PPTX renders the wrong font in PowerPoint / WPS /
+// Keynote" bug. The html-ppt templates lead every font stack with a Latin-only
+// webfont (e.g. `'Inter','Noto Sans SC',…`). dom-to-pptx names a single typeface
+// per text run — the FIRST family in the stack — and writes it to the PowerPoint
+// `<a:latin>`, `<a:ea>` and `<a:cs>` slots alike, so CJK runs get labelled with a
+// font that has no CJK glyphs. Each office suite then substitutes a *different*
+// fallback and the Chinese/Japanese/Korean text renders wrong and inconsistently.
+//
+// The fix resolves the typeface a CJK run should actually name — the first
+// CJK-capable family already in the authored stack — so all three suites land on
+// the same real font. The stack is only reordered (never trimmed) so the browser
+// keeps its own per-glyph fallback while dom-to-pptx reads the promoted leader.
+
+// The real token stacks the html-ppt base + theme CSS ship.
+const SANS = "\"Inter\", \"Noto Sans SC\", -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif";
+const SERIF = "\"Playfair Display\", \"Noto Serif SC\", Georgia, serif";
+const NEO_BRUTALISM_SANS = "\"Space Grotesk\", \"Inter\", \"Noto Sans SC\", sans-serif";
+
+describe('cjkPromotedFontFamily', () => {
+  test('promotes the CJK family ahead of a Latin-only leader for Chinese text', () => {
+    const promoted = cjkPromotedFontFamily(SANS, '设计稿导出');
+    expect(promoted).not.toBeNull();
+    // The run now names Noto Sans SC first, so PowerPoint/WPS/Keynote resolve the
+    // same CJK font instead of substituting an arbitrary one for "Inter".
+    expect(promoted!.split(',')[0].trim()).toBe('"Noto Sans SC"');
+  });
+
+  test('keeps the full stack (only reordered) so browser fallback still works', () => {
+    const promoted = cjkPromotedFontFamily(SANS, '设计');
+    expect(promoted).toBe(
+      '"Noto Sans SC", "Inter", -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif',
+    );
+  });
+
+  test('mixed Latin + CJK text still promotes (the CJK run must be correct)', () => {
+    const promoted = cjkPromotedFontFamily(SANS, 'Open Design 设计工具');
+    expect(promoted!.split(',')[0].trim()).toBe('"Noto Sans SC"');
+  });
+
+  test('promotes the serif CJK family for serif stacks', () => {
+    const promoted = cjkPromotedFontFamily(SERIF, '演示文稿');
+    expect(promoted!.split(',')[0].trim()).toBe('"Noto Serif SC"');
+  });
+
+  test('promotes a CJK family buried two entries deep', () => {
+    const promoted = cjkPromotedFontFamily(NEO_BRUTALISM_SANS, '交付客户');
+    expect(promoted!.split(',')[0].trim()).toBe('"Noto Sans SC"');
+  });
+
+  test('promotes for Japanese kana and Korean hangul, not just Han', () => {
+    expect(cjkPromotedFontFamily(SANS, 'ひらがな')!.split(',')[0].trim()).toBe('"Noto Sans SC"');
+    expect(cjkPromotedFontFamily(SANS, 'カタカナ')!.split(',')[0].trim()).toBe('"Noto Sans SC"');
+    expect(cjkPromotedFontFamily(SANS, '한국어')!.split(',')[0].trim()).toBe('"Noto Sans SC"');
+  });
+
+  test('leaves Latin-only text untouched (no regression for English decks)', () => {
+    expect(cjkPromotedFontFamily(SANS, 'Deliver to the client')).toBeNull();
+    expect(cjkPromotedFontFamily(SANS, '123 — 456')).toBeNull();
+  });
+
+  test('no-ops when a CJK family already leads the stack', () => {
+    expect(cjkPromotedFontFamily('"Noto Sans SC", "Inter", sans-serif', '设计')).toBeNull();
+  });
+
+  test('no-ops when the stack carries no CJK-capable family to promote', () => {
+    // Nothing in the stack can render CJK — promotion cannot invent a font, so the
+    // run is left as authored (PowerPoint applies its own East-Asian fallback).
+    expect(cjkPromotedFontFamily('"Inter", Arial, sans-serif', '设计')).toBeNull();
+  });
+
+  test('no-ops on a single-family stack', () => {
+    expect(cjkPromotedFontFamily('"Inter"', '设计')).toBeNull();
+  });
+
+  test('tolerates missing/empty inputs', () => {
+    expect(cjkPromotedFontFamily('', '设计')).toBeNull();
+    expect(cjkPromotedFontFamily(SANS, '')).toBeNull();
+  });
+
+  test('matches CJK families case-insensitively and with system names', () => {
+    expect(
+      cjkPromotedFontFamily("Inter, 'microsoft yahei', sans-serif", '设计')!.split(',')[0].trim(),
+    ).toBe("'microsoft yahei'");
+    expect(
+      cjkPromotedFontFamily('Inter, PingFang SC, sans-serif', '设计')!.split(',')[0].trim(),
+    ).toBe('PingFang SC');
+  });
+});
+
+describe('runDomToPptx CJK typeface wiring', () => {
+  test('the editable-PPTX DOM prep promotes CJK typefaces before export', () => {
+    const source = runDomToPptx.toString();
+    // The preprocessing step runs and delegates to the shared resolver, so the
+    // pure helper above genuinely governs the exported deck. (Type annotations are
+    // erased by the transpiler, so match the runtime call shape.)
+    expect(source).toContain('promoteCjkTypefaces(slides');
+    expect(source).toContain('cjkPromotedFontFamily(getComputedStyle(el).fontFamily');
+  });
+
+  test('the injected export wrapper is syntactically valid JS', () => {
+    // renderEditablePptx serializes cjkPromotedFontFamily into the same scope as
+    // runDomToPptx so the free reference resolves in the render window. A
+    // serialization/scoping slip would ship a SyntaxError that silently produces
+    // no PPTX, so parse (never invoke) the exact wrapper the export runs.
+    const wrapped = `(() => { const cjkPromotedFontFamily = ${cjkPromotedFontFamily.toString()}; return (${runDomToPptx.toString()})(".slide"); })()`;
+    expect(() => new Function(`return function(){ return ${wrapped}; };`)).not.toThrow();
+  });
+});

--- a/apps/desktop/tests/main/pptx-cjk-typeface.test.ts
+++ b/apps/desktop/tests/main/pptx-cjk-typeface.test.ts
@@ -41,6 +41,18 @@ describe('cjkPromotedFontFamily', () => {
     expect(promoted!.split(',')[0].trim()).toBe('"Noto Sans SC"');
   });
 
+  test('a Latin prefix followed by a CJK suffix still promotes (combined-text contract)', () => {
+    // promoteCjkTypefaces feeds the resolver an element's COMBINED direct text, so
+    // bilingual markup split across text nodes (`Product Launch<br>产品发布`) whose
+    // Latin chunk comes first must still resolve to the CJK typeface.
+    expect(cjkPromotedFontFamily(SANS, 'Product Launch产品发布')!.split(',')[0].trim()).toBe(
+      '"Noto Sans SC"',
+    );
+    expect(cjkPromotedFontFamily(SANS, 'Welcome to Open Design 欢迎')!.split(',')[0].trim()).toBe(
+      '"Noto Sans SC"',
+    );
+  });
+
   test('promotes the serif CJK family for serif stacks', () => {
     const promoted = cjkPromotedFontFamily(SERIF, '演示文稿');
     expect(promoted!.split(',')[0].trim()).toBe('"Noto Serif SC"');
@@ -98,7 +110,10 @@ describe('runDomToPptx CJK typeface wiring', () => {
     // pure helper above genuinely governs the exported deck. (Type annotations are
     // erased by the transpiler, so match the runtime call shape.)
     expect(source).toContain('promoteCjkTypefaces(slides');
-    expect(source).toContain('cjkPromotedFontFamily(getComputedStyle(el).fontFamily');
+    // The walk aggregates an element's combined direct text before resolving, so a
+    // CJK chunk after a Latin one is never skipped (multi-text-node regression).
+    expect(source).toContain('child.nodeType === Node.TEXT_NODE');
+    expect(source).toContain('cjkPromotedFontFamily(getComputedStyle(el).fontFamily, combined)');
   });
 
   test('the injected export wrapper is syntactically valid JS', () => {


### PR DESCRIPTION
<!-- Source: external tracker (not a GitHub issue) -->
Source issue: https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/da351ee7-d85b-46e4-b3cd-e35e2f659203 — “设计师在导出设计稿为PPTX文件时，字体和样式在PowerPoint、WPS、Keynote中显示错乱”.

## Why

A designer reported that decks exported to **editable PPTX** (the default deck → `.pptx` mode) render with the wrong font in PowerPoint, WPS and Keynote, so the file can't be handed to a client as-is. That directly hurts the "generate a deck in Open Design → deliver a polished PPTX" job the export feature exists for.

Root cause (not the symptom): editable PPTX export hands each slide's live DOM to the vendored `dom-to-pptx` engine, which names **one** typeface per text run — the first family in the CSS `font-family` stack — and writes it to the PowerPoint `<a:latin>`, `<a:ea>` (East-Asian) and `<a:cs>` slots alike. The `html-ppt` templates lead every stack with a Latin-only webfont, e.g. `--font-sans: 'Inter','Noto Sans SC',…`. In the browser, CJK glyphs are drawn by the later `Noto Sans SC` via per-glyph fallback and look correct — but the export mislabels those runs with `Inter`, which has **no** CJK glyphs. PowerPoint, WPS and Keynote each then substitute a *different* default CJK font, so the same deck renders three different (wrong) ways — the "字体错乱" users see. Because the substitution only happens for glyphs the named font lacks, this is invisible for English decks and only bites CJK content.

## What users will see

CJK (Chinese / Japanese / Korean) decks exported as editable PPTX now open with the intended CJK font — and render consistently across PowerPoint, WPS and Keynote — instead of each app picking its own fallback. English / Latin decks are unchanged. No UI, setting, or workflow change; the fix is inside the shared off-screen export renderer, so both the web **Export → PPTX (editable)** button and the `od export … --editable` CLI path get it automatically.

## Surface area

- [x] **None** — internal fix to the desktop export renderer + tests. (Both export surfaces — web UI and `od` CLI — call the same daemon route, so no per-surface change is needed.)

## Screenshots

Not a discoverability change — the export entry point (FileViewer → Export → PPTX, mode `editable`) is untouched. The difference is inside the produced `.pptx`: CJK runs now name their CJK typeface instead of `Inter`.

## Bug fix verification

- Test path that reproduces the bug: `apps/desktop/tests/main/pptx-cjk-typeface.test.ts`
- Did the test go red on `main` and green on this branch? **yes** — reverting only the `deck-capture.ts` change (keeping the test) makes all cases fail (`cjkPromotedFontFamily` is undefined and the wiring assertions miss); with the fix all 14 pass.
- The spec pins the invariant as a pure resolver (`cjkPromotedFontFamily`) — e.g. the real `'Inter','Noto Sans SC',…` stack + Chinese text must resolve to `Noto Sans SC` leading, Latin-only text must be left untouched — plus structural + syntax guards that the resolver is actually wired into the serialized `runDomToPptx` export path.

### Adjacent issues (out of scope, noted for follow-up)

- **Webfont embedding**: `dom-to-pptx`'s `autoEmbedFonts` can't read the templates' cross-origin `@import url(https://fonts.googleapis.com/…)` sheets (CSSOM `SecurityError`) and Google serves `woff2` (needs a WASM decompressor that isn't wired up), so no webfont is *embedded* today. This fix makes PowerPoint/WPS/Keynote resolve the correct *named* CJK font consistently; fully embedding arbitrary webfonts is a separate, larger change (self-hosting fonts same-origin) and is left as a follow-up.

## Validation

- `pnpm guard` — pass
- `pnpm --filter @open-design/desktop typecheck` — pass
- `pnpm --filter @open-design/desktop test` — the new suite passes (14/14); full suite has 1 pre-existing, date-sensitive failure in `updater.test.ts` unrelated to this change (confirmed red on baseline with my source change stashed).

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=claude-code · An autonomous AI dev team for your GitHub repos.</sub>