### PR TITLE
fix(message-center): stabilize login and anonymous delivery

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -126,6 +126,11 @@ import type {
   SkillSummary,
 } from './types';
 
+function velaLoginIdentity(status: VelaLoginStatus | null): string | null {
+  if (status?.loggedIn !== true) return null;
+  return `${status.profile}\u0000${status.user?.id ?? ''}`;
+}
+
 type AppCreateProjectInput = Omit<CreateInput, 'metadata'> & {
   metadata?: CreateInput['metadata'];
   pendingPrompt?: string;
@@ -627,6 +632,7 @@ function AppInner() {
   // globals effect below reads it; the sync effects live next to the
   // other AMR plumbing further down.
   const [amrLoginStatus, setAmrLoginStatus] = useState<VelaLoginStatus | null>(null);
+  const amrLoginIdentityRef = useRef<string | null>(null);
 
   // v2 analytics requires every event to carry the configure-state
   // triplet (has_available_configure_cli / configure_type /
@@ -770,7 +776,10 @@ function AppInner() {
     let cancelled = false;
     const sync = async () => {
       const status = await fetchVelaLoginStatus();
-      if (!cancelled && status) setAmrLoginStatus(status);
+      if (!cancelled && status) {
+        amrLoginIdentityRef.current = velaLoginIdentity(status);
+        setAmrLoginStatus(status);
+      }
     };
     void sync();
     const onStatusEvent = () => {
@@ -790,9 +799,13 @@ function AppInner() {
   }, [analytics.setUserId, amrLoginStatus]);
 
   const handleAmrLoginStatusChange = useCallback((status: VelaLoginStatus | null) => {
-    if (status) setAmrLoginStatus(status);
-    if (status?.loggedIn !== true) return;
-    restartAmrPolling();
+    if (!status) return;
+    const nextIdentity = velaLoginIdentity(status);
+    const shouldRestartPolling =
+      nextIdentity !== null && nextIdentity !== amrLoginIdentityRef.current;
+    amrLoginIdentityRef.current = nextIdentity;
+    setAmrLoginStatus(status);
+    if (shouldRestartPolling) restartAmrPolling();
   }, [restartAmrPolling]);
 
   // Bootstrap — detect daemon, then fan out independent fetches so each

--- a/apps/web/src/components/MessageCenterDemo.tsx
+++ b/apps/web/src/components/MessageCenterDemo.tsx
@@ -4,7 +4,6 @@ import { createPortal } from 'react-dom';
 
 import { useI18n } from '../i18n';
 import {
-  anonymousStartedAt,
   clearAnonymousState,
   isAmrLoggedIn,
   markAccountMessageRead,
@@ -72,8 +71,7 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
       readIdsRef.current = new Set();
       pendingReadIdsRef.current = new Set();
     }
-    const startedAt = anonymousStartedAt(window.localStorage);
-    const pulled = await pullMessageCenter({ locale, loggedIn: account, startedAt });
+    const pulled = await pullMessageCenter({ locale, loggedIn: account });
     if (requestId !== syncRequestIdRef.current) return;
     const serverReadIds = new Set(pulled.filter((message) => Boolean(message.readAt)).map((message) => message.id));
     if (account) {
@@ -111,7 +109,6 @@ export function MessageCenterDemo({ onOpenNotificationSettings }: Props) {
   }, []);
 
   useEffect(() => {
-    anonymousStartedAt(window.localStorage);
     commitState(
       readAnonymousMessages(window.localStorage),
       readAnonymousReadIds(window.localStorage),

--- a/apps/web/src/message-center-client.ts
+++ b/apps/web/src/message-center-client.ts
@@ -20,20 +20,10 @@ interface MessageCenterPage {
 
 const ACCOUNT_PROXY = '/api/integrations/vela/message-center';
 const ANONYMOUS_PROXY = '/api/integrations/vela/api-proxy/api/v1/message-center';
-const WINDOW_KEY = 'open-design.message-center.anonymous-started-at.v1';
+const LEGACY_WINDOW_KEY = 'open-design.message-center.anonymous-started-at.v1';
 const MESSAGES_KEY = 'open-design.message-center.anonymous-messages.v1';
 const READ_KEY = 'open-design.message-center.anonymous-read-ids.v1';
 const MAX_MESSAGE_CENTER_PAGES = 20;
-
-export function anonymousStartedAt(storage: Storage, now = new Date()): string {
-  const existing = storage.getItem(WINDOW_KEY);
-  if (existing) return existing;
-  const value = now.toISOString();
-  storage.setItem(WINDOW_KEY, value);
-  storage.setItem(MESSAGES_KEY, '[]');
-  storage.setItem(READ_KEY, '[]');
-  return value;
-}
 
 export function readAnonymousMessages(storage: Storage): MessageCenterMessage[] {
   return parseArray<MessageCenterMessage>(storage.getItem(MESSAGES_KEY));
@@ -55,6 +45,7 @@ export function writeAnonymousState(
 export function clearAnonymousState(storage: Storage): void {
   storage.removeItem(MESSAGES_KEY);
   storage.removeItem(READ_KEY);
+  storage.removeItem(LEGACY_WINDOW_KEY);
 }
 
 export async function isAmrLoggedIn(): Promise<boolean> {
@@ -67,7 +58,6 @@ export async function isAmrLoggedIn(): Promise<boolean> {
 export async function pullMessageCenter(input: {
   locale: string;
   loggedIn: boolean;
-  startedAt?: string;
   filter?: MessageCenterFilter;
 }): Promise<MessageCenterMessage[]> {
   const messages: MessageCenterMessage[] = [];
@@ -83,10 +73,6 @@ export async function pullMessageCenter(input: {
       filter: input.filter ?? 'all',
       limit: '100',
     });
-    if (!input.loggedIn) {
-      if (!input.startedAt) throw new Error('Anonymous Message Center requires startedAt');
-      query.set('startedAt', input.startedAt);
-    }
     if (cursor) query.set('cursor', cursor);
     const proxy = input.loggedIn ? ACCOUNT_PROXY : ANONYMOUS_PROXY;
     const response = await fetch(`${proxy}/messages?${query}`, { cache: 'no-store' });

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -427,6 +427,40 @@ describe('App AMR polling', () => {
     }, { timeout: 4_000 });
   });
 
+  it('does not restart AMR polling repeatedly for the same signed-in identity', async () => {
+    mockedFetchAmrModels.mockReset();
+    mockedFetchAmrModels.mockResolvedValue({
+      source: 'remote',
+      refreshing: false,
+      models: [{ id: 'remote-a', label: 'remote-a' }],
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockedFetchAmrModels).toHaveBeenCalledTimes(1);
+    });
+    fireEvent.click(screen.getByText('open settings'));
+    await waitFor(() => {
+      expect(screen.getByText('mark amr signed in')).toBeTruthy();
+    });
+
+    mockedFetchVelaLoginStatus.mockResolvedValue({
+      loggedIn: true,
+      profile: 'default',
+      user: null,
+      configPath: '/tmp/amr-config.json',
+    });
+    fireEvent.click(screen.getByText('mark amr signed in'));
+    await waitFor(() => {
+      expect(mockedFetchAmrModels).toHaveBeenCalledTimes(2);
+    });
+
+    fireEvent.click(screen.getByText('mark amr signed in'));
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(mockedFetchAmrModels).toHaveBeenCalledTimes(2);
+  });
+
   it('stops polling after the preset retry budget is exhausted when remote never arrives', {
     timeout: 20_000,
   }, async () => {

--- a/apps/web/tests/components/MessageCenterDemo.test.tsx
+++ b/apps/web/tests/components/MessageCenterDemo.test.tsx
@@ -64,11 +64,13 @@ afterEach(() => {
 });
 
 describe('MessageCenterDemo', () => {
-  it('starts a durable anonymous window and renders API messages', async () => {
+  it('renders API messages for anonymous clients without a local window', async () => {
     renderMessageCenter();
     const dialog = await openCenter();
     expect(within(dialog).getByText('Open Design 0.14 is available')).toBeTruthy();
-    expect(localStorage.getItem('open-design.message-center.anonymous-started-at.v1')).toBeTruthy();
+    expect(localStorage.getItem('open-design.message-center.anonymous-started-at.v1')).toBeNull();
+    const anonymousPull = vi.mocked(fetch).mock.calls.find(([url]) => String(url).includes('/api-proxy/') && String(url).includes('/messages?'));
+    expect(String(anonymousPull?.[0])).not.toContain('startedAt=');
   });
 
   it('keeps anonymous read state locally and restores it', async () => {

--- a/apps/web/tests/message-center-client.test.ts
+++ b/apps/web/tests/message-center-client.test.ts
@@ -1,28 +1,36 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { anonymousStartedAt, pullMessageCenter } from '../src/message-center-client';
+import { clearAnonymousState, pullMessageCenter } from '../src/message-center-client';
 
 describe('message center client', () => {
   beforeEach(() => vi.restoreAllMocks());
 
-  it('keeps the first anonymous window after later launches', () => {
+  it('clears legacy anonymous window keys with anonymous state', () => {
     const storage = new Map<string, string>();
-    const adapter = { getItem: (key: string) => storage.get(key) ?? null, setItem: (key: string, value: string) => void storage.set(key, value) } as Storage;
-    const first = anonymousStartedAt(adapter, new Date('2026-07-16T00:00:00Z'));
-    const second = anonymousStartedAt(adapter, new Date('2026-07-17T00:00:00Z'));
-    expect(second).toBe(first);
+    const adapter = {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => void storage.set(key, value),
+      removeItem: (key: string) => void storage.delete(key),
+    } as Storage;
+    storage.set('open-design.message-center.anonymous-started-at.v1', '2026-07-16T00:00:00.000Z');
+    storage.set('open-design.message-center.anonymous-messages.v1', '[]');
+    storage.set('open-design.message-center.anonymous-read-ids.v1', '[]');
+    clearAnonymousState(adapter);
+    expect(storage.has('open-design.message-center.anonymous-started-at.v1')).toBe(false);
+    expect(storage.has('open-design.message-center.anonymous-messages.v1')).toBe(false);
+    expect(storage.has('open-design.message-center.anonymous-read-ids.v1')).toBe(false);
   });
 
   it('follows pagination until the server cursor is exhausted', async () => {
     vi.stubGlobal('fetch', vi.fn()
       .mockResolvedValueOnce(Response.json({ messages: [{ id: 'new' }], nextCursor: 'next', unreadCount: 1 }))
       .mockResolvedValueOnce(Response.json({ messages: [{ id: 'old' }], nextCursor: null, unreadCount: 1 })));
-    const result = await pullMessageCenter({ locale: 'en', loggedIn: false, startedAt: '2026-07-16T00:00:00.000Z' });
+    const result = await pullMessageCenter({ locale: 'en', loggedIn: false });
     expect(result.map((message) => message.id)).toEqual(['new', 'old']);
     expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
-    expect(String(vi.mocked(fetch).mock.calls[0]?.[0])).toContain(
-      '/api/integrations/vela/api-proxy/api/v1/message-center/messages?',
-    );
+    const firstUrl = String(vi.mocked(fetch).mock.calls[0]?.[0]);
+    expect(firstUrl).toContain('/api/integrations/vela/api-proxy/api/v1/message-center/messages?');
+    expect(firstUrl).not.toContain('startedAt=');
   });
 
   it('fails fast when pagination cursors stop advancing', async () => {
@@ -30,7 +38,7 @@ describe('message center client', () => {
       .mockResolvedValueOnce(Response.json({ messages: [{ id: 'new' }], nextCursor: 'stuck', unreadCount: 1 }))
       .mockResolvedValueOnce(Response.json({ messages: [{ id: 'old' }], nextCursor: 'stuck', unreadCount: 1 })));
     await expect(
-      pullMessageCenter({ locale: 'en', loggedIn: false, startedAt: '2026-07-16T00:00:00.000Z' }),
+      pullMessageCenter({ locale: 'en', loggedIn: false }),
     ).rejects.toThrow('Message Center pagination cursor did not advance');
     expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
   });


### PR DESCRIPTION
## What changed

- Prevents repeated reports of the same signed-in Vela identity from restarting AMR polling and creating a React update loop.
- Removes the obsolete anonymous Message Center `startedAt` window and its local-storage initialization.
- Keeps anonymous message/read caching while allowing the Vela API to own message validity and visibility.
- Adds focused regression tests for repeated login-status reports and window-free anonymous pagination.

## Why

Repeated equivalent login-status objects could continuously restart polling, feed status updates back into Settings, and trigger `Maximum update depth exceeded`. Anonymous delivery also retained the old first-open window even after Vela moved to publish-time audiences plus TTL.

## Impact

- Repeated status refreshes for the same Vela identity no longer restart polling.
- Anonymous clients receive all currently valid Global messages without sending `startedAt`.
- Legacy anonymous window state is removed when anonymous Message Center state is cleared.

## Validation

- Focused Message Center tests: 19/19 passed
- Full Web Vitest: 4101 passed, 7 skipped
- `pnpm guard`
- `pnpm typecheck`
- Local browser verification confirmed Settings and Message Center load without the update-depth loop
