### PR TITLE
feat(web): connect message center to vela

### DIFF
--- a/apps/daemon/src/routes/vela.ts
+++ b/apps/daemon/src/routes/vela.ts
@@ -1,5 +1,6 @@
 import type { Express, Request, Response } from 'express';
 import dns from 'node:dns';
+import http from 'node:http';
 import https from 'node:https';
 
 import {
@@ -23,6 +24,7 @@ import {
   parseVelaLoginAttribution,
   peekVelaLiveAccount,
   readVelaCredentialRevision,
+  readVelaControlApiContext,
   readVelaLoginStatus,
   setVelaLiveAccount,
   shouldRefreshVelaLiveAccount,
@@ -42,6 +44,7 @@ import {
 } from '../runtimes/defs/amr.js';
 
 const AMR_API_PROXY_PREFIX = '/api/integrations/vela/api-proxy';
+const VELA_MESSAGE_CENTER_PREFIX = '/api/integrations/vela/message-center';
 const AMR_API_UPSTREAM_ORIGIN = 'https://amr-api.open-design.ai';
 
 type ReadAppConfig = (dataDir: string) => Promise<AppConfigPrefs>;
@@ -138,6 +141,64 @@ function proxyAmrApiRequest(req: Request, res: Response): void {
   } else {
     upstream.end();
   }
+}
+
+function isAllowedMessageCenterRequest(method: string, pathname: string): boolean {
+  if (method === 'GET' && pathname === '/messages') return true;
+  if (method !== 'POST') return false;
+  return pathname === '/read-all' || /^\/messages\/[^/]+\/read$/.test(pathname);
+}
+
+function proxyVelaMessageCenterRequest(
+  req: Request,
+  res: Response,
+  context: { apiUrl: string; controlKey: string },
+): void {
+  const suffix = req.originalUrl.slice(VELA_MESSAGE_CENTER_PREFIX.length);
+  const parsedSuffix = new URL(suffix, 'http://message-center.local');
+  if (!isAllowedMessageCenterRequest(req.method, parsedSuffix.pathname)) {
+    res.status(404).json({ error: 'unknown_message_center_path' });
+    return;
+  }
+  const target = new URL(
+    `/api/v1/message-center${parsedSuffix.pathname}${parsedSuffix.search}`,
+    context.apiUrl,
+  );
+  if (target.protocol !== 'http:' && target.protocol !== 'https:') {
+    res.status(500).json({ error: 'invalid_vela_api_url' });
+    return;
+  }
+  const body = velaProxyRequestBody(req);
+  const headers: Record<string, string> = {
+    accept: typeof req.headers.accept === 'string' ? req.headers.accept : 'application/json',
+    authorization: `Bearer ${context.controlKey}`,
+  };
+  if (typeof req.headers['content-type'] === 'string') {
+    headers['content-type'] = req.headers['content-type'];
+  }
+  if (body) headers['content-length'] = String(body.length);
+  const transport = target.protocol === 'https:' ? https : http;
+  const upstream = transport.request(
+    target,
+    { method: req.method, headers },
+    (upstreamRes) => {
+      res.status(upstreamRes.statusCode ?? 502);
+      for (const [key, value] of Object.entries(upstreamRes.headers)) {
+        if (value !== undefined) res.setHeader(key, value);
+      }
+      upstreamRes.pipe(res);
+    },
+  );
+  upstream.setTimeout(30_000, () => upstream.destroy(new Error('Vela Message Center timed out')));
+  upstream.on('error', (err) => {
+    if (!res.headersSent) {
+      res.status(502).json({ error: err instanceof Error ? err.message : String(err) });
+    } else {
+      res.end();
+    }
+  });
+  if (body) upstream.write(body);
+  upstream.end();
 }
 
 export function registerVelaRoutes(app: Express, deps: RegisterVelaRoutesDeps): void {
@@ -301,6 +362,21 @@ export function registerVelaRoutes(app: Express, deps: RegisterVelaRoutesDeps): 
   });
 
   app.all('/api/integrations/vela/api-proxy/*splat', proxyAmrApiRequest);
+
+  app.all('/api/integrations/vela/message-center/*splat', async (req, res) => {
+    try {
+      const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
+      const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'amr');
+      const context = readVelaControlApiContext(env, configuredEnv);
+      if (!context) {
+        res.status(401).json({ error: 'vela_control_key_required' });
+        return;
+      }
+      proxyVelaMessageCenterRequest(req, res, context);
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
 
   app.post('/api/integrations/vela/login', async (req, res) => {
     try {

--- a/apps/daemon/tests/integrations/vela.routes.test.ts
+++ b/apps/daemon/tests/integrations/vela.routes.test.ts
@@ -1271,11 +1271,27 @@ describe('ALL /api/integrations/vela/message-center/*', () => {
           authorization: 'Bearer ck-seeded-key',
         },
       ]);
-      const rejected = await fetch(
-        `${baseUrl}/api/integrations/vela/message-center/../wallet/balance`,
+      const markRead = await fetch(
+        `${baseUrl}/api/integrations/vela/message-center/messages/release/read`,
+        { method: 'POST' },
       );
+      expect(markRead.status).toBe(200);
+      expect(requests).toEqual([
+        {
+          url: '/api/v1/message-center/messages?locale=en-US&limit=30',
+          method: 'GET',
+          authorization: 'Bearer ck-seeded-key',
+        },
+        {
+          url: '/api/v1/message-center/messages/release/read',
+          method: 'POST',
+          authorization: 'Bearer ck-seeded-key',
+        },
+      ]);
+      const rejected = await fetch(`${baseUrl}/api/integrations/vela/message-center/wallet/balance`);
       expect(rejected.status).toBe(404);
-      expect(requests).toHaveLength(1);
+      expect(await rejected.json()).toEqual({ error: 'unknown_message_center_path' });
+      expect(requests).toHaveLength(2);
     } finally {
       await new Promise<void>((resolve) => upstream.close(() => resolve()));
     }

--- a/apps/daemon/tests/integrations/vela.routes.test.ts
+++ b/apps/daemon/tests/integrations/vela.routes.test.ts
@@ -1243,6 +1243,53 @@ describe('ALL /api/integrations/vela/api-proxy/*', () => {
   });
 });
 
+describe('ALL /api/integrations/vela/message-center/*', () => {
+  it('forwards only Message Center routes to the configured profile origin with its control key', async () => {
+    const requests: Array<{ url: string; method: string; authorization: string | undefined }> = [];
+    const upstream = createServer((req, res) => {
+      requests.push({
+        url: req.url ?? '',
+        method: req.method ?? '',
+        authorization: req.headers.authorization,
+      });
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ messages: [], nextCursor: null, unreadCount: 0 }));
+    });
+    await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+    const address = upstream.address() as AddressInfo;
+    seedLogin('local', { apiUrl: `http://127.0.0.1:${address.port}` });
+    try {
+      const response = await fetch(
+        `${baseUrl}/api/integrations/vela/message-center/messages?locale=en-US&limit=30`,
+        { headers: { authorization: 'Bearer browser-supplied-key' } },
+      );
+      expect(response.status).toBe(200);
+      expect(requests).toEqual([
+        {
+          url: '/api/v1/message-center/messages?locale=en-US&limit=30',
+          method: 'GET',
+          authorization: 'Bearer ck-seeded-key',
+        },
+      ]);
+      const rejected = await fetch(
+        `${baseUrl}/api/integrations/vela/message-center/../wallet/balance`,
+      );
+      expect(rejected.status).toBe(404);
+      expect(requests).toHaveLength(1);
+    } finally {
+      await new Promise<void>((resolve) => upstream.close(() => resolve()));
+    }
+  });
+
+  it('fails visibly when no control key is configured', async () => {
+    const response = await fetch(
+      `${baseUrl}/api/integrations/vela/message-center/messages?locale=en-US`,
+    );
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: 'vela_control_key_required' });
+  });
+});
+
 describe('POST /api/integrations/vela/analytics-entry', () => {
   it('mirrors Open Design AMR entry clicks to the AMR analytics ingest shape', async () => {
     const requests: unknown[] = [];

--- a/apps/web/src/components/MessageCenterDemo.module.css
+++ b/apps/web/src/components/MessageCenterDemo.module.css
@@ -101,6 +101,7 @@
 .close:focus-visible,
 .filter:focus-visible,
 .markAll:focus-visible,
+.syncStatus button:focus-visible,
 .itemSummary:focus-visible,
 .itemActions button:focus-visible,
 .primaryAction:focus-visible,
@@ -195,6 +196,32 @@
   padding: 12px 12px calc(28px + env(safe-area-inset-bottom, 0px));
   scroll-padding-block: 12px calc(28px + env(safe-area-inset-bottom, 0px));
   touch-action: pan-y;
+}
+
+.syncStatus {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid color-mix(in srgb, var(--warning, #d9a441) 32%, var(--border));
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--warning, #d9a441) 10%, var(--bg));
+  color: var(--text);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.syncStatus button {
+  flex: 0 0 auto;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 600;
 }
 
 .item {

--- a/apps/web/src/components/MessageCenterDemo.tsx
+++ b/apps/web/src/components/MessageCenterDemo.tsx
@@ -5,6 +5,7 @@ import { createPortal } from 'react-dom';
 import { useI18n } from '../i18n';
 import {
   anonymousStartedAt,
+  clearAnonymousState,
   isAmrLoggedIn,
   markAccountMessageRead,
   markAllAccountMessagesRead,
@@ -43,6 +44,8 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
   const [readIds, setReadIds] = useState<Set<string>>(new Set());
   const [loggedIn, setLoggedIn] = useState(false);
   const [syncError, setSyncError] = useState(false);
+  const loggedInRef = useRef(false);
+  const authResolvedRef = useRef(false);
   const messagesRef = useRef<MessageCenterMessage[]>([]);
   const readIdsRef = useRef<Set<string>>(new Set());
   const pendingReadIdsRef = useRef<Set<string>>(new Set());
@@ -63,6 +66,9 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
     const requestId = syncRequestIdRef.current + 1;
     syncRequestIdRef.current = requestId;
     const account = await isAmrLoggedIn();
+    authResolvedRef.current = true;
+    loggedInRef.current = account;
+    setLoggedIn(account);
     const startedAt = anonymousStartedAt(window.localStorage);
     const pulled = await pullMessageCenter({ locale, loggedIn: account, startedAt });
     if (requestId !== syncRequestIdRef.current) return;
@@ -75,16 +81,25 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
     const overlayReadIds = new Set([
       ...serverReadIds,
       ...(account ? pendingReadIdsRef.current : []),
-      ...readIdsRef.current,
+      ...(!account ? readIdsRef.current : []),
     ]);
     const merged = pulled.map((message) => ({
       ...message,
       readAt: message.readAt ?? (overlayReadIds.has(message.id) ? new Date().toISOString() : null),
     }));
-    setLoggedIn(account);
+    if (account) clearAnonymousState(window.localStorage);
     commitState(merged, overlayReadIds, { persistAnonymous: !account });
     setSyncError(false);
   }, [commitState, locale]);
+
+  const resolveLoggedInForWrite = useCallback(async () => {
+    if (authResolvedRef.current) return loggedInRef.current;
+    const account = await isAmrLoggedIn();
+    authResolvedRef.current = true;
+    loggedInRef.current = account;
+    setLoggedIn(account);
+    return account;
+  }, []);
 
   const retrySync = useCallback(() => {
     void sync().catch(() => setSyncError(true));
@@ -144,21 +159,29 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
   const markRead = async (messageId: string) => {
     const message = messagesRef.current.find((item) => item.id === messageId);
     if (!message || message.readAt) return;
+    const account = await resolveLoggedInForWrite();
     const readAt = new Date().toISOString();
-    if (loggedIn) await markAccountMessageRead(messageId);
+    if (account) await markAccountMessageRead(messageId);
     const nextIds = new Set(readIdsRef.current).add(messageId);
     const nextMessages = messagesRef.current.map((item) => (item.id === messageId ? { ...item, readAt } : item));
-    if (loggedIn) pendingReadIdsRef.current = new Set(pendingReadIdsRef.current).add(messageId);
-    commitState(nextMessages, nextIds, { persistAnonymous: !loggedIn });
+    if (account) {
+      pendingReadIdsRef.current = new Set(pendingReadIdsRef.current).add(messageId);
+      clearAnonymousState(window.localStorage);
+    }
+    commitState(nextMessages, nextIds, { persistAnonymous: !account });
   };
 
   const markAllRead = async () => {
-    if (loggedIn) await markAllAccountMessagesRead();
+    const account = await resolveLoggedInForWrite();
+    if (account) await markAllAccountMessagesRead();
     const readAt = new Date().toISOString();
     const nextIds = new Set(messagesRef.current.map((message) => message.id));
     const nextMessages = messagesRef.current.map((message) => ({ ...message, readAt: message.readAt ?? readAt }));
-    if (loggedIn) pendingReadIdsRef.current = new Set(nextIds);
-    commitState(nextMessages, nextIds, { persistAnonymous: !loggedIn });
+    if (account) {
+      pendingReadIdsRef.current = new Set(nextIds);
+      clearAnonymousState(window.localStorage);
+    }
+    commitState(nextMessages, nextIds, { persistAnonymous: !account });
   };
 
   const openLabel = unreadCount > 0 ? `${t('messageCenter.openAria')} (${t('messageCenter.unreadCount', { count: unreadCount })})` : t('messageCenter.openAria');

--- a/apps/web/src/components/MessageCenterDemo.tsx
+++ b/apps/web/src/components/MessageCenterDemo.tsx
@@ -1,97 +1,28 @@
 import { Button } from '@open-design/components';
-import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-import type { Dict } from '../i18n/types';
-import { useT } from '../i18n';
+import { useI18n } from '../i18n';
+import {
+  anonymousStartedAt,
+  isAmrLoggedIn,
+  markAccountMessageRead,
+  markAllAccountMessagesRead,
+  pullMessageCenter,
+  readAnonymousMessages,
+  readAnonymousReadIds,
+  type MessageCenterFilter,
+  type MessageCenterMessage,
+  writeAnonymousState,
+} from '../message-center-client';
 import { Icon } from './Icon';
 import styles from './MessageCenterDemo.module.css';
 
-type MessageFilter = 'all' | 'unread' | 'read';
-
-interface DemoMessage {
-  id: string;
-  typeKey: keyof Dict;
-  titleKey: keyof Dict;
-  summaryKey: keyof Dict;
-  bodyKey: keyof Dict;
-  actionKey: keyof Dict;
-  timeKey: keyof Dict;
-  unread: boolean;
-}
-
-interface DemoMessageState {
-  read: boolean;
-  expanded: boolean;
-}
-
-const FILTERS: Array<{ id: MessageFilter; labelKey: keyof Dict }> = [
-  { id: 'all', labelKey: 'messageCenter.filterAll' },
-  { id: 'unread', labelKey: 'messageCenter.filterUnread' },
-  { id: 'read', labelKey: 'messageCenter.filterRead' },
+const FILTERS: Array<{ id: MessageCenterFilter; label: 'messageCenter.filterAll' | 'messageCenter.filterUnread' | 'messageCenter.filterRead' }> = [
+  { id: 'all', label: 'messageCenter.filterAll' },
+  { id: 'unread', label: 'messageCenter.filterUnread' },
+  { id: 'read', label: 'messageCenter.filterRead' },
 ];
-
-const DEMO_MESSAGES: DemoMessage[] = [
-  {
-    id: 'release-0130',
-    typeKey: 'messageCenter.type.product',
-    titleKey: 'messageCenter.demo.release.title',
-    summaryKey: 'messageCenter.demo.release.summary',
-    bodyKey: 'messageCenter.demo.release.body',
-    actionKey: 'messageCenter.demo.release.action',
-    timeKey: 'messageCenter.time.today',
-    unread: true,
-  },
-  {
-    id: 'teams-preview',
-    typeKey: 'messageCenter.type.announcement',
-    titleKey: 'messageCenter.demo.teams.title',
-    summaryKey: 'messageCenter.demo.teams.summary',
-    bodyKey: 'messageCenter.demo.teams.body',
-    actionKey: 'messageCenter.demo.teams.action',
-    timeKey: 'messageCenter.time.yesterday',
-    unread: true,
-  },
-  {
-    id: 'credits-pack',
-    typeKey: 'messageCenter.type.benefit',
-    titleKey: 'messageCenter.demo.credits.title',
-    summaryKey: 'messageCenter.demo.credits.summary',
-    bodyKey: 'messageCenter.demo.credits.body',
-    actionKey: 'messageCenter.demo.credits.action',
-    timeKey: 'messageCenter.time.jun30',
-    unread: false,
-  },
-  {
-    id: 'maintenance',
-    typeKey: 'messageCenter.type.maintenance',
-    titleKey: 'messageCenter.demo.maintenance.title',
-    summaryKey: 'messageCenter.demo.maintenance.summary',
-    bodyKey: 'messageCenter.demo.maintenance.body',
-    actionKey: 'messageCenter.demo.maintenance.action',
-    timeKey: 'messageCenter.time.jun29',
-    unread: true,
-  },
-  {
-    id: 'templates',
-    typeKey: 'messageCenter.type.template',
-    titleKey: 'messageCenter.demo.templates.title',
-    summaryKey: 'messageCenter.demo.templates.summary',
-    bodyKey: 'messageCenter.demo.templates.body',
-    actionKey: 'messageCenter.demo.templates.action',
-    timeKey: 'messageCenter.time.jun27',
-    unread: false,
-  },
-];
-
-function createInitialState(): Record<string, DemoMessageState> {
-  return Object.fromEntries(
-    DEMO_MESSAGES.map((message) => [
-      message.id,
-      { read: !message.unread, expanded: false },
-    ]),
-  );
-}
 
 function unreadBadgeLabel(count: number): string {
   return count > 9 ? '9+' : String(count);
@@ -102,68 +33,75 @@ interface Props {
 }
 
 export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
-  const t = useT();
+  const { locale, t } = useI18n();
   const titleId = useId();
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const panelRef = useRef<HTMLElement | null>(null);
-  const listRef = useRef<HTMLDivElement | null>(null);
-  const itemRefs = useRef<Map<string, HTMLElement>>(new Map());
   const [open, setOpen] = useState(false);
-  const [filter, setFilter] = useState<MessageFilter>('all');
-  const [messages, setMessages] = useState(createInitialState);
-  const [toast, setToast] = useState<string | null>(null);
+  const [filter, setFilter] = useState<MessageCenterFilter>('all');
+  const [messages, setMessages] = useState<MessageCenterMessage[]>([]);
+  const [readIds, setReadIds] = useState<Set<string>>(new Set());
+  const [loggedIn, setLoggedIn] = useState(false);
+  const [syncError, setSyncError] = useState(false);
 
-  const unreadCount = useMemo(
-    () =>
-      DEMO_MESSAGES.filter((message) => {
-        const state = messages[message.id];
-        return state && !state.read;
-      }).length,
-    [messages],
-  );
+  const sync = useCallback(async () => {
+    const account = await isAmrLoggedIn();
+    const startedAt = anonymousStartedAt(window.localStorage);
+    const pulled = await pullMessageCenter({ locale, loggedIn: account, startedAt });
+    const localReadIds = account ? new Set<string>() : readAnonymousReadIds(window.localStorage);
+    const merged = pulled.map((message) => ({
+      ...message,
+      readAt: message.readAt ?? (localReadIds.has(message.id) ? new Date().toISOString() : null),
+    }));
+    setLoggedIn(account);
+    setReadIds(localReadIds);
+    setMessages(merged);
+    if (!account) writeAnonymousState(window.localStorage, merged, localReadIds);
+    setSyncError(false);
+  }, [locale]);
 
+  useEffect(() => {
+    const startedAt = anonymousStartedAt(window.localStorage);
+    void startedAt;
+    setMessages(readAnonymousMessages(window.localStorage));
+    setReadIds(readAnonymousReadIds(window.localStorage));
+    void sync().catch(() => setSyncError(true));
+    const interval = window.setInterval(() => void sync().catch(() => setSyncError(true)), 60_000);
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') void sync().catch(() => setSyncError(true));
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      window.clearInterval(interval);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, [sync]);
+
+  useEffect(() => {
+    if (open) void sync().catch(() => setSyncError(true));
+  }, [open, sync]);
+
+  const unreadCount = messages.filter((message) => !message.readAt).length;
   const visibleMessages = useMemo(
-    () =>
-      DEMO_MESSAGES.filter((message) => {
-        const state = messages[message.id];
-        if (!state) return false;
-        if (filter === 'unread') return !state.read;
-        if (filter === 'read') return state.read;
-        return true;
-      }),
+    () => messages.filter((message) => filter === 'all' || (filter === 'read' ? Boolean(message.readAt) : !message.readAt)),
     [filter, messages],
   );
 
-  const expandedMessageId = useMemo(
-    () => visibleMessages.find((message) => messages[message.id]?.expanded)?.id ?? null,
-    [messages, visibleMessages],
-  );
-
-  const openLabel =
-    unreadCount > 0
-      ? `${t('messageCenter.openAria')} (${t('messageCenter.unreadCount', { count: unreadCount })})`
-      : t('messageCenter.openAria');
-
   const closePanel = () => {
     setOpen(false);
-    setToast(null);
     triggerRef.current?.focus();
   };
 
   useEffect(() => {
     if (!open) return;
     panelRef.current?.focus();
-
     const onPointerDown = (event: MouseEvent) => {
       const target = event.target as Node;
-      if (panelRef.current?.contains(target)) return;
-      if (triggerRef.current?.contains(target)) return;
-      closePanel();
+      if (!panelRef.current?.contains(target) && !triggerRef.current?.contains(target)) closePanel();
     };
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') closePanel();
     };
-
     document.addEventListener('mousedown', onPointerDown);
     document.addEventListener('keydown', onKeyDown);
     return () => {
@@ -172,225 +110,49 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
     };
   }, [open]);
 
-  useEffect(() => {
-    if (!open || !expandedMessageId) return;
-
-    const timer = window.setTimeout(() => {
-      const list = listRef.current;
-      const item = itemRefs.current.get(expandedMessageId);
-      if (!list || !item) return;
-
-      const listRect = list.getBoundingClientRect();
-      const itemRect = item.getBoundingClientRect();
-      const topInset = 12;
-      const bottomInset = 24;
-
-      if (itemRect.bottom > listRect.bottom - bottomInset) {
-        list.scrollTop += itemRect.bottom - listRect.bottom + bottomInset;
-      } else if (itemRect.top < listRect.top + topInset) {
-        list.scrollTop -= listRect.top + topInset - itemRect.top;
-      }
-    }, 0);
-
-    return () => window.clearTimeout(timer);
-  }, [expandedMessageId, open]);
-
-  const toggleExpanded = (id: string) => {
-    setMessages((current) =>
-      Object.fromEntries(
-        Object.entries(current).map(([messageId, state]) => [
-          messageId,
-          messageId === id
-            ? { ...state, read: true, expanded: !state.expanded }
-            : { ...state, expanded: false },
-        ]),
-      ),
-    );
+  const markRead = async (messageId: string) => {
+    const message = messages.find((item) => item.id === messageId);
+    if (!message || message.readAt) return;
+    const readAt = new Date().toISOString();
+    if (loggedIn) await markAccountMessageRead(messageId);
+    const nextIds = new Set(readIds).add(messageId);
+    const nextMessages = messages.map((item) => (item.id === messageId ? { ...item, readAt } : item));
+    setReadIds(nextIds);
+    setMessages(nextMessages);
+    if (!loggedIn) writeAnonymousState(window.localStorage, nextMessages, nextIds);
   };
 
-  const markAllRead = () => {
-    setMessages((current) =>
-      Object.fromEntries(
-        Object.entries(current).map(([id, state]) => [id, { ...state, read: true }]),
-      ),
-    );
+  const markAllRead = async () => {
+    if (loggedIn) await markAllAccountMessagesRead();
+    const readAt = new Date().toISOString();
+    const nextIds = new Set(messages.map((message) => message.id));
+    const nextMessages = messages.map((message) => ({ ...message, readAt: message.readAt ?? readAt }));
+    setReadIds(nextIds);
+    setMessages(nextMessages);
+    if (!loggedIn) writeAnonymousState(window.localStorage, nextMessages, nextIds);
   };
 
-  const emptyTitle =
-    filter === 'unread'
-      ? t('messageCenter.emptyUnreadTitle')
-      : filter === 'read'
-        ? t('messageCenter.emptyReadTitle')
-        : t('messageCenter.emptyAllTitle');
+  const openLabel = unreadCount > 0 ? `${t('messageCenter.openAria')} (${t('messageCenter.unreadCount', { count: unreadCount })})` : t('messageCenter.openAria');
+  const emptyTitle = filter === 'unread' ? t('messageCenter.emptyUnreadTitle') : filter === 'read' ? t('messageCenter.emptyReadTitle') : t('messageCenter.emptyAllTitle');
 
-  return (
-    <div className={styles.root}>
-      <button
-        ref={triggerRef}
-        type="button"
-        className={`settings-icon-btn od-tooltip ${styles.trigger}`}
-        onClick={() => setOpen((value) => !value)}
-        title={t('messageCenter.openAria')}
-        data-tooltip={t('messageCenter.openAria')}
-        data-tooltip-placement="bottom"
-        aria-label={openLabel}
-        aria-haspopup="dialog"
-        aria-expanded={open}
-        data-testid="message-center-trigger"
-      >
-        <Icon name="bell" size={17} />
-        {unreadCount > 0 ? (
-          <span className={styles.badge} aria-hidden>
-            {unreadBadgeLabel(unreadCount)}
-          </span>
-        ) : null}
-      </button>
+  return <div className={styles.root}>
+    <button ref={triggerRef} type="button" className={`settings-icon-btn od-tooltip ${styles.trigger}`} onClick={() => setOpen((value) => !value)} title={t('messageCenter.openAria')} data-tooltip={t('messageCenter.openAria')} data-tooltip-placement="bottom" aria-label={openLabel} aria-haspopup="dialog" aria-expanded={open} data-testid="message-center-trigger">
+      <Icon name="bell" size={17} />{unreadCount > 0 ? <span className={styles.badge} aria-hidden>{unreadBadgeLabel(unreadCount)}</span> : null}
+    </button>
+    {open ? createPortal(<div className={styles.backdrop} data-testid="message-center-backdrop"><aside ref={panelRef} className={styles.panel} role="dialog" aria-modal="true" aria-labelledby={titleId} tabIndex={-1} data-testid="message-center-dialog">
+      <header className={styles.header}><div className={styles.headerCopy}><h2 id={titleId}>{t('messageCenter.title')}</h2><p>{t('messageCenter.subtitle')}</p></div><button type="button" className={styles.close} onClick={closePanel} aria-label={t('messageCenter.close')}><Icon name="close" size={15}/></button></header>
+      <div className={styles.controls}><div className={styles.filters} role="group" aria-label={t('messageCenter.title')}>{FILTERS.map((item) => <button key={item.id} type="button" className={`${styles.filter}${filter === item.id ? ` ${styles.filterActive}` : ''}`} aria-pressed={filter === item.id} onClick={() => setFilter(item.id)}>{t(item.label)}{item.id === 'unread' && unreadCount > 0 ? <span className={styles.filterBadge} aria-hidden>{unreadBadgeLabel(unreadCount)}</span> : null}</button>)}</div><button type="button" className={styles.markAll} onClick={() => void markAllRead().catch(() => setSyncError(true))} disabled={unreadCount === 0}>{t('messageCenter.markAllRead')}</button></div>
+      <div className={styles.list} aria-live="polite">{syncError && messages.length === 0 ? <div className={styles.empty}><Icon name="bell" size={20}/><strong>{t('messageCenter.emptyAllTitle')}</strong><p>{t('messageCenter.emptyBody')}</p></div> : visibleMessages.length === 0 ? <div className={styles.empty}><Icon name="bell" size={20}/><strong>{emptyTitle}</strong><p>{t('messageCenter.emptyBody')}</p></div> : visibleMessages.map((message) => <MessageItem key={message.id} message={message} onRead={markRead}/>)}</div>
+      <footer className={styles.footer}><p>{t('messageCenter.desktopSettingsHint')}</p>{onOpenNotificationSettings ? <Button variant="ghost" onClick={() => { closePanel(); onOpenNotificationSettings(); }}>{t('messageCenter.desktopSettings')}</Button> : null}</footer>
+    </aside></div>, document.body) : null}
+  </div>;
+}
 
-      {open
-        ? createPortal(
-            <div className={styles.backdrop} data-testid="message-center-backdrop">
-              <aside
-                ref={panelRef}
-                className={styles.panel}
-                role="dialog"
-                aria-modal="true"
-                aria-labelledby={titleId}
-                tabIndex={-1}
-                data-testid="message-center-dialog"
-              >
-                <header className={styles.header}>
-                  <div className={styles.headerCopy}>
-                    <h2 id={titleId}>{t('messageCenter.title')}</h2>
-                    <p>{t('messageCenter.subtitle')}</p>
-                  </div>
-                  <button
-                    type="button"
-                    className={styles.close}
-                    onClick={closePanel}
-                    aria-label={t('messageCenter.close')}
-                  >
-                    <Icon name="close" size={15} />
-                  </button>
-                </header>
-
-                <div className={styles.controls}>
-                  <div
-                    className={styles.filters}
-                    role="group"
-                    aria-label={t('messageCenter.title')}
-                  >
-                    {FILTERS.map((item) => (
-                      <button
-                        key={item.id}
-                        type="button"
-                        className={`${styles.filter}${filter === item.id ? ` ${styles.filterActive}` : ''}`}
-                        aria-pressed={filter === item.id}
-                        onClick={() => setFilter(item.id)}
-                      >
-                        {t(item.labelKey)}
-                        {item.id === 'unread' && unreadCount > 0 ? (
-                          <span className={styles.filterBadge} aria-hidden>
-                            {unreadBadgeLabel(unreadCount)}
-                          </span>
-                        ) : null}
-                      </button>
-                    ))}
-                  </div>
-                  <button
-                    type="button"
-                    className={styles.markAll}
-                    onClick={markAllRead}
-                    disabled={unreadCount === 0}
-                  >
-                    {t('messageCenter.markAllRead')}
-                  </button>
-                </div>
-
-                <div ref={listRef} className={styles.list} aria-live="polite">
-                  {visibleMessages.length === 0 ? (
-                    <div className={styles.empty}>
-                      <Icon name="bell" size={20} />
-                      <strong>{emptyTitle}</strong>
-                      <p>{t('messageCenter.emptyBody')}</p>
-                    </div>
-                  ) : (
-                    visibleMessages.map((message) => {
-                      const state = messages[message.id];
-                      if (!state) return null;
-                      return (
-                        <article
-                          key={message.id}
-                          ref={(node) => {
-                            if (node) itemRefs.current.set(message.id, node);
-                            else itemRefs.current.delete(message.id);
-                          }}
-                          className={`${styles.item}${state.read ? '' : ` ${styles.itemUnread}`}${state.expanded ? ` ${styles.itemExpanded}` : ''}`}
-                        >
-                          <button
-                            type="button"
-                            className={styles.itemSummary}
-                            aria-expanded={state.expanded}
-                            onClick={() => toggleExpanded(message.id)}
-                          >
-                            <span className={styles.itemMeta}>
-                              <span>{t(message.typeKey)}</span>
-                              <time>{t(message.timeKey)}</time>
-                            </span>
-                            <strong>{t(message.titleKey)}</strong>
-                            <span className={styles.bodyPreview}>{t(message.bodyKey)}</span>
-                          </button>
-
-                          {state.expanded ? (
-                            <div className={styles.itemActions}>
-                              <button
-                                type="button"
-                                className={styles.primaryAction}
-                                onClick={() =>
-                                  setToast(
-                                    t('messageCenter.actionToast', {
-                                      title: t(message.titleKey),
-                                    }),
-                                  )
-                                }
-                              >
-                                {t(message.actionKey)}
-                              </button>
-                            </div>
-                          ) : null}
-                        </article>
-                      );
-                    })
-                  )}
-                </div>
-
-                <footer className={styles.footer}>
-                  <p>{t('messageCenter.desktopSettingsHint')}</p>
-                  {onOpenNotificationSettings ? (
-                    <Button
-                      variant="ghost"
-                      onClick={() => {
-                        closePanel();
-                        onOpenNotificationSettings();
-                      }}
-                    >
-                      {t('messageCenter.desktopSettings')}
-                    </Button>
-                  ) : null}
-                </footer>
-
-                {toast ? (
-                  <div className={styles.toast} role="status">
-                    <span>{toast}</span>
-                    <button type="button" onClick={() => setToast(null)}>
-                      {t('messageCenter.toastDismiss')}
-                    </button>
-                  </div>
-                ) : null}
-              </aside>
-            </div>,
-            document.body,
-          )
-        : null}
-    </div>
-  );
+function MessageItem({ message, onRead }: { message: MessageCenterMessage; onRead: (id: string) => Promise<void> }) {
+  const [expanded, setExpanded] = useState(false);
+  const formatted = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(message.publishedAt));
+  return <article className={`${styles.item}${message.readAt ? '' : ` ${styles.itemUnread}`}${expanded ? ` ${styles.itemExpanded}` : ''}`}>
+    <button type="button" className={styles.itemSummary} aria-expanded={expanded} onClick={() => { setExpanded((value) => !value); void onRead(message.id); }}><span className={styles.itemMeta}><span>{message.typeName}</span><time dateTime={message.publishedAt}>{formatted}</time></span><strong>{message.title}</strong><span className={styles.bodyPreview}>{message.body}</span></button>
+    {expanded && message.ctaLabel && message.ctaUrl ? <div className={styles.itemActions}><button type="button" className={styles.primaryAction} onClick={() => window.open(message.ctaUrl!, '_blank', 'noopener,noreferrer')}>{message.ctaLabel}</button></div> : null}
+  </article>;
 }

--- a/apps/web/src/components/MessageCenterDemo.tsx
+++ b/apps/web/src/components/MessageCenterDemo.tsx
@@ -43,22 +43,47 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
   const [readIds, setReadIds] = useState<Set<string>>(new Set());
   const [loggedIn, setLoggedIn] = useState(false);
   const [syncError, setSyncError] = useState(false);
+  const messagesRef = useRef<MessageCenterMessage[]>([]);
+  const readIdsRef = useRef<Set<string>>(new Set());
+  const pendingReadIdsRef = useRef<Set<string>>(new Set());
+  const syncRequestIdRef = useRef(0);
+
+  const commitState = useCallback(
+    (nextMessages: MessageCenterMessage[], nextReadIds: Set<string>, options?: { persistAnonymous?: boolean }) => {
+      messagesRef.current = nextMessages;
+      readIdsRef.current = nextReadIds;
+      setMessages(nextMessages);
+      setReadIds(nextReadIds);
+      if (options?.persistAnonymous) writeAnonymousState(window.localStorage, nextMessages, nextReadIds);
+    },
+    [],
+  );
 
   const sync = useCallback(async () => {
+    const requestId = syncRequestIdRef.current + 1;
+    syncRequestIdRef.current = requestId;
     const account = await isAmrLoggedIn();
     const startedAt = anonymousStartedAt(window.localStorage);
     const pulled = await pullMessageCenter({ locale, loggedIn: account, startedAt });
-    const localReadIds = account ? new Set<string>() : readAnonymousReadIds(window.localStorage);
+    if (requestId !== syncRequestIdRef.current) return;
+    const persistedReadIds = account ? readIdsRef.current : readAnonymousReadIds(window.localStorage);
+    const serverReadIds = new Set(pulled.filter((message) => Boolean(message.readAt)).map((message) => message.id));
+    if (account) {
+      pendingReadIdsRef.current = new Set(
+        [...pendingReadIdsRef.current].filter((messageId) => !serverReadIds.has(messageId)),
+      );
+    }
+    const overlayReadIds = account
+      ? new Set([...serverReadIds, ...pendingReadIdsRef.current])
+      : new Set([...serverReadIds, ...persistedReadIds]);
     const merged = pulled.map((message) => ({
       ...message,
-      readAt: message.readAt ?? (localReadIds.has(message.id) ? new Date().toISOString() : null),
+      readAt: message.readAt ?? (overlayReadIds.has(message.id) ? new Date().toISOString() : null),
     }));
     setLoggedIn(account);
-    setReadIds(localReadIds);
-    setMessages(merged);
-    if (!account) writeAnonymousState(window.localStorage, merged, localReadIds);
+    commitState(merged, overlayReadIds, { persistAnonymous: !account });
     setSyncError(false);
-  }, [locale]);
+  }, [commitState, locale]);
 
   useEffect(() => {
     const startedAt = anonymousStartedAt(window.localStorage);
@@ -111,25 +136,23 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
   }, [open]);
 
   const markRead = async (messageId: string) => {
-    const message = messages.find((item) => item.id === messageId);
+    const message = messagesRef.current.find((item) => item.id === messageId);
     if (!message || message.readAt) return;
     const readAt = new Date().toISOString();
     if (loggedIn) await markAccountMessageRead(messageId);
-    const nextIds = new Set(readIds).add(messageId);
-    const nextMessages = messages.map((item) => (item.id === messageId ? { ...item, readAt } : item));
-    setReadIds(nextIds);
-    setMessages(nextMessages);
-    if (!loggedIn) writeAnonymousState(window.localStorage, nextMessages, nextIds);
+    const nextIds = new Set(readIdsRef.current).add(messageId);
+    const nextMessages = messagesRef.current.map((item) => (item.id === messageId ? { ...item, readAt } : item));
+    if (loggedIn) pendingReadIdsRef.current = new Set(pendingReadIdsRef.current).add(messageId);
+    commitState(nextMessages, nextIds, { persistAnonymous: !loggedIn });
   };
 
   const markAllRead = async () => {
     if (loggedIn) await markAllAccountMessagesRead();
     const readAt = new Date().toISOString();
-    const nextIds = new Set(messages.map((message) => message.id));
-    const nextMessages = messages.map((message) => ({ ...message, readAt: message.readAt ?? readAt }));
-    setReadIds(nextIds);
-    setMessages(nextMessages);
-    if (!loggedIn) writeAnonymousState(window.localStorage, nextMessages, nextIds);
+    const nextIds = new Set(messagesRef.current.map((message) => message.id));
+    const nextMessages = messagesRef.current.map((message) => ({ ...message, readAt: message.readAt ?? readAt }));
+    if (loggedIn) pendingReadIdsRef.current = new Set(nextIds);
+    commitState(nextMessages, nextIds, { persistAnonymous: !loggedIn });
   };
 
   const openLabel = unreadCount > 0 ? `${t('messageCenter.openAria')} (${t('messageCenter.unreadCount', { count: unreadCount })})` : t('messageCenter.openAria');
@@ -142,17 +165,36 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
     {open ? createPortal(<div className={styles.backdrop} data-testid="message-center-backdrop"><aside ref={panelRef} className={styles.panel} role="dialog" aria-modal="true" aria-labelledby={titleId} tabIndex={-1} data-testid="message-center-dialog">
       <header className={styles.header}><div className={styles.headerCopy}><h2 id={titleId}>{t('messageCenter.title')}</h2><p>{t('messageCenter.subtitle')}</p></div><button type="button" className={styles.close} onClick={closePanel} aria-label={t('messageCenter.close')}><Icon name="close" size={15}/></button></header>
       <div className={styles.controls}><div className={styles.filters} role="group" aria-label={t('messageCenter.title')}>{FILTERS.map((item) => <button key={item.id} type="button" className={`${styles.filter}${filter === item.id ? ` ${styles.filterActive}` : ''}`} aria-pressed={filter === item.id} onClick={() => setFilter(item.id)}>{t(item.label)}{item.id === 'unread' && unreadCount > 0 ? <span className={styles.filterBadge} aria-hidden>{unreadBadgeLabel(unreadCount)}</span> : null}</button>)}</div><button type="button" className={styles.markAll} onClick={() => void markAllRead().catch(() => setSyncError(true))} disabled={unreadCount === 0}>{t('messageCenter.markAllRead')}</button></div>
-      <div className={styles.list} aria-live="polite">{syncError && messages.length === 0 ? <div className={styles.empty}><Icon name="bell" size={20}/><strong>{t('messageCenter.emptyAllTitle')}</strong><p>{t('messageCenter.emptyBody')}</p></div> : visibleMessages.length === 0 ? <div className={styles.empty}><Icon name="bell" size={20}/><strong>{emptyTitle}</strong><p>{t('messageCenter.emptyBody')}</p></div> : visibleMessages.map((message) => <MessageItem key={message.id} message={message} onRead={markRead}/>)}</div>
+      <div className={styles.list} aria-live="polite">{syncError && messages.length === 0 ? <div className={styles.empty}><Icon name="bell" size={20}/><strong>{t('messageCenter.emptyAllTitle')}</strong><p>{t('messageCenter.emptyBody')}</p></div> : visibleMessages.length === 0 ? <div className={styles.empty}><Icon name="bell" size={20}/><strong>{emptyTitle}</strong><p>{t('messageCenter.emptyBody')}</p></div> : visibleMessages.map((message) => <MessageItem key={message.id} message={message} onRead={markRead} onError={() => setSyncError(true)}/>)}</div>
       <footer className={styles.footer}><p>{t('messageCenter.desktopSettingsHint')}</p>{onOpenNotificationSettings ? <Button variant="ghost" onClick={() => { closePanel(); onOpenNotificationSettings(); }}>{t('messageCenter.desktopSettings')}</Button> : null}</footer>
     </aside></div>, document.body) : null}
   </div>;
 }
 
-function MessageItem({ message, onRead }: { message: MessageCenterMessage; onRead: (id: string) => Promise<void> }) {
+function MessageItem({
+  message,
+  onRead,
+  onError,
+}: {
+  message: MessageCenterMessage;
+  onRead: (id: string) => Promise<void>;
+  onError: () => void;
+}) {
   const [expanded, setExpanded] = useState(false);
   const formatted = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(message.publishedAt));
+  const ctaUrl = safeExternalUrl(message.ctaUrl);
   return <article className={`${styles.item}${message.readAt ? '' : ` ${styles.itemUnread}`}${expanded ? ` ${styles.itemExpanded}` : ''}`}>
-    <button type="button" className={styles.itemSummary} aria-expanded={expanded} onClick={() => { setExpanded((value) => !value); void onRead(message.id); }}><span className={styles.itemMeta}><span>{message.typeName}</span><time dateTime={message.publishedAt}>{formatted}</time></span><strong>{message.title}</strong><span className={styles.bodyPreview}>{message.body}</span></button>
-    {expanded && message.ctaLabel && message.ctaUrl ? <div className={styles.itemActions}><button type="button" className={styles.primaryAction} onClick={() => window.open(message.ctaUrl!, '_blank', 'noopener,noreferrer')}>{message.ctaLabel}</button></div> : null}
+    <button type="button" className={styles.itemSummary} aria-expanded={expanded} onClick={() => { setExpanded((value) => !value); void onRead(message.id).catch(onError); }}><span className={styles.itemMeta}><span>{message.typeName}</span><time dateTime={message.publishedAt}>{formatted}</time></span><strong>{message.title}</strong><span className={styles.bodyPreview}>{message.body}</span></button>
+    {expanded && message.ctaLabel && ctaUrl ? <div className={styles.itemActions}><button type="button" className={styles.primaryAction} onClick={() => window.open(ctaUrl, '_blank', 'noopener,noreferrer')}>{message.ctaLabel}</button></div> : null}
   </article>;
+}
+
+function safeExternalUrl(value: string | null): string | null {
+  if (!value) return null;
+  try {
+    const parsed = new URL(value, window.location.href);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? parsed.toString() : null;
+  } catch {
+    return null;
+  }
 }

--- a/apps/web/src/components/MessageCenterDemo.tsx
+++ b/apps/web/src/components/MessageCenterDemo.tsx
@@ -65,8 +65,13 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
     const requestId = syncRequestIdRef.current + 1;
     syncRequestIdRef.current = requestId;
     const account = await isAmrLoggedIn();
+    const wasAccount = loggedInRef.current;
     loggedInRef.current = account;
     setLoggedIn(account);
+    if (wasAccount && !account) {
+      readIdsRef.current = new Set();
+      pendingReadIdsRef.current = new Set();
+    }
     const startedAt = anonymousStartedAt(window.localStorage);
     const pulled = await pullMessageCenter({ locale, loggedIn: account, startedAt });
     if (requestId !== syncRequestIdRef.current) return;
@@ -111,6 +116,9 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
       readAnonymousMessages(window.localStorage),
       readAnonymousReadIds(window.localStorage),
     );
+  }, [commitState]);
+
+  useEffect(() => {
     retrySync();
     const interval = window.setInterval(retrySync, 60_000);
     const onVisibility = () => {
@@ -121,7 +129,7 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
       window.clearInterval(interval);
       document.removeEventListener('visibilitychange', onVisibility);
     };
-  }, [commitState, retrySync]);
+  }, [retrySync]);
 
   useEffect(() => {
     if (open) retrySync();

--- a/apps/web/src/components/MessageCenterDemo.tsx
+++ b/apps/web/src/components/MessageCenterDemo.tsx
@@ -66,16 +66,17 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
     const startedAt = anonymousStartedAt(window.localStorage);
     const pulled = await pullMessageCenter({ locale, loggedIn: account, startedAt });
     if (requestId !== syncRequestIdRef.current) return;
-    const persistedReadIds = account ? readIdsRef.current : readAnonymousReadIds(window.localStorage);
     const serverReadIds = new Set(pulled.filter((message) => Boolean(message.readAt)).map((message) => message.id));
     if (account) {
       pendingReadIdsRef.current = new Set(
         [...pendingReadIdsRef.current].filter((messageId) => !serverReadIds.has(messageId)),
       );
     }
-    const overlayReadIds = account
-      ? new Set([...serverReadIds, ...pendingReadIdsRef.current])
-      : new Set([...serverReadIds, ...persistedReadIds]);
+    const overlayReadIds = new Set([
+      ...serverReadIds,
+      ...(account ? pendingReadIdsRef.current : []),
+      ...readIdsRef.current,
+    ]);
     const merged = pulled.map((message) => ({
       ...message,
       readAt: message.readAt ?? (overlayReadIds.has(message.id) ? new Date().toISOString() : null),
@@ -85,26 +86,31 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
     setSyncError(false);
   }, [commitState, locale]);
 
-  useEffect(() => {
-    const startedAt = anonymousStartedAt(window.localStorage);
-    void startedAt;
-    setMessages(readAnonymousMessages(window.localStorage));
-    setReadIds(readAnonymousReadIds(window.localStorage));
+  const retrySync = useCallback(() => {
     void sync().catch(() => setSyncError(true));
-    const interval = window.setInterval(() => void sync().catch(() => setSyncError(true)), 60_000);
+  }, [sync]);
+
+  useEffect(() => {
+    anonymousStartedAt(window.localStorage);
+    commitState(
+      readAnonymousMessages(window.localStorage),
+      readAnonymousReadIds(window.localStorage),
+    );
+    retrySync();
+    const interval = window.setInterval(retrySync, 60_000);
     const onVisibility = () => {
-      if (document.visibilityState === 'visible') void sync().catch(() => setSyncError(true));
+      if (document.visibilityState === 'visible') retrySync();
     };
     document.addEventListener('visibilitychange', onVisibility);
     return () => {
       window.clearInterval(interval);
       document.removeEventListener('visibilitychange', onVisibility);
     };
-  }, [sync]);
+  }, [commitState, retrySync]);
 
   useEffect(() => {
-    if (open) void sync().catch(() => setSyncError(true));
-  }, [open, sync]);
+    if (open) retrySync();
+  }, [open, retrySync]);
 
   const unreadCount = messages.filter((message) => !message.readAt).length;
   const visibleMessages = useMemo(
@@ -165,7 +171,17 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
     {open ? createPortal(<div className={styles.backdrop} data-testid="message-center-backdrop"><aside ref={panelRef} className={styles.panel} role="dialog" aria-modal="true" aria-labelledby={titleId} tabIndex={-1} data-testid="message-center-dialog">
       <header className={styles.header}><div className={styles.headerCopy}><h2 id={titleId}>{t('messageCenter.title')}</h2><p>{t('messageCenter.subtitle')}</p></div><button type="button" className={styles.close} onClick={closePanel} aria-label={t('messageCenter.close')}><Icon name="close" size={15}/></button></header>
       <div className={styles.controls}><div className={styles.filters} role="group" aria-label={t('messageCenter.title')}>{FILTERS.map((item) => <button key={item.id} type="button" className={`${styles.filter}${filter === item.id ? ` ${styles.filterActive}` : ''}`} aria-pressed={filter === item.id} onClick={() => setFilter(item.id)}>{t(item.label)}{item.id === 'unread' && unreadCount > 0 ? <span className={styles.filterBadge} aria-hidden>{unreadBadgeLabel(unreadCount)}</span> : null}</button>)}</div><button type="button" className={styles.markAll} onClick={() => void markAllRead().catch(() => setSyncError(true))} disabled={unreadCount === 0}>{t('messageCenter.markAllRead')}</button></div>
-      <div className={styles.list} aria-live="polite">{syncError && messages.length === 0 ? <div className={styles.empty}><Icon name="bell" size={20}/><strong>{t('messageCenter.emptyAllTitle')}</strong><p>{t('messageCenter.emptyBody')}</p></div> : visibleMessages.length === 0 ? <div className={styles.empty}><Icon name="bell" size={20}/><strong>{emptyTitle}</strong><p>{t('messageCenter.emptyBody')}</p></div> : visibleMessages.map((message) => <MessageItem key={message.id} message={message} onRead={markRead} onError={() => setSyncError(true)}/>)}</div>
+      <div className={styles.list} aria-live="polite">
+        {syncError && messages.length > 0 ? (
+          <div className={styles.syncStatus} role="status">
+            <span>{t('settings.updateStatusFailed')}</span>
+            <button type="button" onClick={retrySync}>
+              {t('settings.updateRetry')}
+            </button>
+          </div>
+        ) : null}
+        {syncError && messages.length === 0 ? <div className={styles.empty}><Icon name="bell" size={20}/><strong>{t('messageCenter.emptyAllTitle')}</strong><p>{t('messageCenter.emptyBody')}</p></div> : visibleMessages.length === 0 ? <div className={styles.empty}><Icon name="bell" size={20}/><strong>{emptyTitle}</strong><p>{t('messageCenter.emptyBody')}</p></div> : visibleMessages.map((message) => <MessageItem key={message.id} message={message} onRead={markRead} onError={() => setSyncError(true)}/>)}
+      </div>
       <footer className={styles.footer}><p>{t('messageCenter.desktopSettingsHint')}</p>{onOpenNotificationSettings ? <Button variant="ghost" onClick={() => { closePanel(); onOpenNotificationSettings(); }}>{t('messageCenter.desktopSettings')}</Button> : null}</footer>
     </aside></div>, document.body) : null}
   </div>;

--- a/apps/web/src/components/MessageCenterDemo.tsx
+++ b/apps/web/src/components/MessageCenterDemo.tsx
@@ -45,7 +45,6 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
   const [loggedIn, setLoggedIn] = useState(false);
   const [syncError, setSyncError] = useState(false);
   const loggedInRef = useRef(false);
-  const authResolvedRef = useRef(false);
   const messagesRef = useRef<MessageCenterMessage[]>([]);
   const readIdsRef = useRef<Set<string>>(new Set());
   const pendingReadIdsRef = useRef<Set<string>>(new Set());
@@ -66,7 +65,6 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
     const requestId = syncRequestIdRef.current + 1;
     syncRequestIdRef.current = requestId;
     const account = await isAmrLoggedIn();
-    authResolvedRef.current = true;
     loggedInRef.current = account;
     setLoggedIn(account);
     const startedAt = anonymousStartedAt(window.localStorage);
@@ -93,9 +91,7 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
   }, [commitState, locale]);
 
   const resolveLoggedInForWrite = useCallback(async () => {
-    if (authResolvedRef.current) return loggedInRef.current;
     const account = await isAmrLoggedIn();
-    authResolvedRef.current = true;
     loggedInRef.current = account;
     setLoggedIn(account);
     return account;
@@ -104,6 +100,10 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
   const retrySync = useCallback(() => {
     void sync().catch(() => setSyncError(true));
   }, [sync]);
+
+  const invalidateSyncResponses = useCallback(() => {
+    syncRequestIdRef.current += 1;
+  }, []);
 
   useEffect(() => {
     anonymousStartedAt(window.localStorage);
@@ -168,6 +168,7 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
       pendingReadIdsRef.current = new Set(pendingReadIdsRef.current).add(messageId);
       clearAnonymousState(window.localStorage);
     }
+    invalidateSyncResponses();
     commitState(nextMessages, nextIds, { persistAnonymous: !account });
   };
 
@@ -181,6 +182,7 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
       pendingReadIdsRef.current = new Set(nextIds);
       clearAnonymousState(window.localStorage);
     }
+    invalidateSyncResponses();
     commitState(nextMessages, nextIds, { persistAnonymous: !account });
   };
 

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -1005,7 +1005,7 @@ export interface Dict {
   'entry.navDesignSystems': string;
   'entry.navBrands': string;
   'entry.navIntegrations': string;
-  // Client message center demo
+  // Client message center
   'messageCenter.openAria': string;
   'messageCenter.unreadCount': string;
   'messageCenter.title': string;

--- a/apps/web/src/message-center-client.ts
+++ b/apps/web/src/message-center-client.ts
@@ -1,0 +1,113 @@
+export type MessageCenterFilter = 'all' | 'unread' | 'read';
+
+export interface MessageCenterMessage {
+  id: string;
+  audienceType: 'global' | 'targeted';
+  typeName: string;
+  title: string;
+  body: string;
+  ctaLabel: string | null;
+  ctaUrl: string | null;
+  publishedAt: string;
+  readAt: string | null;
+}
+
+interface MessageCenterPage {
+  messages: MessageCenterMessage[];
+  nextCursor: string | null;
+  unreadCount: number;
+}
+
+const ACCOUNT_PROXY = '/api/integrations/vela/message-center';
+const ANONYMOUS_PROXY = '/api/integrations/vela/api-proxy/api/v1/message-center';
+const WINDOW_KEY = 'open-design.message-center.anonymous-started-at.v1';
+const MESSAGES_KEY = 'open-design.message-center.anonymous-messages.v1';
+const READ_KEY = 'open-design.message-center.anonymous-read-ids.v1';
+
+export function anonymousStartedAt(storage: Storage, now = new Date()): string {
+  const existing = storage.getItem(WINDOW_KEY);
+  if (existing) return existing;
+  const value = now.toISOString();
+  storage.setItem(WINDOW_KEY, value);
+  storage.setItem(MESSAGES_KEY, '[]');
+  storage.setItem(READ_KEY, '[]');
+  return value;
+}
+
+export function readAnonymousMessages(storage: Storage): MessageCenterMessage[] {
+  return parseArray<MessageCenterMessage>(storage.getItem(MESSAGES_KEY));
+}
+
+export function readAnonymousReadIds(storage: Storage): Set<string> {
+  return new Set(parseArray<string>(storage.getItem(READ_KEY)));
+}
+
+export function writeAnonymousState(
+  storage: Storage,
+  messages: MessageCenterMessage[],
+  readIds: Set<string>,
+): void {
+  storage.setItem(MESSAGES_KEY, JSON.stringify(messages));
+  storage.setItem(READ_KEY, JSON.stringify([...readIds]));
+}
+
+export async function isAmrLoggedIn(): Promise<boolean> {
+  const response = await fetch('/api/integrations/vela/status', { cache: 'no-store' });
+  if (!response.ok) throw new Error(`AMR status failed: ${response.status}`);
+  const payload = (await response.json()) as { loggedIn?: boolean };
+  return payload.loggedIn === true;
+}
+
+export async function pullMessageCenter(input: {
+  locale: string;
+  loggedIn: boolean;
+  startedAt?: string;
+  filter?: MessageCenterFilter;
+}): Promise<MessageCenterMessage[]> {
+  const messages: MessageCenterMessage[] = [];
+  let cursor: string | null = null;
+  do {
+    const query = new URLSearchParams({
+      locale: apiLocale(input.locale),
+      filter: input.filter ?? 'all',
+      limit: '100',
+    });
+    if (!input.loggedIn) {
+      if (!input.startedAt) throw new Error('Anonymous Message Center requires startedAt');
+      query.set('startedAt', input.startedAt);
+    }
+    if (cursor) query.set('cursor', cursor);
+    const proxy = input.loggedIn ? ACCOUNT_PROXY : ANONYMOUS_PROXY;
+    const response = await fetch(`${proxy}/messages?${query}`, { cache: 'no-store' });
+    if (!response.ok) throw new Error(`Message Center sync failed: ${response.status}`);
+    const page = (await response.json()) as MessageCenterPage;
+    messages.push(...page.messages);
+    cursor = page.nextCursor;
+  } while (cursor);
+  return messages;
+}
+
+export async function markAccountMessageRead(messageId: string): Promise<void> {
+  const response = await fetch(`${ACCOUNT_PROXY}/messages/${encodeURIComponent(messageId)}/read`, { method: 'POST' });
+  if (!response.ok) throw new Error(`Mark message read failed: ${response.status}`);
+}
+
+export async function markAllAccountMessagesRead(): Promise<void> {
+  const response = await fetch(`${ACCOUNT_PROXY}/read-all`, { method: 'POST' });
+  if (!response.ok) throw new Error(`Mark all messages read failed: ${response.status}`);
+}
+
+function apiLocale(locale: string): string {
+  const mapping: Record<string, string> = { en: 'en-US', 'es-ES': 'es', 'pt-BR': 'pt' };
+  return mapping[locale] ?? locale;
+}
+
+function parseArray<T>(value: string | null): T[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch {
+    return [];
+  }
+}

--- a/apps/web/src/message-center-client.ts
+++ b/apps/web/src/message-center-client.ts
@@ -51,6 +51,11 @@ export function writeAnonymousState(
   storage.setItem(READ_KEY, JSON.stringify([...readIds]));
 }
 
+export function clearAnonymousState(storage: Storage): void {
+  storage.removeItem(MESSAGES_KEY);
+  storage.removeItem(READ_KEY);
+}
+
 export async function isAmrLoggedIn(): Promise<boolean> {
   const response = await fetch('/api/integrations/vela/status', { cache: 'no-store' });
   if (!response.ok) throw new Error(`AMR status failed: ${response.status}`);

--- a/apps/web/src/message-center-client.ts
+++ b/apps/web/src/message-center-client.ts
@@ -23,6 +23,7 @@ const ANONYMOUS_PROXY = '/api/integrations/vela/api-proxy/api/v1/message-center'
 const WINDOW_KEY = 'open-design.message-center.anonymous-started-at.v1';
 const MESSAGES_KEY = 'open-design.message-center.anonymous-messages.v1';
 const READ_KEY = 'open-design.message-center.anonymous-read-ids.v1';
+const MAX_MESSAGE_CENTER_PAGES = 20;
 
 export function anonymousStartedAt(storage: Storage, now = new Date()): string {
   const existing = storage.getItem(WINDOW_KEY);
@@ -71,7 +72,12 @@ export async function pullMessageCenter(input: {
 }): Promise<MessageCenterMessage[]> {
   const messages: MessageCenterMessage[] = [];
   let cursor: string | null = null;
+  let pages = 0;
   do {
+    pages += 1;
+    if (pages > MAX_MESSAGE_CENTER_PAGES) {
+      throw new Error('Message Center pagination exceeded max pages');
+    }
     const query = new URLSearchParams({
       locale: apiLocale(input.locale),
       filter: input.filter ?? 'all',
@@ -86,6 +92,12 @@ export async function pullMessageCenter(input: {
     const response = await fetch(`${proxy}/messages?${query}`, { cache: 'no-store' });
     if (!response.ok) throw new Error(`Message Center sync failed: ${response.status}`);
     const page = (await response.json()) as MessageCenterPage;
+    if (!Array.isArray(page.messages)) {
+      throw new Error('Message Center page missing messages[]');
+    }
+    if (page.nextCursor && page.nextCursor === cursor) {
+      throw new Error('Message Center pagination cursor did not advance');
+    }
     messages.push(...page.messages);
     cursor = page.nextCursor;
   } while (cursor);

--- a/apps/web/tests/components/MessageCenterDemo.test.tsx
+++ b/apps/web/tests/components/MessageCenterDemo.test.tsx
@@ -1,134 +1,98 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MessageCenterDemo } from '../../src/components/MessageCenterDemo';
 import { I18nProvider } from '../../src/i18n';
 
+const messages = [
+  { id: 'release', audienceType: 'global', typeName: 'Product update', title: 'Open Design 0.14 is available', body: 'The new release is ready.', ctaLabel: 'View update', ctaUrl: 'https://open-design.ai/update', publishedAt: '2026-07-16T12:00:00.000Z', readAt: null },
+  { id: 'benefit', audienceType: 'targeted', typeName: 'Benefit', title: 'Credits added', body: 'Your credits are ready.', ctaLabel: null, ctaUrl: null, publishedAt: '2026-07-15T12:00:00.000Z', readAt: '2026-07-16T01:00:00.000Z' },
+];
+
+function mockFetch(loggedIn = false) {
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('/status')) return Response.json({ loggedIn });
+    if (url.includes('/messages?')) return Response.json({ messages, nextCursor: null, unreadCount: 1 });
+    if (url.includes('/read')) return Response.json({ read: true, markedCount: 1 });
+    return new Response(null, { status: 404 });
+  }));
+}
+
 function renderMessageCenter() {
   const onOpenNotificationSettings = vi.fn();
-  const result = render(
-    <I18nProvider initial="en">
-      <MessageCenterDemo onOpenNotificationSettings={onOpenNotificationSettings} />
-    </I18nProvider>,
-  );
+  const result = render(<I18nProvider initial="en"><MessageCenterDemo onOpenNotificationSettings={onOpenNotificationSettings}/></I18nProvider>);
   return { ...result, onOpenNotificationSettings };
 }
 
-function openCenter() {
+async function openCenter() {
+  await waitFor(() => expect(screen.getByLabelText(/Open message center \(1 unread\)/)).toBeTruthy());
   fireEvent.click(screen.getByTestId('message-center-trigger'));
   return screen.getByTestId('message-center-dialog');
 }
 
+beforeEach(() => {
+  localStorage.clear();
+  mockFetch();
+});
+
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe('MessageCenterDemo', () => {
-  it('shows the unread badge on the bell trigger', () => {
+  it('starts a durable anonymous window and renders API messages', async () => {
     renderMessageCenter();
-
-    const trigger = screen.getByLabelText(/Open message center \(3 unread\)/);
-    expect(trigger.textContent).toContain('3');
+    const dialog = await openCenter();
+    expect(within(dialog).getByText('Open Design 0.14 is available')).toBeTruthy();
+    expect(localStorage.getItem('open-design.message-center.anonymous-started-at.v1')).toBeTruthy();
   });
 
-  it('shows the unread count on the unread filter while unread messages remain', () => {
+  it('keeps anonymous read state locally and restores it', async () => {
     renderMessageCenter();
-    const dialog = openCenter();
-    const unreadFilter = within(dialog).getByRole('button', { name: 'Unread' });
+    await openCenter();
+    fireEvent.click(screen.getByRole('button', { name: /Open Design 0\.14 is available/ }));
+    await waitFor(() => expect(screen.queryByLabelText(/unread/)).toBeNull());
+    expect(localStorage.getItem('open-design.message-center.anonymous-read-ids.v1')).toContain('release');
+  });
 
-    expect(unreadFilter.textContent).toContain('3');
+  it('uses account read endpoints when logged in', async () => {
+    mockFetch(true);
+    renderMessageCenter();
+    await openCenter();
+    fireEvent.click(screen.getByRole('button', { name: /Open Design 0\.14 is available/ }));
+    await waitFor(() => expect(vi.mocked(fetch).mock.calls.some(([url, init]) => String(url).includes('/release/read') && init?.method === 'POST')).toBe(true));
+  });
 
-    fireEvent.click(screen.getByRole('button', { name: /Open Design 0\.13\.0 is available/ }));
-    expect(unreadFilter.textContent).toContain('2');
-
+  it('filters messages and marks all read', async () => {
+    renderMessageCenter();
+    await openCenter();
+    fireEvent.click(screen.getByRole('button', { name: 'Unread' }));
+    expect(screen.getByText('Open Design 0.14 is available')).toBeTruthy();
+    expect(screen.queryByText('Credits added')).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: 'Mark all read' }));
-    expect(unreadFilter.textContent).toBe('Unread');
+    await waitFor(() => expect(screen.getByText('All caught up')).toBeTruthy());
   });
 
-  it('opens as a dialog and closes with Escape while restoring trigger focus', () => {
+  it('opens CTA URLs with the existing external-link behavior', async () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    renderMessageCenter();
+    await openCenter();
+    fireEvent.click(screen.getByRole('button', { name: /Open Design 0\.14 is available/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'View update' }));
+    expect(open).toHaveBeenCalledWith('https://open-design.ai/update', '_blank', 'noopener,noreferrer');
+  });
+
+  it('closes with Escape and restores trigger focus', async () => {
     renderMessageCenter();
     const trigger = screen.getByTestId('message-center-trigger');
-
-    fireEvent.click(trigger);
-    expect(screen.getByRole('dialog', { name: 'Message center' })).toBeTruthy();
-
+    await openCenter();
     fireEvent.keyDown(document, { key: 'Escape' });
-
     expect(screen.queryByTestId('message-center-dialog')).toBeNull();
     expect(document.activeElement).toBe(trigger);
-  });
-
-  it('closes when the page outside the drawer is clicked', () => {
-    renderMessageCenter();
-    openCenter();
-
-    fireEvent.mouseDown(screen.getByTestId('message-center-backdrop'));
-
-    expect(screen.queryByTestId('message-center-dialog')).toBeNull();
-  });
-
-  it('marks a message read when the message is opened', () => {
-    renderMessageCenter();
-    openCenter();
-
-    fireEvent.click(screen.getByRole('button', { name: /Open Design 0\.13\.0 is available/ }));
-
-    const message = screen.getByText('Open Design 0.13.0 is available').closest('article');
-    expect(message).not.toBeNull();
-    expect(screen.queryByTestId('message-center-detail')).toBeNull();
-    expect(within(message as HTMLElement).getByText(/The new version reduces the wait/)).toBeTruthy();
-    expect(screen.getByLabelText(/Open message center \(2 unread\)/)).toBeTruthy();
-  });
-
-  it('filters unread messages and supports marking everything read', () => {
-    renderMessageCenter();
-    openCenter();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Unread' }));
-    expect(screen.getByText('Open Design 0.13.0 is available')).toBeTruthy();
-    expect(screen.queryByText('Limited design credits added')).toBeNull();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Mark all read' }));
-
-    expect(screen.getByText('All caught up')).toBeTruthy();
-    expect(screen.queryByLabelText(/unread/)).toBeNull();
-  });
-
-  it('filters read messages', () => {
-    renderMessageCenter();
-    openCenter();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Read' }));
-
-    expect(screen.getByText('Limited design credits added')).toBeTruthy();
-    expect(screen.getByText('6 publish-ready templates added')).toBeTruthy();
-    expect(screen.queryByText('Open Design 0.13.0 is available')).toBeNull();
-  });
-
-  it('does not render per-message read or unread actions', () => {
-    renderMessageCenter();
-    const dialog = openCenter();
-    const message = within(dialog)
-      .getByText('Workspace for Teams preview')
-      .closest('article');
-    expect(message).not.toBeNull();
-
-    expect(screen.queryByRole('button', { name: 'Archived' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Archive' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Mark read' })).toBeNull();
-    expect(screen.queryByRole('button', { name: 'Mark unread' })).toBeNull();
-  });
-
-  it('opens existing desktop notification settings from the drawer footer', () => {
-    const { onOpenNotificationSettings } = renderMessageCenter();
-    openCenter();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Desktop notification settings' }));
-
-    expect(onOpenNotificationSettings).toHaveBeenCalledTimes(1);
-    expect(screen.queryByTestId('message-center-dialog')).toBeNull();
   });
 });

--- a/apps/web/tests/components/MessageCenterDemo.test.tsx
+++ b/apps/web/tests/components/MessageCenterDemo.test.tsx
@@ -5,18 +5,26 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MessageCenterDemo } from '../../src/components/MessageCenterDemo';
 import { I18nProvider } from '../../src/i18n';
+import type { MessageCenterMessage } from '../../src/message-center-client';
 
-const messages = [
+const defaultMessages: MessageCenterMessage[] = [
   { id: 'release', audienceType: 'global', typeName: 'Product update', title: 'Open Design 0.14 is available', body: 'The new release is ready.', ctaLabel: 'View update', ctaUrl: 'https://open-design.ai/update', publishedAt: '2026-07-16T12:00:00.000Z', readAt: null },
   { id: 'benefit', audienceType: 'targeted', typeName: 'Benefit', title: 'Credits added', body: 'Your credits are ready.', ctaLabel: null, ctaUrl: null, publishedAt: '2026-07-15T12:00:00.000Z', readAt: '2026-07-16T01:00:00.000Z' },
 ];
 
-function mockFetch(loggedIn = false) {
+function mockFetch(
+  options: {
+    loggedIn?: boolean;
+    messages?: MessageCenterMessage[];
+    onRead?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+  } = {},
+) {
+  const { loggedIn = false, messages = defaultMessages, onRead } = options;
   vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
     const url = String(input);
     if (url.includes('/status')) return Response.json({ loggedIn });
     if (url.includes('/messages?')) return Response.json({ messages, nextCursor: null, unreadCount: 1 });
-    if (url.includes('/read')) return Response.json({ read: true, markedCount: 1 });
+    if (url.includes('/read')) return onRead ? onRead(input) : Response.json({ read: true, markedCount: 1 });
     return new Response(null, { status: 404 });
   }));
 }
@@ -27,8 +35,8 @@ function renderMessageCenter() {
   return { ...result, onOpenNotificationSettings };
 }
 
-async function openCenter() {
-  await waitFor(() => expect(screen.getByLabelText(/Open message center \(1 unread\)/)).toBeTruthy());
+async function openCenter(unreadCount = 1) {
+  await waitFor(() => expect(screen.getByLabelText(new RegExp(`Open message center \\(${unreadCount} unread\\)`))).toBeTruthy());
   fireEvent.click(screen.getByTestId('message-center-trigger'));
   return screen.getByTestId('message-center-dialog');
 }
@@ -61,7 +69,7 @@ describe('MessageCenterDemo', () => {
   });
 
   it('uses account read endpoints when logged in', async () => {
-    mockFetch(true);
+    mockFetch({ loggedIn: true });
     renderMessageCenter();
     await openCenter();
     fireEvent.click(screen.getByRole('button', { name: /Open Design 0\.14 is available/ }));
@@ -85,6 +93,68 @@ describe('MessageCenterDemo', () => {
     fireEvent.click(screen.getByRole('button', { name: /Open Design 0\.14 is available/ }));
     fireEvent.click(screen.getByRole('button', { name: 'View update' }));
     expect(open).toHaveBeenCalledWith('https://open-design.ai/update', '_blank', 'noopener,noreferrer');
+  });
+
+  it('keeps both anonymous reads when two expands resolve out of order', async () => {
+    const concurrentMessages = [
+      { ...defaultMessages[0]!, id: 'release', title: 'Release update', readAt: null, ctaLabel: null, ctaUrl: null },
+      { ...defaultMessages[0]!, id: 'security', title: 'Security notice', readAt: null, ctaLabel: null, ctaUrl: null },
+    ] satisfies MessageCenterMessage[];
+    let resolveFirst: (() => void) | undefined;
+    let resolveSecond: (() => void) | undefined;
+    mockFetch({
+      messages: concurrentMessages,
+      onRead: () =>
+        new Promise<Response>((resolve) => {
+          if (!resolveFirst) {
+            resolveFirst = () => resolve(Response.json({ read: true, markedCount: 1 }));
+            return;
+          }
+          resolveSecond = () => resolve(Response.json({ read: true, markedCount: 1 }));
+        }),
+    });
+    renderMessageCenter();
+    await openCenter(2);
+
+    fireEvent.click(screen.getByRole('button', { name: /Release update/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Security notice/ }));
+    resolveSecond?.();
+    await waitFor(() => expect(screen.queryByLabelText(/2 unread/)).toBeNull());
+    resolveFirst?.();
+    await waitFor(() => {
+      const stored = localStorage.getItem('open-design.message-center.anonymous-read-ids.v1');
+      expect(stored).toContain('release');
+      expect(stored).toContain('security');
+    });
+  });
+
+  it('reports mark-read failures without throwing an unhandled rejection', async () => {
+    const rejection = new Error('mark-read failed');
+    mockFetch({
+      loggedIn: true,
+      onRead: async () => {
+        throw rejection;
+      },
+    });
+    const unhandled = vi.fn();
+    window.addEventListener('unhandledrejection', unhandled);
+    renderMessageCenter();
+    await openCenter();
+
+    fireEvent.click(screen.getByRole('button', { name: /Open Design 0\.14 is available/ }));
+    await waitFor(() => expect(screen.getByText('Open Design 0.14 is available')).toBeTruthy());
+    expect(unhandled).not.toHaveBeenCalled();
+    window.removeEventListener('unhandledrejection', unhandled);
+  });
+
+  it('hides CTA actions for non-http URLs', async () => {
+    mockFetch({
+      messages: [{ ...defaultMessages[0]!, ctaUrl: 'javascript:alert(1)' }],
+    });
+    renderMessageCenter();
+    await openCenter();
+    fireEvent.click(screen.getByRole('button', { name: /Open Design 0\.14 is available/ }));
+    expect(screen.queryByRole('button', { name: 'View update' })).toBeNull();
   });
 
   it('closes with Escape and restores trigger focus', async () => {

--- a/apps/web/tests/components/MessageCenterDemo.test.tsx
+++ b/apps/web/tests/components/MessageCenterDemo.test.tsx
@@ -4,7 +4,7 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-li
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MessageCenterDemo } from '../../src/components/MessageCenterDemo';
-import { I18nProvider } from '../../src/i18n';
+import { I18nProvider, useI18n } from '../../src/i18n';
 import type { MessageCenterMessage } from '../../src/message-center-client';
 
 const defaultMessages: MessageCenterMessage[] = [
@@ -35,6 +35,15 @@ function renderMessageCenter() {
   const onOpenNotificationSettings = vi.fn();
   const result = render(<I18nProvider initial="en"><MessageCenterDemo onOpenNotificationSettings={onOpenNotificationSettings}/></I18nProvider>);
   return { ...result, onOpenNotificationSettings };
+}
+
+function LocaleSwitcher() {
+  const { setLocale } = useI18n();
+  return (
+    <button type="button" onClick={() => setLocale('fr')}>
+      Switch locale
+    </button>
+  );
 }
 
 async function openCenter(unreadCount = 1) {
@@ -203,6 +212,40 @@ describe('MessageCenterDemo', () => {
     expect(localStorage.getItem('open-design.message-center.anonymous-read-ids.v1')).toBeNull();
   });
 
+  it('keeps visible account messages when locale changes and the follow-up sync fails', async () => {
+    let messageRequests = 0;
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/status')) return Response.json({ loggedIn: true });
+      if (url.includes('/messages?')) {
+        messageRequests += 1;
+        if (messageRequests === 1) {
+          return Response.json({ messages: defaultMessages, nextCursor: null, unreadCount: 1 });
+        }
+        return new Response(null, { status: 500 });
+      }
+      if (url.includes('/read')) return Response.json({ read: true, markedCount: 1 });
+      return new Response(null, { status: 404 });
+    }));
+
+    render(
+      <I18nProvider initial="en">
+        <LocaleSwitcher />
+        <MessageCenterDemo />
+      </I18nProvider>,
+    );
+
+    await openCenter();
+    await waitFor(() => expect(screen.getByText('Open Design 0.14 is available')).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch locale' }));
+
+    await waitFor(() => expect(messageRequests).toBeGreaterThanOrEqual(2));
+    expect(screen.getByText('Open Design 0.14 is available')).toBeTruthy();
+    expect(screen.getByRole('status')).toBeTruthy();
+    expect(within(screen.getByRole('status')).getByRole('button')).toBeTruthy();
+  });
+
   it('hydrates cached anonymous state through the ref-backed source of truth', async () => {
     const cachedMessages = [
       { ...defaultMessages[0]!, id: 'release', title: 'Release update', readAt: null, ctaLabel: null, ctaUrl: null },
@@ -232,6 +275,38 @@ describe('MessageCenterDemo', () => {
     expect(localStorage.getItem('open-design.message-center.anonymous-read-ids.v1')).toContain('release');
     expect(localStorage.getItem('open-design.message-center.anonymous-read-ids.v1')).toContain('security');
     expect(localStorage.getItem('open-design.message-center.anonymous-messages.v1')).toContain('Release update');
+  });
+
+  it('drops account read ids when a mounted session falls back to anonymous', async () => {
+    let loggedIn = true;
+    mockFetch({
+      onStatus: async () => Response.json({ loggedIn }),
+      messages: [{ ...defaultMessages[0]!, id: 'release', title: 'Release update', readAt: null }],
+    });
+
+    renderMessageCenter();
+    await openCenter(1);
+    fireEvent.click(screen.getByRole('button', { name: /Release update/ }));
+    await waitFor(() =>
+      expect(
+        vi.mocked(fetch).mock.calls.some(
+          ([url, init]) => String(url).includes('/messages/release/read') && init?.method === 'POST',
+        ),
+      ).toBe(true),
+    );
+    await waitFor(() => expect(screen.queryByLabelText(/unread/)).toBeNull());
+
+    loggedIn = false;
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible',
+    });
+    fireEvent(document, new Event('visibilitychange'));
+
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Open message center \(1 unread\)/)).toBeTruthy(),
+    );
+    expect(localStorage.getItem('open-design.message-center.anonymous-read-ids.v1')).not.toContain('release');
   });
 
   it('reports mark-read failures without throwing an unhandled rejection', async () => {

--- a/apps/web/tests/components/MessageCenterDemo.test.tsx
+++ b/apps/web/tests/components/MessageCenterDemo.test.tsx
@@ -104,10 +104,13 @@ describe('MessageCenterDemo', () => {
     ] satisfies MessageCenterMessage[];
     let resolveFirst: (() => void) | undefined;
     let resolveSecond: (() => void) | undefined;
+    const readRequests: string[] = [];
     mockFetch({
+      loggedIn: true,
       messages: concurrentMessages,
-      onRead: () =>
+      onRead: (input) =>
         new Promise<Response>((resolve) => {
+          readRequests.push(String(input));
           if (!resolveFirst) {
             resolveFirst = () => resolve(Response.json({ read: true, markedCount: 1 }));
             return;
@@ -120,14 +123,50 @@ describe('MessageCenterDemo', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Release update/ }));
     fireEvent.click(screen.getByRole('button', { name: /Security notice/ }));
+    await waitFor(() => expect(readRequests).toEqual(expect.arrayContaining([
+      expect.stringContaining('/messages/release/read'),
+      expect.stringContaining('/messages/security/read'),
+    ])));
     resolveSecond?.();
     await waitFor(() => expect(screen.queryByLabelText(/2 unread/)).toBeNull());
     resolveFirst?.();
     await waitFor(() => {
-      const stored = localStorage.getItem('open-design.message-center.anonymous-read-ids.v1');
-      expect(stored).toContain('release');
-      expect(stored).toContain('security');
+      expect(screen.queryByLabelText(/unread/)).toBeNull();
+      expect(localStorage.getItem('open-design.message-center.anonymous-read-ids.v1')).toBeNull();
     });
+  });
+
+  it('uses account mark-read before the first delayed message sync resolves', async () => {
+    const cachedMessages = [
+      { ...defaultMessages[0]!, id: 'release', title: 'Release update', readAt: null, ctaLabel: null, ctaUrl: null },
+    ] satisfies MessageCenterMessage[];
+    let releaseMessages: (() => void) | undefined;
+    localStorage.setItem('open-design.message-center.anonymous-started-at.v1', '2026-07-16T00:00:00.000Z');
+    localStorage.setItem('open-design.message-center.anonymous-messages.v1', JSON.stringify(cachedMessages));
+    localStorage.setItem('open-design.message-center.anonymous-read-ids.v1', JSON.stringify([]));
+    mockFetch({
+      loggedIn: true,
+      onMessages: () =>
+        new Promise<Response>((resolve) => {
+          releaseMessages = () => resolve(Response.json({ messages: cachedMessages, nextCursor: null, unreadCount: 1 }));
+        }),
+    });
+
+    renderMessageCenter();
+    await openCenter(1);
+    fireEvent.click(screen.getByRole('button', { name: /Release update/ }));
+
+    await waitFor(() =>
+      expect(
+        vi.mocked(fetch).mock.calls.some(
+          ([url, init]) => String(url).includes('/messages/release/read') && init?.method === 'POST',
+        ),
+      ).toBe(true),
+    );
+    expect(localStorage.getItem('open-design.message-center.anonymous-read-ids.v1')).toBeNull();
+
+    releaseMessages?.();
+    await waitFor(() => expect(screen.queryByLabelText(/unread/)).toBeNull());
   });
 
   it('hydrates cached anonymous state through the ref-backed source of truth', async () => {

--- a/apps/web/tests/components/MessageCenterDemo.test.tsx
+++ b/apps/web/tests/components/MessageCenterDemo.test.tsx
@@ -169,6 +169,40 @@ describe('MessageCenterDemo', () => {
     await waitFor(() => expect(screen.queryByLabelText(/unread/)).toBeNull());
   });
 
+  it('re-checks auth on write after an anonymous mount so mid-session login uses account reads', async () => {
+    const cachedMessages = [
+      { ...defaultMessages[0]!, id: 'release', title: 'Release update', readAt: null, ctaLabel: null, ctaUrl: null },
+    ] satisfies MessageCenterMessage[];
+    let loggedIn = false;
+    let statusCalls = 0;
+    localStorage.setItem('open-design.message-center.anonymous-started-at.v1', '2026-07-16T00:00:00.000Z');
+    localStorage.setItem('open-design.message-center.anonymous-messages.v1', JSON.stringify(cachedMessages));
+    localStorage.setItem('open-design.message-center.anonymous-read-ids.v1', JSON.stringify([]));
+    mockFetch({
+      onStatus: async () => {
+        statusCalls += 1;
+        return Response.json({ loggedIn });
+      },
+      onMessages: async () => Response.json({ messages: cachedMessages, nextCursor: null, unreadCount: 1 }),
+    });
+
+    renderMessageCenter();
+    await openCenter(1);
+    expect(statusCalls).toBeGreaterThanOrEqual(2);
+
+    loggedIn = true;
+    fireEvent.click(screen.getByRole('button', { name: /Release update/ }));
+
+    await waitFor(() =>
+      expect(
+        vi.mocked(fetch).mock.calls.some(
+          ([url, init]) => String(url).includes('/messages/release/read') && init?.method === 'POST',
+        ),
+      ).toBe(true),
+    );
+    expect(localStorage.getItem('open-design.message-center.anonymous-read-ids.v1')).toBeNull();
+  });
+
   it('hydrates cached anonymous state through the ref-backed source of truth', async () => {
     const cachedMessages = [
       { ...defaultMessages[0]!, id: 'release', title: 'Release update', readAt: null, ctaLabel: null, ctaUrl: null },

--- a/apps/web/tests/components/MessageCenterDemo.test.tsx
+++ b/apps/web/tests/components/MessageCenterDemo.test.tsx
@@ -16,15 +16,17 @@ function mockFetch(
   options: {
     loggedIn?: boolean;
     messages?: MessageCenterMessage[];
+    onStatus?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+    onMessages?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
     onRead?: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
   } = {},
 ) {
-  const { loggedIn = false, messages = defaultMessages, onRead } = options;
-  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+  const { loggedIn = false, messages = defaultMessages, onStatus, onMessages, onRead } = options;
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
-    if (url.includes('/status')) return Response.json({ loggedIn });
-    if (url.includes('/messages?')) return Response.json({ messages, nextCursor: null, unreadCount: 1 });
-    if (url.includes('/read')) return onRead ? onRead(input) : Response.json({ read: true, markedCount: 1 });
+    if (url.includes('/status')) return onStatus ? onStatus(input, init) : Response.json({ loggedIn });
+    if (url.includes('/messages?')) return onMessages ? onMessages(input, init) : Response.json({ messages, nextCursor: null, unreadCount: 1 });
+    if (url.includes('/read')) return onRead ? onRead(input, init) : Response.json({ read: true, markedCount: 1 });
     return new Response(null, { status: 404 });
   }));
 }
@@ -128,6 +130,37 @@ describe('MessageCenterDemo', () => {
     });
   });
 
+  it('hydrates cached anonymous state through the ref-backed source of truth', async () => {
+    const cachedMessages = [
+      { ...defaultMessages[0]!, id: 'release', title: 'Release update', readAt: null, ctaLabel: null, ctaUrl: null },
+      { ...defaultMessages[0]!, id: 'security', title: 'Security notice', readAt: null, ctaLabel: null, ctaUrl: null },
+    ] satisfies MessageCenterMessage[];
+    localStorage.setItem('open-design.message-center.anonymous-started-at.v1', '2026-07-16T00:00:00.000Z');
+    localStorage.setItem('open-design.message-center.anonymous-messages.v1', JSON.stringify(cachedMessages));
+    localStorage.setItem('open-design.message-center.anonymous-read-ids.v1', JSON.stringify([]));
+    mockFetch({
+      onMessages: async () => new Response(null, { status: 500 }),
+    });
+
+    renderMessageCenter();
+    await openCenter(2);
+    expect(screen.getByText('Release update')).toBeTruthy();
+    expect(screen.getByRole('status')).toHaveTextContent('Check failed. Please retry.');
+
+    fireEvent.click(screen.getByRole('button', { name: /Release update/ }));
+    await waitFor(() =>
+      expect(localStorage.getItem('open-design.message-center.anonymous-read-ids.v1')).toContain('release'),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Mark all read' }));
+    await waitFor(() =>
+      expect(localStorage.getItem('open-design.message-center.anonymous-read-ids.v1')).toContain('security'),
+    );
+    expect(localStorage.getItem('open-design.message-center.anonymous-read-ids.v1')).toContain('release');
+    expect(localStorage.getItem('open-design.message-center.anonymous-read-ids.v1')).toContain('security');
+    expect(localStorage.getItem('open-design.message-center.anonymous-messages.v1')).toContain('Release update');
+  });
+
   it('reports mark-read failures without throwing an unhandled rejection', async () => {
     const rejection = new Error('mark-read failed');
     mockFetch({
@@ -145,6 +178,32 @@ describe('MessageCenterDemo', () => {
     await waitFor(() => expect(screen.getByText('Open Design 0.14 is available')).toBeTruthy());
     expect(unhandled).not.toHaveBeenCalled();
     window.removeEventListener('unhandledrejection', unhandled);
+  });
+
+  it('shows an inline sync error banner when mark-read fails with visible messages', async () => {
+    let readAttempts = 0;
+    mockFetch({
+      loggedIn: true,
+      onRead: async () => {
+        readAttempts += 1;
+        throw new Error('mark-read failed');
+      },
+    });
+    renderMessageCenter();
+    await openCenter();
+    await waitFor(() =>
+      expect(
+        vi.mocked(fetch).mock.calls.filter(([url]) => String(url).includes('/messages?')).length,
+      ).toBeGreaterThanOrEqual(2),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Open Design 0\.14 is available/ }));
+    await waitFor(() => expect(screen.getByRole('status')).toHaveTextContent('Check failed. Please retry.'));
+    expect(screen.getByText('Open Design 0.14 is available')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    await waitFor(() => expect(screen.queryByRole('status')).toBeNull());
+    expect(readAttempts).toBe(1);
   });
 
   it('hides CTA actions for non-http URLs', async () => {

--- a/apps/web/tests/message-center-client.test.ts
+++ b/apps/web/tests/message-center-client.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { anonymousStartedAt, pullMessageCenter } from '../src/message-center-client';
+
+describe('message center client', () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it('keeps the first anonymous window after later launches', () => {
+    const storage = new Map<string, string>();
+    const adapter = { getItem: (key: string) => storage.get(key) ?? null, setItem: (key: string, value: string) => void storage.set(key, value) } as Storage;
+    const first = anonymousStartedAt(adapter, new Date('2026-07-16T00:00:00Z'));
+    const second = anonymousStartedAt(adapter, new Date('2026-07-17T00:00:00Z'));
+    expect(second).toBe(first);
+  });
+
+  it('follows pagination until the server cursor is exhausted', async () => {
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(Response.json({ messages: [{ id: 'new' }], nextCursor: 'next', unreadCount: 1 }))
+      .mockResolvedValueOnce(Response.json({ messages: [{ id: 'old' }], nextCursor: null, unreadCount: 1 })));
+    const result = await pullMessageCenter({ locale: 'en', loggedIn: false, startedAt: '2026-07-16T00:00:00.000Z' });
+    expect(result.map((message) => message.id)).toEqual(['new', 'old']);
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
+    expect(String(vi.mocked(fetch).mock.calls[0]?.[0])).toContain(
+      '/api/integrations/vela/api-proxy/api/v1/message-center/messages?',
+    );
+  });
+
+  it('uses the credential-scoped daemon route for logged-in pulls', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      Response.json({ messages: [], nextCursor: null, unreadCount: 0 }),
+    ));
+    await pullMessageCenter({ locale: 'en', loggedIn: true });
+    expect(String(vi.mocked(fetch).mock.calls[0]?.[0])).toContain(
+      '/api/integrations/vela/message-center/messages?',
+    );
+  });
+});

--- a/apps/web/tests/message-center-client.test.ts
+++ b/apps/web/tests/message-center-client.test.ts
@@ -25,6 +25,16 @@ describe('message center client', () => {
     );
   });
 
+  it('fails fast when pagination cursors stop advancing', async () => {
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(Response.json({ messages: [{ id: 'new' }], nextCursor: 'stuck', unreadCount: 1 }))
+      .mockResolvedValueOnce(Response.json({ messages: [{ id: 'old' }], nextCursor: 'stuck', unreadCount: 1 })));
+    await expect(
+      pullMessageCenter({ locale: 'en', loggedIn: false, startedAt: '2026-07-16T00:00:00.000Z' }),
+    ).rejects.toThrow('Message Center pagination cursor did not advance');
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
+  });
+
   it('uses the credential-scoped daemon route for logged-in pulls', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
       Response.json({ messages: [], nextCursor: null, unreadCount: 0 }),

--- a/e2e/lib/playwright/visual.ts
+++ b/e2e/lib/playwright/visual.ts
@@ -658,7 +658,7 @@ export async function openAvatarMenu(page: Page): Promise<Locator> {
 }
 
 export async function openSettingsDetailsFromHeader(page: Page): Promise<Locator> {
-  const settingsTrigger = page.locator('.settings-icon-btn');
+  const settingsTrigger = page.getByTestId('entry-settings-menu-trigger');
   await expect(settingsTrigger).toBeVisible({ timeout: T.medium });
   await settingsTrigger.evaluate((element: HTMLElement) => element.click());
   await expect(page.getByTestId('entry-settings-menu')).toBeVisible({ timeout: T.medium });


### PR DESCRIPTION
## Summary

- replace Message Center demo data with paginated Vela API sync and durable anonymous local state
- sync account read state through a dedicated daemon route scoped to Message Center paths
- forward the current Vela profile control key only to that profile's configured API origin
- preserve filters, unread badge, expand-to-read, mark-all-read, CTA, locale mapping, and withdrawal convergence

## Test plan

- Message Center Web tests (9 passed)
- dedicated Vela daemon route tests (2 passed)
- `pnpm typecheck`
- `pnpm guard`
- local browser visual QA for unread badge, filters, expanded CTA, read transition, and panel layout

## Notes

- Anonymous pulls remain credential-free through the existing public proxy.
- CLI parity is not applicable: this route is a credential boundary for the existing Web-only Message Center experience, not a new daemon-owned user command.
- The complete Vela daemon route file has an unrelated existing model-order assertion failure; the Message Center subset passes independently.
