### PR TITLE
fix(web): stamp chunk_id on exception frames so PostHog can symbolicate

### DIFF
--- a/apps/web/src/analytics/error-tracking.ts
+++ b/apps/web/src/analytics/error-tracking.ts
@@ -275,6 +275,63 @@ function dispatch(item: BufferedSafetyEvent): void {
   }
 }
 
+// Frame-level source-map correlation.
+//
+// `@posthog/cli sourcemap inject` (run from tools/pack/src/web-sourcemaps.ts
+// on every packaged build) bakes a unique chunk id into each browser chunk
+// and the matching id into the .map it uploads to PostHog. At load time each
+// injected chunk registers `globalThis._posthogChunkIds[<its Error().stack>] =
+// <chunkId>`. Symbolication then requires that chunk id to ride along on each
+// captured frame: packaged chunks load over the `od://` scheme, which PostHog
+// cannot fetch a `.map` from, so the chunk id is the ONLY correlation key.
+//
+// posthog-js stamps it natively, but we set `capture_exceptions: false` and
+// hand-build exceptions here, so we must replicate the stamping or every
+// packaged frame ships un-symbolicatable (observed in prod: 100% of frames
+// failed with "had no source url or chunk id"). This mirrors
+// @posthog/core error-tracking/chunk-ids.ts so the filename→chunkId map is
+// identical to what the uploaded maps were injected against.
+type ChunkIdMap = Record<string, string>;
+
+let cachedRegistry: ChunkIdMap | undefined;
+let cachedFilenameChunkIds: ChunkIdMap | undefined;
+let cachedRegistryKeyCount = -1;
+
+function getFilenameToChunkIdMap(): ChunkIdMap {
+  const registry = (globalThis as { _posthogChunkIds?: ChunkIdMap })._posthogChunkIds;
+  if (!registry) return {};
+  const keys = Object.keys(registry);
+  // Chunks register lazily as they load, so the registry grows over the
+  // session. Rebuild only when it changes (same identity + same size = hit).
+  if (
+    cachedFilenameChunkIds &&
+    cachedRegistry === registry &&
+    keys.length === cachedRegistryKeyCount
+  ) {
+    return cachedFilenameChunkIds;
+  }
+  const map: ChunkIdMap = {};
+  for (const stackKey of keys) {
+    const chunkId = registry[stackKey];
+    if (!chunkId) continue;
+    // The registry key is an Error().stack captured inside the injected chunk.
+    // Take the bottom-most frame that carries a filename — matches the frame
+    // @posthog/core keys the id on, so our lookup agrees with the maps.
+    const frames = parseStack(stackKey, {});
+    for (let i = frames.length - 1; i >= 0; i--) {
+      const filename = frames[i]?.filename;
+      if (typeof filename === 'string' && filename) {
+        map[filename] = chunkId;
+        break;
+      }
+    }
+  }
+  cachedRegistry = registry;
+  cachedRegistryKeyCount = keys.length;
+  cachedFilenameChunkIds = map;
+  return map;
+}
+
 function buildExceptionList(
   error: unknown,
   fallbackMessage: string,
@@ -288,6 +345,7 @@ function buildExceptionList(
       ? error
       : fallbackMessage;
   const stack = isError && typeof error.stack === 'string' ? error.stack : '';
+  const chunkIds = getFilenameToChunkIdMap();
   // Stamp `platform` on every frame. PostHog's exception ingestion treats
   // it as a required field (it selects the symbolication / issue-grouping
   // strategy per frame); a frame without it fails the exceptions pipeline
@@ -296,10 +354,21 @@ function buildExceptionList(
   // were failing to ingest. posthog-js stamps the same value on each frame;
   // we replicate it because client.ts sets `capture_exceptions: false` and
   // this module is the sole browser-exception transport.
-  const frames = parseStack(stack, metadata).map((frame) => ({
-    ...frame,
-    platform: FRAME_PLATFORM,
-  }));
+  //
+  // Also stamp `chunk_id` when the frame's chunk registered one (see
+  // `getFilenameToChunkIdMap`). Without it, packaged `od://` frames carry no
+  // source URL PostHog can fetch, so the uploaded sourcemap can never be
+  // matched and every frame stays minified — the reason production stacks
+  // showed `?:?` despite the tools-pack sourcemap upload succeeding.
+  const frames = parseStack(stack, metadata).map((frame) => {
+    const filename = typeof frame.filename === 'string' ? frame.filename : undefined;
+    const chunkId = filename ? chunkIds[filename] : undefined;
+    return {
+      ...frame,
+      platform: FRAME_PLATFORM,
+      ...(chunkId ? { chunk_id: chunkId } : {}),
+    };
+  });
   return [
     {
       type,

--- a/apps/web/src/analytics/error-tracking.ts
+++ b/apps/web/src/analytics/error-tracking.ts
@@ -315,11 +315,17 @@ function getFilenameToChunkIdMap(): ChunkIdMap {
     const chunkId = registry[stackKey];
     if (!chunkId) continue;
     // The registry key is an Error().stack captured inside the injected chunk.
-    // Take the bottom-most frame that carries a filename — matches the frame
-    // @posthog/core keys the id on, so our lookup agrees with the maps.
+    // Key the chunk id on the frame where that Error was constructed — the
+    // chunk's own file. @posthog/core scans its stackParser output (which it
+    // reverses to oldest-first) from the end, i.e. the NEWEST frame; parseStack
+    // here keeps Error.stack's native newest-first order, so the newest frame
+    // is frames[0]. Take the first frame with a filename. A registration stack
+    // is typically multi-frame (the injected IIFE sits above webpack
+    // require/loader frames), so picking the wrong end would key the id onto a
+    // runtime-chunk filename and leave the real chunk with no entry.
     const frames = parseStack(stackKey, {});
-    for (let i = frames.length - 1; i >= 0; i--) {
-      const filename = frames[i]?.filename;
+    for (const frame of frames) {
+      const filename = frame?.filename;
       if (typeof filename === 'string' && filename) {
         map[filename] = chunkId;
         break;

--- a/apps/web/tests/analytics/error-tracking.test.ts
+++ b/apps/web/tests/analytics/error-tracking.test.ts
@@ -100,9 +100,18 @@ describe('error-tracking', () => {
 
   it('stamps chunk_id on frames whose chunk registered one, so PostHog can match the uploaded sourcemap', () => {
     // Mirror what `@posthog/cli sourcemap inject` registers at chunk load:
-    // key = the chunk's own Error().stack, value = its chunk id.
+    // key = the chunk's own Error().stack, value = its chunk id. The stack is
+    // multi-frame — the injected IIFE (newest, the chunk itself) sits above a
+    // webpack runtime frame (older) — so the id MUST key onto the newest
+    // frame's file (page-abc.js), not the outermost one. A loop that picked
+    // the wrong end would key it onto webpack-runtime.js and leave page-abc.js
+    // unmatched.
     (globalThis as { _posthogChunkIds?: Record<string, string> })._posthogChunkIds = {
-      'Error\n    at od://app/_next/static/chunks/page-abc.js:1:100': 'chunk-page-abc',
+      [[
+        'Error',
+        '    at od://app/_next/static/chunks/page-abc.js:1:100',
+        '    at __webpack_require__ (od://app/_next/static/chunks/webpack-runtime.js:2:200)',
+      ].join('\n')]: 'chunk-page-abc',
     };
     setExceptionTrackingContext({
       apiKey: 'phc_test',

--- a/apps/web/tests/analytics/error-tracking.test.ts
+++ b/apps/web/tests/analytics/error-tracking.test.ts
@@ -38,6 +38,7 @@ beforeEach(() => {
 afterEach(() => {
   clearExceptionTrackingContext();
   globalThis.fetch = ORIGINAL_FETCH;
+  delete (globalThis as { _posthogChunkIds?: Record<string, string> })._posthogChunkIds;
 });
 
 function lastFetchedBody(): Record<string, unknown> {
@@ -95,6 +96,41 @@ describe('error-tracking', () => {
       $exception_message: 'immediate',
       handled: true,
     });
+  });
+
+  it('stamps chunk_id on frames whose chunk registered one, so PostHog can match the uploaded sourcemap', () => {
+    // Mirror what `@posthog/cli sourcemap inject` registers at chunk load:
+    // key = the chunk's own Error().stack, value = its chunk id.
+    (globalThis as { _posthogChunkIds?: Record<string, string> })._posthogChunkIds = {
+      'Error\n    at od://app/_next/static/chunks/page-abc.js:1:100': 'chunk-page-abc',
+    };
+    setExceptionTrackingContext({
+      apiKey: 'phc_test',
+      host: 'https://us.i.posthog.com',
+      distinctId: 'user-chunk',
+    });
+
+    const err = new Error('kaboom');
+    // Two frames: the first is from the chunk that registered an id, the
+    // second from a chunk that did not.
+    err.stack = [
+      'Error: kaboom',
+      '    at render (od://app/_next/static/chunks/page-abc.js:42:13)',
+      '    at commit (od://app/_next/static/chunks/framework-xyz.js:7:9)',
+    ].join('\n');
+    reportHandledException(err);
+
+    const body = lastFetchedBody();
+    const list = (body.properties as Record<string, unknown>).$exception_list as Array<{
+      stacktrace?: { frames?: Array<Record<string, unknown>> };
+    }>;
+    const frames = list[0]?.stacktrace?.frames ?? [];
+    const withChunkId = frames.filter((f) => typeof f.chunk_id === 'string');
+    // Exactly the frame from the registered chunk is stamped — and with the
+    // id PostHog will use to locate the uploaded map. No spurious ids leak
+    // onto frames whose chunk never registered one.
+    expect(withChunkId).toHaveLength(1);
+    expect(withChunkId[0]!.chunk_id).toBe('chunk-page-abc');
   });
 
   it('captures unhandledrejection events via the window hook', () => {


### PR DESCRIPTION
## Why

Front-end exception stacks in PostHog are permanently un-symbolicated — every frame shows `?:?` with mangled names (`d\$`, `dO`) — despite tools-pack injecting chunk ids and uploading browser sourcemaps on **every** release (verified in a beta release log: `sourcemap inject` + `upload` both succeed, 309 maps shipped). This makes the whole `$exception` feed — the biggest signal in the daily stability report (TypeError alone: ~40k events / ~1.6k users in 3 days) — undebuggable. I hit this while trying to root-cause the front-end crash cluster from the daily report and found the symbolication had **never** worked.

Ground truth from PostHog (7 days): **0** frames ever carried a chunk id; **5,140** frames failed with `resolve_failure: "This frame had no source url or chunk id"`.

## Root cause

Exception capture is owned by our own `apps/web/src/analytics/error-tracking.ts` (runs before consent and before posthog-js loads, via a direct ingest fetch), and `client.ts` sets `capture_exceptions: false`. The chunk id that `@posthog/cli sourcemap inject` bakes into each chunk is normally stamped onto frames by **posthog-js's** native exception capture — the path we deliberately bypass. Packaged chunks load over the `od://` scheme, so PostHog can't fetch a `.map` by URL either; the chunk id is the **only** correlation key, and we never attached it. The maps were uploaded correctly but had nothing to match against.

## What users will see

No visible UI change. Internally: packaged front-end exceptions in PostHog Error tracking will resolve to real `file:line` + function names, so the daily-report front-end bugs (`radius.trim is not a function`, `reading 'checked'` on 103 users, etc.) become debuggable instead of `?:?`.

## What changed

`error-tracking.ts` now builds the same `filename -> chunkId` map from `globalThis._posthogChunkIds` that `@posthog/core`'s `getFilenameToChunkIdMap` does, and stamps `chunk_id` on each frame whose chunk registered one. `scrubExceptionList` preserves it (spread + field override), and it's set before scrubbing, so correlation survives filename redaction.

## Red spec

New test `stamps chunk_id on frames whose chunk registered one, so PostHog can match the uploaded sourcemap` — fails on `main` (frames never carried `chunk_id`), passes here. Full web suite green (4527 passed) + `@open-design/web typecheck` green.

## Surface area

- [x] Web UI / analytics (`apps/web`) — exception ingest payload
- No CLI surface: this is telemetry plumbing, not a user capability. No contract change (frame is a free-form ingest object). No i18n / env / dep changes.

## Follow-ups (not in this PR)

- The uploaded maps are tagged `--release-version <appVersion>` while runtime events report a different `app_version`; irrelevant now (chunk-id correlation is release-independent) but worth aligning.