### PR TITLE
fix(web): portal New Project picker dropdowns

### DIFF
--- a/apps/web/src/components/DsPickerPopover.tsx
+++ b/apps/web/src/components/DsPickerPopover.tsx
@@ -1,0 +1,182 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import type { ReactNode, RefObject } from 'react';
+import { createPortal } from 'react-dom';
+
+interface PopoverAnchor {
+  left: number;
+  width: number;
+  maxHeight: number;
+  sidecarLeft: number;
+  sidecarMaxHeight: number;
+  sidecarWidth: number;
+  top?: number;
+  bottom?: number;
+}
+
+interface DsPickerPopoverProps {
+  open: boolean;
+  triggerRef: RefObject<HTMLElement | null>;
+  onRequestClose: () => void;
+  className?: string;
+  role?: string;
+  id?: string;
+  ariaLabel?: string;
+  ariaMultiselectable?: boolean;
+  dataTestid?: string;
+  sidecar?: ReactNode;
+  sidecarAriaLabel?: string;
+  sidecarClassName?: string;
+  sidecarDataTestid?: string;
+  children: ReactNode;
+}
+
+export function DsPickerPopover({
+  open,
+  triggerRef,
+  onRequestClose,
+  className,
+  role,
+  id,
+  ariaLabel,
+  ariaMultiselectable,
+  dataTestid,
+  sidecar,
+  sidecarAriaLabel,
+  sidecarClassName,
+  sidecarDataTestid,
+  children,
+}: DsPickerPopoverProps) {
+  const [anchor, setAnchor] = useState<PopoverAnchor | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+  const sidecarRef = useRef<HTMLElement | null>(null);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setAnchor(null);
+      return undefined;
+    }
+
+    function updateAnchor() {
+      const trigger = triggerRef.current;
+      if (!trigger) return;
+      const rect = trigger.getBoundingClientRect();
+      const viewport = window.innerWidth;
+      const width = rect.width;
+      const left = Math.max(8, Math.min(viewport - width - 8, rect.left));
+      const gap = 6;
+      const margin = 12;
+      const spaceBelow = window.innerHeight - rect.bottom - gap - margin;
+      const spaceAbove = rect.top - gap - margin;
+      const openUp = spaceBelow < 280 && spaceAbove > spaceBelow;
+      const sidecarGap = 8;
+      const sidecarWidth = 320;
+      const sidecarLeft =
+        left + width + sidecarGap + sidecarWidth <= viewport - 8
+          ? left + width + sidecarGap
+          : Math.max(8, left - sidecarGap - sidecarWidth);
+      const sidecarMaxHeight = Math.max(
+        200,
+        Math.min(560, openUp ? spaceAbove : spaceBelow),
+      );
+
+      if (openUp) {
+        setAnchor({
+          bottom: window.innerHeight - rect.top + gap,
+          left,
+          width,
+          maxHeight: Math.max(200, Math.min(420, spaceAbove)),
+          sidecarLeft,
+          sidecarMaxHeight,
+          sidecarWidth,
+        });
+      } else {
+        setAnchor({
+          top: rect.bottom + gap,
+          left,
+          width,
+          maxHeight: Math.max(200, Math.min(420, spaceBelow)),
+          sidecarLeft,
+          sidecarMaxHeight,
+          sidecarWidth,
+        });
+      }
+    }
+
+    updateAnchor();
+    window.addEventListener('resize', updateAnchor);
+    window.addEventListener('scroll', updateAnchor, true);
+    return () => {
+      window.removeEventListener('resize', updateAnchor);
+      window.removeEventListener('scroll', updateAnchor, true);
+    };
+  }, [open, triggerRef]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+
+    function onPointer(e: MouseEvent) {
+      const target = e.target as Node;
+      if (triggerRef.current?.contains(target)) return;
+      if (popoverRef.current?.contains(target)) return;
+      if (sidecarRef.current?.contains(target)) return;
+      onRequestClose();
+    }
+
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onRequestClose();
+    }
+
+    const id = window.setTimeout(() => {
+      document.addEventListener('mousedown', onPointer);
+      document.addEventListener('keydown', onKey);
+    }, 0);
+    return () => {
+      window.clearTimeout(id);
+      document.removeEventListener('mousedown', onPointer);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open, onRequestClose, triggerRef]);
+
+  if (!open || !anchor || typeof document === 'undefined') return null;
+
+  return createPortal(
+    <>
+      <div
+        ref={popoverRef}
+        className={`ds-picker-popover ds-picker-popover--portal${className ? ` ${className}` : ''}`}
+        role={role}
+        id={id}
+        aria-label={ariaLabel}
+        aria-multiselectable={ariaMultiselectable}
+        data-testid={dataTestid}
+        style={{
+          top: anchor.top ?? 'auto',
+          bottom: anchor.bottom ?? 'auto',
+          left: anchor.left,
+          width: anchor.width,
+          maxHeight: anchor.maxHeight,
+        }}
+      >
+        {children}
+      </div>
+      {sidecar ? (
+        <aside
+          ref={sidecarRef}
+          className={`ds-picker-sidecar ds-picker-sidecar--portal${sidecarClassName ? ` ${sidecarClassName}` : ''}`}
+          aria-label={sidecarAriaLabel}
+          data-testid={sidecarDataTestid}
+          style={{
+            top: anchor.top ?? 'auto',
+            bottom: anchor.bottom ?? 'auto',
+            left: anchor.sidecarLeft,
+            width: anchor.sidecarWidth,
+            maxHeight: anchor.sidecarMaxHeight,
+          }}
+        >
+          {sidecar}
+        </aside>
+      ) : null}
+    </>,
+    document.body,
+  );
+}

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -2315,6 +2315,7 @@ function DesignSystemPicker({
     <div
       className={`newproj-section ds-picker${open ? ' open' : ''}`}
       data-testid="design-system-picker"
+      ref={wrapRef}
     >
       <label className="newproj-label">{t('newproj.designSystem')}</label>
       <button

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -58,6 +58,7 @@ import {
 import { formatPickAndImportFailure } from '../utils/pickAndImportError';
 import { useBrandsByDesignSystemId } from '../runtime/brands';
 import { BrandPreviewCard } from './BrandPreviewCard';
+import { DsPickerPopover } from './DsPickerPopover';
 import { Icon } from './Icon';
 import { Skeleton } from './Loading';
 import { Toast } from './Toast';
@@ -1204,7 +1205,7 @@ function PlatformPicker({
 }) {
   const t = useT();
   const [open, setOpen] = useState(false);
-  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
   const listboxId = useId();
 
   function togglePlatform(next: NewProjectPlatform) {
@@ -1215,39 +1216,16 @@ function PlatformPicker({
     onChange(updated.length > 0 ? updated : ['responsive']);
   }
 
-  useEffect(() => {
-    if (!open) return;
-    function onPointer(e: MouseEvent) {
-      if (wrapRef.current?.contains(e.target as Node)) return;
-      setOpen(false);
-    }
-    function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') setOpen(false);
-    }
-    // Defer listener registration by a tick so the very click that opened
-    // the popover doesn't get re-interpreted as an outside-click on the
-    // mousedown that follows in the same event cycle.
-    const tid = window.setTimeout(() => {
-      document.addEventListener('mousedown', onPointer);
-      document.addEventListener('keydown', onKey);
-    }, 0);
-    return () => {
-      window.clearTimeout(tid);
-      document.removeEventListener('mousedown', onPointer);
-      document.removeEventListener('keydown', onKey);
-    };
-  }, [open]);
-
   const primary = DESIGN_PLATFORMS.find((o) => o.value === value[0]) ?? null;
   const extraCount = Math.max(0, value.length - 1);
 
   return (
     <div
       className={`newproj-section ds-picker platform-picker${open ? ' open' : ''}`}
-      ref={wrapRef}
     >
       <label className="newproj-label">Target platforms</label>
       <button
+        ref={triggerRef}
         type="button"
         className={`ds-picker-trigger${open ? ' open' : ''}${primary ? '' : ' empty'}`}
         onClick={() => setOpen((v) => !v)}
@@ -1270,16 +1248,17 @@ function PlatformPicker({
           style={{ transform: open ? 'rotate(180deg)' : undefined }}
         />
       </button>
-      {open ? (
-        <div
-          className="ds-picker-popover"
-          id={listboxId}
-          role="listbox"
-          aria-label="Target platforms"
-          aria-multiselectable="true"
-        >
-          <div className="ds-picker-list">
-            {DESIGN_PLATFORMS.map((option) => {
+      <DsPickerPopover
+        open={open}
+        triggerRef={triggerRef}
+        onRequestClose={() => setOpen(false)}
+        id={listboxId}
+        role="listbox"
+        ariaLabel="Target platforms"
+        ariaMultiselectable
+      >
+        <div className="ds-picker-list">
+          {DESIGN_PLATFORMS.map((option) => {
               const active = value.includes(option.value);
               return (
                 <button
@@ -1303,9 +1282,8 @@ function PlatformPicker({
                 </button>
               );
             })}
-          </div>
         </div>
-      ) : null}
+      </DsPickerPopover>
     </div>
   );
 }
@@ -1810,7 +1788,7 @@ function PromptTemplatePicker({
   // soon as a pick succeeds or the user picks a different template.
   const [lastFailedPick, setLastFailedPick] =
     useState<PromptTemplateSummary | null>(null);
-  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
   const searchRef = useRef<HTMLInputElement | null>(null);
 
   const surfaceScoped = useMemo(
@@ -1835,26 +1813,6 @@ function PromptTemplatePicker({
     if (!open) return;
     const id = window.setTimeout(() => searchRef.current?.focus(), 30);
     return () => window.clearTimeout(id);
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    function onPointer(e: MouseEvent) {
-      if (wrapRef.current?.contains(e.target as Node)) return;
-      setOpen(false);
-    }
-    function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') setOpen(false);
-    }
-    const id = window.setTimeout(() => {
-      document.addEventListener('mousedown', onPointer);
-      document.addEventListener('keydown', onKey);
-    }, 0);
-    return () => {
-      window.clearTimeout(id);
-      document.removeEventListener('mousedown', onPointer);
-      document.removeEventListener('keydown', onKey);
-    };
   }, [open]);
 
   async function pickTemplate(summary: PromptTemplateSummary) {
@@ -1897,9 +1855,10 @@ function PromptTemplatePicker({
     : t('newproj.promptTemplateNoneSub');
 
   return (
-    <div className="newproj-section ds-picker prompt-template-picker" ref={wrapRef}>
+    <div className="newproj-section ds-picker prompt-template-picker">
       <label className="newproj-label">{t('newproj.promptTemplateLabel')}</label>
       <button
+        ref={triggerRef}
         type="button"
         data-testid="prompt-template-trigger"
         className={`ds-picker-trigger${open ? ' open' : ''}${value ? '' : ' empty'}`}
@@ -1919,8 +1878,12 @@ function PromptTemplatePicker({
           style={{ transform: open ? 'rotate(180deg)' : undefined }}
         />
       </button>
-      {open ? (
-        <div className="ds-picker-popover" role="listbox">
+      <DsPickerPopover
+        open={open}
+        triggerRef={triggerRef}
+        onRequestClose={() => setOpen(false)}
+        role="listbox"
+      >
           <div className="ds-picker-head">
             <input
               ref={searchRef}
@@ -1991,8 +1954,7 @@ function PromptTemplatePicker({
               })
             )}
           </div>
-        </div>
-      ) : null}
+      </DsPickerPopover>
       {error ? (
         <div
           className="prompt-template-error"
@@ -2145,6 +2107,7 @@ function DesignSystemPicker({
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
+  const flyoutRef = useRef<HTMLElement | null>(null);
   const searchRef = useRef<HTMLInputElement | null>(null);
   const [anchor, setAnchor] = useState<{
     top?: number;
@@ -2284,6 +2247,10 @@ function DesignSystemPicker({
       const target = e.target as Node;
       if (wrapRef.current?.contains(target)) return;
       if (popoverRef.current?.contains(target)) return;
+      // The brand flyout is portaled to document.body (like the popover), so it
+      // is not a descendant of wrapRef/popoverRef; without this check clicking
+      // the flyout would be treated as an outside click and close the picker.
+      if (flyoutRef.current?.contains(target)) return;
       setOpen(false);
     }
     function onKey(e: KeyboardEvent) {
@@ -2303,7 +2270,6 @@ function DesignSystemPicker({
       document.removeEventListener('keydown', onKey);
     };
   }, [open]);
-
   function toggle(id: string) {
     if (multi) {
       // Multi-select: tapping toggles membership; the *first* id in the
@@ -2349,7 +2315,6 @@ function DesignSystemPicker({
     <div
       className={`newproj-section ds-picker${open ? ' open' : ''}`}
       data-testid="design-system-picker"
-      ref={wrapRef}
     >
       <label className="newproj-label">{t('newproj.designSystem')}</label>
       <button
@@ -2499,6 +2464,7 @@ function DesignSystemPicker({
       {open && previewBrand && anchor && typeof document !== 'undefined'
         ? createPortal(
         <aside
+          ref={flyoutRef}
           className="ds-picker-brand-flyout ds-picker-brand-flyout-portal"
           data-testid="new-project-ds-brand-flyout"
           aria-label={t('brandDetail.identity')}
@@ -2785,7 +2751,7 @@ function MediaModelCards({
   const t = useT();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
-  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
   const searchRef = useRef<HTMLInputElement | null>(null);
 
   // Group models by provider once. The trigger row needs the same provider
@@ -2871,26 +2837,6 @@ function MediaModelCards({
     return () => window.clearTimeout(id);
   }, [open]);
 
-  useEffect(() => {
-    if (!open) return;
-    function onPointer(e: MouseEvent) {
-      if (wrapRef.current?.contains(e.target as Node)) return;
-      setOpen(false);
-    }
-    function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') setOpen(false);
-    }
-    const id = window.setTimeout(() => {
-      document.addEventListener('mousedown', onPointer);
-      document.addEventListener('keydown', onKey);
-    }, 0);
-    return () => {
-      window.clearTimeout(id);
-      document.removeEventListener('mousedown', onPointer);
-      document.removeEventListener('keydown', onKey);
-    };
-  }, [open]);
-
   function pick(modelId: string) {
     onChange(modelId);
     setOpen(false);
@@ -2909,9 +2855,10 @@ function MediaModelCards({
     : t('newproj.modelMissingSub');
 
   return (
-    <div className="newproj-section ds-picker model-picker" ref={wrapRef}>
+    <div className="newproj-section ds-picker model-picker">
       <label className="newproj-label">{label}</label>
       <button
+        ref={triggerRef}
         type="button"
         data-testid="model-picker-trigger"
         className={`ds-picker-trigger${open ? ' open' : ''}${selected ? '' : ' empty'}`}
@@ -2930,8 +2877,12 @@ function MediaModelCards({
           style={{ transform: open ? 'rotate(180deg)' : undefined }}
         />
       </button>
-      {open ? (
-        <div className="ds-picker-popover" role="listbox">
+      <DsPickerPopover
+        open={open}
+        triggerRef={triggerRef}
+        onRequestClose={() => setOpen(false)}
+        role="listbox"
+      >
           <div className="ds-picker-head">
             <input
               ref={searchRef}
@@ -2988,8 +2939,7 @@ function MediaModelCards({
               ))
             )}
           </div>
-        </div>
-      ) : null}
+      </DsPickerPopover>
     </div>
   );
 }

--- a/apps/web/src/styles/workspace/connectors.css
+++ b/apps/web/src/styles/workspace/connectors.css
@@ -8,7 +8,8 @@
    model picker, toggles, …) would cover the open list. Raising the open
    picker's section above its `z-index: auto` siblings restores the
    expected "dropdown on top" order. */
-.ds-picker:has(.ds-picker-popover) { z-index: 31; }
+.ds-picker:has(.ds-picker-popover),
+.ds-picker.open { z-index: 31; }
 .ds-picker-trigger {
   display: flex;
   align-items: center;
@@ -135,6 +136,18 @@
   overflow: hidden;
   animation: ds-pop-in 140ms cubic-bezier(0.2, 0, 0.2, 1);
 }
+.ds-picker-popover--portal {
+  position: fixed;
+  z-index: 1000;
+}
+.ds-picker-popover--portal .ds-picker-head {
+  flex: 0 0 auto;
+}
+.ds-picker-popover--portal .ds-picker-list {
+  max-height: none;
+  flex: 1 1 auto;
+  min-height: 0;
+}
 @keyframes ds-pop-in {
   from { opacity: 0; transform: translateY(-4px); }
   to { opacity: 1; transform: translateY(0); }
@@ -176,6 +189,10 @@
   border-radius: var(--radius);
   box-shadow: var(--shadow-lg);
   animation: ds-pop-in 140ms cubic-bezier(0.2, 0, 0.2, 1);
+}
+.ds-picker-sidecar--portal {
+  position: fixed;
+  z-index: 1001;
 }
 .ds-picker-head {
   display: flex;

--- a/apps/web/tests/components/NewProjectPanel.brand-preview.test.tsx
+++ b/apps/web/tests/components/NewProjectPanel.brand-preview.test.tsx
@@ -185,6 +185,22 @@ describe('NewProjectPanel brand preview flyout', () => {
     });
   });
 
+  it('re-clicking the trigger closes the picker', () => {
+    renderPanel('user:brand-acme');
+
+    fireEvent.click(screen.getByTestId('design-system-trigger'));
+    expect(screen.getByRole('listbox')).toBeTruthy();
+
+    // Full user press: the outside-click handler runs on mousedown, then the
+    // trigger's onClick toggles. The mousedown must be recognized as inside the
+    // section (wrapRef) so it does not prematurely close the list; the click
+    // then toggles it shut.
+    fireEvent.mouseDown(screen.getByTestId('design-system-trigger'));
+    fireEvent.click(screen.getByTestId('design-system-trigger'));
+
+    expect(screen.queryByRole('listbox')).toBeNull();
+  });
+
   it('keeps the flyout hidden for a non-brand selection', () => {
     renderPanel('clay');
 

--- a/apps/web/tests/components/NewProjectPanel.brand-preview.test.tsx
+++ b/apps/web/tests/components/NewProjectPanel.brand-preview.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { BrandSummary } from '@open-design/contracts';
@@ -162,6 +162,27 @@ describe('NewProjectPanel brand preview flyout', () => {
     expect(screen.getByText('Acme is a bold engineering brand for fast-moving teams.')).toBeTruthy();
     expect(screen.getByText('Space Grotesk')).toBeTruthy();
     expect(screen.getByText('#0b5fff')).toBeTruthy();
+  });
+
+  it('keeps the picker open when interacting with the portaled brand flyout', async () => {
+    renderPanel('user:brand-acme');
+
+    fireEvent.click(screen.getByTestId('design-system-trigger'));
+
+    const flyout = screen.getByTestId('new-project-ds-brand-flyout');
+    expect(flyout.parentElement).toBe(document.body);
+
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+    fireEvent.mouseDown(flyout);
+
+    expect(screen.getByRole('listbox')).toBeTruthy();
+    expect(screen.getByTestId('new-project-ds-brand-flyout')).toBeTruthy();
+
+    fireEvent.mouseDown(document.body);
+    await waitFor(() => {
+      expect(screen.queryByRole('listbox')).toBeNull();
+      expect(screen.queryByTestId('new-project-ds-brand-flyout')).toBeNull();
+    });
   });
 
   it('keeps the flyout hidden for a non-brand selection', () => {

--- a/apps/web/tests/components/NewProjectPanel.test.tsx
+++ b/apps/web/tests/components/NewProjectPanel.test.tsx
@@ -263,6 +263,58 @@ describe('NewProjectPanel design system defaults', () => {
     );
   });
 
+  it('portals the target platform dropdown out of the modal form stack', () => {
+    const { container } = render(
+      <NewProjectPanel
+        skills={skills}
+        designSystems={designSystems}
+        defaultDesignSystemId="clay"
+        templates={[]}
+        promptTemplates={[]}
+        onCreate={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Responsive web/i }));
+
+    const listbox = screen.getByRole('listbox', { name: 'Target platforms' });
+    expect(listbox.closest('.platform-picker')).toBeNull();
+    expect(document.body).toContainElement(listbox);
+    expect(container).not.toContainElement(listbox);
+  });
+
+  it('clears the inherited top offset when a portaled picker opens upward', () => {
+    vi.stubGlobal('innerHeight', 420);
+    render(
+      <NewProjectPanel
+        skills={skills}
+        designSystems={designSystems}
+        defaultDesignSystemId="clay"
+        templates={[]}
+        promptTemplates={[]}
+        onCreate={vi.fn()}
+      />,
+    );
+
+    const trigger = screen.getByRole('button', { name: /Responsive web/i });
+    vi.spyOn(trigger, 'getBoundingClientRect').mockReturnValue({
+      bottom: 394,
+      height: 44,
+      left: 24,
+      right: 344,
+      top: 350,
+      width: 320,
+      x: 24,
+      y: 350,
+      toJSON: () => ({}),
+    });
+    fireEvent.click(trigger);
+
+    const listbox = screen.getByRole('listbox', { name: 'Target platforms' });
+    expect(listbox.style.top).toBe('auto');
+    expect(listbox.style.bottom).not.toBe('auto');
+  });
+
   it('clears design system metadata when freeform is selected in multi mode', () => {
     const onCreate = vi.fn();
     render(


### PR DESCRIPTION
Fixes #4253

## Why

I picked this up from the open high-value bug queue after confirming the previous fix PR (#4374) had auto-closed without merging and there is no active replacement PR. The user-facing pain is in the New project modal: opening the Target platforms dropdown can let the menu overlap/bleed into the Companion surfaces and Fidelity sections, making first-run project setup look broken and harder to use.

The root cause is that the New Project pickers rendered `.ds-picker-popover` inline inside the modal form stack. That leaves the popover inside the `.newproj-body` scroll container and within `.newproj-section` stacking contexts, so the dropdown can be clipped or painted under later sections.

## What users will see

In the New project modal, the Target platforms dropdown now opens as a body-level floating panel anchored to its trigger instead of rendering inside the form section. The same portal path is used for the other New Project picker popovers that shared the same shell, so design-system, prompt-template, and model pickers avoid the same clipping/stacking trap.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached in this pass. The bug is a dropdown layering/clipping issue, and this PR includes a red/green structural regression test proving the Target platforms listbox now escapes the `.platform-picker` / modal form stack and is mounted under `document.body`.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/NewProjectPanel.test.tsx`
- Red/green confirmation: yes. The new `portals the target platform dropdown out of the modal form stack` test failed on the original branch because the listbox still had `.platform-picker` as an ancestor, then passed after the portal fix.

## Validation

- `pnpm install --offline` — completed to materialize worktree dependencies
- `pnpm --filter @open-design/web exec vitest run tests/components/NewProjectPanel.test.tsx -t "portals the target platform dropdown"` — pass
- `pnpm --filter @open-design/web exec vitest run tests/components/NewProjectPanel.test.tsx tests/components/NewProjectPanel.media.test.tsx` — pass, 37 tests
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `git diff --check` — pass

Note: commands warn that this shell is on Node v22.14.0 while the repo asks for Node ~24; the commands above still exited 0.
## Conflict resolution (rebase onto current main)

This branch was rebased onto the current `main` head. `main` moved substantially
since the branch was opened — notably #6142 (workspace-team redesign) reworked
`DesignSystemPicker` with its own portaled popover implementation and brand
flyout. To avoid regressing that landed work, the rebase:

- Keeps `DesignSystemPicker`'s portaled implementation as-is (from `main`),
  including its anchor-based popover and brand flyout.
- Applies the `DsPickerPopover` component to the other three pickers
  (Target platforms, Prompt template, Media model) so they all portal out of
  the modal form stack.
- Fixes one interaction gap the new test surfaced: the portaled brand flyout
  was not covered by the outside-click guard, so clicking the flyout closed the
  picker. `flyoutRef` is now checked in the outside-click handler.
- New tests pass: `NewProjectPanel.test.tsx` + `NewProjectPanel.brand-preview.test.tsx` (36 tests).
- `@open-design/web` typecheck passes.