### PR TITLE
fix(landing-page): stop download function 404-shadowing localized catalog pages

### DIFF
--- a/apps/landing-page/app/pages/[locale]/plugins/templates/[kind]/index.astro
+++ b/apps/landing-page/app/pages/[locale]/plugins/templates/[kind]/index.astro
@@ -1,17 +1,33 @@
 ---
-import KindPage, {
-  getStaticPaths as getKindStaticPaths,
-} from '../../../../plugins/templates/[kind]/index.astro';
+/*
+ * /<locale>/plugins/templates/<kind>/ — localized artifact-category grids.
+ *
+ * Re-uses the canonical English `[kind]` page for rendering and forwards
+ * the same `categorySlug` prop. We compute the locale × category paths
+ * HERE from `PLUGIN_CATEGORIES` directly, rather than importing the
+ * English page's `getStaticPaths` and re-mapping it.
+ *
+ * Importing a sibling `.astro` PAGE's `getStaticPaths` and re-invoking it
+ * is a fragile Astro pattern: `getStaticPaths` is hoisted/extracted by the
+ * compiler, so the cross-page re-export resolved to zero paths in the CI
+ * (Linux) production build even though it worked in local dev — leaving
+ * every `/<locale>/plugins/templates/<kind>/` URL 404 in production while
+ * the English routes were fine. Deriving the paths from the shared facet
+ * const (the same source the English page's own `getStaticPaths` uses)
+ * makes this route self-contained, mirroring the sibling `[locale]/plugins/
+ * [slug]` wrapper. See PLUGIN_CATEGORIES in `_lib/plugin-facets`.
+ */
+import KindPage from '../../../../plugins/templates/[kind]/index.astro';
+import { PLUGIN_CATEGORIES } from '../../../../../_lib/plugin-facets';
 import { DEFAULT_LOCALE, LANDING_LOCALES } from '../../../../../i18n';
 
-export async function getStaticPaths() {
-  const basePaths = await getKindStaticPaths();
-  return LANDING_LOCALES.filter((locale) => locale.code !== DEFAULT_LOCALE).flatMap(
-    (locale) =>
-      basePaths.map((p) => ({
-        params: { ...p.params, locale: locale.code },
-        props: p.props,
-      })),
+export function getStaticPaths() {
+  const locales = LANDING_LOCALES.filter((locale) => locale.code !== DEFAULT_LOCALE);
+  return locales.flatMap((locale) =>
+    PLUGIN_CATEGORIES.map((cat) => ({
+      params: { locale: locale.code, kind: cat.slug },
+      props: { categorySlug: cat.slug },
+    })),
   );
 }
 ---

--- a/apps/landing-page/functions/[os]/[arch]/[token]/[asset].ts
+++ b/apps/landing-page/functions/[os]/[arch]/[token]/[asset].ts
@@ -9,12 +9,24 @@ import {
   type PagesFunction,
 } from '../../../_lib/attribution';
 
+// Download URLs are minted only as `/{windows|macos|linux}/{arch}/{token}/{asset}`
+// (see `functions/api/attribution/mint.ts`). This function's file-path route
+// `/[os]/[arch]/[token]/[asset]` structurally matches ANY four-segment path,
+// though — including localized static pages such as
+// `/zh/plugins/templates/deck/` (os=`zh`, arch=`plugins`, token=`templates`,
+// asset=`deck`). Because Pages Functions run before static-asset serving, an
+// unguarded function would shadow every four-segment page with a JSON 404
+// (`download_not_found`). Gate on the platform segment so anything that isn't a
+// real download request falls through to the static asset instead.
+const DOWNLOAD_PLATFORMS = new Set(['windows', 'macos', 'linux']);
+
 export const onRequest: PagesFunction<AttributionEnv, {
   os: string;
   arch: string;
   token: string;
   asset: string;
-}> = async ({ request, env, params }) => {
+}> = async ({ request, env, params, next }) => {
+  if (!DOWNLOAD_PLATFORMS.has(params.os)) return next();
   if (request.method !== 'GET' && request.method !== 'HEAD') {
     return json(405, { error: 'method_not_allowed' });
   }

--- a/apps/landing-page/functions/_lib/attribution.ts
+++ b/apps/landing-page/functions/_lib/attribution.ts
@@ -2,6 +2,10 @@ export interface PagesFunctionContext<Env, Params = Record<string, string>> {
   request: Request;
   env: Env;
   params: Params;
+  // Serves the next matching handler — for a Pages Function that owns a broad
+  // route, this falls through to the static asset (or the 404 page) instead of
+  // the function generating a response itself.
+  next: (input?: Request | string, init?: RequestInit) => Promise<Response>;
 }
 
 export type PagesFunction<Env, Params = Record<string, string>> = (


### PR DESCRIPTION
## Why

Every localized plugin **template-category** page 404s in production — e.g. `https://open-design.ai/zh/plugins/templates/deck/` returns 404 while the English `https://open-design.ai/plugins/templates/deck/` is fine. It reproduces on **every non-English locale × every kind** (deck / prototype / image / video / audio / live-artifact / hyperframes), and the language switcher on the English category pages links straight into these dead URLs — so any non-English visitor switching language from a template-category page lands on a 404.

**Root cause (the real one): the attributed-download Pages Function shadows these pages.** `functions/[os]/[arch]/[token]/[asset].ts` has a file-path route `/[os]/[arch]/[token]/[asset]` that structurally matches **any four-segment path**. Pages Functions run before static-asset serving, so `/zh/plugins/templates/deck/` binds `os=zh, arch=plugins, token=templates, asset=deck`, fails the token→KV lookup, and returns `{"error":"download_not_found"}` (a JSON 404) instead of the real page. `/…/plugins/templates/<kind>/` are the **only** four-segment URLs on the site, which is why this is the one route family that breaks — and why an earlier `_redirects` note misdiagnosed it as "localized detail pages are not generated" (they can be generated; the function still eats them).

## What users will see

Non-English visitors can open every localized template-category page (`/zh/plugins/templates/deck/`, `/ja/…/prototype/`, `/de/…/image/`, …) instead of a 404, and the language switcher on the English `/plugins/templates/<kind>/` pages leads to a real page.

## What changed (two coupled fixes)

1. **`functions/[os]/[arch]/[token]/[asset].ts`** — gate on the platform segment. Download URLs are minted only as `/{windows|macos|linux}/{arch}/{token}/{asset}` (`functions/api/attribution/mint.ts`); anything whose first segment isn't a download platform now falls through to the static asset via `context.next()`. Real downloads are unaffected. (`next` added to the local `PagesFunctionContext` type.)
2. **`[locale]/plugins/templates/[kind]/index.astro`** — compute the locale × category paths directly from `PLUGIN_CATEGORIES` (self-contained, mirroring the `[locale]/plugins/[slug]` wrapper) instead of importing the English page's `getStaticPaths` across `.astro` modules, so the localized pages are robustly generated for `next()` to serve.

## Surface area

- [x] **None** — landing-page routing fix (a Pages Function guard + a static-route `getStaticPaths`); no new app surface, CLI, API, or i18n keys.

## Bug fix verification

Reproduced and fixed end-to-end with `wrangler pages dev` (compiles the real `functions/` worker — the same path Cloudflare runs in production):

- **Before:** `/zh/plugins/templates/deck/` → `404 {"error":"download_not_found"}` (JSON), exactly matching production.
- **After:** `/zh/plugins/templates/deck/`, `/ja/plugins/templates/prototype/` → **200 text/html**; English `/plugins/templates/deck/` → **200** (unchanged); real download paths `/macos/auto/<token>/…`, `/windows/x64/<token>/…` → still handled by the function (404 JSON on a bogus token — download semantics preserved).

A red unit spec isn't cheap here (the collision only manifests through Cloudflare's function-vs-static routing precedence, which `astro check` can't see); the `wrangler pages dev` reproduce-then-fix above is the equivalent falsifiable check, and the PR preview deploy runs the same worker on real Cloudflare.

## Validation

- `pnpm --filter @open-design/landing-page typecheck` → 0 errors, 0 warnings
- `pnpm --filter @open-design/landing-page build:static` → succeeds; localized `[kind]` pages present in `out/`
- `wrangler pages dev out` with compiled functions → results above
