### PR TITLE
Fix repo-only design system intake

### DIFF
--- a/apps/web/src/components/DesignSystemFlow.tsx
+++ b/apps/web/src/components/DesignSystemFlow.tsx
@@ -913,8 +913,7 @@ export function DesignSystemCreationFlow({
       // drives the kickoff. POST /api/brands creates the backing project and
       // real transcript immediately, then the programmatic pass registers a
       // usable user:<id> design system in the background.
-      const extractUrl =
-        nonGithubSourceUrlsFromState(state)[0] ?? sourceUrlsFromState(state)[0] ?? '';
+      const extractUrl = nonGithubSourceUrlsFromState(state)[0] ?? '';
       const fallbackDesignMd = !extractUrl && !hasDesignMd
         ? buildFallbackDesignMdFromState(state)
         : '';

--- a/apps/web/tests/components/DesignSystemFlow.test.tsx
+++ b/apps/web/tests/components/DesignSystemFlow.test.tsx
@@ -406,7 +406,7 @@ describe('DesignSystemCreationFlow', () => {
     expect(mocks.ensureDesignSystemWorkspace).not.toHaveBeenCalled();
   });
 
-  it('normalizes GitHub SSH source links before starting extraction', async () => {
+  it('keeps GitHub-only source links out of website brand extraction', async () => {
     const project: Project = {
       id: 'brand-github',
       name: 'GitHub Design System',
@@ -430,9 +430,10 @@ describe('DesignSystemCreationFlow', () => {
       | { body: string }
       | undefined;
     expect(requestInit).toBeTruthy();
-    expect(JSON.parse(requestInit!.body)).toMatchObject({
-      url: 'https://github.com/nexu-io/open-design',
-    });
+    const body = JSON.parse(requestInit!.body) as { url?: string; designMd?: string };
+    expect(body.url).toBeUndefined();
+    expect(body.designMd).toEqual(expect.stringContaining('https://github.com/nexu-io/open-design'));
+    expect(body.designMd).toEqual(expect.stringContaining('GitHub repositories: https://github.com/nexu-io/open-design'));
   });
 
   it('keeps protocol-less website paths as website URLs', async () => {


### PR DESCRIPTION
## Summary
- keep GitHub-only repository sources out of website brand extraction kickoff
- fall back to generated design-system markdown for repository-only sources
- update the regression test to assert no website URL is sent for a GitHub-only source

Fixes #5763.

## Surface area
- `DesignSystemCreationFlow` website/repository source selection before `POST /api/brands`
- `DesignSystemFlow` component regression coverage for GitHub-only source intake

## Bug fix verification
- GitHub-only source URLs no longer populate the website extraction `url` field
- repo-only inputs still carry the GitHub repository URL through generated design-system markdown
- existing website-source extraction behavior remains covered by the adjacent focused regression tests

## Validation
- pnpm --filter @open-design/contracts build && pnpm --filter @open-design/web typecheck
- pnpm --filter @open-design/web test -- tests/components/DesignSystemFlow.test.tsx -t 'keeps GitHub-only source links out of website brand extraction'
- pnpm --filter @open-design/web test -- tests/components/DesignSystemFlow.test.tsx -t 'keeps protocol-less website paths as website URLs|extracts a design system from a website via POST /api/brands'
- git diff --check
