### PR TITLE
fix(web): default Community gallery to all types

### DIFF
--- a/apps/web/src/components/PluginsHomeSection.tsx
+++ b/apps/web/src/components/PluginsHomeSection.tsx
@@ -107,7 +107,7 @@ export function PluginsHomeSection({
   } = usePluginFacets({
     plugins,
     savedPluginIds,
-    preferDefaultFacet,
+    preferDefaultFacet: cardLayout === 'gallery' ? false : preferDefaultFacet,
     locale,
   });
   const renderedPlugins = useMemo(
@@ -115,9 +115,7 @@ export function PluginsHomeSection({
     [filtered, renderLimit],
   );
   const hasMorePlugins = renderLimit < filtered.length;
-  const categoryAllVisible = cardLayout !== 'gallery';
   const handlePickCategory = (slug: string | null): void => {
-    if (!categoryAllVisible && slug === selection.category) return;
     pickCategory(slug);
   };
 
@@ -207,7 +205,7 @@ export function PluginsHomeSection({
               onToggleSaved={() =>
                 setMode(mode === 'saved' ? 'all' : 'saved')
               }
-              showAll={categoryAllVisible}
+              showAll
               query={query}
               onQueryChange={setQuery}
               sortOrder={sortOrder}

--- a/apps/web/tests/components/HomeView.community-filter-decouple.test.tsx
+++ b/apps/web/tests/components/HomeView.community-filter-decouple.test.tsx
@@ -91,15 +91,14 @@ describe('HomeView community filter decoupling', () => {
       </I18nProvider>,
     );
 
-    // Home boots with a default active type chip and the Community grid now
-    // leads with Slides directly instead of a generic All bucket.
-    // Wait for the *selected* state, not just the pill mount — under full-suite
-    // CI load the pills can paint one frame before resolveDefaultSelection
-    // applies, which made a bare getByTestId assertion flake.
+    // Home boots with a default active type chip, but the Community grid starts
+    // from its own All selection so users can browse the full catalog first.
+    // Wait for the selected state, not just the pill mount, so the assertion
+    // stays stable under full-suite CI load.
     await waitFor(() => {
-      expect(ariaSelected('plugins-home-pill-category-deck')).toBe('true');
+      expect(ariaSelected('plugins-home-pill-category-all')).toBe('true');
     });
-    expect(screen.queryByTestId('plugins-home-pill-category-all')).toBeNull();
+    expect(ariaSelected('plugins-home-pill-category-deck')).toBe('false');
     expect(ariaSelected('plugins-home-pill-category-prototype')).toBe('false');
 
     // Picking another chip drives the composer, not the gallery filter.
@@ -107,10 +106,12 @@ describe('HomeView community filter decoupling', () => {
     await waitFor(() => {
       expect(screen.getByTestId('home-hero-template-trigger').textContent).toContain('Slide deck');
     });
-    expect(ariaSelected('plugins-home-pill-category-deck')).toBe('true');
+    expect(ariaSelected('plugins-home-pill-category-all')).toBe('true');
+    expect(ariaSelected('plugins-home-pill-category-deck')).toBe('false');
 
     // And the gallery's own pills still work locally.
     fireEvent.click(screen.getByTestId('plugins-home-pill-category-prototype'));
+    expect(ariaSelected('plugins-home-pill-category-all')).toBe('false');
     expect(ariaSelected('plugins-home-pill-category-prototype')).toBe('true');
   });
 

--- a/apps/web/tests/components/plugins-home-section.test.tsx
+++ b/apps/web/tests/components/plugins-home-section.test.tsx
@@ -218,13 +218,35 @@ describe('PluginsHomeSection (community gallery)', () => {
     expect(screen.getByTestId('plugins-home-use-prototype-dashboard')).toBeTruthy();
   });
 
-  it('hides All and keeps Slides selected on the lightweight gallery layout', () => {
+  it('shows all Community types by default on the lightweight gallery layout', () => {
+    const first = renderSection(sample, { cardLayout: 'gallery' });
+
+    expect(screen.getByTestId('plugins-home-pill-category-all').getAttribute('aria-selected')).toBe(
+      'true',
+    );
+    expect(screen.getByTestId('plugins-home-pill-category-deck').getAttribute('aria-selected')).toBe(
+      'false',
+    );
+    expect(screen.queryByTestId('plugins-home-row-subcategory-deck')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('plugins-home-pill-category-deck'));
+    expect(screen.getByTestId('plugins-home-pill-category-all').getAttribute('aria-selected')).toBe(
+      'false',
+    );
+    expect(screen.getByTestId('plugins-home-pill-category-deck').getAttribute('aria-selected')).toBe(
+      'true',
+    );
+    expect(pluginIds()).toEqual(['deck-pitch']);
+
+    first.unmount();
     renderSection(sample, { cardLayout: 'gallery' });
 
-    expect(screen.queryByTestId('plugins-home-pill-category-all')).toBeNull();
-    expect(screen.getByTestId('plugins-home-pill-category-deck').getAttribute('aria-selected')).toBe('true');
-    fireEvent.click(screen.getByTestId('plugins-home-pill-category-deck'));
-    expect(screen.getByTestId('plugins-home-pill-category-deck').getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByTestId('plugins-home-pill-category-all').getAttribute('aria-selected')).toBe(
+      'true',
+    );
+    expect(screen.getByTestId('plugins-home-pill-category-deck').getAttribute('aria-selected')).toBe(
+      'false',
+    );
   });
 });
 


### PR DESCRIPTION
## Why

This follows up the external Plane issue: https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/91096539-8e3f-4712-a3e0-556d6b66515b.

The Community gallery was bootstrapping the type filter to Slides while also hiding the top-level All pill on the lightweight gallery layout. That meant first-time users could not start from the full community catalog before narrowing to Slides, Prototype, Image, and other types.

## What users will see

Home → Community now opens with All selected and shows the combined community catalog. Clicking Slides, Prototype, Image, Video, and other type pills still filters the grid and updates the active pill/counts. Refreshing or remounting the Community section returns to the All default.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This is a filter default-state fix covered by the component regression test below.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/plugins-home-section.test.tsx`
- Red/green confirmation: yes. The updated Community gallery test failed before the source fix because `plugins-home-pill-category-all` was missing and Slides was selected; it passes after the fix.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts --maxWorkers=2 tests/components/plugins-home-section.test.tsx`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>