### PR TITLE
fix(media): accept Codex imagegen call_*.png prefix alongside ig_*.png (#5527)

### DIFF
--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -1046,7 +1046,7 @@ function codexImagegenMissingOutputError(threadDir: string, stdout: string): Err
     );
   }
   return new Error(
-    `Codex imagegen completed but did not write an ig_* image under ${threadDir}. Use an API-backed image provider or a Codex CLI build that writes generated_images output.${suffix}`,
+    `Codex imagegen completed but did not write an ig_* or call_* image under ${threadDir}. Use an API-backed image provider or a Codex CLI build that writes generated_images output.${suffix}`,
   );
 }
 
@@ -1066,7 +1066,11 @@ async function readCodexGeneratedImage(
     throw err;
   }
   const match = entries
-    .filter((name) => /^ig_.*\.(?:png|jpe?g|webp)$/i.test(name))
+    // #5527: Codex imagegen on gpt-image-2 writes files with the `call_*`
+    // prefix (e.g. call_Er2KDML8Fof5QcOXdSovI85V.png); older builds and the
+    // documented contract use `ig_*`. Accept both so a successful generation
+    // is no longer misclassified as a missing-output failure.
+    .filter((name) => /^(?:ig_|call_).*\.(?:png|jpe?g|webp)$/i.test(name))
     .sort()[0];
   if (!match) {
     throw codexImagegenMissingOutputError(threadDir, stdout);

--- a/apps/daemon/tests/media/openai-compatible-providers.test.ts
+++ b/apps/daemon/tests/media/openai-compatible-providers.test.ts
@@ -611,6 +611,60 @@ process.stdin.on('end', () => {
     })).rejects.toThrow(/codex-gpt-image-2/);
   });
 
+  it('accepts the newer call_* filename prefix Codex imagegen writes (#5527)', async () => {
+    // gpt-image-2 on Codex writes `call_*.png` (e.g.
+    // call_Er2KDML8Fof5QcOXdSovI85V.png) instead of the older `ig_*.png`.
+    // The daemon must ingest both so a successful generation is not
+    // misclassified as a missing-output failure.
+    const generatedHome = path.join(root, 'call-prefix-codex-home');
+    await writeCodexAuth(generatedHome, {
+      auth_mode: 'chatgpt',
+      OPENAI_API_KEY: null,
+    });
+    const codexBin = path.join(root, 'fake-codex-call-prefix.mjs');
+    await writeFile(codexBin, `#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const pngBase64 = '${PNG_BASE64}';
+const args = process.argv.slice(2);
+const addDirIndex = args.indexOf('--add-dir');
+const generatedRoot = addDirIndex >= 0 ? args[addDirIndex + 1] : '';
+let stdin = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { stdin += chunk; });
+process.stdin.on('end', () => {
+  if (!stdin.includes('$imagegen') || !generatedRoot) process.exit(7);
+  const outDir = path.join(generatedRoot, 'call-prefix-thread');
+  mkdirSync(outDir, { recursive: true });
+  writeFileSync(path.join(outDir, 'call_Er2KDML8Fof5QcOXdSovI85V.png'), Buffer.from(pngBase64, 'base64'));
+  process.stdout.write(JSON.stringify({ type: 'thread.started', thread_id: 'call-prefix-thread' }) + '\\\\n');
+});
+`, 'utf8');
+    await chmod(codexBin, 0o755);
+    process.env.CODEX_BIN = codexBin;
+    process.env.CODEX_HOME = generatedHome;
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'gpt-image-2',
+      prompt: 'A compact green app icon with a folded page motif',
+      output: 'call-prefix.png',
+    });
+
+    expect(result.providerId).toBe('codex');
+    expect(result.providerNote).toContain('codex/gpt-image-2');
+    expect(fetchMock).not.toHaveBeenCalled();
+    const bytes = await readFile(path.join(projectsRoot, 'project-1', 'call-prefix.png'));
+    expect(bytes.length).toBeGreaterThan(0);
+  });
+
   it('keeps aliased gpt-image-2 on the explicit OpenAI API path', async () => {
     const generatedHome = path.join(root, 'aliased-subscription-codex-home');
     await writeCodexAuth(generatedHome, {

--- a/apps/daemon/tests/media/openai-compatible-providers.test.ts
+++ b/apps/daemon/tests/media/openai-compatible-providers.test.ts
@@ -638,7 +638,7 @@ process.stdin.on('end', () => {
   const outDir = path.join(generatedRoot, 'call-prefix-thread');
   mkdirSync(outDir, { recursive: true });
   writeFileSync(path.join(outDir, 'call_Er2KDML8Fof5QcOXdSovI85V.png'), Buffer.from(pngBase64, 'base64'));
-  process.stdout.write(JSON.stringify({ type: 'thread.started', thread_id: 'call-prefix-thread' }) + '\\\\n');
+  process.stdout.write(JSON.stringify({ type: 'thread.started', thread_id: 'call-prefix-thread' }) + '\\n');
 });
 `, 'utf8');
     await chmod(codexBin, 0o755);


### PR DESCRIPTION
## Problem

Codex imagegen on gpt-image-2 writes files with a `call_*` prefix (e.g. `call_Er2KDML8Fof5QcOXdSovI85V.png`), but the daemon's `readCodexGeneratedImage` regex only matched `ig_*`. A successful image generation was therefore misclassified as a missing-output failure:

> Codex imagegen completed but did not write an ig_\* image under ...

## Fix

- Widen regex in `readCodexGeneratedImage` from `/^ig_.*.(png|jpe?g|webp)$/` to `/^(?:ig_|call_).*.(png|jpe?g|webp)$/` (accept both prefixes)
- Update the error message to mention both prefixes
- Add a regression test with a `call_` filename fixture that asserts the image is correctly ingested

## Testing

- [x] New test: 'accepts the newer call_* filename prefix Codex imagegen writes (#5527)' — creates a fake Codex that writes `call_Er2KDML8Fof5QcOXdSovI85V.png`, runs `generateMedia`, asserts providerId=codex and output bytes > 0.
- [x] Existing test: 'routes default gpt-image-2 through Codex when a subscription login is available' — still passes (ig\_ prefix still works).

Fixes #5527