### PR TITLE
fix(desktop): capture framework decks at authored size

### DIFF
--- a/apps/desktop/src/main/deck-capture.ts
+++ b/apps/desktop/src/main/deck-capture.ts
@@ -105,6 +105,7 @@ export const HIDE_CHROME_SELECTOR =
 // mode clones (`.mini-slide .slide`, `.overview .slide`) are filtered out in the
 // page rather than via a rigid direct-child selector, which missed nested decks.
 const SLIDE_SELECTOR = ".slide, [data-screen-label], .deck-slide, .ppt-slide";
+export const DECK_STAGE_SELECTOR = "deck-stage, #deck-stage, .deck-stage";
 // JS expression (used inside executeJavaScript) returning the real slides.
 const REAL_SLIDES_JS =
   "Array.prototype.slice.call(document.querySelectorAll('.slide, [data-screen-label], .deck-slide, .ppt-slide')).filter(function(el){return !el.closest('.mini-slide, .overview, .notes-overlay, .thumb')})";
@@ -214,7 +215,7 @@ export async function renderDeckSlides(
     // Deck mode only: now apply the deck DOM prep (hide presenter chrome, freeze
     // animations) so each slide reaches its final state for capture.
     await window.webContents.executeJavaScript(
-      `(${prepareDeckStage.toString()})(${JSON.stringify(HIDE_CHROME_SELECTOR)})`,
+      `(${prepareDeckStage.toString()})(${JSON.stringify(HIDE_CHROME_SELECTOR)}, ${JSON.stringify(DECK_STAGE_SELECTOR)})`,
       true,
     );
 
@@ -229,7 +230,10 @@ export async function renderDeckSlides(
     await nextFrames(window);
 
     // Pin the stage to the measured slide size.
-    await window.webContents.executeJavaScript(`(${pinDeckStage.toString()})(${stage.w}, ${stage.h})`, true);
+    await window.webContents.executeJavaScript(
+      `(${pinDeckStage.toString()})(${stage.w}, ${stage.h}, ${JSON.stringify(DECK_STAGE_SELECTOR)})`,
+      true,
+    );
 
     // Editable PPTX: hand the live, laid-out slides to the vendored dom-to-pptx
     // engine (native shapes/text) instead of capturing images.
@@ -336,7 +340,7 @@ export function requestedRenderSize(
 async function measureSlideStage(window: BrowserWindow): Promise<Stage> {
   try {
     const measured = (await window.webContents.executeJavaScript(
-      `(${measureSlide.toString()})(${JSON.stringify(SLIDE_SELECTOR)})`,
+      `(${measureSlide.toString()})(${JSON.stringify(SLIDE_SELECTOR)}, ${JSON.stringify(DECK_STAGE_SELECTOR)})`,
       true,
     )) as { w: number; h: number } | null;
     if (
@@ -1211,7 +1215,7 @@ export async function runDomToPptx(slideSelector: string): Promise<{ b64?: strin
 // chrome, switch any <deck-stage> runtime to authored (1:1) size, and freeze
 // animations/transitions so each slide (and its reveal-on-show inner elements,
 // e.g. `.slide.visible .reveal`) reaches its final state.
-function prepareDeckStage(hideSelector: string): void {
+export function prepareDeckStage(hideSelector: string, stageSelector: string): void {
   document.querySelectorAll(hideSelector).forEach((el) => {
     (el as HTMLElement).style.setProperty("display", "none", "important");
   });
@@ -1221,8 +1225,11 @@ function prepareDeckStage(hideSelector: string): void {
   // it here (no-op for plain `.slide` decks that have no <deck-stage>), or a
   // deck whose authored canvas differs from the 1920x1080 capture viewport would
   // be measured + captured at the preview-scaled size instead of 1:1.
-  document.querySelectorAll("deck-stage").forEach((el) => {
+  document.querySelectorAll(stageSelector).forEach((el) => {
     el.setAttribute("noscale", "");
+    const style = (el as HTMLElement).style;
+    style.setProperty("transform", "none", "important");
+    style.setProperty("transform-origin", "top left", "important");
   });
   const s = document.createElement("style");
   s.textContent =
@@ -1233,11 +1240,11 @@ function prepareDeckStage(hideSelector: string): void {
 // Deck-only: pin to the measured WxH stage so each slide captures
 // deterministically. NOT applied in page mode — an ordinary page must keep its
 // natural width/height.
-function pinDeckStage(w: number, h: number): void {
+function pinDeckStage(w: number, h: number, stageSelector: string): void {
   const style = document.createElement("style");
   style.textContent =
     `html,body{margin:0!important;padding:0!important;width:${w}px!important;height:${h}px!important;overflow:hidden!important}` +
-    `.deck,deck-stage{width:${w}px!important;height:${h}px!important}`;
+    `.deck,${stageSelector}{width:${w}px!important;height:${h}px!important}`;
   document.head.appendChild(style);
 }
 
@@ -1245,7 +1252,7 @@ function pinDeckStage(w: number, h: number): void {
 // that already has a non-zero layout rect (covers decks that hide inactive
 // slides via opacity/visibility); if every slide is display:none, force-measures
 // the first one off-screen. Returns the authored DIP size or null.
-function measureSlide(slideSelector: string): { w: number; h: number } | null {
+function measureSlide(slideSelector: string, stageSelector: string): { w: number; h: number } | null {
   function positiveCssNumber(value: unknown): number | null {
     if (typeof value === "number") return Number.isFinite(value) && value > 1 ? value : null;
     if (typeof value !== "string") return null;
@@ -1266,10 +1273,17 @@ function measureSlide(slideSelector: string): { w: number; h: number } | null {
       (stage as unknown as { designHeight?: unknown }).designHeight,
     );
     if (byProp) return byProp;
-    return sizePair(stage.getAttribute("width"), stage.getAttribute("height"));
+    const byAttr = sizePair(stage.getAttribute("width"), stage.getAttribute("height"));
+    if (byAttr) return byAttr;
+    const byStyle = sizePair(stage.style?.width, stage.style?.height);
+    if (byStyle) return byStyle;
+    const computed = window.getComputedStyle?.(stage);
+    const byComputed = computed ? sizePair(computed.width, computed.height) : null;
+    if (byComputed) return byComputed;
+    return sizePair(stage.offsetWidth, stage.offsetHeight);
   }
   function measureAuthored(el: HTMLElement): { w: number; h: number } | null {
-    const stage = el.closest("deck-stage") as HTMLElement | null;
+    const stage = el.closest(stageSelector) as HTMLElement | null;
     const stageSize = stage ? deckStageAuthoredSize(stage) : null;
     if (stageSize) return stageSize;
     const attrSize = sizePair(el.getAttribute("width"), el.getAttribute("height"));
@@ -1314,7 +1328,7 @@ function measureSlide(slideSelector: string): { w: number; h: number } | null {
 // is intentionally left to the caller as a last resort because it includes
 // fit-to-viewport transforms.
 export function measureAuthoredSlideBox(el: HTMLElement): { w: number; h: number } | null {
-  const stage = el.closest("deck-stage") as HTMLElement | null;
+  const stage = el.closest(DECK_STAGE_SELECTOR) as HTMLElement | null;
   const stageSize = stage ? deckStageAuthoredSize(stage) : null;
   if (stageSize) return stageSize;
 
@@ -1341,7 +1355,15 @@ function deckStageAuthoredSize(stage: HTMLElement): { w: number; h: number } | n
     (stage as unknown as { designHeight?: unknown }).designHeight,
   );
   if (byProp) return byProp;
-  return sizePair(stage.getAttribute("width"), stage.getAttribute("height"));
+  const byAttr = sizePair(stage.getAttribute("width"), stage.getAttribute("height"));
+  if (byAttr) return byAttr;
+  const byStyle = sizePair(stage.style?.width, stage.style?.height);
+  if (byStyle) return byStyle;
+  const view = stage.ownerDocument?.defaultView;
+  const computed = view?.getComputedStyle?.(stage);
+  const byComputed = computed ? sizePair(computed.width, computed.height) : null;
+  if (byComputed) return byComputed;
+  return sizePair(stage.offsetWidth, stage.offsetHeight);
 }
 
 function sizePair(w: unknown, h: unknown): { w: number; h: number } | null {

--- a/apps/desktop/tests/main/scroll-stitch-geometry.test.ts
+++ b/apps/desktop/tests/main/scroll-stitch-geometry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -7,10 +7,12 @@ import { gzip } from 'node:zlib';
 
 import {
   HIDE_CHROME_SELECTOR,
+  DECK_STAGE_SELECTOR,
   activeSlideCaptureOffsetTransform,
   captureDeckSlide,
   measureAuthoredSlideBox,
   paginateViewportBand,
+  prepareDeckStage,
   readDomToPptxBundleFile,
   requestedRenderSize,
   restoreActiveSlideCapture,
@@ -519,9 +521,11 @@ describe('measureAuthoredSlideBox', () => {
     offsetWidth?: number;
     offsetHeight?: number;
     stage?: HTMLElement | null;
+    stageSelector?: string;
   }): HTMLElement {
     return {
-      closest: (selector: string) => (selector === 'deck-stage' ? opts.stage ?? null : null),
+      closest: (selector: string) =>
+        selector === (opts.stageSelector ?? DECK_STAGE_SELECTOR) ? opts.stage ?? null : null,
       getAttribute: (name: string) => opts.attrs?.[name] ?? null,
       style: opts.style ?? {},
       offsetWidth: opts.offsetWidth ?? 0,
@@ -550,6 +554,17 @@ describe('measureAuthoredSlideBox', () => {
     expect(measureAuthoredSlideBox(fakeElement({ stage }))).toEqual({ w: 1024, h: 768 });
   });
 
+  test('uses framework deck-stage wrapper dimensions before transformed slide layout', () => {
+    const stage = fakeElement({ style: { width: '1920px', height: '1080px' } });
+    const slide = fakeElement({
+      stage,
+      stageSelector: 'deck-stage, #deck-stage, .deck-stage',
+      offsetWidth: 960,
+      offsetHeight: 540,
+    });
+    expect(measureAuthoredSlideBox(slide)).toEqual({ w: 1920, h: 1080 });
+  });
+
   test('uses declared slide dimensions before transformed layout fallback', () => {
     const slide = fakeElement({
       style: { width: '1600px', height: '900px' },
@@ -557,6 +572,43 @@ describe('measureAuthoredSlideBox', () => {
       offsetHeight: 450,
     });
     expect(measureAuthoredSlideBox(slide)).toEqual({ w: 1600, h: 900 });
+  });
+});
+
+describe('prepareDeckStage', () => {
+  test('normalizes framework deck stages to authored capture geometry', () => {
+    const hidden = { style: { setProperty: vi.fn() } };
+    const stage = {
+      setAttribute: vi.fn(),
+      style: { setProperty: vi.fn() },
+    };
+    const appended: Array<{ textContent?: string }> = [];
+    const previousDocument = globalThis.document;
+    Object.assign(globalThis, {
+      document: {
+        querySelectorAll: (selector: string) => {
+          if (selector === HIDE_CHROME_SELECTOR) return [hidden];
+          if (selector === DECK_STAGE_SELECTOR) return [stage];
+          return [];
+        },
+        createElement: () => ({ textContent: '' }),
+        head: { appendChild: (node: { textContent?: string }) => appended.push(node) },
+        documentElement: {},
+      },
+    });
+    try {
+      prepareDeckStage(HIDE_CHROME_SELECTOR, DECK_STAGE_SELECTOR);
+      expect(stage.setAttribute).toHaveBeenCalledWith('noscale', '');
+      expect(stage.style.setProperty).toHaveBeenCalledWith('transform', 'none', 'important');
+      expect(stage.style.setProperty).toHaveBeenCalledWith(
+        'transform-origin',
+        'top left',
+        'important',
+      );
+      expect(appended).toHaveLength(1);
+    } finally {
+      Object.assign(globalThis, { document: previousDocument });
+    }
   });
 });
 


### PR DESCRIPTION
Fixes #5319

## Why

The issue's deterministic framework-deck repro showed that preview capture only normalized the custom `<deck-stage>` element. Decks authored with the existing `#deck-stage` / `.deck-stage` wrapper kept their runtime fit transform, so capture used the scaled viewer frame and could include dark shell or letterbox pixels instead of the authored slide canvas.

This aligns the framework wrapper with the custom-element capture path without changing ordinary page capture.

## What users will see

Preview images for framework-style decks use the authored slide dimensions and no longer retain the runtime scale-to-fit transform. The captured frame therefore matches the slide canvas used by Mark/Draw and other visual-context workflows.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No new UI. The issue includes the minimal 1920x1080 framework-deck repro and before-state screenshots showing the viewer-shell pixels around the scaled canvas.

## Bug fix verification

- Test path: `apps/desktop/tests/main/scroll-stitch-geometry.test.ts`
- Red on `main`: yes; the framework stage resolved to the transformed 960x540 slide layout instead of its authored 1920x1080 dimensions.
- Green on this branch: yes; the focused geometry suite passes all 29 tests and also verifies that capture prep removes the runtime stage transform.

## Validation

- `pnpm --filter @open-design/desktop exec vitest run -c vitest.config.ts tests/main/scroll-stitch-geometry.test.ts` — 29 passed
- `pnpm --filter @open-design/desktop test` — 235 passed
- `pnpm --filter @open-design/desktop typecheck` — passed
- `pnpm guard` — passed
- `git diff --check` — passed
