### PR TITLE
fix(daemon): stop ACP model detection from leaving a session in the daemon cwd

### DIFF
--- a/apps/daemon/src/agent-protocol/acp/constants.ts
+++ b/apps/daemon/src/agent-protocol/acp/constants.ts
@@ -39,3 +39,15 @@ export const ACP_RAW_EVENT_SHAPE_DIAGNOSTIC_LIMIT = 8;
 export const AMR_STDERR_RETRY_TAIL_LIMIT = 16_000;
 /** Normalised token IDs that identify a model-selection config option in an ACP `session/new` response's `configOptions` array. */
 export const MODEL_CONFIG_OPTION_IDS = new Set(['model', 'models', 'modelid', 'modelids']);
+// ACP exposes the model list only inside a `session/new` result, so model
+// detection has to open a real session on the agent. Session-persisting
+// agents (Kimi CLI, and any other CLI that writes a durable session index)
+// keep that session forever, so the probe must not inherit the daemon's cwd
+// — under Electron that is `/`, which registers a workspace spanning the
+// whole filesystem. Probe inside a dedicated directory instead, and cache
+// the result so a burst of `detectAgents()` calls opens one session, not one
+// per call.
+/** Directory name, created under the OS temp dir, used as the working directory for ACP model-detection probes. */
+export const ACP_PROBE_DIR_NAME = 'open-design-acp-probe';
+/** How long a successful ACP model-detection result is reused before the probe re-opens a session on the agent. */
+export const ACP_MODEL_CACHE_TTL_MS = 5 * 60 * 1000;

--- a/apps/daemon/src/agent-protocol/acp/constants.ts
+++ b/apps/daemon/src/agent-protocol/acp/constants.ts
@@ -47,7 +47,7 @@ export const MODEL_CONFIG_OPTION_IDS = new Set(['model', 'models', 'modelid', 'm
 // whole filesystem. Probe inside a dedicated directory instead, and cache
 // the result so a burst of `detectAgents()` calls opens one session, not one
 // per call.
-/** Directory name, created under the OS temp dir, used as the working directory for ACP model-detection probes. */
+/** Prefix for the process-private directory used as the working directory for ACP model-detection probes. */
 export const ACP_PROBE_DIR_NAME = 'open-design-acp-probe';
 /** How long a successful ACP model-detection result is reused before the probe re-opens a session on the agent. */
 export const ACP_MODEL_CACHE_TTL_MS = 5 * 60 * 1000;

--- a/apps/daemon/src/agent-protocol/acp/index.ts
+++ b/apps/daemon/src/agent-protocol/acp/index.ts
@@ -6,5 +6,11 @@
  * buildAcpSessionNewParams, AcpMcpServerInput).
  */
 export { type AcpMcpServerInput, buildAcpSessionNewParams } from './session-params.js';
-export { type ModelOption, normalizeModels, detectAcpModels } from './models.js';
+export {
+  type ModelOption,
+  normalizeModels,
+  detectAcpModels,
+  acpProbeCwd,
+  clearAcpModelCache,
+} from './models.js';
 export { attachAcpSession } from './session.js';

--- a/apps/daemon/src/agent-protocol/acp/models.ts
+++ b/apps/daemon/src/agent-protocol/acp/models.ts
@@ -7,9 +7,19 @@
  * acp/rpc, and acp/session-params.
  */
 import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { createJsonLineStream } from '../core/index.js';
 import type { JsonRpcId, JsonObject, TimerHandle } from './types.js';
-import { ACP_PROTOCOL_VERSION, DEFAULT_TIMEOUT_MS, MODEL_CONFIG_OPTION_IDS } from './constants.js';
+import {
+  ACP_MODEL_CACHE_TTL_MS,
+  ACP_PROBE_DIR_NAME,
+  ACP_PROTOCOL_VERSION,
+  DEFAULT_TIMEOUT_MS,
+  MODEL_CONFIG_OPTION_IDS,
+} from './constants.js';
 import { errorMessage, resolveAcpTimeoutMs, asObject } from './json.js';
 import { sendRpc, rpcErrorMessage } from './rpc.js';
 import { buildAcpSessionNewParams } from './session-params.js';
@@ -35,6 +45,64 @@ export interface DetectAcpModelsOptions {
   clientName?: string;
   clientVersion?: string;
   defaultModelOption?: ModelOption;
+  forceRefresh?: boolean;
+}
+
+let probeCwd: string | null = null;
+/**
+ * Returns the working directory ACP model-detection probes run in, creating it
+ * on first use. Probes must not inherit the daemon's cwd: the desktop app
+ * launches the daemon with cwd `/`, and agents that persist sessions would
+ * record a workspace covering the entire filesystem.
+ *
+ * @returns An absolute path to the probe directory, falling back to the OS temp dir when it cannot be created.
+ */
+export function acpProbeCwd(): string {
+  if (probeCwd) return probeCwd;
+  const dir = path.join(os.tmpdir(), ACP_PROBE_DIR_NAME);
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    probeCwd = dir;
+  } catch {
+    probeCwd = os.tmpdir();
+  }
+  return probeCwd;
+}
+
+interface AcpModelCacheEntry {
+  expiresAt: number;
+  models: ModelOption[];
+}
+const modelCache = new Map<string, AcpModelCacheEntry>();
+const inFlightProbes = new Map<string, Promise<ModelOption[]>>();
+
+// The probe environment selects which account and endpoint an agent reports
+// models for, so it belongs in the key — hashed rather than stored verbatim,
+// since it carries API tokens.
+function modelCacheKey(
+  bin: string,
+  args: string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+): string {
+  const envDigest = createHash('sha256')
+    .update(
+      Object.keys(env)
+        .sort()
+        .map((name) => `${name}=${env[name] ?? ''}`)
+        .join('\0'),
+    )
+    .digest('hex');
+  return [bin, cwd, envDigest, ...args].join('\0');
+}
+
+/**
+ * Drops cached ACP model-detection results so the next `detectAcpModels` call
+ * re-probes the agent. Intended for tests and for an explicit user-triggered
+ * refresh; normal detection relies on the TTL.
+ */
+export function clearAcpModelCache(): void {
+  modelCache.clear();
 }
 /**
  * Normalises a raw config-option field value to a lowercase, whitespace- and
@@ -202,20 +270,50 @@ export function currentModelFromSessionResult(result: JsonObject): string | null
  * Used by runtime adapter definitions to populate the model-selection dropdown
  * without waiting for an actual prompt run.
  *
+ * The `session/new` this performs is not a read: agents that persist sessions
+ * keep the probe session permanently. Successful results are therefore cached
+ * for `ACP_MODEL_CACHE_TTL_MS` and concurrent probes for the same binary share
+ * one subprocess, so repeated `detectAgents()` calls do not each open a
+ * session. Pass `forceRefresh` to bypass the cache.
+ *
  * @param options.bin - Absolute path or `$PATH`-resolvable name of the ACP binary.
  * @param options.args - CLI arguments to pass to the binary.
- * @param options.cwd - Working directory for the probe subprocess.
+ * @param options.cwd - Working directory for the probe subprocess (default: a dedicated temp directory).
  * @param options.env - Environment for the probe subprocess (default: `process.env`).
  * @param options.timeoutMs - Hard timeout for the probe; subject to `MAX_TIMEOUT_MS`.
  * @param options.clientName - Client name sent in the `initialize` handshake.
  * @param options.clientVersion - Client version sent in the `initialize` handshake.
  * @param options.defaultModelOption - Fallback option prepended to the result list.
+ * @param options.forceRefresh - Ignore any cached result and re-probe the agent.
  * @returns A promise resolving to the available `ModelOption[]`.
  */
-export async function detectAcpModels({
+export async function detectAcpModels(
+  options: DetectAcpModelsOptions,
+): Promise<ModelOption[]> {
+  const cwd = options.cwd ?? acpProbeCwd();
+  const key = modelCacheKey(options.bin, options.args, cwd, options.env ?? process.env);
+  if (!options.forceRefresh) {
+    const cached = modelCache.get(key);
+    if (cached && cached.expiresAt > Date.now()) return cached.models;
+    const inFlight = inFlightProbes.get(key);
+    if (inFlight) return await inFlight;
+  }
+  const probe = runAcpModelProbe({ ...options, cwd })
+    .then((models) => {
+      modelCache.set(key, { expiresAt: Date.now() + ACP_MODEL_CACHE_TTL_MS, models });
+      return models;
+    })
+    .finally(() => {
+      if (inFlightProbes.get(key) === probe) inFlightProbes.delete(key);
+    });
+  inFlightProbes.set(key, probe);
+  return await probe;
+}
+
+async function runAcpModelProbe({
   bin,
   args,
-  cwd = process.cwd(),
+  cwd = acpProbeCwd(),
   env = process.env,
   timeoutMs = DEFAULT_TIMEOUT_MS,
   clientName = 'open-design-detect',

--- a/apps/daemon/src/agent-protocol/acp/models.ts
+++ b/apps/daemon/src/agent-protocol/acp/models.ts
@@ -50,22 +50,22 @@ export interface DetectAcpModelsOptions {
 
 let probeCwd: string | null = null;
 /**
- * Returns the working directory ACP model-detection probes run in, creating it
- * on first use. Probes must not inherit the daemon's cwd: the desktop app
- * launches the daemon with cwd `/`, and agents that persist sessions would
- * record a workspace covering the entire filesystem.
+ * Returns the private working directory ACP model-detection probes run in,
+ * creating it atomically on first use. Probes must not inherit the daemon's
+ * cwd: the desktop app launches the daemon with cwd `/`, and agents that
+ * persist sessions would record a workspace covering the entire filesystem.
  *
- * @returns An absolute path to the probe directory, falling back to the OS temp dir when it cannot be created.
+ * `mkdtempSync` both chooses an unpredictable suffix and atomically creates the
+ * directory (with owner-only permissions on POSIX). It therefore cannot accept
+ * a pre-existing fixed-name symlink. Creation failures are intentionally
+ * surfaced rather than falling back to the shared temp root, which would
+ * weaken the isolation invariant this helper owns.
+ *
+ * @returns An absolute path to the process-private probe directory.
  */
 export function acpProbeCwd(): string {
   if (probeCwd) return probeCwd;
-  const dir = path.join(os.tmpdir(), ACP_PROBE_DIR_NAME);
-  try {
-    fs.mkdirSync(dir, { recursive: true });
-    probeCwd = dir;
-  } catch {
-    probeCwd = os.tmpdir();
-  }
+  probeCwd = fs.mkdtempSync(path.join(os.tmpdir(), `${ACP_PROBE_DIR_NAME}-`));
   return probeCwd;
 }
 

--- a/apps/daemon/src/agent-protocol/index.ts
+++ b/apps/daemon/src/agent-protocol/index.ts
@@ -9,6 +9,8 @@ export {
   buildAcpSessionNewParams,
   normalizeModels,
   detectAcpModels,
+  acpProbeCwd,
+  clearAcpModelCache,
   attachAcpSession,
 } from './acp/index.js';
 export { mapPiRpcEvent, attachPiRpcSession, parsePiModels } from './pi-rpc/index.js';

--- a/apps/daemon/tests/acp-model-probe-isolation.test.ts
+++ b/apps/daemon/tests/acp-model-probe-isolation.test.ts
@@ -1,0 +1,143 @@
+import assert from 'node:assert/strict';
+import { chmodSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, test } from 'vitest';
+import { acpProbeCwd, clearAcpModelCache, detectAcpModels } from '../src/agent-protocol/index.js';
+
+// A fake ACP agent that records every `session/new` it receives — the request
+// `cwd`, and the cwd the probe subprocess itself was spawned in — so a test can
+// assert both how often a session was opened and where it was rooted.
+function writeRecordingProbe(): { dir: string; bin: string; log: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'od-acp-probe-'));
+  const bin = join(dir, 'recording-acp-probe.mjs');
+  const log = join(dir, 'sessions.jsonl');
+  writeFileSync(
+    bin,
+    [
+      'import { appendFileSync } from "node:fs";',
+      `const log = ${JSON.stringify(log)};`,
+      'process.stdin.setEncoding("utf8");',
+      'let buffer = "";',
+      'process.stdin.on("data", (chunk) => {',
+      '  buffer += chunk;',
+      '  for (;;) {',
+      '    const idx = buffer.indexOf("\\n");',
+      '    if (idx === -1) break;',
+      '    const line = buffer.slice(0, idx).trim();',
+      '    buffer = buffer.slice(idx + 1);',
+      '    if (!line) continue;',
+      '    const message = JSON.parse(line);',
+      '    if (message.method === "session/new") {',
+      '      appendFileSync(log, JSON.stringify({ requestedCwd: message.params.cwd, spawnCwd: process.cwd() }) + "\\n");',
+      '      process.stdout.write(JSON.stringify({ id: message.id, result: { sessionId: "s1", configOptions: [{ type: "select", id: "model", category: "model", currentValue: "m1", options: [{ value: "m1", name: "Model One" }] }] } }) + "\\n");',
+      '      continue;',
+      '    }',
+      '    process.stdout.write(JSON.stringify({ id: message.id, result: {} }) + "\\n");',
+      '  }',
+      '});',
+      'process.stdin.resume();',
+    ].join('\n'),
+    'utf8',
+  );
+  chmodSync(bin, 0o755);
+  return { dir, bin, log };
+}
+
+function readSessions(log: string): { requestedCwd: string; spawnCwd: string }[] {
+  try {
+    return readFileSync(log, 'utf8')
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line) => JSON.parse(line));
+  } catch {
+    return [];
+  }
+}
+
+beforeEach(() => {
+  clearAcpModelCache();
+});
+
+test('ACP model detection does not open its session in the daemon cwd', async () => {
+  const { dir, bin, log } = writeRecordingProbe();
+  try {
+    const models = await detectAcpModels({ bin: process.execPath, args: [bin] });
+    assert.deepEqual(models, [
+      { id: 'default', label: 'Default (CLI config)' },
+      { id: 'm1', label: 'Model One (m1) • current' },
+    ]);
+
+    const [session, ...rest] = readSessions(log);
+    assert.ok(session);
+    assert.equal(rest.length, 0);
+    // The desktop app launches the daemon with cwd `/`; a probe session rooted
+    // there registers a workspace spanning the whole filesystem in agents that
+    // persist their session index.
+    assert.notEqual(session.requestedCwd, process.cwd());
+    assert.notEqual(session.requestedCwd, '/');
+    assert.equal(session.requestedCwd, acpProbeCwd());
+    // macOS resolves the temp dir's /var -> /private/var symlink in the child.
+    assert.equal(realpathSync(session.spawnCwd), realpathSync(acpProbeCwd()));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('ACP model detection reuses a cached list instead of opening another session', async () => {
+  const { dir, bin, log } = writeRecordingProbe();
+  try {
+    const first = await detectAcpModels({ bin: process.execPath, args: [bin] });
+    const second = await detectAcpModels({ bin: process.execPath, args: [bin] });
+
+    assert.deepEqual(second, first);
+    assert.equal(readSessions(log).length, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('concurrent ACP model detection shares a single probe session', async () => {
+  const { dir, bin, log } = writeRecordingProbe();
+  try {
+    const results = await Promise.all([
+      detectAcpModels({ bin: process.execPath, args: [bin] }),
+      detectAcpModels({ bin: process.execPath, args: [bin] }),
+      detectAcpModels({ bin: process.execPath, args: [bin] }),
+    ]);
+
+    assert.deepEqual(results[1], results[0]);
+    assert.deepEqual(results[2], results[0]);
+    assert.equal(readSessions(log).length, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('ACP model detection re-probes when the caller forces a refresh', async () => {
+  const { dir, bin, log } = writeRecordingProbe();
+  try {
+    await detectAcpModels({ bin: process.execPath, args: [bin] });
+    await detectAcpModels({ bin: process.execPath, args: [bin], forceRefresh: true });
+
+    assert.equal(readSessions(log).length, 2);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('ACP model detection still honours an explicit probe cwd', async () => {
+  const { dir, bin, log } = writeRecordingProbe();
+  const projectDir = mkdtempSync(join(tmpdir(), 'od-acp-project-'));
+  try {
+    await detectAcpModels({ bin: process.execPath, args: [bin], cwd: projectDir });
+
+    const [session, ...rest] = readSessions(log);
+    assert.ok(session);
+    assert.equal(rest.length, 0);
+    assert.equal(session.requestedCwd, projectDir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(projectDir, { recursive: true, force: true });
+  }
+});

--- a/apps/daemon/tests/acp-model-probe-isolation.test.ts
+++ b/apps/daemon/tests/acp-model-probe-isolation.test.ts
@@ -1,9 +1,19 @@
 import assert from 'node:assert/strict';
-import { chmodSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { beforeEach, test } from 'vitest';
+import { basename, dirname, join, parse } from 'node:path';
+import { beforeEach, test, vi } from 'vitest';
 import { acpProbeCwd, clearAcpModelCache, detectAcpModels } from '../src/agent-protocol/index.js';
+import { ACP_PROBE_DIR_NAME } from '../src/agent-protocol/acp/constants.js';
 
 // A fake ACP agent that records every `session/new` it receives — the request
 // `cwd`, and the cwd the probe subprocess itself was spawned in — so a test can
@@ -139,5 +149,46 @@ test('ACP model detection still honours an explicit probe cwd', async () => {
   } finally {
     rmSync(dir, { recursive: true, force: true });
     rmSync(projectDir, { recursive: true, force: true });
+  }
+});
+
+test('ACP probe cwd does not follow a hostile fixed-name symlink in the temp directory', async () => {
+  const hostileTmpDir = mkdtempSync(join(tmpdir(), 'od-acp-hostile-tmp-'));
+  const rootDir = parse(hostileTmpDir).root;
+  const predictableProbePath = join(hostileTmpDir, ACP_PROBE_DIR_NAME);
+  const previousTmpEnv = {
+    TMPDIR: process.env.TMPDIR,
+    TMP: process.env.TMP,
+    TEMP: process.env.TEMP,
+  };
+
+  try {
+    symlinkSync(rootDir, predictableProbePath, process.platform === 'win32' ? 'junction' : 'dir');
+    process.env.TMPDIR = hostileTmpDir;
+    process.env.TMP = hostileTmpDir;
+    process.env.TEMP = hostileTmpDir;
+
+    vi.resetModules();
+    const { acpProbeCwd: isolatedAcpProbeCwd } = await import(
+      '../src/agent-protocol/acp/models.js'
+    );
+    const probeDir = isolatedAcpProbeCwd();
+    const probeStat = lstatSync(probeDir);
+
+    assert.equal(dirname(probeDir), hostileTmpDir);
+    assert.match(basename(probeDir), new RegExp(`^${ACP_PROBE_DIR_NAME}-`));
+    assert.notEqual(probeDir, predictableProbePath);
+    assert.equal(probeStat.isDirectory(), true);
+    assert.equal(probeStat.isSymbolicLink(), false);
+    assert.notEqual(realpathSync(probeDir), realpathSync(rootDir));
+    if (process.platform !== 'win32') {
+      assert.equal(probeStat.mode & 0o777, 0o700);
+    }
+  } finally {
+    for (const [name, value] of Object.entries(previousTmpEnv)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+    rmSync(hostileTmpDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Why

I use Open Design with Kimi CLI as the agent. I noticed my Kimi session list filling up with junk: **62 empty "New Session" entries appeared in ~2h45m**, all with `workDir: "/"`, none containing a single user message. They came from Open Design.

The cause is that ACP only exposes an agent's model list inside a `session/new` result, so `detectAcpModels` opens a real session just to read it, then `SIGTERM`s the child. For agents that persist sessions (Kimi CLI writes a global `session_index.jsonl`), that probe session is permanent. Two things make it hurt:

1. **The probe inherits the daemon's cwd.** `detectAcpModels` defaulted to `cwd = process.cwd()`. The desktop app launches the daemon with cwd `/` (verified via `lsof` on the running Helper process), so every probe registered a workspace rooted at the **entire filesystem** — for a coding agent that is both meaningless and a bad default.
2. **Every `detectAgents()` re-probes.** There's no caching, and `detectAgents()` is called from many places (`server.ts` startup, chat runs, analytics, `routes/runs.ts`), sometimes concurrently — so each call opened another permanent session.

Worth flagging: `runtimes/detection.ts` describes these probes as "three post-version probes are independent **reads**". `fetchModels` is not a read — it mutates persistent state in the agent CLI. That mismatch is the underlying bug.

## What users will see

Nothing changes in the UI, and model detection returns the same list. What stops happening is Open Design littering the user's agent CLI with sessions:

- Model detection no longer creates sessions rooted at `/`. It uses an atomically created, process-private `open-design-acp-probe-*` directory under the OS temp dir, so probe sessions are confined to one clearly-named workspace instead of claiming the filesystem root.
- Repeated detection reuses a cached list for 5 minutes, and concurrent detections share one subprocess, so a burst of `detectAgents()` calls opens one probe session rather than one per call.

Measured against the real `kimi` binary, driving detection from cwd `/` exactly as Electron launches the daemon — 11 detection calls (6 sequential + 4 concurrent + 1):

| | sessions persisted by Kimi | `workDir` recorded |
|---|---|---|
| before | 11 | `/` |
| after | 1 | `…/T/open-design-acp-probe-*` |

Trade-off: a model list can be up to 5 minutes stale (`ACP_MODEL_CACHE_TTL_MS`). `detectAcpModels({ forceRefresh: true })` and the exported `clearAcpModelCache()` bypass it if a user-triggered refresh is wired up later. The cache key includes a SHA-256 digest of the probe env, so switching account/endpoint doesn't serve another account's models. Callers that pass an explicit `cwd` are unaffected.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — model detection no longer probes in the daemon's cwd, and results are cached for 5 minutes instead of re-probed on every `detectAgents()`. No schema or setting changes.
- [ ] **None**

## Screenshots

n/a — no UI change.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/acp-model-probe-isolation.test.ts`
- Did the test go red on `main` and green on this branch? **yes** — 5/5 fail on `main`, 5/5 pass here.

The test spawns a fake ACP agent that appends every `session/new` it receives (the requested `cwd`, and the cwd the probe was spawned in) to a log, then asserts the probe is not rooted in `process.cwd()`, that repeated and concurrent detection open exactly one session, that `forceRefresh` re-probes, and that an explicit `cwd` is still honoured.

Additionally verified end-to-end against the real `kimi` binary in a throwaway `KIMI_CODE_HOME`, with the daemon's cwd set to `/`: 11 detection calls produced 11 indexed sessions with `workDir: "/"` before the change and 1 session in the probe directory after it, with the same 4 models detected both times.

## Follow-up (not in this PR)

To be clear about what this does and doesn't fix: it stops Open Design from creating new junk sessions. It cannot clean up the ones already created — ACP has no `session/delete`, so once an agent has persisted a probe session there is no protocol-level way for a client to retract it. Kimi CLI does have `deleteSession` internally (`packages/node-sdk/src/kimi-harness.ts`), it just isn't exposed over ACP.

The real root cause sits in the protocol, not here: ACP exposes an agent's model list **only** as a side effect of `session/new`, which forces every client to mutate persistent agent state to answer a read-only question. Open Design isn't the only client that will hit this, and every session-persisting agent is affected. Two things worth pursuing separately, and I'm happy to take either on if maintainers agree on the direction:

1. Propose a session-less model-enumeration method upstream in the ACP spec (or reuse `initialize`'s `agentCapabilities` to carry the model list), and prefer it when the agent advertises support.
2. Consider whether probe sessions should be opt-out entirely for agents whose `fallbackModels` are already accurate, trading an occasionally stale picker for zero writes into the user's agent history.

## Validation

- `pnpm guard` — 86/86 pass
- `apps/daemon`: `tsc -p tsconfig.json --noEmit` and `tsc -p tsconfig.tests.json --noEmit` — both clean
- `pnpm --filter @open-design/daemon test` scoped to the affected areas: `tests/acp-model-probe-isolation.test.ts`, `tests/acp.test.ts`, `tests/acp-timeout-env.test.ts`, `tests/amr-acp-integration.test.ts`, `tests/runtimes/**` — 670 pass, 1 skipped
- 4 failures in `tests/runtimes/run-failure-telemetry-smoke.test.ts` are pre-existing in my environment (`better-sqlite3` native bindings unbuilt because I installed with `--ignore-scripts`); they fail identically on a pristine checkout.


## Review follow-up (2026-08-10)

The QA blocker on the fixed-name probe path is addressed in `b3cda6fa`:

- `acpProbeCwd()` now uses `mkdtempSync` to atomically create a process-private `open-design-acp-probe-*` directory. It never accepts the old fixed-name path and no longer falls back to the shared temp root.
- Added the hostile `TMPDIR` regression with `open-design-acp-probe -> /`; it verifies a real non-symlink directory, a distinct random suffix, and POSIX mode `0700`. The new case failed on the previous head and passes after the fix.
- Validation: focused isolation test 6/6; daemon typecheck clean; `pnpm guard` 86/86; affected ACP/runtimes scope 710 pass, 1 skipped. The same four documented `run-failure-telemetry-smoke` failures remain because this checkout was installed with `--ignore-scripts` and has no `better-sqlite3` native binding.
