### PR TITLE
fix: update antigravity def for agy v1.1.5 prompt via args

### DIFF
--- a/apps/daemon/src/runtimes/defs/antigravity.ts
+++ b/apps/daemon/src/runtimes/defs/antigravity.ts
@@ -215,17 +215,14 @@ export const antigravityAgentDef = {
         runtimeContext.antigravitySettingsPath,
       );
     }
-    // We invoke agy via `-p -` (print mode + stdin sentinel), NOT
-    // `chat -`. Verified against `agy --help` on v1.0.3 — the
-    // `Available subcommands` list is `changelog / help / install /
-    // plugin / update`, and `chat` is NOT among them. `-p` is the
-    // documented print-mode flag (`Short alias for --print`) and
-    // `agy -p -` reads the prompt from stdin. The looper reviewer
-    // bot's environment runs a different agy build that may have
-    // renamed the entry point; until upstream confirms a stable
+    // We invoke agy via `-p <prompt>` (print mode).
+    // In `agy` v1.0.3, `-p -` read from stdin, but as of v1.1.5,
+    // `-p` requires the prompt to be passed as a positional argument.
+    // The looper reviewer bot's environment runs a different agy build
+    // that may have renamed the entry point; until upstream confirms a stable
     // headless subcommand (see google-antigravity/antigravity-cli#119)
     // and the change actually ships in the auto-update channel that
-    // packaged OD users get, `-p -` is the contract that actually
+    // packaged OD users get, `-p <prompt>` is the contract that actually
     // produces a print-mode reply on the installed CLI.
     const args: string[] = [];
     // Always opt into `--log-file` when the daemon supplied a path so
@@ -243,11 +240,10 @@ export const antigravityAgentDef = {
     if (runtimeContext.agentLogFilePath) {
       args.push('--log-file', runtimeContext.agentLogFilePath);
     }
-    args.push('-p');
-    args.push('-');
+    args.push('-p', _prompt);
     return args;
   },
-  promptViaStdin: true,
+  promptViaStdin: false,
   streamFormat: 'plain',
   installUrl: 'https://antigravity.google/cli',
   docsUrl: 'https://antigravity.google/docs/cli-overview',


### PR DESCRIPTION
## Why

The `agy` CLI has updated from v1.0.3 to v1.1.5. In v1.1.5, the `-p` (or `--print`) flag behavior was changed. Previously, `-p -` was used to read the prompt from `stdin`. In v1.1.5, the `-p` flag now requires the prompt to be passed as a positional argument directly.

Because Open Design was still using the old method, it was passing the literal string `"-"` as the prompt, leading to the agent responding that the user's message was "just a dash" or "empty".

This PR updates the Antigravity CLI integration to pass the composed prompt as an argument directly and disables `promptViaStdin`.

## What users will see

Users utilizing the Antigravity CLI will now be able to communicate with the agent without encountering the "empty message" or "just a dash" issue.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A

## Bug fix verification

- Test path that reproduces the bug: N/A - The bug reproduces naturally in chat when utilizing the Antigravity CLI via daemon processing on `agy` v1.1.5. 
- Did the test go red on `main` and green on this branch? N/A (Test requires manual verification against external CLI version)

## Validation

- Validated via `agy` v1.1.5 using a print command directly (`agy -p <prompt>`) vs the old method `echo "..." | agy -p -`
- Daemon successfully starts, builds the new `.js` configuration correctly, and properly communicates with the Antigravity CLI.
