### PR TITLE
fix(daemon): reconcile run terminals after restart

### DIFF
--- a/apps/daemon/src/analytics.ts
+++ b/apps/daemon/src/analytics.ts
@@ -111,7 +111,7 @@ export interface AnalyticsService {
     appVersion: string;
     properties: Record<string, unknown>;
     insertId: string;
-  }): void;
+  }): Promise<void>;
   /**
    * Safety / reliability events (renderer crashes, daemon uncaught errors,
    * SSE health, etc.) that intentionally BYPASS the user's analytics
@@ -145,7 +145,7 @@ export interface AnalyticsService {
 }
 
 const NOOP_SERVICE: AnalyticsService = {
-  capture: () => undefined,
+  capture: async () => undefined,
   captureSafety: async () => undefined,
   mergeAnonymousPerson: async () => undefined,
   shutdown: async () => undefined,
@@ -195,46 +195,44 @@ export function createAnalyticsService(args: {
   client.on?.('error', () => undefined);
 
   return {
-    capture: ({ eventName, context, appVersion, properties, insertId }) => {
+    capture: async ({ eventName, context, appVersion, properties, insertId }) => {
       // Defense-in-depth consent re-check. The route handler already gates
       // on header presence, but a future header leak or a Settings toggle
       // mid-request would still let events through without this. Reading
       // app-config.json adds one small file read per event; the daemon is
       // not on a hot critical path here.
-      void (async () => {
-        try {
-          const appCfg = await readAppConfig(args.dataDir);
-          if (appCfg.telemetry?.metrics !== true) return;
-          client.capture({
-            distinctId: context.deviceId,
-            event: eventName,
-            properties: {
-              ...properties,
-              event_id: insertId,
-              event_schema_version: EVENT_SCHEMA_VERSION,
-              env: cfg.env,
-              ui_version: appVersion,
-              app_version: appVersion,
-              session_id: context.sessionId,
-              // v2 rename: was `anonymous_id`. Value unchanged.
-              device_id: context.deviceId,
-              client_type: context.clientType,
-              locale: context.locale,
-              // Canonical PostHog OS props so backend events join the same
-              // OS breakdown as posthog-js (which the daemon can't auto-fill).
-              $os: DAEMON_OS_NAME,
-              $os_version: DAEMON_OS_VERSION,
-              ...(context.requestId ? { request_id: context.requestId } : {}),
-              // $insert_id is PostHog's dedup key — passing the same id
-              // from web and daemon prevents the mirrored result event
-              // from being counted twice.
-              $insert_id: insertId,
-            },
-          });
-        } catch {
-          // Swallowed by design; capture failures must never propagate.
-        }
-      })();
+      try {
+        const appCfg = await readAppConfig(args.dataDir);
+        if (appCfg.telemetry?.metrics !== true) return;
+        client.capture({
+          distinctId: context.deviceId,
+          event: eventName,
+          properties: {
+            ...properties,
+            event_id: insertId,
+            event_schema_version: EVENT_SCHEMA_VERSION,
+            env: cfg.env,
+            ui_version: appVersion,
+            app_version: appVersion,
+            session_id: context.sessionId,
+            // v2 rename: was `anonymous_id`. Value unchanged.
+            device_id: context.deviceId,
+            client_type: context.clientType,
+            locale: context.locale,
+            // Canonical PostHog OS props so backend events join the same
+            // OS breakdown as posthog-js (which the daemon can't auto-fill).
+            $os: DAEMON_OS_NAME,
+            $os_version: DAEMON_OS_VERSION,
+            ...(context.requestId ? { request_id: context.requestId } : {}),
+            // $insert_id is PostHog's dedup key — passing the same id
+            // from web and daemon prevents the mirrored result event
+            // from being counted twice.
+            $insert_id: insertId,
+          },
+        });
+      } catch {
+        // Swallowed by design; capture failures must never propagate.
+      }
     },
     captureSafety: async ({ eventName, distinctId, appVersion, properties, insertId }) => {
       // No consent re-check here — that's the entire point of this surface.

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -205,6 +205,12 @@ interface ChatRunService {
   cancel(run: ChatRun): Promise<ChatRunStatusResponse>;
   isTerminal(status: ChatRunStatus): boolean;
   emit?(run: ChatRun, event: string, data: unknown): RunEventRecord;
+  setAnalyticsRecovery?(run: ChatRun, recovery: {
+    context: AnalyticsContext;
+    properties: Record<string, unknown>;
+    insertId: string;
+  }): void;
+  markAnalyticsCompleted?(run: ChatRun): void;
 }
 
 interface AnalyticsService {
@@ -214,7 +220,7 @@ interface AnalyticsService {
     appVersion: string;
     properties: Record<string, unknown>;
     insertId: string;
-  }): void;
+  }): void | Promise<void>;
 }
 
 interface RunRoutesDesignService {
@@ -991,6 +997,11 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         skill_ids: runSkillIds,
         token_count_source: userQueryTokens > 0 ? 'estimated' : 'unknown',
       };
+      design.runs.setAnalyticsRecovery?.(run, {
+        context: analyticsContext,
+        properties: baseProps,
+        insertId: runInsertId,
+      });
       design.analytics.capture({
         eventName: 'run_created',
         context: analyticsContext,
@@ -1185,7 +1196,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
             insertId: `${runInsertId}-${retryEvent.event}-${index}`,
           });
         }
-        design.analytics.capture({
+        await Promise.resolve(design.analytics.capture({
           eventName: 'run_finished',
           context: analyticsContext,
           appVersion: design.getAppVersion(),
@@ -1264,7 +1275,8 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
             token_count_source: usageAnalytics.token_count_source,
           },
           insertId: `${runInsertId}-finish`,
-        });
+        }));
+        design.runs.markAnalyticsCompleted?.(run);
       }).catch(() => {});
     }
   });

--- a/apps/daemon/src/runtimes/run-terminal-reconciliation.ts
+++ b/apps/daemon/src/runtimes/run-terminal-reconciliation.ts
@@ -1,0 +1,289 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import type Database from 'better-sqlite3';
+
+import { appendMessageStatusEvent } from '../db.js';
+import { runResultFromStatus } from '../run-result.js';
+import { runAskedUserQuestion } from './run-artifacts.js';
+
+const TERMINAL_STATUSES = new Set(['succeeded', 'failed', 'canceled']);
+const RESTART_ERROR_CODE = 'DAEMON_RESTARTED';
+const RESTART_ERROR_MESSAGE = 'Run interrupted because the daemon restarted.';
+
+interface AnalyticsRecovery {
+  context: Record<string, unknown>;
+  properties: Record<string, unknown>;
+  insertId: string;
+  completedAt?: number;
+}
+
+interface DurableRunState {
+  schemaVersion: 1;
+  id: string;
+  projectId: string | null;
+  conversationId: string | null;
+  assistantMessageId: string | null;
+  agentId: string | null;
+  status: string;
+  createdAt: number;
+  updatedAt: number;
+  exitCode?: number | null;
+  signal?: string | null;
+  error?: string | null;
+  errorCode?: string | null;
+  artifactCount?: number;
+  endedWithUnfinishedWork?: boolean;
+  userPrompt?: string;
+  model?: string;
+  reasoning?: string;
+  skillId?: string;
+  designSystemId?: string;
+  designSystemDigest?: string;
+  designSystemSelectionSource?: string;
+  clientType?: 'desktop' | 'web' | 'unknown';
+  analyticsTelemetry?: Record<string, unknown>;
+  promptTelemetry?: Record<string, unknown>;
+  promptCache?: Record<string, unknown>;
+  analyticsRecovery?: AnalyticsRecovery;
+  langfuseCompletedAt?: number;
+  terminalRecoveryReason?: 'daemon_restart' | 'analytics_incomplete';
+}
+
+interface AnalyticsLike {
+  capture(args: {
+    eventName: string;
+    context: Record<string, unknown>;
+    appVersion: string;
+    properties: Record<string, unknown>;
+    insertId: string;
+  }): void | Promise<void>;
+}
+
+interface ReconciliationOptions {
+  analytics: AnalyticsLike;
+  appVersion: string;
+  appVersionInfo?: unknown;
+  db: Database.Database;
+  reportLangfuse(args: Record<string, unknown>): unknown | Promise<unknown>;
+  runsLogDir: string;
+}
+
+export interface RunTerminalReconciliationResult {
+  scanned: number;
+  interrupted: number;
+  messagesReconciled: number;
+  analyticsReplayed: number;
+  langfuseReplayed: number;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readState(filePath: string): DurableRunState | null {
+  try {
+    const value = JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+    if (!isObject(value) || value.schemaVersion !== 1) return null;
+    if (typeof value.id !== 'string' || typeof value.status !== 'string') return null;
+    if (typeof value.createdAt !== 'number' || typeof value.updatedAt !== 'number') return null;
+    return value as unknown as DurableRunState;
+  } catch {
+    return null;
+  }
+}
+
+function writeState(filePath: string, state: DurableRunState): void {
+  const tempPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    fs.writeFileSync(tempPath, `${JSON.stringify(state)}\n`, { encoding: 'utf8', mode: 0o600 });
+    fs.renameSync(tempPath, filePath);
+  } catch {
+    try { fs.unlinkSync(tempPath); } catch { /* best-effort cleanup */ }
+  }
+}
+
+function readEvents(runsLogDir: string, runId: string): Array<{
+  id: number;
+  event: string;
+  data: unknown;
+  timestamp?: number;
+}> {
+  try {
+    return fs.readFileSync(path.join(runsLogDir, runId, 'events.jsonl'), 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as unknown)
+      .filter((value): value is { id: number; event: string; data: unknown; timestamp?: number } =>
+        isObject(value) && typeof value.id === 'number' && typeof value.event === 'string');
+  } catch {
+    return [];
+  }
+}
+
+function hydrateRun(state: DurableRunState, events: ReturnType<typeof readEvents>) {
+  return {
+    id: state.id,
+    projectId: state.projectId ?? null,
+    conversationId: state.conversationId ?? null,
+    assistantMessageId: state.assistantMessageId ?? null,
+    agentId: state.agentId ?? null,
+    status: state.status,
+    exitCode: state.exitCode ?? null,
+    signal: state.signal ?? null,
+    error: state.error ?? null,
+    errorCode: state.errorCode ?? null,
+    analyticsTelemetry: state.analyticsTelemetry ?? null,
+    createdAt: state.createdAt,
+    updatedAt: state.updatedAt,
+    events,
+    ...(state.userPrompt !== undefined ? { userPrompt: state.userPrompt } : {}),
+    ...(state.model !== undefined ? { model: state.model } : {}),
+    ...(state.reasoning !== undefined ? { reasoning: state.reasoning } : {}),
+    ...(state.skillId !== undefined ? { skillId: state.skillId } : {}),
+    ...(state.designSystemId !== undefined ? { designSystemId: state.designSystemId } : {}),
+    ...(state.designSystemDigest !== undefined ? { designSystemDigest: state.designSystemDigest } : {}),
+    ...(state.designSystemSelectionSource !== undefined
+      ? { designSystemSelectionSource: state.designSystemSelectionSource }
+      : {}),
+    ...(state.clientType !== undefined ? { clientType: state.clientType } : {}),
+    ...(state.promptTelemetry !== undefined ? { promptTelemetry: state.promptTelemetry } : {}),
+    ...(state.promptCache !== undefined ? { promptCache: state.promptCache } : {}),
+  };
+}
+
+function reconcileMessages(
+  db: Database.Database,
+  statesByRunId: Map<string, DurableRunState>,
+  now: number,
+): number {
+  let rows: Array<{ id: string; runId: string | null }> = [];
+  try {
+    rows = db.prepare(
+      `SELECT id, run_id AS runId
+         FROM messages
+        WHERE run_status IN ('queued', 'running')`,
+    ).all() as Array<{ id: string; runId: string | null }>;
+  } catch {
+    return 0;
+  }
+  for (const row of rows) {
+    const state = row.runId ? statesByRunId.get(row.runId) : undefined;
+    const status = state && TERMINAL_STATUSES.has(state.status) ? state.status : 'failed';
+    db.prepare(
+      `UPDATE messages
+          SET run_status = ?, ended_at = COALESCE(ended_at, ?)
+        WHERE id = ? AND run_status IN ('queued', 'running')`,
+    ).run(status, state?.updatedAt ?? now, row.id);
+    appendMessageStatusEvent(db, row.id, status === 'failed'
+      ? { label: 'error', detail: 'Run interrupted because the daemon restarted.' }
+      : { label: status, detail: 'Run terminal state reconciled after daemon restart.' });
+  }
+  return rows.length;
+}
+
+export async function reconcileDurableRunTerminals(
+  options: ReconciliationOptions,
+): Promise<RunTerminalReconciliationResult> {
+  const result: RunTerminalReconciliationResult = {
+    scanned: 0,
+    interrupted: 0,
+    messagesReconciled: 0,
+    analyticsReplayed: 0,
+    langfuseReplayed: 0,
+  };
+  let entries: fs.Dirent[] = [];
+  try {
+    entries = fs.readdirSync(options.runsLogDir, { withFileTypes: true });
+  } catch {
+    entries = [];
+  }
+
+  const states = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => ({
+      filePath: path.join(options.runsLogDir, entry.name, 'state.json'),
+      state: readState(path.join(options.runsLogDir, entry.name, 'state.json')),
+    }))
+    .filter((entry): entry is { filePath: string; state: DurableRunState } => entry.state !== null);
+  result.scanned = states.length;
+  const now = Date.now();
+
+  for (const entry of states) {
+    if (TERMINAL_STATUSES.has(entry.state.status)) continue;
+    entry.state.status = 'failed';
+    entry.state.updatedAt = now;
+    entry.state.exitCode = 1;
+    entry.state.signal = null;
+    entry.state.error = RESTART_ERROR_MESSAGE;
+    entry.state.errorCode = RESTART_ERROR_CODE;
+    entry.state.terminalRecoveryReason = 'daemon_restart';
+    writeState(entry.filePath, entry.state);
+    result.interrupted += 1;
+  }
+
+  const statesByRunId = new Map(states.map((entry) => [entry.state.id, entry.state]));
+  result.messagesReconciled = reconcileMessages(options.db, statesByRunId, now);
+
+  for (const entry of states) {
+    const { state } = entry;
+    const recoveryReason = state.terminalRecoveryReason ?? 'analytics_incomplete';
+    const events = readEvents(options.runsLogDir, state.id);
+    if (state.analyticsRecovery && !state.analyticsRecovery.completedAt) {
+      const failed = state.status === 'failed';
+      await Promise.resolve(options.analytics.capture({
+        eventName: 'run_finished',
+        context: state.analyticsRecovery.context,
+        appVersion: options.appVersion,
+        properties: {
+          ...state.analyticsRecovery.properties,
+          area: state.analyticsRecovery.properties.area === 'design_system_generation'
+            ? 'design_system_generation'
+            : 'chat_panel',
+          result: runResultFromStatus(state.status),
+          artifact_count: state.artifactCount ?? 0,
+          asked_user_question: runAskedUserQuestion(events),
+          total_duration_ms: Math.max(0, state.updatedAt - state.createdAt),
+          langfuse_trace_id: state.id,
+          terminal_reconciled: true,
+          terminal_recovery_reason: recoveryReason,
+          ...(failed ? {
+            error_code: state.errorCode ?? RESTART_ERROR_CODE,
+            failure_category: 'process_exit',
+            failure_detail: 'interrupted',
+            failure_stage: 'finalize',
+            retryable: true,
+            user_action: 'retry',
+          } : {}),
+        },
+        insertId: `${state.analyticsRecovery.insertId}-finish`,
+      }));
+      state.analyticsRecovery.completedAt = Date.now();
+      writeState(entry.filePath, state);
+      result.analyticsReplayed += 1;
+    }
+
+    if (!state.langfuseCompletedAt) {
+      const delivery = await Promise.resolve(options.reportLangfuse({
+        db: options.db,
+        dataDir: path.dirname(options.runsLogDir),
+        run: hydrateRun(state, events),
+        persistedRunStatus: state.status,
+        persistedEndedAt: state.updatedAt,
+        appVersion: options.appVersionInfo ?? null,
+      }));
+      if (
+        isObject(delivery)
+        && (delivery.langfuse_expected === false
+          || delivery.langfuse_delivery_status === 'accepted')
+      ) {
+        state.langfuseCompletedAt = Date.now();
+        writeState(entry.filePath, state);
+      }
+      result.langfuseReplayed += 1;
+    }
+  }
+
+  return result;
+}

--- a/apps/daemon/src/runtimes/run-terminal-reconciliation.ts
+++ b/apps/daemon/src/runtimes/run-terminal-reconciliation.ts
@@ -5,7 +5,8 @@ import { randomUUID } from 'node:crypto';
 import type Database from 'better-sqlite3';
 
 import { appendMessageStatusEvent } from '../db.js';
-import { runResultFromStatus } from '../run-result.js';
+import { classifyRunFailure } from '../run-failure-classification.js';
+import { deriveRunErrorCode, runResultFromStatus } from '../run-result.js';
 import { runAskedUserQuestion } from './run-artifacts.js';
 
 const TERMINAL_STATUSES = new Set(['succeeded', 'failed', 'canceled']);
@@ -232,6 +233,29 @@ export async function reconcileDurableRunTerminals(
     const events = readEvents(options.runsLogDir, state.id);
     if (state.analyticsRecovery && !state.analyticsRecovery.completedAt) {
       const failed = state.status === 'failed';
+      const runResult = runResultFromStatus(state.status);
+      const errorCode = failed
+        ? recoveryReason === 'daemon_restart'
+          ? state.errorCode ?? RESTART_ERROR_CODE
+          : deriveRunErrorCode(state)
+        : undefined;
+      const failure = failed
+        ? recoveryReason === 'daemon_restart'
+          ? {
+              failure_category: 'process_exit' as const,
+              failure_detail: 'interrupted' as const,
+              failure_stage: 'finalize' as const,
+              retryable: true,
+              user_action: 'retry' as const,
+            }
+          : classifyRunFailure({
+              result: runResult,
+              status: state,
+              ...(errorCode ? { errorCode } : {}),
+              agentId: state.agentId,
+              events,
+            })
+        : undefined;
       await Promise.resolve(options.analytics.capture({
         eventName: 'run_finished',
         context: state.analyticsRecovery.context,
@@ -241,21 +265,15 @@ export async function reconcileDurableRunTerminals(
           area: state.analyticsRecovery.properties.area === 'design_system_generation'
             ? 'design_system_generation'
             : 'chat_panel',
-          result: runResultFromStatus(state.status),
+          result: runResult,
           artifact_count: state.artifactCount ?? 0,
           asked_user_question: runAskedUserQuestion(events),
           total_duration_ms: Math.max(0, state.updatedAt - state.createdAt),
           langfuse_trace_id: state.id,
           terminal_reconciled: true,
           terminal_recovery_reason: recoveryReason,
-          ...(failed ? {
-            error_code: state.errorCode ?? RESTART_ERROR_CODE,
-            failure_category: 'process_exit',
-            failure_detail: 'interrupted',
-            failure_stage: 'finalize',
-            retryable: true,
-            user_action: 'retry',
-          } : {}),
+          ...(errorCode ? { error_code: errorCode } : {}),
+          ...(failure ?? {}),
         },
         insertId: `${state.analyticsRecovery.insertId}-finish`,
       }));

--- a/apps/daemon/src/runtimes/run-terminal-reconciliation.ts
+++ b/apps/daemon/src/runtimes/run-terminal-reconciliation.ts
@@ -12,6 +12,7 @@ import { runAskedUserQuestion } from './run-artifacts.js';
 const TERMINAL_STATUSES = new Set(['succeeded', 'failed', 'canceled']);
 const RESTART_ERROR_CODE = 'DAEMON_RESTARTED';
 const RESTART_ERROR_MESSAGE = 'Run interrupted because the daemon restarted.';
+const RECONCILED_STATUS_MESSAGE = 'Run terminal state reconciled after daemon restart.';
 
 interface AnalyticsRecovery {
   context: Record<string, unknown>;
@@ -177,9 +178,16 @@ function reconcileMessages(
           SET run_status = ?, ended_at = COALESCE(ended_at, ?)
         WHERE id = ? AND run_status IN ('queued', 'running')`,
     ).run(status, state?.updatedAt ?? now, row.id);
+    const isDaemonRestart = state?.terminalRecoveryReason === 'daemon_restart'
+      || state?.errorCode === RESTART_ERROR_CODE;
     appendMessageStatusEvent(db, row.id, status === 'failed'
-      ? { label: 'error', detail: 'Run interrupted because the daemon restarted.' }
-      : { label: status, detail: 'Run terminal state reconciled after daemon restart.' });
+      ? {
+          label: 'error',
+          detail: isDaemonRestart
+            ? RESTART_ERROR_MESSAGE
+            : state?.error ?? RECONCILED_STATUS_MESSAGE,
+        }
+      : { label: status, detail: RECONCILED_STATUS_MESSAGE });
   }
   return rows.length;
 }
@@ -229,9 +237,15 @@ export async function reconcileDurableRunTerminals(
 
   for (const entry of states) {
     const { state } = entry;
+    const needsAnalytics = Boolean(
+      state.analyticsRecovery && !state.analyticsRecovery.completedAt,
+    );
+    const needsLangfuse = !state.langfuseCompletedAt;
+    if (!needsAnalytics && !needsLangfuse) continue;
+
     const recoveryReason = state.terminalRecoveryReason ?? 'analytics_incomplete';
     const events = readEvents(options.runsLogDir, state.id);
-    if (state.analyticsRecovery && !state.analyticsRecovery.completedAt) {
+    if (needsAnalytics && state.analyticsRecovery) {
       const failed = state.status === 'failed';
       const runResult = runResultFromStatus(state.status);
       const errorCode = failed
@@ -282,7 +296,7 @@ export async function reconcileDurableRunTerminals(
       result.analyticsReplayed += 1;
     }
 
-    if (!state.langfuseCompletedAt) {
+    if (needsLangfuse) {
       const delivery = await Promise.resolve(options.reportLangfuse({
         db: options.db,
         dataDir: path.dirname(options.runsLogDir),

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -13,6 +13,56 @@ import { projectWorkspaceProvenance } from '../workspace-contract.js';
 
 export const TERMINAL_RUN_STATUSES = new Set(['succeeded', 'failed', 'canceled']);
 
+const RUN_STATE_SCHEMA_VERSION = 1;
+
+function atomicWriteJson(filePath, value) {
+  const tempPath = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(tempPath, `${JSON.stringify(value)}\n`, { encoding: 'utf8', mode: 0o600 });
+    fs.renameSync(tempPath, filePath);
+  } catch {
+    try { fs.unlinkSync(tempPath); } catch { /* best-effort cleanup */ }
+  }
+}
+
+function durableRunState(run) {
+  return {
+    schemaVersion: RUN_STATE_SCHEMA_VERSION,
+    id: run.id,
+    projectId: run.projectId,
+    conversationId: run.conversationId,
+    assistantMessageId: run.assistantMessageId,
+    agentId: run.agentId,
+    status: run.status,
+    createdAt: run.createdAt,
+    updatedAt: run.updatedAt,
+    exitCode: run.exitCode,
+    signal: run.signal,
+    error: run.error,
+    errorCode: run.errorCode,
+    artifactCount: Number.isFinite(run.artifactCount) ? run.artifactCount : 0,
+    endedWithUnfinishedWork: Boolean(run.endedWithUnfinishedWork),
+    ...(typeof run.userPrompt === 'string' ? { userPrompt: run.userPrompt } : {}),
+    ...(typeof run.model === 'string' ? { model: run.model } : {}),
+    ...(typeof run.reasoning === 'string' ? { reasoning: run.reasoning } : {}),
+    ...(typeof run.skillId === 'string' ? { skillId: run.skillId } : {}),
+    ...(typeof run.designSystemId === 'string' ? { designSystemId: run.designSystemId } : {}),
+    ...(typeof run.designSystemDigest === 'string' ? { designSystemDigest: run.designSystemDigest } : {}),
+    ...(typeof run.designSystemSelectionSource === 'string'
+      ? { designSystemSelectionSource: run.designSystemSelectionSource }
+      : {}),
+    ...(typeof run.clientType === 'string' ? { clientType: run.clientType } : {}),
+    ...(run.analyticsTelemetry ? { analyticsTelemetry: run.analyticsTelemetry } : {}),
+    ...(run.promptTelemetry ? { promptTelemetry: run.promptTelemetry } : {}),
+    ...(run.promptCache ? { promptCache: run.promptCache } : {}),
+    ...(run.analyticsRecovery ? { analyticsRecovery: run.analyticsRecovery } : {}),
+    ...(typeof run.langfuseCompletedAt === 'number'
+      ? { langfuseCompletedAt: run.langfuseCompletedAt }
+      : {}),
+  };
+}
+
 function readString(value) {
   return typeof value === 'string' && value.trim() ? value.trim() : null;
 }
@@ -115,13 +165,41 @@ export function createChatRunService({
       artifactCount: undefined as number | undefined,
       artifactOutcome: undefined,
       eventsLogPath: runsLogDir ? path.join(runsLogDir, id, 'events.jsonl') : null,
+      statePath: runsLogDir ? path.join(runsLogDir, id, 'state.json') : null,
       eventsLogStream: null,
       // Set once finish() has closed the log stream, so a late post-finish emit
       // can't lazily re-open a stream nothing will ever close (FD leak).
       eventsLogClosed: false,
     };
     runs.set(run.id, run);
+    if (run.statePath) atomicWriteJson(run.statePath, durableRunState(run));
     return run;
+  };
+
+  const persistState = (run) => {
+    if (run?.statePath) atomicWriteJson(run.statePath, durableRunState(run));
+  };
+
+  const setAnalyticsRecovery = (run, recovery) => {
+    if (!run || !recovery) return;
+    run.analyticsRecovery = {
+      context: recovery.context,
+      properties: recovery.properties,
+      insertId: recovery.insertId,
+    };
+    persistState(run);
+  };
+
+  const markAnalyticsCompleted = (run) => {
+    if (!run?.analyticsRecovery) return;
+    run.analyticsRecovery.completedAt = Date.now();
+    persistState(run);
+  };
+
+  const markLangfuseCompleted = (run) => {
+    if (!run) return;
+    run.langfuseCompletedAt = Date.now();
+    persistState(run);
   };
 
   const get = (id) => runs.get(id) ?? null;
@@ -180,6 +258,10 @@ export function createChatRunService({
     run.events.push(record);
     if (run.events.length > maxEvents) run.events.splice(0, run.events.length - maxEvents);
     run.updatedAt = Date.now();
+    // State writes are synchronous so they survive process termination. Keep
+    // them on lifecycle boundaries only: agent/text deltas can arrive many
+    // times per second and are already streamed to events.jsonl.
+    if (event === 'start' || event === 'error' || event === 'end') persistState(run);
     const stream = ensureLogStream(run);
     if (stream) {
       try {
@@ -556,6 +638,9 @@ export function createChatRunService({
       try { finalize(); } catch { /* best-effort */ }
     }
     runs.delete(run.id);
+    if (run.statePath) {
+      try { fs.unlinkSync(run.statePath); } catch { /* best-effort */ }
+    }
     for (const sse of run.clients) {
       try { sse.end(); } catch { /* best-effort detach */ }
     }
@@ -579,6 +664,10 @@ export function createChatRunService({
     shutdownActive,
     wait,
     emit,
+    persistState,
+    setAnalyticsRecovery,
+    markAnalyticsCompleted,
+    markLangfuseCompleted,
     finish,
     fail,
     drop,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -390,6 +390,7 @@ import {
   snapshotAiHtmlVersionsForRun,
 } from './run-html-version-snapshots.js';
 import { reportRunCompletedFromDaemon } from './langfuse-bridge.js';
+import { reconcileDurableRunTerminals } from './runtimes/run-terminal-reconciliation.js';
 import { buildPromptStackTelemetry } from './prompt-telemetry.js';
 import { readAnalyticsContext } from './analytics.js';
 import {
@@ -1578,6 +1579,12 @@ export function createFinalizedMessageTelemetryReporter({
         skipReason: state.langfuse_expected === false ? 'not_expected' : undefined,
         status: saved.runStatus,
       });
+      if (
+        state.langfuse_expected === false
+        || state.langfuse_delivery_status === 'accepted'
+      ) {
+        design.runs.markLangfuseCompleted?.(run);
+      }
     })();
   };
 }
@@ -2510,6 +2517,25 @@ export async function startServer({
     getAppVersion: () => telemetry.getCachedAppVersion()?.version ?? '0.0.0',
     readAnalyticsContext,
   };
+
+  // Runs are process-local, but their terminal obligations are durable. On a
+  // fresh daemon boot, repair stale message rows and replay any PostHog or
+  // Langfuse terminal work whose checkpoint was not committed. Network work
+  // stays off the startup critical path.
+  void reconcileDurableRunTerminals({
+    analytics: analyticsService,
+    appVersion: telemetry.getCachedAppVersion()?.version ?? '0.0.0',
+    appVersionInfo: telemetry.getCachedAppVersion(),
+    db,
+    reportLangfuse: reportRunCompletedFromDaemon,
+    runsLogDir: path.join(RUNTIME_DATA_DIR, 'runs'),
+  }).then((reconciled) => {
+    if (reconciled.interrupted > 0 || reconciled.messagesReconciled > 0) {
+      console.warn('[runs] reconciled interrupted run terminals', reconciled);
+    }
+  }).catch((error) => {
+    console.warn('[runs] terminal reconciliation failed', error);
+  });
 
   // Interactive Terminal sessions (node-pty). In-memory, process-local, and
   // killed on daemon shutdown — see shutdownDaemonRuns below.

--- a/apps/daemon/tests/runtimes/run-terminal-reconciliation.test.ts
+++ b/apps/daemon/tests/runtimes/run-terminal-reconciliation.test.ts
@@ -1,0 +1,187 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { reconcileDurableRunTerminals } from '../../src/runtimes/run-terminal-reconciliation.js';
+
+describe('durable run terminal reconciliation', () => {
+  let tmpDir: string;
+  let db: Database.Database;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-run-reconcile-test-'));
+    db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE messages (
+        id TEXT PRIMARY KEY,
+        run_id TEXT,
+        run_status TEXT,
+        ended_at INTEGER,
+        events_json TEXT
+      )
+    `);
+  });
+
+  afterEach(() => {
+    db.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('fails an interrupted run, repairs its message, and emits missing terminal telemetry once', async () => {
+    const runId = 'run-interrupted';
+    const runDir = path.join(tmpDir, runId);
+    fs.mkdirSync(runDir, { recursive: true });
+    fs.writeFileSync(path.join(runDir, 'state.json'), JSON.stringify({
+      schemaVersion: 1,
+      id: runId,
+      projectId: 'p1',
+      conversationId: 'c1',
+      assistantMessageId: 'm1',
+      agentId: 'claude',
+      status: 'running',
+      createdAt: 1_000,
+      updatedAt: 2_000,
+      analyticsRecovery: {
+        context: {
+          deviceId: 'device-1',
+          sessionId: 'session-1',
+          clientType: 'desktop',
+          locale: 'zh-CN',
+        },
+        properties: {
+          page_name: 'chat_panel',
+          area: 'chat_panel',
+          project_id: 'p1',
+          conversation_id: 'c1',
+          run_id: runId,
+          project_kind: 'prototype',
+          design_system_source: 'not_applicable',
+          has_attachment: false,
+          user_query_tokens: 10,
+          model_id: 'default',
+          agent_provider_id: 'claude_code',
+          skill_id: null,
+          mcp_id: null,
+          token_count_source: 'estimated',
+        },
+        insertId: 'run-created-1',
+      },
+    }));
+    db.prepare(
+      `INSERT INTO messages (id, run_id, run_status, events_json)
+       VALUES (?, ?, 'running', '[]')`,
+    ).run('m1', runId);
+    const capture = vi.fn(async () => undefined);
+    const reportLangfuse = vi.fn(async () => ({
+      langfuse_expected: true,
+      langfuse_delivery_status: 'accepted' as const,
+    }));
+
+    const first = await reconcileDurableRunTerminals({
+      analytics: { capture },
+      appVersion: '0.15.1',
+      db,
+      reportLangfuse,
+      runsLogDir: tmpDir,
+    });
+
+    expect(first).toMatchObject({ interrupted: 1, messagesReconciled: 1, analyticsReplayed: 1 });
+    expect(db.prepare(`SELECT run_status AS status, ended_at AS endedAt, events_json AS eventsJson FROM messages WHERE id = 'm1'`).get()).toMatchObject({
+      status: 'failed',
+      endedAt: expect.any(Number),
+      eventsJson: expect.stringContaining('daemon restarted'),
+    });
+    expect(capture).toHaveBeenCalledWith(expect.objectContaining({
+      eventName: 'run_finished',
+      insertId: 'run-created-1-finish',
+      properties: expect.objectContaining({
+        result: 'failed',
+        error_code: 'DAEMON_RESTARTED',
+        terminal_reconciled: true,
+        terminal_recovery_reason: 'daemon_restart',
+      }),
+    }));
+    expect(reportLangfuse).toHaveBeenCalledWith(expect.objectContaining({
+      persistedRunStatus: 'failed',
+      run: expect.objectContaining({ id: runId, status: 'failed' }),
+    }));
+
+    const recoveredState = JSON.parse(fs.readFileSync(path.join(runDir, 'state.json'), 'utf8'));
+    expect(recoveredState).toMatchObject({
+      status: 'failed',
+      errorCode: 'DAEMON_RESTARTED',
+      analyticsRecovery: { completedAt: expect.any(Number) },
+      langfuseCompletedAt: expect.any(Number),
+    });
+
+    const second = await reconcileDurableRunTerminals({
+      analytics: { capture },
+      appVersion: '0.15.1',
+      db,
+      reportLangfuse,
+      runsLogDir: tmpDir,
+    });
+    expect(second.analyticsReplayed).toBe(0);
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(reportLangfuse).toHaveBeenCalledTimes(1);
+  });
+
+  it('repairs legacy queued messages even when no state journal exists', async () => {
+    db.prepare(
+      `INSERT INTO messages (id, run_id, run_status, events_json)
+       VALUES (?, ?, 'queued', '[]')`,
+    ).run('legacy-message', 'legacy-run');
+
+    const result = await reconcileDurableRunTerminals({
+      analytics: { capture: vi.fn() },
+      appVersion: '0.15.1',
+      db,
+      reportLangfuse: vi.fn(),
+      runsLogDir: tmpDir,
+    });
+
+    expect(result.messagesReconciled).toBe(1);
+    expect(db.prepare(`SELECT run_status AS status FROM messages WHERE id = 'legacy-message'`).get())
+      .toEqual({ status: 'failed' });
+  });
+
+  it('leaves failed Langfuse delivery uncheckpointed for the next boot', async () => {
+    const runId = 'run-langfuse-retry';
+    const runDir = path.join(tmpDir, runId);
+    fs.mkdirSync(runDir, { recursive: true });
+    fs.writeFileSync(path.join(runDir, 'state.json'), JSON.stringify({
+      schemaVersion: 1,
+      id: runId,
+      projectId: 'p1',
+      conversationId: 'c1',
+      assistantMessageId: 'm1',
+      agentId: 'codex',
+      status: 'failed',
+      createdAt: 1_000,
+      updatedAt: 2_000,
+      errorCode: 'AGENT_EXIT_1',
+    }));
+    const reportLangfuse = vi.fn(async () => ({
+      langfuse_expected: true,
+      langfuse_delivery_status: 'failed' as const,
+      langfuse_drop_reason: 'network_error' as const,
+    }));
+    const options = {
+      analytics: { capture: vi.fn() },
+      appVersion: '0.15.1',
+      db,
+      reportLangfuse,
+      runsLogDir: tmpDir,
+    };
+
+    await reconcileDurableRunTerminals(options);
+    await reconcileDurableRunTerminals(options);
+
+    expect(reportLangfuse).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(fs.readFileSync(path.join(runDir, 'state.json'), 'utf8')))
+      .not.toHaveProperty('langfuseCompletedAt');
+  });
+});

--- a/apps/daemon/tests/runtimes/run-terminal-reconciliation.test.ts
+++ b/apps/daemon/tests/runtimes/run-terminal-reconciliation.test.ts
@@ -100,6 +100,11 @@ describe('durable run terminal reconciliation', () => {
       properties: expect.objectContaining({
         result: 'failed',
         error_code: 'DAEMON_RESTARTED',
+        failure_category: 'process_exit',
+        failure_detail: 'interrupted',
+        failure_stage: 'finalize',
+        retryable: true,
+        user_action: 'retry',
         terminal_reconciled: true,
         terminal_recovery_reason: 'daemon_restart',
       }),
@@ -146,6 +151,68 @@ describe('durable run terminal reconciliation', () => {
     expect(result.messagesReconciled).toBe(1);
     expect(db.prepare(`SELECT run_status AS status FROM messages WHERE id = 'legacy-message'`).get())
       .toEqual({ status: 'failed' });
+  });
+
+  it('preserves the real failure taxonomy when replaying incomplete analytics', async () => {
+    const runId = 'run-analytics-incomplete';
+    const runDir = path.join(tmpDir, runId);
+    fs.mkdirSync(runDir, { recursive: true });
+    fs.writeFileSync(path.join(runDir, 'state.json'), JSON.stringify({
+      schemaVersion: 1,
+      id: runId,
+      projectId: 'p1',
+      conversationId: 'c1',
+      assistantMessageId: 'm1',
+      agentId: 'claude',
+      status: 'failed',
+      createdAt: 1_000,
+      updatedAt: 2_000,
+      exitCode: 1,
+      error: 'Authentication required before starting the session.',
+      errorCode: 'AGENT_AUTH_REQUIRED',
+      analyticsRecovery: {
+        context: {
+          deviceId: 'device-1',
+          sessionId: 'session-1',
+          clientType: 'desktop',
+          locale: 'en',
+        },
+        properties: {
+          page_name: 'chat_panel',
+          area: 'chat_panel',
+          project_id: 'p1',
+          conversation_id: 'c1',
+          run_id: runId,
+        },
+        insertId: 'run-created-analytics-incomplete',
+      },
+      langfuseCompletedAt: 2_000,
+    }));
+    const capture = vi.fn(async () => undefined);
+
+    const result = await reconcileDurableRunTerminals({
+      analytics: { capture },
+      appVersion: '0.15.1',
+      db,
+      reportLangfuse: vi.fn(),
+      runsLogDir: tmpDir,
+    });
+
+    expect(result).toMatchObject({ interrupted: 0, analyticsReplayed: 1 });
+    expect(capture).toHaveBeenCalledWith(expect.objectContaining({
+      eventName: 'run_finished',
+      properties: expect.objectContaining({
+        result: 'failed',
+        error_code: 'AGENT_AUTH_REQUIRED',
+        failure_category: 'auth',
+        failure_detail: 'auth_required',
+        failure_stage: 'session_init',
+        retryable: false,
+        user_action: 'login',
+        terminal_reconciled: true,
+        terminal_recovery_reason: 'analytics_incomplete',
+      }),
+    }));
   });
 
   it('leaves failed Langfuse delivery uncheckpointed for the next boot', async () => {

--- a/apps/daemon/tests/runtimes/run-terminal-reconciliation.test.ts
+++ b/apps/daemon/tests/runtimes/run-terminal-reconciliation.test.ts
@@ -26,6 +26,7 @@ describe('durable run terminal reconciliation', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     db.close();
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
@@ -188,6 +189,10 @@ describe('durable run terminal reconciliation', () => {
       },
       langfuseCompletedAt: 2_000,
     }));
+    db.prepare(
+      `INSERT INTO messages (id, run_id, run_status, events_json)
+       VALUES (?, ?, 'running', '[]')`,
+    ).run('m1', runId);
     const capture = vi.fn(async () => undefined);
 
     const result = await reconcileDurableRunTerminals({
@@ -198,7 +203,19 @@ describe('durable run terminal reconciliation', () => {
       runsLogDir: tmpDir,
     });
 
-    expect(result).toMatchObject({ interrupted: 0, analyticsReplayed: 1 });
+    expect(result).toMatchObject({
+      interrupted: 0,
+      messagesReconciled: 1,
+      analyticsReplayed: 1,
+    });
+    const message = db.prepare(
+      `SELECT run_status AS status, events_json AS eventsJson FROM messages WHERE id = 'm1'`,
+    ).get() as { status: string; eventsJson: string };
+    expect(message).toMatchObject({
+      status: 'failed',
+      eventsJson: expect.stringContaining('Authentication required before starting the session.'),
+    });
+    expect(message.eventsJson).not.toContain('daemon restarted');
     expect(capture).toHaveBeenCalledWith(expect.objectContaining({
       eventName: 'run_finished',
       properties: expect.objectContaining({
@@ -213,6 +230,50 @@ describe('durable run terminal reconciliation', () => {
         terminal_recovery_reason: 'analytics_incomplete',
       }),
     }));
+  });
+
+  it('does not read events after analytics and Langfuse are checkpointed', async () => {
+    const runId = 'run-fully-checkpointed';
+    const runDir = path.join(tmpDir, runId);
+    fs.mkdirSync(runDir, { recursive: true });
+    fs.writeFileSync(path.join(runDir, 'state.json'), JSON.stringify({
+      schemaVersion: 1,
+      id: runId,
+      projectId: 'p1',
+      conversationId: 'c1',
+      assistantMessageId: 'm1',
+      agentId: 'claude',
+      status: 'succeeded',
+      createdAt: 1_000,
+      updatedAt: 2_000,
+      analyticsRecovery: {
+        context: {},
+        properties: {},
+        insertId: 'run-created-fully-checkpointed',
+        completedAt: 2_000,
+      },
+      langfuseCompletedAt: 2_000,
+    }));
+    const readFile = vi.spyOn(fs, 'readFileSync');
+    const capture = vi.fn();
+    const reportLangfuse = vi.fn();
+
+    const result = await reconcileDurableRunTerminals({
+      analytics: { capture },
+      appVersion: '0.15.1',
+      db,
+      reportLangfuse,
+      runsLogDir: tmpDir,
+    });
+
+    expect(result).toMatchObject({
+      scanned: 1,
+      analyticsReplayed: 0,
+      langfuseReplayed: 0,
+    });
+    expect(readFile).not.toHaveBeenCalledWith(path.join(runDir, 'events.jsonl'), 'utf8');
+    expect(capture).not.toHaveBeenCalled();
+    expect(reportLangfuse).not.toHaveBeenCalled();
   });
 
   it('leaves failed Langfuse delivery uncheckpointed for the next boot', async () => {

--- a/apps/daemon/tests/runtimes/runs.test.ts
+++ b/apps/daemon/tests/runtimes/runs.test.ts
@@ -738,6 +738,56 @@ describe('run event log persistence', () => {
     expect(parsed[2]).toMatchObject({ event: 'end', data: { status: 'succeeded' } });
   });
 
+  it('persists a restart-safe terminal state and telemetry checkpoints', () => {
+    const runs = createRunsWithLog(tmpDir);
+    const run = runs.create({
+      projectId: 'p1',
+      conversationId: 'c1',
+      assistantMessageId: 'm1',
+      agentId: 'claude',
+    });
+    const statePath = path.join(tmpDir, run.id, 'state.json');
+
+    expect(JSON.parse(fs.readFileSync(statePath, 'utf8'))).toMatchObject({
+      schemaVersion: 1,
+      id: run.id,
+      status: 'queued',
+      assistantMessageId: 'm1',
+    });
+
+    runs.setAnalyticsRecovery(run, {
+      context: {
+        deviceId: 'device-1',
+        sessionId: 'session-1',
+        clientType: 'desktop',
+        locale: 'zh-CN',
+      },
+      properties: {
+        page_name: 'chat_panel',
+        area: 'chat_panel',
+        project_id: 'p1',
+        conversation_id: 'c1',
+        run_id: run.id,
+      },
+      insertId: 'run-created-1',
+    });
+    run.status = 'running';
+    runs.emit(run, 'start', { status: 'running' });
+    runs.finish(run, 'failed', 1, null);
+    runs.markAnalyticsCompleted(run);
+    runs.markLangfuseCompleted(run);
+
+    expect(JSON.parse(fs.readFileSync(statePath, 'utf8'))).toMatchObject({
+      status: 'failed',
+      exitCode: 1,
+      analyticsRecovery: {
+        insertId: 'run-created-1',
+        completedAt: expect.any(Number),
+      },
+      langfuseCompletedAt: expect.any(Number),
+    });
+  });
+
   it('persists native session recovery diagnostics in the run event log', async () => {
     const runs = createRunsWithLog(tmpDir);
     const run = runs.create({ projectId: 'p1' });

--- a/apps/daemon/tests/telemetry-message-finalization.test.ts
+++ b/apps/daemon/tests/telemetry-message-finalization.test.ts
@@ -371,6 +371,7 @@ describe('Langfuse message finalization gate', () => {
       events: [],
     };
     const capture = vi.fn();
+    const markLangfuseCompleted = vi.fn();
     const report = vi.fn(async () => ({
       langfuse_expected: true,
       langfuse_delivery_status: 'accepted' as const,
@@ -379,7 +380,7 @@ describe('Langfuse message finalization gate', () => {
       design: {
         analytics: { capture },
         getAppVersion: () => '0.7.0',
-        runs: { get: vi.fn(() => run) },
+        runs: { get: vi.fn(() => run), markLangfuseCompleted },
       },
       db: 'db',
       dataDir: '/tmp/od-data',
@@ -420,6 +421,7 @@ describe('Langfuse message finalization gate', () => {
         }),
       }),
     );
+    expect(markLangfuseCompleted).toHaveBeenCalledWith(run);
   });
 
   it('falls back to the run analytics context when final message headers are missing', async () => {

--- a/packages/contracts/src/analytics/events/result-events.ts
+++ b/packages/contracts/src/analytics/events/result-events.ts
@@ -230,6 +230,10 @@ export interface RunFinishedProps extends Omit<RunCreatedProps, 'area'> {
   failure_stage?: TrackingRunFailureStage;
   retryable?: boolean;
   user_action?: TrackingRunFailureUserAction;
+  // A daemon boot repaired a terminal state that was interrupted before the
+  // normal PostHog/Langfuse finalization path completed.
+  terminal_reconciled?: boolean;
+  terminal_recovery_reason?: 'daemon_restart' | 'analytics_incomplete';
   langfuse_trace_id?: string;
   langfuse_expected?: boolean;
   langfuse_drop_reason?: TrackingLangfuseDropReason;

--- a/packages/contracts/tests/analytics-run-finished-contract.test.ts
+++ b/packages/contracts/tests/analytics-run-finished-contract.test.ts
@@ -52,6 +52,8 @@ describe('analytics run_finished contract', () => {
         failure_stage: 'session_init',
         retryable: true,
         user_action: 'retry',
+        terminal_reconciled: true,
+        terminal_recovery_reason: 'daemon_restart',
         langfuse_trace_id: 'trace-1',
         langfuse_expected: true,
         langfuse_delivery_status: 'failed',
@@ -94,6 +96,8 @@ describe('analytics run_finished contract', () => {
 
     expect(payload.props.failure_category).toBe('rate_limit');
     expect(payload.props.failure_stage).toBe('session_init');
+    expect(payload.props.terminal_reconciled).toBe(true);
+    expect(payload.props.terminal_recovery_reason).toBe('daemon_restart');
     expect(payload.props.user_action).toBe('retry');
     expect(payload.props.langfuse_delivery_status).toBe('failed');
     expect(payload.props.langfuse_drop_reason).toBe('relay_429');


### PR DESCRIPTION
## Why

While investigating the 0.15.0 agent reliability reports, PostHog and Langfuse showed a terminal-state gap: chat runs live only in daemon memory, while message reconciliation and telemetry finalization run asynchronously. If the daemon exits in that window, users can return to an assistant message permanently stuck in `queued`/`running`, and the matching `run_finished` or Langfuse trace may never arrive.

This PR makes those terminal obligations restart-safe without changing the run/SSE protocol.

## What users will see

After a daemon restart, an interrupted agent turn is shown as failed instead of remaining stuck in progress. Runs that had already reached a terminal state but had not finished PostHog or Langfuse reporting are replayed once from the durable checkpoint. Failed Langfuse delivery remains eligible for a later boot retry.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — no UI surface changed.

## Bug fix verification

- Test paths:
  - `apps/daemon/tests/runtimes/run-terminal-reconciliation.test.ts`
  - `apps/daemon/tests/runtimes/runs.test.ts`
  - `apps/daemon/tests/telemetry-message-finalization.test.ts`
  - `packages/contracts/tests/analytics-run-finished-contract.test.ts`
- The new restart-state and reconciliation specs failed on `main` (missing `state.json`, missing reconciliation module) and pass on this branch.
- Coverage includes interrupted-run failure, SQLite message repair, idempotent PostHog replay, accepted Langfuse checkpointing, retry after failed Langfuse delivery, and legacy queued-message repair.

## Validation

- `pnpm typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- 113 focused daemon tests across startup, analytics, Langfuse finalization, run observability, and durable run state
- 4 contracts analytics tests
- `git diff --check`
- `pnpm guard` reaches all relevant checks, but the repository currently fails the unrelated cross-app registry check because `apps/telemetry-worker/package.json` is missing on `main`.
