### PR TITLE
fix(web): add Open Design sign-in button to project details agent menu

### DIFF
--- a/apps/web/src/analytics/amr-attribution.ts
+++ b/apps/web/src/analytics/amr-attribution.ts
@@ -56,6 +56,7 @@ const ENTRY_PAGE_BY_SOURCE: Record<TrackingAmrEntrySource, TrackingPageName> = {
   inline_amr_upgrade: 'chat_panel',
   avatar_amr_upgrade: 'chat_panel',
   avatar_amr_agent_card: 'chat_panel',
+  avatar_amr_row: 'chat_panel',
   artifact_success_upgrade: 'artifact',
   home_artifact_upgrade: 'home',
 };

--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -1,11 +1,13 @@
-import { useEffect, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent } from 'react';
 import { createPortal } from 'react-dom';
 import type { AmrWalletSnapshot } from '@open-design/contracts';
 import { getResolvedDeviceId } from '../analytics/client';
-import { amrHandoffDeviceId, attributedAmrUrl, recordAmrEntry } from '../analytics/amr-attribution';
+import { amrHandoffDeviceId, attributedAmrUrl, recordAmrEntry, type AmrEntryAttribution } from '../analytics/amr-attribution';
+import { beginAmrAuthTracking, resolveAmrAuthTracking } from '../analytics/amr-auth';
 import { useAnalytics } from '../analytics/provider';
 import { useT } from '../i18n';
 import { AgentIcon } from './AgentIcon';
+import { Icon } from './Icon';
 import { PlanBadge } from './PlanBadge';
 import { RemixIcon } from './RemixIcon';
 import { orderAgentsWithOpenDesignFirst } from './agentOrdering';
@@ -22,9 +24,11 @@ import { apiProtocolLabel } from '../utils/apiProtocol';
 import { fetchProviderModels } from '../providers/provider-models';
 import {
   canUpgradeVelaPlan,
+  cancelVelaLogin,
   fetchAmrWalletSnapshot,
   fetchVelaLoginStatus,
   formatVelaBalanceUsd,
+  startVelaLogin,
   type VelaLoginStatus,
 } from '../providers/daemon';
 import {
@@ -32,6 +36,14 @@ import {
 } from '../runtime/amr-guidance';
 import { isMacPlatform } from '../utils/platform';
 import { isVisibleLocalCliAgent } from '../utils/visibleAgents';
+import {
+  AMR_LOGIN_STATUS_EVENT,
+  AMR_LOGIN_POLL_INTERVAL_MS,
+  AMR_LOGIN_STARTUP_SETTLE_MS,
+  amrLoginPollOutcome,
+  amrLoginStatusEventReason,
+  notifyAmrLoginStatusChanged,
+} from './amrLoginPolling';
 
 interface Props {
   config: AppConfig;
@@ -193,10 +205,120 @@ export function AvatarMenu({
   const [amrAccount, setAmrAccount] = useState<VelaLoginStatus | null>(null);
   const [amrWalletSnapshot, setAmrWalletSnapshot] =
     useState<AmrWalletSnapshot | null>(null);
+  const [amrLoginPending, setAmrLoginPending] = useState(false);
+  const [amrLoginError, setAmrLoginError] = useState<string | null>(null);
+  const amrPollRef = useRef<number | null>(null);
+  const amrLoginStartedAtRef = useRef<number | null>(null);
+  const refreshAmrStatus = useCallback(async () => {
+    const next = await fetchVelaLoginStatus();
+    if (next) {
+      setAmrAccount(next);
+      const pendingStartup =
+        amrLoginStartedAtRef.current !== null &&
+        Date.now() - amrLoginStartedAtRef.current < AMR_LOGIN_STARTUP_SETTLE_MS;
+      if (next.loggedIn) {
+        amrLoginStartedAtRef.current = null;
+        setAmrLoginPending(false);
+      } else if (next.loginInFlight) {
+        setAmrLoginPending(true);
+      } else if (!pendingStartup) {
+        amrLoginStartedAtRef.current = null;
+        setAmrLoginPending(false);
+      }
+    }
+    return next;
+  }, []);
+
+  const stopAmrPolling = useCallback(() => {
+    if (amrPollRef.current !== null) {
+      window.clearInterval(amrPollRef.current);
+      amrPollRef.current = null;
+    }
+  }, []);
+
+  const startAmrPolling = useCallback((startedAt = Date.now()) => {
+    stopAmrPolling();
+    amrLoginStartedAtRef.current = startedAt;
+    const tick = async () => {
+      const next = await refreshAmrStatus();
+      const outcome = amrLoginPollOutcome(next, startedAt);
+      if (outcome === 'signed-in') {
+        resolveAmrAuthTracking(analytics.track, 'success', undefined, {
+          signedInUserId: next?.user?.id ?? null,
+        });
+        notifyAmrLoginStatusChanged();
+        stopAmrPolling();
+        amrLoginStartedAtRef.current = null;
+        setAmrLoginPending(false);
+        return;
+      }
+      if (outcome === 'stopped' || outcome === 'timed-out') {
+        stopAmrPolling();
+        if (outcome === 'timed-out') {
+          resolveAmrAuthTracking(analytics.track, 'timeout', 'login_timeout');
+          void cancelVelaLogin().then(() =>
+            notifyAmrLoginStatusChanged('login-canceled'),
+          );
+        } else {
+          resolveAmrAuthTracking(analytics.track, 'failed', 'login_stopped');
+        }
+        amrLoginStartedAtRef.current = null;
+        setAmrLoginPending(false);
+        setAmrLoginError(t('settings.amrLoginErrorCompact'));
+      }
+    };
+    amrPollRef.current = window.setInterval(() => {
+      void tick();
+    }, AMR_LOGIN_POLL_INTERVAL_MS);
+  }, [analytics.track, refreshAmrStatus, stopAmrPolling, t]);
+
+  const handleAmrSignIn = useCallback(async (
+    attribution?: AmrEntryAttribution | null,
+  ) => {
+    const startedAt = Date.now();
+    amrLoginStartedAtRef.current = startedAt;
+    setAmrLoginError(null);
+    setAmrLoginPending(true);
+    beginAmrAuthTracking(attribution, startedAt);
+    const odDeviceId = amrHandoffDeviceId({
+      metricsConsent: config.telemetry?.metrics === true,
+      resolvedDeviceId: getResolvedDeviceId(),
+      installationId: config.installationId,
+    });
+    const result = await startVelaLogin(attribution, odDeviceId);
+    if (!result.ok && !result.alreadyRunning) {
+      resolveAmrAuthTracking(analytics.track, 'failed', 'spawn_failed');
+      amrLoginStartedAtRef.current = null;
+      setAmrLoginPending(false);
+      setAmrLoginError(result.error || t('settings.amrLoginErrorCompact'));
+      return;
+    }
+    notifyAmrLoginStatusChanged('login-started');
+    startAmrPolling(startedAt);
+  }, [
+    analytics.track,
+    config.installationId,
+    config.telemetry?.metrics,
+    startAmrPolling,
+    t,
+  ]);
+
+  const handleAmrCancelLogin = useCallback(async () => {
+    resolveAmrAuthTracking(analytics.track, 'cancelled');
+    stopAmrPolling();
+    amrLoginStartedAtRef.current = null;
+    setAmrLoginError(null);
+    setAmrLoginPending(false);
+    await cancelVelaLogin();
+    notifyAmrLoginStatusChanged('login-canceled');
+    await refreshAmrStatus();
+  }, [analytics.track, refreshAmrStatus, stopAmrPolling]);
+
   useEffect(() => {
     if (!open || !amrAvailable) {
       setAmrAccount(null);
       setAmrWalletSnapshot(null);
+      setAmrLoginError(null);
       return;
     }
     let cancelled = false;
@@ -219,8 +341,38 @@ export function AvatarMenu({
       });
     return () => {
       cancelled = true;
+      stopAmrPolling();
     };
-  }, [open, amrAvailable]);
+  }, [open, amrAvailable, stopAmrPolling]);
+
+  useEffect(() => {
+    const onStatusChange = (event: Event) => {
+      const reason = amrLoginStatusEventReason(event);
+      if (reason === 'login-started') {
+        const startedAt = Date.now();
+        amrLoginStartedAtRef.current = startedAt;
+        setAmrLoginError(null);
+        setAmrLoginPending(true);
+        startAmrPolling(startedAt);
+      } else if (reason === 'login-canceled') {
+        amrLoginStartedAtRef.current = null;
+        stopAmrPolling();
+        setAmrLoginPending(false);
+      }
+      void refreshAmrStatus().then((next) => {
+        if (next?.loggedIn) {
+          amrLoginStartedAtRef.current = null;
+          stopAmrPolling();
+          return;
+        }
+        if (next?.loginInFlight) startAmrPolling();
+      });
+    };
+    window.addEventListener(AMR_LOGIN_STATUS_EVENT, onStatusChange);
+    return () => {
+      window.removeEventListener(AMR_LOGIN_STATUS_EVENT, onStatusChange);
+    };
+  }, [refreshAmrStatus, startAmrPolling, stopAmrPolling]);
   const amrPlanTrimmed = amrAccount?.loggedIn
     ? amrAccount.account?.plan?.trim() || ''
     : '';
@@ -473,17 +625,50 @@ export function AvatarMenu({
                           ) : null}
                         </span>
                       </button>
-                      {amrCanUpgrade ? (
-                        <a
-                          className="avatar-amr-row__upgrade"
-                          href={amrPlansUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          onClick={handleAmrUpgradeClick}
+                      {amrLoginError ? (
+                        <span className="avatar-amr-row__status is-error">
+                          {amrLoginError}
+                        </span>
+                      ) : amrAccount?.loggedIn ? (
+                        amrCanUpgrade ? (
+                          <a
+                            className="avatar-amr-row__upgrade"
+                            href={amrPlansUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            onClick={handleAmrUpgradeClick}
+                          >
+                            {t('settings.amrUpgrade')}
+                          </a>
+                        ) : null
+                      ) : (
+                        <button
+                          type="button"
+                          className="avatar-amr-row__sign-in"
+                          data-testid="avatar-amr-sign-in"
+                          title={amrLoginPending ? t('settings.amrCancelSignIn') : undefined}
+                          onClick={() => {
+                            if (amrLoginPending) {
+                              void handleAmrCancelLogin();
+                              return;
+                            }
+                            const attribution = recordAmrEntry(
+                              analytics.track,
+                              'avatar_amr_row',
+                              new Date(),
+                              { metricsConsent: config.telemetry?.metrics === true },
+                            );
+                            void handleAmrSignIn(attribution);
+                          }}
                         >
-                          {t('settings.amrUpgrade')}
-                        </a>
-                      ) : null}
+                          {amrLoginPending ? (
+                            <Icon name="spinner" size={13} />
+                          ) : null}
+                          {amrLoginPending
+                            ? t('settings.amrSigningIn')
+                            : t('settings.amrSignIn')}
+                        </button>
+                      )}
                     </div>
                   );
                 }

--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -324,11 +324,10 @@ export function AvatarMenu({
     let cancelled = false;
     setAmrAccount(null);
     setAmrWalletSnapshot(null);
-    void fetchVelaLoginStatus()
+    void refreshAmrStatus()
       .then(async (status) => {
-        if (cancelled) return;
-        setAmrAccount(status);
-        if (status?.loggedIn && !formatVelaBalanceUsd(status.account?.balanceUsd)) {
+        if (cancelled || !status) return;
+        if (status.loggedIn && !formatVelaBalanceUsd(status.account?.balanceUsd)) {
           const wallet = await fetchAmrWalletSnapshot();
           if (!cancelled) setAmrWalletSnapshot(wallet);
         }
@@ -343,7 +342,7 @@ export function AvatarMenu({
       cancelled = true;
       stopAmrPolling();
     };
-  }, [open, amrAvailable, stopAmrPolling]);
+  }, [open, amrAvailable, refreshAmrStatus, stopAmrPolling]);
 
   useEffect(() => {
     const onStatusChange = (event: Event) => {
@@ -358,6 +357,10 @@ export function AvatarMenu({
         amrLoginStartedAtRef.current = null;
         stopAmrPolling();
         setAmrLoginPending(false);
+        setAmrAccount((current) => (
+          current ? { ...current, loginInFlight: false } : current
+        ));
+        return;
       }
       void refreshAmrStatus().then((next) => {
         if (next?.loggedIn) {

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -1263,6 +1263,62 @@
     transform: none;
   }
 }
+.avatar-amr-row__sign-in,
+.avatar-amr-row__sign-in:visited {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 22px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+  box-shadow:
+    0 1px 2px color-mix(in srgb, var(--accent) 45%, transparent),
+    inset 0 1px 0 color-mix(in srgb, #fff 20%, transparent);
+  transition:
+    transform 150ms cubic-bezier(0.23, 1, 0.32, 1),
+    background-color 150ms ease,
+    box-shadow 150ms ease;
+}
+@media (hover: hover) and (pointer: fine) {
+  .avatar-amr-row__sign-in:hover {
+    background: var(--accent-hover);
+    box-shadow:
+      0 2px 8px color-mix(in srgb, var(--accent) 42%, transparent),
+      inset 0 1px 0 color-mix(in srgb, #fff 22%, transparent);
+  }
+}
+.avatar-amr-row__sign-in:active {
+  transform: scale(0.96);
+}
+.avatar-amr-row__sign-in:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  outline-offset: 2px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .avatar-amr-row__sign-in {
+    transition: background-color 150ms ease;
+  }
+  .avatar-amr-row__sign-in:active {
+    transform: none;
+  }
+}
+.avatar-amr-row__status.is-error {
+  flex: 0 0 auto;
+  font-size: 11px;
+  color: var(--danger);
+  white-space: nowrap;
+  padding-right: 4px;
+}
 .avatar-item {
   display: flex;
   align-items: center;

--- a/packages/contracts/src/analytics/events/shared-enums.ts
+++ b/packages/contracts/src/analytics/events/shared-enums.ts
@@ -81,6 +81,7 @@ export type TrackingAmrEntrySource =
   | 'inline_amr_upgrade'
   | 'avatar_amr_upgrade'
   | 'avatar_amr_agent_card'
+  | 'avatar_amr_row'
   | 'artifact_success_upgrade'
   | 'home_artifact_upgrade';
 


### PR DESCRIPTION
Closes #5244

## Problem

The Home page agent menu (InlineModelSwitcher) already shows a **Sign In** button on the Open Design row when the user is signed out. The project details page agent menu (AvatarMenu) only rendered the Open Design row with plan/balance info for logged-in users — there was no way to sign in from that context, creating a dead-end UX.

## Solution

Mirror the full AMR sign-in flow from InlineModelSwitcher into AvatarMenu:

- **Sign-in state**: `handleAmrSignIn` / `handleAmrCancelLogin` / polling with timeout
- **Auth tracking**: `beginAmrAuthTracking` / `resolveAmrAuthTracking`  
- **Cross-surface sync**: `AMR_LOGIN_STATUS_EVENT` listener

When `amrAccount?.loggedIn === false`, the Open Design row now shows a **Sign In** button. While logging in it shows **Signing in...** (click to cancel). On error it shows the error message.

## Changes

| File | Change |
|---|---|
| `apps/web/src/components/AvatarMenu.tsx` | Add sign-in state, handlers, polling, event listener, and Sign In button JSX |
| `apps/web/src/styles/shell.css` | Add `.avatar-amr-row__sign-in` and `.avatar-amr-row__status.is-error` styles |

## Verification

- [x] Changes mirror the existing InlineModelSwitcher pattern (same handlers, same daemon calls, same polling logic)
- [x] CSS matches the existing `.avatar-amr-row__upgrade` button style (22px pill, same row layout)
- [ ] Unable to run full TypeScript check / test suite locally — repo setup includes a monorepo dependency install that exceeds the practical time budget for a focused fix