### PR TITLE
fix(byok): preserve provider model order

### DIFF
--- a/apps/daemon/src/integrations/provider-models.ts
+++ b/apps/daemon/src/integrations/provider-models.ts
@@ -91,7 +91,7 @@ function uniqueModels(models: ProviderModelOption[]): ProviderModelOption[] {
     const label = model.label.trim() || id;
     out.push({ ...model, id, label });
   }
-  return out.sort((a, b) => a.id.localeCompare(b.id));
+  return out;
 }
 
 function isOpenAiChatModelId(id: string): boolean {

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -258,14 +258,14 @@ describe('POST /api/provider/models', () => {
       kind: 'success',
       models: [
         {
-          id: 'gpt-4o',
-          label: 'gpt-4o',
-          metadata: { cost: 'medium', capability: 'advanced' },
-        },
-        {
           id: 'gpt-4o-mini',
           label: 'gpt-4o-mini',
           metadata: { cost: 'low', capability: 'standard' },
+        },
+        {
+          id: 'gpt-4o',
+          label: 'gpt-4o',
+          metadata: { cost: 'medium', capability: 'advanced' },
         },
       ],
     });
@@ -386,8 +386,8 @@ describe('POST /api/provider/models', () => {
     await expect(res.json()).resolves.toMatchObject({
       ok: true,
       models: [
-        { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
         { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+        { id: 'claude-haiku-4-5', label: 'Claude Haiku 4.5' },
       ],
     });
   });
@@ -433,8 +433,8 @@ describe('POST /api/provider/models', () => {
     await expect(res.json()).resolves.toMatchObject({
       ok: true,
       models: [
-        { id: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash' },
         { id: 'gemini-custom', label: 'Gemini Custom' },
+        { id: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash' },
       ],
     });
   });

--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -315,8 +315,8 @@ export function AvatarMenu({
 
   const byokModelOptions = mergeProviderModelOptions(
     fetchedByokModels,
-    byokProvider?.models?.length
-      ? byokProvider.models
+    byokProvider?.preferredModels.length
+      ? byokProvider.preferredModels
       : SUGGESTED_MODELS_BY_PROTOCOL[apiProtocol] ?? [],
   );
 
@@ -640,7 +640,7 @@ export function AvatarMenu({
                       ? [
                           {
                             value: config.model,
-                            label: byokProvider?.models?.includes(config.model)
+                            label: byokProvider?.preferredModels.includes(config.model)
                               ? config.model
                               : `${config.model} ${t('avatar.customSuffix')}`,
                           },

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -153,7 +153,10 @@ import {
   API_PROTOCOL_TABS,
   SUGGESTED_MODELS_BY_PROTOCOL,
 } from '../state/apiProtocols';
-import { KNOWN_PROVIDERS } from '../state/config';
+import {
+  defaultKnownProviderModel,
+  KNOWN_PROVIDERS,
+} from '../state/config';
 import type { KnownProvider } from '../state/config';
 import { saveOnboardingProfile } from '../state/onboarding-profile';
 import { testAgent, testApiProvider } from '../providers/connection-test';
@@ -177,6 +180,7 @@ import {
   providerModelsCacheKey,
   type ProviderModelsCache,
 } from './providerModelsCache';
+import { resolveByokModelPreference } from './byok/validation';
 
 // Persist the entry nav-rail open/collapsed state so it survives both a
 // home -> project -> home navigation (EntryShell unmounts on the project
@@ -1877,7 +1881,9 @@ function OnboardingView({
     activeProviderModelsCache[providerModelsInputKey] ?? [];
   const byokModelOptions = mergeOnboardingProviderModelOptions(
     fetchedProviderModels,
-    SUGGESTED_MODELS_BY_PROTOCOL[apiProtocol],
+    selectedProvider?.preferredModels.length
+      ? selectedProvider.preferredModels
+      : SUGGESTED_MODELS_BY_PROTOCOL[apiProtocol],
     config.model,
   ).map((model) => ({
     value: model.id,
@@ -1914,14 +1920,12 @@ function OnboardingView({
     void onConfigPersist(nextConfig);
   }
 
-  function selectFirstProviderModelWhenEmpty(
+  function selectPreferredProviderModelWhenEmpty(
     models: readonly ProviderModelOption[],
     expectedInputKey: string,
   ) {
-    const firstModel = models[0];
     const current = providerModelAutoSelectRef.current;
     if (
-      !firstModel ||
       current.runtime !== 'byok' ||
       current.step !== 0 ||
       current.providerModelsInputKey !== expectedInputKey ||
@@ -1929,8 +1933,14 @@ function OnboardingView({
     ) {
       return;
     }
-    onApiModelChange(firstModel.id);
-    updateApiConfig({ model: firstModel.id });
+    const preference = resolveByokModelPreference({
+      currentModel: '',
+      accountModels: models,
+      providerPreferredModels: selectedProvider?.preferredModels ?? [],
+    });
+    if (!preference.model) return;
+    onApiModelChange(preference.model);
+    updateApiConfig({ model: preference.model });
   }
 
   function clearAgentRevealTimers() {
@@ -2458,7 +2468,7 @@ function OnboardingView({
     providerModelsAutoFetchKeyRef.current = inputKey;
     const cachedModels = activeProviderModelsCache[inputKey];
     if (cachedModels) {
-      selectFirstProviderModelWhenEmpty(cachedModels, inputKey);
+      selectPreferredProviderModelWhenEmpty(cachedModels, inputKey);
       setProviderModelsState({
         status: 'done',
         inputKey,
@@ -2479,7 +2489,7 @@ function OnboardingView({
         apiKey: config.apiKey,
       });
       if (result.ok && result.models?.length) {
-        selectFirstProviderModelWhenEmpty(result.models, inputKey);
+        selectPreferredProviderModelWhenEmpty(result.models, inputKey);
         activeSetProviderModelsCache((current) => ({
           ...current,
           [inputKey]: result.models ?? [],
@@ -2757,7 +2767,7 @@ function OnboardingView({
                       );
                       updateApiConfig({
                         baseUrl: provider?.baseUrl ?? '',
-                        model: provider?.model ?? '',
+                        model: defaultKnownProviderModel(provider),
                         apiProviderBaseUrl: provider?.baseUrl ?? null,
                       });
                     }}
@@ -3432,7 +3442,7 @@ function OnboardingByokSetupPanel({
         {modelOptions.length > 0 ? (
           <OnboardingDropdown
             label={t('settings.model')}
-            placeholder={selectedProvider?.model ?? 'claude-sonnet-4-5'}
+            placeholder={defaultKnownProviderModel(selectedProvider) || 'claude-sonnet-4-5'}
             value={model}
             options={modelOptions}
             onChange={onModelChange}
@@ -3446,7 +3456,7 @@ function OnboardingByokSetupPanel({
             <input
               type="text"
               value={model}
-              placeholder={selectedProvider?.model ?? 'claude-sonnet-4-5'}
+              placeholder={defaultKnownProviderModel(selectedProvider) || 'claude-sonnet-4-5'}
               onChange={(event) => onModelChange(event.target.value.trim())}
             />
           </label>

--- a/apps/web/src/components/InlineModelSwitcher.tsx
+++ b/apps/web/src/components/InlineModelSwitcher.tsx
@@ -588,8 +588,8 @@ export function InlineModelSwitcher({
     () =>
       Array.from(
         new Set(
-          providerForProtocol?.models?.length
-            ? providerForProtocol.models
+          providerForProtocol?.preferredModels.length
+            ? providerForProtocol.preferredModels
             : SUGGESTED_MODELS_BY_PROTOCOL[apiProtocol],
         ),
       ),

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -67,8 +67,10 @@ import {
   SearchableModelSelect,
 } from './modelOptions';
 import {
+  BYOK_PROVIDER_PRESETS,
   DEFAULT_NOTIFICATIONS,
   DEFAULT_ORBIT,
+  defaultKnownProviderModel,
   isStoredMediaProviderEntryEmpty,
   isStoredMediaProviderEntryPresent,
   KNOWN_PROVIDERS,
@@ -221,7 +223,7 @@ interface ByokProviderPreset {
   title: string;
   protocol: ApiProtocol;
   baseUrl: string;
-  model: string;
+  preferredModels: readonly string[];
   custom?: boolean;
 }
 
@@ -866,7 +868,7 @@ function defaultApiProtocolConfig(protocol: ApiProtocol): ApiProtocolConfig {
   return {
     apiKey: '',
     baseUrl: provider?.baseUrl ?? '',
-    model: provider?.model ?? '',
+    model: defaultKnownProviderModel(provider),
     apiVersion: '',
     apiProviderBaseUrl: provider ? provider.baseUrl : null,
   };
@@ -910,7 +912,7 @@ function nextApiProtocolConfig(
     return {
       ...defaultApiProtocolConfig(protocol),
       baseUrl: siblingProvider.baseUrl,
-      model: siblingProvider.model,
+      model: defaultKnownProviderModel(siblingProvider),
       apiProviderBaseUrl: siblingProvider.baseUrl,
     };
   }
@@ -2040,7 +2042,7 @@ export function SettingsDialog({
       return updateCurrentApiProtocolConfig(switchedWithCurrentDraft, {
         ...(providerChanged ? { apiKey: '' } : {}),
         baseUrl: provider.baseUrl,
-        model: provider.model,
+        model: provider.preferredModels[0] ?? '',
         apiProviderBaseUrl: provider.baseUrl,
       });
     });
@@ -2718,187 +2720,13 @@ export function SettingsDialog({
   const apiProtocol = cfg.apiProtocol ?? 'anthropic';
   const defaultApiKeyConsoleLink = API_KEY_CONSOLE_LINKS[apiProtocol];
   const byokProviderPresets: ReadonlyArray<ByokProviderPreset> = [
-    {
-      id: 'anthropic',
-      title: 'Anthropic',
-      protocol: 'anthropic',
-      baseUrl: 'https://api.anthropic.com',
-      model: 'claude-sonnet-4-5',
-    },
-    {
-      id: 'openai',
-      title: 'OpenAI',
-      protocol: 'openai',
-      baseUrl: 'https://api.openai.com/v1',
-      model: 'gpt-4o',
-    },
-    {
-      id: 'atlascloud',
-      title: 'Atlas Cloud',
-      protocol: 'openai',
-      baseUrl: 'https://api.atlascloud.ai/v1',
-      model: 'qwen/qwen3.5-flash',
-    },
-    {
-      id: 'google-ai-studio',
-      title: 'Google Gemini',
-      protocol: 'google',
-      baseUrl: 'https://generativelanguage.googleapis.com',
-      model: 'gemini-3.5-flash',
-    },
-    {
-      id: 'ollama',
-      title: 'Ollama Cloud',
-      protocol: 'ollama',
-      baseUrl: 'https://ollama.com',
-      model: 'gpt-oss:120b',
-    },
-    {
-      id: 'azure',
-      title: 'Azure OpenAI',
-      protocol: 'azure',
-      baseUrl: '',
-      model: '',
-    },
-    {
-      id: 'siliconflow-cn',
-      title: 'SiliconFlow (CN)',
-      protocol: 'openai',
-      baseUrl: 'https://api.siliconflow.cn/v1',
-      model: 'deepseek-ai/DeepSeek-V3.1',
-    },
-    {
-      id: 'siliconflow-global',
-      title: 'SiliconFlow (Global)',
-      protocol: 'openai',
-      baseUrl: 'https://api.siliconflow.com/v1',
-      model: 'deepseek-ai/DeepSeek-V3.1',
-    },
-    {
-      id: 'ppio',
-      title: 'PPIO',
-      protocol: 'openai',
-      baseUrl: 'https://api.ppinfra.com/v3/openai',
-      model: 'deepseek/deepseek-v3.1',
-    },
-    {
-      id: 'nvidia',
-      title: 'NVIDIA',
-      protocol: 'openai',
-      baseUrl: 'https://integrate.api.nvidia.com/v1',
-      model: 'openai/gpt-oss-120b',
-    },
-    {
-      id: 'stepfun',
-      title: 'StepFun',
-      protocol: 'openai',
-      baseUrl: 'https://api.stepfun.ai/v1',
-      model: 'step-2-mini',
-    },
-    {
-      id: 'deepseek',
-      title: 'DeepSeek',
-      protocol: 'openai',
-      baseUrl: 'https://api.deepseek.com',
-      model: 'deepseek-chat',
-    },
-    {
-      id: 'openrouter',
-      title: 'OpenRouter',
-      protocol: 'openai',
-      baseUrl: 'https://openrouter.ai/api/v1',
-      model: 'anthropic/claude-3.7-sonnet',
-    },
-    {
-      id: 'mistral',
-      title: 'Mistral AI',
-      protocol: 'openai',
-      baseUrl: 'https://api.mistral.ai/v1',
-      model: 'mistral-large-latest',
-    },
-    {
-      id: 'xai',
-      title: 'xAI',
-      protocol: 'openai',
-      baseUrl: 'https://api.x.ai/v1',
-      model: 'grok-4',
-    },
-    {
-      id: 'together',
-      title: 'Together AI',
-      protocol: 'openai',
-      baseUrl: 'https://api.together.xyz/v1',
-      model: 'meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo',
-    },
-    {
-      id: 'huggingface',
-      title: 'Hugging Face',
-      protocol: 'openai',
-      baseUrl: 'https://router.huggingface.co/v1',
-      model: 'openai/gpt-oss-120b',
-    },
-    {
-      id: 'qwen',
-      title: '千问',
-      protocol: 'openai',
-      baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
-      model: 'qwen-plus',
-    },
-    {
-      id: 'volcengine',
-      title: '火山引擎',
-      protocol: 'openai',
-      baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
-      model: 'doubao-seed-1-6',
-    },
-    {
-      id: 'qianfan',
-      title: '百度千帆',
-      protocol: 'openai',
-      baseUrl: 'https://qianfan.baidubce.com/v2',
-      model: 'ernie-4.5-turbo-128k',
-    },
-    {
-      id: 'vllm',
-      title: 'vLLM',
-      protocol: 'openai',
-      baseUrl: 'http://127.0.0.1:8000/v1',
-      model: 'model',
-    },
-    {
-      id: 'mimo',
-      title: '小米 MiMo',
-      protocol: 'openai',
-      baseUrl: 'https://token-plan-cn.xiaomimimo.com/v1',
-      model: 'mimo-v2.5-pro',
-    },
-    {
-      id: 'minimax',
-      title: 'MiniMax',
-      protocol: 'anthropic',
-      baseUrl: 'https://api.minimaxi.com/anthropic',
-      model: 'MiniMax-M2.7-highspeed',
-    },
-    {
-      id: 'moonshot',
-      title: 'Moonshot',
-      protocol: 'openai',
-      baseUrl: 'https://api.moonshot.cn/v1',
-      model: 'kimi-k2-0711-preview',
-    },
-    {
-      id: 'zhipu',
-      title: '智谱',
-      protocol: 'openai',
-      baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
-      model: 'glm-4.6',
-    },
+    ...BYOK_PROVIDER_PRESETS,
     {
       id: 'custom',
       title: t('settings.customProvider'),
       protocol: apiProtocol,
       baseUrl: cfg.baseUrl,
-      model: cfg.model,
+      preferredModels: cfg.model ? [cfg.model] : [],
       custom: true,
     },
   ];
@@ -2907,7 +2735,7 @@ export function SettingsDialog({
     title: t('settings.customProvider'),
     protocol: apiProtocol,
     baseUrl: cfg.baseUrl,
-    model: cfg.model,
+    preferredModels: cfg.model ? [cfg.model] : [],
     custom: true,
   };
   const byokPresetProtocols = new Set(
@@ -2924,7 +2752,9 @@ export function SettingsDialog({
         title: tab.title,
         protocol: tab.id,
         baseUrl: fallback.baseUrl || DEFAULT_BASE_URL_BY_PROTOCOL[tab.id],
-        model: fallback.model || SUGGESTED_MODELS_BY_PROTOCOL[tab.id][0] || '',
+        preferredModels: [
+          fallback.model || SUGGESTED_MODELS_BY_PROTOCOL[tab.id][0] || '',
+        ].filter(Boolean),
       };
     }),
     customByokProvider,
@@ -3337,10 +3167,41 @@ export function SettingsDialog({
     apiProtocol !== 'azure' &&
     apiProtocol !== 'ollama' &&
     isProviderModelDiscoveryUnsupported(apiProtocol, cfg.baseUrl);
+  const providerModelDiscoverySupported =
+    apiProtocol !== 'azure' &&
+    apiProtocol !== 'ollama' &&
+    !providerModelDiscoveryUnavailable;
   const fetchedApiModelOptions =
     providerModelDiscoveryUnavailable
       ? []
       : activeProviderModelsCache[providerModelsKey] ?? [];
+  const providerPreferredModels =
+    selectedProvider?.preferredModels ?? SUGGESTED_MODELS_BY_PROTOCOL[apiProtocol];
+  const providerManagedModelIds = useMemo(
+    () => new Set([
+      ...providerPreferredModels,
+      ...(selectedProvider?.retiredModels ?? []),
+    ]),
+    [providerPreferredModels, selectedProvider],
+  );
+  const fetchedApiModelIds = useMemo(
+    () => new Set(fetchedApiModelOptions.map((model) => model.id.trim())),
+    [fetchedApiModelOptions],
+  );
+  const pendingProviderModelReconciliation = (() => {
+    if (cfg.mode !== 'api' || apiModelCustomEditing) return null;
+    if (apiModelUserSelectedRef.current) return null;
+    if (fetchedApiModelOptions.length === 0) return null;
+    const currentModel = cfg.model.trim();
+    if (currentModel && fetchedApiModelIds.has(currentModel)) return null;
+    if (currentModel && !providerManagedModelIds.has(currentModel)) return null;
+    const preference = resolveByokModelPreference({
+      currentModel: '',
+      accountModels: fetchedApiModelOptions,
+      providerPreferredModels,
+    });
+    return preference.model === currentModel ? null : preference.model;
+  })();
   const commitProviderModelsInputs = () => {
     if (
       byokFirstPartyBaseUrl?.hostTypo ||
@@ -3363,17 +3224,14 @@ export function SettingsDialog({
       // effects above: one nulls providerModelsCommittedKey, the other bumps
       // providerTestRevisionRef / clears providerAutoTestKeyRef. So committing
       // the model key or starting the auto-test here would be clobbered — the
-      // model commit before the auto-fetch effect reads it, and the auto-test
-      // result dropped by the stale-revision guard. Defer both until the
-      // cleaned value has landed (effect below), otherwise account models
-      // never auto-load and the auto-test success/error never reaches the UI
-      // for the exact dirty-paste case this handles.
+      // model commit before the auto-fetch effect reads it. Defer the commit
+      // until the cleaned value has landed (effect below); connection testing
+      // waits for model discovery and reconciliation.
       deferAfterKeyCleanRef.current = true;
       updateApiConfig({ apiKey: cleanedApiKey });
       return;
     }
     commitProviderModelsInputs();
-    handleAutoTestProvider();
   };
   useEffect(() => {
     if (!deferAfterKeyCleanRef.current) return;
@@ -3386,9 +3244,6 @@ export function SettingsDialog({
     } else {
       setProviderModelsCommittedKey(providerModelsKey);
     }
-    // Runs after the provider-test reset effect (declaration order) bumped the
-    // revision for the cleaned key, so this auto-test is not flagged stale.
-    handleAutoTestProvider();
   }, [
     byokFirstPartyBaseUrl?.hostTypo,
     byokModelFetchDraftValidation,
@@ -3401,11 +3256,34 @@ export function SettingsDialog({
     if (providerTestState.status === 'running') return;
     if (byokFirstPartyBaseUrl?.hostTypo) return;
     if (blockingByokDraftIssues(byokDraftValidation).length > 0) return;
+    if (providerModelDiscoverySupported) {
+      if (
+        apiProtocol !== 'aihubmix' &&
+        providerModelsCommittedKey !== providerModelsKey
+      ) {
+        const timer = window.setTimeout(() => {
+          setProviderModelsCommittedKey(providerModelsKey);
+        }, 200);
+        return () => window.clearTimeout(timer);
+      }
+      if (
+        providerModelsState.status !== 'done' ||
+        providerModelsState.cacheKey !== providerModelsKey
+      ) return;
+      if (
+        !providerModelsState.result.ok &&
+        (
+          providerModelsState.result.kind === 'auth_failed' ||
+          providerModelsState.result.kind === 'forbidden'
+        )
+      ) return;
+      if (pendingProviderModelReconciliation !== null) return;
+    }
     const key = providerConnectionTestKey(apiProtocol, cfg);
     if (providerAutoTestKeyRef.current === key) return;
     const timer = window.setTimeout(() => {
       handleAutoTestProvider();
-    }, 500);
+    }, providerModelDiscoverySupported ? 0 : 500);
     return () => window.clearTimeout(timer);
   }, [
     apiProtocol,
@@ -3416,6 +3294,11 @@ export function SettingsDialog({
     cfg.baseUrl,
     cfg.mode,
     cfg.model,
+    providerModelDiscoverySupported,
+    pendingProviderModelReconciliation,
+    providerModelsCommittedKey,
+    providerModelsKey,
+    providerModelsState,
     providerTestState.status,
     visualStabilityMode,
   ]);
@@ -3490,13 +3373,13 @@ export function SettingsDialog({
   const suggestedApiModelIds = useMemo(
     () => {
       if (providerModelDiscoveryUnavailable) {
-        return selectedProvider?.models?.length
-          ? Array.from(new Set(selectedProvider.models))
+        return selectedProvider?.preferredModels.length
+          ? Array.from(new Set(selectedProvider.preferredModels))
           : [];
       }
       return Array.from(new Set(
-        selectedProvider?.models?.length
-          ? selectedProvider.models
+        selectedProvider?.preferredModels.length
+          ? selectedProvider.preferredModels
           : SUGGESTED_MODELS_BY_PROTOCOL[apiProtocol],
       ));
     },
@@ -3514,42 +3397,15 @@ export function SettingsDialog({
   const byokImageModelOptions = useByokImageModelOptions(apiProtocol);
   const byokVideoModelOptions = useByokVideoModelOptions(apiProtocol);
   const byokSpeechModelOptions = useByokSpeechModelOptions(apiProtocol);
-  const fetchedApiModelIds = useMemo(
-    () => new Set(fetchedApiModelOptions.map((model) => model.id.trim())),
-    [fetchedApiModelOptions],
-  );
   const apiModelIds = useMemo(
     () => apiModelOptions.map((m) => m.id),
     [apiModelOptions],
   );
-  const providerDefaultModel =
-    selectedProvider?.model.trim() || suggestedApiModelIds[0] || '';
   useEffect(() => {
-    if (cfg.mode !== 'api') return;
-    if (apiModelCustomEditing) return;
-    // Respect an explicit user pick — even when it equals the provider preset
-    // id, the user deliberately chose it and discovery must not rewrite it.
-    if (apiModelUserSelectedRef.current) return;
-    if (fetchedApiModelOptions.length === 0) return;
-    const currentModel = cfg.model.trim();
-    if (currentModel && fetchedApiModelIds.has(currentModel)) return;
-    if (currentModel && currentModel !== providerDefaultModel) return;
-
-    const preference = resolveByokModelPreference({
-      currentModel: '',
-      accountModels: fetchedApiModelOptions,
-      providerDefaultModel,
-    });
-    if (preference.source !== 'account') return;
-    if (preference.model === currentModel) return;
-    updateApiConfig({ model: preference.model });
+    if (pendingProviderModelReconciliation === null) return;
+    updateApiConfig({ model: pendingProviderModelReconciliation });
   }, [
-    apiModelCustomEditing,
-    cfg.mode,
-    cfg.model,
-    fetchedApiModelIds,
-    fetchedApiModelOptions,
-    providerDefaultModel,
+    pendingProviderModelReconciliation,
   ]);
   const apiModelCustomActive =
     shouldShowCustomModelInput(
@@ -5131,7 +4987,7 @@ export function SettingsDialog({
                     setApiModelCustomEditing(false);
                     updateApiConfig({
                       baseUrl: p.baseUrl,
-                      model: p.model,
+                      model: defaultKnownProviderModel(p),
                       apiProviderBaseUrl: p.baseUrl,
                     });
                   }}

--- a/apps/web/src/components/byok/validation.ts
+++ b/apps/web/src/components/byok/validation.ts
@@ -56,7 +56,7 @@ export interface NormalizedByokBaseUrl {
 export type ByokModelPreferenceSource =
   | 'explicit'
   | 'account'
-  | 'provider_default'
+  | 'provider_preferred'
   | 'empty';
 
 export interface ByokModelPreference {
@@ -224,22 +224,34 @@ export function blockingByokDraftFields(
 export function resolveByokModelPreference({
   currentModel,
   accountModels,
-  providerDefaultModel,
+  providerPreferredModels = [],
 }: {
   currentModel: string;
   accountModels: readonly ProviderModelOption[];
-  providerDefaultModel?: string;
+  providerPreferredModels?: readonly string[];
 }): ByokModelPreference {
   const explicit = currentModel.trim();
   if (explicit) return { model: explicit, source: 'explicit' };
-  const account = accountModels.find((model) => model.enabled !== false && model.id.trim());
-  if (account) return { model: account.id, source: 'account' };
-  const providerDefault = providerDefaultModel?.trim() ?? '';
-  const disabledProviderDefault = accountModels.some(
-    (model) => model.id.trim() === providerDefault && model.enabled === false,
+  const enabledAccountModels = accountModels.filter(
+    (model) => model.enabled !== false && model.id.trim(),
   );
-  if (providerDefault && !disabledProviderDefault) {
-    return { model: providerDefault, source: 'provider_default' };
+  const enabledAccountModelIds = new Set(
+    enabledAccountModels.map((model) => model.id.trim()),
+  );
+  const providerPreferred = providerPreferredModels
+    .map((model) => model.trim())
+    .find((model) => model && enabledAccountModelIds.has(model));
+  if (providerPreferred) {
+    return { model: providerPreferred, source: 'provider_preferred' };
+  }
+  if (accountModels.length === 0) {
+    const fallback = providerPreferredModels.find((model) => model.trim())?.trim() ?? '';
+    if (fallback) {
+      return { model: fallback, source: 'provider_preferred' };
+    }
+  }
+  if (enabledAccountModels.length === 1) {
+    return { model: enabledAccountModels[0]!.id.trim(), source: 'account' };
   }
   return { model: '', source: 'empty' };
 }

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -3,6 +3,7 @@ import { MEDIA_PROVIDERS } from '../media/models';
 import { isOpenAICompatible } from '../providers/openai-compatible';
 import type {
   ApiProtocol,
+  ApiProtocolConfig,
   AppConfig,
   MediaProviderCredentials,
   NotificationsConfig,
@@ -21,7 +22,7 @@ import {
 import { randomUUID } from '../utils/uuid';
 
 const STORAGE_KEY = 'open-design:config';
-const CONFIG_MIGRATION_VERSION = 1;
+const CONFIG_MIGRATION_VERSION = 2;
 
 // Hatched out of the box, but tucked away — the user has to go through
 // either the entry-view "adopt a pet" callout or Settings → Pets to
@@ -104,10 +105,10 @@ export interface KnownProvider {
   label: string;
   protocol: ApiProtocol;
   baseUrl: string;
-  /** Default model to apply when the provider is selected. */
-  model: string;
-  /** Optional provider-specific model choices shown in Settings. */
-  models?: string[];
+  /** Ranked provider-owned preferences, matched against the live account catalogue. */
+  preferredModels: string[];
+  /** Model ids that Open Design previously preselected but the provider retired. */
+  retiredModels?: string[];
   /** Optional provider-specific key console link shown in Settings. */
   apiKeyConsoleLink?: { host: string; url: string };
   /** Some local/self-hosted endpoints do not require bearer credentials. */
@@ -120,36 +121,45 @@ export interface KnownProvider {
 // UI can scope quick-fill presets and model suggestions to the selected
 // protocol.
 //
-// Model lists are hand-curated from provider docs/current public presets rather
-// than fetched dynamically. To add a provider, include a user-facing label, the
-// protocol that determines request routing, the base URL, a default model, and
-// optional provider-specific model choices.
+// Preferred model lists are hand-curated from provider docs/current public
+// presets and are reconciled with the live account catalogue before automatic
+// selection. They are not a replacement for provider model discovery.
 export const KNOWN_PROVIDERS: KnownProvider[] = [
   {
     label: 'Anthropic (Claude)',
     protocol: 'anthropic',
     baseUrl: 'https://api.anthropic.com',
-    model: 'claude-sonnet-4-5',
-    models: ['claude-sonnet-4-5', 'claude-opus-4-5', 'claude-haiku-4-5'],
+    preferredModels: ['claude-sonnet-4-5', 'claude-opus-4-5', 'claude-haiku-4-5'],
   },
   {
     label: 'DeepSeek — Anthropic',
     protocol: 'anthropic',
     baseUrl: 'https://api.deepseek.com/anthropic',
-    model: 'deepseek-chat',
-    models: [
-      'deepseek-chat',
-      'deepseek-reasoner',
+    preferredModels: [
       'deepseek-v4-flash',
       'deepseek-v4-pro',
     ],
+    retiredModels: ['deepseek-chat', 'deepseek-reasoner'],
   },
   {
     label: 'MiniMax — Anthropic',
     protocol: 'anthropic',
     baseUrl: 'https://api.minimax.io/anthropic',
-    model: 'MiniMax-M2.7-highspeed',
-    models: [
+    preferredModels: [
+      'MiniMax-M2.7-highspeed',
+      'MiniMax-M2.7',
+      'MiniMax-M2.5-highspeed',
+      'MiniMax-M2.5',
+      'MiniMax-M2.1-highspeed',
+      'MiniMax-M2.1',
+      'MiniMax-M2',
+    ],
+  },
+  {
+    label: 'MiniMax — Anthropic (CN)',
+    protocol: 'anthropic',
+    baseUrl: 'https://api.minimaxi.com/anthropic',
+    preferredModels: [
       'MiniMax-M2.7-highspeed',
       'MiniMax-M2.7',
       'MiniMax-M2.5-highspeed',
@@ -163,15 +173,13 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     label: 'OpenAI',
     protocol: 'openai',
     baseUrl: 'https://api.openai.com/v1',
-    model: 'gpt-4o',
-    models: ['gpt-4o', 'gpt-4o-mini', 'o3', 'o4-mini'],
+    preferredModels: ['gpt-4o', 'gpt-4o-mini', 'o3', 'o4-mini'],
   },
   {
     label: 'Atlas Cloud',
     protocol: 'openai',
     baseUrl: 'https://api.atlascloud.ai/v1',
-    model: 'qwen/qwen3.5-flash',
-    models: [
+    preferredModels: [
       'qwen/qwen3.5-flash',
       'qwen/qwen3.5-plus',
       'qwen/qwen3.7-plus',
@@ -188,8 +196,7 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     label: 'OpenRouter',
     protocol: 'openai',
     baseUrl: 'https://openrouter.ai/api/v1',
-    model: 'anthropic/claude-3.7-sonnet',
-    models: [
+    preferredModels: [
       'anthropic/claude-3.7-sonnet',
       'anthropic/claude-3.5-sonnet',
       'google/gemini-2.5-flash',
@@ -204,15 +211,13 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     label: 'Azure OpenAI',
     protocol: 'azure',
     baseUrl: '',
-    model: '',
-    models: [],
+    preferredModels: [],
   },
   {
     label: 'Google Gemini',
     protocol: 'google',
     baseUrl: 'https://generativelanguage.googleapis.com',
-    model: 'gemini-3.5-flash',
-    models: [
+    preferredModels: [
       'gemini-3.5-flash',
       'gemini-3.1-pro-preview',
       'gemini-3-flash-preview',
@@ -226,8 +231,7 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     label: 'SiliconFlow (CN)',
     protocol: 'openai',
     baseUrl: 'https://api.siliconflow.cn/v1',
-    model: 'deepseek-ai/DeepSeek-V3.1',
-    models: [
+    preferredModels: [
       'deepseek-ai/DeepSeek-V3.1',
       'deepseek-ai/DeepSeek-R1',
       'Qwen/Qwen3-Coder-480B-A35B-Instruct',
@@ -237,8 +241,7 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     label: 'SiliconFlow (Global)',
     protocol: 'openai',
     baseUrl: 'https://api.siliconflow.com/v1',
-    model: 'deepseek-ai/DeepSeek-V3.1',
-    models: [
+    preferredModels: [
       'deepseek-ai/DeepSeek-V3.1',
       'deepseek-ai/DeepSeek-R1',
       'Qwen/Qwen3-Coder-480B-A35B-Instruct',
@@ -248,15 +251,13 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     label: 'PPIO',
     protocol: 'openai',
     baseUrl: 'https://api.ppinfra.com/v3/openai',
-    model: 'deepseek/deepseek-v3.1',
-    models: ['deepseek/deepseek-v3.1', 'deepseek/deepseek-r1'],
+    preferredModels: ['deepseek/deepseek-v3.1', 'deepseek/deepseek-r1'],
   },
   {
     label: 'NVIDIA',
     protocol: 'openai',
     baseUrl: 'https://integrate.api.nvidia.com/v1',
-    model: 'openai/gpt-oss-120b',
-    models: [
+    preferredModels: [
       'openai/gpt-oss-120b',
       'meta/llama-3.1-405b-instruct',
       'nvidia/llama-3.1-nemotron-70b-instruct',
@@ -266,41 +267,35 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     label: 'StepFun',
     protocol: 'openai',
     baseUrl: 'https://api.stepfun.ai/v1',
-    model: 'step-2-mini',
-    models: ['step-2-mini', 'step-1-8k', 'step-1-32k'],
+    preferredModels: ['step-2-mini', 'step-1-8k', 'step-1-32k'],
   },
   {
     label: 'DeepSeek — OpenAI',
     protocol: 'openai',
     baseUrl: 'https://api.deepseek.com',
-    model: 'deepseek-chat',
-    models: [
-      'deepseek-chat',
-      'deepseek-reasoner',
+    preferredModels: [
       'deepseek-v4-flash',
       'deepseek-v4-pro',
     ],
+    retiredModels: ['deepseek-chat', 'deepseek-reasoner'],
   },
   {
     label: 'Mistral AI',
     protocol: 'openai',
     baseUrl: 'https://api.mistral.ai/v1',
-    model: 'mistral-large-latest',
-    models: ['mistral-large-latest', 'ministral-8b-latest', 'ministral-3b-latest'],
+    preferredModels: ['mistral-large-latest', 'ministral-8b-latest', 'ministral-3b-latest'],
   },
   {
     label: 'xAI',
     protocol: 'openai',
     baseUrl: 'https://api.x.ai/v1',
-    model: 'grok-4',
-    models: ['grok-4', 'grok-3', 'grok-3-mini'],
+    preferredModels: ['grok-4', 'grok-3', 'grok-3-mini'],
   },
   {
     label: 'Together AI',
     protocol: 'openai',
     baseUrl: 'https://api.together.xyz/v1',
-    model: 'meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo',
-    models: [
+    preferredModels: [
       'meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo',
       'meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo',
       'Qwen/Qwen2.5-Coder-32B-Instruct',
@@ -310,8 +305,7 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     label: 'Hugging Face',
     protocol: 'openai',
     baseUrl: 'https://router.huggingface.co/v1',
-    model: 'openai/gpt-oss-120b',
-    models: [
+    preferredModels: [
       'openai/gpt-oss-120b',
       'Qwen/Qwen3-Coder-480B-A35B-Instruct',
       'meta-llama/Llama-3.1-8B-Instruct',
@@ -321,37 +315,32 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     label: 'Qwen',
     protocol: 'openai',
     baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
-    model: 'qwen-plus',
-    models: ['qwen-plus', 'qwen-turbo', 'qwen-max', 'qwen3-coder-plus'],
+    preferredModels: ['qwen-plus', 'qwen-turbo', 'qwen-max', 'qwen3-coder-plus'],
   },
   {
     label: 'Volcengine Ark',
     protocol: 'openai',
     baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
-    model: 'doubao-seed-1-6',
-    models: ['doubao-seed-1-6', 'doubao-seed-1-6-thinking', 'deepseek-v3'],
+    preferredModels: ['doubao-seed-1-6', 'doubao-seed-1-6-thinking', 'deepseek-v3'],
   },
   {
     label: 'Baidu Qianfan',
     protocol: 'openai',
     baseUrl: 'https://qianfan.baidubce.com/v2',
-    model: 'ernie-4.5-turbo-128k',
-    models: ['ernie-4.5-turbo-128k', 'ernie-4.5-8k-preview'],
+    preferredModels: ['ernie-4.5-turbo-128k', 'ernie-4.5-8k-preview'],
   },
   {
     label: 'vLLM',
     protocol: 'openai',
     baseUrl: 'http://127.0.0.1:8000/v1',
-    model: 'model',
-    models: ['model', 'llama3', 'qwen3'],
+    preferredModels: ['model', 'llama3', 'qwen3'],
     requiresApiKey: false,
   },
   {
     label: 'MiniMax — OpenAI',
     protocol: 'openai',
     baseUrl: 'https://api.minimax.io/v1',
-    model: 'MiniMax-M2.7-highspeed',
-    models: [
+    preferredModels: [
       'MiniMax-M2.7-highspeed',
       'MiniMax-M2.7',
       'MiniMax-M2.5-highspeed',
@@ -365,29 +354,34 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     label: 'MiMo (Xiaomi) — OpenAI',
     protocol: 'openai',
     baseUrl: 'https://token-plan-cn.xiaomimimo.com/v1',
-    model: 'mimo-v2.5-pro',
-    models: ['mimo-v2.5-pro'],
+    preferredModels: ['mimo-v2.5-pro'],
   },
   {
     label: 'Moonshot',
     protocol: 'openai',
     baseUrl: 'https://api.moonshot.cn/v1',
-    model: 'kimi-k2-0711-preview',
-    models: ['kimi-k2-0711-preview', 'moonshot-v1-8k', 'moonshot-v1-32k', 'moonshot-v1-128k'],
+    preferredModels: [
+      'kimi-k2.6',
+      'kimi-k2.7-code',
+      'kimi-k2.7-code-highspeed',
+      'kimi-k2.5',
+      'moonshot-v1-8k',
+      'moonshot-v1-32k',
+      'moonshot-v1-128k',
+    ],
+    retiredModels: ['kimi-k2-0711-preview'],
   },
   {
     label: 'Zhipu',
     protocol: 'openai',
     baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
-    model: 'glm-4.6',
-    models: ['glm-4.6', 'glm-4-plus', 'glm-4-air'],
+    preferredModels: ['glm-4.6', 'glm-4-plus', 'glm-4-air'],
   },
   {
     label: 'Ollama Cloud (managed)',
     protocol: 'ollama',
     baseUrl: 'https://ollama.com',
-    model: 'gpt-oss:120b',
-    models: [
+    preferredModels: [
       'cogito-2.1:671b',
       'deepseek-v3.1:671b',
       'deepseek-v3.2',
@@ -437,23 +431,20 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     label: 'Ollama Self-hosted (local)',
     protocol: 'ollama',
     baseUrl: 'http://localhost:11434',
-    model: 'gemma3:4b',
-    models: ['gemma3:4b', 'gemma3:12b', 'gemma3:27b', 'gpt-oss:20b'],
+    preferredModels: ['gemma3:4b', 'gemma3:12b', 'gemma3:27b', 'gpt-oss:20b'],
     requiresApiKey: false,
   },
   {
     label: 'MiMo (Xiaomi) — Anthropic',
     protocol: 'anthropic',
     baseUrl: 'https://token-plan-cn.xiaomimimo.com/anthropic',
-    model: 'mimo-v2.5-pro',
-    models: ['mimo-v2.5-pro'],
+    preferredModels: ['mimo-v2.5-pro'],
   },
   {
     label: 'SenseAudio',
     protocol: 'senseaudio',
     baseUrl: 'https://api.senseaudio.cn',
-    model: 'senseaudio-s2',
-    models: [
+    preferredModels: [
       'senseaudio-s2',
       'senseaudio-s2-flash',
       'deepseek-v4-flash',
@@ -468,8 +459,7 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     label: 'AIHubMix',
     protocol: 'aihubmix',
     baseUrl: 'https://aihubmix.com/v1',
-    model: 'gpt-5.5',
-    models: [
+    preferredModels: [
       'gpt-5.5',
       'gpt-4o',
       'gpt-4o-mini',
@@ -482,6 +472,67 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     ],
   },
 ];
+
+export function defaultKnownProviderModel(
+  provider: Pick<KnownProvider, 'preferredModels'> | null | undefined,
+): string {
+  return provider?.preferredModels[0]?.trim() ?? '';
+}
+
+export interface ByokProviderPresetConfig {
+  id: string;
+  title: string;
+  protocol: ApiProtocol;
+  baseUrl: string;
+  preferredModels: readonly string[];
+}
+
+const BYOK_PROVIDER_PRESET_SPECS = [
+  { id: 'anthropic', title: 'Anthropic', providerLabel: 'Anthropic (Claude)' },
+  { id: 'openai', title: 'OpenAI', providerLabel: 'OpenAI' },
+  { id: 'atlascloud', title: 'Atlas Cloud', providerLabel: 'Atlas Cloud' },
+  { id: 'google-ai-studio', title: 'Google Gemini', providerLabel: 'Google Gemini' },
+  { id: 'ollama', title: 'Ollama Cloud', providerLabel: 'Ollama Cloud (managed)' },
+  { id: 'azure', title: 'Azure OpenAI', providerLabel: 'Azure OpenAI' },
+  { id: 'siliconflow-cn', title: 'SiliconFlow (CN)', providerLabel: 'SiliconFlow (CN)' },
+  {
+    id: 'siliconflow-global',
+    title: 'SiliconFlow (Global)',
+    providerLabel: 'SiliconFlow (Global)',
+  },
+  { id: 'ppio', title: 'PPIO', providerLabel: 'PPIO' },
+  { id: 'nvidia', title: 'NVIDIA', providerLabel: 'NVIDIA' },
+  { id: 'stepfun', title: 'StepFun', providerLabel: 'StepFun' },
+  { id: 'deepseek', title: 'DeepSeek', providerLabel: 'DeepSeek — OpenAI' },
+  { id: 'openrouter', title: 'OpenRouter', providerLabel: 'OpenRouter' },
+  { id: 'mistral', title: 'Mistral AI', providerLabel: 'Mistral AI' },
+  { id: 'xai', title: 'xAI', providerLabel: 'xAI' },
+  { id: 'together', title: 'Together AI', providerLabel: 'Together AI' },
+  { id: 'huggingface', title: 'Hugging Face', providerLabel: 'Hugging Face' },
+  { id: 'qwen', title: '千问', providerLabel: 'Qwen' },
+  { id: 'volcengine', title: '火山引擎', providerLabel: 'Volcengine Ark' },
+  { id: 'qianfan', title: '百度千帆', providerLabel: 'Baidu Qianfan' },
+  { id: 'vllm', title: 'vLLM', providerLabel: 'vLLM' },
+  { id: 'mimo', title: '小米 MiMo', providerLabel: 'MiMo (Xiaomi) — OpenAI' },
+  { id: 'minimax', title: 'MiniMax', providerLabel: 'MiniMax — Anthropic (CN)' },
+  { id: 'moonshot', title: 'Moonshot', providerLabel: 'Moonshot' },
+  { id: 'zhipu', title: '智谱', providerLabel: 'Zhipu' },
+] as const;
+
+export const BYOK_PROVIDER_PRESETS: ReadonlyArray<ByokProviderPresetConfig> =
+  BYOK_PROVIDER_PRESET_SPECS.map(({ id, title, providerLabel }) => {
+    const provider = KNOWN_PROVIDERS.find((item) => item.label === providerLabel);
+    if (!provider) {
+      throw new Error(`Missing known provider for BYOK preset: ${providerLabel}`);
+    }
+    return {
+      id,
+      title,
+      protocol: provider.protocol,
+      baseUrl: provider.baseUrl,
+      preferredModels: provider.preferredModels,
+    };
+  });
 
 function normalizePet(input: Partial<PetConfig> | undefined): PetConfig {
   if (!input) return { ...DEFAULT_PET, custom: { ...DEFAULT_PET.custom } };
@@ -569,6 +620,27 @@ function inferApiProtocol(model: string, baseUrl: string): ApiProtocol {
   }
 }
 
+function migrateRetiredKnownProviderModel(
+  protocol: ApiProtocol,
+  config: Pick<
+    ApiProtocolConfig,
+    'baseUrl' | 'model' | 'apiProviderBaseUrl'
+  >,
+): boolean {
+  const provider = KNOWN_PROVIDERS.find((candidate) =>
+    candidate.protocol === protocol &&
+    (
+      candidate.baseUrl === config.apiProviderBaseUrl ||
+      candidate.baseUrl === config.baseUrl
+    ),
+  );
+  if (!provider?.retiredModels?.includes(config.model)) return false;
+  const replacement = defaultKnownProviderModel(provider);
+  if (!replacement || replacement === config.model) return false;
+  config.model = replacement;
+  return true;
+}
+
 export function loadConfig(): AppConfig {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
@@ -607,12 +679,17 @@ export function loadConfig(): AppConfig {
       orbit: normalizeOrbit(parsed.orbit),
     };
 
-    if (parsed.configMigrationVersion !== CONFIG_MIGRATION_VERSION) {
+    let migratedConfig = false;
+    const parsedMigrationVersion =
+      typeof parsed.configMigrationVersion === 'number'
+        ? parsed.configMigrationVersion
+        : 0;
+    if (parsedMigrationVersion !== CONFIG_MIGRATION_VERSION) {
       // Migration v1: configs saved before apiProtocol existed need an explicit
       // protocol so old OpenAI-compatible endpoints keep routing correctly.
       // This is version-gated instead of only field-gated so a later imported
       // legacy config can be migrated when it is loaded.
-      if (!parsedHasApiProtocol) {
+      if (parsedMigrationVersion < 1 && !parsedHasApiProtocol) {
         merged.apiProtocol = inferApiProtocol(merged.model, merged.baseUrl);
         // Ollama Cloud legacy configs may carry a base URL that includes
         // /api or /api/ — normalize to the host root so the daemon's own
@@ -631,6 +708,37 @@ export function loadConfig(): AppConfig {
         );
         merged.apiProviderBaseUrl = knownProvider?.baseUrl ?? null;
       }
+
+      // Migration v2: replace model ids that were previously shipped as
+      // provider defaults but have since been retired. Apply it to every saved
+      // BYOK slot so switching protocols/providers cannot restore a stale id.
+      if (parsedMigrationVersion < 2) {
+        const activeProtocol = merged.apiProtocol ?? inferApiProtocol(
+          merged.model,
+          merged.baseUrl,
+        );
+        migratedConfig = migrateRetiredKnownProviderModel(activeProtocol, merged)
+          || migratedConfig;
+        for (const [protocol, apiConfig] of Object.entries(
+          merged.apiProtocolConfigs ?? {},
+        )) {
+          if (!apiConfig) continue;
+          migratedConfig = migrateRetiredKnownProviderModel(
+            protocol as ApiProtocol,
+            apiConfig,
+          ) || migratedConfig;
+        }
+        for (const [draftKey, draft] of Object.entries(
+          merged.byokProviderConfigDrafts ?? {},
+        )) {
+          const separator = draftKey.indexOf(':');
+          if (separator <= 0) continue;
+          migratedConfig = migrateRetiredKnownProviderModel(
+            draftKey.slice(0, separator) as ApiProtocol,
+            draft.apiConfig,
+          ) || migratedConfig;
+        }
+      }
       merged.configMigrationVersion = CONFIG_MIGRATION_VERSION;
     }
 
@@ -646,7 +754,7 @@ export function loadConfig(): AppConfig {
       merged.baseUrl = resolveFixedOriginBaseUrl(merged.apiProtocol, merged.baseUrl);
     }
 
-    if (downgradedUnsupportedChatProtocol) {
+    if (migratedConfig || downgradedUnsupportedChatProtocol) {
       saveConfig(merged);
     }
 

--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -382,6 +382,7 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     protocol: 'ollama',
     baseUrl: 'https://ollama.com',
     preferredModels: [
+      'gpt-oss:120b',
       'cogito-2.1:671b',
       'deepseek-v3.1:671b',
       'deepseek-v3.2',
@@ -400,7 +401,6 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
       'glm-5.1',
       'glm-5.2',
       'gpt-oss:20b',
-      'gpt-oss:120b',
       'kimi-k2:1t',
       'kimi-k2-thinking',
       'kimi-k2.5',

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -1504,6 +1504,44 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     expect(aboutYouSubmits).toHaveLength(1);
   });
 
+  it('uses provider preferences instead of the first upstream model during BYOK onboarding', async () => {
+    globalThis.fetch = vi.fn(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/api/integrations/vela/status')) {
+        return jsonResponse({ loggedIn: false, profile: 'prod', user: null, configPath: '/x' });
+      }
+      if (url.endsWith('/api/provider/models') && init?.method === 'POST') {
+        return jsonResponse({
+          ok: true,
+          kind: 'success',
+          latencyMs: 10,
+          models: [
+            { id: 'upstream-first', label: 'Upstream First' },
+            { id: 'claude-sonnet-4-5', label: 'Claude Sonnet 4.5' },
+          ],
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+    const props = renderOnboarding({
+      config: baseConfig({
+        apiProtocol: 'anthropic',
+        apiKey: 'test-api-key',
+        baseUrl: 'https://api.anthropic.com',
+        model: '',
+        apiProviderBaseUrl: 'https://api.anthropic.com',
+      }),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Bring your own key/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Fetch models/i }));
+
+    await waitFor(() => {
+      expect(props.onApiModelChange).toHaveBeenCalledWith('claude-sonnet-4-5');
+    });
+    expect(props.onApiModelChange).not.toHaveBeenCalledWith('upstream-first');
+  });
+
   it('persists the BYOK config before finishing onboarding', async () => {
     globalThis.fetch = vi.fn(async (input, init) => {
       const url = String(input);

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -801,7 +801,9 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     fireEvent.click(screen.getByRole('tab', { name: 'OpenAI' }));
     selectGatewayPreset('DeepSeek — OpenAI');
 
-    expect(screen.getByRole('combobox', { name: 'Model' }).textContent).toContain('deepseek-chat');
+    expect(screen.getByRole('combobox', { name: 'Model' }).textContent).toContain(
+      'deepseek-v4-flash',
+    );
     expect((screen.getByLabelText('Base URL') as HTMLInputElement).value).toBe('https://api.deepseek.com');
   });
 
@@ -843,7 +845,9 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
 
     fireEvent.click(within(providerPopover).getByRole('option', { name: 'DeepSeek — Anthropic' }));
 
-    expect(screen.getByRole('combobox', { name: 'Model' }).textContent).toContain('deepseek-chat');
+    expect(screen.getByRole('combobox', { name: 'Model' }).textContent).toContain(
+      'deepseek-v4-flash',
+    );
     expect((screen.getByLabelText('Base URL') as HTMLInputElement).value).toBe(
       'https://api.deepseek.com/anthropic',
     );
@@ -935,10 +939,12 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     await waitFor(() => {
       expect(screen.getByText(/Connected\. Replied in 28 ms/)).toBeTruthy();
     });
-    const testConnectionCalls = fetchMock.mock.calls.filter(
-      ([input]) => input.toString() === '/api/test/connection',
-    );
-    expect(testConnectionCalls).toHaveLength(1);
+    await waitFor(() => {
+      const testConnectionCalls = fetchMock.mock.calls.filter(
+        ([input]) => input.toString() === '/api/test/connection',
+      );
+      expect(testConnectionCalls).toHaveLength(1);
+    });
   });
 
   it('keeps protocol drafts isolated without leaking API keys between tabs', () => {
@@ -1253,6 +1259,104 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
       expect.objectContaining({
         apiProtocol: 'openai',
         model: 'account-ready-model',
+      }),
+      {},
+    );
+  });
+
+  it('replaces a retired preset with the first provider preference available to the account', async () => {
+    const testedModels: string[] = [];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(
+          JSON.stringify({ enabled: true, memories: [], extraction: null }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      expect(url).toBe('/api/test/connection');
+      const body = JSON.parse(String(init?.body)) as { model?: string };
+      testedModels.push(body.model ?? '');
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          kind: 'ok',
+          latencyMs: 7,
+          model: body.model,
+          sample: 'pong',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    fetchProviderModelsMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'success',
+      latencyMs: 12,
+      models: [
+        { id: 'account-first', label: 'Account First' },
+        { id: 'kimi-k2.6', label: 'Kimi K2.6' },
+      ],
+    });
+    const { onPersist } = renderSettingsDialog({
+      apiProtocol: 'openai',
+      apiKey: 'sk-moonshot',
+      baseUrl: 'https://api.moonshot.cn/v1',
+      model: 'kimi-k2-0711-preview',
+      apiProviderBaseUrl: 'https://api.moonshot.cn/v1',
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Moonshot' }));
+
+    expect(await screen.findByText(/✓ Loaded \d+ models(?: from your account)?\./)).toBeTruthy();
+    expect(screen.getByRole('combobox', { name: 'Model' }).textContent).toContain(
+      'Kimi K2.6 (kimi-k2.6) · From your account',
+    );
+    expect(screen.getByRole('combobox', { name: 'Model' }).textContent).not.toContain(
+      'account-first',
+    );
+    await waitForPersist(
+      onPersist,
+      expect.objectContaining({
+        apiProtocol: 'openai',
+        model: 'kimi-k2.6',
+      }),
+      {},
+    );
+    await waitFor(() => {
+      expect(testedModels).toEqual(['kimi-k2.6']);
+    });
+  });
+
+  it('does not treat the first upstream model as the default when no preference matches', async () => {
+    fetchProviderModelsMock.mockResolvedValueOnce({
+      ok: true,
+      kind: 'success',
+      latencyMs: 12,
+      models: [
+        { id: 'account-first', label: 'Account First' },
+        { id: 'account-second', label: 'Account Second' },
+      ],
+    });
+    const { onPersist } = renderSettingsDialog({
+      apiProtocol: 'openai',
+      apiKey: 'sk-openai',
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+      apiProviderBaseUrl: 'https://api.openai.com/v1',
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'OpenAI' }));
+
+    expect(await screen.findByText(/✓ Loaded \d+ models(?: from your account)?\./)).toBeTruthy();
+    expect(screen.getByRole('combobox', { name: 'Model' }).textContent).not.toContain(
+      'account-first',
+    );
+    await waitForPersist(
+      onPersist,
+      expect.objectContaining({
+        apiProtocol: 'openai',
+        model: '',
       }),
       {},
     );
@@ -1996,10 +2100,12 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
       expect(apiKeyInput.value).toBe('sk-ant-test-provider');
     });
     expect(screen.getByText(en['settings.apiKeyCleaned'])).toBeTruthy();
-    const testConnectionCalls = fetchMock.mock.calls.filter(
-      ([input]) => input.toString() === '/api/test/connection',
-    );
-    expect(testConnectionCalls).toHaveLength(1);
+    await waitFor(() => {
+      const testConnectionCalls = fetchMock.mock.calls.filter(
+        ([input]) => input.toString() === '/api/test/connection',
+      );
+      expect(testConnectionCalls).toHaveLength(1);
+    });
   });
 
   it('lets users retry a failed BYOK connection test without editing the API key', async () => {

--- a/apps/web/tests/components/byok-validation.test.ts
+++ b/apps/web/tests/components/byok-validation.test.ts
@@ -259,30 +259,44 @@ describe('BYOK draft validation', () => {
     expect(modelFetchDraft.ok).toBe(true);
   });
 
-  it('defines the model preference order for later model-fetch PRs', () => {
+  it('prefers provider-ranked account models without treating upstream order as a default', () => {
     expect(
       resolveByokModelPreference({
         currentModel: 'custom-model',
         accountModels: [{ id: 'account-model', label: 'Account model' }],
-        providerDefaultModel: 'provider-model',
+        providerPreferredModels: ['provider-model'],
       }),
     ).toEqual({ model: 'custom-model', source: 'explicit' });
 
     expect(
       resolveByokModelPreference({
         currentModel: '',
-        accountModels: [{ id: 'account-model', label: 'Account model' }],
-        providerDefaultModel: 'provider-model',
+        accountModels: [
+          { id: 'upstream-first', label: 'Upstream first' },
+          { id: 'provider-model', label: 'Provider model' },
+        ],
+        providerPreferredModels: ['provider-model'],
       }),
-    ).toEqual({ model: 'account-model', source: 'account' });
+    ).toEqual({ model: 'provider-model', source: 'provider_preferred' });
 
     expect(
       resolveByokModelPreference({
         currentModel: '',
         accountModels: [],
-        providerDefaultModel: 'provider-model',
+        providerPreferredModels: ['provider-model'],
       }),
-    ).toEqual({ model: 'provider-model', source: 'provider_default' });
+    ).toEqual({ model: 'provider-model', source: 'provider_preferred' });
+
+    expect(
+      resolveByokModelPreference({
+        currentModel: '',
+        accountModels: [
+          { id: 'upstream-first', label: 'Upstream first' },
+          { id: 'upstream-second', label: 'Upstream second' },
+        ],
+        providerPreferredModels: ['missing-provider-model'],
+      }),
+    ).toEqual({ model: '', source: 'empty' });
   });
 
   it('skips disabled provider models when choosing an automatic preference', () => {
@@ -293,7 +307,7 @@ describe('BYOK draft validation', () => {
           { id: 'disabled-model', label: 'Disabled model', enabled: false },
           { id: 'enabled-model', label: 'Enabled model' },
         ],
-        providerDefaultModel: 'provider-model',
+        providerPreferredModels: ['disabled-model'],
       }),
     ).toEqual({ model: 'enabled-model', source: 'account' });
 
@@ -303,7 +317,7 @@ describe('BYOK draft validation', () => {
         accountModels: [
           { id: 'disabled-default', label: 'Disabled default', enabled: false },
         ],
-        providerDefaultModel: 'disabled-default',
+        providerPreferredModels: ['disabled-default'],
       }),
     ).toEqual({ model: '', source: 'empty' });
   });

--- a/apps/web/tests/state/api-protocols.test.ts
+++ b/apps/web/tests/state/api-protocols.test.ts
@@ -19,10 +19,10 @@ describe('apiProtocols table consistency', () => {
       (provider) => provider.protocol === 'ollama' && provider.baseUrl === 'https://ollama.com',
     );
 
-    expect(ollamaCloudProvider?.models).toBeDefined();
+    expect(ollamaCloudProvider?.preferredModels).toBeDefined();
     for (const model of recentCloudModels) {
       expect(SUGGESTED_MODELS_BY_PROTOCOL.ollama).toContain(model);
-      expect(ollamaCloudProvider?.models).toContain(model);
+      expect(ollamaCloudProvider?.preferredModels).toContain(model);
     }
   });
 
@@ -35,13 +35,12 @@ describe('apiProtocols table consistency', () => {
 
     expect(atlasCloudProvider).toMatchObject({
       label: 'Atlas Cloud',
-      model: 'qwen/qwen3.5-flash',
       apiKeyConsoleLink: {
         host: 'atlascloud.ai',
         url: 'https://atlascloud.ai/?utm_source=open_design&utm_medium=provider_preset&utm_campaign=atlascloud_byok',
       },
     });
-    expect(atlasCloudProvider?.models).toContain('qwen/qwen3.5-flash');
-    expect(atlasCloudProvider?.models).toContain('deepseek-ai/deepseek-v4-flash');
+    expect(atlasCloudProvider?.preferredModels).toContain('qwen/qwen3.5-flash');
+    expect(atlasCloudProvider?.preferredModels).toContain('deepseek-ai/deepseek-v4-flash');
   });
 });

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   buildMediaProvidersForDaemonSave,
+  BYOK_PROVIDER_PRESETS,
   DEFAULT_CONFIG,
   fetchMediaProvidersFromDaemon,
   isStoredMediaProviderEntryEmpty,
@@ -29,15 +30,49 @@ describe('KNOWN_PROVIDERS', () => {
         label: 'SiliconFlow (CN)',
         protocol: 'openai',
         baseUrl: 'https://api.siliconflow.cn/v1',
-        model: 'deepseek-ai/DeepSeek-V3.1',
+        preferredModels: expect.arrayContaining(['deepseek-ai/DeepSeek-V3.1']),
       }),
       expect.objectContaining({
         label: 'SiliconFlow (Global)',
         protocol: 'openai',
         baseUrl: 'https://api.siliconflow.com/v1',
-        model: 'deepseek-ai/DeepSeek-V3.1',
+        preferredModels: expect.arrayContaining(['deepseek-ai/DeepSeek-V3.1']),
       }),
     ]);
+  });
+
+  it('keeps BYOK presets derived from the canonical provider registry', () => {
+    const moonshot = KNOWN_PROVIDERS.find((provider) => provider.label === 'Moonshot');
+    const moonshotPreset = BYOK_PROVIDER_PRESETS.find((preset) => preset.id === 'moonshot');
+
+    expect(moonshot?.preferredModels).toEqual(expect.arrayContaining([
+      'kimi-k2.6',
+      'kimi-k2.7-code',
+    ]));
+    expect(moonshot?.retiredModels).toContain('kimi-k2-0711-preview');
+    expect(moonshotPreset).toEqual(expect.objectContaining({
+      protocol: moonshot?.protocol,
+      baseUrl: moonshot?.baseUrl,
+      preferredModels: moonshot?.preferredModels,
+    }));
+  });
+
+  it('moves both DeepSeek gateways to the V4 model ids before legacy aliases retire', () => {
+    const deepSeekProviders = KNOWN_PROVIDERS.filter((provider) =>
+      provider.label.startsWith('DeepSeek'),
+    );
+
+    expect(deepSeekProviders).toHaveLength(2);
+    for (const provider of deepSeekProviders) {
+      expect(provider.preferredModels).toEqual([
+        'deepseek-v4-flash',
+        'deepseek-v4-pro',
+      ]);
+      expect(provider.retiredModels).toEqual([
+        'deepseek-chat',
+        'deepseek-reasoner',
+      ]);
+    }
   });
 });
 
@@ -903,9 +938,50 @@ describe('loadConfig', () => {
 
     expect(config.mode).toBe('api');
     expect(config.baseUrl).toBe('https://api.deepseek.com');
-    expect(config.model).toBe('deepseek-chat');
+    expect(config.model).toBe('deepseek-v4-flash');
     expect(config.apiProtocol).toBe('openai');
-    expect(config.configMigrationVersion).toBe(1);
+    expect(config.configMigrationVersion).toBe(2);
+  });
+
+  it('migrates retired provider defaults in active, protocol, and provider-draft configs', () => {
+    const moonshotBaseUrl = 'https://api.moonshot.cn/v1';
+    const persisted: Partial<AppConfig> = {
+      mode: 'api',
+      apiProtocol: 'openai',
+      apiKey: 'sk-moonshot',
+      baseUrl: moonshotBaseUrl,
+      model: 'kimi-k2-0711-preview',
+      apiProviderBaseUrl: moonshotBaseUrl,
+      configMigrationVersion: 1,
+      apiProtocolConfigs: {
+        openai: {
+          apiKey: 'sk-moonshot',
+          baseUrl: moonshotBaseUrl,
+          model: 'kimi-k2-0711-preview',
+          apiProviderBaseUrl: moonshotBaseUrl,
+        },
+      },
+      byokProviderConfigDrafts: {
+        [`openai:${moonshotBaseUrl}`]: {
+          apiConfig: {
+            apiKey: 'sk-moonshot',
+            baseUrl: moonshotBaseUrl,
+            model: 'kimi-k2-0711-preview',
+            apiProviderBaseUrl: moonshotBaseUrl,
+          },
+        },
+      },
+    };
+    store.set('open-design:config', JSON.stringify(persisted));
+
+    const config = loadConfig();
+
+    expect(config.model).toBe('kimi-k2.6');
+    expect(config.apiProtocolConfigs?.openai?.model).toBe('kimi-k2.6');
+    expect(
+      config.byokProviderConfigDrafts?.[`openai:${moonshotBaseUrl}`]?.apiConfig.model,
+    ).toBe('kimi-k2.6');
+    expect(config.configMigrationVersion).toBe(2);
   });
 
   it('migrates legacy SiliconFlow Global configs to the known OpenAI preset', () => {
@@ -924,7 +1000,7 @@ describe('loadConfig', () => {
 
     expect(config.apiProtocol).toBe('openai');
     expect(config.apiProviderBaseUrl).toBe('https://api.siliconflow.com/v1');
-    expect(config.configMigrationVersion).toBe(1);
+    expect(config.configMigrationVersion).toBe(2);
   });
 
   it('backfills the fixed-origin base URL for AIHubMix when persisted empty', () => {
@@ -1106,7 +1182,7 @@ describe('loadConfig', () => {
 
     expect(config.mode).toBe('daemon');
     expect(config.apiProtocol).toBe('openai');
-    expect(config.configMigrationVersion).toBe(1);
+    expect(config.configMigrationVersion).toBe(2);
   });
 
   it('migrates legacy Ollama Cloud configs to an explicit ollama apiProtocol', () => {
@@ -1128,7 +1204,7 @@ describe('loadConfig', () => {
     expect(config.model).toBe('gpt-oss:120b');
     expect(config.apiProtocol).toBe('ollama');
     expect(config.apiProviderBaseUrl).toBe('https://ollama.com');
-    expect(config.configMigrationVersion).toBe(1);
+    expect(config.configMigrationVersion).toBe(2);
   });
 
   it('migrates legacy ollama.com configs with a custom base URL path', () => {
@@ -1250,7 +1326,7 @@ describe('loadConfig', () => {
 
   it('sets an explicit apiProtocol for new default configs', () => {
     expect(DEFAULT_CONFIG.apiProtocol).toBe('anthropic');
-    expect(DEFAULT_CONFIG.configMigrationVersion).toBe(1);
+    expect(DEFAULT_CONFIG.configMigrationVersion).toBe(2);
     expect(DEFAULT_CONFIG.accentColor).toBe('#c96442');
   });
 });

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -3,6 +3,7 @@ import {
   buildMediaProvidersForDaemonSave,
   BYOK_PROVIDER_PRESETS,
   DEFAULT_CONFIG,
+  defaultKnownProviderModel,
   fetchMediaProvidersFromDaemon,
   isStoredMediaProviderEntryEmpty,
   isStoredMediaProviderEntryPresent,
@@ -73,6 +74,14 @@ describe('KNOWN_PROVIDERS', () => {
         'deepseek-reasoner',
       ]);
     }
+  });
+
+  it('keeps gpt-oss:120b as the Ollama Cloud default', () => {
+    const ollamaCloud = KNOWN_PROVIDERS.find(
+      (provider) => provider.label === 'Ollama Cloud (managed)',
+    );
+
+    expect(defaultKnownProviderModel(ollamaCloud)).toBe('gpt-oss:120b');
   });
 });
 

--- a/e2e/specs/mac.spec.ts
+++ b/e2e/specs/mac.spec.ts
@@ -635,7 +635,7 @@ desktopMacDescribe('mac desktop settings smoke', () => {
       mode: 'api',
       apiKey: 'sk-test',
       baseUrl: 'https://api.deepseek.com',
-      model: 'deepseek-chat',
+      model: 'deepseek-v4-flash',
       agentId: null,
       skillId: null,
       designSystemId: null,
@@ -662,7 +662,7 @@ desktopMacDescribe('mac desktop settings smoke', () => {
       expect(snapshot.selectedProtocol).toBe('Anthropic API');
       expect(snapshot.quickFillProvider).toBe('DeepSeek — Anthropic');
       expect(snapshot.baseUrl).toBe('https://api.deepseek.com/anthropic');
-      expect(snapshot.model).toBe('deepseek-chat');
+      expect(snapshot.model).toBe('deepseek-v4-flash');
     });
   }, 45_000);
 
@@ -748,7 +748,7 @@ desktopMacDescribe('mac desktop settings smoke', () => {
       mode: 'daemon',
       apiKey: 'sk-test',
       baseUrl: 'https://api.deepseek.com',
-      model: 'deepseek-chat',
+      model: 'deepseek-v4-flash',
       apiProtocol: 'openai',
       apiProviderBaseUrl: 'https://api.deepseek.com',
       agentId: 'codex',
@@ -774,7 +774,7 @@ desktopMacDescribe('mac desktop settings smoke', () => {
       expect(snapshot.selectedProtocol).toBe('OpenAI API');
       expect(snapshot.quickFillProvider).toBe('DeepSeek — OpenAI');
       expect(snapshot.baseUrl).toBe('https://api.deepseek.com');
-      expect(snapshot.model).toBe('deepseek-chat');
+      expect(snapshot.model).toBe('deepseek-v4-flash');
     });
 
     await clickDesktopExecutionModeTab(desktop, 'Local CLI');
@@ -794,7 +794,7 @@ desktopMacDescribe('mac desktop settings smoke', () => {
       expect(snapshot.selectedProtocol).toBe('OpenAI API');
       expect(snapshot.quickFillProvider).toBe('DeepSeek — OpenAI');
       expect(snapshot.baseUrl).toBe('https://api.deepseek.com');
-      expect(snapshot.model).toBe('deepseek-chat');
+      expect(snapshot.model).toBe('deepseek-v4-flash');
     });
   }, 45_000);
 

--- a/e2e/ui/api-empty-response.test.ts
+++ b/e2e/ui/api-empty-response.test.ts
@@ -17,7 +17,7 @@ test.beforeEach(async ({ page }) => {
         apiProtocol: 'openai',
         apiKey: 'sk-test',
         baseUrl: 'https://api.deepseek.com',
-        model: 'deepseek-chat',
+        model: 'deepseek-v4-flash',
         agentId: null,
         skillId: null,
         designSystemId: null,

--- a/e2e/ui/settings-api-protocol.test.ts
+++ b/e2e/ui/settings-api-protocol.test.ts
@@ -240,7 +240,7 @@ test('[P0] @critical BYOK quick fill provider updates fields and saved settings 
   await dialog.getByRole('tab', { name: 'OpenAI', exact: true }).click();
   const providerPicker = providerPresetCombobox(dialog);
   await selectComboboxOption(page, providerPicker, /DeepSeek — OpenAI/i, '[data-testid="settings-byok-provider-preset-popover"]');
-  await expectModelComboboxText(dialog, /deepseek-chat/i);
+  await expectModelComboboxText(dialog, /deepseek-v4-flash/i);
   await expect(dialog.getByLabel('Base URL')).toHaveValue('https://api.deepseek.com');
 
   await dialog.getByRole('button', { name: 'Show' }).click();
@@ -255,7 +255,7 @@ test('[P0] @critical BYOK quick fill provider updates fields and saved settings 
       apiProtocol: 'openai',
       apiKey: 'sk-openai-test',
       baseUrl: 'https://api.deepseek.com',
-      model: 'deepseek-chat',
+      model: 'deepseek-v4-flash',
       apiProviderBaseUrl: 'https://api.deepseek.com',
     });
 
@@ -268,7 +268,7 @@ test('[P0] @critical BYOK quick fill provider updates fields and saved settings 
     apiProtocol: 'openai',
     apiKey: 'sk-openai-test',
     baseUrl: 'https://api.deepseek.com',
-    model: 'deepseek-chat',
+    model: 'deepseek-v4-flash',
     apiProviderBaseUrl: 'https://api.deepseek.com',
   });
 
@@ -276,7 +276,7 @@ test('[P0] @critical BYOK quick fill provider updates fields and saved settings 
   const reopenedDialog = page.getByRole('dialog');
   await expect(reopenedDialog.getByRole('tab', { name: 'DeepSeek', exact: true })).toHaveAttribute('aria-selected', 'true');
   await expect(providerPresetCombobox(reopenedDialog)).toContainText(/DeepSeek — OpenAI/i);
-  await expectModelComboboxText(reopenedDialog, /deepseek-chat/i);
+  await expectModelComboboxText(reopenedDialog, /deepseek-v4-flash/i);
   await expect(reopenedDialog.getByLabel('Base URL')).toHaveValue('https://api.deepseek.com');
   await expect(reopenedDialog.getByLabel('API key')).toHaveValue('sk-openai-test');
 });

--- a/e2e/ui/settings-api-protocol.test.ts
+++ b/e2e/ui/settings-api-protocol.test.ts
@@ -148,7 +148,7 @@ test('[P1] known OpenAI provider is selected and can switch to Anthropic default
     apiProtocol: 'openai',
     apiVersion: '',
     baseUrl: 'https://api.deepseek.com',
-    model: 'deepseek-chat',
+    model: 'deepseek-v4-flash',
     apiProviderBaseUrl: 'https://api.deepseek.com',
     agentId: null,
     skillId: null,
@@ -170,7 +170,7 @@ test('[P1] known OpenAI provider is selected and can switch to Anthropic default
   await expect(deepSeekTab).toHaveAttribute('aria-selected', 'true');
   await expect(dialog.getByRole('heading', { name: 'OpenAI API' })).toBeVisible();
   await expect(baseUrlInput).toHaveValue('https://api.deepseek.com');
-  await expect(modelSelect).toContainText(/deepseek-chat/i);
+  await expect(modelSelect).toContainText(/deepseek-v4-flash/i);
 
   await anthropicTab.click();
 
@@ -312,11 +312,11 @@ test('[P1] BYOK Anthropic gateway preset updates fields and persists after reope
   );
   await expect(providerPresetCombobox(dialog)).toContainText(/DeepSeek — Anthropic/i);
   await expect(dialog.getByLabel('Base URL')).toHaveValue('https://api.deepseek.com/anthropic');
-  await expectModelComboboxText(dialog, /deepseek-chat/i);
+  await expectModelComboboxText(dialog, /deepseek-v4-flash/i);
   await expect.poll(async () => readSavedConfig(page)).toMatchObject({
     apiProtocol: 'anthropic',
     baseUrl: 'https://api.deepseek.com/anthropic',
-    model: 'deepseek-chat',
+    model: 'deepseek-v4-flash',
     apiProviderBaseUrl: 'https://api.deepseek.com/anthropic',
   });
 
@@ -327,7 +327,7 @@ test('[P1] BYOK Anthropic gateway preset updates fields and persists after reope
   const reopenedDialog = page.getByRole('dialog');
   await expect(providerPresetCombobox(reopenedDialog)).toContainText(/DeepSeek — Anthropic/i);
   await expect(reopenedDialog.getByLabel('Base URL')).toHaveValue('https://api.deepseek.com/anthropic');
-  await expectModelComboboxText(reopenedDialog, /deepseek-chat/i);
+  await expectModelComboboxText(reopenedDialog, /deepseek-v4-flash/i);
 });
 
 test('[P1] BYOK Ollama Cloud exposes refreshed model choices and persists selection', async ({ page }) => {

--- a/e2e/ui/settings-mcp-snippet-chip.test.ts
+++ b/e2e/ui/settings-mcp-snippet-chip.test.ts
@@ -14,7 +14,7 @@ test.beforeEach(async ({ page }) => {
   await page.addInitScript((key) => {
     window.localStorage.setItem(key, JSON.stringify({
       mode: 'api', apiProtocol: 'openai', apiKey: 'sk-test', baseUrl: 'https://api.deepseek.com',
-      model: 'deepseek-chat', agentId: null, skillId: null, designSystemId: null,
+      model: 'deepseek-v4-flash', agentId: null, skillId: null, designSystemId: null,
       onboardingCompleted: true, agentModels: {}, privacyDecisionAt: 1,
       telemetry: { metrics: false, content: false, artifactManifest: false },
     }));


### PR DESCRIPTION
## Why

While configuring Moonshot BYOK, Open Design prefilled `kimi-k2-0711-preview` even when the account model catalogue no longer contained it. The daemon also alphabetically sorted every fetched catalogue, which discarded the provider's native ordering and made it tempting to treat an arbitrary first item as the default.

Provider model IDs change over time: Kimi now recommends K2.7 Code / K2.6 and is retiring the older K2 family, while DeepSeek has announced that `deepseek-chat` and `deepseek-reasoner` will be retired in favor of `deepseek-v4-flash` and `deepseek-v4-pro`. The UI needs to reconcile curated preferences with live account availability instead of assuming a static default remains valid.

Official references:

- https://platform.kimi.com/docs/models
- https://api-docs.deepseek.com/updates/

## What users will see

- Model pickers preserve the order returned by OpenAI-compatible, Anthropic, and Gemini model-list APIs.
- Open Design chooses the first provider-preferred model that actually exists in the account catalogue. It does not blindly choose the catalogue's first item when several unmatched models are returned.
- Existing Moonshot `kimi-k2-0711-preview` and DeepSeek legacy defaults migrate to supported preferred IDs.
- Provider presets in Settings and onboarding now share one canonical registry, so their endpoint and model preferences cannot drift independently.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — this changes model ordering and automatic selection behavior without adding or changing visual structure.

## Bug fix verification

- Red specs: `apps/daemon/tests/connection-test.test.ts`, `apps/web/tests/components/byok-validation.test.ts`, `apps/web/tests/components/EntryShell.onboarding.test.tsx`, `apps/web/tests/components/SettingsDialog.execution.test.tsx`, and `apps/web/tests/state/config.test.ts`.
- The ordering and preference specs failed on `main` and pass on this branch.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `CI=1 pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/SettingsDialog.execution.test.tsx` (142 passed)
- `CI=1 pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/EntryShell.onboarding.test.tsx tests/components/byok-validation.test.ts tests/state/api-protocols.test.ts tests/state/config.test.ts` (113 passed)
- `CI=1 pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/connection-test.test.ts -t 'lists OpenAI-compatible models from /models|lists Anthropic models with display names and a high page limit|lists only Gemini models that support generateContent'` (3 passed)
- Full daemon connection-test file: 151 passed; one unrelated local Kimi CLI harness case failed because the installed Kimi returned `too many arguments. Expected 0 arguments but got 1`. No Kimi adapter code is changed by this PR.
