### PR TITLE
feat(daemon): forward reasoning effort to Claude Code runtime

### DIFF
--- a/apps/daemon/src/runtimes/defs/claude.ts
+++ b/apps/daemon/src/runtimes/defs/claude.ts
@@ -1,5 +1,5 @@
 import { agentCapabilities } from '../capabilities.js';
-import { DEFAULT_MODEL_OPTION } from './shared.js';
+import { DEFAULT_MODEL_OPTION, clampClaudeReasoning } from './shared.js';
 import { loadMmdRouteModels } from '../mmd-routes.js';
 import type { RuntimeAgentDef } from '../types.js';
 
@@ -42,6 +42,19 @@ export const claudeAgentDef = {
     // picker, then keep the built-in aliases as fallback hints.
     fallbackModels: CLAUDE_FALLBACK_MODELS,
     fetchModels: async (_resolvedBin, env) => loadMmdRouteModels(env, CLAUDE_FALLBACK_MODELS),
+    // `default` is the synthetic sentinel the picker falls back to
+    // (AvatarMenu/SettingsDialog use `reasoningOptions[0].id`) and round-trips
+    // to "omit --effort, let the CLI pick." The other five ids are the real
+    // `claude -p --effort <level>` levels; per-model support is narrowed by
+    // clampClaudeReasoning in buildArgs (e.g. Sonnet/Opus 4.6 lack `xhigh`).
+    reasoningOptions: [
+      { id: 'default', label: 'Default' },
+      { id: 'low', label: 'Low' },
+      { id: 'medium', label: 'Medium' },
+      { id: 'high', label: 'High' },
+      { id: 'xhigh', label: 'XHigh' },
+      { id: 'max', label: 'Max' },
+    ],
     // Prompt delivered via stdin to avoid both Linux `spawn E2BIG`
     // (MAX_ARG_STRLEN caps a single argv entry at ~128 KB) and Windows
     // `spawn ENAMETOOLONG` (CreateProcess caps the full command line at
@@ -65,6 +78,10 @@ export const claudeAgentDef = {
       }
       if (options.model && options.model !== 'default') {
         args.push('--model', options.model);
+      }
+      if (options.reasoning && options.reasoning !== 'default') {
+        const effort = clampClaudeReasoning(options.model, options.reasoning);
+        if (effort) args.push('--effort', effort);
       }
       const dirs = (extraAllowedDirs || []).filter(
         (d) => typeof d === 'string' && d.length > 0,

--- a/apps/daemon/src/runtimes/defs/shared.ts
+++ b/apps/daemon/src/runtimes/defs/shared.ts
@@ -35,16 +35,14 @@ export function clampCodexReasoning(
 // model ids (e.g. 'default', 'sonnet', 'opus') are treated as the current
 // (full-range) generation rather than clamped, mirroring how
 // clampCodexReasoning treats an unset model id as the newest family.
-const CLAUDE_NO_XHIGH_MODEL_IDS = new Set([
-  'claude-sonnet-4-6',
-  'claude-sonnet-4.6',
-  'sonnet-4-6',
-  'sonnet-4.6',
-  'claude-opus-4-6',
-  'claude-opus-4.6',
-  'opus-4-6',
-  'opus-4.6',
-]);
+//
+// Matched by family prefix, not an exact-string set: mmd routes (see
+// mmd-routes.test.ts) surface suffixed 4.6 ids like
+// `claude-opus-4-6-thinking` through the same picker, and an exact-match
+// set would silently let `xhigh` through for those. The trailing
+// `(?:[-.].+)?` requires a separator before any suffix, so `4-6` doesn't
+// also match a hypothetical unrelated `4-60`.
+const CLAUDE_NO_XHIGH_FAMILY_RE = /^(?:claude-)?(?:sonnet|opus)-4[-.]6(?:[-.].+)?$/;
 
 export function clampClaudeReasoning(
   modelId: string | null | undefined,
@@ -53,7 +51,7 @@ export function clampClaudeReasoning(
   if (!effort) return effort;
   const raw = String(modelId ?? '').trim().toLowerCase();
   const id = raw.includes('/') ? raw.split('/').pop() : raw;
-  if (effort === 'xhigh' && id && CLAUDE_NO_XHIGH_MODEL_IDS.has(id)) {
+  if (effort === 'xhigh' && id && CLAUDE_NO_XHIGH_FAMILY_RE.test(id)) {
     return 'high';
   }
   return effort;

--- a/apps/daemon/src/runtimes/defs/shared.ts
+++ b/apps/daemon/src/runtimes/defs/shared.ts
@@ -28,6 +28,37 @@ export function clampCodexReasoning(
   return effort;
 }
 
+// Per-model support matrix for the Claude Code CLI's `--effort` flag.
+// Sonnet 5 / Opus 4.8 / Opus 4.7 / Fable 5 support the full
+// low|medium|high|xhigh|max range. The prior generation — Sonnet 4.6 /
+// Opus 4.6 — supports everything except `xhigh`. Unknown/omitted/aliased
+// model ids (e.g. 'default', 'sonnet', 'opus') are treated as the current
+// (full-range) generation rather than clamped, mirroring how
+// clampCodexReasoning treats an unset model id as the newest family.
+const CLAUDE_NO_XHIGH_MODEL_IDS = new Set([
+  'claude-sonnet-4-6',
+  'claude-sonnet-4.6',
+  'sonnet-4-6',
+  'sonnet-4.6',
+  'claude-opus-4-6',
+  'claude-opus-4.6',
+  'opus-4-6',
+  'opus-4.6',
+]);
+
+export function clampClaudeReasoning(
+  modelId: string | null | undefined,
+  effort: string | null | undefined,
+) {
+  if (!effort) return effort;
+  const raw = String(modelId ?? '').trim().toLowerCase();
+  const id = raw.includes('/') ? raw.split('/').pop() : raw;
+  if (effort === 'xhigh' && id && CLAUDE_NO_XHIGH_MODEL_IDS.has(id)) {
+    return 'high';
+  }
+  return effort;
+}
+
 // Parse one-id-per-line stdout from `<cli> models` and prepend the synthetic
 // default option. Used by opencode / cursor-agent.
 export function parseLineSeparatedModels(stdout: string): RuntimeModelOption[] {

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -1007,6 +1007,83 @@ test('claude helpArgs probes the -p subcommand where --add-dir lives (issue #430
   );
 });
 
+// ---- Claude Code reasoning-effort passthrough ------------------------------
+// The model switcher sends `reasoning` through server.ts's `safeReasoning`
+// sanitizer, which nulls the value out unless `def.reasoningOptions` is a
+// non-empty array containing it (see server.ts / routes/chat.ts). Without
+// declaring `reasoningOptions`, a selected effort never survives to reach
+// buildArgs at all — these tests pin both halves of the fix: the declared
+// options list (so the value round-trips through the sanitizer and the
+// AvatarMenu/SettingsDialog picker renders) and the `--effort` flag itself.
+
+test('claude declares reasoningOptions so the daemon sanitizer does not drop effort', () => {
+  const options = claude.reasoningOptions ?? [];
+  assert.ok(options.length > 0);
+  const ids = options.map((o) => o.id);
+  assert.deepEqual(ids, ['default', 'low', 'medium', 'high', 'xhigh', 'max']);
+  // 'default' must be first so AvatarMenu/SettingsDialog's
+  // `reasoningOptions[0].id` fallback resolves to "omit --effort."
+  assert.equal(options[0]?.id, 'default');
+});
+
+test('claude buildArgs appends --effort when reasoning is set', () => {
+  const args = claude.buildArgs('', [], [], { reasoning: 'high' }, {});
+  assert.ok(args.includes('--effort'));
+  assert.equal(args[args.indexOf('--effort') + 1], 'high');
+});
+
+test('claude buildArgs omits --effort when reasoning is unset or the "default" sentinel', () => {
+  const noReasoning = claude.buildArgs('', [], [], {}, {});
+  assert.equal(noReasoning.includes('--effort'), false);
+
+  const defaultReasoning = claude.buildArgs('', [], [], { reasoning: 'default' }, {});
+  assert.equal(defaultReasoning.includes('--effort'), false);
+});
+
+test('claude buildArgs clamps reasoning effort per model (Sonnet/Opus 4.6 lack xhigh)', () => {
+  const cases: Array<[string | undefined, string, string]> = [
+    // [model, requested effort, expected wire-level --effort value]
+    // Current generation supports the full range, including xhigh.
+    [undefined, 'xhigh', 'xhigh'],
+    ['default', 'xhigh', 'xhigh'],
+    ['claude-sonnet-5', 'xhigh', 'xhigh'],
+    ['claude-opus-4-8', 'xhigh', 'xhigh'],
+    ['claude-opus-4-7', 'xhigh', 'xhigh'],
+    ['claude-fable-5', 'xhigh', 'xhigh'],
+    // Prior generation: xhigh -> high, everything else passes through.
+    ['claude-sonnet-4-6', 'xhigh', 'high'],
+    ['claude-sonnet-4-6', 'high', 'high'],
+    ['claude-sonnet-4-6', 'max', 'max'],
+    ['claude-opus-4-6', 'xhigh', 'high'],
+    ['claude-opus-4-6', 'medium', 'medium'],
+    // Case/format tolerance: path-style ids and case variants.
+    ['anthropic/claude-sonnet-4-6', 'xhigh', 'high'],
+    ['CLAUDE-SONNET-4-6', 'xhigh', 'high'],
+    // Aliases and unknown ids: treated as current (full-range) generation.
+    ['sonnet', 'xhigh', 'xhigh'],
+    ['opus', 'xhigh', 'xhigh'],
+  ];
+  for (const [model, reasoning, expected] of cases) {
+    const args = claude.buildArgs(
+      '',
+      [],
+      [],
+      { ...(model === undefined ? {} : { model }), reasoning },
+      {},
+    );
+    const effortIndex = args.indexOf('--effort');
+    assert.ok(
+      effortIndex >= 0,
+      `(model=${model ?? '<none>'}, reasoning=${reasoning}) → expected --effort to be present; args=${JSON.stringify(args)}`,
+    );
+    assert.equal(
+      args[effortIndex + 1],
+      expected,
+      `(model=${model ?? '<none>'}, reasoning=${reasoning}) → expected ${expected}; args=${JSON.stringify(args)}`,
+    );
+  }
+});
+
 // server.ts:4615 branches on `def.promptInputFormat` to decide how to write
 // the composed prompt to a stdin-fed child: 'stream-json' writes one JSONL
 // `user` message and keeps stdin open, anything else writes the raw prompt

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -1059,6 +1059,15 @@ test('claude buildArgs clamps reasoning effort per model (Sonnet/Opus 4.6 lack x
     // Case/format tolerance: path-style ids and case variants.
     ['anthropic/claude-sonnet-4-6', 'xhigh', 'high'],
     ['CLAUDE-SONNET-4-6', 'xhigh', 'high'],
+    // Regression (PR #6046 review): mmd routes surface suffixed 4.6 ids
+    // (see mmd-routes.test.ts's `claude-opus-4-6-thinking` fixture) through
+    // the same picker as the bare ids above. An exact-string match would
+    // miss these and let xhigh through unclamped.
+    ['claude-opus-4-6-thinking', 'xhigh', 'high'],
+    ['claude-sonnet-4-6-thinking', 'xhigh', 'high'],
+    // A suffix on a full-range model must NOT be mistaken for the 4.6
+    // family purely because it also starts with a similar prefix shape.
+    ['claude-opus-4-8-thinking', 'xhigh', 'xhigh'],
     // Aliases and unknown ids: treated as current (full-range) generation.
     ['sonnet', 'xhigh', 'xhigh'],
     ['opus', 'xhigh', 'xhigh'],


### PR DESCRIPTION
## Why

The model switcher lets users pick a reasoning/effort level per agent, but the Claude Code runtime never honored it -- setting e.g. Sonnet to `xhigh` had no effect, since `claudeAgentDef.buildArgs()` never looked at `options.reasoning` at all, unlike `codex.ts` / `codebuddy.ts` / `grok-build.ts`, which already support this.

## What users will see

- Claude Code's entry in the model switcher (AvatarMenu / Settings agent picker) now shows an Effort/Reasoning control -- Default / Low / Medium / High / XHigh / Max -- the same control Codex and Codebuddy already expose. Before this PR, no such control rendered for Claude Code at all, because the daemon didn't declare `reasoningOptions` for it (the picker and the daemon's own `safeReasoning` sanitizer both gate on that field).
- Picking a non-default level now reaches the spawned `claude` process as `--effort <level>`.
- Selecting `xhigh` against an older Sonnet/Opus 4.6-generation model (including suffixed ids like `claude-opus-4-6-thinking`, per review) automatically clamps down to `high` instead of sending an unsupported value through.

## Surface area

- [x] **UI** -- the model switcher (AvatarMenu / SettingsDialog) now renders an Effort/Reasoning control for Claude Code that did not appear before. No new UI code was written for this -- it's the existing generic `reasoningOptions`-driven picker component (already used by Codex/Codebuddy); `claudeAgentDef` simply now populates the field that component already reads.
- [ ] Default behavior change -- not checked: users who never touch the effort setting see identical behavior. The `default` sentinel still omits `--effort` entirely, same as before this PR.

## Screenshots

I didn't have a browser/screenshot tool available in the environment I used for this PR, so instead here's the daemon's own `/api/agents` response for the `claude` entry, which is what actually drives the picker's visibility -- verified against a local build of this branch:

Before (`main` @ f2760fd):
```json
{ "id": "claude" }
```
(no `reasoningOptions` key at all -- picker renders nothing for this agent)

After (this branch):
```json
{
  "id": "claude",
  "reasoningOptions": [
    { "id": "default", "label": "Default" },
    { "id": "low", "label": "Low" },
    { "id": "medium", "label": "Medium" },
    { "id": "high", "label": "High" },
    { "id": "xhigh", "label": "XHigh" },
    { "id": "max", "label": "Max" }
  ]
}
```
Happy to add an actual screenshot of the rendered picker if someone can point me at this repo's preferred way to capture one.

## Bug fix verification

- Test path: `apps/daemon/tests/runtimes/agent-args.test.ts` -- `claude declares reasoningOptions so the daemon sanitizer does not drop effort`, `claude buildArgs appends --effort when reasoning is set`, `claude buildArgs omits --effort when reasoning is unset or the "default" sentinel`, `claude buildArgs clamps reasoning effort per model (Sonnet/Opus 4.6 lack xhigh)`.
- Went red on `main` / green on this branch? Yes, for both fixes in this PR:
  - **Original passthrough gap:** on `main` (f2760fd), `claudeAgentDef.reasoningOptions` is `undefined` and `buildArgs` never emits `--effort` under any input -- all four tests above fail against that commit and pass on this branch.
  - **Follow-up clamp fix** (@nettee's review): reproduced the reported bug directly -- the original exact-match `Set` returns `'xhigh'` unclamped for `claude-opus-4-6-thinking`. The two new regression cases (`claude-opus-4-6-thinking`, `claude-sonnet-4-6-thinking`), plus a control case (`claude-opus-4-8-thinking` staying at `xhigh`), fail against the pre-fix `Set`-based clamp and pass against the new family-prefix regex.

## Validation

- `pnpm guard` -- 86/86 passed
- `tsc -p tsconfig.json --noEmit` and `tsc -p tsconfig.tests.json --noEmit` (apps/daemon) -- clean
- `apps/daemon` vitest suite -- green, aside from two pre-existing failures unrelated to this change (`langfuse-trace.test.ts`, `run-retry-runtime.test.ts`) -- confirmed these fail identically on `main` with this branch's diff stashed out
- Manually ran the exact argv shape against a real `claude` binary (v2.1.218): `--effort high` completed a live turn successfully; separately confirmed `claude -p --effort <invalid-string>` only warns and falls back to the CLI default rather than hard-failing, which is why the per-model clamp -- not CLI-side validation -- is what actually prevents an unsupported-but-syntactically-valid level from reaching an older model
- Rebuilt and locally deployed this exact branch (`pnpm --filter @open-design/daemon build` + daemon restart) and confirmed via the daemon's own `/api/agents` endpoint that `reasoningOptions` now appears for `claude`, matching the screenshot section above

---

(Note on the earlier email notification suggesting an AI agent "take over this PR until it merges" via an external skill URL: not doing that -- responding to review feedback directly and specifically here instead.)
