### PR TITLE
fix: align PDF export width with preview

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -372,7 +372,7 @@ Options:
   --format <fmt>           One of: ${EXPORT_FORMATS.join(' | ')} (required)
   --out <path>             Write the file here (defaults to the suggested name)
   --image-format <fmt>     png | jpeg (for --format image)
-  --width <px>             Responsive layout width for PDF page exports
+  --width <px>             Responsive layout width for --format pdf --page
   --deck                   Treat the artifact as a multi-slide deck
   --page, --no-deck        Treat the artifact as a normal scrollable page
   --title <title>          Title used for metadata / default filename
@@ -455,6 +455,10 @@ async function runExport(args) {
     });
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));
+    process.exit(2);
+  }
+  if (width !== undefined && deckMode !== false) {
+    console.error('--width is only valid for page PDF exports; pass --page or --no-deck');
     process.exit(2);
   }
   const requestBody = buildExportCliRequestBody({

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -350,7 +350,7 @@ const SUBCOMMAND_MAP = {
 };
 
 const EXPORT_STRING_FLAGS = new Set([
-  'daemon-url', 'project', 'format', 'out', 'output', 'image-format', 'title', 'file',
+  'daemon-url', 'project', 'format', 'out', 'output', 'image-format', 'title', 'file', 'width',
 ]);
 const EXPORT_BOOLEAN_FLAGS = new Set(['help', 'h', 'json', 'deck', 'page', 'no-deck']);
 // EXPORT_FORMATS / EXPORT_IMAGE_FORMATS are the shared contract DTO (single
@@ -372,6 +372,7 @@ Options:
   --format <fmt>           One of: ${EXPORT_FORMATS.join(' | ')} (required)
   --out <path>             Write the file here (defaults to the suggested name)
   --image-format <fmt>     png | jpeg (for --format image)
+  --width <px>             Responsive layout width for PDF page exports
   --deck                   Treat the artifact as a multi-slide deck
   --page, --no-deck        Treat the artifact as a normal scrollable page
   --title <title>          Title used for metadata / default filename
@@ -382,6 +383,16 @@ Examples:
   od export index.html --project p1 --format pdf --out page.pdf
   od export slide.html --project p1 --format image --image-format png --out slide.png
   od export deck.html --project p1 --format pptx --out deck.pptx`);
+}
+
+function parseExportWidth(value) {
+  if (value == null) return undefined;
+  const raw = String(value).trim();
+  const width = Number(raw);
+  if (!Number.isFinite(width) || width <= 0) {
+    throw new Error('--width must be a positive number of pixels');
+  }
+  return Math.round(width);
 }
 
 async function runExport(args) {
@@ -416,6 +427,17 @@ async function runExport(args) {
     console.error('--image-format is only valid with --format image');
     process.exit(2);
   }
+  let width;
+  try {
+    width = parseExportWidth(flags.width);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(2);
+  }
+  if (width !== undefined && format !== 'pdf') {
+    console.error('--width is only valid with --format pdf');
+    process.exit(2);
+  }
   const base = await cliDaemonBaseUrl(flags);
   // All three formats rasterize through the desktop screenshot renderer so the
   // CLI matches the UI exactly. In particular `pdf` uses `/export/pdf-image`
@@ -439,6 +461,7 @@ async function runExport(args) {
     fileName: file,
     format,
     deck: deckMode,
+    ...(width !== undefined ? { width } : {}),
     ...(format === 'image' && flags['image-format'] ? { imageFormat: flags['image-format'] } : {}),
     ...(flags.title ? { title: flags.title } : {}),
   });

--- a/apps/daemon/src/export-cli-request.ts
+++ b/apps/daemon/src/export-cli-request.ts
@@ -38,7 +38,7 @@ export function buildExportCliRequestBody(options: ExportCliRequestOptions): Rec
     // PPTX is deck-only. For PDF/image, omit `deck` unless the caller explicitly
     // chooses deck/page mode so the daemon can still auto-detect by default.
     ...(deck !== undefined ? { deck } : {}),
-    ...(typeof options.width === "number" ? { width: options.width } : {}),
+    ...(options.format === "pdf" && deck === false && typeof options.width === "number" ? { width: options.width } : {}),
     ...(options.format === "image" && options.imageFormat ? { imageFormat: options.imageFormat } : {}),
     ...(options.title ? { title: options.title } : {}),
   };

--- a/apps/daemon/src/export-cli-request.ts
+++ b/apps/daemon/src/export-cli-request.ts
@@ -6,6 +6,7 @@ export interface ExportCliRequestOptions {
   deck?: boolean;
   imageFormat?: ExportImageFormat;
   title?: string;
+  width?: number;
 }
 
 export interface ExportCliDeckModeOptions {
@@ -37,6 +38,7 @@ export function buildExportCliRequestBody(options: ExportCliRequestOptions): Rec
     // PPTX is deck-only. For PDF/image, omit `deck` unless the caller explicitly
     // chooses deck/page mode so the daemon can still auto-detect by default.
     ...(deck !== undefined ? { deck } : {}),
+    ...(typeof options.width === "number" ? { width: options.width } : {}),
     ...(options.format === "image" && options.imageFormat ? { imageFormat: options.imageFormat } : {}),
     ...(options.title ? { title: options.title } : {}),
   };

--- a/apps/daemon/tests/export-cli-routing.test.ts
+++ b/apps/daemon/tests/export-cli-routing.test.ts
@@ -101,9 +101,20 @@ describe('buildExportCliRequestBody', () => {
   });
 
   it('serializes explicit export width for responsive PDF/page exports', () => {
-    expect(buildExportCliRequestBody({ fileName: 'landing.html', format: 'pdf', width: 820 })).toEqual({
+    expect(buildExportCliRequestBody({ fileName: 'landing.html', format: 'pdf', deck: false, width: 820 })).toEqual({
       fileName: 'landing.html',
+      deck: false,
       width: 820,
+    });
+  });
+
+  it('does not serialize width for deck or auto-detected PDF exports', () => {
+    expect(buildExportCliRequestBody({ fileName: 'deck.html', format: 'pdf', deck: true, width: 820 })).toEqual({
+      fileName: 'deck.html',
+      deck: true,
+    });
+    expect(buildExportCliRequestBody({ fileName: 'maybe-deck.html', format: 'pdf', width: 820 })).toEqual({
+      fileName: 'maybe-deck.html',
     });
   });
 

--- a/apps/daemon/tests/export-cli-routing.test.ts
+++ b/apps/daemon/tests/export-cli-routing.test.ts
@@ -100,6 +100,13 @@ describe('buildExportCliRequestBody', () => {
     });
   });
 
+  it('serializes explicit export width for responsive PDF/page exports', () => {
+    expect(buildExportCliRequestBody({ fileName: 'landing.html', format: 'pdf', width: 820 })).toEqual({
+      fileName: 'landing.html',
+      width: 820,
+    });
+  });
+
   it('rejects conflicting or impossible CLI deck/page modes', () => {
     expect(() => resolveExportCliDeckMode({ format: 'pdf', deck: true, page: true })).toThrow(
       /cannot be combined/,

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -904,6 +904,33 @@ export function effectivePreviewScale(
   return Math.min(previewScale, fitScale);
 }
 
+function positiveLayoutWidth(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? Math.round(value)
+    : undefined;
+}
+
+export function screenshotPdfExportWidth(opts: {
+  deck: boolean;
+  viewport: PreviewViewportId;
+  iframe?: HTMLIFrameElement | null;
+  previewBodySize?: PreviewCanvasSize;
+}): number | undefined {
+  if (opts.deck) return undefined;
+  const preset = PREVIEW_VIEWPORT_PRESETS.find((item) => item.id === opts.viewport);
+  if (preset?.width) return preset.width;
+  const iframe = opts.iframe ?? null;
+  try {
+    const documentWidth = positiveLayoutWidth(iframe?.contentDocument?.documentElement?.clientWidth);
+    if (documentWidth) return documentWidth;
+  } catch {
+    // Cross-origin powered previews may not expose their document. Fall back to
+    // the iframe box, then the preview canvas, so desktop exports still match
+    // the visible layout as closely as the host allows.
+  }
+  return positiveLayoutWidth(iframe?.clientWidth) ?? positiveLayoutWidth(opts.previewBodySize?.width);
+}
+
 type PreviewOverlayTransform = { scale: number; offsetX: number; offsetY: number };
 
 export function previewOverlayTransform(
@@ -10045,6 +10072,12 @@ function HtmlViewer({
     const pdfSource = context?.content ?? source ?? '';
     const pdfDeck = deckExportSignalForContext(context);
     if (isOpenDesignHostAvailable()) {
+      const width = screenshotPdfExportWidth({
+        deck: pdfDeck,
+        viewport: previewViewport,
+        iframe: iframeRef.current,
+        previewBodySize,
+      });
       const res = await exportProjectScreenshotPdf({
         projectId,
         fileName: file.name,
@@ -10054,6 +10087,7 @@ function HtmlViewer({
         // the SAME signal, so an artifact exports identically with or without
         // a desktop host (no per-host divergence).
         deck: pdfDeck,
+        ...(width ? { width } : {}),
         ...(context?.versionId ? { versionId: context.versionId } : {}),
       });
       if (res.ok) return;

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -905,6 +905,7 @@ export async function exportProjectAsPptx(opts: {
   title?: string;
   format?: 'pptx' | 'pdf';
   deck?: boolean;
+  width?: number;
   versionId?: string;
   // pptx only: produce an editable deck (native shapes/text) instead of a
   // screenshot one (one image per slide).
@@ -927,6 +928,7 @@ export async function exportProjectAsPptx(opts: {
           : typeof opts.deck === 'boolean'
             ? { deck: opts.deck }
             : {}),
+        ...(format === 'pdf' && typeof opts.width === 'number' ? { width: opts.width } : {}),
       }),
     });
   } catch {
@@ -1092,6 +1094,7 @@ export function exportProjectScreenshotPdf(opts: {
   fileName: string;
   title?: string;
   deck?: boolean;
+  width?: number;
   versionId?: string;
 }): Promise<ProjectScreenshotExportResult> {
   return exportProjectAsPptx({ ...opts, format: 'pdf' });

--- a/apps/web/tests/components/file-viewer-version-download.test.tsx
+++ b/apps/web/tests/components/file-viewer-version-download.test.tsx
@@ -63,7 +63,7 @@ vi.mock('../../src/runtime/exports', async () => {
   };
 });
 
-import { FileViewer } from '../../src/components/FileViewer';
+import { FileViewer, screenshotPdfExportWidth } from '../../src/components/FileViewer';
 
 function htmlFile(): ProjectFile {
   return {
@@ -162,6 +162,36 @@ async function renderVersionDialog(file = htmlFile(), selected: 'current' | 'pri
 function openVersionDownloadMenu(versionDialog: HTMLElement, version = 1) {
   fireEvent.click(within(versionDialog).getByRole('button', { name: `Download Version ${version}` }));
 }
+
+describe('screenshotPdfExportWidth', () => {
+  it('uses fixed preview preset widths for responsive page exports', () => {
+    expect(screenshotPdfExportWidth({ deck: false, viewport: 'tablet' })).toBe(820);
+    expect(screenshotPdfExportWidth({ deck: false, viewport: 'mobile' })).toBe(390);
+  });
+
+  it('omits width for deck exports so slide stage measurement controls aspect ratio', () => {
+    expect(screenshotPdfExportWidth({ deck: true, viewport: 'tablet' })).toBeUndefined();
+  });
+
+  it('uses the active desktop iframe layout width when no fixed preset is selected', () => {
+    const iframe = document.createElement('iframe');
+    Object.defineProperty(iframe, 'contentDocument', {
+      value: { documentElement: { clientWidth: 1120 } },
+    });
+
+    expect(screenshotPdfExportWidth({ deck: false, viewport: 'desktop', iframe })).toBe(1120);
+  });
+
+  it('falls back to the preview canvas width when the desktop iframe cannot be measured', () => {
+    expect(
+      screenshotPdfExportWidth({
+        deck: false,
+        viewport: 'desktop',
+        previewBodySize: { width: 960, height: 640 },
+      }),
+    ).toBe(960);
+  });
+});
 
 describe('FileViewer version download actions', () => {
   afterEach(() => {

--- a/apps/web/tests/runtime/exports.test.ts
+++ b/apps/web/tests/runtime/exports.test.ts
@@ -18,6 +18,7 @@ import {
   exportProjectAsHtml,
   exportProjectAsPdf,
   exportProjectAsPptx,
+  exportProjectScreenshotPdf,
   exportProjectAsZip,
   openSandboxedPreviewInNewTab,
   prepareImageExportTarget,
@@ -777,6 +778,23 @@ describe('binary project/design-system downloads', () => {
 
     expect(fetch).toHaveBeenCalledWith('/api/projects/p/export/pdf-image', expect.anything());
     expect(capturedFilename).toBe('deck.pdf');
+  });
+
+  it('passes an explicit layout width through the raster PDF endpoint', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('%PDF-fake', { status: 200 })));
+
+    await exportProjectScreenshotPdf({
+      projectId: 'p',
+      fileName: 'responsive.html',
+      deck: false,
+      width: 820,
+    });
+
+    expect(fetch).toHaveBeenCalledWith('/api/projects/p/export/pdf-image', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ fileName: 'responsive.html', deck: false, width: 820 }),
+    });
   });
 
   it('reports 501 (no off-screen renderer) as unavailable, not a semantic error', async () => {


### PR DESCRIPTION
## Why

This PR implements the Plane bug request for PDF exports whose layout can drift from the HTML preview: https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/14ebd0b0-de70-455b-ba03-dceaf71e107b

Root cause: the daemon/desktop screenshot PDF route already accepts a render `width`, but the Web screenshot-PDF caller never sent the active preview width, and the `od export` CLI had no width entry point. Responsive artifacts therefore exported at the renderer fallback width instead of the preview breakpoint.

## What users will see

PDF exports from the Web preview now use the same responsive layout width the user is previewing: tablet exports at 820px, mobile exports at 390px, and desktop exports from the active iframe layout width when available. Deck PDF exports keep their existing slide-stage measurement behavior so non-16:9 decks are not distorted.

CLI users can now run `od export <file> --project <id> --format pdf --page --width <px> --out page.pdf` to request a matching responsive layout width through the same `/api/*` export path.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI surface changed; this is export request construction and CLI/API behavior.

## Bug fix verification

- Test paths that reproduce/lock the bug:
  - `apps/web/tests/runtime/exports.test.ts` checks that screenshot PDF requests include an explicit layout `width`.
  - `apps/web/tests/components/file-viewer-version-download.test.tsx` checks tablet/mobile preset widths, desktop iframe measurement, and the deck no-width guard.
  - `apps/daemon/tests/export-cli-routing.test.ts` checks that CLI export request bodies preserve explicit width.
- Red/green:
  - The daemon CLI request-body spec went red before implementation because `width` was omitted.
  - The Web request-body spec targets the missing Web caller layer from this bug and is green after the fix.

## Validation

- `pnpm install` to materialize workspace dependencies in this fresh worktree.
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/runtime/exports.test.ts tests/components/file-viewer-version-download.test.tsx` passed.
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/export-cli-routing.test.ts` passed.
- `pnpm --filter @open-design/web typecheck` passed.
- `pnpm --filter @open-design/daemon typecheck` passed.
- `pnpm guard` passed.
- `pnpm typecheck` passed.
- `pnpm --filter @open-design/desktop build` passed.
- Attempted full `pnpm --filter @open-design/web test` and `pnpm --filter @open-design/daemon test`; both were stopped after unrelated suite failures and repeated Vitest worker preload errors under local Node v22.22.0, while this repo requires Node ~24.

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>
