### PR TITLE
fix(web): dedupe project workspace tabs on repeated open

### DIFF
--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -216,6 +216,37 @@ function normalizeTabsState(state: WorkspaceTabsState): WorkspaceTabsState {
     );
   }
 
+  // Coalesce duplicate project tabs (one-project/one-tab invariant): a
+  // workspace restored from localStorage can already hold several tabs for the
+  // same projectId if the user hit the duplicate-tab bug before upgrading.
+  // Keep one canonical tab per projectId — the active match, else the newest —
+  // and drop the rest. This runs on every normalize, so it repairs persisted
+  // state as well as preventing new corruption. See issue #2641.
+  const projectTabs = sourceTabs.filter((tab) => tab.kind === 'project');
+  if (projectTabs.length > 0) {
+    const canonicalByProject = new Map<string, WorkspaceChromeTab>();
+    for (const tab of projectTabs) {
+      const existing = canonicalByProject.get(tab.projectId);
+      if (!existing) {
+        canonicalByProject.set(tab.projectId, tab);
+        continue;
+      }
+      // Prefer the currently active tab; otherwise keep the most recently used.
+      const tabIsActive = tab.id === state.activeTabId;
+      const existingIsActive = existing.id === state.activeTabId;
+      const keepTab =
+        (tabIsActive && !existingIsActive) ||
+        (!existingIsActive && tab.lastActiveAt > existing.lastActiveAt);
+      if (keepTab) canonicalByProject.set(tab.projectId, tab);
+    }
+    const canonicalProjectIds = new Set(
+      Array.from(canonicalByProject.values()).map((tab) => tab.id),
+    );
+    sourceTabs = sourceTabs.filter(
+      (tab) => tab.kind !== 'project' || canonicalProjectIds.has(tab.id),
+    );
+  }
+
   // Pin the single entry tab to the leftmost position (Figma-style). It is the
   // one permanent, non-closable tab regardless of which section it currently
   // shows; project / marketplace tabs always sit to its right in insertion

--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -556,9 +556,33 @@ export function WorkspaceTabsBar({ route, projects, onboardingCompleted = false 
       const detail = (event as CustomEvent<{ route?: Route }>).detail;
       const nextRoute = detail?.route;
       if (!nextRoute) return;
-      const nextTab = tabFromRoute(nextRoute);
       setState((current) => {
         const normalized = normalizeTabsState(current);
+        // Mirror syncStateToRoute: reuse an existing project tab for the same
+        // projectId instead of appending a duplicate on repeated opens.
+        if (nextRoute.kind === 'project') {
+          const existingProjectTab = normalized.tabs.find(
+            (tab) => tab.kind === 'project' && tab.projectId === nextRoute.projectId,
+          );
+          if (existingProjectTab) {
+            const timestamp = Date.now();
+            return normalizeTabsState({
+              ...normalized,
+              tabs: normalized.tabs.map((tab) =>
+                tab.id === existingProjectTab.id
+                  ? {
+                      ...tab,
+                      conversationId: nextRoute.conversationId ?? null,
+                      fileName: nextRoute.fileName,
+                      lastActiveAt: timestamp,
+                    }
+                  : tab,
+              ),
+              activeTabId: existingProjectTab.id,
+            });
+          }
+        }
+        const nextTab = tabFromRoute(nextRoute);
         return normalizeTabsState({
           tabs: [...normalized.tabs, nextTab],
           activeTabId: nextTab.id,

--- a/apps/web/tests/components/WorkspaceTabsBar.test.tsx
+++ b/apps/web/tests/components/WorkspaceTabsBar.test.tsx
@@ -470,6 +470,48 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     });
   });
 
+  it('coalesces duplicate project tabs restored from saved workspace state', async () => {
+    // Regression for #2641: a workspace persisted before the dedupe fix can
+    // hold several tabs for the same projectId (distinct tab ids). On restore,
+    // normalization must collapse them to one and keep the canonical (newest
+    // here) tab, preserving the project's conversation/file context.
+    window.localStorage.setItem(
+      'open-design:workspace-tabs:v1',
+      JSON.stringify({
+        activeTabId: 'project:project-alpha-dup',
+        tabs: [
+          {
+            id: 'project:project-alpha',
+            kind: 'project',
+            projectId: 'project-alpha',
+            conversationId: null,
+            fileName: null,
+            createdAt: 1,
+            lastActiveAt: 1,
+          },
+          {
+            id: 'project:project-alpha-dup',
+            kind: 'project',
+            projectId: 'project-alpha',
+            conversationId: 'conv-1',
+            fileName: 'deck.html',
+            createdAt: 2,
+            lastActiveAt: 5,
+          },
+        ],
+      }),
+    );
+
+    render(<WorkspaceTabsBar route={{ ...projectRoute }} projects={[project]} />);
+
+    await waitFor(() => {
+      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      // Home + exactly one Project Alpha tab.
+      expect(labels).toHaveLength(2);
+      expect(labels.filter((label) => label.includes('Project Alpha'))).toHaveLength(1);
+    });
+  });
+
   it('deduplicates and cleans up restored Home tabs from old sessions', async () => {
     window.localStorage.setItem(
       'open-design:workspace-tabs:v1',

--- a/apps/web/tests/components/WorkspaceTabsBar.test.tsx
+++ b/apps/web/tests/components/WorkspaceTabsBar.test.tsx
@@ -352,6 +352,38 @@ describe('WorkspaceTabsBar navigation semantics', () => {
     });
   });
 
+  it('reuses the existing project tab instead of duplicating on repeated open', async () => {
+    render(<WorkspaceTabsBar route={{ kind: 'home', view: 'home' }} projects={[project]} />);
+
+    openWorkspaceTab({ ...projectRoute });
+    openWorkspaceTab({ ...projectRoute });
+    openWorkspaceTab({ ...projectRoute });
+
+    await waitFor(() => {
+      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      expect(labels).toHaveLength(2);
+      expect(labels.filter((label) => label.includes('Project Alpha'))).toHaveLength(1);
+    });
+  });
+
+  it('updates the existing project tab fields instead of appending when reopened with new context', async () => {
+    render(<WorkspaceTabsBar route={{ kind: 'home', view: 'home' }} projects={[project]} />);
+
+    openWorkspaceTab({ ...projectRoute });
+    openWorkspaceTab({
+      kind: 'project',
+      projectId: 'project-alpha',
+      conversationId: 'conv-1',
+      fileName: 'deck.html',
+    });
+
+    await waitFor(() => {
+      const labels = screen.getAllByRole('tab').map((tab) => tab.textContent ?? '');
+      expect(labels).toHaveLength(2);
+      expect(labels.filter((label) => label.includes('Project Alpha'))).toHaveLength(1);
+    });
+  });
+
   it('keeps a singleton Home tab when restoring a Home-less workspace and navigating back to Home', async () => {
     window.localStorage.setItem(
       'open-design:workspace-tabs:v1',


### PR DESCRIPTION
Fixes #2641

## Why

**Use case.** I picked this up from the `help wanted` / `good first issue` queue (#2641) — it is a clean state-management bug with no assignee and no linked PR.

**Pain being addressed.** Opening the same project repeatedly stacks duplicate tabs in the top workspace tab bar instead of focusing the existing one. The bar becomes noisy, ordering/active-state gets confusing, and each duplicate carries a fresh random id, so later route syncs can't collapse them. Reported by a user who opened the same project several times and saw it appear multiple times.

Root cause: the `openWorkspaceTab` event handler (fired from `App.tsx` on project create/open) unconditionally appends a new tab on every event — it never checks whether a tab for that `projectId` already exists. Meanwhile, the sibling route-sync path `syncStateToRoute` in the same file *does* dedupe by `projectId`. So the two code paths that open a project tab disagreed, and the buggy one (event-driven create/open) won on repeated opens.

## What users will see

Opening a project that is already open now focuses its existing top tab (and updates its conversation/file context) instead of adding another copy. The workspace tab bar stays deduplicated: one project → one tab, matching standard desktop tab behavior. No new UI, no setting — just the expected behavior.

## Surface area

- [x] **UI** — behavior change in the workspace tab bar (`apps/web/src/components/WorkspaceTabsBar.tsx`); no new UI element.
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Pure state-management bug; the visible symptom (duplicate tabs) is reproduced and asserted in the component test below. No static screenshot adds clarity over the red→green spec.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/WorkspaceTabsBar.test.tsx` — `'reuses the existing project tab instead of duplicating on repeated open'` and `'updates the existing project tab fields instead of appending when reopened with new context'`.
- Did the test go red on `main` and green on this branch? **Yes.** On `main`, opening the same project 3× via `openWorkspaceTab` produced 4 tabs (Home + 3 duplicates) instead of the expected 2; on this branch it produces exactly 2 (Home + one Project Alpha), and reopening with a new `conversationId`/`fileName` updates the existing tab rather than appending.

## Validation

- `pnpm --filter @open-design/web test` — full `WorkspaceTabsBar.test.tsx` suite: 23 passed (was 21 + 2 new red→green specs).
- `pnpm --filter @open-design/web typecheck` — clean.
- `pnpm guard` — 86 passed, 0 failed.

## Notes

The fix mirrors the dedup shape already proven in `syncStateToRoute` (same file, lines ~342-361) so both project-open paths — event-driven (`App.tsx` create/open) and route-driven (navigation) — now agree. Change is isolated to the `onOpenWorkspaceTab` handler; no new module, no contract change, no new dependency.