### PR TITLE
fix(ci): make static gate runner-independent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,21 +136,31 @@ jobs:
     timeout-minutes: 10
     env:
       ACTIONLINT_VERSION: 1.7.12
+      SHELLCHECK_VERSION: 0.11.0
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
 
-      - name: Install actionlint
+      - name: Install actionlint and ShellCheck
         run: |
           case "$(uname -m)" in
-            x86_64) actionlint_arch=amd64 ;;
-            aarch64|arm64) actionlint_arch=arm64 ;;
+            x86_64)
+              actionlint_arch=amd64
+              shellcheck_arch=x86_64
+              ;;
+            aarch64|arm64)
+              actionlint_arch=arm64
+              shellcheck_arch=aarch64
+              ;;
             *) echo "Unsupported actionlint architecture: $(uname -m)" >&2; exit 1 ;;
           esac
           curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_${actionlint_arch}.tar.gz" \
             | tar -xz actionlint
+          curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.${shellcheck_arch}.tar.gz" \
+            | tar -xz --strip-components=1 "shellcheck-v${SHELLCHECK_VERSION}/shellcheck"
           sudo install -m 0755 actionlint /usr/local/bin/actionlint
+          sudo install -m 0755 shellcheck /usr/local/bin/shellcheck
 
       - name: Check workflow files
         run: actionlint -color
@@ -723,8 +733,11 @@ jobs:
               marker="<!-- merge-queue-needs-validation -->"
               {
                 printf '%s\n' "$marker"
+                # Markdown code spans are intentional literal text.
+                # shellcheck disable=SC2016
                 printf 'Ejected from the merge queue: this PR still carries the `needs-validation` label.\n\n'
                 printf 'The merge queue gate ([run %s](%s/%s/actions/runs/%s)) blocked the queued group because of the label. That failure runs on the queue'"'"'s transient ref, so it never appears in this PR'"'"'s own checks — they stay green, and this notice is the only visible trace on the PR.\n\n' "$RUN_ID" "$GITHUB_SERVER_URL" "$REPO" "$RUN_ID"
+                # shellcheck disable=SC2016
                 printf 'To land this PR: complete the QA pass the label is tracking, remove the `needs-validation` label, then add the PR back to the merge queue.\n'
               } > "$handoff_dir/body.md"
               jq -n \

--- a/.github/workflows/cut-patch-release.yml
+++ b/.github/workflows/cut-patch-release.yml
@@ -100,10 +100,12 @@ jobs:
           # (e.g. version=0.15.1 gates open-design-v0.15.0, not the latest 0.14.0).
           vmajor=${V%%.*}; vrest=${V#*.}; vminor=${vrest%%.*}
           MINOR_BASE="${vmajor}.${vminor}.0"
-          echo "version=$V"                          >> "$GITHUB_OUTPUT"
-          echo "branch=release/v$V"                  >> "$GITHUB_OUTPUT"
-          echo "minor_base=$MINOR_BASE"              >> "$GITHUB_OUTPUT"
-          echo "minor_tag=open-design-v$MINOR_BASE"  >> "$GITHUB_OUTPUT"
+          {
+            echo "version=$V"
+            echo "branch=release/v$V"
+            echo "minor_base=$MINOR_BASE"
+            echo "minor_tag=open-design-v$MINOR_BASE"
+          } >> "$GITHUB_OUTPUT"
           echo "Cutting patch v$V (branch release/v$V); gating on stable v$MINOR_BASE"
 
       # Guard: the minor this patch sits on (the Tuesday cut) must already be a

--- a/.github/workflows/release-branch-direct-pr-guard.yml
+++ b/.github/workflows/release-branch-direct-pr-guard.yml
@@ -46,6 +46,8 @@ jobs:
             exit 0
           fi
           echo "Blocking direct release PR #$PR into $BASE by $AUTHOR"
+          # Markdown code spans are intentional literal text.
+          # shellcheck disable=SC2016
           body="$(printf '%s\n' \
             '🚫 Direct PRs into release branches are not accepted.' \
             '' \

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1132,6 +1132,20 @@ process.stdin.on("end", () => {
     expect(workflow).not.toContain("needs.runners.outputs.blacksmith_default");
   });
 
+  it("[P1] pins ShellCheck for actionlint across runner profiles", async () => {
+    const workflow = await readFile(ciWorkflowPath, "utf8");
+    const staticGate = sectionBetween(workflow, "  static_gate:", "  preflight:");
+
+    expect(staticGate).toContain("SHELLCHECK_VERSION: 0.11.0");
+    expect(staticGate).toContain("shellcheck_arch=x86_64");
+    expect(staticGate).toContain("shellcheck_arch=aarch64");
+    expect(staticGate).toContain(
+      'koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.${shellcheck_arch}.tar.gz',
+    );
+    expect(staticGate).toContain("sudo install -m 0755 shellcheck /usr/local/bin/shellcheck");
+    expect(staticGate).toContain("run: actionlint -color");
+  });
+
   it("[P2] keeps visual ownership and generic full UI sharding explicit", async () => {
     const playwrightConfig = await readFile(playwrightConfigPath, "utf8");
     const benchmarkWorkflow = await readFile(uiExtendedMainWorkflowPath, "utf8");


### PR DESCRIPTION
## Why

The merge queue was blocked when all `od-ci-hot-poc` runners went offline, so the repository was switched to the supported `economic` runner mode. Its GitHub-hosted control runner exposed that `Static gate` depended on whether the selected runner happened to have ShellCheck installed: the same workflow passed on Contabo and failed on `ubuntu-24.04`.

This PR makes the static validation environment deterministic and clears the seven existing ShellCheck findings that prevented every merge-group run from completing.

## What users will see

No product UI or runtime behavior changes. Maintainers can use the existing `economic` CI mode without merge-queue runs failing because of runner-specific ShellCheck availability.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is CI-only.

## Bug fix verification

- Test path: `e2e/tests/packaged-smoke-workflow.test.ts` — `[P1] pins ShellCheck for actionlint across runner profiles`
- The test went red on `main` because `Static gate` did not install a pinned ShellCheck, then green on this branch.
- `actionlint -color` reproduced the seven SC2016/SC2129 findings on `main` and passes on this branch with actionlint 1.7.12 and ShellCheck 0.11.0.

## Validation

- `actionlint -color`
- `python3 .github/scripts/handoff.py self-check`
- `pnpm --filter @open-design/e2e test tests/packaged-smoke-workflow.test.ts` — 51 passed
- `pnpm guard` — 86 tests passed
- `pnpm typecheck`
- `git diff --check`
- Verified the pinned ShellCheck 0.11.0 Linux x86_64 and aarch64 archive paths and member names.
