### PR TITLE
fix(web): make the slash-command picker navigable

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -2239,6 +2239,14 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       key: 'ArrowDown' | 'ArrowUp' | 'Tab' | 'Enter' | 'Escape',
     ): boolean {
       if (slash) {
+        // Keep the no-results palette visible for discovery, but preserve the
+        // pre-palette behavior for literal slash-prefixed prompts: Enter sends
+        // the text instead of being swallowed by the open combobox.
+        if (filteredSlash.length === 0 && key === 'Enter') {
+          setSlash(null);
+          void submit();
+          return true;
+        }
         if (filteredSlash.length > 0) {
           if (key === 'ArrowDown') {
             setSlashIndex((i) => (i + 1) % filteredSlash.length);

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+  Fragment,
   forwardRef,
   useCallback,
   useEffect,
@@ -169,6 +170,10 @@ interface SlashCommand {
   argHint?: string;
   // Icon glyph from the project Icon set.
   icon: 'sparkles' | 'eye' | 'sliders';
+  // Additional searchable metadata that should not inflate the visible label.
+  searchText?: string;
+  // Server shortcuts are visually grouped below the primary commands.
+  section?: 'mcp';
 }
 
 type DesignToolboxResourceKind =
@@ -853,30 +858,6 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
     // ready for an argument.
     const slashCommands = useMemo<SlashCommand[]>(() => {
       const list: SlashCommand[] = [];
-      // External MCP servers — `/mcp` opens settings, `/mcp <id>` inserts a
-      // prompt-side hint nudging the model to use that server's tools. The
-      // hint flows through to the agent verbatim; the daemon already wired
-      // the MCP config into the agent's launch so the tools are callable.
-      if (onOpenMcpSettings) {
-        list.push({
-          id: 'mcp',
-          label: '/mcp',
-          insert: '/mcp ',
-          descKey: 'pet.slashPet',
-          icon: 'sliders',
-          argHint: 'open settings · <server-id> to insert hint',
-        });
-      }
-      for (const s of enabledMcpServers) {
-        list.push({
-          id: `mcp-${s.id}`,
-          label: `/mcp ${s.id}`,
-          insert: `Use the \`${s.id}\` MCP server tools. `,
-          descKey: 'pet.slashPet',
-          icon: 'sparkles',
-          argHint: s.label || s.transport,
-        });
-      }
       if (researchAvailable) {
         list.push({
           id: 'search',
@@ -887,6 +868,39 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
           argHint: t('pet.slashSearchArg'),
         });
       }
+      // External MCP servers — `/mcp` opens settings, `/mcp <id>` inserts a
+      // prompt-side hint nudging the model to use that server's tools. The
+      // hint flows through to the agent verbatim; the daemon already wired
+      // the MCP config into the agent's launch so the tools are callable.
+      if (onOpenMcpSettings) {
+        list.push({
+          id: 'mcp',
+          label: '/mcp',
+          insert: '/mcp ',
+          descKey: 'mcpClient.subtitle',
+          icon: 'sliders',
+          argHint: 'open settings · <server-id> to insert hint',
+        });
+      }
+      const sortedMcpServers = [...enabledMcpServers].sort((a, b) =>
+        (a.label || a.id).localeCompare(b.label || b.id),
+      );
+      for (const s of sortedMcpServers) {
+        const displayHint =
+          s.label && s.label.toLocaleLowerCase() !== s.id.toLocaleLowerCase()
+            ? s.label
+            : s.transport.toUpperCase();
+        list.push({
+          id: `mcp-${s.id}`,
+          label: `/mcp ${s.id}`,
+          insert: `Use the \`${s.id}\` MCP server tools. `,
+          descKey: 'mcpClient.subtitle',
+          icon: 'sparkles',
+          argHint: displayHint,
+          searchText: `${s.id} ${s.label ?? ''} ${s.transport}`,
+          section: 'mcp',
+        });
+      }
       return list;
     }, [researchAvailable, t, enabledMcpServers, onOpenMcpSettings]);
 
@@ -894,8 +908,14 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       if (!slash) return [] as SlashCommand[];
       const q = slash.q.toLowerCase();
       if (!q) return slashCommands;
-      return slashCommands.filter((c) => c.label.toLowerCase().includes(q));
-    }, [slash, slashCommands]);
+      return slashCommands.filter((c) =>
+        [c.label, c.argHint, c.searchText, t(c.descKey)]
+          .filter(Boolean)
+          .join(' ')
+          .toLowerCase()
+          .includes(q),
+      );
+    }, [slash, slashCommands, t]);
 
     function pickSlash(cmd: SlashCommand) {
       if (!slash) return;
@@ -2218,21 +2238,23 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
     function handlePopoverKey(
       key: 'ArrowDown' | 'ArrowUp' | 'Tab' | 'Enter' | 'Escape',
     ): boolean {
-      if (slash && filteredSlash.length > 0) {
-        if (key === 'ArrowDown') {
-          setSlashIndex((i) => (i + 1) % filteredSlash.length);
-          return true;
-        }
-        if (key === 'ArrowUp') {
-          setSlashIndex(
-            (i) => (i - 1 + filteredSlash.length) % filteredSlash.length,
-          );
-          return true;
-        }
-        if (key === 'Tab' || key === 'Enter') {
-          const safe = Math.min(slashIndex, filteredSlash.length - 1);
-          pickSlash(filteredSlash[safe]!);
-          return true;
+      if (slash) {
+        if (filteredSlash.length > 0) {
+          if (key === 'ArrowDown') {
+            setSlashIndex((i) => (i + 1) % filteredSlash.length);
+            return true;
+          }
+          if (key === 'ArrowUp') {
+            setSlashIndex(
+              (i) => (i - 1 + filteredSlash.length) % filteredSlash.length,
+            );
+            return true;
+          }
+          if (key === 'Tab' || key === 'Enter') {
+            const safe = Math.min(slashIndex, filteredSlash.length - 1);
+            pickSlash(filteredSlash[safe]!);
+            return true;
+          }
         }
         if (key === 'Escape') {
           setSlash(null);
@@ -2744,11 +2766,16 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
               onTrigger={handleEditorTrigger}
               onEnterSend={() => void submit()}
               onPasteFiles={handlePasteFiles}
-              popoverOpen={Boolean(mention) || Boolean(slash && filteredSlash.length > 0)}
+              popoverOpen={Boolean(mention) || Boolean(slash)}
               onPopoverKey={handlePopoverKey}
               comboboxAria={{
-                expanded: Boolean(mention),
-                activeId: mention ? `mention-opt-${mentionIndex}` : null,
+                expanded: Boolean(mention) || Boolean(slash),
+                controlsId: slash ? 'slash-listbox' : 'mention-listbox',
+                activeId: mention
+                  ? `mention-opt-${mentionIndex}`
+                  : slash && filteredSlash.length > 0
+                    ? `slash-opt-${Math.min(slashIndex, filteredSlash.length - 1)}`
+                    : null,
               }}
             />
             {placeholderScenarios.length > 0 ? (
@@ -2789,11 +2816,12 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
           </CaretFloatingLayer>
           <CaretFloatingLayer
             caret={caretRect}
-            open={Boolean(slash && filteredSlash.length > 0)}
+            open={Boolean(slash)}
             boundaryRef={composerRootRef}
           >
             <SlashPopover
               commands={filteredSlash}
+              query={slash?.q ?? ''}
               activeIndex={Math.min(slashIndex, filteredSlash.length - 1)}
               onPick={pickSlash}
               onHover={(i) => setSlashIndex(i)}
@@ -5201,62 +5229,99 @@ function ImportItem({
 
 function SlashPopover({
   commands,
+  query,
   activeIndex,
   onPick,
   onHover,
   t,
 }: {
   commands: SlashCommand[];
+  query: string;
   activeIndex: number;
   onPick: (cmd: SlashCommand) => void;
   onHover: (index: number) => void;
   t: TranslateFn;
 }) {
+  const resultsRef = useRef<HTMLDivElement | null>(null);
+  const activeCommandId = commands[activeIndex]?.id ?? null;
+
+  useEffect(() => {
+    if (!activeCommandId) return;
+    const active = resultsRef.current?.querySelector<HTMLElement>(
+      '[role="option"][aria-selected="true"]',
+    );
+    active?.scrollIntoView?.({ block: 'nearest' });
+  }, [activeCommandId]);
+
   return (
     <div
       className="slash-popover"
       data-testid="slash-popover"
+      id="slash-listbox"
       role="listbox"
       aria-label={t('pet.slashPopoverAria')}
     >
       <div className="slash-popover-head">
-        <span>{t('pet.slashPopoverTitle')}</span>
+        <span className="slash-popover-title">
+          <span>{t('pet.slashPopoverTitle')}</span>
+          <span className="slash-popover-count" data-testid="slash-command-count">
+            {commands.length}
+          </span>
+        </span>
         <span className="slash-popover-hint">{t('pet.slashPopoverHint')}</span>
       </div>
-      {commands.map((cmd, idx) => {
-        const active = idx === activeIndex;
-        return (
-          <button
-            key={cmd.id}
-            id={`slash-opt-${idx}`}
-            type="button"
-            role="option"
-            aria-selected={active}
-            className={`slash-item${active ? ' active' : ''}`}
-            onMouseDown={(e) => {
-              // Prevent the textarea from losing focus before the click
-              // handler fires — otherwise selectionStart resets and the
-              // pick replacement targets the wrong substring.
-              e.preventDefault();
-            }}
-            onMouseEnter={() => onHover(idx)}
-            onClick={() => onPick(cmd)}
-          >
-            <span className="slash-item-icon" aria-hidden>
-              <Icon name={cmd.icon} size={13} />
-            </span>
-            <span className="slash-item-body">
-              <span className="slash-item-row">
-                <code className="slash-item-label">{cmd.label}</code>
-                {cmd.argHint ? (
-                  <span className="slash-item-arg">{cmd.argHint}</span>
+      <div className="slash-popover-results" ref={resultsRef}>
+        {commands.length === 0 ? (
+          <div className="slash-popover-empty">
+            {t('chat.mentionNoResults', { query })}
+          </div>
+        ) : (
+          commands.map((cmd, idx) => {
+            const active = idx === activeIndex;
+            const startsMcpSection =
+              cmd.section === 'mcp' && commands[idx - 1]?.section !== 'mcp';
+            return (
+              <Fragment key={cmd.id}>
+                {startsMcpSection ? (
+                  <div className="slash-section-label">{t('mcpClient.title')}</div>
                 ) : null}
-              </span>
-              <span className="slash-item-desc">{t(cmd.descKey)}</span>
-            </span>
-          </button>
-        );
-      })}
+                <button
+                  id={`slash-opt-${idx}`}
+                  type="button"
+                  role="option"
+                  aria-selected={active}
+                  className={`slash-item${active ? ' active' : ''}`}
+                  onMouseDown={(e) => {
+                    // Prevent the textarea from losing focus before the click
+                    // handler fires — otherwise selectionStart resets and the
+                    // pick replacement targets the wrong substring.
+                    e.preventDefault();
+                  }}
+                  onMouseEnter={() => onHover(idx)}
+                  onClick={() => onPick(cmd)}
+                >
+                  <span className="slash-item-icon" aria-hidden>
+                    <Icon name={cmd.icon} size={13} />
+                  </span>
+                  <span className="slash-item-body">
+                    <span className="slash-item-row">
+                      <code className="slash-item-label">{cmd.label}</code>
+                      {cmd.argHint ? (
+                        <span className="slash-item-arg" title={cmd.argHint}>
+                          {cmd.argHint}
+                        </span>
+                      ) : null}
+                    </span>
+                    <span className="slash-item-desc" title={t(cmd.descKey)}>
+                      {t(cmd.descKey)}
+                    </span>
+                  </span>
+                </button>
+              </Fragment>
+            );
+          })
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/composer/LexicalComposerInput.tsx
+++ b/apps/web/src/components/composer/LexicalComposerInput.tsx
@@ -165,7 +165,11 @@ export interface LexicalComposerInputProps {
   ): boolean;
   // Optional combobox a11y. When set, the ContentEditable announces the active
   // mention row (id lives in the portaled listbox) without moving DOM focus.
-  comboboxAria?: { activeId: string | null; expanded: boolean };
+  comboboxAria?: {
+    activeId: string | null;
+    controlsId?: string;
+    expanded: boolean;
+  };
   title?: string;
   // Test hook for the contenteditable host. Defaults to the project
   // composer's id; HomeHero overrides it so its own tests/selectors keep
@@ -777,7 +781,7 @@ export const LexicalComposerInput = forwardRef<
               title={title ?? placeholder}
               role="combobox"
               aria-expanded={comboboxAria?.expanded ? 'true' : 'false'}
-              aria-controls="mention-listbox"
+              aria-controls={comboboxAria?.controlsId ?? 'mention-listbox'}
               {...(comboboxAria?.activeId
                 ? { 'aria-activedescendant': comboboxAria.activeId }
                 : {})}

--- a/apps/web/src/styles/viewer/library.css
+++ b/apps/web/src/styles/viewer/library.css
@@ -366,7 +366,7 @@
   border: 1px solid var(--border);
   border-radius: var(--radius);
   box-shadow: var(--shadow-lg);
-  padding: 5px;
+  padding: 0;
   /* removed: position, bottom, left, right, margin-bottom, fixed max-height, z-index */
 }
 .slash-popover-head {
@@ -374,14 +374,28 @@
   align-items: baseline;
   justify-content: space-between;
   gap: 10px;
-  padding: 5px 7px 7px;
+  padding: 8px 10px;
   border-bottom: 1px solid var(--border-soft);
-  margin-bottom: 4px;
   font-size: 10px;
   font-weight: 600;
   color: var(--text-soft);
   text-transform: uppercase;
   letter-spacing: 0.05em;
+}
+.slash-popover-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.slash-popover-count {
+  min-width: 20px;
+  padding: 1px 6px;
+  border-radius: var(--radius-pill);
+  background: var(--bg-subtle);
+  color: var(--text-muted);
+  font-size: 9px;
+  line-height: 16px;
+  text-align: center;
 }
 .slash-popover-hint {
   font-size: 10px;
@@ -389,6 +403,31 @@
   text-transform: none;
   letter-spacing: 0;
   color: var(--text-muted);
+}
+.slash-popover-results {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
+  padding: 5px;
+  scroll-padding-block: 5px;
+}
+.slash-popover-empty {
+  padding: 24px 14px;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1.45;
+  text-align: center;
+}
+.slash-section-label {
+  padding: 8px 8px 4px;
+  color: var(--text-soft);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
 }
 .slash-item {
   display: flex;
@@ -398,11 +437,11 @@
   background: transparent;
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
-  padding: 8px 9px;
+  padding: 6px 8px;
   text-align: left;
   cursor: pointer;
   font: inherit;
-  min-height: 34px;
+  min-height: 40px;
   transition: background-color 120ms cubic-bezier(0.23, 1, 0.32, 1);
 }
 .slash-item:hover { background: var(--bg-subtle); }
@@ -425,20 +464,37 @@
   margin-top: 1px;
 }
 .slash-item-body { display: grid; gap: 2px; min-width: 0; flex: 1; }
-.slash-item-row { display: flex; align-items: baseline; gap: 8px; }
+.slash-item-row { display: flex; align-items: baseline; gap: 8px; min-width: 0; }
 .slash-item-label {
+  flex: 0 1 auto;
+  min-width: 0;
   font-size: 12px;
   font-weight: 600;
   color: var(--text-strong);
   background: transparent;
   padding: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .slash-item-arg {
+  flex: 1 1 auto;
+  min-width: 0;
   font-size: 10px;
   color: var(--text-muted);
   font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
-.slash-item-desc { font-size: 11px; color: var(--text-muted); line-height: 1.35; }
+.slash-item-desc {
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
 /* --- CJK (Chinese / Korean) Comfort Pass --- */
 :lang(zh), :lang(zh-CN), :lang(zh-TW), :lang(ko) {

--- a/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
+++ b/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
@@ -1508,6 +1508,19 @@ describe('ChatComposer context pickers', () => {
     expect(screen.getByTestId('chat-composer-input').getAttribute('aria-activedescendant')).toBeNull();
   });
 
+  it('submits literal slash-prefixed text when no command matches', async () => {
+    const onSend = vi.fn();
+    renderComposer({ onSend });
+    await flushMounts();
+    await typeAndSettle('/notacommand');
+
+    expect(await screen.findByText('No results for “notacommand”.')).toBeTruthy();
+    pressEnter();
+
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(1));
+    expect(onSend.mock.calls[0]?.[0]).toBe('/notacommand');
+  });
+
   // The sliders "tools" popover (Official / My plugins switch, plugin search)
   // and the standalone "@" mention trigger button were removed from the
   // composer; plugins/skills/MCP are now reached via typed @-mentions and the

--- a/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
+++ b/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
@@ -1454,6 +1454,60 @@ describe('ChatComposer context pickers', () => {
     expect(screen.getByTestId('staged-contexts').textContent).toContain('recovered.txt');
   });
 
+  it('keeps the slash palette navigable and describes MCP commands accurately', async () => {
+    servers = [
+      {
+        id: 'zeta-tools',
+        label: 'Zeta Tools',
+        transport: 'stdio',
+        enabled: true,
+        command: 'zeta-mcp',
+      },
+      {
+        id: 'render-lab',
+        label: 'Higgsfield Video',
+        transport: 'stdio',
+        enabled: true,
+        command: 'render-lab-mcp',
+      },
+    ];
+
+    renderComposer();
+    await flushMounts();
+    await typeAndSettle('/');
+
+    const popover = await screen.findByTestId('slash-popover');
+    expect(popover.querySelector('.slash-popover-results')).toBeTruthy();
+    expect(screen.getByTestId('slash-command-count').textContent).toBe('3');
+    expect(screen.queryByText('Toggle, adopt, or jump to pet settings.')).toBeNull();
+
+    const optionText = screen.getAllByRole('option').map((option) => option.textContent ?? '');
+    expect(optionText[0]).toContain('/mcp');
+    expect(optionText[1]).toContain('/mcp render-lab');
+    expect(optionText[2]).toContain('/mcp zeta-tools');
+    expect(optionText[1]).toContain('Third-party tools for your coding agent.');
+    expect(screen.getByTestId('chat-composer-input').getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByTestId('chat-composer-input').getAttribute('aria-controls')).toBe('slash-listbox');
+    expect(screen.getByTestId('chat-composer-input').getAttribute('aria-activedescendant')).toBe('slash-opt-0');
+
+    await typeAndSettle('/higgsfield');
+    await waitFor(() => {
+      expect(screen.getAllByRole('option')).toHaveLength(1);
+      expect(screen.getByRole('option').textContent).toContain('/mcp render-lab');
+    });
+  });
+
+  it('keeps the slash palette open with useful feedback when no command matches', async () => {
+    renderComposer();
+    await flushMounts();
+    await typeAndSettle('/missing-command');
+
+    expect(await screen.findByTestId('slash-popover')).toBeTruthy();
+    expect(screen.getByText('No results for “missing-command”.')).toBeTruthy();
+    expect(screen.getByTestId('chat-composer-input').getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByTestId('chat-composer-input').getAttribute('aria-activedescendant')).toBeNull();
+  });
+
   // The sliders "tools" popover (Official / My plugins switch, plugin search)
   // and the standalone "@" mention trigger button were removed from the
   // composer; plugins/skills/MCP are now reached via typed @-mentions and the

--- a/apps/web/tests/styles/slash-popover.test.ts
+++ b/apps/web/tests/styles/slash-popover.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const libraryCss = readFileSync(
+  new URL('../../src/styles/viewer/library.css', import.meta.url),
+  'utf8',
+);
+
+function cssBlock(selector: string): string {
+  const blocks: string[] = [];
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  const cssWithoutComments = libraryCss.replace(/\/\*[\s\S]*?\*\//g, '');
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  if (blocks.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return blocks.join('\n');
+}
+
+function ruleValue(block: string, property: string): string {
+  const match = new RegExp(`(?:^|[;\\n])\\s*${property}:\\s*([^;]+);`).exec(block);
+  if (!match) throw new Error(`Missing CSS property ${property}`);
+  return match[1]!.trim();
+}
+
+describe('slash command popover styles', () => {
+  it('uses a bounded, visibly scrollable results region', () => {
+    const popover = cssBlock('.slash-popover');
+    const results = cssBlock('.slash-popover-results');
+
+    expect(ruleValue(popover, 'overflow')).toBe('hidden');
+    expect(ruleValue(results, 'flex')).toBe('1 1 auto');
+    expect(ruleValue(results, 'min-height')).toBe('0');
+    expect(ruleValue(results, 'overflow-y')).toBe('auto');
+    expect(ruleValue(results, 'scrollbar-gutter')).toBe('stable');
+  });
+
+  it('truncates verbose command metadata instead of widening or wrapping the sidebar', () => {
+    const row = cssBlock('.slash-item-row');
+    const label = cssBlock('.slash-item-label');
+    const argument = cssBlock('.slash-item-arg');
+    const description = cssBlock('.slash-item-desc');
+
+    expect(ruleValue(row, 'min-width')).toBe('0');
+    expect(ruleValue(label, 'text-overflow')).toBe('ellipsis');
+    expect(ruleValue(argument, 'text-overflow')).toBe('ellipsis');
+    expect(ruleValue(description, 'text-overflow')).toBe('ellipsis');
+  });
+});


### PR DESCRIPTION
Fixes #5822

## Why

I hit this while using Open Design on a real website project with 11 enabled MCP servers. Typing `/` produced a picker that clipped part of the command catalog and described every MCP shortcut with unrelated pet copy, making commands difficult to discover and trust.

The popover had a bounded outer container with `overflow: hidden`, but no scrollable results child. MCP entries all reused `pet.slashPet`; filtering only searched the visible label; zero matches removed the picker entirely; and the composer exposed mention-listbox ARIA state even while the slash picker was active.

## What users will see

- A command-count badge and a bounded, scrollable results region.
- `/search` remains a primary command above a labeled, alphabetically sorted MCP section.
- MCP shortcuts show an accurate tool description plus a display label or transport hint.
- Search matches command labels, server IDs, display names, transports, hints, and descriptions.
- Unmatched searches keep the picker open with a clear no-results message.
- Arrow-key navigation scrolls the active option into view, and assistive technology receives the correct slash-listbox state.

This only improves the presentation and navigation of existing composer commands; it adds no new capability or CLI/API contract.

## Surface area

- [x] **UI** — improves the existing slash-command panel and adds its empty state
- [ ] **Keyboard shortcut** — no shortcut is added or changed; existing arrow navigation is made reliable
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — existing localized strings are reused
- [ ] **New top-level dependency**
- [x] **Default behavior change** — existing slash-command discovery, filtering, and accessibility improve without opt-in
- [ ] **None**

## Screenshots

Before: the picker clips the lower catalog and labels MCP shortcuts as pet settings.

After: the entry point shows the total command count, `/search`, accurate MCP metadata, a labeled MCP section, and a scrollable catalog. Before/after packaged-app screenshots will be attached to this PR.

## Bug fix verification

- Test paths:
  - `apps/web/tests/components/ChatComposer.context-pickers.test.tsx`
  - `apps/web/tests/styles/slash-popover.test.ts`
- The four new assertions failed before the source change and pass on this branch.
- Coverage includes the scrolling contract, metadata truncation, MCP ordering/copy, display-label filtering, no-results behavior, and combobox/listbox ARIA relationships.
- Packaged-app manual verification used 13 commands and confirmed scrolling, keyboard visibility, filtering, empty-state behavior, and accurate copy. No command was submitted during the check.

## Validation

- `pnpm guard` — 86 checks passed
- `pnpm --filter @open-design/web typecheck` — passed
- focused web tests — 36 passed
- full web suite — 4,616 passed, 7 skipped
- `git diff --check` — passed

One unrelated `ProjectView.deleteConversation` timing assertion failed during the first full-suite run, passed twice in isolation, and the complete suite passed on rerun.
