### PR TITLE
fix(daemon): keep canceled runs canceled after late agent errors

### DIFF
--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -102,6 +102,7 @@ export function createChatRunService({
       error: null,
       errorCode: null,
       cancelRequested: false,
+      runtimeFailureObservedBeforeCancellation: false,
       retryRestartTimer: null,
       // First failure that triggered a same-run retry. The next attempt creates
       // a fresh startChatRun closure and clears run.error/errorCode, so keep the
@@ -338,9 +339,9 @@ export function createChatRunService({
     if (!run.childExitObservedAt) run.childExitObservedAt = Date.now();
   };
 
-  const waitForChildExit = (child, timeoutMs) => {
+  const waitForChildExit = (child, timeoutMs, { closeOnly = false } = {}) => {
     if (!child) return Promise.resolve(true);
-    if (childHasExited(child)) return Promise.resolve(true);
+    if (!closeOnly && childHasExited(child)) return Promise.resolve(true);
     return new Promise((resolve) => {
       let settled = false;
       const done = (exited) => {
@@ -348,15 +349,29 @@ export function createChatRunService({
         settled = true;
         clearTimeout(timer);
         child.off?.('close', onClose);
-        child.off?.('exit', onClose);
+        if (!closeOnly) child.off?.('exit', onClose);
         resolve(exited);
       };
       const onClose = () => done(true);
       const timer = setTimeout(() => done(false), timeoutMs);
       timer.unref?.();
       child.once?.('close', onClose);
-      child.once?.('exit', onClose);
+      if (!closeOnly) child.once?.('exit', onClose);
     });
+  };
+
+  // A runtime error can be emitted while the child is still draining stdout.
+  // When that happened before cancellation, wait for `close` so server.ts's
+  // earlier close listener can classify and finalize the failure before the
+  // cancel route applies its canceled fallback. Ordinary cancellation keeps
+  // the faster exit-or-close behavior.
+  const waitForCanceledChildExit = (run, timeoutMs) => {
+    if (TERMINAL_RUN_STATUSES.has(run.status)) return Promise.resolve(true);
+    return waitForChildExit(
+      run.child,
+      timeoutMs,
+      { closeOnly: run.runtimeFailureObservedBeforeCancellation === true },
+    );
   };
 
   const forceWaitMs = () => {
@@ -497,24 +512,24 @@ export function createChatRunService({
         // Signal fallback below owns eventual process termination.
       }
       const graceMs = Number(process.env.PI_ABORT_GRACE_MS) || 3000;
-      if (await waitForChildExit(run.child, graceMs)) {
+      if (await waitForCanceledChildExit(run, graceMs)) {
         return finishCanceledFromChildState(run, 'SIGTERM');
       }
       killChild(run, 'SIGTERM');
-      if (await waitForChildExit(run.child, graceMs)) {
+      if (await waitForCanceledChildExit(run, graceMs)) {
         return finishCanceledFromChildState(run, 'SIGTERM');
       }
       killChild(run, 'SIGKILL');
-      await waitForChildExit(run.child, forceWaitMs());
+      await waitForCanceledChildExit(run, forceWaitMs());
       return finishCanceledFromChildState(run, 'SIGKILL');
     }
 
     killChild(run, 'SIGTERM');
-    if (await waitForChildExit(run.child, cancelGraceMs())) {
+    if (await waitForCanceledChildExit(run, cancelGraceMs())) {
       return finishCanceledFromChildState(run, 'SIGTERM');
     }
     killChild(run, 'SIGKILL');
-    await waitForChildExit(run.child, forceWaitMs());
+    await waitForCanceledChildExit(run, forceWaitMs());
     return finishCanceledFromChildState(run, 'SIGKILL');
   };
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -6814,6 +6814,12 @@ export async function startServer({
     // plain streams (most other CLIs) we forward raw chunks unchanged so
     // the browser can append them to the assistant's text buffer.
     let agentStreamError = null;
+    // Preserve whether a latched error predates a later cancel request. The
+    // close handler runs after cancel() has already flipped cancelRequested,
+    // so consulting only the current flag loses the ordering of those events.
+    let agentStreamErrorObservedBeforeCancellation = false;
+    let acpFatalErrorObservedBeforeCancellation = false;
+    run.runtimeFailureObservedBeforeCancellation = false;
     // Holds buffered plain-text stdout chunks for agents (currently
     // antigravity) where we need to inspect the full output at close
     // time before deciding whether to forward it. The auth-prompt guard
@@ -7080,6 +7086,8 @@ export async function startServer({
           String(ev.message || 'Agent stream error'),
           failureText,
         );
+        agentStreamErrorObservedBeforeCancellation = true;
+        run.runtimeFailureObservedBeforeCancellation = true;
         clearInactivityWatchdog();
         const authFailure = classifyAgentAuthFailure(agentId, failureText);
         if (authFailure?.status === 'missing') {
@@ -7224,6 +7232,8 @@ export async function startServer({
           const serviceCode = classifyAgentServiceFailure(failureText);
           agentStreamError = diagnostic?.message
             ?? rewriteKnownAgentStreamError(agentId, message, failureText);
+          agentStreamErrorObservedBeforeCancellation = true;
+          run.runtimeFailureObservedBeforeCancellation = true;
           send('error', createSseErrorPayload(
             diagnostic?.code ?? serviceCode ?? 'AGENT_EXECUTION_FAILED',
             agentStreamError,
@@ -7319,9 +7329,13 @@ export async function startServer({
           if (channel === 'agent') {
             sendAgentEvent(payload);
           } else if (channel === 'error') {
+            if (run.cancelRequested) return;
             if (agentStreamError) return;
             flushVisibleAgentStderr();
             agentStreamError = String(payload?.message || 'Pi session error');
+            agentStreamErrorObservedBeforeCancellation = true;
+            acpFatalErrorObservedBeforeCancellation = true;
+            run.runtimeFailureObservedBeforeCancellation = true;
             const piErrorCode = typeof payload?.code === 'string' ? payload.code : null;
             if (piErrorCode) {
               run.errorCode = piErrorCode;
@@ -7363,6 +7377,11 @@ export async function startServer({
         onCliReady: () => noteCliReadyAt(),
         onSessionInit: () => noteSessionInitDoneAt(),
         send: (event, data) => {
+          if (event === 'error') {
+            if (run.cancelRequested) return;
+            acpFatalErrorObservedBeforeCancellation = true;
+            run.runtimeFailureObservedBeforeCancellation = true;
+          }
           if (event === 'agent') {
             lastAgentEventPhase = summarizeAgentEventForInactivity(data);
           }
@@ -7585,13 +7604,13 @@ export async function startServer({
         ));
         return design.runs.finish(run, 'failed', code ?? 1, signal ?? null);
       }
-      if (!run.cancelRequested && acpSession?.hasFatalError()) {
+      if (acpFatalErrorObservedBeforeCancellation && acpSession?.hasFatalError()) {
         markRpcCloseReason('fatal_rpc_error');
         return finishWithRetryDecision('failed', code ?? 1, signal ?? null);
       }
       parseBufferedAntigravityGeminiJsonEventStream();
       flushAgentTitleMarkerBuffer();
-      if (!run.cancelRequested && agentStreamError) {
+      if (agentStreamErrorObservedBeforeCancellation && agentStreamError) {
         markRpcCloseReason('stream_error');
         return finishWithRetryDecision('failed', code === 0 ? 1 : (code ?? 1), signal ?? null);
       }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -7063,6 +7063,10 @@ export async function startServer({
 
     const sendAgentEvent = (ev) => {
       if (ev?.type === 'error') {
+        // Cancellation is the terminal user intent. Some CLIs flush a final
+        // error record while reacting to SIGTERM; treating that late frame as
+        // a run failure races the cancel route and can make it return failed.
+        if (run.cancelRequested) return;
         if (agentStreamError) return;
         flushVisibleAgentStderr();
         const failureText = [
@@ -7166,6 +7170,10 @@ export async function startServer({
         // init/system line arrives well before the model's first token.
         noteCliReadyAt();
         if (ev?.type === 'error') {
+          // Claude commonly reports its SIGTERM shutdown as an assistant or
+          // result error frame. Once cancellation has been requested, that
+          // frame is shutdown noise rather than a new user-visible failure.
+          if (run.cancelRequested) return;
           if (agentStreamError) return;
           // Hold back a resume-failure error so the close handler's transparent
           // reseed stays invisible. An is_error result frame on a dead --resume
@@ -7480,12 +7488,25 @@ export async function startServer({
       emitVisibleAgentStderr(chunk);
     });
 
+    const finishCanceledIfRequested = (
+      code: number | null,
+      signal: NodeJS.Signals | null,
+    ): boolean => {
+      if (!run.cancelRequested) return false;
+      if (!design.runs.isTerminal(run.status)) {
+        markRpcCloseReason('cancel_requested');
+        finishWithRetryDecision('canceled', code, signal);
+      }
+      return true;
+    };
+
     child.on('error', (err) => {
       clearInactivityWatchdog();
       cleanupPromptFile();
       flushVisibleAgentStderr();
       revokeToolToken('child_exit');
       unregisterChatAgentEventSink();
+      if (finishCanceledIfRequested(1, null)) return;
       send('error', createSseErrorPayload('AGENT_EXECUTION_FAILED', err.message));
       finishWithRetryDecision('failed', 1, null);
     });
@@ -7564,13 +7585,13 @@ export async function startServer({
         ));
         return design.runs.finish(run, 'failed', code ?? 1, signal ?? null);
       }
-      if (acpSession?.hasFatalError()) {
+      if (!run.cancelRequested && acpSession?.hasFatalError()) {
         markRpcCloseReason('fatal_rpc_error');
         return finishWithRetryDecision('failed', code ?? 1, signal ?? null);
       }
       parseBufferedAntigravityGeminiJsonEventStream();
       flushAgentTitleMarkerBuffer();
-      if (agentStreamError) {
+      if (!run.cancelRequested && agentStreamError) {
         markRpcCloseReason('stream_error');
         return finishWithRetryDecision('failed', code === 0 ? 1 : (code ?? 1), signal ?? null);
       }

--- a/apps/daemon/tests/server-startup-smoke.test.ts
+++ b/apps/daemon/tests/server-startup-smoke.test.ts
@@ -1,6 +1,6 @@
 import type http from 'node:http';
 import { randomUUID } from 'node:crypto';
-import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { access, chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
@@ -32,6 +32,9 @@ type RunStatus = {
   error: string | null;
   errorCode: string | null;
   eventsLogPath: string;
+  cancelRequested?: boolean;
+  failureCategory?: string | null;
+  failureDetail?: string | null;
 };
 
 type RunListBody = {
@@ -370,6 +373,63 @@ describe('daemon startup route smoke', () => {
       const health = await fetch(`${started.url}/api/health`);
       expect(health.status).toBe(200);
       await expect(health.json()).resolves.toMatchObject({ ok: true });
+    } finally {
+      await clearAgentCliEnv(started.url);
+      await rm(binDir, { recursive: true, force: true });
+    }
+  });
+
+  it('[P0] keeps a user-canceled Claude run canceled when a late error frame arrives', async () => {
+    const binDir = await mkdtemp(join(tmpdir(), 'od-startup-cancel-error-bin-'));
+    try {
+      const readyFile = join(binDir, 'ready');
+      const claudeBin = await writeCancelErrorClaudeBin(
+        binDir,
+        'claude-cancel-error',
+        readyFile,
+      );
+      await putAppConfig(started.url, {
+        agentId: 'claude',
+        agentCliEnv: { claude: { CLAUDE_BIN: claudeBin } },
+      });
+
+      const runId = await createRun(started.url, {
+        caseId: `cancel_error_run_${randomUUID()}`,
+        agentId: 'claude',
+        message: 'cancel a Claude run that emits a late error frame',
+      });
+      await waitForFile(readyFile);
+
+      const cancel = await fetch(`${started.url}/api/runs/${encodeURIComponent(runId)}/cancel`, {
+        method: 'POST',
+      });
+      expect(cancel.status).toBe(200);
+      await expect(cancel.json()).resolves.toMatchObject({
+        ok: true,
+        run: {
+          id: runId,
+          status: 'canceled',
+          cancelRequested: true,
+        },
+      });
+
+      const canceled = await waitForRun(started.url, runId);
+      expect(canceled).toMatchObject({
+        id: runId,
+        status: 'canceled',
+        cancelRequested: true,
+        error: null,
+        errorCode: null,
+        failureCategory: null,
+        failureDetail: null,
+      });
+
+      const events = await readRunSse(started.url, runId);
+      expect(events).not.toContain('event: error');
+      expect(events).not.toContain('event: run_retry_attempted');
+      expect(events.match(/^event: end$/gmu)).toHaveLength(1);
+      expect(events).toContain('"status":"canceled"');
+      expect(events).not.toContain('"failure_detail":"stream_error"');
     } finally {
       await clearAgentCliEnv(started.url);
       await rm(binDir, { recursive: true, force: true });
@@ -844,6 +904,52 @@ setInterval(() => {}, 1000);
   return bin;
 }
 
+async function writeCancelErrorClaudeBin(
+  dir: string,
+  name: string,
+  readyFile: string,
+): Promise<string> {
+  const bin = join(dir, name);
+  await writeFile(bin, `#!/usr/bin/env node
+const fs = require('node:fs');
+function writeFrame(frame) {
+  fs.writeSync(1, JSON.stringify(frame) + '\\n');
+}
+if (process.argv.includes('--version')) {
+  console.log('claude 0.0.0-cancel-error-smoke');
+  process.exit(0);
+}
+if (process.argv.includes('--help')) {
+  console.log('Usage: claude -p [--include-partial-messages] [--add-dir DIR]');
+  process.exit(0);
+}
+process.on('SIGTERM', () => {
+  writeFrame({
+    type: 'assistant',
+    parent_tool_use_id: null,
+    error: 'canceled',
+    message: {
+      id: 'msg-cancel-error',
+      content: [],
+      stop_reason: null,
+    },
+  });
+  writeFrame({
+    type: 'result',
+    subtype: 'error_during_execution',
+    is_error: true,
+    result: 'Canceled by user',
+    stop_reason: null,
+  });
+  setTimeout(() => process.exit(1), 20);
+});
+fs.writeFileSync(${JSON.stringify(readyFile)}, 'ready');
+setInterval(() => {}, 1000);
+`, 'utf8');
+  await chmod(bin, 0o755);
+  return bin;
+}
+
 async function writeSuccessfulClaudeBin(dir: string, name: string): Promise<string> {
   const bin = join(dir, name);
   await writeFile(bin, `#!/usr/bin/env node
@@ -898,6 +1004,19 @@ function sseEventId(body: string, eventName: string): number {
 
 async function delay(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForFile(filePath: string): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 10_000) {
+    try {
+      await access(filePath);
+      return;
+    } catch {
+      await delay(25);
+    }
+  }
+  throw new Error(`file did not appear: ${filePath}`);
 }
 
 async function rmRecursiveWithRetry(target: string): Promise<void> {

--- a/apps/daemon/tests/server-startup-smoke.test.ts
+++ b/apps/daemon/tests/server-startup-smoke.test.ts
@@ -436,6 +436,63 @@ describe('daemon startup route smoke', () => {
     }
   });
 
+  it('[P0] keeps a Claude stream failure failed when cancellation follows the error', async () => {
+    const binDir = await mkdtemp(join(tmpdir(), 'od-startup-error-cancel-bin-'));
+    try {
+      const readyFile = join(binDir, 'ready');
+      const claudeBin = await writeCancelErrorClaudeBin(
+        binDir,
+        'claude-error-before-cancel',
+        readyFile,
+        'before-cancel',
+      );
+      await putAppConfig(started.url, {
+        agentId: 'claude',
+        agentCliEnv: { claude: { CLAUDE_BIN: claudeBin } },
+      });
+
+      const runId = await createRun(started.url, {
+        caseId: `error_cancel_run_${randomUUID()}`,
+        agentId: 'claude',
+        message: 'fail a Claude run before requesting cancellation',
+      });
+      await waitForFile(readyFile);
+      const errorEvents = await readRunSseUntil(started.url, runId, 'event: error');
+      expect(errorEvents).toContain('provider failed before cancellation');
+
+      const cancel = await fetch(`${started.url}/api/runs/${encodeURIComponent(runId)}/cancel`, {
+        method: 'POST',
+      });
+      expect(cancel.status).toBe(200);
+      await expect(cancel.json()).resolves.toMatchObject({
+        ok: true,
+        run: {
+          id: runId,
+          status: 'failed',
+          cancelRequested: true,
+        },
+      });
+
+      const failed = await waitForRun(started.url, runId);
+      expect(failed).toMatchObject({
+        id: runId,
+        status: 'failed',
+        cancelRequested: true,
+        failureDetail: 'stream_error',
+      });
+
+      const events = await readRunSse(started.url, runId);
+      expect(events).toContain('event: error');
+      expect(events).not.toContain('event: run_retry_attempted');
+      expect(events.match(/^event: end$/gmu)).toHaveLength(1);
+      expect(events).toContain('"status":"failed"');
+      expect(events).toContain('"failure_detail":"stream_error"');
+    } finally {
+      await clearAgentCliEnv(started.url);
+      await rm(binDir, { recursive: true, force: true });
+    }
+  });
+
   it('[P1] result packages preserve failed and canceled terminal status without inventing artifacts', async () => {
     const binDir = await mkdtemp(join(tmpdir(), 'od-startup-result-package-bin-'));
     try {
@@ -908,6 +965,7 @@ async function writeCancelErrorClaudeBin(
   dir: string,
   name: string,
   readyFile: string,
+  errorTiming: 'before-cancel' | 'after-cancel' = 'after-cancel',
 ): Promise<string> {
   const bin = join(dir, name);
   await writeFile(bin, `#!/usr/bin/env node
@@ -915,19 +973,11 @@ const fs = require('node:fs');
 function writeFrame(frame) {
   fs.writeSync(1, JSON.stringify(frame) + '\\n');
 }
-if (process.argv.includes('--version')) {
-  console.log('claude 0.0.0-cancel-error-smoke');
-  process.exit(0);
-}
-if (process.argv.includes('--help')) {
-  console.log('Usage: claude -p [--include-partial-messages] [--add-dir DIR]');
-  process.exit(0);
-}
-process.on('SIGTERM', () => {
+function writeErrorFrames(message) {
   writeFrame({
     type: 'assistant',
     parent_tool_use_id: null,
-    error: 'canceled',
+    error: message,
     message: {
       id: 'msg-cancel-error',
       content: [],
@@ -938,11 +988,27 @@ process.on('SIGTERM', () => {
     type: 'result',
     subtype: 'error_during_execution',
     is_error: true,
-    result: 'Canceled by user',
+    result: message,
     stop_reason: null,
   });
+}
+if (process.argv.includes('--version')) {
+  console.log('claude 0.0.0-cancel-error-smoke');
+  process.exit(0);
+}
+if (process.argv.includes('--help')) {
+  console.log('Usage: claude -p [--include-partial-messages] [--add-dir DIR]');
+  process.exit(0);
+}
+process.on('SIGTERM', () => {
+  if (${JSON.stringify(errorTiming)} === 'after-cancel') {
+    writeErrorFrames('Canceled by user');
+  }
   setTimeout(() => process.exit(1), 20);
 });
+if (${JSON.stringify(errorTiming)} === 'before-cancel') {
+  writeErrorFrames('provider failed before cancellation');
+}
 fs.writeFileSync(${JSON.stringify(readyFile)}, 'ready');
 setInterval(() => {}, 1000);
 `, 'utf8');
@@ -982,6 +1048,31 @@ async function readRunSse(url: string, runId: string, lastEventId?: number): Pro
   });
   expect(response.status).toBe(200);
   return await response.text();
+}
+
+async function readRunSseUntil(url: string, runId: string, marker: string): Promise<string> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+  let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+  try {
+    const response = await fetch(`${url}/api/runs/${encodeURIComponent(runId)}/events`, {
+      signal: controller.signal,
+    });
+    expect(response.status).toBe(200);
+    reader = response.body?.getReader();
+    if (!reader) throw new Error('run SSE response had no body');
+    const decoder = new TextDecoder();
+    let body = '';
+    while (!body.includes(marker)) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      body += decoder.decode(value, { stream: true });
+    }
+    return body;
+  } finally {
+    clearTimeout(timeout);
+    await reader?.cancel().catch(() => undefined);
+  }
 }
 
 function sseIds(body: string): number[] {


### PR DESCRIPTION
## Why

The 0.15.1 reliability review found that some runs recorded as execution failures were actually explicit user cancellations. When a user canceled an active Claude run, the CLI could flush a final assistant/result error while shutting down. That late frame raced the cancel route, latched a stream error, and let the close handler finish the run as failed before the existing cancel-aware classifier ran.

This caused a canceled run to be returned and telemetered as failed, could surface a false execution error in chat, and could make retry policy evaluate a run that the user had already stopped.

## What users will see

Canceling an active agent run now remains canceled even if the agent CLI emits a final error while reacting to SIGTERM. The run no longer surfaces a false execution error, retries because of the shutdown frame, or reports a `stream_error` failure classification.

## Surface area

- [ ] UI
- [ ] CLI / agent surface
- [ ] API / data contracts
- [ ] Design system / design tokens
- [ ] Extension points (`skills/`, `design-systems/`, `design-templates/`, `craft/`)
- [ ] Root dependencies
- [ ] Env vars
- [ ] i18n keys
- [x] Default behavior change
- [ ] None

## Screenshots

Not applicable — this is a daemon-only lifecycle fix with no UI surface change.

## Bug fix verification

- Red spec: `apps/daemon/tests/server-startup-smoke.test.ts` — `[P0] keeps a user-canceled Claude run canceled when a late error frame arrives`.
- Red on `main`: confirmed. The cancel API returned `status: failed` after the fake Claude process emitted canceled assistant/result error frames and exited with code 1.
- Green on this branch: confirmed. The cancel response and final run stay `canceled`; SSE contains no `error` event, no retry, exactly one terminal `end`, and no `stream_error` classification.
- The source change preserves non-cancel failure and retry paths; only events arriving after `cancelRequested` are treated as cancellation shutdown noise.

## Validation

- `corepack pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/server-startup-smoke.test.ts tests/claude-sidechain-assistant-error-false-failure.test.ts tests/chat-run-artifact-quiet-period.test.ts tests/runtimes/runs.test.ts` — 4 files, 83 tests passed.
- Full `tests/server-startup-smoke.test.ts` — 11 tests passed.
- `corepack pnpm --filter @open-design/daemon typecheck` — passed.
- `corepack pnpm --filter @open-design/daemon build` — passed.
- `git diff --check` — passed.
- `corepack pnpm guard` — blocked by the current-main repository baseline because `apps/telemetry-worker/package.json` is missing; the guard checks reported before that manifest load all passed.
