### PR TITLE
fix(web): reconcile historical design delivery after restart

### DIFF
--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -197,6 +197,7 @@ interface RunListFilters {
 interface ChatRunService {
   create(meta: RunCreateMeta): ChatRun;
   get(id: string): ChatRun | null;
+  readPersistedStatus(id: string): ChatRunStatusResponse | null;
   list(filters: RunListFilters): ChatRun[];
   statusBody(run: ChatRun): ChatRunStatusResponse;
   stream(run: ChatRun, req: Request, res: Response): void;
@@ -1366,8 +1367,11 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
     const runId = routeParamId(req);
     if (!runId) return sendApiError(res, 400, 'BAD_REQUEST', 'run id missing');
     const run = design.runs.get(runId);
-    if (!run) return sendApiError(res, 404, 'NOT_FOUND', 'run not found');
-    res.json(design.runs.statusBody(run));
+    const status = run
+      ? design.runs.statusBody(run)
+      : design.runs.readPersistedStatus(runId);
+    if (!status) return sendApiError(res, 404, 'NOT_FOUND', 'run not found');
+    res.json(status);
   });
 
   app.get('/api/runs/:id/events', (req: ApiRequest, res: ApiResponse) => {

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -13,6 +13,9 @@ import { projectWorkspaceProvenance } from '../workspace-contract.js';
 
 export const TERMINAL_RUN_STATUSES = new Set(['succeeded', 'failed', 'canceled']);
 
+const MAX_PERSISTED_EVENT_SCAN_BYTES = 256 * 1024;
+const SAFE_RUN_ID = /^[A-Za-z0-9_-]{1,128}$/;
+
 function readString(value) {
   return typeof value === 'string' && value.trim() ? value.trim() : null;
 }
@@ -125,6 +128,92 @@ export function createChatRunService({
   };
 
   const get = (id) => runs.get(id) ?? null;
+
+  const readPersistedStatus = (id) => {
+    if (!runsLogDir || typeof id !== 'string' || !SAFE_RUN_ID.test(id)) return null;
+    const logPath = path.join(runsLogDir, id, 'events.jsonl');
+    let fd = null;
+    try {
+      const linkStat = fs.lstatSync(logPath);
+      if (!linkStat.isFile() || linkStat.isSymbolicLink() || linkStat.size <= 0) return null;
+      fd = fs.openSync(
+        logPath,
+        fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0),
+      );
+      const stat = fs.fstatSync(fd);
+      if (!stat.isFile() || stat.size <= 0) return null;
+      const tailLength = Math.min(stat.size, MAX_PERSISTED_EVENT_SCAN_BYTES);
+      const tail = Buffer.allocUnsafe(tailLength);
+      fs.readSync(fd, tail, 0, tailLength, stat.size - tailLength);
+      const tailLines = tail.toString('utf8').split('\n');
+      let terminal = null;
+      for (let index = tailLines.length - 1; index >= 0; index -= 1) {
+        const line = tailLines[index]?.trim();
+        if (!line) continue;
+        try {
+          const record = JSON.parse(line);
+          if (
+            record?.event === 'end'
+            && TERMINAL_RUN_STATUSES.has(record?.data?.status)
+          ) {
+            terminal = record;
+            break;
+          }
+        } catch {
+          // A truncated first tail line or malformed diagnostic must not hide
+          // a later valid terminal record.
+        }
+      }
+      if (!terminal) return null;
+
+      const headLength = Math.min(stat.size, MAX_PERSISTED_EVENT_SCAN_BYTES);
+      const head = Buffer.allocUnsafe(headLength);
+      fs.readSync(fd, head, 0, headLength, 0);
+      let createdAt = Number(terminal.timestamp) || stat.birthtimeMs || stat.mtimeMs;
+      for (const line of head.toString('utf8').split('\n')) {
+        if (!line.trim()) continue;
+        try {
+          const record = JSON.parse(line);
+          if (Number.isFinite(record?.timestamp)) {
+            createdAt = record.timestamp;
+            break;
+          }
+        } catch {
+          // Skip malformed records; the terminal timestamp remains a safe
+          // fallback for this read-only historical status.
+        }
+      }
+      const data = terminal.data && typeof terminal.data === 'object' ? terminal.data : {};
+      const artifactCount = Number.isFinite(data.artifactCount) && data.artifactCount >= 0
+        ? data.artifactCount
+        : undefined;
+      return {
+        id,
+        projectId: null,
+        conversationId: null,
+        assistantMessageId: null,
+        agentId: null,
+        status: data.status,
+        createdAt,
+        updatedAt: Number(terminal.timestamp) || stat.mtimeMs,
+        cancelRequested: false,
+        exitCode: typeof data.code === 'number' || data.code === null ? data.code : null,
+        signal: typeof data.signal === 'string' || data.signal === null ? data.signal : null,
+        failureCategory: typeof data.failureCategory === 'string' ? data.failureCategory : null,
+        failureDetail: typeof data.failureDetail === 'string' ? data.failureDetail : null,
+        resumable: data.resumable === true,
+        endedWithUnfinishedWork: data.endedWithUnfinishedWork === true,
+        ...(artifactCount !== undefined ? { artifactCount } : {}),
+        eventsLogPath: logPath,
+      };
+    } catch {
+      return null;
+    } finally {
+      if (fd !== null) {
+        try { fs.closeSync(fd); } catch { /* best-effort */ }
+      }
+    }
+  };
 
   const scheduleCleanup = (run) => {
     setTimeout(() => {
@@ -573,6 +662,7 @@ export function createChatRunService({
     create,
     start,
     get,
+    readPersistedStatus,
     list,
     stream,
     cancel,

--- a/apps/daemon/tests/runtimes/runs.test.ts
+++ b/apps/daemon/tests/runtimes/runs.test.ts
@@ -774,9 +774,25 @@ describe('run event log persistence', () => {
     });
   });
 
-  it('does not read missing, malformed, or traversal-shaped historical run ids', () => {
+  it('does not read missing, malformed, symlinked, or traversal-shaped historical evidence', () => {
     const runs = createRunsWithLog(tmpDir);
     expect(runs.readPersistedStatus('missing-run')).toBeNull();
+    const malformedDir = path.join(tmpDir, 'malformed-run');
+    fs.mkdirSync(malformedDir, { recursive: true });
+    fs.writeFileSync(path.join(malformedDir, 'events.jsonl'), '{not-json}\n');
+    expect(runs.readPersistedStatus('malformed-run')).toBeNull();
+    if (process.platform !== 'win32') {
+      const externalLog = path.join(tmpDir, 'external-events.jsonl');
+      fs.writeFileSync(externalLog, JSON.stringify({
+        event: 'end',
+        data: { status: 'succeeded', artifactCount: 1 },
+        timestamp: Date.now(),
+      }));
+      const symlinkDir = path.join(tmpDir, 'symlink-run');
+      fs.mkdirSync(symlinkDir, { recursive: true });
+      fs.symlinkSync(externalLog, path.join(symlinkDir, 'events.jsonl'));
+      expect(runs.readPersistedStatus('symlink-run')).toBeNull();
+    }
     expect(runs.readPersistedStatus('../outside')).toBeNull();
     expect(runs.readPersistedStatus('')).toBeNull();
   });

--- a/apps/daemon/tests/runtimes/runs.test.ts
+++ b/apps/daemon/tests/runtimes/runs.test.ts
@@ -738,6 +738,49 @@ describe('run event log persistence', () => {
     expect(parsed[2]).toMatchObject({ event: 'end', data: { status: 'succeeded' } });
   });
 
+  it('recovers authoritative terminal artifact evidence after service restart', async () => {
+    const first = createRunsWithLog(tmpDir);
+    const delivered = first.create({ projectId: 'p1', conversationId: 'c1' });
+    delivered.artifactCount = 1;
+    first.finish(delivered, 'succeeded', 0, null);
+    const noResult = first.create({ projectId: 'p1', conversationId: 'c1' });
+    noResult.artifactCount = 0;
+    first.finish(noResult, 'succeeded', 0, null);
+
+    const deliveredLog = path.join(tmpDir, delivered.id, 'events.jsonl');
+    const noResultLog = path.join(tmpDir, noResult.id, 'events.jsonl');
+    for (let i = 0; i < 50; i++) {
+      if (fs.existsSync(deliveredLog) && fs.existsSync(noResultLog)) {
+        const deliveredText = fs.readFileSync(deliveredLog, 'utf8');
+        const noResultText = fs.readFileSync(noResultLog, 'utf8');
+        if (deliveredText.includes('"event":"end"') && noResultText.includes('"event":"end"')) break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+
+    const restarted = createRunsWithLog(tmpDir);
+    expect(restarted.get(delivered.id)).toBeNull();
+    expect(restarted.readPersistedStatus(delivered.id)).toMatchObject({
+      id: delivered.id,
+      status: 'succeeded',
+      artifactCount: 1,
+      exitCode: 0,
+    });
+    expect(restarted.readPersistedStatus(noResult.id)).toMatchObject({
+      id: noResult.id,
+      status: 'succeeded',
+      artifactCount: 0,
+      exitCode: 0,
+    });
+  });
+
+  it('does not read missing, malformed, or traversal-shaped historical run ids', () => {
+    const runs = createRunsWithLog(tmpDir);
+    expect(runs.readPersistedStatus('missing-run')).toBeNull();
+    expect(runs.readPersistedStatus('../outside')).toBeNull();
+    expect(runs.readPersistedStatus('')).toBeNull();
+  });
+
   it('persists native session recovery diagnostics in the run event log', async () => {
     const runs = createRunsWithLog(tmpDir);
     const run = runs.create({ projectId: 'p1' });

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3519,6 +3519,7 @@ export function ProjectView({
           message.runStatus === 'failed' &&
           !!message.runId &&
           hasGenericDisconnectFailureEvent(message);
+        const reconcilingHistoricalDelivery = shouldReconcileHistoricalDesignDelivery(message);
         const replayingTerminalRun =
           shouldReplayTerminalRunMessage(message) || spuriouslyFailedPending;
         const needsFullReplay =
@@ -3586,7 +3587,13 @@ export function ProjectView({
           // For other message states (phantom running rows with no runId),
           // fall through to the original mark-failed behaviour and seal the
           // runId so we don't loop indefinitely.
-          if (spuriouslyFailedPending) {
+          if (reconcilingHistoricalDelivery) {
+            // Historical delivery repair is opportunistic. If neither the
+            // in-memory run nor durable terminal log is available, preserve
+            // the persisted verdict instead of turning it into a process
+            // failure or retrying forever.
+            completedReattachRunsRef.current.add(runId);
+          } else if (spuriouslyFailedPending) {
             const attempts = transientFailedRetriesRef.current.get(runId) ?? 0;
             if (attempts >= MAX_TRANSIENT_RETRIES) {
               // Cap reached — treat as authoritative completion so we stop retrying.
@@ -9299,6 +9306,7 @@ export function shouldReplayTerminalRunMessage(message: ChatMessage): boolean {
   if (message.role !== 'assistant') return false;
   if (!message.runId) return false;
   if (message.runStatus !== 'succeeded') return false;
+  if (shouldReconcileHistoricalDesignDelivery(message)) return true;
   // A daemon can persist terminal success before the browser finishes its
   // project-file refresh. Reattach once even when prose already exists so the
   // delivery invariant can confirm a file or downgrade the turn after reload.
@@ -9312,6 +9320,23 @@ export function shouldReplayTerminalRunMessage(message: ChatMessage): boolean {
     return false;
   }
   return !(message.producedFiles?.length);
+}
+
+export function shouldReconcileHistoricalDesignDelivery(message: ChatMessage): boolean {
+  if (
+    message.role !== 'assistant'
+    || message.sessionMode !== 'design'
+    || message.runStatus !== 'succeeded'
+    || message.resultDeliveryState !== 'no_result'
+  ) {
+    return false;
+  }
+  return (message.events ?? []).some(
+    (event) =>
+      event.kind === 'status'
+      && event.label === 'error'
+      && event.code === 'ARTIFACT_NOT_FOUND',
+  );
 }
 
 function textContentFromAgentEvents(events?: AgentEvent[]): string {
@@ -9571,7 +9596,12 @@ function applyDesignDeliveryOutcome(
   persistenceError?: string,
 ): ChatMessage {
   if (outcome === 'delivered') {
-    return { ...message, resultDeliveryState: 'delivered' };
+    const repaired = removeErrorStatusEvent(
+      message,
+      DESIGN_RESULT_MISSING_DETAIL,
+      'ARTIFACT_NOT_FOUND',
+    );
+    return { ...repaired, resultDeliveryState: 'delivered' };
   }
   if (outcome !== 'no_result' && outcome !== 'delivery_failed') return message;
   const detail =

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3793,6 +3793,7 @@ export function ProjectView({
               events: message.events,
               producedFileCount: produced.length,
               traceObjectFileCount: traceObjectFiles.length,
+              artifactCount: status.artifactCount,
               persistenceSucceeded: artifactPersistenceSucceeded,
               persistenceFailed: artifactPersistenceError !== undefined,
             });
@@ -3884,6 +3885,7 @@ export function ProjectView({
         let liveHtml = '';
         let replayedContent = needsFullReplay ? '' : message.content;
         let replayedEvents: AgentEvent[] = needsFullReplay ? [] : [...(message.events ?? [])];
+        let daemonArtifactCount = status.artifactCount;
         let latestReattachRunStatus: ChatMessage['runStatus'] = status.status;
         const applyContentDelta = (delta: string) => {
           for (const ev of parser.feed(delta)) {
@@ -3979,6 +3981,9 @@ export function ProjectView({
               genericDisconnectBackoffUntilRef.current.delete(runId);
               replayedEvents = [...replayedEvents, ev];
               textBuffer.appendEvent(ev);
+            },
+            onArtifactCount: (count) => {
+              daemonArtifactCount = count;
             },
             onDone: async () => {
               // A reattached run interrupted by a "send now" still receives a
@@ -4119,6 +4124,7 @@ export function ProjectView({
                   events: deliveryEvents,
                   producedFileCount: produced.length,
                   traceObjectFileCount: traceObjectFiles.length,
+                  artifactCount: daemonArtifactCount,
                   persistenceSucceeded: artifactPersistenceSucceeded,
                   persistenceFailed: artifactPersistenceError !== undefined,
                 });
@@ -5019,6 +5025,7 @@ export function ProjectView({
       // that just failed in the current session (the daemon status fetch is only
       // needed on reload, not for runs that are already known to have failed).
       let currentRunId: string | undefined = undefined;
+      let daemonArtifactCount: number | undefined;
       const updateConversationLatestRun = (
         status: NonNullable<ChatMessage['runStatus']>,
         endedAt?: number,
@@ -5356,6 +5363,9 @@ export function ProjectView({
           if (ev.kind === 'text') textBuffer.appendTextEvent(ev.text);
           else pushEvent(ev);
         },
+        onArtifactCount: (count: number) => {
+          daemonArtifactCount = count;
+        },
         onToolInputDelta: (id: string, name: string, delta: string) => {
           setLiveToolInput((prev) => ({
             ...prev,
@@ -5564,6 +5574,7 @@ export function ProjectView({
                 events: deliveryCandidate.events,
                 producedFileCount: produced.length,
                 traceObjectFileCount: traceObjectFiles.length,
+                artifactCount: daemonArtifactCount,
                 persistenceSucceeded: artifactPersistenceSucceeded,
                 persistenceFailed: artifactPersistenceError !== undefined,
               });

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3526,7 +3526,8 @@ export function ProjectView({
           isActiveRunStatus(message.runStatus) ||
           replayingTerminalRun ||
           spuriouslyFailedPending ||
-          recoverableGenericDisconnectFailed;
+          recoverableGenericDisconnectFailed ||
+          reconcilingHistoricalDelivery;
         if (!needsFullReplay) continue;
         const fallbackRun = !message.runId
           ? activeByMessage.get(message.id) ?? historicalByMessage.get(message.id) ?? null
@@ -3617,6 +3618,38 @@ export function ProjectView({
             );
             completedReattachRunsRef.current.add(runId);
           }
+          continue;
+        }
+        if (reconcilingHistoricalDelivery && isTerminalRunStatus(status.status)) {
+          // Durable terminal evidence is sufficient to repair a stale
+          // historical delivery verdict. Do not route this through content
+          // replay or SSE reattach: after restart the status log survives, but
+          // the in-memory event stream intentionally does not.
+          const deliveryContent =
+            textContentFromAgentEvents(message.events).trim() || message.content;
+          const deliveryOutcome = resolveDesignDeliveryOutcome({
+            sessionMode: message.sessionMode,
+            runStatus: status.status,
+            content: deliveryContent,
+            events: message.events,
+            producedFileCount: message.producedFiles?.length ?? 0,
+            traceObjectFileCount: message.traceObjectFiles?.length ?? 0,
+            artifactCount: status.artifactCount,
+          });
+          if (deliveryOutcome === 'delivered') {
+            setError(null);
+            updateMessageById(
+              message.id,
+              (prev) =>
+                applyDesignDeliveryOutcome(
+                  { ...prev, content: deliveryContent },
+                  deliveryOutcome,
+                ),
+              true,
+              { telemetryFinalized: true },
+            );
+          }
+          completedReattachRunsRef.current.add(runId);
           continue;
         }
         // When the daemon authoritative status is 'failed', the run ended in a
@@ -9306,7 +9339,6 @@ export function shouldReplayTerminalRunMessage(message: ChatMessage): boolean {
   if (message.role !== 'assistant') return false;
   if (!message.runId) return false;
   if (message.runStatus !== 'succeeded') return false;
-  if (shouldReconcileHistoricalDesignDelivery(message)) return true;
   // A daemon can persist terminal success before the browser finishes its
   // project-file refresh. Reattach once even when prose already exists so the
   // delivery invariant can confirm a file or downgrade the turn after reload.

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -260,6 +260,8 @@ export function buildDaemonTranscript(history: ChatMessage[], targetAgentId?: st
 
 export interface DaemonStreamHandlers extends StreamHandlers {
   onAgentEvent: (ev: AgentEvent) => void;
+  /** Authoritative artifact count from the daemon's terminal run record. */
+  onArtifactCount?: (count: number) => void;
   /**
    * Live-only incremental tool-input fragment (Claude `input_json_delta`).
    * Kept off `AgentEvent`/`PersistedAgentEvent` because it is ephemeral and
@@ -1063,6 +1065,7 @@ async function consumeDaemonRun({
   const reportArtifactCount = (value: unknown) => {
     if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return;
     resolvedArtifactCount = value;
+    handlers.onArtifactCount?.(value);
   };
   let lastEventId: string | null = initialLastEventId ?? null;
   let canceled = false;

--- a/apps/web/src/runtime/design-delivery.ts
+++ b/apps/web/src/runtime/design-delivery.ts
@@ -18,6 +18,8 @@ export interface DesignDeliveryInput {
   events: AgentEvent[] | undefined;
   producedFileCount: number;
   traceObjectFileCount: number;
+  /** Authoritative artifact count reported by the daemon at run finalization. */
+  artifactCount?: number;
   persistenceSucceeded?: boolean;
   persistenceFailed?: boolean;
 }
@@ -83,6 +85,7 @@ export function resolveDesignDeliveryOutcome(
   if (
     input.producedFileCount > 0 ||
     input.traceObjectFileCount > 0 ||
+    (input.artifactCount ?? 0) > 0 ||
     input.persistenceSucceeded ||
     hasLiveArtifactDelivery(input.events)
   ) {

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -989,6 +989,142 @@ describe('ProjectView conversation run isolation', () => {
     expect(reattachDaemonRun).not.toHaveBeenCalled();
   });
 
+  it('repairs a historical false no-result verdict from durable artifact evidence', async () => {
+    conversationAMessages = [
+      {
+        ...succeededAssistant,
+        content: 'I updated the existing design.',
+        sessionMode: 'design',
+        resultDeliveryState: 'no_result',
+        events: [
+          { kind: 'text', text: 'I updated the existing design.' },
+          {
+            kind: 'status',
+            label: 'error',
+            detail: 'The design run finished without producing a deliverable project file.',
+            code: 'ARTIFACT_NOT_FOUND',
+          },
+        ],
+        preTurnFileNames: ['index.html'],
+        producedFiles: [],
+        traceObjectFiles: [],
+      },
+    ];
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-a',
+      status: 'succeeded',
+      createdAt: 1,
+      updatedAt: 2,
+      exitCode: 0,
+      signal: null,
+      artifactCount: 1,
+    });
+
+    renderProjectView();
+
+    await waitFor(() => {
+      const repaired = saveMessage.mock.calls
+        .map((call) => call[2] as ChatMessage)
+        .find(
+          (message) =>
+            message.id === succeededAssistant.id
+            && message.resultDeliveryState === 'delivered',
+        );
+      expect(repaired).toBeTruthy();
+      expect(repaired?.events).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ code: 'ARTIFACT_NOT_FOUND' }),
+        ]),
+      );
+    });
+    expect(fetchChatRunStatus).toHaveBeenCalledWith('run-a');
+    expect(reattachDaemonRun).not.toHaveBeenCalled();
+  });
+
+  it('preserves a genuine historical zero-output verdict', async () => {
+    conversationAMessages = [
+      {
+        ...succeededAssistant,
+        content: 'I could not create a deliverable.',
+        sessionMode: 'design',
+        resultDeliveryState: 'no_result',
+        events: [
+          { kind: 'text', text: 'I could not create a deliverable.' },
+          {
+            kind: 'status',
+            label: 'error',
+            detail: 'The design run finished without producing a deliverable project file.',
+            code: 'ARTIFACT_NOT_FOUND',
+          },
+        ],
+        preTurnFileNames: ['index.html'],
+        producedFiles: [],
+        traceObjectFiles: [],
+      },
+    ];
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-a',
+      status: 'succeeded',
+      createdAt: 1,
+      updatedAt: 2,
+      exitCode: 0,
+      signal: null,
+      artifactCount: 0,
+    });
+
+    renderProjectView();
+
+    await waitFor(() => {
+      expect(fetchChatRunStatus).toHaveBeenCalledWith('run-a');
+      const delivered = saveMessage.mock.calls
+        .map((call) => call[2] as ChatMessage)
+        .find(
+          (message) =>
+            message.id === succeededAssistant.id
+            && message.resultDeliveryState === 'delivered',
+        );
+      expect(delivered).toBeUndefined();
+    });
+    expect(reattachDaemonRun).not.toHaveBeenCalled();
+  });
+
+  it('leaves historical no-result state untouched when durable evidence is unavailable', async () => {
+    conversationAMessages = [
+      {
+        ...succeededAssistant,
+        content: 'I could not create a deliverable.',
+        sessionMode: 'design',
+        resultDeliveryState: 'no_result',
+        events: [
+          { kind: 'text', text: 'I could not create a deliverable.' },
+          {
+            kind: 'status',
+            label: 'error',
+            detail: 'The design run finished without producing a deliverable project file.',
+            code: 'ARTIFACT_NOT_FOUND',
+          },
+        ],
+        preTurnFileNames: ['index.html'],
+        producedFiles: [],
+        traceObjectFiles: [],
+      },
+    ];
+    fetchChatRunStatus.mockResolvedValue(null);
+
+    renderProjectView();
+
+    await waitFor(() => expect(fetchChatRunStatus).toHaveBeenCalledWith('run-a'));
+    const rewrittenAsFailed = saveMessage.mock.calls
+      .map((call) => call[2] as ChatMessage)
+      .find(
+        (message) =>
+          message.id === succeededAssistant.id
+          && message.runStatus === 'failed',
+      );
+    expect(rewrittenAsFailed).toBeUndefined();
+    expect(reattachDaemonRun).not.toHaveBeenCalled();
+  });
+
   it('trusts the daemon artifact count when browser file reconciliation misses delivered output', async () => {
     conversationAMessages = [
       {

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -989,6 +989,62 @@ describe('ProjectView conversation run isolation', () => {
     expect(reattachDaemonRun).not.toHaveBeenCalled();
   });
 
+  it('trusts the daemon artifact count when browser file reconciliation misses delivered output', async () => {
+    conversationAMessages = [
+      {
+        ...succeededAssistant,
+        content: '',
+        sessionMode: 'design',
+        events: [
+          { kind: 'text', text: 'I finished the design.' },
+          {
+            kind: 'tool_use',
+            id: 'write-1',
+            name: 'Write',
+            input: { file_path: 'index.html', content: '<!doctype html>' },
+          },
+        ],
+        preTurnFileNames: [],
+        producedFiles: undefined,
+        traceObjectFiles: undefined,
+      },
+    ];
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-a',
+      status: 'succeeded',
+      createdAt: 1,
+      updatedAt: 2,
+      exitCode: 0,
+      signal: null,
+      artifactCount: 1,
+    });
+
+    renderProjectView();
+
+    await waitFor(() => {
+      const recoveredMessage = saveMessage.mock.calls
+        .map((call) => call[2] as ChatMessage)
+        .find(
+          (message) =>
+            message.id === succeededAssistant.id
+            && message.resultDeliveryState === 'delivered',
+        );
+      expect(recoveredMessage).toMatchObject({
+        runStatus: 'succeeded',
+        resultDeliveryState: 'delivered',
+        producedFiles: [],
+        traceObjectFiles: [],
+      });
+      expect(recoveredMessage?.events).not.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ code: 'ARTIFACT_NOT_FOUND' }),
+        ]),
+      );
+    });
+    expect(screen.getByTestId('chat-error').textContent).toBe('');
+    expect(reattachDaemonRun).not.toHaveBeenCalled();
+  });
+
   it('keeps a reloaded report-only Design run without file writes on the success path', async () => {
     // Prose-only turns (image analysis, audits) are legitimate zero-file
     // Design results (#5714, #5718); reload must not downgrade them.

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -989,7 +989,7 @@ describe('ProjectView conversation run isolation', () => {
     expect(reattachDaemonRun).not.toHaveBeenCalled();
   });
 
-  it('repairs a historical false no-result verdict from durable artifact evidence', async () => {
+  it('repairs historical no-result from status-only evidence without text-event replay', async () => {
     conversationAMessages = [
       {
         ...succeededAssistant,
@@ -997,7 +997,12 @@ describe('ProjectView conversation run isolation', () => {
         sessionMode: 'design',
         resultDeliveryState: 'no_result',
         events: [
-          { kind: 'text', text: 'I updated the existing design.' },
+          {
+            kind: 'tool_use',
+            id: 'write-1',
+            name: 'Write',
+            input: { file_path: 'index.html', content: '<!doctype html>' },
+          },
           {
             kind: 'status',
             label: 'error',
@@ -1031,6 +1036,7 @@ describe('ProjectView conversation run isolation', () => {
             && message.resultDeliveryState === 'delivered',
         );
       expect(repaired).toBeTruthy();
+      expect(repaired?.content).toBe('I updated the existing design.');
       expect(repaired?.events).not.toEqual(
         expect.arrayContaining([
           expect.objectContaining({ code: 'ARTIFACT_NOT_FOUND' }),

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -99,6 +99,7 @@ describe('streamViaDaemon', () => {
       conversationId: 'conversation-1',
     });
 
+    expect(handlers.onArtifactCount).toHaveBeenCalledWith(2);
     expect(published).toEqual([{
       runId: 'run-artifact-success',
       projectId: 'project-1',
@@ -2214,6 +2215,7 @@ function createDaemonHandlers() {
   return {
     ...createStreamHandlers(),
     onAgentEvent: vi.fn(),
+    onArtifactCount: vi.fn(),
   };
 }
 

--- a/apps/web/tests/runtime/design-delivery.test.ts
+++ b/apps/web/tests/runtime/design-delivery.test.ts
@@ -96,6 +96,17 @@ describe('resolveDesignDeliveryOutcome', () => {
         events: [],
         producedFileCount: 0,
         traceObjectFileCount: 0,
+        artifactCount: 1,
+      }),
+    ).toBe('delivered');
+    expect(
+      resolveDesignDeliveryOutcome({
+        sessionMode: 'design',
+        runStatus: 'succeeded',
+        content: '',
+        events: [],
+        producedFileCount: 0,
+        traceObjectFileCount: 0,
         persistenceSucceeded: true,
       }),
     ).toBe('delivered');


### PR DESCRIPTION
Fixes #5782.

## Why

I hit repeated false `ARTIFACT_NOT_FOUND` cards while working on an existing imported Design project. Twelve succeeded messages were persisted as `no_result` even though their durable terminal run records reported `artifactCount: 1`; one genuine zero-output run reported `artifactCount: 0` and must remain a failure.

Run status is held in memory, while terminal run events are also written to disk. After restart, `GET /api/runs/:id` only consulted the empty in-memory registry and returned 404, even when the durable log still contained the authoritative terminal `end` record. The conversation loader therefore had no positive evidence with which to repair a stale pre-#5750 verdict.

This PR:

- recovers terminal run status from the durable per-run `events.jsonl` log when the in-memory registry is empty;
- reconciles persisted Design messages only when terminal evidence confirms `artifactCount > 0`;
- removes the synthetic `ARTIFACT_NOT_FOUND` event when the verdict is repaired;
- uses a dedicated status-only historical path, never post-restart SSE reattach;
- preserves genuine `artifactCount: 0` failures and leaves messages untouched when durable evidence is unavailable.

## What users will see

After reopening Open Design, a historical Design run that really produced or modified an artifact will no longer retain a false red “finished without producing a deliverable” card. Real zero-output runs keep the existing failure state.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — the existing `GET /api/runs/:id` status path now recovers a same-shape terminal response from durable evidence after restart
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — conversation load repairs persisted `no_result` delivery state and its synthetic error event when durable evidence proves delivery
- [ ] **None** — internal refactor, docs, tests, or translation update only

The touched behavior spans daemon run-status recovery, web conversation-load reconciliation, and persisted delivery state. It does not change preview containment, agent execution, or retry policy.

## Screenshots

No new UI surface. The visible change is removal of an existing false failure card only when durable evidence proves delivery. Visual regression: 0 changed, 53 unchanged, 0 failed.

## Bug fix verification

- Test paths:
  - `apps/daemon/tests/runtimes/runs.test.ts`
  - `apps/web/tests/components/ProjectView.run-isolation.test.tsx`
- The regression cases encode behavior missing on `main`: restart-time status recovery and status-only repair without an in-memory SSE stream. They pass on this branch.
- `artifactCount: 1` repairs the message to `delivered`, preserves content, removes `ARTIFACT_NOT_FOUND`, and never calls `reattachDaemonRun`.
- `artifactCount: 0` remains `no_result`.
- Missing, malformed, symlinked, and traversal-shaped evidence is not trusted.
- A missing durable log leaves the existing persisted verdict untouched.

## Validation

- full web suite: 4,584 passed, 7 skipped
- focused delivery/SSE/ProjectView suite: 134 passed
- daemon run-service suite: 34 passed
- workspace typecheck: passed
- repository guard: passed before the review follow-up; current local rerun is obstructed only by ignored Finder `.DS_Store` files, while PR CI is green
- diff check: passed

## Dependency

This is intentionally stacked on #5750, whose artifact-count propagation is the live/reattached half of the same invariant. Once #5750 lands, this branch can be rebased so the review diff contains only the restart-recovery commits.

Manual QA is appropriate because this changes a user-visible historical failure state. I will not self-merge; maintainers own QA and merge.
