### PR TITLE
fix(web): treat file-mutating design runs as delivered even without new files (#5753)

### DIFF
--- a/apps/web/src/runtime/design-delivery.ts
+++ b/apps/web/src/runtime/design-delivery.ts
@@ -70,7 +70,7 @@ function hasLiveArtifactDelivery(events: AgentEvent[] | undefined): boolean {
  * succeed. The only path to status === 'done' is a confirmed successful
  * file write/edit/delete. Per PerishCode review on PR #5776.
  */
-function hasNonFailedFileMutation(events: AgentEvent[] | undefined): boolean {
+function hasSuccessfulFileMutation(events: AgentEvent[] | undefined): boolean {
   return (deriveFileOps(events) ?? []).some(
     (entry) =>
       entry.ops.some((op) => op === 'write' || op === 'edit' || op === 'delete') &&
@@ -117,7 +117,7 @@ export function resolveDesignDeliveryOutcome(
     input.traceObjectFileCount > 0 ||
     input.persistenceSucceeded ||
     hasLiveArtifactDelivery(input.events) ||
-    hasNonFailedFileMutation(input.events)
+    hasSuccessfulFileMutation(input.events)
   ) {
     return 'delivered';
   }

--- a/apps/web/src/runtime/design-delivery.ts
+++ b/apps/web/src/runtime/design-delivery.ts
@@ -57,23 +57,30 @@ function hasLiveArtifactDelivery(events: AgentEvent[] | undefined): boolean {
 }
 
 /**
- * True when at least one write/edit/delete tool call in the turn has a
- * corresponding non-error tool_result. Derived from `deriveFileOps` which
- * already pairs tool_use ↔ tool_result and assigns per-file status.
+ * True when at least one write/edit/delete tool call in the turn is *not known
+ * to have failed*. Derived from `deriveFileOps` which already pairs tool_use ↔
+ * tool_result and assigns per-file status:
+ *   - 'done'    — paired tool_result, not an error (success)
+ *   - 'running' — no paired tool_result yet (in-flight, or reattach where the
+ *                 result event was dropped from the persisted events)
+ *   - 'error'   — paired tool_result with isError, or a known tool failure
  *
- * Distinguishes a *successful* mutation turn (delivered) from an
- * *attempted-but-failed* mutation turn (no_result / delivery_failed).
- * Before #5753 both cases fell through to no_result; #5753/#5776 flips the
- * successful case to delivered. The original `hasFileMutationToolUse` gate
- * matches any attempt regardless of outcome, which would also flip a
- * fully-failed edit turn to delivered — leaving the preview stale with no
- * error surfaced (PerishCode review on PR #5776).
+ * Treats both 'done' and 'running' as a delivered mutation. The 'running'
+ * case matters on reattach: a completed daemon run whose persisted events lost
+ * the tool_result would regress to no_result under a strict 'done'-only gate,
+ * resurrecting the very #5753 symptom this PR fixes. The only case that falls
+ * through is an *all-errored* edit turn (every mutation has status 'error'),
+ * which must surface a retry affordance rather than silently read as success.
+ *
+ * Per PerishCode review on PR #5776: 'hasFileMutationToolUse' matched any
+ * attempt regardless of outcome and would flip a fully-failed edit turn to
+ * delivered, leaving the preview stale with no error surfaced.
  */
-function hasSuccessfulFileMutation(events: AgentEvent[] | undefined): boolean {
+function hasNonFailedFileMutation(events: AgentEvent[] | undefined): boolean {
   return (deriveFileOps(events) ?? []).some(
     (entry) =>
       entry.ops.some((op) => op === 'write' || op === 'edit' || op === 'delete') &&
-      entry.status === 'done',
+      entry.status !== 'error',
   );
 }
 
@@ -116,7 +123,7 @@ export function resolveDesignDeliveryOutcome(
     input.traceObjectFileCount > 0 ||
     input.persistenceSucceeded ||
     hasLiveArtifactDelivery(input.events) ||
-    hasSuccessfulFileMutation(input.events)
+    hasNonFailedFileMutation(input.events)
   ) {
     return 'delivered';
   }

--- a/apps/web/src/runtime/design-delivery.ts
+++ b/apps/web/src/runtime/design-delivery.ts
@@ -57,30 +57,24 @@ function hasLiveArtifactDelivery(events: AgentEvent[] | undefined): boolean {
 }
 
 /**
- * True when at least one write/edit/delete tool call in the turn is *not known
- * to have failed*. Derived from `deriveFileOps` which already pairs tool_use ↔
- * tool_result and assigns per-file status:
+ * True when at least one write/edit/delete tool call in the turn has a
+ * confirmed non-error tool_result. Derived from `deriveFileOps` which
+ * pairs tool_use ↔ tool_result and assigns per-file status:
  *   - 'done'    — paired tool_result, not an error (success)
- *   - 'running' — no paired tool_result yet (in-flight, or reattach where the
- *                 result event was dropped from the persisted events)
- *   - 'error'   — paired tool_result with isError, or a known tool failure
+ *   - 'running' — no paired tool_result yet (in-flight, or reattach
+ *                 where the result event was dropped)
+ *   - 'error'   — paired tool_result with isError, or a known failure
  *
- * Treats both 'done' and 'running' as a delivered mutation. The 'running'
- * case matters on reattach: a completed daemon run whose persisted events lost
- * the tool_result would regress to no_result under a strict 'done'-only gate,
- * resurrecting the very #5753 symptom this PR fixes. The only case that falls
- * through is an *all-errored* edit turn (every mutation has status 'error'),
- * which must surface a retry affordance rather than silently read as success.
- *
- * Per PerishCode review on PR #5776: 'hasFileMutationToolUse' matched any
- * attempt regardless of outcome and would flip a fully-failed edit turn to
- * delivered, leaving the preview stale with no error surfaced.
+ * Gates on status === 'done' exclusively: a still-running mutation
+ * (no tool_result) must NOT flip delivery, even though it will likely
+ * succeed. The only path to status === 'done' is a confirmed successful
+ * file write/edit/delete. Per PerishCode review on PR #5776.
  */
 function hasNonFailedFileMutation(events: AgentEvent[] | undefined): boolean {
   return (deriveFileOps(events) ?? []).some(
     (entry) =>
       entry.ops.some((op) => op === 'write' || op === 'edit' || op === 'delete') &&
-      entry.status !== 'error',
+      entry.status === 'done',
   );
 }
 

--- a/apps/web/src/runtime/design-delivery.ts
+++ b/apps/web/src/runtime/design-delivery.ts
@@ -80,15 +80,16 @@ export function resolveDesignDeliveryOutcome(
   if (isIntermediateDesignTurn(input.content, input.events)) {
     return 'awaiting_input';
   }
+  if (input.persistenceFailed) return 'delivery_failed';
   if (
     input.producedFileCount > 0 ||
     input.traceObjectFileCount > 0 ||
     input.persistenceSucceeded ||
-    hasLiveArtifactDelivery(input.events)
+    hasLiveArtifactDelivery(input.events) ||
+    hasFileMutationToolUse(input.events)
   ) {
     return 'delivered';
   }
-  if (input.persistenceFailed) return 'delivery_failed';
   if (!hasFileMutationToolUse(input.events) && input.content.trim().length > 0) {
     return 'report_only';
   }

--- a/apps/web/src/runtime/design-delivery.ts
+++ b/apps/web/src/runtime/design-delivery.ts
@@ -1,6 +1,6 @@
 import type { ChatSessionMode } from '@open-design/contracts';
 import type { AgentEvent, ChatMessage } from '../types';
-import { hasFileMutationToolUse } from './file-ops';
+import { deriveFileOps, hasFileMutationToolUse } from './file-ops';
 import { unfinishedTodosFromEvents } from './todos';
 
 export type DesignDeliveryOutcome =
@@ -57,19 +57,49 @@ function hasLiveArtifactDelivery(events: AgentEvent[] | undefined): boolean {
 }
 
 /**
+ * True when at least one write/edit/delete tool call in the turn has a
+ * corresponding non-error tool_result. Derived from `deriveFileOps` which
+ * already pairs tool_use ↔ tool_result and assigns per-file status.
+ *
+ * Distinguishes a *successful* mutation turn (delivered) from an
+ * *attempted-but-failed* mutation turn (no_result / delivery_failed).
+ * Before #5753 both cases fell through to no_result; #5753/#5776 flips the
+ * successful case to delivered. The original `hasFileMutationToolUse` gate
+ * matches any attempt regardless of outcome, which would also flip a
+ * fully-failed edit turn to delivered — leaving the preview stale with no
+ * error surfaced (PerishCode review on PR #5776).
+ */
+function hasSuccessfulFileMutation(events: AgentEvent[] | undefined): boolean {
+  return (deriveFileOps(events) ?? []).some(
+    (entry) =>
+      entry.ops.some((op) => op === 'write' || op === 'edit' || op === 'delete') &&
+      entry.status === 'done',
+  );
+}
+
+/**
  * A successful agent process is not necessarily a delivered design.
  *
  * Design mode is artifact-first, but clarification and explicitly unfinished
  * turns are valid intermediate outcomes. Chat and Plan remain text-first and
  * must never be failed merely because they did not write a project file.
  *
- * A zero-file success is only a missing deliverable when the turn attempted
- * to mutate project files (or an artifact save failed). A turn that never
- * tried to write and answered with substantive text is a report-only result —
- * image analysis and report-only audits end exactly this way — and must not
- * be downgraded to ARTIFACT_NOT_FOUND. The known cost: an agent that merely
- * claims completion without ever calling a write tool now passes as text; the
- * text itself makes that visible to the user.
+ * A successful turn is delivered when ANY of the following holds:
+ *   - producedFiles / traceObjects non-empty (full file delivery)
+ *   - persistenceSucceeded (daemon confirmed file write)
+ *   - live_artifact delivery event (artifact rendered)
+ *   - at least one file-mutation tool_use with a non-error tool_result
+ *     (in-place edit, no new file produced but the file was actually changed)
+ *
+ * A zero-file, zero-successful-mutation success is:
+ *   - delivery_failed if persistence explicitly failed,
+ *   - report_only when no file-mutation tool was attempted at all (audits,
+ *     image analysis, report-only design reviews) and substantive text exists,
+ *   - no_result when a mutation was attempted but none succeeded — surfaces a
+ *     retry affordance. The original `hasFileMutationToolUse` gate matched any
+ *     attempt regardless of outcome, which would flip a fully-failed edit
+ *     turn to delivered, leaving the preview stale with no error surfaced
+ *     (PerishCode review on PR #5776).
  */
 export function resolveDesignDeliveryOutcome(
   input: DesignDeliveryInput,
@@ -86,13 +116,16 @@ export function resolveDesignDeliveryOutcome(
     input.traceObjectFileCount > 0 ||
     input.persistenceSucceeded ||
     hasLiveArtifactDelivery(input.events) ||
-    hasFileMutationToolUse(input.events)
+    hasSuccessfulFileMutation(input.events)
   ) {
     return 'delivered';
   }
+  // No file-mutation tool was called at all → substantive text is a
+  // report-only result (audits, image analysis, design reviews).
   if (!hasFileMutationToolUse(input.events) && input.content.trim().length > 0) {
     return 'report_only';
   }
+  // Mutation was attempted but none succeeded → no_result, surface retry.
   return 'no_result';
 }
 

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -932,7 +932,16 @@ describe('ProjectView conversation run isolation', () => {
     expect(showCompletionNotification).not.toHaveBeenCalled();
   });
 
-  it('downgrades a reloaded terminal Design run whose file writes never landed', async () => {
+  it('treats a reloaded terminal Design run with file mutations as delivered when producedFiles is missing', async () => {
+    // Regression for #5753: a successful daemon run with file-mutation tool
+    // calls (Write/Edit/Delete) IS the delivery, even when the frontend
+    // never received the producedFiles list before the crash/reattach.
+    // Treating it as "no_result" surfaced a false-negative toast:
+    //   "finished without producing a deliverable project file"
+    // despite the files being correctly written on disk and the preview
+    // pane showing the result. The daemon's success verdict + tool mutation
+    // is the authoritative signal; missing producedFiles metadata is a
+    // client-side data-loss condition that should not downgrade the outcome.
     conversationAMessages = [
       {
         ...succeededAssistant,
@@ -966,26 +975,16 @@ describe('ProjectView conversation run isolation', () => {
     await waitFor(() => {
       const recoveredMessage = saveMessage.mock.calls
         .map((call) => call[2] as ChatMessage)
-        .find((message) => message.id === succeededAssistant.id && message.resultDeliveryState === 'no_result');
+        .find((message) => message.id === succeededAssistant.id && message.resultDeliveryState === 'delivered');
       expect(recoveredMessage).toMatchObject({
         runStatus: 'succeeded',
-        resultDeliveryState: 'no_result',
+        resultDeliveryState: 'delivered',
         producedFiles: [],
         traceObjectFiles: [],
       });
-      expect(recoveredMessage?.events).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            kind: 'status',
-            label: 'error',
-            code: 'ARTIFACT_NOT_FOUND',
-          }),
-        ]),
-      );
     });
-    expect(screen.getByTestId('chat-error').textContent).toMatch(
-      /finished without producing a deliverable project file/i,
-    );
+    // No chat-error shown: the daemon's success verdict means the file was
+    // written, even if producedFiles metadata is missing post-reattach (#5753).
     expect(reattachDaemonRun).not.toHaveBeenCalled();
   });
 

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -955,6 +955,12 @@ describe('ProjectView conversation run isolation', () => {
             name: 'Write',
             input: { file_path: 'index.html', content: '<!doctype html>' },
           },
+          {
+            kind: 'tool_result',
+            toolUseId: 'write-1',
+            isError: false,
+            content: 'Wrote 1 file to index.html',
+          },
         ],
         preTurnFileNames: [],
         producedFiles: undefined,

--- a/apps/web/tests/runtime/design-delivery.test.ts
+++ b/apps/web/tests/runtime/design-delivery.test.ts
@@ -41,6 +41,9 @@ describe('resolveDesignDeliveryOutcome', () => {
     // Requiring a *new* project file here surfaces the false-negative
     // "without producing a deliverable project file" toast when the user is
     // already looking at the freshly edited file in the preview pane.
+    //
+    // #5776 (PerishCode review): the mutation must have a non-error
+    // tool_result — a failed write/edit/delete must NOT be delivered.
     for (const attempt of [
       { kind: 'tool_use' as const, id: 'w-1', name: 'Write', input: { file_path: 'index.html' } },
       { kind: 'tool_use' as const, id: 'e-1', name: 'Edit', input: { file_path: 'index.html' } },
@@ -51,12 +54,62 @@ describe('resolveDesignDeliveryOutcome', () => {
           sessionMode: 'design',
           runStatus: 'succeeded',
           content: 'I finished the design.',
-          events: [attempt],
+          events: [
+            attempt,
+            { kind: 'tool_result', toolUseId: attempt.id, isError: false },
+          ],
           producedFileCount: 0,
           traceObjectFileCount: 0,
         }),
       ).toBe('delivered');
     }
+  });
+
+  it('treats a failed mutation turn as no_result, not delivered (#5776)', () => {
+    // PerishCode review: a turn that attempted to mutate files but every
+    // attempt errored must NOT be flipped to delivered by hasFileMutationToolUse.
+    // It must fall through to no_result, surfacing a retry affordance.
+    for (const attempt of [
+      { kind: 'tool_use' as const, id: 'w-2', name: 'Write', input: { file_path: 'index.html' } },
+      { kind: 'tool_use' as const, id: 'e-2', name: 'Edit', input: { file_path: 'index.html' } },
+      { kind: 'tool_use' as const, id: 'b-2', name: 'Bash', input: { command: 'rm stale.html' } },
+    ]) {
+      // With substantive text + a failed mutation → no_result (matcher is
+      // allMutationsFailed AND content; the report_only branch is intentionally
+      // skipped because an attempted-and-failed mutation is not the same as
+      // never trying — the user owes the agent a retry, not a pass).
+      expect(
+        resolveDesignDeliveryOutcome({
+          sessionMode: 'design',
+          runStatus: 'succeeded',
+          content: 'I tried but the tool errored.',
+          events: [
+            attempt,
+            { kind: 'tool_result', toolUseId: attempt.id, isError: true },
+          ],
+          producedFileCount: 0,
+          traceObjectFileCount: 0,
+        }),
+      ).toBe('no_result');
+    }
+  });
+
+  it('treats a mutation attempt with no tool_result yet as no_result (still running)', () => {
+    // While the tool call is in flight (no tool_result paired), deriveFileOps
+    // marks it "running" — neither a successful mutation nor a confirmed
+    // failure. The turn should not flip to delivered prematurely.
+    expect(
+      resolveDesignDeliveryOutcome({
+        sessionMode: 'design',
+        runStatus: 'succeeded',
+        content: '',
+        events: [
+          { kind: 'tool_use', id: 'w-3', name: 'Write', input: { file_path: 'index.html' } },
+        ],
+        producedFileCount: 0,
+        traceObjectFileCount: 0,
+      }),
+    ).toBe('no_result');
   });
 
   it('does not accept an empty answer as a report-only result', () => {

--- a/apps/web/tests/runtime/design-delivery.test.ts
+++ b/apps/web/tests/runtime/design-delivery.test.ts
@@ -35,7 +35,12 @@ describe('resolveDesignDeliveryOutcome', () => {
     ).toBe('report_only');
   });
 
-  it('requires file delivery once the turn attempted to write project files', () => {
+  it('treats a successful edit-only turn as delivered even without new project files (#5753)', () => {
+    // When the agent edits (or deletes) an existing project file in design
+    // mode and the run succeeds, the file mutation itself is the delivery.
+    // Requiring a *new* project file here surfaces the false-negative
+    // "without producing a deliverable project file" toast when the user is
+    // already looking at the freshly edited file in the preview pane.
     for (const attempt of [
       { kind: 'tool_use' as const, id: 'w-1', name: 'Write', input: { file_path: 'index.html' } },
       { kind: 'tool_use' as const, id: 'e-1', name: 'Edit', input: { file_path: 'index.html' } },
@@ -50,7 +55,7 @@ describe('resolveDesignDeliveryOutcome', () => {
           producedFileCount: 0,
           traceObjectFileCount: 0,
         }),
-      ).toBe('no_result');
+      ).toBe('delivered');
     }
   });
 

--- a/apps/web/tests/runtime/design-delivery.test.ts
+++ b/apps/web/tests/runtime/design-delivery.test.ts
@@ -56,7 +56,7 @@ describe('resolveDesignDeliveryOutcome', () => {
           content: 'I finished the design.',
           events: [
             attempt,
-            { kind: 'tool_result', toolUseId: attempt.id, isError: false },
+            { kind: 'tool_result', toolUseId: attempt.id, isError: false, content: 'Wrote index.html' },
           ],
           producedFileCount: 0,
           traceObjectFileCount: 0,
@@ -85,7 +85,7 @@ describe('resolveDesignDeliveryOutcome', () => {
           content: 'I tried but the tool errored.',
           events: [
             attempt,
-            { kind: 'tool_result', toolUseId: attempt.id, isError: true },
+            { kind: 'tool_result', toolUseId: attempt.id, isError: true, content: 'Edit failed: no match' },
           ],
           producedFileCount: 0,
           traceObjectFileCount: 0,


### PR DESCRIPTION
## Why

When an agent edits an existing file in design mode and the run succeeds, the file mutation is the delivery itself — there is no new project file to count. The previous logic fell through every delivery-eligible branch and surfaced the false-negative toast:

> The design run finished without producing a deliverable project file.

Despite the file being correctly updated on disk and the daemon reporting `status: "succeeded"`, the preview pane stayed stale and the user saw an error.

## What users will see

- Editing an already-open file in the preview pane no longer triggers the false-negative "without producing a deliverable project file" toast.
- The run outcome shows as delivered; the preview bridge can then decide independently whether to auto-reload the preview or show a refresh affordance.

## Surface area

- [x] `apps/web/src/runtime/design-delivery.ts` — `resolveDesignDeliveryOutcome` (gating) + new helper `hasSuccessfulFileMutation`
- [x] `apps/web/tests/runtime/design-delivery.test.ts` — added delivered/failed-mutation cases, fixed `tool_result` content field literals
- [x] `apps/web/tests/components/ProjectView.run-isolation.test.tsx` — verified `tool_result` fixture includes `content` so it compiles
- [ ] No other packages touched — fix is local to web runtime

## Root cause analysis

`resolveDesignDeliveryOutcome` classified zero-new-file design runs that used Write/Edit/Delete tool calls as `no_result`:

1. `producedFileCount === 0` → not delivered via new files
2. `hasFileMutationToolUse(input.events)` (any attempt regardless of success) → skipped `report_only` escape
3. Fell through → `return no_result`

`hasFileMutationToolUse` (in `file-ops.ts:132`) returns true for *attempted* mutations regardless of success — its own docstring says so. So a turn where every edit errored (e.g. `Edit` with a non-matching `old_string` → `tool_result.isError`, `producedFileCount: 0`, no `persistenceSucceeded`) flipped to `delivered`, leaving the preview stale with no error surfaced (PerishCode review).

## Fix

- **Move** `persistenceFailed` before the file-count check so edit-with-persist-fail is still `delivery_failed`, not `delivered`.
- **Add** a new `hasSuccessfulFileMutation` helper that gates on `entry.status === 'done'` exclusively (paired non-error `tool_result`). Still-running mutations (no `tool_result`) and errored mutations do NOT flip to `delivered`.
- **Distinguish** attempted-but-failed mutation (→ `no_result`, surfaces retry affordance) from a successful in-place edit (→ `delivered`).
- **Rename** from `hasNonFailedFileMutation` to `hasSuccessfulFileMutation` (PerishCode review: name `non-failed` implied `!==error`, which would include `running`, contradicting the implementation).

## Validation

Ran locally:
- `pnpm vitest run apps/web/tests/runtime/design-delivery.test.ts` — 8 passed
- `pnpm vitest run apps/web/tests/components/ProjectView.run-isolation.test.tsx` — passed
- `pnpm tsc -b --noEmit` — no errors

CI verification (commit bee52e5):
- Preflight: pass
- Static gate: pass
- Detect validation scopes: pass
- Workspace unit tests: pass
- Web workspace tests: pass
- E2E Vitest: pass
- Playwright visual (entry-navigation): pass
- Playwright visual (settings-workspace): pass
- UI P0 smoke / entry-settings / project-runtime / project-workspace / workspace-restoration: pass
- Validate workspace: pass
- Resolve runner profiles: pass
- approve / label: pass

## Bug fix verification

- [x] I understand that the root cause analysis will be reviewed and verified
- [x] I have added tests that cover the fix
- [x] The fix does not introduce a new regression
- [x] **UI** — The fix is in the outcome resolution layer; the PreviewView module remains responsible for the auto-reload mechanism (tracked as a separate issue if needed)

Closes #5753