### PR TITLE
fix(web): close searchable model select popover when trigger scrolls out of safe region

### DIFF
--- a/apps/web/src/components/modelOptions.tsx
+++ b/apps/web/src/components/modelOptions.tsx
@@ -10,6 +10,17 @@ import {
   MODEL_CAPABILITY_TAG_LABEL_KEYS,
 } from './modelCapabilityTags';
 
+function stickyTopbarBottom(pad = 8): number | null {
+  const topbar = document.querySelector('.entry-main__topbar');
+  if (!(topbar instanceof HTMLElement)) return null;
+  const topbarRect = topbar.getBoundingClientRect();
+  return topbarRect.top <= pad && topbarRect.bottom > pad ? topbarRect.bottom : null;
+}
+
+function isInSafeRegion(rect: DOMRect, safeTop: number, safeBottom: number): boolean {
+  return rect.bottom > safeTop && rect.top < safeBottom;
+}
+
 export function renderModelOptions(models: AgentModelOption[]) {
   const groups = new Map<string, AgentModelOption[]>();
   const flat: AgentModelOption[] = [];
@@ -203,22 +214,31 @@ export const SearchableModelSelect = forwardRef<
         buttonRef.current?.getBoundingClientRect() ??
         wrapRef.current?.getBoundingClientRect();
       if (!rect) return;
-      const viewportWidth = typeof window === 'undefined' ? rect.width : window.innerWidth;
-      const viewportHeight = typeof window === 'undefined' ? rect.height : window.innerHeight;
+      const pad = 8;
+      const gap = 6;
+      const viewportWidth = window.innerWidth;
+      const viewportHeight = window.innerHeight;
+      const safeTop = stickyTopbarBottom(pad) ?? pad;
+      const safeBottom = viewportHeight - pad;
+      if (rect.width > 0 && rect.height > 0 && !isInSafeRegion(rect, safeTop, safeBottom)) {
+        setOpen(false);
+        setPopoverStyle(null);
+        return;
+      }
       const desiredWidth = Math.max(rect.width, popoverMinWidth ?? 0);
-      const maxWidth = Math.max(160, viewportWidth - 16);
+      const maxWidth = Math.max(160, viewportWidth - pad * 2);
       const width = Math.min(desiredWidth, maxWidth);
       const left = Math.min(
-        Math.max(8, rect.left),
-        Math.max(8, viewportWidth - width - 8),
+        Math.max(pad, rect.left),
+        Math.max(pad, viewportWidth - width - pad),
       );
-      const availableBelow = Math.max(140, viewportHeight - rect.bottom - 12);
-      const availableAbove = Math.max(140, rect.top - 12);
+      const availableBelow = Math.max(140, safeBottom - rect.bottom - gap);
+      const availableAbove = Math.max(140, rect.top - gap - safeTop);
       const shouldOpenUpward = availableBelow < 260 && availableAbove > availableBelow;
       const maxHeight = Math.min(360, shouldOpenUpward ? availableAbove : availableBelow);
       if (shouldOpenUpward) {
         setPopoverStyle({
-          bottom: Math.max(8, viewportHeight - rect.top + 6),
+          bottom: Math.max(pad, viewportHeight - rect.top + gap),
           left,
           width,
           maxHeight,
@@ -226,7 +246,7 @@ export const SearchableModelSelect = forwardRef<
         return;
       }
       setPopoverStyle({
-        top: rect.bottom + 6,
+        top: rect.bottom + gap,
         left,
         width,
         maxHeight,

--- a/e2e/ui/home-composer-topbar-stacking.test.ts
+++ b/e2e/ui/home-composer-topbar-stacking.test.ts
@@ -166,6 +166,85 @@ test('[P1] sticky topbar chips stay above the composer card while its switcher p
   ).toEqual([]);
 });
 
+test('[P1] nested model list stays inside the topbar safe region or closes when its trigger scrolls away', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1120, height: 640 });
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.getByText('Loading Open Design…').waitFor({ state: 'hidden', timeout: 15_000 });
+  await page.mouse.wheel(0, 500);
+  await scrollComposerUnderTopbar(page);
+
+  await page.getByTestId('inline-model-switcher-chip').click();
+  await expect(page.getByTestId('inline-model-switcher-popover')).toBeVisible();
+  await page.getByTestId('inline-model-switcher-agent-model').click();
+  const modelPopover = page.getByTestId('inline-model-switcher-agent-model-popover');
+  await expect(modelPopover).toBeVisible();
+
+  const beforeScroll = await page.evaluate(() => {
+    const topbar = document.querySelector('.entry-main__topbar');
+    const popover = document.querySelector(
+      '[data-testid="inline-model-switcher-agent-model-popover"]',
+    );
+    if (!topbar || !popover) return { ok: false, reason: 'missing nodes' };
+    const topbarRect = topbar.getBoundingClientRect();
+    const popoverRect = popover.getBoundingClientRect();
+    return {
+      ok: popoverRect.top >= topbarRect.bottom - 2,
+      reason: `popover top ${Math.round(popoverRect.top)} vs topbar bottom ${Math.round(topbarRect.bottom)}`,
+    };
+  });
+  expect(
+    beforeScroll.ok,
+    `nested model list should start below the sticky topbar (${beforeScroll.reason})`,
+  ).toBe(true);
+
+  await page.evaluate(() => {
+    const scroller = document.querySelector('.entry-main--scroll');
+    const card = document.querySelector('.home-hero__input-card');
+    const topbar = document.querySelector('.entry-main__topbar');
+    if (!scroller || !card || !topbar) return;
+    const topbarRect = topbar.getBoundingClientRect();
+    const cardTop = card.getBoundingClientRect().top;
+    scroller.scrollTop += Math.max(0, cardTop - topbarRect.top + topbarRect.height + 24);
+  });
+
+  const afterScroll = await page.evaluate(() => {
+    const topbar = document.querySelector('.entry-main__topbar');
+    const popover = document.querySelector(
+      '[data-testid="inline-model-switcher-agent-model-popover"]',
+    );
+    const trigger = document.querySelector(
+      '[data-testid="inline-model-switcher-agent-model"]',
+    );
+    if (!topbar || !trigger) return { ok: false, reason: 'missing nodes' };
+    const topbarRect = topbar.getBoundingClientRect();
+    const triggerRect = trigger.getBoundingClientRect();
+    const triggerInSafeRegion =
+      triggerRect.bottom > topbarRect.bottom && triggerRect.top < window.innerHeight - 8;
+    if (!popover) {
+      return { ok: true, closed: true, triggerInSafeRegion };
+    }
+    const popoverRect = popover.getBoundingClientRect();
+    return {
+      ok: popoverRect.top >= topbarRect.bottom - 2,
+      closed: false,
+      triggerInSafeRegion,
+      reason: `popover top ${Math.round(popoverRect.top)} vs topbar bottom ${Math.round(topbarRect.bottom)}`,
+    };
+  });
+
+  if (afterScroll.closed) {
+    expect(afterScroll.triggerInSafeRegion).toBe(false);
+    return;
+  }
+
+  expect(
+    afterScroll.ok,
+    `nested model list should stay below the sticky topbar after scrolling (${afterScroll.reason})`,
+  ).toBe(true);
+});
+
 // Scrolls `.entry-main--scroll` so the composer card's top edge lands inside
 // the sticky topbar strip (which stays pinned at the container's top). Fails
 // loudly when the container cannot scroll far enough to create the overlap.


### PR DESCRIPTION
Fixes #5905

## Why

- **Your use case — what made you write this today?** Scratching an itch for visual refinement when scrolling the main workspace layout with open model popovers.
- **The pain being addressed — user-facing problem, technical debt, a prod issue, or unblocking another change:** 
  The model options popover under [SearchableModelSelect](file:///Users/utkarshsinghal/personal/open-design/apps/web/src/components/modelOptions.tsx#L214) could remain open and overflow/overlap with the sticky topbar or scroll completely out of the viewport. This change introduces a safe scroll region bound by the sticky topbar bottom and viewport bottom, closing the popover when the trigger element scrolls outside of it.

## What users will see

- The searchable model selection popover now automatically closes when the user scrolls and the trigger element goes out of view (either behind the sticky topbar or off the bottom of the screen).
- Popover positioning and height constraints are adjusted dynamically based on the sticky topbar's bottom edge.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

<img width="475" height="481" alt="image" src="https://github.com/user-attachments/assets/d3f27339-bea7-4326-a6e1-2f50f1b6de0f" />
<img width="477" height="435" alt="image" src="https://github.com/user-attachments/assets/9f293403-7d79-428a-b0cf-6de6a536655c" />

## Bug fix verification

- Test path that reproduces the bug: [home-composer-topbar-stacking.test.ts#L169-L247](file:///Users/utkarshsinghal/personal/open-design/e2e/ui/home-composer-topbar-stacking.test.ts#L169-L247)
- Did the test go red on `main` and green on this branch? yes

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web test`
