### PR TITLE
fix(web): do not restart CLI scan when re-entering Local onboarding

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -2457,7 +2457,16 @@ function OnboardingView({
         runtime_type: 'local_cli',
       });
       setRuntime('local');
-      void scanCliAgents({ preferExisting: true });
+      // Re-entering the Local runtime must not restart the CLI scan:
+      // if a scan already completed (with or without detected agents),
+      // reuse it. Only the explicit "Rescan" button should re-run
+      // detection. See issue #2646.
+      const scanAlreadyCompleted =
+        cliScanStatus === 'done' ||
+        (cliScanStatus !== 'scanning' && visibleAgentIds.length > 0);
+      if (!scanAlreadyCompleted) {
+        void scanCliAgents({ preferExisting: true });
+      }
       setStep(2);
       return;
     }


### PR DESCRIPTION
Fixes #2646

## Why

**Use case.** Picked up from the `help wanted` queue (#2646).

**Pain being addressed.** In onboarding, selecting the \"Local coding agent\" runtime unconditionally called `scanCliAgents({ preferExisting: true })`. That path runs `beginCliScan`, which flips `cliScanStatus` back to `'scanning'`. So re-entering Local (Back to cloud → Local coding agent again) re-flashed the scanning UI and re-ran the detection flow instead of reusing the scan that already completed. The onboarding setup felt unstable and slow on a flow users revisit.

## What users will see

Going back to the cloud landing and clicking \"Local coding agent\" again no longer restarts the CLI scan — it reuses the already-completed results instantly. The explicit **Rescan** button remains the only way to re-run detection. No new UI; just the expected, stable behavior on re-entry.

## Surface area

- [x] **UI** — behavior change in the onboarding Local-runtime selection (`apps/web/src/components/EntryShell.tsx`); no new element.
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

The visible symptom is a transient scanning-flash on re-entry (the \"Scanning...\" status + spinner reappearing). Best verified by driving the re-entry flow: open onboarding → Local coding agent → Back → Local coding agent again, on `main` vs. this branch.

## Bug fix verification

This is a paint-timing-dependent visual symptom: when `scanCliAgents({ preferExisting: true })` runs with cached agents, `beginCliScan` sets `cliScanStatus` to `'scanning'` and the function synchronously sets it back to `'done'` — React batches both updates in jsdom, so the transient `'scanning'` never renders and a falsifiable red spec can't reproduce the symptom deterministically. Per `AGENTS.md` → \"Bug follow-up workflow\", when a red spec can't be written cheaply the right verification is code inspection + manual QA:

- **Code inspection:** the only change is a guard in the Local-runtime `onClick`. Without the guard, `scanCliAgents` runs every click → `beginCliScan` (EntryShell.tsx ~1998) flips `cliScanStatus` to `'scanning'`. With the guard, a completed scan (`cliScanStatus === 'done'`, or idle with results) skips the call entirely, so `beginCliScan` never runs and the status never resets. The explicit Rescan button (`scanCliAgents()` with no `preferExisting`) is untouched.
- **Manual QA needed:** the re-entry flow above on a real browser, confirming the scanning spinner does not reappear on the second entry.

## Validation

- `pnpm --filter @open-design/web typecheck` — clean.
- `pnpm --filter @open-design/web test` — `EntryShell.onboarding.test.tsx` 36 passed (existing coverage unaffected).
- `pnpm guard` — 86 passed, 0 failed.

## Notes

One-line guard in the Local-runtime click handler. State (`cliScanStatus`, `visibleAgentIds`) is already correctly lifted to `OnboardingView` and survives step switches — the bug was purely the unconditional re-scan on re-entry, not a remount.