### PR TITLE
fix(i18n): localize new project folder action

### DIFF
--- a/apps/web/src/components/NewProjectModal.tsx
+++ b/apps/web/src/components/NewProjectModal.tsx
@@ -12,6 +12,7 @@ import { AnimatePresence, motion } from 'motion/react';
 import type { ConnectorDetail } from '@open-design/contracts';
 import type { OpenDesignHostProjectImportSuccess } from '@open-design/host';
 import { modalOverlay, modalContent } from '../motion';
+import { useT } from '../i18n';
 import type {
   DesignSystemSummary,
   MediaProviderCredentials,
@@ -89,6 +90,8 @@ function NewProjectModalBody({
   const closeRef = useRef<HTMLButtonElement | null>(null);
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
+  const t = useT();
+  const title = t('newproj.titleOther');
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -133,7 +136,7 @@ function NewProjectModalBody({
       className="new-project-modal-backdrop"
       role="dialog"
       aria-modal="true"
-      aria-label="New project"
+      aria-label={title}
       data-testid="new-project-modal"
       onClick={(e) => {
         if (e.target === e.currentTarget && !creating) onClose();
@@ -151,7 +154,7 @@ function NewProjectModalBody({
         exit="exit"
       >
         <header className="new-project-modal__head">
-          <h2 className="new-project-modal__title">New project</h2>
+          <h2 className="new-project-modal__title">{title}</h2>
           <button
             ref={closeRef}
             type="button"

--- a/apps/web/src/components/NewProjectPanel.tsx
+++ b/apps/web/src/components/NewProjectPanel.tsx
@@ -1153,7 +1153,11 @@ export function NewProjectPanel({
               onClick={() => void folderImport.openFolder()}
             >
               <Icon name="folder" size={13} />
-              <span>{folderImport.importing ? 'Opening...' : 'Open folder'}</span>
+              <span>
+                {folderImport.importing
+                  ? t('newproj.openingFolder')
+                  : t('newproj.openFolder')}
+              </span>
             </button>
           </div>
         ) : null}

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1527,6 +1527,8 @@ export const ar: Dict = {
   'newproj.createLiveArtifact': 'إنشاء عنصر مباشر',
   'newproj.createFromTemplate': 'إنشاء من قالب',
   'newproj.createDisabledTitle': 'احفظ مشروعاً كقالب أولاً (قائمة المشاركة داخل أي مشروع).',
+  'newproj.openFolder': 'فتح مجلد',
+  'newproj.openingFolder': 'جاري الفتح…',
   'newproj.importClaudeZip': 'استيراد ZIP من Claude Design',
   'newproj.importClaudeZipTitle': 'استيراد تصدير .zip من Claude Design',
   'newproj.importingClaudeZip': 'جاري الاستيراد...',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -1527,6 +1527,8 @@ export const de: Dict = {
   'newproj.createLiveArtifact': 'Live-Artefakt erstellen',
   'newproj.createFromTemplate': 'Aus Template erstellen',
   'newproj.createDisabledTitle': 'Speichern Sie zuerst ein Projekt als Template (Teilen-Menü in einem beliebigen Projekt).',
+  'newproj.openFolder': 'Ordner öffnen',
+  'newproj.openingFolder': 'Ordner wird geöffnet…',
   'newproj.importClaudeZip': 'Claude Design ZIP importieren',
   'newproj.importClaudeZipTitle': 'Einen Claude Design .zip-Export importieren',
   'newproj.importingClaudeZip': 'Import läuft…',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1527,6 +1527,8 @@ export const en: Dict = {
   'newproj.createLiveArtifact': 'Create live artifact',
   'newproj.createFromTemplate': 'Create from template',
   'newproj.createDisabledTitle': 'Save a project as a template first (Share menu inside any project).',
+  'newproj.openFolder': 'Open folder',
+  'newproj.openingFolder': 'Opening…',
   'newproj.importClaudeZip': 'Import Claude Design ZIP',
   'newproj.importClaudeZipTitle': 'Import a Claude Design .zip export',
   'newproj.importingClaudeZip': 'Importing…',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -1527,6 +1527,8 @@ export const esES: Dict = {
   'newproj.createLiveArtifact': 'Crear artefacto en vivo',
   'newproj.createFromTemplate': 'Crear desde plantilla',
   'newproj.createDisabledTitle': 'Guarda primero un proyecto como plantilla (menú Compartir dentro de cualquier proyecto).',
+  'newproj.openFolder': 'Abrir carpeta',
+  'newproj.openingFolder': 'Abriendo…',
   'newproj.importClaudeZip': 'Importar ZIP de Claude Design',
   'newproj.importClaudeZipTitle': 'Importar una exportación .zip de Claude Design',
   'newproj.importingClaudeZip': 'Importando…',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1527,6 +1527,8 @@ export const fa: Dict = {
   'newproj.createLiveArtifact': 'ایجاد مصنوع زنده',
   'newproj.createFromTemplate': 'ایجاد از قالب',
   'newproj.createDisabledTitle': 'ابتدا یک پروژه را به عنوان قالب ذخیره کنید (منوی اشتراک‌گذاری در داخل هر پروژه).',
+  'newproj.openFolder': 'باز کردن پوشه',
+  'newproj.openingFolder': 'در حال باز کردن…',
   'newproj.importClaudeZip': 'وارد کردن ZIP طراحی Claude',
   'newproj.importClaudeZipTitle': 'وارد کردن یک فایل .zip صادر شده از Claude Design',
   'newproj.importingClaudeZip': 'در حال وارد کردن…',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1527,6 +1527,8 @@ export const fr: Dict = {
   'newproj.createLiveArtifact': 'Créer un artefact dynamique',
   'newproj.createFromTemplate': 'Créer depuis le modèle',
   'newproj.createDisabledTitle': 'Enregistrez d\'abord un projet comme modèle (menu Partager dans un projet).',
+  'newproj.openFolder': 'Ouvrir un dossier',
+  'newproj.openingFolder': 'Ouverture…',
   'newproj.importClaudeZip': 'Importer un ZIP Claude Design',
   'newproj.importClaudeZipTitle': 'Importer une exportation .zip Claude Design',
   'newproj.importingClaudeZip': 'Importation…',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1527,6 +1527,8 @@ export const hu: Dict = {
   'newproj.createLiveArtifact': 'Élő artifact létrehozása',
   'newproj.createFromTemplate': 'Létrehozás sablonból',
   'newproj.createDisabledTitle': 'Először ments el egy projektet sablonként (bármely projekt Megosztás menüjéből).',
+  'newproj.openFolder': 'Mappa megnyitása',
+  'newproj.openingFolder': 'Megnyitás…',
   'newproj.importClaudeZip': 'Claude Design ZIP importálása',
   'newproj.importClaudeZipTitle': 'Claude Design .zip export importálása',
   'newproj.importingClaudeZip': 'Importálás…',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1527,6 +1527,8 @@ export const id: Dict = {
   'newproj.createLiveArtifact': 'Buat live artifact',
   'newproj.createFromTemplate': 'Buat dari templat',
   'newproj.createDisabledTitle': 'Simpan proyek sebagai templat dulu.',
+  'newproj.openFolder': 'Buka folder',
+  'newproj.openingFolder': 'Membuka…',
   'newproj.importClaudeZip': 'Impor ZIP Claude Design',
   'newproj.importClaudeZipTitle': 'Impor file .zip hasil ekspor Claude Design',
   'newproj.importingClaudeZip': 'Mengimpor...',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -1527,6 +1527,8 @@ export const it: Dict = {
   'newproj.createLiveArtifact': 'Crea artefatto live',
   'newproj.createFromTemplate': 'Crea dal modello',
   'newproj.createDisabledTitle': 'Salva prima un progetto come modello (menu Condividi in un progetto).',
+  'newproj.openFolder': 'Apri cartella',
+  'newproj.openingFolder': 'Apertura…',
   'newproj.importClaudeZip': 'Importa un ZIP Claude Design',
   'newproj.importClaudeZipTitle': 'Importa un\'esportazione .zip Claude Design',
   'newproj.importingClaudeZip': 'Importazione…',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -1527,6 +1527,8 @@ export const ja: Dict = {
   'newproj.createLiveArtifact': 'ライブアーティファクトを作成',
   'newproj.createFromTemplate': 'テンプレートから作成',
   'newproj.createDisabledTitle': '最初にプロジェクトをテンプレートとして保存してください（プロジェクト内の共有メニュー）。',
+  'newproj.openFolder': 'フォルダを開く',
+  'newproj.openingFolder': '開いています…',
   'newproj.importClaudeZip': 'Claude Design ZIP をインポート',
   'newproj.importClaudeZipTitle': 'Claude Design の .zip エクスポートをインポート',
   'newproj.importingClaudeZip': 'インポート中…',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1527,6 +1527,8 @@ export const ko: Dict = {
   'newproj.createLiveArtifact': '라이브 아티팩트 만들기',
   'newproj.createFromTemplate': '템플릿으로 생성',
   'newproj.createDisabledTitle': '먼저 프로젝트를 템플릿으로 저장하세요 (프로젝트 내 공유 메뉴 이용).',
+  'newproj.openFolder': '폴더 열기',
+  'newproj.openingFolder': '여는 중…',
   'newproj.importClaudeZip': 'Claude Design ZIP 가져오기',
   'newproj.importClaudeZipTitle': 'Claude Design .zip 내보내기 파일 가져오기',
   'newproj.importingClaudeZip': '가져오는 중…',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1527,6 +1527,8 @@ export const pl: Dict = {
   'newproj.createLiveArtifact': 'Utwórz aktywny artefakt',
   'newproj.createFromTemplate': 'Utwórz z szablonu',
   'newproj.createDisabledTitle': 'Najpierw zapisz projekt jako szablon (menu Udostępnij wewnątrz projektu).',
+  'newproj.openFolder': 'Otwórz folder',
+  'newproj.openingFolder': 'Otwieranie…',
   'newproj.importClaudeZip': 'Importuj Claude Design ZIP',
   'newproj.importClaudeZipTitle': 'Importuj eksport .zip z Claude Design',
   'newproj.importingClaudeZip': 'Importowanie…',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1527,6 +1527,8 @@ export const ptBR: Dict = {
   'newproj.createLiveArtifact': 'Criar artefato live',
   'newproj.createFromTemplate': 'Criar a partir do template',
   'newproj.createDisabledTitle': 'Salve primeiro um projeto como template (menu Compartilhar dentro de qualquer projeto).',
+  'newproj.openFolder': 'Abrir pasta',
+  'newproj.openingFolder': 'Abrindo…',
   'newproj.importClaudeZip': 'Importar ZIP do Claude Design',
   'newproj.importClaudeZipTitle': 'Importar uma exportação .zip do Claude Design',
   'newproj.importingClaudeZip': 'Importando…',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1527,6 +1527,8 @@ export const ru: Dict = {
   'newproj.createLiveArtifact': 'Создать live-артефакт',
   'newproj.createFromTemplate': 'Создать из шаблона',
   'newproj.createDisabledTitle': 'Сначала сохраните проект как шаблон (меню «Поделиться» в любом проекте).',
+  'newproj.openFolder': 'Открыть папку',
+  'newproj.openingFolder': 'Открытие…',
   'newproj.importClaudeZip': 'Импортировать ZIP-файл из Claude Design',
   'newproj.importClaudeZipTitle': 'Импортировать экспорт `.zip` из Claude Design',
   'newproj.importingClaudeZip': 'Импорт…',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -1527,6 +1527,8 @@ export const th: Dict = {
   'newproj.createLiveArtifact': 'สร้าง live artifact',
   'newproj.createFromTemplate': 'สร้างจากเทมเพลต',
   'newproj.createDisabledTitle': 'คุณต้องบันทึกโปรเจกต์เป็นเทมเพลตก่อน',
+  'newproj.openFolder': 'เปิดโฟลเดอร์',
+  'newproj.openingFolder': 'กำลังเปิด…',
   'newproj.importClaudeZip': 'นำเข้า Claude Design ZIP',
   'newproj.importClaudeZipTitle': 'นำเข้า .zip จาก Claude Design',
   'newproj.importingClaudeZip': 'กำลังนำเข้า…',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1527,6 +1527,8 @@ export const tr: Dict = {
   'newproj.createLiveArtifact': 'Canlı artifact oluştur',
   'newproj.createFromTemplate': 'Şablondan oluştur',
   'newproj.createDisabledTitle': 'Önce bir projeyi şablon olarak kaydedin (herhangi bir projenin içinde Paylaş menüsünden).',
+  'newproj.openFolder': 'Klasör aç',
+  'newproj.openingFolder': 'Açılıyor…',
   'newproj.importClaudeZip': 'Claude Design ZIP’i içe aktar',
   'newproj.importClaudeZipTitle': 'Bir Claude Design .zip’ini içe aktarın',
   'newproj.importingClaudeZip': 'İçe aktarılıyor…',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1527,6 +1527,8 @@ export const uk: Dict = {
   'newproj.createLiveArtifact': 'Створити live-артефакт',
   'newproj.createFromTemplate': 'Створити з шаблону',
   'newproj.createDisabledTitle': 'Спочатку збережіть проект як шаблон (меню Поділитися всередині будь-якого проекту).',
+  'newproj.openFolder': 'Відкрити папку',
+  'newproj.openingFolder': 'Відкриття…',
   'newproj.importClaudeZip': 'Імпортувати Claude Design ZIP',
   'newproj.importClaudeZipTitle': 'Імпортувати експорт Claude Design .zip',
   'newproj.importingClaudeZip': 'Імпортування…',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1634,6 +1634,8 @@ export const zhCN: Dict = {
   "newproj.createFromTemplate": "基于模板创建",
   "newproj.createDisabledTitle":
     "请先在任意项目内通过「分享」菜单将其保存为模板。",
+  "newproj.openFolder": "打开文件夹",
+  "newproj.openingFolder": "正在打开…",
   "newproj.importClaudeZip": "导入 Claude Design ZIP",
   "newproj.importClaudeZipTitle": "导入 Claude Design 导出的 .zip 文件",
   "newproj.importingClaudeZip": "正在导入…",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1643,6 +1643,8 @@ export const zhTW: Dict = {
   "newproj.createFromTemplate": "基於範本建立",
   "newproj.createDisabledTitle":
     "請先在任意專案內透過「分享」選單將其儲存為範本。",
+  "newproj.openFolder": "開啟資料夾",
+  "newproj.openingFolder": "正在開啟…",
   "newproj.importClaudeZip": "匯入 Claude Design ZIP",
   "newproj.importClaudeZipTitle": "匯入 Claude Design 匯出的 .zip 檔案",
   "newproj.importingClaudeZip": "正在匯入…",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -2035,6 +2035,8 @@ export interface Dict {
   'newproj.createLiveArtifact': string;
   'newproj.createFromTemplate': string;
   'newproj.createDisabledTitle': string;
+  'newproj.openFolder': string;
+  'newproj.openingFolder': string;
   'newproj.importClaudeZip': string;
   'newproj.importClaudeZipTitle': string;
   'newproj.importingClaudeZip': string;

--- a/apps/web/tests/components/NewProjectModal.test.tsx
+++ b/apps/web/tests/components/NewProjectModal.test.tsx
@@ -10,6 +10,7 @@ vi.mock('@open-design/host', () => ({
 
 import { pickAndImportHostProject } from '@open-design/host';
 import { NewProjectModal } from '../../src/components/NewProjectModal';
+import { I18nProvider } from '../../src/i18n';
 import type {
   DesignSystemSummary,
   ProjectTemplate,
@@ -131,7 +132,12 @@ describe('NewProjectModal layout', () => {
       ok: true,
       projectId: 'project-host',
     } as const;
-    vi.mocked(pickAndImportHostProject).mockResolvedValue(importResult);
+    let resolveImport!: (value: typeof importResult) => void;
+    vi.mocked(pickAndImportHostProject).mockImplementation(
+      () => new Promise<typeof importResult>((resolve) => {
+        resolveImport = resolve;
+      }),
+    );
     const onImportFolderResponse = vi.fn();
 
     render(
@@ -153,9 +159,37 @@ describe('NewProjectModal layout', () => {
     await waitFor(() => {
       expect(pickAndImportHostProject).toHaveBeenCalledWith({ skillId: 'prototype-skill' });
     });
+    expect(screen.getByRole('button', { name: 'Opening…' })).toBeTruthy();
+
+    resolveImport(importResult);
+
     await waitFor(() => {
       expect(onImportFolderResponse).toHaveBeenCalledWith(importResult);
     });
+  });
+
+  it('localizes the modal title and folder action in zh-CN', () => {
+    render(
+      <I18nProvider initial="zh-CN">
+        <NewProjectModal
+          open
+          skills={skills}
+          designSystems={designSystems}
+          defaultDesignSystemId={null}
+          templates={[]}
+          promptTemplates={[]}
+          onCreate={() => {}}
+          onImportFolderResponse={() => {}}
+          onClose={() => {}}
+        />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByRole('dialog', { name: '新建项目' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: '新建项目' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: '打开文件夹' })).toBeTruthy();
+    expect(screen.queryByText('New project')).toBeNull();
+    expect(screen.queryByText('Open folder')).toBeNull();
   });
 });
 


### PR DESCRIPTION
Fixes #5000

## Why

While checking the Chinese new-project flow, I found that the modal title and desktop folder import action still used English copy. This addresses the user-facing localization gap so contributors using Chinese do not hit mixed-language UI in the project creation entry point.

## What users will see

The New Project modal title now follows the selected UI language, and the desktop folder import action now uses localized copy for both the idle and loading states. English behavior remains the same aside from using the existing typographic ellipsis style for the loading label.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

CLI is not applicable because this fixes existing localized web copy and does not add or change a capability, endpoint, command, or workflow contract.

## Screenshots

The CI visual regression report posted on this PR shows 0 changed screenshots across the visual suite. This change keeps the existing modal layout and entry point unchanged; the visible Chinese modal title and folder action are covered by the component test listed below.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/NewProjectModal.test.tsx`
- Did the test go red on `main` and green on this branch? yes
- If a red spec wasn't cheap to write, explain why and what verification you did instead: n/a

## Validation

- `pnpm --dir apps/web exec vitest run -c vitest.config.ts --maxWorkers=2 tests/components/NewProjectModal.test.tsx`
- `pnpm --dir apps/web exec vitest run -c vitest.config.ts --maxWorkers=2 tests/i18n/locales.test.ts`
- `pnpm --filter @open-design/web typecheck`
- `pnpm i18n:check`
- `pnpm guard`
- `git diff --check`
