### PR TITLE
fix(web): make Projects page thumbnails fill cards like Home page

### DIFF
--- a/apps/web/src/styles/workspace/drawer.css
+++ b/apps/web/src/styles/workspace/drawer.css
@@ -448,8 +448,11 @@
 }
 .design-card:hover { border-color: var(--border-strong); box-shadow: var(--shadow-sm); transform: translateY(-1px); }
 .design-card-thumb {
-  flex: 1;
-  min-height: 100px;
+  /* Match Home page recent-projects__card-thumb: fixed 16:9 ratio so the
+   * thumbnail area fills the card the same way regardless of card content
+   * length, plus container-type: inline-size so the HTML iframe can scale
+   * to the card's own width via a container query (see .thumb-iframe). */
+  aspect-ratio: 16 / 9;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -457,6 +460,8 @@
   color: var(--text-faint);
   font-size: 38px;
   position: relative;
+  overflow: hidden;
+  container-type: inline-size;
 }
 .design-card-thumb::before {
   /* Folder-shape icon */
@@ -772,12 +777,18 @@
   display: block;
 }
 .design-card-thumb .thumb-iframe {
+  /* Render the page at a desktop design width, then scale it down to the
+   * card width via a container query so non-responsive galleries don't
+   * collapse at the narrow card size. Mirrors the Home page
+   * recent-projects__thumb-iframe treatment (1280x720 with
+   * transform: scale(calc(100cqw / 1280px))) so Projects and Home page
+   * thumbnails fill the card the same way. */
   position: absolute;
   top: 0;
   left: 0;
-  width: 250%;
-  height: 250%;
-  transform: scale(0.4);
+  width: 1280px;
+  height: 720px;
+  transform: scale(calc(100cqw / 1280px));
   transform-origin: top left;
   border: 0;
   background: var(--bg-panel);


### PR DESCRIPTION
## Why

Fixes #5803.

On the Projects page, project card preview thumbnails appeared letterboxed or constrained inside the thumbnail area instead of filling it. The same project thumbnail rendered better on the Home page recent-project rail, where the preview image fills the card preview area.

## Root cause

The Projects page (`apps/web/src/styles/workspace/drawer.css`) defined the thumbnail container differently from the Home page (`apps/web/src/styles/home/recent-projects.css`):

|                              | Projects (drawer.css)                | Home (recent-projects.css)       |
| ---------------------------- | ------------------------------------ | --------------------------------- |
| Container sizing            | `flex: 1; min-height: 100px` (variable shape — stretches with card content) | `aspect-ratio: 16 / 9` (fixed proportion) |
| `container-type`            | none                                 | `inline-size`                       |
| HTML iframe scaling         | `width: 250%; height: 250%; transform: scale(0.4)` (fixed scale, doesn't track card width) | `width: 1280px; height: 720px; transform: scale(calc(100cqw / 1280px))` (scales with card width via container query) |

The variable container shape (`flex: 1; min-height: 100px`) meant the thumbnail area height changed with card content length, so even though `.thumb-media` already used `position: absolute; inset: 0; object-fit: cover`, the container's aspect ratio differed from the 16:9 used on Home. This produced visible empty space around slide/deck previews on Projects even when the same project's thumbnail filled the card on Home. The legacy 250%/scale(0.4) iframe transform was also a fixed scale that did not track the card width, so HTML-cover thumbnails could render at awkward effective sizes.

## Fix

Align `.design-card-thumb` with `.recent-projects__card-thumb`:

- Use `aspect-ratio: 16 / 9` instead of `flex: 1; min-height: 100px` so the thumbnail area is consistently proportioned regardless of card content length.
- Add `overflow: hidden` and `container-type: inline-size` so the HTML cover iframe can use a container-query-based scale.
- Replace the legacy `width: 250%; height: 250%; transform: scale(0.4)` iframe scaling with `width: 1280px; height: 720px; transform: scale(calc(100cqw / 1280px))`, mirroring `recent-projects__thumb-iframe` so non-responsive HTML galleries render at a desktop design width and scale down to the card width.

No markup changes — the same `.design-card-thumb` element and `.thumb-media` / `.thumb-iframe` children are used; the CSS rules are what differ.

## Surface area

- [ ] **UI** — visual only: Projects page preview thumbnails now fill the card preview area the same way Home page recent-project cards do.
- [ ] **Keyboard shortcut** — none.
- [ ] **CLI / env var** — none.
- [ ] **API / contract** — none.
- [ ] **Extension point** — none.
- [ ] **i18n keys** — none.
- [ ] **New top-level dependency** — none.
- [ ] **Default behavior change** — Projects page card thumbnails now occupy a 16:9 area regardless of card content length. Other card variants that share `.design-card-thumb` (`live-artifact-card`, featured/tutorial card, design-card-skeleton) inherit the same 16:9 fill behavior consistently.
- [x] **None / internal refactor** — CSS-only change to match an existing pattern already in use on the Home page.

## Bug fix verification

- **Test path that reproduces the bug**: there is no unit/E2E test that directly asserts thumbnail fill — the bug is visual. The change is a CSS-only alignment to an existing pattern already in production on the Home page, reducing risk of behavioral regression.
- **Did the test go red on main and green on this branch?** No falsifiable test added because the failure is purely visual (thumbnail letterboxing). The issue itself references screenshots, not a failing test path.
- **No new falsifiable test was added.** A visual regression test would require Playwright snapshot comparison against a captured baseline and would also need a fixture project with image/slide cover; that is a larger undertaking that's out of scope for this CSS-only alignment fix. Adding one is left to a follow-up if the team wants visual snapshot coverage.

## Validation

- [x] `apps/web/tests/components/DesignsTab.select-mode.test.tsx` — covers `.project-thumb-html` element presence, iframe src, and glyph rendering. None of these assertions check thumb height or aspect-ratio, so they pass unmodified (verified by reading the test file).
- [x] Manual: rendered the Projects page before/after for a project with an image cover and a project with a slide/deck cover — both now fill the 16:9 thumbnail area the same way the Home page rail does.
- [ ] CI — pending on push.

## Notes

- Live-artifact thumbnails (`live-artifact-card .live-artifact-thumb`) and featured (tutorial) card variants share `.design-card-thumb` and inherit the same fill behavior consistently. No `.live-artifact-thumb` rule needed to be touched; it already lays out the iframe inside `.design-card-thumb`.
- The `container-type: inline-size` rule requires a browser that supports CSS container queries (Chrome 105+, Safari 16+, Firefox 110+). The Home page recent-projects rail has relied on this since it shipped, so the target browser matrix already supports it.

Fixes #5803
