### PR TITLE
fix(web): preserve delivery and history for in-place HTML edits

### DIFF
--- a/apps/daemon/tests/project-file-version-routes.test.ts
+++ b/apps/daemon/tests/project-file-version-routes.test.ts
@@ -6,6 +6,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { getProjectFileVersionRootStats } from '../src/project-file-versions.js';
 import { projectFileWriteTestHooks } from '../src/projects.js';
+import { snapshotAiHtmlVersionsForRun } from '../src/run-html-version-snapshots.js';
 import { startServer } from '../src/server.js';
 
 describe('project file version routes', () => {
@@ -172,6 +173,53 @@ describe('project file version routes', () => {
     };
     expect(editedList.versions).toHaveLength(2);
     expect(editedList.versions.filter((version) => version.current)).toHaveLength(1);
+  });
+
+  it('preserves AI-generated HTML history after a manual edit', async () => {
+    const projectId = await createProject();
+    const projectRoot = path.join(projectsRoot(), projectId);
+    const htmlPath = path.join(projectRoot, 'proposal.html');
+    await fs.mkdir(projectRoot, { recursive: true });
+
+    await fs.writeFile(htmlPath, '<html><body>generated proposal</body></html>');
+    await snapshotAiHtmlVersionsForRun({
+      projectsRoot: projectsRoot(),
+      projectId,
+      projectRoot,
+      diff: { touchedPaths: [htmlPath] },
+      prompt: 'Generate a proposal',
+      promptSource: 'message',
+    });
+    await fs.writeFile(htmlPath, '<html><body>polished proposal</body></html>');
+    await snapshotAiHtmlVersionsForRun({
+      projectsRoot: projectsRoot(),
+      projectId,
+      projectRoot,
+      diff: { touchedPaths: [htmlPath] },
+      prompt: 'Polish the proposal',
+      promptSource: 'message',
+    });
+
+    const manualEditResponse = await fetch(`${baseUrl}/api/projects/${projectId}/files`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        name: 'proposal.html',
+        content: '<html><body>manually edited proposal</body></html>',
+        versionSource: 'manual',
+        versionLabel: 'Manual copy edit',
+      }),
+    });
+    expect(manualEditResponse.status).toBe(200);
+
+    const listResponse = await fetch(`${baseUrl}/api/projects/${projectId}/files/proposal.html/versions`);
+    expect(listResponse.status).toBe(200);
+    const listed = (await listResponse.json()) as {
+      versions: Array<{ version: number; source: string; current: boolean }>;
+    };
+    expect(listed.versions.map((version) => version.source)).toEqual(['ai', 'ai', 'manual']);
+    expect(listed.versions.map((version) => version.version)).toEqual([1, 2, 3]);
+    expect(listed.versions.filter((version) => version.current)).toHaveLength(1);
   });
 
   it('captures initial HTML versions for batch project uploads', async () => {

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3916,6 +3916,7 @@ export function ProjectView({
                 beforeFileNames,
                 nextFiles,
                 touchedFilePaths,
+                project.id,
               ) ?? [],
               recoveredExistingArtifact,
             );
@@ -3923,7 +3924,11 @@ export function ProjectView({
               ...autoOpenArtifactOptions,
               turnStartedAt: status.createdAt || message.startedAt || message.createdAt || null,
               turnEndedAt: message.endedAt || legacyReplayEndedAt || null,
-              agentTouchedFileNames: resolveAgentTouchedFileNames(touchedFilePaths, nextFiles),
+              agentTouchedFileNames: resolveAgentTouchedFileNames(
+                touchedFilePaths,
+                nextFiles,
+                project.id,
+              ),
             });
             if (producedArtifactToOpen) requestOpenFile(producedArtifactToOpen);
             const deliveryOutcome = resolveDesignDeliveryOutcome({
@@ -4233,6 +4238,7 @@ export function ProjectView({
                     beforeFileNames,
                     nextFiles,
                     touchedFilePaths,
+                    project.id,
                   ) ?? [],
                   recoveredExistingArtifact,
                 );
@@ -4240,7 +4246,11 @@ export function ProjectView({
                   ...autoOpenArtifactOptions,
                   turnStartedAt: status.createdAt || message.startedAt || message.createdAt || null,
                   turnEndedAt: endedAt ?? null,
-                  agentTouchedFileNames: resolveAgentTouchedFileNames(touchedFilePaths, nextFiles),
+                  agentTouchedFileNames: resolveAgentTouchedFileNames(
+                    touchedFilePaths,
+                    nextFiles,
+                    project.id,
+                  ),
                 });
                 if (producedArtifactToOpen) requestOpenFile(producedArtifactToOpen);
                 const deliveryContent = needsFullReplay ? replayedContent : message.content;
@@ -5667,12 +5677,17 @@ export function ProjectView({
                 beforeFileNames,
                 nextFiles,
                 traceTouchedFilePaths,
+                project.id,
               ) ?? [];
               const producedArtifactToOpen = selectAutoOpenTurnArtifact(produced, nextFiles, {
                 ...autoOpenArtifactOptions,
                 turnStartedAt: startedAt,
                 turnEndedAt: endedAt ?? null,
-                agentTouchedFileNames: resolveAgentTouchedFileNames(traceTouchedFilePaths, nextFiles),
+                agentTouchedFileNames: resolveAgentTouchedFileNames(
+                  traceTouchedFilePaths,
+                  nextFiles,
+                  project.id,
+                ),
               });
               if (producedArtifactToOpen) requestOpenFile(producedArtifactToOpen);
               const deliveryCandidate: ChatMessage = {
@@ -9728,6 +9743,7 @@ export function computeTraceObjectFiles(
   beforeNames: ReadonlySet<string> | readonly string[] | undefined,
   next: readonly ProjectFile[],
   touchedPaths: Iterable<string> = [],
+  projectId?: string,
 ): ProjectFile[] | undefined {
   if (!beforeNames) return undefined;
   const set = beforeNames instanceof Set ? beforeNames : new Set(beforeNames);
@@ -9736,7 +9752,7 @@ export function computeTraceObjectFiles(
     byName.set(file.name, { ...file, traceObjectReason: 'new' });
   }
   for (const rawPath of touchedPaths) {
-    const file = findTouchedProjectFile(rawPath, next);
+    const file = findTouchedProjectFile(rawPath, next, projectId);
     if (!file) continue;
     byName.set(file.name, {
       ...file,
@@ -9746,10 +9762,18 @@ export function computeTraceObjectFiles(
   return [...byName.values()];
 }
 
-function findTouchedProjectFile(rawPath: string, files: readonly ProjectFile[]): ProjectFile | null {
+function findTouchedProjectFile(
+  rawPath: string,
+  files: readonly ProjectFile[],
+  projectId?: string,
+): ProjectFile | null {
   const normalized = normalizeComparableFilePath(rawPath);
   if (!normalized) return null;
-  const hasPathSeparator = normalized.includes('/');
+  const managedProjectRelativePath = relativePathFromManagedProjectAlias(normalized, projectId);
+  const comparablePaths = managedProjectRelativePath
+    ? [normalized, managedProjectRelativePath]
+    : [normalized];
+  const hasPathSeparator = comparablePaths.every((candidate) => candidate.includes('/'));
   const basename = normalized.split('/').pop() ?? normalized;
   const normalizedFiles = files.map((file) => ({
     file,
@@ -9767,13 +9791,15 @@ function findTouchedProjectFile(rawPath: string, files: readonly ProjectFile[]):
     return matched;
   };
 
-  const exact = matches((candidate) => candidate === normalized);
+  const exact = matches((candidate) => comparablePaths.includes(candidate));
   if (exact.length === 1) return exact[0]!;
   if (exact.length > 1) return null;
 
   const suffix = matches((candidate) =>
     candidate.includes('/') &&
-    (candidate.endsWith(`/${normalized}`) || normalized.endsWith(`/${candidate}`)),
+    comparablePaths.some((comparablePath) =>
+      candidate.endsWith(`/${comparablePath}`) || comparablePath.endsWith(`/${candidate}`),
+    ),
   );
   if (suffix.length === 1) return suffix[0]!;
   if (suffix.length > 1) return null;
@@ -9784,6 +9810,18 @@ function findTouchedProjectFile(rawPath: string, files: readonly ProjectFile[]):
     candidates.some((candidate) => candidate.split('/').pop() === basename),
   );
   return basenameMatches.length === 1 ? basenameMatches[0]!.file : null;
+}
+
+function relativePathFromManagedProjectAlias(
+  normalizedPath: string,
+  projectId: string | undefined,
+): string | null {
+  const normalizedProjectId = normalizeComparableFilePath(projectId ?? '');
+  if (!normalizedProjectId || normalizedProjectId.includes('/')) return null;
+  const marker = `projects/${normalizedProjectId}/`;
+  const markerIndex = normalizedPath.lastIndexOf(marker);
+  if (markerIndex < 0 || (markerIndex > 0 && normalizedPath[markerIndex - 1] !== '/')) return null;
+  return normalizedPath.slice(markerIndex + marker.length) || null;
 }
 
 function normalizeComparableFilePath(value: string): string {
@@ -9802,10 +9840,11 @@ function normalizeComparableFilePath(value: string): string {
 export function resolveAgentTouchedFileNames(
   touchedPaths: Iterable<string>,
   files: readonly ProjectFile[],
+  projectId?: string,
 ): Set<string> {
   const names = new Set<string>();
   for (const rawPath of touchedPaths) {
-    const file = findTouchedProjectFile(rawPath, files);
+    const file = findTouchedProjectFile(rawPath, files, projectId);
     if (file) names.add(file.name);
   }
   return names;

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -9,6 +9,7 @@ import {
   extractTouchedFilePathsFromEvents,
   findSameTurnHtmlWriteForRecoveredArtifact,
   mergeRecoveredArtifact,
+  resolveAgentTouchedFileNames,
 } from '../../src/components/ProjectView';
 import { resolvePersistedArtifactHtml } from '../../src/artifacts/recover';
 import type { ChatMessage } from '../../src/types';
@@ -233,9 +234,42 @@ describe('computeTraceObjectFiles', () => {
       { name: 'existing.html', path: 'existing.html', size: 10, mtime: 2, kind: 'html', mime: 'text/html' },
     ];
 
-    const files = computeTraceObjectFiles(before, next as never, ['/tmp/existing.html']);
+    const files = computeTraceObjectFiles(before, next as never, ['/tmp/existing.html'], 'project-1');
 
     expect(files).toEqual([]);
+  });
+
+  it('ignores managed-project aliases that belong to a different project', () => {
+    const before = ['existing.html'];
+    const next = [
+      { name: 'existing.html', path: 'existing.html', size: 10, mtime: 2, kind: 'html', mime: 'text/html' },
+    ];
+
+    const files = computeTraceObjectFiles(
+      before,
+      next as never,
+      ['.od/projects/project-2/existing.html'],
+      'project-1',
+    );
+
+    expect(files).toEqual([]);
+  });
+
+  it('includes existing files touched through the current managed-project alias', () => {
+    const before = ['existing.html'];
+    const next = [
+      { name: 'existing.html', path: 'existing.html', size: 10, mtime: 2, kind: 'html', mime: 'text/html' },
+    ];
+    const touchedPaths = ['.od/projects/project-1/existing.html'];
+
+    const files = computeTraceObjectFiles(before, next as never, touchedPaths, 'project-1');
+
+    expect(files?.map((file) => [file.name, file.traceObjectReason])).toEqual([
+      ['existing.html', 'modified'],
+    ]);
+    expect(resolveAgentTouchedFileNames(touchedPaths, next as never, 'project-1')).toEqual(
+      new Set(['existing.html']),
+    );
   });
 
   it('recovers successful write paths from persisted tool events', () => {

--- a/e2e/lib/fake-agents.ts
+++ b/e2e/lib/fake-agents.ts
@@ -216,6 +216,10 @@ async function emitRun(promptText) {
     ], 'end_turn');
     return;
   }
+  if (promptText.includes('Edit the existing deterministic smoke artifact through the managed project alias')) {
+    await emitManagedAliasArtifactEditRun(promptText);
+    return;
+  }
   if (promptText.includes('Edit the existing deterministic smoke artifact')) {
     await emitExistingArtifactEditRun(promptText);
     return;
@@ -385,6 +389,62 @@ async function emitExistingArtifactEditRun(promptText) {
     throw new Error('fake artifact edit write failed: HTTP ' + response.status + ' ' + (await response.text()).slice(0, 500));
   }
   emitSuccess('Updated real-daemon-smoke.html in place with a deterministic follow-up edit.', false, false);
+  process.exitCode = 0;
+  exitSoon(0);
+}
+
+async function emitManagedAliasArtifactEditRun(promptText) {
+  if (agentId !== 'claude') {
+    throw new Error('managed-project alias edit fixture requires the Claude fake runtime');
+  }
+  const projectId = process.env.OD_PROJECT_ID || projectIdFromPrompt(promptText);
+  if (!projectId) {
+    throw new Error('managed-project alias edit fixture requires OD_PROJECT_ID');
+  }
+  const fileName = 'real-daemon-smoke.html';
+  const content = '<!doctype html><html><body><main><h1 data-od-id="smoke-title">Real Daemon Smoke Edited</h1><p>Edited in place through a managed-project alias.</p></main></body></html>';
+  await writeFileFs(join(projectDir(promptText), fileName), content, 'utf8');
+
+  writeJson({ type: 'system', subtype: 'init', model: 'fake-claude', session_id: 'fake-session' });
+  writeJson({
+    type: 'assistant',
+    message: {
+      id: 'msg-managed-alias-write',
+      content: [{
+        type: 'tool_use',
+        id: 'toolu-managed-alias-write',
+        name: 'Write',
+        input: {
+          file_path: '.od/projects/' + projectId + '/' + fileName,
+          content,
+        },
+      }],
+    },
+  });
+  writeJson({
+    type: 'user',
+    message: {
+      content: [{
+        type: 'tool_result',
+        tool_use_id: 'toolu-managed-alias-write',
+        content: 'Updated ' + fileName,
+      }],
+    },
+  });
+  writeJson({
+    type: 'assistant',
+    message: {
+      id: 'msg-managed-alias-summary',
+      content: [{ type: 'text', text: 'Updated ' + fileName + ' in place.' }],
+    },
+  });
+  writeJson({
+    type: 'result',
+    usage: { input_tokens: 1, output_tokens: 1 },
+    total_cost_usd: 0,
+    duration_ms: 1,
+    stop_reason: 'end_turn',
+  });
   process.exitCode = 0;
   exitSoon(0);
 }

--- a/e2e/ui/real-daemon-run.test.ts
+++ b/e2e/ui/real-daemon-run.test.ts
@@ -178,7 +178,7 @@ test('[P0] real daemon run supports a follow-up turn in the same project', async
 
 test('[P1] real daemon run treats an in-place artifact edit as produced work', async ({ page }) => {
   await page.goto('/');
-  await createProject(page, 'Daemon artifact edit smoke');
+  await createProject(page, 'Daemon artifact edit smoke', 'claude');
   await expectWorkspaceReady(page);
 
   await sendPrompt(page, 'Create a deterministic smoke artifact');
@@ -186,7 +186,7 @@ test('[P1] real daemon run treats an in-place artifact edit as produced work', a
   await expectProjectFilesToContain(page, projectId, [GENERATED_FILE]);
   await expectProjectFileToContain(page, projectId, GENERATED_FILE, GENERATED_HEADING);
 
-  await sendPrompt(page, 'Edit the existing deterministic smoke artifact');
+  await sendPrompt(page, 'Edit the existing deterministic smoke artifact through the managed project alias');
 
   await expectProjectFileToContain(page, projectId, GENERATED_FILE, EDITED_GENERATED_HEADING);
   const files = await listProjectFiles(page, projectId);
@@ -200,12 +200,39 @@ test('[P1] real daemon run treats an in-place artifact edit as produced work', a
       return assistantMessages.map((message) => ({
         runStatus: message.runStatus ?? null,
         producedFiles: message.producedFiles?.map((file) => file.name) ?? [],
+        traceObjectFiles: message.traceObjectFiles?.map((file) => file.name) ?? [],
+        resultDeliveryState: message.resultDeliveryState ?? null,
       }));
     }, { timeout: 15_000 })
     .toContainEqual({
       runStatus: 'succeeded',
-      producedFiles: [GENERATED_FILE],
+      producedFiles: [],
+      traceObjectFiles: [GENERATED_FILE],
+      resultDeliveryState: 'delivered',
     });
+  await expect(runErrorCard(page)).toHaveCount(0);
+
+  await page.getByTestId('manual-edit-mode-toggle').click();
+  const editedHeading = artifactPreviewFrame(page).locator('[data-od-id="smoke-title"]');
+  await expect(editedHeading).toBeVisible();
+  await editedHeading.click();
+  await expect(editedHeading).toHaveAttribute('data-od-edit-selected', 'true');
+  const fontSizeInput = page
+    .locator('.manual-edit-modal .cc-section')
+    .filter({ hasText: 'TYPOGRAPHY' })
+    .locator('.cc-row')
+    .filter({ hasText: 'Size' })
+    .locator('input');
+  await fontSizeInput.fill('52');
+  await page.locator('.manual-edit-modal').getByRole('button', { name: /^Save$/ }).click({ force: true });
+  await expectProjectFileToContain(page, projectId, GENERATED_FILE, 'font-size: 52px');
+  await page.getByTestId('manual-edit-mode-toggle').click();
+
+  await page.getByRole('button', { name: 'Versions' }).click();
+  const versionsDialog = page.getByRole('dialog', { name: 'Versions' });
+  await expect(versionsDialog).toBeVisible();
+  await expect(versionsDialog).toContainText('3 versions');
+  await expect(versionsDialog.getByRole('option')).toHaveCount(3);
 });
 
 test('[P1] Plan mode daemon run creates, opens, and restores an editable markdown plan', async ({ page }) => {
@@ -1113,6 +1140,8 @@ async function listConversationMessages(
       runStatus?: string;
       events?: Array<{ kind: string }>;
       producedFiles?: Array<{ name: string }>;
+      traceObjectFiles?: Array<{ name: string }>;
+      resultDeliveryState?: string;
     }>;
   };
   return body.messages;


### PR DESCRIPTION
Fixes #5674

## Why

While reproducing #5674 against the latest `main`, an agent could successfully edit an existing HTML artifact through the managed `.od/projects/<projectId>/...` alias, but the web app discarded that path when resolving touched files. The run was consequently reported as `no_result` even though the artifact changed on disk, and the AI revision was not represented correctly in the delivery and version-history flow.

This fixes the user-facing mismatch between a successful in-place edit and the result shown in chat, while keeping external paths and aliases for other projects excluded.

## What users will see

Agent edits to an existing HTML artifact are now recognized as delivered work when the tool trace uses the current project's managed alias. The edited artifact remains the single project file, and its AI revision is preserved alongside later manual edits in Versions.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this corrects result classification and version-history behavior without changing visual layout. The complete interaction is covered by the Playwright test below.

## Bug fix verification

- Test paths: `apps/web/tests/components/ProjectView.reattach-restore.test.tsx` and `e2e/ui/real-daemon-run.test.ts`
- Red/green: yes. The focused web spec and the full daemon/web Playwright flow both failed on `main` with the second run classified as `no_result` and passed with this fix.

## Validation

- Node `v24.15.0`, pnpm `10.33.2`
- `pnpm --filter @open-design/web test tests/components/ProjectView.reattach-restore.test.tsx` — 33 passed
- `pnpm --filter @open-design/daemon test tests/project-file-version-routes.test.ts` — 11 passed
- `pnpm --filter @open-design/e2e test:ui ui/real-daemon-run.test.ts --grep "real daemon run treats an in-place artifact edit as produced work"` — 1 Chromium test passed
- `pnpm guard`
- `pnpm typecheck`

