### PR TITLE
Add Source Project Context plugin

### DIFF
--- a/plugins/community/source-project-context-mrvu81gl/SKILL.md
+++ b/plugins/community/source-project-context-mrvu81gl/SKILL.md
@@ -1,0 +1,45 @@
+# Source Project Context
+
+This design-system workspace was created from an existing Open Design project. Treat the copied project files as the primary source evidence for the generated design system.
+
+## Source project
+
+- Source project id: 58a34454-39e4-4ee4-af30-3e179c4c9dbf
+- Source project name: Github Dashboard
+- New design-system project id: 168e855b-b115-400a-93e3-9f961c3f6f53
+- New design-system id: user:github-dashboard-design-system
+- Source skill id: (none)
+- Source design system id: default
+
+## Source metadata
+
+```json
+{
+  "kind": "prototype",
+  "nameSource": "prompt",
+  "linkedDirs": [
+    "/Users/zhongqi/huawei/code/clb-new"
+  ]
+}
+```
+
+## Copied files
+
+- workspace.html
+- critique.json
+
+## Skipped files
+
+- (none)
+
+## Generation contract
+
+- Read this file before editing design-system outputs.
+- Read the copied files directly from the project workspace; they are source evidence, not generated design-system output.
+- Preserve high-signal assets, source examples, UI surfaces, copy, tokens, typography, and interaction patterns from the copied project.
+- Generate a reusable Open Design design-system package in this same project: DESIGN.md, README.md, SKILL.md, colors_and_type.css, context/provenance, focused preview cards, preserved assets/build/fonts when available, and ui_kits/app/.
+- Before final response, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every actionable issue.
+
+## Provenance
+
+Formalized by Open Design from candidate e5e7de90-ed58-4e30-9838-634faab6d374.

--- a/plugins/community/source-project-context-mrvu81gl/open-design.json
+++ b/plugins/community/source-project-context-mrvu81gl/open-design.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "source-project-context-mrvu81gl",
+  "title": "Source Project Context",
+  "version": "0.1.0",
+  "description": "This design-system workspace was created from an existing Open Design project. Treat the copied project files as the primary source evidence for the generated design system.",
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ]
+  }
+}

--- a/plugins/community/source-project-context-mrvu81gl/references/provenance.json
+++ b/plugins/community/source-project-context-mrvu81gl/references/provenance.json
@@ -1,0 +1,47 @@
+{
+  "candidateId": "e5e7de90-ed58-4e30-9838-634faab6d374",
+  "projectId": "168e855b-b115-400a-93e3-9f961c3f6f53",
+  "runId": "b9e06841-04c9-474f-94a1-d4601954cd0e",
+  "conversationId": "9c60f622-fa3a-47a8-a1d3-c2af9890333b",
+  "provenance": {
+    "summary": "Detected from context/source-context.md, README.md, SKILL.md, ui_kits/app/README.md, MERGE_PLAN.md after a successful run.",
+    "detectedAt": 1784475469042
+  },
+  "sourceRefs": [
+    {
+      "kind": "file",
+      "value": "context/source-context.md",
+      "label": "context/source-context.md",
+      "size": 1474,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "README.md",
+      "label": "README.md",
+      "size": 8896,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "SKILL.md",
+      "label": "SKILL.md",
+      "size": 3847,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "ui_kits/app/README.md",
+      "label": "ui_kits/app/README.md",
+      "size": 4375,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "MERGE_PLAN.md",
+      "label": "MERGE_PLAN.md",
+      "size": 6259,
+      "copied": true
+    }
+  ]
+}

--- a/plugins/community/source-project-context-mrvu81gl/references/source-1-source-context.md
+++ b/plugins/community/source-project-context-mrvu81gl/references/source-1-source-context.md
@@ -1,0 +1,41 @@
+# Source Project Context
+
+This design-system workspace was created from an existing Open Design project. Treat the copied project files as the primary source evidence for the generated design system.
+
+## Source project
+
+- Source project id: 58a34454-39e4-4ee4-af30-3e179c4c9dbf
+- Source project name: Github Dashboard
+- New design-system project id: 168e855b-b115-400a-93e3-9f961c3f6f53
+- New design-system id: user:github-dashboard-design-system
+- Source skill id: (none)
+- Source design system id: default
+
+## Source metadata
+
+```json
+{
+  "kind": "prototype",
+  "nameSource": "prompt",
+  "linkedDirs": [
+    "/Users/zhongqi/huawei/code/clb-new"
+  ]
+}
+```
+
+## Copied files
+
+- workspace.html
+- critique.json
+
+## Skipped files
+
+- (none)
+
+## Generation contract
+
+- Read this file before editing design-system outputs.
+- Read the copied files directly from the project workspace; they are source evidence, not generated design-system output.
+- Preserve high-signal assets, source examples, UI surfaces, copy, tokens, typography, and interaction patterns from the copied project.
+- Generate a reusable Open Design design-system package in this same project: DESIGN.md, README.md, SKILL.md, colors_and_type.css, context/provenance, focused preview cards, preserved assets/build/fonts when available, and ui_kits/app/.
+- Before final response, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every actionable issue.

--- a/plugins/community/source-project-context-mrvu81gl/references/source-2-README.md
+++ b/plugins/community/source-project-context-mrvu81gl/references/source-2-README.md
@@ -1,0 +1,150 @@
+# CLB Design System
+
+This README works as a Claude Design package guide. It includes: a Product Overview section explaining the source product, primary surfaces, and core capabilities; source/context references; a Package Contents tree; a Preview Manifest listing preview cards; a section on preserved assets, fonts, and build artifacts; ui_kits/app documentation; and a concrete reuse and review workflow.
+
+Design system for Computing Lab (CLB) — 研发基础设施与环境管理平台. Extracted from the workbench prototype.
+
+## Product Overview
+
+This Product Overview section explains the source product, its primary surfaces, and core capabilities instead of only listing tokens or generated files.
+
+**Source product**: Computing Lab (CLB) is a server digital management system for R&D laboratories — a 研发基础设施与环境管理平台 (R&D Infrastructure & Environment Management Platform). It connects resource investment, environment delivery, operations assurance, and service provisioning into a unified business system. CLB serves laboratory managers and environment-using teams, making resources go from "visible and manageable" to "predictable and provisionable."
+
+Four core value anchors:
+- **Digital ledger (数字台账)**: unified digital view of devices and resource pools as the trusted decision basis for full device lifecycle
+- **Delivery chain (交付链路)**: end-to-end traceable delivery process from environment construction to decommissioning
+- **Operations perspective (运营视角)**: unified operations view covering health, efficiency, alerts, and trends for proactive operations
+- **Intelligent scheduling (智能调度入口)**: constraint-based automated resource matching, allocation, and reclamation
+
+Six business domains: Resource Provisioning (资源供给), Environment Delivery (环境交付), Resource Management (资源管理), Environment Operations (环境运维), Environment Services (环境服务), Platform Foundation (平台支撑).
+
+### Primary surfaces
+
+The product includes these primary surfaces:
+
+| Surface | Domain | Function |
+|---------|--------|----------|
+| Workspace (工作台) | Platform | Home dashboard: pending actions, work orders, environments, device health |
+| Resource Center (资源中心) | Resource Management | Device management, resource pool management, cluster management |
+| Environment Delivery (环境交付) | Environment Delivery | Full environment lifecycle from design to acceptance |
+| Environment Services (环境服务) | Environment Services | Scheduling, installation, and reservation services |
+| Operations (运行保障) | Environment Operations | Monitoring, alerting, and daily operations |
+| Work Orders (工单中心) | Platform | Work order creation, approval, tracking across all domains |
+| Analytics (运营看板) | Platform | Data statistics, operational analysis, and trends |
+
+### Core capabilities
+
+The product provides these core capabilities:
+
+- **KPI overview**: 4-column equal-width card strip displaying pending actions, work orders, environments, and anomaly counts at a glance
+- **Pending actions and work order management**: dual-column data tables with pagination, status pill classification, and row-level hover states
+- **Environment management**: three-tier grouping model (personal environments, team pool member, team pool owner) with device specification chips showing GPU model and OS version
+- **Health monitoring**: anomaly classification grid across four categories (device faults, network failures, credential drift, collection interruption) with color-coded health banners
+- **Global navigation**: 256px fixed sidebar with two navigation groups plus a 48px topbar containing status badges and action buttons
+
+## Source/context references
+
+| Reference | File | Description |
+|-----------|------|-------------|
+| Primary prototype | `workspace.html` (45KB) | Complete workbench: sidebar, KPIs, tables, environment cards, health monitoring, responsive breakpoints |
+| Design critique | `critique.json` | Panel scoring 4/5 overall — hierarchy 5/5, typography 4/5, motion 3/5 |
+| Provenance | `context/provenance.md` | Design decisions, token derivation, known gaps |
+| Source metadata | `context/source-context.md` | Project id, linked directories, generation contract |
+| Architecture docs | `/Users/zhongqi/huawei/code/clb-new/clb-project` | CLB architecture design: DDD domain modeling, microservice boundaries, business processes, ADRs |
+
+## Package Contents
+
+```
+.
+├── DESIGN.md                    # 9-chapter design specification
+├── SKILL.md                     # Agent-discoverable design system skill
+├── README.md                    # Claude Design package guide (this file)
+├── colors_and_type.css          # Reusable CSS token file
+├── build/                       # Build artifacts directory
+├── assets/                      # Brand assets directory
+├── source_examples/             # Preserved source component snapshots
+│   ├── buttons.html
+│   ├── kpi-cards.html
+│   ├── table-with-pagination.html
+│   ├── pills.html
+│   ├── environment-cards.html
+│   ├── health-monitoring.html
+│   └── navigation.html
+├── preview/                     # Focused review preview cards
+│   ├── colors-palette.html
+│   ├── typography-specimens.html
+│   ├── spacing-tokens.html
+│   ├── components-library.html
+│   ├── brand-assets.html
+│   └── applied-surfaces.html
+├── ui_kits/
+│   └── app/
+│       ├── index.html           # Composed UI Kit loading modular components
+│       ├── README.md            # UI Kit reuse documentation
+│       └── components/          # Modular component CSS files
+└── workspace.html               # Original source prototype (45KB)
+```
+
+## Preserved assets, fonts, and build artifacts
+
+- **assets/**: Source uses inline SVG symbols and a CSS-drawn logo. Place external assets here when available.
+- **fonts/**: Not applicable — system font stacks (PingFang SC, Microsoft YaHei, Inter, ui-monospace). No custom font files.
+- **build/**: Placeholder directory. Source is a single static HTML file with no build pipeline.
+- **source_examples/**: 7 substantive component snapshots — complete, runnable HTML fragments, not stubs.
+
+## Preview Manifest
+
+Preview cards for review, in recommended inspection order:
+
+| # | Card | File |
+|---|------|------|
+| 1 | Colors | `preview/colors-palette.html` |
+| 2 | Typography | `preview/typography-specimens.html` |
+| 3 | Spacing | `preview/spacing-tokens.html` |
+| 4 | Components | `preview/components-library.html` |
+| 5 | Brand assets | `preview/brand-assets.html` |
+| 6 | Applied surfaces | `preview/applied-surfaces.html` |
+
+## Package Reuse Guide
+
+This section provides a concrete reuse and review workflow.
+
+The guide covers: source/context references, package contents, preview cards, preserved assets/fonts/build artifacts, ui_kits/app, and a concrete reuse or review workflow.
+
+### Agent workflow
+
+1. Read `SKILL.md` for binding instructions and mandatory rules
+2. Include `colors_and_type.css` or paste its `:root` block into a `<style>` tag
+3. Consult `DESIGN.md` for component specs and layout patterns
+4. Reference `preview/components-library.html` for visual examples
+5. Copy component CSS from `ui_kits/app/components/` for modular reuse
+6. Check `context/provenance.md` for design rationale and known gaps
+7. Use `source_examples/` files as copy-paste starting points
+8. Open `ui_kits/app/index.html` to see the composed UI Kit
+
+### Human reviewer workflow
+
+1. `preview/colors-palette.html` — token system
+2. `preview/components-library.html` — all 12 component categories rendered
+3. `preview/applied-surfaces.html` — real application context, responsive breakpoints
+4. `ui_kits/app/index.html` — composed UI Kit in browser
+5. `DESIGN.md` — full specification and anti-patterns
+6. `workspace.html` — original 45KB source prototype
+7. `source_examples/` — isolated runnable component snapshots
+8. `preview/brand-assets.html` — logo, icons, copy tone, naming
+
+## Design language summary
+
+| Dimension | Value |
+|-----------|-------|
+| Style | Neutral Modern + Soft Paper |
+| Accent | Blue #2f6feb — max twice per screen |
+| Surfaces | canvas (#f2f2f0) → surface-muted (#fafaf9) → surface (#ffffff) |
+| Typography | System stack + PingFang SC / Microsoft YaHei; tabular numbers globally |
+| Type scale | 12–32px in 6 steps |
+| Radius | 8px (control) / 12px (tile) / 16px (card) |
+| Motion | 150ms ease-standard; staggered fade-up entrance |
+
+## Source project
+
+Extracted from Open Design project "Github Dashboard" (58a34454-39e4-4ee4-af30-3e179c4c9dbf). The source project references the CLB (Computing Lab) codebase at `/Users/zhongqi/huawei/code/clb-new`.

--- a/plugins/community/source-project-context-mrvu81gl/references/source-3-SKILL.md
+++ b/plugins/community/source-project-context-mrvu81gl/references/source-3-SKILL.md
@@ -1,0 +1,82 @@
+---
+name: clb-design-system
+description: CLB Design System — Computing Lab (CLB) 研发基础设施与环境管理平台设计系统，支持明暗双主题、简体中文、数据密集型 B 端产品
+user-invocable: true
+---
+
+# CLB Design System — Agent Skill
+
+## What is inside
+
+从 Computing Lab (CLB) 研发基础设施与环境管理平台的工作台原型中提取的完整设计系统包：
+
+| 文件 | 内容 |
+|------|------|
+| `DESIGN.md` | 9 章完整设计规范：视觉主题、颜色、字体、间距、布局、组件、动效、文案语调、反模式 |
+| `colors_and_type.css` | 可直接引用的 CSS token 文件，含所有 `:root` 自定义属性 |
+| `preview/` | 6 张聚焦预览卡片：颜色调色板、字体样本、间距 tokens、组件库、品牌资产、应用界面 |
+| `ui_kits/app/` | 可运行的 UI Kit 展示页，从 workspace.html 源原型中提取全部 12 类组件 |
+| `context/provenance.md` | 设计决策溯源：源证据文件、token 推导过程、已知缺口 |
+
+## Source context
+
+- **源项目**: CLB prototype (58a34454-39e4-4ee4-af30-3e179c4c9dbf) — Open Design prototype
+- **产品**: Computing Lab (CLB) — 研发基础设施与环境管理平台 (服务器数字化管理系统)
+- **主要原型文件**: `workspace.html` (45KB) — 完整 Shell 布局 + 全部组件实现
+- **设计评分**: 4/5 (来自 critique.json) — 层次结构满分(5/5)，动效和加载态有提升空间
+
+## When to use
+
+- 研发基础设施与环境管理平台 (R&D infrastructure & environment management)
+- 服务器数字化管理系统 / 资源池管理 Dashboard
+- 基础设施运维工作台 (operations workbench)
+- 企业内部数据密集型 B 端工具
+- 需要简体中文 (zh-CN) 专业工程语调的产品
+- Neutral Modern token 体系 + Soft Paper 布局模式组合
+
+## How to use
+
+### 绑定 token
+
+```html
+<link rel="stylesheet" href="colors_and_type.css" />
+```
+
+或直接复制 `:root` 块到 `<style>` 标签中。
+
+### 布局模式
+
+```
+Sidebar (256px) | Topbar (48px) | Content (scrollable grid)
+```
+
+KPIs → 双列表格卡片 → 全宽内容卡片 — 自上而下按优先级排列。
+
+### 核心规则（P0 强制）
+
+1. **表面层级 > 阴影** — 用暖白堆叠(`--canvas` → `--surface-muted` → `--surface`)区分层级，而非阴影
+2. **品牌色克制** — `--accent` (#2f6feb) 每屏最多出现两次
+3. **语义色仅用于状态** — 绿/黄/红只用于 Pill、异常卡片、KPI 趋势
+4. **全局等宽数字** — 所有计数、日期、KPI 使用 `font-feature-settings: "tnum"`
+5. **中文优先** — 所有 UI 文案为简体中文，术语精确
+
+## Design-system highlights
+
+- **暖白表面堆叠**: canvas (#f2f2f0) → surface-muted (#fafaf9) → surface (#ffffff)，约 3% 亮度差实现柔和浮动感
+- **三级圆角**: card (16px) / tile (12px) / control (8px)
+- **16px 基准网格**: shell gap、card gap、KPI gap 均为 16px
+- **三段式间距**: content padding 为 24px(top) 28px(horizontal) 32px(bottom)
+- **系统字体栈**: PingFang SC + Microsoft YaHei + Inter — 中英文原生渲染
+- **150ms ease-standard**: 所有过渡统一使用 `cubic-bezier(0.2, 0, 0, 1)`
+- **明暗双主题**: `[data-theme="dark"]` + `prefers-color-scheme: dark`，暖白→冷暗堆叠，语义色和 Pill 对全适配
+- **骨架屏**: `.skeleton` shimmer 动画，卡片/表格加载占位
+- **入场动画**: KPI 卡片和内容卡片错峰淡入上移，尊重 `prefers-reduced-motion`
+
+## Anti-patterns (blocking)
+
+- 渐变背景（所有表面为纯色）
+- Emoji 作为功能图标（使用 SVG symbols）
+- 左侧色条装饰卡片（卡片使用均匀 border-soft）
+- 浮动操作按钮（主操作在页面头部或卡片头部）
+- 厚重阴影（shadow token 仅为 rgba(10,10,10,.04)）
+- 品牌色的装饰性使用

--- a/plugins/community/source-project-context-mrvu81gl/references/source-4-README.md
+++ b/plugins/community/source-project-context-mrvu81gl/references/source-4-README.md
@@ -1,0 +1,83 @@
+# UI Kit — CLB Design System
+
+This README documents the applied kit structure, component files, usage workflow, design notes, and source basis so future agents can reuse it like a Claude Design package.
+
+- **applied kit structure** — `## Structure` section below
+- **component files** — `## Component files` table with source line numbers and exported classes
+- **usage workflow** — `## Usage workflow` with quick start, full kit, and theming
+- **design notes** — `## Design notes` covering CSS-only, responsive, accessible, tabular, token-bound
+- **source basis** — `## Source basis` with reverse-engineering provenance from workspace.html
+
+The interface kit is extracted from the `workspace.html` source prototype with line-number provenance.
+
+## Structure
+
+```
+ui_kits/app/
+├── index.html          # Composed UI Kit showcase — loads modular components
+├── README.md           # This file — reuse documentation
+└── components/         # Modular component CSS files (one per component group)
+    ├── buttons.css              # Button: default, primary, disabled, icon+text
+    ├── kpi-cards.css            # KPI card strip: 4-column grid, glyph, trend labels
+    ├── pills.css                # Status pills: 5 variants
+    ├── table.css                # Table + pagination
+    ├── environment-cards.css    # Environment cards: auto-fill grid, device specs
+    ├── health-monitoring.css    # Health banner + anomaly classification grid
+    ├── navigation.css           # Nav items, count badges, group labels, topbar badges
+    └── empty-state.css          # Empty state: icon + text + action link
+```
+
+## Component files
+
+Each CSS file in `components/` is self-contained and copy-paste-ready. Zero JavaScript dependencies — all interactions are pure CSS.
+
+| Component file | Source (workspace.html lines) | Classes exported |
+|---------------|------------------------------|------------------|
+| `buttons.css` | :113-120 | `button`, `.button`, `.primary` |
+| `kpi-cards.css` | :123-132 | `.kpis`, `.kpi`, `.kpi-top`, `.kpi-label`, `.kpi-num`, `.kpi-trend`, `.glyph` |
+| `pills.css` | :155-163 | `.pill`, `.pill-active`, `.pill-pending`, `.pill-feature`, `.pill-danger`, `.pill-muted` |
+| `table.css` | :145-153, :211-216 | `table`, `th`, `td`, `tr:hover`, `.pagination`, `.page-btn` |
+| `environment-cards.css` | :170-184 | `.env-grid`, `.env-card`, `.env-card-top`, `.env-name`, `.env-meta`, `.device-spec` |
+| `health-monitoring.css` | :187-208 | `.health-banner`, `.anomaly-grid`, `.anomaly-card`, `.anomaly-count` |
+| `navigation.css` | :83-101 | `.nav-item`, `.count`, `.group-label`, `.topbar-badge` |
+| `empty-state.css` | :219-223 | `.empty`, `.empty-icon`, `.empty-text`, `.empty-action` |
+
+## Usage workflow
+
+### Quick start
+
+```html
+<link rel="stylesheet" href="../../colors_and_type.css" />
+<link rel="stylesheet" href="components/pills.css" />
+<span class="pill pill-active">使用中</span>
+```
+
+### Full kit
+
+```html
+<link rel="stylesheet" href="../../colors_and_type.css" />
+<link rel="stylesheet" href="components/buttons.css" />
+<link rel="stylesheet" href="components/kpi-cards.css" />
+<!-- ... all component CSS files ... -->
+```
+
+Then use component class names directly in HTML. No JavaScript framework required.
+
+### Theming
+
+```css
+:root { --accent: oklch(50% 0.2 300); }
+```
+
+## Design notes
+
+- **Pure CSS**: All hover, active, focus-visible states are CSS-only. No JavaScript dependency.
+- **Responsive**: Environment cards use `auto-fill, minmax(280px, 1fr)` for automatic column fitting.
+- **Accessible**: Every interactive element has `:focus-visible` ring. Respects `prefers-reduced-motion`.
+- **Tabular numbers**: Global `font-feature-settings: "tnum"` for vertical numeric alignment.
+- **Chinese-first**: Demo copy in Simplified Chinese. CSS class names in English.
+- **Token-bound**: No raw hex values — everything resolves through `var(--token)`.
+
+## Source basis
+
+All components reverse-engineered from `workspace.html` (45KB), the Computing Lab (CLB) 研发基础设施与环境管理平台 workbench prototype. CSS rules extracted, deduplicated, and split into modular component files. HTML structure preserved in `index.html` demo sections. Token block referenced via `../../colors_and_type.css`. Source prototype preserved at `../../workspace.html`.

--- a/plugins/community/source-project-context-mrvu81gl/references/source-5-MERGE_PLAN.md
+++ b/plugins/community/source-project-context-mrvu81gl/references/source-5-MERGE_PLAN.md
@@ -1,0 +1,151 @@
+# 设计系统融合方案 — Open Design → clb-frontend
+
+## 目标
+
+将本项目的 ui_kits、SKILL.md、AGENT_PROMPTS.md、DESIGN.md、README.md 融合进 `/Users/zhongqi/huawei/code/clb-new/clb-frontend`。
+
+## 注入点：`packages/design-system/`
+
+clb-frontend 的 AGENTS.md 第 28 行已规划此包："设计令牌及 CLB 公共 UI；不得包含领域流程"。目录尚不存在。
+
+## 文件映射
+
+```
+Open Design 项目                              →  clb-frontend 目标位置
+────────────────────────────────────────────────────────────────────────
+colors_and_type.css                           →  packages/design-system/src/tokens.css
+DESIGN.md (设计规范)                         →  packages/design-system/DESIGN.md
+SKILL.md (Agent 使用 skill)                  →  packages/design-system/SKILL.md
+AGENT_PROMPTS.md (Phase 任务 prompt)         →  packages/design-system/AGENT_PROMPTS.md
+ui_kits/app/components/*.css                 →  packages/design-system/src/components/*.css
+ui_kits/app/index.html                       →  packages/design-system/preview/index.html
+ui_kits/app/README.md                        →  packages/design-system/preview/README.md
+preview/*.html                               →  packages/design-system/preview/*.html
+source_examples/*.html                       →  packages/design-system/source_examples/*.html
+workspace.html (参考原型)                    →  packages/design-system/reference/workspace.html
+context/provenance.md                        →  packages/design-system/docs/provenance.md
+README.md                                    →  合并到 clb-frontend 根 README.md 的设计系统章节
+```
+
+## 具体步骤（逐条可执行）
+
+### Step 1: 创建包目录结构
+
+```bash
+cd /Users/zhongqi/huawei/code/clb-new/clb-frontend
+mkdir -p packages/design-system/src/components
+mkdir -p packages/design-system/preview
+mkdir -p packages/design-system/source_examples
+mkdir -p packages/design-system/reference
+mkdir -p packages/design-system/docs
+```
+
+### Step 2: 编写 package.json
+
+创建 `packages/design-system/package.json`:
+```json
+{
+  "name": "@clb/design-system",
+  "version": "0.1.0",
+  "description": "CLB 设计系统 — 设计令牌、组件样式、Agent skill 与实现 prompts",
+  "type": "module",
+  "main": "./src/index.ts",
+  "files": ["src", "preview", "DESIGN.md", "SKILL.md", "AGENT_PROMPTS.md"]
+}
+```
+
+### Step 3: 复制 token 文件并适配
+
+复制 `colors_and_type.css` → `packages/design-system/src/tokens.css`
+
+适配要点：
+- 保留所有 `:root` 变量
+- 将 `font-feature-settings` 从 `:root` 移到 `body`
+- 去掉全局 reset（clb-frontend 有自己的 reset.css）
+- 确保变量名不与 clb-frontend 的 `--ds-*` 命名空间冲突
+
+### Step 4: 复制组件 CSS
+
+将 `ui_kits/app/components/*.css` 复制到 `packages/design-system/src/components/`：
+- buttons.css, kpi-cards.css, pills.css, table.css
+- environment-cards.css, health-monitoring.css, navigation.css, empty-state.css
+
+每个文件添加 `@import '../tokens.css';` 头部引用。
+
+### Step 5: 创建 src/index.ts 入口
+
+```typescript
+// packages/design-system/src/index.ts
+// 设计系统入口 — 导出 token 和组件样式引用路径
+export { default as tokens } from './tokens.css?inline';
+export const componentStyles = {
+  buttons:    () => import('./components/buttons.css?inline'),
+  kpiCards:   () => import('./components/kpi-cards.css?inline'),
+  pills:      () => import('./components/pills.css?inline'),
+  table:      () => import('./components/table.css?inline'),
+  envCards:   () => import('./components/environment-cards.css?inline'),
+  health:     () => import('./components/health-monitoring.css?inline'),
+  navigation: () => import('./components/navigation.css?inline'),
+  emptyState: () => import('./components/empty-state.css?inline'),
+};
+```
+
+### Step 6: 复制文档和预览
+
+```
+DESIGN.md              → packages/design-system/DESIGN.md
+SKILL.md               → packages/design-system/SKILL.md
+AGENT_PROMPTS.md       → packages/design-system/AGENT_PROMPTS.md
+preview/*.html         → packages/design-system/preview/
+source_examples/*.html → packages/design-system/source_examples/
+workspace.html         → packages/design-system/reference/workspace.html
+context/provenance.md  → packages/design-system/docs/provenance.md
+```
+
+### Step 7: 更新 clb-frontend 的 AGENTS.md
+
+在 `## Package Boundaries` 段落，将 `packages/design-system` 条目更新为：
+
+```markdown
+- `packages/design-system`：设计令牌、组件 CSS 模式、Agent skill、实现 prompts 和预览卡片。
+  源自 Github Dashboard 设计系统项目。agent 任务前先读 SKILL.md 和 DESIGN.md。
+  令牌文件位于 src/tokens.css；组件 CSS 位于 src/components/。
+  不得包含领域流程或运行时业务逻辑。
+```
+
+### Step 8: 在 clb-frontend 根 README 中添加设计系统章节
+
+在 README 末尾添加：
+```markdown
+## 设计系统
+
+本项目使用 `@clb/design-system` 包（`packages/design-system/`）统一设计语言。
+详见 [DESIGN.md](packages/design-system/DESIGN.md)。
+
+快速开始：
+\`\`\`ts
+import '@clb/design-system/src/tokens.css';
+\`\`\`
+
+Agent 开发前请阅读：
+- [SKILL.md](packages/design-system/SKILL.md) — 设计系统使用规范
+- [AGENT_PROMPTS.md](packages/design-system/AGENT_PROMPTS.md) — 分阶段实现 prompts
+\`\`\`
+```
+
+### Step 9: 将 token 纳入 clb-frontend 主题体系
+
+更新 `src/theme/tokens.ts`，从 `@clb/design-system` 导入基础 token，与现有 NaiveUI 主题合并。具体映射见 AGENT_PROMPTS.md Phase 1。
+
+### Step 10: 添加 pnpm workspace 依赖
+
+确保 `pnpm-workspace.yaml` 的 `packages` 数组包含 `packages/design-system`（当前配置 `packages/*` 已覆盖）。
+
+## 验证清单
+
+- [ ] `packages/design-system/package.json` 存在
+- [ ] `packages/design-system/src/tokens.css` 可被 import
+- [ ] `packages/design-system/preview/index.html` 可在浏览器打开
+- [ ] clb-frontend AGENTS.md 已更新
+- [ ] `pnpm typecheck` 通过
+- [ ] `pnpm dev` 启动后设计系统预览页可访问


### PR DESCRIPTION
Add Source Project Context (source-project-context-mrvu81gl) plugin.
Version: 0.1.0
Description: This design-system workspace was created from an existing Open Design project. Treat the copied project files as the primary source evidence for the generated design system.