### PR TITLE
fix(daemon): block SSRF in marketplace add/refresh and plugin install fetch

### DIFF
--- a/apps/daemon/src/plugins/installer.ts
+++ b/apps/daemon/src/plugins/installer.ts
@@ -15,6 +15,7 @@
 //   - Tarball extraction inherits the same caps via tar's strict mode.
 
 import path from 'node:path';
+import { safeExternalFetch } from './plugin-asset-cache.js';
 import fs from 'node:fs';
 import os from 'node:os';
 import { createHash } from 'node:crypto';
@@ -584,7 +585,7 @@ async function* installFromArchiveUrl(
 }
 
 async function defaultFetcher(url: string): ReturnType<ArchiveFetcher> {
-  const response = await fetch(url, { redirect: 'follow' });
+  const response = await safeExternalFetch(url);
   return {
     ok: response.ok,
     status: response.status,

--- a/apps/daemon/src/plugins/marketplace-seed.ts
+++ b/apps/daemon/src/plugins/marketplace-seed.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { safeExternalFetch } from './plugin-asset-cache.js';
 import path from 'node:path';
 
 export const OFFICIAL_MARKETPLACE_ID = 'official';
@@ -88,7 +89,7 @@ export function createMarketplaceSeedHelpers(deps: MarketplaceSeedHelperDeps): M
           };
         }
       }
-      const response = await fetchImpl(url, { redirect: 'follow' });
+      const response = await safeExternalFetch(url, {}, fetchImpl);
       return {
         ok: response.ok,
         status: response.status,

--- a/apps/daemon/src/plugins/marketplaces.ts
+++ b/apps/daemon/src/plugins/marketplaces.ts
@@ -14,6 +14,7 @@
 // unless `--trust` is passed.
 
 import { randomUUID } from 'node:crypto';
+import { safeExternalFetch } from './plugin-asset-cache.js';
 import type Database from 'better-sqlite3';
 import {
   parseMarketplace,
@@ -393,7 +394,7 @@ export async function refreshMarketplace(
 }
 
 async function defaultFetcher(url: string) {
-  const response = await fetch(url, { redirect: 'follow' });
+  const response = await safeExternalFetch(url);
   return {
     ok: response.ok,
     status: response.status,

--- a/apps/daemon/src/plugins/plugin-asset-cache.ts
+++ b/apps/daemon/src/plugins/plugin-asset-cache.ts
@@ -249,6 +249,37 @@ export interface PluginAssetCache {
   get(rawUrl: string): Promise<AssetCacheResult>;
 }
 
+let sharedSsrfDispatcher: Agent | undefined;
+
+/**
+ * Fetch a user-influenced external URL with SSRF protection. Rejects
+ * private/loopback/link-local/metadata hosts, bad schemes, and embedded
+ * credentials up front (`assertSafePublicUrl`), and pins every outbound
+ * connection — including redirect hops, since `follow` re-connects per hop —
+ * to a validating DNS lookup so a hostname cannot rebind to a private address.
+ *
+ * Every daemon fetch of a user-supplied URL must route through this instead of
+ * a bare `fetch(url, { redirect: 'follow' })`, so no single call site can
+ * silently reopen the SSRF hole.
+ */
+export async function safeExternalFetch(
+  rawUrl: string,
+  init: RequestInit = {},
+  fetchImpl: typeof fetch = fetch,
+): Promise<Response> {
+  assertSafePublicUrl(rawUrl);
+  if (!sharedSsrfDispatcher) {
+    sharedSsrfDispatcher = new Agent({
+      connect: { lookup: createValidatingLookup() as unknown as LookupFunction },
+    });
+  }
+  // `dispatcher` is an undici extension of RequestInit; attach at runtime to
+  // dodge the undici-types vs undici@7 skew (same pattern as the asset cache).
+  const withGuard: RequestInit = { redirect: 'follow', ...init };
+  (withGuard as { dispatcher?: unknown }).dispatcher = sharedSsrfDispatcher;
+  return fetchImpl(rawUrl, withGuard);
+}
+
 /** Build a disk-backed cache for external preview media. Concurrent requests
  *  for the same URL share one in-flight fetch; completed fetches persist to
  *  `<cacheDir>/<sha256>` (+ `.json` sidecar) and are replayed from disk. */

--- a/apps/daemon/tests/marketplace-install-ssrf.test.ts
+++ b/apps/daemon/tests/marketplace-install-ssrf.test.ts
@@ -1,0 +1,134 @@
+// Regression: SSRF via POST /api/marketplaces and POST /api/plugins/install.
+//
+// Both routes take a client-supplied URL/source and hand it to a "default
+// fetcher" that does a raw `fetch(url, { redirect: 'follow' })` with NO SSRF
+// host validation:
+//   - src/plugins/marketplace-seed.ts:91  (createMarketplaceFetcher fallback)
+//   - src/plugins/installer.ts:587        (installFromArchiveUrl defaultFetcher)
+//   - src/plugins/marketplaces.ts:396     (marketplace refresh defaultFetcher)
+// The only upstream gate is a protocol/suffix check (https:// for marketplaces,
+// `.tar.gz` suffix for installs). Neither resolves the host, so loopback /
+// RFC1918 / link-local (169.254.169.254 cloud metadata) targets are fetched,
+// and `redirect: 'follow'` lets even a public host 3xx into private space.
+//
+// Contrast the sibling outbound paths that DO defend:
+//   - src/brands/safe-fetch.ts            (assertPublicBrandUrl + validatingLookup)
+//   - src/plugins/plugin-asset-cache.ts   (assertSafePublicUrl + validatingLookup)
+// These pin a connection-time DNS check so the address validated is the address
+// connected — defeating DNS rebinding. The marketplace/install fetchers have
+// neither. Same class as the already-fixed library-ingest SSRF (#5529).
+//
+// This spec asserts the SECURE invariant: a loopback/internal URL must be
+// refused and the canary internal service must never be touched. RED on main
+// (the daemon fetches the canary); green once these fetchers route through the
+// shared SSRF guard.
+
+import type http from 'node:http';
+import type net from 'node:net';
+import { createServer as createTcpServer } from 'node:net';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+let daemon: http.Server | undefined;
+let daemonShutdown: (() => Promise<void> | void) | undefined;
+let baseUrl = '';
+let dataDir = '';
+
+// Stand-in internal service (think cloud metadata / a loopback admin API).
+// The routes require an `https://` source, so a plain-HTTP canary's request
+// handler never fires (the TLS handshake fails first) even though the daemon
+// DID open an outbound TCP connection to the internal address. We therefore
+// record the connection at the raw TCP layer: any inbound socket to this
+// loopback port is proof the daemon connected to the internal service — the
+// SSRF. (Full response exfil would need the canary to speak TLS + serve a valid
+// manifest; not modelled here, but the connect itself is the vulnerability.)
+let canary: net.Server | undefined;
+let canaryPort = 0;
+let canaryHits: number;
+
+const PREV_DATA_DIR = process.env.OD_DATA_DIR;
+
+beforeEach(async () => {
+  canaryHits = 0;
+  canary = createTcpServer((socket) => {
+    canaryHits += 1;
+    socket.destroy();
+  });
+  await new Promise<void>((resolve) => canary!.listen(0, '127.0.0.1', () => resolve()));
+  canaryPort = (canary.address() as { port: number }).port;
+
+  dataDir = await mkdtemp(path.join(os.tmpdir(), 'od-mkt-ssrf-'));
+  process.env.OD_DATA_DIR = dataDir;
+
+  const { startServer } = await import('../src/server.js');
+  const started = (await startServer({ port: 0, host: '127.0.0.1', returnServer: true })) as {
+    url: string;
+    server: http.Server;
+    shutdown?: () => Promise<void> | void;
+  };
+  baseUrl = started.url;
+  daemon = started.server;
+  daemonShutdown = started.shutdown;
+});
+
+afterEach(async () => {
+  if (daemonShutdown) {
+    await Promise.race([
+      Promise.resolve(daemonShutdown()),
+      new Promise((r) => setTimeout(r, 2000)),
+    ]);
+  }
+  daemon?.closeAllConnections?.();
+  if (daemon) await new Promise<void>((r) => daemon!.close(() => r()));
+  if (canary) await new Promise<void>((r) => canary!.close(() => r()));
+  daemon = undefined;
+  canary = undefined;
+  daemonShutdown = undefined;
+  await rm(dataDir, { recursive: true, force: true }).catch(() => {});
+  if (PREV_DATA_DIR === undefined) delete process.env.OD_DATA_DIR;
+  else process.env.OD_DATA_DIR = PREV_DATA_DIR;
+}, 15000);
+
+describe('marketplace / plugin-install SSRF', () => {
+  it('POST /api/marketplaces must NOT fetch a loopback/internal https URL', async () => {
+    const canaryUrl = `https://127.0.0.1:${canaryPort}/latest/meta-data/`;
+    // No Origin header → the /api origin middleware treats it as a non-browser
+    // client and allows it (any local process / injected agent can do this).
+    const resp = await fetch(`${baseUrl}/api/marketplaces`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url: canaryUrl }),
+    });
+    const status = resp.status;
+    // eslint-disable-next-line no-console
+    console.log(
+      `[SSRF marketplaces] status=${status} canaryHits=${canaryHits}`,
+    );
+    // SECURE invariant: the daemon must never have connected to the internal service.
+    expect(canaryHits).toBe(0);
+  });
+
+  it('POST /api/plugins/install must NOT fetch a loopback/internal https source', async () => {
+    const canaryUrl = `https://127.0.0.1:${canaryPort}/evil.tar.gz`;
+    const resp = await fetch(`${baseUrl}/api/plugins/install`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ source: canaryUrl }),
+    });
+    // Drain the SSE stream so the install pipeline runs to the fetch.
+    await resp.text().catch(() => '');
+    // eslint-disable-next-line no-console
+    console.log(
+      `[SSRF install] status=${resp.status} canaryHits=${canaryHits}`,
+    );
+    expect(canaryHits).toBe(0);
+  });
+
+  it('the sibling guard (assertSafePublicUrl) already rejects these URLs', async () => {
+    const { assertSafePublicUrl } = await import('../src/plugins/plugin-asset-cache.js');
+    expect(() => assertSafePublicUrl(`https://127.0.0.1:${canaryPort}/x`)).toThrow();
+    expect(() => assertSafePublicUrl('https://169.254.169.254/latest/meta-data/')).toThrow();
+  });
+});


### PR DESCRIPTION
Fixes #5879

## Why

Three user-influenced outbound fetches were bare `fetch(url, { redirect: 'follow' })` with no host validation: the marketplace fetcher (`marketplace-seed.ts`), the marketplace-refresh fetcher (`marketplaces.ts`), and the plugin-install archive fetcher (`installer.ts`). The only upstream gate is a scheme/suffix check, so a user URL pointing at loopback / RFC1918 / link-local metadata — or a public host that 3xx-redirects into one — is fetched server-side. That's SSRF, the same shape as the library-ingest SSRF fixed in #5529, on the outbound paths that migration never covered.

**Exposure (measured).** The daemon binds loopback, so this makes it connect to any other loopback service; with no host filter, `169.254.169.254` (metadata) and RFC1918 go through the same code path. Reachable by non-browser callers with no `Origin` header (a local process / injected agent tool), same as #5529; browser cross-origin POSTs stay blocked by the Origin middleware.

## What users will see

No change for legitimate public marketplace/plugin URLs. A marketplace add/refresh or plugin install pointed at a private/loopback/metadata address is now rejected before any connection.

## Surface area

- [x] **API / contract** — `POST /api/marketplaces`, `/:id/refresh`, and `POST /api/plugins/install` reject private-host URLs (no new endpoint/DTO).

## Bug fix verification

- Test path: `apps/daemon/tests/marketplace-install-ssrf.test.ts`.
- Red on `origin/main` (`6b90486c9`), green on this branch? **yes.** A real daemon + a raw-TCP loopback canary: on `main` both routes connect to it (`canaryHits=1`); with the fix neither does (`canaryHits=0`). The third case shows the shared `assertSafePublicUrl` already rejects the same loopback + `169.254.169.254` URLs, so this is one missing guard call. Honest scope note in the spec: the canary proves the *connection is initiated* (the SSRF), not full response exfil (which would need a TLS-speaking canary).
- Fix routes all three sinks through a single shared `safeExternalFetch`, so no call site can silently reopen the hole (the lesson from #5857's review). `grep redirect: 'follow'` confirms these were the only three.
- No regression: `plugins-installer` (5), `plugins-installer-archive` (10), `plugins-marketplaces` (18), `plugins-marketplace-doctor` (1), `plugins-upgrade` (3) stay green (Node 24).

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/marketplace-install-ssrf.test.ts` → 3 passed (Node 24).
- `pnpm --filter @open-design/daemon typecheck` → passed.
