### PR TITLE
fix(message-center): guard invalid published dates

### DIFF
--- a/apps/web/src/components/MessageCenter.tsx
+++ b/apps/web/src/components/MessageCenter.tsx
@@ -28,6 +28,12 @@ function unreadBadgeLabel(count: number): string {
   return count > 9 ? '9+' : String(count);
 }
 
+function formatPublishedDate(value: string, locale: Locale): string | null {
+  const publishedAt = new Date(value);
+  if (Number.isNaN(publishedAt.getTime())) return null;
+  return new Intl.DateTimeFormat(locale, { dateStyle: 'medium' }).format(publishedAt);
+}
+
 interface Props {
   onOpenNotificationSettings?: () => void;
 }
@@ -247,10 +253,10 @@ function MessageItem({
   onError: () => void;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const formatted = new Intl.DateTimeFormat(locale, { dateStyle: 'medium' }).format(new Date(message.publishedAt));
+  const formatted = formatPublishedDate(message.publishedAt, locale);
   const ctaUrl = safeExternalUrl(message.ctaUrl);
   return <article className={`${styles.item}${message.readAt ? '' : ` ${styles.itemUnread}`}${expanded ? ` ${styles.itemExpanded}` : ''}`}>
-    <button type="button" className={styles.itemSummary} aria-expanded={expanded} onClick={() => { setExpanded((value) => !value); void onRead(message.id).catch(onError); }}><span className={styles.itemMeta}><span>{message.typeName}</span><time dateTime={message.publishedAt}>{formatted}</time></span><strong>{message.title}</strong><span className={styles.bodyPreview}>{message.body}</span></button>
+    <button type="button" className={styles.itemSummary} aria-expanded={expanded} onClick={() => { setExpanded((value) => !value); void onRead(message.id).catch(onError); }}><span className={styles.itemMeta}><span>{message.typeName}</span>{formatted ? <time dateTime={message.publishedAt}>{formatted}</time> : null}</span><strong>{message.title}</strong><span className={styles.bodyPreview}>{message.body}</span></button>
     {expanded && message.ctaLabel && ctaUrl ? <div className={styles.itemActions}><button type="button" className={styles.primaryAction} onClick={() => window.open(ctaUrl, '_blank', 'noopener,noreferrer')}>{message.ctaLabel}</button></div> : null}
   </article>;
 }

--- a/apps/web/tests/components/MessageCenter.test.tsx
+++ b/apps/web/tests/components/MessageCenter.test.tsx
@@ -314,6 +314,34 @@ describe('MessageCenter', () => {
     expect(messageRequests).toBeGreaterThanOrEqual(2);
   });
 
+  it('renders cached messages when a published date is invalid', async () => {
+    const cachedMessages = [
+      {
+        ...defaultMessages[0]!,
+        id: 'invalid-date',
+        title: 'Cached update',
+        body: 'Cached body remains visible.',
+        publishedAt: 'not-a-date',
+        readAt: null,
+        ctaLabel: null,
+        ctaUrl: null,
+      },
+    ] satisfies MessageCenterMessage[];
+    localStorage.setItem('open-design.message-center.anonymous-started-at.v1', '2026-07-16T00:00:00.000Z');
+    localStorage.setItem('open-design.message-center.anonymous-messages.v1', JSON.stringify(cachedMessages));
+    localStorage.setItem('open-design.message-center.anonymous-read-ids.v1', JSON.stringify([]));
+    mockFetch({
+      onMessages: async () => new Response(null, { status: 500 }),
+    });
+
+    renderMessageCenter();
+    const dialog = await openCenter(1);
+
+    expect(within(dialog).getByText('Cached update')).toBeTruthy();
+    expect(within(dialog).getByText('Cached body remains visible.')).toBeTruthy();
+    expect(dialog.querySelector('time')).toBeNull();
+  });
+
   it('hydrates cached anonymous state through the ref-backed source of truth', async () => {
     const cachedMessages = [
       { ...defaultMessages[0]!, id: 'release', title: 'Release update', readAt: null, ctaLabel: null, ctaUrl: null },


### PR DESCRIPTION
Fixes #6004

## Why

While dogfooding the Message Center shipped in `open-design-v0.16.0`, I reproduced a cached message whose malformed `publishedAt` value caused `Intl.DateTimeFormat#format` to throw before the panel could finish rendering. A single bad cached or API-provided date should not hide the message content or make the rest of the Message Center unusable.

The issue was reported and scoped in #6004, where the cached-message regression path and focused invalid-date guard were confirmed before implementation.

## What users will see

The Message Center continues rendering a message's title and body when its published date is malformed. Only the invalid date metadata is omitted; valid dates keep the existing locale-aware formatting.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — this does not add or redesign a UI entry point. The malformed-cache behavior is covered at the component render boundary below.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/MessageCenter.test.tsx` (`renders cached messages when a published date is invalid`)
- Did the test go red on `main` and green on this branch? **Yes.** Before the guard, the spec failed with `RangeError: Invalid time value` at `MessageCenter.tsx:250`; after the guard, the title/body render and the invalid `<time>` metadata is absent.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/MessageCenter.test.tsx --maxWorkers=2` — 19/19 pass
- Message Center plus the unrelated timing-sensitive connector file in one process — 32/32 pass
- `pnpm --filter @open-design/web test` — 4,753 pass, 7 skipped, 1 unrelated intermittent failure in `App.connectors.test.tsx`; that file passes 13/13 alone and passes alongside `MessageCenter.test.tsx`. A clean `origin/main` baseline run passed 4,753 with 7 skipped.
