### PR TITLE
fix(packaged): force-stop an orphaned sidecar that ignores SHUTDOWN

### DIFF
--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -281,7 +281,31 @@ export async function waitForStatus<T>(
   }
 }
 
-async function retireExistingSidecarEndpoint(ipcPath: string, logPath: string): Promise<void> {
+/** @internal Injectable process controls so tests never signal real PIDs. */
+export type SidecarRetireControls = {
+  stopProcesses: typeof stopProcesses;
+  waitForExit: typeof waitForProcessExit;
+};
+
+/**
+ * Clear a previous sidecar off `ipcPath` before we spawn its replacement.
+ *
+ * Sidecar children have no parent-death watchdog, so a force-quit or crash of
+ * the desktop main process orphans them: they keep running and keep holding
+ * this fixed socket path. Graceful SHUTDOWN is tried first, but a wedged
+ * orphan ignores it — and `prepareIpcPath` only unlinks a socket whose listener
+ * is *gone*, so a live-but-wedged endpoint is never treated as stale and the
+ * sidecar we are about to spawn cannot bind. Escalate to SIGTERM→SIGKILL for
+ * that case, mirroring how `closeManagedChild` already force-stops a managed
+ * child that ignores SHUTDOWN.
+ */
+export async function retireExistingSidecarEndpoint(
+  ipcPath: string,
+  logPath: string,
+  controls: Partial<SidecarRetireControls> = {},
+): Promise<void> {
+  const waitForExit = controls.waitForExit ?? waitForProcessExit;
+  const stop = controls.stopProcesses ?? stopProcesses;
   let status: { pid?: number | null } | null = null;
   try {
     status = await requestJsonIpc<{ pid?: number | null }>(
@@ -308,11 +332,20 @@ async function retireExistingSidecarEndpoint(ipcPath: string, logPath: string): 
   }
 
   if (pid != null && pid !== process.pid && isProcessAlive(pid)) {
-    const exited = await waitForProcessExit(pid, 2500);
+    const exited = await waitForExit(pid, 2500);
     await appendSidecarLifecycleLog(
       logPath,
       `[open-design packaged] existing sidecar endpoint ${exited ? "exited" : "still-running"} ipc=${ipcPath} pid=${pid}`,
     );
+    if (!exited) {
+      const result = await stop([pid]);
+      const gone = !result.remainingPids.includes(pid);
+      const outcome = !gone ? "survived" : result.forcedPids.includes(pid) ? "sigkill" : "sigterm";
+      await appendSidecarLifecycleLog(
+        logPath,
+        `[open-design packaged] existing sidecar endpoint force-stop ipc=${ipcPath} pid=${pid} outcome=${outcome}`,
+      );
+    }
   }
 }
 

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -15,14 +15,16 @@
  * @see apps/daemon/src/legacy-data-migrator.ts
  * @see https://github.com/nexu-io/open-design/issues/710
  */
+import { spawn } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { delimiter, dirname, join, posix } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { createJsonIpcServer, resolveAppIpcPath } from '@open-design/sidecar';
 import { APP_KEYS, OPEN_DESIGN_SIDECAR_CONTRACT } from '@open-design/sidecar-proto';
+import type { StopProcessesResult, stopProcesses, waitForProcessExit } from '@open-design/platform';
 
 import {
   buildPackagedDaemonSpawnEnv,
@@ -30,6 +32,7 @@ import {
   resolvePackagedChildBaseEnv,
   resolvePackagedElectronNodeCommand,
   resolvePackagedPathEnv,
+  retireExistingSidecarEndpoint,
   waitForStatus,
 } from '../src/sidecars.js';
 import type { PackagedNamespacePaths } from '../src/paths.js';
@@ -565,6 +568,99 @@ describe('waitForStatus child-exit fast-fail', () => {
       expect((captured as Error).message).toContain('sidecar status pid 1234 did not match spawned pid 5678');
     } finally {
       await server.close();
+    }
+  });
+});
+
+describe('retireExistingSidecarEndpoint', () => {
+  /** A real, live PID that is not this process, so `isProcessAlive` is exercised for real. */
+  function spawnLiveChild(): { pid: number; kill: () => void } {
+    const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });
+    return { pid: child.pid as number, kill: () => child.kill('SIGKILL') };
+  }
+
+  function fakeStopResult(pid: number, opts: { forced?: boolean; survived?: boolean } = {}): StopProcessesResult {
+    return {
+      alreadyStopped: false,
+      forcedPids: opts.forced ? [pid] : [],
+      matchedPids: [pid],
+      remainingPids: opts.survived ? [pid] : [],
+      stoppedPids: opts.survived ? [] : [pid],
+    };
+  }
+
+  async function withWedgedEndpoint(
+    pid: number,
+    run: (ipcPath: string, logPath: string) => Promise<void>,
+  ): Promise<void> {
+    const root = mkdtempSync(join(tmpdir(), 'od-retire-'));
+    const ipcPath = join(root, 'sidecar.sock');
+    const logPath = join(root, 'sidecar.log');
+    // Answers STATUS as a live endpoint but never exits on SHUTDOWN — an orphan
+    // left behind by a force-quit, which is exactly what must be force-stopped.
+    const server = await createJsonIpcServer({
+      socketPath: ipcPath,
+      handler: async () => ({ pid, state: 'running' }),
+    });
+    try {
+      await run(ipcPath, logPath);
+    } finally {
+      await server.close();
+      rmSync(root, { force: true, recursive: true });
+    }
+  }
+
+  it('force-stops an orphaned sidecar that ignores SHUTDOWN', async () => {
+    const child = spawnLiveChild();
+    const stop = vi.fn(async () => fakeStopResult(child.pid, { forced: true })) as unknown as typeof stopProcesses;
+    try {
+      await withWedgedEndpoint(child.pid, async (ipcPath, logPath) => {
+        await retireExistingSidecarEndpoint(ipcPath, logPath, {
+          stopProcesses: stop,
+          waitForExit: (async () => false) as typeof waitForProcessExit,
+        });
+        const log = readFileSync(logPath, 'utf8');
+        expect(log).toContain(`still-running`);
+        expect(log).toContain(`force-stop ipc=${ipcPath} pid=${child.pid} outcome=sigkill`);
+      });
+      expect(stop).toHaveBeenCalledWith([child.pid]);
+    } finally {
+      child.kill();
+    }
+  });
+
+  it('leaves a sidecar that shuts down gracefully alone', async () => {
+    const child = spawnLiveChild();
+    const stop = vi.fn(async () => fakeStopResult(child.pid)) as unknown as typeof stopProcesses;
+    try {
+      await withWedgedEndpoint(child.pid, async (ipcPath, logPath) => {
+        await retireExistingSidecarEndpoint(ipcPath, logPath, {
+          stopProcesses: stop,
+          waitForExit: (async () => true) as typeof waitForProcessExit,
+        });
+        const log = readFileSync(logPath, 'utf8');
+        expect(log).toContain('exited');
+        expect(log).not.toContain('force-stop');
+      });
+      expect(stop).not.toHaveBeenCalled();
+    } finally {
+      child.kill();
+    }
+  });
+
+  it('records survived when an orphan cannot be force-stopped', async () => {
+    const child = spawnLiveChild();
+    const stop = vi.fn(async () => fakeStopResult(child.pid, { survived: true })) as unknown as typeof stopProcesses;
+    try {
+      await withWedgedEndpoint(child.pid, async (ipcPath, logPath) => {
+        await retireExistingSidecarEndpoint(ipcPath, logPath, {
+          stopProcesses: stop,
+          waitForExit: (async () => false) as typeof waitForProcessExit,
+        });
+        expect(readFileSync(logPath, 'utf8')).toContain(`force-stop ipc=${ipcPath} pid=${child.pid} outcome=survived`);
+      });
+    } finally {
+      child.kill();
     }
   });
 });


### PR DESCRIPTION
## Why

**My use case:** While tracing the post-update export skew (`render-slides`, fixed in #5677), I audited the other teardown paths and found the same "only wait, never kill" gap a third time — this one on the sidecar-relaunch path.

**The pain:** Sidecar children have **no parent-death watchdog**. Force-quitting the app (⌘⌥Esc, holding ⌥ on the Dock's Quit, Task Manager "End task") or a main-process crash never runs `before-quit`, so `sidecars.close()` never executes and the daemon/web children are **orphaned** — still running, still holding their fixed IPC socket. (A normal quit is fine: `before-quit` → `shutdown()` → `sidecars.close()` → `closeManagedChild`, which already force-stops.)

`retireExistingSidecarEndpoint` exists to clear that endpoint before the replacement spawns, but on a SHUTDOWN the orphan ignores it just logged `still-running` and returned.

**The consequence is worse than a visible failure — it's silent.** `prepareIpcPath` only unlinks a socket whose listener is *gone*, so a live-but-wedged orphan is never treated as stale. I verified the resulting chain with real code:

```
① orphan holds the socket, STATUS answers OLD url
② new sidecar binds the same socket: FAILS -> EADDRINUSE
③ waitForStatus reads -> http://127.0.0.1:1111-OLD
   ==> the app talks to the OLD orphan
```

`waitForStatus` reads that same `ipcPath` and only cares what comes back — not who answered. So the app proceeds against the **previous version's** sidecar URL while believing it started a fresh one. No error surfaces.

## What users will see

After a force-quit or crash, reopening the app now actually runs against the sidecar it just started, instead of silently reattaching to the leftover one from the previous session (which can be an older app version, with that version's features and bugs). No visible UI change — the fix is in packaged sidecar startup.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — a wedged orphaned sidecar is now force-stopped before its replacement spawns, instead of being left running
- [ ] **None**

Not a UI/CLI-dual-track capability: packaged sidecar startup internals, no user-facing surface.

## Bug fix verification

- Test file: `apps/packaged/tests/sidecars.test.ts` → `describe('retireExistingSidecarEndpoint')`
  - `force-stops an orphaned sidecar that ignores SHUTDOWN`
  - `leaves a sidecar that shuts down gracefully alone`
  - `records survived when an orphan cannot be force-stopped`
- **Red/green:** restoring `apps/packaged/src/sidecars.ts` to `origin/main` (tests kept) → the 3 new cases fail; with the fix → 29/29 pass. Full `@open-design/packaged`: 177 passed.

**Real-runtime E2E (real code, zero injection).** A genuinely wedged orphan — separate process, holds the socket via the real `createJsonIpcServer`, answers STATUS, ACKs SHUTDOWN but never exits, and traps `SIGTERM` (a bare `SIGTERM` leaves it alive) — driven through the real `retireExistingSidecarEndpoint`:

```
existing sidecar endpoint detected ipc=… pid=34844; requesting shutdown before relaunch
existing sidecar endpoint still-running ipc=… pid=34844
existing sidecar endpoint force-stop ipc=… pid=34844 outcome=sigkill
orphan alive after retire: false
new sidecar binds socket: OK
```

That last line is the step that fails with EADDRINUSE today. Worst-case added latency is one `stopProcesses` SIGTERM grace (~5s) on top of the existing 2.5s wait — only on the wedged path (~7.7s total observed), and only when an orphan is actually stuck.

The fix reuses the existing, blessed `stopProcesses` (SIGTERM → 5s → SIGKILL), already imported in this file for `closeManagedChild`. This extends an existing invariant rather than introducing a new force-kill policy; the orphan's data is discardable (it is the session being replaced).

## Validation

Node v24.15.0:

- `pnpm --filter @open-design/packaged typecheck`
- `pnpm --filter @open-design/packaged exec vitest run tests/sidecars.test.ts` → 29 passed
- `pnpm --filter @open-design/packaged test` → 177 passed
- `pnpm guard` → 86 passed

## Adjacent issues (not fixed here)

- **Sidecar children have no parent-death watchdog.** This PR cleans orphans up on the *next* launch; it does not stop them being created. A watchdog (child exits when its parent dies) would close that at the source — worth a separate look by desktop infra, since it changes child lifecycle.
- `apps/desktop/src/main/index.ts` registers **two** `before-quit` handlers (lines ~916 and ~922). The second is effectively dead code (`shutdown()` sets `shuttingDown` synchronously before its first `await`, so the second handler always early-returns). Harmless but confusing; left alone to keep this PR scoped.

Related: #5677 (same "only wait, never kill" gap on the launcher relaunch path).
