### PR TITLE
fix(daemon): add current-generation Claude models to the picker

### DIFF
--- a/apps/daemon/src/runtimes/defs/claude.ts
+++ b/apps/daemon/src/runtimes/defs/claude.ts
@@ -8,6 +8,17 @@ const CLAUDE_FALLBACK_MODELS = [
   { id: 'sonnet', label: 'Sonnet (alias)' },
   { id: 'opus', label: 'Opus (alias)' },
   { id: 'haiku', label: 'Haiku (alias)' },
+  // Current generation. Kept in sync with the model support matrix
+  // clampClaudeReasoning (shared.ts) already encodes -- if a model shows up
+  // there, it should be selectable here too.
+  { id: 'claude-fable-5', label: 'claude-fable-5' },
+  { id: 'claude-opus-4-8', label: 'claude-opus-4-8' },
+  { id: 'claude-sonnet-5', label: 'claude-sonnet-5' },
+  { id: 'claude-haiku-4-5-20251001', label: 'claude-haiku-4-5-20251001' },
+  { id: 'claude-opus-4-7', label: 'claude-opus-4-7' },
+  { id: 'claude-sonnet-4-6', label: 'claude-sonnet-4-6' },
+  { id: 'claude-opus-4-6', label: 'claude-opus-4-6' },
+  // Prior generation, kept for anyone still pinned to it.
   { id: 'claude-opus-4-5', label: 'claude-opus-4-5' },
   { id: 'claude-sonnet-4-5', label: 'claude-sonnet-4-5' },
   { id: 'claude-haiku-4-5', label: 'claude-haiku-4-5' },

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -1007,6 +1007,17 @@ test('claude helpArgs probes the -p subcommand where --add-dir lives (issue #430
   );
 });
 
+test('claude fallback models include the current generation, not just 4.5', () => {
+  const ids = claude.fallbackModels.map((m) => m.id);
+  assert.ok(ids.includes('claude-fable-5'), 'Fable 5 must be selectable');
+  assert.ok(ids.includes('claude-opus-4-8'));
+  assert.ok(ids.includes('claude-sonnet-5'));
+  assert.ok(ids.includes('claude-haiku-4-5-20251001'));
+  assert.ok(ids.includes('claude-opus-4-7'));
+  assert.ok(ids.includes('claude-sonnet-4-6'));
+  assert.ok(ids.includes('claude-opus-4-6'));
+});
+
 // server.ts:4615 branches on `def.promptInputFormat` to decide how to write
 // the composed prompt to a stdin-fed child: 'stream-json' writes one JSONL
 // `user` message and keeps stdin open, anything else writes the raw prompt


### PR DESCRIPTION
## Why

While working on #6046 (Claude Code reasoning-effort passthrough), a user asked why Fable 5 wasn't selectable in the model picker. Confirmed it's a real model the installed CLI supports fine (`claude --model claude-fable-5` completes a real turn) -- it's just missing from `claudeAgentDef`'s hardcoded `fallbackModels`, which was stuck on the 4.5 generation (`claude-opus-4-5` / `claude-sonnet-4-5` / `claude-haiku-4-5`). Opus 4.8, Sonnet 5, and the whole 4.6/4.7 tier were all missing too.

This PR is independent of #6046 -- it only touches the static model list, not the reasoning-effort logic -- so it's based directly on `main` rather than stacked on that branch.

## What users will see

- Claude Code's model dropdown in the model switcher now offers `claude-fable-5`, `claude-opus-4-8`, `claude-sonnet-5`, `claude-haiku-4-5-20251001`, `claude-opus-4-7`, `claude-sonnet-4-6`, and `claude-opus-4-6`, in addition to the existing aliases and 4.5-generation entries (kept for anyone still pinned to them).

## Surface area

- [x] **UI** -- more entries appear in the existing model dropdown for Claude Code. No new UI code; this only changes what a static, already-rendered list contains.
- [ ] Default behavior change -- not checked: the default model choice (`sonnet` alias / `DEFAULT_MODEL_OPTION`) is unchanged; this is purely additive to the selectable list.

## Screenshots

Same limitation as #6046 -- no browser/screenshot tool available in the environment I used. Verified via the daemon's own `/api/agents` response instead, on a local build of this branch:

```json
["default","sonnet","opus","haiku","claude-fable-5","claude-opus-4-8","claude-sonnet-5","claude-haiku-4-5-20251001","claude-opus-4-7","claude-sonnet-4-6","claude-opus-4-6","claude-opus-4-5","claude-sonnet-4-5","claude-haiku-4-5"]
```

## Bug fix verification

- Test path: `apps/daemon/tests/runtimes/agent-args.test.ts` -- `claude fallback models include the current generation, not just 4.5`
- Went red on `main` / green on this branch? Yes -- on `main` (f2760fd), `claude.fallbackModels` only contains the 4.5-generation ids, so this test's assertions for `claude-fable-5` / `claude-opus-4-8` / `claude-sonnet-5` / etc. fail; they pass on this branch.

## Validation

- `pnpm --filter @open-design/daemon test` (vitest, this file only) -- 46/46 passed
- `tsc -p tsconfig.json --noEmit` and `tsc -p tsconfig.tests.json --noEmit` (apps/daemon) -- clean
- Manually confirmed `claude --model claude-fable-5` completes a real, successful turn against the actual Anthropic API before adding it to the list
- Rebuilt and locally deployed this exact branch and confirmed via `/api/agents` that all seven new ids are now served for `claude`, matching the screenshot section above
