### PR TITLE
fix(updater): defer locked launcher cleanup

### DIFF
--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -166,6 +166,7 @@ export type DesktopUpdaterDeps = {
   openPath?: (path: string) => Promise<string>;
   processExecPath?: string;
   processPid?: number;
+  removeLauncherPayloadRoot?: (path: string) => Promise<void>;
   spawnDetached?: SpawnInstallerHelper;
 };
 
@@ -178,6 +179,11 @@ export type LauncherPayloadExtractInput = {
 
 type DesktopUpdaterLogger = Pick<Console, "error" | "warn"> & Partial<Pick<Console, "info">>;
 type DetachedProcess = { unref(): void };
+type LauncherPayloadCleanupTrigger = "activate" | "prepare-existing" | "prepare-promoted";
+type LauncherPayloadCleanupFailure = {
+  error: NonNullable<LauncherCleanupEntry["error"]>;
+  version: string;
+};
 type SpawnInstallerHelper = (
   command: string,
   args: string[],
@@ -1275,6 +1281,9 @@ async function prepareLauncherPayloadRelease(input: {
   activeRelease: LoadedRelease;
   config: DesktopUpdaterConfig;
   extractLauncherPayloadArchive: (extractInput: LauncherPayloadExtractInput) => Promise<void>;
+  logger: DesktopUpdaterLogger;
+  now: () => Date;
+  removeLauncherPayloadRoot: (path: string) => Promise<void>;
 }): Promise<void> {
   if (input.config.launcherRoot == null || input.config.launcherRuntimePath == null || input.config.namespace == null) {
     throw new Error("launcher payload prepare requires launcher root, runtime path, and namespace");
@@ -1303,22 +1312,35 @@ async function prepareLauncherPayloadRelease(input: {
       if (!existingVersion.isDirectory() || existingVersion.isSymbolicLink()) {
         throw new Error(`launcher payload version root is not a plain directory: ${versionPaths.versionRoot}`);
       }
+      let existingVersionValid = false;
       try {
         await assertPreparedLauncherPayloadRelease({
           config: input.config,
           root: versionPaths.versionRoot,
           version: input.activeRelease.ref.version,
         });
-        await cleanupLauncherPayloadRoots(versionPaths, new Set([
-          input.activeRelease.ref.version,
-          ...(currentRuntime.active == null ? [] : [currentRuntime.active.version]),
-          ...(currentRuntime.lastSuccessful == null ? [] : [currentRuntime.lastSuccessful.version]),
-        ]));
-        return;
+        existingVersionValid = true;
       } catch {
         // Keep the existing version root intact until the replacement staging
         // payload has fully validated. If validation fails below, the old root
         // remains available for forensic inspection or a later retry.
+      }
+      if (existingVersionValid) {
+        await cleanupLauncherPayloadRoots({
+          config: input.config,
+          currentRuntime,
+          keepVersions: new Set([
+            input.activeRelease.ref.version,
+            ...(currentRuntime.active == null ? [] : [currentRuntime.active.version]),
+            ...(currentRuntime.lastSuccessful == null ? [] : [currentRuntime.lastSuccessful.version]),
+          ]),
+          logger: input.logger,
+          now: input.now,
+          removeLauncherPayloadRoot: input.removeLauncherPayloadRoot,
+          trigger: "prepare-existing",
+          versionPaths,
+        });
+        return;
       }
     }
 
@@ -1340,11 +1362,20 @@ async function prepareLauncherPayloadRelease(input: {
     await rm(versionPaths.versionRoot, { force: true, recursive: true });
     await rename(stagingRoot, versionPaths.versionRoot);
     promoted = true;
-    await cleanupLauncherPayloadRoots(versionPaths, new Set([
-      input.activeRelease.ref.version,
-      ...(currentRuntime.active == null ? [] : [currentRuntime.active.version]),
-      ...(currentRuntime.lastSuccessful == null ? [] : [currentRuntime.lastSuccessful.version]),
-    ]));
+    await cleanupLauncherPayloadRoots({
+      config: input.config,
+      currentRuntime,
+      keepVersions: new Set([
+        input.activeRelease.ref.version,
+        ...(currentRuntime.active == null ? [] : [currentRuntime.active.version]),
+        ...(currentRuntime.lastSuccessful == null ? [] : [currentRuntime.lastSuccessful.version]),
+      ]),
+      logger: input.logger,
+      now: input.now,
+      removeLauncherPayloadRoot: input.removeLauncherPayloadRoot,
+      trigger: "prepare-promoted",
+      versionPaths,
+    });
   } catch (error) {
     if (!promoted) await rm(stagingRoot, { force: true, recursive: true }).catch(() => undefined);
     throw error;
@@ -1354,7 +1385,9 @@ async function prepareLauncherPayloadRelease(input: {
 async function activatePreparedLauncherPayloadRelease(input: {
   activeRelease: LoadedRelease;
   config: DesktopUpdaterConfig;
+  logger: DesktopUpdaterLogger;
   now: () => Date;
+  removeLauncherPayloadRoot: (path: string) => Promise<void>;
 }): Promise<LauncherRuntimeDescriptor> {
   if (input.config.launcherRoot == null || input.config.launcherRuntimePath == null || input.config.namespace == null) {
     throw new Error("launcher payload activate requires launcher root, runtime path, and namespace");
@@ -1395,23 +1428,185 @@ async function activatePreparedLauncherPayloadRelease(input: {
     updatedAt: input.now().toISOString(),
   };
   await writeJson(input.config.launcherRuntimePath, nextRuntime);
-  await cleanupLauncherPayloadRoots(versionPaths, new Set([
-    nextActive.version,
-    ...(currentRuntime.active == null ? [] : [currentRuntime.active.version]),
-    ...(currentRuntime.lastSuccessful == null ? [] : [currentRuntime.lastSuccessful.version]),
-    ...(nextRuntime.lastSuccessful == null ? [] : [nextRuntime.lastSuccessful.version]),
-  ]));
+  await cleanupLauncherPayloadRoots({
+    config: input.config,
+    currentRuntime: nextRuntime,
+    keepVersions: new Set([
+      nextActive.version,
+      ...(currentRuntime.active == null ? [] : [currentRuntime.active.version]),
+      ...(currentRuntime.lastSuccessful == null ? [] : [currentRuntime.lastSuccessful.version]),
+      ...(nextRuntime.lastSuccessful == null ? [] : [nextRuntime.lastSuccessful.version]),
+    ]),
+    logger: input.logger,
+    now: input.now,
+    removeLauncherPayloadRoot: input.removeLauncherPayloadRoot,
+    trigger: "activate",
+    versionPaths,
+  });
   return nextRuntime;
 }
 
-async function cleanupLauncherPayloadRoots(versionPaths: ReturnType<typeof resolveLauncherVersionPaths>, keepVersions: ReadonlySet<string>): Promise<void> {
-  await rm(versionPaths.stagingRoot, { force: true, recursive: true });
-  const entries = await readdir(versionPaths.versionsRoot, { withFileTypes: true }).catch(() => []);
-  await Promise.all(entries.map(async (entry) => {
-    if (!entry.isDirectory()) return;
-    if (keepVersions.has(entry.name)) return;
-    await rm(join(versionPaths.versionsRoot, entry.name), { force: true, recursive: true });
-  }));
+function launcherCleanupErrorFrom(error: unknown): NonNullable<LauncherCleanupEntry["error"]> {
+  const code = (error as NodeJS.ErrnoException).code;
+  return launcherCleanupError(
+    typeof code === "string" && code.length > 0 ? code : "launcher-cleanup-failed",
+    error instanceof Error ? error.message : String(error),
+  );
+}
+
+function launcherRuntimeGenerationForVersion(runtime: LauncherRuntimeDescriptor, version: string): number {
+  return Math.max(
+    ...(runtime.active?.version === version ? [runtime.active.generation] : []),
+    ...(runtime.lastSuccessful?.version === version ? [runtime.lastSuccessful.generation] : []),
+    0,
+  );
+}
+
+async function readLauncherCleanupDescriptor(
+  config: DesktopUpdaterConfig,
+  cleanupPath: string,
+): Promise<LauncherCleanupDescriptor | null> {
+  try {
+    return validateLauncherCleanupDescriptor(
+      await readJsonStrict<LauncherCleanupDescriptor>(cleanupPath),
+      { channel: config.channel, namespace: config.namespace ?? "" },
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+async function writeDeferredLauncherCleanupFailures(input: {
+  cleanup: LauncherCleanupDescriptor | null;
+  config: DesktopUpdaterConfig;
+  currentRuntime: LauncherRuntimeDescriptor;
+  failures: LauncherPayloadCleanupFailure[];
+  nowIso: string;
+  path: string;
+}): Promise<void> {
+  const versions = new Map((input.cleanup?.versions ?? []).map((entry) => [entry.version, entry] as const));
+  for (const failure of input.failures) {
+    const existing = versions.get(failure.version);
+    if (existing?.state === "retained") continue;
+    versions.set(failure.version, {
+      error: failure.error,
+      generation: existing?.generation ?? launcherRuntimeGenerationForVersion(input.currentRuntime, failure.version),
+      reason: "cleanup-failed",
+      state: "cleanup-deferred",
+      updatedAt: input.nowIso,
+      version: failure.version,
+    });
+  }
+  const next: LauncherCleanupDescriptor = {
+    channel: input.config.channel,
+    currentVersion: input.cleanup?.currentVersion ?? input.config.currentVersion,
+    namespace: input.config.namespace ?? "",
+    updatedAt: input.nowIso,
+    version: LAUNCHER_SCHEMA_VERSION,
+    versions: [...versions.values()].sort((left, right) => (
+      compareLauncherVersions(left.version, right.version) || left.version.localeCompare(right.version)
+    )),
+  };
+  await writeJson(input.path, next);
+}
+
+async function cleanupLauncherPayloadRoots(input: {
+  config: DesktopUpdaterConfig;
+  currentRuntime: LauncherRuntimeDescriptor;
+  keepVersions: ReadonlySet<string>;
+  logger: DesktopUpdaterLogger;
+  now: () => Date;
+  removeLauncherPayloadRoot: (path: string) => Promise<void>;
+  trigger: LauncherPayloadCleanupTrigger;
+  versionPaths: ReturnType<typeof resolveLauncherVersionPaths>;
+}): Promise<void> {
+  const { config, currentRuntime, keepVersions, logger, now, removeLauncherPayloadRoot, trigger, versionPaths } = input;
+  await rm(versionPaths.stagingRoot, { force: true, recursive: true }).catch((error: unknown) => {
+    const cleanupError = launcherCleanupErrorFrom(error);
+    logger.warn("[open-design updater] failed post-commit launcher staging cleanup", {
+      error: cleanupError.message,
+      errorCode: cleanupError.code,
+      event: "launcher-payload-cleanup",
+      path: versionPaths.stagingRoot,
+      trigger,
+    });
+  });
+
+  let cleanup: LauncherCleanupDescriptor | null;
+  try {
+    cleanup = await readLauncherCleanupDescriptor(config, versionPaths.cleanupPath);
+  } catch (error) {
+    const cleanupError = launcherCleanupErrorFrom(error);
+    logger.warn("[open-design updater] skipped post-commit launcher cleanup because cleanup state is invalid", {
+      error: cleanupError.message,
+      errorCode: cleanupError.code,
+      event: "launcher-payload-cleanup",
+      path: versionPaths.cleanupPath,
+      trigger,
+    });
+    return;
+  }
+
+  const retainedVersions = new Set([
+    ...keepVersions,
+    ...(cleanup?.versions.filter((entry) => entry.state === "retained").map((entry) => entry.version) ?? []),
+  ]);
+  let entries;
+  try {
+    entries = await readdir(versionPaths.versionsRoot, { withFileTypes: true });
+  } catch (error) {
+    const cleanupError = launcherCleanupErrorFrom(error);
+    logger.warn("[open-design updater] failed to scan launcher payload versions after commit", {
+      error: cleanupError.message,
+      errorCode: cleanupError.code,
+      event: "launcher-payload-cleanup",
+      path: versionPaths.versionsRoot,
+      trigger,
+    });
+    return;
+  }
+
+  const failures: LauncherPayloadCleanupFailure[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory() || retainedVersions.has(entry.name)) continue;
+    const path = join(versionPaths.versionsRoot, entry.name);
+    try {
+      await removeLauncherPayloadRoot(path);
+    } catch (error) {
+      const cleanupError = launcherCleanupErrorFrom(error);
+      failures.push({ error: cleanupError, version: entry.name });
+      logger.warn("[open-design updater] deferred launcher payload cleanup", {
+        error: cleanupError.message,
+        errorCode: cleanupError.code,
+        event: "launcher-payload-cleanup",
+        path,
+        trigger,
+        version: entry.name,
+      });
+    }
+  }
+  if (failures.length === 0) return;
+
+  try {
+    await writeDeferredLauncherCleanupFailures({
+      cleanup,
+      config,
+      currentRuntime,
+      failures,
+      nowIso: now().toISOString(),
+      path: versionPaths.cleanupPath,
+    });
+  } catch (error) {
+    const cleanupError = launcherCleanupErrorFrom(error);
+    logger.warn("[open-design updater] failed to persist deferred launcher payload cleanup", {
+      error: cleanupError.message,
+      errorCode: cleanupError.code,
+      event: "launcher-payload-cleanup",
+      path: versionPaths.cleanupPath,
+      trigger,
+    });
+  }
 }
 
 async function ensureOwnedSubdir(root: string, name: string): Promise<string> {
@@ -2074,7 +2269,7 @@ async function runUpdateReleaseLifecycle(input: {
   });
 }
 
-function launcherCleanupError(code: string, message: string): LauncherCleanupEntry["error"] {
+function launcherCleanupError(code: string, message: string): NonNullable<LauncherCleanupEntry["error"]> {
   return { code, message };
 }
 
@@ -2391,6 +2586,9 @@ export function createDesktopUpdater(
   const openPath = deps.openPath ?? (async () => "openPath is not available");
   const processPid = deps.processPid ?? process.pid;
   const extractLauncherPayloadArchive = deps.extractLauncherPayloadArchive ?? defaultExtractLauncherPayloadArchive;
+  const removeLauncherPayloadRoot = deps.removeLauncherPayloadRoot ?? (async (path) => {
+    await rm(path, { force: true, recursive: true });
+  });
   const spawnDetached: SpawnInstallerHelper = deps.spawnDetached ?? ((command, args, options) => spawn(command, args, options));
   const launchInstallerAfterQuit = deps.launchInstallerAfterQuit ?? ((input) => (
     config.platform === "win32"
@@ -2542,6 +2740,9 @@ export function createDesktopUpdater(
         activeRelease: release,
         config,
         extractLauncherPayloadArchive,
+        logger,
+        now,
+        removeLauncherPayloadRoot,
       });
       return null;
     } catch (prepareError) {
@@ -3043,7 +3244,9 @@ export function createDesktopUpdater(
         await activatePreparedLauncherPayloadRelease({
           activeRelease,
           config,
+          logger,
           now,
+          removeLauncherPayloadRoot,
         });
         const relaunch = await requestPayloadRelaunch(opened.root.realRoot);
         if (relaunch.error != null && relaunch.error.length > 0) {

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -291,6 +291,36 @@ async function writeReleaseFixture(root: string, key: string, channel: FixtureCh
   return releaseDir;
 }
 
+async function writeLauncherPayloadFixture(destinationRoot: string, version: string): Promise<void> {
+  await mkdir(join(destinationRoot, "payload", "resources", "open-design"), { recursive: true });
+  await writeFile(join(destinationRoot, "payload", "Open Design.exe"), "");
+  await writeFile(join(destinationRoot, "payload", "resources", "open-design-config.json"), "{}\n");
+  await writeFile(join(destinationRoot, "manifest.json"), `${JSON.stringify({
+    channel: "beta",
+    entry: {
+      cwd: "payload",
+      executable: "payload/Open Design.exe",
+    },
+    namespace: "release-beta-win",
+    payloadRoot: "payload",
+    platform: "win32",
+    schemaVersion: LAUNCHER_SCHEMA_VERSION,
+    version,
+  })}\n`);
+}
+
+function failLauncherPayloadRemovalForVersion(version: string): (path: string) => Promise<void> {
+  return async (path) => {
+    if (basename(path) === version) {
+      throw Object.assign(
+        new Error(`EPERM: operation not permitted, rm '${join(path, "payload", "opencode.exe")}'`),
+        { code: "EPERM" },
+      );
+    }
+    await rm(path, { force: true, recursive: true });
+  };
+}
+
 describe("desktop updater", () => {
   it("derives installer observation summary paths from safe flow ids only", () => {
     const root = makeRoot();
@@ -614,6 +644,217 @@ describe("desktop updater", () => {
       expect(existsSync(join(root, "launcher", "channels", "beta", "namespaces", "release-beta-win", "versions", "1.0.0-beta.1"))).toBe(true);
       expect(existsSync(join(root, "launcher", "channels", "beta", "namespaces", "release-beta-win", "versions", "0.9.0-beta.1"))).toBe(false);
       expect(existsSync(join(root, "launcher", "channels", "beta", "namespaces", "release-beta-win", "updates", "staging"))).toBe(false);
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("defers locked old launcher cleanup without blocking prepare or re-extracting the promoted payload", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture({
+      channel: "beta",
+      includePayload: true,
+      payloadBody: "open design locked cleanup payload fixture",
+      platform: "win",
+      version: "1.0.0-beta.2",
+    });
+    const launcherPaths = resolveLauncherPaths({
+      channel: "beta",
+      namespace: "release-beta-win",
+      root,
+    });
+    const launcherLaunchPath = join(root, "installed", "Open Design Beta.exe");
+    const logger = { error: vi.fn(), info: vi.fn(), warn: vi.fn() };
+    let extractCount = 0;
+    const createUpdater = (removeLauncherPayloadRoot?: (path: string) => Promise<void>) => createDesktopUpdater({
+      arch: "x64",
+      currentVersion: "1.0.0-beta.1",
+      downloadRoot: join(root, "updates"),
+      env: {
+        ...updaterEnv(fixture.metadataUrl, "win32"),
+        [DESKTOP_UPDATE_ENV.CHANNEL]: DESKTOP_UPDATE_CHANNELS.BETA,
+        [DESKTOP_UPDATE_ENV.CURRENT_VERSION]: "1.0.0-beta.1",
+      },
+      launcherLaunchPath,
+      launcherRoot: root,
+      launcherRuntimePath: launcherPaths.runtimePath,
+      namespace: "release-beta-win",
+      source: SIDECAR_SOURCES.PACKAGED,
+    }, {
+      extractLauncherPayloadArchive: async ({ destinationRoot }) => {
+        extractCount += 1;
+        await writeLauncherPayloadFixture(destinationRoot, "1.0.0-beta.2");
+      },
+      logger,
+      ...(removeLauncherPayloadRoot == null ? {} : { removeLauncherPayloadRoot }),
+    });
+    try {
+      await mkdir(join(root, "installed"), { recursive: true });
+      await writeFile(launcherLaunchPath, "");
+      await mkdir(join(launcherPaths.versionsRoot, "1.0.0-beta.1"), { recursive: true });
+      await mkdir(join(launcherPaths.versionsRoot, "1.0.0-beta.0", "payload"), { recursive: true });
+      await writeFile(join(launcherPaths.versionsRoot, "1.0.0-beta.0", "payload", "opencode.exe"), "locked");
+      await mkdir(launcherPaths.stateRoot, { recursive: true });
+      await writeFile(launcherPaths.runtimePath, `${JSON.stringify({
+        active: { generation: 1, version: "1.0.0-beta.1" },
+        channel: "beta",
+        lastSuccessful: { generation: 1, version: "1.0.0-beta.1" },
+        namespace: "release-beta-win",
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+      })}\n`);
+      await writeFile(launcherPaths.cleanupPath, `${JSON.stringify({
+        channel: "beta",
+        currentVersion: "1.0.0-beta.1",
+        namespace: "release-beta-win",
+        updatedAt: "2026-07-15T00:00:00.000Z",
+        version: LAUNCHER_SCHEMA_VERSION,
+        versions: [
+          {
+            generation: 1,
+            reason: "current-bound-package",
+            state: "retained",
+            updatedAt: "2026-07-15T00:00:00.000Z",
+            version: "1.0.0-beta.1",
+          },
+          {
+            generation: 0,
+            reason: "cleanup-failed",
+            removedAt: "2026-07-15T00:00:00.000Z",
+            state: "cleanup-removed",
+            updatedAt: "2026-07-15T00:00:00.000Z",
+            version: "0.9.0-beta.1",
+          },
+        ],
+      })}\n`);
+
+      const lockedUpdater = createUpdater(failLauncherPayloadRemovalForVersion("1.0.0-beta.0"));
+      const checked = await lockedUpdater.checkForUpdates();
+
+      expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
+      expect(checked.error).toBeUndefined();
+      expect(extractCount).toBe(1);
+      expect(fixture.artifactRequests()).toBe(1);
+      expect(existsSync(join(launcherPaths.versionsRoot, "1.0.0-beta.2", "manifest.json"))).toBe(true);
+      expect(JSON.parse(await readFile(launcherPaths.runtimePath, "utf8"))).toMatchObject({
+        active: { generation: 1, version: "1.0.0-beta.1" },
+        lastSuccessful: { generation: 1, version: "1.0.0-beta.1" },
+      });
+      const deferred = JSON.parse(await readFile(launcherPaths.cleanupPath, "utf8")) as {
+        versions: Array<{ error?: { code?: string; message?: string }; reason: string; state: string; version: string }>;
+      };
+      expect(deferred.versions.find((entry) => entry.version === "1.0.0-beta.0")).toMatchObject({
+        error: { code: "EPERM", message: expect.stringContaining("opencode.exe") },
+        reason: "cleanup-failed",
+        state: "cleanup-deferred",
+      });
+      expect(deferred.versions.find((entry) => entry.version === "1.0.0-beta.1")).toMatchObject({
+        reason: "current-bound-package",
+        state: "retained",
+      });
+      expect(deferred.versions.find((entry) => entry.version === "0.9.0-beta.1")).toMatchObject({
+        reason: "cleanup-failed",
+        state: "cleanup-removed",
+      });
+
+      const rechecked = await lockedUpdater.checkForUpdates();
+      expect(rechecked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
+      expect(rechecked.error).toBeUndefined();
+      expect(extractCount).toBe(1);
+      expect(fixture.artifactRequests()).toBe(1);
+
+      const restored = await createUpdater().status();
+      const cleaned = JSON.parse(await readFile(launcherPaths.cleanupPath, "utf8")) as {
+        versions: Array<{ state: string; version: string }>;
+      };
+      expect(restored.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
+      expect(restored.error).toBeUndefined();
+      expect(extractCount).toBe(1);
+      expect(fixture.artifactRequests()).toBe(1);
+      expect(existsSync(join(launcherPaths.versionsRoot, "1.0.0-beta.0"))).toBe(false);
+      expect(cleaned.versions.find((entry) => entry.version === "1.0.0-beta.0")).toMatchObject({
+        state: "cleanup-removed",
+      });
+    } finally {
+      await fixture.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("keeps launcher activation successful when unrelated old-version cleanup is deferred", async () => {
+    const root = makeRoot();
+    const fixture = await createUpdaterFixture({
+      channel: "beta",
+      includePayload: true,
+      payloadBody: "open design activation cleanup payload fixture",
+      platform: "win",
+      version: "1.0.0-beta.2",
+    });
+    const launcherPaths = resolveLauncherPaths({
+      channel: "beta",
+      namespace: "release-beta-win",
+      root,
+    });
+    const launcherLaunchPath = join(root, "installed", "Open Design Beta.exe");
+    const logger = { error: vi.fn(), info: vi.fn(), warn: vi.fn() };
+    let extractCount = 0;
+    try {
+      await mkdir(join(root, "installed"), { recursive: true });
+      await writeFile(launcherLaunchPath, "");
+      await mkdir(join(launcherPaths.versionsRoot, "1.0.0-beta.1"), { recursive: true });
+      await mkdir(launcherPaths.stateRoot, { recursive: true });
+      await writeFile(launcherPaths.runtimePath, `${JSON.stringify({
+        active: { generation: 1, version: "1.0.0-beta.1" },
+        channel: "beta",
+        lastSuccessful: { generation: 1, version: "1.0.0-beta.1" },
+        namespace: "release-beta-win",
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
+      })}\n`);
+      const updater = createDesktopUpdater({
+        arch: "x64",
+        currentVersion: "1.0.0-beta.1",
+        downloadRoot: join(root, "updates"),
+        env: {
+          ...updaterEnv(fixture.metadataUrl, "win32"),
+          [DESKTOP_UPDATE_ENV.CHANNEL]: DESKTOP_UPDATE_CHANNELS.BETA,
+          [DESKTOP_UPDATE_ENV.CURRENT_VERSION]: "1.0.0-beta.1",
+        },
+        launcherLaunchPath,
+        launcherRoot: root,
+        launcherRuntimePath: launcherPaths.runtimePath,
+        namespace: "release-beta-win",
+        source: SIDECAR_SOURCES.PACKAGED,
+      }, {
+        extractLauncherPayloadArchive: async ({ destinationRoot }) => {
+          extractCount += 1;
+          await writeLauncherPayloadFixture(destinationRoot, "1.0.0-beta.2");
+        },
+        logger,
+        removeLauncherPayloadRoot: failLauncherPayloadRemovalForVersion("1.0.0-beta.0"),
+      });
+
+      const checked = await updater.checkForUpdates();
+      expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
+      await mkdir(join(launcherPaths.versionsRoot, "1.0.0-beta.0", "payload"), { recursive: true });
+      await writeFile(join(launcherPaths.versionsRoot, "1.0.0-beta.0", "payload", "opencode.exe"), "locked");
+
+      const installed = await updater.installUpdate();
+
+      expect(installed.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
+      expect(installed.error).toBeUndefined();
+      expect(installed.installResult?.activeVersion).toBe("1.0.0-beta.2");
+      expect(extractCount).toBe(1);
+      expect(JSON.parse(await readFile(launcherPaths.runtimePath, "utf8"))).toMatchObject({
+        active: { generation: 2, version: "1.0.0-beta.2" },
+        lastSuccessful: { generation: 1, version: "1.0.0-beta.1" },
+      });
+      const cleanup = JSON.parse(await readFile(launcherPaths.cleanupPath, "utf8")) as {
+        versions: Array<{ error?: { code?: string; message?: string }; state: string; version: string }>;
+      };
+      expect(cleanup.versions.find((entry) => entry.version === "1.0.0-beta.0")).toMatchObject({
+        error: { code: "EPERM", message: expect.stringContaining("opencode.exe") },
+        state: "cleanup-deferred",
+      });
     } finally {
       await fixture.close();
       rmSync(root, { force: true, recursive: true });


### PR DESCRIPTION
## Why

While validating the internal Windows prerelease upgrade path, we hit a repeatable failure when an old launcher payload still contained a running `opencode.exe`. Windows returned `EPERM` while deleting that unrelated old version after the new payload had already been validated and promoted.

That cleanup error crossed the updater's commit boundary: prepare reported `launcher-payload-prepare-failed` and re-extracted the already-valid promoted payload on each retry, while activation could write the new runtime pointer and still report `launcher-payload-apply-failed`. This PR keeps successful prepare/activation results authoritative and hands locked-root cleanup to the existing deferred lifecycle.

## What users will see

On Windows, an update no longer fails or repeatedly extracts the new launcher payload merely because an older launcher version still has a running executable. The new payload remains ready or active, and the locked old root is retried by launcher cleanup after the process exits.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — there is no UI change.

## Bug fix verification

- Test path: `apps/desktop/tests/main/updater.test.ts`
- Red/green: yes. After adding only the deterministic launcher-root removal injection seam, the two new specs failed against `main` behavior (`2 failed, 57 passed, 2 skipped`) and passed after the fix (`59 passed, 2 skipped`).
- A native Windows harness also reproduced both original failures with a real running copied executable 20/20 rounds on the old behavior. With this branch, prepare and activation each passed 20/20 rounds, did not repeat extraction, persisted deferred cleanup, and converged after unlock.

## Validation

- `pnpm --filter @open-design/desktop test -- tests/main/updater.test.ts`
- `pnpm --filter @open-design/desktop test`
- `pnpm --filter @open-design/desktop typecheck`
- `pnpm --filter @open-design/desktop build`
- `pnpm guard`
- `pnpm typecheck`
- Native Windows running-executable harness: prepare fixed 20/20; activation fixed 20/20
- `git diff --check`
