### PR TITLE
fix: release question form submit lock after successful submission

### DIFF
--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -2917,7 +2917,7 @@ function FormBlock({
         }
         releaseSubmitLock();
       };
-          const acceptSubmission = () => {
+      const acceptSubmission = () => {
         clearInlineQuestionFormDraft(formKey);
         setDraftAnswers(undefined);
         releaseSubmitLock();

--- a/apps/web/src/components/AssistantMessage.tsx
+++ b/apps/web/src/components/AssistantMessage.tsx
@@ -2917,9 +2917,10 @@ function FormBlock({
         }
         releaseSubmitLock();
       };
-      const acceptSubmission = () => {
+          const acceptSubmission = () => {
         clearInlineQuestionFormDraft(formKey);
         setDraftAnswers(undefined);
+        releaseSubmitLock();
       };
       let submitOutcome: boolean | void | Promise<boolean | void>;
       try {


### PR DESCRIPTION
Refs #5627

## Why

The question form submission flow acquires a submit lock to prevent duplicate submissions, but the success path does not explicitly release that lock. Instead, it relies on a later render triggered by the submitted form history to clear the state. If that update is delayed or does not occur as expected, the form can remain in a permanently disabled state.

## What users will see

After a successful question form submission, the form correctly releases its temporary submit lock instead of remaining disabled.

## Surface area

- [x] **UI** — changes behavior in the web question form
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

N/A

## Bug fix verification

- Test path that reproduces the bug: Submit a question form and verify the submit button is re-enabled after the success path completes.
- Did the test go red on `main` and green on this branch? **No**
- Verification: Code inspection only. I have not yet reproduced the original issue locally.

## Validation

- GitHub Actions CI