### PR TITLE
fix(web): use palette icon for design-systems entry tab

### DIFF
--- a/apps/web/src/components/WorkspaceTabsBar.tsx
+++ b/apps/web/src/components/WorkspaceTabsBar.tsx
@@ -1809,7 +1809,11 @@ function displayTabFor(
     projects: 'folder',
     tasks: 'kanban',
     plugins: 'grid',
-    'design-systems': 'blocks',
+    // `palette` is a clean line glyph that reads as "design system / tokens",
+    // consistent with the other outline entry icons. The heavier `blocks`
+    // glyph renders visually inconsistent next to them (same reason Brand Kit
+    // nav moved off `blocks` — see Icon.tsx swatchbook comment).
+    'design-systems': 'palette',
     library: 'image',
     brands: 'blocks',
     integrations: 'link',


### PR DESCRIPTION
Fixes #2625

## Why

**Use case.** Picked up from the `help wanted` / `good first issue` queue (#2625) — a UI-consistency bug with no assignee and no linked PR.

**Pain being addressed.** The Design systems tab in the top workspace tab bar looks stylistically off compared to the other pinned entry tabs (Home, Projects, Automations, Plugins). Investigating the chrome, the box styling (className, padding, border, active state, icon size) is **byte-identical** to every other entry tab — they all share one render path (`WorkspaceTabsBar.tsx:975-1026`) and no CSS rule keys off `design-systems`. The *only* visual divergence is the icon: `design-systems` maps to the `'blocks'` glyph (Icon.tsx `case 'blocks'`), whose self-intersecting path plus a solid `<rect>` renders substantially heavier/darker than the clean line-style icons used by every other entry (home/folder/grid/kanban/link). At 14px it reads as a solid smudge next to Home's crisp outline.

This is the same problem the codebase already solved once: the Brand Kit nav was retargeted away from `'blocks'` to `'swatchbook'` for exactly this reason (see the `swatchbook` comment in Icon.tsx). The design-systems entry never got the same treatment.

## What users will see

The Design systems tab icon now renders as a clean line-style palette glyph, visually consistent in weight with the Home, Projects, Automations, and Plugins tab icons. No layout, spacing, or behavior change — just a coherent icon.

## Surface area

- [x] **UI** — icon swap on the Design systems workspace entry tab (`apps/web/src/components/WorkspaceTabsBar.tsx`).
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Icon-weight change at 14px; the visual difference is a heavier vs. lighter glyph. Reviewers can see it by opening the app and comparing the Design systems tab icon to the Home tab icon on `main` vs. this branch.

## Bug fix verification

This is a visual/icon-consistency change, not a logic bug — a falsifiable behavioral test that goes red isn't cheap to write meaningfully (asserting a specific SVG glyph in RTL tests nothing useful about visual weight). Instead, verification is:
- Confirmed the root cause by inspection: the only per-entry difference is `entryIcon['design-systems']`; the box chrome is identical across all entry kinds.
- Confirmed the precedent: Brand Kit nav already moved off `'blocks'` for the identical reason.
- Confirmed `'palette'` is a clean line glyph (stroke-only path) consistent with the sibling entry icons.

## Validation

- `pnpm --filter @open-design/web typecheck` — clean.
- `pnpm --filter @open-design/web test` — `WorkspaceTabsBar.test.tsx` (23) + `workspace-tabs-chrome.test.ts` (9) pass.
- `pnpm guard` — 86 passed, 0 failed.

## Notes

One-line change in `displayTabFor`. `brands` still uses `'blocks'` deliberately (separate destination) and is out of scope here.