### PR TITLE
fix(web): route history deck keys to preview

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -2669,6 +2669,12 @@ export function deckKeyboardShortcutForEvent(event: DeckKeyboardShortcutEvent): 
   return null;
 }
 
+function isEditableKeyboardTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || target.isContentEditable;
+}
+
 function normalizeDeckVisualSource(source: string): string {
   return source
     .replace(/\s+(?=<\/body\s*>)/gi, '')
@@ -2967,6 +2973,25 @@ function FileVersionManagerModal({
     const fallback = window.setTimeout(() => setLoadedSrcDoc(srcDoc), 6000);
     return () => window.clearTimeout(fallback);
   }, [srcDoc, loadedSrcDoc]);
+
+  useEffect(() => {
+    if (!isDeckPreview || !selectedContentMatchesVersion || loadingContent) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (document.activeElement === versionPreviewIframeRef.current) return;
+      if (isEditableKeyboardTarget(event.target) || isEditableKeyboardTarget(document.activeElement)) return;
+      const shortcut = deckKeyboardShortcutForEvent(event);
+      if (!shortcut) return;
+      const win = versionPreviewIframeRef.current?.contentWindow;
+      if (!win) return;
+      event.preventDefault();
+      win.postMessage({
+        type: 'od:slide',
+        action: shortcut === 'reset' ? 'first' : shortcut,
+      }, '*');
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [isDeckPreview, loadingContent, selectedContentMatchesVersion]);
 
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -2618,13 +2618,21 @@ function fileVersionSourceToTracking(version: ProjectFileVersion): TrackingFileV
   return 'ai';
 }
 
+function sourceLooksLikeDeckPreview(source: string | null | undefined): boolean {
+  if (!source) return false;
+  return (
+    /class\s*=\s*['"](?:[^'"]*\s)?slide(?:\s|['"])/i.test(source) ||
+    sourceLooksLikeExportableDeck(source)
+  );
+}
+
 export function fileVersionPreviewOptions(
   projectId: string,
   fileName: string,
   source: string | null | undefined,
 ) {
   return {
-    deck: sourceLooksLikeExportableDeck(source),
+    deck: sourceLooksLikeDeckPreview(source),
     baseHref: projectRawUrl(projectId, baseDirFor(fileName)),
   };
 }
@@ -6984,11 +6992,7 @@ function HtmlViewer({
   // never surface and the deck becomes a static, unnavigable preview.
   const looksLikeDeck = useMemo(() => {
     const s = routingHtmlSource;
-    if (!s) return false;
-    return (
-      /class\s*=\s*['"](?:[^'"]*\s)?slide(?:\s|['"])/i.test(s) ||
-      sourceLooksLikeExportableDeck(s)
-    );
+    return sourceLooksLikeDeckPreview(s);
   }, [routingHtmlSource]);
   const effectiveDeck = isDeck || (!passiveLargeHtmlPreview && looksLikeDeck);
   const showDeckNavigation = effectiveDeck && (slideState === null || slideState.count > 0);

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -3431,6 +3431,92 @@ describe('FileViewer SVG artifacts', () => {
     expect(options.baseHref).toBe('/api/projects/project-1/raw/');
   });
 
+  it('routes history deck arrow keys to the preview unless a text input is focused', async () => {
+    const deckSource = [
+      '<!doctype html><html><body>',
+      '<deck-stage>',
+      '<section data-screen-label="01 Cover">Cover</section>',
+      '<section data-screen-label="02 Plan">Plan</section>',
+      '</deck-stage>',
+      '</body></html>',
+    ].join('');
+    const file = baseFile({
+      name: 'index.html',
+      path: 'index.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Deck',
+        entry: 'index.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    });
+    const currentVersion = {
+      id: 'v4',
+      fileName: 'index.html',
+      version: 4,
+      label: 'Current checkpoint',
+      createdAt: 1_725_000_000_000,
+      source: 'manual',
+      prompt: 'Current prompt',
+      size: 42,
+      mime: 'text/html',
+      kind: 'html',
+      current: true,
+    };
+    const earlierVersions = [3, 2, 1].map((version) => ({
+      ...currentVersion,
+      id: `v${version}`,
+      version,
+      label: `Prior checkpoint ${version}`,
+      prompt: `Prior prompt ${version}`,
+      current: false,
+    }));
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      const method = init?.method ?? 'GET';
+      if (url === '/api/projects/project-1/files/index.html/versions' && method === 'GET') {
+        return new Response(JSON.stringify({ file, versions: [currentVersion, ...earlierVersions] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({}), { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="slide_deck"
+        file={file}
+        liveHtml={deckSource}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Versions' }));
+    const versionDialog = await screen.findByRole('dialog', { name: 'Versions' });
+    const currentOption = within(versionDialog).getByRole('option', { name: /Current prompt/ }) as HTMLButtonElement;
+    currentOption.focus();
+    const previewFrame = await waitFor(() => {
+      const frame = versionDialog.querySelector('iframe[title="index.html v4"]') as HTMLIFrameElement | null;
+      expect(frame?.contentWindow).toBeTruthy();
+      return frame!;
+    });
+    const postMessage = vi.spyOn(previewFrame.contentWindow!, 'postMessage').mockImplementation(() => {});
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+
+    expect(postMessage).toHaveBeenCalledWith({ type: 'od:slide', action: 'next' }, '*');
+
+    postMessage.mockClear();
+    const search = within(versionDialog).getByRole('searchbox', { name: 'Search…' }) as HTMLInputElement;
+    search.focus();
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
   it('exposes selected-version download actions and exports that version content', async () => {
     const originalCreateObjectUrl = URL.createObjectURL;
     const originalRevokeObjectUrl = URL.revokeObjectURL;

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -3429,6 +3429,12 @@ describe('FileViewer SVG artifacts', () => {
 
     expect(options.deck).toBe(true);
     expect(options.baseHref).toBe('/api/projects/project-1/raw/');
+
+    expect(fileVersionPreviewOptions(
+      'project-1',
+      'slides.html',
+      '<section class="slide">A</section><section class="slide">B</section>',
+    ).deck).toBe(true);
   });
 
   it('routes history deck arrow keys to the preview unless a text input is focused', async () => {

--- a/e2e/ui/app-manual-edit.test.ts
+++ b/e2e/ui/app-manual-edit.test.ts
@@ -724,6 +724,76 @@ test('[P0] deck host counter stays synced when a self-handling deck stops slide 
   await expect(frame.locator('#deck-cur')).toHaveText('01');
 });
 
+test('[P0] history version deck keyboard navigation advances the displayed preview before iframe click', async ({ page }) => {
+  test.setTimeout(T.xlong);
+  await routeMockAgents(page);
+  const projectId = await createEmptyProject(page, 'History deck keyboard');
+  const fileName = 'history-keyboard-deck.html';
+  await seedDeckArtifact(
+    page,
+    projectId,
+    fileName,
+    'History Keyboard Deck',
+    [
+      'Slide One',
+      'Slide Two',
+      'Slide Three',
+      'Slide Four',
+      'Slide Five',
+      'Slide Six',
+      'Slide Seven',
+      'Slide Eight',
+      'Slide Nine',
+      'Slide Ten',
+    ],
+    { stopsSlideMessagePropagation: true },
+  );
+  const currentVersion = {
+    id: 'v-current',
+    fileName,
+    version: 3,
+    label: 'Selected 10-slide history preview',
+    createdAt: Date.now(),
+    source: 'manual',
+    prompt: 'Selected 10-slide history preview',
+    size: 42,
+    mime: 'text/html',
+    kind: 'html',
+    current: true,
+  };
+  await page.route(`**/api/projects/${projectId}/files/${fileName}/versions`, async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        json: {
+          file: { name: fileName, kind: 'html', mime: 'text/html', size: 42, mtime: Date.now() },
+          versions: [currentVersion],
+        },
+      });
+      return;
+    }
+    await route.continue();
+  });
+  await page.goto(`/projects/${projectId}/files/${fileName}`, { waitUntil: 'domcontentloaded' });
+  await openDesignFile(page, fileName);
+
+  await page.getByRole('button', { name: 'Versions' }).click();
+  const dialog = page.getByRole('dialog', { name: 'Versions' });
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole('option', { name: /Selected 10-slide history preview/i }).focus();
+  const historyFrame = dialog.locator('iframe').first().contentFrame();
+  await expect(historyFrame.locator('#deck-cur')).toHaveText('01');
+  await expect(historyFrame.locator('#deck-total')).toHaveText('10');
+
+  await page.keyboard.press('ArrowRight');
+  await expect(historyFrame.locator('#deck-cur')).toHaveText('02');
+  await page.keyboard.press('PageDown');
+  await expect(historyFrame.locator('#deck-cur')).toHaveText('03');
+  await page.keyboard.press('ArrowLeft');
+  await expect(historyFrame.locator('#deck-cur')).toHaveText('02');
+  await page.keyboard.press('PageUp');
+  await expect(historyFrame.locator('#deck-cur')).toHaveText('01');
+});
+
 
 test('[P0] simple deck keeps the active slide stable in preview-only mode', async ({ page }) => {
   await routeMockAgents(page);


### PR DESCRIPTION
## Why

This fixes the Plane-tracked P1 regression where opening an HTML history version and immediately pressing arrow keys paged the surrounding file/history UI or another host surface until the user clicked inside the preview first.

Source tracker: https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/871550d8-b74c-4b8c-930e-ce0eda4a957f

Root cause: the main deck viewer already owns host-side keyboard routing, but the file-version modal only injected the iframe focus guard. Until the sandboxed history preview actually held browser focus, unmodified arrow keys stayed in the host document and never reached the deck bridge.

## What users will see

History-version deck previews respond to Left/Right, PageUp/PageDown, Home/End, and reset shortcuts immediately after the modal opens. Search fields and other editable controls keep their normal keyboard behavior.

## Surface area

- [x] **UI** — existing history-version preview modal behavior in `apps/web`
- [x] **Keyboard shortcut** — routes existing deck navigation shortcuts to the selected history preview
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope.
- [x] **Default behavior change** — history deck previews now receive deck navigation keys without an initial preview click
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This is a keyboard/focus behavior fix covered by a component-level regression test rather than a visual layout change.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/FileViewer.test.tsx` (`routes history deck arrow keys to the preview unless a text input is focused`)
- Did the test go red on `main` and green on this branch? yes. It failed before the fix because the history preview iframe received no `od:slide` message, then passed after the modal routed deck shortcuts to its preview iframe.

## Validation

- `pnpm install` (lockfile already up to date; emitted Node 22 vs repo Node ~24 engine warnings)
- `pnpm --filter @open-design/web exec vitest run tests/components/FileViewer.test.tsx --testNamePattern "routes history deck arrow keys"` (red before fix, green after fix)
- `pnpm --filter @open-design/web exec vitest run tests/components/FileViewer.test.tsx` (passed; an earlier parallel run timed out one unrelated existing Draw-bar case while root typecheck was also running, then passed solo)
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>