### PR TITLE
feat(daemon): add AtomCode CLI as an agent runtime

### DIFF
--- a/apps/daemon/src/runtimes/defs/atomcode.ts
+++ b/apps/daemon/src/runtimes/defs/atomcode.ts
@@ -1,0 +1,74 @@
+import { DEFAULT_MODEL_OPTION } from './shared.js';
+import type { RuntimeAgentDef } from '../types.js';
+
+// AtomCode — open-source terminal AI coding agent written in Rust.
+// Repo:   https://atomgit.com/atomgit_atomcode/atomcode
+// Docs:   https://atomcode.atomgit.com/docs/en/index.html
+// Install: `cargo install --path crates/atomcode-cli --locked` (from source)
+//          or `npm install -g @atomgit.com/atomcode` / `brew install --cask atomcode`
+//
+// Headless mode (`atomcode -p "..."`) runs a single prompt non-interactively and
+// streams the assistant reply on stdout — Claude Code `-p` style. OD composes
+// the prompt in a temp file (AtomCode exposes `--prompt-file <PATH>`) to stay
+// clear of argv length limits, exactly like grok-build.
+//
+// AtomCode owns its own authentication: users run `atomcode login` (AtomGit
+// OAuth, auto-persisted under `~/.atomcode/`) or set up an API key in
+// `~/.atomcode/config.toml` before OD detects the binary. The daemon does not
+// inject credentials. Any OpenAI-compatible provider works (Anthropic, OpenAI,
+// DeepSeek, Zhipu/GLM, Qwen, SiliconFlow, Ollama, …).
+//
+// Output: AtomCode headless has no structured stream-json mode yet — it emits
+// plain-text assistant replies on stdout and verbose diagnostics (tool calls,
+// token usage) on stderr with `-v`. We therefore use `streamFormat: 'plain'`
+// (single-turn text reply, no tool_use streaming). Upgrading to a structured
+// parser is follow-up work once AtomCode ships a stable JSON event stream.
+//
+// Safety: `--dangerously-skip-permissions` auto-approves every tool call so the
+// headless run doesn't block on an approval prompt it can't surface. This
+// matches the documented headless contract: approval-required `bash` calls are
+// auto-approved, while other approval-required tools are denied. The
+// `-y` short flag is the alias AtomCode documents for CI/eval harnesses.
+export const atomcodeAgentDef = {
+    id: 'atomcode',
+    name: 'AtomCode CLI',
+    bin: 'atomcode',
+    fallbackBins: ['atomcode'],
+    versionArgs: ['--version'],
+    fallbackModels: [
+        DEFAULT_MODEL_OPTION,
+        { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6' },
+        { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+        { id: 'gpt-5.2', label: 'GPT-5.2' },
+        { id: 'glm-5.2', label: 'GLM-5.2' },
+        { id: 'deepseek-v4', label: 'DeepSeek V4' },
+    ],
+    // `--prompt-file <PATH>` avoids argv length limits for long OD prompts.
+    // `-y` auto-approves tool calls in headless mode (no interactive TTY).
+    // `--model <id>` selects the upstream provider/model when non-default.
+    buildArgs: (
+      _prompt,
+      _imagePaths,
+      _extraAllowedDirs = [],
+      options = {},
+      runtimeContext = {},
+    ) => {
+      if (!runtimeContext.promptFilePath) {
+        throw new Error('atomcode requires runtimeContext.promptFilePath');
+      }
+      const args = [
+        '--prompt-file',
+        runtimeContext.promptFilePath,
+        '-y',
+      ];
+      if (options.model && options.model !== DEFAULT_MODEL_OPTION.id) {
+        args.push('--model', options.model);
+      }
+      return args;
+    },
+    promptViaFile: true,
+    promptViaStdin: false,
+    streamFormat: 'plain',
+    installUrl: 'https://atomcode.atomgit.com/docs/en/quickstart.html',
+    docsUrl: 'https://atomcode.atomgit.com/docs/en/index.html',
+} satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/atomcode.ts
+++ b/apps/daemon/src/runtimes/defs/atomcode.ts
@@ -7,10 +7,10 @@ import type { RuntimeAgentDef } from '../types.js';
 // Install: `cargo install --path crates/atomcode-cli --locked` (from source)
 //          or `npm install -g @atomgit.com/atomcode` / `brew install --cask atomcode`
 //
-// Headless mode (`atomcode -p "..."`) runs a single prompt non-interactively and
-// streams the assistant reply on stdout — Claude Code `-p` style. OD composes
-// the prompt in a temp file (AtomCode exposes `--prompt-file <PATH>`) to stay
-// clear of argv length limits, exactly like grok-build.
+// Headless mode with `--prompt-file <PATH>` runs a single prompt
+// non-interactively and streams the assistant reply on stdout. OD composes the
+// prompt in a temp file to stay clear of argv length limits, exactly like
+// grok-build.
 //
 // AtomCode owns its own authentication: users run `atomcode login` (AtomGit
 // OAuth, auto-persisted under `~/.atomcode/`) or set up an API key in
@@ -24,16 +24,12 @@ import type { RuntimeAgentDef } from '../types.js';
 // (single-turn text reply, no tool_use streaming). Upgrading to a structured
 // parser is follow-up work once AtomCode ships a stable JSON event stream.
 //
-// Safety: `--dangerously-skip-permissions` auto-approves every tool call so the
-// headless run doesn't block on an approval prompt it can't surface. This
-// matches the documented headless contract: approval-required `bash` calls are
-// auto-approved, while other approval-required tools are denied. The
-// `-y` short flag is the alias AtomCode documents for CI/eval harnesses.
+// Safety: OD passes AtomCode's documented `-y` flag so the non-interactive run
+// can proceed without waiting for an approval prompt it cannot surface.
 export const atomcodeAgentDef = {
     id: 'atomcode',
     name: 'AtomCode CLI',
     bin: 'atomcode',
-    fallbackBins: ['atomcode'],
     versionArgs: ['--version'],
     fallbackModels: [
         DEFAULT_MODEL_OPTION,

--- a/apps/daemon/src/runtimes/metadata.ts
+++ b/apps/daemon/src/runtimes/metadata.ts
@@ -83,6 +83,10 @@ const AGENT_INSTALL_LINKS: Record<
     installUrl: 'https://www.codebuddy.cn',
     docsUrl: 'https://www.codebuddy.cn/docs/workbuddy/Overview',
   },
+  atomcode: {
+    installUrl: 'https://atomcode.atomgit.com/docs/en/quickstart.html',
+    docsUrl: 'https://atomcode.atomgit.com/docs/en/index.html',
+  },
 };
 
 function sanitizeHttpsUrl(value: string | undefined): string | undefined {

--- a/apps/daemon/src/runtimes/registry.ts
+++ b/apps/daemon/src/runtimes/registry.ts
@@ -23,6 +23,7 @@ import { antigravityAgentDef } from './defs/antigravity.js';
 import { codebuddyAgentDef } from './defs/codebuddy.js';
 import { reasonixAgentDef } from './defs/reasonix.js';
 import { mimoAgentDef } from './defs/mimo.js';
+import { atomcodeAgentDef } from './defs/atomcode.js';
 import { readLocalAgentProfileDefs as readLocalAgentProfileDefsFromFile } from './local-profiles.js';
 import type { RuntimeAgentDef } from './types.js';
 
@@ -52,6 +53,7 @@ const BASE_AGENT_DEFS: RuntimeAgentDef[] = [
   reasonixAgentDef,
   codebuddyAgentDef,
   mimoAgentDef,
+  atomcodeAgentDef,
 ];
 
 export function readLocalAgentProfileDefs(

--- a/apps/daemon/tests/runtimes/atomcode.test.ts
+++ b/apps/daemon/tests/runtimes/atomcode.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { atomcodeAgentDef } from '../../src/runtimes/defs/atomcode.js';
+import { DEFAULT_MODEL_OPTION } from '../../src/runtimes/defs/shared.js';
+
+const promptFileContext = { promptFilePath: '/tmp/open-design/atomcode-prompt.md' };
+
+describe('atomcode buildArgs', () => {
+  it('requires a staged prompt file', () => {
+    expect(() => atomcodeAgentDef.buildArgs('prompt', [], [], {}, {})).toThrow(
+      'atomcode requires runtimeContext.promptFilePath',
+    );
+  });
+
+  it('emits the exact base argv without embedding the prompt', () => {
+    const prompt = 'do not put this prompt in argv';
+    const args = atomcodeAgentDef.buildArgs(prompt, [], [], {}, promptFileContext);
+
+    expect(args).toEqual([
+      '--prompt-file',
+      promptFileContext.promptFilePath,
+      '-y',
+    ]);
+    expect(args).not.toContain(prompt);
+  });
+
+  it('appends --model for a non-default model', () => {
+    const args = atomcodeAgentDef.buildArgs(
+      'prompt',
+      [],
+      [],
+      { model: 'claude-sonnet-4-6' },
+      promptFileContext,
+    );
+
+    expect(args).toEqual([
+      '--prompt-file',
+      promptFileContext.promptFilePath,
+      '-y',
+      '--model',
+      'claude-sonnet-4-6',
+    ]);
+  });
+
+  it('omits --model for the default sentinel', () => {
+    const args = atomcodeAgentDef.buildArgs(
+      'prompt',
+      [],
+      [],
+      { model: DEFAULT_MODEL_OPTION.id },
+      promptFileContext,
+    );
+
+    expect(args).not.toContain('--model');
+  });
+});
+
+describe('atomcode definition metadata', () => {
+  it('declares the runtime identity', () => {
+    expect(atomcodeAgentDef.id).toBe('atomcode');
+    expect(atomcodeAgentDef.name).toBe('AtomCode CLI');
+    expect(atomcodeAgentDef.bin).toBe('atomcode');
+  });
+
+  it('uses prompt-file transport and plain output', () => {
+    expect(atomcodeAgentDef.promptViaFile).toBe(true);
+    expect(atomcodeAgentDef.promptViaStdin).toBe(false);
+    expect(atomcodeAgentDef.streamFormat).toBe('plain');
+  });
+});


### PR DESCRIPTION
Closes #5653

## Why

[AtomCode CLI](https://atomgit.com/atomgit_atomcode/atomcode) is an open-source terminal AI coding agent written in Rust (MIT, v4.26.0). It ships the building blocks Open Design's daemon expects from a headless agent runtime: prompt-file transport (`--prompt-file <PATH>`), non-interactive approvals (`-y`), and multi-provider support (any OpenAI-compatible API).

I wanted to make this Rust-native, multi-provider agent available through Open Design's existing runtime system. Without an adapter, users who already use AtomCode cannot select it in Open Design. Adding it through the declarative `RuntimeAgentDef` path makes it available through the existing web and `od` CLI agent-selection flows without adding a separate integration surface.

## What users will see

- AtomCode CLI appears in **Settings → Agents** when `atomcode` is on PATH.
- Users can select it as the active agent and chat through the web UI or `od` CLI, with AtomCode performing the project work.
- The model picker surfaces AtomCode's known providers/models (Claude Sonnet 4.5/4.6, GPT-5.2, GLM-5.2, DeepSeek V4, …).
- If `atomcode` is not installed, the agent card shows an install link to the [AtomCode quickstart](https://atomcode.atomgit.com/docs/en/quickstart.html).

## How it works

The adapter reuses the same `promptViaFile: true` + `streamFormat: 'plain'` infrastructure that `grok-build` already exercises:

1. The daemon stages the composed prompt in a temp file (`preparePromptFileForAgent`).
2. It spawns `atomcode --prompt-file <PATH> -y [--model <id>]`.
3. AtomCode streams the assistant reply on stdout; the daemon pipes it through the plain-stream handler.
4. Authentication is CLI-owned (`atomcode login` / `~/.atomcode/config.toml`), matching the grok-build / qoder pattern — the daemon does not inject credentials.

AtomCode headless mode does not yet emit a structured JSON event stream (tool-use deltas or token-usage events). As with grok-build, `streamFormat: 'plain'` provides a single-turn text reply now; a structured parser can follow once AtomCode exposes a stable event format.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope
- [x] **Default behavior change** — users with `atomcode` on PATH can now see and select AtomCode through the existing agent discovery path
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — no UI component or layout changed. The existing agent list renders the new runtime from daemon metadata.

## Bug fix verification

Not applicable — this is a feature addition, not a bug fix.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/atomcode.test.ts` — 6/6 pass
- `pnpm --filter @open-design/daemon typecheck` — pass
- `pnpm guard` — 86/86 pass
- Earlier full daemon suite: 603 pass, 1 skip; the separately observed `run-failure-telemetry-smoke` failure was reproduced on `main` and is unrelated to this change
- Manual end-to-end validation remains pending: with AtomCode logged in, start through `pnpm tools-dev`, select AtomCode, send a prompt, and confirm the streamed reply renders in chat

The focused follow-up checks above were rerun under the repository baseline with Node v24.18.0.