### PR TITLE
fix(web): auto-open generated image artifacts in new sessions

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -257,7 +257,10 @@ import {
   markFirstOnboardingGenerationCompleted,
   type OnboardingEntry,
 } from '../onboarding/onboarding-entry';
-import { producedPreviewableArtifact } from '../onboarding/first-generation';
+import {
+  hasPreviewableArtifactForOnboarding,
+  producedPreviewableArtifact,
+} from '../onboarding/first-generation';
 import { sentPrefilledPrompt } from '../onboarding/first-prompt';
 import { beginFirstLoop, recordFirstLoopStep } from '../onboarding/first-loop';
 import { BrandReadyPrompt } from './BrandReadyPrompt';
@@ -724,6 +727,24 @@ function mergeChatAttachments(...groups: ChatAttachment[][]): ChatAttachment[] {
     }
   }
   return out;
+}
+
+function attachmentPathsForAssistant(
+  messages: readonly ChatMessage[],
+  assistantMessageId: string,
+): string[] {
+  const assistantIndex = messages.findIndex((message) => message.id === assistantMessageId);
+  for (let index = assistantIndex - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.role !== 'user') continue;
+    return mergeChatAttachments(
+      message.attachments ?? [],
+      ...(message.commentAttachments ?? []).map((attachment) =>
+        chatAttachmentsFromPreviewCommentImages(attachment.imageAttachments),
+      ),
+    ).map((attachment) => attachment.path);
+  }
+  return [];
 }
 
 function historyWithWorkspaceContext(
@@ -2552,15 +2573,13 @@ export function ProjectView({
     () => new Set(projectFiles.map((f) => f.name)),
     [projectFiles],
   );
-  // A previewable artifact exists once any HTML file has been produced. Gates
-  // the one-time first-generation hint (spec §8.3); the hint component owns its
-  // own once-ever "seen" budget.
-  const hasPreviewableArtifact = useMemo(() => {
-    for (const name of projectFileNames) {
-      if (name.toLowerCase().endsWith('.html')) return true;
-    }
-    return false;
-  }, [projectFileNames]);
+  // Legacy HTML keeps its project-level fallback. Images require successful
+  // assistant-produced provenance so uploaded references cannot trigger the
+  // one-time first-generation hint (spec §8.3).
+  const hasPreviewableArtifact = useMemo(
+    () => hasPreviewableArtifactForOnboarding(projectFiles, messages),
+    [messages, projectFiles],
+  );
   // First-loop ledger: the artifact reaching the preview is the 查看 step of the
   // loop (spec §8.3). Recorded once per project; a no-op for any project not
   // started from a recommendation.
@@ -3507,6 +3526,7 @@ export function ProjectView({
       for (const message of messages) {
         if (cancelled) return;
         if (message.role !== 'assistant') continue;
+        const runAttachmentPaths = attachmentPathsForAssistant(messages, message.id);
 
         // A message whose run_status was spuriously written as 'failed' before
         // the page reloaded (e.g. the SSE reconnect fallback fired while the
@@ -3731,6 +3751,12 @@ export function ProjectView({
             );
 
             let nextFiles = await refreshProjectFiles();
+            const attachmentFileNames = resolveProjectFileNames(
+              runAttachmentPaths,
+              nextFiles,
+              project.id,
+              projectDetail.resolvedDir,
+            );
             const beforeFileNames = new Set(
               message.preTurnFileNames ?? nextFiles.map((f) => f.name),
             );
@@ -3741,7 +3767,11 @@ export function ProjectView({
             let artifactPersistenceSucceeded = false;
             let artifactPersistenceError: string | undefined;
             if (artifactToPersist?.html) {
-              const producedBeforeFallback = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
+              const producedBeforeFallback = computeProducedFiles(
+                beforeFileNames,
+                nextFiles,
+                attachmentFileNames,
+              ) ?? [];
               const runStartedAt = status.createdAt || message.startedAt || message.createdAt;
               recoveredExistingArtifact =
                 await findSameTurnWriteForRecoveredArtifact({
@@ -3772,7 +3802,11 @@ export function ProjectView({
                 nextFiles = await refreshProjectFiles();
               }
             }
-            const diff = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
+            const diff = computeProducedFiles(
+              beforeFileNames,
+              nextFiles,
+              attachmentFileNames,
+            ) ?? [];
             const produced = mergeRecoveredArtifact(diff, recoveredExistingArtifact);
             const touchedFilePaths = extractTouchedFilePathsFromEvents(message.events);
             const traceObjectFiles = mergeRecoveredTraceObjectFile(
@@ -3795,6 +3829,7 @@ export function ProjectView({
                 project.id,
                 projectDetail.resolvedDir,
               ),
+              excludedFileNames: attachmentFileNames,
             });
             if (producedArtifactToOpen) requestOpenFile(producedArtifactToOpen);
             const deliveryOutcome = resolveDesignDeliveryOutcome({
@@ -4052,6 +4087,12 @@ export function ProjectView({
               void (async () => {
                 const preTurn = message.preTurnFileNames;
                 let nextFiles = await refreshProjectFiles();
+                const attachmentFileNames = resolveProjectFileNames(
+                  runAttachmentPaths,
+                  nextFiles,
+                  project.id,
+                  projectDetail.resolvedDir,
+                );
                 let artifactPersistenceSucceeded = false;
                 let artifactPersistenceError: string | undefined;
                 // Use the turn-start snapshot when available so reload
@@ -4063,7 +4104,11 @@ export function ProjectView({
                   ? parsedArtifact
                   : artifactFromStandaloneHtml(replayedContent);
                 if (artifactToPersist?.html) {
-                  const producedBeforeFallback = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
+                  const producedBeforeFallback = computeProducedFiles(
+                    beforeFileNames,
+                    nextFiles,
+                    attachmentFileNames,
+                  ) ?? [];
                   const runStartedAt = status.createdAt || message.startedAt || message.createdAt;
                   recoveredExistingArtifact =
                     await findSameTurnWriteForRecoveredArtifact({
@@ -4094,7 +4139,11 @@ export function ProjectView({
                     nextFiles = await refreshProjectFiles();
                   }
                 }
-                const diff = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
+                const diff = computeProducedFiles(
+                  beforeFileNames,
+                  nextFiles,
+                  attachmentFileNames,
+                ) ?? [];
                 const produced = mergeRecoveredArtifact(diff, recoveredExistingArtifact);
                 const touchedFilePaths = extractTouchedFilePathsFromEvents(
                   needsFullReplay ? replayedEvents : message.events,
@@ -4119,6 +4168,7 @@ export function ProjectView({
                     project.id,
                     projectDetail.resolvedDir,
                   ),
+                  excludedFileNames: attachmentFileNames,
                 });
                 if (producedArtifactToOpen) requestOpenFile(producedArtifactToOpen);
                 const deliveryContent = needsFullReplay ? replayedContent : message.content;
@@ -4193,12 +4243,22 @@ export function ProjectView({
                       : artifactFromStandaloneHtml(replayedContent);
                     if (!artifactToPersist?.html) return;
                     let nextFiles = await refreshProjectFiles();
+                    const attachmentFileNames = resolveProjectFileNames(
+                      runAttachmentPaths,
+                      nextFiles,
+                      project.id,
+                      projectDetail.resolvedDir,
+                    );
                     const beforeFileNames = new Set(
                       message.preTurnFileNames ?? nextFiles.map((f) => f.name),
                     );
                     const runStartedAt =
                       latestRunStatus?.createdAt || message.startedAt || message.createdAt;
-                    const producedBeforeFallback = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
+                    const producedBeforeFallback = computeProducedFiles(
+                      beforeFileNames,
+                      nextFiles,
+                      attachmentFileNames,
+                    ) ?? [];
                     let recoveredExistingArtifact =
                       await findSameTurnWriteForRecoveredArtifact({
                         artifact: artifactToPersist,
@@ -4229,12 +4289,19 @@ export function ProjectView({
                         { minMtime: runStartedAt },
                       );
                     }
-                    const diff = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
+                    const diff = computeProducedFiles(
+                      beforeFileNames,
+                      nextFiles,
+                      attachmentFileNames,
+                    ) ?? [];
                     const produced = mergeRecoveredArtifact(diff, recoveredExistingArtifact);
                     if (produced.length > 0) {
                       recoveredArtifactMessagesRef.current.add(message.id);
                     }
-                    const producedArtifactToOpen = selectAutoOpenProducedArtifact(produced, autoOpenArtifactOptions);
+                    const producedArtifactToOpen = selectAutoOpenProducedArtifact(produced, {
+                      ...autoOpenArtifactOptions,
+                      excludedFileNames: attachmentFileNames,
+                    });
                     if (producedArtifactToOpen) requestOpenFile(producedArtifactToOpen);
                     if (latestRunStatus?.status === 'succeeded') setError(null);
                     if (
@@ -4538,6 +4605,7 @@ export function ProjectView({
         for (const message of recoveryMessages) {
           if (cancelled) return;
           if (!hasRecoverableArtifactMessage(message)) continue;
+          const runAttachmentPaths = attachmentPathsForAssistant(recoveryMessages, message.id);
           if (recoveredArtifactMessagesRef.current.has(message.id)) continue;
           const runId = message.runId;
           if (!runId) continue;
@@ -4580,12 +4648,22 @@ export function ProjectView({
           const latestRunStatus = await fetchChatRunStatus(runId).catch(() => null);
           let nextFiles = await refreshProjectFiles();
           if (cancelled) return;
+          const attachmentFileNames = resolveProjectFileNames(
+            runAttachmentPaths,
+            nextFiles,
+            project.id,
+            projectDetail.resolvedDir,
+          );
           const beforeFileNames = new Set(
             message.preTurnFileNames ?? nextFiles.map((f) => f.name),
           );
           const runStartedAt =
             latestRunStatus?.createdAt || message.startedAt || message.createdAt;
-          const producedBeforeFallback = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
+          const producedBeforeFallback = computeProducedFiles(
+            beforeFileNames,
+            nextFiles,
+            attachmentFileNames,
+          ) ?? [];
           let recoveredExistingArtifact =
             await findSameTurnWriteForRecoveredArtifact({
               artifact: artifactToPersist,
@@ -4617,13 +4695,20 @@ export function ProjectView({
             );
           }
           if (cancelled) return;
-          const diff = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
+          const diff = computeProducedFiles(
+            beforeFileNames,
+            nextFiles,
+            attachmentFileNames,
+          ) ?? [];
           const produced = mergeRecoveredArtifact(diff, recoveredExistingArtifact);
           if (produced.length === 0) {
             continue;
           }
           recoveredArtifactMessagesRef.current.add(message.id);
-          const producedArtifactToOpen = selectAutoOpenProducedArtifact(produced, autoOpenArtifactOptions);
+          const producedArtifactToOpen = selectAutoOpenProducedArtifact(produced, {
+            ...autoOpenArtifactOptions,
+            excludedFileNames: attachmentFileNames,
+          });
           if (producedArtifactToOpen) requestOpenFile(producedArtifactToOpen);
           // This message's persisted runStatus was already terminal (a
           // precondition of hasRecoverableArtifactMessage); when it has no
@@ -4998,6 +5083,9 @@ export function ProjectView({
           chatAttachmentsFromPreviewCommentImages(attachment.imageAttachments),
         ),
       );
+      const runAttachmentPaths = runAttachments
+        .map((attachment) => normalizeComparableFilePath(attachment.path))
+        .filter(Boolean);
       const selectedAgent =
         config.mode === 'daemon' && config.agentId
           ? agentsById.get(config.agentId)
@@ -5022,7 +5110,10 @@ export function ProjectView({
               effectiveSelectedAgentChoice?.model,
             )
           : apiProtocolModelLabel(config.apiProtocol, config.model);
-      const preTurnFileNames = projectFiles.map((f) => f.name);
+      const preTurnFileNames = Array.from(new Set([
+        ...projectFiles.map((file) => file.name),
+        ...runAttachmentPaths,
+      ]));
       const assistantId = randomUUID();
       const assistantMsg: ChatMessage = {
         id: assistantId,
@@ -5495,6 +5586,12 @@ export function ProjectView({
           void (async () => {
             try {
               let nextFiles = await refreshProjectFiles();
+              const attachmentFileNames = resolveProjectFileNames(
+                runAttachmentPaths,
+                nextFiles,
+                project.id,
+                projectDetail.resolvedDir,
+              );
               let artifactPersistenceSucceeded = false;
               let artifactPersistenceError: string | undefined;
               const finalText = streamedText || fullText;
@@ -5502,7 +5599,11 @@ export function ProjectView({
                 ? parsedArtifact
                 : artifactFromStandaloneHtml(finalText);
               if (artifactToPersist?.html) {
-                const producedBeforeFallback = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
+                const producedBeforeFallback = computeProducedFiles(
+                  beforeFileNames,
+                  nextFiles,
+                  attachmentFileNames,
+                ) ?? [];
                 const sameTurnArtifactWrite =
                   await findSameTurnNonHtmlWriteForRecoveredArtifact({
                     artifact: artifactToPersist,
@@ -5532,13 +5633,17 @@ export function ProjectView({
                   nextFiles = await refreshProjectFiles();
                 }
               }
-              const produced = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
+              const produced = computeProducedFiles(
+                beforeFileNames,
+                nextFiles,
+                attachmentFileNames,
+              ) ?? [];
               // Completion half of the onboarding funnel: the first generation
               // in a recommendation-started project that actually produced a
               // previewable artifact. Gated on the same artifact-producing
-              // condition as the first-artifact hint (a produced `.html`), so a
-              // `succeeded` run that returned only text or a clarifying question
-              // does NOT count. Fires once.
+              // condition as the first-artifact hint (HTML or generated image),
+              // so a `succeeded` run that returned only text or a clarifying
+              // question does NOT count. Fires once.
               if (
                 ownsCurrentRun &&
                 onboardingEntryRef.current &&
@@ -5572,6 +5677,7 @@ export function ProjectView({
                   project.id,
                   projectDetail.resolvedDir,
                 ),
+                excludedFileNames: attachmentFileNames,
               });
               if (producedArtifactToOpen) requestOpenFile(producedArtifactToOpen);
               const deliveryCandidate: ChatMessage = {
@@ -9611,10 +9717,13 @@ function applyDesignDeliveryOutcome(
 export function computeProducedFiles(
   beforeNames: ReadonlySet<string> | readonly string[] | undefined,
   next: readonly ProjectFile[],
+  excludedFileNames?: ReadonlySet<string>,
 ): ProjectFile[] | undefined {
   if (!beforeNames) return undefined;
   const set = beforeNames instanceof Set ? beforeNames : new Set(beforeNames);
-  return filterImplicitProducedFiles(next.filter((f) => !set.has(f.name)));
+  return filterImplicitProducedFiles(
+    next.filter((file) => !set.has(file.name) && !excludedFileNames?.has(file.name)),
+  );
 }
 
 export function computeTraceObjectFiles(
@@ -9772,8 +9881,17 @@ export function resolveAgentTouchedFileNames(
   projectId?: string,
   projectRoot?: string | null,
 ): Set<string> {
+  return resolveProjectFileNames(touchedPaths, files, projectId, projectRoot);
+}
+
+function resolveProjectFileNames(
+  paths: Iterable<string>,
+  files: readonly ProjectFile[],
+  projectId?: string,
+  projectRoot?: string | null,
+): Set<string> {
   const names = new Set<string>();
-  for (const rawPath of touchedPaths) {
+  for (const rawPath of paths) {
     const file = findTouchedProjectFile(rawPath, files, projectId, projectRoot);
     if (file) names.add(file.name);
   }

--- a/apps/web/src/components/auto-open-file.ts
+++ b/apps/web/src/components/auto-open-file.ts
@@ -112,14 +112,21 @@ function isMarkdownPreviewFile(file: CandidateFile): boolean {
   return /\.(md|markdown)$/i.test(path);
 }
 
+// Image extensions alone are not sufficient here: the daemon intentionally
+// classifies SVG and sketch-prefixed raster files as `sketch`. Trust its kind
+// so user-authored sketches do not start stealing focus at turn end.
+function isImagePreviewFile(file: CandidateFile): boolean {
+  return file.kind === 'image';
+}
+
 // Auto-open priority for a turn's produced files. Higher wins. HTML is the
-// primary visual deliverable, so when a turn writes both an HTML page and a
-// markdown note (e.g. index.html + README.md) the page takes focus; markdown
-// is the next-best previewable artifact; everything else (decks, images, raw
-// text) has no in-place reshape preview worth stealing focus for and is left
-// for the user to open from the produced-files chips.
+// primary visual deliverable, so site assets cannot displace their page.
+// Generated images come next so a README/report written by the same media turn
+// cannot hide the primary result; markdown remains the final inline preview.
+// Everything else is left for the user to open from the produced-files chips.
 function autoOpenPreviewRank(file: CandidateFile): number {
-  if (isHtmlPreviewFile(file)) return 2;
+  if (isHtmlPreviewFile(file)) return 3;
+  if (isImagePreviewFile(file)) return 2;
   if (isMarkdownPreviewFile(file)) return 1;
   return 0;
 }
@@ -142,6 +149,9 @@ export interface SelectAutoOpenOptions {
   // (ties to newest mtime); turns that produce no index.html keep the
   // standard rank/mtime behavior.
   readonly preferSiteEntry?: boolean;
+  // Project file names that belong to user-provided turn inputs. They never
+  // become generated artifacts, even if the agent overwrites the same path.
+  readonly excludedFileNames?: ReadonlySet<string> | null;
 }
 
 export interface SelectAutoOpenTurnOptions extends SelectAutoOpenOptions {
@@ -228,10 +238,13 @@ export function selectAutoOpenProducedArtifact(
   producedFiles: ReadonlyArray<CandidateFile>,
   options: SelectAutoOpenOptions = {},
 ): string | null {
+  const candidates = options.excludedFileNames?.size
+    ? producedFiles.filter((file) => !options.excludedFileNames!.has(file.name))
+    : producedFiles;
   if (options.preferSiteEntry) {
     let entry: CandidateFile | null = null;
     let entryDepth = Number.POSITIVE_INFINITY;
-    for (const file of producedFiles) {
+    for (const file of candidates) {
       if (!isHtmlPreviewFile(file)) continue;
       const depth = siteEntryDepth(file);
       if (depth === null) continue;
@@ -250,7 +263,7 @@ export function selectAutoOpenProducedArtifact(
   }
   let selected: CandidateFile | null = null;
   let selectedRank = 0;
-  for (const file of producedFiles) {
+  for (const file of candidates) {
     const rank = autoOpenPreviewRank(file);
     if (rank === 0) continue;
     if (!selected || rank > selectedRank) {

--- a/apps/web/src/onboarding/first-generation.ts
+++ b/apps/web/src/onboarding/first-generation.ts
@@ -1,25 +1,66 @@
-// Completion half of the onboarding funnel (spec §11.1).
+import type { ChatMessage, ProjectFile } from '../types';
+
+// Completion half of the onboarding funnel (spec section 11.1).
 //
 // `onboarding_first_generation_completed` must line up with the first-artifact
 // experience the user actually sees: the first-artifact hint is gated on a
-// previewable artifact appearing (any `.html` file — see `hasPreviewableArtifact`
-// in ProjectView), so the completion event must be gated on the SAME condition.
-// A run can finish `succeeded` while producing only assistant text or a
-// clarifying question; counting that as a completed generation overstates the
-// funnel and diverges from the hint. This predicate answers "did this turn
+// previewable artifact appearing, so the completion event must use the same
+// condition. A run can finish `succeeded` while producing only assistant text
+// or a clarifying question; counting that as a completed generation overstates
+// the funnel and diverges from the hint. This predicate answers "did this turn
 // produce a previewable artifact?" from the files produced during the turn.
 
 // Loosened structural shape so callers can pass their richer `ProjectFile`
-// objects (which carry `name`) without importing this module's type.
+// objects without importing this module's type.
 export interface ProducedFileLike {
   name: string;
+  kind?: ProjectFile['kind'];
+  mtime?: ProjectFile['mtime'];
 }
 
-// True when the files produced this turn include a previewable artifact. Kept
-// in lockstep with `hasPreviewableArtifact` (a produced `.html` file); if that
-// definition widens, widen this too.
+export interface AssistantProducedFilesLike {
+  role: ChatMessage['role'];
+  runStatus?: ChatMessage['runStatus'];
+  producedFiles?: ReadonlyArray<ProducedFileLike>;
+}
+
+// HTML keeps its extension fallback for legacy file records. Images use the
+// daemon's canonical kind so uploaded sketches and SVG files remain outside
+// this completion gate.
 export function producedPreviewableArtifact(
   producedFiles: ReadonlyArray<ProducedFileLike>,
 ): boolean {
-  return producedFiles.some((file) => file.name.toLowerCase().endsWith('.html'));
+  return producedFiles.some(
+    (file) => file.kind === 'image' || file.name.toLowerCase().endsWith('.html'),
+  );
+}
+
+// Existing HTML keeps the historical reload fallback. Images need both a
+// successful assistant turn and a matching file still present in the project,
+// so uploaded references and deleted outputs cannot trigger onboarding.
+export function hasPreviewableArtifactForOnboarding(
+  projectFiles: ReadonlyArray<ProducedFileLike>,
+  messages: ReadonlyArray<AssistantProducedFilesLike>,
+): boolean {
+  if (projectFiles.some((file) => file.name.toLowerCase().endsWith('.html'))) return true;
+
+  const currentFilesByName = new Map(projectFiles.map((file) => [file.name, file]));
+  return messages.some(
+    (message) =>
+      message.role === 'assistant' &&
+      message.runStatus === 'succeeded' &&
+      (message.producedFiles ?? []).some((producedFile) => {
+        const currentFile = currentFilesByName.get(producedFile.name);
+        if (producedFile.kind !== 'image' || currentFile?.kind !== 'image') return false;
+        if (
+          typeof producedFile.mtime === 'number' &&
+          Number.isFinite(producedFile.mtime) &&
+          typeof currentFile.mtime === 'number' &&
+          Number.isFinite(currentFile.mtime)
+        ) {
+          return producedFile.mtime === currentFile.mtime;
+        }
+        return true;
+      }),
+  );
 }

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -207,6 +207,16 @@ describe('computeProducedFiles', () => {
     expect(produced?.map((f) => f.name)).toEqual(['diagram.svg']);
   });
 
+  it('excludes user attachment paths from turn output attribution', () => {
+    const next = [
+      { name: 'reference.png', path: '/p/reference.png', size: 2, mtime: 2, kind: 'image', mime: 'image/png' },
+    ];
+
+    const produced = computeProducedFiles([], next as never, new Set(['reference.png']));
+
+    expect(produced).toEqual([]);
+  });
+
   it('returns undefined when no baseline is provided', () => {
     expect(computeProducedFiles(undefined, [] as never)).toBeUndefined();
   });
@@ -489,10 +499,17 @@ describe('ProjectView daemon reattach restore', () => {
     ).toBe(false);
   });
 
-  it('populates producedFiles on the persisted message after reattach completes', async () => {
+  it('does not attribute a preceding user attachment after reattach completes', async () => {
     const startedAt = Date.now();
     listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
     listMessages.mockResolvedValue([
+      {
+        id: 'msg-user',
+        role: 'user',
+        content: 'Use this as a reference.',
+        createdAt: startedAt - 1,
+        attachments: [{ path: 'reference.png', name: 'original-reference.png', kind: 'image' }],
+      } satisfies ChatMessage,
       {
         id: 'msg-reattach',
         role: 'assistant',
@@ -509,6 +526,7 @@ describe('ProjectView daemon reattach restore', () => {
     const beforeFiles = [{ name: 'existing.html', path: '/p/existing.html', size: 1, updatedAt: 0 }];
     const afterFiles = [
       ...beforeFiles,
+      { name: 'reference.png', path: '/p/reference.png', size: 2, updatedAt: 0, kind: 'image' },
       { name: 'new.pptx', path: '/p/new.pptx', size: 2, updatedAt: 0 },
     ];
     fetchProjectFiles.mockResolvedValueOnce(beforeFiles).mockResolvedValue(afterFiles);

--- a/apps/web/tests/components/auto-open-file.test.ts
+++ b/apps/web/tests/components/auto-open-file.test.ts
@@ -182,6 +182,49 @@ describe('selectAutoOpenProducedArtifact', () => {
     expect(result).toBe('index.html');
   });
 
+  it('auto-opens a produced image when the turn has no html artifact', () => {
+    const result = selectAutoOpenProducedArtifact([
+      { name: 'cute-puppy.png', path: 'cute-puppy.png', kind: 'image', mtime: 30 },
+    ]);
+
+    expect(result).toBe('cute-puppy.png');
+  });
+
+  it('prefers html over a newer image produced in the same turn', () => {
+    const result = selectAutoOpenProducedArtifact([
+      { name: 'index.html', path: 'index.html', kind: 'html', mtime: 10 },
+      { name: 'hero.png', path: 'hero.png', kind: 'image', mtime: 30 },
+    ]);
+
+    expect(result).toBe('index.html');
+  });
+
+  it('prefers an image over a newer markdown note produced in the same turn', () => {
+    const result = selectAutoOpenProducedArtifact([
+      { name: 'hero.png', path: 'hero.png', kind: 'image', mtime: 10 },
+      { name: 'README.md', path: 'README.md', kind: 'text', mtime: 30 },
+    ]);
+
+    expect(result).toBe('hero.png');
+  });
+
+  it('prefers the newest image when a turn produces multiple images', () => {
+    const result = selectAutoOpenProducedArtifact([
+      { name: 'draft.png', path: 'draft.png', kind: 'image', mtime: 10 },
+      { name: 'final.png', path: 'final.png', kind: 'image', mtime: 30 },
+    ]);
+
+    expect(result).toBe('final.png');
+  });
+
+  it('does not infer image previewability from a sketch file extension', () => {
+    const result = selectAutoOpenProducedArtifact([
+      { name: 'sketch-preview.png', path: 'sketch-preview.png', kind: 'sketch', mtime: 30 },
+    ]);
+
+    expect(result).toBeNull();
+  });
+
   it('leaves a plain .txt file alone (text kind is shared with markdown)', () => {
     // `.md` and `.txt` both arrive as kind: 'text'; only markdown should open.
     const result = selectAutoOpenProducedArtifact([
@@ -291,6 +334,35 @@ describe('selectAutoOpenTurnArtifact', () => {
     );
 
     expect(result).toBe('index.html');
+  });
+
+  it('opens a pre-existing image the turn rewrote without a Write event', () => {
+    const result = selectAutoOpenTurnArtifact(
+      [],
+      [
+        { name: 'hero.png', path: 'hero.png', kind: 'image', mtime: TURN_START + 5_000 },
+      ],
+      { turnStartedAt: TURN_START, agentTouchedFileNames: new Set() },
+    );
+
+    expect(result).toBe('hero.png');
+  });
+
+  it('never opens a user attachment even when turn attribution includes it', () => {
+    const attachment = {
+      name: 'reference.png',
+      path: 'reference.png',
+      kind: 'image',
+      mtime: TURN_START + 5_000,
+    } as const;
+    const options = {
+      turnStartedAt: TURN_START,
+      agentTouchedFileNames: new Set<string>(),
+      excludedFileNames: new Set(['reference.png']),
+    };
+
+    expect(selectAutoOpenTurnArtifact([attachment], [attachment], options)).toBeNull();
+    expect(selectAutoOpenTurnArtifact([], [attachment], options)).toBeNull();
   });
 
   it('keeps preferring newly produced files and merges rewritten ones by rank', () => {

--- a/apps/web/tests/onboarding-first-generation.test.ts
+++ b/apps/web/tests/onboarding-first-generation.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { producedPreviewableArtifact } from '../src/onboarding/first-generation';
+import {
+  hasPreviewableArtifactForOnboarding,
+  producedPreviewableArtifact,
+} from '../src/onboarding/first-generation';
 
 // Regression for the funnel-inflation bug (PR #5111 review):
 // `onboarding_first_generation_completed` must fire only when a run actually
@@ -26,6 +29,18 @@ describe('producedPreviewableArtifact', () => {
     ).toBe(true);
   });
 
+  it('is true when the turn produced an image artifact', () => {
+    const image = { name: 'cute-puppy.png', kind: 'image' } as const;
+
+    expect(producedPreviewableArtifact([image])).toBe(true);
+  });
+
+  it('uses the canonical file kind for generated image artifacts', () => {
+    const image = { name: 'generated-output.bin', kind: 'image' } as const;
+
+    expect(producedPreviewableArtifact([image])).toBe(true);
+  });
+
   it('is false for a succeeded run that produced no artifact (text/question only)', () => {
     expect(producedPreviewableArtifact([])).toBe(false);
   });
@@ -35,12 +50,75 @@ describe('producedPreviewableArtifact', () => {
       producedPreviewableArtifact([
         { name: 'plan.md' },
         { name: 'palette.json' },
-        { name: 'screenshot.png' },
       ]),
     ).toBe(false);
   });
 
+  it('does not treat a sketch image as a generated image artifact', () => {
+    const sketch = { name: 'sketch-preview.png', kind: 'sketch' } as const;
+
+    expect(producedPreviewableArtifact([sketch])).toBe(false);
+  });
+
   it('does not treat a filename that merely contains "html" as previewable', () => {
     expect(producedPreviewableArtifact([{ name: 'html-notes.md' }])).toBe(false);
+  });
+});
+
+describe('hasPreviewableArtifactForOnboarding', () => {
+  const image = { name: 'cute-puppy.png', kind: 'image' } as const;
+
+  it('keeps the existing project-level html fallback', () => {
+    expect(hasPreviewableArtifactForOnboarding([{ name: 'index.html' }], [])).toBe(true);
+  });
+
+  it('does not treat an arbitrary project image as a generated artifact', () => {
+    expect(hasPreviewableArtifactForOnboarding([image], [])).toBe(false);
+  });
+
+  it('accepts an image still present after a successful assistant turn', () => {
+    expect(
+      hasPreviewableArtifactForOnboarding(
+        [image],
+        [{ role: 'assistant', runStatus: 'succeeded', producedFiles: [image] }],
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects failed or deleted image outputs', () => {
+    expect(
+      hasPreviewableArtifactForOnboarding(
+        [image],
+        [{ role: 'assistant', runStatus: 'failed', producedFiles: [image] }],
+      ),
+    ).toBe(false);
+    expect(
+      hasPreviewableArtifactForOnboarding(
+        [],
+        [{ role: 'assistant', runStatus: 'succeeded', producedFiles: [image] }],
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects a stale image provenance when the current path is no longer an image', () => {
+    expect(
+      hasPreviewableArtifactForOnboarding(
+        [{ name: image.name, kind: 'sketch' }],
+        [{ role: 'assistant', runStatus: 'succeeded', producedFiles: [image] }],
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects a different image version uploaded at the same path', () => {
+    expect(
+      hasPreviewableArtifactForOnboarding(
+        [{ ...image, mtime: 20 }],
+        [{
+          role: 'assistant',
+          runStatus: 'succeeded',
+          producedFiles: [{ ...image, mtime: 10 }],
+        }],
+      ),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #5694

## Why

Generated image turns in a new session completed successfully and showed the file in the chat output card, but the preview pane never opened — users had to click **Open** manually. That breaks the natural "generate → see result" loop for image-first work.

The turn-end auto-open path only ranked HTML/Markdown as previewable, and first-artifact onboarding was `.html`-only, so generated images never won the viewer.

## What users will see

- After a successful image-generation turn (with no HTML page), the image auto-opens in the artifact preview — no manual Open click.
- When a turn produces mixed artifacts, priority is **HTML > image > Markdown** (mtime still breaks ties).
- User-uploaded attachments never auto-open and are not counted as generated artifacts, even if the agent overwrites the same path.
- The first-generation onboarding hint can fire for a generated image, but only with succeeded-turn + still-present provenance.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

This is a default behavior change: turn-end auto-open now includes generated images where it previously only opened HTML/Markdown.

## Screenshots

N/A from this environment. Manual QA: new session → generate an image → confirm it opens in the preview without clicking Open.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/auto-open-file.test.ts` (image rank / sketch exclusion / attachment exclusion), `apps/web/tests/onboarding-first-generation.test.ts` (image provenance), `apps/web/tests/components/ProjectView.reattach-restore.test.tsx` (attachment non-attribution on reattach)
- Did the test go red on `main` and green on this branch? yes for the new image auto-open cases (they assert behavior that was previously null / false)

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/components/auto-open-file.test.ts tests/onboarding-first-generation.test.ts tests/components/ProjectView.reattach-restore.test.tsx` — 94/94 passed
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`

Made with [Cursor](https://cursor.com)