### PR TITLE
Surface provider errors before connection-test timeout

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1831,6 +1831,7 @@ function extractOpenCodeTextFromRawStdout(stdout: string): string {
 
 const OPENCODE_OUTDATED_CLI_DETAIL =
   'OpenCode CLI appears to be outdated or incompatible with this connection test. Update it with `npm i -g opencode-ai@latest`, then retry the OpenCode connection test.';
+const OPENCODE_PROVIDER_CONNECTIVITY_DETAIL_MAX_LENGTH = 240;
 
 function openCodeOutdatedCliDetail(output: string): string | null {
   const value = output.toLowerCase();
@@ -1842,6 +1843,23 @@ function openCodeOutdatedCliDetail(output: string): string | null {
   return looksLikeOpenCodeHelp || looksLikeUnsupportedArgs
     ? OPENCODE_OUTDATED_CLI_DETAIL
     : null;
+}
+
+function openCodeProviderConnectivityDetail(output: string): string | null {
+  for (const rawLine of output.split(/\r?\n/u)) {
+    const line = rawLine.replace(/\s+/gu, ' ').trim();
+    if (!line) continue;
+    const match = /\bCannot connect to API:[^"'`\r\n]+/iu.exec(line) ??
+      /\bUnable to connect[^"'`\r\n]+/iu.exec(line) ??
+      /\bWas there a typo in the url or port\?/iu.exec(line);
+    if (!match) continue;
+    const detail = match[0].trim();
+    const boundedDetail = detail.length > OPENCODE_PROVIDER_CONNECTIVITY_DETAIL_MAX_LENGTH
+      ? `${detail.slice(0, OPENCODE_PROVIDER_CONNECTIVITY_DETAIL_MAX_LENGTH - 3).trimEnd()}...`
+      : detail;
+    return `OpenCode reported a provider connectivity failure before the connection test timed out: ${boundedDetail}`;
+  }
+  return null;
 }
 
 interface AgentSpawnHandle {
@@ -2200,6 +2218,23 @@ async function testAgentConnectionInternal(
     kind: 'timeout' | 'aborted',
   ): ConnectionTestResponse => {
     const latencyMs = Date.now() - start;
+    if (kind === 'timeout' && input.agentId === 'opencode') {
+      const rawDetail = `${sink.getStderrTail()}\n${sink.getRawStdoutTail()}`;
+      const providerDetail = openCodeProviderConnectivityDetail(rawDetail);
+      if (providerDetail) {
+        const detail = redactSecrets(providerDetail);
+        console.warn(`[test:agent] ${def.name} → upstream_unavailable: ${detail}`);
+        return {
+          ok: false,
+          kind: 'upstream_unavailable',
+          latencyMs,
+          model,
+          agentName: def.name,
+          detail,
+          diagnostics: buildDiagnostics({ phase: 'connection_smoke_test' }),
+        };
+      }
+    }
     console.warn(`[test:agent] ${def.name} → ${kind} in ${(latencyMs / 1000).toFixed(1)}s`);
     return {
       ok: false,

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -3627,6 +3627,94 @@ process.stdin.on('end', () => {
     }
   });
 
+  it('surfaces OpenCode provider connectivity errors captured before timeout (#4999)', async () => {
+    const oldTimeout = process.env.OD_CONNECTION_TEST_AGENT_TIMEOUT_MS;
+    process.env.OD_CONNECTION_TEST_AGENT_TIMEOUT_MS = '1500';
+    try {
+      await withFakeOpenCode(
+        `
+const args = process.argv.slice(2);
+if (args[0] === 'models') {
+  console.log('ollama/qwen3.5-9b');
+  process.exit(0);
+}
+console.error('Cannot connect to API: Unable to connect. Is the computer able to access the url?');
+console.log('UNRELATED_STDOUT_TAIL_MARKER');
+setInterval(() => {}, 1000);
+`,
+        async () => {
+          const result = await testAgentConnection({
+            agentId: 'opencode',
+            model: 'ollama/qwen3.5-9b',
+          });
+
+          expect(result.ok).toBe(false);
+          expect(result.kind).toBe('upstream_unavailable');
+          expect(result.detail).toContain('OpenCode reported a provider connectivity failure');
+          expect(result.detail).toContain('Cannot connect to API');
+          expect(result.detail).not.toContain('UNRELATED_STDOUT_TAIL_MARKER');
+          expect(result.diagnostics?.phase).toBe('connection_smoke_test');
+          expect(result.diagnostics?.stderrTail).toContain('Cannot connect to API');
+        },
+      );
+    } finally {
+      if (oldTimeout === undefined) {
+        delete process.env.OD_CONNECTION_TEST_AGENT_TIMEOUT_MS;
+      } else {
+        process.env.OD_CONNECTION_TEST_AGENT_TIMEOUT_MS = oldTimeout;
+      }
+    }
+  });
+
+  it.each([
+    [
+      'Unable to connect fallback',
+      'Unable to connect. Is the computer able to access the url?',
+      'Unable to connect',
+    ],
+    [
+      'URL typo fallback',
+      'Was there a typo in the url or port?',
+      'Was there a typo in the url or port?',
+    ],
+  ])(
+    'surfaces OpenCode provider connectivity errors from %s before timeout (#4999)',
+    async (_name, stderrLine, expectedDetail) => {
+      const oldTimeout = process.env.OD_CONNECTION_TEST_AGENT_TIMEOUT_MS;
+      process.env.OD_CONNECTION_TEST_AGENT_TIMEOUT_MS = '1500';
+      try {
+        await withFakeOpenCode(
+          `
+const args = process.argv.slice(2);
+if (args[0] === 'models') {
+  console.log('ollama/qwen3.5-9b');
+  process.exit(0);
+}
+console.error(${JSON.stringify(stderrLine)});
+setInterval(() => {}, 1000);
+`,
+          async () => {
+            const result = await testAgentConnection({
+              agentId: 'opencode',
+              model: 'ollama/qwen3.5-9b',
+            });
+
+            expect(result.ok).toBe(false);
+            expect(result.kind).toBe('upstream_unavailable');
+            expect(result.detail).toContain(expectedDetail);
+            expect(result.diagnostics?.phase).toBe('connection_smoke_test');
+          },
+        );
+      } finally {
+        if (oldTimeout === undefined) {
+          delete process.env.OD_CONNECTION_TEST_AGENT_TIMEOUT_MS;
+        } else {
+          process.env.OD_CONNECTION_TEST_AGENT_TIMEOUT_MS = oldTimeout;
+        }
+      }
+    },
+  );
+
   it('launches Kimi connection tests without the legacy acp positional arg', async () => {
     const markerDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'od-kimi-argv-'));
     const argvFile = path.join(markerDir, 'argv.json');


### PR DESCRIPTION
Fixes #4999

## Why

The local agent connection test could time out even after the spawned process had already reported a concrete provider connectivity failure. That made Settings show a generic timeout instead of the actionable upstream error that was already present in the captured output.

This keeps the normal timeout fallback, but promotes known provider connectivity output captured before the timeout into a specific connection-test failure with a redacted detail line.

## What users will see

When the local agent reports that it cannot reach the configured provider before the connection-test timeout expires, Settings can show that provider connectivity failure instead of only saying the test timed out.

## Surface area

- [ ] **UI** - new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** - new or changed
- [ ] **CLI / env var** - new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** - new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** - new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** - added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** - adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** - changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** - internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; daemon-only connection-test behavior.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/connection-test.test.ts`
- Did the test go red on `main` and green on this branch? No. I added branch-side regression coverage for the timeout path that already captured a provider connectivity error before cancellation.
- If a red spec wasn't cheap to write, explain why and what verification you did instead: the original repro depends on a packaged-app launch environment plus an unreachable configured provider. The regression uses a fake local agent that emits the same provider connectivity error and then hangs until the connection-test timeout.

## Validation

- `git diff --check`
- `env PATH="$HOME/.nvm/versions/node/v24.17.0/bin:$PATH" pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/connection-test.test.ts --testNamePattern '<focused local-agent connectivity regression set>'`
- `env PATH="$HOME/.nvm/versions/node/v24.17.0/bin:$PATH" pnpm --filter @open-design/daemon typecheck`
