### PR TITLE
fix(packaged): retry idempotent logout proxy requests

### DIFF
--- a/apps/packaged/src/protocol.ts
+++ b/apps/packaged/src/protocol.ts
@@ -28,12 +28,14 @@ function toWebRuntimeUrl(webRuntimeUrl: string, requestUrl: string): string {
 
 const OD_PROXY_RETRYABLE_METHODS = new Set(["GET", "HEAD"]);
 // Most POST requests change state and must never be replayed after an
-// indeterminate socket failure. Logout is deliberately idempotent, though:
-// either attempt leaves the local credential store signed out. Retrying this
-// bodyless request keeps the Settings action usable when Electron's local
-// `net.fetch` hits the same transient socket failures we already absorb for
-// document and asset requests.
+// indeterminate socket failure. These two routes are deliberate exceptions:
+// logout is idempotent, while login deduplicates a second request as
+// "already running" (which the renderer treats as a successful start).
+// Retrying keeps Settings usable when Electron's local `net.fetch` hits the
+// same transient socket failures we already absorb for document and asset
+// requests.
 const OD_PROXY_RETRYABLE_POST_PATHS = new Set([
+  "/api/integrations/vela/login",
   "/api/integrations/vela/logout",
 ]);
 const OD_PROXY_RETRY_ATTEMPTS = 3;
@@ -50,7 +52,7 @@ const defaultRetryDelay = (ms: number): Promise<void> =>
 
 function isRetryableOdProxyRequest(request: Request): boolean {
   if (OD_PROXY_RETRYABLE_METHODS.has(request.method)) return true;
-  if (request.method !== "POST" || request.body !== null) return false;
+  if (request.method !== "POST") return false;
   return OD_PROXY_RETRYABLE_POST_PATHS.has(new URL(request.url).pathname);
 }
 
@@ -85,9 +87,13 @@ async function fetchOdTargetWithTransientRetry(
   const backoffMs = options.backoffMs ?? OD_PROXY_RETRY_BACKOFF_MS;
   const delay = options.delay ?? defaultRetryDelay;
   let lastError: unknown;
+  // Each proxy attempt consumes its Request body. Keep an untouched clone as
+  // the source so the login attribution JSON remains available to a retry.
+  const retrySource = attempts > 1 ? request.clone() : request;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
-      return await fetchImpl(new Request(target, request));
+      const attemptRequest = attempts > 1 ? retrySource.clone() : request;
+      return await fetchImpl(new Request(target, attemptRequest));
     } catch (error) {
       lastError = error;
       if (attempt === attempts) break;

--- a/apps/packaged/src/protocol.ts
+++ b/apps/packaged/src/protocol.ts
@@ -27,6 +27,15 @@ function toWebRuntimeUrl(webRuntimeUrl: string, requestUrl: string): string {
 }
 
 const OD_PROXY_RETRYABLE_METHODS = new Set(["GET", "HEAD"]);
+// Most POST requests change state and must never be replayed after an
+// indeterminate socket failure. Logout is deliberately idempotent, though:
+// either attempt leaves the local credential store signed out. Retrying this
+// bodyless request keeps the Settings action usable when Electron's local
+// `net.fetch` hits the same transient socket failures we already absorb for
+// document and asset requests.
+const OD_PROXY_RETRYABLE_POST_PATHS = new Set([
+  "/api/integrations/vela/logout",
+]);
 const OD_PROXY_RETRY_ATTEMPTS = 3;
 const OD_PROXY_RETRY_BACKOFF_MS = 150; // 150ms, 300ms — throw path only, ~450ms worst-case added
 
@@ -38,6 +47,12 @@ type OdProxyRetryOptions = {
 
 const defaultRetryDelay = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
+
+function isRetryableOdProxyRequest(request: Request): boolean {
+  if (OD_PROXY_RETRYABLE_METHODS.has(request.method)) return true;
+  if (request.method !== "POST" || request.body !== null) return false;
+  return OD_PROXY_RETRYABLE_POST_PATHS.has(new URL(request.url).pathname);
+}
 
 /**
  * Fetch the rewritten sidecar target, absorbing transient socket throws
@@ -64,7 +79,7 @@ async function fetchOdTargetWithTransientRetry(
   fetchImpl: OdProtocolFetch,
   options: OdProxyRetryOptions,
 ): Promise<Response> {
-  const attempts = OD_PROXY_RETRYABLE_METHODS.has(request.method)
+  const attempts = isRetryableOdProxyRequest(request)
     ? (options.attempts ?? OD_PROXY_RETRY_ATTEMPTS)
     : 1;
   const backoffMs = options.backoffMs ?? OD_PROXY_RETRY_BACKOFF_MS;

--- a/apps/packaged/tests/protocol.test.ts
+++ b/apps/packaged/tests/protocol.test.ts
@@ -184,6 +184,33 @@ describe('od:// protocol transient retry', () => {
     expect(calls).toBe(2);
   });
 
+  it('retries login with its attribution body intact when the first attempt throws', async () => {
+    const receivedBodies: string[] = [];
+    const fetchImpl: typeof fetch = async (input) => {
+      const request = input as Request;
+      receivedBodies.push(await request.text());
+      if (receivedBodies.length === 1) throw transientSocketError();
+      return new Response(JSON.stringify({ pid: 42 }), { status: 202 });
+    };
+
+    const response = await handleOdRequest(
+      new Request('od://app/api/integrations/vela/login', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ attribution: { source: 'settings_amr_authorize' } }),
+      }),
+      'http://127.0.0.1:17579/',
+      fetchImpl,
+      noDelay,
+    );
+
+    expect(response.status).toBe(202);
+    expect(receivedBodies).toEqual([
+      JSON.stringify({ attribution: { source: 'settings_amr_authorize' } }),
+      JSON.stringify({ attribution: { source: 'settings_amr_authorize' } }),
+    ]);
+  });
+
   it('gives up after the bounded attempt budget and returns the 502 proxy-failure document', async () => {
     let calls = 0;
     const fetchImpl: typeof fetch = async () => {

--- a/apps/packaged/tests/protocol.test.ts
+++ b/apps/packaged/tests/protocol.test.ts
@@ -165,6 +165,25 @@ describe('od:// protocol transient retry', () => {
     expect(calls).toBe(2);
   });
 
+  it('retries the bodyless logout POST because logout is idempotent', async () => {
+    let calls = 0;
+    const fetchImpl: typeof fetch = async () => {
+      calls += 1;
+      if (calls === 1) throw transientSocketError();
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    };
+
+    const response = await handleOdRequest(
+      new Request('od://app/api/integrations/vela/logout', { method: 'POST' }),
+      'http://127.0.0.1:17579/',
+      fetchImpl,
+      noDelay,
+    );
+
+    expect(response.status).toBe(200);
+    expect(calls).toBe(2);
+  });
+
   it('gives up after the bounded attempt budget and returns the 502 proxy-failure document', async () => {
     let calls = 0;
     const fetchImpl: typeof fetch = async () => {


### PR DESCRIPTION
## Summary

- retry the bodyless, idempotent logout request in the packaged `od://` proxy
- preserve single-attempt behavior for all other POST requests
- add a regression test for a transient local socket failure during logout

## Root cause

The packaged Electron proxy retries GET/HEAD requests after transient `net::ERR_FAILED` failures, but it made only one attempt for logout. A momentary local socket failure therefore made the Settings logout action appear unresponsive even though the daemon endpoint was healthy.

## Validation

- `pnpm --filter @open-design/packaged test -- protocol.test.ts`
- `pnpm --filter @open-design/packaged typecheck`