### PR TITLE
fix daemon Langfuse error redaction

### DIFF
--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -31,6 +31,7 @@ import type {
   RunTimingAnalytics,
 } from './run-analytics-observability.js';
 import type { RunFailureClassification } from './run-failure-classification.js';
+import { redactSecrets } from './redact.js';
 import { readTelemetryEnvironment } from './telemetry-environment.js';
 
 // Langfuse US region: confirmed by an end-to-end smoke on 2026-05-07 — the
@@ -1261,6 +1262,8 @@ function shouldCreateGenerationObservation(ctx: ReportContext): boolean {
 export function buildTracePayload(ctx: ReportContext): unknown[] {
   const wantsContent = ctx.prefs.metrics === true && ctx.prefs.content === true;
   const wantsArtifacts = wantsContent;
+  const safeRunError =
+    ctx.run.error === undefined ? undefined : redactSecrets(ctx.run.error);
 
   const sessionId =
     ctx.conversationId.length <= SESSION_ID_MAX ? ctx.conversationId : undefined;
@@ -1364,7 +1367,7 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
     success,
     env: readTelemetryEnvironment(),
     status: ctx.run.status,
-    error: ctx.run.error ?? undefined,
+    error: safeRunError,
     error_code: ctx.run.errorCode,
     langfuse_trace_id: traceId,
     ...langfuseDelivery,
@@ -1462,7 +1465,7 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
         input: inputText,
         output: outputText,
         level: success ? 'DEFAULT' : 'ERROR',
-        statusMessage: ctx.run.error ?? undefined,
+        statusMessage: safeRunError,
         metadata: {
           status: ctx.run.status,
           messageId: ctx.message.messageId || undefined,
@@ -1497,7 +1500,7 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
         input: generationInput,
         output: outputText,
         level: success ? 'DEFAULT' : 'ERROR',
-        statusMessage: ctx.run.error ?? undefined,
+        statusMessage: safeRunError,
         usage,
         metadata: {
           durationMs: ctx.eventsSummary.durationMs,
@@ -1527,7 +1530,7 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
         input: generationInput,
         output: outputText,
         level: 'ERROR',
-        statusMessage: ctx.run.error ?? undefined,
+        statusMessage: safeRunError,
         metadata: {
           durationMs: ctx.eventsSummary.durationMs,
           cost_usd: costBreakdown.cost_usd,
@@ -1667,7 +1670,7 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
         name: success ? 'error-summary' : 'run-error',
         startTime: endTimeIso,
         level: 'ERROR',
-        statusMessage: ctx.run.error ?? undefined,
+        statusMessage: safeRunError,
         metadata: {
           status: ctx.run.status,
           errors: ctx.eventsSummary.errors,

--- a/apps/daemon/src/redact.ts
+++ b/apps/daemon/src/redact.ts
@@ -60,6 +60,9 @@ const PATTERNS: readonly Pattern[] = [
   { name: 'google_api_key', regex: /\bAQ\.[A-Za-z0-9_-]{20,}\b/g },
   { name: 'google_api_key', regex: /\bAIza[0-9A-Za-z_-]{35}\b/g },
 
+  // NVIDIA NGC / inference API keys.
+  { name: 'nvidia_api_key', regex: /\bnvapi-[A-Za-z0-9_-]{20,}\b/g },
+
   // Slack tokens.
   { name: 'slack_token', regex: /\bxox[abprs]-[0-9A-Za-z-]{10,}\b/g },
 

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -937,6 +937,36 @@ describe('buildTracePayload', () => {
     expect((batch[0] as any).body.metadata.success).toBe(false);
   });
 
+  it('redacts secrets from every failed-run error field sent to Langfuse', () => {
+    const providerToken = ['nvapi', 'A'.repeat(48)].join('-');
+    const rawError = `Header has invalid value: Bearer ${providerToken}`;
+    const batch = buildTracePayload(
+      makeCtx({
+        run: {
+          runId: 'run-secret-error',
+          status: 'failed',
+          startedAt: 1,
+          endedAt: 2,
+          error: rawError,
+        },
+      }),
+    );
+    const redactedError =
+      'Header has invalid value: Bearer [REDACTED:nvidia_api_key]';
+
+    expect(bodyOf(batch, 'span-create', 'agent-run').statusMessage).toBe(
+      redactedError,
+    );
+    expect(bodyOf(batch, 'generation-create', 'llm').statusMessage).toBe(
+      redactedError,
+    );
+    expect(bodyOf(batch, 'event-create', 'run-error').statusMessage).toBe(
+      redactedError,
+    );
+    expect((batch[0] as any).body.metadata.error).toBe(redactedError);
+    expect(JSON.stringify(batch)).not.toContain(providerToken);
+  });
+
   it('uses an agent-runtime span instead of an llm generation for session-init failures with no model usage', () => {
     const batch = buildTracePayload(
       makeCtx({

--- a/apps/daemon/tests/redact.test.ts
+++ b/apps/daemon/tests/redact.test.ts
@@ -44,6 +44,13 @@ describe('redactSecrets', () => {
     ).toBe('GEMINI=[REDACTED:google_api_key]');
   });
 
+  it('redacts NVIDIA API keys even when they are not in a Bearer header', () => {
+    const providerKey = ['nvapi', 'A'.repeat(48)].join('-');
+    expect(redactSecrets(`NVIDIA_API_KEY=${providerKey}`)).toBe(
+      'NVIDIA_API_KEY=[REDACTED:nvidia_api_key]',
+    );
+  });
+
   it('redacts Slack and Stripe tokens', () => {
     expect(redactSecrets('SLACK=xoxb-12345-67890-abcdefghijKLMNOP')).toBe(
       'SLACK=[REDACTED:slack_token]',


### PR DESCRIPTION
## Why

A production reliability audit found that a provider error copied a credential-bearing header value into `ctx.run.error`. `buildTracePayload` then forwarded that string unchanged to Langfuse trace metadata and multiple observation `statusMessage` fields, so malformed provider configuration could persist a secret in new telemetry.

This PR fixes the forward path only. It does not delete, isolate, or backfill existing traces.

## What users will see

No UI changes. Newly reported failed runs redact recognized secrets before the error reaches Langfuse, including NVIDIA `nvapi-*` API keys whether they appear alone or in a Bearer header. Ordinary diagnostic text remains available.

## Surface area

- [ ] UI
- [ ] CLI
- [ ] API / protocol
- [ ] Default behavior
- [ ] Configuration / environment
- [ ] Skills / design systems / templates / craft
- [x] None (internal telemetry hardening only)

## Screenshots

Not applicable — daemon-only telemetry hardening with no UI surface.

## Bug fix verification

- Red spec: `apps/daemon/tests/langfuse-trace.test.ts` and `apps/daemon/tests/redact.test.ts`
- Confirmed red before the source change: raw `nvapi-*` data remained in Langfuse payloads and bare NVIDIA keys were not recognized.
- Confirmed green after the source change: every failed-run error field in the generated Langfuse batch is redacted, and bare NVIDIA keys use the dedicated `nvidia_api_key` marker.

## Validation

- `corepack pnpm --filter @open-design/daemon exec vitest run tests/redact.test.ts tests/langfuse-trace.test.ts tests/langfuse-bridge.test.ts tests/langfuse-bridge-nonblocking.test.ts tests/langfuse-env.test.ts` — 122 tests passed
- `corepack pnpm --filter @open-design/daemon build` — passed
- `corepack pnpm typecheck` — passed
- `git diff --check` — passed
- `corepack pnpm guard` — blocked by a pre-existing `origin/main` workspace inconsistency: `apps/telemetry-worker/package.json` is referenced but absent. All preceding guard checks passed; this PR does not touch that path.