### PR TITLE
fix(desktop): auto-replace mac dmg updates

### DIFF
--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -1506,6 +1506,8 @@ script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
 owned_mount="$script_dir/dmg-mount-$$"
 plist_path="$script_dir/hdiutil-attach-$$.plist"
 mounted_path=""
+scratch_root=""
+preserve_scratch=0
 
 cleanup() {
   if [ -n "$mounted_path" ]; then
@@ -1513,6 +1515,9 @@ cleanup() {
   fi
   rmdir "$owned_mount" >/dev/null 2>&1 || true
   rm -f "$plist_path"
+  if [ "$preserve_scratch" != "1" ] && [ -n "$scratch_root" ]; then
+    rm -rf "$scratch_root"
+  fi
   rm -f "$0"
 }
 trap cleanup EXIT
@@ -1604,14 +1609,13 @@ else
   fi
 fi
 
-tmp_root="$target_parent/.od-update-tmp"
-backup_root="$target_parent/.od-update-back"
+scratch_root=$(mktemp -d "$target_parent/.od-update.XXXXXX") || fallback_open_installer
+tmp_root="$scratch_root/tmp"
+backup_root="$scratch_root/backup"
 tmp_bundle="$tmp_root/$target_base"
 backup_bundle="$backup_root/$target_base"
-rm -rf "$tmp_root" "$backup_root"
 mkdir -p "$tmp_root" "$backup_root" || fallback_open_installer
 if ! ditto "$source_app" "$tmp_bundle"; then
-  rm -rf "$tmp_root" "$backup_root"
   fallback_open_installer
 fi
 for attribute in com.apple.quarantine com.apple.provenance com.apple.macl; do
@@ -1619,22 +1623,22 @@ for attribute in com.apple.quarantine com.apple.provenance com.apple.macl; do
 done
 
 if ! mv "$target_bundle_path" "$backup_bundle"; then
-  rm -rf "$tmp_root" "$backup_root"
   fallback_open_installer
 fi
 if ! mv "$tmp_bundle" "$target_bundle_path"; then
   if [ -d "$backup_bundle" ] && [ ! -e "$target_bundle_path" ]; then
-    mv "$backup_bundle" "$target_bundle_path" >/dev/null 2>&1 || true
+    if mv "$backup_bundle" "$target_bundle_path" >/dev/null 2>&1; then
+      fallback_open_installer
+    fi
   fi
-  rm -rf "$tmp_root" "$backup_root"
-  fallback_open_installer
+  preserve_scratch=1
+  exit 1
 fi
 
 if [ -n "$mounted_path" ]; then
   hdiutil detach "$mounted_path" >/dev/null 2>&1 || true
   mounted_path=""
 fi
-rm -rf "$tmp_root" "$backup_root"
 open -n "$target_bundle_path" >/dev/null 2>&1 &
 exit 0
 `;

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { execFile, spawn } from "node:child_process";
-import { createReadStream } from "node:fs";
+import { constants, createReadStream } from "node:fs";
 import {
   access,
   chmod,
@@ -515,6 +515,21 @@ function macAutoReplaceTarget(input: { launcherLaunchPath?: string; platform: st
     expectedAppName,
     targetBundlePath,
   };
+}
+
+async function macAutoReplaceTargetIfReplaceable(
+  input: { launcherLaunchPath?: string; platform: string },
+): Promise<DeferredInstallerLaunchInput["macAutoReplace"] | undefined> {
+  const target = macAutoReplaceTarget(input);
+  if (target == null) return undefined;
+  try {
+    const targetStat = await lstat(target.targetBundlePath);
+    if (targetStat.isSymbolicLink() || !targetStat.isDirectory()) return undefined;
+    await access(dirname(target.targetBundlePath), constants.W_OK | constants.X_OK);
+    return target;
+  } catch {
+    return undefined;
+  }
 }
 
 function createError(code: string, message: string, details?: unknown): DesktopUpdateErrorSnapshot {
@@ -2598,6 +2613,7 @@ export function createDesktopUpdater(
   let installResult: DesktopUpdateStatusSnapshot["installResult"];
   let installFrozen = false;
   let lifecycleSummary: DesktopUpdateCacheLifecycleSummary | undefined;
+  let macDmgAutoReplaceTarget: DeferredInstallerLaunchInput["macAutoReplace"] | undefined;
   let progress: DesktopUpdateProgressSnapshot | undefined;
   let state: DesktopUpdateState = DESKTOP_UPDATE_STATES.IDLE;
   let error: DesktopUpdateErrorSnapshot | undefined;
@@ -2625,6 +2641,12 @@ export function createDesktopUpdater(
 
   function supported(): boolean {
     return config.enabled && config.mode === DESKTOP_UPDATE_MODES.PACKAGE_LAUNCHER && isSupportedPackageLauncherPlatform(config.platform);
+  }
+
+  async function refreshMacDmgAutoReplaceTarget(artifactType?: string): Promise<void> {
+    macDmgAutoReplaceTarget = artifactType === "dmg"
+      ? await macAutoReplaceTargetIfReplaceable(config)
+      : undefined;
   }
 
   function emit(): void {
@@ -2666,7 +2688,7 @@ export function createDesktopUpdater(
       ...(lifecycleSummary == null ? {} : { cache: { lifecycle: lifecycleSummary } }),
       capabilities: capabilitiesFor({
         artifactType: capabilityArtifactType,
-        canAutoReplaceMacDmg: capabilityArtifactType === "dmg" && macAutoReplaceTarget(config) != null,
+        canAutoReplaceMacDmg: capabilityArtifactType === "dmg" && macDmgAutoReplaceTarget != null,
         mode: config.mode,
         platform: config.platform,
         supported: statusSupported,
@@ -2744,6 +2766,7 @@ export function createDesktopUpdater(
     const loadedActive = await loadActiveRelease(opened.root, restoredMetadata, config, logger);
     if (!loadedActive.ok) return setState(DESKTOP_UPDATE_STATES.ERROR, loadedActive.error);
     activeRelease = loadedActive.active;
+    await refreshMacDmgAutoReplaceTarget(activeRelease?.ref.artifact.type);
     // If the app now runs at or beyond the stored active release, the
     // external installer succeeded and its one-shot UI state is stale.
     const clearedAppliedRelease =
@@ -2862,6 +2885,7 @@ export function createDesktopUpdater(
         logUpdateEvent("check-not-available", { candidateVersion: selected.candidate.version });
         candidate = null;
         activeRelease = null;
+        macDmgAutoReplaceTarget = undefined;
         await writeMetadataPatch((current) => ({
           ...current,
           active: undefined,
@@ -2877,6 +2901,7 @@ export function createDesktopUpdater(
         });
         candidate = selected.candidate;
         metadata = selected.candidate.metadata;
+        await refreshMacDmgAutoReplaceTarget(activeRelease.ref.artifact.type);
         const prepareError = await preparePayloadReleaseForReady(activeRelease);
         if (prepareError != null) return prepareError;
         return setState(DESKTOP_UPDATE_STATES.DOWNLOADED);
@@ -2893,6 +2918,7 @@ export function createDesktopUpdater(
           if (prepareError != null) return prepareError;
           candidate = selected.candidate;
           activeRelease = adoptedRelease;
+          await refreshMacDmgAutoReplaceTarget(activeRelease.ref.artifact.type);
           metadata = adoptedRelease.ref.metadata;
           installFrozen = false;
           installResult = undefined;
@@ -2911,6 +2937,7 @@ export function createDesktopUpdater(
         }
       }
       candidate = selected.candidate;
+      await refreshMacDmgAutoReplaceTarget(selected.candidate.artifact.type);
       logUpdateEvent("check-available", {
         artifactType: selected.candidate.artifact.type,
         size: selected.candidate.artifact.size,
@@ -3068,6 +3095,7 @@ export function createDesktopUpdater(
       progress = undefined;
       activeRelease = downloadedRelease;
       incomingRelease = null;
+      await refreshMacDmgAutoReplaceTarget(activeRelease.ref.artifact.type);
       await writeStoreMetadata(opened.root, {
         ...opened.metadata,
         active: releaseRef,
@@ -3147,7 +3175,8 @@ export function createDesktopUpdater(
 
   async function requestInstallerOpen(resolvedDownload: string, updateRoot: string): Promise<string> {
     if (config.platform !== "darwin" && config.platform !== "win32") return await openPath(resolvedDownload);
-    const macAutoReplace = activeRelease?.ref.artifact.type === "dmg" ? macAutoReplaceTarget(config) : undefined;
+    await refreshMacDmgAutoReplaceTarget(activeRelease?.ref.artifact.type);
+    const macAutoReplace = activeRelease?.ref.artifact.type === "dmg" ? macDmgAutoReplaceTarget : undefined;
     return await launchInstallerAfterQuit({
       appPid: processPid,
       installerPath: resolvedDownload,

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -14,7 +14,7 @@ import {
   stat,
   writeFile,
 } from "node:fs/promises";
-import { dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
+import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import { pipeline } from "node:stream/promises";
 import { promisify } from "node:util";
 
@@ -187,6 +187,10 @@ type SpawnInstallerHelper = (
 export type DeferredInstallerLaunchInput = {
   appPid: number;
   installerPath: string;
+  macAutoReplace?: {
+    expectedAppName: string;
+    targetBundlePath: string;
+  };
   root: string;
   timeoutMs: number;
 };
@@ -474,19 +478,42 @@ function isSupportedPackageLauncherPlatform(platform: string): boolean {
   return platform === "darwin" || platform === "win32";
 }
 
-function capabilitiesFor(status: { artifactType?: string; mode: DesktopUpdateMode; platform: string; supported: boolean }) {
+function capabilitiesFor(status: {
+  artifactType?: string;
+  canAutoReplaceMacDmg?: boolean;
+  mode: DesktopUpdateMode;
+  platform: string;
+  supported: boolean;
+}) {
   const packageLauncher =
     status.mode === DESKTOP_UPDATE_MODES.PACKAGE_LAUNCHER &&
     isSupportedPackageLauncherPlatform(status.platform) &&
     status.supported;
   const payloadUpdate = status.artifactType === "payload";
+  const autoReplaceMacDmg = status.artifactType === "dmg" && status.canAutoReplaceMacDmg === true;
   const hasSelectedArtifact = status.artifactType != null && status.artifactType.length > 0;
-  const manualInstaller = packageLauncher && (!hasSelectedArtifact || !payloadUpdate);
+  const manualInstaller = packageLauncher && (!hasSelectedArtifact || (!payloadUpdate && !autoReplaceMacDmg));
   return {
-    canApplyInPlace: packageLauncher && payloadUpdate,
+    canApplyInPlace: packageLauncher && (payloadUpdate || autoReplaceMacDmg),
     canDownload: packageLauncher,
     canOpenInstaller: manualInstaller,
     requiresManualInstall: manualInstaller,
+  };
+}
+
+function macAutoReplaceTarget(input: { launcherLaunchPath?: string; platform: string }): DeferredInstallerLaunchInput["macAutoReplace"] | undefined {
+  if (input.platform !== "darwin") return undefined;
+  const targetBundlePath = input.launcherLaunchPath;
+  if (targetBundlePath == null || targetBundlePath.length === 0) return undefined;
+  if (!isAbsolute(targetBundlePath) || !targetBundlePath.endsWith(".app")) return undefined;
+  if (targetBundlePath.includes("\0")) return undefined;
+  if (targetBundlePath.startsWith("/Volumes/")) return undefined;
+  if (targetBundlePath.includes("/AppTranslocation/")) return undefined;
+  const expectedAppName = basename(targetBundlePath, ".app");
+  if (expectedAppName.length === 0 || expectedAppName.includes("/")) return undefined;
+  return {
+    expectedAppName,
+    targetBundlePath,
   };
 }
 
@@ -1452,6 +1479,152 @@ exit 0
 `;
 }
 
+function macDeferredDmgReplaceScript(): string {
+  return `#!/bin/sh
+set -eu
+target_pid="$1"
+installer_path="$2"
+timeout_seconds="$3"
+target_bundle_path="$4"
+expected_app_name="$5"
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+owned_mount="$script_dir/dmg-mount-$$"
+plist_path="$script_dir/hdiutil-attach-$$.plist"
+mounted_path=""
+
+cleanup() {
+  if [ -n "$mounted_path" ]; then
+    hdiutil detach "$mounted_path" >/dev/null 2>&1 || true
+  fi
+  rmdir "$owned_mount" >/dev/null 2>&1 || true
+  rm -f "$plist_path"
+  rm -f "$0"
+}
+trap cleanup EXIT
+
+fallback_open_installer() {
+  if [ -n "$mounted_path" ]; then
+    hdiutil detach "$mounted_path" >/dev/null 2>&1 || true
+    mounted_path=""
+  fi
+  open "$installer_path" >/dev/null 2>&1 &
+  exit 0
+}
+
+plist_value() {
+  /usr/libexec/PlistBuddy -c "Print :$2" "$1/Contents/Info.plist" 2>/dev/null || true
+}
+
+deadline=$(($(date +%s) + timeout_seconds))
+while kill -0 "$target_pid" 2>/dev/null; do
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    fallback_open_installer
+  fi
+  sleep 1
+done
+
+case "$target_bundle_path" in
+  /*.app) ;;
+  *) fallback_open_installer ;;
+esac
+case "$target_bundle_path" in
+  /Volumes/*|*/AppTranslocation/*) fallback_open_installer ;;
+esac
+if [ ! -d "$target_bundle_path" ] || [ -L "$target_bundle_path" ]; then
+  fallback_open_installer
+fi
+target_parent=$(dirname -- "$target_bundle_path")
+target_base=$(basename -- "$target_bundle_path")
+if [ ! -w "$target_parent" ]; then
+  fallback_open_installer
+fi
+
+mkdir -p "$owned_mount" || fallback_open_installer
+if hdiutil attach -nobrowse -noverify -readonly -mountpoint "$owned_mount" "$installer_path" >/dev/null 2>&1; then
+  mounted_path="$owned_mount"
+else
+  rmdir "$owned_mount" >/dev/null 2>&1 || true
+  if hdiutil attach -nobrowse -noverify -readonly -plist "$installer_path" >"$plist_path" 2>/dev/null; then
+    index=0
+    while [ "$index" -lt 20 ]; do
+      candidate_mount=$(/usr/libexec/PlistBuddy -c "Print :system-entities:$index:mount-point" "$plist_path" 2>/dev/null || true)
+      if [ -n "$candidate_mount" ]; then
+        mounted_path="$candidate_mount"
+        break
+      fi
+      index=$((index + 1))
+    done
+  fi
+fi
+if [ -z "$mounted_path" ] || [ ! -d "$mounted_path" ]; then
+  fallback_open_installer
+fi
+
+set -- "$mounted_path"/*.app
+if [ "$#" -ne 1 ] || [ ! -e "$1" ]; then
+  fallback_open_installer
+fi
+source_app="$1"
+if [ ! -d "$source_app" ] || [ -L "$source_app" ]; then
+  fallback_open_installer
+fi
+
+source_id=$(plist_value "$source_app" "CFBundleIdentifier")
+target_id=$(plist_value "$target_bundle_path" "CFBundleIdentifier")
+if [ -n "$source_id" ] && [ -n "$target_id" ]; then
+  if [ "$source_id" != "$target_id" ]; then
+    fallback_open_installer
+  fi
+else
+  source_name=$(plist_value "$source_app" "CFBundleName")
+  target_name=$(plist_value "$target_bundle_path" "CFBundleName")
+  if [ -z "$source_name" ]; then
+    source_name=$(basename -- "$source_app" .app)
+  fi
+  if [ -z "$target_name" ]; then
+    target_name=$(basename -- "$target_bundle_path" .app)
+  fi
+  if [ "$source_name" != "$expected_app_name" ] || [ "$target_name" != "$expected_app_name" ]; then
+    fallback_open_installer
+  fi
+fi
+
+tmp_root="$target_parent/.od-update-tmp"
+backup_root="$target_parent/.od-update-back"
+tmp_bundle="$tmp_root/$target_base"
+backup_bundle="$backup_root/$target_base"
+rm -rf "$tmp_root" "$backup_root"
+mkdir -p "$tmp_root" "$backup_root" || fallback_open_installer
+if ! ditto "$source_app" "$tmp_bundle"; then
+  rm -rf "$tmp_root" "$backup_root"
+  fallback_open_installer
+fi
+for attribute in com.apple.quarantine com.apple.provenance com.apple.macl; do
+  xattr -dr "$attribute" "$tmp_bundle" >/dev/null 2>&1 || true
+done
+
+if ! mv "$target_bundle_path" "$backup_bundle"; then
+  rm -rf "$tmp_root" "$backup_root"
+  fallback_open_installer
+fi
+if ! mv "$tmp_bundle" "$target_bundle_path"; then
+  if [ -d "$backup_bundle" ] && [ ! -e "$target_bundle_path" ]; then
+    mv "$backup_bundle" "$target_bundle_path" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$tmp_root" "$backup_root"
+  fallback_open_installer
+fi
+
+if [ -n "$mounted_path" ]; then
+  hdiutil detach "$mounted_path" >/dev/null 2>&1 || true
+  mounted_path=""
+fi
+rm -rf "$tmp_root" "$backup_root"
+open -n "$target_bundle_path" >/dev/null 2>&1 &
+exit 0
+`;
+}
+
 function windowsDeferredInstallerScript(): string {
   return `param(
   [Parameter(Mandatory = $true)]
@@ -1579,13 +1752,24 @@ async function launchMacInstallerAfterQuit(
   try {
     const helpersRoot = await ensureOwnedSubdir(input.root, HELPERS_DIR);
     const suffix = `${deps.now().getTime().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
-    const scriptPath = join(helpersRoot, `open-installer-after-quit-${suffix}.sh`);
-    await writeFile(scriptPath, macDeferredInstallerScript(), { encoding: "utf8", mode: 0o700 });
+    const autoReplace = input.macAutoReplace;
+    const scriptPath = join(
+      helpersRoot,
+      autoReplace == null ? `open-installer-after-quit-${suffix}.sh` : `replace-dmg-after-quit-${suffix}.sh`,
+    );
+    await writeFile(scriptPath, autoReplace == null ? macDeferredInstallerScript() : macDeferredDmgReplaceScript(), { encoding: "utf8", mode: 0o700 });
     await chmod(scriptPath, 0o700);
     const timeoutSeconds = Math.max(1, Math.ceil(input.timeoutMs / 1000)).toString();
+    const args = [
+      scriptPath,
+      input.appPid.toString(),
+      input.installerPath,
+      timeoutSeconds,
+      ...(autoReplace == null ? [] : [autoReplace.targetBundlePath, autoReplace.expectedAppName]),
+    ];
     const child = deps.spawnDetached(
       "/bin/sh",
-      [scriptPath, input.appPid.toString(), input.installerPath, timeoutSeconds],
+      args,
       { detached: true, stdio: "ignore", windowsHide: true },
     );
     child.unref();
@@ -2482,6 +2666,7 @@ export function createDesktopUpdater(
       ...(lifecycleSummary == null ? {} : { cache: { lifecycle: lifecycleSummary } }),
       capabilities: capabilitiesFor({
         artifactType: capabilityArtifactType,
+        canAutoReplaceMacDmg: capabilityArtifactType === "dmg" && macAutoReplaceTarget(config) != null,
         mode: config.mode,
         platform: config.platform,
         supported: statusSupported,
@@ -2962,9 +3147,11 @@ export function createDesktopUpdater(
 
   async function requestInstallerOpen(resolvedDownload: string, updateRoot: string): Promise<string> {
     if (config.platform !== "darwin" && config.platform !== "win32") return await openPath(resolvedDownload);
+    const macAutoReplace = activeRelease?.ref.artifact.type === "dmg" ? macAutoReplaceTarget(config) : undefined;
     return await launchInstallerAfterQuit({
       appPid: processPid,
       installerPath: resolvedDownload,
+      ...(macAutoReplace == null ? {} : { macAutoReplace }),
       root: updateRoot,
       timeoutMs: config.platform === "win32" ? WINDOWS_DEFERRED_INSTALLER_TIMEOUT_MS : MAC_DEFERRED_INSTALLER_TIMEOUT_MS,
     });

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -1679,6 +1679,13 @@ describe("desktop updater", () => {
       expect(script).toContain("hdiutil detach");
       expect(script).toContain('open -n "$target_bundle_path"');
       expect(script).toContain('open "$installer_path"');
+      expect(script).toContain('scratch_root=$(mktemp -d "$target_parent/.od-update.XXXXXX") || fallback_open_installer');
+      expect(script).toContain('tmp_root="$scratch_root/tmp"');
+      expect(script).toContain('backup_root="$scratch_root/backup"');
+      expect(script).toContain('preserve_scratch=1');
+      expect(script).toContain("exit 1");
+      expect(script).not.toContain(".od-update-tmp");
+      expect(script).not.toContain(".od-update-back");
       expect(script).toContain('target_bundle_path="$4"');
       expect(script).toContain('expected_app_name="$5"');
       expect(script).not.toContain(targetBundlePath);

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -1631,13 +1631,14 @@ describe("desktop updater", () => {
   it("writes a mac DMG replacement helper when the installed app bundle path is trusted", async () => {
     const root = makeRoot();
     const fixture = await createUpdaterFixture();
-    const targetBundlePath = "/Applications/Open Design.app";
+    const targetBundlePath = join(root, "installed", "Open Design.app");
     const spawned: Array<{ args: string[]; command: string }> = [];
     try {
+      await mkdir(targetBundlePath, { recursive: true });
       const updater = createDesktopUpdater(
         {
           arch: "arm64",
-          downloadRoot: root,
+          downloadRoot: join(root, "updates"),
           env: {
             ...updaterEnv(fixture.metadataUrl),
             [DESKTOP_UPDATE_ENV.OPEN_DRY_RUN]: "0",
@@ -1665,7 +1666,7 @@ describe("desktop updater", () => {
       expect(spawned).toHaveLength(1);
       expect(spawned[0]?.command).toBe("/bin/sh");
       const [scriptPath, pidArg, installerArg, timeoutArg, targetArg, expectedAppNameArg] = spawned[0]?.args ?? [];
-      expect(scriptPath).toEqual(expect.stringContaining(join(root, "helpers", "replace-dmg-after-quit-")));
+      expect(scriptPath).toEqual(expect.stringContaining(join(root, "updates", "helpers", "replace-dmg-after-quit-")));
       expect(pidArg).toBe("4242");
       expect(installerArg).toBe(checked.downloadPath);
       expect(timeoutArg).toBe("600");
@@ -1681,6 +1682,84 @@ describe("desktop updater", () => {
       expect(script).toContain('target_bundle_path="$4"');
       expect(script).toContain('expected_app_name="$5"');
       expect(script).not.toContain(targetBundlePath);
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("keeps mac DMG updates on the manual installer capability when the installed app bundle is missing", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture();
+    try {
+      const updater = createDesktopUpdater({
+        arch: "arm64",
+        downloadRoot: join(root, "updates"),
+        env: updaterEnv(fixture.metadataUrl),
+        launcherLaunchPath: join(root, "missing", "Open Design.app"),
+        source: SIDECAR_SOURCES.TOOLS_PACK,
+      });
+
+      const checked = await updater.checkForUpdates();
+
+      expect(checked.artifact?.type).toBe("dmg");
+      expect(checked.capabilities.canApplyInPlace).toBe(false);
+      expect(checked.capabilities.canOpenInstaller).toBe(true);
+      expect(checked.capabilities.requiresManualInstall).toBe(true);
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it.skipIf(process.platform === "win32")("keeps mac DMG installer launch manual when the installed app bundle is symlinked", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture();
+    const realBundlePath = join(root, "real", "Open Design.app");
+    const targetBundlePath = join(root, "installed", "Open Design.app");
+    const spawned: Array<{ args: string[]; command: string }> = [];
+    try {
+      await mkdir(realBundlePath, { recursive: true });
+      await mkdir(join(root, "installed"), { recursive: true });
+      symlinkSync(realBundlePath, targetBundlePath, "dir");
+      const updater = createDesktopUpdater(
+        {
+          arch: "arm64",
+          downloadRoot: join(root, "updates"),
+          env: {
+            ...updaterEnv(fixture.metadataUrl),
+            [DESKTOP_UPDATE_ENV.OPEN_DRY_RUN]: "0",
+          },
+          launcherLaunchPath: targetBundlePath,
+          source: SIDECAR_SOURCES.TOOLS_PACK,
+        },
+        {
+          processPid: 4242,
+          spawnDetached: (command, args) => {
+            spawned.push({ args, command });
+            return { unref: vi.fn() };
+          },
+        },
+      );
+
+      const checked = await updater.checkForUpdates();
+      const installed = await updater.installUpdate();
+
+      expect(checked.artifact?.type).toBe("dmg");
+      expect(checked.capabilities.canApplyInPlace).toBe(false);
+      expect(checked.capabilities.canOpenInstaller).toBe(true);
+      expect(checked.capabilities.requiresManualInstall).toBe(true);
+      expect(installed.installResult?.path).toBe(checked.downloadPath);
+      expect(spawned).toHaveLength(1);
+      const [scriptPath, pidArg, installerArg, timeoutArg, targetArg] = spawned[0]?.args ?? [];
+      expect(scriptPath).toEqual(expect.stringContaining(join(root, "updates", "helpers", "open-installer-after-quit-")));
+      expect(pidArg).toBe("4242");
+      expect(installerArg).toBe(checked.downloadPath);
+      expect(timeoutArg).toBe("600");
+      expect(targetArg).toBeUndefined();
+      const script = await readFile(scriptPath ?? "", "utf8");
+      expect(script).toContain('open "$installer_path"');
+      expect(script).not.toContain("ditto");
     } finally {
       await fixture.close();
       rmSync(root, { force: true, recursive: true });

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -1628,6 +1628,65 @@ describe("desktop updater", () => {
     }
   });
 
+  it("writes a mac DMG replacement helper when the installed app bundle path is trusted", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture();
+    const targetBundlePath = "/Applications/Open Design.app";
+    const spawned: Array<{ args: string[]; command: string }> = [];
+    try {
+      const updater = createDesktopUpdater(
+        {
+          arch: "arm64",
+          downloadRoot: root,
+          env: {
+            ...updaterEnv(fixture.metadataUrl),
+            [DESKTOP_UPDATE_ENV.OPEN_DRY_RUN]: "0",
+          },
+          launcherLaunchPath: targetBundlePath,
+          source: SIDECAR_SOURCES.TOOLS_PACK,
+        },
+        {
+          processPid: 4242,
+          spawnDetached: (command, args) => {
+            spawned.push({ args, command });
+            return { unref: vi.fn() };
+          },
+        },
+      );
+
+      const checked = await updater.checkForUpdates();
+      const installed = await updater.installUpdate();
+
+      expect(checked.artifact?.type).toBe("dmg");
+      expect(checked.capabilities.canApplyInPlace).toBe(true);
+      expect(checked.capabilities.canOpenInstaller).toBe(false);
+      expect(checked.capabilities.requiresManualInstall).toBe(false);
+      expect(installed.installResult?.path).toBe(checked.downloadPath);
+      expect(spawned).toHaveLength(1);
+      expect(spawned[0]?.command).toBe("/bin/sh");
+      const [scriptPath, pidArg, installerArg, timeoutArg, targetArg, expectedAppNameArg] = spawned[0]?.args ?? [];
+      expect(scriptPath).toEqual(expect.stringContaining(join(root, "helpers", "replace-dmg-after-quit-")));
+      expect(pidArg).toBe("4242");
+      expect(installerArg).toBe(checked.downloadPath);
+      expect(timeoutArg).toBe("600");
+      expect(targetArg).toBe(targetBundlePath);
+      expect(expectedAppNameArg).toBe("Open Design");
+      const script = await readFile(scriptPath ?? "", "utf8");
+      expect(script).toContain('while kill -0 "$target_pid"');
+      expect(script).toContain("hdiutil attach");
+      expect(script).toContain("ditto");
+      expect(script).toContain("hdiutil detach");
+      expect(script).toContain('open -n "$target_bundle_path"');
+      expect(script).toContain('open "$installer_path"');
+      expect(script).toContain('target_bundle_path="$4"');
+      expect(script).toContain('expected_app_name="$5"');
+      expect(script).not.toContain(targetBundlePath);
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   it("writes and starts the Windows helper script that opens the installer after quit", async () => {
     const root = makeRoot();
     const fixture = await createUpdaterFixture({ platform: "win" });

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -1,9 +1,11 @@
 import { createHash } from "node:crypto";
-import { existsSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { execFile } from "node:child_process";
+import { chmodSync, existsSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
 import { mkdir, readdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import { basename, join, relative } from "node:path";
+import { promisify } from "node:util";
 
 import { describe, expect, it, vi } from "vitest";
 
@@ -37,6 +39,8 @@ type FixtureServer = {
   metadataRequests: () => number;
   metadataUrl: string;
 };
+
+const execFileAsync = promisify(execFile);
 
 type FixturePlatform = "mac" | "win";
 type FixtureChannel = ReleaseChannel;
@@ -228,6 +232,84 @@ function makeRoot(): string {
   return mkdtempSync(join(tmpdir(), "od-updater-test-"));
 }
 
+async function writeExecutable(path: string, contents: string): Promise<void> {
+  await writeFile(path, contents, "utf8");
+  chmodSync(path, 0o755);
+}
+
+async function writeMinimalMacAppBundle(path: string, markerName?: string): Promise<void> {
+  await mkdir(join(path, "Contents"), { recursive: true });
+  await writeFile(join(path, "Contents", "Info.plist"), `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>ai.open-design.app</string>
+  <key>CFBundleName</key>
+  <string>Open Design</string>
+</dict>
+</plist>
+`, "utf8");
+  if (markerName != null) {
+    await writeFile(join(path, markerName), `${markerName}\n`, "utf8");
+  }
+}
+
+async function writeMacDmgHelperCommandStubs(binDir: string, options: { failReplacementRollback?: boolean } = {}): Promise<void> {
+  await mkdir(binDir, { recursive: true });
+  await writeExecutable(join(binDir, "hdiutil"), `#!/bin/sh
+if [ "$1" = "detach" ]; then
+  rm -rf "$2"
+  exit 0
+fi
+mountpoint=""
+previous=""
+for argument in "$@"; do
+  if [ "$previous" = "-mountpoint" ]; then
+    mountpoint="$argument"
+  fi
+  previous="$argument"
+done
+if [ -z "$mountpoint" ]; then
+  exit 1
+fi
+mkdir -p "$mountpoint/Open Design.app"
+mkdir -p "$mountpoint/Open Design.app/Contents"
+cat > "$mountpoint/Open Design.app/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>ai.open-design.app</string>
+  <key>CFBundleName</key>
+  <string>Open Design</string>
+</dict>
+</plist>
+PLIST
+printf 'from-dmg\\n' > "$mountpoint/Open Design.app/source.txt"
+exit 0
+`);
+  await writeExecutable(join(binDir, "ditto"), `#!/bin/sh
+mkdir -p "$2"
+cp -R "$1"/. "$2"/
+`);
+  await writeExecutable(join(binDir, "open"), `#!/bin/sh
+printf '%s\\n' "$*" >> "$OD_TEST_OPEN_LOG"
+`);
+  await writeExecutable(join(binDir, "xattr"), `#!/bin/sh
+exit 0
+`);
+  if (options.failReplacementRollback === true) {
+    await writeExecutable(join(binDir, "mv"), `#!/bin/sh
+case "$1:$2" in
+  */tmp/*.app:*.app|*/backup/*.app:*.app) exit 1 ;;
+esac
+/bin/mv "$@"
+`);
+  }
+}
+
 function updaterEnv(metadataUrl: string, platform = "darwin"): NodeJS.ProcessEnv {
   return {
     [DESKTOP_UPDATE_ENV.AUTO_DOWNLOAD]: "1",
@@ -253,6 +335,14 @@ async function waitForRequestCount(requests: readonly unknown[], count: number):
     await new Promise<void>((resolveWait) => setTimeout(resolveWait, 5));
   }
   throw new Error(`expected ${count} update requests, saw ${requests.length}`);
+}
+
+async function waitForPath(path: string): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (existsSync(path)) return;
+    await new Promise<void>((resolveWait) => setTimeout(resolveWait, 5));
+  }
+  throw new Error(`expected path to exist: ${path}`);
 }
 
 function metadataResponse(version: string): Response {
@@ -1689,6 +1779,177 @@ describe("desktop updater", () => {
       expect(script).toContain('target_bundle_path="$4"');
       expect(script).toContain('expected_app_name="$5"');
       expect(script).not.toContain(targetBundlePath);
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it.skipIf(process.platform === "win32")("executes the mac DMG replacement helper transaction against stubbed macOS commands", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture();
+    const targetBundlePath = join(root, "installed", "Open Design.app");
+    const binDir = join(root, "bin");
+    const openLog = join(root, "open.log");
+    const spawned: Array<{ args: string[]; command: string }> = [];
+    try {
+      await writeMinimalMacAppBundle(targetBundlePath, "old.txt");
+      await writeMacDmgHelperCommandStubs(binDir);
+      const updater = createDesktopUpdater(
+        {
+          arch: "arm64",
+          downloadRoot: join(root, "updates"),
+          env: {
+            ...updaterEnv(fixture.metadataUrl),
+            [DESKTOP_UPDATE_ENV.OPEN_DRY_RUN]: "0",
+          },
+          launcherLaunchPath: targetBundlePath,
+          source: SIDECAR_SOURCES.TOOLS_PACK,
+        },
+        {
+          processPid: 4242,
+          spawnDetached: (command, args) => {
+            spawned.push({ args, command });
+            return { unref: vi.fn() };
+          },
+        },
+      );
+
+      const checked = await updater.checkForUpdates();
+      await updater.installUpdate();
+      const [scriptPath] = spawned[0]?.args ?? [];
+
+      await execFileAsync("/bin/sh", [
+        scriptPath ?? "",
+        "999999",
+        checked.downloadPath ?? "",
+        "1",
+        targetBundlePath,
+        "Open Design",
+      ], {
+        env: {
+          ...process.env,
+          OD_TEST_OPEN_LOG: openLog,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        },
+      });
+
+      expect(await readFile(join(targetBundlePath, "source.txt"), "utf8")).toBe("from-dmg\n");
+      expect(existsSync(join(targetBundlePath, "old.txt"))).toBe(false);
+      expect((await readdir(join(root, "installed"))).filter((name) => name.startsWith(".od-update."))).toEqual([]);
+      await waitForPath(openLog);
+      expect(await readFile(openLog, "utf8")).toBe(`-n ${targetBundlePath}\n`);
+      expect(existsSync(scriptPath ?? "")).toBe(false);
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it.skipIf(process.platform === "win32")("preserves the mac DMG helper backup when replacement rollback fails", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture();
+    const targetParent = join(root, "installed");
+    const targetBundlePath = join(targetParent, "Open Design.app");
+    const binDir = join(root, "bin");
+    const openLog = join(root, "open.log");
+    const spawned: Array<{ args: string[]; command: string }> = [];
+    try {
+      await writeMinimalMacAppBundle(targetBundlePath, "old.txt");
+      await writeMacDmgHelperCommandStubs(binDir, { failReplacementRollback: true });
+      const updater = createDesktopUpdater(
+        {
+          arch: "arm64",
+          downloadRoot: join(root, "updates"),
+          env: {
+            ...updaterEnv(fixture.metadataUrl),
+            [DESKTOP_UPDATE_ENV.OPEN_DRY_RUN]: "0",
+          },
+          launcherLaunchPath: targetBundlePath,
+          source: SIDECAR_SOURCES.TOOLS_PACK,
+        },
+        {
+          processPid: 4242,
+          spawnDetached: (command, args) => {
+            spawned.push({ args, command });
+            return { unref: vi.fn() };
+          },
+        },
+      );
+
+      const checked = await updater.checkForUpdates();
+      await updater.installUpdate();
+      const [scriptPath] = spawned[0]?.args ?? [];
+
+      await expect(execFileAsync("/bin/sh", [
+        scriptPath ?? "",
+        "999999",
+        checked.downloadPath ?? "",
+        "1",
+        targetBundlePath,
+        "Open Design",
+      ], {
+        env: {
+          ...process.env,
+          OD_TEST_OPEN_LOG: openLog,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        },
+      })).rejects.toMatchObject({ code: 1 });
+
+      const scratchRoots = (await readdir(targetParent)).filter((name) => name.startsWith(".od-update."));
+      expect(scratchRoots).toHaveLength(1);
+      expect(existsSync(targetBundlePath)).toBe(false);
+      expect(await readFile(join(targetParent, scratchRoots[0] ?? "", "backup", "Open Design.app", "old.txt"), "utf8")).toBe("old.txt\n");
+      expect(existsSync(openLog)).toBe(false);
+      expect(existsSync(scriptPath ?? "")).toBe(false);
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("falls back to the mac DMG manual installer helper when the bundle disappears after update check", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture();
+    const targetBundlePath = join(root, "installed", "Open Design.app");
+    const spawned: Array<{ args: string[]; command: string }> = [];
+    try {
+      await mkdir(targetBundlePath, { recursive: true });
+      const updater = createDesktopUpdater(
+        {
+          arch: "arm64",
+          downloadRoot: join(root, "updates"),
+          env: {
+            ...updaterEnv(fixture.metadataUrl),
+            [DESKTOP_UPDATE_ENV.OPEN_DRY_RUN]: "0",
+          },
+          launcherLaunchPath: targetBundlePath,
+          source: SIDECAR_SOURCES.TOOLS_PACK,
+        },
+        {
+          processPid: 4242,
+          spawnDetached: (command, args) => {
+            spawned.push({ args, command });
+            return { unref: vi.fn() };
+          },
+        },
+      );
+
+      const checked = await updater.checkForUpdates();
+      await rm(targetBundlePath, { force: true, recursive: true });
+      const installed = await updater.installUpdate();
+
+      expect(checked.artifact?.type).toBe("dmg");
+      expect(checked.capabilities.canApplyInPlace).toBe(true);
+      expect(installed.installResult?.path).toBe(checked.downloadPath);
+      expect(spawned).toHaveLength(1);
+      const [scriptPath, pidArg, installerArg, timeoutArg, targetArg] = spawned[0]?.args ?? [];
+      expect(scriptPath).toEqual(expect.stringContaining(join(root, "updates", "helpers", "open-installer-after-quit-")));
+      expect(pidArg).toBe("4242");
+      expect(installerArg).toBe(checked.downloadPath);
+      expect(timeoutArg).toBe("600");
+      expect(targetArg).toBeUndefined();
+      expect(await readFile(scriptPath ?? "", "utf8")).not.toContain("ditto");
     } finally {
       await fixture.close();
       rmSync(root, { force: true, recursive: true });

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -323,7 +323,7 @@ export function deriveAboutUpdateControl(
       return {
         primaryAction: canInstallUpdate ? 'install' : null,
         primaryLabelKey: canInstallUpdate
-          ? model.updateKind === 'payload'
+          ? model.canApplyInPlace
             ? 'updater.installRestart'
             : 'settings.updateNow'
           : null,

--- a/apps/web/src/components/UpdaterPopup.tsx
+++ b/apps/web/src/components/UpdaterPopup.tsx
@@ -33,14 +33,14 @@ type UpdaterPopupProps = {
 
 function versionText(t: Translator, model: UpdaterModel): string {
   const version = model.availableVersion;
-  if (model.updateKind === 'payload') {
+  if (model.canApplyInPlace) {
     return version == null ? t('updater.payloadReadyGeneric') : t('updater.payloadReadyVersion', { version });
   }
   return version == null ? t('updater.readyGeneric') : t('updater.readyVersion', { version });
 }
 
 function installActionText(t: Translator, model: UpdaterModel, installBusy: boolean): string {
-  if (model.updateKind === 'payload') {
+  if (model.canApplyInPlace) {
     return installBusy ? t('updater.installingRestart') : t('updater.installRestart');
   }
   return installBusy ? t('updater.opening') : t('updater.openInstaller');
@@ -137,7 +137,7 @@ export function UpdaterPopup({
   const installBusy = installState === 'opening' || installState === 'handoff';
   const canStartInstall = ready || installState === 'recoverable';
   const showControl = ready || installState !== 'idle';
-  const controlLabel = model.updateKind === 'payload' ? t('updater.installRestart') : t('updater.openInstaller');
+  const controlLabel = model.canApplyInPlace ? t('updater.installRestart') : t('updater.openInstaller');
   const channelLabel = channelLabelFor(model.status?.channel);
   const analytics = useAnalytics();
   const appVersionBefore = useAppVersion();

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -4930,6 +4930,66 @@ describe('SettingsDialog about interactions', () => {
     expect(screen.getByText('Version 1.2.3-beta.4 is ready to install.')).toBeTruthy();
   });
 
+  it('installs a downloaded auto-replace DMG update from the about page', async () => {
+    const dmgReady = updateStatus({
+      artifact: {
+        name: 'Open Design Beta.dmg',
+        platformKey: 'macAppleSilicon',
+        type: 'dmg',
+        url: 'https://fixture.test/Open Design Beta.dmg',
+      },
+      availableVersion: '1.2.3-beta.4',
+      capabilities: {
+        canApplyInPlace: true,
+        canDownload: true,
+        canOpenInstaller: true,
+        requiresManualInstall: true,
+      },
+      downloadPath: '/tmp/open-design-updater/Open Design Beta.dmg',
+      state: 'downloaded',
+    });
+    const installing = updateStatus({
+      ...dmgReady,
+      state: 'installing',
+    });
+    const install = vi.fn(async () => installing);
+    const quit = vi.fn(async () => ({ ok: true as const }));
+    restoreOpenDesignHost = installMockOpenDesignHost({
+      host: {
+        updater: {
+          install,
+          quit,
+          status: vi.fn(async () => dmgReady),
+        },
+      },
+    });
+
+    renderSettingsDialog(
+      { mode: 'daemon', agentId: 'codex' },
+      {
+        initialSection: 'about',
+        appVersionInfo: {
+          version: '1.2.3-beta.3',
+          channel: 'beta',
+          packaged: true,
+          platform: 'darwin',
+          arch: 'arm64',
+        },
+      },
+    );
+
+    expect(await screen.findByText('Version 1.2.3-beta.4 is ready to install.')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: en['updater.installRestart'] }));
+
+    await waitFor(() => {
+      expect(install).toHaveBeenCalledWith({ payload: { source: 'settings-about' } });
+    });
+    await waitFor(() => {
+      expect(quit).toHaveBeenCalledWith({ payload: { source: 'settings-about' } });
+    });
+  });
+
   it('installs a downloaded payload update from the about page', async () => {
     const payloadReady = updateStatus({
       artifact: {

--- a/apps/web/tests/components/SettingsDialog.test.ts
+++ b/apps/web/tests/components/SettingsDialog.test.ts
@@ -186,6 +186,39 @@ describe('SettingsDialog about update control', () => {
     });
   });
 
+  it('offers install and restart when an auto-replace DMG has already downloaded', () => {
+    const control = deriveAboutUpdateControl(
+      deriveUpdaterModel(
+        updateStatus({
+          artifact: {
+            name: 'Open Design Beta.dmg',
+            platformKey: 'macAppleSilicon',
+            type: 'dmg',
+            url: 'https://fixture.test/Open Design Beta.dmg',
+          },
+          availableVersion: '1.2.3-beta.4',
+          capabilities: {
+            canApplyInPlace: true,
+            canDownload: true,
+            canOpenInstaller: true,
+            requiresManualInstall: true,
+          },
+          downloadPath: '/tmp/open-design-updater/Open Design Beta.dmg',
+          state: 'downloaded',
+        }),
+        { hostAvailable: true },
+      ),
+      packagedVersion,
+    );
+
+    expect(control).toMatchObject({
+      primaryAction: 'install',
+      primaryLabelKey: 'updater.installRestart',
+      statusKey: 'settings.updateStatusReady',
+      statusVars: { version: '1.2.3-beta.4' },
+    });
+  });
+
   it('offers install and restart when a payload update has already downloaded', () => {
     const control = deriveAboutUpdateControl(
       deriveUpdaterModel(

--- a/apps/web/tests/components/UpdaterPopup.test.tsx
+++ b/apps/web/tests/components/UpdaterPopup.test.tsx
@@ -58,6 +58,25 @@ function payloadDownloadedStatus(overrides: Partial<OpenDesignHostUpdaterStatusS
   });
 }
 
+function autoReplaceDmgDownloadedStatus(overrides: Partial<OpenDesignHostUpdaterStatusSnapshot> = {}): OpenDesignHostUpdaterStatusSnapshot {
+  return downloadedStatus({
+    artifact: {
+      name: 'Open Design Beta.dmg',
+      platformKey: 'mac',
+      size: 1024,
+      type: 'dmg',
+      url: 'https://example.test/Open Design Beta.dmg',
+    },
+    capabilities: {
+      canApplyInPlace: true,
+      canDownload: true,
+      canOpenInstaller: false,
+      requiresManualInstall: false,
+    },
+    ...overrides,
+  });
+}
+
 describe('UpdaterPopup', () => {
   let restoreHost: (() => void) | null = null;
 
@@ -161,6 +180,30 @@ describe('UpdaterPopup', () => {
       host: {
         updater: {
           status: vi.fn(async () => payloadDownloadedStatus()),
+        },
+      },
+    });
+
+    render(
+      <I18nProvider initial="zh-CN">
+        <UpdaterPopup />
+      </I18nProvider>,
+    );
+
+    const button = await screen.findByTestId('entry-nav-updater');
+    expect(button.getAttribute('data-tooltip')).toBe('安装并重启');
+    fireEvent.click(button);
+
+    expect(await screen.findByRole('dialog', { name: '更新已就绪' })).toBeTruthy();
+    expect(screen.getByTestId('updater-install-button').textContent).toBe('安装并重启');
+    expect(screen.getByText('Open Design 1.2.3-beta.4 已就绪。Open Design 会关闭并自动重启。')).toBeTruthy();
+  });
+
+  it('uses install-and-restart copy for auto-replace DMG updates', async () => {
+    restoreHost = installMockOpenDesignHost({
+      host: {
+        updater: {
+          status: vi.fn(async () => autoReplaceDmgDownloadedStatus()),
         },
       },
     });

--- a/apps/web/tests/lib/updater.test.ts
+++ b/apps/web/tests/lib/updater.test.ts
@@ -96,6 +96,27 @@ describe('web updater model', () => {
     expect(model.shouldShowControl).toBe(true);
   });
 
+  it('keeps auto-replace DMG updates installable without manual installer capability', () => {
+    const model = deriveUpdaterModel(
+      downloadedStatus({
+        capabilities: {
+          canApplyInPlace: true,
+          canDownload: true,
+          canOpenInstaller: false,
+          requiresManualInstall: false,
+        },
+      }),
+      { hostAvailable: true },
+    );
+    expect(model.environment).toBe('desktop');
+    expect(model.updateKind).toBe('installer');
+    expect(model.canApplyInPlace).toBe(true);
+    expect(model.canOpenInstaller).toBe(false);
+    expect(model.requiresManualInstall).toBe(false);
+    expect(model.shouldPrompt).toBe(true);
+    expect(model.shouldShowControl).toBe(true);
+  });
+
   it('keeps downloading progress internal without showing the updater control', () => {
     const model = deriveUpdaterModel(
       downloadedStatus({


### PR DESCRIPTION
## Why

Source tracker: https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/7b9613f6-e436-408c-8f6a-0db93b9d7aeb

macOS users who fell back to the DMG updater path were only getting the downloaded DMG opened in Finder. That made the "automatic update" flow depend on a manual drag into `/Applications`, so users could close the Finder window and keep running the old version.

## What users will see

When a packaged macOS update uses the DMG fallback and the updater has a trusted installed `.app` bundle path, clicking install will close Open Design, mount the DMG, replace the installed app bundle, detach the DMG, and relaunch the updated app. Unsafe cases still fall back to opening the installer for manual drag-install instead of silently failing.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No screenshot attached. This changes updater behavior and reuses existing updater prompt copy; focused UI tests cover the visible copy decision for auto-replace DMG updates.

## Bug fix verification

- Test path that reproduces the bug: `apps/desktop/tests/main/updater.test.ts` (`writes a mac DMG replacement helper when the installed app bundle path is trusted`).
- Did the test go red on `main` and green on this branch? Yes. Before the fix, the new red spec failed because DMG fallback capabilities still reported `canApplyInPlace: false` and generated only the `open "$installer_path"` helper. After the fix, the focused spec passes.
- Root cause: the macOS DMG fallback path only opened the downloaded DMG after quit, which mounts Finder but never copies the new `.app` over the installed bundle.

## Validation

- `pnpm install` (dependencies were missing in this fresh worktree; lockfile stayed unchanged)
- `pnpm --dir apps/desktop exec vitest run -c vitest.config.ts tests/main/updater.test.ts -t "writes a mac DMG replacement helper"`
- `pnpm --dir apps/desktop exec vitest run -c vitest.config.ts tests/main/updater-host-boundary.test.ts tests/main/preload-host-boundary.test.ts`
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts tests/lib/updater.test.ts tests/components/UpdaterPopup.test.tsx`
- `pnpm --filter @open-design/desktop typecheck`
- `pnpm --filter @open-design/web typecheck`
- `git diff --check`
- `pnpm guard`
- `pnpm typecheck`

Notes:
- Local Node is `v22.22.0`; the repo asks for Node `~24`, so pnpm emitted engine warnings throughout validation.
- The package-script form `pnpm --filter @open-design/desktop test -- tests/main/updater.test.ts` still runs broader configured tests here and fails an unrelated pre-existing cleanup descriptor assertion in `apps/desktop/tests/main/updater.test.ts`.
- The package-script form `pnpm --filter @open-design/web test -- tests/lib/updater.test.ts tests/components/UpdaterPopup.test.tsx` also runs the broader web suite and fails an unrelated pre-existing `FileWorkspace.design-system.test.tsx` expectation. Direct Vitest invocation for the touched updater files passes.

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>