### PR TITLE
Add Source Project Context plugin

### DIFF
--- a/plugins/community/source-project-context-mrqio2m9/SKILL.md
+++ b/plugins/community/source-project-context-mrqio2m9/SKILL.md
@@ -1,0 +1,44 @@
+# Source Project Context
+
+This design-system workspace was created from an existing Open Design project. Treat the copied project files as the primary source evidence for the generated design system.
+
+## Source project
+
+- Source project id: 1a6c12ad-08c7-4177-83eb-279b71ded34c
+- Source project name: Project Design Review
+- New design-system project id: 6e11e93b-7baa-470c-bae1-5742d62ad504
+- New design-system id: user:project-design-review-design-system
+- Source skill id: (none)
+- Source design system id: (none)
+
+## Source metadata
+
+```json
+{
+  "kind": "other",
+  "nameSource": "agent",
+  "linkedDirs": [
+    "/Users/shrey/Code/CardPin"
+  ]
+}
+```
+
+## Copied files
+
+- project-design-review.md
+
+## Skipped files
+
+- (none)
+
+## Generation contract
+
+- Read this file before editing design-system outputs.
+- Read the copied files directly from the project workspace; they are source evidence, not generated design-system output.
+- Preserve high-signal assets, source examples, UI surfaces, copy, tokens, typography, and interaction patterns from the copied project.
+- Generate a reusable Open Design design-system package in this same project: DESIGN.md, README.md, SKILL.md, colors_and_type.css, context/provenance, focused preview cards, preserved assets/build/fonts when available, and ui_kits/app/.
+- Before final response, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every actionable issue.
+
+## Provenance
+
+Formalized by Open Design from candidate 579910ba-59f8-4c7e-9c43-ef6524885dbd.

--- a/plugins/community/source-project-context-mrqio2m9/open-design.json
+++ b/plugins/community/source-project-context-mrqio2m9/open-design.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "source-project-context-mrqio2m9",
+  "title": "Source Project Context",
+  "version": "0.1.0",
+  "description": "This design-system workspace was created from an existing Open Design project. Treat the copied project files as the primary source evidence for the generated design system.",
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ]
+  }
+}

--- a/plugins/community/source-project-context-mrqio2m9/references/provenance.json
+++ b/plugins/community/source-project-context-mrqio2m9/references/provenance.json
@@ -1,0 +1,19 @@
+{
+  "candidateId": "579910ba-59f8-4c7e-9c43-ef6524885dbd",
+  "projectId": "6e11e93b-7baa-470c-bae1-5742d62ad504",
+  "runId": "88c6cf31-62b5-443d-9f44-0aebc5b410a3",
+  "conversationId": "ebb49f13-7931-4d09-af8e-5edb9de2e169",
+  "provenance": {
+    "summary": "Detected from context/source-context.md after a successful run.",
+    "detectedAt": 1784388176699
+  },
+  "sourceRefs": [
+    {
+      "kind": "file",
+      "value": "context/source-context.md",
+      "label": "context/source-context.md",
+      "size": 1463,
+      "copied": true
+    }
+  ]
+}

--- a/plugins/community/source-project-context-mrqio2m9/references/source-1-source-context.md
+++ b/plugins/community/source-project-context-mrqio2m9/references/source-1-source-context.md
@@ -1,0 +1,40 @@
+# Source Project Context
+
+This design-system workspace was created from an existing Open Design project. Treat the copied project files as the primary source evidence for the generated design system.
+
+## Source project
+
+- Source project id: 1a6c12ad-08c7-4177-83eb-279b71ded34c
+- Source project name: Project Design Review
+- New design-system project id: 6e11e93b-7baa-470c-bae1-5742d62ad504
+- New design-system id: user:project-design-review-design-system
+- Source skill id: (none)
+- Source design system id: (none)
+
+## Source metadata
+
+```json
+{
+  "kind": "other",
+  "nameSource": "agent",
+  "linkedDirs": [
+    "/Users/shrey/Code/CardPin"
+  ]
+}
+```
+
+## Copied files
+
+- project-design-review.md
+
+## Skipped files
+
+- (none)
+
+## Generation contract
+
+- Read this file before editing design-system outputs.
+- Read the copied files directly from the project workspace; they are source evidence, not generated design-system output.
+- Preserve high-signal assets, source examples, UI surfaces, copy, tokens, typography, and interaction patterns from the copied project.
+- Generate a reusable Open Design design-system package in this same project: DESIGN.md, README.md, SKILL.md, colors_and_type.css, context/provenance, focused preview cards, preserved assets/build/fonts when available, and ui_kits/app/.
+- Before final response, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every actionable issue.


### PR DESCRIPTION
Add Source Project Context (source-project-context-mrqio2m9) plugin.
Version: 0.1.0
Description: This design-system workspace was created from an existing Open Design project. Treat the copied project files as the primary source evidence for the generated design system.