### PR TITLE
fix(templates): align placeholder asset formats

### DIFF
--- a/design-templates/open-design-landing-deck/README.md
+++ b/design-templates/open-design-landing-deck/README.md
@@ -80,8 +80,9 @@ design-templates/open-design-landing-deck/
 ## Image strategy
 
 The deck inherits the sister template's 16-slot image library. Set
-`inputs.imagery.assets_path` to wherever those PNGs live; the example
-uses `'../open-design-landing/assets/'`.
+`inputs.imagery.assets_path` to the shared asset directory; the example
+uses `'../open-design-landing/assets/'`. The composer references SVG slots
+for `placeholder` and PNG slots for `generate` or `bring-your-own`.
 
 To regenerate or stub:
 

--- a/design-templates/open-design-landing-deck/SKILL.md
+++ b/design-templates/open-design-landing-deck/SKILL.md
@@ -174,8 +174,10 @@ FAL_KEY=... npx tsx ../open-design-landing/scripts/imagegen.ts ../open-design-la
 npx tsx ../open-design-landing/scripts/placeholder.ts ../open-design-landing/assets/
 ```
 
-Set your deck's `inputs.imagery.assets_path` to wherever those PNGs
-live (default in the example: `../open-design-landing/assets/`).
+Set your deck's `inputs.imagery.assets_path` to the shared asset directory
+(default in the example: `../open-design-landing/assets/`). The composer
+uses `.svg` slots for `placeholder` and `.png` slots for `generate` or
+`bring-your-own`, based on `inputs.imagery.strategy`.
 
 ### 3. Compose the deck
 

--- a/design-templates/open-design-landing-deck/schema.ts
+++ b/design-templates/open-design-landing-deck/schema.ts
@@ -11,7 +11,7 @@
  * viewport-height/width frame. Brand identity is shared across slides.
  */
 
-import type { MixedText, BrandBlock, ImageryConfig } from '../open-design-landing/schema';
+import type { MixedText, BrandBlock, ImageryConfig } from '../open-design-landing/schema.js';
 
 export type { MixedText, BrandBlock, ImageryConfig };
 

--- a/design-templates/open-design-landing-deck/scripts/compose.ts
+++ b/design-templates/open-design-landing-deck/scripts/compose.ts
@@ -26,6 +26,7 @@ import { resolve, dirname, isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type {
   OpenDesignLandingDeckInputs,
+  ImageryConfig,
   Slide,
   CoverSlide,
   SectionSlide,
@@ -35,7 +36,7 @@ import type {
   CTASlide,
   EndSlide,
   MixedText,
-} from '../schema';
+} from '../schema.js';
 
 const SKILL_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const SISTER_STYLES = resolve(SKILL_ROOT, '..', 'open-design-landing', 'styles.css');
@@ -62,9 +63,11 @@ function ext(href: string): string {
 
 const ARROW_OUT = `<svg viewBox='0 0 24 24'><path d='M5 19L19 5M19 5H8M19 5v11'/></svg>`;
 
-function imgFor(slot: string | undefined, assets: string): string {
+function imgFor(slot: string | undefined, imagery: ImageryConfig): string {
   if (!slot) return '';
-  return `<img src='${assets}${slot}.png' alt='' />`;
+  const assets = imagery.assets_path.replace(/\/?$/, '/');
+  const extension = imagery.strategy === 'placeholder' ? 'svg' : 'png';
+  return `<img src='${assets}${slot}.${extension}' alt='' />`;
 }
 
 /* ------------------------------------------------------------------ *
@@ -657,7 +660,7 @@ function footStrip(idx: number, total: number, brand: OpenDesignLandingDeckInput
 </div>`;
 }
 
-function renderCover(s: CoverSlide, assets: string): string {
+function renderCover(s: CoverSlide, imagery: ImageryConfig): string {
   return `<div class='slide-inner'>
   <div class='copy'>
     <span class='eyebrow'>${s.eyebrow}</span>
@@ -671,7 +674,7 @@ function renderCover(s: CoverSlide, assets: string): string {
     <span class='corner tr'></span>
     <span class='corner bl'></span>
     <span class='corner br'></span>
-    ${imgFor(s.image_slot, assets)}
+    ${imgFor(s.image_slot, imagery)}
   </div>
 </div>`;
 }
@@ -684,7 +687,7 @@ function renderSection(s: SectionSlide): string {
 </div>`;
 }
 
-function renderContent(s: ContentSlide, assets: string): string {
+function renderContent(s: ContentSlide, imagery: ImageryConfig): string {
   const layout = s.layout ?? 'left';
   const hasArt = !!s.image_slot;
   return `<div class='slide-inner'>
@@ -694,7 +697,7 @@ function renderContent(s: ContentSlide, assets: string): string {
     ${s.body ? `<p class='body'>${s.body}</p>` : ''}
     ${s.bullets && s.bullets.length ? `<ul>${s.bullets.map((b) => `<li>${b}</li>`).join('')}</ul>` : ''}
   </div>
-  ${hasArt ? `<div class='art'>${imgFor(s.image_slot, assets)}</div>` : ''}
+  ${hasArt ? `<div class='art'>${imgFor(s.image_slot, imagery)}</div>` : ''}
 </div>`;
 }
 
@@ -721,7 +724,7 @@ function renderStats(s: StatsSlide): string {
 </div>`;
 }
 
-function renderQuote(s: QuoteSlide, assets: string): string {
+function renderQuote(s: QuoteSlide, imagery: ImageryConfig): string {
   const hasArt = !!s.image_slot;
   return `<div class='slide-inner'>
   <div>
@@ -731,7 +734,7 @@ function renderQuote(s: QuoteSlide, assets: string): string {
       <p>${s.author.name}<span>${s.author.title}</span></p>
     </div>
   </div>
-  ${hasArt ? `<div class='art'>${imgFor(s.image_slot, assets)}</div>` : ''}
+  ${hasArt ? `<div class='art'>${imgFor(s.image_slot, imagery)}</div>` : ''}
 </div>`;
 }
 
@@ -764,13 +767,13 @@ function renderEnd(s: EndSlide): string {
 </div>`;
 }
 
-function renderSlideBody(s: Slide, assets: string): string {
+function renderSlideBody(s: Slide, imagery: ImageryConfig): string {
   switch (s.kind) {
-    case 'cover':   return renderCover(s, assets);
+    case 'cover':   return renderCover(s, imagery);
     case 'section': return renderSection(s);
-    case 'content': return renderContent(s, assets);
+    case 'content': return renderContent(s, imagery);
     case 'stats':   return renderStats(s);
-    case 'quote':   return renderQuote(s, assets);
+    case 'quote':   return renderQuote(s, imagery);
     case 'cta':     return renderCTA(s);
     case 'end':     return renderEnd(s);
   }
@@ -797,11 +800,11 @@ function renderSlide(
   i: number,
   total: number,
   inputs: OpenDesignLandingDeckInputs,
-  assets: string,
+  imagery: ImageryConfig,
 ): string {
   return `<section class='slide ${classFor(s)}' data-slide-kind='${s.kind}'>
 ${chromeStrip(inputs.brand, inputs.deck_title)}
-${renderSlideBody(s, assets)}
+${renderSlideBody(s, imagery)}
 ${footStrip(i, total, inputs.brand)}
 </section>`;
 }
@@ -991,10 +994,9 @@ const RUNTIME_SCRIPT = `
  * ------------------------------------------------------------------ */
 
 export function renderDeck(inputs: OpenDesignLandingDeckInputs, baseCss: string): string {
-  const assets = inputs.imagery.assets_path.replace(/\/?$/, '/');
   const total = inputs.slides.length;
   const slides = inputs.slides
-    .map((s, i) => renderSlide(s, i, total, inputs, assets))
+    .map((s, i) => renderSlide(s, i, total, inputs, inputs.imagery))
     .join('\n  ');
   return [
     `<!DOCTYPE html>`,

--- a/design-templates/open-design-landing/SKILL.md
+++ b/design-templates/open-design-landing/SKILL.md
@@ -202,10 +202,13 @@ Set `inputs.imagery.strategy` accordingly.
 npx tsx scripts/placeholder.ts <out>/assets/
 ```
 
-Writes 16 `.svg` files (with `.png` aliases for compatibility) into
+Writes 16 `.svg` files into
 `<out>/assets/`. Each placeholder shows the slot id, ratio, pixel
 dimensions, and the prompt hint from `image-manifest.json`. The
-composer's `<img src='./assets/hero.png'>` etc. just work.
+composer selects `.svg` references when `imagery.strategy` is
+`placeholder`. To replace them with real PNGs, switch the strategy to
+`generate` or `bring-your-own` and compose the artifact again; no template
+code changes are required.
 
 #### `generate` — gpt-image-2 mode
 

--- a/design-templates/open-design-landing/schema.ts
+++ b/design-templates/open-design-landing/schema.ts
@@ -406,7 +406,8 @@ export interface SectionRules {
  *    via the `imagery_prompts` field on the inputs.
  * `'placeholder'` — emit SVG paper-textured frames into `out/assets/`
  *    so the layout is fully rendered even with no AI image budget.
- *    Users can swap real PNGs in later without touching markup.
+ *    The composer references `.svg` for this strategy. To use real PNGs,
+ *    switch strategies and re-compose without changing template code.
  * `'bring-your-own'` — assume the 16 PNGs are already at the configured
  *    `assets_path`; do nothing.
  */

--- a/design-templates/open-design-landing/scripts/compose.ts
+++ b/design-templates/open-design-landing/scripts/compose.ts
@@ -30,9 +30,16 @@ import type {
   Partner,
   FooterColumn,
   SectionRule,
-} from '../schema';
+  ImageryConfig,
+} from '../schema.js';
 
 const SKILL_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+function assetUrl(imagery: ImageryConfig, slot: string): string {
+  const assets = imagery.assets_path.replace(/\/?$/, '/');
+  const extension = imagery.strategy === 'placeholder' ? 'svg' : 'png';
+  return `${assets}${slot}.${extension}`;
+}
 
 /* ------------------------------------------------------------------ *
  * helpers
@@ -188,7 +195,6 @@ function renderHeroIndex(item: HeroIndexItem): string {
 function renderHero(i: EditorialCollageInputs): string {
   const stats = i.hero.stats.map(renderHeroStat).join('\n          ');
   const index = i.hero.index.map(renderHeroIndex).join('\n      ');
-  const assets = i.imagery.assets_path.replace(/\/?$/, '/');
   return `
 <section class='hero' id='top' data-od-id='hero'>
   <div class='container'>
@@ -234,7 +240,7 @@ function renderHero(i: EditorialCollageInputs): string {
       <span class='annot annot-tr'>${i.hero.annotations.tr}</span>
       <span class='annot annot-bl coord'>${i.hero.annotations.bl}</span>
       <span class='annot annot-br'>${i.hero.annotations.br}</span>
-      <img src='${assets}hero.png' alt='' />
+      <img src='${assetUrl(i.imagery, 'hero')}' alt='' />
       <div class='index'>
       ${index}
       </div>
@@ -245,7 +251,6 @@ function renderHero(i: EditorialCollageInputs): string {
 
 function renderAbout(i: EditorialCollageInputs): string {
   const r = i.rules.about;
-  const assets = i.imagery.assets_path.replace(/\/?$/, '/');
   return `
 <section class='about' data-od-id='about'>
   <div class='container'>
@@ -269,7 +274,7 @@ function renderAbout(i: EditorialCollageInputs): string {
         </div>
       </div>
       <div class='about-art' data-reveal='right'>
-        <img src='${assets}about.png' alt='' />
+        <img src='${assetUrl(i.imagery, 'about')}' alt='' />
         <div class='about-side-note'>
           <b></b>
           ${i.about.side_note}
@@ -300,7 +305,6 @@ function renderCapabilityCard(c: CapabilityCard): string {
 
 function renderCapabilities(i: EditorialCollageInputs): string {
   const cards = i.capabilities.cards.map(renderCapabilityCard).join('\n            ');
-  const assets = i.imagery.assets_path.replace(/\/?$/, '/');
   return `
 <section class='capabilities' id='agents' data-od-id='capabilities'>
   <div class='container'>
@@ -309,7 +313,7 @@ function renderCapabilities(i: EditorialCollageInputs): string {
       <div class='capabilities-art' data-reveal='left'>
         <span class='corner tl'></span>
         <span class='corner br'></span>
-        <img src='${assets}capabilities.png' alt='' />
+        <img src='${assetUrl(i.imagery, 'capabilities')}' alt='' />
         <div class='ribbon'>${i.capabilities.ribbon}</div>
       </div>
       <div class='capabilities-copy' data-reveal>
@@ -329,9 +333,9 @@ function renderLabPill(p: LabPill): string {
   return `<button class='pill${p.active ? ' active' : ''}'>${p.label}<span class='count'>${p.count}</span></button>`;
 }
 
-function renderLabCard(c: LabCard, n: number, assets: string): string {
+function renderLabCard(c: LabCard, imageSrc: string): string {
   return `<div class='lab' data-reveal>
-    <div class='lab-img'><span class='badge'>${c.badge}</span><img src='${assets}lab-${n}.png' alt='' /></div>
+    <div class='lab-img'><span class='badge'>${c.badge}</span><img src='${imageSrc}' alt='' /></div>
     <div class='num-row'><span>${c.num}</span><span>${c.year}</span></div>
     <h4>${c.title}</h4>
     <p>${c.body}</p>
@@ -341,9 +345,8 @@ function renderLabCard(c: LabCard, n: number, assets: string): string {
 
 function renderLabs(i: EditorialCollageInputs): string {
   const pills = i.labs.pills.map(renderLabPill).join('\n          ');
-  const assets = i.imagery.assets_path.replace(/\/?$/, '/');
   const cards = i.labs.cards
-    .map((c, idx) => renderLabCard(c, idx + 1, assets))
+    .map((c, idx) => renderLabCard(c, assetUrl(i.imagery, `lab-${idx + 1}`)))
     .join('\n        ');
   const progress = Array.from({ length: i.labs.progress.total }, (_, k) =>
     k < i.labs.progress.filled ? `<span class='on'></span>` : `<span></span>`,
@@ -381,19 +384,20 @@ function renderLabs(i: EditorialCollageInputs): string {
 </section>`;
 }
 
-function renderMethodStep(s: MethodStep, last: boolean, n: number, assets: string): string {
+function renderMethodStep(s: MethodStep, last: boolean, imageSrc: string): string {
   return `<div class='method-step' data-reveal>
     <div class='num'>${s.num}</div>
     <h4>${s.title}${last ? '' : ` <span class='arrow-r'>→</span>`}</h4>
     <p>${s.body}</p>
-    <div class='img'><img src='${assets}method-${n}.png' alt='' /></div>
+    <div class='img'><img src='${imageSrc}' alt='' /></div>
   </div>`;
 }
 
 function renderMethod(i: EditorialCollageInputs): string {
-  const assets = i.imagery.assets_path.replace(/\/?$/, '/');
   const steps = i.method.steps
-    .map((s, idx, arr) => renderMethodStep(s, idx === arr.length - 1, idx + 1, assets))
+    .map((s, idx, arr) =>
+      renderMethodStep(s, idx === arr.length - 1, assetUrl(i.imagery, `method-${idx + 1}`)),
+    )
     .join('\n        ');
   return `
 <section class='method' data-od-id='method'>
@@ -423,7 +427,7 @@ function renderMethod(i: EditorialCollageInputs): string {
 </section>`;
 }
 
-function renderWorkCard(c: WorkCard, idx: number, assets: string, href: string): string {
+function renderWorkCard(c: WorkCard, idx: number, imageSrc: string, href: string): string {
   return `<a class='work-card${idx === 1 ? ' alt' : ''}' data-reveal href='${href}'${ext(href)}>
     <div class='label-row'>
       <span class='small-label'>${c.small_label}</span>
@@ -431,7 +435,7 @@ function renderWorkCard(c: WorkCard, idx: number, assets: string, href: string):
     </div>
     <h3>${c.title}</h3>
     <p>${c.body}</p>
-    <div class='img'><img src='${assets}work-${idx + 1}.png' alt='' /></div>
+    <div class='img'><img src='${imageSrc}' alt='' /></div>
     <div class='meta-row'>
       <span class='year'>${c.year}</span>
       <span>${c.tag}</span>
@@ -441,11 +445,10 @@ function renderWorkCard(c: WorkCard, idx: number, assets: string, href: string):
 
 function renderWork(i: EditorialCollageInputs): string {
   const r = i.rules.work;
-  const assets = i.imagery.assets_path.replace(/\/?$/, '/');
   // Use the first nav link as the work-card href fallback (we don't model per-card hrefs in WorkCard).
   const fallbackHref = i.nav.find((l) => /skills/i.test(l.label))?.href ?? '#';
   const cards = i.work.cards
-    .map((c, idx) => renderWorkCard(c, idx, assets, fallbackHref))
+    .map((c, idx) => renderWorkCard(c, idx, assetUrl(i.imagery, `work-${idx + 1}`), fallbackHref))
     .join('\n      ');
   return `
 <section class='tight' data-od-id='work'>
@@ -488,7 +491,6 @@ function renderPartner(p: Partner, href: string): string {
 }
 
 function renderTestimonial(i: EditorialCollageInputs): string {
-  const assets = i.imagery.assets_path.replace(/\/?$/, '/');
   // Each Partner can carry its own href. We fall back to the testimonial
   // read-more URL (then '#') so older brand inputs without per-partner
   // links still render valid anchors.
@@ -516,7 +518,7 @@ function renderTestimonial(i: EditorialCollageInputs): string {
         <a class='read-more' href='${i.testimonial.read_more_href}'${ext(i.testimonial.read_more_href)}>${i.testimonial.read_more_label}</a>
       </div>
       <div class='testimonial-art' data-reveal='right'>
-        <img src='${assets}testimonial.png' alt='' />
+        <img src='${assetUrl(i.imagery, 'testimonial')}' alt='' />
       </div>
     </div>
   </div>
@@ -524,7 +526,6 @@ function renderTestimonial(i: EditorialCollageInputs): string {
 }
 
 function renderCTA(i: EditorialCollageInputs): string {
-  const assets = i.imagery.assets_path.replace(/\/?$/, '/');
   return `
 <section class='cta' id='contact' data-od-id='cta'>
   <div class='container'>
@@ -551,7 +552,7 @@ function renderCTA(i: EditorialCollageInputs): string {
         </div>
       </div>
       <div class='cta-art' data-reveal='right'>
-        <img src='${assets}cta.png' alt='' />
+        <img src='${assetUrl(i.imagery, 'cta')}' alt='' />
         <div class='index'>Nº 08</div>
         <div class='ribbon'>${i.cta.ribbon}</div>
       </div>

--- a/design-templates/open-design-landing/scripts/placeholder.ts
+++ b/design-templates/open-design-landing/scripts/placeholder.ts
@@ -4,14 +4,12 @@
  *
  * When `imagery.strategy === 'placeholder'`, this script writes one
  * paper-textured SVG file per slot in `assets/image-manifest.json`.
- * The generated files live alongside the schema-named PNGs that the
- * composer references (`hero.png`, `about.png`, `lab-1.png`, …) so
- * the layout renders fully without any image budget.
+ * The composer references these SVGs when `imagery.strategy` is
+ * `placeholder`, so the layout renders fully without any image budget.
  *
  * Each placeholder shows: slot id · ratio · pixel dimensions · the
- * `prompt_section` hint copied from the manifest. Drop the real PNG
- * with the same filename to swap in production imagery; no markup
- * change required.
+ * `prompt_section` hint copied from the manifest. Switch the imagery
+ * strategy and re-compose after adding generated or user-provided PNGs.
  *
  * Usage:
  *   npx tsx scripts/placeholder.ts <out-dir>
@@ -124,19 +122,10 @@ async function loadManifest(): Promise<Manifest> {
 }
 
 /**
- * Write `<out>/<slot.file>` for every slot. The composer references
- * slots by .png filename; we honor that by writing `<basename>.svg`
- * AND a `<basename>.png.svg` symlink-style fallback. Most static
- * hosts serve SVG to <img> just fine, so the practical convention
- * is: if you want placeholders, point your `imagery.assets_path` at
- * a directory of `.svg` files OR rename the SVGs to `.png` (some
- * browsers honor extensionless content-sniffing).
- *
- * For the most reliable result, write BOTH:
- *   - `<id>.svg`   — clean, editable
- *   - `<file>`     — same SVG content under the .png filename so the
- *                    composer's `<img src='./assets/<id>.png'>` works
- *                    without changing markup.
+ * Write one correctly named `<out>/<slot.id>.svg` for every slot.
+ * Generated and user-provided imagery continues to use the manifest's
+ * `.png` filenames; the composers select the extension from the active
+ * imagery strategy.
  */
 export async function writePlaceholders(outDir: string): Promise<string[]> {
   const manifest = await loadManifest();
@@ -145,10 +134,8 @@ export async function writePlaceholders(outDir: string): Promise<string[]> {
   for (const slot of manifest.slots) {
     const svg = placeholderSvg(slot);
     const svgPath = resolve(outDir, `${slot.id}.svg`);
-    const pngPath = resolve(outDir, slot.file);
     await writeFile(svgPath, svg, 'utf8');
-    await writeFile(pngPath, svg, 'utf8');
-    written.push(svgPath, pngPath);
+    written.push(svgPath);
   }
   return written;
 }
@@ -159,9 +146,8 @@ async function main(): Promise<void> {
     ? outArg!
     : resolve(process.cwd(), outArg ?? './assets/');
   const written = await writePlaceholders(out);
-  const pngs = written.filter((p) => p.endsWith('.png')).length;
   const svgs = written.filter((p) => p.endsWith('.svg')).length;
-  console.log(`✓ wrote ${pngs} png-named placeholders + ${svgs} svg files into ${out}`);
+  console.log(`✓ wrote ${svgs} svg placeholders into ${out}`);
   console.log(`  (${written.map((p) => basename(p)).join(', ')})`);
 }
 

--- a/e2e/tests/open-design-landing-assets.test.ts
+++ b/e2e/tests/open-design-landing-assets.test.ts
@@ -1,0 +1,128 @@
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, test } from 'vitest';
+
+import { renderDeck } from '../../design-templates/open-design-landing-deck/scripts/compose.js';
+import type { OpenDesignLandingDeckInputs } from '../../design-templates/open-design-landing-deck/schema.js';
+import { renderPage } from '../../design-templates/open-design-landing/scripts/compose.js';
+import { writePlaceholders } from '../../design-templates/open-design-landing/scripts/placeholder.js';
+import type {
+  EditorialCollageInputs,
+  ImageStrategy,
+} from '../../design-templates/open-design-landing/schema.js';
+
+const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url));
+const LANDING_ROOT = path.join(REPO_ROOT, 'design-templates', 'open-design-landing');
+const DECK_ROOT = path.join(REPO_ROOT, 'design-templates', 'open-design-landing-deck');
+const workDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(workDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+async function readJson<T>(filePath: string): Promise<T> {
+  return JSON.parse(await readFile(filePath, 'utf8')) as T;
+}
+
+function imageSources(html: string): string[] {
+  return Array.from(html.matchAll(/<img\s+[^>]*src=['"]([^'"]+)['"]/g), (match) => match[1]!);
+}
+
+function withLandingStrategy(
+  inputs: EditorialCollageInputs,
+  strategy: ImageStrategy,
+  assetsPath: string,
+): EditorialCollageInputs {
+  return {
+    ...inputs,
+    imagery: { ...inputs.imagery, strategy, assets_path: assetsPath },
+  };
+}
+
+function withDeckStrategy(
+  inputs: OpenDesignLandingDeckInputs,
+  strategy: ImageStrategy,
+  assetsPath: string,
+): OpenDesignLandingDeckInputs {
+  return {
+    ...inputs,
+    imagery: { ...inputs.imagery, strategy, assets_path: assetsPath },
+  };
+}
+
+describe('open-design landing asset formats', () => {
+  test('placeholder generation writes one valid SVG per manifest slot and no PNG aliases', async () => {
+    const outputDir = await mkdtemp(path.join(tmpdir(), 'open-design-placeholders-'));
+    workDirs.push(outputDir);
+    const manifest = await readJson<{
+      slots: Array<{ id: string; width: number; height: number }>;
+    }>(path.join(LANDING_ROOT, 'assets', 'image-manifest.json'));
+
+    const written = await writePlaceholders(outputDir);
+    const files = (await readdir(outputDir)).sort();
+
+    expect(written).toHaveLength(manifest.slots.length);
+    expect(files).toEqual(manifest.slots.map((slot) => `${slot.id}.svg`).sort());
+    expect(files.some((file) => file.endsWith('.png'))).toBe(false);
+
+    for (const slot of manifest.slots) {
+      const svg = await readFile(path.join(outputDir, `${slot.id}.svg`), 'utf8');
+      expect(svg).toMatch(/^<\?xml version='1\.0' encoding='UTF-8'\?>\s*<svg/);
+      expect(svg).toContain(`viewBox='0 0 ${slot.width} ${slot.height}'`);
+      expect(svg).toContain(`width='${slot.width}' height='${slot.height}'`);
+    }
+  });
+
+  test.each([
+    ['placeholder', 'svg'],
+    ['generate', 'png'],
+    ['bring-your-own', 'png'],
+  ] as const)('landing %s strategy references %s assets', async (strategy, extension) => {
+    const inputs = await readJson<EditorialCollageInputs>(
+      path.join(LANDING_ROOT, 'inputs.example.json'),
+    );
+    const sources = imageSources(
+      renderPage(withLandingStrategy(inputs, strategy, './custom-assets'), ''),
+    );
+
+    expect(sources).toHaveLength(16);
+    expect(sources.every((source) => source.startsWith('./custom-assets/'))).toBe(true);
+    expect(sources.every((source) => source.endsWith(`.${extension}`))).toBe(true);
+    expect(sources.every((source) => !source.includes('custom-assets//'))).toBe(true);
+  });
+
+  test.each([
+    ['placeholder', 'svg'],
+    ['generate', 'png'],
+    ['bring-your-own', 'png'],
+  ] as const)('deck %s strategy references %s assets', async (strategy, extension) => {
+    const inputs = await readJson<OpenDesignLandingDeckInputs>(
+      path.join(DECK_ROOT, 'inputs.example.json'),
+    );
+    const sources = imageSources(
+      renderDeck(withDeckStrategy(inputs, strategy, './shared-assets/'), ''),
+    );
+
+    expect(sources.length).toBeGreaterThan(0);
+    expect(sources.every((source) => source.startsWith('./shared-assets/'))).toBe(true);
+    expect(sources.every((source) => source.endsWith(`.${extension}`))).toBe(true);
+    expect(sources.every((source) => !source.includes('shared-assets//'))).toBe(true);
+  });
+
+  test('every placeholder landing reference has a generated SVG', async () => {
+    const outputDir = await mkdtemp(path.join(tmpdir(), 'open-design-placeholder-refs-'));
+    workDirs.push(outputDir);
+    const generated = new Set((await writePlaceholders(outputDir)).map((file) => path.basename(file)));
+    const inputs = await readJson<EditorialCollageInputs>(
+      path.join(LANDING_ROOT, 'inputs.example.json'),
+    );
+    const referenced = imageSources(
+      renderPage(withLandingStrategy(inputs, 'placeholder', './assets/'), ''),
+    ).map((source) => path.posix.basename(source));
+
+    expect(new Set(referenced)).toEqual(generated);
+  });
+});


### PR DESCRIPTION
Fixes #5903

## Why

Open Design Landing's default `placeholder` image strategy wrote SVG XML to both `.svg` files and `.png` filenames. The landing and sibling deck composers then hard-coded the `.png` paths, while preview/export servers correctly served those paths as `image/png`. Browsers therefore tried to decode SVG text as PNG data and rendered broken images.

I hit this while investigating #5903. The fix keeps each strategy's asset contract honest: placeholders remain lightweight SVGs, while generated and bring-your-own imagery remains PNG. This fixes previews and exported artifacts without weakening MIME handling or adding a rasterization dependency.

## What users will see

Open Design Landing and Open Design Landing Deck artifacts created with the `placeholder` strategy now render all paper-textured placeholder artwork instead of broken-image icons. Switching to `generate` or `bring-your-own` continues to reference PNG assets as before. Existing baked examples and real PNG assets are unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — changed behavior and documentation under `design-templates/`
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — added a root `package.json` dependency
- [x] **Default behavior change** — placeholder output now uses correctly typed SVG assets by default
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. This changes generated artifact asset format and references rather than an Open Design application entry point.

## Bug fix verification

- Test path: `e2e/tests/open-design-landing-assets.test.ts`
- The test covers placeholder output shape, SVG contents and dimensions, no generated PNG aliases, Landing and Deck references for all three image strategies, normalized asset paths, and placeholder-reference completeness.
- Red on the pre-fix implementation: the placeholder generation assertions fail because it emits SVG content under `.png` aliases; renderer assertions fail because both composers hard-code `.png`.
- Green on this branch: yes.

## Validation

- `pnpm.cmd test tests/open-design-landing-assets.test.ts` from `e2e` — 8 tests passed
- `pnpm.cmd typecheck` from `e2e`
- `pnpm.cmd typecheck` from the repository root
- `pnpm.cmd guard` — 86 tests passed