### PR TITLE
Surface blocked preview asset errors

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -149,6 +149,7 @@ import {
   type UrlLoadDecision,
 } from './file-viewer-render-mode';
 import {
+  collectPreviewAssetPaths,
   htmlHasRootRelativeProjectAssetRefs,
   normalizeRootRelativeProjectAssetRefs,
   rewriteInlinedCssAssetRefs,
@@ -293,7 +294,9 @@ const POWERED_PREVIEW_ALLOW =
   'accelerometer; autoplay; camera; cross-origin-isolated; fullscreen; gamepad; gyroscope; microphone; xr-spatial-tracking';
 const HTML_PASSIVE_PREVIEW_FULL_TEXT_LIMIT = 2 * 1024 * 1024;
 const HTML_ROUTING_TEXT_PREVIEW_LIMIT = 96 * 1024;
+const HTML_PREVIEW_ASSET_PREFLIGHT_LIMIT = 32;
 type HtmlSourceLoadMode = 'full' | 'routing-preview';
+type PreviewAssetWarning = { filePath: string };
 
 function previewTextNeedsFullSourceForSafeInline(source: string | null): boolean {
   if (!source) return false;
@@ -303,6 +306,38 @@ function previewTextNeedsFullSourceForSafeInline(source: string | null): boolean
     htmlNeedsRedirectGuard(source) ||
     hasTweaksTemplate(source)
   );
+}
+
+function isBlockedPreviewAssetResponse(body: unknown): boolean {
+  if (typeof body === 'string') {
+    return /path escapes project dir/i.test(body);
+  }
+  if (!body || typeof body !== 'object') return false;
+  const payload = body as { error?: unknown; message?: unknown };
+  const error = payload.error;
+  if (typeof error === 'string') return isBlockedPreviewAssetResponse(error);
+  if (error && typeof error === 'object') {
+    const detail = error as { code?: unknown; message?: unknown };
+    if (detail.code === 'BAD_REQUEST' && isBlockedPreviewAssetResponse(detail.message)) return true;
+    return isBlockedPreviewAssetResponse(detail.message);
+  }
+  return isBlockedPreviewAssetResponse(payload.message);
+}
+
+async function readPreviewAssetResponseBody(resp: Response): Promise<unknown> {
+  const contentType = resp.headers.get('Content-Type') ?? '';
+  if (/json/i.test(contentType)) {
+    try {
+      return await resp.json();
+    } catch {
+      return '';
+    }
+  }
+  try {
+    return await resp.text();
+  } catch {
+    return '';
+  }
 }
 
 const PREVIEW_VIEWPORT_PRESETS: PreviewViewportPreset[] = [
@@ -6148,6 +6183,7 @@ function HtmlViewer({
   const [source, setSource] = useState<string | null>(liveHtml ?? null);
   const [routingSource, setRoutingSource] = useState<string | null>(liveHtml ?? null);
   const [serverPoweredPreviewRequired, setServerPoweredPreviewRequired] = useState(false);
+  const [previewAssetWarning, setPreviewAssetWarning] = useState<PreviewAssetWarning | null>(null);
   const [inlinedSource, setInlinedSource] = useState<string | null>(null);
   const [zoom, setZoom] = useState(100);
   const fileViewportKey = previewViewportStateKey(projectId, file);
@@ -7130,6 +7166,50 @@ function HtmlViewer({
     () => source != null && htmlHasRootRelativeProjectAssetRefs(source, projectFilePathSet),
     [source, projectFilePathSet],
   );
+  useEffect(() => {
+    setPreviewAssetWarning(null);
+    if (mode !== 'preview' || effectiveDeck) return;
+    const s = routingHtmlSource;
+    if (!s) return;
+    const assetPaths = collectPreviewAssetPaths(s, file.name, projectFilePathSet)
+      .filter((assetPath) => assetPath !== file.name)
+      .slice(0, HTML_PREVIEW_ASSET_PREFLIGHT_LIMIT);
+    if (assetPaths.length === 0) return;
+
+    let cancelled = false;
+    const cacheBust = `${Math.round(file.mtime)}-${reloadKey}-${filesRefreshKey}`;
+    void (async () => {
+      for (const assetPath of assetPaths) {
+        try {
+          const resp = await fetch(`${projectRawUrl(projectId, assetPath)}?previewAssetCheck=${encodeURIComponent(cacheBust)}`);
+          if (resp.ok || resp.status === 404) continue;
+          const body = await readPreviewAssetResponseBody(resp);
+          if (isBlockedPreviewAssetResponse(body)) {
+            if (!cancelled) setPreviewAssetWarning({ filePath: assetPath });
+            return;
+          }
+        } catch {
+          // Network/daemon reachability errors are already represented by the
+          // normal preview loading path. This preflight is only for clear raw
+          // route security blocks hidden inside iframe subresource loads.
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    effectiveDeck,
+    file.mtime,
+    file.name,
+    filesRefreshKey,
+    mode,
+    projectFilePathSet,
+    projectId,
+    reloadKey,
+    routingHtmlSource,
+  ]);
   // A real WebGL/Worker/WASM/SharedArrayBuffer artifact needs the "powered
   // preview" path — a cross-origin-isolated iframe with allow-same-origin —
   // which the opaque preview sandbox cannot provide (issue #724). Powered mode
@@ -12136,6 +12216,14 @@ function HtmlViewer({
                       />
                     </div>
                   </PreviewDrawOverlay>
+                  {previewAssetWarning ? (
+                    <div className="preview-asset-warning" role="alert" data-testid="preview-asset-warning">
+                      <strong>Preview asset blocked</strong>
+                      <span>
+                        {previewAssetWarning.filePath} could not be loaded. Replace external symlinks with files inside this project.
+                      </span>
+                    </div>
+                  ) : null}
                 </div>
               </div>
               {boardMode ? (

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -7180,10 +7180,13 @@ function HtmlViewer({
     const cacheBust = `${Math.round(file.mtime)}-${reloadKey}-${filesRefreshKey}`;
     void (async () => {
       for (const assetPath of assetPaths) {
+        if (cancelled) return;
         try {
           const resp = await fetch(`${projectRawUrl(projectId, assetPath)}?previewAssetCheck=${encodeURIComponent(cacheBust)}`);
+          if (cancelled) return;
           if (resp.ok || resp.status === 404) continue;
           const body = await readPreviewAssetResponseBody(resp);
+          if (cancelled) return;
           if (isBlockedPreviewAssetResponse(body)) {
             if (!cancelled) setPreviewAssetWarning({ filePath: assetPath });
             return;
@@ -12218,9 +12221,9 @@ function HtmlViewer({
                   </PreviewDrawOverlay>
                   {previewAssetWarning ? (
                     <div className="preview-asset-warning" role="alert" data-testid="preview-asset-warning">
-                      <strong>Preview asset blocked</strong>
+                      <strong>{t('fileViewer.previewAssetBlockedTitle')}</strong>
                       <span>
-                        {previewAssetWarning.filePath} could not be loaded. Replace external symlinks with files inside this project.
+                        {t('fileViewer.previewAssetBlockedDetail', { filePath: previewAssetWarning.filePath })}
                       </span>
                     </div>
                   ) : null}

--- a/apps/web/src/components/file-viewer-preview-assets.ts
+++ b/apps/web/src/components/file-viewer-preview-assets.ts
@@ -104,6 +104,26 @@ export function htmlHasRootRelativeProjectAssetRefs(
   return found;
 }
 
+/**
+ * Collect project asset paths referenced by an HTML preview. Used by
+ * FileViewer's host-side preflight so raw-route security failures do not stay
+ * hidden as broken images inside a sandboxed iframe.
+ */
+export function collectPreviewAssetPaths(
+  html: string,
+  ownerFilePath: string,
+  projectFilePaths: ReadonlySet<string> | null,
+): string[] {
+  const paths = new Set<string>();
+  eachAssetRef(html, (ref) => {
+    const rootPath = rootRelativeProjectAssetPath(ref, projectFilePaths);
+    const relPath = resolveRelativeAssetPath(ownerFilePath, ref);
+    const projectPath = rootPath ?? relPath;
+    if (projectPath) paths.add(projectPath);
+  });
+  return [...paths];
+}
+
 /** `zh/index.html` → `zh/`; flat files → ``. */
 export function assetBaseDirFor(filePath: string): string {
   const idx = filePath.lastIndexOf('/');

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -2792,6 +2792,8 @@ export const ar: Dict = {
   'fileViewer.speakerNotesSaved': 'تم الحفظ',
   'fileViewer.speakerNotesSaveFailed': 'تعذر حفظ ملاحظات المتحدث.',
   'fileViewer.speakerNotesPlaceholder': 'أضف ملاحظات المتحدث لهذه الشريحة…',
+  'fileViewer.previewAssetBlockedTitle': 'تم حظر أصل المعاينة',
+  'fileViewer.previewAssetBlockedDetail': 'تعذر تحميل {filePath}. استبدل الروابط الرمزية الخارجية بملفات داخل هذا المشروع.',
   'fileViewer.presenterReset': 'إعادة ضبط',
   'fileViewer.present': 'تقديم',
   'fileViewer.presentInTab': 'في علامة التبويب هذه',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -2792,6 +2792,8 @@ export const de: Dict = {
   'fileViewer.speakerNotesSaved': 'Gespeichert',
   'fileViewer.speakerNotesSaveFailed': 'Sprechernotizen konnten nicht gespeichert werden.',
   'fileViewer.speakerNotesPlaceholder': 'Sprechernotizen für diese Folie hinzufügen…',
+  'fileViewer.previewAssetBlockedTitle': 'Vorschau-Asset blockiert',
+  'fileViewer.previewAssetBlockedDetail': '{filePath} konnte nicht geladen werden. Ersetzen Sie externe Symlinks durch Dateien innerhalb dieses Projekts.',
   'fileViewer.presenterReset': 'Zurücksetzen',
   'fileViewer.present': 'Präsentieren',
   'fileViewer.presentInTab': 'In diesem Tab',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -2806,6 +2806,8 @@ export const en: Dict = {
   'fileViewer.speakerNotesSaved': 'Saved',
   'fileViewer.speakerNotesSaveFailed': 'Could not save speaker notes.',
   'fileViewer.speakerNotesPlaceholder': 'Add speaker notes for this slide...',
+  'fileViewer.previewAssetBlockedTitle': 'Preview asset blocked',
+  'fileViewer.previewAssetBlockedDetail': '{filePath} could not be loaded. Replace external symlinks with files inside this project.',
   'fileViewer.presenterReset': 'Reset',
   'fileViewer.present': 'Present',
   'fileViewer.presentInTab': 'In this tab',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -2792,6 +2792,8 @@ export const esES: Dict = {
   'fileViewer.speakerNotesSaved': 'Guardado',
   'fileViewer.speakerNotesSaveFailed': 'No se pudieron guardar las notas del orador.',
   'fileViewer.speakerNotesPlaceholder': 'Añade notas del orador para esta diapositiva…',
+  'fileViewer.previewAssetBlockedTitle': 'Recurso de vista previa bloqueado',
+  'fileViewer.previewAssetBlockedDetail': 'No se pudo cargar {filePath}. Sustituye los enlaces simbólicos externos por archivos dentro de este proyecto.',
   'fileViewer.presenterReset': 'Restablecer',
   'fileViewer.present': 'Presentar',
   'fileViewer.presentInTab': 'En esta pestaña',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -2792,6 +2792,8 @@ export const fa: Dict = {
   'fileViewer.speakerNotesSaved': 'ذخیره شد',
   'fileViewer.speakerNotesSaveFailed': 'ذخیره یادداشت‌های سخنران ممکن نشد.',
   'fileViewer.speakerNotesPlaceholder': 'برای این اسلاید یادداشت سخنران اضافه کنید…',
+  'fileViewer.previewAssetBlockedTitle': 'دارایی پیش‌نمایش مسدود شد',
+  'fileViewer.previewAssetBlockedDetail': '{filePath} بارگیری نشد. پیوندهای نمادین خارجی را با فایل‌های داخل این پروژه جایگزین کنید.',
   'fileViewer.presenterReset': 'بازنشانی',
   'fileViewer.present': 'ارائه',
   'fileViewer.presentInTab': 'در این تب',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -2792,6 +2792,8 @@ export const fr: Dict = {
   'fileViewer.speakerNotesSaved': 'Enregistré',
   'fileViewer.speakerNotesSaveFailed': 'Impossible d’enregistrer les notes du présentateur.',
   'fileViewer.speakerNotesPlaceholder': 'Ajouter des notes pour cette diapositive…',
+  'fileViewer.previewAssetBlockedTitle': 'Ressource d’aperçu bloquée',
+  'fileViewer.previewAssetBlockedDetail': 'Impossible de charger {filePath}. Remplacez les liens symboliques externes par des fichiers dans ce projet.',
   'fileViewer.presenterReset': 'Réinitialiser',
   'fileViewer.present': 'Présenter',
   'fileViewer.presentInTab': 'Dans cet onglet',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -2792,6 +2792,8 @@ export const hu: Dict = {
   'fileViewer.speakerNotesSaved': 'Mentve',
   'fileViewer.speakerNotesSaveFailed': 'Az előadói jegyzetek mentése nem sikerült.',
   'fileViewer.speakerNotesPlaceholder': 'Adj előadói jegyzeteket ehhez a diához…',
+  'fileViewer.previewAssetBlockedTitle': 'Az előnézeti elem blokkolva',
+  'fileViewer.previewAssetBlockedDetail': 'A(z) {filePath} nem tölthető be. Cseréld a külső szimbolikus linkeket a projekten belüli fájlokra.',
   'fileViewer.presenterReset': 'Visszaállítás',
   'fileViewer.present': 'Bemutatás',
   'fileViewer.presentInTab': 'Ezen a lapon',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -2792,6 +2792,8 @@ export const id: Dict = {
   'fileViewer.speakerNotesSaved': 'Tersimpan',
   'fileViewer.speakerNotesSaveFailed': 'Tidak dapat menyimpan catatan pembicara.',
   'fileViewer.speakerNotesPlaceholder': 'Tambahkan catatan pembicara untuk slide ini…',
+  'fileViewer.previewAssetBlockedTitle': 'Aset pratinjau diblokir',
+  'fileViewer.previewAssetBlockedDetail': '{filePath} tidak dapat dimuat. Ganti symlink eksternal dengan file di dalam proyek ini.',
   'fileViewer.presenterReset': 'Atur ulang',
   'fileViewer.present': 'Presentasikan',
   'fileViewer.presentInTab': 'Presentasikan di tab',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -2792,6 +2792,8 @@ export const it: Dict = {
   'fileViewer.speakerNotesSaved': 'Salvato',
   'fileViewer.speakerNotesSaveFailed': 'Impossibile salvare le note del relatore.',
   'fileViewer.speakerNotesPlaceholder': 'Aggiungi note del relatore per questa diapositiva…',
+  'fileViewer.previewAssetBlockedTitle': 'Asset anteprima bloccato',
+  'fileViewer.previewAssetBlockedDetail': 'Impossibile caricare {filePath}. Sostituisci i symlink esterni con file all’interno di questo progetto.',
   'fileViewer.presenterReset': 'Reimposta',
   'fileViewer.present': 'Presenta',
   'fileViewer.presentInTab': 'In questa scheda',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -2792,6 +2792,8 @@ export const ja: Dict = {
   'fileViewer.speakerNotesSaved': '保存済み',
   'fileViewer.speakerNotesSaveFailed': 'スピーカーノートを保存できませんでした。',
   'fileViewer.speakerNotesPlaceholder': 'このスライドのスピーカーノートを追加…',
+  'fileViewer.previewAssetBlockedTitle': 'プレビューアセットがブロックされました',
+  'fileViewer.previewAssetBlockedDetail': '{filePath} を読み込めませんでした。外部シンボリックリンクをこのプロジェクト内のファイルに置き換えてください。',
   'fileViewer.presenterReset': 'リセット',
   'fileViewer.present': 'プレゼン',
   'fileViewer.presentInTab': 'このタブで',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -2792,6 +2792,8 @@ export const ko: Dict = {
   'fileViewer.speakerNotesSaved': '저장됨',
   'fileViewer.speakerNotesSaveFailed': '발표자 노트를 저장하지 못했습니다.',
   'fileViewer.speakerNotesPlaceholder': '이 슬라이드의 발표자 노트를 추가하세요…',
+  'fileViewer.previewAssetBlockedTitle': '미리보기 에셋이 차단됨',
+  'fileViewer.previewAssetBlockedDetail': '{filePath}을(를) 불러올 수 없습니다. 외부 심볼릭 링크를 이 프로젝트 안의 파일로 바꾸세요.',
   'fileViewer.presenterReset': '초기화',
   'fileViewer.present': '프레젠테이션',
   'fileViewer.presentInTab': '현재 탭에서',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -2792,6 +2792,8 @@ export const pl: Dict = {
   'fileViewer.speakerNotesSaved': 'Zapisano',
   'fileViewer.speakerNotesSaveFailed': 'Nie udało się zapisać notatek prelegenta.',
   'fileViewer.speakerNotesPlaceholder': 'Dodaj notatki prelegenta do tego slajdu…',
+  'fileViewer.previewAssetBlockedTitle': 'Zablokowano zasób podglądu',
+  'fileViewer.previewAssetBlockedDetail': 'Nie udało się wczytać {filePath}. Zastąp zewnętrzne dowiązania symboliczne plikami wewnątrz tego projektu.',
   'fileViewer.presenterReset': 'Resetuj',
   'fileViewer.present': 'Prezentuj',
   'fileViewer.presentInTab': 'W tej karcie',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -2792,6 +2792,8 @@ export const ptBR: Dict = {
   'fileViewer.speakerNotesSaved': 'Salvo',
   'fileViewer.speakerNotesSaveFailed': 'Não foi possível salvar as notas do apresentador.',
   'fileViewer.speakerNotesPlaceholder': 'Adicione notas do apresentador para este slide…',
+  'fileViewer.previewAssetBlockedTitle': 'Recurso da prévia bloqueado',
+  'fileViewer.previewAssetBlockedDetail': 'Não foi possível carregar {filePath}. Substitua symlinks externos por arquivos dentro deste projeto.',
   'fileViewer.presenterReset': 'Redefinir',
   'fileViewer.present': 'Apresentar',
   'fileViewer.presentInTab': 'Nesta aba',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -2792,6 +2792,8 @@ export const ru: Dict = {
   'fileViewer.speakerNotesSaved': 'Сохранено',
   'fileViewer.speakerNotesSaveFailed': 'Не удалось сохранить заметки докладчика.',
   'fileViewer.speakerNotesPlaceholder': 'Добавьте заметки докладчика для этого слайда…',
+  'fileViewer.previewAssetBlockedTitle': 'Ресурс предпросмотра заблокирован',
+  'fileViewer.previewAssetBlockedDetail': 'Не удалось загрузить {filePath}. Замените внешние символические ссылки файлами внутри этого проекта.',
   'fileViewer.presenterReset': 'Сбросить',
   'fileViewer.present': 'Презентация',
   'fileViewer.presentInTab': 'В этой вкладке',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -2792,6 +2792,8 @@ export const th: Dict = {
   'fileViewer.speakerNotesSaved': 'บันทึกแล้ว',
   'fileViewer.speakerNotesSaveFailed': 'ไม่สามารถบันทึกโน้ตผู้บรรยายได้',
   'fileViewer.speakerNotesPlaceholder': 'เพิ่มโน้ตผู้บรรยายสำหรับสไลด์นี้…',
+  'fileViewer.previewAssetBlockedTitle': 'บล็อกแอสเซ็ตตัวอย่างแล้ว',
+  'fileViewer.previewAssetBlockedDetail': 'โหลด {filePath} ไม่ได้ แทนที่ symlink ภายนอกด้วยไฟล์ภายในโปรเจกต์นี้',
   'fileViewer.presenterReset': 'รีเซ็ต',
   'fileViewer.present': 'เปิดจอโชว์',
   'fileViewer.presentInTab': 'ค้างในหน้าจอแท็บ',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -2792,6 +2792,8 @@ export const tr: Dict = {
   'fileViewer.speakerNotesSaved': 'Kaydedildi',
   'fileViewer.speakerNotesSaveFailed': 'Konuşmacı notları kaydedilemedi.',
   'fileViewer.speakerNotesPlaceholder': 'Bu slayt için konuşmacı notu ekleyin…',
+  'fileViewer.previewAssetBlockedTitle': 'Önizleme varlığı engellendi',
+  'fileViewer.previewAssetBlockedDetail': '{filePath} yüklenemedi. Harici symlinkleri bu projenin içindeki dosyalarla değiştirin.',
   'fileViewer.presenterReset': 'Sıfırla',
   'fileViewer.present': 'Sun',
   'fileViewer.presentInTab': 'Bu pencerede sun',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -2792,6 +2792,8 @@ export const uk: Dict = {
   'fileViewer.speakerNotesSaved': 'Збережено',
   'fileViewer.speakerNotesSaveFailed': 'Не вдалося зберегти нотатки доповідача.',
   'fileViewer.speakerNotesPlaceholder': 'Додайте нотатки доповідача для цього слайда…',
+  'fileViewer.previewAssetBlockedTitle': 'Ресурс попереднього перегляду заблоковано',
+  'fileViewer.previewAssetBlockedDetail': 'Не вдалося завантажити {filePath}. Замініть зовнішні символічні посилання файлами всередині цього проєкту.',
   'fileViewer.presenterReset': 'Скинути',
   'fileViewer.present': 'Презентувати',
   'fileViewer.presentInTab': 'На цій вкладці',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -3006,6 +3006,8 @@ export const zhCN: Dict = {
   "fileViewer.speakerNotesSaved": "已保存",
   "fileViewer.speakerNotesSaveFailed": "无法保存演讲者备注。",
   "fileViewer.speakerNotesPlaceholder": "为这一页添加演讲者备注...",
+  "fileViewer.previewAssetBlockedTitle": "预览资源已被阻止",
+  "fileViewer.previewAssetBlockedDetail": "无法加载 {filePath}。请将外部符号链接替换为此项目内的文件。",
   "fileViewer.presenterReset": "重置",
   "fileViewer.present": "演示",
   "fileViewer.presentInTab": "在当前标签页",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -3016,6 +3016,8 @@ export const zhTW: Dict = {
   "fileViewer.speakerNotesSaved": "已儲存",
   "fileViewer.speakerNotesSaveFailed": "無法儲存演講者備註。",
   "fileViewer.speakerNotesPlaceholder": "為這一頁新增演講者備註...",
+  "fileViewer.previewAssetBlockedTitle": "預覽資源已被阻止",
+  "fileViewer.previewAssetBlockedDetail": "無法載入 {filePath}。請將外部符號連結替換為此專案內的檔案。",
   "fileViewer.presenterReset": "重設",
   "fileViewer.present": "簡報",
   "fileViewer.presentInTab": "在當前分頁",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -3570,6 +3570,8 @@ export interface Dict {
   'fileViewer.speakerNotesSaved': string;
   'fileViewer.speakerNotesSaveFailed': string;
   'fileViewer.speakerNotesPlaceholder': string;
+  'fileViewer.previewAssetBlockedTitle': string;
+  'fileViewer.previewAssetBlockedDetail': string;
   'fileViewer.presenterReset': string;
   'fileViewer.present': string;
   'fileViewer.presentInTab': string;

--- a/apps/web/src/styles/viewer/core.css
+++ b/apps/web/src/styles/viewer/core.css
@@ -1284,6 +1284,34 @@
   visibility: hidden;
   pointer-events: none;
 }
+.preview-asset-warning {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: 12px;
+  z-index: 6;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 36px;
+  padding: 8px 10px;
+  border: 1px solid color-mix(in srgb, var(--warning, #d97706) 34%, var(--border));
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--bg-panel) 94%, var(--warning, #d97706) 6%);
+  color: var(--text);
+  box-shadow: 0 10px 28px color-mix(in srgb, var(--shadow-color, #000) 14%, transparent);
+  font-size: 12px;
+  line-height: 1.35;
+}
+.preview-asset-warning strong {
+  flex: 0 0 auto;
+  color: var(--warning, #d97706);
+  font-weight: 600;
+}
+.preview-asset-warning span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
 .viewer-viewport-switcher {
   position: relative;
   display: inline-flex;

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -4702,6 +4702,57 @@ describe('FileViewer tweaks toolbar', () => {
     expect(hiddenAfterExit.srcdoc).toContain('Materialize me');
   });
 
+  it('surfaces raw-route security failures for preview assets without leaking the symlink target', async () => {
+    const source = '<html><body><img src="assets/hero.png" alt="Hero"></body></html>';
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url.includes('/api/projects/project-1/files')) {
+        return new Response(JSON.stringify({
+          files: [
+            htmlPreviewFile(),
+            baseFile({
+              name: 'assets/hero.png',
+              path: 'assets/hero.png',
+              type: 'file',
+              kind: 'image',
+              mime: 'image/png',
+            }),
+          ],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (url.includes('/api/projects/project-1/deployments')) {
+        return new Response(JSON.stringify({ deployments: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (url.includes('/api/projects/project-1/raw/assets/hero.png')) {
+        return new Response(JSON.stringify({
+          error: {
+            code: 'BAD_REQUEST',
+            message: 'Error: path escapes project dir via symlink /Users/me/.ssh/id_rsa',
+          },
+        }), { status: 400, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlPreviewFile()}
+        liveHtml={source}
+      />,
+    );
+
+    const warning = await screen.findByTestId('preview-asset-warning');
+    expect(warning.textContent).toContain('assets/hero.png');
+    expect(warning.textContent).toContain('Replace external symlinks');
+    expect(warning.textContent).not.toContain('/Users/me/.ssh');
+  });
+
   it('always injects the manual-edit bridge into the preview srcDoc so entering Edit after materialization does not reload', async () => {
     const { container } = render(
       <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}

--- a/apps/web/tests/components/file-viewer-preview-assets.test.ts
+++ b/apps/web/tests/components/file-viewer-preview-assets.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  collectPreviewAssetPaths,
   htmlHasRootRelativeProjectAssetRefs,
   normalizeRootRelativeProjectAssetRefs,
   ownerRelativeAssetPath,
@@ -87,6 +88,42 @@ describe('htmlHasRootRelativeProjectAssetRefs', () => {
     ).toBe(false);
     expect(htmlHasRootRelativeProjectAssetRefs('<img src="/not-here.png">', files)).toBe(false);
     expect(htmlHasRootRelativeProjectAssetRefs('<img src="images/hero.png">', files)).toBe(false);
+  });
+});
+
+describe('collectPreviewAssetPaths', () => {
+  const files = new Set(['images/hero.png', 'css/app.css', 'nested/card.png']);
+
+  it('collects unique relative and confirmed root-relative asset paths', () => {
+    const html = [
+      '<link rel="stylesheet" href="/css/app.css">',
+      '<img src="./images/hero.png" srcset="./images/hero.png 1x, ./nested/card.png 2x">',
+      '<style>.card { background: url("./nested/card.png"); }</style>',
+      '<a href="/css/app.css">download</a>',
+    ].join('\n');
+
+    expect(collectPreviewAssetPaths(html, 'index.html', files)).toEqual([
+      'images/hero.png',
+      'css/app.css',
+      'nested/card.png',
+    ]);
+  });
+
+  it('keeps unconfirmed root-relative candidates while the file list is loading', () => {
+    expect(collectPreviewAssetPaths('<img src="/maybe-later.png">', 'index.html', null)).toEqual([
+      'maybe-later.png',
+    ]);
+  });
+
+  it('rejects external schemes, navigation links, and traversal refs', () => {
+    const html = [
+      '<img src="https://cdn.example.com/a.png">',
+      '<img src="data:image/png;base64,xx">',
+      '<img src="../escape.png">',
+      '<a href="images/hero.png">open</a>',
+    ].join('\n');
+
+    expect(collectPreviewAssetPaths(html, 'index.html', files)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

- preflight HTML preview asset references through the raw route so security blocks are visible instead of appearing as broken iframe images
- show the project asset path without leaking the blocked symlink target
- localize the warning text and stop cancelled preflight sweeps from issuing more raw-route requests

## Surface area

- `FileViewer` HTML preview only; source mode, raw route enforcement, and daemon path validation are unchanged
- host-side preflight is capped at 32 asset references and ignores ordinary missing assets so normal 404 previews keep their existing behavior
- adds two `fileViewer.*` strings to the typed i18n dictionary and every bundled locale

## Validation

- `pnpm --dir apps/web exec vitest run tests/components/file-viewer-preview-assets.test.ts --maxWorkers=1`
- `pnpm --dir apps/web exec vitest run tests/components/FileViewer.test.tsx --maxWorkers=1`
- `pnpm --dir apps/web typecheck`
- `git diff --check`

Fixes #5783.
