### PR TITLE
fix packaged mac relaunch blocked by obsolete outer

### DIFF
--- a/apps/desktop/src/main/external-show.ts
+++ b/apps/desktop/src/main/external-show.ts
@@ -1,0 +1,24 @@
+export type DesktopExternalShowOptions = {
+  onError?: (error: unknown) => void;
+};
+
+/**
+ * Notify an optional host after the desktop has accepted an external SHOW.
+ * The callback starts immediately after focus so a packaged host can minimize
+ * the interval in which an obsolete caller remains alive. Its asynchronous
+ * completion does not delay the SHOW acknowledgement.
+ */
+export function notifyDesktopExternalShow(
+  callback: (() => void | Promise<void>) | undefined,
+  options: DesktopExternalShowOptions = {},
+): void {
+  if (callback == null) return;
+  const onError = options.onError ?? ((error: unknown) => {
+    console.error("desktop external SHOW callback failed", error);
+  });
+  try {
+    void Promise.resolve(callback()).catch(onError);
+  } catch (error) {
+    onError(error);
+  }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -63,6 +63,7 @@ import {
   exportDiagnosticsToFile,
   registerDesktopDiagnosticsIpc,
 } from "./diagnostics.js";
+import { notifyDesktopExternalShow } from "./external-show.js";
 
 // Re-export pure URL-policy helpers so the packaged workspace's
 // vitest can pin their behaviour without spinning up a full Electron
@@ -141,6 +142,7 @@ export function applyOsLocaleSwitch(electronApp: Electron.App): string {
 
 export type DesktopMainOptions = {
   beforeShutdown?: () => Promise<void>;
+  onExternalShow?: () => void | Promise<void>;
   discoverWebUrl?: () => Promise<string | null>;
   /**
    * Round-7 (lefarcen P2 @ runtime.ts:336): packaged builds report the
@@ -866,6 +868,7 @@ export async function runDesktopMain(
             return activeDesktop.console();
           case SIDECAR_MESSAGES.SHOW:
             activeDesktop.show();
+            notifyDesktopExternalShow(options.onExternalShow);
             return { accepted: true };
           case SIDECAR_MESSAGES.CLICK:
             return await activeDesktop.click(request.input as DesktopClickInput);

--- a/apps/desktop/tests/main/external-show.test.ts
+++ b/apps/desktop/tests/main/external-show.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { notifyDesktopExternalShow } from "../../src/main/external-show.js";
+
+describe("notifyDesktopExternalShow", () => {
+  it("starts the packaged compatibility callback immediately without awaiting it", () => {
+    let finish: (() => void) | undefined;
+    const callback = vi.fn(() => new Promise<void>((resolve) => {
+      finish = resolve;
+    }));
+
+    notifyDesktopExternalShow(callback);
+
+    expect(callback).toHaveBeenCalledOnce();
+    finish?.();
+  });
+
+  it("contains callback failures at the optional host boundary", async () => {
+    const onError = vi.fn();
+
+    notifyDesktopExternalShow(async () => {
+      throw new Error("retirement failed");
+    }, {
+      onError,
+    });
+
+    await vi.waitFor(() => expect(onError).toHaveBeenCalledWith(expect.objectContaining({
+      message: "retirement failed",
+    })));
+  });
+
+  it("contains synchronous callback failures", () => {
+    const onError = vi.fn();
+
+    notifyDesktopExternalShow(() => {
+      throw new Error("retirement failed synchronously");
+    }, { onError });
+
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({
+      message: "retirement failed synchronously",
+    }));
+  });
+
+  it("does nothing when the packaged host did not opt in", () => {
+    const onError = vi.fn();
+
+    notifyDesktopExternalShow(undefined, { onError });
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/tests/main/updater-host-boundary.test.ts
+++ b/apps/desktop/tests/main/updater-host-boundary.test.ts
@@ -46,6 +46,21 @@ describe("desktop updater host boundary", () => {
     expect(startupIpcBody).toContain("desktop runtime is not initialized");
   });
 
+  it("keeps obsolete installed-outer policy outside generic desktop while exposing the SHOW hook", () => {
+    const main = source("src/main/index.ts");
+    const showStart = main.indexOf("case SIDECAR_MESSAGES.SHOW:");
+    const clickStart = main.indexOf("case SIDECAR_MESSAGES.CLICK:", showStart);
+    expect(showStart).toBeGreaterThanOrEqual(0);
+    expect(clickStart).toBeGreaterThan(showStart);
+    const showHandler = main.slice(showStart, clickStart);
+    expect(showHandler).toContain("activeDesktop.show()");
+    expect(showHandler).toContain("notifyDesktopExternalShow(options.onExternalShow)");
+    expect(showHandler.indexOf("activeDesktop.show()"))
+      .toBeLessThan(showHandler.indexOf("notifyDesktopExternalShow(options.onExternalShow)"));
+    expect(main).not.toContain("listProcessSnapshots");
+    expect(main).not.toContain("stopProcesses");
+  });
+
   it("keeps desktop STATUS responsive when updater status is slow", () => {
     const main = source("src/main/index.ts");
     expect(main).toContain("async function snapshotUpdateForStatus()");

--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -49,6 +49,7 @@ import { startPackagedSidecars } from "./sidecars.js";
 import { reportStartupFailure, resolveStartupDistinctId } from "./startup-telemetry.js";
 import { resolvePackagedWindowTitle } from "./window-title.js";
 import { syncWindowsUninstallDisplayVersion } from "./windows-lifecycle.js";
+import { createObsoleteInstalledOuterRetirement } from "./obsolete-installed-outer.js";
 
 let packagedLogger: PackagedDesktopLogger | null = null;
 let pendingSecondInstanceFocus = false;
@@ -174,6 +175,15 @@ async function main(): Promise<void> {
   });
   packagedLogger = createPackagedDesktopLogger(paths);
   attachPackagedDesktopProcessLogging({ logger: packagedLogger, paths, stamp });
+  const retireObsoleteInstalledOuter = createObsoleteInstalledOuterRetirement({
+    currentExecutablePath: process.execPath,
+    currentPid: process.pid,
+    installedLaunchPath: launcherRuntime.installedLaunchPath,
+    logger: packagedLogger,
+    payloadDesktopProcess: launcherRuntime.payloadDesktopProcess,
+    payloadExecutablePath: launcherRuntime.desktopExecutablePath,
+    platform: process.platform,
+  });
   applyPackagedElectronPathOverrides(paths);
   applyPackagedUpdaterEnv(activeConfig.updateMetadataUrl);
   if (!claimPackagedSingleInstanceLock(app, () => {
@@ -259,9 +269,13 @@ async function main(): Promise<void> {
     splashStartedAt: splash.startedAt,
     async beforeShutdown() {
       try {
-        await sidecars.close();
+        await retireObsoleteInstalledOuter();
       } finally {
-        await identity.close();
+        try {
+          await sidecars.close();
+        } finally {
+          await identity.close();
+        }
       }
     },
     async discoverWebUrl() {
@@ -275,6 +289,9 @@ async function main(): Promise<void> {
       return sidecars.daemon.url;
     },
     windowTitle: resolvePackagedWindowTitle(activeConfig),
+    async onExternalShow() {
+      await retireObsoleteInstalledOuter();
+    },
     onDesktopReady(controls) {
       void confirmPackagedLauncherRuntime(launcherRuntime).catch((error: unknown) => {
         packagedLogger?.warn("failed to confirm packaged launcher runtime", { error });

--- a/apps/packaged/src/obsolete-installed-outer.ts
+++ b/apps/packaged/src/obsolete-installed-outer.ts
@@ -1,0 +1,158 @@
+import { lstat } from "node:fs/promises";
+import { posix } from "node:path";
+
+import {
+  collectProcessTreePids,
+  listProcessSnapshots,
+  processCommandExactlyRunsExecutable,
+  stopProcesses,
+  type StopProcessesResult,
+} from "@open-design/platform";
+
+type RetirementLogger = {
+  info(message: string, meta?: Record<string, unknown>): void;
+  warn(message: string, meta?: Record<string, unknown>): void;
+};
+
+export type ObsoleteInstalledOuterRetirementContext = {
+  currentExecutablePath: string;
+  currentPid: number;
+  installedLaunchPath: string | null;
+  logger: RetirementLogger;
+  payloadDesktopProcess: boolean;
+  payloadExecutablePath: string | null;
+  platform: NodeJS.Platform;
+};
+
+type ObsoleteInstalledOuterRetirementDeps = {
+  listProcessSnapshots?: typeof listProcessSnapshots;
+  stopProcesses?: typeof stopProcesses;
+};
+
+export type ObsoleteInstalledOuterRetirementResult =
+  | {
+      reason:
+        | "invalid-install-anchor"
+        | "not-payload-desktop"
+        | "same-executable"
+        | "unsupported-platform"
+        | "unsafe-current-descendant";
+      status: "skipped";
+    }
+  | {
+      executablePath: string;
+      reason: "no-match";
+      status: "skipped";
+    }
+  | {
+      executablePath: string;
+      result: StopProcessesResult;
+      rootPids: number[];
+      status: "failed" | "retired";
+      treePids: number[];
+    };
+
+function sameExecutablePath(left: string, right: string): boolean {
+  return posix.normalize(left) === posix.normalize(right);
+}
+
+async function resolveInstalledOuterExecutable(
+  installedLaunchPath: string | null,
+  platform: NodeJS.Platform,
+): Promise<string | null> {
+  if (installedLaunchPath == null || installedLaunchPath.length === 0) return null;
+  if (platform !== "darwin" || !posix.isAbsolute(installedLaunchPath)) return null;
+
+  const launchEntry = await lstat(installedLaunchPath).catch(() => null);
+  if (launchEntry == null || launchEntry.isSymbolicLink()) return null;
+
+  if (!launchEntry.isDirectory() || !installedLaunchPath.endsWith(".app")) return null;
+  const appName = posix.basename(installedLaunchPath, ".app");
+  const executablePath = posix.join(installedLaunchPath, "Contents", "MacOS", appName);
+
+  const executableEntry = await lstat(executablePath).catch(() => null);
+  if (executableEntry == null || !executableEntry.isFile() || executableEntry.isSymbolicLink()) return null;
+  return executablePath;
+}
+
+async function retireObsoleteInstalledOuter(
+  context: ObsoleteInstalledOuterRetirementContext,
+  deps: ObsoleteInstalledOuterRetirementDeps,
+): Promise<ObsoleteInstalledOuterRetirementResult> {
+  if (!context.payloadDesktopProcess || context.payloadExecutablePath == null || !sameExecutablePath(
+    context.currentExecutablePath,
+    context.payloadExecutablePath,
+  )) {
+    return { reason: "not-payload-desktop", status: "skipped" };
+  }
+  if (context.platform !== "darwin") {
+    return { reason: "unsupported-platform", status: "skipped" };
+  }
+
+  const executablePath = await resolveInstalledOuterExecutable(context.installedLaunchPath, context.platform);
+  if (executablePath == null) return { reason: "invalid-install-anchor", status: "skipped" };
+  if (sameExecutablePath(executablePath, context.currentExecutablePath)) {
+    return { reason: "same-executable", status: "skipped" };
+  }
+
+  const snapshots = await (deps.listProcessSnapshots ?? listProcessSnapshots)();
+  const rootPids = snapshots
+    .filter((snapshot) => snapshot.pid !== context.currentPid && processCommandExactlyRunsExecutable(
+      snapshot.command,
+      executablePath,
+      "darwin",
+    ))
+    .map((snapshot) => snapshot.pid)
+    .sort((left, right) => right - left);
+  if (rootPids.length === 0) return { executablePath, reason: "no-match", status: "skipped" };
+
+  const safeRootPids = rootPids.filter((rootPid) => {
+    const tree = collectProcessTreePids(snapshots, [rootPid]);
+    return !tree.includes(context.currentPid);
+  });
+  if (safeRootPids.length === 0) {
+    context.logger.warn("skipped obsolete installed outer retirement because it contains current payload", {
+      currentPid: context.currentPid,
+      executablePath,
+      rootPids,
+    });
+    return { reason: "unsafe-current-descendant", status: "skipped" };
+  }
+
+  const treePids = collectProcessTreePids(snapshots, safeRootPids);
+  const result = await (deps.stopProcesses ?? stopProcesses)(treePids);
+  const status = result.remainingPids.length === 0 ? "retired" : "failed";
+  const meta = {
+    executablePath,
+    forcedPids: result.forcedPids,
+    remainingPids: result.remainingPids,
+    rootPids: safeRootPids,
+    stoppedPids: result.stoppedPids,
+    treePids,
+  };
+  if (status === "retired") {
+    context.logger.info("retired obsolete installed outer", meta);
+  } else {
+    context.logger.warn("obsolete installed outer survived retirement", meta);
+  }
+  return { executablePath, result, rootPids: safeRootPids, status, treePids };
+}
+
+/**
+ * Build a re-usable, single-flight cleanup callback for desktop SHOW and quit.
+ * A later invocation starts a fresh scan so a later LaunchServices open is not
+ * hidden by a previously successful retirement.
+ */
+export function createObsoleteInstalledOuterRetirement(
+  context: ObsoleteInstalledOuterRetirementContext,
+  deps: ObsoleteInstalledOuterRetirementDeps = {},
+): () => Promise<ObsoleteInstalledOuterRetirementResult> {
+  let pending: Promise<ObsoleteInstalledOuterRetirementResult> | null = null;
+  return () => {
+    if (pending != null) return pending;
+    pending = retireObsoleteInstalledOuter(context, deps).finally(() => {
+      pending = null;
+    });
+    return pending;
+  };
+}

--- a/apps/packaged/tests/obsolete-installed-outer.test.ts
+++ b/apps/packaged/tests/obsolete-installed-outer.test.ts
@@ -1,0 +1,210 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { ProcessSnapshot, StopProcessesResult } from "@open-design/platform";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createObsoleteInstalledOuterRetirement,
+} from "../src/obsolete-installed-outer.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { force: true, recursive: true })));
+});
+
+async function createMacInstalledOuter(): Promise<{ executablePath: string; launchPath: string }> {
+  const root = await mkdtemp(join(tmpdir(), "od-obsolete-outer-"));
+  roots.push(root);
+  const launchPath = join(root, "Open Design.app");
+  const executablePath = join(launchPath, "Contents", "MacOS", "Open Design");
+  await mkdir(join(launchPath, "Contents", "MacOS"), { recursive: true });
+  await writeFile(executablePath, "legacy outer", "utf8");
+  return { executablePath, launchPath };
+}
+
+function snapshot(pid: number, ppid: number, command: string): ProcessSnapshot {
+  return { command, pid, ppid };
+}
+
+function stopped(pids: number[]): StopProcessesResult {
+  return {
+    alreadyStopped: pids.length === 0,
+    forcedPids: [],
+    matchedPids: pids,
+    remainingPids: [],
+    stoppedPids: pids,
+  };
+}
+
+function stopMock() {
+  return vi.fn(async (pids: Array<number | null | undefined>) => stopped(
+    pids.filter((pid): pid is number => pid != null),
+  ));
+}
+
+describe("createObsoleteInstalledOuterRetirement", () => {
+  it("stops only the exact installed outer root and its descendants", async () => {
+    const { executablePath, launchPath } = await createMacInstalledOuter();
+    const snapshots = [
+      snapshot(101, 1, executablePath),
+      snapshot(102, 101, `${launchPath}/Contents/Frameworks/Open Design Helper.app/Contents/MacOS/Open Design Helper`),
+      snapshot(103, 102, "helper-child"),
+      snapshot(104, 1, `${executablePath} Helper`),
+      snapshot(105, 1, "/unrelated/Open Design"),
+      snapshot(900, 1, "/payload/Open Design.app/Contents/MacOS/Open Design"),
+    ];
+    const stopProcesses = stopMock();
+    const logger = { info: vi.fn(), warn: vi.fn() };
+    const retire = createObsoleteInstalledOuterRetirement({
+      currentExecutablePath: "/payload/Open Design.app/Contents/MacOS/Open Design",
+      currentPid: 900,
+      installedLaunchPath: launchPath,
+      logger,
+      payloadDesktopProcess: true,
+      payloadExecutablePath: "/payload/Open Design.app/Contents/MacOS/Open Design",
+      platform: "darwin",
+    }, {
+      listProcessSnapshots: async () => snapshots,
+      stopProcesses,
+    });
+
+    const result = await retire();
+
+    expect(stopProcesses).toHaveBeenCalledExactlyOnceWith([103, 102, 101]);
+    expect(result).toMatchObject({
+      executablePath,
+      rootPids: [101],
+      status: "retired",
+      treePids: [103, 102, 101],
+    });
+    expect(logger.info).toHaveBeenCalledWith(
+      "retired obsolete installed outer",
+      expect.objectContaining({ rootPids: [101], stoppedPids: [103, 102, 101] }),
+    );
+  });
+
+  it("does nothing outside an exact payload desktop process", async () => {
+    const { launchPath } = await createMacInstalledOuter();
+    const listProcessSnapshots = vi.fn(async () => []);
+    const stopProcesses = vi.fn(async () => stopped([]));
+    const retire = createObsoleteInstalledOuterRetirement({
+      currentExecutablePath: "/installed/Open Design",
+      currentPid: 900,
+      installedLaunchPath: launchPath,
+      logger: { info: vi.fn(), warn: vi.fn() },
+      payloadDesktopProcess: false,
+      payloadExecutablePath: null,
+      platform: "darwin",
+    }, { listProcessSnapshots, stopProcesses });
+
+    await expect(retire()).resolves.toMatchObject({ reason: "not-payload-desktop", status: "skipped" });
+    expect(listProcessSnapshots).not.toHaveBeenCalled();
+    expect(stopProcesses).not.toHaveBeenCalled();
+  });
+
+  it("stays disabled on Windows until the platform path is independently validated", async () => {
+    const listProcessSnapshots = vi.fn(async () => []);
+    const stopProcesses = stopMock();
+    const retire = createObsoleteInstalledOuterRetirement({
+      currentExecutablePath: "C:\\payload\\Open Design.exe",
+      currentPid: 900,
+      installedLaunchPath: "C:\\Program Files\\Open Design\\Open Design.exe",
+      logger: { info: vi.fn(), warn: vi.fn() },
+      payloadDesktopProcess: true,
+      payloadExecutablePath: "C:\\payload\\Open Design.exe",
+      platform: "win32",
+    }, { listProcessSnapshots, stopProcesses });
+
+    await expect(retire()).resolves.toMatchObject({ reason: "unsupported-platform", status: "skipped" });
+    expect(listProcessSnapshots).not.toHaveBeenCalled();
+    expect(stopProcesses).not.toHaveBeenCalled();
+  });
+
+  it("rejects a symlinked install executable before enumerating processes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "od-obsolete-outer-symlink-"));
+    roots.push(root);
+    const launchPath = join(root, "Open Design.app");
+    const executableDirectory = join(launchPath, "Contents", "MacOS");
+    const target = join(root, "target");
+    await mkdir(executableDirectory, { recursive: true });
+    await writeFile(target, "not the installed executable", "utf8");
+    await symlink(target, join(executableDirectory, "Open Design"));
+    const listProcessSnapshots = vi.fn(async () => []);
+    const retire = createObsoleteInstalledOuterRetirement({
+      currentExecutablePath: "/payload/Open Design",
+      currentPid: 900,
+      installedLaunchPath: launchPath,
+      logger: { info: vi.fn(), warn: vi.fn() },
+      payloadDesktopProcess: true,
+      payloadExecutablePath: "/payload/Open Design",
+      platform: "darwin",
+    }, { listProcessSnapshots, stopProcesses: async (pids) => stopped(pids.filter((pid): pid is number => pid != null)) });
+
+    await expect(retire()).resolves.toMatchObject({ reason: "invalid-install-anchor", status: "skipped" });
+    expect(listProcessSnapshots).not.toHaveBeenCalled();
+  });
+
+  it("refuses to stop an outer tree that contains the current payload", async () => {
+    const { executablePath, launchPath } = await createMacInstalledOuter();
+    const stopProcesses = stopMock();
+    const retire = createObsoleteInstalledOuterRetirement({
+      currentExecutablePath: "/payload/Open Design",
+      currentPid: 900,
+      installedLaunchPath: launchPath,
+      logger: { info: vi.fn(), warn: vi.fn() },
+      payloadDesktopProcess: true,
+      payloadExecutablePath: "/payload/Open Design",
+      platform: "darwin",
+    }, {
+      listProcessSnapshots: async () => [
+        snapshot(101, 1, executablePath),
+        snapshot(800, 101, "handoff daemon"),
+        snapshot(900, 800, "/payload/Open Design"),
+        snapshot(901, 900, "payload helper"),
+      ],
+      stopProcesses,
+    });
+
+    await expect(retire()).resolves.toMatchObject({
+      reason: "unsafe-current-descendant",
+      status: "skipped",
+    });
+    expect(stopProcesses).not.toHaveBeenCalled();
+  });
+
+  it("coalesces concurrent retirement requests without suppressing later opens", async () => {
+    const { executablePath, launchPath } = await createMacInstalledOuter();
+    let releaseEnumeration: (() => void) | undefined;
+    const listProcessSnapshots = vi.fn(async () => {
+      await new Promise<void>((resolve) => {
+        releaseEnumeration = resolve;
+      });
+      return [snapshot(101, 1, executablePath)];
+    });
+    const stopProcesses = stopMock();
+    const retire = createObsoleteInstalledOuterRetirement({
+      currentExecutablePath: "/payload/Open Design",
+      currentPid: 900,
+      installedLaunchPath: launchPath,
+      logger: { info: vi.fn(), warn: vi.fn() },
+      payloadDesktopProcess: true,
+      payloadExecutablePath: "/payload/Open Design",
+      platform: "darwin",
+    }, { listProcessSnapshots, stopProcesses });
+
+    const first = retire();
+    const concurrent = retire();
+    await vi.waitFor(() => expect(releaseEnumeration).toBeTypeOf("function"));
+    releaseEnumeration?.();
+    await Promise.all([first, concurrent]);
+    expect(listProcessSnapshots).toHaveBeenCalledTimes(1);
+
+    const later = retire();
+    await vi.waitFor(() => expect(listProcessSnapshots).toHaveBeenCalledTimes(2));
+    releaseEnumeration?.();
+    await later;
+  });
+});

--- a/packages/platform/src/index.ts
+++ b/packages/platform/src/index.ts
@@ -42,6 +42,7 @@ export {
   listProcessSnapshots,
   matchesProcessStamp,
   matchesStampedProcess,
+  processCommandExactlyRunsExecutable,
   readFlagValue,
   readProcessStamp,
   readProcessStampFromCommand,

--- a/packages/platform/src/process.ts
+++ b/packages/platform/src/process.ts
@@ -11,6 +11,7 @@
  * `errorCode` copy so it owns no cross-module runtime surface.
  */
 import { execFile, spawn, type ChildProcess, type StdioOptions } from "node:child_process";
+import { posix, win32 } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 
 import { createCommandInvocation, type CommandInvocationRequest } from "./command.js";
@@ -50,6 +51,31 @@ export type StopProcessesResult = {
   remainingPids: number[];
   stoppedPids: number[];
 };
+
+function normalizeExecutablePath(path: string, platform: NodeJS.Platform): string {
+  const normalized = platform === "win32" ? win32.normalize(path) : posix.normalize(path);
+  return platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+/**
+ * Test whether a process command line contains only the given executable path.
+ * Windows process enumeration may wrap a no-argument executable in quotes;
+ * commands with arguments are deliberately rejected on every platform.
+ */
+export function processCommandExactlyRunsExecutable(
+  command: string,
+  executablePath: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  const trimmed = command.trim();
+  if (normalizeExecutablePath(trimmed, platform) === normalizeExecutablePath(executablePath, platform)) {
+    return true;
+  }
+  if (platform !== "win32" || trimmed.length < 2 || !trimmed.startsWith('"') || !trimmed.endsWith('"')) {
+    return false;
+  }
+  return normalizeExecutablePath(trimmed.slice(1, -1), platform) === normalizeExecutablePath(executablePath, platform);
+}
 
 type WindowsProcessRecord = {
   CommandLine?: string | null;

--- a/packages/platform/tests/process-tree.test.ts
+++ b/packages/platform/tests/process-tree.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { collectProcessTreePids, type ProcessSnapshot } from "../src/index.js";
+import {
+  collectProcessTreePids,
+  processCommandExactlyRunsExecutable,
+  type ProcessSnapshot,
+} from "../src/index.js";
 
 function snapshot(pid: number, ppid: number, command = `pid-${pid}`): ProcessSnapshot {
   return { command, pid, ppid };
@@ -37,5 +41,26 @@ describe("collectProcessTreePids", () => {
   it("terminates on parent-child cycles instead of looping forever", () => {
     const processes = [snapshot(100, 200), snapshot(200, 100)];
     expect(collectProcessTreePids(processes, [100])).toEqual([200, 100]);
+  });
+});
+
+describe("processCommandExactlyRunsExecutable", () => {
+  it("accepts exact POSIX and quoted Windows executable commands", () => {
+    expect(processCommandExactlyRunsExecutable(
+      "/Applications/Open Design.app/Contents/MacOS/Open Design",
+      "/Applications/Open Design.app/Contents/MacOS/Open Design",
+      "darwin",
+    )).toBe(true);
+    expect(processCommandExactlyRunsExecutable(
+      '"C:\\Program Files\\Open Design\\Open Design.exe"',
+      "C:\\Program Files\\Open Design\\Open Design.exe",
+      "win32",
+    )).toBe(true);
+  });
+
+  it("rejects arguments and lookalike executable prefixes", () => {
+    const executable = "/Applications/Open Design.app/Contents/MacOS/Open Design";
+    expect(processCommandExactlyRunsExecutable(`${executable} --inspect`, executable, "darwin")).toBe(false);
+    expect(processCommandExactlyRunsExecutable(`${executable} Helper`, executable, "darwin")).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #5939

## Why

The stable `0.16.0` upgrade investigation reproduced a macOS compatibility failure with an official `0.12.0` installed outer and newer launcher payloads. Opening the unchanged installed app correctly focused the active payload desktop, but the historical outer and two Electron helpers remained alive because that old implementation returned from its focus gate without exiting.

If the active payload later stopped, the obsolete outer retained the app's single-instance ownership. Subsequent Finder or LaunchServices opens appeared to do nothing until the process tree or machine was restarted. A payload update cannot rewrite the historical app on disk, so the active payload needs a narrow compatibility cleanup path.

## What users will see

On macOS, opening an old physically installed Open Design app while a newer payload desktop is active still focuses the current window. The current payload then retires the exact obsolete installed-app process tree, so quitting and reopening the app continues to launch the active payload instead of being blocked by a hidden historical process.

There is no new UI, setting, protocol, updater state, or metadata shape. Windows remains explicitly disabled until its installer path and process behavior are independently validated.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this changes packaged process lifecycle only and adds no UI.

## Bug fix verification

- Test paths: `apps/desktop/tests/main/external-show.test.ts`, `apps/desktop/tests/main/updater-host-boundary.test.ts`, `apps/packaged/tests/obsolete-installed-outer.test.ts`, and `packages/platform/tests/process-tree.test.ts`.
- Red on `main`, green on this branch: yes. Before the implementation, the new module/hook specs failed because the external-SHOW host seam and exact installed-outer retirement did not exist.
- Real reproduction: official stable `0.12.0` mac arm64 outer -> official stable `0.15.1` payload -> patched local `0.16.0` payload. Five repeated LaunchServices opens each retired the old main plus two helpers with no forced or remaining PIDs. After payload termination and cold restart through the unchanged `0.12.0` app, launcher active/lastSuccessful returned to `0.16.0`, attempt was null, and handoff was confirmed.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/platform test` — 3 files / 79 tests
- `pnpm --filter @open-design/desktop test` — 27 files / 248 tests
- `pnpm --filter @open-design/packaged test` — 19 files / 216 tests
- `pnpm --filter @open-design/platform typecheck`
- `pnpm --filter @open-design/desktop typecheck`
- `pnpm --filter @open-design/packaged typecheck`
- `pnpm guard`
- `pnpm typecheck`
- mac full packaged smoke: local `0.15.1` DMG -> `0.16.0` payload via `tools-serve`; real PPTX export, complete stop, installed-outer cold start, payload identity, health, and repeated post-restart assertions passed (1 test passed, 16 unrelated suites skipped).
- `git diff --check`

## Safety boundary

- Cleanup runs only inside an exact launcher payload desktop on macOS.
- The install anchor must be an absolute, real, non-symlink `.app` directory with a real, non-symlink executable.
- Process matching requires the exact installed executable command; prefixes and commands with arguments are rejected.
- Only the matched root and its snapshotted descendants are stopped, and any tree containing the current payload PID is refused.
- External SHOW starts cleanup immediately after focus without waiting for completion; graceful shutdown repeats the scan before sidecars close.
- A simultaneous hard payload crash before cleanup completes cannot be made atomic from a historical outer. Restarting macOS clears that user-process-only residue and preserves launcher/data state; changing the physical outer remains the absolute fallback for host-level incompatibilities.

