### PR TITLE
fix: trust daemon artifact count for design delivery

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3793,6 +3793,7 @@ export function ProjectView({
               events: message.events,
               producedFileCount: produced.length,
               traceObjectFileCount: traceObjectFiles.length,
+              artifactCount: status.artifactCount,
               persistenceSucceeded: artifactPersistenceSucceeded,
               persistenceFailed: artifactPersistenceError !== undefined,
             });
@@ -3884,6 +3885,7 @@ export function ProjectView({
         let liveHtml = '';
         let replayedContent = needsFullReplay ? '' : message.content;
         let replayedEvents: AgentEvent[] = needsFullReplay ? [] : [...(message.events ?? [])];
+        let daemonArtifactCount = status.artifactCount;
         let latestReattachRunStatus: ChatMessage['runStatus'] = status.status;
         const applyContentDelta = (delta: string) => {
           for (const ev of parser.feed(delta)) {
@@ -3979,6 +3981,9 @@ export function ProjectView({
               genericDisconnectBackoffUntilRef.current.delete(runId);
               replayedEvents = [...replayedEvents, ev];
               textBuffer.appendEvent(ev);
+            },
+            onArtifactCount: (count) => {
+              daemonArtifactCount = count;
             },
             onDone: async () => {
               // A reattached run interrupted by a "send now" still receives a
@@ -4119,6 +4124,7 @@ export function ProjectView({
                   events: deliveryEvents,
                   producedFileCount: produced.length,
                   traceObjectFileCount: traceObjectFiles.length,
+                  artifactCount: daemonArtifactCount,
                   persistenceSucceeded: artifactPersistenceSucceeded,
                   persistenceFailed: artifactPersistenceError !== undefined,
                 });
@@ -5019,6 +5025,7 @@ export function ProjectView({
       // that just failed in the current session (the daemon status fetch is only
       // needed on reload, not for runs that are already known to have failed).
       let currentRunId: string | undefined = undefined;
+      let daemonArtifactCount: number | undefined;
       const updateConversationLatestRun = (
         status: NonNullable<ChatMessage['runStatus']>,
         endedAt?: number,
@@ -5356,6 +5363,9 @@ export function ProjectView({
           if (ev.kind === 'text') textBuffer.appendTextEvent(ev.text);
           else pushEvent(ev);
         },
+        onArtifactCount: (count: number) => {
+          daemonArtifactCount = count;
+        },
         onToolInputDelta: (id: string, name: string, delta: string) => {
           setLiveToolInput((prev) => ({
             ...prev,
@@ -5564,6 +5574,7 @@ export function ProjectView({
                 events: deliveryCandidate.events,
                 producedFileCount: produced.length,
                 traceObjectFileCount: traceObjectFiles.length,
+                artifactCount: daemonArtifactCount,
                 persistenceSucceeded: artifactPersistenceSucceeded,
                 persistenceFailed: artifactPersistenceError !== undefined,
               });

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -260,6 +260,8 @@ export function buildDaemonTranscript(history: ChatMessage[], targetAgentId?: st
 
 export interface DaemonStreamHandlers extends StreamHandlers {
   onAgentEvent: (ev: AgentEvent) => void;
+  /** Authoritative artifact count from the daemon's terminal run record. */
+  onArtifactCount?: (count: number) => void;
   /**
    * Live-only incremental tool-input fragment (Claude `input_json_delta`).
    * Kept off `AgentEvent`/`PersistedAgentEvent` because it is ephemeral and
@@ -1063,6 +1065,7 @@ async function consumeDaemonRun({
   const reportArtifactCount = (value: unknown) => {
     if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return;
     resolvedArtifactCount = value;
+    handlers.onArtifactCount?.(value);
   };
   let lastEventId: string | null = initialLastEventId ?? null;
   let canceled = false;

--- a/apps/web/src/runtime/design-delivery.ts
+++ b/apps/web/src/runtime/design-delivery.ts
@@ -18,6 +18,8 @@ export interface DesignDeliveryInput {
   events: AgentEvent[] | undefined;
   producedFileCount: number;
   traceObjectFileCount: number;
+  /** Authoritative artifact count reported by the daemon at run finalization. */
+  artifactCount?: number;
   persistenceSucceeded?: boolean;
   persistenceFailed?: boolean;
 }
@@ -83,6 +85,7 @@ export function resolveDesignDeliveryOutcome(
   if (
     input.producedFileCount > 0 ||
     input.traceObjectFileCount > 0 ||
+    (input.artifactCount ?? 0) > 0 ||
     input.persistenceSucceeded ||
     hasLiveArtifactDelivery(input.events)
   ) {

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -989,6 +989,62 @@ describe('ProjectView conversation run isolation', () => {
     expect(reattachDaemonRun).not.toHaveBeenCalled();
   });
 
+  it('trusts the daemon artifact count when browser file reconciliation misses delivered output', async () => {
+    conversationAMessages = [
+      {
+        ...succeededAssistant,
+        content: '',
+        sessionMode: 'design',
+        events: [
+          { kind: 'text', text: 'I finished the design.' },
+          {
+            kind: 'tool_use',
+            id: 'write-1',
+            name: 'Write',
+            input: { file_path: 'index.html', content: '<!doctype html>' },
+          },
+        ],
+        preTurnFileNames: [],
+        producedFiles: undefined,
+        traceObjectFiles: undefined,
+      },
+    ];
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-a',
+      status: 'succeeded',
+      createdAt: 1,
+      updatedAt: 2,
+      exitCode: 0,
+      signal: null,
+      artifactCount: 1,
+    });
+
+    renderProjectView();
+
+    await waitFor(() => {
+      const recoveredMessage = saveMessage.mock.calls
+        .map((call) => call[2] as ChatMessage)
+        .find(
+          (message) =>
+            message.id === succeededAssistant.id
+            && message.resultDeliveryState === 'delivered',
+        );
+      expect(recoveredMessage).toMatchObject({
+        runStatus: 'succeeded',
+        resultDeliveryState: 'delivered',
+        producedFiles: [],
+        traceObjectFiles: [],
+      });
+      expect(recoveredMessage?.events).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ code: 'ARTIFACT_NOT_FOUND' }),
+        ]),
+      );
+    });
+    expect(screen.getByTestId('chat-error').textContent).toBe('');
+    expect(reattachDaemonRun).not.toHaveBeenCalled();
+  });
+
   it('keeps a reloaded report-only Design run without file writes on the success path', async () => {
     // Prose-only turns (image analysis, audits) are legitimate zero-file
     // Design results (#5714, #5718); reload must not downgrade them.

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -99,6 +99,7 @@ describe('streamViaDaemon', () => {
       conversationId: 'conversation-1',
     });
 
+    expect(handlers.onArtifactCount).toHaveBeenCalledWith(2);
     expect(published).toEqual([{
       runId: 'run-artifact-success',
       projectId: 'project-1',
@@ -2214,6 +2215,7 @@ function createDaemonHandlers() {
   return {
     ...createStreamHandlers(),
     onAgentEvent: vi.fn(),
+    onArtifactCount: vi.fn(),
   };
 }
 

--- a/apps/web/tests/runtime/design-delivery.test.ts
+++ b/apps/web/tests/runtime/design-delivery.test.ts
@@ -96,6 +96,17 @@ describe('resolveDesignDeliveryOutcome', () => {
         events: [],
         producedFileCount: 0,
         traceObjectFileCount: 0,
+        artifactCount: 1,
+      }),
+    ).toBe('delivered');
+    expect(
+      resolveDesignDeliveryOutcome({
+        sessionMode: 'design',
+        runStatus: 'succeeded',
+        content: '',
+        events: [],
+        producedFileCount: 0,
+        traceObjectFileCount: 0,
         persistenceSucceeded: true,
       }),
     ).toBe('delivered');


### PR DESCRIPTION
## Why

A Design-mode run can successfully create or modify a deliverable while browser-side file reconciliation still produces empty `producedFiles` and `traceObjectFiles`. The daemon already reports an authoritative positive `artifactCount`, but that signal was previously used only for telemetry and discarded before delivery classification. The UI could therefore surface a false `ARTIFACT_NOT_FOUND` error.

This was reproduced in Open Design 0.15.0 from a real run that finalized successfully with `artifactCount: 1`, while the persisted assistant message contained empty produced-file and trace-object lists. This is complementary to #5685, which addresses internal project-path normalization.

## What users will see

Successful Design runs no longer show “finished without producing a deliverable project file” solely because browser-side reconciliation missed a file that daemon finalization confirmed.

Genuine zero-output runs still show the delivery error. Report-only, awaiting-input, canceled, failed-persistence, and failed-run behavior is unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — successful Design delivery now trusts a positive daemon-finalized artifact count
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No UI layout or styling changed. The visual-regression job reported 0 changed and 0 failed cases; its new cases lack an upstream baseline and are advisory.

## Bug fix verification

- Regression paths:
  - `apps/web/tests/runtime/design-delivery.test.ts`
  - `apps/web/tests/providers/sse.test.ts`
  - `apps/web/tests/components/ProjectView.run-isolation.test.tsx`
- The production failure was reproduced from the reported run diagnostics: daemon success with `artifactCount: 1`, but empty browser delivery lists and a false `ARTIFACT_NOT_FOUND` state.
- A separate pristine-main red-test checkout was not run. The added assertions exercise behavior absent from `main`: propagate the daemon count and classify positive counts as delivered.
- All added and adjacent focused tests are green on this branch.
- Manual QA is requested before merge. This PR will not be self-merged.

## Validation

- 84 runtime and daemon-stream tests passed.
- 47 ProjectView run-isolation tests passed.
- `pnpm --filter @open-design/web typecheck` passed under Node 24.
- `git diff --check` passed.