### PR TITLE
fix(daemon): give deploy failures specific error codes instead of one opaque 400

### DIFF
--- a/apps/daemon/src/deploy.ts
+++ b/apps/daemon/src/deploy.ts
@@ -813,7 +813,8 @@ function cloudflarePagesDnsConflictError(selection: CloudflarePagesDeploySelecti
       dnsRecordId: conflicting.id,
       dnsOwnership: 'external',
     },
-   'CF_DNS_RECORD_CONFLICT');
+    'CF_DNS_RECORD_CONFLICT',
+  );
 }
 
 async function maybeReuseCloudflarePagesCnameAfterDuplicate({ err, config, selection, targetHost, marker }: { err: unknown; config: DeployConfig; selection: CloudflarePagesDeploySelection; targetHost: string; marker: string }) {
@@ -902,7 +903,8 @@ async function ensureCloudflarePagesDomain(config: DeployConfig, hostname: strin
           errorCode: 'cloudflare_domain_already_bound',
           domainStatus: 'conflict',
         },
-       'CF_DOMAIN_ALREADY_BOUND');
+        'CF_DOMAIN_ALREADY_BOUND',
+      );
     }
     throw cloudflareError(json, resp.status, 'Cloudflare Pages custom domain setup failed.');
   }
@@ -1917,7 +1919,14 @@ function cloudflareError(json: JsonObject, status: number, fallback: string) {
     json?.message ||
     fallback ||
     `Cloudflare request failed (${status}).`;
-  return new DeployError(message, status, json, 'PROVIDER_ERROR');
+  // Deliberately NO structured code: this is the catch-all for any Cloudflare
+  // API rejection, where the provider's HTTP status IS the signal. The client
+  // (apps/web/src/providers/registry.ts) only falls back to `HTTP_${status}`
+  // when the envelope code is generic, so stamping one code here would fold
+  // auth (403), quota (429) and upstream faults (5xx) into a single bucket —
+  // the opposite of what this file's specific codes are for. Add a code here
+  // only for a failure whose CAUSE is known, not merely its status.
+  return new DeployError(message, status, json);
 }
 
 function isCloudflareAlreadyExists(body: unknown) {
@@ -1942,7 +1951,9 @@ function vercelError(json: JsonObject, status: number) {
   if (code === 'forbidden' || /permission/i.test(message)) {
     return new DeployError("You don't have permission to create a project.", status, json, 'PROVIDER_FORBIDDEN');
   }
-  return new DeployError(message, status, json, 'PROVIDER_ERROR');
+  // Catch-all — no structured code, so the client keeps bucketing by the real
+  // provider status. See cloudflareError above.
+  return new DeployError(message, status, json);
 }
 
 function deploymentUrl(json: JsonObject | null | undefined) {

--- a/apps/daemon/src/deploy.ts
+++ b/apps/daemon/src/deploy.ts
@@ -142,8 +142,8 @@ export async function writeCloudflarePagesConfig(input: Partial<DeployConfig>) {
     projectName: '',
   };
   if (Object.keys(cloudflarePages).length > 0) next.cloudflarePages = cloudflarePages;
-  if (!next.token) throw new DeployError('Cloudflare API token is required.', 400);
-  if (!next.accountId) throw new DeployError('Cloudflare account ID is required.', 400);
+  if (!next.token) throw new DeployError('Cloudflare API token is required.', 400, undefined, 'CF_TOKEN_REQUIRED');
+  if (!next.accountId) throw new DeployError('Cloudflare account ID is required.', 400, undefined, 'CF_ACCOUNT_ID_REQUIRED');
   await writeDeployConfigFile(deployConfigPath(CLOUDFLARE_PAGES_PROVIDER_ID), next);
   return publicCloudflarePagesConfig(next);
 }
@@ -241,7 +241,7 @@ function normalizeCloudflarePagesConfigHints(input: unknown, fallback: Cloudflar
 export async function buildDeployFilePlan(projectsRoot: string, projectId: string, entryName: string, options: DeployOptions = {}): Promise<DeployFilePlan> {
   const entryPath = validateProjectPath(entryName);
   if (!/\.html?$/i.test(entryPath)) {
-    throw new DeployError('Only HTML files can be deployed.', 400);
+    throw new DeployError('Only HTML files can be deployed.', 400, undefined, 'NOT_HTML');
   }
 
   const entry = await readProjectFile(projectsRoot, projectId, entryPath, options.metadata);
@@ -349,7 +349,7 @@ export async function buildDeployFileSet(projectsRoot: string, projectId: string
     throw new DeployError(`Could not deploy referenced files (${parts.join('; ')}).`, 400, {
       missing: plan.missing,
       invalid: plan.invalid,
-    });
+    }, 'MISSING_REFERENCES');
   }
   return plan.files;
 }
@@ -387,7 +387,7 @@ function isLinkedFolderProject(metadata: unknown) {
 
 export async function deployToVercel({ config, files, projectId }: { config: DeployConfig; files: DeployFile[]; projectId: string }) {
   if (!config?.token) {
-    throw new DeployError('Vercel token is required.', 400);
+    throw new DeployError('Vercel token is required.', 400, undefined, 'VERCEL_TOKEN_REQUIRED');
   }
 
   const createResp = await fetch(`${VERCEL_API}/v13/deployments${vercelTeamQuery(config)}`, {
@@ -416,7 +416,7 @@ export async function deployToVercel({ config, files, projectId }: { config: Dep
     ? await pollVercelDeployment(config, deploymentId)
     : created;
   if (ready?.readyState === 'ERROR') {
-    throw new DeployError(ready?.error?.message || 'Vercel deployment failed.', 502, ready);
+    throw new DeployError(ready?.error?.message || 'Vercel deployment failed.', 502, ready, 'VERCEL_DEPLOY_FAILED');
   }
 
   const candidates = deploymentUrlCandidates(ready, created);
@@ -437,8 +437,8 @@ export async function deployToVercel({ config, files, projectId }: { config: Dep
 }
 
 export async function listCloudflarePagesZones(config: DeployConfig) {
-  if (!config?.token) throw new DeployError('Cloudflare API token is required.', 400);
-  if (!config?.accountId) throw new DeployError('Cloudflare account ID is required.', 400);
+  if (!config?.token) throw new DeployError('Cloudflare API token is required.', 400, undefined, 'CF_TOKEN_REQUIRED');
+  if (!config?.accountId) throw new DeployError('Cloudflare account ID is required.', 400, undefined, 'CF_ACCOUNT_ID_REQUIRED');
   const accountId = config.accountId;
   const zones = await fetchCloudflarePaginatedResult(
     config,
@@ -476,9 +476,9 @@ export async function deployToCloudflarePages(input: { config: DeployConfig; fil
     priorMetadata = undefined,
     target = 'production',
   } = input || {};
-  if (!config?.token) throw new DeployError('Cloudflare API token is required.', 400);
-  if (!config?.accountId) throw new DeployError('Cloudflare account ID is required.', 400);
-  if (!config?.projectName) throw new DeployError('Cloudflare Pages project name could not be generated.', 400);
+  if (!config?.token) throw new DeployError('Cloudflare API token is required.', 400, undefined, 'CF_TOKEN_REQUIRED');
+  if (!config?.accountId) throw new DeployError('Cloudflare account ID is required.', 400, undefined, 'CF_ACCOUNT_ID_REQUIRED');
+  if (!config?.projectName) throw new DeployError('Cloudflare Pages project name could not be generated.', 400, undefined, 'CF_PROJECT_NAME_UNRESOLVED');
 
   const customDomainSelection = await validateCloudflarePagesDeploySelection(
     config,
@@ -571,12 +571,12 @@ function normalizeCloudflarePagesDeploySelection(input: unknown): CloudflarePage
   if (!rawZoneId && !rawZoneName && !rawPrefix) return null;
   const zoneName = normalizeCloudflareZoneName(rawZoneName);
   const domainPrefix = normalizeCloudflareDomainPrefix(rawPrefix);
-  if (!rawZoneId) throw new DeployError('Cloudflare zone is required for a custom domain.', 400);
+  if (!rawZoneId) throw new DeployError('Cloudflare zone is required for a custom domain.', 400, undefined, 'CF_ZONE_REQUIRED');
   if (!zoneName || !isValidCloudflareZoneName(zoneName)) {
-    throw new DeployError('Select a valid Cloudflare domain for the custom domain.', 400);
+    throw new DeployError('Select a valid Cloudflare domain for the custom domain.', 400, undefined, 'CF_ZONE_INVALID');
   }
   if (!domainPrefix) {
-    throw new DeployError('Enter a valid subdomain prefix, for example "demo".', 400);
+    throw new DeployError('Enter a valid subdomain prefix, for example "demo".', 400, undefined, 'CF_SUBDOMAIN_INVALID');
   }
   return {
     zoneId: rawZoneId,
@@ -600,23 +600,23 @@ async function validateCloudflarePagesDeploySelection(config: DeployConfig, sele
   if (!zoneName || zoneName !== selection.zoneName) {
     throw new DeployError('Cloudflare zone selection no longer matches the selected domain.', 400, {
       errorCode: 'cloudflare_zone_mismatch',
-    });
+    }, 'CF_ZONE_MISMATCH');
   }
   if (zone?.status && zone.status !== 'active') {
     throw new DeployError('Cloudflare custom domains require an active zone.', 400, {
       errorCode: 'cloudflare_zone_inactive',
-    });
+    }, 'CF_ZONE_INACTIVE');
   }
   if (zone?.type && zone.type !== 'full') {
     throw new DeployError('Cloudflare custom domains require a full DNS zone.', 400, {
       errorCode: 'cloudflare_zone_not_full',
-    });
+    }, 'CF_ZONE_PARTIAL');
   }
   return { ...selection, zoneName };
 }
 
 async function setupCloudflarePagesCustomDomain({ config, projectId, selection, pagesDevUrl, priorMetadata }: { config: DeployConfig; projectId: string; selection: CloudflarePagesDeploySelection; pagesDevUrl: string; priorMetadata?: JsonObject | undefined }) {
-  if (!config.projectName) throw new DeployError('Cloudflare Pages project name could not be generated.', 400);
+  if (!config.projectName) throw new DeployError('Cloudflare Pages project name could not be generated.', 400, undefined, 'CF_PROJECT_NAME_UNRESOLVED');
   const pagesTarget = normalizeHostname(hostnameFromUrl(pagesDevUrl) || `${config.projectName}.pages.dev`);
   const marker = cloudflarePagesDnsMarker(projectId, config.projectName, pagesTarget);
   const base = {
@@ -710,7 +710,7 @@ async function ensureCloudflarePagesCnameRecord({ config, selection, target, mar
   if (conflicting) {
     if (canPatchCloudflarePagesCname(conflicting, selection, marker, priorMetadata)) {
       const conflictingId = conflicting.id;
-      if (!conflictingId) throw new DeployError('Cloudflare DNS record id is missing.', 502);
+      if (!conflictingId) throw new DeployError('Cloudflare DNS record id is missing.', 502, undefined, 'CF_DNS_RECORD_MISSING');
       const patched = await patchCloudflareDnsRecord(config, selection.zoneId, conflictingId, {
         type: 'CNAME',
         name: selection.hostname,
@@ -813,7 +813,7 @@ function cloudflarePagesDnsConflictError(selection: CloudflarePagesDeploySelecti
       dnsRecordId: conflicting.id,
       dnsOwnership: 'external',
     },
-  );
+   'CF_DNS_RECORD_CONFLICT');
 }
 
 async function maybeReuseCloudflarePagesCnameAfterDuplicate({ err, config, selection, targetHost, marker }: { err: unknown; config: DeployConfig; selection: CloudflarePagesDeploySelection; targetHost: string; marker: string }) {
@@ -902,7 +902,7 @@ async function ensureCloudflarePagesDomain(config: DeployConfig, hostname: strin
           errorCode: 'cloudflare_domain_already_bound',
           domainStatus: 'conflict',
         },
-      );
+       'CF_DOMAIN_ALREADY_BOUND');
     }
     throw cloudflareError(json, resp.status, 'Cloudflare Pages custom domain setup failed.');
   }
@@ -925,9 +925,9 @@ async function findCloudflarePagesDomain(config: DeployConfig, hostname: string)
 }
 
 export async function readCloudflarePagesDomain(config: DeployConfig, hostname: string) {
-  if (!config?.token) throw new DeployError('Cloudflare API token is required.', 400);
-  if (!config?.accountId) throw new DeployError('Cloudflare account ID is required.', 400);
-  if (!config?.projectName) throw new DeployError('Cloudflare Pages project name could not be generated.', 400);
+  if (!config?.token) throw new DeployError('Cloudflare API token is required.', 400, undefined, 'CF_TOKEN_REQUIRED');
+  if (!config?.accountId) throw new DeployError('Cloudflare account ID is required.', 400, undefined, 'CF_ACCOUNT_ID_REQUIRED');
+  if (!config?.projectName) throw new DeployError('Cloudflare Pages project name could not be generated.', 400, undefined, 'CF_PROJECT_NAME_UNRESOLVED');
   return findCloudflarePagesDomain(config, hostname);
 }
 
@@ -1054,6 +1054,8 @@ async function uploadCloudflarePagesAssets(uploadToken: string, files: DeployFil
       throw new DeployError(
         `Cloudflare Pages assets must be ${formatMib(CLOUDFLARE_PAGES_ASSET_MAX_BYTES)} or smaller: ${file.file} is ${formatMib(data.length)}.`,
         400,
+        undefined,
+        'CF_ASSET_TOO_LARGE',
       );
     }
     const hash = cloudflarePagesAssetHash({ ...file, data });
@@ -1070,7 +1072,7 @@ async function uploadCloudflarePagesAssets(uploadToken: string, files: DeployFil
   if (missing.length > 0) {
     const missingFiles = missing.map((hash) => {
       const file = uniqueFiles.get(hash);
-      if (!file) throw new DeployError(`Cloudflare reported an unknown asset hash: ${hash}`, 502);
+      if (!file) throw new DeployError(`Cloudflare reported an unknown asset hash: ${hash}`, 502, undefined, 'CF_UNKNOWN_ASSET_HASH');
       return {
         ...file,
         hash,
@@ -1813,12 +1815,12 @@ function vercelTeamQuery(config: DeployConfig) {
 }
 
 function cloudflareAccountPagesProjectsUrl(config: DeployConfig) {
-  if (!config.accountId) throw new DeployError('Cloudflare account ID is required.', 400);
+  if (!config.accountId) throw new DeployError('Cloudflare account ID is required.', 400, undefined, 'CF_ACCOUNT_ID_REQUIRED');
   return `${CLOUDFLARE_API}/accounts/${encodeURIComponent(config.accountId)}/pages/projects`;
 }
 
 function cloudflarePagesProjectUrl(config: DeployConfig, suffix = '') {
-  if (!config.projectName) throw new DeployError('Cloudflare Pages project name could not be generated.', 400);
+  if (!config.projectName) throw new DeployError('Cloudflare Pages project name could not be generated.', 400, undefined, 'CF_PROJECT_NAME_UNRESOLVED');
   const base = `${cloudflareAccountPagesProjectsUrl(config)}/${encodeURIComponent(config.projectName)}`;
   return suffix ? `${base}/${suffix}` : base;
 }
@@ -1861,7 +1863,7 @@ async function readCloudflareJson(resp: Response): Promise<JsonObject> {
   try {
     return await resp.json() as JsonObject;
   } catch {
-    throw new DeployError('Cloudflare returned a non-JSON response.', resp.status || 502);
+    throw new DeployError('Cloudflare returned a non-JSON response.', resp.status || 502, undefined, 'CF_BAD_RESPONSE');
   }
 }
 
@@ -1904,7 +1906,7 @@ async function readVercelJson(resp: Response): Promise<JsonObject> {
   try {
     return await resp.json() as JsonObject;
   } catch {
-    throw new DeployError('Vercel returned a non-JSON response.', resp.status || 502);
+    throw new DeployError('Vercel returned a non-JSON response.', resp.status || 502, undefined, 'VERCEL_BAD_RESPONSE');
   }
 }
 
@@ -1915,7 +1917,7 @@ function cloudflareError(json: JsonObject, status: number, fallback: string) {
     json?.message ||
     fallback ||
     `Cloudflare request failed (${status}).`;
-  return new DeployError(message, status, json);
+  return new DeployError(message, status, json, 'PROVIDER_ERROR');
 }
 
 function isCloudflareAlreadyExists(body: unknown) {
@@ -1938,9 +1940,9 @@ function vercelError(json: JsonObject, status: number) {
   const code = json?.error?.code;
   const message = json?.error?.message || json?.message || `Vercel request failed (${status}).`;
   if (code === 'forbidden' || /permission/i.test(message)) {
-    return new DeployError("You don't have permission to create a project.", status, json);
+    return new DeployError("You don't have permission to create a project.", status, json, 'PROVIDER_FORBIDDEN');
   }
-  return new DeployError(message, status, json);
+  return new DeployError(message, status, json, 'PROVIDER_ERROR');
 }
 
 function deploymentUrl(json: JsonObject | null | undefined) {

--- a/apps/daemon/src/routes/deploy.ts
+++ b/apps/daemon/src/routes/deploy.ts
@@ -9,6 +9,18 @@ export interface RegisterDeployRoutesDeps extends RouteDeps<'db' | 'http' | 'pat
 export function registerDeployRoutes(app: Express, ctx: RegisterDeployRoutesDeps) {
   const { db } = ctx;
   const { sendApiError } = ctx.http;
+
+  /**
+   * A DeployError now carries a specific `code` (MISSING_REFERENCES,
+   * CF_ASSET_TOO_LARGE, VERCEL_TOKEN_REQUIRED, …). Pass it through instead of
+   * flattening every failure to BAD_REQUEST: the client mirrors the envelope
+   * code into `artifact_deploy_result.error_code`, so without this every
+   * distinct cause — missing token, non-HTML file, unresolved asset reference,
+   * oversized asset — collapsed into one opaque HTTP_400 bucket.
+   */
+  const deployErrorCodeFor = (err: any, status: number): string =>
+    (err instanceof DeployError && err.code) ||
+    (status === 404 ? 'FILE_NOT_FOUND' : 'BAD_REQUEST');
   const { PROJECTS_DIR } = ctx.paths;
   const { randomUUID } = ctx.ids;
   const { getProject } = ctx.projectStore;
@@ -57,7 +69,7 @@ export function registerDeployRoutes(app: Express, ctx: RegisterDeployRoutesDeps
         err instanceof DeployError && err.details
           ? { details: err.details }
           : {};
-      sendApiError(res, status, 'BAD_REQUEST', String(err?.message || err), init);
+      sendApiError(res, status, deployErrorCodeFor(err, status), String(err?.message || err), init);
     }
   });
 
@@ -181,7 +193,7 @@ export function registerDeployRoutes(app: Express, ctx: RegisterDeployRoutesDeps
       sendApiError(
         res,
         status,
-        status === 404 ? 'FILE_NOT_FOUND' : 'BAD_REQUEST',
+        deployErrorCodeFor(err, status),
         String(err?.message || err),
         init,
       );
@@ -224,7 +236,7 @@ export function registerDeployRoutes(app: Express, ctx: RegisterDeployRoutesDeps
       sendApiError(
         res,
         status,
-        status === 404 ? 'FILE_NOT_FOUND' : 'BAD_REQUEST',
+        deployErrorCodeFor(err, status),
         String(err?.message || err),
       );
     }

--- a/apps/daemon/src/routes/deploy.ts
+++ b/apps/daemon/src/routes/deploy.ts
@@ -9,6 +9,10 @@ export interface RegisterDeployRoutesDeps extends RouteDeps<'db' | 'http' | 'pat
 export function registerDeployRoutes(app: Express, ctx: RegisterDeployRoutesDeps) {
   const { db } = ctx;
   const { sendApiError } = ctx.http;
+  const { PROJECTS_DIR } = ctx.paths;
+  const { randomUUID } = ctx.ids;
+  const { getProject } = ctx.projectStore;
+  const { VERCEL_PROVIDER_ID, CLOUDFLARE_PAGES_PROVIDER_ID, isDeployProviderId, publicDeployConfigForProvider, readDeployConfig, writeDeployConfig, listCloudflarePagesZones, DeployError, listDeployments, publicDeployments, getDeployment, buildDeployFileSet, cloudflarePagesProjectNameForDeploy, deployToCloudflarePages, deployToVercel, upsertDeployment, publicDeployment, cloudflarePagesDeploymentMetadata, prepareDeployPreflight } = ctx.deploy;
 
   /**
    * A DeployError now carries a specific `code` (MISSING_REFERENCES,
@@ -17,14 +21,17 @@ export function registerDeployRoutes(app: Express, ctx: RegisterDeployRoutesDeps
    * code into `artifact_deploy_result.error_code`, so without this every
    * distinct cause — missing token, non-HTML file, unresolved asset reference,
    * oversized asset — collapsed into one opaque HTTP_400 bucket.
+   *
+   * Provider transport failures deliberately arrive WITHOUT a code (see
+   * cloudflareError / vercelError in apps/daemon/src/deploy.ts): they fall back
+   * to the generic envelope code so the client keeps bucketing them by the real
+   * provider status (HTTP_403 / HTTP_429 / HTTP_502) instead of collapsing
+   * auth, quota and upstream faults into one.
    */
   const deployErrorCodeFor = (err: any, status: number): string =>
     (err instanceof DeployError && err.code) ||
     (status === 404 ? 'FILE_NOT_FOUND' : 'BAD_REQUEST');
-  const { PROJECTS_DIR } = ctx.paths;
-  const { randomUUID } = ctx.ids;
-  const { getProject } = ctx.projectStore;
-  const { VERCEL_PROVIDER_ID, CLOUDFLARE_PAGES_PROVIDER_ID, isDeployProviderId, publicDeployConfigForProvider, readDeployConfig, writeDeployConfig, listCloudflarePagesZones, DeployError, listDeployments, publicDeployments, getDeployment, buildDeployFileSet, cloudflarePagesProjectNameForDeploy, deployToCloudflarePages, deployToVercel, upsertDeployment, publicDeployment, cloudflarePagesDeploymentMetadata, prepareDeployPreflight } = ctx.deploy;
+
   // ---- Deploy --------------------------------------------------------------
 
   app.get('/api/deploy/config', async (req, res) => {
@@ -54,7 +61,7 @@ export function registerDeployRoutes(app: Express, ctx: RegisterDeployRoutesDeps
       const body = await writeDeployConfig(providerId, input);
       res.json(body);
     } catch (err: any) {
-      sendApiError(res, 400, 'BAD_REQUEST', String(err?.message || err));
+      sendApiError(res, 400, deployErrorCodeFor(err, 400), String(err?.message || err));
     }
   });
 

--- a/apps/daemon/tests/deploy-routes.test.ts
+++ b/apps/daemon/tests/deploy-routes.test.ts
@@ -1280,6 +1280,118 @@ describe('deploy provider routes', () => {
     }
   });
 
+  // The other half of the same telemetry contract: a failure the provider
+  // rejected is classified by ITS HTTP status client-side (HTTP_403 /
+  // HTTP_429 / HTTP_502), and the client only falls back to that status when
+  // the envelope code is generic. So the provider catch-alls must NOT stamp a
+  // structured code — doing so would fold auth, quota and upstream faults into
+  // one bucket, which is coarser than what production already had.
+  it('leaves a provider-rejected deploy on the generic envelope code so the client keeps status bucketing', async () => {
+    const stateRoot = await mkdtemp(path.join(os.tmpdir(), 'od-deploy-route-provider-status-'));
+    const priorStateRoot = process.env.OD_USER_STATE_DIR;
+    process.env.OD_USER_STATE_DIR = stateRoot;
+    try {
+      const projectId = await setupProjectAndVercelConfig('provider-status', 'Provider status test');
+      const realFetch = globalThis.fetch;
+      const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+        if (url.startsWith(baseUrl)) return realFetch(input, init);
+        if (url.includes('/v13/deployments')) {
+          return new Response(JSON.stringify({ error: { code: 'too_many_requests', message: 'Too many requests.' } }), {
+            status: 429,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+      });
+      vi.stubGlobal('fetch', fetchMock);
+      try {
+        const resp = await realFetch(`${baseUrl}/api/projects/${projectId}/deploy`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ fileName: 'index.html', providerId: VERCEL_PROVIDER_ID }),
+        });
+        const text = await resp.text();
+        expect(resp.status, text).toBe(429);
+        const body = JSON.parse(text) as { error?: { code?: string } };
+        expect(body.error?.code).toBe('BAD_REQUEST');
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    } finally {
+      if (priorStateRoot === undefined) delete process.env.OD_USER_STATE_DIR;
+      else process.env.OD_USER_STATE_DIR = priorStateRoot;
+      await rm(stateRoot, { recursive: true, force: true });
+    }
+  });
+
+  // A provider failure whose CAUSE is known — not merely its status — still
+  // earns a specific code.
+  it('reports PROVIDER_FORBIDDEN when the provider names a permission failure', async () => {
+    const stateRoot = await mkdtemp(path.join(os.tmpdir(), 'od-deploy-route-provider-forbidden-'));
+    const priorStateRoot = process.env.OD_USER_STATE_DIR;
+    process.env.OD_USER_STATE_DIR = stateRoot;
+    try {
+      const projectId = await setupProjectAndVercelConfig('provider-forbidden', 'Provider forbidden test');
+      const realFetch = globalThis.fetch;
+      const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+        if (url.startsWith(baseUrl)) return realFetch(input, init);
+        if (url.includes('/v13/deployments')) {
+          return new Response(JSON.stringify({ error: { code: 'forbidden', message: 'Not authorized.' } }), {
+            status: 403,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+      });
+      vi.stubGlobal('fetch', fetchMock);
+      try {
+        const resp = await realFetch(`${baseUrl}/api/projects/${projectId}/deploy`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ fileName: 'index.html', providerId: VERCEL_PROVIDER_ID }),
+        });
+        const text = await resp.text();
+        expect(resp.status, text).toBe(403);
+        const body = JSON.parse(text) as { error?: { code?: string } };
+        expect(body.error?.code).toBe('PROVIDER_FORBIDDEN');
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    } finally {
+      if (priorStateRoot === undefined) delete process.env.OD_USER_STATE_DIR;
+      else process.env.OD_USER_STATE_DIR = priorStateRoot;
+      await rm(stateRoot, { recursive: true, force: true });
+    }
+  });
+
+  // The config-save route is the only place CF_TOKEN_REQUIRED can surface, so
+  // it needs the same passthrough as the deploy route — otherwise the code is
+  // dead on arrival.
+  it('surfaces CF_TOKEN_REQUIRED when saving a Cloudflare Pages config without a token', async () => {
+    const stateRoot = await mkdtemp(path.join(os.tmpdir(), 'od-deploy-route-cf-token-'));
+    const priorStateRoot = process.env.OD_USER_STATE_DIR;
+    process.env.OD_USER_STATE_DIR = stateRoot;
+    try {
+      const resp = await fetch(`${baseUrl}/api/deploy/config`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ providerId: CLOUDFLARE_PAGES_PROVIDER_ID, accountId: 'acct-1' }),
+      });
+      const text = await resp.text();
+      expect(resp.status, text).toBe(400);
+      const body = JSON.parse(text) as { error?: { code?: string } };
+      expect(body.error?.code).toBe('CF_TOKEN_REQUIRED');
+    } finally {
+      if (priorStateRoot === undefined) delete process.env.OD_USER_STATE_DIR;
+      else process.env.OD_USER_STATE_DIR = priorStateRoot;
+      await rm(stateRoot, { recursive: true, force: true });
+    }
+  });
+
   it('rejects vercel-self target=production with 400 BAD_REQUEST before attempting a deploy', async () => {
     const stateRoot = await mkdtemp(path.join(os.tmpdir(), 'od-deploy-route-vercel-prod-reject-'));
     const priorStateRoot = process.env.OD_USER_STATE_DIR;

--- a/apps/daemon/tests/deploy-routes.test.ts
+++ b/apps/daemon/tests/deploy-routes.test.ts
@@ -1247,6 +1247,39 @@ describe('deploy provider routes', () => {
     });
   }
 
+  // Every deploy failure used to flatten to the envelope's BAD_REQUEST, so a
+  // missing token, a non-HTML file, an unresolved asset reference and an
+  // oversized asset were indistinguishable once the client mirrored the code
+  // into `artifact_deploy_result.error_code` — in production that collapsed
+  // into one opaque HTTP_400 bucket we could not act on. Distinct causes must
+  // carry distinct codes.
+  it('surfaces a specific error code for a non-HTML deploy instead of a generic BAD_REQUEST', async () => {
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR is required for daemon route tests');
+    const stateRoot = await mkdtemp(path.join(os.tmpdir(), 'od-deploy-route-error-code-'));
+    const priorStateRoot = process.env.OD_USER_STATE_DIR;
+    process.env.OD_USER_STATE_DIR = stateRoot;
+    try {
+      const projectId = await setupProjectAndVercelConfig('deploy-error-code', 'Deploy error code test');
+      await writeFile(path.join(dataDir, 'projects', projectId, 'notes.txt'), 'not html');
+
+      const resp = await fetch(`${baseUrl}/api/projects/${projectId}/deploy`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ fileName: 'notes.txt', providerId: VERCEL_PROVIDER_ID }),
+      });
+      const text = await resp.text();
+      expect(resp.status, text).toBe(400);
+      const body = JSON.parse(text) as { error?: { code?: string; message?: string } };
+      expect(body.error?.code).toBe('NOT_HTML');
+      expect(body.error?.message).toMatch(/HTML/i);
+    } finally {
+      if (priorStateRoot === undefined) delete process.env.OD_USER_STATE_DIR;
+      else process.env.OD_USER_STATE_DIR = priorStateRoot;
+      await rm(stateRoot, { recursive: true, force: true });
+    }
+  });
+
   it('rejects vercel-self target=production with 400 BAD_REQUEST before attempting a deploy', async () => {
     const stateRoot = await mkdtemp(path.join(os.tmpdir(), 'od-deploy-route-vercel-prod-reject-'));
     const priorStateRoot = process.env.OD_USER_STATE_DIR;

--- a/apps/web/src/analytics/deploy-error-code.ts
+++ b/apps/web/src/analytics/deploy-error-code.ts
@@ -18,11 +18,13 @@
  * Mirrors apps/web/src/analytics/export-error-code.ts (issue-#5220 pattern).
  */
 
-// The daemon deploy route (apps/daemon/src/routes/deploy.ts) collapses every
-// non-404 failure's code to `BAD_REQUEST` (and 404 to `FILE_NOT_FOUND`) while
-// keeping the real provider HTTP status + message. Those envelope codes carry no
-// signal, so they must NOT win over status/message-based bucketing — treated as
-// "no structured code" both at the throw site and here as a safety net.
+// The daemon deploy route (apps/daemon/src/routes/deploy.ts) names the failures
+// it can classify itself (NOT_HTML, MISSING_REFERENCES, CF_ASSET_TOO_LARGE, …)
+// and falls back to `BAD_REQUEST` (404 → `FILE_NOT_FOUND`) for everything else —
+// notably a provider transport failure, where the real signal is the HTTP status
+// it keeps on the response. Those fallback codes carry no signal, so they must
+// NOT win over status/message-based bucketing — treated as "no structured code"
+// both at the throw site and here as a safety net.
 export const GENERIC_DEPLOY_ENVELOPE_CODES = new Set(['BAD_REQUEST', 'FILE_NOT_FOUND', 'INTERNAL', 'INTERNAL_ERROR', 'UNKNOWN']);
 
 export function deployErrorCode(err: unknown): string {

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -1695,11 +1695,13 @@ export async function deployProjectFile(
     const message = payload?.error?.message || payload?.message || `Deploy failed (${resp.status})`;
     // Preserve a queryable failure code for analytics (`deployErrorCode` reads
     // `.code` first). The daemon deploy route (apps/daemon/src/routes/deploy.ts)
-    // collapses every non-404 failure's code to a generic `BAD_REQUEST` (and 404
-    // to `FILE_NOT_FOUND`) while keeping the REAL provider HTTP status on the
-    // response and the real message in the body — so ignore those envelope codes
-    // and fall back to `HTTP_${resp.status}`, which then buckets as HTTP_403 /
-    // HTTP_429 / HTTP_500 instead of collapsing every failure into one code.
+    // names the causes it can classify (NOT_HTML, MISSING_REFERENCES, …) and
+    // falls back to a generic `BAD_REQUEST` (404 → `FILE_NOT_FOUND`) for a
+    // provider transport failure, where it keeps the REAL provider HTTP status
+    // on the response and the real message in the body — so ignore those generic
+    // envelope codes and fall back to `HTTP_${resp.status}`, which then buckets
+    // as HTTP_403 / HTTP_429 / HTTP_500 instead of collapsing every failure into
+    // one code.
     const rawCode = payload?.error?.code || payload?.code;
     const code = rawCode && !GENERIC_DEPLOY_ENVELOPE_CODES.has(rawCode) ? rawCode : `HTTP_${resp.status}`;
     throw Object.assign(new Error(message), { code });


### PR DESCRIPTION
## Why

**Author use case:** I was drilling into the daily stability report and found the artifact deploy feature failing at **~45%** on 0.15.1 (111/246 over 3 days). I tried to find the root cause and couldn't — **57% of those failures (63) report a single `error_code: HTTP_400`**, with no way to tell them apart.

**The pain:** That `HTTP_400` is not a malformed request. It's our own envelope collapsing every distinct cause into one code. `routes/deploy.ts` stamped every `DeployError` as `BAD_REQUEST`, and **none of the 33 `new DeployError(...)` sites passed the `code` argument the constructor has always accepted**. So a missing Vercel token, a non-HTML file, an unresolved asset reference, an oversized Cloudflare asset and a zone-config mistake are all indistinguishable in production telemetry. We cannot fix the dominant cause because we cannot see it.

I explicitly checked whether this was a code regression: the daemon deploy path is **byte-identical across v0.14.1 → v0.15.0 → v0.15.1**, and the two structural explanations I could test in PostHog are both refuted — `web_clone` projects fail *below* average (36.4%, n=11), and first-time configurers fail at 47.6% vs 44.9% for already-configured users. So the honest position is: the rate is high and broad, and the next step is to make it attributable.

## What users will see

Nothing directly — no status, message or request shape changes. The payoff is on the next release: `artifact_deploy_result.error_code` starts splitting the HTTP_400 blob into causes we can act on, and the reader of a failed deploy gets a precise code rather than a generic one.

## What changed

- `apps/daemon/src/deploy.ts` — every `DeployError` thrown for a cause we can *name* now passes a specific code: `NOT_HTML`, `MISSING_REFERENCES`, `CF_ASSET_TOO_LARGE`, `VERCEL_TOKEN_REQUIRED`, `CF_TOKEN_REQUIRED`, `CF_ACCOUNT_ID_REQUIRED`, `CF_PROJECT_NAME_UNRESOLVED`, `CF_ZONE_REQUIRED/INVALID/MISMATCH/INACTIVE/PARTIAL`, `CF_SUBDOMAIN_INVALID`, `CF_DNS_RECORD_CONFLICT`, `CF_DOMAIN_ALREADY_BOUND`, `CF_UNKNOWN_ASSET_HASH`, `VERCEL_DEPLOY_FAILED`, `PROVIDER_FORBIDDEN`, …
- `apps/daemon/src/deploy.ts` — the **catch-all provider helpers deliberately carry no code**. `cloudflareError` and a generic `vercelError` describe a failure by its HTTP status, not its cause, so the client must keep bucketing them as `HTTP_403` / `HTTP_429` / `HTTP_502`. (First revision stamped them `PROVIDER_ERROR`, which folded auth, quota and upstream faults into one bucket — coarser than production already had. Caught in review, fixed, and now locked by a test.)
- `apps/daemon/src/routes/deploy.ts` — a `deployErrorCodeFor` helper passes `err.code` through instead of flattening to `BAD_REQUEST` (falling back to the old behavior when a code is absent). Applied on the deploy route, the zones route **and `PUT /api/deploy/config`** — that last one is the only path that raises `CF_TOKEN_REQUIRED` / `CF_ACCOUNT_ID_REQUIRED`, so without it those codes were dead on arrival.
- **No client behavior change needed** — `deployErrorCode` already prefers a structured `.code` and only falls back to `HTTP_${status}`. The two client comments that described the daemon as flattening *every* failure to `BAD_REQUEST` are updated, since that is no longer what it does.

## Bug fix verification

Every behavioral claim here has a route test that was **verified red before the fix and green after**, at the daemon HTTP boundary (`apps/daemon/tests/deploy-routes.test.ts`) — the cheapest layer that can see the envelope the client actually reads.

| Spec | Red (before) | Green (after) |
| --- | --- | --- |
| non-HTML deploy reports its own cause | `expected 'BAD_REQUEST' to be 'NOT_HTML'` | ✅ |
| provider rejection stays status-bucketed | `expected 'PROVIDER_ERROR' to be 'BAD_REQUEST'` | ✅ |
| config save surfaces the missing-token cause | `expected 'BAD_REQUEST' to be 'CF_TOKEN_REQUIRED'` | ✅ |

A fourth test pins the semantic exception: a provider failure whose *cause* is named (Vercel `forbidden`) still reports `PROVIDER_FORBIDDEN` rather than falling back to a status bucket.

**Production signal expected after this ships:** the `HTTP_400` bucket in `artifact_deploy_result.error_code` should split into the named local-validation codes above, while `HTTP_403` / `HTTP_429` / `HTTP_5xx` keep their current shape — that is the invariant the second test protects.

## Adjacent issues (deliberately not in this PR)

- **`slide_deck` deploys fail 6/6 (100%)** on 0.15.1. Once these codes ship we'll know which cause it is; fixing it blind now would be guesswork.
- **The all-or-nothing reference check** (`buildDeployFileSet` throws if *any* referenced file is missing, while `buildDeployFilePlan` already supports deploy-with-warning) is my leading hypothesis for the broad failure rate — but that's a product decision, not a telemetry fix.
- **`HTTP_403` (26 cases)** is a genuine provider auth rejection (revoked/insufficient-scope token) and needs a re-auth UX, separate from this.
- **`deploy-error-code.ts` `\b[45]\d\d\b`** can misread `missing: 404.html` as `HTTP_404`; only affects the message-fallback path.
- The `check-link` route still flattens to `BAD_REQUEST`. Its failures are not mirrored into `artifact_deploy_result.error_code`, so it is out of scope here.

## Surface area

- [x] Daemon (`apps/daemon`) — error codes + envelope passthrough
- [x] Web (`apps/web`) — comment-only; no behavior change
- [x] Tests — 4 route specs (3 red-first) + 114 existing deploy tests pass unchanged
- [ ] `od` CLI — n/a, no user-invokable capability added
- [ ] Contracts / i18n / env vars — none

## Validation

`pnpm --filter @open-design/daemon typecheck` exit 0 · `pnpm --filter @open-design/web typecheck` exit 0 · **full daemon suite: 672 files / 8598 tests passed, 0 failed, exit 0** · `deploy-error-code` + `registry` web tests **90 passed** · red→green verified per the table above · `pnpm guard` clean · rebased onto current `main`.

**Runtime + UI validation** (details in the PR comments): driven against an isolated local runtime and the **real Cloudflare / Vercel APIs**, both through `curl` at the HTTP boundary and through the actual browser deploy dialog. A Cloudflare rejection stays on the generic envelope code (`BAD_REQUEST` / 400 → client buckets `HTTP_400`) while a Vercel permission rejection reports `PROVIDER_FORBIDDEN` / 403 — and both render correctly in the deploy dialog, since the UI reads `err.message` and only analytics consumes the code.
