### PR TITLE
feat(daemon): route completed-run telemetry through Vela

### DIFF
--- a/apps/daemon/src/integrations/telemetry-relay.ts
+++ b/apps/daemon/src/integrations/telemetry-relay.ts
@@ -1,0 +1,19 @@
+export const OPEN_DESIGN_TELEMETRY_RELAY_URLS = {
+  test: 'https://telemetry-test.open-design.ai/api/langfuse',
+  prod: 'https://telemetry.open-design.ai/api/langfuse',
+} as const;
+
+const LEGACY_TEST_RELAY_ORIGIN = 'https://telemetry-selfhost.open-design.ai';
+const TEST_RELAY_ORIGIN = 'https://telemetry-test.open-design.ai';
+
+/**
+ * Keep legacy test configurations working while moving the test Worker to its
+ * environment-owned hostname. Production and custom relay URLs are unchanged.
+ */
+export function normalizeOpenDesignTelemetryRelayUrl(value: string): string {
+  const normalized = value.trim().replace(/\/+$/, '');
+  return normalized.startsWith(`${LEGACY_TEST_RELAY_ORIGIN}/`) ||
+    normalized === LEGACY_TEST_RELAY_ORIGIN
+    ? `${TEST_RELAY_ORIGIN}${normalized.slice(LEGACY_TEST_RELAY_ORIGIN.length)}`
+    : normalized;
+}

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -17,6 +17,7 @@ import { modelIdForTracking } from '@open-design/contracts/analytics';
 import { agentCliEnvForAgent, readAppConfig } from './app-config.js';
 import type { AppVersionInfo } from './app-version.js';
 import { listMessages } from './db.js';
+import { normalizeOpenDesignTelemetryRelayUrl } from './integrations/telemetry-relay.js';
 import {
   deriveLangfuseDeliveryState,
   readFeedbackTelemetrySinkConfig,
@@ -187,14 +188,21 @@ function inferObjectRegistrationRelayUrl(env: NodeJS.ProcessEnv = process.env): 
   const objectRelayUrl = env.OPEN_DESIGN_OBJECT_RELAY_URL?.trim();
   if (!objectRelayUrl) {
     const telemetryRelayUrl = env.OPEN_DESIGN_TELEMETRY_RELAY_URL?.trim();
-    return telemetryRelayUrl ? telemetryRelayUrl.replace(/\/+$/, '') : null;
+    return telemetryRelayUrl
+      ? normalizeOpenDesignTelemetryRelayUrl(telemetryRelayUrl)
+      : null;
   }
+  const normalizedObjectRelayUrl = normalizeOpenDesignTelemetryRelayUrl(
+    objectRelayUrl,
+  );
   try {
-    const url = new URL(objectRelayUrl);
+    const url = new URL(normalizedObjectRelayUrl);
     url.pathname = url.pathname.replace(/\/api\/objects\/batch\/?$/, '/api/langfuse');
     return url.toString().replace(/\/+$/, '');
   } catch {
-    return objectRelayUrl.replace(/\/api\/objects\/batch\/?$/, '/api/langfuse').replace(/\/+$/, '');
+    return normalizedObjectRelayUrl
+      .replace(/\/api\/objects\/batch\/?$/, '/api/langfuse')
+      .replace(/\/+$/, '');
   }
 }
 

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -14,12 +14,12 @@ import path from 'node:path';
 
 import { modelIdForTracking } from '@open-design/contracts/analytics';
 
-import { readAppConfig } from './app-config.js';
+import { agentCliEnvForAgent, readAppConfig } from './app-config.js';
 import type { AppVersionInfo } from './app-version.js';
 import { listMessages } from './db.js';
 import {
   deriveLangfuseDeliveryState,
-  readTelemetrySinkConfig,
+  readFeedbackTelemetrySinkConfig,
   reportRunCompleted,
   reportRunFeedback,
   type AgentEventSummary,
@@ -941,6 +941,7 @@ export async function reportRunCompletedFromDaemon(
       return deriveLangfuseDeliveryState(prefs, null);
     }
     const installationId = cfg.installationId ?? null;
+    const configuredAmrEnv = agentCliEnvForAgent(cfg.agentCliEnv, 'amr');
 
     let messageContent = '';
     let producedFilesRaw: unknown = undefined;
@@ -1114,6 +1115,7 @@ export async function reportRunCompletedFromDaemon(
         buildContext(mergeTraceSafeManifests(manifests, registrationManifests)),
         {
           config: objectRegistrationTelemetryConfig(),
+          deliveryPurpose: 'object-registration',
           ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
         },
       );
@@ -1126,7 +1128,10 @@ export async function reportRunCompletedFromDaemon(
         traceObjectFilesRaw,
         ...(uploadedManifests ? { uploaded: uploadedManifests } : {}),
       })),
-      opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {},
+      {
+        configuredEnv: configuredAmrEnv,
+        ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+      },
     );
   } catch (err) {
     console.warn('[langfuse-bridge] report failed:', String(err));
@@ -1179,7 +1184,8 @@ export async function reportRunFeedbackFromDaemon(
   // Pre-resolve the sink before claiming `accepted`. Avoids advertising a
   // successful enqueue to callers when there's no Langfuse endpoint
   // configured to ship the score to.
-  const sink = readTelemetrySinkConfig();
+  const configuredAmrEnv = agentCliEnvForAgent(cfg.agentCliEnv, 'amr');
+  const sink = readFeedbackTelemetrySinkConfig(process.env, configuredAmrEnv);
   if (!sink) {
     return { status: 'skipped_no_sink' };
   }
@@ -1199,7 +1205,10 @@ export async function reportRunFeedbackFromDaemon(
   // telemetry, not a client-facing signal.
   void reportRunFeedback(
     ctx,
-    opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {},
+    {
+      configuredEnv: configuredAmrEnv,
+      ...(opts.fetchImpl ? { fetchImpl: opts.fetchImpl } : {}),
+    },
   ).catch((err) => {
     console.warn('[langfuse-bridge] feedback report failed:', String(err));
   });

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -19,6 +19,7 @@
 import { createHash, randomUUID } from 'node:crypto';
 
 import type { TelemetryPrefs } from './app-config.js';
+import { normalizeOpenDesignTelemetryRelayUrl } from './integrations/telemetry-relay.js';
 import { readVelaControlApiContext } from './integrations/vela.js';
 import {
   buildPromptStackFlatMetadata,
@@ -401,7 +402,7 @@ export function readTelemetrySinkConfig(
   if (relayUrl) {
     return {
       kind: 'relay',
-      relayUrl: relayUrl.replace(/\/+$/, ''),
+      relayUrl: normalizeOpenDesignTelemetryRelayUrl(relayUrl),
       timeoutMs: parsePositiveInt(
         env.OPEN_DESIGN_TELEMETRY_TIMEOUT_MS ?? env.LANGFUSE_TIMEOUT_MS,
         DEFAULT_FETCH_TIMEOUT_MS,

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -339,7 +339,7 @@ export interface ReportRunOpts {
 }
 
 export interface ReportFeedbackOpts {
-  config?: TelemetrySinkConfig | LangfuseConfig | null;
+  config?: RunTelemetrySinkConfig | LangfuseConfig | null;
   fetchImpl?: typeof fetch;
   configuredEnv?: Record<string, string>;
 }
@@ -424,9 +424,10 @@ function isVelaTelemetryEnabled(env: NodeJS.ProcessEnv): boolean {
 }
 
 /**
- * Completed-run telemetry may use the authenticated Vela entry. Feedback keeps
- * using readTelemetrySinkConfig() until Vela exposes a server-owned receipt
- * protocol, so this resolver must not be reused by reportRunFeedback().
+ * Completed-run and feedback telemetry share the same sink selection: Vela when
+ * a Control Key is present, otherwise the anonymous relay / direct Langfuse.
+ * Feedback score-only batches keep the client run id as `data.traceId`; Vela
+ * re-scopes it with the same account hash as the original run batch.
  */
 export function readRunTelemetrySinkConfig(
   env: NodeJS.ProcessEnv = process.env,
@@ -458,16 +459,14 @@ export function readRunTelemetrySinkConfig(
 }
 
 /**
- * Scores cannot safely target Vela-scoped trace IDs until the server returns
- * an opaque receipt for the accepted run. Skip them while Vela is selected;
- * anonymous runs retain the existing relay/direct-Langfuse behavior.
+ * Feedback uses the same sink as completed-run telemetry. Vela accepts
+ * score-only batches on the same endpoint and binds them via client run id.
  */
 export function readFeedbackTelemetrySinkConfig(
   env: NodeJS.ProcessEnv = process.env,
   configuredEnv: Record<string, string> = {},
-): TelemetrySinkConfig | null {
-  const runSink = readRunTelemetrySinkConfig(env, configuredEnv);
-  return runSink?.kind === 'vela' ? null : readTelemetrySinkConfig(env);
+): RunTelemetrySinkConfig | null {
+  return readRunTelemetrySinkConfig(env, configuredEnv);
 }
 
 export function deriveLangfuseDeliveryState(
@@ -1919,6 +1918,7 @@ const LANGFUSE_TYPE_TO_VELA_KIND = {
   'span-create': 'span',
   'generation-create': 'generation',
   'event-create': 'event',
+  'score-create': 'score',
 } as const;
 
 type VelaSourceEventType = keyof typeof LANGFUSE_TYPE_TO_VELA_KIND;
@@ -2100,7 +2100,7 @@ function resolveRunReportConfig(
 
 function resolveFeedbackReportConfig(
   opts: ReportFeedbackOpts,
-): TelemetrySinkConfig | null {
+): RunTelemetrySinkConfig | null {
   if (opts.config === undefined) {
     return readFeedbackTelemetrySinkConfig(
       process.env,
@@ -2108,8 +2108,7 @@ function resolveFeedbackReportConfig(
     );
   }
   if (opts.config == null) return null;
-  if ('kind' in opts.config) return opts.config;
-  return { kind: 'langfuse', ...opts.config };
+  return normalizeRunTelemetrySinkConfig(opts.config);
 }
 
 function ingestionDropReasonFromStatus(
@@ -2397,6 +2396,21 @@ export async function reportRunFeedback(
   }
 
   const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  if (config.kind === 'vela') {
+    const installationId = ctx.installationId?.trim() ?? '';
+    if (!installationId) {
+      const fallback = readTelemetrySinkConfig();
+      if (!fallback) return;
+      if (fallback.kind === 'relay') {
+        await postRelayBatch(fallback, serialized, fetchImpl);
+        return;
+      }
+      await postLangfuseBatch(fallback, batch, fetchImpl);
+      return;
+    }
+    await postVelaBatch(config, batch, installationId, fetchImpl);
+    return;
+  }
   if (config.kind === 'relay') {
     await postRelayBatch(config, serialized, fetchImpl);
     return;

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -16,9 +16,10 @@
 //
 // See: specs/change/20260507-langfuse-telemetry/spec.md
 
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 
 import type { TelemetryPrefs } from './app-config.js';
+import { readVelaControlApiContext } from './integrations/vela.js';
 import {
   buildPromptStackFlatMetadata,
   promptStackWithoutContent,
@@ -74,6 +75,12 @@ export type LangfuseDropReason =
   | 'relay_5xx'
   | 'langfuse_4xx'
   | 'langfuse_5xx'
+  | 'vela_400'
+  | 'vela_401'
+  | 'vela_403'
+  | 'vela_413'
+  | 'vela_429'
+  | 'vela_5xx'
   | 'network_error';
 
 export interface LangfuseDeliveryState {
@@ -92,6 +99,18 @@ export type TelemetrySinkConfig =
   | ({
       kind: 'langfuse';
     } & LangfuseConfig);
+
+export interface VelaTelemetrySinkConfig {
+  kind: 'vela';
+  apiUrl: string;
+  controlKey: string;
+  timeoutMs: number;
+  retries: number;
+}
+
+export type RunTelemetrySinkConfig =
+  | TelemetrySinkConfig
+  | VelaTelemetrySinkConfig;
 
 export interface RunSummary {
   runId: string;
@@ -310,8 +329,18 @@ export interface ReportContext {
 }
 
 export interface ReportRunOpts {
+  config?: RunTelemetrySinkConfig | LangfuseConfig | null;
+  fetchImpl?: typeof fetch;
+  /** App-config AMR env used only when resolving the completed-run Vela sink. */
+  configuredEnv?: Record<string, string>;
+  /** Keep object-authority registration anonymous and content-free. */
+  deliveryPurpose?: 'final' | 'object-registration';
+}
+
+export interface ReportFeedbackOpts {
   config?: TelemetrySinkConfig | LangfuseConfig | null;
   fetchImpl?: typeof fetch;
+  configuredEnv?: Record<string, string>;
 }
 
 /**
@@ -388,9 +417,61 @@ export function readTelemetrySinkConfig(
   return config == null ? null : { kind: 'langfuse', ...config };
 }
 
+function isVelaTelemetryEnabled(env: NodeJS.ProcessEnv): boolean {
+  const raw = env.OPEN_DESIGN_VELA_TELEMETRY?.trim().toLowerCase();
+  return raw !== '0' && raw !== 'false' && raw !== 'off' && raw !== 'no';
+}
+
+/**
+ * Completed-run telemetry may use the authenticated Vela entry. Feedback keeps
+ * using readTelemetrySinkConfig() until Vela exposes a server-owned receipt
+ * protocol, so this resolver must not be reused by reportRunFeedback().
+ */
+export function readRunTelemetrySinkConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  configuredEnv: Record<string, string> = {},
+): RunTelemetrySinkConfig | null {
+  if (isVelaTelemetryEnabled(env)) {
+    const context = readVelaControlApiContext(env, configuredEnv);
+    const controlKey = context?.controlKey?.trim() ?? '';
+    if (context && controlKey) {
+      return {
+        kind: 'vela',
+        apiUrl: (context.apiUrl.trim() || 'https://amr-api.open-design.ai').replace(
+          /\/+$/,
+          '',
+        ),
+        controlKey,
+        timeoutMs: parsePositiveInt(
+          env.OPEN_DESIGN_TELEMETRY_TIMEOUT_MS ?? env.LANGFUSE_TIMEOUT_MS,
+          DEFAULT_FETCH_TIMEOUT_MS,
+        ),
+        retries: parseNonNegativeInt(
+          env.OPEN_DESIGN_TELEMETRY_RETRIES ?? env.LANGFUSE_RETRIES,
+          DEFAULT_FETCH_RETRIES,
+        ),
+      };
+    }
+  }
+  return readTelemetrySinkConfig(env);
+}
+
+/**
+ * Scores cannot safely target Vela-scoped trace IDs until the server returns
+ * an opaque receipt for the accepted run. Skip them while Vela is selected;
+ * anonymous runs retain the existing relay/direct-Langfuse behavior.
+ */
+export function readFeedbackTelemetrySinkConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  configuredEnv: Record<string, string> = {},
+): TelemetrySinkConfig | null {
+  const runSink = readRunTelemetrySinkConfig(env, configuredEnv);
+  return runSink?.kind === 'vela' ? null : readTelemetrySinkConfig(env);
+}
+
 export function deriveLangfuseDeliveryState(
   prefs: TelemetryPrefs,
-  sink: TelemetrySinkConfig | null,
+  sink: RunTelemetrySinkConfig | null,
 ): LangfuseDeliveryState {
   if (prefs.metrics !== true) {
     return {
@@ -1332,7 +1413,8 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
   const success = ctx.run.status === 'succeeded';
   const traceId = ctx.run.runId;
   const langfuseDelivery =
-    ctx.langfuse ?? deriveLangfuseDeliveryState(ctx.prefs, readTelemetrySinkConfig());
+    ctx.langfuse ??
+    deriveLangfuseDeliveryState(ctx.prefs, readRunTelemetrySinkConfig());
   const agentSpanId = `${ctx.run.runId}-agent`;
   const generationId = `${ctx.run.runId}-gen`;
   const createGeneration = shouldCreateGenerationObservation(ctx);
@@ -1831,31 +1913,216 @@ async function postRelayBatch(
   };
 }
 
+const LANGFUSE_TYPE_TO_VELA_KIND = {
+  'trace-create': 'trace',
+  'span-create': 'span',
+  'generation-create': 'generation',
+  'event-create': 'event',
+} as const;
+
+type VelaSourceEventType = keyof typeof LANGFUSE_TYPE_TO_VELA_KIND;
+
+interface VelaSourceEvent {
+  type: VelaSourceEventType;
+  timestamp: string;
+  body: Record<string, unknown>;
+}
+
+interface VelaTelemetryEnvelope {
+  version: 1;
+  installationId: string;
+  events: Array<{
+    id: string;
+    kind: (typeof LANGFUSE_TYPE_TO_VELA_KIND)[VelaSourceEventType];
+    timestamp: string;
+    data: Record<string, unknown>;
+  }>;
+}
+
+function asVelaSourceEvents(batch: unknown[]): VelaSourceEvent[] {
+  return batch.filter((item): item is VelaSourceEvent => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) return false;
+    const event = item as Partial<VelaSourceEvent>;
+    return (
+      typeof event.type === 'string' &&
+      event.type in LANGFUSE_TYPE_TO_VELA_KIND &&
+      typeof event.timestamp === 'string' &&
+      !!event.body &&
+      typeof event.body === 'object' &&
+      !Array.isArray(event.body)
+    );
+  });
+}
+
+function stableVelaEventId(event: VelaSourceEvent): string {
+  const bodyId =
+    typeof event.body.id === 'string' && event.body.id.trim()
+      ? event.body.id.trim()
+      : JSON.stringify(event.body);
+  return `od-${createHash('sha256')
+    .update(`${event.type}\n${bodyId}`, 'utf8')
+    .digest('hex')}`;
+}
+
+function buildVelaEnvelope(
+  batch: unknown[],
+  installationId: string,
+): VelaTelemetryEnvelope {
+  return {
+    version: 1,
+    installationId,
+    events: asVelaSourceEvents(batch).map((event) => ({
+      id: stableVelaEventId(event),
+      kind: LANGFUSE_TYPE_TO_VELA_KIND[event.type],
+      timestamp: event.timestamp,
+      data: event.body,
+    })),
+  };
+}
+
+function velaIdempotencyKey(envelope: VelaTelemetryEnvelope): string {
+  // Wrapper timestamps are excluded: rebuilding an otherwise identical run
+  // should retain its key, while any changed trace/observation body gets a new
+  // key. Retries of this request reuse the same serialized envelope and key.
+  const canonical = {
+    version: envelope.version,
+    installationId: envelope.installationId,
+    events: envelope.events.map(({ id, kind, data }) => ({ id, kind, data })),
+  };
+  return createHash('sha256').update(JSON.stringify(canonical), 'utf8').digest('hex');
+}
+
+async function postVelaBatch(
+  config: VelaTelemetrySinkConfig,
+  batch: unknown[],
+  installationId: string,
+  fetchImpl: typeof fetch,
+): Promise<LangfuseDeliveryState> {
+  const envelope = buildVelaEnvelope(batch, installationId);
+  const body = JSON.stringify(envelope);
+  const idempotencyKey = velaIdempotencyKey(envelope);
+  const attempts = config.retries + 1;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const response = await fetchImpl(
+        `${config.apiUrl}/api/v1/open-design/telemetry`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${config.controlKey}`,
+            'Content-Type': 'application/json',
+            'Idempotency-Key': idempotencyKey,
+          },
+          signal: AbortSignal.timeout(config.timeoutMs),
+          body,
+        },
+      );
+      if (response.status === 202) {
+        return {
+          langfuse_expected: true,
+          langfuse_delivery_status: 'accepted',
+        };
+      }
+
+      await response.text().catch(() => '');
+      if (response.status === 401 || response.status === 403) {
+        const fallback = readTelemetrySinkConfig();
+        if (fallback) {
+          const serialized = JSON.stringify({ batch });
+          return fallback.kind === 'relay'
+            ? postRelayBatch(fallback, serialized, fetchImpl)
+            : postLangfuseBatch(fallback, batch, fetchImpl);
+        }
+      }
+      if (
+        attempt < attempts &&
+        (response.status === 429 || response.status >= 500)
+      ) {
+        await waitBeforeRetry(attempt);
+        continue;
+      }
+      console.warn(
+        `[langfuse-trace] Vela telemetry failed status=${response.status}`,
+      );
+      return {
+        langfuse_expected: true,
+        langfuse_delivery_status: 'failed',
+        langfuse_drop_reason: ingestionDropReasonFromStatus(
+          response.status,
+          'vela',
+        ),
+      };
+    } catch (error) {
+      if (attempt < attempts) {
+        await waitBeforeRetry(attempt);
+        continue;
+      }
+      console.warn(`[langfuse-trace] Vela telemetry fetch error: ${String(error)}`);
+      return {
+        langfuse_expected: true,
+        langfuse_delivery_status: 'failed',
+        langfuse_drop_reason: 'network_error',
+      };
+    }
+  }
+
+  return {
+    langfuse_expected: true,
+    langfuse_delivery_status: 'failed',
+    langfuse_drop_reason: 'network_error',
+  };
+}
+
 function waitBeforeRetry(attempt: number): Promise<void> {
   return new Promise((resolve) =>
     setTimeout(resolve, Math.min(250 * attempt, 1000)),
   );
 }
 
-function normalizeTelemetrySinkConfig(
-  config: TelemetrySinkConfig | LangfuseConfig,
-): TelemetrySinkConfig {
+function normalizeRunTelemetrySinkConfig(
+  config: RunTelemetrySinkConfig | LangfuseConfig,
+): RunTelemetrySinkConfig {
   if ('kind' in config) return config;
   return { kind: 'langfuse', ...config };
 }
 
-function resolveReportConfig(
+function resolveRunReportConfig(
   opts: ReportRunOpts,
-): TelemetrySinkConfig | null {
-  if (opts.config === undefined) return readTelemetrySinkConfig();
+): RunTelemetrySinkConfig | null {
+  if (opts.config === undefined) {
+    return readRunTelemetrySinkConfig(process.env, opts.configuredEnv ?? {});
+  }
   if (opts.config == null) return null;
-  return normalizeTelemetrySinkConfig(opts.config);
+  return normalizeRunTelemetrySinkConfig(opts.config);
+}
+
+function resolveFeedbackReportConfig(
+  opts: ReportFeedbackOpts,
+): TelemetrySinkConfig | null {
+  if (opts.config === undefined) {
+    return readFeedbackTelemetrySinkConfig(
+      process.env,
+      opts.configuredEnv ?? {},
+    );
+  }
+  if (opts.config == null) return null;
+  if ('kind' in opts.config) return opts.config;
+  return { kind: 'langfuse', ...opts.config };
 }
 
 function ingestionDropReasonFromStatus(
   status: number,
-  sinkKind: TelemetrySinkConfig['kind'],
+  sinkKind: RunTelemetrySinkConfig['kind'],
 ): LangfuseDropReason {
+  if (sinkKind === 'vela') {
+    if (status === 401) return 'vela_401';
+    if (status === 403) return 'vela_403';
+    if (status === 413) return 'vela_413';
+    if (status === 429) return 'vela_429';
+    if (status >= 500) return 'vela_5xx';
+    return 'vela_400';
+  }
   if (sinkKind === 'relay') {
     if (status === 429) return 'relay_429';
     if (status === 413) return 'relay_413';
@@ -1913,6 +2180,50 @@ function warnPerEventErrors(responseBody: string, label: string): boolean {
   return false;
 }
 
+function objectRegistrationBatch(batch: unknown[]): unknown[] {
+  const trace = batch.find((item) => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) return false;
+    return (item as { type?: unknown }).type === 'trace-create';
+  });
+  if (!trace || typeof trace !== 'object' || Array.isArray(trace)) return [];
+  const source = trace as {
+    id?: unknown;
+    type?: unknown;
+    timestamp?: unknown;
+    body?: unknown;
+  };
+  if (!source.body || typeof source.body !== 'object' || Array.isArray(source.body)) {
+    return [];
+  }
+  const body = source.body as Record<string, unknown>;
+  const sourceMetadata =
+    body.metadata &&
+    typeof body.metadata === 'object' &&
+    !Array.isArray(body.metadata)
+      ? (body.metadata as Record<string, unknown>)
+      : {};
+  return [
+    {
+      id: source.id,
+      type: source.type,
+      timestamp: source.timestamp,
+      body: {
+        id: body.id,
+        name: body.name,
+        userId: body.userId,
+        metadata: {
+          projectId: sourceMetadata.projectId,
+          attachment_manifest: sourceMetadata.attachment_manifest,
+          artifact_manifest: sourceMetadata.artifact_manifest,
+          input_text_snapshot_manifest:
+            sourceMetadata.input_text_snapshot_manifest,
+          registration_only: true,
+        },
+      },
+    },
+  ];
+}
+
 export async function reportRunCompleted(
   ctx: ReportContext,
   opts: ReportRunOpts = {},
@@ -1921,7 +2232,7 @@ export async function reportRunCompleted(
   if (ctx.prefs.metrics !== true) return notExpected;
   if (ctx.prefs.content !== true) return notExpected;
 
-  const config = resolveReportConfig(opts);
+  const config = resolveRunReportConfig(opts);
   const langfuseDelivery = deriveLangfuseDeliveryState(ctx.prefs, config);
   if (!config) {
     if (!missingTelemetrySinkWarned) {
@@ -1938,6 +2249,9 @@ export async function reportRunCompleted(
   let batch: unknown[];
   try {
     batch = buildTracePayload({ ...ctx, langfuse: langfuseDelivery });
+    if (opts.deliveryPurpose === 'object-registration') {
+      batch = objectRegistrationBatch(batch);
+    }
   } catch (error) {
     console.warn(`[langfuse-trace] Payload build error: ${String(error)}`);
     return {
@@ -1964,6 +2278,23 @@ export async function reportRunCompleted(
   }
 
   const fetchImpl = opts.fetchImpl ?? globalThis.fetch;
+  if (config.kind === 'vela') {
+    const installationId = ctx.installationId?.trim() ?? '';
+    if (!installationId) {
+      const fallback = readTelemetrySinkConfig();
+      if (!fallback) {
+        return {
+          langfuse_expected: false,
+          langfuse_delivery_status: 'not_expected',
+          langfuse_drop_reason: 'missing_sink_config',
+        };
+      }
+      return fallback.kind === 'relay'
+        ? postRelayBatch(fallback, serialized, fetchImpl)
+        : postLangfuseBatch(fallback, batch, fetchImpl);
+    }
+    return postVelaBatch(config, batch, installationId, fetchImpl);
+  }
   if (config.kind === 'relay') {
     return postRelayBatch(config, serialized, fetchImpl);
   }
@@ -2039,12 +2370,12 @@ export function buildFeedbackPayload(ctx: FeedbackReportContext): unknown[] {
 
 export async function reportRunFeedback(
   ctx: FeedbackReportContext,
-  opts: ReportRunOpts = {},
+  opts: ReportFeedbackOpts = {},
 ): Promise<void> {
   if (ctx.prefs.metrics !== true) return;
   if (ctx.prefs.content !== true) return;
 
-  const config = resolveReportConfig(opts);
+  const config = resolveFeedbackReportConfig(opts);
   if (!config) return;
 
   let batch: unknown[];

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -1998,7 +1998,13 @@ async function postVelaBatch(
   batch: unknown[],
   installationId: string,
   fetchImpl: typeof fetch,
+  opts: { allowAnonymousAuthFallback?: boolean } = {},
 ): Promise<LangfuseDeliveryState> {
+  // Completed-run batches may fall back to the anonymous relay when Vela
+  // rejects auth (expired Control Key, etc.). Score-only feedback must not:
+  // the matching trace is account-scoped on Vela, so anonymous delivery would
+  // orphan the scores while the feedback route has already reported accepted.
+  const allowAnonymousAuthFallback = opts.allowAnonymousAuthFallback !== false;
   const envelope = buildVelaEnvelope(batch, installationId);
   const body = JSON.stringify(envelope);
   const idempotencyKey = velaIdempotencyKey(envelope);
@@ -2027,7 +2033,10 @@ async function postVelaBatch(
       }
 
       await response.text().catch(() => '');
-      if (response.status === 401 || response.status === 403) {
+      if (
+        allowAnonymousAuthFallback &&
+        (response.status === 401 || response.status === 403)
+      ) {
         const fallback = readTelemetrySinkConfig();
         if (fallback) {
           const serialized = JSON.stringify({ batch });
@@ -2408,7 +2417,11 @@ export async function reportRunFeedback(
       await postLangfuseBatch(fallback, batch, fetchImpl);
       return;
     }
-    await postVelaBatch(config, batch, installationId, fetchImpl);
+    // Never fall back to anonymous sinks for feedback: scores need the
+    // account-scoped Vela trace from the completed run.
+    await postVelaBatch(config, batch, installationId, fetchImpl, {
+      allowAnonymousAuthFallback: false,
+    });
     return;
   }
   if (config.kind === 'relay') {

--- a/apps/daemon/src/trace-object-manifest.ts
+++ b/apps/daemon/src/trace-object-manifest.ts
@@ -9,6 +9,7 @@ import type {
   ObjectManifestCompleteness,
 } from './langfuse-trace.js';
 import { INPUT_MAX_BYTES } from './langfuse-trace.js';
+import { normalizeOpenDesignTelemetryRelayUrl } from './integrations/telemetry-relay.js';
 import { mimeFor, readProjectFile, resolveProjectFilePath } from './projects.js';
 
 const OBJECT_RELAY_MARKER_HEADER = 'X-Open-Design-Telemetry';
@@ -136,10 +137,10 @@ function storageRef(projectId: string, runId: string, objectClass: ObjectClass, 
 
 function inferRelayUrl(env: NodeJS.ProcessEnv): string | null {
   const explicit = env.OPEN_DESIGN_OBJECT_RELAY_URL?.trim();
-  if (explicit) return explicit.replace(/\/+$/, '');
+  if (explicit) return normalizeOpenDesignTelemetryRelayUrl(explicit);
   const rawTelemetryRelayUrl = env.OPEN_DESIGN_TELEMETRY_RELAY_URL?.trim();
   if (!rawTelemetryRelayUrl) return null;
-  const telemetryRelayUrl = rawTelemetryRelayUrl.replace(/\/+$/, '');
+  const telemetryRelayUrl = normalizeOpenDesignTelemetryRelayUrl(rawTelemetryRelayUrl);
   try {
     const url = new URL(telemetryRelayUrl);
     if (!/\/api\/langfuse\/?$/u.test(url.pathname)) return null;

--- a/apps/daemon/tests/integrations/telemetry-relay.test.ts
+++ b/apps/daemon/tests/integrations/telemetry-relay.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  normalizeOpenDesignTelemetryRelayUrl,
+  OPEN_DESIGN_TELEMETRY_RELAY_URLS,
+} from '../../src/integrations/telemetry-relay.js';
+
+describe('Open Design telemetry relay URLs', () => {
+  it('keeps production on telemetry.open-design.ai', () => {
+    expect(OPEN_DESIGN_TELEMETRY_RELAY_URLS.prod).toBe(
+      'https://telemetry.open-design.ai/api/langfuse',
+    );
+    expect(normalizeOpenDesignTelemetryRelayUrl(
+      'https://telemetry.open-design.ai/api/langfuse//',
+    )).toBe(OPEN_DESIGN_TELEMETRY_RELAY_URLS.prod);
+  });
+
+  it('moves legacy self-host test URLs to telemetry-test.open-design.ai', () => {
+    expect(normalizeOpenDesignTelemetryRelayUrl(
+      'https://telemetry-selfhost.open-design.ai/api/langfuse/',
+    )).toBe(OPEN_DESIGN_TELEMETRY_RELAY_URLS.test);
+  });
+
+  it('leaves custom relay URLs unchanged', () => {
+    expect(normalizeOpenDesignTelemetryRelayUrl(
+      'https://telemetry.example.test/api/langfuse/',
+    )).toBe('https://telemetry.example.test/api/langfuse');
+  });
+});

--- a/apps/daemon/tests/langfuse-bridge-nonblocking.test.ts
+++ b/apps/daemon/tests/langfuse-bridge-nonblocking.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const readAppConfigMock = vi.fn();
+const agentCliEnvForAgentMock = vi.fn();
 const listMessagesMock = vi.fn();
 const reportRunCompletedMock = vi.fn();
 
 vi.mock('../src/app-config.js', () => ({
+  agentCliEnvForAgent: agentCliEnvForAgentMock,
   readAppConfig: readAppConfigMock,
 }));
 
@@ -13,7 +15,7 @@ vi.mock('../src/db.js', () => ({
 }));
 
 vi.mock('../src/langfuse-trace.js', () => ({
-  readTelemetrySinkConfig: vi.fn(() => ({ kind: 'langfuse' })),
+  readFeedbackTelemetrySinkConfig: vi.fn(() => ({ kind: 'langfuse' })),
   reportRunCompleted: reportRunCompletedMock,
   reportRunFeedback: vi.fn(),
 }));
@@ -66,6 +68,8 @@ function makeRun(overrides: Record<string, unknown> = {}) {
 
 describe('langfuse-bridge non-blocking behavior', () => {
   beforeEach(() => {
+    agentCliEnvForAgentMock.mockReset();
+    agentCliEnvForAgentMock.mockReturnValue({});
     readAppConfigMock.mockResolvedValue({
       installationId: 'install-1',
       telemetry: { metrics: true, content: true },
@@ -76,6 +80,28 @@ describe('langfuse-bridge non-blocking behavior', () => {
       langfuse_expected: true,
       langfuse_delivery_status: 'accepted',
     });
+  });
+
+  it('passes configured AMR env only to the completed-run reporter', async () => {
+    const configuredEnv = {
+      VELA_CONTROL_KEY: 'ck_profile',
+      VELA_API_URL: 'https://vela.example.test',
+    };
+    agentCliEnvForAgentMock.mockReturnValue(configuredEnv);
+    listMessagesMock.mockReturnValue([]);
+
+    await reportRunCompletedFromDaemon({
+      db: {},
+      dataDir: '/tmp/od-test',
+      run: makeRun() as any,
+      fetchImpl: vi.fn() as any,
+    });
+
+    expect(agentCliEnvForAgentMock).toHaveBeenCalledWith(undefined, 'amr');
+    expect(reportRunCompletedMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ configuredEnv }),
+    );
   });
 
   afterEach(() => {

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -725,7 +725,10 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(4);
     expect(fetchSpy.mock.calls[0]![0]).toContain('/api/langfuse');
     const registrationBody = JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string).batch as any[];
+    expect(registrationBody).toHaveLength(1);
     const registrationTrace = registrationBody[0].body;
+    expect(registrationTrace).not.toHaveProperty('input');
+    expect(registrationTrace).not.toHaveProperty('output');
     expect(registrationTrace.metadata.attachment_manifest[0]).not.toHaveProperty('reason');
     expect(registrationTrace.metadata.artifact_manifest[0]).not.toHaveProperty('reason');
     expect(registrationTrace.metadata.input_text_snapshot_manifest[0]).not.toHaveProperty('reason');

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -188,6 +188,17 @@ describe('readTelemetrySinkConfig', () => {
     });
   });
 
+  it('migrates the legacy self-host test relay hostname', () => {
+    const cfg = readTelemetrySinkConfig({
+      OPEN_DESIGN_TELEMETRY_RELAY_URL:
+        'https://telemetry-selfhost.open-design.ai/api/langfuse',
+    });
+    expect(cfg).toMatchObject({
+      kind: 'relay',
+      relayUrl: 'https://telemetry-test.open-design.ai/api/langfuse',
+    });
+  });
+
   it('falls back to direct Langfuse config for local smoke tests', () => {
     const cfg = readTelemetrySinkConfig({
       LANGFUSE_PUBLIC_KEY: 'pk',

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -2417,6 +2417,26 @@ describe('reportRunFeedback', () => {
     });
   });
 
+  it('does not fall back anonymously when Vela rejects feedback auth', async () => {
+    vi.stubEnv('VELA_CONTROL_KEY', 'ck_expired');
+    vi.stubEnv('VELA_API_URL', 'https://vela.example.test');
+    vi.stubEnv(
+      'OPEN_DESIGN_TELEMETRY_RELAY_URL',
+      'https://telemetry.open-design.ai/api/langfuse',
+    );
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 401 }));
+
+    await reportRunFeedback(
+      makeFeedbackCtx({ reasonCodes: ['matched_request'] }),
+      { fetchImpl: fetchSpy as any },
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]![0]).toBe(
+      'https://vela.example.test/api/v1/open-design/telemetry',
+    );
+  });
+
   it('skips when metrics consent is off', async () => {
     const fetchSpy = vi.fn();
     await reportRunFeedback(makeFeedbackCtx({ prefs: { metrics: false, content: true } }), {

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -2369,18 +2369,52 @@ describe('reportRunFeedback', () => {
     vi.unstubAllEnvs();
   });
 
-  it('skips feedback while completed-run telemetry is using Vela', async () => {
+  it('posts feedback scores to Vela when completed-run telemetry uses Vela', async () => {
     vi.stubEnv('VELA_CONTROL_KEY', 'ck_secret');
     vi.stubEnv('VELA_API_URL', 'https://vela.example.test');
     vi.stubEnv(
       'OPEN_DESIGN_TELEMETRY_RELAY_URL',
       'https://telemetry.open-design.ai/api/langfuse',
     );
-    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+    const fetchSpy = vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({
+        ok: true,
+        idempotencyKey: 'feedback-key',
+        receipt: {
+          clientTraceId: 'run-feedback-1',
+          scopedTraceId: 'scoped-run-feedback-1',
+        },
+      }),
+      { status: 202 },
+    ));
 
-    await reportRunFeedback(makeFeedbackCtx(), { fetchImpl: fetchSpy as any });
+    await reportRunFeedback(
+      makeFeedbackCtx({ reasonCodes: ['matched_request'] }),
+      { fetchImpl: fetchSpy as any },
+    );
 
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe('https://vela.example.test/api/v1/open-design/telemetry');
+    expect(init.headers.Authorization).toBe('Bearer ck_secret');
+    const envelope = JSON.parse(init.body);
+    expect(envelope.installationId).toBe('install-uuid-1');
+    expect(envelope.events.map((event: { kind: string }) => event.kind)).toEqual([
+      'score',
+      'score',
+    ]);
+    expect(envelope.events[0].data).toMatchObject({
+      id: 'run-feedback-1-rating',
+      traceId: 'run-feedback-1',
+      name: 'user_rating',
+      value: 1,
+    });
+    expect(envelope.events[1].data).toMatchObject({
+      id: 'run-feedback-1-reason-matched_request',
+      traceId: 'run-feedback-1',
+      name: 'user_rating_reason',
+      value: 'matched_request',
+    });
   });
 
   it('skips when metrics consent is off', async () => {

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -5,6 +5,7 @@ import {
   buildTracePayload,
   deriveLangfuseDeliveryState,
   readLangfuseConfig,
+  readRunTelemetrySinkConfig,
   readTelemetrySinkConfig,
   reportRunCompleted,
   reportRunFeedback,
@@ -12,6 +13,7 @@ import {
   type LangfuseConfig,
   type ReportContext,
   type TelemetrySinkConfig,
+  type VelaTelemetrySinkConfig,
 } from '../src/langfuse-trace.js';
 import { buildPromptStackTelemetry } from '../src/prompt-telemetry.js';
 
@@ -194,6 +196,45 @@ describe('readTelemetrySinkConfig', () => {
     expect(cfg).toMatchObject({
       kind: 'langfuse',
       baseUrl: 'https://us.cloud.langfuse.com',
+    });
+  });
+});
+
+describe('readRunTelemetrySinkConfig', () => {
+  it('uses Vela only for completed-run telemetry when a Control Key exists', () => {
+    const cfg = readRunTelemetrySinkConfig(
+      {
+        OPEN_DESIGN_TELEMETRY_RELAY_URL:
+          'https://telemetry.open-design.ai/api/langfuse',
+      },
+      {
+        VELA_CONTROL_KEY: 'ck_test',
+        VELA_API_URL: 'https://vela.example.test/',
+      },
+    );
+
+    expect(cfg).toEqual({
+      kind: 'vela',
+      apiUrl: 'https://vela.example.test',
+      controlKey: 'ck_test',
+      timeoutMs: 20_000,
+      retries: 1,
+    });
+  });
+
+  it('falls back to the anonymous resolver when Vela telemetry is disabled', () => {
+    const cfg = readRunTelemetrySinkConfig(
+      {
+        OPEN_DESIGN_VELA_TELEMETRY: 'off',
+        OPEN_DESIGN_TELEMETRY_RELAY_URL:
+          'https://telemetry.open-design.ai/api/langfuse',
+      },
+      { VELA_CONTROL_KEY: 'ck_test' },
+    );
+
+    expect(cfg).toMatchObject({
+      kind: 'relay',
+      relayUrl: 'https://telemetry.open-design.ai/api/langfuse',
     });
   });
 });
@@ -1568,6 +1609,162 @@ describe('reportRunCompleted', () => {
   afterEach(() => {
     warnSpy.mockRestore();
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it('posts completed-run telemetry to the authenticated Vela endpoint', async () => {
+    const velaConfig: VelaTelemetrySinkConfig = {
+      kind: 'vela',
+      apiUrl: 'https://vela.example.test',
+      controlKey: 'ck_secret',
+      timeoutMs: 1_000,
+      retries: 0,
+    };
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
+
+    const result = await reportRunCompleted(
+      makeCtx({
+        prefs: { metrics: true, content: true, artifactManifest: false },
+      }),
+      { config: velaConfig, fetchImpl: fetchSpy as any },
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe('https://vela.example.test/api/v1/open-design/telemetry');
+    expect(init.headers.Authorization).toBe('Bearer ck_secret');
+    expect(init.headers['Idempotency-Key']).toMatch(/^[a-f0-9]{64}$/);
+    const envelope = JSON.parse(init.body);
+    expect(envelope.version).toBe(1);
+    expect(envelope.installationId).toBe('install-uuid-1');
+    expect(envelope.events.map((event: any) => event.kind)).toEqual([
+      'trace',
+      'span',
+      'generation',
+      'span',
+      'span',
+    ]);
+    expect(envelope.events.every((event: any) => event.kind !== 'score')).toBe(true);
+    expect(result).toEqual({
+      langfuse_expected: true,
+      langfuse_delivery_status: 'accepted',
+    });
+  });
+
+  it('reuses one Vela idempotency key across transport retries', async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce(new Response('', { status: 202 }));
+
+    await reportRunCompleted(
+      makeCtx({
+        prefs: { metrics: true, content: true, artifactManifest: false },
+      }),
+      {
+        config: {
+          kind: 'vela',
+          apiUrl: 'https://vela.example.test',
+          controlKey: 'ck_secret',
+          timeoutMs: 1_000,
+          retries: 1,
+        },
+        fetchImpl: fetchSpy as any,
+      },
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy.mock.calls[0]![1].headers['Idempotency-Key']).toBe(
+      fetchSpy.mock.calls[1]![1].headers['Idempotency-Key'],
+    );
+  });
+
+  it('keeps the Vela key stable when the same completed run is rebuilt', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 202 }));
+    const context = makeCtx({
+      prefs: { metrics: true, content: true, artifactManifest: false },
+    });
+    const opts = {
+      config: {
+        kind: 'vela' as const,
+        apiUrl: 'https://vela.example.test',
+        controlKey: 'ck_secret',
+        timeoutMs: 1_000,
+        retries: 0,
+      },
+      fetchImpl: fetchSpy as any,
+    };
+
+    await reportRunCompleted(context, opts);
+    await reportRunCompleted(context, opts);
+
+    expect(fetchSpy.mock.calls[0]![1].headers['Idempotency-Key']).toBe(
+      fetchSpy.mock.calls[1]![1].headers['Idempotency-Key'],
+    );
+  });
+
+  it('falls back anonymously on an explicit Vela auth rejection', async () => {
+    vi.stubEnv(
+      'OPEN_DESIGN_TELEMETRY_RELAY_URL',
+      'https://telemetry.open-design.ai/api/langfuse',
+    );
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('', { status: 401 }))
+      .mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+    const result = await reportRunCompleted(
+      makeCtx({
+        prefs: { metrics: true, content: true, artifactManifest: false },
+      }),
+      {
+        config: {
+          kind: 'vela',
+          apiUrl: 'https://vela.example.test',
+          controlKey: 'ck_expired',
+          timeoutMs: 1_000,
+          retries: 0,
+        },
+        fetchImpl: fetchSpy as any,
+      },
+    );
+
+    expect(fetchSpy.mock.calls.map((call) => call[0])).toEqual([
+      'https://vela.example.test/api/v1/open-design/telemetry',
+      'https://telemetry.open-design.ai/api/langfuse',
+    ]);
+    expect(result.langfuse_delivery_status).toBe('accepted');
+  });
+
+  it('does not anonymously overwrite a throttled Vela delivery', async () => {
+    vi.stubEnv(
+      'OPEN_DESIGN_TELEMETRY_RELAY_URL',
+      'https://telemetry.open-design.ai/api/langfuse',
+    );
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('', { status: 429 }));
+
+    const result = await reportRunCompleted(
+      makeCtx({
+        prefs: { metrics: true, content: true, artifactManifest: false },
+      }),
+      {
+        config: {
+          kind: 'vela',
+          apiUrl: 'https://vela.example.test',
+          controlKey: 'ck_secret',
+          timeoutMs: 1_000,
+          retries: 0,
+        },
+        fetchImpl: fetchSpy as any,
+      },
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      langfuse_expected: true,
+      langfuse_delivery_status: 'failed',
+      langfuse_drop_reason: 'vela_429',
+    });
   });
 
   it('does nothing when metrics gate is off', async () => {
@@ -2155,6 +2352,24 @@ describe('reportRunFeedback', () => {
 
   beforeEach(() => {
     vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('skips feedback while completed-run telemetry is using Vela', async () => {
+    vi.stubEnv('VELA_CONTROL_KEY', 'ck_secret');
+    vi.stubEnv('VELA_API_URL', 'https://vela.example.test');
+    vi.stubEnv(
+      'OPEN_DESIGN_TELEMETRY_RELAY_URL',
+      'https://telemetry.open-design.ai/api/langfuse',
+    );
+    const fetchSpy = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await reportRunFeedback(makeFeedbackCtx(), { fetchImpl: fetchSpy as any });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it('skips when metrics consent is off', async () => {

--- a/packages/contracts/src/analytics/events/shared-enums.ts
+++ b/packages/contracts/src/analytics/events/shared-enums.ts
@@ -361,6 +361,12 @@ export type TrackingLangfuseDropReason =
   | 'relay_5xx'
   | 'langfuse_4xx'
   | 'langfuse_5xx'
+  | 'vela_400'
+  | 'vela_401'
+  | 'vela_403'
+  | 'vela_413'
+  | 'vela_429'
+  | 'vela_5xx'
   | 'network_error';
 export type TrackingLangfuseReportResult =
   | 'accepted'


### PR DESCRIPTION
## Why

Authenticated Vela telemetry needs a deliberately narrow daemon integration: completed-run telemetry should use the logged-in Vela Control Key so Vela can inject trusted account identity, while logged-out users keep the existing anonymous relay path.

The previous attempt in #5624 coupled run delivery with feedback attachment, persistence, message reuse, and late-final coordination. This PR is a scoped replacement for its transport-only intent: select the account-aware transport and keep generation non-blocking. Vela trace scoring remains out of scope until Vela exposes a server-owned receipt/attachment protocol.

## What users will see

Logged-in Vela users who have telemetry consent enabled will have completed-run telemetry delivered through Vela. Logged-out users continue using the existing anonymous telemetry relay. Telemetry failures never block generation.

Logged-in Vela users' thumbs/feedback scores are also delivered to the same account-scoped Vela telemetry endpoint, bound by the client run id so scores attach to the account-owned completed-run trace. On a Vela auth rejection, feedback delivery fails closed: there is no anonymous relay/Langfuse fallback for those score batches (anonymous fallback remains only for completed-run telemetry transport selection elsewhere). Setting `OPEN_DESIGN_VELA_TELEMETRY=0`, `false`, `off`, or `no` restores the anonymous path as an operational rollback for both completed-run and feedback telemetry sinks.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — adds the `OPEN_DESIGN_VELA_TELEMETRY` rollback env var
- [x] **API / contract** — adds Vela delivery drop reasons to the shared analytics contract and calls the Vela telemetry endpoint
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope
- [x] **Default behavior change** — logged-in Vela users with telemetry consent use the account-aware Vela transport by default (completed-run telemetry and feedback scores)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — no UI changes.

## Bug fix verification

Not applicable — this is a scoped feature integration.

## Validation

- [x] `pnpm guard`
- [x] `pnpm typecheck`
- [x] `pnpm --filter @open-design/contracts test` (34 files, 240 tests passed)
- [x] `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/langfuse-trace.test.ts tests/langfuse-bridge.test.ts tests/langfuse-bridge-nonblocking.test.ts` (3 files, 108 tests passed)
- [x] `git diff --check`

Focused coverage includes Vela selection from app AMR config, anonymous behavior without a Control Key, rollback behavior, stable idempotency, accepted delivery, auth fallback for completed-run telemetry, retryable failures, Vela feedback score delivery with fail-closed auth (no anonymous fallback), and content-free object registration.

The full `pnpm --filter @open-design/daemon test` suite was also attempted. Existing environment-dependent AMR session, MCP spawn, and provider smoke cases failed or hung outside the touched telemetry path; the focused telemetry/bridge suite above is green.
