### PR TITLE
fix(daemon): preflight incompatible Codex models

### DIFF
--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -88,6 +88,8 @@ interface DaemonRunRecord {
   // into chatBody / req across the createChatRunService boundary.
   userPrompt?: string;
   model?: string;
+  resolvedModelId?: string | null;
+  preflightAgentCliVersion?: string | null;
   reasoning?: string;
   skillId?: string;
   designSystemId?: string;
@@ -257,6 +259,8 @@ function turnInfoFromRun(
     turn.model = run.model;
   } else if (agentReportedModel && agentReportedModel.trim().length > 0) {
     turn.model = agentReportedModel.trim();
+  } else if (run.resolvedModelId && run.resolvedModelId.trim().length > 0) {
+    turn.model = run.resolvedModelId.trim();
   } else {
     // Keep Langfuse aligned with PostHog's model bucket when the user selected
     // "Default (CLI config)" and the runtime did not emit a resolved model.
@@ -1044,6 +1048,9 @@ export async function reportRunCompletedFromDaemon(
       ...getRuntimeInfo(opts.appVersion ?? null),
       ...(run.clientType ? { clientType: run.clientType } : {}),
       ...(getDetectedRuntimeVersions(run.agentId) ?? {}),
+      ...(run.preflightAgentCliVersion
+        ? { agentCliVersion: run.preflightAgentCliVersion }
+        : {}),
     };
     const artifacts = summarizeProducedFiles(traceObjectFilesRaw);
     const diagnostics = summarizeRunDiagnosticsForAnalytics({

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -163,6 +163,8 @@ interface ChatRun {
   clients: Set<SseClient>;
   analyticsContext?: AnalyticsContext;
   analyticsTelemetry?: RunTelemetryTimestamps;
+  resolvedModelId?: string | null;
+  preflightAgentCliVersion?: string | null;
   // E-lite root-cause telemetry read at run_finished. `stdinBackpressure`: the
   // prompt write to child stdin was queued (pipe buffer full). `lastAgentActivityAt`:
   // the inactivity-watchdog clock, used to derive `last_progress_age_ms`.
@@ -1250,8 +1252,12 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         });
         const finishedModelId = hasExplicitRequestedModelForAnalytics(reqBody.model)
           ? modelIdForTracking(reqBody.model)
-          : modelIdForTracking(usageAnalytics.agent_reported_model);
+          : modelIdForTracking(
+              usageAnalytics.agent_reported_model ?? run.resolvedModelId,
+            );
         const runtimeVersions = getDetectedRuntimeVersions(run.agentId);
+        const agentCliVersion =
+          run.preflightAgentCliVersion ?? runtimeVersions?.agentCliVersion;
         for (const [index, retryEvent] of runRetryEventsForAnalytics(run.events).entries()) {
           design.analytics.capture({
             eventName: retryEvent.event,
@@ -1288,8 +1294,8 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
             asked_user_question: runAskedUserQuestion(run.events),
             retry_attempt_count: run.retryAttemptCount ?? 0,
             retry_final_result: run.retryFinalResult ?? 'not_attempted',
-            ...(runtimeVersions?.agentCliVersion
-              ? { agent_cli_version: runtimeVersions.agentCliVersion }
+            ...(agentCliVersion
+              ? { agent_cli_version: agentCliVersion }
               : {}),
             ...(runtimeVersions?.runtimeCompanionName
               ? { runtime_companion_name: runtimeVersions.runtimeCompanionName }

--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -353,6 +353,21 @@ function modelUnavailableDetail(text: string): TrackingRunFailureDetail | null {
   return null;
 }
 
+function wasBlockedByModelCapabilityPreflight(
+  events: RunEventForFailureClassification[] | undefined,
+): boolean {
+  return (events ?? []).some((event) => {
+    if (event.event !== 'diagnostic' || !event.data || typeof event.data !== 'object') {
+      return false;
+    }
+    const data = event.data as Record<string, unknown>;
+    return (
+      data.type === 'model_capability_preflight' &&
+      data.status === 'incompatible'
+    );
+  });
+}
+
 function authDetail(text: string): TrackingRunFailureDetail {
   if (/\brefresh token (?:was )?(?:already used|expired|invalid)|access token could not be refreshed\b/i
     .test(text)) {
@@ -696,7 +711,10 @@ export function classifyRunFailure(
     return classification(
       'model_unavailable',
       modelDetail,
-      'model_select',
+      modelDetail === 'cli_version_incompatible' &&
+        wasBlockedByModelCapabilityPreflight(input.events)
+        ? 'preflight'
+        : 'model_select',
       false,
       'switch_model',
     );

--- a/apps/daemon/src/runtimes/codex-model-preflight.ts
+++ b/apps/daemon/src/runtimes/codex-model-preflight.ts
@@ -43,6 +43,7 @@ export type CodexModelPreflightResult =
         | 'custom_provider'
         | 'config_overlay'
         | 'auth_override'
+        | 'system_config'
         | 'managed_config'
         | 'version_unavailable'
         | 'no_known_requirement'
@@ -282,6 +283,33 @@ function hasAuthOrEndpointOverride(env: NodeJS.ProcessEnv): boolean {
   );
 }
 
+function envValueCaseInsensitive(
+  env: NodeJS.ProcessEnv,
+  expectedKey: string,
+): string | null {
+  const matched = Object.entries(env).find(
+    ([key, value]) =>
+      key.toUpperCase() === expectedKey
+      && typeof value === 'string'
+      && value.trim().length > 0,
+  )?.[1];
+  return matched?.trim() || null;
+}
+
+async function hasSystemConfigLayer(
+  env: NodeJS.ProcessEnv,
+): Promise<boolean> {
+  const configPath = process.platform === 'win32'
+    ? path.join(
+        envValueCaseInsensitive(env, 'PROGRAMDATA') ?? 'C:\\ProgramData',
+        'OpenAI',
+        'Codex',
+        'config.toml',
+      )
+    : '/etc/codex/config.toml';
+  return await pathState(configPath) !== 'missing';
+}
+
 async function hasMacManagedConfigPreference(
   env: NodeJS.ProcessEnv,
 ): Promise<boolean> {
@@ -337,7 +365,13 @@ async function hasMacManagedConfigPreference(
 
 async function hasManagedConfigLayer(env: NodeJS.ProcessEnv): Promise<boolean> {
   const configDir = path.dirname(resolveCodexConfigPath(env));
-  const candidates = [path.join(configDir, 'managed_config.toml')];
+  const candidates = [
+    path.join(configDir, 'managed_config.toml'),
+    // Codex stores fetched enterprise config bundles here. We do not parse the
+    // signed payload or assume it is current; presence alone means a non-user
+    // layer may affect the effective provider or endpoint, so fail open.
+    path.join(configDir, 'cloud-config-bundle-cache.json'),
+  ];
   if (process.platform !== 'win32') {
     candidates.push('/etc/codex/managed_config.toml');
   }
@@ -416,6 +450,9 @@ export async function preflightCodexDefaultModel(
     };
   }
 
+  if (await hasSystemConfigLayer(input.env)) {
+    return { status: 'unknown', reason: 'system_config' };
+  }
   if (await hasManagedConfigLayer(input.env)) {
     return { status: 'unknown', reason: 'managed_config' };
   }
@@ -426,6 +463,12 @@ export async function preflightCodexDefaultModel(
   // before blocking the child process.
   if (!await hasConfirmedChatGptAuth(input.launchPath, input.env)) {
     return { status: 'unknown', reason: 'auth_unconfirmed' };
+  }
+  // `codex login status` loads the effective Codex config and can populate the
+  // enterprise bundle cache on a first run. Re-check after that probe so a
+  // newly materialized cloud layer cannot race the incompatibility decision.
+  if (await hasManagedConfigLayer(input.env)) {
+    return { status: 'unknown', reason: 'managed_config' };
   }
   return {
     status: 'incompatible',

--- a/apps/daemon/src/runtimes/codex-model-preflight.ts
+++ b/apps/daemon/src/runtimes/codex-model-preflight.ts
@@ -1,0 +1,436 @@
+import { readFile, realpath, stat } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { resolveCodexConfigPath } from '../codex-config-normalize.js';
+import { execAgentFile } from './invocation.js';
+
+type StableCodexVersion = {
+  major: number;
+  minor: number;
+  patch: number;
+};
+
+type CodexVersionProbe = {
+  cliVersion: string;
+  stableVersion: StableCodexVersion | null;
+};
+
+type KnownModelRequirement = {
+  minimum: StableCodexVersion;
+  minimumLabel: string;
+};
+
+const KNOWN_MODEL_REQUIREMENTS: Readonly<Record<string, KnownModelRequirement>> = {
+  // Production traces showed 0.142.5 rejecting this ChatGPT-backed model with
+  // "requires a newer version of Codex". Upstream confirms 0.143.0 can start
+  // it explicitly even when the interactive model picker omits it, so version
+  // is the compatibility contract here—not catalog visibility.
+  'gpt-5.6-terra': {
+    minimum: { major: 0, minor: 143, patch: 0 },
+    minimumLabel: '0.143.0',
+  },
+};
+
+export type CodexModelPreflightResult =
+  | {
+      status: 'not_applicable' | 'unknown';
+      reason:
+        | 'explicit_model'
+        | 'project_config'
+        | 'config_unavailable'
+        | 'configured_model_missing'
+        | 'custom_provider'
+        | 'config_overlay'
+        | 'auth_override'
+        | 'managed_config'
+        | 'version_unavailable'
+        | 'no_known_requirement'
+        | 'auth_unconfirmed';
+    }
+  | {
+      status: 'compatible' | 'incompatible';
+      model: string;
+      cliVersion: string;
+      requiredCliVersion: string;
+    };
+
+export interface CodexModelPreflightInput {
+  launchPath: string;
+  env: NodeJS.ProcessEnv;
+  requestedModel: string | null | undefined;
+  projectRoot?: string | null;
+}
+
+const versionProbeCache = new Map<string, Promise<CodexVersionProbe | null>>();
+let macManagedConfigProbe: Promise<boolean> | null = null;
+
+function stripTomlComment(line: string): string {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (ch === "'" && !inDouble) inSingle = !inSingle;
+    else if (ch === '"' && !inSingle) inDouble = !inDouble;
+    else if (ch === '#' && !inSingle && !inDouble) return line.slice(0, i);
+  }
+  return line;
+}
+
+function quotedRootValue(line: string, key: string): string | null {
+  const tomlKey = `(?:${key}|"${key}"|'${key}')`;
+  const match = new RegExp(
+    `^${tomlKey}\\s*=\\s*(?:"([^"]*)"|'([^']*)')\\s*$`,
+  ).exec(line);
+  if (!match) return null;
+  const value = (match[1] ?? match[2] ?? '').trim();
+  return value || null;
+}
+
+function assignsKey(line: string, key: string): boolean {
+  const tomlKey = `(?:${key}|"${key}"|'${key}')`;
+  return new RegExp(`^${tomlKey}\\s*=`).test(line);
+}
+
+export function extractCodexRootModelConfig(content: string): {
+  model: string | null;
+  modelProvider: string | null;
+  hasCompatibilityOverlay: boolean;
+} {
+  let model: string | null = null;
+  let modelProvider: string | null = null;
+  let hasCompatibilityOverlay = false;
+  let inRootTable = true;
+  let inOpenAiProviderTable = false;
+
+  for (const raw of String(content || '').split(/\r?\n/)) {
+    const line = stripTomlComment(raw).trim();
+    if (!line) continue;
+
+    if (line.startsWith('[')) {
+      inRootTable = false;
+      inOpenAiProviderTable = /^\[model_providers\.openai\]$/.test(line);
+      if (inOpenAiProviderTable) hasCompatibilityOverlay = true;
+      continue;
+    }
+
+    // These settings can replace the server/model source independently of the
+    // root model string. Without fully evaluating Codex's config stack, a
+    // version-only rejection would be unsafe, so their presence makes the
+    // preflight fail open.
+    if (
+      assignsKey(line, 'model_catalog_json')
+      || assignsKey(line, 'openai_base_url')
+      || assignsKey(line, 'chatgpt_base_url')
+      || assignsKey(line, 'base_url')
+    ) {
+      hasCompatibilityOverlay = true;
+    }
+
+    if (!inRootTable) continue;
+    if (
+      assignsKey(line, 'profile')
+      || assignsKey(line, 'project_root_markers')
+    ) {
+      hasCompatibilityOverlay = true;
+    }
+    model = quotedRootValue(line, 'model') ?? model;
+    modelProvider = quotedRootValue(line, 'model_provider') ?? modelProvider;
+  }
+
+  return { model, modelProvider, hasCompatibilityOverlay };
+}
+
+function safeVersion(stdout: unknown, stderr: unknown): string | null {
+  const text = `${String(stdout || '')}\n${String(stderr || '')}`.trim();
+  const firstLine = text.split(/\r?\n/, 1)[0]?.trim() ?? '';
+  if (!firstLine) return null;
+  return firstLine.replace(/[^\x20-\x7E]/g, '').slice(0, 120) || null;
+}
+
+export function parseStableCodexVersion(value: string): StableCodexVersion | null {
+  // Prerelease/build versions intentionally fail open. We only have a
+  // production boundary for stable 0.142.5 (bad) and 0.143.0 (good).
+  const match = /(?:^|[^\d])(\d+)\.(\d+)\.(\d+)(?![\dA-Za-z.+-])/.exec(value);
+  if (!match) return null;
+  const [, major, minor, patch] = match;
+  return {
+    major: Number(major),
+    minor: Number(minor),
+    patch: Number(patch),
+  };
+}
+
+function compareVersions(left: StableCodexVersion, right: StableCodexVersion): number {
+  if (left.major !== right.major) return left.major - right.major;
+  if (left.minor !== right.minor) return left.minor - right.minor;
+  return left.patch - right.patch;
+}
+
+async function executableCacheKey(launchPath: string): Promise<string | null> {
+  try {
+    const info = await stat(launchPath);
+    return `${launchPath}\0${info.size}\0${info.mtimeMs}`;
+  } catch {
+    return null;
+  }
+}
+
+async function probeVersion(
+  launchPath: string,
+  env: NodeJS.ProcessEnv,
+): Promise<CodexVersionProbe | null> {
+  const cacheKey = await executableCacheKey(launchPath);
+  if (!cacheKey) return null;
+  const cached = versionProbeCache.get(cacheKey);
+  if (cached) return cached;
+
+  const pending = (async (): Promise<CodexVersionProbe | null> => {
+    try {
+      const result = await execAgentFile(launchPath, ['--version'], {
+        env,
+        timeout: 3_000,
+      });
+      const cliVersion = safeVersion(result.stdout, result.stderr);
+      const stableVersion = cliVersion
+        ? parseStableCodexVersion(cliVersion)
+        : null;
+      return cliVersion ? { cliVersion, stableVersion } : null;
+    } catch {
+      return null;
+    }
+  })();
+  versionProbeCache.set(cacheKey, pending);
+  void pending.then((result) => {
+    // Only transient execution failures are evicted. A successful probe with
+    // an unrecognised/prerelease version is cached as a fail-open result so
+    // every run does not pay for another `codex --version` process.
+    if (!result && versionProbeCache.get(cacheKey) === pending) {
+      versionProbeCache.delete(cacheKey);
+    }
+  });
+  return pending;
+}
+
+async function pathState(filePath: string): Promise<'present' | 'missing' | 'uncertain'> {
+  try {
+    await stat(filePath);
+    return 'present';
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code === 'ENOENT' || code === 'ENOTDIR' ? 'missing' : 'uncertain';
+  }
+}
+
+async function projectConfigExists(projectCwd: string | null | undefined): Promise<boolean> {
+  if (!projectCwd) return false;
+  let start: string;
+  try {
+    // Node/Codex resolves the child cwd physically. Scan that same path so a
+    // symlinked imported workspace cannot hide its real repository config.
+    start = await realpath(path.resolve(projectCwd));
+  } catch {
+    return true;
+  }
+  const ancestors: string[] = [];
+  let current = start;
+  let gitRoot: string | null = null;
+
+  // Codex layers project config from the repository root down to cwd. Find the
+  // nearest repository boundary first; when there is no repository, inspect
+  // only the explicit project cwd so a user's global ~/.codex/config.toml is
+  // never mistaken for a project override.
+  while (true) {
+    ancestors.push(current);
+    const gitState = await pathState(path.join(current, '.git'));
+    if (gitState === 'uncertain') return true;
+    if (gitState === 'present') {
+      gitRoot = current;
+      break;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+
+  const searchDirs = gitRoot
+    ? ancestors.slice(0, ancestors.indexOf(gitRoot) + 1)
+    : [start];
+  for (const dir of searchDirs) {
+    const configState = await pathState(path.join(dir, '.codex', 'config.toml'));
+    if (configState !== 'missing') return true;
+  }
+  return false;
+}
+
+const AUTH_OR_ENDPOINT_ENV_KEYS = new Set([
+  'OPENAI_API_KEY',
+  'OPENAI_BASE_URL',
+  'OPENAI_API_BASE',
+  'CODEX_API_KEY',
+]);
+
+function hasAuthOrEndpointOverride(env: NodeJS.ProcessEnv): boolean {
+  // Windows environment names are case-insensitive, while a plain JS object is
+  // not. Match keys case-insensitively on every platform so mixed-case inherited
+  // variables cannot bypass this fail-open boundary.
+  return Object.entries(env).some(
+    ([key, value]) =>
+      AUTH_OR_ENDPOINT_ENV_KEYS.has(key.toUpperCase())
+      && typeof value === 'string'
+      && value.trim().length > 0,
+  );
+}
+
+async function hasMacManagedConfigPreference(
+  env: NodeJS.ProcessEnv,
+): Promise<boolean> {
+  if (process.platform !== 'darwin') return false;
+  if (macManagedConfigProbe) return macManagedConfigProbe;
+
+  macManagedConfigProbe = (async () => {
+    const managedPreferencePaths = [
+      '/Library/Managed Preferences/com.openai.codex.plist',
+    ];
+    try {
+      managedPreferencePaths.push(
+        path.join(
+          '/Library/Managed Preferences',
+          os.userInfo().username,
+          'com.openai.codex.plist',
+        ),
+      );
+    } catch {
+      // `defaults` below remains the authoritative fallback.
+    }
+    for (const preferencePath of managedPreferencePaths) {
+      const state = await pathState(preferencePath);
+      if (state !== 'missing') return true;
+    }
+
+    try {
+      const result = await execAgentFile(
+        '/usr/bin/defaults',
+        ['read', 'com.openai.codex', 'config_toml_base64'],
+        { env, timeout: 1_500 },
+      );
+      return Boolean(
+        `${String(result.stdout || '')}\n${String(result.stderr || '')}`.trim(),
+      );
+    } catch (error) {
+      const probed = error as NodeJS.ErrnoException & {
+        stdout?: unknown;
+        stderr?: unknown;
+      };
+      const text = [
+        probed.message,
+        String(probed.stdout || ''),
+        String(probed.stderr || ''),
+      ].join('\n');
+      // `defaults` uses exit 1 for a definitely absent domain/key. Any other
+      // failure is an uncertain enterprise boundary and must fail open.
+      return !/domain\/default pair .* does not exist/i.test(text);
+    }
+  })();
+  return macManagedConfigProbe;
+}
+
+async function hasManagedConfigLayer(env: NodeJS.ProcessEnv): Promise<boolean> {
+  const configDir = path.dirname(resolveCodexConfigPath(env));
+  const candidates = [path.join(configDir, 'managed_config.toml')];
+  if (process.platform !== 'win32') {
+    candidates.push('/etc/codex/managed_config.toml');
+  }
+  for (const candidate of candidates) {
+    const state = await pathState(candidate);
+    if (state !== 'missing') return true;
+  }
+  return hasMacManagedConfigPreference(env);
+}
+
+async function hasConfirmedChatGptAuth(
+  launchPath: string,
+  env: NodeJS.ProcessEnv,
+): Promise<boolean> {
+  try {
+    const result = await execAgentFile(launchPath, ['login', 'status'], {
+      env,
+      timeout: 3_000,
+    });
+    const output = `${String(result.stdout || '')}\n${String(result.stderr || '')}`;
+    return /\bLogged in using ChatGPT\b/i.test(output);
+  } catch {
+    return false;
+  }
+}
+
+export async function preflightCodexDefaultModel(
+  input: CodexModelPreflightInput,
+): Promise<CodexModelPreflightResult> {
+  const requestedModel = input.requestedModel?.trim() ?? '';
+  if (requestedModel && requestedModel !== 'default') {
+    return { status: 'not_applicable', reason: 'explicit_model' };
+  }
+  if (await projectConfigExists(input.projectRoot)) {
+    return { status: 'unknown', reason: 'project_config' };
+  }
+
+  let content: string;
+  try {
+    content = await readFile(resolveCodexConfigPath(input.env), 'utf8');
+  } catch {
+    return { status: 'unknown', reason: 'config_unavailable' };
+  }
+  const configured = extractCodexRootModelConfig(content);
+  if (!configured.model) {
+    return { status: 'not_applicable', reason: 'configured_model_missing' };
+  }
+  if (
+    configured.modelProvider
+    && configured.modelProvider.toLowerCase() !== 'openai'
+  ) {
+    return { status: 'not_applicable', reason: 'custom_provider' };
+  }
+  if (configured.hasCompatibilityOverlay) {
+    return { status: 'unknown', reason: 'config_overlay' };
+  }
+  if (hasAuthOrEndpointOverride(input.env)) {
+    return { status: 'unknown', reason: 'auth_override' };
+  }
+
+  const requirement = KNOWN_MODEL_REQUIREMENTS[configured.model];
+  if (!requirement) {
+    return { status: 'not_applicable', reason: 'no_known_requirement' };
+  }
+  const version = await probeVersion(input.launchPath, input.env);
+  if (!version?.stableVersion) {
+    return { status: 'unknown', reason: 'version_unavailable' };
+  }
+
+  if (compareVersions(version.stableVersion, requirement.minimum) >= 0) {
+    return {
+      status: 'compatible',
+      model: configured.model,
+      cliVersion: version.cliVersion,
+      requiredCliVersion: requirement.minimumLabel,
+    };
+  }
+
+  if (await hasManagedConfigLayer(input.env)) {
+    return { status: 'unknown', reason: 'managed_config' };
+  }
+
+  // The known incompatibility applies to the ChatGPT/Codex backend's client
+  // gate. API-key and custom-endpoint paths deliberately fail open above; for
+  // the remaining old-version case, require positive ChatGPT auth evidence
+  // before blocking the child process.
+  if (!await hasConfirmedChatGptAuth(input.launchPath, input.env)) {
+    return { status: 'unknown', reason: 'auth_unconfirmed' };
+  }
+  return {
+    status: 'incompatible',
+    model: configured.model,
+    cliVersion: version.cliVersion,
+    requiredCliVersion: requirement.minimumLabel,
+  };
+}

--- a/apps/daemon/src/runtimes/run-terminal-reconciliation.ts
+++ b/apps/daemon/src/runtimes/run-terminal-reconciliation.ts
@@ -39,6 +39,8 @@ interface DurableRunState {
   endedWithUnfinishedWork?: boolean;
   userPrompt?: string;
   model?: string;
+  resolvedModelId?: string;
+  preflightAgentCliVersion?: string;
   reasoning?: string;
   skillId?: string;
   designSystemId?: string;
@@ -142,6 +144,12 @@ function hydrateRun(state: DurableRunState, events: ReturnType<typeof readEvents
     events,
     ...(state.userPrompt !== undefined ? { userPrompt: state.userPrompt } : {}),
     ...(state.model !== undefined ? { model: state.model } : {}),
+    ...(state.resolvedModelId !== undefined
+      ? { resolvedModelId: state.resolvedModelId }
+      : {}),
+    ...(state.preflightAgentCliVersion !== undefined
+      ? { preflightAgentCliVersion: state.preflightAgentCliVersion }
+      : {}),
     ...(state.reasoning !== undefined ? { reasoning: state.reasoning } : {}),
     ...(state.skillId !== undefined ? { skillId: state.skillId } : {}),
     ...(state.designSystemId !== undefined ? { designSystemId: state.designSystemId } : {}),

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -45,6 +45,12 @@ function durableRunState(run) {
     endedWithUnfinishedWork: Boolean(run.endedWithUnfinishedWork),
     ...(typeof run.userPrompt === 'string' ? { userPrompt: run.userPrompt } : {}),
     ...(typeof run.model === 'string' ? { model: run.model } : {}),
+    ...(typeof run.resolvedModelId === 'string'
+      ? { resolvedModelId: run.resolvedModelId }
+      : {}),
+    ...(typeof run.preflightAgentCliVersion === 'string'
+      ? { preflightAgentCliVersion: run.preflightAgentCliVersion }
+      : {}),
     ...(typeof run.reasoning === 'string' ? { reasoning: run.reasoning } : {}),
     ...(typeof run.skillId === 'string' ? { skillId: run.skillId } : {}),
     ...(typeof run.designSystemId === 'string' ? { designSystemId: run.designSystemId } : {}),

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -206,6 +206,7 @@ import {
   resolveModelForServiceTier,
 } from './runtimes/models.js';
 import { loadMmdRouteLaunchEnv } from './runtimes/mmd-routes.js';
+import { preflightCodexDefaultModel } from './runtimes/codex-model-preflight.js';
 import { preparePromptFileForAgent } from './runtimes/prompt-file.js';
 import { TerminalControlSequenceStripper } from './runtimes/terminal-control.js';
 import {
@@ -1534,7 +1535,9 @@ export function createFinalizedMessageTelemetryReporter({
         ...(terminalResult ? { result: terminalResult } : {}),
         ...(run?.errorCode ? { error_code: run.errorCode } : {}),
         ...(run?.agentId ? { agent_provider_id: agentIdToTracking(run.agentId) } : {}),
-        ...(run?.model !== undefined ? { model_id: modelIdForTracking(run.model) } : {}),
+        ...(run?.model !== undefined || run?.resolvedModelId !== undefined
+          ? { model_id: modelIdForTracking(run.resolvedModelId ?? run.model) }
+          : {}),
       },
       insertId: `${runId}-langfuse-report-${reportTrigger}-${reportResult}${skipReason ? `-${skipReason}` : ''}`,
     });
@@ -5998,9 +6001,78 @@ export async function startServer({
       // in the normalizer while the child resolves it to the absolute path,
       // leaving the real config untouched. Mirrors the diagnostics-export.ts
       // `envFor('codex')` pattern. See issue #4276.
-      await normalizeCodexConfigFile(
-        spawnEnvForAgent('codex', process.env, configuredAgentEnv),
+      const codexConfigEnv = spawnEnvForAgent(
+        'codex',
+        process.env,
+        configuredAgentEnv,
+        undefined,
+        { resolvedBin: agentLaunch.selectedPath },
       );
+      await normalizeCodexConfigFile(codexConfigEnv);
+
+      // When Open Design leaves model selection at `default`, Codex resolves
+      // the concrete model from config.toml. A known-old CLI can accept the
+      // config, start `exec`, and only then reject a newer configured model.
+      // Gate only evidence-backed stable-version/model combinations before
+      // buildArgs/spawn. Every uncertain boundary (custom provider, API-key
+      // auth, config overlays, project config, unknown/prerelease version)
+      // fails open so Codex keeps its existing forward compatibility.
+      if (agentLaunch.launchPath) {
+        if (run.cancelRequested || design.runs.isTerminal(run.status)) {
+          lifecycle.mark('launch_preflight_end');
+          cleanupPromptFile();
+          return;
+        }
+        const preflight = await preflightCodexDefaultModel({
+          launchPath: agentLaunch.launchPath,
+          env: applyAgentLaunchEnv(codexConfigEnv, agentLaunch),
+          requestedModel: safeModel,
+          projectRoot: effectiveCwd,
+        });
+        if (run.cancelRequested || design.runs.isTerminal(run.status)) {
+          lifecycle.mark('launch_preflight_end');
+          cleanupPromptFile();
+          return;
+        }
+        if (preflight.status === 'compatible' || preflight.status === 'incompatible') {
+          run.resolvedModelId = preflight.model;
+          run.preflightAgentCliVersion = preflight.cliVersion;
+        }
+        if (preflight.status === 'incompatible') {
+          lifecycle.mark('launch_preflight_end');
+          const message =
+            `The '${preflight.model}' model requires a newer version of Codex. ` +
+            `The installed Codex CLI (${preflight.cliVersion}) is older than the known-compatible ` +
+            `minimum (${preflight.requiredCliVersion}). ` +
+            'Upgrade the Codex CLI or choose a model supported by this installation, then retry.';
+          design.runs.emit(run, 'diagnostic', {
+            type: 'model_capability_preflight',
+            status: 'incompatible',
+            model: preflight.model,
+            cli_version: preflight.cliVersion,
+            required_cli_version: preflight.requiredCliVersion,
+          });
+          send('error', createSseErrorPayload(
+            'AGENT_EXECUTION_FAILED',
+            message,
+            {
+              retryable: false,
+              details: {
+                failureCategory: 'model_unavailable',
+                failureDetail: 'cli_version_incompatible',
+                model: preflight.model,
+                requiredCliVersion: preflight.requiredCliVersion,
+              },
+            },
+          ));
+          cleanupPromptFile();
+          // No child was spawned, so there is no process exit code to report.
+          // Passing null preserves the preflight attribution instead of
+          // polluting exit_nonzero transport metrics with a synthetic exit 1.
+          finishWithRetryDecision('failed', null, null);
+          return;
+        }
+      }
     }
 
     // Serialize antigravity spawns whose buildArgs writes a concrete

--- a/apps/daemon/tests/codex-model-capability-preflight.test.ts
+++ b/apps/daemon/tests/codex-model-capability-preflight.test.ts
@@ -23,6 +23,28 @@ type RunStatus = {
   failureDetail?: string | null;
 };
 
+const CODEX_AUTH_OR_ENDPOINT_ENV_KEYS = [
+  'OPENAI_API_KEY',
+  'OPENAI_BASE_URL',
+  'OPENAI_API_BASE',
+  'CODEX_API_KEY',
+] as const;
+
+const EXTERNAL_ENV_KEYS = [
+  'LANGFUSE_PUBLIC_KEY',
+  'LANGFUSE_SECRET_KEY',
+  'LANGFUSE_BASE_URL',
+  'OPEN_DESIGN_TELEMETRY_RELAY_URL',
+  'POSTHOG_KEY',
+  'POSTHOG_HOST',
+  ...CODEX_AUTH_OR_ENDPOINT_ENV_KEYS,
+] as const;
+
+type EnvSnapshot = {
+  keys: readonly string[];
+  entries: Array<[string, string]>;
+};
+
 describe('Codex configured-model capability preflight', () => {
   const originalEnv = snapshotEnv();
   let started: StartedServer | null = null;
@@ -53,7 +75,10 @@ describe('Codex configured-model capability preflight', () => {
       'utf8',
     );
 
-    disableExternalTelemetry();
+    // Exercise the host-dependent case explicitly: the suite must remove even
+    // mixed-case inherited keys before starting the server.
+    process.env.OpenAI_Api_Key = 'ambient-test-only';
+    isolateExternalProcessEnv();
     started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
     await putConfig(started.url, {
       agentId: 'codex',
@@ -90,7 +115,7 @@ describe('Codex configured-model capability preflight', () => {
       'utf8',
     );
 
-    disableExternalTelemetry();
+    isolateExternalProcessEnv();
     started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
     await putConfig(started.url, {
       agentId: 'codex',
@@ -127,7 +152,7 @@ describe('Codex configured-model capability preflight', () => {
       'utf8',
     );
 
-    disableExternalTelemetry();
+    isolateExternalProcessEnv();
     started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
     await putConfig(started.url, {
       agentId: 'codex',
@@ -163,31 +188,35 @@ describe('Codex configured-model capability preflight', () => {
   });
 });
 
-function snapshotEnv(): Record<string, string | undefined> {
+function snapshotEnv(): EnvSnapshot {
   return {
-    LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
-    LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
-    LANGFUSE_BASE_URL: process.env.LANGFUSE_BASE_URL,
-    OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
-    POSTHOG_KEY: process.env.POSTHOG_KEY,
-    POSTHOG_HOST: process.env.POSTHOG_HOST,
+    keys: EXTERNAL_ENV_KEYS,
+    entries: Object.entries(process.env).filter(
+      (entry): entry is [string, string] =>
+        typeof entry[1] === 'string'
+        && EXTERNAL_ENV_KEYS.some(
+          (expected) => entry[0].toUpperCase() === expected,
+        ),
+    ),
   };
 }
 
-function restoreEnv(env: Record<string, string | undefined>): void {
-  for (const [key, value] of Object.entries(env)) {
-    if (value === undefined) delete process.env[key];
-    else process.env[key] = value;
+function deleteEnvKeysCaseInsensitive(keys: readonly string[]): void {
+  const normalized = new Set(keys.map((key) => key.toUpperCase()));
+  for (const key of Object.keys(process.env)) {
+    if (normalized.has(key.toUpperCase())) delete process.env[key];
   }
 }
 
-function disableExternalTelemetry(): void {
-  delete process.env.POSTHOG_KEY;
-  delete process.env.POSTHOG_HOST;
-  delete process.env.LANGFUSE_PUBLIC_KEY;
-  delete process.env.LANGFUSE_SECRET_KEY;
-  delete process.env.LANGFUSE_BASE_URL;
-  delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+function restoreEnv(snapshot: EnvSnapshot): void {
+  deleteEnvKeysCaseInsensitive(snapshot.keys);
+  for (const [key, value] of snapshot.entries) {
+    process.env[key] = value;
+  }
+}
+
+function isolateExternalProcessEnv(): void {
+  deleteEnvKeysCaseInsensitive(EXTERNAL_ENV_KEYS);
 }
 
 async function writeFakeCodex(
@@ -274,10 +303,6 @@ function codexTestEnv(fakeCodex: string, codexHome: string): Record<string, stri
   return {
     CODEX_BIN: fakeCodex,
     CODEX_HOME: codexHome,
-    OPENAI_API_KEY: '',
-    OPENAI_BASE_URL: '',
-    OPENAI_API_BASE: '',
-    CODEX_API_KEY: '',
   };
 }
 

--- a/apps/daemon/tests/codex-model-capability-preflight.test.ts
+++ b/apps/daemon/tests/codex-model-capability-preflight.test.ts
@@ -1,0 +1,370 @@
+import type { Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { access, chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { startServer } from '../src/server.js';
+
+type StartedServer = {
+  url: string;
+  server: Server;
+  shutdown?: () => Promise<void> | void;
+};
+
+type RunStatus = {
+  id: string;
+  status: string;
+  error: string | null;
+  errorCode: string | null;
+  exitCode?: number | null;
+  failureCategory?: string | null;
+  failureDetail?: string | null;
+};
+
+describe('Codex configured-model capability preflight', () => {
+  const originalEnv = snapshotEnv();
+  let started: StartedServer | null = null;
+  let tempDir: string | null = null;
+
+  afterEach(async () => {
+    await Promise.resolve(started?.shutdown?.());
+    if (started?.server) {
+      await new Promise<void>((resolve) => started?.server.close(() => resolve()));
+    }
+    started = null;
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+    }
+    tempDir = null;
+    restoreEnv(originalEnv);
+  });
+
+  it('blocks an unsupported configured default model before spawning Codex exec', async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'od-codex-model-preflight-'));
+    const codexHome = path.join(tempDir, 'codex-home');
+    const spawnMarker = path.join(tempDir, 'codex-exec-spawned');
+    const fakeCodex = await writeFakeCodex(tempDir, spawnMarker);
+    await mkdir(codexHome, { recursive: true });
+    await writeFile(
+      path.join(codexHome, 'config.toml'),
+      'model = "gpt-5.6-terra"\n',
+      'utf8',
+    );
+
+    disableExternalTelemetry();
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'codex',
+      agentCliEnv: {
+        codex: codexTestEnv(fakeCodex, codexHome),
+      },
+      telemetry: { metrics: false, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const { projectId, conversationId } = await createConversation(started.url);
+    const failed = await sendRunAndWait(started.url, projectId, conversationId);
+
+    expect(failed.status).toBe('failed');
+    expect(failed.errorCode).toBe('AGENT_EXECUTION_FAILED');
+    expect(failed.failureCategory).toBe('model_unavailable');
+    expect(failed.failureDetail).toBe('cli_version_incompatible');
+    expect(failed.exitCode).toBeNull();
+    await expect(pathExists(spawnMarker)).resolves.toBe(false);
+  });
+
+  it('continues to Codex exec at the known-compatible version without consulting a model catalog', async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'od-codex-model-compatible-'));
+    const codexHome = path.join(tempDir, 'codex-home');
+    const spawnMarker = path.join(tempDir, 'codex-exec-spawned');
+    const fakeCodex = await writeFakeCodex(tempDir, spawnMarker, {
+      version: 'codex-cli 0.143.0',
+      spawnSucceeds: true,
+    });
+    await mkdir(codexHome, { recursive: true });
+    await writeFile(
+      path.join(codexHome, 'config.toml'),
+      'model = "gpt-5.6-terra"\n',
+      'utf8',
+    );
+
+    disableExternalTelemetry();
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'codex',
+      agentCliEnv: {
+        codex: codexTestEnv(fakeCodex, codexHome),
+      },
+      telemetry: { metrics: false, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const { projectId, conversationId } = await createConversation(started.url);
+    const finished = await sendRunAndWait(started.url, projectId, conversationId);
+
+    expect(finished.status).toBe('succeeded');
+    await expect(pathExists(spawnMarker)).resolves.toBe(true);
+  });
+
+  it('does not overwrite cancellation while the version probe is in flight', async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'od-codex-model-cancel-'));
+    const codexHome = path.join(tempDir, 'codex-home');
+    const spawnMarker = path.join(tempDir, 'codex-exec-spawned');
+    const probeMarker = path.join(tempDir, 'codex-version-probed');
+    const loginProbeMarker = path.join(tempDir, 'codex-login-probed');
+    const fakeCodex = await writeFakeCodex(tempDir, spawnMarker, {
+      version: 'codex-cli 0.142.5',
+      versionDelayMs: 750,
+      versionProbeMarker: probeMarker,
+      loginProbeMarker,
+    });
+    await mkdir(codexHome, { recursive: true });
+    await writeFile(
+      path.join(codexHome, 'config.toml'),
+      'model = "gpt-5.6-terra"\n',
+      'utf8',
+    );
+
+    disableExternalTelemetry();
+    started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'codex',
+      agentCliEnv: {
+        codex: codexTestEnv(fakeCodex, codexHome),
+      },
+      telemetry: { metrics: false, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const { projectId, conversationId } = await createConversation(started.url);
+    const runId = await startRun(started.url, projectId, conversationId);
+    await waitForPath(probeMarker);
+    const cancel = await fetch(
+      `${started.url}/api/runs/${encodeURIComponent(runId)}/cancel`,
+      { method: 'POST' },
+    );
+    expect(cancel.status).toBe(200);
+
+    await waitForPath(loginProbeMarker);
+    // The login marker is written just before the auth probe exits. Give the
+    // awaiting preflight continuation time to run, then read status again so
+    // this catches any late error emission after cancellation.
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    const canceled = await getRun(started.url, runId);
+    expect(canceled.status).toBe('canceled');
+    expect(canceled.error).toBeNull();
+    expect(canceled.errorCode).toBeNull();
+    expect(canceled.failureCategory).toBeNull();
+    expect(canceled.failureDetail).toBeNull();
+    expect(canceled.exitCode).toBeNull();
+    await expect(pathExists(spawnMarker)).resolves.toBe(false);
+  });
+});
+
+function snapshotEnv(): Record<string, string | undefined> {
+  return {
+    LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
+    LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
+    LANGFUSE_BASE_URL: process.env.LANGFUSE_BASE_URL,
+    OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
+    POSTHOG_KEY: process.env.POSTHOG_KEY,
+    POSTHOG_HOST: process.env.POSTHOG_HOST,
+  };
+}
+
+function restoreEnv(env: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+function disableExternalTelemetry(): void {
+  delete process.env.POSTHOG_KEY;
+  delete process.env.POSTHOG_HOST;
+  delete process.env.LANGFUSE_PUBLIC_KEY;
+  delete process.env.LANGFUSE_SECRET_KEY;
+  delete process.env.LANGFUSE_BASE_URL;
+  delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+}
+
+async function writeFakeCodex(
+  dir: string,
+  spawnMarker: string,
+  options: {
+    version?: string;
+    versionDelayMs?: number;
+    versionProbeMarker?: string;
+    loginProbeMarker?: string;
+    spawnSucceeds?: boolean;
+  } = {},
+): Promise<string> {
+  const script = path.join(dir, 'fake-codex.cjs');
+  await writeFile(
+    script,
+    `
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+if (args.includes('--version')) {
+  ${options.versionProbeMarker
+    ? `fs.writeFileSync(${JSON.stringify(options.versionProbeMarker)}, '1');`
+    : ''}
+  setTimeout(() => {
+    console.log(${JSON.stringify(options.version ?? 'codex-cli 0.142.5')});
+    process.exit(0);
+  }, ${JSON.stringify(options.versionDelayMs ?? 0)});
+} else if (args[0] === 'login' && args[1] === 'status') {
+  ${options.loginProbeMarker
+    ? `fs.writeFileSync(${JSON.stringify(options.loginProbeMarker)}, '1');`
+    : ''}
+  console.log('Logged in using ChatGPT');
+  process.exit(0);
+} else {
+  fs.writeFileSync(${JSON.stringify(spawnMarker)}, JSON.stringify(args));
+  if (${JSON.stringify(options.spawnSucceeds === true)}) {
+    console.log(JSON.stringify({ type: 'thread.started', thread_id: '019f-test-preflight-compatible' }));
+    console.log(JSON.stringify({ type: 'turn.started' }));
+    console.log(JSON.stringify({
+      type: 'item.completed',
+      item: { id: 'item-1', type: 'agent_message', text: 'Compatible model reply.' },
+    }));
+    console.log(JSON.stringify({
+      type: 'turn.completed',
+      usage: { input_tokens: 10, cached_input_tokens: 0, output_tokens: 3 },
+    }));
+    setTimeout(() => process.exit(0), 20);
+  } else {
+    process.stderr.write("The 'gpt-5.6-terra' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again.\\n");
+    process.exit(1);
+  }
+}
+`,
+    'utf8',
+  );
+  const bin = path.join(dir, process.platform === 'win32' ? 'codex-old.cmd' : 'codex-old');
+  if (process.platform === 'win32') {
+    await writeFile(
+      bin,
+      `@echo off\r\n"${process.execPath}" "${script}" %*\r\nexit /b %ERRORLEVEL%\r\n`,
+      'utf8',
+    );
+  } else {
+    await writeFile(
+      bin,
+      `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(script)} "$@"\n`,
+      'utf8',
+    );
+    await chmod(bin, 0o755);
+  }
+  return bin;
+}
+
+async function putConfig(url: string, patch: Record<string, unknown>): Promise<void> {
+  const response = await fetch(`${url}/api/app-config`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  expect(response.status).toBe(200);
+}
+
+function codexTestEnv(fakeCodex: string, codexHome: string): Record<string, string> {
+  return {
+    CODEX_BIN: fakeCodex,
+    CODEX_HOME: codexHome,
+    OPENAI_API_KEY: '',
+    OPENAI_BASE_URL: '',
+    OPENAI_API_BASE: '',
+    CODEX_API_KEY: '',
+  };
+}
+
+async function createConversation(
+  url: string,
+): Promise<{ projectId: string; conversationId: string }> {
+  const projectId = `codex_preflight_${randomUUID()}`;
+  const projectResponse = await fetch(`${url}/api/projects`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      id: projectId,
+      name: 'Codex model capability preflight',
+      metadata: { kind: 'prototype' },
+      skipDiscoveryBrief: true,
+    }),
+  });
+  expect(projectResponse.status).toBe(200);
+  const body = (await projectResponse.json()) as { conversationId: string };
+  return { projectId, conversationId: body.conversationId };
+}
+
+async function sendRunAndWait(
+  url: string,
+  projectId: string,
+  conversationId: string,
+): Promise<RunStatus> {
+  const runId = await startRun(url, projectId, conversationId);
+  return await waitForRun(url, runId);
+}
+
+async function startRun(
+  url: string,
+  projectId: string,
+  conversationId: string,
+): Promise<string> {
+  const response = await fetch(`${url}/api/runs`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      projectId,
+      conversationId,
+      assistantMessageId: `assistant_codex_preflight_${randomUUID()}`,
+      clientRequestId: `client_codex_preflight_${randomUUID()}`,
+      agentId: 'codex',
+      model: 'default',
+      message: 'Create a small text artifact.',
+      currentPrompt: 'Create a small text artifact.',
+    }),
+  });
+  expect(response.status).toBe(202);
+  const body = (await response.json()) as { runId: string };
+  return body.runId;
+}
+
+async function waitForRun(url: string, runId: string): Promise<RunStatus> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 10_000) {
+    const run = await getRun(url, runId);
+    if (run.status === 'failed' || run.status === 'succeeded' || run.status === 'canceled') {
+      return run;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`run ${runId} did not finish`);
+}
+
+async function getRun(url: string, runId: string): Promise<RunStatus> {
+  const response = await fetch(`${url}/api/runs/${encodeURIComponent(runId)}`);
+  expect(response.status).toBe(200);
+  return (await response.json()) as RunStatus;
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForPath(filePath: string): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 5_000) {
+    if (await pathExists(filePath)) return;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`path did not appear: ${filePath}`);
+}

--- a/apps/daemon/tests/codex-session-resume.test.ts
+++ b/apps/daemon/tests/codex-session-resume.test.ts
@@ -84,7 +84,7 @@ describe('codex native session resume', () => {
     started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
     await putConfig(started.url, {
       agentId: 'codex',
-      agentCliEnv: { codex: { CODEX_BIN: bin } },
+      agentCliEnv: { codex: { CODEX_BIN: bin, CODEX_HOME: binDir } },
       telemetry: { metrics: true, content: false, artifactManifest: false },
       privacyDecisionAt: Date.now(),
     });
@@ -131,7 +131,7 @@ describe('codex native session resume', () => {
     started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
     await putConfig(started.url, {
       agentId: 'codex',
-      agentCliEnv: { codex: { CODEX_BIN: bin } },
+      agentCliEnv: { codex: { CODEX_BIN: bin, CODEX_HOME: binDir } },
       telemetry: { metrics: true, content: false, artifactManifest: false },
       privacyDecisionAt: Date.now(),
     });
@@ -179,7 +179,7 @@ describe('codex native session resume', () => {
     started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
     await putConfig(started.url, {
       agentId: 'codex',
-      agentCliEnv: { codex: { CODEX_BIN: bin } },
+      agentCliEnv: { codex: { CODEX_BIN: bin, CODEX_HOME: binDir } },
       telemetry: { metrics: true, content: false, artifactManifest: false },
       privacyDecisionAt: Date.now(),
     });
@@ -208,7 +208,10 @@ describe('codex native session resume', () => {
     started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
     await putConfig(started.url, {
       agentId: 'codex',
-      agentCliEnv: { codex: { CODEX_BIN: bin }, claude: { CLAUDE_BIN: claudeBin } },
+      agentCliEnv: {
+        codex: { CODEX_BIN: bin, CODEX_HOME: binDir },
+        claude: { CLAUDE_BIN: claudeBin },
+      },
       telemetry: { metrics: true, content: false, artifactManifest: false },
       privacyDecisionAt: Date.now(),
     });
@@ -256,7 +259,7 @@ describe('codex native session resume', () => {
     started = (await startServer({ port: 0, returnServer: true })) as StartedServer;
     await putConfig(started.url, {
       agentId: 'codex',
-      agentCliEnv: { codex: { CODEX_BIN: bin } },
+      agentCliEnv: { codex: { CODEX_BIN: bin, CODEX_HOME: binDir } },
       telemetry: { metrics: true, content: false, artifactManifest: false },
       privacyDecisionAt: Date.now(),
     });

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -1546,6 +1546,43 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     expect(generation.model).toBe('claude-opus-4-1');
   });
 
+  it('labels a preflight failure with its resolved model and CLI version', async () => {
+    await writeAppCfg({
+      installationId: 'install-uuid-preflight',
+      telemetry: { metrics: true, content: true, artifactManifest: false },
+    });
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(new Response('{}', { status: 207 }));
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk';
+    process.env.LANGFUSE_SECRET_KEY = 'sk';
+    try {
+      await reportRunCompletedFromDaemon({
+        db: makeDbWithListMessages({ 'conv-1': [] }),
+        dataDir,
+        run: makeRun({
+          agentId: 'codex',
+          model: 'default',
+          resolvedModelId: 'gpt-5.6-terra',
+          preflightAgentCliVersion: 'codex-cli 0.142.5',
+        }) as any,
+        fetchImpl: fetchSpy as any,
+      });
+    } finally {
+      delete process.env.LANGFUSE_PUBLIC_KEY;
+      delete process.env.LANGFUSE_SECRET_KEY;
+    }
+    const init = fetchSpy.mock.calls[0]![1] as RequestInit;
+    const batch = JSON.parse(init.body as string).batch as any[];
+    const trace = batch[0].body;
+    const generation = bodyOf(batch, 'generation-create', 'llm');
+
+    expect(trace.metadata.model).toBe('gpt-5.6-terra');
+    expect(trace.metadata.agentCliVersion).toBe('codex-cli 0.142.5');
+    expect(trace.tags).toEqual(expect.arrayContaining(['model:gpt-5.6-terra']));
+    expect(generation.model).toBe('gpt-5.6-terra');
+  });
+
   it('forwards token usage for a totalTokens-only usage event', async () => {
     await writeAppCfg({
       installationId: 'install-uuid-3',

--- a/apps/daemon/tests/run-failure-classification.test.ts
+++ b/apps/daemon/tests/run-failure-classification.test.ts
@@ -902,6 +902,34 @@ describe('classifyRunFailure — signal and interrupt attribution', () => {
     });
 
     expect(
+      classify(
+        'AGENT_EXECUTION_FAILED',
+        "The 'gpt-5.6-terra' model requires a newer version of Codex.",
+        [
+          {
+            event: 'diagnostic',
+            data: {
+              type: 'model_capability_preflight',
+              status: 'incompatible',
+              model: 'gpt-5.6-terra',
+            },
+          },
+          errorEvent(
+            'AGENT_EXECUTION_FAILED',
+            "The 'gpt-5.6-terra' model requires a newer version of Codex.",
+            false,
+          ),
+        ],
+      ),
+    ).toMatchObject({
+      failure_category: 'model_unavailable',
+      failure_detail: 'cli_version_incompatible',
+      failure_stage: 'preflight',
+      retryable: false,
+      user_action: 'switch_model',
+    });
+
+    expect(
       classify(null, 'Selected model is at capacity. Please try a different model.'),
     ).toMatchObject({
       failure_category: 'upstream_unavailable',

--- a/apps/daemon/tests/runtimes/codex-model-preflight.test.ts
+++ b/apps/daemon/tests/runtimes/codex-model-preflight.test.ts
@@ -1,0 +1,399 @@
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  extractCodexRootModelConfig,
+  parseStableCodexVersion,
+  preflightCodexDefaultModel,
+} from '../../src/runtimes/codex-model-preflight.js';
+
+describe('Codex model capability preflight', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.splice(0).map((dir) =>
+        rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 }),
+      ),
+    );
+  });
+
+  it('reads only root model settings and detects compatibility overlays', () => {
+    expect(
+      extractCodexRootModelConfig([
+        'model = "gpt-5.6-terra" # active model',
+        'model_provider = "openai"',
+        'profile = "work"',
+        'notes = "value # not a comment"',
+        '[profiles.other]',
+        'model = "gpt-5.4"',
+      ].join('\n')),
+    ).toEqual({
+      model: 'gpt-5.6-terra',
+      modelProvider: 'openai',
+      hasCompatibilityOverlay: true,
+    });
+
+    expect(
+      extractCodexRootModelConfig([
+        'model = "gpt-5.6-terra"',
+        'project_root_markers = [".hg", ".git"]',
+      ].join('\n')).hasCompatibilityOverlay,
+    ).toBe(true);
+
+    expect(
+      extractCodexRootModelConfig([
+        'model = "gpt-5.6-terra"',
+        '[model_providers.openai]',
+        'base_url = "https://example.invalid/v1"',
+      ].join('\n')).hasCompatibilityOverlay,
+    ).toBe(true);
+
+    expect(
+      extractCodexRootModelConfig([
+        '"model" = "gpt-5.6-terra"',
+        '"chatgpt_base_url" = "https://chatgpt-proxy.example.invalid/backend-api/"',
+      ].join('\n')),
+    ).toEqual({
+      model: 'gpt-5.6-terra',
+      modelProvider: null,
+      hasCompatibilityOverlay: true,
+    });
+  });
+
+  it('accepts only stable Codex versions for the known boundary', () => {
+    expect(parseStableCodexVersion('codex-cli 0.142.5')).toEqual({
+      major: 0,
+      minor: 142,
+      patch: 5,
+    });
+    expect(parseStableCodexVersion('codex-cli 0.145.0-alpha.30')).toBeNull();
+    expect(parseStableCodexVersion('codex-cli unknown')).toBeNull();
+  });
+
+  it('blocks the known-old stable CLI only with confirmed ChatGPT auth', async () => {
+    const fixture = await createFixture({
+      config: 'model = "gpt-5.6-terra"\n',
+      version: 'codex-cli 0.142.5',
+      loginStatus: 'Logged in using ChatGPT',
+    });
+
+    await expect(preflightCodexDefaultModel({
+      launchPath: fixture.bin,
+      env: cleanCodexEnv(fixture.codexHome),
+      requestedModel: 'default',
+      projectRoot: fixture.projectRoot,
+    })).resolves.toEqual({
+      status: 'incompatible',
+      model: 'gpt-5.6-terra',
+      cliVersion: 'codex-cli 0.142.5',
+      requiredCliVersion: '0.143.0',
+    });
+  });
+
+  it('allows 0.143.0 even when no model catalog command exists', async () => {
+    const fixture = await createFixture({
+      config: 'model = "gpt-5.6-terra"\n',
+      version: 'codex-cli 0.143.0',
+    });
+
+    await expect(preflightCodexDefaultModel({
+      launchPath: fixture.bin,
+      env: cleanCodexEnv(fixture.codexHome),
+      requestedModel: null,
+      projectRoot: fixture.projectRoot,
+    })).resolves.toEqual({
+      status: 'compatible',
+      model: 'gpt-5.6-terra',
+      cliVersion: 'codex-cli 0.143.0',
+      requiredCliVersion: '0.143.0',
+    });
+  });
+
+  it('fails open for explicit models, custom providers, and project config', async () => {
+    await expect(preflightCodexDefaultModel({
+      launchPath: '/path/that/does/not/exist',
+      env: {},
+      requestedModel: 'future-custom-model',
+    })).resolves.toEqual({
+      status: 'not_applicable',
+      reason: 'explicit_model',
+    });
+
+    const customProvider = await createFixture({
+      config: [
+        'model = "deployment-name"',
+        'model_provider = "azure"',
+      ].join('\n'),
+    });
+    await expect(preflightCodexDefaultModel({
+      launchPath: customProvider.bin,
+      env: cleanCodexEnv(customProvider.codexHome),
+      requestedModel: 'default',
+      projectRoot: customProvider.projectRoot,
+    })).resolves.toEqual({
+      status: 'not_applicable',
+      reason: 'custom_provider',
+    });
+
+    const projectConfig = await createFixture({
+      config: 'model = "gpt-5.6-terra"\n',
+    });
+    await mkdir(path.join(projectConfig.projectRoot, '.codex'), { recursive: true });
+    await writeFile(
+      path.join(projectConfig.projectRoot, '.codex', 'config.toml'),
+      'model = "project-model"\n',
+      'utf8',
+    );
+    await expect(preflightCodexDefaultModel({
+      launchPath: projectConfig.bin,
+      env: cleanCodexEnv(projectConfig.codexHome),
+      requestedModel: 'default',
+      projectRoot: projectConfig.projectRoot,
+    })).resolves.toEqual({
+      status: 'unknown',
+      reason: 'project_config',
+    });
+
+    const parentProjectConfig = await createFixture({
+      config: 'model = "gpt-5.6-terra"\n',
+    });
+    const nestedCwd = path.join(parentProjectConfig.projectRoot, 'packages', 'app');
+    await Promise.all([
+      mkdir(path.join(parentProjectConfig.projectRoot, '.git'), { recursive: true }),
+      mkdir(path.join(parentProjectConfig.projectRoot, '.codex'), { recursive: true }),
+      mkdir(nestedCwd, { recursive: true }),
+    ]);
+    await writeFile(
+      path.join(parentProjectConfig.projectRoot, '.codex', 'config.toml'),
+      'model = "project-model"\n',
+      'utf8',
+    );
+    await expect(preflightCodexDefaultModel({
+      launchPath: parentProjectConfig.bin,
+      env: cleanCodexEnv(parentProjectConfig.codexHome),
+      requestedModel: 'default',
+      projectRoot: nestedCwd,
+    })).resolves.toEqual({
+      status: 'unknown',
+      reason: 'project_config',
+    });
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'resolves a symlinked project cwd before checking project config',
+    async () => {
+      const fixture = await createFixture({
+        config: 'model = "gpt-5.6-terra"\n',
+      });
+      await Promise.all([
+        mkdir(path.join(fixture.projectRoot, '.git'), { recursive: true }),
+        mkdir(path.join(fixture.projectRoot, '.codex'), { recursive: true }),
+      ]);
+      await writeFile(
+        path.join(fixture.projectRoot, '.codex', 'config.toml'),
+        'model = "project-model"\n',
+        'utf8',
+      );
+      const linkedProject = path.join(path.dirname(fixture.projectRoot), 'project-link');
+      await symlink(fixture.projectRoot, linkedProject, 'dir');
+
+      await expect(preflightCodexDefaultModel({
+        launchPath: fixture.bin,
+        env: cleanCodexEnv(fixture.codexHome),
+        requestedModel: 'default',
+        projectRoot: linkedProject,
+      })).resolves.toEqual({
+        status: 'unknown',
+        reason: 'project_config',
+      });
+    },
+  );
+
+  it('fails open for config overlays, API auth, and unconfirmed ChatGPT auth', async () => {
+    const overlay = await createFixture({
+      config: [
+        'model = "gpt-5.6-terra"',
+        'openai_base_url = "https://example.invalid/v1"',
+      ].join('\n'),
+    });
+    await expect(preflightCodexDefaultModel({
+      launchPath: overlay.bin,
+      env: cleanCodexEnv(overlay.codexHome),
+      requestedModel: 'default',
+      projectRoot: overlay.projectRoot,
+    })).resolves.toEqual({
+      status: 'unknown',
+      reason: 'config_overlay',
+    });
+
+    const apiAuth = await createFixture({
+      config: 'model = "gpt-5.6-terra"\n',
+    });
+    await expect(preflightCodexDefaultModel({
+      launchPath: apiAuth.bin,
+      env: {
+        ...cleanCodexEnv(apiAuth.codexHome),
+        OpenAI_Api_Key: 'test-only-key',
+      },
+      requestedModel: 'default',
+      projectRoot: apiAuth.projectRoot,
+    })).resolves.toEqual({
+      status: 'unknown',
+      reason: 'auth_override',
+    });
+
+    const noChatGpt = await createFixture({
+      config: 'model = "gpt-5.6-terra"\n',
+      version: 'codex-cli 0.142.5',
+      loginStatus: 'Not logged in',
+    });
+    await expect(preflightCodexDefaultModel({
+      launchPath: noChatGpt.bin,
+      env: cleanCodexEnv(noChatGpt.codexHome),
+      requestedModel: 'default',
+      projectRoot: noChatGpt.projectRoot,
+    })).resolves.toEqual({
+      status: 'unknown',
+      reason: 'auth_unconfirmed',
+    });
+
+    const managed = await createFixture({
+      config: 'model = "gpt-5.6-terra"\n',
+      version: 'codex-cli 0.142.5',
+    });
+    await writeFile(
+      path.join(managed.codexHome, 'managed_config.toml'),
+      'model = "managed-model"\n',
+      'utf8',
+    );
+    await expect(preflightCodexDefaultModel({
+      launchPath: managed.bin,
+      env: cleanCodexEnv(managed.codexHome),
+      requestedModel: 'default',
+      projectRoot: managed.projectRoot,
+    })).resolves.toEqual({
+      status: 'unknown',
+      reason: 'managed_config',
+    });
+  });
+
+  it('fails open for prerelease versions and models without a known requirement', async () => {
+    const prerelease = await createFixture({
+      config: 'model = "gpt-5.6-terra"\n',
+      version: 'codex-cli 0.145.0-alpha.30',
+    });
+    const prereleaseInput = {
+      launchPath: prerelease.bin,
+      env: cleanCodexEnv(prerelease.codexHome),
+      requestedModel: 'default',
+      projectRoot: prerelease.projectRoot,
+    } as const;
+    await expect(preflightCodexDefaultModel(prereleaseInput)).resolves.toEqual({
+      status: 'unknown',
+      reason: 'version_unavailable',
+    });
+    await expect(preflightCodexDefaultModel(prereleaseInput)).resolves.toEqual({
+      status: 'unknown',
+      reason: 'version_unavailable',
+    });
+    expect(
+      (await readFile(prerelease.versionProbeCount, 'utf8'))
+        .trim()
+        .split(/\r?\n/),
+    ).toHaveLength(1);
+
+    const futureModel = await createFixture({
+      config: 'model = "future-model"\n',
+      version: 'codex-cli 0.142.5',
+    });
+    await expect(preflightCodexDefaultModel({
+      launchPath: futureModel.bin,
+      env: cleanCodexEnv(futureModel.codexHome),
+      requestedModel: 'default',
+      projectRoot: futureModel.projectRoot,
+    })).resolves.toEqual({
+      status: 'not_applicable',
+      reason: 'no_known_requirement',
+    });
+  });
+
+  function cleanCodexEnv(codexHome: string): NodeJS.ProcessEnv {
+    const {
+      OPENAI_API_KEY: _openAiApiKey,
+      OPENAI_BASE_URL: _openAiBaseUrl,
+      OPENAI_API_BASE: _openAiApiBase,
+      CODEX_API_KEY: _codexApiKey,
+      ...env
+    } = process.env;
+    return { ...env, CODEX_HOME: codexHome };
+  }
+
+  async function createFixture(input: {
+    config: string;
+    version?: string;
+    loginStatus?: string;
+  }): Promise<{
+    bin: string;
+    codexHome: string;
+    projectRoot: string;
+    versionProbeCount: string;
+  }> {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'od-codex-preflight-unit-'));
+    tempDirs.push(dir);
+    const codexHome = path.join(dir, 'codex-home');
+    const projectRoot = path.join(dir, 'project');
+    await Promise.all([
+      mkdir(codexHome, { recursive: true }),
+      mkdir(projectRoot, { recursive: true }),
+    ]);
+    await writeFile(path.join(codexHome, 'config.toml'), input.config, 'utf8');
+
+    const script = path.join(dir, 'fake-codex.cjs');
+    const versionProbeCount = path.join(dir, 'version-probes.txt');
+    await writeFile(
+      script,
+      `
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+if (args.includes('--version')) {
+  fs.appendFileSync(${JSON.stringify(versionProbeCount)}, '1\\n');
+  console.log(${JSON.stringify(input.version ?? 'codex-cli 0.143.0')});
+  process.exit(0);
+}
+if (args[0] === 'login' && args[1] === 'status') {
+  console.log(${JSON.stringify(input.loginStatus ?? 'Logged in using ChatGPT')});
+  process.exit(0);
+}
+process.exit(2);
+`,
+      'utf8',
+    );
+    const bin = path.join(dir, process.platform === 'win32' ? 'codex.cmd' : 'codex');
+    if (process.platform === 'win32') {
+      await writeFile(
+        bin,
+        `@echo off\r\n"${process.execPath}" "${script}" %*\r\nexit /b %ERRORLEVEL%\r\n`,
+        'utf8',
+      );
+    } else {
+      await writeFile(
+        bin,
+        `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(script)} "$@"\n`,
+        'utf8',
+      );
+      await chmod(bin, 0o755);
+    }
+    return { bin, codexHome, projectRoot, versionProbeCount };
+  }
+});

--- a/apps/daemon/tests/runtimes/codex-model-preflight.test.ts
+++ b/apps/daemon/tests/runtimes/codex-model-preflight.test.ts
@@ -9,7 +9,7 @@ import {
 } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   extractCodexRootModelConfig,
@@ -17,10 +17,24 @@ import {
   preflightCodexDefaultModel,
 } from '../../src/runtimes/codex-model-preflight.js';
 
+const { statPathFixtures } = vi.hoisted(() => ({
+  statPathFixtures: new Map<string, string>(),
+}));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    stat: (filePath: Parameters<typeof actual.stat>[0]) =>
+      actual.stat(statPathFixtures.get(String(filePath)) ?? filePath),
+  };
+});
+
 describe('Codex model capability preflight', () => {
   const tempDirs: string[] = [];
 
   afterEach(async () => {
+    statPathFixtures.clear();
     await Promise.all(
       tempDirs.splice(0).map((dir) =>
         rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 }),
@@ -98,6 +112,34 @@ describe('Codex model capability preflight', () => {
       model: 'gpt-5.6-terra',
       cliVersion: 'codex-cli 0.142.5',
       requiredCliVersion: '0.143.0',
+    });
+  });
+
+  it('fails open when a system config layer can override the endpoint', async () => {
+    const fixture = await createFixture({
+      config: 'model = "gpt-5.6-terra"\n',
+      version: 'codex-cli 0.142.5',
+      loginStatus: 'Logged in using ChatGPT',
+    });
+    const systemConfigFixture = path.join(
+      path.dirname(fixture.codexHome),
+      'system-config.toml',
+    );
+    await writeFile(
+      systemConfigFixture,
+      'openai_base_url = "https://system.example.invalid/v1"\n',
+      'utf8',
+    );
+    statPathFixtures.set(codexSystemConfigPath(), systemConfigFixture);
+
+    await expect(preflightCodexDefaultModel({
+      launchPath: fixture.bin,
+      env: cleanCodexEnv(fixture.codexHome),
+      requestedModel: 'default',
+      projectRoot: fixture.projectRoot,
+    })).resolves.toEqual({
+      status: 'unknown',
+      reason: 'system_config',
     });
   });
 
@@ -286,6 +328,25 @@ describe('Codex model capability preflight', () => {
       status: 'unknown',
       reason: 'managed_config',
     });
+
+    const cloudManaged = await createFixture({
+      config: 'model = "gpt-5.6-terra"\n',
+      version: 'codex-cli 0.142.5',
+    });
+    await writeFile(
+      path.join(cloudManaged.codexHome, 'cloud-config-bundle-cache.json'),
+      '{"signed_payload":{"bundle":{"config":{"openai_base_url":"https://enterprise.example.invalid/v1"}}}}\n',
+      'utf8',
+    );
+    await expect(preflightCodexDefaultModel({
+      launchPath: cloudManaged.bin,
+      env: cleanCodexEnv(cloudManaged.codexHome),
+      requestedModel: 'default',
+      projectRoot: cloudManaged.projectRoot,
+    })).resolves.toEqual({
+      status: 'unknown',
+      reason: 'managed_config',
+    });
   });
 
   it('fails open for prerelease versions and models without a known requirement', async () => {
@@ -337,6 +398,17 @@ describe('Codex model capability preflight', () => {
       ...env
     } = process.env;
     return { ...env, CODEX_HOME: codexHome };
+  }
+
+  function codexSystemConfigPath(): string {
+    if (process.platform !== 'win32') return '/etc/codex/config.toml';
+    const programData = Object.entries(process.env).find(
+      ([key, value]) =>
+        key.toUpperCase() === 'PROGRAMDATA'
+        && typeof value === 'string'
+        && value.trim().length > 0,
+    )?.[1] ?? 'C:\\ProgramData';
+    return path.join(programData, 'OpenAI', 'Codex', 'config.toml');
   }
 
   async function createFixture(input: {


### PR DESCRIPTION
Fixes #6035

## Why

Production reliability traces showed a deterministic Codex launch failure when Open Design inherited `gpt-5.6-terra` from the root Codex config while the resolved Codex CLI was `0.142.5`. The daemon spawned `codex exec` and only then surfaced the provider error that the model required a newer CLI, so users paid the launch cost for a failure we could already identify.

This change adds a deliberately narrow compatibility preflight for that known combination. It does not use model-catalog absence as a blocker: upstream Codex evidence shows an explicitly selected model can execute even when it is missing from the picker/catalog ([openai/codex#31873](https://github.com/openai/codex/issues/31873)).

The preflight therefore fails open whenever effective configuration cannot be established safely, including explicit model selection, custom providers or endpoint overrides, layered project or managed configuration, unknown authentication, and unknown or prerelease CLI versions.

## What users will see

When the default model is `gpt-5.6-terra`, the resolved stable Codex CLI is older than `0.143.0`, and ChatGPT authentication is positively confirmed, the run now stops before the agent process starts. The existing error surface tells the user to upgrade the Codex CLI or choose a supported model.

All explicit-model, custom-provider, custom-endpoint, uncertain-configuration, and newer-CLI paths continue to launch normally. Cancellation during an in-flight probe remains cancellation rather than becoming a late failure.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. This is a daemon-only launch preflight and reuses the existing run error surface; no UI entry point or layout changed.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/codex-model-capability-preflight.test.ts`
- The test went red before the source change by proving `codex exec` was still spawned for the known `0.142.5` / `gpt-5.6-terra` combination, then green after the preflight was implemented.
- Additional unit coverage in `apps/daemon/tests/runtimes/codex-model-preflight.test.ts` locks the fail-open boundaries, version-probe cache, project/managed config handling, symlinked working directories, authentication check, and cross-platform wrapper behavior.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/daemon build`
- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/codex-model-preflight.test.ts tests/codex-model-capability-preflight.test.ts tests/run-failure-classification.test.ts tests/langfuse-bridge.test.ts tests/codex-session-resume.test.ts` — 5 files, 140 tests passed
- `pnpm --filter @open-design/daemon test` — attempted the complete daemon suite: 478 files passed, 3 skipped, and 5 unrelated files failed (6,030 tests passed; 17 failed). Each failure reproduced independently without this patch:
  - `brand-routes.test.ts` and `brand-prefetch.test.ts`: six 20-second timeouts
  - `project-watchers.test.ts`: pre-existing file-descriptor delta of 160 against a `<32` assertion
  - `langfuse-trace.test.ts`: local endpoint expectation differs from the active telemetry endpoint
  - `proxy-dispatcher-options.test.ts`: the machine's macOS system proxy at `127.0.0.1:10808` is detected even with proxy environment variables cleared
- `git diff --cached --check`
