### PR TITLE
fix(daemon): improve Windows packaged CLI resolution

### DIFF
--- a/apps/daemon/src/runtimes/executables.ts
+++ b/apps/daemon/src/runtimes/executables.ts
@@ -38,6 +38,7 @@ const AGENT_BIN_ENV_KEYS = new Map<string, string>([
   ['vibe', 'VIBE_BIN'],
 ]);
 
+const DEFAULT_WINDOWS_EXECUTABLE_EXTENSIONS = ['.EXE', '.CMD', '.BAT'];
 const TOOLCHAIN_DIR_CACHE_TTL_MS = 5000;
 let cachedToolchainHome: string | null = null;
 let cachedToolchainDirs: string[] | null = null;
@@ -119,6 +120,25 @@ export function agentSearchDirs(): string[] {
   return resolvePathDirs();
 }
 
+function windowsExecutableExtensions(options: { includeBare: boolean }): string[] {
+  const values = [
+    ...(options.includeBare ? [''] : []),
+    ...(process.env.PATHEXT ?? '').split(';'),
+    ...DEFAULT_WINDOWS_EXECUTABLE_EXTENSIONS,
+  ];
+  const seen = new Set<string>();
+  return values
+    .map((value) => value.trim())
+    .filter((value) => value || options.includeBare)
+    .map((value) => (value && !value.startsWith('.') ? `.${value}` : value))
+    .filter((value) => {
+      const key = value.toUpperCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+}
+
 // The `*_BIN` environment variable that overrides PATH detection for a given
 // agent id (e.g. `cursor-agent` → `CURSOR_AGENT_BIN`), or null when the agent
 // has no override key. Drives the `setEnv` / `clearEnv` fix intents.
@@ -130,7 +150,7 @@ export function agentBinEnvKey(agentId: string | undefined): string | null {
 export function resolveOnPath(bin: string): string | null {
   const exts =
     process.platform === 'win32'
-      ? (process.env.PATHEXT || '.EXE;.CMD;.BAT').split(';')
+      ? windowsExecutableExtensions({ includeBare: true })
       : [''];
   const dirs = resolvePathDirs();
   for (const dir of dirs) {
@@ -145,10 +165,8 @@ export function resolveOnPath(bin: string): string | null {
 function looksExecutableOnWindows(filePath: string): boolean {
   const ext = path.extname(filePath).trim().toUpperCase();
   if (!ext) return false;
-  const executableExts = (process.env.PATHEXT || '.EXE;.CMD;.BAT')
-    .split(';')
-    .map((value) => value.trim().toUpperCase())
-    .filter(Boolean);
+  const executableExts = windowsExecutableExtensions({ includeBare: false })
+    .map((value) => value.toUpperCase());
   return executableExts.includes(ext);
 }
 

--- a/apps/daemon/tests/runtimes/executables.test.ts
+++ b/apps/daemon/tests/runtimes/executables.test.ts
@@ -60,6 +60,53 @@ test('resolveAgentExecutable finds Grok Build in OD_AGENT_HOME on Windows', () =
   }
 });
 
+test('resolveAgentExecutable finds Windows npm .cmd shims when PATHEXT is stripped', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-windows-path-cmd-shim-'));
+  try {
+    return withEnvSnapshot(['PATH', 'PATHEXT', 'OD_AGENT_HOME'], () =>
+      withPlatform('win32', () => {
+        const codexCmd = join(dir, 'codex.cmd');
+        writeFileSync(codexCmd, '');
+        process.env.PATH = dir;
+        process.env.PATHEXT = '.EXE';
+        process.env.OD_AGENT_HOME = join(dir, 'empty-home');
+
+        assert.equal(
+          resolveAgentExecutable(minimalAgentDef({ id: 'codex', bin: 'codex' }))?.toLowerCase(),
+          codexCmd.toLowerCase(),
+        );
+      }),
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resolveAgentExecutable accepts configured Windows .cmd overrides when PATHEXT is stripped', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-windows-configured-cmd-shim-'));
+  try {
+    return withEnvSnapshot(['PATH', 'PATHEXT', 'OD_AGENT_HOME'], () =>
+      withPlatform('win32', () => {
+        const codexCmd = join(dir, 'codex.cmd');
+        writeFileSync(codexCmd, '');
+        process.env.PATH = '';
+        process.env.PATHEXT = '.EXE';
+        process.env.OD_AGENT_HOME = join(dir, 'empty-home');
+
+        assert.equal(
+          resolveAgentExecutable(
+            minimalAgentDef({ id: 'codex', bin: 'codex' }),
+            { CODEX_BIN: codexCmd },
+          ),
+          codexCmd,
+        );
+      }),
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 // resolveAgentExecutable touches the filesystem via existsSync; on
 // Windows resolveOnPath also walks PATHEXT extensions, which our fixture
 // files don't carry. Skip the filesystem-backed cases there — the

--- a/tools/pack/src/win/payload.ts
+++ b/tools/pack/src/win/payload.ts
@@ -299,6 +299,40 @@ function archiveRelativePath(value: string): string {
   return value.replaceAll("/", "\\").replaceAll("\\", "\\");
 }
 
+type PayloadPackagedConfig = {
+  daemonCliEntryRelative?: unknown;
+  daemonSidecarEntryRelative?: unknown;
+  webOutputMode?: unknown;
+  webSidecarEntryRelative?: unknown;
+};
+
+function packagedConfigString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+async function requirePayloadConfigEntry(
+  extractRoot: string,
+  config: PayloadPackagedConfig,
+  key: "daemonCliEntryRelative" | "daemonSidecarEntryRelative" | "webSidecarEntryRelative",
+): Promise<void> {
+  const relativeEntry = packagedConfigString(config[key]);
+  if (relativeEntry == null) {
+    throw new Error(`Windows launcher payload packaged config is missing ${key}`);
+  }
+  await stat(join(extractRoot, archiveRelativePath(`payload/resources/${relativeEntry}`)));
+}
+
+async function validatePayloadPackagedConfigEntrypoints(
+  extractRoot: string,
+  configPath: string,
+): Promise<void> {
+  const config = JSON.parse(await readFile(configPath, "utf8")) as PayloadPackagedConfig;
+  if (config.webOutputMode !== "standalone") return;
+  await requirePayloadConfigEntry(extractRoot, config, "daemonCliEntryRelative");
+  await requirePayloadConfigEntry(extractRoot, config, "daemonSidecarEntryRelative");
+  await requirePayloadConfigEntry(extractRoot, config, "webSidecarEntryRelative");
+}
+
 export async function validateWinLauncherPayloadArchive(input: {
   expectedVersion: string;
   namespace: string;
@@ -331,7 +365,9 @@ export async function validateWinLauncherPayloadArchive(input: {
     requirePayloadManifestValue(manifest.entry?.executable, "entry.executable", "payload/Open Design.exe");
 
     await stat(join(extractRoot, archiveRelativePath("payload/Open Design.exe")));
-    await stat(join(extractRoot, archiveRelativePath("payload/resources/open-design-config.json")));
+    const packagedConfigPath = join(extractRoot, archiveRelativePath("payload/resources/open-design-config.json"));
+    await stat(packagedConfigPath);
+    await validatePayloadPackagedConfigEntrypoints(extractRoot, packagedConfigPath);
     return { manifest, payloadPath, valid: true };
   } finally {
     await rm(extractRoot, { force: true, recursive: true });

--- a/tools/pack/src/win/payload.ts
+++ b/tools/pack/src/win/payload.ts
@@ -327,7 +327,12 @@ async function validatePayloadPackagedConfigEntrypoints(
   configPath: string,
 ): Promise<void> {
   const config = JSON.parse(await readFile(configPath, "utf8")) as PayloadPackagedConfig;
-  if (config.webOutputMode !== "standalone") return;
+  if (config.webOutputMode !== "standalone" && config.webOutputMode !== "server") {
+    throw new Error(
+      `Windows launcher payload packaged config webOutputMode expected "standalone" or "server" but got ${JSON.stringify(config.webOutputMode)}`,
+    );
+  }
+  if (config.webOutputMode === "server") return;
   await requirePayloadConfigEntry(extractRoot, config, "daemonCliEntryRelative");
   await requirePayloadConfigEntry(extractRoot, config, "daemonSidecarEntryRelative");
   await requirePayloadConfigEntry(extractRoot, config, "webSidecarEntryRelative");

--- a/tools/pack/tests/launcher-payload.test.ts
+++ b/tools/pack/tests/launcher-payload.test.ts
@@ -340,6 +340,31 @@ describe("tools-pack launcher payload archives", () => {
         payloadPath: paths.launcherPayloadPath,
         workspaceRoot: root,
       })).rejects.toThrow("launcher payload manifest version expected");
+
+      const malformedOverlayRoot = join(root, "malformed-overlay");
+      await mkdir(join(malformedOverlayRoot, "payload", "resources"), { recursive: true });
+      await writeFile(
+        join(malformedOverlayRoot, "payload", "resources", "open-design-config.json"),
+        `${JSON.stringify({
+          appVersion: version,
+          daemonCliEntryRelative: "open-design/prebundled/daemon/daemon-cli.mjs",
+          daemonSidecarEntryRelative: "open-design/prebundled/daemon/daemon-sidecar.mjs",
+          namespace,
+          nodeCommandRelative: "open-design/bin/node",
+          webSidecarEntryRelative: "open-design/prebundled/web/web-sidecar.mjs",
+        }, null, 2)}\n`,
+        "utf8",
+      );
+      await execFileAsync(winResources.sevenZipExe, ["u", "-t7z", paths.launcherPayloadPath, ".\\*"], {
+        cwd: malformedOverlayRoot,
+        windowsHide: true,
+      });
+      await expect(validateWinLauncherPayloadArchive({
+        expectedVersion: version,
+        namespace,
+        payloadPath: paths.launcherPayloadPath,
+        workspaceRoot: root,
+      })).rejects.toThrow("webOutputMode expected");
     } finally {
       await rm(root, { force: true, recursive: true });
     }

--- a/tools/pack/tests/launcher-payload.test.ts
+++ b/tools/pack/tests/launcher-payload.test.ts
@@ -156,10 +156,16 @@ async function writeFakeWinUnpackedApp(root: string, namespace: string, version:
   const paths = createWinPaths(root, namespace);
   await mkdir(join(paths.unpackedRoot, "resources"), { recursive: true });
   await writeFile(join(paths.unpackedRoot, "Open Design.exe"), "fake executable\n", "utf8");
+  await mkdir(join(paths.unpackedRoot, "resources", "open-design", "prebundled", "daemon"), { recursive: true });
+  await mkdir(join(paths.unpackedRoot, "resources", "open-design", "prebundled", "web"), { recursive: true });
+  await writeFile(join(paths.unpackedRoot, "resources", "open-design", "prebundled", "daemon", "daemon-cli.mjs"), "export {};\n", "utf8");
+  await writeFile(join(paths.unpackedRoot, "resources", "open-design", "prebundled", "daemon", "daemon-sidecar.mjs"), "export {};\n", "utf8");
+  await writeFile(join(paths.unpackedRoot, "resources", "open-design", "prebundled", "web", "web-sidecar.mjs"), "export {};\n", "utf8");
   await writeFile(
     join(paths.unpackedRoot, "resources", "open-design-config.json"),
     `${JSON.stringify({
       appVersion: version,
+      daemonCliEntryRelative: "open-design/prebundled/daemon/daemon-cli.mjs",
       daemonSidecarEntryRelative: "open-design/prebundled/daemon/daemon-sidecar.mjs",
       namespace,
       nodeCommandRelative: "open-design/bin/node",
@@ -179,6 +185,7 @@ async function writeFakeWinUnpackedApp(root: string, namespace: string, version:
     paths.packagedConfigPath,
     `${JSON.stringify({
       appVersion: version,
+      daemonCliEntryRelative: "open-design/prebundled/daemon/daemon-cli.mjs",
       daemonSidecarEntryRelative: "open-design/prebundled/daemon/daemon-sidecar.mjs",
       namespace,
       nodeCommandRelative: "open-design/bin/node",


### PR DESCRIPTION
## Summary

- Resolve Windows CLI `.cmd`/`.bat` shims even when a packaged GUI environment has stripped or narrowed `PATHEXT`.
- Accept configured Windows CLI overrides such as `codex.cmd` independently of inherited `PATHEXT`.
- Validate standalone Windows launcher payloads contain the configured daemon CLI, daemon sidecar, and web sidecar entries.
- Reject payload configs with a missing or invalid `webOutputMode` during packaging validation.

## Why

While auditing reported Windows packaged CLI and handoff failures, I found that executable resolution trusted the inherited `PATHEXT`. Packaged GUI launches can inherit a reduced environment, making documented CLI and MCP commands fail late on user machines. A malformed launcher payload could also skip entrypoint validation and fail only during startup. This moves both classes of failure into deterministic resolution and packaging validation.

## What users will see

Windows packaged and GUI launches can resolve npm-generated `.cmd`/`.bat` agent shims even when `PATHEXT` is missing or narrowed. Release builds with malformed standalone launcher payloads now fail during packaging instead of shipping and failing at startup. There are no UI changes.

## Surface area

- [ ] **UI** - new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** - new or changed
- [x] **CLI / env var** - new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** - new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** - new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** - added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** - adding any new entry to the root `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope
- [x] **Default behavior change** - changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** - internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this PR has no UI changes.

## Bug fix verification

- Test paths: `apps/daemon/tests/runtimes/executables.test.ts` and `tools/pack/tests/launcher-payload.test.ts`.
- The daemon tests cover PATH resolution and configured `.cmd` overrides with `PATHEXT=.EXE`.
- The archive-level packaging test replaces the packaged config with one missing `webOutputMode` and verifies validation rejects it before startup.
- Red on `main`, green on this branch: not executed in a separate `main` worktree; the new targeted tests pass on this branch and directly encode the previously unhandled conditions.

## Validation

- `corepack pnpm exec vitest run -c vitest.config.ts tests/runtimes/executables.test.ts -t "PATHEXT is stripped"` from `apps/daemon`
- `corepack pnpm exec tsc -p tsconfig.json --noEmit` from `apps/daemon`
- `corepack pnpm exec tsc -p tsconfig.tests.json --noEmit` from `apps/daemon`
- `corepack pnpm exec vitest run tests/launcher-payload.test.ts -t "validates Windows launcher payload archives"` from `tools/pack`
- `corepack pnpm exec tsc -p tsconfig.json --noEmit` from `tools/pack`
- `corepack pnpm exec tsc -p tsconfig.tests.json --noEmit` from `tools/pack`
- `git diff --check` (only Windows CRLF working-copy warnings)