### PR TITLE
fix(brand): preserve authored seed overrides in validateBrand (#5612)

### DIFF
--- a/apps/daemon/src/brands/validate.ts
+++ b/apps/daemon/src/brands/validate.ts
@@ -1,8 +1,9 @@
 // Brand validation + normalization.
 //
 // Ported from the branding-agent schema, retargeted onto the '@open-design/
-// contracts' Brand type and BRAND_COLOR_ROLES. The SeedToken / seed-override
-// path from the source is dropped — Open Design brands carry no Ant seed.
+// contracts' Brand type and BRAND_COLOR_ROLES. Authored `seed` overrides on
+// the source brand are retained (sanitized) so downstream finalize can apply
+// them — see #5612.
 
 import {
   BRAND_COLOR_ROLES,
@@ -12,6 +13,7 @@ import {
   type BrandFontSpec,
   type BrandImagerySample,
 } from '@open-design/contracts';
+import { sanitizeSeedOverrides } from './schema.js';
 
 const isStr = (v: unknown): v is string => typeof v === 'string';
 const strArr = (v: unknown): string[] => (Array.isArray(v) ? v.filter(isStr) : []);
@@ -94,6 +96,7 @@ export function validateBrand(raw: unknown, sourceUrl: string): Brand {
     tagline: isStr(o.tagline) ? o.tagline : '',
     description: isStr(o.description) ? o.description : '',
     sourceUrl,
+    ...(sanitizeSeedOverrides(o.seed) ? { seed: sanitizeSeedOverrides(o.seed) } : {}),
     logo: {
       primary: isStr(logoRaw.primary) && logoRaw.primary ? logoRaw.primary : null,
       alternates: strArr(logoRaw.alternates),

--- a/apps/daemon/tests/brand-extraction-engine.test.ts
+++ b/apps/daemon/tests/brand-extraction-engine.test.ts
@@ -1344,6 +1344,64 @@ describe('agent-driven brand extraction engine', () => {
     expect(detail?.meta.designSystemId).toBe(first.designSystemId);
   });
 
+  it('finalizeBrand preserves authored seed overrides into system/seed.json (#5612)', async () => {
+    // Regression guard: validateBrand previously reconstructed the Brand
+    // without copying o.seed, so a sanctioned controlHeight:44 override
+    // in the authored brand.json was dropped and rebuildSystem fell back
+    // to the default 32. The fix retains sanitized seed overrides through
+    // validateBrand; this test pins the end-to-end behavior.
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const started = await startOfflineBrandExtraction({
+      url: 'acme.com',
+      brandsRoot,
+      projectsRoot,
+      skillsRoot: SKILLS_ROOT,
+      db,
+      logoFallback: NO_LOGO_FALLBACK,
+      imageryFallback: NO_IMAGERY_FALLBACK,
+    });
+
+    const projectDir = path.join(projectsRoot, started.projectId);
+    writeFileSync(
+      path.join(projectDir, 'brand.json'),
+      JSON.stringify({
+        ...VALID_BRAND,
+        sourceUrl: started.sourceUrl,
+        // The authored brand.json carries engine-level overrides that
+        // must survive validateBrand → rebuildSystem.
+        seed: { controlHeight: 44, borderRadius: 8 },
+      }),
+      'utf8',
+    );
+    writeFileSync(path.join(projectDir, 'BRAND.md'), '# Acme Brand Guide\n', 'utf8');
+
+    const finalized = await finalizeBrand({
+      id: started.id,
+      brandsRoot,
+      userDesignSystemsRoot,
+      projectsRoot,
+      skillsRoot: SKILLS_ROOT,
+      db,
+      logoFallback: NO_LOGO_FALLBACK,
+      imageryFallback: NO_IMAGERY_FALLBACK,
+    });
+
+    // The Brand object returned by finalize carries the overrides.
+    expect(finalized.brand.seed?.controlHeight).toBe(44);
+    expect(finalized.brand.seed?.borderRadius).toBe(8);
+
+    // The persisted system/seed.json is the engine's full SeedToken
+    // with the overrides baked in (not just the override keys).
+    const systemSeed = JSON.parse(
+      readFileSync(path.join(projectDir, 'system', 'seed.json'), 'utf8'),
+    );
+    expect(systemSeed.controlHeight).toBe(44);
+    expect(systemSeed.borderRadius).toBe(8);
+
+    // A non-overridden field still uses the engine's derived default.
+    expect(systemSeed.fontSize).toBe(14);
+  });
+
   it('finalizeBrand fails clearly when the agent has not written brand.json yet', async () => {
     const db = openDatabase(tempDir, { dataDir: tempDir });
     const started = await startOfflineBrandExtraction({


### PR DESCRIPTION
## Problem

`od brand finalize <brand-id>` silently drops supported overrides authored under `brand.json.seed`. `validateBrand()` reconstructs the brand object without copying `o.seed`, so a requested `controlHeight: 44` falls back to the default 32.

## Fix

`validateBrand()` now calls `sanitizeSeedOverrides(o.seed)` (already existed in `schema.ts`) and spreads the result into the returned `Brand` object via:

```ts
...(sanitizeSeedOverrides(o.seed) ? { seed: sanitizeSeedOverrides(o.seed) } : {}),
```

Downstream `rebuildSystem` already reads `brand.seed` through the same `sanitizeSeedOverrides()` helper, so the override path works end-to-end once `validateBrand` retains the field.

## What users will see

No visible change to the `od brand finalize` CLI output. Users who have authored `brand.json.seed` with engine-level overrides will now see those overrides honoured in the generated design system (e.g. taller control height, larger border radius). Previously the overrides were silently discarded and the engine defaults applied, which could cause confusion when a re-finalize seemed to ignore the authored intent.

## Surface area

- **`apps/daemon/src/brands/validate.ts`** — comment + import + one spread line changed
- `sanitizeSeedOverrides` handles type-checking (rejects unexpected types, keeps only `string|number|boolean` fields), so unsupported fields are still safely dropped

## Bug fix verification

E2E regression test added in `apps/daemon/tests/brand-extraction-engine.test.ts`:
1. Writes a `brand.json` with `seed: { controlHeight: 44, borderRadius: 8 }`
2. Runs `finalizeBrand`
3. Asserts `finalized.brand.seed.controlHeight === 44` and `finalized.brand.seed.borderRadius === 8`
4. Reads `system/seed.json` on disk and verifies the overrides are baked in
5. Verifies a non-overridden field (`fontSize`) still uses the engine default (14)

## Validation

- `pnpm --filter @open-design/daemon test` — 47 tests pass in `brand-extraction-engine.test.ts`
- The new regression test (`finalizeBrand preserves authored seed overrides into system/seed.json (#5612)`) passes
- No pre-existing test failures in the daemon test suite

Fixes #5612