### PR TITLE
Manual edit: action-bar edge avoidance, click-to-select (no reflow), non-text paste shortcut

### DIFF
--- a/apps/web/src/components/ManualEditSelectionOverlay.tsx
+++ b/apps/web/src/components/ManualEditSelectionOverlay.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from 'react';
 import { useT } from '../i18n';
 import {
+  manualEditActionBarTop,
   manualEditClampedCenter,
   manualEditGestureRect,
   manualEditMovePreviewTransform,
@@ -80,6 +81,7 @@ function rectsEqual(a: ManualEditRect, b: ManualEditRect): boolean {
 }
 
 const ACTION_BAR_HEIGHT = 34;
+const ACTION_BAR_GAP = 8;
 const CROP_MIN_SIZE = 16;
 
 function round1(value: number): number {
@@ -472,7 +474,19 @@ export function ManualEditSelectionOverlay({
   };
 
   const isImage = target.kind === 'image';
-  const barTop = Math.max(4, frame.top - ACTION_BAR_HEIGHT - 8);
+  // Keep the action bar off the element's frame + handles: prefer above, flip
+  // below near the top edge, and stay inside the canvas. Otherwise a small or
+  // edge-hugging element has its move pill / resize handles covered and can no
+  // longer be grabbed.
+  const barPlacement = manualEditActionBarTop(
+    frame.top,
+    frame.height,
+    ACTION_BAR_HEIGHT,
+    ACTION_BAR_GAP,
+    canvasSize?.height,
+    4,
+  );
+  const barTop = barPlacement.top;
   const barLeft = manualEditClampedCenter(
     frame.left + frame.width / 2,
     actionBarWidth || 120,
@@ -612,6 +626,7 @@ export function ManualEditSelectionOverlay({
           ref={actionBarRef}
           className={styles.actionBar}
           data-testid="manual-edit-action-bar"
+          data-placement={barPlacement.placement}
           style={{ left: barLeft, top: barTop }}
         >
           {isImage && onReplaceImage ? (

--- a/apps/web/src/edit-mode/bridge.ts
+++ b/apps/web/src/edit-mode/bridge.ts
@@ -1035,6 +1035,19 @@ export function buildManualEditBridge(enabled: boolean): string {
       window.parent.postMessage({ type: 'od-edit-copy-request', id: stableId(selected) }, '*');
       return;
     }
+    if (meta && key === 'v' && !ev.shiftKey && !ev.altKey) {
+      // The native paste event only fires while an editable element owns the
+      // caret — which never happens for a selected image or container (only
+      // text/link become contentEditable). Without this, Cmd/Ctrl+V does
+      // nothing for those. This branch is only reached for non-editable
+      // selections (the guard above returns early inside a text session), so
+      // it never double-pastes with the native paste handler; preventDefault
+      // also suppresses the browser's own paste for the suppressed case.
+      ev.preventDefault();
+      ev.stopPropagation();
+      window.parent.postMessage({ type: 'od-edit-paste-request', id: stableId(selected) }, '*');
+      return;
+    }
     if (ev.key === 'Delete' || ev.key === 'Backspace') {
       ev.preventDefault();
       ev.stopPropagation();
@@ -1084,8 +1097,17 @@ export function buildManualEditBridge(enabled: boolean): string {
     // previous edit is never silently dropped.
     if (activeTextEdit && activeTextEdit.el !== el) finishActiveTextEdit(true);
     var kind = inferKind(el);
+    // The FIRST click only selects — it must not enter inline editing. Making a
+    // text box contenteditable reflows it (a deck's line-clamped / height-capped
+    // paragraph releases its truncation and visibly grows the instant it is
+    // selected), so selection would jump the element's size. Editing begins on
+    // an explicit second gesture: a click on the ALREADY-selected element or a
+    // double-click. This also makes text select the same way images/containers
+    // already do — first click selects, nothing reflows.
+    var alreadySelected = !!(el.hasAttribute && el.hasAttribute('data-od-edit-selected'));
+    var wantsEdit = alreadySelected || (ev && ev.detail >= 2);
     window.parent.postMessage({ type: 'od-edit-select', target: targetFrom(el, true) }, '*');
-    if (kind === 'text' || kind === 'link') {
+    if ((kind === 'text' || kind === 'link') && wantsEdit) {
       makeEditable(el, ev);
       return;
     }

--- a/apps/web/src/edit-mode/gestures.ts
+++ b/apps/web/src/edit-mode/gestures.ts
@@ -143,6 +143,41 @@ export function manualEditClampedCenter(
   return Math.min(Math.max(desiredCenter, min), max);
 }
 
+export interface ManualEditBarPlacement {
+  top: number;
+  placement: 'above' | 'below';
+}
+
+/**
+ * Vertical placement for the floating action bar so it never covers the
+ * element's frame or its move/resize handles. Prefers sitting ABOVE the frame
+ * (clearing the top move pill); flips BELOW when the element hugs the top edge
+ * and there is room beneath it; and, when the element is too tall for either
+ * side to have clean room, clamps the bar just inside the canvas biased to the
+ * top. `gap` is the breathing room kept between the bar and the frame.
+ */
+export function manualEditActionBarTop(
+  frameTop: number,
+  frameHeight: number,
+  barHeight: number,
+  gap: number,
+  canvasHeight: number | undefined,
+  margin = 4,
+): ManualEditBarPlacement {
+  const above = frameTop - barHeight - gap;
+  const below = frameTop + frameHeight + gap;
+  if (above >= margin) return { top: above, placement: 'above' };
+  if (canvasHeight && canvasHeight > 0) {
+    if (below + barHeight <= canvasHeight - margin) return { top: below, placement: 'below' };
+    // Element taller than the room on either side: keep the bar on-canvas,
+    // biased to the top edge, rather than letting it slide off.
+    const max = Math.max(margin, canvasHeight - margin - barHeight);
+    return { top: Math.min(Math.max(above, margin), max), placement: 'above' };
+  }
+  // Canvas height unknown: still flip below rather than clamp onto the element.
+  return { top: below, placement: 'below' };
+}
+
 /** Apply raw pointer deltas to the gesture's starting rect (pre-snap). */
 export function manualEditGestureRect(
   kind: ManualEditGestureKind,

--- a/apps/web/tests/components/ManualEditSelectionOverlay.test.tsx
+++ b/apps/web/tests/components/ManualEditSelectionOverlay.test.tsx
@@ -167,6 +167,40 @@ describe('ManualEditSelectionOverlay pointer capture fallbacks', () => {
   });
 });
 
+describe('ManualEditSelectionOverlay action bar placement', () => {
+  function renderAt(rect: ManualEditRect) {
+    render(
+      <ManualEditSelectionOverlay
+        target={{ ...target, rect }}
+        targets={[target]}
+        scale={1}
+        canvasSize={{ width: 1000, height: 800 }}
+        onGesturePreview={vi.fn()}
+        onGestureCommit={vi.fn()}
+        onGestureCancel={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+  }
+
+  it('places the bar above an element with room, keeping it off the handles', () => {
+    renderAt({ x: 100, y: 300, width: 200, height: 80 });
+    const bar = screen.getByTestId('manual-edit-action-bar');
+    expect(bar).toHaveAttribute('data-placement', 'above');
+    // Bar bottom clears the frame top (which carries the move pill).
+    expect(Number.parseFloat(bar.style.top)).toBeLessThan(300);
+  });
+
+  it('flips the bar below a top-hugging element so the frame stays grabbable', () => {
+    renderAt({ x: 100, y: 2, width: 200, height: 40 });
+    const bar = screen.getByTestId('manual-edit-action-bar');
+    expect(bar).toHaveAttribute('data-placement', 'below');
+    // Bar top is beneath the frame bottom (2 + 40), not on top of the handles.
+    expect(Number.parseFloat(bar.style.top)).toBeGreaterThanOrEqual(42);
+  });
+});
+
 describe('ManualEditSelectionOverlay whole-image move', () => {
   function renderImageOverlay() {
     const onGestureCommit = vi.fn();

--- a/apps/web/tests/edit-mode/bridge.test.ts
+++ b/apps/web/tests/edit-mode/bridge.test.ts
@@ -616,6 +616,7 @@ describe('manual edit bridge target normalization', () => {
       cancelable: true,
       clientX: 8,
       clientY: 8,
+      detail: 2,
     }));
     expect(title.getAttribute('contenteditable')).toBe('plaintext-only');
     expect(title.getAttribute('data-od-editing')).toBe('true');
@@ -651,6 +652,59 @@ describe('manual edit bridge target normalization', () => {
     dom.window.close();
   });
 
+  it('selects a text target on the first click without entering inline edit', () => {
+    // Regression: making a text box contenteditable on the SELECTING click
+    // reflows deck text (releases its line-clamp/height cap) so the element
+    // visibly grows the instant it is selected. The first click must only
+    // select — no contenteditable, no reflow.
+    const dom = new JSDOM(
+      `<main><h1 data-od-id="title">Original title</h1></main>${buildManualEditBridge(true)}`,
+      { runScripts: 'dangerously', url: 'http://localhost' },
+    );
+    const title = dom.window.document.querySelector('[data-od-id="title"]') as HTMLElement;
+    const postMessage = vi.spyOn(dom.window.parent, 'postMessage');
+
+    title.dispatchEvent(new dom.window.MouseEvent('click', {
+      bubbles: true, cancelable: true, clientX: 8, clientY: 8,
+    }));
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'od-edit-select',
+      target: expect.objectContaining({ id: 'title', kind: 'text' }),
+    }, '*');
+    expect(title.hasAttribute('contenteditable')).toBe(false);
+    expect(title.hasAttribute('data-od-editing')).toBe(false);
+
+    dom.window.close();
+  });
+
+  it('enters inline edit on a second click of the already-selected text target', () => {
+    const dom = new JSDOM(
+      `<main><h1 data-od-id="title">Original title</h1></main>${buildManualEditBridge(true)}`,
+      { runScripts: 'dangerously', url: 'http://localhost' },
+    );
+    const title = dom.window.document.querySelector('[data-od-id="title"]') as HTMLElement;
+
+    // First click selects only.
+    title.dispatchEvent(new dom.window.MouseEvent('click', {
+      bubbles: true, cancelable: true, clientX: 8, clientY: 8,
+    }));
+    expect(title.hasAttribute('contenteditable')).toBe(false);
+
+    // The host echoes the selection back, marking the element selected; a
+    // second click on the now-selected element begins editing.
+    dom.window.dispatchEvent(new dom.window.MessageEvent('message', {
+      data: { type: 'od-edit-selected-target', id: 'title' },
+    }));
+    title.dispatchEvent(new dom.window.MouseEvent('click', {
+      bubbles: true, cancelable: true, clientX: 8, clientY: 8,
+    }));
+    expect(title.getAttribute('contenteditable')).toBe('plaintext-only');
+    expect(title.getAttribute('data-od-editing')).toBe('true');
+
+    dom.window.close();
+  });
+
   // #3646 focus-loss half: once editing, blurring the iframe (e.g. moving the
   // pointer to the host's floating inspector) must NOT end the session or
   // commit. Only an explicit finish (Enter/Escape/od-edit-text-finish) commits.
@@ -667,6 +721,7 @@ describe('manual edit bridge target normalization', () => {
       cancelable: true,
       clientX: 8,
       clientY: 8,
+      detail: 2,
     }));
     title.textContent = 'Edited title';
     title.dispatchEvent(new dom.window.FocusEvent('blur', { bubbles: false }));
@@ -703,7 +758,7 @@ describe('manual edit bridge target normalization', () => {
     const title = dom.window.document.querySelector('[data-od-id="title"]') as HTMLElement;
     const postMessage = vi.spyOn(dom.window.parent, 'postMessage');
 
-    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true }));
+    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, detail: 2 }));
     title.textContent = 'Edited';
     dom.window.document.body.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true }));
 
@@ -731,7 +786,7 @@ describe('manual edit bridge target normalization', () => {
     const body = dom.window.document.querySelector('[data-od-id="body"]') as HTMLElement;
     const postMessage = vi.spyOn(dom.window.parent, 'postMessage');
 
-    body.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true }));
+    body.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, detail: 2 }));
     body.textContent = 'Draft body';
     body.dispatchEvent(new dom.window.KeyboardEvent('keydown', {
       bubbles: true,
@@ -964,7 +1019,7 @@ describe('manual edit rich text sessions', () => {
     );
     const title = dom.window.document.querySelector('[data-od-id="title"]') as HTMLElement;
 
-    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, clientX: 8, clientY: 8 }));
+    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, clientX: 8, clientY: 8, detail: 2 }));
     expect(title.getAttribute('contenteditable')).toBe('plaintext-only');
 
     dom.window.close();
@@ -978,7 +1033,7 @@ describe('manual edit rich text sessions', () => {
     const title = dom.window.document.querySelector('[data-od-id="title"]') as HTMLElement;
     const postMessage = vi.spyOn(dom.window.parent, 'postMessage');
 
-    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, clientX: 8, clientY: 8 }));
+    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, clientX: 8, clientY: 8, detail: 2 }));
     // Simulate what a formatting execCommand does to the live element.
     title.innerHTML = 'Original <span style="font-weight:700">title</span>';
 
@@ -1003,7 +1058,7 @@ describe('manual edit rich text sessions', () => {
     );
     const title = dom.window.document.querySelector('[data-od-id="title"]') as HTMLElement;
 
-    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, clientX: 8, clientY: 8 }));
+    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, clientX: 8, clientY: 8, detail: 2 }));
     title.innerHTML = 'Trashed';
 
     dom.window.dispatchEvent(new dom.window.MessageEvent('message', {
@@ -1022,7 +1077,7 @@ describe('manual edit rich text sessions', () => {
     );
     const title = dom.window.document.querySelector('[data-od-id="title"]') as HTMLElement;
 
-    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, clientX: 8, clientY: 8 }));
+    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, clientX: 8, clientY: 8, detail: 2 }));
     expect(title.getAttribute('contenteditable')).toBe('plaintext-only');
 
     dom.window.dispatchEvent(new dom.window.MessageEvent('message', {
@@ -1045,7 +1100,7 @@ describe('manual edit rich text sessions', () => {
       { runScripts: 'dangerously', url: 'http://localhost' },
     );
     const title = dom.window.document.querySelector('[data-od-id="title"]') as HTMLElement;
-    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, clientX: 8, clientY: 8 }));
+    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, clientX: 8, clientY: 8, detail: 2 }));
     expect(title.getAttribute('contenteditable')).toBe('plaintext-only');
 
     const endEvent = new dom.window.KeyboardEvent('keydown', { key: 'End', bubbles: true, cancelable: true });
@@ -1073,8 +1128,8 @@ describe('manual edit rich text sessions', () => {
       { runScripts: 'dangerously', url: 'http://localhost' },
     );
     const title = dom.window.document.querySelector('[data-od-id="title"]') as HTMLElement;
-    // First click starts the session.
-    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, clientX: 8, clientY: 8 }));
+    // Double-click starts the session (a single click only selects).
+    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, clientX: 8, clientY: 8, detail: 2 }));
     expect(title.getAttribute('contenteditable')).toBe('plaintext-only');
 
     // Simulate the browser's native dblclick word selection…
@@ -1098,7 +1153,7 @@ describe('manual edit rich text sessions', () => {
       { runScripts: 'dangerously', url: 'http://localhost' },
     );
     const title = dom.window.document.querySelector('[data-od-id="title"]') as HTMLElement;
-    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, clientX: 8, clientY: 8 }));
+    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, clientX: 8, clientY: 8, detail: 2 }));
     const postMessage = vi.spyOn(dom.window.parent, 'postMessage');
 
     // Select the whole text run and announce it — the toolbar reads `format`
@@ -1439,6 +1494,29 @@ describe('manual edit keyboard forwarding', () => {
     dom.window.close();
   });
 
+  it('forwards Cmd/Ctrl+V as an element paste for a selected non-editable target', () => {
+    const dom = loadDom();
+    const postMessage = vi.spyOn(dom.window.parent, 'postMessage');
+
+    // Nothing selected → keydown paste is inert (no anchor to paste against).
+    dom.window.document.body.dispatchEvent(new dom.window.KeyboardEvent('keydown', {
+      key: 'v', metaKey: true, bubbles: true, cancelable: true,
+    }));
+    expect(postMessage).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'od-edit-paste-request' }), '*');
+
+    // A selected non-editable target (image/container never gets a caret, so
+    // the native paste event never fires) must still paste via the shortcut.
+    dom.window.dispatchEvent(new dom.window.MessageEvent('message', {
+      data: { type: 'od-edit-selected-target', id: 'title' },
+    }));
+    dom.window.document.body.dispatchEvent(new dom.window.KeyboardEvent('keydown', {
+      key: 'v', metaKey: true, bubbles: true, cancelable: true,
+    }));
+    expect(postMessage).toHaveBeenCalledWith({ type: 'od-edit-paste-request', id: 'title' }, '*');
+
+    dom.window.close();
+  });
+
   it('routes paste to element paste or image insert by clipboard payload', async () => {
     const dom = loadDom();
     const postMessage = vi.spyOn(dom.window.parent, 'postMessage');
@@ -1494,7 +1572,7 @@ describe('manual edit keyboard forwarding', () => {
     const postMessage = vi.spyOn(dom.window.parent, 'postMessage');
     const title = dom.window.document.querySelector('[data-od-id="title"]') as HTMLElement;
 
-    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, clientX: 8, clientY: 8 }));
+    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, clientX: 8, clientY: 8, detail: 2 }));
     title.textContent = 'Changed';
     postMessage.mockClear();
 
@@ -1517,7 +1595,7 @@ describe('manual edit keyboard forwarding', () => {
     const postMessage = vi.spyOn(dom.window.parent, 'postMessage');
     const title = dom.window.document.querySelector('[data-od-id="title"]') as HTMLElement;
 
-    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, clientX: 8, clientY: 8 }));
+    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, clientX: 8, clientY: 8, detail: 2 }));
     postMessage.mockClear();
 
     const undoKey = new dom.window.KeyboardEvent('keydown', {
@@ -1563,7 +1641,7 @@ describe('manual edit page inertness', () => {
       { runScripts: 'dangerously', url: 'http://localhost' },
     );
     const title = dom.window.document.querySelector('[data-od-id="title"]') as HTMLElement;
-    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, clientX: 8, clientY: 8 }));
+    title.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true, cancelable: true, clientX: 8, clientY: 8, detail: 2 }));
     expect(title.getAttribute('data-od-editing')).toBe('true');
 
     // Page-style handlers: a delegated document listener (gallery lightbox /

--- a/apps/web/tests/edit-mode/gestures.test.ts
+++ b/apps/web/tests/edit-mode/gestures.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   MANUAL_EDIT_MIN_GESTURE_SIZE,
+  manualEditActionBarTop,
   manualEditClampedCenter,
   manualEditGestureRect,
   manualEditMovePreviewTransform,
@@ -267,5 +268,42 @@ describe('manual edit floating bar clamping', () => {
   it('only guards the left edge when the canvas size is unknown', () => {
     expect(manualEditClampedCenter(-50, 200, undefined)).toBe(106);
     expect(manualEditClampedCenter(800, 200, undefined)).toBe(800);
+  });
+});
+
+describe('manual edit action bar vertical placement', () => {
+  const BAR = 34;
+  const GAP = 8;
+
+  it('sits above the frame when there is room, clearing the move pill', () => {
+    // Frame at y=300 in an 800px canvas: bar goes above with the gap.
+    expect(manualEditActionBarTop(300, 80, BAR, GAP, 800)).toEqual({
+      top: 300 - BAR - GAP,
+      placement: 'above',
+    });
+  });
+
+  it('flips below when the element hugs the top edge', () => {
+    // Frame at y=6: no room for the bar above, so drop it under the frame.
+    expect(manualEditActionBarTop(6, 40, BAR, GAP, 800)).toEqual({
+      top: 6 + 40 + GAP,
+      placement: 'below',
+    });
+  });
+
+  it('clamps inside the canvas when the element is taller than either side allows', () => {
+    // Frame fills the canvas top-to-bottom: neither above nor below fits, so
+    // keep the bar on-canvas biased to the top rather than off-screen.
+    const placement = manualEditActionBarTop(2, 780, BAR, GAP, 800);
+    expect(placement.placement).toBe('above');
+    expect(placement.top).toBeGreaterThanOrEqual(4);
+    expect(placement.top).toBeLessThanOrEqual(800 - 4 - BAR);
+  });
+
+  it('still flips below rather than covering the element when canvas height is unknown', () => {
+    expect(manualEditActionBarTop(5, 40, BAR, GAP, undefined)).toEqual({
+      top: 5 + 40 + GAP,
+      placement: 'below',
+    });
   });
 });

--- a/specs/current/manual-edit-direct-manipulation.zh-CN.md
+++ b/specs/current/manual-edit-direct-manipulation.zh-CN.md
@@ -166,3 +166,15 @@
 2. **选中框跟随元素实测盒(修错位)**。根因:resize 手势里选中框画的是**手势意图矩形**的 x/width,只吸收 iframe 回报的 y/height;而目标元素在拉伸时可能重新居中(`margin:auto`/flex 居中的图,变宽时固定边内滑)、`max-width` 截断、按内在比例缩放或在父容器里回流——真实渲染盒在**两个轴**上都偏离意图,框只在纵向被纠正,横向永久飘移。修复:`DragState.measuredY/measuredHeight` 合并为单个 `measured: ManualEditRect | null`,`adoptMeasuredExtent` 吸收**完整**实测盒(x/y/width/height),`displayRect = state.measured ?? state.rect`。手势仍以 `state.rect`(意图)落盘 `set-style`,只有用户所见的选中框跟随实测——首帧(尚无测量)与整个 move(纯合成器 transform,不测量)回退到意图矩形。提交时 `outcome = displayRect(state)` 也即实测盒,乐观写入 `target.rect` 与 `heldRect` 与刷新后的真实 rect 对齐,松手零闪跳。
 
 新增测试:`ManualEditSelectionOverlay`「整图 body 拖拽提交 move / 非图片无 body 面」「resize 吸收实测盒纠正横向错位」。
+
+### v2.6 修订(选中框动作条避让 + 选中不再入编辑抖动 + 非文本键盘粘贴,2026-07-20)
+
+用户实测(deck/landing)提三点:小元素或贴近上下左右边界时,**动作条(参数/复制/删除)盖住选中框与手柄**,拉伸/移动的触点点不到;**文本元素一选中就突然变大**,选中态与未选中态尺寸不一致;画布里**图片选中后无法用快捷键复制粘贴**。
+
+1. **动作条边界避让**。新增纯函数 `manualEditActionBarTop(frameTop, frameHeight, barHeight, gap, canvasHeight)`(`edit-mode/gestures.ts`,可单测):默认置于选中框**上方**并留 `gap` 间距(让开顶部 move pill);上方空间不足(贴近上边缘)则**翻到下方**;元素高到两侧都放不下时夹在画布内偏上。横向仍用既有 `manualEditClampedCenter`(贴右边缘左移、贴左边缘右移),因此四边都不再遮挡手柄。`ManualEditSelectionOverlay` 用它替换旧的 `Math.max(4, frame.top - H - 8)` 硬夹,并给动作条加 `data-placement=above|below`。
+
+2. **选中与入编辑解耦(修「选中变大」抖动)**。根因:桥的 click 处理把「选中」和「进入行内编辑」合成一次手势——单击文本/链接立即 `makeEditable` 置 `contenteditable`,而给 deck 里被 line-clamp / 定高截断的文本框加 contenteditable 会**释放截断**,元素瞬间变高。修复:`bridge.ts` 的 click 里**首击只选中**(仅发 `od-edit-select`,不改 DOM,零回流);进入编辑改为**显式二段手势**——点击**已选中**元素(`data-od-edit-selected` 已在)或**双击**(`ev.detail >= 2`)。这也让文本与图片/容器的选中语义一致(首击都只选中)。
+
+3. **非文本元素键盘粘贴**。根因:原生 `paste` 事件只在有可编辑元素持有 caret 时触发,而图片/容器选中后从不 contenteditable,故 Cmd/Ctrl+V 无反应(文本因入编辑有 caret 才生效)。修复:桥 keydown 增 Cmd/Ctrl+V 分支,对选中的非可编辑元素转发 `od-edit-paste-request`(元素缓冲区粘贴);该分支只在非编辑态到达(编辑态由前置 guard 提前 return,原生 paste 仍处理文本/图片文件),preventDefault 兼防重复粘贴。配套 Cmd/Ctrl+C 早已在 keydown 转发 `od-edit-copy-request`,故图片「选中→Cmd+C→Cmd+V」闭环打通。
+
+新增/更新测试:gestures「动作条上方/贴顶翻下方/过高夹内/未知画布高度」;bridge「首击只选中不入编辑」「二击已选中元素入编辑」「Cmd/Ctrl+V 对非可编辑选中转发 paste」,并把 14 个行内编辑用例的入编辑手势改为双击(`detail:2`);ManualEditSelectionOverlay「动作条 above/贴顶 below」。


### PR DESCRIPTION
## Why

Follow-up to the merged whole-image-move / frame-sync PR (#5888), from continued hands-on editing of prototype/landing/deck artifacts. Three direct-manipulation papercuts made small or edge-hugging elements hard or surprising to work with:

1. On a small element, or one near the top/bottom/left/right edge, the floating action bar (params / duplicate / delete) sat on top of the selection frame and its handles — so the move pill and resize handles couldn't be grabbed at all.
2. Selecting a text element made it visibly jump/grow: the click that selected it also made it `contenteditable`, and a deck's line-clamped / height-capped paragraph releases its truncation the instant it becomes editable.
3. A selected image couldn't be copy-pasted with the keyboard in the canvas, even though other flows can.

## What users will see

- **Action bar never covers the element.** It sits above the selection by default, flips below when the element hugs the top edge, and stays inside the canvas — so the move/resize handles are always reachable, even for tiny or edge-pinned elements.
- **Clicking a text element selects it without it jumping in size.** The first click only selects (like images/containers already do); to edit text you now double-click it (or click it again while selected). This removes the grow-on-select jump.
- **Copy/paste a selected image (or other non-text element) with the keyboard.** Cmd/Ctrl+C then Cmd/Ctrl+V now duplicates it in place, matching the existing element-copy for text.

## Surface area

- [x] **UI** — action-bar placement + selection/edit gesture in `apps/web` manual edit mode
- [x] **Keyboard shortcut** — Cmd/Ctrl+V now pastes a copied element onto a selected non-editable target
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — none added (reuses existing `manualEdit.*` keys)
- [ ] **New top-level dependency**
- [x] **Default behavior change** — entering inline text edit now takes a double-click / second click instead of a single click (first click selects). This is the fix for the grow-on-select jump and unifies selection with images/containers.

## Screenshots

Not attached — this environment can't run the app (Node 22; Electron/native installs blocked by the proxy). Entry points for a manual pass: select a small element near the top edge of a deck slide (action bar should appear below it); single-click a deck text block (selects, no size jump) then double-click (enters edit); select an image, Cmd/Ctrl+C, Cmd/Ctrl+V.

## Bug fix verification

Encoded as unit specs at the cheapest layer that sees each symptom:

- `apps/web/tests/edit-mode/gestures.test.ts` — action-bar placement (above / flip-below near top / clamp-inside / unknown canvas height).
- `apps/web/tests/edit-mode/bridge.test.ts` — first click selects without `contenteditable`; second click of the selected element enters edit; Cmd/Ctrl+V forwards a paste for a selected non-editable target. The 14 existing inline-edit specs were updated to enter edit via double-click.
- `apps/web/tests/components/ManualEditSelectionOverlay.test.tsx` — action bar `above` vs `below` placement.

Verified green on this branch; the feature under test lives on `bramble-parsley`, so these run against that base rather than `main`.

## Validation

- `pnpm --filter @open-design/web test` — edit-mode + overlay + FileViewer manual-edit suites (197 tests) pass on the rebased `bramble-parsley` base.
- `pnpm guard` — 86/86 pass.
- `pnpm --filter @open-design/web typecheck` — clean for all files in this change. (One unrelated, pre-existing error remains on the base in `apps/web/tests/lib/updater.test.ts` re: `setMenuLabels` — untouched by this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VURoYki65XDX6EYo9KMQS5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VURoYki65XDX6EYo9KMQS5)_