### PR TITLE
fix(daemon): full ACP tool transcript and richer usage telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,10 @@ deploy/agent-bins/
 
 # Looper harness attachments (bug screenshots etc.) — agent scratch, not repo content
 .looper-attachments/
+
+# Deepwork local progress (git-local; OpenCode-readable via .ignore)
+.slim/deepwork/
+
+# Local agent worktrees (must stay git-ignored so pnpm guard does not scan them)
+.slim/worktrees/
+.slim/worktrees.json

--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,3 @@
+# Keep deepwork progress readable by OpenCode while git-ignored
+!.slim/deepwork/
+!.slim/deepwork/**

--- a/apps/daemon/src/agent-protocol/acp/rpc.ts
+++ b/apps/daemon/src/agent-protocol/acp/rpc.ts
@@ -128,15 +128,40 @@ export function promotedOpenCodeSessionErrorPayload(data: unknown, fallbackMessa
 export interface FormattedUsage {
   input_tokens?: number;
   output_tokens?: number;
+  /** OpenAI-like inclusive cache-read subset (input already includes cache). */
   cached_read_tokens?: number;
+  /** Anthropic-like additive cache-read (input is uncached remainder). */
+  cache_read_input_tokens?: number;
+  /** Generic / OpenAI-like cache write alias. */
+  cache_creation_tokens?: number;
+  /** Anthropic-like cache creation field name. */
+  cache_creation_input_tokens?: number;
+  /** OpenAI-like cache write alias used by some ACP adapters. */
+  cached_write_tokens?: number;
   thought_tokens?: number;
   total_tokens?: number;
 }
+
+function firstFiniteNumber(src: Record<string, unknown>, keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = src[key];
+    if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
 /**
- * Normalises an ACP agent's raw `usage` object (camelCase keys) into the
- * snake_case `FormattedUsage` shape used by the daemon event stream. Returns
- * `null` when the input is not a recognisable usage object or has no known
- * fields.
+ * Normalises an ACP agent's raw `usage` object (camelCase and/or snake_case
+ * keys) into the snake_case `FormattedUsage` shape used by the daemon event
+ * stream. Returns `null` when the input is not a recognisable usage object or
+ * has no known fields.
+ *
+ * Cache field names are preserved by family so
+ * `scanRunEventsForUsageAnalytics` can classify anthropic (additive) vs
+ * openai (inclusive) correctly. Do not collapse Anthropic
+ * `cache_read_input_tokens` into `cached_read_tokens`.
  *
  * @param usage - The raw `result.usage` value from a `session/prompt` response.
  * @returns A `FormattedUsage` object with at least one field, or `null`.
@@ -145,13 +170,43 @@ export function formatUsage(usage: unknown): FormattedUsage | null {
   const src = asObject(usage);
   if (!src) return null;
   const out: FormattedUsage = {};
-  if (typeof src.inputTokens === 'number') out.input_tokens = src.inputTokens;
-  if (typeof src.outputTokens === 'number') out.output_tokens = src.outputTokens;
-  if (typeof src.cachedReadTokens === 'number') {
-    out.cached_read_tokens = src.cachedReadTokens;
+  const inputTokens = firstFiniteNumber(src, ['inputTokens', 'input_tokens']);
+  const outputTokens = firstFiniteNumber(src, ['outputTokens', 'output_tokens']);
+  // Prefer source-family keys independently so mixed payloads keep both
+  // semantics when present; otherwise map only within the matching family.
+  const anthropicCacheRead = firstFiniteNumber(src, [
+    'cache_read_input_tokens',
+    'cacheReadInputTokens',
+  ]);
+  const openAiCacheRead = firstFiniteNumber(src, [
+    'cachedReadTokens',
+    'cached_read_tokens',
+  ]);
+  const anthropicCacheCreation = firstFiniteNumber(src, [
+    'cache_creation_input_tokens',
+    'cacheCreationInputTokens',
+  ]);
+  const openAiCacheCreation = firstFiniteNumber(src, [
+    'cacheCreationTokens',
+    'cache_creation_tokens',
+  ]);
+  const openAiCachedWrite = firstFiniteNumber(src, [
+    'cached_write_tokens',
+    'cachedWriteTokens',
+  ]);
+  const thoughtTokens = firstFiniteNumber(src, ['thoughtTokens', 'thought_tokens']);
+  const totalTokens = firstFiniteNumber(src, ['totalTokens', 'total_tokens']);
+  if (inputTokens !== undefined) out.input_tokens = inputTokens;
+  if (outputTokens !== undefined) out.output_tokens = outputTokens;
+  if (anthropicCacheRead !== undefined) out.cache_read_input_tokens = anthropicCacheRead;
+  if (openAiCacheRead !== undefined) out.cached_read_tokens = openAiCacheRead;
+  if (anthropicCacheCreation !== undefined) {
+    out.cache_creation_input_tokens = anthropicCacheCreation;
   }
-  if (typeof src.thoughtTokens === 'number') out.thought_tokens = src.thoughtTokens;
-  if (typeof src.totalTokens === 'number') out.total_tokens = src.totalTokens;
+  if (openAiCacheCreation !== undefined) out.cache_creation_tokens = openAiCacheCreation;
+  if (openAiCachedWrite !== undefined) out.cached_write_tokens = openAiCachedWrite;
+  if (thoughtTokens !== undefined) out.thought_tokens = thoughtTokens;
+  if (totalTokens !== undefined) out.total_tokens = totalTokens;
   return Object.keys(out).length > 0 ? out : null;
 }
 /**

--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -858,6 +858,12 @@ export function attachAcpSession({
       return;
     }
     if (promptRequestId !== null && obj.id === promptRequestId) {
+      // Flush still-open tools before AMR no-output classification. A successful
+      // session/prompt may omit a terminal tool_call_update; clean-closing those
+      // pending non-think tools flips emittedConcreteToolEvent so we take
+      // finishCleanPrompt instead of acp_no_visible_output (which would re-flush
+      // them as isError via fail()). Think-only open tools do not flip the flag.
+      flushOpenAcpTools();
       const usage = formatUsage(result.usage);
       if (!emittedVisibleTextChunk && !emittedConcreteToolEvent && modelUnavailableErrorCode) {
         const outputTokens = usage?.output_tokens;

--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -238,11 +238,14 @@ export function attachAcpSession({
     emittedConcreteToolEvent = true;
   };
 
-  const flushOpenAcpTools = () => {
+  // Flush tools that never received a terminal `tool_call_update`. Clean
+  // completion uses isError=false (best-effort close); fail paths use
+  // isError=true so Langfuse/PostHog and the persisted transcript keep the
+  // open tool as an errored result instead of dropping it entirely.
+  const flushOpenAcpTools = (isError = false) => {
     for (const [toolCallId, st] of acpToolRunEventState) {
       if (st.emitted) continue;
-      // Incomplete tools: best-effort flush so traces stay complete.
-      emitTerminalToolPair(toolCallId, st, false);
+      emitTerminalToolPair(toolCallId, st, isError);
     }
     acpToolRunEventState.clear();
   };
@@ -288,6 +291,9 @@ export function attachAcpSession({
 
   const failWithPayload = (payload: unknown) => {
     if (finished) return;
+    // Emit pending tools as errored before terminal state so deferred
+    // tool_use pairs are not lost on timeout / process death / RPC error.
+    flushOpenAcpTools(true);
     finished = true;
     fatal = true;
     clearStageTimer();
@@ -300,6 +306,9 @@ export function attachAcpSession({
     options: { forceModelUnavailable?: boolean; details?: unknown; retryable?: boolean } = {},
   ) => {
     if (finished) return;
+    // Emit pending tools as errored before terminal state so deferred
+    // tool_use pairs are not lost on timeout / process death / RPC error.
+    flushOpenAcpTools(true);
     finished = true;
     fatal = true;
     clearStageTimer();

--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -36,12 +36,17 @@ import {
 } from './rpc.js';
 import {
   acpRawEventShape,
-  isAcpCompletedStatus,
   isAcpTerminalFailureStatus,
   acpToolCallId,
   isAcpArtifactWriteLabel,
   isAcpArtifactWriteUpdate,
-  acpArtifactWritePath,
+  isAcpTerminalToolStatus,
+  isAcpThinkOnlyTool,
+  isAcpRecognizedKind,
+  acpArtifactWritePathRanked,
+  acpToolName,
+  acpToolInput,
+  acpToolResultContent,
   promotedAmrRetryStatusPayload,
   promotedAmrStderrPayload,
 } from './updates.js';
@@ -97,7 +102,8 @@ export interface AttachAcpSessionOptions {
  * 5. Streams `session/update` events to the `send` callback, translating:
  *    - `agent_thought_chunk` → `thinking_start` / `thinking_delta`
  *    - `agent_message_chunk` → `text_delta` (with DSML and tool-call text suppression)
- *    - `tool_call` / `tool_call_update` → deferred `tool_use` / `tool_result` pairs
+ *    - `tool_call` / `tool_call_update` → full `tool_use` / `tool_result` transcript
+ *      (all tools; write tools keep Claude-shaped names + `file_path` for artifact count)
  *    - status updates → `agent.status` events
  * 6. Handles `session/request_permission` calls by auto-approving.
  * 7. On prompt completion, flushes suppression buffers, emits usage, and closes stdin.
@@ -180,12 +186,66 @@ export function attachAcpSession({
     closedBlocks: 0,
   };
   const acpArtifactWriteToolCallIds = new Set<string>();
-  // Per artifact-write tool call, accumulate the best concrete file path seen
-  // across its frames and whether we have already mirrored it into canonical
-  // tool_use/tool_result events. Emission is deferred to the terminal frame so
-  // a `locations`/`rawInput` path that ACP only sends on a later update is used
-  // for classification, instead of locking in a first-frame guess.
-  const acpArtifactRunEventState = new Map<string, { path: string | null; emitted: boolean }>();
+  // Per toolCallId: accumulate name/input/path/result across partial ACP frames
+  // and emit exactly one tool_use + one tool_result at terminal status (or on
+  // prompt flush for still-open tools). Think-only tools are tracked but never
+  // transcribed and never flip emittedConcreteToolEvent. Entries stay after
+  // emit so a repeated terminal frame cannot re-create + re-emit.
+  type AcpToolNameSource = 'kind' | 'other';
+  type AcpToolRunState = {
+    name: string;
+    nameSource: AcpToolNameSource;
+    input: Record<string, unknown>;
+    path: string | null;
+    pathRank: number;
+    resultContent: string;
+    /** Sticky: once true, never cleared by later status-only frames. */
+    thinkOnly: boolean;
+    firstSeenAt: number;
+    emitted: boolean;
+  };
+  const acpToolRunEventState = new Map<string, AcpToolRunState>();
+
+  const buildToolUseInput = (st: AcpToolRunState): Record<string, unknown> => {
+    const input = { ...st.input };
+    if (st.path) input.file_path = st.path;
+    else delete input.file_path;
+    return input;
+  };
+
+  const emitTerminalToolPair = (toolCallId: string, st: AcpToolRunState, isError: boolean) => {
+    if (st.emitted) return;
+    st.emitted = true;
+    // Think/reason frames are activity noise for AMR no-output detection and
+    // must not appear as concrete tool_use/tool_result events.
+    if (st.thinkOnly) return;
+    send('agent', {
+      type: 'tool_use',
+      id: toolCallId,
+      name: st.name,
+      input: buildToolUseInput(st),
+      // Wall-clock start of the first ACP frame for this toolCallId so analytics
+      // can compute real duration even though tool_use is emitted at terminal.
+      startedAt: st.firstSeenAt,
+    });
+    send('agent', {
+      type: 'tool_result',
+      toolUseId: toolCallId,
+      content: st.resultContent,
+      isError,
+    });
+    // Concrete only on terminal tool_result for a real (non-think) tool.
+    emittedConcreteToolEvent = true;
+  };
+
+  const flushOpenAcpTools = () => {
+    for (const [toolCallId, st] of acpToolRunEventState) {
+      if (st.emitted) continue;
+      // Incomplete tools: best-effort flush so traces stay complete.
+      emitTerminalToolPair(toolCallId, st, false);
+    }
+    acpToolRunEventState.clear();
+  };
 
   const stageWatchdogDisabled = stageTimeoutMs <= 0;
   const resetStageTimer = (label: string) => {
@@ -408,8 +468,24 @@ export function attachAcpSession({
     nextId += 1;
   };
 
+  // Best-effort: emit provider usage before terminal fail/success so failed
+  // ACP runs still contribute token fields to PostHog/Langfuse when the agent
+  // returned a usage object on the prompt result.
+  const emitUsageIfPresent = (usageSource?: unknown) => {
+    const usage = formatUsage(usageSource);
+    if (!usage) return;
+    send('agent', {
+      type: 'usage',
+      usage,
+      durationMs: Date.now() - runStartedAt,
+    });
+  };
+
   const finishCleanPrompt = (usageSource?: unknown) => {
     if (finished) return;
+    // Flush any tools still open when the prompt completes so traces stay
+    // complete (one tool_use + tool_result per id).
+    flushOpenAcpTools();
     const flushedToolText = toolCallTextSuppressor.flush();
     noteToolCallTextSuppression('tool_call_xml_flush');
     const flushedText = flushedToolText ? (dsmlArtifactSuppressor?.strip(flushedToolText) ?? flushedToolText) : '';
@@ -419,14 +495,7 @@ export function attachAcpSession({
     noteArtifactTextSuppression('artifact_flush');
     emitToolCallTextSuppressionSummary();
     emitArtifactTextSuppressionSummary();
-    const usage = formatUsage(usageSource);
-    if (usage) {
-      send('agent', {
-        type: 'usage',
-        usage,
-        durationMs: Date.now() - runStartedAt,
-      });
-    }
+    emitUsageIfPresent(usageSource);
     finished = true;
     clearStageTimer();
     stdin.end();
@@ -633,51 +702,62 @@ export function attachAcpSession({
         if (toolCallId && isAcpArtifactWriteLabel(update)) {
           acpArtifactWriteToolCallIds.add(toolCallId);
         }
-        // Mirror artifact-write tool calls into the daemon's canonical
-        // tool_use/tool_result event shape so `countNewArtifacts`
-        // (run-artifacts.ts) can see ACP file writes. Without this, every ACP
-        // agent (AMR, Hermes, Kilo, Kiro, Devin, Vibe, …) reported
-        // run_finished.artifact_count: 0 even when the run wrote artifacts,
-        // because the ACP adapter emitted only text/status/thinking events and
-        // never the tool_use/tool_result pair the counter scans for.
-        //
-        // This path only feeds the NO-PROJECT fallback (project runs use the
-        // filesystem snapshot). Two correctness rules, both learned the hard
-        // way in review:
-        //   1. Defer emission to the TERMINAL frame and accumulate the best
-        //      concrete path across frames — ACP often sends `locations` only
-        //      on the completing update, and emitting on the first frame would
-        //      lock in a wrong/empty guess that a later path can't correct.
-        //   2. Never fabricate an artifact extension. `isArtifactPath` is what
-        //      decides whether a write counts; feeding it a real path lets it
-        //      correctly EXCLUDE non-artifact edits (`config.json`, `README.md`)
-        //      and INCLUDE real artifacts. A write that never carries a concrete
-        //      path stays keyed on its (extension-less) toolCallId, so it is
-        //      simply not counted rather than inflating the metric with a
-        //      synthetic `.html` — under-counting a truly opaque write is
-        //      acceptable; a false-positive artifact is not.
+        // Full ACP tool transcript → canonical tool_use/tool_result events for
+        // Langfuse/PostHog and `countNewArtifacts` (run-artifacts.ts). Every
+        // non-think tool is mirrored once at terminal status (accumulate
+        // partial frames first). Write tools keep Claude-shaped Write/Edit
+        // names and a real `file_path` when present. Never use toolCallId as
+        // file_path.
         if (toolCallId) {
-          const isWriteCall =
-            isAcpArtifactWriteLabel(update) || acpArtifactWriteToolCallIds.has(toolCallId);
-          if (isWriteCall) {
-            let st = acpArtifactRunEventState.get(toolCallId);
-            if (!st) {
-              st = { path: null, emitted: false };
-              acpArtifactRunEventState.set(toolCallId, st);
+          const nextName = acpToolName(update);
+          const nextInput = acpToolInput(update);
+          const nextPath = acpArtifactWritePathRanked(update);
+          const nextResult = acpToolResultContent(update);
+          const nextThinkOnly = isAcpThinkOnlyTool(update);
+          const kindRaw = typeof update.kind === 'string' ? update.kind.trim() : '';
+          const nameFromKind = Boolean(kindRaw && isAcpRecognizedKind(kindRaw));
+          let st = acpToolRunEventState.get(toolCallId);
+          if (!st) {
+            st = {
+              name: nextName,
+              nameSource: nameFromKind ? 'kind' : 'other',
+              input: nextInput,
+              path: nextPath?.path ?? null,
+              pathRank: nextPath?.rank ?? 0,
+              resultContent: nextResult,
+              thinkOnly: nextThinkOnly,
+              firstSeenAt: Date.now(),
+              emitted: false,
+            };
+            acpToolRunEventState.set(toolCallId, st);
+          } else if (!st.emitted) {
+            // Kind-locked names must not be overwritten by later title-only frames
+            // (e.g. kind:read then title "Update cache" must stay Read).
+            if (nameFromKind) {
+              st.name = nextName;
+              st.nameSource = 'kind';
+            } else if (st.nameSource !== 'kind') {
+              // Prefer a more specific name over the generic fallback.
+              if (nextName !== 'Tool' || st.name === 'Tool') st.name = nextName;
             }
-            if (!st.path) st.path = acpArtifactWritePath(update);
+            // Shallow merge rawInput; later keys win.
+            st.input = { ...st.input, ...nextInput };
+            // Upgrade path when a higher-precedence source appears.
+            if (nextPath && (!st.path || nextPath.rank >= st.pathRank)) {
+              st.path = nextPath.path;
+              st.pathRank = nextPath.rank;
+            }
+            // Keep last non-empty result payload (terminal may be status-only).
+            if (nextResult) st.resultContent = nextResult;
+            // Sticky think-only: once classified, never clear on later frames
+            // (terminal status-only frames have no title and would otherwise
+            // flip thinkOnly false and emit a fake concrete tool).
+            if (nextThinkOnly) st.thinkOnly = true;
+          }
+          if (isAcpTerminalToolStatus(update)) {
             const failed = isAcpTerminalFailureStatus(update);
-            if (!st.emitted && (failed || isAcpCompletedStatus(update))) {
-              st.emitted = true;
-              send('agent', {
-                type: 'tool_use',
-                id: toolCallId,
-                name: 'Write',
-                input: { file_path: st.path ?? toolCallId },
-              });
-              send('agent', { type: 'tool_result', toolUseId: toolCallId, isError: failed });
-              emittedConcreteToolEvent = true;
-            }
+            emitTerminalToolPair(toolCallId, st, failed);
+            // Keep the entry (emitted=true) so a repeated terminal cannot re-emit.
           }
         }
         if (isAcpArtifactWriteUpdate(update, acpArtifactWriteToolCallIds)) {
@@ -770,6 +850,8 @@ export function attachAcpSession({
       if (!emittedVisibleTextChunk && !emittedConcreteToolEvent && modelUnavailableErrorCode) {
         const outputTokens = usage?.output_tokens;
         const hadCompletionTokens = typeof outputTokens === 'number' && outputTokens > 0;
+        // Emit usage before fail so analytics still sees provider tokens.
+        emitUsageIfPresent(result.usage);
         if (hadCompletionTokens || emittedToolCall || emittedTextChunk) {
           fail(
             'ACP session completed after reporting model activity, but did not produce visible assistant text, concrete tool results, or artifacts.',

--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -222,8 +222,9 @@ export function attachAcpSession({
     // must not appear as concrete tool_use/tool_result events.
     if (st.thinkOnly) return;
     // Raw ACP toolCallId stays as the local Map key for frame correlation; the
-    // transcript/telemetry id is opaque so path-like adapter ids never leak
-    // into Langfuse span ids or metadata.toolCallId.
+    // transcript/telemetry id is always an opaque hash so adapter-supplied
+    // ids (paths, tokens, JWTs) never leak into Langfuse span ids or
+    // metadata.toolCallId.
     const telemetryToolCallId = acpTelemetryToolCallId(toolCallId);
     send('agent', {
       type: 'tool_use',

--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -251,12 +251,17 @@ export function attachAcpSession({
   // completion uses isError=false (best-effort close); fail paths use
   // isError=true so Langfuse/PostHog and the persisted transcript keep the
   // open tool as an errored result instead of dropping it entirely.
+  //
+  // Do not clear the map after flush. Emitted entries must stay until the
+  // session ends so a late/racy terminal `tool_call_update` (timeout/abort/
+  // prompt-response flush racing buffered stdout) cannot recreate the same
+  // id as a fresh open tool and emit a second, possibly contradictory
+  // tool_use/tool_result pair. `st.emitted` already suppresses re-emission.
   const flushOpenAcpTools = (isError = false) => {
     for (const [toolCallId, st] of acpToolRunEventState) {
       if (st.emitted) continue;
       emitTerminalToolPair(toolCallId, st, isError);
     }
-    acpToolRunEventState.clear();
   };
 
   const stageWatchdogDisabled = stageTimeoutMs <= 0;

--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -48,6 +48,7 @@ import {
   acpToolInput,
   acpToolResultContent,
   acpSafeToolResultContent,
+  acpTelemetryToolCallId,
   promotedAmrRetryStatusPayload,
   promotedAmrStderrPayload,
 } from './updates.js';
@@ -220,9 +221,13 @@ export function attachAcpSession({
     // Think/reason frames are activity noise for AMR no-output detection and
     // must not appear as concrete tool_use/tool_result events.
     if (st.thinkOnly) return;
+    // Raw ACP toolCallId stays as the local Map key for frame correlation; the
+    // transcript/telemetry id is opaque so path-like adapter ids never leak
+    // into Langfuse span ids or metadata.toolCallId.
+    const telemetryToolCallId = acpTelemetryToolCallId(toolCallId);
     send('agent', {
       type: 'tool_use',
-      id: toolCallId,
+      id: telemetryToolCallId,
       name: st.name,
       input: buildToolUseInput(st),
       // Wall-clock start of the first ACP frame for this toolCallId so analytics
@@ -231,7 +236,7 @@ export function attachAcpSession({
     });
     send('agent', {
       type: 'tool_result',
-      toolUseId: toolCallId,
+      toolUseId: telemetryToolCallId,
       // Bash/execute stdout can dump private files (cat .env). Langfuse only
       // lexically masks Bash, so redact before the canonical transcript ships.
       content: acpSafeToolResultContent(st.name, st.resultContent),

--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -955,6 +955,11 @@ export function attachAcpSession({
      */
     abort() {
       if (aborted || finished) return;
+      // Flush deferred tool pairs as errored before terminal cancel. Tools are
+      // held until a terminal tool_call_update; without this flush, user cancel
+      // (runs.ts → acpSession.abort) drops in-progress tools from the transcript
+      // and from Langfuse/PostHog — unlike timeout and child-exit fail paths.
+      flushOpenAcpTools(true);
       aborted = true;
       finished = true;
       clearStageTimer();

--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -47,6 +47,7 @@ import {
   acpToolName,
   acpToolInput,
   acpToolResultContent,
+  acpSafeToolResultContent,
   promotedAmrRetryStatusPayload,
   promotedAmrStderrPayload,
 } from './updates.js';
@@ -231,7 +232,9 @@ export function attachAcpSession({
     send('agent', {
       type: 'tool_result',
       toolUseId: toolCallId,
-      content: st.resultContent,
+      // Bash/execute stdout can dump private files (cat .env). Langfuse only
+      // lexically masks Bash, so redact before the canonical transcript ships.
+      content: acpSafeToolResultContent(st.name, st.resultContent),
       isError,
     });
     // Concrete only on terminal tool_result for a real (non-think) tool.

--- a/apps/daemon/src/agent-protocol/acp/updates.ts
+++ b/apps/daemon/src/agent-protocol/acp/updates.ts
@@ -582,6 +582,41 @@ export function acpToolResultContent(update: JsonObject, maxChars = 8000): strin
 }
 
 /**
+ * Execute-family tools whose stdout can contain arbitrary private file content
+ * (`cat .env`, dumps of secrets, etc.). Normalized ACP names for these kinds
+ * are Claude-shaped `Bash` plus common aliases.
+ */
+const ACP_EXECUTE_TOOL_NAMES_LOWER: ReadonlySet<string> = new Set([
+  'bash',
+  'shell',
+  'execute',
+  'terminal',
+]);
+
+/** True when `toolName` is an ACP execute/bash-family tool. */
+export function isAcpExecuteToolName(toolName: string): boolean {
+  const normalized = toolName.trim().toLowerCase();
+  if (!normalized) return false;
+  return ACP_EXECUTE_TOOL_NAMES_LOWER.has(normalized);
+}
+
+/**
+ * Sanitizes ACP tool_result content for the canonical agent transcript.
+ *
+ * Content tools (Read/Write/…) keep full bodies so the local UI and Langfuse
+ * content-tool redactor can each do their job. Execute/Bash is different:
+ * Langfuse only applies lexical secret+path masking to Bash, and ACP only
+ * started forwarding execute results with the full-transcript change — so a
+ * `cat .env` body would ship to telemetry almost intact. Replace raw stdout
+ * with a length summary before emit.
+ */
+export function acpSafeToolResultContent(toolName: string, content: string): string {
+  if (!content) return content;
+  if (!isAcpExecuteToolName(toolName)) return content;
+  return `[REDACTED:acp_bash_output:${content.length}_chars]`;
+}
+
+/**
  * Best-effort extraction of a concrete file path from an ACP tool-call update,
  * checking three sources in priority order:
  * 1. `locations` or `content` array entries with a `path` field.

--- a/apps/daemon/src/agent-protocol/acp/updates.ts
+++ b/apps/daemon/src/agent-protocol/acp/updates.ts
@@ -479,9 +479,10 @@ export function isAcpPartialRedactToolName(toolName: string): boolean {
  * collapses to the opaque family label `Other`. Langfuse additionally
  * canonicalizes non-allowlisted names at the telemetry boundary.
  *
- * Callers that resolve names under trusted `kind:other` must also reject
- * Bash-like partial-redact labels via `isAcpPartialRedactToolName` so custom
- * tools cannot impersonate the sole non-fail-closed family.
+ * Callers that resolve names without a recognized execute-family kind
+ * (missing kind, kind:other, unknown kinds) must also reject Bash-like
+ * partial-redact labels via `isAcpPartialRedactToolName` so custom tools
+ * cannot impersonate the sole non-fail-closed family.
  */
 export function sanitizeAcpCustomToolName(raw: string): string {
   const trimmed = raw.trim();
@@ -529,11 +530,13 @@ export function acpTelemetryToolCallId(raw: string): string {
  * exception: it is recognized for stickiness but is not a family, so an
  * explicit identifier-like name still wins there for UI/transcript — except
  * Bash-like partial-redact labels, which collapse to `Other` so custom MCP
- * tools cannot bypass Langfuse fail-closed payload redaction. Untrusted
- * free-text names (paths, tokens, titles) are collapsed to `Other` before the
- * event is emitted so Langfuse span labels cannot carry user-specific strings.
- * Payloads for unknown tools still fail closed in Langfuse
- * (`shouldFullyRedactToolPayload`). Write-label override to Write/Edit
+ * tools cannot bypass Langfuse fail-closed payload redaction. The same rule
+ * applies when `kind` is missing: a bare `name: "Bash"` (or Bash-like title)
+ * must not unlock partial redaction without a recognized execute-family kind.
+ * Untrusted free-text names (paths, tokens, titles) are collapsed to `Other`
+ * before the event is emitted so Langfuse span labels cannot carry
+ * user-specific strings. Payloads for unknown tools still fail closed in
+ * Langfuse (`shouldFullyRedactToolPayload`). Write-label override to Write/Edit
  * applies only when there is no recognized non-write kind, so
  * `countNewArtifacts` keeps working for title-only write frames.
  */
@@ -551,15 +554,18 @@ export function acpToolName(update: JsonObject): string {
     // Content-tool redaction keys off stable Claude-shaped families; keeping
     // adapter-local names would skip the known-content path (unknown names
     // still fail closed in Langfuse, but canonical families stay precise).
+    // Execute-family kinds are the only path that may emit Bash (partial-redact).
     name = kindName;
   } else if (typeof update.name === 'string' && update.name.trim()) {
-    // kind:other / custom: keep only identifier-like adapter names. Paths,
-    // tokens, and free text collapse to Other before the event is emitted.
+    // kind:other / missing kind / unknown kind: keep only identifier-like
+    // adapter names. Paths, tokens, and free text collapse to Other before
+    // the event is emitted.
     name = sanitizeAcpCustomToolName(update.name);
-    // Fail closed: kind:other must not claim Bash/shell/execute/terminal.
-    // Those names unlock Langfuse partial-redact (lexical masking only);
-    // custom MCP tools can put arbitrary private content in rawInput.
-    if (kindToken === 'other' && isAcpPartialRedactToolName(name)) {
+    // Fail closed: without a recognized execute-family kind, never claim
+    // Bash/shell/execute/terminal. Those names unlock Langfuse partial-redact
+    // (lexical masking only); unclassified custom tools (no kind, kind:other)
+    // can put arbitrary private content in rawInput.
+    if (isAcpPartialRedactToolName(name)) {
       name = 'Other';
     }
   } else if (recognizedKind && kindName) {
@@ -570,8 +576,9 @@ export function acpToolName(update: JsonObject): string {
     const fromTitle = acpToolNameFromTitle(update.title);
     // Title heuristics can still surface path-like first tokens; sanitize.
     name = fromTitle ? sanitizeAcpCustomToolName(fromTitle) : null;
-    // Same fail-closed rule when kind:other reaches title (no name field).
-    if (name && kindToken === 'other' && isAcpPartialRedactToolName(name)) {
+    // Same fail-closed rule for title-derived Bash labels without execute kind
+    // (missing kind, kind:other, or any non-canonical-family path).
+    if (name && isAcpPartialRedactToolName(name)) {
       name = 'Other';
     }
   } else if (kindName) {

--- a/apps/daemon/src/agent-protocol/acp/updates.ts
+++ b/apps/daemon/src/agent-protocol/acp/updates.ts
@@ -72,6 +72,13 @@ export function isAcpTerminalFailureStatus(update: JsonObject): boolean {
   return status === 'failed' || status === 'failure' || status === 'error' || status === 'cancelled' || status === 'canceled';
 }
 /**
+ * Returns `true` when the update's status is a terminal tool outcome
+ * (completed or failed). Used to decide when to emit `tool_result`.
+ */
+export function isAcpTerminalToolStatus(update: JsonObject): boolean {
+  return isAcpCompletedStatus(update) || isAcpTerminalFailureStatus(update);
+}
+/**
  * Returns `true` when the update's status is `'retry'`. Signals that the AMR
  * agent wants to restart the request; the session promoter maps this to a
  * structured error payload via `promotedAmrRetryStatusPayload`.
@@ -185,20 +192,130 @@ export function acpToolCallId(update: JsonObject): string | null {
     ? update.toolCallId.trim()
     : null;
 }
+/** True when ACP `kind` is a recognized write/edit family token. */
+function isAcpWriteEditKind(kind: string): boolean {
+  const token = kind.trim().toLowerCase();
+  return (
+    token === 'edit' ||
+    token === 'write' ||
+    token === 'create' ||
+    token === 'patch' ||
+    token === 'replace' ||
+    token === 'update' ||
+    token === 'save'
+  );
+}
+
 /**
- * Returns `true` when the update's `title` or `name` field contains a word
- * that indicates a file-write operation (`edit`, `write`, `create`, `update`,
- * `save`, `patch`, or `replace`). Used to heuristically identify
- * artifact-write tool calls before their `toolCallId` is known.
+ * True when ACP `kind` is a known tool family we trust over title heuristics.
+ * Unknown kinds still map to a display name but do not lock the tool name
+ * across partial frames (agents sometimes invent kind strings).
+ */
+export function isAcpRecognizedKind(kind: string): boolean {
+  const token = kind.trim().toLowerCase();
+  if (!token) return false;
+  if (isAcpWriteEditKind(token)) return true;
+  return (
+    token === 'read' ||
+    token === 'execute' ||
+    token === 'bash' ||
+    token === 'shell' ||
+    token === 'terminal' ||
+    token === 'search' ||
+    token === 'grep' ||
+    token === 'glob' ||
+    token === 'think' ||
+    token === 'thought' ||
+    token === 'reason' ||
+    token === 'reasoning' ||
+    token === 'fetch' ||
+    token === 'web' ||
+    token === 'other'
+  );
+}
+
+/**
+ * Returns `true` when the update's `kind`, `title`, or `name` field indicates
+ * a file-write operation (`edit`, `write`, `create`, `update`, `save`,
+ * `patch`, or `replace`). Used to identify artifact-write tool calls for the
+ * DSML suppressor (including kind-only write frames with no title words).
  *
  * @param update - A parsed ACP `session/update` params object.
  */
 export function isAcpArtifactWriteLabel(update: JsonObject): boolean {
+  if (typeof update.kind === 'string' && isAcpWriteEditKind(update.kind)) {
+    return true;
+  }
   const label = [
     typeof update.title === 'string' ? update.title : '',
     typeof update.name === 'string' ? update.name : '',
   ].join(' ');
   return /\b(?:edit|write|create|update|save|patch|replace)\b/i.test(label);
+}
+
+/**
+ * Returns `true` when the tool is pure think/reason activity and must not
+ * count as a concrete tool event for AMR no-output detection (and is omitted
+ * from the tool_use/tool_result transcript).
+ */
+export function isAcpThinkOnlyTool(update: JsonObject): boolean {
+  const kind = typeof update.kind === 'string' ? update.kind.trim().toLowerCase() : '';
+  if (
+    kind === 'think' ||
+    kind === 'thought' ||
+    kind === 'reason' ||
+    kind === 'reasoning'
+  ) {
+    return true;
+  }
+  const name = typeof update.name === 'string' ? update.name.trim() : '';
+  if (name && /^(think|thinking|thought|reason|reasoning)$/i.test(name)) {
+    return true;
+  }
+  const title = typeof update.title === 'string' ? update.title.trim() : '';
+  if (title && /^(think|thinking|thought|reason|reasoning)\b/i.test(title)) {
+    return true;
+  }
+  return false;
+}
+
+/** Path source rank: higher wins when merging partial ACP frames. */
+export const ACP_PATH_RANK_LOCATIONS = 3;
+export const ACP_PATH_RANK_RAW_INPUT = 2;
+export const ACP_PATH_RANK_TITLE = 1;
+
+export type AcpPathCandidate = { path: string; rank: number };
+
+/**
+ * Best-effort path extraction with a precedence rank so partial-frame merges
+ * can upgrade a weak title path when locations/rawInput arrive later.
+ */
+export function acpArtifactWritePathRanked(update: JsonObject): AcpPathCandidate | null {
+  // 1. ACP `locations: [{ path }]` and `content: [{ path }]` (diff entries).
+  for (const field of [update.locations, update.content]) {
+    if (!Array.isArray(field)) continue;
+    for (const entry of field) {
+      const path = asObject(entry)?.path;
+      if (typeof path === 'string' && path.trim()) {
+        return { path: path.trim(), rank: ACP_PATH_RANK_LOCATIONS };
+      }
+    }
+  }
+  // 2. Tool input: path / file_path / filename / filePath (camelCase).
+  const rawInput = asObject(update.rawInput);
+  for (const key of ['path', 'file_path', 'filename', 'filePath']) {
+    const value = rawInput?.[key];
+    if (typeof value === 'string' && value.trim()) {
+      return { path: value.trim(), rank: ACP_PATH_RANK_RAW_INPUT };
+    }
+  }
+  // 3. A path-like filename token in the human title (reject `Image.open`).
+  const title = typeof update.title === 'string' ? update.title : '';
+  const match = title.match(/[\w./\\-]+\.[A-Za-z0-9]+/);
+  if (match?.[0] && isAcpPathLikeToken(match[0])) {
+    return { path: match[0], rank: ACP_PATH_RANK_TITLE };
+  }
+  return null;
 }
 /**
  * Returns `true` when an ACP update represents the terminal completion of an
@@ -214,44 +331,252 @@ export function isAcpArtifactWriteUpdate(update: JsonObject, writeToolCallIds: S
   const toolCallId = acpToolCallId(update);
   return isAcpArtifactWriteLabel(update) || (toolCallId ? writeToolCallIds.has(toolCallId) : false);
 }
-// Best-effort file path for an ACP artifact-write tool call. ACP can carry a
-// `locations: [{ path }]` array and/or `content: [{ type:'diff', path }]`
-// entries, but many agents omit both and send only a human `title` ("edit").
-// Returns null when no concrete path is present; the caller then falls back to
-// the toolCallId as a dedup key.
+/** Tool names that `countNewArtifacts` treats as write/edit operations. */
+const ACP_WRITE_OR_EDIT_TOOL_NAMES: ReadonlySet<string> = new Set([
+  'Write',
+  'create_file',
+  'Edit',
+  'str_replace_edit',
+  'MultiEdit',
+  'multi_edit',
+]);
+
+/** Extensions that make a dotted title token look like a real file path. */
+const ACP_PATH_LIKE_EXTENSIONS: ReadonlySet<string> = new Set([
+  'html',
+  'htm',
+  'css',
+  'js',
+  'ts',
+  'tsx',
+  'jsx',
+  'mjs',
+  'cjs',
+  'md',
+  'mdx',
+  'json',
+  'jsonc',
+  'yaml',
+  'yml',
+  'toml',
+  'svg',
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'webp',
+  'avif',
+  'ico',
+  'mp4',
+  'mov',
+  'webm',
+  'mp3',
+  'wav',
+  'm4a',
+  'pdf',
+  'txt',
+  'csv',
+  'xml',
+  'py',
+  'go',
+  'rs',
+  'rb',
+  'php',
+  'sh',
+  'bash',
+  'zsh',
+  'vue',
+  'svelte',
+  'astro',
+  'scss',
+  'less',
+  'map',
+  'wasm',
+]);
+
 /**
- * Best-effort extraction of a concrete file path from an ACP artifact-write
- * tool call update, checking three sources in priority order:
+ * Returns `true` when `token` looks like a filesystem path rather than a
+ * dotted identifier (`Image.open`, `f.read`, `pptx.util`).
+ */
+export function isAcpPathLikeToken(token: string): boolean {
+  const value = token.trim();
+  if (!value) return false;
+  if (value.startsWith('.') || value.includes('/') || value.includes('\\')) return true;
+  const dot = value.lastIndexOf('.');
+  if (dot <= 0 || dot === value.length - 1) return false;
+  const ext = value.slice(dot + 1).toLowerCase();
+  return ACP_PATH_LIKE_EXTENSIONS.has(ext);
+}
+
+/**
+ * Maps a common ACP `kind` string to a stable Claude-shaped tool name.
+ */
+function acpToolNameFromKind(kind: string): string | null {
+  const token = kind.trim().toLowerCase();
+  if (!token) return null;
+  if (token === 'edit' || token === 'patch' || token === 'replace' || token === 'update') {
+    return 'Edit';
+  }
+  if (token === 'write' || token === 'create' || token === 'save') return 'Write';
+  if (token === 'read') return 'Read';
+  if (token === 'execute' || token === 'bash' || token === 'shell' || token === 'terminal') {
+    return 'Bash';
+  }
+  if (token === 'search' || token === 'grep' || token === 'glob') return 'Grep';
+  if (token === 'think' || token === 'thought' || token === 'reason' || token === 'reasoning') {
+    return 'Think';
+  }
+  if (token === 'fetch' || token === 'web') return 'Fetch';
+  // Title-case unknown kinds for a stable display name.
+  return token.charAt(0).toUpperCase() + token.slice(1);
+}
+
+/**
+ * Derives a tool name from a human `title` when `name`/`kind` are absent.
+ */
+function acpToolNameFromTitle(title: string): string | null {
+  const trimmed = title.trim();
+  if (!trimmed) return null;
+  if (/\b(?:grep|search|glob)\b/i.test(trimmed)) return 'Grep';
+  if (/\b(?:bash|shell|execute|terminal|run)\b/i.test(trimmed)) return 'Bash';
+  if (/\bread\b/i.test(trimmed)) return 'Read';
+  if (/\b(?:edit|patch|replace)\b/i.test(trimmed)) return 'Edit';
+  if (/\b(?:write|create|save|update)\b/i.test(trimmed)) return 'Write';
+  const first = trimmed.split(/\s+/)[0];
+  if (!first) return null;
+  return first.charAt(0).toUpperCase() + first.slice(1);
+}
+
+/**
+ * Resolves a stable Claude-shaped tool name from an ACP tool-call update.
+ * Trusted ACP `kind` wins over title heuristics when the kind is recognized
+ * (so `kind: read` + title "update …" stays Read). Explicit `name` still wins
+ * when present. Write-label override to Write/Edit applies only when there is
+ * no recognized non-write kind, so `countNewArtifacts` keeps working for
+ * title-only write frames.
+ */
+export function acpToolName(update: JsonObject): string {
+  const kindRaw = typeof update.kind === 'string' ? update.kind.trim() : '';
+  const recognizedKind = kindRaw ? isAcpRecognizedKind(kindRaw) : false;
+  const kindName = kindRaw ? acpToolNameFromKind(kindRaw) : null;
+
+  let name: string | null = null;
+  if (typeof update.name === 'string' && update.name.trim()) {
+    name = update.name.trim();
+  } else if (recognizedKind && kindName) {
+    // Kind is authoritative over title heuristics.
+    name = kindName;
+  } else if (typeof update.title === 'string' && update.title.trim()) {
+    name = acpToolNameFromTitle(update.title);
+  } else if (kindName) {
+    name = kindName;
+  }
+  if (!name) name = 'Tool';
+
+  // Write-label override: only when kind is absent/unrecognized, or is already
+  // a write/edit family kind. Never turn kind:read into Write because the title
+  // contains "update".
+  if (isAcpArtifactWriteLabel(update) && !ACP_WRITE_OR_EDIT_TOOL_NAMES.has(name)) {
+    if (recognizedKind && !isAcpWriteEditKind(kindRaw)) {
+      return name;
+    }
+    const label = [
+      typeof update.title === 'string' ? update.title : '',
+      typeof update.name === 'string' ? update.name : '',
+      typeof update.kind === 'string' ? update.kind : '',
+    ].join(' ');
+    if (/\b(?:edit|patch|replace)\b/i.test(label)) return 'Edit';
+    return 'Write';
+  }
+  return name;
+}
+
+/**
+ * Builds a Claude-shaped tool input object from an ACP tool-call update.
+ * Starts from `rawInput` when present, attaches `file_path` when a real path
+ * is available, and never fabricates a path from `toolCallId`.
+ */
+export function acpToolInput(update: JsonObject): Record<string, unknown> {
+  const rawInput = asObject(update.rawInput);
+  const input: Record<string, unknown> = rawInput ? { ...rawInput } : {};
+  const path = acpArtifactWritePath(update);
+  if (path) {
+    input.file_path = path;
+  }
+  if (Object.keys(input).length === 0) {
+    if (typeof update.title === 'string' && update.title.trim()) {
+      return { title: update.title.trim() };
+    }
+    return {};
+  }
+  return input;
+}
+
+/**
+ * Extracts tool-result text from an ACP terminal tool-call update.
+ * Prefers `rawOutput`, then text/diff content entries. Truncates large
+ * payloads so trace storage stays bounded.
+ */
+export function acpToolResultContent(update: JsonObject, maxChars = 8000): string {
+  const rawOutput = update.rawOutput;
+  let text = '';
+  if (typeof rawOutput === 'string') {
+    text = rawOutput;
+  } else if (rawOutput !== undefined && rawOutput !== null) {
+    try {
+      text = JSON.stringify(rawOutput);
+    } catch {
+      text = String(rawOutput);
+    }
+  } else if (Array.isArray(update.content)) {
+    const parts: string[] = [];
+    for (const entry of update.content) {
+      const obj = asObject(entry);
+      if (!obj) {
+        if (typeof entry === 'string' && entry) parts.push(entry);
+        continue;
+      }
+      if (typeof obj.text === 'string' && obj.text) {
+        parts.push(obj.text);
+        continue;
+      }
+      if (typeof obj.diff === 'string' && obj.diff) {
+        parts.push(obj.diff);
+        continue;
+      }
+      // ACP diff entries often carry oldText/newText instead of a unified diff.
+      const oldText = typeof obj.oldText === 'string' ? obj.oldText : '';
+      const newText = typeof obj.newText === 'string' ? obj.newText : '';
+      if (oldText || newText) {
+        parts.push(`--- old\n${oldText}\n+++ new\n${newText}`);
+        continue;
+      }
+      const extracted = extractAcpUpdateText(obj);
+      if (extracted) parts.push(extracted);
+    }
+    text = parts.join('\n');
+  } else {
+    text = extractAcpUpdateText(update) ?? '';
+  }
+  if (!text) return '';
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars)}\n…[truncated]`;
+}
+
+/**
+ * Best-effort extraction of a concrete file path from an ACP tool-call update,
+ * checking three sources in priority order:
  * 1. `locations` or `content` array entries with a `path` field.
- * 2. `rawInput.path`, `rawInput.file_path`, or `rawInput.filename`.
- * 3. A filename token embedded in the human-readable `title` field.
+ * 2. `rawInput.path`, `rawInput.file_path`, `rawInput.filename`, or `rawInput.filePath`.
+ * 3. A path-like filename token embedded in the human-readable `title` field
+ *    (rejects dotted identifiers like `Image.open`).
  *
- * Returns `null` when no concrete path is present; the caller then falls
- * back to the toolCallId as a dedup key.
+ * Returns `null` when no concrete path is present. Does not use `toolCallId`
+ * as a path — callers decide how to key pathless writes.
  *
  * @param update - A parsed ACP `session/update` params object.
  * @returns An absolute or relative file path string, or `null` when absent.
  */
 export function acpArtifactWritePath(update: JsonObject): string | null {
-  // 1. ACP `locations: [{ path }]` and `content: [{ path }]` (diff entries).
-  for (const field of [update.locations, update.content]) {
-    if (!Array.isArray(field)) continue;
-    for (const entry of field) {
-      const path = asObject(entry)?.path;
-      if (typeof path === 'string' && path.trim()) return path.trim();
-    }
-  }
-  // 2. Tool input echoed by some agents as `rawInput.{path,file_path,filename}`.
-  const rawInput = asObject(update.rawInput);
-  for (const key of ['path', 'file_path', 'filename']) {
-    const value = rawInput?.[key];
-    if (typeof value === 'string' && value.trim()) return value.trim();
-  }
-  // 3. A filename token embedded in the human title, e.g. "Write index.html".
-  // Keeping the real extension lets `isArtifactPath` correctly EXCLUDE
-  // non-artifact writes (e.g. "edit config.json"), matching the claude path.
-  const title = typeof update.title === 'string' ? update.title : '';
-  const match = title.match(/[\w./-]+\.[A-Za-z0-9]+/);
-  if (match?.[0]) return match[0];
-  return null;
+  return acpArtifactWritePathRanked(update)?.path ?? null;
 }

--- a/apps/daemon/src/agent-protocol/acp/updates.ts
+++ b/apps/daemon/src/agent-protocol/acp/updates.ts
@@ -449,6 +449,27 @@ function acpToolNameFromTitle(title: string): string | null {
 }
 
 /**
+ * Execute-family names that Langfuse treats as partial-redact only (secret+path
+ * lexical masking, not full payload replacement). Custom `kind:other` tools must
+ * never inherit these labels — a malicious or misconfigured MCP adapter can
+ * otherwise place private content in `rawInput` and bypass fail-closed redaction.
+ * Keep in sync with `PARTIAL_REDACT_TOOL_NAMES_LOWER` in langfuse-trace.ts.
+ */
+const ACP_PARTIAL_REDACT_TOOL_NAMES_LOWER: ReadonlySet<string> = new Set([
+  'bash',
+  'shell',
+  'execute',
+  'terminal',
+]);
+
+/** True when a tool name would enter Langfuse's Bash-like partial-redact allowlist. */
+export function isAcpPartialRedactToolName(toolName: string): boolean {
+  const normalized = toolName.trim().toLowerCase();
+  if (!normalized) return false;
+  return ACP_PARTIAL_REDACT_TOOL_NAMES_LOWER.has(normalized);
+}
+
+/**
  * Sanitizes an ACP custom/adapter tool name before it enters the transcript.
  *
  * Kind `other` tools may ship free-text `name` values that embed paths, URLs,
@@ -457,6 +478,10 @@ function acpToolNameFromTitle(title: string): string | null {
  * telemetry is off). Only identifier-like names are kept; everything else
  * collapses to the opaque family label `Other`. Langfuse additionally
  * canonicalizes non-allowlisted names at the telemetry boundary.
+ *
+ * Callers that resolve names under trusted `kind:other` must also reject
+ * Bash-like partial-redact labels via `isAcpPartialRedactToolName` so custom
+ * tools cannot impersonate the sole non-fail-closed family.
  */
 export function sanitizeAcpCustomToolName(raw: string): string {
   const trimmed = raw.trim();
@@ -502,7 +527,9 @@ export function acpTelemetryToolCallId(raw: string): string {
  * title "update …" stays Read). That keeps content-tool redaction and analytics
  * families aligned with Langfuse's canonical name set. Kind `other` is the
  * exception: it is recognized for stickiness but is not a family, so an
- * explicit identifier-like name still wins there for UI/transcript. Untrusted
+ * explicit identifier-like name still wins there for UI/transcript — except
+ * Bash-like partial-redact labels, which collapse to `Other` so custom MCP
+ * tools cannot bypass Langfuse fail-closed payload redaction. Untrusted
  * free-text names (paths, tokens, titles) are collapsed to `Other` before the
  * event is emitted so Langfuse span labels cannot carry user-specific strings.
  * Payloads for unknown tools still fail closed in Langfuse
@@ -529,6 +556,12 @@ export function acpToolName(update: JsonObject): string {
     // kind:other / custom: keep only identifier-like adapter names. Paths,
     // tokens, and free text collapse to Other before the event is emitted.
     name = sanitizeAcpCustomToolName(update.name);
+    // Fail closed: kind:other must not claim Bash/shell/execute/terminal.
+    // Those names unlock Langfuse partial-redact (lexical masking only);
+    // custom MCP tools can put arbitrary private content in rawInput.
+    if (kindToken === 'other' && isAcpPartialRedactToolName(name)) {
+      name = 'Other';
+    }
   } else if (recognizedKind && kindName) {
     // kind:other without an explicit name (title-case "Other"), or remaining
     // recognized kinds without a preferred name.
@@ -537,6 +570,10 @@ export function acpToolName(update: JsonObject): string {
     const fromTitle = acpToolNameFromTitle(update.title);
     // Title heuristics can still surface path-like first tokens; sanitize.
     name = fromTitle ? sanitizeAcpCustomToolName(fromTitle) : null;
+    // Same fail-closed rule when kind:other reaches title (no name field).
+    if (name && kindToken === 'other' && isAcpPartialRedactToolName(name)) {
+      name = 'Other';
+    }
   } else if (kindName) {
     name = kindName;
   }

--- a/apps/daemon/src/agent-protocol/acp/updates.ts
+++ b/apps/daemon/src/agent-protocol/acp/updates.ts
@@ -4,6 +4,7 @@
  * event-shape diagnostics. Depends on acp/types, acp/json, and the vela-errors
  * integration; consumed exclusively by acp/session.ts.
  */
+import { createHash } from 'node:crypto';
 import type { JsonObject } from './types.js';
 import { asObject, acpValueKind, objectKeys, extractAcpUpdateText } from './json.js';
 import { classifyAmrAccountFailure, amrAccountFailureDetails } from '../../integrations/vela-errors.js';
@@ -475,6 +476,30 @@ export function sanitizeAcpCustomToolName(raw: string): string {
     return 'Other';
   }
   return trimmed;
+}
+
+/**
+ * Maps an ACP adapter `toolCallId` to a transcript/telemetry-safe id.
+ *
+ * Adapters may embed user paths or secrets in toolCallId (for example
+ * `read:/home/alice/.env`). Those values would otherwise flow into
+ * tool_use/tool_result events, then into Langfuse span ids and
+ * `metadata.toolCallId`. Identifier-like ids (UUID, call-1, …) pass through
+ * so local correlation stays readable; everything else is replaced with a
+ * stable opaque hash. Session-local maps may still key off the raw id.
+ */
+export function acpTelemetryToolCallId(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return 'acp_empty';
+  // Safe adapter/local ids: alphanumeric with limited separators, no paths.
+  if (
+    trimmed.length <= 128 &&
+    /^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(trimmed) &&
+    !trimmed.includes('..')
+  ) {
+    return trimmed;
+  }
+  return `acp_${createHash('sha256').update(trimmed, 'utf8').digest('hex').slice(0, 24)}`;
 }
 
 /**

--- a/apps/daemon/src/agent-protocol/acp/updates.ts
+++ b/apps/daemon/src/agent-protocol/acp/updates.ts
@@ -482,23 +482,16 @@ export function sanitizeAcpCustomToolName(raw: string): string {
  * Maps an ACP adapter `toolCallId` to a transcript/telemetry-safe id.
  *
  * Adapters may embed user paths or secrets in toolCallId (for example
- * `read:/home/alice/.env`). Those values would otherwise flow into
- * tool_use/tool_result events, then into Langfuse span ids and
- * `metadata.toolCallId`. Identifier-like ids (UUID, call-1, …) pass through
- * so local correlation stays readable; everything else is replaced with a
- * stable opaque hash. Session-local maps may still key off the raw id.
+ * `read:/home/alice/.env`, `sk-proj-…`, `ghp_…`, or a JWT). Those values
+ * would otherwise flow into tool_use/tool_result events, then into Langfuse
+ * span ids and `metadata.toolCallId`. Every non-empty adapter id is replaced
+ * with a stable opaque hash so identifier-shaped secrets cannot leak even
+ * when they contain no path characters. Session-local maps may still key
+ * off the raw id for frame correlation.
  */
 export function acpTelemetryToolCallId(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) return 'acp_empty';
-  // Safe adapter/local ids: alphanumeric with limited separators, no paths.
-  if (
-    trimmed.length <= 128 &&
-    /^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(trimmed) &&
-    !trimmed.includes('..')
-  ) {
-    return trimmed;
-  }
   return `acp_${createHash('sha256').update(trimmed, 'utf8').digest('hex').slice(0, 24)}`;
 }
 

--- a/apps/daemon/src/agent-protocol/acp/updates.ts
+++ b/apps/daemon/src/agent-protocol/acp/updates.ts
@@ -449,22 +449,33 @@ function acpToolNameFromTitle(title: string): string | null {
 
 /**
  * Resolves a stable Claude-shaped tool name from an ACP tool-call update.
- * Trusted ACP `kind` wins over title heuristics when the kind is recognized
- * (so `kind: read` + title "update …" stays Read). Explicit `name` still wins
- * when present. Write-label override to Write/Edit applies only when there is
- * no recognized non-write kind, so `countNewArtifacts` keeps working for
- * title-only write frames.
+ * Trusted ACP `kind` wins over both explicit `name` and title heuristics when
+ * the kind is a known tool family (so `kind: read` + `name: read_file` or
+ * title "update …" stays Read). That keeps content-tool redaction and analytics
+ * families aligned with Langfuse's canonical name set. Kind `other` is the
+ * exception: it is recognized for stickiness but is not a family, so an
+ * explicit name still wins there. Write-label override to Write/Edit applies
+ * only when there is no recognized non-write kind, so `countNewArtifacts`
+ * keeps working for title-only write frames.
  */
 export function acpToolName(update: JsonObject): string {
   const kindRaw = typeof update.kind === 'string' ? update.kind.trim() : '';
+  const kindToken = kindRaw.toLowerCase();
   const recognizedKind = kindRaw ? isAcpRecognizedKind(kindRaw) : false;
   const kindName = kindRaw ? acpToolNameFromKind(kindRaw) : null;
+  // "other" is a valid ACP kind for custom tools, not a canonical family.
+  const kindIsCanonicalFamily = recognizedKind && kindToken !== 'other';
 
   let name: string | null = null;
-  if (typeof update.name === 'string' && update.name.trim()) {
+  if (kindIsCanonicalFamily && kindName) {
+    // Canonical kind wins over explicit noncanonical names (read_file, etc.).
+    // Content-tool redaction keys off stable Claude-shaped families; keeping
+    // adapter-local names would skip redaction and leak file contents.
+    name = kindName;
+  } else if (typeof update.name === 'string' && update.name.trim()) {
     name = update.name.trim();
   } else if (recognizedKind && kindName) {
-    // Kind is authoritative over title heuristics.
+    // kind:other (or any remaining recognized kind without a preferred name).
     name = kindName;
   } else if (typeof update.title === 'string' && update.title.trim()) {
     name = acpToolNameFromTitle(update.title);

--- a/apps/daemon/src/agent-protocol/acp/updates.ts
+++ b/apps/daemon/src/agent-protocol/acp/updates.ts
@@ -454,9 +454,12 @@ function acpToolNameFromTitle(title: string): string | null {
  * title "update …" stays Read). That keeps content-tool redaction and analytics
  * families aligned with Langfuse's canonical name set. Kind `other` is the
  * exception: it is recognized for stickiness but is not a family, so an
- * explicit name still wins there. Write-label override to Write/Edit applies
- * only when there is no recognized non-write kind, so `countNewArtifacts`
- * keeps working for title-only write frames.
+ * explicit name still wins there (UI/transcript keep the real custom name).
+ * Telemetry redaction for those custom names is fail-closed in Langfuse
+ * (`shouldFullyRedactToolPayload`) so arbitrary MCP/content tools cannot leak
+ * file bodies under only lexical masking. Write-label override to Write/Edit
+ * applies only when there is no recognized non-write kind, so
+ * `countNewArtifacts` keeps working for title-only write frames.
  */
 export function acpToolName(update: JsonObject): string {
   const kindRaw = typeof update.kind === 'string' ? update.kind.trim() : '';
@@ -470,12 +473,16 @@ export function acpToolName(update: JsonObject): string {
   if (kindIsCanonicalFamily && kindName) {
     // Canonical kind wins over explicit noncanonical names (read_file, etc.).
     // Content-tool redaction keys off stable Claude-shaped families; keeping
-    // adapter-local names would skip redaction and leak file contents.
+    // adapter-local names would skip the known-content path (unknown names
+    // still fail closed in Langfuse, but canonical families stay precise).
     name = kindName;
   } else if (typeof update.name === 'string' && update.name.trim()) {
+    // kind:other / custom: preserve adapter name for UI + analytics labels.
+    // Langfuse fully redacts unknown tool payloads fail-closed.
     name = update.name.trim();
   } else if (recognizedKind && kindName) {
-    // kind:other (or any remaining recognized kind without a preferred name).
+    // kind:other without an explicit name (title-case "Other"), or remaining
+    // recognized kinds without a preferred name.
     name = kindName;
   } else if (typeof update.title === 'string' && update.title.trim()) {
     name = acpToolNameFromTitle(update.title);

--- a/apps/daemon/src/agent-protocol/acp/updates.ts
+++ b/apps/daemon/src/agent-protocol/acp/updates.ts
@@ -448,16 +448,47 @@ function acpToolNameFromTitle(title: string): string | null {
 }
 
 /**
+ * Sanitizes an ACP custom/adapter tool name before it enters the transcript.
+ *
+ * Kind `other` tools may ship free-text `name` values that embed paths, URLs,
+ * tokens, or other user-specific strings. Those names flow into tool_use events
+ * and then into Langfuse span labels / toolName metadata (even when content
+ * telemetry is off). Only identifier-like names are kept; everything else
+ * collapses to the opaque family label `Other`. Langfuse additionally
+ * canonicalizes non-allowlisted names at the telemetry boundary.
+ */
+export function sanitizeAcpCustomToolName(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return 'Other';
+  // Paths, URLs, free-text titles, and overlong strings are never safe labels.
+  if (
+    trimmed.includes('/') ||
+    trimmed.includes('\\') ||
+    trimmed.includes('://') ||
+    /\s/.test(trimmed) ||
+    trimmed.length > 64
+  ) {
+    return 'Other';
+  }
+  // Identifier-like only (snake_case, TitleCase, mcp__server__tool, …).
+  if (!/^[A-Za-z][A-Za-z0-9_.-]*$/.test(trimmed)) {
+    return 'Other';
+  }
+  return trimmed;
+}
+
+/**
  * Resolves a stable Claude-shaped tool name from an ACP tool-call update.
  * Trusted ACP `kind` wins over both explicit `name` and title heuristics when
  * the kind is a known tool family (so `kind: read` + `name: read_file` or
  * title "update …" stays Read). That keeps content-tool redaction and analytics
  * families aligned with Langfuse's canonical name set. Kind `other` is the
  * exception: it is recognized for stickiness but is not a family, so an
- * explicit name still wins there (UI/transcript keep the real custom name).
- * Telemetry redaction for those custom names is fail-closed in Langfuse
- * (`shouldFullyRedactToolPayload`) so arbitrary MCP/content tools cannot leak
- * file bodies under only lexical masking. Write-label override to Write/Edit
+ * explicit identifier-like name still wins there for UI/transcript. Untrusted
+ * free-text names (paths, tokens, titles) are collapsed to `Other` before the
+ * event is emitted so Langfuse span labels cannot carry user-specific strings.
+ * Payloads for unknown tools still fail closed in Langfuse
+ * (`shouldFullyRedactToolPayload`). Write-label override to Write/Edit
  * applies only when there is no recognized non-write kind, so
  * `countNewArtifacts` keeps working for title-only write frames.
  */
@@ -477,15 +508,17 @@ export function acpToolName(update: JsonObject): string {
     // still fail closed in Langfuse, but canonical families stay precise).
     name = kindName;
   } else if (typeof update.name === 'string' && update.name.trim()) {
-    // kind:other / custom: preserve adapter name for UI + analytics labels.
-    // Langfuse fully redacts unknown tool payloads fail-closed.
-    name = update.name.trim();
+    // kind:other / custom: keep only identifier-like adapter names. Paths,
+    // tokens, and free text collapse to Other before the event is emitted.
+    name = sanitizeAcpCustomToolName(update.name);
   } else if (recognizedKind && kindName) {
     // kind:other without an explicit name (title-case "Other"), or remaining
     // recognized kinds without a preferred name.
     name = kindName;
   } else if (typeof update.title === 'string' && update.title.trim()) {
-    name = acpToolNameFromTitle(update.title);
+    const fromTitle = acpToolNameFromTitle(update.title);
+    // Title heuristics can still surface path-like first tokens; sanitize.
+    name = fromTitle ? sanitizeAcpCustomToolName(fromTitle) : null;
   } else if (kindName) {
     name = kindName;
   }

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -368,9 +368,18 @@ function eventTimestamp(
 }
 
 function redactLocalPaths(value: string): string {
+  // macOS /Users, Linux /home + /root, Windows C:\Users — Linux is a primary
+  // supported environment, so Bash inputs like `cat /home/alice/.env` must not
+  // leak home directories into Langfuse tool spans.
   return value
-    .replace(/\/Users\/[^/\s"']+(?:\/[^ \n\r\t"'`<>)]*)?/g, '[REDACTED:local_path]')
-    .replace(/[A-Za-z]:\\Users\\[^\\\s"']+(?:\\[^ \n\r\t"'`<>)]*)?/g, '[REDACTED:local_path]');
+    .replace(
+      /\/(?:Users|home|root)\/[^/\s"']+(?:\/[^ \n\r\t"'`<>)]*)?/g,
+      '[REDACTED:local_path]',
+    )
+    .replace(
+      /[A-Za-z]:\\Users\\[^\\\s"']+(?:\\[^ \n\r\t"'`<>)]*)?/g,
+      '[REDACTED:local_path]',
+    );
 }
 
 function serializeToolPayload(

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -39,6 +39,7 @@ import {
   type TraceObjectSummary,
   type ToolCallSummary,
   type TurnInfo,
+  isContentToolName,
 } from './langfuse-trace.js';
 import type { PromptStackTelemetry } from './prompt-telemetry.js';
 import { redactSecrets } from './redact.js';
@@ -318,6 +319,7 @@ function messageUsageFromAnalytics(
     usage.input_tokens_effective !== undefined ||
     usage.output_tokens !== undefined ||
     usage.total_tokens !== undefined ||
+    usage.thought_tokens !== undefined ||
     usage.cache_read_input_tokens !== undefined ||
     usage.cache_creation_input_tokens !== undefined ||
     usage.uncached_input_tokens !== undefined ||
@@ -335,6 +337,7 @@ function messageUsageFromAnalytics(
   }
   if (usage.output_tokens !== undefined) out.outputTokens = usage.output_tokens;
   if (usage.total_tokens !== undefined) out.totalTokens = usage.total_tokens;
+  if (usage.thought_tokens !== undefined) out.thoughtTokens = usage.thought_tokens;
   if (usage.cache_read_input_tokens !== undefined) {
     out.cacheReadInputTokens = usage.cache_read_input_tokens;
   }
@@ -363,14 +366,6 @@ function eventTimestamp(
     : fallback;
 }
 
-const CONTENT_TOOL_NAMES = new Set([
-  'Read',
-  'Write',
-  'Edit',
-  'MultiEdit',
-  'NotebookEdit',
-]);
-
 function redactLocalPaths(value: string): string {
   return value
     .replace(/\/Users\/[^/\s"']+(?:\/[^ \n\r\t"'`<>)]*)?/g, '[REDACTED:local_path]')
@@ -382,7 +377,7 @@ function serializeToolPayload(
   opts: { toolName: string; direction: 'input' | 'output' },
 ): string | undefined {
   if (value === undefined || value === null) return undefined;
-  if (CONTENT_TOOL_NAMES.has(opts.toolName)) {
+  if (isContentToolName(opts.toolName)) {
     return `[REDACTED:tool_${opts.direction}:content_tool:${opts.toolName}]`;
   }
   if (typeof value === 'string') return redactLocalPaths(redactSecrets(value));
@@ -414,19 +409,43 @@ function collectToolCalls(
       | null
       | undefined;
     if (data?.type === 'tool_use' && typeof data.id === 'string') {
-      const timestamp = eventTimestamp(rec, runStartedAt + rec.id);
-      const summary: ToolCallSummary = {
-        id: data.id,
-        name: typeof data.name === 'string' && data.name ? data.name : 'unknown',
-        startedAt: timestamp,
-        endedAt: timestamp,
-      };
-      const input = serializeToolPayload(data.input, {
-        toolName: summary.name,
-        direction: 'input',
-      });
-      if (input !== undefined) summary.input = input;
-      tools.set(data.id, summary);
+      const eventTs = eventTimestamp(rec, runStartedAt + rec.id);
+      // Prefer producer-supplied start time (ACP firstSeenAt) over event log ts.
+      const payloadStartedAt =
+        typeof (data as { startedAt?: unknown }).startedAt === 'number' &&
+        Number.isFinite((data as { startedAt: number }).startedAt)
+          ? (data as { startedAt: number }).startedAt
+          : undefined;
+      const timestamp = payloadStartedAt ?? eventTs;
+      const name = typeof data.name === 'string' && data.name ? data.name : 'unknown';
+      const existing = tools.get(data.id);
+      if (existing) {
+        // Second tool_use for the same id: refresh name/input, keep original startedAt.
+        existing.name = name;
+        const input = serializeToolPayload(data.input, {
+          toolName: name,
+          direction: 'input',
+        });
+        if (input !== undefined) existing.input = input;
+        else delete existing.input;
+        // If a later frame carries an earlier startedAt, prefer the earlier one.
+        if (payloadStartedAt !== undefined && payloadStartedAt < existing.startedAt) {
+          existing.startedAt = payloadStartedAt;
+        }
+      } else {
+        const summary: ToolCallSummary = {
+          id: data.id,
+          name,
+          startedAt: timestamp,
+          endedAt: eventTs,
+        };
+        const input = serializeToolPayload(data.input, {
+          toolName: name,
+          direction: 'input',
+        });
+        if (input !== undefined) summary.input = input;
+        tools.set(data.id, summary);
+      }
     } else if (
       data?.type === 'tool_result' &&
       typeof data.toolUseId === 'string'

--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -39,7 +39,8 @@ import {
   type TraceObjectSummary,
   type ToolCallSummary,
   type TurnInfo,
-  isContentToolName,
+  shouldFullyRedactToolPayload,
+  toolPayloadRedactionPlaceholder,
 } from './langfuse-trace.js';
 import type { PromptStackTelemetry } from './prompt-telemetry.js';
 import { redactSecrets } from './redact.js';
@@ -377,8 +378,11 @@ function serializeToolPayload(
   opts: { toolName: string; direction: 'input' | 'output' },
 ): string | undefined {
   if (value === undefined || value === null) return undefined;
-  if (isContentToolName(opts.toolName)) {
-    return `[REDACTED:tool_${opts.direction}:content_tool:${opts.toolName}]`;
+  // Fail-closed: known content tools AND unknown/custom ACP tool names
+  // (kind:other MCP readers, etc.) fully redact. Only bash-like execute
+  // tools keep secret+path lexical masking.
+  if (shouldFullyRedactToolPayload(opts.toolName)) {
+    return toolPayloadRedactionPlaceholder(opts.toolName, opts.direction);
   }
   if (typeof value === 'string') return redactLocalPaths(redactSecrets(value));
   try {

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -1320,9 +1320,14 @@ function redactArtifactBlocks(value: string | undefined): string | undefined {
 }
 
 /**
- * Tool names whose input/output payloads are fully redacted in Langfuse
- * (content-bearing read/write/search/think tools, including ACP aliases).
- * Bash stays on secret+path redaction only.
+ * Tool names known to be content-bearing (read/write/search/think tools,
+ * including ACP aliases). Used for redaction reason labels and docs.
+ *
+ * Full redaction policy is fail-closed via `shouldFullyRedactToolPayload`:
+ * only bash-like execute tools keep secret+path lexical masking; known
+ * content tools AND any unknown/custom ACP tool name (e.g. kind:other MCP
+ * filesystem readers) fully redact so private file bodies cannot leak to
+ * Langfuse under best-effort masking alone.
  *
  * Matching is case-insensitive. Canonical Claude-shaped names are listed
  * here; lowercase ACP kind tokens (read/write/edit/…) are covered via the
@@ -1358,11 +1363,55 @@ const CONTENT_TOOL_NAMES_LOWER: ReadonlySet<string> = new Set(
   [...CONTENT_TOOL_NAMES].map((name) => name.toLowerCase()),
 );
 
-/** True when tool payloads should be fully content-redacted for telemetry. */
+/**
+ * Execute-family tools allowed to keep secret+path-only redaction (not full
+ * payload replacement). Everything else fails closed to a placeholder.
+ */
+const PARTIAL_REDACT_TOOL_NAMES_LOWER: ReadonlySet<string> = new Set([
+  'bash',
+  'shell',
+  'execute',
+  'terminal',
+]);
+
+/** True when the tool is a known content-bearing family name. */
 export function isContentToolName(toolName: string): boolean {
   const normalized = toolName.trim().toLowerCase();
   if (!normalized) return false;
   return CONTENT_TOOL_NAMES_LOWER.has(normalized);
+}
+
+/**
+ * True when tool I/O may keep lexical (secret+path) redaction for telemetry.
+ * Only bash-like execute tools qualify; empty/unknown/custom names do not.
+ */
+export function isPartialRedactToolName(toolName: string): boolean {
+  const normalized = toolName.trim().toLowerCase();
+  if (!normalized) return false;
+  return PARTIAL_REDACT_TOOL_NAMES_LOWER.has(normalized);
+}
+
+/**
+ * Fail-closed telemetry gate: fully redact tool input/output unless the tool
+ * is an allowlisted bash-like execute family. Unknown/custom ACP names
+ * (kind:other, MCP tools, etc.) must not ship raw payloads to Langfuse.
+ */
+export function shouldFullyRedactToolPayload(toolName: string): boolean {
+  return !isPartialRedactToolName(toolName);
+}
+
+/**
+ * Builds the fixed placeholder used when tool I/O is fully redacted for
+ * content telemetry. Known content families keep `content_tool`; everything
+ * else (including custom ACP/MCP names) uses `unknown_tool`.
+ */
+export function toolPayloadRedactionPlaceholder(
+  toolName: string,
+  direction: 'input' | 'output',
+): string {
+  const label = toolName.trim() || 'unnamed';
+  const reason = isContentToolName(label) ? 'content_tool' : 'unknown_tool';
+  return `[REDACTED:tool_${direction}:${reason}:${label}]`;
 }
 
 function redactLocalPaths(value: string | undefined): string | undefined {
@@ -1378,8 +1427,8 @@ function traceSafeToolPayload(
   value: string | undefined,
 ): string | undefined {
   if (value === undefined) return undefined;
-  if (isContentToolName(toolName)) {
-    return `[REDACTED:tool_${direction}:content_tool:${toolName}]`;
+  if (shouldFullyRedactToolPayload(toolName)) {
+    return toolPayloadRedactionPlaceholder(toolName, direction);
   }
   return redactLocalPaths(redactArtifactBlocks(value));
 }

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -1416,9 +1416,18 @@ export function toolPayloadRedactionPlaceholder(
 
 function redactLocalPaths(value: string | undefined): string | undefined {
   if (value === undefined) return undefined;
+  // macOS /Users, Linux /home + /root, Windows C:\Users — Linux is a primary
+  // supported environment, so Bash inputs like `cat /home/alice/.env` must not
+  // leak home directories into Langfuse tool spans.
   return value
-    .replace(/\/Users\/[^/\s"']+(?:\/[^ \n\r\t"'`<>)]*)?/g, '[REDACTED:local_path]')
-    .replace(/[A-Za-z]:\\Users\\[^\\\s"']+(?:\\[^ \n\r\t"'`<>)]*)?/g, '[REDACTED:local_path]');
+    .replace(
+      /\/(?:Users|home|root)\/[^/\s"']+(?:\/[^ \n\r\t"'`<>)]*)?/g,
+      '[REDACTED:local_path]',
+    )
+    .replace(
+      /[A-Za-z]:\\Users\\[^\\\s"']+(?:\\[^ \n\r\t"'`<>)]*)?/g,
+      '[REDACTED:local_path]',
+    );
 }
 
 function traceSafeToolPayload(

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -28,9 +28,10 @@ import {
   type PromptTelemetrySection,
   type PromptStackTelemetry,
 } from './prompt-telemetry.js';
-import type {
-  RunTelemetryTimestamps,
-  RunTimingAnalytics,
+import {
+  canonicalizeToolAnalyticsName,
+  type RunTelemetryTimestamps,
+  type RunTimingAnalytics,
 } from './run-analytics-observability.js';
 import type { RunFailureClassification } from './run-failure-classification.js';
 import { redactSecrets } from './redact.js';
@@ -905,10 +906,12 @@ function buildToolPerformanceDiagnostics(
 
   for (const tool of list) {
     const d = durationMs(tool.startedAt, tool.endedAt);
+    // Aggregate under allowlisted family names only — never raw ACP/MCP labels.
+    const safeName = telemetrySafeToolName(tool.name);
     const current =
-      byName.get(tool.name) ??
+      byName.get(safeName) ??
       {
-        tool_name: tool.name,
+        tool_name: safeName,
         call_count: 0,
         error_count: 0,
         total_duration_ms: 0,
@@ -924,7 +927,7 @@ function buildToolPerformanceDiagnostics(
       current.error_count += 1;
       current.failure_types.add('tool_result_error');
     }
-    byName.set(tool.name, current);
+    byName.set(safeName, current);
   }
 
   return {
@@ -1401,17 +1404,30 @@ export function shouldFullyRedactToolPayload(toolName: string): boolean {
 }
 
 /**
+ * Map an arbitrary tool name to a Langfuse-safe label (bounded family allowlist).
+ * Custom ACP/MCP names, paths, and free text never leave the host as span names
+ * or toolName metadata — even when content telemetry is off.
+ */
+export function telemetrySafeToolName(toolName: string): string {
+  return canonicalizeToolAnalyticsName(toolName);
+}
+
+/**
  * Builds the fixed placeholder used when tool I/O is fully redacted for
- * content telemetry. Known content families keep `content_tool`; everything
- * else (including custom ACP/MCP names) uses `unknown_tool`.
+ * content telemetry. Known content families keep `content_tool` plus a
+ * allowlisted family label; everything else uses `unknown_tool` without
+ * embedding the untrusted custom name (paths/tokens/MCP ids must not leak).
  */
 export function toolPayloadRedactionPlaceholder(
   toolName: string,
   direction: 'input' | 'output',
 ): string {
   const label = toolName.trim() || 'unnamed';
-  const reason = isContentToolName(label) ? 'content_tool' : 'unknown_tool';
-  return `[REDACTED:tool_${direction}:${reason}:${label}]`;
+  if (isContentToolName(label)) {
+    // Stable allowlisted family only — never the raw adapter string.
+    return `[REDACTED:tool_${direction}:content_tool:${telemetrySafeToolName(label)}]`;
+  }
+  return `[REDACTED:tool_${direction}:unknown_tool]`;
 }
 
 function redactLocalPaths(value: string | undefined): string | undefined {
@@ -1797,6 +1813,9 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
       const toolStartedAt = new Date(tool.startedAt).toISOString();
       const toolEndedAt = new Date(tool.endedAt).toISOString();
       const toolDurationMs = durationMs(tool.startedAt, tool.endedAt);
+      // Redaction policy still keys off the producer name (Bash vs content vs
+      // unknown); only the labels we emit to Langfuse are allowlisted.
+      const safeToolName = telemetrySafeToolName(tool.name);
       const toolInput = wantsContent
         ? truncate(
             traceSafeToolPayload(tool.name, 'input', tool.input),
@@ -1817,7 +1836,7 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
           id: toolSpanId,
           traceId,
           parentObservationId: toolParentObservationId,
-          name: `tool:${tool.name}`,
+          name: `tool:${safeToolName}`,
           startTime: toolStartedAt,
           endTime: toolEndedAt,
           input: toolInput,
@@ -1825,7 +1844,7 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
           level: tool.isError ? 'ERROR' : 'DEFAULT',
           metadata: {
             toolCallId: tool.id,
-            toolName: tool.name,
+            toolName: safeToolName,
             durationMs: toolDurationMs,
             hasInput: tool.input !== undefined,
             hasOutput: tool.output !== undefined,

--- a/apps/daemon/src/langfuse-trace.ts
+++ b/apps/daemon/src/langfuse-trace.ts
@@ -151,6 +151,7 @@ export interface MessageSummary {
     inputTokensEffective?: number;
     outputTokens?: number;
     totalTokens?: number;
+    thoughtTokens?: number;
     cacheReadInputTokens?: number;
     cacheCreationInputTokens?: number;
     uncachedInputTokens?: number;
@@ -655,6 +656,7 @@ function tokenUsageSummary(
     input_effective: usage.inputTokensEffective,
     output: usage.outputTokens,
     total: usage.totalTokens,
+    thought: usage.thoughtTokens,
     cache_read_input: usage.cacheReadInputTokens,
     cache_creation_input: usage.cacheCreationInputTokens,
     uncached_input: usage.uncachedInputTokens,
@@ -1295,6 +1297,7 @@ function usageTotal(usage: MessageSummary['usage']): number {
     usage.inputTokensEffective,
     usage.outputTokens,
     usage.totalTokens,
+    usage.thoughtTokens,
     usage.cacheReadInputTokens,
     usage.cacheCreationInputTokens,
     usage.uncachedInputTokens,
@@ -1316,13 +1319,51 @@ function redactArtifactBlocks(value: string | undefined): string | undefined {
   );
 }
 
-const CONTENT_TOOL_NAMES = new Set([
+/**
+ * Tool names whose input/output payloads are fully redacted in Langfuse
+ * (content-bearing read/write/search/think tools, including ACP aliases).
+ * Bash stays on secret+path redaction only.
+ *
+ * Matching is case-insensitive. Canonical Claude-shaped names are listed
+ * here; lowercase ACP kind tokens (read/write/edit/…) are covered via the
+ * lowercased lookup set built below.
+ */
+export const CONTENT_TOOL_NAMES: ReadonlySet<string> = new Set([
   'Read',
   'Write',
   'Edit',
   'MultiEdit',
   'NotebookEdit',
+  'create_file',
+  'str_replace_edit',
+  'multi_edit',
+  'Grep',
+  'Search',
+  'Glob',
+  'Fetch',
+  'Think',
+  'Thinking',
+  // Common lowercase ACP kind / title tokens (also matched case-insensitively).
+  'read',
+  'write',
+  'edit',
+  'grep',
+  'search',
+  'fetch',
+  'think',
+  'glob',
 ]);
+
+const CONTENT_TOOL_NAMES_LOWER: ReadonlySet<string> = new Set(
+  [...CONTENT_TOOL_NAMES].map((name) => name.toLowerCase()),
+);
+
+/** True when tool payloads should be fully content-redacted for telemetry. */
+export function isContentToolName(toolName: string): boolean {
+  const normalized = toolName.trim().toLowerCase();
+  if (!normalized) return false;
+  return CONTENT_TOOL_NAMES_LOWER.has(normalized);
+}
 
 function redactLocalPaths(value: string | undefined): string | undefined {
   if (value === undefined) return undefined;
@@ -1337,7 +1378,7 @@ function traceSafeToolPayload(
   value: string | undefined,
 ): string | undefined {
   if (value === undefined) return undefined;
-  if (CONTENT_TOOL_NAMES.has(toolName)) {
+  if (isContentToolName(toolName)) {
     return `[REDACTED:tool_${direction}:content_tool:${toolName}]`;
   }
   return redactLocalPaths(redactArtifactBlocks(value));
@@ -1403,6 +1444,7 @@ export function buildTracePayload(ctx: ReportContext): unknown[] {
         inputEffective: ctx.message.usage.inputTokensEffective,
         output: ctx.message.usage.outputTokens,
         total: ctx.message.usage.totalTokens,
+        thought: ctx.message.usage.thoughtTokens,
         cacheReadInput: ctx.message.usage.cacheReadInputTokens,
         cacheCreationInput: ctx.message.usage.cacheCreationInputTokens,
         uncachedInput: ctx.message.usage.uncachedInputTokens,

--- a/apps/daemon/src/routes/runs.ts
+++ b/apps/daemon/src/routes/runs.ts
@@ -67,6 +67,7 @@ import {
   runtimeTypeForRunAnalytics,
   scanRunEventsForUsageAnalytics,
   summarizeRunTimingAnalytics,
+  summarizeToolAnalytics,
   type RunEventForAnalyticsObservability,
   type RunTelemetryTimestamps,
 } from '../run-analytics-observability.js';
@@ -1189,6 +1190,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
         ...(run.analyticsTelemetry ? { telemetry: run.analyticsTelemetry } : {}),
           events: run.events,
         });
+        const toolAnalytics = summarizeToolAnalytics(run.events);
         const toolStreamArtifactCount = (): number => runArtifactCountForRun(run);
         const toolStreamDesignSystemCreated = (): boolean =>
           runDesignSystemCreatedForRun(run);
@@ -1267,11 +1269,7 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
             insertId: `${runInsertId}-${retryEvent.event}-${index}`,
           });
         }
-        await Promise.resolve(design.analytics.capture({
-          eventName: 'run_finished',
-          context: analyticsContext,
-          appVersion: design.getAppVersion(),
-          properties: {
+        const finishedProperties = {
             ...baseProps,
             design_system_id: run.designSystemId ?? undefined,
             design_system_digest: run.designSystemDigest ?? undefined,
@@ -1356,6 +1354,9 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
             ...(usageAnalytics.total_tokens !== undefined
               ? { total_tokens: usageAnalytics.total_tokens }
               : {}),
+            ...(usageAnalytics.thought_tokens !== undefined
+              ? { thought_tokens: usageAnalytics.thought_tokens }
+              : {}),
             ...(usageAnalytics.cache_read_input_tokens !== undefined
               ? { cache_read_input_tokens: usageAnalytics.cache_read_input_tokens }
               : {}),
@@ -1381,8 +1382,27 @@ export function registerRunRoutes(app: Express, ctx: RegisterRunRoutesDeps) {
             ...(firstCallUsage ?? {}),
             is_followup_turn: isFollowupTurn,
             cache_token_source: usageAnalytics.cache_token_source,
+            // Prefer provider scan over run_created baseProps (`estimated`).
             token_count_source: usageAnalytics.token_count_source,
-          },
+            tool_error_count: toolAnalytics.tool_error_count,
+            tool_name_count: toolAnalytics.tool_name_count,
+            tool_names: toolAnalytics.tool_names_csv,
+          };
+        // Refresh local recovery snapshot so crash recovery matches PostHog
+        // `run_finished` (usage/timing/tools), not only run_created baseProps.
+        // Keep the base insertId here: reconcileDurableRunTerminals appends
+        // `-finish` when replaying. Storing `${runInsertId}-finish` would
+        // produce `…-finish-finish` and can duplicate PostHog events.
+        design.runs.setAnalyticsRecovery?.(run, {
+          context: analyticsContext,
+          properties: finishedProperties,
+          insertId: runInsertId,
+        });
+        await Promise.resolve(design.analytics.capture({
+          eventName: 'run_finished',
+          context: analyticsContext,
+          appVersion: design.getAppVersion(),
+          properties: finishedProperties,
           insertId: `${runInsertId}-finish`,
         }));
         design.runs.markAnalyticsCompleted?.(run);

--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -119,6 +119,7 @@ export interface RunUsageAnalytics {
   input_tokens_effective?: number;
   output_tokens?: number;
   total_tokens?: number;
+  thought_tokens?: number;
   cache_read_input_tokens?: number;
   cache_creation_input_tokens?: number;
   uncached_input_tokens?: number;
@@ -138,6 +139,18 @@ export interface RunUsageAnalytics {
   cache_token_source: 'anthropic' | 'openai' | 'unavailable';
   token_count_source: 'provider_usage' | 'estimated' | 'unknown';
   agent_reported_model: string | null;
+}
+
+/** Compact tool histogram for PostHog `run_finished` (no inputs/outputs). */
+export interface RunToolAnalyticsSummary {
+  /** Unique toolUseIds that reported isError (not duplicate result frames). */
+  tool_error_count: number;
+  /** Distinct canonical tool families seen (uncapped true count). */
+  tool_name_count: number;
+  /** Sorted unique canonical tool families (bounded allowlist). */
+  tool_names: string[];
+  /** Comma-separated unique canonical families for sinks that prefer a string prop. */
+  tool_names_csv: string;
 }
 
 export interface RunTimingAnalytics {
@@ -289,6 +302,7 @@ interface UsageCacheFields {
   inputTokens: number | undefined;
   outputTokens: number | undefined;
   totalTokens: number | undefined;
+  thoughtTokens: number | undefined;
   cacheReadInputTokens: number | undefined;
   cacheCreationInputTokens: number | undefined;
   cacheTokenSource: 'anthropic' | 'openai' | undefined;
@@ -300,14 +314,32 @@ interface UsageCacheFields {
 // `cache_hit_ratio` vs `first_call_cache_hit_ratio` — can never drift apart as
 // new aliases are added.
 function extractUsageCacheFields(usage: Record<string, unknown>): UsageCacheFields {
-  const inputTokens = firstNumber(usage, ['input_tokens', 'prompt_tokens']);
-  const outputTokens = firstNumber(usage, ['output_tokens', 'completion_tokens']);
+  const inputTokens = firstNumber(usage, [
+    'input_tokens',
+    'prompt_tokens',
+    'inputTokens',
+  ]);
+  const outputTokens = firstNumber(usage, [
+    'output_tokens',
+    'completion_tokens',
+    'outputTokens',
+  ]);
   const totalTokens = firstNumber(usage, ['total_tokens', 'totalTokens']);
-  const anthropicCacheReadInputTokens = firstNumber(usage, ['cache_read_input_tokens']);
+  const thoughtTokens = firstNumber(usage, [
+    'thought_tokens',
+    'thoughtTokens',
+    'reasoning_tokens',
+    'reasoning_output_tokens',
+  ]);
+  const anthropicCacheReadInputTokens = firstNumber(usage, [
+    'cache_read_input_tokens',
+    'cacheReadInputTokens',
+  ]);
   const normalizedCachedReadInputTokens = firstNumber(usage, [
     'cached_input_tokens',
     'cache_read_tokens',
     'cached_read_tokens',
+    'cachedReadTokens',
   ]);
   const openAiCachedInputTokens = readNestedNumber(usage, [
     'prompt_tokens_details',
@@ -317,12 +349,24 @@ function extractUsageCacheFields(usage: Record<string, unknown>): UsageCacheFiel
     anthropicCacheReadInputTokens ??
     normalizedCachedReadInputTokens ??
     openAiCachedInputTokens;
+  // Anthropic-only creation aliases (additive). Do NOT include
+  // `cache_creation_tokens` / `cacheCreationTokens` here — those are the
+  // OpenAI-like family used by ACP formatUsage and must stay inclusive.
   const anthropicCacheCreationInputTokens = firstNumber(
     usage,
-    ['cache_creation_input_tokens', 'cache_write_input_tokens', 'cache_creation_tokens'],
+    [
+      'cache_creation_input_tokens',
+      'cache_write_input_tokens',
+      'cacheCreationInputTokens',
+    ],
     [['cache_creation', 'input_tokens']],
   );
-  const normalizedCachedWriteInputTokens = firstNumber(usage, ['cached_write_tokens']);
+  const normalizedCachedWriteInputTokens = firstNumber(usage, [
+    'cached_write_tokens',
+    'cachedWriteTokens',
+    'cache_creation_tokens',
+    'cacheCreationTokens',
+  ]);
   const cacheCreationInputTokens =
     anthropicCacheCreationInputTokens ?? normalizedCachedWriteInputTokens;
   let cacheTokenSource: 'anthropic' | 'openai' | undefined;
@@ -342,6 +386,7 @@ function extractUsageCacheFields(usage: Record<string, unknown>): UsageCacheFiel
     inputTokens,
     outputTokens,
     totalTokens,
+    thoughtTokens,
     cacheReadInputTokens,
     cacheCreationInputTokens,
     cacheTokenSource,
@@ -416,6 +461,7 @@ export function scanRunEventsForUsageAnalytics(
   let inputTokens: number | undefined;
   let outputTokens: number | undefined;
   let providerTotalTokens: number | undefined;
+  let thoughtTokens: number | undefined;
   let cacheReadInputTokens: number | undefined;
   let cacheCreationInputTokens: number | undefined;
   let cacheTokenSource: RunUsageAnalytics['cache_token_source'] = 'unavailable';
@@ -447,10 +493,20 @@ export function scanRunEventsForUsageAnalytics(
         inputTokens = fields.inputTokens;
         outputTokens = fields.outputTokens;
         providerTotalTokens = fields.totalTokens;
+        thoughtTokens = fields.thoughtTokens;
         cacheReadInputTokens = fields.cacheReadInputTokens;
         cacheCreationInputTokens = fields.cacheCreationInputTokens;
         if (fields.cacheTokenSource) cacheTokenSource = fields.cacheTokenSource;
-        haveUsageTokens = inputTokens !== undefined || outputTokens !== undefined;
+        // Any real provider token field counts as provider_usage (not only
+        // input/output) so thought-only or total-only ACP payloads still mark
+        // the source correctly for PostHog/Langfuse.
+        haveUsageTokens =
+          inputTokens !== undefined ||
+          outputTokens !== undefined ||
+          providerTotalTokens !== undefined ||
+          thoughtTokens !== undefined ||
+          cacheReadInputTokens !== undefined ||
+          cacheCreationInputTokens !== undefined;
       }
     }
 
@@ -551,6 +607,7 @@ export function scanRunEventsForUsageAnalytics(
       : {}),
     ...(outputTokens !== undefined ? { output_tokens: outputTokens } : {}),
     ...(totalTokens !== undefined ? { total_tokens: totalTokens } : {}),
+    ...(thoughtTokens !== undefined ? { thought_tokens: thoughtTokens } : {}),
     ...(cacheReadInputTokens !== undefined
       ? { cache_read_input_tokens: cacheReadInputTokens }
       : {}),
@@ -582,6 +639,156 @@ export function scanRunEventsForUsageAnalytics(
   };
 }
 
+/**
+ * Canonical tool families shipped to PostHog. Raw ACP/CLI tool names are
+ * never forwarded — only this small allowlist (plus `other`).
+ */
+const TOOL_ANALYTICS_FAMILIES = [
+  'Write',
+  'Edit',
+  'Read',
+  'Bash',
+  'Grep',
+  'Search',
+  'Fetch',
+  'Think',
+  'Tool',
+  'other',
+] as const;
+
+type ToolAnalyticsFamily = (typeof TOOL_ANALYTICS_FAMILIES)[number];
+
+const TOOL_ANALYTICS_FAMILY_SET = new Set<string>(TOOL_ANALYTICS_FAMILIES);
+
+/** Case-insensitive aliases → canonical family (privacy-safe, bounded). */
+const TOOL_ANALYTICS_FAMILY_ALIASES: Readonly<Record<string, ToolAnalyticsFamily>> = {
+  write: 'Write',
+  edit: 'Edit',
+  multiedit: 'Edit',
+  read: 'Read',
+  bash: 'Bash',
+  shell: 'Bash',
+  terminal: 'Bash',
+  grep: 'Grep',
+  search: 'Search',
+  glob: 'Search',
+  find: 'Search',
+  fetch: 'Fetch',
+  webfetch: 'Fetch',
+  websearch: 'Search',
+  think: 'Think',
+  thinking: 'Think',
+  tool: 'Tool',
+  other: 'other',
+  unknown: 'other',
+};
+
+/**
+ * Map an arbitrary tool name to a PostHog-safe canonical family.
+ * Never returns paths, URLs, or free-text titles.
+ */
+export function canonicalizeToolAnalyticsName(raw: string | undefined): ToolAnalyticsFamily {
+  if (!raw) return 'other';
+  const trimmed = raw.trim();
+  if (!trimmed) return 'other';
+  // Reject anything that looks like a path, URL, or free-text title.
+  if (
+    trimmed.includes('/') ||
+    trimmed.includes('\\') ||
+    trimmed.includes('://') ||
+    trimmed.includes(' ') ||
+    trimmed.length > 64
+  ) {
+    return 'other';
+  }
+  const lower = trimmed.toLowerCase();
+  const compact = lower.replace(/[^a-z0-9]/g, '');
+  const aliased =
+    TOOL_ANALYTICS_FAMILY_ALIASES[lower] ??
+    (compact ? TOOL_ANALYTICS_FAMILY_ALIASES[compact] : undefined);
+  if (aliased) return aliased;
+  // Exact canonical family (already Title-case allowlist member).
+  if (TOOL_ANALYTICS_FAMILY_SET.has(trimmed)) {
+    return trimmed as ToolAnalyticsFamily;
+  }
+  // Case-insensitive match against the allowlist itself.
+  for (const family of TOOL_ANALYTICS_FAMILIES) {
+    if (family.toLowerCase() === lower || family.toLowerCase() === compact) {
+      return family;
+    }
+  }
+  return 'other';
+}
+
+/**
+ * Cheap tool family histogram + error counts from tool_use/tool_result events.
+ * Canonicalizes names to a small allowlist; never includes inputs/outputs
+ * (PostHog payload safety). tool_error_count is unique failed toolUseIds.
+ */
+export function summarizeToolAnalytics(
+  events: RunEventForAnalyticsObservability[],
+): RunToolAnalyticsSummary {
+  const seenIds = new Set<string>();
+  const namesById = new Map<string, ToolAnalyticsFamily>();
+  const uniqueNameSet = new Set<ToolAnalyticsFamily>();
+  const erroredToolUseIds = new Set<string>();
+
+  for (const rec of events) {
+    if (rec.event !== 'agent') continue;
+    const data = rec.data as
+      | {
+          type?: string;
+          id?: unknown;
+          name?: unknown;
+          toolUseId?: unknown;
+          isError?: unknown;
+        }
+      | null
+      | undefined;
+    if (!data) continue;
+
+    if (data.type === 'tool_use' && typeof data.id === 'string') {
+      if (seenIds.has(data.id)) continue;
+      seenIds.add(data.id);
+      const family = canonicalizeToolAnalyticsName(toolName(data));
+      namesById.set(data.id, family);
+      uniqueNameSet.add(family);
+    } else if (data.type === 'tool_result' && data.isError === true) {
+      const toolUseId =
+        typeof data.toolUseId === 'string' && data.toolUseId
+          ? data.toolUseId
+          : undefined;
+      if (toolUseId) {
+        if (erroredToolUseIds.has(toolUseId)) continue;
+        erroredToolUseIds.add(toolUseId);
+        // Orphan error results (no prior tool_use) still count as `other`.
+        if (!namesById.has(toolUseId)) {
+          uniqueNameSet.add('other');
+        }
+      } else {
+        // No toolUseId: count once per frame under a synthetic key so we do
+        // not silently drop errors, but still avoid unbounded inflation from
+        // the same anonymous frame if callers re-scan.
+        const synthetic = `__anon_error_${erroredToolUseIds.size}`;
+        erroredToolUseIds.add(synthetic);
+        uniqueNameSet.add('other');
+      }
+    }
+  }
+
+  // Stable allowlist order (not locale-dependent); `other` stays last.
+  const uniqueNames = TOOL_ANALYTICS_FAMILIES.filter((family) =>
+    uniqueNameSet.has(family),
+  );
+
+  return {
+    tool_error_count: erroredToolUseIds.size,
+    tool_name_count: uniqueNames.length,
+    tool_names: [...uniqueNames],
+    tool_names_csv: uniqueNames.join(','),
+  };
+}
+
 function eventTimestamp(
   rec: RunEventForAnalyticsObservability,
 ): number | undefined {
@@ -608,6 +815,9 @@ export function summarizeRunTimingAnalytics(args: {
   let liveArtifactSeen = false;
   const openTools = new Map<string, number>();
   const openToolNames = new Map<string, string>();
+  // Count unique tool_use ids so historical double-emits (or retries) do not
+  // inflate tool_call_count.
+  const seenToolUseIds = new Set<string>();
 
   for (const rec of args.events) {
     const data = rec.data as
@@ -637,17 +847,35 @@ export function summarizeRunTimingAnalytics(args: {
     if (ts === undefined) continue;
     if (data?.type === 'tool_use' && typeof data.id === 'string') {
       firstObservedModelEventType = firstObservedModelEventType ?? 'tool_use';
-      toolCallCount += 1;
-      openTools.set(data.id, ts);
+      if (!seenToolUseIds.has(data.id)) {
+        seenToolUseIds.add(data.id);
+        toolCallCount += 1;
+      }
+      // Prefer producer-supplied start time (ACP firstSeenAt) when present.
+      const payloadStartedAt =
+        typeof (data as { startedAt?: unknown }).startedAt === 'number' &&
+        Number.isFinite((data as { startedAt: number }).startedAt)
+          ? (data as { startedAt: number }).startedAt
+          : undefined;
+      const toolStartedAt = payloadStartedAt ?? ts;
+      // First tool_use timestamp wins for duration pairing.
+      if (!openTools.has(data.id)) {
+        openTools.set(data.id, toolStartedAt);
+      } else if (payloadStartedAt !== undefined) {
+        const prev = openTools.get(data.id);
+        if (prev !== undefined && payloadStartedAt < prev) {
+          openTools.set(data.id, payloadStartedAt);
+        }
+      }
       const name = toolName(data);
       if (name) openToolNames.set(data.id, name);
-      firstToolUseAt = firstToolUseAt ?? ts;
+      firstToolUseAt = firstToolUseAt ?? toolStartedAt;
       lastToolActivityAt = ts;
       if (
         firstArtifactWriteToolStartedAt === undefined &&
         isArtifactWriteToolName(name)
       ) {
-        firstArtifactWriteToolStartedAt = ts;
+        firstArtifactWriteToolStartedAt = toolStartedAt;
         artifactWriteSource = 'write_tool';
       }
     } else if (

--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -472,8 +472,13 @@ export function scanRunEventsForUsageAnalytics(
   // known — a trailing output-only or input-only frame must keep the reverse
   // scan open so earlier frames can fill the missing primary fields (and cache).
   // total alone is not enough to stop; providers often emit it without the pair.
+  // Cache counters are independent of the primary pair: a newer complete
+  // input/output frame that omits cache must not freeze the scan before an
+  // earlier cache_read/cache_creation frame is merged (the inverse of a
+  // trailing cache-only frame).
   let haveProviderUsage = false;
   let havePrimaryUsage = false;
+  let haveCacheFields = false;
 
   for (let i = events.length - 1; i >= 0; i -= 1) {
     const ev = events[i];
@@ -488,7 +493,14 @@ export function scanRunEventsForUsageAnalytics(
         }
       | null
       | undefined;
-    if (ev?.event === 'agent' && data?.type === 'usage' && !havePrimaryUsage) {
+    // Keep merging usage while primary or cache counters are still incomplete.
+    // Stopping on primary alone drops earlier cache-only frames when a newer
+    // frame already supplied input+output without cache.
+    if (
+      ev?.event === 'agent' &&
+      data?.type === 'usage' &&
+      !(havePrimaryUsage && haveCacheFields)
+    ) {
       const usage = data.usage && typeof data.usage === 'object'
         ? data.usage
         : data.modelUsage && typeof data.modelUsage === 'object'
@@ -541,6 +553,12 @@ export function scanRunEventsForUsageAnalytics(
         // total-only) must not freeze the reverse scan.
         havePrimaryUsage =
           inputTokens !== undefined && outputTokens !== undefined;
+        // Cache fields resolve only once both counters are present. If a
+        // stream never emits them, the loop exhausts usage events instead of
+        // treating "no cache seen yet" as complete.
+        haveCacheFields =
+          cacheReadInputTokens !== undefined &&
+          cacheCreationInputTokens !== undefined;
       }
     }
 
@@ -561,10 +579,17 @@ export function scanRunEventsForUsageAnalytics(
       }
     }
 
-    // Stop only once both input and output are known. Partial primary frames
-    // (and thought/cache-only frames) keep the reverse scan open so earlier
-    // counters still merge.
-    if (havePrimaryUsage && (!needAgentModel || agentReportedModel)) break;
+    // Stop only once primary input/output and both cache counters are known.
+    // Partial primary frames, cache-only frames, and the inverse (complete
+    // primary without cache) keep the reverse scan open so earlier counters
+    // still merge. Streams with no cache frames simply finish the loop.
+    if (
+      havePrimaryUsage &&
+      haveCacheFields &&
+      (!needAgentModel || agentReportedModel)
+    ) {
+      break;
+    }
   }
 
   // Forward scan for the turn's FIRST model-call usage (the reverse loop above

--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -468,9 +468,10 @@ export function scanRunEventsForUsageAnalytics(
   let agentReportedModel: string | null = null;
   const needAgentModel = !hasExplicitRequestedModelForAnalytics(reqBodyModel);
   // Provider-usage is true for any real token field (including thought/cache-only
-  // ACP frames). Primary usage is input/output/total — enough to stop seeking
-  // older frames. Keeping these separate prevents a later partial `usage`
-  // frame from hiding an earlier complete record.
+  // ACP frames). Primary usage is complete only once both input and output are
+  // known — a trailing output-only or input-only frame must keep the reverse
+  // scan open so earlier frames can fill the missing primary fields (and cache).
+  // total alone is not enough to stop; providers often emit it without the pair.
   let haveProviderUsage = false;
   let havePrimaryUsage = false;
 
@@ -496,8 +497,8 @@ export function scanRunEventsForUsageAnalytics(
       if (usage) {
         const fields = extractUsageCacheFields(usage);
         // Reverse-scan merge: most-recent frame wins per field; fill gaps from
-        // older frames so a trailing thought/cache-only update still keeps
-        // earlier input/output/total.
+        // older frames so a trailing partial update still keeps earlier
+        // input/output/total/cache counters.
         if (inputTokens === undefined && fields.inputTokens !== undefined) {
           inputTokens = fields.inputTokens;
         }
@@ -535,10 +536,11 @@ export function scanRunEventsForUsageAnalytics(
         ) {
           haveProviderUsage = true;
         }
+        // Require both input and output before treating primary usage as
+        // complete. A single-field trailing frame (output-only / input-only /
+        // total-only) must not freeze the reverse scan.
         havePrimaryUsage =
-          inputTokens !== undefined ||
-          outputTokens !== undefined ||
-          providerTotalTokens !== undefined;
+          inputTokens !== undefined && outputTokens !== undefined;
       }
     }
 
@@ -559,8 +561,9 @@ export function scanRunEventsForUsageAnalytics(
       }
     }
 
-    // Stop once we have primary (input/output/total) usage. Thought/cache-only
-    // frames mark provider_usage but do not complete the reverse scan.
+    // Stop only once both input and output are known. Partial primary frames
+    // (and thought/cache-only frames) keep the reverse scan open so earlier
+    // counters still merge.
     if (havePrimaryUsage && (!needAgentModel || agentReportedModel)) break;
   }
 

--- a/apps/daemon/src/run-analytics-observability.ts
+++ b/apps/daemon/src/run-analytics-observability.ts
@@ -467,7 +467,12 @@ export function scanRunEventsForUsageAnalytics(
   let cacheTokenSource: RunUsageAnalytics['cache_token_source'] = 'unavailable';
   let agentReportedModel: string | null = null;
   const needAgentModel = !hasExplicitRequestedModelForAnalytics(reqBodyModel);
-  let haveUsageTokens = false;
+  // Provider-usage is true for any real token field (including thought/cache-only
+  // ACP frames). Primary usage is input/output/total — enough to stop seeking
+  // older frames. Keeping these separate prevents a later partial `usage`
+  // frame from hiding an earlier complete record.
+  let haveProviderUsage = false;
+  let havePrimaryUsage = false;
 
   for (let i = events.length - 1; i >= 0; i -= 1) {
     const ev = events[i];
@@ -482,7 +487,7 @@ export function scanRunEventsForUsageAnalytics(
         }
       | null
       | undefined;
-    if (ev?.event === 'agent' && data?.type === 'usage' && !haveUsageTokens) {
+    if (ev?.event === 'agent' && data?.type === 'usage' && !havePrimaryUsage) {
       const usage = data.usage && typeof data.usage === 'object'
         ? data.usage
         : data.modelUsage && typeof data.modelUsage === 'object'
@@ -490,23 +495,50 @@ export function scanRunEventsForUsageAnalytics(
           : null;
       if (usage) {
         const fields = extractUsageCacheFields(usage);
-        inputTokens = fields.inputTokens;
-        outputTokens = fields.outputTokens;
-        providerTotalTokens = fields.totalTokens;
-        thoughtTokens = fields.thoughtTokens;
-        cacheReadInputTokens = fields.cacheReadInputTokens;
-        cacheCreationInputTokens = fields.cacheCreationInputTokens;
-        if (fields.cacheTokenSource) cacheTokenSource = fields.cacheTokenSource;
+        // Reverse-scan merge: most-recent frame wins per field; fill gaps from
+        // older frames so a trailing thought/cache-only update still keeps
+        // earlier input/output/total.
+        if (inputTokens === undefined && fields.inputTokens !== undefined) {
+          inputTokens = fields.inputTokens;
+        }
+        if (outputTokens === undefined && fields.outputTokens !== undefined) {
+          outputTokens = fields.outputTokens;
+        }
+        if (providerTotalTokens === undefined && fields.totalTokens !== undefined) {
+          providerTotalTokens = fields.totalTokens;
+        }
+        if (thoughtTokens === undefined && fields.thoughtTokens !== undefined) {
+          thoughtTokens = fields.thoughtTokens;
+        }
+        if (cacheReadInputTokens === undefined && fields.cacheReadInputTokens !== undefined) {
+          cacheReadInputTokens = fields.cacheReadInputTokens;
+        }
+        if (
+          cacheCreationInputTokens === undefined &&
+          fields.cacheCreationInputTokens !== undefined
+        ) {
+          cacheCreationInputTokens = fields.cacheCreationInputTokens;
+        }
+        if (cacheTokenSource === 'unavailable' && fields.cacheTokenSource) {
+          cacheTokenSource = fields.cacheTokenSource;
+        }
         // Any real provider token field counts as provider_usage (not only
         // input/output) so thought-only or total-only ACP payloads still mark
         // the source correctly for PostHog/Langfuse.
-        haveUsageTokens =
+        if (
+          fields.inputTokens !== undefined ||
+          fields.outputTokens !== undefined ||
+          fields.totalTokens !== undefined ||
+          fields.thoughtTokens !== undefined ||
+          fields.cacheReadInputTokens !== undefined ||
+          fields.cacheCreationInputTokens !== undefined
+        ) {
+          haveProviderUsage = true;
+        }
+        havePrimaryUsage =
           inputTokens !== undefined ||
           outputTokens !== undefined ||
-          providerTotalTokens !== undefined ||
-          thoughtTokens !== undefined ||
-          cacheReadInputTokens !== undefined ||
-          cacheCreationInputTokens !== undefined;
+          providerTotalTokens !== undefined;
       }
     }
 
@@ -527,7 +559,9 @@ export function scanRunEventsForUsageAnalytics(
       }
     }
 
-    if (haveUsageTokens && (!needAgentModel || agentReportedModel)) break;
+    // Stop once we have primary (input/output/total) usage. Thought/cache-only
+    // frames mark provider_usage but do not complete the reverse scan.
+    if (havePrimaryUsage && (!needAgentModel || agentReportedModel)) break;
   }
 
   // Forward scan for the turn's FIRST model-call usage (the reverse loop above
@@ -634,7 +668,7 @@ export function scanRunEventsForUsageAnalytics(
       ? { first_call_cache_hit_ratio: firstCallCacheHitRatio }
       : {}),
     cache_token_source: cacheTokenSource,
-    token_count_source: haveUsageTokens ? 'provider_usage' : 'unknown',
+    token_count_source: haveProviderUsage ? 'provider_usage' : 'unknown',
     agent_reported_model: agentReportedModel,
   };
 }

--- a/apps/daemon/src/runtimes/chat-run-messages.ts
+++ b/apps/daemon/src/runtimes/chat-run-messages.ts
@@ -211,7 +211,15 @@ export function daemonAgentPayloadToPersistedAgentEvent(data: unknown): Persiste
     };
   }
   if (type === 'tool_use' && typeof data.id === 'string' && typeof data.name === 'string') {
-    return { kind: 'tool_use', id: data.id, name: data.name, input: normalizePersistedToolInput(data.input) };
+    return {
+      kind: 'tool_use',
+      id: data.id,
+      name: data.name,
+      input: normalizePersistedToolInput(data.input),
+      ...(typeof data.startedAt === 'number' && Number.isFinite(data.startedAt)
+        ? { startedAt: data.startedAt }
+        : {}),
+    };
   }
   if (type === 'tool_input_delta') return null;
   if (type === 'tool_result' && typeof data.toolUseId === 'string') {

--- a/apps/daemon/tests/acp-format-usage.test.ts
+++ b/apps/daemon/tests/acp-format-usage.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatUsage } from '../src/agent-protocol/acp/rpc.js';
+import { scanRunEventsForUsageAnalytics } from '../src/run-analytics-observability.js';
+
+describe('formatUsage', () => {
+  it('normalizes camelCase ACP usage including thought_tokens', () => {
+    expect(
+      formatUsage({
+        inputTokens: 100,
+        outputTokens: 20,
+        cachedReadTokens: 40,
+        thoughtTokens: 8,
+        totalTokens: 128,
+      }),
+    ).toEqual({
+      input_tokens: 100,
+      output_tokens: 20,
+      cached_read_tokens: 40,
+      thought_tokens: 8,
+      total_tokens: 128,
+    });
+  });
+
+  it('normalizes snake_case usage aliases including cache creation', () => {
+    expect(
+      formatUsage({
+        input_tokens: 200,
+        output_tokens: 30,
+        cached_read_tokens: 50,
+        cache_creation_input_tokens: 10,
+        thought_tokens: 12,
+        total_tokens: 242,
+      }),
+    ).toEqual({
+      input_tokens: 200,
+      output_tokens: 30,
+      cached_read_tokens: 50,
+      // Anthropic-style creation key is preserved (not collapsed to generic).
+      cache_creation_input_tokens: 10,
+      thought_tokens: 12,
+      total_tokens: 242,
+    });
+  });
+
+  it('preserves anthropic cache_read_input_tokens (does not map to cached_read_tokens)', () => {
+    expect(
+      formatUsage({
+        input_tokens: 10,
+        cache_read_input_tokens: 4,
+      }),
+    ).toEqual({
+      input_tokens: 10,
+      cache_read_input_tokens: 4,
+    });
+  });
+
+  it('preserves openai-like cached_read_tokens separately from anthropic keys', () => {
+    expect(
+      formatUsage({
+        input_tokens: 100,
+        cached_read_tokens: 40,
+        cached_write_tokens: 5,
+      }),
+    ).toEqual({
+      input_tokens: 100,
+      cached_read_tokens: 40,
+      cached_write_tokens: 5,
+    });
+  });
+
+  it('returns null for empty or non-object input', () => {
+    expect(formatUsage(null)).toBeNull();
+    expect(formatUsage(undefined)).toBeNull();
+    expect(formatUsage({})).toBeNull();
+    expect(formatUsage({ unknown: 1 })).toBeNull();
+  });
+
+  it('ignores non-finite numbers', () => {
+    expect(
+      formatUsage({
+        inputTokens: Number.NaN,
+        outputTokens: -1,
+        thoughtTokens: 3,
+      }),
+    ).toEqual({ thought_tokens: 3 });
+  });
+
+  it('formatUsage anthropic cache fields scan as additive (cache_token_source anthropic)', () => {
+    const formatted = formatUsage({
+      cache_read_input_tokens: 10,
+      input_tokens: 5,
+    });
+    expect(formatted).toEqual({
+      input_tokens: 5,
+      cache_read_input_tokens: 10,
+    });
+
+    const scanned = scanRunEventsForUsageAnalytics(
+      [
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            usage: formatted,
+          },
+        },
+      ],
+      'claude-sonnet',
+      0,
+    );
+
+    expect(scanned).toMatchObject({
+      input_tokens_provider: 5,
+      // Additive: effective = input + cache_read
+      input_tokens_effective: 15,
+      cache_read_input_tokens: 10,
+      uncached_input_tokens: 5,
+      cache_token_source: 'anthropic',
+      token_count_source: 'provider_usage',
+    });
+    expect(scanned.cache_hit_ratio).toBeCloseTo(10 / 15);
+  });
+
+  it('formatUsage openai cacheCreationTokens scan as inclusive (not anthropic additive)', () => {
+    const formatted = formatUsage({
+      inputTokens: 100,
+      cachedReadTokens: 40,
+      cacheCreationTokens: 5,
+    });
+    expect(formatted).toEqual({
+      input_tokens: 100,
+      cached_read_tokens: 40,
+      cache_creation_tokens: 5,
+    });
+
+    const scanned = scanRunEventsForUsageAnalytics(
+      [
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            usage: formatted,
+          },
+        },
+      ],
+      'gpt-4.1',
+      0,
+    );
+
+    expect(scanned).toMatchObject({
+      input_tokens_provider: 100,
+      // Inclusive: effective = input (cache read is a subset)
+      input_tokens_effective: 100,
+      cache_read_input_tokens: 40,
+      cache_creation_input_tokens: 5,
+      uncached_input_tokens: 60,
+      cache_token_source: 'openai',
+      token_count_source: 'provider_usage',
+    });
+    expect(scanned.cache_hit_ratio).toBeCloseTo(40 / 100);
+  });
+});

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -1793,6 +1793,122 @@ test('attachAcpSession honors caller-supplied stageTimeoutMs override', async ()
   }
 });
 
+test('fail paths flush open ACP tools as errored tool_use/tool_result pairs', async () => {
+  // tool_use is deferred until terminal status. If the session fails while a
+  // tool is still open (stage timeout / child exit), the pending entry must
+  // still appear in the transcript as isError so Langfuse/PostHog keep it.
+  vi.useFakeTimers();
+  try {
+    const child = new FakeAcpChild();
+    const events: Array<{ event: string; payload: unknown }> = [];
+
+    attachAcpSession({
+      child: child as never,
+      prompt: 'run a long bash',
+      cwd: '/tmp/od-project',
+      model: null,
+      mcpServers: [],
+      send: (event, payload) => events.push({ event, payload }),
+      stageTimeoutMs: 1_000,
+    });
+
+    writeAcpResult(child, 1, {});
+    writeAcpResult(child, 2, { sessionId: 'session-1' });
+    writeAcpUpdate(child, {
+      sessionUpdate: 'tool_call',
+      toolCallId: 'open-bash-1',
+      kind: 'execute',
+      title: 'bash',
+      status: 'in_progress',
+      rawInput: { command: 'sleep 999' },
+    });
+    // No terminal tool_call_update — session dies mid-tool.
+
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    const error = events.find((e) => e.event === 'error');
+    assert.ok(error, 'expected stage-timeout failure');
+
+    const toolUse = events.find(
+      (e) =>
+        e.event === 'agent' &&
+        (e.payload as { type?: string; id?: string }).type === 'tool_use' &&
+        (e.payload as { id?: string }).id === 'open-bash-1',
+    );
+    assert.ok(toolUse, 'open tool must be flushed as tool_use on fail');
+    assert.equal((toolUse.payload as { name?: string }).name, 'Bash');
+
+    const toolResult = events.find(
+      (e) =>
+        e.event === 'agent' &&
+        (e.payload as { type?: string; toolUseId?: string }).type === 'tool_result' &&
+        (e.payload as { toolUseId?: string }).toolUseId === 'open-bash-1',
+    );
+    assert.ok(toolResult, 'open tool must be flushed as tool_result on fail');
+    assert.equal((toolResult.payload as { isError?: boolean }).isError, true);
+
+    // tool pair must precede the terminal error event so analytics consumers
+    // that stop at first error still see the open tool.
+    const toolUseIdx = events.indexOf(toolUse);
+    const errorIdx = events.indexOf(error);
+    assert.ok(toolUseIdx < errorIdx, 'flush open tools before sending error');
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+test('child-exit fail path flushes open ACP tools as errored pairs', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'read a file',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'open-read-1',
+    kind: 'read',
+    title: 'Read src/app.ts',
+    status: 'pending',
+    locations: [{ path: 'src/app.ts' }],
+  });
+  // Process dies before terminal tool_call_update.
+  child.emit('close', 1, null);
+
+  const error = events.find((e) => e.event === 'error');
+  assert.ok(error, 'expected exit-before-completion failure');
+  assert.match(
+    (error.payload as { message?: string }).message ?? '',
+    /exited before completion/,
+  );
+
+  const toolUse = events.find(
+    (e) =>
+      e.event === 'agent' &&
+      (e.payload as { type?: string; id?: string }).type === 'tool_use' &&
+      (e.payload as { id?: string }).id === 'open-read-1',
+  );
+  assert.ok(toolUse, 'open tool must be flushed on child-exit fail');
+  assert.equal((toolUse.payload as { name?: string }).name, 'Read');
+
+  const toolResult = events.find(
+    (e) =>
+      e.event === 'agent' &&
+      (e.payload as { type?: string; toolUseId?: string }).type === 'tool_result' &&
+      (e.payload as { toolUseId?: string }).toolUseId === 'open-read-1',
+  );
+  assert.ok(toolResult, 'open tool must flush tool_result on child-exit fail');
+  assert.equal((toolResult.payload as { isError?: boolean }).isError, true);
+});
+
 test('attachAcpSession treats stageTimeoutMs <= 0 as a watchdog disable, not an immediate-failure schedule', async () => {
   vi.useFakeTimers();
   try {

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -803,6 +803,58 @@ test('kind:other cannot claim Bash-like names that unlock partial redaction', ()
   assert.equal(isAcpPartialRedactToolName((toolUse.payload as { name?: string }).name ?? ''), false);
 });
 
+test('missing kind cannot claim Bash-like names that unlock partial redaction', () => {
+  // No-kind is the bypass left after kind:other was fail-closed: an adapter
+  // that omits kind but sends name/title "Bash" must not enter Langfuse's
+  // partial-redact allowlist. Only a recognized execute-family kind may.
+  for (const impersonator of ['Bash', 'bash', 'shell', 'Execute', 'terminal']) {
+    assert.equal(
+      acpToolName({ name: impersonator }),
+      'Other',
+      `no-kind name=${impersonator}`,
+    );
+  }
+  assert.equal(acpToolName({ title: 'Bash' }), 'Other');
+  assert.equal(acpToolName({ title: 'run shell command' }), 'Other');
+  // Non-Bash identifiers without kind remain available.
+  assert.equal(acpToolName({ name: 'my_special_tool' }), 'my_special_tool');
+  // Execute-family kinds still unlock Bash.
+  assert.equal(acpToolName({ kind: 'execute', name: 'Bash' }), 'Bash');
+  assert.equal(acpToolName({ kind: 'shell', title: 'run something' }), 'Bash');
+
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'no-kind bash-named tool',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'no-kind-bash-1',
+    // Intentionally omit kind — name alone must not unlock partial redaction.
+    name: 'Bash',
+    status: 'completed',
+    rawInput: { secret: 'API_KEY=super-secret', command: 'cat /Users/alice/.env' },
+    rawOutput: 'should not matter',
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const toolUse = events.find(
+    (e) => e.event === 'agent' && (e.payload as { type?: string }).type === 'tool_use',
+  );
+  assert.ok(toolUse);
+  assert.equal((toolUse.payload as { name?: string }).name, 'Other');
+  assert.equal(isAcpPartialRedactToolName((toolUse.payload as { name?: string }).name ?? ''), false);
+});
+
 test('sticky thinkOnly: pending Thinking then status-only completed emits no tool events', () => {
   const child = new FakeAcpChild();
   const events: Array<{ event: string; payload: unknown }> = [];

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -952,7 +952,11 @@ test('terminal status-only frame keeps earlier rawOutput content', () => {
     .map((e) => ({ event: 'agent', data: e.payload }));
   const toolResult = runEvents.find((e) => (e.data as { type?: string }).type === 'tool_result');
   assert.ok(toolResult);
-  assert.equal((toolResult.data as { content?: string }).content, 'hi\n');
+  // Earlier rawOutput is retained, then redacted at emit for execute tools.
+  assert.equal(
+    (toolResult.data as { content?: string }).content,
+    `[REDACTED:acp_bash_output:${'hi\n'.length}_chars]`,
+  );
 });
 
 test('an ACP write whose title names a NON-artifact file is not counted', () => {
@@ -1038,8 +1042,64 @@ test('attachAcpSession mirrors bash-like ACP tools with command input and rawOut
       (e.data as { toolUseId?: string }).toolUseId === 'bash-1',
   );
   assert.ok(toolResult);
-  assert.equal((toolResult.data as { content?: string }).content, 'total 0\n.');
+  // Execute stdout is replaced with a length summary so private dumps (cat .env)
+  // never enter the canonical tool_result transcript / Langfuse path.
+  assert.equal(
+    (toolResult.data as { content?: string }).content,
+    `[REDACTED:acp_bash_output:${'total 0\n.'.length}_chars]`,
+  );
   assert.equal(countNewArtifacts(runEvents), 0);
+});
+
+test('ACP execute tool_result redacts private stdout (cat .env)', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+  const secretDump = 'API_KEY=super-secret\nPASSWORD=also-secret\n';
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'cat secrets',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'bash-secret-1',
+    kind: 'execute',
+    status: 'completed',
+    rawInput: { command: 'cat .env' },
+    rawOutput: secretDump,
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const toolUse = events.find(
+    (e) =>
+      e.event === 'agent' &&
+      (e.payload as { type?: string; id?: string }).type === 'tool_use' &&
+      (e.payload as { id?: string }).id === 'bash-secret-1',
+  );
+  const toolResult = events.find(
+    (e) =>
+      e.event === 'agent' &&
+      (e.payload as { type?: string; toolUseId?: string }).type === 'tool_result' &&
+      (e.payload as { toolUseId?: string }).toolUseId === 'bash-secret-1',
+  );
+  assert.ok(toolUse);
+  assert.equal((toolUse.payload as { name?: string }).name, 'Bash');
+  // Command stays for observability; only stdout is redacted.
+  assert.equal(
+    (toolUse.payload as { input?: { command?: string } }).input?.command,
+    'cat .env',
+  );
+  assert.ok(toolResult);
+  const content = String((toolResult.payload as { content?: string }).content ?? '');
+  assert.equal(content, `[REDACTED:acp_bash_output:${secretDump.length}_chars]`);
+  assert.doesNotMatch(content, /API_KEY|PASSWORD|super-secret/);
 });
 
 test('ACP title Image.open must not become file_path', () => {

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -836,6 +836,80 @@ test('exactly-once emission: repeated terminal frames for same toolCallId emit o
   assert.equal(toolResults.length, 1);
 });
 
+test('flush retains tool ids so late terminal cannot emit a second contradictory pair', () => {
+  // Regression: flushOpenAcpTools must not clear acpToolRunEventState. A racy
+  // completed tool_call_update after abort/timeout flush must not recreate the
+  // same id as a fresh open tool and emit a successful pair after isError=true.
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'run a long bash',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'flush-race-1',
+    kind: 'execute',
+    title: 'bash',
+    status: 'in_progress',
+    rawInput: { command: 'sleep 999' },
+  });
+  // Abort flushes the open tool as isError=true and must retain the map entry.
+  session.abort();
+
+  const afterAbortUses = events.filter(
+    (e) =>
+      e.event === 'agent' &&
+      (e.payload as { type?: string; id?: string }).type === 'tool_use' &&
+      (e.payload as { id?: string }).id === acpTelemetryToolCallId('flush-race-1'),
+  );
+  const afterAbortResults = events.filter(
+    (e) =>
+      e.event === 'agent' &&
+      (e.payload as { type?: string; toolUseId?: string }).type === 'tool_result' &&
+      (e.payload as { toolUseId?: string }).toolUseId === acpTelemetryToolCallId('flush-race-1'),
+  );
+  assert.equal(afterAbortUses.length, 1, 'abort must flush exactly one tool_use');
+  assert.equal(afterAbortResults.length, 1, 'abort must flush exactly one tool_result');
+  assert.equal((afterAbortResults[0]?.payload as { isError?: boolean }).isError, true);
+
+  // Late terminal (buffered agent stdout racing cancel). Must not add a second pair.
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'flush-race-1',
+    status: 'completed',
+    content: [{ type: 'content', content: { type: 'text', text: 'should not win' } }],
+  });
+
+  const finalUses = events.filter(
+    (e) =>
+      e.event === 'agent' &&
+      (e.payload as { type?: string; id?: string }).type === 'tool_use' &&
+      (e.payload as { id?: string }).id === acpTelemetryToolCallId('flush-race-1'),
+  );
+  const finalResults = events.filter(
+    (e) =>
+      e.event === 'agent' &&
+      (e.payload as { type?: string; toolUseId?: string }).type === 'tool_result' &&
+      (e.payload as { toolUseId?: string }).toolUseId === acpTelemetryToolCallId('flush-race-1'),
+  );
+  assert.equal(finalUses.length, 1, 'late terminal must not emit a second tool_use');
+  assert.equal(finalResults.length, 1, 'late terminal must not emit a second tool_result');
+  assert.equal(
+    (finalResults[0]?.payload as { isError?: boolean }).isError,
+    true,
+    'flushed failure must not be replaced by a successful late terminal',
+  );
+});
+
 test('sticky kind name: kind:read pending then title-only completed stays Read', () => {
   const child = new FakeAcpChild();
   const events: Array<{ event: string; payload: unknown }> = [];

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -2078,6 +2078,65 @@ test('attachAcpSession does not fail a tool-only AMR turn that emits no assistan
   assert.deepEqual(errorEvents, [], 'a turn that produced tool calls must not be reported as model-unavailable');
 });
 
+test('successful session/prompt with open concrete tool flushes clean (not no-output fail)', () => {
+  // Regression: session/prompt can succeed after an in-progress tool frame without a
+  // terminal tool_call_update. Clean-flush the open tool before AMR no-output
+  // classification so the run succeeds with isError=false instead of failing and
+  // re-flushing the tool as an error.
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'read a file',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE',
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'open-read-1',
+    kind: 'read',
+    title: 'Read src/app.ts',
+    status: 'in_progress',
+    locations: [{ path: 'src/app.ts' }],
+  });
+  // Prompt completes successfully with usage but no terminal tool_call_update.
+  writeAcpResult(child, 3, {
+    stopReason: 'end_turn',
+    usage: { inputTokens: 10, outputTokens: 50, totalTokens: 60 },
+  });
+
+  assert.equal(session.hasFatalError(), false);
+  assert.equal(session.completedSuccessfully(), true);
+
+  const errorEvents = events.filter((entry) => entry.event === 'error');
+  assert.deepEqual(errorEvents, [], 'open concrete tool must not trigger acp_no_visible_output');
+
+  const toolUse = events.find(
+    (e) =>
+      e.event === 'agent' &&
+      (e.payload as { type?: string; id?: string }).type === 'tool_use' &&
+      (e.payload as { id?: string }).id === 'open-read-1',
+  );
+  assert.ok(toolUse, 'open concrete tool must be clean-flushed as tool_use');
+  assert.equal((toolUse.payload as { name?: string }).name, 'Read');
+
+  const toolResult = events.find(
+    (e) =>
+      e.event === 'agent' &&
+      (e.payload as { type?: string; toolUseId?: string }).type === 'tool_result' &&
+      (e.payload as { toolUseId?: string }).toolUseId === 'open-read-1',
+  );
+  assert.ok(toolResult, 'open concrete tool must be clean-flushed as tool_result');
+  assert.equal((toolResult.payload as { isError?: boolean }).isError, false);
+});
+
 test('attachAcpSession still fails an AMR turn that produces no text and no tool calls', () => {
   const child = new FakeAcpChild();
   const events: Array<{ event: string; payload: unknown }> = [];

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -467,7 +467,8 @@ test('attachAcpSession mirrors artifact-write tool calls into countable tool_use
     toolCallId: 'write-1',
     status: 'completed',
   });
-  // A read-only tool call must NOT surface as an artifact.
+  // A read-only tool call must still produce tool_use/tool_result, but must
+  // NOT surface as an artifact.
   writeAcpUpdate(child, {
     sessionUpdate: 'tool_call',
     toolCallId: 'grep-1',
@@ -482,17 +483,32 @@ test('attachAcpSession mirrors artifact-write tool calls into countable tool_use
     .filter((e) => e.event === 'agent')
     .map((e) => ({ event: 'agent', data: e.payload }));
 
-  const toolUse = runEvents.find((e) => (e.data as { type?: string }).type === 'tool_use');
-  assert.ok(toolUse, 'expected a tool_use event for the ACP write tool call');
-  assert.equal((toolUse.data as { name?: string }).name, 'Write');
+  const toolUses = runEvents.filter((e) => (e.data as { type?: string }).type === 'tool_use');
+  const writeUse = toolUses.find((e) => (e.data as { id?: string }).id === 'write-1');
+  assert.ok(writeUse, 'expected a tool_use event for the ACP write tool call');
+  assert.equal((writeUse.data as { name?: string }).name, 'Write');
   assert.equal(
-    (toolUse.data as { input?: { file_path?: string } }).input?.file_path,
+    (writeUse.data as { input?: { file_path?: string } }).input?.file_path,
     'index.html',
   );
 
-  const toolResult = runEvents.find((e) => (e.data as { type?: string }).type === 'tool_result');
-  assert.ok(toolResult, 'expected a paired tool_result event');
-  assert.equal((toolResult.data as { isError?: boolean }).isError, false);
+  const grepUse = toolUses.find((e) => (e.data as { id?: string }).id === 'grep-1');
+  assert.ok(grepUse, 'expected a tool_use event for the read-only grep call');
+  assert.notEqual((grepUse.data as { name?: string }).name, 'Write');
+  const grepResult = runEvents.find(
+    (e) =>
+      (e.data as { type?: string; toolUseId?: string }).type === 'tool_result' &&
+      (e.data as { toolUseId?: string }).toolUseId === 'grep-1',
+  );
+  assert.ok(grepResult, 'expected a paired tool_result for grep');
+
+  const writeResult = runEvents.find(
+    (e) =>
+      (e.data as { type?: string; toolUseId?: string }).type === 'tool_result' &&
+      (e.data as { toolUseId?: string }).toolUseId === 'write-1',
+  );
+  assert.ok(writeResult, 'expected a paired tool_result event');
+  assert.equal((writeResult.data as { isError?: boolean }).isError, false);
 
   // Before the fix this returned 0 for every ACP run; the read-only grep call
   // must not inflate the count.
@@ -527,15 +543,17 @@ test('a truly PATHLESS ACP write is NOT coerced into an artifact (no false posit
     .map((e) => ({ event: 'agent', data: e.payload }));
 
   const toolUse = runEvents.find((e) => (e.data as { type?: string }).type === 'tool_use');
+  assert.ok(toolUse, 'pathless edit may still emit tool_use');
   const filePath = (toolUse?.data as { input?: { file_path?: string } } | undefined)?.input?.file_path ?? '';
   assert.doesNotMatch(filePath, /\.html$/, 'must not fabricate a synthetic .html extension');
+  assert.notEqual(filePath, 'edit-1', 'must not use toolCallId as file_path');
   assert.equal(countNewArtifacts(runEvents), 0);
 });
 
 test('an ACP artifact path arriving only on the completing frame is still counted', () => {
-  // ACP frequently sends `locations` only on the terminal update. Emission is
-  // deferred to the terminal frame so that late path is used for classification
-  // (emitting on the first/pending frame would have missed it).
+  // ACP frequently sends `locations` only on the terminal update. Accumulate
+  // partial frames and emit exactly one tool_use + tool_result at terminal
+  // with the late path so classification sees landing.html.
   const child = new FakeAcpChild();
   const events: Array<{ event: string; payload: unknown }> = [];
 
@@ -562,9 +580,303 @@ test('an ACP artifact path arriving only on the completing frame is still counte
   const runEvents = events
     .filter((e) => e.event === 'agent')
     .map((e) => ({ event: 'agent', data: e.payload }));
-  const toolUse = runEvents.find((e) => (e.data as { type?: string }).type === 'tool_use');
-  assert.equal((toolUse?.data as { input?: { file_path?: string } } | undefined)?.input?.file_path, 'landing.html');
+  const toolUses = runEvents.filter(
+    (e) =>
+      (e.data as { type?: string; id?: string }).type === 'tool_use' &&
+      (e.data as { id?: string }).id === 'w-2',
+  );
+  const toolResults = runEvents.filter(
+    (e) =>
+      (e.data as { type?: string; toolUseId?: string }).type === 'tool_result' &&
+      (e.data as { toolUseId?: string }).toolUseId === 'w-2',
+  );
+  assert.equal(toolUses.length, 1, 'exactly one tool_use even when path arrives late');
+  assert.equal(toolResults.length, 1, 'exactly one tool_result');
+  assert.equal(
+    (toolUses[0]?.data as { input?: { file_path?: string } } | undefined)?.input?.file_path,
+    'landing.html',
+  );
   assert.equal(countNewArtifacts(runEvents), 1);
+});
+
+test('kind:read + title containing update stays Read, not Write', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'read file',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'read-upd',
+    kind: 'read',
+    title: 'update cache from disk',
+    status: 'completed',
+    locations: [{ path: 'cache.json' }],
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const runEvents = events
+    .filter((e) => e.event === 'agent')
+    .map((e) => ({ event: 'agent', data: e.payload }));
+  const toolUse = runEvents.find((e) => (e.data as { type?: string }).type === 'tool_use');
+  assert.ok(toolUse);
+  assert.equal((toolUse.data as { name?: string }).name, 'Read');
+  assert.equal(countNewArtifacts(runEvents), 0);
+});
+
+test('sticky thinkOnly: pending Thinking then status-only completed emits no tool events', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'think',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'think-1',
+    title: 'Thinking',
+    status: 'pending',
+  });
+  // Terminal frame is status-only (no title) — must not clear sticky thinkOnly.
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'think-1',
+    status: 'completed',
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const toolUses = events.filter(
+    (e) => e.event === 'agent' && (e.payload as { type?: string }).type === 'tool_use',
+  );
+  const toolResults = events.filter(
+    (e) => e.event === 'agent' && (e.payload as { type?: string }).type === 'tool_result',
+  );
+  assert.equal(toolUses.length, 0, 'think-only must not emit tool_use');
+  assert.equal(toolResults.length, 0, 'think-only must not emit tool_result');
+});
+
+test('exactly-once emission: repeated terminal frames for same toolCallId emit one pair', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'write once',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'once-1',
+    kind: 'write',
+    status: 'pending',
+    locations: [{ path: 'page.html' }],
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'once-1',
+    status: 'completed',
+  });
+  // Duplicate terminal (agent retry / replay) must not double-emit.
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'once-1',
+    status: 'completed',
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const toolUses = events.filter(
+    (e) =>
+      e.event === 'agent' &&
+      (e.payload as { type?: string; id?: string }).type === 'tool_use' &&
+      (e.payload as { id?: string }).id === 'once-1',
+  );
+  const toolResults = events.filter(
+    (e) =>
+      e.event === 'agent' &&
+      (e.payload as { type?: string; toolUseId?: string }).type === 'tool_result' &&
+      (e.payload as { toolUseId?: string }).toolUseId === 'once-1',
+  );
+  assert.equal(toolUses.length, 1);
+  assert.equal(toolResults.length, 1);
+});
+
+test('sticky kind name: kind:read pending then title-only completed stays Read', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'read file',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'read-sticky',
+    kind: 'read',
+    status: 'pending',
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'read-sticky',
+    title: 'Update cache',
+    status: 'completed',
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const toolUse = events.find(
+    (e) => e.event === 'agent' && (e.payload as { type?: string }).type === 'tool_use',
+  );
+  assert.ok(toolUse);
+  assert.equal((toolUse.payload as { name?: string }).name, 'Read');
+});
+
+test('tool_use carries startedAt from firstSeenAt for duration analytics', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+  const before = Date.now();
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'bash',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'dur-1',
+    kind: 'execute',
+    status: 'pending',
+    rawInput: { command: 'echo hi' },
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'dur-1',
+    status: 'completed',
+    rawOutput: 'hi\n',
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+  const after = Date.now();
+
+  const toolUse = events.find(
+    (e) =>
+      e.event === 'agent' &&
+      (e.payload as { type?: string; id?: string }).type === 'tool_use' &&
+      (e.payload as { id?: string }).id === 'dur-1',
+  );
+  assert.ok(toolUse);
+  const startedAt = (toolUse.payload as { startedAt?: number }).startedAt;
+  assert.equal(typeof startedAt, 'number');
+  assert.ok(Number.isFinite(startedAt));
+  assert.ok(startedAt! >= before && startedAt! <= after);
+});
+
+test('rawInput.filePath (camelCase) is recognized as file_path', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'write page',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'fp-1',
+    kind: 'write',
+    status: 'completed',
+    rawInput: { filePath: 'pages/home.html' },
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const runEvents = events
+    .filter((e) => e.event === 'agent')
+    .map((e) => ({ event: 'agent', data: e.payload }));
+  const toolUse = runEvents.find((e) => (e.data as { type?: string }).type === 'tool_use');
+  assert.ok(toolUse);
+  assert.equal(
+    (toolUse.data as { input?: { file_path?: string } }).input?.file_path,
+    'pages/home.html',
+  );
+  assert.equal(countNewArtifacts(runEvents), 1);
+});
+
+test('terminal status-only frame keeps earlier rawOutput content', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'run cmd',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'out-1',
+    kind: 'execute',
+    status: 'in_progress',
+    rawInput: { command: 'echo hi' },
+    rawOutput: 'hi\n',
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'out-1',
+    status: 'completed',
+    // status-only — no rawOutput on terminal frame
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const runEvents = events
+    .filter((e) => e.event === 'agent')
+    .map((e) => ({ event: 'agent', data: e.payload }));
+  const toolResult = runEvents.find((e) => (e.data as { type?: string }).type === 'tool_result');
+  assert.ok(toolResult);
+  assert.equal((toolResult.data as { content?: string }).content, 'hi\n');
 });
 
 test('an ACP write whose title names a NON-artifact file is not counted', () => {
@@ -597,6 +909,176 @@ test('an ACP write whose title names a NON-artifact file is not counted', () => 
     .filter((e) => e.event === 'agent')
     .map((e) => ({ event: 'agent', data: e.payload }));
   assert.equal(countNewArtifacts(runEvents), 0);
+});
+
+test('attachAcpSession mirrors bash-like ACP tools with command input and rawOutput result', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'list files',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'bash-1',
+    kind: 'execute',
+    title: 'ls',
+    status: 'pending',
+    rawInput: { command: 'ls -la' },
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call_update',
+    toolCallId: 'bash-1',
+    status: 'completed',
+    rawOutput: 'total 0\n.',
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const runEvents = events
+    .filter((e) => e.event === 'agent')
+    .map((e) => ({ event: 'agent', data: e.payload }));
+  const toolUse = runEvents.find(
+    (e) =>
+      (e.data as { type?: string; id?: string }).type === 'tool_use' &&
+      (e.data as { id?: string }).id === 'bash-1',
+  );
+  assert.ok(toolUse, 'expected bash tool_use');
+  assert.equal((toolUse.data as { name?: string }).name, 'Bash');
+  assert.equal(
+    (toolUse.data as { input?: { command?: string } }).input?.command,
+    'ls -la',
+  );
+  const toolResult = runEvents.find(
+    (e) =>
+      (e.data as { type?: string; toolUseId?: string }).type === 'tool_result' &&
+      (e.data as { toolUseId?: string }).toolUseId === 'bash-1',
+  );
+  assert.ok(toolResult);
+  assert.equal((toolResult.data as { content?: string }).content, 'total 0\n.');
+  assert.equal(countNewArtifacts(runEvents), 0);
+});
+
+test('ACP title Image.open must not become file_path', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'open image',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'img-1',
+    title: 'Image.open',
+    status: 'completed',
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const runEvents = events
+    .filter((e) => e.event === 'agent')
+    .map((e) => ({ event: 'agent', data: e.payload }));
+  const toolUse = runEvents.find((e) => (e.data as { type?: string }).type === 'tool_use');
+  assert.ok(toolUse);
+  const filePath = (toolUse.data as { input?: { file_path?: string } }).input?.file_path;
+  assert.notEqual(filePath, 'Image.open');
+  assert.equal(countNewArtifacts(runEvents), 0);
+});
+
+test('ACP tool_result content is forwarded from rawOutput and truncated when huge', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'read big file',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  const huge = 'x'.repeat(9000);
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'read-1',
+    kind: 'read',
+    status: 'completed',
+    rawOutput: huge,
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const runEvents = events
+    .filter((e) => e.event === 'agent')
+    .map((e) => ({ event: 'agent', data: e.payload }));
+  const toolResult = runEvents.find(
+    (e) => (e.data as { type?: string }).type === 'tool_result',
+  );
+  assert.ok(toolResult);
+  const content = (toolResult.data as { content?: string }).content ?? '';
+  assert.ok(content.endsWith('\n…[truncated]'), 'expected truncation suffix');
+  assert.ok(content.length < huge.length);
+  assert.ok(content.startsWith('xxxx'));
+});
+
+test('attachAcpSession emits tool_use pairs for write + bash in one turn', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'write and list',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'w-multi',
+    title: 'Write index.html',
+    status: 'completed',
+    locations: [{ path: 'index.html' }],
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'b-multi',
+    kind: 'bash',
+    status: 'completed',
+    rawInput: { command: 'ls' },
+    rawOutput: 'index.html\n',
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const runEvents = events
+    .filter((e) => e.event === 'agent')
+    .map((e) => ({ event: 'agent', data: e.payload }));
+  const toolUses = runEvents.filter((e) => (e.data as { type?: string }).type === 'tool_use');
+  const toolResults = runEvents.filter((e) => (e.data as { type?: string }).type === 'tool_result');
+  assert.ok(toolUses.some((e) => (e.data as { id?: string }).id === 'w-multi'));
+  assert.ok(toolUses.some((e) => (e.data as { id?: string }).id === 'b-multi'));
+  assert.ok(toolResults.some((e) => (e.data as { toolUseId?: string }).toolUseId === 'w-multi'));
+  assert.ok(toolResults.some((e) => (e.data as { toolUseId?: string }).toolUseId === 'b-multi'));
+  assert.equal(countNewArtifacts(runEvents), 1);
 });
 
 test('attachAcpSession suppresses incremental artifact echo after earlier assistant text', () => {

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -1138,6 +1138,60 @@ test('ACP execute tool_result redacts private stdout (cat .env)', () => {
   assert.doesNotMatch(content, /API_KEY|PASSWORD|super-secret/);
 });
 
+test('ACP path-like toolCallId is hashed before tool_use/tool_result emission', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+  // Adapter-derived id that embeds a user home path / secret file name.
+  const rawToolCallId = 'read:/home/alice/.env';
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'read env',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: rawToolCallId,
+    kind: 'read',
+    status: 'completed',
+    locations: [{ path: '/home/alice/.env' }],
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const toolUse = events.find(
+    (e) => e.event === 'agent' && (e.payload as { type?: string }).type === 'tool_use',
+  );
+  const toolResult = events.find(
+    (e) => e.event === 'agent' && (e.payload as { type?: string }).type === 'tool_result',
+  );
+  assert.ok(toolUse, 'expected tool_use for path-like toolCallId');
+  assert.ok(toolResult, 'expected tool_result for path-like toolCallId');
+  const useId = (toolUse.payload as { id?: string }).id ?? '';
+  const resultId = (toolResult.payload as { toolUseId?: string }).toolUseId ?? '';
+  // Transcript/telemetry must not carry the raw path-bearing adapter id.
+  assert.notEqual(useId, rawToolCallId);
+  assert.notEqual(resultId, rawToolCallId);
+  assert.equal(useId, resultId, 'tool_use and tool_result stay paired');
+  assert.match(useId, /^acp_[0-9a-f]{24}$/);
+  assert.doesNotMatch(useId, /alice|\.env|\/home\//);
+  // Safe identifier-like ids still pass through unchanged.
+  assert.equal(
+    events.some(
+      (e) =>
+        e.event === 'agent' &&
+        (e.payload as { type?: string; id?: string }).type === 'tool_use' &&
+        String((e.payload as { id?: string }).id ?? '').includes('alice'),
+    ),
+    false,
+  );
+});
+
 test('ACP title Image.open must not become file_path', () => {
   const child = new FakeAcpChild();
   const events: Array<{ event: string; payload: unknown }> = [];

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -633,6 +633,82 @@ test('kind:read + title containing update stays Read, not Write', () => {
   assert.equal(countNewArtifacts(runEvents), 0);
 });
 
+test('kind:read + explicit noncanonical name read_file normalizes to Read', () => {
+  // Content-tool redaction only matches canonical families (Read/Write/Edit/…).
+  // ACP adapters commonly send kind:"read" with name:"read_file"; the transcript
+  // must still emit Read so rawOutput is redacted in Langfuse, not serialized.
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'read secrets',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'read-file-1',
+    kind: 'read',
+    name: 'read_file',
+    status: 'completed',
+    locations: [{ path: 'secrets.env' }],
+    rawOutput: 'API_KEY=super-secret\nPASSWORD=also-secret\n',
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const toolUse = events.find(
+    (e) => e.event === 'agent' && (e.payload as { type?: string }).type === 'tool_use',
+  );
+  const toolResult = events.find(
+    (e) => e.event === 'agent' && (e.payload as { type?: string }).type === 'tool_result',
+  );
+  assert.ok(toolUse);
+  assert.equal((toolUse.payload as { name?: string }).name, 'Read');
+  assert.ok(toolResult);
+  assert.match(
+    String((toolResult.payload as { content?: string }).content ?? ''),
+    /API_KEY=super-secret/,
+  );
+});
+
+test('kind:other keeps explicit custom tool name', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'custom tool',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'custom-1',
+    kind: 'other',
+    name: 'my_special_tool',
+    status: 'completed',
+    rawOutput: 'ok',
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const toolUse = events.find(
+    (e) => e.event === 'agent' && (e.payload as { type?: string }).type === 'tool_use',
+  );
+  assert.ok(toolUse);
+  assert.equal((toolUse.payload as { name?: string }).name, 'my_special_tool');
+});
+
 test('sticky thinkOnly: pending Thinking then status-only completed emits no tool events', () => {
   const child = new FakeAcpChild();
   const events: Array<{ event: string; payload: unknown }> = [];

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -2005,6 +2005,63 @@ test('child-exit fail path flushes open ACP tools as errored pairs', () => {
   assert.equal((toolResult.payload as { isError?: boolean }).isError, true);
 });
 
+test('abort flushes open ACP tools as errored pairs', () => {
+  // User cancel calls abort() without going through fail(). Deferred tools
+  // must still emit tool_use/tool_result so canceled runs keep a complete
+  // transcript for Langfuse/PostHog (same as timeout / child-exit fails).
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'run a long bash',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'open-bash-cancel-1',
+    kind: 'execute',
+    title: 'bash',
+    status: 'in_progress',
+    rawInput: { command: 'sleep 999' },
+  });
+  // No terminal tool_call_update — user cancels mid-tool.
+  session.abort();
+
+  const toolUse = events.find(
+    (e) =>
+      e.event === 'agent' &&
+      (e.payload as { type?: string; id?: string }).type === 'tool_use' &&
+      (e.payload as { id?: string }).id === 'open-bash-cancel-1',
+  );
+  assert.ok(toolUse, 'open tool must be flushed as tool_use on abort');
+  assert.equal((toolUse.payload as { name?: string }).name, 'Bash');
+
+  const toolResult = events.find(
+    (e) =>
+      e.event === 'agent' &&
+      (e.payload as { type?: string; toolUseId?: string }).type === 'tool_result' &&
+      (e.payload as { toolUseId?: string }).toolUseId === 'open-bash-cancel-1',
+  );
+  assert.ok(toolResult, 'open tool must be flushed as tool_result on abort');
+  assert.equal((toolResult.payload as { isError?: boolean }).isError, true);
+
+  // Idempotent: second abort must not re-emit the pair.
+  const agentCountBefore = events.filter((e) => e.event === 'agent').length;
+  session.abort();
+  assert.equal(
+    events.filter((e) => e.event === 'agent').length,
+    agentCountBefore,
+    'abort flush must be idempotent',
+  );
+});
+
 test('attachAcpSession treats stageTimeoutMs <= 0 as a watchdog disable, not an immediate-failure schedule', async () => {
   vi.useFakeTimers();
   try {

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -6,6 +6,7 @@ import { PassThrough } from 'node:stream';
 import path from 'node:path';
 import { test, vi } from 'vitest';
 import { attachAcpSession, buildAcpSessionNewParams, createJsonLineStream, normalizeModels } from '../src/agent-protocol/index.js';
+import { acpTelemetryToolCallId } from '../src/agent-protocol/acp/updates.js';
 import { countNewArtifacts } from '../src/runtimes/run-artifacts.js';
 
 const DEFAULT_MODEL_OPTION = { id: 'default', label: 'Default (CLI config)' };
@@ -484,7 +485,7 @@ test('attachAcpSession mirrors artifact-write tool calls into countable tool_use
     .map((e) => ({ event: 'agent', data: e.payload }));
 
   const toolUses = runEvents.filter((e) => (e.data as { type?: string }).type === 'tool_use');
-  const writeUse = toolUses.find((e) => (e.data as { id?: string }).id === 'write-1');
+  const writeUse = toolUses.find((e) => (e.data as { id?: string }).id === acpTelemetryToolCallId('write-1'));
   assert.ok(writeUse, 'expected a tool_use event for the ACP write tool call');
   assert.equal((writeUse.data as { name?: string }).name, 'Write');
   assert.equal(
@@ -492,20 +493,20 @@ test('attachAcpSession mirrors artifact-write tool calls into countable tool_use
     'index.html',
   );
 
-  const grepUse = toolUses.find((e) => (e.data as { id?: string }).id === 'grep-1');
+  const grepUse = toolUses.find((e) => (e.data as { id?: string }).id === acpTelemetryToolCallId('grep-1'));
   assert.ok(grepUse, 'expected a tool_use event for the read-only grep call');
   assert.notEqual((grepUse.data as { name?: string }).name, 'Write');
   const grepResult = runEvents.find(
     (e) =>
       (e.data as { type?: string; toolUseId?: string }).type === 'tool_result' &&
-      (e.data as { toolUseId?: string }).toolUseId === 'grep-1',
+      (e.data as { toolUseId?: string }).toolUseId === acpTelemetryToolCallId('grep-1'),
   );
   assert.ok(grepResult, 'expected a paired tool_result for grep');
 
   const writeResult = runEvents.find(
     (e) =>
       (e.data as { type?: string; toolUseId?: string }).type === 'tool_result' &&
-      (e.data as { toolUseId?: string }).toolUseId === 'write-1',
+      (e.data as { toolUseId?: string }).toolUseId === acpTelemetryToolCallId('write-1'),
   );
   assert.ok(writeResult, 'expected a paired tool_result event');
   assert.equal((writeResult.data as { isError?: boolean }).isError, false);
@@ -583,12 +584,12 @@ test('an ACP artifact path arriving only on the completing frame is still counte
   const toolUses = runEvents.filter(
     (e) =>
       (e.data as { type?: string; id?: string }).type === 'tool_use' &&
-      (e.data as { id?: string }).id === 'w-2',
+      (e.data as { id?: string }).id === acpTelemetryToolCallId('w-2'),
   );
   const toolResults = runEvents.filter(
     (e) =>
       (e.data as { type?: string; toolUseId?: string }).type === 'tool_result' &&
-      (e.data as { toolUseId?: string }).toolUseId === 'w-2',
+      (e.data as { toolUseId?: string }).toolUseId === acpTelemetryToolCallId('w-2'),
   );
   assert.equal(toolUses.length, 1, 'exactly one tool_use even when path arrives late');
   assert.equal(toolResults.length, 1, 'exactly one tool_result');
@@ -823,13 +824,13 @@ test('exactly-once emission: repeated terminal frames for same toolCallId emit o
     (e) =>
       e.event === 'agent' &&
       (e.payload as { type?: string; id?: string }).type === 'tool_use' &&
-      (e.payload as { id?: string }).id === 'once-1',
+      (e.payload as { id?: string }).id === acpTelemetryToolCallId('once-1'),
   );
   const toolResults = events.filter(
     (e) =>
       e.event === 'agent' &&
       (e.payload as { type?: string; toolUseId?: string }).type === 'tool_result' &&
-      (e.payload as { toolUseId?: string }).toolUseId === 'once-1',
+      (e.payload as { toolUseId?: string }).toolUseId === acpTelemetryToolCallId('once-1'),
   );
   assert.equal(toolUses.length, 1);
   assert.equal(toolResults.length, 1);
@@ -907,7 +908,7 @@ test('tool_use carries startedAt from firstSeenAt for duration analytics', () =>
     (e) =>
       e.event === 'agent' &&
       (e.payload as { type?: string; id?: string }).type === 'tool_use' &&
-      (e.payload as { id?: string }).id === 'dur-1',
+      (e.payload as { id?: string }).id === acpTelemetryToolCallId('dur-1'),
   );
   assert.ok(toolUse);
   const startedAt = (toolUse.payload as { startedAt?: number }).startedAt;
@@ -1064,7 +1065,7 @@ test('attachAcpSession mirrors bash-like ACP tools with command input and rawOut
   const toolUse = runEvents.find(
     (e) =>
       (e.data as { type?: string; id?: string }).type === 'tool_use' &&
-      (e.data as { id?: string }).id === 'bash-1',
+      (e.data as { id?: string }).id === acpTelemetryToolCallId('bash-1'),
   );
   assert.ok(toolUse, 'expected bash tool_use');
   assert.equal((toolUse.data as { name?: string }).name, 'Bash');
@@ -1075,7 +1076,7 @@ test('attachAcpSession mirrors bash-like ACP tools with command input and rawOut
   const toolResult = runEvents.find(
     (e) =>
       (e.data as { type?: string; toolUseId?: string }).type === 'tool_result' &&
-      (e.data as { toolUseId?: string }).toolUseId === 'bash-1',
+      (e.data as { toolUseId?: string }).toolUseId === acpTelemetryToolCallId('bash-1'),
   );
   assert.ok(toolResult);
   // Execute stdout is replaced with a length summary so private dumps (cat .env)
@@ -1117,13 +1118,13 @@ test('ACP execute tool_result redacts private stdout (cat .env)', () => {
     (e) =>
       e.event === 'agent' &&
       (e.payload as { type?: string; id?: string }).type === 'tool_use' &&
-      (e.payload as { id?: string }).id === 'bash-secret-1',
+      (e.payload as { id?: string }).id === acpTelemetryToolCallId('bash-secret-1'),
   );
   const toolResult = events.find(
     (e) =>
       e.event === 'agent' &&
       (e.payload as { type?: string; toolUseId?: string }).type === 'tool_result' &&
-      (e.payload as { toolUseId?: string }).toolUseId === 'bash-secret-1',
+      (e.payload as { toolUseId?: string }).toolUseId === acpTelemetryToolCallId('bash-secret-1'),
   );
   assert.ok(toolUse);
   assert.equal((toolUse.payload as { name?: string }).name, 'Bash');
@@ -1138,7 +1139,28 @@ test('ACP execute tool_result redacts private stdout (cat .env)', () => {
   assert.doesNotMatch(content, /API_KEY|PASSWORD|super-secret/);
 });
 
-test('ACP path-like toolCallId is hashed before tool_use/tool_result emission', () => {
+test('ACP adapter toolCallId is always hashed before tool_use/tool_result emission', () => {
+  // Path-like, identifier-shaped secrets, and plain local ids must all become
+  // opaque hashes — never pass through to Langfuse span ids / metadata.
+  const cases = [
+    'read:/home/alice/.env',
+    'sk-proj-abcdefghijklmnopqrstuvwxyz012345',
+    'ghp_abcdefghijklmnopqrstuvwxyz012345',
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature',
+    'call-1',
+  ];
+  for (const rawToolCallId of cases) {
+    assert.match(
+      acpTelemetryToolCallId(rawToolCallId),
+      /^acp_[0-9a-f]{24}$/,
+      `expected opaque hash for ${rawToolCallId.slice(0, 24)}…`,
+    );
+    assert.notEqual(acpTelemetryToolCallId(rawToolCallId), rawToolCallId);
+  }
+  // Empty / whitespace collapses to a fixed non-secret sentinel.
+  assert.equal(acpTelemetryToolCallId(''), 'acp_empty');
+  assert.equal(acpTelemetryToolCallId('   '), 'acp_empty');
+
   const child = new FakeAcpChild();
   const events: Array<{ event: string; payload: unknown }> = [];
   // Adapter-derived id that embeds a user home path / secret file name.
@@ -1170,17 +1192,15 @@ test('ACP path-like toolCallId is hashed before tool_use/tool_result emission', 
   const toolResult = events.find(
     (e) => e.event === 'agent' && (e.payload as { type?: string }).type === 'tool_result',
   );
-  assert.ok(toolUse, 'expected tool_use for path-like toolCallId');
-  assert.ok(toolResult, 'expected tool_result for path-like toolCallId');
+  assert.ok(toolUse, 'expected tool_use for adapter toolCallId');
+  assert.ok(toolResult, 'expected tool_result for adapter toolCallId');
   const useId = (toolUse.payload as { id?: string }).id ?? '';
   const resultId = (toolResult.payload as { toolUseId?: string }).toolUseId ?? '';
-  // Transcript/telemetry must not carry the raw path-bearing adapter id.
-  assert.notEqual(useId, rawToolCallId);
-  assert.notEqual(resultId, rawToolCallId);
-  assert.equal(useId, resultId, 'tool_use and tool_result stay paired');
+  // Transcript/telemetry must not carry the raw adapter id.
+  assert.equal(useId, acpTelemetryToolCallId(rawToolCallId));
+  assert.equal(resultId, useId, 'tool_use and tool_result stay paired');
   assert.match(useId, /^acp_[0-9a-f]{24}$/);
-  assert.doesNotMatch(useId, /alice|\.env|\/home\//);
-  // Safe identifier-like ids still pass through unchanged.
+  assert.doesNotMatch(useId, /alice|\.env|\/home\/|sk-proj|ghp_/);
   assert.equal(
     events.some(
       (e) =>
@@ -1300,10 +1320,10 @@ test('attachAcpSession emits tool_use pairs for write + bash in one turn', () =>
     .map((e) => ({ event: 'agent', data: e.payload }));
   const toolUses = runEvents.filter((e) => (e.data as { type?: string }).type === 'tool_use');
   const toolResults = runEvents.filter((e) => (e.data as { type?: string }).type === 'tool_result');
-  assert.ok(toolUses.some((e) => (e.data as { id?: string }).id === 'w-multi'));
-  assert.ok(toolUses.some((e) => (e.data as { id?: string }).id === 'b-multi'));
-  assert.ok(toolResults.some((e) => (e.data as { toolUseId?: string }).toolUseId === 'w-multi'));
-  assert.ok(toolResults.some((e) => (e.data as { toolUseId?: string }).toolUseId === 'b-multi'));
+  assert.ok(toolUses.some((e) => (e.data as { id?: string }).id === acpTelemetryToolCallId('w-multi')));
+  assert.ok(toolUses.some((e) => (e.data as { id?: string }).id === acpTelemetryToolCallId('b-multi')));
+  assert.ok(toolResults.some((e) => (e.data as { toolUseId?: string }).toolUseId === acpTelemetryToolCallId('w-multi')));
+  assert.ok(toolResults.some((e) => (e.data as { toolUseId?: string }).toolUseId === acpTelemetryToolCallId('b-multi')));
   assert.equal(countNewArtifacts(runEvents), 1);
 });
 
@@ -1983,7 +2003,7 @@ test('fail paths flush open ACP tools as errored tool_use/tool_result pairs', as
       (e) =>
         e.event === 'agent' &&
         (e.payload as { type?: string; id?: string }).type === 'tool_use' &&
-        (e.payload as { id?: string }).id === 'open-bash-1',
+        (e.payload as { id?: string }).id === acpTelemetryToolCallId('open-bash-1'),
     );
     assert.ok(toolUse, 'open tool must be flushed as tool_use on fail');
     assert.equal((toolUse.payload as { name?: string }).name, 'Bash');
@@ -1992,7 +2012,7 @@ test('fail paths flush open ACP tools as errored tool_use/tool_result pairs', as
       (e) =>
         e.event === 'agent' &&
         (e.payload as { type?: string; toolUseId?: string }).type === 'tool_result' &&
-        (e.payload as { toolUseId?: string }).toolUseId === 'open-bash-1',
+        (e.payload as { toolUseId?: string }).toolUseId === acpTelemetryToolCallId('open-bash-1'),
     );
     assert.ok(toolResult, 'open tool must be flushed as tool_result on fail');
     assert.equal((toolResult.payload as { isError?: boolean }).isError, true);
@@ -2044,7 +2064,7 @@ test('child-exit fail path flushes open ACP tools as errored pairs', () => {
     (e) =>
       e.event === 'agent' &&
       (e.payload as { type?: string; id?: string }).type === 'tool_use' &&
-      (e.payload as { id?: string }).id === 'open-read-1',
+      (e.payload as { id?: string }).id === acpTelemetryToolCallId('open-read-1'),
   );
   assert.ok(toolUse, 'open tool must be flushed on child-exit fail');
   assert.equal((toolUse.payload as { name?: string }).name, 'Read');
@@ -2053,7 +2073,7 @@ test('child-exit fail path flushes open ACP tools as errored pairs', () => {
     (e) =>
       e.event === 'agent' &&
       (e.payload as { type?: string; toolUseId?: string }).type === 'tool_result' &&
-      (e.payload as { toolUseId?: string }).toolUseId === 'open-read-1',
+      (e.payload as { toolUseId?: string }).toolUseId === acpTelemetryToolCallId('open-read-1'),
   );
   assert.ok(toolResult, 'open tool must flush tool_result on child-exit fail');
   assert.equal((toolResult.payload as { isError?: boolean }).isError, true);
@@ -2092,7 +2112,7 @@ test('abort flushes open ACP tools as errored pairs', () => {
     (e) =>
       e.event === 'agent' &&
       (e.payload as { type?: string; id?: string }).type === 'tool_use' &&
-      (e.payload as { id?: string }).id === 'open-bash-cancel-1',
+      (e.payload as { id?: string }).id === acpTelemetryToolCallId('open-bash-cancel-1'),
   );
   assert.ok(toolUse, 'open tool must be flushed as tool_use on abort');
   assert.equal((toolUse.payload as { name?: string }).name, 'Bash');
@@ -2101,7 +2121,7 @@ test('abort flushes open ACP tools as errored pairs', () => {
     (e) =>
       e.event === 'agent' &&
       (e.payload as { type?: string; toolUseId?: string }).type === 'tool_result' &&
-      (e.payload as { toolUseId?: string }).toolUseId === 'open-bash-cancel-1',
+      (e.payload as { toolUseId?: string }).toolUseId === acpTelemetryToolCallId('open-bash-cancel-1'),
   );
   assert.ok(toolResult, 'open tool must be flushed as tool_result on abort');
   assert.equal((toolResult.payload as { isError?: boolean }).isError, true);
@@ -2233,7 +2253,7 @@ test('successful session/prompt with open concrete tool flushes clean (not no-ou
     (e) =>
       e.event === 'agent' &&
       (e.payload as { type?: string; id?: string }).type === 'tool_use' &&
-      (e.payload as { id?: string }).id === 'open-read-1',
+      (e.payload as { id?: string }).id === acpTelemetryToolCallId('open-read-1'),
   );
   assert.ok(toolUse, 'open concrete tool must be clean-flushed as tool_use');
   assert.equal((toolUse.payload as { name?: string }).name, 'Read');
@@ -2242,7 +2262,7 @@ test('successful session/prompt with open concrete tool flushes clean (not no-ou
     (e) =>
       e.event === 'agent' &&
       (e.payload as { type?: string; toolUseId?: string }).type === 'tool_result' &&
-      (e.payload as { toolUseId?: string }).toolUseId === 'open-read-1',
+      (e.payload as { toolUseId?: string }).toolUseId === acpTelemetryToolCallId('open-read-1'),
   );
   assert.ok(toolResult, 'open concrete tool must be clean-flushed as tool_result');
   assert.equal((toolResult.payload as { isError?: boolean }).isError, false);

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -709,6 +709,42 @@ test('kind:other keeps explicit custom tool name', () => {
   assert.equal((toolUse.payload as { name?: string }).name, 'my_special_tool');
 });
 
+test('kind:other redacts path-like custom tool names before transcript emit', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'custom tool path name',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'custom-path-1',
+    kind: 'other',
+    // Untrusted free-text that must not become a tool_use name / Langfuse label.
+    name: '/Users/alice/.ssh/id_rsa',
+    status: 'completed',
+    rawOutput: 'ok',
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const toolUse = events.find(
+    (e) => e.event === 'agent' && (e.payload as { type?: string }).type === 'tool_use',
+  );
+  assert.ok(toolUse);
+  assert.equal((toolUse.payload as { name?: string }).name, 'Other');
+  const serialized = JSON.stringify(events);
+  assert.equal(serialized.includes('/Users/alice'), false);
+  assert.equal(serialized.includes('id_rsa'), false);
+});
+
 test('sticky thinkOnly: pending Thinking then status-only completed emits no tool events', () => {
   const child = new FakeAcpChild();
   const events: Array<{ event: string; payload: unknown }> = [];

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -6,7 +6,11 @@ import { PassThrough } from 'node:stream';
 import path from 'node:path';
 import { test, vi } from 'vitest';
 import { attachAcpSession, buildAcpSessionNewParams, createJsonLineStream, normalizeModels } from '../src/agent-protocol/index.js';
-import { acpTelemetryToolCallId } from '../src/agent-protocol/acp/updates.js';
+import {
+  acpTelemetryToolCallId,
+  acpToolName,
+  isAcpPartialRedactToolName,
+} from '../src/agent-protocol/acp/updates.js';
 import { countNewArtifacts } from '../src/runtimes/run-artifacts.js';
 
 const DEFAULT_MODEL_OPTION = { id: 'default', label: 'Default (CLI config)' };
@@ -744,6 +748,59 @@ test('kind:other redacts path-like custom tool names before transcript emit', ()
   const serialized = JSON.stringify(events);
   assert.equal(serialized.includes('/Users/alice'), false);
   assert.equal(serialized.includes('id_rsa'), false);
+});
+
+test('kind:other cannot claim Bash-like names that unlock partial redaction', () => {
+  // Direct resolver: custom kind:other + Bash-like identifier collapses to Other
+  // so Langfuse fail-closed redaction still applies to rawInput.
+  for (const impersonator of ['Bash', 'bash', 'shell', 'Execute', 'terminal']) {
+    assert.equal(
+      acpToolName({ kind: 'other', name: impersonator }),
+      'Other',
+      `kind:other name=${impersonator}`,
+    );
+    assert.equal(isAcpPartialRedactToolName(impersonator), true);
+  }
+  // Trusted execute-family kinds still map to Bash.
+  assert.equal(acpToolName({ kind: 'execute', name: 'run_cmd' }), 'Bash');
+  assert.equal(acpToolName({ kind: 'bash' }), 'Bash');
+  // Non-Bash custom identifiers remain available for UI/transcript.
+  assert.equal(acpToolName({ kind: 'other', name: 'my_special_tool' }), 'my_special_tool');
+
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  attachAcpSession({
+    child: child as never,
+    prompt: 'custom bash-named tool',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'tool_call',
+    toolCallId: 'fake-bash-1',
+    kind: 'other',
+    // Identifier-like but must not enter Langfuse's Bash partial-redact allowlist.
+    name: 'Bash',
+    status: 'completed',
+    rawInput: { secret: 'API_KEY=super-secret', command: 'cat /Users/alice/.env' },
+    rawOutput: 'should not matter',
+  });
+  writeAcpResult(child, 3, { usage: { inputTokens: 1, outputTokens: 2 } });
+
+  const toolUse = events.find(
+    (e) => e.event === 'agent' && (e.payload as { type?: string }).type === 'tool_use',
+  );
+  assert.ok(toolUse);
+  assert.equal((toolUse.payload as { name?: string }).name, 'Other');
+  // Name collapsed; payload may still carry input in the live transcript — Langfuse
+  // fail-closed redaction keys off the emitted name (Other → full redact).
+  assert.equal(isAcpPartialRedactToolName((toolUse.payload as { name?: string }).name ?? ''), false);
 });
 
 test('sticky thinkOnly: pending Thinking then status-only completed emits no tool events', () => {

--- a/apps/daemon/tests/amr-acp-integration.test.ts
+++ b/apps/daemon/tests/amr-acp-integration.test.ts
@@ -1266,6 +1266,59 @@ describe('AMR ACP transport — end-to-end against fake vela stub', () => {
     expect(agentEvents).not.toContainEqual(expect.objectContaining({ type: 'tool_use' }));
   });
 
+  it('fails AMR turns when think-only tool completes via status-only frame (no title)', async () => {
+    // Sticky thinkOnly: pending title "Thinking" then terminal status-only must
+    // not emit tool_use and must still take the no-visible-output failure path.
+    const child = spawnAcpUpdateFixture(
+      [
+        {
+          sessionUpdate: 'tool_call',
+          toolCallId: 'call_think',
+          title: 'Thinking',
+          status: 'pending',
+        },
+        {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'call_think',
+          status: 'completed',
+        },
+      ],
+      { inputTokens: 10, outputTokens: 100, totalTokens: 110 },
+    );
+    const errors: Array<{ event: string; payload: unknown }> = [];
+    const agentEvents: unknown[] = [];
+    try {
+      const session = attachAcpSession({
+        child: child as never,
+        prompt: 'Generate a test',
+        cwd: process.cwd(),
+        model: 'step-3.7-flash',
+        mcpServers: [],
+        modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE',
+        send: (event, payload) => {
+          if (event === 'error') errors.push({ event, payload });
+          if (event === 'agent') agentEvents.push(payload);
+        },
+      });
+
+      await waitForExit(child);
+      expect(session.hasFatalError()).toBe(true);
+      expect(session.completedSuccessfully()).toBe(false);
+    } finally {
+      if (child.exitCode === null) child.kill('SIGTERM');
+    }
+
+    const payload = errors[0]?.payload as {
+      message?: unknown;
+      error?: { code?: unknown; retryable?: unknown; details?: Record<string, unknown> };
+    };
+    expect(String(payload?.message ?? '')).toContain('did not produce visible assistant text');
+    expect(payload?.error?.code).toBe('AGENT_EXECUTION_FAILED');
+    expect(payload?.error?.retryable).toBe(true);
+    expect(agentEvents).not.toContainEqual(expect.objectContaining({ type: 'tool_use' }));
+    expect(agentEvents).not.toContainEqual(expect.objectContaining({ type: 'tool_result' }));
+  });
+
   it('accepts ACP message chunks that carry text outside content.text', async () => {
     const child = spawnAcpUpdateFixture([
       {

--- a/apps/daemon/tests/amr-acp-integration.test.ts
+++ b/apps/daemon/tests/amr-acp-integration.test.ts
@@ -22,6 +22,7 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import { attachAcpSession, detectAcpModels } from '../src/agent-protocol/index.js';
+import { acpTelemetryToolCallId } from '../src/agent-protocol/acp/updates.js';
 import { classifyAmrAccountFailure } from '../src/integrations/vela-errors.js';
 import { AmrModelLoadingCache } from '../src/runtimes/amr-model-cache.js';
 import {
@@ -1413,7 +1414,7 @@ describe('AMR ACP transport — end-to-end against fake vela stub', () => {
     expect(agentEvents).toContainEqual(
       expect.objectContaining({
         type: 'tool_use',
-        id: 'write_1',
+        id: acpTelemetryToolCallId('write_1'),
         name: 'Write',
         input: { file_path: 'index.html' },
       }),

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -1469,6 +1469,87 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     expect(payload).not.toContain('<html>SECRET</html>');
   });
 
+  it('fail-closed redacts kind:other custom ACP tool payloads (unknown tool names)', async () => {
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true, artifactManifest: true },
+    });
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(new Response('{}', { status: 207 }));
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk';
+    process.env.LANGFUSE_SECRET_KEY = 'sk';
+    const now = Date.now();
+    try {
+      await reportRunCompletedFromDaemon({
+        db: makeDbWithListMessages({
+          'conv-1': [
+            {
+              id: 'user-1',
+              role: 'user',
+              content: 'Read secrets via MCP.',
+              attachments: [],
+            },
+            {
+              id: 'msg-1',
+              role: 'assistant',
+              content: 'Done.',
+              producedFiles: [],
+            },
+          ],
+        }),
+        dataDir,
+        run: makeRun({
+          createdAt: now - 2000,
+          updatedAt: now,
+          events: [
+            {
+              id: 1,
+              event: 'agent',
+              data: {
+                type: 'tool_use',
+                id: 'custom-mcp-1',
+                // ACP kind:other preserves arbitrary adapter/MCP names.
+                name: 'mcp__filesystem__read_file',
+                input: {
+                  path: '/Users/alice/secrets.env',
+                },
+              },
+            },
+            {
+              id: 2,
+              event: 'agent',
+              data: {
+                type: 'tool_result',
+                toolUseId: 'custom-mcp-1',
+                content: 'API_KEY=super-secret\nPASSWORD=also-secret\n',
+                isError: false,
+              },
+            },
+          ],
+        }) as any,
+        fetchImpl: fetchSpy as any,
+      });
+    } finally {
+      delete process.env.LANGFUSE_PUBLIC_KEY;
+      delete process.env.LANGFUSE_SECRET_KEY;
+    }
+
+    const init = fetchSpy.mock.calls[0]![1] as RequestInit;
+    const batch = JSON.parse(init.body as string).batch as any[];
+    const custom = bodyOf(batch, 'span-create', 'tool:mcp__filesystem__read_file');
+    expect(custom.input).toBe(
+      '[REDACTED:tool_input:unknown_tool:mcp__filesystem__read_file]',
+    );
+    expect(custom.output).toBe(
+      '[REDACTED:tool_output:unknown_tool:mcp__filesystem__read_file]',
+    );
+    const payload = JSON.stringify(batch);
+    expect(payload).not.toContain('super-secret');
+    expect(payload).not.toContain('also-secret');
+    expect(payload).not.toContain('/Users/alice/secrets.env');
+  });
+
   it('forwards run prompt telemetry into trace and generation metadata', async () => {
     await writeAppCfg({
       installationId: 'install-uuid-1',

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -1550,6 +1550,78 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     expect(payload).not.toContain('/Users/alice/secrets.env');
   });
 
+  it('redacts Linux home paths in ACP Bash tool inputs when content telemetry is on', async () => {
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true, artifactManifest: false },
+    });
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(new Response('{}', { status: 207 }));
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk';
+    process.env.LANGFUSE_SECRET_KEY = 'sk';
+    const now = Date.now();
+    try {
+      await reportRunCompletedFromDaemon({
+        db: makeDbWithListMessages({
+          'conv-1': [
+            {
+              id: 'user-1',
+              role: 'user',
+              content: 'Check env.',
+              attachments: [],
+            },
+            {
+              id: 'msg-1',
+              role: 'assistant',
+              content: 'Done.',
+              producedFiles: [],
+            },
+          ],
+        }),
+        dataDir,
+        run: makeRun({
+          createdAt: now - 2000,
+          updatedAt: now,
+          events: [
+            {
+              id: 1,
+              event: 'agent',
+              data: {
+                type: 'tool_use',
+                id: 'bash-linux-1',
+                name: 'Bash',
+                input: { command: 'cat /home/alice/.env' },
+              },
+            },
+            {
+              id: 2,
+              event: 'agent',
+              data: {
+                type: 'tool_result',
+                toolUseId: 'bash-linux-1',
+                content: 'KEY=value',
+                isError: false,
+              },
+            },
+          ],
+        }) as any,
+        fetchImpl: fetchSpy as any,
+      });
+    } finally {
+      delete process.env.LANGFUSE_PUBLIC_KEY;
+      delete process.env.LANGFUSE_SECRET_KEY;
+    }
+
+    const init = fetchSpy.mock.calls[0]![1] as RequestInit;
+    const batch = JSON.parse(init.body as string).batch as any[];
+    const bash = bodyOf(batch, 'span-create', 'tool:Bash');
+    expect(bash.input).toContain('[REDACTED:local_path]');
+    expect(bash.input).toContain('cat');
+    expect(bash.input).not.toContain('/home/alice');
+    expect(JSON.stringify(batch)).not.toContain('/home/alice/.env');
+  });
+
   it('forwards run prompt telemetry into trace and generation metadata', async () => {
     await writeAppCfg({
       installationId: 'install-uuid-1',

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -1456,12 +1456,13 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
 
     const init = fetchSpy.mock.calls[0]![1] as RequestInit;
     const batch = JSON.parse(init.body as string).batch as any[];
-    const read = bodyOf(batch, 'span-create', 'tool:read');
-    const write = bodyOf(batch, 'span-create', 'tool:write');
-    expect(read.input).toBe('[REDACTED:tool_input:content_tool:read]');
-    expect(read.output).toBe('[REDACTED:tool_output:content_tool:read]');
-    expect(write.input).toBe('[REDACTED:tool_input:content_tool:write]');
-    expect(write.output).toBe('[REDACTED:tool_output:content_tool:write]');
+    // Lowercase ACP kind tokens are canonicalized to Title-case family labels.
+    const read = bodyOf(batch, 'span-create', 'tool:Read');
+    const write = bodyOf(batch, 'span-create', 'tool:Write');
+    expect(read.input).toBe('[REDACTED:tool_input:content_tool:Read]');
+    expect(read.output).toBe('[REDACTED:tool_output:content_tool:Read]');
+    expect(write.input).toBe('[REDACTED:tool_input:content_tool:Write]');
+    expect(write.output).toBe('[REDACTED:tool_output:content_tool:Write]');
     // startedAt on tool_use should drive span startTime earlier than event log ts.
     expect(new Date(read.startTime).getTime()).toBe(toolStartedAt);
     const payload = JSON.stringify(batch);
@@ -1537,17 +1538,16 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
 
     const init = fetchSpy.mock.calls[0]![1] as RequestInit;
     const batch = JSON.parse(init.body as string).batch as any[];
-    const custom = bodyOf(batch, 'span-create', 'tool:mcp__filesystem__read_file');
-    expect(custom.input).toBe(
-      '[REDACTED:tool_input:unknown_tool:mcp__filesystem__read_file]',
-    );
-    expect(custom.output).toBe(
-      '[REDACTED:tool_output:unknown_tool:mcp__filesystem__read_file]',
-    );
+    // Span label + toolName metadata use the allowlisted `other` family only.
+    const custom = bodyOf(batch, 'span-create', 'tool:other');
+    expect(custom.metadata.toolName).toBe('other');
+    expect(custom.input).toBe('[REDACTED:tool_input:unknown_tool]');
+    expect(custom.output).toBe('[REDACTED:tool_output:unknown_tool]');
     const payload = JSON.stringify(batch);
     expect(payload).not.toContain('super-secret');
     expect(payload).not.toContain('also-secret');
     expect(payload).not.toContain('/Users/alice/secrets.env');
+    expect(payload).not.toContain('mcp__filesystem__read_file');
   });
 
   it('redacts Linux home paths in ACP Bash tool inputs when content telemetry is on', async () => {

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -1363,6 +1363,112 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     expect(payload).not.toContain('<!doctype html>');
   });
 
+  it('redacts lowercase ACP content-tool names like read/write', async () => {
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true, artifactManifest: true },
+    });
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(new Response('{}', { status: 207 }));
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk';
+    process.env.LANGFUSE_SECRET_KEY = 'sk';
+    const now = Date.now();
+    const toolStartedAt = now - 4000;
+    const toolEndedAt = now - 500;
+    try {
+      await reportRunCompletedFromDaemon({
+        db: makeDbWithListMessages({
+          'conv-1': [
+            {
+              id: 'user-1',
+              role: 'user',
+              content: 'Use this private reference.',
+              attachments: [],
+            },
+            {
+              id: 'msg-1',
+              role: 'assistant',
+              content: 'Done.',
+              producedFiles: [],
+            },
+          ],
+        }),
+        dataDir,
+        run: makeRun({
+          createdAt: now - 4500,
+          updatedAt: now,
+          events: [
+            {
+              id: 1,
+              event: 'agent',
+              // Event log time is late (terminal); startedAt is first frame.
+              timestamp: toolEndedAt,
+              data: {
+                type: 'tool_use',
+                id: 'read-lc',
+                name: 'read',
+                input: { file_path: '/Users/alice/secret.txt', content: 'SECRET_BODY' },
+                startedAt: toolStartedAt,
+              },
+            },
+            {
+              id: 2,
+              event: 'agent',
+              timestamp: toolEndedAt,
+              data: {
+                type: 'tool_result',
+                toolUseId: 'read-lc',
+                content: 'SECRET_BODY',
+                isError: false,
+              },
+            },
+            {
+              id: 3,
+              event: 'agent',
+              timestamp: toolEndedAt,
+              data: {
+                type: 'tool_use',
+                id: 'write-lc',
+                name: 'write',
+                input: { file_path: '/Users/alice/out.html', content: '<html>SECRET</html>' },
+              },
+            },
+            {
+              id: 4,
+              event: 'agent',
+              timestamp: toolEndedAt,
+              data: {
+                type: 'tool_result',
+                toolUseId: 'write-lc',
+                content: 'ok',
+                isError: false,
+              },
+            },
+          ],
+        }) as any,
+        fetchImpl: fetchSpy as any,
+      });
+    } finally {
+      delete process.env.LANGFUSE_PUBLIC_KEY;
+      delete process.env.LANGFUSE_SECRET_KEY;
+    }
+
+    const init = fetchSpy.mock.calls[0]![1] as RequestInit;
+    const batch = JSON.parse(init.body as string).batch as any[];
+    const read = bodyOf(batch, 'span-create', 'tool:read');
+    const write = bodyOf(batch, 'span-create', 'tool:write');
+    expect(read.input).toBe('[REDACTED:tool_input:content_tool:read]');
+    expect(read.output).toBe('[REDACTED:tool_output:content_tool:read]');
+    expect(write.input).toBe('[REDACTED:tool_input:content_tool:write]');
+    expect(write.output).toBe('[REDACTED:tool_output:content_tool:write]');
+    // startedAt on tool_use should drive span startTime earlier than event log ts.
+    expect(new Date(read.startTime).getTime()).toBe(toolStartedAt);
+    const payload = JSON.stringify(batch);
+    expect(payload).not.toContain('SECRET_BODY');
+    expect(payload).not.toContain('<html>SECRET</html>');
+  });
+
   it('forwards run prompt telemetry into trace and generation metadata', async () => {
     await writeAppCfg({
       installationId: 'install-uuid-1',
@@ -1628,6 +1734,53 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     expect(trace.metadata.tokens.output).toBeUndefined();
     // …and onto the Langfuse generation usage so cost/token views populate.
     expect(generation.usage.total).toBe(512);
+  });
+
+  it('forwards thought_tokens from ACP-shaped usage into Langfuse metadata', async () => {
+    await writeAppCfg({
+      installationId: 'install-uuid-thought',
+      telemetry: { metrics: true, content: true, artifactManifest: false },
+    });
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(new Response('{}', { status: 207 }));
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk';
+    process.env.LANGFUSE_SECRET_KEY = 'sk';
+    try {
+      const run = makeRun() as any;
+      run.events = [
+        {
+          id: 1,
+          event: 'agent',
+          timestamp: run.createdAt + 1000,
+          data: {
+            type: 'usage',
+            usage: {
+              input_tokens: 1_000,
+              output_tokens: 50,
+              cached_read_tokens: 200,
+              thought_tokens: 77,
+              total_tokens: 1_127,
+            },
+          },
+        },
+      ];
+      await reportRunCompletedFromDaemon({
+        db: makeDbWithListMessages({ 'conv-1': [] }),
+        dataDir,
+        run,
+        fetchImpl: fetchSpy as any,
+      });
+    } finally {
+      delete process.env.LANGFUSE_PUBLIC_KEY;
+      delete process.env.LANGFUSE_SECRET_KEY;
+    }
+    const init = fetchSpy.mock.calls[0]![1] as RequestInit;
+    const batch = JSON.parse(init.body as string).batch as any[];
+    const trace = batch[0].body;
+    expect(trace.metadata.tokens.thought).toBe(77);
+    expect(trace.metadata.tokens.total).toBe(1_127);
+    expect(trace.metadata.tokens.cacheReadInput).toBe(200);
   });
 
   it('uses the default model bucket for a default-model run with no status/model event', async () => {

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -351,15 +351,22 @@ describe('shouldFullyRedactToolPayload (fail-closed)', () => {
     expect(shouldFullyRedactToolPayload('unknown')).toBe(true);
   });
 
-  it('labels known content tools vs unknown custom names in placeholders', () => {
+  it('labels known content tools without embedding untrusted custom names', () => {
     expect(toolPayloadRedactionPlaceholder('Read', 'output')).toBe(
       '[REDACTED:tool_output:content_tool:Read]',
     );
+    // Unknown/custom ACP names must not appear in the placeholder string.
     expect(toolPayloadRedactionPlaceholder('mcp__filesystem__read_file', 'output')).toBe(
-      '[REDACTED:tool_output:unknown_tool:mcp__filesystem__read_file]',
+      '[REDACTED:tool_output:unknown_tool]',
     );
     expect(toolPayloadRedactionPlaceholder('  ', 'input')).toBe(
-      '[REDACTED:tool_input:unknown_tool:unnamed]',
+      '[REDACTED:tool_input:unknown_tool]',
+    );
+    expect(toolPayloadRedactionPlaceholder('/Users/alice/secret-tool', 'output')).toBe(
+      '[REDACTED:tool_output:unknown_tool]',
+    );
+    expect(toolPayloadRedactionPlaceholder('/Users/alice/secret-tool', 'output')).not.toContain(
+      '/Users/alice',
     );
   });
 });
@@ -469,17 +476,42 @@ describe('buildTracePayload', () => {
         ],
       }),
     );
-    const custom = bodyOf(batch, 'span-create', 'tool:mcp__filesystem__read_file');
-    expect(custom.input).toBe(
-      '[REDACTED:tool_input:unknown_tool:mcp__filesystem__read_file]',
-    );
-    expect(custom.output).toBe(
-      '[REDACTED:tool_output:unknown_tool:mcp__filesystem__read_file]',
-    );
+    // Custom ACP/MCP names are canonicalized to the allowlisted `other` family
+    // for span labels and metadata — never shipped raw to Langfuse.
+    const custom = bodyOf(batch, 'span-create', 'tool:other');
+    expect(custom.metadata.toolName).toBe('other');
+    expect(custom.input).toBe('[REDACTED:tool_input:unknown_tool]');
+    expect(custom.output).toBe('[REDACTED:tool_output:unknown_tool]');
     const payload = JSON.stringify(batch);
     expect(payload).not.toContain('super-secret');
     expect(payload).not.toContain('also-secret');
     expect(payload).not.toContain('/Users/alice/secrets.env');
+    expect(payload).not.toContain('mcp__filesystem__read_file');
+  });
+
+  it('does not ship path-like custom tool names when content telemetry is off', () => {
+    const batch = buildTracePayload(
+      makeCtx({
+        prefs: { metrics: true, content: false, artifactManifest: false },
+        tools: [
+          {
+            id: 'path-tool-1',
+            name: '/Users/alice/.ssh/id_rsa',
+            startedAt: 1_700_000_001_000,
+            endedAt: 1_700_000_001_800,
+            input: 'ignored-when-content-off',
+            output: 'ignored-when-content-off',
+          },
+        ],
+      }),
+    );
+    const custom = bodyOf(batch, 'span-create', 'tool:other');
+    expect(custom.metadata.toolName).toBe('other');
+    expect(custom.input).toBeUndefined();
+    expect(custom.output).toBeUndefined();
+    const payload = JSON.stringify(batch);
+    expect(payload).not.toContain('/Users/alice');
+    expect(payload).not.toContain('id_rsa');
   });
 
   it('adds full prompt-stack content once on generation input and flat metadata elsewhere', () => {

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -5,11 +5,14 @@ import {
   buildTracePayload,
   deriveLangfuseDeliveryState,
   isContentToolName,
+  isPartialRedactToolName,
   readLangfuseConfig,
   readRunTelemetrySinkConfig,
   readTelemetrySinkConfig,
   reportRunCompleted,
   reportRunFeedback,
+  shouldFullyRedactToolPayload,
+  toolPayloadRedactionPlaceholder,
   type FeedbackReportContext,
   type LangfuseConfig,
   type ReportContext,
@@ -327,6 +330,40 @@ describe('isContentToolName', () => {
   });
 });
 
+describe('shouldFullyRedactToolPayload (fail-closed)', () => {
+  it('allows only bash-like execute tools to keep partial redaction', () => {
+    expect(isPartialRedactToolName('Bash')).toBe(true);
+    expect(isPartialRedactToolName('shell')).toBe(true);
+    expect(isPartialRedactToolName('execute')).toBe(true);
+    expect(isPartialRedactToolName('Terminal')).toBe(true);
+    expect(shouldFullyRedactToolPayload('Bash')).toBe(false);
+    expect(shouldFullyRedactToolPayload('shell')).toBe(false);
+  });
+
+  it('fully redacts known content tools and unknown/custom ACP names', () => {
+    expect(shouldFullyRedactToolPayload('Read')).toBe(true);
+    expect(shouldFullyRedactToolPayload('Write')).toBe(true);
+    // kind:other custom / MCP filesystem-style names must not leak raw I/O.
+    expect(shouldFullyRedactToolPayload('mcp__filesystem__read_file')).toBe(true);
+    expect(shouldFullyRedactToolPayload('my_special_tool')).toBe(true);
+    expect(shouldFullyRedactToolPayload('Other')).toBe(true);
+    expect(shouldFullyRedactToolPayload('')).toBe(true);
+    expect(shouldFullyRedactToolPayload('unknown')).toBe(true);
+  });
+
+  it('labels known content tools vs unknown custom names in placeholders', () => {
+    expect(toolPayloadRedactionPlaceholder('Read', 'output')).toBe(
+      '[REDACTED:tool_output:content_tool:Read]',
+    );
+    expect(toolPayloadRedactionPlaceholder('mcp__filesystem__read_file', 'output')).toBe(
+      '[REDACTED:tool_output:unknown_tool:mcp__filesystem__read_file]',
+    );
+    expect(toolPayloadRedactionPlaceholder('  ', 'input')).toBe(
+      '[REDACTED:tool_input:unknown_tool:unnamed]',
+    );
+  });
+});
+
 describe('buildTracePayload', () => {
   it('emits a trace with nested agent + generation observations', () => {
     const batch = buildTracePayload(makeCtx());
@@ -391,6 +428,35 @@ describe('buildTracePayload', () => {
     expect(tool.output).toBe('total 0');
     expect(write.input).toBe('[REDACTED:tool_input:content_tool:Write]');
     expect(write.output).toBe('[REDACTED:tool_output:content_tool:Write]');
+  });
+
+  it('fail-closed redacts unknown/custom ACP tool payloads when content gate is on', () => {
+    const batch = buildTracePayload(
+      makeCtx({
+        prefs: { metrics: true, content: true, artifactManifest: false },
+        tools: [
+          {
+            id: 'custom-1',
+            name: 'mcp__filesystem__read_file',
+            startedAt: 1_700_000_001_000,
+            endedAt: 1_700_000_001_800,
+            input: '{"path":"/Users/alice/secrets.env"}',
+            output: 'API_KEY=super-secret\nPASSWORD=also-secret\n',
+          },
+        ],
+      }),
+    );
+    const custom = bodyOf(batch, 'span-create', 'tool:mcp__filesystem__read_file');
+    expect(custom.input).toBe(
+      '[REDACTED:tool_input:unknown_tool:mcp__filesystem__read_file]',
+    );
+    expect(custom.output).toBe(
+      '[REDACTED:tool_output:unknown_tool:mcp__filesystem__read_file]',
+    );
+    const payload = JSON.stringify(batch);
+    expect(payload).not.toContain('super-secret');
+    expect(payload).not.toContain('also-secret');
+    expect(payload).not.toContain('/Users/alice/secrets.env');
   });
 
   it('adds full prompt-stack content once on generation input and flat metadata elsewhere', () => {

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -4,6 +4,7 @@ import {
   buildFeedbackPayload,
   buildTracePayload,
   deriveLangfuseDeliveryState,
+  isContentToolName,
   readLangfuseConfig,
   readRunTelemetrySinkConfig,
   readTelemetrySinkConfig,
@@ -300,6 +301,29 @@ describe('deriveLangfuseDeliveryState', () => {
       langfuse_expected: true,
       langfuse_delivery_status: 'queued',
     });
+  });
+});
+
+describe('isContentToolName', () => {
+  it('matches Claude-shaped names case-insensitively', () => {
+    expect(isContentToolName('Read')).toBe(true);
+    expect(isContentToolName('read')).toBe(true);
+    expect(isContentToolName('WRITE')).toBe(true);
+    expect(isContentToolName('write')).toBe(true);
+    expect(isContentToolName('Edit')).toBe(true);
+    expect(isContentToolName('edit')).toBe(true);
+    expect(isContentToolName('grep')).toBe(true);
+    expect(isContentToolName('search')).toBe(true);
+    expect(isContentToolName('fetch')).toBe(true);
+    expect(isContentToolName('think')).toBe(true);
+    expect(isContentToolName('create_file')).toBe(true);
+    expect(isContentToolName('str_replace_edit')).toBe(true);
+  });
+
+  it('does not treat Bash as a content tool', () => {
+    expect(isContentToolName('Bash')).toBe(false);
+    expect(isContentToolName('bash')).toBe(false);
+    expect(isContentToolName('')).toBe(false);
   });
 });
 

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -430,6 +430,29 @@ describe('buildTracePayload', () => {
     expect(write.output).toBe('[REDACTED:tool_output:content_tool:Write]');
   });
 
+  it('redacts Linux home paths in Bash tool inputs when content gate is on', () => {
+    const batch = buildTracePayload(
+      makeCtx({
+        prefs: { metrics: true, content: true, artifactManifest: false },
+        tools: [
+          {
+            id: 'bash-linux-1',
+            name: 'Bash',
+            startedAt: 1_700_000_001_000,
+            endedAt: 1_700_000_001_800,
+            input: '{"command":"cat /home/alice/.env"}',
+            output: 'KEY=value',
+          },
+        ],
+      }),
+    );
+    const bash = bodyOf(batch, 'span-create', 'tool:Bash');
+    expect(bash.input).toContain('[REDACTED:local_path]');
+    expect(bash.input).toContain('cat');
+    expect(bash.input).not.toContain('/home/alice');
+    expect(JSON.stringify(batch)).not.toContain('/home/alice/.env');
+  });
+
   it('fail-closed redacts unknown/custom ACP tool payloads when content gate is on', () => {
     const batch = buildTracePayload(
       makeCtx({

--- a/apps/daemon/tests/run-analytics-observability.test.ts
+++ b/apps/daemon/tests/run-analytics-observability.test.ts
@@ -223,6 +223,82 @@ describe('scanRunEventsForUsageAnalytics', () => {
     expect(result.token_count_source).toBe('provider_usage');
   });
 
+  it('merges a later thought-only usage frame with earlier complete input/output', () => {
+    // ACP runtimes can emit a complete usage frame, then a trailing partial
+    // frame with only thought_tokens (or cache counters). Reverse-scan must
+    // keep the complete fields and layer the later thought tokens on top.
+    const result = scanRunEventsForUsageAnalytics(
+      [
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            usage: {
+              input_tokens: 12_000,
+              output_tokens: 400,
+              total_tokens: 12_400,
+            },
+          },
+        },
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            usage: { thought_tokens: 256 },
+          },
+        },
+      ],
+      'amr-model',
+      0,
+    );
+
+    expect(result).toMatchObject({
+      input_tokens: 12_000,
+      output_tokens: 400,
+      total_tokens: 12_400,
+      thought_tokens: 256,
+      token_count_source: 'provider_usage',
+    });
+  });
+
+  it('merges a later cache-only usage frame without dropping earlier input/output', () => {
+    const result = scanRunEventsForUsageAnalytics(
+      [
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            usage: {
+              input_tokens: 1000,
+              output_tokens: 50,
+            },
+          },
+        },
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            usage: {
+              cache_read_input_tokens: 250,
+              cache_creation_input_tokens: 100,
+            },
+          },
+        },
+      ],
+      '',
+      0,
+    );
+
+    expect(result).toMatchObject({
+      input_tokens: 1000,
+      output_tokens: 50,
+      cache_read_input_tokens: 250,
+      cache_creation_input_tokens: 100,
+      cache_token_source: 'anthropic',
+      token_count_source: 'provider_usage',
+    });
+  });
+
   it('normalizes additive Responses-API / ACP usage where cache_read exceeds input_tokens', () => {
     // Real AMR/vela follow-up shape: the stream reports input_tokens as the
     // UNCACHED remainder with cached_input_tokens reported separately ON TOP, so

--- a/apps/daemon/tests/run-analytics-observability.test.ts
+++ b/apps/daemon/tests/run-analytics-observability.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   scanRunEventsForUsageAnalytics,
   summarizeRunTimingAnalytics,
+  summarizeToolAnalytics,
 } from '../src/run-analytics-observability.js';
 
 describe('scanRunEventsForUsageAnalytics', () => {
@@ -163,11 +164,63 @@ describe('scanRunEventsForUsageAnalytics', () => {
       input_tokens_effective: 31_711,
       output_tokens: 30,
       total_tokens: 31_741,
+      thought_tokens: 20,
       cache_read_input_tokens: 2_560,
       uncached_input_tokens: 29_151,
       cache_token_source: 'openai',
+      token_count_source: 'provider_usage',
     });
     expect(result.cache_hit_ratio).toBeCloseTo(2_560 / 31_711);
+  });
+
+  it('extracts ACP-shaped usage with thought_tokens + cached_read_tokens as provider_usage', () => {
+    const result = scanRunEventsForUsageAnalytics(
+      [
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            usage: {
+              input_tokens: 12_000,
+              output_tokens: 400,
+              cached_read_tokens: 8_000,
+              thought_tokens: 256,
+              total_tokens: 12_656,
+            },
+          },
+        },
+      ],
+      'amr-model',
+      0,
+    );
+
+    expect(result).toMatchObject({
+      input_tokens: 12_000,
+      output_tokens: 400,
+      thought_tokens: 256,
+      total_tokens: 12_656,
+      cache_read_input_tokens: 8_000,
+      token_count_source: 'provider_usage',
+      cache_token_source: 'openai',
+    });
+  });
+
+  it('marks provider_usage when only thought_tokens are present', () => {
+    const result = scanRunEventsForUsageAnalytics(
+      [
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            usage: { thought_tokens: 42 },
+          },
+        },
+      ],
+      '',
+      0,
+    );
+    expect(result.thought_tokens).toBe(42);
+    expect(result.token_count_source).toBe('provider_usage');
   });
 
   it('normalizes additive Responses-API / ACP usage where cache_read exceeds input_tokens', () => {
@@ -728,7 +781,8 @@ describe('scanRunEventsForUsageAnalytics', () => {
     expect(result).toEqual({
       total_tokens: 345,
       cache_token_source: 'unavailable',
-      token_count_source: 'unknown',
+      // Any real provider token field (including total-only) is provider_usage.
+      token_count_source: 'provider_usage',
       agent_reported_model: null,
     });
   });
@@ -768,7 +822,7 @@ describe('scanRunEventsForUsageAnalytics', () => {
     expect(result.cache_hit_ratio).toBeCloseTo(120 / 650);
   });
 
-  it('preserves unknown token source when only cache-adjacent aliases exist without concrete input totals', () => {
+  it('marks provider_usage when only cache-adjacent aliases exist without concrete input totals', () => {
     const result = scanRunEventsForUsageAnalytics(
       [
         {
@@ -790,7 +844,7 @@ describe('scanRunEventsForUsageAnalytics', () => {
       cache_read_input_tokens: 33,
       cache_creation_input_tokens: 7,
       cache_token_source: 'openai',
-      token_count_source: 'unknown',
+      token_count_source: 'provider_usage',
       agent_reported_model: null,
     });
   });
@@ -1029,5 +1083,204 @@ describe('summarizeRunTimingAnalytics', () => {
     expect(result.time_to_first_token_ms).toBeUndefined();
     expect(result.last_observed_phase).toBe('tool_execution');
     expect(result.attempt_terminal_phase).toBe('tool_execution');
+  });
+
+  it('counts unique tool_use ids for tool_call_count (duplicate ids do not inflate)', () => {
+    const result = summarizeRunTimingAnalytics({
+      runCreatedAt: 1_000,
+      runUpdatedAt: 5_000,
+      analyticsCapturedAt: 5_010,
+      telemetry: {
+        startChatRunStartedAt: 1_100,
+      },
+      events: [
+        {
+          id: 1,
+          event: 'agent',
+          timestamp: 2_000,
+          data: { type: 'tool_use', id: 'dup-1', name: 'Read' },
+        },
+        {
+          id: 2,
+          event: 'agent',
+          timestamp: 2_100,
+          data: {
+            type: 'tool_use',
+            id: 'dup-1',
+            name: 'Read',
+            input: { file_path: 'late.html' },
+          },
+        },
+        {
+          id: 3,
+          event: 'agent',
+          timestamp: 2_500,
+          data: { type: 'tool_result', toolUseId: 'dup-1' },
+        },
+        {
+          id: 4,
+          event: 'agent',
+          timestamp: 3_000,
+          data: { type: 'tool_use', id: 'other', name: 'Bash' },
+        },
+        {
+          id: 5,
+          event: 'agent',
+          timestamp: 3_200,
+          data: { type: 'tool_result', toolUseId: 'other' },
+        },
+      ],
+    });
+
+    expect(result.tool_call_count).toBe(2);
+    // Duration pairs from first tool_use timestamp, not the duplicate.
+    expect(result.tool_duration_ms).toBe(500 + 200);
+  });
+
+  it('prefers tool_use.startedAt over event timestamp for tool duration', () => {
+    const result = summarizeRunTimingAnalytics({
+      runCreatedAt: 1_000,
+      runUpdatedAt: 10_000,
+      analyticsCapturedAt: 10_010,
+      telemetry: {
+        startChatRunStartedAt: 1_100,
+      },
+      events: [
+        {
+          id: 1,
+          event: 'agent',
+          // Event log time is late (terminal emit); startedAt is first frame.
+          timestamp: 5_000,
+          data: {
+            type: 'tool_use',
+            id: 'acp-1',
+            name: 'Bash',
+            startedAt: 2_000,
+          },
+        },
+        {
+          id: 2,
+          event: 'agent',
+          timestamp: 5_500,
+          data: { type: 'tool_result', toolUseId: 'acp-1' },
+        },
+      ],
+    });
+
+    expect(result.tool_call_count).toBe(1);
+    // 5500 (result) - 2000 (startedAt) = 3500, not 5500 - 5000 = 500.
+    expect(result.tool_duration_ms).toBe(3_500);
+  });
+});
+
+describe('summarizeToolAnalytics', () => {
+  it('counts unique canonical families and unique tool_result errors', () => {
+    const result = summarizeToolAnalytics([
+      {
+        event: 'agent',
+        data: { type: 'tool_use', id: 't1', name: 'Read' },
+      },
+      {
+        event: 'agent',
+        data: { type: 'tool_result', toolUseId: 't1', isError: false },
+      },
+      {
+        event: 'agent',
+        data: { type: 'tool_use', id: 't2', name: 'Bash' },
+      },
+      {
+        event: 'agent',
+        data: { type: 'tool_result', toolUseId: 't2', isError: true },
+      },
+      {
+        event: 'agent',
+        data: { type: 'tool_use', id: 't3', name: 'Read' },
+      },
+      {
+        event: 'agent',
+        data: { type: 'tool_result', toolUseId: 't3', isError: true },
+      },
+      // Duplicate tool_use id must not inflate unique names.
+      {
+        event: 'agent',
+        data: { type: 'tool_use', id: 't1', name: 'Read' },
+      },
+      // Duplicate error result frames for the same toolUseId must not inflate.
+      {
+        event: 'agent',
+        data: { type: 'tool_result', toolUseId: 't2', isError: true },
+      },
+    ]);
+
+    expect(result.tool_error_count).toBe(2);
+    expect(result.tool_name_count).toBe(2);
+    // Allowlist order: Read before Bash.
+    expect(result.tool_names).toEqual(['Read', 'Bash']);
+    expect(result.tool_names_csv).toBe('Read,Bash');
+  });
+
+  it('canonicalizes arbitrary ACP names and never ships raw free-text', () => {
+    const result = summarizeToolAnalytics([
+      {
+        event: 'agent',
+        data: { type: 'tool_use', id: 'a', name: 'MultiEdit' },
+      },
+      {
+        event: 'agent',
+        data: { type: 'tool_use', id: 'b', name: 'web_fetch' },
+      },
+      {
+        event: 'agent',
+        data: { type: 'tool_use', id: 'c', name: 'Glob' },
+      },
+      {
+        event: 'agent',
+        data: { type: 'tool_use', id: 'd', name: 'mcp__custom__do_thing' },
+      },
+      {
+        event: 'agent',
+        data: { type: 'tool_use', id: 'e', name: '/Users/secret/path.ts' },
+      },
+      {
+        event: 'agent',
+        data: { type: 'tool_use', id: 'f', name: 'https://evil.example/x' },
+      },
+      {
+        event: 'agent',
+        data: { type: 'tool_use', id: 'g', name: 'read' },
+      },
+    ]);
+
+    // MultiEdit→Edit, web_fetch→Fetch, Glob→Search, mcp/path/url → other,
+    // read→Read. Allowlist order; other last.
+    expect(result.tool_names).toEqual(['Edit', 'Read', 'Search', 'Fetch', 'other']);
+    expect(result.tool_name_count).toBe(5);
+    expect(result.tool_names_csv).toBe('Edit,Read,Search,Fetch,other');
+    expect(result.tool_names.every((n) => !n.includes('/') && !n.includes('://'))).toBe(
+      true,
+    );
+  });
+
+  it('maps unknown raw names to other (bounded family set, not 25 raw names)', () => {
+    const events = Array.from({ length: 30 }, (_, i) => ({
+      event: 'agent' as const,
+      data: { type: 'tool_use', id: `id-${i}`, name: `Tool${i}` },
+    }));
+    const result = summarizeToolAnalytics(events);
+    // All ToolN collapse to `other` (not the Tool family — ToolN ≠ Tool).
+    expect(result.tool_name_count).toBe(1);
+    expect(result.tool_names).toEqual(['other']);
+    expect(result.tool_names_csv).toBe('other');
+  });
+
+  it('aliases case-insensitive known families including Tool', () => {
+    const result = summarizeToolAnalytics([
+      { event: 'agent', data: { type: 'tool_use', id: '1', name: 'WRITE' } },
+      { event: 'agent', data: { type: 'tool_use', id: '2', name: 'tool' } },
+      { event: 'agent', data: { type: 'tool_use', id: '3', name: 'Shell' } },
+      { event: 'agent', data: { type: 'tool_use', id: '4', name: 'WebFetch' } },
+    ]);
+    expect(result.tool_names).toEqual(['Write', 'Bash', 'Fetch', 'Tool']);
+    expect(result.tool_name_count).toBe(4);
   });
 });

--- a/apps/daemon/tests/run-analytics-observability.test.ts
+++ b/apps/daemon/tests/run-analytics-observability.test.ts
@@ -299,6 +299,49 @@ describe('scanRunEventsForUsageAnalytics', () => {
     });
   });
 
+  it('merges earlier cache counters when a later frame already has input and output', () => {
+    // Inverse of the trailing cache-only case: providers may emit cache on an
+    // earlier frame and a complete input/output pair later. Reverse-scan must
+    // keep walking after primary is filled so cache_read/cache_creation still merge.
+    const result = scanRunEventsForUsageAnalytics(
+      [
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            usage: {
+              cache_read_input_tokens: 250,
+              cache_creation_input_tokens: 100,
+            },
+          },
+        },
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            usage: {
+              input_tokens: 1000,
+              output_tokens: 50,
+              total_tokens: 1050,
+            },
+          },
+        },
+      ],
+      '',
+      0,
+    );
+
+    expect(result).toMatchObject({
+      input_tokens: 1000,
+      output_tokens: 50,
+      total_tokens: 1050,
+      cache_read_input_tokens: 250,
+      cache_creation_input_tokens: 100,
+      cache_token_source: 'anthropic',
+      token_count_source: 'provider_usage',
+    });
+  });
+
   it('merges a later output-only usage frame with earlier input and cache fields', () => {
     // A trailing frame with only output_tokens must not freeze the reverse
     // scan: earlier input/cache counters still need to merge into run_finished.

--- a/apps/daemon/tests/run-analytics-observability.test.ts
+++ b/apps/daemon/tests/run-analytics-observability.test.ts
@@ -299,6 +299,74 @@ describe('scanRunEventsForUsageAnalytics', () => {
     });
   });
 
+  it('merges a later output-only usage frame with earlier input and cache fields', () => {
+    // A trailing frame with only output_tokens must not freeze the reverse
+    // scan: earlier input/cache counters still need to merge into run_finished.
+    const result = scanRunEventsForUsageAnalytics(
+      [
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            usage: {
+              input_tokens: 8_000,
+              cache_read_input_tokens: 2_000,
+              cache_creation_input_tokens: 500,
+            },
+          },
+        },
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            usage: { output_tokens: 120 },
+          },
+        },
+      ],
+      'amr-model',
+      0,
+    );
+
+    expect(result).toMatchObject({
+      input_tokens: 8_000,
+      output_tokens: 120,
+      cache_read_input_tokens: 2_000,
+      cache_creation_input_tokens: 500,
+      cache_token_source: 'anthropic',
+      token_count_source: 'provider_usage',
+    });
+  });
+
+  it('merges a later input-only usage frame with earlier output tokens', () => {
+    const result = scanRunEventsForUsageAnalytics(
+      [
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            usage: { output_tokens: 90, total_tokens: 4_090 },
+          },
+        },
+        {
+          event: 'agent',
+          data: {
+            type: 'usage',
+            usage: { input_tokens: 4_000 },
+          },
+        },
+      ],
+      '',
+      0,
+    );
+
+    expect(result).toMatchObject({
+      input_tokens: 4_000,
+      output_tokens: 90,
+      total_tokens: 4_090,
+      token_count_source: 'provider_usage',
+    });
+  });
+
   it('normalizes additive Responses-API / ACP usage where cache_read exceeds input_tokens', () => {
     // Real AMR/vela follow-up shape: the stream reports input_tokens as the
     // UNCACHED remainder with cached_input_tokens reported separately ON TOP, so

--- a/e2e/ui/app.test.ts
+++ b/e2e/ui/app.test.ts
@@ -513,8 +513,7 @@ test('[P0] sending preview comments opens the refreshed follow-up artifact', asy
 
   await page.getByTestId('board-mode-toggle').click();
   await page.getByTestId('comment-panel-toggle').click();
-  const frame = artifactPreviewFrame(page);
-  await frame.locator('[data-od-id="hero-title"]').click();
+  await clickCommentTargetInPreview(page, '[data-od-id="hero-title"]');
   await expect(page.getByTestId('comment-popover')).toBeVisible();
   await page.getByTestId('comment-popover-input').fill('Make the headline more specific.');
   await page.getByTestId('comment-popover-save').click();
@@ -1104,14 +1103,22 @@ async function runGenerationDoesNotCreateExtraFileFlow(
   await expectScenarioProjectState(page, entry, projectId);
 }
 
+async function clickCommentTargetInPreview(page: Page, selector: string) {
+  const target = artifactPreviewFrame(page).locator(selector);
+  await expect(target).toBeVisible();
+  // Auto-fit zoom + comment-bridge injection can keep the iframe target
+  // moving for long enough that Playwright's stability check never settles
+  // (CI: "element is not stable" until test timeout). Force once visible.
+  await target.click({ force: true });
+}
+
 async function runCommentAttachmentFlow(
   page: Page,
   entry: UiScenario,
 ) {
   await page.getByTestId('board-mode-toggle').click();
   await page.getByTestId('comment-panel-toggle').click();
-  const frame = artifactPreviewFrame(page);
-  await frame.locator('[data-od-id="hero-title"]').click();
+  await clickCommentTargetInPreview(page, '[data-od-id="hero-title"]');
   await expect(page.getByTestId('comment-popover')).toBeVisible();
   await page.getByTestId('comment-popover-input').fill('Make the headline more specific.');
   await page.getByTestId('comment-popover-save').click();

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -610,7 +610,14 @@ export type PersistedAgentEvent =
       refreshedSourceCount?: number;
       error?: string;
     }
-  | { kind: 'tool_use'; id: string; name: string; input: unknown }
+  | {
+      kind: 'tool_use';
+      id: string;
+      name: string;
+      input: unknown;
+      /** Optional wall-clock ms when the tool first started (e.g. ACP first frame). */
+      startedAt?: number;
+    }
   | { kind: 'tool_result'; toolUseId: string; content: string; isError: boolean }
   | {
       kind: 'diagnostic';

--- a/packages/contracts/src/sse/chat.ts
+++ b/packages/contracts/src/sse/chat.ts
@@ -113,7 +113,14 @@ export type DaemonAgentPayload =
   | LiveArtifactSsePayload
   | LiveArtifactRefreshSsePayload
   | PlainStreamArtifactSsePayload
-  | { type: 'tool_use'; id: string; name: string; input: unknown }
+  | {
+      type: 'tool_use';
+      id: string;
+      name: string;
+      input: unknown;
+      /** Optional wall-clock ms when the tool first started (e.g. ACP first frame). */
+      startedAt?: number;
+    }
   /**
    * Live-only incremental tool-input fragment, emitted while the model is still
    * streaming a tool call's JSON arguments (Claude `input_json_delta`). `delta`

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -52,6 +52,8 @@ const residualSkippedDirectories = new Set([
   ".od",
   ".od-e2e",
   ".opencode",
+  // Local agent deepwork/worktree scratch (git-ignored; not product source).
+  ".slim",
   ".task",
   ".tmp",
   ".vite",


### PR DESCRIPTION
## Why

Local Open Design Prerelease AMR/ACP runs stored incomplete tool transcripts (only synthetic `Write` pairs with garbage paths and empty results) and weak token usage for PostHog/Langfuse. Investigation of failed/succeeded prerelease runs showed ~475 ACP tool frames collapsing to 19 fake Writes, and usage often missing or only partially reported. This blocks observability of real agent workflows (bash/read/search loops) and token accounting.

Author use case: fix trace data storage and reporting after a prerelease handoff so internal Langfuse/PostHog debugging matches what the agent actually did — without changing UI code.

## What users will see

No intentional product UI change. Chat may show more accurate tool cards for ACP agents (AMR, Hermes, etc.) because the daemon now emits real `tool_use`/`tool_result` events instead of a write-only shim. Analytics/telemetry for operators become complete: full tool families, thought tokens, and correct cache accounting on `run_finished` and Langfuse traces.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

Contract note: optional `startedAt` on live/persisted `tool_use` for ACP tool duration; no new endpoints.

## Screenshots

N/A — no UI surface changes.

## Bug fix verification

- Test paths:
  - `apps/daemon/tests/acp.test.ts` (full tool transcript, path tighten, kind authority, think-only, exactly-once)
  - `apps/daemon/tests/acp-format-usage.test.ts` (usage aliases + anthropic/openai cache semantics)
  - `apps/daemon/tests/amr-acp-integration.test.ts` (AMR no-output / think-only)
  - `apps/daemon/tests/run-analytics-observability.test.ts` (unique tool counts, canonical tool families, thought_tokens)
  - `apps/daemon/tests/langfuse-bridge.test.ts` / `langfuse-trace.test.ts` (content redaction, thoughtTokens, startedAt)
- Red-on-main / green-on-branch: yes for the new/updated specs above (focused suite 177 pass after rebase onto latest main).

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/acp.test.ts tests/acp-format-usage.test.ts tests/run-analytics-observability.test.ts tests/langfuse-bridge.test.ts tests/amr-acp-integration.test.ts` — 177 passed
- `pnpm --filter @open-design/daemon typecheck` — pass
- `pnpm guard` — pass
- Note: 2 pre-existing `langfuse-trace` `reportRunFeedback` failures on main (default relay URL env) are unrelated

## Summary of fix

1. **ACP adapter**: accumulate tool frames; emit one terminal `tool_use`+`tool_result` per id with real names/inputs/results; Write/Edit normalize for `countNewArtifacts`; sticky kind + thinkOnly; `startedAt` from first frame.
2. **Usage**: broader `formatUsage`; preserve anthropic vs openai cache fields; `thought_tokens` through PostHog + Langfuse; usage-before-fail when prompt result carries usage.
3. **PostHog**: canonical tool families only; unique tool errors; finish-path analytics recovery keeps base insertId.
4. **Langfuse**: shared case-insensitive content-tool redaction; tool spans use `startedAt`.
