### PR TITLE
fix(daemon): abort oversized or failed Composio logo fetches instead of leaking them

### DIFF
--- a/apps/daemon/src/connectors/routes.ts
+++ b/apps/daemon/src/connectors/routes.ts
@@ -130,9 +130,17 @@ function parsePositiveIntegerHeader(value: string | null): number | null {
   return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
 }
 
-async function readComposioLogoBody(response: globalThis.Response): Promise<Buffer | null> {
+async function readComposioLogoBody(
+  response: globalThis.Response,
+  controller: AbortController,
+): Promise<Buffer | null> {
   const contentLength = parsePositiveIntegerHeader(response.headers.get('content-length'));
-  if (contentLength !== null && contentLength > COMPOSIO_LOGO_MAX_BYTES) return null;
+  if (contentLength !== null && contentLength > COMPOSIO_LOGO_MAX_BYTES) {
+    // Abort so the unread response body is torn down instead of leaving the
+    // upstream connection occupied until GC.
+    controller.abort();
+    return null;
+  }
 
   const reader = response.body?.getReader();
   if (!reader) {
@@ -142,13 +150,26 @@ async function readComposioLogoBody(response: globalThis.Response): Promise<Buff
 
   const chunks: Uint8Array[] = [];
   let totalBytes = 0;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    if (!value) continue;
-    totalBytes += value.byteLength;
-    if (totalBytes > COMPOSIO_LOGO_MAX_BYTES) return null;
-    chunks.push(value);
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      totalBytes += value.byteLength;
+      if (totalBytes > COMPOSIO_LOGO_MAX_BYTES) {
+        controller.abort(); // stop pulling more bytes from the upstream logo host
+        return null;
+      }
+      chunks.push(value);
+    }
+  } finally {
+    // Release the upstream connection instead of leaving the body half-read
+    // until GC (matches readBodyCapped in plugin-asset-cache.ts).
+    try {
+      await reader.cancel();
+    } catch {
+      // reader already closed / errored — nothing to release
+    }
   }
   return Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)), totalBytes);
 }
@@ -198,8 +219,13 @@ async function fetchComposioLogo(slug: string, theme: 'light' | 'dark'): Promise
         headers: { accept: 'image/avif,image/webp,image/apng,image/png,image/jpeg' },
         signal: controller.signal,
       });
-      if (!response.ok) return null;
-      const body = await readComposioLogoBody(response);
+      if (!response.ok) {
+        // Discard the error-response body so a run of misses (e.g. 404s for
+        // unknown slugs) can't exhaust reusable upstream connections.
+        controller.abort();
+        return null;
+      }
+      const body = await readComposioLogoBody(response, controller);
       if (!body) return null;
       const contentType = normalizeImageContentType(response.headers.get('content-type'));
       if (!contentType) return null;

--- a/apps/daemon/tests/connectors-routes.test.ts
+++ b/apps/daemon/tests/connectors-routes.test.ts
@@ -1069,6 +1069,80 @@ describe('connector routes', () => {
     expect(upstreamRequests).toBe(2);
   });
 
+  it('cancels the upstream stream when a Composio logo exceeds the cap mid-stream', async () => {
+    let cancelled = false;
+    let signal: AbortSignal | undefined;
+    const slug = 'streaming_oversized_logo';
+    const chunk = new Uint8Array(600 * 1024); // 600 KiB chunks; the cap is 1 MiB
+    mockComposioFetch({
+      logoFetch: async (_parsed, init) => {
+        signal = init?.signal ?? undefined;
+        const stream = new ReadableStream<Uint8Array>({
+          pull(streamController) {
+            // Keep feeding chunks so the running total crosses the cap on the
+            // second read (no content-length, so this takes the streaming path).
+            streamController.enqueue(chunk);
+          },
+          cancel() {
+            cancelled = true;
+          },
+        });
+        return {
+          ok: true,
+          headers: new Headers({ 'content-type': 'image/png' }),
+          body: stream,
+        } as unknown as Response;
+      },
+    });
+
+    const response = await fetch(`${baseUrl}/api/connectors/logos/${slug}?theme=dark`);
+
+    expect(response.status).toBe(404);
+    // the half-read upstream body is both cancelled and aborted, not leaked
+    expect(cancelled).toBe(true);
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it('aborts an oversized-Content-Length Composio logo before reading its body', async () => {
+    let signal: AbortSignal | undefined;
+    mockComposioFetch({
+      logoFetch: async (_parsed, init) => {
+        signal = init?.signal ?? undefined;
+        return {
+          ok: true,
+          headers: new Headers({ 'content-type': 'image/png', 'content-length': '1048577' }),
+          body: new ReadableStream<Uint8Array>(),
+        } as unknown as Response;
+      },
+    });
+
+    const response = await fetch(`${baseUrl}/api/connectors/logos/cl_oversized?theme=dark`);
+
+    expect(response.status).toBe(404);
+    // the content-length check rejects it and aborts the connection, not leaks it
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it('aborts a non-2xx Composio logo response body', async () => {
+    let signal: AbortSignal | undefined;
+    mockComposioFetch({
+      logoFetch: async (_parsed, init) => {
+        signal = init?.signal ?? undefined;
+        return {
+          ok: false,
+          status: 502,
+          headers: new Headers({ 'content-type': 'text/plain' }),
+          body: new ReadableStream<Uint8Array>(),
+        } as unknown as Response;
+      },
+    });
+
+    const response = await fetch(`${baseUrl}/api/connectors/logos/missing_slug?theme=dark`);
+
+    expect(response.status).toBe(404);
+    expect(signal?.aborted).toBe(true);
+  });
+
   it('evicts the least recently used Composio logo cache entry when the cache is full', async () => {
     let upstreamRequests = 0;
     mockComposioFetch({


### PR DESCRIPTION
## Why

Scratching an itch found while auditing the daemon's outbound fetches. When the daemon proxies a connector logo from `logos.composio.dev`, three early-return paths in `fetchComposioLogo` / `readComposioLogoBody` returned without consuming or cancelling the response body, leaving the undici connection occupied until GC. A run of oversized or failing logo requests (e.g. repeated 404s for unknown slugs) could exhaust reusable upstream connections.

## What users will see

No visible change. Connector logos load exactly as before; the fix only ensures the daemon releases the upstream connection on the error/oversize paths instead of leaking it.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/connectors-routes.test.ts` → the three cases "cancels the upstream stream when a Composio logo exceeds the cap mid-stream", "aborts an oversized-Content-Length Composio logo before reading its body", and "aborts a non-2xx Composio logo response body".
- Did the tests go red on `main` and green on this branch? **yes** — on `main` the aborted-signal / stream-cancel assertions fail (the body is left un-consumed); on this branch all three pass. Full `connectors-routes.test.ts` is 45/45.

## Validation

- `pnpm --filter @open-design/daemon test` for `tests/connectors-routes.test.ts` (45/45 green). Full `pnpm guard` / `pnpm typecheck` left to CI.

---

`readComposioLogoBody` now aborts the fetch on the `Content-Length` over-cap pre-check and cancels the reader in a `finally` on the streaming over-cap path; `fetchComposioLogo` aborts on the non-2xx path. This mirrors the existing `readBodyCapped` helper in `plugins/plugin-asset-cache.ts`. The `!reader` / `arrayBuffer()` and success paths fully consume the body and need no abort.
