### PR TITLE
fix(daemon): audit split token CSS packages

### DIFF
--- a/apps/daemon/src/tools-connectors-cli.ts
+++ b/apps/daemon/src/tools-connectors-cli.ts
@@ -1768,11 +1768,20 @@ export async function auditDesignSystemPackage(
   }
   requireFile('README.md', 'Claude Design-style packages need README.md so the system is reusable outside the current run.');
   requireFile('SKILL.md', 'Claude Design-style packages need SKILL.md with agent-facing usage instructions.');
-  requireFile('colors_and_type.css', 'Claude Design-style packages need colors_and_type.css for reusable color, type, spacing, radius, and state tokens.');
+  requireFile('colors_and_type.css', 'Claude Design-style packages need colors_and_type.css for reusable color and typography foundations; spacing and radius may live in tokens.css.');
+  const companionTokenCss = fileSet.has('tokens.css')
+    ? await readAuditText(projectPath, 'tokens.css')
+    : undefined;
   await requireContent('DESIGN.md', 800, 'thin_design_rules', 'DESIGN.md is too thin to be a reusable rules document; include source-backed context, foundations, tokens, components, motion, voice, and anti-patterns.', validateDesignRules);
   await requireContent('README.md', 600, 'thin_readme', 'README.md is too thin to explain the package, source evidence, generated files, and reuse workflow.', requireMarkdownHeading);
   await requireContent('SKILL.md', 500, 'thin_skill', 'SKILL.md is too thin to guide future agents on how to use this design system.', validateSkillInstructions);
-  await requireContent('colors_and_type.css', 500, 'thin_token_css', 'colors_and_type.css is too thin to carry reusable color, typography, spacing, radius, and state tokens.', validateTokenCss);
+  await requireContent(
+    'colors_and_type.css',
+    500,
+    'thin_token_css',
+    'colors_and_type.css is too thin to carry reusable color and typography foundations.',
+    (text) => validateTokenCss(text, companionTokenCss),
+  );
   if (fileSet.has('SKILL.md')) {
     const skillText = await readAuditText(projectPath, 'SKILL.md');
     if (skillText !== undefined && !skillHasAgentFrontmatter(skillText)) {
@@ -2336,14 +2345,15 @@ function validateDesignRules(text: string): string | undefined {
     : `DESIGN.md is missing source-backed sections for ${missing.map((group) => group[0]).join(', ')}.`;
 }
 
-function validateTokenCss(text: string): string | undefined {
+function validateTokenCss(text: string, companionText?: string): string | undefined {
   const variables = [...text.matchAll(/--[a-z0-9_-]+\s*:/giu)].length;
   if (variables < 12) return `Expected at least 12 CSS custom properties, found ${variables}.`;
   const colors = [...text.matchAll(/#[0-9a-f]{3,8}\b|rgb[a]?\(|hsl[a]?\(/giu)].length;
   if (colors < 4) return `Expected concrete color values in colors_and_type.css, found ${colors}.`;
   if (!/font(-family)?|--[^:]*font/iu.test(text)) return 'Expected font-family or font token declarations.';
-  if (!/radius|border-radius/iu.test(text)) return 'Expected radius token declarations.';
-  if (!/space|spacing|gap/iu.test(text)) return 'Expected spacing token declarations.';
+  const layoutTokens = companionText === undefined ? text : `${text}\n${companionText}`;
+  if (!/radius|border-radius/iu.test(layoutTokens)) return 'Expected radius token declarations in colors_and_type.css or tokens.css.';
+  if (!/space|spacing|gap/iu.test(layoutTokens)) return 'Expected spacing token declarations in colors_and_type.css or tokens.css.';
   return undefined;
 }
 

--- a/apps/daemon/tests/tools-connectors-cli.test.ts
+++ b/apps/daemon/tests/tools-connectors-cli.test.ts
@@ -3,7 +3,7 @@ import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises
 import os from 'node:os';
 import path from 'node:path';
 
-import { runConnectorsToolCli } from '../src/tools-connectors-cli.js';
+import { auditDesignSystemPackage, runConnectorsToolCli } from '../src/tools-connectors-cli.js';
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -276,6 +276,23 @@ const AUDIT_TOKENS_CSS = `@font-face {
 }
 
 ${UNBOUND_FONT_AUDIT_TOKENS_CSS}`;
+
+const SPLIT_AUDIT_COLORS_AND_TYPE_CSS = AUDIT_TOKENS_CSS
+  .replace(/^  --cherry-(?:radius|space)-.*\n/gmu, '')
+  .replace(
+    /\n\}\n$/u,
+    '\n  --cherry-font-size-body: 16px;\n  --cherry-line-height-body: 1.5;\n}\n',
+  );
+
+const SPLIT_AUDIT_LAYOUT_TOKENS_CSS = `:root {
+  --cherry-radius-sm: 6px;
+  --cherry-radius-md: 10px;
+  --cherry-space-1: 4px;
+  --cherry-space-2: 8px;
+  --cherry-space-3: 12px;
+  --cherry-space-4: 16px;
+}
+`;
 
 const AUDIT_COMPONENT_FILES = [
   'App.jsx',
@@ -882,6 +899,20 @@ exit 128
       ok: true,
       errors: [],
     });
+
+    await cleanupTempDir(tmpDir);
+  });
+
+  it('accepts tokens.css as a companion for spacing and radius token validation', async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'od-package-audit-split-tokens-'));
+    await writeFile(path.join(tmpDir, 'colors_and_type.css'), SPLIT_AUDIT_COLORS_AND_TYPE_CSS);
+    await writeFile(path.join(tmpDir, 'tokens.css'), SPLIT_AUDIT_LAYOUT_TOKENS_CSS);
+
+    const audit = await auditDesignSystemPackage(tmpDir);
+
+    expect(audit.errors).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'thin_token_css' }),
+    ]));
 
     await cleanupTempDir(tmpDir);
   });


### PR DESCRIPTION
## Why

While auditing a design-system package that intentionally separates color and typography foundations into `colors_and_type.css` and layout primitives into `tokens.css`, the daemon reported `thin_token_css` even though the package contained valid spacing and radius tokens.

The audit only passed `colors_and_type.css` to `validateTokenCss`, so it could not see the optional companion file. This blocked valid split-token packages and encouraged duplicating tokens solely to satisfy the audit.

## What users will see

`od tools connectors design-system-package-audit` now accepts spacing and radius declarations from an optional root-level `tokens.css` companion. Color values, typography declarations, the custom-property minimum, and the minimum size of `colors_and_type.css` are still validated against the primary file.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — added to the root `package.json`
- [x] **Default behavior change** — existing package audits no longer reject valid split-token packages
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. This changes daemon audit behavior and adds no UI.

## Bug fix verification

- Test path: `apps/daemon/tests/tools-connectors-cli.test.ts`
- Red on the pre-fix source: yes, the split-token fixture reported `thin_token_css` with `Expected radius token declarations.`
- Green on this branch: yes.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/tools-connectors-cli.test.ts` — 40 passed
- `pnpm --filter @open-design/daemon typecheck` — passed
- `pnpm guard` — passed
- `pnpm typecheck` — passed
- Fixed-source audit against the affected XiuAI Media root package — 2,169 files, 0 errors, 0 warnings
- Fixed-source audit against its registered package — 991 files, 0 errors, 0 warnings

## Adjacent issue

The currently installed stable Open Design application still contains the old bundled validator and will continue showing the false positive until a release includes this change.
