### PR TITLE
fix(tools-dev): wait for visible Windows cold starts

### DIFF
--- a/tools/dev/src/sidecar-client.ts
+++ b/tools/dev/src/sidecar-client.ts
@@ -13,6 +13,14 @@ export type AppRuntimeLookup = {
   namespace: string;
 };
 
+export const DESKTOP_STARTUP_TIMEOUT_MS = 90_000;
+
+export type DesktopRuntimeWaitDeps = {
+  inspect?: typeof inspectDesktopRuntime;
+  now?: () => number;
+  sleep?: (delayMs: number) => Promise<void>;
+};
+
 export function resolveDaemonIpcPath(runtime: AppRuntimeLookup): string {
   return resolveAppIpcPath({ app: APP_KEYS.DAEMON, contract: OPEN_DESIGN_SIDECAR_CONTRACT, namespace: runtime.namespace });
 }
@@ -69,12 +77,21 @@ export async function inspectDesktopRuntime(runtime: AppRuntimeLookup, timeoutMs
   }
 }
 
-export async function waitForDesktopRuntime(runtime: AppRuntimeLookup, timeoutMs = 15000): Promise<DesktopStatusSnapshot> {
-  const startedAt = Date.now();
-  while (Date.now() - startedAt < timeoutMs) {
-    const snapshot = await inspectDesktopRuntime(runtime, 800);
+export async function waitForDesktopRuntime(
+  runtime: AppRuntimeLookup,
+  timeoutMs = DESKTOP_STARTUP_TIMEOUT_MS,
+  deps: DesktopRuntimeWaitDeps = {},
+): Promise<DesktopStatusSnapshot> {
+  const now = deps.now ?? Date.now;
+  const inspect = deps.inspect ?? inspectDesktopRuntime;
+  const sleep =
+    deps.sleep ??
+    ((delayMs: number) => new Promise<void>((resolveWait) => setTimeout(resolveWait, delayMs)));
+  const startedAt = now();
+  while (now() - startedAt < timeoutMs) {
+    const snapshot = await inspect(runtime, 800);
     if (snapshot != null) return snapshot;
-    await new Promise((resolveWait) => setTimeout(resolveWait, 150));
+    await sleep(150);
   }
   throw new Error("desktop did not expose status in time");
 }

--- a/tools/dev/src/sidecar-client.ts
+++ b/tools/dev/src/sidecar-client.ts
@@ -90,8 +90,14 @@ export async function waitForDesktopRuntime(
   const startedAt = now();
   while (now() - startedAt < timeoutMs) {
     const snapshot = await inspect(runtime, 800);
-    if (snapshot != null) return snapshot;
+    if (
+      snapshot?.state === "running" &&
+      snapshot.url != null &&
+      snapshot.windowVisible === true
+    ) {
+      return snapshot;
+    }
     await sleep(150);
   }
-  throw new Error("desktop did not expose status in time");
+  throw new Error("desktop did not expose a visible window in time");
 }

--- a/tools/dev/src/sidecar-client.ts
+++ b/tools/dev/src/sidecar-client.ts
@@ -13,7 +13,7 @@ export type AppRuntimeLookup = {
   namespace: string;
 };
 
-export const DESKTOP_STARTUP_TIMEOUT_MS = 90_000;
+export const DESKTOP_STARTUP_TIMEOUT_MS = 180_000;
 
 export type DesktopRuntimeWaitDeps = {
   inspect?: typeof inspectDesktopRuntime;

--- a/tools/dev/tests/sidecar-client.test.ts
+++ b/tools/dev/tests/sidecar-client.test.ts
@@ -6,13 +6,13 @@ import type { DesktopStatusSnapshot } from "@open-design/sidecar-proto";
 import { waitForDesktopRuntime } from "../src/sidecar-client.js";
 
 describe("tools-dev sidecar client", () => {
-  it("waits for a cold desktop window to become visible after 15 seconds", async () => {
+  it("waits for a cold desktop window to become visible after 90 seconds", async () => {
     let now = 0;
     const expected = {
       pid: 42,
       state: "running",
       title: "Open Design",
-      updatedAt: "2026-07-23T00:00:20.000Z",
+      updatedAt: "2026-07-23T00:02:00.000Z",
       url: "http://127.0.0.1:3000",
       windowVisible: true,
     } as DesktopStatusSnapshot;
@@ -26,7 +26,7 @@ describe("tools-dev sidecar client", () => {
       { base: "test", namespace: "windows-cold-start" },
       undefined,
       {
-        inspect: async () => (now >= 20_000 ? expected : now >= 1_000 ? hidden : null),
+        inspect: async () => (now >= 120_000 ? expected : now >= 1_000 ? hidden : null),
         now: () => now,
         sleep: async (delayMs) => {
           now += delayMs;
@@ -35,6 +35,6 @@ describe("tools-dev sidecar client", () => {
     );
 
     assert.equal(actual, expected);
-    assert.ok(now > 15_000);
+    assert.ok(now > 90_000);
   });
 });

--- a/tools/dev/tests/sidecar-client.test.ts
+++ b/tools/dev/tests/sidecar-client.test.ts
@@ -6,7 +6,7 @@ import type { DesktopStatusSnapshot } from "@open-design/sidecar-proto";
 import { waitForDesktopRuntime } from "../src/sidecar-client.js";
 
 describe("tools-dev sidecar client", () => {
-  it("allows a cold desktop runtime to become ready after 15 seconds", async () => {
+  it("waits for a cold desktop window to become visible after 15 seconds", async () => {
     let now = 0;
     const expected = {
       pid: 42,
@@ -16,12 +16,17 @@ describe("tools-dev sidecar client", () => {
       url: "http://127.0.0.1:3000",
       windowVisible: true,
     } as DesktopStatusSnapshot;
+    const hidden = {
+      ...expected,
+      updatedAt: "2026-07-23T00:00:01.000Z",
+      windowVisible: false,
+    } as DesktopStatusSnapshot;
 
     const actual = await waitForDesktopRuntime(
       { base: "test", namespace: "windows-cold-start" },
       undefined,
       {
-        inspect: async () => (now >= 20_000 ? expected : null),
+        inspect: async () => (now >= 20_000 ? expected : now >= 1_000 ? hidden : null),
         now: () => now,
         sleep: async (delayMs) => {
           now += delayMs;

--- a/tools/dev/tests/sidecar-client.test.ts
+++ b/tools/dev/tests/sidecar-client.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { DesktopStatusSnapshot } from "@open-design/sidecar-proto";
+
+import { waitForDesktopRuntime } from "../src/sidecar-client.js";
+
+describe("tools-dev sidecar client", () => {
+  it("allows a cold desktop runtime to become ready after 15 seconds", async () => {
+    let now = 0;
+    const expected = {
+      pid: 42,
+      state: "running",
+      title: "Open Design",
+      updatedAt: "2026-07-23T00:00:20.000Z",
+      url: "http://127.0.0.1:3000",
+      windowVisible: true,
+    } as DesktopStatusSnapshot;
+
+    const actual = await waitForDesktopRuntime(
+      { base: "test", namespace: "windows-cold-start" },
+      undefined,
+      {
+        inspect: async () => (now >= 20_000 ? expected : null),
+        now: () => now,
+        sleep: async (delayMs) => {
+          now += delayMs;
+        },
+      },
+    );
+
+    assert.equal(actual, expected);
+    assert.ok(now > 15_000);
+  });
+});


### PR DESCRIPTION
Fixes #6041

## Why

I hit this while bringing up a real Open Design evaluation worker on a clean
Windows 11 VM. The first native desktop build was healthy but substantially
slower than a warm developer loop, so `tools-dev` declared failure while
Electron was still compiling.

The readiness helper had two related problems: its fixed 15-second budget was
too short for a genuine cold start, and it accepted the first IPC snapshot even
when the desktop was not yet running with a loaded, visible window.

## What users will see

On a cold or slower machine, `tools-dev` now allows up to three minutes for the
desktop to become ready. It returns only after desktop state is `running`, a URL
is present, and the Electron window reports that it is visible. Warm starts keep
returning as soon as those conditions are met.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — this changes lifecycle readiness, not the product UI.

## Bug fix verification

- Test: [`tools/dev/tests/sidecar-client.test.ts`](https://github.com/nexu-io/open-design/blob/fix/windows-tools-dev-cold-start/tools/dev/tests/sidecar-client.test.ts)
- The test went red against the pre-fix helper, which timed out before a
  simulated desktop became visible after 90 seconds, and is green on this
  branch.
- A real Windows 11 6 vCPU / 12 GB cold start took about 89 seconds for the
  root build plus 42 seconds for the desktop phase. A 90-second outer budget
  failed; the 180-second readiness budget reached the loaded visible window.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @open-design/tools-dev test` — 39 passed
- `pnpm guard` — 86 tests passed
- `pnpm typecheck`
- Native Windows cold-start smoke with a real Electron window, followed by
  process cleanup verification
