### PR TITLE
docs(wsl): point daemon reachability check at /api/health

### DIFF
--- a/docs/wsl-setup.md
+++ b/docs/wsl-setup.md
@@ -97,7 +97,20 @@ od --no-open
 In another WSL terminal, verify it is reachable:
 
 ```bash
-curl -sSf http://127.0.0.1:7456 >/dev/null && echo "Open Design daemon is reachable"
+curl -sSf http://127.0.0.1:7456/api/health && echo "Open Design daemon is reachable"
+```
+
+Expected output includes `{"ok":true,...}` followed by the echo line.
+
+Do not probe the root URL (`curl http://127.0.0.1:7456`) for this check. The
+root path serves the web UI only after the web package has been built, so on a
+fresh source install it returns 404 even though the daemon is healthy. The MCP
+integrations below do not need the web build. If you also want the browser UI
+at `http://127.0.0.1:7456`, build it once and restart the daemon:
+
+```bash
+cd ~/tools/open-design
+pnpm --filter @open-design/web build
 ```
 
 Leave the daemon terminal running while using MCP integrations.


### PR DESCRIPTION
## Why

I hit this today while setting up Open Design in WSL2 by following `docs/wsl-setup.md`. The guide's "verify it is reachable" step (`curl -sSf http://127.0.0.1:7456`) returns `curl: (22) ... 404` on a fresh source install, which reads as a broken daemon even though the daemon is healthy.

Root cause: the daemon serves `/` only when the web UI static export exists at `apps/web/out` (`apps/daemon/src/server.ts` guards `express.static(STATIC_DIR)` on `fs.existsSync`), and the guide's `pnpm install` step does not build `apps/web` (`scripts/postinstall.mjs` `buildTargets` covers the daemon and packages only). So everyone following the guide as written hits a false failure at the verification step.

## What users will see

- The WSL2 guide's reachability check now curls `/api/health` (the daemon's unauthenticated health probe) and shows the expected `{"ok":true,...}` output, so it succeeds on a fresh source install.
- A short note explains that the root URL 404s until the web package is built, that MCP integrations do not need the web build, and gives the optional `pnpm --filter @open-design/web build` command for users who want the browser UI.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only

## Validation

- Reproduced the failure end-to-end on a fresh WSL2 source install following the guide as written: `curl -sSf http://127.0.0.1:7456` → `curl: (22) The requested URL returned error: 404` while the daemon was running.
- Ran the new command from the doc against that same running daemon: `curl -sSf http://127.0.0.1:7456/api/health` → `{"ok":true,"version":"0.15.1"}`.
- Verified the endpoint is registered and listed in the unauthenticated `openProbePaths` set in `apps/daemon/src/server.ts`.
- Docs-only change; no code touched.
