### PR TITLE
fix(updater): quiet Windows payload extraction

### DIFF
--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -1233,10 +1233,24 @@ async function defaultExtractLauncherPayloadArchive(input: LauncherPayloadExtrac
     return;
   }
   if (input.platform === "win32") {
-    await execFileAsync(input.extractorPath ?? "7z", ["x", "-y", `-o${input.destinationRoot}`, input.archivePath], { windowsHide: true });
+    await execFileAsync(input.extractorPath ?? "7z", windowsLauncherPayloadExtractArgs(input), { windowsHide: true });
     return;
   }
   throw new Error(`launcher payload extraction is not supported on ${input.platform}`);
+}
+
+export function windowsLauncherPayloadExtractArgs(
+  input: Pick<LauncherPayloadExtractInput, "archivePath" | "destinationRoot">,
+): string[] {
+  return [
+    "x",
+    "-y",
+    "-bso0",
+    "-bsp0",
+    "-bse2",
+    `-o${input.destinationRoot}`,
+    input.archivePath,
+  ];
 }
 
 async function assertPreparedLauncherPayloadRelease(input: {

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -27,6 +27,7 @@ import {
   createDesktopUpdaterScheduler,
   DESKTOP_UPDATE_ENV,
   resolveDesktopUpdaterConfig,
+  windowsLauncherPayloadExtractArgs,
 } from "../../src/main/updater.js";
 import { installerObservationSummaryPath } from "../../src/main/installer-observations.js";
 
@@ -292,6 +293,21 @@ async function writeReleaseFixture(root: string, key: string, channel: FixtureCh
 }
 
 describe("desktop updater", () => {
+  it("silences Windows launcher payload extraction without hiding 7z errors", () => {
+    expect(windowsLauncherPayloadExtractArgs({
+      archivePath: "C:\\updates\\payload.7z",
+      destinationRoot: "C:\\updates\\staging",
+    })).toEqual([
+      "x",
+      "-y",
+      "-bso0",
+      "-bsp0",
+      "-bse2",
+      "-oC:\\updates\\staging",
+      "C:\\updates\\payload.7z",
+    ]);
+  });
+
   it("derives installer observation summary paths from safe flow ids only", () => {
     const root = makeRoot();
     try {

--- a/tools/pack/src/win/payload.ts
+++ b/tools/pack/src/win/payload.ts
@@ -57,6 +57,24 @@ export function buildWinLauncherPayloadManifest(input: {
   };
 }
 
+export type WinLauncherPayloadScratchPaths = {
+  overlayRoot: string;
+  root: string;
+  stageRoot: string;
+};
+
+export async function createWinLauncherPayloadScratchPaths(
+  outputPlatformRoot: string,
+): Promise<WinLauncherPayloadScratchPaths> {
+  await mkdir(outputPlatformRoot, { recursive: true });
+  const root = await mkdtemp(join(outputPlatformRoot, ".p-"));
+  return {
+    overlayRoot: join(root, "o"),
+    root,
+    stageRoot: join(root, "s"),
+  };
+}
+
 function logWinPayloadProgress(message: string, fields: Record<string, unknown> = {}): void {
   const suffix = Object.entries(fields)
     .map(([key, value]) => `${key}=${String(value)}`)
@@ -82,9 +100,10 @@ export async function buildWinLauncherPayloadArchive(
     root: launcherRoot,
     version: packagedVersion,
   });
-  const stageRoot = join(dirname(paths.launcherPayloadPath), "stage");
+  const scratch = await createWinLauncherPayloadScratchPaths(config.roots.output.platformRoot);
+  const stageRoot = scratch.stageRoot;
   const payloadRoot = join(stageRoot, "payload");
-  const overlayRoot = join(dirname(paths.launcherPayloadPath), "overlay");
+  const overlayRoot = scratch.overlayRoot;
   const manifest = buildWinLauncherPayloadManifest({
     channel,
     namespace: config.namespace,
@@ -191,99 +210,102 @@ export async function buildWinLauncherPayloadArchive(
     });
   };
 
-  await runSegment("launcher-payload:prepare", async () => {
-    await rm(stageRoot, { force: true, recursive: true });
-    await rm(overlayRoot, { force: true, recursive: true });
-    await rm(paths.launcherPayloadPath, { force: true });
-    await mkdir(dirname(paths.launcherPayloadPath), { recursive: true });
-  });
-
-  if (cache == null) {
-    await runSegment("launcher-payload:stage", async () => {
-      await createPayloadArchive(paths.launcherPayloadPath);
+  try {
+    await runSegment("launcher-payload:prepare", async () => {
+      await rm(stageRoot, { force: true, recursive: true });
+      await rm(overlayRoot, { force: true, recursive: true });
+      await rm(paths.launcherPayloadPath, { force: true });
+      await mkdir(dirname(paths.launcherPayloadPath), { recursive: true });
     });
-  } else {
-    const sourceKey = builtApp.cacheEntryPath == null
-      ? await runSegment("launcher-payload:base-input-hash", async () => hashPath(builtApp.unpackedRoot))
-      : `cache-entry:${builtApp.cacheEntryPath}`;
-    const configBody = await readFile(paths.packagedConfigPath, "utf8");
-    let baseArchivePath: string | null = null;
-    const usesInstallerSeed = options.seedFromInstallerPayload === true && await pathExists(paths.installerBasePayloadPath);
-    if (!usesInstallerSeed) {
-      const baseNode = {
+
+    if (cache == null) {
+      await runSegment("launcher-payload:stage", async () => {
+        await createPayloadArchive(paths.launcherPayloadPath);
+      });
+    } else {
+      const sourceKey = builtApp.cacheEntryPath == null
+        ? await runSegment("launcher-payload:base-input-hash", async () => hashPath(builtApp.unpackedRoot))
+        : `cache-entry:${builtApp.cacheEntryPath}`;
+      const configBody = await readFile(paths.packagedConfigPath, "utf8");
+      let baseArchivePath: string | null = null;
+      const usesInstallerSeed = options.seedFromInstallerPayload === true && await pathExists(paths.installerBasePayloadPath);
+      if (!usesInstallerSeed) {
+        const baseNode = {
+          build: async ({ entryRoot }: { entryRoot: string }): Promise<{ createdAt: string; sourceKey: string }> => {
+            await createBaseArchive(join(entryRoot, "payload-base.7z"));
+            return { createdAt: new Date().toISOString(), sourceKey };
+          },
+          id: "win.launcher-payload-base",
+          invalidate: async () => null,
+          key: hashJson({
+            cacheVersion: WIN_LAUNCHER_PAYLOAD_BASE_CACHE_VERSION,
+            channel,
+            namespace: config.namespace,
+            node: "win.launcher-payload-base",
+            sourceKey,
+          }),
+          outputs: ["payload-base.7z"],
+        };
+        await runSegment("launcher-payload:base-cache", async () => {
+          const cached = await cache.acquire({
+            materialize: [],
+            node: baseNode,
+          });
+          baseArchivePath = join(cached.entryPath, "payload-base.7z");
+        });
+      }
+
+      const archiveNode = {
         build: async ({ entryRoot }: { entryRoot: string }): Promise<{ createdAt: string; sourceKey: string }> => {
-          await createBaseArchive(join(entryRoot, "payload-base.7z"));
+          const outputPath = join(entryRoot, "payload.7z");
+          if (usesInstallerSeed) {
+            if (!(await createArchiveFromInstallerBase(outputPath))) {
+              throw new Error("missing Windows NSIS base payload for launcher payload seed");
+            }
+          } else {
+            if (baseArchivePath == null) throw new Error("missing Windows launcher payload base cache path");
+            await cp(baseArchivePath, outputPath);
+            await writeOverlay({ includeExecutable: false });
+            await execFileAsync(winResources.sevenZipExe, ["u", "-t7z", outputPath, ".\\*"], {
+              cwd: overlayRoot,
+              windowsHide: true,
+            });
+          }
           return { createdAt: new Date().toISOString(), sourceKey };
         },
-        id: "win.launcher-payload-base",
+        id: "win.launcher-payload",
         invalidate: async () => null,
         key: hashJson({
-          cacheVersion: WIN_LAUNCHER_PAYLOAD_BASE_CACHE_VERSION,
+          baseCacheVersion: WIN_LAUNCHER_PAYLOAD_BASE_CACHE_VERSION,
+          cacheVersion: WIN_LAUNCHER_PAYLOAD_ARCHIVE_CACHE_VERSION,
           channel,
+          configBody,
+          manifest,
           namespace: config.namespace,
-          node: "win.launcher-payload-base",
+          node: "win.launcher-payload",
+          seed: usesInstallerSeed ? "nsis-base" : "launcher-base",
           sourceKey,
         }),
-        outputs: ["payload-base.7z"],
+        outputs: ["payload.7z"],
       };
-      await runSegment("launcher-payload:base-cache", async () => {
-        const cached = await cache.acquire({
-          materialize: [],
-          node: baseNode,
+      await runSegment("launcher-payload:archive-cache", async () => {
+        await cache.acquire({
+          materialize: [{ from: "payload.7z", reuse: true, to: paths.launcherPayloadPath }],
+          node: archiveNode,
         });
-        baseArchivePath = join(cached.entryPath, "payload-base.7z");
       });
     }
-
-    const archiveNode = {
-      build: async ({ entryRoot }: { entryRoot: string }): Promise<{ createdAt: string; sourceKey: string }> => {
-        const outputPath = join(entryRoot, "payload.7z");
-        if (usesInstallerSeed) {
-          if (!(await createArchiveFromInstallerBase(outputPath))) {
-            throw new Error("missing Windows NSIS base payload for launcher payload seed");
-          }
-        } else {
-          if (baseArchivePath == null) throw new Error("missing Windows launcher payload base cache path");
-          await cp(baseArchivePath, outputPath);
-          await writeOverlay({ includeExecutable: false });
-          await execFileAsync(winResources.sevenZipExe, ["u", "-t7z", outputPath, ".\\*"], {
-            cwd: overlayRoot,
-            windowsHide: true,
-          });
-        }
-        return { createdAt: new Date().toISOString(), sourceKey };
-      },
-      id: "win.launcher-payload",
-      invalidate: async () => null,
-      key: hashJson({
-        baseCacheVersion: WIN_LAUNCHER_PAYLOAD_BASE_CACHE_VERSION,
-        cacheVersion: WIN_LAUNCHER_PAYLOAD_ARCHIVE_CACHE_VERSION,
-        channel,
-        configBody,
-        manifest,
-        namespace: config.namespace,
-        node: "win.launcher-payload",
-        seed: usesInstallerSeed ? "nsis-base" : "launcher-base",
-        sourceKey,
-      }),
-      outputs: ["payload.7z"],
-    };
-    await runSegment("launcher-payload:archive-cache", async () => {
-      await cache.acquire({
-        materialize: [{ from: "payload.7z", reuse: true, to: paths.launcherPayloadPath }],
-        node: archiveNode,
-      });
+    await runSegment("launcher-payload:stat", async () => {
+      const archive = await stat(paths.launcherPayloadPath);
+      if (archive.size <= 0) throw new Error(`Windows launcher payload archive is empty: ${paths.launcherPayloadPath}`);
     });
+    await runSegment("launcher-payload:cleanup", async () => {
+      await rm(scratch.root, { force: true, recursive: true });
+    });
+    return timings;
+  } finally {
+    await rm(scratch.root, { force: true, recursive: true }).catch(() => undefined);
   }
-  await runSegment("launcher-payload:stat", async () => {
-    const archive = await stat(paths.launcherPayloadPath);
-    if (archive.size <= 0) throw new Error(`Windows launcher payload archive is empty: ${paths.launcherPayloadPath}`);
-  });
-  await runSegment("launcher-payload:cleanup", async () => {
-    await rm(stageRoot, { force: true, recursive: true });
-    await rm(overlayRoot, { force: true, recursive: true });
-  });
-  return timings;
 }
 
 function requirePayloadManifestValue(value: unknown, name: string, expected: unknown): void {

--- a/tools/pack/tests/launcher-payload.test.ts
+++ b/tools/pack/tests/launcher-payload.test.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
-import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { promisify } from "node:util";
 
 import { LAUNCHER_SCHEMA_VERSION } from "@open-design/launcher-proto";
@@ -19,6 +19,7 @@ import { winResources } from "../src/resources.js";
 import {
   buildWinLauncherPayloadArchive,
   buildWinLauncherPayloadManifest,
+  createWinLauncherPayloadScratchPaths,
   validateWinLauncherPayloadArchive,
 } from "../src/win/payload.js";
 import type { WinBuiltAppManifest, WinPaths } from "../src/win/types.js";
@@ -203,6 +204,27 @@ async function writeFakeWinUnpackedApp(root: string, namespace: string, version:
 }
 
 describe("tools-pack launcher payload archives", () => {
+  it("uses a short same-volume scratch root for Windows payload builds", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-tools-pack-win-scratch-"));
+    try {
+      const config = makeConfig(root, "win", "release-prerelease-win", "0.15.1-prerelease.9");
+      const scratch = await createWinLauncherPayloadScratchPaths(config.roots.output.platformRoot);
+      try {
+        expect(dirname(scratch.root)).toBe(config.roots.output.platformRoot);
+        expect(basename(scratch.root)).toMatch(/^\.p-/);
+        expect(scratch.stageRoot).toBe(join(scratch.root, "s"));
+        expect(scratch.overlayRoot).toBe(join(scratch.root, "o"));
+        expect(scratch.stageRoot.length).toBeLessThan(
+          join(config.roots.output.namespaceRoot, "payload", "stage").length,
+        );
+      } finally {
+        await rm(scratch.root, { force: true, recursive: true });
+      }
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
   it("builds channel and namespace scoped payload manifests for both desktop platforms", () => {
     const macIdentity = resolveMacInstallIdentity({ appVersion: "0.9.0-beta.2", namespace: "release-beta" });
 
@@ -284,6 +306,7 @@ describe("tools-pack launcher payload archives", () => {
       const config = makeConfig(root, "win", namespace, version);
       const { builtApp, paths } = await writeFakeWinUnpackedApp(root, namespace, version);
       await buildWinLauncherPayloadArchive(config, paths, builtApp);
+      expect((await readdir(config.roots.output.platformRoot)).filter((entry) => entry.startsWith(".p-"))).toEqual([]);
 
       const extractRoot = join(root, "extracted");
       await mkdir(extractRoot, { recursive: true });


### PR DESCRIPTION
## Why

Windows auto-update payload extraction can exceed Node's default 1 MiB `execFile` stdout buffer because 7z prints every extracted path. The resulting extraction failure prevents the launcher payload from being prepared and blocks the upgrade.

This PR is a focused prerelease hotfix: suppress routine 7z output at the desktop execution boundary and shorten tools-pack's Windows payload scratch paths without changing release identity, archive contents, final artifact paths, or launcher protocol.

## What users will see

Windows auto-updates no longer fail while preparing a launcher payload solely because 7z produced too much routine output. Packaged artifacts and the update UI remain unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; there is no UI change.

## Bug fix verification

- Test paths: `apps/desktop/tests/main/updater.test.ts` and `tools/pack/tests/launcher-payload.test.ts`
- Both new specs went red on `main` before the source changes and green on this branch.
- The desktop spec locks the quiet 7z stream routing (`-bso0 -bsp0 -bse2`); the tools-pack specs lock the short same-volume scratch layout and successful cleanup.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm guard` (passed from a clean worktree; the primary worktree contains unrelated ignored `apps/.od` and `e2e/.tmp` artifacts)
- `pnpm typecheck`
- `pnpm --filter @open-design/desktop typecheck`
- `pnpm --filter @open-design/tools-pack typecheck`
- `pnpm --filter @open-design/desktop build`
- `pnpm --filter @open-design/tools-pack build`
- `pnpm --filter @open-design/tools-pack test` — 238 passed, 8 Windows-only skipped
- Focused desktop 7z regression spec — passed
- `pnpm --filter @open-design/desktop test` — 227 passed, 1 unrelated baseline failure in `cleans deprecated launcher payload versions on cold start from the launcher cleanup descriptor`; the same assertion fails on `origin/main`
- Windows-native archive execution remains covered by the Windows CI/prerelease validation chain.
