### PR TITLE
fix(web): remove duplicate preview run elapsed

### DIFF
--- a/apps/web/src/components/PreviewRunStatusBar.tsx
+++ b/apps/web/src/components/PreviewRunStatusBar.tsx
@@ -4,7 +4,6 @@ import { trackPreviewRunStatusSurfaceView } from '../analytics/events';
 import { useAnalytics } from '../analytics/provider';
 import { useI18n } from '../i18n';
 import {
-  formatPreviewRunElapsed,
   latestPreviewRunStatus,
   PREVIEW_RUN_SUCCESS_VISIBLE_MS,
   previewRunStatusCompletedAt,
@@ -127,10 +126,10 @@ export function PreviewRunStatusBar({
   const displayed = current ?? lastVisible;
   if (!displayed) return null;
 
-  const elapsed = formatPreviewRunElapsed(displayed.elapsedMs);
-  const isFailure = displayed.phase === 'failed';
   const label = t(statusLabelKey(displayed));
 
+  // Keep the floating preview hint focused on the current stage. Precise run
+  // timing already appears in Chat, so repeating it here obscures the preview.
   return (
     <div
       className={`${styles.root}${leaving ? ` ${styles.leaving}` : ''}`}
@@ -146,11 +145,6 @@ export function PreviewRunStatusBar({
         >
           {label}
         </span>
-        {isFailure ? null : (
-          <span className={styles.elapsed} aria-hidden="true">
-            {t('previewRunStatus.elapsed', { time: elapsed })}
-          </span>
-        )}
       </div>
     </div>
   );

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -3178,6 +3178,7 @@ describe('FileWorkspace empty-project generation contract', () => {
     expect(previewStatus.closest('[data-testid="design-files-empty"]')).toBeNull();
     expect(previewStatus).not.toHaveAttribute('aria-live');
     expect(within(previewStatus).getByRole('status')).toHaveTextContent('Design ready');
-    expect(previewStatus.querySelector('[aria-hidden="true"]')).toHaveTextContent('Elapsed 0:03');
+    expect(previewStatus).not.toHaveTextContent('Elapsed');
+    expect(previewStatus.querySelector('[aria-hidden="true"]')).toBeNull();
   });
 });

--- a/apps/web/tests/components/PreviewRunStatusBar.test.tsx
+++ b/apps/web/tests/components/PreviewRunStatusBar.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { render, screen } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const { analyticsTrack } = vi.hoisted(() => ({ analyticsTrack: vi.fn() }));
@@ -29,6 +29,19 @@ function deliveredMessage(): ChatMessage {
   };
 }
 
+function runningMessage(): ChatMessage {
+  return {
+    id: 'running-message',
+    role: 'assistant',
+    content: '',
+    sessionMode: 'design',
+    runStatus: 'running',
+    createdAt: STARTED_AT,
+    startedAt: STARTED_AT,
+    events: [{ kind: 'tool_use', id: 'tool-1', name: 'write_file', input: {} }],
+  };
+}
+
 function renderStatus(messages: ChatMessage[]) {
   return render(
     <I18nProvider initial="en">
@@ -43,8 +56,21 @@ function renderStatus(messages: ChatMessage[]) {
 
 describe('PreviewRunStatusBar', () => {
   afterEach(() => {
+    cleanup();
     analyticsTrack.mockReset();
     vi.useRealTimers();
+  });
+
+  it('renders only the stage label while a Design run is active', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(STARTED_AT + 8 * 60_000 + 18_000);
+
+    renderStatus([runningMessage()]);
+
+    const status = screen.getByTestId('preview-run-status');
+    expect(status).toHaveTextContent('Building design solution');
+    expect(status).not.toHaveTextContent('Elapsed');
+    expect(status.querySelector('[aria-hidden="true"]')).toBeNull();
   });
 
   it('does not flash or track an already-expired delivered turn after an idle rerender', () => {


### PR DESCRIPTION
## Why

While validating a long-running Design-mode generation, the preview canvas showed
`Building design solution · Elapsed 8:18` over the artifact at the same time that
Chat already displayed the run duration. The second timer reads like stray
generated content, obscures the preview, and duplicates the timing source users
already have in Chat.

The root cause is `PreviewRunStatusBar` rendering the same persisted run's elapsed
time inside its absolutely positioned preview hint. This PR keeps the useful
stage/delivery label but removes the redundant timer.

This is the focused alternative to #6002: that PR removes the entire preview
status feature and its analytics/i18n/runtime coverage, while this change only
removes the duplicated elapsed text. The focused behavior was selected for the
`v0.16.1` patch line so the backport fixes the reported defect without removing
the broader preview delivery-feedback feature.

## What users will see

During Design-mode generation, verification, success, or delivery failure, the
preview canvas continues to show its short stage label, such as “Building design
solution” or “Design ready”, but no longer appends `Elapsed m:ss`. Chat continues
to display precise run timing.

## Surface area

- [x] **UI** — changes the existing Design preview status hint in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — removes redundant elapsed text without requiring an opt-in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Before: the original report captured `正在构建设计方案 · 已用时 8:18` centered
over the artifact while Chat simultaneously showed the running duration.

After: the same preview hint renders only `正在构建设计方案`. The exact before
and after strings are pinned by the red/green component specs below.

## Bug fix verification

- Test paths:
  - `apps/web/tests/components/PreviewRunStatusBar.test.tsx`
  - `apps/web/tests/components/FileWorkspace.test.tsx`
- Did the test go red on `main` and green on this branch? **Yes.**
  - Red on `origin/main`: active status rendered `Building design solutionElapsed 8:18`; delivered status rendered `Design readyElapsed 0:03`.
  - Green on this branch: both focused suites pass, 72/72 tests.

## Validation

- `pnpm exec vitest run -c vitest.config.ts --maxWorkers=2 tests/components/PreviewRunStatusBar.test.tsx tests/components/FileWorkspace.test.tsx` (from `apps/web`) — 72 passed
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
