### PR TITLE
fix(web): keep Azure deployment names editable

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1468,7 +1468,10 @@ function OnboardingView({
   const selectedProvider = KNOWN_PROVIDERS.find(
     (provider) =>
       provider.protocol === apiProtocol &&
-      provider.baseUrl === (config.apiProviderBaseUrl ?? config.baseUrl),
+      (
+        provider.baseUrl === (config.apiProviderBaseUrl ?? config.baseUrl) ||
+        (apiProtocol === 'azure' && provider.baseUrl === '' && Boolean(config.baseUrl?.trim()))
+      ),
   ) ?? null;
   const availableCliAgents = agents.filter((agent) => agent.available && agent.id !== 'amr');
   const visibleAgents = availableCliAgents.filter((agent) => visibleAgentIds.includes(agent.id));
@@ -1869,9 +1872,14 @@ function OnboardingView({
     }
   }
 
+  const protocolProviders = KNOWN_PROVIDERS.filter((provider) => provider.protocol === apiProtocol);
+  const hasProtocolOwnedEmptyProvider =
+    apiProtocol === 'azure' && protocolProviders.some((provider) => provider.baseUrl === '');
   const byokProviderOptions = [
-    { value: '', label: t('settings.customProvider') },
-    ...KNOWN_PROVIDERS.filter((provider) => provider.protocol === apiProtocol).map((provider) => ({
+    ...(hasProtocolOwnedEmptyProvider
+      ? []
+      : [{ value: '', label: t('settings.customProvider') }]),
+    ...protocolProviders.map((provider) => ({
       value: provider.baseUrl,
       label: provider.label,
     })),
@@ -2784,7 +2792,10 @@ function OnboardingView({
                       updateApiConfig({ model });
                     }}
                     onBaseUrlChange={(baseUrl) =>
-                      updateApiConfig({ baseUrl, apiProviderBaseUrl: null })
+                      updateApiConfig({
+                        baseUrl,
+                        apiProviderBaseUrl: apiProtocol === 'azure' ? '' : null,
+                      })
                     }
                     modelOptions={byokModelOptions}
                     testState={visibleProviderTestState}
@@ -3366,6 +3377,7 @@ function OnboardingByokSetupPanel({
   const t = useT();
   const running = testState.status === 'running';
   const fetchingModels = modelsState.status === 'running';
+  const useDeploymentInput = apiProtocol === 'azure';
   return (
     <div className="onboarding-view__setup-panel">
       <div className="onboarding-view__setup-head">
@@ -3418,6 +3430,7 @@ function OnboardingByokSetupPanel({
         value={selectedProvider?.baseUrl ?? ''}
         options={providerOptions}
         onChange={onProviderChange}
+        allowEmptyValue={apiProtocol === 'azure'}
         searchable
         searchPlaceholder={t('settings.quickFillProvider')}
       />
@@ -3446,7 +3459,7 @@ function OnboardingByokSetupPanel({
             onChange={(event) => onBaseUrlChange(event.target.value)}
           />
         </label>
-        {modelOptions.length > 0 ? (
+        {modelOptions.length > 0 && !useDeploymentInput ? (
           <OnboardingDropdown
             label={t('settings.model')}
             placeholder={defaultKnownProviderModel(selectedProvider) || 'claude-sonnet-4-5'}
@@ -3459,11 +3472,19 @@ function OnboardingByokSetupPanel({
           />
         ) : (
           <label className="onboarding-view__inline-field">
-            <span>{t('settings.model')}</span>
+            <span>
+              {useDeploymentInput
+                ? t('settings.azureDeploymentModel')
+                : t('settings.model')}
+            </span>
             <input
               type="text"
               value={model}
-              placeholder={defaultKnownProviderModel(selectedProvider) || 'claude-sonnet-4-5'}
+              placeholder={
+                useDeploymentInput
+                  ? t('settings.azureDeploymentModel')
+                  : defaultKnownProviderModel(selectedProvider) || 'claude-sonnet-4-5'
+              }
               onChange={(event) => onModelChange(event.target.value.trim())}
             />
           </label>
@@ -3748,6 +3769,7 @@ type OnboardingDropdownBaseProps = {
   searchable?: boolean;
   searchPlaceholder?: string;
   sourceTone?: string;
+  allowEmptyValue?: boolean;
 };
 
 type OnboardingDropdownProps =
@@ -3774,6 +3796,7 @@ export function OnboardingDropdown(props: OnboardingDropdownProps) {
     searchable = false,
     searchPlaceholder,
     sourceTone,
+    allowEmptyValue = false,
   } = props;
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
@@ -3781,7 +3804,11 @@ export function OnboardingDropdown(props: OnboardingDropdownProps) {
   const [menuMaxHeight, setMenuMaxHeight] = useState(240);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const dropdownIdRef = useRef(`onboarding-dropdown-${Math.random().toString(36).slice(2)}`);
-  const selectedValues = Array.isArray(value) ? value : value ? [value] : [];
+  const selectedValues = Array.isArray(value)
+    ? value
+    : value || allowEmptyValue
+      ? [value]
+      : [];
   const selectedOptions = options.filter((option) => selectedValues.includes(option.value));
   const selectedOption = selectedOptions[0];
   const hasValue = selectedOptions.length > 0;

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -3244,11 +3244,15 @@ export function SettingsDialog({
     [apiProtocol],
   );
   const selectedProviderIndex =
-    cfg.apiProviderBaseUrl == null
-      ? -1
-      : protocolProviders.findIndex(
-          (p) => p.baseUrl === cfg.apiProviderBaseUrl && p.baseUrl === cfg.baseUrl,
-        );
+    protocolProviders.findIndex((p) => {
+      if (cfg.apiProviderBaseUrl == null) {
+        return apiProtocol === 'azure' && p.baseUrl === '' && Boolean(cfg.baseUrl?.trim());
+      }
+      return (
+        p.baseUrl === cfg.apiProviderBaseUrl &&
+        (p.baseUrl === cfg.baseUrl || (apiProtocol === 'azure' && p.baseUrl === ''))
+      );
+    });
   const selectedProvider = selectedProviderIndex >= 0 ? protocolProviders[selectedProviderIndex] : undefined;
   const apiKeyConsoleLink =
     selectedProvider?.apiKeyConsoleLink ?? defaultApiKeyConsoleLink;
@@ -3279,7 +3283,12 @@ export function SettingsDialog({
           ? undefined
           : cfg.apiProtocolConfigs?.[provider.protocol]
       );
-    if (!entry || entry.baseUrl !== provider.baseUrl) return false;
+    if (!entry) return false;
+    if (provider.baseUrl) {
+      if (entry.baseUrl !== provider.baseUrl) return false;
+    } else if (provider.protocol !== 'azure' && entry.baseUrl !== provider.baseUrl) {
+      return false;
+    }
     const knownProvider = KNOWN_PROVIDERS.find((item) => item.baseUrl === provider.baseUrl);
     return canRunProviderConnectionTest(entry, {
       requiresApiKey: byokProviderRequiresApiKey(
@@ -5345,7 +5354,12 @@ export function SettingsDialog({
                     azureHint: t('settings.azureBaseUrlHint'),
                   }}
                   onBlur={commitProviderModelsInputs}
-                  onChange={(value) => updateApiConfig({ baseUrl: value, apiProviderBaseUrl: null })}
+                  onChange={(value) =>
+                    updateApiConfig({
+                      baseUrl: value,
+                      apiProviderBaseUrl: apiProtocol === 'azure' ? '' : null,
+                    })
+                  }
                   onCustomize={() => {
                     updateApiConfig({ apiProviderBaseUrl: null });
                     window.setTimeout(() => baseUrlInputRef.current?.focus(), 0);
@@ -5387,7 +5401,7 @@ export function SettingsDialog({
                     ? t('settings.azureCustomDeploymentName')
                     : t('settings.modelCustomLabel'),
                   customModelPlaceholder: apiProtocol === 'azure'
-                    ? 'e.g. gpt-4o-production'
+                    ? t('settings.azureDeploymentModel')
                     : t('settings.modelCustomPlaceholder'),
                   fetchModelsUnsupported: t('settings.fetchModelsUnsupported'),
                   model: apiProtocol === 'azure'
@@ -5424,6 +5438,7 @@ export function SettingsDialog({
                     : null
                 }
                 providerModelsFailureMessage={providerModelsFailureMessage}
+                forceTextInput={apiProtocol === 'azure'}
                 showAzureModelFetchHint={apiProtocol === 'azure'}
                 showFetchModelsUnsupportedHint={
                   apiProtocol !== 'azure' &&

--- a/apps/web/src/components/byok/ByokModelField.tsx
+++ b/apps/web/src/components/byok/ByokModelField.tsx
@@ -23,6 +23,7 @@ interface ByokModelFieldProps {
   models: AgentModelOption[];
   modelsLoadedFromAccountMessage: string | null;
   providerModelsFailureMessage: string | null;
+  forceTextInput?: boolean;
   showAzureModelFetchHint: boolean;
   showFetchModelsUnsupportedHint: boolean;
   showSuggestedModelsHint: boolean;
@@ -42,6 +43,7 @@ export function ByokModelField({
   models,
   modelsLoadedFromAccountMessage,
   providerModelsFailureMessage,
+  forceTextInput = false,
   showAzureModelFetchHint,
   showFetchModelsUnsupportedHint,
   showSuggestedModelsHint,
@@ -57,53 +59,73 @@ export function ByokModelField({
 
   return (
     <>
-      <label className="field">
-        <span className="field-label">
-          {labels.model}
-          <span className="field-required" aria-label={labels.required}>
-            *
+      {forceTextInput ? (
+        <label className={'field' + (model.trim() ? '' : ' settings-byok-required-empty')}>
+          <span className="field-label">
+            {labels.model}
+            <span className="field-required" aria-label={labels.required}>
+              *
+            </span>
           </span>
+          <input
+            ref={customInputRef}
+            aria-label={labels.model}
+            type="text"
+            value={model}
+            placeholder={labels.customModelPlaceholder}
+            onFocus={onFocus}
+            onChange={(e) => onCustomModelChange(e.target.value.trim())}
+          />
+        </label>
+      ) : (
+        <label className="field">
+          <span className="field-label">
+            {labels.model}
+            <span className="field-required" aria-label={labels.required}>
+              *
+            </span>
+          </span>
+          <SearchableModelSelect
+            ref={modelSelectRef}
+            className="inline-switcher__select settings-model-select settings-model-select--byok"
+            aria-label={labels.model}
+            searchPlaceholder={labels.searchPlaceholder}
+            searchInputTestId="settings-byok-model-search"
+            popoverTestId="settings-byok-model-popover"
+            popoverClassName="settings-byok-select-popover"
+            models={models}
+            value={selectValue}
+            onFocus={onFocus}
+            onChange={(nextValue) => {
+              if (nextValue === CUSTOM_MODEL_SENTINEL) {
+                onCustomModelSelect();
+              } else {
+                onModelSelect(nextValue);
+              }
+            }}
+            additionalOptions={[
+              {
+                value: CUSTOM_MODEL_SENTINEL,
+                label: labels.customModel,
+              },
+            ]}
+          />
+        </label>
+      )}
+      {modelsLoadedFromAccountMessage ? (
+        <span className="field-inline-status success" role="status">
+          {modelsLoadedFromAccountMessage}
         </span>
-        <SearchableModelSelect
-          ref={modelSelectRef}
-          className="inline-switcher__select settings-model-select settings-model-select--byok"
-          aria-label={labels.model}
-          searchPlaceholder={labels.searchPlaceholder}
-          searchInputTestId="settings-byok-model-search"
-          popoverTestId="settings-byok-model-popover"
-          popoverClassName="settings-byok-select-popover"
-          models={models}
-          value={selectValue}
-          onFocus={onFocus}
-          onChange={(nextValue) => {
-            if (nextValue === CUSTOM_MODEL_SENTINEL) {
-              onCustomModelSelect();
-            } else {
-              onModelSelect(nextValue);
-            }
-          }}
-          additionalOptions={[
-            {
-              value: CUSTOM_MODEL_SENTINEL,
-              label: labels.customModel,
-            },
-          ]}
-        />
-        {modelsLoadedFromAccountMessage ? (
-          <span className="field-inline-status success" role="status">
-            {modelsLoadedFromAccountMessage}
-          </span>
-        ) : null}
-        {providerModelsFailureMessage ? (
-          <span className="field-error" role="alert">
-            {providerModelsFailureMessage}
-          </span>
-        ) : null}
-      </label>
+      ) : null}
+      {providerModelsFailureMessage ? (
+        <span className="field-error" role="alert">
+          {providerModelsFailureMessage}
+        </span>
+      ) : null}
       {showSuggestedModelsHint ? (
         <p className="hint">{labels.suggestedModelsHint}</p>
       ) : null}
-      {customActive ? (
+      {!forceTextInput && customActive ? (
         <label className={'field' + (model.trim() ? '' : ' settings-byok-required-empty')}>
           <span className="field-label">
             {labels.customModelLabel}

--- a/apps/web/tests/components/ByokModelField.test.tsx
+++ b/apps/web/tests/components/ByokModelField.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ByokModelField } from '../../src/components/byok/ByokModelField';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+const labels = {
+  customModel: 'Custom model',
+  customModelLabel: 'Custom model id',
+  customModelPlaceholder: 'Deployment name',
+  fetchModelsUnsupported: 'Fetch models is unavailable.',
+  model: 'Deployment name',
+  required: 'Required',
+  searchPlaceholder: 'Search models',
+  suggestedModelsHint: 'Suggested models are shown.',
+};
+
+describe('ByokModelField', () => {
+  it('keeps direct deployment input feedback visible', () => {
+    const onCustomModelChange = vi.fn();
+
+    render(
+      <ByokModelField
+        customActive={false}
+        customInputRef={null}
+        labels={labels}
+        model="deployment-one"
+        modelSelectRef={null}
+        models={[{ id: 'suggested-model', label: 'Suggested model' }]}
+        modelsLoadedFromAccountMessage="Loaded 1 model from your account."
+        providerModelsFailureMessage="Provider models could not be loaded."
+        forceTextInput
+        showAzureModelFetchHint={false}
+        showFetchModelsUnsupportedHint={false}
+        showSuggestedModelsHint={false}
+        azureModelFetchHint="Enter a deployment name."
+        onCustomModelChange={onCustomModelChange}
+        onCustomModelSelect={vi.fn()}
+        onFocus={vi.fn()}
+        onModelSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText('Deployment name')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Deployment name' })).toBeNull();
+    expect(screen.getByRole('status').textContent).toContain('Loaded 1 model');
+    expect(screen.getByRole('alert').textContent).toContain('Provider models');
+
+    fireEvent.change(screen.getByLabelText('Deployment name'), {
+      target: { value: 'deployment-two' },
+    });
+
+    expect(onCustomModelChange).toHaveBeenCalledWith('deployment-two');
+  });
+});

--- a/apps/web/tests/components/EntryShell.onboarding-dropdown.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding-dropdown.test.tsx
@@ -143,6 +143,39 @@ describe('OnboardingDropdown', () => {
     expect(screen.queryByText('No compatible text models were returned.')).toBeNull();
   });
 
+  it('only treats an empty option as selected when explicitly allowed', () => {
+    const options = [
+      { value: '', label: 'Azure OpenAI' },
+      { value: 'https://api.example.test', label: 'Example provider' },
+    ];
+
+    const { rerender } = render(
+      <OnboardingDropdown
+        label="Provider"
+        placeholder="Custom provider"
+        value=""
+        options={options}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /Custom provider/ })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Azure OpenAI/ })).toBeNull();
+
+    rerender(
+      <OnboardingDropdown
+        label="Provider"
+        placeholder="Custom provider"
+        value=""
+        options={options}
+        onChange={vi.fn()}
+        allowEmptyValue
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /Azure OpenAI/ })).toBeTruthy();
+  });
+
   it('renders model tag and cost metadata as option text', () => {
     render(
       <OnboardingDropdown

--- a/apps/web/tests/components/EntryShell.onboarding.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding.test.tsx
@@ -1615,6 +1615,71 @@ describe('EntryShell onboarding Open Design AMR runtime', () => {
     });
   });
 
+  it('lets Azure BYOK onboarding enter a custom deployment directly', async () => {
+    globalThis.fetch = vi.fn(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/api/integrations/vela/status')) {
+        return jsonResponse({ loggedIn: false, profile: 'prod', user: null, configPath: '/x' });
+      }
+      if (url.endsWith('/api/test/connection') && init?.method === 'POST') {
+        const body = JSON.parse(String(init.body ?? '{}'));
+        expect(body).toMatchObject({
+          protocol: 'azure',
+          apiKey: 'azure-key',
+          baseUrl: 'https://example.openai.azure.com',
+          model: 'deployment-one',
+        });
+        return jsonResponse({
+          ok: true,
+          kind: 'success',
+          latencyMs: 11,
+          model: 'deployment-one',
+          sample: 'Connected',
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+    const props = renderOnboarding({
+      config: baseConfig({
+        mode: 'api',
+        apiProtocol: 'azure',
+        apiProviderBaseUrl: '',
+      }),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /Bring your own key/i }));
+
+    expect(screen.getByRole('tab', { name: 'Azure OpenAI' }).getAttribute('aria-selected')).toBe(
+      'true',
+    );
+    expect((screen.getByRole('button', { name: /Fetch models/i }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect(screen.getAllByRole('button', { name: 'Azure OpenAI' }).length).toBeGreaterThan(0);
+
+    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'azure-key' } });
+    fireEvent.change(screen.getByLabelText('Base URL'), {
+      target: { value: 'https://example.openai.azure.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Deployment name'), {
+      target: { value: 'deployment-one' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Test$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Connected\. Replied in 11 ms/i)).toBeTruthy();
+    });
+    expect(props.onApiModelChange).toHaveBeenCalledWith('deployment-one');
+    expect((props.onConfigPersist as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0]).toMatchObject({
+      mode: 'api',
+      apiProtocol: 'azure',
+      apiKey: 'azure-key',
+      apiProviderBaseUrl: '',
+      baseUrl: 'https://example.openai.azure.com',
+      model: 'deployment-one',
+    });
+  });
+
   it('keeps the cloud sign-in landing stable while AMR detection is still in flight', async () => {
     globalThis.fetch = vi.fn(async () =>
       jsonResponse({ loggedIn: false, profile: 'prod', user: null, configPath: '/x' }),

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -1214,10 +1214,8 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     fireEvent.change(screen.getByLabelText('API key'), {
       target: { value: 'azure-key' },
     });
+    expect(screen.queryByLabelText('Custom deployment name')).toBeNull();
     fireEvent.change(screen.getByLabelText('Deployment name'), {
-      target: { value: '__custom__' },
-    });
-    fireEvent.change(screen.getByLabelText('Custom deployment name'), {
       target: { value: 'deployment-one' },
     });
     fireEvent.change(screen.getByLabelText('Base URL'), {
@@ -1240,10 +1238,26 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
         model: 'deployment-one',
         baseUrl: 'https://example.openai.azure.com',
         apiVersion: '2024-10-21',
-        apiProviderBaseUrl: null,
+        apiProviderBaseUrl: '',
       }),
       {},
     );
+
+    const persistedConfig = onPersist.mock.calls.at(-1)?.[0] as AppConfig;
+    cleanup();
+
+    renderSettingsDialog(persistedConfig);
+
+    expect((screen.getByLabelText('Deployment name') as HTMLInputElement).value).toBe(
+      'deployment-one',
+    );
+    expect((screen.getByLabelText('Base URL') as HTMLInputElement).value).toBe(
+      'https://example.openai.azure.com',
+    );
+    expect((screen.getByLabelText('API version') as HTMLInputElement).value).toBe(
+      '2024-10-21',
+    );
+    expect(screen.queryByLabelText('Custom deployment name')).toBeNull();
   });
 
   it('does not fetch provider models while the API key edit is still uncommitted', async () => {


### PR DESCRIPTION
Fixes #6028

## Why

Azure BYOK setup currently makes deployment names hard to keep configured from the UI. Typing the Azure resource endpoint can make the provider look like a custom provider, and users can lose the deployment name when they reopen Settings.

## What users will see

In onboarding and Settings, the Azure BYOK model field is now a direct Deployment name input. Users can paste their Azure endpoint, enter the deployment name they created, test the connection, and reopen Settings without the provider/deployment fields falling back to custom-provider state.

## Surface area

- [x] UI
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [x] Default behavior change
- [ ] None

## Screenshots

Onboarding with endpoint, deployment name, and connection result:

![Onboarding Azure BYOK connection result](https://gist.githubusercontent.com/mturac/1635c1ac17edab44fd052e1da4e318b8/raw/7f37bd363e634842b7d11415c163adc5353c46c5/onboarding-azure-byok-connection.svg)

Settings after saving, closing, and reopening, with the Azure preset and deployment retained:

![Settings Azure BYOK persisted deployment](https://gist.githubusercontent.com/mturac/1635c1ac17edab44fd052e1da4e318b8/raw/411bcabd50e37cabd23ae63432d286c694e25e85/settings-azure-reopen-retains-deployment.svg)

## Bug fix verification

- Test path that reproduces the bug: apps/web/tests/components/EntryShell.onboarding.test.tsx and apps/web/tests/components/SettingsDialog.execution.test.tsx
- Did the test go red on main and green on this branch? No; the regression tests were added on this branch and cover the reported Azure setup path.

## Validation

- pnpm --dir apps/web exec vitest run -c vitest.config.ts --maxWorkers=2 tests/components/EntryShell.onboarding-dropdown.test.tsx tests/components/ByokModelField.test.tsx tests/components/EntryShell.onboarding.test.tsx tests/components/SettingsDialog.execution.test.tsx -t "lets Azure BYOK onboarding enter a custom deployment directly|shows Azure-specific fields and autosaves an Azure config|only treats an empty option as selected when explicitly allowed|keeps direct deployment input feedback visible"
- pnpm --filter @open-design/web typecheck
- git diff --check

