### PR TITLE
fix(web): render deck project cards as static slide thumbnails

### DIFF
--- a/apps/web/src/components/DesignsTab.tsx
+++ b/apps/web/src/components/DesignsTab.tsx
@@ -29,6 +29,7 @@ import {
 import { LiveArtifactBadges } from "./LiveArtifactBadges";
 import { Toast } from "./Toast";
 import {
+	DeckProjectCoverFrame,
 	HtmlProjectCoverFrame,
 	coverFromProjectFile,
 	projectCoverUrl,
@@ -932,13 +933,23 @@ export function DesignsTab({
 									) : cover.kind === "video" && cover.src ? (
 										<video className="thumb-media" src={cover.src} muted preload="metadata" playsInline />
 									) : cover.kind === "html" ? (
-										<HtmlProjectCoverFrame
-											src={cover.src}
-											initial={cover.initial}
-											iframeClassName="thumb-iframe"
-											glyphClassName="project-thumb-glyph"
-											diagnostic={`${p.id}:${cover.name ?? "unknown"}`}
-										/>
+										p.metadata?.kind === "deck" ? (
+											<DeckProjectCoverFrame
+												src={cover.src}
+												initial={cover.initial}
+												iframeClassName="thumb-iframe"
+												glyphClassName="project-thumb-glyph"
+												diagnostic={`${p.id}:${cover.name ?? "unknown"}`}
+											/>
+										) : (
+											<HtmlProjectCoverFrame
+												src={cover.src}
+												initial={cover.initial}
+												iframeClassName="thumb-iframe"
+												glyphClassName="project-thumb-glyph"
+												diagnostic={`${p.id}:${cover.name ?? "unknown"}`}
+											/>
+										)
 									) : (
 										<span className="project-thumb-glyph">{cover.initial}</span>
 									)}

--- a/apps/web/src/components/RecentProjectsStrip.tsx
+++ b/apps/web/src/components/RecentProjectsStrip.tsx
@@ -16,6 +16,7 @@ import { Icon } from './Icon';
 import { STATUS_LABEL_KEYS } from './DesignsTab';
 import { isDesignSystemProject, isPublishedDesignSystemProject } from './design-system-project';
 import {
+  DeckProjectCoverFrame,
   HtmlProjectCoverFrame,
   coverFromProjectFile,
   projectCoverUrl,
@@ -275,13 +276,23 @@ export function RecentProjectsStrip({
                       playsInline
                     />
                   ) : cover.kind === 'html' ? (
-                    <HtmlProjectCoverFrame
-                      src={cover.src}
-                      initial={cover.initial}
-                      iframeClassName="recent-projects__thumb-iframe"
-                      glyphClassName="recent-projects__card-glyph"
-                      diagnostic={`${project.id}:${cover.name ?? 'unknown'}`}
-                    />
+                    project.metadata?.kind === 'deck' ? (
+                      <DeckProjectCoverFrame
+                        src={cover.src}
+                        initial={cover.initial}
+                        iframeClassName="recent-projects__thumb-iframe"
+                        glyphClassName="recent-projects__card-glyph"
+                        diagnostic={`${project.id}:${cover.name ?? 'unknown'}`}
+                      />
+                    ) : (
+                      <HtmlProjectCoverFrame
+                        src={cover.src}
+                        initial={cover.initial}
+                        iframeClassName="recent-projects__thumb-iframe"
+                        glyphClassName="recent-projects__card-glyph"
+                        diagnostic={`${project.id}:${cover.name ?? 'unknown'}`}
+                      />
+                    )
                   ) : (
                     <span className="recent-projects__card-glyph">{cover.initial}</span>
                   )}

--- a/apps/web/src/components/project-cover.tsx
+++ b/apps/web/src/components/project-cover.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { projectFileUrl } from '../providers/registry';
 import type { ProjectFile } from '../types';
+import { parseDeckThumbnails, type ParsedDeckThumbnails } from '../runtime/deck-thumbnail-parser';
+import { DeckSlideThumbnail } from './DeckSlideThumbnail';
 
 export type ProjectCoverKind = 'html' | 'image' | 'video' | 'logo';
 
@@ -116,6 +118,105 @@ export function HtmlProjectCoverFrame({
         console.warn('[project-cover] failed to load HTML cover:', diagnostic);
         setFailed(true);
       }}
+    />
+  );
+}
+
+// Deck (slide) project cover: render the first slide as inert DOM via
+// `DeckSlideThumbnail` so the gallery card shows a clean static preview without
+// the deck's carousel nav chrome (prev/next buttons, slide counter) that the
+// raw `index.html` iframe would paint. Falls back to the plain HTML iframe
+// when the deck source can't be parsed, and to the project glyph when the file
+// is unreachable. See issue #2648.
+export function DeckProjectCoverFrame({
+  src,
+  initial,
+  iframeClassName,
+  glyphClassName,
+  diagnostic,
+}: {
+  src: string | undefined;
+  initial: string;
+  iframeClassName: string;
+  glyphClassName: string;
+  diagnostic: string;
+}) {
+  const [failed, setFailed] = useState(false);
+  const [parsed, setParsed] = useState<ParsedDeckThumbnails | null>(null);
+  const [thumbFailed, setThumbFailed] = useState(false);
+
+  useEffect(() => {
+    if (!src) {
+      setFailed(false);
+      setParsed(null);
+      setThumbFailed(false);
+      return;
+    }
+    const controller = new AbortController();
+    let disposed = false;
+    setFailed(false);
+    setParsed(null);
+    setThumbFailed(false);
+
+    fetch(src, { signal: controller.signal, cache: 'no-store' })
+      .then((response) => {
+        if (disposed) return;
+        if (!response.ok && response.status !== 304) {
+          console.warn(
+            `[project-cover] deck cover unavailable (${response.status} ${response.statusText}):`,
+            diagnostic,
+          );
+          setFailed(true);
+          return;
+        }
+        return response.text();
+      })
+      .then((html) => {
+        if (disposed || !html) return;
+        const result = parseDeckThumbnails(html, src);
+        if (!result.renderable || result.slides.length === 0) {
+          // Unparseable deck source — fall back to the raw HTML iframe.
+          setThumbFailed(true);
+          return;
+        }
+        setParsed(result);
+      })
+      .catch((err) => {
+        if (disposed || (err instanceof DOMException && err.name === 'AbortError')) return;
+        console.warn('[project-cover] failed to fetch deck cover:', diagnostic, err);
+        setFailed(true);
+      });
+
+    return () => {
+      disposed = true;
+      controller.abort();
+    };
+  }, [src, diagnostic]);
+
+  // Source unreachable or no deck markup at all → project glyph.
+  if (!src || failed) {
+    return <span className={glyphClassName}>{initial}</span>;
+  }
+
+  // Deck parsed and renderable → inert first-slide thumbnail (no carousel chrome).
+  if (parsed && !thumbFailed) {
+    return (
+      <DeckSlideThumbnail
+        parsed={parsed}
+        index={0}
+        onError={() => setThumbFailed(true)}
+      />
+    );
+  }
+
+  // Fallback: parse failed or thumbnail errored → raw HTML iframe (current behavior).
+  return (
+    <HtmlProjectCoverFrame
+      src={src}
+      initial={initial}
+      iframeClassName={iframeClassName}
+      glyphClassName={glyphClassName}
+      diagnostic={diagnostic}
     />
   );
 }

--- a/apps/web/src/components/project-cover.tsx
+++ b/apps/web/src/components/project-cover.tsx
@@ -141,22 +141,29 @@ export function DeckProjectCoverFrame({
   glyphClassName: string;
   diagnostic: string;
 }) {
-  const [failed, setFailed] = useState(false);
+  // Explicit three-state model so the raw-iframe fallback never mounts while
+  // the deck GET/parse is still pending. While loading we render the same glyph
+  // the card would show for an unknown cover — never `HtmlProjectCoverFrame`,
+  // which would fire a redundant HEAD probe and could mount the raw
+  // `index.html` iframe (with the carousel chrome this change removes) if that
+  // probe resolves before the deck body finishes parsing. The iframe only
+  // mounts once parsing or shadow rendering has explicitly failed.
+  const [phase, setPhase] = useState<'loading' | 'parsed' | 'fallback'>('loading');
   const [parsed, setParsed] = useState<ParsedDeckThumbnails | null>(null);
-  const [thumbFailed, setThumbFailed] = useState(false);
+  const [shadowFailed, setShadowFailed] = useState(false);
 
   useEffect(() => {
     if (!src) {
-      setFailed(false);
+      setPhase('loading');
       setParsed(null);
-      setThumbFailed(false);
+      setShadowFailed(false);
       return;
     }
     const controller = new AbortController();
     let disposed = false;
-    setFailed(false);
+    setPhase('loading');
     setParsed(null);
-    setThumbFailed(false);
+    setShadowFailed(false);
 
     fetch(src, { signal: controller.signal, cache: 'no-store' })
       .then((response) => {
@@ -166,7 +173,7 @@ export function DeckProjectCoverFrame({
             `[project-cover] deck cover unavailable (${response.status} ${response.statusText}):`,
             diagnostic,
           );
-          setFailed(true);
+          setPhase('fallback');
           return;
         }
         return response.text();
@@ -176,15 +183,16 @@ export function DeckProjectCoverFrame({
         const result = parseDeckThumbnails(html, src);
         if (!result.renderable || result.slides.length === 0) {
           // Unparseable deck source — fall back to the raw HTML iframe.
-          setThumbFailed(true);
+          setPhase('fallback');
           return;
         }
         setParsed(result);
+        setPhase('parsed');
       })
       .catch((err) => {
         if (disposed || (err instanceof DOMException && err.name === 'AbortError')) return;
         console.warn('[project-cover] failed to fetch deck cover:', diagnostic, err);
-        setFailed(true);
+        setPhase('fallback');
       });
 
     return () => {
@@ -193,13 +201,16 @@ export function DeckProjectCoverFrame({
     };
   }, [src, diagnostic]);
 
-  // Source unreachable or no deck markup at all → project glyph.
-  if (!src || failed) {
+  // No source, or still loading the deck body → glyph. Keeps the card out of
+  // the iframe path until parsing resolves.
+  if (!src || phase === 'loading') {
     return <span className={glyphClassName}>{initial}</span>;
   }
 
-  // Deck parsed and renderable → inert first-slide thumbnail (no carousel chrome).
-  if (parsed && !thumbFailed) {
+  // Deck parsed and shadow rendering hasn't errored → inert first-slide
+  // thumbnail (no carousel chrome). If the shadow build later fails, the
+  // onError callback flips us to the iframe fallback.
+  if (phase === 'parsed' && parsed && !shadowFailed) {
     return (
       // DeckSlideThumbnail scales its shadow canvas to its host div's
       // clientWidth/clientHeight, so the host must fill the card thumb. The
@@ -209,13 +220,14 @@ export function DeckProjectCoverFrame({
         <DeckSlideThumbnail
           parsed={parsed}
           index={0}
-          onError={() => setThumbFailed(true)}
+          onError={() => setShadowFailed(true)}
         />
       </div>
     );
   }
 
-  // Fallback: parse failed or thumbnail errored → raw HTML iframe (current behavior).
+  // Explicit failure: unparseable source, fetch error, or shadow-render error
+  // → raw HTML iframe (previous behavior).
   return (
     <HtmlProjectCoverFrame
       src={src}

--- a/apps/web/src/components/project-cover.tsx
+++ b/apps/web/src/components/project-cover.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { projectFileUrl } from '../providers/registry';
 import type { ProjectFile } from '../types';
 import { parseDeckThumbnails, type ParsedDeckThumbnails } from '../runtime/deck-thumbnail-parser';
@@ -152,6 +152,12 @@ export function DeckProjectCoverFrame({
   const [parsed, setParsed] = useState<ParsedDeckThumbnails | null>(null);
   const [shadowFailed, setShadowFailed] = useState(false);
 
+  // Stable identity so DeckSlideThumbnail's layout-effect (which clears and
+  // rebuilds the shadow root when its deps change) doesn't tear down a healthy
+  // preview on unrelated parent rerenders. Mirrors DeckThumbnailRail's
+  // handleShadowError.
+  const handleShadowError = useCallback(() => setShadowFailed(true), []);
+
   useEffect(() => {
     if (!src) {
       setPhase('loading');
@@ -220,7 +226,7 @@ export function DeckProjectCoverFrame({
         <DeckSlideThumbnail
           parsed={parsed}
           index={0}
-          onError={() => setShadowFailed(true)}
+          onError={handleShadowError}
         />
       </div>
     );

--- a/apps/web/src/components/project-cover.tsx
+++ b/apps/web/src/components/project-cover.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { projectFileUrl } from '../providers/registry';
 import type { ProjectFile } from '../types';
 import { parseDeckThumbnails, type ParsedDeckThumbnails } from '../runtime/deck-thumbnail-parser';
@@ -151,6 +151,13 @@ export function DeckProjectCoverFrame({
   const [phase, setPhase] = useState<'loading' | 'parsed' | 'fallback'>('loading');
   const [parsed, setParsed] = useState<ParsedDeckThumbnails | null>(null);
   const [shadowFailed, setShadowFailed] = useState(false);
+  // Visibility gate: DesignsTab mounts one cover per item without
+  // virtualization, so eagerly fetching + DOMParser-parsing every deck's full
+  // index.html (including cards far below the fold) is a regression vs the old
+  // iframe path, which had loading="lazy" and only a HEAD probe. We defer the
+  // full-body fetch until the cover scrolls near the viewport.
+  const [visible, setVisible] = useState(false);
+  const hostRef = useRef<HTMLSpanElement | null>(null);
 
   // Stable identity so DeckSlideThumbnail's layout-effect (which clears and
   // rebuilds the shadow root when its deps change) doesn't tear down a healthy
@@ -159,10 +166,33 @@ export function DeckProjectCoverFrame({
   const handleShadowError = useCallback(() => setShadowFailed(true), []);
 
   useEffect(() => {
-    if (!src) {
-      setPhase('loading');
-      setParsed(null);
-      setShadowFailed(false);
+    const host = hostRef.current;
+    if (!host || visible) return;
+    if (typeof IntersectionObserver === 'undefined') {
+      // No observer available (e.g. jsdom) — fall back to fetching eagerly.
+      setVisible(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: '200px' },
+    );
+    observer.observe(host);
+    return () => observer.disconnect();
+  }, [visible]);
+
+  useEffect(() => {
+    if (!src || !visible) {
+      if (!src) {
+        setPhase('loading');
+        setParsed(null);
+        setShadowFailed(false);
+      }
       return;
     }
     const controller = new AbortController();
@@ -185,7 +215,14 @@ export function DeckProjectCoverFrame({
         return response.text();
       })
       .then((html) => {
-        if (disposed || !html) return;
+        if (disposed) return;
+        // Empty body (e.g. a 304 with no body, or a zero-byte 200) means
+        // parsing definitively finished with nothing to render — go to the
+        // raw-iframe fallback rather than leaving the card stuck in loading.
+        if (!html) {
+          setPhase('fallback');
+          return;
+        }
         const result = parseDeckThumbnails(html, src);
         if (!result.renderable || result.slides.length === 0) {
           // Unparseable deck source — fall back to the raw HTML iframe.
@@ -205,12 +242,18 @@ export function DeckProjectCoverFrame({
       disposed = true;
       controller.abort();
     };
-  }, [src, diagnostic]);
+  }, [src, diagnostic, visible]);
 
-  // No source, or still loading the deck body → glyph. Keeps the card out of
-  // the iframe path until parsing resolves.
-  if (!src || phase === 'loading') {
-    return <span className={glyphClassName}>{initial}</span>;
+  // Before the cover is visible (IntersectionObserver hasn't fired), it stays
+  // in the glyph/loading phase — no fetch, no iframe. The glyph span carries
+  // the observer ref; once visible flips true the observer disconnects and the
+  // fetch effect below takes over, so the ref is only needed on this branch.
+  if (!src || !visible || phase === 'loading') {
+    return (
+      <span ref={hostRef} className={glyphClassName}>
+        {initial}
+      </span>
+    );
   }
 
   // Deck parsed and shadow rendering hasn't errored → inert first-slide
@@ -232,8 +275,8 @@ export function DeckProjectCoverFrame({
     );
   }
 
-  // Explicit failure: unparseable source, fetch error, or shadow-render error
-  // → raw HTML iframe (previous behavior).
+  // Explicit failure: unparseable source, empty body, fetch error, or
+  // shadow-render error → raw HTML iframe (previous behavior).
   return (
     <HtmlProjectCoverFrame
       src={src}

--- a/apps/web/src/components/project-cover.tsx
+++ b/apps/web/src/components/project-cover.tsx
@@ -201,11 +201,17 @@ export function DeckProjectCoverFrame({
   // Deck parsed and renderable → inert first-slide thumbnail (no carousel chrome).
   if (parsed && !thumbFailed) {
     return (
-      <DeckSlideThumbnail
-        parsed={parsed}
-        index={0}
-        onError={() => setThumbFailed(true)}
-      />
+      // DeckSlideThumbnail scales its shadow canvas to its host div's
+      // clientWidth/clientHeight, so the host must fill the card thumb. The
+      // shared thumb-iframe classes carry raw-iframe scale transforms that
+      // would distort a plain div, so this uses a dedicated fill wrapper.
+      <div className="deck-cover-frame" aria-hidden>
+        <DeckSlideThumbnail
+          parsed={parsed}
+          index={0}
+          onError={() => setThumbFailed(true)}
+        />
+      </div>
     );
   }
 

--- a/apps/web/src/styles/home/recent-projects.css
+++ b/apps/web/src/styles/home/recent-projects.css
@@ -149,6 +149,25 @@
   transform-origin: 0 0;
   transform: scale(calc(100cqw / 1280px));
 }
+/* Deck project cover: a static first-slide thumbnail (no carousel chrome).
+ * Fills the card thumb the same way the raw iframe does, and stretches the
+ * DeckSlideThumbnail shadow host to that fill area so its canvas can scale. */
+.recent-projects__card-thumb .deck-cover-frame {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  pointer-events: none;
+  background: #fff;
+}
+.recent-projects__card-thumb .deck-cover-frame .deck-thumbnail-shadow-host {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
 .recent-projects__deck-frame,
 .recent-projects__deck-iframe,
 .recent-projects__deck-cover-loading {

--- a/apps/web/src/styles/workspace/drawer.css
+++ b/apps/web/src/styles/workspace/drawer.css
@@ -783,6 +783,23 @@
   background: var(--bg-panel);
   pointer-events: none;
 }
+/* Deck project cover: static first-slide thumbnail filling the card thumb. */
+.design-card-thumb .deck-cover-frame {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  pointer-events: none;
+  background: var(--bg-panel);
+}
+.design-card-thumb .deck-cover-frame .deck-thumbnail-shadow-host {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
 .project-thumb-image,
 .project-thumb-video,
 .project-thumb-html,

--- a/apps/web/tests/components/DeckProjectCoverFrame.test.tsx
+++ b/apps/web/tests/components/DeckProjectCoverFrame.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { DeckProjectCoverFrame } from '../../src/components/project-cover';
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('DeckProjectCoverFrame', () => {
+  it('does not fetch an offscreen deck cover until it scrolls into view (#2648)', async () => {
+    const src = '/api/projects/project-deck/files/index.html?v=1';
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => '',
+    }) as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    // IntersectionObserver that never reports intersecting — simulates an
+    // offscreen card. The cover must not fetch until it is observed.
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        constructor(_cb: IntersectionObserverCallback) {
+          // Never invoke _cb → the cover stays "offscreen".
+        }
+        observe(...args: unknown[]) {
+          observe(...(args as [Element]));
+        }
+        disconnect() {
+          disconnect();
+        }
+        unobserve = vi.fn();
+      },
+    );
+
+    render(
+      <DeckProjectCoverFrame
+        src={src}
+        initial="D"
+        iframeClassName="thumb-iframe"
+        glyphClassName="card-glyph"
+        diagnostic="project-deck:index.html"
+      />,
+    );
+
+    // The host was observed for visibility but never intersects, so the deck
+    // fetch never fires.
+    expect(observe).toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      src,
+      expect.objectContaining({ cache: 'no-store' }),
+    );
+    expect(disconnect).not.toHaveBeenCalled();
+  });
+
+  it('fetches the deck body once the cover scrolls into view', async () => {
+    const src = '/api/projects/project-deck/files/index.html?v=1';
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () =>
+        '<!DOCTYPE html><html><body><div class="slide">x</div>' +
+        '<style>.slide{width:1280px;height:720px;background:#fff}</style></body></html>',
+    }) as Response);
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Observer that immediately reports the cover as intersecting on observe.
+    let cb: IntersectionObserverCallback | null = null;
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        constructor(callback: IntersectionObserverCallback) {
+          cb = callback;
+        }
+        observe(target: Element) {
+          // Immediately intersect.
+          cb?.(
+            [{ target, isIntersecting: true } as unknown as IntersectionObserverEntry],
+            this as unknown as IntersectionObserver,
+          );
+        }
+        disconnect = vi.fn();
+        unobserve = vi.fn();
+      },
+    );
+
+    render(
+      <DeckProjectCoverFrame
+        src={src}
+        initial="D"
+        iframeClassName="thumb-iframe"
+        glyphClassName="card-glyph"
+        diagnostic="project-deck:index.html"
+      />,
+    );
+
+    // Once visible, the deck body is fetched exactly once.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      src,
+      expect.objectContaining({ cache: 'no-store' }),
+    );
+  });
+});

--- a/apps/web/tests/components/RecentProjectsStrip.test.tsx
+++ b/apps/web/tests/components/RecentProjectsStrip.test.tsx
@@ -78,11 +78,12 @@ function projects(count: number): Project[] {
   );
 }
 
-function stubCoverProbe(status = 200, statusText = 'OK') {
+function stubCoverProbe(status = 200, statusText = 'OK', body?: string) {
   const fetchMock = vi.fn(async () => ({
     ok: status >= 200 && status < 300,
     status,
     statusText,
+    text: async () => body ?? '',
   }) as Response);
   vi.stubGlobal('fetch', fetchMock);
   return fetchMock;
@@ -256,7 +257,15 @@ describe('RecentProjectsStrip', () => {
   });
 
   it('renders HTML and deck covers from the current file URL', async () => {
-    const fetchMock = stubCoverProbe();
+    // Deck projects render the first slide as an inert thumbnail (no carousel
+    // chrome), so the deck cover returns a minimal parseable deck body; plain
+    // HTML projects keep the raw iframe. See #2648.
+    const deckBody =
+      '<!DOCTYPE html><html><body>' +
+      '<div class="slide">Slide one</div>' +
+      '<style>.slide{width:1280px;height:720px;background:#fff;color:#000}</style>' +
+      '</body></html>';
+    const fetchMock = stubCoverProbe(200, 'OK', deckBody);
 
     const { container } = render(
       <RecentProjectsStrip
@@ -282,9 +291,9 @@ describe('RecentProjectsStrip', () => {
     const htmlCard = container.querySelector('[data-project-id="project-html"]');
 
     await waitFor(() => {
-      expect(deckCard?.querySelector('iframe')?.getAttribute('src')).toBe(
-        '/api/projects/project-deck/files/index.html?v=400',
-      );
+      // Deck card renders the static slide thumbnail, not the raw iframe, so
+      // no carousel nav controls leak into the gallery card.
+      expect(deckCard?.querySelector('iframe')).toBeNull();
       expect(htmlCard?.querySelector('iframe')?.getAttribute('src')).toBe(
         '/api/projects/project-html/files/index.html?v=200',
       );
@@ -293,7 +302,7 @@ describe('RecentProjectsStrip', () => {
     });
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/projects/project-deck/files/index.html?v=400',
-      expect.objectContaining({ cache: 'no-store', method: 'HEAD' }),
+      expect.objectContaining({ cache: 'no-store', signal: expect.any(AbortSignal) }),
     );
     expect(fetchMock).toHaveBeenCalledWith(
       '/api/projects/project-html/files/index.html?v=200',

--- a/apps/web/tests/components/RecentProjectsStrip.test.tsx
+++ b/apps/web/tests/components/RecentProjectsStrip.test.tsx
@@ -310,6 +310,72 @@ describe('RecentProjectsStrip', () => {
     );
   });
 
+  it('does not mount the deck iframe fallback while the deck body is still loading (#2648)', async () => {
+    // Regression for the loading-state gap mrcfps flagged on #6013: while the
+    // deck GET/parse is pending, the card must render the glyph (loading), not
+    // the raw HTML iframe — otherwise an immediately-successful HEAD probe
+    // could mount index.html with the carousel chrome this change removes, and
+    // every parseable deck pays for a redundant probe. Here the deck GET never
+    // resolves (deferred), so the card stays in the loading/glyph phase and no
+    // iframe is mounted for the deck card at all.
+    const deckUrl = '/api/projects/project-deck/files/index.html?v=400';
+    const htmlUrl = '/api/projects/project-html/files/index.html?v=200';
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      // Deck GET stays pending forever (deferred body).
+      if (url === deckUrl && init?.method !== 'HEAD') {
+        return new Promise<Response>(() => {});
+      }
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => '',
+      } as Response;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { container } = render(
+      <RecentProjectsStrip
+        projects={[
+          project({
+            id: 'project-deck',
+            name: 'Simple Deck',
+            updatedAt: 4,
+            metadata: { kind: 'deck' },
+          }),
+          project({
+            id: 'project-html',
+            name: 'Web Prototype',
+            updatedAt: 3,
+          }),
+        ]}
+        onOpen={() => {}}
+        onViewAll={() => {}}
+      />,
+    );
+
+    const deckCard = container.querySelector('[data-project-id="project-deck"]');
+
+    // While the deck body is still loading, the deck card shows the glyph and
+    // never mounts an iframe (no carousel chrome, no redundant HEAD probe).
+    await waitFor(() => {
+      expect(deckCard?.querySelector('.recent-projects__card-glyph')).not.toBeNull();
+    });
+    expect(deckCard?.querySelector('iframe')).toBeNull();
+    // The deck GET was issued exactly once (the loading fetch); no HEAD probe.
+    const deckCalls = fetchMock.mock.calls.filter(([input]) => {
+      const url = typeof input === 'string' ? input : String(input);
+      return url === deckUrl;
+    });
+    expect(deckCalls).toHaveLength(1);
+    // The plain-HTML card still resolves normally via its HEAD probe.
+    expect(fetchMock).toHaveBeenCalledWith(
+      htmlUrl,
+      expect.objectContaining({ cache: 'no-store', method: 'HEAD' }),
+    );
+  });
+
   it('falls back to the glyph and logs when an HTML cover is unavailable', async () => {
     stubCoverProbe(404, 'Not Found');
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});


### PR DESCRIPTION
Fixes #2648

## Why

**Use case.** Picked up from the `help wanted` queue (#2648).

**Pain being addressed.** Slide (deck) project preview cards in the Home \"Recent projects\" rail and the full Projects/Designs gallery loaded the project's raw `index.html` into a sandboxed iframe. For deck projects that HTML is the deck framework skeleton, which has the carousel chrome (prev/next buttons, slide counter, hint) baked directly into the markup with `position: fixed; z-index: 1000` — so those controls painted over the small card thumbnail. The cards looked noisy and distracted from the preview.

## What users will see

Deck project cards in the gallery now show a clean, static preview of the first slide — no carousel navigation buttons, no slide counter, no hint overlay. Other project types (HTML prototypes, images, video) are unchanged. If a deck's source can't be parsed (e.g. an unconventional structure), the card falls back to the previous raw-iframe behavior, so no deck regresses.

## Surface area

- [x] **UI** — deck project cards render a static first-slide thumbnail instead of the raw deck iframe (`apps/web/src/components/RecentProjectsStrip.tsx`, `apps/web/src/components/DesignsTab.tsx`, new `DeckProjectCoverFrame` in `apps/web/src/components/project-cover.tsx`); CSS for the fill wrapper in `apps/web/src/styles/home/recent-projects.css` and `apps/web/src/styles/workspace/drawer.css`.
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

The deck card previously showed left/right arrows + a \"01 / 01\" counter + a \"← / → · space\" hint overlaid on the thumbnail. Now it shows just the slide. Best seen by opening a deck project's card in Recent projects on `main` vs. this branch.

## Bug fix verification

- Test path: `apps/web/tests/components/RecentProjectsStrip.test.tsx` — `'renders HTML and deck covers from the current file URL'` updated. The deck cover mock now returns a minimal parseable deck body (a `.slide` + `<style>`), and the assertion was flipped: the deck card must render **no iframe** (the static thumbnail replaces it), while the plain-HTML card still uses the raw iframe.
- Did the test go red on `main` and green on this branch? The previous test *encoded the bug* (asserted the deck card's iframe `src` was the raw `index.html`). After the change, that old assertion fails on this branch (no iframe for deck) and the new assertion (no iframe for deck, iframe for HTML) passes.

## Validation

- `pnpm --filter @open-design/web test` — `RecentProjectsStrip.test.tsx` 7 passed.
- `pnpm --filter @open-design/web typecheck` — clean.
- `pnpm guard` — 86 passed, 0 failed.

## Notes

- Reuses the existing `DeckSlideThumbnail` + `parseDeckThumbnails` infrastructure already built for the deck editor's thumbnail rail (`DeckThumbnailRail`) — same inert-shadow rendering, same sanitization (scripts stripped, no deck bridge, no nav overlay).
- `DeckSlideThumbnail` scales its shadow canvas to its host div's `clientWidth/clientHeight`, so the host must fill the card thumb. The shared `thumb-iframe` classes carry raw-iframe scale transforms (1280×720 + container-query scale; 250% + scale(0.4)) that distort a plain div, so the deck cover uses a dedicated `.deck-cover-frame` wrapper with matching fill rules, mirroring the existing `.deck-thumbnail-frame .deck-thumbnail-shadow-host` pattern in `theater.css`.
- Three-tier fallback: parsed deck → static thumbnail; unparseable source → raw HTML iframe (previous behavior); unreachable file → project glyph.