### PR TITLE
feat(tools-pack): add .deb packaging target for linux build

### DIFF
--- a/tools/pack/AGENTS.md
+++ b/tools/pack/AGENTS.md
@@ -12,6 +12,7 @@ Read `tools/pack/CACHE.md` before changing any build-cache node key, adding a ca
 - Windows registry observation/cleanup must go through `reg.exe` and stay scoped to entries matching the namespace install/uninstaller paths.
 - Windows lifecycle logs must expose NSIS automation logs/markers/timings in addition to app runtime logs.
 - Linux AppImage build/install/start/stop/logs/uninstall/cleanup smoke commands.
+- Linux `.deb` build via `--to deb` (standards-compliant Debian package; build target only, no lifecycle smoke). Packaging assets live under `resources/linux/debian/`.
 - Linux headless (no-Electron) install/start/stop via `--headless` flag on `install`, `start`, and `stop`.
 - Linux containerized builds via `electronuserland/builder` Docker image for distro-agnostic glibc compat.
 - Consuming sidecar/process/path primitives from `@open-design/sidecar-proto`, `@open-design/sidecar`, and `@open-design/platform`.

--- a/tools/pack/README.md
+++ b/tools/pack/README.md
@@ -96,6 +96,7 @@ Local lifecycle commands:
 
 - `tools-pack linux build --to all` (default; produces AppImage)
 - `tools-pack linux build --to appimage` (explicit AppImage)
+- `tools-pack linux build --to deb` (standards-compliant Debian package; build target only — no install/start/stop lifecycle smoke)
 - `tools-pack linux build --to dir` (unpacked output for fast iteration)
 - `tools-pack linux build --containerized` (run electron-builder inside `electronuserland/builder:base` Docker for a wider glibc compatibility target — requires Docker)
 - `tools-pack linux build --to all --portable` (release artifacts that must not bake local tools-pack runtime paths)
@@ -176,8 +177,12 @@ Linux desktop apps in this space split across formats: VS Code ships `.deb` + `.
 
 - AppImage signing (`--signed`) — deferred pending a GPG key infrastructure decision and a user-facing verification flow design (no ETA).
 - AppImage auto-update feed (`latest-linux.yml`) — the linux electron-builder config has no `publish` block wired, so a generated feed would point users at a feed that never updates. Tracked alongside signing.
-- `.deb` build is supported via `--to deb` — a standards-compliant Debian package (`Package: open-design`, install under `/opt/OpenDesign`, section `devel`, RFC822 maintainer, `libc6` + t64-aware `depends`, DEP-5 `copyright` and a valid Debian `changelog`; verified with `dpkg-deb`, `lintian`, and a real boot). Publishing it through the release pipeline, package **signing**, and an **APT repository** remain deferred (separate follow-up plus a GPG key + hosting decision).
-- Additional package formats: `.rpm`, Snap, Flatpak — deferred until there is demand and an owner for per-distro metadata, signing/store/repository plumbing, install/remove hooks, and release validation.
+- `.deb` build is supported via `--to deb` — a standards-compliant Debian package (`Package: open-design`, install under `/opt/OpenDesign`, section `devel`, RFC822 maintainer, `libc6` + t64-aware `depends`, DEP-5 `copyright`, a valid Debian `changelog`, and a `/usr/share/lintian/overrides` file documenting the bundled-Electron deviations; verified with `dpkg-deb`, `lintian`, and a real boot). Current scope is **build-only**:
+  - the tools-pack lifecycle (`install`/`start`/`stop`) and its smoke coverage stay **AppImage-only** — there is no `dpkg -i` acceptance smoke yet (planned);
+  - the release pipeline (`tools/release`), CI, and the landing page are **not** wired for `.deb` in this increment (release-lane wiring is a separate change);
+  - package **signing** and an **APT repository** remain deferred (GPG key + hosting decision).
+- `.rpm` is the planned next increment — `linux.maintainer` is already rpm-ready — but needs its own per-distro `depends`/section and `rpmlint` + install validation, so it is deferred rather than shipped untested.
+- Snap, Flatpak — deferred until there is demand and an owner for per-distro metadata, signing/store/repository plumbing, install/remove hooks, and release validation.
 - Full Linux AppImage PR smoke remains release-lane only; PR validation runs the Linux headless packaged smoke because it does not require a display server.
 
 `--to dmg` is manual-install DMG output only. Any builder-generated updater metadata such as `latest-mac.yml` or

--- a/tools/pack/README.md
+++ b/tools/pack/README.md
@@ -170,14 +170,15 @@ Verified smoke coverage in this repository currently includes:
 
 ### Format choice: why AppImage first
 
-Linux desktop apps in this space split across formats: VS Code ships `.deb` + `.rpm` + Snap; Discord ships AppImage + `.deb`; Slack ships `.deb` + `.rpm`; Cursor and Obsidian ship AppImage. We start with AppImage because one artifact can cover the widest glibc-compatible target without distro repositories, store packaging, signing infrastructure, or per-format install scripts, and it integrates cleanly with the namespace-scoped install layout. `.deb` / `.rpm` / Snap / Flatpak can land incrementally when user demand justifies the extra release ownership.
+Linux desktop apps in this space split across formats: VS Code ships `.deb` + `.rpm` + Snap; Discord ships AppImage + `.deb`; Slack ships `.deb` + `.rpm`; Cursor and Obsidian ship AppImage. We started with AppImage because one artifact can cover the widest glibc-compatible target without distro repositories, store packaging, signing infrastructure, or per-format install scripts, and it integrates cleanly with the namespace-scoped install layout. A standards-compliant `.deb` target is now also supported (`--to deb`); `.rpm` / Snap / Flatpak can still land incrementally when user demand justifies the extra release ownership.
 
 ### Out of scope (later phases)
 
 - AppImage signing (`--signed`) — deferred pending a GPG key infrastructure decision and a user-facing verification flow design (no ETA).
 - AppImage auto-update feed (`latest-linux.yml`) — the linux electron-builder config has no `publish` block wired, so a generated feed would point users at a feed that never updates. Tracked alongside signing.
-- Additional package formats: `.deb`, `.rpm`, Snap, Flatpak — deferred until there is demand and an owner for per-distro metadata, signing/store/repository plumbing, install/remove hooks, and release validation.
-- Full Linux AppImage and headless packaged smoke remain outside the main PR gate; run the applicable tools-pack validation manually or through a release lane when Linux packaging changes.
+- `.deb` build is supported via `--to deb` — a standards-compliant Debian package (`Package: open-design`, install under `/opt/OpenDesign`, section `devel`, RFC822 maintainer, `libc6` + t64-aware `depends`, DEP-5 `copyright` and a valid Debian `changelog`; verified with `dpkg-deb`, `lintian`, and a real boot). Publishing it through the release pipeline, package **signing**, and an **APT repository** remain deferred (separate follow-up plus a GPG key + hosting decision).
+- Additional package formats: `.rpm`, Snap, Flatpak — deferred until there is demand and an owner for per-distro metadata, signing/store/repository plumbing, install/remove hooks, and release validation.
+- Full Linux AppImage PR smoke remains release-lane only; PR validation runs the Linux headless packaged smoke because it does not require a display server.
 
 `--to dmg` is manual-install DMG output only. Any builder-generated updater metadata such as `latest-mac.yml` or
 `.blockmap` files is treated as scratch and cleaned from the builder directory; release-beta generates the authoritative

--- a/tools/pack/resources/linux/debian/changelog.template
+++ b/tools/pack/resources/linux/debian/changelog.template
@@ -2,4 +2,4 @@
 
   * Packaged release.
 
- -- Open Design Contributors <eric.lemesre@gmail.com>  @@DATE@@
+ -- Open Design Contributors <contributors@open-design.ai>  @@DATE@@

--- a/tools/pack/resources/linux/debian/changelog.template
+++ b/tools/pack/resources/linux/debian/changelog.template
@@ -1,0 +1,5 @@
+@@PACKAGE@@ (@@VERSION@@) unstable; urgency=medium
+
+  * Packaged release.
+
+ -- Open Design Contributors <eric.lemesre@gmail.com>  @@DATE@@

--- a/tools/pack/resources/linux/debian/copyright
+++ b/tools/pack/resources/linux/debian/copyright
@@ -1,0 +1,17 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: Open Design
+Source: https://github.com/nexu-io/open-design
+
+Files: *
+Copyright: 2024-2026 Open Design Contributors
+License: Apache-2.0
+
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+     https://www.apache.org/licenses/LICENSE-2.0
+ .
+ On Debian systems, the full text of the Apache License version 2.0 can be
+ found in the file /usr/share/common-licenses/Apache-2.0.

--- a/tools/pack/resources/linux/debian/lintian-overrides
+++ b/tools/pack/resources/linux/debian/lintian-overrides
@@ -1,0 +1,54 @@
+# Open Design ships as a bundled Electron application: the package carries its own
+# Electron/Chromium runtime and a production node_modules tree. The tags below are
+# inherent to that model — the same class of deviations VS Code, Slack and Discord
+# document via their own /usr/share/lintian/overrides file. They are assumed and
+# recorded here rather than "fixed", which would mean unbundling the runtime.
+
+# --- Third-party install location (FHS /opt, not the Debian archive) ---
+open-design: dir-or-file-in-opt
+
+# --- Bundled runtime libraries / binaries (Electron, Chromium, prebuilt *.node) ---
+open-design: embedded-library
+open-design: embedded-javascript-library
+open-design: unstripped-binary-or-object
+open-design: statically-linked-binary
+open-design: shared-library-is-executable
+open-design: odd-permissions-on-shared-library
+open-design: hardening-no-pie
+open-design: hardening-no-relro
+
+# --- Permissions of the bundled tree (as produced by electron-builder) ---
+open-design: non-standard-file-perm
+open-design: non-standard-dir-perm
+open-design: non-standard-executable-perm
+open-design: executable-not-elf-or-script
+
+# --- Bundled fonts / web assets that reference external resources ---
+open-design: duplicate-font-file
+open-design: opentype-font-prohibits-installable-embedding
+open-design: privacy-breach-generic
+open-design: privacy-breach-uses-embedded-file
+open-design: privacy-breach-twitter
+
+# --- Bundled scripts executed by the app's own Node/Electron runtime, or shipped
+#     for other platforms and never run by a system interpreter on Linux, so their
+#     interpreters are intentionally not package dependencies. ---
+open-design: missing-dep-for-interpreter
+open-design: python3-script-but-no-python3-dep
+open-design: unusual-interpreter
+open-design: script-not-executable
+
+# --- fpm-emitted control fields (informational; not standard Debian control
+#     fields). The authoritative license lives in the DEP-5 copyright file. ---
+open-design: unknown-field Vendor
+open-design: unknown-field License
+
+# --- electron-builder maintainer scripts (update-alternatives symlink management) ---
+open-design: maintainer-script-ignores-errors
+open-design: command-with-path-in-maintainer-script
+open-design: postrm-removes-alternative
+
+# --- Misc bundled-tree artifacts ---
+open-design: package-contains-timestamped-gzip
+open-design: package-contains-vcs-control-file
+open-design: missing-depends-on-sensible-utils

--- a/tools/pack/src/config/index.ts
+++ b/tools/pack/src/config/index.ts
@@ -34,7 +34,7 @@ function resolveToolPackRoot(startDir: string): string {
 export const WORKSPACE_ROOT = resolve(resolveToolPackRoot(__dirname), "../..");
 
 export type ToolPackPlatform = "mac" | "win" | "linux";
-export type ToolPackBuildOutput = "all" | "app" | "appimage" | "dir" | "dmg" | "nsis" | "zip";
+export type ToolPackBuildOutput = "all" | "app" | "appimage" | "deb" | "dir" | "dmg" | "nsis" | "zip";
 export type ToolPackMacCompression = "store" | "normal" | "maximum";
 export type ToolPackWebOutputMode = "server" | "standalone";
 export type ToolPackAmrProfile = "prod" | "test" | "feature-test" | "local";
@@ -176,7 +176,7 @@ function resolveToolPackBuildOutput(platform: ToolPackPlatform, value: string | 
   if (value == null || value.length === 0) return platform === "win" ? "nsis" : "all";
   if (platform === "mac" && (value === "all" || value === "app" || value === "dmg" || value === "zip")) return value;
   if (platform === "win" && (value === "all" || value === "dir" || value === "nsis" || value === "zip")) return value;
-  if (platform === "linux" && (value === "all" || value === "appimage" || value === "dir")) return value;
+  if (platform === "linux" && (value === "all" || value === "appimage" || value === "deb" || value === "dir")) return value;
   throw new Error(`unsupported ${platform} --to target: ${value}`);
 }
 

--- a/tools/pack/src/index.ts
+++ b/tools/pack/src/index.ts
@@ -80,7 +80,7 @@ function addSharedOptions(command: CacCommand) {
 // config.ts. Keep these in sync: the resolver throws on any value not listed
 // here for the given platform.
 const TO_HELP_BY_PLATFORM: Record<ToolPackPlatform, string> = {
-  linux: "build target: all|appimage|dir (default: all)",
+  linux: "build target: all|appimage|deb|dir (default: all)",
   mac: "build target: all|app|dmg|zip (default: all)",
   win: "build target: all|dir|nsis|zip (default: nsis). `zip` produces a portable zip from the unpacked build; `all` produces dir+nsis+zip.",
 };

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -619,6 +619,12 @@ async function writeLinuxAppImageAppRun(paths: LinuxPaths): Promise<void> {
 // Maps the tools-pack `--to` target to the electron-builder Linux target list.
 // "dir" produces an unpacked tree, "deb" a Debian package, and everything else
 // ("appimage"/"all") an AppImage — the historical default.
+//
+// Note: on Linux `all` == AppImage only, which is intentionally NOT symmetric with
+// Windows (`all` == dir+nsis+zip). The deb build is a SEPARATE electron-builder run:
+// its productName ("OpenDesign", for a path-safe /opt) is mutually exclusive with
+// the AppImage's ("Open Design"), so they cannot be produced in one combined run.
+// `all` therefore stays AppImage-only; build the deb explicitly with `--to deb`.
 export function resolveLinuxBuilderTargets(to: ToolPackConfig["to"]): string[] {
   if (to === "dir") return ["dir"];
   if (to === "deb") return ["deb"];
@@ -650,13 +656,18 @@ const DEB_DISPLAY_NAME = "Open Design";
 async function writeDebMetadataFiles(
   paths: LinuxPaths,
   version: string,
-): Promise<{ copyrightPath: string; changelogPath: string }> {
+): Promise<{ copyrightPath: string; changelogPath: string; lintianOverridesPath: string }> {
   const metaDir = join(dirname(paths.appBuilderConfigPath), "deb-meta");
   await mkdir(metaDir, { recursive: true });
 
   // Copyright is fully static — copy the checked-in DEP-5 file verbatim.
   const copyrightPath = join(metaDir, "copyright");
   await cp(linuxResources.debianCopyright, copyrightPath);
+
+  // lintian overrides: a static, checked-in file documenting the deviations
+  // inherent to a bundled Electron package (see the file for rationale).
+  const lintianOverridesPath = join(metaDir, "lintian-overrides");
+  await cp(linuxResources.debianLintianOverrides, lintianOverridesPath);
 
   // Changelog carries the build version and date; render the template. The date
   // must be RFC 5322 with a numeric zone — toUTCString gives the correct
@@ -670,7 +681,7 @@ async function writeDebMetadataFiles(
     .replace(/@@DATE@@/g, date);
   await writeFile(changelogPath, changelog, "utf8");
 
-  return { copyrightPath, changelogPath };
+  return { copyrightPath, changelogPath, lintianOverridesPath };
 }
 
 async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths): Promise<void> {
@@ -728,7 +739,18 @@ async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths
           ],
         }
       : {}),
-    files: ["**/*", "!**/node_modules/.bin", "!**/node_modules/electron{,/**/*}"],
+    files: [
+      "**/*",
+      "!**/node_modules/.bin",
+      "!**/node_modules/electron{,/**/*}",
+      // Bundled node_modules cruft that lintian flags and that no runtime needs:
+      // eslint configs (package-contains-eslint-config-file) and node-pty's
+      // Windows-only winpty build sources (its python helper scripts trip
+      // python3-script-but-no-python3-dep on Linux, where they never run).
+      "!**/.eslintrc{,.*}",
+      "!**/eslint.config.{js,cjs,mjs,ts}",
+      "!**/node_modules/node-pty/deps/winpty{,/**/*}",
+    ],
     icon: linuxResources.icon,
     linux: {
       target,
@@ -774,14 +796,20 @@ async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths
             //                      Debian Package name is independent of the npm name,
             //                      so this touches nothing macOS/Windows/launcher use.
             //   --deb-changelog -> replaces electron-builder's invalid auto changelog.
-            //   copyright=...    -> DEP-5 copyright at /usr/share/doc/<pkg>/copyright
+            //   --license       -> fills the fpm License field (else "unknown").
+            //   copyright=...   -> DEP-5 copyright at /usr/share/doc/<pkg>/copyright
             //                      (electron-builder ships none: lintian no-copyright-file).
+            //   lintian-overrides=... -> documents the assumed bundled-Electron
+            //                      deviations at /usr/share/lintian/overrides/<pkg>.
             fpm: [
               "--name",
               DEB_PACKAGE_NAME,
+              "--license",
+              "Apache-2.0",
               "--deb-changelog",
               debMeta!.changelogPath,
               `${debMeta!.copyrightPath}=/usr/share/doc/${DEB_PACKAGE_NAME}/copyright`,
+              `${debMeta!.lintianOverridesPath}=/usr/share/lintian/overrides/${DEB_PACKAGE_NAME}`,
             ],
             // Debian-standard filename `<package>_<version>_<arch>.deb`. The
             // namespace is intentionally omitted (unlike the AppImage artifact):

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -740,6 +740,10 @@ async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths
   const linuxProductName = isDeb ? DEB_PRODUCT_NAME : PRODUCT_NAME;
   const linuxExecutableName = isDeb ? DEB_PACKAGE_NAME : PRODUCT_NAME;
   const debMeta = isDeb ? await writeDebMetadataFiles(paths, packageVersion) : null;
+  // Distinct one-line synopsis + a concise single-line description. A bare
+  // product-name description trips lintian's description-is-pkg-name.
+  const linuxSynopsis = "Local-first design agent driven by your installed code CLI";
+  const linuxDescription = "Runs design skills and design systems, previewing artifacts in a sandbox.";
 
   const builderConfig: Record<string, unknown> = {
     appId: "io.open-design.desktop",
@@ -787,12 +791,8 @@ async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths
       target,
       icon: linuxResources.icon,
       category: "Development",
-      // Distinct one-line synopsis + a concise single-line description. A bare
-      // product-name description trips lintian's description-is-pkg-name; keeping
-      // the description to one short line (< 80 chars) sidesteps the extended
-      // Description formatting quirks fpm produces for multi-line input.
-      synopsis: "Local-first design agent driven by your installed code CLI",
-      description: "Runs design skills and design systems, previewing artifacts in a sandbox.",
+      synopsis: linuxSynopsis,
+      description: linuxDescription,
       // Path-safe product name (OpenDesign) keeps /opt and /usr/bin clean, but the
       // menu entry should still show the real brand. Override the .desktop Name so
       // the display stays "Open Design" regardless of the executable/dir name.
@@ -835,9 +835,15 @@ async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths
             //                      (electron-builder ships none: lintian no-copyright-file).
             //   lintian-overrides=... -> documents the assumed bundled-Electron
             //                      deviations at /usr/share/lintian/overrides/<pkg>.
+            //   --description  -> electron-builder already indents the extended
+            //                      description line, then fpm indents it again
+            //                      (description-starts-with-leading-spaces); passing
+            //                      the raw two-line text here lets fpm indent once.
             fpm: [
               "--name",
               DEB_PACKAGE_NAME,
+              "--description",
+              `${linuxSynopsis}\n${linuxDescription}`,
               "--license",
               "Apache-2.0",
               "--deb-changelog",

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -734,30 +734,28 @@ async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths
       target,
       icon: linuxResources.icon,
       category: "Development",
-      // A distinct one-line synopsis + a hard-wrapped extended description. Lines
-      // are kept under 80 chars and free of leading whitespace so lintian does not
-      // flag extended-description-line-too-long / description-starts-with-leading-spaces;
-      // a bare product-name description would trip description-is-pkg-name.
+      // Distinct one-line synopsis + a concise single-line description. A bare
+      // product-name description trips lintian's description-is-pkg-name; keeping
+      // the description to one short line (< 80 chars) sidesteps the extended
+      // Description formatting quirks fpm produces for multi-line input.
       synopsis: "Local-first design agent driven by your installed code CLI",
-      description: [
-        "Open Design detects your installed code-agent CLI and runs design",
-        "skills and design systems, streaming generated artifacts into a",
-        "sandboxed live preview.",
-      ].join("\n"),
+      description: "Runs design skills and design systems, previewing artifacts in a sandbox.",
       // Path-safe product name (OpenDesign) keeps /opt and /usr/bin clean, but the
       // menu entry should still show the real brand. Override the .desktop Name so
       // the display stays "Open Design" regardless of the executable/dir name.
       desktop: { entry: { Name: DEB_DISPLAY_NAME } },
       // Debian Policy requires an RFC822 `Maintainer: Name <email>`; a bare name
-      // trips lintian's maintainer-address-malformed. Used for deb (and rpm) via
-      // electron-builder's shared linux.maintainer.
-      maintainer: "Open Design Contributors <eric.lemesre@gmail.com>",
+      // trips lintian's maintainer-address-malformed. Community project → a neutral
+      // project role address, never a personal one (it is shown by `apt show` on
+      // every install). Maintainers can point this at their preferred packaging
+      // contact. Used for deb (and rpm) via electron-builder's shared linux.maintainer.
+      maintainer: "Open Design Contributors <contributors@open-design.ai>",
     },
     // Debian package metadata. Only consulted when the `deb` target is built.
-    // Keep the runtime `depends` unset so electron-builder's Electron-version
-    // aware defaults apply; overriding replaces (not merges) the whole list and
-    // is the usual source of "installs but won't launch" breakage. The
-    // artifactName follows the Debian convention `<pkg>_<version>_<arch>.deb`
+    // `deb.depends` is set explicitly below (not left to electron-builder's
+    // defaults): overriding REPLACES — does not merge — the whole list, so it must
+    // carry every runtime dep itself, including libc6 and the t64-aware libraries.
+    // The artifactName follows the Debian convention `<pkg>_<version>_<arch>.deb`
     // (lowercase, no spaces), unlike the AppImage which keeps the product name.
     ...(config.to === "deb"
       ? {

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -136,7 +136,7 @@ export function buildDockerArgs(
   //   - config.namespace is sanitized at config-time by resolveNamespace() in
   //     @open-design/sidecar-proto (restricted to namespace charset)
   //   - config.to is enum-validated by resolveToolPackBuildOutput() in config.ts
-  //     to one of "all" | "appimage" | "dir"
+  //     to one of "all" | "appimage" | "deb" | "dir"
   //   - config.portable is a boolean
   //   - config.appVersion is shell-quoted below because release versions can
   //     carry punctuation that is not part of the namespace / target enums.
@@ -616,11 +616,77 @@ async function writeLinuxAppImageAppRun(paths: LinuxPaths): Promise<void> {
 
 // --- Step 5: writeLinuxBuilderConfig helper ---
 
+// Maps the tools-pack `--to` target to the electron-builder Linux target list.
+// "dir" produces an unpacked tree, "deb" a Debian package, and everything else
+// ("appimage"/"all") an AppImage — the historical default.
+export function resolveLinuxBuilderTargets(to: ToolPackConfig["to"]): string[] {
+  if (to === "dir") return ["dir"];
+  if (to === "deb") return ["deb"];
+  return ["AppImage"];
+}
+
+// The AppRun wrapper and its extraFiles injection are AppImage-only concerns.
+// deb/dir builds must not receive them: a .deb installs Electron directly under
+// /opt and symlinks the executable into /usr/bin, with no FUSE AppRun shim.
+export function linuxBuildsAppImage(to: ToolPackConfig["to"]): boolean {
+  return to === "all" || to === "appimage";
+}
+
+// Debian archive package name, install directory, and display name. These are
+// deliberately distinct concerns that electron-builder couples to a single
+// `productName`:
+//   - DEB_PACKAGE_NAME  -> control `Package:` + /usr/share/doc/<name> (via fpm)
+//   - DEB_PRODUCT_NAME  -> /opt/<dir> and the executable base (path-safe, no space)
+//   - DEB_DISPLAY_NAME  -> the .desktop `Name=` shown in menus (keeps the brand)
+const DEB_PACKAGE_NAME = "open-design";
+const DEB_PRODUCT_NAME = "OpenDesign";
+const DEB_DISPLAY_NAME = "Open Design";
+
+// electron-builder ships no machine-readable copyright (lintian: no-copyright-file,
+// an error) and an auto-generated changelog that lintian rejects as "not a Debian
+// changelog". Stage the checked-in DEP-5 copyright and render the Debian changelog
+// template (from tools/pack/resources/linux/debian/), then map them into the
+// package via fpm args. Returns their staged paths.
+async function writeDebMetadataFiles(
+  paths: LinuxPaths,
+  version: string,
+): Promise<{ copyrightPath: string; changelogPath: string }> {
+  const metaDir = join(dirname(paths.appBuilderConfigPath), "deb-meta");
+  await mkdir(metaDir, { recursive: true });
+
+  // Copyright is fully static — copy the checked-in DEP-5 file verbatim.
+  const copyrightPath = join(metaDir, "copyright");
+  await cp(linuxResources.debianCopyright, copyrightPath);
+
+  // Changelog carries the build version and date; render the template. The date
+  // must be RFC 5322 with a numeric zone — toUTCString gives the correct
+  // day-of-week and "... GMT", which we rewrite to "+0000".
+  const changelogPath = join(metaDir, "changelog");
+  const date = new Date().toUTCString().replace(/ GMT$/, " +0000");
+  const changelogTemplate = await readFile(linuxResources.debianChangelogTemplate, "utf8");
+  const changelog = changelogTemplate
+    .replace(/@@PACKAGE@@/g, DEB_PACKAGE_NAME)
+    .replace(/@@VERSION@@/g, version)
+    .replace(/@@DATE@@/g, date);
+  await writeFile(changelogPath, changelog, "utf8");
+
+  return { copyrightPath, changelogPath };
+}
+
 async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths): Promise<void> {
-  const target = config.to === "dir" ? ["dir"] : ["AppImage"];
+  const target = resolveLinuxBuilderTargets(config.to);
+  const buildsAppImage = linuxBuildsAppImage(config.to);
   const namespaceToken = sanitizeNamespace(config.namespace);
   const packagedVersion = await readPackagedVersion(config);
   const packageVersion = electronBuilderVersionForAppVersion(packagedVersion);
+
+  // The deb installs to /opt and symlinks into /usr/bin, so its product/executable
+  // names must be path-safe (no space). The AppImage keeps "Open Design" because
+  // matchesAppImageProcess and the AppRun wrapper match that exact binary name.
+  const isDeb = config.to === "deb";
+  const linuxProductName = isDeb ? DEB_PRODUCT_NAME : PRODUCT_NAME;
+  const linuxExecutableName = isDeb ? DEB_PACKAGE_NAME : PRODUCT_NAME;
+  const debMeta = isDeb ? await writeDebMetadataFiles(paths, packageVersion) : null;
 
   const builderConfig: Record<string, unknown> = {
     appId: "io.open-design.desktop",
@@ -637,11 +703,11 @@ async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths
     // See tools/pack/src/win/builder.ts: rely on electron-builder's own
     // Electron download rather than node_modules' dist, which pnpm does not
     // reliably materialize on CI runners.
-    executableName: PRODUCT_NAME,
+    executableName: linuxExecutableName,
     extraMetadata: {
       main: "./main.cjs",
       name: "open-design-packaged-app",
-      productName: PRODUCT_NAME,
+      productName: linuxProductName,
       version: packageVersion,
       ...(config.portable ? {} : { odToolsPackRuntimeRoot: config.roots.runtime.namespaceBaseRoot }),
     },
@@ -652,25 +718,109 @@ async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths
       // process.resourcesPath by the desktop main at runtime).
       domToPptxBundleResource(config),
     ],
-    ...(config.to === "dir"
-      ? {}
-      : {
+    ...(buildsAppImage
+      ? {
           extraFiles: [
             {
               from: paths.appImageAppRunPath,
               to: "AppRun",
             },
           ],
-        }),
+        }
+      : {}),
     files: ["**/*", "!**/node_modules/.bin", "!**/node_modules/electron{,/**/*}"],
     icon: linuxResources.icon,
     linux: {
       target,
       icon: linuxResources.icon,
       category: "Development",
-      synopsis: "Open Design",
-      maintainer: "Open Design Contributors",
+      // A distinct one-line synopsis + a hard-wrapped extended description. Lines
+      // are kept under 80 chars and free of leading whitespace so lintian does not
+      // flag extended-description-line-too-long / description-starts-with-leading-spaces;
+      // a bare product-name description would trip description-is-pkg-name.
+      synopsis: "Local-first design agent driven by your installed code CLI",
+      description: [
+        "Open Design detects your installed code-agent CLI and runs design",
+        "skills and design systems, streaming generated artifacts into a",
+        "sandboxed live preview.",
+      ].join("\n"),
+      // Path-safe product name (OpenDesign) keeps /opt and /usr/bin clean, but the
+      // menu entry should still show the real brand. Override the .desktop Name so
+      // the display stays "Open Design" regardless of the executable/dir name.
+      desktop: { entry: { Name: DEB_DISPLAY_NAME } },
+      // Debian Policy requires an RFC822 `Maintainer: Name <email>`; a bare name
+      // trips lintian's maintainer-address-malformed. Used for deb (and rpm) via
+      // electron-builder's shared linux.maintainer.
+      maintainer: "Open Design Contributors <eric.lemesre@gmail.com>",
     },
+    // Debian package metadata. Only consulted when the `deb` target is built.
+    // Keep the runtime `depends` unset so electron-builder's Electron-version
+    // aware defaults apply; overriding replaces (not merges) the whole list and
+    // is the usual source of "installs but won't launch" breakage. The
+    // artifactName follows the Debian convention `<pkg>_<version>_<arch>.deb`
+    // (lowercase, no spaces), unlike the AppImage which keeps the product name.
+    ...(config.to === "deb"
+      ? {
+          deb: {
+            priority: "optional",
+            // Debian archive Section. fpm/electron-builder otherwise emit
+            // `Section: default`, which lintian flags as unknown-section. "devel"
+            // is the Debian section for development tools, matching the freedesktop
+            // Development category above.
+            packageCategory: "devel",
+            // fpm passthrough for the deb only:
+            //   --name          -> Debian `Package:` field. electron-builder would
+            //                      otherwise derive it from the internal Electron app
+            //                      name (`open-design-packaged-app`), a cross-platform
+            //                      build identity, not a distro package name. The
+            //                      Debian Package name is independent of the npm name,
+            //                      so this touches nothing macOS/Windows/launcher use.
+            //   --deb-changelog -> replaces electron-builder's invalid auto changelog.
+            //   copyright=...    -> DEP-5 copyright at /usr/share/doc/<pkg>/copyright
+            //                      (electron-builder ships none: lintian no-copyright-file).
+            fpm: [
+              "--name",
+              DEB_PACKAGE_NAME,
+              "--deb-changelog",
+              debMeta!.changelogPath,
+              `${debMeta!.copyrightPath}=/usr/share/doc/${DEB_PACKAGE_NAME}/copyright`,
+            ],
+            // Debian-standard filename `<package>_<version>_<arch>.deb`. The
+            // namespace is intentionally omitted (unlike the AppImage artifact):
+            // each namespace already writes to its own output directory, so the
+            // token adds nothing here and would break the Debian convention.
+            // Release channels stay distinguishable through the version suffix
+            // (e.g. 0.15.1-beta.1) baked into ${version}.
+            artifactName: "open-design_${version}_${arch}.deb",
+            // Runtime shared libraries for an Electron 41 app. electron-builder's
+            // defaults already resolve on Debian, but we spell out the intent and
+            // alternate the two libraries renamed by the time_t 64-bit (t64)
+            // transition so resolution never relies solely on compat `Provides:`:
+            //   - libgtk-3-0     -> libgtk-3-0t64     (trixie+/sid)
+            //   - libatspi2.0-0  -> libatspi2.0-0t64  (trixie+/sid)
+            // Verified installable on bookworm (native names) and trixie/sid.
+            depends: [
+              // electron-builder's baseline deb.depends (which we replace here)
+              // omits libc6; hardcoding the list drops the shlib-scanned libc dep,
+              // so declare it explicitly (lintian: missing-dependency-on-libc).
+              "libc6",
+              "libgtk-3-0 | libgtk-3-0t64",
+              "libnotify4",
+              "libnss3",
+              "libxss1",
+              "libxtst6",
+              "xdg-utils",
+              "libatspi2.0-0 | libatspi2.0-0t64",
+              "libuuid1",
+              "libsecret-1-0",
+            ],
+            // System-tray indicator is optional. libappindicator3-1 was removed
+            // from bookworm/trixie/sid; the Ayatana fork provides it, so prefer it
+            // and fall back to the historical name.
+            recommends: ["libayatana-appindicator3-1 | libappindicator3-1"],
+          },
+        }
+      : {}),
     // Keep the AppImage launch fallback explicit. Our top-level AppRun wrapper
     // clears ELECTRON_RUN_AS_NODE before these Chromium flags reach Electron,
     // including for AppImageLauncher-generated desktop entries.
@@ -679,7 +829,7 @@ async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths
     },
     nodeGypRebuild: false,
     npmRebuild: false,
-    productName: PRODUCT_NAME,
+    productName: linuxProductName,
   };
 
   await mkdir(dirname(paths.appBuilderConfigPath), { recursive: true });
@@ -706,17 +856,22 @@ async function runElectronBuilderLinux(config: ToolPackConfig, paths: LinuxPaths
   });
 }
 
-async function findBuiltAppImage(paths: LinuxPaths): Promise<string | null> {
+async function findBuiltArtifact(paths: LinuxPaths, ext: string): Promise<string | null> {
   if (!(await pathExists(paths.appBuilderOutputRoot))) return null;
   const entries = await readdir(paths.appBuilderOutputRoot);
-  const appImage = entries.find((entry) => entry.endsWith(".AppImage"));
-  return appImage ? join(paths.appBuilderOutputRoot, appImage) : null;
+  const match = entries.find((entry) => entry.endsWith(ext));
+  return match ? join(paths.appBuilderOutputRoot, match) : null;
+}
+
+async function findBuiltAppImage(paths: LinuxPaths): Promise<string | null> {
+  return findBuiltArtifact(paths, ".AppImage");
 }
 
 // --- Step 7: packLinux orchestrator + result type + stub for runBuildInContainer ---
 
 export type LinuxPackResult = {
   appImagePath: string | null;
+  debPath: string | null;
   outputRoot: string;
   resourceRoot: string;
   runtimeNamespaceRoot: string;
@@ -728,9 +883,11 @@ export async function packLinux(config: ToolPackConfig): Promise<LinuxPackResult
   if (config.containerized) {
     await runBuildInContainer(config);
     const paths = resolveLinuxPaths(config);
-    const appImagePath = config.to === "dir" ? null : await findBuiltAppImage(paths);
+    const appImagePath = linuxBuildsAppImage(config.to) ? await findBuiltAppImage(paths) : null;
+    const debPath = config.to === "deb" ? await findBuiltArtifact(paths, ".deb") : null;
     return {
       appImagePath,
+      debPath,
       outputRoot: paths.appBuilderOutputRoot,
       resourceRoot: paths.resourceRoot,
       runtimeNamespaceRoot: config.roots.runtime.namespaceRoot,
@@ -748,15 +905,17 @@ export async function packLinux(config: ToolPackConfig): Promise<LinuxPackResult
   await copyResourceTree(config, paths);
   const tarballs = await collectWorkspaceTarballs(config, paths);
   await writeAssembledApp(config, paths, tarballs);
-  if (config.to !== "dir") {
+  if (linuxBuildsAppImage(config.to)) {
     await writeLinuxAppImageAppRun(paths);
   }
   await writeLinuxBuilderConfig(config, paths);
   await runElectronBuilderLinux(config, paths);
 
-  const appImagePath = config.to === "dir" ? null : await findBuiltAppImage(paths);
+  const appImagePath = linuxBuildsAppImage(config.to) ? await findBuiltAppImage(paths) : null;
+  const debPath = config.to === "deb" ? await findBuiltArtifact(paths, ".deb") : null;
   return {
     appImagePath,
+    debPath,
     outputRoot: paths.appBuilderOutputRoot,
     resourceRoot: paths.resourceRoot,
     runtimeNamespaceRoot: config.roots.runtime.namespaceRoot,

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -779,7 +779,10 @@ async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths
     // carry every runtime dep itself, including libc6 and the t64-aware libraries.
     // The artifactName follows the Debian convention `<pkg>_<version>_<arch>.deb`
     // (lowercase, no spaces), unlike the AppImage which keeps the product name.
-    ...(config.to === "deb"
+    // Gate on debMeta (non-null iff the deb target is built) rather than
+    // re-testing config.to: this lets TypeScript narrow debMeta to non-null
+    // inside the block, so the fpm passthrough needs no non-null assertions.
+    ...(debMeta
       ? {
           deb: {
             priority: "optional",
@@ -807,9 +810,9 @@ async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths
               "--license",
               "Apache-2.0",
               "--deb-changelog",
-              debMeta!.changelogPath,
-              `${debMeta!.copyrightPath}=/usr/share/doc/${DEB_PACKAGE_NAME}/copyright`,
-              `${debMeta!.lintianOverridesPath}=/usr/share/lintian/overrides/${DEB_PACKAGE_NAME}`,
+              debMeta.changelogPath,
+              `${debMeta.copyrightPath}=/usr/share/doc/${DEB_PACKAGE_NAME}/copyright`,
+              `${debMeta.lintianOverridesPath}=/usr/share/lintian/overrides/${DEB_PACKAGE_NAME}`,
             ],
             // Debian-standard filename `<package>_<version>_<arch>.deb`. The
             // namespace is intentionally omitted (unlike the AppImage artifact):

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -684,6 +684,48 @@ async function writeDebMetadataFiles(
   return { copyrightPath, changelogPath, lintianOverridesPath };
 }
 
+/**
+ * electron-builder `files` patterns for the Linux bundle: everything in the
+ * assembled app minus the node_modules cruft no Linux runtime needs. Keeping it
+ * out is what makes the .deb clean (lintian) and smaller; every exclusion below
+ * names the tag or the bytes it removes.
+ *
+ * `hostArch` is Node's `process.arch` of the machine producing the bundle
+ * (electron-builder targets the host arch): prebuilt native binaries for every
+ * other platform/arch are dropped. Anything not listed is kept, so a new
+ * multi-platform dependency shows up in lintian before it silently bloats the
+ * package.
+ */
+export function linuxBundledFilePatterns(hostArch: string): string[] {
+  const arch = hostArch === "arm64" ? "arm64" : "x64";
+  const otherArch = arch === "x64" ? "arm64" : "x64";
+  return [
+    "**/*",
+    "!**/node_modules/.bin",
+    "!**/node_modules/electron{,/**/*}",
+    // eslint configs (package-contains-eslint-config-file) and node-pty's
+    // Windows-only winpty build sources (its python helper scripts trip
+    // python3-script-but-no-python3-dep on Linux, where they never run).
+    "!**/.eslintrc{,.*}",
+    "!**/eslint.config.{js,cjs,mjs,ts}",
+    "!**/node_modules/node-pty/deps/winpty{,/**/*}",
+    // Editor backup files published by mistake in @ffmpeg-installer/ffmpeg
+    // (backup-file-in-package).
+    "!**/*~",
+    // node-pty ships prebuilt bindings for every platform; only the Linux
+    // ones can load here.
+    "!**/node_modules/node-pty/prebuilds/{darwin,win32}-*{,/**/*}",
+    // onnxruntime-node (via hyperframes) bundles every platform and arch
+    // (binary-from-other-architecture, ~100 MB), plus the CUDA/TensorRT
+    // execution providers for linux (~345 MB) that need a CUDA toolkit this
+    // package does not depend on. hyperframes falls back to the CPU provider
+    // when they are absent.
+    "!**/node_modules/onnxruntime-node/bin/napi-v3/{darwin,win32}{,/**/*}",
+    `!**/node_modules/onnxruntime-node/bin/napi-v3/linux/${otherArch}{,/**/*}`,
+    `!**/node_modules/onnxruntime-node/bin/napi-v3/linux/${arch}/libonnxruntime_providers_{cuda,tensorrt}.so`,
+  ];
+}
+
 async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths): Promise<void> {
   const target = resolveLinuxBuilderTargets(config.to);
   const buildsAppImage = linuxBuildsAppImage(config.to);
@@ -739,18 +781,7 @@ async function writeLinuxBuilderConfig(config: ToolPackConfig, paths: LinuxPaths
           ],
         }
       : {}),
-    files: [
-      "**/*",
-      "!**/node_modules/.bin",
-      "!**/node_modules/electron{,/**/*}",
-      // Bundled node_modules cruft that lintian flags and that no runtime needs:
-      // eslint configs (package-contains-eslint-config-file) and node-pty's
-      // Windows-only winpty build sources (its python helper scripts trip
-      // python3-script-but-no-python3-dep on Linux, where they never run).
-      "!**/.eslintrc{,.*}",
-      "!**/eslint.config.{js,cjs,mjs,ts}",
-      "!**/node_modules/node-pty/deps/winpty{,/**/*}",
-    ],
+    files: linuxBundledFilePatterns(process.arch),
     icon: linuxResources.icon,
     linux: {
       target,

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -176,8 +176,14 @@ export function buildDockerArgs(
     `mv ${CONTAINER_PNPM_PATH}.tmp ${CONTAINER_PNPM_PATH} && ` +
     `chmod +x ${CONTAINER_PNPM_PATH} && ` +
     `PNPM_HOME=${CONTAINER_PNPM_HOME} PATH=${CONTAINER_PNPM_HOME}:$PATH ${CONTAINER_PNPM_PATH} env use --global ${CONTAINER_NODE_VERSION} && ` +
-    `export PNPM_HOME=${CONTAINER_PNPM_HOME} PATH=${CONTAINER_PNPM_HOME}:$PATH && ` +
-    `command -v node >/dev/null`;
+    // Put the pnpm-managed Node bin (node/npm/npx/corepack) on PATH and expose the
+    // standalone pnpm as a bare `pnpm`. electron-builder's node-module-collector
+    // spawns the detected package manager directly (pnpm here — the assembled app
+    // has a node_modules/.pnpm dir); builder:base ships none of these on PATH,
+    // which surfaced as "Node module collector process exited with code 127".
+    `export PNPM_HOME=${CONTAINER_PNPM_HOME} PATH=${CONTAINER_PNPM_HOME}/nodejs/${CONTAINER_NODE_VERSION}/bin:${CONTAINER_PNPM_HOME}:$PATH && ` +
+    `ln -sf ${CONTAINER_PNPM_PATH} ${CONTAINER_PNPM_HOME}/pnpm && ` +
+    `command -v node >/dev/null && command -v npm >/dev/null && command -v pnpm >/dev/null`;
   const pnpmCmd = CONTAINER_PNPM_PATH;
   const innerArgs = [
     `node ${CONTAINER_TOOLS_PACK_CLI_PATH} linux build`,
@@ -213,12 +219,41 @@ export function buildDockerArgs(
     `${electronBuilderCache}:/home/builder/.cache/electron-builder`,
     "-e",
     "HOME=/home/builder",
+    // Match the CI environment the containerized build models. The inner
+    // `pnpm install --frozen-lockfile` runs against the mounted /project, which
+    // on a developer machine already contains a host-installed node_modules with
+    // a different store/config. pnpm decides that modules directory must be
+    // purged and rebuilt; without a TTY and without CI it refuses the
+    // destructive purge and aborts with ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY.
+    // A fresh CI checkout has no node_modules so this never triggers there.
+    // Setting CI=true makes pnpm proceed non-interactively, exactly as it does in
+    // CI. Note: this reinstalls node_modules inside the mounted workspace, so a
+    // local containerized build leaves the host tree with container-built native
+    // modules; re-run host `pnpm install` afterward if you switch back to host dev.
+    "-e",
+    "CI=true",
     "-e",
     "ELECTRON_CACHE=/home/builder/.cache/electron",
     "-e",
     "ELECTRON_BUILDER_CACHE=/home/builder/.cache/electron-builder",
+    // Production install of the assembled app uses npm (resolveProductionInstallCommand's
+    // default), NOT the standalone pnpm. npm is available because the PATH export below
+    // includes the pnpm-managed Node bin, which bundles npm. We deliberately do not set
+    // OD_TOOLS_PACK_PNPM_BIN: a pnpm `--prod --no-lockfile` install over the file: tarballs
+    // failed to materialize transitive deps (jszip's `setimmediate` went missing), yielding
+    // a package that built but crashed on boot. npm's flat hoist matches the working host
+    // build and installs the full tree.
+    // Nested `runPnpm` calls (buildWorkspaceArtifacts, collectWorkspaceTarballs)
+    // route through createPackageManagerInvocation, which prefers `npm_execpath`
+    // and otherwise falls back to `corepack pnpm …`. The inner build is launched
+    // as `node tools-pack.mjs` (not via pnpm), so npm_execpath is unset, and the
+    // builder:base image has no corepack on PATH (pnpm's managed Node only
+    // symlinks `node` into PNPM_HOME) — the fallback dies with `spawn corepack
+    // ENOENT`. Point npm_execpath at the standalone pnpm we bootstrapped so every
+    // nested invocation runs `${CONTAINER_PNPM_PATH} …` directly, bypassing
+    // corepack entirely.
     "-e",
-    `${PRODUCTION_INSTALL_PNPM_BIN_ENV}=${CONTAINER_PNPM_PATH}`,
+    `npm_execpath=${CONTAINER_PNPM_PATH}`,
   ];
   if (config.telemetryRelayUrl != null) {
     dockerArgs.push("-e", `OPEN_DESIGN_TELEMETRY_RELAY_URL=${config.telemetryRelayUrl}`);
@@ -431,14 +466,14 @@ async function runPnpm(
 export type ProductionInstallCommand = { command: string; args: string[] };
 
 // Picks the package manager used to materialize the assembled-app node_modules
-// during writeAssembledApp. The default (`npm`) preserves host behavior for
-// developer-machine builds. When the build runs inside
-// `electronuserland/builder:base` (which strips npm, npx, and corepack),
-// buildDockerArgs sets OD_TOOLS_PACK_PNPM_BIN to the standalone pnpm binary it
-// bootstrapped, and this resolver routes the install through that binary.
-// `--config.node-linker=hoisted` keeps the resulting layout flat so
-// electron-builder packs node_modules the same way it does for npm-installed
-// trees.
+// during writeAssembledApp. Both the host and (now) the containerized build use
+// npm: it hoists the file: internal deps flat and installs the full transitive
+// tree, which is what actually boots. The containerized build exposes npm by
+// putting the pnpm-managed Node bin on PATH (see buildDockerArgs), so it no longer
+// sets OD_TOOLS_PACK_PNPM_BIN. The OD_TOOLS_PACK_PNPM_BIN branch is retained as an
+// opt-in escape hatch, but it is not the container default anymore: a pnpm
+// `--prod --no-lockfile` install over the file: tarballs dropped transitive deps
+// (jszip's `setimmediate`), yielding a package that built but crashed on boot.
 export function resolveProductionInstallCommand(env: NodeJS.ProcessEnv): ProductionInstallCommand {
   const pnpmBin = env[PRODUCTION_INSTALL_PNPM_BIN_ENV];
   if (pnpmBin != null && pnpmBin.length > 0) {

--- a/tools/pack/src/resources/index.ts
+++ b/tools/pack/src/resources/index.ts
@@ -55,6 +55,11 @@ export const winResources = {
 export const linuxResources = {
   icon: join(resourcesRoot, "linux", "icon.png"),
   desktopTemplate: join(resourcesRoot, "linux", "open-design.desktop.template"),
+  // Debian-specific packaging assets, kept as files under a `debian/` directory
+  // (mirroring the Debian maintainer convention) instead of inline strings. These
+  // feed the `deb` target's fpm source=destination / --deb-changelog args.
+  debianCopyright: join(resourcesRoot, "linux", "debian", "copyright"),
+  debianChangelogTemplate: join(resourcesRoot, "linux", "debian", "changelog.template"),
 } as const;
 
 const BUNDLED_RESOURCE_TREES = [

--- a/tools/pack/src/resources/index.ts
+++ b/tools/pack/src/resources/index.ts
@@ -60,6 +60,7 @@ export const linuxResources = {
   // feed the `deb` target's fpm source=destination / --deb-changelog args.
   debianCopyright: join(resourcesRoot, "linux", "debian", "copyright"),
   debianChangelogTemplate: join(resourcesRoot, "linux", "debian", "changelog.template"),
+  debianLintianOverrides: join(resourcesRoot, "linux", "debian", "lintian-overrides"),
 } as const;
 
 const BUNDLED_RESOURCE_TREES = [

--- a/tools/pack/tests/linux.test.ts
+++ b/tools/pack/tests/linux.test.ts
@@ -168,6 +168,22 @@ describe("buildDockerArgs", () => {
     expect(args).toContain("ELECTRON_BUILDER_CACHE=/home/builder/.cache/electron-builder");
   });
 
+  it("sets CI=true so the inner pnpm install does not abort the modules-dir purge on a populated host tree", () => {
+    // Regression guard for ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY: a local
+    // developer tree mounts an existing node_modules the container pnpm wants to
+    // rebuild; without CI it refuses the purge with no TTY and the build fails.
+    const args = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
+    expect(args).toContain("CI=true");
+  });
+
+  it("points npm_execpath at the standalone container pnpm so nested runPnpm calls avoid corepack", () => {
+    // Regression guard for `spawn corepack ENOENT`: the builder:base image has no
+    // corepack, so createPackageManagerInvocation must resolve to the bootstrapped
+    // pnpm instead of the corepack fallback.
+    const args = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
+    expect(args).toContain("npm_execpath=/tmp/pnpm");
+  });
+
   it("passes the telemetry relay URL into containerized builds when configured", () => {
     const args = buildDockerArgs(
       {
@@ -343,12 +359,16 @@ describe("buildDockerArgs", () => {
     expect(last).toContain("--app-version '0.5.0-beta.1'\\''quoted'");
   });
 
-  it("exports OD_TOOLS_PACK_PNPM_BIN=/tmp/pnpm so the inner build's production install skips npm", () => {
+  it("does not export OD_TOOLS_PACK_PNPM_BIN so the assembled-app production install uses npm", () => {
+    // The container now exposes npm (pnpm-managed Node bin on PATH). A pnpm
+    // `--prod --no-lockfile` install over the file: tarballs dropped transitive
+    // deps (jszip's `setimmediate`) and the package crashed on boot, so the
+    // production install falls back to npm's full flat hoist.
     const args = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
     const envFlagIndex = args.findIndex(
-      (arg, i) => arg === "-e" && args[i + 1] === "OD_TOOLS_PACK_PNPM_BIN=/tmp/pnpm",
+      (arg, i) => arg === "-e" && args[i + 1]?.startsWith("OD_TOOLS_PACK_PNPM_BIN="),
     );
-    expect(envFlagIndex).toBeGreaterThan(-1);
+    expect(envFlagIndex).toBe(-1);
   });
 });
 
@@ -558,21 +578,23 @@ describe("resolveProductionInstallCommand", () => {
     });
   });
 
-  it("chains end-to-end with buildDockerArgs: docker exports OD_TOOLS_PACK_PNPM_BIN and the resolver returns the standalone pnpm install for that value", () => {
+  it("chains end-to-end with buildDockerArgs: the container omits OD_TOOLS_PACK_PNPM_BIN so the resolver returns the npm install", () => {
+    // The containerized build exposes npm on PATH and relies on it for the
+    // assembled-app production install (pnpm dropped transitive deps like
+    // jszip's `setimmediate`, crashing the packaged app on boot). So docker must
+    // NOT export OD_TOOLS_PACK_PNPM_BIN, and the resolver — reading the same
+    // (absent) env — must return npm.
     const dockerArgs = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
     const envFlagIndex = dockerArgs.findIndex(
       (arg, i) => arg === "-e" && dockerArgs[i + 1]?.startsWith("OD_TOOLS_PACK_PNPM_BIN="),
     );
-    expect(envFlagIndex).toBeGreaterThan(-1);
-    const envValue = dockerArgs[envFlagIndex + 1]?.split("=")[1];
-    expect(envValue).toBe("/tmp/pnpm");
+    expect(envFlagIndex).toBe(-1);
 
-    const resolved = resolveProductionInstallCommand({ OD_TOOLS_PACK_PNPM_BIN: envValue });
+    const resolved = resolveProductionInstallCommand({});
     expect(resolved).toEqual({
-      command: "/tmp/pnpm",
-      args: ["install", "--prod", "--no-lockfile", "--config.node-linker=hoisted"],
+      command: "npm",
+      args: ["install", "--omit=dev", "--no-package-lock"],
     });
-    expect(resolved.command).not.toBe("npm");
   });
 });
 

--- a/tools/pack/tests/linux.test.ts
+++ b/tools/pack/tests/linux.test.ts
@@ -60,8 +60,10 @@ import {
   createLinuxDesktopLaunchEnv,
   inspectPackedLinuxApp,
   LINUX_APPIMAGE_EXECUTABLE_ARGS,
+  linuxBuildsAppImage,
   matchesAppImageProcess,
   renderDesktopTemplate,
+  resolveLinuxBuilderTargets,
   renderLinuxAppImageAppRun,
   renderLinuxPackagedMainEntry,
   resolveLinuxLifecycleMode,
@@ -800,6 +802,30 @@ describe("resolveLinuxLifecycleMode", () => {
     expect(resolveLinuxLifecycleMode({}, "stop")).toBe("appimage");
     expect(resolveLinuxLifecycleMode({}, "uninstall")).toBe("appimage");
     expect(resolveLinuxLifecycleMode({}, "cleanup")).toBe("appimage");
+  });
+});
+
+describe("resolveLinuxBuilderTargets", () => {
+  it("maps deb to the electron-builder deb target", () => {
+    expect(resolveLinuxBuilderTargets("deb")).toEqual(["deb"]);
+  });
+
+  it("maps dir to an unpacked build", () => {
+    expect(resolveLinuxBuilderTargets("dir")).toEqual(["dir"]);
+  });
+
+  it("defaults appimage and all to AppImage", () => {
+    expect(resolveLinuxBuilderTargets("appimage")).toEqual(["AppImage"]);
+    expect(resolveLinuxBuilderTargets("all")).toEqual(["AppImage"]);
+  });
+});
+
+describe("linuxBuildsAppImage", () => {
+  it("is true only for appimage/all so deb and dir skip the AppRun wrapper", () => {
+    expect(linuxBuildsAppImage("appimage")).toBe(true);
+    expect(linuxBuildsAppImage("all")).toBe(true);
+    expect(linuxBuildsAppImage("deb")).toBe(false);
+    expect(linuxBuildsAppImage("dir")).toBe(false);
   });
 });
 

--- a/tools/pack/tests/linux.test.ts
+++ b/tools/pack/tests/linux.test.ts
@@ -61,6 +61,7 @@ import {
   inspectPackedLinuxApp,
   LINUX_APPIMAGE_EXECUTABLE_ARGS,
   linuxBuildsAppImage,
+  linuxBundledFilePatterns,
   matchesAppImageProcess,
   renderDesktopTemplate,
   resolveLinuxBuilderTargets,
@@ -802,6 +803,72 @@ describe("resolveLinuxLifecycleMode", () => {
     expect(resolveLinuxLifecycleMode({}, "stop")).toBe("appimage");
     expect(resolveLinuxLifecycleMode({}, "uninstall")).toBe("appimage");
     expect(resolveLinuxLifecycleMode({}, "cleanup")).toBe("appimage");
+  });
+});
+
+describe("linuxBundledFilePatterns", () => {
+  // Paths as they appear in the assembled app, relative to its root.
+  const bundledCruft = [
+    "node_modules/@ffmpeg-installer/ffmpeg/index.js~",
+    "node_modules/@ffmpeg-installer/ffmpeg/lib/manifest.js~",
+    "node_modules/node-pty/prebuilds/win32-x64/pty.node",
+    "node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper",
+    "node_modules/onnxruntime-node/bin/napi-v3/darwin/x64/libonnxruntime.1.21.1.dylib",
+    "node_modules/onnxruntime-node/bin/napi-v3/win32/arm64/onnxruntime_binding.node",
+    "node_modules/onnxruntime-node/bin/napi-v3/linux/x64/libonnxruntime_providers_cuda.so",
+    "node_modules/onnxruntime-node/bin/napi-v3/linux/x64/libonnxruntime_providers_tensorrt.so",
+  ];
+  const linuxX64Runtime = [
+    "node_modules/node-pty/prebuilds/linux-x64/pty.node",
+    "node_modules/onnxruntime-node/bin/napi-v3/linux/x64/onnxruntime_binding.node",
+    "node_modules/onnxruntime-node/bin/napi-v3/linux/x64/libonnxruntime.so.1",
+    "node_modules/onnxruntime-node/bin/napi-v3/linux/x64/libonnxruntime_providers_shared.so",
+    "node_modules/@ffmpeg-installer/ffmpeg/index.js",
+  ];
+
+  // Mirrors electron-builder's `files` semantics closely enough for these
+  // patterns: the last matching rule wins, `!` negates.
+  function bundled(patterns: string[], file: string): boolean {
+    let keep = false;
+    for (const pattern of patterns) {
+      const negated = pattern.startsWith("!");
+      const glob = negated ? pattern.slice(1) : pattern;
+      if (globMatches(glob, file)) keep = !negated;
+    }
+    return keep;
+  }
+  function expandBraces(glob: string): string[] {
+    const match = /\{([^{}]*)\}/.exec(glob);
+    if (!match) return [glob];
+    return match[1]
+      .split(",")
+      .flatMap((alt) => expandBraces(glob.slice(0, match.index) + alt + glob.slice(match.index + match[0].length)));
+  }
+  function globMatches(glob: string, file: string): boolean {
+    return expandBraces(glob).some((variant) => {
+      const source = variant
+        .split(/(\*\*\/|\*\*|\*)/)
+        .map((part) => (part === "**/" ? "(?:.*/)?" : part === "**" ? ".*" : part === "*" ? "[^/]*" : escape(part)))
+        .join("");
+      return new RegExp(`^${source}$`).test(file);
+    });
+  }
+  function escape(value: string): string {
+    return value.replace(/[.+^$()|[\]\\?]/g, "\\$&");
+  }
+
+  it("drops foreign-platform binaries, GPU providers and backup files on x64", () => {
+    const patterns = linuxBundledFilePatterns("x64");
+    for (const file of bundledCruft) expect(bundled(patterns, file), file).toBe(false);
+    for (const file of linuxX64Runtime) expect(bundled(patterns, file), file).toBe(true);
+    expect(bundled(patterns, "node_modules/onnxruntime-node/bin/napi-v3/linux/arm64/libonnxruntime.so.1")).toBe(false);
+  });
+
+  it("keeps the arm64 linux runtime and drops x64 when building on arm64", () => {
+    const patterns = linuxBundledFilePatterns("arm64");
+    expect(bundled(patterns, "node_modules/onnxruntime-node/bin/napi-v3/linux/arm64/libonnxruntime.so.1")).toBe(true);
+    expect(bundled(patterns, "node_modules/onnxruntime-node/bin/napi-v3/linux/x64/libonnxruntime.so.1")).toBe(false);
+    expect(bundled(patterns, "node_modules/onnxruntime-node/bin/napi-v3/linux/arm64/libonnxruntime_providers_cuda.so")).toBe(false);
   });
 });
 


### PR DESCRIPTION
Fixes #5982

> **Stacked on #7767** (containerized-build fix, formerly #6009 which the
> inactivity bot closed while approved). GitHub can't base a PR on a fork
> branch, so this PR's diff also contains that single commit (`334a613`, the
> rebased form of #7767's `d72f8ad`). Please review **#7767 first**, or skip that
> commit here; once it merges I will rebase and this PR's diff reduces to the
> `.deb` target commits. The `.deb` feature's `--containerized` acceptance path
> depends on #7767.
>
> Rebased on current `main` (0.21.1) on 2026-09-04; the two newest commits add the
> bundle cleanup described below.

## Why

Linux users have no native, distro-integrated package: `tools-pack linux build`
produced only an AppImage. `tools/pack/README.md` explicitly defers `.deb`/`.rpm`
*"until there is demand and an owner for per-distro metadata … and release
validation."* This is that demand — I hit it building on top of OD and am
volunteering to own the `.deb` slice. Relates to #5531 (Linux advertised, no
download available).

## What users will see

A new build target:

```
pnpm tools-pack linux build --to deb            # native
pnpm tools-pack linux build --to deb --containerized   # glibc-portable (needs #6009)
```

produces a **standards-compliant** `open-design_<version>_<arch>.deb` that:
- installs with `apt install ./open-design_*.deb` (deps resolve on bookworm/trixie/sid),
- shows **Open Design** in the application menu, installs under `/opt/OpenDesign/`,
  and provides the `open-design` command,
- is removable with `apt remove open-design`.

Debian metadata is done properly (not electron-builder defaults): `Package: open-design`,
`Section: devel`, `Priority: optional`, RFC822 `Maintainer`, time_t-64 aware `Depends`
(`libgtk-3-0 | libgtk-3-0t64`, …) plus `libc6`, Ayatana tray `Recommends`, DEP-5
`copyright`, a valid Debian `changelog`, and a checked-in `lintian` overrides file
documenting the assumed bundled-Electron deviations.

All of this is **deb-scoped** — the AppImage and the macOS/Windows app identity
(`productName` "Open Design", executable name, launcher/tests) are untouched.

## Surface area

- [x] **CLI / env var** — `tools-pack linux build --to deb`
- [x] **Extension point** — new packaging assets under `tools/pack/resources/linux/debian/` (DEP-5 `copyright`, `changelog.template`, `lintian-overrides`)

## Screenshots

N/A — CLI / packaging change, no UI surface.

## Validation

- `pnpm guard` · `pnpm --filter @open-design/tools-pack typecheck` · `pnpm --filter @open-design/tools-pack test` (309 pass, 9 skipped — on `main` 0.21.1)
- `pnpm tools-pack linux build --to deb --portable` (native) and `--containerized`
- `dpkg-deb -f/-c` confirms `Package: open-design`, `License: Apache-2.0`,
  `Maintainer: Open Design Contributors <contributors@open-design.ai>`, `/opt/OpenDesign/`,
  `/usr/bin/open-design`, `.desktop Name=Open Design`, copyright + changelog + overrides present; archive valid.
- **`lintian` clean: 0 errors / 0 warnings** with the checked-in overrides file applied
  (re-verified on the 0.21.1 rebase after the bundle cleanup; `--tag-display-limit 0`).
  The overrides document only the embedded-Electron-runtime deviations every Electron
  `.deb` carries (VS Code/Slack/Discord alike — a bundled Electron app cannot be a
  Policy-clean Debian *source* package); no controllable metadata is suppressed.
- Boot smoke: extract + launch `open-design` → starts, 0 fatal errors.

## Bundle cleanup (applies to the AppImage too)

Since `main` picked up `hyperframes` (#7030), the packaged `node_modules` carries
`onnxruntime-node`, which ships prebuilt binaries for every platform/arch plus the
CUDA/TensorRT execution providers — ~445 MB that can never load from a Linux
amd64 package and that `lintian` flags as `binary-from-other-architecture`.
`node-pty` likewise bundles its darwin/win32 prebuilds, and
`@ffmpeg-installer/ffmpeg` publishes editor backup files (`*~`).

The electron-builder `files` list now lives in `linuxBundledFilePatterns(hostArch)`
and drops those trees, keeping only the host-arch Linux runtime (hyperframes
falls back to its CPU provider when CUDA is absent — the package never depended on
a CUDA toolkit). A pattern test pins the known cruft as excluded and the Linux
runtime as kept. The `.deb` goes from 693 MB to 527 MB; the AppImage shares the
same list and shrinks accordingly.

A last commit fixes `description-starts-with-leading-spaces`: electron-builder
already indents the extended description line before fpm indents it again, so the
deb passthrough now hands fpm the raw two-line text (same override pattern as
`--name`).

## Scope & limits (build-only, stated up front)

- **`--to all` builds the AppImage only** on Linux — the `.deb` is a separate
  invocation (`--to deb`). This is intentional and asymmetric with Windows `all`:
  the deb's `productName`/`executableName` (`OpenDesign`/`open-design`) are
  path-safe and **mutually exclusive** with the AppImage's "Open Design", so a
  combined electron-builder run would corrupt one of them. Commented at
  `resolveLinuxBuilderTargets`.
- **No release/updater/landing wiring here.** Publishing the `.deb` as a release
  artifact (R2 upload + `metadata.json`) is the follow-up **#6017**, stacked on top.
- **e2e install smoke stays AppImage-only.** `e2e/specs/linux.spec.ts`
  (`OD_PACKAGED_E2E_LINUX_APPIMAGE`) installs/starts/inspects/uninstalls the
  AppImage; there is **no `dpkg -i` / `apt install` smoke for the `.deb` yet**.
  The deb is validated at build-artifact level (`dpkg-deb`, `lintian`, boot),
  not through the packaged lifecycle harness. A containerized `dpkg -i` smoke is
  a sensible next increment.
- **`.rpm` is not included.** `linux.maintainer` is already rpm-ready, but a real
  `.rpm` needs its own section/deps + `rpmlint`/install validation, so it is the
  planned next increment rather than shipped untested.

## Out of scope (deferred, agreed)

Package signing and an APT repository (`reprepro`/`aptly` publish with GPG) — to
land when the apt repo is set up.


