### PR TITLE
fix(pack): preserve native fsevents in mac bundles

### DIFF
--- a/tools/pack/src/mac-prebundle.ts
+++ b/tools/pack/src/mac-prebundle.ts
@@ -15,7 +15,8 @@ export const MAC_PREBUNDLE_ENTRYPOINTS_DIR_NAME = "prebundle-entrypoints";
 
 // Runtime externals the prebundled daemon loads from node_modules at boot
 // (see the `externals` in MAC_PREBUNDLE_POLICIES below). Their pinned versions
-// MUST stay in lockstep with apps/daemon/package.json / the pnpm lockfile: the
+// MUST stay in lockstep with apps/daemon/package.json and its transitive native
+// dependencies in the pnpm lockfile: the
 // app is assembled with these as its declared deps (mac/app.ts), and
 // electron-builder 26's pnpm node_modules collector DROPS a dependency whose
 // pin doesn't semver-satisfy the version resolvable on disk — silently
@@ -25,6 +26,14 @@ export const MAC_PREBUNDLE_ENTRYPOINTS_DIR_NAME = "prebundle-entrypoints";
 export const MAC_PREBUNDLE_RUNTIME_DEPENDENCIES = {
   "better-sqlite3": "12.10.0",
   "blake3-wasm": "2.1.5",
+} as const;
+
+// npm 11 synthesizes a `node-gyp rebuild` install step for fsevents even
+// though its published package already contains a universal prebuilt binding
+// and no binding.gyp. Keep it optional during npm assembly, then copy the
+// pnpm-materialized package into the app after install (mac/app.ts).
+export const MAC_PREBUNDLE_COPIED_RUNTIME_DEPENDENCIES = {
+  "fsevents": "2.3.3",
 } as const;
 
 export const MAC_STANDALONE_PREBUNDLE_EXCLUDED_INTERNAL_PACKAGES = [
@@ -51,12 +60,13 @@ export const MAC_PREBUNDLE_POLICIES = {
     label: "packaged main",
   },
   daemonCli: {
-    externals: ["better-sqlite3", "blake3-wasm"],
+    externals: ["better-sqlite3", "blake3-wasm", "fsevents"],
     forbiddenInputs: [
       "/node_modules/@open-design/daemon/",
       "/node_modules/better-sqlite3/",
       "/node_modules/blake3-wasm/",
       "/node_modules/electron/",
+      "/node_modules/fsevents/",
       "/node_modules/next/",
       "/node_modules/openai/",
       "/node_modules/react/",
@@ -65,12 +75,13 @@ export const MAC_PREBUNDLE_POLICIES = {
     label: "daemon cli",
   },
   daemonSidecar: {
-    externals: ["better-sqlite3", "blake3-wasm"],
+    externals: ["better-sqlite3", "blake3-wasm", "fsevents"],
     forbiddenInputs: [
       "/node_modules/@open-design/daemon/",
       "/node_modules/better-sqlite3/",
       "/node_modules/blake3-wasm/",
       "/node_modules/electron/",
+      "/node_modules/fsevents/",
       "/node_modules/next/",
       "/node_modules/openai/",
       "/node_modules/react/",

--- a/tools/pack/src/mac/app.ts
+++ b/tools/pack/src/mac/app.ts
@@ -1,4 +1,5 @@
-import { cp, mkdir, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { cp, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { dirname, join, relative } from "node:path";
 
 import { rebuild, type RebuildOptions } from "@electron/rebuild";
@@ -6,6 +7,7 @@ import { rebuild, type RebuildOptions } from "@electron/rebuild";
 import type { ToolPackConfig } from "../config.js";
 import {
   MAC_DAEMON_PREBUNDLE_ESM_REQUIRE_BANNER,
+  MAC_PREBUNDLE_COPIED_RUNTIME_DEPENDENCIES,
   MAC_PREBUNDLE_ESBUILD_TARGET,
   MAC_PREBUNDLE_POLICIES,
   MAC_PREBUNDLE_RUNTIME_DEPENDENCIES,
@@ -172,6 +174,33 @@ export function renderMacPackagedConfig(options: {
   )}\n`;
 }
 
+export async function copyMacPrebundleRuntimeDependencies(
+  config: ToolPackConfig,
+  appRoot: string,
+): Promise<void> {
+  const daemonRequire = createRequire(join(config.workspaceRoot, "apps", "daemon", "package.json"));
+  const chokidarRequire = createRequire(daemonRequire.resolve("chokidar/package.json"));
+  for (const [packageName, expectedVersion] of Object.entries(MAC_PREBUNDLE_COPIED_RUNTIME_DEPENDENCIES)) {
+    const sourceManifestPath = chokidarRequire.resolve(`${packageName}/package.json`);
+    const sourceRoot = dirname(sourceManifestPath);
+    const sourceManifest = JSON.parse(await readFile(sourceManifestPath, "utf8")) as { version?: unknown };
+    if (sourceManifest.version !== expectedVersion) {
+      throw new Error(
+        `mac prebundle runtime dependency ${packageName} expected ${expectedVersion}, found ${String(sourceManifest.version)}`,
+      );
+    }
+
+    const nativeBindingPath = join(sourceRoot, `${packageName}.node`);
+    if (!(await stat(nativeBindingPath)).isFile()) {
+      throw new Error(`mac prebundle runtime dependency native binding is missing: ${nativeBindingPath}`);
+    }
+
+    const targetRoot = join(appRoot, "node_modules", packageName);
+    await rm(targetRoot, { force: true, recursive: true });
+    await cp(sourceRoot, targetRoot, { dereference: true, recursive: true });
+  }
+}
+
 export function createMacElectronRebuildOptions(
   config: ToolPackConfig,
   appRoot: string,
@@ -300,6 +329,9 @@ export async function writeAssembledApp(
     ...internalDependencies,
     ...(usePrebundledStandaloneWeb ? MAC_PREBUNDLE_RUNTIME_DEPENDENCIES : {}),
   };
+  const optionalDependencies = usePrebundledStandaloneWeb
+    ? MAC_PREBUNDLE_COPIED_RUNTIME_DEPENDENCIES
+    : undefined;
 
   await writeFile(
     paths.assembledPackageJsonPath,
@@ -309,6 +341,7 @@ export async function writeAssembledApp(
         description: "Open Design packaged runtime",
         main: "./main.cjs",
         name: "open-design-packaged-app",
+        ...(optionalDependencies == null ? {} : { optionalDependencies }),
         private: true,
         productName: identity.productName,
         version: packageVersion,
@@ -336,5 +369,8 @@ export async function writeAssembledApp(
     "utf8",
   );
   await runNpmInstall(paths.assembledAppRoot);
+  if (usePrebundledStandaloneWeb) {
+    await copyMacPrebundleRuntimeDependencies(config, paths.assembledAppRoot);
+  }
   await runMacElectronRebuild(config, paths.assembledAppRoot);
 }

--- a/tools/pack/tests/mac-prebundle.test.ts
+++ b/tools/pack/tests/mac-prebundle.test.ts
@@ -1,11 +1,14 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
+import { build } from "esbuild";
 import { describe, expect, it } from "vitest";
 
 import {
   MAC_DAEMON_PREBUNDLE_ESM_REQUIRE_BANNER,
+  MAC_PREBUNDLE_COPIED_RUNTIME_DEPENDENCIES,
   MAC_PREBUNDLE_ESBUILD_TARGET,
   MAC_PREBUNDLE_POLICIES,
   MAC_PREBUNDLE_RUNTIME_DEPENDENCIES,
@@ -73,8 +76,16 @@ describe("mac standalone prebundle policy", () => {
   it("documents the explicit code-level bundle boundaries", () => {
     expect(MAC_PREBUNDLE_ESBUILD_TARGET).toBe("node24");
     expect(MAC_PREBUNDLE_POLICIES.packagedMain.externals).toEqual(["electron"]);
-    expect(MAC_PREBUNDLE_POLICIES.daemonCli.externals).toEqual(["better-sqlite3", "blake3-wasm"]);
-    expect(MAC_PREBUNDLE_POLICIES.daemonSidecar.externals).toEqual(["better-sqlite3", "blake3-wasm"]);
+    expect(MAC_PREBUNDLE_POLICIES.daemonCli.externals).toEqual([
+      "better-sqlite3",
+      "blake3-wasm",
+      "fsevents",
+    ]);
+    expect(MAC_PREBUNDLE_POLICIES.daemonSidecar.externals).toEqual([
+      "better-sqlite3",
+      "blake3-wasm",
+      "fsevents",
+    ]);
     expect(MAC_PREBUNDLE_POLICIES.webSidecar.externals).toEqual([]);
     expect(MAC_DAEMON_PREBUNDLE_ESM_REQUIRE_BANNER).toContain("createRequire");
     // Must match apps/daemon/package.json / the pnpm lockfile, or
@@ -84,10 +95,38 @@ describe("mac standalone prebundle policy", () => {
       "better-sqlite3": "12.10.0",
       "blake3-wasm": "2.1.5",
     });
+    expect(MAC_PREBUNDLE_COPIED_RUNTIME_DEPENDENCIES).toEqual({ "fsevents": "2.3.3" });
     expect(MAC_PREBUNDLED_DAEMON_CLI_RELATIVE_PATH).toBe("app/prebundled/daemon/daemon-cli.mjs");
     expect(MAC_PREBUNDLED_DAEMON_SIDECAR_RELATIVE_PATH).toBe("app/prebundled/daemon/daemon-sidecar.mjs");
     expect(MAC_PREBUNDLED_WEB_SIDECAR_RELATIVE_PATH).toBe("app/prebundled/web-sidecar.mjs");
   });
+
+  it.skipIf(process.platform !== "darwin")(
+    "keeps chokidar's native fsevents binding outside daemon bundles",
+    async () => {
+      const workspaceRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+      const result = await build({
+        banner: { js: MAC_DAEMON_PREBUNDLE_ESM_REQUIRE_BANNER },
+        bundle: true,
+        external: [...MAC_PREBUNDLE_POLICIES.daemonSidecar.externals],
+        format: "esm",
+        logLevel: "silent",
+        metafile: true,
+        platform: "node",
+        stdin: {
+          contents: 'import "chokidar";',
+          loader: "js",
+          resolveDir: join(workspaceRoot, "apps", "daemon"),
+        },
+        target: MAC_PREBUNDLE_ESBUILD_TARGET,
+        write: false,
+      });
+
+      expect(Object.keys(result.metafile.inputs).some((input) => input.includes("/node_modules/fsevents/"))).toBe(
+        false,
+      );
+    },
+  );
 });
 
 describe("findForbiddenMacPrebundleInputs", () => {
@@ -155,6 +194,25 @@ describe("assertMacPrebundleMetafile", () => {
       await writeFile(
         metafilePath,
         JSON.stringify({ inputs: { "/repo/node_modules/blake3-wasm/dist/node/index.js": {} } }),
+        "utf8",
+      );
+
+      await expect(
+        assertMacPrebundleMetafile({ metafilePath, policyName: "daemonSidecar" }),
+      ).rejects.toThrow(/daemon sidecar prebundle included forbidden inputs/);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects a daemon metafile that bundled native runtime dependencies", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-mac-prebundle-"));
+    const metafilePath = join(root, "unsafe-native-daemon.json");
+
+    try {
+      await writeFile(
+        metafilePath,
+        JSON.stringify({ inputs: { "/repo/node_modules/fsevents/fsevents.js": {} } }),
         "utf8",
       );
 

--- a/tools/pack/tests/mac.test.ts
+++ b/tools/pack/tests/mac.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import type { ToolPackConfig } from "../src/config.js";
 import {
+  copyMacPrebundleRuntimeDependencies,
   copyResourceTree,
   createMacElectronRebuildOptions,
   renderMacPackagedConfig,
@@ -178,6 +179,52 @@ describe("copyResourceTree", () => {
       await copyResourceTree(config, paths);
 
       expect(await pathExists(join(paths.resourceRoot, "bin", "node"))).toBe(false);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("copyMacPrebundleRuntimeDependencies", () => {
+  it("copies the pinned prebuilt fsevents binding into the assembled app", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-tools-pack-mac-"));
+    try {
+      const config = makeConfig(root);
+      const chokidarRoot = join(root, "apps", "daemon", "node_modules", "chokidar");
+      const sourceRoot = join(chokidarRoot, "node_modules", "fsevents");
+      const appRoot = join(root, "assembled", "app");
+      await mkdir(sourceRoot, { recursive: true });
+      await writeFile(join(chokidarRoot, "package.json"), '{"name":"chokidar","version":"3.6.0"}\n', "utf8");
+      await writeFile(join(sourceRoot, "package.json"), '{"name":"fsevents","version":"2.3.3"}\n', "utf8");
+      await writeFile(join(sourceRoot, "fsevents.js"), "module.exports = {};\n", "utf8");
+      await writeFile(join(sourceRoot, "fsevents.node"), "prebuilt-native-binding", "utf8");
+
+      await copyMacPrebundleRuntimeDependencies(config, appRoot);
+
+      await expect(readFile(join(appRoot, "node_modules", "fsevents", "fsevents.node"), "utf8")).resolves.toBe(
+        "prebuilt-native-binding",
+      );
+      await expect(readFile(join(appRoot, "node_modules", "fsevents", "fsevents.js"), "utf8")).resolves.toBe(
+        "module.exports = {};\n",
+      );
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects a workspace fsevents version that drifted from the assembly contract", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-tools-pack-mac-"));
+    try {
+      const config = makeConfig(root);
+      const chokidarRoot = join(root, "apps", "daemon", "node_modules", "chokidar");
+      const sourceRoot = join(chokidarRoot, "node_modules", "fsevents");
+      await mkdir(sourceRoot, { recursive: true });
+      await writeFile(join(chokidarRoot, "package.json"), '{"name":"chokidar","version":"3.6.0"}\n', "utf8");
+      await writeFile(join(sourceRoot, "package.json"), '{"name":"fsevents","version":"2.3.2"}\n', "utf8");
+
+      await expect(copyMacPrebundleRuntimeDependencies(config, join(root, "assembled", "app"))).rejects.toThrow(
+        /fsevents expected 2\.3\.3, found 2\.3\.2/,
+      );
     } finally {
       await rm(root, { force: true, recursive: true });
     }


### PR DESCRIPTION
## Why

While validating the `0.16.0` prerelease, both mac arm64 and mac x64 jobs failed in `assembled-app` after #5922 moved the daemon to `chokidar@3.6.0`. Chokidar's macOS path loads the native `fsevents` binding, but the standalone daemon prebundle still tried to feed `fsevents.node` through esbuild and stopped with `No loader is configured for ".node" files`.

This blocks every new notarized mac prerelease—and therefore stable validation—even though the application/runtime change itself is otherwise valid.

## What users will see

macOS packaged builds using chokidar 3 complete successfully and ship the native FSEvents watcher used by the daemon. There is no UI or updater behavior change.

The implementation keeps `fsevents` outside the JavaScript bundle, declares it in the assembled app's optional runtime dependency contract, and copies the version-checked prebuilt universal binding materialized by pnpm. This avoids npm 11's synthesized `node-gyp rebuild`, which fails because the published `fsevents` package does not include `binding.gyp`.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI changes.

## Bug fix verification

- Test path: `tools/pack/tests/mac-prebundle.test.ts`, `keeps chokidar's native fsevents binding outside daemon bundles`
- Red on `main`: yes. Before source changes the focused spec failed with the same `fsevents/fsevents.node: No loader is configured for ".node" files` error as both prerelease mac jobs. The policy and metafile guard assertions also failed.
- Green on this branch: yes. The focused tests, full tools-pack suite, and a complete mac arm64 standalone App build all pass.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @open-design/tools-pack exec vitest run tests/mac-prebundle.test.ts tests/mac.test.ts`
- `pnpm --filter @open-design/tools-pack test` — 36 files passed, 246 tests passed, 8 skipped
- `pnpm --filter @open-design/tools-pack typecheck`
- `pnpm --filter @open-design/tools-pack build`
- `pnpm guard`
- `pnpm typecheck`
- `pnpm tools-pack mac build --dir <workspace-temp> --namespace release-prerelease --app-version 0.16.0-prerelease.9 --portable --to app --json`
- Verified the daemon metafile contains no `fsevents` inputs.
- Verified the final App contains `fsevents@2.3.3` and a universal arm64/x86_64 `fsevents.node`.
- Loaded the shipped module successfully with the final App's Electron runtime in Node mode (`watch` and `getInfo` exported as functions).
