### PR TITLE
fix(web): refresh MiniMax provider presets

### DIFF
--- a/apps/web/src/state/config.ts
+++ b/apps/web/src/state/config.ts
@@ -146,6 +146,7 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     protocol: 'anthropic',
     baseUrl: 'https://api.minimax.io/anthropic',
     preferredModels: [
+      'MiniMax-M3',
       'MiniMax-M2.7-highspeed',
       'MiniMax-M2.7',
       'MiniMax-M2.5-highspeed',
@@ -160,6 +161,7 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     protocol: 'anthropic',
     baseUrl: 'https://api.minimaxi.com/anthropic',
     preferredModels: [
+      'MiniMax-M3',
       'MiniMax-M2.7-highspeed',
       'MiniMax-M2.7',
       'MiniMax-M2.5-highspeed',
@@ -341,6 +343,22 @@ export const KNOWN_PROVIDERS: KnownProvider[] = [
     protocol: 'openai',
     baseUrl: 'https://api.minimax.io/v1',
     preferredModels: [
+      'MiniMax-M3',
+      'MiniMax-M2.7-highspeed',
+      'MiniMax-M2.7',
+      'MiniMax-M2.5-highspeed',
+      'MiniMax-M2.5',
+      'MiniMax-M2.1-highspeed',
+      'MiniMax-M2.1',
+      'MiniMax-M2',
+    ],
+  },
+  {
+    label: 'MiniMax — OpenAI (CN)',
+    protocol: 'openai',
+    baseUrl: 'https://api.minimaxi.com/v1',
+    preferredModels: [
+      'MiniMax-M3',
       'MiniMax-M2.7-highspeed',
       'MiniMax-M2.7',
       'MiniMax-M2.5-highspeed',

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -42,6 +42,37 @@ describe('KNOWN_PROVIDERS', () => {
     ]);
   });
 
+  it('keeps MiniMax model presets available across global and CN gateways', () => {
+    expect(
+      KNOWN_PROVIDERS.filter((provider) => provider.label.startsWith('MiniMax')),
+    ).toEqual([
+      expect.objectContaining({
+        label: 'MiniMax — Anthropic',
+        protocol: 'anthropic',
+        baseUrl: 'https://api.minimax.io/anthropic',
+        preferredModels: expect.arrayContaining(['MiniMax-M3', 'MiniMax-M2.7']),
+      }),
+      expect.objectContaining({
+        label: 'MiniMax — Anthropic (CN)',
+        protocol: 'anthropic',
+        baseUrl: 'https://api.minimaxi.com/anthropic',
+        preferredModels: expect.arrayContaining(['MiniMax-M3', 'MiniMax-M2.7']),
+      }),
+      expect.objectContaining({
+        label: 'MiniMax — OpenAI',
+        protocol: 'openai',
+        baseUrl: 'https://api.minimax.io/v1',
+        preferredModels: expect.arrayContaining(['MiniMax-M3', 'MiniMax-M2.7']),
+      }),
+      expect.objectContaining({
+        label: 'MiniMax — OpenAI (CN)',
+        protocol: 'openai',
+        baseUrl: 'https://api.minimaxi.com/v1',
+        preferredModels: expect.arrayContaining(['MiniMax-M3', 'MiniMax-M2.7']),
+      }),
+    ]);
+  });
+
   it('keeps BYOK presets derived from the canonical provider registry', () => {
     const moonshot = KNOWN_PROVIDERS.find((provider) => provider.label === 'Moonshot');
     const moonshotPreset = BYOK_PROVIDER_PRESETS.find((preset) => preset.id === 'moonshot');


### PR DESCRIPTION
## Why

The MiniMax preset matrix was incomplete: MiniMax-M3 was missing from existing presets, and users targeting the China OpenAI-compatible gateway had no matching preset.

## What users will see

- MiniMax-M3 and MiniMax-M2.7 are available from the global and China Anthropic-compatible presets.
- MiniMax-M3 and MiniMax-M2.7 are available from the global and China OpenAI-compatible presets.
- The new MiniMax - OpenAI (CN) entry points to https://api.minimaxi.com/v1.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Bug fix verification

The base branch omitted the MiniMax-M3 and China OpenAI preset entries. The regression tests now assert all four global/CN and Anthropic/OpenAI preset combinations, including the https://api.minimaxi.com/v1 route.

## Validation

- pnpm exec vitest run -c vitest.config.ts --maxWorkers=2 tests/state/config.test.ts -t MiniMax-or-BYOK-presets-derived
- pnpm --filter @open-design/web typecheck
- Repository CI passed, including workspace/web tests, E2E Vitest, UI P0 checks, visual checks, and workspace validation.
- Manual QA remains pending with the maintainer team before merge.
