### PR TITLE
name the BYOK config gap and the AMR auth failure

### DIFF
--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -200,6 +200,10 @@ function isAgentConfigInvalidText(text: string): boolean {
     /\bdefault_permissions refers to undefined profile\b/i.test(text) ||
     /\bError loading config\.toml:[\s\S]*\bduplicate key\b/i.test(text) ||
     /\bBYOK OpenCode requires a provider, API key, and model for this run\b/i.test(text) ||
+    // Matches both the bare token and the gap-qualified codes
+    // (`BYOK_PROVIDER_REQUIRED.MODEL_DEFAULT`, …). The suffix is what makes the
+    // 702/day BYOK population breakable down in analytics; the bucket name must
+    // stay put so a widened code does not read as the regression disappearing.
     /\bBYOK_PROVIDER_REQUIRED\b/i.test(text) ||
     /\bEACCES: permission denied, mkdir\b[\s\S]*\.config[\\/]+opencode\b/i.test(text);
 }

--- a/apps/daemon/src/runtimes/byok-opencode.ts
+++ b/apps/daemon/src/runtimes/byok-opencode.ts
@@ -39,14 +39,45 @@ export function opencodeByokModelId(model: string | null | undefined): string | 
   return `${BYOK_OPENCODE_PROVIDER_ID}/${trimmed}`;
 }
 
-export function buildOpenCodeByokProviderConfig(
+/**
+ * Which guard rejected a BYOK OpenCode config.
+ *
+ * These six rejections used to be six bare `return null`s, and the caller
+ * turned all of them into one constant error string — so `agent_config_invalid`
+ * (703 runs / 277 users in 24h, 702 of them BYOK) could not be broken down at
+ * all, in analytics OR in Langfuse, because the recorded text was a constant.
+ */
+export type ByokOpenCodeConfigGap =
+  | 'provider_missing'
+  | 'protocol_unsupported'
+  | 'api_key_required'
+  | 'model_required'
+  | 'model_default'
+  | 'base_url_required'
+  | 'model_id_invalid';
+
+export type ByokOpenCodeConfigResolution =
+  | { ok: true; config: OpenCodeByokProviderConfig }
+  | { ok: false; gap: ByokOpenCodeConfigGap };
+
+/**
+ * The error code a rejected run is failed with. Kept as a `BYOK_*` token so
+ * `isAgentConfigInvalidText` still buckets the run as `agent_config_invalid`
+ * (the dashboards track that name) while `run_finished.error_code` now carries
+ * the specific gap.
+ */
+export function byokOpenCodeGapErrorCode(gap: ByokOpenCodeConfigGap): string {
+  return `BYOK_PROVIDER_REQUIRED.${gap.toUpperCase()}`;
+}
+
+export function resolveOpenCodeByokProviderConfig(
   provider: ByokChatProviderConfig | null | undefined,
   model: string | null | undefined,
-): OpenCodeByokProviderConfig | null {
-  if (!provider || typeof provider !== 'object') return null;
+): ByokOpenCodeConfigResolution {
+  if (!provider || typeof provider !== 'object') return { ok: false, gap: 'provider_missing' };
   const protocol = provider.protocol;
   if (!Object.prototype.hasOwnProperty.call(DEFAULT_BASE_URL_BY_PROTOCOL, protocol)) {
-    return null;
+    return { ok: false, gap: 'protocol_unsupported' };
   }
   const apiKey = typeof provider.apiKey === 'string' ? provider.apiKey.trim() : '';
   const rawModel = typeof model === 'string' ? model.trim() : '';
@@ -58,12 +89,15 @@ export function buildOpenCodeByokProviderConfig(
       : defaultBaseUrl,
   );
   const needsApiKey = requiresApiKey(provider, baseUrl);
-  if (needsApiKey && !apiKey) return null;
-  if (!rawModel || rawModel.toLowerCase() === 'default') return null;
-  if (!baseUrl) return null;
+  if (needsApiKey && !apiKey) return { ok: false, gap: 'api_key_required' };
+  // `default` is its own population: the user never picked a model rather than
+  // having cleared one, which is a different fix in the UI.
+  if (!rawModel) return { ok: false, gap: 'model_required' };
+  if (rawModel.toLowerCase() === 'default') return { ok: false, gap: 'model_default' };
+  if (!baseUrl) return { ok: false, gap: 'base_url_required' };
 
   const modelId = opencodeByokModelId(rawModel);
-  if (!modelId) return null;
+  if (!modelId) return { ok: false, gap: 'model_id_invalid' };
 
   const providerEntry = buildProviderEntry(
     protocol,
@@ -90,11 +124,29 @@ export function buildOpenCodeByokProviderConfig(
   };
 
   return {
-    providerId: BYOK_OPENCODE_PROVIDER_ID,
-    modelId,
-    env: needsApiKey ? { [BYOK_OPENCODE_API_KEY_ENV]: apiKey } : {},
-    config,
+    ok: true,
+    config: {
+      providerId: BYOK_OPENCODE_PROVIDER_ID,
+      modelId,
+      env: needsApiKey ? { [BYOK_OPENCODE_API_KEY_ENV]: apiKey } : {},
+      config,
+    },
   };
+}
+
+/**
+ * Config-or-null projection of {@link resolveOpenCodeByokProviderConfig}, kept
+ * so the existing `!== null` call sites are untouched. Deliberately a pure
+ * projection rather than a second implementation — two copies of these guards
+ * would drift, and the looser copy is exactly how an invalid config reaches the
+ * daemon in the first place.
+ */
+export function buildOpenCodeByokProviderConfig(
+  provider: ByokChatProviderConfig | null | undefined,
+  model: string | null | undefined,
+): OpenCodeByokProviderConfig | null {
+  const resolution = resolveOpenCodeByokProviderConfig(provider, model);
+  return resolution.ok ? resolution.config : null;
 }
 
 function normalizeProviderBaseUrl(

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -203,6 +203,8 @@ import { preparePromptFileForAgent } from './runtimes/prompt-file.js';
 import { TerminalControlSequenceStripper } from './runtimes/terminal-control.js';
 import {
   buildOpenCodeByokProviderConfig,
+  byokOpenCodeGapErrorCode,
+  resolveOpenCodeByokProviderConfig,
   BYOK_OPENCODE_PROVIDER_REQUIRED_MESSAGE,
 } from './runtimes/byok-opencode.js';
 import {
@@ -4320,17 +4322,25 @@ export async function startServer({
       );
     if (!def.bin)
       return design.runs.fail(run, 'AGENT_UNAVAILABLE', 'agent has no binary');
-    const byokOpenCodeProvider = def.id === 'byok-opencode'
-      ? buildOpenCodeByokProviderConfig(
+    const byokOpenCodeResolution = def.id === 'byok-opencode'
+      ? resolveOpenCodeByokProviderConfig(
           byokProvider,
           typeof model === 'string' ? model : null,
         )
       : null;
-    if (def.id === 'byok-opencode' && !byokOpenCodeProvider) {
+    const byokOpenCodeProvider = byokOpenCodeResolution?.ok
+      ? byokOpenCodeResolution.config
+      : null;
+    if (byokOpenCodeResolution && !byokOpenCodeResolution.ok) {
+      // Fail with the specific gap. The daemon rejects this config from six
+      // different guards, and reporting one constant for all of them is why
+      // `agent_config_invalid` — the largest engineering failure bucket — could
+      // not be broken down. The code flows to `run_finished.error_code` via
+      // deriveRunErrorCode, so the split is queryable without a contract change.
       return design.runs.fail(
         run,
-        'BYOK_PROVIDER_REQUIRED',
-        BYOK_OPENCODE_PROVIDER_REQUIRED_MESSAGE,
+        byokOpenCodeGapErrorCode(byokOpenCodeResolution.gap),
+        `${BYOK_OPENCODE_PROVIDER_REQUIRED_MESSAGE} (${byokOpenCodeResolution.gap})`,
       );
     }
     // Validate the checked-in `inactivityTimeoutMs` hint immediately

--- a/apps/daemon/tests/byok-opencode-config-gap.test.ts
+++ b/apps/daemon/tests/byok-opencode-config-gap.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildOpenCodeByokProviderConfig,
+  byokOpenCodeGapErrorCode,
+  resolveOpenCodeByokProviderConfig,
+} from '../src/runtimes/byok-opencode.js';
+import { classifyRunFailure } from '../src/run-failure-classification.js';
+
+/**
+ * `agent_config_invalid` is the top engineering failure in the daily report:
+ * 703 runs / 277 users in 24h (+140% over baseline), of which 702 are BYOK and
+ * 1 is CLI. Nothing tells us WHICH part of the config was rejected.
+ *
+ * The cause is structural, not missing instrumentation.
+ * `buildOpenCodeByokProviderConfig` rejects a config from six separate guards
+ * and returns a bare `null` from every one, and the caller
+ * (apps/daemon/src/server.ts) then fails the run with a fixed constant string.
+ * So the discriminating information is destroyed before anything is recorded —
+ * it is absent from `run_finished` AND from Langfuse, because the error text is
+ * a constant.
+ *
+ * These pin that every rejection reason survives as a distinct error code, and
+ * that widening the codes does not knock the run out of the
+ * `agent_config_invalid` bucket the dashboards already track.
+ */
+describe('resolveOpenCodeByokProviderConfig', () => {
+  const validProvider = {
+    protocol: 'openai' as const,
+    apiKey: 'sk-test',
+    baseUrl: 'https://api.openai.com/v1',
+  };
+
+  it('resolves a complete config', () => {
+    const r = resolveOpenCodeByokProviderConfig(validProvider, 'gpt-4o');
+    expect(r.ok).toBe(true);
+  });
+
+  it('names a missing provider', () => {
+    expect(resolveOpenCodeByokProviderConfig(null, 'gpt-4o')).toMatchObject({
+      ok: false,
+      gap: 'provider_missing',
+    });
+  });
+
+  it('names an unsupported protocol', () => {
+    expect(
+      resolveOpenCodeByokProviderConfig(
+        { ...validProvider, protocol: 'not-a-protocol' as never },
+        'gpt-4o',
+      ),
+    ).toMatchObject({ ok: false, gap: 'protocol_unsupported' });
+  });
+
+  it('names a missing API key separately from a missing model', () => {
+    expect(
+      resolveOpenCodeByokProviderConfig({ ...validProvider, apiKey: '' }, 'gpt-4o'),
+    ).toMatchObject({ ok: false, gap: 'api_key_required' });
+    expect(resolveOpenCodeByokProviderConfig(validProvider, '')).toMatchObject({
+      ok: false,
+      gap: 'model_required',
+    });
+  });
+
+  it('separates the literal "default" model from an absent one', () => {
+    // A distinct population: the user never picked a model, rather than having
+    // cleared one. They need different UI, so they must be countable apart.
+    expect(resolveOpenCodeByokProviderConfig(validProvider, 'default')).toMatchObject({
+      ok: false,
+      gap: 'model_default',
+    });
+  });
+
+  it('names a missing base URL (azure has no default to fall back on)', () => {
+    expect(
+      resolveOpenCodeByokProviderConfig(
+        { protocol: 'azure' as const, apiKey: 'k', baseUrl: '' },
+        'gpt-4o',
+      ),
+    ).toMatchObject({ ok: false, gap: 'base_url_required' });
+  });
+
+  it('keeps buildOpenCodeByokProviderConfig behaviour identical for callers', () => {
+    // The wrapper is what the existing `!== null` call sites use; it must stay
+    // a pure projection of the resolver so the two cannot drift.
+    expect(buildOpenCodeByokProviderConfig(null, 'gpt-4o')).toBeNull();
+    expect(buildOpenCodeByokProviderConfig(validProvider, '')).toBeNull();
+    expect(buildOpenCodeByokProviderConfig(validProvider, 'gpt-4o')).not.toBeNull();
+  });
+});
+
+describe('byokOpenCodeGapErrorCode', () => {
+  it('gives every gap its own code', () => {
+    const codes = (
+      [
+        'provider_missing',
+        'protocol_unsupported',
+        'api_key_required',
+        'model_required',
+        'model_default',
+        'base_url_required',
+        'model_id_invalid',
+      ] as const
+    ).map(byokOpenCodeGapErrorCode);
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+
+  it('keeps every code inside the agent_config_invalid bucket', () => {
+    // Widening the codes must not silently reclassify these runs: the daily
+    // report tracks `agent_config_invalid`, and a run that fell out of it would
+    // look like the regression had been fixed when it had only been renamed.
+    for (const gap of [
+      'provider_missing',
+      'protocol_unsupported',
+      'api_key_required',
+      'model_required',
+      'model_default',
+      'base_url_required',
+      'model_id_invalid',
+    ] as const) {
+      const code = byokOpenCodeGapErrorCode(gap);
+      const classified = classifyRunFailure({
+        result: 'failed',
+        agentId: 'byok-opencode',
+        errorCode: code,
+        status: { status: 'failed', errorCode: code, error: code },
+        events: [],
+      });
+      expect(classified?.failure_detail, `gap ${gap} (${code})`).toBe('agent_config_invalid');
+    }
+  });
+});

--- a/apps/web/src/analytics/amr-auth.ts
+++ b/apps/web/src/analytics/amr-auth.ts
@@ -69,11 +69,32 @@ export function beginAmrAuthTracking(
 // capture below — and before the single-flight gate, since registration
 // is idempotent — so the success row itself carries `user_id` instead of
 // waiting for React to commit the status and App.tsx to re-register it.
+// Bound the stderr we forward. This is CLI/daemon failure text, so it is build
+// and OS strings rather than anything the user typed, but it can still carry a
+// home directory — scrub paths and cap the length before it leaves the client.
+const AMR_ERROR_DETAIL_MAX = 300;
+
+export function amrAuthErrorDetail(detail: string | null | undefined): string | undefined {
+  const raw = typeof detail === 'string' ? detail.trim() : '';
+  if (!raw) return undefined;
+  const scrubbed = raw
+    .replace(/([A-Za-z]:[\\/]Users[\\/])[^\\/\r\n]+/g, '$1<redacted>')
+    .replace(/\/(Users|home)\/[^/\s]+/g, '/$1/<redacted>');
+  return scrubbed.length > AMR_ERROR_DETAIL_MAX
+    ? `${scrubbed.slice(0, AMR_ERROR_DETAIL_MAX)}…`
+    : scrubbed;
+}
+
 export function resolveAmrAuthTracking(
   track: Track,
   result: AmrAuthResultProps['result'],
   errorCode?: string,
-  options?: { signedInUserId?: string | null },
+  options?: {
+    signedInUserId?: string | null;
+    // The daemon's HTTP status and failure text for a refused login start.
+    errorStatus?: number | null;
+    errorDetail?: string | null;
+  },
 ): void {
   if (options && 'signedInUserId' in options) {
     setAnalyticsUserId(options.signedInUserId ?? null);
@@ -87,6 +108,13 @@ export function resolveAmrAuthTracking(
     area: 'amr_auth',
     result,
     ...(errorCode ? { error_code: errorCode } : {}),
+    ...(typeof options?.errorStatus === 'number'
+      ? { error_status: options.errorStatus }
+      : {}),
+    ...(() => {
+      const detail = amrAuthErrorDetail(options?.errorDetail);
+      return detail ? { error_detail: detail } : {};
+    })(),
     duration_ms: Math.max(0, Date.now() - attempt.startedAt),
     ...(attempt.entryId ? { entry_id: attempt.entryId } : {}),
     ...(attempt.sourceDetail ? { source_detail: attempt.sourceDetail } : {}),

--- a/apps/web/src/analytics/amr-auth.ts
+++ b/apps/web/src/analytics/amr-auth.ts
@@ -92,8 +92,11 @@ export function resolveAmrAuthTracking(
   options?: {
     signedInUserId?: string | null;
     // The daemon's HTTP status and failure text for a refused login start.
-    errorStatus?: number | null;
-    errorDetail?: string | null;
+    // `StartVelaLoginResult.error` is an optional `string`, so the call sites
+    // hand this an explicit `undefined`; the type matches `amrAuthErrorDetail`'s
+    // own input rather than forcing every caller to strip the key first.
+    errorStatus?: number | null | undefined;
+    errorDetail?: string | null | undefined;
   },
 ): void {
   if (options && 'signedInUserId' in options) {

--- a/apps/web/src/components/AmrLoginPill.tsx
+++ b/apps/web/src/components/AmrLoginPill.tsx
@@ -476,7 +476,10 @@ export function AmrLoginPill({
       });
       const result = await startVelaLogin(attribution, odDeviceId);
       if (!result.ok && !result.alreadyRunning) {
-        resolveAmrAuthTracking(analytics.track, 'failed', 'spawn_failed');
+        resolveAmrAuthTracking(analytics.track, 'failed', 'spawn_failed', {
+          errorStatus: result.status,
+          errorDetail: result.error,
+        });
         loginStartedAtRef.current = null;
         loginPendingRef.current = false;
         setPending(null);

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -2187,7 +2187,10 @@ function OnboardingView({
         return;
       }
       if (!loginResult.ok && !loginResult.alreadyRunning) {
-        resolveAmrAuthTracking(analytics.track, 'failed', 'spawn_failed');
+        resolveAmrAuthTracking(analytics.track, 'failed', 'spawn_failed', {
+          errorStatus: loginResult.status,
+          errorDetail: loginResult.error,
+        });
         setAmrLoginError(loginResult.error || t('settings.amrLoginErrorCompact'));
         return;
       }

--- a/apps/web/src/components/InlineModelSwitcher.tsx
+++ b/apps/web/src/components/InlineModelSwitcher.tsx
@@ -286,7 +286,10 @@ export function InlineModelSwitcher({
     });
     const result = await startVelaLogin(attribution, odDeviceId);
     if (!result.ok && !result.alreadyRunning) {
-      resolveAmrAuthTracking(analytics.track, 'failed', 'spawn_failed');
+      resolveAmrAuthTracking(analytics.track, 'failed', 'spawn_failed', {
+        errorStatus: result.status,
+        errorDetail: result.error,
+      });
       amrLoginStartedAtRef.current = null;
       setAmrLoginPending(false);
       setAmrLoginError(result.error || t('settings.amrLoginErrorCompact'));

--- a/apps/web/tests/analytics/amr-auth-detail.test.ts
+++ b/apps/web/tests/analytics/amr-auth-detail.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  amrAuthErrorDetail,
+  beginAmrAuthTracking,
+  resolveAmrAuthTracking,
+} from '../../src/analytics/amr-auth';
+
+/**
+ * `amr_auth_result` reports 615 failures across 395 devices in 24h (+65%),
+ * heavily concentrated in 0.15.1 — and carries only three fixed error_code
+ * tokens. `spawn_failed` in particular covers every way the login start can be
+ * refused: a missing vela binary, an unregistered runtime def, and the
+ * upstream's own `502: Invalid IP address: undefined` all report the same
+ * token, even though the daemon's HTTP status and the CLI's stderr are live
+ * variables at the call site.
+ *
+ * These pin that the detail survives, and that it is scrubbed on the way out —
+ * the text is process stderr, which can carry a home directory.
+ */
+describe('amrAuthErrorDetail', () => {
+  it('drops empty detail rather than sending a blank field', () => {
+    expect(amrAuthErrorDetail(undefined)).toBeUndefined();
+    expect(amrAuthErrorDetail(null)).toBeUndefined();
+    expect(amrAuthErrorDetail('   ')).toBeUndefined();
+  });
+
+  it('keeps the upstream failure text that distinguishes the causes', () => {
+    expect(amrAuthErrorDetail('502: Invalid IP address: undefined')).toBe(
+      '502: Invalid IP address: undefined',
+    );
+    expect(amrAuthErrorDetail('vela binary not found; install vela or configure VELA_BIN')).toBe(
+      'vela binary not found; install vela or configure VELA_BIN',
+    );
+  });
+
+  it('scrubs the user home directory out of CLI stderr', () => {
+    expect(amrAuthErrorDetail('EACCES: permission denied, open /Users/lefarcen/.amr/config.json'))
+      .toBe('EACCES: permission denied, open /Users/<redacted>/.amr/config.json');
+    expect(amrAuthErrorDetail('cannot write C:\\Users\\John Doe\\AppData\\vela.log')).toBe(
+      'cannot write C:\\Users\\<redacted>\\AppData\\vela.log',
+    );
+  });
+
+  it('caps a runaway stderr dump', () => {
+    const detail = amrAuthErrorDetail('x'.repeat(5000));
+    expect(detail!.length).toBeLessThanOrEqual(301);
+  });
+});
+
+describe('resolveAmrAuthTracking failure detail', () => {
+  it('attaches the daemon status and stderr to a refused login start', () => {
+    const track = vi.fn();
+    beginAmrAuthTracking(null);
+    resolveAmrAuthTracking(track, 'failed', 'spawn_failed', {
+      errorStatus: 500,
+      errorDetail: 'vela login exited before authentication completed (code 1, signal null)',
+    });
+
+    expect(track).toHaveBeenCalledTimes(1);
+    const props = track.mock.calls[0]![1] as Record<string, unknown>;
+    expect(props.error_code).toBe('spawn_failed');
+    expect(props.error_status).toBe(500);
+    expect(props.error_detail).toContain('exited before authentication completed');
+  });
+
+  it('records a status of 0 — a request that never got a response is not the same as 500', () => {
+    const track = vi.fn();
+    beginAmrAuthTracking(null);
+    resolveAmrAuthTracking(track, 'failed', 'spawn_failed', {
+      errorStatus: 0,
+      errorDetail: 'Failed to fetch',
+    });
+
+    const props = track.mock.calls[0]![1] as Record<string, unknown>;
+    expect(props.error_status).toBe(0);
+  });
+
+  it('omits the fields entirely when there is nothing to report', () => {
+    const track = vi.fn();
+    beginAmrAuthTracking(null);
+    resolveAmrAuthTracking(track, 'cancelled');
+
+    const props = track.mock.calls[0]![1] as Record<string, unknown>;
+    expect('error_status' in props).toBe(false);
+    expect('error_detail' in props).toBe(false);
+  });
+});

--- a/packages/contracts/src/analytics/events/ui-click.ts
+++ b/packages/contracts/src/analytics/events/ui-click.ts
@@ -954,6 +954,21 @@ export interface AmrAuthResultProps {
   area: 'amr_auth';
   result: 'success' | 'failed' | 'cancelled' | 'timeout';
   error_code?: string;
+  // Why the attempt failed, beyond the three fixed `error_code` tokens.
+  //
+  // `spawn_failed` alone covered every way `POST /api/integrations/vela/login`
+  // can refuse — a missing vela binary, an unregistered AMR runtime def, and
+  // the upstream's own `502: Invalid IP address: undefined` all collapsed into
+  // one token, while the HTTP status and the CLI's stderr were live variables
+  // at the call site. At 615 failures / 395 devices in 24h that is the whole
+  // population, undiagnosable.
+  //
+  // `error_status` is the daemon's HTTP status (0 when the request never got a
+  // response). `error_detail` is the daemon/CLI failure text, scrubbed of file
+  // paths and length-capped at the emission site — it is process stderr, not
+  // user content.
+  error_status?: number;
+  error_detail?: string;
   duration_ms: number;
   // Attribution carried over from the amr_entry click that started this
   // attempt; absent when login was started without a recorded entry.


### PR DESCRIPTION
## Why

The two biggest rows in today's reliability report describe a failure and identify nothing. In both cases the reason is a live variable at the emission site that is discarded before anything is recorded — so no amount of dashboard work can recover it.

| Report row | Volume (24h) | What the event actually says |
|---|---|---|
| `agent_config_invalid` | **703 runs / 277 users, +140%** — 702 BYOK, 1 CLI | one constant code |
| `amr_auth_result` failures | **615 / ~395 devices, +65%**, concentrated in 0.15.1 | one of three fixed tokens |

I confirmed both against production before writing anything:

```
agent_config_invalid, last 24h, by error_code:
  BYOK_PROVIDER_REQUIRED   686 events / 265 devices
  AGENT_EXECUTION_FAILED     6 events /   2 devices
```

686 of 692 are the same constant string.

### Why the reason cannot be recovered today

`buildOpenCodeByokProviderConfig` rejects a config from **six separate guards** and returns a bare `null` from every one. The caller (`server.ts`) then fails the run with a fixed constant message. So the discriminating information is destroyed before it is recorded — it is absent from `run_finished`, and absent from **Langfuse too**, because the recorded text is a constant rather than a thrown message. This is the one case where the usual "check the trace" fallback does not work.

For AMR, `spawn_failed` covers a missing vela binary, an unregistered runtime def, and the upstream's own `502: Invalid IP address: undefined` — while `result.status` and `result.error` (the CLI's own stderr, surfaced by the daemon route) are sitting in scope at all three call sites and are only ever rendered into UI state.

## What users will see

Nothing. No validation becomes stricter or looser, no request behavior changes, no copy changes. A config that was accepted is still accepted; one that was rejected is still rejected, with the same HTTP status and the same user-facing message. Only the recorded reason changes.

## What changed

- **`byok-opencode.ts`** — `resolveOpenCodeByokProviderConfig` returns a named `ByokOpenCodeConfigGap` (`provider_missing`, `protocol_unsupported`, `api_key_required`, `model_required`, `model_default`, `base_url_required`, `model_id_invalid`). `buildOpenCodeByokProviderConfig` keeps its exact signature and becomes a **pure projection** of the resolver — not a second copy of the guards — so the existing `!== null` call sites are untouched and the two cannot drift.
- **`server.ts`** — fails with the gap-specific code, which reaches `run_finished.error_code` through `deriveRunErrorCode`. No contract change: `error_code` is already free text on `RunFinishedProps`.
- **`ui-click.ts` / `amr-auth.ts` / 3 call sites** — `AmrAuthResultProps` gains `error_status` and `error_detail`; the three `spawn_failed` sites pass the daemon's HTTP status and failure text. The detail is scrubbed of home directories and capped at 300 chars before it leaves the client.

### One detail worth a reviewer's eye

The gap is appended with a **`.`**, not `_`. The classifier matches `/\bBYOK_PROVIDER_REQUIRED\b/`, and `_` is a word character — so `BYOK_PROVIDER_REQUIRED_MODEL` would **fail that boundary** and silently drop these 686/day out of the `agent_config_invalid` bucket, which would read as the regression having disappeared. I verified both forms in a REPL before choosing, and a test pins every gap code back to the bucket.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — additive only: two optional fields on `AmrAuthResultProps`. The daemon's `error_code` value becomes more specific on a path whose code has no consumer (verified: zero references to `BYOK_PROVIDER_REQUIRED` anywhere in `apps/web` or `packages/`).
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

N/A — no UI surface.

## Bug fix verification

- Test paths: `apps/daemon/tests/byok-opencode-config-gap.test.ts` (new), `apps/web/tests/analytics/amr-auth-detail.test.ts` (new).
- Red before / green after: **yes**.
- The daemon spec asserts each of the six guards resolves to its own gap, that the wrapper stays behaviourally identical for existing callers, and that **every** gap code still classifies as `agent_config_invalid`.

## Validation

- `pnpm typecheck` — clean across the workspace
- `pnpm --filter @open-design/daemon test` (new spec) — 9/9
- `pnpm --filter @open-design/web test` — 4708 pass, 7 skipped, 437/437 files
- Full `apps/daemon` suite run and **diffed against clean `origin/main`**: `chat-route`, `connection-test` and `connectors-routes` fail identically on both, so they are pre-existing. In particular `passes keyless BYOK provider config without auth fields to OpenCode` reads like this change but fails inside `buildProviderEntry` (`@ai-sdk/openai` vs `@ai-sdk/openai-compatible`), which this PR does not touch.

## Open question this PR is designed to answer

`hasCompleteByokOpenCodeConfig` already rejects an incomplete config with a 400 at three points in `routes/runs.ts`, using the **same** builder — and those paths never create a run, so they cannot produce these 703 `run_finished` events. Something is letting a config pass validation at request time and fail it at execution time. I deliberately did not guess at the mechanism: once the gap codes ship, *which* guard fires will point straight at it.
