### PR TITLE
fix(web): make deck preview zoom actually scale the slide canvas

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -1345,11 +1345,31 @@ export function previewOverlayTransform(
   };
 }
 
-function previewScaleShellStyle(
+export function previewScaleShellStyle(
   viewport: PreviewViewportId,
   previewScale: number,
+  options?: { isDeck?: boolean },
 ): CSSProperties & Record<string, string | number> {
   if (viewport === 'desktop') {
+    // For deck/slide previews the iframe renders at a fixed canvas size and
+    // zoom is optical-only, so the shell must keep the full canvas size and
+    // let `transform: scale()` actually scale it. Using `width: 100/scale%`
+    // here would cancel out the scale (an algebraic inverse), leaving the
+    // slide visually stuck at 100% regardless of the zoom value (#5805). The
+    // outer `.comment-frame-clip` already clips overflow for zoom-in.
+    if (options?.isDeck) {
+      return {
+        width: '100%',
+        height: '100%',
+        transform: `scale(${previewScale})`,
+        transformOrigin: '0 0',
+      };
+    }
+    // For non-deck HTML previews (the auto-fit / reflow flow) the
+    // inverse-percentage trick is intentional browser-zoom semantics: the
+    // layout box grows by 1/scale so content reflows, then `transform:
+    // scale()` shrinks it back to fit the clip. This lets zoom-out show more
+    // content instead of just optically shrinking the same layout.
     return {
       width: `${100 / previewScale}%`,
       height: `${100 / previewScale}%`,
@@ -15286,7 +15306,7 @@ function HtmlViewer({
                   style={
                     manualEditMode
                       ? manualEditPreviewShellStyle(previewViewport, previewScale, manualEditViewportWidth)
-                      : previewScaleShellStyle(previewViewport, previewScale)
+                      : previewScaleShellStyle(previewViewport, previewScale, { isDeck: effectiveDeck })
                   }
                 >
                   <PreviewDrawOverlay

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -67,6 +67,7 @@ import {
   parseInspectOverridesFromSource,
   previewOverlayTransform,
   previewMeasurementFrameIsUsable,
+  previewScaleShellStyle,
   resolveDesktopPreviewContentMeasurement,
   resolveDesktopPreviewZoomPercent,
   serializeInspectOverrides,
@@ -1138,6 +1139,35 @@ describe('FileViewer preview scale', () => {
     expect(tablet.scale).toBeCloseTo(752 / 1180, 5);
     expect(tablet.offsetX).toBeCloseTo(24 + (1152 - 820 * (752 / 1180)) / 2, 5);
     expect(tablet.offsetY).toBe(24);
+  });
+
+  it('keeps the desktop deck shell at 100% and applies the inverse-percentage trick only for non-deck (#5805)', () => {
+    // Deck/slide previews render on a fixed canvas and zoom optically, so the
+    // shell must stay at 100% and let transform: scale() actually scale it.
+    // Using width: 100/scale% here would cancel the scale out algebraically
+    // and leave the slide visually stuck at 100% regardless of zoom.
+    expect(previewScaleShellStyle('desktop', 1.5, { isDeck: true })).toEqual({
+      width: '100%',
+      height: '100%',
+      transform: 'scale(1.5)',
+      transformOrigin: '0 0',
+    });
+    // Non-deck desktop HTML previews keep the inverse-percentage trick:
+    // the layout box grows by 1/scale so content reflows, then scale() shrinks
+    // it back to fit the clip (browser-zoom semantics for auto-fit).
+    expect(previewScaleShellStyle('desktop', 2)).toEqual({
+      width: '50%',
+      height: '50%',
+      transform: 'scale(2)',
+      transformOrigin: '0 0',
+    });
+    // Mobile/tablet (CSS-var driven) is unaffected by the deck option.
+    expect(previewScaleShellStyle('mobile', 1.5, { isDeck: true })).toEqual({
+      width: 'var(--preview-viewport-width)',
+      height: 'var(--preview-viewport-height)',
+      transform: 'scale(var(--preview-scale, 1))',
+      transformOrigin: '0 0',
+    });
   });
 });
 


### PR DESCRIPTION
Fixes #5805

## Why

**Use case.** Picked up from the `help wanted` queue (#5805) after lefarcen re-opened it for community contribution because the prior PR (#5820) stalled.

**Pain being addressed.** PPT / slide preview zoom controls changed state but the slide never visually scaled — users could not zoom in to inspect text/alignment or zoom out to review the deck layout.

Root cause: `previewScaleShellStyle`'s desktop branch used an inverse-percentage shell (`width/height: 100/scale%`) plus `transform: scale(scale)`. The `100/scale%` size is an algebraic inverse that cancels the scale transform, so the rendered box stayed at 100% regardless of the zoom value. For non-deck HTML previews this is intentional (browser-zoom / reflow semantics for auto-fit), but deck previews render on a fixed canvas and zoom optically — there the inverse-percentage trick cancels the zoom entirely.

## What users will see

Zooming a deck/slide preview now visibly scales the slide (zoom in to inspect details, zoom out to see the whole layout), matching the expected Office/PowerPoint-style behavior. Non-deck HTML previews are unchanged (their zoom still reflows content via the inverse-percentage auto-fit).

## Surface area

- [x] **UI** — deck preview zoom behavior in `apps/web/src/components/FileViewer.tsx`; no new UI element.
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Behavior change (zoom now scales the slide canvas). Best verified by opening a deck project, using the zoom control on `main` (slide stays at 100%) vs. this branch (slide scales). The prior PR #5820 was QA-verified by @AmyShang-alt confirming 50%/150%/200% all visibly take effect.

## Bug fix verification

- Test path: `apps/web/tests/components/FileViewer.test.tsx` — `'keeps the desktop deck shell at 100% and applies the inverse-percentage trick only for non-deck (#5805)'`. Asserts all three branches: deck desktop → `width: '100%'`/`height: '100%'` + `scale(1.5)`; non-deck desktop → `width: '50%'`/`height: '50%'` + `scale(2)` (inverse-percentage preserved); mobile → CSS-var driven (unaffected by `isDeck`).
- Did the test go red on `main` and green on this branch? **Yes.** On `main` the deck assertion (`width: '100%'`) fails because the old code returns `100/1.5 = 66.67%`; on this branch it returns `100%`.

## Validation

- `pnpm --filter @open-design/web typecheck` — clean.
- `pnpm --filter @open-design/web test` — `FileViewer.test.tsx` 205 passed (204 existing + 1 new).
- `pnpm guard` — passes (86 checks; note: `scripts/guard.ts` has a pre-existing local `ERR_MODULE_NOT_FOUND` on this Node 22 machine around `daemon/design-systems/frontmatter.js`, unrelated to this diff — CI on Node 24 passes).

## Notes

- Mirrors the approved-but-stalled #5820 approach, including the scoping fix @mrcfps requested there: the deck/non-deck branch keeps the existing desktop HTML auto-fit behavior intact (the original #5820 head regressed it; this head preserves it).
- `previewScaleShellStyle` is promoted to `export function` so the regression test can call it directly, consistent with the already-exported siblings `previewOverlayTransform` and `effectivePreviewScale`. It is module-private otherwise (no cross-module consumer).
- `LiveArtifactViewer` and the `manualEditPreviewShellStyle` fallback stay non-deck (default) — their zoom semantics are unrelated to deck optical zoom.