### PR TITLE
fix(daemon): dedup concurrent library ingests instead of 500-ing the hash-race loser

### DIFF
--- a/apps/daemon/src/library.ts
+++ b/apps/daemon/src/library.ts
@@ -286,6 +286,36 @@ export interface RegisterLibraryAssetResult {
   taskId?: string;
 }
 
+/** Append this ingest's source + tags onto an asset that already holds these
+ * exact bytes (either a prior ingest, or a concurrent one that won the insert
+ * race). This is the single idempotent-by-content-hash convergence point. */
+function dedupIntoExistingAsset(
+  db: SqliteDb,
+  existing: LibraryAssetRecord,
+  input: RegisterLibraryAssetInput,
+): RegisterLibraryAssetResult {
+  addLibraryAssetSource(db, { assetId: existing.id, ...input.source });
+  if (input.tags && input.tags.length) {
+    const merged = dedupeTags([...existing.tags, ...input.tags]);
+    updateLibraryAsset(db, existing.id, { tags: merged });
+  }
+  const refreshed = getLibraryAsset(db, existing.id) ?? existing;
+  return { asset: refreshed, deduped: true };
+}
+
+/** True when `err` is the UNIQUE(content_hash) constraint firing on insert. */
+function isUniqueContentHashViolation(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const code = (err as { code?: unknown }).code;
+  const message = (err as { message?: unknown }).message;
+  return (
+    code === 'SQLITE_CONSTRAINT_UNIQUE' ||
+    (typeof message === 'string' &&
+      message.includes('UNIQUE constraint failed') &&
+      message.includes('content_hash'))
+  );
+}
+
 /**
  * Index an asset into the library. Idempotent by content hash. Owned assets
  * are written content-addressed under LIBRARY_DIR; referenced assets only
@@ -314,13 +344,7 @@ export async function registerLibraryAsset(
   // Dedup: same bytes already indexed → append source, union tags.
   const existing = findLibraryAssetByHash(db, contentHash);
   if (existing) {
-    addLibraryAssetSource(db, { assetId: existing.id, ...input.source });
-    if (input.tags && input.tags.length) {
-      const merged = dedupeTags([...existing.tags, ...input.tags]);
-      updateLibraryAsset(db, existing.id, { tags: merged });
-    }
-    const refreshed = getLibraryAsset(db, existing.id) ?? existing;
-    return { asset: refreshed, deduped: true };
+    return dedupIntoExistingAsset(db, existing, input);
   }
 
   if (!mime) mime = detectMime(bytes, input.filename);
@@ -346,26 +370,39 @@ export async function registerLibraryAsset(
   const domain = domainFromUrl(input.sourceUrl);
   const tags = dedupeTags([...(input.tags ?? []), domain]);
 
-  insertLibraryAsset(db, {
-    id,
-    kind,
-    storage: input.storage,
-    sourceUrl: input.sourceUrl,
-    sourceTitle: input.sourceTitle,
-    sourceDomain: domain,
-    capturedAt,
-    archivedDate: archivedDateFor(capturedAt),
-    filePath,
-    originProjectId: input.originProjectId,
-    relPath: input.relPath,
-    mime,
-    width: dims?.width,
-    height: dims?.height,
-    size: bytes.length,
-    contentHash,
-    tags,
-    metadata: input.metadata,
-  });
+  try {
+    insertLibraryAsset(db, {
+      id,
+      kind,
+      storage: input.storage,
+      sourceUrl: input.sourceUrl,
+      sourceTitle: input.sourceTitle,
+      sourceDomain: domain,
+      capturedAt,
+      archivedDate: archivedDateFor(capturedAt),
+      filePath,
+      originProjectId: input.originProjectId,
+      relPath: input.relPath,
+      mime,
+      width: dims?.width,
+      height: dims?.height,
+      size: bytes.length,
+      contentHash,
+      tags,
+      metadata: input.metadata,
+    });
+  } catch (err) {
+    // A concurrent ingest of the same bytes won the UNIQUE(content_hash) race in
+    // the window between our findLibraryAssetByHash SELECT above and this INSERT
+    // (the `await mkdir`/`await writeFile` yield lets a sibling request slip
+    // through the same not-found check). registerLibraryAsset is idempotent by
+    // content hash, so fold into the dedup branch rather than surfacing a 500.
+    if (isUniqueContentHashViolation(err)) {
+      const winner = findLibraryAssetByHash(db, contentHash);
+      if (winner) return dedupIntoExistingAsset(db, winner, input);
+    }
+    throw err;
+  }
   addLibraryAssetSource(db, { assetId: id, ...input.source });
 
   const taskId = recordEnrichmentTask(db, id, kind);

--- a/apps/daemon/tests/library-ingest-concurrent-hash-race.test.ts
+++ b/apps/daemon/tests/library-ingest-concurrent-hash-race.test.ts
@@ -5,14 +5,19 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { startServer } from '../src/server.js';
 
 // Red spec: two (or more) concurrent Library ingests of the SAME bytes must
-// both succeed and dedup to a single asset. `registerLibraryAsset` (library.ts)
-// checks `findLibraryAssetByHash` (SELECT), then `await mkdir` + `await
-// writeFile`, then `insertLibraryAsset` (INSERT) — with a bare `UNIQUE(content_hash)`
+// both succeed AND fully converge — one deduped asset that preserves every
+// request's source/tag contribution. `registerLibraryAsset` (library.ts) checks
+// `findLibraryAssetByHash` (SELECT), then `await mkdir` + `await writeFile`,
+// then `insertLibraryAsset` (INSERT) — with a bare `UNIQUE(content_hash)`
 // constraint and no surrounding transaction or ON CONFLICT. Two concurrent
 // requests both pass the SELECT (neither has inserted yet), both await the file
 // write, then both INSERT — the loser hits "UNIQUE constraint failed:
 // library_assets.content_hash" and the route returns 500 INGEST_FAILED, dropping
 // that upload's source/tags instead of deduping.
+//
+// The assertions cover BOTH halves of the bug: (1) the loser must not 500, and
+// (2) the loser's data (a unique tag) must survive the dedup merge — a silent
+// data-integrity loss that a "no 500 + one asset id" check alone would miss.
 
 type StartedServer = {
   url: string;
@@ -31,7 +36,7 @@ describe('concurrent Library ingest content-hash race', () => {
     started = null;
   });
 
-  it('dedups concurrent identical uploads instead of 500-ing the losers', async () => {
+  it('dedups concurrent identical uploads without losing any request\'s tag', async () => {
     started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
 
     // Unique bytes per run so we never collide with a prior run's asset in the
@@ -44,33 +49,62 @@ describe('concurrent Library ingest content-hash race', () => {
     const dataUrl = `data:image/png;base64,${bytes.toString('base64')}`;
 
     const CONCURRENCY = 12;
+    // Every request carries a DISTINCT tag that must survive the dedup merge.
+    // On the bug, a loser 500s and its tag is dropped; a correct dedup folds
+    // each request's tag onto the single converged asset.
+    const tags = Array.from({ length: CONCURRENCY }, (_, i) => `race-tag-${unique}-${i}`);
     const responses = await Promise.all(
-      Array.from({ length: CONCURRENCY }, () =>
+      tags.map((tag) =>
         fetch(`${started!.url}/api/library/ingest`, {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ dataUrl, filename: 'race.png', mime: 'image/png' }),
+          body: JSON.stringify({ dataUrl, filename: 'race.png', mime: 'image/png', tags: [tag] }),
         }),
       ),
     );
 
-    const statuses = await Promise.all(
+    const results = await Promise.all(
       responses.map(async (r) => ({ status: r.status, body: await r.json().catch(() => null) })),
     );
-    const failures = statuses.filter((s) => s.status !== 200);
-    const assetIds = new Set(
-      statuses
-        .filter((s) => s.status === 200)
-        .map((s) => (s.body as { asset?: { id?: string } })?.asset?.id)
-        .filter(Boolean),
-    );
 
+    // (1) No loser may 500.
+    const failures = results.filter((s) => s.status !== 200);
     expect(
       failures,
       `concurrent identical ingests must all dedup to one asset, but ${failures.length}/${CONCURRENCY} ` +
         `returned an error: ${JSON.stringify(failures.map((f) => f.status + ':' + JSON.stringify(f.body)))}`,
     ).toEqual([]);
-    // All survivors must point at the same deduped asset.
-    expect(assetIds.size).toBe(1);
+
+    // Each success must be a complete, well-shaped result — not just a 200: a
+    // non-empty asset id and a boolean `deduped`. Guards against a "200 with no
+    // asset.id" regression slipping past.
+    const oks = results.map((r) => r.body as { asset?: { id?: string }; deduped?: unknown });
+    for (const b of oks) {
+      expect(typeof b.asset?.id, `each 200 must carry an asset id, got ${JSON.stringify(b)}`).toBe('string');
+      expect(b.asset?.id).toBeTruthy();
+      expect(typeof b.deduped, 'each 200 must report a boolean deduped').toBe('boolean');
+    }
+
+    // All requests converge on ONE asset, with exactly one fresh insert
+    // (deduped=false) and the rest folded in (deduped=true).
+    const assetIds = new Set(oks.map((b) => b.asset!.id as string));
+    expect(assetIds.size, 'all concurrent ingests must converge on one asset').toBe(1);
+    expect(
+      oks.filter((b) => b.deduped === false).length,
+      'exactly one request performs the fresh insert; the rest fold into it',
+    ).toBe(1);
+
+    // (2) Data-integrity core: fetch the converged asset and prove EVERY
+    // request's unique tag survived the concurrent dedup merge — none dropped.
+    const assetId = [...assetIds][0];
+    const getRes = await fetch(`${started!.url}/api/library/assets/${assetId}`);
+    expect(getRes.status).toBe(200);
+    const finalAsset = (await getRes.json()) as { asset?: { tags?: string[] } };
+    const finalTags = new Set(finalAsset.asset?.tags ?? []);
+    const dropped = tags.filter((t) => !finalTags.has(t));
+    expect(
+      dropped,
+      `every concurrent ingest's tag must survive dedup, but ${dropped.length}/${CONCURRENCY} were dropped: ${JSON.stringify(dropped)}`,
+    ).toEqual([]);
   });
 });

--- a/apps/daemon/tests/library-ingest-concurrent-hash-race.test.ts
+++ b/apps/daemon/tests/library-ingest-concurrent-hash-race.test.ts
@@ -1,0 +1,76 @@
+import type { Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+// Red spec: two (or more) concurrent Library ingests of the SAME bytes must
+// both succeed and dedup to a single asset. `registerLibraryAsset` (library.ts)
+// checks `findLibraryAssetByHash` (SELECT), then `await mkdir` + `await
+// writeFile`, then `insertLibraryAsset` (INSERT) — with a bare `UNIQUE(content_hash)`
+// constraint and no surrounding transaction or ON CONFLICT. Two concurrent
+// requests both pass the SELECT (neither has inserted yet), both await the file
+// write, then both INSERT — the loser hits "UNIQUE constraint failed:
+// library_assets.content_hash" and the route returns 500 INGEST_FAILED, dropping
+// that upload's source/tags instead of deduping.
+
+type StartedServer = {
+  url: string;
+  server: Server;
+  shutdown?: () => Promise<void> | void;
+};
+
+describe('concurrent Library ingest content-hash race', () => {
+  let started: StartedServer | null = null;
+
+  afterEach(async () => {
+    await Promise.resolve(started?.shutdown?.());
+    if (started?.server) {
+      await new Promise<void>((resolve) => started?.server.close(() => resolve()));
+    }
+    started = null;
+  });
+
+  it('dedups concurrent identical uploads instead of 500-ing the losers', async () => {
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+
+    // Unique bytes per run so we never collide with a prior run's asset in the
+    // shared vitest data dir. A tiny PNG-ish payload with a unique tail.
+    const unique = randomUUID();
+    const bytes = Buffer.concat([
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      Buffer.from(`open-design-race-${unique}`, 'utf8'),
+    ]);
+    const dataUrl = `data:image/png;base64,${bytes.toString('base64')}`;
+
+    const CONCURRENCY = 12;
+    const responses = await Promise.all(
+      Array.from({ length: CONCURRENCY }, () =>
+        fetch(`${started!.url}/api/library/ingest`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ dataUrl, filename: 'race.png', mime: 'image/png' }),
+        }),
+      ),
+    );
+
+    const statuses = await Promise.all(
+      responses.map(async (r) => ({ status: r.status, body: await r.json().catch(() => null) })),
+    );
+    const failures = statuses.filter((s) => s.status !== 200);
+    const assetIds = new Set(
+      statuses
+        .filter((s) => s.status === 200)
+        .map((s) => (s.body as { asset?: { id?: string } })?.asset?.id)
+        .filter(Boolean),
+    );
+
+    expect(
+      failures,
+      `concurrent identical ingests must all dedup to one asset, but ${failures.length}/${CONCURRENCY} ` +
+        `returned an error: ${JSON.stringify(failures.map((f) => f.status + ':' + JSON.stringify(f.body)))}`,
+    ).toEqual([]);
+    // All survivors must point at the same deduped asset.
+    expect(assetIds.size).toBe(1);
+  });
+});


### PR DESCRIPTION
## Why

**Use case:** hunting daemon data-integrity/resource bugs in `apps/daemon`; found this one by auditing the "idempotent by content hash" claim on the Library ingest path against what actually happens under concurrency.

**The pain:** `registerLibraryAsset` (`apps/daemon/src/library.ts`) is documented as idempotent by content hash — the same bytes seen twice collapse to one asset and it "must never throw into a caller's main flow." But for `storage: 'owned'` (manual uploads) it does a bare `findLibraryAssetByHash` SELECT (library.ts:315), then `await mkdir` + `await writeFile` (339-340), then `insertLibraryAsset` (349) against a `UNIQUE(content_hash)` column with no transaction or `ON CONFLICT`. The `await`s yield the event loop between the check and the insert, so two concurrent ingests of identical bytes both pass the not-found SELECT, both write the (content-addressed, byte-identical) file, then both INSERT — the loser hits `UNIQUE constraint failed: library_assets.content_hash`. The route (`routes/library.ts:437`) surfaces that as **500 INGEST_FAILED**, and — more quietly — the throw skips that upload's `addLibraryAssetSource`/tag-merge, so the asset's "used in N places" back-link graph **silently loses an edge**. Classic TOCTOU: the SELECT's answer is stale by the time the INSERT runs.

## What users will see

Uploading the same asset from two places at once (or any concurrent identical ingest — e.g. a batch drop, or the UI and a `od`-driven job racing) no longer returns a spurious `500 INGEST_FAILED` for the loser. Both converge on one deduped asset and both keep their source/tag back-links. No user-visible surface changes; it's a correctness fix on the existing endpoint.

## Surface area

- [x] **None** — daemon-internal correctness fix on an existing endpoint; no new UI/CLI/API surface, no contract-shape change, no schema change. Covered by a new red-spec test.

## Bug fix verification

- Test path: `apps/daemon/tests/library-ingest-concurrent-hash-race.test.ts` — fires 12 concurrent identical `POST /api/library/ingest` and asserts all return 200 and dedup to a single asset id. Black-box over the production HTTP API; no source backdoors.
- Red on `main`, green on this branch? **yes** — on `main` it fails with **4–5/12** responses returning `500 UNIQUE constraint failed: library_assets.content_hash` (reproduced repeatedly, deterministic); green on this branch, confirmed 3× (no flakiness).
- Note: the suite must run under Node 24 (`better-sqlite3` native binding) or you hit a `NODE_MODULE_VERSION` mismatch at `db.ts` unrelated to this change.

## Fix

Let the `UNIQUE(content_hash)` constraint be the arbiter instead of the pre-`await` SELECT: wrap the INSERT in `try/catch`, and on a `UNIQUE(content_hash)` violation re-run `findLibraryAssetByHash` and fold into the existing dedup branch (extracted verbatim as `dedupIntoExistingAsset`) — appending the loser's source/tags and returning `deduped: true`. The loser `return`s inside the catch, so it correctly skips the post-insert `addLibraryAssetSource` keyed on its own now-unused id. No lock, no schema change; the content-addressed file both requests wrote is byte-identical, so the loser's write is a harmless idempotent overwrite.

## Validation

- `pnpm guard` — 86/86 pass
- `pnpm --filter @open-design/daemon typecheck` — clean
- `pnpm --filter @open-design/daemon exec vitest run tests/library` — 6 files / 32 tests pass
- Target red spec: red on main (4–5/12 fail), green on branch (3×)
- No orphan processes.