### PR TITLE
feat(mcp): add guarded Latchshot template

### DIFF
--- a/apps/daemon/src/mcp-config.ts
+++ b/apps/daemon/src/mcp-config.ts
@@ -869,6 +869,28 @@ export const MCP_TEMPLATES: McpTemplate[] = [
     ],
   },
   {
+    id: 'latchshot',
+    label: 'Latchshot (guarded public-page capture)',
+    description:
+      'Hosted Streamable HTTP screenshot and PDF API for publicly reachable HTTP(S) pages on ports 80/443. Returns PNG, JPEG and PDF content inline without a local browser process. Use it for a guarded public-page capture path; it does not support authenticated or private-network targets, selectors, scripts, proxies, browser sessions or provider-hosted result URLs. Get a Free API key at latchshot.fly.dev.',
+    transport: 'http',
+    authMode: 'none',
+    category: 'web-capture',
+    homepage: 'https://latchshot.fly.dev/guides/screenshot-mcp-server.html',
+    example:
+      'Capture a 1280×800 PNG of https://example.com and return the image inline.',
+    url: 'https://latchshot.fly.dev/mcp',
+    headerFields: [
+      {
+        key: 'Authorization',
+        label: 'Authorization (Bearer <Latchshot API key>)',
+        required: true,
+        placeholder: 'Bearer ls_live_...',
+        secret: true,
+      },
+    ],
+  },
+  {
     id: 'pagecast',
     label: 'Pagecast (browser → demo GIF / MP4)',
     description:

--- a/apps/daemon/tests/mcp-config.test.ts
+++ b/apps/daemon/tests/mcp-config.test.ts
@@ -905,6 +905,20 @@ describe('MCP_TEMPLATES', () => {
     expect(key?.secret).toBe(true);
   });
 
+  it('includes the guarded Latchshot hosted-HTTP template with required Authorization', () => {
+    const tpl = MCP_TEMPLATES.find((t) => t.id === 'latchshot');
+    expect(tpl).toBeDefined();
+    expect(tpl?.category).toBe('web-capture');
+    expect(tpl?.transport).toBe('http');
+    expect(tpl?.authMode).toBe('none');
+    expect(tpl?.url).toBe('https://latchshot.fly.dev/mcp');
+    expect(tpl?.description).toContain('publicly reachable HTTP(S) pages');
+    expect(tpl?.description).toContain('does not support authenticated or private-network targets');
+    const auth = tpl?.headerFields?.find((f) => f.key === 'Authorization');
+    expect(auth?.required).toBe(true);
+    expect(auth?.secret).toBe(true);
+  });
+
   it('includes the 21st.dev Magic UI-component template (positional API_KEY arg)', () => {
     const tpl = MCP_TEMPLATES.find((t) => t.id === '21st-dev-magic');
     expect(tpl).toBeDefined();


### PR DESCRIPTION
Fixes #5898

## Why

I maintain Latchshot and opened #5898 before writing code so the repository could decide whether a vendor-maintained preset belongs in the built-in picker. The maintainer response confirmed that its guarded hosted-HTTP contract fits the existing `web-capture` surface and invited this focused PR.

The current category covers local screenshot capture, ScreenshotOne's broader managed feature set, and interactive demo recording. This adds a narrower hosted option for users who want direct screenshot/PDF artifacts from publicly reachable pages without running a local browser process.

Latchshot complements rather than replaces ScreenshotOne: its template explicitly excludes authenticated/private-network targets, selectors, scripts, proxies, browser sessions, and provider-hosted result URLs. Users who need those broader controls should keep using ScreenshotOne.

## What users will see

Settings → External MCP servers → Add server → Web capture includes a new **Latchshot (guarded public-page capture)** entry. Selecting it pre-fills:

- the Streamable HTTP endpoint `https://latchshot.fly.dev/mcp`;
- manual auth mode with one required, secret `Authorization` header;
- a Bearer-key placeholder and the public setup guide;
- an example public-page PNG capture;
- the public-page-only and unsupported-capability boundaries in the description.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

The UI box is the closest match because this creates a new selectable entry in the existing picker. It changes no UI component or layout, API shape, default, dependency, or automatic network behavior.

## Screenshots

Not included. The existing picker UI and layout are unchanged; this PR supplies one additional template row through the existing data path.

## Bug fix verification

Not a bug fix.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @open-design/daemon exec vitest run tests/mcp-config.test.ts` — 86/86 passed
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon build`
- `pnpm guard`
- `pnpm typecheck` — completed with zero errors; the landing-page checker reported its existing hints
- Public contract check: the guide returned HTTP 200 and unauthenticated MCP initialization returned HTTP 401
