### PR TITLE
fix web export filtering and select all

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.module.css
+++ b/apps/web/src/components/DesignFilesPanel.module.css
@@ -1,0 +1,197 @@
+.listControls {
+  position: relative;
+  z-index: 4;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 30px;
+  margin: 0 20px 8px;
+}
+
+.kindFilter {
+  position: relative;
+  display: inline-flex;
+}
+
+.filterTrigger {
+  min-height: 30px;
+  padding: 4px 10px;
+  gap: 6px;
+  border-color: var(--border);
+  color: var(--text-muted);
+  font-size: 11.5px;
+}
+
+.filterTrigger.active {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--border));
+  background: var(--accent-tint);
+  color: var(--text);
+}
+
+.filterTriggerLabel {
+  white-space: nowrap;
+}
+
+.filterCount {
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: var(--accent);
+  color: white;
+  font-size: 10.5px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.filterPopover {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 20;
+  width: max(220px, 100%);
+  max-height: min(360px, calc(100vh - 96px));
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  overflow: hidden;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+  box-shadow: var(--shadow-lg);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(-4px) scale(0.98);
+  transform-origin: top left;
+  transition:
+    opacity 140ms cubic-bezier(0.23, 1, 0.32, 1),
+    transform 140ms cubic-bezier(0.23, 1, 0.32, 1),
+    visibility 0s linear 140ms;
+}
+
+.filterPopover.open {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0) scale(1);
+  transition-duration: 200ms, 200ms, 0s;
+  transition-delay: 0s;
+}
+
+.filterHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 4px 8px 6px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-faint);
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.filterHeader .filterClear {
+  min-height: 0;
+  padding: 2px 4px;
+  border: 0;
+  color: var(--text-muted);
+  font-size: 11px;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.filterList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.filterList li + li {
+  border-top: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+}
+
+.filterItem {
+  display: grid;
+  grid-template-columns: 18px 22px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  color: var(--text);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.filterItem:hover {
+  background: var(--bg-subtle);
+}
+
+.filterItem:focus-within {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.filterItem input[type='checkbox'] {
+  margin: 0;
+  cursor: pointer;
+}
+
+.filterGlyph {
+  color: var(--text-faint);
+  font-family: var(--mono, ui-monospace, monospace);
+  font-size: 11px;
+  text-align: center;
+}
+
+.filterLabel {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.filterItemCount {
+  color: var(--text-faint);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.selectAllToggle {
+  min-height: 30px;
+  padding: 4px 8px;
+  border-color: transparent;
+  color: var(--text-muted);
+  font-size: 11.5px;
+}
+
+.selectAllToggle.active {
+  color: var(--text);
+}
+
+.selectAllBox {
+  width: 15px;
+  height: 15px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  background: var(--bg-panel);
+  color: white;
+}
+
+.selectAllToggle.active .selectAllBox {
+  border-color: var(--accent);
+  background: var(--accent);
+}

--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@open-design/components';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useAnalytics } from '../analytics/provider';
 import { trackFileManagerClick } from '../analytics/events';
@@ -20,6 +21,7 @@ import { getPluginFolderCandidates } from './design-files/pluginFolders';
 import { Icon } from './Icon';
 import { LiveArtifactBadges } from './LiveArtifactBadges';
 import { isRenderableSketchJson, SketchPreview } from './SketchPreview';
+import styles from './DesignFilesPanel.module.css';
 
 type TranslateFn = (key: keyof Dict, vars?: Record<string, string | number>) => string;
 
@@ -331,6 +333,12 @@ export function DesignFilesPanel({
   const [preview, setPreview] = useState<string | null>(null);
   const autoPreviewAppliedRef = useRef(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [kindFilter, setKindFilter] = useState<Set<ProjectFileKind>>(
+    () => new Set(navState?.kindFilter ?? []),
+  );
+  const [filterMenuOpen, setFilterMenuOpen] = useState(false);
+  const filterMenuRef = useRef<HTMLDivElement | null>(null);
+  const filterPopoverRef = useRef<HTMLDivElement | null>(null);
   const lastKeyPress = useRef<Map<string, number>>(new Map());
   const [deleting, setDeleting] = useState(false);
   const [installingFolder, setInstallingFolder] = useState<string | null>(null);
@@ -351,12 +359,12 @@ export function DesignFilesPanel({
 
   useEffect(() => {
     onNavStateChange?.({
-      kindFilter: navState?.kindFilter ?? new Set(),
+      kindFilter,
       currentDir,
       page: 0,
       pageSize: 30,
     });
-  }, [currentDir, navState?.kindFilter, onNavStateChange]);
+  }, [currentDir, kindFilter, onNavStateChange]);
 
   // Derive immediate subdirectories and files at the current directory level
   // from the flat files list. Files with names like "a/b/c.html" contribute
@@ -391,11 +399,49 @@ export function DesignFilesPanel({
     };
   }, [files, folders, currentDir]);
 
+  const kindCounts = useMemo(() => {
+    const counts = new Map<ProjectFileKind, number>();
+    for (const file of filesAtCurrentDir) {
+      counts.set(file.kind, (counts.get(file.kind) ?? 0) + 1);
+    }
+    return counts;
+  }, [filesAtCurrentDir]);
+
+  const availableKinds = useMemo(
+    () =>
+      Array.from(kindCounts.keys()).sort(
+        (a, b) => SECTION_ORDER.indexOf(a) - SECTION_ORDER.indexOf(b),
+      ),
+    [kindCounts],
+  );
+
+  useEffect(() => {
+    if (availableKinds.length === 0) return;
+    setKindFilter((previous) => {
+      if (previous.size === 0) return previous;
+      const available = new Set(availableKinds);
+      const next = new Set(Array.from(previous).filter((kind) => available.has(kind)));
+      return next.size === previous.size ? previous : next;
+    });
+  }, [availableKinds]);
+
+  const filteredFilesAtCurrentDir = useMemo(() => {
+    if (kindFilter.size === 0) return filesAtCurrentDir;
+    return filesAtCurrentDir.filter((file) => kindFilter.has(file.kind));
+  }, [filesAtCurrentDir, kindFilter]);
+
+  const allVisibleFilesSelected =
+    filteredFilesAtCurrentDir.length > 0 &&
+    filteredFilesAtCurrentDir.every((file) => selected.has(file.name));
+  const someVisibleFilesSelected =
+    !allVisibleFilesSelected &&
+    filteredFilesAtCurrentDir.some((file) => selected.has(file.name));
+
   // Group files at the current level into semantic sections, ordered by
   // SECTION_ORDER. Files within a section sort most-recently-modified first.
   const sections = useMemo(() => {
     const grouped = new Map<FileCategory, ProjectFile[]>();
-    for (const f of filesAtCurrentDir) {
+    for (const f of filteredFilesAtCurrentDir) {
       const category = fileCategory(f);
       const bucket = grouped.get(category) ?? [];
       bucket.push(f);
@@ -407,7 +453,17 @@ export function DesignFilesPanel({
     return SECTION_ORDER.filter((category) => grouped.has(category)).map(
       (category) => [category, grouped.get(category)!] as const,
     );
-  }, [filesAtCurrentDir]);
+  }, [filteredFilesAtCurrentDir]);
+
+  useEffect(() => {
+    if (kindFilter.size === 0) return;
+    setSelected((previous) => {
+      if (previous.size === 0) return previous;
+      const visibleNames = new Set(filteredFilesAtCurrentDir.map((file) => file.name));
+      const next = new Set(Array.from(previous).filter((name) => visibleNames.has(name)));
+      return next.size === previous.size ? previous : next;
+    });
+  }, [filteredFilesAtCurrentDir, kindFilter]);
 
   // Reset selection and renaming state when the user navigates into or out of
   // a directory.
@@ -530,6 +586,50 @@ export function DesignFilesPanel({
       document.removeEventListener('keydown', handleKeyDown);
     };
   }, [projectMenuOpen]);
+
+  useEffect(() => {
+    if (!filterMenuOpen) return;
+    function handlePointerDown(event: PointerEvent) {
+      const target = event.target;
+      if (target instanceof Node && filterMenuRef.current?.contains(target)) return;
+      setFilterMenuOpen(false);
+    }
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setFilterMenuOpen(false);
+    }
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [filterMenuOpen]);
+
+  useEffect(() => {
+    if (filterPopoverRef.current) {
+      filterPopoverRef.current.inert = !filterMenuOpen;
+    }
+  }, [filterMenuOpen]);
+
+  function toggleKindFilter(kind: ProjectFileKind) {
+    setKindFilter((previous) => {
+      const next = new Set(previous);
+      if (next.has(kind)) next.delete(kind);
+      else next.add(kind);
+      return next;
+    });
+  }
+
+  function toggleSelectVisibleFiles() {
+    setSelected((previous) => {
+      const next = new Set(previous);
+      for (const file of filteredFilesAtCurrentDir) {
+        if (allVisibleFilesSelected) next.delete(file.name);
+        else next.add(file.name);
+      }
+      return next;
+    });
+  }
 
   function toggleSelect(name: string) {
     setSelected((prev) => {
@@ -1010,6 +1110,95 @@ export function DesignFilesPanel({
     </nav>
   );
 
+  const kindFilterControl = availableKinds.length > 1 ? (
+    <div className={styles.kindFilter} ref={filterMenuRef}>
+      <Button
+        variant="ghost"
+        className={`${styles.filterTrigger}${
+          kindFilter.size > 0 ? ` ${styles.active}` : ''
+        }`}
+        aria-haspopup="dialog"
+        aria-expanded={filterMenuOpen}
+        aria-label={t('designFiles.filterBy')}
+        onClick={() => setFilterMenuOpen((open) => !open)}
+      >
+        <Icon name="sliders" size={13} />
+        <span className={styles.filterTriggerLabel}>
+          {kindFilter.size === 0
+            ? t('designFiles.filterBy')
+            : kindFilter.size === 1
+              ? kindLabel(Array.from(kindFilter)[0]!, t)
+              : t('designFiles.filterCount', { n: kindFilter.size })}
+        </span>
+        {kindFilter.size > 0 ? (
+          <span className={styles.filterCount} aria-hidden>
+            {kindFilter.size}
+          </span>
+        ) : null}
+      </Button>
+      <div
+        ref={filterPopoverRef}
+        className={`${styles.filterPopover}${filterMenuOpen ? ` ${styles.open}` : ''}`}
+        role="dialog"
+        aria-label={t('designFiles.filterBy')}
+        aria-hidden={!filterMenuOpen}
+      >
+        <div className={styles.filterHeader}>
+          <span>{t('designFiles.filterBy')}</span>
+          {kindFilter.size > 0 ? (
+            <Button
+              variant="ghost"
+              className={styles.filterClear}
+              onClick={() => setKindFilter(new Set())}
+            >
+              {t('designFiles.filterClear')}
+            </Button>
+          ) : null}
+        </div>
+        <ul className={styles.filterList}>
+          {availableKinds.map((kind) => (
+            <li key={kind}>
+              <label className={styles.filterItem}>
+                <input
+                  type="checkbox"
+                  checked={kindFilter.has(kind)}
+                  onChange={() => toggleKindFilter(kind)}
+                />
+                <span className={styles.filterGlyph} aria-hidden>
+                  {kindGlyph(kind)}
+                </span>
+                <span className={styles.filterLabel}>{kindLabel(kind, t)}</span>
+                <span className={styles.filterItemCount}>{kindCounts.get(kind) ?? 0}</span>
+              </label>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  ) : null;
+
+  const selectAllControl = filteredFilesAtCurrentDir.length > 0 ? (
+    <Button
+      variant="ghost"
+      className={`${styles.selectAllToggle}${
+        allVisibleFilesSelected || someVisibleFilesSelected ? ` ${styles.active}` : ''
+      }`}
+      role="checkbox"
+      aria-label={t('designFiles.selectAll')}
+      aria-checked={someVisibleFilesSelected ? 'mixed' : allVisibleFilesSelected}
+      onClick={toggleSelectVisibleFiles}
+    >
+      <span className={styles.selectAllBox} aria-hidden>
+        {allVisibleFilesSelected ? (
+          <Icon name="check" size={12} />
+        ) : someVisibleFilesSelected ? (
+          <Icon name="minus" size={12} />
+        ) : null}
+      </span>
+      <span>{allVisibleFilesSelected ? t('designFiles.clearSelection') : t('designFiles.selectAll')}</span>
+    </Button>
+  ) : null;
+
   const visibleUploadError = uploadError ?? dropReadError;
   const hasSelection = selected.size > 0;
 
@@ -1028,6 +1217,12 @@ export function DesignFilesPanel({
           <div className="df-topbar-left">{breadcrumbs}</div>
           <div className="df-topbar-right">{fileActions}</div>
         </div>
+        {kindFilterControl || selectAllControl ? (
+          <div className={styles.listControls}>
+            {kindFilterControl}
+            {selectAllControl}
+          </div>
+        ) : null}
         <div
           className="df-body"
           onDragEnter={(ev) => {

--- a/apps/web/tests/components/DesignFilesPanel.test.tsx
+++ b/apps/web/tests/components/DesignFilesPanel.test.tsx
@@ -137,15 +137,27 @@ describe("DesignFilesPanel sections", () => {
     vi.useRealTimers();
   });
 
-  it("does not show grouping, sort, filter, or pagination chrome", () => {
+  it("does not show grouping, sort, or pagination chrome", () => {
     renderPanel(generateFiles(60));
 
     expect(screen.queryByRole("group", { name: "Group by" })).toBeNull();
     expect(document.querySelector(".df-table")).toBeNull();
     expect(document.querySelector(".df-th-sortable")).toBeNull();
-    expect(document.querySelector(".df-kind-filter")).toBeNull();
     expect(document.querySelector(".df-pagination")).toBeNull();
     expect(document.querySelector(".df-page-btn")).toBeNull();
+  });
+
+  it("filters the visible export candidates by file kind", () => {
+    renderPanel([
+      file({ name: "page.html", kind: "html", mime: "text/html" }),
+      file({ name: "chart.png", kind: "image", mime: "image/png" }),
+    ]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Filter by kind" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: /^Image/ }));
+
+    expect(screen.getByTestId("design-file-row-chart.png")).toBeTruthy();
+    expect(screen.queryByTestId("design-file-row-page.html")).toBeNull();
   });
 
   it("renders a single-line toolbar with file actions and no up/refresh buttons", () => {
@@ -266,6 +278,63 @@ describe("DesignFilesPanel large list", () => {
 describe("DesignFilesPanel selection", () => {
   afterEach(() => cleanup());
 
+  it("selects and clears every file visible through the active kind filter", () => {
+    const { container } = renderPanel([
+      file({ name: "page.html", kind: "html", mime: "text/html" }),
+      file({ name: "chart.png", kind: "image", mime: "image/png" }),
+      file({ name: "photo.jpg", kind: "image", mime: "image/jpeg" }),
+    ]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Filter by kind" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: /^Image/ }));
+
+    const selectVisible = screen.getByRole("checkbox", {
+      name: "Select everything",
+    });
+    fireEvent.click(selectVisible);
+
+    expect(selectVisible.getAttribute("aria-checked")).toBe("true");
+    expect(
+      Array.from(container.querySelectorAll(".df-file-row.selected")).map(
+        (row) => row.getAttribute("data-testid"),
+      ),
+    ).toEqual([
+      "design-file-row-chart.png",
+      "design-file-row-photo.jpg",
+    ]);
+
+    fireEvent.click(selectVisible);
+    expect(selectVisible.getAttribute("aria-checked")).toBe("false");
+    expect(container.querySelectorAll(".df-file-row.selected")).toHaveLength(0);
+  });
+
+  it("removes hidden selections before a filtered batch action", async () => {
+    const { onDeleteFiles } = renderPanel([
+      file({ name: "page.html", kind: "html", mime: "text/html" }),
+      file({ name: "chart.png", kind: "image", mime: "image/png" }),
+    ]);
+
+    fireEvent.click(
+      screen
+        .getByTestId("design-file-row-page.html")
+        .querySelector(".df-row-check")!,
+    );
+    fireEvent.click(
+      screen
+        .getByTestId("design-file-row-chart.png")
+        .querySelector(".df-row-check")!,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Filter by kind" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: /^Image/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Download 1 as ZIP")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId("design-files-batch-delete"));
+
+    expect(onDeleteFiles).toHaveBeenCalledWith(["chart.png"]);
+  });
+
   it("shows the batch bar and passes every selected file to batch delete", () => {
     const files = generateFiles(3);
     const { container, onDeleteFiles } = renderPanel(files);
@@ -283,6 +352,11 @@ describe("DesignFilesPanel selection", () => {
     expect(
       container.querySelector('[data-testid="design-files-batch-bar"]'),
     ).toBeTruthy();
+    expect(
+      screen
+        .getByRole("checkbox", { name: "Select everything" })
+        .getAttribute("aria-checked"),
+    ).toBe("mixed");
 
     fireEvent.click(
       container.querySelector('[data-testid="design-files-batch-delete"]')!,
@@ -632,6 +706,49 @@ describe("DesignFilesPanel directory navigation", () => {
       "assets",
     );
     expect(screen.getByTestId("design-file-row-assets/logo.png")).toBeTruthy();
+  });
+
+  it("preserves the active kind filter when remounted with navState", async () => {
+    let saved: DesignFilesNavState | undefined;
+    const files = [
+      file({ name: "page.html", kind: "html", mime: "text/html" }),
+      file({ name: "chart.png", kind: "image", mime: "image/png" }),
+    ];
+
+    function makePanel(nav?: DesignFilesNavState) {
+      return (
+        <DesignFilesPanel
+          projectId="test-project"
+          files={files}
+          liveArtifacts={[]}
+          navState={nav}
+          onNavStateChange={(state) => {
+            saved = state;
+          }}
+          onRefreshFiles={vi.fn()}
+          onOpenFile={vi.fn()}
+          onOpenLiveArtifact={vi.fn()}
+          onRenameFile={vi.fn()}
+          onDeleteFile={vi.fn()}
+          onDeleteFiles={vi.fn()}
+          onUpload={vi.fn()}
+          onUploadFiles={vi.fn()}
+          onPaste={vi.fn()}
+          onNewSketch={vi.fn()}
+        />
+      );
+    }
+
+    const { unmount } = render(makePanel());
+    fireEvent.click(screen.getByRole("button", { name: "Filter by kind" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: /^Image/ }));
+    await waitFor(() => expect(saved?.kindFilter.has("image")).toBe(true));
+
+    unmount();
+    render(makePanel(saved));
+
+    expect(screen.getByTestId("design-file-row-chart.png")).toBeTruthy();
+    expect(screen.queryByTestId("design-file-row-page.html")).toBeNull();
   });
 
   it("navigates up one level via the parent breadcrumb", () => {

--- a/e2e/ui/app-design-files.test.ts
+++ b/e2e/ui/app-design-files.test.ts
@@ -794,7 +794,7 @@ test('[P1] design files batch delete removes selected files and keeps cancel ret
     .toBe(true);
 });
 
-test('[P1] design files batch download posts selected names to the archive endpoint', async ({ page }) => {
+test('[P1] design files filters by kind and downloads every visible file', async ({ page }) => {
   await routeMockAgents(page);
 
   await gotoEntryHome(page);
@@ -804,9 +804,9 @@ test('[P1] design files batch download posts selected names to the archive endpo
   await expectWorkspaceReady(page);
 
   const { projectId } = await getCurrentProjectContext(page);
-  let archiveRequest: { files?: string[] } | null = null;
+  const archiveCapture: { request?: { files?: string[] } } = {};
   await page.route(`**/api/projects/${projectId}/archive/batch`, async (route) => {
-    archiveRequest = route.request().postDataJSON() as { files?: string[] };
+    archiveCapture.request = route.request().postDataJSON() as { files?: string[] };
     await route.fulfill({
       status: 200,
       headers: {
@@ -817,26 +817,35 @@ test('[P1] design files batch download posts selected names to the archive endpo
     });
   });
 
-  await seedProjectFile(page, projectId, 'download-alpha.txt', 'alpha');
-  await seedProjectFile(page, projectId, 'download-beta.txt', 'beta');
-  await seedProjectFile(page, projectId, 'download-skip.txt', 'skip');
+  await seedProjectFile(page, projectId, 'download-alpha.png', TINY_PNG_B64, 'base64');
+  await seedProjectFile(page, projectId, 'download-beta.png', TINY_PNG_B64, 'base64');
+  await seedProjectFile(page, projectId, 'download-skip.html', '<!doctype html><p>skip</p>');
   await page.reload();
   await expectWorkspaceReady(page);
   await openAllProjectFiles(page);
 
-  const alpha = page.getByTestId('design-file-row-download-alpha.txt');
-  const beta = page.getByTestId('design-file-row-download-beta.txt');
+  const alpha = page.getByTestId('design-file-row-download-alpha.png');
+  const beta = page.getByTestId('design-file-row-download-beta.png');
   await expect(alpha).toBeVisible();
   await expect(beta).toBeVisible();
-  await alpha.getByRole('checkbox').click();
-  await beta.getByRole('checkbox').click();
+
+  await page.getByRole('button', { name: /filter by kind/i }).click();
+  await page.getByRole('checkbox', { name: /^image/i }).click();
+  await expect(page.getByTestId('design-file-row-download-skip.html')).toHaveCount(0);
+  await page.getByRole('checkbox', { name: /select everything/i }).click();
+  await expect(page.getByTestId('design-files-batch-bar')).toContainText('2');
 
   const downloadPromise = page.waitForEvent('download');
   await page.getByTestId('design-files-batch-bar').getByRole('button', { name: /^Download$/i }).click();
   const download = await downloadPromise;
 
   expect(download.suggestedFilename()).toBe('selected-design-files.zip');
-  expect(archiveRequest).toEqual({ files: ['download-alpha.txt', 'download-beta.txt'] });
+  expect(archiveCapture.request).toBeDefined();
+  const requestedFiles = archiveCapture.request?.files ?? [];
+  expect([...requestedFiles].sort()).toEqual([
+    'download-alpha.png',
+    'download-beta.png',
+  ]);
 });
 
 test('[P0] @critical file workspace restores HTML preview after switching through a source file', async ({ page }) => {


### PR DESCRIPTION
Fixes #4300

## Why

The project-file export workspace lost file-type filtering and bulk selection during its redesign. This surfaced while validating OPEND-234 for teams preparing final project assets for publishing.

Without these controls, larger projects require repetitive manual selection and make it easier to miss required assets. Restoring the prior workflow makes export faster while keeping bulk actions limited to files the user can see.

## What users will see

In **All project files**:

- A **Filter by kind** control lists the file kinds in the current directory with counts.
- A **Select everything / Clear** toggle selects or clears every file visible through the active filter.
- Applying a filter drops selections that become hidden, so download and delete actions never silently include invisible files.
- The active kind filter is restored with the existing file-navigation state.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Restored file-kind filtering and the **Select everything** entry point:

<img width="1280" height="720" alt="File-kind filter and Select everything controls in All project files" src="https://github.com/user-attachments/assets/46c00232-2e55-45e5-8c18-22cf642c0108" />

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/DesignFilesPanel.test.tsx`
- Did the test go red on `main` and green on this branch? **Yes**
- Browser coverage: `e2e/ui/app-design-files.test.ts` filters to images, selects every visible image, downloads the archive, and asserts that the hidden HTML file is excluded.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm guard`
- `corepack pnpm typecheck`
- `corepack pnpm --filter @open-design/web exec vitest run -c vitest.config.ts --maxWorkers=2 tests/components/DesignFilesPanel.test.tsx` — 36 passed
- `corepack pnpm exec playwright test -c playwright.config.ts ui/app-design-files.test.ts --grep "filters by kind and downloads every visible file" --workers=1` — 1 passed