### PR TITLE
fix: normalize internal project paths for existing HTML edits

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -9615,11 +9615,48 @@ function stripInternalStorageProjectPrefix(value: string): string {
   return value.replace(/^\.od\/projects\/[^/]+\//, '');
 }
 
-function findTouchedProjectFile(rawPath: string, files: readonly ProjectFile[]): ProjectFile | null {
-  const normalized = normalizeComparableFilePath(stripInternalStorageProjectPrefix(rawPath));
-  if (!normalized) return null;
-  const hasPathSeparator = normalized.includes('/');
-  const basename = normalized.split('/').pop() ?? normalized;
+function findTouchedProjectFile(
+  rawPath: string,
+  files: readonly ProjectFile[],
+  projectId?: string,
+  projectRoot?: string | null,
+): ProjectFile | null {
+  const slashed = stripInternalStorageProjectPrefix(rawPath).replace(/\\/g, '/');
+
+// Lexically resolve `.`/`..` first.
+const segments = lexicallyNormalizePathSegments(slashed);
+if (!segments || segments.length === 0) return null;
+
+let normalized = segments.join('/');
+
+const managedProjectRelativePath =
+  relativePathFromManagedProjectAlias(normalized, projectId);
+
+if (!managedProjectRelativePath && isAbsoluteToolPath(slashed)) {
+  const rootSegments = projectRoot
+    ? lexicallyNormalizePathSegments(projectRoot.replace(/\\/g, '/'))
+    : null;
+
+  if (rootSegments && rootSegments.length > 0) {
+    if (segments.length <= rootSegments.length) return null;
+
+    for (let i = 0; i < rootSegments.length; i += 1) {
+      if (segments[i] !== rootSegments[i]) return null;
+    }
+
+    normalized = segments.slice(rootSegments.length).join('/');
+  }
+}
+
+const comparablePaths = managedProjectRelativePath
+  ? [normalized, managedProjectRelativePath]
+  : [normalized];
+
+const hasPathSeparator = comparablePaths.every((candidate) =>
+  candidate.includes('/'),
+);
+
+const basename = normalized.split('/').pop() ?? normalized;
   const normalizedFiles = files.map((file) => ({
     file,
     candidates: [

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -9611,49 +9611,14 @@ export function computeTraceObjectFiles(
   }
   return [...byName.values()];
 }
+function stripInternalStorageProjectPrefix(value: string): string {
+  return value.replace(/^\.od\/projects\/[^/]+\//, '');
+}
 
-function findTouchedProjectFile(
-  rawPath: string,
-  files: readonly ProjectFile[],
-  projectId?: string,
-  projectRoot?: string | null,
-): ProjectFile | null {
-  const slashed = rawPath.replace(/\\/g, '/');
-  // Lexically resolve `.`/`..` first: a path whose `..` climbs above its own
-  // anchor can never be proven to stay anywhere, so it is rejected outright —
-  // before any suffix matching could pair it with an in-project file.
-  const segments = lexicallyNormalizePathSegments(slashed);
-  if (!segments || segments.length === 0) return null;
-  let normalized = segments.join('/');
-  // A managed-project alias (`…/projects/<projectId>/…`) identifies the file's
-  // project-relative form regardless of where the alias mount lives, so it is
-  // trusted as-is; containment below only anchors paths without that marker.
-  const managedProjectRelativePath = relativePathFromManagedProjectAlias(normalized, projectId);
-  if (!managedProjectRelativePath && isAbsoluteToolPath(slashed)) {
-    const rootSegments = projectRoot
-      ? lexicallyNormalizePathSegments(projectRoot.replace(/\\/g, '/'))
-      : null;
-    if (rootSegments && rootSegments.length > 0) {
-      // An absolute tool path is only trusted when it provably lives under
-      // the project root: require the root's segments as a prefix and match
-      // on the remaining project-relative form (/workspace/index.html →
-      // index.html). Out-of-root paths (including `..` escapes that resolve
-      // outside the root) are rejected here rather than falling through to
-      // suffix matching, where /tmp/site/index.html could otherwise pick the
-      // project's own index.html.
-      if (segments.length <= rootSegments.length) return null;
-      for (let i = 0; i < rootSegments.length; i += 1) {
-        if (segments[i] !== rootSegments[i]) return null;
-      }
-      normalized = segments.slice(rootSegments.length).join('/');
-    }
-    // Without a usable root there is no anchor to judge containment against;
-    // keep the legacy suffix behavior below.
-  }
-  const comparablePaths = managedProjectRelativePath
-    ? [normalized, managedProjectRelativePath]
-    : [normalized];
-  const hasPathSeparator = comparablePaths.every((candidate) => candidate.includes('/'));
+function findTouchedProjectFile(rawPath: string, files: readonly ProjectFile[]): ProjectFile | null {
+  const normalized = normalizeComparableFilePath(stripInternalStorageProjectPrefix(rawPath));
+  if (!normalized) return null;
+  const hasPathSeparator = normalized.includes('/');
   const basename = normalized.split('/').pop() ?? normalized;
   const normalizedFiles = files.map((file) => ({
     file,

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -238,30 +238,65 @@ describe('computeTraceObjectFiles', () => {
 
     expect(files).toEqual([]);
   });
+
+  // #5674 / PR #5685: a relative internal storage path
+  // (`.od/projects/<projectId>/...`) must strip its internal prefix and
+  // resolve to the existing root-level project file, instead of falsely
+  // reporting no touched files (which surfaced as ARTIFACT_NOT_FOUND).
   it('resolves internal .od/projects/<id>/ touched paths to the existing project file', () => {
-  const before = ['existing.html'];
+    const before = ['existing.html'];
 
-  const next = [
-    {
-      name: 'existing.html',
-      path: 'existing.html',
-      size: 10,
-      mtime: 2,
-      kind: 'html',
-      mime: 'text/html',
-    },
-  ];
+    const next = [
+      {
+        name: 'existing.html',
+        path: 'existing.html',
+        size: 10,
+        mtime: 2,
+        kind: 'html',
+        mime: 'text/html',
+      },
+    ];
 
-  const files = computeTraceObjectFiles(
-    before,
-    next as never,
-    ['.od/projects/46041b54/existing.html'],
-  );
+    const files = computeTraceObjectFiles(
+      before,
+      next as never,
+      ['.od/projects/46041b54/existing.html'],
+    );
 
-  expect(files?.map((file) => [file.name, file.traceObjectReason])).toEqual([
-    ['existing.html', 'modified'],
-  ]);
-});
+    expect(files?.map((file) => [file.name, file.traceObjectReason])).toEqual([
+      ['existing.html', 'modified'],
+    ]);
+  });
+
+  // PR #5685 review (PerishCode): agent `file_path` inputs are frequently
+  // absolute, and the internal storage marker can appear embedded anywhere in
+  // an absolute path (e.g. `/home/bryan/projects/open-design/.od/projects/<id>/...`),
+  // not just at the start of a project-relative path. This must resolve to
+  // the same existing project file as the relative form above.
+  it('resolves internal .od/projects/<id>/ touched paths embedded in an absolute path', () => {
+    const before = ['existing.html'];
+
+    const next = [
+      {
+        name: 'existing.html',
+        path: 'existing.html',
+        size: 10,
+        mtime: 2,
+        kind: 'html',
+        mime: 'text/html',
+      },
+    ];
+
+    const files = computeTraceObjectFiles(
+      before,
+      next as never,
+      ['/home/bryan/projects/open-design/.od/projects/46041b54/existing.html'],
+    );
+
+    expect(files?.map((file) => [file.name, file.traceObjectReason])).toEqual([
+      ['existing.html', 'modified'],
+    ]);
+  });
 
   it('ignores managed-project aliases that belong to a different project', () => {
     const before = ['existing.html'];

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -258,10 +258,11 @@ describe('computeTraceObjectFiles', () => {
     ];
 
     const files = computeTraceObjectFiles(
-      before,
-      next as never,
-      ['.od/projects/46041b54/existing.html'],
-    );
+  before,
+  next as never,
+  ['/home/bryan/projects/open-design/.od/projects/46041b54/existing.html'],
+  '46041b54',
+);
 
     expect(files?.map((file) => [file.name, file.traceObjectReason])).toEqual([
       ['existing.html', 'modified'],

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -238,6 +238,30 @@ describe('computeTraceObjectFiles', () => {
 
     expect(files).toEqual([]);
   });
+  it('resolves internal .od/projects/<id>/ touched paths to the existing project file', () => {
+  const before = ['existing.html'];
+
+  const next = [
+    {
+      name: 'existing.html',
+      path: 'existing.html',
+      size: 10,
+      mtime: 2,
+      kind: 'html',
+      mime: 'text/html',
+    },
+  ];
+
+  const files = computeTraceObjectFiles(
+    before,
+    next as never,
+    ['.od/projects/46041b54/existing.html'],
+  );
+
+  expect(files?.map((file) => [file.name, file.traceObjectReason])).toEqual([
+    ['existing.html', 'modified'],
+  ]);
+});
 
   it('ignores managed-project aliases that belong to a different project', () => {
     const before = ['existing.html'];

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -288,11 +288,12 @@ describe('computeTraceObjectFiles', () => {
       },
     ];
 
-    const files = computeTraceObjectFiles(
-      before,
-      next as never,
-      ['/home/bryan/projects/open-design/.od/projects/46041b54/existing.html'],
-    );
+   const files = computeTraceObjectFiles(
+  before,
+  next as never,
+  ['/home/bryan/projects/open-design/.od/projects/46041b54/existing.html'],
+  '46041b54',
+);
 
     expect(files?.map((file) => [file.name, file.traceObjectReason])).toEqual([
       ['existing.html', 'modified'],


### PR DESCRIPTION
Refs #5674

## Why

A design run that successfully updates an existing HTML deliverable can incorrectly be treated as producing no deliverable when the touched file path is emitted with the internal `.od/projects/<projectId>/...` prefix. This results in a false `ARTIFACT_NOT_FOUND` state even though the HTML file was successfully modified.

## What users will see

Successful edits to an existing HTML deliverable are recognized as delivered output instead of showing the `ARTIFACT_NOT_FOUND` failure state.

This PR does not change the HTML version-history behavior described in #5674.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None**

## Screenshots

N/A

## Bug fix verification

- Added a regression test covering `.od/projects/<projectId>/...` touched paths.
- Manual QA for the HTML version-history symptom has **not** been completed, so that symptom remains out of scope for this PR.

## Validation

- GitHub Actions CI passed.
- Added a regression test for `computeTraceObjectFiles`.