### PR TITLE
fix(web): make PPT/slide zoom actually take effect in desktop viewport

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -977,11 +977,31 @@ export function previewOverlayTransform(
 function previewScaleShellStyle(
   viewport: PreviewViewportId,
   previewScale: number,
+  options?: { isDeck?: boolean },
 ): CSSProperties & Record<string, string | number> {
   if (viewport === 'desktop') {
+    if (options?.isDeck) {
+      // For deck/slide previews the iframe renders at a fixed canvas size and
+      // zoom is optical-only, so the shell must keep the full canvas size and
+      // let `transform: scale()` actually scale it. Using `width: 100/scale%`
+      // here would cancel out the scale (an algebraic inverse), leaving the
+      // slide visually stuck at 100% regardless of the zoom value. The outer
+      // `.comment-frame-clip` already clips overflow for zoom-in.
+      return {
+        width: '100%',
+        height: '100%',
+        transform: `scale(${previewScale})`,
+        transformOrigin: '0 0',
+      };
+    }
+    // For non-deck HTML previews (the auto-fit / reflow flow described in #5751)
+    // the inverse-percentage trick is intentional browser-zoom semantics: the
+    // layout box grows by 1/scale so content reflows, then `transform: scale()`
+    // shrinks it back to fit the clip. This lets zoom-out show more content
+    // instead of just optically shrinking the same layout.
     return {
-      width: '100%',
-      height: '100%',
+      width: `${100 / previewScale}%`,
+      height: `${100 / previewScale}%`,
       transform: `scale(${previewScale})`,
       transformOrigin: '0 0',
     };
@@ -3675,7 +3695,7 @@ function FileVersionManagerModal({
                     style={previewViewportStyle(previewViewport, 1, previewFrameSize, { canvasPadding: 24 })}
                   >
                     <div className="preview-frame-clip">
-                      <div style={previewScaleShellStyle(previewViewport, 1)}>
+                      <div style={previewScaleShellStyle(previewViewport, 1, { isDeck: isDeckPreview })}>
                         <iframe
                           ref={versionPreviewIframeRef}
                           title={selectedVersion ? `${file.name} v${selectedVersion.version}` : file.name}
@@ -12118,7 +12138,7 @@ function HtmlViewer({
                   style={
                     manualEditMode
                       ? manualEditPreviewShellStyle(previewViewport, previewScale, manualEditViewportWidth)
-                      : previewScaleShellStyle(previewViewport, previewScale)
+                      : previewScaleShellStyle(previewViewport, previewScale, { isDeck: effectiveDeck })
                   }
                 >
                   <PreviewDrawOverlay

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -980,8 +980,8 @@ function previewScaleShellStyle(
 ): CSSProperties & Record<string, string | number> {
   if (viewport === 'desktop') {
     return {
-      width: `${100 / previewScale}%`,
-      height: `${100 / previewScale}%`,
+      width: '100%',
+      height: '100%',
       transform: `scale(${previewScale})`,
       transformOrigin: '0 0',
     };


### PR DESCRIPTION
## Summary

Fixes #5805 — PPT/slide preview zoom controls did not visually affect the slide.

## Root cause

`previewScaleShellStyle` returned this style for the desktop viewport:

```ts
{
  width: `${100 / previewScale}%`,
  height: `${100 / previewScale}%`,
  transform: `scale(${previewScale})`,
  transformOrigin: "0 0",
}
```

For **non-deck HTML previews** this inverse-percentage trick is intentional browser-zoom semantics: the shell layout box grows by `1/scale` so iframe content reflows, then `transform: scale(scale)` shrinks it back to fill the clip. This is what powers #5751 auto-fit wide HTML previews.

For **deck/slide previews** the slide iframe renders at a fixed canvas size and zoom should be **optical only**. The same inverse math cancels out:

```
shell_w = (100 / scale) * canvas_w
visual_w = shell_w * scale = canvas_w  (constant — zoom slider has no visible effect)
```

So the zoom slider never visibly scaled the slide preview.

## Fix

Scope the fix to deck previews only by adding an `isDeck` option to `previewScaleShellStyle`:

- `isDeck: true` → fixed `width: 100%; height: 100%` shell so `transform: scale()` actually scales the canvas. Outer `.comment-frame-clip` already has `overflow: hidden`, so zoom-in clips (PowerPoint-style) instead of overflowing.
- `isDeck: false / undefined` → unchanged inverse-percentage path (preserves #5751 auto-fit reflow behavior).

### Call sites updated

| Call site | Deck signal | Behavior |
|---|---|---|
| HtmlViewer main preview (~L12121) | `effectiveDeck` | New deck path when previewing a deck |
| File-version preview modal (~L3678) | `isDeckPreview` | New deck path for deck version previews |
| LiveArtifactViewer (~L1874) | none | Unchanged legacy path (live artifact iframe is not a deck) |

## Surface area

- **Files changed**: `apps/web/src/components/FileViewer.tsx` (single file, +24/-4)
- **Functions changed**: `previewScaleShellStyle` (signature add `options?: { isDeck?: boolean }`, new deck branch only)
- **Call sites touched**: 2 of 3 (`HtmlViewer`, `FileVersionPreviewModal`). `LiveArtifactViewer` left unchanged.
- **No CSS changes**: relies on existing `.comment-frame-clip { overflow: hidden }` for zoom-in clipping
- **No new exported symbols**, no public API change, no i18n change
- **Coverage**: existing jsdom tests assert `transform: scale(0.625)` but not shell width — deck branch is exercised by Playwright visual + UI P0 critical paths already in CI

## Validation

- [x] `npx tsc --noEmit -p apps/web/tsconfig.json` — no FileViewer/type errors
- [ ] CI: Web workspace tests
- [ ] CI: Playwright critical (entry-settings / project-workspace / project-runtime / workspace-restoration)
- [ ] CI: Playwright visual (entry-navigation, settings-workspace)
- [ ] CI: UI P0 smoke + entry-settings + project-workspace + project-runtime + workspace-restoration
- [ ] Manual: open PPT/slide artifact → change zoom (50/100/150/200%) → slide visually scales
- [ ] Manual: switch to mobile/tablet viewport → zoom still works (unchanged code path)
- [ ] Manual: non-deck HTML preview → zoom still reflows content (#5751 auto-fit preserved)
- [ ] Manual: file-version preview modal → deck preview zoom works

## Notes

- Followed `mrcfps` CHANGES_REQUESTED review on the initial commit: shared shell change regressed non-deck HTML auto-fit. The deck-only `isDeck` option preserves the legacy reflow semantics for non-deck paths.
- Per `lefarcen` request: not self-merging, holding for manual QA pass.
- Mobile/tablet viewports never affected (they use `var(--preview-viewport-width) * scale` on the parent, not inverse-percentage shell).

Fixes #5805