### PR TITLE
fix: harden Windows NSIS packaging and classify Gemini 429 quota failures

### DIFF
--- a/apps/daemon/src/agent-protocol/acp/updates.ts
+++ b/apps/daemon/src/agent-protocol/acp/updates.ts
@@ -156,8 +156,8 @@ export function promotedAmrRetryStatusPayload(update: JsonObject) {
  * @returns A structured error payload, or `null` when not applicable.
  */
 export function promotedAmrStderrPayload(chunk: string) {
-  if (!/opencode_event_stream_failure|session\.status/i.test(chunk)) return null;
-  if (!/\bretry\b/i.test(chunk)) return null;
+  if (!/opencode_event_stream_failure|session\.status|agent\.conversation_loop/i.test(chunk)) return null;
+  if (!/\bretry(ing)?\b/i.test(chunk)) return null;
   const failure = classifyAmrAccountFailure(chunk);
   if (!failure) return null;
   return {

--- a/apps/daemon/src/integrations/vela-errors.ts
+++ b/apps/daemon/src/integrations/vela-errors.ts
@@ -64,6 +64,10 @@ function containsInsufficientBalanceSignal(value: string): boolean {
   return value.includes('quota') && /\b(wallet|balance|credit|billing|funds?)\b/.test(value);
 }
 
+function containsGeminiQuotaSignal(value: string): boolean {
+  return value.includes('gemini http 429') && value.includes('resource_exhausted');
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
@@ -129,6 +133,15 @@ export function classifyAmrAccountFailureSignal(
 export function classifyAmrAccountFailure(text: string): AmrAccountFailure | null {
   const value = normalizeFailureText(text);
   if (!value.trim()) return null;
+
+  if (containsGeminiQuotaSignal(value)) {
+    return {
+      code: 'AMR_INSUFFICIENT_BALANCE',
+      message: 'Your Google Gemini API key has exceeded its quota or free tier limit. Check your plan and billing details at https://aistudio.google.com/apikey, or switch to a different model.',
+      action: 'recharge',
+      actionUrl: 'https://aistudio.google.com/apikey',
+    };
+  }
 
   if (containsInsufficientBalanceSignal(value)) {
     return {

--- a/tools/pack/src/win/custom-installer.ts
+++ b/tools/pack/src/win/custom-installer.ts
@@ -34,7 +34,7 @@ const WIN_NSIS_OVERLAY_RELATIVE_PATHS = [
 ] as const;
 
 export const WIN_PAYLOAD_SEVEN_Z_CREATE_ARGS = ["-t7z", "-m0=LZMA2", "-mx=1", "-mf=off"] as const;
-const WIN_NSIS_PAYLOAD_SEVEN_Z_TIMEOUT_MS = 300_000;
+const WIN_NSIS_PAYLOAD_SEVEN_Z_TIMEOUT_MS = 1_200_000; // increased from 300s to 20min for large builds
 
 function escapeNsisString(value: string): string {
   return value.replace(/\$/g, "$$").replace(/"/g, '$\\"').replace(/\r?\n/g, "$\\r$\\n");
@@ -307,11 +307,15 @@ async function findElectronBuilderMakensis(config: ToolPackConfig): Promise<stri
     const direct = await findFirstExistingPath([
       join(cacheRoot, "nsis", "nsis-3.0.4.1-nsis-3.0.4.1", "makensis.exe"),
       join(cacheRoot, "nsis", "nsis-3.0.4.1-nsis-3.0.4.1", "Bin", "makensis.exe"),
+      // Fallback for installations where folder name does not have the duplicated suffix
+      join(cacheRoot, "nsis", "nsis-3.0.4.1", "makensis.exe"),
+      join(cacheRoot, "nsis", "nsis-3.0.4.1", "Bin", "makensis.exe"),
     ]);
     if (direct != null) return direct;
   }
   return null;
 }
+
 
 async function resolveMakensisCommand(config: ToolPackConfig): Promise<string> {
   const cached = await findElectronBuilderMakensis(config);

--- a/tools/pack/tests/resources.test.ts
+++ b/tools/pack/tests/resources.test.ts
@@ -199,7 +199,7 @@ describe("copyOptionalVelaCliBinary", () => {
       const target = join(resourceRoot, "bin", process.platform === "win32" ? "vela.exe" : "vela");
       expect(copied?.target).toBe(target);
       await expect(access(target)).resolves.toBeUndefined();
-      await expect(access(join(resourceRoot, "bin", "libexec", "opencode", "opencode"))).resolves.toBeUndefined();
+      await expect(access(join(resourceRoot, "bin", "libexec", "opencode", process.platform === "win32" ? "opencode.exe" : "opencode"))).resolves.toBeUndefined();
     } finally {
       await rm(root, { force: true, recursive: true });
     }


### PR DESCRIPTION
## Why

Hit both of these while running Open Design natively on Windows 11 (best-effort platform per AGENTS.md):

- `tools-pack win build` aborted mid-compression on this machine: the 7z payload step exceeded the 300s timeout on a slower disk, and `makensis.exe` was not found because the local electron-builder cache lays the NSIS dir out flat (`nsis-3.0.4.1/`) without the duplicated version suffix the probe expects.
- Driving vela/AMR against a Gemini free-tier key, `gemini http 429` / `RESOURCE_EXHAUSTED` stderr never matched `classifyAmrAccountFailure`, so runs stalled silently in retry loops instead of surfacing a structured account error. Retry chunks logged under `agent.conversation_loop` (and the "retrying" spelling) were also skipped by `promotedAmrStderrPayload`.

## What users will see

- Windows packaged builds on slower machines complete instead of aborting during NSIS payload compression (timeout 300s → 20min), and `makensis` is found in more electron-builder cache layouts.
- When vela's Gemini backend exhausts its quota, the chat shows a structured "insufficient balance" error with an actionable link to https://aistudio.google.com/apikey instead of a silent stall.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

No new surfaces — behavior-level bug fixes inside existing error classification and the existing win packaging path (no new endpoints, flags, or contract shapes).

## Screenshots

N/A — no UI change.

## Bug fix verification

- No new red specs in this PR — both fixes came out of live debugging on a real Windows 11 machine (actual failing `tools-pack win build`, actual Gemini 429 sessions), which is where the symptoms are observable. Happy to add table-driven specs for `containsGeminiQuotaSignal` / the widened `promotedAmrStderrPayload` regex in a follow-up if maintainers want them encoded.
- `tools/pack/tests/resources.test.ts` is itself a Windows-native test fix: `copyOptionalVelaCliBinary` copies `opencode.exe` on win32, so the existing assertion could never pass there.

## Validation

- `pnpm typecheck` — passes.
- `pnpm guard` — every check passes except the design-system `components.manifest.json` staleness gate, which fails for **all 151 brands** on this Windows-native checkout because the tracked `components.html` / `tokens.css` are materialized with CRLF (git `core.autocrlf=true`), so the content hashes never match the LF-based manifests. Pre-existing on an unmodified `main` checkout on this machine and untouched by this PR (no `design-systems/` changes); noting it here as a Windows-native (best-effort platform) friction candidate for a separate issue.
- `pnpm --filter @open-design/tools-pack test` — 35 files, 229 passed / 3 skipped
- `vitest run tests/integrations/vela-errors.test.ts tests/run-failure-classification.test.ts tests/amr-acp-integration.test.ts` (daemon suites covering `classifyAmrAccountFailure` / `promotedAmrStderrPayload`) — `vela-errors` and `run-failure-classification` pass fully (118 tests). `amr-acp-integration` has 6 pre-existing failures on this machine, all `spawn EFTYPE` from executing the fake-vela script fixture on Windows (shebang scripts aren't executable there); untouched code paths (`invocation.ts` / `amr.ts` model fetch), same failures without this branch's changes.

All validation ran on Windows 11 native (best-effort platform); the two guard/test caveats above are Windows-checkout artifacts, not effects of this change.
