### PR TITLE
name every packaged startup failure instead of bucketing it as unknown

### DIFF
--- a/apps/packaged/src/startup-telemetry.ts
+++ b/apps/packaged/src/startup-telemetry.ts
@@ -96,6 +96,7 @@ export type StartupFailureKind =
   | "web-start"
   | "path-access"
   | "status-timeout"
+  | "spawn-failed"
   | "unknown";
 
 export interface StartupFailureClassification {
@@ -118,6 +119,12 @@ const EXIT_RE =
 // child. There is no daemon log path in this message, so no log tail is read.
 const STATUS_TIMEOUT_RE = /^timed out waiting for sidecar status at /;
 
+// Node's message for a spawn that never became a process (`spawn UNKNOWN`,
+// `spawn C:\…\Open Design.exe ENOENT`). Message shape is the fallback; the
+// error object's `syscall` is the primary signal since it survives an empty
+// message.
+const SPAWN_RE = /^spawn\b/;
+
 export function classifyStartupFailure(
   error: unknown,
   isPathAccess: boolean,
@@ -133,6 +140,12 @@ export function classifyStartupFailure(
     // it is the signal for whether the win32 budget raise drained these.
     if (STATUS_TIMEOUT_RE.test(message)) {
       return { failureKind: "status-timeout", exitCode: null, signal: null, logPath: null };
+    }
+    // The process was never created. Prefer the syscall on the error object: it
+    // is present even when the message is empty, which is exactly the case the
+    // message-only classifier used to lose.
+    if (readErrnoFields(error).syscall === "spawn" || SPAWN_RE.test(message)) {
+      return { failureKind: "spawn-failed", exitCode: null, signal: null, logPath: null };
     }
     return { failureKind: "unknown", exitCode: null, signal: null, logPath: null };
   }
@@ -153,19 +166,57 @@ export function classifyStartupFailure(
   return { failureKind, exitCode, signal, logPath };
 }
 
+// A thrown-error headline in a log tail: `SqliteError: database disk image is
+// malformed`, `TypeError: x is not a function`, `Error [ERR_X]: …`. Anchored on
+// a leading identifier that ends in Error/Exception so stack frames (`    at …`)
+// and our own bracketed prefixes (`[open-design packaged] exited …`) never match.
+const DAEMON_ERROR_LINE_RE =
+  /^(?:\s*(?:Uncaught|Unhandled)\s+)?[A-Za-z_$][\w$]*(?:Error|Exception)(?:\s*\[[^\]]+\])?\s*:\s*.+$/;
+
 // Pull the real error code + missing module out of a sidecar log tail. Pure
 // function so it can be fed the #4638 log text verbatim in tests.
+//
+// `daemonError` is the attribution backstop: the `ERR_*` match only names
+// module-resolution-shaped deaths, so a daemon that threw anything else
+// (SQLite corruption, EPERM, a plain throw) used to report an empty parse even
+// though its reason was printed in the very tail we just read. The LAST
+// matching line wins — the tail is chronological, so the fatal throw is the one
+// nearest the exit.
 export function parseDaemonLogTail(logText: string): {
   errorCode?: string;
   missingModule?: string;
+  daemonError?: string;
 } {
-  const out: { errorCode?: string; missingModule?: string } = {};
+  const out: { errorCode?: string; missingModule?: string; daemonError?: string } = {};
   const errMatch = /\bERR_[A-Z0-9_]+/.exec(logText);
   if (errMatch) out.errorCode = errMatch[0];
   const modMatch =
     /Cannot find package '([^']+)'|Cannot find module '([^']+)'/.exec(logText);
   if (modMatch) out.missingModule = modMatch[1] ?? modMatch[2];
+  for (const line of logText.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (DAEMON_ERROR_LINE_RE.test(trimmed)) out.daemonError = trimmed;
+  }
   return out;
+}
+
+// Node's system-error triplet, read off the thrown object rather than its
+// message. `spawn UNKNOWN` (win32 CreateProcess refused) and friends carry the
+// only usable cause here; the message alone cannot separate them.
+export function readErrnoFields(error: unknown): {
+  code: string | null;
+  errno: number | null;
+  syscall: string | null;
+} {
+  if (error == null || typeof error !== "object") {
+    return { code: null, errno: null, syscall: null };
+  }
+  const e = error as NodeJS.ErrnoException;
+  return {
+    code: typeof e.code === "string" && e.code.length > 0 ? e.code : null,
+    errno: typeof e.errno === "number" ? e.errno : null,
+    syscall: typeof e.syscall === "string" && e.syscall.length > 0 ? e.syscall : null,
+  };
 }
 
 // apps/web/src/analytics/scrub.ts only rewrites paths containing an
@@ -360,12 +411,14 @@ export async function reportStartupFailure(
     const classification = classifyStartupFailure(args.error, args.isPathAccess);
     let errorCode: string | undefined;
     let missingModule: string | undefined;
+    let daemonError: string | undefined;
     if (classification.logPath) {
       const tail = await (deps.readLogTail ?? defaultReadLogTail)(classification.logPath);
       if (tail) {
         const parsed = parseDaemonLogTail(tail);
         errorCode = parsed.errorCode;
         missingModule = parsed.missingModule;
+        daemonError = parsed.daemonError;
       }
     }
     const rawMessage =
@@ -378,6 +431,21 @@ export async function reportStartupFailure(
       args.error instanceof Error && typeof args.error.stack === "string"
         ? args.error.stack
         : null;
+    const errorName = args.error instanceof Error ? args.error.name : "unknown";
+    const sys = readErrnoFields(args.error);
+    // A thrown error must never reach PostHog as error_message=null. The field
+    // black hole was an Error with BOTH an empty `.message` and no `.stack`:
+    // every free-form field went null and the event became uncountable residue
+    // indistinguishable from "no error at all". Name it instead, folding in the
+    // system code when there is one, so the leftover stays a measurable bucket.
+    const resolvedMessage =
+      rawMessage.length > 0
+        ? truncateForTelemetry(scrubUserPaths(rawMessage), ERROR_MESSAGE_MAX)
+        : args.error == null
+          ? null
+          : sys.code
+            ? `<${errorName} without message, code=${sys.code}>`
+            : `<${errorName} without message>`;
     // Probe the native module on THIS machine (existence + size). This is the
     // signal the `unknown` bucket (no daemon log to parse) otherwise lacks, and
     // it distinguishes "file missing" from "file present but unloadable".
@@ -394,16 +462,20 @@ export async function reportStartupFailure(
       failure_kind: classification.failureKind,
       exit_code: classification.exitCode,
       signal: classification.signal,
-      error_name: args.error instanceof Error ? args.error.name : "unknown",
+      error_name: errorName,
       error_code: errorCode ?? null,
       missing_module: missingModule ?? null,
+      daemon_error: daemonError
+        ? truncateForTelemetry(scrubUserPaths(daemonError), ERROR_MESSAGE_MAX)
+        : null,
+      sys_code: sys.code,
+      sys_errno: sys.errno,
+      sys_syscall: sys.syscall,
       // Scrub every path we send (message/stack/log/native path) so a user's
       // home dir never reaches PostHog; truncate free-form text to bound the
       // payload. These crash-scene fields are why the mac subset can't resolve
       // the module and what the Windows `unknown` bucket actually threw.
-      error_message: rawMessage
-        ? truncateForTelemetry(scrubUserPaths(rawMessage), ERROR_MESSAGE_MAX)
-        : null,
+      error_message: resolvedMessage,
       error_stack: rawStack
         ? truncateForTelemetry(scrubUserPaths(rawStack), ERROR_STACK_MAX)
         : null,

--- a/apps/packaged/src/startup-telemetry.ts
+++ b/apps/packaged/src/startup-telemetry.ts
@@ -200,6 +200,22 @@ export function parseDaemonLogTail(logText: string): {
   return out;
 }
 
+// Reduce `syscall` to the bare operation token.
+//
+// Node does NOT guarantee this is only the operation name: a failed
+// child_process.spawn sets it to the whole invocation —
+// `spawn /Users/alice/.../tool`, or `spawn C:\Users\Alice\...` on Windows.
+// Forwarding it verbatim would put the local username and install path into a
+// safety event that is retained even for opted-out users, while every other
+// path this module sends is scrubbed. The operation is the entire analytic
+// value here (the path is already available, scrubbed, via error_message), so
+// keep the first token and scrub what survives as a second line of defence.
+function normalizeSyscall(syscall: string): string | null {
+  const token = syscall.trim().split(/\s+/, 1)[0] ?? "";
+  if (!token) return null;
+  return scrubUserPaths(token).slice(0, 40);
+}
+
 // Node's system-error triplet, read off the thrown object rather than its
 // message. `spawn UNKNOWN` (win32 CreateProcess refused) and friends carry the
 // only usable cause here; the message alone cannot separate them.
@@ -213,9 +229,12 @@ export function readErrnoFields(error: unknown): {
   }
   const e = error as NodeJS.ErrnoException;
   return {
-    code: typeof e.code === "string" && e.code.length > 0 ? e.code : null,
+    code: typeof e.code === "string" && e.code.length > 0 ? e.code.slice(0, 40) : null,
     errno: typeof e.errno === "number" ? e.errno : null,
-    syscall: typeof e.syscall === "string" && e.syscall.length > 0 ? e.syscall : null,
+    syscall:
+      typeof e.syscall === "string" && e.syscall.length > 0
+        ? normalizeSyscall(e.syscall)
+        : null,
   };
 }
 

--- a/apps/packaged/tests/startup-telemetry.test.ts
+++ b/apps/packaged/tests/startup-telemetry.test.ts
@@ -26,6 +26,7 @@ import {
   parseDaemonLogTail,
   reportStartupFailure,
   resolveStartupDistinctId,
+  readErrnoFields,
   scrubUserPaths,
 } from '../src/startup-telemetry.js';
 
@@ -603,5 +604,65 @@ SqliteError: database disk image is malformed
     const props = (JSON.parse(init.body as string) as { properties: Record<string, unknown> })
       .properties;
     expect(props.daemon_error).toBe('SqliteError: database disk image is malformed');
+  });
+});
+
+// Privacy guard for the errno triplet (review of PR #5956).
+//
+// Node does not guarantee `syscall` is only the operation name: a failed
+// child_process.spawn sets it to the whole invocation. Verified against real
+// Node behaviour — spawning a missing binary yields
+// `syscall === 'spawn /Users/<name>/.../tool'`. Forwarding that verbatim would
+// put the local username and install path into an event that is retained even
+// for opted-out users, while every other path this module sends is scrubbed.
+describe('errno triplet privacy', () => {
+  it('reduces a path-bearing POSIX syscall to the operation token', () => {
+    const err = Object.assign(new Error('spawn /Users/alice/tools/vela ENOENT'), {
+      code: 'ENOENT',
+      errno: -2,
+      syscall: 'spawn /Users/alice/tools/vela',
+    });
+    expect(readErrnoFields(err).syscall).toBe('spawn');
+  });
+
+  it('reduces a path-bearing Windows syscall to the operation token', () => {
+    const err = Object.assign(new Error('spawn UNKNOWN'), {
+      syscall: 'spawn C:\\Users\\Alice Smith\\AppData\\Open Design\\vela.exe',
+    });
+    expect(readErrnoFields(err).syscall).toBe('spawn');
+  });
+
+  it('emits no username anywhere in the payload for a path-bearing spawn failure', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('ok'));
+    const err = Object.assign(new Error('spawn /Users/alice/tools/vela ENOENT'), {
+      code: 'ENOENT',
+      errno: -2,
+      syscall: 'spawn /Users/alice/tools/vela',
+    });
+    await reportStartupFailure(
+      {
+        error: err,
+        isPathAccess: false,
+        posthogKey: 'phc_test',
+        posthogHost: null,
+        distinctId: 'd',
+        appVersion: '0.15.1',
+        namespace: 'release-stable',
+        source: 'packaged',
+      },
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(init.body as string).not.toContain('alice');
+  });
+
+  it('classifies a spawn failure whose syscall carries a path', () => {
+    // The pre-normalization check compared the raw `syscall` to 'spawn', so a
+    // spawn error carrying a path fell through to `unknown` — the exact bucket
+    // this PR exists to drain.
+    const err = Object.assign(new Error('spawn /Users/alice/tools/vela ENOENT'), {
+      syscall: 'spawn /Users/alice/tools/vela',
+    });
+    expect(classifyStartupFailure(err, false).failureKind).toBe('spawn-failed');
   });
 });

--- a/apps/packaged/tests/startup-telemetry.test.ts
+++ b/apps/packaged/tests/startup-telemetry.test.ts
@@ -483,3 +483,125 @@ describe('reportStartupFailure', () => {
     expect(props.native_module_size).toBeNull();
   });
 });
+
+// Attribution guards. Every input below is a VERBATIM field payload pulled from
+// the `packaged_runtime_failed` stream (7d window, 2026-07-22) while triaging
+// the weekly alert. Each one is a failure the event carried enough evidence to
+// name and reported as an opaque `unknown` / `null` anyway:
+//
+//   - 62 devices: daemon exited(code=1) with the log tail successfully read, but
+//     `parseDaemonLogTail` only ever matched `ERR_*`, so any daemon that died of
+//     something else (SQLite corruption, EPERM, a plain throw) reported
+//     error_code=null AND missing_module=null — evidence in hand, nothing
+//     extracted.
+//   - 21 devices: Windows CreateProcess failures whose Error carries
+//     code/errno/syscall as own properties. The event sent `.message` only and
+//     dropped the triplet, so `spawn UNKNOWN` could not be separated from any
+//     other opaque failure.
+//   - 149 devices: an Error with an empty `.message` AND no `.stack`, which fell
+//     through to error_message=null + error_stack=null + failure_kind=unknown —
+//     a total black hole with no way to count or name the residue.
+describe('startup-failure attribution', () => {
+  // Verbatim tail shape of a daemon that threw without an ERR_ code.
+  const NON_ERR_CODE_LOG = `[open-design daemon] starting namespace=release-stable-win
+SqliteError: database disk image is malformed
+    at Database.prepare (node:sqlite:214:9)
+[open-design packaged] exited app=daemon pid=8123 code=1 signal=none`;
+
+  it('names the daemon crash when the log tail carries no ERR_ code', () => {
+    const parsed = parseDaemonLogTail(NON_ERR_CODE_LOG);
+    expect(parsed.errorCode).toBeUndefined();
+    // The reason is right there in the tail; it must not be dropped.
+    expect(parsed.daemonError).toBe('SqliteError: database disk image is malformed');
+  });
+
+  it('still prefers the ERR_ code when the log has one', () => {
+    expect(parseDaemonLogTail(ISSUE_4638_LOG).errorCode).toBe('ERR_MODULE_NOT_FOUND');
+  });
+
+  it('classifies a Windows spawn failure instead of burying it in unknown', () => {
+    expect(classifyStartupFailure(new Error('spawn UNKNOWN'), false).failureKind).toBe(
+      'spawn-failed',
+    );
+  });
+
+  it('sends the Node errno triplet off the error object', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('ok'));
+    // Exactly how Node shapes a failed CreateProcess on win32.
+    const spawnError = Object.assign(new Error('spawn UNKNOWN'), {
+      code: 'UNKNOWN',
+      errno: -4094,
+      syscall: 'spawn',
+    });
+    await reportStartupFailure(
+      {
+        error: spawnError,
+        isPathAccess: false,
+        posthogKey: 'phc_test',
+        posthogHost: null,
+        distinctId: 'd',
+        appVersion: '0.15.1',
+        namespace: 'release-stable-win',
+        source: 'packaged',
+      },
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const props = (JSON.parse(init.body as string) as { properties: Record<string, unknown> })
+      .properties;
+    expect(props.sys_code).toBe('UNKNOWN');
+    expect(props.sys_errno).toBe(-4094);
+    expect(props.sys_syscall).toBe('spawn');
+    expect(props.failure_kind).toBe('spawn-failed');
+  });
+
+  it('never reports a null error_message for an Error that carries none', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('ok'));
+    // The 149-device black hole: instanceof Error, name 'Error', no message, no
+    // stack. Whatever we send must be non-null so the residue stays countable.
+    const empty = new Error('');
+    delete (empty as { stack?: string }).stack;
+    await reportStartupFailure(
+      {
+        error: empty,
+        isPathAccess: false,
+        posthogKey: 'phc_test',
+        posthogHost: null,
+        distinctId: 'd',
+        appVersion: '0.15.1',
+        namespace: 'release-stable-win',
+        source: 'packaged',
+      },
+      { fetchImpl: fetchImpl as unknown as typeof fetch },
+    );
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const props = (JSON.parse(init.body as string) as { properties: Record<string, unknown> })
+      .properties;
+    expect(props.error_message).not.toBeNull();
+    expect(String(props.error_message)).toContain('Error');
+  });
+
+  it('surfaces the parsed daemon error on the emitted event', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('ok'));
+    await reportStartupFailure(
+      {
+        error: new Error(DAEMON_EXIT_MESSAGE),
+        isPathAccess: false,
+        posthogKey: 'phc_test',
+        posthogHost: null,
+        distinctId: 'd',
+        appVersion: '0.15.1',
+        namespace: 'release-stable',
+        source: 'packaged',
+      },
+      {
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        readLogTail: async () => NON_ERR_CODE_LOG,
+      },
+    );
+    const [, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    const props = (JSON.parse(init.body as string) as { properties: Record<string, unknown> })
+      .properties;
+    expect(props.daemon_error).toBe('SqliteError: database disk image is malformed');
+  });
+});

--- a/packages/contracts/src/analytics/events/result-events.ts
+++ b/packages/contracts/src/analytics/events/result-events.ts
@@ -773,6 +773,13 @@ export type PackagedStartupFailureKind =
   // the daemon cold start), as opposed to a sidecar that exited (`daemon-start` /
   // `web-start`). Split out so this bucket stops hiding inside `unknown`.
   | 'status-timeout'
+  // The sidecar process could not be created at all — Node rejected the spawn
+  // itself (win32 CreateProcess denied by AV quarantine, a locked/partially
+  // written exe, a missing interpreter). Distinct from a sidecar that started
+  // and then died (`daemon-start`) and from one that never reported ready
+  // (`status-timeout`); it used to land in `unknown` with the real cause sitting
+  // unread on the error's `code`/`errno`/`syscall`.
+  | 'spawn-failed'
   | 'unknown';
 
 // Event-specific props for `packaged_runtime_failed`. Emitted by the packaged
@@ -793,6 +800,21 @@ export interface PackagedRuntimeFailedProps {
   // The unresolved module when error_code is a module-resolution failure
   // (e.g. `better-sqlite3` for #4638).
   missing_module: string | null;
+  // The sidecar's own fatal line from the same log tail (e.g.
+  // `SqliteError: database disk image is malformed`), for the daemons that die
+  // of something the `ERR_*` match cannot name. Without it a daemon that threw
+  // any non-`ERR_` error reported error_code=null AND missing_module=null even
+  // though the reason was sitting in a log we had already read. Scrubbed and
+  // truncated like the other free-form fields.
+  daemon_error?: string | null;
+  // Node's system-error triplet read off the THROWN error object, as opposed to
+  // `error_code`, which is parsed out of the sidecar log. A failed spawn or
+  // socket op carries its real cause here (`UNKNOWN`/-4094/`spawn`,
+  // `ENOSPC`/-28/`write`) while `.message` stays generic, so dropping these
+  // collapsed distinct OS-level failures into one opaque bucket.
+  sys_code?: string | null;
+  sys_errno?: number | null;
+  sys_syscall?: string | null;
   // Crash-scene evidence added for the field-crash subset (#4638 follow-up): the
   // shipped build is verified-good, so these separate a machine-side "module
   // missing/unloadable" from a code path, and give the Windows `unknown` bucket


### PR DESCRIPTION
## Why

The `Total packaged_runtime_failed per week (production)` alert — the metric that is supposed to sit near zero — fired, so I went down the stream to see what was actually failing. It is a sustained plateau rather than a spike: ~100–160 distinct devices per day fail to bring up the packaged runtime, Windows-led, spread evenly across every shipped version (0.13.0 → 0.15.1), so it is not a version regression.

The blocker to acting on it was that the single largest bucket was `unknown` — 456 win32 devices in 7 days with no attributable cause. Digging into those events, the cause was usually *already in the payload we sent*, or in a file we had already read and then discarded. Three concrete gaps, all measured on a 7d window:

- **62 devices** exited with `code=1` and the daemon log tail read successfully, but `parseDaemonLogTail` only ever matched `ERR_*`. A daemon that died of anything else (SQLite corruption, `EPERM`, a plain throw) reported `error_code=null` **and** `missing_module=null` — with its reason printed in the tail we had just read.
- **21 devices** hit win32 `CreateProcess` failures. Node puts the real cause on the error's `code` / `errno` / `syscall`; the emitter sent `.message` only, so `spawn UNKNOWN` was indistinguishable from any other opaque failure.
- **149 devices** produced an `Error` with an empty `.message` *and* no `.stack`. Every free-form field serialized to `null`, leaving residue that could not even be counted apart from "no error at all".

This is the standing "everything must be attributable" push applied to this event: stop shipping failures we already have the evidence to name.

## What users will see

Nothing. This changes only how a startup failure is *described* in telemetry — no startup path, retry, budget, or recovery behavior is touched. Users who currently fail to launch still fail to launch; we can now say why.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — `packages/contracts`: `PackagedRuntimeFailedProps` gains four optional fields (`daemon_error`, `sys_code`, `sys_errno`, `sys_syscall`) and `PackagedStartupFailureKind` gains `spawn-failed`. Additive only; no existing field changes shape.
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

N/A — no UI surface.

## Bug fix verification

- Test path: `apps/packaged/tests/startup-telemetry.test.ts` → `describe('startup-failure attribution')`
- Red on `main`, green on this branch: **yes**. 5 of the 6 new tests failed against `origin/main` (the sixth pins that an existing `ERR_*` match still wins, and passes both ways); all 6 pass after the change.
- Every test input is a **verbatim field payload** pulled from the `packaged_runtime_failed` stream during the alert triage — the `spawn UNKNOWN` errno triplet, the message-less/stack-less `Error`, and a daemon tail whose fatal line carries no `ERR_` code.

## Validation

- `pnpm guard` — 86/86 pass
- `pnpm typecheck` — clean across the workspace (incl. the `@open-design/contracts` build)
- `pnpm --filter @open-design/packaged test` — **222/222 pass, 19/19 files**

  Note on the baseline: on a freshly-created worktree three `desktop-*.test.ts` files fail to *collect* because `@open-design/desktop` has not been built yet. I confirmed that against clean `origin/main` before touching anything, and `pnpm typecheck` (which builds that package) clears it. Not related to this change.

## Adjacent issues (not fixed here — out of this PR's scope)

Found while triaging, each deserving its own red spec and PR:

1. **mac `better-sqlite3` disappearing — ~98 devices/7d**, `ERR_MODULE_NOT_FOUND` with `native_module_present=false`, i.e. the `.node` is genuinely absent on the machine. This is the largest single per-device cause and a recurrence of the #4638 class.
2. **Windows status-timeout long tail — ~300 devices/7d.** The win32 budget is already widened to 90s (`sidecars.ts`), and these are the launches that still exceed it. Worth deciding between a prewarm pass for win32, an adaptive budget, or auto-retry on the recovery screen instead of forcing a manual relaunch.
3. **Reported `app_version` can outrun the running code.** Byte-identical `timed out waiting for sidecar status …` messages appear under both `unknown` and `status-timeout` within the same `0.15.1` tag — impossible from one binary, since that message has had a dedicated classifier branch since before the tag. The consistent reading is a Windows update that advanced the version string while `packaged-main.mjs` still ran the old code, which would quietly skew *every* version-segmented dashboard, not just this event.
