### PR TITLE
fix daemon: bypass BYOK OpenCode permission prompts

### DIFF
--- a/apps/daemon/src/runtimes/defs/byok-opencode.ts
+++ b/apps/daemon/src/runtimes/defs/byok-opencode.ts
@@ -1,4 +1,8 @@
 import { opencodeByokModelId } from '../byok-opencode.js';
+import {
+  OPENCODE_PERMISSION_CAPABILITY,
+  appendOpenCodePermissionBypass,
+} from '../opencode-permissions.js';
 import { DEFAULT_MODEL_OPTION } from './shared.js';
 import type { RuntimeAgentDef } from '../types.js';
 
@@ -8,9 +12,11 @@ export const byokOpenCodeAgentDef = {
   bin: 'opencode-cli',
   fallbackBins: ['opencode'],
   versionArgs: ['--version'],
+  ...OPENCODE_PERMISSION_CAPABILITY,
   fallbackModels: [DEFAULT_MODEL_OPTION],
   buildArgs: (_prompt, _imagePaths, _extra, options = {}) => {
     const args = ['run', '--format', 'json'];
+    appendOpenCodePermissionBypass(args, 'byok-opencode');
     const model = opencodeByokModelId(options.model);
     if (model) args.push('-m', model);
     return args;

--- a/apps/daemon/src/runtimes/defs/opencode.ts
+++ b/apps/daemon/src/runtimes/defs/opencode.ts
@@ -1,8 +1,9 @@
 import { DEFAULT_MODEL_OPTION, parseLineSeparatedModels } from './shared.js';
-import { agentCapabilities } from '../capabilities.js';
+import {
+  OPENCODE_PERMISSION_CAPABILITY,
+  appendOpenCodePermissionBypass,
+} from '../opencode-permissions.js';
 import type { RuntimeAgentDef } from '../types.js';
-
-const SKIP_PERMISSIONS_FLAG = '--dangerously-skip-permissions';
 
 export const opencodeAgentDef = {
     id: 'opencode',
@@ -10,10 +11,7 @@ export const opencodeAgentDef = {
     bin: 'opencode-cli',
     fallbackBins: ['opencode'],
     versionArgs: ['--version'],
-    helpArgs: ['run', '--help'],
-    capabilityFlags: {
-      [SKIP_PERMISSIONS_FLAG]: 'skipPermissions',
-    },
+    ...OPENCODE_PERMISSION_CAPABILITY,
     // `opencode models` prints `provider/model` per line. Real-world
     // `opencode models` calls can take >8s (network round-trip to the
     // provider registry), so the previous 8s budget timed out and fell back
@@ -50,9 +48,7 @@ export const opencodeAgentDef = {
         '--format',
         'json',
       ];
-      if (agentCapabilities.get('opencode')?.skipPermissions) {
-        args.push(SKIP_PERMISSIONS_FLAG);
-      }
+      appendOpenCodePermissionBypass(args, 'opencode');
       // Capture-style resume: OpenCode mints its own session id (reported on
       // the stream as `sessionID`, e.g. `ses_...`). On a follow-up turn the
       // daemon continues that session with `-s <id>` instead of re-sending the

--- a/apps/daemon/src/runtimes/opencode-permissions.ts
+++ b/apps/daemon/src/runtimes/opencode-permissions.ts
@@ -1,0 +1,17 @@
+import { agentCapabilities } from './capabilities.js';
+import type { RuntimeAgentDef } from './types.js';
+
+export const OPENCODE_SKIP_PERMISSIONS_FLAG = '--dangerously-skip-permissions';
+
+export const OPENCODE_PERMISSION_CAPABILITY = {
+  helpArgs: ['run', '--help'],
+  capabilityFlags: {
+    [OPENCODE_SKIP_PERMISSIONS_FLAG]: 'skipPermissions',
+  },
+} satisfies Pick<RuntimeAgentDef, 'helpArgs' | 'capabilityFlags'>;
+
+export function appendOpenCodePermissionBypass(args: string[], agentId: string): void {
+  if (agentCapabilities.get(agentId)?.skipPermissions) {
+    args.push(OPENCODE_SKIP_PERMISSIONS_FLAG);
+  }
+}

--- a/apps/daemon/tests/runtimes/byok-opencode.test.ts
+++ b/apps/daemon/tests/runtimes/byok-opencode.test.ts
@@ -1,13 +1,42 @@
 import { describe, expect, it } from 'vitest';
 
+import { agentCapabilities } from '../../src/runtimes/capabilities.js';
 import {
   BYOK_OPENCODE_API_KEY_ENV,
   BYOK_OPENCODE_PROVIDER_ID,
   buildOpenCodeByokProviderConfig,
   opencodeByokModelId,
 } from '../../src/runtimes/byok-opencode.js';
+import { byokOpenCodeAgentDef } from '../../src/runtimes/defs/byok-opencode.js';
 
 describe('byok-opencode runtime config', () => {
+  it('gates non-interactive permission bypass on the installed OpenCode capability', () => {
+    agentCapabilities.delete('byok-opencode');
+    expect(byokOpenCodeAgentDef.helpArgs).toEqual(['run', '--help']);
+    expect(byokOpenCodeAgentDef.capabilityFlags).toEqual({
+      '--dangerously-skip-permissions': 'skipPermissions',
+    });
+    expect(byokOpenCodeAgentDef.buildArgs('', [], [], {})).toEqual([
+      'run',
+      '--format',
+      'json',
+    ]);
+
+    agentCapabilities.set('byok-opencode', { skipPermissions: true });
+    try {
+      expect(byokOpenCodeAgentDef.buildArgs('', [], [], { model: 'gpt-5.5' })).toEqual([
+        'run',
+        '--format',
+        'json',
+        '--dangerously-skip-permissions',
+        '-m',
+        'open-design-byok/gpt-5.5',
+      ]);
+    } finally {
+      agentCapabilities.delete('byok-opencode');
+    }
+  });
+
   it('prefixes raw BYOK models with the run-scoped OpenCode provider id', () => {
     expect(opencodeByokModelId('gpt-4o-mini')).toBe('open-design-byok/gpt-4o-mini');
     expect(opencodeByokModelId('open-design-byok/gpt-4o-mini')).toBe('open-design-byok/gpt-4o-mini');


### PR DESCRIPTION
## Why

BYOK now runs through the daemon-backed OpenCode runtime, but its runtime definition did not declare the same non-interactive permission capability as the regular OpenCode adapter. I found the gap while comparing the BYOK and AMR/Vela permission paths.

Because Open Design launches this runtime headlessly, an OpenCode tool permission prompt has no interactive surface to complete. That can stall or reject filesystem and shell work even though the installed OpenCode CLI already supports a per-run permission bypass.

## What users will see

BYOK OpenCode runs automatically bypass tool permission prompts when the installed OpenCode CLI advertises `--dangerously-skip-permissions`. Older OpenCode versions keep the existing argument shape because the flag remains capability-gated.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — BYOK OpenCode tool permissions are bypassed for non-interactive runs when supported
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — no UI changes.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/runtimes/byok-opencode.test.ts`
- Did the test go red on `main` and green on this branch? Yes. Before the source change, the new test failed because `byokOpenCodeAgentDef.helpArgs` was undefined; it passes after sharing the OpenCode capability probe and argument injection.
- The regression covers both the unsupported baseline, which omits the flag, and the supported path, which adds the flag while preserving BYOK model mapping.

## Validation

- `corepack pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/byok-opencode.test.ts tests/runtimes/agent-args.test.ts tests/runtimes/opencode-resume-args.test.ts` — 64 tests passed
- `corepack pnpm guard`
- `corepack pnpm typecheck`
- `git diff --check`
