### PR TITLE
fix(pack): make Windows installer updates transactional

### DIFF
--- a/tools/pack/src/win/custom-installer.ts
+++ b/tools/pack/src/win/custom-installer.ts
@@ -103,6 +103,7 @@ function createLauncherRuntimeSyncScript(
   if (config.portable) {
     return `
 Function SyncLauncherRuntime
+  StrCpy $LauncherRuntimeSyncFailed "0"
 FunctionEnd
 `;
   }
@@ -115,6 +116,7 @@ FunctionEnd
 
   return `
 Function SyncLauncherRuntime
+  StrCpy $LauncherRuntimeSyncFailed "0"
   Push $0
   InitPluginsDir
   File "/oname=$PLUGINSDIR\\${helperFileName}" "${escapeNsisString(helperScriptPath)}"
@@ -123,11 +125,13 @@ Function SyncLauncherRuntime
   Push "launcher runtime sync exit=$0"
   Call LogInstallerEvent
   \${If} $0 != "0"
+    StrCpy $LauncherRuntimeSyncFailed "1"
     DetailPrint "launcher runtime sync failed with exit code $0"
-    Abort
+    Goto done
   \${EndIf}
   Push "event=launcher_runtime_after_write path=${escapedRuntimePath}"
   Call LogInstallerEvent
+done:
   Pop $0
 FunctionEnd
 `;
@@ -333,80 +337,185 @@ async function resolveMakensisCommand(config: ToolPackConfig): Promise<string> {
   throw new Error("makensis is required to build the Windows installer; install NSIS or populate the electron-builder NSIS cache");
 }
 
-function createRunningInstancesScript(): string {
+export function createRunningInstancesScript(): string {
   return `param(
   [ValidateSet("detect", "close")]
   [string]$Action,
   [string]$Install,
-  [string]$Registered
+  [string]$ExecutableName,
+  [string]$LauncherBackup
 )
 
 $ErrorActionPreference = "Stop"
 
-$roots = @($Install, $Registered) |
+$roots = @($Install) |
   Where-Object { $_ } |
   ForEach-Object {
     $root = $_.TrimEnd([char]92).ToLowerInvariant()
     [pscustomobject]@{ Exact = $root; Prefix = ($root + [char]92) }
-  } |
-  Select-Object -Unique Exact, Prefix
+  }
 
-$matches = Get-CimInstance Win32_Process | Where-Object {
-  $matched = $false
-  $exe = $_.ExecutablePath
-  if ($null -ne $exe) {
-    $exe = $exe.ToLowerInvariant()
-    foreach ($root in $roots) {
-      if ($root.Exact -and (($exe -eq $root.Exact) -or $exe.StartsWith($root.Prefix))) {
-        $matched = $true
-        break
-      }
-    }
-  } else {
-    $cmd = $_.CommandLine
-    if ($null -ne $cmd) {
-      $cmdLc = $cmd.ToLowerInvariant()
+function Get-MatchingProcesses {
+  return @(Get-CimInstance Win32_Process | Where-Object {
+    $matched = $false
+    $exe = $_.ExecutablePath
+    if ($null -ne $exe) {
+      $exe = $exe.ToLowerInvariant()
       foreach ($root in $roots) {
-        if ($root.Prefix -and $cmdLc.Contains($root.Prefix)) {
+        if ($root.Exact -and (($exe -eq $root.Exact) -or $exe.StartsWith($root.Prefix))) {
           $matched = $true
           break
         }
       }
+    } else {
+      $cmd = $_.CommandLine
+      if ($null -ne $cmd) {
+        $cmdLc = $cmd.ToLowerInvariant()
+        foreach ($root in $roots) {
+          if ($root.Prefix -and $cmdLc.Contains($root.Prefix)) {
+            $matched = $true
+            break
+          }
+        }
+      }
+    }
+    $matched
+  })
+}
+
+function Get-LauncherPaths {
+  if (-not $Install) {
+    return @()
+  }
+  return @(Join-Path $Install $ExecutableName)
+}
+
+function Quarantine-Launchers {
+  $quarantined = @()
+  foreach ($launcherPath in @(Get-LauncherPaths)) {
+    if (-not (Test-Path -LiteralPath $launcherPath -PathType Leaf)) {
+      throw "expected launcher is missing: $launcherPath"
+    }
+    if (-not $LauncherBackup) {
+      throw "launcher backup path is required"
+    }
+    if (Test-Path -LiteralPath $LauncherBackup) {
+      throw "launcher backup already exists: $LauncherBackup"
+    }
+    $launcher = Get-Item -LiteralPath $launcherPath -ErrorAction Stop
+    if ([long]$launcher.Length -le 0) {
+      throw "expected launcher is empty: $launcherPath"
+    }
+    Move-Item -LiteralPath $launcherPath -Destination $LauncherBackup -ErrorAction Stop
+    $backup = Get-Item -LiteralPath $LauncherBackup -ErrorAction Stop
+    $quarantined += [pscustomobject]@{ Original = $launcherPath; Quarantine = $LauncherBackup }
+    if ((Test-Path -LiteralPath $launcherPath) -or [long]$backup.Length -le 0) {
+      throw "launcher quarantine verification failed: $launcherPath"
     }
   }
-  $matched
+  return $quarantined
 }
 
-$ids = @($matches | ForEach-Object { $_.ProcessId })
+function Restore-Launchers {
+  param([object[]]$Quarantined)
+  foreach ($item in $Quarantined) {
+    if (Test-Path -LiteralPath $item.Quarantine -PathType Leaf) {
+      if (Test-Path -LiteralPath $item.Original) {
+        throw "launcher restore conflict: original already exists and quarantine preserved: $($item.Original)"
+      }
+      Move-Item -LiteralPath $item.Quarantine -Destination $item.Original -ErrorAction Stop
+      if ((Test-Path -LiteralPath $item.Quarantine) -or
+          -not (Test-Path -LiteralPath $item.Original -PathType Leaf)) {
+        throw "launcher restore verification failed: $($item.Original)"
+      }
+    }
+  }
+}
+
+function Get-LiveProcess {
+  param([object]$Identity)
+  $current = Get-CimInstance Win32_Process -Filter ("ProcessId = {0}" -f $Identity.ProcessId) -ErrorAction SilentlyContinue
+  if ($null -eq $current -or $current.CreationDate -ne $Identity.CreationDate) {
+    return $null
+  }
+  try {
+    return [System.Diagnostics.Process]::GetProcessById([int]$Identity.ProcessId)
+  } catch {
+    return $null
+  }
+}
+
+function Close-MatchingProcesses {
+  param([object[]]$Processes)
+  $identities = @($Processes |
+    Sort-Object ProcessId -Unique |
+    ForEach-Object {
+      [pscustomobject]@{ ProcessId = [int]$_.ProcessId; CreationDate = $_.CreationDate }
+    })
+  foreach ($identity in $identities) {
+    $process = Get-LiveProcess $identity
+    if ($null -ne $process) {
+      try { [void]$process.CloseMainWindow() } catch {}
+    }
+  }
+  if ($identities.Count -gt 0) {
+    Start-Sleep -Milliseconds 1500
+  }
+  foreach ($identity in $identities) {
+    $process = Get-LiveProcess $identity
+    if ($null -ne $process) {
+      try {
+        if (-not $process.HasExited) {
+          Stop-Process -Id $identity.ProcessId -Force -ErrorAction SilentlyContinue
+        }
+      } catch {}
+    }
+  }
+  foreach ($identity in $identities) {
+    $process = Get-LiveProcess $identity
+    if ($null -ne $process) {
+      try {
+        if (-not $process.HasExited) {
+          [void]$process.WaitForExit(5000)
+        }
+      } catch {}
+    }
+  }
+}
+
+$matches = @(Get-MatchingProcesses)
 if ($Action -eq "close") {
-  foreach ($id in $ids) {
-    try { [void][System.Diagnostics.Process]::GetProcessById($id).CloseMainWindow() } catch {}
-  }
-  Start-Sleep -Milliseconds 1500
-  foreach ($id in $ids) {
-    try {
-      $p = [System.Diagnostics.Process]::GetProcessById($id)
-      if (-not $p.HasExited) {
-        Stop-Process -Id $id -Force -ErrorAction SilentlyContinue
-      }
-    } catch {}
-  }
-  foreach ($id in $ids) {
-    try {
-      $p = [System.Diagnostics.Process]::GetProcessById($id)
-      if (-not $p.HasExited) {
-        [void]$p.WaitForExit(5000)
-      }
-    } catch {}
+  $quarantined = @()
+  try {
+    # Remove the stable spawn target before terminating any process. External
+    # clients may otherwise recreate an MCP child between Stop-Process and the
+    # installer's verification pass.
+    $quarantined = @(Quarantine-Launchers)
+    $pending = $matches
+    if ($pending.Count -eq 0) {
+      $pending = @(Get-MatchingProcesses)
+    }
+    for ($attempt = 0; $attempt -lt 3 -and $pending.Count -gt 0; $attempt++) {
+      Close-MatchingProcesses $pending
+      $pending = @(Get-MatchingProcesses)
+    }
+    if ($pending.Count -gt 0) {
+      Restore-Launchers $quarantined
+      $matches = $pending
+    } else {
+      $matches = @()
+    }
+  } catch {
+    Restore-Launchers $quarantined
+    throw
   }
 }
 
-if ($ids) {
+if ($matches.Count -gt 0) {
   $matches | ForEach-Object { [string]$_.ProcessId + [char]32 + $_.Name }
 }
 `;
 }
-
 async function writeInstallerScript(config: ToolPackConfig, paths: WinPaths, packagedVersion: string): Promise<void> {
   const identity = resolveWinInstallIdentity(config);
   const launcher = resolveToolPackLauncherLayout(config);
@@ -460,6 +569,7 @@ RequestExecutionLevel user
 
 !include "MUI2.nsh"
 !include "LogicLib.nsh"
+!include "FileFunc.nsh"
 !include "nsDialogs.nsh"
 !include "WinMessages.nsh"
 
@@ -475,11 +585,11 @@ ShowUninstDetails hide
 !define MUI_ABORTWARNING
 !define MUI_ICON "\${APP_ICON}"
 !define MUI_UNICON "\${APP_ICON}"
-Page custom RunningInstancesPage RunningInstancesPageLeave
 !insertmacro MUI_PAGE_WELCOME
 !define MUI_PAGE_CUSTOMFUNCTION_LEAVE DirectoryPageLeave
 !insertmacro MUI_PAGE_DIRECTORY
 !undef MUI_PAGE_CUSTOMFUNCTION_LEAVE
+Page custom RunningInstancesPage
 !insertmacro MUI_PAGE_INSTFILES
 !define MUI_FINISHPAGE_RUN "$INSTDIR\\${exeName}"
 !define MUI_FINISHPAGE_RUN_TEXT "$(LaunchApp)"
@@ -504,9 +614,11 @@ ${createNsisLangString("RunningInstancesSubtitle", "Close it before continuing i
 ${createNsisLangString("RunningInstancesMessage", `${productName} must be closed before installation can continue.`, { LANG_SIMPCHINESE: `继续安装前需要关闭 ${productName}。` })}
 ${createNsisLangString("CloseAndContinue", "Close and continue", { LANG_SIMPCHINESE: "关闭并继续" })}
 ${createNsisLangString("RunningInstancesCloseFailed", `${productName} could not be closed. Close it manually, then try again.`, { LANG_SIMPCHINESE: `无法关闭 ${productName}。请手动关闭后重试。` })}
-${createNsisLangString("RunningInstancesSilentAbort", `${productName} is still running. Close it before running the installer silently.`, { LANG_SIMPCHINESE: `${productName} 仍在运行。请先关闭它，再运行静默安装。` })}
 ${createNsisLangString("ExistingInstallMessage", `${productName} is already installed in the selected folder. Choose OK to overwrite it, or Cancel to stop installation.`, { LANG_SIMPCHINESE: `所选文件夹中已经安装了 ${productName}。选择确定覆盖，或取消安装。` })}
 ${createNsisLangString("ExistingInstallSilentOverwrite", "Existing installation found; silent install will overwrite it.", { LANG_SIMPCHINESE: "发现已有安装；静默安装将覆盖它。" })}
+${createNsisLangString("UnsafeInstallDirectory", "The selected folder contains files but is not a recognized Open Design installation. Choose an empty folder or the existing installation folder.", { LANG_SIMPCHINESE: "所选文件夹包含文件，但不是可识别的 Open Design 安装。请选择空文件夹或现有安装文件夹。" })}
+${createNsisLangString("InstallDirectoryRemoveFailed", "The existing Open Design installation could not be replaced safely. No new files were installed.", { LANG_SIMPCHINESE: "无法安全替换现有 Open Design 安装。未安装任何新文件。" })}
+${createNsisLangString("InstallFinalizeFailed", "Open Design files were installed, but setup could not finish system registration. Retry the installer; any replacement backup was preserved.", { LANG_SIMPCHINESE: "Open Design 文件已安装，但安装程序无法完成系统注册。请重试安装程序；任何替换备份均已保留。" })}
 
 Var RemoveDesktopShortcutCheckbox
 Var RemoveCacheDataCheckbox
@@ -515,8 +627,22 @@ Var RemoveDesktopShortcutState
 Var RemoveCacheDataState
 Var RemoveLocalDataState
 Var RunningInstancesOutput
-Var ExistingInstallLocation
 Var RunningInstancesInstallRoot
+Var RunningInstancesCloseFailed
+Var ExistingInstallTarget
+Var RegisteredInstallLocation
+Var InstallDirHasEntries
+Var InstallTransactionRoot
+Var InstallLauncherBackup
+Var InstallDirBackup
+Var InstallReplacementDir
+Var EmptyInstallDirBackup
+Var EmptyInstallDirQuarantined
+Var EmptyInstallDirRestoreFailed
+Var FreshInstallTargetWasEmpty
+Var EmptyInstallDirHasEntries
+Var InstallTargetAttributeState
+Var LauncherRuntimeSyncFailed
 Var LE
 Var LT
 Var LX
@@ -561,12 +687,12 @@ write:
 FunctionEnd
 
 ${createLauncherRuntimeSyncScript(
-  config,
-  launcher.paths.runtimePath,
-  launcher.paths.attemptsPath,
-  launcher.paths.cleanupPath,
-  launcherRuntimeSyncScriptPath,
-)}
+    config,
+    launcher.paths.runtimePath,
+    launcher.paths.attemptsPath,
+    launcher.paths.cleanupPath,
+    launcherRuntimeSyncScriptPath,
+  )}
 
 Function un.LogInstallerEvent
   Exch $0
@@ -609,7 +735,7 @@ Function DetectRunningInstances
   File "/oname=$PLUGINSDIR\\running-instances.ps1" "\${RUNNING_INSTANCES_PS1}"
 
   ; Try pwsh.exe first (PowerShell 7)
-  nsExec::ExecToStack 'pwsh.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\\running-instances.ps1" detect "$RunningInstancesInstallRoot" "$ExistingInstallLocation"'
+  nsExec::ExecToStack 'pwsh.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\\running-instances.ps1" detect "$RunningInstancesInstallRoot" "${exeName}" "$InstallLauncherBackup"'
   Pop $0
   Pop $1
 
@@ -623,7 +749,7 @@ Function DetectRunningInstances
   Push "pwsh.exe failed exit=$0, trying powershell.exe"
   Call LogInstallerEvent
 
-  nsExec::ExecToStack 'powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\\running-instances.ps1" detect "$RunningInstancesInstallRoot" "$ExistingInstallLocation"'
+  nsExec::ExecToStack 'powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\\running-instances.ps1" detect "$RunningInstancesInstallRoot" "${exeName}" "$InstallLauncherBackup"'
   Pop $0
   Pop $1
 
@@ -645,6 +771,7 @@ done:
 FunctionEnd
 
 Function CloseRunningInstances
+  StrCpy $RunningInstancesCloseFailed "0"
   Push $0
   Push $1
   Push $2
@@ -652,7 +779,7 @@ Function CloseRunningInstances
   File "/oname=$PLUGINSDIR\\running-instances.ps1" "\${RUNNING_INSTANCES_PS1}"
 
   ; Try pwsh.exe first (PowerShell 7)
-  nsExec::ExecToStack 'pwsh.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\\running-instances.ps1" close "$RunningInstancesInstallRoot" "$ExistingInstallLocation"'
+  nsExec::ExecToStack 'pwsh.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\\running-instances.ps1" close "$RunningInstancesInstallRoot" "${exeName}" "$InstallLauncherBackup"'
   Pop $0
   Pop $1
 
@@ -667,7 +794,7 @@ Function CloseRunningInstances
   Push "pwsh.exe failed exit=$0, trying powershell.exe"
   Call LogInstallerEvent
 
-  nsExec::ExecToStack 'powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\\running-instances.ps1" close "$RunningInstancesInstallRoot" "$ExistingInstallLocation"'
+  nsExec::ExecToStack 'powershell.exe -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\\running-instances.ps1" close "$RunningInstancesInstallRoot" "${exeName}" "$InstallLauncherBackup"'
   Pop $0
   Pop $1
 
@@ -679,6 +806,7 @@ Function CloseRunningInstances
   \${EndIf}
 
   ; Both failed
+  StrCpy $RunningInstancesCloseFailed "1"
   Push "running instances close failed: both pwsh.exe and powershell.exe failed, last exit=$0 output=$1"
   Call LogInstallerEvent
 
@@ -690,53 +818,32 @@ FunctionEnd
 
 Function .onInit
   SetShellVarContext current
-  ReadRegStr $ExistingInstallLocation HKCU "${registryKey}" "InstallLocation"
-  StrCpy $RunningInstancesInstallRoot ""
-  \${If} $ExistingInstallLocation != ""
-    IfFileExists "$ExistingInstallLocation\\${exeName}" valid_existing_location invalid_existing_location
-invalid_existing_location:
-    Push "ignoring registered install location without expected exe: $ExistingInstallLocation"
+  StrCpy $RegisteredInstallLocation ""
+  ReadRegStr $RegisteredInstallLocation HKCU "${registryKey}" "InstallLocation"
+  IfFileExists "$RegisteredInstallLocation\\${exeName}" registered_install_valid registered_install_invalid
+registered_install_valid:
+  GetFullPathName $RegisteredInstallLocation "$RegisteredInstallLocation"
+  Goto inspect_selected_install
+registered_install_invalid:
+  \${If} $RegisteredInstallLocation != ""
+    Push "ignoring registered install location without expected exe: $RegisteredInstallLocation"
     Call LogInstallerEvent
-    StrCpy $ExistingInstallLocation ""
-valid_existing_location:
   \${EndIf}
-
-  IfSilent silent_check no_existing_install
-silent_check:
-  IfFileExists "$INSTDIR\\${exeName}" 0 silent_detect_running_instances
-  StrCpy $RunningInstancesInstallRoot "$INSTDIR"
-silent_detect_running_instances:
-  Call DetectRunningInstances
-  \${If} $RunningInstancesOutput != ""
-    Push "running instances detected before silent install: $RunningInstancesOutput"
-    Call LogInstallerEvent
-    Call CloseRunningInstances
-    Call DetectRunningInstances
-    \${If} $RunningInstancesOutput != ""
-      Push "install aborted: running instances still detected before silent install: $RunningInstancesOutput"
-      Call LogInstallerEvent
-      Abort "$(RunningInstancesSilentAbort)"
-    \${EndIf}
-  \${EndIf}
-
+  StrCpy $RegisteredInstallLocation ""
+inspect_selected_install:
   IfFileExists "$INSTDIR\\${exeName}" existing_install no_existing_install
 existing_install:
   IfSilent 0 no_existing_install
     Push "existing installation found; silent install will overwrite it"
     Call LogInstallerEvent
     Goto no_existing_install
-
-cancel_install:
-  Push "install cancelled before file changes"
-  Call LogInstallerEvent
-  Abort
-
 no_existing_install:
 FunctionEnd
 
 Function RunningInstancesPage
   IfSilent done
-  StrCpy $RunningInstancesInstallRoot ""
+  IfFileExists "$INSTDIR\\${exeName}" 0 done
+  StrCpy $RunningInstancesInstallRoot "$INSTDIR"
   Call DetectRunningInstances
   \${If} $RunningInstancesOutput == ""
     Abort
@@ -763,35 +870,44 @@ Function RunningInstancesPage
 done:
 FunctionEnd
 
-Function RunningInstancesPageLeave
-  StrCpy $RunningInstancesInstallRoot ""
-  Call CloseRunningInstances
+
+Function GuardRegisteredInstallInstances
+  StrCmp $RegisteredInstallLocation "" done
+  StrCmp $RegisteredInstallLocation "$INSTDIR" done
+  StrCpy $RunningInstancesInstallRoot "$RegisteredInstallLocation"
   Call DetectRunningInstances
   \${If} $RunningInstancesOutput != ""
-    Push "running instances still detected after close: $RunningInstancesOutput"
+    Push "install aborted: registered installation still running at $RegisteredInstallLocation: $RunningInstancesOutput"
     Call LogInstallerEvent
-    MessageBox MB_OK|MB_ICONEXCLAMATION "$(RunningInstancesCloseFailed)"
-    Abort
+    Call CleanupInstallTransaction
+    Abort "$(RunningInstancesCloseFailed)"
   \${EndIf}
+done:
 FunctionEnd
 
 Function GuardRunningInstancesBeforeInstall
-  StrCpy $RunningInstancesInstallRoot ""
-  IfFileExists "$INSTDIR\\${exeName}" 0 detect_running_instances
-  StrCpy $RunningInstancesInstallRoot "$INSTDIR"
-detect_running_instances:
-  Call DetectRunningInstances
-  \${If} $RunningInstancesOutput == ""
+  Call GuardRegisteredInstallInstances
+  \${If} $ExistingInstallTarget != "1"
     Return
   \${EndIf}
-
-  Push "running instances detected at install section: $RunningInstancesOutput"
-  Call LogInstallerEvent
+  StrCpy $RunningInstancesInstallRoot "$INSTDIR"
+  Call DetectRunningInstances
+  \${If} $RunningInstancesOutput != ""
+    Push "running instances detected at install section: $RunningInstancesOutput"
+    Call LogInstallerEvent
+  \${EndIf}
   Call CloseRunningInstances
+  \${If} $RunningInstancesCloseFailed == "1"
+    Call RestoreQuarantinedLauncher
+    Call CleanupAfterLauncherRestore
+    Abort "$(RunningInstancesCloseFailed)"
+  \${EndIf}
   Call DetectRunningInstances
   \${If} $RunningInstancesOutput != ""
     Push "install aborted: running instances still detected before file changes: $RunningInstancesOutput"
     Call LogInstallerEvent
+    Call RestoreQuarantinedLauncher
+    Call CleanupAfterLauncherRestore
     Abort "$(RunningInstancesCloseFailed)"
   \${EndIf}
 FunctionEnd
@@ -816,15 +932,414 @@ Function CreateDesktopShortcut
   !insertmacro LOG_PATH_STATE "desktop_shortcut_after_create" "$DESKTOP\\${shortcutName}"
 FunctionEnd
 
-Function RemoveInstallDir
-  !insertmacro LOG_PATH_STATE "install_dir_before_remove" "$INSTDIR"
+Function InspectInstallDir
+  StrCpy $InstallDirHasEntries "0"
   Push $0
-  nsExec::ExecToLog 'cmd.exe /d /s /c if exist "$INSTDIR" rmdir /s /q "\\\\?\\$INSTDIR"'
+  Push $1
+  ClearErrors
+  FindFirst $0 $1 "$INSTDIR\\*"
+  IfErrors done
+scan:
+  StrCmp $1 "." next
+  StrCmp $1 ".." next
+  StrCpy $InstallDirHasEntries "1"
+  Goto close
+next:
+  ClearErrors
+  FindNext $0 $1
+  IfErrors close scan
+close:
+  FindClose $0
+done:
+  Pop $1
   Pop $0
-  Push "install dir remove exit=$0"
+FunctionEnd
+
+Function PrepareInstallTransaction
+  Push $0
+  \${GetParent} "$INSTDIR" $0
+  ClearErrors
+  CreateDirectory "$0"
+  IfErrors failed
+  ClearErrors
+  GetTempFileName $InstallTransactionRoot "$0"
+  IfErrors failed
+  Delete "$InstallTransactionRoot"
+  IfErrors failed
+  CreateDirectory "$InstallTransactionRoot"
+  IfErrors failed
+  IfFileExists "$InstallTransactionRoot" transaction_ready failed
+transaction_ready:
+  StrCpy $EmptyInstallDirBackup "$InstallTransactionRoot\\empty-target"
+  StrCpy $InstallLauncherBackup "$InstallTransactionRoot\\launcher"
+  StrCpy $InstallDirBackup "$InstallTransactionRoot\\previous"
+  StrCpy $InstallReplacementDir "$InstallTransactionRoot\\replacement"
+  Goto done
+failed:
+  IfFileExists "$InstallTransactionRoot" remove_transaction clear_transaction
+remove_transaction:
+  RMDir /r "$InstallTransactionRoot"
+clear_transaction:
+  StrCpy $InstallTransactionRoot ""
+  StrCpy $InstallLauncherBackup ""
+  StrCpy $InstallDirBackup ""
+  StrCpy $InstallReplacementDir ""
+  StrCpy $EmptyInstallDirBackup ""
+  Pop $0
+  Abort "$(InstallDirectoryRemoveFailed)"
+done:
+  Pop $0
+FunctionEnd
+
+Function ValidateInstallDirectory
+  Push $0
+  Push $1
+  GetFullPathName $0 "$INSTDIR"
+  \${GetRoot} "$0" $1
+  StrCpy $1 "$1\\"
+  StrCmp $0 $1 unsafe valid
+unsafe:
+  Pop $1
+  Pop $0
+  Abort "$(UnsafeInstallDirectory)"
+valid:
+  StrCpy $INSTDIR $0
+  Pop $1
+  Pop $0
+FunctionEnd
+
+Function RestoreLauncherBackup
+  IfFileExists "$InstallLauncherBackup" restore done
+restore:
+  CreateDirectory "$INSTDIR"
+  ClearErrors
+  Rename "$InstallLauncherBackup" "$INSTDIR\\${exeName}"
+  IfErrors restore_failed
+  IfFileExists "$INSTDIR\\${exeName}" verify_backup restore_failed
+verify_backup:
+  IfFileExists "$InstallLauncherBackup" restore_failed restored
+restored:
+  !insertmacro LOG_PATH_STATE "installed_exe_after_restore" "$INSTDIR\\${exeName}"
+  Goto done
+restore_failed:
+  Push "launcher restore failed; backup preserved at $InstallLauncherBackup"
   Call LogInstallerEvent
+done:
+FunctionEnd
+
+Function RestoreQuarantinedLauncher
+  IfFileExists "$INSTDIR\\${exeName}" done
+  Call RestoreLauncherBackup
+done:
+FunctionEnd
+
+Function CleanupAfterLauncherRestore
+  IfFileExists "$INSTDIR\\${exeName}" launcher_present preserve_transaction
+launcher_present:
+  IfFileExists "$InstallLauncherBackup" preserve_transaction cleanup_transaction
+cleanup_transaction:
+  Call CleanupInstallTransaction
+  Return
+preserve_transaction:
+  Push "launcher restore incomplete; transaction preserved at $InstallTransactionRoot"
+  Call LogInstallerEvent
+FunctionEnd
+
+Function QuarantineInstallDir
+  IfFileExists "$InstallLauncherBackup" launcher_backup_ready launcher_backup_missing
+launcher_backup_missing:
+  Call RestoreQuarantinedLauncher
+  Call CleanupAfterLauncherRestore
+  Abort "$(InstallDirectoryRemoveFailed)"
+launcher_backup_ready:
+  !insertmacro LOG_PATH_STATE "install_dir_before_quarantine" "$INSTDIR"
+  ClearErrors
+  Rename "$INSTDIR" "$InstallDirBackup"
+  IfErrors directory_not_moved
+  IfFileExists "$INSTDIR" rollback_moved directory_moved
+directory_moved:
+  IfFileExists "$InstallDirBackup" attach_launcher rollback_moved
+attach_launcher:
+  ClearErrors
+  Rename "$InstallLauncherBackup" "$InstallDirBackup\\${exeName}"
+  IfErrors rollback_moved
+  IfFileExists "$InstallDirBackup\\${exeName}" verify_launcher_backup rollback_moved
+verify_launcher_backup:
+  IfFileExists "$InstallLauncherBackup" rollback_moved done
+rollback_moved:
+  IfFileExists "$INSTDIR" rollback_failed rollback_directory
+rollback_directory:
+  ClearErrors
+  Rename "$InstallDirBackup" "$INSTDIR"
+  IfErrors rollback_failed
+  Call RestoreQuarantinedLauncher
+  Call CleanupAfterLauncherRestore
+  IfFileExists "$INSTDIR\\${exeName}" rollback_abort rollback_failed
+rollback_abort:
+  Abort "$(InstallDirectoryRemoveFailed)"
+directory_not_moved:
+  Call RestoreQuarantinedLauncher
+  Call CleanupAfterLauncherRestore
+  Abort "$(InstallDirectoryRemoveFailed)"
+rollback_failed:
+  Push "install directory quarantine rollback failed; backups preserved at $InstallDirBackup and $InstallLauncherBackup"
+  Call LogInstallerEvent
+  Abort "$(InstallDirectoryRemoveFailed)"
+done:
+  !insertmacro LOG_PATH_STATE "install_dir_after_quarantine" "$InstallDirBackup"
+FunctionEnd
+
+Function RestoreInstallDirBackup
+  IfFileExists "$InstallDirBackup" backup_present rollback_failed
+backup_present:
+  IfFileExists "$INSTDIR" target_recreated restore_old
+target_recreated:
+  Push "install directory rollback blocked because target reappeared; previous install preserved at $InstallDirBackup"
+  Call LogInstallerEvent
+  Goto done
+restore_old:
+  ClearErrors
+  Rename "$InstallDirBackup" "$INSTDIR"
+  IfErrors rollback_failed
+  IfFileExists "$INSTDIR\\${exeName}" verify_backup rollback_failed
+verify_backup:
+  IfFileExists "$InstallDirBackup" rollback_failed restored
+restored:
+  !insertmacro LOG_PATH_STATE "install_dir_after_restore" "$INSTDIR"
+  Call CleanupInstallTransaction
+  Goto done
+rollback_failed:
+  Push "install directory rollback failed; previous install preserved at $InstallDirBackup"
+  Call LogInstallerEvent
+done:
+FunctionEnd
+
+Function RecordFreshInstallTargetState
+  StrCpy $FreshInstallTargetWasEmpty "0"
+  \${If} $ExistingInstallTarget == "1"
+    Return
+  \${EndIf}
+  IfFileExists "$INSTDIR" inspect_existing done
+inspect_existing:
+  \${GetFileAttributes} "$INSTDIR" "DIRECTORY" $InstallTargetAttributeState
+  StrCmp $InstallTargetAttributeState "1" inspect_reparse reject_target
+inspect_reparse:
+  \${GetFileAttributes} "$INSTDIR" "REPARSE_POINT" $InstallTargetAttributeState
+  StrCmp $InstallTargetAttributeState "1" reject_target inspect_empty
+inspect_empty:
+  Call InspectInstallDir
+  StrCmp $InstallDirHasEntries "1" reject_target record_empty
+record_empty:
+  StrCpy $FreshInstallTargetWasEmpty "1"
+  Return
+reject_target:
+  Push "fresh install target is not an empty regular directory: $INSTDIR"
+  Call LogInstallerEvent
+  Abort "$(UnsafeInstallDirectory)"
+done:
+FunctionEnd
+
+Function InspectEmptyInstallDirBackup
+  StrCpy $EmptyInstallDirHasEntries "0"
+  Push $0
+  Push $1
+  ClearErrors
+  FindFirst $0 $1 "$EmptyInstallDirBackup\\*"
+  IfErrors done
+scan:
+  StrCmp $1 "." next
+  StrCmp $1 ".." next
+  StrCpy $EmptyInstallDirHasEntries "1"
+  Goto close
+next:
+  ClearErrors
+  FindNext $0 $1
+  IfErrors close scan
+close:
+  FindClose $0
+done:
+  Pop $1
   Pop $0
-  !insertmacro LOG_PATH_STATE "install_dir_after_remove" "$INSTDIR"
+FunctionEnd
+
+Function QuarantineEmptyFreshInstallDir
+  StrCpy $EmptyInstallDirQuarantined "0"
+  \${If} $ExistingInstallTarget == "1"
+    Return
+  \${EndIf}
+  \${If} $FreshInstallTargetWasEmpty != "1"
+    IfFileExists "$INSTDIR" target_changed done
+  \${EndIf}
+  IfFileExists "$INSTDIR" inspect_target target_changed
+inspect_target:
+  \${GetFileAttributes} "$INSTDIR" "DIRECTORY" $InstallTargetAttributeState
+  StrCmp $InstallTargetAttributeState "1" inspect_reparse target_changed
+inspect_reparse:
+  \${GetFileAttributes} "$INSTDIR" "REPARSE_POINT" $InstallTargetAttributeState
+  StrCmp $InstallTargetAttributeState "1" target_changed inspect_empty
+inspect_empty:
+  Call InspectInstallDir
+  StrCmp $InstallDirHasEntries "1" target_changed quarantine_empty
+quarantine_empty:
+  ClearErrors
+  Rename "$INSTDIR" "$EmptyInstallDirBackup"
+  IfErrors quarantine_failed
+  StrCpy $EmptyInstallDirQuarantined "1"
+  IfFileExists "$INSTDIR" quarantine_failed verify_backup
+verify_backup:
+  IfFileExists "$EmptyInstallDirBackup" inspect_backup_attributes quarantine_failed
+inspect_backup_attributes:
+  \${GetFileAttributes} "$EmptyInstallDirBackup" "DIRECTORY" $InstallTargetAttributeState
+  StrCmp $InstallTargetAttributeState "1" inspect_backup_reparse backup_changed
+inspect_backup_reparse:
+  \${GetFileAttributes} "$EmptyInstallDirBackup" "REPARSE_POINT" $InstallTargetAttributeState
+  StrCmp $InstallTargetAttributeState "1" backup_changed inspect_backup
+inspect_backup:
+  Call InspectEmptyInstallDirBackup
+  StrCmp $EmptyInstallDirHasEntries "1" backup_changed quarantined
+backup_changed:
+  Push "fresh install target changed while it was quarantined: $INSTDIR"
+  Call LogInstallerEvent
+  Call RestoreEmptyFreshInstallDir
+  \${If} $EmptyInstallDirRestoreFailed != "1"
+    Call CleanupInstallTransaction
+  \${EndIf}
+  Abort "$(UnsafeInstallDirectory)"
+quarantined:
+  !insertmacro LOG_PATH_STATE "empty_install_dir_after_quarantine" "$EmptyInstallDirBackup"
+  Return
+target_changed:
+  Push "fresh install target changed before staging: $INSTDIR"
+  Call LogInstallerEvent
+  Call CleanupInstallTransaction
+  Abort "$(UnsafeInstallDirectory)"
+quarantine_failed:
+  IfFileExists "$EmptyInstallDirBackup" preserve_transaction cleanup_transaction
+cleanup_transaction:
+  Call CleanupInstallTransaction
+  Push "empty fresh install target quarantine failed; target left unchanged: $INSTDIR"
+  Call LogInstallerEvent
+  Goto abort_install
+preserve_transaction:
+  Push "empty fresh install target quarantine failed; transaction preserved at $InstallTransactionRoot"
+  Call LogInstallerEvent
+abort_install:
+  Abort "$(InstallDirectoryRemoveFailed)"
+done:
+FunctionEnd
+
+Function RestoreEmptyFreshInstallDir
+  StrCpy $EmptyInstallDirRestoreFailed "0"
+  \${If} $ExistingInstallTarget == "1"
+    Return
+  \${EndIf}
+  \${If} $EmptyInstallDirQuarantined != "1"
+    Return
+  \${EndIf}
+  IfFileExists "$EmptyInstallDirBackup" restore restore_failed
+restore:
+  IfFileExists "$INSTDIR" restore_failed rename_backup
+rename_backup:
+  ClearErrors
+  Rename "$EmptyInstallDirBackup" "$INSTDIR"
+  IfErrors restore_failed
+  IfFileExists "$INSTDIR" verify_backup restore_failed
+verify_backup:
+  IfFileExists "$EmptyInstallDirBackup" restore_failed restored
+restored:
+  !insertmacro LOG_PATH_STATE "empty_install_dir_after_restore" "$INSTDIR"
+  Return
+restore_failed:
+  StrCpy $EmptyInstallDirRestoreFailed "1"
+  Push "empty fresh install target restore failed; transaction preserved at $InstallTransactionRoot"
+  Call LogInstallerEvent
+FunctionEnd
+
+Function RollbackFailedInstall
+  \${If} $ExistingInstallTarget == "1"
+    Call RestoreInstallDirBackup
+  \${Else}
+    Call RestoreEmptyFreshInstallDir
+    \${If} $EmptyInstallDirRestoreFailed != "1"
+      Push "failed fresh install staging removed; target restored unchanged: $INSTDIR"
+      Call LogInstallerEvent
+      Call CleanupInstallTransaction
+    \${EndIf}
+  \${EndIf}
+FunctionEnd
+
+Function CommitInstallDir
+  !insertmacro LOG_PATH_STATE "replacement_dir_before_commit" "$InstallReplacementDir"
+  IfFileExists "$InstallReplacementDir\\${exeName}" replacement_ready commit_safe_rollback
+replacement_ready:
+  IfFileExists "$INSTDIR" target_conflict target_absent
+target_absent:
+  ClearErrors
+  Rename "$InstallReplacementDir" "$INSTDIR"
+  IfErrors commit_failed commit_published
+commit_failed:
+  IfFileExists "$INSTDIR" target_conflict commit_safe_rollback
+commit_safe_rollback:
+  Push "replacement commit failed before stable launcher publish: $InstallReplacementDir"
+  Call LogInstallerEvent
+  Call RollbackFailedInstall
+  Abort "$(InstallDirectoryRemoveFailed)"
+target_conflict:
+  Push "replacement commit blocked by a recreated target; transaction preserved at $InstallTransactionRoot"
+  Call LogInstallerEvent
+  Call RollbackFailedInstall
+  Abort "$(UnsafeInstallDirectory)"
+commit_published:
+  IfFileExists "$INSTDIR\\${exeName}" committed publish_verification_failed
+committed:
+  !insertmacro LOG_PATH_STATE "install_dir_after_commit" "$INSTDIR"
+  Return
+publish_verification_failed:
+  Push "replacement publish verification failed; transaction preserved at $InstallTransactionRoot"
+  Call LogInstallerEvent
+  Abort "$(InstallFinalizeFailed)"
+FunctionEnd
+
+Function CleanupCommittedInstallTransaction
+  \${If} $ExistingInstallTarget == "1"
+    Call CleanupInstallTransaction
+    Return
+  \${EndIf}
+  \${If} $EmptyInstallDirQuarantined != "1"
+    Call CleanupInstallTransaction
+    Return
+  \${EndIf}
+  IfFileExists "$EmptyInstallDirBackup" inspect_backup_attributes cleanup_transaction
+inspect_backup_attributes:
+  \${GetFileAttributes} "$EmptyInstallDirBackup" "DIRECTORY" $InstallTargetAttributeState
+  StrCmp $InstallTargetAttributeState "1" inspect_backup_reparse preserve_transaction
+inspect_backup_reparse:
+  \${GetFileAttributes} "$EmptyInstallDirBackup" "REPARSE_POINT" $InstallTargetAttributeState
+  StrCmp $InstallTargetAttributeState "1" preserve_transaction inspect_backup
+inspect_backup:
+  Call InspectEmptyInstallDirBackup
+  \${If} $EmptyInstallDirHasEntries == "1"
+    Goto preserve_transaction
+  \${EndIf}
+  ClearErrors
+  RMDir "$EmptyInstallDirBackup"
+  IfErrors preserve_transaction
+cleanup_transaction:
+  Call CleanupInstallTransaction
+  Return
+preserve_transaction:
+  Push "committed install cleanup preserved a changed empty target at $EmptyInstallDirBackup"
+  Call LogInstallerEvent
+FunctionEnd
+
+Function CleanupInstallTransaction
+  IfFileExists "$InstallTransactionRoot" cleanup done
+cleanup:
+  nsExec::ExecToLog 'cmd.exe /d /s /c if exist "$InstallTransactionRoot" rmdir /s /q "\\\\?\\$InstallTransactionRoot"'
+  Pop $0
+  Push "install transaction cleanup exit=$0 path=$InstallTransactionRoot"
+  Call LogInstallerEvent
+done:
 FunctionEnd
 
 Function un.UninstallOptionsPage
@@ -923,48 +1438,95 @@ Section "Install"
   SetShellVarContext current
   Push "install section start"
   Call LogInstallerEvent
-  Call GuardRunningInstancesBeforeInstall
-  !insertmacro LOG_PATH_STATE "install_dir_before_install" "$INSTDIR"
-  !insertmacro LOG_PATH_STATE "installed_exe_before_install" "$INSTDIR\\${exeName}"
+  Call ValidateInstallDirectory
 
-  IfFileExists "$INSTDIR\\${exeName}" 0 prepare_install_dir
-  Call RemoveInstallDir
+  StrCpy $ExistingInstallTarget "0"
+  IfFileExists "$INSTDIR\\${exeName}" existing_install_target inspect_install_target
+existing_install_target:
+  StrCpy $ExistingInstallTarget "1"
+  Goto stage_payload
+inspect_install_target:
+  Call InspectInstallDir
+  StrCmp $InstallDirHasEntries "1" unsafe_install_target stage_payload
+unsafe_install_target:
+  Push "install aborted: non-empty target is not a recognized installation: $INSTDIR"
+  Call LogInstallerEvent
+  Abort "$(UnsafeInstallDirectory)"
 
-prepare_install_dir:
+stage_payload:
   InitPluginsDir
   SetOutPath "$PLUGINSDIR"
   File "/oname=$PLUGINSDIR\\payload-base.7z" "\${PAYLOAD_BASE_7Z}"
   File "/oname=$PLUGINSDIR\\payload-overlay.7z" "\${PAYLOAD_OVERLAY_7Z}"
   File "/oname=$PLUGINSDIR\\7z.exe" "\${SEVEN_Z_EXE}"
   File "/oname=$PLUGINSDIR\\7z.dll" "\${SEVEN_Z_DLL}"
+  \${If} $ExistingInstallTarget == "1"
+    IfFileExists "$INSTDIR\\${exeName}" validated_install_target unsafe_install_target
+  \${Else}
+    Call InspectInstallDir
+    StrCmp $InstallDirHasEntries "1" unsafe_install_target validated_install_target
+  \${EndIf}
+validated_install_target:
+  StrCpy $EmptyInstallDirBackup ""
+  StrCpy $EmptyInstallDirQuarantined "0"
+  StrCpy $EmptyInstallDirRestoreFailed "0"
+  StrCpy $FreshInstallTargetWasEmpty "0"
+  StrCpy $EmptyInstallDirHasEntries "0"
+  StrCpy $InstallTargetAttributeState ""
+  Call RecordFreshInstallTargetState
+  Call PrepareInstallTransaction
 
-  CreateDirectory "$INSTDIR"
+  Call GuardRunningInstancesBeforeInstall
+  Call QuarantineEmptyFreshInstallDir
+  !insertmacro LOG_PATH_STATE "install_dir_before_install" "$INSTDIR"
+  !insertmacro LOG_PATH_STATE "installed_exe_before_install" "$INSTDIR\\${exeName}"
+  \${If} $ExistingInstallTarget == "1"
+    Call QuarantineInstallDir
+  \${EndIf}
+
+  CreateDirectory "$InstallReplacementDir"
   Push "payload base extraction start"
   Call LogInstallerEvent
-  nsExec::ExecToLog '"$PLUGINSDIR\\7z.exe" x -y "$PLUGINSDIR\\payload-base.7z" "-o$INSTDIR"'
+  nsExec::ExecToLog '"$PLUGINSDIR\\7z.exe" x -y "$PLUGINSDIR\\payload-base.7z" "-o$InstallReplacementDir"'
   Pop $0
   Push "payload base extraction exit=$0"
   Call LogInstallerEvent
   \${If} $0 != "0"
     DetailPrint "base payload extraction failed with exit code $0"
+    Call RollbackFailedInstall
     Abort
   \${EndIf}
 
   Push "payload overlay extraction start"
   Call LogInstallerEvent
-  nsExec::ExecToLog '"$PLUGINSDIR\\7z.exe" x -y "$PLUGINSDIR\\payload-overlay.7z" "-o$INSTDIR"'
+  nsExec::ExecToLog '"$PLUGINSDIR\\7z.exe" x -y "$PLUGINSDIR\\payload-overlay.7z" "-o$InstallReplacementDir"'
   Pop $0
   Push "payload overlay extraction exit=$0"
   Call LogInstallerEvent
   \${If} $0 != "0"
     DetailPrint "overlay payload extraction failed with exit code $0"
+    Call RollbackFailedInstall
     Abort
   \${EndIf}
+  IfFileExists "$InstallReplacementDir\\${exeName}" staged_launcher_ready staged_launcher_missing
+staged_launcher_missing:
+  Call RollbackFailedInstall
+  Abort "$(InstallDirectoryRemoveFailed)"
+staged_launcher_ready:
 
+  !insertmacro LOG_PATH_STATE "replacement_dir_after_extract" "$InstallReplacementDir"
+  !insertmacro LOG_PATH_STATE "replacement_exe_after_extract" "$InstallReplacementDir\\${exeName}"
+  ClearErrors
+  WriteUninstaller "$InstallReplacementDir\\${uninstallerName}"
+  IfErrors uninstaller_failed uninstaller_written
+uninstaller_failed:
+  Call RollbackFailedInstall
+  Abort "$(InstallDirectoryRemoveFailed)"
+uninstaller_written:
+  !insertmacro LOG_PATH_STATE "replacement_uninstaller_after_write" "$InstallReplacementDir\\${uninstallerName}"
+  Call CommitInstallDir
   !insertmacro LOG_PATH_STATE "install_dir_after_extract" "$INSTDIR"
   !insertmacro LOG_PATH_STATE "installed_exe_after_extract" "$INSTDIR\\${exeName}"
-  WriteUninstaller "$INSTDIR\\${uninstallerName}"
-  !insertmacro LOG_PATH_STATE "uninstaller_after_write" "$INSTDIR\\${uninstallerName}"
   SetOutPath "$INSTDIR"
   IfSilent 0 skip_silent_desktop_shortcut
   !insertmacro LOG_PATH_STATE "desktop_shortcut_before_create" "$DESKTOP\\${shortcutName}"
@@ -974,6 +1536,7 @@ skip_silent_desktop_shortcut:
   !insertmacro LOG_PATH_STATE "start_menu_shortcut_before_create" "$SMPROGRAMS\\${shortcutName}"
   CreateShortCut "$SMPROGRAMS\\${shortcutName}" "$INSTDIR\\${exeName}" "" "$INSTDIR\\${exeName}" 0
   !insertmacro LOG_PATH_STATE "start_menu_shortcut_after_create" "$SMPROGRAMS\\${shortcutName}"
+  ClearErrors
   WriteRegStr HKCU "${registryKey}" "DisplayName" "${productName}"
   WriteRegStr HKCU "${registryKey}" "DisplayVersion" "\${APP_VERSION}"
   WriteRegStr HKCU "${registryKey}" "InstallLocation" "$INSTDIR"
@@ -981,9 +1544,27 @@ skip_silent_desktop_shortcut:
   WriteRegStr HKCU "${registryKey}" "QuietUninstallString" '"$INSTDIR\\${uninstallerName}" /currentuser /S'
   WriteRegStr HKCU "${registryKey}" "DisplayIcon" "$INSTDIR\\${exeName},0"
   WriteRegStr HKCU "${appPathsKey}" "" "$INSTDIR\\${exeName}"
+  IfErrors registry_failed registry_written
+registry_failed:
+  Push "install finalization failed during registry write; transaction preserved at $InstallTransactionRoot"
+  Call LogInstallerEvent
+  \${If} $ExistingInstallTarget != "1"
+    Call CleanupCommittedInstallTransaction
+  \${EndIf}
+  Abort "$(InstallFinalizeFailed)"
+registry_written:
   Push "event=registry_after_write key=${registryKey} appPathsKey=${appPathsKey}"
   Call LogInstallerEvent
   Call SyncLauncherRuntime
+  \${If} $LauncherRuntimeSyncFailed == "1"
+    Push "install finalization failed during launcher runtime sync; transaction preserved at $InstallTransactionRoot"
+    Call LogInstallerEvent
+    \${If} $ExistingInstallTarget != "1"
+      Call CleanupCommittedInstallTransaction
+    \${EndIf}
+    Abort "$(InstallFinalizeFailed)"
+  \${EndIf}
+  Call CleanupCommittedInstallTransaction
   Push "install section done"
   Call LogInstallerEvent
 SectionEnd

--- a/tools/pack/tests/win-identity.test.ts
+++ b/tools/pack/tests/win-identity.test.ts
@@ -83,18 +83,96 @@ describe("resolveWinInstallIdentity", () => {
     expect(source).not.toContain('"DisplayName" "${productName} \\${APP_VERSION}"');
   });
 
-  it("checks the silent install target directory for running instances before overwriting files", async () => {
+  it("stages a complete replacement before publishing the stable launcher", async () => {
     const source = await readFile(new URL("../src/win/custom-installer.ts", import.meta.url), "utf8");
-    const silentCheck = source.slice(source.indexOf("silent_check:"), source.indexOf("IfFileExists \"$INSTDIR\\\\${exeName}\" existing_install"));
-    expect(silentCheck).toContain('IfFileExists "$INSTDIR\\\\${exeName}" 0 silent_detect_running_instances');
-    expect(silentCheck).toContain('StrCpy $RunningInstancesInstallRoot "$INSTDIR"');
-    expect(silentCheck.indexOf('StrCpy $RunningInstancesInstallRoot "$INSTDIR"')).toBeLessThan(
-      silentCheck.indexOf("Call DetectRunningInstances"),
+    const initialization = source.slice(source.indexOf("Function .onInit"), source.indexOf("Function RunningInstancesPage"));
+    const guard = source.slice(source.indexOf("Function GuardRunningInstancesBeforeInstall"), source.indexOf("Function DirectoryPageLeave"));
+    const transaction = source.slice(source.indexOf("Function PrepareInstallTransaction"), source.indexOf("Function un.UninstallOptionsPage"));
+    const recordTarget = source.slice(source.indexOf("Function RecordFreshInstallTargetState"), source.indexOf("Function InspectEmptyInstallDirBackup"));
+    const emptyTarget = source.slice(source.indexOf("Function QuarantineEmptyFreshInstallDir"), source.indexOf("Function CommitInstallDir"));
+    const committedCleanup = source.slice(source.indexOf("Function CleanupCommittedInstallTransaction"), source.indexOf("Function CleanupInstallTransaction"));
+    const install = source.slice(source.indexOf('Section "Install"'), source.indexOf("SectionEnd", source.indexOf('Section "Install"')));
+    const commitIndex = install.indexOf("Call CommitInstallDir");
+    const preCommit = install.slice(0, commitIndex);
+    const postCommit = install.slice(commitIndex);
+
+    expect(initialization).not.toContain("Call CloseRunningInstances");
+    expect(source).not.toContain("$ExistingInstallLocation");
+    expect(initialization).toContain('IfFileExists "$INSTDIR\\\\${exeName}" existing_install no_existing_install');
+    expect(guard).toContain('StrCpy $RunningInstancesInstallRoot "$INSTDIR"');
+    expect(guard.indexOf("Call CloseRunningInstances")).toBeLessThan(guard.lastIndexOf("Call DetectRunningInstances"));
+    expect(initialization).toContain('ReadRegStr $RegisteredInstallLocation HKCU "${registryKey}" "InstallLocation"');
+    expect(guard).toContain("Call GuardRegisteredInstallInstances");
+    expect(guard).toContain("Call CleanupAfterLauncherRestore");
+    expect(source).toContain("Function InspectInstallDir");
+    expect(source).toContain('FindFirst $0 $1 "$INSTDIR\\\\*"');
+    expect(install.split("Call InspectInstallDir").length - 1).toBe(2);
+    expect(install).not.toContain('IfFileExists "$INSTDIR\\\\*.*"');
+    expect(install.split('IfFileExists "$INSTDIR\\\\${exeName}"').length - 1).toBe(2);
+
+    expect(source).toContain('GetTempFileName $InstallTransactionRoot "$0"');
+    expect(source).toContain('CreateDirectory "$InstallTransactionRoot"');
+    expect(source).not.toContain("GetTempFileName $InstallLauncherBackup");
+    expect(source).toContain('StrCpy $InstallLauncherBackup "$InstallTransactionRoot\\\\launcher"');
+    expect(source).toContain('StrCpy $InstallDirBackup "$InstallTransactionRoot\\\\previous"');
+    expect(source).toContain('StrCpy $InstallReplacementDir "$InstallTransactionRoot\\\\replacement"');
+    expect(source).toContain('StrCpy $EmptyInstallDirBackup "$InstallTransactionRoot\\\\empty-target"');
+    expect(source).not.toContain("$FailedInstallDir");
+    expect(source).toContain('Rename "$InstallLauncherBackup" "$InstallDirBackup\\\\${exeName}"');
+    expect(source).toContain('Rename "$INSTDIR" "$InstallDirBackup"');
+    expect(source).toContain('Rename "$InstallDirBackup" "$INSTDIR"');
+    expect(source).toContain('Rename "$InstallReplacementDir" "$INSTDIR"');
+    expect(transaction).not.toContain('RMDir "$INSTDIR"');
+    expect(transaction).not.toContain('RMDir /r "$INSTDIR"');
+    expect(source).toContain('\\${GetParent} "$INSTDIR" $0');
+    expect(source).toContain('\\${GetRoot} "$0" $1');
+    expect(source).not.toContain("$EmptyInstallDirRemoved");
+    expect(emptyTarget).toContain('Rename "$INSTDIR" "$EmptyInstallDirBackup"');
+    expect(emptyTarget).toContain('Rename "$EmptyInstallDirBackup" "$INSTDIR"');
+    expect(emptyTarget).not.toContain('CreateDirectory "$INSTDIR"');
+    expect(recordTarget).toContain('\\${GetFileAttributes} "$INSTDIR" "DIRECTORY"');
+    expect(recordTarget).toContain('\\${GetFileAttributes} "$INSTDIR" "REPARSE_POINT"');
+    expect(recordTarget).toContain('StrCpy $FreshInstallTargetWasEmpty "1"');
+    expect(emptyTarget).toContain('$FreshInstallTargetWasEmpty != "1"');
+    expect(emptyTarget).toContain("Call InspectEmptyInstallDirBackup");
+    expect(emptyTarget).toContain("fresh install target changed while it was quarantined");
+    expect(emptyTarget.split('\\${GetFileAttributes} "$EmptyInstallDirBackup"').length - 1).toBe(2);
+    expect(committedCleanup).toContain('RMDir "$EmptyInstallDirBackup"');
+    expect(committedCleanup).toContain("committed install cleanup preserved a changed empty target");
+    expect(committedCleanup.split('\\${GetFileAttributes} "$EmptyInstallDirBackup"').length - 1).toBe(2);
+
+    expect(install.indexOf('File "/oname=$PLUGINSDIR\\\\payload-base.7z"')).toBeLessThan(
+      install.indexOf("Call GuardRunningInstancesBeforeInstall"),
     );
+    expect(install.indexOf("Call GuardRunningInstancesBeforeInstall")).toBeLessThan(
+      install.indexOf("Call QuarantineInstallDir"),
+    );
+    expect(install.indexOf("Call RecordFreshInstallTargetState")).toBeLessThan(
+      install.indexOf("Call PrepareInstallTransaction"),
+    );
+    expect(install.indexOf("Call QuarantineEmptyFreshInstallDir")).toBeLessThan(
+      install.indexOf('CreateDirectory "$InstallReplacementDir"'),
+    );
+    expect(preCommit).toContain('"-o$InstallReplacementDir"');
+    expect(preCommit).not.toContain('"-o$INSTDIR"');
+    expect(preCommit).toContain('WriteUninstaller "$InstallReplacementDir\\\\${uninstallerName}"');
+    expect(preCommit.indexOf("payload overlay extraction start")).toBeLessThan(
+      preCommit.indexOf('WriteUninstaller "$InstallReplacementDir\\\\${uninstallerName}"'),
+    );
+    expect(postCommit).not.toContain("Call RollbackFailedInstall");
+    expect(postCommit.indexOf("Call CommitInstallDir")).toBeLessThan(postCommit.indexOf('SetOutPath "$INSTDIR"'));
+    expect(transaction).toContain("failed fresh install staging removed; target restored unchanged");
+    expect(transaction).toContain("fresh install target changed before staging");
+    expect(transaction).toContain("target reappeared; previous install preserved");
+    expect(transaction).toContain("replacement commit blocked by a recreated target");
+    expect(transaction).toContain("Call RestoreEmptyFreshInstallDir");
+    expect(transaction).toContain("launcher restore incomplete; transaction preserved");
+    expect(transaction).not.toContain('rmdir /s /q "\\\\\\\\?\\\\$INSTDIR"');
   });
 
   it("syncs launcher runtime metadata after a successful Windows install", async () => {
     const source = await readFile(new URL("../src/win/custom-installer.ts", import.meta.url), "utf8");
+    const latePublish = source.slice(source.lastIndexOf("registry_failed:"), source.indexOf('Push "install section done"'));
     expect(source).toContain("Function SyncLauncherRuntime");
     expect(source).toContain("sync-launcher-runtime.ps1");
     expect(source).toContain("-CleanupPath");
@@ -102,10 +180,16 @@ describe("resolveWinInstallIdentity", () => {
     expect(source).toContain("older-than-bound-package");
     expect(source).toContain("[System.IO.File]::WriteAllText($CleanupPath");
     expect(source).toContain('Push "event=launcher_runtime_after_write path=${escapedRuntimePath}"');
+    expect(source).toContain('$LauncherRuntimeSyncFailed "1"');
+    expect(source).toContain("IfErrors registry_failed registry_written");
+    expect(source).toContain("Call CleanupCommittedInstallTransaction");
+    expect(latePublish).not.toContain("Call RollbackFailedInstall");
+    expect(latePublish).toContain('Abort "$(InstallFinalizeFailed)"');
     expect(source.indexOf('Push "event=registry_after_write key=${registryKey} appPathsKey=${appPathsKey}"')).toBeLessThan(
       source.indexOf("Call SyncLauncherRuntime"),
     );
     expect(source.indexOf("Call SyncLauncherRuntime")).toBeLessThan(source.indexOf('Push "install section done"'));
+    expect(source.indexOf("Call SyncLauncherRuntime")).toBeLessThan(source.lastIndexOf("Call CleanupCommittedInstallTransaction"));
   });
 
   it.skipIf(process.platform !== "win32")("writes cleanup metadata when installer runtime sync supersedes an older runtime", async () => {

--- a/tools/pack/tests/win-running-instances.test.ts
+++ b/tools/pack/tests/win-running-instances.test.ts
@@ -1,0 +1,301 @@
+import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { once } from "node:events";
+import { access, copyFile, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+import { createRunningInstancesScript } from "../src/win/custom-installer.js";
+
+const execFileAsync = promisify(execFile);
+
+async function waitForOutput(child: ChildProcess, marker: string): Promise<void> {
+  const stdout = child.stdout;
+  if (stdout == null) throw new Error("child stdout is not piped");
+  const { promise, resolve, reject } = Promise.withResolvers<void>();
+  let output = "";
+  stdout.on("data", (chunk) => {
+    output += String(chunk);
+    if (output.includes(marker)) resolve();
+  });
+  child.once("error", reject);
+  child.once("exit", (code) => reject(new Error(`child exited before ${marker}: ${code ?? "signal"}`)));
+  await promise;
+}
+
+describe("Windows installer running-instance guard", () => {
+  it.skipIf(process.platform !== "win32")(
+    "quarantines the launcher before killing processes that an external client auto-respawns",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "od-installer-respawn-"));
+      const executablePath = join(root, "Open Design.exe");
+      const launcherBackupPath = `${root}.open-design-update-launcher.old`;
+      const helperPath = join(root, "running-instances.ps1");
+      const watcherPath = join(root, "watcher.cjs");
+      const powershellPath = join(
+        process.env.SystemRoot ?? "C:\\Windows",
+        "System32",
+        "WindowsPowerShell",
+        "v1.0",
+        "powershell.exe",
+      );
+      let watcher: ChildProcess | null = null;
+
+      const runHelper = async (action: "close" | "detect") => {
+        const result = await execFileAsync(
+          powershellPath,
+          [
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            helperPath,
+            action,
+            root,
+            "Open Design.exe",
+            launcherBackupPath,
+          ],
+          { windowsHide: true },
+        );
+        return result.stdout.trim();
+      };
+
+      try {
+        await copyFile(process.execPath, executablePath);
+        await writeFile(helperPath, createRunningInstancesScript(), "utf8");
+        await writeFile(
+          watcherPath,
+          `const { existsSync } = require("node:fs");
+const { spawn } = require("node:child_process");
+const [executablePath] = process.argv.slice(2);
+let child = null;
+let spawnCount = 0;
+let stopping = false;
+function startChild() {
+  if (stopping || child !== null || !existsSync(executablePath)) return;
+  let candidate;
+  try {
+    candidate = spawn(executablePath, ["-e", "process.stdin.resume()"], {
+      stdio: ["pipe", "ignore", "ignore"],
+      windowsHide: true,
+    });
+  } catch {
+    return;
+  }
+  child = candidate;
+  child.once("spawn", () => {
+    spawnCount += 1;
+    process.stdout.write("spawn:" + spawnCount + ":" + child.pid + "\\n");
+  });
+  child.once("error", () => {
+    child = null;
+  });
+  child.once("exit", () => {
+    child = null;
+  });
+}
+const retry = setInterval(startChild, 25);
+function stop() {
+  if (stopping) return;
+  stopping = true;
+  clearInterval(retry);
+  if (child === null) process.exit(0);
+  child.once("exit", () => process.exit(0));
+  child.kill();
+}
+process.on("SIGINT", stop);
+process.on("SIGTERM", stop);
+startChild();
+`,
+          "utf8",
+        );
+
+        watcher = spawn(process.execPath, [watcherPath, executablePath], {
+          stdio: ["ignore", "pipe", "ignore"],
+          windowsHide: true,
+        });
+        await waitForOutput(watcher, "spawn:1:");
+
+        await runHelper("close");
+
+        await expect(access(executablePath)).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(access(launcherBackupPath)).resolves.toBeUndefined();
+        expect((await stat(launcherBackupPath)).size).toBeGreaterThan(0);
+        expect(await runHelper("detect")).toBe("");
+
+        const respawned = waitForOutput(watcher, "spawn:2:");
+        await copyFile(process.execPath, executablePath);
+        await respawned;
+        expect(await runHelper("detect")).not.toBe("");
+      } finally {
+        if (watcher != null && watcher.exitCode == null && watcher.pid != null) {
+          const exited = once(watcher, "exit");
+          await execFileAsync("taskkill", ["/pid", String(watcher.pid), "/t", "/f"], {
+            windowsHide: true,
+          }).catch(() => {});
+          await exited;
+        }
+        await rm(launcherBackupPath, { force: true });
+        await rm(root, { force: true, recursive: true });
+      }
+    },
+    40_000,
+  );
+  it.skipIf(process.platform !== "win32")(
+    "preserves both launchers when restore finds a recreated original",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "od-installer-restore-conflict-"));
+      const originalPath = join(root, "Open Design.exe");
+      const quarantinePath = join(root, "Open Design.exe.quarantine");
+      const helperPath = join(root, "restore-launchers.ps1");
+      const powershellPath = join(
+        process.env.SystemRoot ?? "C:\\Windows",
+        "System32",
+        "WindowsPowerShell",
+        "v1.0",
+        "powershell.exe",
+      );
+      const generatedScript = createRunningInstancesScript();
+      const restoreStart = generatedScript.indexOf("function Restore-Launchers {");
+      const restoreEnd = generatedScript.indexOf("\nfunction Get-LiveProcess", restoreStart);
+
+      expect(restoreStart).toBeGreaterThanOrEqual(0);
+      expect(restoreEnd).toBeGreaterThan(restoreStart);
+
+      try {
+        await writeFile(originalPath, "recreated-launcher", "utf8");
+        await writeFile(quarantinePath, "quarantined-launcher", "utf8");
+        await writeFile(
+          helperPath,
+          `$ErrorActionPreference = "Stop"
+${generatedScript.slice(restoreStart, restoreEnd)}
+Restore-Launchers @([pscustomobject]@{ Original = $args[0]; Quarantine = $args[1] })
+`,
+          "utf8",
+        );
+
+        await expect(
+          execFileAsync(
+            powershellPath,
+            ["-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", helperPath, originalPath, quarantinePath],
+            { windowsHide: true },
+          ),
+        ).rejects.toMatchObject({ stderr: expect.stringContaining("launcher restore conflict") });
+        await expect(readFile(originalPath, "utf8")).resolves.toBe("recreated-launcher");
+        await expect(readFile(quarantinePath, "utf8")).resolves.toBe("quarantined-launcher");
+      } finally {
+        await rm(root, { force: true, recursive: true });
+      }
+    },
+    20_000,
+  );
+  it.skipIf(process.platform !== "win32")(
+    "preserves both launchers when the original reappears during restore",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "od-installer-restore-race-"));
+      const originalPath = join(root, "Open Design.exe");
+      const quarantinePath = join(root, "Open Design.exe.quarantine");
+      const helperPath = join(root, "restore-launchers.ps1");
+      const powershellPath = join(
+        process.env.SystemRoot ?? "C:\\Windows",
+        "System32",
+        "WindowsPowerShell",
+        "v1.0",
+        "powershell.exe",
+      );
+      const generatedScript = createRunningInstancesScript();
+      const restoreStart = generatedScript.indexOf("function Restore-Launchers {");
+      const restoreEnd = generatedScript.indexOf("\nfunction Get-LiveProcess", restoreStart);
+
+      expect(restoreStart).toBeGreaterThanOrEqual(0);
+      expect(restoreEnd).toBeGreaterThan(restoreStart);
+
+      try {
+        await writeFile(quarantinePath, "quarantined-launcher", "utf8");
+        await writeFile(
+          helperPath,
+          `param([string]$OriginalPath, [string]$QuarantinePath)
+$ErrorActionPreference = "Stop"
+${generatedScript.slice(restoreStart, restoreEnd)}
+$script:OriginalPath = $OriginalPath
+$script:Recreated = $false
+$script:NativeTestPath = Get-Command -Name Test-Path -CommandType Cmdlet
+function Test-Path {
+  param([string]$LiteralPath, [string]$PathType)
+  if (-not $script:Recreated -and $LiteralPath -eq $script:OriginalPath -and -not $PSBoundParameters.ContainsKey("PathType")) {
+    [System.IO.File]::WriteAllText($LiteralPath, "recreated-launcher")
+    $script:Recreated = $true
+    return $false
+  }
+  if ($PSBoundParameters.ContainsKey("PathType")) {
+    return (& $script:NativeTestPath -LiteralPath $LiteralPath -PathType $PathType)
+  }
+  return (& $script:NativeTestPath -LiteralPath $LiteralPath)
+}
+Restore-Launchers @([pscustomobject]@{ Original = $OriginalPath; Quarantine = $QuarantinePath })
+`,
+          "utf8",
+        );
+        await expect(
+          execFileAsync(
+            powershellPath,
+            ["-NoLogo", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", helperPath, originalPath, quarantinePath],
+            { windowsHide: true },
+          ),
+        ).rejects.toMatchObject({ stderr: expect.any(String) });
+        await expect(readFile(originalPath, "utf8")).resolves.toBe("recreated-launcher");
+        await expect(readFile(quarantinePath, "utf8")).resolves.toBe("quarantined-launcher");
+      } finally {
+        await rm(root, { force: true, recursive: true });
+      }
+    },
+    20_000,
+  );
+
+  it.skipIf(process.platform !== "win32")(
+    "fails closed when an existing target loses its launcher before quarantine",
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "od-installer-missing-launcher-"));
+      const helperPath = join(root, "running-instances.ps1");
+      const launcherBackupPath = join(root, "launcher-backup.exe");
+      const powershellPath = join(
+        process.env.SystemRoot ?? "C:\\Windows",
+        "System32",
+        "WindowsPowerShell",
+        "v1.0",
+        "powershell.exe",
+      );
+
+      try {
+        await writeFile(helperPath, createRunningInstancesScript(), "utf8");
+        await expect(
+          execFileAsync(
+            powershellPath,
+            [
+              "-NoLogo",
+              "-NoProfile",
+              "-NonInteractive",
+              "-ExecutionPolicy",
+              "Bypass",
+              "-File",
+              helperPath,
+              "close",
+              root,
+              "Open Design.exe",
+              launcherBackupPath,
+            ],
+            { windowsHide: true },
+          ),
+        ).rejects.toMatchObject({ stderr: expect.stringContaining("expected launcher is missing") });
+        await expect(access(launcherBackupPath)).rejects.toMatchObject({ code: "ENOENT" });
+      } finally {
+        await rm(root, { force: true, recursive: true });
+      }
+    },
+    20_000,
+  );
+});


### PR DESCRIPTION
## Why

I encountered a Windows update-safety failure mode in the packaged installer: an external MCP or client process can automatically respawn the installed launcher after the installer closes it. That race can reintroduce the target executable while NSIS is replacing it, risking a partial replacement or loss of the prior working installation. This change makes the update path transactional so the old installation remains recoverable until the replacement and registration steps have completed.

## What users will see

When updating Open Design on Windows, the installer now protects the active launcher before stopping running instances, stages the replacement separately, and publishes it only after the transaction can safely commit. If the target reappears or changes during the update, installation fails closed while preserving the prior installation or changed target instead of overwriting it.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this changes the non-interactive Windows installer update transaction; no application UI is added or changed.

## Bug fix verification

- Regression coverage: `tools/pack/tests/win-identity.test.ts` validates staging, commit, rollback, and changed-target preservation contracts; `tools/pack/tests/win-running-instances.test.ts` exercises an externally respawning launcher on Windows and the restore-conflict race. The final focused run covered 5 tools-pack files and 25 tests. The installer itself was not run.

## Validation

- Final focused verification: 5 tools-pack files / 25 tests, one worker.
- `tools-pack` build and typecheck passed.
- Root guard and root typecheck passed.
- Independent code review: **APPROVE**.
- The installer was not run.
