### PR TITLE
fix(daemon): restore Antigravity STDIN pipe by omitting legacy -p flag

### DIFF
--- a/apps/daemon/src/app-config.ts
+++ b/apps/daemon/src/app-config.ts
@@ -195,6 +195,7 @@ const AGENT_CLI_ENV_KEYS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
     'OPENCODE_TEST_HOME',
   ])],
   ['aider', new Set(['AIDER_BIN'])],
+  ['antigravity', new Set(['AGY_BIN'])],
   ['claude', new Set(['CLAUDE_CONFIG_DIR', 'CLAUDE_BIN', 'ANTHROPIC_BASE_URL', 'ANTHROPIC_API_KEY', 'ANTHROPIC_AUTH_TOKEN', 'MMD_MODEL_ROUTES_FILE'])],
   ['codex', new Set(['CODEX_HOME', 'CODEX_BIN', 'OPENAI_BASE_URL', 'CODEX_API_KEY', 'OPENAI_API_KEY'])],
   ['copilot', new Set(['COPILOT_BIN'])],

--- a/apps/daemon/src/runtimes/defs/antigravity.ts
+++ b/apps/daemon/src/runtimes/defs/antigravity.ts
@@ -209,33 +209,6 @@ export const antigravityAgentDef = {
     options = {},
     runtimeContext = {},
   ) => {
-    if (process.platform === 'win32' && prompt.length > 30000) {
-      // Workaround: write the massive payload to a temp file and have agy's AI read it
-      const tmpDir = join(process.cwd(), '.tmp', 'agy_payloads');
-      if (!existsSync(tmpDir)) {
-        mkdirSync(tmpDir, { recursive: true });
-      }
-      const tempPath = join(tmpDir, `od_payload_${Date.now()}.txt`);
-      writeFileSync(tempPath, prompt, 'utf8');
-      
-      prompt = `Read the file ${tempPath} using your file reading tool. Treat the entire contents of that file as your system instructions and the user's prompt. Execute the instructions inside it exactly, and output the final response exactly as the instructions dictate. Do NOT output anything else.`;
-      
-      // We must also inject --dangerously-skip-permissions to allow the read_file tool to work headlessly
-      const args: string[] = [];
-      if (options.model && options.model !== DEFAULT_MODEL_OPTION.id) {
-        writeAntigravityModelSelection(
-          options.model,
-          runtimeContext.antigravitySettingsPath,
-        );
-      }
-      if (runtimeContext.agentLogFilePath) {
-        args.push('--log-file', runtimeContext.agentLogFilePath);
-      }
-      args.push('--dangerously-skip-permissions');
-      args.push('-p', prompt);
-      return args;
-    }
-
     if (options.model && options.model !== DEFAULT_MODEL_OPTION.id) {
       writeAntigravityModelSelection(
         options.model,
@@ -243,9 +216,23 @@ export const antigravityAgentDef = {
       );
     }
     const args: string[] = [];
+    // Always opt into `--log-file` when the daemon supplied a path so
+    // it can post-exit grep for the actual upstream failure shape
+    // (auth missing vs quota reached vs upstream error) — without it
+    // the chat surfaces a generic "empty response" because print mode
+    // never echoes those errors on stdout. See server.ts empty-output
+    // guard for the consumer.
+    //
+    // Flag order is load-bearing on agy: `agy -p --log-file /tmp/x <prompt>`
+    // runs, while the reverse leaves the log empty.
     if (runtimeContext.agentLogFilePath) {
       args.push('--log-file', runtimeContext.agentLogFilePath);
     }
+    // agy's `-p`/`--print` takes the prompt as a command-line argument;
+    // it does not read from stdin and has no `-` stdin sentinel. Passing
+    // the literal `-` (the old behavior) made agy treat the dash as an
+    // empty prompt and reply "your request was empty or a placeholder
+    // (-)". Deliver the composed prompt as the `-p` argument instead.
     args.push('-p', prompt);
     return args;
   },

--- a/apps/daemon/src/runtimes/defs/antigravity.ts
+++ b/apps/daemon/src/runtimes/defs/antigravity.ts
@@ -6,7 +6,12 @@ import {
 } from 'node:fs';
 import { readFile as fsReadFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, delimiter } from 'node:path';
+
+const localAgyPath = join(process.cwd(), '.agy');
+if (existsSync(localAgyPath) && !process.env.PATH?.includes(localAgyPath)) {
+  process.env.PATH = localAgyPath + delimiter + process.env.PATH;
+}
 
 import { DEFAULT_MODEL_OPTION } from './shared.js';
 import type { RuntimeAgentDef } from '../types.js';
@@ -232,11 +237,11 @@ export const antigravityAgentDef = {
     // it does not read from stdin and has no `-` stdin sentinel. Passing
     // the literal `-` (the old behavior) made agy treat the dash as an
     // empty prompt and reply "your request was empty or a placeholder
-    // (-)". Deliver the composed prompt as the `-p` argument instead.
-    args.push('-p', prompt);
+    // (-)". The latest agy 1.1.x versions automatically read from STDIN,
+    // so we simply omit the -p flag entirely.
     return args;
   },
-  promptViaStdin: false,
+  promptViaStdin: true,
   streamFormat: 'plain',
   installUrl: 'https://antigravity.google/cli',
   docsUrl: 'https://antigravity.google/docs/cli-overview',

--- a/apps/daemon/src/runtimes/defs/antigravity.ts
+++ b/apps/daemon/src/runtimes/defs/antigravity.ts
@@ -6,12 +6,7 @@ import {
 } from 'node:fs';
 import { readFile as fsReadFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { dirname, join, delimiter } from 'node:path';
-
-const localAgyPath = join(process.cwd(), '.agy');
-if (existsSync(localAgyPath) && !process.env.PATH?.includes(localAgyPath)) {
-  process.env.PATH = localAgyPath + delimiter + process.env.PATH;
-}
+import { dirname, join } from 'node:path';
 
 import { DEFAULT_MODEL_OPTION } from './shared.js';
 import type { RuntimeAgentDef } from '../types.js';
@@ -208,7 +203,7 @@ export const antigravityAgentDef = {
   // composed in server.ts gives a second line of defense for weak
   // plain-stream models like Gemini 3.5 Flash.
   buildArgs: (
-    prompt,
+    _prompt,
     _imagePaths,
     _extra = [],
     options = {},
@@ -228,17 +223,9 @@ export const antigravityAgentDef = {
     // never echoes those errors on stdout. See server.ts empty-output
     // guard for the consumer.
     //
-    // Flag order is load-bearing on agy: `agy -p --log-file /tmp/x <prompt>`
-    // runs, while the reverse leaves the log empty.
     if (runtimeContext.agentLogFilePath) {
       args.push('--log-file', runtimeContext.agentLogFilePath);
     }
-    // agy's `-p`/`--print` takes the prompt as a command-line argument;
-    // it does not read from stdin and has no `-` stdin sentinel. Passing
-    // the literal `-` (the old behavior) made agy treat the dash as an
-    // empty prompt and reply "your request was empty or a placeholder
-    // (-)". The latest agy 1.1.x versions automatically read from STDIN,
-    // so we simply omit the -p flag entirely.
     return args;
   },
   promptViaStdin: true,

--- a/apps/daemon/src/runtimes/defs/antigravity.ts
+++ b/apps/daemon/src/runtimes/defs/antigravity.ts
@@ -203,7 +203,7 @@ export const antigravityAgentDef = {
   // composed in server.ts gives a second line of defense for weak
   // plain-stream models like Gemini 3.5 Flash.
   buildArgs: (
-    _prompt,
+    prompt,
     _imagePaths,
     _extra = [],
     options = {},
@@ -215,18 +215,6 @@ export const antigravityAgentDef = {
         runtimeContext.antigravitySettingsPath,
       );
     }
-    // We invoke agy via `-p -` (print mode + stdin sentinel), NOT
-    // `chat -`. Verified against `agy --help` on v1.0.3 — the
-    // `Available subcommands` list is `changelog / help / install /
-    // plugin / update`, and `chat` is NOT among them. `-p` is the
-    // documented print-mode flag (`Short alias for --print`) and
-    // `agy -p -` reads the prompt from stdin. The looper reviewer
-    // bot's environment runs a different agy build that may have
-    // renamed the entry point; until upstream confirms a stable
-    // headless subcommand (see google-antigravity/antigravity-cli#119)
-    // and the change actually ships in the auto-update channel that
-    // packaged OD users get, `-p -` is the contract that actually
-    // produces a print-mode reply on the installed CLI.
     const args: string[] = [];
     // Always opt into `--log-file` when the daemon supplied a path so
     // it can post-exit grep for the actual upstream failure shape
@@ -235,19 +223,20 @@ export const antigravityAgentDef = {
     // never echoes those errors on stdout. See server.ts empty-output
     // guard for the consumer.
     //
-    // Flag order is load-bearing on agy v1.0.3: `agy -p --log-file
-    // /tmp/x -` runs successfully but leaves /tmp/x empty, while `agy
-    // --log-file /tmp/x -p -` captures the diagnostic log, including
-    // `Propagating selected model override to backend: label="<model>"`
-    // and auth/quota failures.
+    // Flag order is load-bearing on agy: `agy -p --log-file /tmp/x <prompt>`
+    // runs, while the reverse leaves the log empty.
     if (runtimeContext.agentLogFilePath) {
       args.push('--log-file', runtimeContext.agentLogFilePath);
     }
-    args.push('-p');
-    args.push('-');
+    // agy's `-p`/`--print` takes the prompt as a command-line argument;
+    // it does not read from stdin and has no `-` stdin sentinel. Passing
+    // the literal `-` (the old behavior) made agy treat the dash as an
+    // empty prompt and reply "your request was empty or a placeholder
+    // (-)". Deliver the composed prompt as the `-p` argument instead.
+    args.push('-p', prompt);
     return args;
   },
-  promptViaStdin: true,
+  promptViaStdin: false,
   streamFormat: 'plain',
   installUrl: 'https://antigravity.google/cli',
   docsUrl: 'https://antigravity.google/docs/cli-overview',

--- a/apps/daemon/src/runtimes/defs/antigravity.ts
+++ b/apps/daemon/src/runtimes/defs/antigravity.ts
@@ -209,6 +209,33 @@ export const antigravityAgentDef = {
     options = {},
     runtimeContext = {},
   ) => {
+    if (process.platform === 'win32' && prompt.length > 30000) {
+      // Workaround: write the massive payload to a temp file and have agy's AI read it
+      const tmpDir = join(process.cwd(), '.tmp', 'agy_payloads');
+      if (!existsSync(tmpDir)) {
+        mkdirSync(tmpDir, { recursive: true });
+      }
+      const tempPath = join(tmpDir, `od_payload_${Date.now()}.txt`);
+      writeFileSync(tempPath, prompt, 'utf8');
+      
+      prompt = `Read the file ${tempPath} using your file reading tool. Treat the entire contents of that file as your system instructions and the user's prompt. Execute the instructions inside it exactly, and output the final response exactly as the instructions dictate. Do NOT output anything else.`;
+      
+      // We must also inject --dangerously-skip-permissions to allow the read_file tool to work headlessly
+      const args: string[] = [];
+      if (options.model && options.model !== DEFAULT_MODEL_OPTION.id) {
+        writeAntigravityModelSelection(
+          options.model,
+          runtimeContext.antigravitySettingsPath,
+        );
+      }
+      if (runtimeContext.agentLogFilePath) {
+        args.push('--log-file', runtimeContext.agentLogFilePath);
+      }
+      args.push('--dangerously-skip-permissions');
+      args.push('-p', prompt);
+      return args;
+    }
+
     if (options.model && options.model !== DEFAULT_MODEL_OPTION.id) {
       writeAntigravityModelSelection(
         options.model,
@@ -216,23 +243,9 @@ export const antigravityAgentDef = {
       );
     }
     const args: string[] = [];
-    // Always opt into `--log-file` when the daemon supplied a path so
-    // it can post-exit grep for the actual upstream failure shape
-    // (auth missing vs quota reached vs upstream error) — without it
-    // the chat surfaces a generic "empty response" because print mode
-    // never echoes those errors on stdout. See server.ts empty-output
-    // guard for the consumer.
-    //
-    // Flag order is load-bearing on agy: `agy -p --log-file /tmp/x <prompt>`
-    // runs, while the reverse leaves the log empty.
     if (runtimeContext.agentLogFilePath) {
       args.push('--log-file', runtimeContext.agentLogFilePath);
     }
-    // agy's `-p`/`--print` takes the prompt as a command-line argument;
-    // it does not read from stdin and has no `-` stdin sentinel. Passing
-    // the literal `-` (the old behavior) made agy treat the dash as an
-    // empty prompt and reply "your request was empty or a placeholder
-    // (-)". Deliver the composed prompt as the `-p` argument instead.
     args.push('-p', prompt);
     return args;
   },

--- a/apps/daemon/src/runtimes/executables.ts
+++ b/apps/daemon/src/runtimes/executables.ts
@@ -16,6 +16,7 @@ const RUNTIME_PROJECT_ROOT = path.resolve(
 const AGENT_BIN_ENV_KEYS = new Map<string, string>([
   ['amr', 'VELA_BIN'],
   ['aider', 'AIDER_BIN'],
+  ['antigravity', 'AGY_BIN'],
   ['claude', 'CLAUDE_BIN'],
   ['codebuddy', 'CODEBUDDY_BIN'],
   ['codex', 'CODEX_BIN'],

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -534,18 +534,18 @@ test('qwen args check promptViaStdin, base args, model args and exclude `-` sent
 // the daemon would render the resulting empty reply as a "successful"
 // agent response — exactly the failure mode the auth/quota guard at
 // server.ts ~12090 is meant to catch but for the wrong reason.
-test('antigravity passes the prompt as the -p argument (print mode)', () => {
+test('antigravity uses STDIN for the prompt instead of the legacy -p flag', () => {
   assert.equal(antigravity.bin, 'agy');
   assert.equal(antigravity.streamFormat, 'plain');
-  assert.equal(antigravity.promptViaStdin, false);
+  assert.equal(antigravity.promptViaStdin, true);
 
   const args = antigravity.buildArgs('write hello world', [], [], {}, {});
-  assert.deepEqual(args, ['-p', 'write hello world']);
+  assert.deepEqual(args, []);
 
   const argsWithLog = antigravity.buildArgs('write hello world', [], [], {}, {
     agentLogFilePath: '/tmp/od-agy-test.log',
   });
-  assert.deepEqual(argsWithLog, ['--log-file', '/tmp/od-agy-test.log', '-p', 'write hello world']);
+  assert.deepEqual(argsWithLog, ['--log-file', '/tmp/od-agy-test.log']);
 
   // No `--model` flag exists upstream, so buildArgs argv must stay the
   // same regardless of which label the user picks.
@@ -560,7 +560,7 @@ test('antigravity passes the prompt as the -p argument (print mode)', () => {
       antigravitySettingsPath: join(settingsDir, 'settings.json'),
     });
     assert.equal(withModel.includes('--model'), false);
-    assert.deepEqual(withModel, ['--log-file', '/tmp/od-agy-test.log', '-p', 'hi']);
+    assert.deepEqual(withModel, ['--log-file', '/tmp/od-agy-test.log']);
   } finally {
     rmSync(settingsDir, { recursive: true, force: true });
   }
@@ -576,13 +576,13 @@ test('antigravity passes the prompt as the -p argument (print mode)', () => {
   const followUp = antigravity.buildArgs('next message', [], [], {}, {
     hasPriorAssistantTurn: true,
   });
-  assert.deepEqual(followUp, ['-p', 'next message']);
+  assert.deepEqual(followUp, []);
   assert.equal(followUp.includes('-c'), false);
 
   const firstTurn = antigravity.buildArgs('first', [], [], {}, {
     hasPriorAssistantTurn: false,
   });
-  assert.deepEqual(firstTurn, ['-p', 'first']);
+  assert.deepEqual(firstTurn, []);
   assert.equal(antigravity.resumesSessionViaCli, undefined);
 
   assert.equal(antigravity.maxPromptArgBytes, undefined);

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -534,18 +534,18 @@ test('qwen args check promptViaStdin, base args, model args and exclude `-` sent
 // the daemon would render the resulting empty reply as a "successful"
 // agent response — exactly the failure mode the auth/quota guard at
 // server.ts ~12090 is meant to catch but for the wrong reason.
-test('antigravity pipes prompt via stdin via -p flag (print mode)', () => {
+test('antigravity passes the prompt as the -p argument (print mode)', () => {
   assert.equal(antigravity.bin, 'agy');
   assert.equal(antigravity.streamFormat, 'plain');
-  assert.equal(antigravity.promptViaStdin, true);
+  assert.equal(antigravity.promptViaStdin, false);
 
   const args = antigravity.buildArgs('write hello world', [], [], {}, {});
-  assert.deepEqual(args, ['-p', '-']);
+  assert.deepEqual(args, ['-p', 'write hello world']);
 
   const argsWithLog = antigravity.buildArgs('write hello world', [], [], {}, {
     agentLogFilePath: '/tmp/od-agy-test.log',
   });
-  assert.deepEqual(argsWithLog, ['--log-file', '/tmp/od-agy-test.log', '-p', '-']);
+  assert.deepEqual(argsWithLog, ['--log-file', '/tmp/od-agy-test.log', '-p', 'write hello world']);
 
   // No `--model` flag exists upstream, so buildArgs argv must stay the
   // same regardless of which label the user picks.
@@ -560,7 +560,7 @@ test('antigravity pipes prompt via stdin via -p flag (print mode)', () => {
       antigravitySettingsPath: join(settingsDir, 'settings.json'),
     });
     assert.equal(withModel.includes('--model'), false);
-    assert.deepEqual(withModel, ['--log-file', '/tmp/od-agy-test.log', '-p', '-']);
+    assert.deepEqual(withModel, ['--log-file', '/tmp/od-agy-test.log', '-p', 'hi']);
   } finally {
     rmSync(settingsDir, { recursive: true, force: true });
   }
@@ -576,13 +576,13 @@ test('antigravity pipes prompt via stdin via -p flag (print mode)', () => {
   const followUp = antigravity.buildArgs('next message', [], [], {}, {
     hasPriorAssistantTurn: true,
   });
-  assert.deepEqual(followUp, ['-p', '-']);
+  assert.deepEqual(followUp, ['-p', 'next message']);
   assert.equal(followUp.includes('-c'), false);
 
   const firstTurn = antigravity.buildArgs('first', [], [], {}, {
     hasPriorAssistantTurn: false,
   });
-  assert.deepEqual(firstTurn, ['-p', '-']);
+  assert.deepEqual(firstTurn, ['-p', 'first']);
   assert.equal(antigravity.resumesSessionViaCli, undefined);
 
   assert.equal(antigravity.maxPromptArgBytes, undefined);


### PR DESCRIPTION
Fixes #5495

## Why
This fixes the ENAMETOOLONG crash on Windows when using the latest agy 1.1.x versions with large plugins (like the Default design router). 

As noted in #5495, agy 1.1.x broke the legacy -p - CLI flag contract, treating the dash as an empty prompt rather than a STDIN sentinel. However, the background STDIN pipe itself still works natively in 1.1.x if the flag is omitted entirely. 

This PR removes the explicit -p flag argument from buildArgs. When promptViaStdin is enabled, the daemon now correctly pipes the payload natively, completely resolving the Windows limit crash without needing temporary files or legacy binary downgrades.

## What users will see
- Windows users will no longer experience spawn failed: spawn ENAMETOOLONG crashes when generating designs with large context windows.
- Users can safely use the latest global agy versions (1.1.x) instead of being pinned to 1.0.3.

**Proof it works!**
Here is Open Design flawlessly rendering a massive payload using the latest agy 1.1.x on Windows without crashing:

### Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only

### Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/runtimes/agent-args.test.ts`
- Did the test go red on `main` and green on this branch? yes
- We explicitly verified the new STDIN logic against `agy 1.1.5` on Windows where a 30KB payload previously triggered `ENAMETOOLONG`.

### Validation

- `npx vitest run tests/runtimes/agent-args.test.ts`
- End-to-end testing with a large context generation via `npx pnpm run tools-dev`.

<img width="1920" height="1200" alt="Screenshot (1396)" src="https://github.com/user-attachments/assets/5fe65816-dab6-4312-a2cc-8e844ffc3ad1" />

