### PR TITLE
Add Design System Source Context plugin

### DIFF
--- a/plugins/community/design-system-source-context-mrv61vi0/SKILL.md
+++ b/plugins/community/design-system-source-context-mrv61vi0/SKILL.md
@@ -1,0 +1,160 @@
+# Design System Source Context
+
+This file is generated during setup and should be treated as source evidence for the design-system project. Use it before writing or revising DESIGN.md, previews, tokens, UI kit examples, or assets.
+
+## Company / Product
+
+Canonical design-system title: Peok
+
+**Product:** Peok - Private Personal CRM / Second Memory
+**Company:** Private project by Thorsten Schiebler
+**Category:** Brands / SaaS / Personal Productivity
+
+### Product Context
+Peok ist ein privates Personal CRM – ein sicherer Ort, um Beziehungswissen wie Geburtstage, Gespräche, Interessen, Wünsche und Verbindungen zwischen Personen zu speichern. 
+
+Die inhaltlichen Leitplanken:
+- Privat statt sozial
+- Beziehungswissen statt Commodity-Apps
+- Deterministik vor LLM
+
+### Source Links
+- Primary: https://github.com/thorstenschiebler/peok
+- Website: https://peok.de
+- Logo: https://www.peok.de/logo-192.png
+
+## Source Links
+
+- https://github.com/thorstenschiebler/peok
+
+## GitHub Repositories
+
+- https://github.com/thorstenschiebler/peok
+
+Connector status: GitHub connector is not configured; repository intake will use local git credentials or authenticated GitHub CLI when possible.
+
+### GitHub Connector Intake Runbook
+
+GitHub repository intake is required before drafting the design system:
+1. For each linked repository, run the bounded intake command before writing design-system files. The command tries this-device access first (`git clone`, then authenticated GitHub CLI via `gh auth login --web`) and uses the Composio GitHub connector only as a connector-platform fallback.
+   - `"$OD_NODE_BIN" "$OD_BIN" tools connectors github-design-context --repo 'https://github.com/thorstenschiebler/peok' --output context/github/thorstenschiebler-peok.md`
+2. Do not call GitHub connector tree/content/raw tools directly from the agent. Large repositories can trigger `CONNECTOR_OUTPUT_TOO_LARGE`; the bounded intake command is the only allowed GitHub repository intake path for this workflow.
+3. The intake command selects design-system-relevant source files plus available logos/icons/fonts and writes a reviewable evidence note plus file snapshots under `context/github/`; keep those files as the source evidence for this design-system project.
+4. If you already hit `CONNECTOR_OUTPUT_TOO_LARGE` or `CONNECTOR_RATE_LIMITED` from a direct connector call, do not stop and do not retry the same direct tool. Run the bounded intake command above, then inspect the written snapshots.
+5. Treat `Read method: git-clone` as the preferred this-device path. Treat `Read method: connector` as valid connector-platform fallback evidence when local git/GitHub CLI could not read the repository.
+6. The command is strict: if the bounded intake command cannot write snapshot files, stop and explain the permission, GitHub CLI login, connection, rate-limit, or clone problem. Do not use ad-hoc public GitHub browsing, memory, or URL-only inference for design-system files.
+7. Inspect the generated evidence note plus snapshots for README, package manifests, Tailwind/theme/token files, global CSS, font declarations, component source for buttons/forms/navigation/cards/tables, layout shells, icons/logos/assets, and representative app entry files.
+8. Use that evidence to create or update `DESIGN.md`, `colors_and_type.css`, `README.md`, `SKILL.md`, `preview/`, `ui_kits/app/`, `assets/`, and `fonts/` so the Design System tab can review the output as a reusable package.
+
+## Local Code
+
+Linked folders readable by the local agent: none.
+
+Copied browser-selected code snapshot files under `context/local-code/`:
+- context/local-code/peok/skills-lock.json
+- context/local-code/peok/PRODUCT.md
+- context/local-code/peok/_DS_Store
+- context/local-code/peok/_env.local
+- context/local-code/peok/docs.json
+- context/local-code/peok/vercel.json
+- context/local-code/peok/postcss.config.mjs
+- context/local-code/peok/vitest.rls.config.ts
+- context/local-code/peok/tsconfig.tsbuildinfo
+- context/local-code/peok/_mcp.json
+- context/local-code/peok/design-preview.html
+- context/local-code/peok/next-env.d.ts
+- context/local-code/peok/README.md
+- context/local-code/peok/_gitignore
+- context/local-code/peok/package-lock.json
+- context/local-code/peok/package.json
+- context/local-code/peok/tsconfig.json
+- context/local-code/peok/playwright.config.ts
+- context/local-code/peok/AGENTS.md
+- context/local-code/peok/vitest.config.ts
+- context/local-code/peok/eslint.config.mjs
+- context/local-code/peok/CLAUDE.md
+- context/local-code/peok/next.config.ts
+- context/local-code/peok/src/_DS_Store
+- context/local-code/peok/src/proxy.ts
+- context/local-code/peok/src/i18n/navigation.ts
+- context/local-code/peok/src/i18n/routing.ts
+- context/local-code/peok/src/i18n/request.ts
+- context/local-code/peok/src/i18n/redirect.ts
+- context/local-code/peok/src/lib/push.ts
+- context/local-code/peok/src/lib/group-helpers.ts
+- context/local-code/peok/src/lib/person-helpers.ts
+- context/local-code/peok/src/lib/confirm-from-pending.ts
+- context/local-code/peok/src/lib/roster-mention-fallback.ts
+- context/local-code/peok/src/lib/pending-changes.test.ts
+- context/local-code/peok/src/lib/cold-rehydrate.test.ts
+- context/local-code/peok/src/lib/timezone.ts
+- context/local-code/peok/src/lib/stripe.ts
+- context/local-code/peok/src/lib/ai-constants.ts
+- context/local-code/peok/src/lib/capture-inbox.ts
+- ...and 80 more files.
+
+## Design And Brand Resources
+
+Figma files selected: none.
+
+Decoded Figma snapshots: none.
+Fonts, logos, and assets selected: none.
+
+Uploaded brand asset files under `assets/`: none.
+
+## Notes
+
+No additional notes provided.
+
+## Review Contract
+
+- `/design-systems/create` only collected setup inputs. All GitHub extraction, website/source URL review, local evidence intake, source reading, design-system construction, package audit, and artifact writes should happen inside this project workspace.
+- DESIGN.md is the canonical source of truth.
+- Use the canonical design-system title above for headings, README/SKILL names, preview labels, and UI-kit copy unless inspected evidence proves a more accurate product name. Never title the system from URL protocol text such as `https`.
+- colors_and_type.css should hold concrete reusable tokens when the source evidence supports them; if fonts/ contains preserved font files, colors_and_type.css must bind those files with @font-face, @import, or url(...) references so typography does not fall back to substitute fonts.
+- README.md and SKILL.md should make the extracted system reusable as a real Open Design design-system package.
+- README.md should include a source-backed Product Overview/Product Context section, source repository or source folder references, package contents, a concrete `## Preview Manifest` listing every generated `preview/*.html` card, and reuse workflow, similar to Claude Design exports.
+- SKILL.md should include YAML frontmatter with `name`, `description`, and `user-invocable`, plus Claude-style reusable skill sections: What is inside, Source context, When to use this skill, How to use, and Design system highlights. The usage guidance should point agents at README.md, DESIGN.md, colors_and_type.css, preview/, assets/, build/, fonts/, source_examples/, and ui_kits/app/.
+- README.md, SKILL.md, DESIGN.md, and ui_kits/app/README.md must describe the final focused preview cards and `ui_kits/app/` paths, not old scaffold names such as `preview/typography-scale.html` or `ui_kits/generated_interface/`.
+- preview/ should contain small reviewable HTML cards for typography, color themes, spacing, radius, shadows, brand assets, and component evidence.
+- source_examples/ or equivalent root/nested source files should preserve selected high-signal original components when snapshots include substantial app/component source, similar to Claude Design exports that keep files like SelectModelButton.tsx or ChatNavBar/index.tsx alongside the package. These examples should contain substantive original implementation code, not tiny stubs that only share the component name.
+- ui_kits/app/ should contain an applied interface example, plus substantive role-based files under `ui_kits/app/components/` when the source snapshots include representative app shells, navigation, chat/input surfaces, or reusable components. `ui_kits/app/README.md` should explain structure, component files, usage, design notes, and source basis. `ui_kits/app/index.html` must load `../../colors_and_type.css`, must load/import/compose the modular component files, and must mount/render the composed interface instead of staying as a standalone generic static mock or disconnected script list. If the entry directly loads `.jsx`/`.tsx` files, include React, ReactDOM, and Babel standalone scripts and expose each loaded component as `window.ComponentName` / `globalThis.ComponentName`, or write compiled browser-ready JavaScript instead. For chat/workspace evidence, cover app shell, sidebar/navigation, assistant/list rail, chat area, input bar/composer, and message bubble/comment roles; the app shell component must compose those roles into one product-like surface. Placeholder component shells are not sufficient.
+Claude-style UI-kit entry contract:
+- When `ui_kits/app/components/*.jsx` or `*.tsx` files exist, `ui_kits/app/index.html` must behave like a runnable browser entry, not a static mock.
+- Use the same structure as Claude Design exports: load React, ReactDOM, and Babel standalone scripts, load `../../colors_and_type.css`, create a `#root`, load each component script from `components/`, then render the composed `App` component.
+- `App.jsx` must assign `window.App = App` (or `globalThis.App = App`), and every directly loaded component file must expose the same browser global for its component name.
+- Use this skeleton for direct JSX component kits, replacing the component list only when evidence supports different names:
+```html
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js"></script>
+<link rel="stylesheet" href="../../colors_and_type.css">
+<div id="root"></div>
+<script type="text/babel" src="components/Sidebar.jsx"></script>
+<script type="text/babel" src="components/AssistantsList.jsx"></script>
+<script type="text/babel" src="components/ChatArea.jsx"></script>
+<script type="text/babel" src="components/MessageBubble.jsx"></script>
+<script type="text/babel" src="components/InputBar.jsx"></script>
+<script type="text/babel" src="components/App.jsx"></script>
+<script type="text/babel">
+const { App } = window;
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);
+</script>
+```
+- Preview cards and UI-kit visuals should explicitly label or model source-backed modules from the captured evidence instead of generic placeholder modules.
+- assets/, build/, fonts/, and context/ should preserve logos, app icons, tray icons, installer/runtime icons, wordmarks, font files, provenance, and source notes for future projects.
+Claude-style build asset contract:
+- When evidence includes `context/.../files/build/...`, create a root `build/` directory and copy representative runtime assets there with their original filenames and path intent, such as `build/icon.png`, `build/logo.png`, `build/tray_icon.png`, and `build/icon.ico`.
+- Copy those runtime assets byte-for-byte from the captured `context/.../files/...` snapshots. Do not redraw, re-encode, optimize, or substitute generated placeholders for files that the evidence already captured.
+- Do not satisfy build/runtime icon evidence by only renaming those files into `assets/`. `assets/` may include convenience aliases, but root `build/` must preserve the source runtime files for future agents and package consumers.
+- `preview/brand-assets.html` should reference at least some real preserved files from `build/` or `assets/` with `<img>`, `<picture>`, `<object>`, or CSS `url(...)`, and README.md / SKILL.md should mention `build/` in the package manifest when it exists.
+- preview/brand-assets.html should visibly reference preserved files from assets/ or build/ instead of recreating logos/icons as inline placeholder drawings.
+- GitHub evidence must come from the bounded `github-design-context` command, not direct connector tree/content/raw tool calls. The command tries this-device git first, authenticated GitHub CLI second, and connector-platform fallback only when local access cannot read the repository.
+- Linked local folder evidence should come from the bounded `local-design-context` command, which writes a local evidence note and snapshots under `context/local-code/` before final design-system rules are drafted.
+- Before marking the design system ready, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every reported error or warning.
+- Draft design systems cannot be used by other projects until published.
+
+## Provenance
+
+Formalized by Open Design from candidate 4e2a7606-5657-436b-b421-790ccf61606e.

--- a/plugins/community/design-system-source-context-mrv61vi0/open-design.json
+++ b/plugins/community/design-system-source-context-mrv61vi0/open-design.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "design-system-source-context-mrv61vi0",
+  "title": "Design System Source Context",
+  "version": "0.1.0",
+  "description": "This file is generated during setup and should be treated as source evidence for the design-system project. Use it before writing or revising DESIGN.md, previews, tokens, UI kit examples, or assets.",
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ]
+  }
+}

--- a/plugins/community/design-system-source-context-mrv61vi0/references/provenance.json
+++ b/plugins/community/design-system-source-context-mrv61vi0/references/provenance.json
@@ -1,0 +1,19 @@
+{
+  "candidateId": "4e2a7606-5657-436b-b421-790ccf61606e",
+  "projectId": "brand-github-e21407",
+  "runId": "a29b1c1a-02ec-4b42-8c2d-50392cb6afa5",
+  "conversationId": "db93cbe2-7078-4b40-a0f5-8bce06827b9f",
+  "provenance": {
+    "summary": "Detected from context/source-context.md after a successful run.",
+    "detectedAt": 1784669229058
+  },
+  "sourceRefs": [
+    {
+      "kind": "file",
+      "value": "context/source-context.md",
+      "label": "context/source-context.md",
+      "size": 13043,
+      "copied": true
+    }
+  ]
+}

--- a/plugins/community/design-system-source-context-mrv61vi0/references/source-1-source-context.md
+++ b/plugins/community/design-system-source-context-mrv61vi0/references/source-1-source-context.md
@@ -1,0 +1,156 @@
+# Design System Source Context
+
+This file is generated during setup and should be treated as source evidence for the design-system project. Use it before writing or revising DESIGN.md, previews, tokens, UI kit examples, or assets.
+
+## Company / Product
+
+Canonical design-system title: Peok
+
+**Product:** Peok - Private Personal CRM / Second Memory
+**Company:** Private project by Thorsten Schiebler
+**Category:** Brands / SaaS / Personal Productivity
+
+### Product Context
+Peok ist ein privates Personal CRM – ein sicherer Ort, um Beziehungswissen wie Geburtstage, Gespräche, Interessen, Wünsche und Verbindungen zwischen Personen zu speichern. 
+
+Die inhaltlichen Leitplanken:
+- Privat statt sozial
+- Beziehungswissen statt Commodity-Apps
+- Deterministik vor LLM
+
+### Source Links
+- Primary: https://github.com/thorstenschiebler/peok
+- Website: https://peok.de
+- Logo: https://www.peok.de/logo-192.png
+
+## Source Links
+
+- https://github.com/thorstenschiebler/peok
+
+## GitHub Repositories
+
+- https://github.com/thorstenschiebler/peok
+
+Connector status: GitHub connector is not configured; repository intake will use local git credentials or authenticated GitHub CLI when possible.
+
+### GitHub Connector Intake Runbook
+
+GitHub repository intake is required before drafting the design system:
+1. For each linked repository, run the bounded intake command before writing design-system files. The command tries this-device access first (`git clone`, then authenticated GitHub CLI via `gh auth login --web`) and uses the Composio GitHub connector only as a connector-platform fallback.
+   - `"$OD_NODE_BIN" "$OD_BIN" tools connectors github-design-context --repo 'https://github.com/thorstenschiebler/peok' --output context/github/thorstenschiebler-peok.md`
+2. Do not call GitHub connector tree/content/raw tools directly from the agent. Large repositories can trigger `CONNECTOR_OUTPUT_TOO_LARGE`; the bounded intake command is the only allowed GitHub repository intake path for this workflow.
+3. The intake command selects design-system-relevant source files plus available logos/icons/fonts and writes a reviewable evidence note plus file snapshots under `context/github/`; keep those files as the source evidence for this design-system project.
+4. If you already hit `CONNECTOR_OUTPUT_TOO_LARGE` or `CONNECTOR_RATE_LIMITED` from a direct connector call, do not stop and do not retry the same direct tool. Run the bounded intake command above, then inspect the written snapshots.
+5. Treat `Read method: git-clone` as the preferred this-device path. Treat `Read method: connector` as valid connector-platform fallback evidence when local git/GitHub CLI could not read the repository.
+6. The command is strict: if the bounded intake command cannot write snapshot files, stop and explain the permission, GitHub CLI login, connection, rate-limit, or clone problem. Do not use ad-hoc public GitHub browsing, memory, or URL-only inference for design-system files.
+7. Inspect the generated evidence note plus snapshots for README, package manifests, Tailwind/theme/token files, global CSS, font declarations, component source for buttons/forms/navigation/cards/tables, layout shells, icons/logos/assets, and representative app entry files.
+8. Use that evidence to create or update `DESIGN.md`, `colors_and_type.css`, `README.md`, `SKILL.md`, `preview/`, `ui_kits/app/`, `assets/`, and `fonts/` so the Design System tab can review the output as a reusable package.
+
+## Local Code
+
+Linked folders readable by the local agent: none.
+
+Copied browser-selected code snapshot files under `context/local-code/`:
+- context/local-code/peok/skills-lock.json
+- context/local-code/peok/PRODUCT.md
+- context/local-code/peok/_DS_Store
+- context/local-code/peok/_env.local
+- context/local-code/peok/docs.json
+- context/local-code/peok/vercel.json
+- context/local-code/peok/postcss.config.mjs
+- context/local-code/peok/vitest.rls.config.ts
+- context/local-code/peok/tsconfig.tsbuildinfo
+- context/local-code/peok/_mcp.json
+- context/local-code/peok/design-preview.html
+- context/local-code/peok/next-env.d.ts
+- context/local-code/peok/README.md
+- context/local-code/peok/_gitignore
+- context/local-code/peok/package-lock.json
+- context/local-code/peok/package.json
+- context/local-code/peok/tsconfig.json
+- context/local-code/peok/playwright.config.ts
+- context/local-code/peok/AGENTS.md
+- context/local-code/peok/vitest.config.ts
+- context/local-code/peok/eslint.config.mjs
+- context/local-code/peok/CLAUDE.md
+- context/local-code/peok/next.config.ts
+- context/local-code/peok/src/_DS_Store
+- context/local-code/peok/src/proxy.ts
+- context/local-code/peok/src/i18n/navigation.ts
+- context/local-code/peok/src/i18n/routing.ts
+- context/local-code/peok/src/i18n/request.ts
+- context/local-code/peok/src/i18n/redirect.ts
+- context/local-code/peok/src/lib/push.ts
+- context/local-code/peok/src/lib/group-helpers.ts
+- context/local-code/peok/src/lib/person-helpers.ts
+- context/local-code/peok/src/lib/confirm-from-pending.ts
+- context/local-code/peok/src/lib/roster-mention-fallback.ts
+- context/local-code/peok/src/lib/pending-changes.test.ts
+- context/local-code/peok/src/lib/cold-rehydrate.test.ts
+- context/local-code/peok/src/lib/timezone.ts
+- context/local-code/peok/src/lib/stripe.ts
+- context/local-code/peok/src/lib/ai-constants.ts
+- context/local-code/peok/src/lib/capture-inbox.ts
+- ...and 80 more files.
+
+## Design And Brand Resources
+
+Figma files selected: none.
+
+Decoded Figma snapshots: none.
+Fonts, logos, and assets selected: none.
+
+Uploaded brand asset files under `assets/`: none.
+
+## Notes
+
+No additional notes provided.
+
+## Review Contract
+
+- `/design-systems/create` only collected setup inputs. All GitHub extraction, website/source URL review, local evidence intake, source reading, design-system construction, package audit, and artifact writes should happen inside this project workspace.
+- DESIGN.md is the canonical source of truth.
+- Use the canonical design-system title above for headings, README/SKILL names, preview labels, and UI-kit copy unless inspected evidence proves a more accurate product name. Never title the system from URL protocol text such as `https`.
+- colors_and_type.css should hold concrete reusable tokens when the source evidence supports them; if fonts/ contains preserved font files, colors_and_type.css must bind those files with @font-face, @import, or url(...) references so typography does not fall back to substitute fonts.
+- README.md and SKILL.md should make the extracted system reusable as a real Open Design design-system package.
+- README.md should include a source-backed Product Overview/Product Context section, source repository or source folder references, package contents, a concrete `## Preview Manifest` listing every generated `preview/*.html` card, and reuse workflow, similar to Claude Design exports.
+- SKILL.md should include YAML frontmatter with `name`, `description`, and `user-invocable`, plus Claude-style reusable skill sections: What is inside, Source context, When to use this skill, How to use, and Design system highlights. The usage guidance should point agents at README.md, DESIGN.md, colors_and_type.css, preview/, assets/, build/, fonts/, source_examples/, and ui_kits/app/.
+- README.md, SKILL.md, DESIGN.md, and ui_kits/app/README.md must describe the final focused preview cards and `ui_kits/app/` paths, not old scaffold names such as `preview/typography-scale.html` or `ui_kits/generated_interface/`.
+- preview/ should contain small reviewable HTML cards for typography, color themes, spacing, radius, shadows, brand assets, and component evidence.
+- source_examples/ or equivalent root/nested source files should preserve selected high-signal original components when snapshots include substantial app/component source, similar to Claude Design exports that keep files like SelectModelButton.tsx or ChatNavBar/index.tsx alongside the package. These examples should contain substantive original implementation code, not tiny stubs that only share the component name.
+- ui_kits/app/ should contain an applied interface example, plus substantive role-based files under `ui_kits/app/components/` when the source snapshots include representative app shells, navigation, chat/input surfaces, or reusable components. `ui_kits/app/README.md` should explain structure, component files, usage, design notes, and source basis. `ui_kits/app/index.html` must load `../../colors_and_type.css`, must load/import/compose the modular component files, and must mount/render the composed interface instead of staying as a standalone generic static mock or disconnected script list. If the entry directly loads `.jsx`/`.tsx` files, include React, ReactDOM, and Babel standalone scripts and expose each loaded component as `window.ComponentName` / `globalThis.ComponentName`, or write compiled browser-ready JavaScript instead. For chat/workspace evidence, cover app shell, sidebar/navigation, assistant/list rail, chat area, input bar/composer, and message bubble/comment roles; the app shell component must compose those roles into one product-like surface. Placeholder component shells are not sufficient.
+Claude-style UI-kit entry contract:
+- When `ui_kits/app/components/*.jsx` or `*.tsx` files exist, `ui_kits/app/index.html` must behave like a runnable browser entry, not a static mock.
+- Use the same structure as Claude Design exports: load React, ReactDOM, and Babel standalone scripts, load `../../colors_and_type.css`, create a `#root`, load each component script from `components/`, then render the composed `App` component.
+- `App.jsx` must assign `window.App = App` (or `globalThis.App = App`), and every directly loaded component file must expose the same browser global for its component name.
+- Use this skeleton for direct JSX component kits, replacing the component list only when evidence supports different names:
+```html
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js"></script>
+<link rel="stylesheet" href="../../colors_and_type.css">
+<div id="root"></div>
+<script type="text/babel" src="components/Sidebar.jsx"></script>
+<script type="text/babel" src="components/AssistantsList.jsx"></script>
+<script type="text/babel" src="components/ChatArea.jsx"></script>
+<script type="text/babel" src="components/MessageBubble.jsx"></script>
+<script type="text/babel" src="components/InputBar.jsx"></script>
+<script type="text/babel" src="components/App.jsx"></script>
+<script type="text/babel">
+const { App } = window;
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);
+</script>
+```
+- Preview cards and UI-kit visuals should explicitly label or model source-backed modules from the captured evidence instead of generic placeholder modules.
+- assets/, build/, fonts/, and context/ should preserve logos, app icons, tray icons, installer/runtime icons, wordmarks, font files, provenance, and source notes for future projects.
+Claude-style build asset contract:
+- When evidence includes `context/.../files/build/...`, create a root `build/` directory and copy representative runtime assets there with their original filenames and path intent, such as `build/icon.png`, `build/logo.png`, `build/tray_icon.png`, and `build/icon.ico`.
+- Copy those runtime assets byte-for-byte from the captured `context/.../files/...` snapshots. Do not redraw, re-encode, optimize, or substitute generated placeholders for files that the evidence already captured.
+- Do not satisfy build/runtime icon evidence by only renaming those files into `assets/`. `assets/` may include convenience aliases, but root `build/` must preserve the source runtime files for future agents and package consumers.
+- `preview/brand-assets.html` should reference at least some real preserved files from `build/` or `assets/` with `<img>`, `<picture>`, `<object>`, or CSS `url(...)`, and README.md / SKILL.md should mention `build/` in the package manifest when it exists.
+- preview/brand-assets.html should visibly reference preserved files from assets/ or build/ instead of recreating logos/icons as inline placeholder drawings.
+- GitHub evidence must come from the bounded `github-design-context` command, not direct connector tree/content/raw tool calls. The command tries this-device git first, authenticated GitHub CLI second, and connector-platform fallback only when local access cannot read the repository.
+- Linked local folder evidence should come from the bounded `local-design-context` command, which writes a local evidence note and snapshots under `context/local-code/` before final design-system rules are drafted.
+- Before marking the design system ready, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every reported error or warning.
+- Draft design systems cannot be used by other projects until published.


### PR DESCRIPTION
Add Design System Source Context (design-system-source-context-mrv61vi0) plugin.
Version: 0.1.0
Description: This file is generated during setup and should be treated as source evidence for the design-system project. Use it before writing or revising DESIGN.md, previews, tokens, UI kit examples, or assets.