### PR TITLE
fix(daemon): stop imported folders exposing home dotfiles + block $HOME import

### DIFF
--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -1,7 +1,9 @@
 import type { Express, Response } from 'express';
 import { PROJECT_EXPORT_MANIFEST_SCHEMA, isExportFormat } from '@open-design/contracts';
 import nodePath from 'node:path';
+import os from 'node:os';
 import { readFile, rm } from 'node:fs/promises';
+import { isBlocked as isBlockedSystemDir } from './linked-dirs.js';
 import type { RouteDeps } from './server-context.js';
 import {
   InlineAssetsLimitError,
@@ -333,6 +335,23 @@ export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps
         normalizedPath.startsWith(RUNTIME_DATA_DIR_CANONICAL + path.sep)
       ) {
         return sendApiError(res, 400, 'BAD_REQUEST', 'cannot import the data directory');
+      }
+      // Refuse to import a system directory or a credential store. Importing the
+      // home root (or ~/.ssh, ~/.aws, ~/.gnupg) would bind the project's file
+      // API to the user's private keys/credentials — GET/DELETE raw/* could then
+      // read or delete them. `isBlockedSystemDir` covers /etc, /proc, etc.; the
+      // credential set is checked with a prefix match, and the home ROOT only
+      // by exact match so legitimate subfolders (e.g. ~/Projects) stay allowed.
+      let homeReal = os.homedir();
+      try { homeReal = await fs.promises.realpath(homeReal); } catch { /* keep as-is */ }
+      const credentialDirs = ['.ssh', '.aws', '.gnupg', '.kube', '.docker'].map((d) =>
+        path.join(homeReal, d),
+      );
+      const inCredentialDir = credentialDirs.some(
+        (dir) => normalizedPath === dir || normalizedPath.startsWith(dir + path.sep),
+      );
+      if (isBlockedSystemDir(normalizedPath) || normalizedPath === homeReal || inCredentialDir) {
+        return sendApiError(res, 400, 'BAD_REQUEST', 'cannot import a system or credential directory');
       }
       const sandboxReason = normalizedOrchestratorWorkspace && trustedPickerImport
         ? null

--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -33,6 +33,28 @@ export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps
   const { fs, path } = ctx.node;
   const { randomId } = ctx.ids;
   const { PROJECTS_DIR, RUNTIME_DATA_DIR_CANONICAL } = ctx.paths;
+
+  // A project root (imported folder OR a working-dir rebind) must not point at a
+  // system directory or a credential store. Binding it at $HOME / ~/.ssh / etc.
+  // would let the project file API read or delete the user's private keys and
+  // credentials. `isBlockedSystemDir` covers /etc, /proc, …; credential dirs use
+  // a prefix match; the home ROOT only exact-matches so legitimate subfolders
+  // (e.g. ~/Projects) stay usable. Shared by both entry points so neither can
+  // be used to bypass the other. Returns a rejection reason, or null if allowed.
+  async function blockedProjectRootReason(normalizedPath: string): Promise<string | null> {
+    let homeReal = os.homedir();
+    try { homeReal = await fs.promises.realpath(homeReal); } catch { /* keep as-is */ }
+    const credentialDirs = ['.ssh', '.aws', '.gnupg', '.kube', '.docker'].map((d) =>
+      path.join(homeReal, d),
+    );
+    const inCredentialDir = credentialDirs.some(
+      (dir) => normalizedPath === dir || normalizedPath.startsWith(dir + path.sep),
+    );
+    if (isBlockedSystemDir(normalizedPath) || normalizedPath === homeReal || inCredentialDir) {
+      return 'cannot use a system or credential directory as a project root';
+    }
+    return null;
+  }
   const { importClaudeDesignZip, projectDir, detectEntryFile } = ctx.imports;
   const {
     consumedImportNonces,
@@ -202,6 +224,10 @@ export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps
       ) {
         return sendApiError(res, 400, 'BAD_REQUEST', 'cannot point at the data directory');
       }
+      const workingDirBlockReason = await blockedProjectRootReason(normalizedPath);
+      if (workingDirBlockReason) {
+        return sendApiError(res, 400, 'BAD_REQUEST', workingDirBlockReason);
+      }
       const sandboxReason = normalizedOrchestratorWorkspace && trustedPickerImport
         ? null
         : sandboxImportedProjectRootUnavailableReason(normalizedPath);
@@ -336,22 +362,9 @@ export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps
       ) {
         return sendApiError(res, 400, 'BAD_REQUEST', 'cannot import the data directory');
       }
-      // Refuse to import a system directory or a credential store. Importing the
-      // home root (or ~/.ssh, ~/.aws, ~/.gnupg) would bind the project's file
-      // API to the user's private keys/credentials — GET/DELETE raw/* could then
-      // read or delete them. `isBlockedSystemDir` covers /etc, /proc, etc.; the
-      // credential set is checked with a prefix match, and the home ROOT only
-      // by exact match so legitimate subfolders (e.g. ~/Projects) stay allowed.
-      let homeReal = os.homedir();
-      try { homeReal = await fs.promises.realpath(homeReal); } catch { /* keep as-is */ }
-      const credentialDirs = ['.ssh', '.aws', '.gnupg', '.kube', '.docker'].map((d) =>
-        path.join(homeReal, d),
-      );
-      const inCredentialDir = credentialDirs.some(
-        (dir) => normalizedPath === dir || normalizedPath.startsWith(dir + path.sep),
-      );
-      if (isBlockedSystemDir(normalizedPath) || normalizedPath === homeReal || inCredentialDir) {
-        return sendApiError(res, 400, 'BAD_REQUEST', 'cannot import a system or credential directory');
+      const importBlockReason = await blockedProjectRootReason(normalizedPath);
+      if (importBlockReason) {
+        return sendApiError(res, 400, 'BAD_REQUEST', importBlockReason);
       }
       const sandboxReason = normalizedOrchestratorWorkspace && trustedPickerImport
         ? null

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -77,6 +77,22 @@ function hasExternalProjectRoot(metadata?) {
   return path.isAbsolute(path.normalize(metadata.baseDir));
 }
 
+// For folder-imported projects (external baseDir) the file API resolves under
+// the user's OWN directory, so a hidden path segment (.ssh, .aws, .gnupg, …)
+// would let read/write/delete/rename/folder ops reach credential dotfiles that
+// live outside the app's managed data. Reject hidden segments for every such
+// operation — the single choke point every project file/folder mutation and
+// read funnels through — mirroring the rule buildBatchArchive already enforces
+// for exports. Managed projects (under PROJECTS_DIR, no external baseDir) are
+// unaffected. Callers pass the raw request name; we normalize before checking.
+export function assertVisibleForImportedProject(name, metadata?) {
+  if (!hasExternalProjectRoot(metadata)) return;
+  const segments = String(name ?? '').replace(/\\/g, '/').split('/').filter(Boolean);
+  if (segments.some((segment) => segment.startsWith('.'))) {
+    throw new Error('hidden path segments are not accessible in imported folders');
+  }
+}
+
 export function assertSandboxProjectRootAvailable(metadata?) {
   if (
     isSandboxModeEnabled(process.env) &&
@@ -171,6 +187,7 @@ async function collectFolders(dir, relDir, out, shouldSkipDir?: (name: string) =
 }
 
 export async function createProjectFolder(projectsRoot, projectId, name, metadata?) {
+  assertVisibleForImportedProject(name, metadata);
   const dir = await ensureProject(projectsRoot, projectId, metadata);
   const safeName = sanitizePath(name);
   const target = await resolveSafeReal(dir, safeName);
@@ -209,6 +226,7 @@ export async function ensureProjectSubdir(projectsRoot, projectId, subdir, metad
 // sandbox. Refuses to delete the project root itself. resolveSafeReal confines
 // the target to the project tree even across descendant symlinks.
 export async function deleteProjectFolder(projectsRoot, projectId, name, metadata?) {
+  assertVisibleForImportedProject(name, metadata);
   const dir = resolveProjectDir(projectsRoot, projectId, metadata);
   const safeName = sanitizePath(name);
   const target = await resolveSafeReal(dir, safeName);
@@ -721,6 +739,7 @@ ${list(assetFiles)}
 }
 
 export async function readProjectFile(projectsRoot, projectId, name, metadata?) {
+  assertVisibleForImportedProject(name, metadata);
   const dir = resolveProjectDir(projectsRoot, projectId, metadata);
   const file = await resolveSafeReal(dir, name);
   const buf = await readFile(file);
@@ -744,6 +763,7 @@ export async function readProjectFile(projectsRoot, projectId, name, metadata?) 
 // Like readProjectFile but skips loading the file content into memory.
 // Used by the media streaming endpoint so large video files are never buffered.
 export async function resolveProjectFilePath(projectsRoot, projectId, name, metadata?) {
+  assertVisibleForImportedProject(name, metadata);
   const dir = resolveProjectDir(projectsRoot, projectId, metadata);
   const file = await resolveSafeReal(dir, name);
   const st = await stat(file);
@@ -767,6 +787,7 @@ export async function writeProjectFile(
   { overwrite = true, artifactManifest = null } = {},
   metadata?,
 ) {
+  assertVisibleForImportedProject(name, metadata);
   const dir = await ensureProject(projectsRoot, projectId, metadata);
   const safeName = sanitizePath(name);
   const target = await resolveSafeReal(dir, safeName);
@@ -944,12 +965,15 @@ function parseManifest(raw) {
 }
 
 export async function deleteProjectFile(projectsRoot, projectId, name, metadata?) {
+  assertVisibleForImportedProject(name, metadata);
   const dir = resolveProjectDir(projectsRoot, projectId, metadata);
   const file = await resolveSafeReal(dir, name);
   await unlink(file);
 }
 
 export async function renameProjectFile(projectsRoot, projectId, fromName, toName, metadata?) {
+  assertVisibleForImportedProject(fromName, metadata);
+  assertVisibleForImportedProject(toName, metadata);
   const dir = resolveProjectDir(projectsRoot, projectId, metadata);
   const oldName = validateProjectPath(fromName);
   const newName = sanitizePath(toName);

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -2594,33 +2594,6 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
     return true;
   }
 
-  // A folder-imported project resolves files against an external, user-chosen
-  // `metadata.baseDir` instead of PROJECTS_DIR. `validateProjectPath` only
-  // blocks `..`/absolute escapes, so a tree imported at (say) $HOME would let
-  // the raw read / raw delete / folders-delete sinks reach hidden credential
-  // files like `.ssh/id_rsa` or `.aws/credentials`. Mirror the visible-file
-  // rule buildBatchArchive already enforces for archives: reject any hidden
-  // path segment for imported projects, so an imported folder can never serve
-  // or delete dotfiles over the API. Managed projects (no external baseDir)
-  // are unaffected.
-  function rejectHiddenSegmentInImportedProject(
-    res: Response,
-    relPath: unknown,
-    metadata: unknown,
-  ): boolean {
-    const baseDir =
-      metadata && typeof metadata === 'object' && typeof (metadata as { baseDir?: unknown }).baseDir === 'string'
-        ? (metadata as { baseDir: string }).baseDir
-        : '';
-    if (!baseDir) return false;
-    const segments = String(relPath ?? '').replace(/\\/g, '/').split('/').filter(Boolean);
-    if (segments.some((segment) => segment.startsWith('.'))) {
-      sendApiError(res, 400, 'BAD_REQUEST', 'hidden path segments are not accessible in imported folders');
-      return true;
-    }
-    return false;
-  }
-
   function normalizeProjectFileVersionSource(value: unknown): ProjectFileVersionSource | undefined {
     return value === 'ai' || value === 'manual' || value === 'restore' ? value : undefined;
   }
@@ -3124,7 +3097,6 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
       if (!project) {
         return sendApiError(res, 404, 'PROJECT_NOT_FOUND', 'project not found');
       }
-      if (rejectHiddenSegmentInImportedProject(res, folderPath, project.metadata)) return;
       await deleteProjectFolder(
         PROJECTS_DIR,
         req.params.id,
@@ -3312,7 +3284,6 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
       const relPath = String(params[1] ?? '');
       if (rejectInternalVersionPath(res, relPath)) return;
       const project = getProject(db, projectId);
-      if (rejectHiddenSegmentInImportedProject(res, relPath, project?.metadata)) return;
       // PreviewModal loads artifact HTML via srcdoc, giving the iframe Origin: "null".
       // data: URIs, file://, and some sandboxed iframes also send null — all are
       // local-only callers, so this is safe. Real cross-origin sites send a real
@@ -3425,7 +3396,6 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
       const rawSplat = String(params[1] ?? '');
       if (rejectInternalVersionPath(res, rawSplat)) return;
       const project = getProject(db, projectId);
-      if (rejectHiddenSegmentInImportedProject(res, rawSplat, project?.metadata)) return;
       await deleteProjectFile(PROJECTS_DIR, projectId, rawSplat, project?.metadata);
       await markProjectFileVersionStoreDeleted(PROJECTS_DIR, projectId, rawSplat, project?.metadata);
       /** @type {import('@open-design/contracts').DeleteProjectFileResponse} */

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -2594,6 +2594,33 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
     return true;
   }
 
+  // A folder-imported project resolves files against an external, user-chosen
+  // `metadata.baseDir` instead of PROJECTS_DIR. `validateProjectPath` only
+  // blocks `..`/absolute escapes, so a tree imported at (say) $HOME would let
+  // the raw read / raw delete / folders-delete sinks reach hidden credential
+  // files like `.ssh/id_rsa` or `.aws/credentials`. Mirror the visible-file
+  // rule buildBatchArchive already enforces for archives: reject any hidden
+  // path segment for imported projects, so an imported folder can never serve
+  // or delete dotfiles over the API. Managed projects (no external baseDir)
+  // are unaffected.
+  function rejectHiddenSegmentInImportedProject(
+    res: Response,
+    relPath: unknown,
+    metadata: unknown,
+  ): boolean {
+    const baseDir =
+      metadata && typeof metadata === 'object' && typeof (metadata as { baseDir?: unknown }).baseDir === 'string'
+        ? (metadata as { baseDir: string }).baseDir
+        : '';
+    if (!baseDir) return false;
+    const segments = String(relPath ?? '').replace(/\\/g, '/').split('/').filter(Boolean);
+    if (segments.some((segment) => segment.startsWith('.'))) {
+      sendApiError(res, 400, 'BAD_REQUEST', 'hidden path segments are not accessible in imported folders');
+      return true;
+    }
+    return false;
+  }
+
   function normalizeProjectFileVersionSource(value: unknown): ProjectFileVersionSource | undefined {
     return value === 'ai' || value === 'manual' || value === 'restore' ? value : undefined;
   }
@@ -3097,6 +3124,7 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
       if (!project) {
         return sendApiError(res, 404, 'PROJECT_NOT_FOUND', 'project not found');
       }
+      if (rejectHiddenSegmentInImportedProject(res, folderPath, project.metadata)) return;
       await deleteProjectFolder(
         PROJECTS_DIR,
         req.params.id,
@@ -3284,6 +3312,7 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
       const relPath = String(params[1] ?? '');
       if (rejectInternalVersionPath(res, relPath)) return;
       const project = getProject(db, projectId);
+      if (rejectHiddenSegmentInImportedProject(res, relPath, project?.metadata)) return;
       // PreviewModal loads artifact HTML via srcdoc, giving the iframe Origin: "null".
       // data: URIs, file://, and some sandboxed iframes also send null — all are
       // local-only callers, so this is safe. Real cross-origin sites send a real
@@ -3396,6 +3425,7 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
       const rawSplat = String(params[1] ?? '');
       if (rejectInternalVersionPath(res, rawSplat)) return;
       const project = getProject(db, projectId);
+      if (rejectHiddenSegmentInImportedProject(res, rawSplat, project?.metadata)) return;
       await deleteProjectFile(PROJECTS_DIR, projectId, rawSplat, project?.metadata);
       await markProjectFileVersionStoreDeleted(PROJECTS_DIR, projectId, rawSplat, project?.metadata);
       /** @type {import('@open-design/contracts').DeleteProjectFileResponse} */

--- a/apps/daemon/tests/security-import-folder-dotfiles.test.ts
+++ b/apps/daemon/tests/security-import-folder-dotfiles.test.ts
@@ -1,0 +1,242 @@
+// Security regression: arbitrary-folder import turns the project file routes
+// into a read/delete primitive over the user's whole home directory, dotfiles
+// included.
+//
+// Chain (taint -> sink):
+//   POST /api/import/folder { baseDir }          (src/import-export-routes.ts:241)
+//     - validates only: absolute path, realpath, isDirectory, not fs-root,
+//       not RUNTIME_DATA_DIR, sandbox-mode allowlist (no-op unless
+//       OD_SANDBOX_MODE is on). NO sensitive-dir blocklist ($HOME, ~/.ssh,
+//       ~/.aws, ...) — the existing BLOCKED_CANONICAL list in
+//       src/linked-dirs.ts is never consulted on this route — and no dotfile
+//       rule. baseDir is persisted into project metadata.
+//   GET    /api/projects/:id/raw/*               (src/routes/project/index.ts:3280)
+//   DELETE /api/projects/:id/raw/*               (src/routes/project/index.ts:3392)
+//   DELETE /api/projects/:id/folders { path }    (src/routes/project/index.ts:3090)
+//     - per-file paths go through validateProjectPath (src/projects.ts:1377),
+//       which rejects '' / '.' / '..' and reserved segments (.file-versions,
+//       .live-artifacts) but happily admits dot segments: '.ssh/id_rsa'
+//       passes verbatim. resolveSafeReal then anchors at baseDir = $HOME, so
+//       readFile/unlink land on ~/.ssh/id_rsa, ~/.aws/credentials, ... and the
+//       bytes are returned over HTTP / the file is unlinked.
+//
+// Asymmetry (the sibling that does it right): buildBatchArchive
+// (src/projects.ts:373-384) explicitly rejects any hidden path segment
+// ("hidden segments are not eligible for archive"), and the collectors
+// (collectFiles/collectFolders/collectArchiveEntries) skip dot entries. The
+// per-file raw/files routes are the siblings missing that guard.
+//
+// Exposure: the /api origin middleware (src/server.ts:2222) lets any request
+// WITHOUT an Origin header through — i.e. any local process (prompt-injected
+// agent, malware, another app) can drive this unauthenticated on loopback.
+// Real cross-origin browser requests (Origin: https://evil.example) and
+// Origin: null on mutating routes are still blocked by that middleware; those
+// facts are probed and asserted in the exposure test below.
+//
+// These specs assert the SECURE end-state invariants (import of a home-like
+// tree must not make dotfiles readable/deletable over HTTP, and must not make
+// arbitrary user dirs recursively removable). RED on current origin/main;
+// green under either fix direction (blocklist at import, or a hidden-segment
+// guard in the per-file chain).
+
+import type http from 'node:http';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+let daemon: http.Server | undefined;
+let daemonShutdown: (() => Promise<void> | void) | undefined;
+let baseUrl = '';
+let dataDir = '';
+let fakeHome = '';
+
+const SSH_KEY = path.join('.ssh', 'id_rsa');
+const AWS_CREDS = path.join('.aws', 'credentials');
+const SENTINEL_KEY = 'SENTINEL-PRIVATE-KEY-do-not-leak-7f3a';
+const SENTINEL_CREDS = 'SENTINEL-AWS-CREDS-do-not-leak-9b21';
+
+const PREV_DATA_DIR = process.env.OD_DATA_DIR;
+
+beforeEach(async () => {
+  // Sentinel "home directory". Everything the daemon touches lives under this
+  // mkdtemp — no real user file is ever read or deleted by this spec.
+  fakeHome = await mkdtemp(path.join(os.tmpdir(), 'od-fakehome-'));
+  await mkdir(path.join(fakeHome, '.ssh'), { recursive: true });
+  await mkdir(path.join(fakeHome, '.aws'), { recursive: true });
+  await mkdir(path.join(fakeHome, 'docs'), { recursive: true });
+  await writeFile(path.join(fakeHome, SSH_KEY), SENTINEL_KEY);
+  await writeFile(path.join(fakeHome, AWS_CREDS), SENTINEL_CREDS);
+  await writeFile(path.join(fakeHome, 'docs', 'keep.txt'), 'precious');
+
+  dataDir = await mkdtemp(path.join(os.tmpdir(), 'od-importsec-'));
+  process.env.OD_DATA_DIR = dataDir;
+
+  // Dynamic import AFTER OD_DATA_DIR is set: RUNTIME_DATA_DIR is resolved at
+  // module-eval time, so a static import would pin the real data dir.
+  const { startServer } = await import('../src/server.js');
+  const started = (await startServer({ port: 0, host: '127.0.0.1', returnServer: true })) as {
+    url: string;
+    server: http.Server;
+    shutdown?: () => Promise<void> | void;
+  };
+  baseUrl = started.url;
+  daemon = started.server;
+  daemonShutdown = started.shutdown;
+});
+
+afterEach(async () => {
+  if (daemonShutdown) {
+    await Promise.race([
+      Promise.resolve(daemonShutdown()),
+      new Promise((r) => setTimeout(r, 2000)),
+    ]);
+  }
+  daemon?.closeAllConnections?.();
+  if (daemon) await new Promise<void>((r) => daemon!.close(() => r()));
+  daemon = undefined;
+  daemonShutdown = undefined;
+  await rm(dataDir, { recursive: true, force: true }).catch(() => {});
+  await rm(fakeHome, { recursive: true, force: true }).catch(() => {});
+  if (PREV_DATA_DIR === undefined) delete process.env.OD_DATA_DIR;
+  else process.env.OD_DATA_DIR = PREV_DATA_DIR;
+}, 15000);
+
+// Import the sentinel home dir through the real HTTP boundary, exactly as an
+// unauthenticated local caller would (no Origin header → middleware allows).
+async function importFakeHome(): Promise<{ status: number; projectId: string | null }> {
+  const resp = await fetch(`${baseUrl}/api/import/folder`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ baseDir: fakeHome, name: 'sentinel-home' }),
+  });
+  const json = (await resp.json().catch(() => ({}))) as { project?: { id?: string } };
+  return { status: resp.status, projectId: json.project?.id ?? null };
+}
+
+describe('import/folder -> home-tree file primitives', () => {
+  it('exposure: no-Origin requests reach the route; real cross-origin and null origins are blocked', async () => {
+    // A real cross-origin browser request must stay blocked by the /api
+    // origin middleware (this is the guard working as intended).
+    const evil = await fetch(`${baseUrl}/api/import/folder`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Origin: 'https://evil.example' },
+      body: JSON.stringify({ baseDir: fakeHome }),
+    });
+    expect(evil.status).toBe(403);
+
+    // Origin: null is only allowed for a small read-only GET allowlist; the
+    // mutating import route must reject it.
+    const nullOrigin = await fetch(`${baseUrl}/api/import/folder`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Origin: 'null' },
+      body: JSON.stringify({ baseDir: fakeHome }),
+    });
+    expect(nullOrigin.status).toBe(403);
+
+    // The exposure hole: a NON-browser client sends no Origin header at all
+    // and is allowed through unauthenticated (server.ts:2222). Any local
+    // process can therefore drive the chains below.
+    const noOrigin = await importFakeHome();
+    // eslint-disable-next-line no-console
+    console.log(
+      `[EXPOSURE] import/folder: no-Origin status=${noOrigin.status} ` +
+        `(evil-Origin=${evil.status}, null-Origin=${nullOrigin.status})`,
+    );
+  });
+
+  it('must NOT serve dotfiles (e.g. .ssh/id_rsa) from an imported home-like tree over HTTP', async () => {
+    const { status: importStatus, projectId } = await importFakeHome();
+    let readStatus = 0;
+    let readBody = '';
+    if (projectId) {
+      const resp = await fetch(
+        `${baseUrl}/api/projects/${projectId}/raw/${SSH_KEY.split(path.sep).join('/')}`,
+      );
+      readStatus = resp.status;
+      readBody = await resp.text().catch(() => '');
+    }
+    // eslint-disable-next-line no-console
+    console.log(
+      `[READ EVIDENCE] import=${importStatus} projectId=${projectId ?? '(rejected)'} ` +
+        `GET raw/.ssh/id_rsa status=${readStatus} leakedSentinel=${readBody.includes(SENTINEL_KEY)}`,
+    );
+
+    // SECURE invariant: the private key bytes must never leave the daemon.
+    // Holds under either fix (import refused, or dotfile read refused).
+    expect(readStatus).not.toBe(200);
+    expect(readBody).not.toContain(SENTINEL_KEY);
+  }, 30000);
+
+  it('must NOT delete dotfiles (e.g. .aws/credentials) from an imported home-like tree', async () => {
+    const { status: importStatus, projectId } = await importFakeHome();
+    let delStatus = 0;
+    if (projectId) {
+      const resp = await fetch(
+        `${baseUrl}/api/projects/${projectId}/raw/${AWS_CREDS.split(path.sep).join('/')}`,
+        { method: 'DELETE' },
+      );
+      delStatus = resp.status;
+    }
+    const stillOnDisk = existsSync(path.join(fakeHome, AWS_CREDS));
+    // eslint-disable-next-line no-console
+    console.log(
+      `[DELETE EVIDENCE] import=${importStatus} projectId=${projectId ?? '(rejected)'} ` +
+        `DELETE raw/.aws/credentials status=${delStatus} fileStillOnDisk=${stillOnDisk}`,
+    );
+
+    // SECURE invariant: the credentials file must survive on disk.
+    expect(stillOnDisk).toBe(true);
+  }, 30000);
+
+  // The rm-rf-of-a-user-directory reach exists because the home root can be
+  // imported at all (deleting a subfolder of a legitimately-imported project is
+  // a valid feature — the abuse is binding the project to $HOME). Close it at
+  // the source: importing the home root or a credential store must be rejected
+  // before a project is ever created. (Importing a temp folder and deleting its
+  // `docs` subfolder is NOT asserted here — that is legitimate.)
+  it('must reject importing the home root or a credential directory (no project bound to it)', async () => {
+    const importDir = async (baseDir: string) => {
+      const resp = await fetch(`${baseUrl}/api/import/folder`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ baseDir, name: 'blocked-import' }),
+      });
+      const json = (await resp.json().catch(() => ({}))) as { project?: { id?: string } };
+      return { status: resp.status, projectId: json.project?.id ?? null };
+    };
+
+    const home = os.homedir();
+    const homeResult = await importDir(home);
+    // eslint-disable-next-line no-console
+    console.log(`[BLOCKLIST EVIDENCE] import $HOME status=${homeResult.status} projectId=${homeResult.projectId ?? '(rejected)'}`);
+    expect(homeResult.status).toBeGreaterThanOrEqual(400);
+    expect(homeResult.projectId).toBeNull();
+
+    const ssh = path.join(home, '.ssh');
+    if (existsSync(ssh)) {
+      const sshResult = await importDir(ssh);
+      // eslint-disable-next-line no-console
+      console.log(`[BLOCKLIST EVIDENCE] import ~/.ssh status=${sshResult.status} projectId=${sshResult.projectId ?? '(rejected)'}`);
+      expect(sshResult.status).toBeGreaterThanOrEqual(400);
+      expect(sshResult.projectId).toBeNull();
+    }
+  }, 30000);
+
+  // A/B causal: the per-file read/delete chain runs every path through
+  // validateProjectPath — and that helper has no hidden-segment rule, unlike
+  // its sibling buildBatchArchive (src/projects.ts:373-384) which explicitly
+  // rejects dot segments for the same project tree. One omitted check, not a
+  // design gap.
+  it('A/B: validateProjectPath (raw read/delete chain) admits dot segments its sibling rejects', async () => {
+    const { validateProjectPath } = await import('../src/projects.js');
+    // The hole: '.ssh/id_rsa' sails through the guard used by GET/DELETE raw.
+    expect(validateProjectPath('.ssh/id_rsa')).toBe('.ssh/id_rsa');
+    expect(validateProjectPath('.aws/credentials')).toBe('.aws/credentials');
+    // While traversal and reserved segments ARE rejected — the guard exists,
+    // it just never learned the hidden-segment rule its sibling has.
+    expect(() => validateProjectPath('../escape')).toThrow();
+    expect(() => validateProjectPath('.file-versions/x')).toThrow();
+  });
+});

--- a/apps/daemon/tests/security-import-folder-dotfiles.test.ts
+++ b/apps/daemon/tests/security-import-folder-dotfiles.test.ts
@@ -239,4 +239,49 @@ describe('import/folder -> home-tree file primitives', () => {
     expect(() => validateProjectPath('../escape')).toThrow();
     expect(() => validateProjectPath('.file-versions/x')).toThrow();
   });
+
+  // Coverage guard (raised by review on #5857): the dotfile denial must live at
+  // the file-op choke point, not just the 3 raw/folders route handlers — every
+  // sibling read route (files/*, text-preview/*, powered/*) resolves through the
+  // same readProjectFile/resolveProjectFilePath and must equally refuse
+  // dotfiles from an imported tree.
+  it('must NOT serve dotfiles through the sibling GET files/* route either', async () => {
+    const { projectId } = await importFakeHome();
+    let status = 0;
+    let body = '';
+    if (projectId) {
+      const resp = await fetch(
+        `${baseUrl}/api/projects/${projectId}/files/${SSH_KEY.split(path.sep).join('/')}`,
+      );
+      status = resp.status;
+      body = await resp.text().catch(() => '');
+    }
+    // eslint-disable-next-line no-console
+    console.log(`[SIBLING READ EVIDENCE] GET files/.ssh/id_rsa status=${status} leaked=${body.includes(SENTINEL_KEY)}`);
+    expect(status).not.toBe(200);
+    expect(body).not.toContain(SENTINEL_KEY);
+  }, 30000);
+
+  // Coverage guard (raised by review on #5857): the sensitive-dir blocklist must
+  // also cover the sibling rebind route POST /api/projects/:id/working-dir,
+  // otherwise a caller creates an ordinary project then rebinds its baseDir to
+  // $HOME to bypass the import-route blocklist.
+  it('must reject rebinding a project working-dir to the home root', async () => {
+    const pid = `rebind_target_${Math.random().toString(36).slice(2)}`;
+    const createResp = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: pid, name: 'rebind-target', metadata: { kind: 'prototype' }, skipDiscoveryBrief: true }),
+    });
+    expect(createResp.status).toBe(200);
+
+    const resp = await fetch(`${baseUrl}/api/projects/${pid}/working-dir`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ baseDir: os.homedir() }),
+    });
+    // eslint-disable-next-line no-console
+    console.log(`[WORKING-DIR EVIDENCE] rebind $HOME status=${resp.status}`);
+    expect(resp.status).toBeGreaterThanOrEqual(400);
+  }, 30000);
 });


### PR DESCRIPTION
Fixes #5856

## Why

Auditing the daemon's on-disk routes, I found that arbitrary-folder import turns the project file API into a read/delete primitive over the user's home directory, dotfiles included. `POST /api/import/folder` persists a user-chosen `baseDir` with no sensitive-dir blocklist, and the raw read/delete/folders sinks validate paths with `validateProjectPath`, which blocks `..`/absolute escapes but not hidden segments. A folder imported at `$HOME` then lets a caller `GET raw/.ssh/id_rsa` (private key over HTTP) or `DELETE raw/.aws/credentials`.

The sibling `buildBatchArchive` already rejects hidden segments for the same tree ("hidden segments are not eligible for archive"); the raw sinks never learned that rule.

**Exposure (measured).** Cross-origin/null-Origin requests to the import route get `403`; only a no-`Origin` request reaches it (`200`). Not a web-CSRF vector — reachable by non-browser callers (a sandboxed local process; a LAN client when bound off loopback via `OD_BIND_HOST`). Default binding is loopback, so severity is moderate-to-high (credential disclosure).

## What users will see

No change for normal projects or legitimate imports (e.g. `~/Projects/mydesign`). Importing the home root or a credential store (`~/.ssh`, `~/.aws`, …) now returns `400`, and hidden files inside an imported folder are no longer served or deleted through the API.

## Surface area

- [x] **API / contract** — `POST /api/import/folder` rejects sensitive dirs (400); `GET/DELETE /api/projects/:id/raw/*` and `DELETE .../folders` reject hidden segments for imported projects. No new endpoint/DTO.

## Bug fix verification

- Test path: `apps/daemon/tests/security-import-folder-dotfiles.test.ts`.
- Red on `origin/main` (`6b90486c9`), green on this branch? **yes.** A live daemon over HTTP: on `main` `GET raw/.ssh/id_rsa` returns the key (`leakedSentinel=true`) and `DELETE raw/.aws/credentials` unlinks it; with the fix both are rejected and the sentinels (all under `mkdtemp`) survive. The re-scoped third case asserts importing `$HOME`/`~/.ssh` is rejected (each fix proven independently necessary: removing the route guard reddens the dotfile cases, removing the blocklist reddens the import case). The A/B case pins the `validateProjectPath` hidden-segment omission vs its `buildBatchArchive` sibling.
- No regression: `folder-import-route` (33), `folder-import-projects` (17), `project-raw-cache` (8), `project-file-rename` (11) stay green (Node 24).

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/security-import-folder-dotfiles.test.ts` → 5 passed (Node 24).
- `pnpm --filter @open-design/daemon typecheck` → passed.
