### PR TITLE
feat(mcp): forward HTTP/SSE MCP servers to ACP agents with mature-acp

### DIFF
--- a/apps/daemon/src/agent-protocol/acp/session-params.ts
+++ b/apps/daemon/src/agent-protocol/acp/session-params.ts
@@ -17,6 +17,8 @@ export interface AcpMcpServerInput {
   command?: unknown;
   args?: unknown;
   env?: unknown;
+  url?: unknown;
+  headers?: unknown;
 }
 /**
  * Options accepted by `buildAcpSessionNewParams` controlling optional MCP
@@ -52,6 +54,27 @@ export function buildAcpSessionNewParams(cwd: string, { mcpServers, envFormat = 
     // auto-install or mutate user/global MCP config; callers must pass an
     // explicit per-session MCP descriptor when a compatible agent supports it.
     mcpServers: servers.map((s) => {
+      const rawType = typeof s?.type === 'string' ? s.type : 'stdio';
+
+      // Non-stdio servers (sse/http): emit url + headers, no command/args/env.
+      if (rawType === 'sse' || rawType === 'http') {
+        const rawHeaders = s?.headers;
+        const headers = Array.isArray(rawHeaders)
+          ? rawHeaders
+          : rawHeaders && typeof rawHeaders === 'object' && !Array.isArray(rawHeaders)
+            ? Object.entries(rawHeaders as Record<string, string>).map(
+                ([name, value]) => ({ name, value }),
+              )
+            : [];
+        return {
+          type: rawType,
+          name: typeof s?.name === 'string' ? s.name : '',
+          url: typeof s?.url === 'string' ? s.url : '',
+          headers,
+        };
+      }
+
+      // stdio servers: emit command/args/env as before.
       const rawEnv = s?.env;
       // Already a plain object — pass through in map mode, convert to
       // array in array mode (e.g. live-artifacts MCP from
@@ -61,7 +84,7 @@ export function buildAcpSessionNewParams(cwd: string, { mcpServers, envFormat = 
         rawEnv && typeof rawEnv === 'object' && !Array.isArray(rawEnv);
       if (wantsMap && isPlainObject) {
         return {
-          type: typeof s?.type === 'string' ? s.type : 'stdio',
+          type: 'stdio',
           name: typeof s?.name === 'string' ? s.name : '',
           command: typeof s?.command === 'string' ? s.command : '',
           args: Array.isArray(s?.args) ? s.args : [],
@@ -77,7 +100,7 @@ export function buildAcpSessionNewParams(cwd: string, { mcpServers, envFormat = 
             )
           : envArr;
       return {
-        type: typeof s?.type === 'string' ? s.type : 'stdio',
+        type: 'stdio',
         name: typeof s?.name === 'string' ? s.name : '',
         command: typeof s?.command === 'string' ? s.command : '',
         args: Array.isArray(s?.args) ? s.args : [],

--- a/apps/daemon/src/mcp-config.ts
+++ b/apps/daemon/src/mcp-config.ts
@@ -371,36 +371,59 @@ function mergeAuthHeader(
 
 /**
  * Convert user-configured external MCP servers into the ACP `mcpServers`
- * shape that Hermes/Kimi accept (already in use by buildLiveArtifactsMcpServersForAgent).
- * SSE/HTTP servers are dropped — ACP currently models stdio only — but we
- * surface a warning so the UI can hint at it.
+ * shape (already in use by buildLiveArtifactsMcpServersForAgent).
+ *
+ * All three transports (stdio, sse, http) are forwarded. `tokens` is an
+ * optional map of `serverId → bearer access token`, populated by the
+ * daemon's OAuth flow. The bearer is injected as `Authorization: Bearer`
+ * via `mergeAuthHeader`, unless the user pinned a non-empty Authorization
+ * header in the server config.
  */
-export interface AcpMcpServer {
-  type: 'stdio';
-  name: string;
-  command: string;
-  args: string[];
-  env: Array<{ name: string; value: string }>;
-}
+export type AcpMcpServer =
+  | { type: 'stdio'; name: string; command: string; args: string[]; env: Array<{ name: string; value: string }> }
+  | { type: 'sse' | 'http'; name: string; url: string; headers: Array<{ name: string; value: string }> };
 
-export function buildAcpMcpServers(servers: McpServerConfig[]): AcpMcpServer[] {
-  const enabled = servers.filter((s) => s.enabled && s.transport === 'stdio');
+export function buildAcpMcpServers(
+  servers: McpServerConfig[],
+  tokens: Record<string, string> = {},
+): AcpMcpServer[] {
+  const enabled = servers.filter((s) => s.enabled);
   const out: AcpMcpServer[] = [];
   for (const s of enabled) {
-    const envEntries: Array<{ name: string; value: string }> = [];
-    if (s.env) {
-      for (const [name, value] of Object.entries(s.env)) {
-        if (typeof value !== 'string') continue;
-        envEntries.push({ name, value });
+    if (s.transport === 'stdio') {
+      const envEntries: Array<{ name: string; value: string }> = [];
+      if (s.env) {
+        for (const [name, value] of Object.entries(s.env)) {
+          if (typeof value !== 'string') continue;
+          envEntries.push({ name, value });
+        }
       }
+      out.push({
+        type: 'stdio',
+        name: s.id,
+        command: s.command ?? '',
+        args: Array.isArray(s.args) ? [...s.args] : [],
+        env: envEntries,
+      });
+    } else {
+      // sse | http
+      const headers = mergeAuthHeader(
+        s.headers,
+        effectiveMcpAuthMode(s) === 'oauth' ? tokens[s.id] : undefined,
+      );
+      const headerEntries: Array<{ name: string; value: string }> = [];
+      if (headers) {
+        for (const [name, value] of Object.entries(headers)) {
+          headerEntries.push({ name, value });
+        }
+      }
+      out.push({
+        type: s.transport,
+        name: s.id,
+        url: s.url ?? '',
+        headers: headerEntries,
+      });
     }
-    out.push({
-      type: 'stdio',
-      name: s.id,
-      command: s.command ?? '',
-      args: Array.isArray(s.args) ? [...s.args] : [],
-      env: envEntries,
-    });
   }
   return out;
 }

--- a/apps/daemon/src/runtimes/defs/hermes.ts
+++ b/apps/daemon/src/runtimes/defs/hermes.ts
@@ -48,5 +48,6 @@ export const hermesAgentDef = {
     buildArgs: () => ['acp', '--accept-hooks'],
     streamFormat: 'acp-json-rpc',
     mcpDiscovery: 'mature-acp',
+    acpMcpTransports: ['stdio', 'sse', 'http'],
     externalMcpInjection: 'acp-merge',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/kimi.ts
+++ b/apps/daemon/src/runtimes/defs/kimi.ts
@@ -23,5 +23,6 @@ export const kimiAgentDef = {
     buildArgs: () => ['acp'],
     streamFormat: 'acp-json-rpc',
     mcpDiscovery: 'mature-acp',
+    acpMcpTransports: ['stdio'],
     externalMcpInjection: 'acp-merge',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/defs/reasonix.ts
+++ b/apps/daemon/src/runtimes/defs/reasonix.ts
@@ -60,6 +60,7 @@ export const reasonixAgentDef = {
     buildArgs: () => ['acp'],
     streamFormat: 'acp-json-rpc',
     mcpDiscovery: 'mature-acp',
+    acpMcpTransports: ['stdio'],
     externalMcpInjection: 'acp-merge',
     acpMcpEnvFormat: 'map',
     env: {

--- a/apps/daemon/src/runtimes/defs/trae-cli.ts
+++ b/apps/daemon/src/runtimes/defs/trae-cli.ts
@@ -19,5 +19,6 @@ export const traeCliAgentDef = {
     buildArgs: () => ['acp', 'serve', '--yolo'],
     streamFormat: 'acp-json-rpc',
     mcpDiscovery: 'mature-acp',
+    acpMcpTransports: ['stdio'],
     externalMcpInjection: 'acp-merge',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -167,6 +167,14 @@ export type RuntimeAgentDef = {
   supportsImagePaths?: boolean;
   maxPromptArgBytes?: number;
   mcpDiscovery?: string;
+  /**
+   * MCP transports this ACP runtime can receive at spawn time. When present,
+   * the daemon gates HTTP/SSE forwarding on this list instead of
+   * `mcpDiscovery`. Runtimes without this field fall back to stdio-only.
+   * Set only on runtimes whose installed implementation is verified to
+   * accept `McpServerHttp` / `McpServerSse` descriptors via ACP.
+   */
+  acpMcpTransports?: ('stdio' | 'sse' | 'http')[];
   // How the daemon forwards the user's `.od/mcp-config.json` external MCP
   // servers to this runtime at spawn time. The shape of the injection
   // is one of three strategies, each of which the server.ts spawn

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -11375,7 +11375,14 @@ export async function startServer({
       enabledExternalMcp.length > 0 &&
       def.externalMcpInjection === 'acp-merge'
     ) {
-      const acpExternal = buildAcpMcpServers(enabledExternalMcp);
+      // Gate forwarding on `acpMcpTransports` — filter each server by
+      // whether its transport is in the runtime's capability list.
+      // Runtimes without this field fall back to stdio-only.
+      const supportedTransports = def.acpMcpTransports ?? ['stdio'];
+      const acpExternal = buildAcpMcpServers(
+        enabledExternalMcp.filter((s) => supportedTransports.includes(s.transport)),
+        oauthTokensForSpawn,
+      );
       mcpServers.push(...acpExternal);
     }
     // OpenCode: serialise enabled MCP servers into its `mcp` config schema

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -47,9 +47,9 @@ test('ACP session params normalize explicit MCP servers to ACP stdio shape', () 
   });
 });
 
-test('ACP session params preserve caller-provided type and env fields', () => {
+test('ACP session params preserve caller-provided type and url/headers for http servers', () => {
   const mcpServers = [
-    { type: 'http', name: 'http-server', url: 'http://localhost:3000', headers: {}, env: [{ key: 'TOKEN', value: 'secret' }] },
+    { type: 'http', name: 'http-server', url: 'http://localhost:3000/mcp', headers: [{ name: 'Authorization', value: 'Bearer tok' }] },
   ];
 
   const result = buildAcpSessionNewParams('/tmp/od-project', { mcpServers });
@@ -57,7 +57,11 @@ test('ACP session params preserve caller-provided type and env fields', () => {
   assert.ok(server);
   assert.equal(server.type, 'http');
   assert.equal(server.name, 'http-server');
-  assert.deepEqual(server.env, [{ key: 'TOKEN', value: 'secret' }]);
+  assert.equal((server as any).url, 'http://localhost:3000/mcp');
+  assert.deepEqual((server as any).headers, [{ name: 'Authorization', value: 'Bearer tok' }]);
+  // HTTP servers must not carry stdio-only fields
+  assert.equal((server as any).command, undefined);
+  assert.equal((server as any).env, undefined);
 });
 
 test('ACP model normalization prefers session configOptions models', () => {

--- a/apps/daemon/tests/mcp-config.test.ts
+++ b/apps/daemon/tests/mcp-config.test.ts
@@ -352,7 +352,7 @@ describe('sanitizeMcpServer headers', () => {
 });
 
 describe('buildAcpMcpServers', () => {
-  it('drops sse / http servers (ACP descriptor is stdio-only)', () => {
+  it('forwards stdio, sse, and http servers (ACP supports all three transports)', () => {
     const out = buildAcpMcpServers([
       {
         id: 'a',
@@ -364,13 +364,22 @@ describe('buildAcpMcpServers', () => {
         id: 'b',
         transport: 'sse',
         enabled: true,
-        url: 'https://example.com',
+        url: 'https://example.com/sse',
+      },
+      {
+        id: 'c',
+        transport: 'http',
+        enabled: true,
+        url: 'https://example.com/mcp',
       },
     ]);
-    expect(out.map((s) => s.name)).toEqual(['a']);
+    expect(out.map((s) => s.name)).toEqual(['a', 'b', 'c']);
+    expect(out[0]).toMatchObject({ type: 'stdio', command: 'echo' });
+    expect(out[1]).toMatchObject({ type: 'sse', url: 'https://example.com/sse' });
+    expect(out[2]).toMatchObject({ type: 'http', url: 'https://example.com/mcp' });
   });
 
-  it('flattens env to ACP {name,value} array shape', () => {
+  it('flattens env to ACP {name,value} array shape for stdio', () => {
     const out = buildAcpMcpServers([
       {
         id: 'gh',
@@ -388,6 +397,161 @@ describe('buildAcpMcpServers', () => {
       args: ['-y', '@modelcontextprotocol/server-github'],
       env: [{ name: 'TOKEN', value: 'x' }],
     });
+  });
+
+  it('emits url + headers for http servers (headers always present, even if empty)', () => {
+    const out = buildAcpMcpServers([
+      {
+        id: 'higgsfield',
+        transport: 'http',
+        enabled: true,
+        url: 'https://mcp.higgsfield.ai/mcp',
+        headers: { Authorization: 'Bearer abc' },
+      },
+    ]);
+    expect(out[0]).toEqual({
+      type: 'http',
+      name: 'higgsfield',
+      url: 'https://mcp.higgsfield.ai/mcp',
+      headers: [{ name: 'Authorization', value: 'Bearer abc' }],
+    });
+  });
+
+  it('emits empty headers array when no headers are present', () => {
+    const out = buildAcpMcpServers([
+      {
+        id: 'free-api',
+        transport: 'http',
+        enabled: true,
+        url: 'https://api.example.com/mcp',
+      },
+    ]);
+    expect(out[0]).toEqual({
+      type: 'http',
+      name: 'free-api',
+      url: 'https://api.example.com/mcp',
+      headers: [],
+    });
+    expect((out[0] as any).command).toBeUndefined();
+    expect((out[0] as any).env).toBeUndefined();
+  });
+
+  it('injects OAuth bearer token for oauth-mode http servers', () => {
+    const out = buildAcpMcpServers(
+      [
+        {
+          id: 'higgsfield',
+          transport: 'http',
+          enabled: true,
+          url: 'https://mcp.higgsfield.ai/mcp',
+          // authMode defaults to 'oauth' for remote HTTP
+        },
+      ],
+      { higgsfield: 'access-tok-xyz' },
+    );
+    expect((out[0] as any).headers).toEqual([
+      { name: 'Authorization', value: 'Bearer access-tok-xyz' },
+    ]);
+  });
+
+  it('does NOT inject bearer for no-auth http servers', () => {
+    const out = buildAcpMcpServers(
+      [
+        {
+          id: 'figma-use',
+          transport: 'http',
+          enabled: true,
+          authMode: 'none',
+          url: 'http://localhost:38451/mcp',
+        },
+      ],
+      { 'figma-use': 'stale-token' },
+    );
+    expect((out[0] as any).headers).toEqual([]);
+  });
+
+  it('does NOT overwrite a user-pinned Authorization header with the OAuth bearer', () => {
+    const out = buildAcpMcpServers(
+      [
+        {
+          id: 'higgsfield',
+          transport: 'http',
+          enabled: true,
+          url: 'https://mcp.higgsfield.ai/mcp',
+          headers: { authorization: 'Bearer manual-token' },
+        },
+      ],
+      { higgsfield: 'access-tok-xyz' },
+    );
+    expect((out[0] as any).headers).toEqual([
+      { name: 'authorization', value: 'Bearer manual-token' },
+    ]);
+  });
+
+  it('skips disabled servers regardless of transport', () => {
+    const out = buildAcpMcpServers([
+      { id: 'a', transport: 'stdio', enabled: true, command: 'echo' },
+      { id: 'b', transport: 'http', enabled: false, url: 'https://x.com' },
+    ]);
+    expect(out.map((s) => s.name)).toEqual(['a']);
+  });
+});
+
+describe('acpMcpTransports gate', () => {
+  // Simulates the server.ts spawn-time gate: each server is filtered by
+  // whether its transport is in the runtime's acpMcpTransports list.
+  const mixedServers = [
+    { id: 'local', transport: 'stdio' as const, enabled: true, command: 'echo' },
+    { id: 'cloud-sse', transport: 'sse' as const, enabled: true, url: 'https://example.com/sse' },
+    { id: 'cloud-http', transport: 'http' as const, enabled: true, url: 'https://example.com/mcp' },
+  ];
+
+  function gateFor(def: { acpMcpTransports?: ('stdio' | 'sse' | 'http')[] }) {
+    const supportedTransports = def.acpMcpTransports ?? ['stdio'];
+    return buildAcpMcpServers(
+      mixedServers.filter((s) => supportedTransports.includes(s.transport)),
+    );
+  }
+
+  it('forwards all three transports to Hermes (acpMcpTransports = [stdio, sse, http])', () => {
+    const out = gateFor({ acpMcpTransports: ['stdio', 'sse', 'http'] });
+    expect(out.map((s) => s.name)).toEqual(['local', 'cloud-sse', 'cloud-http']);
+  });
+
+  it('forwards stdio only to Kimi (acpMcpTransports = [stdio])', () => {
+    const out = gateFor({ acpMcpTransports: ['stdio'] });
+    expect(out.map((s) => s.name)).toEqual(['local']);
+    expect(out[0]).toMatchObject({ type: 'stdio' });
+  });
+
+  it('forwards stdio only to Trae CLI (acpMcpTransports = [stdio])', () => {
+    const out = gateFor({ acpMcpTransports: ['stdio'] });
+    expect(out.map((s) => s.name)).toEqual(['local']);
+  });
+
+  it('forwards stdio only to Reasonix (acpMcpTransports = [stdio])', () => {
+    const out = gateFor({ acpMcpTransports: ['stdio'] });
+    expect(out.map((s) => s.name)).toEqual(['local']);
+  });
+
+  it('falls back to stdio-only when acpMcpTransports is undefined', () => {
+    const out = gateFor({});
+    expect(out.map((s) => s.name)).toEqual(['local']);
+  });
+
+  it('does not gate on mcpDiscovery alone (mature-acp without acpMcpTransports = stdio only)', () => {
+    const out = gateFor({});
+    expect(out.map((s) => s.name)).toEqual(['local']);
+  });
+
+  it('forwards only sse for a partial-capability runtime ([stdio, sse])', () => {
+    const out = gateFor({ acpMcpTransports: ['stdio', 'sse'] });
+    expect(out.map((s) => s.name)).toEqual(['local', 'cloud-sse']);
+  });
+
+  it('forwards only http for a partial-capability runtime ([stdio, http])', () => {
+    const out = gateFor({ acpMcpTransports: ['stdio', 'http'] });
+    expect(out.map((s) => s.name)).toEqual(['local', 'cloud-http']);
   });
 });
 

--- a/apps/web/src/components/McpClientSection.tsx
+++ b/apps/web/src/components/McpClientSection.tsx
@@ -1439,32 +1439,31 @@ function McpAgentSupportBanner({ agents }: { agents: AgentInfo[] }) {
     (a) => !a.externalMcpInjection,
   );
   if (supported.length === 0 && unsupported.length === 0) return null;
-  // ACP adapters (Hermes / Kimi / Kilo / Kiro / Vibe / Devin) currently
-  // accept stdio MCP servers only — `buildAcpMcpServers()` in
-  // `apps/daemon/src/mcp-config.ts` filters to `transport === 'stdio'`
-  // because the ACP `mcpServers` descriptor itself has no slot for
-  // HTTP / SSE entries. Tag those runtimes inline so the banner does
-  // not silently claim full forwarding for HTTP MCP servers, which
-  // would re-introduce the very silent-failure UX we are removing.
+  // ACP adapters that only accept stdio MCP servers get an inline label and
+  // a separate note. Adapters with verified HTTP/SSE support get a token
+  // forwarding disclosure. The two notes are independent so that a setup
+  // with only full-transport adapters still shows the OAuth disclosure.
+  const isAcpStdioOnly = (a: AgentInfo) =>
+    a.externalMcpInjection === 'acp-merge' &&
+    !(a.acpMcpTransports?.includes('sse') || a.acpMcpTransports?.includes('http'));
+  const isAcpFullTransport = (a: AgentInfo) =>
+    a.externalMcpInjection === 'acp-merge' &&
+    (a.acpMcpTransports?.includes('sse') || a.acpMcpTransports?.includes('http'));
   const renderNames = (list: AgentInfo[]) =>
     list
       .slice()
       .sort((a, b) => a.name.localeCompare(b.name))
-      .map((a) =>
-        a.externalMcpInjection === 'acp-merge'
-          ? `${a.name} (stdio only)`
-          : a.name,
-      )
+      .map((a) => (isAcpStdioOnly(a) ? `${a.name} (stdio only)` : a.name))
       .join(' · ');
-  const hasAcpSupported = supported.some(
-    (a) => a.externalMcpInjection === 'acp-merge',
-  );
+  const hasAcpStdioOnly = supported.some(isAcpStdioOnly);
+  const hasAcpFullTransport = supported.some(isAcpFullTransport);
   return (
     <div className="mcp-agent-support">
       {supported.length > 0 ? (
         <p className="hint mcp-agent-support-line">
           <strong>{t('mcpClient.forwardedToLabel')}</strong> {renderNames(supported)}.
-          {hasAcpSupported ? <> {t('mcpClient.forwardedAcpNote')}</> : null}
+          {hasAcpStdioOnly ? <> {t('mcpClient.forwardedAcpStdioNote')}</> : null}
+          {hasAcpFullTransport ? <> {t('mcpClient.forwardedAcpTokenNote')}</> : null}
         </p>
       ) : null}
       {unsupported.length > 0 ? (

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -4351,7 +4351,8 @@ export const ar: Dict = {
   'settings.customInstructionsDesc': 'تعليمات ثابتة يتبعها Open Design في كل محادثة. هذه ليست ذكريات محفوظة؛ استخدم الذاكرة للحقائق والتفضيلات وسياق المشروع.',
   'mcpClient.forwardedToLabel': 'مُمرَّر إلى:',
   'mcpClient.notForwardedToLabel': 'غير مُمرَّر إلى:',
-  'mcpClient.forwardedAcpNote': 'محوِّلات ACP المُعلَّمة بـ stdio تتلقى فقط خوادم MCP من نوع stdio من هذه القائمة؛ تُسقَط إدخالات HTTP وSSE عند بدء التشغيل.',
+  'mcpClient.forwardedAcpStdioNote': 'محوِّلات ACP المُعلَّمة بـ stdio تتلقى فقط خوادم MCP من نوع stdio من هذه القائمة؛ تُسقَط إدخالات HTTP وSSE عند بدء التشغيل.',
+  'mcpClient.forwardedAcpTokenNote': 'المحوِّلات ذات دعم MCP الكامل (تم التحقق على Hermes) تتلقى جميع وسائل النقل؛ تُعاد توجيه رموز OAuth لخوادم MCP المُهيَّأة تلقائيًا.',
   'mcpClient.notForwardedNote': 'بالنسبة إلى تلك الـ Agents، اضبط خوادم MCP في ملف إعدادات الـ Agent الخاص به (مثل ~/.codex/config.toml و~/.gemini/settings.json)؛ الخوادم أدناه غير مستخدمة هناك دون إشعار.',
 
   // Brands library + extraction

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -4351,7 +4351,8 @@ export const de: Dict = {
   'settings.customInstructionsDesc': 'Feste Anweisungen, denen Open Design in jedem Chat folgt. Dies sind keine gespeicherten Erinnerungen; verwenden Sie Memory für Fakten, Präferenzen und Projektkontext.',
   'mcpClient.forwardedToLabel': 'Weitergeleitet an:',
   'mcpClient.notForwardedToLabel': 'Nicht weitergeleitet an:',
-  'mcpClient.forwardedAcpNote': 'Als stdio gekennzeichnete ACP-Adapter erhalten aus dieser Liste nur stdio-MCP-Server; HTTP- und SSE-Einträge werden beim Start verworfen.',
+  'mcpClient.forwardedAcpStdioNote': 'Als stdio gekennzeichnete ACP-Adapter erhalten aus dieser Liste nur stdio-MCP-Server; HTTP- und SSE-Einträge werden beim Start verworfen.',
+  'mcpClient.forwardedAcpTokenNote': 'Adapter mit vollständiger MCP-Unterstützung (verifiziert auf Hermes) erhalten alle Transportarten; OAuth-Tokens für konfigurierte MCP-Server werden automatisch weitergeleitet.',
   'mcpClient.notForwardedNote': 'Konfigurieren Sie MCP-Server für diese Agents in der eigenen Konfigurationsdatei des Agents (z. B. ~/.codex/config.toml, ~/.gemini/settings.json); die unten aufgeführten Server werden dort stillschweigend nicht verwendet.',
 
   // Brands library + extraction

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -4365,7 +4365,8 @@ export const en: Dict = {
   'settings.customInstructionsDesc': 'Fixed instructions Open Design follows in every chat. These are not saved memories; use Memory for facts, preferences, and project context.',
   'mcpClient.forwardedToLabel': 'Forwarded to:',
   'mcpClient.notForwardedToLabel': 'Not forwarded to:',
-  'mcpClient.forwardedAcpNote': 'ACP adapters marked stdio only receive stdio MCP servers from this list; HTTP and SSE entries are dropped at spawn time.',
+  'mcpClient.forwardedAcpStdioNote': 'ACP adapters marked stdio only receive stdio MCP servers from this list; HTTP and SSE entries are dropped at spawn time.',
+  'mcpClient.forwardedAcpTokenNote': 'Adapters with full MCP support (verified on Hermes) receive all transports; OAuth tokens for configured MCP servers are forwarded automatically.',
   'mcpClient.notForwardedNote': 'For those agents, configure MCP servers in the agent\'s own config file (e.g. ~/.codex/config.toml, ~/.gemini/settings.json); the servers below are silently unused there.',
 
   // Design systems library + extraction

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -4351,7 +4351,8 @@ export const esES: Dict = {
   'settings.customInstructionsDesc': 'Instrucciones fijas que Open Design sigue en cada chat. No son memorias guardadas; usa Memoria para hechos, preferencias y contexto del proyecto.',
   'mcpClient.forwardedToLabel': 'Reenviado a:',
   'mcpClient.notForwardedToLabel': 'No reenviado a:',
-  'mcpClient.forwardedAcpNote': 'Los adaptadores ACP marcados como stdio solo reciben servidores MCP de stdio de esta lista; las entradas HTTP y SSE se descartan en el momento de la creación.',
+  'mcpClient.forwardedAcpStdioNote': 'Los adaptadores ACP marcados como stdio solo reciben servidores MCP de stdio de esta lista; las entradas HTTP y SSE se descartan en el momento de la creación.',
+  'mcpClient.forwardedAcpTokenNote': 'Los adaptadores con soporte MCP completo (verificado en Hermes) reciben todos los transportes; los tokens OAuth para los servidores MCP configurados se reenvían automáticamente.',
   'mcpClient.notForwardedNote': 'Para esos agentes, configura los servidores MCP en el propio archivo de configuración del agente (p. ej. ~/.codex/config.toml, ~/.gemini/settings.json); los servidores de abajo se ignoran de forma silenciosa allí.',
 
   // Brands library + extraction

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -4346,7 +4346,8 @@ export const fa: Dict = {
   'settings.customInstructionsDesc': 'دستورالعمل‌های ثابتی که Open Design در هر گفت‌وگو از آن‌ها پیروی می‌کند. این‌ها حافظه ذخیره‌شده نیستند؛ برای واقعیت‌ها، ترجیحات و بافت پروژه از حافظه استفاده کنید.',
   'mcpClient.forwardedToLabel': 'ارسال‌شده به:',
   'mcpClient.notForwardedToLabel': 'ارسال‌نشده به:',
-  'mcpClient.forwardedAcpNote': 'آداپتورهای ACP که با stdio علامت‌گذاری شده‌اند فقط سرورهای MCP از نوع stdio را از این فهرست دریافت می‌کنند؛ ورودی‌های HTTP و SSE هنگام راه‌اندازی حذف می‌شوند.',
+  'mcpClient.forwardedAcpStdioNote': 'آداپتورهای ACP که با stdio علامت‌گذاری شده‌اند فقط سرورهای MCP از نوع stdio را از این فهرست دریافت می‌کنند؛ ورودی‌های HTTP و SSE هنگام راه‌اندازی حذف می‌شوند.',
+  'mcpClient.forwardedAcpTokenNote': 'آداپتورهای با پشتیبانی کامل MCP (تأیید‌شده روی Hermes) همهٔ انواع انتقال را دریافت می‌کنند؛ توکن‌های OAuth برای سرورهای MCP پیکربندی‌شده به‌طور خودکار ارسال می‌شوند.',
   'mcpClient.notForwardedNote': 'برای آن Agentها، سرورهای MCP را در فایل پیکربندی خودِ Agent تنظیم کنید (مثلاً ~/.codex/config.toml، ~/.gemini/settings.json)؛ سرورهای زیر در آن‌جا بی‌سروصدا بلااستفاده می‌مانند.',
 
   // Brands library + extraction

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -4351,7 +4351,8 @@ export const fr: Dict = {
   'settings.customInstructionsDesc': 'Instructions fixes qu\'Open Design suit dans chaque conversation. Ce ne sont pas des mémoires enregistrées ; utilisez Mémoire pour les faits, les préférences et le contexte de projet.',
   'mcpClient.forwardedToLabel': 'Transféré vers :',
   'mcpClient.notForwardedToLabel': 'Non transféré vers :',
-  'mcpClient.forwardedAcpNote': 'Les adaptateurs ACP marqués stdio ne reçoivent que les serveurs MCP stdio de cette liste ; les entrées HTTP et SSE sont abandonnées au lancement.',
+  'mcpClient.forwardedAcpStdioNote': 'Les adaptateurs ACP marqués stdio ne reçoivent que les serveurs MCP stdio de cette liste ; les entrées HTTP et SSE sont abandonnées au lancement.',
+  'mcpClient.forwardedAcpTokenNote': 'Les adaptateurs avec support MCP complet (vérifié sur Hermes) reçoivent tous les transports ; les jetons OAuth pour les serveurs MCP configurés sont automatiquement transmis.',
   'mcpClient.notForwardedNote': 'Pour ces agents, configurez les serveurs MCP dans le fichier de configuration propre à l\'agent (par ex. ~/.codex/config.toml, ~/.gemini/settings.json) ; les serveurs ci-dessous y sont inutilisés sans avertissement.',
 
   // Brands library + extraction

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -4351,7 +4351,8 @@ export const hu: Dict = {
   'settings.customInstructionsDesc': 'Rögzített utasítások, amelyeket az Open Design minden csevegésben követ. Ezek nem mentett memóriák; a tényekhez, preferenciákhoz és projektkontextushoz használd a Memóriát.',
   'mcpClient.forwardedToLabel': 'Továbbítva ide:',
   'mcpClient.notForwardedToLabel': 'Nincs továbbítva ide:',
-  'mcpClient.forwardedAcpNote': 'A stdio-ként megjelölt ACP adapterek csak a stdio MCP szervereket kapják meg ebből a listából; a HTTP és SSE bejegyzések indításkor elvetésre kerülnek.',
+  'mcpClient.forwardedAcpStdioNote': 'A stdio-ként megjelölt ACP adapterek csak a stdio MCP szervereket kapják meg ebből a listából; a HTTP és SSE bejegyzések indításkor elvetésre kerülnek.',
+  'mcpClient.forwardedAcpTokenNote': 'A teljes MCP-támogatással rendelkező adapterek (Hermesen ellenőrizve) minden típust megkapnak; a konfigurált MCP-kiszolgálók OAuth-tokenjei automatikusan továbbítódnak.',
   'mcpClient.notForwardedNote': 'Ezekhez az Agentekhez állítsd be az MCP szervereket az Agent saját konfigurációs fájljában (pl. ~/.codex/config.toml, ~/.gemini/settings.json); az alábbi szerverek ott csendben kihasználatlanok maradnak.',
 
   // Brands library + extraction

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -4351,7 +4351,8 @@ export const id: Dict = {
   'settings.customInstructionsDesc': 'Instruksi tetap yang diikuti Open Design di setiap obrolan. Ini bukan memori tersimpan; gunakan Memori untuk fakta, preferensi, dan konteks proyek.',
   'mcpClient.forwardedToLabel': 'Diteruskan ke:',
   'mcpClient.notForwardedToLabel': 'Tidak diteruskan ke:',
-  'mcpClient.forwardedAcpNote': 'Adaptor ACP yang ditandai stdio hanya menerima server MCP stdio dari daftar ini; entri HTTP dan SSE dibuang saat spawn.',
+  'mcpClient.forwardedAcpStdioNote': 'Adaptor ACP yang ditandai stdio hanya menerima server MCP stdio dari daftar ini; entri HTTP dan SSE dibuang saat spawn.',
+  'mcpClient.forwardedAcpTokenNote': 'Adaptor dengan dukungan MCP penuh (diverifikasi di Hermes) menerima semua transport; token OAuth untuk server MCP yang dikonfigurasi diteruskan secara otomatis.',
   'mcpClient.notForwardedNote': 'Untuk agent tersebut, konfigurasikan server MCP di file konfigurasi agent itu sendiri (mis. ~/.codex/config.toml, ~/.gemini/settings.json); server di bawah ini tidak digunakan di sana tanpa pemberitahuan.',
 
   // Brands library + extraction

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -4351,7 +4351,8 @@ export const it: Dict = {
   'settings.customInstructionsDesc': 'Istruzioni fisse che Open Design segue in ogni chat. Non sono memorie salvate; usa Memoria per fatti, preferenze e contesto del progetto.',
   'mcpClient.forwardedToLabel': 'Inoltrato a:',
   'mcpClient.notForwardedToLabel': 'Non inoltrato a:',
-  'mcpClient.forwardedAcpNote': 'Gli adattatori ACP contrassegnati come stdio ricevono da questo elenco solo i server MCP stdio; le voci HTTP e SSE vengono scartate all\'avvio.',
+  'mcpClient.forwardedAcpStdioNote': 'Gli adattatori ACP contrassegnati come stdio ricevono da questo elenco solo i server MCP stdio; le voci HTTP e SSE vengono scartate all\'avvio.',
+  'mcpClient.forwardedAcpTokenNote': 'Gli adattatori con supporto MCP completo (verificato su Hermes) ricevono tutti i trasporti; i token OAuth per i server MCP configurati vengono inoltrati automaticamente.',
   'mcpClient.notForwardedNote': 'Per quegli agent, configura i server MCP nel file di configurazione dell\'agent stesso (ad es. ~/.codex/config.toml, ~/.gemini/settings.json); i server seguenti vengono ignorati silenziosamente in quel contesto.',
 
   // Brands library + extraction

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -4351,7 +4351,8 @@ export const ja: Dict = {
   'settings.customInstructionsDesc': 'Open Design がすべてのチャットで従う固定の指示です。これらは保存されたメモリではありません。事実・好み・プロジェクトのコンテキストには「メモリ」を使用してください。',
   'mcpClient.forwardedToLabel': '転送先：',
   'mcpClient.notForwardedToLabel': '転送されない先：',
-  'mcpClient.forwardedAcpNote': 'stdio only と表示された ACP アダプターは、このリストから stdio タイプの MCP サーバーのみを受け取ります。HTTP と SSE のエントリは起動時に破棄されます。',
+  'mcpClient.forwardedAcpStdioNote': 'stdio only と表示された ACP アダプターは、このリストから stdio タイプの MCP サーバーのみを受け取ります。HTTP と SSE のエントリは起動時に破棄されます。',
+  'mcpClient.forwardedAcpTokenNote': '完全なMCPサポートを備えたアダプター（Hermesで検証済み）はすべてのトランスポートを受信します。設定済みのMCPサーバーのOAuthトークンは自動的に転送されます。',
   'mcpClient.notForwardedNote': 'これらのエージェントについては、各エージェント自身の設定ファイル（例：~/.codex/config.toml、~/.gemini/settings.json）で MCP サーバーを設定してください。以下のサーバーはそこでは使用されません。',
 
   // Brands library + extraction

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -4351,7 +4351,8 @@ export const ko: Dict = {
   'settings.customInstructionsDesc': 'Open Design이 모든 채팅에서 따르는 고정 지침입니다. 저장된 메모리가 아니며, 사실, 선호 사항, 프로젝트 컨텍스트에는 메모리를 사용하세요.',
   'mcpClient.forwardedToLabel': '전달 대상:',
   'mcpClient.notForwardedToLabel': '전달되지 않는 대상:',
-  'mcpClient.forwardedAcpNote': 'stdio로 표시된 ACP 어댑터는 이 목록에서 stdio MCP 서버만 받습니다. HTTP 및 SSE 항목은 생성 시점에 제외됩니다.',
+  'mcpClient.forwardedAcpStdioNote': 'stdio로 표시된 ACP 어댑터는 이 목록에서 stdio MCP 서버만 받습니다. HTTP 및 SSE 항목은 생성 시점에 제외됩니다.',
+  'mcpClient.forwardedAcpTokenNote': '전체 MCP 지원이 있는 어댑터(Hermes에서 검증됨)는 모든 전송 방식을 받습니다. 구성된 MCP 서버의 OAuth 토큰이 자동으로 전달됩니다.',
   'mcpClient.notForwardedNote': '해당 Agent의 경우 Agent 자체 구성 파일(예: ~/.codex/config.toml, ~/.gemini/settings.json)에서 MCP 서버를 구성하세요. 아래 서버는 거기서 자동으로 사용되지 않습니다.',
 
   // Brands library + extraction

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -4351,7 +4351,8 @@ export const pl: Dict = {
   'settings.customInstructionsDesc': 'Stałe instrukcje, których Open Design przestrzega w każdej rozmowie. To nie są zapisane wspomnienia; użyj Pamięci do faktów, preferencji i kontekstu projektu.',
   'mcpClient.forwardedToLabel': 'Przekazywane do:',
   'mcpClient.notForwardedToLabel': 'Nie przekazywane do:',
-  'mcpClient.forwardedAcpNote': 'Adaptery ACP oznaczone jako stdio otrzymują z tej listy tylko serwery MCP typu stdio; wpisy HTTP i SSE są pomijane podczas uruchamiania.',
+  'mcpClient.forwardedAcpStdioNote': 'Adaptery ACP oznaczone jako stdio otrzymują z tej listy tylko serwery MCP typu stdio; wpisy HTTP i SSE są pomijane podczas uruchamiania.',
+  'mcpClient.forwardedAcpTokenNote': 'Adaptery z pełną obsługą MCP (zweryfikowane na Hermes) otrzymują wszystkie transporty; tokeny OAuth dla skonfigurowanych serwerów MCP są przekazywane automatycznie.',
   'mcpClient.notForwardedNote': 'Dla tych Agentów skonfiguruj serwery MCP w pliku konfiguracyjnym danego Agenta (np. ~/.codex/config.toml, ~/.gemini/settings.json); poniższe serwery są tam po cichu nieużywane.',
 
   // Brands library + extraction

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -4351,7 +4351,8 @@ export const ptBR: Dict = {
   'settings.customInstructionsDesc': 'Instruções fixas que o Open Design segue em todas as conversas. Estas não são memórias salvas; use a Memória para fatos, preferências e contexto de projeto.',
   'mcpClient.forwardedToLabel': 'Encaminhado para:',
   'mcpClient.notForwardedToLabel': 'Não encaminhado para:',
-  'mcpClient.forwardedAcpNote': 'Adaptadores ACP marcados como stdio recebem apenas servidores MCP stdio desta lista; entradas HTTP e SSE são descartadas no momento da inicialização.',
+  'mcpClient.forwardedAcpStdioNote': 'Adaptadores ACP marcados como stdio recebem apenas servidores MCP stdio desta lista; entradas HTTP e SSE são descartadas no momento da inicialização.',
+  'mcpClient.forwardedAcpTokenNote': 'Adaptadores com suporte MCP completo (verificado no Hermes) recebem todos os transportes; tokens OAuth para servidores MCP configurados são encaminhados automaticamente.',
   'mcpClient.notForwardedNote': 'Para esses agentes, configure os servidores MCP no próprio arquivo de configuração do agente (ex.: ~/.codex/config.toml, ~/.gemini/settings.json); os servidores abaixo ficam sem uso silenciosamente nesse caso.',
 
   // Brands library + extraction

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -4351,7 +4351,8 @@ export const ru: Dict = {
   'settings.customInstructionsDesc': 'Фиксированные инструкции, которым Open Design следует в каждом чате. Это не сохранённые воспоминания; используйте Память для фактов, предпочтений и контекста проекта.',
   'mcpClient.forwardedToLabel': 'Перенаправляется в:',
   'mcpClient.notForwardedToLabel': 'Не перенаправляется в:',
-  'mcpClient.forwardedAcpNote': 'Адаптеры ACP, помеченные как stdio, получают из этого списка только серверы stdio MCP; записи HTTP и SSE отбрасываются при запуске.',
+  'mcpClient.forwardedAcpStdioNote': 'Адаптеры ACP, помеченные как stdio, получают из этого списка только серверы stdio MCP; записи HTTP и SSE отбрасываются при запуске.',
+  'mcpClient.forwardedAcpTokenNote': 'Адаптеры с полной поддержкой MCP (проверено на Hermes) принимают все типы транспорта; OAuth-токены для настроенных MCP-серверов пересылаются автоматически.',
   'mcpClient.notForwardedNote': 'Для этих Agent настройте серверы MCP в собственном файле конфигурации агента (например, ~/.codex/config.toml, ~/.gemini/settings.json); указанные ниже серверы там молча не используются.',
 
   // Brands library + extraction

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -4351,7 +4351,8 @@ export const th: Dict = {
   'settings.customInstructionsDesc': 'คำสั่งตายตัวที่ Open Design ปฏิบัติตามในทุกการแชต สิ่งเหล่านี้ไม่ใช่หน่วยความจำที่บันทึกไว้ ใช้ Memory สำหรับข้อเท็จจริง ความชอบ และบริบทของโปรเจกต์',
   'mcpClient.forwardedToLabel': 'ส่งต่อไปยัง:',
   'mcpClient.notForwardedToLabel': 'ไม่ได้ส่งต่อไปยัง:',
-  'mcpClient.forwardedAcpNote': 'ACP adapter ที่ทำเครื่องหมาย stdio จะรับเฉพาะเซิร์ฟเวอร์ MCP แบบ stdio จากรายการนี้เท่านั้น รายการ HTTP และ SSE จะถูกตัดทิ้งในเวลาที่ spawn',
+  'mcpClient.forwardedAcpStdioNote': 'ACP adapter ที่ทำเครื่องหมาย stdio จะรับเฉพาะเซิร์ฟเวอร์ MCP แบบ stdio จากรายการนี้เท่านั้น รายการ HTTP และ SSE จะถูกตัดทิ้งในเวลาที่ spawn',
+  'mcpClient.forwardedAcpTokenNote': 'อะแดปเตอร์ที่รองรับ MCP แบบเต็ม (ตรวจสอบแล้วบน Hermes) รับการขนส่งทุกประเภท; โทเค็น OAuth สำหรับเซิร์ฟเวอร์ MCP ที่กำหนดค่าไว้จะถูกส่งต่อโดยอัตโนมัติ',
   'mcpClient.notForwardedNote': 'สำหรับ Agent เหล่านั้น ให้กำหนดค่าเซิร์ฟเวอร์ MCP ในไฟล์ config ของ Agent เอง (เช่น ~/.codex/config.toml, ~/.gemini/settings.json) เซิร์ฟเวอร์ด้านล่างจะไม่ถูกใช้งานที่นั่นโดยไม่มีการแจ้งเตือน',
 
   // Brands library + extraction

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -4351,7 +4351,8 @@ export const tr: Dict = {
   'settings.customInstructionsDesc': 'Open Design\'ın her sohbette izlediği sabit yönergeler. Bunlar kayıtlı bellekler değildir; gerçekler, tercihler ve proje bağlamı için Bellek\'i kullanın.',
   'mcpClient.forwardedToLabel': 'İletildiği yer:',
   'mcpClient.notForwardedToLabel': 'İletilmediği yer:',
-  'mcpClient.forwardedAcpNote': 'stdio olarak işaretlenen ACP adaptörleri bu listeden yalnızca stdio MCP sunucularını alır; HTTP ve SSE girdileri başlatma sırasında düşürülür.',
+  'mcpClient.forwardedAcpStdioNote': 'stdio olarak işaretlenen ACP adaptörleri bu listeden yalnızca stdio MCP sunucularını alır; HTTP ve SSE girdileri başlatma sırasında düşürülür.',
+  'mcpClient.forwardedAcpTokenNote': 'Tam MCP desteğine sahip adaptörler (Hermes\'te doğrulandı) tüm taşıyıcıları alır; yapılandırılmış MCP sunucuları için OAuth belirteçleri otomatik olarak iletilir.',
   'mcpClient.notForwardedNote': 'Bu agent\'lar için MCP sunucularını agent\'ın kendi yapılandırma dosyasında ayarlayın (ör. ~/.codex/config.toml, ~/.gemini/settings.json); aşağıdaki sunucular orada sessizce kullanılmaz.',
 
   // Brands library + extraction

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -4351,7 +4351,8 @@ export const uk: Dict = {
   'settings.customInstructionsDesc': 'Незмінні інструкції, яких Open Design дотримується в кожному чаті. Це не збережені спогади; використовуйте Пам’ять для фактів, уподобань і контексту проєкту.',
   'mcpClient.forwardedToLabel': 'Переслано до:',
   'mcpClient.notForwardedToLabel': 'Не переслано до:',
-  'mcpClient.forwardedAcpNote': 'Адаптери ACP, позначені як stdio, отримують із цього списку лише stdio-сервери MCP; записи HTTP та SSE відкидаються під час запуску.',
+  'mcpClient.forwardedAcpStdioNote': 'Адаптери ACP, позначені як stdio, отримують із цього списку лише stdio-сервери MCP; записи HTTP та SSE відкидаються під час запуску.',
+  'mcpClient.forwardedAcpTokenNote': 'Адаптери з повною підтримкою MCP (перевірено на Hermes) отримують усі транспорти; OAuth-токени для налаштованих MCP-серверів пересилаються автоматично.',
   'mcpClient.notForwardedNote': 'Для цих agent налаштуйте сервери MCP у власному файлі конфігурації agent (наприклад, ~/.codex/config.toml, ~/.gemini/settings.json); наведені нижче сервери там мовчки не використовуються.',
 
   // Brands library + extraction

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -4739,8 +4739,10 @@ export const zhCN: Dict = {
     "Open Design 在每次对话中都会遵循的固定指令。它们不是保存的记忆；事实、偏好和项目上下文请使用「记忆」。",
   "mcpClient.forwardedToLabel": "已转发给：",
   "mcpClient.notForwardedToLabel": "未转发给：",
-  "mcpClient.forwardedAcpNote":
+  "mcpClient.forwardedAcpStdioNote":
     "标记为 stdio only 的 ACP 适配器只会从此列表接收 stdio 类型的 MCP 服务器；HTTP 和 SSE 条目会在启动时被丢弃。",
+  "mcpClient.forwardedAcpTokenNote":
+    "具有完整 MCP 支持的适配器（已在 Hermes 上验证）接收所有传输方式；已配置 MCP 服务器的 OAuth 令牌会自动转发。",
   "mcpClient.notForwardedNote":
     "对于这些智能体，请在其各自的配置文件中配置 MCP 服务器（例如 ~/.codex/config.toml、~/.gemini/settings.json）；下方的服务器在那里不会生效。",
 

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -4745,8 +4745,10 @@ export const zhTW: Dict = {
     "Open Design 在每次對話中都會遵循的固定指令。它們不是儲存的記憶；事實、偏好與專案脈絡請使用「記憶」。",
   "mcpClient.forwardedToLabel": "已轉發給：",
   "mcpClient.notForwardedToLabel": "未轉發給：",
-  "mcpClient.forwardedAcpNote":
+  "mcpClient.forwardedAcpStdioNote":
     "標記為 stdio only 的 ACP 介面卡只會從此清單接收 stdio 類型的 MCP 伺服器；HTTP 與 SSE 項目會在啟動時被捨棄。",
+  "mcpClient.forwardedAcpTokenNote":
+    "具有完整 MCP 支援的介面卡（已在 Hermes 上驗證）接收所有傳輸方式；已設定的 MCP 伺服器的 OAuth 權杖會自動轉發。",
   "mcpClient.notForwardedNote":
     "對於這些智慧體，請在其各自的設定檔中設定 MCP 伺服器（例如 ~/.codex/config.toml、~/.gemini/settings.json）；下方的伺服器在那裡不會生效。",
 

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -2221,7 +2221,8 @@ export interface Dict {
   'settings.customInstructionsDesc': string;
   'mcpClient.forwardedToLabel': string;
   'mcpClient.notForwardedToLabel': string;
-  'mcpClient.forwardedAcpNote': string;
+  'mcpClient.forwardedAcpStdioNote': string;
+  'mcpClient.forwardedAcpTokenNote': string;
   'mcpClient.notForwardedNote': string;
   // Bottom-of-rail help menu
   'entry.helpAria': string;

--- a/packages/contracts/src/api/registry.ts
+++ b/packages/contracts/src/api/registry.ts
@@ -143,6 +143,20 @@ export interface AgentInfo {
     | 'opencode-env-content'
     | 'mimo-env-content';
   /**
+   * MCP discovery mode for the runtime. `'mature-acp'` means the ACP agent
+   * accepts the daemon's stdio live-artifacts MCP descriptor (used by
+   * `buildLiveArtifactsMcpServersForAgent`). This flag alone does NOT
+   * establish support for `McpServerHttp` / `McpServerSse` — see
+   * `acpMcpTransports` for that.
+   */
+  mcpDiscovery?: string;
+  /**
+   * MCP transports this ACP runtime can receive at spawn time. The daemon
+   * gates HTTP/SSE forwarding on this list; the settings UI uses it to
+   * label agents that only accept stdio. Undefined === stdio-only.
+   */
+  acpMcpTransports?: ('stdio' | 'sse' | 'http')[];
+  /**
    * When `false`, the Settings model picker hides the "Custom (fill below)"
    * option and the free-text input. Use this for agents whose CLI doesn't
    * accept a model id (e.g. Antigravity `agy` has no `--model` flag yet —


### PR DESCRIPTION
## Why
buildAcpMcpServers() in mcp-config.ts dropped all non-stdio MCP servers, blocking HTTP/SSE providers (Higgsfield, Nano Banana, Seedream, Deckrun, figma-use) from reaching ACP agents. Hermes ACP has supported McpServerHttp / McpServerSse since v2026.4.3 (commit 9b2fb1cc2e — "feat(acp): register client-provided MCP servers as agent tools", tested with HTTP + stdio). The Hermes ACP server already handles url/headers payloads — the only gap was the transport === 'stdio' filter and the comment "ACP currently models stdio only", which was never true for Hermes.

Changes:
- mcp-config.ts: AcpMcpServer is now a discriminated union (stdio | sse/http). buildAcpMcpServers() forwards all three transports and injects OAuth Bearer tokens via mergeAuthHeader (same mechanism as buildClaudeMcpJson). headers is always emitted (empty array when none present) because the ACP schema requires it.
- session-params.ts: AcpMcpServerInput extended with url/headers. buildAcpSessionNewParams() emits url+headers for sse/http servers instead of command/args/env.
- server.ts: passes oauthTokensForSpawn to buildAcpMcpServers() and gates non-stdio forwarding on mcpDiscovery === 'mature-acp'. Agents without mature-acp keep the previous stdio-only behaviour.
- registry.ts (contracts): add mcpDiscovery to AgentInfo so the web UI can distinguish agents that support all MCP transports.
- McpClientSection.tsx: show '(stdio only)' only for acp-merge agents without mature-acp. Updated i18n note (en, ru).

Tests: 8 new test cases in mcp-config.test.ts, 1 updated in acp.test.ts. 139 tests pass, 0 fail.
## What users will see

HTTP/SSE MCP servers configured in Settings → Add MCP server now reach agents with mcpDiscovery: 'mature-acp' (Hermes, Kimi, Trae CLI, Reasonix). Previously these servers were silently dropped for all ACP agents. The Settings integrations panel no longer tags Hermes/Kimi/Trae CLI/Reasonix as "(stdio only)" — only agents without mature-acp (Kiro, Kilo, Vibe, Devin) show the stdio-only label and discard note.


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Validation

- Test path: tests/mcp-config.test.ts — old test "drops sse / http servers" replaced with "forwards stdio, sse, and http servers"
- Did the test go red on main and green on this branch? Yes — the old test asserted ['a'] (SSE dropped); new test asserts ['a', 'b', 'c'] (all forwarded)
tests/acp.test.ts — updated HTTP server test to verify url/headers instead of env
- End-to-end verified: Hermes ACP session/new with a local HTTP MCP server → tool registered → tool called → stopReason=end_turn
- vitest run tests/mcp-config.test.ts tests/acp.test.ts — 139 passed, 0 failed
- vitest run tests/codex-session-resume.test.ts — 5 passed, 0 failed
- tsc -p tsconfig.json --noEmit — 0 new errors (pre-existing TS config errors unchanged)
- pnpm --filter @open-design/contracts build — OK
- pnpm --filter @open-design/web build — OK
