### PR TITLE
fix(daemon): bound macOS watcher file descriptors

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -48,7 +48,7 @@
     "better-sqlite3": "12.10.0",
     "blake3-wasm": "2.1.5",
     "cheerio": "1.2.0",
-    "chokidar": "5.0.0",
+    "chokidar": "3.6.0",
     "express": "5.2.1",
     "jszip": "3.10.1",
     "kiwi-schema": "0.5.0",

--- a/apps/daemon/src/project-watchers.ts
+++ b/apps/daemon/src/project-watchers.ts
@@ -1,3 +1,4 @@
+import type { Stats } from 'node:fs';
 import path from 'node:path';
 import chokidar, { type FSWatcher } from 'chokidar';
 
@@ -21,8 +22,9 @@ const WATCHER_ONLY_IGNORE_NAMES = new Set(['.ds_store']);
 export type ProjectWatchKind = 'add' | 'change' | 'unlink';
 export interface ProjectWatchEvent { type: 'file-changed'; path: string; kind: ProjectWatchKind }
 export type ProjectWatchCallback = (evt: ProjectWatchEvent) => void;
+type ProjectWatchIgnored = (absPath: string, stats?: Stats) => boolean;
 export interface ProjectWatcherOptions {
-  ignored?: (absPath: string) => boolean;
+  ignored?: ProjectWatchIgnored;
   awaitWriteFinish?: false | { stabilityThreshold: number; pollInterval: number };
   metadata?: unknown;
   _watcherFactory?: WatcherFactory;
@@ -36,8 +38,12 @@ interface WatcherEntry {
 }
 type WatcherFactory = (dir: string, opts: Required<Pick<ProjectWatcherOptions, 'ignored' | 'awaitWriteFinish'>>) => WatcherEntry;
 
-export function makeIgnored(rootDir: string): (absPath: string) => boolean {
-  return (absPath: string): boolean => {
+export function makeIgnored(rootDir: string): ProjectWatchIgnored {
+  return (absPath: string, stats?: Stats): boolean => {
+    // chokidar 3's macOS FSEvents backend can traverse directory symlinks even
+    // with followSymlinks disabled. Reject them in the shared predicate too so
+    // a project watcher never observes files outside its selected root.
+    if (stats?.isSymbolicLink()) return true;
     const rel = path.relative(rootDir, absPath);
     if (!rel || rel === '' || rel.startsWith('..')) return false; // never ignore root itself
     return rel.split(/[\\/]/).some((seg) => {

--- a/apps/daemon/src/project-watchers.ts
+++ b/apps/daemon/src/project-watchers.ts
@@ -40,12 +40,12 @@ type WatcherFactory = (dir: string, opts: Required<Pick<ProjectWatcherOptions, '
 
 export function makeIgnored(rootDir: string): ProjectWatchIgnored {
   return (absPath: string, stats?: Stats): boolean => {
+    const rel = path.relative(rootDir, absPath);
+    if (!rel || rel === '' || rel.startsWith('..')) return false; // never ignore root itself
     // chokidar 3's macOS FSEvents backend can traverse directory symlinks even
     // with followSymlinks disabled. Reject them in the shared predicate too so
     // a project watcher never observes files outside its selected root.
     if (stats?.isSymbolicLink()) return true;
-    const rel = path.relative(rootDir, absPath);
-    if (!rel || rel === '' || rel.startsWith('..')) return false; // never ignore root itself
     return rel.split(/[\\/]/).some((seg) => {
       const normalized = seg.toLowerCase();
       return WATCHER_ONLY_IGNORE_NAMES.has(normalized) || isIgnoredProjectDirName(normalized);

--- a/apps/daemon/tests/project-watchers.test.ts
+++ b/apps/daemon/tests/project-watchers.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { EventEmitter } from 'node:events';
@@ -155,6 +155,38 @@ describe('project-watchers (refcounting)', () => {
 });
 
 describe('project-watchers (real chokidar)', () => {
+  it.skipIf(process.platform !== 'darwin')(
+    'keeps macOS file-descriptor usage bounded for projects with many files',
+    async () => {
+      const { root, projectId } = await makeProjectsRoot();
+      const projectRoot = path.join(root, projectId);
+      await Promise.all(
+        Array.from({ length: 160 }, async (_, index) => {
+          const sourceDir = path.join(projectRoot, `section-${index}`, 'src');
+          await mkdir(sourceDir, { recursive: true });
+          await writeFile(path.join(sourceDir, 'index.txt'), 'watched');
+        }),
+      );
+
+      // Chokidar 5 opens one descriptor per watched file on Darwin in this
+      // configuration (160 here), eventually leaving agent spawns to fail with
+      // EBADF. The FSEvents-backed watcher should stay well below that linear
+      // growth; leave some headroom for descriptors owned by the test runner.
+      const before = (await readdir('/dev/fd')).length;
+      const sub = subscribe(root, projectId, () => {}, FAST_WATCH_OPTIONS);
+      await sub.ready;
+
+      try {
+        const after = (await readdir('/dev/fd')).length;
+        expect(after - before).toBeLessThan(32);
+      } finally {
+        await sub.unsubscribe();
+        await rm(root, { recursive: true, force: true });
+      }
+    },
+    REAL_WATCHER_TEST_TIMEOUT_MS,
+  );
+
   it('ignores generated build trees case-insensitively before chokidar descends', async () => {
     const { root, projectId } = await makeProjectsRoot();
     const projectRoot = path.join(root, projectId);

--- a/apps/daemon/tests/project-watchers.test.ts
+++ b/apps/daemon/tests/project-watchers.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
+import { lstat, mkdir, mkdtemp, readdir, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { EventEmitter } from 'node:events';
@@ -199,6 +199,20 @@ describe('project-watchers (real chokidar)', () => {
     expect(ignored(path.join(projectRoot, 'src', 'App.swift'))).toBe(false);
 
     await rm(root, { recursive: true, force: true });
+  });
+
+  it('never ignores the watch root when it is a directory symlink', async () => {
+    const dataRoot = await mkdtemp(path.join(tmpdir(), 'od-symlink-root-'));
+    const targetRoot = path.join(dataRoot, 'target');
+    const symlinkRoot = path.join(dataRoot, 'root');
+    await mkdir(targetRoot);
+
+    try {
+      await symlink(targetRoot, symlinkRoot, 'dir');
+      expect(makeIgnored(symlinkRoot)(symlinkRoot, await lstat(symlinkRoot))).toBe(false);
+    } finally {
+      await rm(dataRoot, { recursive: true, force: true });
+    }
   });
 
   it('emits file-changed events on add / change / unlink', async () => {

--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -9,6 +9,6 @@
   # 1. Temporarily set the consuming `hash = lib.fakeHash;`
   # 2. Run the relevant nix build/flake check
   # 3. Copy the expected hash printed by Nix into the matching field below
-  daemonHash = "sha256-4lknuG1bS4INm+F6+u8JAQ9s27KgXRi4+y2Cke3rFGA=";
-  webHash = "sha256-v/nupkuzndC5tFCMVNuzF0MkL6XzMgBt7HHzQHbeCA0=";
+  daemonHash = "sha256-7/ePsm1S6V0ZZlS4vW2HQUCJojpyHfvFtC9YlMLHWm0=";
+  webHash = "sha256-2Ky0K8NBidDhE5hG5wQkUwVdo0gYSqaOf5FABhOTWOI=";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,8 +96,8 @@ importers:
         specifier: 1.2.0
         version: 1.2.0
       chokidar:
-        specifier: 5.0.0
-        version: 5.0.0
+        specifier: 3.6.0
+        version: 3.6.0
       express:
         specifier: 5.2.1
         version: 5.2.1


### PR DESCRIPTION
Refs #3408

## Why

While investigating the residual `spawn EBADF` failures in the 0.15.1 stable release, PostHog and Langfuse showed 17 packaged macOS arm64 failures across Codex and AMR. They all failed synchronously in `process_spawn`, before stdout, stderr, a first token, or any tool call. The dominant device also failed across multiple projects and agents without concurrent runs, which points to daemon-level file-descriptor pressure rather than an adapter-specific regression.

The project watcher provided a deterministic reproduction: with Chokidar 5 on Darwin, 160 ordinary project files added 160 open descriptors. Under reduced descriptor headroom, the next child process can synchronously throw `spawn EBADF`.

## What users will see

Opening projects with many files no longer consumes one file descriptor per watched file on macOS, so later agent launches remain available instead of intermittently failing with `spawn EBADF`. File live-reload behavior remains unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal daemon reliability fix and regression coverage only

## Screenshots

N/A — no UI changes.

## Bug fix verification

- Test path: `apps/daemon/tests/project-watchers.test.ts`
- Red on `main`: yes — the Darwin regression test measured a +160 FD delta and failed the bounded-resource assertion.
- Green on this branch: yes — the same test passes while the existing add/change/unlink, ignored-tree, production-layout, and symlink-isolation tests remain green.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/project-watchers.test.ts` — 12/12 passed
- `pnpm --filter @open-design/daemon typecheck` — passed
- Electron 41.3 / Node 24.15 packaged-runtime harness with `ulimit -n 64`: 160 watched files used 12 additional FDs and a three-stream detached child spawn exited 0
- `git diff --check` — passed
- `pnpm guard` — passed
- `pnpm typecheck` — passed
- Full daemon suite: 5,884 passed, 12 failed, 6 skipped, 4 todo. The 12 failures are unrelated existing environment/fixture drift in local proxy settings, Kimi/OpenCode mocks, prompt snapshots, and failure-telemetry fixtures; the watcher suite is green.
