### PR TITLE
test(daemon): stop run-retry-runtime stall cases racing node cold-start

### DIFF
--- a/apps/daemon/tests/run-retry-runtime.test.ts
+++ b/apps/daemon/tests/run-retry-runtime.test.ts
@@ -37,6 +37,17 @@ type RunEvent = {
 
 const FAKE_VELA = fileURLToPath(new URL('./fixtures/fake-vela.mjs', import.meta.url));
 
+// The two silent-stall cases below make the inactivity watchdog do two jobs with
+// one budget: trip on the first (silent) attempt so the same-run retry fires,
+// and NOT trip on that retry before its fresh child clears node cold-start and
+// emits its first token. The old 400ms sat too close to cold-start on a loaded
+// host, so the retry occasionally tripped its own watchdog and the spec flaked
+// (#5721; same watchdog path as #5292). The first attempt stalls for ~60s, so
+// any value trips it deterministically — sizing the budget well above any
+// realistic subprocess cold-start removes the race. 40 consecutive runs of both
+// stall cases were clean at 3000ms; 400ms flaked ~1/8.
+const STALL_WATCHDOG_TIMEOUT_MS = '3000';
+
 describe('same-run retry runtime', () => {
   const originalEnv = snapshotEnv();
   let started: StartedServer | null = null;
@@ -190,11 +201,10 @@ describe('same-run retry runtime', () => {
     delete process.env.LANGFUSE_SECRET_KEY;
     delete process.env.LANGFUSE_BASE_URL;
     delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
-    // Trip the no-output inactivity watchdog quickly so the first (silent)
-    // attempt stalls at first_token_wait and the same-run retry can fire. Kept
-    // comfortably above node cold-start so the recovered retry attempt's own
-    // watchdog does not also trip before it emits its first token.
-    process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS = '400';
+    // Trip the no-output watchdog on the silent first attempt so the same-run
+    // retry fires; sized above cold-start so the retry doesn't trip it too
+    // (see STALL_WATCHDOG_TIMEOUT_MS).
+    process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS = STALL_WATCHDOG_TIMEOUT_MS;
 
     started = await startServer({ port: 0, returnServer: true }) as StartedServer;
     await putConfig(started.url, {
@@ -261,10 +271,15 @@ describe('same-run retry runtime', () => {
     delete process.env.LANGFUSE_SECRET_KEY;
     delete process.env.LANGFUSE_BASE_URL;
     delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
-    // Watchdog trips the first (silent) attempt fast; the escalation grace is
-    // shortened so the stale SIGTERM/SIGKILL land while the retry child is
-    // mid-work (retry backoff is <=500ms, so 800ms grace guarantees overlap).
-    process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS = '400';
+    // Watchdog trips the first (silent) attempt; the escalation grace is short
+    // so the stale SIGTERM/SIGKILL land while the retry child is mid-work. Both
+    // the escalation window (trip + grace) and the retry lifetime (trip +
+    // backoff) are anchored to the trip, so the overlap that makes this a valid
+    // regression is independent of the timeout value; the timeout only has to
+    // clear the retry's cold-start (see STALL_WATCHDOG_TIMEOUT_MS). Retry backoff
+    // is <=500ms and the retry keeps emitting for ~2.1s, so the 800ms grace
+    // still lands mid-work.
+    process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS = STALL_WATCHDOG_TIMEOUT_MS;
     process.env.OD_CHAT_RUN_INACTIVITY_KILL_GRACE_MS = '800';
 
     started = await startServer({ port: 0, returnServer: true }) as StartedServer;


### PR DESCRIPTION
Fixes #5721

## Why

**Use case:** while landing #5584 I hit `tests/run-retry-runtime.test.ts` failing intermittently in QA, traced it, and filed #5721 — this is that fix.

**The pain:** the two silent-stall cases (`retries a silent first-token stall caught by the inactivity watchdog` and `does not let a stalled attempt’s forced-shutdown timers kill the healthy retry`) pin `OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS = '400'`. That single budget has to do two conflicting jobs: trip the no-output watchdog on the first (silent) attempt so the same-run retry fires, and **not** trip it on the retry before that fresh child clears node cold-start and emits its first token. On a loaded host the retry's cold-start exceeds 400ms, so it trips its own watchdog and the run fails — a wall-clock race, not a product bug. It reds unrelated PRs' QA (it blocked #5584, which touches no retry code). Same watchdog path as #5292.

## What users will see

Nothing user-facing — test-only reliability fix.

## Surface area

- [x] **None** — a test-harness timing change; no product/src change.

## Fix

The first attempt stalls for ~60s, so **any** timeout trips it deterministically; the value only needs to sit above any realistic subprocess cold-start. Raised to `3000ms` via a shared, documented `STALL_WATCHDOG_TIMEOUT_MS` constant. For the forced-shutdown case, the escalation window (trip + grace) and the retry lifetime (trip + backoff) are both anchored to the trip time, so the overlap that makes it a valid regression is independent of the timeout — only the retry's cold-start margin changes (verified the case still asserts `succeeded` + no signal).

## Bug fix verification

This is a flake-rate fix, so the evidence is the before/after rate on this host (Node 24):

| `OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS` | flake rate |
|---|---|
| 400ms (main) | ~1/8 |
| 1500ms | ~1/30 |
| **3000ms (this PR)** | **0 across 40 runs of both stall cases + 15 runs of the full 5-test suite** |

## Validation

- `pnpm guard` — 86/86
- `pnpm --filter @open-design/daemon typecheck` — clean
- `tests/run-retry-runtime.test.ts` — 5/5, 15 consecutive full-suite runs green; the two stall cases green 40/40.

## Note on the alternative

The fully deterministic fix is a production-side injectable clock for the inactivity watchdog, but that means threading a fake timer through the core run-lifecycle watchdog in `server.ts` — too much risk for a test-reliability change. Left that direction tracked in #5721 for a follow-up if wanted; @lefarcen flagged it as acceptable in the issue thread.