### PR TITLE
fix(landing): show 0.14.0/0.15.0 release covers on the blog index

### DIFF
--- a/apps/landing-page/app/pages/blog/index.astro
+++ b/apps/landing-page/app/pages/blog/index.astro
@@ -119,6 +119,14 @@ const postImages: Record<string, { src: string; alt: string }> = {
     src: '/blog/ppt-master-cover.webp',
     alt: 'A clean illustration of a document turning into an editable slide made of native shape blocks, the slide held in a green selection frame with corner handles, on a near-white dot-grid ground',
   },
+  'open-design-0-14-0-inspiration-time-machine': {
+    src: '/blog/open-design-0-14-0-inspiration-time-machine-cover.webp',
+    alt: 'A warm editorial illustration of a hand-drawn idea sketch with a lightbulb becoming a calm sage-green planning workspace with a structured outline and a version-history timeline, beside soft plants and a coffee mug',
+  },
+  'open-design-0-15-0-cost-less-ship-faster': {
+    src: '/blog/open-design-0-15-0-cost-less-ship-faster-cover.webp',
+    alt: 'A warm editorial illustration of a hand-drawn deck sketch becoming a calm sage-green slide workspace shipping fast beside a timer, on a near-white paper desk with soft plants and a coffee mug',
+  },
   'how-to-use-claude-code-for-frontend-design': {
     src: '/blog/how-to-use-claude-code-for-frontend-design-cover.webp',
     alt: 'A warm editorial illustration of a terminal prompt becoming a polished UI screen on a tablet, with a design-system file card (DESIGN.md) held in a green selection frame connecting the two, beside soft plants and a coffee mug',


### PR DESCRIPTION
## Why

Follow-up to the 0.14.0/0.15.0 release posts. The blog index resolves each card's cover from the hardcoded `postImages` map, not from the `/blog/<id>-cover.webp` convention the detail page uses. The two release posts shipped their warm editorial covers but were never added to that map, so on the index their cards fell back to the generated line-art placeholder — visibly inconsistent with the rest of the warm cover cluster.

## What users will see

On `/blog/`, the 0.14.0 ("inspiration time machine") and 0.15.0 ("cost less, ship faster") cards now show their warm editorial cover art instead of the line-art placeholder.

## Surface area

- [x] **None** — landing-page blog index image map only.

## Screenshots

Cloudflare Pages preview builds automatically (`pr-<N>.open-design-landing-staging.pages.dev/blog/`) — the 0.15.0 card shows the warm "faster & leaner" cover.

## Validation

- `pnpm --filter @open-design/landing-page typecheck` → 0 errors.
- Ran the dev server: `/blog/` renders both release cards with `has-image` and their warm cover webp (verified in the rendered HTML and a headless screenshot).