### PR TITLE
fix(web): keep report-only Design runs off the ARTIFACT_NOT_FOUND path

### DIFF
--- a/apps/web/src/runtime/design-delivery.ts
+++ b/apps/web/src/runtime/design-delivery.ts
@@ -1,11 +1,13 @@
 import type { ChatSessionMode } from '@open-design/contracts';
 import type { AgentEvent, ChatMessage } from '../types';
+import { hasFileMutationToolUse } from './file-ops';
 import { unfinishedTodosFromEvents } from './todos';
 
 export type DesignDeliveryOutcome =
   | 'not_required'
   | 'awaiting_input'
   | 'delivered'
+  | 'report_only'
   | 'no_result'
   | 'delivery_failed';
 
@@ -60,6 +62,14 @@ function hasLiveArtifactDelivery(events: AgentEvent[] | undefined): boolean {
  * Design mode is artifact-first, but clarification and explicitly unfinished
  * turns are valid intermediate outcomes. Chat and Plan remain text-first and
  * must never be failed merely because they did not write a project file.
+ *
+ * A zero-file success is only a missing deliverable when the turn attempted
+ * to mutate project files (or an artifact save failed). A turn that never
+ * tried to write and answered with substantive text is a report-only result —
+ * image analysis and report-only audits end exactly this way — and must not
+ * be downgraded to ARTIFACT_NOT_FOUND. The known cost: an agent that merely
+ * claims completion without ever calling a write tool now passes as text; the
+ * text itself makes that visible to the user.
  */
 export function resolveDesignDeliveryOutcome(
   input: DesignDeliveryInput,
@@ -78,7 +88,11 @@ export function resolveDesignDeliveryOutcome(
   ) {
     return 'delivered';
   }
-  return input.persistenceFailed ? 'delivery_failed' : 'no_result';
+  if (input.persistenceFailed) return 'delivery_failed';
+  if (!hasFileMutationToolUse(input.events) && input.content.trim().length > 0) {
+    return 'report_only';
+  }
+  return 'no_result';
 }
 
 /**

--- a/apps/web/src/runtime/file-ops.ts
+++ b/apps/web/src/runtime/file-ops.ts
@@ -129,6 +129,25 @@ export function deriveFileOps(events: AgentEvent[] | undefined): FileOpEntry[] {
   return Array.from(byPath.values());
 }
 
+/**
+ * True when the run attempted any file mutation (write/edit/delete tool call,
+ * or a simple Bash rm/unlink), regardless of whether the attempt succeeded.
+ * Tool names must stay aligned with the daemon's cross-runtime
+ * `WRITE_OR_EDIT_TOOL_NAMES` set in `apps/daemon/src/runtimes/run-artifacts.ts`.
+ */
+export function hasFileMutationToolUse(events: AgentEvent[] | undefined): boolean {
+  for (const ev of events ?? []) {
+    if (ev.kind !== 'tool_use') continue;
+    if (ev.name === 'Bash') {
+      if (extractSimpleBashDeletes(ev.input).length > 0) return true;
+      continue;
+    }
+    const kind = classify(ev.name);
+    if (kind === 'write' || kind === 'edit' || kind === 'delete') return true;
+  }
+  return false;
+}
+
 export type FileOpCounts = Record<FileOpKind, number>;
 
 /** Total tool_use count per op family across `entries`. */

--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -403,9 +403,45 @@ describe('ProjectView API empty response handling', () => {
     });
   });
 
-  it('records no_result without downgrading a successful Design run', async () => {
+  it('keeps a text-only successful Design run as a report-only success', async () => {
+    // Report-only turns (image analysis, audits) legitimately end with prose
+    // and zero produced files (#5714, #5718). They must not be downgraded to
+    // ARTIFACT_NOT_FOUND.
     mockedStreamViaDaemon.mockImplementation(async (options: DaemonStreamOptions) => {
       const { handlers } = options;
+      handlers.onDelta('hello');
+      handlers.onDone('hello');
+    });
+    renderProjectView();
+
+    await sendTestPrompt();
+
+    await waitFor(() => expect(screen.getAllByText('hello').length).toBeGreaterThan(0));
+    await waitFor(() => {
+      expect(
+        hasSavedAssistantMessage(
+          (message) =>
+            message.runStatus === 'succeeded' &&
+            message.resultDeliveryState === undefined &&
+            message.producedFiles !== undefined &&
+            message.events?.some(
+              (event) => event.kind === 'status' && event.code === 'ARTIFACT_NOT_FOUND',
+            ) !== true,
+        ),
+      ).toBe(true);
+    });
+    expect(screen.queryByText(/without producing a deliverable project file/i)).toBeNull();
+  });
+
+  it('records no_result when a Design run attempted file writes that never landed', async () => {
+    mockedStreamViaDaemon.mockImplementation(async (options: DaemonStreamOptions) => {
+      const { handlers } = options;
+      handlers.onAgentEvent({
+        kind: 'tool_use',
+        id: 'write-1',
+        name: 'Write',
+        input: { file_path: 'index.html', content: '<!doctype html>' },
+      });
       handlers.onDelta('hello');
       handlers.onDone('hello');
     });
@@ -548,6 +584,12 @@ describe('ProjectView API empty response handling', () => {
   it('waits for delivery verification before playing the failure sound for a missing result', async () => {
     mockedStreamViaDaemon.mockImplementation(async (options: DaemonStreamOptions) => {
       const { handlers } = options;
+      handlers.onAgentEvent({
+        kind: 'tool_use',
+        id: 'write-1',
+        name: 'Write',
+        input: { file_path: 'index.html', content: '<!doctype html>' },
+      });
       handlers.onDelta('hello');
       handlers.onDone('hello');
     });

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -932,13 +932,21 @@ describe('ProjectView conversation run isolation', () => {
     expect(showCompletionNotification).not.toHaveBeenCalled();
   });
 
-  it('downgrades a reloaded terminal Design run with prose but no delivered file', async () => {
+  it('downgrades a reloaded terminal Design run whose file writes never landed', async () => {
     conversationAMessages = [
       {
         ...succeededAssistant,
         content: '',
         sessionMode: 'design',
-        events: [{ kind: 'text', text: 'I finished the design.' }],
+        events: [
+          { kind: 'text', text: 'I finished the design.' },
+          {
+            kind: 'tool_use',
+            id: 'write-1',
+            name: 'Write',
+            input: { file_path: 'index.html', content: '<!doctype html>' },
+          },
+        ],
         preTurnFileNames: [],
         producedFiles: undefined,
         traceObjectFiles: undefined,
@@ -978,6 +986,54 @@ describe('ProjectView conversation run isolation', () => {
     expect(screen.getByTestId('chat-error').textContent).toMatch(
       /finished without producing a deliverable project file/i,
     );
+    expect(reattachDaemonRun).not.toHaveBeenCalled();
+  });
+
+  it('keeps a reloaded report-only Design run without file writes on the success path', async () => {
+    // Prose-only turns (image analysis, audits) are legitimate zero-file
+    // Design results (#5714, #5718); reload must not downgrade them.
+    conversationAMessages = [
+      {
+        ...succeededAssistant,
+        content: '',
+        sessionMode: 'design',
+        events: [{ kind: 'text', text: 'The hero image contrast is too low.' }],
+        preTurnFileNames: [],
+        producedFiles: undefined,
+        traceObjectFiles: undefined,
+      },
+    ];
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-a',
+      status: 'succeeded',
+      createdAt: 1,
+      updatedAt: 2,
+      exitCode: 0,
+      signal: null,
+    });
+
+    renderProjectView();
+
+    await waitFor(() => {
+      const recoveredMessage = saveMessage.mock.calls
+        .map((call) => call[2] as ChatMessage)
+        .find(
+          (message) =>
+            message.id === succeededAssistant.id && message.producedFiles !== undefined,
+        );
+      expect(recoveredMessage).toMatchObject({
+        runStatus: 'succeeded',
+        producedFiles: [],
+        traceObjectFiles: [],
+      });
+      expect(recoveredMessage?.resultDeliveryState).toBeUndefined();
+      expect(recoveredMessage?.events).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ code: 'ARTIFACT_NOT_FOUND' }),
+        ]),
+      );
+    });
+    expect(screen.getByTestId('chat-error').textContent).toBe('');
     expect(reattachDaemonRun).not.toHaveBeenCalled();
   });
 

--- a/apps/web/tests/runtime/design-delivery.test.ts
+++ b/apps/web/tests/runtime/design-delivery.test.ts
@@ -5,12 +5,61 @@ import {
 } from '../../src/runtime/design-delivery';
 
 describe('resolveDesignDeliveryOutcome', () => {
-  it('requires file delivery for a successfully completed Design-mode turn', () => {
+  it('treats a text answer without any file-write attempt as a report-only result', () => {
+    // Image analysis / report-only audits legitimately end with prose and no
+    // new project file (#5714, #5718). Only fail delivery when the agent
+    // actually attempted to write files and nothing landed.
+    expect(
+      resolveDesignDeliveryOutcome({
+        sessionMode: 'design',
+        runStatus: 'succeeded',
+        content: 'The hero image uses low contrast; increase it for readability.',
+        events: [
+          { kind: 'tool_use', id: 'read-1', name: 'Read', input: { file_path: 'hero.png' } },
+        ],
+        producedFileCount: 0,
+        traceObjectFileCount: 0,
+      }),
+    ).toBe('report_only');
+    // BYOK API runs have no tool events at all; a substantive text answer is
+    // still a report-only result, not a missing artifact.
     expect(
       resolveDesignDeliveryOutcome({
         sessionMode: 'design',
         runStatus: 'succeeded',
         content: 'I finished the design.',
+        events: [],
+        producedFileCount: 0,
+        traceObjectFileCount: 0,
+      }),
+    ).toBe('report_only');
+  });
+
+  it('requires file delivery once the turn attempted to write project files', () => {
+    for (const attempt of [
+      { kind: 'tool_use' as const, id: 'w-1', name: 'Write', input: { file_path: 'index.html' } },
+      { kind: 'tool_use' as const, id: 'e-1', name: 'Edit', input: { file_path: 'index.html' } },
+      { kind: 'tool_use' as const, id: 'b-1', name: 'Bash', input: { command: 'rm stale.html' } },
+    ]) {
+      expect(
+        resolveDesignDeliveryOutcome({
+          sessionMode: 'design',
+          runStatus: 'succeeded',
+          content: 'I finished the design.',
+          events: [attempt],
+          producedFileCount: 0,
+          traceObjectFileCount: 0,
+        }),
+      ).toBe('no_result');
+    }
+  });
+
+  it('does not accept an empty answer as a report-only result', () => {
+    expect(
+      resolveDesignDeliveryOutcome({
+        sessionMode: 'design',
+        runStatus: 'succeeded',
+        content: '   ',
         events: [],
         producedFileCount: 0,
         traceObjectFileCount: 0,
@@ -76,6 +125,22 @@ describe('resolveDesignDeliveryOutcome', () => {
         sessionMode: 'design',
         runStatus: 'succeeded',
         content: '<artifact type="text/html">broken</artifact>',
+        events: [],
+        producedFileCount: 0,
+        traceObjectFileCount: 0,
+        persistenceFailed: true,
+      }),
+    ).toBe('delivery_failed');
+  });
+
+  it('keeps a failed artifact save a failure even without file-write tool calls', () => {
+    // A BYOK <artifact> block that failed to persist is a delivery failure;
+    // the report-only escape must never mask it.
+    expect(
+      resolveDesignDeliveryOutcome({
+        sessionMode: 'design',
+        runStatus: 'succeeded',
+        content: 'Here is the landing page you asked for.',
         events: [],
         producedFileCount: 0,
         traceObjectFileCount: 0,


### PR DESCRIPTION
Fixes #5714
Fixes #5718

## Why

Users keep hitting a failed task card on runs that actually succeeded. Two reports this week describe the same family: a report-only Design audit (#5714, reproduced 11× locally with `runtime status: succeeded`, `produced_files_json: []`) and an image-reading/analysis run (#5718). In both, the agent legitimately answers in prose — the user asked for analysis, not a new file — yet the app appends `ARTIFACT_NOT_FOUND` ("The design run finished without producing a deliverable project file.") and paints the turn as a failure.

The root cause is post-run delivery classification, not the runs themselves. `resolveDesignDeliveryOutcome()` (introduced in #5525 to catch agents that claim completion while producing nothing, refined for in-place edits in #5689) treats **every** zero-file successful Design turn as `no_result`. It cannot tell "the agent intentionally answered in text" apart from "the agent tried to deliver a file and nothing landed".

This PR teaches the classifier that difference using evidence already present in the run's persisted events: whether the turn ever attempted a file mutation.

- Zero files **and no write/edit/delete tool call in the whole run** and a substantive text answer → new `report_only` outcome. The turn stays a plain success: no `ARTIFACT_NOT_FOUND` event, no failure banner, no failure sound, no retry downgrade.
- Zero files **but the run did attempt writes** → still `no_result` with the existing failure UX. The anti-slop protection from #5525 is preserved.
- A failed artifact save is still `delivery_failed` — the report-only escape is checked only after `persistenceFailed`, so it can never mask a real save error.
- An empty answer with no writes is still `no_result`.

Write-attempt detection lives in `file-ops.ts` (`hasFileMutationToolUse`) and reuses the same tool-name sets the file-op cards already use, which are kept aligned with the daemon's cross-runtime `WRITE_OR_EDIT_TOOL_NAMES` (Claude-style, Codex-style, ACP/MCP shapes), plus the existing simple-Bash `rm`/`unlink` parser.

Known trade-off (called out in the docblock): an agent that merely *claims* completion without ever calling a write tool now finishes as a text result instead of a failure card. The text itself makes that visible to the user, and daemon-side `artifact_count` telemetry is unaffected, so the generation funnel still measures real deliveries.

`ProjectView.tsx` needed no changes: unknown outcomes already pass through `applyDesignDeliveryOutcome()` untouched, and `report_only` deliberately leaves `resultDeliveryState` unset (same as Chat/Plan turns), so no contract or daemon schema change is needed.

## What users will see

Asking the agent to read, inspect, critique, or analyze an existing design or image in Design mode now ends like a normal chat answer: the analysis text, a success chime, and no red "task failed" card. Previously the same run ended with "The design run finished without producing a deliverable project file. error_code: ARTIFACT_NOT_FOUND" even though the answer was right there.

Runs that were supposed to produce or edit files and didn't (the agent attempted writes but nothing landed in the project) still show the existing failure card with retry.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

(Default behavior change: successful zero-file Design turns without any file-write attempt no longer surface a failure card. No new UI element — the change removes an incorrect error state.)

## Screenshots

No new UI surface; the change removes an erroneous failure card on existing flows. Issue #5718's screenshot shows the before state.

## Bug fix verification

- Test paths that reproduce the bugs:
  - `apps/web/tests/runtime/design-delivery.test.ts` → "treats a text answer without any file-write attempt as a report-only result"
  - `apps/web/tests/components/ProjectView.api-empty-response.test.tsx` → "keeps a text-only successful Design run as a report-only success"
  - `apps/web/tests/components/ProjectView.run-isolation.test.tsx` → "keeps a reloaded report-only Design run without file writes on the success path" (reattach/reload path)
- Red on `main`, green on this branch: **yes** (the design-delivery spec was run against the unfixed tree first: expected `report_only`, received `no_result`).
- The previous zero-file-failure locks were not deleted but re-anchored on a genuine write attempt: "requires file delivery once the turn attempted to write project files", "records no_result when a Design run attempted file writes that never landed", and "downgrades a reloaded terminal Design run whose file writes never landed" keep the #5525 anti-slop path pinned.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web test` (full suite)
