### PR TITLE
feat: add independent read-only Codex reviews

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -6101,6 +6101,9 @@ async function runRun(args) {
   od run start --project <projectId> [--conversation <id>] [--message "<text>"]
                [--plugin <id>] [--inputs <json>] [--grant-caps a,b]
                [--agent claude|codex|opencode] [--model <id>] [--follow] [--json]
+  od run review --project <projectId> [--message "<text>" | --prompt-file <path|->]
+               [--model <id>] [--follow] [--json]
+                                           Start a fresh read-only Codex review.
   od run redesign [--path <folder>] [--message "<text>" | --prompt-file <path|->]
                [--agent claude] [--model <id>] [--follow] [--json]
   od run watch  <runId>                     ND-JSON event stream on stdout.
@@ -6121,6 +6124,29 @@ Common options:
   const flags = parseFlags(rest, { string: PROJECT_STRING_FLAGS, boolean: PROJECT_BOOLEAN_FLAGS });
   const base = (await projectDaemonUrl(flags)).replace(/\/$/, '');
   switch (sub) {
+    case 'review': {
+      if (!flags.project) {
+        console.error('--project <projectId> is required');
+        process.exit(2);
+      }
+      const defaultMessage =
+        'Review the current project changes without modifying files. Report actionable findings in severity order with file and line references. If there are no findings, say so explicitly.';
+      const message = await readRunMessageFromFlags(flags, defaultMessage);
+      const body = {
+        projectId: flags.project,
+        agentId: 'codex',
+        purpose: 'review',
+        message,
+        ...(flags.model ? { model: flags.model } : {}),
+      };
+      const data = await postJsonToDaemon(base, '/api/runs', body);
+      if (flags.json && !flags.follow) {
+        return process.stdout.write(JSON.stringify(data, null, 2) + '\n');
+      }
+      console.log(`[run] review started ${data.runId} (conversation ${data.conversationId ?? '-'})`);
+      if (flags.follow) await streamRunEvents(base, data.runId);
+      return;
+    }
     case 'list': {
       const url = flags.project
         ? `${base}/api/runs?projectId=${encodeURIComponent(flags.project)}`
@@ -6191,6 +6217,17 @@ Common options:
       const statusResp = await fetch(`${base}/api/runs/${encodeURIComponent(id)}`);
       if (!statusResp.ok) return structuredHttpFailure(statusResp, 'run-not-found');
       const status = await statusResp.json();
+      if (status?.purpose === 'review') {
+        const payload = {
+          error: {
+            code: 'review-run-not-continuable',
+            message: `Independent review run ${id} cannot be continued with writable access. Start a new review instead.`,
+          },
+        };
+        if (flags.json) process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+        else console.error(payload.error.message);
+        process.exit(1);
+      }
       if (status?.resumable !== true) {
         const payload = {
           error: {

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -8,9 +8,11 @@ import {
   type AppliedPluginSnapshot,
   type ArtifactManifest,
   type ByokChatProviderConfig,
+  type ChatRunPurpose,
   type ChatRunStatus,
   type ChatRunStatusResponse,
   type ProjectMetadata as ContractProjectMetadata,
+  type ProjectConversationCreatedSsePayload,
   type RunResultPackageResponse,
 } from '@open-design/contracts';
 import {
@@ -35,6 +37,7 @@ import {
   conversationTurnIndexForRun,
   getConversation,
   getProject,
+  insertConversation,
   listConversations,
   normalizeConversationSessionMode,
   updateProject,
@@ -144,6 +147,7 @@ interface ChatRun {
   conversationId: string | null;
   assistantMessageId: string | null;
   agentId: string | null;
+  purpose?: ChatRunPurpose | null;
   model?: string | null;
   status: ChatRunStatus;
   createdAt: number;
@@ -205,6 +209,7 @@ interface RunCreateMeta extends JsonRecord {
   appliedPluginSnapshotId?: string;
   message?: string;
   currentPrompt?: string;
+  purpose?: ChatRunPurpose;
   projectMetadata?: ProjectMetadata;
 }
 
@@ -306,6 +311,12 @@ export interface RegisterRunRoutesDeps {
   };
   lifecycle: {
     isDaemonShuttingDown: () => boolean;
+  };
+  events: {
+    emitProjectEvent: (
+      projectId: string,
+      payload: ProjectConversationCreatedSsePayload,
+    ) => boolean;
   };
   plugins: {
     connectorService: ConnectorService;
@@ -500,6 +511,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
   const { PROJECTS_DIR, RUNTIME_DATA_DIR } = ctx.paths;
   const { detectAgents, getAgentDef } = ctx.agents;
   const { startChatRun } = ctx.chat;
+  const { emitProjectEvent } = ctx.events;
   const {
     connectorService,
     detectSkillPluginCandidateOnRunSuccess,
@@ -540,6 +552,50 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       return sendApiError(res, 503, 'UPSTREAM_UNAVAILABLE', 'daemon is shutting down');
     }
     const requestBody = toJsonRecord(req.body);
+    if (requestBody.purpose !== undefined && requestBody.purpose !== 'review') {
+      return sendApiError(res, 400, 'BAD_REQUEST', 'purpose must be review when provided');
+    }
+    const isReviewRun = requestBody.purpose === 'review';
+    let reviewConversationCreatedEvent: ProjectConversationCreatedSsePayload | null = null;
+    if (isReviewRun) {
+      const allowedReviewFields = new Set([
+        'projectId',
+        'purpose',
+        'message',
+        'agentId',
+        'model',
+      ]);
+      const unsupportedReviewFields = Object.keys(requestBody)
+        .filter((field) => !allowedReviewFields.has(field));
+      if (unsupportedReviewFields.length > 0) {
+        return sendApiError(
+          res,
+          400,
+          'BAD_REQUEST',
+          `review runs do not accept ${unsupportedReviewFields.join(', ')}`,
+        );
+      }
+      if (typeof requestBody.projectId !== 'string' || !requestBody.projectId) {
+        return sendApiError(res, 400, 'BAD_REQUEST', 'review runs require projectId');
+      }
+      if (typeof requestBody.message !== 'string' || !requestBody.message.trim()) {
+        return sendApiError(res, 400, 'BAD_REQUEST', 'review runs require message');
+      }
+      if (requestBody.conversationId !== undefined && requestBody.conversationId !== null) {
+        return sendApiError(
+          res,
+          400,
+          'BAD_REQUEST',
+          'review runs always create a fresh conversation',
+        );
+      }
+      if (requestBody.agentId !== undefined && requestBody.agentId !== 'codex') {
+        return sendApiError(res, 400, 'BAD_REQUEST', 'review runs currently require Codex');
+      }
+      requestBody.agentId = 'codex';
+      requestBody.sessionMode = 'plan';
+      requestBody.currentPrompt = requestBody.currentPrompt ?? requestBody.message;
+    }
     const mediaExecution = parseMediaExecutionPolicyInput(requestBody.mediaExecution);
     if (!mediaExecution.ok) {
       return sendApiError(res, 400, 'BAD_REQUEST', mediaExecution.message);
@@ -557,7 +613,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       );
     }
     let resolvedSnapshot = null;
-    if (typeof requestBody.projectId === 'string' && requestBody.projectId) {
+    if (!isReviewRun && typeof requestBody.projectId === 'string' && requestBody.projectId) {
       let registryView: Parameters<typeof resolvePluginSnapshot>[0]['registry'];
       try {
         registryView = await loadPluginRegistryView();
@@ -677,6 +733,39 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
     if (runProject?.metadata) {
       meta.projectMetadata = runProject.metadata;
     }
+    if (isReviewRun) {
+      if (!runProject || typeof meta.projectId !== 'string' || !meta.projectId) {
+        return sendApiError(res, 404, 'NOT_FOUND', 'project not found');
+      }
+      const now = Date.now();
+      const conversation = insertConversation(db, {
+        id: randomUUID(),
+        projectId: meta.projectId,
+        title: 'Independent review',
+        sessionMode: 'plan',
+        createdAt: now,
+        updatedAt: now,
+      });
+      if (!conversation) {
+        return sendApiError(res, 500, 'INTERNAL_ERROR', 'failed to create review conversation');
+      }
+      meta.conversationId = conversation.id;
+      meta.assistantMessageId = randomUUID();
+      reviewConversationCreatedEvent = {
+        type: 'conversation-created',
+        projectId: meta.projectId,
+        conversationId: conversation.id,
+        title: 'Independent review',
+        createdAt: now,
+      };
+      upsertMessage(db, conversation.id, {
+        id: randomUUID(),
+        role: 'user',
+        content: String(meta.message),
+        startedAt: now,
+        endedAt: now,
+      });
+    }
     if (
       typeof meta.projectId === 'string' &&
       meta.projectId &&
@@ -771,6 +860,9 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         : {}),
     };
     res.status(202).json(body);
+    if (reviewConversationCreatedEvent) {
+      emitProjectEvent(meta.projectId as string, reviewConversationCreatedEvent);
+    }
     if (resolvedSnapshot?.ok && resolvedSnapshot.snapshot.pipeline) {
       firePipelineForRun({
         run,
@@ -780,7 +872,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       });
     }
     reconcileAssistantMessageOnRunEnd(db, design.runs, run);
-    if (run.projectId && run.conversationId) {
+    if (!isReviewRun && run.projectId && run.conversationId) {
       try {
         const project = toProjectRecord(getProject(db, run.projectId));
         const projectRoot = resolveProjectDir(PROJECTS_DIR, run.projectId, project?.metadata);
@@ -1551,6 +1643,14 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
       return sendApiError(res, 503, 'UPSTREAM_UNAVAILABLE', 'daemon is shutting down');
     }
     const requestBody = toJsonRecord(req.body);
+    if (requestBody.purpose !== undefined) {
+      return sendApiError(
+        res,
+        400,
+        'BAD_REQUEST',
+        'purpose is only supported by POST /api/runs',
+      );
+    }
     const mediaExecution = parseMediaExecutionPolicyInput(requestBody.mediaExecution);
     if (!mediaExecution.ok) {
       return sendApiError(res, 400, 'BAD_REQUEST', mediaExecution.message);

--- a/apps/daemon/src/runtimes/defs/codex.ts
+++ b/apps/daemon/src/runtimes/defs/codex.ts
@@ -117,6 +117,7 @@ export const codexAgentDef = {
       // and Linux (Landlock+seccomp) keep workspace-write because their
       // sandbox enforcement permits shell while restricting writes.
       const needsDangerFullAccess = codexNeedsDangerFullAccessSandbox();
+      const readOnly = options.filesystemAccess === 'read-only';
       // Capture-style resume: when the daemon has a stored Codex thread id for
       // this conversation it asks the CLI to continue that session with
       // `exec resume <thread_id>` instead of `exec` (a fresh session). Codex
@@ -134,7 +135,11 @@ export const codexAgentDef = {
       // the create turn so Codex's per-turn `turn_context` block byte-matches
       // across turns and does not break the upstream prefix cache the resume
       // is meant to reuse.
-      const sandboxArgs = needsDangerFullAccess
+      const sandboxArgs = readOnly
+        ? resumeSessionId
+          ? ['-c', 'sandbox_mode="read-only"']
+          : ['--sandbox', 'read-only']
+        : needsDangerFullAccess
         ? resumeSessionId
           ? ['-c', 'sandbox_mode="danger-full-access"']
           : ['--sandbox', 'danger-full-access']
@@ -154,8 +159,14 @@ export const codexAgentDef = {
       const args = resumeSessionId
         ? ['exec', 'resume', '--json', '--skip-git-repo-check', ...sandboxArgs]
         : ['exec', '--json', '--skip-git-repo-check', ...sandboxArgs];
-      if (process.env.OD_CODEX_DISABLE_PLUGINS === '1') {
+      // A read-only review must not inherit Codex plugins. Plugin processes run
+      // outside the shell sandbox and could otherwise write or use the network
+      // even though the main Codex turn is constrained to read-only access.
+      if (readOnly || process.env.OD_CODEX_DISABLE_PLUGINS === '1') {
         args.push('--disable', 'plugins');
+      }
+      if (readOnly) {
+        args.push('--ephemeral', '--ignore-user-config', '--ignore-rules');
       }
       // `-C <cwd>` and `--add-dir <dir>` are CREATE-only flags: `codex exec
       // resume` rejects both (`error: unexpected argument '-C' found`), so
@@ -169,11 +180,13 @@ export const codexAgentDef = {
         if (runtimeContext.cwd) {
           args.push('-C', runtimeContext.cwd);
         }
-        const dirs = (extraAllowedDirs || []).filter(
-          (d) => typeof d === 'string' && d.length > 0,
-        );
-        for (const d of dirs) {
-          args.push('--add-dir', d);
+        if (!readOnly) {
+          const dirs = (extraAllowedDirs || []).filter(
+            (d) => typeof d === 'string' && d.length > 0,
+          );
+          for (const d of dirs) {
+            args.push('--add-dir', d);
+          }
         }
       }
       if (options.model && options.model !== 'default') {

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -34,6 +34,7 @@ function durableRunState(run) {
     conversationId: run.conversationId,
     assistantMessageId: run.assistantMessageId,
     agentId: run.agentId,
+    purpose: run.purpose ?? null,
     status: run.status,
     createdAt: run.createdAt,
     updatedAt: run.updatedAt,
@@ -108,6 +109,7 @@ export function createChatRunService({
       assistantMessageId: typeof meta.assistantMessageId === 'string' && meta.assistantMessageId ? meta.assistantMessageId : null,
       clientRequestId: typeof meta.clientRequestId === 'string' && meta.clientRequestId ? meta.clientRequestId : null,
       agentId: typeof meta.agentId === 'string' && meta.agentId ? meta.agentId : null,
+      purpose: meta.purpose === 'review' ? 'review' : null,
       projectMetadata:
         meta.projectMetadata && typeof meta.projectMetadata === 'object' && !Array.isArray(meta.projectMetadata)
           ? meta.projectMetadata
@@ -295,6 +297,7 @@ export function createChatRunService({
     conversationId: run.conversationId,
     assistantMessageId: run.assistantMessageId,
     agentId: run.agentId,
+    purpose: run.purpose ?? null,
     designSystemId: run.designSystemId ?? null,
     designSystemRequestedId: run.designSystemRequestedId ?? null,
     designSystemSelectionSource: run.designSystemSelectionSource ?? null,

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -22,6 +22,7 @@ export type RuntimeReasoningOption = RuntimeModelOption;
 export type RuntimeBuildOptions = {
   model?: string | null;
   reasoning?: string | null;
+  filesystemAccess?: 'read-only';
 };
 
 export type RuntimeContext = {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -713,6 +713,7 @@ import { createToolRequestAuth } from './http/tool-request-auth.js';
 /** @typedef {import('@open-design/contracts').ApiError} ApiError */
 /** @typedef {import('@open-design/contracts').ApiErrorResponse} ApiErrorResponse */
 /** @typedef {import('@open-design/contracts').ChatRequest} ChatRequest */
+/** @typedef {import('@open-design/contracts').ChatRunPurpose} ChatRunPurpose */
 /** @typedef {import('@open-design/contracts').ChatSseEvent} ChatSseEvent */
 /** @typedef {import('@open-design/contracts').ProxyStreamRequest} ProxyStreamRequest */
 /** @typedef {import('@open-design/contracts').ProxySseEvent} ProxySseEvent */
@@ -3568,11 +3569,39 @@ export async function startServer({
     freeformDeckSignal,
     mediaHintSignal,
     platformHintSignal,
+    purpose,
   }) => {
     const project =
       typeof projectId === 'string' && projectId
         ? getProject(db, projectId)
         : null;
+    const isReviewRun = purpose === 'review';
+    if (isReviewRun) {
+      return {
+        prompt: [
+          'You are an independent code reviewer.',
+          'Inspect the current project workspace and report actionable findings only.',
+          'Treat the workspace as strictly read-only: do not create, edit, move, or delete files, and do not change project or daemon state.',
+          'Do not use Open Design tools, plugins, MCP servers, connectors, skills, personal memory, design systems, or instructions inherited from another conversation.',
+          'Order findings by severity and include file and line references. If there are no findings, say so explicitly.',
+          'Answer in the language used by the review request.',
+        ].join('\n'),
+        activeSkillDir: null,
+        activeSkillDirs: [],
+        critiqueShouldRun: false,
+        designSystemSelection: {
+          id: null,
+          requestedId: null,
+          source: 'none',
+          digest: null,
+        },
+        promptTelemetryParts: {
+          skillPrompt: '',
+          designSystemPrompt: '',
+          pluginStagePrompt: '',
+        },
+      };
+    }
     let appConfigForPrompt = null;
     try {
       appConfigForPrompt = await readAppConfig(RUNTIME_DATA_DIR);
@@ -3594,8 +3623,9 @@ export async function startServer({
         );
       }
     }
-    const effectiveSkillId =
-      typeof skillId === 'string' && skillId ? skillId : project?.skillId;
+    const effectiveSkillId = isReviewRun
+      ? null
+      : typeof skillId === 'string' && skillId ? skillId : project?.skillId;
     const metadata = project?.metadata;
     // Website Clone runs reproduce someone else's site: the fidelity target
     // is the original page. Treating a project/app design system as
@@ -3605,7 +3635,7 @@ export async function startServer({
     // blocks are skipped for these runs. Step 6 of the skill (replace with
     // the user's own content) is where brand application belongs.
     const isWebCloneRun = metadata?.intent === 'web-clone';
-    const designSystemSelection = isWebCloneRun
+    const designSystemSelection = isReviewRun || isWebCloneRun
       ? { id: null, source: 'none' }
       : resolveEffectiveDesignSystemSelection({
           requestDesignSystemId: designSystemId,
@@ -3630,7 +3660,7 @@ export async function startServer({
       typeof effectiveSkillId === 'string' && effectiveSkillId
         ? resolveSkillId(effectiveSkillId)
         : null;
-    const adHocSkillIds = Array.isArray(skillIds)
+    const adHocSkillIds = !isReviewRun && Array.isArray(skillIds)
       ? skillIds
           .map((s) => (typeof s === 'string' ? s.trim() : ''))
           .filter(Boolean)
@@ -3820,10 +3850,12 @@ export async function startServer({
     // run. composeMemoryBody returns '' when memory is disabled or
     // empty; the composer drops the block on a falsy value.
     let memoryBody = '';
-    try {
-      memoryBody = await composeMemoryBody(RUNTIME_DATA_DIR);
-    } catch (err) {
-      console.warn('[memory] composeMemoryBody failed', err);
+    if (!isReviewRun) {
+      try {
+        memoryBody = await composeMemoryBody(RUNTIME_DATA_DIR);
+      } catch (err) {
+        console.warn('[memory] composeMemoryBody failed', err);
+      }
     }
 
     // Per-hook switches for the two-loop memory feature. Read alongside the
@@ -3833,20 +3865,22 @@ export async function startServer({
     // composer treats as on-by-default — matching the config's default-on
     // semantics.
     let memoryHooks: { profile?: boolean; rewrite?: boolean; verify?: boolean } | undefined;
-    try {
-      const memCfg = await readMemoryConfig(RUNTIME_DATA_DIR);
-      memoryHooks = {
-        profile: memCfg.profileEnabled,
-        rewrite: memCfg.rewriteEnabled,
-        verify: memCfg.verifyEnabled,
-      };
-    } catch (err) {
-      console.warn('[memory] readMemoryConfig failed', err);
+    if (!isReviewRun) {
+      try {
+        const memCfg = await readMemoryConfig(RUNTIME_DATA_DIR);
+        memoryHooks = {
+          profile: memCfg.profileEnabled,
+          rewrite: memCfg.rewriteEnabled,
+          verify: memCfg.verifyEnabled,
+        };
+      } catch (err) {
+        console.warn('[memory] readMemoryConfig failed', err);
+      }
     }
 
     // User-level custom instructions from app-config.json.
     let userInstructions = '';
-    if (appConfigForPrompt?.customInstructions) {
+    if (!isReviewRun && appConfigForPrompt?.customInstructions) {
       userInstructions = appConfigForPrompt.customInstructions;
     }
 
@@ -3927,7 +3961,7 @@ export async function startServer({
 
     const excludedCraft = new Set(designSystemCraftExemptions);
     // Web-clone fidelity exemption — see `isWebCloneRun` above.
-    const requestedCraft = isWebCloneRun
+    const requestedCraft = isReviewRun || isWebCloneRun
       ? []
       : Array.from(
           new Set([...skillCraftRequires, ...designSystemCraftApplies]),
@@ -3941,12 +3975,13 @@ export async function startServer({
     }
 
     const template =
-      metadata?.kind === 'template' && typeof metadata.templateId === 'string'
+      !isReviewRun && metadata?.kind === 'template' && typeof metadata.templateId === 'string'
         ? (getTemplate(db, metadata.templateId) ?? undefined)
         : undefined;
     let audioVoiceOptions = [];
     let audioVoiceOptionsError;
     if (
+      !isReviewRun &&
       metadata?.kind === 'audio' &&
       metadata?.audioKind === 'speech' &&
       metadata?.audioModel === 'elevenlabs-v3' &&
@@ -4017,7 +4052,7 @@ export async function startServer({
     // is instructed to emit Critique Theater tags that no orchestrator
     // consumes.
     const resolvedExclusiveSurface = resolveExclusiveSurface({
-      metadata,
+      metadata: isReviewRun ? undefined : metadata,
       skillMode,
       skillModes: skillModes.size > 0 ? Array.from(skillModes) : undefined,
     });
@@ -4256,7 +4291,7 @@ export async function startServer({
   const startChatRun = async (chatBody, run) => {
     const lifecycle = createRunLifecycleTracer(run);
     lifecycle.mark('chat_run_started');
-    /** @type {Partial<ChatRequest> & { imagePaths?: string[] }} */
+    /** @type {Partial<ChatRequest> & { imagePaths?: string[], purpose?: ChatRunPurpose }} */
     chatBody = chatBody || {};
     const {
       agentId,
@@ -4276,6 +4311,7 @@ export async function startServer({
       commentAttachments = [],
       model,
       reasoning,
+      purpose,
       locale,
       research,
       context,
@@ -4365,10 +4401,12 @@ export async function startServer({
     ) {
       return design.runs.fail(run, 'BAD_REQUEST', 'message required');
     }
-    const browserUseRunState = buildBrowserUseRunState({
-      requested: isBrowserUseRequested(message, currentPrompt, systemPrompt),
-      agentId: def.id,
-    });
+    const browserUseRunState = purpose === 'review'
+      ? null
+      : buildBrowserUseRunState({
+          requested: isBrowserUseRequested(message, currentPrompt, systemPrompt),
+          agentId: def.id,
+        });
     if (browserUseRunState) {
       run.browserUse = browserUseRunState;
       design.runs.emit(run, 'diagnostic', {
@@ -4387,6 +4425,7 @@ export async function startServer({
     // turn's prompt. Failures are swallowed — memory is best-effort and
     // must never block the agent run.
     if (
+      purpose !== 'review' &&
       (run.retryAttemptCount ?? 0) === 0 &&
       typeof message === 'string' &&
       message.trim().length > 0
@@ -4416,12 +4455,29 @@ export async function startServer({
         // folders with no managed copy in sandbox mode), so we pass chatMeta
         // through instead of branching on baseDir here.
         assertSandboxProjectRootAvailable(chatMeta);
-        cwd = await ensureProject(PROJECTS_DIR, projectId, chatMeta);
+        if (purpose === 'review') {
+          cwd = resolveProjectDir(PROJECTS_DIR, projectId, chatMeta);
+          const projectRootStat = await fs.promises.stat(cwd);
+          if (!projectRootStat.isDirectory()) {
+            throw new Error('review project workspace is not a directory');
+          }
+        } else {
+          cwd = await ensureProject(PROJECTS_DIR, projectId, chatMeta);
+        }
         existingProjectFiles = await listFiles(PROJECTS_DIR, projectId, { metadata: chatMeta });
         existingProjectFolders = await listProjectFolders(PROJECTS_DIR, projectId, { metadata: chatMeta });
       } catch (err) {
         if (err instanceof SandboxImportedProjectError) {
           return design.runs.fail(run, 'BAD_REQUEST', err.message);
+        }
+        if (purpose === 'review') {
+          return design.runs.fail(
+            run,
+            'BAD_REQUEST',
+            err instanceof Error
+              ? `review project workspace is unavailable: ${err.message}`
+              : 'review project workspace is unavailable',
+          );
         }
         cwd = null;
         existingProjectFiles = [];
@@ -4473,8 +4529,10 @@ export async function startServer({
       typeof projectId === 'string' && projectId
         ? getProject(db, projectId)
         : null;
-    const runContextPrompt = renderRunContextPrompt(context, projectRecord?.metadata);
-    const linkedDirs = (() => {
+    const runContextPrompt = purpose === 'review'
+      ? ''
+      : renderRunContextPrompt(context, projectRecord?.metadata);
+    const linkedDirs = purpose === 'review' ? [] : (() => {
       if (!Array.isArray(projectRecord?.metadata?.linkedDirs)) return [];
       const v = validateLinkedDirs(projectRecord.metadata.linkedDirs);
       return v.dirs ?? [];
@@ -4503,7 +4561,7 @@ export async function startServer({
         };
       }
     }
-    const toolTokenGrant = cwd && typeof projectId === 'string' && projectId
+    const toolTokenGrant = purpose !== 'review' && cwd && typeof projectId === 'string' && projectId
       ? toolTokenRegistry.mint({
           runId,
           projectId,
@@ -4533,7 +4591,9 @@ export async function startServer({
         activeChatRunHandles.delete(sinkRunId);
       };
     }
-    const runtimeToolPrompt = createAgentRuntimeToolPrompt(daemonUrl, toolTokenGrant);
+    const runtimeToolPrompt = purpose === 'review'
+      ? ''
+      : createAgentRuntimeToolPrompt(daemonUrl, toolTokenGrant);
     const commentHint = renderCommentAttachmentHint(safeCommentAttachments);
 
     // Resolve external MCP config + stored OAuth tokens up-front so the
@@ -4543,7 +4603,7 @@ export async function startServer({
     // values further down at .mcp.json write time — see the spawn block
     // below — instead of re-reading.
     let externalMcpConfig = { servers: [] };
-    if (!SANDBOX_RUNTIME.enabled) {
+    if (purpose !== 'review' && !SANDBOX_RUNTIME.enabled) {
       try {
         externalMcpConfig = await readMcpConfig(RUNTIME_DATA_DIR);
       } catch (err) {
@@ -4637,8 +4697,9 @@ export async function startServer({
       media: detectMediaIntentSignal(...intentSignalTexts),
       platform: detectPlatformIntentSignal(...intentSignalTexts),
     };
-    const intentSignals =
-      !legacyIntentSignalScan && typeof run.conversationId === 'string' && run.conversationId
+    const intentSignals = purpose === 'review'
+      ? { deck: false, media: false, platform: false }
+      : !legacyIntentSignalScan && typeof run.conversationId === 'string' && run.conversationId
         ? latchConversationIntentSignals(db, run.conversationId, freshIntentSignals)
         : freshIntentSignals;
 
@@ -4671,6 +4732,7 @@ export async function startServer({
         freeformDeckSignal: intentSignals.deck,
         mediaHintSignal: intentSignals.media,
         platformHintSignal: intentSignals.platform,
+        purpose,
       });
 
     run.designSystemId = designSystemSelection?.id ?? null;
@@ -4733,7 +4795,7 @@ export async function startServer({
     // for ANY agent (not just claude_code). Only for real project runs: a
     // null `cwd` means a no-project run rooted at PROJECT_ROOT, whose churn is
     // not the user's artifacts — those fall back to the tool-stream count.
-    if (run?.id && cwd) {
+    if (purpose !== 'review' && run?.id && cwd) {
       try {
         runArtifactBaselines.remember(run.id, cwd, snapshotProjectArtifacts(cwd));
       } catch {
@@ -4770,6 +4832,7 @@ export async function startServer({
     };
     const resolveRunArtifactOutcomeBeforeFinish = () => {
       if (!run?.id) return null;
+      if (purpose === 'review') return null;
       if (run.artifactOutcome) return run.artifactOutcome;
 
       const artifactBaseline = runArtifactBaselines.take(run.id);
@@ -4805,6 +4868,7 @@ export async function startServer({
       return outcome;
     };
     const snapshotAiHtmlVersionsBeforeSuccess = async () => {
+      if (purpose === 'review') return;
       const outcome = resolveRunArtifactOutcomeBeforeFinish();
       if (!outcome?.diff || !outcome.projectRoot || !run.projectId) return;
       const promptInfo = latestRunPromptForHtmlVersionSnapshot();
@@ -4829,13 +4893,15 @@ export async function startServer({
         resolveRunArtifactOutcomeBeforeFinish();
       }
     };
-    let codexGeneratedImagesDir = resolveCodexGeneratedImagesDir(
-      agentId,
-      projectRecord?.metadata,
-      process.env,
-      os.homedir(),
-      run?.mediaExecution,
-    );
+    let codexGeneratedImagesDir = purpose === 'review'
+      ? null
+      : resolveCodexGeneratedImagesDir(
+          agentId,
+          projectRecord?.metadata,
+          process.env,
+          os.homedir(),
+          run?.mediaExecution,
+        );
     if (codexGeneratedImagesDir) {
       codexGeneratedImagesDir = validateCodexGeneratedImagesDir(
         codexGeneratedImagesDir,
@@ -4858,10 +4924,9 @@ export async function startServer({
       extraAllowedDirs,
       mediaExecution: run?.mediaExecution,
     });
-    const researchCommandContract = resolveResearchCommandContract(
-      research,
-      message,
-    );
+    const researchCommandContract = purpose === 'review'
+      ? ''
+      : resolveResearchCommandContract(research, message);
     // Resume-capable adapters continue their own upstream session so they
     // keep working memory across turns. Decide once per run; reuse for the
     // prompt-composition skipTranscript choice, the buildArgs flags, and the
@@ -4889,6 +4954,45 @@ export async function startServer({
     } catch {
       configuredAgentEnv = {};
     }
+    let isolatedReviewCodexHome = null;
+    const cleanupIsolatedReviewCodexHome = () => {
+      if (!isolatedReviewCodexHome) return;
+      const dir = isolatedReviewCodexHome;
+      isolatedReviewCodexHome = null;
+      fs.promises.rm(dir, { recursive: true, force: true }).catch(() => {});
+    };
+    if (purpose === 'review' && def.id === 'codex') {
+      const sourceEnv = spawnEnvForAgent('codex', process.env, configuredAgentEnv);
+      const sourceHome = sourceEnv.CODEX_HOME?.trim() || path.join(os.homedir(), '.codex');
+      isolatedReviewCodexHome = await fs.promises.mkdtemp(
+        path.join(os.tmpdir(), 'od-codex-review-'),
+      );
+      try {
+        // Preserve login state only. In particular, do not copy config.toml,
+        // plugins, skills, or MCP definitions into the independent review.
+        await fs.promises.copyFile(
+          path.join(sourceHome, 'auth.json'),
+          path.join(isolatedReviewCodexHome, 'auth.json'),
+        );
+      } catch (err) {
+        if (err?.code !== 'ENOENT') {
+          cleanupIsolatedReviewCodexHome();
+          throw err;
+        }
+      }
+      configuredAgentEnv = {
+        ...configuredAgentEnv,
+        CODEX_HOME: isolatedReviewCodexHome,
+      };
+      const previousOnFinalize = run.onFinalize;
+      run.onFinalize = () => {
+        try {
+          previousOnFinalize?.();
+        } finally {
+          cleanupIsolatedReviewCodexHome();
+        }
+      };
+    }
     const requestedLiveModelScope = def.id === 'amr'
       ? resolveAmrProfile({
           ...process.env,
@@ -4915,7 +5019,11 @@ export async function startServer({
       typeof reasoning === 'string' && Array.isArray(def.reasoningOptions)
         ? (def.reasoningOptions.find((r) => r.id === reasoning)?.id ?? null)
         : null;
-    const agentOptions = { model: safeModel, reasoning: safeReasoning };
+    const agentOptions = {
+      model: safeModel,
+      reasoning: safeReasoning,
+      ...(purpose === 'review' ? { filesystemAccess: 'read-only' } : {}),
+    };
     const agentLaunch = resolveAgentLaunch(def, configuredAgentEnv);
     const resolvedBin = agentLaunch.selectedPath;
     if (def.id === 'amr' && resolvedBin && agentLaunch.launchPath) {
@@ -5535,6 +5643,7 @@ export async function startServer({
           ? capturedSessionId
           : agentResumeCtx.newSessionId;
       const resumableFailure =
+        purpose !== 'review' &&
         result === 'failed' &&
         def.resumesSessionViaCli === true &&
         !!run.conversationId &&
@@ -6050,7 +6159,7 @@ export async function startServer({
     }
 
     let persistDeliveredAgentSessionState = () => {};
-    if (def.resumesSessionViaCli === true && run.conversationId) {
+    if (purpose !== 'review' && def.resumesSessionViaCli === true && run.conversationId) {
       let persisted = false;
       persistDeliveredAgentSessionState = () => {
         if (persisted) return;
@@ -6463,6 +6572,22 @@ export async function startServer({
           ? { [isMiMoContent ? 'MIMOCODE_CONFIG_CONTENT' : 'OPENCODE_CONFIG_CONTENT']: opencodeConfigContent }
           : {}),
       }, agentLaunch);
+      if (purpose === 'review') {
+        for (const key of Object.keys(env)) {
+          const normalizedKey = key.toUpperCase();
+          if (
+            normalizedKey.startsWith('OD_')
+            || normalizedKey.startsWith('OPEN_DESIGN_')
+            || normalizedKey.startsWith('CODEX_')
+          ) {
+            delete env[key];
+          }
+        }
+        // Sandbox mode may rewrite CODEX_HOME after configured env is merged.
+        // Re-pin the isolated home at the final spawn boundary after removing
+        // every Open Design runtime capability from the child environment.
+        if (isolatedReviewCodexHome) env.CODEX_HOME = isolatedReviewCodexHome;
+      }
       spawnedAgentEnv = env;
       const invocation = createCommandInvocation({
         command: agentLaunch.launchPath,
@@ -6592,7 +6717,7 @@ export async function startServer({
     // hook_started/hook_response frames — none of which is the reply; mining it
     // produced empty extractions that, near-identical across a build's re-fires,
     // caused the same turn to be re-analyzed dozens of times.
-    child.on('close', () => {
+    if (purpose !== 'review') child.on('close', () => {
       const userMsg = typeof message === 'string' ? message : '';
       // Forward the chat agent id so memory-llm.pickProvider can
       // constrain its auto-pick to the chat protocol's family — keeps
@@ -8335,6 +8460,7 @@ export async function startServer({
     agents: { detectAgents, getAgentDef },
     chat: { startChatRun },
     lifecycle: { isDaemonShuttingDown: () => daemonShuttingDown },
+    events: { emitProjectEvent },
     plugins: {
       connectorService,
       detectSkillPluginCandidateOnRunSuccess,

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -196,6 +196,24 @@ describe('/api/chat', () => {
     expect(body).toContain('AGENT_UNAVAILABLE');
   });
 
+  it('rejects independent review purpose on the legacy chat endpoint', async () => {
+    const response = await fetch(`${baseUrl}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentId: 'codex',
+        conversationId: `existing-${randomUUID()}`,
+        message: 'review this project',
+        purpose: 'review',
+      }),
+    });
+    const body = await response.json() as { error?: { code?: string; message?: string } };
+
+    expect(response.status).toBe(400);
+    expect(body.error?.code).toBe('BAD_REQUEST');
+    expect(body.error?.message).toContain('POST /api/runs');
+  });
+
   it('keeps serving when delivered-session persistence has no conversation row', async () => {
     const conversationId = `missing-conversation-${randomUUID()}`;
 

--- a/apps/daemon/tests/codex-session-resume.test.ts
+++ b/apps/daemon/tests/codex-session-resume.test.ts
@@ -1,6 +1,6 @@
 import type { Server } from 'node:http';
 import { randomUUID } from 'node:crypto';
-import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -39,10 +39,22 @@ type RunStatus = {
   errorCode: string | null;
   eventsLogPath: string;
   resumable?: boolean;
+  purpose?: 'review' | null;
 };
 
-type ExecInvocation = { argv: string[]; stdin: string; cwd: string };
+type ExecInvocation = {
+  argv: string[];
+  stdin: string;
+  cwd: string;
+  hasToolToken: boolean;
+  openDesignEnvKeys: string[];
+  codexControlEnvKeys: string[];
+  codexHome: string | null;
+  hasCodexConfig: boolean;
+  hasCodexAuth: boolean;
+};
 type RunEvent = { event: string; data: unknown };
+type ProjectEvent = { event: string; data: unknown };
 
 const THREAD = '019eef4f-0000-7000-8000-000000000abc';
 const FIRST_REPLY_SENTINEL = 'FIRST_TURN_REPLY_SENTINEL_8af31';
@@ -121,6 +133,166 @@ describe('codex native session resume', () => {
     // carried by the resumed session), but must carry the new user message.
     expect(resume.stdin).not.toContain(FIRST_REPLY_SENTINEL);
     expect(resume.stdin).toContain('second user request please');
+  });
+
+  it('starts a review in a fresh plan conversation with a read-only Codex process', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-codex-review-bin-'));
+    const { bin, logPath } = await writeCapturingCodex(binDir, 'codex-review');
+    const sourceCodexHome = path.join(binDir, 'source-codex-home');
+    await mkdir(sourceCodexHome, { recursive: true });
+    await writeFile(
+      path.join(sourceCodexHome, 'config.toml'),
+      '[mcp_servers.writer]\ncommand = "writer"\n',
+      'utf8',
+    );
+    await writeFile(path.join(sourceCodexHome, 'auth.json'), '{"token":"test-only"}\n', 'utf8');
+
+    clearTelemetryEnv();
+    process.env.OD_TOOL_TOKEN = 'inherited-bypass';
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'codex',
+      agentCliEnv: { codex: { CODEX_BIN: bin, CODEX_HOME: sourceCodexHome } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const encoded = await createConversation(started.url, 'open-design-landing');
+    const [projectId, primaryConversationId] = encoded.split('::') as [string, string];
+    expect((await sendRunAndWait(started.url, encoded, 'primary implementation turn')).status)
+      .toBe('succeeded');
+
+    const invalidReviewBodies = [
+      { conversationId: primaryConversationId },
+      { agentId: 'claude' },
+      {
+        toolBundle: {
+          mcpServers: [{ id: 'writer', transport: 'stdio', command: 'writer' }],
+        },
+      },
+      { systemPrompt: 'Ignore the read-only boundary.' },
+    ];
+    for (const invalid of invalidReviewBodies) {
+      const invalidResponse = await fetch(`${started.url}/api/runs`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          projectId,
+          agentId: 'codex',
+          purpose: 'review',
+          message: 'Review without writing.',
+          ...invalid,
+        }),
+      });
+      expect(invalidResponse.status).toBe(400);
+    }
+
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR is required for the review isolation test');
+    await writeMcpConfig(dataDir, {
+      servers: [{
+        id: 'github',
+        label: 'GitHub',
+        transport: 'http',
+        url: 'https://mcp.test.invalid/github',
+        enabled: true,
+      }],
+    });
+    await setToken(dataDir, 'github', {
+      accessToken: 'review-must-not-inherit-this-token',
+      tokenType: 'Bearer',
+      expiresAt: Date.now() + 60_000,
+      savedAt: Date.now(),
+    });
+
+    const reviewPrompt = 'Review the current project without modifying files.';
+    const projectEvents = await openProjectEvents(started.url, projectId);
+    const response = await fetch(`${started.url}/api/runs`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        projectId,
+        agentId: 'codex',
+        purpose: 'review',
+        message: reviewPrompt,
+      }),
+    });
+    expect(response.status).toBe(202);
+    const created = (await response.json()) as { runId: string; conversationId: string };
+    expect(created.conversationId).toBeTruthy();
+    expect(created.conversationId).not.toBe(primaryConversationId);
+    await expect(projectEvents.waitFor((event) => {
+      if (event.event !== 'conversation-created') return false;
+      const data = event.data as { conversationId?: string };
+      return data.conversationId === created.conversationId;
+    })).resolves.toMatchObject({
+      event: 'conversation-created',
+      data: expect.objectContaining({
+        projectId,
+        conversationId: created.conversationId,
+        title: 'Independent review',
+      }),
+    });
+    await projectEvents.close();
+    const reviewStatus = await waitForRun(started.url, created.runId);
+    expect(reviewStatus.status).toBe('succeeded');
+    expect(reviewStatus.purpose).toBe('review');
+    expect(reviewStatus.resumable).toBe(false);
+
+    const invocations = await readChatTurnExecs(logPath, encoded);
+    expect(invocations).toHaveLength(2);
+    const review = invocations[1]!;
+    expect(review.argv[0]).toBe('exec');
+    expect(review.argv).not.toContain('resume');
+    const sandboxIndex = review.argv.indexOf('--sandbox');
+    expect(sandboxIndex).toBeGreaterThan(-1);
+    expect(review.argv[sandboxIndex + 1]).toBe('read-only');
+    expect(review.argv.slice(review.argv.indexOf('--disable'), review.argv.indexOf('--disable') + 2))
+      .toEqual(['--disable', 'plugins']);
+    expect(review.argv).toContain('--ephemeral');
+    expect(review.argv).toContain('--ignore-user-config');
+    expect(review.argv).toContain('--ignore-rules');
+    expect(review.hasToolToken).toBe(false);
+    expect(review.openDesignEnvKeys).toEqual([]);
+    expect(review.codexControlEnvKeys).toEqual([]);
+    expect(review.codexHome).not.toBe(sourceCodexHome);
+    expect(review.hasCodexConfig).toBe(false);
+    expect(review.hasCodexAuth).toBe(true);
+    expect(review.stdin).not.toContain('Runtime tool environment');
+    expect(review.stdin).not.toContain('`github`');
+    expect(review.stdin).not.toContain('Atelier Zero visual language');
+
+    const conversationsResponse = await fetch(
+      `${started.url}/api/projects/${encodeURIComponent(projectId)}/conversations`,
+    );
+    expect(conversationsResponse.status).toBe(200);
+    const conversationsBody = (await conversationsResponse.json()) as {
+      conversations: Array<{ id: string; sessionMode: string }>;
+    };
+    expect(conversationsBody.conversations).toContainEqual(
+      expect.objectContaining({ id: created.conversationId, sessionMode: 'plan' }),
+    );
+
+    const messagesResponse = await fetch(
+      `${started.url}/api/projects/${encodeURIComponent(projectId)}`
+        + `/conversations/${encodeURIComponent(created.conversationId)}/messages`,
+    );
+    expect(messagesResponse.status).toBe(200);
+    const messagesBody = (await messagesResponse.json()) as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    expect(messagesBody.messages).toContainEqual(
+      expect.objectContaining({ role: 'user', content: reviewPrompt }),
+    );
+
+    expect((await sendRunAndWait(
+      started.url,
+      `${projectId}::${created.conversationId}`,
+      'start a normal follow-up turn',
+    )).status).toBe('succeeded');
+    const afterReview = await readChatTurnExecs(logPath, encoded);
+    expect(afterReview).toHaveLength(3);
+    expect(afterReview[2]!.argv).not.toContain('resume');
   });
 
   it('transparently auto-reseeds within the same turn on `no rollout found`', async () => {
@@ -422,6 +594,7 @@ async function writeNoHandleCodex(
 function fakeCodexSource(opts: { logPath: string; body: string }): string {
   return `#!/usr/bin/env node
 const fs = require('node:fs');
+const path = require('node:path');
 const logPath = ${JSON.stringify(opts.logPath)};
 const THREAD = ${JSON.stringify(THREAD)};
 const argv = process.argv.slice(2);
@@ -431,7 +604,23 @@ let stdin = '';
 let done = false;
 function finish() {
   if (done) return; done = true;
-  try { fs.appendFileSync(logPath, JSON.stringify({ argv, stdin, cwd: process.cwd() }) + '\\n'); } catch {}
+  try {
+    fs.appendFileSync(logPath, JSON.stringify({
+      argv,
+      stdin,
+      cwd: process.cwd(),
+      hasToolToken: Boolean(process.env.OD_TOOL_TOKEN),
+      openDesignEnvKeys: Object.keys(process.env)
+        .filter((key) => /^(?:OD_|OPEN_DESIGN_)/i.test(key))
+        .sort(),
+      codexControlEnvKeys: Object.keys(process.env)
+        .filter((key) => /^CODEX_/i.test(key) && key.toUpperCase() !== 'CODEX_HOME')
+        .sort(),
+      codexHome: process.env.CODEX_HOME || null,
+      hasCodexConfig: Boolean(process.env.CODEX_HOME && fs.existsSync(path.join(process.env.CODEX_HOME, 'config.toml'))),
+      hasCodexAuth: Boolean(process.env.CODEX_HOME && fs.existsSync(path.join(process.env.CODEX_HOME, 'auth.json'))),
+    }) + '\\n');
+  } catch {}
   run();
 }
 function run() {
@@ -458,6 +647,7 @@ function snapshotEnv(): Record<string, string | undefined> {
     LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
     LANGFUSE_BASE_URL: process.env.LANGFUSE_BASE_URL,
     OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
+    OD_TOOL_TOKEN: process.env.OD_TOOL_TOKEN,
     POSTHOG_KEY: process.env.POSTHOG_KEY,
     POSTHOG_HOST: process.env.POSTHOG_HOST,
   };
@@ -488,7 +678,7 @@ async function putConfig(url: string, patch: Record<string, unknown>): Promise<v
   expect(response.status).toBe(200);
 }
 
-async function createConversation(url: string): Promise<string> {
+async function createConversation(url: string, skillId?: string): Promise<string> {
   const projectId = `codex_resume_${randomUUID()}`;
   const projectResponse = await fetch(`${url}/api/projects`, {
     method: 'POST',
@@ -497,6 +687,7 @@ async function createConversation(url: string): Promise<string> {
       id: projectId,
       name: 'Codex resume smoke',
       metadata: { kind: 'prototype' },
+      ...(skillId ? { skillId } : {}),
       skipDiscoveryBrief: true,
     }),
   });
@@ -537,6 +728,64 @@ async function sendRunAndWait(
   expect(runResponse.status).toBe(202);
   const body = (await runResponse.json()) as { runId: string };
   return await waitForRun(url, body.runId);
+}
+
+async function openProjectEvents(url: string, projectId: string): Promise<{
+  waitFor: (
+    predicate: (event: ProjectEvent) => boolean,
+    timeoutMs?: number,
+  ) => Promise<ProjectEvent>;
+  close: () => Promise<void>;
+}> {
+  const response = await fetch(
+    `${url}/api/projects/${encodeURIComponent(projectId)}/events`,
+    { headers: { accept: 'text/event-stream' } },
+  );
+  if (!response.ok || !response.body) {
+    throw new Error(`failed to open project events: ${response.status}`);
+  }
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  const events: ProjectEvent[] = [];
+  let buffer = '';
+  const pump = (async () => {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) return;
+      buffer += decoder.decode(value, { stream: true });
+      const blocks = buffer.split('\n\n');
+      buffer = blocks.pop() ?? '';
+      for (const block of blocks) {
+        if (!block.trim() || block.startsWith(':')) continue;
+        let event = 'message';
+        let data = '';
+        for (const line of block.split('\n')) {
+          if (line.startsWith('event: ')) event = line.slice(7);
+          if (line.startsWith('data: ')) data += line.slice(6);
+        }
+        let parsed: unknown = data;
+        try {
+          parsed = JSON.parse(data);
+        } catch {}
+        events.push({ event, data: parsed });
+      }
+    }
+  })();
+  return {
+    async waitFor(predicate, timeoutMs = 5_000) {
+      const startedAt = Date.now();
+      while (Date.now() - startedAt < timeoutMs) {
+        const found = events.find(predicate);
+        if (found) return found;
+        await delay(20);
+      }
+      throw new Error(`timed out waiting for project event: ${JSON.stringify(events)}`);
+    },
+    async close() {
+      await reader.cancel().catch(() => {});
+      await pump.catch(() => {});
+    },
+  };
 }
 
 async function waitForRun(url: string, runId: string): Promise<RunStatus> {

--- a/apps/daemon/tests/run-cli.test.ts
+++ b/apps/daemon/tests/run-cli.test.ts
@@ -31,7 +31,10 @@ afterEach(async () => {
   stub = null;
 });
 
-async function startRunStubServer(resumable: boolean): Promise<StubServer> {
+async function startRunStubServer(
+  resumable: boolean,
+  purpose: 'review' | null = null,
+): Promise<StubServer> {
   const requests: CapturedRequest[] = [];
   const server = http.createServer((req, res) => {
     let raw = '';
@@ -56,6 +59,7 @@ async function startRunStubServer(resumable: boolean): Promise<StubServer> {
           agentId: 'claude',
           status: 'failed',
           resumable,
+          purpose,
         }));
         return;
       }
@@ -106,6 +110,35 @@ async function runCli(args: string[]): Promise<{ stdout: string; stderr: string;
 }
 
 describe('od run CLI', () => {
+  it('starts an independent Codex review through the normal run API', async () => {
+    stub = await startRunStubServer(false);
+
+    const result = await runCli([
+      'run',
+      'review',
+      '--project',
+      'project-1',
+      '--message',
+      'Review the current changes.',
+      '--daemon-url',
+      stub.baseUrl,
+      '--json',
+    ]);
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(JSON.parse(result.stdout)).toEqual({ runId: 'run-2' });
+    expect(stub.requests.map((request) => `${request.method} ${request.url}`)).toEqual([
+      'POST /api/runs',
+    ]);
+    expect(JSON.parse(stub.requests[0]!.body)).toEqual({
+      projectId: 'project-1',
+      agentId: 'codex',
+      purpose: 'review',
+      message: 'Review the current changes.',
+    });
+  });
+
   it('continues a resumable run through the normal run creation API', async () => {
     stub = await startRunStubServer(true);
 
@@ -149,6 +182,24 @@ describe('od run CLI', () => {
     expect(result.code).toBe(1);
     expect(result.stdout).toBe('');
     expect(result.stderr).toContain('Run run-1 does not have a safe recoverable native session.');
+    expect(stub.requests.map((request) => `${request.method} ${request.url}`)).toEqual([
+      'GET /api/runs/run-1',
+    ]);
+  });
+
+  it('never continues an independent review as a writable normal run', async () => {
+    stub = await startRunStubServer(true, 'review');
+
+    const result = await runCli([
+      'run',
+      'continue',
+      'run-1',
+      '--daemon-url',
+      stub.baseUrl,
+    ]);
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('cannot be continued with writable access');
     expect(stub.requests.map((request) => `${request.method} ${request.url}`)).toEqual([
       'GET /api/runs/run-1',
     ]);

--- a/apps/daemon/tests/runtimes/codex-resume-args.test.ts
+++ b/apps/daemon/tests/runtimes/codex-resume-args.test.ts
@@ -94,6 +94,34 @@ describe('codex buildArgs session resume', () => {
     expect(args).not.toContain('resume');
   });
 
+  it('keeps an independent review read-only even when the operator default is danger-full-access', () => {
+    const previous = process.env.OD_CODEX_SANDBOX;
+    process.env.OD_CODEX_SANDBOX = 'danger-full-access';
+    try {
+      const args = codexAgentDef.buildArgs(
+        'review prompt',
+        [],
+        ['/extra/writable/dir'],
+        { filesystemAccess: 'read-only' },
+        { cwd: '/some/project/dir' },
+      );
+      const sandboxIndex = args.indexOf('--sandbox');
+      expect(sandboxIndex).toBeGreaterThan(-1);
+      expect(args[sandboxIndex + 1]).toBe('read-only');
+      expect(args).not.toContain('danger-full-access');
+      expect(args).not.toContain('--add-dir');
+      expect(args).not.toContain('/extra/writable/dir');
+      expect(args).toContain('--disable');
+      expect(args[args.indexOf('--disable') + 1]).toBe('plugins');
+      expect(args).toContain('--ephemeral');
+      expect(args).toContain('--ignore-user-config');
+      expect(args).toContain('--ignore-rules');
+    } finally {
+      if (previous === undefined) delete process.env.OD_CODEX_SANDBOX;
+      else process.env.OD_CODEX_SANDBOX = previous;
+    }
+  });
+
   it('declares CLI-managed, capture-style session resume', () => {
     expect(codexAgentDef.resumesSessionViaCli).toBe(true);
     expect(codexAgentDef.capturesSessionIdFromStream).toBe(true);

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -14,6 +14,7 @@ import {
   type ReactNode,
 } from 'react';
 import { createPortal } from 'react-dom';
+import { Button } from '@open-design/components';
 import { hasOdCard } from '@open-design/contracts';
 import { useAnalytics } from '../analytics/provider';
 import { getResolvedDeviceId } from '../analytics/client';
@@ -555,6 +556,9 @@ interface Props {
   // Header "+" button — kicks off ProjectView's create-conversation flow.
   onNewConversation?: () => void;
   newConversationDisabled?: boolean;
+  onIndependentReview?: () => void;
+  independentReviewBusy?: boolean;
+  independentReviewDisabled?: boolean;
   // Conversation list that used to live in the topbar. The chat tab now
   // owns the list so users can browse + switch conversations without
   // leaving the pane.
@@ -843,6 +847,9 @@ export function ChatPane({
   forkingMessageId = null,
   onNewConversation,
   newConversationDisabled = false,
+  onIndependentReview,
+  independentReviewBusy = false,
+  independentReviewDisabled = false,
   conversations,
   activeConversationId,
   messagesConversationId = null,
@@ -2142,6 +2149,23 @@ export function ChatPane({
         ) : null}
         {projectHeader ? (
           <span className="chat-project-header-title">{projectHeader}</span>
+        ) : null}
+        {onIndependentReview ? (
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            className="chat-session-trigger icon-only"
+            data-testid="independent-review-trigger"
+            title={independentReviewBusy
+              ? t('chat.independentReviewStarting')
+              : t('chat.independentReview')}
+            aria-label={t('chat.independentReview')}
+            disabled={independentReviewBusy || independentReviewDisabled}
+            onClick={onIndependentReview}
+          >
+            <Icon name={independentReviewBusy ? 'spinner' : 'check'} size={16} />
+          </Button>
         ) : null}
         <div
           className={`chat-history-wrap chat-session-switcher${showConvList ? ' open' : ''}`}

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -28,6 +28,7 @@ import {
   publishDaemonRunFinishedEvent,
   reattachDaemonRun,
   reportChatRunFeedback,
+  startIndependentReview,
   streamViaDaemon,
 } from '../providers/daemon';
 import { normalizeCustomReason } from '@open-design/contracts/analytics';
@@ -1806,6 +1807,7 @@ export function ProjectView({
   // correctly gate new-conversation creation even during async loads.
   const messagesConversationIdRef = useRef<string | null>(null);
   const creatingConversationRef = useRef(false);
+  const independentReviewStartingRef = useRef(false);
   // Last conversation id this view pushed into the URL. Lets the
   // route -> active-conversation sync tell a genuine external navigation
   // apart from the URL merely lagging a local conversation switch.
@@ -1839,6 +1841,7 @@ export function ProjectView({
   // allowed to apply its result.
   const conversationsRefreshTokenRef = useRef(0);
   const [creatingConversation, setCreatingConversation] = useState(false);
+  const [independentReviewStarting, setIndependentReviewStarting] = useState(false);
   const currentConversationHasProgrammaticBrandExtractionRun = useMemo(
     () => messages.some((m) => isProgrammaticBrandExtractionStatusMessage(m, currentProject.metadata)),
     [messages, currentProject.metadata],
@@ -2625,9 +2628,9 @@ export function ProjectView({
       return;
     }
     if (evt.type === 'conversation-created') {
-      // A new conversation was inserted into this project by a path the
-      // open project view can't observe through its own state (currently:
-      // Routines "Run now" in reuse-an-existing-project mode, #1361).
+      // A new conversation was inserted into this project by a server-side
+      // path the open project view may not observe through its own state
+      // (for example a routine or an independent review run).
       // Refetch the conversation list so the new entry becomes visible
       // without requiring the user to leave and re-enter the project.
       // Deliberately do NOT change the active conversation here — the
@@ -7048,6 +7051,48 @@ export function ProjectView({
     setMessageLoadRetryNonce((nonce) => nonce + 1);
   }, [activeConversationId, failedMessagesConversationId, project.id, openTabsState.active]);
 
+  const handleIndependentReview = useCallback(async () => {
+    if (independentReviewStartingRef.current || currentConversationActionDisabled) return;
+    independentReviewStartingRef.current = true;
+    setIndependentReviewStarting(true);
+    setConversationLoadError(null);
+    try {
+      const capturedProjectId = project.id;
+      const created = await startIndependentReview(capturedProjectId);
+      if (!created.conversationId) {
+        throw new Error('The daemon did not return an independent review conversation.');
+      }
+      if (projectIdRef.current !== capturedProjectId) return;
+      const conversationId = created.conversationId;
+      const myToken = ++conversationsRefreshTokenRef.current;
+      setConversations((current) =>
+        ensureConversationPresent(current, conversationId, capturedProjectId));
+      handleSelectConversation(created.conversationId);
+      setError(null);
+      // The daemon has already accepted the review. Refreshing the sidebar is
+      // best-effort: a transient list failure must not report that start as a
+      // failure and tempt the user to create a duplicate review. The monotonic
+      // token also prevents this response from overwriting a newer project
+      // event refresh.
+      void listConversations(capturedProjectId)
+        .then((list) => {
+          if (projectIdRef.current !== capturedProjectId) return;
+          if (conversationsRefreshTokenRef.current !== myToken) return;
+          setConversations(ensureConversationPresent(list, conversationId, capturedProjectId));
+        })
+        .catch(() => {});
+    } catch (err) {
+      const message = err instanceof Error
+        ? err.message
+        : 'Could not start an independent review.';
+      setConversationLoadError(message);
+      setError(message);
+    } finally {
+      independentReviewStartingRef.current = false;
+      setIndependentReviewStarting(false);
+    }
+  }, [currentConversationActionDisabled, handleSelectConversation, project.id]);
+
   const refreshConversationsForProgrammaticBrandRetry = useCallback(
     async (conversationId: string): Promise<boolean> => {
       const capturedProjectId = project.id;
@@ -8613,6 +8658,13 @@ export function ProjectView({
               forkingMessageId={forkingMessageId}
               onNewConversation={handleNewConversation}
               newConversationDisabled={newConversationDisabled}
+              onIndependentReview={
+                config.mode === 'daemon' && daemonLive
+                  ? () => void handleIndependentReview()
+                  : undefined
+              }
+              independentReviewBusy={independentReviewStarting}
+              independentReviewDisabled={currentConversationActionDisabled}
               conversations={conversations}
               activeConversationId={activeConversationId}
               messagesConversationId={messagesConversationId}

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1829,6 +1829,8 @@ export const ar: Dict = {
   'chat.annotationUploadFailed': 'فشل رفع المرفق. يُرجى المحاولة مرة أخرى.',
   'chat.conversationsTitle': 'المحادثات',
   'chat.conversationsAria': 'سجل المحادثات',
+  'chat.independentReview': 'مراجعة مستقلة',
+  'chat.independentReviewStarting': 'جارٍ بدء المراجعة المستقلة…',
   'chat.newConversation': 'محادثة جديدة',
   'chat.newConversationsTitle': 'محادثة جديدة',
   'chat.conversationsHeading': 'المحادثات',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -1829,6 +1829,8 @@ export const de: Dict = {
   'chat.annotationUploadFailed': 'Hochladen des Anhangs fehlgeschlagen. Bitte versuche es erneut.',
   'chat.conversationsTitle': 'Konversationen',
   'chat.conversationsAria': 'Konversationsverlauf',
+  'chat.independentReview': 'Unabhängige Prüfung',
+  'chat.independentReviewStarting': 'Unabhängige Prüfung wird gestartet…',
   'chat.newConversation': 'Neue Konversation',
   'chat.newConversationsTitle': 'Neue Konversation',
   'chat.conversationsHeading': 'Konversationen',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1829,6 +1829,8 @@ export const en: Dict = {
   'chat.annotationUploadFailed': 'Attachment upload failed. Please try again.',
   'chat.conversationsTitle': 'Conversations',
   'chat.conversationsAria': 'Conversation history',
+  'chat.independentReview': 'Independent review',
+  'chat.independentReviewStarting': 'Starting independent review…',
   'chat.newConversation': 'New conversation',
   'chat.newConversationsTitle': 'New conversation',
   'chat.conversationsHeading': 'Conversations',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -1829,6 +1829,8 @@ export const esES: Dict = {
   'chat.annotationUploadFailed': 'Error al subir el adjunto. Inténtalo de nuevo.',
   'chat.conversationsTitle': 'Conversaciones',
   'chat.conversationsAria': 'Historial de conversaciones',
+  'chat.independentReview': 'Revisión independiente',
+  'chat.independentReviewStarting': 'Iniciando revisión independiente…',
   'chat.newConversation': 'Nueva conversación',
   'chat.newConversationsTitle': 'Nueva conversación',
   'chat.conversationsHeading': 'Conversaciones',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1829,6 +1829,8 @@ export const fa: Dict = {
   'chat.annotationUploadFailed': 'بارگذاری پیوست ناموفق بود. لطفاً دوباره تلاش کنید.',
   'chat.conversationsTitle': 'مکالمات',
   'chat.conversationsAria': 'تاریخچه مکالمات',
+  'chat.independentReview': 'بررسی مستقل',
+  'chat.independentReviewStarting': 'در حال شروع بررسی مستقل…',
   'chat.newConversation': 'مکالمه جدید',
   'chat.newConversationsTitle': 'مکالمه جدید',
   'chat.conversationsHeading': 'مکالمات',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1829,6 +1829,8 @@ export const fr: Dict = {
   'chat.annotationUploadFailed': 'L’envoi de la pièce jointe a échoué. Veuillez réessayer.',
   'chat.conversationsTitle': 'Conversations',
   'chat.conversationsAria': 'Historique des conversations',
+  'chat.independentReview': 'Revue indépendante',
+  'chat.independentReviewStarting': 'Démarrage de la revue indépendante…',
   'chat.newConversation': 'Nouvelle conversation',
   'chat.newConversationsTitle': 'Nouvelle conversation',
   'chat.conversationsHeading': 'Conversations',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1829,6 +1829,8 @@ export const hu: Dict = {
   'chat.annotationUploadFailed': 'A melléklet feltöltése nem sikerült. Kérjük, próbálja újra.',
   'chat.conversationsTitle': 'Beszélgetések',
   'chat.conversationsAria': 'Beszélgetések előzménye',
+  'chat.independentReview': 'Független ellenőrzés',
+  'chat.independentReviewStarting': 'Független ellenőrzés indítása…',
   'chat.newConversation': 'Új beszélgetés',
   'chat.newConversationsTitle': 'Új beszélgetés',
   'chat.conversationsHeading': 'Beszélgetések',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1829,6 +1829,8 @@ export const id: Dict = {
   'chat.annotationUploadFailed': 'Attachment upload failed. Please try again.',
   'chat.conversationsTitle': 'Percakapan',
   'chat.conversationsAria': 'Buka percakapan',
+  'chat.independentReview': 'Tinjauan independen',
+  'chat.independentReviewStarting': 'Memulai tinjauan independen…',
   'chat.newConversation': 'Percakapan baru',
   'chat.newConversationsTitle': 'Mulai percakapan baru',
   'chat.conversationsHeading': 'Percakapan',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -1829,6 +1829,8 @@ export const it: Dict = {
   'chat.annotationUploadFailed': 'Caricamento dell\'allegato non riuscito. Riprova.',
   'chat.conversationsTitle': 'Conversazioni',
   'chat.conversationsAria': 'Cronologia delle conversazioni',
+  'chat.independentReview': 'Revisione indipendente',
+  'chat.independentReviewStarting': 'Avvio della revisione indipendente…',
   'chat.newConversation': 'Nuova conversazione',
   'chat.newConversationsTitle': 'Nuova conversazione',
   'chat.conversationsHeading': 'Conversazioni',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -1829,6 +1829,8 @@ export const ja: Dict = {
   'chat.annotationUploadFailed': '添付ファイルのアップロードに失敗しました。もう一度お試しください。',
   'chat.conversationsTitle': '会話',
   'chat.conversationsAria': '会話履歴',
+  'chat.independentReview': '独立レビュー',
+  'chat.independentReviewStarting': '独立レビューを開始しています…',
   'chat.newConversation': '新しい会話',
   'chat.newConversationsTitle': '新しい会話',
   'chat.conversationsHeading': '会話',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1829,6 +1829,8 @@ export const ko: Dict = {
   'chat.annotationUploadFailed': '첨부 파일 업로드에 실패했습니다. 다시 시도해 주세요.',
   'chat.conversationsTitle': '대화 목록',
   'chat.conversationsAria': '대화 내역',
+  'chat.independentReview': '독립 검토',
+  'chat.independentReviewStarting': '독립 검토를 시작하는 중…',
   'chat.newConversation': '새 대화 시작',
   'chat.newConversationsTitle': '새 대화',
   'chat.conversationsHeading': '대화 목록',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1829,6 +1829,8 @@ export const pl: Dict = {
   'chat.annotationUploadFailed': 'Nie udało się przesłać załącznika. Spróbuj ponownie.',
   'chat.conversationsTitle': 'Rozmowy',
   'chat.conversationsAria': 'Historia rozmów',
+  'chat.independentReview': 'Niezależny przegląd',
+  'chat.independentReviewStarting': 'Rozpoczynanie niezależnego przeglądu…',
   'chat.newConversation': 'Nowa rozmowa',
   'chat.newConversationsTitle': 'Nowa rozmowa',
   'chat.conversationsHeading': 'Rozmowy',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1829,6 +1829,8 @@ export const ptBR: Dict = {
   'chat.annotationUploadFailed': 'Falha ao enviar o anexo. Tente novamente.',
   'chat.conversationsTitle': 'Conversas',
   'chat.conversationsAria': 'Histórico de conversas',
+  'chat.independentReview': 'Revisão independente',
+  'chat.independentReviewStarting': 'Iniciando revisão independente…',
   'chat.newConversation': 'Nova conversa',
   'chat.newConversationsTitle': 'Nova conversa',
   'chat.conversationsHeading': 'Conversas',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1829,6 +1829,8 @@ export const ru: Dict = {
   'chat.annotationUploadFailed': 'Не удалось загрузить вложение. Попробуйте ещё раз.',
   'chat.conversationsTitle': 'Разговоры',
   'chat.conversationsAria': 'История разговоров',
+  'chat.independentReview': 'Независимая проверка',
+  'chat.independentReviewStarting': 'Запуск независимой проверки…',
   'chat.newConversation': 'Новый разговор',
   'chat.newConversationsTitle': 'Новый разговор',
   'chat.conversationsHeading': 'Разговоры',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -1829,6 +1829,8 @@ export const th: Dict = {
   'chat.annotationUploadFailed': 'การอัปโหลดไฟล์แนบล้มเหลว โปรดลองอีกครั้ง',
   'chat.conversationsTitle': 'การสนทนา',
   'chat.conversationsAria': 'ประวัติ',
+  'chat.independentReview': 'การตรวจสอบอิสระ',
+  'chat.independentReviewStarting': 'กำลังเริ่มการตรวจสอบอิสระ…',
   'chat.newConversation': 'สนทนาใหม่',
   'chat.newConversationsTitle': 'เริ่มใหม่',
   'chat.conversationsHeading': 'บทสนทนาทั้งหมด',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1829,6 +1829,8 @@ export const tr: Dict = {
   'chat.annotationUploadFailed': 'Ek yükleme başarısız oldu. Lütfen tekrar deneyin.',
   'chat.conversationsTitle': 'Konuşmalar',
   'chat.conversationsAria': 'Konuşma geçmişi',
+  'chat.independentReview': 'Bağımsız inceleme',
+  'chat.independentReviewStarting': 'Bağımsız inceleme başlatılıyor…',
   'chat.newConversation': 'Yeni konuşma',
   'chat.newConversationsTitle': 'Yeni Konuşma',
   'chat.conversationsHeading': 'Konuşmalar',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1829,6 +1829,8 @@ export const uk: Dict = {
   'chat.annotationUploadFailed': 'Не вдалося завантажити вкладення. Спробуйте ще раз.',
   'chat.conversationsTitle': 'Розмови',
   'chat.conversationsAria': 'Історія розмов',
+  'chat.independentReview': 'Незалежна перевірка',
+  'chat.independentReviewStarting': 'Запуск незалежної перевірки…',
   'chat.newConversation': 'Нова розмова',
   'chat.newConversationsTitle': 'Нова розмова',
   'chat.conversationsHeading': 'Розмови',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1938,6 +1938,8 @@ export const zhCN: Dict = {
   "chat.annotationUploadFailed": "附件上传失败，请重试",
   "chat.conversationsTitle": "对话历史",
   "chat.conversationsAria": "对话历史",
+  "chat.independentReview": "独立审查",
+  "chat.independentReviewStarting": "正在启动独立审查…",
   "chat.newConversation": "新建对话",
   "chat.newConversationsTitle": "新建对话",
   "chat.conversationsHeading": "对话",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1947,6 +1947,8 @@ export const zhTW: Dict = {
   "chat.annotationUploadFailed": "附件上傳失敗，請重試。",
   "chat.conversationsTitle": "對話紀錄",
   "chat.conversationsAria": "對話紀錄",
+  "chat.independentReview": "獨立審查",
+  "chat.independentReviewStarting": "正在啟動獨立審查…",
   "chat.newConversation": "新建對話",
   "chat.newConversationsTitle": "新建對話",
   "chat.conversationsHeading": "對話",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -2606,6 +2606,8 @@ export interface Dict {
   'chat.inspect.commentHint': string;
   'chat.conversationsTitle': string;
   'chat.conversationsAria': string;
+  'chat.independentReview': string;
+  'chat.independentReviewStarting': string;
   'chat.newConversation': string;
   'chat.newConversationsTitle': string;
   'chat.conversationsHeading': string;

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -14,6 +14,7 @@ import type { AmrEntryAttribution } from '../analytics/amr-attribution';
 import type {
   ChatAnalyticsHints,
   ChatRunCreateResponse,
+  IndependentReviewRunCreateRequest,
   ChatRunListResponse,
   ChatRunStatus,
   ChatRunStatusResponse,
@@ -48,12 +49,42 @@ function detectClientType(): 'desktop' | 'web' | 'unknown' {
   if (ua) return 'web';
   return 'unknown';
 }
+
 import { parseSseFrame } from './sse';
 import {
   summarizeArtifactsForTranscript,
   type PersistedArtifactFileRef,
 } from '../artifacts/strip';
 import { trackRunProgress, trackRunStart, trackRunTerminal } from '../observability/stuck-run';
+
+const DEFAULT_INDEPENDENT_REVIEW_PROMPT =
+  'Review the current project changes without modifying files. Report actionable findings in severity order with file and line references. If there are no findings, say so explicitly.';
+
+export async function startIndependentReview(
+  projectId: string,
+): Promise<ChatRunCreateResponse> {
+  const request: IndependentReviewRunCreateRequest = {
+    projectId,
+    purpose: 'review',
+    agentId: 'codex',
+    message: DEFAULT_INDEPENDENT_REVIEW_PROMPT,
+  };
+  const response = await fetch('/api/runs', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-OD-Client': detectClientType(),
+    },
+    body: JSON.stringify(request),
+  });
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '');
+    throw new Error(`daemon ${response.status}: ${detail || 'could not start independent review'}`);
+  }
+  const created = (await response.json()) as ChatRunCreateResponse;
+  notifyRunsChanged();
+  return created;
+}
 
 const MAX_TRANSCRIPT_MESSAGE_CHARS = 12_000;
 const LARGE_TOOL_RESULT_CHARS = 8_000;

--- a/apps/web/tests/components/ChatPane.conversation-title.test.tsx
+++ b/apps/web/tests/components/ChatPane.conversation-title.test.tsx
@@ -102,6 +102,18 @@ describe('ChatPane session switcher', () => {
     expect(screen.queryByDisplayValue('Contract review draft')).toBeNull();
   });
 
+  it('starts an independent review from the project header', () => {
+    const onIndependentReview = vi.fn();
+    renderChatPane({
+      conversations: [conversation({ id: 'conv-1', title: 'Current' })],
+      activeConversationId: 'conv-1',
+      onIndependentReview,
+    });
+
+    fireEvent.click(screen.getByTestId('independent-review-trigger'));
+    expect(onIndependentReview).toHaveBeenCalledTimes(1);
+  });
+
   it('tracks run_failed_toast exposure for AMR balance guidance', async () => {
     render(
       <ChatPane
@@ -229,6 +241,7 @@ function renderChatPane(props: {
   conversations: Conversation[];
   activeConversationId: string | null;
   onSelectConversation?: (id: string) => void;
+  onIndependentReview?: () => void;
 }) {
   return render(chatPaneElement(props));
 }
@@ -237,10 +250,12 @@ function chatPaneElement({
   conversations,
   activeConversationId,
   onSelectConversation,
+  onIndependentReview,
 }: {
   conversations: Conversation[];
   activeConversationId: string | null;
   onSelectConversation?: (id: string) => void;
+  onIndependentReview?: () => void;
 }) {
   return (
     <ChatPane
@@ -256,6 +271,7 @@ function chatPaneElement({
       activeConversationId={activeConversationId}
       onSelectConversation={onSelectConversation ?? vi.fn()}
       onDeleteConversation={vi.fn()}
+      onIndependentReview={onIndependentReview}
     />
   );
 }

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -6,6 +6,7 @@ import {
   latestUserPromptFromHistory,
   reattachDaemonRun,
   sanitizePriorAssistantTurnForTranscript,
+  startIndependentReview,
   streamViaDaemon,
   type DaemonRunFinishedEventDetail,
 } from '../../src/providers/daemon';
@@ -35,6 +36,31 @@ describe('parseSseFrame', () => {
 
   it('returns empty for frames without data or comments', () => {
     expect(parseSseFrame('')).toEqual({ kind: 'empty' });
+  });
+});
+
+describe('startIndependentReview', () => {
+  it('starts a fresh Codex review through the dedicated run purpose', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({
+      runId: 'review-run',
+      conversationId: 'review-conversation',
+      assistantMessageId: 'review-assistant',
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(startIndependentReview('project-1')).resolves.toMatchObject({
+      runId: 'review-run',
+      conversationId: 'review-conversation',
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('/api/runs');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      projectId: 'project-1',
+      purpose: 'review',
+      agentId: 'codex',
+    });
   });
 });
 

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -229,6 +229,13 @@ the active-run staging implementation is in
 - Follow-up turns use `codex exec resume --json ... <thread-id>`. Resume uses
   `-c sandbox_mode=...` because Codex rejects create-only `--sandbox`, `-C`,
   and `--add-dir` flags on `exec resume`.
+- `od run review --project <project-id>` starts a fresh daemon-owned Codex
+  conversation with a forced `read-only` sandbox. Review runs do not resume an
+  existing Codex thread, add linked write roots, or receive daemon tool tokens;
+  an operator `OD_CODEX_SANDBOX` override cannot widen this policy. They also
+  run from a temporary `CODEX_HOME` that carries login state but excludes the
+  user's config, MCP servers, and plugins; plugins are disabled explicitly.
+  The Web UI exposes the same run from the project chat header.
 - Detection uses `codex login status` for auth and `codex debug models` for
   live model discovery, with static model hints as a fallback. Skills use the
   shared composition/staging path in §4 rather than version-gated loading from

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -29,6 +29,7 @@ export type RunFailureDetail = TrackingRunFailureDetail;
 
 export type ChatRole = 'user' | 'assistant';
 export type ChatSessionMode = 'design' | 'chat' | 'plan';
+export type ChatRunPurpose = 'review';
 export type ChatCommentSelectionKind = PreviewCommentSelectionKind | 'visual';
 export type ByokChatProtocol =
   | 'anthropic'
@@ -289,6 +290,19 @@ export interface ChatRunCreateRequest extends ChatRequest {
 }
 
 /**
+ * A daemon-owned independent review. The daemon creates the conversation and
+ * forces Codex into a read-only filesystem policy; callers cannot attach the
+ * run to an existing conversation or widen its tool access.
+ */
+export interface IndependentReviewRunCreateRequest {
+  projectId: string;
+  purpose: 'review';
+  message: string;
+  agentId?: 'codex';
+  model?: string;
+}
+
+/**
  * Minimal POST /api/runs shape accepted from MCP / SDK callers that do not
  * manage conversation state client-side. Only `projectId` is required;
  * `message` and `agentId` are optional — the daemon resolves `agentId` from
@@ -450,6 +464,8 @@ export interface ChatRunStatusResponse {
   conversationId: string | null;
   assistantMessageId: string | null;
   agentId: string | null;
+  /** Special daemon execution policy, when this is not a normal chat run. */
+  purpose?: ChatRunPurpose | null;
   /** Design system whose prompt context was actually injected for this run. */
   designSystemId?: string | null;
   /** Selected design system before usability/body checks; useful for diagnostics. */

--- a/packages/contracts/src/sse/chat.ts
+++ b/packages/contracts/src/sse/chat.ts
@@ -45,8 +45,8 @@ export interface PlainStreamArtifactSsePayload {
 /**
  * Emitted by the daemon on `/api/projects/:id/events` when a new
  * conversation is inserted into a project from a path the open
- * project view can't observe through its own state — currently
- * Routines "Run now" in reuse-an-existing-project mode (#1361).
+ * project view can't observe through its own state, including routines
+ * and independent review runs.
  *
  * Lives in `packages/contracts` so the daemon producer and the web
  * consumer share one type and can't drift as the stream grows.

--- a/specs/current/run.md
+++ b/specs/current/run.md
@@ -224,6 +224,29 @@ interface ChatRunCreateRequest {
 }
 ```
 
+Independent code review reuses `POST /api/runs` with a constrained request:
+
+```ts
+interface IndependentReviewRunCreateRequest {
+  projectId: string;
+  purpose: 'review';
+  message: string;
+  agentId?: 'codex';
+  model?: string;
+}
+```
+
+The daemon creates a fresh conversation for every independent review and
+forces the Codex process into a read-only filesystem sandbox. Review requests
+cannot attach to an existing conversation, load plugins or skills, provide a
+tool bundle, or receive a daemon tool token. The process uses an isolated
+temporary `CODEX_HOME` containing only copied login state and explicitly
+disables plugins, so user MCP/plugin configuration cannot widen the sandbox.
+The legacy `/api/chat` endpoint
+does not accept `purpose`. The project chat header exposes the same operation
+as an **Independent review** action and switches to the daemon-created review
+conversation after the run is accepted. `od run review` is the CLI equivalent.
+
 `GET /api/runs/:id` should return enough state for recovery:
 
 ```ts


### PR DESCRIPTION
Closes #5893

## Why

I wanted a reliable way to request a fresh code review after an implementation without leaving Open Design. A normal follow-up shares the implementation conversation and agent configuration, while an independent reviewer should neither inherit that context nor be able to modify the workspace.

This adds an explicit review run whose boundary is enforced by the daemon: a fresh conversation, Codex only, a read-only sandbox, no resume handle, no Open Design tool token, and no inherited plugins, MCP servers, skills, memory, design system, user configuration, or project-linked writable directories.

## What users will see

- A new **Independent review** action in the project header. It creates a separate plan conversation, starts a read-only Codex review, and switches the UI to that conversation.
- A new CLI command: `od run review --project <id>`, with message/prompt-file, model, follow, and JSON options.
- The daemon accepts `POST /api/runs` with `purpose: "review"` and returns both the new run ID and conversation ID.
- Review runs cannot be resumed or continued as review sessions.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

This is a draft PR; a project-header screenshot can be added before marking it ready.

## Bug fix verification

- Not applicable; this is an opt-in feature. The new daemon, CLI, contract, SSE, and Web behavior is covered by focused tests.

## Validation

- `pnpm guard` — passed (86 checks)
- daemon focused tests — 2 files, 15 tests passed
- Web full test suite — 4,682 passed, 7 skipped
- `pnpm --filter @open-design/daemon typecheck` — passed
- `pnpm --filter @open-design/daemon build` — passed
- Web production build — passed
- root typecheck — 0 errors (existing landing-page hints remain)
- i18n validation — passed for all 19 locales
- `git diff --check` — passed

The full daemon suite was also attempted. It still has unrelated existing/environment failures in BYOK/chat compatibility cases and image CDN/provider timeout tests; the focused review and Codex resume suites pass. Independent review was run in multiple rounds; the final extra pass hung after extended inspection and was terminated, and its environment-isolation concern was addressed with dedicated regression coverage.
