### PR TITLE
fix packaged payload desktop handoff

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -595,6 +595,7 @@ jobs:
           OD_PACKAGED_E2E_BUILD_LOG_PATH: ${{ runner.temp }}/release-build/mac_arm64/build.log
           OD_PACKAGED_E2E_MAC: "1"
           OD_PACKAGED_E2E_MAC_UPDATE_BUILD_JSON_PATH: ${{ steps.mac_arm64_update_fixture.outputs.update_build_json_path }}
+          OD_PACKAGED_E2E_MAC_UPDATE_FIXTURE: ${{ inputs.mac_arm64_smoke_mode == 'full' && inputs.mac_arm64_update_metadata_url == '' && inputs.mac_arm64_update_target_version == '' && 'tools-serve' || '' }}
           OD_PACKAGED_E2E_MAC_UPDATE_METADATA_URL: ${{ inputs.mac_arm64_update_metadata_url }}
           OD_PACKAGED_E2E_MAC_UPDATE_VERSION: ${{ inputs.mac_arm64_update_target_version != '' && inputs.mac_arm64_update_target_version || steps.mac_arm64_update_fixture.outputs.update_version }}
           OD_PACKAGED_E2E_MAC_SMOKE_PROFILE: ${{ inputs.mac_arm64_smoke_mode }}

--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -37,6 +37,7 @@
     "@open-design/agui-adapter": "workspace:*",
     "@open-design/contracts": "workspace:*",
     "@open-design/diagnostics": "workspace:*",
+    "@open-design/launcher-proto": "workspace:*",
     "@open-design/platform": "workspace:*",
     "@open-design/plugin-runtime": "workspace:*",
     "@open-design/registry-protocol": "workspace:*",

--- a/apps/daemon/src/sidecar/index.ts
+++ b/apps/daemon/src/sidecar/index.ts
@@ -3,6 +3,10 @@ import { bootstrapSidecarRuntime } from "@open-design/sidecar";
 import { readProcessStamp } from "@open-design/platform";
 
 import { startDaemonSidecar } from "./server.js";
+import {
+  executeLegacyPayloadDesktopHandoff,
+  prepareLegacyPayloadDesktopHandoff,
+} from "./payload-desktop-handoff.js";
 
 async function main(): Promise<void> {
   const stamp = readProcessStamp(process.argv.slice(2), OPEN_DESIGN_SIDECAR_CONTRACT);
@@ -12,9 +16,29 @@ async function main(): Promise<void> {
     app: APP_KEYS.DAEMON,
     contract: OPEN_DESIGN_SIDECAR_CONTRACT,
   });
+  const desktopHandoff = await prepareLegacyPayloadDesktopHandoff({
+    namespace: runtime.namespace,
+    runtimeRoot: runtime.base,
+    source: runtime.source,
+  }).catch((error: unknown) => {
+    console.warn("[packaged desktop handoff] prepare failed", error);
+    return null;
+  });
   const server = await startDaemonSidecar(runtime);
 
   process.stdout.write(`${JSON.stringify(await server.status(), null, 2)}\n`);
+  if (desktopHandoff?.kind === "none") {
+    console.info("[packaged desktop handoff] skipped", { reason: desktopHandoff.reason });
+  }
+  if (desktopHandoff?.kind === "prepared") {
+    void executeLegacyPayloadDesktopHandoff(desktopHandoff)
+      .then((result) => {
+        console.info("[packaged desktop handoff]", result);
+      })
+      .catch((error: unknown) => {
+        console.warn("[packaged desktop handoff] execute failed", error);
+      });
+  }
   await server.waitUntilStopped();
 }
 

--- a/apps/daemon/src/sidecar/payload-desktop-handoff.ts
+++ b/apps/daemon/src/sidecar/payload-desktop-handoff.ts
@@ -479,10 +479,6 @@ export async function executeLegacyPayloadDesktopHandoff(
     updatedAt: now,
   };
 
-  await writeJsonFile(prepared.launcherPaths.handoffPath, armed);
-  await writeJsonFile(prepared.launcherPaths.attemptsPath, attempt);
-  await writeJsonFile(prepared.launcherPaths.runtimePath, runtime);
-
   const desktopStamp: SidecarStamp = {
     app: APP_KEYS.DESKTOP,
     ipc: desktopIpcPath,
@@ -521,5 +517,18 @@ export async function executeLegacyPayloadDesktopHandoff(
   } catch {
     return { kind: "aborted", reason: "shutdown-failed" };
   }
+
+  // Commit the armed journal and rewritten runtime/attempt state only after both
+  // the payload child has actually spawned and the old desktop has accepted the
+  // shutdown. Writing earlier would strand an "armed" journal on disk when
+  // `spawn()` throws or the shutdown request fails: the next cold start bails out
+  // of prepareLegacyPayloadDesktopHandoff() with reason "already-armed" and the
+  // install stays pinned to the old desktop generation. The old desktop is still
+  // alive while it acks the shutdown, and the payload waits for its pid to exit
+  // before resuming, so these writes still land before the payload reads them.
+  await writeJsonFile(prepared.launcherPaths.handoffPath, armed);
+  await writeJsonFile(prepared.launcherPaths.attemptsPath, attempt);
+  await writeJsonFile(prepared.launcherPaths.runtimePath, runtime);
+
   return { kind: "scheduled", target };
 }

--- a/apps/daemon/src/sidecar/payload-desktop-handoff.ts
+++ b/apps/daemon/src/sidecar/payload-desktop-handoff.ts
@@ -1,0 +1,516 @@
+import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+import { lstat, rm } from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, resolve, sep } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+
+import {
+  LAUNCHER_SCHEMA_VERSION,
+  buildLauncherAfterQuitArgs,
+  buildLauncherHandoffResumeArgs,
+  normalizeLauncherVersion,
+  resolveLauncherPaths,
+  resolveLauncherVersionPaths,
+  validateLauncherAttemptDescriptor,
+  validateLauncherDesktopHandoffDescriptor,
+  validateLauncherRuntimeDescriptor,
+  type LauncherAttemptDescriptor,
+  type LauncherDesktopHandoffDescriptor,
+  type LauncherPaths,
+  type LauncherRuntimeDescriptor,
+  type LauncherVersionPointer,
+} from "@open-design/launcher-proto";
+import { createProcessStampArgs } from "@open-design/platform";
+import { releaseChannelFromNamespace, releaseChannelFromVersion } from "@open-design/release";
+import {
+  readJsonFile,
+  requestJsonIpc,
+  resolveAppIpcPath,
+  writeJsonFile,
+} from "@open-design/sidecar";
+import {
+  APP_KEYS,
+  OPEN_DESIGN_SIDECAR_CONTRACT,
+  SIDECAR_MESSAGES,
+  SIDECAR_MODES,
+  SIDECAR_SOURCES,
+  type DesktopStatusSnapshot,
+  type SidecarSource,
+  type SidecarStamp,
+} from "@open-design/sidecar-proto";
+
+const HANDOFF_CONFIRM_TIMEOUT_MS = 60_000;
+const HANDOFF_POLL_INTERVAL_MS = 100;
+const HANDOFF_PAYLOAD_WAIT_TIMEOUT_MS = 60_000;
+const SIDECAR_ONLY_ENV_KEYS = [
+  "ELECTRON_RUN_AS_NODE",
+  "OD_SIDECAR_BASE",
+  "OD_SIDECAR_IPC_PATH",
+  "OD_SIDECAR_NAMESPACE",
+  "OD_SIDECAR_SOURCE",
+] as const;
+
+type DesktopRootIdentity = {
+  executablePath: string;
+  pid: number;
+  stamp: SidecarStamp;
+  version: number;
+};
+
+type LauncherPayloadManifest = {
+  channel: string;
+  entry: {
+    executable: string;
+  };
+  namespace: string;
+  platform: "darwin" | "win32";
+  schemaVersion: typeof LAUNCHER_SCHEMA_VERSION;
+  version: string;
+};
+
+type LauncherInstallDescriptor = {
+  channel: string;
+  launchPath: string;
+  namespace: string;
+  schemaVersion: typeof LAUNCHER_SCHEMA_VERSION;
+};
+
+export type PreparedLegacyPayloadDesktopHandoff = {
+  descriptor: LauncherDesktopHandoffDescriptor;
+  kind: "prepared";
+  launcherPaths: LauncherPaths;
+  runtimeRoot: string;
+};
+
+export type LegacyPayloadDesktopHandoffPreparation =
+  | PreparedLegacyPayloadDesktopHandoff
+  | {
+      kind: "none";
+      reason:
+        | "already-armed"
+        | "desktop-identity-mismatch"
+        | "invalid-install-anchor"
+        | "invalid-launcher-state"
+        | "invalid-payload"
+        | "invalid-runtime"
+        | "launcher-state-not-eligible"
+        | "missing-environment"
+        | "not-packaged"
+        | "payload-desktop-active"
+        | "unsupported-platform";
+    };
+
+export type LegacyPayloadDesktopHandoffResult =
+  | { kind: "aborted"; reason: "outer-not-confirmed" | "payload-desktop-active" | "shutdown-failed" | "spawn-failed" }
+  | { kind: "scheduled"; target: LauncherVersionPointer };
+
+function samePointer(
+  left: LauncherVersionPointer | null,
+  right: LauncherVersionPointer | null,
+): boolean {
+  return left != null && right != null &&
+    left.generation === right.generation &&
+    left.version === right.version;
+}
+
+function samePath(left: string, right: string, platform: NodeJS.Platform): boolean {
+  const normalizedLeft = resolve(left);
+  const normalizedRight = resolve(right);
+  return platform === "win32"
+    ? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+    : normalizedLeft === normalizedRight;
+}
+
+function containsPath(root: string, target: string): boolean {
+  const normalizedRoot = resolve(root);
+  const normalizedTarget = resolve(target);
+  return normalizedTarget === normalizedRoot || normalizedTarget.startsWith(`${normalizedRoot}${sep}`);
+}
+
+function desktopProcessEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const desktopEnv = { ...env };
+  for (const key of SIDECAR_ONLY_ENV_KEYS) delete desktopEnv[key];
+  return desktopEnv;
+}
+
+async function resolvePayloadExecutable(options: {
+  appVersion: string;
+  launcherPaths: LauncherPaths;
+  namespace: string;
+  platform: NodeJS.Platform;
+}): Promise<string | null> {
+  const versionPaths = resolveLauncherVersionPaths({
+    channel: options.launcherPaths.channel,
+    namespace: options.namespace,
+    root: options.launcherPaths.root,
+    version: options.appVersion,
+  });
+  const manifest = await readJsonFile<LauncherPayloadManifest>(versionPaths.manifestPath);
+  if (
+    manifest == null ||
+    manifest.schemaVersion !== LAUNCHER_SCHEMA_VERSION ||
+    manifest.channel !== options.launcherPaths.channel ||
+    manifest.namespace !== options.namespace ||
+    manifest.version !== options.appVersion ||
+    manifest.platform !== options.platform ||
+    typeof manifest.entry?.executable !== "string"
+  ) return null;
+  const executablePath = resolve(versionPaths.versionRoot, manifest.entry.executable);
+  if (!containsPath(versionPaths.versionRoot, executablePath)) return null;
+  const entry = await lstat(executablePath).catch(() => null);
+  return entry != null && entry.isFile() && !entry.isSymbolicLink()
+    ? executablePath
+    : null;
+}
+
+async function readDesktopIdentity(
+  runtimeRoot: string,
+  namespace: string,
+): Promise<DesktopRootIdentity | null> {
+  const identity = await readJsonFile<DesktopRootIdentity>(join(runtimeRoot, "desktop-root.json"));
+  if (
+    identity == null ||
+    identity.version !== 1 ||
+    !Number.isSafeInteger(identity.pid) ||
+    identity.pid <= 0 ||
+    typeof identity.executablePath !== "string" ||
+    !isAbsolute(identity.executablePath) ||
+    identity.stamp?.app !== APP_KEYS.DESKTOP ||
+    identity.stamp.namespace !== namespace ||
+    identity.stamp.source !== SIDECAR_SOURCES.PACKAGED
+  ) return null;
+  return identity;
+}
+
+async function readRuntime(
+  launcherPaths: LauncherPaths,
+): Promise<LauncherRuntimeDescriptor | null> {
+  const value = await readJsonFile<LauncherRuntimeDescriptor>(launcherPaths.runtimePath);
+  if (value == null) return null;
+  try {
+    return validateLauncherRuntimeDescriptor(value, launcherPaths);
+  } catch {
+    return null;
+  }
+}
+
+async function readAttempt(
+  launcherPaths: LauncherPaths,
+): Promise<LauncherAttemptDescriptor | null> {
+  const value = await readJsonFile<LauncherAttemptDescriptor>(launcherPaths.attemptsPath);
+  if (value == null) return null;
+  try {
+    return validateLauncherAttemptDescriptor(value, launcherPaths);
+  } catch {
+    return null;
+  }
+}
+
+async function resolveInstalledOuterIdentity(options: {
+  launcherPaths: LauncherPaths;
+  parentPid: number;
+  platform: NodeJS.Platform;
+}): Promise<LauncherDesktopHandoffDescriptor["outer"] | null> {
+  if (!Number.isSafeInteger(options.parentPid) || options.parentPid <= 0) return null;
+  const install = await readJsonFile<LauncherInstallDescriptor>(options.launcherPaths.installPath);
+  if (
+    install == null ||
+    install.schemaVersion !== LAUNCHER_SCHEMA_VERSION ||
+    install.channel !== options.launcherPaths.channel ||
+    install.namespace !== options.launcherPaths.namespace ||
+    typeof install.launchPath !== "string" ||
+    !isAbsolute(install.launchPath)
+  ) return null;
+  const executablePath = options.platform === "darwin" && install.launchPath.endsWith(".app")
+    ? join(
+      install.launchPath,
+      "Contents",
+      "MacOS",
+      basename(install.launchPath, ".app"),
+    )
+    : install.launchPath;
+  const entry = await lstat(executablePath).catch(() => null);
+  if (entry == null || !entry.isFile() || entry.isSymbolicLink()) return null;
+  return { executablePath, pid: options.parentPid };
+}
+
+export async function prepareLegacyPayloadDesktopHandoff(options: {
+  env?: NodeJS.ProcessEnv;
+  namespace: string;
+  now?: () => Date;
+  parentPid?: number;
+  platform?: NodeJS.Platform;
+  randomId?: () => string;
+  runtimeRoot: string;
+  source: SidecarSource;
+}): Promise<LegacyPayloadDesktopHandoffPreparation> {
+  if (options.source !== SIDECAR_SOURCES.PACKAGED) {
+    return { kind: "none", reason: "not-packaged" };
+  }
+  const platform = options.platform ?? process.platform;
+  if (platform !== "darwin" && platform !== "win32") {
+    return { kind: "none", reason: "unsupported-platform" };
+  }
+  const env = options.env ?? process.env;
+  const installationRoot = env.OD_INSTALLATION_DIR;
+  const rawAppVersion = env.OD_APP_VERSION;
+  if (
+    installationRoot == null ||
+    !isAbsolute(installationRoot) ||
+    rawAppVersion == null
+  ) return { kind: "none", reason: "missing-environment" };
+
+  let appVersion: string;
+  try {
+    appVersion = normalizeLauncherVersion(rawAppVersion);
+  } catch {
+    return { kind: "none", reason: "invalid-launcher-state" };
+  }
+  const channel = releaseChannelFromVersion(appVersion)
+    ?? releaseChannelFromNamespace(options.namespace, "default")
+    ?? "stable";
+  const launcherPaths = resolveLauncherPaths({
+    channel,
+    namespace: options.namespace,
+    root: installationRoot,
+  });
+  const [runtime, attempt, identity, outer, payloadExecutablePath] = await Promise.all([
+    readRuntime(launcherPaths),
+    readAttempt(launcherPaths),
+    readDesktopIdentity(options.runtimeRoot, options.namespace),
+    resolveInstalledOuterIdentity({
+      launcherPaths,
+      parentPid: options.parentPid ?? process.ppid,
+      platform,
+    }),
+    resolvePayloadExecutable({
+      appVersion,
+      launcherPaths,
+      namespace: options.namespace,
+      platform,
+    }),
+  ]);
+  if (runtime == null) return { kind: "none", reason: "invalid-runtime" };
+  if (outer == null) return { kind: "none", reason: "invalid-install-anchor" };
+  if (payloadExecutablePath == null) return { kind: "none", reason: "invalid-payload" };
+  if (identity != null && samePath(identity.executablePath, payloadExecutablePath, platform)) {
+    return { kind: "none", reason: "payload-desktop-active" };
+  }
+  if (identity != null && (
+    identity.pid !== outer.pid ||
+    !samePath(identity.executablePath, outer.executablePath, platform)
+  )) return { kind: "none", reason: "desktop-identity-mismatch" };
+
+  const existingRaw = await readJsonFile<LauncherDesktopHandoffDescriptor>(launcherPaths.handoffPath);
+  const existing = existingRaw == null
+    ? null
+    : (() => {
+        try {
+          return validateLauncherDesktopHandoffDescriptor(existingRaw, launcherPaths);
+        } catch {
+          return null;
+        }
+      })();
+  if (existing?.state === "armed") return { kind: "none", reason: "already-armed" };
+
+  const initialSource = runtime.active;
+  const initialPrevious = runtime.lastSuccessful;
+  const canCaptureInitialState =
+    initialSource?.version === appVersion &&
+    initialPrevious != null &&
+    !samePointer(initialSource, initialPrevious) &&
+    samePointer(attempt, initialSource);
+  const canCaptureConfirmedBinding =
+    existing?.state === "confirmed" &&
+    existing.target != null &&
+    initialSource?.version === appVersion &&
+    samePointer(existing.source, existing.target) &&
+    samePointer(existing.target, initialSource) &&
+    samePointer(initialPrevious, initialSource) &&
+    samePointer(attempt, initialSource);
+  const canResumePreparedState =
+    existing?.state === "prepared" &&
+    existing.source.version === appVersion &&
+    samePointer(runtime.active, existing.source) &&
+    (
+      samePointer(runtime.lastSuccessful, existing.previous) ||
+      samePointer(runtime.lastSuccessful, existing.source)
+    );
+  if (!canCaptureInitialState && !canCaptureConfirmedBinding && !canResumePreparedState) {
+    return { kind: "none", reason: "launcher-state-not-eligible" };
+  }
+
+  const now = (options.now ?? (() => new Date()))().toISOString();
+  const descriptor: LauncherDesktopHandoffDescriptor = canResumePreparedState && existing != null
+    ? {
+        ...existing,
+        outer,
+        payloadExecutablePath,
+        updatedAt: now,
+      }
+    : {
+        channel,
+        createdAt: now,
+        handoffId: (options.randomId ?? randomUUID)(),
+        namespace: options.namespace,
+        outer,
+        payloadExecutablePath,
+        previous: canCaptureConfirmedBinding && existing != null
+          ? existing.previous
+          : initialPrevious as LauncherVersionPointer,
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+        source: initialSource as LauncherVersionPointer,
+        state: "prepared",
+        updatedAt: now,
+      };
+  await writeJsonFile(launcherPaths.handoffPath, descriptor);
+  return {
+    descriptor,
+    kind: "prepared",
+    launcherPaths,
+    runtimeRoot: options.runtimeRoot,
+  };
+}
+
+async function waitForOuterConfirm(
+  prepared: PreparedLegacyPayloadDesktopHandoff,
+  options: {
+    confirmTimeoutMs: number;
+    requestDesktop: (message: "shutdown" | "status") => Promise<unknown>;
+    sleep: (durationMs: number) => Promise<unknown>;
+  },
+): Promise<"confirmed" | "outer-not-confirmed" | "payload-desktop-active"> {
+  const deadline = Date.now() + options.confirmTimeoutMs;
+  while (Date.now() < deadline) {
+    const [runtime, attempt, identity, status] = await Promise.all([
+      readRuntime(prepared.launcherPaths),
+      readAttempt(prepared.launcherPaths),
+      readDesktopIdentity(prepared.runtimeRoot, prepared.descriptor.namespace),
+      options.requestDesktop("status").catch(() => null) as Promise<DesktopStatusSnapshot | null>,
+    ]);
+    if (
+      identity?.pid === prepared.descriptor.outer.pid &&
+      samePath(identity.executablePath, prepared.descriptor.payloadExecutablePath, process.platform)
+    ) return "payload-desktop-active";
+    if (
+      runtime != null &&
+      attempt == null &&
+      samePointer(runtime.active, prepared.descriptor.source) &&
+      samePointer(runtime.lastSuccessful, prepared.descriptor.source) &&
+      identity?.pid === prepared.descriptor.outer.pid &&
+      samePath(identity.executablePath, prepared.descriptor.outer.executablePath, process.platform) &&
+      status?.state === "running" &&
+      status.pid === prepared.descriptor.outer.pid
+    ) return "confirmed";
+    await options.sleep(HANDOFF_POLL_INTERVAL_MS);
+  }
+  return "outer-not-confirmed";
+}
+
+export async function executeLegacyPayloadDesktopHandoff(
+  prepared: PreparedLegacyPayloadDesktopHandoff,
+  options: {
+    confirmTimeoutMs?: number;
+    env?: NodeJS.ProcessEnv;
+    now?: () => Date;
+    requestDesktop?: (message: "shutdown" | "status") => Promise<unknown>;
+    sleep?: (durationMs: number) => Promise<unknown>;
+    spawn?: typeof spawn;
+  } = {},
+): Promise<LegacyPayloadDesktopHandoffResult> {
+  const desktopIpcPath = resolveAppIpcPath({
+    app: APP_KEYS.DESKTOP,
+    contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+    namespace: prepared.descriptor.namespace,
+  });
+  const requestDesktop = options.requestDesktop ?? (async (message) => await requestJsonIpc(
+    desktopIpcPath,
+    { type: message === "status" ? SIDECAR_MESSAGES.STATUS : SIDECAR_MESSAGES.SHUTDOWN },
+    { timeoutMs: 800 },
+  ));
+  const confirmation = await waitForOuterConfirm(prepared, {
+    confirmTimeoutMs: options.confirmTimeoutMs ?? HANDOFF_CONFIRM_TIMEOUT_MS,
+    requestDesktop,
+    sleep: options.sleep ?? (async (durationMs) => await sleep(durationMs)),
+  });
+  if (confirmation === "payload-desktop-active") {
+    await rm(prepared.launcherPaths.handoffPath, { force: true });
+    return { kind: "aborted", reason: confirmation };
+  }
+  if (confirmation === "outer-not-confirmed") return { kind: "aborted", reason: confirmation };
+
+  const now = (options.now ?? (() => new Date()))().toISOString();
+  const target: LauncherVersionPointer = {
+    generation: Math.max(
+      prepared.descriptor.source.generation,
+      prepared.descriptor.previous.generation,
+    ) + 1,
+    version: prepared.descriptor.source.version,
+  };
+  const armed: LauncherDesktopHandoffDescriptor = {
+    ...prepared.descriptor,
+    state: "armed",
+    target,
+    updatedAt: now,
+  };
+  const attempt: LauncherAttemptDescriptor = {
+    channel: prepared.launcherPaths.channel,
+    generation: target.generation,
+    namespace: prepared.launcherPaths.namespace,
+    schemaVersion: LAUNCHER_SCHEMA_VERSION,
+    startedAt: now,
+    version: target.version,
+  };
+  const runtime: LauncherRuntimeDescriptor = {
+    active: target,
+    channel: prepared.launcherPaths.channel,
+    lastSuccessful: prepared.descriptor.previous,
+    namespace: prepared.launcherPaths.namespace,
+    schemaVersion: LAUNCHER_SCHEMA_VERSION,
+    updatedAt: now,
+  };
+
+  await writeJsonFile(prepared.launcherPaths.handoffPath, armed);
+  await writeJsonFile(prepared.launcherPaths.attemptsPath, attempt);
+  await writeJsonFile(prepared.launcherPaths.runtimePath, runtime);
+
+  const desktopStamp: SidecarStamp = {
+    app: APP_KEYS.DESKTOP,
+    ipc: desktopIpcPath,
+    mode: SIDECAR_MODES.RUNTIME,
+    namespace: prepared.descriptor.namespace,
+    source: SIDECAR_SOURCES.PACKAGED,
+  };
+  const args = [
+    ...buildLauncherAfterQuitArgs({
+      targetPid: prepared.descriptor.outer.pid,
+      timeoutMs: HANDOFF_PAYLOAD_WAIT_TIMEOUT_MS,
+    }),
+    ...buildLauncherHandoffResumeArgs({ handoffId: prepared.descriptor.handoffId }),
+    ...createProcessStampArgs(desktopStamp, OPEN_DESIGN_SIDECAR_CONTRACT),
+  ];
+  let child: ReturnType<typeof spawn>;
+  try {
+    child = (options.spawn ?? spawn)(prepared.descriptor.payloadExecutablePath, args, {
+      cwd: dirname(prepared.descriptor.payloadExecutablePath),
+      detached: true,
+      env: desktopProcessEnv(options.env ?? process.env),
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    await new Promise<void>((resolveSpawn, rejectSpawn) => {
+      child.once("spawn", () => resolveSpawn());
+      child.once("error", rejectSpawn);
+    });
+    child.unref();
+  } catch {
+    return { kind: "aborted", reason: "spawn-failed" };
+  }
+
+  try {
+    await requestDesktop("shutdown");
+  } catch {
+    return { kind: "aborted", reason: "shutdown-failed" };
+  }
+  return { kind: "scheduled", target };
+}

--- a/apps/daemon/src/sidecar/payload-desktop-handoff.ts
+++ b/apps/daemon/src/sidecar/payload-desktop-handoff.ts
@@ -42,6 +42,7 @@ import {
 const HANDOFF_CONFIRM_TIMEOUT_MS = 60_000;
 const HANDOFF_POLL_INTERVAL_MS = 100;
 const HANDOFF_PAYLOAD_WAIT_TIMEOUT_MS = 60_000;
+const PACKAGED_NAMESPACE_BASE_ROOT_ENV = "OD_PACKAGED_NAMESPACE_BASE_ROOT";
 const SIDECAR_ONLY_ENV_KEYS = [
   "ELECTRON_RUN_AS_NODE",
   "OD_SIDECAR_BASE",
@@ -127,8 +128,11 @@ function containsPath(root: string, target: string): boolean {
   return normalizedTarget === normalizedRoot || normalizedTarget.startsWith(`${normalizedRoot}${sep}`);
 }
 
-function desktopProcessEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  const desktopEnv = { ...env };
+function desktopProcessEnv(env: NodeJS.ProcessEnv, runtimeRoot: string): NodeJS.ProcessEnv {
+  const desktopEnv: NodeJS.ProcessEnv = {
+    ...env,
+    [PACKAGED_NAMESPACE_BASE_ROOT_ENV]: dirname(dirname(runtimeRoot)),
+  };
   for (const key of SIDECAR_ONLY_ENV_KEYS) delete desktopEnv[key];
   return desktopEnv;
 }
@@ -177,7 +181,10 @@ async function readDesktopIdentity(
     !isAbsolute(identity.executablePath) ||
     identity.stamp?.app !== APP_KEYS.DESKTOP ||
     identity.stamp.namespace !== namespace ||
-    identity.stamp.source !== SIDECAR_SOURCES.PACKAGED
+    (
+      identity.stamp.source !== SIDECAR_SOURCES.PACKAGED &&
+      identity.stamp.source !== SIDECAR_SOURCES.TOOLS_PACK
+    )
   ) return null;
   return identity;
 }
@@ -244,7 +251,10 @@ export async function prepareLegacyPayloadDesktopHandoff(options: {
   runtimeRoot: string;
   source: SidecarSource;
 }): Promise<LegacyPayloadDesktopHandoffPreparation> {
-  if (options.source !== SIDECAR_SOURCES.PACKAGED) {
+  if (
+    options.source !== SIDECAR_SOURCES.PACKAGED &&
+    options.source !== SIDECAR_SOURCES.TOOLS_PACK
+  ) {
     return { kind: "none", reason: "not-packaged" };
   }
   const platform = options.platform ?? process.platform;
@@ -326,8 +336,7 @@ export async function prepareLegacyPayloadDesktopHandoff(options: {
     initialSource?.version === appVersion &&
     samePointer(existing.source, existing.target) &&
     samePointer(existing.target, initialSource) &&
-    samePointer(initialPrevious, initialSource) &&
-    samePointer(attempt, initialSource);
+    samePointer(initialPrevious, initialSource);
   const canResumePreparedState =
     existing?.state === "prepared" &&
     existing.source.version === appVersion &&
@@ -494,7 +503,7 @@ export async function executeLegacyPayloadDesktopHandoff(
     child = (options.spawn ?? spawn)(prepared.descriptor.payloadExecutablePath, args, {
       cwd: dirname(prepared.descriptor.payloadExecutablePath),
       detached: true,
-      env: desktopProcessEnv(options.env ?? process.env),
+      env: desktopProcessEnv(options.env ?? process.env, prepared.runtimeRoot),
       stdio: "ignore",
       windowsHide: true,
     });

--- a/apps/daemon/tests/sidecar/payload-desktop-handoff.test.ts
+++ b/apps/daemon/tests/sidecar/payload-desktop-handoff.test.ts
@@ -261,6 +261,207 @@ describe("legacy payload desktop handoff", () => {
     }
   });
 
+  async function armedHandoffFixture(): Promise<{
+    launcherPaths: ReturnType<typeof resolveLauncherPaths>;
+    prepared: Extract<
+      Awaited<ReturnType<typeof prepareLegacyPayloadDesktopHandoff>>,
+      { kind: "prepared" }
+    >;
+    root: string;
+  }> {
+    const root = await mkdtemp(join(tmpdir(), "od-daemon-payload-handoff-fail-"));
+    const namespace = "release-beta";
+    const runtimeRoot = join(root, "namespaces", namespace, "runtime");
+    const launcherPaths = resolveLauncherPaths({ channel: "beta", namespace, root });
+    const versionPaths = resolveLauncherVersionPaths({
+      channel: "beta",
+      namespace,
+      root,
+      version: "1.2.3-beta.5",
+    });
+    const outerExecutablePath = join(root, "installed", "Open Design Beta.app", "Contents", "MacOS", "Open Design Beta");
+    const payloadExecutablePath = join(
+      versionPaths.payloadRoot,
+      "Open Design Beta.app",
+      "Contents",
+      "MacOS",
+      "Open Design Beta",
+    );
+    await mkdir(join(payloadExecutablePath, ".."), { recursive: true });
+    await mkdir(join(outerExecutablePath, ".."), { recursive: true });
+    await mkdir(runtimeRoot, { recursive: true });
+    await mkdir(launcherPaths.stateRoot, { recursive: true });
+    await writeFile(payloadExecutablePath, "");
+    await writeFile(outerExecutablePath, "");
+    await writeFile(versionPaths.manifestPath, `${JSON.stringify({
+      channel: "beta",
+      entry: {
+        cwd: "payload/Open Design Beta.app",
+        executable: "payload/Open Design Beta.app/Contents/MacOS/Open Design Beta",
+      },
+      namespace,
+      payloadRoot: "payload",
+      platform: "darwin",
+      schemaVersion: LAUNCHER_SCHEMA_VERSION,
+      version: "1.2.3-beta.5",
+    })}\n`);
+    await writeFile(launcherPaths.runtimePath, `${JSON.stringify({
+      active: { generation: 1, version: "1.2.3-beta.5" },
+      channel: "beta",
+      lastSuccessful: { generation: 0, version: "1.2.3-beta.4" },
+      namespace,
+      schemaVersion: LAUNCHER_SCHEMA_VERSION,
+    })}\n`);
+    await writeFile(launcherPaths.attemptsPath, `${JSON.stringify({
+      channel: "beta",
+      generation: 1,
+      namespace,
+      schemaVersion: LAUNCHER_SCHEMA_VERSION,
+      version: "1.2.3-beta.5",
+    })}\n`);
+    await writeFile(launcherPaths.installPath, `${JSON.stringify({
+      channel: "beta",
+      launchPath: join(root, "installed", "Open Design Beta.app"),
+      namespace,
+      schemaVersion: LAUNCHER_SCHEMA_VERSION,
+    })}\n`);
+
+    const prepared = await prepareLegacyPayloadDesktopHandoff({
+      env: {
+        OD_APP_VERSION: "1.2.3-beta.5",
+        OD_INSTALLATION_DIR: root,
+      },
+      namespace,
+      parentPid: 4321,
+      platform: "darwin",
+      randomId: () => "f5d4a712-8ba9-4c28-bcad-6dbed5db2d7c",
+      runtimeRoot,
+      source: SIDECAR_SOURCES.PACKAGED,
+    });
+    if (prepared.kind !== "prepared") throw new Error("expected prepared handoff");
+
+    // Simulate the old outer confirming: the launcher promoted lastSuccessful to
+    // the payload source and cleared the pending attempt.
+    await writeFile(join(runtimeRoot, "desktop-root.json"), `${JSON.stringify({
+      executablePath: outerExecutablePath,
+      pid: 4321,
+      stamp: {
+        app: APP_KEYS.DESKTOP,
+        ipc: "/tmp/open-design/ipc/release-beta/desktop.sock",
+        mode: "runtime",
+        namespace,
+        source: SIDECAR_SOURCES.PACKAGED,
+      },
+      version: 1,
+    })}\n`);
+    await writeFile(launcherPaths.runtimePath, `${JSON.stringify({
+      active: { generation: 1, version: "1.2.3-beta.5" },
+      channel: "beta",
+      lastSuccessful: { generation: 1, version: "1.2.3-beta.5" },
+      namespace,
+      schemaVersion: LAUNCHER_SCHEMA_VERSION,
+    })}\n`);
+    await rm(launcherPaths.attemptsPath, { force: true });
+
+    return { launcherPaths, prepared, root };
+  }
+
+  it("does not strand launcher state when the payload desktop spawn fails", async () => {
+    const { launcherPaths, prepared, root } = await armedHandoffFixture();
+    try {
+      const spawn = vi.fn(() => {
+        throw new Error("spawn ENOENT");
+      });
+      const requestDesktop = vi.fn(async (message: "shutdown" | "status") => (
+        message === "status"
+          ? { pid: 4321, state: "running" }
+          : { accepted: true }
+      ));
+
+      const result = await executeLegacyPayloadDesktopHandoff(prepared, {
+        confirmTimeoutMs: 100,
+        env: { PATH: "/usr/bin" },
+        now: () => new Date("2026-07-15T02:00:00.000Z"),
+        requestDesktop,
+        sleep: async () => undefined,
+        spawn: spawn as never,
+      });
+
+      expect(result).toEqual({ kind: "aborted", reason: "spawn-failed" });
+      // The shutdown must not have been requested, and no armed journal / runtime
+      // rewrite may remain on disk to block the next cold-start retry.
+      expect(requestDesktop).not.toHaveBeenCalledWith("shutdown");
+      expect(JSON.parse(await readFile(launcherPaths.handoffPath, "utf8"))).toMatchObject({
+        state: "prepared",
+      });
+      expect(JSON.parse(await readFile(launcherPaths.handoffPath, "utf8"))).not.toHaveProperty("target");
+      expect(JSON.parse(await readFile(launcherPaths.runtimePath, "utf8"))).toMatchObject({
+        active: { generation: 1, version: "1.2.3-beta.5" },
+      });
+      await expect(readFile(launcherPaths.attemptsPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("does not strand launcher state when the old desktop shutdown fails", async () => {
+    const { launcherPaths, prepared, root } = await armedHandoffFixture();
+    try {
+      const child = {
+        once: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
+          if (event === "spawn") queueMicrotask(callback);
+          return child;
+        }),
+        unref: vi.fn(),
+      };
+      const spawn = vi.fn(() => child);
+      const requestDesktop = vi.fn(async (message: "shutdown" | "status") => {
+        if (message === "shutdown") throw new Error("desktop ipc gone");
+        return { pid: 4321, state: "running" };
+      });
+
+      const result = await executeLegacyPayloadDesktopHandoff(prepared, {
+        confirmTimeoutMs: 100,
+        env: { PATH: "/usr/bin" },
+        now: () => new Date("2026-07-15T02:00:00.000Z"),
+        requestDesktop,
+        sleep: async () => undefined,
+        spawn: spawn as never,
+      });
+
+      expect(result).toEqual({ kind: "aborted", reason: "shutdown-failed" });
+      expect(spawn).toHaveBeenCalledOnce();
+      // Even though the payload child already spawned, the failed shutdown must
+      // leave the journal at "prepared" so a later cold start can retry instead
+      // of bailing on "already-armed".
+      expect(JSON.parse(await readFile(launcherPaths.handoffPath, "utf8"))).toMatchObject({
+        state: "prepared",
+      });
+      expect(JSON.parse(await readFile(launcherPaths.handoffPath, "utf8"))).not.toHaveProperty("target");
+      expect(JSON.parse(await readFile(launcherPaths.runtimePath, "utf8"))).toMatchObject({
+        active: { generation: 1, version: "1.2.3-beta.5" },
+      });
+      await expect(readFile(launcherPaths.attemptsPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+
+      // A subsequent cold start resumes the prepared handoff rather than reporting
+      // "already-armed".
+      const retry = await prepareLegacyPayloadDesktopHandoff({
+        env: {
+          OD_APP_VERSION: "1.2.3-beta.5",
+          OD_INSTALLATION_DIR: root,
+        },
+        namespace: prepared.descriptor.namespace,
+        parentPid: 4321,
+        platform: "darwin",
+        runtimeRoot: prepared.runtimeRoot,
+        source: SIDECAR_SOURCES.PACKAGED,
+      });
+      expect(retry.kind).toBe("prepared");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
   it("does nothing outside the packaged desktop runtime", async () => {
     await expect(prepareLegacyPayloadDesktopHandoff({
       env: {},

--- a/apps/daemon/tests/sidecar/payload-desktop-handoff.test.ts
+++ b/apps/daemon/tests/sidecar/payload-desktop-handoff.test.ts
@@ -1,0 +1,352 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  LAUNCHER_SCHEMA_VERSION,
+  parseLauncherAfterQuitArgs,
+  parseLauncherHandoffResumeArgs,
+  resolveLauncherPaths,
+  resolveLauncherVersionPaths,
+} from "@open-design/launcher-proto";
+import { readProcessStamp } from "@open-design/platform";
+import {
+  APP_KEYS,
+  OPEN_DESIGN_SIDECAR_CONTRACT,
+  SIDECAR_SOURCES,
+} from "@open-design/sidecar-proto";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  executeLegacyPayloadDesktopHandoff,
+  prepareLegacyPayloadDesktopHandoff,
+} from "../../src/sidecar/payload-desktop-handoff.js";
+
+describe("legacy payload desktop handoff", () => {
+  it("captures the real previous pointer before old outer confirm, then arms and launches payload desktop", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-daemon-payload-handoff-"));
+    try {
+      const namespace = "release-beta";
+      const runtimeRoot = join(root, "namespaces", namespace, "runtime");
+      const launcherPaths = resolveLauncherPaths({ channel: "beta", namespace, root });
+      const versionPaths = resolveLauncherVersionPaths({
+        channel: "beta",
+        namespace,
+        root,
+        version: "1.2.3-beta.5",
+      });
+      const outerExecutablePath = join(root, "installed", "Open Design Beta.app", "Contents", "MacOS", "Open Design Beta");
+      const payloadExecutablePath = join(
+        versionPaths.payloadRoot,
+        "Open Design Beta.app",
+        "Contents",
+        "MacOS",
+        "Open Design Beta",
+      );
+      await mkdir(join(payloadExecutablePath, ".."), { recursive: true });
+      await mkdir(join(outerExecutablePath, ".."), { recursive: true });
+      await mkdir(runtimeRoot, { recursive: true });
+      await mkdir(launcherPaths.stateRoot, { recursive: true });
+      await writeFile(payloadExecutablePath, "");
+      await writeFile(outerExecutablePath, "");
+      await writeFile(versionPaths.manifestPath, `${JSON.stringify({
+        channel: "beta",
+        entry: {
+          cwd: "payload/Open Design Beta.app",
+          executable: "payload/Open Design Beta.app/Contents/MacOS/Open Design Beta",
+        },
+        namespace,
+        payloadRoot: "payload",
+        platform: "darwin",
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+        version: "1.2.3-beta.5",
+      })}\n`);
+      await writeFile(launcherPaths.runtimePath, `${JSON.stringify({
+        active: { generation: 1, version: "1.2.3-beta.5" },
+        channel: "beta",
+        lastSuccessful: { generation: 0, version: "1.2.3-beta.4" },
+        namespace,
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+      })}\n`);
+      await writeFile(launcherPaths.attemptsPath, `${JSON.stringify({
+        channel: "beta",
+        generation: 1,
+        namespace,
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+        version: "1.2.3-beta.5",
+      })}\n`);
+      await writeFile(launcherPaths.installPath, `${JSON.stringify({
+        channel: "beta",
+        launchPath: join(root, "installed", "Open Design Beta.app"),
+        namespace,
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+      })}\n`);
+
+      const prepared = await prepareLegacyPayloadDesktopHandoff({
+        env: {
+          OD_APP_VERSION: "1.2.3-beta.5",
+          OD_INSTALLATION_DIR: root,
+        },
+        namespace,
+        parentPid: 4321,
+        platform: "darwin",
+        randomId: () => "f5d4a712-8ba9-4c28-bcad-6dbed5db2d7c",
+        runtimeRoot,
+        source: SIDECAR_SOURCES.PACKAGED,
+      });
+
+      expect(prepared.kind).toBe("prepared");
+      expect(JSON.parse(await readFile(launcherPaths.handoffPath, "utf8"))).toMatchObject({
+        previous: { generation: 0, version: "1.2.3-beta.4" },
+        source: { generation: 1, version: "1.2.3-beta.5" },
+        state: "prepared",
+      });
+
+      await writeFile(join(runtimeRoot, "desktop-root.json"), `${JSON.stringify({
+        executablePath: outerExecutablePath,
+        pid: 4321,
+        stamp: {
+          app: APP_KEYS.DESKTOP,
+          ipc: "/tmp/open-design/ipc/release-beta/desktop.sock",
+          mode: "runtime",
+          namespace,
+          source: SIDECAR_SOURCES.PACKAGED,
+        },
+        version: 1,
+      })}\n`);
+
+      await writeFile(launcherPaths.runtimePath, `${JSON.stringify({
+        active: { generation: 1, version: "1.2.3-beta.5" },
+        channel: "beta",
+        lastSuccessful: { generation: 1, version: "1.2.3-beta.5" },
+        namespace,
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+      })}\n`);
+      await rm(launcherPaths.attemptsPath, { force: true });
+
+      const child = {
+        once: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
+          if (event === "spawn") queueMicrotask(callback);
+          return child;
+        }),
+        unref: vi.fn(),
+      };
+      let launchedArgs: string[] = [];
+      let launchedEnv: NodeJS.ProcessEnv | undefined;
+      const spawn = vi.fn((_command: string, args: string[], options: { env?: NodeJS.ProcessEnv }) => {
+        launchedArgs = args;
+        launchedEnv = options.env;
+        return child;
+      });
+      const requestDesktop = vi.fn(async (message: "shutdown" | "status") => (
+        message === "status"
+          ? { pid: 4321, state: "running" }
+          : { accepted: true }
+      ));
+      if (prepared.kind !== "prepared") throw new Error("expected prepared handoff");
+      const result = await executeLegacyPayloadDesktopHandoff(prepared, {
+        confirmTimeoutMs: 100,
+        env: {
+          ELECTRON_RUN_AS_NODE: "1",
+          OD_SIDECAR_BASE: runtimeRoot,
+          PATH: "/usr/bin",
+        },
+        now: () => new Date("2026-07-15T02:00:00.000Z"),
+        requestDesktop,
+        sleep: async () => undefined,
+        spawn: spawn as never,
+      });
+
+      expect(result).toMatchObject({
+        kind: "scheduled",
+        target: { generation: 2, version: "1.2.3-beta.5" },
+      });
+      expect(JSON.parse(await readFile(launcherPaths.runtimePath, "utf8"))).toMatchObject({
+        active: { generation: 2, version: "1.2.3-beta.5" },
+        lastSuccessful: { generation: 0, version: "1.2.3-beta.4" },
+      });
+      expect(JSON.parse(await readFile(launcherPaths.attemptsPath, "utf8"))).toMatchObject({
+        generation: 2,
+        version: "1.2.3-beta.5",
+      });
+      expect(JSON.parse(await readFile(launcherPaths.handoffPath, "utf8"))).toMatchObject({
+        state: "armed",
+        target: { generation: 2, version: "1.2.3-beta.5" },
+      });
+      expect(spawn).toHaveBeenCalledOnce();
+      expect(launchedEnv).not.toHaveProperty("ELECTRON_RUN_AS_NODE");
+      expect(launchedEnv).not.toHaveProperty("OD_SIDECAR_BASE");
+      expect(launchedEnv).toMatchObject({ PATH: "/usr/bin" });
+      expect(parseLauncherAfterQuitArgs(launchedArgs)).toEqual({ targetPid: 4321, timeoutMs: 60_000 });
+      expect(parseLauncherHandoffResumeArgs(launchedArgs)).toEqual({
+        handoffId: "f5d4a712-8ba9-4c28-bcad-6dbed5db2d7c",
+      });
+      expect(readProcessStamp(launchedArgs, OPEN_DESIGN_SIDECAR_CONTRACT)).toMatchObject({
+        app: APP_KEYS.DESKTOP,
+        namespace,
+        source: SIDECAR_SOURCES.PACKAGED,
+      });
+      expect(requestDesktop).toHaveBeenLastCalledWith("shutdown");
+
+      await writeFile(launcherPaths.runtimePath, `${JSON.stringify({
+        active: { generation: 2, version: "1.2.3-beta.5" },
+        channel: "beta",
+        lastSuccessful: { generation: 2, version: "1.2.3-beta.5" },
+        namespace,
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+      })}\n`);
+      await writeFile(launcherPaths.attemptsPath, `${JSON.stringify({
+        channel: "beta",
+        generation: 2,
+        namespace,
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+        version: "1.2.3-beta.5",
+      })}\n`);
+      await writeFile(launcherPaths.handoffPath, `${JSON.stringify({
+        ...JSON.parse(await readFile(launcherPaths.handoffPath, "utf8")),
+        source: { generation: 2, version: "1.2.3-beta.5" },
+        state: "confirmed",
+        target: { generation: 2, version: "1.2.3-beta.5" },
+      })}\n`);
+
+      const coldStart = await prepareLegacyPayloadDesktopHandoff({
+        env: {
+          OD_APP_VERSION: "1.2.3-beta.5",
+          OD_INSTALLATION_DIR: root,
+        },
+        namespace,
+        now: () => new Date("2026-07-15T03:00:00.000Z"),
+        parentPid: 4321,
+        platform: "darwin",
+        randomId: () => "e7e48cc4-7334-4d99-ab8e-830b2360dff0",
+        runtimeRoot,
+        source: SIDECAR_SOURCES.PACKAGED,
+      });
+
+      expect(coldStart).toMatchObject({
+        descriptor: {
+          handoffId: "e7e48cc4-7334-4d99-ab8e-830b2360dff0",
+          previous: { generation: 0, version: "1.2.3-beta.4" },
+          source: { generation: 2, version: "1.2.3-beta.5" },
+          state: "prepared",
+        },
+        kind: "prepared",
+      });
+      if (coldStart.kind !== "prepared") throw new Error("expected cold-start handoff");
+      expect(coldStart.descriptor).not.toHaveProperty("target");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("does nothing outside the packaged desktop runtime", async () => {
+    await expect(prepareLegacyPayloadDesktopHandoff({
+      env: {},
+      namespace: "default",
+      platform: "darwin",
+      runtimeRoot: "/tmp/open-design/runtime",
+      source: SIDECAR_SOURCES.TOOLS_DEV,
+    })).resolves.toEqual({ kind: "none", reason: "not-packaged" });
+  });
+
+  it("resolves the installed outer and payload executable for the real Windows beta namespace", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-daemon-win-payload-handoff-"));
+    try {
+      const namespace = "release-beta-win";
+      const version = "1.2.3-beta.5";
+      const runtimeRoot = join(root, "namespaces", namespace, "runtime");
+      const launcherPaths = resolveLauncherPaths({ channel: "beta", namespace, root });
+      const versionPaths = resolveLauncherVersionPaths({
+        channel: "beta",
+        namespace,
+        root,
+        version,
+      });
+      const outerExecutablePath = join(root, "installed", "Open Design Beta.exe");
+      const payloadExecutablePath = join(versionPaths.payloadRoot, "Open Design Beta.exe");
+      await mkdir(join(root, "installed"), { recursive: true });
+      await mkdir(versionPaths.payloadRoot, { recursive: true });
+      await mkdir(runtimeRoot, { recursive: true });
+      await mkdir(launcherPaths.stateRoot, { recursive: true });
+      await writeFile(outerExecutablePath, "");
+      await writeFile(payloadExecutablePath, "");
+      await writeFile(versionPaths.manifestPath, `${JSON.stringify({
+        channel: "beta",
+        entry: {
+          cwd: "payload",
+          executable: "payload/Open Design Beta.exe",
+        },
+        namespace,
+        payloadRoot: "payload",
+        platform: "win32",
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+        version,
+      })}\n`);
+      await writeFile(launcherPaths.runtimePath, `${JSON.stringify({
+        active: { generation: 1, version },
+        channel: "beta",
+        lastSuccessful: { generation: 0, version: "1.2.3-beta.4" },
+        namespace,
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+      })}\n`);
+      await writeFile(launcherPaths.attemptsPath, `${JSON.stringify({
+        channel: "beta",
+        generation: 1,
+        namespace,
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+        version,
+      })}\n`);
+      await writeFile(launcherPaths.installPath, `${JSON.stringify({
+        channel: "beta",
+        launchPath: outerExecutablePath,
+        namespace,
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+      })}\n`);
+
+      const prepared = await prepareLegacyPayloadDesktopHandoff({
+        env: {
+          OD_APP_VERSION: version,
+          OD_INSTALLATION_DIR: root,
+        },
+        namespace,
+        parentPid: 9876,
+        platform: "win32",
+        randomId: () => "4c5ca585-c7a1-4b9a-b725-495d72a5f97b",
+        runtimeRoot,
+        source: SIDECAR_SOURCES.PACKAGED,
+      });
+
+      expect(prepared).toMatchObject({
+        descriptor: {
+          outer: { executablePath: outerExecutablePath, pid: 9876 },
+          payloadExecutablePath,
+          previous: { generation: 0, version: "1.2.3-beta.4" },
+          source: { generation: 1, version },
+          state: "prepared",
+        },
+        kind: "prepared",
+      });
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("uses the stable channel for an unlabelled version and custom namespace", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-daemon-stable-handoff-"));
+    try {
+      await expect(prepareLegacyPayloadDesktopHandoff({
+        env: {
+          OD_APP_VERSION: "1.2.3",
+          OD_INSTALLATION_DIR: root,
+        },
+        namespace: "custom-stable-namespace",
+        parentPid: 4321,
+        platform: "darwin",
+        runtimeRoot: join(root, "runtime"),
+        source: SIDECAR_SOURCES.PACKAGED,
+      })).resolves.toEqual({ kind: "none", reason: "invalid-runtime" });
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/apps/daemon/tests/sidecar/payload-desktop-handoff.test.ts
+++ b/apps/daemon/tests/sidecar/payload-desktop-handoff.test.ts
@@ -176,7 +176,10 @@ describe("legacy payload desktop handoff", () => {
       expect(spawn).toHaveBeenCalledOnce();
       expect(launchedEnv).not.toHaveProperty("ELECTRON_RUN_AS_NODE");
       expect(launchedEnv).not.toHaveProperty("OD_SIDECAR_BASE");
-      expect(launchedEnv).toMatchObject({ PATH: "/usr/bin" });
+      expect(launchedEnv).toMatchObject({
+        OD_PACKAGED_NAMESPACE_BASE_ROOT: join(root, "namespaces"),
+        PATH: "/usr/bin",
+      });
       expect(parseLauncherAfterQuitArgs(launchedArgs)).toEqual({ targetPid: 4321, timeoutMs: 60_000 });
       expect(parseLauncherHandoffResumeArgs(launchedArgs)).toEqual({
         handoffId: "f5d4a712-8ba9-4c28-bcad-6dbed5db2d7c",
@@ -195,18 +198,24 @@ describe("legacy payload desktop handoff", () => {
         namespace,
         schemaVersion: LAUNCHER_SCHEMA_VERSION,
       })}\n`);
-      await writeFile(launcherPaths.attemptsPath, `${JSON.stringify({
-        channel: "beta",
-        generation: 2,
-        namespace,
-        schemaVersion: LAUNCHER_SCHEMA_VERSION,
-        version: "1.2.3-beta.5",
-      })}\n`);
+      await rm(launcherPaths.attemptsPath, { force: true });
       await writeFile(launcherPaths.handoffPath, `${JSON.stringify({
         ...JSON.parse(await readFile(launcherPaths.handoffPath, "utf8")),
         source: { generation: 2, version: "1.2.3-beta.5" },
         state: "confirmed",
         target: { generation: 2, version: "1.2.3-beta.5" },
+      })}\n`);
+      await writeFile(join(runtimeRoot, "desktop-root.json"), `${JSON.stringify({
+        executablePath: outerExecutablePath,
+        pid: 4321,
+        stamp: {
+          app: APP_KEYS.DESKTOP,
+          ipc: "/tmp/open-design/ipc/release-beta/desktop.sock",
+          mode: "runtime",
+          namespace,
+          source: SIDECAR_SOURCES.TOOLS_PACK,
+        },
+        version: 1,
       })}\n`);
 
       const coldStart = await prepareLegacyPayloadDesktopHandoff({
@@ -220,7 +229,7 @@ describe("legacy payload desktop handoff", () => {
         platform: "darwin",
         randomId: () => "e7e48cc4-7334-4d99-ab8e-830b2360dff0",
         runtimeRoot,
-        source: SIDECAR_SOURCES.PACKAGED,
+        source: SIDECAR_SOURCES.TOOLS_PACK,
       });
 
       expect(coldStart).toMatchObject({
@@ -234,6 +243,19 @@ describe("legacy payload desktop handoff", () => {
       });
       if (coldStart.kind !== "prepared") throw new Error("expected cold-start handoff");
       expect(coldStart.descriptor).not.toHaveProperty("target");
+      spawn.mockClear();
+      await expect(executeLegacyPayloadDesktopHandoff(coldStart, {
+        confirmTimeoutMs: 100,
+        env: { PATH: "/usr/bin" },
+        now: () => new Date("2026-07-15T03:00:01.000Z"),
+        requestDesktop,
+        sleep: async () => undefined,
+        spawn: spawn as never,
+      })).resolves.toMatchObject({
+        kind: "scheduled",
+        target: { generation: 3, version: "1.2.3-beta.5" },
+      });
+      expect(spawn).toHaveBeenCalledOnce();
     } finally {
       await rm(root, { force: true, recursive: true });
     }

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -180,7 +180,7 @@ export type LauncherPayloadExtractInput = {
 };
 
 type DesktopUpdaterLogger = Pick<Console, "error" | "warn"> & Partial<Pick<Console, "info">>;
-type DetachedProcess = { unref(): void };
+type DetachedProcess = Pick<ReturnType<typeof spawn>, "once" | "unref">;
 type LauncherPayloadCleanupTrigger = "activate" | "prepare-existing" | "prepare-promoted";
 type LauncherPayloadCleanupFailure = {
   error: NonNullable<LauncherCleanupEntry["error"]>;
@@ -1866,6 +1866,10 @@ async function launchPayloadAppAfterQuit(
       buildLauncherAfterQuitArgs({ targetPid: input.appPid, timeoutMs: input.timeoutMs }),
       { detached: true, stdio: "ignore", windowsHide: true },
     );
+    await new Promise<void>((resolveSpawn, rejectSpawn) => {
+      child.once("spawn", () => resolveSpawn());
+      child.once("error", rejectSpawn);
+    });
     child.unref();
     return {};
   } catch (error) {

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -31,10 +31,12 @@ import {
   compareLauncherVersions,
   resolveLauncherPaths,
   resolveLauncherVersionPaths,
+  validateLauncherAttemptDescriptor,
   validateLauncherCleanupDescriptor,
   validateLauncherRuntimeDescriptor,
   type LauncherCleanupDescriptor,
   type LauncherCleanupEntry,
+  type LauncherAttemptDescriptor,
   type LauncherRuntimeDescriptor,
 } from "@open-design/launcher-proto";
 import {
@@ -1249,7 +1251,7 @@ async function assertPreparedLauncherPayloadRelease(input: {
   config: DesktopUpdaterConfig;
   root: string;
   version: string;
-}): Promise<void> {
+}): Promise<string> {
   const manifest = validateLauncherPayloadManifest(await readJsonStrict<unknown>(join(input.root, "manifest.json")), {
     channel: input.config.channel,
     namespace: input.config.namespace ?? "",
@@ -1275,6 +1277,7 @@ async function assertPreparedLauncherPayloadRelease(input: {
     throw new Error("launcher payload root must be a plain directory");
   }
   await assertLauncherPayloadBootConfig({ manifest, payloadRoot, stagingRoot: input.root });
+  return entryExecutable;
 }
 
 async function prepareLauncherPayloadRelease(input: {
@@ -1388,7 +1391,7 @@ async function activatePreparedLauncherPayloadRelease(input: {
   logger: DesktopUpdaterLogger;
   now: () => Date;
   removeLauncherPayloadRoot: (path: string) => Promise<void>;
-}): Promise<LauncherRuntimeDescriptor> {
+}): Promise<{ launchPath: string; runtime: LauncherRuntimeDescriptor }> {
   if (input.config.launcherRoot == null || input.config.launcherRuntimePath == null || input.config.namespace == null) {
     throw new Error("launcher payload activate requires launcher root, runtime path, and namespace");
   }
@@ -1403,14 +1406,29 @@ async function activatePreparedLauncherPayloadRelease(input: {
     root: input.config.launcherRoot,
     version: input.activeRelease.ref.version,
   });
-  await assertPreparedLauncherPayloadRelease({
+  const launchPath = await assertPreparedLauncherPayloadRelease({
     config: input.config,
     root: versionPaths.versionRoot,
     version: input.activeRelease.ref.version,
   });
+  const launcherPaths = resolveLauncherPaths({
+    channel: input.config.channel,
+    namespace: input.config.namespace,
+    root: input.config.launcherRoot,
+  });
+  const currentAttempt = await readJsonStrict<LauncherAttemptDescriptor>(launcherPaths.attemptsPath)
+    .then((value) => validateLauncherAttemptDescriptor(value, {
+      channel: input.config.channel,
+      namespace: input.config.namespace ?? "",
+    }))
+    .catch(() => null);
   const activeRuntimeVersion = currentRuntime.active;
   const alreadyActive = activeRuntimeVersion?.version === input.activeRelease.ref.version;
-  const nextActive = alreadyActive && activeRuntimeVersion != null
+  const retryFailedGeneration = alreadyActive &&
+    activeRuntimeVersion != null &&
+    currentAttempt?.version === activeRuntimeVersion.version &&
+    currentAttempt.generation === activeRuntimeVersion.generation;
+  const nextActive = alreadyActive && activeRuntimeVersion != null && !retryFailedGeneration
     ? activeRuntimeVersion
     : {
         generation: Math.max(
@@ -1428,6 +1446,9 @@ async function activatePreparedLauncherPayloadRelease(input: {
     updatedAt: input.now().toISOString(),
   };
   await writeJson(input.config.launcherRuntimePath, nextRuntime);
+  if (retryFailedGeneration) {
+    await rm(launcherPaths.handoffPath, { force: true });
+  }
   await cleanupLauncherPayloadRoots({
     config: input.config,
     currentRuntime: nextRuntime,
@@ -1443,7 +1464,7 @@ async function activatePreparedLauncherPayloadRelease(input: {
     trigger: "activate",
     versionPaths,
   });
-  return nextRuntime;
+  return { launchPath, runtime: nextRuntime };
 }
 
 function launcherCleanupErrorFrom(error: unknown): NonNullable<LauncherCleanupEntry["error"]> {
@@ -1835,7 +1856,7 @@ async function launchWindowsInstallerAfterQuit(
   }
 }
 
-async function launchWindowsAppAfterQuit(
+async function launchPayloadAppAfterQuit(
   input: DeferredAppLaunchInput,
   deps: { now: () => Date; spawnDetached: SpawnInstallerHelper },
 ): Promise<DeferredLaunchResult> {
@@ -2597,12 +2618,7 @@ export function createDesktopUpdater(
       : launchMacInstallerAfterQuit(input, { now, spawnDetached })
   ));
   const launchAppAfterQuit = deps.launchAppAfterQuit ?? (async (input) => {
-    if (config.platform === "win32") return await launchWindowsAppAfterQuit(input, { now, spawnDetached });
-    const error = await launchMacInstallerAfterQuit(
-      { appPid: input.appPid, installerPath: input.launchPath, root: input.root, timeoutMs: input.timeoutMs },
-      { now, spawnDetached },
-    );
-    return error.length > 0 ? { error } : {};
+    return await launchPayloadAppAfterQuit(input, { now, spawnDetached });
   });
   const listeners = new Set<() => void>();
   let candidate: UpdateCandidate | null = null;
@@ -3208,18 +3224,17 @@ export function createDesktopUpdater(
     });
   }
 
-  async function requestPayloadRelaunch(updateRoot: string): Promise<DeferredLaunchResult & { launchPath?: string }> {
+  async function requestPayloadRelaunch(
+    updateRoot: string,
+    launchPath: string,
+  ): Promise<DeferredLaunchResult & { launchPath?: string }> {
     if (config.openDryRun) return {};
     if (config.platform !== "darwin" && config.platform !== "win32") return {};
-    const launchPath = config.launcherLaunchPath;
-    if (launchPath == null || launchPath.length === 0) {
-      return { error: "launcher payload relaunch requires a stable launcher launch path" };
-    }
     try {
       await access(launchPath);
       const launcherTarget = await lstat(launchPath);
-      if (launcherTarget.isSymbolicLink() || (!launcherTarget.isFile() && !launcherTarget.isDirectory())) {
-        return { error: `launcher launch path is not a plain file or directory: ${launchPath}` };
+      if (launcherTarget.isSymbolicLink() || !launcherTarget.isFile()) {
+        return { error: `launcher payload executable is not a plain file: ${launchPath}` };
       }
     } catch (launchPathError) {
       return { error: launchPathError instanceof Error ? launchPathError.message : String(launchPathError) };
@@ -3278,14 +3293,14 @@ export function createDesktopUpdater(
     if (activeRelease.ref.artifact.type === "payload") {
       try {
         const appliedAt = now().toISOString();
-        await activatePreparedLauncherPayloadRelease({
+        const activation = await activatePreparedLauncherPayloadRelease({
           activeRelease,
           config,
           logger,
           now,
           removeLauncherPayloadRoot,
         });
-        const relaunch = await requestPayloadRelaunch(opened.root.realRoot);
+        const relaunch = await requestPayloadRelaunch(opened.root.realRoot, activation.launchPath);
         if (relaunch.error != null && relaunch.error.length > 0) {
           return setState(DESKTOP_UPDATE_STATES.ERROR, createError("payload-relaunch-failed", relaunch.error));
         }

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -623,7 +623,19 @@ describe("desktop updater", () => {
       expect(installed.installResult?.path).toBe(checked.downloadPath);
       expect(installed.installResult?.artifactPath).toBe(checked.downloadPath);
       expect(installed.installResult?.activeVersion).toBe("1.0.0-beta.2");
-      expect(installed.installResult?.launchPath).toBe(launcherLaunchPath);
+      const payloadLaunchPath = join(
+        root,
+        "launcher",
+        "channels",
+        "beta",
+        "namespaces",
+        "release-beta-win",
+        "versions",
+        "1.0.0-beta.2",
+        "payload",
+        "Open Design.exe",
+      );
+      expect(installed.installResult?.launchPath).toBe(payloadLaunchPath);
       expect(installed.installResult?.launcherRuntimePath).toBe(launcherRuntimePath);
       expect(installed.installResult?.helperLogPath).toEqual(expect.stringContaining("open-app-after-quit-test.log"));
       expect(installed.installResult?.dryRun).toBe(false);
@@ -631,7 +643,7 @@ describe("desktop updater", () => {
       expect(launches).toEqual([
         {
           appPid: 4242,
-          launchPath: launcherLaunchPath,
+          launchPath: payloadLaunchPath,
           root: await realpath(join(root, "updates")),
         },
       ]);
@@ -1207,7 +1219,7 @@ describe("desktop updater", () => {
     }
   });
 
-  it("relaunches mac launcher payloads through the installed app bundle from a payload-backed process", async () => {
+  it("relaunches mac launcher payloads through the prepared payload executable", async () => {
     const root = makeRoot();
     const fixture = await createUpdaterFixture({
       artifactBody: "open design mac dmg fixture",
@@ -1297,7 +1309,21 @@ describe("desktop updater", () => {
       expect(launches).toEqual([
         {
           appPid: 4243,
-          launchPath: launcherLaunchPath,
+          launchPath: join(
+            root,
+            "launcher",
+            "channels",
+            "beta",
+            "namespaces",
+            "release-beta",
+            "versions",
+            "1.0.0-beta.3",
+            "payload",
+            "Open Design Beta.app",
+            "Contents",
+            "MacOS",
+            "Open Design Beta",
+          ),
           root: await realpath(join(root, "updates")),
         },
       ]);
@@ -1307,7 +1333,7 @@ describe("desktop updater", () => {
     }
   });
 
-  it("relaunches Windows launcher payloads through the installed executable from a payload-backed process", async () => {
+  it("relaunches Windows launcher payloads through the prepared payload executable", async () => {
     const root = makeRoot();
     const fixture = await createUpdaterFixture({
       artifactBody: "open design windows installer fixture",
@@ -1397,7 +1423,18 @@ describe("desktop updater", () => {
       expect(launches).toEqual([
         {
           appPid: 4244,
-          launchPath: launcherLaunchPath,
+          launchPath: join(
+            root,
+            "launcher",
+            "channels",
+            "beta",
+            "namespaces",
+            "release-beta-win",
+            "versions",
+            "1.0.0-beta.3",
+            "payload",
+            "Open Design.exe",
+          ),
           root: await realpath(join(root, "updates")),
         },
       ]);
@@ -1407,7 +1444,7 @@ describe("desktop updater", () => {
     }
   });
 
-  it("fails launcher payload relaunch when the stable launcher entry is unavailable", async () => {
+  it("relaunches the prepared payload even when the stable outer entry disappears", async () => {
     const root = makeRoot();
     const fixture = await createUpdaterFixture({
       artifactBody: "open design windows installer fixture",
@@ -1488,17 +1525,32 @@ describe("desktop updater", () => {
 
       const installed = await updater.installUpdate();
 
-      expect(installed.state).toBe(DESKTOP_UPDATE_STATES.ERROR);
-      expect(installed.error?.code).toBe("payload-relaunch-failed");
-      expect(installed.error?.message).toContain("Open Design.exe");
-      expect(launches).toEqual([]);
+      expect(installed.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
+      expect(installed.error).toBeUndefined();
+      expect(launches).toEqual([
+        expect.objectContaining({
+          appPid: 4246,
+          launchPath: join(
+            root,
+            "launcher",
+            "channels",
+            "beta",
+            "namespaces",
+            "release-beta-win",
+            "versions",
+            "1.0.0-beta.3",
+            "payload",
+            "Open Design.exe",
+          ),
+        }),
+      ]);
     } finally {
       await fixture.close();
       rmSync(root, { force: true, recursive: true });
     }
   });
 
-  it("starts the stable Windows launcher in after-quit mode for payload installs", async () => {
+  it("starts the Windows payload executable in after-quit mode for payload installs", async () => {
     const root = makeRoot();
     const fixture = await createUpdaterFixture({
       artifactBody: "open design windows installer fixture",
@@ -1575,11 +1627,23 @@ describe("desktop updater", () => {
 
       expect(installed.error).toBeUndefined();
       expect(installed.installResult?.path).toBe(checked.downloadPath);
-      expect(installed.installResult?.launchPath).toBe(launcherLaunchPath);
+      const payloadLaunchPath = join(
+        root,
+        "launcher",
+        "channels",
+        "beta",
+        "namespaces",
+        "release-beta-win",
+        "versions",
+        "1.0.0-beta.3",
+        "payload",
+        "Open Design.exe",
+      );
+      expect(installed.installResult?.launchPath).toBe(payloadLaunchPath);
       expect(installed.installResult?.helperLogPath).toBeUndefined();
       expect(spawned).toHaveLength(1);
       expect(unref).toHaveBeenCalledTimes(1);
-      expect(spawned[0]?.command).toBe(launcherLaunchPath);
+      expect(spawned[0]?.command).toBe(payloadLaunchPath);
       expect(spawned[0]?.options).toEqual({ detached: true, stdio: "ignore", windowsHide: true });
       const args = spawned[0]?.args ?? [];
       expect(args).toEqual(expect.arrayContaining([

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -1565,6 +1565,13 @@ describe("desktop updater", () => {
     const launcherLaunchPath = join(root, "installed", "Open Design.exe");
     const spawned: Array<{ args: string[]; command: string; options: unknown }> = [];
     const unref = vi.fn();
+    const child = {
+      once: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+        if (event === "spawn") queueMicrotask(listener);
+        return child;
+      }),
+      unref,
+    };
     try {
       await mkdir(join(root, "installed"), { recursive: true });
       await writeFile(launcherLaunchPath, "");
@@ -1618,7 +1625,7 @@ describe("desktop updater", () => {
         processPid: 4245,
         spawnDetached: (command, args, options) => {
           spawned.push({ args, command, options });
-          return { unref };
+          return child as never;
         },
       });
 
@@ -1653,6 +1660,106 @@ describe("desktop updater", () => {
         LAUNCHER_AFTER_QUIT_TIMEOUT_MS_ARG,
         "600000",
       ]));
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("reports an asynchronous payload spawn error instead of freezing a successful install", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture({
+      artifactBody: "open design windows installer fixture",
+      channel: "beta",
+      includePayload: true,
+      payloadBody: "open design windows payload fixture",
+      platform: "win",
+      version: "1.0.0-beta.3",
+    });
+    const launcherRuntimePath = join(root, "launcher", "runtime.json");
+    const launcherRoot = root;
+    const launcherLaunchPath = join(root, "installed", "Open Design.exe");
+    const unref = vi.fn();
+    try {
+      await mkdir(join(root, "installed"), { recursive: true });
+      await writeFile(launcherLaunchPath, "");
+      await mkdir(join(root, "launcher"), { recursive: true });
+      await mkdir(join(
+        root,
+        "launcher",
+        "channels",
+        "beta",
+        "namespaces",
+        "release-beta-win",
+        "versions",
+        "1.0.0-beta.2",
+      ), { recursive: true });
+      await writeFile(
+        launcherRuntimePath,
+        `${JSON.stringify({
+          active: { generation: 0, version: "1.0.0-beta.2" },
+          channel: "beta",
+          lastSuccessful: { generation: 0, version: "1.0.0-beta.2" },
+          namespace: "release-beta-win",
+          schemaVersion: LAUNCHER_SCHEMA_VERSION,
+        })}\n`,
+      );
+      const child = {
+        once: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+          if (event === "error") queueMicrotask(() => listener(new Error("spawn ENOENT")));
+          return child;
+        }),
+        unref,
+      };
+      const updater = createDesktopUpdater({
+        arch: "x64",
+        currentVersion: "1.0.0-beta.2",
+        downloadRoot: join(root, "updates"),
+        env: {
+          ...updaterEnv(fixture.metadataUrl, "win32"),
+          [DESKTOP_UPDATE_ENV.CURRENT_VERSION]: "1.0.0-beta.2",
+          [DESKTOP_UPDATE_ENV.OPEN_DRY_RUN]: "0",
+        },
+        launcherRoot,
+        launcherLaunchPath,
+        launcherRuntimePath,
+        namespace: "release-beta-win",
+        source: SIDECAR_SOURCES.PACKAGED,
+      }, {
+        extractLauncherPayloadArchive: async ({ destinationRoot }) => {
+          await mkdir(join(destinationRoot, "payload", "resources", "open-design"), { recursive: true });
+          await writeFile(join(destinationRoot, "payload", "Open Design.exe"), "");
+          await writeFile(join(destinationRoot, "payload", "resources", "open-design-config.json"), "{}\n");
+          await writeFile(
+            join(destinationRoot, "manifest.json"),
+            `${JSON.stringify({
+              channel: "beta",
+              entry: {
+                cwd: "payload",
+                executable: "payload/Open Design.exe",
+              },
+              namespace: "release-beta-win",
+              payloadRoot: "payload",
+              platform: "win32",
+              schemaVersion: LAUNCHER_SCHEMA_VERSION,
+              version: "1.0.0-beta.3",
+            })}\n`,
+          );
+        },
+        processPid: 4245,
+        spawnDetached: () => child as never,
+      });
+
+      await updater.checkForUpdates();
+      const installed = await updater.installUpdate();
+
+      expect(installed.state).toBe(DESKTOP_UPDATE_STATES.ERROR);
+      expect(installed.error).toMatchObject({
+        code: "payload-relaunch-failed",
+        message: "spawn ENOENT",
+      });
+      expect(installed.installResult).toBeUndefined();
+      expect(unref).not.toHaveBeenCalled();
     } finally {
       await fixture.close();
       rmSync(root, { force: true, recursive: true });
@@ -1907,7 +2014,7 @@ describe("desktop updater", () => {
           processPid: 4242,
           spawnDetached: (command, args) => {
             spawned.push({ args, command });
-            return { unref: vi.fn() };
+            return { unref: vi.fn() } as never;
           },
         },
       );
@@ -1955,7 +2062,7 @@ describe("desktop updater", () => {
           processPid: 4242,
           spawnDetached: (command, args, options) => {
             spawned.push({ args, command, options });
-            return { unref };
+            return { unref } as never;
           },
         },
       );

--- a/apps/packaged/src/config.ts
+++ b/apps/packaged/src/config.ts
@@ -14,6 +14,7 @@ async function loadElectronApp() {
 
 export const PACKAGED_CONFIG_PATH_ENV = "OD_PACKAGED_CONFIG_PATH";
 export const PACKAGED_NAMESPACE_ENV = "OD_PACKAGED_NAMESPACE";
+export const PACKAGED_NAMESPACE_BASE_ROOT_ENV = "OD_PACKAGED_NAMESPACE_BASE_ROOT";
 export const PACKAGED_WEB_OUTPUT_MODE_OVERRIDE_ENV = "OD_PACKAGED_ALLOW_WEB_OUTPUT_MODE_OVERRIDE";
 export const PACKAGED_WEB_STANDALONE_ROOT_ENV = "OD_WEB_STANDALONE_ROOT";
 export const PACKAGED_WEB_OUTPUT_MODE_ENV = "OD_WEB_OUTPUT_MODE";
@@ -103,6 +104,16 @@ function resolveOptionalPath(value: string | undefined): string | undefined {
   return value == null || value.length === 0 ? undefined : resolve(value);
 }
 
+export function resolvePackagedNamespaceBaseRoot(
+  rawNamespaceBaseRoot: string | undefined,
+  electronUserDataRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return resolveOptionalPath(env[PACKAGED_NAMESPACE_BASE_ROOT_ENV])
+    ?? resolveOptionalPath(rawNamespaceBaseRoot)
+    ?? join(electronUserDataRoot, "namespaces");
+}
+
 // Config DTOs use null for optional scalar values consumed by runtime options;
 // optional paths use undefined so callers can distinguish "no path" from a resolved path string.
 function cleanOptionalString(value: string | undefined): string | null {
@@ -154,8 +165,10 @@ export async function readPackagedConfig(): Promise<PackagedConfig> {
     process.env[PACKAGED_NAMESPACE_ENV] ?? raw.namespace ?? SIDECAR_DEFAULTS.namespace,
   );
   const electronApp = await loadElectronApp();
-  const namespaceBaseRoot =
-    resolveOptionalPath(raw.namespaceBaseRoot) ?? join(electronApp.getPath("userData"), "namespaces");
+  const namespaceBaseRoot = resolvePackagedNamespaceBaseRoot(
+    raw.namespaceBaseRoot,
+    electronApp.getPath("userData"),
+  );
   const resourceRoot = resolveOptionalPath(raw.resourceRoot) ?? join(process.resourcesPath, "open-design");
   const relativeNodeCommand =
     raw.nodeCommandRelative == null || raw.nodeCommandRelative.length === 0

--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -5,7 +5,10 @@ import {
   SIDECAR_SOURCES,
   type SidecarStamp,
 } from "@open-design/sidecar-proto";
-import { parseLauncherAfterQuitArgs } from "@open-design/launcher-proto";
+import {
+  parseLauncherAfterQuitArgs,
+  parseLauncherHandoffResumeArgs,
+} from "@open-design/launcher-proto";
 import {
   bootstrapSidecarRuntime,
   createSidecarLaunchEnv,
@@ -36,6 +39,7 @@ import {
   type PackagedDesktopLogger,
 } from "./logging.js";
 import { resolvePackagedNamespacePaths } from "./paths.js";
+import { launchPackagedPayloadDesktop } from "./payload-desktop-launch.js";
 import { packagedEntryUrl, registerOdProtocol } from "./protocol.js";
 import { startPackagedSidecars } from "./sidecars.js";
 import { reportStartupFailure, resolveStartupDistinctId } from "./startup-telemetry.js";
@@ -105,11 +109,15 @@ async function main(): Promise<void> {
 
   const config = await readPackagedConfig();
   const afterQuit = parseLauncherAfterQuitArgs(process.argv.slice(1));
+  const handoffResume = parseLauncherHandoffResumeArgs(process.argv.slice(1));
   const argvStamp = readProcessStamp(process.argv.slice(1), OPEN_DESIGN_SIDECAR_CONTRACT);
   const namespace = argvStamp?.namespace ?? config.namespace;
   const namespaceConfig = namespace === config.namespace ? config : { ...config, namespace };
   const initialPaths = resolvePackagedNamespacePaths(namespaceConfig, namespace, process.env);
-  await waitForLauncherAfterQuit(afterQuit, initialPaths);
+  if (!await waitForLauncherAfterQuit(afterQuit, initialPaths)) {
+    app.exit(1);
+    return;
+  }
   const existingDesktop = await inspectExistingDesktopForLauncher(namespace, {
     logger: console,
     paths: initialPaths,
@@ -117,10 +125,16 @@ async function main(): Promise<void> {
   if (existingDesktop.action === "exit") {
     return;
   }
-  const launcherRuntime = await resolvePackagedLauncherRuntime(namespaceConfig, initialPaths);
+  const stamp = argvStamp ?? createPackagedDesktopStamp(namespace);
+  const launcherRuntime = await resolvePackagedLauncherRuntime(namespaceConfig, initialPaths, {
+    resume: handoffResume,
+  });
+  if (await launchPackagedPayloadDesktop(launcherRuntime, stamp)) {
+    app.exit(0);
+    return;
+  }
   const activeConfig = launcherRuntime.config;
   const paths = launcherRuntime.paths;
-  const stamp = argvStamp ?? createPackagedDesktopStamp(namespace);
 
   // Arm fatal-exit telemetry now that we know the channel key/version. The
   // startPackagedSidecars call below is THE failure this covers (daemon/web

--- a/apps/packaged/src/launcher-after-quit.ts
+++ b/apps/packaged/src/launcher-after-quit.ts
@@ -72,22 +72,22 @@ export async function waitForLauncherAfterQuit(
   paths: PackagedNamespacePaths,
   logger: LauncherAfterQuitLogger = console,
   controls: Partial<LauncherProcessControls> = {},
-): Promise<void> {
-  if (request == null) return;
+): Promise<boolean> {
+  if (request == null) return true;
   const waitForExit = controls.waitForExit ?? waitForProcessExit;
   const stop = controls.stopProcesses ?? stopProcesses;
   await writeLauncherAfterQuitLog(paths, `armed targetPid=${request.targetPid} timeoutMs=${request.timeoutMs}`);
   const exited = await waitForExit(request.targetPid, request.timeoutMs);
   if (exited) {
     await writeLauncherAfterQuitLog(paths, `observed-exit targetPid=${request.targetPid}`);
-    return;
+    return true;
   }
   // The old process outlived its quit grace and still holds the fixed socket.
   // Force it off so the relaunched app binds cleanly instead of skewing.
   const message = `timed-out targetPid=${request.targetPid}; forcing stop`;
   await writeLauncherAfterQuitLog(paths, message);
   logger.warn(`[open-design launcher] ${message}`);
-  await forceStopLingeringDesktop(request.targetPid, "after-quit-timeout", paths, logger, stop);
+  return await forceStopLingeringDesktop(request.targetPid, "after-quit-timeout", paths, logger, stop);
 }
 
 export async function inspectExistingDesktopForLauncher(

--- a/apps/packaged/src/launcher-runtime.ts
+++ b/apps/packaged/src/launcher-runtime.ts
@@ -1,11 +1,13 @@
 import { createHash } from "node:crypto";
-import { access, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
-import { basename, dirname, join } from "node:path";
+import { access, lstat, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { basename, dirname, join, resolve, sep } from "node:path";
 
 import {
   LAUNCHER_SCHEMA_VERSION,
   compareLauncherVersions,
   type LauncherChannel,
+  type LauncherDesktopHandoffDescriptor,
+  type LauncherHandoffResumeRequest,
   type LauncherPaths,
   type LauncherRuntimeDescriptor,
   type LauncherVersionPaths,
@@ -15,6 +17,7 @@ import {
   resolveLauncherPaths,
   resolveLauncherVersionPaths,
   selectLauncherRuntimeTarget,
+  validateLauncherDesktopHandoffDescriptor,
   validateLauncherRuntimeDescriptor,
   type LauncherAttemptDescriptor,
   type LauncherTargetSelection,
@@ -39,11 +42,13 @@ type LauncherPayloadManifest = {
 
 export type PackagedLauncherRuntime = {
   config: PackagedConfig;
+  desktopExecutablePath: string | null;
   descriptor: LauncherRuntimeDescriptor;
   electronNodeCommand: string | null;
   installedLaunchPath: string | null;
   launcherPaths: LauncherPaths;
   paths: PackagedNamespacePaths;
+  payloadDesktopProcess: boolean;
   selection: LauncherTargetSelection;
   source: "current-package" | "payload";
   targetVersion: string | null;
@@ -76,7 +81,13 @@ type LauncherCleanupEntry = {
 
 type ResolvedPayloadConfig = {
   config: PackagedConfig;
+  desktopExecutablePath: string;
   electronNodeCommand: string | null;
+};
+
+export type ResolvePackagedLauncherRuntimeOptions = {
+  currentExecutablePath?: string;
+  resume?: LauncherHandoffResumeRequest | null;
 };
 
 async function pathExists(path: string): Promise<boolean> {
@@ -195,6 +206,31 @@ async function resolveOptionalVersionEntry(versionRoot: string, relative: string
   return (await pathExists(entry)) ? entry : null;
 }
 
+function containsPath(root: string, target: string): boolean {
+  const normalizedRoot = resolve(root);
+  const normalizedTarget = resolve(target);
+  return normalizedTarget === normalizedRoot || normalizedTarget.startsWith(`${normalizedRoot}${sep}`);
+}
+
+async function resolvePayloadDesktopExecutable(
+  versionPaths: LauncherVersionPaths,
+  relative: string,
+): Promise<string | null> {
+  const executablePath = resolve(versionPaths.versionRoot, relative);
+  if (!containsPath(versionPaths.versionRoot, executablePath)) return null;
+  const entry = await lstat(executablePath).catch(() => null);
+  if (entry == null || !entry.isFile() || entry.isSymbolicLink()) return null;
+  return executablePath;
+}
+
+function sameExecutablePath(left: string, right: string): boolean {
+  const normalizedLeft = resolve(left);
+  const normalizedRight = resolve(right);
+  return process.platform === "win32"
+    ? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+    : normalizedLeft === normalizedRight;
+}
+
 async function resolveWindowsPayloadDirectoryAlias(
   versionPaths: LauncherVersionPaths,
   kind: string,
@@ -245,6 +281,11 @@ async function resolvePayloadConfig(
     namespace: config.namespace,
     version: versionPaths.version,
   });
+  const desktopExecutablePath = await resolvePayloadDesktopExecutable(
+    versionPaths,
+    manifest.entry.executable,
+  );
+  if (desktopExecutablePath == null) return null;
   const resourcesPath = manifest.platform === "darwin"
     ? join(versionPaths.versionRoot, manifest.entry.cwd, "Contents", "Resources")
     : join(versionPaths.versionRoot, manifest.payloadRoot, "resources");
@@ -287,6 +328,7 @@ async function resolvePayloadConfig(
       webSidecarEntry: await resolveOptionalPayloadEntry(resourcesPath, raw.webSidecarEntryRelative),
       webStandaloneRoot,
     },
+    desktopExecutablePath,
     electronNodeCommand,
   };
 }
@@ -395,6 +437,7 @@ async function reconcileRuntimeWithBoundPackage(
 export async function resolvePackagedLauncherRuntime(
   config: PackagedConfig,
   paths: PackagedNamespacePaths,
+  options: ResolvePackagedLauncherRuntimeOptions = {},
 ): Promise<PackagedLauncherRuntime> {
   const channel = inferLauncherChannel(config);
   const launcherPaths = resolveLauncherPaths({
@@ -409,7 +452,27 @@ export async function resolvePackagedLauncherRuntime(
     channel,
   );
   const attempted = await readLauncherAttempt(launcherPaths, channel, config.namespace).catch(() => null);
-  const selection = selectLauncherRuntimeTarget({ attempted, runtime: descriptor });
+  const currentExecutablePath = options.currentExecutablePath ?? process.execPath;
+  const handoff = options.resume == null
+    ? null
+    : await readJsonFile<LauncherDesktopHandoffDescriptor>(launcherPaths.handoffPath)
+      .then((value) => validateLauncherDesktopHandoffDescriptor(value, {
+        channel,
+        namespace: config.namespace,
+      }))
+      .catch(() => null);
+  const requestedResume = options.resume != null &&
+    handoff?.state === "armed" &&
+    handoff.handoffId === options.resume.handoffId &&
+    handoff.target != null &&
+    descriptor.active?.version === handoff.target.version &&
+    descriptor.active.generation === handoff.target.generation &&
+    attempted?.version === handoff.target.version &&
+    attempted.generation === handoff.target.generation &&
+    sameExecutablePath(currentExecutablePath, handoff.payloadExecutablePath)
+    ? handoff.target
+    : null;
+  const selection = selectLauncherRuntimeTarget({ attempted, resume: requestedResume, runtime: descriptor });
   const persistedInstall = await readLauncherInstallDescriptor(launcherPaths, channel, config.namespace).catch(() => null);
   const currentPackageLaunchPath = stableAppLaunchPathFromExecutable(process.execPath);
 
@@ -422,7 +485,23 @@ export async function resolvePackagedLauncherRuntime(
     });
     const payloadConfig = await resolvePayloadConfig(config, versionPaths, channel);
     if (payloadConfig != null) {
-      if (selection.reason === "active") {
+      const payloadDesktopProcess = sameExecutablePath(
+        currentExecutablePath,
+        payloadConfig.desktopExecutablePath,
+      );
+      if (
+        selection.reason === "active-resume" &&
+        (handoff == null || !payloadDesktopProcess || !sameExecutablePath(
+          handoff.payloadExecutablePath,
+          payloadConfig.desktopExecutablePath,
+        ))
+      ) {
+        return await resolvePackagedLauncherRuntime(config, paths, {
+          currentExecutablePath,
+          resume: null,
+        });
+      }
+      if (selection.reason === "active" && payloadDesktopProcess) {
         await writeJsonFile(launcherPaths.attemptsPath, {
           channel,
           generation: selection.pointer.generation,
@@ -434,11 +513,13 @@ export async function resolvePackagedLauncherRuntime(
       }
       return {
         config: payloadConfig.config,
+        desktopExecutablePath: payloadConfig.desktopExecutablePath,
         descriptor,
         electronNodeCommand: payloadConfig.electronNodeCommand,
         installedLaunchPath: persistedInstall?.launchPath ?? currentPackageLaunchPath,
         launcherPaths,
         paths: { ...paths, resourceRoot: payloadConfig.config.resourceRoot },
+        payloadDesktopProcess,
         selection,
         source: "payload",
         targetVersion: selection.pointer.version,
@@ -448,6 +529,7 @@ export async function resolvePackagedLauncherRuntime(
 
   return {
     config,
+    desktopExecutablePath: null,
     descriptor,
     electronNodeCommand: null,
     installedLaunchPath: (await writeLauncherInstallDescriptor(
@@ -458,6 +540,7 @@ export async function resolvePackagedLauncherRuntime(
     )).launchPath,
     launcherPaths,
     paths,
+    payloadDesktopProcess: false,
     selection,
     source: "current-package",
     targetVersion: null,
@@ -469,15 +552,55 @@ async function writeJsonFile(path: string, payload: unknown): Promise<void> {
   await writeFile(path, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
 }
 
-export async function confirmPackagedLauncherRuntime(runtime: PackagedLauncherRuntime): Promise<void> {
+export async function recordPackagedLauncherRuntimeFailedAttempt(
+  runtime: PackagedLauncherRuntime,
+): Promise<void> {
   if (runtime.source !== "payload") return;
   if (!runtime.selection.selected || runtime.selection.reason !== "active") return;
+  await writeJsonFile(runtime.launcherPaths.attemptsPath, {
+    channel: runtime.launcherPaths.channel,
+    generation: runtime.selection.pointer.generation,
+    namespace: runtime.launcherPaths.namespace,
+    schemaVersion: LAUNCHER_SCHEMA_VERSION,
+    startedAt: new Date().toISOString(),
+    version: runtime.selection.pointer.version,
+  } satisfies LauncherAttemptDescriptor);
+}
+
+export async function confirmPackagedLauncherRuntime(runtime: PackagedLauncherRuntime): Promise<void> {
+  if (runtime.source !== "payload") return;
+  if (!runtime.payloadDesktopProcess) return;
+  if (runtime.desktopExecutablePath == null) return;
+  if (!runtime.selection.selected || (
+    runtime.selection.reason !== "active" && runtime.selection.reason !== "active-resume"
+  )) return;
+  const confirmedAt = new Date().toISOString();
   const next: LauncherRuntimeDescriptor = {
     ...runtime.descriptor,
     active: runtime.selection.pointer,
     lastSuccessful: runtime.selection.pointer,
-    updatedAt: new Date().toISOString(),
+    updatedAt: confirmedAt,
   };
-  await writeJsonFile(runtime.launcherPaths.runtimePath, next);
+  const handoff = await readJsonFile<LauncherDesktopHandoffDescriptor>(runtime.launcherPaths.handoffPath)
+    .then((value) => validateLauncherDesktopHandoffDescriptor(value, runtime.launcherPaths))
+    .catch(() => null);
+  const canConfirmResumeBinding =
+    runtime.selection.reason === "active-resume" &&
+    handoff?.state === "armed" &&
+    handoff.target != null &&
+    handoff.target.generation === runtime.selection.pointer.generation &&
+    handoff.target.version === runtime.selection.pointer.version;
+  const canRefreshConfirmedBinding = handoff?.state === "confirmed";
+  if (handoff != null && (canConfirmResumeBinding || canRefreshConfirmedBinding)) {
+    await writeJsonFile(runtime.launcherPaths.handoffPath, {
+      ...handoff,
+      payloadExecutablePath: runtime.desktopExecutablePath,
+      source: runtime.selection.pointer,
+      state: "confirmed",
+      target: runtime.selection.pointer,
+      updatedAt: confirmedAt,
+    } satisfies LauncherDesktopHandoffDescriptor);
+  }
   await rm(runtime.launcherPaths.attemptsPath, { force: true });
+  await writeJsonFile(runtime.launcherPaths.runtimePath, next);
 }

--- a/apps/packaged/src/launcher-runtime.ts
+++ b/apps/packaged/src/launcher-runtime.ts
@@ -592,9 +592,18 @@ export async function confirmPackagedLauncherRuntime(runtime: PackagedLauncherRu
     handoff.target.version === runtime.selection.pointer.version;
   const canRefreshConfirmedBinding = handoff?.state === "confirmed";
   if (handoff != null && (canConfirmResumeBinding || canRefreshConfirmedBinding)) {
+    const advancesConfirmedBinding =
+      canRefreshConfirmedBinding &&
+      (
+        handoff.source.generation !== runtime.selection.pointer.generation ||
+        handoff.source.version !== runtime.selection.pointer.version
+      );
     await writeJsonFile(runtime.launcherPaths.handoffPath, {
       ...handoff,
       payloadExecutablePath: runtime.desktopExecutablePath,
+      previous: advancesConfirmedBinding && runtime.descriptor.lastSuccessful != null
+        ? runtime.descriptor.lastSuccessful
+        : handoff.previous,
       source: runtime.selection.pointer,
       state: "confirmed",
       target: runtime.selection.pointer,

--- a/apps/packaged/src/paths.ts
+++ b/apps/packaged/src/paths.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { isAbsolute, join, win32 } from "node:path";
+import { join, posix, win32 } from "node:path";
 
 import { APP_KEYS, normalizeNamespace } from "@open-design/sidecar-proto";
 
@@ -60,7 +60,7 @@ function resolvePackagedDataRoot(
     const expanded = expandHomePrefix(odDataDir);
     const isAbs = process.platform === "win32"
       ? win32.isAbsolute(expanded)
-      : isAbsolute(expanded);
+      : posix.isAbsolute(expanded);
     if (!isAbs) {
       throw new PackagedPathAccessError(
         [

--- a/apps/packaged/src/payload-desktop-launch.ts
+++ b/apps/packaged/src/payload-desktop-launch.ts
@@ -1,0 +1,75 @@
+import { spawn } from "node:child_process";
+import { dirname } from "node:path";
+
+import { buildLauncherAfterQuitArgs } from "@open-design/launcher-proto";
+import { createProcessStampArgs } from "@open-design/platform";
+import { OPEN_DESIGN_SIDECAR_CONTRACT, type SidecarStamp } from "@open-design/sidecar-proto";
+
+import {
+  recordPackagedLauncherRuntimeFailedAttempt,
+  type PackagedLauncherRuntime,
+} from "./launcher-runtime.js";
+
+const DEFAULT_DELEGATION_TIMEOUT_MS = 60_000;
+
+export type PackagedPayloadDesktopLaunchPlan = {
+  args: string[];
+  command: string;
+  cwd: string;
+};
+
+export function planPackagedPayloadDesktopDelegation(
+  runtime: PackagedLauncherRuntime,
+  stamp: SidecarStamp,
+  options: {
+    currentPid?: number;
+    timeoutMs?: number;
+  } = {},
+): PackagedPayloadDesktopLaunchPlan | null {
+  if (runtime.source !== "payload" || runtime.payloadDesktopProcess) return null;
+  if (runtime.desktopExecutablePath == null) return null;
+
+  return {
+    args: [
+      ...buildLauncherAfterQuitArgs({
+        targetPid: options.currentPid ?? process.pid,
+        timeoutMs: options.timeoutMs ?? DEFAULT_DELEGATION_TIMEOUT_MS,
+      }),
+      ...createProcessStampArgs(stamp, OPEN_DESIGN_SIDECAR_CONTRACT),
+    ],
+    command: runtime.desktopExecutablePath,
+    cwd: dirname(runtime.desktopExecutablePath),
+  };
+}
+
+export async function launchPackagedPayloadDesktop(
+  runtime: PackagedLauncherRuntime,
+  stamp: SidecarStamp,
+  options: {
+    currentPid?: number;
+    recordFailedAttempt?: (runtime: PackagedLauncherRuntime) => Promise<void>;
+    spawn?: typeof spawn;
+    timeoutMs?: number;
+  } = {},
+): Promise<boolean> {
+  const plan = planPackagedPayloadDesktopDelegation(runtime, stamp, options);
+  if (plan == null) return false;
+
+  try {
+    const child = (options.spawn ?? spawn)(plan.command, plan.args, {
+      cwd: plan.cwd,
+      detached: true,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    await new Promise<void>((resolveSpawn, rejectSpawn) => {
+      child.once("spawn", () => resolveSpawn());
+      child.once("error", rejectSpawn);
+    });
+    child.unref();
+  } catch (error) {
+    await (options.recordFailedAttempt ?? recordPackagedLauncherRuntimeFailedAttempt)(runtime);
+    throw error;
+  }
+  return true;
+}

--- a/apps/packaged/tests/config.test.ts
+++ b/apps/packaged/tests/config.test.ts
@@ -1,0 +1,29 @@
+import { join, resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  PACKAGED_NAMESPACE_BASE_ROOT_ENV,
+  resolvePackagedNamespaceBaseRoot,
+} from '../src/config.js';
+
+describe('resolvePackagedNamespaceBaseRoot', () => {
+  it('lets a historical handoff preserve the already-resolved namespace base root', () => {
+    const inheritedRoot = join('C:', 'tools-pack', 'runtime', 'namespaces');
+    const bakedRoot = join('C:', 'Users', 'Nexu', 'AppData', 'Roaming', 'Open Design', 'namespaces');
+
+    expect(resolvePackagedNamespaceBaseRoot(bakedRoot, join('C:', 'fallback'), {
+      [PACKAGED_NAMESPACE_BASE_ROOT_ENV]: inheritedRoot,
+    })).toBe(resolve(inheritedRoot));
+  });
+
+  it('falls back to the payload config and then Electron userData', () => {
+    const bakedRoot = join('C:', 'packaged', 'namespaces');
+    const userDataRoot = join('C:', 'user-data');
+
+    expect(resolvePackagedNamespaceBaseRoot(bakedRoot, userDataRoot, {})).toBe(resolve(bakedRoot));
+    expect(resolvePackagedNamespaceBaseRoot(undefined, userDataRoot, {})).toBe(
+      join(userDataRoot, 'namespaces'),
+    );
+  });
+});

--- a/apps/packaged/tests/launcher-after-quit.test.ts
+++ b/apps/packaged/tests/launcher-after-quit.test.ts
@@ -53,8 +53,9 @@ describe("waitForLauncherAfterQuit", () => {
     try {
       const paths = fakePaths(root);
 
-      await waitForLauncherAfterQuit({ targetPid: 999999, timeoutMs: 1000 }, paths);
+      const exited = await waitForLauncherAfterQuit({ targetPid: 999999, timeoutMs: 1000 }, paths);
 
+      expect(exited).toBe(true);
       const log = await readFile(join(root, "logs", "launcher", "after-quit.log"), "utf8");
       expect(log).toContain("armed targetPid=999999 timeoutMs=1000");
       expect(log).toContain("observed-exit targetPid=999999");
@@ -66,15 +67,21 @@ describe("waitForLauncherAfterQuit", () => {
   it("logs and warns on timeout", async () => {
     const root = await mkdtemp(join(tmpdir(), "od-launcher-after-quit-timeout-"));
     const logger = { warn: vi.fn() };
+    const stop = fakeStop(4242, { survived: true });
     try {
       const paths = fakePaths(root);
 
-      await waitForLauncherAfterQuit({ targetPid: process.pid, timeoutMs: 1 }, paths, logger);
+      const exited = await waitForLauncherAfterQuit({ targetPid: 4242, timeoutMs: 1 }, paths, logger, {
+        stopProcesses: stop,
+        waitForExit: neverExits,
+      });
 
+      expect(exited).toBe(false);
       const log = await readFile(join(root, "logs", "launcher", "after-quit.log"), "utf8");
-      expect(log).toContain(`armed targetPid=${process.pid} timeoutMs=1`);
-      expect(log).toContain(`timed-out targetPid=${process.pid}`);
-      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining(`timed-out targetPid=${process.pid}`));
+      expect(log).toContain("armed targetPid=4242 timeoutMs=1");
+      expect(log).toContain("timed-out targetPid=4242; forcing stop");
+      expect(log).toContain("force-stop after-quit-timeout pid=4242 outcome=survived");
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("timed-out targetPid=4242"));
     } finally {
       await rm(root, { force: true, recursive: true });
     }
@@ -86,11 +93,12 @@ describe("waitForLauncherAfterQuit", () => {
     try {
       const paths = fakePaths(root);
 
-      await waitForLauncherAfterQuit({ targetPid: 4242, timeoutMs: 5 }, paths, { warn: vi.fn() }, {
+      const exited = await waitForLauncherAfterQuit({ targetPid: 4242, timeoutMs: 5 }, paths, { warn: vi.fn() }, {
         stopProcesses: stop,
         waitForExit: neverExits,
       });
 
+      expect(exited).toBe(true);
       expect(stop).toHaveBeenCalledWith([4242]);
       const log = await readFile(join(root, "logs", "launcher", "after-quit.log"), "utf8");
       expect(log).toContain("timed-out targetPid=4242; forcing stop");

--- a/apps/packaged/tests/launcher-runtime.test.ts
+++ b/apps/packaged/tests/launcher-runtime.test.ts
@@ -10,7 +10,11 @@ import {
 import { describe, expect, it } from "vitest";
 
 import type { PackagedConfig } from "../src/config.js";
-import { confirmPackagedLauncherRuntime, resolvePackagedLauncherRuntime } from "../src/launcher-runtime.js";
+import {
+  confirmPackagedLauncherRuntime,
+  type PackagedLauncherRuntime,
+  resolvePackagedLauncherRuntime,
+} from "../src/launcher-runtime.js";
 import { resolvePackagedNamespacePaths } from "../src/paths.js";
 
 function fakeConfig(root: string, appVersion = "1.2.3-beta.4"): PackagedConfig {
@@ -203,6 +207,99 @@ describe("resolvePackagedLauncherRuntime", () => {
       expect(JSON.parse(await readFile(resumedRuntime.launcherPaths.runtimePath, "utf8"))).toMatchObject({
         active: { generation: 1, version: "1.2.3-beta.5" },
         lastSuccessful: { generation: 1, version: "1.2.3-beta.5" },
+      });
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("refreshes a confirmed handoff with the current last-successful payload before advancing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-packaged-launcher-handoff-refresh-"));
+    try {
+      const config = fakeConfig(root);
+      const paths = resolvePackagedNamespacePaths(config);
+      const currentPackageRuntime = await resolvePackagedLauncherRuntime(config, paths);
+      const firstPayload = { generation: 1, version: "1.2.3-beta.5" };
+      const secondPayload = { generation: 2, version: "1.2.3-beta.6" };
+      const secondPayloadExecutablePath = join(
+        root,
+        "launcher",
+        "channels",
+        "beta",
+        "namespaces",
+        config.namespace,
+        "versions",
+        secondPayload.version,
+        "payload",
+        "Open Design Beta.app",
+        "Contents",
+        "MacOS",
+        "Open Design Beta",
+      );
+      await mkdir(currentPackageRuntime.launcherPaths.stateRoot, { recursive: true });
+      await writeFile(
+        currentPackageRuntime.launcherPaths.handoffPath,
+        `${JSON.stringify({
+          channel: "beta",
+          createdAt: "2026-07-15T01:00:00.000Z",
+          handoffId: "f5d4a712-8ba9-4c28-bcad-6dbed5db2d7c",
+          namespace: config.namespace,
+          outer: {
+            executablePath: process.execPath,
+            pid: process.pid,
+          },
+          payloadExecutablePath: join(root, "payload-v1"),
+          previous: { generation: 0, version: "1.2.3-beta.4" },
+          schemaVersion: LAUNCHER_SCHEMA_VERSION,
+          source: firstPayload,
+          state: "confirmed",
+          target: firstPayload,
+          updatedAt: "2026-07-15T02:00:00.000Z",
+        } satisfies LauncherDesktopHandoffDescriptor)}\n`,
+      );
+      const secondPayloadRuntime = {
+        ...currentPackageRuntime,
+        desktopExecutablePath: secondPayloadExecutablePath,
+        descriptor: {
+          ...currentPackageRuntime.descriptor,
+          active: secondPayload,
+          lastSuccessful: firstPayload,
+        },
+        payloadDesktopProcess: true,
+        selection: {
+          pointer: secondPayload,
+          reason: "active",
+          selected: true,
+        },
+        source: "payload",
+        targetVersion: secondPayload.version,
+      } satisfies PackagedLauncherRuntime;
+
+      await confirmPackagedLauncherRuntime(secondPayloadRuntime);
+
+      expect(JSON.parse(
+        await readFile(secondPayloadRuntime.launcherPaths.handoffPath, "utf8"),
+      )).toMatchObject({
+        previous: firstPayload,
+        source: secondPayload,
+        state: "confirmed",
+        target: secondPayload,
+      });
+
+      await confirmPackagedLauncherRuntime({
+        ...secondPayloadRuntime,
+        descriptor: {
+          ...secondPayloadRuntime.descriptor,
+          lastSuccessful: secondPayload,
+        },
+      });
+      expect(JSON.parse(
+        await readFile(secondPayloadRuntime.launcherPaths.handoffPath, "utf8"),
+      )).toMatchObject({
+        previous: firstPayload,
+        source: secondPayload,
+        state: "confirmed",
+        target: secondPayload,
       });
     } finally {
       await rm(root, { force: true, recursive: true });

--- a/apps/packaged/tests/launcher-runtime.test.ts
+++ b/apps/packaged/tests/launcher-runtime.test.ts
@@ -2,7 +2,11 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, sep } from "node:path";
 
-import { LAUNCHER_SCHEMA_VERSION, resolveLauncherVersionPaths } from "@open-design/launcher-proto";
+import {
+  LAUNCHER_SCHEMA_VERSION,
+  resolveLauncherVersionPaths,
+  type LauncherDesktopHandoffDescriptor,
+} from "@open-design/launcher-proto";
 import { describe, expect, it } from "vitest";
 
 import type { PackagedConfig } from "../src/config.js";
@@ -75,10 +79,19 @@ describe("resolvePackagedLauncherRuntime", () => {
         version: "1.2.3-beta.5",
       });
       const resourcesPath = join(versionPaths.payloadRoot, "Open Design Beta.app", "Contents", "Resources");
+      const payloadExecutablePath = join(
+        versionPaths.payloadRoot,
+        "Open Design Beta.app",
+        "Contents",
+        "MacOS",
+        "Open Design Beta",
+      );
       await mkdir(join(resourcesPath, "open-design", "bin"), { recursive: true });
+      await mkdir(join(versionPaths.payloadRoot, "Open Design Beta.app", "Contents", "MacOS"), { recursive: true });
       await mkdir(join(resourcesPath, "prebundled", "daemon"), { recursive: true });
       await mkdir(join(resourcesPath, "prebundled", "web"), { recursive: true });
       await writeFile(join(resourcesPath, "open-design", "bin", "node"), "");
+      await writeFile(payloadExecutablePath, "");
       await writeFile(join(resourcesPath, "prebundled", "daemon", "daemon-sidecar.mjs"), "");
       await writeFile(join(resourcesPath, "prebundled", "web", "web-sidecar.mjs"), "");
       await writeFile(
@@ -130,6 +143,7 @@ describe("resolvePackagedLauncherRuntime", () => {
       const runtime = await resolvePackagedLauncherRuntime(config, paths);
 
       expect(runtime.source).toBe("payload");
+      expect(runtime.desktopExecutablePath).toBe(payloadExecutablePath);
       expect(runtime.electronNodeCommand).toBeNull();
       expect(runtime.installedLaunchPath).toBe("/Applications/Open Design Beta.app");
       expect(runtime.targetVersion).toBe("1.2.3-beta.5");
@@ -139,7 +153,13 @@ describe("resolvePackagedLauncherRuntime", () => {
       expect(runtime.config.webSidecarEntry).toBe(join(resourcesPath, "prebundled", "web", "web-sidecar.mjs"));
       expect(runtime.config.webStandaloneRoot).toBe(join(resourcesPath, "open-design-web-standalone"));
       expect(runtime.paths.resourceRoot).toBe(join(resourcesPath, "open-design"));
-      expect(JSON.parse(await readFile(runtime.launcherPaths.attemptsPath, "utf8"))).toMatchObject({
+      await expect(readFile(runtime.launcherPaths.attemptsPath, "utf8")).rejects.toThrow();
+
+      const payloadRuntime = await resolvePackagedLauncherRuntime(config, paths, {
+        currentExecutablePath: payloadExecutablePath,
+      });
+      expect(payloadRuntime.selection.reason).toBe("active");
+      expect(JSON.parse(await readFile(payloadRuntime.launcherPaths.attemptsPath, "utf8"))).toMatchObject({
         channel: "beta",
         generation: 1,
         namespace: config.namespace,
@@ -147,9 +167,40 @@ describe("resolvePackagedLauncherRuntime", () => {
         version: "1.2.3-beta.5",
       });
 
-      await confirmPackagedLauncherRuntime(runtime);
-      await expect(readFile(runtime.launcherPaths.attemptsPath, "utf8")).rejects.toThrow();
-      expect(JSON.parse(await readFile(runtime.launcherPaths.runtimePath, "utf8"))).toMatchObject({
+      const handoff: LauncherDesktopHandoffDescriptor = {
+        channel: "beta",
+        createdAt: "2026-07-15T01:00:00.000Z",
+        handoffId: "f5d4a712-8ba9-4c28-bcad-6dbed5db2d7c",
+        namespace: config.namespace,
+        outer: {
+          executablePath: process.execPath,
+          pid: process.pid,
+        },
+        payloadExecutablePath,
+        previous: { generation: 0, version: "1.2.3-beta.4" },
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+        source: { generation: 1, version: "1.2.3-beta.5" },
+        state: "armed",
+        target: { generation: 1, version: "1.2.3-beta.5" },
+        updatedAt: "2026-07-15T01:00:00.000Z",
+      };
+      await writeFile(payloadRuntime.launcherPaths.handoffPath, `${JSON.stringify(handoff)}\n`);
+
+      const resumedRuntime = await resolvePackagedLauncherRuntime(config, paths, {
+        currentExecutablePath: payloadExecutablePath,
+        resume: { handoffId: handoff.handoffId },
+      });
+      expect(resumedRuntime.selection.reason).toBe("active-resume");
+
+      await confirmPackagedLauncherRuntime(resumedRuntime);
+      await expect(readFile(resumedRuntime.launcherPaths.attemptsPath, "utf8")).rejects.toThrow();
+      expect(JSON.parse(await readFile(resumedRuntime.launcherPaths.handoffPath, "utf8"))).toMatchObject({
+        previous: { generation: 0, version: "1.2.3-beta.4" },
+        source: { generation: 1, version: "1.2.3-beta.5" },
+        state: "confirmed",
+        target: { generation: 1, version: "1.2.3-beta.5" },
+      });
+      expect(JSON.parse(await readFile(resumedRuntime.launcherPaths.runtimePath, "utf8"))).toMatchObject({
         active: { generation: 1, version: "1.2.3-beta.5" },
         lastSuccessful: { generation: 1, version: "1.2.3-beta.5" },
       });

--- a/apps/packaged/tests/payload-desktop-launch.test.ts
+++ b/apps/packaged/tests/payload-desktop-launch.test.ts
@@ -1,0 +1,131 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { parseLauncherAfterQuitArgs } from "@open-design/launcher-proto";
+import { readProcessStamp } from "@open-design/platform";
+import {
+  APP_KEYS,
+  OPEN_DESIGN_SIDECAR_CONTRACT,
+  SIDECAR_MODES,
+  SIDECAR_SOURCES,
+  type SidecarStamp,
+} from "@open-design/sidecar-proto";
+import { describe, expect, it, vi } from "vitest";
+
+import type { PackagedLauncherRuntime } from "../src/launcher-runtime.js";
+import {
+  launchPackagedPayloadDesktop,
+  planPackagedPayloadDesktopDelegation,
+} from "../src/payload-desktop-launch.js";
+
+const stamp: SidecarStamp = {
+  app: APP_KEYS.DESKTOP,
+  ipc: "/tmp/open-design/ipc/release-beta/desktop.sock",
+  mode: SIDECAR_MODES.RUNTIME,
+  namespace: "release-beta",
+  source: SIDECAR_SOURCES.PACKAGED,
+};
+
+function fakeRuntime(payloadDesktopProcess: boolean): PackagedLauncherRuntime {
+  return {
+    config: {} as PackagedLauncherRuntime["config"],
+    desktopExecutablePath: "/tmp/payload/Open Design Beta.app/Contents/MacOS/Open Design Beta",
+    descriptor: {} as PackagedLauncherRuntime["descriptor"],
+    electronNodeCommand: null,
+    installedLaunchPath: "/Applications/Open Design Beta.app",
+    launcherPaths: {} as PackagedLauncherRuntime["launcherPaths"],
+    paths: {} as PackagedLauncherRuntime["paths"],
+    payloadDesktopProcess,
+    selection: {
+      pointer: { generation: 1, version: "1.2.3-beta.5" },
+      reason: "active",
+      selected: true,
+    },
+    source: "payload",
+    targetVersion: "1.2.3-beta.5",
+  };
+}
+
+describe("payload desktop delegation", () => {
+  it("plans an early outer-to-payload handoff with stable after-quit and stamp args", () => {
+    const runtime = fakeRuntime(false);
+    const plan = planPackagedPayloadDesktopDelegation(runtime, stamp, {
+      currentPid: 4321,
+      timeoutMs: 60_000,
+    });
+
+    expect(plan).toEqual(expect.objectContaining({
+      command: runtime.desktopExecutablePath,
+      cwd: dirname(runtime.desktopExecutablePath ?? ""),
+    }));
+    expect(parseLauncherAfterQuitArgs(plan?.args ?? [])).toEqual({
+      targetPid: 4321,
+      timeoutMs: 60_000,
+    });
+    expect(readProcessStamp(plan?.args ?? [], OPEN_DESIGN_SIDECAR_CONTRACT)).toEqual(stamp);
+  });
+
+  it("does not delegate once the current process already is the payload desktop", () => {
+    expect(planPackagedPayloadDesktopDelegation(fakeRuntime(true), stamp, {
+      currentPid: 4321,
+      timeoutMs: 60_000,
+    })).toBeNull();
+  });
+
+  it("waits for spawn acceptance and detaches the payload child", async () => {
+    const once = vi.fn((event: string, callback: (...args: unknown[]) => void) => {
+      if (event === "spawn") queueMicrotask(callback);
+      return child;
+    });
+    const child = {
+      once,
+      unref: vi.fn(),
+    };
+    const spawn = vi.fn(() => child);
+
+    const delegated = await launchPackagedPayloadDesktop(fakeRuntime(false), stamp, {
+      currentPid: 4321,
+      spawn: spawn as never,
+      timeoutMs: 60_000,
+    });
+
+    expect(delegated).toBe(true);
+    expect(spawn).toHaveBeenCalledOnce();
+    expect(child.unref).toHaveBeenCalledOnce();
+  });
+
+  it("records a failed attempt when the payload executable cannot spawn", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-payload-desktop-spawn-failure-"));
+    const runtime = fakeRuntime(false);
+    runtime.launcherPaths = {
+      attemptsPath: join(root, "state", "attempt.json"),
+      channel: "beta",
+      namespace: "release-beta",
+    } as PackagedLauncherRuntime["launcherPaths"];
+    const spawnError = new Error("spawn EACCES");
+    const child = {
+      once: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
+        if (event === "error") queueMicrotask(() => callback(spawnError));
+        return child;
+      }),
+      unref: vi.fn(),
+    };
+    try {
+      await expect(launchPackagedPayloadDesktop(runtime, stamp, {
+        spawn: vi.fn(() => child) as never,
+      })).rejects.toThrow("spawn EACCES");
+
+      expect(JSON.parse(await readFile(runtime.launcherPaths.attemptsPath, "utf8"))).toMatchObject({
+        channel: "beta",
+        generation: 1,
+        namespace: "release-beta",
+        schemaVersion: 1,
+        version: "1.2.3-beta.5",
+      });
+      expect(child.unref).not.toHaveBeenCalled();
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/e2e/lib/vitest/tools-serve-updater-fixture.ts
+++ b/e2e/lib/vitest/tools-serve-updater-fixture.ts
@@ -7,6 +7,9 @@ import type { ReleaseChannel } from '@open-design/release';
 export type ToolsServeUpdaterFixture = {
   close: () => Promise<void>;
   info: {
+    artifactPath: string | null;
+    artifactSha256: string;
+    artifactUrl: string;
     metadataUrl: string;
     payloadPath: string | null;
     payloadSha256: string | null;
@@ -16,8 +19,9 @@ export type ToolsServeUpdaterFixture = {
 };
 
 export async function startToolsServeUpdaterFixture(options: {
+  artifactPath?: string;
   channel: ReleaseChannel;
-  payloadPath: string;
+  payloadPath?: string;
   platform: 'mac' | 'win';
   version: string;
   workspaceRoot: string;
@@ -35,10 +39,9 @@ export async function startToolsServeUpdaterFixture(options: {
     options.version,
     '--platform',
     options.platform,
-    '--include-payload',
-    '--payload-path',
-    options.payloadPath,
   ];
+  if (options.artifactPath != null) pnpmArgs.push('--artifact-path', options.artifactPath);
+  if (options.payloadPath != null) pnpmArgs.push('--include-payload', '--payload-path', options.payloadPath);
   const command = process.platform === 'win32' ? (process.env.ComSpec ?? 'cmd.exe') : 'pnpm';
   const args = process.platform === 'win32' ? ['/d', '/s', '/c', 'pnpm.cmd', ...pnpmArgs] : pnpmArgs;
   const child = spawn(command, args, {
@@ -127,14 +130,23 @@ async function readStartupInfo(
 }
 
 function parseInfo(line: string): ToolsServeUpdaterFixture['info'] {
-  const parsed = JSON.parse(line) as Partial<ToolsServeUpdaterFixture['info']>;
+  const parsed = JSON.parse(line) as Partial<ToolsServeUpdaterFixture['info']> & { sha256?: unknown };
   if (typeof parsed.metadataUrl !== 'string' || parsed.metadataUrl.length === 0) {
     throw new Error(`tools-serve updater fixture did not print metadataUrl: ${line}`);
   }
   if (typeof parsed.version !== 'string' || parsed.version.length === 0) {
     throw new Error(`tools-serve updater fixture did not print version: ${line}`);
   }
+  if (typeof parsed.sha256 !== 'string' || parsed.sha256.length === 0) {
+    throw new Error(`tools-serve updater fixture did not print artifact sha256: ${line}`);
+  }
+  if (typeof parsed.artifactUrl !== 'string' || parsed.artifactUrl.length === 0) {
+    throw new Error(`tools-serve updater fixture did not print artifactUrl: ${line}`);
+  }
   return {
+    artifactPath: typeof parsed.artifactPath === 'string' ? parsed.artifactPath : null,
+    artifactSha256: parsed.sha256,
+    artifactUrl: parsed.artifactUrl,
     metadataUrl: parsed.metadataUrl,
     payloadPath: typeof parsed.payloadPath === 'string' ? parsed.payloadPath : null,
     payloadSha256: typeof parsed.payloadSha256 === 'string' ? parsed.payloadSha256 : null,

--- a/e2e/specs/mac.spec.ts
+++ b/e2e/specs/mac.spec.ts
@@ -49,25 +49,40 @@ const healthExpression = `
     };
   })()
 `;
-const pptxExportExpression = `
+const upgradePersistenceProjectId = `packaged-upgrade-persistence-${Date.now().toString(36)}`;
+const upgradePersistenceSeedExpression = `
   (async () => {
-    const projectId = 'packaged-payload-pptx-' + Date.now().toString(36);
+    const projectId = ${JSON.stringify(upgradePersistenceProjectId)};
     const html = '<!doctype html><html><head><style>' +
       'html,body{margin:0}.slide{width:1920px;height:1080px;display:flex;align-items:center;justify-content:center;font:96px sans-serif;color:white}' +
       '.slide:first-child{background:#17324d}.slide:last-child{background:#8b3a2b}' +
-      '</style></head><body><section class="slide">Payload One</section><section class="slide">Payload Two</section></body></html>';
+      '</style></head><body><section class="slide">Upgrade From Outer</section><section class="slide">Persistence Check</section></body></html>';
     const created = await fetch('/api/projects', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id: projectId, name: 'Packaged payload PPTX' }),
+      body: JSON.stringify({ id: projectId, name: 'Packaged upgrade persistence' }),
     });
-    if (!created.ok) throw new Error('project create failed: ' + created.status);
-    const written = await fetch('/api/projects/' + encodeURIComponent(projectId) + '/files', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: 'deck.html', content: html }),
-    });
-    if (!written.ok) throw new Error('deck write failed: ' + written.status);
+    const written = created.ok
+      ? await fetch('/api/projects/' + encodeURIComponent(projectId) + '/files', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'deck.html', content: html }),
+        })
+      : null;
+    return {
+      createdOk: created.ok,
+      createdStatus: created.status,
+      projectId,
+      writtenOk: written?.ok ?? false,
+      writtenStatus: written?.status ?? null,
+    };
+  })()
+`;
+
+function existingProjectPptxExportExpression(projectId: string): string {
+  return `
+  (async () => {
+    const projectId = ${JSON.stringify(projectId)};
     const exported = await fetch('/api/projects/' + encodeURIComponent(projectId) + '/export/pptx', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -82,7 +97,8 @@ const pptxExportExpression = `
       status: exported.status,
     };
   })()
-`;
+  `;
+}
 const updaterPopupExpression = `
   (() => {
     const popup = document.querySelector('[data-testid="updater-popup"]');
@@ -268,6 +284,14 @@ type PptxExportEvalValue = {
   status: number;
 };
 
+type UpgradePersistenceSeed = {
+  createdOk: boolean;
+  createdStatus: number;
+  projectId: string;
+  writtenOk: boolean;
+  writtenStatus: number | null;
+};
+
 type DesktopIdentityMarker = {
   appPath: string;
   executablePath: string;
@@ -280,6 +304,7 @@ type PayloadRuntimeAcceptance = {
     health: HealthEvalValue;
     identity: DesktopIdentityMarker;
     launcher: LauncherSnapshot;
+    pptx: PptxExportEvalValue;
     start: MacStartResult;
   };
   identity: DesktopIdentityMarker;
@@ -337,6 +362,7 @@ macDescribe('packaged mac runtime smoke', () => {
     let updateInstall: NonNullable<MacInspectResult['update']> | { skipped: true } = { skipped: true };
     let updateStatus: NonNullable<MacInspectResult['update']> | { skipped: true } = { skipped: true };
     let payloadRuntime: PayloadRuntimeAcceptance | { skipped: true } = { skipped: true };
+    let upgradePersistence: UpgradePersistenceSeed | { skipped: true } = { skipped: true };
     let passed = false;
     try {
       const install = await runToolsPackJson<MacInstallResult>('install');
@@ -407,6 +433,12 @@ macDescribe('packaged mac runtime smoke', () => {
         if (updaterVersion == null || updaterVersion.length === 0) {
           throw new Error('full packaged mac payload smoke requires an update target version');
         }
+        const persistenceInspect = await runToolsPackJson<MacInspectResult>('inspect', [
+          '--expr',
+          upgradePersistenceSeedExpression,
+        ]);
+        const persistence = assertUpgradePersistenceSeed(persistenceInspect.eval?.value);
+        upgradePersistence = persistence;
         const readyUpdate = await waitForUpdaterStatus(
           (status) =>
             status.update?.state === 'downloaded' &&
@@ -445,8 +477,20 @@ macDescribe('packaged mac runtime smoke', () => {
         expect(postUpdateHealth.status).toBe(200);
         expect(postUpdateHealth.health.ok).toBe(true);
         expect(postUpdateHealth.health.version).toBe(updaterVersion);
-        assertLauncherPointer(postUpdateInspect.launcher.active, updaterVersion, 1, 'post-relaunch active');
-        assertLauncherPointer(postUpdateInspect.launcher.lastSuccessful, updaterVersion, 1, 'post-relaunch lastSuccessful');
+        const confirmedGeneration = settledLauncherGeneration(postUpdateInspect.launcher, updaterVersion);
+        if (confirmedGeneration == null) throw new Error('post-update launcher did not settle on the target version');
+        assertLauncherPointer(
+          postUpdateInspect.launcher.active,
+          updaterVersion,
+          confirmedGeneration,
+          'post-relaunch active',
+        );
+        assertLauncherPointer(
+          postUpdateInspect.launcher.lastSuccessful,
+          updaterVersion,
+          confirmedGeneration,
+          'post-relaunch lastSuccessful',
+        );
         const terminalUpdate = await waitForUpdaterStatus(
           (status) => status.update?.state === 'not-available' && status.update.currentVersion === updaterVersion,
           'post-relaunch updater terminal state',
@@ -459,8 +503,10 @@ macDescribe('packaged mac runtime smoke', () => {
         expect(postUpdateInspect.launcher.attempt).toBeNull();
         assertSettledDesktopHandoff(postUpdateInspect.launcher.handoff);
 
-        const pptxInspect = await runToolsPackJson<MacInspectResult>('inspect', ['--expr', pptxExportExpression]);
+        const persistedPptxExpression = existingProjectPptxExportExpression(persistence.projectId);
+        const pptxInspect = await runToolsPackJson<MacInspectResult>('inspect', ['--expr', persistedPptxExpression]);
         const pptx = assertPptxExportEvalValue(pptxInspect.eval?.value);
+        expect(pptx.projectId).toBe(persistence.projectId);
 
         const coldStop = await runToolsPackJson<MacStopResult>('stop');
         started = false;
@@ -476,13 +522,14 @@ macDescribe('packaged mac runtime smoke', () => {
         expect(coldHealth.status).toBe(200);
         expect(coldHealth.health.ok).toBe(true);
         expect(coldHealth.health.version).toBe(updaterVersion);
-        const confirmedGeneration = postUpdateInspect.launcher.active?.generation;
-        if (confirmedGeneration == null) throw new Error('post-update launcher active pointer is missing');
-        assertLauncherPointer(coldInspect.launcher.active, updaterVersion, confirmedGeneration, 'cold-start active');
+        const coldGeneration = settledLauncherGeneration(coldInspect.launcher, updaterVersion);
+        if (coldGeneration == null) throw new Error('cold-start launcher did not settle on the target version');
+        expect(coldGeneration).toBeGreaterThanOrEqual(confirmedGeneration);
+        assertLauncherPointer(coldInspect.launcher.active, updaterVersion, coldGeneration, 'cold-start active');
         assertLauncherPointer(
           coldInspect.launcher.lastSuccessful,
           updaterVersion,
-          confirmedGeneration,
+          coldGeneration,
           'cold-start lastSuccessful',
         );
         expect(coldInspect.launcher.attempt).toBeNull();
@@ -490,11 +537,15 @@ macDescribe('packaged mac runtime smoke', () => {
         const coldIdentity = await readDesktopIdentityMarker();
         assertPayloadDesktopIdentity(coldIdentity, coldInspect.launcher, updaterVersion);
         expect(coldIdentity.pid).not.toBe(identity.pid);
+        const coldPptxInspect = await runToolsPackJson<MacInspectResult>('inspect', ['--expr', persistedPptxExpression]);
+        const coldPptx = assertPptxExportEvalValue(coldPptxInspect.eval?.value);
+        expect(coldPptx.projectId).toBe(persistence.projectId);
         payloadRuntime = {
           coldStart: {
             health: coldHealth,
             identity: coldIdentity,
             launcher: coldInspect.launcher,
+            pptx: coldPptx,
             start: coldStart,
           },
           identity,
@@ -552,6 +603,7 @@ macDescribe('packaged mac runtime smoke', () => {
           status: updateStatus,
           install: updateInstall,
         },
+        upgradePersistence,
       });
       passed = true;
     } finally {
@@ -2056,7 +2108,8 @@ async function waitForHealthyDesktopVersion(expectedVersion: string, previousPid
           value?.status === 200 &&
           value.health.ok === true &&
           value.health.version === expectedVersion &&
-          (previousPid == null || inspect.status.pid !== previousPid)
+          (previousPid == null || inspect.status.pid !== previousPid) &&
+          settledLauncherGeneration(inspect.launcher, expectedVersion) != null
         ) {
           return inspect;
         }
@@ -2227,6 +2280,22 @@ function assertPptxExportEvalValue(value: unknown): PptxExportEvalValue {
   return value as PptxExportEvalValue;
 }
 
+function assertUpgradePersistenceSeed(value: unknown): UpgradePersistenceSeed {
+  if (
+    !isRecord(value) ||
+    typeof value.createdOk !== 'boolean' ||
+    typeof value.createdStatus !== 'number' ||
+    typeof value.projectId !== 'string' ||
+    typeof value.writtenOk !== 'boolean' ||
+    (value.writtenStatus != null && typeof value.writtenStatus !== 'number')
+  ) {
+    throw new Error(`unexpected upgrade persistence seed value: ${formatUnknown(value)}`);
+  }
+  expect(value.createdOk).toBe(true);
+  expect(value.writtenOk).toBe(true);
+  return value as UpgradePersistenceSeed;
+}
+
 function assertSettledDesktopHandoff(value: unknown | null): void {
   if (value == null) return;
   if (!isRecord(value)) throw new Error(`invalid launcher desktop handoff: ${formatUnknown(value)}`);
@@ -2243,6 +2312,25 @@ function assertLauncherPointer(
     generation: expectedGeneration,
     version: expectedVersion,
   });
+}
+
+function settledLauncherGeneration(launcher: LauncherSnapshot, expectedVersion: string): number | null {
+  const active = launcher.active;
+  const lastSuccessful = launcher.lastSuccessful;
+  if (
+    active == null ||
+    lastSuccessful == null ||
+    active.version !== expectedVersion ||
+    lastSuccessful.version !== expectedVersion ||
+    active.generation !== lastSuccessful.generation ||
+    launcher.attempt != null
+  ) {
+    return null;
+  }
+  if (launcher.handoff != null && (!isRecord(launcher.handoff) || launcher.handoff.state !== 'confirmed')) {
+    return null;
+  }
+  return active.generation;
 }
 
 function assertLogPathsAndContent(result: LogsResult): void {

--- a/e2e/specs/mac.spec.ts
+++ b/e2e/specs/mac.spec.ts
@@ -49,6 +49,40 @@ const healthExpression = `
     };
   })()
 `;
+const pptxExportExpression = `
+  (async () => {
+    const projectId = 'packaged-payload-pptx-' + Date.now().toString(36);
+    const html = '<!doctype html><html><head><style>' +
+      'html,body{margin:0}.slide{width:1920px;height:1080px;display:flex;align-items:center;justify-content:center;font:96px sans-serif;color:white}' +
+      '.slide:first-child{background:#17324d}.slide:last-child{background:#8b3a2b}' +
+      '</style></head><body><section class="slide">Payload One</section><section class="slide">Payload Two</section></body></html>';
+    const created = await fetch('/api/projects', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: projectId, name: 'Packaged payload PPTX' }),
+    });
+    if (!created.ok) throw new Error('project create failed: ' + created.status);
+    const written = await fetch('/api/projects/' + encodeURIComponent(projectId) + '/files', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'deck.html', content: html }),
+    });
+    if (!written.ok) throw new Error('deck write failed: ' + written.status);
+    const exported = await fetch('/api/projects/' + encodeURIComponent(projectId) + '/export/pptx', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fileName: 'deck.html' }),
+    });
+    const bytes = new Uint8Array(await exported.arrayBuffer());
+    return {
+      byteLength: bytes.length,
+      contentType: exported.headers.get('content-type'),
+      magic: String.fromCharCode(...bytes.slice(0, 2)),
+      projectId,
+      status: exported.status,
+    };
+  })()
+`;
 const updaterPopupExpression = `
   (() => {
     const popup = document.querySelector('[data-testid="updater-popup"]');
@@ -194,6 +228,8 @@ type LauncherSnapshot = {
   channel: string;
   error?: string;
   exists: boolean;
+  handoff: unknown | null;
+  handoffPath: string;
   lastSuccessful: LauncherPointer | null;
   namespace: string;
   root: string;
@@ -222,6 +258,32 @@ type HealthEvalValue = {
   href: string;
   status: number;
   title: string;
+};
+
+type PptxExportEvalValue = {
+  byteLength: number;
+  contentType: string | null;
+  magic: string;
+  projectId: string;
+  status: number;
+};
+
+type DesktopIdentityMarker = {
+  appPath: string;
+  executablePath: string;
+  pid: number;
+  version: number;
+};
+
+type PayloadRuntimeAcceptance = {
+  coldStart: {
+    health: HealthEvalValue;
+    identity: DesktopIdentityMarker;
+    launcher: LauncherSnapshot;
+    start: MacStartResult;
+  };
+  identity: DesktopIdentityMarker;
+  pptx: PptxExportEvalValue;
 };
 
 type UpdaterPopupEvalValue = {
@@ -274,6 +336,7 @@ macDescribe('packaged mac runtime smoke', () => {
     let popup: UpdaterPopupEvalValue | { skipped: true } = { skipped: true };
     let updateInstall: NonNullable<MacInspectResult['update']> | { skipped: true } = { skipped: true };
     let updateStatus: NonNullable<MacInspectResult['update']> | { skipped: true } = { skipped: true };
+    let payloadRuntime: PayloadRuntimeAcceptance | { skipped: true } = { skipped: true };
     let passed = false;
     try {
       const install = await runToolsPackJson<MacInstallResult>('install');
@@ -390,6 +453,53 @@ macDescribe('packaged mac runtime smoke', () => {
         );
         if (terminalUpdate.update == null) throw new Error('mac terminal update status is missing');
         updateInstall = terminalUpdate.update;
+
+        const identity = await readDesktopIdentityMarker();
+        assertPayloadDesktopIdentity(identity, postUpdateInspect.launcher, updaterVersion);
+        expect(postUpdateInspect.launcher.attempt).toBeNull();
+        assertSettledDesktopHandoff(postUpdateInspect.launcher.handoff);
+
+        const pptxInspect = await runToolsPackJson<MacInspectResult>('inspect', ['--expr', pptxExportExpression]);
+        const pptx = assertPptxExportEvalValue(pptxInspect.eval?.value);
+
+        const coldStop = await runToolsPackJson<MacStopResult>('stop');
+        started = false;
+        expect(coldStop.status).not.toBe('partial');
+        expect(coldStop.remainingPids).toEqual([]);
+
+        const coldStart = await runToolsPackJson<MacStartResult>('start');
+        started = true;
+        expect(coldStart.source).toBe('installed');
+        expect(coldStart.appPath).toBe(install.installedAppPath);
+        const coldInspect = await waitForHealthyDesktopVersion(updaterVersion, identity.pid);
+        const coldHealth = assertHealthEvalValue(coldInspect.eval?.value);
+        expect(coldHealth.status).toBe(200);
+        expect(coldHealth.health.ok).toBe(true);
+        expect(coldHealth.health.version).toBe(updaterVersion);
+        const confirmedGeneration = postUpdateInspect.launcher.active?.generation;
+        if (confirmedGeneration == null) throw new Error('post-update launcher active pointer is missing');
+        assertLauncherPointer(coldInspect.launcher.active, updaterVersion, confirmedGeneration, 'cold-start active');
+        assertLauncherPointer(
+          coldInspect.launcher.lastSuccessful,
+          updaterVersion,
+          confirmedGeneration,
+          'cold-start lastSuccessful',
+        );
+        expect(coldInspect.launcher.attempt).toBeNull();
+        assertSettledDesktopHandoff(coldInspect.launcher.handoff);
+        const coldIdentity = await readDesktopIdentityMarker();
+        assertPayloadDesktopIdentity(coldIdentity, coldInspect.launcher, updaterVersion);
+        expect(coldIdentity.pid).not.toBe(identity.pid);
+        payloadRuntime = {
+          coldStart: {
+            health: coldHealth,
+            identity: coldIdentity,
+            launcher: coldInspect.launcher,
+            start: coldStart,
+          },
+          identity,
+          pptx,
+        };
       }
 
       await mkdir(dirname(screenshotPath), { recursive: true });
@@ -425,6 +535,7 @@ macDescribe('packaged mac runtime smoke', () => {
         },
         logs: 'skipped' in logs ? logs : summarizeLogs(logs),
         namespace,
+        payloadRuntime,
         screenshot: report.screenshotRelpath,
         start: {
           appPath: start.appPath,
@@ -462,7 +573,7 @@ macDescribe('packaged mac runtime smoke', () => {
         installedAppPath = null;
       }
     }
-  }, 180_000);
+  }, 240_000);
 });
 
 macOnboardingDescribe('packaged mac onboarding AMR smoke', () => {
@@ -2068,6 +2179,58 @@ async function waitForUpdaterPopupMatching(
   }
 
   throw new Error(`${label}: updater popup timed out: ${formatUnknown(lastResult)}`);
+}
+
+async function readDesktopIdentityMarker(): Promise<DesktopIdentityMarker> {
+  const markerPath = join(runtimeNamespaceRoot, 'runtime', 'desktop-root.json');
+  const value = JSON.parse(await readFile(markerPath, 'utf8')) as unknown;
+  if (
+    !isRecord(value) ||
+    typeof value.appPath !== 'string' ||
+    typeof value.executablePath !== 'string' ||
+    typeof value.pid !== 'number' ||
+    value.version !== 1
+  ) {
+    throw new Error(`invalid packaged desktop identity at ${markerPath}: ${formatUnknown(value)}`);
+  }
+  return value as DesktopIdentityMarker;
+}
+
+function assertPayloadDesktopIdentity(
+  identity: DesktopIdentityMarker,
+  launcher: LauncherSnapshot,
+  version: string,
+): void {
+  const payloadRoot = join(launcher.versionsRoot, version, 'payload');
+  expect(identity.pid).toBeGreaterThan(0);
+  expectPathInside(identity.appPath, payloadRoot);
+  expectPathInside(identity.executablePath, payloadRoot);
+}
+
+function assertPptxExportEvalValue(value: unknown): PptxExportEvalValue {
+  if (
+    !isRecord(value) ||
+    typeof value.byteLength !== 'number' ||
+    (value.contentType != null && typeof value.contentType !== 'string') ||
+    typeof value.magic !== 'string' ||
+    typeof value.projectId !== 'string' ||
+    typeof value.status !== 'number'
+  ) {
+    throw new Error(`unexpected PPTX export eval value: ${formatUnknown(value)}`);
+  }
+  expect(value.status).toBe(200);
+  expect(value.contentType).toContain(
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  );
+  expect(value.byteLength).toBeGreaterThan(0);
+  expect(value.magic).toBe('PK');
+  return value as PptxExportEvalValue;
+}
+
+function assertSettledDesktopHandoff(value: unknown | null): void {
+  if (value == null) return;
+  if (!isRecord(value)) throw new Error(`invalid launcher desktop handoff: ${formatUnknown(value)}`);
+  expect(value.state).toBe('confirmed');
 }
 
 function assertLauncherPointer(

--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -1,6 +1,8 @@
 // @vitest-environment node
 
 import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
 import { mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { basename, dirname, isAbsolute, join, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -27,15 +29,17 @@ const maxInstallDurationMs = Number.parseInt(process.env.OD_PACKAGED_E2E_WIN_MAX
 const smokeProfile = process.env.OD_PACKAGED_E2E_WIN_SMOKE_PROFILE ?? 'core';
 const verifyCoreOnly = smokeProfile === 'core';
 const verifyReinstallWhileRunning = !verifyCoreOnly && process.env.OD_PACKAGED_E2E_WIN_VERIFY_REINSTALL !== '0';
+const verifyUpgradePersistence =
+  !verifyCoreOnly && process.env.OD_PACKAGED_E2E_WIN_VERIFY_UPGRADE_PERSISTENCE === '1';
 const updateMetadataUrl = normalizeOptionalEnv(process.env.OD_PACKAGED_E2E_WIN_UPDATE_METADATA_URL);
 const updateVersion = normalizeOptionalEnv(process.env.OD_PACKAGED_E2E_WIN_UPDATE_VERSION);
 const updateBuildJsonPath = normalizeOptionalEnv(process.env.OD_PACKAGED_E2E_WIN_UPDATE_BUILD_JSON_PATH);
 const updateFixture = normalizeOptionalEnv(process.env.OD_PACKAGED_E2E_WIN_UPDATE_FIXTURE);
+const updateFixtureMode = resolveUpdateFixtureMode(process.env.OD_PACKAGED_E2E_WIN_UPDATE_MODE);
 const releaseChannel = process.env.OD_PACKAGED_E2E_RELEASE_CHANNEL;
 const releaseVersion = process.env.OD_PACKAGED_E2E_RELEASE_VERSION;
 const updateScenario = resolvePackagedUpdateScenario({ releaseChannel, releaseVersion });
 const installIdentity = resolvePackagedWinInstallIdentity({ namespace, releaseVersion });
-const toolsPackReleaseVersionArgs = releaseAppVersionArgs(releaseVersion);
 
 const outputNamespaceRoot = join(toolsPackDir, 'out', 'win', 'namespaces', namespace);
 const runtimeNamespaceRoot = join(toolsPackDir, 'runtime', 'win', 'namespaces', namespace);
@@ -107,6 +111,56 @@ const pptxExportExpression = `
     };
   })()
 `;
+const upgradePersistenceProjectId = `packaged-upgrade-persistence-${Date.now().toString(36)}`;
+const upgradePersistenceSeedExpression = `
+  (async () => {
+    const projectId = ${JSON.stringify(upgradePersistenceProjectId)};
+    const html = '<!doctype html><html><head><style>' +
+      'html,body{margin:0}.slide{width:1920px;height:1080px;display:flex;align-items:center;justify-content:center;font:96px sans-serif;color:white}' +
+      '.slide:first-child{background:#17324d}.slide:last-child{background:#8b3a2b}' +
+      '</style></head><body><section class="slide">Upgrade From 0.12</section><section class="slide">Persistence Check</section></body></html>';
+    const created = await fetch('/api/projects', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: projectId, name: 'Packaged upgrade persistence' }),
+    });
+    const written = created.ok
+      ? await fetch('/api/projects/' + encodeURIComponent(projectId) + '/files', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name: 'deck.html', content: html }),
+        })
+      : null;
+    return {
+      createdOk: created.ok,
+      createdStatus: created.status,
+      projectId,
+      writtenOk: written?.ok ?? false,
+      writtenStatus: written?.status ?? null,
+    };
+  })()
+`;
+
+function existingProjectPptxExportExpression(projectId: string): string {
+  return `
+    (async () => {
+      const projectId = ${JSON.stringify(projectId)};
+      const exported = await fetch('/api/projects/' + encodeURIComponent(projectId) + '/export/pptx', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ fileName: 'deck.html' }),
+      });
+      const bytes = new Uint8Array(await exported.arrayBuffer());
+      return {
+        byteLength: bytes.length,
+        contentType: exported.headers.get('content-type'),
+        magic: String.fromCharCode(...bytes.slice(0, 2)),
+        projectId,
+        status: exported.status,
+      };
+    })()
+  `;
+}
 const updaterPopupExpression = `
   (() => {
     const popup = document.querySelector('[data-testid="updater-popup"]');
@@ -268,6 +322,21 @@ type WinUninstallResult = {
   residueObservation?: WinCleanupResult['residueObservation'];
 };
 
+type WinListResult = {
+  current: {
+    installDir: string;
+    installedExeExists: boolean;
+    installedExePath: string;
+    registryEntries: Array<{
+      displayName: string | null;
+      displayVersion: string | null;
+      installLocation: string | null;
+      keyPath: string;
+    }>;
+    registryResidues: string[];
+  };
+};
+
 type WinInspectResult = {
   daemonStatus: DesktopStatus | null;
   daemonStatusError?: string;
@@ -370,6 +439,14 @@ type PptxExportEvalValue = {
   status: number;
 };
 
+type UpgradePersistenceSeed = {
+  createdOk: boolean;
+  createdStatus: number;
+  projectId: string;
+  writtenOk: boolean;
+  writtenStatus: number | null;
+};
+
 type DesktopIdentityMarker = {
   appPath: string;
   executablePath: string;
@@ -417,6 +494,8 @@ type DirectInstallerResult = {
   nsisLogTail: string[];
 };
 
+type UpdateFixtureMode = 'installer' | 'payload';
+
 const shouldRunPackagedWinSmoke = process.platform === 'win32' && process.env.OD_PACKAGED_E2E_WIN === '1';
 const winDescribe = shouldRunPackagedWinSmoke ? describe : describe.skip;
 const shouldRunPackagedWinOnboardingSmoke =
@@ -431,11 +510,12 @@ winDescribe('packaged windows runtime smoke', () => {
     const report = await createPackagedSmokeReport('win');
     let passed = false;
     const timings: SmokeTiming[] = [];
-    let payloadUpdate: PayloadUpdateSummary | { skipped: true } = { skipped: true };
+    let payloadUpdate: InstallerFallbackSummary | PayloadUpdateSummary | { skipped: true } = { skipped: true };
     let reinstall: DirectInstallerResult | { skipped: true } = { skipped: true };
     let logs: LogsResult | { skipped: true } = { skipped: true };
     let stop: WinStopResult | { skipped: true } = { skipped: true };
     let postUpdateHealth: HealthEvalValue | { skipped: true } = { skipped: true };
+    let upgradePersistence: UpgradePersistenceSeed | { skipped: true } = { skipped: true };
     let payloadFixture: ToolsServeUpdaterFixture | null = null;
     const updateEnv = captureUpdateEnv();
     try {
@@ -491,13 +571,14 @@ winDescribe('packaged windows runtime smoke', () => {
           applyPackagedUpdateEnv(process.env, updateScenario, updateMetadataUrl, { openDryRun: false });
         } else {
           assertToolsServeFixtureEnabled('Windows', updateFixture);
-          const localPayload = await resolveLocalPayloadUpdateFixture();
-          expectedPayloadUpdateVersion = localPayload.targetVersion;
+          const localUpdate = await resolveLocalUpdateFixture();
+          expectedPayloadUpdateVersion = localUpdate.targetVersion;
           payloadFixture = await startToolsServeUpdaterFixture({
+            ...(updateFixtureMode === 'installer' ? { artifactPath: localUpdate.installerPath } : {}),
             channel: updateScenario.channel,
-            payloadPath: localPayload.payloadPath,
+            ...(updateFixtureMode === 'payload' ? { payloadPath: localUpdate.payloadPath } : {}),
             platform: 'win',
-            version: localPayload.targetVersion,
+            version: localUpdate.targetVersion,
             workspaceRoot,
           });
           applyPackagedUpdateEnv(process.env, updateScenario, payloadFixture.info.metadataUrl, { openDryRun: false });
@@ -530,6 +611,13 @@ winDescribe('packaged windows runtime smoke', () => {
       if (!inspect.desktopIpcUnavailable) {
         await measureSmokeStep(timings, 'ensure main app shell', async () => ensureMainAppShell());
 
+        if (verifyUpgradePersistence) {
+          const seedInspect = await measureSmokeStep(timings, 'seed pre-update persistence project', async () =>
+            runToolsPackJson<WinInspectResult>('inspect', ['--expr', upgradePersistenceSeedExpression]),
+          );
+          upgradePersistence = assertUpgradePersistenceSeed(seedInspect.eval?.value);
+        }
+
         await mkdir(dirname(preUpdateScreenshotPath), { recursive: true });
         const preUpdateScreenshot = await measureSmokeStep(timings, 'inspect screenshot before update', async () =>
           runToolsPackJson<WinInspectResult>('inspect', ['--path', preUpdateScreenshotPath]),
@@ -537,13 +625,21 @@ winDescribe('packaged windows runtime smoke', () => {
         expect(preUpdateScreenshot.screenshot?.path).toBe(preUpdateScreenshotPath);
         expect(await fileSizeBytes(preUpdateScreenshotPath)).toBeGreaterThan(0);
         await report.report.save('screenshots/open-design-win-before-update.png', await readFile(preUpdateScreenshotPath));
+      } else if (verifyUpgradePersistence) {
+        throw new Error('upgrade persistence validation requires desktop IPC eval support');
       }
 
       if (!verifyCoreOnly) {
-        payloadUpdate = await measureSmokeStep(timings, 'payload update acceptance', async () =>
-          runPayloadUpdateAcceptance({
-            expectedVersion: expectedPayloadUpdateVersion,
-          }),
+        const persistedProjectId = 'skipped' in upgradePersistence ? null : upgradePersistence.projectId;
+        payloadUpdate = await measureSmokeStep(timings, `${updateFixtureMode} update acceptance`, async () =>
+          updateFixtureMode === 'installer'
+            ? runInstallerFallbackAcceptance({
+                expectedVersion: expectedPayloadUpdateVersion,
+                fixture: payloadFixture,
+                installDir: install.installDir,
+                persistedProjectId,
+              })
+            : runPayloadUpdateAcceptance({ expectedVersion: expectedPayloadUpdateVersion, persistedProjectId }),
         );
         postUpdateHealth = payloadUpdate.health;
       }
@@ -648,6 +744,7 @@ winDescribe('packaged windows runtime smoke', () => {
           before: value,
           after: postUpdateHealth,
         },
+        upgradePersistence,
       });
       printLifecycleTimings('install lifecycle timings', install.lifecycleTimings);
       printLifecycleTimings('uninstall lifecycle timings', uninstall.lifecycleTimings);
@@ -882,10 +979,27 @@ type PayloadUpdateSummary = {
   targetVersion: string;
 };
 
+type InstallerFallbackSummary = {
+  coldStart: {
+    health: HealthEvalValue;
+    start: WinStartResult;
+    stop: WinStopResult;
+  };
+  downloaded: NonNullable<WinInspectResult['update']>;
+  downloadedSha256: string;
+  fixtureSha256: string;
+  health: HealthEvalValue;
+  install: DirectInstallerResult;
+  list: WinListResult;
+  pptx: PptxExportEvalValue;
+  targetVersion: string;
+};
+
 async function runPayloadUpdateAcceptance(options: {
   expectedVersion: string | null;
+  persistedProjectId: string | null;
 }): Promise<PayloadUpdateSummary> {
-  const downloadedInspect = await waitForDownloadedUpdater(options.expectedVersion);
+  const downloadedInspect = await waitForDownloadedUpdater(options.expectedVersion, 'payload');
   if (downloadedInspect.update == null) throw new Error('payload update download did not return update status');
   const targetVersion = downloadedInspect.update.availableVersion;
   if (targetVersion == null || targetVersion.length === 0) {
@@ -913,15 +1027,26 @@ async function runPayloadUpdateAcceptance(options: {
   expect(health.status).toBe(200);
   expect(health.health.ok).toBe(true);
   expect(health.health.version).toBe(targetVersion);
-  assertLauncherPointer(postUpdateInspect.launcher.active, targetVersion, 1, 'post-relaunch active');
-  assertLauncherPointer(postUpdateInspect.launcher.lastSuccessful, targetVersion, 1, 'post-relaunch lastSuccessful');
+  const confirmedGeneration = settledLauncherGeneration(postUpdateInspect.launcher, targetVersion);
+  if (confirmedGeneration == null) throw new Error('post-update launcher did not settle on the target version');
+  assertLauncherPointer(postUpdateInspect.launcher.active, targetVersion, confirmedGeneration, 'post-relaunch active');
+  assertLauncherPointer(
+    postUpdateInspect.launcher.lastSuccessful,
+    targetVersion,
+    confirmedGeneration,
+    'post-relaunch lastSuccessful',
+  );
   expect(postUpdateInspect.launcher.attempt).toBeNull();
   assertSettledDesktopHandoff(postUpdateInspect.launcher.handoff);
   const identity = await readDesktopIdentityMarker();
   assertPayloadDesktopIdentity(identity, postUpdateInspect.launcher, targetVersion);
 
-  const pptxInspect = await runToolsPackJson<WinInspectResult>('inspect', ['--expr', pptxExportExpression]);
+  const pptxExpression = options.persistedProjectId == null
+    ? pptxExportExpression
+    : existingProjectPptxExportExpression(options.persistedProjectId);
+  const pptxInspect = await runToolsPackJson<WinInspectResult>('inspect', ['--expr', pptxExpression]);
   const pptx = assertPptxExportEvalValue(pptxInspect.eval?.value);
+  if (options.persistedProjectId != null) expect(pptx.projectId).toBe(options.persistedProjectId);
   const terminal = await waitForTerminalUpdateState(targetVersion);
   if (terminal.update == null) throw new Error('payload update terminal state did not return update status');
 
@@ -936,13 +1061,14 @@ async function runPayloadUpdateAcceptance(options: {
   expect(coldHealth.status).toBe(200);
   expect(coldHealth.health.ok).toBe(true);
   expect(coldHealth.health.version).toBe(targetVersion);
-  const confirmedGeneration = postUpdateInspect.launcher.active?.generation;
-  if (confirmedGeneration == null) throw new Error('post-update launcher active pointer is missing');
-  assertLauncherPointer(coldInspect.launcher.active, targetVersion, confirmedGeneration, 'cold-start active');
+  const coldGeneration = settledLauncherGeneration(coldInspect.launcher, targetVersion);
+  if (coldGeneration == null) throw new Error('cold-start launcher did not settle on the target version');
+  expect(coldGeneration).toBeGreaterThanOrEqual(confirmedGeneration);
+  assertLauncherPointer(coldInspect.launcher.active, targetVersion, coldGeneration, 'cold-start active');
   assertLauncherPointer(
     coldInspect.launcher.lastSuccessful,
     targetVersion,
-    confirmedGeneration,
+    coldGeneration,
     'cold-start lastSuccessful',
   );
   expect(coldInspect.launcher.attempt).toBeNull();
@@ -969,7 +1095,93 @@ async function runPayloadUpdateAcceptance(options: {
   };
 }
 
+async function runInstallerFallbackAcceptance(options: {
+  expectedVersion: string | null;
+  fixture: ToolsServeUpdaterFixture | null;
+  installDir: string;
+  persistedProjectId: string | null;
+}): Promise<InstallerFallbackSummary> {
+  if (options.fixture == null) throw new Error('installer fallback requires a tools-serve fixture');
+  if (options.fixture.info.artifactPath == null) throw new Error('installer fallback fixture did not expose its artifact path');
+  const downloadedInspect = await waitForDownloadedUpdater(options.expectedVersion, 'installer');
+  if (downloadedInspect.update == null) throw new Error('installer update download did not return update status');
+  const targetVersion = downloadedInspect.update.availableVersion;
+  const downloadPath = downloadedInspect.update.downloadPath;
+  if (targetVersion == null || targetVersion.length === 0 || downloadPath == null || downloadPath.length === 0) {
+    throw new Error(`installer update did not report target version and path: ${formatUnknown(downloadedInspect.update)}`);
+  }
+  expectPathInside(downloadPath, join(runtimeNamespaceRoot, 'updates'));
+  const downloadedSha256 = await sha256File(downloadPath);
+  expect(downloadedSha256).toBe(options.fixture.info.artifactSha256);
+
+  const fixtureNamespaceRoot = dirname(dirname(options.fixture.info.artifactPath));
+  const install = await runDirectInstaller(
+    downloadPath,
+    options.installDir,
+    join(fixtureNamespaceRoot, 'logs', 'nsis.log'),
+  );
+  expect(install.code).toBe(0);
+  expect(install.nsisLogTail.join('\n')).toContain('running instances detected before silent install');
+  expect(install.nsisLogTail.join('\n')).toMatch(/running instances close via (?:pwsh|powershell)\.exe exit=0/);
+  process.env.OD_UPDATE_CURRENT_VERSION = targetVersion;
+
+  const start = await runToolsPackJsonForVersion<WinStartResult>('start', targetVersion);
+  expect(start.source).toBe('installed');
+  expect(start.executablePath).toBe(join(options.installDir, 'Open Design.exe'));
+  const postInstallInspect = await waitForHealthyDesktopVersion(targetVersion, downloadedInspect.status?.pid, false);
+  const health = assertHealthEvalValue(postInstallInspect.eval?.value);
+  expect(health.status).toBe(200);
+  expect(health.health.ok).toBe(true);
+  expect(health.health.version).toBe(targetVersion);
+
+  const list = await runToolsPackJsonForVersion<WinListResult>('list', targetVersion);
+  expect(list.current.installedExeExists).toBe(true);
+  expect(list.current.installedExePath).toBe(start.executablePath);
+  expect(list.current.installDir).toBe(options.installDir);
+  expect(list.current.registryEntries).toHaveLength(1);
+  expect(list.current.registryResidues).toHaveLength(1);
+  expect(list.current.registryEntries[0]?.displayName).toBe(installIdentity.displayName);
+  expect(list.current.registryEntries[0]?.displayVersion).toBe(targetVersion);
+  expect(list.current.registryEntries[0]?.installLocation).toBe(options.installDir);
+
+  const pptxExpression = options.persistedProjectId == null
+    ? pptxExportExpression
+    : existingProjectPptxExportExpression(options.persistedProjectId);
+  const pptxInspect = await runToolsPackJsonForVersion<WinInspectResult>('inspect', targetVersion, ['--expr', pptxExpression]);
+  const pptx = assertPptxExportEvalValue(pptxInspect.eval?.value);
+  if (options.persistedProjectId != null) expect(pptx.projectId).toBe(options.persistedProjectId);
+
+  const stop = await runToolsPackJsonForVersion<WinStopResult>('stop', targetVersion);
+  expect(stop.status).not.toBe('partial');
+  expect(stop.remainingPids).toEqual([]);
+  const coldStart = await runToolsPackJsonForVersion<WinStartResult>('start', targetVersion);
+  const coldInspect = await waitForHealthyDesktopVersion(targetVersion, postInstallInspect.status?.pid, false);
+  const coldHealth = assertHealthEvalValue(coldInspect.eval?.value);
+  expect(coldHealth.status).toBe(200);
+  expect(coldHealth.health.ok).toBe(true);
+  expect(coldHealth.health.version).toBe(targetVersion);
+  return {
+    coldStart: { health: coldHealth, start: coldStart, stop },
+    downloaded: downloadedInspect.update,
+    downloadedSha256,
+    fixtureSha256: options.fixture.info.artifactSha256,
+    health,
+    install,
+    list,
+    pptx,
+    targetVersion,
+  };
+}
+
 async function runToolsPackJson<T>(action: string, extraArgs: string[] = []): Promise<T> {
+  return runToolsPackJsonForVersion(action, releaseVersion, extraArgs);
+}
+
+async function runToolsPackJsonForVersion<T>(
+  action: string,
+  appVersion: string | null | undefined,
+  extraArgs: string[] = [],
+): Promise<T> {
   const args = [
     toolsPackBin,
     'win',
@@ -978,7 +1190,7 @@ async function runToolsPackJson<T>(action: string, extraArgs: string[] = []): Pr
     toolsPackDir,
     '--namespace',
     namespace,
-    ...toolsPackReleaseVersionArgs,
+    ...releaseAppVersionArgs(appVersion),
     '--json',
     ...extraArgs,
   ];
@@ -1008,8 +1220,12 @@ async function runToolsPackJson<T>(action: string, extraArgs: string[] = []): Pr
 }
 
 
-async function runDirectInstaller(installerPath: string, installDir: string): Promise<DirectInstallerResult> {
-  const previousLogLines = await readNsisLogLines();
+async function runDirectInstaller(
+  installerPath: string,
+  installDir: string,
+  nsisLogPath = join(outputNamespaceRoot, 'logs', 'nsis.log'),
+): Promise<DirectInstallerResult> {
+  const previousLogLines = await readNsisLogLines(nsisLogPath);
   const command =
     process.platform === 'win32'
       ? execFileAsync(
@@ -1044,16 +1260,16 @@ async function runDirectInstaller(installerPath: string, installDir: string): Pr
   const code = isExecError(error) ? Number(error.code) : error == null ? 0 : null;
   return {
     code,
-    nsisLogTail: (await readNsisLogLines()).slice(previousLogLines.length),
+    nsisLogTail: (await readNsisLogLines(nsisLogPath)).slice(previousLogLines.length),
   };
 }
 
-async function readNsisLogLines(): Promise<string[]> {
-  const raw = await readFile(join(outputNamespaceRoot, 'logs', 'nsis.log'), 'utf8').catch(() => '');
+async function readNsisLogLines(nsisLogPath = join(outputNamespaceRoot, 'logs', 'nsis.log')): Promise<string[]> {
+  const raw = await readFile(nsisLogPath, 'utf8').catch(() => '');
   return raw.split(/\r?\n/).filter((line) => line.length > 0);
 }
 
-async function resolveLocalPayloadUpdateFixture(): Promise<{ payloadPath: string; targetVersion: string }> {
+async function resolveLocalUpdateFixture(): Promise<{ installerPath: string; payloadPath: string; targetVersion: string }> {
   const fallbackBuildJsonPath = resolveFallbackUpdateBuildJsonPath();
   if (fallbackBuildJsonPath == null) {
     throw new Error(
@@ -1061,9 +1277,13 @@ async function resolveLocalPayloadUpdateFixture(): Promise<{ payloadPath: string
     );
   }
   const updateBuild = JSON.parse(stripUtf8Bom(await readFile(fallbackBuildJsonPath, 'utf8'))) as {
+    installerPath?: unknown;
     latestYmlPath?: unknown;
     payloadPath?: unknown;
   };
+  if (typeof updateBuild.installerPath !== 'string' || updateBuild.installerPath.length === 0) {
+    throw new Error(`upgrade build metadata missing installerPath: ${fallbackBuildJsonPath}`);
+  }
   if (typeof updateBuild.payloadPath !== 'string' || updateBuild.payloadPath.length === 0) {
     throw new Error(`upgrade build metadata missing payloadPath: ${fallbackBuildJsonPath}`);
   }
@@ -1076,12 +1296,17 @@ async function resolveLocalPayloadUpdateFixture(): Promise<{ payloadPath: string
     throw new Error(`upgrade build metadata missing version: ${fallbackBuildJsonPath}`);
   }
   return {
+    installerPath: resolveFromWorkspace(updateBuild.installerPath),
     payloadPath: resolveFromWorkspace(updateBuild.payloadPath),
     targetVersion,
   };
 }
 
-async function waitForDownloadedUpdater(expectedVersion: string | null, timeoutMs = 120_000): Promise<WinInspectResult> {
+async function waitForDownloadedUpdater(
+  expectedVersion: string | null,
+  expectedArtifactType: UpdateFixtureMode,
+  timeoutMs = 120_000,
+): Promise<WinInspectResult> {
   const startedAt = Date.now();
   let lastResult: unknown = null;
   while (Date.now() - startedAt < timeoutMs) {
@@ -1098,7 +1323,7 @@ async function waitForDownloadedUpdater(expectedVersion: string | null, timeoutM
         if (expectedVersion != null && expectedVersion !== '') {
           expect(inspect.update.availableVersion).toBe(expectedVersion);
         }
-        expect(inspect.update.artifact?.type).toBe('payload');
+        expect(inspect.update.artifact?.type).toBe(expectedArtifactType);
         expect(inspect.update.channel).toBe(updateScenario.channel);
         expect(inspect.update.currentVersion).toBe(updateScenario.expectedCurrentVersion);
         return inspect;
@@ -1108,7 +1333,7 @@ async function waitForDownloadedUpdater(expectedVersion: string | null, timeoutM
     }
     await delay(1000);
   }
-  throw new Error(`external Windows updater did not download an installer: ${formatUnknown(lastResult)}`);
+  throw new Error(`external Windows updater did not download ${expectedArtifactType}: ${formatUnknown(lastResult)}`);
 }
 
 function assertLauncherPointer(
@@ -1121,6 +1346,25 @@ function assertLauncherPointer(
     generation: expectedGeneration,
     version: expectedVersion,
   });
+}
+
+function settledLauncherGeneration(launcher: LauncherSnapshot, expectedVersion: string): number | null {
+  const active = launcher.active;
+  const lastSuccessful = launcher.lastSuccessful;
+  if (
+    active == null ||
+    lastSuccessful == null ||
+    active.version !== expectedVersion ||
+    lastSuccessful.version !== expectedVersion ||
+    active.generation !== lastSuccessful.generation ||
+    launcher.attempt != null
+  ) {
+    return null;
+  }
+  if (launcher.handoff != null && (!isRecord(launcher.handoff) || launcher.handoff.state !== 'confirmed')) {
+    return null;
+  }
+  return active.generation;
 }
 
 function resolveFallbackUpdateBuildJsonPath(): string | null {
@@ -1273,7 +1517,11 @@ async function ensureMainAppShell(timeoutMs = 45_000): Promise<void> {
   throw new Error(`packaged windows runtime did not reach main app shell: ${formatUnknown(lastResult)}`);
 }
 
-async function waitForHealthyDesktopVersion(expectedVersion: string, previousPid: number | null | undefined): Promise<WinInspectResult> {
+async function waitForHealthyDesktopVersion(
+  expectedVersion: string,
+  previousPid: number | null | undefined,
+  requireSettledLauncher = true,
+): Promise<WinInspectResult> {
   const timeoutMs = 120_000;
   const startedAt = Date.now();
   let lastResult: unknown = null;
@@ -1302,7 +1550,8 @@ async function waitForHealthyDesktopVersion(expectedVersion: string, previousPid
           value?.status === 200 &&
           value.health.ok === true &&
           value.health.version === expectedVersion &&
-          (previousPid == null || inspect.status?.pid !== previousPid)
+          (previousPid == null || inspect.status?.pid !== previousPid) &&
+          (!requireSettledLauncher || settledLauncherGeneration(inspect.launcher, expectedVersion) != null)
         ) {
           return inspect;
         }
@@ -1532,6 +1781,22 @@ function assertPptxExportEvalValue(value: unknown): PptxExportEvalValue {
   return value as PptxExportEvalValue;
 }
 
+function assertUpgradePersistenceSeed(value: unknown): UpgradePersistenceSeed {
+  if (
+    !isRecord(value) ||
+    typeof value.createdOk !== 'boolean' ||
+    typeof value.createdStatus !== 'number' ||
+    typeof value.projectId !== 'string' ||
+    typeof value.writtenOk !== 'boolean' ||
+    (value.writtenStatus != null && typeof value.writtenStatus !== 'number')
+  ) {
+    throw new Error(`unexpected upgrade persistence seed value: ${formatUnknown(value)}`);
+  }
+  expect(value.createdOk).toBe(true);
+  expect(value.writtenOk).toBe(true);
+  return value as UpgradePersistenceSeed;
+}
+
 function assertSettledDesktopHandoff(value: unknown | null): void {
   if (value == null) return;
   if (!isRecord(value)) throw new Error(`invalid launcher desktop handoff: ${formatUnknown(value)}`);
@@ -1725,6 +1990,17 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
 }
 
+async function sha256File(path: string): Promise<string> {
+  const hash = createHash('sha256');
+  const stream = createReadStream(path);
+  await new Promise<void>((resolveHash, rejectHash) => {
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.once('error', rejectHash);
+    stream.once('end', resolveHash);
+  });
+  return hash.digest('hex');
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value != null && !Array.isArray(value);
 }
@@ -1750,4 +2026,10 @@ function formatUnknown(value: unknown): string {
 function normalizeOptionalEnv(value: string | undefined): string | null {
   const normalized = value?.trim();
   return normalized == null || normalized.length === 0 ? null : normalized;
+}
+
+function resolveUpdateFixtureMode(value: string | undefined): UpdateFixtureMode {
+  const normalized = normalizeOptionalEnv(value) ?? 'payload';
+  if (normalized === 'installer' || normalized === 'payload') return normalized;
+  throw new Error(`OD_PACKAGED_E2E_WIN_UPDATE_MODE must be installer or payload, received ${JSON.stringify(normalized)}`);
 }

--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -73,6 +73,40 @@ const healthExpression = `
     }
   })()
 `;
+const pptxExportExpression = `
+  (async () => {
+    const projectId = 'packaged-payload-pptx-' + Date.now().toString(36);
+    const html = '<!doctype html><html><head><style>' +
+      'html,body{margin:0}.slide{width:1920px;height:1080px;display:flex;align-items:center;justify-content:center;font:96px sans-serif;color:white}' +
+      '.slide:first-child{background:#17324d}.slide:last-child{background:#8b3a2b}' +
+      '</style></head><body><section class="slide">Payload One</section><section class="slide">Payload Two</section></body></html>';
+    const created = await fetch('/api/projects', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: projectId, name: 'Packaged payload PPTX' }),
+    });
+    if (!created.ok) throw new Error('project create failed: ' + created.status);
+    const written = await fetch('/api/projects/' + encodeURIComponent(projectId) + '/files', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'deck.html', content: html }),
+    });
+    if (!written.ok) throw new Error('deck write failed: ' + written.status);
+    const exported = await fetch('/api/projects/' + encodeURIComponent(projectId) + '/export/pptx', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fileName: 'deck.html' }),
+    });
+    const bytes = new Uint8Array(await exported.arrayBuffer());
+    return {
+      byteLength: bytes.length,
+      contentType: exported.headers.get('content-type'),
+      magic: String.fromCharCode(...bytes.slice(0, 2)),
+      projectId,
+      status: exported.status,
+    };
+  })()
+`;
 const updaterPopupExpression = `
   (() => {
     const popup = document.querySelector('[data-testid="updater-popup"]');
@@ -290,6 +324,8 @@ type LauncherSnapshot = {
   channel: string;
   error?: string;
   exists: boolean;
+  handoff: unknown | null;
+  handoffPath: string;
   lastSuccessful: LauncherPointer | null;
   namespace: string;
   root: string;
@@ -324,6 +360,21 @@ type HealthEvalValue = {
   href: string;
   status: number;
   title: string;
+};
+
+type PptxExportEvalValue = {
+  byteLength: number;
+  contentType: string | null;
+  magic: string;
+  projectId: string;
+  status: number;
+};
+
+type DesktopIdentityMarker = {
+  appPath: string;
+  executablePath: string;
+  pid: number;
+  version: number;
 };
 
 type UpdaterPopupEvalValue = {
@@ -388,6 +439,9 @@ winDescribe('packaged windows runtime smoke', () => {
     let payloadFixture: ToolsServeUpdaterFixture | null = null;
     const updateEnv = captureUpdateEnv();
     try {
+      if (!verifyCoreOnly && updateScenario.channel === 'beta') {
+        expect(namespace).toBe('release-beta-win');
+      }
       await measureSmokeStep(timings, 'pre-clean uninstall', async () => {
         await runToolsPackJson<WinUninstallResult>('uninstall', ['--remove-product-user-data']).catch(() => null);
       });
@@ -811,10 +865,19 @@ function printLifecycleTimings(title: string, timings: SmokeTiming[] | undefined
 }
 
 type PayloadUpdateSummary = {
+  coldStart: {
+    health: HealthEvalValue;
+    identity: DesktopIdentityMarker;
+    launcher: LauncherSnapshot;
+    start: WinStartResult;
+    stop: WinStopResult;
+  };
   downloaded: NonNullable<WinInspectResult['update']>;
   health: HealthEvalValue;
+  identity: DesktopIdentityMarker;
   launcherAfterConfirm: LauncherSnapshot;
   popup: UpdaterPopupEvalValue;
+  pptx: PptxExportEvalValue;
   terminal: NonNullable<WinInspectResult['update']>;
   targetVersion: string;
 };
@@ -852,13 +915,55 @@ async function runPayloadUpdateAcceptance(options: {
   expect(health.health.version).toBe(targetVersion);
   assertLauncherPointer(postUpdateInspect.launcher.active, targetVersion, 1, 'post-relaunch active');
   assertLauncherPointer(postUpdateInspect.launcher.lastSuccessful, targetVersion, 1, 'post-relaunch lastSuccessful');
+  expect(postUpdateInspect.launcher.attempt).toBeNull();
+  assertSettledDesktopHandoff(postUpdateInspect.launcher.handoff);
+  const identity = await readDesktopIdentityMarker();
+  assertPayloadDesktopIdentity(identity, postUpdateInspect.launcher, targetVersion);
+
+  const pptxInspect = await runToolsPackJson<WinInspectResult>('inspect', ['--expr', pptxExportExpression]);
+  const pptx = assertPptxExportEvalValue(pptxInspect.eval?.value);
   const terminal = await waitForTerminalUpdateState(targetVersion);
   if (terminal.update == null) throw new Error('payload update terminal state did not return update status');
+
+  const stop = await runToolsPackJson<WinStopResult>('stop');
+  expect(stop.status).not.toBe('partial');
+  expect(stop.remainingPids).toEqual([]);
+  const start = await runToolsPackJson<WinStartResult>('start');
+  expect(start.source).toBe('installed');
+  const coldInspect = await waitForHealthyDesktopVersion(targetVersion, identity.pid);
+  const coldHealth = assertHealthEvalValue(coldInspect.eval?.value);
+  expectWindowsPackagedAppUrl(coldHealth.href);
+  expect(coldHealth.status).toBe(200);
+  expect(coldHealth.health.ok).toBe(true);
+  expect(coldHealth.health.version).toBe(targetVersion);
+  const confirmedGeneration = postUpdateInspect.launcher.active?.generation;
+  if (confirmedGeneration == null) throw new Error('post-update launcher active pointer is missing');
+  assertLauncherPointer(coldInspect.launcher.active, targetVersion, confirmedGeneration, 'cold-start active');
+  assertLauncherPointer(
+    coldInspect.launcher.lastSuccessful,
+    targetVersion,
+    confirmedGeneration,
+    'cold-start lastSuccessful',
+  );
+  expect(coldInspect.launcher.attempt).toBeNull();
+  assertSettledDesktopHandoff(coldInspect.launcher.handoff);
+  const coldIdentity = await readDesktopIdentityMarker();
+  assertPayloadDesktopIdentity(coldIdentity, coldInspect.launcher, targetVersion);
+  expect(coldIdentity.pid).not.toBe(identity.pid);
   return {
+    coldStart: {
+      health: coldHealth,
+      identity: coldIdentity,
+      launcher: coldInspect.launcher,
+      start,
+      stop,
+    },
     downloaded: downloadedInspect.update,
     health,
+    identity,
     launcherAfterConfirm: postUpdateInspect.launcher,
     popup,
+    pptx,
     terminal: terminal.update,
     targetVersion,
   };
@@ -1380,6 +1485,57 @@ async function printLauncherRuntimeSnapshot(): Promise<void> {
   const content = await readFile(runtimePath, 'utf8').catch(() => null);
   console.error(`[launcher-runtime] ${runtimePath}`);
   console.error(content?.trim() ?? '(missing)');
+}
+
+async function readDesktopIdentityMarker(): Promise<DesktopIdentityMarker> {
+  const markerPath = join(runtimeNamespaceRoot, 'runtime', 'desktop-root.json');
+  const value = JSON.parse(await readFile(markerPath, 'utf8')) as unknown;
+  if (
+    !isRecord(value) ||
+    typeof value.appPath !== 'string' ||
+    typeof value.executablePath !== 'string' ||
+    typeof value.pid !== 'number' ||
+    value.version !== 1
+  ) {
+    throw new Error(`invalid packaged desktop identity at ${markerPath}: ${formatUnknown(value)}`);
+  }
+  return value as DesktopIdentityMarker;
+}
+
+function assertPayloadDesktopIdentity(
+  identity: DesktopIdentityMarker,
+  launcher: LauncherSnapshot,
+  version: string,
+): void {
+  const payloadRoot = join(launcher.versionsRoot, version, 'payload');
+  expect(identity.pid).toBeGreaterThan(0);
+  expectPathInside(identity.executablePath, payloadRoot);
+}
+
+function assertPptxExportEvalValue(value: unknown): PptxExportEvalValue {
+  if (
+    !isRecord(value) ||
+    typeof value.byteLength !== 'number' ||
+    (value.contentType != null && typeof value.contentType !== 'string') ||
+    typeof value.magic !== 'string' ||
+    typeof value.projectId !== 'string' ||
+    typeof value.status !== 'number'
+  ) {
+    throw new Error(`unexpected PPTX export eval value: ${formatUnknown(value)}`);
+  }
+  expect(value.status).toBe(200);
+  expect(value.contentType).toContain(
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  );
+  expect(value.byteLength).toBeGreaterThan(0);
+  expect(value.magic).toBe('PK');
+  return value as PptxExportEvalValue;
+}
+
+function assertSettledDesktopHandoff(value: unknown | null): void {
+  if (value == null) return;
+  if (!isRecord(value)) throw new Error(`invalid launcher desktop handoff: ${formatUnknown(value)}`);
+  expect(value.state).toBe('confirmed');
 }
 
 function assertHealthEvalValue(value: unknown): HealthEvalValue {

--- a/e2e/tests/packaged-launcher-update-loop.test.ts
+++ b/e2e/tests/packaged-launcher-update-loop.test.ts
@@ -74,7 +74,11 @@ type PackagedLauncherRuntime = {
 
 type PackagedLauncherRuntimeModule = {
   confirmPackagedLauncherRuntime: (runtime: PackagedLauncherRuntime) => Promise<void>;
-  resolvePackagedLauncherRuntime: (config: PackagedConfigLike, paths: PackagedPaths) => Promise<PackagedLauncherRuntime>;
+  resolvePackagedLauncherRuntime: (
+    config: PackagedConfigLike,
+    paths: PackagedPaths,
+    options?: { currentExecutablePath?: string },
+  ) => Promise<PackagedLauncherRuntime>;
 };
 
 type FixtureServer = {
@@ -85,6 +89,7 @@ type FixtureServer = {
 type PlatformCase = {
   arch: "arm64" | "x64";
   currentVersion: string;
+  expectedPayloadExecutablePath: (root: string, namespace: string) => string;
   expectedResourceRoot: (root: string, namespace: string) => string;
   fixturePlatformKey: "mac" | "win";
   namespace: "release-beta" | "release-beta-win";
@@ -272,6 +277,8 @@ const platformCases: PlatformCase[] = [
   {
     arch: "x64",
     currentVersion: "1.2.3-beta.4",
+    expectedPayloadExecutablePath: (root, namespace) =>
+      join(root, "launcher", "channels", "beta", "namespaces", namespace, "versions", "1.2.3-beta.5", "payload", "Open Design.exe"),
     expectedResourceRoot: (root, namespace) =>
       join(root, "launcher", "channels", "beta", "namespaces", namespace, "versions", "1.2.3-beta.5", "payload", "resources", "open-design"),
     fixturePlatformKey: "win",
@@ -285,6 +292,8 @@ const platformCases: PlatformCase[] = [
   {
     arch: "arm64",
     currentVersion: "1.2.3-beta.4",
+    expectedPayloadExecutablePath: (root, namespace) =>
+      join(root, "launcher", "channels", "beta", "namespaces", namespace, "versions", "1.2.3-beta.5", "payload", "Open Design Beta.app", "Contents", "MacOS", "Open Design Beta"),
     expectedResourceRoot: (root, namespace) =>
       join(root, "launcher", "channels", "beta", "namespaces", namespace, "versions", "1.2.3-beta.5", "payload", "Open Design Beta.app", "Contents", "Resources", "open-design"),
     fixturePlatformKey: "mac",
@@ -366,7 +375,7 @@ describe("packaged launcher payload update loop", () => {
       expect(launchRequests).toEqual([
         {
           appPid: process.pid,
-          launchPath: initialRuntime.installedLaunchPath,
+          launchPath: testCase.expectedPayloadExecutablePath(paths.installationRoot, config.namespace),
           root: await realpath(paths.updateRoot),
         },
       ]);
@@ -378,7 +387,9 @@ describe("packaged launcher payload update loop", () => {
       expect(runtimeAfterApply.active).toEqual({ generation: 1, version: testCase.promotedVersion });
       expect(runtimeAfterApply.lastSuccessful).toEqual({ generation: 0, version: testCase.currentVersion });
 
-      const promoted = await resolvePackagedLauncherRuntime(config, paths);
+      const promoted = await resolvePackagedLauncherRuntime(config, paths, {
+        currentExecutablePath: testCase.expectedPayloadExecutablePath(paths.installationRoot, config.namespace),
+      });
       expect(promoted.source).toBe("payload");
       expect(promoted.targetVersion).toBe(testCase.promotedVersion);
       expect(promoted.config.appVersion).toBe(testCase.promotedVersion);

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1236,6 +1236,7 @@ process.stdin.on("end", () => {
     expect(releaseBetaWorkflow).toContain("RELEASE_TARGET: win_x64");
     expect(releaseBetaWorkflow).toContain("RELEASE_TARGET: mac_x64");
     expect(releaseBetaWorkflow).toContain("RELEASE_TARGET: linux_x64");
+    expect(releaseBetaWorkflow).toContain("OD_PACKAGED_E2E_MAC_UPDATE_FIXTURE: ${{ inputs.mac_arm64_smoke_mode == 'full' && inputs.mac_arm64_update_metadata_url == '' && inputs.mac_arm64_update_target_version == '' && 'tools-serve' || '' }}");
     const betaWinJob = sectionBetween(releaseBetaWorkflow, "  build_win_x64:", "  build_linux_x64:");
     expect(betaWinJob).not.toContain("tools\\release\\scripts\\build-platform.ps1");
     expect(betaWinJob).toContain("uses: actions/cache/restore@v5");

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -21,6 +21,7 @@ const reportWorkflowPath = join(workspaceRoot, ".github", "workflows", "report.a
 const bakePluginPreviewsWorkflowPath = join(workspaceRoot, ".github", "workflows", "bake-plugin-previews.yml");
 const bakePluginPreviewsPrWorkflowPath = join(workspaceRoot, ".github", "workflows", "bake-plugin-previews-pr.yml");
 const dockerImageWorkflowPath = join(workspaceRoot, ".github", "workflows", "docker-image.yml");
+const flakePath = join(workspaceRoot, "flake.nix");
 const backportAutomergeWorkflowPath = join(workspaceRoot, ".github", "workflows", "backport-automerge.yml");
 const bakePreviewsAutomergeWorkflowPath = join(
   workspaceRoot,
@@ -970,6 +971,16 @@ process.stdin.on("end", () => {
       web_workspace_tests: { result: "failure" },
     };
     await expect(validateGatePasses(workflow, needsWithFailedWeb)).resolves.toBe(false);
+  });
+
+  it("[P1] includes launcher protocol in the Nix daemon workspace build", async () => {
+    const flake = await readFile(flakePath, "utf8");
+    const daemonWorkspaces = sectionBetween(flake, "      daemonWorkspacePaths = [", "      ];");
+
+    expect(daemonWorkspaces).toContain('"packages/launcher-proto"');
+    expect(daemonWorkspaces.indexOf('"packages/launcher-proto"')).toBeLessThan(
+      daemonWorkspaces.indexOf('"apps/daemon"'),
+    );
   });
 
   it("[P2] routes default CI through cost-sensitive runner tiers", async () => {

--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,7 @@
         "packages/agui-adapter"
         "packages/plugin-runtime"
         "packages/sidecar-proto"
+        "packages/launcher-proto"
         "packages/sidecar"
         "packages/platform"
         "packages/diagnostics"

--- a/packages/launcher-proto/src/index.ts
+++ b/packages/launcher-proto/src/index.ts
@@ -7,6 +7,7 @@ export const LAUNCHER_SCHEMA_VERSION = 1 as const;
 export const LAUNCHER_AFTER_QUIT_FLAG = "--od-launcher-after-quit" as const;
 export const LAUNCHER_AFTER_QUIT_TARGET_PID_ARG = "--od-launcher-target-pid" as const;
 export const LAUNCHER_AFTER_QUIT_TIMEOUT_MS_ARG = "--od-launcher-timeout-ms" as const;
+export const LAUNCHER_HANDOFF_RESUME_ARG = "--od-launcher-resume-handoff" as const;
 
 export const LAUNCHER_CHANNELS = Object.freeze({
   BETA: RELEASE_CHANNELS.BETA,
@@ -36,6 +37,7 @@ export type LauncherPaths = {
   channelRoot: string;
   cleanupPath: string;
   downloadsRoot: string;
+  handoffPath: string;
   installPath: string;
   launcherPath: string;
   lockRoot: string;
@@ -81,6 +83,24 @@ export type LauncherAttemptDescriptor = {
   version: string;
 };
 
+export type LauncherDesktopHandoffDescriptor = {
+  channel: LauncherChannel;
+  createdAt: string;
+  handoffId: string;
+  namespace: string;
+  outer: {
+    executablePath: string;
+    pid: number;
+  };
+  payloadExecutablePath: string;
+  previous: LauncherVersionPointer;
+  schemaVersion: typeof LAUNCHER_SCHEMA_VERSION;
+  source: LauncherVersionPointer;
+  state: "armed" | "confirmed" | "prepared";
+  target?: LauncherVersionPointer;
+  updatedAt: string;
+};
+
 export type LauncherCleanupState = "cleanup-deferred" | "cleanup-removed" | "deprecated" | "retained";
 
 export type LauncherCleanupReason =
@@ -112,12 +132,17 @@ export type LauncherCleanupDescriptor = {
 
 export type LauncherTargetSelection =
   | { pointer: LauncherVersionPointer; reason: "active"; selected: true }
+  | { pointer: LauncherVersionPointer; reason: "active-resume"; selected: true }
   | { pointer: LauncherVersionPointer; reason: "last-successful"; selected: true }
   | { reason: "no-runtime-target"; selected: false };
 
 export type LauncherAfterQuitRequest = {
   targetPid: number;
   timeoutMs: number;
+};
+
+export type LauncherHandoffResumeRequest = {
+  handoffId: string;
 };
 
 export class LauncherProtocolError extends Error {
@@ -224,6 +249,13 @@ function valueAfterArg(args: readonly string[], name: string): string | null {
   return args[index + 1] ?? null;
 }
 
+function normalizeLauncherHandoffId(value: unknown): string {
+  if (typeof value !== "string" || !/^[A-Za-z0-9][A-Za-z0-9_-]{15,127}$/.test(value)) {
+    throw new LauncherProtocolError("launcher handoff id must be 16-128 URL-safe characters");
+  }
+  return value;
+}
+
 export function buildLauncherAfterQuitArgs(request: LauncherAfterQuitRequest): string[] {
   return [
     LAUNCHER_AFTER_QUIT_FLAG,
@@ -245,6 +277,17 @@ export function parseLauncherAfterQuitArgs(args: readonly string[]): LauncherAft
       valueAfterArg(args, LAUNCHER_AFTER_QUIT_TIMEOUT_MS_ARG),
       "launcher after-quit timeout",
     ),
+  };
+}
+
+export function buildLauncherHandoffResumeArgs(request: LauncherHandoffResumeRequest): string[] {
+  return [LAUNCHER_HANDOFF_RESUME_ARG, normalizeLauncherHandoffId(request.handoffId)];
+}
+
+export function parseLauncherHandoffResumeArgs(args: readonly string[]): LauncherHandoffResumeRequest | null {
+  if (!args.includes(LAUNCHER_HANDOFF_RESUME_ARG)) return null;
+  return {
+    handoffId: normalizeLauncherHandoffId(valueAfterArg(args, LAUNCHER_HANDOFF_RESUME_ARG)),
   };
 }
 
@@ -288,6 +331,7 @@ export function resolveLauncherPaths(request: LauncherRootRequest): LauncherPath
     channelRoot,
     cleanupPath: assertUnderRoot(root, join(stateRoot, "cleanup.json")),
     downloadsRoot: assertUnderRoot(root, join(updatesRoot, "downloads")),
+    handoffPath: assertUnderRoot(root, join(stateRoot, "desktop-handoff.json")),
     installPath: assertUnderRoot(root, join(namespaceRoot, "install.json")),
     launcherPath,
     lockRoot: assertUnderRoot(root, join(stateRoot, "lock")),
@@ -324,6 +368,12 @@ function normalizePointer(value: LauncherVersionPointer | null): LauncherVersion
     throw new LauncherProtocolError(`launcher generation must be a non-negative safe integer: ${value.generation}`);
   }
   return { generation: value.generation, version };
+}
+
+function normalizeRequiredPointer(value: LauncherVersionPointer | null, label: string): LauncherVersionPointer {
+  const pointer = normalizePointer(value);
+  if (pointer == null) throw new LauncherProtocolError(`${label} is required`);
+  return pointer;
 }
 
 function normalizeOptionalIsoString(value: unknown, label: string): string | undefined {
@@ -430,6 +480,103 @@ export function validateLauncherRuntimeDescriptor(
   };
 }
 
+export function validateLauncherAttemptDescriptor(
+  attempt: LauncherAttemptDescriptor,
+  expected: { channel: string; namespace: string },
+): LauncherAttemptDescriptor {
+  if (attempt.schemaVersion !== LAUNCHER_SCHEMA_VERSION) {
+    throw new LauncherProtocolError(`unsupported launcher attempt schemaVersion: ${String(attempt.schemaVersion)}`);
+  }
+  const channel = normalizeLauncherChannel(attempt.channel);
+  const expectedChannel = normalizeLauncherChannel(expected.channel);
+  if (channel !== expectedChannel) {
+    throw new LauncherProtocolError(`launcher attempt channel ${channel} does not match expected channel ${expectedChannel}`);
+  }
+  const namespace = normalizeLauncherNamespace(attempt.namespace);
+  const expectedNamespace = normalizeLauncherNamespace(expected.namespace);
+  if (namespace !== expectedNamespace) {
+    throw new LauncherProtocolError(`launcher attempt namespace ${namespace} does not match expected namespace ${expectedNamespace}`);
+  }
+  const pointer = normalizeRequiredPointer(attempt, "launcher attempt pointer");
+  return {
+    channel,
+    generation: pointer.generation,
+    namespace,
+    schemaVersion: LAUNCHER_SCHEMA_VERSION,
+    ...(attempt.startedAt == null ? {} : {
+      startedAt: normalizeIsoString(attempt.startedAt, "launcher attempt startedAt"),
+    }),
+    version: pointer.version,
+  };
+}
+
+function normalizeAbsoluteLauncherPath(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0 || value.includes("\0")) {
+    throw new LauncherProtocolError(`${label} must be a non-empty absolute path`);
+  }
+  if (!isAbsolute(value)) throw new LauncherProtocolError(`${label} must be absolute: ${value}`);
+  return resolve(value);
+}
+
+export function validateLauncherDesktopHandoffDescriptor(
+  handoff: LauncherDesktopHandoffDescriptor,
+  expected: { channel: string; namespace: string },
+): LauncherDesktopHandoffDescriptor {
+  if (handoff.schemaVersion !== LAUNCHER_SCHEMA_VERSION) {
+    throw new LauncherProtocolError(`unsupported launcher desktop handoff schemaVersion: ${String(handoff.schemaVersion)}`);
+  }
+  const channel = normalizeLauncherChannel(handoff.channel);
+  const expectedChannel = normalizeLauncherChannel(expected.channel);
+  if (channel !== expectedChannel) {
+    throw new LauncherProtocolError(`launcher desktop handoff channel ${channel} does not match expected channel ${expectedChannel}`);
+  }
+  const namespace = normalizeLauncherNamespace(handoff.namespace);
+  const expectedNamespace = normalizeLauncherNamespace(expected.namespace);
+  if (namespace !== expectedNamespace) {
+    throw new LauncherProtocolError(`launcher desktop handoff namespace ${namespace} does not match expected namespace ${expectedNamespace}`);
+  }
+  if (
+    handoff.state !== "prepared" &&
+    handoff.state !== "armed" &&
+    handoff.state !== "confirmed"
+  ) {
+    throw new LauncherProtocolError(`unsupported launcher desktop handoff state: ${String(handoff.state)}`);
+  }
+  const target = handoff.target == null ? null : normalizePointer(handoff.target);
+  if ((handoff.state === "armed" || handoff.state === "confirmed") && target == null) {
+    throw new LauncherProtocolError(`${handoff.state} launcher desktop handoff requires a target pointer`);
+  }
+  if (handoff.state === "prepared" && target != null) {
+    throw new LauncherProtocolError("prepared launcher desktop handoff must not include a target pointer");
+  }
+  if (handoff.outer == null || typeof handoff.outer !== "object") {
+    throw new LauncherProtocolError("launcher desktop handoff outer identity is required");
+  }
+  return {
+    channel,
+    createdAt: normalizeIsoString(handoff.createdAt, "launcher desktop handoff createdAt"),
+    handoffId: normalizeLauncherHandoffId(handoff.handoffId),
+    namespace,
+    outer: {
+      executablePath: normalizeAbsoluteLauncherPath(
+        handoff.outer.executablePath,
+        "launcher desktop handoff outer executablePath",
+      ),
+      pid: normalizePositiveInteger(handoff.outer.pid, "launcher desktop handoff outer pid"),
+    },
+    payloadExecutablePath: normalizeAbsoluteLauncherPath(
+      handoff.payloadExecutablePath,
+      "launcher desktop handoff payloadExecutablePath",
+    ),
+    previous: normalizeRequiredPointer(handoff.previous, "launcher desktop handoff previous pointer"),
+    schemaVersion: LAUNCHER_SCHEMA_VERSION,
+    source: normalizeRequiredPointer(handoff.source, "launcher desktop handoff source pointer"),
+    state: handoff.state,
+    ...(target == null ? {} : { target }),
+    updatedAt: normalizeIsoString(handoff.updatedAt, "launcher desktop handoff updatedAt"),
+  };
+}
+
 export function validateLauncherCleanupDescriptor(
   cleanup: LauncherCleanupDescriptor,
   expected: { channel: string; namespace: string },
@@ -462,10 +609,12 @@ export function validateLauncherCleanupDescriptor(
 
 export function selectLauncherRuntimeTarget(input: {
   attempted?: LauncherAttemptDescriptor | null;
+  resume?: LauncherVersionPointer | null;
   runtime: LauncherRuntimeDescriptor;
 }): LauncherTargetSelection {
   const active = normalizePointer(input.runtime.active);
   const lastSuccessful = normalizePointer(input.runtime.lastSuccessful);
+  const resume = input.resume == null ? null : normalizePointer(input.resume);
   const attempted = input.attempted == null
     ? null
     : {
@@ -482,9 +631,16 @@ export function selectLauncherRuntimeTarget(input: {
   if (
     attempted != null &&
     attempted.version === active.version &&
-    attempted.generation === active.generation &&
-    lastSuccessful != null
+    attempted.generation === active.generation
   ) {
+    if (
+      resume != null &&
+      resume.version === active.version &&
+      resume.generation === active.generation
+    ) {
+      return { pointer: active, reason: "active-resume", selected: true };
+    }
+    if (lastSuccessful == null) return { pointer: active, reason: "active", selected: true };
     return { pointer: lastSuccessful, reason: "last-successful", selected: true };
   }
 

--- a/packages/launcher-proto/tests/index.test.ts
+++ b/packages/launcher-proto/tests/index.test.ts
@@ -6,14 +6,18 @@ import {
   LAUNCHER_SCHEMA_VERSION,
   LauncherProtocolError,
   buildLauncherAfterQuitArgs,
+  buildLauncherHandoffResumeArgs,
   compareLauncherVersions,
   parseLauncherAfterQuitArgs,
+  parseLauncherHandoffResumeArgs,
   resolveLauncherPaths,
   resolveLauncherVersionPaths,
   selectLauncherRuntimeTarget,
   validateLauncherCleanupDescriptor,
+  validateLauncherDesktopHandoffDescriptor,
   validateLauncherRuntimeDescriptor,
   type LauncherCleanupDescriptor,
+  type LauncherDesktopHandoffDescriptor,
   type LauncherRuntimeDescriptor,
 } from "../src/index.js";
 
@@ -26,6 +30,7 @@ describe("launcher protocol paths", () => {
     expect(paths.namespaceRoot).toBe(join(root, "launcher", "channels", "beta", "namespaces", "release-beta"));
     expect(paths.runtimePath).toBe(join(paths.namespaceRoot, "runtime.json"));
     expect(paths.installPath).toBe(join(paths.namespaceRoot, "install.json"));
+    expect(paths.handoffPath).toBe(join(paths.namespaceRoot, "state", "desktop-handoff.json"));
     expect(paths.downloadsRoot).toBe(join(paths.namespaceRoot, "updates", "downloads"));
     expect(paths.stagingRoot).toBe(join(paths.namespaceRoot, "updates", "staging"));
     expect(paths.releasesRoot).toBe(join(paths.namespaceRoot, "updates", "releases"));
@@ -57,6 +62,22 @@ describe("launcher protocol paths", () => {
     expect(() => resolveLauncherPaths({ channel: "beta", namespace: "release-beta", root: "relative" })).toThrow(LauncherProtocolError);
     expect(() => resolveLauncherVersionPaths({ channel: "beta", namespace: "release-beta", root, version: "../0.8.1" })).toThrow(LauncherProtocolError);
     expect(() => resolveLauncherVersionPaths({ channel: "beta", namespace: "release-beta", root, version: "0.8..1" })).toThrow(LauncherProtocolError);
+  });
+});
+
+describe("launcher handoff resume argv", () => {
+  it("round-trips one opaque handoff id", () => {
+    const args = buildLauncherHandoffResumeArgs({ handoffId: "f5d4a712-8ba9-4c28-bcad-6dbed5db2d7c" });
+
+    expect(parseLauncherHandoffResumeArgs(args)).toEqual({
+      handoffId: "f5d4a712-8ba9-4c28-bcad-6dbed5db2d7c",
+    });
+  });
+
+  it("rejects missing or unsafe handoff ids", () => {
+    expect(parseLauncherHandoffResumeArgs(["--other"])).toBeNull();
+    expect(() => parseLauncherHandoffResumeArgs(["--od-launcher-resume-handoff"])).toThrow(LauncherProtocolError);
+    expect(() => buildLauncherHandoffResumeArgs({ handoffId: "../handoff" })).toThrow(LauncherProtocolError);
   });
 });
 
@@ -116,6 +137,24 @@ describe("launcher runtime descriptors", () => {
       reason: "last-successful",
       selected: true,
     });
+
+    expect(
+      selectLauncherRuntimeTarget({
+        attempted: {
+          channel: "beta",
+          generation: 2,
+          namespace: "release-beta",
+          schemaVersion: LAUNCHER_SCHEMA_VERSION,
+          version: "0.8.1-beta.2",
+        },
+        resume: { generation: 2, version: "0.8.1-beta.2" },
+        runtime,
+      }),
+    ).toEqual({
+      pointer: { generation: 2, version: "0.8.1-beta.2" },
+      reason: "active-resume",
+      selected: true,
+    });
   });
 
   it("falls back cleanly when no active runtime target exists", () => {
@@ -137,6 +176,72 @@ describe("launcher runtime descriptors", () => {
         lastSuccessful: null,
       },
     })).toEqual({ reason: "no-runtime-target", selected: false });
+  });
+});
+
+describe("launcher desktop handoff descriptors", () => {
+  const prepared: LauncherDesktopHandoffDescriptor = {
+    channel: "beta",
+    createdAt: "2026-07-15T01:00:00.000Z",
+    handoffId: "f5d4a712-8ba9-4c28-bcad-6dbed5db2d7c",
+    namespace: "release-beta",
+    outer: {
+      executablePath: process.platform === "win32" ? "C:\\Program Files\\Open Design Beta\\Open Design Beta.exe" : "/Applications/Open Design Beta.app/Contents/MacOS/Open Design Beta",
+      pid: 4321,
+    },
+    payloadExecutablePath: process.platform === "win32" ? "C:\\od-data\\payload\\Open Design Beta.exe" : "/tmp/od-data/payload/Open Design Beta.app/Contents/MacOS/Open Design Beta",
+    previous: { generation: 0, version: "0.8.1-beta.1" },
+    schemaVersion: LAUNCHER_SCHEMA_VERSION,
+    source: { generation: 1, version: "0.8.1-beta.2" },
+    state: "prepared",
+    updatedAt: "2026-07-15T01:00:00.000Z",
+  };
+
+  it("validates prepared, armed, and confirmed recovery state", () => {
+    expect(validateLauncherDesktopHandoffDescriptor(prepared, {
+      channel: "beta",
+      namespace: "release-beta",
+    })).toEqual(prepared);
+
+    expect(validateLauncherDesktopHandoffDescriptor({
+      ...prepared,
+      state: "armed",
+      target: { generation: 2, version: "0.8.1-beta.2" },
+    }, {
+      channel: "beta",
+      namespace: "release-beta",
+    })).toMatchObject({
+      state: "armed",
+      target: { generation: 2, version: "0.8.1-beta.2" },
+    });
+
+    expect(validateLauncherDesktopHandoffDescriptor({
+      ...prepared,
+      source: { generation: 2, version: "0.8.1-beta.2" },
+      state: "confirmed",
+      target: { generation: 2, version: "0.8.1-beta.2" },
+    }, {
+      channel: "beta",
+      namespace: "release-beta",
+    })).toMatchObject({
+      source: { generation: 2, version: "0.8.1-beta.2" },
+      state: "confirmed",
+      target: { generation: 2, version: "0.8.1-beta.2" },
+    });
+  });
+
+  it("rejects an armed handoff without a target and mismatched identity", () => {
+    expect(() => validateLauncherDesktopHandoffDescriptor({
+      ...prepared,
+      state: "armed",
+    }, {
+      channel: "beta",
+      namespace: "release-beta",
+    })).toThrow(LauncherProtocolError);
+    expect(() => validateLauncherDesktopHandoffDescriptor(prepared, {
+      channel: "stable",
+      namespace: "release-beta",
+    })).toThrow(LauncherProtocolError);
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@open-design/diagnostics':
         specifier: workspace:*
         version: link:../../packages/diagnostics
+      '@open-design/launcher-proto':
+        specifier: workspace:*
+        version: link:../../packages/launcher-proto
       '@open-design/platform':
         specifier: workspace:*
         version: link:../../packages/platform

--- a/tools/pack/AGENTS.md
+++ b/tools/pack/AGENTS.md
@@ -43,7 +43,10 @@ Read this section before changing packaged auto-update behavior. The updater cro
 - `apps/desktop/src/main/index.ts` wires the scheduler. Native menu update actions are intentionally not the user-facing surface; the web updater UI owns discovery and action prompts.
 - `apps/web/src/lib/updater.ts` normalizes host updater snapshots into UI-ready state.
 - `apps/web/src/components/UpdaterPopup.tsx` is the visible updater surface in the left rail. All visible copy must go through `apps/web/src/i18n`.
-- `apps/packaged/src/index.ts` passes packaged `appVersion` and namespace-scoped `updateRoot` into desktop main.
+- `packages/launcher-proto` owns launcher pointer, attempt, and desktop-handoff journal shapes plus payload selection. `runtime.json` together with `attempt.json` is the only payload-version state machine.
+- `apps/packaged/src/index.ts` delegates to the selected payload desktop before initializing the outer Electron runtime, then passes packaged `appVersion` and namespace-scoped `updateRoot` into desktop main only when the outer itself must run.
+- `apps/daemon/src/sidecar/payload-desktop-handoff.ts` is the isolated compatibility bridge for historical outers that cannot delegate. It rearms the selected payload with the real previous pointer, launches that payload's desktop after the old outer exits, and persists a small desktop-binding journal for later shortcut cold starts. The journal is not a second version selector.
+- `install.json` continues to identify the physically installed outer executable for recovery. Payload activation or handoff must not rewrite it to a versioned payload executable.
 - `tools/serve` owns deterministic local updater fixtures only. It must not contain product updater runtime logic.
 - `tools/pack` owns packaged build/install/start/inspect/logs/uninstall/cleanup and the platform installer harness, including Windows NSIS registry observation and cleanup.
 
@@ -51,8 +54,7 @@ Read this section before changing packaged auto-update behavior. The updater cro
 
 The runtime updater reads `https://releases.open-design.ai/<channel>/latest/metadata.json` unless `OD_UPDATE_METADATA_URL` overrides it. For package-launcher updates:
 
-- mac selects `platforms.mac.artifacts.dmg`.
-- Windows selects `platforms.win.artifacts.installer`.
+- A valid packaged-launcher context prefers `platforms.<platform>.artifacts.payload`; the platform installer (`dmg` on macOS or `installer` on Windows) remains the recovery/fallback path.
 - The artifact must have a checksum, preferably `sha256Url`; the updater verifies bytes before exposing an install action.
 - `OD_UPDATE_CURRENT_VERSION` may override the packaged version for tests, but user-flow package validation should prefer building the package with the intended `--app-version`.
 - Release metadata may include `releaseNote.content`, with a `defaultLocale` and locale descriptors containing `url`, `mediaType`, `sha256`, and `size`. The updater does not currently consume this block; `tools-release` owns its publication and verification independently from updater UI behavior.
@@ -127,7 +129,9 @@ C:\odtp-beta-release-fixed\out\win\namespaces\release-beta-win\builder\Open Desi
 - For the payload path, the app downloads `platforms.win.artifacts.payload`, verifies sha256, prepares the payload under `%APPDATA%\Open Design\launcher\channels\beta\namespaces\release-beta-win\versions\<version>\payload`, and shows the web updater popup.
 - The native File menu must not expose update actions.
 - The updater popup uses i18n strings and download progress must not flash to 100% before real bytes arrive.
-- Applying the payload update should quit and relaunch into the prepared payload version, then mark launcher `active` and `lastSuccessful` to that version.
+- Applying the payload update should quit and relaunch the exact executable under the prepared version's `payload` directory, then mark launcher `active` and `lastSuccessful` to that version and clear `attempt.json`.
+- A historical outer may first create a mixed generation. Its daemon-sidecar compatibility handoff must replace the historical desktop with the exact payload desktop executable, preserve the true previous pointer for recovery, and leave the handoff journal either absent or `confirmed`—never stranded in `prepared` or `armed`.
+- After a full stop, launching the installed shortcut/outer again must still converge on the same active payload desktop and preserve daemon/API behavior, including a real PPTX export.
 - If the updater falls back to the installer path, clicking `Open installer` opens the real downloaded beta installer. Installing it should overwrite the same `Open Design-release-beta-win` registry key, not create a second beta key.
 
 5. Registry and launcher sanity check after beta.6 update:
@@ -141,7 +145,7 @@ Get-Content "$env:APPDATA\Open Design\launcher\channels\beta\namespaces\release-
 ```
 
 For a clean beta channel result, expect one beta entry with `PSChildName` `Open Design-release-beta-win` and the latest `DisplayVersion`.
-For the payload path, also expect launcher `active.version` and `lastSuccessful.version` to match the latest beta version.
+For the payload path, also expect launcher `active.version` and `lastSuccessful.version` to match the latest beta version, `attempt.json` to be absent, and the running desktop executable to resolve below that version's `payload` directory. `desktop-handoff.json` may be absent for a current outer or `confirmed` for a historical outer; `prepared` and `armed` are not successful terminal states.
 Windows Settings > Apps may cache uninstall metadata within the current view. If Settings still shows the previous beta version after the registry query is correct, switch away from the Apps view and back, or reopen Settings, before treating it as an installer failure. The registry query above is the source of truth for this harness.
 
 6. Avoid leaving validation residue. Stop running app processes first, then use tools-pack uninstall/cleanup for tool-managed namespaces. Only delete explicit temp roots after verifying the resolved path is exactly the intended directory.
@@ -174,3 +178,4 @@ pnpm typecheck
 ```
 
 Run the high-confidence local user-flow acceptance whenever a change touches real release feed selection, channel identity, Windows registry/install behavior, installer opening, or visible updater UI behavior.
+For launcher payload or handoff changes, also run the platform full spec. The full profile must validate exact desktop executable identity, a real PPTX response, a complete stop followed by an installed-outer cold start, and the same checks again after restart. Windows beta full validation must use `release-beta-win`; a beta-like local namespace is not equivalent delivery evidence.

--- a/tools/pack/src/launcher-runtime-snapshot.ts
+++ b/tools/pack/src/launcher-runtime-snapshot.ts
@@ -1,8 +1,10 @@
 import { readFile, readdir, stat } from "node:fs/promises";
 
 import {
+  validateLauncherDesktopHandoffDescriptor,
   validateLauncherRuntimeDescriptor,
   type LauncherAttemptDescriptor,
+  type LauncherDesktopHandoffDescriptor,
   type LauncherRuntimeDescriptor,
   type LauncherVersionPointer,
 } from "@open-design/launcher-proto";
@@ -16,6 +18,8 @@ export type ToolPackLauncherRuntimeSnapshot = {
   channel: string;
   error?: string;
   exists: boolean;
+  handoff: LauncherDesktopHandoffDescriptor | null;
+  handoffPath: string;
   lastSuccessful: LauncherVersionPointer | null;
   active: LauncherVersionPointer | null;
   namespace: string;
@@ -34,6 +38,7 @@ export async function readToolPackLauncherRuntimeSnapshot(
   const base = {
     attemptsPath: paths.attemptsPath,
     channel: launcher.channel,
+    handoffPath: paths.handoffPath,
     namespace: config.namespace,
     root: launcher.root,
     runtimePath: paths.runtimePath,
@@ -44,12 +49,26 @@ export async function readToolPackLauncherRuntimeSnapshot(
 
   const runtimeRaw = await readOptionalJson<LauncherRuntimeDescriptor>(paths.runtimePath);
   const attempt = await readOptionalJson<LauncherAttemptDescriptor>(paths.attemptsPath);
+  const handoffRaw = await readOptionalJson<LauncherDesktopHandoffDescriptor>(paths.handoffPath);
+  const handoff = handoffRaw == null
+    ? null
+    : (() => {
+        try {
+          return validateLauncherDesktopHandoffDescriptor(handoffRaw, {
+            channel: launcher.channel,
+            namespace: config.namespace,
+          });
+        } catch {
+          return null;
+        }
+      })();
   if (runtimeRaw == null) {
     return {
       ...base,
       active: null,
       attempt,
       exists: false,
+      handoff,
       lastSuccessful: null,
     };
   }
@@ -64,6 +83,7 @@ export async function readToolPackLauncherRuntimeSnapshot(
       active: runtime.active,
       attempt,
       exists: true,
+      handoff,
       lastSuccessful: runtime.lastSuccessful,
     };
   } catch (error) {
@@ -73,6 +93,7 @@ export async function readToolPackLauncherRuntimeSnapshot(
       attempt,
       error: error instanceof Error ? error.message : String(error),
       exists: true,
+      handoff,
       lastSuccessful: null,
     };
   }

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -1,7 +1,7 @@
 import { execFile, spawn } from "node:child_process";
 import { access, chmod, cp, mkdir, open, readFile, readdir, readlink, rename, rm, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, join, posix } from "node:path";
 import { promisify } from "node:util";
 
 import {
@@ -341,8 +341,8 @@ export function matchesAppImageProcess(
   // Direct AppRun launches do not know the installed .AppImage path. Our AppRun
   // fallback sets $APPIMAGE to the sibling AppRun before execing Electron.
   return (
-    basename(snapshot.executable) === PRODUCT_NAME &&
-    snapshot.env.APPIMAGE === join(dirname(snapshot.executable), "AppRun")
+    posix.basename(snapshot.executable) === PRODUCT_NAME &&
+    snapshot.env.APPIMAGE === posix.join(posix.dirname(snapshot.executable), "AppRun")
   );
 }
 

--- a/tools/pack/src/mac/lifecycle.ts
+++ b/tools/pack/src/mac/lifecycle.ts
@@ -558,7 +558,8 @@ export async function startPackedMacApp(config: ToolPackConfig): Promise<MacStar
   const exit = watchProcessExit(child);
   const earlyExit = await exit.wait(1500);
   child.unref();
-  if (earlyExit != null) {
+  const cleanLauncherExit = earlyExit?.code === 0 && earlyExit.signal == null;
+  if (earlyExit != null && !cleanLauncherExit) {
     throw new Error(await createLaunchFailureMessage(config, target, {
       pid,
       reason: `process exited early ${formatExit(earlyExit)}`,
@@ -566,6 +567,12 @@ export async function startPackedMacApp(config: ToolPackConfig): Promise<MacStar
   }
 
   const status = await waitForDesktopStatus(config);
+  if (status == null && earlyExit != null) {
+    throw new Error(await createLaunchFailureMessage(config, target, {
+      pid,
+      reason: `launcher exited cleanly before desktop IPC was available ${formatExit(earlyExit)}`,
+    }));
+  }
   const delayedExit = exit.current();
   if (status == null && delayedExit != null) {
     throw new Error(await createLaunchFailureMessage(config, target, {
@@ -579,12 +586,13 @@ export async function startPackedMacApp(config: ToolPackConfig): Promise<MacStar
       reason: "process exited before desktop IPC was available without an observed exit event",
     }));
   }
+  const activePid = typeof status?.pid === "number" && status.pid > 0 ? status.pid : pid;
   return {
     appPath: target.appPath,
     executablePath: target.executablePath,
     logPath,
     namespace: config.namespace,
-    pid,
+    pid: activePid,
     source: target.source,
     status,
   };

--- a/tools/pack/src/mac/lifecycle.ts
+++ b/tools/pack/src/mac/lifecycle.ts
@@ -605,11 +605,13 @@ async function findManagedDesktopProcessTree(config: ToolPackConfig): Promise<{
   const processes = await listProcessSnapshots();
   const stampedRootPids = processes
     .filter((processInfo) =>
-      matchesStampedProcess(processInfo, {
-        mode: SIDECAR_MODES.RUNTIME,
-        namespace: config.namespace,
-        source: SIDECAR_SOURCES.TOOLS_PACK,
-      }, OPEN_DESIGN_SIDECAR_CONTRACT),
+      [SIDECAR_SOURCES.TOOLS_PACK, SIDECAR_SOURCES.PACKAGED].some((source) =>
+        matchesStampedProcess(
+          processInfo,
+          { mode: SIDECAR_MODES.RUNTIME, namespace: config.namespace, source },
+          OPEN_DESIGN_SIDECAR_CONTRACT,
+        )
+      ),
     )
     .map((processInfo) => processInfo.pid);
   const identity = await resolveDesktopRootIdentityFallback(config);

--- a/tools/pack/src/win/custom-installer.ts
+++ b/tools/pack/src/win/custom-installer.ts
@@ -34,7 +34,7 @@ const WIN_NSIS_OVERLAY_RELATIVE_PATHS = [
 ] as const;
 
 export const WIN_PAYLOAD_SEVEN_Z_CREATE_ARGS = ["-t7z", "-m0=LZMA2", "-mx=1", "-mf=off"] as const;
-const WIN_NSIS_PAYLOAD_SEVEN_Z_TIMEOUT_MS = 300_000;
+const WIN_NSIS_PAYLOAD_SEVEN_Z_TIMEOUT_MS = 15 * 60_000;
 
 function escapeNsisString(value: string): string {
   return value.replace(/\$/g, "$$").replace(/"/g, '$\\"').replace(/\r?\n/g, "$\\r$\\n");

--- a/tools/pack/src/win/lifecycle.ts
+++ b/tools/pack/src/win/lifecycle.ts
@@ -276,7 +276,13 @@ async function findManagedDesktopProcessTree(config: ToolPackConfig): Promise<nu
   const processes = await listProcessSnapshots();
   const stampedRootPids = processes
     .filter((processInfo) =>
-      matchesStampedProcess(processInfo, { mode: SIDECAR_MODES.RUNTIME, namespace: config.namespace, source: SIDECAR_SOURCES.TOOLS_PACK }, OPEN_DESIGN_SIDECAR_CONTRACT),
+      [SIDECAR_SOURCES.TOOLS_PACK, SIDECAR_SOURCES.PACKAGED].some((source) =>
+        matchesStampedProcess(
+          processInfo,
+          { mode: SIDECAR_MODES.RUNTIME, namespace: config.namespace, source },
+          OPEN_DESIGN_SIDECAR_CONTRACT,
+        )
+      ),
     )
     .map((processInfo) => processInfo.pid);
   return collectProcessTreePids(processes, stampedRootPids);

--- a/tools/pack/tests/launcher-runtime-snapshot.test.ts
+++ b/tools/pack/tests/launcher-runtime-snapshot.test.ts
@@ -1,0 +1,79 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  LAUNCHER_SCHEMA_VERSION,
+  resolveLauncherPaths,
+} from "@open-design/launcher-proto";
+import { describe, expect, it } from "vitest";
+
+import type { ToolPackConfig } from "../src/config.js";
+import { readToolPackLauncherRuntimeSnapshot } from "../src/launcher-runtime-snapshot.js";
+
+describe("launcher runtime snapshot", () => {
+  it("reports the validated desktop handoff journal with the launcher pointers", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-tools-pack-launcher-snapshot-"));
+    try {
+      const namespace = "release-beta-win";
+      const namespaceBaseRoot = join(root, "runtime", "win", "namespaces");
+      const launcherRoot = join(root, "runtime", "win");
+      const launcherPaths = resolveLauncherPaths({
+        channel: "beta",
+        namespace,
+        root: launcherRoot,
+      });
+      await mkdir(launcherPaths.stateRoot, { recursive: true });
+      await writeFile(launcherPaths.runtimePath, `${JSON.stringify({
+        active: { generation: 2, version: "1.2.3-beta.5" },
+        channel: "beta",
+        lastSuccessful: { generation: 2, version: "1.2.3-beta.5" },
+        namespace,
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+      })}\n`);
+      await writeFile(launcherPaths.handoffPath, `${JSON.stringify({
+        channel: "beta",
+        createdAt: "2026-07-15T01:00:00.000Z",
+        handoffId: "4c5ca585-c7a1-4b9a-b725-495d72a5f97b",
+        namespace,
+        outer: {
+          executablePath: join(root, "installed", "Open Design Beta.exe"),
+          pid: 4321,
+        },
+        payloadExecutablePath: join(
+          launcherPaths.versionsRoot,
+          "1.2.3-beta.5",
+          "payload",
+          "Open Design Beta.exe",
+        ),
+        previous: { generation: 0, version: "1.2.3-beta.4" },
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+        source: { generation: 2, version: "1.2.3-beta.5" },
+        state: "confirmed",
+        target: { generation: 2, version: "1.2.3-beta.5" },
+        updatedAt: "2026-07-15T01:00:05.000Z",
+      })}\n`);
+
+      const snapshot = await readToolPackLauncherRuntimeSnapshot({
+        appVersion: "1.2.3-beta.5",
+        namespace,
+        roots: {
+          runtime: {
+            namespaceBaseRoot,
+          },
+        } as ToolPackConfig["roots"],
+      });
+
+      expect(snapshot.active).toEqual({ generation: 2, version: "1.2.3-beta.5" });
+      expect(snapshot.lastSuccessful).toEqual({ generation: 2, version: "1.2.3-beta.5" });
+      expect(snapshot.handoffPath).toBe(launcherPaths.handoffPath);
+      expect(snapshot.handoff).toMatchObject({
+        previous: { generation: 0, version: "1.2.3-beta.4" },
+        state: "confirmed",
+        target: { generation: 2, version: "1.2.3-beta.5" },
+      });
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/tools/pack/tests/linux.test.ts
+++ b/tools/pack/tests/linux.test.ts
@@ -2,7 +2,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { access, chmod, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { posix } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -836,9 +836,7 @@ describe("createLinuxDesktopLaunchEnv", () => {
 
     expect(env.ELECTRON_RUN_AS_NODE).toBeUndefined();
     expect(env.KEEP_ME).toBe("yes");
-    expect(env.OD_SIDECAR_BASE).toBe(
-      "/work/.tmp/tools-pack/runtime/linux/namespaces/default/runtime",
-    );
+    expect(env.OD_SIDECAR_BASE).toBe(resolve(config.roots.runtime.namespaceRoot, "runtime"));
   });
 });
 

--- a/tools/pack/tests/mac-lifecycle.test.ts
+++ b/tools/pack/tests/mac-lifecycle.test.ts
@@ -5,11 +5,12 @@ import { join } from "node:path";
 import type { ChildProcess } from "node:child_process";
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { DesktopStatusSnapshot } from "@open-design/sidecar-proto";
 
 import type { ToolPackConfig } from "../src/config.js";
 import { resolveMacPaths } from "../src/mac/paths.js";
 
-const requestJsonIpc = vi.fn(async () => ({ state: "running" }));
+const requestJsonIpc = vi.fn(async (): Promise<DesktopStatusSnapshot> => ({ state: "running" }));
 const resolveAppIpcPath = vi.fn(() => "/tmp/open-design/ipc/test/desktop.sock");
 const createSidecarLaunchEnv = vi.fn(({ extraEnv }: { extraEnv: NodeJS.ProcessEnv }) => extraEnv);
 const spawnLoggedProcess = vi.fn(async ({ env }: { env: NodeJS.ProcessEnv }) => {
@@ -83,6 +84,63 @@ afterEach(() => {
 });
 
 describe("startPackedMacApp", () => {
+  it("accepts a clean launcher exit when the delegated desktop becomes healthy", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-tools-pack-mac-lifecycle-"));
+    try {
+      const config = makeConfig(root);
+      const paths = resolveMacPaths(config);
+      const executablePath = join(paths.installedAppPath, "Contents", "MacOS", "Open Design");
+      const delegatedPid = 5678;
+
+      await mkdir(join(paths.installedAppPath, "Contents", "MacOS"), { recursive: true });
+      await writeFile(executablePath, "#!/bin/sh\nexit 0\n", "utf8");
+      await chmod(executablePath, 0o755);
+      requestJsonIpc.mockResolvedValue({ pid: delegatedPid, state: "running" });
+      spawnLoggedProcess.mockImplementationOnce(async ({ env }: { env: NodeJS.ProcessEnv }) => {
+        const child = Object.assign(new EventEmitter(), {
+          env,
+          pid: 1234,
+          unref: vi.fn(),
+        }) as unknown as ChildProcess & { env: NodeJS.ProcessEnv };
+        setTimeout(() => child.emit("exit", 0, null), 10);
+        return child;
+      });
+
+      const result = await startPackedMacApp(config);
+
+      expect(result.pid).toBe(delegatedPid);
+      expect(result.status).toEqual({ pid: delegatedPid, state: "running" });
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects a non-zero launcher exit before desktop handoff", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-tools-pack-mac-lifecycle-"));
+    try {
+      const config = makeConfig(root);
+      const paths = resolveMacPaths(config);
+      const executablePath = join(paths.installedAppPath, "Contents", "MacOS", "Open Design");
+
+      await mkdir(join(paths.installedAppPath, "Contents", "MacOS"), { recursive: true });
+      await writeFile(executablePath, "#!/bin/sh\nexit 1\n", "utf8");
+      await chmod(executablePath, 0o755);
+      spawnLoggedProcess.mockImplementationOnce(async ({ env }: { env: NodeJS.ProcessEnv }) => {
+        const child = Object.assign(new EventEmitter(), {
+          env,
+          pid: 1234,
+          unref: vi.fn(),
+        }) as unknown as ChildProcess & { env: NodeJS.ProcessEnv };
+        setTimeout(() => child.emit("exit", 1, null), 10);
+        return child;
+      });
+
+      await expect(startPackedMacApp(config)).rejects.toThrow("process exited early code=1 signal=null");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
   it("writes a launch override when the bundled config is missing", async () => {
     const root = await mkdtemp(join(tmpdir(), "open-design-tools-pack-mac-lifecycle-"));
     try {

--- a/tools/pack/tests/mac-lifecycle.test.ts
+++ b/tools/pack/tests/mac-lifecycle.test.ts
@@ -13,6 +13,13 @@ import { resolveMacPaths } from "../src/mac/paths.js";
 const requestJsonIpc = vi.fn(async (): Promise<DesktopStatusSnapshot> => ({ state: "running" }));
 const resolveAppIpcPath = vi.fn(() => "/tmp/open-design/ipc/test/desktop.sock");
 const createSidecarLaunchEnv = vi.fn(({ extraEnv }: { extraEnv: NodeJS.ProcessEnv }) => extraEnv);
+const collectProcessTreePids = vi.fn(
+  (_processes: unknown[], rootPids: Array<number | null>) =>
+    rootPids.filter((pid): pid is number => typeof pid === "number"),
+);
+const listProcessSnapshots = vi.fn(async () => [] as Array<{ command: string; pid: number; ppid: number }>);
+const matchesStampedProcess = vi.fn<typeof import("@open-design/platform").matchesStampedProcess>(() => false);
+const stopProcesses = vi.fn(async (pids: number[]) => ({ remainingPids: [], stoppedPids: pids }));
 const spawnLoggedProcess = vi.fn(async ({ env }: { env: NodeJS.ProcessEnv }) => {
   return Object.assign(new EventEmitter(), {
     env,
@@ -28,17 +35,17 @@ vi.mock("@open-design/sidecar", () => ({
 }));
 
 vi.mock("@open-design/platform", () => ({
-  collectProcessTreePids: vi.fn(),
+  collectProcessTreePids,
   createProcessStampArgs: vi.fn(() => []),
   isProcessAlive: vi.fn(() => true),
-  listProcessSnapshots: vi.fn(async () => []),
-  matchesStampedProcess: vi.fn(() => false),
+  listProcessSnapshots,
+  matchesStampedProcess,
   readLogTail: vi.fn(async () => []),
   spawnLoggedProcess,
-  stopProcesses: vi.fn(async () => []),
+  stopProcesses,
 }));
 
-const { startPackedMacApp } = await import("../src/mac/lifecycle.js");
+const { startPackedMacApp, stopPackedMacApp } = await import("../src/mac/lifecycle.js");
 
 function makeConfig(root: string, overrides: Partial<ToolPackConfig> = {}): ToolPackConfig {
   return {
@@ -81,6 +88,13 @@ function makeConfig(root: string, overrides: Partial<ToolPackConfig> = {}): Tool
 afterEach(() => {
   vi.clearAllMocks();
   requestJsonIpc.mockResolvedValue({ state: "running" });
+  listProcessSnapshots.mockResolvedValue([]);
+  matchesStampedProcess.mockReturnValue(false);
+  collectProcessTreePids.mockImplementation(
+    (_processes: unknown[], rootPids: Array<number | null>) =>
+      rootPids.filter((pid): pid is number => typeof pid === "number"),
+  );
+  stopProcesses.mockImplementation(async (pids: number[]) => ({ remainingPids: [], stoppedPids: pids }));
 });
 
 describe("startPackedMacApp", () => {
@@ -222,6 +236,47 @@ describe("startPackedMacApp", () => {
       expect(result.source).toBe("installed");
       expect(result.executablePath).toBe(executablePath);
       expect(result.status?.state).toBe("running");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("stopPackedMacApp", () => {
+  it("waits for a packaged-source payload desktop to exit after graceful shutdown", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-tools-pack-mac-lifecycle-"));
+    const config = makeConfig(root);
+    const payloadDesktop = { command: "payload-desktop", pid: 4242, ppid: 1 };
+
+    try {
+      requestJsonIpc.mockResolvedValue({ state: "running" });
+      listProcessSnapshots
+        .mockResolvedValueOnce([payloadDesktop])
+        .mockResolvedValueOnce([payloadDesktop])
+        .mockResolvedValueOnce([]);
+      matchesStampedProcess.mockImplementation((processInfo, criteria) => {
+        const sidecarCriteria = criteria as { namespace?: string; source?: string };
+        return (
+          processInfo.command === payloadDesktop.command &&
+          sidecarCriteria.namespace === config.namespace &&
+          sidecarCriteria.source === "packaged"
+        );
+      });
+
+      await expect(stopPackedMacApp(config)).resolves.toMatchObject({
+        gracefulRequested: true,
+        namespace: config.namespace,
+        remainingPids: [],
+        status: "stopped",
+        stoppedPids: [payloadDesktop.pid],
+      });
+      expect(listProcessSnapshots).toHaveBeenCalledTimes(3);
+      expect(matchesStampedProcess).toHaveBeenCalledWith(
+        payloadDesktop,
+        expect.objectContaining({ namespace: config.namespace, source: "packaged" }),
+        expect.anything(),
+      );
+      expect(stopProcesses).not.toHaveBeenCalled();
     } finally {
       await rm(root, { force: true, recursive: true });
     }

--- a/tools/pack/tests/release-workflows.test.ts
+++ b/tools/pack/tests/release-workflows.test.ts
@@ -80,6 +80,7 @@ describe("release workflows", () => {
     expect(mac).toContain("build_args+=(--signed --notarize)");
     expect(mac).toContain("Build beta mac_arm64 update fixture");
     expect(mac).toContain("OD_PACKAGED_E2E_MAC_UPDATE_BUILD_JSON_PATH: ${{ steps.mac_arm64_update_fixture.outputs.update_build_json_path }}");
+    expect(mac).toContain("OD_PACKAGED_E2E_MAC_UPDATE_FIXTURE: ${{ inputs.mac_arm64_smoke_mode == 'full' && inputs.mac_arm64_update_metadata_url == '' && inputs.mac_arm64_update_target_version == '' && 'tools-serve' || '' }}");
     expect(mac).toContain("pnpm exec tsx scripts/release-smoke.ts mac specs/mac.spec.ts");
     expect(mac).toContain("bash .github/scripts/release/cache/mac.sh");
     expect(macX64).toContain("uses: actions/cache/restore@v5");

--- a/tools/pack/tests/resources.test.ts
+++ b/tools/pack/tests/resources.test.ts
@@ -199,7 +199,8 @@ describe("copyOptionalVelaCliBinary", () => {
       const target = join(resourceRoot, "bin", process.platform === "win32" ? "vela.exe" : "vela");
       expect(copied?.target).toBe(target);
       await expect(access(target)).resolves.toBeUndefined();
-      await expect(access(join(resourceRoot, "bin", "libexec", "opencode", "opencode"))).resolves.toBeUndefined();
+      const openCodeName = process.platform === "win32" ? "opencode.exe" : "opencode";
+      await expect(access(join(resourceRoot, "bin", "libexec", "opencode", openCodeName))).resolves.toBeUndefined();
     } finally {
       await rm(root, { force: true, recursive: true });
     }

--- a/tools/pack/tests/win-lifecycle.test.ts
+++ b/tools/pack/tests/win-lifecycle.test.ts
@@ -8,7 +8,12 @@ import { describe, expect, it, vi } from "vitest";
 import type { ToolPackConfig } from "../src/config.js";
 
 const requestJsonIpc = vi.hoisted(() => vi.fn());
-const listProcessSnapshots = vi.hoisted(() => vi.fn(async () => []));
+const listProcessSnapshots = vi.hoisted(() =>
+  vi.fn<typeof import("@open-design/platform").listProcessSnapshots>(async () => []),
+);
+const matchesStampedProcess = vi.hoisted(() =>
+  vi.fn<typeof import("@open-design/platform").matchesStampedProcess>(() => false),
+);
 const spawnBackgroundProcess = vi.hoisted(() => vi.fn(async () => ({ pid: 12345 })));
 const stopProcesses = vi.hoisted(() => vi.fn(async () => undefined));
 
@@ -25,12 +30,13 @@ vi.mock("@open-design/platform", async () => {
   return {
     ...actual,
     listProcessSnapshots,
+    matchesStampedProcess,
     spawnBackgroundProcess,
     stopProcesses,
   };
 });
 
-const { diagnosePackedWinIpc, inspectPackedWinApp } = await import("../src/win/lifecycle.js");
+const { diagnosePackedWinIpc, inspectPackedWinApp, stopPackedWinApp } = await import("../src/win/lifecycle.js");
 const { resolveWinPaths } = await import("../src/win/paths.js");
 
 function createConfig(root: string): ToolPackConfig {
@@ -212,6 +218,46 @@ describe("inspectPackedWinApp", () => {
       } else {
         process.env.OD_JSON_IPC_TRACE = previousTrace;
       }
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("stopPackedWinApp", () => {
+  it("waits for a packaged-source payload desktop to exit after graceful shutdown", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-lifecycle-"));
+    const config = createConfig(root);
+    const payloadDesktop = { command: "payload-desktop", pid: 4242, ppid: 1 };
+
+    try {
+      requestJsonIpc.mockReset();
+      requestJsonIpc.mockResolvedValue({ accepted: true });
+      listProcessSnapshots.mockReset();
+      listProcessSnapshots
+        .mockResolvedValueOnce([payloadDesktop])
+        .mockResolvedValueOnce([payloadDesktop])
+        .mockResolvedValueOnce([]);
+      matchesStampedProcess.mockReset();
+      matchesStampedProcess.mockImplementation((processInfo, criteria) => {
+        const sidecarCriteria = criteria as { namespace?: string; source?: string };
+        return (
+          processInfo.command === payloadDesktop.command &&
+          sidecarCriteria.namespace === config.namespace &&
+          sidecarCriteria.source === "packaged"
+        );
+      });
+      stopProcesses.mockClear();
+
+      await expect(stopPackedWinApp(config)).resolves.toEqual({
+        gracefulRequested: true,
+        namespace: config.namespace,
+        remainingPids: [],
+        status: "stopped",
+        stoppedPids: [payloadDesktop.pid],
+      });
+      expect(listProcessSnapshots).toHaveBeenCalledTimes(3);
+      expect(stopProcesses).not.toHaveBeenCalled();
+    } finally {
       await rm(root, { force: true, recursive: true });
     }
   });


### PR DESCRIPTION
## Why

While validating payload upgrades from historical packaged launchers, I reproduced a generation skew where the upgraded daemon and web runtime came from the payload but Electron desktop still came from the outer installation. That older desktop could not understand the newer `render-slides` sidecar message, so PPTX export failed even though the payload itself had downloaded, activated, and passed health checks.

This change closes that compatibility gap for already-shipped launchers. A payload-selected run now hands desktop ownership to the payload executable while preserving the outer installation as the physical recovery entry point. This is required for payload upgrades to be genuinely backward-compatible rather than depending on older clients understanding a newer `min-version` installer guard.

## What users will see

Users upgrading an older packaged installation through the payload channel can export PPTX after the upgrade without reinstalling the outer app. After a full stop and another launch through the historical outer app, the payload desktop is selected again so daemon and desktop remain on the same generation.

If payload desktop launch or confirmation fails, the existing attempt/last-successful recovery path remains available instead of leaving the installation permanently unable to start.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. This changes packaged process handoff and upgrade behavior without adding or changing a UI surface.

## Bug fix verification

- Test paths: `packages/launcher-proto/tests/index.test.ts`, `apps/packaged/tests/launcher-runtime.test.ts`, `apps/packaged/tests/payload-desktop-launch.test.ts`, `apps/daemon/tests/sidecar/payload-desktop-handoff.test.ts`, `apps/desktop/tests/main/updater.test.ts`, `tools/pack/tests/mac-lifecycle.test.ts`, `tools/pack/tests/launcher-runtime-snapshot.test.ts`, `e2e/tests/packaged-launcher-update-loop.test.ts`, `e2e/specs/mac.spec.ts`, and `e2e/specs/win.spec.ts`.
- The historical-launcher reproduction failed before the fix with `desktop renderer unavailable: unknown desktop sidecar message: render-slides`; the branch's local macOS old-outer → real payload run completed payload activation, PPTX export, full shutdown, and cold relaunch successfully.
- The focused regression suites pass on this branch: launcher protocol 16/16, packaged 173/173, daemon handoff 4/4, desktop payload updater 5/5, and tools-pack snapshot 1/1.

## Validation

- `pnpm install`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
- A real macOS `tools-pack` + `tools-serve` replay from historical outer 0.12.0 to a final-worktree 0.15.2 payload (297,676,658 bytes; SHA-256 `9d96ebdf360dd2a65a07e2aa919bf2c2e3d230cb4020f6e2a4060d6f5e3bbaaa`)
- Verified payload desktop executable identity, generation-2 activation, a 117,967-byte PPTX export, full stop, and generation-3 cold relaunch with confirmed handoff and no pending attempt
- `pnpm --filter @open-design/tools-pack test`: 240 passed, 8 skipped
- `e2e/tests/packaged-launcher-update-loop.test.ts`: macOS and Windows payload install/restart/confirm/fallback cases 2/2 passed
- Release Beta run [29401601338](https://github.com/nexu-io/open-design/actions/runs/29401601338) completed successfully for commit `ec86598bfc9649e9852a263cf50ff76aae540086`, publishing `0.15.1-beta.1`
- macOS arm64 signed/notarized full profile passed: payload desktop identity, 92,444-byte PPTX export, generation-1 payload cold start, confirmed handoff, and clean stop
- Windows x64 unsigned beta full profile passed under the required `release-beta-win` namespace: payload desktop identity, 94,814-byte PPTX export, cold restart, uninstall, and zero registry residue
- Published metadata: https://releases.open-design.ai/beta/latest/metadata.json; macOS report: https://releases.open-design.ai/beta/versions/0.15.1-beta.1.signed/report/mac_arm64/report.json; Windows report: https://releases.open-design.ai/beta/versions/0.15.1-beta.1.unsigned/report/win_x64/report.json
- Manual hot CI run [29404621489](https://github.com/nexu-io/open-design/actions/runs/29404621489) passed at final head `10248c7bb`: Nix flake, E2E Vitest, Preflight/typecheck, workspace/web tests, Windows tools-pack payload tests, UI/visual suites, Docker build, and Validate workspace
- The Nix daemon source/build graph now includes `packages/launcher-proto`; the real Nix runner passed without a pnpm fixed-output hash refresh
