### PR TITLE
chore(pack): bump bundled Vela CLI to 0.0.22

### DIFF
--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -9,6 +9,6 @@
   # 1. Temporarily set the consuming `hash = lib.fakeHash;`
   # 2. Run the relevant nix build/flake check
   # 3. Copy the expected hash printed by Nix into the matching field below
-  daemonHash = "sha256-k2mLkO5BXrVXpqYNuJbSxwQ4TzR+Hd35UG5tLxLvwww=";
-  webHash = "sha256-mKqQx7UcW1hBli9iSJiSv+JJte++nKJC81+NchP29k4=";
+  daemonHash = "sha256-vWjs6hwLMVVFQbTxpnpkrU5IwVh/WLxt55Q/bZ6Rlkc=";
+  webHash = "sha256-+fP6LX/6HzUkT4pYxOLok1qFXu/a7rrd4mwz6cahcHQ=";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -795,8 +795,8 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       '@powerformer/vela-cli':
-        specifier: 0.0.21
-        version: 0.0.21
+        specifier: 0.0.22
+        version: 0.0.22
 
   tools/release:
     dependencies:
@@ -2032,33 +2032,33 @@ packages:
   '@posthog/types@1.374.2':
     resolution: {integrity: sha512-ZghQSFMi+HFJNPvPjBoyY/jWQ+q6mSQVtWQxOHMSbBidUZjsyYbxYxBFbHy2qWLNe4mEpX+Wqir2Q4I/4AVvJQ==}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.21':
-    resolution: {integrity: sha512-OGDpLOh/F+mYQTRPteG3Ea5dAxTGHwGyMu1q0hCNjP8S7lCj/6f+on81FwQo8ICjI8QF4zA8PK8/14KWCMbQKA==}
+  '@powerformer/vela-cli-darwin-arm64@0.0.22':
+    resolution: {integrity: sha512-v7XKQY1KR79Jn2iZ16wOt0WEobdGAnui1UzbeosoAjGG8MmkPjVV92W4BJbSLR4vcT8r++CbzCJmQfcPqIw6BQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@powerformer/vela-cli-darwin-x64@0.0.21':
-    resolution: {integrity: sha512-+POj6rNahFstuxRnYs3C6R2j2Dt9Pdw69tL3Nari2xJ9t9NxhEYG1X1LUQrszo03kn2iotlbUmYULqmdkzrZ9A==}
+  '@powerformer/vela-cli-darwin-x64@0.0.22':
+    resolution: {integrity: sha512-SqwMrrbWwbLuDgZ68r4zkc5qyGM9BBmUWlvA8uqeL5I5ylj5qHuJ65o1HrleXHEp0/7Y/iHG6gZ32kALCROzQQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@powerformer/vela-cli-linux-arm64@0.0.21':
-    resolution: {integrity: sha512-BpxN2D1uJRLXAr+1CIpfZD0GOEIAG1gfsQDpWFq9Xi3eT3hXyaNC92KYxEanWl/tYqgAKYAJroyqlQwPgNSWvg==}
+  '@powerformer/vela-cli-linux-arm64@0.0.22':
+    resolution: {integrity: sha512-dxt76Zpwe4Sqad8cm5g8Y53Cbif5jUzb44Zow2O4Ii0J8AB3Pim9Uboj17Fbr19ZhYF3QX/9vqIVwEbnVx46IQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@powerformer/vela-cli-linux-x64@0.0.21':
-    resolution: {integrity: sha512-/0KuR0v9mTW/OuHw+b8jlE7v1Nl2EgEi/5T8Bj9UoSH7yhYB9ZsJnTbXmiyRCgsvGH6mIu+8Xu0EqsEJoXY3Lg==}
+  '@powerformer/vela-cli-linux-x64@0.0.22':
+    resolution: {integrity: sha512-ckorxoV22MdNcgbqKr1spceM+GnpnzgdNWsX2IdNIoHoGBEMZkXxOmkgK3pZSvagkVKAd7b+QwQtjqCvmDO68A==}
     cpu: [x64]
     os: [linux]
 
-  '@powerformer/vela-cli-win32-x64@0.0.21':
-    resolution: {integrity: sha512-3RHkEMNarP+bVrecu0uJYsp+eVZFeaY7Up6XlfMJXo/XPa5tyRV/Ds5OOynPBaVr+Zi69tBPL0Ov8gNjn28dRA==}
+  '@powerformer/vela-cli-win32-x64@0.0.22':
+    resolution: {integrity: sha512-TDKGXruOUfDePUEdGebWjoLS1fu7v6HbCqX8GTS2x2DfOYvRnXjevatzAqFOqYSDYaGDgbjom47f8QHdwPySaA==}
     cpu: [x64]
     os: [win32]
 
-  '@powerformer/vela-cli@0.0.21':
-    resolution: {integrity: sha512-c2p95iEosfo3M0ASFJZbFctdm6C+oUOpZXqV1XAg5odAqtPNJJnTsQMkS7wPo00/NpBVakxOL5RoQVN3yw0SLQ==}
+  '@powerformer/vela-cli@0.0.22':
+    resolution: {integrity: sha512-TdzIJ+SRt72CDInlIVcoNU/R0r5PU2RDaAcWleQV5CT3s95Dt7cWDo/sOZcloKO5TBf1qc1NFqSutFOlX1k9nQ==}
     hasBin: true
 
   '@preact/signals-core@1.14.2':
@@ -7870,28 +7870,28 @@ snapshots:
 
   '@posthog/types@1.374.2': {}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.21':
+  '@powerformer/vela-cli-darwin-arm64@0.0.22':
     optional: true
 
-  '@powerformer/vela-cli-darwin-x64@0.0.21':
+  '@powerformer/vela-cli-darwin-x64@0.0.22':
     optional: true
 
-  '@powerformer/vela-cli-linux-arm64@0.0.21':
+  '@powerformer/vela-cli-linux-arm64@0.0.22':
     optional: true
 
-  '@powerformer/vela-cli-linux-x64@0.0.21':
+  '@powerformer/vela-cli-linux-x64@0.0.22':
     optional: true
 
-  '@powerformer/vela-cli-win32-x64@0.0.21':
+  '@powerformer/vela-cli-win32-x64@0.0.22':
     optional: true
 
-  '@powerformer/vela-cli@0.0.21':
+  '@powerformer/vela-cli@0.0.22':
     optionalDependencies:
-      '@powerformer/vela-cli-darwin-arm64': 0.0.21
-      '@powerformer/vela-cli-darwin-x64': 0.0.21
-      '@powerformer/vela-cli-linux-arm64': 0.0.21
-      '@powerformer/vela-cli-linux-x64': 0.0.21
-      '@powerformer/vela-cli-win32-x64': 0.0.21
+      '@powerformer/vela-cli-darwin-arm64': 0.0.22
+      '@powerformer/vela-cli-darwin-x64': 0.0.22
+      '@powerformer/vela-cli-linux-arm64': 0.0.22
+      '@powerformer/vela-cli-linux-x64': 0.0.22
+      '@powerformer/vela-cli-win32-x64': 0.0.22
     optional: true
 
   '@preact/signals-core@1.14.2': {}

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -25,7 +25,7 @@
     "resedit": "1.7.2"
   },
   "optionalDependencies": {
-    "@powerformer/vela-cli": "0.0.21"
+    "@powerformer/vela-cli": "0.0.22"
   },
   "devDependencies": {
     "@types/node": "24.12.2",


### PR DESCRIPTION
## Why

Vela CLI 0.0.22 has been published and packaged Open Design builds should consume the latest available Vela runtime. Keeping the bundled dependency current ensures new packages use the matching platform binaries across macOS, Linux, and Windows.

## What users will see

There is no new UI. Newly packaged Open Design builds will bundle Vela CLI 0.0.22 instead of 0.0.21.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal packaging dependency update only

## Screenshots

Not applicable; this change has no UI surface.

## Bug fix verification

Not applicable; this is a dependency version update.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @open-design/tools-pack exec vela --version` → `0.0.22`
- `pnpm --filter @open-design/tools-pack test -- tests/resources.test.ts` (237 passed, 8 skipped)
- `pnpm --filter @open-design/tools-pack typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
