### PR TITLE
fix(platform): detect Grok Build in official user bin

### DIFF
--- a/apps/daemon/tests/runtimes/executables.test.ts
+++ b/apps/daemon/tests/runtimes/executables.test.ts
@@ -37,6 +37,29 @@ test('deepseek entry declares codewhale as a fallback bin (issue #2983)', () => 
   );
 });
 
+test('resolveAgentExecutable finds Grok Build in OD_AGENT_HOME on Windows', () => {
+  const home = mkdtempSync(join(tmpdir(), 'od-grok-build-home-'));
+  try {
+    return withEnvSnapshot(['PATH', 'PATHEXT', 'OD_AGENT_HOME'], () =>
+      withPlatform('win32', () => {
+        const grok = join(home, '.grok', 'bin', 'grok.EXE');
+        mkdirSync(join(home, '.grok', 'bin'), { recursive: true });
+        writeFileSync(grok, '');
+        process.env.PATH = '';
+        process.env.PATHEXT = '.EXE';
+        process.env.OD_AGENT_HOME = home;
+
+        assert.equal(
+          resolveAgentExecutable(minimalAgentDef({ id: 'grok-build', bin: 'grok' })),
+          grok,
+        );
+      }),
+    );
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
 // resolveAgentExecutable touches the filesystem via existsSync; on
 // Windows resolveOnPath also walks PATHEXT extensions, which our fixture
 // files don't carry. Skip the filesystem-backed cases there — the

--- a/packages/platform/src/toolchain.ts
+++ b/packages/platform/src/toolchain.ts
@@ -119,6 +119,7 @@ export function wellKnownUserToolchainBins(
     join(home, ".vite-plus", "bin"),
     join(home, ".kimi-code", "bin"),
     join(home, ".opencode", "bin"),
+    join(home, ".grok", "bin"),
     join(home, ".bun", "bin"),
     join(home, ".volta", "bin"),
     join(home, ".asdf", "shims"),

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -804,6 +804,16 @@ describe("wellKnownUserToolchainBins", () => {
     }
   });
 
+  it("includes ~/.grok/bin when PATH is stripped so Windows Grok Build resolves", () => {
+    const home = mkdtempSync(join(tmpdir(), "wkutb-grok-"));
+    try {
+      const dirs = wellKnownUserToolchainBins({ home, env: { PATH: "" }, includeSystemBins: false });
+      expect(dirs).toContain(join(home, ".grok", "bin"));
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   // Non-Node user toolchains that still ship agent CLIs (or their deps):
   // Deno's install root, Go's default GOBIN, and pyenv's shim dir. GUI
   // launches inherit a stripped PATH, so these must be searched explicitly.


### PR DESCRIPTION
## Why

I hit this in packaged Open Design on Windows: Grok Build 0.2.101 was installed by xAI's current PowerShell installer and `grok --version` worked from the shell, but Open Design reported the runtime as unavailable. GUI-launched packaged processes inherit a minimal PATH, and the shared user-toolchain discovery list did not include xAI's default `%USERPROFILE%\.grok\bin` location.

The fix stays in the existing `packages/platform` toolchain boundary, which is shared by daemon executable resolution and packaged sidecar PATH construction.

## What users will see

Packaged Open Design can detect a default Grok Build installation on Windows even when `.grok\bin` was not inherited through PATH. The existing Grok Build option becomes available after restart; there is no new setting or UI.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — official Grok Build installs are now discovered under a stripped packaged PATH
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI changed.

## Bug fix verification

- Test paths that reproduce the bug:
  - `packages/platform/tests/index.test.ts`
  - `apps/daemon/tests/runtimes/executables.test.ts`
- Red on `main`: yes. With only the new resolver test applied to `958cc8871`, `resolveAgentExecutable` returned `null` instead of the fixture's `.grok/bin/grok.EXE` path (1 failed, 2 passed, 23 skipped). The platform helper assertion also failed because the candidate list omitted `.grok/bin`.
- Green on this branch: yes. The Windows resolver test passes with an isolated `OD_AGENT_HOME`, empty PATH, and `PATHEXT=.EXE`; the platform suite passes 77 tests.
- Live reproduction: the installed packaged app reported `grok-build.available=false` while `where grok` resolved `C:\Users\btf\.grok\bin\grok.exe` and `grok --version` returned 0.2.101.
- First-party source: xAI's current installer defaults `$BinDir` to `$USERPROFILE/.grok/bin`: https://x.ai/cli/install.ps1

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/executables.test.ts`
- `pnpm --filter @open-design/platform test`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/platform typecheck`
- `pnpm guard`
- `pnpm typecheck`
