### PR TITLE
fix(pack): align prebundle better-sqlite3 pin to 12.10.0 so mac daemon starts

### DIFF
--- a/tools/pack/src/mac-prebundle.ts
+++ b/tools/pack/src/mac-prebundle.ts
@@ -13,8 +13,17 @@ export const MAC_DAEMON_PREBUNDLE_ESM_REQUIRE_BANNER =
   'import { createRequire as __odCreateRequire } from "node:module"; const require = __odCreateRequire(import.meta.url);';
 export const MAC_PREBUNDLE_ENTRYPOINTS_DIR_NAME = "prebundle-entrypoints";
 
+// Runtime externals the prebundled daemon loads from node_modules at boot
+// (see the `externals` in MAC_PREBUNDLE_POLICIES below). Their pinned versions
+// MUST stay in lockstep with apps/daemon/package.json / the pnpm lockfile: the
+// app is assembled with these as its declared deps (mac/app.ts), and
+// electron-builder 26's pnpm node_modules collector DROPS a dependency whose
+// pin doesn't semver-satisfy the version resolvable on disk — silently
+// shipping a mac app whose daemon dies at boot with `ERR_MODULE_NOT_FOUND`
+// (issue #4638). A stale `12.9.0` pin here vs `12.10.0` on disk did exactly
+// that. Keep this equal to the daemon's better-sqlite3 pin whenever it moves.
 export const MAC_PREBUNDLE_RUNTIME_DEPENDENCIES = {
-  "better-sqlite3": "12.9.0",
+  "better-sqlite3": "12.10.0",
   "blake3-wasm": "2.1.5",
 } as const;
 

--- a/tools/pack/src/win-prebundle.ts
+++ b/tools/pack/src/win-prebundle.ts
@@ -13,8 +13,17 @@ export const WIN_DAEMON_PREBUNDLE_ESM_REQUIRE_BANNER =
   'import { createRequire as __odCreateRequire } from "node:module"; const require = __odCreateRequire(import.meta.url);';
 export const WIN_PREBUNDLE_ENTRYPOINTS_DIR_NAME = "prebundle-entrypoints";
 
+// Runtime externals the prebundled daemon loads from node_modules at boot
+// (see the `externals` in WIN_PREBUNDLE_POLICIES below). Their pinned versions
+// MUST stay in lockstep with apps/daemon/package.json / the pnpm lockfile: the
+// app is assembled with these as its declared deps (win/app.ts), and
+// electron-builder 26's pnpm node_modules collector DROPS a dependency whose
+// pin doesn't semver-satisfy the version resolvable on disk — silently
+// shipping an app whose daemon dies at boot with `ERR_MODULE_NOT_FOUND`
+// (issue #4638). A stale `12.9.0` pin here vs `12.10.0` on disk did exactly
+// that. Keep this equal to the daemon's better-sqlite3 pin whenever it moves.
 export const WIN_PREBUNDLE_RUNTIME_DEPENDENCIES = {
-  "better-sqlite3": "12.9.0",
+  "better-sqlite3": "12.10.0",
   "blake3-wasm": "2.1.5",
 } as const;
 

--- a/tools/pack/tests/mac-prebundle.test.ts
+++ b/tools/pack/tests/mac-prebundle.test.ts
@@ -77,8 +77,11 @@ describe("mac standalone prebundle policy", () => {
     expect(MAC_PREBUNDLE_POLICIES.daemonSidecar.externals).toEqual(["better-sqlite3", "blake3-wasm"]);
     expect(MAC_PREBUNDLE_POLICIES.webSidecar.externals).toEqual([]);
     expect(MAC_DAEMON_PREBUNDLE_ESM_REQUIRE_BANNER).toContain("createRequire");
+    // Must match apps/daemon/package.json / the pnpm lockfile, or
+    // electron-builder's collector drops the module from the shipped app and
+    // the daemon dies at boot with ERR_MODULE_NOT_FOUND (issue #4638).
     expect(MAC_PREBUNDLE_RUNTIME_DEPENDENCIES).toEqual({
-      "better-sqlite3": "12.9.0",
+      "better-sqlite3": "12.10.0",
       "blake3-wasm": "2.1.5",
     });
     expect(MAC_PREBUNDLED_DAEMON_CLI_RELATIVE_PATH).toBe("app/prebundled/daemon/daemon-cli.mjs");

--- a/tools/pack/tests/win-prebundle.test.ts
+++ b/tools/pack/tests/win-prebundle.test.ts
@@ -77,8 +77,11 @@ describe("win standalone prebundle policy", () => {
     expect(WIN_PREBUNDLE_POLICIES.daemonSidecar.externals).toEqual(["better-sqlite3", "blake3-wasm"]);
     expect(WIN_PREBUNDLE_POLICIES.webSidecar.externals).toEqual([]);
     expect(WIN_DAEMON_PREBUNDLE_ESM_REQUIRE_BANNER).toContain("createRequire");
+    // Must match apps/daemon/package.json / the pnpm lockfile, or
+    // electron-builder's collector drops the module from the shipped app and
+    // the daemon dies at boot with ERR_MODULE_NOT_FOUND (issue #4638).
     expect(WIN_PREBUNDLE_RUNTIME_DEPENDENCIES).toEqual({
-      "better-sqlite3": "12.9.0",
+      "better-sqlite3": "12.10.0",
       "blake3-wasm": "2.1.5",
     });
     expect(WIN_PREBUNDLED_DAEMON_CLI_RELATIVE_PATH).toBe("app/prebundled/daemon/daemon-cli.mjs");


### PR DESCRIPTION
## Why

A large share of packaged macOS users can't launch the app: the daemon exits `code=1` at boot with `ERR_MODULE_NOT_FOUND`, telemetry `missing_module = better-sqlite3` — ~270 hits in 4 days, dominant across 0.13.0–0.15.0. With the daemon dead the whole app is unusable and the shell keeps retrying, which is the "机器一直闪退、疯狂自动重启" report. I found this drilling the daily stability report's `packaged_runtime_failed` spike.

## Root cause

`tools/pack/src/mac-prebundle.ts` / `win-prebundle.ts` pin the daemon's runtime externals at `better-sqlite3@12.9.0`, but `apps/daemon/package.json` and the pnpm lockfile resolve **`12.10.0`**. The assembled app declares `12.9.0` as a dependency; electron-builder 26's pnpm `NodeModulesCollector` keeps a dependency only when the on-disk version semver-satisfies the pin. `12.10.0` does not satisfy exact `12.9.0`, so the collector **drops** `better-sqlite3` from `Contents/Resources/app/node_modules` with a non-fatal warning, and the prebundled daemon's `import Database from 'better-sqlite3'` can't resolve at runtime → `ERR_MODULE_NOT_FOUND` (a specifier-resolution failure, not a native `.node` load error — which is why even pure-wasm `blake3-wasm` can throw the same error when it's dropped too). `blake3-wasm` is pinned `2.1.5` matching disk, so it usually survives.

Chronic since ≥0.13.0 because the stale pin + the electron-builder-26 pnpm collector have been in place the whole time; whether the drop happens is environment-sensitive (pnpm-vs-traversal collector path), so it's a large-but-not-universal share.

## What users will see

Packaged macOS (and Windows) users whose daemon was silently missing its database module will have the app actually start instead of crash-looping. No UI change.

## What changed

Bump the pin to `12.10.0` in both prebundle manifests to match the daemon / lockfile. Unit assertions updated — they are a red-on-`main` (which pins `12.9.0`) / green-here spec.

## Validation

- `@open-design/tools-pack typecheck` green; `prebundle` unit tests green (20 passed).
- **Not yet validated on a real packaged build** (needs a GUI mac + full DMG build): the definitive confirmation is a packaged mac app where the daemon starts and `Contents/Resources/app/node_modules/better-sqlite3` is present. Recommend a maintainer run one `tools-pack mac build` + launch before/after, per the bug-verification workflow.

## Surface area

- [x] Packaging / `tools/pack` (mac + win prebundle manifests)
- No UI/CLI/contract/i18n/env surface — this is a build-manifest version alignment.

## Follow-ups (not in this PR)

- **Fail loud, never ship broken again:** add a post-build assertion that `Contents/Resources/app/node_modules/better-sqlite3/package.json` (+ `better_sqlite3.node` ≥ threshold) exists and throw if missing — `mac/report.ts` already computes `betterSqlite3Bytes`, so this is a threshold check. Would have caught every affected release.
- **Durable drift guard:** a consistency check that the prebundle pin equals `apps/daemon/package.json`'s `better-sqlite3` — this observes two package boundaries so it belongs in `e2e/tests/` per the repo boundary rule.
- **Deterministic collection:** give the assembled app an npm identity (drop `--no-package-lock`, or add a `packageManager` field) so electron-builder doesn't misdetect pnpm and semver-drop deps in the first place.

Addresses the dominant driver of #4638.