### PR TITLE
Fix image move UX and selection frame drift on resize

### DIFF
--- a/apps/web/src/components/ManualEditSelectionOverlay.module.css
+++ b/apps/web/src/components/ManualEditSelectionOverlay.module.css
@@ -30,6 +30,21 @@
   box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.08);
 }
 
+/* Whole-image move surface. Fills the frame interior so an image can be
+   dragged from anywhere on the picture, not only the top pill. Sits under the
+   side/top handles (later in DOM) so their edge hit areas keep resizing. */
+.moveBody {
+  position: absolute;
+  inset: 0;
+  cursor: grab;
+  pointer-events: auto;
+  touch-action: none;
+}
+
+.moveBody:active {
+  cursor: grabbing;
+}
+
 /* Top-center pill: free move. */
 .moveHandle {
   position: absolute;

--- a/apps/web/src/components/ManualEditSelectionOverlay.tsx
+++ b/apps/web/src/components/ManualEditSelectionOverlay.tsx
@@ -30,22 +30,30 @@ interface DragState {
   guides: ManualEditAlignmentGuide[];
   moved: boolean;
   /**
-   * Vertical extent last measured in the iframe. A resize gesture owns x and
-   * width; height is whatever the content reflowed to, which the gesture
-   * cannot predict — widening a text box pulls its text onto fewer lines and
-   * makes it shorter.
+   * The element's REAL box as the iframe last measured it after a resize
+   * preview applied. The gesture rect (`rect`) is only the intent: the element
+   * it targets can re-center (a `margin:auto` / flex-centred image slides a
+   * fixed edge inward as it widens), cap at `max-width`, honor an intrinsic
+   * aspect ratio, or reflow inside its parent — so its rendered box drifts from
+   * the intent on BOTH axes, not just the reflowed height. The frame draws this
+   * measured box (see `displayRect`) so the selection chrome stays locked to
+   * the element instead of trailing beside it — the resize "错位" report. Null
+   * until the first measurement of a gesture, and always null for moves (they
+   * preview through a compositor-only transform and are never measured).
    */
-  measuredY: number | null;
-  measuredHeight: number | null;
+  measured: ManualEditRect | null;
 }
 
-/** The rect the frame draws and the commit records: gesture x/width, measured y/height. */
+/**
+ * The rect the frame draws and the commit records. During a resize the iframe
+ * reports the element's actual box after each preview; the frame follows THAT
+ * so it stays wrapped around the element even when the element re-centers or
+ * caps instead of honoring the raw gesture rect. Before the first measurement
+ * (and for the whole of a move, which is never measured) it falls back to the
+ * gesture rect.
+ */
 function displayRect(state: DragState): ManualEditRect {
-  return {
-    ...state.rect,
-    y: state.measuredY ?? state.rect.y,
-    height: state.measuredHeight ?? state.rect.height,
-  };
+  return state.measured ?? state.rect;
 }
 
 interface CropHandleState {
@@ -270,8 +278,7 @@ export function ManualEditSelectionOverlay({
       rect: startRect,
       guides: [],
       moved: false,
-      measuredY: null,
-      measuredHeight: null,
+      measured: null,
     };
     setDragKind(kind);
     onGestureActiveChange?.(true);
@@ -286,17 +293,18 @@ export function ManualEditSelectionOverlay({
       // listeners below still finish the gesture instead of leaving it stuck.
     }
 
-    // Widening a text box pulls its text onto fewer lines, so the box gets
-    // SHORTER while the gesture only tracks width. Without adopting the height
-    // the iframe measured, the frame stays frozen at the pre-drag height for
-    // the whole drag and only snaps once the commit round-trips — which reads
-    // as "the text never reflowed".
+    // Lock the frame onto the element's real box after each resize preview.
+    // Adopting the FULL measured rect — x and width included, not just the
+    // reflowed y/height — is what keeps the frame from drifting off an element
+    // that re-centers or caps as it resizes (a widened text box also gets
+    // SHORTER as its text pulls onto fewer lines; the height comes back the
+    // same way). The gesture still persists the intent (`state.rect`); only the
+    // chrome the user sees follows the measurement.
     const adoptMeasuredExtent = (measured: ManualEditRect | null) => {
       const state = dragRef.current;
       if (!state || !measured || state.kind === 'move') return;
-      if (state.measuredHeight === measured.height && state.measuredY === measured.y) return;
-      state.measuredY = measured.y;
-      state.measuredHeight = measured.height;
+      if (state.measured && rectsEqual(state.measured, measured)) return;
+      state.measured = measured;
       applyFrameGeometry(displayRect(state));
     };
 
@@ -570,6 +578,18 @@ export function ManualEditSelectionOverlay({
         data-testid="manual-edit-selection-frame"
         style={frame}
       >
+        {isImage ? (
+          // Whole-image move surface: dragging anywhere on the picture moves it,
+          // so moving no longer requires grabbing the top pill. Rendered before
+          // the handles so their edge hit areas paint on top and still resize.
+          // Scoped to images — text/link bodies stay click-to-edit.
+          <div
+            className={styles.moveBody}
+            data-testid="manual-edit-move-body"
+            title={t('manualEdit.moveElement')}
+            onPointerDown={startGesture('move')}
+          />
+        ) : null}
         <div
           className={styles.moveHandle}
           data-testid="manual-edit-move-handle"

--- a/apps/web/tests/components/ManualEditSelectionOverlay.test.tsx
+++ b/apps/web/tests/components/ManualEditSelectionOverlay.test.tsx
@@ -1,10 +1,10 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ManualEditSelectionOverlay } from '../../src/components/ManualEditSelectionOverlay';
-import { emptyManualEditStyles, type ManualEditTarget } from '../../src/edit-mode/types';
+import { emptyManualEditStyles, type ManualEditRect, type ManualEditTarget } from '../../src/edit-mode/types';
 
 const target: ManualEditTarget = {
   id: 'move-me',
@@ -26,6 +26,16 @@ const target: ManualEditTarget = {
   },
   isLayoutContainer: false,
   outerHtml: '<div data-od-id="move-me">Move me</div>',
+};
+
+const imageTarget: ManualEditTarget = {
+  ...target,
+  id: 'photo',
+  kind: 'image',
+  tagName: 'IMG',
+  label: 'Photo',
+  fields: { src: 'photo.png', alt: '' },
+  outerHtml: '<img data-od-id="photo" src="photo.png" alt="">',
 };
 
 let originalSetPointerCapture: typeof HTMLElement.prototype.setPointerCapture | undefined;
@@ -154,6 +164,86 @@ describe('ManualEditSelectionOverlay pointer capture fallbacks', () => {
       'move',
     );
     expect(onGestureCancel).not.toHaveBeenCalled();
+  });
+});
+
+describe('ManualEditSelectionOverlay whole-image move', () => {
+  function renderImageOverlay() {
+    const onGestureCommit = vi.fn();
+    render(
+      <ManualEditSelectionOverlay
+        target={imageTarget}
+        targets={[imageTarget]}
+        scale={1}
+        canvasSize={{ width: 1000, height: 800 }}
+        onGesturePreview={vi.fn()}
+        onGestureCommit={onGestureCommit}
+        onGestureCancel={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    return { onGestureCommit };
+  }
+
+  it('moves an image by dragging its body, not only the top pill', () => {
+    const { onGestureCommit } = renderImageOverlay();
+    const body = screen.getByTestId('manual-edit-move-body');
+
+    fireEvent.pointerDown(body, { clientX: 200, clientY: 140, pointerId: 4 });
+    fireEvent.pointerMove(document, { clientX: 260, clientY: 180, pointerId: 4 });
+    fireEvent.pointerUp(document, { clientX: 260, clientY: 180, pointerId: 4 });
+
+    expect(onGestureCommit).toHaveBeenCalledTimes(1);
+    expect(onGestureCommit).toHaveBeenCalledWith(
+      expect.objectContaining({ left: '160px', top: '140px' }),
+      expect.objectContaining({ x: 160, y: 140 }),
+      'move',
+    );
+  });
+
+  it('keeps the body-drag surface off non-image targets so text stays click-to-edit', () => {
+    renderOverlay();
+    expect(screen.queryByTestId('manual-edit-move-body')).toBeNull();
+  });
+});
+
+describe('ManualEditSelectionOverlay resize frame sync', () => {
+  it('locks the frame onto the element measured box, not the raw gesture rect', () => {
+    let applied: ((rect: ManualEditRect | null) => void) | undefined;
+    render(
+      <ManualEditSelectionOverlay
+        target={imageTarget}
+        targets={[imageTarget]}
+        scale={1}
+        canvasSize={{ width: 1000, height: 800 }}
+        onGesturePreview={(_partial, onApplied) => {
+          applied = onApplied;
+        }}
+        onGestureCommit={vi.fn()}
+        onGestureCancel={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    const handle = screen.getByTestId('manual-edit-resize-right');
+    const frame = screen.getByTestId('manual-edit-selection-frame');
+
+    // Right handle sits at the element's right edge (x + width = 300); drag it
+    // out by 60px. The gesture INTENT keeps the left edge at 100 and widens to
+    // 260, so before any measurement the frame follows that intent.
+    fireEvent.pointerDown(handle, { clientX: 300, clientY: 140, pointerId: 3 });
+    fireEvent.pointerMove(document, { clientX: 360, clientY: 140, pointerId: 3 });
+    expect(applied).toBeInstanceOf(Function);
+    expect(frame.style.left).toBe('100px');
+    expect(frame.style.width).toBe('260px');
+
+    // The element actually re-centred as it widened (a margin:auto image slides
+    // its left edge inward): its real box starts at x=70. The frame must adopt
+    // that measured box on BOTH axes, or it drifts off the picture (the 错位).
+    act(() => applied!({ x: 70, y: 100, width: 260, height: 80 }));
+    expect(frame.style.left).toBe('70px');
+    expect(frame.style.width).toBe('260px');
   });
 });
 

--- a/specs/current/manual-edit-direct-manipulation.zh-CN.md
+++ b/specs/current/manual-edit-direct-manipulation.zh-CN.md
@@ -157,3 +157,12 @@
 协议增量:`od-edit-text-selection` 增 `format {bold,italic,underline,strike} | null`;`od-edit-apply-dom` 增 `op: replace|insert-after|append-child|prepend-child|remove`(默认 replace,向后兼容)。
 
 新增测试:bridge「选区格式状态上报」「insert-after/append-child/prepend-child/remove 原地应用」「重标注跟随位移 + 新元素就地 stamp + 授权 id 不动 + replace 后仍 source-mappable」;source-patches「插入读回(授权锚/位置锚/__body__)」「删除还原描述符(前兄弟/父级 prepend/__body__/缺失)」;FileViewer「文本提交原地不换 srcdoc」「删除走 remove op」「粘贴图片原地插入 + 选中交接」「undo 原地 + Undo 版本 label」。
+
+### v2.5 修订(整图拖拽移动 + 选中框跟随实测盒,2026-07-20)
+
+用户实测(prototype/landing/deck 三种编辑模式)提两点:图片只能靠顶部锚点(pill)拖动,期望**整张图任意处点击拖拽即移动**;拉伸边框时**外层选中框与图片错位**(尤其居中/`max-width`/带比例的图,拉伸后框飘在图旁边),要求所有元素框在交互中与元素**始终一致**。
+
+1. **整图整体移动**。`ManualEditSelectionOverlay` 在选中框内新增一层填满内部的 `moveBody`(`inset:0`、`pointer-events:auto`、`cursor:grab`),`onPointerDown` 复用 `startGesture('move')`——与顶部 pill 完全同一条手势管线(transform 预览 + 松手落 left/top,可撤销、产版本)。仅对 `kind === 'image'` 渲染:文本/链接元素的正文保持「点击进入行内编辑」语义,不被拖拽劫持。`moveBody` 排在 DOM 中的手柄之前,左右/顶部手柄(靠后绘制)在重叠区仍吃到指针,拉伸不受影响。
+2. **选中框跟随元素实测盒(修错位)**。根因:resize 手势里选中框画的是**手势意图矩形**的 x/width,只吸收 iframe 回报的 y/height;而目标元素在拉伸时可能重新居中(`margin:auto`/flex 居中的图,变宽时固定边内滑)、`max-width` 截断、按内在比例缩放或在父容器里回流——真实渲染盒在**两个轴**上都偏离意图,框只在纵向被纠正,横向永久飘移。修复:`DragState.measuredY/measuredHeight` 合并为单个 `measured: ManualEditRect | null`,`adoptMeasuredExtent` 吸收**完整**实测盒(x/y/width/height),`displayRect = state.measured ?? state.rect`。手势仍以 `state.rect`(意图)落盘 `set-style`,只有用户所见的选中框跟随实测——首帧(尚无测量)与整个 move(纯合成器 transform,不测量)回退到意图矩形。提交时 `outcome = displayRect(state)` 也即实测盒,乐观写入 `target.rect` 与 `heldRect` 与刷新后的真实 rect 对齐,松手零闪跳。
+
+新增测试:`ManualEditSelectionOverlay`「整图 body 拖拽提交 move / 非图片无 body 面」「resize 吸收实测盒纠正横向错位」。


### PR DESCRIPTION
Fixes #

## Why

User feedback from prototype/landing/deck editing modes identified two UX issues:
1. Images could only be moved by dragging the top pill anchor, not by clicking anywhere on the image itself
2. The selection frame drifted away from images during resize, especially for centered or max-width constrained images

The root cause of the drift: during resize gestures, the frame was only adopting the measured y/height from the iframe, but elements can re-center (margin:auto, flex-centered), cap at max-width, scale by intrinsic aspect ratio, or reflow — causing the real rendered box to shift on BOTH axes, not just vertically. The frame only corrected the vertical axis, leaving horizontal drift.

## What users will see

**Whole-image move**: Images can now be dragged from anywhere on the picture to move them, not just from the top pill. The move gesture uses the same pipeline as before (compositor transform preview + left/top commit on release), so it's undoable and version-tracked.

**Selection frame stays locked to element**: During resize, the selection frame now follows the element's actual measured box on all axes (x, y, width, height), not just the gesture intent. This eliminates the "错位" (drift) where the frame would float beside a resizing image.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Implementation details

**Whole-image move surface**: Added a `moveBody` div that fills the selection frame interior (`inset: 0`) with `cursor: grab` and `pointer-events: auto`. It's rendered only for `kind === 'image'` to preserve click-to-edit semantics for text/link elements. The div is positioned before resize handles in the DOM so their edge hit areas paint on top and continue to work.

**Selection frame sync**: Replaced `DragState.measuredY` and `measuredHeight` with a single `measured: ManualEditRect | null` that captures the complete element box. The `adoptMeasuredExtent` callback now absorbs the full measured rect and updates the frame accordingly. The `displayRect` helper returns `state.measured ?? state.rect`, so the frame follows the real box when available, falling back to gesture intent before first measurement or for moves (which are never measured).

## Validation

- Added test: "moves an image by dragging its body, not only the top pill" — verifies whole-image move commits correctly
- Added test: "keeps the body-drag surface off non-image targets so text stays click-to-edit" — ensures text/link elements are unaffected
- Added test: "locks the frame onto the element measured box, not the raw gesture rect" — verifies frame adopts full measured rect and corrects horizontal drift
- Existing tests continue to pass

https://claude.ai/code/session_01VURoYki65XDX6EYo9KMQS5