### PR TITLE
fix(web): local-CLI balance card reads vela's USD figure, not raw credits

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -4542,9 +4542,18 @@ export function SettingsDialog({
                           // source of truth and wins here for the same reason;
                           // the account-scoped pair stays as the fallback for
                           // local/BYOK use with no workspace billing at all.
+                          //
+                          // recvqakgSc1Pwd: this must read `balanceUsd` — the
+                          // dollar figure vela already computed — not
+                          // `totalAvailableCredits`, a raw credits COUNT on a
+                          // completely different scale (vela reports
+                          // thousands of credits per dollar). Formatting the
+                          // credits count as a dollar amount is what put
+                          // "Balance $388307.00" on a workspace whose real
+                          // balance was under $39.
                           const amrWorkspaceBalance =
                             amrWalletVisible && workspaceBilling
-                              ? formatVelaBalanceUsd(String(workspaceBilling.totalAvailableCredits))
+                              ? formatVelaBalanceUsd(workspaceBilling.balanceUsd)
                               : null;
                           const amrCardBalanceLabel =
                             isAmrAgent && active && amrCardStatus?.loggedIn

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -3836,10 +3836,17 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
             summary: {
               workspaceId: 'ws-team',
               membershipTier: 'team',
-              totalAvailableCredits: 21.01,
-              subscriptionCredits: 21.01,
+              // recvqakgSc1Pwd: B reports credits and USD on separate scales
+              // (thousands of credits per dollar) — a real workspace read
+              // 99933 credits / $9.9933. Earlier fixture data used a
+              // fractional credits count that coincidentally equaled its own
+              // balanceUsd string, which let a totalAvailableCredits-as-USD
+              // regression pass silently. These numbers are deliberately far
+              // apart so only reading `balanceUsd` can produce '$9.99'.
+              totalAvailableCredits: 99933,
+              subscriptionCredits: 99933,
               rechargeCredits: 0,
-              balanceUsd: '21.01',
+              balanceUsd: '9.9933',
               subscriptionStatus: 'active',
               availableActions: [],
             },
@@ -3893,7 +3900,13 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
 
     fireEvent.click(screen.getByRole('tab', { name: /Local CLI.*1 installed/i }));
 
-    expect(await screen.findByText('$21.01')).toBeTruthy();
+    // recvqakgSc1Pwd: the card must format `balanceUsd` (a real dollar
+    // figure vela reports), never `totalAvailableCredits` (a raw credits
+    // count) — feeding the credits count through the USD formatter is how a
+    // FEATURE TEST workspace with 388307 credits rendered "Balance
+    // $388307.00" in Settings > Models & providers > Local CLI.
+    expect(await screen.findByText('$9.99')).toBeTruthy();
+    expect(screen.queryByText('$99933.00')).toBeNull();
     expect(screen.queryByText('$138.63')).toBeNull();
   });
 


### PR DESCRIPTION
Fixes: recvqakgSc1Pwd (Feishu, 统一为额度，不用积分作为单位)

## Why

Tonight's screenshot on `recvqakgSc1Pwd` showed Settings → Models & providers
→ Local CLI rendering **"Balance $388307.00"** for a real FEATURE TEST team
workspace — obviously not a real dollar amount. Investigating this bug (not
speculative — reproduced live on our own dogfood owner account, see below)
turned up the exact root cause and a one-line fix with no backend dependency.

**The pain**: a team member opening Settings sees a nonsense six-figure
"balance", which reads as either a serious billing bug or an exploit,
undermining trust in the whole billing surface right when workspace-scoped
billing (tonight's vela `workspace-credit-isolation` push, PR #951/#952/#959)
is trying to make per-workspace numbers trustworthy.

**Root cause**: `f4c81278e` (2026-07-22, fixing `recvpZPzGJL7o7` — a team
member's balance showing their personal wallet instead of the team's) added
`amrWorkspaceBalance`, but formatted the wrong field:

```ts
formatVelaBalanceUsd(String(workspaceBilling.totalAvailableCredits))
```

`totalAvailableCredits` is a raw **credits** count; vela reports credits and
USD on very different scales (a live read: 99933 credits / $9.9933 — roughly
10000 credits per dollar). `formatVelaBalanceUsd` just prepends `$` and pads
two decimals, so the credits count got printed as if it were already dollars.
`workspaceBilling.balanceUsd` — the real dollar figure vela computes — has
been sitting on `WorkspaceBillingSummary` unused since `79791d61a`
(2026-07-21); nothing else in `apps/web/src` reads it. This fix just wires it
in.

The existing regression test for `f4c81278e` didn't catch this because its
fixture used a fractional credits count (`21.01`) that happened to equal its
own `balanceUsd` string — real reads never look like that. Updated the
fixture to realistic, deliberately mismatched numbers (99933 credits /
$9.9933, matching a live dogfood read) so the assertion can only pass by
reading `balanceUsd`.

**Investigated, confirmed out of scope for this fix**: whether the number
is genuinely workspace-scoped. It is not, and this PR does not change that.
`vela billing summary` sends no workspace header at all (unlike
`collab`/`resource`/`team-projects`, which route through
`workspaceScopedClient`), and B's `GET /api/v1/billing/summary` only accepts
`timeZone` and resolves off the caller's `profile.id` — confirmed by reading
`powerformer/vela@c9346c4b` (`origin/feat/workspace-team` HEAD, includes
tonight's PR #951/#952/#959). A team member's balance will read identically
regardless of which workspace is active until vela grows a workspace-scoped
wallet summary endpoint. This fix only stops the number from being wrong by
4-5 orders of magnitude and mislabeled as USD — it does not claim to fix
workspace isolation.

## What users will see

Settings → Models & providers → Local CLI → the "Open Design" card's
"Balance" now shows the real USD figure vela reports (e.g. "$9.99") instead
of the raw credits count with a `$` slapped on it (e.g. "$99933.00"). No
other surface changes.

## Surface area

- [x] **UI** — existing Settings dialog field now formats the correct value; no new UI
- [ ] Keyboard shortcut
- [ ] CLI / env var — `od workspace billing` already prints `Credits:` and `Balance (USD):` separately and was never affected
- [ ] API / contract — no contract change; `balanceUsd` already existed on `WorkspaceBillingSummary`
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [ ] None

## Screenshots

Before (live dogfood owner account, `mashu@refly.ai`, FEATURE TEST workspace,
credits=99933 / balanceUsd=9.9933 — same bug pattern as the reported
$388307.00): "Balance $99933.00".

After (identical account/workspace, fixed code, throwaway verify instance
reusing the same vela session, no change to the running dogfood pair):
"Balance $9.99".

(Screenshots captured via ad hoc Playwright script against the live daemon
API — not committed to the repo; happy to attach as PR comment images if
useful for review.)

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/SettingsDialog.execution.test.tsx` → `prefers the workspace billing balance over the account-scoped wallet snapshot`
- Did the test go red on the unfixed code and green on this branch? **Yes.** Verified by reverting only the source file to `HEAD` while keeping the updated (realistic-numbers) test fixture — confirmed `1 failed` — then restoring the fix — confirmed `1 passed`.
- Additionally reproduced live: hit the real dogfood owner daemon's `/api/workspace/billing` (`totalAvailableCredits: 99933`, `balanceUsd: "9.9933"`) and drove the actual Settings UI via Playwright before and after the fix, matching the test's before/after exactly.

## Validation

- `pnpm --filter @open-design/web typecheck` — clean
- `pnpm guard` — clean (71/71)
- `apps/web` vitest: `SettingsDialog.execution.test.tsx`, `SettingsDialog.test.ts`, `InlineModelSwitcher.test.tsx`, `AvatarMenu.test.tsx`, `AmrBalanceDialog.test.tsx`, `AmrLowBalanceDialog.test.tsx` — 267/267 passed
- `apps/daemon` vitest: `vela-billing.test.ts` — 9/9 passed (daemon side untouched; confirms `balanceUsd` parsing already correct)