### PR TITLE
feat(daemon): attribute stable-prefix drift to the input that caused it

### DIFF
--- a/apps/daemon/src/agent-session-resume.ts
+++ b/apps/daemon/src/agent-session-resume.ts
@@ -9,6 +9,10 @@ import {
   latestCompletedAssistantMessageId,
   upsertAgentSession,
 } from './db.js';
+import {
+  parseStableSections,
+  type StableSectionHashes,
+} from './prompts/stable-sections.js';
 
 type SqliteDb = Database.Database;
 
@@ -25,6 +29,12 @@ export interface AgentResumeContext {
   isResuming: boolean;
   /** Hash of the stable instruction block last sent on this session, or null. */
   storedStablePromptHash: string | null;
+  /**
+   * Per-section digests behind `storedStablePromptHash`, for naming which input
+   * drifted when the hash no longer matches. Diagnostic only — never an input
+   * to the resume decision.
+   */
+  storedStableSections: StableSectionHashes | null;
   /** Set when a stored session existed but was rejected; see the type. */
   invalidationReason: ResumeInvalidationReason | null;
 }
@@ -112,6 +122,7 @@ export function resolveAgentResumeContext(
     newSessionId: randomUUID(),
     isResuming: resumable,
     storedStablePromptHash: resumable ? (record?.stablePromptHash ?? null) : null,
+    storedStableSections: resumable ? parseStableSections(record?.stablePromptSections) : null,
     invalidationReason,
   };
 }
@@ -131,6 +142,7 @@ export function persistCapturedAgentSession(
     agentId: string;
     sessionId: string | null;
     stablePromptHash?: string | null;
+    stablePromptSections?: string | null;
     // Resume identity (see resolveAgentResumeContext). Must be stored alongside
     // the captured session so the next turn can verify the session is still
     // safe to resume; omitting them leaves a null cursor that the guard treats
@@ -147,6 +159,7 @@ export function persistCapturedAgentSession(
       agentId: input.agentId,
       sessionId: input.sessionId,
       stablePromptHash: input.stablePromptHash ?? null,
+      stablePromptSections: input.stablePromptSections ?? null,
       model: input.model ?? null,
       cwd: input.cwd ?? null,
       lastMessageId: input.lastMessageId ?? null,

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -94,6 +94,12 @@ function migrate(db: SqliteDb): void {
       agent_id        TEXT NOT NULL,
       session_id      TEXT NOT NULL,
       stable_prompt_hash TEXT,
+      -- Per-section digests of the stable prefix inputs behind
+      -- stable_prompt_hash, as JSON (see prompts/stable-sections.ts). Purely
+      -- diagnostic: when the hash moves, diffing this against the current turn
+      -- names WHICH input drifted. Never gates a re-send -- stable_prompt_hash
+      -- stays the only source of truth for that.
+      stable_prompt_sections TEXT,
       -- Resume identity guard: the session is only safe to resume when the
       -- conversation has not changed shape under it. model/cwd are the runtime
       -- identity the upstream session was created with; a change forces a fresh
@@ -366,6 +372,12 @@ function migrate(db: SqliteDb): void {
   const agentSessionCols = db.prepare(`PRAGMA table_info(agent_sessions)`).all() as DbRow[];
   if (agentSessionCols.length > 0 && !agentSessionCols.some((c: DbRow) => c.name === 'stable_prompt_hash')) {
     db.exec(`ALTER TABLE agent_sessions ADD COLUMN stable_prompt_hash TEXT`);
+  }
+  // Drift attribution (see agent_sessions CREATE TABLE comment). Rows written
+  // before this column exists read back null and report `unattributed` for one
+  // turn, then self-heal on the next write.
+  if (agentSessionCols.length > 0 && !agentSessionCols.some((c: DbRow) => c.name === 'stable_prompt_sections')) {
+    db.exec(`ALTER TABLE agent_sessions ADD COLUMN stable_prompt_sections TEXT`);
   }
   // Resume identity guard columns (see agent_sessions CREATE TABLE comment).
   if (agentSessionCols.length > 0 && !agentSessionCols.some((c: DbRow) => c.name === 'model')) {
@@ -1364,6 +1376,7 @@ export function upsertAgentSession(
     agentId: string;
     sessionId: string;
     stablePromptHash?: string | null;
+    stablePromptSections?: string | null;
     model?: string | null;
     cwd?: string | null;
     lastMessageId?: string | null;
@@ -1371,11 +1384,13 @@ export function upsertAgentSession(
 ): void {
   db.prepare(
     `INSERT INTO agent_sessions
-       (conversation_id, agent_id, session_id, stable_prompt_hash, model, cwd, last_message_id, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       (conversation_id, agent_id, session_id, stable_prompt_hash, stable_prompt_sections,
+        model, cwd, last_message_id, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(conversation_id, agent_id)
        DO UPDATE SET session_id = excluded.session_id,
                      stable_prompt_hash = excluded.stable_prompt_hash,
+                     stable_prompt_sections = excluded.stable_prompt_sections,
                      model = excluded.model,
                      cwd = excluded.cwd,
                      last_message_id = excluded.last_message_id,
@@ -1385,6 +1400,7 @@ export function upsertAgentSession(
     input.agentId,
     input.sessionId,
     input.stablePromptHash ?? null,
+    input.stablePromptSections ?? null,
     input.model ?? null,
     input.cwd ?? null,
     input.lastMessageId ?? null,
@@ -1399,13 +1415,15 @@ export function getAgentSessionRecord(
 ): {
   sessionId: string;
   stablePromptHash: string | null;
+  stablePromptSections: string | null;
   model: string | null;
   cwd: string | null;
   lastMessageId: string | null;
 } | null {
   const row = db
     .prepare(
-      `SELECT session_id, stable_prompt_hash, model, cwd, last_message_id FROM agent_sessions
+      `SELECT session_id, stable_prompt_hash, stable_prompt_sections, model, cwd, last_message_id
+         FROM agent_sessions
         WHERE conversation_id = ? AND agent_id = ?`,
     )
     .get(conversationId, agentId) as DbRow | undefined;
@@ -1414,6 +1432,8 @@ export function getAgentSessionRecord(
     sessionId: row.session_id,
     stablePromptHash:
       typeof row.stable_prompt_hash === 'string' ? row.stable_prompt_hash : null,
+    stablePromptSections:
+      typeof row.stable_prompt_sections === 'string' ? row.stable_prompt_sections : null,
     model: typeof row.model === 'string' ? row.model : null,
     cwd: typeof row.cwd === 'string' ? row.cwd : null,
     lastMessageId: typeof row.last_message_id === 'string' ? row.last_message_id : null,

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -92,6 +92,7 @@ interface DaemonRunRecord {
     stablePromptHash: string;
     hit: boolean;
     missReason: string | null;
+    changedSections?: string[] | null;
   };
   clientType?: 'desktop' | 'web' | 'unknown';
   promptTelemetry?: PromptStackTelemetry;

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -279,6 +279,7 @@ export interface TurnInfo {
     stablePromptHash: string;
     hit: boolean;
     missReason: string | null;
+    changedSections?: string[] | null;
   };
 }
 
@@ -1405,6 +1406,7 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
     stablePromptHash: ctx.turn?.promptCache?.stablePromptHash,
     stablePromptCacheHit: ctx.turn?.promptCache?.hit,
     stablePromptCacheMissReason: ctx.turn?.promptCache?.missReason,
+    stablePromptChangedSections: ctx.turn?.promptCache?.changedSections,
     appVersion: ctx.runtime?.appVersion,
     appChannel: ctx.runtime?.appChannel,
     packaged: ctx.runtime?.packaged,

--- a/apps/daemon/src/prompts/stable-sections.ts
+++ b/apps/daemon/src/prompts/stable-sections.ts
@@ -1,0 +1,204 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Attribution for stable-prefix drift.
+ *
+ * A resumed agent session holds the stable instruction prefix (daemon prompt +
+ * tool contract + client system prompt). When any byte of it changes between
+ * turns we must re-send the whole block, which also invalidates the upstream
+ * prompt cache for everything downstream of it — including the conversation
+ * history. `stable_prompt_cache_miss_reason='stable-prompt-changed'` records
+ * THAT this happened; this module records WHICH named input caused it.
+ *
+ * Attribution is computed over the composer's INPUTS rather than by slicing the
+ * composed prompt on its `---` separators. The question a drift event has to
+ * answer is "what caused the prefix to move", and the cause is always an input;
+ * splitting the output would report which bytes differ but still leave the
+ * mapping back to a cause to a human diffing Langfuse traces by hand — which is
+ * the manual step this exists to remove.
+ *
+ * INVARIANT: the sha256 over the whole composed block (`stablePromptHash`) is
+ * the only source of truth for cache hit/miss. Section hashes are attribution
+ * metadata and must never gate a re-send decision — a section-map bug must be
+ * able to mislabel a drift event but never to suppress or fabricate one.
+ */
+
+/**
+ * Every named input that feeds the stable prefix, grouped into the section it
+ * is attributed to. Keys are `composeSystemPrompt` argument names plus the two
+ * inputs the caller merges in (`runtimeToolPrompt`, `clientSystemPrompt`).
+ *
+ * Adding an input to the stable prefix without adding it here does not corrupt
+ * the drift signal: the overall hash still moves and the turn is reported as
+ * `unattributed`, which is the alarm that this table has fallen behind.
+ */
+const SECTION_INPUTS = {
+  // Auto-extracted personal memory. Known to churn WITHIN a session as the
+  // extractor sediments new facts — the dominant first-resume drift cause.
+  memory: ['memoryBody', 'memoryHooks'],
+  // Project intent: artifact kind, fidelity, speaker-notes/animation intent,
+  // plus the derived deck/media/platform signals. Those signals are latched per
+  // conversation (#5709) precisely because re-deriving them per turn flipped
+  // the prefix mid-session; this section is how a regression there stays
+  // visible instead of needing a hand diff of Langfuse traces.
+  intent: [
+    'metadata',
+    'template',
+    'freeformDeckSignal',
+    'mediaHintSignal',
+    'platformHintSignal',
+  ],
+  // Per-conversation mode (design/plan/chat) and the handoff profile.
+  mode: ['sessionMode', 'executionProfile', 'streamFormat'],
+  'design-system': [
+    'designSystemBody',
+    'designSystemTitle',
+    'designSystemUsageMd',
+    'designSystemTokensCss',
+    'designSystemComponentsManifest',
+    'designSystemFixtureHtml',
+    'designSystemPullIndex',
+    'designSystemImportMode',
+  ],
+  skill: ['skillBody', 'skillName', 'skillMode', 'skillModes'],
+  craft: ['craftBody', 'craftSections'],
+  plugin: ['pluginBlock', 'activeStageBlocks'],
+  instructions: ['userInstructions', 'projectInstructions'],
+  locale: ['locale'],
+  media: [
+    'mediaExecution',
+    'byokMediaDefaults',
+    'audioVoiceOptions',
+    'audioVoiceOptionsError',
+  ],
+  critique: ['critique', 'critiqueBrand', 'critiqueSkill'],
+  // Dormant by design: #5336 moved the connected-MCP directive out of the
+  // cached prefix into the per-turn slice, because it reflects live OAuth token
+  // validity and flipped mid-conversation. The key is absent today, so this
+  // section never reports — it exists so that re-admitting that input (or any
+  // future live-token input under this name) is attributed on sight rather than
+  // rediscovered by hand.
+  mcp: ['connectedExternalMcp'],
+  runtime: [
+    'agentId',
+    'includeCodexImagegenOverride',
+    'promptCoreVariant',
+    'runtimeToolPrompt',
+  ],
+  'client-system': ['clientSystemPrompt'],
+} as const satisfies Readonly<Record<string, readonly string[]>>;
+
+export type StableSectionName = keyof typeof SECTION_INPUTS;
+
+export const STABLE_SECTION_NAMES = Object.keys(SECTION_INPUTS) as StableSectionName[];
+
+/** Section name -> short digest of that section's inputs for one turn. */
+export type StableSectionHashes = Readonly<Partial<Record<StableSectionName, string>>>;
+
+/**
+ * `unattributed` means the composed prefix changed but no tracked section did:
+ * the input that moved is missing from SECTION_INPUTS. It is a coverage gap
+ * report, not a drift cause.
+ */
+export type StableChangedSection = StableSectionName | 'unattributed';
+
+/**
+ * JSON with object keys sorted at every level, so two structurally equal inputs
+ * hash equal regardless of the order their keys were built in.
+ */
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, val: unknown) => {
+    if (val === null || typeof val !== 'object' || Array.isArray(val)) return val;
+    return Object.fromEntries(
+      Object.entries(val as Record<string, unknown>).sort(([a], [b]) =>
+        a < b ? -1 : a > b ? 1 : 0,
+      ),
+    );
+  });
+}
+
+/**
+ * 64-bit digest. These are only ever compared for equality against another
+ * digest of the same input shape, so a full sha256 would spend storage and
+ * event payload on collision resistance nothing here needs.
+ */
+function digest(value: unknown): string {
+  return createHash('sha256').update(stableStringify(value), 'utf8').digest('hex').slice(0, 16);
+}
+
+/**
+ * Hash each section of the stable prefix from the composer inputs.
+ *
+ * A section whose inputs are all absent is omitted rather than hashed as empty,
+ * so a section appearing or disappearing between turns (memory extracted for
+ * the first time, a design system detached) reads as a change.
+ */
+export function computeStableSectionHashes(
+  inputs: Readonly<Record<string, unknown>>,
+): StableSectionHashes {
+  const hashes: Partial<Record<StableSectionName, string>> = {};
+  for (const section of STABLE_SECTION_NAMES) {
+    const present = SECTION_INPUTS[section].filter((key) => inputs[key] !== undefined);
+    if (present.length === 0) continue;
+    hashes[section] = digest(present.map((key) => [key, inputs[key]]));
+  }
+  return hashes;
+}
+
+/**
+ * Sections whose hash differs between the seeding turn and this turn, in
+ * declaration order.
+ *
+ * Returns an empty list when nothing tracked moved. Callers that already know
+ * the overall prefix changed should read that emptiness as `unattributed`
+ * rather than as "no drift" — see `describeChangedStableSections`.
+ */
+export function diffStableSections(
+  storedSections: StableSectionHashes | null | undefined,
+  currentSections: StableSectionHashes,
+): StableSectionName[] {
+  const stored = storedSections ?? {};
+  return STABLE_SECTION_NAMES.filter((name) => stored[name] !== currentSections[name]);
+}
+
+/**
+ * The changed-section list to report for a turn already known to have drifted.
+ *
+ * Never returns an empty list: a drift we cannot attribute is reported as
+ * `unattributed` so the coverage gap shows up in telemetry instead of looking
+ * like a clean turn.
+ */
+export function describeChangedStableSections(
+  storedSections: StableSectionHashes | null | undefined,
+  currentSections: StableSectionHashes,
+): StableChangedSection[] {
+  const changed = diffStableSections(storedSections, currentSections);
+  return changed.length > 0 ? changed : ['unattributed'];
+}
+
+/** Serialize for the `agent_sessions.stable_prompt_sections` column. */
+export function serializeStableSections(sections: StableSectionHashes): string {
+  return JSON.stringify(sections);
+}
+
+/**
+ * Parse a stored section map. Unknown or malformed entries are dropped rather
+ * than thrown on: a row written by a newer/older daemon must degrade to
+ * `unattributed`, never break the turn.
+ */
+export function parseStableSections(raw: unknown): StableSectionHashes | null {
+  if (typeof raw !== 'string' || raw.length === 0) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  const hashes: Partial<Record<StableSectionName, string>> = {};
+  for (const name of STABLE_SECTION_NAMES) {
+    const value = (parsed as Record<string, unknown>)[name];
+    if (typeof value === 'string' && value.length > 0) hashes[name] = value;
+  }
+  return hashes;
+}

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -173,6 +173,7 @@ interface ChatRun {
     stablePromptHash?: string;
     hit?: boolean;
     missReason?: string | null;
+    changedSections?: string[] | null;
   };
 }
 
@@ -1197,6 +1198,11 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
             stable_prompt_hash: run.promptCache?.stablePromptHash,
             stable_prompt_cache_hit: run.promptCache?.hit,
             stable_prompt_cache_miss_reason: run.promptCache?.missReason,
+            // Which stable-prefix input drifted, for miss_reason
+            // 'stable-prompt-changed' only. `unattributed` means the prefix
+            // moved but no tracked section did — a coverage gap in
+            // prompts/stable-sections.ts, not a cause.
+            stable_prompt_changed_sections: run.promptCache?.changedSections ?? undefined,
             area: isDesignSystemRun ? 'design_system_generation' : 'chat_panel',
             result,
             ...(activationMilestones ? { $set_once: activationMilestones } : {}),

--- a/apps/daemon/src/runtimes/chat-prompt-inputs.ts
+++ b/apps/daemon/src/runtimes/chat-prompt-inputs.ts
@@ -7,6 +7,11 @@ import {
   shouldRenderCodexImagegenOverride,
 } from '../prompts/system.js';
 import { renderResearchCommandContract } from '../prompts/research-contract.js';
+import {
+  describeChangedStableSections,
+  type StableChangedSection,
+  type StableSectionHashes,
+} from '../prompts/stable-sections.js';
 
 export const MAX_CHAT_IMAGE_BYTES = 1024 * 1024;
 export const UPLOAD_DIR = path.join(os.tmpdir(), 'od-uploads');
@@ -390,20 +395,26 @@ export function describeStablePromptCache({
   isResuming,
   storedStablePromptHash,
   currentStableHash,
+  storedStableSections,
+  currentStableSections,
 }: {
   isResuming: boolean;
   storedStablePromptHash: string | null;
   currentStableHash: string;
+  storedStableSections?: StableSectionHashes | null;
+  currentStableSections?: StableSectionHashes | null;
 }): {
   stablePromptHash: string;
   hit: boolean;
   missReason: StablePromptCacheMissReason;
+  changedSections: StableChangedSection[] | null;
 } {
   if (!isResuming) {
     return {
       stablePromptHash: currentStableHash,
       hit: false,
       missReason: 'new-session',
+      changedSections: null,
     };
   }
   if (storedStablePromptHash === currentStableHash) {
@@ -411,14 +422,22 @@ export function describeStablePromptCache({
       stablePromptHash: currentStableHash,
       hit: true,
       missReason: null,
+      changedSections: null,
     };
   }
+  const missReason: StablePromptCacheMissReason = storedStablePromptHash === null
+    ? 'missing-stored-hash'
+    : 'stable-prompt-changed';
   return {
     stablePromptHash: currentStableHash,
     hit: false,
-    missReason: storedStablePromptHash === null
-      ? 'missing-stored-hash'
-      : 'stable-prompt-changed',
+    missReason,
+    // Attribute only real drift. `missing-stored-hash` is a legacy/again-seeded
+    // row with no baseline to diff against, so naming sections there would
+    // report the whole map as "changed" and drown the signal we care about.
+    changedSections: missReason === 'stable-prompt-changed' && currentStableSections
+      ? describeChangedStableSections(storedStableSections, currentStableSections)
+      : null,
   };
 }
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -28,6 +28,11 @@ import {
   renderConnectedExternalMcpDirective,
   resolveExclusiveSurface,
 } from './prompts/system.js';
+import {
+  computeStableSectionHashes,
+  serializeStableSections,
+  type StableSectionHashes,
+} from './prompts/stable-sections.js';
 import { emittedRenderableQuestionForm } from './question-form-detect.js';
 import { resolveProjectRoot } from './project-root.js';
 import {
@@ -4025,7 +4030,11 @@ export async function startServer({
       }
     }
 
-    const prompt = composeSystemPrompt({
+    // Hoisted verbatim out of the composeSystemPrompt() call so the exact same
+    // object both composes the prompt and feeds section-level drift
+    // attribution — a second, hand-maintained copy of these inputs would drift
+    // from the real ones and mislabel the telemetry it exists to explain.
+    const systemPromptInputs = {
       agentId,
       includeCodexImagegenOverride: false,
       skillBody,
@@ -4079,7 +4088,8 @@ export async function startServer({
       // restores the classic stack. main keeps classic as the default —
       // do NOT carry this flip into a PR against main.
       promptCoreVariant: process.env.OD_PROMPT_CORE === 'classic' ? undefined : 'slim',
-    });
+    };
+    const prompt = composeSystemPrompt(systemPromptInputs);
     // The chat handler also needs to know where the active skill lives
     // on disk so it can stage a per-project copy of its side files
     // before spawning the agent. Returning that here avoids a second
@@ -4104,6 +4114,10 @@ export async function startServer({
           .filter((part) => typeof part === 'string' && part.trim().length > 0)
           .join('\n\n---\n\n'),
       },
+      // Diagnostic only. The caller merges its own stable inputs
+      // (runtimeToolPrompt, the client system prompt) in before hashing, so the
+      // section map covers the whole fingerprint rather than just this half.
+      stableSectionInputs: systemPromptInputs,
     };
   };
 
@@ -4588,6 +4602,7 @@ export async function startServer({
       critiqueShouldRun,
       designSystemSelection,
       promptTelemetryParts,
+      stableSectionInputs,
     } =
       await composeDaemonSystemPrompt({
         agentId,
@@ -4904,7 +4919,7 @@ export async function startServer({
             currentCwd: effectiveCwd,
             currentAssistantMessageId: run.assistantMessageId ?? null,
           })
-        : { storedSessionId: null as string | null, resumeSessionId: null as string | null, newSessionId: undefined as string | undefined, isResuming: false, storedStablePromptHash: null as string | null, invalidationReason: null };
+        : { storedSessionId: null as string | null, resumeSessionId: null as string | null, newSessionId: undefined as string | undefined, isResuming: false, storedStablePromptHash: null as string | null, storedStableSections: null as StableSectionHashes | null, invalidationReason: null };
     const publishNativeSessionRecoveryMetadata = () => {
       if (!run.nativeSessionRecovery) return;
       design.runs.emit(run, 'diagnostic', {
@@ -4942,6 +4957,14 @@ export async function startServer({
       .map((part) => (typeof part === 'string' ? part.trim() : ''))
       .join('\n\n---\n\n');
     const currentStableHash = hashStableInstructions(stableInstructionFingerprint);
+    // Per-section digests of the SAME inputs the fingerprint is built from, so a
+    // drift event can name which one moved. `currentStableHash` above stays the
+    // sole re-send decider — these only label a decision already made.
+    const currentStableSections = computeStableSectionHashes({
+      ...(stableSectionInputs ?? {}),
+      runtimeToolPrompt,
+      clientSystemPrompt: systemPrompt,
+    });
     // `runtimeToolPrompt` is part of the fingerprint and varies only when the
     // tool-token grant's presence flips between turns (rare cwd/projectId edge
     // cases); any such change correctly forces a full re-send that turn.
@@ -4954,7 +4977,10 @@ export async function startServer({
       isResuming: agentResumeCtx.isResuming,
       storedStablePromptHash: agentResumeCtx.storedStablePromptHash,
       currentStableHash,
+      storedStableSections: agentResumeCtx.storedStableSections,
+      currentStableSections,
     });
+    const currentStableSectionsJson = serializeStableSections(currentStableSections);
     const browserUsePromptGuard = renderBrowserUseUnavailablePrompt(run.browserUse ?? null);
     const titleGenerationRequested =
       titleGeneration &&
@@ -5462,6 +5488,7 @@ export async function startServer({
           agentId: def.id,
           sessionId: liveSessionId,
           stablePromptHash: currentStableHash,
+          stablePromptSections: currentStableSectionsJson,
           model: safeModel ?? null,
           cwd: effectiveCwd,
           lastMessageId: run.assistantMessageId ?? null,
@@ -5973,6 +6000,7 @@ export async function startServer({
             agentId: def.id,
             sessionId: createTurnSessionId,
             stablePromptHash: currentStableHash,
+            stablePromptSections: currentStableSectionsJson,
             model: safeModel ?? null,
             cwd: effectiveCwd,
             lastMessageId: run.assistantMessageId ?? null,
@@ -5999,6 +6027,7 @@ export async function startServer({
             agentId: def.id,
             sessionId: agentResumeCtx.resumeSessionId,
             stablePromptHash: currentStableHash,
+            stablePromptSections: currentStableSectionsJson,
             model: safeModel ?? null,
             cwd: effectiveCwd,
             lastMessageId: run.assistantMessageId ?? null,
@@ -7866,6 +7895,7 @@ export async function startServer({
             agentId: def.id,
             sessionId: sessionPath,
             stablePromptHash: currentStableHash,
+            stablePromptSections: currentStableSectionsJson,
             model: safeModel ?? null,
             cwd: effectiveCwd,
             lastMessageId: run.assistantMessageId ?? null,
@@ -7895,6 +7925,7 @@ export async function startServer({
           agentId: def.id,
           sessionId: acpSession.getDurableSessionId(),
           stablePromptHash: currentStableHash,
+          stablePromptSections: currentStableSectionsJson,
           model: safeModel ?? null,
           cwd: effectiveCwd,
           lastMessageId: run.assistantMessageId ?? null,

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -3553,6 +3553,7 @@ describe('chat prompt helpers', () => {
       stablePromptHash: 'hash-a',
       hit: false,
       missReason: 'new-session',
+      changedSections: null,
     });
 
     expect(describeStablePromptCache({
@@ -3563,6 +3564,7 @@ describe('chat prompt helpers', () => {
       stablePromptHash: 'hash-a',
       hit: true,
       missReason: null,
+      changedSections: null,
     });
 
     expect(describeStablePromptCache({
@@ -3573,6 +3575,55 @@ describe('chat prompt helpers', () => {
       stablePromptHash: 'hash-b',
       hit: false,
       missReason: 'stable-prompt-changed',
+      // No section map supplied: report no attribution rather than invent one.
+      changedSections: null,
+    });
+  });
+
+  it('names the drifted sections when a section map is supplied', () => {
+    expect(describeStablePromptCache({
+      isResuming: true,
+      storedStablePromptHash: 'hash-a',
+      currentStableHash: 'hash-b',
+      storedStableSections: { memory: 'm1', skill: 's1' },
+      currentStableSections: { memory: 'm2', skill: 's1' },
+    })).toEqual({
+      stablePromptHash: 'hash-b',
+      hit: false,
+      missReason: 'stable-prompt-changed',
+      changedSections: ['memory'],
+    });
+  });
+
+  it('reports unattributed drift when the prefix moved but no tracked section did', () => {
+    // The hash is the source of truth, so this is a real miss; an empty list
+    // would read as a drift with no cause instead of the coverage gap it is.
+    expect(describeStablePromptCache({
+      isResuming: true,
+      storedStablePromptHash: 'hash-a',
+      currentStableHash: 'hash-b',
+      storedStableSections: { memory: 'm1' },
+      currentStableSections: { memory: 'm1' },
+    })).toMatchObject({
+      missReason: 'stable-prompt-changed',
+      changedSections: ['unattributed'],
+    });
+  });
+
+  it('does not attribute sections for a missing stored hash', () => {
+    // A legacy/reseeded row has no baseline to diff, so every section would
+    // read as "changed" and drown the signal real drift carries.
+    expect(describeStablePromptCache({
+      isResuming: true,
+      storedStablePromptHash: null,
+      currentStableHash: 'hash-b',
+      storedStableSections: null,
+      currentStableSections: { memory: 'm1' },
+    })).toEqual({
+      stablePromptHash: 'hash-b',
+      hit: false,
+      missReason: 'missing-stored-hash',
+      changedSections: null,
     });
   });
 

--- a/apps/daemon/tests/intent-signal-stable-prompt-cache.test.ts
+++ b/apps/daemon/tests/intent-signal-stable-prompt-cache.test.ts
@@ -5,7 +5,12 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { readMemoryConfig, writeMemoryConfig } from '../src/memory.js';
+import {
+  deleteMemoryEntry,
+  readMemoryConfig,
+  upsertMemoryEntry,
+  writeMemoryConfig,
+} from '../src/memory.js';
 import { startServer } from '../src/server.js';
 
 // Stable-prompt cache regression for the intent-signal hotfix
@@ -30,7 +35,11 @@ type RunStatus = { id: string; status: string; error: string | null };
 
 type RunWithPromptCache = {
   id: string;
-  promptCache?: { hit: boolean; missReason: string | null };
+  promptCache?: {
+    hit: boolean;
+    missReason: string | null;
+    changedSections?: string[] | null;
+  };
 };
 
 const SESSION = 'ses_intentsignal0001';
@@ -79,6 +88,7 @@ describe('intent signals × stable prompt cache', () => {
   let started: StartedServer | null = null;
   let binDir: string | null = null;
   let originalMemoryConfig: Awaited<ReturnType<typeof readMemoryConfig>> | null = null;
+  const createdMemoryIds: string[] = [];
 
   afterEach(async () => {
     await Promise.resolve(started?.shutdown?.());
@@ -88,6 +98,14 @@ describe('intent signals × stable prompt cache', () => {
     started = null;
     if (binDir) await rm(binDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
     binDir = null;
+    // OD_DATA_DIR is shared by every test file in this Vitest process, so a
+    // memory entry left behind here would silently join the personal-memory
+    // block of unrelated suites.
+    if (process.env.OD_DATA_DIR) {
+      for (const id of createdMemoryIds.splice(0)) {
+        await deleteMemoryEntry(process.env.OD_DATA_DIR, id);
+      }
+    }
     if (process.env.OD_DATA_DIR && originalMemoryConfig) {
       await writeMemoryConfig(process.env.OD_DATA_DIR, {
         enabled: originalMemoryConfig.enabled,
@@ -98,16 +116,41 @@ describe('intent signals × stable prompt cache', () => {
     restoreEnv(originalEnv);
   });
 
-  async function bootServer(): Promise<{ url: string }> {
+  /**
+   * Land a fact in the personal-memory store the way the extractor would, but
+   * deterministically. `extraction` stays null so no model-driven extraction
+   * competes with what the test wrote.
+   */
+  async function addMemoryEntry(input: {
+    name: string;
+    description: string;
+    type: string;
+    body: string;
+  }): Promise<void> {
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR must be set for this suite');
+    const entry = await upsertMemoryEntry(dataDir, input, { silent: true, source: 'manual' });
+    createdMemoryIds.push(entry.id);
+  }
+
+  async function bootServer({ memoryEnabled = false }: { memoryEnabled?: boolean } = {}): Promise<{
+    url: string;
+  }> {
     binDir = await mkdtemp(path.join(os.tmpdir(), 'od-intent-cache-bin-'));
     const bin = await writeResumingOpencode(binDir);
     clearTelemetryEnv();
     // Memory auto-extraction folds prior form answers into the stable-region
     // "Personal memory" block, which legitimately changes the stable hash —
     // disable it so the assertions isolate the intent-signal contribution.
+    // `memoryEnabled` turns the block back on for the tests that assert on
+    // memory attribution itself; `extraction` stays null either way so only
+    // what the test writes can move the block.
     if (process.env.OD_DATA_DIR) {
       originalMemoryConfig = await readMemoryConfig(process.env.OD_DATA_DIR);
-      await writeMemoryConfig(process.env.OD_DATA_DIR, { enabled: false, extraction: null });
+      await writeMemoryConfig(process.env.OD_DATA_DIR, {
+        enabled: memoryEnabled,
+        extraction: null,
+      });
     }
     started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
     await putConfig(started.url, {
@@ -167,6 +210,10 @@ describe('intent signals × stable prompt cache', () => {
     expect(await runPromptCache(url, conversationId, turn2.id)).toMatchObject({
       hit: false,
       missReason: 'stable-prompt-changed',
+      // The deck signal is the only thing that moved, so attribution must name
+      // `intent` alone. A wider list would mean the section map cannot isolate
+      // a cause; `unattributed` would mean it missed this input entirely.
+      changedSections: ['intent'],
     });
 
     // t3 has no deck vocabulary of its own; the conversation latch must hold
@@ -178,6 +225,71 @@ describe('intent signals × stable prompt cache', () => {
     });
     expect(turn3.status).toBe('succeeded');
     expect(await runPromptCache(url, conversationId, turn3.id)).toMatchObject({ hit: true });
+  });
+
+  // Drift attribution (prompts/stable-sections.ts). `stable-prompt-changed`
+  // says only THAT the cached prefix moved; these assert it also says WHICH
+  // input moved, which is what makes a drift actionable without hand-diffing
+  // Langfuse prompts. Memory is the case that matters most: it is the dominant
+  // cause of first-resume drift in production.
+  it('attributes a mid-conversation memory change to the memory section alone', async () => {
+    const { url } = await bootServer({ memoryEnabled: true });
+    const { projectId, conversationId } = await createFreeformProject(url);
+
+    const turn1 = await sendRunAndWait(url, projectId, conversationId, {
+      message: `## user\n${TURN1_BRIEF}`,
+      currentPrompt: TURN1_BRIEF,
+    });
+    expect(turn1.status).toBe('succeeded');
+
+    // A fact lands in the store after the session was seeded, exactly as the
+    // extractor does mid-conversation in production.
+    await addMemoryEntry({
+      name: 'Tone preference',
+      description: 'prefers terse copy',
+      type: 'user',
+      body: 'Writes in short declarative sentences.',
+    });
+
+    // A follow-up with no deck/media/platform vocabulary of its own, so no
+    // intent signal may flip: `memory` has to be the ONLY named section. A
+    // wider list here would mean the map cannot isolate a cause, and
+    // `unattributed` would mean it missed the memory input entirely.
+    const followUp = 'make the header a bit bolder';
+    const turn2 = await sendRunAndWait(url, projectId, conversationId, {
+      message: `## user\n${followUp}`,
+      currentPrompt: followUp,
+    });
+    expect(turn2.status).toBe('succeeded');
+    expect(await runPromptCache(url, conversationId, turn2.id)).toMatchObject({
+      hit: false,
+      missReason: 'stable-prompt-changed',
+      changedSections: ['memory'],
+    });
+  });
+
+  it('names no sections on a cache hit', async () => {
+    const { url } = await bootServer();
+    const { projectId, conversationId } = await createFreeformProject(url);
+
+    const turn1 = await sendRunAndWait(url, projectId, conversationId, {
+      message: `## user\n${TURN1_BRIEF}`,
+      currentPrompt: TURN1_BRIEF,
+    });
+    expect(turn1.status).toBe('succeeded');
+
+    const followUp = 'make the header a bit bolder';
+    const turn2 = await sendRunAndWait(url, projectId, conversationId, {
+      message: `## user\n${followUp}`,
+      currentPrompt: followUp,
+    });
+    expect(turn2.status).toBe('succeeded');
+    // Attribution must stay silent when nothing drifted — an empty-but-present
+    // list would read in telemetry as a drift with no cause.
+    expect(await runPromptCache(url, conversationId, turn2.id)).toMatchObject({
+      hit: true,
+      changedSections: null,
+    });
   });
 });
 
@@ -268,7 +380,9 @@ async function runPromptCache(
   url: string,
   conversationId: string,
   runId: string,
-): Promise<{ hit: boolean; missReason: string | null } | undefined> {
+): Promise<
+  { hit: boolean; missReason: string | null; changedSections?: string[] | null } | undefined
+> {
   const response = await fetch(
     `${url}/api/runs?conversationId=${encodeURIComponent(conversationId)}`,
   );

--- a/apps/daemon/tests/prompts/stable-sections.test.ts
+++ b/apps/daemon/tests/prompts/stable-sections.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeStableSectionHashes,
+  describeChangedStableSections,
+  diffStableSections,
+  parseStableSections,
+  serializeStableSections,
+  STABLE_SECTION_NAMES,
+} from '../../src/prompts/stable-sections.js';
+
+// A minimal set of inputs standing in for one turn's stable prefix. Only the
+// keys a section actually reads matter; everything else is ignored by design so
+// adding an unrelated composer argument cannot silently join a section.
+const BASE = {
+  agentId: 'claude',
+  memoryBody: '## Personal memory\n\n- prefers terse copy',
+  sessionMode: 'design',
+  designSystemBody: '# Acme\n\n- primary: #000',
+  skillBody: '# Skill\n\nbuild a deck',
+  locale: 'en',
+  runtimeToolPrompt: '## Tools\n\n- od_read',
+  clientSystemPrompt: 'be helpful',
+};
+
+describe('computeStableSectionHashes', () => {
+  it('is deterministic for the same inputs', () => {
+    expect(computeStableSectionHashes(BASE)).toEqual(computeStableSectionHashes({ ...BASE }));
+  });
+
+  it('ignores the order keys were built in', () => {
+    const reordered = Object.fromEntries(Object.entries(BASE).reverse());
+    expect(computeStableSectionHashes(reordered)).toEqual(computeStableSectionHashes(BASE));
+  });
+
+  it('hashes nested objects by value, not by key insertion order', () => {
+    const a = { ...BASE, metadata: { kind: 'deck', fidelity: 'high' } };
+    const b = { ...BASE, metadata: { fidelity: 'high', kind: 'deck' } };
+    expect(computeStableSectionHashes(a).intent).toBe(computeStableSectionHashes(b).intent);
+  });
+
+  it('omits a section whose inputs are all absent rather than hashing it as empty', () => {
+    const hashes = computeStableSectionHashes({ memoryBody: 'x' });
+    expect(hashes.memory).toBeTypeOf('string');
+    expect(hashes).not.toHaveProperty('design-system');
+    expect(hashes).not.toHaveProperty('critique');
+  });
+
+  it('leaves the mcp section dormant: #5336 removed that input from the prefix', () => {
+    // The section exists to catch a live-OAuth input being re-admitted to the
+    // cached prefix. Nothing passes `connectedExternalMcp` today, so it must
+    // stay absent — a hash here would mean the mistake is back.
+    expect(computeStableSectionHashes(BASE)).not.toHaveProperty('mcp');
+    expect(computeStableSectionHashes({ ...BASE, connectedExternalMcp: [{ id: 'github' }] }))
+      .toHaveProperty('mcp');
+  });
+});
+
+describe('diffStableSections', () => {
+  it('names only the section whose input moved', () => {
+    const before = computeStableSectionHashes(BASE);
+    const after = computeStableSectionHashes({ ...BASE, memoryBody: `${BASE.memoryBody}\n- likes dark mode` });
+    expect(diffStableSections(before, after)).toEqual(['memory']);
+  });
+
+  it('names every section that moved, in declaration order', () => {
+    const before = computeStableSectionHashes(BASE);
+    const after = computeStableSectionHashes({
+      ...BASE,
+      memoryBody: 'changed',
+      sessionMode: 'plan',
+      designSystemBody: 'changed',
+    });
+    expect(diffStableSections(before, after)).toEqual(['memory', 'mode', 'design-system']);
+  });
+
+  it('treats a section appearing for the first time as a change', () => {
+    const before = computeStableSectionHashes({ agentId: 'claude' });
+    const after = computeStableSectionHashes({ agentId: 'claude', memoryBody: 'first fact' });
+    expect(diffStableSections(before, after)).toEqual(['memory']);
+  });
+
+  it('treats a section disappearing as a change', () => {
+    const before = computeStableSectionHashes({ agentId: 'claude', memoryBody: 'a fact' });
+    const after = computeStableSectionHashes({ agentId: 'claude' });
+    expect(diffStableSections(before, after)).toEqual(['memory']);
+  });
+
+  it('reports nothing when the inputs are unchanged', () => {
+    const hashes = computeStableSectionHashes(BASE);
+    expect(diffStableSections(hashes, hashes)).toEqual([]);
+  });
+
+  it('treats a missing baseline as everything-changed', () => {
+    expect(diffStableSections(null, computeStableSectionHashes(BASE)).length).toBeGreaterThan(0);
+  });
+});
+
+describe('describeChangedStableSections', () => {
+  it('reports the changed section for an attributable drift', () => {
+    const before = computeStableSectionHashes(BASE);
+    const after = computeStableSectionHashes({ ...BASE, skillBody: 'a different skill' });
+    expect(describeChangedStableSections(before, after)).toEqual(['skill']);
+  });
+
+  it('reports `unattributed` when the prefix drifted but no tracked section did', () => {
+    // The caller only asks once the overall hash already moved, so "nothing
+    // changed" can only mean the input that moved is missing from the section
+    // table — a coverage gap that has to be visible, not silently clean.
+    const hashes = computeStableSectionHashes(BASE);
+    expect(describeChangedStableSections(hashes, hashes)).toEqual(['unattributed']);
+  });
+});
+
+describe('serializeStableSections / parseStableSections', () => {
+  it('round-trips', () => {
+    const hashes = computeStableSectionHashes(BASE);
+    expect(parseStableSections(serializeStableSections(hashes))).toEqual(hashes);
+  });
+
+  it('reads a legacy row with no stored sections as null', () => {
+    expect(parseStableSections(null)).toBeNull();
+    expect(parseStableSections('')).toBeNull();
+  });
+
+  it('degrades to null on malformed JSON instead of throwing', () => {
+    // A row written by another daemon build must never break the turn.
+    expect(parseStableSections('{not json')).toBeNull();
+    expect(parseStableSections('[]')).toBeNull();
+    expect(parseStableSections('"a string"')).toBeNull();
+  });
+
+  it('drops entries that are not known sections with string digests', () => {
+    const parsed = parseStableSections(
+      JSON.stringify({ memory: 'abc123', unknownSection: 'def', mode: 42 }),
+    );
+    expect(parsed).toEqual({ memory: 'abc123' });
+  });
+});
+
+describe('section table', () => {
+  it('covers the sections the drift investigation asked for', () => {
+    // Minimum split agreed in the 0.14.1 drift investigation, so telemetry can
+    // answer "which part moved" without a hand diff of Langfuse prompts.
+    for (const name of ['memory', 'intent', 'mode', 'design-system', 'skill', 'runtime']) {
+      expect(STABLE_SECTION_NAMES).toContain(name);
+    }
+  });
+});


### PR DESCRIPTION
## Why

**My use case.** I was following up on the 0.14.1 prompt-cache drift investigation (a colleague's write-up + the drift dashboard I built for #622). Both stall at the same wall: `stable_prompt_cache_miss_reason='stable-prompt-changed'` tells us **that** the cached prefix moved, but never **which** input moved. Every diagnosis so far has been a human pairing Langfuse traces and eyeballing two multi-KB prompts for a diff. That does not scale, and it is the concrete blocker on driving drift down.

**The pain.** Drift is real, large, and worsening every release. AMR, from PostHog:

| | 07-09 | 07-16 |
|---|---|---|
| drift events | 77 | **1,032** |
| eligible resume turns | 506 | 2,583 |
| drift rate | 15.2% | **40.0%** |

Absolute drift grew 13.4×: traffic 5.1× × rate 2.6×. Both are real — the rate alone went 15.2% → 40.0%. It worsens monotonically per release: `0.13.0 20.2% → 0.14.0 26.0% → 0.14.1 37.7% → 0.15.0 50.5%`.

And it is not an AMR story. Over 30 days, by drift rate on resume turns: **codex_cli 52.2%, opencode 40.3%, claude_code 36.6%, amr 34.0%** — AMR is the *best* of the four and only ~5.6% of the ~132k total drift events. (The other 15 runtimes are structurally 0: only native-resume runtimes can report drift at all.)

The part that decides scope: over 14 days on AMR, **later-resume turns (turn ≥2) carry 4,812 of 6,828 drift events — 71% of the total**, despite a much lower rate (27.0% vs 67.2%) than first-resume's smaller base. First-resume drift has a known story (memory extraction sediments new facts mid-session). **Nothing in today's telemetry can say what drives the other 4,812.** This PR is what makes that question answerable.

This is instrumentation, deliberately not a fix. It ships no behavior change so it can land fast and start collecting; the actual remediations (freezing the memory snapshot at session start being the big one) need that attribution to be targeted and to be verifiable afterwards.

## What users will see

Nothing. No UI, no CLI, no prompt bytes, no model-visible change. This adds one diagnostic property to an existing analytics event and one nullable SQLite column.

Two notes for reviewers, since both are questions this PR invites:

1. **The prompt is byte-identical.** The only prompt-adjacent change is hoisting the existing `composeSystemPrompt({...})` argument literal into a `const` and passing it — so one object both composes the prompt and feeds attribution, instead of a second hand-maintained copy that would drift from the real inputs and mislabel the very telemetry it exists to explain. The literal is unchanged. See Validation for how this is proven rather than asserted (the obvious guard — the system-prompt snapshot suite — is already red on `main`, so it could not carry the claim on its own).
2. **No CLI surface.** AGENTS.md's UI/CLI dual-track rule covers user-facing capabilities. This is internal instrumentation on an existing event — there is no capability for `od` to expose.

## Surface area

- [x] **Default behavior change** — additive nullable SQLite column `agent_sessions.stable_prompt_sections`, guarded by the existing `PRAGMA table_info` migration pattern. Old rows read back null and report `unattributed` for exactly one turn, then self-heal on the next write. No backfill, no downgrade hazard (an older daemon ignores the column).
- [ ] UI / Keyboard shortcut / CLI / env var / API / contract / Extension point / i18n / New top-level dependency

## Design

Attribution is computed over the composer's **inputs**, not by slicing the composed prompt on its `---` separators. A drift event has to answer *"what caused the prefix to move"*, and the cause is always an input — splitting the output would report which bytes differ but still leave the mapping back to a cause to a human reading Langfuse, which is the manual step this exists to remove. It also means zero risk of touching prompt assembly.

`prompts/stable-sections.ts` holds one table mapping each composer argument to its section (`memory`, `intent`, `mode`, `design-system`, `skill`, `craft`, `plugin`, `instructions`, `locale`, `media`, `critique`, `mcp`, `runtime`, `client-system`) — covering the `memory / intent / mode / design-system / skill / runtime` split the investigation asked for.

Two properties worth calling out:

- **`stablePromptHash` stays the only source of truth for hit/miss.** Section hashes never gate a re-send. A bug in the section table can mislabel a drift event but can never suppress or fabricate one.
- **`unattributed` is a designed outcome, not a failure mode.** If the prefix moves and no tracked section did, the input that moved is missing from the table. That is a coverage-gap alarm rather than a silently clean turn — and its rate tells us how good our coverage is. This is what makes the design self-validating: adding a future input to the stable prefix without registering it here shows up in telemetry instead of hiding.

The `mcp` section is deliberately dormant: #5336 moved `connectedExternalMcp` out of the cached prefix (it reflects live OAuth token validity and flipped mid-conversation). Nothing passes that key today, so the section never reports — it exists so re-admitting a live-token input is attributed on sight rather than rediscovered by hand a third time. `memory`, `intent`, and MCP tokens are three instances of one disease: live per-turn state ending up in a prefix that is supposed to be stable.

## Bug fix verification

Not a bug fix (instrumentation), but the e2e assertions are falsifiable and were verified as load-bearing rather than assumed:

- `apps/daemon/tests/intent-signal-stable-prompt-cache.test.ts` — real daemon, real session resume, real drift:
  - a genuine deck-intent flip → `changedSections: ['intent']`
  - a memory entry landing mid-conversation → `changedSections: ['memory']` **and nothing else** (the follow-up carries no deck/media/platform vocabulary, so attribution must isolate one cause)
  - a cache hit → `changedSections: null`
- **Mutation-tested.** Moving `memoryBody` out of the `memory` section turns the memory test red (`changedSections` stops being `['memory']`). The assertions read real production-path data — they are not vacuously green.

## Adjacent issues

Found while working here, deliberately **not** fixed in this PR to keep the diff's answer to "did you change the prompt?" an unambiguous no:

- `apps/daemon/src/server.ts` carries a stale comment above `promptCoreVariant`: *"VALIDATION DEFAULT — feat/system-prompt integration branch only … main keeps classic as the default — do NOT carry this flip into a PR against main."* #5603 intentionally landed slim as the default charter on main, so the code is right and the comment now tells the next reader the opposite of the truth. Comment-only fix, worth its own PR.
- The drift dashboard's alert (mine) fires on absolute daily count `>150`, which the investigation correctly flags as traffic-sensitive. Fixed on the dashboard side, not here: ratio as the regression signal, absolute retained as the scoreboard (the goal is 0, and 0 does not scale with traffic).
- **The dashboard's `eligible` denominator was wrong, and I fixed it while writing this up.** `stable_prompt_cache_miss_reason != 'new-session'` also matches turns from builds predating this telemetry (≤0.11.0 — 35k AMR turns per 30d), where the property is simply absent. Counting those as eligible inflated every denominator ~2.5× and understated drift accordingly (AMR read 12.7% when it is 34.0%). The honest marker is `stable_prompt_cache_hit is set`, which is present iff the daemon computed a cache decision. The figures in this PR are the corrected ones. This is a query-side fix only — no code change — but it is worth knowing that published drift rates before today were low by ~2.5×.

## Validation

- `pnpm guard` — 86/86 pass
- `pnpm --filter @open-design/daemon typecheck` — clean
- `pnpm --filter @open-design/daemon test` — full daemon suite: **7 failed | 5846 passed | 6 skipped**
- `apps/daemon/tests/prompts/stable-sections.test.ts` — 18 new unit tests (determinism, key-order independence, section isolation, appearing/disappearing sections, `unattributed`, malformed-row degradation)
- `apps/daemon/tests/chat-route.test.ts` — `describeStablePromptCache`'s existing case updated for the new field, plus 3 new cases (named sections, `unattributed`, no attribution without a baseline)

**Byte-identity of the prompt, proven not asserted.** The natural guard, `tests/prompts/system-prompt-matrix.test.ts` → *"keeps the section gating matrix stable across scenarios"*, is **already failing on `main`** (stale snapshot, pre-dates this branch), so a green run could not have carried the claim. Instead I compared the snapshot mismatch output itself between baseline and this branch: **271 lines, byte-for-byte identical**. The hoist changes no prompt bytes. (Refreshing that stale snapshot is main's problem, not this PR's — touching it here would be exactly the prompt change this PR must be able to deny.)

**All 7 failures diffed against baseline** (`origin/main` @ `1dd813f00`) rather than assumed:

| | Test Files | Tests |
|---|---|---|
| baseline (`chat-route` + `connection-test`) | 2 failed | 3 failed \| 220 passed |
| this branch (same two files) | 2 failed | 3 failed \| **223** passed |

- Six are reproduced identically on baseline: `launches Kimi connection tests without the legacy acp positional arg`, `passes keyless BYOK provider config without auth fields to OpenCode`, `does not leave a pinned assistant message queued when legacy chat fails before spawning`, `returns signed_out without reading an upstream wallet API`, `drives representative failed runs through analytics and Langfuse diagnostics`, `keeps the section gating matrix stable across scenarios`.
- The seventh, `discovers the default tools-dev daemon URL when no sidecar IPC path is available`, is a load-dependent flake: `tests/daemon-url.test.ts` is 5/5 green in isolation on **both** baseline and this branch.

This branch adds 3 passing tests to the two files that already had failures, and nothing new to the failure set.
