### PR TITLE
fix(web): improve dark-mode toggle contrast

### DIFF
--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -17,6 +17,7 @@
   --border: #e1e5eb;
   --border-strong: #c9d0da;
   --border-soft: #edf0f4;
+  --toggle-track-off: var(--border-strong);
 
   --text: #1a1916;
   --text-strong: #0d0c0a;
@@ -111,6 +112,7 @@
   --border: #333128;
   --border-strong: #46433c;
   --border-soft: #2a2825;
+  --toggle-track-off: var(--text-soft);
 
   --text: #e8e4dc;
   --text-strong: #f2ede4;
@@ -164,6 +166,7 @@
     --border: #333128;
     --border-strong: #46433c;
     --border-soft: #2a2825;
+    --toggle-track-off: var(--text-soft);
 
     --text: #e8e4dc;
     --text-strong: #f2ede4;

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -3334,7 +3334,7 @@
   width: 32px;
   height: 18px;
   border-radius: var(--radius-pill);
-  background: var(--border-strong);
+  background: var(--toggle-track-off);
   transition: background 160ms var(--ease-out);
 }
 .toggle-row-switch::after {
@@ -3397,7 +3397,7 @@
   width: 28px;
   height: 16px;
   border-radius: var(--radius-pill);
-  background: var(--border-strong);
+  background: var(--toggle-track-off);
   transition: background 160ms var(--ease-out);
 }
 .compact-toggle-switch::after {

--- a/apps/web/tests/styles/toggle-contrast.test.ts
+++ b/apps/web/tests/styles/toggle-contrast.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const tokensCss = readFileSync(new URL('../../src/styles/tokens.css', import.meta.url), 'utf8');
+const artifactsCss = readFileSync(
+  new URL('../../src/styles/workspace/artifacts.css', import.meta.url),
+  'utf8',
+);
+
+function declarationsFor(css: string, selector: string): string {
+  const escapedSelector = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = css.match(new RegExp(`${escapedSelector}\\s*{([^}]*)}`));
+  expect(match, `missing CSS block for ${selector}`).toBeTruthy();
+  return match?.[1] ?? '';
+}
+
+describe('toggle off-state contrast', () => {
+  it('uses a theme-aware track token for shared toggle variants', () => {
+    expect(declarationsFor(tokensCss, ':root')).toContain(
+      '--toggle-track-off: var(--border-strong);',
+    );
+    expect(declarationsFor(tokensCss, '[data-theme="dark"]')).toContain(
+      '--toggle-track-off: var(--text-soft);',
+    );
+    expect(declarationsFor(tokensCss, 'html:not([data-theme])')).toContain(
+      '--toggle-track-off: var(--text-soft);',
+    );
+    expect(declarationsFor(artifactsCss, '.toggle-row-switch')).toContain(
+      'background: var(--toggle-track-off);',
+    );
+    expect(declarationsFor(artifactsCss, '.compact-toggle-switch')).toContain(
+      'background: var(--toggle-track-off);',
+    );
+  });
+});


### PR DESCRIPTION
Fixes #5298

## Why

I picked up this community issue after it was reopened because the previous draft had gone inactive. In dark mode, the off-state speaker-notes toggle blended into the Quick Confirm/project-creation surface, making the control hard to discover and its state harder to read.

The root cause was that both shared toggle variants used `--border-strong` for their off-state track. Against `--bg-panel` in the dark theme, that combination measured only 1.63:1 contrast.

## What users will see

Off-state toggles are now visibly distinct from dark panels. The track contrast rises from 1.63:1 to 3.03:1, while the light theme and enabled-state styling remain unchanged.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

| Before (issue report) | After (this branch) |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/730d8828-03be-4512-b46b-ad52a5eceb8b" width="420" alt="Low-contrast toggle in the original dark-mode report"> | <img src="https://raw.githubusercontent.com/ckdwns9121/open-design/pr-assets-5298/.github/pr-assets/5298-after.png" width="420" alt="Visible off-state speaker-notes toggle in the dark-mode slide-deck flow"> |

## Bug fix verification

- Test path: `apps/web/tests/styles/toggle-contrast.test.ts`
- The focused test went red on `main` and green after the token and consumer changes.
- Playwright rendered the real dark-mode Slide deck entry flow and confirmed the speaker-notes toggle remained visible.

## Validation

- Node `24.18.0`
- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web test` — 423 files passed, 4,427 tests passed, 7 skipped
- Focused style tests — 2 files passed, 5 tests passed
- Playwright `project-management-flows` dark-mode deck path — 1 passed
- Manual contrast calculation: 1.63:1 → 3.03:1 against `--bg-panel`

## Prior work

This takeover follows the token-driven direction already reviewed in #5313. Credit to @someshk1703 for the original implementation approach; this PR adds the red-to-green regression spec and rendered validation evidence needed to carry the reopened issue forward.
