### PR TITLE
fix(daemon): recover PPTX export renderer failures

### DIFF
--- a/apps/daemon/src/http/response.ts
+++ b/apps/daemon/src/http/response.ts
@@ -25,6 +25,7 @@ const ERROR_STATUS_BY_CODE: Partial<Record<ApiErrorCode, number>> = {
   INTERNAL_ERROR: 500,
   AGENT_UNAVAILABLE: 503,
   UPSTREAM_UNAVAILABLE: 502,
+  DESKTOP_SIDECAR_UNKNOWN_MESSAGE: 502,
 };
 
 export function statusForError(error: ApiError): number {

--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -1,5 +1,6 @@
 import type { Express, Response } from 'express';
 import { PROJECT_EXPORT_MANIFEST_SCHEMA, isExportFormat } from '@open-design/contracts';
+import type { DesktopRenderSlidesInput, DesktopRenderSlidesResult } from '@open-design/sidecar-proto';
 import nodePath from 'node:path';
 import { readFile, rm } from 'node:fs/promises';
 import type { RouteDeps } from './server-context.js';
@@ -23,6 +24,28 @@ import { sandboxImportedProjectRootUnavailableReason } from './sandbox-mode.js';
 import { parseOrchestratorWorkspace } from './workspace-contract.js';
 
 export interface RegisterImportRoutesDeps extends RouteDeps<'db' | 'http' | 'uploads' | 'node' | 'ids' | 'paths' | 'imports' | 'auth' | 'projectStore' | 'conversations' | 'projectFiles' | 'validation'> {}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * A freshly updated daemon can ask an older still-running desktop main process
+ * to handle `render-slides`. Retrying screenshot PPTX cannot help there because
+ * both editable and screenshot PPTX use the same desktop message.
+ */
+function isSidecarVersionSkewError(err: unknown): boolean {
+  return /unknown \w+ sidecar message/i.test(errorMessage(err));
+}
+
+/**
+ * Editable PPTX depends on the vendored dom-to-pptx browser bundle. If only
+ * that bundle path is broken, the desktop renderer can still capture slide
+ * screenshots, so the daemon can return a usable screenshot PPTX.
+ */
+function isRendererBundleMissingError(err: unknown): boolean {
+  return /dom-to-pptx vendor bundle not found/i.test(errorMessage(err));
+}
 
 export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps) {
   const { db } = ctx;
@@ -627,16 +650,56 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
       // renderer outage — surface it as 502 UPSTREAM_UNAVAILABLE (matching the
       // `!rendered.ok` branch below), not the outer 400 BAD_REQUEST which is for
       // genuine request-validation / assembly errors.
-      let rendered;
+      let rendered: DesktopRenderSlidesResult;
+      const sendSidecarSkewError = (err: unknown) =>
+        sendApiError(
+          res,
+          502,
+          'DESKTOP_SIDECAR_UNKNOWN_MESSAGE',
+          `desktop renderer does not support render-slides: ${errorMessage(err)}`,
+          {
+            details: {
+              hint: 'Restart or update the desktop app so the daemon and desktop renderer use the same version.',
+            },
+            retryable: true,
+          },
+        );
+      const renderScreenshotPptxFallback = async (): Promise<DesktopRenderSlidesResult | null> => {
+        const fallbackInput: DesktopRenderSlidesInput = { ...input, editable: false };
+        try {
+          return await desktopSlideRenderer(fallbackInput);
+        } catch (fallbackErr: any) {
+          if (isSidecarVersionSkewError(fallbackErr)) {
+            sendSidecarSkewError(fallbackErr);
+          } else {
+            sendApiError(
+              res,
+              502,
+              'UPSTREAM_UNAVAILABLE',
+              `desktop renderer unavailable: ${errorMessage(fallbackErr)}`,
+            );
+          }
+          return null;
+        }
+      };
       try {
         rendered = await desktopSlideRenderer(input);
       } catch (err: any) {
-        return sendApiError(
-          res,
-          502,
-          'UPSTREAM_UNAVAILABLE',
-          `desktop renderer unavailable: ${err?.message || String(err)}`,
-        );
+        if (isSidecarVersionSkewError(err)) {
+          return sendSidecarSkewError(err);
+        }
+        if (renderOptions.editable && isRendererBundleMissingError(err)) {
+          const fallback = await renderScreenshotPptxFallback();
+          if (!fallback) return;
+          rendered = fallback;
+        } else {
+          return sendApiError(
+            res,
+            502,
+            'UPSTREAM_UNAVAILABLE',
+            `desktop renderer unavailable: ${errorMessage(err)}`,
+          );
+        }
       }
       const tRendered = Date.now();
 
@@ -648,15 +711,17 @@ export function registerProjectExportRoutes(app: Express, ctx: RegisterProjectEx
       // Editable PPTX: the renderer wrote a finished .pptx (native shapes/text)
       // to the scratch dir. Stream it directly — no image assembly. Confine the
       // path to the scratch dir, same defense as the image handoff.
-      if (renderOptions.editable) {
-        if (!rendered.ok || typeof rendered.pptxFile !== 'string') {
-          return sendApiError(
-            res,
-            502,
-            'UPSTREAM_UNAVAILABLE',
-            rendered.error || 'editable PPTX renderer returned no file',
-          );
-        }
+      if (
+        renderOptions.editable &&
+        (!rendered.ok || typeof rendered.pptxFile !== 'string') &&
+        isRendererBundleMissingError(rendered.error)
+      ) {
+        const fallback = await renderScreenshotPptxFallback();
+        if (!fallback) return;
+        rendered = fallback;
+      }
+
+      if (renderOptions.editable && rendered.ok && typeof rendered.pptxFile === 'string') {
         const canonicalDir = await fs.promises.realpath(renderOutputDir).catch(() => renderOutputDir);
         const realPptx = await fs.promises.realpath(rendered.pptxFile).catch(() => null);
         if (!realPptx || (realPptx !== canonicalDir && !realPptx.startsWith(canonicalDir + path.sep))) {

--- a/apps/daemon/tests/screenshot-export-file-handoff.test.ts
+++ b/apps/daemon/tests/screenshot-export-file-handoff.test.ts
@@ -271,6 +271,70 @@ describe('screenshot export desktop renderer file handoff', () => {
     expect(bytes.equals(PPTX)).toBe(true);
   });
 
+  it('returns a structured sidecar-skew error when an older desktop does not know render-slides', async () => {
+    const skewedRenderer = async (): Promise<DesktopRenderSlidesResult> => {
+      throw new Error('unknown desktop sidecar message: render-slides');
+    };
+    const srv = (await startServer({
+      port: 0,
+      returnServer: true,
+      desktopSlideRenderer: skewedRenderer,
+    })) as { url: string; server: http.Server };
+    try {
+      const res = await fetch(`${srv.url}/api/projects/${projectId}/export/pptx`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ fileName: 'index.html', editable: true }),
+      });
+      expect(res.status).toBe(502);
+      const body = (await res.json()) as {
+        error?: { code?: string; details?: { hint?: string }; message?: string; retryable?: boolean };
+      };
+      expect(body.error?.code).toBe('DESKTOP_SIDECAR_UNKNOWN_MESSAGE');
+      expect(body.error?.message).toContain('render-slides');
+      expect(body.error?.details?.hint).toContain('Restart or update');
+      expect(body.error?.retryable).toBe(true);
+    } finally {
+      await new Promise<void>((resolve) => srv.server.close(() => resolve()));
+    }
+  });
+
+  it('falls back to screenshot PPTX when editable rendering cannot load the dom-to-pptx bundle', async () => {
+    const fallbackInputs: DesktopRenderSlidesInput[] = [];
+    const bundleMissingRenderer = async (input: DesktopRenderSlidesInput): Promise<DesktopRenderSlidesResult> => {
+      fallbackInputs.push(input);
+      if (input.editable) throw new Error('dom-to-pptx vendor bundle not found');
+      if (!input.outputDir) return { ok: false, error: 'expected an outputDir handoff' };
+      await mkdir(input.outputDir, { recursive: true });
+      const file = path.join(input.outputDir, 'slide-0.png');
+      await writeFile(file, PNG);
+      return { ok: true, slideFiles: [file], width: 1920, height: 1080, mode: 'deck' };
+    };
+    const srv = (await startServer({
+      port: 0,
+      returnServer: true,
+      desktopSlideRenderer: bundleMissingRenderer,
+    })) as { url: string; server: http.Server };
+    try {
+      const res = await fetch(`${srv.url}/api/projects/${projectId}/export/pptx`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ fileName: 'index.html', editable: true }),
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toContain(
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+      );
+      const bytes = Buffer.from(await res.arrayBuffer());
+      expect(bytes.subarray(0, 2).toString('latin1')).toBe('PK');
+      expect(fallbackInputs).toHaveLength(2);
+      expect(fallbackInputs[0]?.editable).toBe(true);
+      expect(fallbackInputs[1]?.editable).toBe(false);
+    } finally {
+      await new Promise<void>((resolve) => srv.server.close(() => resolve()));
+    }
+  });
+
   it('returns 422 when PPTX export is requested for a non-deck page', async () => {
     const noSlideRenderer = async (): Promise<DesktopRenderSlidesResult> => ({
       ok: false,

--- a/packages/contracts/src/errors.ts
+++ b/packages/contracts/src/errors.ts
@@ -79,6 +79,10 @@ export const API_ERROR_CODES = [
   // `tools live-artifacts create` path) as a 422.
   'ARTIFACT_PUBLICATION_BLOCKED',
   'UPSTREAM_UNAVAILABLE',
+  // The daemon and desktop sidecar contract are version-skewed. A newer daemon
+  // sent a message such as `render-slides`, but the running desktop main process
+  // predates that message and rejected it before rendering could start.
+  'DESKTOP_SIDECAR_UNKNOWN_MESSAGE',
   'RATE_LIMITED',
   // PR #974 round-4: desktop-paired daemon received an import request
   // but the desktop main process has not yet registered its HMAC secret

--- a/tools/pack/src/win/builder.ts
+++ b/tools/pack/src/win/builder.ts
@@ -127,46 +127,17 @@ async function writeWebStandaloneHookConfig(config: ToolPackConfig, paths: WinPa
   return paths.webStandaloneHookConfigPath;
 }
 
-async function runElectronBuilderRaw(
+export function createWinElectronBuilderConfig(
   config: ToolPackConfig,
   paths: WinPaths,
-  projectDir: string,
-): Promise<WinPackTiming[]> {
-  const segments: WinPackTiming[] = [];
-  const runSegment = async <T>(
-    phase: string,
-    task: () => Promise<T>,
-    details?: Record<string, unknown>,
-  ): Promise<T> => {
-    const startedAt = Date.now();
-    logWinBuildProgress("segment:start", { phase });
-    try {
-      const result = await task();
-      logWinBuildProgress("segment:done", { durationMs: Date.now() - startedAt, phase });
-      return result;
-    } catch (error) {
-      logWinBuildProgress("segment:failed", {
-        durationMs: Date.now() - startedAt,
-        error: error instanceof Error ? error.message : String(error),
-        phase,
-      });
-      throw error;
-    } finally {
-      segments.push({ details, durationMs: Date.now() - startedAt, phase });
-    }
-  };
-
-  const namespaceToken = sanitizeNamespace(config.namespace);
-  const packagedVersion = await runSegment("electron-builder-raw:read-packaged-version", async () =>
-    readPackagedVersion(config)
-  );
-  const packageVersion = electronBuilderVersionForAppVersion(packagedVersion);
-  const webStandaloneHookConfigPath = config.webOutputMode === "standalone"
-    ? await runSegment("electron-builder-raw:write-web-standalone-hook-config", async () =>
-      writeWebStandaloneHookConfig(config, paths)
-    )
-    : null;
-  const builderConfig = {
+  options: {
+    namespaceToken: string;
+    packageVersion: string;
+    webStandaloneHookConfigPath: string | null;
+  },
+) {
+  const { namespaceToken, packageVersion, webStandaloneHookConfigPath } = options;
+  return {
     appId: "io.open-design.desktop",
     afterPack: webStandaloneHookConfigPath == null ? undefined : winResources.webStandaloneAfterPackHook,
     asar: ELECTRON_BUILDER_ASAR,
@@ -224,6 +195,52 @@ async function runElectronBuilderRaw(
       target: resolveElectronBuilderWinTargets(config.to).map((target) => ({ arch: ["x64"], target })),
     },
   };
+}
+
+async function runElectronBuilderRaw(
+  config: ToolPackConfig,
+  paths: WinPaths,
+  projectDir: string,
+): Promise<WinPackTiming[]> {
+  const segments: WinPackTiming[] = [];
+  const runSegment = async <T>(
+    phase: string,
+    task: () => Promise<T>,
+    details?: Record<string, unknown>,
+  ): Promise<T> => {
+    const startedAt = Date.now();
+    logWinBuildProgress("segment:start", { phase });
+    try {
+      const result = await task();
+      logWinBuildProgress("segment:done", { durationMs: Date.now() - startedAt, phase });
+      return result;
+    } catch (error) {
+      logWinBuildProgress("segment:failed", {
+        durationMs: Date.now() - startedAt,
+        error: error instanceof Error ? error.message : String(error),
+        phase,
+      });
+      throw error;
+    } finally {
+      segments.push({ details, durationMs: Date.now() - startedAt, phase });
+    }
+  };
+
+  const namespaceToken = sanitizeNamespace(config.namespace);
+  const packagedVersion = await runSegment("electron-builder-raw:read-packaged-version", async () =>
+    readPackagedVersion(config)
+  );
+  const packageVersion = electronBuilderVersionForAppVersion(packagedVersion);
+  const webStandaloneHookConfigPath = config.webOutputMode === "standalone"
+    ? await runSegment("electron-builder-raw:write-web-standalone-hook-config", async () =>
+      writeWebStandaloneHookConfig(config, paths)
+    )
+    : null;
+  const builderConfig = createWinElectronBuilderConfig(config, paths, {
+    namespaceToken,
+    packageVersion,
+    webStandaloneHookConfigPath,
+  });
 
   await runSegment("electron-builder-raw:prepare-config", async () => {
     await removeTree(paths.appBuilderOutputRoot);

--- a/tools/pack/tests/win-builder.test.ts
+++ b/tools/pack/tests/win-builder.test.ts
@@ -7,7 +7,8 @@ import { promisify } from "node:util";
 import { NtExecutable, NtExecutableResource, Resource } from "resedit";
 import { describe, expect, it } from "vitest";
 
-import { materializeCachedUnpackedForInstaller } from "../src/win/builder.js";
+import { domToPptxBundleResource } from "../src/dom-to-pptx-resource.js";
+import { createWinElectronBuilderConfig, materializeCachedUnpackedForInstaller } from "../src/win/builder.js";
 import { createLauncherRuntimeSyncPowerShellScript } from "../src/win/custom-installer.js";
 import type { WinPaths } from "../src/win/types.js";
 import { readWinExecutableVersionSnapshot } from "../src/win/version-resource.js";
@@ -125,6 +126,36 @@ describe("materializeCachedUnpackedForInstaller", () => {
 });
 
 describe("Windows pack artifact boundaries", () => {
+  it("wires the dom-to-pptx bundle into electron-builder extraResources", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-builder-config-"));
+    const paths = createPaths(root);
+    const config = {
+      electronBuilderCliPath: "electron-builder",
+      electronVersion: "38.0.0",
+      namespace: "second",
+      portable: false,
+      to: "nsis",
+      webOutputMode: "standalone",
+      workspaceRoot: root,
+    } as Parameters<typeof createWinElectronBuilderConfig>[0];
+
+    try {
+      const builderConfig = createWinElectronBuilderConfig(config, paths, {
+        namespaceToken: "second",
+        packageVersion: "0.13.1",
+        webStandaloneHookConfigPath: null,
+      });
+
+      expect(builderConfig.extraResources).toContainEqual(domToPptxBundleResource(config));
+      expect(builderConfig.extraResources).toContainEqual({
+        from: join(root, "apps", "desktop", "vendor", "dom-to-pptx", "dom-to-pptx.bundle.js.gz"),
+        to: "dom-to-pptx.bundle.js.gz",
+      });
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
   it("does not build launcher payload artifacts for a pure dir target", async () => {
     const source = await readFile(new URL("../src/win/build.ts", import.meta.url), "utf8");
     expect(source).toContain("const hasLauncherPayloadTarget = hasNsisTarget || hasZipTarget");


### PR DESCRIPTION
## Why

This fixes the externally reported Windows PPTX export failure from Plane: https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/dd58b5b4-7cea-4699-912b-532d924da92f.

The user-facing pain is that PPTX export is a core presentation handoff path. The observed `unknown desktop sidecar message: render-slides` fingerprint points to daemon/desktop version skew: a newer daemon can ask an older still-running desktop renderer to handle `render-slides`, and the old desktop rejects the message before any export can happen. A second adjacent failure mode is Windows editable PPTX packaging/resource resolution: if the vendored `dom-to-pptx` bundle is missing, editable export fails even though screenshot rendering can still produce a usable deck.

## What users will see

PPTX export failures from a version-skewed desktop renderer now return a structured, actionable error that tells users to restart or update the desktop app instead of a generic opaque renderer failure.

When editable PPTX rendering fails specifically because the `dom-to-pptx` bundle is unavailable but the desktop renderer is otherwise reachable, export retries as screenshot PPTX so users still receive an openable `.pptx` file.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. This is an export/runtime error handling fix with no new UI entry point.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/screenshot-export-file-handoff.test.ts`
  - `returns a structured sidecar-skew error when an older desktop does not know render-slides`
  - `falls back to screenshot PPTX when editable rendering cannot load the dom-to-pptx bundle`
- Packaging guard: `tools/pack/tests/win-builder.test.ts`
  - `wires the dom-to-pptx bundle into electron-builder extraResources`
- Red/green: the new packaging guard failed before the builder-config extraction (`createWinElectronBuilderConfig is not a function`) and passed after the fix. The daemon repros encode the two runtime failure modes and pass against the fixed route. I did not run a native Windows 0.13.0 installer reproduction in this environment; the HTTP-boundary tests simulate the observed desktop sidecar responses.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/screenshot-export-file-handoff.test.ts`
- `pnpm --filter @open-design/tools-pack exec vitest run tests/win-builder.test.ts`
- `pnpm --filter @open-design/web exec vitest run tests/analytics/export-error-code.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/tools-pack typecheck`
- `pnpm --filter @open-design/contracts typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/daemon build`
- `pnpm --filter @open-design/tools-pack build`

Note: this machine is running Node v22.22.0, while the repo target is Node `~24`; all commands above completed with the expected engine warning.

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>