### PR TITLE
fix(web): restore HTML project covers

### DIFF
--- a/apps/web/src/components/DesignsTab.tsx
+++ b/apps/web/src/components/DesignsTab.tsx
@@ -10,7 +10,7 @@ import {
   trackProjectsMorePopoverClick,
 } from "../analytics/events";
 import { useT } from "../i18n";
-import { deleteLiveArtifact, fetchLiveArtifacts, fetchProjectFiles, liveArtifactPreviewUrl, projectFileUrl } from "../providers/registry";
+import { deleteLiveArtifact, fetchLiveArtifacts, fetchProjectFiles, liveArtifactPreviewUrl } from "../providers/registry";
 import type {
 	DesignSystemSummary,
 	LiveArtifactSummary,
@@ -28,6 +28,13 @@ import {
 } from "./design-system-project";
 import { LiveArtifactBadges } from "./LiveArtifactBadges";
 import { Toast } from "./Toast";
+import {
+	HtmlProjectCoverFrame,
+	coverFromProjectFile,
+	projectCoverUrl,
+	selectProjectFileCover,
+	type ProjectCoverOverride,
+} from "./project-cover";
 
 type SubTab = "recent" | "yours";
 type ViewMode = "grid" | "kanban";
@@ -116,7 +123,7 @@ export function DesignsTab({
 		Record<string, LiveArtifactSummary[]>
 	>({});
 	const [coverByProject, setCoverByProject] = useState<
-		Record<string, { kind: "html" | "image" | "video" | "logo"; name: string } | null>
+		Record<string, ProjectCoverOverride | null>
 	>({});
 	const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
 	const [selectMode, setSelectMode] = useState(false);
@@ -197,32 +204,11 @@ export function DesignsTab({
 				if (designSystemProject) {
 					const logo = findDesignSystemLogoFile(files);
 					if (logo) {
-						return [
-							project.id,
-							{ kind: "logo" as const, name: logo.path ?? logo.name },
-						] as const;
+						return [project.id, coverFromProjectFile(logo, "logo")] as const;
 					}
 					return [project.id, null] as const;
 				}
-				const image = files
-					.filter((f) => f.kind === "image")
-					.sort((a, b) => b.mtime - a.mtime)[0];
-				if (image) {
-					return [
-						project.id,
-						{ kind: "image" as const, name: image.path ?? image.name },
-					] as const;
-				}
-				const video = files
-					.filter((f) => f.kind === "video")
-					.sort((a, b) => b.mtime - a.mtime)[0];
-				if (video) {
-					return [
-						project.id,
-						{ kind: "video" as const, name: video.path ?? video.name },
-					] as const;
-				}
-				return [project.id, null] as const;
+				return [project.id, selectProjectFileCover(files)] as const;
 			}),
 		).then((entries) => {
 			if (cancelled) return;
@@ -946,7 +932,13 @@ export function DesignsTab({
 									) : cover.kind === "video" && cover.src ? (
 										<video className="thumb-media" src={cover.src} muted preload="metadata" playsInline />
 									) : cover.kind === "html" ? (
-										<span className="project-thumb-glyph">{cover.initial}</span>
+										<HtmlProjectCoverFrame
+											src={cover.src}
+											initial={cover.initial}
+											iframeClassName="thumb-iframe"
+											glyphClassName="project-thumb-glyph"
+											diagnostic={`${p.id}:${cover.name ?? "unknown"}`}
+										/>
 									) : (
 										<span className="project-thumb-glyph">{cover.initial}</span>
 									)}
@@ -1223,12 +1215,13 @@ function isOrbitProject(project: Project): boolean {
 
 function projectCover(
 	project: Project,
-	override: { kind: "html" | "image" | "video" | "logo"; name: string } | null,
+	override: ProjectCoverOverride | null,
 ): {
 	kind: "image" | "video" | "html" | "logo" | "brand" | "fallback";
 	src?: string;
 	style: CSSProperties;
 	initial: string;
+	name?: string;
 	brandId?: string;
 	brandHost?: string;
 } {
@@ -1260,17 +1253,18 @@ function projectCover(
 	if (override) {
 		return {
 			kind: override.kind,
-			src: projectFileUrl(project.id, override.name),
+			src: projectCoverUrl(project.id, override.name, override.mtime),
 			style,
 			initial,
+			name: override.name,
 		};
 	}
 	const entry = meta?.entryFile;
 	if (entry) {
-		const src = projectFileUrl(project.id, entry);
+		const src = projectCoverUrl(project.id, entry, project.updatedAt);
 		if (meta?.kind === "image") return { kind: "image", src, style, initial };
 		if (meta?.kind === "video") return { kind: "video", src, style, initial };
-		if (/\.html?$/i.test(entry)) return { kind: "html", src, style, initial };
+		if (/\.html?$/i.test(entry)) return { kind: "html", src, style, initial, name: entry };
 	}
 	return { kind: "fallback", style, initial };
 }

--- a/apps/web/src/components/RecentProjectsStrip.tsx
+++ b/apps/web/src/components/RecentProjectsStrip.tsx
@@ -10,11 +10,18 @@ import type { CSSProperties } from 'react';
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { Dialog, DialogDescription, DialogFooter, DialogTitle } from '@open-design/components';
 import { useT } from '../i18n';
-import { fetchProjectFiles, fetchProjectFileText, projectFileUrl } from '../providers/registry';
+import { fetchProjectFiles, fetchProjectFileText } from '../providers/registry';
 import type { DesignSystemSummary, Project, ProjectDisplayStatus, ProjectFile } from '../types';
 import { Icon } from './Icon';
 import { STATUS_LABEL_KEYS } from './DesignsTab';
 import { isDesignSystemProject, isPublishedDesignSystemProject } from './design-system-project';
+import {
+  HtmlProjectCoverFrame,
+  coverFromProjectFile,
+  projectCoverUrl,
+  selectProjectFileCover,
+  type ProjectCoverOverride,
+} from './project-cover';
 
 interface Props {
   projects: Project[];
@@ -92,7 +99,7 @@ export function RecentProjectsStrip({
     [projects, resolvedLimit],
   );
   const [coverByProject, setCoverByProject] = useState<
-    Record<string, { kind: 'html' | 'image' | 'video' | 'logo'; name: string } | null>
+    Record<string, ProjectCoverOverride | null>
   >({});
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
   const [renameTarget, setRenameTarget] = useState<{ id: string; original: string } | null>(null);
@@ -141,36 +148,7 @@ export function RecentProjectsStrip({
           }
           return [project.id, null] as const;
         }
-        const html =
-          files.find((file) => (file.path ?? file.name) === 'index.html') ??
-          files
-            .filter((file) => file.kind === 'html')
-            .sort((a, b) => b.mtime - a.mtime)[0];
-        if (html) {
-          return [
-            project.id,
-            { kind: 'html' as const, name: html.path ?? html.name },
-          ] as const;
-        }
-        const image = files
-          .filter((file) => file.kind === 'image')
-          .sort((a, b) => b.mtime - a.mtime)[0];
-        if (image) {
-          return [
-            project.id,
-            { kind: 'image' as const, name: image.path ?? image.name },
-          ] as const;
-        }
-        const video = files
-          .filter((file) => file.kind === 'video')
-          .sort((a, b) => b.mtime - a.mtime)[0];
-        if (video) {
-          return [
-            project.id,
-            { kind: 'video' as const, name: video.path ?? video.name },
-          ] as const;
-        }
-        return [project.id, null] as const;
+        return [project.id, selectProjectFileCover(files)] as const;
       }),
     ).then((entries) => {
       if (cancelled) return;
@@ -297,7 +275,13 @@ export function RecentProjectsStrip({
                       playsInline
                     />
                   ) : cover.kind === 'html' ? (
-                    <span className="recent-projects__card-glyph">{cover.initial}</span>
+                    <HtmlProjectCoverFrame
+                      src={cover.src}
+                      initial={cover.initial}
+                      iframeClassName="recent-projects__thumb-iframe"
+                      glyphClassName="recent-projects__card-glyph"
+                      diagnostic={`${project.id}:${cover.name ?? 'unknown'}`}
+                    />
                   ) : (
                     <span className="recent-projects__card-glyph">{cover.initial}</span>
                   )}
@@ -462,12 +446,13 @@ function relativeTime(ts: number, t: ReturnType<typeof useT>): string {
 
 function projectCover(
   project: Project,
-  override: { kind: 'html' | 'image' | 'video' | 'logo'; name: string } | null,
+  override: ProjectCoverOverride | null,
 ): {
   kind: 'image' | 'video' | 'html' | 'logo' | 'fallback';
   src?: string;
   style: CSSProperties;
   initial: string;
+  name?: string;
 } {
   let h = 0;
   for (let i = 0; i < project.id.length; i += 1) {
@@ -483,18 +468,19 @@ function projectCover(
   if (override) {
     return {
       kind: override.kind,
-      src: projectFileUrl(project.id, override.name),
+      src: projectCoverUrl(project.id, override.name, override.mtime),
       style,
       initial,
+      name: override.name,
     };
   }
   const meta = project.metadata;
   const entry = meta?.entryFile;
   if (entry) {
-    const src = projectFileUrl(project.id, entry);
+    const src = projectCoverUrl(project.id, entry, project.updatedAt);
     if (meta?.kind === 'image') return { kind: 'image', src, style, initial };
     if (meta?.kind === 'video') return { kind: 'video', src, style, initial };
-    if (/\.html?$/i.test(entry)) return { kind: 'html', src, style, initial };
+    if (/\.html?$/i.test(entry)) return { kind: 'html', src, style, initial, name: entry };
   }
   return { kind: 'fallback', style, initial };
 }
@@ -550,20 +536,20 @@ function findDesignSystemLogoFile(files: ProjectFile[]): ProjectFile | null {
 async function findDesignSystemCover(
   projectId: string,
   files: ProjectFile[],
-): Promise<{ kind: 'image' | 'logo'; name: string } | null> {
-  const knownFiles = new Set(files.map((file) => file.path ?? file.name));
+): Promise<ProjectCoverOverride | null> {
+  const knownFiles = new Map(files.map((file) => [file.path ?? file.name, file]));
   const brandCover = await designSystemCoverFromBrandJson(projectId, knownFiles);
   if (brandCover) return brandCover;
 
   const logo = findDesignSystemLogoFile(files);
   if (!logo) return null;
-  return { kind: 'logo', name: logo.path ?? logo.name };
+  return coverFromProjectFile(logo, 'logo');
 }
 
 async function designSystemCoverFromBrandJson(
   projectId: string,
-  knownFiles: ReadonlySet<string>,
-): Promise<{ kind: 'image' | 'logo'; name: string } | null> {
+  knownFiles: ReadonlyMap<string, ProjectFile>,
+): Promise<ProjectCoverOverride | null> {
   const raw = await fetchProjectFileText(projectId, 'brand.json', { cache: 'no-store' });
   if (!raw) return null;
   let brand: unknown;
@@ -584,7 +570,7 @@ async function designSystemCoverFromBrandJson(
     .map((sample) => typeof sample.file === 'string' ? sample.file : null)
     .filter((file): file is string => Boolean(file));
   const image = samplePaths.find((file) => knownFiles.has(file) && isRasterOrSvgImage(file));
-  if (image) return { kind: 'image', name: image };
+  if (image) return coverFromProjectFile(knownFiles.get(image)!, 'image');
 
   const logo = root.logo && typeof root.logo === 'object' ? root.logo as Record<string, unknown> : null;
   const alternates = Array.isArray(logo?.alternates) ? logo.alternates : [];
@@ -599,9 +585,9 @@ async function designSystemCoverFromBrandJson(
       isRasterOrSvgImage(candidate) &&
       !/(^|\/)favicon[-.]/iu.test(candidate),
   );
-  if (nonFaviconLogo) return { kind: 'logo', name: nonFaviconLogo };
+  if (nonFaviconLogo) return coverFromProjectFile(knownFiles.get(nonFaviconLogo)!, 'logo');
   if (typeof logo?.primary === 'string' && knownFiles.has(logo.primary) && isRasterOrSvgImage(logo.primary)) {
-    return { kind: 'logo', name: logo.primary };
+    return coverFromProjectFile(knownFiles.get(logo.primary)!, 'logo');
   }
   return null;
 }

--- a/apps/web/src/components/project-cover.tsx
+++ b/apps/web/src/components/project-cover.tsx
@@ -60,12 +60,47 @@ export function HtmlProjectCoverFrame({
   diagnostic: string;
 }) {
   const [failed, setFailed] = useState(false);
+  const [verified, setVerified] = useState(false);
 
   useEffect(() => {
-    setFailed(false);
-  }, [src]);
+    if (!src) {
+      setFailed(false);
+      setVerified(false);
+      return;
+    }
 
-  if (!src || failed) {
+    const controller = new AbortController();
+    let disposed = false;
+
+    setFailed(false);
+    setVerified(false);
+
+    fetch(src, { method: 'HEAD', cache: 'no-store', signal: controller.signal })
+      .then((response) => {
+        if (disposed) return;
+        if (response.ok || response.status === 304) {
+          setVerified(true);
+          return;
+        }
+        console.warn(
+          `[project-cover] HTML cover unavailable (${response.status} ${response.statusText}):`,
+          diagnostic,
+        );
+        setFailed(true);
+      })
+      .catch((err) => {
+        if (disposed || (err instanceof DOMException && err.name === 'AbortError')) return;
+        console.warn('[project-cover] failed to verify HTML cover:', diagnostic, err);
+        setFailed(true);
+      });
+
+    return () => {
+      disposed = true;
+      controller.abort();
+    };
+  }, [src, diagnostic]);
+
+  if (!src || failed || !verified) {
     return <span className={glyphClassName}>{initial}</span>;
   }
 

--- a/apps/web/src/components/project-cover.tsx
+++ b/apps/web/src/components/project-cover.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from 'react';
+import { projectFileUrl } from '../providers/registry';
+import type { ProjectFile } from '../types';
+
+export type ProjectCoverKind = 'html' | 'image' | 'video' | 'logo';
+
+export interface ProjectCoverOverride {
+  kind: ProjectCoverKind;
+  name: string;
+  mtime?: number;
+}
+
+export function coverFromProjectFile(
+  file: ProjectFile,
+  kind: ProjectCoverKind = file.kind as ProjectCoverKind,
+): ProjectCoverOverride | null {
+  if (kind !== 'html' && kind !== 'image' && kind !== 'video' && kind !== 'logo') return null;
+  return { kind, name: file.path ?? file.name, mtime: file.mtime };
+}
+
+export function selectProjectFileCover(files: ProjectFile[]): ProjectCoverOverride | null {
+  const html =
+    files.find((file) => (file.path ?? file.name) === 'index.html') ??
+    files
+      .filter((file) => file.kind === 'html')
+      .sort((a, b) => b.mtime - a.mtime)[0];
+  if (html) return coverFromProjectFile(html, 'html');
+
+  const image = files
+    .filter((file) => file.kind === 'image')
+    .sort((a, b) => b.mtime - a.mtime)[0];
+  if (image) return coverFromProjectFile(image, 'image');
+
+  const video = files
+    .filter((file) => file.kind === 'video')
+    .sort((a, b) => b.mtime - a.mtime)[0];
+  if (video) return coverFromProjectFile(video, 'video');
+
+  return null;
+}
+
+export function projectCoverUrl(projectId: string, name: string, version?: number): string {
+  const url = projectFileUrl(projectId, name);
+  if (!Number.isFinite(version) || version === undefined || version <= 0) return url;
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}v=${encodeURIComponent(String(Math.trunc(version)))}`;
+}
+
+export function HtmlProjectCoverFrame({
+  src,
+  initial,
+  iframeClassName,
+  glyphClassName,
+  diagnostic,
+}: {
+  src: string | undefined;
+  initial: string;
+  iframeClassName: string;
+  glyphClassName: string;
+  diagnostic: string;
+}) {
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    setFailed(false);
+  }, [src]);
+
+  if (!src || failed) {
+    return <span className={glyphClassName}>{initial}</span>;
+  }
+
+  return (
+    <iframe
+      className={iframeClassName}
+      src={src}
+      title=""
+      loading="lazy"
+      sandbox="allow-scripts"
+      tabIndex={-1}
+      onError={() => {
+        console.warn('[project-cover] failed to load HTML cover:', diagnostic);
+        setFailed(true);
+      }}
+    />
+  );
+}

--- a/apps/web/tests/components/DesignsTab.select-mode.test.tsx
+++ b/apps/web/tests/components/DesignsTab.select-mode.test.tsx
@@ -9,7 +9,12 @@ import type { Project } from '../../src/types';
 vi.mock('../../src/providers/registry', () => ({
   deleteLiveArtifact: vi.fn(),
   fetchLiveArtifacts: vi.fn(async () => []),
-  fetchProjectFiles: vi.fn(async () => []),
+  fetchProjectFiles: vi.fn(async (projectId: string) => {
+    if (projectId === 'project-html-scan') {
+      return [{ name: 'index.html', kind: 'html', mtime: 300 }];
+    }
+    return [];
+  }),
   liveArtifactPreviewUrl: (projectId: string, artifactId: string) =>
     `/api/projects/${projectId}/live-artifacts/${artifactId}/preview`,
   projectFileUrl: (projectId: string, fileName: string) =>
@@ -74,11 +79,12 @@ describe('DesignsTab select mode', () => {
     });
   });
 
-  it('does not iframe HTML entry files inside project cards', () => {
+  it('renders HTML entry files inside project cards with a refreshable URL', () => {
     const htmlProject: Project = {
       ...project,
       id: 'project-html',
       name: 'WebGL Experience',
+      updatedAt: 700,
       metadata: { kind: 'prototype', entryFile: 'index.html' },
     };
     const { container } = render(
@@ -96,8 +102,38 @@ describe('DesignsTab select mode', () => {
 
     const thumb = container.querySelector('.project-thumb-html');
     expect(thumb).toBeTruthy();
-    expect(thumb?.querySelector('iframe')).toBeNull();
-    expect(thumb?.querySelector('.project-thumb-glyph')).toBeTruthy();
+    expect(thumb?.querySelector('iframe')?.getAttribute('src')).toBe(
+      '/api/projects/project-html/files/index.html?v=700',
+    );
+    expect(thumb?.querySelector('.project-thumb-glyph')).toBeNull();
+  });
+
+  it('uses the same HTML cover source as the recent projects strip when scanning files', async () => {
+    const htmlProject: Project = {
+      ...project,
+      id: 'project-html-scan',
+      name: 'Scanned HTML',
+      metadata: { kind: 'prototype' },
+    };
+    const { container } = render(
+      <DesignsTab
+        projects={[htmlProject]}
+        skills={[]}
+        designSystems={[]}
+        onOpen={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDelete={vi.fn()}
+        onRename={vi.fn()}
+        isActive={false}
+      />,
+    );
+
+    await waitFor(() => {
+      const frame = container.querySelector<HTMLIFrameElement>('.project-thumb-html iframe');
+      expect(frame).toBeTruthy();
+      expect(frame?.getAttribute('src')).toBe('/api/projects/project-html-scan/files/index.html?v=300');
+      expect(container.querySelector('.project-thumb-html .project-thumb-glyph')).toBeNull();
+    });
   });
 
   it('contains refresh failures and returns the toolbar button to idle', async () => {

--- a/apps/web/tests/components/DesignsTab.select-mode.test.tsx
+++ b/apps/web/tests/components/DesignsTab.select-mode.test.tsx
@@ -31,6 +31,16 @@ const project: Project = {
   status: { value: 'not_started' },
 };
 
+function stubCoverProbe(status = 200, statusText = 'OK') {
+  const fetchMock = vi.fn(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+  }) as Response);
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
 describe('DesignsTab select mode', () => {
   beforeAll(() => {
     if (window.localStorage) return;
@@ -48,11 +58,13 @@ describe('DesignsTab select mode', () => {
 
   beforeEach(() => {
     window.localStorage.clear();
+    stubCoverProbe();
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
     cleanup();
   });
 
@@ -79,7 +91,7 @@ describe('DesignsTab select mode', () => {
     });
   });
 
-  it('renders HTML entry files inside project cards with a refreshable URL', () => {
+  it('renders HTML entry files inside project cards with a refreshable URL', async () => {
     const htmlProject: Project = {
       ...project,
       id: 'project-html',
@@ -102,10 +114,12 @@ describe('DesignsTab select mode', () => {
 
     const thumb = container.querySelector('.project-thumb-html');
     expect(thumb).toBeTruthy();
-    expect(thumb?.querySelector('iframe')?.getAttribute('src')).toBe(
-      '/api/projects/project-html/files/index.html?v=700',
-    );
-    expect(thumb?.querySelector('.project-thumb-glyph')).toBeNull();
+    await waitFor(() => {
+      expect(thumb?.querySelector('iframe')?.getAttribute('src')).toBe(
+        '/api/projects/project-html/files/index.html?v=700',
+      );
+      expect(thumb?.querySelector('.project-thumb-glyph')).toBeNull();
+    });
   });
 
   it('uses the same HTML cover source as the recent projects strip when scanning files', async () => {

--- a/apps/web/tests/components/RecentProjectsStrip.test.tsx
+++ b/apps/web/tests/components/RecentProjectsStrip.test.tsx
@@ -78,6 +78,16 @@ function projects(count: number): Project[] {
   );
 }
 
+function stubCoverProbe(status = 200, statusText = 'OK') {
+  const fetchMock = vi.fn(async () => ({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+  }) as Response);
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
 describe('RecentProjectsStrip', () => {
   it('shows seven projects when the row has room for a seventh card', async () => {
     vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function getRect(this: HTMLElement) {
@@ -173,6 +183,8 @@ describe('RecentProjectsStrip', () => {
   });
 
   it('matches project cards with previews and design-system tags', async () => {
+    stubCoverProbe();
+
     const { container } = render(
       <RecentProjectsStrip
         projects={[
@@ -244,8 +256,7 @@ describe('RecentProjectsStrip', () => {
   });
 
   it('renders HTML and deck covers from the current file URL', async () => {
-    const fetchMock = vi.fn();
-    vi.stubGlobal('fetch', fetchMock);
+    const fetchMock = stubCoverProbe();
 
     const { container } = render(
       <RecentProjectsStrip
@@ -280,6 +291,42 @@ describe('RecentProjectsStrip', () => {
       expect(deckCard?.querySelector('.recent-projects__card-glyph')).toBeNull();
       expect(htmlCard?.querySelector('.recent-projects__card-glyph')).toBeNull();
     });
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/projects/project-deck/files/index.html?v=400',
+      expect.objectContaining({ cache: 'no-store', method: 'HEAD' }),
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/projects/project-html/files/index.html?v=200',
+      expect.objectContaining({ cache: 'no-store', method: 'HEAD' }),
+    );
+  });
+
+  it('falls back to the glyph and logs when an HTML cover is unavailable', async () => {
+    stubCoverProbe(404, 'Not Found');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { container } = render(
+      <RecentProjectsStrip
+        projects={[
+          project({
+            id: 'project-html',
+            name: 'Web Prototype',
+            updatedAt: 3,
+          }),
+        ]}
+        onOpen={() => {}}
+        onViewAll={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      const htmlThumb = container.querySelector('.recent-projects__card-thumb-html');
+      expect(htmlThumb?.querySelector('iframe')).toBeNull();
+      expect(htmlThumb?.querySelector('.recent-projects__card-glyph')?.textContent).toBe('W');
+      expect(warn).toHaveBeenCalledWith(
+        '[project-cover] HTML cover unavailable (404 Not Found):',
+        'project-html:index.html',
+      );
+    });
   });
 });

--- a/apps/web/tests/components/RecentProjectsStrip.test.tsx
+++ b/apps/web/tests/components/RecentProjectsStrip.test.tsx
@@ -38,10 +38,10 @@ vi.mock('../../src/providers/registry', () => ({
       ];
     }
     if (projectId === 'project-html') {
-      return [{ name: 'index.html', kind: 'html', mtime: 2 }];
+      return [{ name: 'index.html', kind: 'html', mtime: 200 }];
     }
     if (projectId === 'project-deck') {
-      return [{ name: 'index.html', kind: 'html', mtime: 2 }];
+      return [{ name: 'index.html', kind: 'html', mtime: 400 }];
     }
     return [];
   }),
@@ -205,10 +205,12 @@ describe('RecentProjectsStrip', () => {
     await waitFor(() => {
       expect(designSystemCard?.querySelector('.recent-projects__card-thumb-image img')).toBeTruthy();
       expect(designSystemCard?.querySelector('img')?.getAttribute('src')).toBe(
-        '/api/projects/project-ds/files/imagery/cover-0.png',
+        '/api/projects/project-ds/files/imagery/cover-0.png?v=3',
       );
-      expect(container.querySelector('.recent-projects__card-thumb-html iframe')).toBeNull();
-      expect(container.querySelector('.recent-projects__card-thumb-html .recent-projects__card-glyph')).toBeTruthy();
+      const htmlFrame = container.querySelector<HTMLIFrameElement>('.recent-projects__card-thumb-html iframe');
+      expect(htmlFrame).toBeTruthy();
+      expect(htmlFrame?.getAttribute('src')).toBe('/api/projects/project-html/files/index.html?v=200');
+      expect(container.querySelector('.recent-projects__card-thumb-html .recent-projects__card-glyph')).toBeNull();
     });
   });
 
@@ -236,12 +238,12 @@ describe('RecentProjectsStrip', () => {
     await waitFor(() => {
       expect(designSystemCard?.querySelector('.recent-projects__card-thumb-logo img')).toBeTruthy();
       expect(designSystemCard?.querySelector('img')?.getAttribute('src')).toBe(
-        '/api/projects/project-ds-fallback/files/logos/wordmark.svg',
+        '/api/projects/project-ds-fallback/files/logos/wordmark.svg?v=3',
       );
     });
   });
 
-  it('does not run HTML or deck previews inside recent project cards', async () => {
+  it('renders HTML and deck covers from the current file URL', async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);
 
@@ -269,10 +271,14 @@ describe('RecentProjectsStrip', () => {
     const htmlCard = container.querySelector('[data-project-id="project-html"]');
 
     await waitFor(() => {
-      expect(deckCard?.querySelector('iframe')).toBeNull();
-      expect(htmlCard?.querySelector('iframe')).toBeNull();
-      expect(deckCard?.querySelector('.recent-projects__card-glyph')).toBeTruthy();
-      expect(htmlCard?.querySelector('.recent-projects__card-glyph')).toBeTruthy();
+      expect(deckCard?.querySelector('iframe')?.getAttribute('src')).toBe(
+        '/api/projects/project-deck/files/index.html?v=400',
+      );
+      expect(htmlCard?.querySelector('iframe')?.getAttribute('src')).toBe(
+        '/api/projects/project-html/files/index.html?v=200',
+      );
+      expect(deckCard?.querySelector('.recent-projects__card-glyph')).toBeNull();
+      expect(htmlCard?.querySelector('.recent-projects__card-glyph')).toBeNull();
     });
     expect(fetchMock).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
Source issue: https://plane.powerformer.net/open-design/projects/49832a02-3158-4faf-bf2f-d0e39c40c7e6/issues/33b16dc4-88e4-4f00-803d-fb2a7828d4d8

## Why

This fixes the 0.15.0 acceptance regression where generated HTML projects showed only gradient letter placeholders in Home → Recent projects and the full Projects list. The root cause was that the card cover path selected HTML files inconsistently, threw away file mtimes, and rendered `html` covers as glyph fallbacks instead of loading the project artifact.

## What users will see

HTML projects in both Recent projects and Projects now show the generated HTML artifact as the card cover. Regenerating or refreshing a project uses a versioned cover URL so a current thumbnail is not replaced by stale cached content. If the HTML cover fails to load, the card falls back to the existing letter glyph and logs the failed project/file for diagnosis.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached; this branch was validated with focused jsdom component coverage for the card rendering paths rather than a running browser screenshot.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/RecentProjectsStrip.test.tsx` and `apps/web/tests/components/DesignsTab.select-mode.test.tsx`
- Did the test go red on `main` and green on this branch? yes. The updated focused specs failed before the source fix because HTML covers rendered as glyphs, Projects did not scan HTML files, and cover URLs lacked file-version cache busting; they pass after the fix.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/components/RecentProjectsStrip.test.tsx tests/components/DesignsTab.select-mode.test.tsx` (from `apps/web`)
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`

Note: local commands emitted the existing Node engine warning because this shell is running Node v22.22.0 while the repo targets Node ~24; commands still completed successfully.

<!-- looper:stamp v=1 -->
<sub>🔁 Powered by <a href="https://github.com/nexu-io/looper">Looper</a> · runner=worker · agent=codex · An autonomous AI dev team for your GitHub repos.</sub>