### PR TITLE
fix: fall back for blog indexing gsc auth

### DIFF
--- a/apps/landing-page/scripts/blog-indexing/lib.ts
+++ b/apps/landing-page/scripts/blog-indexing/lib.ts
@@ -163,20 +163,35 @@ export async function fetchWithRetry(
 let cachedToken: { token: string; expiresAt: number } | null = null;
 
 /**
- * Returns a Google OAuth2 access token for the service account in
- * `GSC_SERVICE_ACCOUNT_KEY`. Caches in-process for ~50 minutes.
+ * Returns a Google OAuth2 access token. OAuth user refresh tokens are preferred,
+ * but a configured service account remains a fallback when the user token is
+ * revoked or expires.
  *
- * Tokens are JWT-signed locally (RS256) and exchanged with Google's
- * OAuth2 endpoint. We avoid the full `googleapis` package to keep the
+ * Service account tokens are JWT-signed locally (RS256) and exchanged with
+ * Google's OAuth2 endpoint. We avoid the full `googleapis` package to keep the
  * landing-page workspace dep-free for what is purely a CI surface.
  */
 export async function getAccessToken(): Promise<string> {
   if (cachedToken && Date.now() < cachedToken.expiresAt) {
     return cachedToken.token;
   }
-  const oauthToken = await getOAuthAccessToken();
+  const oauthToken = await getOAuthAccessTokenWithFallback();
   if (oauthToken) return oauthToken;
   return getServiceAccountAccessToken();
+}
+
+async function getOAuthAccessTokenWithFallback(): Promise<string | null> {
+  try {
+    return await getOAuthAccessToken();
+  } catch (err) {
+    if (!process.env.GSC_SERVICE_ACCOUNT_KEY) {
+      throw err;
+    }
+    console.warn(
+      `GSC OAuth token refresh failed; falling back to service account auth: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  }
 }
 
 async function getOAuthAccessToken(): Promise<string | null> {

--- a/apps/landing-page/tests/blog-indexing-auth.test.ts
+++ b/apps/landing-page/tests/blog-indexing-auth.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { generateKeyPairSync } from 'node:crypto';
+import test from 'node:test';
+
+import { getAccessToken } from '../scripts/blog-indexing/lib.ts';
+
+const originalEnv = { ...process.env };
+const originalFetch = globalThis.fetch;
+const originalWarn = console.warn;
+
+test.afterEach(() => {
+  process.env = { ...originalEnv };
+  globalThis.fetch = originalFetch;
+  console.warn = originalWarn;
+});
+
+test('blog indexing auth falls back to service account when OAuth refresh token is invalid', async () => {
+  const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const serviceAccountKey = {
+    client_email: 'blog-indexing@example.iam.gserviceaccount.com',
+    private_key: privateKey.export({ type: 'pkcs8', format: 'pem' }).toString(),
+    token_uri: 'https://oauth2.googleapis.com/token',
+  };
+  const calls: Array<{ url: string; body: string }> = [];
+
+  process.env.GSC_OAUTH_CLIENT_ID = 'client-id';
+  process.env.GSC_OAUTH_CLIENT_SECRET = 'client-secret';
+  process.env.GSC_OAUTH_REFRESH_TOKEN = 'stale-refresh-token';
+  process.env.GSC_SERVICE_ACCOUNT_KEY = JSON.stringify(serviceAccountKey);
+  const warnings: string[] = [];
+  console.warn = (message?: unknown) => {
+    warnings.push(String(message));
+  };
+
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), body: String(init?.body ?? '') });
+    if (calls.length === 1) {
+      return new Response(
+        JSON.stringify({ error: 'invalid_grant', error_description: 'Bad Request' }),
+        { status: 400 },
+      );
+    }
+    return Response.json({ access_token: 'service-account-token', expires_in: 3600 });
+  };
+
+  const token = await getAccessToken();
+
+  assert.equal(token, 'service-account-token');
+  assert.equal(calls.length, 2);
+  assert.match(calls[0]!.body, /grant_type=refresh_token/);
+  assert.match(calls[1]!.body, /grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer/);
+  assert.match(warnings[0] ?? '', /falling back to service account auth/);
+});


### PR DESCRIPTION
## Summary
- fall back to `GSC_SERVICE_ACCOUNT_KEY` when the blog-indexing OAuth refresh token fails
- add a regression test for the `invalid_grant` OAuth path

## Why
`blog-indexing-on-deploy` has been failing in `Submit sitemap to Search Console` because the configured Google OAuth refresh token returns `400 invalid_grant`. The workflow already has a service account secret configured, but the auth helper threw before reaching that fallback.

## Verification
- `node --import tsx --test apps/landing-page/tests/blog-indexing-auth.test.ts`
- `git diff --check origin/main...HEAD`
