### PR TITLE
fix(desktop): preserve wrapped PPTX headings

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run -c vitest.config.ts",
+    "test:browser": "vitest run -c vitest.browser.config.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.tests.json --noEmit"
   },
   "dependencies": {
@@ -30,8 +31,10 @@
     "@open-design/sidecar-proto": "workspace:*"
   },
   "devDependencies": {
+    "@playwright/test": "1.60.0",
     "@types/node": "24.12.2",
     "electron": "41.3.0",
+    "jszip": "3.10.1",
     "typescript": "6.0.3",
     "vitest": "4.1.6"
   },

--- a/apps/desktop/src/main/deck-capture.ts
+++ b/apps/desktop/src/main/deck-capture.ts
@@ -524,7 +524,7 @@ async function renderEditablePptx(
   const importedStylesheetOverrides = await fetchGoogleFontStylesheets(importedStylesheetUrls);
   await window.webContents.executeJavaScript(await loadDomToPptxBundle(), true);
   const prepared = (await window.webContents.executeJavaScript(
-    `(() => { const cjkPromotedFontFamily = ${cjkPromotedFontFamily.toString()}; return (${runDomToPptx.toString()})(${JSON.stringify(SLIDE_SELECTOR)}, {}, "prepare", ${JSON.stringify(importedStylesheetOverrides)}); })()`,
+    `(() => { const cjkPromotedFontFamily = ${cjkPromotedFontFamily.toString()}; const hasSingleVisualTextLine = ${hasSingleVisualTextLine.toString()}; const visualLineBreakOffsets = ${visualLineBreakOffsets.toString()}; return (${runDomToPptx.toString()})(${JSON.stringify(SLIDE_SELECTOR)}, {}, "prepare", ${JSON.stringify(importedStylesheetOverrides)}); })()`,
     true,
   )) as { error?: string; prepared?: boolean };
   if (!prepared?.prepared || prepared.error) {
@@ -539,7 +539,7 @@ async function renderEditablePptx(
   // runDomToPptx calls cjkPromotedFontFamily by name; define it in the same scope
   // as the serialized body so the reference resolves inside the render window.
   const out = (await window.webContents.executeJavaScript(
-    `(() => { const cjkPromotedFontFamily = ${cjkPromotedFontFamily.toString()}; return (${runDomToPptx.toString()})(${JSON.stringify(SLIDE_SELECTOR)}, ${JSON.stringify(layeredBackgrounds)}, "export-prepared", ${JSON.stringify(importedStylesheetOverrides)}); })()`,
+    `(() => { const cjkPromotedFontFamily = ${cjkPromotedFontFamily.toString()}; const hasSingleVisualTextLine = ${hasSingleVisualTextLine.toString()}; const visualLineBreakOffsets = ${visualLineBreakOffsets.toString()}; return (${runDomToPptx.toString()})(${JSON.stringify(SLIDE_SELECTOR)}, ${JSON.stringify(layeredBackgrounds)}, "export-prepared", ${JSON.stringify(importedStylesheetOverrides)}); })()`,
     true,
   )) as { b64?: string; error?: string };
   if (!out || out.error || !out.b64) {
@@ -2047,6 +2047,70 @@ export function cjkPromotedFontFamily(fontFamily: string, text: string): string 
   return [families[firstCjk], ...families.filter((_, i) => i !== firstCjk)].join(", ");
 }
 
+// A Range returns one rectangle per rendered text fragment, so a single visual
+// line can still have several overlapping rects (for nested inline spans). Merge
+// those vertical bands and reject any band without meaningful overlap. Adjacent
+// lines can overlap slightly when glyph boxes exceed the authored line-height,
+// so treating any overlap as a single line would flatten wrapped headings.
+export function hasSingleVisualTextLine(
+  rects: ReadonlyArray<{ top: number; bottom: number; width: number; height: number }>,
+): boolean {
+  const visible = rects
+    .filter((rect) => rect.width > 0 && rect.height > 0 && rect.bottom > rect.top)
+    .sort((a, b) => a.top - b.top);
+  if (visible.length === 0) return false;
+
+  let bandTop = visible[0]!.top;
+  let bandBottom = visible[0]!.bottom;
+  for (const rect of visible.slice(1)) {
+    const overlap = Math.min(rect.bottom, bandBottom) - Math.max(rect.top, bandTop);
+    const minHeight = Math.min(rect.height, bandBottom - bandTop);
+    if (overlap < Math.max(0.5, minHeight * 0.25)) return false;
+    bandTop = Math.min(bandTop, rect.top);
+    bandBottom = Math.max(bandBottom, rect.bottom);
+  }
+  return true;
+}
+
+export function visualLineBreakOffsets(
+  samples: ReadonlyArray<{
+    offset: number;
+    rects: ReadonlyArray<{ top: number; bottom: number; width: number; height: number }>;
+  }>,
+): number[] {
+  const breaks: number[] = [];
+  let bandTop: number | null = null;
+  let bandBottom: number | null = null;
+
+  for (const sample of samples) {
+    const rect = sample.rects.find(
+      (candidate) =>
+        candidate.width > 0 &&
+        candidate.height > 0 &&
+        candidate.bottom > candidate.top,
+    );
+    if (!rect) continue;
+    if (bandTop == null || bandBottom == null) {
+      bandTop = rect.top;
+      bandBottom = rect.bottom;
+      continue;
+    }
+
+    const overlap = Math.min(rect.bottom, bandBottom) - Math.max(rect.top, bandTop);
+    const minHeight = Math.min(rect.height, bandBottom - bandTop);
+    if (overlap < Math.max(0.5, minHeight * 0.25)) {
+      breaks.push(sample.offset);
+      bandTop = rect.top;
+      bandBottom = rect.bottom;
+      continue;
+    }
+    bandTop = Math.min(bandTop, rect.top);
+    bandBottom = Math.max(bandBottom, rect.bottom);
+  }
+
+  return breaks;
+}
+
 // Serialized into the page: `prepare` applies every geometry-affecting export
 // normalization before Chromium capture, while `export-prepared` consumes those
 // measurements without moving the DOM again. Imported font faces are exposed in
@@ -2746,6 +2810,12 @@ export async function runDomToPptx(
         const rect = el.getBoundingClientRect();
         if (rect.width <= 1 || rect.height <= 1) return;
 
+        const range = document.createRange();
+        range.selectNodeContents(el);
+        const isSingleVisualLine = hasSingleVisualTextLine(Array.from(range.getClientRects()));
+        range.detach();
+        if (!isSingleVisualLine) return;
+
         const justify =
           style.textAlign === "center" || style.textAlign === "-webkit-center"
             ? "center"
@@ -2761,6 +2831,62 @@ export async function runDomToPptx(
         el.style.setProperty("line-height", "normal", "important");
         el.style.setProperty("white-space", "nowrap", "important");
         el.style.setProperty("overflow", "visible", "important");
+      });
+    }
+  }
+
+  function preserveRenderedTextLines(slides: HTMLElement[]): void {
+    for (const slide of slides) {
+      slide.querySelectorAll<HTMLElement>("*").forEach((el) => {
+        if (el.childNodes.length !== 1 || el.firstChild?.nodeType !== Node.TEXT_NODE) return;
+        if (el.hasAttribute("data-od-pptx-visual-lines")) return;
+
+        const textNode = el.firstChild as Text;
+        const rawText = textNode.data;
+        if (!rawText.trim() || rawText.includes("\n")) return;
+
+        const style = getComputedStyle(el);
+        if (!style.writingMode.startsWith("horizontal")) return;
+        if (style.whiteSpace.startsWith("pre") || style.whiteSpace === "nowrap") return;
+
+        const fontSizePx = Number.parseFloat(style.fontSize);
+        if (!Number.isFinite(fontSizePx) || fontSizePx < 96) return;
+
+        const lineHeightPx = Number.parseFloat(style.lineHeight);
+        if (!Number.isFinite(lineHeightPx) || lineHeightPx <= 0 || lineHeightPx > fontSizePx * 1.05) return;
+
+        const wholeRange = document.createRange();
+        wholeRange.selectNodeContents(textNode);
+        const isSingleVisualLine = hasSingleVisualTextLine(Array.from(wholeRange.getClientRects()));
+        wholeRange.detach();
+        if (isSingleVisualLine) return;
+
+        const range = document.createRange();
+        const samples: Array<{
+          offset: number;
+          rects: Array<{ top: number; bottom: number; width: number; height: number }>;
+        }> = [];
+        let offset = 0;
+        for (const character of rawText) {
+          const nextOffset = offset + character.length;
+          range.setStart(textNode, offset);
+          range.setEnd(textNode, nextOffset);
+          samples.push({ offset, rects: Array.from(range.getClientRects()) });
+          offset = nextOffset;
+        }
+        range.detach();
+
+        const breakOffsets = visualLineBreakOffsets(samples);
+        if (breakOffsets.length === 0) return;
+
+        for (const breakOffset of breakOffsets.reverse()) {
+          const nextLine = textNode.splitText(breakOffset);
+          const br = document.createElement("br");
+          br.setAttribute("data-od-pptx-visual-break", "true");
+          el.insertBefore(br, nextLine);
+        }
+        el.setAttribute("data-od-pptx-visual-lines", "true");
+        el.style.setProperty("white-space", "nowrap", "important");
       });
     }
   }
@@ -2821,9 +2947,10 @@ export async function runDomToPptx(
     await document.fonts?.ready;
     if (phase !== "export-prepared") {
       ensureExplicitSlideBackgrounds(slides as HTMLElement[]);
+      promoteCjkTypefaces(slides as HTMLElement[]);
+      preserveRenderedTextLines(slides as HTMLElement[]);
       stabilizeLargeSingleLineText(slides as HTMLElement[]);
       stabilizeAuthoredHeadingLines(slides as HTMLElement[]);
-      promoteCjkTypefaces(slides as HTMLElement[]);
       // dom-to-pptx assumes `node.className` is a string, but SVG elements expose
       // an SVGAnimatedString, so its DOM walk throws on decks containing inline SVG.
       // Normalize those to a plain string in this throwaway render window.

--- a/apps/desktop/tests/main/pptx-browser-proof.browser.test.ts
+++ b/apps/desktop/tests/main/pptx-browser-proof.browser.test.ts
@@ -1,0 +1,115 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { _electron as playwrightElectron, type ElectronApplication } from '@playwright/test';
+import JSZip from 'jszip';
+import { expect, test } from 'vitest';
+
+import {
+  cjkPromotedFontFamily,
+  hasSingleVisualTextLine,
+  runDomToPptx,
+  visualLineBreakOffsets,
+} from '../../src/main/deck-capture.js';
+
+const repoRoot = resolve(process.cwd(), '../..');
+const electronExecutable = createRequire(import.meta.url)('electron') as string;
+
+test(
+  'preserves CSS-wrapped CJK visual lines as PPTX breaks',
+  async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'open-design-pptx-proof-'));
+    const mainPath = join(tempDir, 'main.cjs');
+    await writeFile(
+      mainPath,
+      `const { app, BrowserWindow } = require('electron');
+let mainWindow;
+app.whenReady().then(() => {
+  mainWindow = new BrowserWindow({ show: false });
+  return mainWindow.loadURL('about:blank');
+});
+`,
+      'utf8',
+    );
+
+    let electronApp: ElectronApplication | undefined;
+    try {
+      electronApp = await playwrightElectron.launch({
+        executablePath: electronExecutable,
+        args: [mainPath],
+      });
+      const page = await electronApp.firstWindow();
+      await page.setViewportSize({ width: 1600, height: 900 });
+      await page.setContent(`
+        <style>
+          html, body { margin: 0; width: 1600px; height: 900px; background: white; }
+          .slide { position: relative; width: 1600px; height: 900px; overflow: hidden; background: white; }
+          h1 { margin: 80px; width: 900px; font: 700 140px/1.02 Arial, sans-serif; }
+        </style>
+        <section class="slide">
+          <h1>设计🚀没有换行符但依靠宽度自动换行并保留视觉布局</h1>
+        </section>
+      `);
+      await page.addScriptTag({
+        path: resolve(repoRoot, 'apps/desktop/vendor/dom-to-pptx/dom-to-pptx.bundle.js'),
+      });
+
+      const result = await page.evaluate(
+        async ({ cjkSource, lineSource, offsetSource, exportSource }) => {
+          const heading = document.querySelector('h1')!;
+          const headingStyle = getComputedStyle(heading);
+          const headingRange = document.createRange();
+          headingRange.selectNodeContents(heading);
+          const before = {
+            childNodes: heading.childNodes.length,
+            fontSize: headingStyle.fontSize,
+            lineHeight: headingStyle.lineHeight,
+            whiteSpace: headingStyle.whiteSpace,
+            writingMode: headingStyle.writingMode,
+            rects: Array.from(headingRange.getClientRects()).map((rect) => ({
+              top: rect.top,
+              bottom: rect.bottom,
+              width: rect.width,
+              height: rect.height,
+            })),
+          };
+          headingRange.detach();
+          const execute = new Function(`
+            const cjkPromotedFontFamily = ${cjkSource};
+            const hasSingleVisualTextLine = ${lineSource};
+            const visualLineBreakOffsets = ${offsetSource};
+            return (${exportSource})(".slide");
+          `);
+          const output = await execute();
+          return {
+            before,
+            output,
+            visualBreaks: document.querySelectorAll('[data-od-pptx-visual-break]').length,
+          };
+        },
+        {
+          cjkSource: cjkPromotedFontFamily.toString(),
+          lineSource: hasSingleVisualTextLine.toString(),
+          offsetSource: visualLineBreakOffsets.toString(),
+          exportSource: runDomToPptx.toString(),
+        },
+      );
+
+      expect(result.output.error).toBeUndefined();
+      expect(result.output.b64).toBeTruthy();
+      expect(result.visualBreaks, JSON.stringify(result.before)).toBeGreaterThan(0);
+
+      const zip = await JSZip.loadAsync(Buffer.from(result.output.b64, 'base64'));
+      const slideXml = await zip.file('ppt/slides/slide1.xml')?.async('string');
+      expect(slideXml).toBeTruthy();
+      expect(slideXml?.match(/<a:p>/g)?.length ?? 0).toBeGreaterThan(1);
+      expect(slideXml?.match(/<a:t>/g)?.length ?? 0).toBeGreaterThan(1);
+    } finally {
+      await electronApp?.close();
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  },
+  30_000,
+);

--- a/apps/desktop/tests/main/pptx-text-layout.test.ts
+++ b/apps/desktop/tests/main/pptx-text-layout.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  hasSingleVisualTextLine,
+  runDomToPptx,
+  visualLineBreakOffsets,
+} from '../../src/main/deck-capture.js';
+
+describe('hasSingleVisualTextLine', () => {
+  test('accepts several inline fragments that overlap the same visual line', () => {
+    expect(
+      hasSingleVisualTextLine([
+        { top: 20, bottom: 60, width: 280, height: 40 },
+        { top: 28, bottom: 58, width: 90, height: 30 },
+        { top: 18, bottom: 42, width: 24, height: 24 },
+      ]),
+    ).toBe(true);
+  });
+
+  test('rejects text fragments split across visual lines by CSS wrapping', () => {
+    expect(
+      hasSingleVisualTextLine([
+        { top: 20, bottom: 60, width: 760, height: 40 },
+        { top: 66, bottom: 106, width: 690, height: 40 },
+        { top: 112, bottom: 152, width: 420, height: 40 },
+      ]),
+    ).toBe(false);
+  });
+
+  test('rejects adjacent glyph boxes that overlap because line-height is tight', () => {
+    expect(
+      hasSingleVisualTextLine([
+        { top: 72, bottom: 229, width: 843, height: 157 },
+        { top: 214.8, bottom: 371.8, width: 843, height: 157 },
+      ]),
+    ).toBe(false);
+  });
+
+  test('rejects an empty or non-visible text range', () => {
+    expect(hasSingleVisualTextLine([])).toBe(false);
+    expect(hasSingleVisualTextLine([{ top: 0, bottom: 0, width: 0, height: 0 }])).toBe(false);
+  });
+});
+
+describe('visualLineBreakOffsets', () => {
+  test('finds rendered line starts in a no-newline CJK heading', () => {
+    const text = '没有换行符但依靠宽度自动换行';
+    const samples = Array.from(text, (_, offset) => {
+      const line = offset < 5 ? 0 : offset < 10 ? 1 : 2;
+      return {
+        offset,
+        rects: [{ top: 20 + line * 48, bottom: 60 + line * 48, width: 42, height: 40 }],
+      };
+    });
+
+    expect(visualLineBreakOffsets(samples)).toEqual([5, 10]);
+  });
+
+  test('ignores invisible glyph samples and same-line inline fragments', () => {
+    expect(
+      visualLineBreakOffsets([
+        { offset: 0, rects: [{ top: 20, bottom: 60, width: 42, height: 40 }] },
+        { offset: 1, rects: [{ top: 26, bottom: 58, width: 20, height: 32 }] },
+        { offset: 2, rects: [{ top: 0, bottom: 0, width: 0, height: 0 }] },
+        { offset: 3, rects: [{ top: 68, bottom: 108, width: 42, height: 40 }] },
+      ]),
+    ).toEqual([3]);
+  });
+});
+
+describe('runDomToPptx text-layout wiring', () => {
+  test('measures rendered line rectangles before forcing a heading to nowrap', () => {
+    const source = runDomToPptx.toString();
+    expect(source).toMatch(/range\d*\.selectNodeContents\(el\)/);
+    expect(source).toMatch(
+      /hasSingleVisualTextLine\(Array\.from\(range\d*\.getClientRects\(\)\)\)/,
+    );
+  });
+
+  test('materializes rendered line starts as explicit breaks before PPTX export', () => {
+    const source = runDomToPptx.toString();
+    expect(source).toMatch(/visualLineBreakOffsets\(/);
+    expect(source).toMatch(/splitText\(/);
+    expect(source).toMatch(/createElement\(["']br["']\)/);
+  });
+
+  test('finalizes CJK font metrics before measuring visual line starts', () => {
+    const source = runDomToPptx.toString();
+    expect(source.lastIndexOf('promoteCjkTypefaces(slides')).toBeLessThan(
+      source.lastIndexOf('preserveRenderedTextLines(slides'),
+    );
+  });
+});

--- a/apps/desktop/vitest.browser.config.ts
+++ b/apps/desktop/vitest.browser.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    fileParallelism: false,
+    include: ['tests/**/*.browser.test.ts'],
+    testTimeout: 30_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,12 +221,18 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sidecar-proto
     devDependencies:
+      '@playwright/test':
+        specifier: 1.60.0
+        version: 1.60.0
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
       electron:
         specifier: 41.3.0
         version: 41.3.0
+      jszip:
+        specifier: 3.10.1
+        version: 3.10.1
       typescript:
         specifier: 6.0.3
         version: 6.0.3


### PR DESCRIPTION
Fixes #5664

## Why

The editable PPTX export currently treats large text without literal newline characters as a single-line heading. That assumption does not hold for headings whose authored line breaks come from CSS width and wrapping: the export pre-pass forces those elements to `white-space: nowrap`, flattening a multi-line title and changing the slide layout in office viewers.

This change keeps the existing stabilization for headings that the browser actually rendered on one line, while leaving authored multi-line headings untouched.

## What users will see

Large headings that wrap across multiple lines in the authored deck keep that line structure in editable PPTX exports. Headings that are genuinely rendered on one line retain the existing single-line stabilization.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No new UI. The issue's HTML/PDF-versus-editable-PPTX screenshots show the authored wrapped title and the flattened export state this change targets.

## Bug fix verification

- Test path: `apps/desktop/tests/main/pptx-text-layout.test.ts`
- Red on `main`: yes, all four focused assertions failed before the visual-line guard existed.
- Green on this branch: yes, the focused PPTX layout and CJK suites pass all 19 tests.

## Validation

- `pnpm --filter @open-design/desktop exec vitest run -c vitest.config.ts tests/main/pptx-text-layout.test.ts tests/main/pptx-cjk-typeface.test.ts` — 19 passed
- `pnpm --filter @open-design/desktop test` — 237 passed
- `pnpm --filter @open-design/desktop typecheck` — passed
- `pnpm guard` — passed
- `git diff --check` — passed
