### PR TITLE
fix(web): remove preview run status overlay

### DIFF
--- a/apps/web/src/components/FileWorkspace.tsx
+++ b/apps/web/src/components/FileWorkspace.tsx
@@ -139,7 +139,6 @@ import { useInView } from './plugins-home/useInView';
 import { LiveArtifactBadges } from './LiveArtifactBadges';
 import { MissingBrandFontsBanner } from './MissingBrandFontsBanner';
 import { LibraryPicker } from './LibraryPicker';
-import { PreviewRunStatusBar } from './PreviewRunStatusBar';
 import { QuickSwitcher } from './QuickSwitcher';
 import { SketchEditor } from './SketchEditor';
 import { SketchEnginePrewarm } from './SketchEnginePrewarm';
@@ -2847,12 +2846,6 @@ export function FileWorkspace({
     return liveArtifactEntries.find((entry) => entry.tabId === activeTab) ?? null;
   }, [activeTab, liveArtifactEntries]);
 
-  // The delivery hint belongs to the main design-preview surface only. Browser,
-  // terminal, questions, design-system, and side-chat tabs carry their own
-  // context and must not inherit status/analytics from the primary chat.
-  const showPreviewRunStatus =
-    activeTab === DESIGN_FILES_TAB || activeLiveArtifact !== null || activeFile !== null;
-
   // Identity-stable props for the memoized FileViewer. Without these, every
   // FileWorkspace state change (closing an adjacent tab, drag hover, launcher
   // toggles) would hand FileViewer fresh object/function identities and drag
@@ -3903,15 +3896,6 @@ export function FileWorkspace({
             .
           </div>
         )}
-        {showPreviewRunStatus ? (
-          <div className="ws-preview-run-status-slot">
-            <PreviewRunStatusBar
-              projectId={projectId}
-              conversationId={conversationId}
-              messages={messages}
-            />
-          </div>
-        ) : null}
       </div>
       <PageCreatorDialog
         open={pageCreatorOpen}

--- a/apps/web/src/styles/workspace/drawer.css
+++ b/apps/web/src/styles/workspace/drawer.css
@@ -2548,26 +2548,6 @@
   position: relative;
 }
 
-/* Canvas-local Design delivery feedback. It stays with the workspace while
-   the empty placeholder hands over to an actual file preview, rather than
-   becoming a bottom-of-screen notification. */
-.ws-preview-run-status-slot {
-  position: absolute;
-  z-index: 2;
-  top: 50%;
-  left: 50%;
-  max-width: calc(100% - 48px);
-  pointer-events: none;
-  transform: translate(-50%, 116px);
-}
-
-@media (max-width: 640px) {
-  .ws-preview-run-status-slot {
-    max-width: calc(100% - 32px);
-    transform: translate(-50%, 104px);
-  }
-}
-
 .ws-browser-panel {
   display: flex;
   position: absolute;

--- a/apps/web/tests/components/FileWorkspace.test.tsx
+++ b/apps/web/tests/components/FileWorkspace.test.tsx
@@ -3076,11 +3076,12 @@ describe('FileWorkspace empty-project generation contract', () => {
 
       expect(screen.queryByTestId('generating-tab')).toBeNull();
       expect(screen.queryByTestId('generation-preview-stage')).toBeNull();
+      expect(screen.queryByTestId('preview-run-status')).toBeNull();
       expect(screen.getByTestId('design-files-empty')).toBeTruthy();
     },
   );
 
-  it('keeps delivery recovery in Chat and leaves a passive failure hint over existing preview files', () => {
+  it('keeps delivery recovery in Chat without mounting status over existing preview files', () => {
     render(
       <FileWorkspace
         projectId="project-1"
@@ -3104,13 +3105,9 @@ describe('FileWorkspace empty-project generation contract', () => {
       />,
     );
 
-    const previewStatus = screen.getByTestId('preview-run-status');
-    expect(previewStatus).toHaveTextContent('Delivery needs attention · Retry in Chat');
-    expect(previewStatus.closest('.ws-preview-run-status-slot')).not.toBeNull();
-    expect(previewStatus.closest('[data-testid="design-files-empty"]')).toBeNull();
+    expect(screen.queryByTestId('preview-run-status')).toBeNull();
     expect(screen.queryByTestId('preview-run-status-retry')).toBeNull();
     expect(screen.queryByTestId('preview-run-status-view-details')).toBeNull();
-    expect(previewStatus).not.toHaveTextContent('Elapsed');
   });
 
   it('does not mount main-preview delivery feedback over a browser tab', () => {
@@ -3145,7 +3142,7 @@ describe('FileWorkspace empty-project generation contract', () => {
     expect(screen.queryByTestId('preview-run-status')).toBeNull();
   });
 
-  it('keeps a delivered confirmation on the preview canvas after files arrive', () => {
+  it('does not mount a delivered confirmation over the preview canvas', () => {
     const now = 1_700_000_012_500;
     vi.spyOn(Date, 'now').mockReturnValue(now);
     render(
@@ -3172,13 +3169,6 @@ describe('FileWorkspace empty-project generation contract', () => {
       />,
     );
 
-    const previewStatus = screen.getByTestId('preview-run-status');
-    expect(previewStatus).toHaveTextContent('Design ready');
-    expect(previewStatus.closest('.ws-preview-run-status-slot')).not.toBeNull();
-    expect(previewStatus.closest('[data-testid="design-files-empty"]')).toBeNull();
-    expect(previewStatus).not.toHaveAttribute('aria-live');
-    expect(within(previewStatus).getByRole('status')).toHaveTextContent('Design ready');
-    expect(previewStatus).not.toHaveTextContent('Elapsed');
-    expect(previewStatus.querySelector('[aria-hidden="true"]')).toBeNull();
+    expect(screen.queryByTestId('preview-run-status')).toBeNull();
   });
 });

--- a/e2e/ui/preview-run-status.test.ts
+++ b/e2e/ui/preview-run-status.test.ts
@@ -16,7 +16,7 @@ test.beforeAll(async () => {
   codexEnv = runtimes.codex.env;
 });
 
-test('[P1] preview delivery status keeps persisted delivery-failure recovery in Chat', async ({ page }) => {
+test('[P1] preview canvas omits run status while Chat keeps delivery recovery', async ({ page }) => {
   test.setTimeout(T.xlong);
   const projectId = `preview-run-status-${Date.now()}`;
   const now = Date.now();
@@ -78,23 +78,17 @@ test('[P1] preview delivery status keeps persisted delivery-failure recovery in 
   expect(failedResponse.ok(), await failedResponse.text()).toBeTruthy();
 
   await gotoProject(page, projectId);
-  const status = page.getByTestId('preview-run-status');
-  await expect(status).toContainText('Delivery needs attention');
-  await expect(status.locator('xpath=ancestor::*[contains(@class, "ws-preview-run-status-slot")]')).toHaveCount(1);
-  await expect(status.locator('xpath=ancestor::*[@data-testid="design-files-empty"]')).toHaveCount(0);
-  await expect(status).not.toContainText('Elapsed');
+  await expect(page.getByTestId('preview-run-status')).toHaveCount(0);
   await expect(page.getByTestId('preview-run-status-retry')).toHaveCount(0);
-  await expect(status).toContainText('Retry in Chat');
   await expect(page.getByTestId('preview-run-status-view-details')).toHaveCount(0);
   const chatRetry = page.locator('.chat-error-retry');
   await expect(chatRetry).toBeVisible();
 
-  // The persisted preview hint stays passive after navigation; the Chat
-  // failure card remains the sole retry entry point.
+  // The preview stays unobstructed after navigation; the Chat failure card
+  // remains the sole retry entry point.
   await gotoEntryHome(page);
   await gotoProject(page, projectId);
-  await expect(page.getByTestId('preview-run-status')).toContainText('Delivery needs attention');
-  await expect(page.getByTestId('preview-run-status')).not.toContainText('Elapsed');
+  await expect(page.getByTestId('preview-run-status')).toHaveCount(0);
   await expect(page.locator('.chat-error-retry')).toBeVisible();
 
   await page.locator('.chat-error-retry').click();
@@ -118,8 +112,5 @@ test('[P1] preview delivery status keeps persisted delivery-failure recovery in 
     }, { timeout: T.long })
     .toContain('fake-agent-runtime-codex.html');
 
-  await expect(page.getByTestId('preview-run-status')).toContainText('Design ready');
-  await expect(
-    page.getByTestId('preview-run-status').locator('xpath=ancestor::*[contains(@class, "ws-preview-run-status-slot")]'),
-  ).toHaveCount(1);
+  await expect(page.getByTestId('preview-run-status')).toHaveCount(0);
 });


### PR DESCRIPTION
## Why

Prerelease validation showed that the preview-canvas run status still covered generated content even after the elapsed-time copy was removed in #6005. The canvas should remain an unobstructed output surface; run progress and delivery recovery already have an established owner in Chat.

This is intentionally narrower than the cleanup proposed in #6002: it removes only the preview-canvas mount and its positioning styles while preserving the shared status component and Chat behavior.

## What users will see

The centered run-status text no longer appears over design previews while a run is building, succeeds, or needs delivery recovery. Chat continues to show run progress and remains the sole retry entry point after delivery failures.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Before: prerelease validation showed the centered “正在构建设计方案” status overlaying preview content.

After: the regression specs assert that no `preview-run-status` element is mounted on the preview canvas in running, failed, and delivered states. A packaged after-screenshot will be captured during prerelease acceptance.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/FileWorkspace.test.tsx`
- Did the test go red on `main` and green on this branch? **yes** — the focused spec failed with the existing preview status mount, then passed after the source change.
- E2E regression: `e2e/ui/preview-run-status.test.ts` verifies the canvas remains status-free while Chat retains delivery recovery.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts --pool=threads --maxWorkers=1 tests/components/FileWorkspace.test.tsx` — 70 passed
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/e2e typecheck`
- `pnpm guard` — 86 guard tests passed
- `git diff --check`
