### PR TITLE
fix(daemon): contain session persistence failures

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5958,6 +5958,12 @@ export async function startServer({
       persistDeliveredAgentSessionState = () => {
         if (persisted) return;
         persisted = true;
+        if (!getConversation(db, run.conversationId)) {
+          console.warn(
+            '[sessions] skipped delivered session persistence because the conversation is not persisted',
+          );
+          return;
+        }
         // The id to persist for a create turn: capture-style adapters store the
         // session id the CLI minted and reported on the stream; specify-style
         // adapters store the daemon-minted id they passed to the CLI. A
@@ -7926,7 +7932,11 @@ export async function startServer({
           design.runs.finish(run, 'failed', 1, signal);
           return;
         }
-        persistDeliveredAgentSessionState();
+        try {
+          persistDeliveredAgentSessionState();
+        } catch (err) {
+          console.warn('[sessions] delivered session persistence failed', err);
+        }
       }
       finishWithRetryDecision(status, code, signal);
       } finally {

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -196,6 +196,43 @@ describe('/api/chat', () => {
     expect(body).toContain('AGENT_UNAVAILABLE');
   });
 
+  it('keeps serving when delivered-session persistence has no conversation row', async () => {
+    const conversationId = `missing-conversation-${randomUUID()}`;
+
+    await withFakeAgent(
+      'opencode',
+      `
+console.log(JSON.stringify({ type: 'step_start', sessionID: 'missing-conversation-session' }));
+console.log(JSON.stringify({
+  type: 'text',
+  sessionID: 'missing-conversation-session',
+  part: { text: '<question-form id="discovery">{"questions":[{"id":"style","label":"Style?"}]}</question-form>' },
+}));
+console.log(JSON.stringify({ type: 'step_finish', part: { tokens: { input: 1, output: 1 } } }));
+process.exit(0);
+`,
+      async () => {
+        const response = await fetch(`${baseUrl}/api/chat`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'opencode',
+            conversationId,
+            message: 'ask for clarification',
+          }),
+        });
+        const body = await response.text();
+
+        expect(response.ok).toBe(true);
+        expect(body).toContain('<question-form');
+        expect(body).toContain('"status":"succeeded"');
+
+        const healthResponse = await fetch(`${baseUrl}/api/health`);
+        expect(healthResponse.status).toBe(200);
+      },
+    );
+  });
+
   it('marks json stream runs failed when an error frame exits with code 0', async () => {
     const conversationId = `conv-${randomUUID()}`;
 


### PR DESCRIPTION
Related to #5728

## Why

A headless `/api/chat` client can supply a conversation id that has no matching database row. A successful resume-capable agent turn then attempts to persist its native session during child-close, hits the conversation foreign key, and leaves the shared daemon on its fatal unhandled-rejection path.

## What users will see

The affected chat turn now completes without terminating the daemon. Session persistence is skipped when the conversation is not stored, and any other synchronous persistence failure is logged without interrupting run finalization.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Not applicable.

## Bug fix verification

- Test path: `apps/daemon/tests/chat-route.test.ts`
- The focused test timed out before the source change because child-close finalization was interrupted, then passed after the fix.

## Validation

- `pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/chat-route.test.ts -t 'keeps serving when delivered-session persistence has no conversation row'`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`

The complete `chat-route.test.ts` run had 70 passing tests and two existing failures that also reproduce independently: the keyless provider package expectation and the legacy assistant-row fixture. The original Windows media CLI failure from #5728 remains out of scope.
