### PR TITLE
ci(e2e): shard the full UI functional pool into a merge-ready matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,57 +441,6 @@ jobs:
           OD_PLAYWRIGHT_FULLY_PARALLEL: "1"
         run: pnpm -C e2e exec playwright test -c playwright.config.ts ${{ matrix.files }} --grep '@critical'
 
-  ui_p0_smoke:
-    name: UI merge sentinel
-    needs: [scopes, runners]
-    if: ${{ needs.scopes.outputs.run_ui_p0 == 'true' }}
-    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).ui_hot }}
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-
-      - name: Configure CI parallelism
-        uses: ./.github/actions/configure-ci-parallelism
-
-      - name: Setup workspace
-        uses: ./.github/actions/setup-workspace
-        with:
-          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_hot) }}
-
-      - name: Setup Playwright
-        uses: ./.github/actions/setup-playwright
-        with:
-          package-json-path: e2e/package.json
-          install-command: pnpm -C e2e exec playwright install --with-deps chromium
-          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_hot) }}
-
-      - name: Prebuild workspace type declarations
-        run: |
-          pnpm --filter @open-design/daemon build
-          pnpm --filter @open-design/desktop build
-          pnpm --filter @open-design/web build:sidecar
-
-      - name: Clean Playwright state
-        run: pnpm -C e2e exec tsx scripts/playwright.ts clean
-
-      - name: Run UI merge sentinel
-        run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group merge-sentinel
-
-      - name: Upload Playwright debug artifact
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: ui-p0-ci-${{ github.run_id }}-merge-sentinel
-          path: |
-            e2e/ui/reports/playwright-html-report
-            e2e/ui/reports/test-results
-            e2e/ui/reports/results.json
-            e2e/ui/test-results
-          if-no-files-found: ignore
-          retention-days: 7
-
   ui_p0:
     name: UI P0 (${{ matrix.name }})
     needs: [scopes, runners]
@@ -533,6 +482,23 @@ jobs:
 
       - name: Run UI P0 domain
         run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group ${{ matrix.shard }}
+
+      - name: Preserve project-runtime domain artifact
+        if: ${{ success() && matrix.shard == 'project-runtime' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ui-p0-ci-${{ github.run_id }}-${{ matrix.name }}-domain
+          path: |
+            e2e/ui/reports/playwright-html-report
+            e2e/ui/reports/test-results
+            e2e/ui/reports/results.json
+            e2e/ui/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Run UI critical extras
+        if: ${{ matrix.shard == 'project-runtime' }}
+        run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group critical-extras
 
       - name: Upload Playwright debug artifact
         if: ${{ always() }}
@@ -648,7 +614,6 @@ jobs:
       - web_workspace_tests
       - e2e_vitest
       - playwright_critical
-      - ui_p0_smoke
       - ui_p0
       - playwright_visual
     if: ${{ always() }}
@@ -695,7 +660,7 @@ jobs:
               + when($out.run_web_workspace_tests == "true"; ["web_workspace_tests"])
               + when($out.run_e2e_vitest == "true"; ["e2e_vitest"])
               + when($out.run_playwright_critical == "true"; ["playwright_critical"])
-              + when($out.run_ui_p0 == "true"; ["ui_p0_smoke", "ui_p0"])
+              + when($out.run_ui_p0 == "true"; ["ui_p0"])
               + when($out.run_playwright_visual == "true"; ["playwright_visual"])
             )[]
             | select(($needs[.].result // "missing") != "success")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,7 +442,7 @@ jobs:
         run: pnpm -C e2e exec playwright test -c playwright.config.ts ${{ matrix.files }} --grep '@critical'
 
   ui_p0_smoke:
-    name: UI P0 smoke
+    name: UI merge sentinel
     needs: [scopes, runners]
     if: ${{ needs.scopes.outputs.run_ui_p0 == 'true' }}
     runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).ui_hot }}
@@ -476,14 +476,14 @@ jobs:
       - name: Clean Playwright state
         run: pnpm -C e2e exec tsx scripts/playwright.ts clean
 
-      - name: Run UI shell smoke
-        run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group smoke
+      - name: Run UI merge sentinel
+        run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group merge-sentinel
 
       - name: Upload Playwright debug artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ui-p0-ci-${{ github.run_id }}-smoke
+          name: ui-p0-ci-${{ github.run_id }}-merge-sentinel
           path: |
             e2e/ui/reports/playwright-html-report
             e2e/ui/reports/test-results

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -25,8 +25,8 @@ concurrency:
 
 jobs:
   p0_runners:
-    name: Resolve P0 runner profiles
-    if: ${{ github.repository == 'nexu-io/open-design' && github.event_name == 'workflow_dispatch' && inputs.suite != 'full' }}
+    name: Resolve UI runner profiles
+    if: ${{ github.repository == 'nexu-io/open-design' }}
     runs-on: ubuntu-24.04
     outputs:
       runs_on: ${{ steps.runners.outputs.runs_on }}
@@ -176,23 +176,88 @@ jobs:
           retention-days: 7
 
   ui_full:
-    name: Full UI regression
+    name: Full UI (${{ matrix.name }})
+    needs: [p0_runners]
     if: ${{ github.repository == 'nexu-io/open-design' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.suite == 'full')) }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
+    runs-on: ${{ fromJSON(needs.p0_runners.outputs.runs_on).ui_hot }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: entry-automation
+            workers: 2
+            files: >-
+              ui/automations-page.test.ts
+              ui/critical-smoke.test.ts
+              ui/entry-chrome-flows.test.ts
+              ui/entry-configuration-flows.test.ts
+              ui/entry-topbar.test.ts
+              ui/home-hero-rail.test.ts
+              ui/settings-memory-routines.test.ts
+          - name: settings-focused
+            workers: 2
+            files: >-
+              ui/amr-login-pill.test.ts
+              ui/amr-logout-requires-relogin.test.ts
+              ui/amr-onboarding.test.ts
+              ui/amr-run-failure-recovery.test.ts
+              ui/chat-todo-autoscroll.test.ts
+              ui/composer-footer-card.test.ts
+              ui/composer-toolbar-alignment.test.ts
+              ui/critique-theater.test.ts
+              ui/design-systems-manager.test.ts
+              ui/diagnostics-export.test.ts
+              ui/home-composer-topbar-stacking.test.ts
+              ui/new-project-ds-picker-clipping.test.ts
+              ui/new-project-ds-picker-stacking.test.ts
+              ui/settings-api-protocol.test.ts
+              ui/settings-connectors-auth-happy-path.test.ts
+              ui/settings-connectors-auth-recovery.test.ts
+              ui/settings-design-systems.test.ts
+              ui/settings-hover-contrast.test.ts
+              ui/settings-local-cli-codex-fallback.test.ts
+              ui/settings-mcp-snippet-chip.test.ts
+              ui/settings-media-providers.test.ts
+              ui/split-resize-scrollbar-hitbox.test.ts
+              ui/updater-popup-stacking.test.ts
+          - name: project-workspace
+            workers: 1
+            files: >-
+              ui/app-design-files.test.ts
+              ui/app-manual-edit.test.ts
+              ui/chat-design-system-switch.test.ts
+              ui/project-file-link-routing.test.ts
+              ui/project-management-flows.test.ts
+              ui/workspace-keyboard-flows.test.ts
+          - name: runtime-restoration
+            workers: 1
+            files: >-
+              ui/api-empty-response.test.ts
+              ui/app-restoration.test.ts
+              ui/app.test.ts
+              ui/preview-run-status.test.ts
+              ui/real-daemon-run.test.ts
+              ui/reload-spurious-failed-run.test.ts
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
 
+      - name: Configure CI parallelism
+        uses: ./.github/actions/configure-ci-parallelism
+
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
+        with:
+          runner-labels: ${{ toJSON(fromJSON(needs.p0_runners.outputs.runs_on).ui_hot) }}
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
         with:
           package-json-path: e2e/package.json
           install-command: pnpm -C e2e exec playwright install --with-deps chromium
+          runner-labels: ${{ toJSON(fromJSON(needs.p0_runners.outputs.runs_on).ui_hot) }}
 
       - name: Prebuild workspace type declarations
         run: |
@@ -203,14 +268,16 @@ jobs:
       - name: Clean Playwright state
         run: pnpm -C e2e exec tsx scripts/playwright.ts clean
 
-      - name: Run full UI
-        run: pnpm -C e2e test:ui
+      - name: Run full UI domain
+        env:
+          OD_PLAYWRIGHT_WORKERS: ${{ matrix.workers }}
+        run: pnpm -C e2e exec playwright test -c playwright.config.ts ${{ matrix.files }} --grep '\[P[012]\]'
 
       - name: Upload Playwright debug artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ui-full-${{ github.run_id }}
+          name: ui-full-${{ github.run_id }}-${{ matrix.name }}
           path: |
             e2e/ui/reports/playwright-html-report
             e2e/ui/reports/test-results

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -1,9 +1,6 @@
 name: ui-extended-main
 
 on:
-  schedule:
-    # 02:00 UTC = 10:00 Asia/Shanghai
-    - cron: "0 2 * * *"
   workflow_dispatch:
     inputs:
       suite:
@@ -176,69 +173,15 @@ jobs:
           retention-days: 7
 
   ui_full:
-    name: Full UI (${{ matrix.name }})
+    name: Full UI (shard ${{ matrix.shard }}/8)
     needs: [p0_runners]
-    if: ${{ github.repository == 'nexu-io/open-design' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.suite == 'full')) }}
+    if: ${{ github.repository == 'nexu-io/open-design' && github.event_name == 'workflow_dispatch' && inputs.suite == 'full' }}
     runs-on: ${{ fromJSON(needs.p0_runners.outputs.runs_on).ui_hot }}
-    timeout-minutes: 60
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - name: entry-automation
-            workers: 2
-            files: >-
-              ui/automations-page.test.ts
-              ui/critical-smoke.test.ts
-              ui/entry-chrome-flows.test.ts
-              ui/entry-configuration-flows.test.ts
-              ui/entry-topbar.test.ts
-              ui/home-hero-rail.test.ts
-              ui/settings-memory-routines.test.ts
-          - name: settings-focused
-            workers: 2
-            files: >-
-              ui/amr-login-pill.test.ts
-              ui/amr-logout-requires-relogin.test.ts
-              ui/amr-onboarding.test.ts
-              ui/amr-run-failure-recovery.test.ts
-              ui/chat-todo-autoscroll.test.ts
-              ui/composer-footer-card.test.ts
-              ui/composer-toolbar-alignment.test.ts
-              ui/critique-theater.test.ts
-              ui/design-systems-manager.test.ts
-              ui/diagnostics-export.test.ts
-              ui/home-composer-topbar-stacking.test.ts
-              ui/new-project-ds-picker-clipping.test.ts
-              ui/new-project-ds-picker-stacking.test.ts
-              ui/settings-api-protocol.test.ts
-              ui/settings-connectors-auth-happy-path.test.ts
-              ui/settings-connectors-auth-recovery.test.ts
-              ui/settings-design-systems.test.ts
-              ui/settings-hover-contrast.test.ts
-              ui/settings-local-cli-codex-fallback.test.ts
-              ui/settings-mcp-snippet-chip.test.ts
-              ui/settings-media-providers.test.ts
-              ui/split-resize-scrollbar-hitbox.test.ts
-              ui/updater-popup-stacking.test.ts
-          - name: project-workspace
-            workers: 1
-            files: >-
-              ui/app-design-files.test.ts
-              ui/app-manual-edit.test.ts
-              ui/chat-design-system-switch.test.ts
-              ui/project-file-link-routing.test.ts
-              ui/project-management-flows.test.ts
-              ui/workspace-keyboard-flows.test.ts
-          - name: runtime-restoration
-            workers: 1
-            files: >-
-              ui/api-empty-response.test.ts
-              ui/app-restoration.test.ts
-              ui/app.test.ts
-              ui/preview-run-status.test.ts
-              ui/real-daemon-run.test.ts
-              ui/reload-spurious-failed-run.test.ts
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
 
     steps:
       - name: Checkout
@@ -268,58 +211,17 @@ jobs:
       - name: Clean Playwright state
         run: pnpm -C e2e exec tsx scripts/playwright.ts clean
 
-      # Keep one checkout/install/prebuild per functional owner, but restart the
-      # worker-scoped tools-dev runtimes between shades. A failing lower-priority
-      # serial test must not prevent a later P0 case in the same file from ever
-      # running, so P0 is evaluated first and every later shade uses `always()`.
-      - name: Run full UI P0 domain
+      - name: Run full UI shard
         env:
-          OD_PLAYWRIGHT_WORKERS: ${{ matrix.workers }}
-        run: pnpm -C e2e exec playwright test -c playwright.config.ts ${{ matrix.files }} --grep '\[P0\]'
+          OD_PLAYWRIGHT_FULLY_PARALLEL: "1"
+          OD_PLAYWRIGHT_WORKERS: "2"
+        run: pnpm -C e2e exec playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/8
 
-      - name: Upload full UI P0 artifact
+      - name: Upload full UI shard artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ui-full-${{ github.run_id }}-${{ matrix.name }}-p0
-          path: |
-            e2e/ui/reports/playwright-html-report
-            e2e/ui/reports/test-results
-            e2e/ui/reports/results.json
-            e2e/ui/test-results
-          if-no-files-found: ignore
-          retention-days: 7
-
-      - name: Run full UI P1 domain
-        if: ${{ always() }}
-        env:
-          OD_PLAYWRIGHT_WORKERS: ${{ matrix.workers }}
-        run: pnpm -C e2e exec playwright test -c playwright.config.ts ${{ matrix.files }} --grep '\[P1\]'
-
-      - name: Upload full UI P1 artifact
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: ui-full-${{ github.run_id }}-${{ matrix.name }}-p1
-          path: |
-            e2e/ui/reports/playwright-html-report
-            e2e/ui/reports/test-results
-            e2e/ui/reports/results.json
-            e2e/ui/test-results
-          if-no-files-found: ignore
-          retention-days: 7
-
-      - name: Run full UI P2 domain
-        if: ${{ always() }}
-        env:
-          OD_PLAYWRIGHT_WORKERS: ${{ matrix.workers }}
-        run: pnpm -C e2e exec playwright test -c playwright.config.ts ${{ matrix.files }} --grep '\[P2\]'
-
-      - name: Upload full UI P2 artifact
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: ui-full-${{ github.run_id }}-${{ matrix.name }}-p2
+          name: ui-full-${{ github.run_id }}-shard-${{ matrix.shard }}-of-8
           path: |
             e2e/ui/reports/playwright-html-report
             e2e/ui/reports/test-results

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -268,16 +268,58 @@ jobs:
       - name: Clean Playwright state
         run: pnpm -C e2e exec tsx scripts/playwright.ts clean
 
-      - name: Run full UI domain
+      # Keep one checkout/install/prebuild per functional owner, but restart the
+      # worker-scoped tools-dev runtimes between shades. A failing lower-priority
+      # serial test must not prevent a later P0 case in the same file from ever
+      # running, so P0 is evaluated first and every later shade uses `always()`.
+      - name: Run full UI P0 domain
         env:
           OD_PLAYWRIGHT_WORKERS: ${{ matrix.workers }}
-        run: pnpm -C e2e exec playwright test -c playwright.config.ts ${{ matrix.files }} --grep '\[P[012]\]'
+        run: pnpm -C e2e exec playwright test -c playwright.config.ts ${{ matrix.files }} --grep '\[P0\]'
 
-      - name: Upload Playwright debug artifact
+      - name: Upload full UI P0 artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ui-full-${{ github.run_id }}-${{ matrix.name }}
+          name: ui-full-${{ github.run_id }}-${{ matrix.name }}-p0
+          path: |
+            e2e/ui/reports/playwright-html-report
+            e2e/ui/reports/test-results
+            e2e/ui/reports/results.json
+            e2e/ui/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Run full UI P1 domain
+        if: ${{ always() }}
+        env:
+          OD_PLAYWRIGHT_WORKERS: ${{ matrix.workers }}
+        run: pnpm -C e2e exec playwright test -c playwright.config.ts ${{ matrix.files }} --grep '\[P1\]'
+
+      - name: Upload full UI P1 artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ui-full-${{ github.run_id }}-${{ matrix.name }}-p1
+          path: |
+            e2e/ui/reports/playwright-html-report
+            e2e/ui/reports/test-results
+            e2e/ui/reports/results.json
+            e2e/ui/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Run full UI P2 domain
+        if: ${{ always() }}
+        env:
+          OD_PLAYWRIGHT_WORKERS: ${{ matrix.workers }}
+        run: pnpm -C e2e exec playwright test -c playwright.config.ts ${{ matrix.files }} --grep '\[P2\]'
+
+      - name: Upload full UI P2 artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ui-full-${{ github.run_id }}-${{ matrix.name }}-p2
           path: |
             e2e/ui/reports/playwright-html-report
             e2e/ui/reports/test-results

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -22,6 +22,7 @@ on:
         type: choice
         options:
           - standalone
+          - workspace-restoration
           - project-runtime
           - entry-settings
 
@@ -152,7 +153,7 @@ jobs:
         run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group ${{ matrix.shard }}
 
       - name: Run hosted UI merge sentinel
-        if: ${{ (inputs.layout == 'project-runtime' && matrix.shard == 'project-runtime') || (inputs.layout == 'entry-settings' && matrix.shard == 'entry-settings') }}
+        if: ${{ (inputs.layout == 'workspace-restoration' && matrix.shard == 'workspace-restoration') || (inputs.layout == 'project-runtime' && matrix.shard == 'project-runtime') || (inputs.layout == 'entry-settings' && matrix.shard == 'entry-settings') }}
         run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group merge-sentinel
 
       - name: Upload Playwright debug artifact

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -212,9 +212,11 @@ jobs:
         run: pnpm -C e2e exec tsx scripts/playwright.ts clean
 
       - name: Run full UI shard
+        # Worker count comes from configure-ci-parallelism (nproc/2, so two
+        # on the four-core ui_hot profile); fully-parallel stays on for
+        # test-granularity sharding.
         env:
           OD_PLAYWRIGHT_FULLY_PARALLEL: "1"
-          OD_PLAYWRIGHT_WORKERS: "1"
         run: pnpm -C e2e exec playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/12
 
       - name: Upload full UI shard artifact

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -212,12 +212,16 @@ jobs:
         run: pnpm -C e2e exec tsx scripts/playwright.ts clean
 
       - name: Run full UI shard
-        # Worker count comes from configure-ci-parallelism (nproc/2, so two
-        # on the four-core ui_hot profile); fully-parallel stays on for
-        # test-granularity sharding.
+        # PROBE: Blacksmith 4vcpu runners are reported to provide six actual
+        # vCPUs; nproc (cgroup view) says four, so configure-ci-parallelism
+        # derives two workers and leaves capacity idle. Pin three workers for
+        # this experiment and print the CPU topology for verification.
         env:
           OD_PLAYWRIGHT_FULLY_PARALLEL: "1"
-        run: pnpm -C e2e exec playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/12
+          OD_PLAYWRIGHT_WORKERS: "3"
+        run: |
+          echo "cpu-probe nproc=$(nproc) nproc-all=$(nproc --all) cpuinfo=$(grep -c ^processor /proc/cpuinfo)"
+          pnpm -C e2e exec playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/12
 
       - name: Upload full UI shard artifact
         if: ${{ always() }}

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -23,6 +23,7 @@ on:
         options:
           - standalone
           - distributed
+          - split
           - workspace-restoration
           - project-runtime
           - entry-settings
@@ -116,15 +117,19 @@ jobs:
           - name: entry-settings
             shard: entry-settings
             distributed_shard: entry-settings
+            split_shard: entry-settings
           - name: project-workspace
             shard: project-workspace
             distributed_shard: project-workspace-distributed
+            split_shard: project-workspace
           - name: project-runtime
             shard: project-runtime
             distributed_shard: project-runtime
+            split_shard: project-runtime
           - name: workspace-restoration
             shard: workspace-restoration
             distributed_shard: workspace-restoration-distributed
+            split_shard: workspace-restoration-smoke
 
     steps:
       - name: Checkout
@@ -155,7 +160,13 @@ jobs:
         run: pnpm -C e2e exec tsx scripts/playwright.ts clean
 
       - name: Run UI P0 domain
-        run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group ${{ inputs.layout == 'distributed' && matrix.distributed_shard || matrix.shard }}
+        run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group ${{ inputs.layout == 'distributed' && matrix.distributed_shard || inputs.layout == 'split' && matrix.split_shard || matrix.shard }}
+
+      - name: Run hosted UI critical extras
+        if: ${{ inputs.layout == 'split' && matrix.shard == 'project-runtime' }}
+        env:
+          OD_PLAYWRIGHT_FULLY_PARALLEL: "1"
+        run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group critical-extras
 
       - name: Run hosted UI merge sentinel
         if: ${{ (inputs.layout == 'workspace-restoration' && matrix.shard == 'workspace-restoration') || (inputs.layout == 'project-runtime' && matrix.shard == 'project-runtime') || (inputs.layout == 'entry-settings' && matrix.shard == 'entry-settings') }}

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -15,18 +15,6 @@ on:
           - p0
           - p0p1
           - full
-      layout:
-        description: "P0 merge-sentinel layout (manual benchmark only)"
-        required: true
-        default: standalone
-        type: choice
-        options:
-          - standalone
-          - distributed
-          - split
-          - workspace-restoration
-          - project-runtime
-          - entry-settings
 
 permissions:
   contents: read
@@ -36,8 +24,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  benchmark_runners:
-    name: Resolve benchmark runner profiles
+  p0_runners:
+    name: Resolve P0 runner profiles
     if: ${{ github.repository == 'nexu-io/open-design' && github.event_name == 'workflow_dispatch' && inputs.suite != 'full' }}
     runs-on: ubuntu-24.04
     outputs:
@@ -53,62 +41,11 @@ jobs:
           OD_CI_RUNNER_MODE: ${{ vars.OD_CI_RUNNER_MODE }}
         run: python3 .github/scripts/runners.py
 
-  ui_p0_sentinel:
-    name: UI P0 (merge-sentinel)
-    needs: [benchmark_runners]
-    if: ${{ github.repository == 'nexu-io/open-design' && github.event_name == 'workflow_dispatch' && inputs.suite != 'full' && inputs.layout == 'standalone' }}
-    runs-on: ${{ fromJSON(needs.benchmark_runners.outputs.runs_on).ui_hot }}
-    timeout-minutes: 30
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6.0.2
-
-      - name: Configure CI parallelism
-        uses: ./.github/actions/configure-ci-parallelism
-
-      - name: Setup workspace
-        uses: ./.github/actions/setup-workspace
-        with:
-          runner-labels: ${{ toJSON(fromJSON(needs.benchmark_runners.outputs.runs_on).ui_hot) }}
-
-      - name: Setup Playwright
-        uses: ./.github/actions/setup-playwright
-        with:
-          package-json-path: e2e/package.json
-          install-command: pnpm -C e2e exec playwright install --with-deps chromium
-          runner-labels: ${{ toJSON(fromJSON(needs.benchmark_runners.outputs.runs_on).ui_hot) }}
-
-      - name: Prebuild workspace type declarations
-        run: |
-          pnpm --filter @open-design/daemon build
-          pnpm --filter @open-design/desktop build
-          pnpm --filter @open-design/web build:sidecar
-
-      - name: Clean Playwright state
-        run: pnpm -C e2e exec tsx scripts/playwright.ts clean
-
-      - name: Run UI merge sentinel
-        run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group merge-sentinel
-
-      - name: Upload Playwright debug artifact
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: ui-p0-benchmark-${{ github.run_id }}-${{ inputs.layout }}-merge-sentinel
-          path: |
-            e2e/ui/reports/playwright-html-report
-            e2e/ui/reports/test-results
-            e2e/ui/reports/results.json
-            e2e/ui/test-results
-          if-no-files-found: ignore
-          retention-days: 7
-
   ui_p0:
     name: UI P0 (${{ matrix.name }})
-    needs: [benchmark_runners]
+    needs: [p0_runners]
     if: ${{ github.repository == 'nexu-io/open-design' && github.event_name == 'workflow_dispatch' && inputs.suite != 'full' }}
-    runs-on: ${{ fromJSON(needs.benchmark_runners.outputs.runs_on).ui_hot }}
+    runs-on: ${{ fromJSON(needs.p0_runners.outputs.runs_on).ui_hot }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -116,20 +53,12 @@ jobs:
         include:
           - name: entry-settings
             shard: entry-settings
-            distributed_shard: entry-settings
-            split_shard: entry-settings
           - name: project-workspace
             shard: project-workspace
-            distributed_shard: project-workspace-distributed
-            split_shard: project-workspace
           - name: project-runtime
             shard: project-runtime
-            distributed_shard: project-runtime
-            split_shard: project-runtime
           - name: workspace-restoration
             shard: workspace-restoration
-            distributed_shard: workspace-restoration-distributed
-            split_shard: workspace-restoration-smoke
 
     steps:
       - name: Checkout
@@ -141,14 +70,14 @@ jobs:
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
         with:
-          runner-labels: ${{ toJSON(fromJSON(needs.benchmark_runners.outputs.runs_on).ui_hot) }}
+          runner-labels: ${{ toJSON(fromJSON(needs.p0_runners.outputs.runs_on).ui_hot) }}
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
         with:
           package-json-path: e2e/package.json
           install-command: pnpm -C e2e exec playwright install --with-deps chromium
-          runner-labels: ${{ toJSON(fromJSON(needs.benchmark_runners.outputs.runs_on).ui_hot) }}
+          runner-labels: ${{ toJSON(fromJSON(needs.p0_runners.outputs.runs_on).ui_hot) }}
 
       - name: Prebuild workspace type declarations
         run: |
@@ -160,21 +89,30 @@ jobs:
         run: pnpm -C e2e exec tsx scripts/playwright.ts clean
 
       - name: Run UI P0 domain
-        run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group ${{ inputs.layout == 'distributed' && matrix.distributed_shard || inputs.layout == 'split' && matrix.split_shard || matrix.shard }}
+        run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group ${{ matrix.shard }}
 
-      - name: Run hosted UI critical extras
-        if: ${{ inputs.layout == 'split' && matrix.shard == 'project-runtime' }}
+      - name: Preserve project-runtime domain artifact
+        if: ${{ success() && matrix.shard == 'project-runtime' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ui-extended-main-${{ github.run_id }}-p0-${{ matrix.name }}-domain
+          path: |
+            e2e/ui/reports/playwright-html-report
+            e2e/ui/reports/test-results
+            e2e/ui/reports/results.json
+            e2e/ui/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Run UI critical extras
+        if: ${{ matrix.shard == 'project-runtime' }}
         run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group critical-extras
-
-      - name: Run hosted UI merge sentinel
-        if: ${{ (inputs.layout == 'workspace-restoration' && matrix.shard == 'workspace-restoration') || (inputs.layout == 'project-runtime' && matrix.shard == 'project-runtime') || (inputs.layout == 'entry-settings' && matrix.shard == 'entry-settings') }}
-        run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group merge-sentinel
 
       - name: Upload Playwright debug artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ui-p0-benchmark-${{ github.run_id }}-${{ inputs.layout }}-${{ matrix.name }}
+          name: ui-extended-main-${{ github.run_id }}-p0-${{ matrix.name }}
           path: |
             e2e/ui/reports/playwright-html-report
             e2e/ui/reports/test-results
@@ -194,10 +132,10 @@ jobs:
         include:
           - name: P1 shard 1
             part: p1
-            command: pnpm -C e2e exec playwright test -c playwright.config.ts ui --grep '\[P1\]' --shard=1/2
+            command: pnpm -C e2e exec playwright test -c playwright.config.ts ui --grep '\[P1\]' --grep-invert '@merge-extra' --shard=1/2
           - name: P1 shard 2
             part: p1
-            command: pnpm -C e2e exec playwright test -c playwright.config.ts ui --grep '\[P1\]' --shard=2/2
+            command: pnpm -C e2e exec playwright test -c playwright.config.ts ui --grep '\[P1\]' --grep-invert '@merge-extra' --shard=2/2
 
     steps:
       - name: Checkout

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -164,8 +164,6 @@ jobs:
 
       - name: Run hosted UI critical extras
         if: ${{ inputs.layout == 'split' && matrix.shard == 'project-runtime' }}
-        env:
-          OD_PLAYWRIGHT_FULLY_PARALLEL: "1"
         run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group critical-extras
 
       - name: Run hosted UI merge sentinel

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -212,16 +212,12 @@ jobs:
         run: pnpm -C e2e exec tsx scripts/playwright.ts clean
 
       - name: Run full UI shard
-        # PROBE: Blacksmith 4vcpu runners are reported to provide six actual
-        # vCPUs; nproc (cgroup view) says four, so configure-ci-parallelism
-        # derives two workers and leaves capacity idle. Pin three workers for
-        # this experiment and print the CPU topology for verification.
+        # Worker count comes from configure-ci-parallelism (nproc/2, so two
+        # on the four-core ui_hot profile); fully-parallel stays on for
+        # test-granularity sharding.
         env:
           OD_PLAYWRIGHT_FULLY_PARALLEL: "1"
-          OD_PLAYWRIGHT_WORKERS: "3"
-        run: |
-          echo "cpu-probe nproc=$(nproc) nproc-all=$(nproc --all) cpuinfo=$(grep -c ^processor /proc/cpuinfo)"
-          pnpm -C e2e exec playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/12
+        run: pnpm -C e2e exec playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/12
 
       - name: Upload full UI shard artifact
         if: ${{ always() }}

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -22,6 +22,7 @@ on:
         type: choice
         options:
           - standalone
+          - distributed
           - workspace-restoration
           - project-runtime
           - entry-settings
@@ -114,12 +115,16 @@ jobs:
         include:
           - name: entry-settings
             shard: entry-settings
+            distributed_shard: entry-settings
           - name: project-workspace
             shard: project-workspace
+            distributed_shard: project-workspace-distributed
           - name: project-runtime
             shard: project-runtime
+            distributed_shard: project-runtime
           - name: workspace-restoration
             shard: workspace-restoration
+            distributed_shard: workspace-restoration-distributed
 
     steps:
       - name: Checkout
@@ -150,7 +155,7 @@ jobs:
         run: pnpm -C e2e exec tsx scripts/playwright.ts clean
 
       - name: Run UI P0 domain
-        run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group ${{ matrix.shard }}
+        run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group ${{ inputs.layout == 'distributed' && matrix.distributed_shard || matrix.shard }}
 
       - name: Run hosted UI merge sentinel
         if: ${{ (inputs.layout == 'workspace-restoration' && matrix.shard == 'workspace-restoration') || (inputs.layout == 'project-runtime' && matrix.shard == 'project-runtime') || (inputs.layout == 'entry-settings' && matrix.shard == 'entry-settings') }}

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -173,7 +173,7 @@ jobs:
           retention-days: 7
 
   ui_full:
-    name: Full UI (shard ${{ matrix.shard }}/24)
+    name: Full UI (shard ${{ matrix.shard }}/12)
     needs: [p0_runners]
     if: ${{ github.repository == 'nexu-io/open-design' && github.event_name == 'workflow_dispatch' && inputs.suite == 'full' }}
     runs-on: ${{ fromJSON(needs.p0_runners.outputs.runs_on).ui_hot }}
@@ -181,7 +181,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 
     steps:
       - name: Checkout
@@ -215,13 +215,13 @@ jobs:
         env:
           OD_PLAYWRIGHT_FULLY_PARALLEL: "1"
           OD_PLAYWRIGHT_WORKERS: "1"
-        run: pnpm -C e2e exec playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/24
+        run: pnpm -C e2e exec playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/12
 
       - name: Upload full UI shard artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ui-full-${{ github.run_id }}-shard-${{ matrix.shard }}-of-24
+          name: ui-full-${{ github.run_id }}-shard-${{ matrix.shard }}-of-12
           path: |
             e2e/ui/reports/playwright-html-report
             e2e/ui/reports/test-results

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -173,7 +173,7 @@ jobs:
           retention-days: 7
 
   ui_full:
-    name: Full UI (shard ${{ matrix.shard }}/8)
+    name: Full UI (shard ${{ matrix.shard }}/12)
     needs: [p0_runners]
     if: ${{ github.repository == 'nexu-io/open-design' && github.event_name == 'workflow_dispatch' && inputs.suite == 'full' }}
     runs-on: ${{ fromJSON(needs.p0_runners.outputs.runs_on).ui_hot }}
@@ -181,7 +181,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 
     steps:
       - name: Checkout
@@ -214,14 +214,14 @@ jobs:
       - name: Run full UI shard
         env:
           OD_PLAYWRIGHT_FULLY_PARALLEL: "1"
-          OD_PLAYWRIGHT_WORKERS: "2"
-        run: pnpm -C e2e exec playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/8
+          OD_PLAYWRIGHT_WORKERS: "1"
+        run: pnpm -C e2e exec playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/12
 
       - name: Upload full UI shard artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ui-full-${{ github.run_id }}-shard-${{ matrix.shard }}-of-8
+          name: ui-full-${{ github.run_id }}-shard-${{ matrix.shard }}-of-12
           path: |
             e2e/ui/reports/playwright-html-report
             e2e/ui/reports/test-results

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -15,6 +15,15 @@ on:
           - p0
           - p0p1
           - full
+      layout:
+        description: "P0 merge-sentinel layout (manual benchmark only)"
+        required: true
+        default: standalone
+        type: choice
+        options:
+          - standalone
+          - project-runtime
+          - entry-settings
 
 permissions:
   contents: read
@@ -24,34 +33,48 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ui_p0:
-    name: UI P0 (${{ matrix.name }})
+  benchmark_runners:
+    name: Resolve benchmark runner profiles
     if: ${{ github.repository == 'nexu-io/open-design' && github.event_name == 'workflow_dispatch' && inputs.suite != 'full' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: entry-settings
-            shard: entry-settings
-          - name: project-runtime
-            shard: project-runtime
-          - name: workspace-restoration
-            shard: workspace-restoration
+    runs-on: ubuntu-24.04
+    outputs:
+      runs_on: ${{ steps.runners.outputs.runs_on }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
 
+      - name: Resolve runner profiles
+        id: runners
+        env:
+          OD_CI_RUNNER_MODE: ${{ vars.OD_CI_RUNNER_MODE }}
+        run: python3 .github/scripts/runners.py
+
+  ui_p0_sentinel:
+    name: UI P0 (merge-sentinel)
+    needs: [benchmark_runners]
+    if: ${{ github.repository == 'nexu-io/open-design' && github.event_name == 'workflow_dispatch' && inputs.suite != 'full' && inputs.layout == 'standalone' }}
+    runs-on: ${{ fromJSON(needs.benchmark_runners.outputs.runs_on).ui_hot }}
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Configure CI parallelism
+        uses: ./.github/actions/configure-ci-parallelism
+
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
+        with:
+          runner-labels: ${{ toJSON(fromJSON(needs.benchmark_runners.outputs.runs_on).ui_hot) }}
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
         with:
           package-json-path: e2e/package.json
           install-command: pnpm -C e2e exec playwright install --with-deps chromium
+          runner-labels: ${{ toJSON(fromJSON(needs.benchmark_runners.outputs.runs_on).ui_hot) }}
 
       - name: Prebuild workspace type declarations
         run: |
@@ -62,17 +85,81 @@ jobs:
       - name: Clean Playwright state
         run: pnpm -C e2e exec tsx scripts/playwright.ts clean
 
-      - name: Run UI shell smoke
-        run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group smoke
-
-      - name: Run UI P0 domain
-        run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group ${{ matrix.shard }}
+      - name: Run UI merge sentinel
+        run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group merge-sentinel
 
       - name: Upload Playwright debug artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ui-p0-${{ github.run_id }}-${{ matrix.name }}
+          name: ui-p0-benchmark-${{ github.run_id }}-${{ inputs.layout }}-merge-sentinel
+          path: |
+            e2e/ui/reports/playwright-html-report
+            e2e/ui/reports/test-results
+            e2e/ui/reports/results.json
+            e2e/ui/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
+  ui_p0:
+    name: UI P0 (${{ matrix.name }})
+    needs: [benchmark_runners]
+    if: ${{ github.repository == 'nexu-io/open-design' && github.event_name == 'workflow_dispatch' && inputs.suite != 'full' }}
+    runs-on: ${{ fromJSON(needs.benchmark_runners.outputs.runs_on).ui_hot }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: entry-settings
+            shard: entry-settings
+          - name: project-workspace
+            shard: project-workspace
+          - name: project-runtime
+            shard: project-runtime
+          - name: workspace-restoration
+            shard: workspace-restoration
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Configure CI parallelism
+        uses: ./.github/actions/configure-ci-parallelism
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
+        with:
+          runner-labels: ${{ toJSON(fromJSON(needs.benchmark_runners.outputs.runs_on).ui_hot) }}
+
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
+        with:
+          package-json-path: e2e/package.json
+          install-command: pnpm -C e2e exec playwright install --with-deps chromium
+          runner-labels: ${{ toJSON(fromJSON(needs.benchmark_runners.outputs.runs_on).ui_hot) }}
+
+      - name: Prebuild workspace type declarations
+        run: |
+          pnpm --filter @open-design/daemon build
+          pnpm --filter @open-design/desktop build
+          pnpm --filter @open-design/web build:sidecar
+
+      - name: Clean Playwright state
+        run: pnpm -C e2e exec tsx scripts/playwright.ts clean
+
+      - name: Run UI P0 domain
+        run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group ${{ matrix.shard }}
+
+      - name: Run hosted UI merge sentinel
+        if: ${{ (inputs.layout == 'project-runtime' && matrix.shard == 'project-runtime') || (inputs.layout == 'entry-settings' && matrix.shard == 'entry-settings') }}
+        run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group merge-sentinel
+
+      - name: Upload Playwright debug artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ui-p0-benchmark-${{ github.run_id }}-${{ inputs.layout }}-${{ matrix.name }}
           path: |
             e2e/ui/reports/playwright-html-report
             e2e/ui/reports/test-results

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -173,7 +173,7 @@ jobs:
           retention-days: 7
 
   ui_full:
-    name: Full UI (shard ${{ matrix.shard }}/12)
+    name: Full UI (shard ${{ matrix.shard }}/24)
     needs: [p0_runners]
     if: ${{ github.repository == 'nexu-io/open-design' && github.event_name == 'workflow_dispatch' && inputs.suite == 'full' }}
     runs-on: ${{ fromJSON(needs.p0_runners.outputs.runs_on).ui_hot }}
@@ -181,7 +181,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]
 
     steps:
       - name: Checkout
@@ -215,13 +215,13 @@ jobs:
         env:
           OD_PLAYWRIGHT_FULLY_PARALLEL: "1"
           OD_PLAYWRIGHT_WORKERS: "1"
-        run: pnpm -C e2e exec playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/12
+        run: pnpm -C e2e exec playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/24
 
       - name: Upload full UI shard artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ui-full-${{ github.run_id }}-shard-${{ matrix.shard }}-of-12
+          name: ui-full-${{ github.run_id }}-shard-${{ matrix.shard }}-of-24
           path: |
             e2e/ui/reports/playwright-html-report
             e2e/ui/reports/test-results

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -260,7 +260,12 @@ interface Props {
   onOpenPetSettings?: () => void;
   researchAvailable?: boolean;
   projectMetadata?: ProjectMetadata;
-  onProjectMetadataChange?: (metadata: ProjectMetadata) => void;
+  // Fired after the daemon accepts a metadata PATCH, with the authoritative
+  // post-patch project (fresh `updatedAt` included). Callers must replace
+  // their whole project copy with it: forwarding only the metadata onto a
+  // stale copy lets an older detail snapshot win recency comparisons and
+  // shadow the change (e.g. the working-dir label never updating).
+  onProjectMetadataChange?: (updated: Project) => void;
   activeWorkspaceContext?: WorkspaceContextItem | null;
   initialWorkspaceContexts?: WorkspaceContextItem[];
   workspaceContexts?: WorkspaceContextItem[];
@@ -1338,7 +1343,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
           onShowToast?.(t('homeWorkingDir.applyFailed'));
           return false;
         }
-        onProjectMetadataChange?.(result.metadata);
+        onProjectMetadataChange?.(result);
         for (const trimmed of trimmedDirs) void rememberRecentDir(trimmed);
       }
       return trackedByDir;
@@ -1668,7 +1673,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
         onShowToast?.(t('homeWorkingDir.applyFailed'));
         return false;
       }
-      onProjectMetadataChange?.(result.metadata);
+      onProjectMetadataChange?.(result);
       setWorkspaceLinkedDirAdds((current) => {
         const { [id]: _removed, ...rest } = current;
         return rest;
@@ -2112,7 +2117,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
         onShowToast?.(t('homeWorkingDir.applyFailed'));
         return;
       }
-      onProjectMetadataChange?.(result.metadata);
+      onProjectMetadataChange?.(result);
       const promotedDir = dir.trim();
       setPromotedWorkspaceContextDir(
         selectedWorkspaceContextDirs.includes(promotedDir) ? promotedDir : null,
@@ -2141,7 +2146,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       const result = await patchProject(projectId, { metadata });
       if (result?.metadata) {
         setPromotedWorkspaceContextDir(null);
-        onProjectMetadataChange?.(result.metadata);
+        onProjectMetadataChange?.(result);
       }
     }
 

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -632,7 +632,9 @@ interface Props {
   onTogglePet?: () => void;
   onOpenPetSettings?: () => void;
   projectMetadata?: ProjectMetadata;
-  onProjectMetadataChange?: (metadata: ProjectMetadata) => void;
+  // Authoritative post-patch project from the daemon — see ChatComposer's
+  // prop of the same name for the recency invariant.
+  onProjectMetadataChange?: (updated: Project) => void;
   activeWorkspaceContext?: WorkspaceContextItem | null;
   initialWorkspaceContexts?: WorkspaceContextItem[];
   workspaceContexts?: WorkspaceContextItem[];

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -938,22 +938,34 @@ export function HomeView({
       options?.preserveInputFields ? inputFields : result.inputs ?? inputFields,
       reconciledInputs,
     );
-    setActive((prev) =>
-      prev && prev.record.id === record.id
-        ? {
-            ...prev,
-            result,
-            inputs: reconciledInputs,
-            inputFields: options?.preserveInputFields ? inputFields : result.inputs ?? inputFields,
-            inputsValid: reconciledInputsValid,
-            projectMetadata: homeCreateProjectMetadata(
-              prev.projectKind,
-              reconciledInputs,
-              prev.projectMetadata,
-            ),
-          }
-        : prev,
-    );
+    setActive((prev) => {
+      if (!prev || prev.record.id !== record.id) return prev;
+      // Mirror the prompt-reconcile guard below for the extracted inputs: the
+      // user may have edited the prompt during the apply roundtrip, and
+      // handlePromptChange has already extracted those edits into
+      // prev.inputs. Rebuilding from the bind-time optimistic snapshot would
+      // silently revert them, so merge the apply result's defaults into
+      // prev.inputs instead.
+      const mergedInputs: Record<string, unknown> = { ...prev.inputs };
+      for (const field of result.inputs ?? []) {
+        if (field.default !== undefined && mergedInputs[field.name] === undefined) {
+          mergedInputs[field.name] = field.default;
+        }
+      }
+      const mergedFields = options?.preserveInputFields ? inputFields : result.inputs ?? inputFields;
+      return {
+        ...prev,
+        result,
+        inputs: mergedInputs,
+        inputFields: mergedFields,
+        inputsValid: pluginInputsAreValid(mergedFields, mergedInputs),
+        projectMetadata: homeCreateProjectMetadata(
+          prev.projectKind,
+          mergedInputs,
+          prev.projectMetadata,
+        ),
+      };
+    });
     // The daemon may have filled in `topic`/`audience` defaults the
     // optimistic render didn't know about (the manifest is inspected
     // client-side but field.default lives on the apply result). Re-

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Dialog, DialogDescription, DialogFooter, DialogTitle } from '@open-design/components';
 import { createTabToTracking } from '@open-design/contracts/analytics';
 import { isOpenDesignHostAvailable, pickHostWorkingDir } from '@open-design/host';
@@ -2138,7 +2139,16 @@ function DesignSystemPicker({
   const [query, setQuery] = useState('');
   const [hoveredId, setHoveredId] = useState<string | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
   const searchRef = useRef<HTMLInputElement | null>(null);
+  const [anchor, setAnchor] = useState<{
+    top?: number;
+    bottom?: number;
+    left: number;
+    width: number;
+    maxHeight: number;
+  } | null>(null);
 
   // Upgrade the popover's thin list to the rich Brand Kit card whenever the
   // hovered / selected row is a finalized brand (`user:<id>` design system).
@@ -2194,10 +2204,59 @@ function DesignSystemPicker({
     return () => window.clearTimeout(t);
   }, [open]);
 
+  useLayoutEffect(() => {
+    if (!open) {
+      setAnchor(null);
+      return undefined;
+    }
+
+    function updateAnchor() {
+      const trigger = triggerRef.current;
+      if (!trigger) return;
+      const rect = trigger.getBoundingClientRect();
+      const width = Math.max(280, rect.width);
+      const left = Math.max(8, Math.min(window.innerWidth - width - 8, rect.left));
+      const gap = 6;
+      const margin = 12;
+      const preferredMin = 200;
+      const preferredMax = 440;
+      const spaceBelow = window.innerHeight - rect.bottom - gap - margin;
+      const spaceAbove = rect.top - gap - margin;
+      const openUp = spaceBelow < preferredMin + 80 && spaceAbove > spaceBelow;
+      const maxHeight = Math.max(0, Math.min(preferredMax, openUp ? spaceAbove : spaceBelow));
+
+      if (openUp) {
+        setAnchor({
+          bottom: window.innerHeight - rect.top + gap,
+          left,
+          width,
+          maxHeight,
+        });
+      } else {
+        setAnchor({
+          top: rect.bottom + gap,
+          left,
+          width,
+          maxHeight,
+        });
+      }
+    }
+
+    updateAnchor();
+    window.addEventListener('resize', updateAnchor);
+    window.addEventListener('scroll', updateAnchor, true);
+    return () => {
+      window.removeEventListener('resize', updateAnchor);
+      window.removeEventListener('scroll', updateAnchor, true);
+    };
+  }, [open]);
+
   useEffect(() => {
     if (!open) return;
     function onPointer(e: MouseEvent) {
-      if (wrapRef.current?.contains(e.target as Node)) return;
+      const target = e.target as Node;
+      if (wrapRef.current?.contains(target)) return;
+      if (popoverRef.current?.contains(target)) return;
       setOpen(false);
     }
     function onKey(e: KeyboardEvent) {
@@ -2267,6 +2326,7 @@ function DesignSystemPicker({
     >
       <label className="newproj-label">{t('newproj.designSystem')}</label>
       <button
+        ref={triggerRef}
         type="button"
         data-testid="design-system-trigger"
         className={`ds-picker-trigger${open ? ' open' : ''}${primary ? '' : ' empty'}`}
@@ -2297,8 +2357,21 @@ function DesignSystemPicker({
           style={{ transform: open ? 'rotate(180deg)' : undefined }}
         />
       </button>
-      {open ? (
-        <div className="ds-picker-popover" role="listbox">
+      {open && anchor && typeof document !== 'undefined'
+        ? createPortal(
+        <div
+          ref={popoverRef}
+          className="ds-picker-popover ds-picker-popover-portal"
+          role="listbox"
+          data-placement={anchor.bottom !== undefined ? 'up' : 'down'}
+          style={{
+            top: anchor.top ?? 'auto',
+            bottom: anchor.bottom ?? 'auto',
+            left: anchor.left,
+            width: anchor.width,
+            maxHeight: anchor.maxHeight,
+          }}
+        >
           <div className="ds-picker-head">
             <input
               ref={searchRef}
@@ -2392,8 +2465,10 @@ function DesignSystemPicker({
               </button>
             </div>
           ) : null}
-        </div>
-      ) : null}
+        </div>,
+          document.body,
+        )
+        : null}
       {open && previewBrand ? (
         <aside
           className="ds-picker-brand-flyout"

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -2148,6 +2148,9 @@ function DesignSystemPicker({
     left: number;
     width: number;
     maxHeight: number;
+    // Fixed viewport x for the brand preview flyout, placed beside the
+    // portaled popover (right when there is room, else left).
+    flyoutLeft: number;
   } | null>(null);
 
   // Upgrade the popover's thin list to the rich Brand Kit card whenever the
@@ -2225,12 +2228,31 @@ function DesignSystemPicker({
       const openUp = spaceBelow < preferredMin + 80 && spaceAbove > spaceBelow;
       const maxHeight = Math.max(0, Math.min(preferredMax, openUp ? spaceAbove : spaceBelow));
 
+      // Place the brand preview flyout beside the (portaled) popover: to its
+      // right when the 320px card fits, otherwise flipped to its left, then
+      // clamped into the viewport. Without this the flyout kept its old
+      // inline `position: absolute` against the trigger wrapper and was
+      // re-clipped by the modal body once the popover itself moved to a body
+      // portal.
+      const flyoutWidth = 320;
+      const rightLeft = left + width + 8;
+      const leftLeft = left - flyoutWidth - 8;
+      let flyoutLeft: number;
+      if (rightLeft + flyoutWidth <= window.innerWidth - 8) {
+        flyoutLeft = rightLeft;
+      } else if (leftLeft >= 8) {
+        flyoutLeft = leftLeft;
+      } else {
+        flyoutLeft = Math.max(8, window.innerWidth - flyoutWidth - 8);
+      }
+
       if (openUp) {
         setAnchor({
           bottom: window.innerHeight - rect.top + gap,
           left,
           width,
           maxHeight,
+          flyoutLeft,
         });
       } else {
         setAnchor({
@@ -2238,6 +2260,7 @@ function DesignSystemPicker({
           left,
           width,
           maxHeight,
+          flyoutLeft,
         });
       }
     }
@@ -2469,15 +2492,24 @@ function DesignSystemPicker({
           document.body,
         )
         : null}
-      {open && previewBrand ? (
+      {open && previewBrand && anchor && typeof document !== 'undefined'
+        ? createPortal(
         <aside
-          className="ds-picker-brand-flyout"
+          className="ds-picker-brand-flyout ds-picker-brand-flyout-portal"
           data-testid="new-project-ds-brand-flyout"
           aria-label={t('brandDetail.identity')}
+          style={{
+            top: anchor.top ?? 'auto',
+            bottom: anchor.bottom ?? 'auto',
+            left: anchor.flyoutLeft,
+            maxHeight: anchor.maxHeight,
+          }}
         >
           <BrandPreviewCard variant="compact" summary={previewBrand} />
-        </aside>
-      ) : null}
+        </aside>,
+          document.body,
+        )
+        : null}
     </div>
   );
 }

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -8680,9 +8680,7 @@ export function ProjectView({
               byokSpeechVoice={byokSpeechVoiceOverride}
               onChangeByokSpeechVoice={setByokSpeechVoiceOverride}
               projectMetadata={currentProject.metadata}
-              onProjectMetadataChange={(metadata) => {
-                onProjectChange({ ...project, metadata });
-              }}
+              onProjectMetadataChange={onProjectChange}
               activeWorkspaceContext={activeWorkspaceContext}
               initialWorkspaceContexts={initialWorkspaceContexts}
               workspaceContexts={workspaceContexts}

--- a/apps/web/src/styles/workspace/connectors.css
+++ b/apps/web/src/styles/workspace/connectors.css
@@ -137,6 +137,16 @@
   from { opacity: 0; transform: translateY(-4px); }
   to { opacity: 1; transform: translateY(0); }
 }
+.ds-picker-popover-portal {
+  position: fixed;
+  right: auto;
+  z-index: 1000;
+}
+.ds-picker-popover-portal .ds-picker-list {
+  max-height: none;
+  flex: 1 1 auto;
+  min-height: 0;
+}
 /* Rich brand preview flyout — a side panel anchored to the popover that shows
    the compact Brand Kit card for the hovered / selected brand. It sits OUTSIDE
    the `overflow: hidden` popover (as a sibling) so it is not clipped, and to

--- a/apps/web/src/styles/workspace/connectors.css
+++ b/apps/web/src/styles/workspace/connectors.css
@@ -147,6 +147,15 @@
   flex: 1 1 auto;
   min-height: 0;
 }
+/* Portaled brand flyout: fixed to the viewport beside the popover (JS supplies
+   top/bottom/left), overriding the inline `absolute` offsets it uses when the
+   picker is not portaled. */
+.ds-picker-brand-flyout-portal {
+  position: fixed;
+  top: auto;
+  left: auto;
+  z-index: 1000;
+}
 /* Rich brand preview flyout — a side panel anchored to the popover that shows
    the compact Brand Kit card for the hovered / selected brand. It sits OUTSIDE
    the `overflow: hidden` popover (as a sibling) so it is not clipped, and to

--- a/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
+++ b/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
@@ -541,7 +541,7 @@ describe('ChatComposer context pickers', () => {
       expect(screen.queryByText('reference-dir')).toBeNull();
     });
     expect(onProjectMetadataChange).toHaveBeenLastCalledWith(
-      expect.objectContaining({ linkedDirs: [] }),
+      expect.objectContaining({ metadata: expect.objectContaining({ linkedDirs: [] }) }),
     );
   });
 
@@ -599,11 +599,13 @@ describe('ChatComposer context pickers', () => {
     });
     expect(onProjectMetadataChange).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        linkedDirs: [
-          '/Users/me/work-dir',
-          '/tmp/open-design/reference-a',
-          '/tmp/open-design/reference-b',
-        ],
+        metadata: expect.objectContaining({
+          linkedDirs: [
+            '/Users/me/work-dir',
+            '/tmp/open-design/reference-a',
+            '/tmp/open-design/reference-b',
+          ],
+        }),
       }),
     );
   });
@@ -657,7 +659,7 @@ describe('ChatComposer context pickers', () => {
         projectMetadata: metadata,
         onProjectMetadataChange: (next) => {
           onProjectMetadataChange(next);
-          setMetadata(next);
+          setMetadata(next.metadata ?? { kind: 'prototype' });
         },
         onSend,
       });
@@ -700,7 +702,7 @@ describe('ChatComposer context pickers', () => {
     expect(projectPatchBodies()[1]?.metadata?.linkedDirs).toEqual([]);
     expect(screen.queryByTestId('staged-contexts')?.textContent ?? '').not.toContain('reference-dir');
     expect(onProjectMetadataChange).toHaveBeenLastCalledWith(
-      expect.objectContaining({ linkedDirs: [] }),
+      expect.objectContaining({ metadata: expect.objectContaining({ linkedDirs: [] }) }),
     );
   });
 
@@ -819,7 +821,7 @@ describe('ChatComposer context pickers', () => {
         projectMetadata: metadata,
         onProjectMetadataChange: (next) => {
           onProjectMetadataChange(next);
-          setMetadata(next);
+          setMetadata(next.metadata ?? { kind: 'prototype' });
         },
       });
     }
@@ -873,7 +875,7 @@ describe('ChatComposer context pickers', () => {
         projectMetadata: metadata,
         onProjectMetadataChange: (next) => {
           onProjectMetadataChange(next);
-          setMetadata(next);
+          setMetadata(next.metadata ?? { kind: 'prototype' });
         },
       });
     }
@@ -908,7 +910,7 @@ describe('ChatComposer context pickers', () => {
     expect(projectPatchBodies()).toHaveLength(2);
     expect(screen.getByTestId('working-dir-trigger').textContent).toContain('shared');
     expect(onProjectMetadataChange).toHaveBeenLastCalledWith(
-      expect.objectContaining({ linkedDirs: ['/Users/me/shared'] }),
+      expect.objectContaining({ metadata: expect.objectContaining({ linkedDirs: ['/Users/me/shared'] }) }),
     );
   });
 
@@ -922,7 +924,7 @@ describe('ChatComposer context pickers', () => {
         projectMetadata: metadata,
         onProjectMetadataChange: (next) => {
           onProjectMetadataChange(next);
-          setMetadata(next);
+          setMetadata(next.metadata ?? { kind: 'prototype' });
         },
       });
     }
@@ -959,7 +961,7 @@ describe('ChatComposer context pickers', () => {
     expect(screen.getByTestId('staged-contexts').textContent).toContain('shared');
     expect(screen.getByTestId('working-dir-trigger').textContent).not.toContain('shared');
     expect(onProjectMetadataChange).toHaveBeenLastCalledWith(
-      expect.objectContaining({ linkedDirs: ['/Users/me/shared'] }),
+      expect.objectContaining({ metadata: expect.objectContaining({ linkedDirs: ['/Users/me/shared'] }) }),
     );
   });
 
@@ -996,7 +998,7 @@ describe('ChatComposer context pickers', () => {
     });
     expect(projectPatchBodies()).toHaveLength(1);
     expect(onProjectMetadataChange).toHaveBeenLastCalledWith(
-      expect.objectContaining({ linkedDirs: ['/Users/me/shared'] }),
+      expect.objectContaining({ metadata: expect.objectContaining({ linkedDirs: ['/Users/me/shared'] }) }),
     );
   });
 

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -2,7 +2,7 @@
 
 Follow the root `AGENTS.md` first. This package owns user-level end-to-end smoke tests and Playwright UI automation only.
 
-For the current coverage posture, recent hardening work, grouped-run status, and known intentional gaps, see [`docs/testing/e2e-coverage/status.md`](../docs/testing/e2e-coverage/status.md).
+For the current coverage posture, recent hardening work, grouped-run status, and known intentional gaps, see [`docs/testing/e2e-coverage/status.md`](../docs/testing/e2e-coverage/status.md). For the invariants new and repaired UI tests must hold under the sharded full pool, see [UI test stability rules](#ui-test-stability-rules) below.
 
 ## Directory layout
 
@@ -34,6 +34,127 @@ For the current coverage posture, recent hardening work, grouped-run status, and
 - Keep new non-UI e2e smoke chains pure inspect by default. Do not use Playwright for these chains; use daemon/web APIs, sidecar IPC, tools-dev/tools-pack inspect, logs, reports, and screenshots when available.
 - External service dependencies must use temporary server-level mocks. Do not rely on real API keys, real provider accounts, or UI-level route patching for core e2e smoke.
 - Every atomic suite must run in an isolated namespace. Successful suites should keep only curated reports and high-value artifacts, then clean process/runtime scratch. Failed suites should preserve runtime scratch, logs, mock requests, screenshots, and report pointers for diagnosis.
+
+## UI test stability rules
+
+These invariants complement the coverage posture in
+[`docs/testing/e2e-coverage/status.md`](../docs/testing/e2e-coverage/status.md);
+this section is the source of truth for how a UI test must be written to stay
+green under the sharded full pool.
+
+The `ui-extended-main` full pool (`workflow_dispatch` with `suite=full`)
+executes every non-visual functional shade in one generically sharded matrix
+(`visual-*.test.ts` is excluded by the config's `testIgnore` and runs in its
+own lane): arbitrary P0/P1/P2 interleavings, contiguous shard slices that
+start mid-file, an isolated tools-dev runtime per Playwright worker
+(`nproc / 2`, so two on the `ui_hot` runner) with
+`OD_PLAYWRIGHT_FULLY_PARALLEL=1`, and slow CI runners. It is the only lane
+that runs the whole non-visual `ui` suite together — every P1/P2 shade, plus
+the P0 cases no merge lane covers: `ci.yml`'s `ui_p0` runs only the files
+listed in a `uiP0Groups` group, and `playwright_critical` only its own
+`@critical` file matrix, so a `[P0]`/`@critical` tag does not enroll a new
+file (the P0 cases in `automations-page.test.ts` and `home-hero-rail.test.ts`,
+for instance, run nowhere but the full pool). Two order hazards then hide from
+narrower runs: within-file interleaving (the tests of one file racing under
+fully-parallel workers) and cross-file carry-over (the worker-scoped tools-dev
+runtime — `suite.ts`, `scope: 'worker'` — retaining daemon/config/project
+state between the files a worker runs in sequence). Merge lanes touch each in
+part — `playwright_critical` runs fully-parallel, `ui_p0`'s single-worker
+multi-file groups accumulate carry-over — but only the full pool exercises the
+whole suite interleaved with mid-file shards, so treat it as the acceptance
+gate. New and repaired UI tests must hold the following invariants.
+
+- **Order independence is the contract.** Each test performs its own complete
+  setup — whatever that file's model requires — and never relies on a
+  predecessor's side effects; any contiguous subset of the suite must pass
+  with the rest absent. There is no universal setup list, and the axis that
+  matters is test-scoped browser mocks versus worker-scoped daemon state: the
+  daemon/data root is shared across a worker's tests (`suite.ts`), while
+  localStorage seeds and `applyStandardMocks` route interception are per-test.
+  Real-daemon specs reset config and create real projects; entry-surface
+  specs route-mock the same endpoints and may also create real daemon
+  projects. Match the file's existing model rather than adding route stubs a
+  core smoke chain forbids. Do not add
+  `test.describe.configure({ mode: 'serial' })`: a serial group is atomic
+  within one shard (it cannot be split across the matrix) and adds
+  skip-after-failure, which floors the pool's wall time. Running a file's
+  standalone halves — `--shard=1/2` and `--shard=2/2` with
+  `OD_PLAYWRIGHT_FULLY_PARALLEL=1` — checks within-file split-independence, but
+  each is a fresh process, so it cannot expose the cross-file, same-worker
+  carry-over above; run the whole `ui` folder (one worker runtime spans the
+  files) to surface that, or the full pool, which additionally stresses it
+  with fully-parallel mid-file shards.
+- **Treat a retry-only pass as a signal, not flake.** CI retries a failed
+  functional test once (the visual config sets `retries: 0`), and the retry
+  runs after the Playwright worker restarts with a fresh tools-dev runtime — so a first attempt that failed on a dirty
+  predecessor state can pass on the clean retry and leave the run green. A
+  test that only ever fails on its first attempt is telling you something: it
+  may be carried-over predecessor state, worker-startup instability, or an
+  in-test async-readiness race (the settle and readiness rules below). Don't
+  wave it through — reproduce it locally (CI keeps only the failed roots' paths
+  and the retry's trace, not the failed attempt's runtime) and fix the
+  actual cause.
+- **Settle async surfaces before interacting.** Late-resolving fetches
+  re-render the home surface and a remount silently resets transient UI
+  state: the projects list can remount the templates reveal container. Arm a
+  best-effort response waiter before the navigation or reload that triggers the
+  fetch (entry-chrome-flows's `gotoEntryHome` waits on `/api/projects`, but
+  swallows its own timeout, so it only narrows the race — and the many other
+  same-named helpers do not arm it at all). The load-bearing half is requiring
+  the observed state to survive a settle window rather than trusting the first
+  observation, as `revealHomeTemplates` does by retrying on reveal regression.
+- **An enabled control is not a ready control.** A precondition that arrives
+  over a stream is a distinct gate from a remount reset. Agents load through an
+  incremental `/api/agents` SSE stream, and a BYOK-OpenCode run checks that
+  agent's availability before it will POST: until the stream publishes,
+  `ProjectView` rejects the submit with a visible unavailable error instead of
+  creating a run — even though `chat-send` already reports enabled and the fake
+  runtime env makes availability possible. This pre-POST check is
+  BYOK-OpenCode-specific, not a universal composer invariant, but the pattern
+  generalizes: when a control's readiness depends on a streamed precondition,
+  wait for that signal — ideally a side-effect-free one — rather than for
+  `toBeEnabled`. The BYOK spec in `ui/real-daemon-run.test.ts` instead retries
+  the submit itself until the stream catches up (its `sendPrompt` reports
+  whether a create-run request was issued at all); that is safe only because
+  its oracle tolerates the repeated rejected attempts, and a submit that
+  persisted state on each try would need an idempotent oracle or a
+  non-mutating readiness wait.
+- **Never force-click into gated containers.** An `inert` container swallows
+  force-clicks with no error, and `isVisible()` is true for content inside a
+  collapsed reveal container. Route gallery interactions through the
+  reveal-aware helpers and treat actionability (hit-target), not visibility,
+  as the readiness signal.
+- **Hermetic dependencies only.** CI runners have no host binaries and no
+  provider accounts, so agent availability must come from the harness, by one
+  of two mechanisms. Route-mocked specs intercept `/api/agents` with
+  `routeAgents` / `fulfillAgentsRoute` (via `applyStandardMocks`); that mock
+  must serve both the JSON and the `?stream=1` SSE shape including the
+  terminal `done` event — without it the streamed availability lands
+  transiently and is then cleared when the client rejects the incomplete
+  stream.
+  Real-daemon specs instead run a fake CLI through `createFakeAgentRuntimes` +
+  `agentCliEnv` — and daemon detection resolves `byok-opencode` through the
+  `opencode` agent's env. A spec that only passes where a real CLI happens to
+  be installed is broken.
+- **Oracles assert the running product's observable behavior.** When a spec
+  goes stale, realign it against the current product, not the spec's own
+  history. A merged product PR is not proof its oracle is verified: what runs
+  on the merge path is governed by registration, not priority tag — the
+  `ui_p0` group files and the `@merge-extra` P1 subset (`playwright_critical`
+  is a mutually-exclusive PR fallback — `run_playwright_critical` is
+  `&& !runUiP0` — so `@critical` does not add coverage on the merge queue). A
+  non-visual P1 case outside those also runs in the manual `p0p1` lane; a
+  non-visual P2 case, or a P0 case in a file no group lists, runs only in the
+  full pool (visual tests have their own lane). Confirm a realigned oracle in
+  the lane that actually executes it, not by the PR merging.
+- **Name your failure causes.** A long wait should fail with a diagnosis, not
+  an opaque timeout. `sendPrompt` in `ui/real-daemon-run.test.ts` tracks
+  whether the create-run request was ever issued, so its failure separates "no
+  request left the page" (a composer/overlay gate) from "no accepted response
+  arrived" — enough to point at the right layer in a CI-only reproduction.
+  Assert gate preconditions explicitly for the same reason. A hang is usually a
+  missing gate, not a too-short budget — diagnose the state the wait targets
+  before raising it.
 
 ## Naming and tools
 

--- a/e2e/lib/playwright/mock-factory.ts
+++ b/e2e/lib/playwright/mock-factory.ts
@@ -47,6 +47,18 @@ export async function applyStandardMocks(page: Page): Promise<void> {
   await applyStorageConfig(page);
   await routeMockAgents(page);
   await routeAppConfig(page);
+  await suppressWhatsNew(page);
+}
+
+/** Keep unrelated release announcements from covering the surface under test. */
+export async function suppressWhatsNew(page: Page): Promise<void> {
+  await page.route('**/api/whats-new', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({ json: { version: 'e2e', id: null, content: null } });
+  });
 }
 
 /** Seed localStorage with the standard config only (no route interception). */

--- a/e2e/lib/playwright/suite.ts
+++ b/e2e/lib/playwright/suite.ts
@@ -33,6 +33,13 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
       let stopError: unknown = null;
       try {
         await toolsDev.startWeb();
+        const warmupResponse = await fetch(toolsDev.url.web('/'));
+        if (!warmupResponse.ok) {
+          throw new Error(
+            `Playwright web warmup failed with ${warmupResponse.status} ${warmupResponse.statusText}`,
+          );
+        }
+        await warmupResponse.arrayBuffer();
         await use(toolsDev);
       } catch (error) {
         useError = error;

--- a/e2e/lib/playwright/suites.ts
+++ b/e2e/lib/playwright/suites.ts
@@ -15,6 +15,10 @@ export type VisualCiMatrixEntry = {
 };
 
 export const uiP0Groups = {
+  "merge-sentinel": {
+    grep: "@merge-sentinel",
+    files: ["ui/critical-smoke.test.ts", "ui/app.test.ts"],
+  },
   smoke: {
     grep: String.raw`\[P0\]`,
     files: ["ui/critical-smoke.test.ts"],

--- a/e2e/lib/playwright/suites.ts
+++ b/e2e/lib/playwright/suites.ts
@@ -15,27 +15,12 @@ export type VisualCiMatrixEntry = {
 };
 
 export const uiP0Groups = {
-  "merge-sentinel": {
-    grep: "@merge-sentinel",
-    files: ["ui/critical-smoke.test.ts", "ui/app.test.ts"],
-  },
   "critical-extras": {
-    grep: "@merge-sentinel",
+    grep: "@merge-extra",
+    workers: 1,
     files: ["ui/app.test.ts"],
   },
-  smoke: {
-    grep: String.raw`\[P0\]`,
-    files: ["ui/critical-smoke.test.ts"],
-  },
   "workspace-restoration": {
-    grep: String.raw`\[P0\]`,
-    files: ["ui/app-restoration.test.ts"],
-  },
-  "workspace-restoration-distributed": {
-    grep: String.raw`\[P0\]`,
-    files: ["ui/app-restoration.test.ts", "ui/critical-smoke.test.ts"],
-  },
-  "workspace-restoration-smoke": {
     grep: String.raw`\[P0\]`,
     files: ["ui/app-restoration.test.ts", "ui/critical-smoke.test.ts"],
   },
@@ -53,17 +38,6 @@ export const uiP0Groups = {
   },
   "project-workspace": {
     grep: String.raw`\[P0\]`,
-    workers: 1,
-    files: [
-      "ui/app.test.ts",
-      "ui/app-design-files.test.ts",
-      "ui/app-manual-edit.test.ts",
-      "ui/project-management-flows.test.ts",
-      "ui/workspace-keyboard-flows.test.ts",
-    ],
-  },
-  "project-workspace-distributed": {
-    grep: String.raw`\[P0\]|@merge-sentinel`,
     workers: 1,
     files: [
       "ui/app.test.ts",
@@ -108,6 +82,7 @@ const uiP0CoverageFiles = [
   "ui/app-manual-edit.test.ts",
   "ui/app-restoration.test.ts",
   "ui/app.test.ts",
+  "ui/critical-smoke.test.ts",
   "ui/entry-chrome-flows.test.ts",
   "ui/entry-configuration-flows.test.ts",
   "ui/project-management-flows.test.ts",

--- a/e2e/lib/playwright/suites.ts
+++ b/e2e/lib/playwright/suites.ts
@@ -27,6 +27,10 @@ export const uiP0Groups = {
     grep: String.raw`\[P0\]`,
     files: ["ui/app-restoration.test.ts"],
   },
+  "workspace-restoration-distributed": {
+    grep: String.raw`\[P0\]`,
+    files: ["ui/app-restoration.test.ts", "ui/critical-smoke.test.ts"],
+  },
   "entry-settings": {
     grep: String.raw`\[P0\]`,
     files: [
@@ -41,6 +45,17 @@ export const uiP0Groups = {
   },
   "project-workspace": {
     grep: String.raw`\[P0\]`,
+    workers: 1,
+    files: [
+      "ui/app.test.ts",
+      "ui/app-design-files.test.ts",
+      "ui/app-manual-edit.test.ts",
+      "ui/project-management-flows.test.ts",
+      "ui/workspace-keyboard-flows.test.ts",
+    ],
+  },
+  "project-workspace-distributed": {
+    grep: String.raw`\[P0\]|@merge-sentinel`,
     workers: 1,
     files: [
       "ui/app.test.ts",

--- a/e2e/lib/playwright/suites.ts
+++ b/e2e/lib/playwright/suites.ts
@@ -19,6 +19,10 @@ export const uiP0Groups = {
     grep: "@merge-sentinel",
     files: ["ui/critical-smoke.test.ts", "ui/app.test.ts"],
   },
+  "critical-extras": {
+    grep: "@merge-sentinel",
+    files: ["ui/app.test.ts"],
+  },
   smoke: {
     grep: String.raw`\[P0\]`,
     files: ["ui/critical-smoke.test.ts"],
@@ -28,6 +32,10 @@ export const uiP0Groups = {
     files: ["ui/app-restoration.test.ts"],
   },
   "workspace-restoration-distributed": {
+    grep: String.raw`\[P0\]`,
+    files: ["ui/app-restoration.test.ts", "ui/critical-smoke.test.ts"],
+  },
+  "workspace-restoration-smoke": {
     grep: String.raw`\[P0\]`,
     files: ["ui/app-restoration.test.ts", "ui/critical-smoke.test.ts"],
   },

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -11,6 +11,7 @@ function parseWorkerCount(value: string | undefined): number {
 
 export default defineConfig({
   testDir: './ui',
+  testIgnore: 'visual-*.test.ts',
   outputDir: './ui/reports/test-results',
   timeout: Number(process.env.OD_PLAYWRIGHT_TIMEOUT) || 45_000,
   retries: process.env.CI ? 1 : 0,

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -11,6 +11,13 @@ function parseWorkerCount(value: string | undefined): number {
 
 export default defineConfig({
   testDir: './ui',
+  // This is the functional config. Strict-visual specs (`visual-*.test.ts`)
+  // are owned by `playwright.visual.config.ts` (its own `testMatch`,
+  // snapshot/output settings, and the `playwright_visual` CI lane), so they
+  // must never be picked up here — otherwise a bare `pnpm test:ui` or the
+  // generic full-pool shard run would execute them without their visual
+  // config. Excluding them at the config level keeps every functional
+  // consumer (full pool, `test:ui*`, ui_p0 groups) aligned.
   testIgnore: 'visual-*.test.ts',
   outputDir: './ui/reports/test-results',
   timeout: Number(process.env.OD_PLAYWRIGHT_TIMEOUT) || 45_000,

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -906,7 +906,7 @@ process.stdin.on("end", () => {
     expect(scopes).toContain("ui_p0_validation_required: ${{ steps.detect.outputs.ui_p0_validation_required }}");
     expect(scopes).toContain("run_ui_p0: ${{ steps.detect.outputs.run_ui_p0 }}");
     expect(workflow).toContain("needs.scopes.outputs.run_ui_p0 == 'true'");
-    expect(validate).toContain('when($out.run_ui_p0 == "true"; ["ui_p0_smoke", "ui_p0"])');
+    expect(validate).toContain('when($out.run_ui_p0 == "true"; ["ui_p0"])');
 
     await expect(runScopesPrint("workflow_dispatch", { inputs: { ci_mode: "hot" } }, ["apps/web/src/app/page.tsx"])).resolves.toMatchObject({
       ci_mode: "hot",
@@ -1040,29 +1040,18 @@ process.stdin.on("end", () => {
       "ui/workspace-keyboard-flows.test.ts",
     ]);
     expect(uiP0Groups["project-workspace"].workers).toBe(1);
-    expect(uiP0Groups["project-workspace-distributed"]).toEqual({
-      grep: String.raw`\[P0\]|@merge-sentinel`,
+    expect(uiP0Groups["critical-extras"]).toEqual({
+      grep: "@merge-extra",
       workers: 1,
-      files: uiP0Groups["project-workspace"].files,
+      files: ["ui/app.test.ts"],
     });
-    expect(uiP0Groups["workspace-restoration-distributed"]).toEqual({
+    expect(uiP0Groups["workspace-restoration"]).toEqual({
       grep: String.raw`\[P0\]`,
       files: ["ui/app-restoration.test.ts", "ui/critical-smoke.test.ts"],
     });
-    expect(uiP0Groups["critical-extras"]).toEqual({
-      grep: "@merge-sentinel",
-      files: ["ui/app.test.ts"],
-    });
-    expect(uiP0Groups["workspace-restoration-smoke"]).toEqual(
-      uiP0Groups["workspace-restoration-distributed"],
-    );
-    expect(uiP0Groups["merge-sentinel"]).toEqual({
-      grep: "@merge-sentinel",
-      files: ["ui/critical-smoke.test.ts", "ui/app.test.ts"],
-    });
-    const sentinel = sectionBetween(workflow, "  ui_p0_smoke:", "  ui_p0:");
-    expect(sentinel).toContain("run-ui-group merge-sentinel");
-    expect(sentinel).not.toContain("run-ui-group smoke");
+    expect(workflow).not.toContain("  ui_p0_smoke:");
+    expect(uiP0).toContain("run-ui-group critical-extras");
+    expect(uiP0).toContain("Preserve project-runtime domain artifact");
     expect(visual).toContain("fromJSON(needs.runners.outputs.runs_on).visual_hot");
     expect(visual).toContain("toJSON(fromJSON(needs.runners.outputs.runs_on).visual_hot)");
     expect(workflow).not.toContain("needs.runners.outputs.contabo_control");
@@ -1070,19 +1059,15 @@ process.stdin.on("end", () => {
     expect(workflow).not.toContain("needs.runners.outputs.blacksmith_default");
   });
 
-  it("[P2] keeps functional visual ownership and P0 benchmark layouts explicit", async () => {
+  it("[P2] keeps functional visual ownership and manual P0 topology explicit", async () => {
     const playwrightConfig = await readFile(playwrightConfigPath, "utf8");
     const benchmarkWorkflow = await readFile(uiExtendedMainWorkflowPath, "utf8");
 
     expect(playwrightConfig).toContain("testIgnore: 'visual-*.test.ts'");
-    expect(benchmarkWorkflow).toContain("layout:");
-    expect(benchmarkWorkflow).toContain("- standalone");
-    expect(benchmarkWorkflow).toContain("- distributed");
-    expect(benchmarkWorkflow).toContain("- split");
-    expect(benchmarkWorkflow).toContain("- workspace-restoration");
-    expect(benchmarkWorkflow).toContain("- project-runtime");
-    expect(benchmarkWorkflow).toContain("- entry-settings");
-    expect(benchmarkWorkflow).toContain("run-ui-group merge-sentinel");
+    expect(benchmarkWorkflow).not.toContain("layout:");
+    expect(benchmarkWorkflow).toContain("run-ui-group critical-extras");
+    expect(benchmarkWorkflow).toContain("Preserve project-runtime domain artifact");
+    expect(benchmarkWorkflow).toContain("--grep-invert '@merge-extra'");
     expect(benchmarkWorkflow).toContain("name: project-workspace");
   });
 

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -15,6 +15,8 @@ const execFileAsync = promisify(execFile);
 const e2eRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const workspaceRoot = dirname(e2eRoot);
 const ciWorkflowPath = join(workspaceRoot, ".github", "workflows", "ci.yml");
+const uiExtendedMainWorkflowPath = join(workspaceRoot, ".github", "workflows", "ui-extended-main.yml");
+const playwrightConfigPath = join(e2eRoot, "playwright.config.ts");
 const commentWorkflowPath = join(workspaceRoot, ".github", "workflows", "comment.atom.yml");
 const autofixWorkflowPath = join(workspaceRoot, ".github", "workflows", "autofix.atom.yml");
 const reportWorkflowPath = join(workspaceRoot, ".github", "workflows", "report.atom.yml");
@@ -909,16 +911,24 @@ process.stdin.on("end", () => {
     await expect(runScopesPrint("workflow_dispatch", { inputs: { ci_mode: "hot" } }, ["apps/web/src/app/page.tsx"])).resolves.toMatchObject({
       ci_mode: "hot",
       run_ui_p0: true,
+      run_playwright_critical: false,
+    });
+    await expect(runScopesPrint("workflow_dispatch", { inputs: { ci_mode: "hot" } }, ["tools/pack/src/index.ts"])).resolves.toMatchObject({
+      ci_mode: "hot",
+      run_ui_p0: false,
+      run_playwright_critical: true,
     });
     await expect(runScopesPrint("workflow_dispatch", { inputs: {} })).resolves.toMatchObject({
       ci_mode: "full",
       ui_p0_validation_required: true,
+      run_playwright_critical: false,
       run_ui_p0: true,
       run_preflight: true,
     });
     await expect(runScopesPrint("merge_group", {})).resolves.toMatchObject({
       ci_mode: "full",
       ui_p0_validation_required: true,
+      run_playwright_critical: false,
       run_ui_p0: true,
       run_preflight: true,
     });
@@ -1030,11 +1040,31 @@ process.stdin.on("end", () => {
       "ui/workspace-keyboard-flows.test.ts",
     ]);
     expect(uiP0Groups["project-workspace"].workers).toBe(1);
+    expect(uiP0Groups["merge-sentinel"]).toEqual({
+      grep: "@merge-sentinel",
+      files: ["ui/critical-smoke.test.ts", "ui/app.test.ts"],
+    });
+    const sentinel = sectionBetween(workflow, "  ui_p0_smoke:", "  ui_p0:");
+    expect(sentinel).toContain("run-ui-group merge-sentinel");
+    expect(sentinel).not.toContain("run-ui-group smoke");
     expect(visual).toContain("fromJSON(needs.runners.outputs.runs_on).visual_hot");
     expect(visual).toContain("toJSON(fromJSON(needs.runners.outputs.runs_on).visual_hot)");
     expect(workflow).not.toContain("needs.runners.outputs.contabo_control");
     expect(workflow).not.toContain("needs.runners.outputs.hosted_or_blacksmith");
     expect(workflow).not.toContain("needs.runners.outputs.blacksmith_default");
+  });
+
+  it("[P2] keeps functional visual ownership and P0 benchmark layouts explicit", async () => {
+    const playwrightConfig = await readFile(playwrightConfigPath, "utf8");
+    const benchmarkWorkflow = await readFile(uiExtendedMainWorkflowPath, "utf8");
+
+    expect(playwrightConfig).toContain("testIgnore: 'visual-*.test.ts'");
+    expect(benchmarkWorkflow).toContain("layout:");
+    expect(benchmarkWorkflow).toContain("- standalone");
+    expect(benchmarkWorkflow).toContain("- project-runtime");
+    expect(benchmarkWorkflow).toContain("- entry-settings");
+    expect(benchmarkWorkflow).toContain("run-ui-group merge-sentinel");
+    expect(benchmarkWorkflow).toContain("name: project-workspace");
   });
 
   it("[P2] resolves CI runner profiles by mode", async () => {

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -913,7 +913,7 @@ process.stdin.on("end", () => {
       run_ui_p0: true,
       run_playwright_critical: false,
     });
-    await expect(runScopesPrint("workflow_dispatch", { inputs: { ci_mode: "hot" } }, ["tools/pack/src/index.ts"])).resolves.toMatchObject({
+    await expect(runScopesPrint("workflow_dispatch", { inputs: { ci_mode: "hot" } }, ["tools/dev/src/index.ts"])).resolves.toMatchObject({
       ci_mode: "hot",
       run_ui_p0: false,
       run_playwright_critical: true,
@@ -943,6 +943,79 @@ process.stdin.on("end", () => {
       expect(plan).not.toHaveProperty("nix_validation_required");
       expect(plan).not.toHaveProperty("docker_validation_required");
     }
+  });
+
+  it("[P2] skips the critical fallback for pure packaged-leaf changes and stays fail-closed elsewhere", async () => {
+    const hot = { inputs: { ci_mode: "hot" } };
+
+    // Playwright never starts the desktop, packaged, or tools-pack
+    // entrypoints, so a change confined to those leaf roots keeps its
+    // package tests but must not pay the two-job critical fallback.
+    for (const file of [
+      "apps/desktop/src/main.ts",
+      "apps/packaged/src/index.ts",
+      "tools/pack/src/win/installer.ts",
+    ]) {
+      await expect(runScopesPrint("workflow_dispatch", hot, [file])).resolves.toMatchObject({
+        run_playwright_critical: false,
+        run_ui_p0: false,
+        ui_critical_validation_required: false,
+        workspace_validation_required: true,
+      });
+    }
+
+    // Fail-closed: anything that can reach the Playwright runtime — tools-dev,
+    // transitive packages (including the undeclared metatool edge), scripts,
+    // runtime resources, or unknown roots — retains the fallback.
+    for (const file of [
+      "tools/dev/src/index.ts",
+      "packages/metatool/src/index.ts",
+      "packages/agui-adapter/src/adapter.ts",
+      "packages/diagnostics/src/index.ts",
+      "packages/plugin-runtime/src/index.ts",
+      "packages/registry-protocol/src/index.ts",
+      "scripts/guard.ts",
+      "mocks/bin/opencode",
+      "some-new-root/file.ts",
+    ]) {
+      await expect(runScopesPrint("workflow_dispatch", hot, [file])).resolves.toMatchObject({
+        run_playwright_critical: true,
+        ui_critical_validation_required: true,
+      });
+    }
+
+    // A mixed leaf + runtime change retains the fallback.
+    await expect(
+      runScopesPrint("workflow_dispatch", hot, ["apps/desktop/src/main.ts", "tools/dev/src/index.ts"]),
+    ).resolves.toMatchObject({
+      run_playwright_critical: true,
+      ui_critical_validation_required: true,
+    });
+
+    // Root manifest/lock/workspace files keep enabling P0, which retains the
+    // existing critical/P0 mutual exclusion.
+    for (const file of ["package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml"]) {
+      await expect(runScopesPrint("workflow_dispatch", hot, [file])).resolves.toMatchObject({
+        run_ui_p0: true,
+        run_playwright_critical: false,
+      });
+    }
+
+    // Documentation-only changes stay exempt from both.
+    await expect(runScopesPrint("workflow_dispatch", hot, ["docs/spec.md"])).resolves.toMatchObject({
+      run_playwright_critical: false,
+      ui_critical_validation_required: false,
+      workspace_validation_required: false,
+    });
+
+    // merge_group/full behavior is unchanged: everything is required and the
+    // matrix covers critical, so the fallback stays off.
+    await expect(runScopesPrint("merge_group", {})).resolves.toMatchObject({
+      ci_mode: "full",
+      ui_critical_validation_required: true,
+      run_playwright_critical: false,
+      run_ui_p0: true,
+    });
   });
 
   it("[P2] keeps packaging (nix/docker) off the core Validate workspace gate", async () => {

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1075,12 +1075,12 @@ process.stdin.on("end", () => {
     expect(benchmarkWorkflow).toContain("--grep-invert '@merge-extra'");
     expect(benchmarkWorkflow).toContain("name: project-workspace");
     expect(fullUi).toContain("fromJSON(needs.p0_runners.outputs.runs_on).ui_hot");
-    expect(fullUi).toContain("shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]");
+    expect(fullUi).toContain("shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]");
     expect(fullUi).toContain('OD_PLAYWRIGHT_FULLY_PARALLEL: "1"');
     expect(fullUi).toContain('OD_PLAYWRIGHT_WORKERS: "1"');
     expect(fullUi).toContain("name: Run full UI shard");
-    expect(fullUi).toContain("playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/24");
-    expect(fullUi).toContain("name: ui-full-${{ github.run_id }}-shard-${{ matrix.shard }}-of-24");
+    expect(fullUi).toContain("playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/12");
+    expect(fullUi).toContain("name: ui-full-${{ github.run_id }}-shard-${{ matrix.shard }}-of-12");
     expect(fullUi).not.toContain("matrix.files");
     expect(fullUi).not.toContain("--grep");
     expect(fullUiFiles).toEqual([]);

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1049,6 +1049,13 @@ process.stdin.on("end", () => {
       grep: String.raw`\[P0\]`,
       files: ["ui/app-restoration.test.ts", "ui/critical-smoke.test.ts"],
     });
+    expect(uiP0Groups["critical-extras"]).toEqual({
+      grep: "@merge-sentinel",
+      files: ["ui/app.test.ts"],
+    });
+    expect(uiP0Groups["workspace-restoration-smoke"]).toEqual(
+      uiP0Groups["workspace-restoration-distributed"],
+    );
     expect(uiP0Groups["merge-sentinel"]).toEqual({
       grep: "@merge-sentinel",
       files: ["ui/critical-smoke.test.ts", "ui/app.test.ts"],
@@ -1071,6 +1078,7 @@ process.stdin.on("end", () => {
     expect(benchmarkWorkflow).toContain("layout:");
     expect(benchmarkWorkflow).toContain("- standalone");
     expect(benchmarkWorkflow).toContain("- distributed");
+    expect(benchmarkWorkflow).toContain("- split");
     expect(benchmarkWorkflow).toContain("- workspace-restoration");
     expect(benchmarkWorkflow).toContain("- project-runtime");
     expect(benchmarkWorkflow).toContain("- entry-settings");

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1059,39 +1059,31 @@ process.stdin.on("end", () => {
     expect(workflow).not.toContain("needs.runners.outputs.blacksmith_default");
   });
 
-  it("[P2] keeps functional visual ownership and manual P0 topology explicit", async () => {
+  it("[P2] keeps visual ownership and generic full UI sharding explicit", async () => {
     const playwrightConfig = await readFile(playwrightConfigPath, "utf8");
     const benchmarkWorkflow = await readFile(uiExtendedMainWorkflowPath, "utf8");
     const fullUi = benchmarkWorkflow.slice(benchmarkWorkflow.indexOf("  ui_full:"));
-    const functionalUiFiles = (await readdir(join(e2eRoot, "ui")))
-      .filter((file) => file.endsWith(".test.ts") && !file.startsWith("visual-"))
-      .map((file) => `ui/${file}`)
-      .sort();
     const fullUiFiles = [...fullUi.matchAll(/ui\/[a-z0-9-]+\.test\.ts/g)]
       .map(([file]) => file)
       .sort();
 
     expect(playwrightConfig).toContain("testIgnore: 'visual-*.test.ts'");
+    expect(benchmarkWorkflow).not.toContain("\n  schedule:");
     expect(benchmarkWorkflow).not.toContain("layout:");
     expect(benchmarkWorkflow).toContain("run-ui-group critical-extras");
     expect(benchmarkWorkflow).toContain("Preserve project-runtime domain artifact");
     expect(benchmarkWorkflow).toContain("--grep-invert '@merge-extra'");
     expect(benchmarkWorkflow).toContain("name: project-workspace");
-    expect(fullUi).toContain("name: entry-automation");
-    expect(fullUi).toContain("name: settings-focused");
-    expect(fullUi).toContain("name: runtime-restoration");
     expect(fullUi).toContain("fromJSON(needs.p0_runners.outputs.runs_on).ui_hot");
-    expect(fullUi).toContain("OD_PLAYWRIGHT_WORKERS: ${{ matrix.workers }}");
-    expect(fullUi).toContain("name: Run full UI P0 domain");
-    expect(fullUi).toContain("name: Run full UI P1 domain");
-    expect(fullUi).toContain("name: Run full UI P2 domain");
-    expect(fullUi).toContain("--grep '\\[P0\\]'");
-    expect(fullUi).toContain("--grep '\\[P1\\]'");
-    expect(fullUi).toContain("--grep '\\[P2\\]'");
-    expect(fullUi).toContain("name: ui-full-${{ github.run_id }}-${{ matrix.name }}-p0");
-    expect(fullUi).toContain("name: ui-full-${{ github.run_id }}-${{ matrix.name }}-p1");
-    expect(fullUi).toContain("name: ui-full-${{ github.run_id }}-${{ matrix.name }}-p2");
-    expect(fullUiFiles).toEqual(functionalUiFiles);
+    expect(fullUi).toContain("shard: [1, 2, 3, 4, 5, 6, 7, 8]");
+    expect(fullUi).toContain('OD_PLAYWRIGHT_FULLY_PARALLEL: "1"');
+    expect(fullUi).toContain('OD_PLAYWRIGHT_WORKERS: "2"');
+    expect(fullUi).toContain("name: Run full UI shard");
+    expect(fullUi).toContain("playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/8");
+    expect(fullUi).toContain("name: ui-full-${{ github.run_id }}-shard-${{ matrix.shard }}-of-8");
+    expect(fullUi).not.toContain("matrix.files");
+    expect(fullUi).not.toContain("--grep");
+    expect(fullUiFiles).toEqual([]);
   });
 
   it("[P2] resolves CI runner profiles by mode", async () => {

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1075,12 +1075,12 @@ process.stdin.on("end", () => {
     expect(benchmarkWorkflow).toContain("--grep-invert '@merge-extra'");
     expect(benchmarkWorkflow).toContain("name: project-workspace");
     expect(fullUi).toContain("fromJSON(needs.p0_runners.outputs.runs_on).ui_hot");
-    expect(fullUi).toContain("shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]");
+    expect(fullUi).toContain("shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]");
     expect(fullUi).toContain('OD_PLAYWRIGHT_FULLY_PARALLEL: "1"');
     expect(fullUi).toContain('OD_PLAYWRIGHT_WORKERS: "1"');
     expect(fullUi).toContain("name: Run full UI shard");
-    expect(fullUi).toContain("playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/12");
-    expect(fullUi).toContain("name: ui-full-${{ github.run_id }}-shard-${{ matrix.shard }}-of-12");
+    expect(fullUi).toContain("playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/24");
+    expect(fullUi).toContain("name: ui-full-${{ github.run_id }}-shard-${{ matrix.shard }}-of-24");
     expect(fullUi).not.toContain("matrix.files");
     expect(fullUi).not.toContain("--grep");
     expect(fullUiFiles).toEqual([]);

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1075,12 +1075,12 @@ process.stdin.on("end", () => {
     expect(benchmarkWorkflow).toContain("--grep-invert '@merge-extra'");
     expect(benchmarkWorkflow).toContain("name: project-workspace");
     expect(fullUi).toContain("fromJSON(needs.p0_runners.outputs.runs_on).ui_hot");
-    expect(fullUi).toContain("shard: [1, 2, 3, 4, 5, 6, 7, 8]");
+    expect(fullUi).toContain("shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]");
     expect(fullUi).toContain('OD_PLAYWRIGHT_FULLY_PARALLEL: "1"');
-    expect(fullUi).toContain('OD_PLAYWRIGHT_WORKERS: "2"');
+    expect(fullUi).toContain('OD_PLAYWRIGHT_WORKERS: "1"');
     expect(fullUi).toContain("name: Run full UI shard");
-    expect(fullUi).toContain("playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/8");
-    expect(fullUi).toContain("name: ui-full-${{ github.run_id }}-shard-${{ matrix.shard }}-of-8");
+    expect(fullUi).toContain("playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/12");
+    expect(fullUi).toContain("name: ui-full-${{ github.run_id }}-shard-${{ matrix.shard }}-of-12");
     expect(fullUi).not.toContain("matrix.files");
     expect(fullUi).not.toContain("--grep");
     expect(fullUiFiles).toEqual([]);

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1040,6 +1040,15 @@ process.stdin.on("end", () => {
       "ui/workspace-keyboard-flows.test.ts",
     ]);
     expect(uiP0Groups["project-workspace"].workers).toBe(1);
+    expect(uiP0Groups["project-workspace-distributed"]).toEqual({
+      grep: String.raw`\[P0\]|@merge-sentinel`,
+      workers: 1,
+      files: uiP0Groups["project-workspace"].files,
+    });
+    expect(uiP0Groups["workspace-restoration-distributed"]).toEqual({
+      grep: String.raw`\[P0\]`,
+      files: ["ui/app-restoration.test.ts", "ui/critical-smoke.test.ts"],
+    });
     expect(uiP0Groups["merge-sentinel"]).toEqual({
       grep: "@merge-sentinel",
       files: ["ui/critical-smoke.test.ts", "ui/app.test.ts"],
@@ -1061,6 +1070,7 @@ process.stdin.on("end", () => {
     expect(playwrightConfig).toContain("testIgnore: 'visual-*.test.ts'");
     expect(benchmarkWorkflow).toContain("layout:");
     expect(benchmarkWorkflow).toContain("- standalone");
+    expect(benchmarkWorkflow).toContain("- distributed");
     expect(benchmarkWorkflow).toContain("- workspace-restoration");
     expect(benchmarkWorkflow).toContain("- project-runtime");
     expect(benchmarkWorkflow).toContain("- entry-settings");

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1077,7 +1077,7 @@ process.stdin.on("end", () => {
     expect(fullUi).toContain("fromJSON(needs.p0_runners.outputs.runs_on).ui_hot");
     expect(fullUi).toContain("shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]");
     expect(fullUi).toContain('OD_PLAYWRIGHT_FULLY_PARALLEL: "1"');
-    expect(fullUi).toContain('OD_PLAYWRIGHT_WORKERS: "3"');
+    expect(fullUi).not.toContain("OD_PLAYWRIGHT_WORKERS");
     expect(fullUi).toContain("name: Run full UI shard");
     expect(fullUi).toContain("playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/12");
     expect(fullUi).toContain("name: ui-full-${{ github.run_id }}-shard-${{ matrix.shard }}-of-12");

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { createServer as createHttpsServer } from "node:https";
 import { tmpdir } from "node:os";
@@ -1062,6 +1062,14 @@ process.stdin.on("end", () => {
   it("[P2] keeps functional visual ownership and manual P0 topology explicit", async () => {
     const playwrightConfig = await readFile(playwrightConfigPath, "utf8");
     const benchmarkWorkflow = await readFile(uiExtendedMainWorkflowPath, "utf8");
+    const fullUi = benchmarkWorkflow.slice(benchmarkWorkflow.indexOf("  ui_full:"));
+    const functionalUiFiles = (await readdir(join(e2eRoot, "ui")))
+      .filter((file) => file.endsWith(".test.ts") && !file.startsWith("visual-"))
+      .map((file) => `ui/${file}`)
+      .sort();
+    const fullUiFiles = [...fullUi.matchAll(/ui\/[a-z0-9-]+\.test\.ts/g)]
+      .map(([file]) => file)
+      .sort();
 
     expect(playwrightConfig).toContain("testIgnore: 'visual-*.test.ts'");
     expect(benchmarkWorkflow).not.toContain("layout:");
@@ -1069,6 +1077,12 @@ process.stdin.on("end", () => {
     expect(benchmarkWorkflow).toContain("Preserve project-runtime domain artifact");
     expect(benchmarkWorkflow).toContain("--grep-invert '@merge-extra'");
     expect(benchmarkWorkflow).toContain("name: project-workspace");
+    expect(fullUi).toContain("name: entry-automation");
+    expect(fullUi).toContain("name: settings-focused");
+    expect(fullUi).toContain("name: runtime-restoration");
+    expect(fullUi).toContain("fromJSON(needs.p0_runners.outputs.runs_on).ui_hot");
+    expect(fullUi).toContain("OD_PLAYWRIGHT_WORKERS: ${{ matrix.workers }}");
+    expect(fullUiFiles).toEqual(functionalUiFiles);
   });
 
   it("[P2] resolves CI runner profiles by mode", async () => {

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1061,6 +1061,7 @@ process.stdin.on("end", () => {
     expect(playwrightConfig).toContain("testIgnore: 'visual-*.test.ts'");
     expect(benchmarkWorkflow).toContain("layout:");
     expect(benchmarkWorkflow).toContain("- standalone");
+    expect(benchmarkWorkflow).toContain("- workspace-restoration");
     expect(benchmarkWorkflow).toContain("- project-runtime");
     expect(benchmarkWorkflow).toContain("- entry-settings");
     expect(benchmarkWorkflow).toContain("run-ui-group merge-sentinel");

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1077,7 +1077,7 @@ process.stdin.on("end", () => {
     expect(fullUi).toContain("fromJSON(needs.p0_runners.outputs.runs_on).ui_hot");
     expect(fullUi).toContain("shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]");
     expect(fullUi).toContain('OD_PLAYWRIGHT_FULLY_PARALLEL: "1"');
-    expect(fullUi).not.toContain("OD_PLAYWRIGHT_WORKERS");
+    expect(fullUi).toContain('OD_PLAYWRIGHT_WORKERS: "3"');
     expect(fullUi).toContain("name: Run full UI shard");
     expect(fullUi).toContain("playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/12");
     expect(fullUi).toContain("name: ui-full-${{ github.run_id }}-shard-${{ matrix.shard }}-of-12");

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1077,7 +1077,7 @@ process.stdin.on("end", () => {
     expect(fullUi).toContain("fromJSON(needs.p0_runners.outputs.runs_on).ui_hot");
     expect(fullUi).toContain("shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]");
     expect(fullUi).toContain('OD_PLAYWRIGHT_FULLY_PARALLEL: "1"');
-    expect(fullUi).toContain('OD_PLAYWRIGHT_WORKERS: "1"');
+    expect(fullUi).not.toContain("OD_PLAYWRIGHT_WORKERS");
     expect(fullUi).toContain("name: Run full UI shard");
     expect(fullUi).toContain("playwright test -c playwright.config.ts ui --shard=${{ matrix.shard }}/12");
     expect(fullUi).toContain("name: ui-full-${{ github.run_id }}-shard-${{ matrix.shard }}-of-12");

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1082,6 +1082,15 @@ process.stdin.on("end", () => {
     expect(fullUi).toContain("name: runtime-restoration");
     expect(fullUi).toContain("fromJSON(needs.p0_runners.outputs.runs_on).ui_hot");
     expect(fullUi).toContain("OD_PLAYWRIGHT_WORKERS: ${{ matrix.workers }}");
+    expect(fullUi).toContain("name: Run full UI P0 domain");
+    expect(fullUi).toContain("name: Run full UI P1 domain");
+    expect(fullUi).toContain("name: Run full UI P2 domain");
+    expect(fullUi).toContain("--grep '\\[P0\\]'");
+    expect(fullUi).toContain("--grep '\\[P1\\]'");
+    expect(fullUi).toContain("--grep '\\[P2\\]'");
+    expect(fullUi).toContain("name: ui-full-${{ github.run_id }}-${{ matrix.name }}-p0");
+    expect(fullUi).toContain("name: ui-full-${{ github.run_id }}-${{ matrix.name }}-p1");
+    expect(fullUi).toContain("name: ui-full-${{ github.run_id }}-${{ matrix.name }}-p2");
     expect(fullUiFiles).toEqual(functionalUiFiles);
   });
 

--- a/e2e/ui/amr-run-failure-recovery.test.ts
+++ b/e2e/ui/amr-run-failure-recovery.test.ts
@@ -48,7 +48,10 @@ const ANTIGRAVITY_AGENT = {
   models: [{ id: 'default', label: 'Default' }],
 };
 
-test.describe.configure({ mode: 'serial', timeout: T.xlong });
+// Timeout-only configure: each test stubs its own catalogs/agents/status
+// routes and creates its own project, so order independence holds and the
+// file stays splittable across CI shards (a serial group cannot be split).
+test.describe.configure({ timeout: T.xlong });
 
 async function stubCatalogsEmpty(page: Page) {
   await page.route('**/api/skills', async (route) => {

--- a/e2e/ui/app-design-files.test.ts
+++ b/e2e/ui/app-design-files.test.ts
@@ -549,7 +549,7 @@ test('[P1] design files new sketch creates a persisted sketch tab and restores i
   await page.goto(`/projects/${projectId}`, { waitUntil: 'domcontentloaded' });
   await expectWorkspaceReady(page);
 
-  await page.getByTestId('design-files-tab').click();
+  await openAllProjectFiles(page);
   await page.getByTestId('design-files-empty-new-sketch').click();
 
   const sketchName = await waitForSingleSketchFile(page, projectId);
@@ -578,7 +578,7 @@ test('[P1] design files sketch toolbar creates a sketch and exposes editor menu 
   await seedProjectFile(page, projectId, 'alpha.html', '<!doctype html><title>alpha</title><h1>alpha</h1>');
   await page.goto(`/projects/${projectId}`, { waitUntil: 'domcontentloaded' });
   await expectWorkspaceReady(page);
-  await page.getByTestId('design-files-tab').click();
+  await openAllProjectFiles(page);
 
   await expect(page.getByTestId('design-file-row-alpha.html')).toBeVisible();
   await page.getByRole('button', { name: /new sketch/i }).click();
@@ -660,7 +660,7 @@ test('[P1] plan mode selection and new Excalidraw sketch emit analytics dimensio
   await page.goto(`/projects/${projectId}`, { waitUntil: 'domcontentloaded' });
   await expectWorkspaceReady(page);
   await selectComposerSessionMode(page, 'Plan mode');
-  await page.getByTestId('design-files-tab').click();
+  await openAllProjectFiles(page);
   await page.getByTestId('design-files-empty-new-sketch').click();
 
   const sketchName = await waitForSingleSketchFile(page, projectId);
@@ -668,9 +668,9 @@ test('[P1] plan mode selection and new Excalidraw sketch emit analytics dimensio
   await expectProjectFileToContain(page, projectId, sketchName, '"type": "excalidraw"');
 
   await expect.poll(() => analyticsBodies.join('\n')).toContain('session_mode_toggle');
+  await expect.poll(() => analyticsBodies.join('\n'), { timeout: T.medium }).toContain('new_sketch');
   const raw = analyticsBodies.join('\n');
   expect(raw).toContain('"mode_after":"plan"');
-  expect(raw).toContain('new_sketch');
   expect(raw).toContain(projectId);
 });
 

--- a/e2e/ui/app-design-files.test.ts
+++ b/e2e/ui/app-design-files.test.ts
@@ -521,7 +521,7 @@ test('[P1] design files page keeps the current single-file actions and context h
 
   await expect(page.getByTestId('design-files-upload-trigger')).toBeVisible();
   await expect(page.getByRole('button', { name: /new sketch/i })).toBeVisible();
-  await expect(page.getByRole('button', { name: /paste/i })).toBeVisible();
+  await expect(page.getByRole('button', { name: /create document/i })).toBeVisible();
 
   await expect(page.getByRole('button', { name: /filter by kind/i })).toHaveCount(0);
   await expect(page.getByTestId('design-files-batch-delete')).toHaveCount(0);

--- a/e2e/ui/app-manual-edit.test.ts
+++ b/e2e/ui/app-manual-edit.test.ts
@@ -374,7 +374,13 @@ test('[P1] HTML preview toolbar exposes screenshot, comments, mark, and edit wor
   await expect(page.getByTestId('draw-overlay-toggle')).toHaveAttribute('aria-pressed', 'true');
   await expect(page.getByRole('button', { name: 'Box select' })).toBeVisible();
   await page.getByPlaceholder('Add a note for this mark').fill('Mark this hero crop');
-  await expect(page.getByRole('button', { name: 'Add to input' })).toBeEnabled();
+  const submitOptionsButton = page.getByRole('button', { name: 'Submit options' });
+  await expect(submitOptionsButton).toBeEnabled();
+  await submitOptionsButton.click();
+  const submitOptionsMenu = page.getByRole('menu', { name: 'Submit options' });
+  await expect(submitOptionsMenu.getByRole('menuitemradio', { name: 'Add to input' })).toBeEnabled();
+  await submitOptionsButton.click();
+  await expect(submitOptionsMenu).toHaveCount(0);
 
   const previewBox = await artifactPreview(page).boundingBox();
   expect(previewBox).not.toBeNull();
@@ -382,9 +388,10 @@ test('[P1] HTML preview toolbar exposes screenshot, comments, mark, and edit wor
   await page.mouse.down();
   await page.mouse.move(previewBox!.x + 220, previewBox!.y + 170);
   await page.mouse.up();
-  const queueButton = page.getByRole('button', { name: 'Queue' });
-  await expect(queueButton).toBeEnabled();
-  await queueButton.click();
+  await submitOptionsButton.click();
+  const queueOption = submitOptionsMenu.getByRole('menuitemradio', { name: 'Queue' });
+  await expect(queueOption).toBeEnabled();
+  await queueOption.click();
   const queuedStrip = page.getByTestId('chat-queued-send-strip');
   await expect(queuedStrip).toBeVisible();
   await expect(queuedStrip).toContainText('Mark this hero crop');

--- a/e2e/ui/app-restoration.test.ts
+++ b/e2e/ui/app-restoration.test.ts
@@ -2679,6 +2679,13 @@ test('[P1] completed background run sends the configured desktop notification', 
 
   await createEmptyProject(page, 'Background notification run');
   await expectWorkspaceReady(page);
+  const sessionModeTrigger = page.getByTestId('chat-composer').getByTestId('session-mode-trigger');
+  await sessionModeTrigger.click();
+  await page
+    .locator('.session-mode-toggle__menu[role="menu"]')
+    .getByRole('menuitemradio', { name: 'Ask mode' })
+    .click();
+  await expect(sessionModeTrigger).toHaveAttribute('aria-label', 'Ask mode');
   await sendPrompt(page, 'Finish and notify me');
   await expect(page.getByRole('button', { name: 'Stop' })).toBeVisible();
   releaseEvents();
@@ -3294,7 +3301,8 @@ test('[P1] inline question form submits selected answers into the next run reque
 });
 
 test('[P1] project composer working directory replace and clear update linked dirs metadata', async ({ page }) => {
-  const workingDir = '/Users/mac/open-design/open-design/e2e';
+  const workingDir = process.cwd();
+  const workingDirLabel = workingDir.split(/[\\/]/).at(-1) ?? workingDir;
   const patchBodies: Array<Record<string, unknown>> = [];
 
   await page.route('**/api/recent-dirs', async (route) => {
@@ -3325,7 +3333,7 @@ test('[P1] project composer working directory replace and clear update linked di
 
   await page.getByTestId('working-dir-trigger').click();
   await page.getByTestId('working-dir-pick').click();
-  await expect(page.getByTestId('working-dir-trigger')).toContainText('e2e');
+  await expect(page.getByTestId('working-dir-trigger')).toContainText(workingDirLabel);
   await expect
     .poll(() => patchBodies.at(-1)?.metadata)
     .toMatchObject({ linkedDirs: [workingDir] });

--- a/e2e/ui/app.test.ts
+++ b/e2e/ui/app.test.ts
@@ -34,7 +34,7 @@ const CRITICAL_SCENARIO_IDS = new Set([
   'file-upload-send',
   'conversation-delete-recovery',
 ]);
-const MERGE_SENTINEL_SCENARIO_IDS = new Set([
+const MERGE_EXTRA_SCENARIO_IDS = new Set([
   'prototype-basic',
   'deck-basic',
   'file-mention',
@@ -100,7 +100,7 @@ test.beforeEach(async ({ page }) => {
 for (const entry of automatedUiScenarios().filter(
   (scenario) => !APP_OWNED_SCENARIO_FLOWS.has(scenario.flow ?? ''),
 )) {
-  test(`[${scenarioPriority(entry)}]${criticalScenarioTag(entry)}${mergeSentinelScenarioTag(entry)} ${entry.id}: ${entry.title}`, async ({ page }) => {
+  test(`[${scenarioPriority(entry)}]${criticalScenarioTag(entry)}${mergeExtraScenarioTag(entry)} ${entry.id}: ${entry.title}`, async ({ page }) => {
     await routeMockAgents(page);
 
     if (entry.flow === 'example-use-prompt') {
@@ -616,8 +616,8 @@ function criticalScenarioTag(entry: UiScenario): string {
   return CRITICAL_SCENARIO_IDS.has(entry.id) ? ' @critical' : '';
 }
 
-function mergeSentinelScenarioTag(entry: UiScenario): string {
-  return MERGE_SENTINEL_SCENARIO_IDS.has(entry.id) ? ' @merge-sentinel' : '';
+function mergeExtraScenarioTag(entry: UiScenario): string {
+  return MERGE_EXTRA_SCENARIO_IDS.has(entry.id) ? ' @merge-extra' : '';
 }
 
 async function routeMockSuccessfulRun(page: Page, runId: string) {

--- a/e2e/ui/app.test.ts
+++ b/e2e/ui/app.test.ts
@@ -1042,7 +1042,9 @@ async function runQuestionFormSubmitPersistenceFlow(
   const firstRunBody = (await firstRunRequestPromise).postDataJSON() as Record<string, unknown>;
   expectScenarioRunRequest(firstRunBody, entry);
 
-  const form = page.locator('.question-form').first();
+  const panel = page.getByTestId('questions-panel');
+  await expect(panel).toBeVisible();
+  const form = panel.locator('.question-form');
   await expect(form).toBeVisible();
 
   const toneQuestion = form.locator('.qf-field', { has: page.getByText('Visual tone') });
@@ -1050,7 +1052,9 @@ async function runQuestionFormSubmitPersistenceFlow(
   await toneQuestion.locator('label.qf-visual-card[title="Quiet SaaS"]').click();
   await expect(modern).toBeChecked();
 
-  await form.getByRole('button', { name: 'Send answers' }).click();
+  const continueButton = panel.getByRole('button', { name: /^Continue$/i });
+  await expect(continueButton).toBeEnabled();
+  await continueButton.click();
 
   const summary = page.getByTestId('question-form-summary');
   await expect(summary).toBeVisible();
@@ -1066,6 +1070,8 @@ async function runQuestionFormSubmitPersistenceFlow(
   const { messages } = (await messagesResponse.json()) as { messages: Array<{ role: string; content: string }> };
   const formAnswerMessage = messages.find((message) => message.role === 'user' && message.content.includes('[form answers — discovery]'));
   expect(formAnswerMessage).toBeTruthy();
+  expect(formAnswerMessage?.content).toContain('Editorial / magazine');
+  expect(formAnswerMessage?.content).toContain('Modern minimal');
 
   await page.reload();
   await expectWorkspaceReady(page);

--- a/e2e/ui/app.test.ts
+++ b/e2e/ui/app.test.ts
@@ -34,6 +34,12 @@ const CRITICAL_SCENARIO_IDS = new Set([
   'file-upload-send',
   'conversation-delete-recovery',
 ]);
+const MERGE_SENTINEL_SCENARIO_IDS = new Set([
+  'prototype-basic',
+  'deck-basic',
+  'file-mention',
+  'deep-link-preview',
+]);
 test.describe.configure({ timeout: 45_000 });
 
 function artifactPreview(page: Page) {
@@ -94,7 +100,7 @@ test.beforeEach(async ({ page }) => {
 for (const entry of automatedUiScenarios().filter(
   (scenario) => !APP_OWNED_SCENARIO_FLOWS.has(scenario.flow ?? ''),
 )) {
-  test(`[${scenarioPriority(entry)}]${criticalScenarioTag(entry)} ${entry.id}: ${entry.title}`, async ({ page }) => {
+  test(`[${scenarioPriority(entry)}]${criticalScenarioTag(entry)}${mergeSentinelScenarioTag(entry)} ${entry.id}: ${entry.title}`, async ({ page }) => {
     await routeMockAgents(page);
 
     if (entry.flow === 'example-use-prompt') {
@@ -608,6 +614,10 @@ function scenarioPriority(entry: UiScenario): 'P0' | 'P1' | 'P2' {
 
 function criticalScenarioTag(entry: UiScenario): string {
   return CRITICAL_SCENARIO_IDS.has(entry.id) ? ' @critical' : '';
+}
+
+function mergeSentinelScenarioTag(entry: UiScenario): string {
+  return MERGE_SENTINEL_SCENARIO_IDS.has(entry.id) ? ' @merge-sentinel' : '';
 }
 
 async function routeMockSuccessfulRun(page: Page, runId: string) {

--- a/e2e/ui/app.test.ts
+++ b/e2e/ui/app.test.ts
@@ -1042,9 +1042,9 @@ async function runQuestionFormSubmitPersistenceFlow(
   const firstRunBody = (await firstRunRequestPromise).postDataJSON() as Record<string, unknown>;
   expectScenarioRunRequest(firstRunBody, entry);
 
-  const panel = page.getByTestId('questions-panel');
-  await expect(panel).toBeVisible();
-  const form = panel.locator('.question-form');
+  // Studio discovery renders the clarification form inline in the chat flow
+  // (the legacy Questions workspace tab is gone), so locate the form directly.
+  const form = page.locator('.question-form').first();
   await expect(form).toBeVisible();
 
   const toneQuestion = form.locator('.qf-field', { has: page.getByText('Visual tone') });
@@ -1052,15 +1052,15 @@ async function runQuestionFormSubmitPersistenceFlow(
   await toneQuestion.locator('label.qf-visual-card[title="Quiet SaaS"]').click();
   await expect(modern).toBeChecked();
 
-  const continueButton = panel.getByRole('button', { name: /^Continue$/i });
-  await expect(continueButton).toBeEnabled();
-  await continueButton.click();
+  await form.getByRole('button', { name: 'Send answers' }).click();
 
   const summary = page.getByTestId('question-form-summary');
   await expect(summary).toBeVisible();
   await expect(summary.getByText('Questions answered')).toBeVisible();
   await expect(summary.getByText('Visual tone')).toBeVisible();
-  await expect(summary.getByText('Modern minimal')).toBeVisible();
+  // The summary echoes the picked visual-style card (its title), not the
+  // underlying option label.
+  await expect(summary.getByText('Quiet SaaS')).toBeVisible();
 
   const { projectId, conversationId } = await getCurrentProjectContext(page);
   const messagesResponse = await page.request.get(
@@ -1070,15 +1070,17 @@ async function runQuestionFormSubmitPersistenceFlow(
   const { messages } = (await messagesResponse.json()) as { messages: Array<{ role: string; content: string }> };
   const formAnswerMessage = messages.find((message) => message.role === 'user' && message.content.includes('[form answers — discovery]'));
   expect(formAnswerMessage).toBeTruthy();
-  expect(formAnswerMessage?.content).toContain('Editorial / magazine');
-  expect(formAnswerMessage?.content).toContain('Modern minimal');
+  // Inline discovery submits the picked visual-style card and its value id,
+  // not the raw option labels.
+  expect(formAnswerMessage?.content).toContain('Visual tone: Quiet SaaS');
+  expect(formAnswerMessage?.content).toContain('[value: prototype-quiet-saas]');
 
   await page.reload();
   await expectWorkspaceReady(page);
   const restoredSummary = page.getByTestId('question-form-summary');
   await expect(restoredSummary).toBeVisible();
   await expect(restoredSummary.getByText('Visual tone')).toBeVisible();
-  await expect(restoredSummary.getByText('Modern minimal')).toBeVisible();
+  await expect(restoredSummary.getByText('Quiet SaaS')).toBeVisible();
   await expect(page.locator('.question-form')).toHaveCount(0);
 }
 

--- a/e2e/ui/automations-page.test.ts
+++ b/e2e/ui/automations-page.test.ts
@@ -292,8 +292,8 @@ test.describe('Automations page', () => {
 
     await view.getByRole('button', { name: 'New automation' }).click();
     const modal = page.getByTestId('automation-modal');
-    await modal.getByLabel('Automation title').fill('Weekly digest');
-    await expect(modal.getByLabel('Automation title')).toHaveValue('Weekly digest');
+    await modal.getByTestId('automation-modal-title').fill('Weekly digest');
+    await expect(modal.getByTestId('automation-modal-title')).toHaveValue('Weekly digest');
     await modal.getByTestId('automation-modal-prompt').fill('Summarize GitHub and design activity.');
     await expect(modal.getByTestId('automation-modal-prompt')).toHaveValue('Summarize GitHub and design activity.');
     await modal.getByRole('button', { name: 'Create' }).click();
@@ -424,7 +424,7 @@ test.describe('Automations page', () => {
 
     await view.getByRole('button', { name: 'New automation' }).click();
     const modal = page.getByTestId('automation-modal');
-    await modal.getByLabel('Automation title').fill('Newest digest');
+    await modal.getByTestId('automation-modal-title').fill('Newest digest');
     await modal.getByTestId('automation-modal-prompt').fill('Summarize the newest activity.');
     await modal.getByRole('button', { name: 'Create' }).click();
 
@@ -512,14 +512,14 @@ test.describe('Automations page', () => {
 
     await view.getByRole('button', { name: 'New automation' }).click();
     const modal = page.getByTestId('automation-modal');
-    await modal.getByLabel('Automation title').fill('Friday launch digest');
+    await modal.getByTestId('automation-modal-title').fill('Friday launch digest');
     await modal.getByTestId('automation-modal-prompt').fill('Summarize launch readiness every Friday.');
     await modal.getByRole('button', { name: /Daily/i }).click();
     await page.getByRole('tab', { name: 'Weekly' }).click();
     await page.locator('.automation-popover__weekdays').getByRole('button', { name: 'Fri' }).click();
     await page.locator('.automation-popover--schedule input[type="time"]').fill('16:45');
     await page.locator('.automation-popover--schedule select').selectOption('UTC');
-    await page.getByRole('button', { name: 'Done' }).click();
+    await page.locator('.automation-popover--schedule .automation-popover__done-btn').click();
     await expect(modal.getByRole('button', { name: /Friday.*4:45 PM.*UTC/i })).toBeVisible();
 
     await modal.getByRole('button', { name: 'Create' }).click();
@@ -709,24 +709,25 @@ test.describe('Automations page', () => {
     await row.getByRole('button', { name: 'Edit' }).click();
 
     const modal = page.getByTestId('automation-modal');
-    await expect(modal).toHaveAttribute('aria-label', 'Edit automation');
-    await expect(modal.getByLabel('Automation title')).toHaveValue('Daily digest');
+    await expect(modal).toHaveAttribute('aria-label', 'Edit');
+    await expect(modal.getByTestId('automation-modal-title')).toHaveValue('Daily digest');
     await expect(modal.getByTestId('automation-modal-prompt')).toHaveValue('Summarize GitHub and design activity.');
 
     await modal.getByRole('button', { name: /New project each run/i }).click();
-    await modal.getByRole('button', { name: 'Launch Room' }).click();
-    await expect(modal.getByRole('button', { name: /Launch Room/i })).toBeVisible();
+    await modal
+      .locator('.automation-popover')
+      .getByRole('button', { name: 'Launch Room', exact: true })
+      .click();
+    await expect(modal.locator('.automation-pill').first()).toContainText('Launch Room');
 
     await modal.getByRole('button', { name: /Daily/i }).click();
-    await page.getByRole('tab', { name: 'Weekdays' }).click();
+    const schedulePopover = page.locator('.automation-popover--schedule');
+    await schedulePopover.getByRole('tab', { name: 'Weekdays' }).click();
     await page.locator('.automation-popover--schedule input[type="time"]').fill('10:30');
-    await page.locator('.automation-popover--schedule select').selectOption('UTC');
-    await page.getByRole('button', { name: 'Done' }).click();
-    await expect(modal.getByRole('button', { name: /Weekdays.*10:30 AM.*UTC/i })).toBeVisible();
 
-    await modal.getByLabel('Automation title').fill('Launch digest');
+    await modal.getByTestId('automation-modal-title').fill('Launch digest');
     await modal.getByTestId('automation-modal-prompt').fill('Summarize launch readiness and open blockers.');
-    await expect(modal.getByLabel('Automation title')).toHaveValue('Launch digest');
+    await expect(modal.getByTestId('automation-modal-title')).toHaveValue('Launch digest');
     await expect(modal.getByTestId('automation-modal-prompt')).toHaveValue('Summarize launch readiness and open blockers.');
 
     await modal.getByRole('button', { name: 'Save' }).click();
@@ -746,7 +747,7 @@ test.describe('Automations page', () => {
     });
 
     await expect(row).toContainText('Launch digest');
-    await expect(row).toContainText('Weekdays at 10:30 AM');
+    await expect(row).toContainText('Runs Mon–Fri at 10:30 AM');
     await expect(row).toContainText('Launch Room');
     await expect(row).toContainText('Summarize launch readiness and open blockers.');
   });
@@ -857,7 +858,7 @@ test.describe('Automations page', () => {
     const view = await gotoAutomations(page);
     await view.getByRole('button', { name: 'New automation' }).click();
     const modal = page.getByTestId('automation-modal');
-    await modal.getByLabel('Automation title').fill('Reuse launch project');
+    await modal.getByTestId('automation-modal-title').fill('Reuse launch project');
     await modal.getByTestId('automation-modal-prompt').fill('Append launch readiness notes.');
 
     await modal.getByRole('button', { name: /New project each run/i }).click();
@@ -1033,11 +1034,11 @@ test.describe('Automations page', () => {
 
     await view.getByRole('button', { name: 'New automation' }).click();
     const modal = page.getByTestId('automation-modal');
-    await modal.getByLabel('Automation title').fill('Weekly digest');
+    await modal.getByTestId('automation-modal-title').fill('Weekly digest');
     await modal.getByTestId('automation-modal-prompt').fill('Summarize GitHub and design activity.');
     await modal.getByRole('button', { name: 'Create' }).click();
 
-    await expect(modal.getByLabel('Automation title')).toHaveValue('Weekly digest');
+    await expect(modal.getByTestId('automation-modal-title')).toHaveValue('Weekly digest');
     await expect(modal.getByTestId('automation-modal-prompt')).toHaveValue('Summarize GitHub and design activity.');
     await expect(modal.getByText('provider unavailable')).toBeVisible();
     await expect(view.getByText('No automations yet')).toBeVisible();
@@ -1700,8 +1701,8 @@ test.describe('Automations page', () => {
 
     await row.getByRole('button', { name: 'Edit' }).click();
     const modal = page.getByTestId('automation-modal');
-    await expect(modal.getByLabel('Automation title')).toHaveValue('Daily digest');
-    await modal.getByLabel('Automation title').fill('Daily digest edited');
+    await expect(modal.getByTestId('automation-modal-title')).toHaveValue('Daily digest');
+    await modal.getByTestId('automation-modal-title').fill('Daily digest edited');
     await modal.getByRole('button', { name: /^Save/i }).click();
 
     await expect(view.getByText('Daily digest edited')).toBeVisible();
@@ -1796,13 +1797,13 @@ test.describe('Automations page', () => {
 
     await row.getByRole('button', { name: 'Edit' }).click();
     const modal = page.getByTestId('automation-modal');
-    await expect(modal.getByLabel('Automation title')).toHaveValue('Daily launch digest');
+    await expect(modal.getByTestId('automation-modal-title')).toHaveValue('Daily launch digest');
     await modal.getByRole('button', { name: /Daily/i }).click();
     await page.getByRole('tab', { name: 'Weekly' }).click();
     await page.locator('.automation-popover__weekdays').getByRole('button', { name: 'Tue' }).click();
     await page.locator('.automation-popover--schedule input[type="time"]').fill('08:15');
     await page.locator('.automation-popover--schedule select').selectOption('UTC');
-    await page.getByRole('button', { name: 'Done' }).click();
+    await page.locator('.automation-popover--schedule .automation-popover__done-btn').click();
     await modal.getByRole('button', { name: /^Save/i }).click();
 
     await expect.poll(() => patchBodies.length).toBe(1);
@@ -1976,7 +1977,7 @@ test.describe('Automations page', () => {
 
     await view.getByRole('button', { name: /Memory refresh template/i }).click();
     const modal = page.getByTestId('automation-modal');
-    await expect(modal.getByLabel('Automation title')).toHaveValue('Memory refresh template');
+    await expect(modal.getByTestId('automation-modal-title')).toHaveValue('Memory refresh template');
     await expect(modal.getByTestId('automation-modal-prompt')).toHaveValue(/Use Automation template "memory-refresh-template"/);
     await expect(modal.getByTestId('automation-modal-prompt')).toHaveValue(/Pipeline: Collect source packets -> Compact durable context -> Update memory/);
 
@@ -2094,15 +2095,19 @@ test.describe('Automations page', () => {
 
     await view.getByRole('button', { name: /Design system watch template/i }).click();
     const modal = page.getByTestId('automation-modal');
-    await expect(modal.getByLabel('Automation title')).toHaveValue('Design system watch template');
+    await expect(modal.getByTestId('automation-modal-title')).toHaveValue('Design system watch template');
     await modal.getByRole('button', { name: /New project each run/i }).click();
-    await page.getByRole('button', { name: 'Template Target Project' }).click();
+    await page
+      .locator('.automation-popover')
+      .getByRole('button', { name: 'Template Target Project', exact: true })
+      .click();
     await modal.getByRole('button', { name: /Daily/i }).click();
-    await page.getByRole('tab', { name: 'Weekly' }).click();
-    await page.locator('.automation-popover__weekdays').getByRole('button', { name: 'Thu' }).click();
-    await page.locator('.automation-popover--schedule input[type="time"]').fill('13:30');
-    await page.locator('.automation-popover--schedule select').selectOption('UTC');
-    await page.getByRole('button', { name: 'Done' }).click();
+    const schedulePopover = page.locator('.automation-popover--schedule');
+    await schedulePopover.getByRole('tab', { name: 'Weekly' }).click();
+    await schedulePopover.locator('.automation-popover__weekdays').getByRole('button', { name: 'Thu' }).click();
+    await schedulePopover.locator('input[type="time"]').fill('13:30');
+    await schedulePopover.locator('select').selectOption('UTC');
+    await schedulePopover.locator('.automation-popover__done-btn').click();
 
     await modal.getByRole('button', { name: 'Create' }).click();
     await expect.poll(() => createBodies.length).toBe(1);

--- a/e2e/ui/chat-design-system-switch.test.ts
+++ b/e2e/ui/chat-design-system-switch.test.ts
@@ -121,24 +121,21 @@ test('[P1] chat composer switches the project design system mid-chat', async ({ 
     data: { designSystemId: null },
   });
 
-  await openImportTab(page);
+  await openDesignSystemPicker(page);
 
-  const dsEntry = page.getByTestId('composer-import-design-systems');
-  await expect(dsEntry).toBeEnabled();
-  await dsEntry.click();
-
-  await expect(page.getByTestId('composer-ds-picker')).toBeVisible();
+  await expect(page.getByTestId('project-ds-picker-popover')).toBeVisible();
   await page
-    .getByTestId('composer-ds-picker-search')
+    .getByTestId('project-ds-picker-search')
     .fill('editorial');
-  await page.getByTestId('composer-ds-picker-item-editorial').click();
+  await page.getByTestId('project-ds-picker-option-editorial').click();
 
   // The composer closes the popover on a successful switch, so the
   // picker disappears and the project mirrors the new DS.
-  await expect(page.getByTestId('composer-ds-picker')).toHaveCount(0);
+  await expect(page.getByTestId('project-ds-picker-popover')).toHaveCount(0);
 
-  const after = await fetchCurrentProject(page);
-  expect(after.designSystemId).toBe('editorial');
+  await expect
+    .poll(async () => (await fetchCurrentProject(page)).designSystemId)
+    .toBe('editorial');
 
   // The regression boundary: send a chat turn and assert the outbound
   // run carries the *switched* design system. If the composer kept
@@ -160,13 +157,10 @@ test('[P1] chat composer switches the project design system mid-chat', async ({ 
   expect(runRequestBodies[0]?.designSystemId).toBe('editorial');
 });
 
-async function openImportTab(page: Page) {
-  // The leading "tools" button in the composer host the import menu.
-  await page.getByLabel(/Open CLI and model settings/i).click();
-  const importTab = page.getByRole('tab', { name: /import/i });
-  if (await importTab.isVisible().catch(() => false)) {
-    await importTab.click();
-  }
+async function openDesignSystemPicker(page: Page) {
+  const composer = page.getByTestId('chat-composer');
+  await composer.getByTestId('chat-plus-trigger').click();
+  await page.getByTestId('composer-plus-design-system').click();
 }
 
 async function createProject(page: Page, projectName: string): Promise<void> {

--- a/e2e/ui/chat-todo-autoscroll.test.ts
+++ b/e2e/ui/chat-todo-autoscroll.test.ts
@@ -2,14 +2,14 @@ import { expect, test } from '@/playwright/suite';
 import type { Page } from '@playwright/test';
 import { routeAgents } from '@/playwright/mock-factory';
 
-// Verifies that the chat-log stays pinned to the bottom when the PinnedTodoSlot
-// grows (scenario A) and that a deliberate scroll-up is not overridden by a
-// subsequent TodoWrite snapshot (scenario B).
+// Verifies that the chat-log stays pinned to the bottom when its inline
+// conversation TodoCard grows (scenario A) and that a deliberate scroll-up is
+// not overridden by a subsequent TodoWrite snapshot (scenario B).
 //
 // jsdom cannot exercise ResizeObserver or real flex-layout geometry, so these
 // assertions must run in a real browser via Playwright. The Vitest unit spec
 // in apps/web/tests/components/chat-todo-autoscroll.test.tsx confirms that
-// the pinned-todo element is observed; this spec confirms that the resulting
+// inline message growth is observed; this spec confirms that the resulting
 // scroll behaviour is correct end-to-end.
 
 const STORAGE_KEY = 'open-design:config';
@@ -206,40 +206,39 @@ async function chatLogScrollableHeight(page: Page): Promise<number> {
   });
 }
 
-// Simulate what happens when the .chat-pinned-todo element grows by manually
-// setting the chat-log's scrollTop to mimic the drift that occurs in production
-// environments where scroll-anchoring may not compensate fully for a flex-layout
-// reflow caused by a sibling growing outside the scroll container.
+// Simulate what happens when the inline conversation TodoCard grows by manually
+// setting the chat-log's scrollTop to mimic a browser that does not compensate
+// for the additional scroll height.
 //
 // The mechanism:
 //  1. Verify the chat-log is currently pinned to the bottom.
-//  2. Grow .chat-pinned-todo (reducing .chat-log.clientHeight in the flex layout).
+//  2. Grow the inline `.op-card.op-todo` (increasing `.chat-log.scrollHeight`).
 //  3. Manually set scrollTop to its pre-grow value (i.e. do NOT adjust for the
-//     reduced clientHeight). This leaves the user `extraPx` above the new bottom.
+//     added content). This leaves the user `extraPx` above the new bottom.
 //  4. Wait one rAF cycle. On the fix branch, the ResizeObserver on
-//     .chat-pinned-todo fires followLatestIfPinned which snaps scrollTop back
-//     to scrollHeight. On main the observer does not fire, so the drift persists.
-async function growPinnedTodo(page: Page, extraPx: number) {
+//     the rendered message fires followLatestIfPinned, which snaps scrollTop
+//     back to the bottom. Without that observation, the drift persists.
+async function growInlineTodoCard(page: Page, extraPx: number) {
   await page.evaluate((px) => {
     const logEl = document.querySelector<HTMLElement>('.chat-log');
     if (!logEl) throw new Error('No .chat-log element found');
 
-    const el = document.querySelector<HTMLElement>('.chat-pinned-todo');
-    if (!el) throw new Error('No .chat-pinned-todo element found');
+    const el = document.querySelector<HTMLElement>('.chat-log .op-card.op-todo');
+    if (!el) throw new Error('No inline TodoCard element found');
 
     // Snapshot the current scrollTop (user is at the bottom, so this equals
     // scrollHeight - clientHeight approximately).
     const scrollTopBefore = logEl.scrollTop;
 
-    // Grow the element. The flex reflow reduces logEl.clientHeight by ~px.
+    // Grow the inline card. This increases the chat log's scrollHeight by ~px.
     el.style.minHeight = `${el.offsetHeight + px}px`;
-    // Force layout so clientHeight is updated synchronously.
-    void logEl.clientHeight;
+    // Force layout so scrollHeight is updated synchronously.
+    void logEl.scrollHeight;
 
     // Re-apply the pre-grow scrollTop. This cancels any scroll-anchoring
     // adjustment the browser made, leaving the user drifted above the bottom.
-    // The ChatPane's followLatestIfPinned (if its ResizeObserver fires) will
-    // correct this; on main it won't because the observer is not on this element.
+    // ChatPane's message ResizeObserver corrects this only while the user is
+    // still considered pinned.
     logEl.scrollTop = scrollTopBefore;
   }, extraPx);
   // Give the browser two rAF cycles to flush ResizeObserver callbacks and the
@@ -247,14 +246,14 @@ async function growPinnedTodo(page: Page, extraPx: number) {
   await page.waitForTimeout(100);
 }
 
-test.describe('chat pane autoscroll on TodoCard growth', () => {
+test.describe('chat pane autoscroll on inline TodoCard growth', () => {
   test.describe.configure({ timeout: 45_000 });
 
   test.beforeEach(async ({ page }) => {
     await seedAppConfig(page);
   });
 
-  test('[P2] scenario A: pinned user stays at bottom after PinnedTodoCard grows', async ({
+  test('[P2] scenario A: pinned user stays at bottom after inline TodoCard grows', async ({
     page,
   }) => {
     const { projectId, conversationId } = await seedProjectWithTodos(page, {
@@ -284,32 +283,32 @@ test.describe('chat pane autoscroll on TodoCard growth', () => {
       `seed more filler messages if this fires`,
     ).toBeGreaterThan(50);
 
-    // Verify the PinnedTodoSlot rendered.
-    await expect(page.locator('.chat-pinned-todo')).toBeVisible({ timeout: 5_000 });
+    // Verify the canonical conversation TodoCard rendered inline.
+    await expect(page.locator('.chat-log .op-card.op-todo')).toBeVisible({ timeout: 5_000 });
 
-    // Capture clientHeight before growing so we can assert the grow step
+    // Capture scrollHeight before growing so we can assert the grow step
     // actually changed the layout this test is designed to protect against.
-    const clientHeightBeforeGrow = await page.evaluate(
-      () => document.querySelector<HTMLElement>('.chat-log')?.clientHeight ?? -1,
+    const scrollHeightBeforeGrow = await page.evaluate(
+      () => document.querySelector<HTMLElement>('.chat-log')?.scrollHeight ?? -1,
     );
 
-    // Grow the pinned-todo card by 80 px (simulates a new TodoWrite snapshot with
+    // Grow the inline TodoCard by 80 px (simulates a new TodoWrite snapshot with
     // more items) and verify the chat-log snaps back to the bottom.
-    await growPinnedTodo(page, 80);
+    await growInlineTodoCard(page, 80);
 
-    // Hard precondition: the grow step must have reduced clientHeight. If a
-    // layout change stops .chat-pinned-todo from shrinking .chat-log.clientHeight,
+    // Hard precondition: the grow step must have increased scrollHeight. If a
+    // layout change stops the card from changing `.chat-log.scrollHeight`,
     // distanceAfterGrow < 20 passes vacuously and the regression detector is
     // defeated — fail fast instead.
-    const clientHeightAfterGrow = await page.evaluate(
-      () => document.querySelector<HTMLElement>('.chat-log')?.clientHeight ?? -1,
+    const scrollHeightAfterGrow = await page.evaluate(
+      () => document.querySelector<HTMLElement>('.chat-log')?.scrollHeight ?? -1,
     );
     expect(
-      clientHeightAfterGrow,
-      `expected grow step to reduce chat-log clientHeight ` +
-      `(before=${clientHeightBeforeGrow} after=${clientHeightAfterGrow}); ` +
-      `increase extraPx in growPinnedTodo or check the layout if this fires`,
-    ).toBeLessThan(clientHeightBeforeGrow);
+      scrollHeightAfterGrow,
+      `expected grow step to increase chat-log scrollHeight ` +
+      `(before=${scrollHeightBeforeGrow} after=${scrollHeightAfterGrow}); ` +
+      `increase extraPx in growInlineTodoCard or check the layout if this fires`,
+    ).toBeGreaterThan(scrollHeightBeforeGrow);
 
     const distanceAfterGrow = await chatLogBottomDistance(page);
     expect(
@@ -318,7 +317,7 @@ test.describe('chat pane autoscroll on TodoCard growth', () => {
     ).toBeLessThan(20);
   });
 
-  test('[P2] scenario B: user scroll-up is preserved when PinnedTodoCard grows', async ({
+  test('[P2] scenario B: user scroll-up is preserved when inline TodoCard grows', async ({
     page,
   }) => {
     const { projectId, conversationId } = await seedProjectWithTodos(page, {
@@ -331,8 +330,8 @@ test.describe('chat pane autoscroll on TodoCard growth', () => {
     });
     await waitForChatReady(page);
 
-    // Verify PinnedTodoSlot is mounted.
-    await expect(page.locator('.chat-pinned-todo')).toBeVisible({ timeout: 5_000 });
+    // Verify the canonical conversation TodoCard rendered inline.
+    await expect(page.locator('.chat-log .op-card.op-todo')).toBeVisible({ timeout: 5_000 });
 
     // Scroll the chat-log up by 150 px to break the pinned-to-bottom invariant.
     // We scroll by at least 80 px (the pinnedToBottomRef threshold) to ensure
@@ -360,33 +359,32 @@ test.describe('chat pane autoscroll on TodoCard growth', () => {
       `seed more filler messages or increase the scroll offset if this fires`,
     ).toBeGreaterThan(80);
 
-    // Capture scrollTop and clientHeight before growing — the invariant is that
+    // Capture scrollTop and scrollHeight before growing — the invariant is that
     // scrollTop (not distance-to-bottom) is preserved. Distance-to-bottom
-    // naturally increases by ~extraPx because growPinnedTodo reduces clientHeight
-    // while holding scrollTop fixed, so comparing distances before/after would
-    // fail on correct behavior.
+    // naturally increases by ~extraPx because the inline card adds scrollable
+    // content while scrollTop stays fixed.
     const scrollTopBeforeGrow = await page.evaluate(
       () => document.querySelector<HTMLElement>('.chat-log')?.scrollTop ?? -1,
     );
-    const clientHeightBeforeGrow = await page.evaluate(
-      () => document.querySelector<HTMLElement>('.chat-log')?.clientHeight ?? -1,
+    const scrollHeightBeforeGrow = await page.evaluate(
+      () => document.querySelector<HTMLElement>('.chat-log')?.scrollHeight ?? -1,
     );
 
     // Now grow the todo card — the non-pinned user should NOT be dragged back.
-    await growPinnedTodo(page, 80);
+    await growInlineTodoCard(page, 80);
 
-    // Hard precondition: the grow step must have actually changed clientHeight.
+    // Hard precondition: the grow step must have actually changed scrollHeight.
     // If this fails, the layout changed and the test no longer exercises the
     // "user scrolled away, do not yank them back" path — fail fast.
-    const clientHeightAfterGrow = await page.evaluate(
-      () => document.querySelector<HTMLElement>('.chat-log')?.clientHeight ?? -1,
+    const scrollHeightAfterGrow = await page.evaluate(
+      () => document.querySelector<HTMLElement>('.chat-log')?.scrollHeight ?? -1,
     );
     expect(
-      clientHeightAfterGrow,
-      `expected grow step to reduce chat-log clientHeight ` +
-      `(before=${clientHeightBeforeGrow} after=${clientHeightAfterGrow}); ` +
-      `increase extraPx in growPinnedTodo or check the layout if this fires`,
-    ).toBeLessThan(clientHeightBeforeGrow);
+      scrollHeightAfterGrow,
+      `expected grow step to increase chat-log scrollHeight ` +
+      `(before=${scrollHeightBeforeGrow} after=${scrollHeightAfterGrow}); ` +
+      `increase extraPx in growInlineTodoCard or check the layout if this fires`,
+    ).toBeGreaterThan(scrollHeightBeforeGrow);
 
     // Core invariant: scrollTop must be preserved. A regression where
     // followLatestIfPinned fires and snaps the user back to the bottom would

--- a/e2e/ui/critical-smoke.test.ts
+++ b/e2e/ui/critical-smoke.test.ts
@@ -10,7 +10,7 @@ test.beforeEach(async ({ page }) => {
   await applyStandardMocks(page);
 });
 
-test('[P0] @critical home loads with the primary entry controls', async ({ page }) => {
+test('[P0] @critical @merge-sentinel home loads with the primary entry controls', async ({ page }) => {
   await gotoEntryHome(page);
 
   // The rail is collapsed by default — the hero owns the first screen and the
@@ -23,7 +23,7 @@ test('[P0] @critical home loads with the primary entry controls', async ({ page 
   await expect(page.getByTestId('entry-nav-new-project')).toBeVisible();
 });
 
-test('[P0] @critical settings dialog is reachable from home', async ({ page }) => {
+test('[P0] @critical @merge-sentinel settings dialog is reachable from home', async ({ page }) => {
   await gotoEntryHome(page);
 
   // The home settings entry is a menu: open it, then the "Settings" item
@@ -35,7 +35,7 @@ test('[P0] @critical settings dialog is reachable from home', async ({ page }) =
   await expect(settingsDialog.getByRole('heading', { name: 'Execution mode' })).toBeVisible();
 });
 
-test('[P0] @critical prototype project creation reaches the workspace shell', async ({ page }) => {
+test('[P0] @critical @merge-sentinel prototype project creation reaches the workspace shell', async ({ page }) => {
   await gotoEntryHome(page);
   await openNewProjectModal(page);
   await page.getByTestId('new-project-tab-prototype').click();

--- a/e2e/ui/critical-smoke.test.ts
+++ b/e2e/ui/critical-smoke.test.ts
@@ -10,7 +10,7 @@ test.beforeEach(async ({ page }) => {
   await applyStandardMocks(page);
 });
 
-test('[P0] @critical @merge-sentinel home loads with the primary entry controls', async ({ page }) => {
+test('[P0] @critical home loads with the primary entry controls', async ({ page }) => {
   await gotoEntryHome(page);
 
   // The rail is collapsed by default — the hero owns the first screen and the
@@ -23,7 +23,7 @@ test('[P0] @critical @merge-sentinel home loads with the primary entry controls'
   await expect(page.getByTestId('entry-nav-new-project')).toBeVisible();
 });
 
-test('[P0] @critical @merge-sentinel settings dialog is reachable from home', async ({ page }) => {
+test('[P0] @critical settings dialog is reachable from home', async ({ page }) => {
   await gotoEntryHome(page);
 
   // The home settings entry is a menu: open it, then the "Settings" item
@@ -35,7 +35,7 @@ test('[P0] @critical @merge-sentinel settings dialog is reachable from home', as
   await expect(settingsDialog.getByRole('heading', { name: 'Execution mode' })).toBeVisible();
 });
 
-test('[P0] @critical @merge-sentinel prototype project creation reaches the workspace shell', async ({ page }) => {
+test('[P0] @critical prototype project creation reaches the workspace shell', async ({ page }) => {
   await gotoEntryHome(page);
   await openNewProjectModal(page);
   await page.getByTestId('new-project-tab-prototype').click();

--- a/e2e/ui/design-systems-manager.test.ts
+++ b/e2e/ui/design-systems-manager.test.ts
@@ -248,60 +248,18 @@ test('[P1] publishing a user design system promotes it to the default system in 
   await expect(page).toHaveURL(/\/design-systems$/);
   await page.getByRole('tab', { name: 'Your systems' }).click();
 
-  const manager = page.locator('section[aria-label="Your design systems"]');
-  const alphaRow = manager.locator('.ds-user-row').filter({ hasText: 'Brand Alpha' });
+  const alphaCard = page.getByTestId('design-system-card-brand-alpha');
+  await alphaCard.click();
+  const detail = page.getByTestId('design-system-detail-brand-alpha');
+  const statusToggle = detail.getByRole('button', { name: 'Draft' });
 
-  await expect(alphaRow.getByRole('button', { name: 'Make default' })).toHaveCount(0);
-  await alphaRow.locator('.ds-status-toggle').click();
-  await expect(alphaRow.locator('.ds-status-toggle')).toContainText('Published');
-  await expect(alphaRow.getByText('Default')).toBeVisible();
+  await expect(detail.getByTestId('design-kit-more-actions')).toBeVisible();
+  await statusToggle.click();
+  await expect(detail.getByRole('button', { name: 'Published' })).toBeVisible();
+  await expect(alphaCard).toContainText(/default/i);
   await expect
     .poll(() => persistedConfigs.at(-1)?.designSystemId)
     .toBe('brand-alpha');
-});
-
-test('[P1] filters user design systems by draft and published status in the manager', async ({ page }) => {
-  await seedEntryBase(page);
-  const systems: UserSystem[] = [
-    {
-      id: 'brand-alpha',
-      title: 'Brand Alpha',
-      category: 'Productivity & SaaS',
-      summary: 'Draft internal design system.',
-      surface: 'web',
-      source: 'user',
-      status: 'draft',
-      updatedAt: '2026-05-28T01:00:00.000Z',
-    },
-    {
-      id: 'brand-beta',
-      title: 'Brand Beta',
-      category: 'Productivity & SaaS',
-      summary: 'Published baseline system.',
-      surface: 'web',
-      source: 'user',
-      status: 'published',
-      updatedAt: '2026-05-28T00:00:00.000Z',
-    },
-  ];
-  await routeDesignSystemsManager(page, systems);
-
-  await gotoEntryHome(page);
-  await ensureRailOpen(page);
-  await page.getByTestId('entry-nav-design-systems').click();
-  await expect(page).toHaveURL(/\/design-systems$/);
-  await page.getByRole('tab', { name: 'Your systems' }).click();
-
-  const manager = page.locator('section[aria-label="Your design systems"]');
-  const filter = manager.getByRole('combobox', { name: 'Filter design systems' });
-
-  await filter.selectOption('published');
-  await expect(manager.getByText('Brand Beta')).toBeVisible();
-  await expect(manager.getByText('Brand Alpha')).toHaveCount(0);
-
-  await filter.selectOption('draft');
-  await expect(manager.getByText('Brand Alpha')).toBeVisible();
-  await expect(manager.getByText('Brand Beta')).toHaveCount(0);
 });
 
 test('[P1] deleting the active design system falls back to another user system', async ({ page }) => {
@@ -340,14 +298,15 @@ test('[P1] deleting the active design system falls back to another user system',
 
   page.once('dialog', (dialog) => dialog.accept());
 
-  const manager = page.locator('section[aria-label="Your design systems"]');
-  const alphaRow = manager.locator('.ds-user-row').filter({ hasText: 'Brand Alpha' });
-  await alphaRow.getByRole('button', { name: 'Delete Brand Alpha' }).click();
+  const alphaCard = page.getByTestId('design-system-card-brand-alpha');
+  await alphaCard.click();
+  const detail = page.getByTestId('design-system-detail-brand-alpha');
+  await detail.getByTestId('design-kit-more-actions').click();
+  await page.getByRole('menuitem', { name: 'Delete Brand Alpha' }).click();
 
-  await expect(alphaRow).toHaveCount(0);
+  await expect(alphaCard).toHaveCount(0);
   await expect
     .poll(() => persistedConfigs.at(-1)?.designSystemId)
     .toBe('brand-beta');
-  const betaRow = manager.locator('.ds-user-row').filter({ hasText: 'Brand Beta' });
-  await expect(betaRow.getByText('Default')).toBeVisible();
+  await expect(page.getByTestId('design-system-card-brand-beta')).toContainText(/default/i);
 });

--- a/e2e/ui/entry-chrome-flows.test.ts
+++ b/e2e/ui/entry-chrome-flows.test.ts
@@ -371,7 +371,8 @@ test('[P1] home view exposes the redesigned hero, recent projects, and starters'
   await expect(page.getByTestId('recent-projects-view-all')).toBeVisible();
   await expect(home.getByTestId('plugins-home-section')).toBeVisible();
   await expect(home.getByTestId('plugins-home-browse-registry')).toBeVisible();
-  await expect(home.getByTestId('plugins-home-pill-category-all')).toHaveAttribute('aria-selected', 'true');
+  await expect(home.getByTestId('plugins-home-pill-category-all')).toHaveCount(0);
+  await expect(home.getByTestId('plugins-home-pill-category-deck')).toHaveAttribute('aria-selected', 'true');
   await expect(page.getByTestId('home-hero')).toBeVisible();
   await expect(page.getByTestId('home-templates-hint')).toHaveCount(0);
   await expect(page.getByTestId('entry-nav-home')).toHaveAttribute('aria-current', 'page');
@@ -977,19 +978,12 @@ test('[P2] home starters search and facet filters narrow the visible gallery', a
   await gotoEntryHome(page);
 
   const home = await revealHomeTemplates(page);
-  await expect(home.getByTestId('plugins-home-pill-category-all')).toContainText('4');
-
-  await home.getByTestId('plugins-home-pill-category-deck').click({ force: true });
+  const deckCategory = home.getByTestId('plugins-home-pill-category-deck');
+  await expect(deckCategory).toHaveAttribute('aria-selected', 'true');
   await expect(home.locator('[data-plugin-id="deck-writer"]')).toBeVisible();
   await expect(home.locator('[data-plugin-id="figma-importer"]')).toHaveCount(0);
   await expect(home.locator('[data-plugin-id="localized-plugin"]')).toHaveCount(0);
   await expect(home.locator('[data-plugin-id="hyperframes-video"]')).toHaveCount(0);
-
-  await home.getByTestId('plugins-home-pill-category-all').click({ force: true });
-  await expect(home.locator('[data-plugin-id="figma-importer"]')).toBeVisible();
-  await expect(home.locator('[data-plugin-id="localized-plugin"]')).toBeVisible();
-  await expect(home.locator('[data-plugin-id="hyperframes-video"]')).toBeVisible();
-  await expect(home.locator('[data-plugin-id="deck-writer"]')).toBeVisible();
 
   const search = home.getByTestId('plugins-home-search');
   await search.fill('Deck Writer');
@@ -997,7 +991,7 @@ test('[P2] home starters search and facet filters narrow the visible gallery', a
   await expect(home.locator('[data-plugin-id="localized-plugin"]')).toHaveCount(0);
   await expect(home.locator('[data-plugin-id="hyperframes-video"]')).toHaveCount(0);
   await home.getByTestId('plugins-home-search-clear').click({ force: true });
-  await expect(home.locator('[data-plugin-id="localized-plugin"]')).toBeVisible();
+  await expect(home.locator('[data-plugin-id="deck-writer"]')).toBeVisible();
 });
 
 test('[P1] home starters category tabs and subcategory tabs switch the gallery slice', async ({ page }) => {
@@ -1012,9 +1006,10 @@ test('[P1] home starters category tabs and subcategory tabs switch the gallery s
   await gotoEntryHome(page);
   const home = await revealHomeTemplates(page);
 
-  await expect(home.getByTestId('plugins-home-pill-category-all')).toContainText('8');
-  await expect(home.locator('[data-plugin-id="facet-landing-prototype"]')).toBeVisible();
-  await expect(home.locator('[data-plugin-id="facet-audio"]')).toBeVisible();
+  await expect(home.getByTestId('plugins-home-pill-category-all')).toHaveCount(0);
+  await expect(home.getByTestId('plugins-home-pill-category-deck')).toHaveAttribute('aria-selected', 'true');
+  await expect(home.locator('[data-plugin-id="facet-deck"]')).toBeVisible();
+  await expect(home.locator('[data-plugin-id="facet-landing-prototype"]')).toHaveCount(0);
 
   const categoryCases = [
     ['prototype', 'facet-landing-prototype', 'facet-deck'],
@@ -1036,12 +1031,10 @@ test('[P1] home starters category tabs and subcategory tabs switch the gallery s
     await expect(home.locator(`[data-plugin-id="${hiddenId}"]`)).toHaveCount(0);
   }
 
-  await home.getByTestId('plugins-home-pill-category-all').click({ force: true });
-  await expect(home.getByTestId('plugins-home-pill-category-all')).toHaveAttribute('aria-selected', 'true');
-  await expect(home.locator('[data-plugin-id="facet-landing-prototype"]')).toBeVisible();
-  await expect(home.locator('[data-plugin-id="facet-audio"]')).toBeVisible();
-
-  await home.getByTestId('plugins-home-pill-category-prototype').click({ force: true });
+  const prototypeCategory = home.getByTestId('plugins-home-pill-category-prototype');
+  await prototypeCategory.scrollIntoViewIfNeeded();
+  await expect(prototypeCategory).toBeVisible();
+  await prototypeCategory.click();
   await expect(home.getByTestId('plugins-home-row-subcategory-prototype')).toBeVisible();
   await home.getByTestId('plugins-home-pill-subcategory-prototype-landing-marketing').click({ force: true });
   await expect(home.getByTestId('plugins-home-pill-subcategory-prototype-landing-marketing')).toHaveAttribute('aria-selected', 'true');
@@ -1091,7 +1084,6 @@ test('[P2] home starters search can enter a no-results state and recover with cl
   // plugins views (both stay mounted), so scope to the home view to keep these
   // strict-mode locators unambiguous.
   const home = await revealHomeTemplates(page);
-  await home.getByTestId('plugins-home-pill-category-all').click({ force: true });
   const search = home.getByTestId('plugins-home-search');
   await search.click({ force: true });
   await search.fill('no-such-starter');
@@ -1682,7 +1674,6 @@ test('[P1] home starters Use plugin from the details modal applies the plugin to
   });
 
   await gotoEntryHome(page);
-  await page.locator('article.plugins-home__card[data-plugin-id="detail-use-plugin"]').hover();
   await page.getByTestId('plugins-home-details-detail-use-plugin').click({ force: true });
 
   const dialog = page.getByRole('dialog', { name: /Detail Use Plugin preview/i });

--- a/e2e/ui/entry-chrome-flows.test.ts
+++ b/e2e/ui/entry-chrome-flows.test.ts
@@ -507,8 +507,11 @@ test('[P1] disabled design systems are filtered from entry creation surfaces', a
   const modal = page.getByTestId('new-project-modal');
   await expect(modal).toBeVisible();
   await modal.getByTestId('design-system-trigger').click();
-  await expect(modal.getByRole('option', { name: /Agentic/i })).toBeVisible();
-  await expect(modal.getByRole('option', { name: /Airbnb/i })).toHaveCount(0);
+  // The picker popover renders through a document.body portal (so short
+  // viewports cannot clip it), so its options live outside the modal subtree.
+  const modalPicker = page.locator('.ds-picker-popover');
+  await expect(modalPicker.getByRole('option', { name: /Agentic/i })).toBeVisible();
+  await expect(modalPicker.getByRole('option', { name: /Airbnb/i })).toHaveCount(0);
   await page.keyboard.press('Escape');
   await page.keyboard.press('Escape');
   await expect(modal).toHaveCount(0);
@@ -1061,7 +1064,10 @@ test('[P1] home starters can jump into plugin creation through the registry brow
   });
 
   await gotoEntryHome(page);
-  await page.getByTestId('plugins-home-browse-registry').click();
+  // The browse link lives inside the first-run reveal container; reveal it
+  // first or the collapsed overlay intercepts the click.
+  const home = await revealHomeTemplates(page);
+  await home.getByTestId('plugins-home-browse-registry').click();
   await expect(page).toHaveURL(/\/plugins$/);
   await expect(page.locator('h1').filter({ hasText: 'Plugins' })).toBeVisible();
   await page.getByTestId('plugins-create-button').click();
@@ -2318,8 +2324,21 @@ test('[P1] rail can be collapsed again on coarse-pointer / non-hover devices', a
 });
 
 async function gotoEntryHome(page: Page) {
+  // The home surface re-renders (and can remount transient UI such as the
+  // templates reveal container or an open details modal) when the async
+  // projects list resolves. Arm the waiter before navigating and hold until
+  // that fetch settles so tests never interact inside the remount window.
+  const projectsSettled = page
+    .waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === '/api/projects' &&
+        response.request().method() === 'GET',
+      { timeout: 10_000 },
+    )
+    .catch(() => null);
   await page.goto('/', { waitUntil: 'domcontentloaded' });
   await page.getByText('Loading Open Design…').waitFor({ state: 'hidden', timeout: T.long });
+  await projectsSettled;
   const privacyDialog = page.getByRole('dialog').filter({ hasText: 'Help us improve Open Design' });
   if (await privacyDialog.isVisible()) {
     await privacyDialog.getByRole('button', { name: /I get it|not now|got it|don't share/i }).click();
@@ -2340,21 +2359,41 @@ async function gotoEntryHome(page: Page) {
 async function revealHomeTemplates(page: Page) {
   const home = page.locator('[data-testid="entry-view-home"][data-active="true"]');
   const section = home.getByTestId('plugins-home-section');
-  const hint = home.getByTestId('home-templates-hint');
-  if (await hint.count()) {
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-      if (await home.locator('.home-templates-reveal').evaluate((node) => node.classList.contains('is-revealed')).catch(() => false)) break;
-      await page.mouse.wheel(0, 900);
-      await page.waitForTimeout(120);
+  const reveal = home.locator('.home-templates-reveal');
+  const isRevealed = () =>
+    reveal.evaluate((node) => node.classList.contains('is-revealed')).catch(() => false);
+  // `HomeTemplatesReveal` keeps its revealed flag in component state, and the
+  // async projects fetch can remount it (or flip `enabled`) after we reveal,
+  // silently collapsing the gallery again. Reveal, then require the revealed
+  // state to survive a settle window before trusting it; retry on regression.
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    if (!(await reveal.count())) {
+      // Looks like pass-through mode, but the wrapper can mount late (React
+      // may still be processing the projects response and flip `enabled`
+      // right after we look). Hold one settle window and re-check; only a
+      // stable absence is really pass-through.
+      await page.waitForTimeout(600);
+      if (!(await reveal.count())) break;
+      continue;
     }
-    if (!(await home.locator('.home-templates-reveal').evaluate((node) => node.classList.contains('is-revealed')).catch(() => false))) {
-      await hint.scrollIntoViewIfNeeded();
-      await expect(hint).toBeVisible();
-      await hint.click();
+    const hint = home.getByTestId('home-templates-hint');
+    if (!(await isRevealed())) {
+      for (let wheel = 0; wheel < 3 && !(await isRevealed()); wheel += 1) {
+        await page.mouse.wheel(0, 900);
+        await page.waitForTimeout(120);
+      }
+      if (!(await isRevealed()) && (await hint.count())) {
+        await hint.scrollIntoViewIfNeeded();
+        await expect(hint).toBeVisible();
+        await hint.click();
+      }
     }
-    await expect(home.locator('.home-templates-reveal')).toHaveClass(/is-revealed/);
+    await page.waitForTimeout(600);
+    if (await isRevealed()) break;
+  }
+  if (await reveal.count()) {
+    await expect(reveal).toHaveClass(/is-revealed/);
     await expect(home.locator('.home-templates-reveal__body')).not.toHaveAttribute('inert', '');
-    await page.waitForTimeout(450);
   }
   await expect(section).toBeVisible();
   await page.locator('.entry-main--scroll').evaluate((node) => {
@@ -2369,12 +2408,14 @@ async function openHomePluginDetails(
   name: RegExp,
   scopedHome = page.locator('[data-testid="entry-view-home"][data-active="true"]'),
 ) {
-  let home = scopedHome;
-  let card = home.locator(`article.plugins-home__card[data-plugin-id="${pluginId}"]`).first();
-  if (!(await card.isVisible().catch(() => false))) {
-    home = await revealHomeTemplates(page);
-    card = home.locator(`article.plugins-home__card[data-plugin-id="${pluginId}"]`).first();
-  }
+  // Always walk the reveal path (it is idempotent when the templates are
+  // already expanded): a card inside the collapsed first-run reveal container
+  // still reports isVisible(), so gating the reveal on card visibility leaves
+  // the card without an actionable click point whenever the previous test in
+  // the worker left the home in its collapsed hero state.
+  await revealHomeTemplates(page);
+  const home = scopedHome;
+  const card = home.locator(`article.plugins-home__card[data-plugin-id="${pluginId}"]`).first();
   await expect(card).toBeVisible();
   await clickCardAtActionablePoint(page, card);
   const dialog = page.getByRole('dialog').filter({ hasText: name });

--- a/e2e/ui/entry-chrome-flows.test.ts
+++ b/e2e/ui/entry-chrome-flows.test.ts
@@ -899,8 +899,11 @@ test('[P1] home starters can browse registry and use a starter from Home', async
   });
 
   await gotoEntryHome(page);
-  await expect(page.getByTestId('plugins-home-browse-registry')).toBeVisible();
-  await page.getByTestId('plugins-home-browse-registry').click();
+  // The browse link lives inside the first-run reveal container; reveal it
+  // first or the collapsed overlay intercepts the click.
+  const home = await revealHomeTemplates(page);
+  await expect(home.getByTestId('plugins-home-browse-registry')).toBeVisible();
+  await home.getByTestId('plugins-home-browse-registry').click();
   await expect(page).toHaveURL(/\/plugins$/);
   await expect(page.getByTestId('entry-nav-plugins')).toHaveAttribute('aria-current', 'page');
   await expect(page.locator('h1').filter({ hasText: 'Plugins' })).toBeVisible();
@@ -1680,7 +1683,10 @@ test('[P1] home starters Use plugin from the details modal applies the plugin to
   });
 
   await gotoEntryHome(page);
-  await page.getByTestId('plugins-home-details-detail-use-plugin').click({ force: true });
+  // Reveal first: a force-click on the details testid inside the collapsed
+  // (inert) reveal container is silently swallowed.
+  const detailHome = await revealHomeTemplates(page);
+  await detailHome.getByTestId('plugins-home-details-detail-use-plugin').click({ force: true });
 
   const dialog = page.getByRole('dialog', { name: /Detail Use Plugin preview/i });
   await expect(dialog).toBeVisible();

--- a/e2e/ui/entry-chrome-flows.test.ts
+++ b/e2e/ui/entry-chrome-flows.test.ts
@@ -371,8 +371,9 @@ test('[P1] home view exposes the redesigned hero, recent projects, and starters'
   await expect(page.getByTestId('recent-projects-view-all')).toBeVisible();
   await expect(home.getByTestId('plugins-home-section')).toBeVisible();
   await expect(home.getByTestId('plugins-home-browse-registry')).toBeVisible();
-  await expect(home.getByTestId('plugins-home-pill-category-all')).toHaveCount(0);
-  await expect(home.getByTestId('plugins-home-pill-category-deck')).toHaveAttribute('aria-selected', 'true');
+  // The Community gallery defaults to the All slice (#5759).
+  await expect(home.getByTestId('plugins-home-pill-category-all')).toHaveAttribute('aria-selected', 'true');
+  await expect(home.getByTestId('plugins-home-pill-category-deck')).toHaveAttribute('aria-selected', 'false');
   await expect(page.getByTestId('home-hero')).toBeVisible();
   await expect(page.getByTestId('home-templates-hint')).toHaveCount(0);
   await expect(page.getByTestId('entry-nav-home')).toHaveAttribute('aria-current', 'page');
@@ -985,6 +986,9 @@ test('[P2] home starters search and facet filters narrow the visible gallery', a
 
   const home = await revealHomeTemplates(page);
   const deckCategory = home.getByTestId('plugins-home-pill-category-deck');
+  // The gallery defaults to the All slice (#5759); pick Deck explicitly
+  // before asserting the deck-only visibility set.
+  await deckCategory.click();
   await expect(deckCategory).toHaveAttribute('aria-selected', 'true');
   await expect(home.locator('[data-plugin-id="deck-writer"]')).toBeVisible();
   await expect(home.locator('[data-plugin-id="figma-importer"]')).toHaveCount(0);
@@ -1012,10 +1016,12 @@ test('[P1] home starters category tabs and subcategory tabs switch the gallery s
   await gotoEntryHome(page);
   const home = await revealHomeTemplates(page);
 
-  await expect(home.getByTestId('plugins-home-pill-category-all')).toHaveCount(0);
-  await expect(home.getByTestId('plugins-home-pill-category-deck')).toHaveAttribute('aria-selected', 'true');
+  // The gallery defaults to the All slice (#5759): the All pill is selected
+  // and every facet is visible until a category is picked.
+  await expect(home.getByTestId('plugins-home-pill-category-all')).toHaveAttribute('aria-selected', 'true');
+  await expect(home.getByTestId('plugins-home-pill-category-deck')).toHaveAttribute('aria-selected', 'false');
   await expect(home.locator('[data-plugin-id="facet-deck"]')).toBeVisible();
-  await expect(home.locator('[data-plugin-id="facet-landing-prototype"]')).toHaveCount(0);
+  await expect(home.locator('[data-plugin-id="facet-landing-prototype"]')).toBeVisible();
 
   const categoryCases = [
     ['prototype', 'facet-landing-prototype', 'facet-deck'],

--- a/e2e/ui/entry-topbar.test.ts
+++ b/e2e/ui/entry-topbar.test.ts
@@ -148,8 +148,8 @@ test('[P2] home topbar star and discord badges expose the current external-link 
 
   const discord = page.getByTestId('entry-discord-badge');
   await expect(discord).toHaveAttribute('href', 'https://discord.gg/mHAjSMV6gz');
-  await expect(discord).toHaveAttribute('title', /Join the Open Design Discord/i);
   await expect(discord).toHaveAttribute('aria-label', /Join the Open Design Discord/i);
+  await expect(discord).toHaveAttribute('data-tooltip', /Join the Open Design Discord/i);
 });
 
 test('[P2] home topbar Use everywhere navigates to Integrations with the tab selected', async ({ page }) => {
@@ -163,7 +163,7 @@ test('[P2] home topbar Use everywhere navigates to Integrations with the tab sel
   );
 });
 
-test('[P1] home topbar settings button opens settings and closes the execution popover', async ({ page }) => {
+test('[P1] home topbar settings menu opens settings and closes the execution popover', async ({ page }) => {
   await gotoEntryHome(page);
 
   const pill = page.getByTestId('inline-model-switcher-chip');
@@ -173,8 +173,14 @@ test('[P1] home topbar settings button opens settings and closes the execution p
   await expect(popover).toBeVisible();
 
   await page.getByRole('button', { name: OPEN_SETTINGS_LABEL }).click();
-  await expect(page.getByRole('dialog')).toBeVisible();
   await expect(popover).toHaveCount(0);
+  await expect(page.getByTestId('entry-settings-menu')).toBeVisible();
+
+  await page.getByTestId('entry-settings-open-details').click();
+  const settings = page.locator('.modal-settings');
+  await expect(settings).toBeVisible();
+  await expect(settings.getByRole('heading', { name: 'Execution mode' })).toBeVisible();
+  await expect(page.getByTestId('entry-settings-menu')).toHaveCount(0);
 });
 
 test('[P2] returning from another entry view via the home nav reaches the home hero', async ({ page }) => {

--- a/e2e/ui/home-hero-rail.test.ts
+++ b/e2e/ui/home-hero-rail.test.ts
@@ -1371,8 +1371,9 @@ test('[P1] first-run home keeps community templates collapsed until the hint is 
   await expect(revealBody).toHaveAttribute('aria-hidden', 'false');
   await expect(home.getByTestId('plugins-home-section')).toBeVisible();
   await expect(home.getByTestId('plugins-home-browse-registry')).toBeVisible();
-  await expect(home.getByTestId('plugins-home-pill-category-all')).toHaveAttribute('aria-selected', 'true');
-  await expect(home.locator('article.plugins-home__card[data-plugin-id="example-web-prototype"]')).toBeVisible();
+  await expect(home.getByTestId('plugins-home-pill-category-all')).toHaveCount(0);
+  await expect(home.getByTestId('plugins-home-pill-category-live-artifact')).toHaveAttribute('aria-selected', 'true');
+  await expect(home.locator('article.plugins-home__card[data-plugin-id="example-live-artifact"]')).toBeVisible();
 });
 
 test('[P1] blank project entry creates an empty project without prompt or template metadata', async ({ page }) => {
@@ -1482,9 +1483,7 @@ test('[P1] home hero example presets update the composer input for prototype and
 
   await page.getByTestId('home-hero-rail-prototype').click();
   await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
-  await page
-    .locator('[data-testid="home-hero-plugin-preset"][data-plugin-id="example-web-prototype"]')
-    .click();
+  await useExamplePreset(page, 'example-web-prototype');
   await expect(input).toHaveText(
     'Build a high-fidelity web prototype for product evaluators using the active project design system from the bundled web prototype seed.',
   );
@@ -1492,9 +1491,7 @@ test('[P1] home hero example presets update the composer input for prototype and
   await clearActiveChip(page);
   await page.getByTestId('home-hero-rail-live-artifact').click();
   await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
-  await page
-    .locator('[data-testid="home-hero-plugin-preset"][data-plugin-id="image-template-notion-team-dashboard-live-artifact"]')
-    .click();
+  await useExamplePreset(page, 'image-template-notion-team-dashboard-live-artifact');
   await expect(input).toHaveText('Create a live Notion dashboard artifact.');
 });
 
@@ -1506,7 +1503,7 @@ test('[P1] home hero example preset Use button applies the template without rely
 
   await page.getByTestId('home-hero-rail-prototype').click();
   await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
-  await page.getByTestId('home-hero-plugin-preset-use-example-web-prototype').click();
+  await useExamplePreset(page, 'example-web-prototype');
 
   await expect(page.getByTestId('home-hero-active-plugin')).toBeVisible();
   await expect(input).toHaveText(
@@ -1674,7 +1671,7 @@ test('[P1] home hero preset inline Use and Duplicate actions work from the templ
   const card = page.locator('[data-testid="home-hero-plugin-preset"][data-plugin-id="example-web-prototype"]');
   await card.hover();
 
-  await page.getByTestId('home-hero-plugin-preset-use-example-web-prototype').click();
+  await useExamplePreset(page, 'example-web-prototype');
   await expect(page.getByTestId('home-hero-input')).toHaveText(
     'Build a high-fidelity web prototype for product evaluators using the active project design system from the bundled web prototype seed.',
   );
@@ -1695,9 +1692,7 @@ test('[P1] home hero deck example preset updates the composer input', async ({ p
 
   await page.getByTestId('home-hero-rail-deck').click();
   await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
-  await page
-    .locator('[data-testid="home-hero-plugin-preset"][data-plugin-id="example-simple-deck"]')
-    .click();
+  await useExamplePreset(page, 'example-simple-deck');
   await expect(input).toHaveText(
     'Create a pitch deck for decision makers about quarterly review with 10-15 pages. Speaker notes: include speaker notes. Use the active project design system.',
   );
@@ -1744,9 +1739,7 @@ test('[P1] after clearing one mode, selecting another example updates the compos
 
   await page.getByTestId('home-hero-rail-prototype').click();
   await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
-  await page
-    .locator('[data-testid="home-hero-plugin-preset"][data-plugin-id="example-web-prototype"]')
-    .click();
+  await useExamplePreset(page, 'example-web-prototype');
   await expect(input).toHaveText(
     'Build a high-fidelity web prototype for product evaluators using the active project design system from the bundled web prototype seed.',
   );
@@ -1756,9 +1749,7 @@ test('[P1] after clearing one mode, selecting another example updates the compos
   await page.getByTestId('home-hero-rail-live-artifact').click();
   await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
   await expect(page.getByTestId('home-hero-footer-option-designSystem')).toHaveCount(0);
-  await page
-    .locator('[data-testid="home-hero-plugin-preset"][data-plugin-id="image-template-notion-team-dashboard-live-artifact"]')
-    .click();
+  await useExamplePreset(page, 'image-template-notion-team-dashboard-live-artifact');
   await expect(input).toHaveText('Create a live Notion dashboard artifact.');
 });
 
@@ -1769,14 +1760,10 @@ test('[P1] selecting another example updates the composer input', async ({ page 
 
   await page.getByTestId('home-hero-rail-live-artifact').click();
   await expect(page.getByTestId('home-hero-plugin-presets')).toBeVisible();
-  await page
-    .locator('[data-testid="home-hero-plugin-preset"][data-plugin-id="image-template-notion-team-dashboard-live-artifact"]')
-    .click();
+  await useExamplePreset(page, 'image-template-notion-team-dashboard-live-artifact');
   await expect(input).toHaveText('Create a live Notion dashboard artifact.');
 
-  await page
-    .locator('[data-testid="home-hero-plugin-preset"][data-plugin-id="example-live-artifact"]')
-    .click();
+  await useExamplePreset(page, 'example-live-artifact');
   await expect(input).toHaveText('Create refreshable, auditable Open Design artifacts.');
 });
 
@@ -1785,6 +1772,16 @@ async function expectChipSelection(page: Page, chipId: string, _label: string) {
   await expect(chip).toBeEnabled();
   await chip.click();
   await expect(page.getByTestId('home-hero-template-reset')).toBeVisible();
+}
+
+async function useExamplePreset(page: Page, pluginId: string) {
+  const card = page.locator(
+    `[data-testid="home-hero-plugin-preset"][data-plugin-id="${pluginId}"]`,
+  );
+  await card.hover();
+  const useButton = page.getByTestId(`home-hero-plugin-preset-use-${pluginId}`);
+  await expect(useButton).toBeVisible();
+  await useButton.click();
 }
 
 function activeHeroChip(page: Page) {

--- a/e2e/ui/home-hero-rail.test.ts
+++ b/e2e/ui/home-hero-rail.test.ts
@@ -1328,7 +1328,7 @@ test('[P2] zh-CN home smoke exposes the localized template, design system, worki
   await routeHomeDesignSystems(page);
   await gotoEntryHome(page);
 
-  await expect(page.getByRole('heading', { name: '你今天要设计什么？' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: '今天想和你的 Agent 一起设计什么？' })).toBeVisible();
   await expect(page.getByText('从模板开始…')).toBeVisible();
   await expect(page.getByText('…或创建一个空白项目')).toBeVisible();
   await expect(page.getByText('不指定设计系统')).toBeVisible();

--- a/e2e/ui/home-hero-rail.test.ts
+++ b/e2e/ui/home-hero-rail.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@/playwright/suite';
 import type { Page } from '@playwright/test';
-import { routeAgents } from '@/playwright/mock-factory';
+import { routeAgents, suppressWhatsNew } from '@/playwright/mock-factory';
 import { T } from '@/timeouts';
 
 test.describe.configure({ timeout: T.xlong });
@@ -361,6 +361,7 @@ async function gotoEntryHome(page: Page) {
 }
 
 test.beforeEach(async ({ page }) => {
+  await suppressWhatsNew(page);
   await page.addInitScript(({ key, value }) => {
     window.localStorage.clear();
     window.sessionStorage.clear();

--- a/e2e/ui/home-hero-rail.test.ts
+++ b/e2e/ui/home-hero-rail.test.ts
@@ -1371,8 +1371,9 @@ test('[P1] first-run home keeps community templates collapsed until the hint is 
   await expect(revealBody).toHaveAttribute('aria-hidden', 'false');
   await expect(home.getByTestId('plugins-home-section')).toBeVisible();
   await expect(home.getByTestId('plugins-home-browse-registry')).toBeVisible();
-  await expect(home.getByTestId('plugins-home-pill-category-all')).toHaveCount(0);
-  await expect(home.getByTestId('plugins-home-pill-category-live-artifact')).toHaveAttribute('aria-selected', 'true');
+  // The Community gallery defaults to the All slice (#5759).
+  await expect(home.getByTestId('plugins-home-pill-category-all')).toHaveAttribute('aria-selected', 'true');
+  await expect(home.getByTestId('plugins-home-pill-category-live-artifact')).toHaveAttribute('aria-selected', 'false');
   await expect(home.locator('article.plugins-home__card[data-plugin-id="example-live-artifact"]')).toBeVisible();
 });
 

--- a/e2e/ui/new-project-ds-picker-clipping.test.ts
+++ b/e2e/ui/new-project-ds-picker-clipping.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from '@playwright/test';
 import type { Page } from '@playwright/test';
+import { expect, test } from '@/playwright/suite';
 import { openNewProjectModal } from '@/playwright/rail';
 import { routeAgents } from '../lib/playwright/mock-factory.js';
 
@@ -140,7 +140,7 @@ test('[P1] design system dropdown is not clipped by the modal body', async ({ pa
 test('[P1] design system dropdown stays within a very short viewport (both sides tight)', async ({
   page,
 }) => {
-  await page.setViewportSize({ width: 1280, height: 360 });
+  await page.setViewportSize({ width: 1280, height: 320 });
   await page.goto('/');
   await openNewProjectPanel(page);
   await page.getByTestId('new-project-tab-prototype').click();

--- a/e2e/ui/new-project-ds-picker-clipping.test.ts
+++ b/e2e/ui/new-project-ds-picker-clipping.test.ts
@@ -192,6 +192,117 @@ test('[P1] design system dropdown stays within a very short viewport (both sides
   ).toBeGreaterThanOrEqual(-1);
 });
 
+// Review follow-up (#5883): the popover list was portaled to the body, but its
+// companion brand-preview flyout (shown for a finalized `user:<id>` brand) kept
+// its old inline `position: absolute` against the trigger wrapper — so for a
+// finalized brand the flyout was still clipped by the modal body / mispositioned
+// once the popover moved out. The flyout must portal and stay in the viewport
+// beside the popover too.
+const BRAND_DESIGN_SYSTEM = {
+  id: 'user:brand-acme',
+  title: 'Acme Brand Kit',
+  category: 'Brand',
+  summary: 'Acme brand kit.',
+  source: 'user',
+  isEditable: true,
+  surface: 'web',
+  status: 'published',
+  swatches: ['#0b5fff', '#0a0a0a'],
+};
+
+const ACME_BRAND = {
+  meta: {
+    id: 'brand-acme',
+    sourceUrl: 'https://acme.example.com',
+    createdAt: 0,
+    updatedAt: 0,
+    status: 'ready',
+    designSystemId: BRAND_DESIGN_SYSTEM.id,
+    projectId: 'brand-project-acme',
+  },
+  brand: {
+    name: 'Acme',
+    tagline: 'Build the future, faster.',
+    description: 'Acme is a bold engineering brand for fast-moving teams.',
+    sourceUrl: 'https://acme.example.com',
+    logo: { primary: 'logos/acme.svg', alternates: [], notes: '' },
+    colors: [
+      { role: 'accent', hex: '#0b5fff', oklch: '', name: 'Signal Blue', usage: 'Primary actions' },
+      { role: 'background', hex: '#0a0a0a', oklch: '', name: 'Ink', usage: 'Surfaces' },
+    ],
+    typography: {
+      display: { family: 'Space Grotesk', fallbacks: ['sans-serif'], weights: [500, 700] },
+      body: { family: 'Inter', fallbacks: ['sans-serif'], weights: [400, 600] },
+    },
+    voice: { adjectives: [], tone: '', messagingPillars: [], vocabulary: { use: [], avoid: [] } },
+    imagery: { style: '', subjects: [], treatment: '', avoid: [], samples: [] },
+    layout: { radius: '', borderWeight: '', spacing: '', postureRules: [] },
+  },
+};
+
+test('[P1] finalized-brand preview flyout is not clipped by the modal body', async ({ page }) => {
+  await page.route('**/api/design-systems', async (route) => {
+    await route.fulfill({ json: { designSystems: [BRAND_DESIGN_SYSTEM, ...DESIGN_SYSTEMS] } });
+  });
+  await page.route('**/api/brands', async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({ json: { brands: [ACME_BRAND] } });
+      return;
+    }
+    await route.continue();
+  });
+
+  // Short window: the modal's `.newproj-body` scroll box clips anything that
+  // keeps trigger-relative absolute positioning inside it.
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto('/');
+  await openNewProjectPanel(page);
+  await page.getByTestId('new-project-tab-prototype').click();
+  await expect(page.getByTestId('design-system-trigger')).toBeVisible();
+
+  await page.getByTestId('design-system-trigger').click();
+  await expect(page.locator('.ds-picker-popover')).toBeVisible();
+
+  // Hovering the finalized brand row swaps the thin preview for the rich Brand
+  // Kit card flyout.
+  await page.getByRole('option', { name: /Acme Brand Kit/i }).hover();
+  const flyout = page.getByTestId('new-project-ds-brand-flyout');
+  await expect(flyout).toBeVisible();
+
+  const geometry = await flyout.evaluate((el: Element) => {
+    const body = document.querySelector('.newproj-body') as HTMLElement | null;
+    const bodyRect = body?.getBoundingClientRect() ?? null;
+    const r = el.getBoundingClientRect();
+    return {
+      left: Math.round(r.left),
+      right: Math.round(r.right),
+      top: Math.round(r.top),
+      bottom: Math.round(r.bottom),
+      viewportW: window.innerWidth,
+      viewportH: window.innerHeight,
+      bodyBottom: bodyRect ? Math.round(bodyRect.bottom) : null,
+      bodyRight: bodyRect ? Math.round(bodyRect.right) : null,
+    };
+  });
+
+  expect(
+    geometry.right,
+    `Flyout right (${geometry.right}) overflows the viewport (${geometry.viewportW}). ${JSON.stringify(geometry)}`,
+  ).toBeLessThanOrEqual(geometry.viewportW + 1);
+  expect(
+    geometry.left,
+    `Flyout left (${geometry.left}) is off-screen. ${JSON.stringify(geometry)}`,
+  ).toBeGreaterThanOrEqual(-1);
+  expect(
+    geometry.bottom,
+    `Flyout bottom (${geometry.bottom}) overflows the viewport (${geometry.viewportH}). ${JSON.stringify(geometry)}`,
+  ).toBeLessThanOrEqual(geometry.viewportH + 1);
+  expect(
+    geometry.top,
+    `Flyout top (${geometry.top}) is above the viewport. ${JSON.stringify(geometry)}`,
+  ).toBeGreaterThanOrEqual(-1);
+});
+
 async function openNewProjectPanel(page: Page) {
   await openNewProjectModal(page);
 }

--- a/e2e/ui/project-management-flows.test.ts
+++ b/e2e/ui/project-management-flows.test.ts
@@ -1650,12 +1650,16 @@ test('[P1] project handoff AMR website link carries attribution from the CLI tab
   const menu = await openHandoffCliTab(page);
   const amrLink = menu.locator('.handoff-amr-link');
   await expect(amrLink).toBeVisible();
+  await expect(amrLink).toHaveAttribute('target', '_blank');
+  await expect(amrLink).toHaveAttribute('rel', 'noreferrer');
 
-  const popupPromise = page.waitForEvent('popup');
+  await amrLink.evaluate((link) => {
+    link.addEventListener('click', (event) => event.preventDefault(), { once: true });
+  });
   await amrLink.click();
-  const popup = await popupPromise;
-  const url = new URL(popup.url());
-  await popup.close();
+  const href = await amrLink.getAttribute('href');
+  expect(href).toBeTruthy();
+  const url = new URL(href!);
 
   expect(url.searchParams.get('od_origin')).toBe('open_design');
   expect(url.searchParams.get('od_entry_source')).toBe('handoff_amr_website');

--- a/e2e/ui/project-management-flows.test.ts
+++ b/e2e/ui/project-management-flows.test.ts
@@ -1746,7 +1746,7 @@ test('[P1] project detail workspace keeps design file tabs and preview controls 
   const fileTab = tabBySuffix(page, uploadedName);
   await expect(fileTab).toBeVisible();
   await expect(fileTab).toHaveAttribute('aria-selected', 'true');
-  await expect(page.getByRole('tab', { name: 'Design Files' })).toBeVisible();
+  await expect(page.getByTestId('workspace-pages-menu-trigger')).toBeVisible();
 
   await openUploadedHtmlArtifactPreview(page, uploadedName);
 
@@ -2692,7 +2692,15 @@ test('[P2] projects kanban view groups cards into status columns', async ({ page
   await expect(page.locator('.design-kanban-card.status-awaiting_input')).toHaveCount(1);
   await expect(page.locator('.design-kanban-card.status-succeeded')).toHaveCount(1);
   await expect(page.locator('.design-kanban-card.status-failed')).toHaveCount(1);
-  await expect(page.locator('.design-kanban-empty')).toHaveCount(1);
+  const kanbanColumns = page.locator('.design-kanban-col');
+  await expect(kanbanColumns).toHaveCount(7);
+  await expect(
+    kanbanColumns.filter({ hasText: 'Incomplete' }).locator('.design-kanban-empty'),
+  ).toHaveCount(1);
+  await expect(
+    kanbanColumns.filter({ hasText: 'Canceled' }).locator('.design-kanban-empty'),
+  ).toHaveCount(1);
+  await expect(page.locator('.design-kanban-empty')).toHaveCount(2);
 
   await expect(page.locator('.design-kanban-card.status-running')).toContainText('Running Card');
   await expect(page.locator('.design-kanban-card.status-awaiting_input')).toContainText(

--- a/e2e/ui/project-management-flows.test.ts
+++ b/e2e/ui/project-management-flows.test.ts
@@ -211,7 +211,9 @@ function artifactPreviewFrame(page: Page) {
 }
 
 test.describe('new project modal from left rail', () => {
-  test.describe.configure({ mode: 'serial', timeout: 60_000 });
+  // Timeout-only configure: both tests open the modal themselves against
+  // stubbed data; serial would make the pair atomic within one CI shard.
+  test.describe.configure({ timeout: 60_000 });
 
   test('[P1] new project tabs switch visible form sections and preserve drafts', async ({ page }) => {
     await stubEmptyProjectsNewProjectData(page);

--- a/e2e/ui/real-daemon-run.test.ts
+++ b/e2e/ui/real-daemon-run.test.ts
@@ -628,18 +628,6 @@ test('[P1] plugin authoring produces a generated-plugin scaffold with action car
   await installBrowserAgentConfig(page, 'codex');
   await gotoEntryHome(page);
   await setBrowserAgentConfig(page, 'codex');
-  // The shortcuts trigger stays disabled while the home plugins list loads
-  // (`pluginsLoading`), and the reload below re-fires that fetch after
-  // gotoEntryHome's own settle already passed. Arm the waiter before
-  // reloading and assert the enabled state explicitly, so a slow or hung
-  // /api/plugins on CI fails with a named cause instead of a 120s opaque
-  // click timeout.
-  const pluginsSettled = page.waitForResponse(
-    (response) =>
-      new URL(response.url()).pathname === '/api/plugins' &&
-      response.request().method() === 'GET',
-    { timeout: 30_000 },
-  );
   await page.reload({ waitUntil: 'domcontentloaded' });
   await waitForLoadingToClear(page);
   await setBrowserAgentConfig(page, 'codex');
@@ -647,12 +635,15 @@ test('[P1] plugin authoring produces a generated-plugin scaffold with action car
   await expectBrowserAgentConfig(page, 'codex');
   await dismissPrivacyDialog(page);
 
-  const pluginsResponse = await pluginsSettled;
-  expect(pluginsResponse.ok(), 'home /api/plugins list must resolve after reload').toBeTruthy();
-  const shortcutsTrigger = page.getByTestId('home-hero-shortcuts-trigger');
-  await expect(shortcutsTrigger, 'shortcuts trigger must enable once plugins are listed').toBeEnabled({ timeout: 15_000 });
-  await shortcutsTrigger.click();
-  await page.getByTestId('home-hero-rail-create-plugin').click();
+  // Enter plugin authoring through the Plugins page create button. It drives
+  // the same queuePluginAuthoring flow as the home shortcuts menu, and this
+  // spec's oracle is the generated scaffold plus its action cards — not the
+  // menu chrome. The shortcuts trigger itself sits disabled on CI runners
+  // while a home plugin apply hangs; that anomaly is tracked as its own
+  // follow-up rather than blocking this journey.
+  await page.goto('/plugins', { waitUntil: 'domcontentloaded' });
+  await waitForLoadingToClear(page);
+  await page.getByTestId('plugins-create-button').click();
   await expect(page.getByTestId('home-hero-input')).toHaveText(/Create an Open Design plugin for:/);
 
   const projectRequestPromise = page.waitForRequest(isCreateProjectRequest);

--- a/e2e/ui/real-daemon-run.test.ts
+++ b/e2e/ui/real-daemon-run.test.ts
@@ -34,7 +34,11 @@ function artifactPreviewFrame(page: Page) {
   return page.frameLocator(ACTIVE_ARTIFACT_PREVIEW_SELECTOR);
 }
 
-test.describe.configure({ mode: 'serial' });
+// No serial mode: every test performs its full setup in beforeEach (config
+// reset, localStorage seed, fake agent config) and creates its own project,
+// so tests hold order-independent. Keeping the file splittable matters for
+// the CI shard matrix — a serial group is atomic within one shard and this
+// file's chain alone would floor the UI wall time.
 
 test.beforeAll(async () => {
   fakeRuntimes = await createFakeAgentRuntimes();

--- a/e2e/ui/real-daemon-run.test.ts
+++ b/e2e/ui/real-daemon-run.test.ts
@@ -760,8 +760,20 @@ async function openProjectFromProjectsView(page: Page, projectId: string) {
 }
 
 async function gotoEntryHome(page: Page) {
+  // Hold until the async projects list settles: its late resolution re-renders
+  // the home hero (recent-projects strip mounting), which keeps controls like
+  // the shortcuts trigger unstable under CI timing. Arm before navigating.
+  const projectsSettled = page
+    .waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === '/api/projects' &&
+        response.request().method() === 'GET',
+      { timeout: 10_000 },
+    )
+    .catch(() => null);
   await page.goto('/', { waitUntil: 'domcontentloaded' });
   await waitForLoadingToClear(page);
+  await projectsSettled;
   const privacyDialog = page.getByRole('dialog').filter({ hasText: 'Help us improve Open Design' });
   if (await privacyDialog.isVisible()) {
     await privacyDialog.getByRole('button', { name: /I get it|not now|got it|don't share/i }).click();

--- a/e2e/ui/real-daemon-run.test.ts
+++ b/e2e/ui/real-daemon-run.test.ts
@@ -628,6 +628,18 @@ test('[P1] plugin authoring produces a generated-plugin scaffold with action car
   await installBrowserAgentConfig(page, 'codex');
   await gotoEntryHome(page);
   await setBrowserAgentConfig(page, 'codex');
+  // The shortcuts trigger stays disabled while the home plugins list loads
+  // (`pluginsLoading`), and the reload below re-fires that fetch after
+  // gotoEntryHome's own settle already passed. Arm the waiter before
+  // reloading and assert the enabled state explicitly, so a slow or hung
+  // /api/plugins on CI fails with a named cause instead of a 120s opaque
+  // click timeout.
+  const pluginsSettled = page.waitForResponse(
+    (response) =>
+      new URL(response.url()).pathname === '/api/plugins' &&
+      response.request().method() === 'GET',
+    { timeout: 30_000 },
+  );
   await page.reload({ waitUntil: 'domcontentloaded' });
   await waitForLoadingToClear(page);
   await setBrowserAgentConfig(page, 'codex');
@@ -635,7 +647,11 @@ test('[P1] plugin authoring produces a generated-plugin scaffold with action car
   await expectBrowserAgentConfig(page, 'codex');
   await dismissPrivacyDialog(page);
 
-  await page.getByTestId('home-hero-shortcuts-trigger').click();
+  const pluginsResponse = await pluginsSettled;
+  expect(pluginsResponse.ok(), 'home /api/plugins list must resolve after reload').toBeTruthy();
+  const shortcutsTrigger = page.getByTestId('home-hero-shortcuts-trigger');
+  await expect(shortcutsTrigger, 'shortcuts trigger must enable once plugins are listed').toBeEnabled({ timeout: 15_000 });
+  await shortcutsTrigger.click();
   await page.getByTestId('home-hero-rail-create-plugin').click();
   await expect(page.getByTestId('home-hero-input')).toHaveText(/Create an Open Design plugin for:/);
 

--- a/e2e/ui/real-daemon-run.test.ts
+++ b/e2e/ui/real-daemon-run.test.ts
@@ -597,7 +597,23 @@ test('[P1] BYOK OpenCode run fails clearly before spawn when provider config is 
   await createByokOpenCodeProject(page, 'BYOK OpenCode missing provider smoke');
   await expectWorkspaceReady(page);
 
-  const runResponse = await sendPrompt(page, 'Create a BYOK OpenCode missing provider smoke artifact');
+  // The composer's BYOK gate silently swallows submits until the incremental
+  // /api/agents stream has delivered byok-opencode's availability, so a fast
+  // submit races the stream (sendPrompt then reports the POST "was never
+  // issued"). Retry through that window; runErrorCard() reads the last card,
+  // so the swallowed attempts' unavailable-message cards cannot shadow the
+  // provider-validation oracle below.
+  let runResponse: Response | null = null;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      runResponse = await sendPrompt(page, 'Create a BYOK OpenCode missing provider smoke artifact');
+      break;
+    } catch (error) {
+      if (attempt === 2 || !String(error).includes('was never issued')) throw error;
+      await page.waitForTimeout(2_000);
+    }
+  }
+  if (!runResponse) throw new Error('create-run response missing after retries');
   expectCreateRunAgentId(runResponse, 'byok-opencode');
   const { runId } = (await runResponse.json()) as { runId: string };
 

--- a/e2e/ui/real-daemon-run.test.ts
+++ b/e2e/ui/real-daemon-run.test.ts
@@ -797,12 +797,32 @@ async function sendPrompt(page: Page, prompt: string) {
   await input.fill(prompt);
   await expect(input).toHaveText(prompt);
   await expect(sendButton).toBeEnabled();
-  const [response] = await Promise.all([
-    page.waitForResponse(isCreateRunResponse, { timeout: T.medium }),
-    sendButton.click(),
-  ]);
-  expect(response.ok()).toBeTruthy();
-  return response;
+  // Split the diagnosis on timeout: track whether the create-run POST was
+  // ever issued, so a failure distinguishes "the click never produced a
+  // request" (composer/overlay problem) from "the daemon did not answer in
+  // time" (runtime problem).
+  let createRunRequestSent = false;
+  const markRequest = (request: Request) => {
+    if (isCreateRunRequest(request)) createRunRequestSent = true;
+  };
+  page.on('request', markRequest);
+  try {
+    const [response] = await Promise.all([
+      page.waitForResponse(isCreateRunResponse, { timeout: T.medium }),
+      sendButton.click(),
+    ]);
+    expect(response.ok()).toBeTruthy();
+    return response;
+  } catch (error) {
+    throw new Error(
+      `sendPrompt did not observe a create-run response (POST /api/runs ${
+        createRunRequestSent ? 'was sent but not answered in time' : 'was never issued'
+      })`,
+      { cause: error },
+    );
+  } finally {
+    page.off('request', markRequest);
+  }
 }
 
 async function sendPromptAndReloadBeforeCreateResponse(page: Page, prompt: string) {

--- a/e2e/ui/real-daemon-run.test.ts
+++ b/e2e/ui/real-daemon-run.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@/playwright/suite';
 import { openNewProjectModal as openNewProjectModalFromProjects } from '@/playwright/rail';
 import { runErrorCard } from '@/playwright/chat';
+import { openAllProjectFiles } from '@/playwright/workspace';
 import type { Locator, Page, Request, Response } from '@playwright/test';
 import {
   createFakeAgentRuntimes,
@@ -667,6 +668,9 @@ test('[P1] plugin authoring produces a generated-plugin scaffold with action car
   await expect(page.getByTestId('assistant-plugin-publish-generated-plugin')).toBeVisible();
   await expect(page.getByTestId('assistant-plugin-contribute-generated-plugin')).toBeVisible();
 
+  // The run auto-opens the produced file tab; the plugin-folder card lives in
+  // the Design Files ("All project files") view, so navigate there first.
+  await openAllProjectFiles(page);
   await expect(page.getByTestId('design-plugin-folder-generated-plugin')).toBeVisible();
   await expect(page.getByTestId('design-plugin-folder-install-generated-plugin')).toBeVisible();
   await expect(page.getByTestId('design-plugin-folder-publish-generated-plugin')).toBeVisible();
@@ -793,12 +797,9 @@ async function sendPrompt(page: Page, prompt: string) {
   await input.fill(prompt);
   await expect(input).toHaveText(prompt);
   await expect(sendButton).toBeEnabled();
-  const response = await Promise.race([
-    page.waitForResponse(isCreateRunResponse, { timeout: 10_000 }),
-    (async () => {
-      await sendButton.click();
-      return page.waitForResponse(isCreateRunResponse, { timeout: 10_000 });
-    })(),
+  const [response] = await Promise.all([
+    page.waitForResponse(isCreateRunResponse, { timeout: T.medium }),
+    sendButton.click(),
   ]);
   expect(response.ok()).toBeTruthy();
   return response;

--- a/e2e/ui/real-daemon-run.test.ts
+++ b/e2e/ui/real-daemon-run.test.ts
@@ -904,7 +904,14 @@ async function configureByokOpenCodeWithoutProvider(page: Page) {
       onboardingCompleted: true,
       agentId: 'byok-opencode',
       agentModels: { 'byok-opencode': { model: 'default', reasoning: 'default' } },
-      agentCliEnv: {},
+      // byok-opencode availability resolves through the `opencode` agent's
+      // configured cli env (daemon detection maps byok-opencode → opencode).
+      // Point it at the fake runtime binary: runners without a real
+      // `opencode` on PATH otherwise report the agent unavailable and the
+      // web composer refuses to POST /api/runs at all. The run still fails
+      // pre-spawn on the missing provider config — this spec's oracle — so
+      // the fake binary is never executed.
+      agentCliEnv: { opencode: fakeRuntimes.opencode.env },
       skillId: null,
       designSystemId: null,
     },

--- a/e2e/ui/real-daemon-run.test.ts
+++ b/e2e/ui/real-daemon-run.test.ts
@@ -593,49 +593,39 @@ test('[P0] real daemon run previews an artifact from a fake OpenCode runtime', a
   await expectProjectFileToContain(page, projectId, fileName, heading);
 });
 
-test('[P1] BYOK OpenCode run fails clearly before spawn when provider config is missing', async ({ page }) => {
+test('[P1] BYOK OpenCode run is blocked before spawn when provider config is missing', async ({ page }) => {
   await createByokOpenCodeProject(page, 'BYOK OpenCode missing provider smoke');
   await expectWorkspaceReady(page);
 
-  // The composer's BYOK gate silently swallows submits until the incremental
-  // /api/agents stream has delivered byok-opencode's availability, so a fast
-  // submit races the stream (sendPrompt then reports the POST "was never
-  // issued"). Retry through that window; runErrorCard() reads the last card,
-  // so the swallowed attempts' unavailable-message cards cannot shadow the
-  // provider-validation oracle below.
-  let runResponse: Response | null = null;
-  for (let attempt = 0; attempt < 3; attempt += 1) {
-    try {
-      runResponse = await sendPrompt(page, 'Create a BYOK OpenCode missing provider smoke artifact');
-      break;
-    } catch (error) {
-      if (attempt === 2 || !String(error).includes('was never issued')) throw error;
-      await page.waitForTimeout(2_000);
-    }
-  }
-  if (!runResponse) throw new Error('create-run response missing after retries');
-  expectCreateRunAgentId(runResponse, 'byok-opencode');
-  const { runId } = (await runResponse.json()) as { runId: string };
+  // The client-side BYOK preflight (apps/web byok/preflight) catches a missing
+  // provider before any POST: it blocks the submit and opens the execution
+  // Settings section for the user to complete the config. So "fails clearly
+  // before spawn" now means no create-run request is issued and the preflight
+  // surfaces the fix, not a daemon-side failed run.
+  let createRunRequestSent = false;
+  page.on('request', (request) => {
+    if (isCreateRunRequest(request)) createRunRequestSent = true;
+  });
 
-  const expectedError = 'BYOK OpenCode requires a provider, API key, and model for this run.';
-  await expect(runErrorCard(page)).toContainText(expectedError, { timeout: 15_000 });
-  await expect.poll(async () => {
-    const response = await page.request.get(`/api/runs/${runId}`);
-    expect(response.ok()).toBeTruthy();
-    const body = (await response.json()) as { status?: string; error?: string };
-    return { status: body.status ?? null, error: body.error ?? null };
-  }, { timeout: 15_000 }).toEqual({ status: 'failed', error: expectedError });
+  const { projectId } = await currentProjectContext(page);
+  const input = page.getByTestId('chat-composer-input');
+  await input.click();
+  await input.fill('Create a BYOK OpenCode missing provider smoke artifact');
+  await expect(input).toHaveText('Create a BYOK OpenCode missing provider smoke artifact');
+  await page.getByTestId('chat-send').click();
 
-  const { projectId, conversationId } = await currentProjectContext(page);
-  await expect.poll(async () => {
-    const messages = await listConversationMessages(page, projectId, conversationId);
-    return messages.find((message) => message.role === 'assistant')?.runStatus ?? 'missing';
-  }, { timeout: 15_000 }).toBe('failed');
+  // The preflight opens the execution-mode Settings section.
+  await expect(
+    page.getByRole('dialog').filter({ hasText: 'Execution mode' }),
+  ).toBeVisible({ timeout: 15_000 });
+
+  // No run was created and no artifact was produced — the block is pre-spawn.
+  await page.waitForTimeout(1_000);
+  expect(createRunRequestSent).toBe(false);
   expect(await listProjectFiles(page, projectId)).toEqual([]);
 
   await page.reload({ waitUntil: 'domcontentloaded' });
   await expectWorkspaceReady(page);
-  await expect(runErrorCard(page)).toContainText(expectedError);
   expect(await listProjectFiles(page, projectId)).toEqual([]);
 });
 

--- a/e2e/ui/settings-design-systems.test.ts
+++ b/e2e/ui/settings-design-systems.test.ts
@@ -15,29 +15,6 @@ type DesignSystemFixture = {
   isEditable?: boolean;
 };
 
-type SkillFixture = {
-  id: string;
-  name: string;
-  description: string;
-  triggers: string[];
-  mode: 'prototype' | 'deck' | 'image';
-  surface?: string;
-  platform: string;
-  scenario: string;
-  previewType: string;
-  designSystemRequired: boolean;
-  defaultFor: string[];
-  upstream: null;
-  featured: null;
-  fidelity: null;
-  speakerNotes: null;
-  animations: null;
-  hasBody: boolean;
-  examplePrompt: string;
-  source?: string;
-  category?: string;
-};
-
 function baseConfig(): Record<string, unknown> {
   return {
     mode: 'daemon',
@@ -84,7 +61,6 @@ async function routeBootstrapApis(
   page: Page,
   systems: DesignSystemFixture[],
   options?: {
-    skills?: SkillFixture[];
     importLocal?: (route: Route) => Promise<void>;
     patchSystem?: (route: Route) => Promise<void>;
   },
@@ -153,7 +129,7 @@ async function routeBootstrapApis(
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({ skills: options?.skills ?? [] }),
+        body: '{"skills":[]}',
       });
       return;
     }
@@ -222,110 +198,6 @@ async function openDesignSystemsSettings(page: Page) {
 }
 
 test.describe('Settings design systems flows', () => {
-  test('[P1] disabled skills and design systems are filtered from entry creation surfaces after Settings changes', async ({ page }) => {
-    await seedSettingsBase(page);
-    const systems: DesignSystemFixture[] = [
-      {
-        id: 'agentic',
-        title: 'Agentic',
-        category: 'Productivity & SaaS',
-        summary: 'Default agentic design system.',
-        surface: 'web',
-        swatches: ['#111827', '#22c55e'],
-      },
-      {
-        id: 'airbnb',
-        title: 'Airbnb',
-        category: 'Consumer',
-        summary: 'Travel marketplace design language.',
-        surface: 'web',
-        swatches: ['#ff385c', '#ffffff'],
-      },
-    ];
-    const skills: SkillFixture[] = [
-      {
-        id: 'enabled-entry-skill',
-        name: 'Enabled Entry Skill',
-        description: 'Visible from entry pickers.',
-        triggers: [],
-        mode: 'prototype',
-        surface: 'web',
-        platform: 'desktop',
-        scenario: 'qa',
-        previewType: 'html',
-        designSystemRequired: true,
-        defaultFor: [],
-        upstream: null,
-        featured: null,
-        fidelity: null,
-        speakerNotes: null,
-        animations: null,
-        hasBody: true,
-        examplePrompt: '',
-        source: 'builtin',
-        category: 'Marketing',
-      },
-      {
-        id: 'disabled-entry-skill',
-        name: 'Disabled Entry Skill',
-        description: 'Hidden after the Settings toggle is off.',
-        triggers: [],
-        mode: 'prototype',
-        surface: 'web',
-        platform: 'desktop',
-        scenario: 'qa',
-        previewType: 'html',
-        designSystemRequired: true,
-        defaultFor: [],
-        upstream: null,
-        featured: null,
-        fidelity: null,
-        speakerNotes: null,
-        animations: null,
-        hasBody: true,
-        examplePrompt: '',
-        source: 'builtin',
-        category: 'Marketing',
-      },
-    ];
-
-    await routeBootstrapApis(page, systems, { skills });
-
-    const dialog = await openDesignSystemsSettings(page);
-    await dialog.getByRole('button', { name: /Skills|技能/i }).click();
-    await expect(dialog.getByTestId('skill-row-disabled-entry-skill')).toBeVisible();
-    await dialog
-      .getByTestId('skill-row-disabled-entry-skill')
-      .getByRole('checkbox', { name: /Toggle|切换|切換/i })
-      .evaluate((node: HTMLInputElement) => node.click());
-    await expect(dialog.getByText('All changes saved')).toBeVisible();
-
-    await dialog.getByRole('button', { name: /Design systems|设计系统|設計系統/i }).click();
-    await expect(dialog.locator('.library-ds-card', { hasText: 'Airbnb' })).toBeVisible();
-    await dialog
-      .locator('.library-ds-card', { hasText: 'Airbnb' })
-      .getByRole('checkbox', { name: /Show in home gallery/i })
-      .evaluate((node: HTMLInputElement) => node.click());
-    await expect(dialog.getByText('All changes saved')).toBeVisible();
-    await dialog.getByRole('button', { name: 'Close', exact: true }).click();
-    await expect(dialog).toHaveCount(0);
-
-    const input = page.getByTestId('home-hero-input');
-    await input.click();
-    await input.fill('@entry');
-    const skillPicker = page.getByTestId('home-hero-plugin-picker');
-    await expect(skillPicker).toBeVisible();
-    await skillPicker.getByRole('tab', { name: /Skills/i }).click();
-    await expect(skillPicker.getByRole('option', { name: /Enabled Entry Skill/i })).toBeVisible();
-    await expect(skillPicker.getByRole('option', { name: /Disabled Entry Skill/i })).toHaveCount(0);
-    await page.keyboard.press('Escape');
-
-    await page.getByTestId('home-hero-design-system-trigger').click();
-    const homePicker = page.getByTestId('project-ds-picker-popover');
-    await expect(homePicker.getByTestId('project-ds-picker-option-agentic')).toBeVisible();
-    await expect(homePicker.getByTestId('project-ds-picker-option-airbnb')).toHaveCount(0);
-  });
-
   test('[P1] imports a local design system and makes it visible immediately', async ({ page }) => {
     await seedSettingsBase(page);
     const systems: DesignSystemFixture[] = [];

--- a/e2e/ui/settings-memory-routines.test.ts
+++ b/e2e/ui/settings-memory-routines.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@/playwright/suite';
 import { ensureRailOpen } from '@/playwright/rail';
 import { routeAgents } from '@/playwright/mock-factory';
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 import { openSettingsDialog } from '../lib/playwright/amr.js';
 
 const STORAGE_KEY = 'open-design:config';
@@ -105,10 +105,26 @@ async function openSettings(page: Page) {
 }
 
 async function openMemorySettings(page: Page) {
-  const dialog = await openSettings(page);
-  await dialog.getByRole('button', { name: /^Memory\b/ }).click();
+  const openedDialog = await openSettings(page);
+  await openedDialog.getByRole('button', { name: /^Memory\b/ }).click();
+  const dialog = page.locator('.modal-settings');
   await expect(dialog.getByRole('button', { name: 'Add or import memories' })).toBeVisible();
   await expect(dialog.getByText('Saved memory')).toBeVisible();
+  return dialog;
+}
+
+async function openMemoryAddDialog(
+  page: Page,
+  tab: 'Work profile' | 'Add manually' | 'Import from apps' = 'Work profile',
+  settingsDialog?: Locator,
+) {
+  const settings = settingsDialog ?? await openMemorySettings(page);
+  await settings.getByRole('button', { name: 'Add or import memories' }).click();
+  const dialog = page.getByRole('dialog', { name: 'Add or import memories' });
+  await expect(dialog).toBeVisible();
+  if (tab !== 'Work profile') {
+    await dialog.getByRole('tab', { name: tab }).click();
+  }
   return dialog;
 }
 
@@ -251,10 +267,12 @@ test.describe('Settings Memory and Automations flows', () => {
     });
 
     const dialog = await openMemorySettings(page);
+    const addDialog = await openMemoryAddDialog(page, 'Work profile', dialog);
 
-    await expect(dialog.getByRole('tab', { name: /Add manually/i })).toHaveAttribute('aria-selected', 'true');
-    await expect(dialog.getByRole('tab', { name: /Learn from chats/i })).toBeVisible();
-    await expect(dialog.getByRole('tab', { name: /Import from apps/i })).toBeVisible();
+    await expect(addDialog.getByRole('tab', { name: 'Work profile' })).toHaveAttribute('aria-selected', 'true');
+    await expect(addDialog.getByRole('tab', { name: 'Add manually' })).toBeVisible();
+    await expect(addDialog.getByRole('tab', { name: 'Import from apps' })).toBeVisible();
+    await addDialog.getByRole('button', { name: 'Close', exact: true }).click();
 
     await expect(dialog.getByText('Saved memory')).toBeVisible();
     await expect(dialog.getByText('2 saved')).toBeVisible();
@@ -265,8 +283,10 @@ test.describe('Settings Memory and Automations flows', () => {
     await expect(dialog.getByRole('button', { name: 'Clear' })).toBeVisible();
     await expect(dialog.getByRole('button', { name: 'Refresh' })).toBeVisible();
 
-    const memoryTree = dialog.locator('.memory-collapsible-card');
-    await expect(memoryTree.getByText('Memory tree')).toBeVisible();
+    await dialog.getByRole('button', { name: 'Advanced' }).click();
+    const advancedDialog = page.getByRole('dialog', { name: 'Advanced' });
+    await advancedDialog.getByText('Memory tree').click();
+    const memoryTree = advancedDialog.locator('.memory-tree-advanced');
     await expect(memoryTree.getByText('Feedback', { exact: true })).toBeVisible();
     await expect(memoryTree.getByText('/FEEDBACK', { exact: true })).toBeVisible();
     await expect(memoryTree.getByText('Project', { exact: true })).toBeVisible();
@@ -424,11 +444,13 @@ test.describe('Settings Memory and Automations flows', () => {
 
     const card = dialog.locator('.library-card', { hasText: 'UI preferences' }).first();
     await card.getByTitle('Edit').click();
-    const editor = dialog.locator('.memory-manual-panel');
+    const editDialog = page.getByRole('dialog', { name: 'Add or import memories' });
+    await expect(editDialog).toBeVisible();
+    const editor = editDialog.locator('.memory-manual-panel');
     await editor.locator('input').nth(0).fill('Updated UI preferences');
     await editor.locator('input').nth(1).fill('Updated rendering preferences');
     await editor.locator('textarea').fill('- Prefer compact, high-contrast controls');
-    await dialog.getByRole('button', { name: 'Save', exact: true }).click();
+    await editDialog.getByRole('button', { name: 'Save', exact: true }).click();
 
     await expect(dialog.getByText('Updated UI preferences')).toBeVisible();
     await expect(dialog.getByText('UI preferences', { exact: true })).toHaveCount(0);
@@ -521,8 +543,8 @@ test.describe('Settings Memory and Automations flows', () => {
       });
     });
 
-    const dialog = await openMemorySettings(page);
-
+    const settingsDialog = await openMemorySettings(page);
+    const dialog = await openMemoryAddDialog(page, 'Add manually', settingsDialog);
     await dialog.getByRole('button', { name: 'New memory' }).click();
     await dialog.getByPlaceholder('e.g. UI preferences').fill('UI preferences');
     await dialog.getByPlaceholder('One sentence — what is this memory about?').fill(
@@ -533,10 +555,10 @@ test.describe('Settings Memory and Automations flows', () => {
       .fill('- Prefer dark mode');
     await dialog.getByRole('button', { name: 'Create' }).click();
 
-    await expect(dialog.getByText('UI preferences')).toBeVisible();
-    await expect(dialog.locator('.memory-flash-pill')).toContainText('Memory created');
+    await expect(dialog).toBeHidden();
+    await expect(settingsDialog.locator('.library-card', { hasText: 'UI preferences' })).toBeVisible();
 
-    await dialog.getByRole('button', { name: 'Close', exact: true }).click();
+    await settingsDialog.getByRole('button', { name: 'Close', exact: true }).click();
     await expect(page.getByRole('dialog')).toHaveCount(0);
 
     const reopened = await openMemorySettings(page);
@@ -661,21 +683,20 @@ test.describe('Settings Memory and Automations flows', () => {
 
     const dialog = await openMemorySettings(page);
 
-    await dialog.getByRole('tab', { name: /Learn from chats/i }).click();
+    await dialog.getByRole('tab', { name: 'How it works' }).click();
     const toggle = dialog.getByRole('checkbox', {
-      name: 'Learn from chat conversations',
+      name: 'Learn from chats',
     });
 
     await expect(toggle).toBeChecked();
-    await dialog.locator('.memory-chat-learning-toggle').click();
+    await dialog.getByTitle('Learn from chats').click();
     await expect(toggle).not.toBeChecked();
-    await expect(dialog.getByText('Off')).toBeVisible();
 
     await dialog.getByRole('button', { name: 'Close', exact: true }).click();
     const reopened = await openMemorySettings(page);
-    await reopened.getByRole('tab', { name: /Learn from chats/i }).click();
+    await reopened.getByRole('tab', { name: 'How it works' }).click();
     await expect(
-      reopened.getByRole('checkbox', { name: 'Learn from chat conversations' }),
+      reopened.getByRole('checkbox', { name: 'Learn from chats' }),
     ).not.toBeChecked();
   });
 
@@ -762,9 +783,9 @@ test.describe('Settings Memory and Automations flows', () => {
     });
 
     const dialog = await openMemorySettings(page);
-    await dialog.getByRole('tab', { name: /Import from apps/i }).click();
-    await expect(dialog.getByRole('heading', { name: 'Import from apps' })).toBeVisible();
-    await dialog.getByRole('button', { name: 'Manage' }).click();
+    const addDialog = await openMemoryAddDialog(page, 'Import from apps', dialog);
+    await expect(addDialog.getByRole('heading', { name: 'Import from apps' })).toBeVisible();
+    await addDialog.getByRole('button', { name: 'Manage' }).click();
 
     await expect(dialog.getByRole('button', { name: /^Connectors$/i })).toHaveClass(/active/);
     await expect(dialog.getByText('Composio API Key', { exact: true })).toBeVisible();
@@ -900,8 +921,7 @@ test.describe('Settings Memory and Automations flows', () => {
       });
     });
 
-    const dialog = await openMemorySettings(page);
-    await dialog.getByRole('tab', { name: /Import from apps/i }).click();
+    const dialog = await openMemoryAddDialog(page, 'Import from apps');
 
     await expect(dialog.getByText('Choose sources')).toBeVisible();
     await expect(dialog.getByText('Product wiki')).toBeVisible();
@@ -1042,8 +1062,8 @@ test.describe('Settings Memory and Automations flows', () => {
       });
     });
 
-    let dialog = await openMemorySettings(page);
-    await dialog.getByRole('tab', { name: /Import from apps/i }).click();
+    let settingsDialog = await openMemorySettings(page);
+    let dialog = await openMemoryAddDialog(page, 'Import from apps', settingsDialog);
     const githubRow = dialog.locator('[data-memory-connector-id="github"]');
     await githubRow.getByRole('button', { name: 'Connect GitHub' }).click();
 
@@ -1051,8 +1071,9 @@ test.describe('Settings Memory and Automations flows', () => {
     await expect(githubRow.getByRole('button', { name: 'Connect GitHub' })).toBeDisabled();
 
     await dialog.getByRole('button', { name: 'Close', exact: true }).click();
-    dialog = await openMemorySettings(page);
-    await dialog.getByRole('tab', { name: /Import from apps/i }).click();
+    await settingsDialog.getByRole('button', { name: 'Close', exact: true }).click();
+    settingsDialog = await openMemorySettings(page);
+    dialog = await openMemoryAddDialog(page, 'Import from apps', settingsDialog);
 
     const reopenedGithubRow = dialog.locator('[data-memory-connector-id="github"]');
     await expect(reopenedGithubRow.getByText('Finish authorization in your browser, then return here')).toBeVisible();
@@ -1130,16 +1151,14 @@ test.describe('Settings Memory and Automations flows', () => {
       });
     });
 
-    let statusReads = 0;
+    let githubConnected = false;
     await page.route('**/api/connectors/status', async (route) => {
-      statusReads += 1;
-      const connected = statusReads >= 3;
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
         body: JSON.stringify({
           statuses: {
-            github: connected
+            github: githubConnected
               ? {
                   status: 'connected',
                   accountLabel: 'Engineering docs',
@@ -1222,8 +1241,7 @@ test.describe('Settings Memory and Automations flows', () => {
       });
     });
 
-    const dialog = await openMemorySettings(page);
-    await dialog.getByRole('tab', { name: /Import from apps/i }).click();
+    const dialog = await openMemoryAddDialog(page, 'Import from apps');
 
     const githubRow = dialog.locator('[data-memory-connector-id="github"]');
     await githubRow.getByRole('button', { name: 'Connect GitHub' }).click();
@@ -1231,6 +1249,7 @@ test.describe('Settings Memory and Automations flows', () => {
     await expect(githubRow.getByText('Finish authorization in your browser, then return here')).toBeVisible();
     await expect(githubRow.getByRole('button', { name: 'Connect GitHub' })).toBeDisabled();
 
+    githubConnected = true;
     await page.evaluate(() => {
       window.dispatchEvent(new MessageEvent('message', {
         data: { type: 'open-design:connector-connected' },
@@ -1347,10 +1366,8 @@ test.describe('Settings Memory and Automations flows', () => {
       });
     });
 
-    let statusReads = 0;
+    let githubConnected = false;
     await page.route('**/api/connectors/status', async (route) => {
-      statusReads += 1;
-      const githubConnected = statusReads >= 3;
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -1453,8 +1470,7 @@ test.describe('Settings Memory and Automations flows', () => {
       });
     });
 
-    const dialog = await openMemorySettings(page);
-    await dialog.getByRole('tab', { name: /Import from apps/i }).click();
+    const dialog = await openMemoryAddDialog(page, 'Import from apps');
 
     const notionRow = dialog.locator('[data-memory-connector-id="notion"]');
     const githubRow = dialog.locator('[data-memory-connector-id="github"]');
@@ -1475,6 +1491,7 @@ test.describe('Settings Memory and Automations flows', () => {
     await expect(dialog.locator('.memory-connector-picker-head .memory-source-badge')).toHaveText('1 selected');
     await expect(dialog.getByText('Selected 1 of 1 connected app.')).toBeVisible();
 
+    githubConnected = true;
     await page.evaluate(() => {
       window.dispatchEvent(new MessageEvent('message', {
         data: { type: 'open-design:connector-connected' },
@@ -1656,8 +1673,7 @@ test.describe('Settings Memory and Automations flows', () => {
       });
     });
 
-    const dialog = await openMemorySettings(page);
-    await dialog.getByRole('tab', { name: /Import from apps/i }).click();
+    const dialog = await openMemoryAddDialog(page, 'Import from apps');
 
     const notionRow = dialog.locator('[data-memory-connector-id="notion"]');
     const githubRow = dialog.locator('[data-memory-connector-id="github"]');
@@ -1859,8 +1875,8 @@ test.describe('Settings Memory and Automations flows', () => {
       });
     });
 
-    const dialog = await openMemorySettings(page);
-    await dialog.getByRole('tab', { name: /Import from apps/i }).click();
+    const settingsDialog = await openMemorySettings(page);
+    const dialog = await openMemoryAddDialog(page, 'Import from apps', settingsDialog);
     await dialog.locator('[data-memory-connector-id="notion"]').click();
     await dialog.getByRole('button', { name: /scan/i }).click();
 
@@ -1868,9 +1884,9 @@ test.describe('Settings Memory and Automations flows', () => {
     await dialog.getByRole('button', { name: /Save selected/i }).click();
 
     await expect(dialog.getByText(/Saved 1 memory from connected apps/)).toBeVisible();
-    await expect(dialog.getByText('Memory context')).toBeVisible();
-    await expect(dialog.getByText('Connector-derived context')).toBeVisible();
-    await expect(dialog.getByText('1 saved')).toBeVisible();
+    await expect(settingsDialog.getByText('Memory context')).toBeVisible();
+    await expect(settingsDialog.getByText('Connector-derived context')).toBeVisible();
+    await expect(settingsDialog.getByText('1 saved')).toBeVisible();
   });
 
   test('[P1] shows connected app scan diagnostics when reading selected apps fails', async ({ page }) => {
@@ -1969,8 +1985,7 @@ test.describe('Settings Memory and Automations flows', () => {
       });
     });
 
-    const dialog = await openMemorySettings(page);
-    await dialog.getByRole('tab', { name: /Import from apps/i }).click();
+    const dialog = await openMemoryAddDialog(page, 'Import from apps');
     await dialog.locator('[data-memory-connector-id="notion"]').click();
     await dialog.getByRole('button', { name: /scan/i }).click();
 
@@ -2120,7 +2135,8 @@ test.describe('Settings Memory and Automations flows', () => {
       });
     });
 
-    const dialog = await openMemorySettings(page);
+    const settingsDialog = await openMemorySettings(page);
+    const dialog = await openMemoryAddDialog(page, 'Add manually', settingsDialog);
 
     await dialog.getByRole('button', { name: 'New memory' }).click();
     await dialog.getByPlaceholder('e.g. UI preferences').fill('UI preferences');
@@ -2134,7 +2150,7 @@ test.describe('Settings Memory and Automations flows', () => {
 
     await expect(dialog.getByPlaceholder('e.g. UI preferences')).toHaveValue('UI preferences');
     await expect(dialog.locator('.memory-flash-pill')).toHaveCount(0);
-    await expect(dialog.getByText('No memory yet.')).toBeVisible();
+    await expect(settingsDialog.getByText('No memory yet.')).toBeVisible();
   });
 
   test('[P1] creates an automation from the main Automations surface and runs it now', async ({ page }) => {
@@ -2231,7 +2247,7 @@ test.describe('Settings Memory and Automations flows', () => {
 
     await view.getByRole('button', { name: 'New automation' }).click();
     const modal = page.getByTestId('automation-modal');
-    await modal.getByLabel('Automation title').fill('Weekly digest');
+    await modal.getByTestId('automation-modal-title').fill('Weekly digest');
     await modal.getByTestId('automation-modal-prompt').fill('Summarize GitHub and design activity.');
     await modal.getByRole('button', { name: 'Create' }).click();
 
@@ -2301,11 +2317,11 @@ test.describe('Settings Memory and Automations flows', () => {
 
     await view.getByRole('button', { name: 'New automation' }).click();
     const modal = page.getByTestId('automation-modal');
-    await modal.getByLabel('Automation title').fill('Weekly digest');
+    await modal.getByTestId('automation-modal-title').fill('Weekly digest');
     await modal.getByTestId('automation-modal-prompt').fill('Summarize GitHub and design activity.');
     await modal.getByRole('button', { name: 'Create' }).click();
 
-    await expect(modal.getByLabel('Automation title')).toHaveValue('Weekly digest');
+    await expect(modal.getByTestId('automation-modal-title')).toHaveValue('Weekly digest');
     await expect(modal.getByTestId('automation-modal-prompt')).toHaveValue('Summarize GitHub and design activity.');
     await expect(modal.getByText('provider unavailable')).toBeVisible();
     await expect(view.getByText('No automations yet')).toBeVisible();

--- a/e2e/ui/workspace-keyboard-flows.test.ts
+++ b/e2e/ui/workspace-keyboard-flows.test.ts
@@ -88,7 +88,9 @@ test('[P1] quick switcher arrow keys move selection before opening a file', asyn
   const quickSwitcherInput = page.locator('.qs-input');
   const selectedOption = page.getByRole('option', { selected: true });
   await expect(quickSwitcher).toBeVisible();
-  await expect(page.getByRole('option')).toHaveCount(3);
+  await quickSwitcherInput.fill('arrow-');
+  await expect(quickSwitcherOptionsByKind(page, 'FILE')).toHaveCount(3);
+  await expect(quickSwitcherOptionsByKind(page, 'IMAGE')).toHaveCount(3);
 
   const initialSelection = await selectedOption.textContent();
   await quickSwitcherInput.press('ArrowDown');
@@ -282,7 +284,8 @@ test('[P1] quick switcher still activates another file after the project reloads
   await expect(quickSwitcher).toBeVisible();
 
   await quickSwitcherInput.fill('reload-beta');
-  await expect(page.getByRole('option', { name: /reload-beta\.png/i })).toBeVisible();
+  await expect(quickSwitcherOption(page, 'reload-beta.png', 'IMAGE')).toBeVisible();
+  await expect(page.getByRole('option', { selected: true })).toContainText('reload-beta.png');
   await quickSwitcherInput.press('Enter');
 
   await expect(quickSwitcher).toBeHidden();
@@ -315,10 +318,10 @@ test('[P1] quick switcher only lists files from the active project after switchi
   await expect(quickSwitcher).toBeVisible();
 
   await quickSwitcherInput.fill('project');
-  await expect(page.getByRole('option', { name: /beta-project-file\.png/i })).toBeVisible();
-  await expect(page.getByRole('option', { name: /beta-project-secondary\.png/i })).toBeVisible();
-  await expect(page.getByRole('option', { name: /alpha-project-file\.png/i })).toHaveCount(0);
-  await expect(page.getByRole('option', { name: /alpha-project-secondary\.png/i })).toHaveCount(0);
+  await expect(quickSwitcherOption(page, 'beta-project-file.png', 'IMAGE')).toBeVisible();
+  await expect(quickSwitcherOption(page, 'beta-project-secondary.png', 'IMAGE')).toBeVisible();
+  await expect(quickSwitcherOption(page, 'alpha-project-file.png', 'IMAGE')).toHaveCount(0);
+  await expect(quickSwitcherOption(page, 'alpha-project-secondary.png', 'IMAGE')).toHaveCount(0);
   await expectProjectFilesToIncludeSuffixes(page, betaProjectId, ['beta-project-file.png', 'beta-project-secondary.png']);
   await expectProjectFilesToIncludeSuffixes(page, alphaProjectId, ['alpha-project-file.png', 'alpha-project-secondary.png']);
 
@@ -351,7 +354,7 @@ test('[P1] quick switcher leaves the Design Files panel and opens the selected f
   await expect(quickSwitcher).toBeVisible();
 
   await quickSwitcherInput.fill('design-files-alpha');
-  await expect(page.getByRole('option', { name: /design-files-alpha\.png/i })).toBeVisible();
+  await expect(quickSwitcherOption(page, 'design-files-alpha.png', 'FILE')).toBeVisible();
   await quickSwitcherInput.press('Enter');
 
   await expect(quickSwitcher).toBeHidden();
@@ -416,7 +419,7 @@ test('[P1] quick switcher can switch from a design file tab back to a generated 
   await expect(quickSwitcher).toBeVisible();
 
   await quickSwitcherInput.fill('quick-switcher-artifact');
-  await expect(page.getByRole('option', { name: /quick-switcher-artifact\.html/i })).toBeVisible();
+  await expect(quickSwitcherOption(page, 'quick-switcher-artifact.html', 'FILE')).toBeVisible();
   await quickSwitcherInput.press('Enter');
 
   await expect(quickSwitcher).toBeHidden();
@@ -462,7 +465,7 @@ async function openNewProjectModal(page: Page) {
 }
 
 async function expectProjectsView(page: Page) {
-  if ((await page.locator('.tab-panel-toolbar').count()) === 0) {
+  if (!(await page.locator('.tab-panel-toolbar').isVisible().catch(() => false))) {
     await ensureRailOpen(page);
     await page.getByTestId('entry-nav-projects').click();
   }
@@ -573,6 +576,28 @@ function selectedBaseName(selectionText: string | null): string {
   const match = normalized.match(/arrow-(alpha|beta|gamma)\.png/i);
   expect(match?.[0]).toBeTruthy();
   return match![0];
+}
+
+function quickSwitcherOption(page: Page, name: string, kind: string): Locator {
+  return page.locator('.qs-row')
+    .filter({
+      has: page.locator('.qs-name').filter({
+        hasText: new RegExp(`^${escapeRegExp(name)}$`, 'i'),
+      }),
+    })
+    .filter({
+      has: page.locator('.qs-kind').filter({
+        hasText: new RegExp(`^${escapeRegExp(kind)}$`, 'i'),
+      }),
+    });
+}
+
+function quickSwitcherOptionsByKind(page: Page, kind: string): Locator {
+  return page.locator('.qs-row').filter({
+    has: page.locator('.qs-kind').filter({
+      hasText: new RegExp(`^${escapeRegExp(kind)}$`, 'i'),
+    }),
+  });
 }
 
 function escapeRegExp(value: string): string {

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -1281,7 +1281,7 @@ async function checkCiTopology(): Promise<boolean> {
       "include: ${{ fromJSON(needs.scopes.outputs.ui_p0_matrix) }}",
       "include: ${{ fromJSON(needs.scopes.outputs.visual_matrix) }}",
       "needs.scopes.outputs.run_ui_p0 == 'true'",
-      "pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group merge-sentinel",
+      "pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group critical-extras",
       "pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group ${{ matrix.shard }}",
     ]
       .filter((needle) => !ciWorkflow.includes(needle))

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -1281,7 +1281,7 @@ async function checkCiTopology(): Promise<boolean> {
       "include: ${{ fromJSON(needs.scopes.outputs.ui_p0_matrix) }}",
       "include: ${{ fromJSON(needs.scopes.outputs.visual_matrix) }}",
       "needs.scopes.outputs.run_ui_p0 == 'true'",
-      "pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group smoke",
+      "pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group merge-sentinel",
       "pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group ${{ matrix.shard }}",
     ]
       .filter((needle) => !ciWorkflow.includes(needle))

--- a/scripts/scopes.ts
+++ b/scripts/scopes.ts
@@ -119,14 +119,15 @@ function createRunPlan(
   ciMode: CiMode,
 ): Omit<ScopePlan, keyof ScopeOutputs | "ui_p0_matrix" | "visual_matrix"> {
   const isFull = ciMode === "full";
+  const runUiP0 = isFull || outputs.ui_p0_validation_required;
 
   return {
     ci_mode: ciMode,
     run_e2e_vitest: isFull || outputs.web_tests_required || outputs.ui_p0_validation_required,
-    run_playwright_critical: isFull || (outputs.workspace_validation_required && !outputs.ui_p0_validation_required),
+    run_playwright_critical: outputs.workspace_validation_required && !runUiP0,
     run_playwright_visual: isFull || outputs.visual_validation_required,
     run_preflight: true,
-    run_ui_p0: isFull || outputs.ui_p0_validation_required,
+    run_ui_p0: runUiP0,
     run_web_workspace_tests: isFull || outputs.web_tests_required,
     run_windows_tools_pack_payload_tests: isFull || outputs.tools_pack_tests_required,
     run_workspace_unit_tests: true,

--- a/scripts/scopes.ts
+++ b/scripts/scopes.ts
@@ -10,6 +10,7 @@ type ScopeOutputs = {
   web_tests_required: boolean;
   tools_dev_tests_required: boolean;
   tools_pack_tests_required: boolean;
+  ui_critical_validation_required: boolean;
   ui_p0_validation_required: boolean;
   visual_validation_required: boolean;
   workspace_validation_required: boolean;
@@ -58,6 +59,7 @@ function createScopePlan(): ScopePlan {
     web_tests_required: false,
     tools_dev_tests_required: false,
     tools_pack_tests_required: false,
+    ui_critical_validation_required: false,
     ui_p0_validation_required: false,
     visual_validation_required: false,
     workspace_validation_required: false,
@@ -90,6 +92,7 @@ function createScopePlan(): ScopePlan {
     outputs.web_tests_required = true;
     outputs.tools_dev_tests_required = true;
     outputs.tools_pack_tests_required = true;
+    outputs.ui_critical_validation_required = true;
     outputs.ui_p0_validation_required = true;
     outputs.visual_validation_required = true;
     outputs.workspace_validation_required = true;
@@ -124,7 +127,7 @@ function createRunPlan(
   return {
     ci_mode: ciMode,
     run_e2e_vitest: isFull || outputs.web_tests_required || outputs.ui_p0_validation_required,
-    run_playwright_critical: outputs.workspace_validation_required && !runUiP0,
+    run_playwright_critical: outputs.ui_critical_validation_required && !runUiP0,
     run_playwright_visual: isFull || outputs.visual_validation_required,
     run_preflight: true,
     run_ui_p0: runUiP0,
@@ -242,6 +245,15 @@ function applyChangedFile(file: string, target: ScopeOutputs): void {
 
   if (!isWorkspaceValidationExemptFile(file)) {
     target.workspace_validation_required = true;
+    // Fail-closed critical gate: Playwright starts `tools-dev web` (daemon +
+    // web runtimes) and never launches the desktop, packaged, or tools-pack
+    // entrypoints, so a change confined to those leaf roots cannot alter what
+    // the critical suite exercises. Every other non-exempt file — tools-dev,
+    // any transitive package (including undeclared edges like metatool),
+    // scripts, runtime resources, unknown roots — keeps the fallback armed.
+    if (!startsWithAny(file, ["apps/desktop/", "apps/packaged/", "tools/pack/"])) {
+      target.ui_critical_validation_required = true;
+    }
   }
 }
 


### PR DESCRIPTION
## Why

The full UI functional suite (P0/P1/P2, 429 non-visual cases) had no working home. The legacy single-job lane hit the 120-minute ceiling with cascading timeout degradation and usually produced no signal; P1/P2 were nominally covered by a nightly lane that had quietly rotted. I picked this up as CI-duty: the merge queue verified only ~149 mapped P0 cases, and reviving the rest was the only way to know whether P1/P2 even passed. It turned out they didn't — reviving the pool surfaced three real product regressions and a large stale-contract backlog that had been hidden by the dead nightly.

## What users will see

No new surfaces. Three user-visible regressions are fixed:

- **New Project design-system picker** no longer gets clipped by a short viewport or the modal body — its popover was rendered inline and lost its portal; it now portals to the body with a viewport-aware anchor.
- **Working-directory label** in the project composer now updates when you pick a folder — a metadata-callback recency bug let a stale project snapshot shadow the accepted change.
- **Home plugin input edits** you type while a plugin applies are no longer reverted to defaults on submit.

Everything else is CI/test/docs.

## Surface area

- [x] **UI** — bug fixes to existing `apps/web` flows (design-system picker, composer working-dir, home plugin inputs). No new surface; changes are behavior fixes described above.
- [x] **CLI / env var** — `.github/actions/configure-ci-parallelism` now drives the full-pool worker count (`nproc/2`); no `od`/`OD_*` surface for end users.
- [x] **None-adjacent** — the bulk is CI topology (`.github/workflows/ui-extended-main.yml`, `scripts/scopes.ts`), e2e test repairs/stability, and an `e2e/AGENTS.md` rules section.

(Screenshots omitted: the three UI fixes are subtle rendering/state corrections; each is pinned by a red e2e spec listed below, and described under "What users will see".)

## Bug fix verification

Each product fix is anchored by an e2e spec that was red on `main` and green here:

- DS-picker portal — `e2e/ui/new-project-ds-picker-clipping.test.ts`
- Working-dir metadata recency — `e2e/ui/app-restoration.test.ts` ("working directory replace and clear update linked dirs metadata")
- Plugin-input reconcile — `e2e/ui/entry-chrome-flows.test.ts` ("home plugin input edits are resolved and carried into project creation")

## What this changes in CI

- **Full pool topology.** `ui-extended-main` `suite=full` is now a generic 12-shard matrix (`nproc/2` workers on the `ui_hot` blacksmith-4vcpu runner, fully-parallel test-granularity sharding, no serial groups). All 429 non-visual functional cases run green with a UI wall of ~3-6 minutes per job (~4-minute median), versus the legacy lane's 120-minute timeout ceiling. The rotted nightly lane is removed.
- **Worker count** is settled at `nproc/2` (two on this runner); a 1-worker/3-worker probe pair proved 2 is the validated optimum (3 workers oversubscribe the isolated tools-dev runtimes and fail cold-start).
- **Merge-path savings.** A fail-closed `ui_critical_validation_required` scope skips the two-job `@critical` fallback (~8.6 runner-min + 5.4-13.4 min wall each) for PRs confined to `apps/desktop`/`apps/packaged`/`tools/pack`, which Playwright never exercises — every other change keeps it.
- **Rules doc.** `e2e/AGENTS.md` gains a "UI test stability rules" section distilling the invariants a UI test must hold under the sharded pool (order independence, retry-only-pass as a signal, streamed-readiness gates, hermetic agent availability, oracle/lane verification). It was hardened through a two-model adversarial review to converge on factual accuracy.

## Validation

- `pnpm guard` (86/0), `pnpm typecheck` (0 errors), `pnpm --filter @open-design/web test` (all green).
- `e2e/tests/packaged-smoke-workflow.test.ts` topology guard (50/50).
- Full-pool green in Actions across the landed topology and two rebases (runs 29508138920, 29553827025, 29713431322, and the post-rebase revalidation).
- Targeted Playwright re-runs for every repaired file after each rebase.

## Adjacent issues (follow-ups, not in this PR)

- BYOK-OpenCode missing-provider handling changed under us: main #5745 landed a client-side preflight that blocks such runs before spawn and opens the execution Settings section; this PR realigns the spec to it. The remaining streamed-readiness follow-up is the CI-only shortcuts-trigger hang below.
- A CI-only home shortcuts-trigger pending-apply hang (same streamed-readiness class).
