### PR TITLE
fix(desktop): bound renderer log growth

### DIFF
--- a/apps/desktop/src/main/renderer-log.ts
+++ b/apps/desktop/src/main/renderer-log.ts
@@ -1,0 +1,308 @@
+import {
+  appendFile,
+  mkdir,
+  open,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { dirname } from "node:path";
+
+export const DEFAULT_RENDERER_LOG_MAX_BYTES = 10 * 1024 * 1024;
+export const DEFAULT_RENDERER_LOG_MAX_ENTRY_BYTES = 256 * 1024;
+
+export type RendererLogEntry = {
+  timestamp: string;
+  level: string;
+  text: string;
+};
+
+export type RotatingRendererLogWriterOptions = {
+  logPath: string;
+  maxBytes?: number;
+  onError?: (error: unknown) => void;
+};
+
+function isMissingFileError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
+export class RotatingRendererLogWriter {
+  readonly #logPath: string;
+  readonly #backupPath: string;
+  readonly #maxBytes: number;
+  readonly #onError?: (error: unknown) => void;
+  #currentBytes: number | null = null;
+  #pending: Promise<void> = Promise.resolve();
+
+  constructor(options: RotatingRendererLogWriterOptions) {
+    if (!Number.isSafeInteger(options.maxBytes ?? DEFAULT_RENDERER_LOG_MAX_BYTES)) {
+      throw new TypeError("renderer log maxBytes must be a safe integer");
+    }
+    if ((options.maxBytes ?? DEFAULT_RENDERER_LOG_MAX_BYTES) <= 0) {
+      throw new RangeError("renderer log maxBytes must be greater than zero");
+    }
+    this.#logPath = options.logPath;
+    this.#backupPath = `${options.logPath}.1`;
+    this.#maxBytes = options.maxBytes ?? DEFAULT_RENDERER_LOG_MAX_BYTES;
+    this.#onError = options.onError;
+  }
+
+  append(line: string): Promise<boolean> {
+    return this.#enqueue(() => this.#appendNow(line));
+  }
+
+  initialize(): Promise<boolean> {
+    return this.#enqueue(async () => {
+      if (this.#currentBytes == null) {
+        await this.#initializeSize();
+      }
+      return true;
+    });
+  }
+
+  flush(): Promise<void> {
+    return this.#pending;
+  }
+
+  #enqueue(operation: () => Promise<boolean>): Promise<boolean> {
+    const queued = this.#pending.then(operation);
+    this.#pending = queued.then(
+      () => undefined,
+      () => undefined,
+    );
+    return queued.catch((error: unknown) => {
+      this.#currentBytes = null;
+      try {
+        this.#onError?.(error);
+      } catch {
+        // A logging error callback must not escape into the caller.
+      }
+      return false;
+    });
+  }
+
+  async #appendNow(line: string): Promise<boolean> {
+    const lineBytes = Buffer.byteLength(line, "utf8");
+    if (lineBytes > this.#maxBytes) {
+      throw new RangeError("renderer log entry exceeds the configured file limit");
+    }
+
+    let currentBytes =
+      this.#currentBytes ?? (await this.#initializeSize());
+
+    if (
+      currentBytes > 0 &&
+      currentBytes + lineBytes > this.#maxBytes
+    ) {
+      await this.#rotate(currentBytes);
+      currentBytes = 0;
+    }
+
+    await appendFile(this.#logPath, line, "utf8");
+    this.#currentBytes = currentBytes + lineBytes;
+    return true;
+  }
+
+  async #initializeSize(): Promise<number> {
+    await mkdir(dirname(this.#logPath), { recursive: true });
+    await rm(`${this.#backupPath}.tmp`, { force: true });
+    await this.#normalizeExistingBackup();
+
+    let currentBytes: number;
+    try {
+      currentBytes = (await stat(this.#logPath)).size;
+    } catch (error) {
+      if (!isMissingFileError(error)) throw error;
+      currentBytes = 0;
+    }
+    if (currentBytes > this.#maxBytes) {
+      await this.#rotate(currentBytes);
+      currentBytes = 0;
+    } else if (currentBytes > 0) {
+      currentBytes = await this.#normalizeExistingFile(
+        this.#logPath,
+        currentBytes,
+      );
+    }
+    this.#currentBytes = currentBytes;
+    return currentBytes;
+  }
+
+  async #normalizeExistingBackup(): Promise<void> {
+    let backupBytes: number;
+    try {
+      backupBytes = (await stat(this.#backupPath)).size;
+    } catch (error) {
+      if (isMissingFileError(error)) return;
+      throw error;
+    }
+    await this.#normalizeExistingFile(this.#backupPath, backupBytes);
+  }
+
+  async #normalizeExistingFile(
+    path: string,
+    fileBytes: number,
+  ): Promise<number> {
+    const recentLines = await this.#readRecentCompleteLines(path, fileBytes);
+    if (recentLines.length === fileBytes) return fileBytes;
+
+    const target = await open(path, "r+");
+    try {
+      await target.truncate(0);
+      let bytesWritten = 0;
+      while (bytesWritten < recentLines.length) {
+        const result = await target.write(
+          recentLines,
+          bytesWritten,
+          recentLines.length - bytesWritten,
+          bytesWritten,
+        );
+        if (result.bytesWritten === 0) {
+          throw new Error("renderer log rewrite made no progress");
+        }
+        bytesWritten += result.bytesWritten;
+      }
+      await target.truncate(recentLines.length);
+    } finally {
+      await target.close();
+    }
+    return recentLines.length;
+  }
+
+  async #readRecentCompleteLines(
+    path: string,
+    fileBytes: number,
+  ): Promise<Buffer> {
+    const bytesToRead = Math.min(fileBytes, this.#maxBytes);
+    const startPosition = fileBytes - bytesToRead;
+    const buffer = Buffer.allocUnsafe(bytesToRead);
+    const source = await open(path, "r");
+    let bytesRead = 0;
+    try {
+      while (bytesRead < bytesToRead) {
+        const result = await source.read(
+          buffer,
+          bytesRead,
+          bytesToRead - bytesRead,
+          startPosition + bytesRead,
+        );
+        if (result.bytesRead === 0) break;
+        bytesRead += result.bytesRead;
+      }
+    } finally {
+      await source.close();
+    }
+
+    let recentLines = buffer.subarray(0, bytesRead);
+    if (startPosition > 0) {
+      const firstLineEnd = recentLines.indexOf(0x0a);
+      recentLines =
+        firstLineEnd === -1
+          ? recentLines.subarray(recentLines.length)
+          : recentLines.subarray(firstLineEnd + 1);
+    }
+    if (
+      recentLines.length > 0 &&
+      recentLines[recentLines.length - 1] !== 0x0a
+    ) {
+      const finalLineEnd = recentLines.lastIndexOf(0x0a);
+      recentLines =
+        finalLineEnd === -1
+          ? recentLines.subarray(recentLines.length)
+          : recentLines.subarray(0, finalLineEnd + 1);
+    }
+    return recentLines;
+  }
+
+  async #rotate(currentBytes: number): Promise<void> {
+    const temporaryBackupPath = `${this.#backupPath}.tmp`;
+    await rm(this.#backupPath, { force: true });
+    await rm(temporaryBackupPath, { force: true });
+
+    if (currentBytes <= this.#maxBytes) {
+      try {
+        await rename(this.#logPath, this.#backupPath);
+      } catch (error) {
+        if (!isMissingFileError(error)) throw error;
+      }
+      this.#currentBytes = 0;
+      return;
+    }
+
+    const recentLines = await this.#readRecentCompleteLines(
+      this.#logPath,
+      currentBytes,
+    );
+    await writeFile(temporaryBackupPath, recentLines);
+    await rename(temporaryBackupPath, this.#backupPath);
+    await rm(this.#logPath, { force: true });
+    this.#currentBytes = 0;
+  }
+}
+
+function truncateAtCodePointBoundary(text: string, length: number): string {
+  let safeLength = length;
+  if (safeLength > 0) {
+    const finalCodeUnit = text.charCodeAt(safeLength - 1);
+    const isHighSurrogate =
+      finalCodeUnit >= 0xd800 && finalCodeUnit <= 0xdbff;
+    const isLowSurrogate =
+      finalCodeUnit >= 0xdc00 && finalCodeUnit <= 0xdfff;
+    const previousCodeUnit =
+      safeLength > 1 ? text.charCodeAt(safeLength - 2) : -1;
+    const hasMatchingHighSurrogate =
+      previousCodeUnit >= 0xd800 && previousCodeUnit <= 0xdbff;
+    if (isHighSurrogate || (isLowSurrogate && !hasMatchingHighSurrogate)) {
+      safeLength -= 1;
+    }
+  }
+  return text.slice(0, safeLength);
+}
+
+export function serializeRendererLogEntry(
+  entry: RendererLogEntry,
+  maxLineBytes = DEFAULT_RENDERER_LOG_MAX_ENTRY_BYTES,
+): string {
+  if (!Number.isSafeInteger(maxLineBytes) || maxLineBytes <= 0) {
+    throw new RangeError("renderer log maxLineBytes must be a positive safe integer");
+  }
+
+  const serialize = (text: string): string =>
+    `${JSON.stringify({
+      timestamp: entry.timestamp,
+      level: entry.level,
+      text,
+    })}\n`;
+  const unmodified = serialize(entry.text);
+  if (Buffer.byteLength(unmodified, "utf8") <= maxLineBytes) {
+    return unmodified;
+  }
+
+  const originalBytes = Buffer.byteLength(entry.text, "utf8");
+  const suffix = `… [truncated from ${originalBytes} bytes]`;
+  let best = serialize(suffix);
+  if (Buffer.byteLength(best, "utf8") > maxLineBytes) {
+    throw new RangeError("renderer log line budget is too small for entry metadata");
+  }
+
+  let low = 0;
+  let high = entry.text.length;
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    const prefix = truncateAtCodePointBoundary(entry.text, middle);
+    const candidate = serialize(`${prefix}${suffix}`);
+    if (Buffer.byteLength(candidate, "utf8") <= maxLineBytes) {
+      best = candidate;
+      low = middle + 1;
+    } else {
+      high = middle - 1;
+    }
+  }
+  return best;
+}

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { createHmac, randomBytes } from "node:crypto";
-import { appendFile, mkdir, realpath, stat, writeFile } from "node:fs/promises";
+import { mkdir, realpath, stat, writeFile } from "node:fs/promises";
 import { release } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -33,6 +33,10 @@ import { exportArtifact as exportArtifactFromHtml } from "./artifact-export.js";
 import { createElectronPdfTarget, exportPdfFromHtml, savePrintReadyDocumentAsPdf } from "./pdf-export.js";
 import { SPLASH_VIDEO_DATA_URL } from "./splash-video.js";
 import { RendererCrashLoopBreaker } from "./renderer-crash-loop.js";
+import {
+  RotatingRendererLogWriter,
+  serializeRendererLogEntry,
+} from "./renderer-log.js";
 import type { PrintReadyPdfOptions } from "./pdf-export.js";
 import type { DesktopUpdater } from "./updater.js";
 import { parseDesktopUpdateMenuLabels } from "./update-menu.js";
@@ -2529,23 +2533,33 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
   }
 
   const rendererLogPath = options.rendererLogPath ?? null;
-  let rendererLogReady: Promise<void> | null = null;
-  const ensureRendererLogDir = async (): Promise<void> => {
-    if (rendererLogPath == null) return;
-    if (rendererLogReady == null) {
-      rendererLogReady = mkdir(dirname(rendererLogPath), { recursive: true }).then(() => undefined);
-    }
-    await rendererLogReady;
-  };
-  const persistRendererEntry = async (entry: DesktopConsoleEntry): Promise<void> => {
-    if (rendererLogPath == null) return;
-    if (entry.level !== "error" && entry.level !== "warn") return;
+  const rendererLogWriter =
+    rendererLogPath == null
+      ? null
+      : new RotatingRendererLogWriter({
+          logPath: rendererLogPath,
+          onError: (error) => {
+            console.error("desktop renderer log append failed", error);
+          },
+        });
+  void rendererLogWriter?.initialize();
+  let rendererLogClosed = false;
+  const persistRendererEntry = (entry: DesktopConsoleEntry): void => {
+    if (rendererLogClosed || rendererLogWriter == null) return;
+    if (
+      entry.level !== "error" &&
+      entry.level !== "warn" &&
+      entry.level !== "warning"
+    ) return;
     try {
-      await ensureRendererLogDir();
-      const line = `${JSON.stringify({ timestamp: entry.timestamp, level: entry.level, text: entry.text })}\n`;
-      await appendFile(rendererLogPath, line, "utf8");
+      const line = serializeRendererLogEntry({
+        timestamp: entry.timestamp,
+        level: entry.level,
+        text: entry.text,
+      });
+      void rendererLogWriter.append(line);
     } catch (error) {
-      console.error("desktop renderer log append failed", error);
+      console.error("desktop renderer log serialization failed", error);
     }
   };
 
@@ -2790,6 +2804,8 @@ export async function createDesktopRuntime(options: DesktopRuntimeOptions): Prom
     },
     async close() {
       stopped = true;
+      rendererLogClosed = true;
+      await rendererLogWriter?.flush();
       if (timer != null) {
         clearTimeout(timer);
         timer = null;

--- a/apps/desktop/tests/main/renderer-log.test.ts
+++ b/apps/desktop/tests/main/renderer-log.test.ts
@@ -1,0 +1,278 @@
+import { readFileSync } from "node:fs";
+import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  RotatingRendererLogWriter,
+  serializeRendererLogEntry,
+} from "../../src/main/renderer-log.js";
+
+const temporaryDirectories: string[] = [];
+
+async function createTemporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "open-design-renderer-log-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      rm(directory, { force: true, recursive: true }),
+    ),
+  );
+});
+
+describe("RotatingRendererLogWriter", () => {
+  test("serializes concurrent appends and rotates before the configured limit", async () => {
+    const directory = await createTemporaryDirectory();
+    const logPath = join(directory, "renderer.log");
+    const writer = new RotatingRendererLogWriter({
+      logPath,
+      maxBytes: 80,
+    });
+    const first = `${"a".repeat(30)}\n`;
+    const second = `${"b".repeat(30)}\n`;
+    const third = `${"c".repeat(30)}\n`;
+
+    await expect(
+      Promise.all([
+        writer.append(first),
+        writer.append(second),
+        writer.append(third),
+      ]),
+    ).resolves.toEqual([true, true, true]);
+
+    await expect(readFile(`${logPath}.1`, "utf8")).resolves.toBe(
+      `${first}${second}`,
+    );
+    await expect(readFile(logPath, "utf8")).resolves.toBe(third);
+    await expect(stat(logPath)).resolves.toMatchObject({ size: 31 });
+  });
+
+  test("bounds a pre-existing oversized log before writing a new entry", async () => {
+    const directory = await createTemporaryDirectory();
+    const logPath = join(directory, "renderer.log");
+    const oldLines = ["a", "b", "c"].map(
+      (letter) => `${letter.repeat(30)}\n`,
+    );
+    await writeFile(logPath, `${oldLines.join("")}partial`, "utf8");
+    const writer = new RotatingRendererLogWriter({
+      logPath,
+      maxBytes: 80,
+    });
+
+    await expect(writer.initialize()).resolves.toBe(true);
+    await expect(readFile(`${logPath}.1`, "utf8")).resolves.toBe(
+      `${oldLines[1]}${oldLines[2]}`,
+    );
+    await expect(stat(logPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(writer.append("new\n")).resolves.toBe(true);
+
+    await expect(readFile(`${logPath}.1`, "utf8")).resolves.toBe(
+      `${oldLines[1]}${oldLines[2]}`,
+    );
+    await expect(stat(`${logPath}.1`)).resolves.toMatchObject({ size: 62 });
+    await expect(readFile(logPath, "utf8")).resolves.toBe("new\n");
+  });
+
+  test("drops a crash-truncated trailing fragment before appending", async () => {
+    const directory = await createTemporaryDirectory();
+    const logPath = join(directory, "renderer.log");
+    await writeFile(logPath, "complete\npartial", "utf8");
+    const writer = new RotatingRendererLogWriter({
+      logPath,
+      maxBytes: 80,
+    });
+
+    await expect(writer.append("new\n")).resolves.toBe(true);
+
+    await expect(readFile(logPath, "utf8")).resolves.toBe(
+      "complete\nnew\n",
+    );
+  });
+
+  test("reconciles stale backup and temporary files on first append", async () => {
+    const directory = await createTemporaryDirectory();
+    const logPath = join(directory, "renderer.log");
+    const backupPath = `${logPath}.1`;
+    const temporaryBackupPath = `${backupPath}.tmp`;
+    const backupLines = ["a", "b", "c"].map(
+      (letter) => `${letter.repeat(30)}\n`,
+    );
+    await writeFile(logPath, "current\n", "utf8");
+    await writeFile(backupPath, `${backupLines.join("")}partial`, "utf8");
+    await writeFile(temporaryBackupPath, "stale temporary data", "utf8");
+    const writer = new RotatingRendererLogWriter({
+      logPath,
+      maxBytes: 80,
+    });
+
+    await expect(writer.initialize()).resolves.toBe(true);
+    await expect(writer.append("new\n")).resolves.toBe(true);
+
+    await expect(readFile(backupPath, "utf8")).resolves.toBe(
+      `${backupLines[1]}${backupLines[2]}`,
+    );
+    await expect(stat(backupPath)).resolves.toMatchObject({ size: 62 });
+    await expect(stat(temporaryBackupPath)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(readFile(logPath, "utf8")).resolves.toBe(
+      "current\nnew\n",
+    );
+  });
+
+  test("flush waits for queued appends", async () => {
+    const directory = await createTemporaryDirectory();
+    const logPath = join(directory, "renderer.log");
+    const writer = new RotatingRendererLogWriter({
+      logPath,
+      maxBytes: 80,
+    });
+
+    void writer.append("first\n");
+    void writer.append("second\n");
+    await expect(writer.flush()).resolves.toBeUndefined();
+
+    await expect(readFile(logPath, "utf8")).resolves.toBe(
+      "first\nsecond\n",
+    );
+  });
+
+  test("retains only the newest backup generation", async () => {
+    const directory = await createTemporaryDirectory();
+    const logPath = join(directory, "renderer.log");
+    const writer = new RotatingRendererLogWriter({
+      logPath,
+      maxBytes: 80,
+    });
+    const lines = ["a", "b", "c", "d", "e"].map(
+      (letter) => `${letter.repeat(30)}\n`,
+    );
+
+    for (const line of lines) {
+      await expect(writer.append(line)).resolves.toBe(true);
+    }
+
+    await expect(readFile(`${logPath}.1`, "utf8")).resolves.toBe(
+      `${lines[2]}${lines[3]}`,
+    );
+    await expect(readFile(logPath, "utf8")).resolves.toBe(lines[4]);
+  });
+
+  test("contains file-system failures and can recover on a later append", async () => {
+    const directory = await createTemporaryDirectory();
+    const logPath = join(directory, "renderer.log");
+    const backupPath = `${logPath}.1`;
+    const onError = vi.fn();
+    await writeFile(logPath, `${"x".repeat(70)}\n`, "utf8");
+    await mkdir(backupPath);
+    await writeFile(join(backupPath, "keep"), "occupied", "utf8");
+    const writer = new RotatingRendererLogWriter({
+      logPath,
+      maxBytes: 80,
+      onError,
+    });
+
+    await expect(writer.append(`${"y".repeat(20)}\n`)).resolves.toBe(false);
+    expect(onError).toHaveBeenCalledTimes(1);
+    await rm(backupPath, { force: true, recursive: true });
+
+    await expect(writer.append("recovered\n")).resolves.toBe(true);
+    await expect(readFile(logPath, "utf8")).resolves.toBe("recovered\n");
+  });
+
+  test("rejects a single entry larger than the file limit without growing the log", async () => {
+    const directory = await createTemporaryDirectory();
+    const logPath = join(directory, "renderer.log");
+    const onError = vi.fn();
+    const writer = new RotatingRendererLogWriter({
+      logPath,
+      maxBytes: 10,
+      onError,
+    });
+
+    await expect(writer.append("x".repeat(11))).resolves.toBe(false);
+    expect(onError).toHaveBeenCalledTimes(1);
+    await expect(writer.append("ok\n")).resolves.toBe(true);
+    await expect(readFile(logPath, "utf8")).resolves.toBe("ok\n");
+  });
+});
+
+describe("serializeRendererLogEntry", () => {
+  test("preserves entries that fit within the line budget", () => {
+    const line = serializeRendererLogEntry(
+      {
+        timestamp: "2026-07-19T00:00:00.000Z",
+        level: "error",
+        text: "failed to fetch",
+      },
+      512,
+    );
+
+    expect(JSON.parse(line)).toEqual({
+      timestamp: "2026-07-19T00:00:00.000Z",
+      level: "error",
+      text: "failed to fetch",
+    });
+    expect(line.endsWith("\n")).toBe(true);
+  });
+
+  test("truncates oversized UTF-8 text while keeping valid bounded JSONL", () => {
+    const line = serializeRendererLogEntry(
+      {
+        timestamp: "2026-07-19T00:00:00.000Z",
+        level: "error",
+        text: `${"😀\\\"".repeat(200)}tail`,
+      },
+      220,
+    );
+
+    expect(Buffer.byteLength(line, "utf8")).toBeLessThanOrEqual(220);
+    const parsed = JSON.parse(line) as { text: string };
+    expect(parsed.text).toContain("[truncated from");
+    const markerIndex = parsed.text.indexOf("… [truncated from");
+    const finalPrefixCodeUnit = parsed.text.charCodeAt(markerIndex - 1);
+    expect(
+      finalPrefixCodeUnit >= 0xd800 && finalPrefixCodeUnit <= 0xdbff,
+    ).toBe(false);
+    expect(line.endsWith("\n")).toBe(true);
+  });
+});
+
+const runtimeSource = readFileSync(
+  new URL("../../src/main/runtime.ts", import.meta.url),
+  "utf8",
+);
+const rendererLogWiring =
+  /const rendererLogPath = options\.rendererLogPath[\s\S]*?\n  \};/.exec(
+    runtimeSource,
+  )?.[0] ?? "";
+
+describe("renderer log runtime wiring", () => {
+  test("routes renderer entries through the bounded writer", () => {
+    expect(rendererLogWiring).toContain("new RotatingRendererLogWriter(");
+    expect(rendererLogWiring).toContain("void rendererLogWriter?.initialize();");
+    expect(rendererLogWiring).toContain("serializeRendererLogEntry(");
+    expect(rendererLogWiring).toContain("void rendererLogWriter.append(line);");
+    expect(rendererLogWiring).not.toContain("appendFile(");
+  });
+
+  test("keeps persistence limited to Electron warning and error entries", () => {
+    expect(rendererLogWiring).toContain('entry.level !== "error"');
+    expect(rendererLogWiring).toContain('entry.level !== "warn"');
+    expect(rendererLogWiring).toContain('entry.level !== "warning"');
+  });
+
+  test("flushes queued entries before closing desktop windows", () => {
+    const closeBlock =
+      /async close\(\) \{([\s\S]*?)\n    \},/.exec(runtimeSource)?.[0] ?? "";
+    const flushIndex = closeBlock.indexOf("await rendererLogWriter?.flush();");
+    const closeIndex = closeBlock.indexOf("window.close()");
+    expect(flushIndex).toBeGreaterThan(-1);
+    expect(closeIndex).toBeGreaterThan(flushIndex);
+  });
+});


### PR DESCRIPTION
Fixes #5691

## Why

This is an issue-driven community fix for the reported `renderer.log` growth to 18 GB. The current desktop path appends every renderer warning/error without a size limit or rotation, and concurrent fire-and-forget appends are not ordered.

The scope follows the issue claim and maintainer confirmation: add a defensive bound that works independently of the specific retry/CSP source, while leaving those individual noise sources out of this PR.

## What users will see

There is no UI change. Desktop renderer diagnostics now stay bounded instead of growing indefinitely:

- `renderer.log` is capped at 10 MiB
- one `renderer.log.1` backup is retained, also capped at 10 MiB
- entries are serialized and limited to 256 KiB while remaining valid JSONL
- existing oversized or crash-truncated files are reconciled on startup, retaining recent complete records
- queued entries are flushed before the desktop runtime closes

The existing `renderer.log` diagnostics path and warning/error-only behavior remain unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — no UI surface changed.

## Bug fix verification

- Test path: `apps/desktop/tests/main/renderer-log.test.ts`
- The new test initially failed because the bounded writer did not exist; against the minimal append-only implementation, the rotation, pre-existing-file bound, failure recovery, and UTF-8 entry-bound cases failed as expected. It is green with this branch.
- Coverage includes concurrent ordering, repeated rotation, eager cleanup of oversized/current/backup/temp files, crash-truncated records, filesystem failure recovery, oversized entries, UTF-8 JSONL truncation, runtime wiring, and shutdown flush ordering.

## Validation

- `pnpm --filter @open-design/desktop exec vitest run -c vitest.config.ts tests/main/renderer-log.test.ts --reporter=verbose` — 13 tests passed
- `pnpm --filter @open-design/desktop test` — 27 files / 256 tests passed
- `pnpm --filter @open-design/desktop build`
- `pnpm guard` — 86 tests passed
- `pnpm typecheck`
- `git diff --check`
- Added-line security scan plus UTF-8 / CRLF / NUL checks