### PR TITLE
fix(i18n): localize BYOK provider titles to English

### DIFF
--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -509,14 +509,14 @@ const BYOK_PROVIDER_PRESET_SPECS = [
   { id: 'xai', title: 'xAI', providerLabel: 'xAI' },
   { id: 'together', title: 'Together AI', providerLabel: 'Together AI' },
   { id: 'huggingface', title: 'Hugging Face', providerLabel: 'Hugging Face' },
-  { id: 'qwen', title: '千问', providerLabel: 'Qwen' },
-  { id: 'volcengine', title: '火山引擎', providerLabel: 'Volcengine Ark' },
-  { id: 'qianfan', title: '百度千帆', providerLabel: 'Baidu Qianfan' },
+  { id: 'qwen', title: 'Qwen', providerLabel: 'Qwen' },
+  { id: 'volcengine', title: 'Volcengine Ark', providerLabel: 'Volcengine Ark' },
+  { id: 'qianfan', title: 'Baidu Qianfan', providerLabel: 'Baidu Qianfan' },
   { id: 'vllm', title: 'vLLM', providerLabel: 'vLLM' },
-  { id: 'mimo', title: '小米 MiMo', providerLabel: 'MiMo (Xiaomi) — OpenAI' },
+  { id: 'mimo', title: 'Xiaomi MiMo', providerLabel: 'MiMo (Xiaomi) — OpenAI' },
   { id: 'minimax', title: 'MiniMax', providerLabel: 'MiniMax — Anthropic (CN)' },
   { id: 'moonshot', title: 'Moonshot', providerLabel: 'Moonshot' },
-  { id: 'zhipu', title: '智谱', providerLabel: 'Zhipu' },
+  { id: 'zhipu', title: 'Zhipu AI', providerLabel: 'Zhipu' },
 ] as const;
 
 export const BYOK_PROVIDER_PRESETS: ReadonlyArray<ByokProviderPresetConfig> =

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1187,7 +1187,7 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     expect(screen.getByText('Model discovery is not available for this protocol.')).toBeTruthy();
 
     fetchProviderModelsMock.mockClear();
-    fireEvent.click(screen.getByRole('tab', { name: '小米 MiMo' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Xiaomi MiMo' }));
     await new Promise((resolve) => window.setTimeout(resolve, 350));
 
     expect(fetchProviderModelsMock).not.toHaveBeenCalled();
@@ -1625,7 +1625,7 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
       apiProviderBaseUrl: 'https://open.bigmodel.cn/api/paas/v4',
     });
 
-    fireEvent.click(screen.getByRole('tab', { name: '智谱' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Zhipu AI' }));
 
     expect(await screen.findByText('✓ Loaded 8 models from your account.')).toBeTruthy();
     fireEvent.click(screen.getByRole('combobox', { name: 'Model' }));


### PR DESCRIPTION
## Why

In English UI mode the BYOK provider chip list under Settings > Execution mode was a mixed-language list: most providers were already English, but five remained in Chinese (`千问` / `火山引擎` / `百度千帆` / `小米 MiMo` / `智谱`). This is a long-standing i18n polish bug tracked in #5693 — I picked it up because it's tightly scoped, single-file, no behavior change, exactly the kind of small leak that accumulates if not fixed.

## What users will see

In English UI mode (Settings > Execution mode > BYOK provider chip list), the five previously-Chinese chips now read `Qwen` / `Volcengine Ark` / `Baidu Qianfan` / `Xiaomi MiMo` / `Zhipu AI`, alongside the already-English `Anthropic` / `OpenAI` / `xAI` / `Mistral AI` / … Nothing else changes — provider routing, gateway lookup, and existing user configs are untouched. In Chinese UI mode the chips were never localized (these are brand names matching `Anthropic` / `OpenAI` / etc.), so the new English titles are consistent with the existing treatment of other provider brand names in zh.

## Root cause

`apps/web/src/state/config.ts` defines a `BYOK_PROVIDER_PRESET_SPECS` array, and each entry has both a `title` (used as the chip display name) and a `providerLabel` (used as the canonical provider identifier in `KNOWN_PROVIDERS`). For five entries, `title` was hardcoded in Chinese while `providerLabel` was already in English. The chip list renders `title` verbatim, so the Chinese strings were shown in English mode.

| id | old title | new title | providerLabel (unchanged) |
|---|---|---|---|
| `qwen` | 千问 | Qwen | Qwen |
| `volcengine` | 火山引擎 | Volcengine Ark | Volcengine Ark |
| `qianfan` | 百度千帆 | Baidu Qianfan | Baidu Qianfan |
| `mimo` | 小米 MiMo | Xiaomi MiMo | MiMo (Xiaomi) — OpenAI |
| `zhipu` | 智谱 | Zhipu AI | Zhipu |

## Fix

Replace the five Chinese `title` strings with English-facing names. The chosen titles mirror the existing English `providerLabel` phrasing where the providerLabel read naturally as a standalone name (`Qwen`, `Volcengine Ark`, `Baidu Qianfan`, `Zhipu AI`), and use a friendly "Xiaomi MiMo" for `mimo` where `providerLabel` carried an "OpenAI" suffix not appropriate for a chip title.

## Surface area

- [x] **UI** — chip labels in the BYOK provider chip list under Settings > Execution mode (5 strings changed in `apps/web/src/state/config.ts`).
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — no new translation keys introduced; the `title` field is the raw display string and was never localized. The five edits rewrite existing display strings to English. See `TRANSLATIONS.md` for the locale workflow — this PR doesn't touch it.
- [ ] **New top-level dependency** — none
- [ ] **Default behavior change** — none. `providerLabel` for the five entries is unchanged, so `KNOWN_PROVIDERS` lookup, gateway routing, and existing user configs match as before. Existing users only see the chip label change.
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Chip-level text-only change; visual regression bot auto-attached the affected cases (visual-settings-byok, visual-settings-byok-model-dropdown, visual-settings-byok-openai) below — diffs are sub-0.6% and show the renamed chips only.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/SettingsDialog.execution.test.tsx` — two existing assertions hardcoded the old Chinese tab accessible names (`小米 MiMo` at line ~1190, `智谱` at line ~1628). After the source change these tests go red because the accessible name derives from the same `title` field that the chip renders.
- Did the test go red on `main` and green on this branch? Yes — without the test patch (commit b45b0ea), `Web workspace tests` would fail with "unable to find role=tab with name `小米 MiMo`". With both source and test commits applied, Web workspace tests pass (CI run 29579572895).
- This isn't a new falsifiable red-spec — the existing tests already encoded the old contract via the old accessible names. The fix surfaces them as a name-only delta, so we update the existing assertions rather than adding a new spec. Per AGENTS.md, red-spec work isn't required when a test that already encodes the contract goes red on `main`; that's the case here.

## Validation

- [x] `grep -rn "title:.*千问\|title:.*火山引擎\|title:.*百度千帆\|title:.*小米 MiMo\|title:.*智谱" apps/web/src` returns 0 matches after the fix.
- [x] Verified no other Chinese provider names leaked into `media/models.ts`, `i18n/locales/*`, or other presets.
- [x] Diff is 5 lines changed, 0 net new lines in `apps/web/src/state/config.ts` — preserves `vllm` row that sits between the edited entries.
- [x] CI: Web workspace tests — passed (run 29579572895).
- [x] CI: Static gate / Preflight / E2E Vitest / UI P0 smoke / UI P0 (entry-settings) / UI P0 (project-workspace) / UI P0 (project-runtime) / UI P0 (workspace-restoration) / Playwright visual (entry-navigation) / Playwright visual (settings-workspace) / Validate workspace / Runtime summary — all SUCCESS.
- [x] CI: TypeScript build (verifies the `as const` tuple shape is preserved) — covered by Static gate + Workspace unit tests; both green.
- [ ] Manual: set UI language to English → open Settings → Execution mode → BYOK → all provider chips are now English — held for maintainer QA (per lefarcen's standing request, not self-merging).
- [ ] Manual: set UI language to Chinese → confirm the providers still appear correctly — held for maintainer QA. The chip title will be English `Qwen` / `Volcengine Ark` / `Baidu Qianfan` / `Xiaomi MiMo` / `Zhipu AI`; these are brand names and were not localized in zh either, matching the existing treatment of `Anthropic` / `OpenAI` / `xAI` / `Mistral AI`.

## Notes

- Per lefarcen's standing request on prior PRs: not self-merging, holding for manual QA pass.
- mrcfps's prior review feedback on #5820 about scoped-vs-broader changes is reflected here — only the five reported entries are modified; `vllm` sitting between them is left untouched, no helper introduced, no shared i18n utility added (would be over-scope for an i18n-only fix).
- Related: #5697 by @coyaSONG is a broader fix in the same area; this PR intentionally takes the narrow path to keep the risk surface minimal.

Fixes #5693
