### PR TITLE
fix: support pnpm install --ignore-scripts with pnpm bootstrap

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -332,7 +332,7 @@ open-design/
 
 ## Troubleshooting
 
-- **`better-sqlite3` fails to load / ABI mismatch after a Node.js version change** — `pnpm install` re-runs `postinstall` automatically and rebuilds the native addon for the current Node.js. To rebuild manually or verify the fix: `pnpm --filter @open-design/daemon rebuild better-sqlite3` then `pnpm --filter @open-design/daemon exec node -e "require('better-sqlite3')"`. Requires build tools: `python3`, `make`, `g++` (or `clang++`). If you have `ignore-scripts=true` in your `.npmrc`, run `node scripts/postinstall.mjs` after `pnpm install`.
+- **`better-sqlite3` fails to load / ABI mismatch after a Node.js version change** — `pnpm install` re-runs `postinstall` automatically and rebuilds the native addon for the current Node.js. To rebuild manually or verify the fix: `pnpm --filter @open-design/daemon rebuild better-sqlite3` then `pnpm --filter @open-design/daemon exec node -e "require('better-sqlite3')"`. Requires build tools: `python3`, `make`, `g++` (or `clang++`). If you use `ignore-scripts=true` in your `.npmrc` (common for AUR packages), run `pnpm bootstrap` after `pnpm install`.
 - **"no agents found on PATH"** — install one of the local runtimes registered in [`apps/daemon/src/runtimes/registry.ts`](apps/daemon/src/runtimes/registry.ts), make sure its executable is visible to the daemon, then use **Rescan** in **Settings → Execution mode**. Or configure a BYOK runtime in Settings.
 - **Claude Code exits with code 1** — Open Design was able to start `claude`, but the spawned non-interactive run failed before producing a response. From the same shell or app environment that starts Open Design, check:
   ```bash

--- a/apps/daemon/bin/od.mjs
+++ b/apps/daemon/bin/od.mjs
@@ -9,7 +9,7 @@ const distEntry = resolve(entryDir, "../dist/cli.js");
 
 if (!existsSync(distEntry)) {
   throw new Error(
-    `Open Design daemon dist entry not found at ${distEntry}. Run "pnpm --filter @open-design/daemon build" first.`,
+    `Open Design daemon dist entry not found at ${distEntry}. Run "pnpm bootstrap" after install (or "pnpm --filter @open-design/daemon build").`,
   );
 }
 

--- a/apps/desktop/vendor/dom-to-pptx/README.md
+++ b/apps/desktop/vendor/dom-to-pptx/README.md
@@ -2,7 +2,7 @@
 
 `dom-to-pptx.bundle.js.gz` is the checked-in compressed **browser UMD build** of
 [`dom-to-pptx`](https://github.com/atharva9167j/dom-to-pptx) (MIT), pinned at the
-version below. `scripts/postinstall.mjs` expands it to the ignored
+version below. `scripts/postinstall.mjs` (run via `pnpm bootstrap` or automatically during `pnpm install`) expands it to the ignored
 `dom-to-pptx.bundle.js` runtime file. The bundle is the engine behind
 **editable** PowerPoint export: it walks a rendered slide's live DOM and emits
 native PowerPoint shapes/text/images (not a flat screenshot) via PptxGenJS.
@@ -18,7 +18,7 @@ The npm package declares `puppeteer` + `@puppeteer/browsers` as dependencies
 Chromium (~150 MB+). We never use that path — we inject this self-contained
 browser bundle into our **existing** Electron Chromium render window
 (`apps/desktop/src/main/deck-capture.ts`). Keeping the gzip source in git and
-materializing the runtime file during postinstall preserves the "no second
+materializing the runtime file during `pnpm bootstrap` (or `postinstall`) preserves the "no second
 rendering engine / no install-time Chromium download" property without adding a
 multi-megabyte JavaScript blob to the PR.
 

--- a/docs/i18n/QUICKSTART.ko.md
+++ b/docs/i18n/QUICKSTART.ko.md
@@ -330,7 +330,7 @@ open-design/
 
 ## 문제 해결
 
-- **Node.js 버전을 바꾼 뒤 `better-sqlite3`가 로드되지 않거나 ABI가 맞지 않을 때** — `pnpm install`이 `postinstall`을 자동으로 다시 돌려 현재 Node.js에 맞게 네이티브 애드온을 리빌드합니다. 직접 리빌드하거나 수정을 확인하려면 `pnpm --filter @open-design/daemon rebuild better-sqlite3`를 실행한 뒤 `pnpm --filter @open-design/daemon exec node -e "require('better-sqlite3')"`를 돌리세요. 빌드 도구 `python3`, `make`, `g++`(또는 `clang++`)가 필요합니다. `.npmrc`에 `ignore-scripts=true`가 있다면, `pnpm install` 후 `node scripts/postinstall.mjs`를 실행하세요.
+- **Node.js 버전을 바꾼 뒤 `better-sqlite3`가 로드되지 않거나 ABI가 맞지 않을 때** — `pnpm install`이 `postinstall`을 자동으로 다시 돌려 현재 Node.js에 맞게 네이티브 애드온을 리빌드합니다. 직접 리빌드하거나 수정을 확인하려면 `pnpm --filter @open-design/daemon rebuild better-sqlite3`를 실행한 뒤 `pnpm --filter @open-design/daemon exec node -e "require('better-sqlite3')"`를 돌리세요. 빌드 도구 `python3`, `make`, `g++`(또는 `clang++`)가 필요합니다. `.npmrc`에 `ignore-scripts=true`가 있다면(AUR 패키지의 일반적인 경우), `pnpm install` 후 `pnpm bootstrap`을 실행하세요.
 - **"no agents found on PATH"** — [`apps/daemon/src/runtimes/registry.ts`](../../apps/daemon/src/runtimes/registry.ts)에 등록된 로컬 런타임 중 하나를 설치하고 실행 파일이 daemon에 보이는지 확인한 뒤, **Settings → Execution mode**에서 **Rescan**을 실행하세요. 또는 Settings에서 BYOK 런타임을 구성하세요.
 - **Claude Code가 코드 1로 종료될 때** — Open Design이 `claude`를 시작하긴 했지만, spawn된 비대화형 실행이 응답을 내기 전에 실패한 경우입니다. Open Design을 시작하는 셸이나 앱 환경과 같은 곳에서 다음을 확인하세요.
   ```bash

--- a/docs/i18n/QUICKSTART.th.md
+++ b/docs/i18n/QUICKSTART.th.md
@@ -346,7 +346,7 @@ open-design/
 
 ## Troubleshooting
 
-- **`better-sqlite3` fails to load / ABI mismatch after a Node.js version change** — `pnpm install` จะ re-run `postinstall` อัตโนมัติและ rebuild native addon สำหรับ Node.js ปัจจุบัน. ถ้าต้องการ rebuild เองหรือตรวจ fix: `pnpm --filter @open-design/daemon rebuild better-sqlite3` แล้ว `pnpm --filter @open-design/daemon exec node -e "require('better-sqlite3')"`. ต้องมี build tools: `python3`, `make`, `g++` (หรือ `clang++`). ถ้าคุณมี `ignore-scripts=true` ใน `.npmrc`, ให้รัน `node scripts/postinstall.mjs` หลัง `pnpm install`.
+- **`better-sqlite3` fails to load / ABI mismatch after a Node.js version change** — `pnpm install` จะ re-run `postinstall` อัตโนมัติและ rebuild native addon สำหรับ Node.js ปัจจุบัน. ถ้าต้องการ rebuild เองหรือตรวจ fix: `pnpm --filter @open-design/daemon rebuild better-sqlite3` แล้ว `pnpm --filter @open-design/daemon exec node -e "require('better-sqlite3')"`. ต้องมี build tools: `python3`, `make`, `g++` (หรือ `clang++`). ถ้าคุณใช้ `ignore-scripts=true` ใน `.npmrc` (พบบ่อยใน AUR packages), ให้รัน `pnpm bootstrap` หลัง `pnpm install`.
 - **"no agents found on PATH"** — ติดตั้ง local runtime ที่ register ไว้ใน [`apps/daemon/src/runtimes/registry.ts`](../../apps/daemon/src/runtimes/registry.ts), ตรวจว่า daemon มองเห็น executable แล้วใช้ **Rescan** ใน **Settings → Execution mode**. หรือ configure BYOK runtime ใน Settings.
 - **Claude Code exits with code 1** — Open Design start `claude` ได้แล้ว แต่ spawned non-interactive run fail ก่อน produce response. จาก shell หรือ app environment เดียวกับที่ start Open Design ให้เช็ค:
   ```bash

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "postinstall": "node ./scripts/postinstall.mjs",
+    "bootstrap": "node ./scripts/postinstall.mjs",
     "tools-dev": "pnpm exec tools-dev",
     "tools-pack": "pnpm exec tools-pack",
     "tools-release": "pnpm exec tools-release",

--- a/packages/metatool/src/index.ts
+++ b/packages/metatool/src/index.ts
@@ -125,7 +125,7 @@ async function readToolBuildMetadata(toolRoot: string): Promise<{
 
 function createBuildRequiredError(policy: ToolBuildMetadataPolicy, toolRoot: string, reason: string): Error {
   return new Error(
-    `[${policy.toolName}] ${reason} Run "${policy.buildCommand}" first.\n` +
+    `[${policy.toolName}] ${reason} Run "pnpm bootstrap" (or "${policy.buildCommand}").\n` +
     `tool root: ${toolRoot}\n` +
     `metadata: ${resolveMetadataPath(toolRoot)}`,
   );

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -240,10 +240,13 @@ try {
 const req = createRequire(resolve(repoRoot, "apps/daemon/package.json"));
 let needsRebuild = false;
 try {
-  req("better-sqlite3");
+  // Try to actually use the native addon; merely requiring the JS wrapper
+  // succeeds even when the binary is missing (e.g. after `pnpm install --ignore-scripts`).
+  const Database = req("better-sqlite3");
+  new Database(":memory:");
 } catch (e) {
   // MODULE_NOT_FOUND means daemon deps aren't installed yet — not our problem.
-  // Any other error (ERR_DLOPEN_FAILED, ABI mismatch, etc.) warrants a rebuild.
+  // Any other error (missing binary, ERR_DLOPEN_FAILED, ABI mismatch, etc.) warrants a rebuild.
   if (e?.code !== "MODULE_NOT_FOUND") {
     needsRebuild = true;
   }


### PR DESCRIPTION
Fixes # (no linked issue — searched open issues and did not find an exact match)

## Why

Every time I install this from AUR with `ignore-scripts=true` in my `.npmrc`, the install leaves the workspace broken. The CLI tools need built `dist/` files and `better-sqlite3` needs a compiled native binary, both of which normally come from the root `postinstall`. With install scripts disabled, `pnpm tools-dev` and `od` fail immediately and the daemon cannot load SQLite.

## What users will see

- A new root script: `pnpm bootstrap`. It runs the same workspace build and better-sqlite3 verification as the automatic `postinstall`, so it can be called explicitly after `pnpm install --ignore-scripts`.
- If a tool's `dist/` entry is missing, the error message now points to `pnpm bootstrap` instead of a package-specific build command.
- The Korean and Thai QUICKSTART troubleshooting lines now mention `pnpm bootstrap` for `ignore-scripts=true` users.

## Surface area

- [ ] UI
- [ ] Keyboard shortcut
- [x] CLI / env var — new root `pnpm bootstrap` script
- [ ] API / contract
- [ ] Extension point
- [x] i18n keys — updated existing troubleshooting strings in `ko` and `th` QUICKSTART
- [ ] New top-level dependency
- [ ] Default behavior change
- [ ] None

## Screenshots

N/A — no UI change.

## Bug fix verification

N/A — this is a new install path, not a fix for a tracked bug.

## Validation

- `pnpm guard` — passed
- `pnpm typecheck` — passed
- `pnpm --filter @open-design/e2e test tests/scripts/postinstall.test.ts` — passed
- `pnpm --filter @open-design/metatool test` — passed
- Manual: deleted all `dist/` directories, ran `pnpm install --ignore-scripts`, then `pnpm bootstrap`; both `pnpm tools-dev --help` and `pnpm od --help` worked.
