### PR TITLE
Add Source Project Context plugin

### DIFF
--- a/plugins/community/source-project-context-mrulgah5/SKILL.md
+++ b/plugins/community/source-project-context-mrulgah5/SKILL.md
@@ -1,0 +1,50 @@
+# Source Project Context
+
+This design-system workspace was created from an existing Open Design project. Treat the copied project files as the primary source evidence for the generated design system.
+
+## Source project
+
+- Source project id: a4b376d0-5b42-4024-af98-faedbcf9cbc2
+- Source project name: Ixigo Flight Booking UI
+- New design-system project id: 05abffcf-0b71-4e0a-94de-0cc1b2d2470f
+- New design-system id: user:ixigo-flight-booking-ui-design-system
+- Source skill id: (none)
+- Source design system id: (none)
+
+## Source metadata
+
+```json
+{
+  "kind": "other",
+  "nameSource": "agent"
+}
+```
+
+## Copied files
+
+- payment.html
+- traveler-details.html
+- index.html
+- flight-search.html
+- booking-confirmation.html
+- flight-details.html
+- flight-results.html
+- assets/app.js
+- assets/design-system.css
+- brand-spec.md
+
+## Skipped files
+
+- (none)
+
+## Generation contract
+
+- Read this file before editing design-system outputs.
+- Read the copied files directly from the project workspace; they are source evidence, not generated design-system output.
+- Preserve high-signal assets, source examples, UI surfaces, copy, tokens, typography, and interaction patterns from the copied project.
+- Generate a reusable Open Design design-system package in this same project: DESIGN.md, README.md, SKILL.md, colors_and_type.css, context/provenance, focused preview cards, preserved assets/build/fonts when available, and ui_kits/app/.
+- Before final response, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every actionable issue.
+
+## Provenance
+
+Formalized by Open Design from candidate dc04a740-421e-46e5-988f-01d2e27a9602.

--- a/plugins/community/source-project-context-mrulgah5/open-design.json
+++ b/plugins/community/source-project-context-mrulgah5/open-design.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "source-project-context-mrulgah5",
+  "title": "Source Project Context",
+  "version": "0.1.0",
+  "description": "This design-system workspace was created from an existing Open Design project. Treat the copied project files as the primary source evidence for the generated design system.",
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ]
+  }
+}

--- a/plugins/community/source-project-context-mrulgah5/references/provenance.json
+++ b/plugins/community/source-project-context-mrulgah5/references/provenance.json
@@ -1,0 +1,33 @@
+{
+  "candidateId": "dc04a740-421e-46e5-988f-01d2e27a9602",
+  "projectId": "05abffcf-0b71-4e0a-94de-0cc1b2d2470f",
+  "runId": "6485dbf0-a848-4d85-9435-c66c53b7b2f8",
+  "conversationId": "321525d4-eaeb-43c9-8080-45f6c8e52753",
+  "provenance": {
+    "summary": "Detected from context/source-context.md, README.md, SKILL.md after a successful run.",
+    "detectedAt": 1784634647257
+  },
+  "sourceRefs": [
+    {
+      "kind": "file",
+      "value": "context/source-context.md",
+      "label": "context/source-context.md",
+      "size": 1589,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "README.md",
+      "label": "README.md",
+      "size": 5951,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "SKILL.md",
+      "label": "SKILL.md",
+      "size": 6690,
+      "copied": true
+    }
+  ]
+}

--- a/plugins/community/source-project-context-mrulgah5/references/source-1-source-context.md
+++ b/plugins/community/source-project-context-mrulgah5/references/source-1-source-context.md
@@ -1,0 +1,46 @@
+# Source Project Context
+
+This design-system workspace was created from an existing Open Design project. Treat the copied project files as the primary source evidence for the generated design system.
+
+## Source project
+
+- Source project id: a4b376d0-5b42-4024-af98-faedbcf9cbc2
+- Source project name: Ixigo Flight Booking UI
+- New design-system project id: 05abffcf-0b71-4e0a-94de-0cc1b2d2470f
+- New design-system id: user:ixigo-flight-booking-ui-design-system
+- Source skill id: (none)
+- Source design system id: (none)
+
+## Source metadata
+
+```json
+{
+  "kind": "other",
+  "nameSource": "agent"
+}
+```
+
+## Copied files
+
+- payment.html
+- traveler-details.html
+- index.html
+- flight-search.html
+- booking-confirmation.html
+- flight-details.html
+- flight-results.html
+- assets/app.js
+- assets/design-system.css
+- brand-spec.md
+
+## Skipped files
+
+- (none)
+
+## Generation contract
+
+- Read this file before editing design-system outputs.
+- Read the copied files directly from the project workspace; they are source evidence, not generated design-system output.
+- Preserve high-signal assets, source examples, UI surfaces, copy, tokens, typography, and interaction patterns from the copied project.
+- Generate a reusable Open Design design-system package in this same project: DESIGN.md, README.md, SKILL.md, colors_and_type.css, context/provenance, focused preview cards, preserved assets/build/fonts when available, and ui_kits/app/.
+- Before final response, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every actionable issue.

--- a/plugins/community/source-project-context-mrulgah5/references/source-2-README.md
+++ b/plugins/community/source-project-context-mrulgah5/references/source-2-README.md
@@ -1,0 +1,53 @@
+# Ixigo Flight Booking UI — Design System
+
+A reusable Open Design design-system package generated from the "Ixigo Flight Booking UI" prototype project (`a4b376d0-5b42-4024-af98-faedbcf9cbc2`).
+
+## Product Overview
+
+The source product is a 6-screen responsive web prototype covering the full domestic flight-booking journey for the India/INR market: search → results → fare & seat selection → traveller details → payment → confirmation. It supports origin/destination autocomplete, one-way/round-trip/multi-city search, trip filtering and sorting, seat-map and meal/baggage add-ons, per-traveller forms with GST invoice fields, a multi-method payment flow (UPI/card/netbanking/wallet), and a boarding-pass-style e-ticket confirmation. The interface is built as a trust-first, blue-accented, data-dense OTA (online travel agency) experience — visual tokens were extracted directly from ixigo.com's live production CSS rather than guessed, and every price/time/duration is rendered in a distinct monospace font as the system's signature typographic tell. All flight and pricing data in the prototype is seeded sample data (no live booking connector), which this package documents explicitly so it is never mistaken for a real inventory feed.
+
+Read **`DESIGN.md`** first — it is the authoritative spec (color, type, spacing, layout, components, motion, voice, anti-patterns). Everything else in this package implements or demonstrates it.
+
+## Package Contents
+
+| Path | What it is |
+|---|---|
+| `DESIGN.md` | Authoritative design spec — read this first. |
+| `SKILL.md` | Agent-facing instructions for binding this system into a new build. |
+| `colors_and_type.css` | Portable token layer — color, type, spacing, radius, shadow, motion custom properties. Drop into any new project's `<style>`. |
+| `brand-spec.md` | Original brand extraction notes (source evidence: real hex pulled from ixigo.com's production CSS). |
+| `context/source-context.md` | How this design-system project relates to its source prototype project. |
+| `context/provenance.md` | Exactly which tokens/assets are real (pulled from ixigo.com) vs. reconstructed, and what is sample data. |
+| `assets/design-system.css` | The source prototype's full shared stylesheet (tokens + layout + every component class) — preserved as source evidence and reused by the preserved screens. |
+| `assets/app.js` | The source prototype's shared state/mock-data module (seeded flight generator, INR formatting, localStorage flow state). Preserved as source evidence. |
+| `assets/logo/` | Brand mark assets (wordmark + app-icon mark) reconstructed as real SVG files from the CSS-drawn logo in the source screens. |
+| `preview/` | Focused, standalone HTML review cards — colors, typography, spacing, radius/shadows, components, brand assets, applied UI surfaces. Open any file directly in a browser. |
+| `ui_kits/app/` | An applied interface kit: an index page plus standalone component files (search widget, flight result card, flight-summary preview card, price summary, payment method switcher) assembled from the real source markup. |
+| `index.html`, `flight-search.html`, `flight-results.html`, `flight-details.html`, `traveler-details.html`, `payment.html`, `booking-confirmation.html` | The original 6-screen prototype flow, preserved verbatim as the highest-fidelity source example. Start at `flight-search.html` — state carries forward via `localStorage` (see `assets/app.js`). |
+
+## Source Context
+
+This package was generated entirely from a local Open Design project (`a4b376d0-5b42-4024-af98-faedbcf9cbc2`, "Ixigo Flight Booking UI"), not a linked GitHub repository. The copied files (6 HTML screens, `assets/design-system.css`, `assets/app.js`, `brand-spec.md`) are the primary evidence — see `context/source-context.md` for the intake manifest and `context/provenance.md` for exactly which values trace back to ixigo.com's real production CSS versus a documented substitution.
+
+## Preview Manifest
+
+Focused, standalone review cards under `preview/` — open any file directly in a browser:
+
+- `preview/colors-primary.html` — surface/text/brand/state color tokens as live swatches.
+- `preview/typography-specimens.html` — the two type families, the full type scale, and the numerics-in-mono convention applied.
+- `preview/spacing-tokens.html` — the spacing scale, card rhythm, and container width.
+- `preview/radius-shadows.html` — radius tokens and the three shadow levels.
+- `preview/components-buttons.html` — buttons, tab/pill groups, chips, and the booking stepper.
+- `preview/components-forms.html` — form fields (default/focus/invalid) and radio-card selection.
+- `preview/brand-assets.html` — the wordmark and app-icon mark, plus the live CSS-drawn header logo.
+- `preview/applied-surfaces.html` — live thumbnails of all 6 real preserved screens.
+
+## Reuse Workflow
+
+1. Read `DESIGN.md` in full.
+2. Paste `colors_and_type.css`'s `:root` block into your new file's first `<style>` tag (or `<link>` it directly).
+3. Copy component shapes from `assets/design-system.css` and `ui_kits/app/` rather than writing CSS from scratch — match class names where practical (`.card`, `.btn-primary`, `.chip-*`, `.price-summary`, etc.).
+4. Keep the numeric-in-mono convention (DESIGN.md §3) — it's the system's strongest brand tell.
+5. If you need real flight/pricing data, replace `assets/app.js`'s `generateFlights()` — everything downstream (results, details, payment, confirmation) currently runs on seeded sample data, not a live connector.
+
+Reviewers inspecting this package for the first time should open, in order: `preview/colors-primary.html` and `preview/typography-specimens.html` (the token foundation), `preview/components-buttons.html` and `preview/applied-surfaces.html` (components in context), `ui_kits/app/index.html` (the applied kit), then `flight-search.html` to click through the live flow (the full-fidelity source example).

--- a/plugins/community/source-project-context-mrulgah5/references/source-3-SKILL.md
+++ b/plugins/community/source-project-context-mrulgah5/references/source-3-SKILL.md
@@ -1,0 +1,72 @@
+---
+name: ixigo-flight-booking-ui-design-system
+description: Ixigo-style flight booking design system — trust-first, blue-accented, data-dense OTA visual language for the India/INR domestic flight market. Use whenever building or editing screens in this design system's bound project (flight search/results/details/booking, or any travel/OTA-flavored booking flow reusing these tokens).
+user-invocable: true
+---
+
+# Ixigo Flight Booking UI — design-system skill
+
+Agent-facing usage instructions. `DESIGN.md` is the authoritative spec; this file is the workflow layer on top of it.
+
+## What's inside
+
+- `DESIGN.md` — the authoritative rules document (color, typography, spacing, layout, components, motion, voice, anti-patterns).
+- `colors_and_type.css` — the portable token layer (colors, fonts, type scale, spacing scale, radius, shadow, motion).
+- `assets/` — preserved source stylesheet (`design-system.css`), shared state module (`app.js`), and brand mark assets (`logo/`).
+- `preview/` — focused review cards for colors, typography, spacing, radius/shadows, components, and applied surfaces.
+- `ui_kits/app/` — an applied interface kit (index page + standalone components) assembled from the real source markup.
+- The 6 preserved screen files at the project root (`flight-search.html` through `booking-confirmation.html`) — the full-fidelity source example of the booking flow.
+
+## Source context
+
+This design system was extracted from the "Ixigo Flight Booking UI" prototype project — a 6-screen domestic flight booking flow (search → results → fare & seat → traveller → payment → confirmation) for the India/INR market, visually based on ixigo.com. Color and font tokens were pulled from ixigo.com's real production CSS, not guessed — see `context/provenance.md` for exactly what's real evidence versus a documented substitution, and `brand-spec.md` for the original extraction notes.
+
+## When to use this skill
+
+Use this skill when building or editing prototypes, mockups, or production interfaces that extend this ixigo-style flight/travel booking flow, or any similarly data-dense OTA-style booking design that should reuse this system's tokens and components rather than starting from scratch.
+
+## How to use
+
+1. Read `DESIGN.md` in full before writing any layout.
+2. Paste `colors_and_type.css`'s `:root` custom-property block (plus its Google Fonts `@import`) into the new file's first `<style>` tag — never re-derive or re-guess the hex/oklch values.
+3. Copy component shapes from `assets/design-system.css` and `ui_kits/app/` rather than writing CSS from scratch — match class names where practical (`.card`, `.btn-primary`, `.chip-*`, `.price-summary`, `.stepper`, etc.).
+4. For a full applied example of a component in context, open the matching file in `ui_kits/app/components/`, or the relevant screen at the project root, and copy its markup structure.
+5. Reuse `assets/app.js` (`window.IxigoProto`) for shared state, INR formatting, and sample flight data rather than inventing new mock data inline.
+
+## Design system highlights
+
+- One accent (`--accent`, ixigo blue) drives every primary action and active state; `--warn` (orange) is reserved strictly for scarcity/urgency badges.
+- Numerics — every price, clock time, duration, and PNR/flight code — render in `DM Mono`, never the `Plus Jakarta Sans` body font. This is the system's strongest brand tell.
+- Spacing is data-dense and utilitarian (18–22px card padding, 12–14px field gaps), not airy marketing whitespace.
+- Radius is soft (8–12px, full pill for tabs/chips) and shadows stay flat (`--shadow-card`/`--shadow-nav`), never heavy or colored.
+- Layout follows a booking-stepper + sticky-price-summary pattern across every multi-step checkout screen, collapsing to single-column/bottom-sheet on mobile rather than squeezing the desktop grid.
+- Interaction is understated: `translateY(1px)` button presses, `.18s ease` opacity/transform panel swaps, an inline spinner (not a page loader) for the pay button's loading state.
+
+## Non-negotiable rules
+
+See `DESIGN.md` for full rationale behind each of these:
+
+1. **Numerics are always mono.** Any price, clock time, duration, or PNR/flight code gets `class="mono"` (or `var(--font-mono)`) — never the sans body font.
+2. **One accent, `--accent`, drives every primary action and active state.** At most twice per screen as a solid fill (primary CTA + one active tab/pill).
+3. **`--warn` (orange) is scarcity/urgency-only.** Never a second brand accent, never on a primary button, never blended into a gradient with `--accent`.
+4. **Currency is always ₹ (INR)**, formatted with `en-IN` grouping — reuse `fmtINR()` from `assets/app.js`.
+5. **Booking stepper on every post-search screen.** New funnel steps get inserted into the existing 6-step stepper, not a new wayfinding pattern.
+6. **Sticky price summary on multi-step checkout screens.** Reuse `.price-summary` verbatim so the payable amount never changes shape between screens.
+7. **Two-column desktop layouts collapse to single-column on mobile — they are never squeezed.** Follow the documented breakpoints (640/700/860/900/980px).
+8. **All flight/pricing data is sample data** generated by a seeded PRNG in `assets/app.js`. Never present it as live/real without saying so.
+
+## Workflow for a new screen in this flow
+
+1. Copy the closest existing screen file (e.g. `flight-details.html` for another mid-funnel step) as a starting template — it already has the header, stepper, and stylesheet link wired up correctly.
+2. Update the stepper's active/done states to reflect the new screen's position.
+3. Pull shared state (`selectedFlight`, `travellers`, `fareTotal`, etc.) via `window.IxigoProto.getState()` / `.setState()` — this is how state survives across the separate screen files via `localStorage`.
+4. Add a redirect-to-search guard at the top of the script block if the screen depends on upstream state not being present (every screen past `flight-search.html` does this already — match the pattern).
+5. Run the self-check from the charter (layout integrity, no clipped mono numerics, stepper correctness, `data-od-id` on interactive/named regions) before handing off.
+
+## Anti-patterns — do not do these
+
+See DESIGN.md §9 for the full list. Most common mistakes to avoid when extending this system:
+- Adding a gradient background as a "modern" touch — this system uses flat surfaces only.
+- Setting a price or time in the sans font because it "reads fine" — it must be mono.
+- Introducing a second saturated accent color for variety — there is exactly one (`--accent`).
+- Building a new booking step without adding it to the stepper.


### PR DESCRIPTION
Add Source Project Context (source-project-context-mrulgah5) plugin.
Version: 0.1.0
Description: This design-system workspace was created from an existing Open Design project. Treat the copied project files as the primary source evidence for the generated design system.