### PR TITLE
Fix image export viewport sizing

### DIFF
--- a/apps/daemon/tests/screenshot-export-file-handoff.test.ts
+++ b/apps/daemon/tests/screenshot-export-file-handoff.test.ts
@@ -209,6 +209,20 @@ describe('screenshot export desktop renderer file handoff', () => {
     expect(seenInputs.at(-1)?.height).toBe(720);
   });
 
+  it('forwards dedicated image export viewport dimensions to the renderer', async () => {
+    const before = seenInputs.length;
+    const res = await fetch(`${baseUrl}/api/projects/${projectId}/export/image`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fileName: 'page.html', deck: false, width: 390, height: 844 }),
+    });
+    expect(res.status).toBe(200);
+    expect(seenInputs.length).toBe(before + 1);
+    expect(seenInputs.at(-1)?.deck).toBe(false);
+    expect(seenInputs.at(-1)?.width).toBe(390);
+    expect(seenInputs.at(-1)?.height).toBe(844);
+  });
+
   it('routes generic POST /export pdf through the raster screenshot renderer, not the vector path', async () => {
     // Regression: the generic /export route used to render `format: pdf` with the
     // vector printToPDF path (desktopArtifactExporter), which drops CJK glyphs in

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -10394,9 +10394,11 @@ function HtmlViewer({
     // in the browser screenshot flow (DesignBrowserPanel).
     await waitForAnimationFrame();
     await waitForAnimationFrame();
-    // Prefer the daemon's off-screen render (desktop only): viewport-independent
-    // and, rendering the artifact alone in a hidden window, it can never capture
-    // Open Design's own UI. `wholeDeck` (Export as image) stitches every slide
+    // Prefer the daemon's off-screen render (desktop only): isolated from the
+    // preview pane and, rendering the artifact alone in a hidden window, it can
+    // never capture Open Design's own UI. Page exports use the selected preview
+    // preset; desktop pages and decks retain the renderer defaults. `wholeDeck`
+    // (Export as image) stitches every slide
     // top-to-bottom into one long image — matching the slide count the viewer
     // reports; otherwise (Copy screenshot, Mark/Draw capture) it grabs the
     // CURRENT slide, mirroring what's on screen. An ordinary page is its
@@ -10417,11 +10419,16 @@ function HtmlViewer({
       const trackedActive = slideState?.active ?? htmlPreviewSlideState.get(previewStateKey)?.active ?? null;
       const plan = planDeckImageCapture({ deck: imageDeckSignal, wholeDeck, trackedActive });
       if (plan.useOffscreen) {
+        const exportViewport = !imageDeckSignal && previewViewport !== 'desktop'
+          ? PREVIEW_VIEWPORT_PRESETS.find((preset) => preset.id === previewViewport)
+          : null;
         const rendered = await exportProjectImageDataUrl({
           projectId,
           fileName: file.name,
           deck: imageDeckSignal,
           ...(plan.index != null ? { index: plan.index } : {}),
+          ...(exportViewport?.width != null ? { width: exportViewport.width } : {}),
+          ...(exportViewport?.height != null ? { height: exportViewport.height } : {}),
           ...(exportContext?.versionId ? { versionId: exportContext.versionId } : {}),
         });
         if (rendered.ok) return rendered.snapshot;
@@ -10486,6 +10493,7 @@ function HtmlViewer({
     deckExportSignalForContext,
     slideState?.active,
     previewStateKey,
+    previewViewport,
     projectId,
     file.name,
   ]);

--- a/apps/web/src/runtime/exports.ts
+++ b/apps/web/src/runtime/exports.ts
@@ -1019,10 +1019,11 @@ export function planDeckImageCapture(opts: {
 }
 
 // Programmatic image export: render a single pixel-perfect PNG via the daemon
-// (off-screen Electron Chromium), independent of the preview pane size. For a
-// deck pass the current slide `index` (Copy screenshot); omit it to stitch the
-// WHOLE deck top-to-bottom into one long image (Export as image) or to capture an
-// ordinary page at natural size. Returns a {dataUrl,w,h} snapshot compatible with
+// (off-screen Electron Chromium). Optional width/height select a responsive page
+// viewport without depending on preview-pane geometry. For a deck pass the
+// current slide `index` (Copy screenshot); omit it to stitch the WHOLE deck
+// top-to-bottom into one long image (Export as image) or to capture an ordinary
+// page at natural size. Returns a {dataUrl,w,h} snapshot compatible with
 // the existing image-export pipeline, or null if unavailable.
 // Discriminates a genuinely-unavailable off-screen renderer (no desktop host /
 // 501 / network) — where the caller may fall back to a visible-preview capture —
@@ -1038,6 +1039,8 @@ export async function exportProjectImageDataUrl(opts: {
   fileName: string;
   index?: number;
   deck?: boolean;
+  width?: number;
+  height?: number;
   versionId?: string;
 }): Promise<ProjectImageExportResult> {
   const url = `/api/projects/${encodeURIComponent(opts.projectId)}/export/image`;
@@ -1050,6 +1053,8 @@ export async function exportProjectImageDataUrl(opts: {
         fileName: opts.fileName,
         ...(typeof opts.index === 'number' ? { index: opts.index } : {}),
         ...(typeof opts.deck === 'boolean' ? { deck: opts.deck } : {}),
+        ...(typeof opts.width === 'number' ? { width: opts.width } : {}),
+        ...(typeof opts.height === 'number' ? { height: opts.height } : {}),
         ...(opts.versionId ? { versionId: opts.versionId } : {}),
       }),
     });

--- a/apps/web/tests/components/file-viewer-image-export.test.tsx
+++ b/apps/web/tests/components/file-viewer-image-export.test.tsx
@@ -67,18 +67,21 @@ function htmlFile(): ProjectFile {
   };
 }
 
-function renderHtmlPreview() {
+function renderHtmlPreview(
+  liveHtml = '<html><body><main>Workspace</main></body></html>',
+  expectedRenderMode: 'url-load' | 'srcdoc' = 'url-load',
+) {
   const view = render(
     <FileViewer
       projectId="project-1"
       projectKind="prototype"
       file={htmlFile()}
-      liveHtml="<html><body><main>Workspace</main></body></html>"
+      liveHtml={liveHtml}
     />,
   );
   const { container } = view;
   const activeFrame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
-  expect(activeFrame.getAttribute('data-od-render-mode')).toBe('url-load');
+  expect(activeFrame.getAttribute('data-od-render-mode')).toBe(expectedRenderMode);
   const srcDocFrame = container.querySelector<HTMLIFrameElement>('iframe[data-od-render-mode="srcdoc"]');
   expect(srcDocFrame).toBeTruthy();
   fireEvent.load(srcDocFrame as HTMLIFrameElement);
@@ -299,6 +302,105 @@ describe('FileViewer image export', () => {
     });
     expect(saveImageBlobMock).not.toHaveBeenCalled();
     expect(await screen.findByText('Download started')).toBeTruthy();
+  });
+
+  it('passes the selected mobile viewport to the off-screen image exporter', async () => {
+    isOpenDesignHostAvailableMock.mockReturnValue(true);
+    exportProjectImageDataUrlMock.mockResolvedValueOnce({
+      ok: true,
+      snapshot: {
+        dataUrl: 'data:image/png;base64,mobile',
+        w: 390,
+        h: 844,
+      },
+    });
+    imageDataUrlToBlobMock.mockResolvedValueOnce(new Blob(['png'], { type: 'image/png' }));
+    prepareImageExportTargetMock.mockResolvedValueOnce({
+      filename: 'workspace.png',
+      method: 'download',
+      save: saveImageBlobMock,
+    });
+
+    renderHtmlPreview();
+    fireEvent.click(screen.getByRole('button', { name: 'Preview viewport' }));
+    fireEvent.click(screen.getByRole('option', { name: /mobile/i }));
+    await openImageExportDialog();
+    await clickSave();
+
+    await waitFor(() => {
+      expect(exportProjectImageDataUrlMock).toHaveBeenCalledWith(expect.objectContaining({
+        projectId: 'project-1',
+        fileName: 'workspace.html',
+        deck: false,
+        width: 390,
+        height: 844,
+      }));
+    });
+  });
+
+  it('keeps desktop page exports on the renderer defaults', async () => {
+    isOpenDesignHostAvailableMock.mockReturnValue(true);
+    exportProjectImageDataUrlMock.mockResolvedValueOnce({
+      ok: true,
+      snapshot: {
+        dataUrl: 'data:image/png;base64,desktop',
+        w: 1440,
+        h: 900,
+      },
+    });
+    imageDataUrlToBlobMock.mockResolvedValueOnce(new Blob(['png'], { type: 'image/png' }));
+
+    renderHtmlPreview();
+    fireEvent.click(screen.getByRole('button', { name: 'Preview viewport' }));
+    fireEvent.click(screen.getByRole('option', { name: /desktop/i }));
+    await openImageExportDialog();
+    await clickSave();
+
+    await waitFor(() => {
+      expect(exportProjectImageDataUrlMock).toHaveBeenCalled();
+    });
+    const exportOptions = exportProjectImageDataUrlMock.mock.calls.at(-1)?.[0];
+    expect(exportOptions).toEqual(expect.objectContaining({
+      projectId: 'project-1',
+      fileName: 'workspace.html',
+      deck: false,
+    }));
+    expect(exportOptions).not.toHaveProperty('width');
+    expect(exportOptions).not.toHaveProperty('height');
+  });
+
+  it('keeps deck exports on the renderer defaults when mobile preview is selected', async () => {
+    isOpenDesignHostAvailableMock.mockReturnValue(true);
+    exportProjectImageDataUrlMock.mockResolvedValueOnce({
+      ok: true,
+      snapshot: {
+        dataUrl: 'data:image/png;base64,deck',
+        w: 1440,
+        h: 1800,
+      },
+    });
+    imageDataUrlToBlobMock.mockResolvedValueOnce(new Blob(['png'], { type: 'image/png' }));
+
+    renderHtmlPreview(
+      '<html><body><div class="deck"><section class="slide">Cover</section></div></body></html>',
+      'srcdoc',
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Preview viewport' }));
+    fireEvent.click(screen.getByRole('option', { name: /mobile/i }));
+    await openImageExportDialog();
+    await clickSave();
+
+    await waitFor(() => {
+      expect(exportProjectImageDataUrlMock).toHaveBeenCalled();
+    });
+    const exportOptions = exportProjectImageDataUrlMock.mock.calls.at(-1)?.[0];
+    expect(exportOptions).toEqual(expect.objectContaining({
+      projectId: 'project-1',
+      fileName: 'workspace.html',
+      deck: true,
+    }));
+    expect(exportOptions).not.toHaveProperty('width');
+    expect(exportOptions).not.toHaveProperty('height');
   });
 
   it('does not create a save target when snapshot capture fails', async () => {

--- a/apps/web/tests/runtime/exports.test.ts
+++ b/apps/web/tests/runtime/exports.test.ts
@@ -632,6 +632,8 @@ describe('exportProjectImageDataUrl', () => {
       fileName: 'screens/main page.html',
       index: 2,
       deck: false,
+      width: 390,
+      height: 844,
       versionId: 'v1',
     });
 
@@ -643,8 +645,29 @@ describe('exportProjectImageDataUrl', () => {
         fileName: 'screens/main page.html',
         index: 2,
         deck: false,
+        width: 390,
+        height: 844,
         versionId: 'v1',
       }),
+    });
+  });
+
+  it('omits viewport dimensions when the caller uses renderer defaults', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ error: { message: 'desktop only' } }), { status: 501 })),
+    );
+
+    await exportProjectImageDataUrl({
+      projectId: 'proj-1',
+      fileName: 'index.html',
+      deck: false,
+    });
+
+    expect(fetch).toHaveBeenCalledWith('/api/projects/proj-1/export/image', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ fileName: 'index.html', deck: false }),
     });
   });
 });


### PR DESCRIPTION
Fixes #5665

## Why

Selecting the Mobile or Tablet preview changes how an ordinary HTML page is laid out, but `Export as image` still rendered it in the desktop host's fixed 1440x900 viewport. The resulting PNG therefore did not match the responsive layout the user had selected and was viewing.

## What users will see

Image exports for ordinary HTML pages now use the selected Mobile or Tablet preview dimensions. Desktop page exports and deck exports retain their existing renderer defaults.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No visual controls changed. The before-state reproduction and screenshots are attached to #5665.

## Bug fix verification

- Test paths: `apps/web/tests/components/file-viewer-image-export.test.tsx`, `apps/web/tests/runtime/exports.test.ts`, and `apps/daemon/tests/screenshot-export-file-handoff.test.ts`
- Yes. The focused viewer test failed on the upstream baseline because the off-screen request omitted `width` and `height`, then passed with the change.
- Coverage also verifies that desktop pages and decks omit viewport dimensions, and that the dedicated daemon image endpoint forwards supplied dimensions to the renderer.

## Validation

- `corepack pnpm --filter @open-design/web exec vitest run tests/components/file-viewer-image-export.test.tsx tests/runtime/exports.test.ts -c vitest.config.ts`
- `corepack pnpm --filter @open-design/daemon exec vitest run tests/screenshot-export-file-handoff.test.ts -c vitest.config.ts`
- `corepack pnpm typecheck`
- `corepack pnpm guard`
- `git diff --check`
