### PR TITLE
fix packaged updates after payload cwd cleanup

### DIFF
--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -195,6 +195,8 @@ type SpawnInstallerHelper = (
 
 export type DeferredInstallerLaunchInput = {
   appPid: number;
+  /** Stable namespace root inherited by the installer helper process. */
+  cwd: string;
   installerPath: string;
   root: string;
   timeoutMs: number;
@@ -1806,7 +1808,7 @@ async function launchMacInstallerAfterQuit(
     const child = deps.spawnDetached(
       "/bin/sh",
       [scriptPath, input.appPid.toString(), input.installerPath, timeoutSeconds],
-      { detached: true, stdio: "ignore", windowsHide: true },
+      { cwd: input.cwd, detached: true, stdio: "ignore", windowsHide: true },
     );
     child.unref();
     return "";
@@ -1851,7 +1853,7 @@ async function launchWindowsInstallerAfterQuit(
         "-LogPath",
         logPath,
       ],
-      { detached: true, stdio: "ignore", windowsHide: true },
+      { cwd: input.cwd, detached: true, stdio: "ignore", windowsHide: true },
     );
     child.unref();
     return "";
@@ -3226,6 +3228,7 @@ export function createDesktopUpdater(
     if (config.platform !== "darwin" && config.platform !== "win32") return await openPath(resolvedDownload);
     return await launchInstallerAfterQuit({
       appPid: processPid,
+      cwd: config.runtimeBase,
       installerPath: resolvedDownload,
       root: updateRoot,
       timeoutMs: config.platform === "win32" ? WINDOWS_DEFERRED_INSTALLER_TIMEOUT_MS : MAC_DEFERRED_INSTALLER_TIMEOUT_MS,

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -155,6 +155,7 @@ export type DesktopUpdaterConfig = {
   namespace?: string;
   openDryRun: boolean;
   platform: string;
+  runtimeBase: string;
   source: SidecarSource;
 };
 
@@ -189,7 +190,7 @@ type LauncherPayloadCleanupFailure = {
 type SpawnInstallerHelper = (
   command: string,
   args: string[],
-  options: { detached?: true; stdio: "ignore"; windowsHide: true },
+  options: { cwd?: string; detached?: true; stdio: "ignore"; windowsHide: true },
 ) => DetachedProcess;
 
 export type DeferredInstallerLaunchInput = {
@@ -201,6 +202,8 @@ export type DeferredInstallerLaunchInput = {
 
 export type DeferredAppLaunchInput = {
   appPid: number;
+  /** Stable namespace root inherited by the next payload process. */
+  cwd: string;
   launchPath: string;
   root: string;
   timeoutMs: number;
@@ -416,7 +419,7 @@ export function resolveDesktopUpdaterConfig(input: DesktopUpdaterConfigInput): D
   const mode = normalizeMode(env[DESKTOP_UPDATE_ENV.MODE], input.mode ?? DESKTOP_UPDATE_MODES.PACKAGE_LAUNCHER);
   const defaultEnabled = input.source === SIDECAR_SOURCES.PACKAGED;
   const enabled = isTruthyEnv(env[DESKTOP_UPDATE_ENV.ENABLED]) ?? defaultEnabled;
-  const runtimeBase = input.runtimeBase == null ? process.cwd() : input.runtimeBase;
+  const runtimeBase = resolve(input.runtimeBase == null ? process.cwd() : input.runtimeBase);
   const downloadRoot = normalizeDownloadRoot(
     env[DESKTOP_UPDATE_ENV.DOWNLOAD_ROOT] ??
       input.downloadRoot ??
@@ -474,6 +477,7 @@ export function resolveDesktopUpdaterConfig(input: DesktopUpdaterConfigInput): D
     ...(namespace == null ? {} : { namespace }),
     openDryRun: isTruthyEnv(env[DESKTOP_UPDATE_ENV.OPEN_DRY_RUN]) ?? false,
     platform: env[DESKTOP_UPDATE_ENV.PLATFORM] ?? input.platform ?? process.platform,
+    runtimeBase,
     source: input.source,
   };
 }
@@ -1864,7 +1868,7 @@ async function launchPayloadAppAfterQuit(
     const child = deps.spawnDetached(
       input.launchPath,
       buildLauncherAfterQuitArgs({ targetPid: input.appPid, timeoutMs: input.timeoutMs }),
-      { detached: true, stdio: "ignore", windowsHide: true },
+      { cwd: input.cwd, detached: true, stdio: "ignore", windowsHide: true },
     );
     await new Promise<void>((resolveSpawn, rejectSpawn) => {
       child.once("spawn", () => resolveSpawn());
@@ -3245,6 +3249,7 @@ export function createDesktopUpdater(
     }
     const result = await launchAppAfterQuit({
       appPid: processPid,
+      cwd: config.runtimeBase,
       launchPath,
       root: updateRoot,
       timeoutMs: config.platform === "win32" ? WINDOWS_DEFERRED_INSTALLER_TIMEOUT_MS : MAC_DEFERRED_INSTALLER_TIMEOUT_MS,

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -1575,6 +1575,7 @@ describe("desktop updater", () => {
     const launcherRuntimePath = join(root, "launcher", "runtime.json");
     const launcherRoot = root;
     const launcherLaunchPath = join(root, "installed", "Open Design.exe");
+    const runtimeBase = join(root, "runtime");
     const spawned: Array<{ args: string[]; command: string; options: unknown }> = [];
     const unref = vi.fn();
     const child = {
@@ -1612,6 +1613,7 @@ describe("desktop updater", () => {
         launcherLaunchPath,
         launcherRuntimePath,
         namespace: "release-beta-win",
+        runtimeBase,
         source: SIDECAR_SOURCES.PACKAGED,
       }, {
         extractLauncherPayloadArchive: async ({ destinationRoot }) => {
@@ -1663,7 +1665,7 @@ describe("desktop updater", () => {
       expect(spawned).toHaveLength(1);
       expect(unref).toHaveBeenCalledTimes(1);
       expect(spawned[0]?.command).toBe(payloadLaunchPath);
-      expect(spawned[0]?.options).toEqual({ detached: true, stdio: "ignore", windowsHide: true });
+      expect(spawned[0]?.options).toEqual({ cwd: runtimeBase, detached: true, stdio: "ignore", windowsHide: true });
       const args = spawned[0]?.args ?? [];
       expect(args).toEqual(expect.arrayContaining([
         LAUNCHER_AFTER_QUIT_FLAG,

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -1922,7 +1922,8 @@ describe("desktop updater", () => {
     const root = makeRoot();
     const observationRoot = join(root, "observations", "installer");
     const fixture = await createUpdaterFixture();
-    const launches: Array<{ appPid: number; installerPath: string; root: string; timeoutMs: number }> = [];
+    const launches: Array<{ appPid: number; cwd: string; installerPath: string; root: string; timeoutMs: number }> = [];
+    const runtimeBase = join(root, "runtime");
     try {
       const updater = createDesktopUpdater(
         {
@@ -1934,6 +1935,7 @@ describe("desktop updater", () => {
           },
           installerObservationRoot: observationRoot,
           namespace: "release",
+          runtimeBase,
           source: SIDECAR_SOURCES.TOOLS_PACK,
         },
         { launchInstallerAfterQuit: async (input) => {
@@ -1951,6 +1953,7 @@ describe("desktop updater", () => {
       expect(installed.installResult?.path).toBe(checked.downloadPath);
       expect(launches).toEqual([{
         appPid: process.pid,
+        cwd: runtimeBase,
         installerPath: checked.downloadPath,
         root: updateRoot,
         timeoutMs: 10 * 60 * 1000,
@@ -2012,7 +2015,8 @@ describe("desktop updater", () => {
   it("writes and detaches the mac helper script that opens the installer after quit", async () => {
     const root = makeRoot();
     const fixture = await createUpdaterFixture();
-    const spawned: Array<{ args: string[]; command: string }> = [];
+    const runtimeBase = join(root, "runtime");
+    const spawned: Array<{ args: string[]; command: string; options: unknown }> = [];
     try {
       const updater = createDesktopUpdater(
         {
@@ -2022,12 +2026,13 @@ describe("desktop updater", () => {
             ...updaterEnv(fixture.metadataUrl),
             [DESKTOP_UPDATE_ENV.OPEN_DRY_RUN]: "0",
           },
+          runtimeBase,
           source: SIDECAR_SOURCES.TOOLS_PACK,
         },
         {
           processPid: 4242,
-          spawnDetached: (command, args) => {
-            spawned.push({ args, command });
+          spawnDetached: (command, args, options) => {
+            spawned.push({ args, command, options });
             return { unref: vi.fn() } as never;
           },
         },
@@ -2039,6 +2044,7 @@ describe("desktop updater", () => {
       expect(installed.installResult?.path).toBe(checked.downloadPath);
       expect(spawned).toHaveLength(1);
       expect(spawned[0]?.command).toBe("/bin/sh");
+      expect(spawned[0]?.options).toEqual({ cwd: runtimeBase, detached: true, stdio: "ignore", windowsHide: true });
       const [scriptPath, pidArg, installerArg, timeoutArg] = spawned[0]?.args ?? [];
       expect(scriptPath).toEqual(expect.stringContaining(join(root, "helpers", "open-installer-after-quit-")));
       expect(pidArg).toBe("4242");
@@ -2058,6 +2064,7 @@ describe("desktop updater", () => {
     const root = makeRoot();
     const fixture = await createUpdaterFixture({ platform: "win" });
     const openPath = vi.fn(async () => "openPath should not run for Windows deferred installer launch");
+    const runtimeBase = join(root, "runtime");
     const unref = vi.fn();
     const spawned: Array<{ args: string[]; command: string; options: unknown }> = [];
     try {
@@ -2069,6 +2076,7 @@ describe("desktop updater", () => {
             ...updaterEnv(fixture.metadataUrl, "win32"),
             [DESKTOP_UPDATE_ENV.OPEN_DRY_RUN]: "0",
           },
+          runtimeBase,
           source: SIDECAR_SOURCES.TOOLS_PACK,
         },
         {
@@ -2089,7 +2097,7 @@ describe("desktop updater", () => {
       expect(spawned).toHaveLength(1);
       expect(unref).toHaveBeenCalledTimes(1);
       expect(spawned[0]?.command).toEqual(expect.stringContaining(join("System32", "WindowsPowerShell", "v1.0", "powershell.exe")));
-      expect(spawned[0]?.options).toEqual({ detached: true, stdio: "ignore", windowsHide: true });
+      expect(spawned[0]?.options).toEqual({ cwd: runtimeBase, detached: true, stdio: "ignore", windowsHide: true });
       const args = spawned[0]?.args ?? [];
       const launcherPath = args.at(args.indexOf("-File") + 1);
       const scriptPath = args.at(args.indexOf("-HelperPath") + 1);

--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -36,6 +36,7 @@ import {
   applyPackagedElectronPathOverrides,
   claimPackagedSingleInstanceLock,
   ensurePackagedNamespacePaths,
+  stabilizePackagedWorkingDirectory,
 } from "./launch.js";
 import {
   attachPackagedDesktopProcessLogging,
@@ -169,6 +170,7 @@ async function main(): Promise<void> {
   };
 
   await ensurePackagedNamespacePaths(paths);
+  stabilizePackagedWorkingDirectory(paths);
   const downloadAttribution = await discoverPackagedDownloadAttribution(paths, console).catch((error: unknown) => {
     console.warn("[attribution] failed to discover packaged download attribution", error);
     return null;

--- a/apps/packaged/src/launch.ts
+++ b/apps/packaged/src/launch.ts
@@ -106,6 +106,15 @@ export async function ensurePackagedNamespacePaths(
   ]);
 }
 
+export function stabilizePackagedWorkingDirectory(
+  paths: Pick<PackagedNamespacePaths, "runtimeRoot">,
+  chdir: (directory: string) => void = (directory) => process.chdir(directory),
+): void {
+  // Payload launches can inherit a cwd inside an older version directory. Move
+  // to the namespace-scoped root before release cleanup makes that cwd invalid.
+  chdir(paths.runtimeRoot);
+}
+
 export function applyPackagedElectronPathOverrides(
   paths: PackagedNamespacePaths,
 ): void {

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -511,12 +511,11 @@ async function spawnSidecarChild(options: {
   const child = spawn(
     command,
     [options.entryPath, ...createProcessStampArgs(stamp, OPEN_DESIGN_SIDECAR_CONTRACT)],
-    {
-      cwd: process.cwd(),
+    createPackagedSidecarSpawnOptions({
       env: childEnv,
-      stdio: ["ignore", logHandle.fd, logHandle.fd],
-      windowsHide: true,
-    },
+      logFd: logHandle.fd,
+      paths: options.paths,
+    }),
   );
 
   await new Promise<void>((resolveSpawn, rejectSpawn) => {
@@ -525,6 +524,24 @@ async function spawnSidecarChild(options: {
   });
 
   return { app: options.app, child, ipcPath, logHandle, logPath };
+}
+
+export function createPackagedSidecarSpawnOptions(input: {
+  env: NodeJS.ProcessEnv;
+  logFd: number;
+  paths: Pick<PackagedNamespacePaths, "runtimeRoot">;
+}): {
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  stdio: ["ignore", number, number];
+  windowsHide: true;
+} {
+  return {
+    cwd: input.paths.runtimeRoot,
+    env: input.env,
+    stdio: ["ignore", input.logFd, input.logFd],
+    windowsHide: true,
+  };
 }
 
 async function closeManagedChild(child: ManagedSidecarChild): Promise<void> {

--- a/apps/packaged/tests/launch.test.ts
+++ b/apps/packaged/tests/launch.test.ts
@@ -11,8 +11,28 @@ vi.mock("electron", () => ({
 import { PackagedPathAccessError } from "../src/errors.js";
 import {
   claimPackagedSingleInstanceLock,
+  stabilizePackagedWorkingDirectory,
   verifyPackagedDataRootWritable,
 } from "../src/launch.js";
+
+describe("stabilizePackagedWorkingDirectory", () => {
+  it("switches to the namespace runtime root without reading the inherited cwd", () => {
+    const runtimeRoot = join(tmpdir(), "od-packaged-runtime");
+    const chdir = vi.fn();
+    const cwd = vi.spyOn(process, "cwd").mockImplementation(() => {
+      throw new Error("uv_cwd");
+    });
+
+    try {
+      stabilizePackagedWorkingDirectory({ runtimeRoot }, chdir);
+
+      expect(chdir).toHaveBeenCalledWith(runtimeRoot);
+      expect(cwd).not.toHaveBeenCalled();
+    } finally {
+      cwd.mockRestore();
+    }
+  });
+});
 
 describe("verifyPackagedDataRootWritable", () => {
   it("accepts a writable dataRoot", async () => {

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -19,13 +19,14 @@ import { EventEmitter } from 'node:events';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { delimiter, dirname, join, posix } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { createJsonIpcServer, resolveAppIpcPath } from '@open-design/sidecar';
 import { APP_KEYS, OPEN_DESIGN_SIDECAR_CONTRACT } from '@open-design/sidecar-proto';
 
 import {
   buildPackagedDaemonSpawnEnv,
+  createPackagedSidecarSpawnOptions,
   resolveDaemonStatusTimeoutMs,
   resolvePackagedChildBaseEnv,
   resolvePackagedElectronNodeCommand,
@@ -351,6 +352,28 @@ describe('buildPackagedDaemonSpawnEnv', () => {
       webIdentityPath: '/tmp/od-pkg/runtime/web-root.json',
     };
   }
+
+  it('uses the namespace runtime root for child processes without reading cwd', () => {
+    const cwd = vi.spyOn(process, 'cwd').mockImplementation(() => {
+      throw new Error('uv_cwd');
+    });
+
+    try {
+      expect(createPackagedSidecarSpawnOptions({
+        env: { NODE_ENV: 'production' },
+        logFd: 42,
+        paths: fakePaths(),
+      })).toEqual({
+        cwd: '/tmp/od-pkg/runtime',
+        env: { NODE_ENV: 'production' },
+        stdio: ['ignore', 42, 42],
+        windowsHide: true,
+      });
+      expect(cwd).not.toHaveBeenCalled();
+    } finally {
+      cwd.mockRestore();
+    }
+  });
 
   it('sets OD_REQUIRE_DESKTOP_AUTH=1 when requireDesktopAuth=true (Electron entry)', () => {
     const env = buildPackagedDaemonSpawnEnv(fakePaths(), {

--- a/packages/sidecar/src/paths.ts
+++ b/packages/sidecar/src/paths.ts
@@ -83,10 +83,17 @@ export function resolveSidecarBase<TStamp extends SidecarStampShape>({
   base,
   contract,
   env = process.env,
-  projectRoot = process.cwd(),
+  projectRoot,
   source,
 }: BaseResolutionOptions<TStamp>): string {
-  return resolve(base ?? env[contract.env.base] ?? resolveSourceRuntimeRoot({ contract, projectRoot, source }));
+  const explicitBase = base ?? env[contract.env.base];
+  if (explicitBase != null && explicitBase.length > 0) return resolve(explicitBase);
+
+  return resolve(resolveSourceRuntimeRoot({
+    contract,
+    projectRoot: projectRoot ?? process.cwd(),
+    source,
+  }));
 }
 
 /**

--- a/packages/sidecar/tests/index.test.ts
+++ b/packages/sidecar/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { mkdtemp, rm } from "node:fs/promises";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -108,6 +108,35 @@ describe("generic sidecar path boundary", () => {
 
     expect(resolveNamespace({ contract: fakeContract, env })).toBe("selected");
     expect(resolveSidecarBase({ contract: fakeContract, env, projectRoot: "/repo/product", source: "tool" })).toBe(resolve("/runtime/base"));
+  });
+
+  it("does not read cwd when an explicit or environment base is available", () => {
+    const explicitBase = resolve(tmpdir(), "runtime-explicit");
+    const environmentBase = resolve(tmpdir(), "runtime-env");
+    const launchBase = resolve(tmpdir(), "runtime-launch");
+    const cwd = vi.spyOn(process, "cwd").mockImplementation(() => {
+      throw new Error("uv_cwd");
+    });
+    const stamp: FakeStamp = {
+      app: "api",
+      ipc: resolveAppIpcPath({ app: "api", contract: fakeContract, namespace: "alpha" }),
+      mode: "dev",
+      namespace: "alpha",
+      source: "tool",
+    };
+
+    try {
+      expect(resolveSidecarBase({ base: explicitBase, contract: fakeContract, source: "tool" })).toBe(explicitBase);
+      expect(resolveSidecarBase({ contract: fakeContract, env: { FAKE_BASE: environmentBase }, source: "tool" })).toBe(
+        environmentBase,
+      );
+      expect(createSidecarLaunchEnv({ base: launchBase, contract: fakeContract, extraEnv: {}, stamp })).toMatchObject({
+        FAKE_BASE: launchBase,
+      });
+      expect(cwd).not.toHaveBeenCalled();
+    } finally {
+      cwd.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
## Why

A prerelease upgrade incident exposed two ways a packaged payload could inherit a working directory inside an older version directory. Once release cleanup removed that directory, the next payload could fail during early startup with `uv_cwd`; the launcher then correctly rolled back to `lastSuccessful`, but the user remained on the old release.

The immediate crash came from `resolveSidecarBase()` eagerly evaluating `process.cwd()` even when the caller had already supplied an absolute runtime base. The broader lifecycle problem was that packaged and desktop child processes inherited a disposable cwd at all. This PR fixes both layers so already-affected clients can recover and future payload launches do not recreate the condition.

## What users will see

Packaged updates can start successfully even when cleanup has removed the previous payload directory that used to be the process cwd. The launcher can confirm the new version instead of rolling back solely because of `uv_cwd`. There is no UI or update-policy change.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. This changes packaged process startup and updater relaunch behavior without changing UI.

## Bug fix verification

- Red specs:
  - `packages/sidecar/tests/index.test.ts` makes `process.cwd()` throw and verifies explicit/env sidecar bases still resolve.
  - `apps/packaged/tests/launch.test.ts` verifies startup stabilizes cwd to the namespace runtime root without reading the inherited cwd.
  - `apps/packaged/tests/sidecars.test.ts` verifies packaged sidecars receive the stable runtime root as cwd.
  - `apps/desktop/tests/main/updater.test.ts` verifies updater payload relaunch receives the stable runtime base as cwd.
- The specs failed on `main` before the source changes (`uv_cwd`, missing stabilization helpers, and missing spawn `cwd`) and pass on this branch.
- Safety boundary: the stable cwd is the already-created namespace runtime root, outside version cleanup. Launcher active/attempt/lastSuccessful behavior is unchanged. Source-mode sidecar resolution still falls back to `process.cwd()` only when no explicit or environment base exists.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/sidecar test` — 9 passed
- `pnpm --filter @open-design/desktop test` — 248 passed, 2 skipped
- `pnpm --filter @open-design/packaged exec vitest run --exclude tests/prewarm.test.ts` — 211 passed
- Full packaged suite was also run. Its only failures were the existing five Windows-native assertions in `tests/prewarm.test.ts` that assume POSIX paths/FUSE behavior; all other packaged tests passed.
- Built signed-shape prerelease `.90` and `.91` payload/installer artifacts for `release-prerelease-win`; both manifests and payload checks passed.
- Ran the isolated Windows packaged updater acceptance flow with namespace `cwdfix`: installed `.90`, downloaded and activated `.91`, confirmed health/version, `active == lastSuccessful == .91`, `attempt == null`, old version cleanup, persisted project data, real PPTX export, full stop, and installed-outer cold restart into the exact `.91` payload. Result: 1 passed, 1 skipped.
- The machine's existing prerelease installation/registry entry was preserved unchanged by using the isolated namespace.
- The exact deleted-cwd macOS filesystem incident cannot be executed on this Windows host; the red specs simulate `process.cwd()` throwing `uv_cwd`, while macOS CI/build validation remains required.
