### PR TITLE
fix(message-center): honor active AMR profile for anonymous sync

### DIFF
--- a/apps/daemon/src/integrations/vela.ts
+++ b/apps/daemon/src/integrations/vela.ts
@@ -305,6 +305,12 @@ interface VelaConfigFileShape {
   profiles?: Record<string, VelaProfileShape>;
 }
 
+interface VelaProfileConfigSnapshot {
+  profile: string;
+  stored: VelaProfileShape | undefined;
+  configMtimeMs: number | null;
+}
+
 export function mergeVelaEnv(
   env: NodeJS.ProcessEnv = process.env,
   configuredEnv: Record<string, string> = {},
@@ -334,6 +340,20 @@ function readConfigFile(): VelaConfigFileShape | null {
   } catch {
     return null;
   }
+}
+
+function readVelaProfileConfigSnapshot(
+  env: NodeJS.ProcessEnv = process.env,
+  configuredEnv: Record<string, string> = {},
+): VelaProfileConfigSnapshot {
+  const mergedEnv = mergeVelaEnv(env, configuredEnv);
+  const profile = resolveAmrProfile(mergedEnv);
+  const file = readConfigFile();
+  return {
+    profile,
+    stored: file?.profiles?.[profile],
+    configMtimeMs: existsSync(amrConfigPath()) ? statSync(amrConfigPath()).mtimeMs : null,
+  };
 }
 
 export function readVelaLoginStatus(
@@ -541,30 +561,29 @@ export function readVelaControlApiContext(
       configMtimeMs: null,
     };
   }
-  const apiContext = readVelaApiContext(env, configuredEnv);
-  const file = readConfigFile();
-  const stored = file?.profiles?.[apiContext.profile];
+  const snapshot = readVelaProfileConfigSnapshot(env, configuredEnv);
+  const apiContext = readVelaApiContext(env, configuredEnv, snapshot);
+  const stored = snapshot.stored;
   const controlKey = stored?.controlKey?.trim() ?? '';
   if (!controlKey) return null;
   return {
     ...apiContext,
     controlKey,
     user: stored?.user ?? null,
-    configMtimeMs: existsSync(amrConfigPath()) ? statSync(amrConfigPath()).mtimeMs : null,
+    configMtimeMs: snapshot.configMtimeMs,
   };
 }
 
 export function readVelaApiContext(
   env: NodeJS.ProcessEnv = process.env,
   configuredEnv: Record<string, string> = {},
+  snapshot: VelaProfileConfigSnapshot = readVelaProfileConfigSnapshot(env, configuredEnv),
 ): VelaApiContext {
   const mergedEnv = mergeVelaEnv(env, configuredEnv);
-  const profile = resolveAmrProfile(mergedEnv);
-  const stored = readConfigFile()?.profiles?.[profile];
   return {
-    profile,
+    profile: snapshot.profile,
     apiUrl:
-      stored?.apiUrl?.trim()
+      snapshot.stored?.apiUrl?.trim()
       || mergedEnv.VELA_API_URL?.trim()
       || 'https://amr-api.open-design.ai',
   };

--- a/apps/daemon/src/integrations/vela.ts
+++ b/apps/daemon/src/integrations/vela.ts
@@ -288,12 +288,9 @@ export interface VelaControlApiContext {
   configMtimeMs: number | null;
 }
 
-export interface VelaControlApiContext {
+export interface VelaApiContext {
   profile: string;
   apiUrl: string;
-  controlKey: string;
-  user: VelaUser | null;
-  configMtimeMs: number | null;
 }
 
 interface VelaProfileShape {
@@ -544,16 +541,32 @@ export function readVelaControlApiContext(
       configMtimeMs: null,
     };
   }
+  const apiContext = readVelaApiContext(env, configuredEnv);
   const file = readConfigFile();
-  const stored = file?.profiles?.[profile];
+  const stored = file?.profiles?.[apiContext.profile];
   const controlKey = stored?.controlKey?.trim() ?? '';
   if (!controlKey) return null;
   return {
-    profile,
-    apiUrl: stored?.apiUrl?.trim() || envApiUrl || 'https://amr-api.open-design.ai',
+    ...apiContext,
     controlKey,
     user: stored?.user ?? null,
     configMtimeMs: existsSync(amrConfigPath()) ? statSync(amrConfigPath()).mtimeMs : null,
+  };
+}
+
+export function readVelaApiContext(
+  env: NodeJS.ProcessEnv = process.env,
+  configuredEnv: Record<string, string> = {},
+): VelaApiContext {
+  const mergedEnv = mergeVelaEnv(env, configuredEnv);
+  const profile = resolveAmrProfile(mergedEnv);
+  const stored = readConfigFile()?.profiles?.[profile];
+  return {
+    profile,
+    apiUrl:
+      stored?.apiUrl?.trim()
+      || mergedEnv.VELA_API_URL?.trim()
+      || 'https://amr-api.open-design.ai',
   };
 }
 

--- a/apps/daemon/src/routes/vela.ts
+++ b/apps/daemon/src/routes/vela.ts
@@ -23,6 +23,7 @@ import {
   clearAllVelaLiveAccounts,
   parseVelaLoginAttribution,
   peekVelaLiveAccount,
+  readVelaApiContext,
   readVelaCredentialRevision,
   readVelaControlApiContext,
   readVelaLoginStatus,
@@ -46,6 +47,7 @@ import {
 
 const AMR_API_PROXY_PREFIX = '/api/integrations/vela/api-proxy';
 const VELA_MESSAGE_CENTER_PREFIX = '/api/integrations/vela/message-center';
+const VELA_PUBLIC_MESSAGE_CENTER_PREFIX = '/api/integrations/vela/message-center-public';
 const AMR_API_UPSTREAM_ORIGIN = 'https://amr-api.open-design.ai';
 
 type ReadAppConfig = (dataDir: string) => Promise<AppConfigPrefs>;
@@ -180,9 +182,10 @@ function isAllowedMessageCenterRequest(method: string, pathname: string): boolea
 function proxyVelaMessageCenterRequest(
   req: Request,
   res: Response,
-  context: { apiUrl: string; controlKey: string },
+  context: { apiUrl: string; controlKey?: string },
+  proxyPrefix = VELA_MESSAGE_CENTER_PREFIX,
 ): void {
-  const suffix = req.originalUrl.slice(VELA_MESSAGE_CENTER_PREFIX.length);
+  const suffix = req.originalUrl.slice(proxyPrefix.length);
   const parsedSuffix = new URL(suffix, 'http://message-center.local');
   if (!isAllowedMessageCenterRequest(req.method, parsedSuffix.pathname)) {
     res.status(404).json({ error: 'unknown_message_center_path' });
@@ -199,8 +202,8 @@ function proxyVelaMessageCenterRequest(
   const body = velaProxyRequestBody(req);
   const headers: Record<string, string> = {
     accept: typeof req.headers.accept === 'string' ? req.headers.accept : 'application/json',
-    authorization: `Bearer ${context.controlKey}`,
   };
+  if (context.controlKey) headers.authorization = `Bearer ${context.controlKey}`;
   if (typeof req.headers['content-type'] === 'string') {
     headers['content-type'] = req.headers['content-type'];
   }
@@ -420,6 +423,17 @@ export function registerVelaRoutes(app: Express, deps: RegisterVelaRoutesDeps): 
   });
 
   app.all('/api/integrations/vela/api-proxy/*splat', proxyAmrApiRequest);
+
+  app.get('/api/integrations/vela/message-center-public/messages', async (req, res) => {
+    try {
+      const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
+      const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'amr');
+      const context = readVelaApiContext(env, configuredEnv);
+      proxyVelaMessageCenterRequest(req, res, context, VELA_PUBLIC_MESSAGE_CENTER_PREFIX);
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
 
   app.all('/api/integrations/vela/message-center/*splat', async (req, res) => {
     try {

--- a/apps/daemon/tests/integrations/vela.routes.test.ts
+++ b/apps/daemon/tests/integrations/vela.routes.test.ts
@@ -1439,6 +1439,43 @@ describe('ALL /api/integrations/vela/api-proxy/*', () => {
 });
 
 describe('ALL /api/integrations/vela/message-center/*', () => {
+  it('uses the selected profile origin for anonymous messages without forwarding credentials', async () => {
+    const requests: Array<{ url: string; authorization: string | undefined }> = [];
+    const upstream = createServer((req, res) => {
+      requests.push({
+        url: req.url ?? '',
+        authorization: req.headers.authorization,
+      });
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ messages: [], nextCursor: null, unreadCount: 0 }));
+    });
+    await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+    const address = upstream.address() as AddressInfo;
+    seedLogin('test', {
+      apiUrl: `http://127.0.0.1:${address.port}`,
+      controlKey: undefined,
+      runtimeKey: undefined,
+      user: undefined,
+    });
+    await setSettingsAmrEnv({ OPEN_DESIGN_AMR_PROFILE: 'test' });
+    try {
+      const response = await fetch(
+        `${baseUrl}/api/integrations/vela/message-center-public/messages?locale=en-US&limit=30`,
+        { headers: { authorization: 'Bearer browser-supplied-key' } },
+      );
+      expect(response.status).toBe(200);
+      expect(requests).toEqual([
+        {
+          url: '/api/v1/message-center/messages?locale=en-US&limit=30',
+          authorization: undefined,
+        },
+      ]);
+    } finally {
+      await setSettingsAmrEnv({ OPEN_DESIGN_AMR_PROFILE: undefined });
+      await new Promise<void>((resolve) => upstream.close(() => resolve()));
+    }
+  });
+
   it('forwards only Message Center routes to the configured profile origin with its control key', async () => {
     const requests: Array<{ url: string; method: string; authorization: string | undefined }> = [];
     const upstream = createServer((req, res) => {

--- a/apps/daemon/tests/integrations/vela.test.ts
+++ b/apps/daemon/tests/integrations/vela.test.ts
@@ -322,6 +322,64 @@ describe('readVelaCredentialRevision', () => {
   });
 });
 
+describe('readVelaControlApiContext', () => {
+  it('keeps apiUrl and controlKey on the same config snapshot', async () => {
+    vi.resetModules();
+    const configPath = path.join(tmpHome, '.amr', 'config.json');
+    let configReads = 0;
+
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+      const readFileSyncMock = vi.fn(
+        (target: Parameters<typeof actual.readFileSync>[0], options?: Parameters<typeof actual.readFileSync>[1]) => {
+          if (typeof target === 'string' && target === configPath) {
+            configReads += 1;
+            return JSON.stringify({
+              profiles: {
+                test:
+                  configReads === 1
+                    ? {
+                        apiUrl: 'https://old.example',
+                        controlKey: 'ck-old',
+                        user: { id: 'u-old', email: 'old@example.com' },
+                      }
+                    : {
+                        apiUrl: 'https://new.example',
+                        controlKey: 'ck-new',
+                        user: { id: 'u-new', email: 'new@example.com' },
+                      },
+              },
+            });
+          }
+          return actual.readFileSync(target, options as never);
+        },
+      );
+      return {
+        ...actual,
+        existsSync: vi.fn((target: string) =>
+          target.endsWith(path.join('.amr', 'config.json')) ? true : actual.existsSync(target),
+        ),
+        readFileSync: readFileSyncMock,
+        statSync: vi.fn(() => ({ mtimeMs: 123 } as ReturnType<typeof actual.statSync>)),
+      };
+    });
+
+    const vela = await import('../../src/integrations/vela.js');
+    const context = vela.readVelaControlApiContext({ HOME: tmpHome, OPEN_DESIGN_AMR_PROFILE: 'test' });
+    expect(context).toEqual({
+      profile: 'test',
+      apiUrl: 'https://old.example',
+      controlKey: 'ck-old',
+      user: { id: 'u-old', email: 'old@example.com' },
+      configMtimeMs: 123,
+    });
+    expect(configReads).toBe(1);
+
+    vi.doUnmock('node:fs');
+    vi.resetModules();
+  });
+});
+
 describe('forgetVelaLogin', () => {
   it('removes only the resolved profile credentials and preserves the rest of the config', () => {
     const file = writeConfig({

--- a/apps/web/src/message-center-client.ts
+++ b/apps/web/src/message-center-client.ts
@@ -19,7 +19,7 @@ interface MessageCenterPage {
 }
 
 const ACCOUNT_PROXY = '/api/integrations/vela/message-center';
-const ANONYMOUS_PROXY = '/api/integrations/vela/api-proxy/api/v1/message-center';
+const ANONYMOUS_PROXY = '/api/integrations/vela/message-center-public';
 const LEGACY_WINDOW_KEY = 'open-design.message-center.anonymous-started-at.v1';
 const MESSAGES_KEY = 'open-design.message-center.anonymous-messages.v1';
 const READ_KEY = 'open-design.message-center.anonymous-read-ids.v1';

--- a/apps/web/tests/message-center-client.test.ts
+++ b/apps/web/tests/message-center-client.test.ts
@@ -29,7 +29,7 @@ describe('message center client', () => {
     expect(result.map((message) => message.id)).toEqual(['new', 'old']);
     expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
     const firstUrl = String(vi.mocked(fetch).mock.calls[0]?.[0]);
-    expect(firstUrl).toContain('/api/integrations/vela/api-proxy/api/v1/message-center/messages?');
+    expect(firstUrl).toContain('/api/integrations/vela/message-center-public/messages?');
     expect(firstUrl).not.toContain('startedAt=');
   });
 


### PR DESCRIPTION
## Why

While testing Open Design with the active AMR profile set to `test`, signed-out Message Center sync still went through the generic AMR API proxy, whose upstream is fixed to production. This made anonymous users request the wrong environment and surface a retry error when Message Center was deployed only to the selected profile environment.

The fix keeps endpoint selection and credential forwarding separate: anonymous Message Center traffic follows the active profile's API origin without receiving any control key, while signed-in traffic keeps using the credential-scoped route.

## What users will see

Signed-out users now load global Message Center messages from the currently selected AMR profile (`prod`, `test`, or `local`, including its configured API URL) instead of always contacting production. Signed-in behavior is unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this changes Message Center request routing without changing the UI.

## Bug fix verification

- Test path: `apps/daemon/tests/integrations/vela.routes.test.ts`
- Did the test go red on `main` and green on this branch? No separate red run was recorded; on `main` the tested profile-aware public endpoint does not exist. The original failure was reproduced against an anonymous `test` profile, where the request went to production and returned 404.
- The regression test selects the `test` profile, points it at a local upstream, supplies no profile control key, and verifies that the request reaches that upstream without forwarding even a browser-supplied `Authorization` header.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/integrations/vela.routes.test.ts` (62 passed)
- `pnpm exec vitest run -c vitest.config.ts tests/message-center-client.test.ts` (4 passed)
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
