### PR TITLE
fix(rtl): move sidebar toggle to the corect position in RTL

### DIFF
--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -155,7 +155,7 @@
   justify-content: center;
   width: 30px;
   height: 30px;
-  margin-right: auto;
+  margin-inline-end: auto;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--bg-panel);


### PR DESCRIPTION
## Why

In RTL the sidebar toggle button positioned in the wrong side.

## What users will see

The toggle button will be displays on the other side.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

LTR:

<img width="1508" height="930" alt="Screenshot 2026-07-23 at 22 20 28" src="https://github.com/user-attachments/assets/383c055c-2094-4862-a1a0-c3fe08ac6d67" />

Current RTL:

<img width="1506" height="931" alt="Screenshot 2026-07-23 at 22 21 10" src="https://github.com/user-attachments/assets/9f79f5c2-6453-4975-80c7-2e0adc67a03f" />

New RTL:

<img width="1512" height="932" alt="Screenshot 2026-07-23 at 22 24 41" src="https://github.com/user-attachments/assets/b9aa97ad-aa1c-4e77-b699-45c74bc029df" />

## Bug fix verification

- Test path: None (?)
- Did the test go red on `main` and green on this branch? green on both.
- Verification: Manual browser check of the collapsed sidebar toggle in LTR and RTL; screenshots attached.

## Validation

- Typecheck passed.
- Tests passed.
