### PR TITLE
fix(landing-page): keep locale variants of proper-noun blog posts out of the index

### DIFF
--- a/apps/landing-page/app/_components/seo-head.astro
+++ b/apps/landing-page/app/_components/seo-head.astro
@@ -48,6 +48,13 @@ export interface SeoHeadProps {
   /** Set when this page has no generated per-locale variants. */
   localeCanonicalOnly?: boolean;
   /**
+   * Keep this single page out of the search index. Independent of the
+   * site-wide staging flag below: staging emits `noindex, nofollow` for the
+   * whole mirror, whereas a page opting in here emits `noindex, follow` so
+   * crawlers still traverse its outbound links.
+   */
+  noindex?: boolean;
+  /**
    * Optional Google Search Console verification token. When set, renders
    * `<meta name="google-site-verification" content="...">`. Only needed on
    * one page (typically `/`) for URL-prefix property verification; the
@@ -68,7 +75,12 @@ const props = Astro.props as SeoHeadProps;
 // `__OD_LANDING_NOINDEX__` is a compile-time constant injected by
 // `vite.define` in astro.config.ts — `.astro` frontmatter is transformed by
 // Vite and cannot read process.env directly.
-const noindex = __OD_LANDING_NOINDEX__;
+const stagingNoindex = __OD_LANDING_NOINDEX__;
+const noindex = stagingNoindex || props.noindex === true;
+// Staging hides the whole mirror, so nothing there is worth crawling onward.
+// A page-level opt-out is the opposite case: the page itself shouldn't rank,
+// but its outbound links should still pass equity, hence `follow`.
+const robotsContent = stagingNoindex ? 'noindex, nofollow' : 'noindex, follow';
 
 const SITE_NAME = 'Open Design';
 const TAGLINE = 'Design with the agent already on your laptop.';
@@ -171,7 +183,7 @@ const blogJsonLd =
 <title>{fullTitle}</title>
 <meta name='description' content={metaDescription} />
 <meta name='theme-color' content='#efe7d2' />
-{noindex && <meta name='robots' content='noindex, nofollow' />}
+{noindex && <meta name='robots' content={robotsContent} />}
 <link rel='canonical' href={canonical} />
 {alternateLinks.map((entry) => (
   <link rel='alternate' hreflang={entry.hreflang} href={entry.href} />

--- a/apps/landing-page/app/_components/seo-head.astro
+++ b/apps/landing-page/app/_components/seo-head.astro
@@ -48,6 +48,14 @@ export interface SeoHeadProps {
   /** Set when this page has no generated per-locale variants. */
   localeCanonicalOnly?: boolean;
   /**
+   * Drop the hreflang cluster because this page's locale variants are served
+   * with `noindex`. Deliberately NOT `localeCanonicalOnly`: the variants do
+   * exist here and stay reachable through the language switcher, they just
+   * must not be advertised to search engines, since hreflang may not point at
+   * noindexed URLs.
+   */
+  noindexedLocaleVariants?: boolean;
+  /**
    * Keep this single page out of the search index. Independent of the
    * site-wide staging flag below: staging emits `noindex, nofollow` for the
    * whole mirror, whereas a page opting in here emits `noindex, follow` so
@@ -89,7 +97,7 @@ const locale = localeFromPath(props.pathname);
 const localeDef = getLocaleDefinition(locale);
 const basePath = stripLocaleFromPath(props.pathname).pathname;
 const altEntries = alternateLinksForPath(props.pathname);
-const alternateLinks = props.localeCanonicalOnly
+const alternateLinks = props.localeCanonicalOnly || props.noindexedLocaleVariants
   ? []
   : altEntries.map((entry) => ({
       ...entry,

--- a/apps/landing-page/app/content.config.ts
+++ b/apps/landing-page/app/content.config.ts
@@ -126,6 +126,24 @@ const blog = defineCollection({
       author: z.string().optional(),
       socialImage: z.string().optional(),
       ctaKind: z.enum(['download-app', 'event-register']).optional(),
+      /**
+       * Keep the generated `/{locale}/blog/<slug>/` variants out of the search
+       * index (the English post stays indexable).
+       *
+       * Set this on posts whose subject is a language-neutral proper noun — a
+       * product name like `marp` or `slidev`. Google treats those queries as
+       * navigational and ranks every translated copy against the *same*
+       * English-language SERP, so the localized variants accumulate large
+       * impression counts at a click-through rate of ~0.02% while adding
+       * nothing a searcher wants. Left alone they drown out the rest of the
+       * site's Search Console data and read as thin duplicate coverage.
+       *
+       * When set, `blog/[slug].astro` emits `noindex, follow` on the localized
+       * variants (outbound link equity still flows) and suppresses the hreflang
+       * cluster on all variants including English, since hreflang must not
+       * point at noindexed URLs.
+       */
+      noindexLocaleVariants: z.boolean().optional(),
       ctaHref: z.string().url().optional(),
       ctaTitle: z.string().min(1).optional(),
       ctaBody: z.string().min(1).optional(),

--- a/apps/landing-page/app/content/blog/marp.md
+++ b/apps/landing-page/app/content/blog/marp.md
@@ -4,6 +4,7 @@ date: 2026-07-10
 category: "Tools & Skills"
 readingTime: 7
 summary: "Marp is the open-source Markdown presentation ecosystem — write slides in Markdown, then use the Marp CLI to export HTML, PDF, or PowerPoint. This guide covers Marp themes, Markdown authoring, marp-cli export to pptx (as images), how it compares to reveal.js and Slidev, and where an agent-native design workspace fits."
+noindexLocaleVariants: true
 ctaKind: download-app
 author: nadia-haddad
 i18n:

--- a/apps/landing-page/app/content/blog/reveal-js.md
+++ b/apps/landing-page/app/content/blog/reveal-js.md
@@ -4,6 +4,7 @@ date: 2026-07-10
 category: "Tools & Skills"
 readingTime: 7
 summary: "reveal.js is the open-source HTML presentation framework with 71.9k GitHub stars — you author slides in HTML or Markdown and present in any browser. Here's an honest guide: how themes, templates and examples work, how PDF and PowerPoint export really behaves, how it compares to Slidev and Marp, and where an agent-native design workspace fits."
+noindexLocaleVariants: true
 ctaKind: download-app
 author: mira-zhao
 i18n:

--- a/apps/landing-page/app/content/blog/slidev.md
+++ b/apps/landing-page/app/content/blog/slidev.md
@@ -4,6 +4,7 @@ date: 2026-07-10
 category: "Tools & Skills"
 readingTime: 7
 summary: "Slidev is the open-source, developer-first presentation tool with 47.6k GitHub stars — you author slides in Markdown with embedded Vue components and present in the browser. Here's an honest guide: how themes and examples work, how PDF and PowerPoint export really behaves, how it compares to Marp and reveal.js, and where an agent-native design workspace fits."
+noindexLocaleVariants: true
 ctaKind: download-app
 author: theo-lindqvist
 i18n:

--- a/apps/landing-page/app/pages/blog/[slug].astro
+++ b/apps/landing-page/app/pages/blog/[slug].astro
@@ -30,6 +30,7 @@ import {
   localizeBlogPostText,
 } from '../../content-i18n';
 import {
+  DEFAULT_LOCALE,
   getHeaderLocaleSwitcher,
   getLandingUiCopy,
   getLocaleDefinition,
@@ -224,6 +225,16 @@ const fmtDate = (d: Date) =>
 // Optional team-persona byline (avatar + name + role). Posts without an
 // `author` frontmatter id render no byline, unchanged.
 const author = getBlogAuthor((post.data as { author?: string }).author);
+
+// Posts about a language-neutral proper noun (a product name like `marp`)
+// rank every translated copy against the same English SERP. See the
+// `noindexLocaleVariants` docblock in content.config.ts for the full
+// rationale. English stays indexable; the localized variants drop out, and
+// the hreflang cluster is suppressed everywhere because hreflang must not
+// advertise URLs that carry `noindex`.
+const noindexLocaleVariants =
+  (post.data as { noindexLocaleVariants?: boolean }).noindexLocaleVariants === true;
+const isLocalizedVariant = locale !== DEFAULT_LOCALE;
 ---
 
 <!doctype html>
@@ -239,6 +250,8 @@ const author = getBlogAuthor((post.data as { author?: string }).author);
       image={coverImage}
       datePublished={post.data.date}
       category={post.data.category}
+      noindex={noindexLocaleVariants && isLocalizedVariant}
+      localeCanonicalOnly={noindexLocaleVariants}
     />
     <script is:inline type='application/ld+json' set:html={JSON.stringify(breadcrumbJsonLd)} />
     <SiteAnalytics />

--- a/apps/landing-page/app/pages/blog/[slug].astro
+++ b/apps/landing-page/app/pages/blog/[slug].astro
@@ -251,7 +251,7 @@ const isLocalizedVariant = locale !== DEFAULT_LOCALE;
       datePublished={post.data.date}
       category={post.data.category}
       noindex={noindexLocaleVariants && isLocalizedVariant}
-      localeCanonicalOnly={noindexLocaleVariants}
+      noindexedLocaleVariants={noindexLocaleVariants}
     />
     <script is:inline type='application/ld+json' set:html={JSON.stringify(breadcrumbJsonLd)} />
     <SiteAnalytics />


### PR DESCRIPTION
## Why

Joey (CMO) flagged a Search Console anomaly: impressions were climbing hard while clicks fell. Site-wide impressions went 28.3K → 70.0K between 07-14 and 07-17 while average CTR collapsed from 14.07% to 3.72%.

Pulling the Search Console API, the entire surge traces to three blog posts and their locale variants. Four navigational queries account for 38% of all impressions over seven days and produce five clicks between them:

| query | impressions | clicks | CTR |
|---|---|---|---|
| `marp` | 33,772 | 3 | 0.01% |
| `slidev` | 31,494 | 2 | 0.01% |
| `sli dev` | 28,699 | 0 | 0% |
| `reveal js` | 23,500 | 0 | 0% |

Per-post the concentration is near-total: 99.7–99.9% of each post's impressions come from a single product-name query, with roughly 180 impressions of long tail across all three over eight days.

The root cause is that these queries are language-neutral proper nouns. Google ranks every translated copy against the same English SERP, so all ten locale variants compete for one navigational query that belongs to the upstream project's own site. The Spanish copies were outranking the English originals: `/es/blog/slidev/` took 27,465 impressions against the English post's 3,431.

Over 07-01..07-18 the thirty localized URLs took ~96,206 impressions and returned 19 clicks — a 0.02% CTR, about one click per day spread across thirty pages.

This also matches the plan these posts were written against. `notes/2026-07-09-1228-semrush-recon.md` explicitly scoped each post away from its brand head term (`reveal.js`, `slidev`, and `marp` are each listed under "do not target — the upstream site owns it") and specified English body plus localized metadata only. Full eleven-language bodies shipped instead, which is what created the surface area this PR removes.

## What users will see

Nothing changes visually, and no page is removed. All thirty locale URLs still resolve, still render their translation, and are still reachable from the language switcher — a reader arriving from a link or social post sees exactly what they saw before.

The change is search-engine-facing only: the ten non-English variants of these three posts now carry `noindex, follow`, so they drop out of search results over the next few weeks as Google recrawls. The English posts stay fully indexable.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — three frontmatter lines plus the SEO head plumbing behind them.

## Bug fix verification

Not a code bug, so there is no red spec to write; the failure is externally observable in Search Console rather than reproducible in-process. Verification was done against the built output instead, listed under Validation.

## Validation

`astro check` — 0 errors. `astro build` — 4,673 pages.

Assertions against the built HTML in `out/`:

- 30/30 locale variants of the three posts emit `noindex, follow`
- the three English posts emit no `robots` meta at all
- all three posts emit zero non-`x-default` hreflang links
- control post `claude-ppt-skills` is untouched: no `robots` meta, all 11 hreflang links intact
- the sitemap lists only the English URL per post, with no alternates and no locale URLs
- language switcher parity: `/es/blog/marp/` and the control post both still emit 10 locale links
- staging regression: a full `OD_LANDING_NOINDEX=1` build still emits `noindex, nofollow` site-wide, unchanged, and still appends the catch-all `_headers` rule

`pnpm guard` was not run cleanly in this worktree — deps were installed with `--filter @open-design/landing-page...`, so guard's resolution of `@open-design/contracts/dist` fails for reasons unrelated to this change. This PR adds no `.js`/`.mjs`/`.cjs` files, which is guard's main concern here. CI runs it in full.

## Notes for review

Two design choices worth a look:

`noindex, follow` rather than `noindex, nofollow`. These posts link to `/`, `/plugins/templates/`, and `/blog/claude-ppt-skills/`. The pages should stop ranking; their outbound equity should keep flowing.

hreflang is dropped from all variants **including English**. Google does not permit hreflang to advertise noindexed URLs, so suppressing it on the variants while leaving the English post pointing at eleven now-noindexed siblings would be internally contradictory.

The second commit exists because the first version borrowed `localeCanonicalOnly` to suppress hreflang. That prop means "this page has no per-locale variants" and also drives the language switcher and locale auto-redirect in `sub-page-layout`. These posts do have variants — all thirty build and stay in the switcher — so the flag produced correct HTML only because `SeoHead` ignores the switcher half of its meaning. `noindexedLocaleVariants` now carries that intent on its own; output is byte-identical.

The flag is opt-in per post via frontmatter, so nothing else in the blog collection is affected.
