### PR TITLE
fix daemon BYOK OpenCode Not Found classification

### DIFF
--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -275,6 +275,27 @@ function isUpstreamClientErrorText(text: string): boolean {
     .test(text);
 }
 
+// OpenCode providers do not consistently preserve HTTP status metadata. Some
+// return only a bare "Not Found" (or an equivalent provider JSON body), which
+// previously fell through to the retryable stream_error close reason. Keep the
+// broad bare-text shapes scoped to BYOK OpenCode so an unrelated agent's local
+// resource/session miss is not reclassified as an upstream provider response.
+function isByokOpenCodeProviderNotFoundText(
+  agentId: string | null | undefined,
+  text: string,
+): boolean {
+  if (agentId !== 'byok-opencode') return false;
+
+  return /(?:^|\n)\s*(?:Not Found|Resource not found|The requested resource was not found)\s*(?=\n|$)/i
+    .test(text) ||
+    /\b(?:404(?:\s+(?:page|route))?\s+not found|resource_not_found_error|the requested resource was not found|Not Found:\s*Not support|NotFoundError)\b/i
+      .test(text) ||
+    /\bopencode (?:session error|event stream):[^\n]*\bNot Found\s*(?=$|\n)/im
+      .test(text) ||
+    /\"(?:detail|message)\"\s*:\s*\"Not Found\"/i.test(text) ||
+    /\bstatusCode[\"']?\s*:\s*404\b/i.test(text);
+}
+
 function modelUnavailableDetail(text: string): TrackingRunFailureDetail | null {
   if (/\brequires a newer version of codex\b|\bunknown option [`'"]?--[\w-]+[`'"]?\b/i.test(text)) {
     return 'cli_version_incompatible';
@@ -540,6 +561,10 @@ export function classifyRunFailure(
   const text = collectFailureText(input);
   const retryableHint = latestRetryable(input.events);
   const amrFailure = classifyAmrAccountFailure(text);
+  const byokOpenCodeProviderNotFound = isByokOpenCodeProviderNotFoundText(
+    input.agentId,
+    text,
+  );
 
   if (
     errorCode === 'AMR_INSUFFICIENT_BALANCE' ||
@@ -713,12 +738,15 @@ export function classifyRunFailure(
     errorCode === 'UPSTREAM_UNAVAILABLE' ||
     errorCode === 'AGENT_CONNECTION_DROPPED' ||
     serviceFailure === 'UPSTREAM_UNAVAILABLE' ||
-    isUpstreamDetailText(text)
+    isUpstreamDetailText(text) ||
+    byokOpenCodeProviderNotFound
   ) {
-    const retryable = retryableHint ?? !isUpstreamClientErrorText(text);
+    const retryable = byokOpenCodeProviderNotFound
+      ? false
+      : retryableHint ?? !isUpstreamClientErrorText(text);
     return classification(
       'upstream_unavailable',
-      upstreamDetail(text),
+      byokOpenCodeProviderNotFound ? 'upstream_client_error' : upstreamDetail(text),
       inferFailureStageFromEvents(input.events, 'first_token_wait'),
       retryable,
       retryable ? 'retry' : 'none',

--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -517,7 +517,12 @@ export function isResumableFailure(
   failure: RunFailureClassification | undefined,
 ): boolean {
   if (!failure) return false;
-  if (failure.failure_category === 'upstream_unavailable') return true;
+  if (
+    failure.failure_category === 'upstream_unavailable' &&
+    failure.failure_detail !== 'upstream_client_error'
+  ) {
+    return true;
+  }
   if (
     failure.failure_category === 'timeout' &&
     failure.failure_detail === 'inactivity_timeout'

--- a/apps/daemon/tests/run-failure-classification.test.ts
+++ b/apps/daemon/tests/run-failure-classification.test.ts
@@ -66,7 +66,8 @@ function errorEvent(
   };
 }
 
-function classify(
+function classifyForAgent(
+  agentId: string,
   code: string | null,
   message = '',
   events: RunEventForFailureClassification[] = code
@@ -83,9 +84,19 @@ function classify(
       signal: null,
     },
     ...(code ? { errorCode: code } : {}),
-    agentId: 'claude',
+    agentId,
     events,
   });
+}
+
+function classify(
+  code: string | null,
+  message = '',
+  events: RunEventForFailureClassification[] = code
+    ? [errorEvent(code, message)]
+    : [],
+) {
+  return classifyForAgent('claude', code, message, events);
 }
 
 describe('classifyRunFailure', () => {
@@ -1374,7 +1385,8 @@ describe('classifyRunFailure — batch A reclassification out of execution_faile
 
 describe('classifyRunFailure — BYOK OpenCode reclassification out of stream_error', () => {
   it('classifies missing BYOK OpenCode run config as fixable agent config', () => {
-    const result = classify(
+    const result = classifyForAgent(
+      'byok-opencode',
       'BYOK_PROVIDER_REQUIRED',
       'BYOK OpenCode requires a provider, API key, and model for this run.',
     );
@@ -1388,7 +1400,8 @@ describe('classifyRunFailure — BYOK OpenCode reclassification out of stream_er
   });
 
   it('classifies BYOK OpenCode 404 provider responses as non-retryable upstream client errors', () => {
-    const result = classify(
+    const result = classifyForAgent(
+      'byok-opencode',
       'AGENT_EXECUTION_FAILED',
       'json-rpc id 4: opencode event stream: opencode session error: Not Found: 404 page not found',
     );
@@ -1401,8 +1414,54 @@ describe('classifyRunFailure — BYOK OpenCode reclassification out of stream_er
     });
   });
 
-  it('classifies BYOK OpenCode provider request-shape rejections as non-retryable upstream client errors', () => {
+  it.each([
+    'Not Found',
+    'Resource not found',
+    'Not Found: {"error":{"message":"The requested resource was not found","type":"resource_not_found_error"}}',
+    'Not Found: {"error_msg":"404 Route Not Found"}',
+    'Not Found: Not support',
+    'Not Found: {"error":{"message":"Not found","type":"api_error"}}',
+    'Not Found: {"detail":"Not Found"}',
+  ])('classifies the production BYOK provider shape %j as a non-retryable client error', (message) => {
+    const result = classifyForAgent(
+      'byok-opencode',
+      'AGENT_EXECUTION_FAILED',
+      message,
+      [
+        errorEvent('AGENT_EXECUTION_FAILED', message, true),
+        runtimeCloseEvent('stream_error'),
+      ],
+    );
+
+    expect(result).toMatchObject({
+      failure_category: 'upstream_unavailable',
+      failure_detail: 'upstream_client_error',
+      failure_stage: 'first_token_wait',
+      retryable: false,
+      user_action: 'none',
+    });
+  });
+
+  it('does not globally reinterpret a bare Not Found from another agent as an upstream client error', () => {
     const result = classify(
+      'AGENT_EXECUTION_FAILED',
+      'Not Found',
+      [
+        errorEvent('AGENT_EXECUTION_FAILED', 'Not Found', true),
+        runtimeCloseEvent('stream_error'),
+      ],
+    );
+
+    expect(result).toMatchObject({
+      failure_category: 'process_exit',
+      failure_detail: 'stream_error',
+      retryable: true,
+    });
+  });
+
+  it('classifies BYOK OpenCode provider request-shape rejections as non-retryable upstream client errors', () => {
+    const result = classifyForAgent(
+      'byok-opencode',
       'AGENT_EXECUTION_FAILED',
       'json-rpc id 4: opencode event stream: data did not match any variant of untagged enum InputParam',
     );
@@ -1415,7 +1474,8 @@ describe('classifyRunFailure — BYOK OpenCode reclassification out of stream_er
   });
 
   it('classifies BYOK OpenCode Responses API request rejections as non-retryable upstream client errors', () => {
-    const result = classify(
+    const result = classifyForAgent(
+      'byok-opencode',
       'AGENT_EXECUTION_FAILED',
       'json-rpc id 4: opencode event stream: Invalid Responses API request',
     );
@@ -1428,7 +1488,8 @@ describe('classifyRunFailure — BYOK OpenCode reclassification out of stream_er
   });
 
   it('classifies BYOK OpenCode config directory permission errors as fixable agent config', () => {
-    const result = classify(
+    const result = classifyForAgent(
+      'byok-opencode',
       'AGENT_EXECUTION_FAILED',
       [
         "EACCES: permission denied, mkdir '/Users/11140200/.config/opencode'",

--- a/apps/daemon/tests/run-failure-classification.test.ts
+++ b/apps/daemon/tests/run-failure-classification.test.ts
@@ -45,6 +45,7 @@ vi.mock('../src/runtimes/auth.js', () => ({
 
 import {
   classifyRunFailure,
+  isResumableFailure,
   type RunEventForFailureClassification,
 } from '../src/run-failure-classification.js';
 
@@ -1412,6 +1413,35 @@ describe('classifyRunFailure — BYOK OpenCode reclassification out of stream_er
       retryable: false,
       user_action: 'none',
     });
+  });
+
+  it('does not treat a committed-work BYOK provider 404 as resumable', () => {
+    const message = 'Not Found';
+    const failure = classifyForAgent(
+      'byok-opencode',
+      'AGENT_EXECUTION_FAILED',
+      message,
+      [
+        {
+          event: 'agent',
+          data: {
+            type: 'tool_use',
+            id: 'toolu_byok_404',
+            name: 'Bash',
+            input: { command: 'echo committed' },
+          },
+        },
+        errorEvent('AGENT_EXECUTION_FAILED', message, false),
+        runtimeCloseEvent('stream_error'),
+      ],
+    );
+
+    expect(failure).toMatchObject({
+      failure_category: 'upstream_unavailable',
+      failure_detail: 'upstream_client_error',
+      retryable: false,
+    });
+    expect(isResumableFailure(failure)).toBe(false);
   });
 
   it.each([

--- a/apps/daemon/tests/run-resume-on-failure.test.ts
+++ b/apps/daemon/tests/run-resume-on-failure.test.ts
@@ -32,6 +32,8 @@ type RunStatus = {
   errorCode: string | null;
   eventsLogPath: string;
   resumable?: boolean;
+  failureCategory?: string | null;
+  failureDetail?: string | null;
   nativeSessionRecovery?: {
     agentId: string | null;
     state: string;
@@ -194,6 +196,47 @@ describe('resume-on-failure runtime', () => {
     expect(failed.status).toBe('failed');
     expect(failed.resumable).not.toBe(true);
   });
+
+  it('does not resume a provider 404 after a committed tool block', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-resume-client-error-bin-'));
+    const { bin: fakeOpenCode, argsLogPath } = await writeClientErrorOpenCode(
+      binDir,
+      'opencode-client-error',
+    );
+
+    delete process.env.POSTHOG_KEY;
+    delete process.env.POSTHOG_HOST;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_BASE_URL;
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+
+    started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'opencode',
+      agentCliEnv: { opencode: { OPENCODE_BIN: fakeOpenCode } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const conversationId = await createConversation(started.url);
+
+    const failed = await sendRunAndWait(started.url, conversationId, 'opencode');
+    expect(failed.status).toBe('failed');
+    expect(failed).toMatchObject({
+      failureCategory: 'upstream_unavailable',
+      failureDetail: 'upstream_client_error',
+    });
+    expect(failed.resumable).not.toBe(true);
+
+    const nextTurn = await sendRunAndWait(started.url, conversationId, 'opencode');
+    expect(nextTurn.status).toBe('succeeded');
+
+    const attempts = await readArgs(argsLogPath);
+    expect(attempts).toHaveLength(2);
+    expect(attempts[0]).not.toContain('-s');
+    expect(attempts[1]).not.toContain('-s');
+  });
 });
 
 function snapshotEnv(): Record<string, string | undefined> {
@@ -321,6 +364,63 @@ setTimeout(() => process.exit(1), 20);
   return { bin };
 }
 
+// Fake OpenCode CLI: the first invocation captures a session and commits a
+// tool block before a provider 404; the next invocation succeeds. Records argv
+// so the test can prove the invalid provider session was not persisted/resumed.
+async function writeClientErrorOpenCode(
+  dir: string,
+  name: string,
+): Promise<{ bin: string; argsLogPath: string }> {
+  const bin = path.join(dir, name);
+  const counterPath = path.join(dir, `${name}-attempts`);
+  const argsLogPath = path.join(dir, `${name}-args.jsonl`);
+  await writeFile(bin, `#!/usr/bin/env node
+const fs = require('node:fs');
+const counterPath = ${JSON.stringify(counterPath)};
+const argsLogPath = ${JSON.stringify(argsLogPath)};
+const sessionID = 'ses_provider_404_committed';
+if (process.argv.includes('--version')) { console.log('1.17.7'); process.exit(0); }
+if (process.argv.includes('--help')) { console.log('opencode run [message..]'); process.exit(0); }
+if (process.argv[2] === 'models') { console.log('test/provider-model'); process.exit(0); }
+let attempts = 0;
+try { attempts = Number(fs.readFileSync(counterPath, 'utf8')) || 0; } catch {}
+fs.writeFileSync(counterPath, String(attempts + 1));
+fs.appendFileSync(argsLogPath, JSON.stringify(process.argv.slice(2)) + '\\n');
+console.log(JSON.stringify({ type: 'step_start', sessionID, part: { type: 'step-start' } }));
+if (attempts === 0) {
+  console.log(JSON.stringify({
+    type: 'tool_use',
+    sessionID,
+    part: {
+      type: 'tool',
+      callID: 'tool_provider_404',
+      tool: 'Bash',
+      state: { status: 'completed', input: '{"command":"echo committed"}', output: 'committed' }
+    }
+  }));
+  console.log(JSON.stringify({
+    type: 'error',
+    sessionID,
+    error: {
+      name: 'APIError',
+      data: { message: 'Not Found: 404 page not found', statusCode: 404, isRetryable: false }
+    }
+  }));
+  setTimeout(() => process.exit(0), 20);
+} else {
+  console.log(JSON.stringify({ type: 'text', sessionID, part: { type: 'text', text: 'Started fresh.' } }));
+  console.log(JSON.stringify({
+    type: 'step_finish',
+    sessionID,
+    part: { type: 'step-finish', tokens: { input: 1, output: 1, reasoning: 0, cache: { read: 0, write: 0 } }, cost: 0 }
+  }));
+  setTimeout(() => process.exit(0), 20);
+}
+`, 'utf8');
+  await chmod(bin, 0o755);
+  return { bin, argsLogPath };
+}
+
 async function putConfig(url: string, patch: Record<string, unknown>): Promise<void> {
   const response = await fetch(`${url}/api/app-config`, {
     method: 'PUT',
@@ -351,7 +451,11 @@ async function createConversation(url: string): Promise<string> {
   return `${projectId}::${projectBody.conversationId}`;
 }
 
-async function sendRunAndWait(url: string, encoded: string): Promise<RunStatus> {
+async function sendRunAndWait(
+  url: string,
+  encoded: string,
+  agentId = 'claude',
+): Promise<RunStatus> {
   const [projectId, conversationId] = encoded.split('::');
   const assistantMessageId = `assistant_resume_${randomUUID()}`;
   const runResponse = await fetch(`${url}/api/runs`, {
@@ -367,7 +471,7 @@ async function sendRunAndWait(url: string, encoded: string): Promise<RunStatus> 
       conversationId,
       assistantMessageId,
       clientRequestId: `client_resume_${randomUUID()}`,
-      agentId: 'claude',
+      agentId,
       message: 'please do the task',
       currentPrompt: 'please do the task',
     }),


### PR DESCRIPTION
## Why

A production failure audit for 0.15.0 found BYOK OpenCode provider responses such as `Not Found`, `Resource not found`, `resource_not_found_error`, and `404 Route Not Found` still landing in the generic `stream_error` bucket.

Those runs inherited `retryable: true` from the OpenCode error event and could trigger a same-run retry even though a provider 404 is a client/config/model-routing error, not a transient disconnect. The root cause was that the generic upstream matcher intentionally required more specific 404 text, while some OpenCode providers discard the HTTP status and return only a bare Not Found body.

This PR keeps the broad bare-text match scoped to `byok-opencode`, so local resource or session misses from other agents are not reclassified.

## What users will see

BYOK OpenCode runs that receive a provider Not Found/404 response stop immediately instead of retrying as a stream interruption. Analytics report them as `upstream_client_error` under `upstream_unavailable`, making the remaining production failure buckets actionable.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — daemon-only failure classification and retry behavior.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/run-failure-classification.test.ts`
- Did the test go red on `main` and green on this branch? Yes. The seven production-shaped cases all failed as `process_exit / stream_error / retryable=true` before the source change, then passed after the scoped classifier was added.
- A negative control confirms another agent's bare `Not Found` remains a retryable `stream_error` instead of being globally reclassified.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm guard`
- `corepack pnpm typecheck`
- `corepack pnpm --filter @open-design/daemon build`
- `corepack pnpm exec vitest run -c vitest.config.ts tests/run-failure-classification.test.ts tests/run-retry-policy.test.ts` (98 tests passed)
- `git diff --check origin/main...HEAD`