### PR TITLE
Fix packaged wrapper node runtime

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -736,7 +736,32 @@ const PLUGIN_PREVIEWS_DIR = resolveDaemonPluginPreviewsDir({
   projectRoot: PROJECT_ROOT,
 });
 const OD_BIN = resolveDaemonCliPath();
-const OD_NODE_BIN = process.execPath;
+export function resolveOpenDesignNodeBin({
+  env = process.env,
+  execPath = process.execPath,
+  platform = process.platform,
+  resourceRoot = DAEMON_RESOURCE_ROOT,
+  exists = fs.existsSync,
+}: {
+  env?: NodeJS.ProcessEnv | Record<string, string | undefined>;
+  execPath?: string;
+  platform?: NodeJS.Platform;
+  resourceRoot?: string | null;
+  exists?: (path: string) => boolean;
+} = {}): string {
+  const configured = env.OD_NODE_BIN?.trim();
+  if (configured) return configured;
+
+  const bundledName = platform === 'win32' ? 'node.exe' : 'node';
+  const bundled = resourceRoot
+    ? (platform === 'win32' ? path.win32 : path).join(resourceRoot, 'bin', bundledName)
+    : null;
+  if (bundled && exists(bundled)) return bundled;
+
+  return execPath;
+}
+
+const OD_NODE_BIN = resolveOpenDesignNodeBin();
 const SKILLS_DIR = resolveDaemonResourceDir(
   DAEMON_RESOURCE_ROOT,
   'skills',
@@ -1088,7 +1113,7 @@ export function createAgentRuntimeEnv(
   baseEnv: NodeJS.ProcessEnv | Record<string, string | undefined>,
   daemonUrl: string,
   toolTokenGrant: { token?: string } | null = null,
-  nodeBin: string = process.execPath,
+  nodeBin: string = OD_NODE_BIN,
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = applySandboxRuntimeEnv(
     {

--- a/apps/daemon/tests/runtimes/agent-runtime-env.test.ts
+++ b/apps/daemon/tests/runtimes/agent-runtime-env.test.ts
@@ -8,11 +8,31 @@ import {
   createAgentRuntimeToolPrompt,
   createDaemonDataDirConfiguredAgentEnv,
   createOpenDesignToolEnv,
+  resolveOpenDesignNodeBin,
 } from '../../src/server.js';
 import { applyAgentLaunchEnv } from '../../src/runtimes/launch.js';
 import { spawnEnvForAgent } from '../../src/runtimes/env.js';
 
 describe('agent runtime tool environment', () => {
+  it('prefers explicit OD_NODE_BIN over the process executable', () => {
+    expect(resolveOpenDesignNodeBin({
+      env: { OD_NODE_BIN: 'C:\\Open Design\\resources\\open-design\\bin\\node.exe' },
+      execPath: 'C:\\Users\\Ada\\AppData\\Roaming\\Open Design\\en\\hash\\Open Design.exe',
+      platform: 'win32',
+      resourceRoot: null,
+    })).toBe('C:\\Open Design\\resources\\open-design\\bin\\node.exe');
+  });
+
+  it('resolves the bundled resource node before falling back to process.execPath', () => {
+    expect(resolveOpenDesignNodeBin({
+      env: {},
+      execPath: 'C:\\Users\\Ada\\AppData\\Roaming\\Open Design\\en\\hash\\Open Design.exe',
+      platform: 'win32',
+      resourceRoot: 'C:\\Users\\Ada\\AppData\\Local\\Programs\\Open Design\\resources\\open-design',
+      exists: (candidate) => candidate.endsWith('\\resources\\open-design\\bin\\node.exe'),
+    })).toBe('C:\\Users\\Ada\\AppData\\Local\\Programs\\Open Design\\resources\\open-design\\bin\\node.exe');
+  });
+
   it('injects daemon URL and run-scoped tool token into agent sessions', () => {
     const env = createAgentRuntimeEnv(
       { PATH: '/bin', OD_TOOL_TOKEN: 'stale-token' },

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -369,6 +369,7 @@ export type PackagedDaemonSpawnEnvOptions = {
   appVersion: string | null;
   amrProfile?: string | null;
   daemonCliEntry: string | null;
+  nodeCommand?: string | null;
   /**
    * PR #974 round-5 (lefarcen P2): only pin the daemon's import-folder
    * gate ON when the desktop runtime is actually being started in the
@@ -411,6 +412,9 @@ export function buildPackagedDaemonSpawnEnv(
     // fallback, but packaged runtime must not rely on path inference from
     // Electron userData, bundle names, or ports.
     ...createPackagedDaemonManagedPathEnv(paths),
+    ...(options.nodeCommand == null || options.nodeCommand.length === 0
+      ? {}
+      : { OD_NODE_BIN: options.nodeCommand }),
     ...(options.amrProfile == null || options.amrProfile.length === 0
       ? {}
       : { OPEN_DESIGN_AMR_PROFILE: options.amrProfile }),
@@ -582,6 +586,7 @@ export async function startPackagedSidecars(
         amrProfile: options.amrProfile,
         daemonCliEntry: options.daemonCliEntry,
         legacyDataDir: process.env.OD_LEGACY_DATA_DIR ?? null,
+        nodeCommand: options.nodeCommand,
         requireDesktopAuth: options.requireDesktopAuth,
         telemetryRelayUrl: options.telemetryRelayUrl,
         posthogKey: options.posthogKey,

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -403,6 +403,20 @@ describe('buildPackagedDaemonSpawnEnv', () => {
     expect(env.OD_DAEMON_CLI_PATH).toBe('/path/to/cli/dist/index.js');
   });
 
+  it('forwards the packaged node command as OD_NODE_BIN for agent wrapper calls', () => {
+    const env = buildPackagedDaemonSpawnEnv(fakePaths(), {
+      appVersion: null,
+      daemonCliEntry: null,
+      legacyDataDir: null,
+      nodeCommand: 'C:\\Users\\Ada\\AppData\\Local\\Programs\\Open Design\\resources\\open-design\\bin\\node.exe',
+      requireDesktopAuth: true,
+    });
+
+    expect(env.OD_NODE_BIN).toBe(
+      'C:\\Users\\Ada\\AppData\\Local\\Programs\\Open Design\\resources\\open-design\\bin\\node.exe',
+    );
+  });
+
   it('forwards the packaged telemetry relay URL to the daemon when configured', () => {
     const env = buildPackagedDaemonSpawnEnv(fakePaths(), {
       appVersion: null,


### PR DESCRIPTION
## Summary

- pass the packaged Node command into the daemon as `OD_NODE_BIN`
- make daemon wrapper envs prefer explicit `OD_NODE_BIN` or the bundled resource Node before falling back to `process.execPath`
- add Windows packaged regression coverage for the wrapper runtime path

Fixes #5731.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** - new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** - new or changed
- [x] **CLI / env var** - forwards the packaged Node command into the daemon as `OD_NODE_BIN`
- [ ] **API / contract** - new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** - new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** - added new translation keys
- [ ] **New top-level dependency** - adding any new entry to the root `package.json`
- [x] **Default behavior change** - packaged daemon wrapper envs now prefer the bundled Node runtime instead of falling back to the Electron executable
- [ ] **None** - internal refactor, docs, tests, or translation update only

This is limited to packaged/daemon runtime wrapper behavior. The packaged launcher now forwards the already-resolved packaged Node command into the daemon spawn env, and daemon-created agent wrapper envs use that runtime for `OD_NODE_BIN`.

It does not change media dispatch, provider config, task polling, or non-packaged wrapper commands.

## Bug fix verification

The regression coverage pins the Windows packaged failure mode where `process.execPath` can be an Electron GUI executable while the real bundled Node runtime lives under `resources/open-design/bin/node.exe`.

The daemon test verifies both explicit `OD_NODE_BIN` forwarding and bundled resource-node fallback. The packaged test verifies the packaged daemon spawn env carries the resolved Node command as `OD_NODE_BIN`.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/agent-runtime-env.test.ts`
- `pnpm --filter @open-design/packaged exec vitest run -c vitest.config.ts tests/sidecars.test.ts`
- `pnpm --filter @open-design/desktop build`
- `pnpm --filter @open-design/daemon build`
- `pnpm --filter @open-design/packaged build`
