### PR TITLE
Fix large HTML preview fallback

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -138,6 +138,7 @@ import {
   upsertSpeakerNotesInHtml,
 } from '../runtime/speaker-notes';
 import {
+  hasTweaksTemplate,
   hasUrlModeBridge,
   htmlNeedsFocusGuard,
   htmlNeedsPoweredPreview,
@@ -292,6 +293,18 @@ const POWERED_PREVIEW_ALLOW =
   'accelerometer; autoplay; camera; cross-origin-isolated; fullscreen; gamepad; gyroscope; microphone; xr-spatial-tracking';
 const HTML_PASSIVE_PREVIEW_FULL_TEXT_LIMIT = 2 * 1024 * 1024;
 const HTML_ROUTING_TEXT_PREVIEW_LIMIT = 96 * 1024;
+type HtmlSourceLoadMode = 'full' | 'routing-preview';
+
+function previewTextNeedsFullSourceForSafeInline(source: string | null): boolean {
+  if (!source) return false;
+  return (
+    htmlNeedsSandboxShim(source) ||
+    htmlNeedsFocusGuard(source) ||
+    htmlNeedsRedirectGuard(source) ||
+    hasTweaksTemplate(source)
+  );
+}
+
 const PREVIEW_VIEWPORT_PRESETS: PreviewViewportPreset[] = [
   {
     id: 'desktop',
@@ -6825,15 +6838,30 @@ function HtmlViewer({
       ? fetchProjectFileTextPreview(projectId, file.name, {
           limit: HTML_ROUTING_TEXT_PREVIEW_LIMIT,
           cacheBustKey,
-        }).then((preview) => ({
-          text: preview?.text ?? null,
-          poweredPreviewRequired: preview?.poweredPreview.required === true,
-        }))
+        }).then(async (preview) => {
+          const previewText = preview?.text ?? null;
+          if (previewTextNeedsFullSourceForSafeInline(previewText)) {
+            const fullText = await fetchProjectFileText(projectId, file.name, { cacheBustKey });
+            if (fullText !== null) {
+              return {
+                text: fullText,
+                poweredPreviewRequired: preview?.poweredPreview.required === true,
+                sourceLoadMode: 'full' as HtmlSourceLoadMode,
+              };
+            }
+          }
+          return {
+            text: previewText,
+            poweredPreviewRequired: preview?.poweredPreview.required === true,
+            sourceLoadMode: 'routing-preview' as HtmlSourceLoadMode,
+          };
+        })
       : fetchProjectFileText(projectId, file.name, { cacheBustKey }).then((text) => ({
-          text,
-          poweredPreviewRequired: false,
-        }));
-    void loadText.then(({ text, poweredPreviewRequired }) => {
+        text,
+        poweredPreviewRequired: false,
+        sourceLoadMode: 'full' as HtmlSourceLoadMode,
+      }));
+    void loadText.then(({ text, poweredPreviewRequired, sourceLoadMode }) => {
       if (cancelled) return;
       setServerPoweredPreviewRequired(poweredPreviewRequired);
       // Chokidar emits agent rewrites as unlink+add+change bursts; a
@@ -6880,7 +6908,7 @@ function HtmlViewer({
       sourceEverLoadedRef.current = true;
       lastGoodSourceForRoutingRef.current = text;
       setRoutingSource(text);
-      if (shouldDeferPassivePreviewSource) {
+      if (sourceLoadMode === 'routing-preview') {
         sourceRef.current = null;
       } else {
         setSource(text);

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -6819,7 +6819,11 @@ function HtmlViewer({
       // switches but before the effect has run.
     }
     let cancelled = false;
-    if (shouldDeferPassivePreviewSource && sourceRef.current !== null) {
+    if (
+      shouldDeferPassivePreviewSource &&
+      sourceRef.current !== null &&
+      !previewTextNeedsFullSourceForSafeInline(sourceRef.current)
+    ) {
       setRoutingSource(sourceRef.current);
       sourceEverLoadedRef.current = true;
       return () => {

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -755,6 +755,62 @@ describe('FileViewer SVG artifacts', () => {
     expect(screen.getByTestId('artifact-preview-frame')).toBe(firstFrame);
   });
 
+  it('promotes large HTML files to the srcDoc path when the routing preview shows sandbox-unsafe scripts', async () => {
+    const file = baseFile({
+      name: 'index.html',
+      path: 'index.html',
+      mime: 'text/html',
+      kind: 'html',
+      size: 3 * 1024 * 1024,
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Imported app',
+        entry: 'index.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    });
+    const previewText = '<!doctype html><html><head><script src="./app.js"></script></head>';
+    const fullHtml = `${previewText}<body><main>Imported filesystem app</main></body></html>`;
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url.startsWith('/api/projects/project-1/text-preview/index.html')) {
+        return new Response(JSON.stringify({
+          text: previewText,
+          poweredPreview: { required: false, reasons: [] },
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.startsWith('/api/projects/project-1/raw/index.html')) {
+        return new Response(fullHtml, {
+          status: 200,
+          headers: { 'Content-Type': 'text/html' },
+        });
+      }
+      if (url === '/api/projects/project-1/files') {
+        return new Response(JSON.stringify({ files: [file] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response('', { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(<FileViewer projectId="project-1" projectKind="prototype" file={file} />);
+
+    await waitFor(() => {
+      const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      expect(frame.getAttribute('data-od-render-mode')).toBe('srcdoc');
+      expect(frame.getAttribute('srcDoc')).toContain('Imported filesystem app');
+    });
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/api/projects/project-1/text-preview/index.html'), { cache: 'no-store' });
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/api/projects/project-1/raw/index.html?cacheBust='), {});
+  });
+
   it('evicts least-recent inactive preview iframes once the pool exceeds its limit', () => {
     function Harness({ activeKey }: { activeKey: string | null }) {
       return (

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -772,7 +772,7 @@ describe('FileViewer SVG artifacts', () => {
       },
     });
     const previewText = '<!doctype html><html><head><script src="./app.js"></script></head>';
-    const fullHtml = `${previewText}<body><main>Imported filesystem app</main></body></html>`;
+    let fullHtml = `${previewText}<body><main>Imported filesystem app</main></body></html>`;
     const fetchMock = vi.fn(async (input: string | URL | Request) => {
       const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
       if (url.startsWith('/api/projects/project-1/text-preview/index.html')) {
@@ -800,7 +800,7 @@ describe('FileViewer SVG artifacts', () => {
     });
     vi.stubGlobal('fetch', fetchMock);
 
-    render(<FileViewer projectId="project-1" projectKind="prototype" file={file} />);
+    const { rerender } = render(<FileViewer projectId="project-1" projectKind="prototype" file={file} />);
 
     await waitFor(() => {
       const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
@@ -809,6 +809,21 @@ describe('FileViewer SVG artifacts', () => {
     });
     expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/api/projects/project-1/text-preview/index.html'), { cache: 'no-store' });
     expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/api/projects/project-1/raw/index.html?cacheBust='), {});
+
+    fullHtml = `${previewText}<body><main>Updated filesystem app</main></body></html>`;
+    rerender(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={{ ...file, mtime: file.mtime + 1 }}
+      />,
+    );
+
+    await waitFor(() => {
+      const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      expect(frame.getAttribute('data-od-render-mode')).toBe('srcdoc');
+      expect(frame.getAttribute('srcDoc')).toContain('Updated filesystem app');
+    });
   });
 
   it('evicts least-recent inactive preview iframes once the pool exceeds its limit', () => {


### PR DESCRIPTION
## Summary

- Promote large HTML previews from routing-only text preview to full source when the routing preview shows sandbox-unsafe HTML patterns.
- Keep the existing powered-preview signal while switching to full source.
- Refresh promoted large-HTML srcDoc previews on reload / mtime changes instead of reusing stale cached source.
- Add regression coverage for a large filesystem-style HTML file with an external script opening through the srcDoc path and updating after the file changes.

Fixes #5695

## Surface area

- `FileViewer` / `HtmlViewer` passive HTML preview loading.
- Large HTML files above the passive preview limit.
- The srcDoc fallback path used when a routing preview reveals sandbox-unsafe inline behavior, including external scripts.

## Bug fix verification

- Before the fix, a promoted large HTML preview could cache the full srcDoc source and then reuse that stale source after reload / mtime changes.
- The updated regression test promotes a large HTML file through the external-script preview path, bumps the file mtime, and verifies the srcDoc iframe renders the updated full source.

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/components/FileViewer.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `git diff --check origin/main...HEAD`
