### PR TITLE
feat(web): surface local projects in tab search

### DIFF
--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -488,6 +488,24 @@ export function WorkspaceTabsBar({ route, projects, onboardingCompleted = false 
       .slice(0, MAX_SEARCH_RESULTS);
   }, [displayTabs, query]);
 
+  // Local projects that match the query but aren't already open as tabs. The
+  // open-tabs list above only searches in-memory tabs, so a closed project was
+  // previously unreachable from search (#2693). This group only appears while
+  // searching; with no query the popover keeps showing open tabs alone.
+  const filteredProjects = useMemo(() => {
+    const needle = normalizeSearch(query);
+    if (!needle) return [];
+    const openProjectIds = new Set(
+      state.tabs.flatMap((tab) => (tab.kind === 'project' ? [tab.projectId] : [])),
+    );
+    return projects
+      .filter((project) => !openProjectIds.has(project.id))
+      .filter((project) => (project.name.trim() || t('common.untitled')).toLocaleLowerCase().includes(needle))
+      .slice()
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+      .slice(0, MAX_SEARCH_RESULTS);
+  }, [projects, state.tabs, query, t]);
+
   useEffect(() => {
     setState((current) => syncStateToRoute(current, route));
   }, [route]);
@@ -739,6 +757,15 @@ export function WorkspaceTabsBar({ route, projects, onboardingCompleted = false 
       return;
     }
     activateTab(tab);
+  }
+
+  // Open a local project chosen from the search popover. Navigation is enough:
+  // the route change reconciles into a project tab via the route-sync effect,
+  // matching how projects are opened elsewhere (App `onOpenProject`).
+  function openProjectFromSearch(projectId: string) {
+    setTabsMenuOpen(false);
+    dismissHoverPreview();
+    navigate({ kind: 'project', projectId, conversationId: null, fileName: null });
   }
 
   function createNewTab() {
@@ -1081,6 +1108,51 @@ export function WorkspaceTabsBar({ route, projects, onboardingCompleted = false 
                     <div className="workspace-tabs-empty">No tabs found</div>
                   )}
                 </div>
+                {filteredProjects.length > 0 ? (
+                  <>
+                    <div className="workspace-tabs-popover__section">
+                      <span>Local projects</span>
+                      <span>{filteredProjects.length}</span>
+                    </div>
+                    <div
+                      className="workspace-tabs-list"
+                      role="listbox"
+                      aria-label="Local projects"
+                    >
+                      {filteredProjects.map((project) => {
+                        const name = project.name.trim() || t('common.untitled');
+                        return (
+                          <div
+                            key={project.id}
+                            className="workspace-tabs-list__item"
+                            role="option"
+                            aria-selected={false}
+                          >
+                            <button
+                              type="button"
+                              className="workspace-tabs-list__main od-tooltip"
+                              onClick={() => openProjectFromSearch(project.id)}
+                              aria-label={name}
+                              title={name}
+                              data-tooltip={name}
+                              data-tooltip-placement="right"
+                            >
+                              <span className="workspace-tabs-list__icon" aria-hidden>
+                                <Icon name="folder" size={15} />
+                              </span>
+                              <span className="workspace-tabs-list__text">
+                                <span className="workspace-tabs-list__title">{name}</span>
+                                <span className="workspace-tabs-list__meta">
+                                  {t('workspaceTabs.project')}
+                                </span>
+                              </span>
+                            </button>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </>
+                ) : null}
               </div>,
               document.body,
             )

--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -501,7 +501,6 @@ export function WorkspaceTabsBar({ route, projects, onboardingCompleted = false 
     return projects
       .filter((project) => !openProjectIds.has(project.id))
       .filter((project) => (project.name.trim() || t('common.untitled')).toLocaleLowerCase().includes(needle))
-      .slice()
       .sort((a, b) => b.updatedAt - a.updatedAt)
       .slice(0, MAX_SEARCH_RESULTS);
   }, [projects, state.tabs, query, t]);
@@ -1105,7 +1104,9 @@ export function WorkspaceTabsBar({ route, projects, onboardingCompleted = false 
                       );
                     })
                   ) : (
-                    <div className="workspace-tabs-empty">No tabs found</div>
+                    filteredProjects.length === 0 ? (
+                      <div className="workspace-tabs-empty">No tabs found</div>
+                    ) : null
                   )}
                 </div>
                 {filteredProjects.length > 0 ? (

--- a/apps/web/tests/components/WorkspaceTabsBar.test.tsx
+++ b/apps/web/tests/components/WorkspaceTabsBar.test.tsx
@@ -219,6 +219,32 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     expect(screen.queryByRole('button', { name: 'Search tabs' })).toBeNull();
   });
 
+  it('surfaces local projects that are not open as tabs when searching', async () => {
+    // Only the singleton Home entry tab is open — neither project is open as a
+    // tab. Searching must still find a closed local project (the #2693 gap:
+    // results were limited to open tabs).
+    render(
+      <WorkspaceTabsBar
+        route={{ kind: 'home', view: 'home' }}
+        projects={[project, projectBeta]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Search tabs' }));
+    const input = await screen.findByPlaceholderText('Search tabs');
+    fireEvent.change(input, { target: { value: 'Beta' } });
+
+    const result = await screen.findByRole('button', { name: 'Project Beta' });
+    fireEvent.click(result);
+
+    expect(navigate).toHaveBeenCalledWith({
+      kind: 'project',
+      projectId: 'project-beta',
+      conversationId: null,
+      fileName: null,
+    });
+  });
+
   it('collapses every entry section into the single leftmost tab (no new tab per section)', async () => {
     const { rerender } = render(
       <WorkspaceTabsBar route={{ kind: 'home', view: 'home' }} projects={[project]} />,

--- a/apps/web/tests/components/WorkspaceTabsBar.test.tsx
+++ b/apps/web/tests/components/WorkspaceTabsBar.test.tsx
@@ -1,7 +1,7 @@
 
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -243,6 +243,21 @@ describe('WorkspaceTabsBar navigation semantics', () => {
       conversationId: null,
       fileName: null,
     });
+  });
+
+  it('excludes projects already open as tabs from the local projects group', async () => {
+    // Alpha is open as the active project tab; Beta is closed. Searching a term
+    // that matches both must list Beta under Local projects but not Alpha —
+    // Alpha already lives in the Open tabs group, so duplicating it would be noise.
+    render(<WorkspaceTabsBar route={projectRoute} projects={[project, projectBeta]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Search tabs' }));
+    const input = await screen.findByPlaceholderText('Search tabs');
+    fireEvent.change(input, { target: { value: 'Project' } });
+
+    const localGroup = await screen.findByRole('listbox', { name: 'Local projects' });
+    expect(within(localGroup).getByRole('button', { name: 'Project Beta' })).toBeTruthy();
+    expect(within(localGroup).queryByRole('button', { name: 'Project Alpha' })).toBeNull();
   });
 
   it('collapses every entry section into the single leftmost tab (no new tab per section)', async () => {


### PR DESCRIPTION
Fixes #2693

## Why

Scratching the reported itch. I hit the same gap while working in OD: the workspace tab-search popover only searches currently-open tabs, so a project I'd closed was invisible to search — I had to leave the popover and reopen it from the Projects list. @lefarcen scoped this in the issue (search popover builds results from in-memory open tabs only; the full local project list is already in scope on this surface), and this implements that scoping.

## What users will see

Opening the tab-search popover (the search icon in the workspace tab bar) and typing now shows a new **"Local projects"** group beneath "Open tabs", listing local projects whose name matches the query — including ones that aren't currently open as tabs. Selecting one opens that project. With an empty query the popover is unchanged (open tabs only), so the default view isn't affected.

## Surface area

- [x] **UI** — new "Local projects" result group in the workspace tab-search popover
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — none added; reuses existing `workspaceTabs.project` / `common.untitled` and matches the hardcoded "Open tabs" section-header style
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — the empty-query popover is unchanged; the new group only appears while searching
- [ ] **None**

## Screenshots

Searching `aurora` in the tab-search popover — "Aurora Notes" is a local project that is **not** open as a tab, and it now surfaces under the new "Local projects" group (the "Open tabs" group has no match and no longer shows a stray "No tabs found" line since there are real results below):

![Local projects search group](https://raw.githubusercontent.com/maxmilian/open-design/assets/pr-2693/2693-local-projects.png)

## Bug fix verification

- Test path that reproduces the gap: `apps/web/tests/components/WorkspaceTabsBar.test.tsx` → `surfaces local projects that are not open as tabs when searching`
- Did the test go red on `main` and green on this branch? **yes** — on `main` the popover renders "No tabs found" when searching for a closed project (the search only sees open tabs); on this branch the project appears under "Local projects" and clicking it navigates to the project route.

## Validation

- `pnpm --filter @open-design/web test` — 335 files, 3344 passed / 1 skipped (incl. the new test)
- `pnpm typecheck` — all packages green
- `pnpm guard` — 60 passed
