### PR TITLE
fix packaged Windows obsolete outer cleanup

### DIFF
--- a/apps/packaged/src/obsolete-installed-outer.ts
+++ b/apps/packaged/src/obsolete-installed-outer.ts
@@ -1,5 +1,5 @@
 import { lstat } from "node:fs/promises";
-import { posix } from "node:path";
+import { posix, win32 } from "node:path";
 
 import {
   collectProcessTreePids,
@@ -25,6 +25,11 @@ export type ObsoleteInstalledOuterRetirementContext = {
 };
 
 type ObsoleteInstalledOuterRetirementDeps = {
+  inspectInstalledOuterPath?: (path: string) => Promise<{
+    isDirectory(): boolean;
+    isFile(): boolean;
+    isSymbolicLink(): boolean;
+  } | null>;
   listProcessSnapshots?: typeof listProcessSnapshots;
   stopProcesses?: typeof stopProcesses;
 };
@@ -52,25 +57,43 @@ export type ObsoleteInstalledOuterRetirementResult =
       treePids: number[];
     };
 
-function sameExecutablePath(left: string, right: string): boolean {
+function sameExecutablePath(left: string, right: string, platform: NodeJS.Platform): boolean {
+  if (platform === "win32") {
+    return win32.normalize(left).toLowerCase() === win32.normalize(right).toLowerCase();
+  }
   return posix.normalize(left) === posix.normalize(right);
 }
 
 async function resolveInstalledOuterExecutable(
   installedLaunchPath: string | null,
+  payloadExecutablePath: string,
   platform: NodeJS.Platform,
+  inspectInstalledOuterPath: NonNullable<ObsoleteInstalledOuterRetirementDeps["inspectInstalledOuterPath"]>,
 ): Promise<string | null> {
   if (installedLaunchPath == null || installedLaunchPath.length === 0) return null;
+
+  if (platform === "win32") {
+    if (!win32.isAbsolute(installedLaunchPath) || !win32.isAbsolute(payloadExecutablePath)) return null;
+    if (win32.extname(installedLaunchPath).toLowerCase() !== ".exe") return null;
+    if (win32.basename(installedLaunchPath).toLowerCase() !== win32.basename(payloadExecutablePath).toLowerCase()) {
+      return null;
+    }
+
+    const executableEntry = await inspectInstalledOuterPath(installedLaunchPath);
+    if (executableEntry == null || !executableEntry.isFile() || executableEntry.isSymbolicLink()) return null;
+    return installedLaunchPath;
+  }
+
   if (platform !== "darwin" || !posix.isAbsolute(installedLaunchPath)) return null;
 
-  const launchEntry = await lstat(installedLaunchPath).catch(() => null);
+  const launchEntry = await inspectInstalledOuterPath(installedLaunchPath);
   if (launchEntry == null || launchEntry.isSymbolicLink()) return null;
 
   if (!launchEntry.isDirectory() || !installedLaunchPath.endsWith(".app")) return null;
   const appName = posix.basename(installedLaunchPath, ".app");
   const executablePath = posix.join(installedLaunchPath, "Contents", "MacOS", appName);
 
-  const executableEntry = await lstat(executablePath).catch(() => null);
+  const executableEntry = await inspectInstalledOuterPath(executablePath);
   if (executableEntry == null || !executableEntry.isFile() || executableEntry.isSymbolicLink()) return null;
   return executablePath;
 }
@@ -82,29 +105,52 @@ async function retireObsoleteInstalledOuter(
   if (!context.payloadDesktopProcess || context.payloadExecutablePath == null || !sameExecutablePath(
     context.currentExecutablePath,
     context.payloadExecutablePath,
+    context.platform,
   )) {
     return { reason: "not-payload-desktop", status: "skipped" };
   }
-  if (context.platform !== "darwin") {
+  if (context.platform !== "darwin" && context.platform !== "win32") {
     return { reason: "unsupported-platform", status: "skipped" };
   }
 
-  const executablePath = await resolveInstalledOuterExecutable(context.installedLaunchPath, context.platform);
+  const inspectInstalledOuterPath = deps.inspectInstalledOuterPath
+    ?? (async (path: string) => lstat(path).catch(() => null));
+  const executablePath = await resolveInstalledOuterExecutable(
+    context.installedLaunchPath,
+    context.payloadExecutablePath,
+    context.platform,
+    inspectInstalledOuterPath,
+  );
   if (executablePath == null) return { reason: "invalid-install-anchor", status: "skipped" };
-  if (sameExecutablePath(executablePath, context.currentExecutablePath)) {
+  if (sameExecutablePath(executablePath, context.currentExecutablePath, context.platform)) {
     return { reason: "same-executable", status: "skipped" };
   }
 
-  const snapshots = await (deps.listProcessSnapshots ?? listProcessSnapshots)();
-  const rootPids = snapshots
+  const enumerateProcesses = deps.listProcessSnapshots ?? listProcessSnapshots;
+  let snapshots = await enumerateProcesses();
+  let rootPids = snapshots
     .filter((snapshot) => snapshot.pid !== context.currentPid && processCommandExactlyRunsExecutable(
       snapshot.command,
       executablePath,
-      "darwin",
+      context.platform,
     ))
     .map((snapshot) => snapshot.pid)
     .sort((left, right) => right - left);
   if (rootPids.length === 0) return { executablePath, reason: "no-match", status: "skipped" };
+
+  if (context.platform === "win32") {
+    snapshots = await enumerateProcesses();
+    const expectedRootPids = new Set(rootPids);
+    rootPids = snapshots
+      .filter((snapshot) => expectedRootPids.has(snapshot.pid) && processCommandExactlyRunsExecutable(
+        snapshot.command,
+        executablePath,
+        context.platform,
+      ))
+      .map((snapshot) => snapshot.pid)
+      .sort((left, right) => right - left);
+    if (rootPids.length === 0) return { executablePath, reason: "no-match", status: "skipped" };
+  }
 
   const safeRootPids = rootPids.filter((rootPid) => {
     const tree = collectProcessTreePids(snapshots, [rootPid]);
@@ -140,8 +186,8 @@ async function retireObsoleteInstalledOuter(
 
 /**
  * Build a re-usable, single-flight cleanup callback for desktop SHOW and quit.
- * A later invocation starts a fresh scan so a later LaunchServices open is not
- * hidden by a previously successful retirement.
+ * A later invocation starts a fresh scan so a later installed-outer open is
+ * not hidden by a previously successful retirement.
  */
 export function createObsoleteInstalledOuterRetirement(
   context: ObsoleteInstalledOuterRetirementContext,

--- a/apps/packaged/tests/obsolete-installed-outer.test.ts
+++ b/apps/packaged/tests/obsolete-installed-outer.test.ts
@@ -15,7 +15,49 @@ afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { force: true, recursive: true })));
 });
 
-async function createMacInstalledOuter(): Promise<{ executablePath: string; launchPath: string }> {
+type InspectInstalledOuterPath = (path: string) => Promise<{
+  isDirectory(): boolean;
+  isFile(): boolean;
+  isSymbolicLink(): boolean;
+} | null>;
+
+function inspectedEntry(options: {
+  directory?: boolean;
+  symbolicLink?: boolean;
+} = {}) {
+  return {
+    isDirectory: () => options.directory ?? false,
+    isFile: () => !(options.directory ?? false),
+    isSymbolicLink: () => options.symbolicLink ?? false,
+  };
+}
+
+function macInspectMock(
+  launchPath: string,
+  executablePath: string,
+  executableSymbolicLink = false,
+): InspectInstalledOuterPath {
+  return vi.fn(async (path) => {
+    if (path === launchPath) return inspectedEntry({ directory: true });
+    if (path === executablePath) return inspectedEntry({ symbolicLink: executableSymbolicLink });
+    return null;
+  });
+}
+
+async function createMacInstalledOuter(): Promise<{
+  executablePath: string;
+  inspectInstalledOuterPath?: InspectInstalledOuterPath;
+  launchPath: string;
+}> {
+  if (process.platform === "win32") {
+    const launchPath = "/Applications/Open Design.app";
+    const executablePath = `${launchPath}/Contents/MacOS/Open Design`;
+    return {
+      executablePath,
+      inspectInstalledOuterPath: macInspectMock(launchPath, executablePath),
+      launchPath,
+    };
+  }
   const root = await mkdtemp(join(tmpdir(), "od-obsolete-outer-"));
   roots.push(root);
   const launchPath = join(root, "Open Design.app");
@@ -23,6 +65,28 @@ async function createMacInstalledOuter(): Promise<{ executablePath: string; laun
   await mkdir(join(launchPath, "Contents", "MacOS"), { recursive: true });
   await writeFile(executablePath, "legacy outer", "utf8");
   return { executablePath, launchPath };
+}
+
+function fileInspectMock(symbolicLink = false): InspectInstalledOuterPath {
+  return vi.fn(async () => inspectedEntry({ symbolicLink }));
+}
+
+async function createWindowsInstalledOuter(
+  executableName = "Open Design.exe",
+): Promise<{
+  executablePath: string;
+  inspectInstalledOuterPath?: InspectInstalledOuterPath;
+  launchPath: string;
+}> {
+  if (process.platform !== "win32") {
+    const executablePath = `C:\\Program Files\\Open Design\\${executableName}`;
+    return { executablePath, inspectInstalledOuterPath: fileInspectMock(), launchPath: executablePath };
+  }
+  const root = await mkdtemp(join(tmpdir(), "od-obsolete-outer-win-"));
+  roots.push(root);
+  const executablePath = join(root, executableName);
+  await writeFile(executablePath, "legacy outer", "utf8");
+  return { executablePath, launchPath: executablePath };
 }
 
 function snapshot(pid: number, ppid: number, command: string): ProcessSnapshot {
@@ -47,7 +111,7 @@ function stopMock() {
 
 describe("createObsoleteInstalledOuterRetirement", () => {
   it("stops only the exact installed outer root and its descendants", async () => {
-    const { executablePath, launchPath } = await createMacInstalledOuter();
+    const { executablePath, inspectInstalledOuterPath, launchPath } = await createMacInstalledOuter();
     const snapshots = [
       snapshot(101, 1, executablePath),
       snapshot(102, 101, `${launchPath}/Contents/Frameworks/Open Design Helper.app/Contents/MacOS/Open Design Helper`),
@@ -67,6 +131,7 @@ describe("createObsoleteInstalledOuterRetirement", () => {
       payloadExecutablePath: "/payload/Open Design.app/Contents/MacOS/Open Design",
       platform: "darwin",
     }, {
+      inspectInstalledOuterPath,
       listProcessSnapshots: async () => snapshots,
       stopProcesses,
     });
@@ -105,33 +170,23 @@ describe("createObsoleteInstalledOuterRetirement", () => {
     expect(stopProcesses).not.toHaveBeenCalled();
   });
 
-  it("stays disabled on Windows until the platform path is independently validated", async () => {
-    const listProcessSnapshots = vi.fn(async () => []);
-    const stopProcesses = stopMock();
-    const retire = createObsoleteInstalledOuterRetirement({
-      currentExecutablePath: "C:\\payload\\Open Design.exe",
-      currentPid: 900,
-      installedLaunchPath: "C:\\Program Files\\Open Design\\Open Design.exe",
-      logger: { info: vi.fn(), warn: vi.fn() },
-      payloadDesktopProcess: true,
-      payloadExecutablePath: "C:\\payload\\Open Design.exe",
-      platform: "win32",
-    }, { listProcessSnapshots, stopProcesses });
-
-    await expect(retire()).resolves.toMatchObject({ reason: "unsupported-platform", status: "skipped" });
-    expect(listProcessSnapshots).not.toHaveBeenCalled();
-    expect(stopProcesses).not.toHaveBeenCalled();
-  });
-
   it("rejects a symlinked install executable before enumerating processes", async () => {
-    const root = await mkdtemp(join(tmpdir(), "od-obsolete-outer-symlink-"));
-    roots.push(root);
-    const launchPath = join(root, "Open Design.app");
-    const executableDirectory = join(launchPath, "Contents", "MacOS");
-    const target = join(root, "target");
-    await mkdir(executableDirectory, { recursive: true });
-    await writeFile(target, "not the installed executable", "utf8");
-    await symlink(target, join(executableDirectory, "Open Design"));
+    let inspectInstalledOuterPath: InspectInstalledOuterPath | undefined;
+    let launchPath: string;
+    if (process.platform === "win32") {
+      launchPath = "/Applications/Open Design.app";
+      const executablePath = `${launchPath}/Contents/MacOS/Open Design`;
+      inspectInstalledOuterPath = macInspectMock(launchPath, executablePath, true);
+    } else {
+      const root = await mkdtemp(join(tmpdir(), "od-obsolete-outer-symlink-"));
+      roots.push(root);
+      launchPath = join(root, "Open Design.app");
+      const executableDirectory = join(launchPath, "Contents", "MacOS");
+      const target = join(root, "target");
+      await mkdir(executableDirectory, { recursive: true });
+      await writeFile(target, "not the installed executable", "utf8");
+      await symlink(target, join(executableDirectory, "Open Design"));
+    }
     const listProcessSnapshots = vi.fn(async () => []);
     const retire = createObsoleteInstalledOuterRetirement({
       currentExecutablePath: "/payload/Open Design",
@@ -141,14 +196,18 @@ describe("createObsoleteInstalledOuterRetirement", () => {
       payloadDesktopProcess: true,
       payloadExecutablePath: "/payload/Open Design",
       platform: "darwin",
-    }, { listProcessSnapshots, stopProcesses: async (pids) => stopped(pids.filter((pid): pid is number => pid != null)) });
+    }, {
+      inspectInstalledOuterPath,
+      listProcessSnapshots,
+      stopProcesses: async (pids) => stopped(pids.filter((pid): pid is number => pid != null)),
+    });
 
     await expect(retire()).resolves.toMatchObject({ reason: "invalid-install-anchor", status: "skipped" });
     expect(listProcessSnapshots).not.toHaveBeenCalled();
   });
 
   it("refuses to stop an outer tree that contains the current payload", async () => {
-    const { executablePath, launchPath } = await createMacInstalledOuter();
+    const { executablePath, inspectInstalledOuterPath, launchPath } = await createMacInstalledOuter();
     const stopProcesses = stopMock();
     const retire = createObsoleteInstalledOuterRetirement({
       currentExecutablePath: "/payload/Open Design",
@@ -159,6 +218,7 @@ describe("createObsoleteInstalledOuterRetirement", () => {
       payloadExecutablePath: "/payload/Open Design",
       platform: "darwin",
     }, {
+      inspectInstalledOuterPath,
       listProcessSnapshots: async () => [
         snapshot(101, 1, executablePath),
         snapshot(800, 101, "handoff daemon"),
@@ -176,7 +236,7 @@ describe("createObsoleteInstalledOuterRetirement", () => {
   });
 
   it("coalesces concurrent retirement requests without suppressing later opens", async () => {
-    const { executablePath, launchPath } = await createMacInstalledOuter();
+    const { executablePath, inspectInstalledOuterPath, launchPath } = await createMacInstalledOuter();
     let releaseEnumeration: (() => void) | undefined;
     const listProcessSnapshots = vi.fn(async () => {
       await new Promise<void>((resolve) => {
@@ -193,7 +253,7 @@ describe("createObsoleteInstalledOuterRetirement", () => {
       payloadDesktopProcess: true,
       payloadExecutablePath: "/payload/Open Design",
       platform: "darwin",
-    }, { listProcessSnapshots, stopProcesses });
+    }, { inspectInstalledOuterPath, listProcessSnapshots, stopProcesses });
 
     const first = retire();
     const concurrent = retire();
@@ -206,5 +266,148 @@ describe("createObsoleteInstalledOuterRetirement", () => {
     await vi.waitFor(() => expect(listProcessSnapshots).toHaveBeenCalledTimes(2));
     releaseEnumeration?.();
     await later;
+  });
+});
+
+describe("Windows obsolete installed outer retirement", () => {
+  it("stops the revalidated exact installed outer root and its current descendants", async () => {
+    const { executablePath, inspectInstalledOuterPath, launchPath } = await createWindowsInstalledOuter();
+    const firstSnapshots = [
+      snapshot(201, 1, `"${executablePath.toUpperCase()}"`),
+      snapshot(202, 201, "Open Design.exe --type=gpu-process"),
+      snapshot(203, 202, "Open Design.exe --type=utility"),
+      snapshot(204, 1, `"${executablePath}" od://project/123`),
+      snapshot(205, 1, `${executablePath}.old`),
+      snapshot(900, 1, "C:\\payload\\Open Design.exe"),
+    ];
+    const secondSnapshots = [
+      snapshot(201, 1, `"${executablePath}"`),
+      snapshot(202, 201, "Open Design.exe --type=gpu-process"),
+      snapshot(206, 202, "Open Design.exe --type=renderer"),
+      snapshot(204, 1, `"${executablePath}" od://project/123`),
+      snapshot(205, 1, `${executablePath}.old`),
+      snapshot(900, 1, "C:\\payload\\Open Design.exe"),
+    ];
+    const listProcessSnapshots = vi.fn()
+      .mockResolvedValueOnce(firstSnapshots)
+      .mockResolvedValueOnce(secondSnapshots);
+    const stopProcesses = stopMock();
+    const logger = { info: vi.fn(), warn: vi.fn() };
+    const retire = createObsoleteInstalledOuterRetirement({
+      currentExecutablePath: "C:\\PAYLOAD\\OPEN DESIGN.EXE",
+      currentPid: 900,
+      installedLaunchPath: launchPath,
+      logger,
+      payloadDesktopProcess: true,
+      payloadExecutablePath: "c:\\payload\\Open Design.exe",
+      platform: "win32",
+    }, { inspectInstalledOuterPath, listProcessSnapshots, stopProcesses });
+
+    const result = await retire();
+
+    expect(listProcessSnapshots).toHaveBeenCalledTimes(2);
+    expect(stopProcesses).toHaveBeenCalledExactlyOnceWith([206, 202, 201]);
+    expect(result).toMatchObject({
+      executablePath,
+      rootPids: [201],
+      status: "retired",
+      treePids: [206, 202, 201],
+    });
+  });
+
+  it("skips a reused root pid when the second snapshot no longer matches the executable", async () => {
+    const { executablePath, inspectInstalledOuterPath, launchPath } = await createWindowsInstalledOuter();
+    const listProcessSnapshots = vi.fn()
+      .mockResolvedValueOnce([
+        snapshot(201, 1, `"${executablePath}"`),
+        snapshot(202, 201, "Open Design.exe --type=gpu-process"),
+      ])
+      .mockResolvedValueOnce([
+        snapshot(201, 1, "C:\\Windows\\System32\\notepad.exe"),
+        snapshot(202, 201, "Open Design.exe --type=gpu-process"),
+      ]);
+    const stopProcesses = stopMock();
+    const retire = createObsoleteInstalledOuterRetirement({
+      currentExecutablePath: "C:\\payload\\Open Design.exe",
+      currentPid: 900,
+      installedLaunchPath: launchPath,
+      logger: { info: vi.fn(), warn: vi.fn() },
+      payloadDesktopProcess: true,
+      payloadExecutablePath: "C:\\payload\\Open Design.exe",
+      platform: "win32",
+    }, { inspectInstalledOuterPath, listProcessSnapshots, stopProcesses });
+
+    await expect(retire()).resolves.toMatchObject({ reason: "no-match", status: "skipped" });
+    expect(listProcessSnapshots).toHaveBeenCalledTimes(2);
+    expect(stopProcesses).not.toHaveBeenCalled();
+  });
+
+  it("rejects installed executables whose basename does not match the payload", async () => {
+    const { inspectInstalledOuterPath, launchPath } = await createWindowsInstalledOuter("Not Open Design.exe");
+    const listProcessSnapshots = vi.fn(async () => []);
+    const stopProcesses = stopMock();
+    const retire = createObsoleteInstalledOuterRetirement({
+      currentExecutablePath: "C:\\payload\\Open Design.exe",
+      currentPid: 900,
+      installedLaunchPath: launchPath,
+      logger: { info: vi.fn(), warn: vi.fn() },
+      payloadDesktopProcess: true,
+      payloadExecutablePath: "C:\\payload\\Open Design.exe",
+      platform: "win32",
+    }, { inspectInstalledOuterPath, listProcessSnapshots, stopProcesses });
+
+    await expect(retire()).resolves.toMatchObject({ reason: "invalid-install-anchor", status: "skipped" });
+    expect(listProcessSnapshots).not.toHaveBeenCalled();
+    expect(stopProcesses).not.toHaveBeenCalled();
+  });
+
+  it("refuses a revalidated outer tree that contains the current payload", async () => {
+    const { executablePath, inspectInstalledOuterPath, launchPath } = await createWindowsInstalledOuter();
+    const snapshots = [
+      snapshot(201, 1, `"${executablePath}"`),
+      snapshot(800, 201, "handoff daemon"),
+      snapshot(900, 800, "C:\\payload\\Open Design.exe"),
+    ];
+    const listProcessSnapshots = vi.fn(async () => snapshots);
+    const stopProcesses = stopMock();
+    const retire = createObsoleteInstalledOuterRetirement({
+      currentExecutablePath: "C:\\payload\\Open Design.exe",
+      currentPid: 900,
+      installedLaunchPath: launchPath,
+      logger: { info: vi.fn(), warn: vi.fn() },
+      payloadDesktopProcess: true,
+      payloadExecutablePath: "C:\\payload\\Open Design.exe",
+      platform: "win32",
+    }, { inspectInstalledOuterPath, listProcessSnapshots, stopProcesses });
+
+    await expect(retire()).resolves.toMatchObject({
+      reason: "unsafe-current-descendant",
+      status: "skipped",
+    });
+    expect(listProcessSnapshots).toHaveBeenCalledTimes(2);
+    expect(stopProcesses).not.toHaveBeenCalled();
+  });
+
+  it("rejects a symlinked Windows executable before enumerating processes", async () => {
+    const executablePath = "C:\\Program Files\\Open Design\\Open Design.exe";
+    const listProcessSnapshots = vi.fn(async () => []);
+    const stopProcesses = stopMock();
+    const retire = createObsoleteInstalledOuterRetirement({
+      currentExecutablePath: "C:\\payload\\Open Design.exe",
+      currentPid: 900,
+      installedLaunchPath: executablePath,
+      logger: { info: vi.fn(), warn: vi.fn() },
+      payloadDesktopProcess: true,
+      payloadExecutablePath: "C:\\payload\\Open Design.exe",
+      platform: "win32",
+    }, {
+      inspectInstalledOuterPath: fileInspectMock(true),
+      listProcessSnapshots,
+      stopProcesses,
+    });
+
+    await expect(retire()).resolves.toMatchObject({ reason: "invalid-install-anchor", status: "skipped" });
+    expect(listProcessSnapshots).not.toHaveBeenCalled();
+    expect(stopProcesses).not.toHaveBeenCalled();
   });
 });

--- a/packages/platform/tests/process-tree.test.ts
+++ b/packages/platform/tests/process-tree.test.ts
@@ -62,5 +62,25 @@ describe("processCommandExactlyRunsExecutable", () => {
     const executable = "/Applications/Open Design.app/Contents/MacOS/Open Design";
     expect(processCommandExactlyRunsExecutable(`${executable} --inspect`, executable, "darwin")).toBe(false);
     expect(processCommandExactlyRunsExecutable(`${executable} Helper`, executable, "darwin")).toBe(false);
+
+    const windowsExecutable = "C:\\Program Files\\Open Design\\Open Design.exe";
+    expect(processCommandExactlyRunsExecutable(
+      `"${windowsExecutable}" od://project/123`,
+      windowsExecutable,
+      "win32",
+    )).toBe(false);
+    expect(processCommandExactlyRunsExecutable(
+      `"${windowsExecutable}.old"`,
+      windowsExecutable,
+      "win32",
+    )).toBe(false);
+  });
+
+  it("compares Windows executable paths case-insensitively", () => {
+    expect(processCommandExactlyRunsExecutable(
+      '"C:\\PROGRAM FILES\\OPEN DESIGN\\OPEN DESIGN.EXE"',
+      "c:\\Program Files\\Open Design\\Open Design.exe",
+      "win32",
+    )).toBe(true);
   });
 });


### PR DESCRIPTION
## Why

This is the Windows follow-up to #5940. While validating the most complex supported updater chain—stable 0.12.0 packaged outer, official 0.15.1 payload, and the pending 0.16.0 payload—I reproduced the same obsolete-installed-outer leak on Windows.

Windows did not show the macOS cold-start single-instance block, but every later open of the installed 0.12.0 executable left an obsolete main process and two helpers beside the active payload. Those ghosts accumulate and can retain handles to the installation path, making later install or uninstall operations less reliable.

## What users will see

After an in-place Windows payload update, opening Open Design again from the installed shortcut or executable keeps the active payload window and automatically retires the obsolete installed outer process tree. Repeated opens no longer accumulate legacy Open Design processes.

The cleanup remains deliberately narrow: only a real, non-symlinked installed `.exe` whose basename matches the payload is eligible, only an exact no-argument root command is matched, the root PID is revalidated immediately before cleanup, and a tree containing the active payload is refused.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. This changes packaged Windows process lifecycle behavior and has no new UI surface.

## Bug fix verification

- Test paths: `apps/packaged/tests/obsolete-installed-outer.test.ts` and `packages/platform/tests/process-tree.test.ts`.
- The four new Windows retirement specs went red on `main` with `unsupported-platform` before the product change, then the focused packaged suite went green at 10/10 on this branch.
- Coverage includes quoted and case-insensitive exact executable matching, basename and symlink anchor rejection, PID identity change between snapshots, active-payload ancestry refusal, descendant recomputation, and later-open single-flight behavior.

## Validation

- `pnpm install`
- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/platform test` — 80 passed
- `pnpm --filter @open-design/desktop test` — 246 passed, 2 skipped
- `pnpm --filter @open-design/packaged exec vitest run -c vitest.config.ts --exclude tests/prewarm.test.ts` — 199 passed
- Focused packaged obsolete-outer suite — 10 passed
- Focused platform process-tree suite — 9 passed
- Packaged, desktop, and platform typechecks
- Built a patched 0.16.0 Windows NSIS installer and payload with the real `release-stable-win` namespace, then validated the payload manifest as Windows/stable/0.16.0.
- Exercised the full Windows updater chain: official stable 0.12.0 packaged install → official 0.15.1 payload → patched 0.16.0 payload.
- Confirmed the 0.16.0 handoff, then reopened the installed 0.12.0 executable six times. Every obsolete root plus its two helpers retired with no remaining/forced PIDs while the same 0.16.0 payload PID stayed alive.
- Performed a complete stop and cold start from the installed 0.12.0 entry. The old outer exited, a new 0.16.0 payload took over, launcher generation 4 was confirmed, and no attempt or installed-outer process remained.
- Exported a real PPTX both before and after the cold restart; both returned HTTP 200, the standard PPTX MIME type, and a `PK` archive header.
- Uninstalled the stable namespace while the payload was active. No stable executable, uninstaller, shortcut, registry entry, or managed process remained; the existing prerelease installation was unchanged.

The unfiltered packaged suite also reports five existing Windows-host failures in `tests/prewarm.test.ts`: its POSIX path/FUSE fixtures are interpreted with Windows host path semantics. The other 199 packaged tests pass, and this PR does not touch the prewarm path.
