### PR TITLE
fix packaged upgrades blocked by stale payloads

### DIFF
--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -26,7 +26,11 @@ import {
 } from "./download-attribution.js";
 import { writePackagedDesktopIdentity } from "./identity.js";
 import { PackagedPathAccessError } from "./errors.js";
-import { inspectExistingDesktopForLauncher, waitForLauncherAfterQuit } from "./launcher-after-quit.js";
+import {
+  exitPackagedLauncherForExistingDesktop,
+  inspectExistingDesktopForLauncher,
+  waitForLauncherAfterQuit,
+} from "./launcher-after-quit.js";
 import { confirmPackagedLauncherRuntime, resolvePackagedLauncherRuntime } from "./launcher-runtime.js";
 import {
   applyPackagedElectronPathOverrides,
@@ -123,7 +127,7 @@ async function main(): Promise<void> {
     logger: console,
     paths: initialPaths,
   });
-  if (existingDesktop.action === "exit") {
+  if (exitPackagedLauncherForExistingDesktop(existingDesktop, (code) => app.exit(code))) {
     return;
   }
   const stamp = argvStamp ?? createPackagedDesktopStamp(namespace);

--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -119,6 +119,7 @@ async function main(): Promise<void> {
     return;
   }
   const existingDesktop = await inspectExistingDesktopForLauncher(namespace, {
+    incomingVersion: namespaceConfig.appVersion,
     logger: console,
     paths: initialPaths,
   });

--- a/apps/packaged/src/launcher-after-quit.ts
+++ b/apps/packaged/src/launcher-after-quit.ts
@@ -2,7 +2,7 @@ import { appendFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 
 import { stopProcesses, waitForProcessExit, type StopProcessesResult } from "@open-design/platform";
-import type { LauncherAfterQuitRequest } from "@open-design/launcher-proto";
+import { compareLauncherVersions, type LauncherAfterQuitRequest } from "@open-design/launcher-proto";
 import {
   APP_KEYS,
   OPEN_DESIGN_SIDECAR_CONTRACT,
@@ -17,7 +17,7 @@ import type { PackagedNamespacePaths } from "./paths.js";
 type LauncherAfterQuitLogger = Pick<Console, "warn"> & Partial<Pick<Console, "info">>;
 
 export type LauncherExistingDesktopGateResult =
-  | { action: "continue"; reason: "inspect-failed" | "not-running" | "stale-sidecar" }
+  | { action: "continue"; reason: "inspect-failed" | "not-running" | "stale-sidecar" | "superseded-version" }
   | { action: "exit"; reason: "existing-focused" | "existing-focus-failed" };
 
 async function writeLauncherAfterQuitLog(paths: PackagedNamespacePaths, message: string): Promise<void> {
@@ -67,6 +67,60 @@ async function forceStopLingeringDesktop(
   return gone;
 }
 
+async function restartExistingDesktop(
+  input: {
+    ipcPath: string;
+    logger: LauncherAfterQuitLogger;
+    namespace: string;
+    paths: PackagedNamespacePaths;
+    pid: number | null;
+    reason: "stale-sidecar" | "superseded-version";
+    requestIpc: typeof requestJsonIpc;
+    stop: typeof stopProcesses;
+    waitForExit: typeof waitForProcessExit;
+  },
+): Promise<boolean> {
+  try {
+    await input.requestIpc(input.ipcPath, { type: SIDECAR_MESSAGES.SHUTDOWN }, { timeoutMs: 800 });
+  } catch (error) {
+    const message = `inspect-found-existing namespace=${input.namespace} shutdown=failed reason=${input.reason} error=${error instanceof Error ? error.message : String(error)}`;
+    await writeLauncherAfterQuitLog(input.paths, message);
+    input.logger.warn(`[open-design launcher] ${message}`);
+    return false;
+  }
+  if (input.pid == null) return true;
+
+  const exited = await input.waitForExit(input.pid, 5000);
+  await writeLauncherAfterQuitLog(
+    input.paths,
+    `inspect-found-existing namespace=${input.namespace} shutdown=${exited ? "exited" : "timed-out"} reason=${input.reason} pid=${input.pid}`,
+  );
+  if (exited) return true;
+
+  return await forceStopLingeringDesktop(
+    input.pid,
+    input.reason,
+    input.paths,
+    input.logger,
+    input.stop,
+  );
+}
+
+function incomingVersionSupersedesExisting(
+  incomingVersion: string | null | undefined,
+  existingVersion: string | null | undefined,
+): boolean {
+  if (incomingVersion == null || existingVersion == null) return false;
+  const incoming = incomingVersion.trim();
+  const existing = existingVersion.trim();
+  if (incoming.length === 0 || existing.length === 0) return false;
+  try {
+    return compareLauncherVersions(incoming, existing) > 0;
+  } catch {
+    return false;
+  }
+}
+
 export async function waitForLauncherAfterQuit(
   request: LauncherAfterQuitRequest | null,
   paths: PackagedNamespacePaths,
@@ -93,6 +147,7 @@ export async function waitForLauncherAfterQuit(
 export async function inspectExistingDesktopForLauncher(
   namespace: string,
   options: {
+    incomingVersion?: string | null;
     logger?: LauncherAfterQuitLogger;
     paths: PackagedNamespacePaths;
     requestIpc?: typeof requestJsonIpc;
@@ -151,29 +206,41 @@ export async function inspectExistingDesktopForLauncher(
       options.paths,
       `inspect-found-existing namespace=${namespace} action=restart reason=stale-sidecar apps=${staleSidecars.join(",")} pid=${pid ?? "unknown"}`,
     );
-    try {
-      await requestIpc(ipcPath, { type: SIDECAR_MESSAGES.SHUTDOWN }, { timeoutMs: 800 });
-    } catch (error) {
-      const message = `inspect-found-existing namespace=${namespace} shutdown=failed reason=stale-sidecar error=${error instanceof Error ? error.message : String(error)}`;
-      await writeLauncherAfterQuitLog(options.paths, message);
-      logger.warn(`[open-design launcher] ${message}`);
-      return { action: "exit", reason: "existing-focus-failed" };
-    }
-    if (pid != null) {
-      const exited = await waitForExit(pid, 5000);
-      await writeLauncherAfterQuitLog(
-        options.paths,
-        `inspect-found-existing namespace=${namespace} shutdown=${exited ? "exited" : "timed-out"} reason=stale-sidecar pid=${pid}`,
-      );
-      // A skewed desktop (running, but its own daemon/web sidecars are stale)
-      // that ignores SHUTDOWN would otherwise make us exit and leave the user
-      // pinned to it. Force it off the socket instead, then restart fresh.
-      if (!exited) {
-        const gone = await forceStopLingeringDesktop(pid, "stale-sidecar", options.paths, logger, stop);
-        if (!gone) return { action: "exit", reason: "existing-focus-failed" };
-      }
-    }
+    const restarted = await restartExistingDesktop({
+      ipcPath,
+      logger,
+      namespace,
+      paths: options.paths,
+      pid,
+      reason: "stale-sidecar",
+      requestIpc,
+      stop,
+      waitForExit,
+    });
+    if (!restarted) return { action: "exit", reason: "existing-focus-failed" };
     return { action: "continue", reason: "stale-sidecar" };
+  }
+
+  const existingVersion = status.update?.currentVersion;
+  if (incomingVersionSupersedesExisting(options.incomingVersion, existingVersion)) {
+    const pid = typeof status.pid === "number" ? status.pid : null;
+    await writeLauncherAfterQuitLog(
+      options.paths,
+      `inspect-found-existing namespace=${namespace} action=restart reason=superseded-version incomingVersion=${options.incomingVersion?.trim()} existingVersion=${existingVersion?.trim()} pid=${pid ?? "unknown"}`,
+    );
+    const restarted = await restartExistingDesktop({
+      ipcPath,
+      logger,
+      namespace,
+      paths: options.paths,
+      pid,
+      reason: "superseded-version",
+      requestIpc,
+      stop,
+      waitForExit,
+    });
+    if (!restarted) return { action: "exit", reason: "existing-focus-failed" };
+    return { action: "continue", reason: "superseded-version" };
   }
 
   try {

--- a/apps/packaged/src/launcher-after-quit.ts
+++ b/apps/packaged/src/launcher-after-quit.ts
@@ -20,6 +20,22 @@ export type LauncherExistingDesktopGateResult =
   | { action: "continue"; reason: "inspect-failed" | "not-running" | "stale-sidecar" | "superseded-version" }
   | { action: "exit"; reason: "existing-focused" | "existing-focus-failed" };
 
+/**
+ * Finish a duplicate packaged entry after the healthy namespace desktop has
+ * accepted focus (or after focus failed without making a duplicate safe).
+ *
+ * Returning from `main()` alone does not terminate Electron's event loop: the
+ * unused outer can keep a main process and Chromium helpers alive indefinitely.
+ */
+export function exitPackagedLauncherForExistingDesktop(
+  result: LauncherExistingDesktopGateResult,
+  exit: (code: number) => void,
+): boolean {
+  if (result.action !== "exit") return false;
+  exit(0);
+  return true;
+}
+
 async function writeLauncherAfterQuitLog(paths: PackagedNamespacePaths, message: string): Promise<void> {
   const logDir = join(paths.logsRoot, "launcher");
   await mkdir(logDir, { recursive: true });

--- a/apps/packaged/tests/launcher-after-quit.test.ts
+++ b/apps/packaged/tests/launcher-after-quit.test.ts
@@ -110,13 +110,62 @@ describe("waitForLauncherAfterQuit", () => {
 });
 
 describe("inspectExistingDesktopForLauncher", () => {
-  it("focuses an existing namespace desktop and exits", async () => {
+  it("restarts a healthy older desktop before a newer installed package continues", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-launcher-inspect-superseded-"));
+    const requests: unknown[] = [];
+    try {
+      const paths = fakePaths(root);
+
+      const result = await inspectExistingDesktopForLauncher("release-prerelease", {
+        incomingVersion: "0.16.0-prerelease.1",
+        paths,
+        requestIpc: (async (ipcPath: string, message: unknown) => {
+          requests.push(message);
+          if ((message as { type?: string }).type === SIDECAR_MESSAGES.STATUS) {
+            if (ipcPath.includes("daemon") || ipcPath.includes("web")) {
+              return { pid: 2345, state: "running", updatedAt: new Date().toISOString(), url: "http://127.0.0.1:1234" };
+            }
+            return {
+              pid: 1234,
+              state: "running",
+              update: { currentVersion: "0.15.1-prerelease.15" },
+              updatedAt: new Date().toISOString(),
+            };
+          }
+          return { accepted: true };
+        }) as typeof import("@open-design/sidecar").requestJsonIpc,
+        waitForExit: (async (pid: number) => pid === 1234) as typeof import("@open-design/platform").waitForProcessExit,
+      });
+
+      expect(result).toEqual({ action: "continue", reason: "superseded-version" });
+      expect(requests).toEqual([
+        { type: SIDECAR_MESSAGES.STATUS },
+        { type: SIDECAR_MESSAGES.STATUS },
+        { type: SIDECAR_MESSAGES.STATUS },
+        { type: SIDECAR_MESSAGES.SHUTDOWN },
+      ]);
+      const log = await readFile(join(root, "logs", "launcher", "after-quit.log"), "utf8");
+      expect(log).toContain(
+        "action=restart reason=superseded-version incomingVersion=0.16.0-prerelease.1 existingVersion=0.15.1-prerelease.15 pid=1234",
+      );
+      expect(log).toContain("shutdown=exited reason=superseded-version pid=1234");
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it.each([
+    { existingVersion: "0.16.0-prerelease.1", incomingVersion: "0.16.0-prerelease.1", label: "the same version" },
+    { existingVersion: "0.16.0-prerelease.2", incomingVersion: "0.16.0-prerelease.1", label: "a newer version" },
+    { existingVersion: undefined, incomingVersion: "0.16.0-prerelease.1", label: "an unknown historical version" },
+  ])("focuses an existing namespace desktop running $label", async ({ existingVersion, incomingVersion }) => {
     const root = await mkdtemp(join(tmpdir(), "od-launcher-inspect-focus-"));
     const requests: Array<{ message: unknown; timeoutMs?: number }> = [];
     try {
       const paths = fakePaths(root);
 
       const result = await inspectExistingDesktopForLauncher("release-beta-win", {
+        incomingVersion,
         paths,
         requestIpc: (async (ipcPath: string, message: unknown, options?: { timeoutMs?: number }) => {
           requests.push({ message, timeoutMs: options?.timeoutMs });
@@ -124,7 +173,12 @@ describe("inspectExistingDesktopForLauncher", () => {
             if (ipcPath.includes("daemon") || ipcPath.includes("web")) {
               return { pid: 2345, state: "running", updatedAt: new Date().toISOString(), url: "http://127.0.0.1:1234" };
             }
-            return { pid: 1234, state: "running", updatedAt: new Date().toISOString() };
+            return {
+              pid: 1234,
+              state: "running",
+              ...(existingVersion == null ? {} : { update: { currentVersion: existingVersion } }),
+              updatedAt: new Date().toISOString(),
+            };
           }
           return { accepted: true };
         }) as typeof import("@open-design/sidecar").requestJsonIpc,

--- a/apps/packaged/tests/launcher-after-quit.test.ts
+++ b/apps/packaged/tests/launcher-after-quit.test.ts
@@ -6,7 +6,11 @@ import { describe, expect, it, vi } from "vitest";
 import { SIDECAR_MESSAGES } from "@open-design/sidecar-proto";
 import type { StopProcessesResult, stopProcesses, waitForProcessExit } from "@open-design/platform";
 
-import { inspectExistingDesktopForLauncher, waitForLauncherAfterQuit } from "../src/launcher-after-quit.js";
+import {
+  exitPackagedLauncherForExistingDesktop,
+  inspectExistingDesktopForLauncher,
+  waitForLauncherAfterQuit,
+} from "../src/launcher-after-quit.js";
 import type { PackagedNamespacePaths } from "../src/paths.js";
 
 /** Build a `stopProcesses` result without signalling any real PID. */
@@ -106,6 +110,28 @@ describe("waitForLauncherAfterQuit", () => {
     } finally {
       await rm(root, { force: true, recursive: true });
     }
+  });
+});
+
+describe("exitPackagedLauncherForExistingDesktop", () => {
+  it.each(["existing-focused", "existing-focus-failed"] as const)(
+    "terminates the duplicate outer after %s",
+    (reason) => {
+      const exit = vi.fn();
+
+      expect(exitPackagedLauncherForExistingDesktop({ action: "exit", reason }, exit)).toBe(true);
+      expect(exit).toHaveBeenCalledExactlyOnceWith(0);
+    },
+  );
+
+  it("keeps the outer alive when startup must continue", () => {
+    const exit = vi.fn();
+
+    expect(exitPackagedLauncherForExistingDesktop(
+      { action: "continue", reason: "superseded-version" },
+      exit,
+    )).toBe(false);
+    expect(exit).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Fixes #4397

## Why

While validating the 0.16.0 prerelease, I reproduced a production upgrade failure where the installed app was `0.16.0-prerelease.1` but a healthy `0.15.1-prerelease.15` launcher payload kept handling every launch. The existing-desktop gate focused that old process and exited before the bound-package/runtime reconciliation could run.

That leaves users testing and reporting against the wrong version even after reinstalling. It also prevents the channel from converging without manually deleting launcher state. Strict updater validation additionally showed that a duplicate same-version outer could remain alive without a window after focusing the healthy payload because returning from packaged `main()` does not terminate Electron's event loop.

## What users will see

Opening a newly installed packaged app now replaces a healthy older payload before continuing startup. The existing runtime reconciliation then selects the installed version and updates launcher state. An existing instance with the same version, a newer version, or no reported historical version keeps the current single-instance focus behavior, and the unused duplicate outer now exits cleanly instead of leaving background Electron/Chromium processes.

This PR does not change macOS TCC permission behavior or the updater transaction/state-machine contract.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; there is no UI change.

## Bug fix verification

- Test path: `apps/packaged/tests/launcher-after-quit.test.ts`
- Yes. Before the supersession source change, the regression test failed because a newer incoming app returned `{ action: "exit", reason: "existing-focused" }`; it passes with a `SHUTDOWN` handshake and `{ action: "continue", reason: "superseded-version" }`.
- Yes. Before the duplicate-outer source change, the added exit specs failed because `exitPackagedLauncherForExistingDesktop` did not exist; they pass for both focus outcomes and verify that continuation is unaffected.

## Validation

- `pnpm --filter @open-design/packaged exec vitest run -c vitest.config.ts tests/launcher-after-quit.test.ts`
- `pnpm --filter @open-design/packaged test` — 18 files, 210 tests passed
- `pnpm --filter @open-design/packaged typecheck`
- `pnpm guard`
- `pnpm typecheck`
- macOS arm64 manual-overwrite acceptance: official stable 0.15.1 payload remained healthy while the 0.16.0 PR candidate outer opened. The launcher logged `reason=superseded-version`, stopped the old PID, and reconciled the actual process/runtime to 0.16.0. The unfixed control remained on 0.15.1.
- macOS arm64 strict updater acceptance, run twice with isolated namespaces: official stable 0.15.1 performed updater `check`, full real-payload `download`, non-dry-run `install`, renderer quit IPC, updater-helper relaunch/handoff, runtime confirmation, and full-stop cold start into a locally built stable 0.16.0 payload. Actual process path, updater metadata, runtime active/last-successful, `/api/health`, and `/api/version` all converged to 0.16.0.
- The strict run proves the normal updater path already stops the old process before handoff; the supersession guard is for abnormal stale healthy-payload recovery/manual overwrite. It also reproduced the duplicate-outer ghost, and the enhanced build exited that outer with code 0 in about 3.3 seconds without leaving candidate outer/helpers or replacing the healthy payload PID.
- Remaining release gates: macOS x64, Windows x64, and the final signed/notarized public candidate. TCC validation is intentionally separate.
