### PR TITLE
fix(collab): harden workspace resource synchronization

### DIFF
--- a/apps/daemon/src/collab/publish-scheduler.ts
+++ b/apps/daemon/src/collab/publish-scheduler.ts
@@ -18,6 +18,11 @@ export interface ResourcePublishInput {
   principal?: ResourceHubPrincipal;
 }
 
+export interface PublishedResourceVersion {
+  version: number;
+  versionId?: string;
+}
+
 export interface ResourcePublishAdapter {
   /**
    * Publish the current state of a project's sync unit to the resource hub and
@@ -25,14 +30,14 @@ export interface ResourcePublishAdapter {
    * written (content-first / pointer-last). Returns the new version, or null if
    * there was nothing to publish.
    */
-  publish(input: ResourcePublishInput & { reason: string }): Promise<{ version: number } | null>;
+  publish(input: ResourcePublishInput & { reason: string }): Promise<PublishedResourceVersion | null>;
   /**
    * Read the currently-published head for a project. The scheduler decides
    * *when* a member pulls; the adapter reports what head is available. Optional:
    * the local stub reports the in-memory head; the real hub adapter resolves the
    * published ref. Returns null when nothing has been published yet.
    */
-  syncLatest?(input: ResourcePublishInput): Promise<{ version: number } | null>;
+  syncLatest?(input: ResourcePublishInput): Promise<PublishedResourceVersion | null>;
   /**
    * Materialize the published tree into the member's local copy. Optional: the
    * local stub has no bytes to fetch; the real hub adapter fetches the missing
@@ -52,7 +57,12 @@ export interface CollabPublishSchedulerOptions {
   /** Coalesce window (ms). Rapid changes within it collapse into one publish. */
   debounceMs?: number;
   /** Fired after a successful publish so the orchestrator can notify members. */
-  onPublished?: (result: { projectId: string; version: number; reason: string }) => void;
+  onPublished?: (result: {
+    projectId: string;
+    version: number;
+    versionId?: string;
+    reason: string;
+  }) => void;
   onError?: (result: { projectId: string; error: unknown }) => void;
 }
 
@@ -133,7 +143,14 @@ export class CollabPublishScheduler {
     const reason = state.reason;
     try {
       const result = await this.adapter.publish({ projectId, reason });
-      if (result) this.onPublished?.({ projectId, version: result.version, reason });
+      if (result) {
+        this.onPublished?.({
+          projectId,
+          version: result.version,
+          ...(result.versionId ? { versionId: result.versionId } : {}),
+          reason,
+        });
+      }
     } catch (error) {
       this.onError?.({ projectId, error });
     } finally {

--- a/apps/daemon/src/collab/resource-principal.ts
+++ b/apps/daemon/src/collab/resource-principal.ts
@@ -17,7 +17,11 @@ export interface ResourceHubPrincipal {
 export function contextToResourceHubPrincipal(
   context: WorkspaceCollabContext | null,
 ): ResourceHubPrincipal | null {
-  if (!context?.workspaceId || !context.workspaceMemberId) return null;
+  if (
+    context?.workspaceType !== 'team' ||
+    !context.workspaceId ||
+    !context.workspaceMemberId
+  ) return null;
   return {
     memberId: context.workspaceMemberId,
     teamId: context.teamId ?? context.workspaceId,

--- a/apps/daemon/src/collab/runtime.ts
+++ b/apps/daemon/src/collab/runtime.ts
@@ -14,6 +14,7 @@ import {
 import {
   CollabPublishScheduler,
   type CollabPublishSchedulerOptions,
+  type PublishedResourceVersion,
   type ResourcePublishAdapter,
 } from './publish-scheduler.js';
 import {
@@ -74,7 +75,7 @@ export interface CollabRuntime {
   requestTeamShare(
     projectId: string,
     share?: string | ResourceHubPrincipal,
-  ): Promise<{ version: number | null }>;
+  ): Promise<{ version: number | null; versionId?: string }>;
   /** Move a project out of the team space. */
   requestTeamUnshare(projectId: string, principal?: ResourceHubPrincipal | null): Promise<void>;
   /** Restore a persisted team share into runtime bookkeeping without publishing. */
@@ -104,6 +105,7 @@ export interface CreateCollabRuntimeOptions {
   onPublished?: (result: {
     projectId: string;
     version: number;
+    versionId?: string;
     reason: string;
     principal: ResourceHubPrincipal | null;
   }) => void;
@@ -133,12 +135,16 @@ function selectResourcePublishAdapter(
 export function createCollabRuntime(options: CreateCollabRuntimeOptions = {}): CollabRuntime {
   const workspaceContext = options.workspaceContext ?? createWorkspaceContextProviderFromEnv();
   const sharePrincipals = new Map<string, Map<string, ResourceHubPrincipal>>();
+  const knownScopedPrincipals = new Map<string, ResourceHubPrincipal>();
   const scopedOwners = new Map<string, string>();
   const published = new Map<string, number>();
   const syncStates = new Map<string, ProjectSyncState>();
   const owners = new Map<string, string>();
   const unshared = new Set<string>();
-  const barePublishResults = new Map<string, Map<string, number>>();
+  const barePublishResults = new Map<
+    string,
+    Map<string, PublishedResourceVersion>
+  >();
   const SCOPED_PROJECT_SEPARATOR = '\u0000';
 
   const scopedProjectKey = (projectId: string, principal: ResourceHubPrincipal) =>
@@ -151,9 +157,8 @@ export function createCollabRuntime(options: CreateCollabRuntimeOptions = {}): C
   function parseScopedProjectKey(key: string) {
     const separatorIndex = key.indexOf(SCOPED_PROJECT_SEPARATOR);
     if (separatorIndex < 0) return { projectId: key, principal: null };
-    const teamId = key.slice(0, separatorIndex);
     const projectId = key.slice(separatorIndex + SCOPED_PROJECT_SEPARATOR.length);
-    return { projectId, principal: sharePrincipals.get(projectId)?.get(teamId) ?? null };
+    return { projectId, principal: knownScopedPrincipals.get(key) ?? null };
   }
 
   const getProjectPrincipal = async (projectId?: string) => {
@@ -179,6 +184,7 @@ export function createCollabRuntime(options: CreateCollabRuntimeOptions = {}): C
     share: ResourceHubPrincipal,
     syncState?: ProjectSyncState,
   ) {
+    knownScopedPrincipals.set(scopedProjectKey(projectId, share), share);
     owners.set(projectId, share.memberId);
     scopedOwners.set(scopedProjectKey(projectId, share), share.memberId);
     let principals = sharePrincipals.get(projectId);
@@ -193,10 +199,41 @@ export function createCollabRuntime(options: CreateCollabRuntimeOptions = {}): C
     }
   }
 
+  function refreshProjectAggregate(projectId: string) {
+    const principals = principalsForProject(projectId);
+    if (principals.length === 0) {
+      owners.delete(projectId);
+      published.delete(projectId);
+      syncStates.set(projectId, 'local_only');
+      return;
+    }
+
+    owners.set(projectId, principals[0]!.memberId);
+    const remainingVersions = principals
+      .map((candidate) => published.get(scopedProjectKey(projectId, candidate)))
+      .filter((version): version is number => version != null);
+    const aggregateVersion = remainingVersions.at(-1);
+    if (aggregateVersion == null) published.delete(projectId);
+    else published.set(projectId, aggregateVersion);
+
+    const remainingStates = principals.map(
+      (candidate) => syncStates.get(scopedProjectKey(projectId, candidate)) ?? 'local_only',
+    );
+    const aggregateState = remainingStates.includes('pending_upload')
+      ? 'pending_upload'
+      : remainingStates.includes('sync_failed')
+        ? 'sync_failed'
+        : remainingStates.includes('synced')
+          ? 'synced'
+          : 'local_only';
+    syncStates.set(projectId, aggregateState);
+  }
+
   async function markTeamProject(
     projectId: string,
     syncState: TeamProjectCatalogSyncState,
     principal?: ResourceHubPrincipal | null,
+    lastSyncedVersionId?: string,
   ) {
     const descriptor = await options.describeProject?.(projectId) ?? null;
     const displayName = typeof descriptor?.name === 'string'
@@ -216,6 +253,7 @@ export function createCollabRuntime(options: CreateCollabRuntimeOptions = {}): C
           resourceId: projectResourceIdFor(projectId, target),
           ...(displayName ? { displayName } : {}),
           syncState,
+          ...(lastSyncedVersionId ? { lastSyncedVersionId } : {}),
           ...(descriptor ? { metadata: descriptor } : {}),
         },
         target,
@@ -227,8 +265,14 @@ export function createCollabRuntime(options: CreateCollabRuntimeOptions = {}): C
     projectId: string,
     syncState: TeamProjectCatalogSyncState,
     principal?: ResourceHubPrincipal | null,
+    lastSyncedVersionId?: string,
   ) {
-    void markTeamProject(projectId, syncState, principal).catch((error) => {
+    void markTeamProject(
+      projectId,
+      syncState,
+      principal,
+      lastSyncedVersionId,
+    ).catch((error) => {
       const principals = principal ? [principal] : principalsForProject(projectId);
       if (principals.length === 0) {
         options.onError?.({ projectId, error, principal: null });
@@ -246,17 +290,20 @@ export function createCollabRuntime(options: CreateCollabRuntimeOptions = {}): C
       if (!principal) {
         const principals = principalsForProject(projectId);
         if (principals.length > 0) {
-          const versions = new Map<string, number>();
+          const versions = new Map<string, PublishedResourceVersion>();
           for (const scopedPrincipal of principals) {
             const result = await baseAdapter.publish({
               projectId,
               reason,
               principal: scopedPrincipal,
             });
-            if (result) versions.set(scopedPrincipal.teamId, result.version);
+            if (result) versions.set(scopedPrincipal.teamId, result);
           }
           barePublishResults.set(projectId, versions);
-          return versions.size > 0 ? { version: Math.max(...versions.values()) } : null;
+          if (versions.size === 0) return null;
+          return [...versions.values()].reduce((highest, candidate) =>
+            candidate.version > highest.version ? candidate : highest,
+          );
         }
       }
       return baseAdapter.publish({
@@ -298,8 +345,9 @@ export function createCollabRuntime(options: CreateCollabRuntimeOptions = {}): C
     projectId: string,
     reason: string,
     principal?: ResourceHubPrincipal | null,
-  ): Promise<{ version: number | null }> {
+  ): Promise<{ version: number | null; versionId?: string }> {
     const key = principal ? scopedProjectKey(projectId, principal) : projectId;
+    let publishedResult: PublishedResourceVersion | null = null;
     try {
       const result = await baseAdapter.publish({
         projectId,
@@ -307,15 +355,19 @@ export function createCollabRuntime(options: CreateCollabRuntimeOptions = {}): C
         ...(principal ? { principal } : {}),
       });
       if (!result) return { version: null };
+      publishedResult = result;
       if (unshared.has(key) || unshared.has(projectId)) {
         await baseAdapter.unpublish?.({
           projectId,
           ...(principal ? { principal } : {}),
         });
-        published.delete(projectId);
         published.delete(key);
-        syncStates.set(projectId, 'local_only');
         syncStates.set(key, 'local_only');
+        if (principal) refreshProjectAggregate(projectId);
+        else {
+          published.delete(projectId);
+          syncStates.set(projectId, 'local_only');
+        }
         return { version: null };
       }
       published.set(projectId, result.version);
@@ -324,10 +376,34 @@ export function createCollabRuntime(options: CreateCollabRuntimeOptions = {}): C
         published.set(key, result.version);
         syncStates.set(key, 'synced');
       }
-      markTeamProjectSoon(projectId, 'synced', principal);
-      options.onPublished?.({ projectId, version: result.version, reason, principal: principal ?? null });
-      return { version: result.version };
+      await markTeamProject(
+        projectId,
+        'synced',
+        principal,
+        result.versionId,
+      );
+      options.onPublished?.({
+        projectId,
+        version: result.version,
+        ...(result.versionId ? { versionId: result.versionId } : {}),
+        reason,
+        principal: principal ?? null,
+      });
+      return {
+        version: result.version,
+        ...(result.versionId ? { versionId: result.versionId } : {}),
+      };
     } catch (error) {
+      if (publishedResult) {
+        await baseAdapter.unpublish?.({
+          projectId,
+          ...(principal ? { principal } : {}),
+        }).catch(() => undefined);
+        await options.teamProjectCatalog?.remove?.(
+          projectId,
+          principal,
+        ).catch(() => undefined);
+      }
       syncStates.set(projectId, 'sync_failed');
       if (principal) syncStates.set(key, 'sync_failed');
       options.onError?.({ projectId, error, principal: principal ?? null });
@@ -340,14 +416,17 @@ export function createCollabRuntime(options: CreateCollabRuntimeOptions = {}): C
     onPublished: (result) => {
       const { projectId, principal } = parseScopedProjectKey(result.projectId);
       const key = principal ? scopedProjectKey(projectId, principal) : projectId;
-      if (unshared.has(key) || unshared.has(projectId)) {
+      if (unshared.has(result.projectId) || unshared.has(key) || unshared.has(projectId)) {
         void schedulerAdapter.unpublish?.({ projectId: result.projectId }).catch((error: unknown) => {
           options.onError?.({ projectId, error, principal });
         });
-        published.delete(projectId);
         published.delete(key);
-        syncStates.set(projectId, 'local_only');
         syncStates.set(key, 'local_only');
+        if (principal) refreshProjectAggregate(projectId);
+        else {
+          published.delete(projectId);
+          syncStates.set(projectId, 'local_only');
+        }
         return;
       }
       published.set(projectId, result.version);
@@ -355,19 +434,40 @@ export function createCollabRuntime(options: CreateCollabRuntimeOptions = {}): C
       if (principal) {
         published.set(key, result.version);
         syncStates.set(key, 'synced');
-        markTeamProjectSoon(projectId, 'synced', principal);
+        markTeamProjectSoon(
+          projectId,
+          'synced',
+          principal,
+          result.versionId,
+        );
         options.onPublished?.({ ...result, projectId, principal });
         return;
       }
       const versions = barePublishResults.get(projectId);
       if (versions) {
         for (const scopedPrincipal of principalsForProject(projectId)) {
-          const version = versions.get(scopedPrincipal.teamId);
-          if (version === undefined) continue;
-          published.set(scopedProjectKey(projectId, scopedPrincipal), version);
+          const publishedResult = versions.get(scopedPrincipal.teamId);
+          if (!publishedResult) continue;
+          published.set(
+            scopedProjectKey(projectId, scopedPrincipal),
+            publishedResult.version,
+          );
           syncStates.set(scopedProjectKey(projectId, scopedPrincipal), 'synced');
-          markTeamProjectSoon(projectId, 'synced', scopedPrincipal);
-          options.onPublished?.({ projectId, version, reason: result.reason, principal: scopedPrincipal });
+          markTeamProjectSoon(
+            projectId,
+            'synced',
+            scopedPrincipal,
+            publishedResult.versionId,
+          );
+          options.onPublished?.({
+            projectId,
+            version: publishedResult.version,
+            ...(publishedResult.versionId
+              ? { versionId: publishedResult.versionId }
+              : {}),
+            reason: result.reason,
+            principal: scopedPrincipal,
+          });
         }
         barePublishResults.delete(projectId);
         return;
@@ -378,9 +478,10 @@ export function createCollabRuntime(options: CreateCollabRuntimeOptions = {}): C
     onError: (result) => {
       const { projectId, principal } = parseScopedProjectKey(result.projectId);
       const key = principal ? scopedProjectKey(projectId, principal) : projectId;
-      if (unshared.has(key) || unshared.has(projectId)) {
-        syncStates.set(projectId, 'local_only');
+      if (unshared.has(result.projectId) || unshared.has(key) || unshared.has(projectId)) {
         syncStates.set(key, 'local_only');
+        if (principal) refreshProjectAggregate(projectId);
+        else syncStates.set(projectId, 'local_only');
         return;
       }
       syncStates.set(projectId, 'sync_failed');
@@ -424,7 +525,7 @@ export function createCollabRuntime(options: CreateCollabRuntimeOptions = {}): C
     },
     projectSyncState: (projectId, principal) => {
       if (principal) {
-        return syncStates.get(scopedProjectKey(projectId, principal)) ?? syncStates.get(projectId) ?? 'local_only';
+        return syncStates.get(scopedProjectKey(projectId, principal)) ?? 'local_only';
       }
       const states = principalsForProject(projectId)
         .map((candidate) => syncStates.get(scopedProjectKey(projectId, candidate)))
@@ -447,13 +548,13 @@ export function createCollabRuntime(options: CreateCollabRuntimeOptions = {}): C
       return publishNow(projectId, 'share', principal);
     },
     async requestTeamUnshare(projectId, principal) {
-      unshared.add(projectId);
       const targets = principal
         ? [principal]
         : principalsForProject(projectId).length > 0
           ? principalsForProject(projectId)
           : [await getProjectPrincipal(projectId)].filter((candidate): candidate is ResourceHubPrincipal => Boolean(candidate));
       if (targets.length === 0) {
+        unshared.add(projectId);
         await baseAdapter.unpublish?.({ projectId });
       }
       for (const target of targets) {
@@ -464,14 +565,25 @@ export function createCollabRuntime(options: CreateCollabRuntimeOptions = {}): C
         published.delete(key);
         syncStates.set(key, 'local_only');
         scopedOwners.delete(key);
+        sharePrincipals.get(projectId)?.delete(target.teamId);
       }
+      if (principal) {
+        if (sharePrincipals.get(projectId)?.size === 0) {
+          sharePrincipals.delete(projectId);
+          unshared.add(projectId);
+        }
+        refreshProjectAggregate(projectId);
+        return;
+      }
+
+      unshared.add(projectId);
       owners.delete(projectId);
       published.delete(projectId);
       syncStates.set(projectId, 'local_only');
       sharePrincipals.delete(projectId);
     },
     projectOwnerMemberId: (projectId, principal) => {
-      if (principal) return scopedOwners.get(scopedProjectKey(projectId, principal)) ?? owners.get(projectId) ?? null;
+      if (principal) return scopedOwners.get(scopedProjectKey(projectId, principal)) ?? null;
       return owners.get(projectId) ?? null;
     },
     rememberTeamShare,

--- a/apps/daemon/src/collab/team-resource-share.ts
+++ b/apps/daemon/src/collab/team-resource-share.ts
@@ -26,6 +26,8 @@ export interface TeamResourceShareRecord {
   description?: string;
   ownerMemberId?: string;
   canUnshare?: boolean;
+  versionId?: string;
+  version?: number;
 }
 
 export interface TeamResourceShareService {
@@ -64,7 +66,7 @@ export interface CreateTeamResourceShareOptions {
   /** Optional resource-index metadata shown in teammate team lists. */
   describeResource?: (resourceId: string) => Record<string, unknown> | null | Promise<Record<string, unknown> | null>;
   /** Injectable Vela resource runner for tests. */
-  run?: (args: string[]) => Promise<string>;
+  run?: (args: string[], workspaceId?: string) => Promise<string>;
   env?: NodeJS.ProcessEnv;
 }
 
@@ -96,6 +98,12 @@ export function createTeamResourceShareService(
   // the hub; this is the fast local view the team collection reads until a hub
   // listing query lands.
   const shared = new Set<string>();
+  let sharedWorkspaceId: string | null = null;
+  const activateWorkspace = (workspaceId: string) => {
+    if (sharedWorkspaceId === workspaceId) return;
+    sharedWorkspaceId = workspaceId;
+    shared.clear();
+  };
 
   const adapter: ResourcePublishAdapter = createVelaCliResourceAdapter({
     resolveProjectDir: options.resolveDir,
@@ -116,18 +124,26 @@ export function createTeamResourceShareService(
         if (await options.getPrincipal()) throw new TeamResourceShareForbiddenError();
         return null;
       }
-      const result = await adapter.publish({ projectId: resourceId, reason: 'share' });
+      const principal = await options.getPrincipal();
+      if (!principal) return null;
+      activateWorkspace(principal.teamId);
+      const result = await adapter.publish({
+        projectId: resourceId,
+        principal,
+        reason: 'share',
+      });
       if (result) shared.add(resourceId);
       return result;
     },
     async unshare(resourceId) {
       const principal = await options.getPrincipal();
       if (!principal) return false;
+      activateWorkspace(principal.teamId);
       const sharedResource = (await this.sharedResources()).find((resource) => resource.id === resourceId);
       if (sharedResource && !sharedResource.canUnshare) {
         throw new TeamResourceShareForbiddenError();
       }
-      await adapter.unpublish?.({ projectId: resourceId });
+      await adapter.unpublish?.({ projectId: resourceId, principal });
       shared.delete(resourceId);
       return true;
     },
@@ -137,8 +153,12 @@ export function createTeamResourceShareService(
     async sharedResources() {
       const principal = await options.getPrincipal();
       if (!principal) return [];
+      activateWorkspace(principal.teamId);
       try {
-        const out = await (options.run ?? defaultRun)(['shared', '--json']);
+        const out = await (options.run ?? defaultRun)(
+          ['shared', '--json'],
+          principal.teamId,
+        );
         const scopedResources = parseSharedResourceRecords(out, options.kind, scopedIdPrefixFor(principal));
         const legacyResources = principal.workspaceType === 'personal'
           ? []
@@ -150,10 +170,14 @@ export function createTeamResourceShareService(
         shared.clear();
         for (const resource of resources) shared.add(resource.id);
         return resources
-          .map((resource) => ({
-            ...resource,
-            canUnshare: canManageSharedResource(principal, resource),
-          }))
+          .map((resource) => {
+            // Keep the non-enumerable hubResourceId attached for the local
+            // materializer. Spreading into a new object drops that descriptor
+            // and makes workspace-scoped resources fall back to the legacy,
+            // unscoped id when a teammate pulls them.
+            resource.canUnshare = canManageSharedResource(principal, resource);
+            return resource;
+          })
           .sort((a, b) => a.id.localeCompare(b.id));
       } catch {
         return [...shared].sort().map((id) => ({ id, canUnshare: true }));
@@ -164,9 +188,9 @@ export function createTeamResourceShareService(
   };
 }
 
-async function defaultRun(args: string[]): Promise<string> {
+async function defaultRun(args: string[], workspaceId?: string): Promise<string> {
   const { runVelaResourceCommand } = await import('./vela-cli-resource-adapter.js');
-  return runVelaResourceCommand(args);
+  return runVelaResourceCommand(args, workspaceId);
 }
 
 interface SharedResourceListPayload {
@@ -176,6 +200,7 @@ interface SharedResourceListPayload {
     deletedAt?: unknown;
     metadata?: unknown;
     ownerMemberId?: unknown;
+    publishedVersion?: unknown;
   }>;
 }
 
@@ -214,11 +239,20 @@ export function parseSharedResourceRecords(
     const title = stringValue(metadata.title) || stringValue(metadata.name);
     const description = stringValue(metadata.description);
     const ownerMemberId = stringValue(resource.ownerMemberId);
+    const publishedVersion = isObjectRecord(resource.publishedVersion)
+      ? resource.publishedVersion
+      : null;
+    const versionId = stringValue(publishedVersion?.id);
+    const version = typeof publishedVersion?.version === 'number'
+      ? publishedVersion.version
+      : undefined;
     const record: TeamResourceShareRecord = {
       id: localId,
       ...(title ? { title } : {}),
       ...(description ? { description } : {}),
       ...(ownerMemberId ? { ownerMemberId } : {}),
+      ...(versionId ? { versionId } : {}),
+      ...(version !== undefined ? { version } : {}),
     };
     Object.defineProperty(record, 'hubResourceId', {
       value: resource.id,

--- a/apps/daemon/src/collab/team-resource-version-store.ts
+++ b/apps/daemon/src/collab/team-resource-version-store.ts
@@ -1,0 +1,59 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+type StoredVersions = Record<string, string>;
+
+export interface TeamResourceVersionStore {
+  get(workspaceId: string, kind: string, resourceId: string): string | null;
+  set(
+    workspaceId: string,
+    kind: string,
+    resourceId: string,
+    versionId: string,
+  ): Promise<void>;
+}
+
+function versionKey(workspaceId: string, kind: string, resourceId: string) {
+  return JSON.stringify([workspaceId, kind, resourceId]);
+}
+
+export function createTeamResourceVersionStore(
+  runtimeDataDir: string,
+): TeamResourceVersionStore {
+  const filePath = path.join(runtimeDataDir, 'team-resource-versions.json');
+  let versions: StoredVersions = {};
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      versions = Object.fromEntries(
+        Object.entries(parsed).filter(
+          (entry): entry is [string, string] =>
+            typeof entry[1] === 'string' && entry[1].length > 0,
+        ),
+      );
+    }
+  } catch {
+    versions = {};
+  }
+
+  let writeQueue = Promise.resolve();
+  return {
+    get(workspaceId, kind, resourceId) {
+      return versions[versionKey(workspaceId, kind, resourceId)] ?? null;
+    },
+    async set(workspaceId, kind, resourceId, versionId) {
+      versions[versionKey(workspaceId, kind, resourceId)] = versionId;
+      writeQueue = writeQueue.catch(() => undefined).then(async () => {
+        await fs.promises.mkdir(runtimeDataDir, { recursive: true });
+        const tempPath = `${filePath}.${process.pid}.tmp`;
+        await fs.promises.writeFile(
+          tempPath,
+          `${JSON.stringify(versions, null, 2)}\n`,
+          { encoding: 'utf8', mode: 0o600 },
+        );
+        await fs.promises.rename(tempPath, filePath);
+      });
+      await writeQueue;
+    },
+  };
+}

--- a/apps/daemon/src/collab/vela-cli-collab-client.ts
+++ b/apps/daemon/src/collab/vela-cli-collab-client.ts
@@ -4,12 +4,19 @@ import type {
   CollabMemberRole,
   CollabPresenceMember,
 } from '@open-design/contracts';
-import { runVelaCommand } from '../integrations/vela-command.js';
+import {
+  runVelaCommand,
+  velaWorkspaceCommandOptions,
+} from '../integrations/vela-command.js';
 
-export type RunVelaCollab = (args: string[]) => Promise<string>;
+export type RunVelaCollab = (
+  args: string[],
+  workspaceId?: string,
+) => Promise<string>;
 
 export interface VelaCliCollabClientOptions {
   run?: RunVelaCollab;
+  getWorkspaceId?: () => string | null | undefined;
 }
 
 type MemberWire = {
@@ -47,8 +54,10 @@ type PresenceActivity = Exclude<CollabPresenceMember['activity'], undefined>;
 export function createVelaCliCollabClient(options: VelaCliCollabClientOptions = {}) {
   const run = options.run ?? defaultRunVelaCollab;
 
-  async function runJson<T>(args: string[]): Promise<T> {
-    const stdout = await run(args);
+  async function runJson<T>(args: string[], workspaceId?: string): Promise<T> {
+    const requestedWorkspaceId =
+      workspaceId?.trim() || options.getWorkspaceId?.()?.trim() || undefined;
+    const stdout = await run(args, requestedWorkspaceId);
     const trimmed = stdout.trim();
     if (!trimmed) return {} as T;
     return JSON.parse(trimmed) as T;
@@ -65,12 +74,15 @@ export function createVelaCliCollabClient(options: VelaCliCollabClientOptions = 
       input: { displayName: string; role: CollabMemberRole },
     ): Promise<CollabCloudMemberDirectoryEntry> {
       const args = ['member', 'register', '--display-name', input.displayName, '--role', input.role];
-      const payload = await runJson<{ member?: MemberWire }>(args);
+      const payload = await runJson<{ member?: MemberWire }>(args, _teamId);
       return toDirectoryEntry(payload.member);
     },
 
     async listMembers(_teamId: string): Promise<CollabCloudMemberDirectoryEntry[]> {
-      const payload = await runJson<{ members?: MemberWire[] }>(['member', 'list']);
+      const payload = await runJson<{ members?: MemberWire[] }>(
+        ['member', 'list'],
+        _teamId,
+      );
       return Array.isArray(payload.members) ? payload.members.map(toDirectoryEntry) : [];
     },
 
@@ -85,7 +97,7 @@ export function createVelaCliCollabClient(options: VelaCliCollabClientOptions = 
         projectId,
         '--comment-json',
         JSON.stringify(comment),
-      ]);
+      ], _teamId);
       return { seq: typeof payload.seq === 'number' ? payload.seq : 0 };
     },
 
@@ -105,7 +117,7 @@ export function createVelaCliCollabClient(options: VelaCliCollabClientOptions = 
         projectId,
         '--since-seq',
         String(sinceSeq),
-      ]);
+      ], _teamId);
       const comments = Array.isArray(payload.comments)
         ? (payload.comments as CollabCloudComment[])
         : [];
@@ -202,8 +214,11 @@ function isRole(value: unknown): value is CollabMemberRole {
   return value === 'owner' || value === 'admin' || value === 'member';
 }
 
-const defaultRunVelaCollab: RunVelaCollab = (args) =>
-  runVelaCommand(['collab', ...args]);
+const defaultRunVelaCollab: RunVelaCollab = (args, workspaceId) =>
+  runVelaCommand(
+    ['collab', ...args],
+    velaWorkspaceCommandOptions(workspaceId),
+  );
 
 export function shouldUseVelaCliCollabTransport(
   env: NodeJS.ProcessEnv = process.env,
@@ -218,6 +233,9 @@ export function shouldUseVelaCliCollabTransport(
 
 export function createVelaCliCollabClientFromEnv(
   env: NodeJS.ProcessEnv = process.env,
+  options: Omit<VelaCliCollabClientOptions, 'run'> = {},
 ): VelaCliCollabClient | null {
-  return shouldUseVelaCliCollabTransport(env) ? createVelaCliCollabClient() : null;
+  return shouldUseVelaCliCollabTransport(env)
+    ? createVelaCliCollabClient(options)
+    : null;
 }

--- a/apps/daemon/src/collab/vela-cli-resource-adapter.ts
+++ b/apps/daemon/src/collab/vela-cli-resource-adapter.ts
@@ -1,5 +1,8 @@
 import type { WorkspaceCollabContext } from '@open-design/contracts';
-import { runVelaCommand } from '../integrations/vela-command.js';
+import {
+  runVelaCommand,
+  velaWorkspaceCommandOptions,
+} from '../integrations/vela-command.js';
 import { projectResourceIdFor } from '../integrations/vela-team-projects.js';
 import type { ResourcePublishAdapter } from './publish-scheduler.js';
 import type { ResourceHubPrincipal } from './resource-principal.js';
@@ -20,10 +23,32 @@ const MEMBER_MIRROR_EXCLUDED_ENTRIES = [
   '.file-versions',
   '.live-artifacts',
   '.od-skills',
+  '.git',
+  'node_modules',
+  '.npmrc',
+  '.yarnrc',
+  '.yarnrc.yml',
+  '.aws',
+  '.ssh',
+  '.azure',
+  '.docker',
+  '.gnupg',
+  '.kube',
+  '.pulumi',
+  '.terraform',
+  '.git-credentials',
+  '.netrc',
+  '.pypirc',
+  'terraform.tfstate',
+  'terraform.tfstate.backup',
 ] as const;
+const MEMBER_MIRROR_EXCLUDED_PREFIXES = ['.env'] as const;
 
 /** Run `vela resource <args>` and resolve its stdout. */
-export type RunVelaResource = (args: string[]) => Promise<string>;
+export type RunVelaResource = (
+  args: string[],
+  workspaceId?: string,
+) => Promise<string>;
 
 export interface VelaCliResourceAdapterOptions {
   /** The project's source directory to publish (managed-project root). */
@@ -48,6 +73,7 @@ export interface VelaCliResourceAdapterOptions {
 }
 
 interface VelaVersionRecord {
+  id?: string;
   version?: number;
 }
 
@@ -86,6 +112,9 @@ export function createVelaCliResourceAdapter(
         for (const name of MEMBER_MIRROR_EXCLUDED_ENTRIES) {
           args.push('--exclude', name);
         }
+        for (const prefix of MEMBER_MIRROR_EXCLUDED_PREFIXES) {
+          args.push('--exclude-prefix', prefix);
+        }
         const metadata = await options.describeProject?.(projectId);
         const resourceMetadata = kind === PROJECT_KIND
           ? { projectId, ...(metadata ?? {}) }
@@ -93,9 +122,8 @@ export function createVelaCliResourceAdapter(
         if (resourceMetadata && Object.keys(resourceMetadata).length > 0) {
           args.push('--metadata-json', JSON.stringify(resourceMetadata));
         }
-        const out = await run(args);
-        const version = parseVersion(out);
-        return version == null ? null : { version };
+        const out = await run(args, principal?.teamId);
+        return parseVersion(out);
       }, null);
     },
 
@@ -104,9 +132,12 @@ export function createVelaCliResourceAdapter(
         // `head` reports the published version without downloading — a null
         // version means nothing is published yet.
         for (const resourceId of resourceIdsFor(projectId, principal)) {
-          const out = await run(['head', resourceId, '--ref', PUBLISHED_REF, '--json']);
+          const out = await run(
+            ['head', resourceId, '--ref', PUBLISHED_REF, '--json'],
+            principal?.teamId,
+          );
           const version = parseVersion(out);
-          if (version != null) return { version };
+          if (version != null) return version;
         }
         return null;
       }, null);
@@ -116,12 +147,20 @@ export function createVelaCliResourceAdapter(
       await gated(async () => {
         const dir = await resolvePullDir(projectId);
         let lastError: unknown;
-        for (const resourceId of resourceIdsFor(projectId, principal)) {
+        const resourceIds = resourceIdsFor(projectId, principal);
+        for (const [index, resourceId] of resourceIds.entries()) {
           try {
-            await run(['pull', kind, resourceId, dir, '--ref', PUBLISHED_REF, '--json']);
+            await run(
+              ['pull', kind, resourceId, dir, '--ref', PUBLISHED_REF, '--json'],
+              principal?.teamId,
+            );
             return;
           } catch (error) {
             lastError = error;
+            if (
+              index === resourceIds.length - 1 ||
+              !isMissingResourceError(error)
+            ) throw error;
           }
         }
         throw lastError;
@@ -130,24 +169,39 @@ export function createVelaCliResourceAdapter(
 
     async unpublish({ projectId, principal }) {
       await gated(async () => {
-        await run(['remove', resourceIdFor(projectId, principal), '--json']);
+        await run(
+          ['remove', resourceIdFor(projectId, principal), '--json'],
+          principal?.teamId,
+        );
       }, undefined);
     },
   };
 }
 
+function isMissingResourceError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /resource_not_found|status\s+404|ref_not_found/u.test(message);
+}
+
 /** Parse the `version` field out of a `vela resource` --json line. Returns null
  *  when the field is absent or explicitly null (e.g. `head` on an unpublished
  *  resource), so callers treat "nothing published" as a clean empty result. */
-function parseVersion(stdout: string): number | null {
+function parseVersion(
+  stdout: string,
+): { version: number; versionId?: string } | null {
   const trimmed = stdout.trim();
   if (!trimmed) return null;
-  try {
-    const parsed = JSON.parse(trimmed) as VelaVersionRecord;
-    return typeof parsed.version === 'number' ? parsed.version : null;
-  } catch {
-    return null;
+  const parsed = JSON.parse(trimmed) as VelaVersionRecord;
+  if (parsed.version == null) return null;
+  if (typeof parsed.version !== 'number') {
+    throw new Error('vela resource response has an invalid version');
   }
+  return {
+    version: parsed.version,
+    ...(typeof parsed.id === 'string' && parsed.id.trim()
+      ? { versionId: parsed.id.trim() }
+      : {}),
+  };
 }
 
 export function parseVelaResourceSnapshot(stdout: string): VelaResourceSnapshotRecord | null {
@@ -169,8 +223,11 @@ export function parseVelaResourceSnapshot(stdout: string): VelaResourceSnapshotR
   }
 }
 
-export const runVelaResourceCommand: RunVelaResource = (args) =>
-  runVelaCommand(['resource', ...args]);
+export const runVelaResourceCommand: RunVelaResource = (args, workspaceId) =>
+  runVelaCommand(
+    ['resource', ...args],
+    velaWorkspaceCommandOptions(workspaceId),
+  );
 
 const defaultRunVelaResource: RunVelaResource = runVelaResourceCommand;
 
@@ -191,5 +248,9 @@ export function shouldUseVelaCliResourceTransport(env: NodeJS.ProcessEnv = proce
 
 /** Derive the resource-identity gate from the one workspace context. */
 export function contextHasTeamIdentity(context: WorkspaceCollabContext | null): boolean {
-  return Boolean(context?.workspaceId && context.workspaceMemberId);
+  return Boolean(
+    context?.workspaceType === 'team' &&
+    context.workspaceId &&
+    context.workspaceMemberId,
+  );
 }

--- a/apps/daemon/src/collab/vela-cli-team-projects.ts
+++ b/apps/daemon/src/collab/vela-cli-team-projects.ts
@@ -5,17 +5,27 @@ import type {
   VelaTeamProjectRecord,
   VelaTeamProjectSyncState,
 } from '../integrations/vela-team-projects.js';
-import { runVelaCommand } from '../integrations/vela-command.js';
+import {
+  runVelaCommand,
+  velaWorkspaceCommandOptions,
+} from '../integrations/vela-command.js';
 
 const PROJECT_RESOURCE_PREFIX = 'project-';
 
-export type RunVelaTeamProjects = (args: string[]) => Promise<string>;
-export type RunVelaResources = (args: string[]) => Promise<string>;
+export type RunVelaTeamProjects = (
+  args: string[],
+  workspaceId?: string,
+) => Promise<string>;
+export type RunVelaResources = (
+  args: string[],
+  workspaceId?: string,
+) => Promise<string>;
 
 interface VelaCliTeamProjectCatalogOptions {
   run?: RunVelaTeamProjects;
   runResource?: RunVelaResources;
   supportsTeamProjects?: () => boolean | Promise<boolean>;
+  getWorkspaceId?: () => string | null | undefined;
 }
 
 export interface VelaTeamProjectCatalog {
@@ -71,10 +81,15 @@ export function createVelaCliTeamProjectCatalog(
 ): VelaTeamProjectCatalog {
   const run = options.run ?? defaultRunVelaTeamProjects;
   const runResource = options.runResource ?? defaultRunVelaResources;
-  const supportsTeamProjects = createTeamProjectsCapabilityCheck(run, options.supportsTeamProjects);
+  const getWorkspaceId = () => options.getWorkspaceId?.()?.trim() || undefined;
+  const supportsTeamProjects = createTeamProjectsCapabilityCheck(
+    run,
+    options.supportsTeamProjects,
+    getWorkspaceId,
+  );
 
   async function runJson<T>(args: string[]): Promise<T> {
-    const stdout = await run(args);
+    const stdout = await run(args, getWorkspaceId());
     const trimmed = stdout.trim();
     if (!trimmed) return {} as T;
     return JSON.parse(trimmed) as T;
@@ -83,7 +98,10 @@ export function createVelaCliTeamProjectCatalog(
   return {
     async list(): Promise<TeamProject[]> {
       if (!(await supportsTeamProjects())) {
-        const resources = await listSharedProjectResources(runResource);
+        const resources = await listSharedProjectResources(
+          runResource,
+          getWorkspaceId(),
+        );
         return resources.map(toFallbackTeamProject);
       }
       const payload = await runJson<TeamProjectsListWire>(['list']);
@@ -111,14 +129,14 @@ export function createVelaCliTeamProjectCatalog(
       if (input.metadata && Object.keys(input.metadata).length > 0) {
         args.push('--metadata-json', JSON.stringify(input.metadata));
       }
-      await run(args);
+      await run(args, getWorkspaceId());
     },
 
     async remove(projectId): Promise<void> {
       // The resource adapter removes the resource-index row in compatibility
       // mode; there is no separate catalog row to delete.
       if (!(await supportsTeamProjects())) return;
-      await run(['remove', projectId]);
+      await run(['remove', projectId], getWorkspaceId());
     },
   };
 }
@@ -128,10 +146,15 @@ export function createVelaCliTeamProjectCatalogClient(
 ): VelaTeamProjectCatalogClient {
   const run = options.run ?? defaultRunVelaTeamProjects;
   const runResource = options.runResource ?? defaultRunVelaResources;
-  const supportsTeamProjects = createTeamProjectsCapabilityCheck(run, options.supportsTeamProjects);
+  const getWorkspaceId = () => options.getWorkspaceId?.()?.trim() || undefined;
+  const supportsTeamProjects = createTeamProjectsCapabilityCheck(
+    run,
+    options.supportsTeamProjects,
+    getWorkspaceId,
+  );
 
   async function runJson<T>(args: string[]): Promise<T> {
-    const stdout = await run(args);
+    const stdout = await run(args, getWorkspaceId());
     const trimmed = stdout.trim();
     if (!trimmed) return {} as T;
     return JSON.parse(trimmed) as T;
@@ -140,7 +163,10 @@ export function createVelaCliTeamProjectCatalogClient(
   return {
     async list(): Promise<VelaTeamProjectRecord[]> {
       if (!(await supportsTeamProjects())) {
-        const resources = await listSharedProjectResources(runResource);
+        const resources = await listSharedProjectResources(
+          runResource,
+          getWorkspaceId(),
+        );
         return resources.map(toFallbackVelaTeamProjectRecord);
       }
       const payload = await runJson<TeamProjectsListWire>(['list']);
@@ -165,18 +191,26 @@ export function createVelaCliTeamProjectCatalogClient(
       if (input.lastSyncedVersionId?.trim()) {
         args.push('--last-synced-version-id', input.lastSyncedVersionId.trim());
       }
-      const stdout = await run(args);
+      const stdout = await run(args, getWorkspaceId());
       return toVelaTeamProjectRecord(JSON.parse(stdout.trim()) as unknown);
     },
   };
 }
 
-export function createVelaCliTeamProjectCatalogClientFromEnv(): VelaTeamProjectCatalogClient | null {
-  return shouldUseVelaCliTeamProjectCatalog() ? createVelaCliTeamProjectCatalogClient() : null;
+export function createVelaCliTeamProjectCatalogClientFromEnv(
+  options: VelaCliTeamProjectCatalogOptions = {},
+): VelaTeamProjectCatalogClient | null {
+  return shouldUseVelaCliTeamProjectCatalog()
+    ? createVelaCliTeamProjectCatalogClient(options)
+    : null;
 }
 
-export function createVelaCliTeamProjectCatalogFromEnv(): VelaTeamProjectCatalog | null {
-  return shouldUseVelaCliTeamProjectCatalog() ? createVelaCliTeamProjectCatalog() : null;
+export function createVelaCliTeamProjectCatalogFromEnv(
+  options: VelaCliTeamProjectCatalogOptions = {},
+): VelaTeamProjectCatalog | null {
+  return shouldUseVelaCliTeamProjectCatalog()
+    ? createVelaCliTeamProjectCatalog(options)
+    : null;
 }
 
 export function shouldUseVelaCliTeamProjectCatalog(env: NodeJS.ProcessEnv = process.env): boolean {
@@ -286,15 +320,26 @@ function recordObject(value: unknown): Record<string, unknown> | null {
 function createTeamProjectsCapabilityCheck(
   run: RunVelaTeamProjects,
   injected?: () => boolean | Promise<boolean>,
+  getWorkspaceId?: () => string | undefined,
 ): () => Promise<boolean> {
   // The packaged dependency can lag the source-built CLI. Probe once per
   // adapter so source builds use the richer catalog while older builds retain
   // resource-index discovery without a version pin.
   let result: Promise<boolean> | null = null;
   return () => {
+    if (!injected && run === defaultRunVelaTeamProjects) {
+      defaultTeamProjectsCapability ??= run(
+        ['--help'],
+        getWorkspaceId?.(),
+      ).then(
+        () => true,
+        () => false,
+      );
+      return defaultTeamProjectsCapability;
+    }
     result ??= injected
       ? Promise.resolve().then(injected)
-      : run(['--help']).then(
+      : run(['--help'], getWorkspaceId?.()).then(
           () => true,
           () => false,
         );
@@ -302,10 +347,13 @@ function createTeamProjectsCapabilityCheck(
   };
 }
 
+let defaultTeamProjectsCapability: Promise<boolean> | null = null;
+
 async function listSharedProjectResources(
   runResource: RunVelaResources,
+  workspaceId?: string,
 ): Promise<SharedResourceWire[]> {
-  const stdout = await runResource(['shared', '--json']);
+  const stdout = await runResource(['shared', '--json'], workspaceId);
   const trimmed = stdout.trim();
   if (!trimmed) return [];
   const payload = JSON.parse(trimmed) as SharedResourcesListWire;
@@ -398,8 +446,14 @@ function fallbackProjectId(
   return suffix;
 }
 
-const defaultRunVelaTeamProjects: RunVelaTeamProjects = (args) =>
-  runVelaCommand(['team-projects', ...args]);
+const defaultRunVelaTeamProjects: RunVelaTeamProjects = (args, workspaceId) =>
+  runVelaCommand(
+    ['team-projects', ...args],
+    velaWorkspaceCommandOptions(workspaceId),
+  );
 
-const defaultRunVelaResources: RunVelaResources = (args) =>
-  runVelaCommand(['resource', ...args]);
+const defaultRunVelaResources: RunVelaResources = (args, workspaceId) =>
+  runVelaCommand(
+    ['resource', ...args],
+    velaWorkspaceCommandOptions(workspaceId),
+  );

--- a/apps/daemon/src/integrations/vela-command.ts
+++ b/apps/daemon/src/integrations/vela-command.ts
@@ -19,6 +19,20 @@ export interface VelaCommandOptions {
   maxBuffer?: number;
 }
 
+export function velaWorkspaceCommandOptions(
+  workspaceId: string | null | undefined,
+): VelaCommandOptions {
+  const requestedWorkspaceId = workspaceId?.trim();
+  return {
+    configuredEnv: {
+      VELA_INVOCATION_SOURCE: 'open-design',
+      ...(requestedWorkspaceId
+        ? { VELA_WORKSPACE_ID: requestedWorkspaceId }
+        : {}),
+    },
+  };
+}
+
 function configuredAmrEnv(
   env: NodeJS.ProcessEnv,
   explicit: Record<string, string> = {},

--- a/apps/daemon/src/routes/collab-sync.ts
+++ b/apps/daemon/src/routes/collab-sync.ts
@@ -10,7 +10,6 @@ import {
 } from '../collab/resource-principal.js';
 import { parseVelaResourceSnapshot, runVelaResourceCommand } from '../collab/vela-cli-resource-adapter.js';
 import { readVelaControlApiContext } from '../integrations/vela.js';
-import { projectResourceIdFor } from '../integrations/vela-team-projects.js';
 import { readProjectManifest } from '../project-locations.js';
 
 /** The fields register-on-pull reads out of a pulled project's manifest. */
@@ -39,21 +38,6 @@ export interface PulledProjectStore {
   update?: (input: RegisterPulledProjectInput) => void;
 }
 
-interface TeamProjectCatalogWriter {
-  upsert(
-    input: {
-      projectId: string;
-      resourceId?: string;
-      displayName?: string | null;
-      syncState?: 'pending_upload' | 'syncing' | 'synced' | 'failed';
-      lastSyncedVersionId?: string | null;
-      metadata?: Record<string, unknown> | null;
-    },
-    principal?: ResourceHubPrincipal | null,
-  ): Promise<unknown>;
-  remove(projectId: string, principal?: ResourceHubPrincipal | null): Promise<unknown>;
-}
-
 export interface RegisterCollabSyncRoutesDeps {
   collab: Pick<
     CollabRuntime,
@@ -75,8 +59,6 @@ export interface RegisterCollabSyncRoutesDeps {
   resolveOwnerDisplayName?: (
     memberId: string,
   ) => Promise<{ displayName: string; role: 'owner' | 'admin' | 'member' } | null>;
-  teamProjectCatalog?: TeamProjectCatalogWriter;
-  describeProject?: (projectId: string) => Promise<PulledProjectManifest | null> | PulledProjectManifest | null;
   projectStore?: PulledProjectStore;
   resolveProjectDir?: (projectId: string) => string | Promise<string>;
   resolvePullDir?: (projectId: string) => string;
@@ -294,8 +276,6 @@ export function registerCollabSyncRoutes(app: Express, deps: RegisterCollabSyncR
     resolveSharedProject,
     markTeamProjectRevoked,
     resolveOwnerDisplayName,
-    teamProjectCatalog,
-    describeProject,
   } = deps;
   const readManifest = deps.readManifest ?? readProjectManifest;
 
@@ -471,7 +451,7 @@ export function registerCollabSyncRoutes(app: Express, deps: RegisterCollabSyncR
         '--metadata-json',
         JSON.stringify(metadata),
         '--json',
-      ]);
+      ], principal.teamId);
       const snapshot = parseVelaResourceSnapshot(await runVelaResourceCommand([
         'snapshot',
         resourceId,
@@ -480,7 +460,7 @@ export function registerCollabSyncRoutes(app: Express, deps: RegisterCollabSyncR
         '--name',
         path.basename(filePath),
         '--json',
-      ]));
+      ], principal.teamId));
       if (!snapshot) {
         return res.status(502).json({ error: 'PUBLIC_SNAPSHOT_UNAVAILABLE' });
       }
@@ -531,7 +511,7 @@ export function registerCollabSyncRoutes(app: Express, deps: RegisterCollabSyncR
         resourceId,
         slug,
         '--json',
-      ]);
+      ], principal.teamId);
       publicFilePublications.delete(publicFilePublicationKey(projectId, filePath, principal));
       return res.json({ ok: true, slug, fileName: filePath });
     } catch (error) {
@@ -602,25 +582,6 @@ export function registerCollabSyncRoutes(app: Express, deps: RegisterCollabSyncR
       if (nextPublishedVersion == null) {
         return res.status(502).json({ error: 'TEAM_PROJECT_PUBLISH_UNAVAILABLE' });
       }
-      try {
-        const project = await describeProject?.(projectId) ?? null;
-        await teamProjectCatalog?.upsert(
-          {
-            projectId,
-            ...(principal ? { resourceId: projectResourceIdFor(projectId, principal) } : {}),
-            displayName: project?.name ?? null,
-            syncState: 'synced',
-            ...(project ? { metadata: { ...project } } : {}),
-          },
-          principal,
-        );
-      } catch (error) {
-        console.warn('[od] failed to write Vela team project catalog:', error);
-        await requestTeamUnshare(projectId, principal).catch((unshareError: unknown) => {
-          console.warn('[od] failed to roll back team-shared project after catalog failure:', unshareError);
-        });
-        return res.status(502).json({ error: 'TEAM_PROJECT_CATALOG_UNAVAILABLE' });
-      }
       deps.onTeamShareStateChanged?.({
         projectId,
         principal,
@@ -644,12 +605,6 @@ export function registerCollabSyncRoutes(app: Express, deps: RegisterCollabSyncR
       const ownerMemberId = sharedProject?.ownerMemberId ?? projectOwnerMemberId(projectId, principal);
       if (ownerMemberId && ownerMemberId !== callerMemberId) {
         return res.status(403).json({ error: 'WORKSPACE_PROJECT_UNSHARE_DENIED' });
-      }
-      try {
-        await teamProjectCatalog?.remove(projectId, principal);
-      } catch (error) {
-        console.warn('[od] failed to remove Vela team project catalog entry:', error);
-        return res.status(502).json({ error: 'TEAM_PROJECT_CATALOG_UNAVAILABLE' });
       }
       await requestTeamUnshare(projectId, principal);
       deps.onTeamShareStateChanged?.({

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -159,6 +159,7 @@ import {
   readVelaLoginStatus,
   resolveAmrProfile,
 } from './integrations/vela.js';
+import { projectResourceIdFor } from './integrations/vela-team-projects.js';
 import {
   amrAccountFailureDetails,
   classifyAmrAccountFailureSignal,
@@ -595,6 +596,7 @@ import {
   type TeamResourceShareRecord,
   type TeamResourceShareService,
 } from './collab/team-resource-share.js';
+import { createTeamResourceVersionStore } from './collab/team-resource-version-store.js';
 import {
   contextToResourceHubPrincipal,
   type ResourceHubPrincipal,
@@ -3845,10 +3847,19 @@ export async function startServer({
       ...(project.metadata ? { metadata: project.metadata } : {}),
     };
   };
-  const velaCliCollabClient = createVelaCliCollabClientFromEnv();
-  const velaCliTeamProjectCatalog = createVelaCliTeamProjectCatalogFromEnv();
-  const velaCliWorkspaceTeamProjectCatalog = createVelaCliTeamProjectCatalogClientFromEnv();
   const activeWorkspace = createActiveWorkspaceSelectionStore(RUNTIME_DATA_DIR);
+  const teamResourceVersions = createTeamResourceVersionStore(RUNTIME_DATA_DIR);
+  const getActiveWorkspaceId = () => activeWorkspace.get();
+  const velaCliCollabClient = createVelaCliCollabClientFromEnv(process.env, {
+    getWorkspaceId: getActiveWorkspaceId,
+  });
+  const velaCliTeamProjectCatalog = createVelaCliTeamProjectCatalogFromEnv({
+    getWorkspaceId: getActiveWorkspaceId,
+  });
+  const velaCliWorkspaceTeamProjectCatalog =
+    createVelaCliTeamProjectCatalogClientFromEnv({
+      getWorkspaceId: getActiveWorkspaceId,
+    });
   // Generic stale-while-revalidate cache: after the first load every call
   // returns the last value for the key immediately and refreshes in the
   // background once it is older than freshMs; concurrent callers coalesce on the
@@ -4191,9 +4202,7 @@ export async function startServer({
       }
       updateProject(db, projectId, { metadata });
     },
-    describeProject: describeCollabProject,
     onTeamShareStateChanged: persistWorkspaceProjectVisibility,
-    ...(velaCliTeamProjectCatalog ? { teamProjectCatalog: velaCliTeamProjectCatalog } : {}),
     // Resolve the owner's display name + role from the collab-cloud directory so
     // /collab/status can hand the client a named "shared project" banner.
     ...(collabCloud
@@ -4253,11 +4262,24 @@ export async function startServer({
   };
   async function syncSharedTeamPlugin(resource): Promise<void> {
     const existing = getInstalledPlugin(db, resource.id);
+    const currentContext = await collab.workspaceContext.current({});
+    const workspaceId = currentContext?.workspaceId;
+    const isOwnedByCurrentMember =
+      typeof resource.ownerMemberId === 'string' &&
+      typeof currentContext?.workspaceMemberId === 'string' &&
+      resource.ownerMemberId === currentContext.workspaceMemberId;
+    if (isOwnedByCurrentMember) return;
+    if (
+      existing &&
+      workspaceId &&
+      resource.versionId &&
+      teamResourceVersions.get(workspaceId, 'plugin', resource.id) === resource.versionId
+    ) return;
     const remoteDescription = typeof resource.description === 'string' ? resource.description.trim() : '';
     const localDescription = typeof existing?.manifest?.description === 'string'
       ? existing.manifest.description.trim()
       : '';
-    if (existing && (!remoteDescription || localDescription === remoteDescription)) return;
+    if (existing && !resource.versionId && (!remoteDescription || localDescription === remoteDescription)) return;
 
     const stagedFolder = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'od-team-plugin-'));
     try {
@@ -4270,7 +4292,8 @@ export async function startServer({
         '--ref',
         'published',
         '--json',
-      ]);
+      ], activeWorkspace.get() ?? undefined);
+      let installed = false;
       for await (const ev of installFromLocalFolder(db, {
         source: `team:plugin:${resource.id}`,
         roots: PLUGIN_REGISTRY_ROOTS,
@@ -4278,11 +4301,22 @@ export async function startServer({
         _stagedSourceKind: 'user',
         lockfilePath: PLUGIN_LOCKFILE_PATH,
       })) {
-        if (ev.kind === 'success') return;
+        if (ev.kind === 'success') {
+          installed = true;
+          break;
+        }
         if (ev.kind === 'error') {
           console.warn(`[team-resources] failed to install shared plugin ${resource.id}: ${ev.message}`);
           return;
         }
+      }
+      if (installed && workspaceId && resource.versionId) {
+        await teamResourceVersions.set(
+          workspaceId,
+          'plugin',
+          resource.id,
+          resource.versionId,
+        );
       }
     } catch (error) {
       console.warn(
@@ -4302,6 +4336,7 @@ export async function startServer({
       typeof resource.ownerMemberId === 'string' &&
       typeof currentContext?.workspaceMemberId === 'string' &&
       resource.ownerMemberId === currentContext.workspaceMemberId;
+    const workspaceId = currentContext?.workspaceId;
     async function markTeamSynced(): Promise<void> {
       if (isOwnedByCurrentMember) return;
       const metadataPath = path.join(targetDir, 'metadata.json');
@@ -4321,7 +4356,21 @@ export async function startServer({
         'utf8',
       );
     }
-    if (fs.existsSync(targetDir)) {
+    if (isOwnedByCurrentMember) return;
+    if (
+      fs.existsSync(targetDir) &&
+      workspaceId &&
+      resource.versionId &&
+      teamResourceVersions.get(
+        workspaceId,
+        'design_system',
+        resource.id,
+      ) === resource.versionId
+    ) {
+      await markTeamSynced();
+      return;
+    }
+    if (fs.existsSync(targetDir) && !resource.versionId) {
       await markTeamSynced();
       return;
     }
@@ -4336,14 +4385,75 @@ export async function startServer({
         '--ref',
         'published',
         '--json',
-      ]);
+      ], activeWorkspace.get() ?? undefined);
       await fs.promises.rm(targetDir, { recursive: true, force: true }).catch(() => undefined);
       await fs.promises.mkdir(USER_DESIGN_SYSTEMS_DIR, { recursive: true });
       await fs.promises.rename(stagedFolder, targetDir);
       await markTeamSynced();
+      if (workspaceId && resource.versionId) {
+        await teamResourceVersions.set(
+          workspaceId,
+          'design_system',
+          resource.id,
+          resource.versionId,
+        );
+      }
     } catch (error) {
       console.warn(
         `[team-resources] failed to pull shared design system ${resource.id}:`,
+        error instanceof Error ? error.message : error,
+      );
+      await fs.promises.rm(stagedFolder, { recursive: true, force: true }).catch(() => undefined);
+    }
+  }
+  async function syncSharedTeamSkill(resource): Promise<void> {
+    const dirId = stripPrefixAndValidateId(
+      resource.id,
+      resource.id.startsWith('user:') ? 'user:' : '',
+    );
+    if (!dirId) return;
+    const targetDir = path.join(USER_SKILLS_DIR, dirId);
+    const currentContext = await collab.workspaceContext.current({});
+    const workspaceId = currentContext?.workspaceId;
+    const isOwnedByCurrentMember =
+      typeof resource.ownerMemberId === 'string' &&
+      typeof currentContext?.workspaceMemberId === 'string' &&
+      resource.ownerMemberId === currentContext.workspaceMemberId;
+    if (isOwnedByCurrentMember) return;
+    if (
+      fs.existsSync(targetDir) &&
+      workspaceId &&
+      resource.versionId &&
+      teamResourceVersions.get(workspaceId, 'skill', resource.id) === resource.versionId
+    ) return;
+    if (fs.existsSync(targetDir) && !resource.versionId) return;
+
+    const stagedFolder = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'od-team-skill-'));
+    try {
+      const { runVelaResourceCommand } = await import('./collab/vela-cli-resource-adapter.js');
+      await runVelaResourceCommand([
+        'pull',
+        'skill',
+        resource.hubResourceId ?? `skill-${resource.id.replace(/[^a-zA-Z0-9_-]/g, '-')}`,
+        stagedFolder,
+        '--ref',
+        'published',
+        '--json',
+      ], workspaceId);
+      await fs.promises.rm(targetDir, { recursive: true, force: true });
+      await fs.promises.mkdir(USER_SKILLS_DIR, { recursive: true });
+      await fs.promises.rename(stagedFolder, targetDir);
+      if (workspaceId && resource.versionId) {
+        await teamResourceVersions.set(
+          workspaceId,
+          'skill',
+          resource.id,
+          resource.versionId,
+        );
+      }
+    } catch (error) {
+      console.warn(
+        `[team-resources] failed to pull shared skill ${resource.id}:`,
         error instanceof Error ? error.message : error,
       );
       await fs.promises.rm(stagedFolder, { recursive: true, force: true }).catch(() => undefined);
@@ -4368,6 +4478,27 @@ export async function startServer({
       () => activeWorkspace.get() ?? '',
       3000,
     );
+  const sharedTeamResourcesCommand = createSwrCache(
+    async () => {
+      const { runVelaResourceCommand } = await import('./collab/vela-cli-resource-adapter.js');
+      return runVelaResourceCommand(
+        ['shared', '--json'],
+        activeWorkspace.get() ?? undefined,
+      );
+    },
+    () => activeWorkspace.get() ?? '',
+    3000,
+  );
+  const runTeamResourceCommand = async (
+    args: string[],
+    workspaceId?: string,
+  ) => {
+    if (args.length === 2 && args[0] === 'shared' && args[1] === '--json') {
+      return sharedTeamResourcesCommand();
+    }
+    const { runVelaResourceCommand } = await import('./collab/vela-cli-resource-adapter.js');
+    return runVelaResourceCommand(args, workspaceId);
+  };
   const designSystemsTeamShare = createTeamResourceShareService({
     kind: 'design_system',
     idPrefix: 'ds',
@@ -4383,6 +4514,7 @@ export async function startServer({
     },
     getPrincipal: teamShareGetPrincipal,
     getCanShare: teamShareGetCanShare,
+    run: runTeamResourceCommand,
   });
   registerTeamResourceShareRoutes(app, {
     basePath: 'design-systems',
@@ -4409,6 +4541,7 @@ export async function startServer({
     },
     getPrincipal: teamShareGetPrincipal,
     getCanShare: teamShareGetCanShare,
+    run: runTeamResourceCommand,
   });
   registerTeamResourceShareRoutes(app, {
     basePath: 'plugins',
@@ -4435,11 +4568,13 @@ export async function startServer({
     },
     getPrincipal: teamShareGetPrincipal,
     getCanShare: teamShareGetCanShare,
+    run: runTeamResourceCommand,
   });
   registerTeamResourceShareRoutes(app, {
     basePath: 'skills',
+    syncSharedResource: syncSharedTeamSkill,
     share: skillsTeamShare,
-    listTeam: cachedTeamResourceList(skillsTeamShare),
+    listTeam: cachedTeamResourceList(skillsTeamShare, syncSharedTeamSkill),
   });
 
   registerMemoryRoutes(app, {

--- a/apps/daemon/tests/collab-cloud.test.ts
+++ b/apps/daemon/tests/collab-cloud.test.ts
@@ -476,9 +476,12 @@ describe('VelaCliCollabClient', () => {
 
   it('uses vela collab commands for comments, directory, and presence', async () => {
     const calls: string[][] = [];
+    const workspaces: Array<string | undefined> = [];
     const client = createVelaCliCollabClient({
-      run: async (args) => {
+      getWorkspaceId: () => 'team-1',
+      run: async (args, workspaceId) => {
         calls.push(args);
+        workspaces.push(workspaceId);
         if (args[0] === 'member' && args[1] === 'register') {
           return JSON.stringify({ member: { memberId: 'm-self', displayName: '麻薯', role: 'owner' } });
         }
@@ -548,5 +551,6 @@ describe('VelaCliCollabClient', () => {
       '--activity-json',
       JSON.stringify({ label: '正在评论 Typography' }),
     ]);
+    expect(workspaces).toEqual(['team-1', 'team-1', 'team-1', 'team-1']);
   });
 });

--- a/apps/daemon/tests/collab-sync-routes.test.ts
+++ b/apps/daemon/tests/collab-sync-routes.test.ts
@@ -220,6 +220,62 @@ describe('collab sync routes', () => {
     expect(runtime.publishedVersion(projectId, workspaceB)).toBe(22);
   });
 
+  it('unshares only the requested workspace and keeps other workspace state live', async () => {
+    const publish = vi.fn(async (input: { principal?: { memberId?: string } }) => ({
+      version: input.principal?.memberId === 'member-a' ? 11 : 22,
+    }));
+    const unpublish = vi.fn(async () => undefined);
+    const teamProjectCatalog = {
+      upsert: vi.fn(async () => undefined),
+      remove: vi.fn(async () => undefined),
+    };
+    runtime = createCollabRuntime({
+      adapter: { publish, unpublish },
+      teamProjectCatalog,
+    });
+    const projectId = 'shared-project';
+    const workspaceA = {
+      memberId: 'member-a',
+      teamId: 'workspace-a',
+      role: 'admin' as const,
+      lifecycleState: 'active' as const,
+    };
+    const workspaceB = {
+      memberId: 'member-b',
+      teamId: 'workspace-b',
+      role: 'admin' as const,
+      lifecycleState: 'active' as const,
+    };
+
+    await runtime.requestTeamShare(projectId, workspaceA);
+    await runtime.requestTeamShare(projectId, workspaceB);
+    await runtime.requestTeamUnshare(projectId, workspaceA);
+
+    expect(unpublish).toHaveBeenCalledWith({ projectId, principal: workspaceA });
+    expect(teamProjectCatalog.remove).toHaveBeenCalledWith(projectId, workspaceA);
+    expect(runtime.publishedVersion(projectId, workspaceA)).toBeNull();
+    expect(runtime.projectSyncState(projectId, workspaceA)).toBe('local_only');
+    expect(runtime.projectOwnerMemberId(projectId, workspaceA)).toBeNull();
+    expect(runtime.publishedVersion(projectId, workspaceB)).toBe(22);
+    expect(runtime.projectSyncState(projectId, workspaceB)).toBe('synced');
+    expect(runtime.projectOwnerMemberId(projectId, workspaceB)).toBe('member-b');
+    expect(runtime.publishedVersion(projectId)).toBe(22);
+    expect(runtime.projectSyncState(projectId)).toBe('synced');
+
+    publish.mockClear();
+    runtime.scheduler.notifyChanged(projectId, 'save');
+    runtime.scheduler.runBoundary(projectId);
+    for (let i = 0; i < 40 && publish.mock.calls.length < 1; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish).toHaveBeenCalledWith({
+      projectId,
+      reason: 'save',
+      principal: workspaceB,
+    });
+  });
+
   it('reports ordinary publish failures to every workspace sharing the same project', async () => {
     let failPublish = false;
     const onError = vi.fn();
@@ -592,12 +648,6 @@ describe('collab sync routes', () => {
           sharedAt: new Date(1).toISOString(),
           name: 'Owner Project',
         }),
-        teamProjectCatalog: {
-          upsert: async () => {
-            throw new Error('catalog should not be written');
-          },
-          remove: async () => {},
-        },
       },
       {
         adapter: {
@@ -623,7 +673,6 @@ describe('collab sync routes', () => {
   });
 
   it('refuses to unshare a project owned by another member', async () => {
-    const removes: string[] = [];
     const api = await startSyncServer(fixedShareContextProvider(true), {
       resolveSharedProject: async () => ({
         projectId: 'p1',
@@ -631,12 +680,6 @@ describe('collab sync routes', () => {
         sharedAt: new Date(1).toISOString(),
         name: 'Owner Project',
       }),
-      teamProjectCatalog: {
-        upsert: async () => {},
-        remove: async (projectId) => {
-          removes.push(projectId);
-        },
-      },
     });
 
     const res = await api.json('/api/projects/p1/collab/sync-intent', {
@@ -646,7 +689,6 @@ describe('collab sync routes', () => {
 
     expect(res.status).toBe(403);
     expect(res.body.error).toBe('WORKSPACE_PROJECT_UNSHARE_DENIED');
-    expect(removes).toEqual([]);
   });
 
   it('refuses public file publishing for a shared project owned by another member', async () => {
@@ -853,23 +895,31 @@ describe('collab sync routes', () => {
   it('writes and removes the Vela team-project catalog around share intents', async () => {
     const writes: unknown[] = [];
     const removes: string[] = [];
-    const api = await startSyncServer(fixedShareContextProvider(true), {
-      describeProject: () => ({
-        name: 'Electric Studio 2',
-        skillId: null,
-        designSystemId: null,
-        createdAt: 1,
-        updatedAt: 2,
-      }),
-      teamProjectCatalog: {
-        upsert: async (input) => {
-          writes.push(input);
+    const api = await startSyncServer(
+      fixedShareContextProvider(true),
+      undefined,
+      {
+        adapter: {
+          publish: async () => ({ version: 1, versionId: 'version-1' }),
+          unpublish: async () => {},
         },
-        remove: async (projectId) => {
-          removes.push(projectId);
+        describeProject: () => ({
+          name: 'Electric Studio 2',
+          skillId: null,
+          designSystemId: null,
+          createdAt: 1,
+          updatedAt: 2,
+        }),
+        teamProjectCatalog: {
+          upsert: async (input) => {
+            writes.push(input);
+          },
+          remove: async (projectId) => {
+            removes.push(projectId);
+          },
         },
       },
-    });
+    );
 
     const share = await api.json('/api/projects/p1/collab/sync-intent', {
       method: 'POST',
@@ -887,6 +937,7 @@ describe('collab sync routes', () => {
         }),
         displayName: 'Electric Studio 2',
         syncState: 'synced',
+        lastSyncedVersionId: 'version-1',
         metadata: {
           name: 'Electric Studio 2',
           skillId: null,
@@ -906,28 +957,39 @@ describe('collab sync routes', () => {
   });
 
   it('does not pretend a project is shared when the Vela catalog write fails', async () => {
-    const api = await startSyncServer(fixedShareContextProvider(true), {
-      teamProjectCatalog: {
-        upsert: async () => {
-          throw new Error('catalog unavailable');
+    const unpublish = vi.fn(async () => undefined);
+    const api = await startSyncServer(
+      fixedShareContextProvider(true),
+      undefined,
+      {
+        adapter: {
+          publish: async () => ({ version: 1, versionId: 'version-1' }),
+          unpublish,
         },
-        remove: async () => {},
+        teamProjectCatalog: {
+          upsert: async () => {
+            throw new Error('catalog unavailable');
+          },
+          remove: async () => {},
+        },
       },
-    });
+    );
 
     const res = await api.json('/api/projects/p1/collab/sync-intent', {
       method: 'POST',
       body: { event: 'project_team_share_requested', projectId: 'p1' },
     });
     expect(res.status).toBe(502);
-    expect(res.body.error).toBe('TEAM_PROJECT_CATALOG_UNAVAILABLE');
-    expect((await api.json('/api/projects/p1/collab/status')).body.syncState).toBe('local_only');
+    expect(res.body.error).toBe('TEAM_PROJECT_PUBLISH_UNAVAILABLE');
+    expect(unpublish).toHaveBeenCalledTimes(1);
+    expect((await api.json('/api/projects/p1/collab/status')).body.syncState).toBe('sync_failed');
   });
 
   it('does not write the team catalog when resource publishing fails', async () => {
     const writes: unknown[] = [];
     const api = await startSyncServer(
       fixedShareContextProvider(true),
+      undefined,
       {
         teamProjectCatalog: {
           upsert: async (input) => {
@@ -935,8 +997,6 @@ describe('collab sync routes', () => {
           },
           remove: async () => {},
         },
-      },
-      {
         adapter: {
           publish: async () => {
             throw new Error('resource hub unavailable');

--- a/apps/daemon/tests/team-resource-share.test.ts
+++ b/apps/daemon/tests/team-resource-share.test.ts
@@ -84,7 +84,11 @@ describe('team resource share permission gate', () => {
     expect(service.isShared('mock-team-expert-kit')).toBe(true);
     await expect(service.unshare('mock-team-expert-kit')).resolves.toBe(true);
     expect(service.isShared('mock-team-expert-kit')).toBe(false);
-    expect(calls.at(-1)).toEqual(['remove', 'skill-mock-team-expert-kit', '--json']);
+    expect(calls.at(-1)).toEqual([
+      'remove',
+      'skill-t-1-mock-team-expert-kit',
+      '--json',
+    ]);
   });
 
   it('lists resources already shared through another daemon via Vela CLI', async () => {
@@ -125,6 +129,37 @@ describe('team resource share permission gate', () => {
       },
     ]);
     expect(service.isShared('mock-team-expert-kit')).toBe(true);
+  });
+
+  it('preserves the workspace-scoped hub id for teammate materialization', async () => {
+    const service = createTeamResourceShareService({
+      kind: 'skill',
+      idPrefix: 'skill',
+      resolveDir: () => '/tmp/skill',
+      getPrincipal: () => principal,
+      getCanShare: () => false,
+      run: async () => JSON.stringify({
+        resources: [
+          {
+            id: 'skill-t-1-shared-kit',
+            kind: 'skill',
+            deletedAt: null,
+            ownerMemberId: 'wm-owner',
+            metadata: { localId: 'shared-kit' },
+          },
+        ],
+      }),
+      env: { OD_WORKSPACE_CONTEXT_SOURCE: 'vela' },
+    });
+
+    const [resource] = await service.sharedResources();
+    expect(resource).toEqual({
+      id: 'shared-kit',
+      ownerMemberId: 'wm-owner',
+      canUnshare: false,
+    });
+    expect(resource?.hubResourceId).toBe('skill-t-1-shared-kit');
+    expect(Object.keys(resource ?? {})).not.toContain('hubResourceId');
   });
 
   it('reconciles stale local shared ids when Vela reports the resource removed', async () => {

--- a/apps/daemon/tests/team-resource-version-store.test.ts
+++ b/apps/daemon/tests/team-resource-version-store.test.ts
@@ -1,0 +1,33 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createTeamResourceVersionStore } from '../src/collab/team-resource-version-store.js';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) =>
+      fs.promises.rm(root, { recursive: true, force: true }),
+    ),
+  );
+});
+
+describe('team resource version store', () => {
+  it('persists independent workspace and resource cursors', async () => {
+    const root = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'od-team-resource-versions-'),
+    );
+    roots.push(root);
+    const store = createTeamResourceVersionStore(root);
+
+    await store.set('team-a', 'skill', 'review-kit', 'version-1');
+    await store.set('team-b', 'skill', 'review-kit', 'version-2');
+
+    const reloaded = createTeamResourceVersionStore(root);
+    expect(reloaded.get('team-a', 'skill', 'review-kit')).toBe('version-1');
+    expect(reloaded.get('team-b', 'skill', 'review-kit')).toBe('version-2');
+    expect(reloaded.get('team-a', 'plugin', 'review-kit')).toBeNull();
+  });
+});

--- a/apps/daemon/tests/vela-cli-resource-adapter.test.ts
+++ b/apps/daemon/tests/vela-cli-resource-adapter.test.ts
@@ -7,11 +7,13 @@ import {
 
 function recordingRun(outputs: Record<string, string>) {
   const calls: string[][] = [];
-  const run = async (args: string[]): Promise<string> => {
+  const workspaces: Array<string | undefined> = [];
+  const run = async (args: string[], workspaceId?: string): Promise<string> => {
     calls.push(args);
+    workspaces.push(workspaceId);
     return outputs[args[0] ?? ''] ?? '';
   };
-  return { run, calls };
+  return { run, calls, workspaces };
 }
 
 function scriptedRun(steps: Array<{ match: string[]; output?: string; error?: Error }>) {
@@ -40,7 +42,7 @@ describe('createVelaCliResourceAdapter', () => {
     const { run, calls } = recordingRun({ push: JSON.stringify({ version: 7, id: 'v7' }) });
     const adapter = createVelaCliResourceAdapter({ ...OPTS, run });
     const result = await adapter.publish({ projectId: 'p1', reason: 'edit' });
-    expect(result).toEqual({ version: 7 });
+    expect(result).toEqual({ version: 7, versionId: 'v7' });
     expect(calls[0]).toEqual([
       'push',
       'design_system',
@@ -55,6 +57,44 @@ describe('createVelaCliResourceAdapter', () => {
       '.live-artifacts',
       '--exclude',
       '.od-skills',
+      '--exclude',
+      '.git',
+      '--exclude',
+      'node_modules',
+      '--exclude',
+      '.npmrc',
+      '--exclude',
+      '.yarnrc',
+      '--exclude',
+      '.yarnrc.yml',
+      '--exclude',
+      '.aws',
+      '--exclude',
+      '.ssh',
+      '--exclude',
+      '.azure',
+      '--exclude',
+      '.docker',
+      '--exclude',
+      '.gnupg',
+      '--exclude',
+      '.kube',
+      '--exclude',
+      '.pulumi',
+      '--exclude',
+      '.terraform',
+      '--exclude',
+      '.git-credentials',
+      '--exclude',
+      '.netrc',
+      '--exclude',
+      '.pypirc',
+      '--exclude',
+      'terraform.tfstate',
+      '--exclude',
+      'terraform.tfstate.backup',
+      '--exclude-prefix',
+      '.env',
     ]);
   });
 
@@ -80,6 +120,44 @@ describe('createVelaCliResourceAdapter', () => {
       '.live-artifacts',
       '--exclude',
       '.od-skills',
+      '--exclude',
+      '.git',
+      '--exclude',
+      'node_modules',
+      '--exclude',
+      '.npmrc',
+      '--exclude',
+      '.yarnrc',
+      '--exclude',
+      '.yarnrc.yml',
+      '--exclude',
+      '.aws',
+      '--exclude',
+      '.ssh',
+      '--exclude',
+      '.azure',
+      '--exclude',
+      '.docker',
+      '--exclude',
+      '.gnupg',
+      '--exclude',
+      '.kube',
+      '--exclude',
+      '.pulumi',
+      '--exclude',
+      '.terraform',
+      '--exclude',
+      '.git-credentials',
+      '--exclude',
+      '.netrc',
+      '--exclude',
+      '.pypirc',
+      '--exclude',
+      'terraform.tfstate',
+      '--exclude',
+      'terraform.tfstate.backup',
+      '--exclude-prefix',
+      '.env',
       '--metadata-json',
       JSON.stringify({ name: 'Launch Deck', metadata: { kind: 'deck' } }),
     ]);
@@ -107,6 +185,35 @@ describe('createVelaCliResourceAdapter', () => {
     const adapter = createVelaCliResourceAdapter({ ...OPTS, run });
     expect(await adapter.syncLatest!({ projectId: 'p1' })).toEqual({ version: 3 });
     expect(calls[0]).toEqual(['head', 'project-p1', '--ref', 'published', '--json']);
+  });
+
+  it('passes the selected team workspace to every scoped Vela invocation', async () => {
+    const principal = {
+      teamId: 'team-selected',
+      memberId: 'member-1',
+      role: 'member',
+      lifecycleState: 'active',
+      workspaceType: 'team',
+    } as const;
+    const { run, workspaces } = recordingRun({
+      push: JSON.stringify({ version: 7 }),
+      head: JSON.stringify({ version: 7 }),
+      pull: '{}',
+      remove: '{}',
+    });
+    const adapter = createVelaCliResourceAdapter({ ...OPTS, run });
+
+    await adapter.publish({ projectId: 'p1', principal, reason: 'edit' });
+    await adapter.syncLatest!({ projectId: 'p1', principal });
+    await adapter.pull!({ projectId: 'p1', principal });
+    await adapter.unpublish!({ projectId: 'p1', principal });
+
+    expect(workspaces).toEqual([
+      'team-selected',
+      'team-selected',
+      'team-selected',
+      'team-selected',
+    ]);
   });
 
   it('treats a null head version (nothing published) as no result', async () => {
@@ -166,6 +273,27 @@ describe('createVelaCliResourceAdapter', () => {
     expect(calls).toHaveLength(2);
   });
 
+  it('does not hide authentication failures behind a legacy pull fallback', async () => {
+    const principal = { teamId: 't1', memberId: 'm1', role: 'member', lifecycleState: 'active' } as const;
+    const { run, calls } = scriptedRun([
+      {
+        match: ['pull', 'design_system', 'project-t1-m1-p1', '/copies/p1', '--ref', 'published', '--json'],
+        error: new Error('API request failed with status 403: missing_principal'),
+      },
+    ]);
+    const adapter = createVelaCliResourceAdapter({
+      ...OPTS,
+      resourceIdFor: (id, inputPrincipal) =>
+        inputPrincipal ? `project-${inputPrincipal.teamId}-${inputPrincipal.memberId}-${id}` : `project-${id}`,
+      run,
+    });
+
+    await expect(adapter.pull!({ projectId: 'p1', principal })).rejects.toThrow(
+      'missing_principal',
+    );
+    expect(calls).toHaveLength(1);
+  });
+
   it('removes a project from the team resource index', async () => {
     const { run, calls } = recordingRun({ remove: JSON.stringify({ ok: true }) });
     const adapter = createVelaCliResourceAdapter({ ...OPTS, run });
@@ -200,9 +328,17 @@ describe('transport selection', () => {
 
   it('gates team identity on a live team workspace context', () => {
     expect(
-      contextHasTeamIdentity({ workspaceType: 'team', teamId: 't1' } as never),
+      contextHasTeamIdentity({
+        workspaceType: 'team',
+        workspaceId: 't1',
+        workspaceMemberId: 'm1',
+      } as never),
     ).toBe(true);
-    expect(contextHasTeamIdentity({ workspaceType: 'personal' } as never)).toBe(false);
+    expect(contextHasTeamIdentity({
+      workspaceType: 'personal',
+      workspaceId: 'personal-1',
+      workspaceMemberId: 'm1',
+    } as never)).toBe(false);
     expect(contextHasTeamIdentity(null)).toBe(false);
   });
 });

--- a/apps/daemon/tests/vela-cli-team-projects.test.ts
+++ b/apps/daemon/tests/vela-cli-team-projects.test.ts
@@ -9,8 +9,10 @@ describe('Vela CLI team-project catalog adapter', () => {
   it('maps list output into team-project DTOs', async () => {
     const catalog = createVelaCliTeamProjectCatalog({
       supportsTeamProjects: () => true,
-      run: async (args) => {
+      getWorkspaceId: () => 'team-selected',
+      run: async (args, workspaceId) => {
         expect(args).toEqual(['list']);
+        expect(workspaceId).toBe('team-selected');
         return JSON.stringify({
           projects: [
             {


### PR DESCRIPTION
## What changed

- route every Vela Resource, Team Project, Collab, and public-snapshot invocation through the active authenticated workspace
- keep workspace-scoped publication, owner, version, sync, and unshare state isolated when the same project exists in multiple workspaces
- make the collaboration runtime the single catalog writer, persist immutable version cursors, and roll back publication when catalog persistence fails
- refresh teammate design-system, plugin, and skill materializations when their published version advances while preserving owner copies
- exclude `.env*` and common credential/tool state from project publication
- retain the non-enumerable workspace-scoped `hubResourceId` while decorating shared resources, preventing teammate pulls from falling back to legacy unscoped ids
- narrow legacy resource fallback to genuine not-found responses and suppress duplicate Vela analytics

## Why

The previous integration mixed local/project state across workspace scopes, could lose immutable version identity, and did not refresh non-project team resources. A spread operation also dropped the hidden scoped hub id, causing teammate materialization to request legacy ids and return 404. This change makes the login-backed Vela CLI the single transport and keeps all collaboration state workspace-aware.

## Impact

- local two-user/two-workspace E2E passed design-system, plugin, and skill publication/materialization from v1 to v2
- shared projects passed share, teammate catalog/pull, v2 exact replacement, unshare, catalog removal, and post-revocation pull denial
- workspace B remained isolated while workspace A changed
- no internal Resource Hub token is required by OpenDesign; real OTP login and Vela device authorization provide the identity

## Validation

- root `pnpm typecheck`
- `pnpm guard`
- focused daemon collaboration suite — 6 files / 92 tests
- `pnpm --filter @open-design/daemon build`
- `git diff --check`
- full local Vela API/Web + two isolated daemon/Web E2E

The broader daemon suite has an existing unrelated baseline of 21 failures among 5,644 tests in host/runtime fixtures; all touched collaboration suites pass.

## Companion

- powerformer/vela#827

## Delivery boundary

This uses a locally built Vela CLI and does not pin a newly published package version.
