### PR TITLE
feat(preview): give localStorage-using artifacts real, persisting Web Storage

### DIFF
--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -895,6 +895,87 @@ function applyUrlPreviewBridgesToHtml(
   return html;
 }
 
+// Powered previews (apps/web/src/runtime/powered-preview.ts) load from one
+// shared cross-origin-isolated loopback origin regardless of which project
+// they belong to — the project id is only a URL path segment, not part of
+// the origin, so a bare `localStorage`/`sessionStorage` write from one
+// project's powered preview is visible to (and can collide with) every other
+// project's powered preview. This wraps `window.localStorage` /
+// `window.sessionStorage` in the served document with a per-project
+// key-prefixed store, backed by the real native storage (unlike
+// injectSandboxShim's in-memory fake in apps/web/src/runtime/srcdoc.ts, which
+// exists only so non-powered srcDoc previews don't crash and never persists).
+// Injected as early as possible (right after `<head>`/`<body>` opens) so it
+// runs before any artifact script reads storage at module-eval/mount time.
+function injectPoweredStorageNamespaceShim(
+  html: string | Buffer,
+  mime: string,
+  projectId: string,
+): string | Buffer {
+  if (!/^text\/html(?:;|$)/i.test(mime)) return html;
+  const doc = Buffer.isBuffer(html) ? html.toString('utf8') : html;
+  const marker = 'data-od-powered-storage-namespace';
+  if (doc.includes(marker)) return doc;
+  const prefix = `od:proj:${projectId}:`;
+  const shim = `<script ${marker}>(function(){
+  var PREFIX = ${JSON.stringify(prefix)};
+  function makeNamespacedStore(real){
+    function pk(k){ return PREFIX + String(k); }
+    var api = {
+      getItem: function(k){ try { return real.getItem(pk(k)); } catch (_) { return null; } },
+      setItem: function(k, v){ try { real.setItem(pk(k), String(v)); } catch (_) {} },
+      removeItem: function(k){ try { real.removeItem(pk(k)); } catch (_) {} },
+      clear: function(){
+        try {
+          var toRemove = [];
+          for (var i = 0; i < real.length; i++) {
+            var fk = real.key(i);
+            if (fk !== null && fk.indexOf(PREFIX) === 0) toRemove.push(fk);
+          }
+          for (var j = 0; j < toRemove.length; j++) real.removeItem(toRemove[j]);
+        } catch (_) {}
+      },
+      key: function(i){
+        try {
+          var count = -1;
+          for (var idx = 0; idx < real.length; idx++) {
+            var fk = real.key(idx);
+            if (fk !== null && fk.indexOf(PREFIX) === 0) {
+              count++;
+              if (count === i) return fk.slice(PREFIX.length);
+            }
+          }
+        } catch (_) {}
+        return null;
+      }
+    };
+    Object.defineProperty(api, 'length', { get: function(){
+      try {
+        var count = 0;
+        for (var i = 0; i < real.length; i++) {
+          var fk = real.key(i);
+          if (fk !== null && fk.indexOf(PREFIX) === 0) count++;
+        }
+        return count;
+      } catch (_) { return 0; }
+    } });
+    return api;
+  }
+  function swap(name){
+    try {
+      var real = window[name];
+      if (!real || typeof real.getItem !== 'function') return;
+      Object.defineProperty(window, name, { configurable: true, value: makeNamespacedStore(real) });
+    } catch (_) {}
+  }
+  swap('localStorage');
+  swap('sessionStorage');
+})();</script>`;
+  if (/<head[^>]*>/i.test(doc)) return doc.replace(/<head[^>]*>/i, (m) => `${m}${shim}`);
+  if (/<body[^>]*>/i.test(doc)) return doc.replace(/<body[^>]*>/i, (m) => `${m}${shim}`);
+  return shim + doc;
+}
+
 // ---------------------------------------------------------------------------
 // Teams-safe title sanitization for the URL-load preview path (issue #3918).
 //
@@ -3375,7 +3456,8 @@ export function registerProjectFileRoutes(app: Express, ctx: RegisterProjectFile
             projectsRoot: PROJECTS_DIR,
             readProjectFile,
           });
-          return applyUrlPreviewBridgesToHtml(transformed, file.mime, req.query.odPreviewBridge);
+          const withBridges = applyUrlPreviewBridgesToHtml(transformed, file.mime, req.query.odPreviewBridge);
+          return injectPoweredStorageNamespaceShim(withBridges, file.mime, projectId);
         },
       );
     } catch (err: any) {

--- a/apps/daemon/tests/project-file-range.test.ts
+++ b/apps/daemon/tests/project-file-range.test.ts
@@ -410,7 +410,9 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     expect(res.status).toBe(200);
     expect(res.headers.get('document-isolation-policy')).toBe('isolate-and-credentialless');
     expect(res.headers.get('access-control-allow-origin')).toBeNull();
-    expect(await res.text()).toBe('<html/>');
+    // Powered previews now also carry the per-project storage-namespace shim
+    // (see the dedicated test below), so this is no longer a byte-exact match.
+    expect(await res.text()).toContain('<html/>');
 
     const foreign = await fetch(poweredUrl('page.html'), {
       headers: { Origin: 'https://foreign.example' },
@@ -427,6 +429,23 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     });
     expect(preflight.status).toBe(204);
     expect(preflight.headers.get('access-control-allow-origin')).toBeNull();
+  });
+
+  it('injects a per-project storage-namespace shim into powered previews only', async () => {
+    const powered = await fetch(poweredUrl('page.html'));
+    expect(powered.status).toBe(200);
+    const poweredHtml = await powered.text();
+    expect(poweredHtml).toContain('data-od-powered-storage-namespace');
+    expect(poweredHtml).toContain(`"od:proj:${projectId}:"`);
+    expect(poweredHtml).toContain('localStorage');
+    expect(poweredHtml).toContain('sessionStorage');
+
+    // The non-powered /raw/ route serves the same file untouched -- its
+    // bare `allow-scripts` sandbox (no allow-same-origin) can't reach real
+    // storage anyway, so there's nothing for the shim to namespace there.
+    const raw = await fetch(rawUrl('page.html'));
+    expect(raw.status).toBe(200);
+    expect(await raw.text()).not.toContain('data-od-powered-storage-namespace');
   });
 
   it('injects the URL preview scroll bridge for powered previews when requested', async () => {
@@ -450,7 +469,9 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
       },
     });
     expect(poweredFile.status).toBe(200);
-    expect(await poweredFile.text()).toBe('<html/>');
+    // The powered route also carries the per-project storage-namespace shim
+    // (see the dedicated test above), so this is no longer a byte-exact match.
+    expect(await poweredFile.text()).toContain('<html/>');
 
     const api = await fetch(`${origin}/api/projects`, {
       headers: {

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -141,9 +141,9 @@ import {
   hasTweaksTemplate,
   hasUrlModeBridge,
   htmlNeedsFocusGuard,
-  htmlNeedsPoweredPreview,
   htmlNeedsRedirectGuard,
   htmlNeedsSandboxShim,
+  needsPoweredPreview,
   parseForceInline,
   shouldUrlLoadHtmlPreview,
   type UrlLoadDecision,
@@ -7320,11 +7320,22 @@ function HtmlViewer({
   // needs. The interactive-bridge srcDoc modes (deck/inspect/edit/palette/
   // tweaks/comment) still win — they require host-injected bridges powered mode
   // can't carry.
-  const needsPowered = useMemo(() => {
-    if (serverPoweredPreviewRequired) return true;
-    const s = routingHtmlSource;
-    return s != null && htmlNeedsPoweredPreview(s);
-  }, [routingHtmlSource, serverPoweredPreviewRequired]);
+  //
+  // `needsSandboxShim` artifacts (Babel/localStorage/external-script signals —
+  // htmlNeedsSandboxShim) also route through powered mode rather than the
+  // srcDoc in-memory shim: they get real, persisting Web Storage instead of a
+  // fake store that resets every reload. The daemon's `/powered/*` route
+  // injects a per-project key-prefix shim (injectPoweredStorageNamespaceShim)
+  // so different projects sharing the one powered-preview origin can't
+  // collide on the same storage keys.
+  const needsPowered = useMemo(
+    () =>
+      needsPoweredPreview(routingHtmlSource, {
+        serverRequired: serverPoweredPreviewRequired,
+        sandboxShimNeeded: needsSandboxShim,
+      }),
+    [routingHtmlSource, serverPoweredPreviewRequired, needsSandboxShim],
+  );
   const [urlSelectionBridgeReady, setUrlSelectionBridgeReady] = useState(false);
   const urlLoadDecision: UrlLoadDecision = {
     mode,

--- a/apps/web/src/components/file-viewer-render-mode.ts
+++ b/apps/web/src/components/file-viewer-render-mode.ts
@@ -251,6 +251,37 @@ export function htmlNeedsPoweredPreview(source: string | null | undefined): bool
   return false;
 }
 
+/**
+ * Combined powered-preview trigger FileViewer actually uses to compute
+ * `needsPowered`. Isolated here (rather than inlined in the component) so the
+ * composition is directly unit-testable, matching every other decision in
+ * this file.
+ *
+ * Artifacts that only need `htmlNeedsSandboxShim` (Babel / localStorage /
+ * external-script signals) also route through powered mode now: instead of
+ * `injectSandboxShim`'s in-memory fake store (apps/web/src/runtime/srcdoc.ts
+ * — exists purely so the preview doesn't crash, never persists), they get
+ * the powered path's real, same-origin Web Storage. The daemon's
+ * `injectPoweredStorageNamespaceShim` (apps/daemon/src/routes/project/
+ * index.ts) key-prefixes that storage per project, since every project's
+ * powered preview shares one cross-origin-isolated loopback origin.
+ *
+ * `sandboxShimNeeded` is a parameter rather than re-derived from `source`
+ * here because FileViewer's own `needsSandboxShim` memo additionally gates on
+ * `passiveLargeHtmlPreview` (skip the full scan on huge passive previews) —
+ * recomputing it from raw `source` in this function would silently lose that
+ * gate. `htmlNeedsPoweredPreview` has no such gate today, so `source` is
+ * still scanned directly for it.
+ */
+export function needsPoweredPreview(
+  source: string | null | undefined,
+  options: { serverRequired: boolean; sandboxShimNeeded: boolean },
+): boolean {
+  if (options.serverRequired || options.sandboxShimNeeded) return true;
+  if (source == null) return false;
+  return htmlNeedsPoweredPreview(source);
+}
+
 export function htmlNeedsSandboxShim(source: string): boolean {
   // Quote-optional: HTML5 permits unquoted attribute values
   // (`<script type=text/babel src=app.jsx>`). The trailing `\b` rejects

--- a/apps/web/tests/components/FileViewer.srcdoc-reload-races.test.tsx
+++ b/apps/web/tests/components/FileViewer.srcdoc-reload-races.test.tsx
@@ -428,11 +428,12 @@ describe('FileViewer srcDoc reload — prevSourceBeforeReloadRef race conditions
   // source=null window opened by a Reload click on an artifact whose srcDoc
   // path is driven by a source-derived predicate (htmlNeedsSandboxShim).
   // ---------------------------------------------------------------------------
-  it('keeps the srcDoc iframe active (does not flip to URL-load) while source is null after a Reload click on an htmlNeedsSandboxShim artifact', async () => {
-    // An HTML file that uses localStorage — triggers htmlNeedsSandboxShim and
-    // therefore forces the srcDoc path (forceInline=true).  No .slide class so
-    // looksLikeDeck stays false and isDeck is passed as false; the ONLY reason
-    // this file takes the srcDoc path is the sandbox-shim predicate.
+  it('keeps the powered iframe active (does not flip to plain URL-load) while source is null after a Reload click on an htmlNeedsSandboxShim artifact', async () => {
+    // An HTML file that uses localStorage — triggers htmlNeedsSandboxShim,
+    // which now routes through powered mode (needsPoweredPreview) for real,
+    // persisting Web Storage instead of the srcDoc in-memory shim.  No .slide
+    // class so looksLikeDeck stays false and isDeck is passed as false; the
+    // ONLY reason this file takes the powered path is the sandbox-shim signal.
     const shimFile: ProjectFile = {
       name: 'app.html',
       path: 'app.html',
@@ -444,10 +445,21 @@ describe('FileViewer srcDoc reload — prevSourceBeforeReloadRef race conditions
     };
     const shimHtml =
       '<html><body><script>localStorage.setItem("key","val");</script><p>loaded</p></body></html>';
+    const isolationResponse = () =>
+      new Response(JSON.stringify({ supported: true, baseOrigin: 'http://127.0.0.1:43111' }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    const poweredSrcPrefix = 'http://localhost:43111/api/projects/project-1/powered/app.html';
 
     // Step 1: mount with shimHtml — source is non-null, needsSandboxShim=true,
-    // forceInline=true, useUrlLoadPreview=false → srcDoc iframe is active.
-    vi.stubGlobal('fetch', fetchReturning(shimHtml));
+    // needsPowered=true. Once the (mocked) isolation probe resolves, the
+    // powered iframe becomes the active `artifact-preview-frame`.
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url === '/api/preview/isolation') return isolationResponse();
+      if (url.startsWith(RAW_URL_PREFIX)) return new Response(shimHtml, { status: 200 });
+      return new Response('', { status: 404 });
+    }));
 
     render(
       <FileViewer
@@ -458,47 +470,59 @@ describe('FileViewer srcDoc reload — prevSourceBeforeReloadRef race conditions
       />,
     );
 
-    // Wait for the source fetch to resolve so the component has non-null source.
+    // Wait for the source fetch AND the isolation probe to resolve so the
+    // component has settled on the powered iframe as active.
     await waitFor(() => {
-      // The srcDoc iframe is active: its testid is 'artifact-preview-frame'
-      // (not 'artifact-preview-frame-srcdoc') when useUrlLoadPreview=false.
       const frame = screen.queryByTestId('artifact-preview-frame');
       expect(frame).not.toBeNull();
-      expect((frame as HTMLIFrameElement).getAttribute('data-od-render-mode')).toBe('srcdoc');
+      expect((frame as HTMLIFrameElement).getAttribute('data-od-render-mode')).toBe('url-load');
+      expect((frame as HTMLIFrameElement).getAttribute('data-od-powered')).toBe('true');
+      expect((frame as HTMLIFrameElement).getAttribute('src')).toMatch(new RegExp(`^${poweredSrcPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
     });
 
-    // Step 2: click Reload — source goes null synchronously.  Without the fix,
-    // needsSandboxShim(null)=false → forceInline flips → useUrlLoadPreview
-    // becomes true → the URL-load iframe hijacks testid 'artifact-preview-frame'
-    // and the srcDoc iframe is renamed to 'artifact-preview-frame-srcdoc'.
-    const { handle: reloadHandle, stub: reloadStub } = deferredFetch();
-    vi.stubGlobal('fetch', reloadStub);
+    // Step 2: click Reload — source goes null synchronously. Without the fix,
+    // needsSandboxShim(null)=false → needsPowered flips false → the plain
+    // (non-powered) URL-load iframe would hijack testid 'artifact-preview-frame'.
+    const rawHandle: { resolve: (html: string) => void } = { resolve: () => {} };
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url === '/api/preview/isolation') return isolationResponse();
+      if (url.startsWith(RAW_URL_PREFIX)) {
+        return new Promise<Response>((ok) => {
+          rawHandle.resolve = (html: string) => ok(new Response(html, { status: 200 }));
+        });
+      }
+      return new Response('', { status: 404 });
+    }));
 
     act(() => {
       fireEvent.click(screen.getByRole('button', { name: /reload preview/i }));
     });
 
-    // Step 3: assert BEFORE the fetch resolves — this is the reload window
+    // Drain one microtask tick: the (cached) isolation probe re-resolves via
+    // a fresh .then() on file/reload-key change even though fetchPreviewIsolation
+    // itself hits the cache instantly — the resulting setState still needs a
+    // tick to flush. This is well before the deferred raw-html fetch below
+    // resolves, so the reload window this test guards is still open.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Step 3: assert BEFORE the raw fetch resolves — this is the reload window
     // where the source=null race can expose the bug.
     //
-    // The srcDoc iframe must remain the active iframe: its testid stays
-    // 'artifact-preview-frame' and its data-od-render-mode is 'srcdoc'.
-    // If the routing flipped, a URL-load iframe would have taken the
-    // 'artifact-preview-frame' testid and data-od-active='true' instead.
+    // The powered iframe must remain the active iframe: its testid stays
+    // 'artifact-preview-frame', still on url-load/powered. If the routing
+    // flipped, a plain (non-powered) URL-load iframe would have taken over
+    // instead.
     const activeFrame = screen.getByTestId('artifact-preview-frame');
-    expect(activeFrame.getAttribute('data-od-render-mode')).toBe('srcdoc');
+    expect(activeFrame.getAttribute('data-od-render-mode')).toBe('url-load');
+    expect(activeFrame.getAttribute('data-od-powered')).toBe('true');
     expect(activeFrame.getAttribute('data-od-active')).toBe('true');
-
-    // Confirm the URL-load iframe is NOT the active one (it would carry
-    // data-od-render-mode='url-load' and data-od-active='true' on a buggy build).
-    const urlLoadFrame = screen.queryByTestId('artifact-preview-frame-url-load');
-    if (urlLoadFrame) {
-      expect(urlLoadFrame.getAttribute('data-od-active')).toBe('false');
-    }
 
     // Drain the deferred fetch so it doesn't leak into subsequent tests.
     await act(async () => {
-      reloadHandle.resolve(shimHtml);
+      rawHandle.resolve(shimHtml);
       await Promise.resolve();
     });
   });
@@ -926,9 +950,12 @@ describe('FileViewer srcDoc reload — prevSourceBeforeReloadRef race conditions
   // was not silently dropped.
   // ---------------------------------------------------------------------------
   it('saves a Manual Edit patch made during the Reload window instead of silently discarding it', async () => {
-    // Include localStorage to trigger htmlNeedsSandboxShim → forceInline=true
-    // → srcDoc render path even before Manual Edit mode is entered.  This lets
-    // the test confirm srcdoc content in Step 1 and verify the iframe is active.
+    // Include localStorage to trigger htmlNeedsSandboxShim, which now routes
+    // through powered mode (needsPoweredPreview) rather than forceInline/
+    // srcDoc — Step 1 below waits for the powered iframe instead of srcdoc
+    // content. Entering Manual Edit mode in Step 2 forces srcDoc regardless
+    // (editMode always wins over powered — see shouldUrlLoadHtmlPreview), so
+    // everything from Step 2 onward is unaffected by the pre-edit transport.
     const initialSource =
       '<!doctype html><html><body>' +
       '<script>localStorage.setItem("k","v");</script>' +
@@ -956,6 +983,16 @@ describe('FileViewer srcDoc reload — prevSourceBeforeReloadRef race conditions
         return new Response(
           JSON.stringify({ file: manualEditFile() }),
           { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+
+      // Powered-preview isolation probe — the localStorage signal below now
+      // routes this file through powered mode pre-edit-mode (see the comment
+      // above this test).
+      if (url === '/api/preview/isolation') {
+        return new Response(
+          JSON.stringify({ supported: true, baseOrigin: 'http://127.0.0.1:43111' }),
+          { headers: { 'Content-Type': 'application/json' } },
         );
       }
 
@@ -1017,7 +1054,8 @@ describe('FileViewer srcDoc reload — prevSourceBeforeReloadRef race conditions
 
     await waitFor(() => {
       const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
-      expect(frame.srcdoc).toContain('Hello');
+      expect(frame.getAttribute('data-od-render-mode')).toBe('url-load');
+      expect(frame.getAttribute('data-od-powered')).toBe('true');
     });
 
     // Step 2: enter Manual Edit mode — manualEditFrozenSource captures V1.

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -796,7 +796,7 @@ describe('FileViewer SVG artifacts', () => {
     expect(screen.getByTestId('artifact-preview-frame')).toBe(firstFrame);
   });
 
-  it('promotes large HTML files to the srcDoc path when the routing preview shows sandbox-unsafe scripts', async () => {
+  it('promotes large HTML files to the powered path when the routing preview shows sandbox-unsafe scripts', async () => {
     const file = baseFile({
       name: 'index.html',
       path: 'index.html',
@@ -813,12 +813,25 @@ describe('FileViewer SVG artifacts', () => {
       },
     });
     const previewText = '<!doctype html><html><head><script src="./app.js"></script></head>';
-    let fullHtml = `${previewText}<body><main>Imported filesystem app</main></body></html>`;
+    const fullHtml = `${previewText}<body><main>Imported filesystem app</main></body></html>`;
     const fetchMock = vi.fn(async (input: string | URL | Request) => {
       const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url === '/api/preview/isolation') {
+        return new Response(JSON.stringify({
+          supported: true,
+          baseOrigin: 'http://127.0.0.1:43111',
+        }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
       if (url.startsWith('/api/projects/project-1/text-preview/index.html')) {
         return new Response(JSON.stringify({
           text: previewText,
+          // The external <script src="./app.js"> signal comes from the client-
+          // side htmlNeedsSandboxShim scan of this routing preview text, not
+          // from the server's own WebGL/Worker/WASM poweredPreview hint — this
+          // stays `required: false` on purpose to prove the client-side signal
+          // alone is what promotes the file to powered mode.
           poweredPreview: { required: false, reasons: [] },
         }), {
           status: 200,
@@ -845,13 +858,14 @@ describe('FileViewer SVG artifacts', () => {
 
     await waitFor(() => {
       const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
-      expect(frame.getAttribute('data-od-render-mode')).toBe('srcdoc');
-      expect(frame.getAttribute('srcDoc')).toContain('Imported filesystem app');
+      expect(frame.getAttribute('data-od-render-mode')).toBe('url-load');
+      expect(frame.getAttribute('data-od-powered')).toBe('true');
+      expect(frame.getAttribute('src')).toBe(
+        `http://localhost:43111/api/projects/project-1/powered/index.html?v=${file.mtime}&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot`,
+      );
     });
     expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/api/projects/project-1/text-preview/index.html'), { cache: 'no-store' });
-    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/api/projects/project-1/raw/index.html?cacheBust='), {});
 
-    fullHtml = `${previewText}<body><main>Updated filesystem app</main></body></html>`;
     rerender(
       <FileViewer
         projectId="project-1"
@@ -862,8 +876,10 @@ describe('FileViewer SVG artifacts', () => {
 
     await waitFor(() => {
       const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
-      expect(frame.getAttribute('data-od-render-mode')).toBe('srcdoc');
-      expect(frame.getAttribute('srcDoc')).toContain('Updated filesystem app');
+      expect(frame.getAttribute('data-od-render-mode')).toBe('url-load');
+      expect(frame.getAttribute('src')).toBe(
+        `http://localhost:43111/api/projects/project-1/powered/index.html?v=${file.mtime + 1}&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot`,
+      );
     });
   });
 
@@ -1651,7 +1667,20 @@ describe('FileViewer SVG artifacts', () => {
     expect(toggle.getAttribute('aria-pressed')).toBe('true');
   });
 
-  it('renders sandbox-shim artifacts on the srcdoc transport without entering edit mode (#2791)', () => {
+  it('renders sandbox-shim artifacts on the powered transport without entering edit mode (#2791)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url === '/api/preview/isolation') {
+        return new Response(JSON.stringify({
+          supported: true,
+          baseOrigin: 'http://127.0.0.1:43111',
+        }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response('', { status: 404 });
+    }));
+
     const file = baseFile({
       name: 'search.html',
       path: 'search.html',
@@ -1676,11 +1705,25 @@ describe('FileViewer SVG artifacts', () => {
       />,
     );
 
-    const srcDocFrame = container.querySelector('iframe[data-od-render-mode="srcdoc"]') as HTMLIFrameElement | null;
-    expect(srcDocFrame?.getAttribute('data-od-active')).toBe('true');
-    expect(srcDocFrame?.srcdoc).toContain('data-od-id="results"');
-    expect(srcDocFrame?.srcdoc).not.toContain('data-od-lazy-srcdoc-transport');
-    expect(srcDocFrame?.srcdoc).toContain('data-od-sandbox-shim');
+    // The external <script src="app.js"> signal (htmlNeedsSandboxShim) now
+    // routes through powered mode for real, persisting Web Storage instead of
+    // the srcDoc in-memory shim (see needsPoweredPreview) -- the daemon
+    // (apps/daemon/src/routes/project/index.ts) is responsible for actually
+    // injecting the per-project storage shim into what it serves at this URL;
+    // that's covered separately in project-file-range.test.ts. This test only
+    // confirms the frontend picks the powered transport (and never detours
+    // through manual-edit mode) for sandbox-unsafe content.
+    await waitFor(() => {
+      const frame = container.querySelector('iframe[data-od-render-mode="url-load"]') as HTMLIFrameElement | null;
+      expect(frame?.getAttribute('data-od-active')).toBe('true');
+      expect(frame?.getAttribute('data-od-powered')).toBe('true');
+      expect(frame?.getAttribute('src')).toBe(
+        `http://localhost:43111/api/projects/project-1/powered/search.html?v=${file.mtime}&r=0&odPreviewBridge=scroll&odPreviewBridge=selection&odPreviewBridge=snapshot`,
+      );
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('manual-edit-mode-toggle').getAttribute('aria-pressed')).toBe('false'),
+    );
   });
 
   it('keeps srcDoc HTML previews available with a compact Code action', async () => {

--- a/apps/web/tests/components/file-viewer-render-mode.test.ts
+++ b/apps/web/tests/components/file-viewer-render-mode.test.ts
@@ -7,6 +7,7 @@ import {
   htmlNeedsPoweredPreview,
   htmlNeedsRedirectGuard,
   htmlNeedsSandboxShim,
+  needsPoweredPreview,
   parseForceInline,
   shouldUrlLoadHtmlPreview,
 } from '../../src/components/file-viewer-render-mode';
@@ -374,6 +375,43 @@ describe('htmlNeedsPoweredPreview', () => {
   it('does NOT match unrelated prose that mentions the words', () => {
     expect(htmlNeedsPoweredPreview('<p>Our web worker culture is great</p>')).toBe(false);
     expect(htmlNeedsPoweredPreview('<p>A workshop about 3D printing</p>')).toBe(false);
+  });
+});
+
+describe('needsPoweredPreview', () => {
+  const opts = (overrides: Partial<{ serverRequired: boolean; sandboxShimNeeded: boolean }> = {}) => ({
+    serverRequired: false,
+    sandboxShimNeeded: false,
+    ...overrides,
+  });
+
+  it('returns false for null/empty source with no other trigger', () => {
+    expect(needsPoweredPreview(null, opts())).toBe(false);
+    expect(needsPoweredPreview('', opts())).toBe(false);
+  });
+
+  it('routes a WebGL2/Worker/WASM artifact through powered mode (unchanged behavior)', () => {
+    expect(needsPoweredPreview("new Worker('sort.js')", opts())).toBe(true);
+    expect(needsPoweredPreview('<p>plain html</p>', opts())).toBe(false);
+  });
+
+  it('routes an artifact that only needs the sandbox shim through powered mode too', () => {
+    // e.g. localStorage usage or an external <script src> — see
+    // htmlNeedsSandboxShim. These previously got only the srcDoc in-memory
+    // shim; they now get real, persisting storage via powered mode.
+    expect(needsPoweredPreview('<p>no signals here</p>', opts({ sandboxShimNeeded: true }))).toBe(true);
+  });
+
+  it('honors serverRequired regardless of source content', () => {
+    expect(needsPoweredPreview(null, opts({ serverRequired: true }))).toBe(true);
+    expect(needsPoweredPreview('<p>plain html</p>', opts({ serverRequired: true }))).toBe(true);
+  });
+
+  it('does not fall back to scanning source for the sandbox-shim signal itself', () => {
+    // sandboxShimNeeded must be passed in already-computed (it's gated by
+    // FileViewer's own passiveLargeHtmlPreview check) -- this function must
+    // not re-derive it from source, or that gate would silently disappear.
+    expect(needsPoweredPreview('localStorage.getItem("x")', opts())).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Why

HTML prototypes that rely on `localStorage` for real CRUD-style state (the common case for "full working prototype" testing) silently lose all data on every preview refresh, with no real workaround short of not using `localStorage` at all.

Root cause, confirmed by reading the actual rendering code (not assumed): **neither existing preview mode gives real persistence.** Both URL-load and srcDoc use `sandbox="allow-scripts allow-downloads"` with no `allow-same-origin`, so `localStorage`/`sessionStorage` throw `SecurityError` in both. srcDoc's `injectSandboxShim` (srcdoc.ts) papers over this with an in-memory fake store -- it exists purely so artifacts reading storage at mount don't crash, and was never meant to persist.

There IS already a mode with real storage: "powered preview" (issue #724), which loads the iframe from a genuinely cross-origin loopback host (a `127.0.0.1`<->`localhost` swap, isolated from the daemon's own session/cookies -- confirmed safe by reading `powered-preview.ts`). It's currently gated to WebGL/Worker/WASM/SharedArrayBuffer signals only (`htmlNeedsPoweredPreview`).

## What users will see

- An HTML artifact that reads/writes `localStorage`/`sessionStorage`, uses Babel-standalone (`type="text/babel"`), or has an external `<script src>` (the same three signals `htmlNeedsSandboxShim` already detects) now renders through the powered preview path instead of the srcDoc in-memory shim.
- Concretely: state written to `localStorage` now survives a preview reload, matching how a real browser tab behaves.

## Surface area

- [x] **Default behavior change** -- artifacts matching the sandbox-shim heuristic now render through a different (safer, real-storage) transport than before. No opt-in required; this is the intended fix, and the old in-memory shim never persisted anything regardless of transport, so there's no prior working state this could regress.
- [ ] UI -- no new UI surface; this changes which existing transport an artifact uses, invisibly to the user except for the (fixed) persistence behavior.

## New risk surfaced, and how it's addressed

Broadening powered-preview eligibility surfaces a real risk I confirmed by reading the actual route registration: **every project's powered preview currently shares ONE storage origin.** The project id is a URL path segment (`/api/projects/:id/powered/...`), not part of the origin, so two different projects both writing a generic key like `"clients"` would silently collide.

Fixed with `injectPoweredStorageNamespaceShim` (`apps/daemon/src/routes/project/index.ts`): wraps `window.localStorage`/`sessionStorage` in the served powered-preview document with a per-project key-prefixed store, backed by the REAL native storage object (unlike `injectSandboxShim`'s in-memory fake), injected as early as possible (right after `<head>`/`<body>`) so it runs before any artifact script reads storage at mount/module-eval time. Only wired into the `/powered/*` route -- the plain `/raw/*` route's bare sandbox still can't reach real storage at all regardless, so there's nothing to namespace there.

## Implementation

- `needsPoweredPreview` (new, `file-viewer-render-mode.ts`): the composed trigger FileViewer actually uses, isolated as a pure function so it's directly unit-testable rather than inlined in the component (matching every other decision in this file). Takes the already-gated `needsSandboxShim` boolean as a parameter rather than re-deriving it from `source`, because FileViewer's own memo for that value additionally gates on `passiveLargeHtmlPreview` (skip the full scan on huge passive previews) -- recomputing it from raw source here would silently lose that gate.
- `injectPoweredStorageNamespaceShim` (new, daemon `routes/project/index.ts`): per-project storage namespacing, described above.

## Bug fix verification

- Test paths:
  - `apps/web/tests/components/file-viewer-render-mode.test.ts` -- `needsPoweredPreview` unit tests, including the case proving it does NOT silently re-scan `source` for the sandbox-shim signal itself (would lose the `passiveLargeHtmlPreview` gate).
  - `apps/daemon/tests/project-file-range.test.ts` -- `injects a per-project storage-namespace shim into powered previews only`, asserting the shim + correct project-id prefix are present in `/powered/*` responses and absent from `/raw/*`.
- Went red on `main` / green on this branch? Yes -- `needsPoweredPreview` and `injectPoweredStorageNamespaceShim` don't exist on `main`, so both new test suites fail to even reference them there; they pass on this branch.
- Three existing tests encoded the pre-fix behavior by name/assertion (expecting `srcdoc` for sandbox-shim artifacts) and needed updating to the new correct transport, not just left broken: `FileViewer.test.tsx` (`promotes large HTML files to the powered path...`, `renders sandbox-shim artifacts on the powered transport...(#2791)`) and `FileViewer.srcdoc-reload-races.test.tsx` (`keeps the powered iframe active...`, plus a follow-on Manual Edit test whose Step 1 pre-edit-mode assertion needed to check the powered transport instead of inline srcdoc content -- Manual Edit itself still always forces srcDoc regardless of powered state, so everything from Step 2 onward in that test is unchanged).

## Validation

- `apps/daemon` vitest (`project-file-range.test.ts` + broader preview/route-adjacent files: `project-preview-containment`, `project-raw-cache`, `plugins-preview-fallback`, `plugin-preview-bakes`, `plugins-preview-route`, `design-system-preview`, `project-routes-title-sanitize`) -- all green
- `apps/web` vitest (`FileViewer.test.tsx`, `FileViewer.srcdoc-reload-races.test.tsx`, `FileViewer.srcdoc-reload.test.tsx`, `FileViewer.deploy-target.test.tsx`, `FileViewer.manual-edit*.test.tsx`, `file-viewer-preview-assets.test.ts`, `file-viewer-render-mode.test.ts`, plus markdown-copy/version-download/screenshot-tooltip/image-export) -- 360+ tests green
- `tsc -b --noEmit` (web) and `tsc --noEmit` (daemon, both tsconfig.json and tsconfig.tests.json) -- clean
- Manually verified live against a real project on this install (not just unit tests): fetched the actual powered-preview URL for a real `.dc.html` file and confirmed the injected shim carries that exact project's id as the storage key prefix
- Confirmed via clean-checkout comparison that pre-existing, unrelated test failures on this box (`langfuse-trace.test.ts`, `run-retry-runtime.test.ts`, `amr-session-resume.test.ts`) fail identically with this branch's changes stashed out -- not caused by this change
