### PR TITLE
fix(media): retry transient image generation responses

### DIFF
--- a/apps/daemon/src/media/image-generation-retry.ts
+++ b/apps/daemon/src/media/image-generation-retry.ts
@@ -1,0 +1,133 @@
+// Paid image-generation POSTs are deliberately retried on a narrow response
+// allowlist only. A fetch rejection is ambiguous (the provider may already
+// have accepted and billed the request), so this helper reports it and lets it
+// fail without issuing a second POST.
+export type ImageGenerationRetryReason = 'rate_limit_429' | 'service_unavailable_503';
+
+export type ImageGenerationRequestSummary = {
+  attemptCount: number;
+  retryCount: number;
+  initialResponseStatus?: number;
+  responseStatus?: number;
+  retryReason?: ImageGenerationRetryReason;
+  retryAfterMs?: number;
+  retryDelayMs?: number;
+  retryFinalResult: 'not_attempted' | 'success' | 'failed' | 'skipped_retry_after_budget';
+};
+
+type RetryDependencies = {
+  now?: () => number;
+  random?: () => number;
+  sleep?: (delayMs: number) => Promise<void>;
+};
+
+const DEFAULT_RETRY_DELAY_MS = 1_000;
+const RETRY_JITTER_MS = 250;
+const MAX_RETRY_DELAY_MS = 60_000;
+
+export async function fetchImageGenerationWithResponseRetry(
+  issueRequest: () => Promise<Response>,
+  onSettled?: (summary: ImageGenerationRequestSummary) => void,
+  dependencies: RetryDependencies = {},
+): Promise<Response> {
+  const summary: ImageGenerationRequestSummary = {
+    attemptCount: 0,
+    retryCount: 0,
+    retryFinalResult: 'not_attempted',
+  };
+  const settle = () => {
+    try {
+      onSettled?.({ ...summary });
+    } catch {
+      // Observability must never change whether a paid provider request succeeds.
+    }
+  };
+
+  try {
+    summary.attemptCount = 1;
+    const initialResponse = await issueRequest();
+    summary.initialResponseStatus = initialResponse.status;
+    summary.responseStatus = initialResponse.status;
+
+    const retryReason = retryReasonForStatus(initialResponse.status);
+    if (!retryReason) {
+      settle();
+      return initialResponse;
+    }
+
+    summary.retryReason = retryReason;
+    const retryAfterMs = parseRetryAfterMs(
+      initialResponse.headers.get('retry-after'),
+      dependencies.now?.() ?? Date.now(),
+    );
+    if (retryAfterMs !== undefined) {
+      summary.retryAfterMs = retryAfterMs;
+    }
+    if (retryAfterMs !== undefined && retryAfterMs > MAX_RETRY_DELAY_MS) {
+      summary.retryFinalResult = 'skipped_retry_after_budget';
+      settle();
+      return initialResponse;
+    }
+
+    const random = clampRandom(dependencies.random?.() ?? Math.random());
+    const retryDelayMs = retryAfterMs
+      ?? DEFAULT_RETRY_DELAY_MS + Math.floor(random * RETRY_JITTER_MS);
+    summary.retryCount = 1;
+    summary.retryDelayMs = retryDelayMs;
+    summary.retryFinalResult = 'failed';
+
+    try {
+      await initialResponse.body?.cancel();
+    } catch {
+      // Best effort: discard the first response before reissuing the POST.
+    }
+    if (retryDelayMs > 0) {
+      await (dependencies.sleep ?? sleep)(retryDelayMs);
+    }
+
+    delete summary.responseStatus;
+    summary.attemptCount = 2;
+    const retryResponse = await issueRequest();
+    summary.responseStatus = retryResponse.status;
+    summary.retryFinalResult = retryResponse.ok ? 'success' : 'failed';
+    settle();
+    return retryResponse;
+  } catch (error) {
+    settle();
+    throw error;
+  }
+}
+
+function retryReasonForStatus(status: number): ImageGenerationRetryReason | undefined {
+  if (status === 429) return 'rate_limit_429';
+  if (status === 503) return 'service_unavailable_503';
+  return undefined;
+}
+
+function parseRetryAfterMs(value: string | null, nowMs: number): number | undefined {
+  const retryAfter = value?.trim();
+  if (!retryAfter) return undefined;
+
+  if (/^\d+$/.test(retryAfter)) {
+    const seconds = Number(retryAfter);
+    return Number.isSafeInteger(seconds) && seconds <= Number.MAX_SAFE_INTEGER / 1_000
+      ? seconds * 1_000
+      : Number.MAX_SAFE_INTEGER;
+  }
+  if (/^[+-]?\d+(?:\.\d+)?$/.test(retryAfter)) {
+    return undefined;
+  }
+
+  const dateMs = Date.parse(retryAfter);
+  if (!Number.isFinite(dateMs)) return undefined;
+  return Math.max(0, dateMs - nowMs);
+}
+
+function clampRandom(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(Math.max(value, 0), 0.9999999999999999);
+}
+
+function sleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}

--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -76,6 +76,10 @@ import {
   resolveModelAlias,
   resolveProviderConfig,
 } from './config.js';
+import {
+  fetchImageGenerationWithResponseRetry,
+  type ImageGenerationRequestSummary,
+} from './image-generation-retry.js';
 import { codexNeedsDangerFullAccessSandbox } from '../runtimes/defs/codex.js';
 import {
   ensureProject,
@@ -139,6 +143,9 @@ type MediaContext = {
   /** Additional reference images for multi-image i2v / style reference flows. */
   imageRefs: ImageRef[];
   projectRoot: string;
+  onProviderRequestSettled:
+    | ((summary: ImageGenerationRequestSummary & { providerId: string }) => void)
+    | undefined;
 };
 type RenderResult = { bytes: Buffer; providerNote: string; suggestedExt?: string };
 type JsonRecord = Record<string, unknown>;
@@ -318,6 +325,7 @@ export async function generateMedia(args: {
   prompt?: string; output?: string; aspect?: string; length?: number; duration?: number; voice?: string;
   audioKind?: AudioKind; language?: string; loop?: boolean; promptInfluence?: number;
   compositionDir?: string; image?: string; images?: string[]; onProgress?: ProgressFn; requestInit?: MediaRequestInit;
+  onProviderRequestSettled?: (summary: ImageGenerationRequestSummary & { providerId: string }) => void;
 }) {
   const {
     projectRoot,
@@ -338,6 +346,7 @@ export async function generateMedia(args: {
     compositionDir,
     image,
     requestInit,
+    onProviderRequestSettled,
   } = args;
 
   if (!projectRoot) throw new Error('projectRoot required');
@@ -473,7 +482,7 @@ export async function generateMedia(args: {
   // instructions, MINIMAX/FISHAUDIO TTS map) continue to key off the
   // catalog id while the provider's request body carries the alias.
   const wireModel = await resolveModelAlias(projectRoot, model);
-  const ctx = {
+  const ctx: MediaContext = {
     surface,
     model,
     wireModel,
@@ -500,6 +509,7 @@ export async function generateMedia(args: {
     requestInit: requestInit || {},
     imageRefs,
     projectRoot,
+    onProviderRequestSettled,
   };
 
   const credentials = await resolveProviderConfig(projectRoot, def.provider);
@@ -1241,11 +1251,17 @@ async function renderCustomOpenAIImage(ctx: MediaContext, credentials: ProviderC
     url = buildOpenAIImageEditUrl(baseUrl);
   }
 
-  const resp = await fetch(url, withMediaRequestInit(ctx, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify(body),
-  }));
+  const resp = await fetchImageGenerationWithResponseRetry(
+    () => fetch(url, withMediaRequestInit(ctx, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    })),
+    (summary) => ctx.onProviderRequestSettled?.({
+      providerId: 'custom-image',
+      ...summary,
+    }),
+  );
   const data = await parseOpenAICompatibleJson(resp, 'custom image');
   const bytes = await bytesFromOpenAICompatibleData(data, 'custom image', ctx.requestInit);
   return {
@@ -1816,7 +1832,8 @@ async function renderGrokImage(ctx: MediaContext, credentials: ProviderConfig): 
 }
 
 async function renderNanoBananaImage(ctx: MediaContext, credentials: ProviderConfig): Promise<RenderResult> {
-  if (!credentials.apiKey) {
+  const apiKey = credentials.apiKey;
+  if (!apiKey) {
     throw new Error(
       'no Nano Banana API key — configure it in Settings or set OD_NANOBANANA_API_KEY',
     );
@@ -1839,11 +1856,17 @@ async function renderNanoBananaImage(ctx: MediaContext, credentials: ProviderCon
     },
   };
 
-  const resp = await fetch(`${baseUrl}/v1beta/models/${encodeURIComponent(wireModel)}:generateContent`, withMediaRequestInit(ctx, {
-    method: 'POST',
-    headers: nanoBananaHeaders(baseUrl, credentials.apiKey),
-    body: JSON.stringify(body),
-  }));
+  const resp = await fetchImageGenerationWithResponseRetry(
+    () => fetch(`${baseUrl}/v1beta/models/${encodeURIComponent(wireModel)}:generateContent`, withMediaRequestInit(ctx, {
+      method: 'POST',
+      headers: nanoBananaHeaders(baseUrl, apiKey),
+      body: JSON.stringify(body),
+    })),
+    (summary) => ctx.onProviderRequestSettled?.({
+      providerId: 'nanobanana',
+      ...summary,
+    }),
+  );
   const text = await resp.text();
   if (!resp.ok) {
     throw new Error(`nano-banana image ${resp.status}: ${truncate(text, 240)}`);

--- a/apps/daemon/src/routes/media.ts
+++ b/apps/daemon/src/routes/media.ts
@@ -1,7 +1,12 @@
 import fs from 'node:fs';
 import type { Express } from 'express';
-import type { MediaExecutionPolicy } from '@open-design/contracts';
+import type {
+  MediaExecutionPolicy,
+  MediaGenerationResultProps,
+} from '@open-design/contracts';
+import type { AnalyticsContext } from '../analytics.js';
 import { defaultMediaExecutionPolicy, mediaPolicyDenial } from '../media/policy.js';
+import type { ImageGenerationRequestSummary } from '../media/image-generation-retry.js';
 import type { RouteDeps } from '../server-context.js';
 import { proxyDispatcherRequestInit } from '../connectionTest.js';
 import {
@@ -99,6 +104,39 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
     return { ok: true, policy: run.mediaExecution ?? defaultMediaExecutionPolicy() };
   };
 
+  const mediaAnalyticsContext = async (
+    req: any,
+    grant: ToolTokenGrant | null,
+  ): Promise<AnalyticsContext | null> => {
+    const requestContext = design.readAnalyticsContext(req);
+    if (requestContext) return requestContext;
+
+    const runContext = grant?.runId
+      ? design.runs.get(grant.runId)?.analyticsContext ?? null
+      : null;
+    if (runContext) return runContext;
+
+    // Standalone `od media generate` requests do not carry browser analytics
+    // headers or a parent run. Match the updater's daemon-internal identity
+    // fallback, but only after explicit metrics consent; capture() re-checks
+    // the same consent before sending.
+    const appConfig = await readAppConfig(RUNTIME_DATA_DIR).catch(() => null);
+    const installationId =
+      appConfig?.telemetry?.metrics === true
+      && typeof appConfig.installationId === 'string'
+      && appConfig.installationId
+        ? appConfig.installationId
+        : null;
+    if (!installationId) return null;
+    return {
+      deviceId: installationId,
+      sessionId: installationId,
+      clientType: 'desktop',
+      locale: 'en',
+      requestId: null,
+    };
+  };
+
   const handleGenerate = async (
     req: any,
     res: any,
@@ -129,6 +167,10 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
     let task: ReturnType<typeof createMediaTask> | null = null;
     try {
       const taskId = randomUUID();
+      const analyticsContext = await mediaAnalyticsContext(req, options.grant);
+      let providerRequestSummary:
+        | (ImageGenerationRequestSummary & { providerId: string })
+        | null = null;
       task = createMediaTask(taskId, projectId, {
         surface: req.body?.surface,
         model: req.body?.model,
@@ -173,12 +215,28 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
         images: Array.isArray(req.body?.images) ? req.body.images : undefined,
         onProgress: (line: any) => appendTaskProgress(task, line),
         requestInit: proxyDispatcher.requestInit,
+        onProviderRequestSettled: (summary: ImageGenerationRequestSummary & { providerId: string }) => {
+          providerRequestSummary = summary;
+        },
       })
         .then((meta: any) => {
           task.status = 'done';
           task.file = meta;
           task.endedAt = Date.now();
           persistMediaTask(task);
+          if (analyticsContext && providerRequestSummary) {
+            captureMediaGenerationResult({
+              analyticsContext,
+              durationMs: task.endedAt - task.startedAt,
+              meta,
+              model,
+              projectId,
+              providerRequestSummary,
+              ...(options.grant?.runId ? { runId: options.grant.runId } : {}),
+              surface,
+              taskId,
+            });
+          }
           notifyTaskWaiters(task);
           console.error(
             `[task ${taskId.slice(0, 8)}] done size=${meta?.size} mime=${meta?.mime} ` +
@@ -194,6 +252,18 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
           };
           task.endedAt = Date.now();
           persistMediaTask(task);
+          if (analyticsContext && providerRequestSummary) {
+            captureMediaGenerationResult({
+              analyticsContext,
+              durationMs: task.endedAt - task.startedAt,
+              model,
+              projectId,
+              providerRequestSummary,
+              ...(options.grant?.runId ? { runId: options.grant.runId } : {}),
+              surface,
+              taskId,
+            });
+          }
           notifyTaskWaiters(task);
           console.error(
             `[task ${taskId.slice(0, 8)}] failed status=${task.error.status} ` +
@@ -220,6 +290,63 @@ export function registerMediaRoutes(app: Express, ctx: RegisterMediaRoutesDeps) 
         notifyTaskWaiters(task);
       }
       throw err;
+    }
+  };
+
+  const captureMediaGenerationResult = (input: {
+    analyticsContext: AnalyticsContext;
+    durationMs: number;
+    meta?: { providerError?: string | null; usedStubFallback?: boolean };
+    model: string;
+    projectId: string;
+    providerRequestSummary: ImageGenerationRequestSummary & { providerId: string };
+    runId?: string;
+    surface: 'image' | 'video' | 'audio';
+    taskId: string;
+  }) => {
+    const summary = input.providerRequestSummary;
+    const props = {
+      page_name: 'studio',
+      area: 'media_generation',
+      project_id: input.projectId,
+      task_id: input.taskId,
+      ...(input.runId ? { run_id: input.runId } : {}),
+      surface: input.surface,
+      provider_id: summary.providerId,
+      model_id: input.model,
+      result: input.meta && !input.meta.providerError && !input.meta.usedStubFallback
+        ? 'success'
+        : 'failed',
+      ...(summary.initialResponseStatus !== undefined
+        ? { initial_response_status: summary.initialResponseStatus }
+        : {}),
+      ...(summary.responseStatus !== undefined
+        ? { response_status: summary.responseStatus }
+        : {}),
+      attempt_count: summary.attemptCount,
+      retry_count: summary.retryCount,
+      ...(summary.retryReason ? { retry_reason: summary.retryReason } : {}),
+      ...(summary.retryAfterMs !== undefined
+        ? { retry_after_ms: summary.retryAfterMs }
+        : {}),
+      ...(summary.retryDelayMs !== undefined
+        ? { retry_delay_ms: summary.retryDelayMs }
+        : {}),
+      retry_final_result: summary.retryFinalResult,
+      duration_ms: Math.max(0, input.durationMs),
+      used_stub_fallback: input.meta?.usedStubFallback === true,
+    } satisfies MediaGenerationResultProps;
+
+    try {
+      design.analytics.capture({
+        eventName: 'media_generation_result',
+        context: input.analyticsContext,
+        appVersion: design.getAppVersion(),
+        properties: props,
+        insertId: `media_generation_result:${input.taskId}`,
+      });
+    } catch {
+      // Analytics is best-effort and must not change the media task outcome.
     }
   };
   app.get('/api/media/models', (_req, res) => {

--- a/apps/daemon/tests/media/analytics-routes.test.ts
+++ b/apps/daemon/tests/media/analytics-routes.test.ts
@@ -1,0 +1,285 @@
+import { randomUUID } from 'node:crypto';
+import { gunzipSync } from 'node:zlib';
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from 'node:http';
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { closeDatabase } from '../../src/db.js';
+import { startServer } from '../../src/server.js';
+
+const PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2uoAAAAASUVORK5CYII=';
+const PRIVATE_PROMPT = 'PRIVATE_PROMPT_NEVER_REPORT';
+const PRIVATE_RESPONSE_BODY = 'PRIVATE_UPSTREAM_BODY_NEVER_REPORT';
+const PRIVATE_API_KEY = 'PRIVATE_API_KEY_NEVER_REPORT';
+
+type StartedServer = {
+  url: string;
+  server: Server;
+  shutdown?: () => Promise<void> | void;
+};
+
+type PostHogEvent = {
+  event: string;
+  properties: Record<string, unknown>;
+};
+
+describe('media generation analytics', () => {
+  const originalEnv = snapshotEnv();
+  let daemon: StartedServer | null = null;
+  let provider: Server | null = null;
+  let ingestion: Server | null = null;
+
+  afterEach(async () => {
+    await Promise.resolve(daemon?.shutdown?.());
+    await closeServer(daemon?.server ?? null);
+    await closeServer(provider);
+    await closeServer(ingestion);
+    daemon = null;
+    provider = null;
+    ingestion = null;
+    closeDatabase();
+    restoreEnv(originalEnv);
+  });
+
+  it('reports one consent-gated final event for retried success and failure without private payloads', async () => {
+    const captured: PostHogEvent[] = [];
+    const ingestionStarted = await listen((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+      req.on('end', () => {
+        const compressed = Buffer.concat(chunks);
+        const raw = req.headers['content-encoding'] === 'gzip'
+          ? gunzipSync(compressed)
+          : compressed;
+        const body = JSON.parse(raw.toString('utf8')) as { batch?: PostHogEvent[] };
+        captured.push(...(body.batch ?? []));
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end('{}');
+      });
+    });
+    ingestion = ingestionStarted.server;
+
+    const attemptsByPrompt = new Map<string, number>();
+    const providerStarted = await listen((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer) => chunks.push(Buffer.from(chunk)));
+      req.on('end', () => {
+        const body = JSON.parse(Buffer.concat(chunks).toString('utf8')) as { prompt?: string };
+        const prompt = body.prompt ?? '';
+        const attempt = (attemptsByPrompt.get(prompt) ?? 0) + 1;
+        attemptsByPrompt.set(prompt, attempt);
+
+        if (prompt.includes('always-fail') || attempt === 1) {
+          res.writeHead(429, {
+            'content-type': 'application/json',
+            'retry-after': '0',
+          });
+          res.end(JSON.stringify({ error: { message: PRIVATE_RESPONSE_BODY } }));
+          return;
+        }
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ data: [{ b64_json: PNG_BASE64 }] }));
+      });
+    });
+    provider = providerStarted.server;
+
+    process.env.POSTHOG_KEY = 'phc_media_test';
+    process.env.POSTHOG_HOST = ingestionStarted.url;
+    process.env.NO_PROXY = '127.0.0.1,localhost';
+    delete process.env.HTTP_PROXY;
+    delete process.env.HTTPS_PROXY;
+    delete process.env.ALL_PROXY;
+    delete process.env.OD_MEDIA_ALLOW_STUBS;
+
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('test setup did not provide OD_DATA_DIR');
+    await writeFile(path.join(dataDir, 'media-config.json'), JSON.stringify({
+      providers: {
+        'custom-image': {
+          apiKey: PRIVATE_API_KEY,
+          baseUrl: `${providerStarted.url}/v1`,
+          model: 'acme-image-model',
+        },
+      },
+    }));
+
+    daemon = await startServer({ port: 0, returnServer: true }) as StartedServer;
+    await putAppConfig(daemon.url, {
+      installationId: 'media-installation-test',
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const projectId = `media_analytics_${randomUUID()}`;
+    const projectResponse = await fetch(`${daemon.url}/api/projects`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        id: projectId,
+        name: 'Media analytics probe',
+        metadata: { kind: 'prototype' },
+        skipDiscoveryBrief: true,
+      }),
+    });
+    expect(projectResponse.status).toBe(200);
+
+    const successTaskId = await generateAndWait(
+      daemon.url,
+      projectId,
+      `${PRIVATE_PROMPT} retry-success`,
+      'done',
+      false,
+    );
+    const failedTaskId = await generateAndWait(daemon.url, projectId, `${PRIVATE_PROMPT} always-fail`, 'failed');
+    const mediaEvents = await waitForMediaEvents(captured, 2);
+
+    expect(mediaEvents).toHaveLength(2);
+    const success = mediaEvents.find((event) => event.properties.task_id === successTaskId);
+    const failure = mediaEvents.find((event) => event.properties.task_id === failedTaskId);
+    expect(success?.properties).toMatchObject({
+      page_name: 'studio',
+      area: 'media_generation',
+      client_type: 'desktop',
+      device_id: 'media-installation-test',
+      project_id: projectId,
+      surface: 'image',
+      provider_id: 'custom-image',
+      model_id: 'custom-image',
+      result: 'success',
+      initial_response_status: 429,
+      response_status: 200,
+      attempt_count: 2,
+      retry_count: 1,
+      retry_reason: 'rate_limit_429',
+      retry_after_ms: 0,
+      retry_delay_ms: 0,
+      retry_final_result: 'success',
+      used_stub_fallback: false,
+    });
+    expect(failure?.properties).toMatchObject({
+      client_type: 'web',
+      device_id: 'media-device-test',
+      result: 'failed',
+      initial_response_status: 429,
+      response_status: 429,
+      attempt_count: 2,
+      retry_count: 1,
+      retry_reason: 'rate_limit_429',
+      retry_final_result: 'failed',
+      used_stub_fallback: false,
+    });
+
+    const serializedEvents = JSON.stringify(mediaEvents);
+    expect(serializedEvents).not.toContain(PRIVATE_PROMPT);
+    expect(serializedEvents).not.toContain(PRIVATE_RESPONSE_BODY);
+    expect(serializedEvents).not.toContain(PRIVATE_API_KEY);
+    expect(serializedEvents).not.toContain(providerStarted.url);
+
+    await putAppConfig(daemon.url, {
+      telemetry: { metrics: false, content: false, artifactManifest: false },
+    });
+    await generateAndWait(daemon.url, projectId, `${PRIVATE_PROMPT} opted-out`, 'done', false);
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    expect(captured.filter((event) => event.event === 'media_generation_result')).toHaveLength(2);
+  });
+});
+
+async function listen(
+  handler: (req: IncomingMessage, res: ServerResponse) => void,
+): Promise<{ server: Server; url: string }> {
+  const server = createServer(handler);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('missing server address');
+  return { server, url: `http://127.0.0.1:${address.port}` };
+}
+
+async function closeServer(server: Server | null): Promise<void> {
+  if (!server?.listening) return;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+async function putAppConfig(url: string, patch: Record<string, unknown>): Promise<void> {
+  const response = await fetch(`${url}/api/app-config`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  expect(response.status).toBe(200);
+}
+
+async function generateAndWait(
+  url: string,
+  projectId: string,
+  prompt: string,
+  expectedStatus: 'done' | 'failed' = 'done',
+  includeAnalyticsHeaders = true,
+): Promise<string> {
+  const response = await fetch(`${url}/api/projects/${encodeURIComponent(projectId)}/media/generate`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...(includeAnalyticsHeaders
+        ? {
+            'x-od-analytics-device-id': 'media-device-test',
+            'x-od-analytics-session-id': 'media-session-test',
+            'x-od-analytics-client-type': 'web',
+            'x-od-analytics-locale': 'en',
+          }
+        : {}),
+    },
+    body: JSON.stringify({
+      surface: 'image',
+      model: 'custom-image',
+      prompt,
+      output: `${expectedStatus}-${randomUUID()}.png`,
+    }),
+  });
+  expect(response.status).toBe(202);
+  const { taskId } = await response.json() as { taskId: string };
+
+  const waitResponse = await fetch(`${url}/api/media/tasks/${encodeURIComponent(taskId)}/wait`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ since: 0, timeoutMs: 5_000 }),
+  });
+  expect(waitResponse.status).toBe(200);
+  const task = await waitResponse.json() as { status: string };
+  expect(task.status).toBe(expectedStatus);
+  return taskId;
+}
+
+async function waitForMediaEvents(events: PostHogEvent[], count: number): Promise<PostHogEvent[]> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 3_000) {
+    const found = events.filter((event) => event.event === 'media_generation_result');
+    if (found.length >= count) return found;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return events.filter((event) => event.event === 'media_generation_result');
+}
+
+function snapshotEnv(): Record<string, string | undefined> {
+  return Object.fromEntries([
+    'POSTHOG_KEY',
+    'POSTHOG_HOST',
+    'NO_PROXY',
+    'HTTP_PROXY',
+    'HTTPS_PROXY',
+    'ALL_PROXY',
+    'OD_MEDIA_ALLOW_STUBS',
+  ].map((key) => [key, process.env[key]]));
+}
+
+function restoreEnv(env: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}

--- a/apps/daemon/tests/media/image-generation-retry.test.ts
+++ b/apps/daemon/tests/media/image-generation-retry.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { fetchImageGenerationWithResponseRetry } from '../../src/media/image-generation-retry.js';
+
+describe('image-generation response retry', () => {
+  it('respects an HTTP-date Retry-After before retrying', async () => {
+    const now = Date.parse('Wed, 21 Oct 2015 07:28:00 GMT');
+    const sleep = vi.fn(async () => {});
+    const issueRequest = vi.fn()
+      .mockResolvedValueOnce(new Response('busy', {
+        status: 429,
+        headers: { 'retry-after': 'Wed, 21 Oct 2015 07:28:02 GMT' },
+      }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    const response = await fetchImageGenerationWithResponseRetry(
+      issueRequest,
+      undefined,
+      { now: () => now, sleep },
+    );
+
+    expect(response.status).toBe(200);
+    expect(issueRequest).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledOnce();
+    expect(sleep).toHaveBeenCalledWith(2_000);
+  });
+
+  it('retries immediately when an HTTP-date Retry-After is already past', async () => {
+    const sleep = vi.fn(async () => {});
+    const issueRequest = vi.fn()
+      .mockResolvedValueOnce(new Response('busy', {
+        status: 429,
+        headers: { 'retry-after': 'Wed, 21 Oct 2015 07:27:59 GMT' },
+      }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    await fetchImageGenerationWithResponseRetry(issueRequest, undefined, {
+      now: () => Date.parse('Wed, 21 Oct 2015 07:28:00 GMT'),
+      sleep,
+    });
+
+    expect(issueRequest).toHaveBeenCalledTimes(2);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it.each([undefined, 'not-a-date'])(
+    'uses a short jittered delay when Retry-After is %s',
+    async (retryAfter) => {
+      const sleep = vi.fn(async () => {});
+      const onSettled = vi.fn();
+      const issueRequest = vi.fn()
+        .mockResolvedValueOnce(new Response('busy', {
+          status: 503,
+          ...(retryAfter ? { headers: { 'retry-after': retryAfter } } : {}),
+        }))
+        .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+      await fetchImageGenerationWithResponseRetry(issueRequest, onSettled, {
+        random: () => 0.5,
+        sleep,
+      });
+
+      expect(sleep).toHaveBeenCalledWith(1_125);
+      expect(onSettled).toHaveBeenCalledWith(expect.objectContaining({
+        retryReason: 'service_unavailable_503',
+        retryDelayMs: 1_125,
+        retryFinalResult: 'success',
+      }));
+    },
+  );
+
+  it('does not retry early when Retry-After exceeds the wait budget', async () => {
+    const sleep = vi.fn(async () => {});
+    const onSettled = vi.fn();
+    const issueRequest = vi.fn(async () => new Response('come back later', {
+      status: 429,
+      headers: { 'retry-after': '61' },
+    }));
+
+    const response = await fetchImageGenerationWithResponseRetry(
+      issueRequest,
+      onSettled,
+      { sleep },
+    );
+
+    expect(issueRequest).toHaveBeenCalledOnce();
+    expect(sleep).not.toHaveBeenCalled();
+    expect(await response.text()).toBe('come back later');
+    expect(onSettled).toHaveBeenCalledWith({
+      attemptCount: 1,
+      retryCount: 0,
+      initialResponseStatus: 429,
+      responseStatus: 429,
+      retryReason: 'rate_limit_429',
+      retryAfterMs: 61_000,
+      retryFinalResult: 'skipped_retry_after_budget',
+    });
+  });
+
+  it('makes at most one retry and preserves the final response', async () => {
+    const onSettled = vi.fn();
+    const issueRequest = vi.fn()
+      .mockResolvedValueOnce(new Response('first failure', {
+        status: 503,
+        headers: { 'retry-after': '0' },
+      }))
+      .mockResolvedValueOnce(new Response('final failure', { status: 503 }));
+
+    const response = await fetchImageGenerationWithResponseRetry(issueRequest, onSettled);
+
+    expect(issueRequest).toHaveBeenCalledTimes(2);
+    expect(await response.text()).toBe('final failure');
+    expect(onSettled).toHaveBeenCalledWith({
+      attemptCount: 2,
+      retryCount: 1,
+      initialResponseStatus: 503,
+      responseStatus: 503,
+      retryReason: 'service_unavailable_503',
+      retryAfterMs: 0,
+      retryDelayMs: 0,
+      retryFinalResult: 'failed',
+    });
+  });
+
+  it('does not report the initial response as the final status when the retry is rejected', async () => {
+    const networkError = new TypeError('retry fetch failed');
+    const onSettled = vi.fn();
+    const issueRequest = vi.fn()
+      .mockResolvedValueOnce(new Response('rate limited', {
+        status: 429,
+        headers: { 'retry-after': '0' },
+      }))
+      .mockRejectedValueOnce(networkError);
+
+    await expect(fetchImageGenerationWithResponseRetry(issueRequest, onSettled))
+      .rejects.toBe(networkError);
+
+    expect(issueRequest).toHaveBeenCalledTimes(2);
+    expect(onSettled).toHaveBeenCalledWith({
+      attemptCount: 2,
+      retryCount: 1,
+      initialResponseStatus: 429,
+      retryReason: 'rate_limit_429',
+      retryAfterMs: 0,
+      retryDelayMs: 0,
+      retryFinalResult: 'failed',
+    });
+  });
+
+  it('does not retry other response failures', async () => {
+    const issueRequest = vi.fn(async () => new Response('bad gateway', { status: 502 }));
+
+    const response = await fetchImageGenerationWithResponseRetry(issueRequest);
+
+    expect(response.status).toBe(502);
+    expect(issueRequest).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    new TypeError('fetch failed'),
+    new DOMException('request timed out', 'AbortError'),
+  ])('does not retry rejected fetches (%s)', async (networkError) => {
+    const onSettled = vi.fn();
+    const issueRequest = vi.fn(async () => {
+      throw networkError;
+    });
+
+    await expect(fetchImageGenerationWithResponseRetry(issueRequest, onSettled))
+      .rejects.toBe(networkError);
+
+    expect(issueRequest).toHaveBeenCalledOnce();
+    expect(onSettled).toHaveBeenCalledWith({
+      attemptCount: 1,
+      retryCount: 0,
+      retryFinalResult: 'not_attempted',
+    });
+  });
+});

--- a/apps/daemon/tests/media/nanobanana.test.ts
+++ b/apps/daemon/tests/media/nanobanana.test.ts
@@ -93,7 +93,6 @@ describe('nano-banana media generation', () => {
       });
     });
     vi.stubGlobal('fetch', fetchMock);
-
     const result = await generateMedia({
       projectRoot,
       projectsRoot,
@@ -156,6 +155,76 @@ describe('nano-banana media generation', () => {
     expect(result.name).toBe('official.png');
   });
 
+  it('retries a rate-limited Nano Banana request with the same provider', async () => {
+    await writeConfig({
+      providers: {
+        nanobanana: {
+          baseUrl: TEST_NANOBANANA_BASE_URL,
+          model: 'custom-nano-model',
+        },
+      },
+    });
+    const onProviderRequestSettled = vi.fn();
+
+    const fetchMock = vi.fn(async () => {
+      if (fetchMock.mock.calls.length === 1) {
+        return new Response(JSON.stringify({
+          error: { message: 'rate limited' },
+        }), {
+          status: 429,
+          headers: {
+            'content-type': 'application/json',
+            'retry-after': '0',
+          },
+        });
+      }
+      return new Response(JSON.stringify({
+        candidates: [{
+          content: {
+            parts: [{
+              inlineData: {
+                mimeType: 'image/png',
+                data: PNG_BASE64,
+              },
+            }],
+          },
+        }],
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'gemini-3.1-flash-image-preview',
+      prompt: 'A neon city skyline',
+      aspect: '1:1',
+      output: 'retried.png',
+      onProviderRequestSettled,
+    });
+
+    expect(result.providerId).toBe('nanobanana');
+    expect(result.name).toBe('retried.png');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(onProviderRequestSettled).toHaveBeenCalledOnce();
+    expect(onProviderRequestSettled).toHaveBeenCalledWith({
+      providerId: 'nanobanana',
+      attemptCount: 2,
+      retryCount: 1,
+      initialResponseStatus: 429,
+      responseStatus: 200,
+      retryReason: 'rate_limit_429',
+      retryAfterMs: 0,
+      retryDelayMs: 0,
+      retryFinalResult: 'success',
+    });
+  });
+
   it('surfaces upstream Nano Banana errors', async () => {
     await writeConfig({
       providers: {
@@ -165,12 +234,16 @@ describe('nano-banana media generation', () => {
       },
     });
 
-    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
       error: { message: 'quota exceeded' },
     }), {
       status: 429,
-      headers: { 'content-type': 'application/json' },
-    })));
+      headers: {
+        'content-type': 'application/json',
+        'retry-after': '0',
+      },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
 
     await expect(generateMedia({
       projectRoot,
@@ -180,6 +253,7 @@ describe('nano-banana media generation', () => {
       model: 'gemini-3.1-flash-image-preview',
       prompt: 'A neon city skyline',
       aspect: '1:1',
-    })).rejects.toThrow(/nano-banana image 429/);
+    })).rejects.toThrow(/nano-banana image 429:.*quota exceeded/);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/daemon/tests/media/openai-compatible-providers.test.ts
+++ b/apps/daemon/tests/media/openai-compatible-providers.test.ts
@@ -222,6 +222,69 @@ process.stdin.on('end', () => {
     expect(bytes.length).toBeGreaterThan(0);
   });
 
+  it('retries a temporarily unavailable custom-image request with the same provider', async () => {
+    await writeConfig({
+      providers: {
+        'custom-image': {
+          baseUrl: 'https://images.example.test/v1',
+          model: 'acme-image-model',
+        },
+      },
+    });
+
+    const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
+      expect(String(input)).toBe('https://images.example.test/v1/images/generations');
+      expect(init?.method).toBe('POST');
+      expect(JSON.parse(String(init?.body))).toMatchObject({
+        prompt: 'A product render on white seamless paper',
+        model: 'acme-image-model',
+      });
+      if (fetchMock.mock.calls.length === 1) {
+        return new Response(JSON.stringify({ error: { message: 'try again' } }), {
+          status: 503,
+          headers: {
+            'content-type': 'application/json',
+            'retry-after': '0',
+          },
+        });
+      }
+      return new Response(JSON.stringify({
+        data: [{ b64_json: PNG_BASE64 }],
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const onProviderRequestSettled = vi.fn();
+
+    const result = await generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'custom-image',
+      prompt: 'A product render on white seamless paper',
+      output: 'custom-retried.png',
+      onProviderRequestSettled,
+    });
+
+    expect(result.providerId).toBe('custom-image');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(onProviderRequestSettled).toHaveBeenCalledOnce();
+    expect(onProviderRequestSettled).toHaveBeenCalledWith({
+      providerId: 'custom-image',
+      attemptCount: 2,
+      retryCount: 1,
+      initialResponseStatus: 503,
+      responseStatus: 200,
+      retryReason: 'service_unavailable_503',
+      retryAfterMs: 0,
+      retryDelayMs: 0,
+      retryFinalResult: 'success',
+    });
+  });
+
   it('forwards requestInit.dispatcher through custom-image submit and asset fetches', async () => {
     await writeConfig({
       providers: {
@@ -260,6 +323,46 @@ process.stdin.on('end', () => {
       requestInit: { dispatcher },
     });
 
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not resubmit custom-image generation when the returned asset download fails', async () => {
+    await writeConfig({
+      providers: {
+        'custom-image': {
+          baseUrl: 'https://images.example.test/v1',
+          model: 'acme-image-model',
+        },
+      },
+    });
+
+    let submitCalls = 0;
+    const fetchMock = vi.fn(async (input: unknown) => {
+      if (String(input) === 'https://images.example.test/v1/images/generations') {
+        submitCalls += 1;
+        return new Response(JSON.stringify({
+          data: [{ url: 'https://cdn.example.test/generated.png' }],
+        }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      expect(String(input)).toBe('https://cdn.example.test/generated.png');
+      return new Response('temporarily unavailable', { status: 503 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(generateMedia({
+      projectRoot,
+      projectsRoot,
+      projectId: 'project-1',
+      surface: 'image',
+      model: 'custom-image',
+      prompt: 'A product render on white seamless paper',
+      output: 'custom-download-failure.png',
+    })).rejects.toThrow('custom image media fetch 503');
+
+    expect(submitCalls).toBe(1);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 

--- a/packages/contracts/src/analytics/events/event-names.ts
+++ b/packages/contracts/src/analytics/events/event-names.ts
@@ -19,6 +19,8 @@ export type AnalyticsEventName =
   | 'langfuse_report_result'
   | 'run_retry_attempted'
   | 'run_retry_finished'
+  // Paid media provider request outcome and bounded response retry.
+  | 'media_generation_result'
   // Packaged updater lifecycle
   | 'update_install_result'
   | 'update_apply_observed'
@@ -106,4 +108,3 @@ export type TrackingPageName =
 // Alias kept for backwards-compatibility inside the contracts file; v2 wire
 // format uses the field name `page_name` for settings events too.
 export type TrackingSettingsPage = 'settings';
-

--- a/packages/contracts/src/analytics/events/event-payload.ts
+++ b/packages/contracts/src/analytics/events/event-payload.ts
@@ -6,7 +6,7 @@ import type { AnalyticsEventName } from './event-names.js';
 import type { DesignSystemApplyResultProps, DesignSystemCreateResultProps, DesignSystemEnrichResultProps, DesignSystemReviewResultProps, DesignSystemSourceIngestResultProps, DesignSystemStatusResultProps } from './design-systems.js';
 import type { OnboardingCompletedProps, OnboardingCompleteResultProps, OnboardingFirstGenerationCompletedProps, OnboardingFirstPromptSentProps, OnboardingPromptPrefilledProps, OnboardingRuntimeScanResultProps } from './onboarding.js';
 import type { PageViewProps } from './page-view.js';
-import type { ArtifactDeployResultProps, ArtifactExportResultProps, AssistantFeedbackClickProps, AssistantFeedbackReasonClickProps, AssistantFeedbackReasonSubmitProps, AssistantFeedbackReasonViewProps, ContextLinkResultProps, FeedbackSubmitResultProps, FileUploadResultProps, FileVersionRestoreResultProps, LangfuseReportResultProps, PackagedRuntimeFailedProps, PluginImportResultProps, PluginReplacementResultProps, ProjectCreateResultProps, RunCreatedProps, RunFinishedProps, RunRetryAttemptedProps, RunRetryFinishedProps, SettingsByokModelsFetchResultProps, SettingsByokTestResultProps, SettingsCliTestResultProps, SettingsConnectorAuthResultProps, SettingsViewProps, SketchExportResultProps, SketchSaveResultProps, SpeakerNotesSaveResultProps, UpdateApplyObservedProps, UpdateInstallResultProps } from './result-events.js';
+import type { ArtifactDeployResultProps, ArtifactExportResultProps, AssistantFeedbackClickProps, AssistantFeedbackReasonClickProps, AssistantFeedbackReasonSubmitProps, AssistantFeedbackReasonViewProps, ContextLinkResultProps, FeedbackSubmitResultProps, FileUploadResultProps, FileVersionRestoreResultProps, LangfuseReportResultProps, MediaGenerationResultProps, PackagedRuntimeFailedProps, PluginImportResultProps, PluginReplacementResultProps, ProjectCreateResultProps, RunCreatedProps, RunFinishedProps, RunRetryAttemptedProps, RunRetryFinishedProps, SettingsByokModelsFetchResultProps, SettingsByokTestResultProps, SettingsCliTestResultProps, SettingsConnectorAuthResultProps, SettingsViewProps, SketchExportResultProps, SketchSaveResultProps, SpeakerNotesSaveResultProps, UpdateApplyObservedProps, UpdateInstallResultProps } from './result-events.js';
 import type { SurfaceViewProps } from './surface-view.js';
 import type { AmrAuthResultProps, UiClickProps } from './ui-click.js';
 // ---- Discriminated union of all event payloads ---------------------------
@@ -24,6 +24,7 @@ export type AnalyticsEventPayload =
   | { event: 'langfuse_report_result'; props: LangfuseReportResultProps }
   | { event: 'run_retry_attempted'; props: RunRetryAttemptedProps }
   | { event: 'run_retry_finished'; props: RunRetryFinishedProps }
+  | { event: 'media_generation_result'; props: MediaGenerationResultProps }
   | { event: 'update_install_result'; props: UpdateInstallResultProps }
   | { event: 'update_apply_observed'; props: UpdateApplyObservedProps }
   | { event: 'file_upload_result'; props: FileUploadResultProps }

--- a/packages/contracts/src/analytics/events/result-events.ts
+++ b/packages/contracts/src/analytics/events/result-events.ts
@@ -10,6 +10,30 @@ import type { TrackingArtifactKind, TrackingArtifactWriteSource, TrackingArtifac
 import type { TrackingFileVersionSource, TrackingPluginImportSource, TrackingSessionMode, TrackingSettingsArea } from './ui-click.js';
 // ---- Result events -------------------------------------------------------
 
+// Final outcome for the paid provider submission. Keep this envelope free of
+// prompts, response bodies, configured URLs, credentials, and output paths.
+export interface MediaGenerationResultProps {
+  page_name: 'studio';
+  area: 'media_generation';
+  project_id: string;
+  task_id: string;
+  run_id?: string;
+  surface: 'image' | 'video' | 'audio';
+  provider_id: string;
+  model_id: string;
+  result: 'success' | 'failed';
+  initial_response_status?: number;
+  response_status?: number;
+  attempt_count: number;
+  retry_count: number;
+  retry_reason?: 'rate_limit_429' | 'service_unavailable_503';
+  retry_after_ms?: number;
+  retry_delay_ms?: number;
+  retry_final_result: 'not_attempted' | 'success' | 'failed' | 'skipped_retry_after_budget';
+  duration_ms: number;
+  used_stub_fallback: boolean;
+}
+
 export interface ProjectCreateResultProps {
   page_name: 'home';
   area: 'new_project';
@@ -741,4 +765,3 @@ export interface PackagedRuntimeFailedProps {
   source: string;
   platform: string;
 }
-

--- a/packages/contracts/tests/analytics-media-generation-contract.test.ts
+++ b/packages/contracts/tests/analytics-media-generation-contract.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  AnalyticsEventPayload,
+  MediaGenerationResultProps,
+} from '../src/analytics/events.js';
+
+describe('analytics media_generation_result contract', () => {
+  it('accepts a successful generation without a retry', () => {
+    const props = {
+      page_name: 'studio',
+      area: 'media_generation',
+      project_id: 'project-1',
+      task_id: 'task-1',
+      run_id: 'run-1',
+      surface: 'image',
+      provider_id: 'custom-image',
+      model_id: 'custom-image',
+      result: 'success',
+      initial_response_status: 200,
+      response_status: 200,
+      attempt_count: 1,
+      retry_count: 0,
+      retry_final_result: 'not_attempted',
+      duration_ms: 120,
+      used_stub_fallback: false,
+    } satisfies MediaGenerationResultProps;
+    const payload = {
+      event: 'media_generation_result',
+      props,
+    } satisfies Extract<AnalyticsEventPayload, { event: 'media_generation_result' }>;
+
+    expect(payload.props.result).toBe('success');
+    expect(payload.props.retry_count).toBe(0);
+  });
+
+  it('accepts retry and bounded-wait outcome fields', () => {
+    const payload = {
+      event: 'media_generation_result',
+      props: {
+        page_name: 'studio',
+        area: 'media_generation',
+        project_id: 'project-1',
+        task_id: 'task-2',
+        surface: 'image',
+        provider_id: 'nanobanana',
+        model_id: 'gemini-3.1-flash-image-preview',
+        result: 'failed',
+        initial_response_status: 429,
+        response_status: 429,
+        attempt_count: 1,
+        retry_count: 0,
+        retry_reason: 'rate_limit_429',
+        retry_after_ms: 61_000,
+        retry_final_result: 'skipped_retry_after_budget',
+        duration_ms: 25,
+        used_stub_fallback: false,
+      },
+    } satisfies Extract<AnalyticsEventPayload, { event: 'media_generation_result' }>;
+
+    expect(payload.props.retry_final_result).toBe('skipped_retry_after_budget');
+  });
+});


### PR DESCRIPTION
## Why

While auditing the paid image-generation paths, I found that both Nano Banana and custom-image issued a single provider `fetch` and failed immediately on rate limits or explicit service-unavailable responses. That made short-lived provider pressure surface as a failed media task even when the provider supplied a usable `Retry-After` hint.

The root cause was the absence of a shared response-retry policy and a low-sensitivity completion signal for these provider submissions. This change adds the narrow retry behavior requested for the same provider only, while avoiding ambiguous network retries that could duplicate a paid request.

## What users will see

Nano Banana and custom-image generation now retry once against the same provider and model after an HTTP `429` or `503`. The daemon respects integer-seconds and HTTP-date `Retry-After` values; values beyond the 60-second wait budget fail without retrying early. When the header is missing or invalid, the retry uses a short jittered delay.

Fetch rejections, timeouts/abort errors, other response codes, and custom-image CDN downloads are not retried. There is no cross-model or cross-provider fallback.

The daemon also emits one consent-gated `media_generation_result` event per completed provider submission, containing provider/model identifiers, response status, attempt/retry counts, retry timing, duration, and final result. It does not include prompts, response bodies, configured URLs, credentials, image content, or output paths.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — no UI changes.

## Bug fix verification

- Test paths:
  - `apps/daemon/tests/media/nanobanana.test.ts`
  - `apps/daemon/tests/media/openai-compatible-providers.test.ts`
  - `apps/daemon/tests/media/image-generation-retry.test.ts`
  - `apps/daemon/tests/media/analytics-routes.test.ts`
  - `packages/contracts/tests/analytics-media-generation-contract.test.ts`
- The Nano Banana `429 -> 200`, custom-image `503 -> 200`, and analytics contract/integration specs went red before the implementation and green afterward.

## Validation

- `corepack pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/media/image-generation-retry.test.ts tests/media/nanobanana.test.ts tests/media/openai-compatible-providers.test.ts tests/media/analytics-routes.test.ts` — 36 passed
- `corepack pnpm --filter @open-design/contracts exec vitest run tests/analytics-media-generation-contract.test.ts` — 2 passed
- `corepack pnpm --filter @open-design/daemon typecheck`
- `corepack pnpm typecheck`
- `corepack pnpm guard`
