### PR TITLE
fix(web): auto-fit wide html previews

### DIFF
--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -862,6 +862,39 @@ function injectUrlPreviewBridge(html: string, bridge: 'scroll' | 'selection' | '
   return injectBeforeBodyClose(html, 'data-od-url-snapshot-bridge', URL_PREVIEW_SNAPSHOT_BRIDGE);
 }
 
+function applyUrlPreviewBridgesToHtml(
+  transformed: string | Buffer,
+  mime: string,
+  requestedBridge: unknown,
+): string | Buffer {
+  if (
+    !(
+      wantsUrlPreviewScrollBridge(requestedBridge) ||
+      wantsUrlPreviewSelectionBridge(requestedBridge) ||
+      wantsUrlPreviewSnapshotBridge(requestedBridge)
+    ) ||
+    !/^text\/html(?:;|$)/i.test(mime)
+  ) {
+    return transformed;
+  }
+
+  let html = Buffer.isBuffer(transformed) ? transformed.toString('utf8') : transformed;
+  // Sanitize the <title> so Cmd+P -> "Save as PDF" produces a Teams-safe
+  // filename. URL-load iframes cannot rely on the host rewriting the document
+  // title after load, and powered previews are intentionally cross-origin.
+  html = daemonSanitizeTitleInDoc(html);
+  if (wantsUrlPreviewScrollBridge(requestedBridge)) {
+    html = injectUrlPreviewBridge(html, 'scroll');
+  }
+  if (wantsUrlPreviewSelectionBridge(requestedBridge)) {
+    html = injectUrlPreviewBridge(html, 'selection');
+  }
+  if (wantsUrlPreviewSnapshotBridge(requestedBridge)) {
+    html = injectUrlPreviewBridge(html, 'snapshot');
+  }
+  return html;
+}
+
 // ---------------------------------------------------------------------------
 // Teams-safe title sanitization for the URL-load preview path (issue #3918).
 //
@@ -3275,7 +3308,7 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
         project?.metadata,
         undefined,
         skipHtmlPreviewBridge ? undefined : async (file) => {
-          let transformed = await maybeResolveVitePreviewHtml({
+          const transformed = await maybeResolveVitePreviewHtml({
             file,
             projectId,
             relPath,
@@ -3283,31 +3316,7 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
             projectsRoot: PROJECTS_DIR,
             readProjectFile,
           });
-          if (
-            (wantsUrlPreviewScrollBridge(req.query.odPreviewBridge) ||
-              wantsUrlPreviewSelectionBridge(req.query.odPreviewBridge) ||
-              wantsUrlPreviewSnapshotBridge(req.query.odPreviewBridge)) &&
-            /^text\/html(?:;|$)/i.test(file.mime)
-          ) {
-            let html = Buffer.isBuffer(transformed) ? transformed.toString('utf8') : transformed;
-            // Sanitize the <title> so Cmd+P → "Save as PDF" produces a
-            // Teams-safe filename. The URL-load iframe uses sandbox without
-            // allow-same-origin, so the host cannot rewrite contentDocument.title
-            // after load — we must do it here in the response. The srcDoc path
-            // has its own sanitization in buildSrcdoc (apps/web/src/runtime/srcdoc.ts).
-            html = daemonSanitizeTitleInDoc(html);
-            if (wantsUrlPreviewScrollBridge(req.query.odPreviewBridge)) {
-              html = injectUrlPreviewBridge(html, 'scroll');
-            }
-            if (wantsUrlPreviewSelectionBridge(req.query.odPreviewBridge)) {
-              html = injectUrlPreviewBridge(html, 'selection');
-            }
-            if (wantsUrlPreviewSnapshotBridge(req.query.odPreviewBridge)) {
-              html = injectUrlPreviewBridge(html, 'snapshot');
-            }
-            transformed = html;
-          }
-          return transformed;
+          return applyUrlPreviewBridgesToHtml(transformed, file.mime, req.query.odPreviewBridge);
         },
         true, // revalidate: emit ETag/Last-Modified so covers/preview/export reuse cached assets
       );
@@ -3357,15 +3366,17 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
         relPath,
         project?.metadata,
         () => setPoweredPreviewHeaders(res),
-        skipPoweredTransform ? undefined : async (file) =>
-          maybeResolveVitePreviewHtml({
+        skipPoweredTransform ? undefined : async (file) => {
+          const transformed = await maybeResolveVitePreviewHtml({
             file,
             projectId,
-              relPath,
-              metadata: project?.metadata,
-              projectsRoot: PROJECTS_DIR,
-              readProjectFile,
-            }),
+            relPath,
+            metadata: project?.metadata,
+            projectsRoot: PROJECTS_DIR,
+            readProjectFile,
+          });
+          return applyUrlPreviewBridgesToHtml(transformed, file.mime, req.query.odPreviewBridge);
+        },
       );
     } catch (err: any) {
       const status = err && err.code === 'ENOENT' ? 404 : 400;

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -111,12 +111,43 @@ const URL_PREVIEW_SCROLL_BRIDGE = `<script data-od-url-scroll-bridge>
   if (window.__odUrlScrollBridge) return;
   window.__odUrlScrollBridge = true;
   var pending = false;
+  var contentSizePending = false;
   function scrollElement(){
     return document.querySelector('.design-canvas') || document.scrollingElement || document.documentElement;
   }
   function num(value){
     var next = Number(value || 0);
     return Number.isFinite(next) ? next : 0;
+  }
+  function measureContentWidth(){
+    var root = document.documentElement;
+    var body = document.body || root;
+    if (!root) return null;
+    var values = [
+      root.scrollWidth,
+      body && body.scrollWidth,
+      root.offsetWidth,
+      body && body.offsetWidth,
+      root.clientWidth,
+      body && body.clientWidth
+    ];
+    var width = 0;
+    for (var i = 0; i < values.length; i += 1) {
+      var next = num(values[i]);
+      if (next > width) width = next;
+    }
+    return width > 0 ? Math.ceil(width) : null;
+  }
+  function postContentSize(){
+    window.parent.postMessage({ type: 'od:preview-content-size', width: measureContentWidth() }, '*');
+  }
+  function scheduleContentSize(){
+    if (contentSizePending) return;
+    contentSizePending = true;
+    window.requestAnimationFrame(function(){
+      contentSizePending = false;
+      postContentSize();
+    });
   }
   function post(){
     var el = scrollElement();
@@ -172,21 +203,43 @@ const URL_PREVIEW_SCROLL_BRIDGE = `<script data-od-url-scroll-bridge>
     if (data.type === 'od:preview-scroll-by') {
       scrollBy(scrollElement(), data.left, data.top);
       schedule();
+      scheduleContentSize();
+      return;
+    }
+    if (data.type === 'od:preview-content-size-request') {
+      scheduleContentSize();
     }
   });
   window.addEventListener('scroll', schedule, true);
   document.addEventListener('scroll', schedule, true);
-  window.addEventListener('resize', schedule);
+  window.addEventListener('resize', function(){
+    schedule();
+    scheduleContentSize();
+  });
+  if (typeof ResizeObserver !== 'undefined') {
+    try {
+      var observer = new ResizeObserver(scheduleContentSize);
+      observer.observe(document.documentElement);
+      if (document.body) observer.observe(document.body);
+    } catch (_) {}
+  }
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', function(){
       requestRestore();
       schedule();
+      scheduleContentSize();
     });
   } else {
     setTimeout(function(){
       requestRestore();
       schedule();
+      scheduleContentSize();
     }, 0);
+  }
+  setTimeout(scheduleContentSize, 80);
+  setTimeout(scheduleContentSize, 260);
+  if (document.fonts && document.fonts.ready) {
+    document.fonts.ready.then(scheduleContentSize).catch(function(){});
   }
 })();
 </script>`;

--- a/apps/daemon/tests/project-file-range.test.ts
+++ b/apps/daemon/tests/project-file-range.test.ts
@@ -429,6 +429,16 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     expect(preflight.headers.get('access-control-allow-origin')).toBeNull();
   });
 
+  it('injects the URL preview scroll bridge for powered previews when requested', async () => {
+    const bridged = await fetch(`${poweredUrl('page.html')}?odPreviewBridge=scroll`);
+    expect(bridged.status).toBe(200);
+    expect(bridged.headers.get('document-isolation-policy')).toBe('isolate-and-credentialless');
+    const html = await bridged.text();
+    expect(html).toContain('data-od-url-scroll-bridge');
+    expect(html).toContain("type: 'od:preview-content-size'");
+    expect(html).toContain('od:preview-content-size-request');
+  });
+
   it('does not let the powered preview origin call normal daemon APIs', async () => {
     const origin = poweredOrigin();
     const poweredReferer = `${origin}/api/projects/${projectId}/powered/page.html`;

--- a/apps/daemon/tests/project-file-range.test.ts
+++ b/apps/daemon/tests/project-file-range.test.ts
@@ -349,6 +349,8 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     const html = await bridged.text();
     expect(html).toContain('data-od-url-scroll-bridge');
     expect(html).toContain("type: 'od:preview-scroll'");
+    expect(html).toContain("type: 'od:preview-content-size'");
+    expect(html).toContain('od:preview-content-size-request');
   });
 
   it('injects the URL preview scroll bridge before the closing body tag', async () => {

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -329,6 +329,8 @@ const PREVIEW_VIEWPORT_PRESETS: PreviewViewportPreset[] = [
   },
 ];
 
+const DESKTOP_PREVIEW_AUTO_FIT_WIDTH = 1440;
+
 function previewViewportIcon(viewport: PreviewViewportId): string {
   if (viewport === 'tablet') return 'tablet-line';
   if (viewport === 'mobile') return 'smartphone-line';
@@ -922,6 +924,18 @@ export function effectivePreviewScale(
   const availableHeight = Math.max(1, canvasSize.height - canvasPadding);
   const fitScale = Math.min(1, availableWidth / preset.width, availableHeight / preset.height);
   return Math.min(previewScale, fitScale);
+}
+
+export function desktopPreviewAutoFitZoomPercent(
+  canvasSize: PreviewCanvasSize | undefined,
+  designWidth = DESKTOP_PREVIEW_AUTO_FIT_WIDTH,
+): number {
+  if (!canvasSize?.width || !Number.isFinite(canvasSize.width) || designWidth <= 0) return 100;
+  return Math.max(1, Math.min(100, (canvasSize.width / designWidth) * 100));
+}
+
+function zoomPercentLabel(zoomPercent: number): string {
+  return `${Math.round(zoomPercent)}%`;
 }
 
 type PreviewOverlayTransform = { scale: number; offsetX: number; offsetY: number };
@@ -6150,6 +6164,7 @@ function HtmlViewer({
   const [serverPoweredPreviewRequired, setServerPoweredPreviewRequired] = useState(false);
   const [inlinedSource, setInlinedSource] = useState<string | null>(null);
   const [zoom, setZoom] = useState(100);
+  const [zoomMode, setZoomMode] = useState<'auto' | 'manual'>('auto');
   const fileViewportKey = previewViewportStateKey(projectId, file);
   const [previewViewport, setPreviewViewportState] = useState<PreviewViewportId>(
     () => htmlPreviewViewportState.get(fileViewportKey) ?? 'desktop',
@@ -6179,6 +6194,8 @@ function HtmlViewer({
 
   useEffect(() => {
     setPreviewViewportState(htmlPreviewViewportState.get(fileViewportKey) ?? 'desktop');
+    setZoom(100);
+    setZoomMode('auto');
   }, [fileViewportKey]);
   const [templateDescription, setTemplateDescription] = useState('');
   const [templateSaveError, setTemplateSaveError] = useState<string | null>(null);
@@ -6612,7 +6629,6 @@ function HtmlViewer({
   const [commentSidePanelCollapsed, setCommentSidePanelCollapsed] = useState(false);
   const [strokePoints, setStrokePoints] = useState<StrokePoint[]>([]);
   const previewStateKey = `${projectId}:${file.name}`;
-  const previewScale = zoom / 100;
   const localCommentSideDockActive = commentPanelOpen && !commentPortalHost;
   const boardPreviewCanvasSize = commentPreviewCanvasSize(previewBodySize, {
     boardMode: localCommentSideDockActive,
@@ -6761,6 +6777,12 @@ function HtmlViewer({
   const [speakerNotesStatus, setSpeakerNotesStatus] = useState<'saved' | 'error' | null>(null);
   const speakerNotesTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const boardPreviewScaleOptions = localCommentSideDockActive ? { canvasPadding: 0 } : undefined;
+  const previewZoomPercent = zoomMode === 'auto' && previewViewport === 'desktop'
+    ? desktopPreviewAutoFitZoomPercent(boardPreviewCanvasSize)
+    : zoom;
+  const previewScale = previewZoomPercent / 100;
+  const previewZoomText = zoomPercentLabel(previewZoomPercent);
+  const zoomLevelActive = (level: number) => Math.abs(previewZoomPercent - level) < 0.001;
   const overlayPreviewScale = effectivePreviewScale(
     previewViewport,
     previewScale,
@@ -11403,7 +11425,7 @@ function HtmlViewer({
                       setZoomMenuOpen((v) => !v);
                     }}
                   >
-                    <span style={{ fontVariantNumeric: 'tabular-nums' }}>{zoom}%</span>
+                    <span style={{ fontVariantNumeric: 'tabular-nums' }}>{previewZoomText}</span>
                   </button>
                   {zoomMenuOpen ? (
                     <div className="zoom-menu-popover" role="menu">
@@ -11411,15 +11433,16 @@ function HtmlViewer({
                         <button
                           key={level}
                           type="button"
-                          className={`zoom-menu-item${zoom === level ? ' active' : ''}`}
+                          className={`zoom-menu-item${zoomLevelActive(level) ? ' active' : ''}`}
                           role="menuitem"
                           onClick={() => {
+                            setZoomMode('manual');
                             setZoom(level);
                             setZoomMenuOpen(false);
                           }}
                         >
                           <span style={{ fontVariantNumeric: 'tabular-nums' }}>{level}%</span>
-                          {zoom === level ? (
+                          {zoomLevelActive(level) ? (
                             <Icon name="check" size={13} />
                           ) : null}
                         </button>
@@ -11586,16 +11609,17 @@ function HtmlViewer({
                           <button
                             key={level}
                             type="button"
-                            className={`viewer-toolbar-more-item${zoom === level ? ' active' : ''}`}
+                            className={`viewer-toolbar-more-item${zoomLevelActive(level) ? ' active' : ''}`}
                             role="menuitem"
                             onClick={() => {
+                              setZoomMode('manual');
                               setZoom(level);
                               setToolbarMoreOpen(false);
                             }}
                           >
                             <RemixIcon name="zoom-in-line" size={15} />
                             <span style={{ fontVariantNumeric: 'tabular-nums' }}>{level}%</span>
-                            {zoom === level ? <Icon name="check" size={13} /> : null}
+                            {zoomLevelActive(level) ? <Icon name="check" size={13} /> : null}
                           </button>
                         ))}
                       </>

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -291,6 +291,7 @@ const POWERED_PREVIEW_SANDBOX =
   'allow-scripts allow-same-origin allow-downloads allow-popups allow-forms allow-modals allow-pointer-lock';
 const POWERED_PREVIEW_ALLOW =
   'accelerometer; autoplay; camera; cross-origin-isolated; fullscreen; gamepad; gyroscope; microphone; xr-spatial-tracking';
+const PREVIEW_BRIDGE_QUERY = 'odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot';
 const HTML_PASSIVE_PREVIEW_FULL_TEXT_LIMIT = 2 * 1024 * 1024;
 const HTML_ROUTING_TEXT_PREVIEW_LIMIT = 96 * 1024;
 type HtmlSourceLoadMode = 'full' | 'routing-preview';
@@ -7222,7 +7223,7 @@ function HtmlViewer({
   };
   const useUrlLoadPreview = shouldUrlLoadHtmlPreview(urlLoadDecision) && !manualEditRequiresSrcDoc;
   const basePreviewSrcUrl = useMemo(
-    () => `${projectRawUrl(projectId, file.name)}?v=${Math.round(file.mtime)}&r=${reloadKey}&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot`,
+    () => `${projectRawUrl(projectId, file.name)}?v=${Math.round(file.mtime)}&r=${reloadKey}&${PREVIEW_BRIDGE_QUERY}`,
     [projectId, file.name, file.mtime, reloadKey],
   );
   const [previewSrcUrl, setPreviewSrcUrl] = useState(basePreviewSrcUrl);
@@ -7341,7 +7342,7 @@ function HtmlViewer({
       if (cancelled) return;
       setPowered({
         resolved: true,
-        url: base ? `${base}?v=${Math.round(file.mtime)}&r=${reloadKey}` : null,
+        url: base ? `${base}?v=${Math.round(file.mtime)}&r=${reloadKey}&${PREVIEW_BRIDGE_QUERY}` : null,
       });
     });
     return () => {

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -6316,23 +6316,17 @@ function HtmlViewer({
   const setCommentPreviewCanvasRef = useCallback((node: HTMLDivElement | null) => {
     setCommentPreviewCanvasNode((current) => (current === node ? current : node));
   }, []);
-  const measureDesktopPreviewContentWidth = useCallback((target: HTMLIFrameElement | null = iframeRef.current) => {
-    let measuredWidth: number | null = null;
-    try {
-      measuredWidth = desktopPreviewDocumentContentWidth(target?.contentWindow?.document);
-    } catch {
-      measuredWidth = null;
-    }
-    setDesktopPreviewContentWidth((current) => (current === measuredWidth ? current : measuredWidth));
+  const requestDesktopPreviewContentMeasure = useCallback((target: HTMLIFrameElement | null = iframeRef.current) => {
+    target?.contentWindow?.postMessage({ type: 'od:preview-content-size-request' }, '*');
   }, []);
   const scheduleDesktopPreviewContentMeasure = useCallback((target: HTMLIFrameElement | null = iframeRef.current) => {
-    measureDesktopPreviewContentWidth(target);
+    requestDesktopPreviewContentMeasure(target);
     window.requestAnimationFrame(() => {
-      measureDesktopPreviewContentWidth(target);
-      window.setTimeout(() => measureDesktopPreviewContentWidth(target), 80);
-      window.setTimeout(() => measureDesktopPreviewContentWidth(target), 260);
+      requestDesktopPreviewContentMeasure(target);
+      window.setTimeout(() => requestDesktopPreviewContentMeasure(target), 80);
+      window.setTimeout(() => requestDesktopPreviewContentMeasure(target), 260);
     });
-  }, [measureDesktopPreviewContentWidth]);
+  }, [requestDesktopPreviewContentMeasure]);
   useEffect(() => {
     if (!onBrandExtractionStopRequest) return;
     const requestStop = onBrandExtractionStopRequest;
@@ -7764,13 +7758,25 @@ function HtmlViewer({
         }, '*');
       }
     }
+    function onContentSizeMessage(ev: MessageEvent) {
+      if (!isOurPreviewIframeSource(ev.source)) return;
+      if (!isActivePreviewIframeSource(ev.source)) return;
+      const data = ev.data as { type?: string; width?: number | null } | null;
+      if (!data || data.type !== 'od:preview-content-size') return;
+      const measuredWidth = typeof data.width === 'number' && Number.isFinite(data.width) && data.width > 0
+        ? Math.ceil(data.width)
+        : null;
+      setDesktopPreviewContentWidth((current) => (current === measuredWidth ? current : measuredWidth));
+    }
     window.addEventListener('message', onMessage);
     window.addEventListener('message', onRestoreRequest);
     window.addEventListener('message', onDcViewportMessage);
+    window.addEventListener('message', onContentSizeMessage);
     return () => {
       window.removeEventListener('message', onMessage);
       window.removeEventListener('message', onRestoreRequest);
       window.removeEventListener('message', onDcViewportMessage);
+      window.removeEventListener('message', onContentSizeMessage);
     };
   }, [isActivePreviewIframeSource, isOurPreviewIframeSource]);
 

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -329,8 +329,6 @@ const PREVIEW_VIEWPORT_PRESETS: PreviewViewportPreset[] = [
   },
 ];
 
-const DESKTOP_PREVIEW_AUTO_FIT_WIDTH = 1440;
-
 function previewViewportIcon(viewport: PreviewViewportId): string {
   if (viewport === 'tablet') return 'tablet-line';
   if (viewport === 'mobile') return 'smartphone-line';
@@ -928,10 +926,26 @@ export function effectivePreviewScale(
 
 export function desktopPreviewAutoFitZoomPercent(
   canvasSize: PreviewCanvasSize | undefined,
-  designWidth = DESKTOP_PREVIEW_AUTO_FIT_WIDTH,
+  contentWidth?: number | null,
 ): number {
-  if (!canvasSize?.width || !Number.isFinite(canvasSize.width) || designWidth <= 0) return 100;
-  return Math.max(1, Math.min(100, (canvasSize.width / designWidth) * 100));
+  if (!canvasSize?.width || !Number.isFinite(canvasSize.width)) return 100;
+  if (!contentWidth || !Number.isFinite(contentWidth) || contentWidth <= canvasSize.width) return 100;
+  return Math.max(1, Math.min(100, (canvasSize.width / contentWidth) * 100));
+}
+
+export function desktopPreviewDocumentContentWidth(doc: Document | null | undefined): number | null {
+  if (!doc) return null;
+  const root = doc.documentElement;
+  const body = doc.body;
+  const widths = [
+    root?.scrollWidth,
+    body?.scrollWidth,
+    root?.offsetWidth,
+    body?.offsetWidth,
+    root?.clientWidth,
+    body?.clientWidth,
+  ].filter((value): value is number => typeof value === 'number' && Number.isFinite(value) && value > 0);
+  return widths.length ? Math.max(...widths) : null;
 }
 
 function zoomPercentLabel(zoomPercent: number): string {
@@ -6273,6 +6287,7 @@ function HtmlViewer({
   const [previewBodyRef, previewBodySize] = usePreviewCanvasSize<HTMLDivElement>();
   const [commentComposerHost, setCommentComposerHost] = useState<HTMLDivElement | null>(null);
   const [commentPreviewCanvasNode, setCommentPreviewCanvasNode] = useState<HTMLDivElement | null>(null);
+  const [desktopPreviewContentWidth, setDesktopPreviewContentWidth] = useState<number | null>(null);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const urlPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
   const srcDocPreviewIframeRef = useRef<HTMLIFrameElement | null>(null);
@@ -6301,6 +6316,23 @@ function HtmlViewer({
   const setCommentPreviewCanvasRef = useCallback((node: HTMLDivElement | null) => {
     setCommentPreviewCanvasNode((current) => (current === node ? current : node));
   }, []);
+  const measureDesktopPreviewContentWidth = useCallback((target: HTMLIFrameElement | null = iframeRef.current) => {
+    let measuredWidth: number | null = null;
+    try {
+      measuredWidth = desktopPreviewDocumentContentWidth(target?.contentWindow?.document);
+    } catch {
+      measuredWidth = null;
+    }
+    setDesktopPreviewContentWidth((current) => (current === measuredWidth ? current : measuredWidth));
+  }, []);
+  const scheduleDesktopPreviewContentMeasure = useCallback((target: HTMLIFrameElement | null = iframeRef.current) => {
+    measureDesktopPreviewContentWidth(target);
+    window.requestAnimationFrame(() => {
+      measureDesktopPreviewContentWidth(target);
+      window.setTimeout(() => measureDesktopPreviewContentWidth(target), 80);
+      window.setTimeout(() => measureDesktopPreviewContentWidth(target), 260);
+    });
+  }, [measureDesktopPreviewContentWidth]);
   useEffect(() => {
     if (!onBrandExtractionStopRequest) return;
     const requestStop = onBrandExtractionStopRequest;
@@ -6349,6 +6381,7 @@ function HtmlViewer({
   useEffect(() => {
     setManualEditSrcDocActive(false);
     setManualEditFrozenSource(null);
+    setDesktopPreviewContentWidth(null);
   }, [projectId, file.name]);
   useEffect(() => {
     onCommentModeChange?.(commentPanelOpen);
@@ -6640,6 +6673,16 @@ function HtmlViewer({
     sidePanelCollapsed: commentSidePanelCollapsed,
     viewport: previewViewport,
   });
+  useEffect(() => {
+    if (previewViewport !== 'desktop' || zoomMode !== 'auto') return;
+    scheduleDesktopPreviewContentMeasure();
+  }, [
+    boardPreviewCanvasSize?.width,
+    boardPreviewCanvasSize?.height,
+    previewViewport,
+    scheduleDesktopPreviewContentMeasure,
+    zoomMode,
+  ]);
 
   function deploymentMapForCurrentFile(items: WebDeploymentInfo[]) {
     const next: Partial<Record<WebDeployProviderId, WebDeploymentInfo>> = {};
@@ -6778,7 +6821,7 @@ function HtmlViewer({
   const speakerNotesTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   const boardPreviewScaleOptions = localCommentSideDockActive ? { canvasPadding: 0 } : undefined;
   const previewZoomPercent = zoomMode === 'auto' && previewViewport === 'desktop'
-    ? desktopPreviewAutoFitZoomPercent(boardPreviewCanvasSize)
+    ? desktopPreviewAutoFitZoomPercent(boardPreviewCanvasSize, desktopPreviewContentWidth)
     : zoom;
   const previewScale = previewZoomPercent / 100;
   const previewZoomText = zoomPercentLabel(previewZoomPercent);
@@ -12067,6 +12110,7 @@ function HtmlViewer({
                             frame?.contentWindow?.postMessage({ type: 'od:url-selection-bridge-probe' }, '*');
                             syncBridgeModes(frame);
                             if (useUrlLoadPreview) restorePreviewScrollPosition();
+                            if (useUrlLoadPreview) scheduleDesktopPreviewContentMeasure(frame);
                           }}
                         />
                       ) : (
@@ -12094,6 +12138,7 @@ function HtmlViewer({
                             frame?.contentWindow?.postMessage({ type: 'od:url-selection-bridge-probe' }, '*');
                             syncBridgeModes(frame);
                             if (useUrlLoadPreview) restorePreviewScrollPosition();
+                            if (useUrlLoadPreview) scheduleDesktopPreviewContentMeasure(frame);
                           }}
                         />
                       )}
@@ -12156,6 +12201,7 @@ function HtmlViewer({
                           syncBridgeModes(frame);
                           syncCachedSlideStateToIframe(frame);
                           if (!useUrlLoadPreview) restorePreviewScrollPosition();
+                          if (!useUrlLoadPreview) scheduleDesktopPreviewContentMeasure(frame);
                         }}
                       />
                     </div>

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -425,7 +425,7 @@ export function buildSrcdoc(
   // visible flash) every time the host toggle flips.
   const withTweaks = injectTweaksBridge(withEdit);
   const withTransport = injectSrcdocTransportActivationBridge(
-    injectExportCaptureBridge(injectSnapshotBridge(withTweaks)),
+    injectExportCaptureBridge(injectSnapshotBridge(injectPreviewContentSizeBridge(withTweaks))),
   );
   // Embed the reload counter so the srcdoc string differs across reloads even
   // when the underlying HTML bytes are identical.  This ensures the browser
@@ -720,6 +720,68 @@ function injectSnapshotBridge(doc: string): string {
       window.parent.postMessage({ type: 'od:snapshot:result', id: String(data.id), error: String(err && err.message || err) }, '*');
     });
   });
+})();</script>`;
+  return injectBeforeBodyEnd(doc, script);
+}
+
+function injectPreviewContentSizeBridge(doc: string): string {
+  const script = `<script data-od-preview-content-size-bridge>(function(){
+  if (window.__odPreviewContentSizeBridge) return;
+  window.__odPreviewContentSizeBridge = true;
+  var pending = false;
+  function measure(){
+    var root = document.documentElement;
+    var body = document.body || root;
+    if (!root) return null;
+    var values = [
+      root.scrollWidth,
+      body && body.scrollWidth,
+      root.offsetWidth,
+      body && body.offsetWidth,
+      root.clientWidth,
+      body && body.clientWidth
+    ];
+    var width = 0;
+    for (var i = 0; i < values.length; i += 1) {
+      var next = Number(values[i] || 0);
+      if (Number.isFinite(next) && next > width) width = next;
+    }
+    return width > 0 ? Math.ceil(width) : null;
+  }
+  function post(){
+    try { window.parent.postMessage({ type: 'od:preview-content-size', width: measure() }, '*'); } catch (_) {}
+  }
+  function schedule(){
+    if (pending) return;
+    pending = true;
+    window.requestAnimationFrame(function(){
+      pending = false;
+      post();
+    });
+  }
+  window.addEventListener('message', function(ev){
+    var data = ev && ev.data;
+    if (!data || data.type !== 'od:preview-content-size-request') return;
+    schedule();
+  });
+  window.addEventListener('resize', schedule);
+  if (typeof ResizeObserver !== 'undefined') {
+    try {
+      var observer = new ResizeObserver(schedule);
+      observer.observe(document.documentElement);
+      if (document.body) observer.observe(document.body);
+    } catch (_) {}
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', schedule);
+  } else {
+    setTimeout(schedule, 0);
+  }
+  setTimeout(schedule, 80);
+  setTimeout(schedule, 260);
+  if (document.fonts && document.fonts.ready) {
+    document.fonts.ready.then(schedule).catch(function(){});
+  }
 })();</script>`;
   return injectBeforeBodyEnd(doc, script);
 }

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -59,6 +59,7 @@ import {
   appendSavedPreviewCommentOrder,
   applyInspectOverridesToSource,
   commentPreviewCanvasSize,
+  desktopPreviewAutoFitZoomPercent,
   deckKeyboardShortcutForEvent,
   effectivePreviewScale,
   fileVersionPreviewOptions,
@@ -346,6 +347,11 @@ describe('FileViewer preview scale', () => {
 
   it('uses the requested zoom for desktop preview overlays', () => {
     expect(effectivePreviewScale('desktop', 1.5, { width: 320, height: 480 })).toBe(1.5);
+  });
+
+  it('calculates a desktop auto-fit zoom for wide landing pages', () => {
+    expect(desktopPreviewAutoFitZoomPercent({ width: 900, height: 700 })).toBeCloseTo(62.5);
+    expect(desktopPreviewAutoFitZoomPercent({ width: 1600, height: 900 })).toBe(100);
   });
 
   it('only treats unmodified deck keyboard presses as deck shortcuts', () => {
@@ -5136,6 +5142,59 @@ describe('FileViewer tweaks toolbar', () => {
     await waitFor(() => {
       expect(layout.className).not.toContain('comment-preview-layer-with-side-dock');
       expect(Number(layout.style.getPropertyValue('--preview-scale'))).toBeCloseTo((700 - 48) / 1180);
+    });
+  });
+
+  it('auto-fits wide desktop HTML previews until the user manually zooms', async () => {
+    let viewerBodyWidth = 900;
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function getBoundingClientRectMock(this: HTMLElement) {
+        if (this.classList.contains('viewer-body')) return testRect(0, 0, viewerBodyWidth, 700);
+        return testRect(0, 0, 0, 0);
+      });
+
+    const { container } = render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlPreviewFile({
+          name: 'wide-autofit-preview.html',
+          path: 'wide-autofit-preview.html',
+          artifactManifest: {
+            version: 1,
+            kind: 'html',
+            title: 'Wide autofit preview',
+            entry: 'wide-autofit-preview.html',
+            renderer: 'html',
+            exports: ['html'],
+          },
+        })}
+        liveHtml='<html><body><main style="min-width:1440px">Wide landing page</main></body></html>'
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '63%' })).toBeTruthy();
+    });
+    const scaledShell = Array.from(container.querySelectorAll('div')).find(
+      (node) => node.style.transform === 'scale(0.625)',
+    );
+    expect(scaledShell).toBeTruthy();
+
+    viewerBodyWidth = 720;
+    window.dispatchEvent(new Event('resize'));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '50%' })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '50%' }));
+    fireEvent.click(screen.getByRole('menuitem', { name: '75%' }));
+
+    viewerBodyWidth = 1000;
+    window.dispatchEvent(new Event('resize'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '75%' })).toBeTruthy();
     });
   });
 

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1160,7 +1160,7 @@ describe('FileViewer SVG artifacts', () => {
       },
     });
     const workerHtml = '<!doctype html><html><body><script>new Worker("worker.js")</script></body></html>';
-    const poweredSrc = 'http://localhost:43111/api/projects/project-1/powered/worker.html?v=1000&r=0';
+    const poweredSrc = 'http://localhost:43111/api/projects/project-1/powered/worker.html?v=1000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot';
 
     const { rerender } = render(
       <FileViewer
@@ -5235,6 +5235,65 @@ describe('FileViewer tweaks toolbar', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: '75%' })).toBeTruthy();
+    });
+  });
+
+  it('requests the content-size bridge for powered desktop previews before auto-fitting', async () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function getBoundingClientRectMock(this: HTMLElement) {
+        if (this.classList.contains('viewer-body')) return testRect(0, 0, 900, 700);
+        return testRect(0, 0, 0, 0);
+      });
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url === '/api/preview/isolation') {
+        return new Response(JSON.stringify({
+          supported: true,
+          baseOrigin: 'http://127.0.0.1:48123',
+          pathPrefix: 'powered',
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url === '/api/projects/project-1/files') {
+        return new Response(JSON.stringify({ files: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response('', { status: 404 });
+    }));
+
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlPreviewFile({
+          name: 'powered-wide.html',
+          path: 'powered-wide.html',
+          mtime: 1710000000,
+        })}
+        liveHtml='<html><body><script>new SharedArrayBuffer(8)</script><main style="min-width:1440px">Wide powered page</main></body></html>'
+      />,
+    );
+
+    await screen.findByTestId('artifact-preview-frame');
+    await waitFor(() => {
+      const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+      expect(frame.getAttribute('data-od-powered')).toBe('true');
+      expect(frame.getAttribute('src')).toBe(
+        'http://localhost:48123/api/projects/project-1/powered/powered-wide.html?v=1710000000&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot',
+      );
+    });
+
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    const previewWindow = installSandboxedPreviewWindow(frame);
+    fireEvent.load(frame);
+    act(() => postPreviewContentWidth(previewWindow, 1440));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '63%' })).toBeTruthy();
     });
   });
 

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -165,26 +165,28 @@ function testRect(left: number, top: number, width: number, height: number): DOM
   } as DOMRect;
 }
 
-function setIframeDocumentContentWidth(frame: HTMLIFrameElement, width: number) {
-  let doc = frame.contentWindow?.document ?? frame.contentDocument;
-  if (!doc?.documentElement) {
-    doc = document.implementation.createHTMLDocument('preview');
-    Object.defineProperty(frame, 'contentWindow', {
-      configurable: true,
-      value: {
-        document: doc,
-        postMessage: vi.fn(),
-      },
-    });
-  }
-  if (!doc.body) {
-    doc.documentElement.appendChild(doc.createElement('body'));
-  }
-  for (const target of [doc.documentElement, doc.body]) {
-    Object.defineProperty(target, 'scrollWidth', { configurable: true, value: width });
-    Object.defineProperty(target, 'offsetWidth', { configurable: true, value: width });
-    Object.defineProperty(target, 'clientWidth', { configurable: true, value: width });
-  }
+function installSandboxedPreviewWindow(frame: HTMLIFrameElement): Window {
+  const previewWindow = {
+    postMessage: vi.fn(),
+  } as unknown as Window;
+  Object.defineProperty(previewWindow, 'document', {
+    configurable: true,
+    get() {
+      throw new DOMException('Blocked by iframe sandbox', 'SecurityError');
+    },
+  });
+  Object.defineProperty(frame, 'contentWindow', {
+    configurable: true,
+    value: previewWindow,
+  });
+  return previewWindow;
+}
+
+function postPreviewContentWidth(source: Window, width: number) {
+  window.dispatchEvent(new MessageEvent('message', {
+    source,
+    data: { type: 'od:preview-content-size', width },
+  }));
 }
 
 function clickAgentTool(testId: string) {
@@ -5207,8 +5209,9 @@ describe('FileViewer tweaks toolbar', () => {
     );
 
     const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
-    setIframeDocumentContentWidth(frame, 1440);
+    const previewWindow = installSandboxedPreviewWindow(frame);
     fireEvent.load(frame);
+    act(() => postPreviewContentWidth(previewWindow, 1440));
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: '63%' })).toBeTruthy();
@@ -5263,8 +5266,9 @@ describe('FileViewer tweaks toolbar', () => {
     );
 
     const responsiveFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
-    setIframeDocumentContentWidth(responsiveFrame, 900);
+    const previewWindow = installSandboxedPreviewWindow(responsiveFrame);
     fireEvent.load(responsiveFrame);
+    act(() => postPreviewContentWidth(previewWindow, 900));
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: '100%' })).toBeTruthy();

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -60,6 +60,7 @@ import {
   applyInspectOverridesToSource,
   commentPreviewCanvasSize,
   desktopPreviewAutoFitZoomPercent,
+  desktopPreviewDocumentContentWidth,
   deckKeyboardShortcutForEvent,
   effectivePreviewScale,
   fileVersionPreviewOptions,
@@ -162,6 +163,28 @@ function testRect(left: number, top: number, width: number, height: number): DOM
     bottom: top + height,
     toJSON: () => ({}),
   } as DOMRect;
+}
+
+function setIframeDocumentContentWidth(frame: HTMLIFrameElement, width: number) {
+  let doc = frame.contentWindow?.document ?? frame.contentDocument;
+  if (!doc?.documentElement) {
+    doc = document.implementation.createHTMLDocument('preview');
+    Object.defineProperty(frame, 'contentWindow', {
+      configurable: true,
+      value: {
+        document: doc,
+        postMessage: vi.fn(),
+      },
+    });
+  }
+  if (!doc.body) {
+    doc.documentElement.appendChild(doc.createElement('body'));
+  }
+  for (const target of [doc.documentElement, doc.body]) {
+    Object.defineProperty(target, 'scrollWidth', { configurable: true, value: width });
+    Object.defineProperty(target, 'offsetWidth', { configurable: true, value: width });
+    Object.defineProperty(target, 'clientWidth', { configurable: true, value: width });
+  }
 }
 
 function clickAgentTool(testId: string) {
@@ -350,8 +373,18 @@ describe('FileViewer preview scale', () => {
   });
 
   it('calculates a desktop auto-fit zoom for wide landing pages', () => {
-    expect(desktopPreviewAutoFitZoomPercent({ width: 900, height: 700 })).toBeCloseTo(62.5);
-    expect(desktopPreviewAutoFitZoomPercent({ width: 1600, height: 900 })).toBe(100);
+    expect(desktopPreviewAutoFitZoomPercent({ width: 900, height: 700 })).toBe(100);
+    expect(desktopPreviewAutoFitZoomPercent({ width: 900, height: 700 }, 1440)).toBeCloseTo(62.5);
+    expect(desktopPreviewAutoFitZoomPercent({ width: 900, height: 700 }, 900)).toBe(100);
+    expect(desktopPreviewAutoFitZoomPercent({ width: 1600, height: 900 }, 1440)).toBe(100);
+  });
+
+  it('measures desktop preview document content width from real iframe layout', () => {
+    const doc = document.implementation.createHTMLDocument('preview');
+    Object.defineProperty(doc.documentElement, 'scrollWidth', { configurable: true, value: 960 });
+    Object.defineProperty(doc.body, 'scrollWidth', { configurable: true, value: 1440 });
+
+    expect(desktopPreviewDocumentContentWidth(doc)).toBe(1440);
   });
 
   it('only treats unmodified deck keyboard presses as deck shortcuts', () => {
@@ -5173,6 +5206,10 @@ describe('FileViewer tweaks toolbar', () => {
       />,
     );
 
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    setIframeDocumentContentWidth(frame, 1440);
+    fireEvent.load(frame);
+
     await waitFor(() => {
       expect(screen.getByRole('button', { name: '63%' })).toBeTruthy();
     });
@@ -5196,6 +5233,46 @@ describe('FileViewer tweaks toolbar', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: '75%' })).toBeTruthy();
     });
+  });
+
+  it('keeps desktop HTML previews at 100% when measured content already fits', async () => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function getBoundingClientRectMock(this: HTMLElement) {
+        if (this.classList.contains('viewer-body')) return testRect(0, 0, 900, 700);
+        return testRect(0, 0, 0, 0);
+      });
+
+    const { container } = render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlPreviewFile({
+          name: 'responsive-preview.html',
+          path: 'responsive-preview.html',
+          artifactManifest: {
+            version: 1,
+            kind: 'html',
+            title: 'Responsive preview',
+            entry: 'responsive-preview.html',
+            renderer: 'html',
+            exports: ['html'],
+          },
+        })}
+        liveHtml='<html><body><main style="width:100%">Responsive landing page</main></body></html>'
+      />,
+    );
+
+    const responsiveFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    setIframeDocumentContentWidth(responsiveFrame, 900);
+    fireEvent.load(responsiveFrame);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '100%' })).toBeTruthy();
+    });
+    const scaledShell = Array.from(container.querySelectorAll('div')).find(
+      (node) => node.style.transform === 'scale(1)',
+    );
+    expect(scaledShell).toBeTruthy();
   });
 
   it('portals the comment composer to the preview viewport instead of the clipped canvas', async () => {

--- a/e2e/lib/playwright/visual.ts
+++ b/e2e/lib/playwright/visual.ts
@@ -608,12 +608,13 @@ export async function gotoVisualWorkspace(page: Page): Promise<void> {
 }
 
 export async function prepareVisualWorkspaceFileList(page: Page): Promise<void> {
-  const fileRow = page.getByTestId('design-file-row-index.html');
-  if (!(await fileRow.isVisible().catch(() => false))) {
-    await page.getByTestId('workspace-pages-menu-trigger').click();
+  const trigger = page.getByTestId('workspace-pages-menu-trigger');
+  const triggerText = await trigger.textContent().catch(() => '');
+  if (!/\bAll project files\b/.test(triggerText ?? '')) {
+    await trigger.click();
     await page.getByRole('menuitem', { name: 'All project files' }).click();
   }
-  await expect(page.getByTestId('workspace-pages-menu-trigger')).toContainText('All project files');
+  await expect(trigger).toContainText('All project files');
   await expect(page.getByTestId('design-file-row-index.html')).toBeVisible();
   await expect(page.getByTestId('design-file-preview')).toHaveCount(0);
   await resetVisualScroll(page);

--- a/e2e/ui/app-manual-edit.test.ts
+++ b/e2e/ui/app-manual-edit.test.ts
@@ -215,7 +215,7 @@ test('[P0] @critical preview toolbar keeps share, download, comment, and zoom ac
   await expect(page.getByTestId('board-mode-toggle')).toHaveAttribute('aria-pressed', 'false');
 
   const zoomButton = page.locator('.viewer-toolbar-zoom .zoom-trigger');
-  await expect(zoomButton).toHaveText('100%');
+  await expect(zoomButton).toHaveText(/^\d+%$/);
   await zoomButton.click();
   const zoomMenu = page.locator('.zoom-menu-popover[role="menu"]');
   await expect(zoomMenu).toBeVisible();


### PR DESCRIPTION
## Why

Source tracker: https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/1f00dfb2-1624-4f12-8fe6-89cdd548f2f3

Generated web landing pages can include a desktop-width layout around 1440px. The artifact viewer previously opened desktop previews at 100% zoom against the visible pane width, so wide pages with fixed/min-width desktop layouts were clipped on the right instead of being scaled to the preview area. This PR fixes that default preview behavior while preserving explicit user zoom choices.

## What users will see

HTML artifact previews now auto-fit wide desktop pages to the available preview pane on first open and when the preview pane resizes. If the user picks a zoom level from the toolbar, that manual zoom remains stable across later pane/window resizes.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. The changed behavior is covered by a focused jsdom component regression that exercises desktop auto-fit, resize recomputation, and manual zoom preservation.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/FileViewer.test.tsx` (`auto-fits wide desktop HTML previews until the user manually zooms`)
- Did the test go red on `main` and green on this branch? yes. The red-spec expectation fails on the old behavior because the preview remains at `100%`; it passes after the auto-fit change.

## Validation

- `pnpm install` (needed because this worktree had no `node_modules`; completed with Node `v22.22.0` engine warnings for the repo's `~24` target)
- `pnpm exec vitest run -c vitest.config.ts tests/components/FileViewer.test.tsx` from `apps/web` (199 passed)
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>