### PR TITLE
fix release: notarize prerelease mac builds

### DIFF
--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -329,6 +329,10 @@ jobs:
           fi
       - name: Retry prerelease mac_arm64 without restored cache
         if: ${{ steps.mac_arm64_tools_pack_build.outcome == 'failure' }}
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           set -euo pipefail
           rm -rf "$RUNNER_TEMP/tools-pack-cache"
@@ -684,6 +688,10 @@ jobs:
 
       - name: Retry prerelease mac_x64 without restored cache
         if: ${{ steps.mac_x64_tools_pack_build.outcome == 'failure' }}
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           set -euo pipefail
           rm -rf "$RUNNER_TEMP/tools-pack-cache"

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -318,6 +318,7 @@ jobs:
             --to all
             --json
             --signed
+            --notarize
           )
           if build_output="$(pnpm "${build_args[@]}" 2> >(tee -a "$RUNNER_TEMP/release-build/mac_arm64/build.log" >&2))"; then
             printf '%s\n' "$build_output" | tee "$RUNNER_TEMP/release-build/mac_arm64/build.json"
@@ -345,6 +346,7 @@ jobs:
             --to all
             --json
             --signed
+            --notarize
           )
           if build_output="$(pnpm "${build_args[@]}" 2> >(tee -a "$RUNNER_TEMP/release-build/mac_arm64/build.log" >&2))"; then
             printf '%s\n' "$build_output" | tee "$RUNNER_TEMP/release-build/mac_arm64/build.json"
@@ -371,6 +373,33 @@ jobs:
             fi
           done <<< "$cache_ids"
           echo "deletedFailedCacheKey=$matched_key count=$count"
+
+      - name: Verify prerelease mac_arm64 notarization
+        run: |
+          set -euo pipefail
+          build_json="$RUNNER_TEMP/release-build/mac_arm64/build.json"
+          dmg_path="$(node -e 'const fs = require("node:fs"); const value = JSON.parse(fs.readFileSync(process.argv[1], "utf8")).dmgPath; if (typeof value !== "string" || value.length === 0) process.exit(1); process.stdout.write(value);' "$build_json")"
+          if [ ! -f "$dmg_path" ]; then
+            echo "prerelease mac_arm64 DMG not found: $dmg_path" >&2
+            exit 1
+          fi
+
+          mount_point="$(mktemp -d "$RUNNER_TEMP/prerelease-mac-arm64.XXXXXX")"
+          cleanup() {
+            hdiutil detach "$mount_point" >/dev/null 2>&1 || true
+            rmdir "$mount_point" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          hdiutil attach "$dmg_path" -nobrowse -readonly -mountpoint "$mount_point"
+          candidate_app="$mount_point/Open Design Prerelease.app"
+          if [ ! -d "$candidate_app" ]; then
+            echo "prerelease app not found in DMG: $candidate_app" >&2
+            exit 1
+          fi
+          codesign --verify --deep --strict "$candidate_app"
+          xcrun stapler validate "$candidate_app"
+          spctl --assess --type execute --verbose=4 "$candidate_app"
 
       - name: Capture mac framework diagnostics
         if: ${{ failure() }}
@@ -643,6 +672,7 @@ jobs:
             --to all
             --json
             --signed
+            --notarize
           )
           if build_output="$(pnpm "${build_args[@]}" 2> >(tee -a "$RUNNER_TEMP/release-build/mac_x64/build.log" >&2))"; then
             printf '%s\n' "$build_output" | tee "$RUNNER_TEMP/release-build/mac_x64/build.json"
@@ -671,6 +701,7 @@ jobs:
             --to all
             --json
             --signed
+            --notarize
           )
           if build_output="$(pnpm "${build_args[@]}" 2> >(tee -a "$RUNNER_TEMP/release-build/mac_x64/build.log" >&2))"; then
             printf '%s\n' "$build_output" | tee "$RUNNER_TEMP/release-build/mac_x64/build.json"
@@ -697,6 +728,33 @@ jobs:
             fi
           done <<< "$cache_ids"
           echo "deletedFailedCacheKey=$matched_key count=$count"
+
+      - name: Verify prerelease mac_x64 notarization
+        run: |
+          set -euo pipefail
+          build_json="$RUNNER_TEMP/release-build/mac_x64/build.json"
+          dmg_path="$(node -e 'const fs = require("node:fs"); const value = JSON.parse(fs.readFileSync(process.argv[1], "utf8")).dmgPath; if (typeof value !== "string" || value.length === 0) process.exit(1); process.stdout.write(value);' "$build_json")"
+          if [ ! -f "$dmg_path" ]; then
+            echo "prerelease mac_x64 DMG not found: $dmg_path" >&2
+            exit 1
+          fi
+
+          mount_point="$(mktemp -d "$RUNNER_TEMP/prerelease-mac-x64.XXXXXX")"
+          cleanup() {
+            hdiutil detach "$mount_point" >/dev/null 2>&1 || true
+            rmdir "$mount_point" >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          hdiutil attach "$dmg_path" -nobrowse -readonly -mountpoint "$mount_point"
+          candidate_app="$mount_point/Open Design Prerelease.app"
+          if [ ! -d "$candidate_app" ]; then
+            echo "prerelease app not found in DMG: $candidate_app" >&2
+            exit 1
+          fi
+          codesign --verify --deep --strict "$candidate_app"
+          xcrun stapler validate "$candidate_app"
+          spctl --assess --type execute --verbose=4 "$candidate_app"
 
       - name: Write mac_x64 release report
         if: ${{ always() }}

--- a/tools/pack/tests/release-workflows.test.ts
+++ b/tools/pack/tests/release-workflows.test.ts
@@ -272,6 +272,20 @@ describe("release workflows", () => {
     expect(prereleaseMac).toContain("exec tools-pack mac build");
     expect(prereleaseMac).toContain("--cache-dir \"$RUNNER_TEMP/tools-pack-cache\"");
     expect(countOccurrences(prereleaseMac, "--notarize")).toBe(2);
+    // Both the primary build and the cache-miss retry must carry Apple notary
+    // env, or notarization fails closed on the retry path.
+    expect(
+      countOccurrences(prereleaseMac, "APPLE_ID: ${{ secrets.APPLE_ID }}"),
+    ).toBe(2);
+    expect(
+      countOccurrences(
+        prereleaseMac,
+        "APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}",
+      ),
+    ).toBe(2);
+    expect(
+      countOccurrences(prereleaseMac, "APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}"),
+    ).toBe(2);
     expect(prereleaseMac).toContain("tools-release write-report");
     expect(prereleaseMacX64).toContain("uses: actions/cache/restore@v5");
     expect(prereleaseMacX64).toContain("uses: actions/cache/save@v5");
@@ -280,6 +294,18 @@ describe("release workflows", () => {
     expect(prereleaseMacX64).toContain("exec tools-pack mac build");
     expect(prereleaseMacX64).toContain("--cache-dir \"$RUNNER_TEMP/tools-pack-cache\"");
     expect(countOccurrences(prereleaseMacX64, "--notarize")).toBe(2);
+    expect(
+      countOccurrences(prereleaseMacX64, "APPLE_ID: ${{ secrets.APPLE_ID }}"),
+    ).toBe(2);
+    expect(
+      countOccurrences(
+        prereleaseMacX64,
+        "APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}",
+      ),
+    ).toBe(2);
+    expect(
+      countOccurrences(prereleaseMacX64, "APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}"),
+    ).toBe(2);
     expect(prereleaseMacX64).toContain("tools-release write-report");
     for (const [prereleaseMacJob, nextStep] of [
       [prereleaseMac, "Smoke prerelease mac"],

--- a/tools/pack/tests/release-workflows.test.ts
+++ b/tools/pack/tests/release-workflows.test.ts
@@ -271,6 +271,7 @@ describe("release workflows", () => {
     expect(prereleaseMac).toContain("pnpm exec tools-pack mac cleanup --dir \"$RUNNER_TEMP/tools-pack\" --namespace release-prerelease --json");
     expect(prereleaseMac).toContain("exec tools-pack mac build");
     expect(prereleaseMac).toContain("--cache-dir \"$RUNNER_TEMP/tools-pack-cache\"");
+    expect(countOccurrences(prereleaseMac, "--notarize")).toBe(2);
     expect(prereleaseMac).toContain("tools-release write-report");
     expect(prereleaseMacX64).toContain("uses: actions/cache/restore@v5");
     expect(prereleaseMacX64).toContain("uses: actions/cache/save@v5");
@@ -278,7 +279,21 @@ describe("release workflows", () => {
     expect(prereleaseMacX64).toContain("pnpm exec tools-pack mac cleanup --dir \"$RUNNER_TEMP/tools-pack\" --namespace release-prerelease-intel --json");
     expect(prereleaseMacX64).toContain("exec tools-pack mac build");
     expect(prereleaseMacX64).toContain("--cache-dir \"$RUNNER_TEMP/tools-pack-cache\"");
+    expect(countOccurrences(prereleaseMacX64, "--notarize")).toBe(2);
     expect(prereleaseMacX64).toContain("tools-release write-report");
+    for (const [prereleaseMacJob, nextStep] of [
+      [prereleaseMac, "Smoke prerelease mac"],
+      [prereleaseMacX64, "Write mac_x64 release report"],
+    ] as const) {
+      expect(prereleaseMacJob).toContain("Verify prerelease mac");
+      expect(prereleaseMacJob).toContain('hdiutil attach "$dmg_path" -nobrowse -readonly -mountpoint "$mount_point"');
+      expect(prereleaseMacJob).toContain('codesign --verify --deep --strict "$candidate_app"');
+      expect(prereleaseMacJob).toContain('xcrun stapler validate "$candidate_app"');
+      expect(prereleaseMacJob).toContain('spctl --assess --type execute --verbose=4 "$candidate_app"');
+      expect(prereleaseMacJob.indexOf("Verify prerelease mac")).toBeLessThan(
+        prereleaseMacJob.indexOf(nextStep),
+      );
+    }
     expect(prereleaseWin).toContain("tools-pack-win-v1-prerelease-$env:RUNNER_OS-");
     expect(prereleaseWin).toContain("tools-pack win validate-payload");
     expect(prereleaseWin).toContain("release-build\\win_x64\\build.json");


### PR DESCRIPTION
## Why

While validating the `0.16.0-prerelease.1` DMG, I hit the release through the same downloaded-installer path macOS users take. The app was Developer ID signed but not notarized or stapled, so Gatekeeper assessed it as `Unnotarized Developer ID`.

The prerelease workflow passed `--signed` without `--notarize` in both mac architectures and both cache/retry paths. That made successful workflow and publish runs insufficient evidence that the prerelease candidate could pass normal macOS installation checks. This PR closes that release blocker before the candidate is promoted to stable.

## What users will see

macOS prerelease DMGs are notarized and their contained `Open Design Prerelease.app` is checked against codesign, the stapled notarization ticket, and Gatekeeper before the artifact can proceed to smoke testing or publication. A broken or unnotarized candidate now fails the workflow instead of reaching users.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — prerelease mac builds now notarize by default and fail closed when the generated DMG does not pass macOS trust checks
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this changes release packaging and validation, not product UI.

## Bug fix verification

- Test path that reproduces the bug: `tools/pack/tests/release-workflows.test.ts`
- Red on `main`: yes — the prerelease mac job sections contained zero `--notarize` arguments, while the new regression expected both the primary and retry paths to contain it.
- Green on this branch: yes — both mac jobs now include notarization and verify the app mounted from the generated DMG before smoke/report/publish steps.

## Validation

- `pnpm --filter @open-design/tools-pack exec vitest run tests/release-workflows.test.ts` — passed
- `pnpm --filter @open-design/tools-pack test` — 242 passed, 8 skipped
- `pnpm --filter @open-design/e2e exec vitest run tests/packaged-smoke-workflow.test.ts` — 50 passed
- `pnpm guard` — passed
- `pnpm typecheck` — passed
- `actionlint -color .github/workflows/release-prerelease.yml` — passed
- `git diff --check` — passed
