### PR TITLE
fix(web): prune per-project tab-state cache on project deletion

### DIFF
--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -369,6 +369,10 @@ export async function deleteProject(id: string): Promise<boolean> {
     const resp = await fetch(`/api/projects/${encodeURIComponent(id)}`, {
       method: 'DELETE',
     });
+    // Drop the project's local tab-state cache once it is gone server-side, so
+    // the `open-design:project-tabs:*` keys don't accumulate in localStorage
+    // for the lifetime of the browser profile as projects are deleted.
+    if (resp.ok) removeCachedTabs(id);
     return resp.ok;
   } catch {
     return false;
@@ -666,6 +670,15 @@ function readCachedTabs(projectId: string): OpenTabsState | null {
     return normalizeTabsState(JSON.parse(window.localStorage.getItem(tabsCacheKey(projectId)) ?? 'null'));
   } catch {
     return null;
+  }
+}
+
+function removeCachedTabs(projectId: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(tabsCacheKey(projectId));
+  } catch {
+    // Ignore private-mode/quota errors; the cache entry is best-effort.
   }
 }
 

--- a/apps/web/tests/state/projects.test.ts
+++ b/apps/web/tests/state/projects.test.ts
@@ -4,6 +4,7 @@ import {
   contributeGeneratedPluginToOpenDesign,
   createProject,
   createPluginShareProject,
+  deleteProject,
   importClaudeDesignZip,
   importFolderProject,
   installGeneratedPluginFolder,
@@ -458,5 +459,43 @@ describe('pickLocalFolderPath', () => {
     )));
 
     await expect(pickLocalFolderPath()).rejects.toThrow('cross-origin request rejected');
+  });
+});
+
+describe('deleteProject tabs cache', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const tabsKey = 'open-design:project-tabs:v1:p1';
+
+  function stubWindowStore(): Map<string, string> {
+    const store = new Map<string, string>([[tabsKey, JSON.stringify({ tabs: [], active: null })]]);
+    vi.stubGlobal('window', {
+      localStorage: {
+        getItem: (k: string) => store.get(k) ?? null,
+        setItem: (k: string, v: string) => {
+          store.set(k, v);
+        },
+        removeItem: (k: string) => {
+          store.delete(k);
+        },
+      },
+    });
+    return store;
+  }
+
+  it('prunes the project tabs cache on a successful delete', async () => {
+    const store = stubWindowStore();
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(null, { status: 200 })));
+    await expect(deleteProject('p1')).resolves.toBe(true);
+    expect(store.has(tabsKey)).toBe(false);
+  });
+
+  it('keeps the tabs cache when the delete fails', async () => {
+    const store = stubWindowStore();
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(null, { status: 500 })));
+    await expect(deleteProject('p1')).resolves.toBe(false);
+    expect(store.has(tabsKey)).toBe(true);
   });
 });


### PR DESCRIPTION
## Why

Scratching an itch found while auditing the web client's local-state persistence. `deleteProject()` in `apps/web/src/state/projects.ts` never removed the deleted project's tab-state cache, so `open-design:project-tabs:v1:*` keys accumulated in `localStorage` for the lifetime of the browser profile as projects were deleted.

> Note: this PR was narrowed from an earlier version. The `saveMessage` return-type change has been dropped per review feedback (a failure signal with no consumer does not fix the user-facing bug); it will return as a separate PR that also wires the signal to a user-facing surface. This PR is now the self-contained tab-cache fix only.

## What users will see

No visible change. Tab-cache pruning is invisible — it just stops unbounded `localStorage` growth as projects are deleted.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/state/projects.test.ts` → `describe('deleteProject tabs cache')` (delete success prunes the cache key, delete failure keeps it).
- Did the tests go red on `main` and green on this branch? **yes** — on `main` `deleteProject` leaves the `open-design:project-tabs:v1:<id>` key; on this branch a successful delete prunes it while a failed delete keeps it.

## Validation

- `pnpm --filter @open-design/web test` for `tests/state/projects.test.ts` (green) plus `tsc` on the changed file. Full `pnpm guard` / `pnpm typecheck` left to CI.

---

`deleteProject()` calls a new `removeCachedTabs(id)` helper on a successful DELETE (`if (resp.ok) removeCachedTabs(id)`) to drop the project's `open-design:project-tabs:v1:<id>` entry. The helper is `window`-guarded (SSR-safe) with a `try/catch` around `localStorage.removeItem` (private-mode / quota safe). Cache is preserved on a failed delete, and `resp.ok` is the correct signal — the daemon's DELETE route is idempotent and returns 200 even when the project row is already absent, so it never produces a "project gone" 404 that would need special handling.
