### PR TITLE
feat(mcp): add Raven installer target

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Inside a project's Studio, the same design system streams out multiple artifact 
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | ✅ Supported | `od mcp install claude` |
 | [Codex CLI](https://github.com/openai/codex) | ✅ Supported | `od mcp install codex` |
 | [DeepSeek Reasonix](https://github.com/esengine/DeepSeek-Reasonix) | ✅ Supported | `od mcp install reasonix` |
+| [Raven](https://github.com/EverMind-AI/Raven) | ✅ Supported | `od mcp install raven` |
 | [Cursor](https://www.cursor.com/cli) | ✅ Supported | `od mcp install cursor` |
 | [VS Code + GitHub Copilot](https://github.com/features/copilot) | ✅ Supported | `od mcp install copilot` |
 | [GitHub Copilot CLI](https://github.com/features/copilot/cli) | ✅ Supported | `od mcp install copilot` |
@@ -310,7 +311,7 @@ client-specific snippet; it uses absolute paths and does not rely on the bare
 ```bash
 # One-line install into the agent you're using:
 od mcp install <agent>
-# <agent> = claude | codex | reasonix | cursor | copilot | openclaw
+# <agent> = claude | codex | reasonix | raven | cursor | copilot | openclaw
 #         | antigravity | gemini | pi | vibe | hermes | cline | kimi
 #         | trae | opencode
 

--- a/apps/daemon/src/mcp-agent-install.ts
+++ b/apps/daemon/src/mcp-agent-install.ts
@@ -15,7 +15,7 @@
 //   - 'json'   : the agent reads a JSON config file with a known schema.
 //                We deep-merge one server entry, never clobbering the
 //                rest of the file. Used for cursor / copilot / cline /
-//                opencode / openclaw / antigravity / kiro / trae.
+//                opencode / openclaw / antigravity / kiro / raven / trae.
 //   - 'manual' : we could not verify the agent's config path/format
 //                authoritatively (pi / hermes / vibe). We refuse to write
 //                a guessed path and instead print a ready-to-paste
@@ -33,6 +33,7 @@ export const AGENT_SLUGS = [
   'claude',
   'codex',
   'reasonix',
+  'raven',
   'cursor',
   'copilot',
   'openclaw',
@@ -211,6 +212,15 @@ export function planAgentInstall(
         keyPath: ['mcpServers'],
         serverKey: serverName,
         entry: jsonEntry(spec, { type: 'stdio' }),
+      };
+    case 'raven':
+      return {
+        kind: 'json',
+        slug,
+        configPath: path.join(home, '.raven', 'config.json'),
+        keyPath: ['tools', 'mcpServers'],
+        serverKey: serverName,
+        entry: { ...jsonEntry(spec, { type: 'stdio' }), env: spec.env },
       };
     case 'copilot':
       // GitHub Copilot CLI: ~/.copilot/mcp-config.json, type "local".

--- a/apps/daemon/tests/mcp-agent-install.test.ts
+++ b/apps/daemon/tests/mcp-agent-install.test.ts
@@ -28,9 +28,10 @@ describe('agent slug guard', () => {
   it('accepts every documented slug and rejects others', () => {
     for (const s of AGENT_SLUGS) expect(isAgentSlug(s)).toBe(true);
     expect(isAgentSlug('not-an-agent')).toBe(false);
-    expect(AGENT_SLUGS).toHaveLength(15);
+    expect(AGENT_SLUGS).toHaveLength(16);
     expect(isAgentSlug('kiro')).toBe(true);
     expect(isAgentSlug('reasonix')).toBe(true);
+    expect(isAgentSlug('raven')).toBe(true);
   });
 });
 
@@ -117,6 +118,49 @@ describe('JSON-config agents', () => {
       args: SPEC.args,
       env: SPEC.env,
     });
+  });
+
+  it('raven plans a stdio entry under tools.mcpServers', () => {
+    const plan = planAgentInstall('raven', SPEC, ctx());
+    if (plan.kind !== 'json') throw new Error('expected json');
+    expect(plan.configPath).toBe('/home/u/.raven/config.json');
+    expect(plan.keyPath).toEqual(['tools', 'mcpServers']);
+    expect(plan.serverKey).toBe('open-design');
+    expect(plan.entry).toEqual({
+      command: SPEC.command,
+      args: SPEC.args,
+      type: 'stdio',
+      env: SPEC.env,
+    });
+  });
+
+  it('raven keeps the env field when no environment variables are needed', () => {
+    const plan = planAgentInstall('raven', SPEC_NO_ENV, ctx());
+    if (plan.kind !== 'json') throw new Error('expected json');
+    expect(plan.entry).toEqual({
+      command: SPEC.command,
+      args: SPEC.args,
+      type: 'stdio',
+      env: {},
+    });
+  });
+
+  it('raven install and removal preserve existing config and sibling servers', () => {
+    const plan = planAgentInstall('raven', SPEC, ctx());
+    if (plan.kind !== 'json') throw new Error('expected json');
+    const existing = JSON.stringify({
+      theme: 'dark',
+      tools: { mcpServers: { existing: { command: 'existing-command' } } },
+    });
+
+    const installed = JSON.parse(applyJsonInstall(existing, plan));
+    expect(installed.theme).toBe('dark');
+    expect(installed.tools.mcpServers.existing).toEqual({ command: 'existing-command' });
+    expect(installed.tools.mcpServers['open-design']).toEqual(plan.entry);
+
+    const removed = removeJsonInstall(JSON.stringify(installed), plan);
+    expect(removed).not.toBeNull();
+    expect(JSON.parse(removed ?? '{}')).toEqual(JSON.parse(existing));
   });
 
   it('omits env entirely when the launch spec has no env', () => {


### PR DESCRIPTION
Fixes #5958

## Why

Raven users currently have to configure Open Design's MCP server by hand. Raven v0.1.7 has a stable user configuration contract at `~/.raven/config.json`, so Open Design can support it through the existing JSON installer path without adding a Raven runtime adapter or changing either project's architecture.

## What users will see

`od mcp install raven` now safely merges the Open Design stdio server into `tools.mcpServers.open-design` in Raven's config. Existing top-level settings and sibling MCP servers are preserved. `od mcp install raven --uninstall` removes only the Open Design entry.

The supported-target table and canonical CLI target list now include Raven.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — there is no UI change.

## Bug fix verification

Not applicable — this is a new supported installer target.

## Validation

- TDD RED: the focused installer suite failed for the expected missing-Raven reasons (3 failed, 17 passed) before production changes.
- Review follow-up RED: an empty-environment Raven plan omitted the `env` field; a focused regression failed before the fix and now proves Raven always writes `env`, including `env: {}`.
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/mcp-agent-install.test.ts tests/mcp-install-cli.test.ts --reporter=verbose` — 22/22 passed.
- `pnpm --filter @open-design/daemon typecheck` — passed.
- `pnpm --filter @open-design/daemon build` — passed.
- `pnpm typecheck` — passed across the workspace.
- `pnpm guard` — passed, including 86/86 policy tests.
- Real CLI round trip under an isolated `HOME` — dry runs did not mutate the file; install preserved unrelated config and a sibling MCP server; uninstall restored the seeded config by removing only `open-design`.
- `git diff --check`, added-line security scan, UTF-8 validation, and LF validation — passed.
