### PR TITLE
Fix MCP prompts for resumed runs

### DIFF
--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -1074,7 +1074,10 @@ function slugifyProjectId(name: string): string {
 async function startRun(baseUrl: string, args: McpArgs) {
   const { id, resolved, active } = await resolveProjectArg(baseUrl, args.project);
   const body: JsonObject = { projectId: id };
-  if (typeof args.prompt === 'string' && args.prompt.length > 0) body.message = args.prompt;
+  if (typeof args.prompt === 'string' && args.prompt.length > 0) {
+    body.message = args.prompt;
+    body.currentPrompt = args.prompt;
+  }
   if (typeof args.skill === 'string' && args.skill.length > 0) body.skillId = args.skill;
   if (typeof args.plugin === 'string' && args.plugin.length > 0) body.pluginId = args.plugin;
   if (typeof args.agent === 'string' && args.agent.length > 0) body.agentId = args.agent;

--- a/apps/daemon/tests/mcp-runs.test.ts
+++ b/apps/daemon/tests/mcp-runs.test.ts
@@ -57,6 +57,7 @@ describe('public MCP discovery + generation tools', () => {
     expect(postBody).toEqual({
       projectId: 'project-1',
       message: 'A 5-slide seed pitch deck',
+      currentPrompt: 'A 5-slide seed pitch deck',
       pluginId: 'pitch-deck',
       pluginInputs: { tone: 'bold' },
       agentId: 'claude',
@@ -77,7 +78,11 @@ describe('public MCP discovery + generation tools', () => {
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'start_run', { prompt: 'iterate' });
 
     const postBody = JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body));
-    expect(postBody).toMatchObject({ projectId: 'active-1', message: 'iterate' });
+    expect(postBody).toMatchObject({
+      projectId: 'active-1',
+      message: 'iterate',
+      currentPrompt: 'iterate',
+    });
     expect(JSON.parse(firstText(result))).toMatchObject({
       runId: 'run-7',
       usedActiveContext: { projectId: 'active-1' },


### PR DESCRIPTION
Fixes #5810

## Why

While following the confirmed daemon-side trace in #5810, I reproduced the request-body gap in the MCP `start_run` path. The MCP prompt was persisted as `message`, but resumed sessions consume `currentPrompt` when the transcript is skipped. That left a follow-up run without its latest user turn and allowed it to finish successfully without producing new artifacts.

## What users will see

Repeated MCP `start_run` calls on the same conversation now deliver the latest prompt to the resumed session. Follow-up requests can produce the requested artifacts instead of silently completing with no new output.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this change has no UI surface.

## Bug fix verification

- Test path: `apps/daemon/tests/mcp-runs.test.ts`
- Red/green proof: yes. The focused suite failed on the missing `currentPrompt` field before the source change (2 failed, 30 passed), then passed after the fix (32 passed).

## Validation

- `corepack pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/mcp-runs.test.ts`
- `corepack pnpm --filter @open-design/daemon typecheck`
- `corepack pnpm guard`
- `git diff --check`

