### PR TITLE
fix(web): keep model picker anchored within visible bounds

### DIFF
--- a/apps/web/src/components/InlineModelSwitcher.tsx
+++ b/apps/web/src/components/InlineModelSwitcher.tsx
@@ -172,6 +172,7 @@ export function InlineModelSwitcher({
   const analytics = useAnalytics();
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement | null>(null);
+  const chipRef = useRef<HTMLButtonElement | null>(null);
   const providerModelsFetchingRef = useRef<Set<string>>(new Set());
   const [amrStatus, setAmrStatus] = useState<VelaLoginStatus | null>(null);
   const [amrWalletSnapshot, setAmrWalletSnapshot] =
@@ -184,6 +185,28 @@ export function InlineModelSwitcher({
     useState(false);
   const amrPollRef = useRef<number | null>(null);
   const amrLoginStartedAtRef = useRef<number | null>(null);
+
+  const getModelPopoverBoundary = useCallback(() => {
+    const scrollContainer = wrapRef.current?.closest<HTMLElement>(
+      '.entry-main--scroll',
+    );
+    const scrollRect = scrollContainer?.getBoundingClientRect();
+    const topbarRect = scrollContainer
+      ?.querySelector<HTMLElement>('.entry-main__topbar')
+      ?.getBoundingClientRect();
+    return {
+      top: Math.max(8, (topbarRect?.bottom ?? scrollRect?.top ?? 0) + 8),
+      right: Math.min(
+        window.innerWidth - 8,
+        (scrollRect?.right ?? window.innerWidth) - 8,
+      ),
+      bottom: Math.min(
+        window.innerHeight - 8,
+        (scrollRect?.bottom ?? window.innerHeight) - 8,
+      ),
+      left: Math.max(8, (scrollRect?.left ?? 0) + 8),
+    };
+  }, []);
 
   const stopAmrPolling = useCallback(() => {
     if (amrPollRef.current !== null) {
@@ -351,6 +374,48 @@ export function InlineModelSwitcher({
     return () => {
       document.removeEventListener('mousedown', onClick);
       document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const scrollContainer = wrapRef.current?.closest('.entry-main--scroll');
+    if (!(scrollContainer instanceof HTMLElement)) return;
+    let frame = 0;
+    const updateAnchorVisibility = () => {
+      frame = 0;
+      const triggerRect = chipRef.current?.getBoundingClientRect();
+      if (!triggerRect) return;
+      const scrollRect = scrollContainer.getBoundingClientRect();
+      const topbarBottom = scrollContainer
+        .querySelector<HTMLElement>('.entry-main__topbar')
+        ?.getBoundingClientRect().bottom;
+      const safeTop = Math.max(scrollRect.top, topbarBottom ?? scrollRect.top);
+      const safeBottom = Math.min(window.innerHeight, scrollRect.bottom);
+      const safeLeft = Math.max(0, scrollRect.left);
+      const safeRight = Math.min(window.innerWidth, scrollRect.right);
+      if (
+        triggerRect.bottom <= safeTop ||
+        triggerRect.top >= safeBottom ||
+        triggerRect.right <= safeLeft ||
+        triggerRect.left >= safeRight
+      ) {
+        setOpen(false);
+      }
+    };
+    const scheduleVisibilityUpdate = () => {
+      if (frame !== 0) return;
+      frame = window.requestAnimationFrame(updateAnchorVisibility);
+    };
+    updateAnchorVisibility();
+    scrollContainer.addEventListener('scroll', scheduleVisibilityUpdate, {
+      passive: true,
+    });
+    window.addEventListener('resize', scheduleVisibilityUpdate);
+    return () => {
+      if (frame !== 0) window.cancelAnimationFrame(frame);
+      scrollContainer.removeEventListener('scroll', scheduleVisibilityUpdate);
+      window.removeEventListener('resize', scheduleVisibilityUpdate);
     };
   }, [open]);
 
@@ -652,6 +717,7 @@ export function InlineModelSwitcher({
       data-testid="inline-model-switcher"
     >
       <button
+        ref={chipRef}
         type="button"
         className={
           'inline-switcher__chip od-tooltip' +
@@ -972,6 +1038,7 @@ export function InlineModelSwitcher({
                     searchInputTestId="inline-model-switcher-agent-model-search"
                     popoverTestId="inline-model-switcher-agent-model-popover"
                     searchPlaceholder={t('designs.searchPlaceholder')}
+                    getPopoverBoundary={getModelPopoverBoundary}
                     aria-label={t('inlineSwitcher.modelLabel')}
                     models={inlineAgentModelOptions}
                     value={currentModelId ?? ''}
@@ -1097,6 +1164,7 @@ export function InlineModelSwitcher({
                     searchInputTestId="inline-model-switcher-api-model-search"
                     popoverTestId="inline-model-switcher-api-model-popover"
                     searchPlaceholder={t('designs.searchPlaceholder')}
+                    getPopoverBoundary={getModelPopoverBoundary}
                     aria-label={t('inlineSwitcher.modelLabel')}
                     models={apiModelChoices}
                     value={config.model}

--- a/apps/web/src/components/modelOptions.tsx
+++ b/apps/web/src/components/modelOptions.tsx
@@ -96,6 +96,12 @@ interface SearchableModelSelectProps
   onDisabledOptionUpgrade?: (option: AgentModelOption) => void;
   minSearchableOptions?: number;
   popoverMinWidth?: number;
+  getPopoverBoundary?: () => {
+    top?: number;
+    right?: number;
+    bottom?: number;
+    left?: number;
+  } | null;
 }
 
 export const SearchableModelSelect = forwardRef<
@@ -115,6 +121,7 @@ export const SearchableModelSelect = forwardRef<
     onDisabledOptionUpgrade,
     minSearchableOptions = 8,
     popoverMinWidth,
+    getPopoverBoundary,
     className,
     ...buttonProps
   },
@@ -123,11 +130,18 @@ export const SearchableModelSelect = forwardRef<
   const t = useT();
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
-  const [popoverStyle, setPopoverStyle] = useState<({ left: number; width: number; maxHeight: number } & ({ top: number; bottom?: never } | { bottom: number; top?: never })) | null>(null);
+  const [popoverStyle, setPopoverStyle] = useState<{
+    placement: 'above' | 'below';
+    offset: number;
+    left: number;
+    width: number;
+    maxHeight: number;
+  } | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const searchRef = useRef<HTMLInputElement | null>(null);
+  const placementRef = useRef<'above' | 'below' | null>(null);
   const listboxId = useMemo(
     () => `model-picker-${Math.random().toString(36).slice(2, 10)}`,
     [],
@@ -205,28 +219,84 @@ export const SearchableModelSelect = forwardRef<
       if (!rect) return;
       const viewportWidth = typeof window === 'undefined' ? rect.width : window.innerWidth;
       const viewportHeight = typeof window === 'undefined' ? rect.height : window.innerHeight;
-      const desiredWidth = Math.max(rect.width, popoverMinWidth ?? 0);
-      const maxWidth = Math.max(160, viewportWidth - 16);
-      const width = Math.min(desiredWidth, maxWidth);
-      const left = Math.min(
-        Math.max(8, rect.left),
-        Math.max(8, viewportWidth - width - 8),
+      const requestedBoundary = getPopoverBoundary?.();
+      const boundaryLeft = Math.min(
+        viewportWidth,
+        Math.max(0, requestedBoundary?.left ?? 8),
       );
-      const availableBelow = Math.max(140, viewportHeight - rect.bottom - 12);
-      const availableAbove = Math.max(140, rect.top - 12);
-      const shouldOpenUpward = availableBelow < 260 && availableAbove > availableBelow;
-      const maxHeight = Math.min(360, shouldOpenUpward ? availableAbove : availableBelow);
-      if (shouldOpenUpward) {
-        setPopoverStyle({
-          bottom: Math.max(8, viewportHeight - rect.top + 6),
-          left,
-          width,
-          maxHeight,
-        });
+      const boundaryRight = Math.max(
+        boundaryLeft,
+        Math.min(viewportWidth, requestedBoundary?.right ?? viewportWidth - 8),
+      );
+      const boundaryTop = Math.min(
+        viewportHeight,
+        Math.max(0, requestedBoundary?.top ?? 8),
+      );
+      const boundaryBottom = Math.max(
+        boundaryTop,
+        Math.min(
+          viewportHeight,
+          requestedBoundary?.bottom ?? viewportHeight - 8,
+        ),
+      );
+
+      const referenceHasLayout = rect.width > 0 || rect.height > 0;
+      const referenceIsOutsideBoundary =
+        referenceHasLayout &&
+        (rect.bottom <= boundaryTop ||
+          rect.top >= boundaryBottom ||
+          rect.right <= boundaryLeft ||
+          rect.left >= boundaryRight);
+      if (referenceIsOutsideBoundary) {
+        setPopoverStyle(null);
+        setOpen(false);
         return;
       }
+
+      const desiredWidth = Math.max(rect.width, popoverMinWidth ?? 0);
+      const maxWidth = Math.max(0, boundaryRight - boundaryLeft);
+      const width = Math.min(desiredWidth, maxWidth);
+      const left = Math.min(
+        Math.max(boundaryLeft, rect.left),
+        Math.max(boundaryLeft, boundaryRight - width),
+      );
+      const gap = 6;
+      const availableBelow = Math.max(0, boundaryBottom - rect.bottom - gap);
+      const availableAbove = Math.max(0, rect.top - boundaryTop - gap);
+      const minimumHeight = shouldShowSearch ? 96 : 52;
+      let placement = placementRef.current;
+      if (placement === null) {
+        placement =
+          availableBelow < 260 && availableAbove > availableBelow
+            ? 'above'
+            : 'below';
+      } else {
+        const currentAvailable =
+          placement === 'above' ? availableAbove : availableBelow;
+        const oppositeAvailable =
+          placement === 'above' ? availableBelow : availableAbove;
+        if (
+          currentAvailable < minimumHeight &&
+          oppositeAvailable >= minimumHeight
+        ) {
+          placement = placement === 'above' ? 'below' : 'above';
+        }
+      }
+      const availableHeight =
+        placement === 'above' ? availableAbove : availableBelow;
+      if ((referenceHasLayout && width <= 0) || availableHeight < minimumHeight) {
+        setPopoverStyle(null);
+        setOpen(false);
+        return;
+      }
+      placementRef.current = placement;
+      const maxHeight = Math.min(360, availableHeight);
       setPopoverStyle({
-        top: rect.bottom + 6,
+        placement,
+        offset:
+          placement === 'above'
+            ? viewportHeight - rect.top + gap
+            : rect.bottom + gap,
         left,
         width,
         maxHeight,
@@ -239,15 +309,18 @@ export const SearchableModelSelect = forwardRef<
       window.removeEventListener('resize', updatePosition);
       window.removeEventListener('scroll', updatePosition, true);
     };
-  }, [open, popoverMinWidth]);
+  }, [getPopoverBoundary, open, popoverMinWidth, shouldShowSearch]);
 
   useEffect(() => {
     if (!open || !shouldShowSearch) return;
-    searchRef.current?.focus();
+    searchRef.current?.focus({ preventScroll: true });
   }, [open, shouldShowSearch]);
 
   useEffect(() => {
-    if (!open) setQuery('');
+    if (!open) {
+      placementRef.current = null;
+      setQuery('');
+    }
   }, [open]);
 
   return (
@@ -298,8 +371,15 @@ export const SearchableModelSelect = forwardRef<
               onKeyDown={handlePopoverKeyDown}
               style={{
                 position: 'fixed',
-                top: popoverStyle.top != null ? `${popoverStyle.top}px` : 'auto',
-                bottom: popoverStyle.bottom != null ? `${popoverStyle.bottom}px` : 'auto',
+                top:
+                  popoverStyle.placement === 'below'
+                    ? `${popoverStyle.offset}px`
+                    : 'auto',
+                right: 'auto',
+                bottom:
+                  popoverStyle.placement === 'above'
+                    ? `${popoverStyle.offset}px`
+                    : 'auto',
                 left: `${popoverStyle.left}px`,
                 width: `${popoverStyle.width}px`,
                 maxHeight: `${popoverStyle.maxHeight}px`,
@@ -324,7 +404,7 @@ export const SearchableModelSelect = forwardRef<
                 id={listboxId}
                 role="listbox"
                 style={{
-                  maxHeight: `${Math.max(96, popoverStyle.maxHeight - (shouldShowSearch ? 52 : 12))}px`,
+                  maxHeight: `${Math.max(0, popoverStyle.maxHeight - (shouldShowSearch ? 52 : 12))}px`,
                 }}
               >
                 {filteredOptions.map((option, index) => {

--- a/apps/web/tests/components/modelOptions.test.tsx
+++ b/apps/web/tests/components/modelOptions.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   CUSTOM_MODEL_SENTINEL,
@@ -100,6 +100,75 @@ describe('orderModelOptionsByAvailability', () => {
 });
 
 describe('SearchableModelSelect', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      x: 120,
+      y: 200,
+      top: 200,
+      right: 360,
+      bottom: 236,
+      left: 120,
+      width: 240,
+      height: 36,
+      toJSON: () => ({}),
+    });
+  });
+
+  it('clamps an upward popover and keeps that placement while it still fits', async () => {
+    let triggerRect = {
+      x: 120,
+      y: 300,
+      top: 300,
+      right: 360,
+      bottom: 336,
+      left: 120,
+      width: 240,
+      height: 36,
+      toJSON: () => ({}),
+    };
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(
+      () => triggerRect,
+    );
+
+    render(
+      <SearchableModelSelect
+        models={Array.from({ length: 9 }, (_, index) => ({
+          id: `model-${index}`,
+          label: `Model ${index}`,
+        }))}
+        value="model-0"
+        onChange={vi.fn()}
+        searchPlaceholder="Search models"
+        popoverTestId="model-popover"
+        getPopoverBoundary={() => ({
+          top: 80,
+          right: 500,
+          bottom: 400,
+          left: 8,
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('combobox'));
+
+    const popover = await screen.findByTestId('model-popover');
+    expect(popover.style.bottom).toBe(`${window.innerHeight - 300 + 6}px`);
+    expect(popover.style.maxHeight).toBe('214px');
+
+    triggerRect = {
+      ...triggerRect,
+      y: 200,
+      top: 200,
+      bottom: 236,
+    };
+    fireEvent.scroll(window);
+
+    await waitFor(() => {
+      expect(popover.style.bottom).toBe(`${window.innerHeight - 200 + 6}px`);
+      expect(popover.style.maxHeight).toBe('114px');
+    });
+  });
+
   it('renders capability tag and cost metadata as option text', async () => {
     render(
       <SearchableModelSelect

--- a/e2e/ui/home-composer-topbar-stacking.test.ts
+++ b/e2e/ui/home-composer-topbar-stacking.test.ts
@@ -51,7 +51,17 @@ test.beforeEach(async ({ page }) => {
       bin: 'codex',
       available: true,
       version: '0.80.0',
-      models: [{ id: 'default', label: 'Default' }],
+      models: [
+        { id: 'default', label: 'Default (CLI config)' },
+        { id: 'gpt-5.6-sol', label: 'GPT-5.6-Sol' },
+        { id: 'gpt-5.6-terra', label: 'GPT-5.6-Terra' },
+        { id: 'gpt-5.6-luna', label: 'GPT-5.6-Luna' },
+        { id: 'gpt-5.5', label: 'GPT-5.5' },
+        { id: 'gpt-5.4', label: 'GPT-5.4' },
+        { id: 'gpt-5.4-mini', label: 'GPT-5.4-Mini' },
+        { id: 'gpt-5.3-codex-spark', label: 'GPT-5.3-Codex-Spark' },
+        { id: 'codex-auto-review', label: 'Codex Auto Review' },
+      ],
     },
   ]);
 
@@ -88,7 +98,7 @@ test('[P1] sticky topbar chips stay above the composer card while its switcher p
   // Reveal the community templates section (first-run gesture) so the scroll
   // container has enough content height to slide the composer under the
   // sticky topbar strip.
-  await page.mouse.wheel(0, 500);
+  await revealCommunityTemplates(page);
 
   // Scroll the entry main container until the composer card's top edge sits
   // inside the sticky topbar strip, vertically overlapping the chip row.
@@ -166,6 +176,77 @@ test('[P1] sticky topbar chips stay above the composer card while its switcher p
   ).toEqual([]);
 });
 
+test('[P1] nested model picker stays inside the visible area below the sticky topbar', async ({
+  page,
+}) => {
+  await openNestedModelPicker(page);
+
+  const geometry = await page.evaluate(() => {
+    const topbar = document.querySelector('.entry-main__topbar');
+    const popover = document.querySelector('[data-testid="inline-model-switcher-agent-model-popover"]');
+    if (topbar == null || popover == null) return null;
+    const topbarRect = topbar.getBoundingClientRect();
+    const popoverRect = popover.getBoundingClientRect();
+    return {
+      popoverBottom: popoverRect.bottom,
+      popoverTop: popoverRect.top,
+      topbarBottom: topbarRect.bottom,
+      viewportHeight: window.innerHeight,
+    };
+  });
+
+  expect(geometry, 'topbar and nested model picker must both be present').not.toBeNull();
+  expect(geometry!.popoverTop).toBeGreaterThanOrEqual(geometry!.topbarBottom + 6);
+  expect(geometry!.popoverBottom).toBeLessThanOrEqual(geometry!.viewportHeight - 8);
+});
+
+test('[P1] nested model picker follows the visible anchor and closes after it exits', async ({
+  page,
+}) => {
+  await openNestedModelPicker(page);
+
+  const modelPopover = page.getByTestId('inline-model-switcher-agent-model-popover');
+  const switcherPopover = page.getByTestId('inline-model-switcher-popover');
+  const modelList = modelPopover.locator('.model-select-searchable__list');
+
+  const listCanScroll = await modelList.evaluate((element) => {
+    element.scrollTop = 48;
+    element.dispatchEvent(new Event('scroll'));
+    return element.scrollHeight > element.clientHeight;
+  });
+  expect(listCanScroll, 'test setup: compact model list must have internal scroll room').toBe(true);
+  await expect(modelPopover).toBeVisible();
+  await expect(switcherPopover).toBeVisible();
+
+  const beforeScroll = await modelAnchorGeometry(page);
+  await page.locator('.entry-main--scroll').evaluate((element) => {
+    element.scrollTop += 48;
+    element.dispatchEvent(new Event('scroll'));
+  });
+
+  await expect(modelPopover).toBeVisible();
+  await expect(switcherPopover).toBeVisible();
+  const afterScroll = await modelAnchorGeometry(page);
+  expect(afterScroll.placement).toBe(beforeScroll.placement);
+  expect(afterScroll.gap).toBeGreaterThanOrEqual(5);
+  expect(afterScroll.gap).toBeLessThanOrEqual(7);
+  expect(afterScroll.popoverTop).toBeGreaterThanOrEqual(afterScroll.topbarBottom + 6);
+  expect(afterScroll.popoverBottom).toBeLessThanOrEqual(afterScroll.viewportHeight - 8);
+
+  await page.locator('.entry-main--scroll').evaluate((element) => {
+    const chip = document.querySelector('[data-testid="inline-model-switcher-chip"]');
+    const topbar = document.querySelector('.entry-main__topbar');
+    if (chip == null || topbar == null) throw new Error('missing anchor geometry');
+    const distanceToOcclusion =
+      chip.getBoundingClientRect().bottom - topbar.getBoundingClientRect().bottom;
+    element.scrollTop += Math.max(1, distanceToOcclusion + 12);
+    element.dispatchEvent(new Event('scroll'));
+  });
+
+  await expect(modelPopover).toBeHidden();
+  await expect(switcherPopover).toBeHidden();
+});
+
 // Scrolls `.entry-main--scroll` so the composer card's top edge lands inside
 // the sticky topbar strip (which stays pinned at the container's top). Fails
 // loudly when the container cannot scroll far enough to create the overlap.
@@ -189,4 +270,60 @@ async function scrollComposerUnderTopbar(page: Page) {
   expect(result.ok, `test setup: could not scroll the composer under the topbar (${result.reason})`).toBe(
     true,
   );
+}
+
+async function openNestedModelPicker(page: Page) {
+  // Keep the outer switcher's model field reachable without scrolling while
+  // leaving too little room below it for the full nested model list.
+  await page.setViewportSize({ width: 546, height: 640 });
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.getByText('Loading Open Design…').waitFor({ state: 'hidden', timeout: T.long });
+  await expect(page.getByTestId('home-hero-input')).toBeVisible();
+  await revealCommunityTemplates(page);
+
+  await page.getByTestId('inline-model-switcher-chip').click();
+  await expect(page.getByTestId('inline-model-switcher-popover')).toBeVisible();
+  await page.getByTestId('inline-model-switcher-agent-model').click();
+  await expect(page.getByTestId('inline-model-switcher-agent-model-popover')).toBeVisible();
+}
+
+async function modelAnchorGeometry(page: Page) {
+  return page.evaluate(() => {
+    const trigger = document.querySelector(
+      '[data-testid="inline-model-switcher-agent-model"]',
+    );
+    const popover = document.querySelector(
+      '[data-testid="inline-model-switcher-agent-model-popover"]',
+    );
+    const topbar = document.querySelector('.entry-main__topbar');
+    if (trigger == null || popover == null || topbar == null) {
+      throw new Error('missing model picker geometry');
+    }
+    const triggerRect = trigger.getBoundingClientRect();
+    const popoverRect = popover.getBoundingClientRect();
+    const placement = popoverRect.bottom <= triggerRect.top ? 'above' : 'below';
+    return {
+      gap:
+        placement === 'above'
+          ? triggerRect.top - popoverRect.bottom
+          : popoverRect.top - triggerRect.bottom,
+      placement,
+      popoverBottom: popoverRect.bottom,
+      popoverTop: popoverRect.top,
+      topbarBottom: topbar.getBoundingClientRect().bottom,
+      viewportHeight: window.innerHeight,
+    };
+  });
+}
+
+async function revealCommunityTemplates(page: Page) {
+  await expect(page.getByTestId('home-templates-hint')).toBeVisible();
+  await page.evaluate(() => {
+    window.dispatchEvent(new WheelEvent('wheel', { deltaY: 500 }));
+  });
+  await expect(page.locator('.home-templates-reveal')).toHaveClass(/is-revealed/);
+  await page.locator('.entry-main--scroll').evaluate((element) => {
+    element.scrollTop = 0;
+    element.dispatchEvent(new Event('scroll'));
+  });
 }


### PR DESCRIPTION
Fixes #5895

## Why

**Use case:** QA reproduced the nested model picker crossing the homepage sticky topbar while the main content scrolls in both Web and Electron.

**Pain:** The detached list can cover navigation, drift away from its trigger, and leave users unsure which control owns the open model menu.

## What users will see

The nested model list stays anchored to its visible trigger, remains inside the area below the sticky topbar, scrolls internally when its options do not fit, and closes once its trigger leaves the safe visible region.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

- Before/after evidence was captured during Web and Electron verification; the image upload is pending an authenticated GitHub web session.

## Bug fix verification

- Test path that reproduces the bug: `e2e/ui/home-composer-topbar-stacking.test.ts`
- Red on `main`: yes
- Green on this branch: yes
- Explanation: The component regression also lives in apps/web/tests/components/modelOptions.test.tsx.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/modelOptions.test.tsx tests/components/InlineModelSwitcher.test.tsx tests/components/AvatarMenu.test.tsx --maxWorkers=2 (50 passed)`
- `pnpm --filter @open-design/e2e exec playwright test -c playwright.config.ts ui/home-composer-topbar-stacking.test.ts --workers=1 (3 passed)`
- `Red-spec check on origin/main: component suite failed 1/50 and focused Playwright failed 1/3 before applying the source fix`
- `Manual Web and Electron verification: the popovers remain anchored during moderate scroll and close after the trigger enters the sticky topbar region`
