### PR TITLE
fix: upgrade tar to 7.5.19 (CVE-2026-59873)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
       "postcss": "8.5.15",
       "protobufjs": "8.4.0",
       "qs": "6.15.2",
+      "tar": "7.5.19",
       "tmp": "0.2.7",
       "yaml": "2.9.0"
     },
@@ -65,8 +66,5 @@
       "protobufjs",
       "sharp"
     ]
-  },
-  "dependencies": {
-    "tar": "7.5.19"
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,5 +65,8 @@
       "protobufjs",
       "sharp"
     ]
+  },
+  "dependencies": {
+    "tar": "7.5.19"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,10 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      tar:
+        specifier: 7.5.19
+        version: 7.5.19
     devDependencies:
       '@open-design/components':
         specifier: workspace:*
@@ -5863,6 +5867,10 @@ packages:
 
   tar@7.5.15:
     resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
+    engines: {node: '>=18'}
+
+  tar@7.5.19:
+    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
     engines: {node: '>=18'}
 
   tdigest@0.1.2:
@@ -12320,6 +12328,14 @@ snapshots:
       readable-stream: 3.6.2
 
   tar@7.5.15:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
+  tar@7.5.19:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,16 +13,13 @@ overrides:
   postcss: 8.5.15
   protobufjs: 8.4.0
   qs: 6.15.2
+  tar: 7.5.19
   tmp: 0.2.7
   yaml: 2.9.0
 
 importers:
 
   .:
-    dependencies:
-      tar:
-        specifier: 7.5.19
-        version: 7.5.19
     devDependencies:
       '@open-design/components':
         specifier: workspace:*
@@ -130,8 +127,8 @@ importers:
         specifier: 15.1.3
         version: 15.1.3
       tar:
-        specifier: 7.5.15
-        version: 7.5.15
+        specifier: 7.5.19
+        version: 7.5.19
       undici:
         specifier: 7.25.0
         version: 7.25.0
@@ -5865,10 +5862,6 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
-  tar@7.5.15:
-    resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
-    engines: {node: '>=18'}
-
   tar@7.5.19:
     resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
     engines: {node: '>=18'}
@@ -9013,7 +9006,7 @@ snapshots:
       proper-lockfile: 4.1.2
       resedit: 1.7.2
       semver: 7.7.4
-      tar: 7.5.15
+      tar: 7.5.19
       temp-file: 3.4.0
       tiny-async-pool: 1.3.0
       which: 5.0.0
@@ -11386,7 +11379,7 @@ snapshots:
       nopt: 9.0.0
       proc-log: 6.1.0
       semver: 7.7.4
-      tar: 7.5.15
+      tar: 7.5.19
       tinyglobby: 0.2.16
       undici: 6.25.0
       which: 6.0.1
@@ -12326,14 +12319,6 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
-
-  tar@7.5.15:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.1.0
-      yallist: 5.0.0
 
   tar@7.5.19:
     dependencies:


### PR DESCRIPTION
## Summary
Upgrade tar from 7.5.15 to 7.5.19 to fix CVE-2026-59873.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-59873 |
| **Severity** | CRITICAL |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-59873` |
| **File** | `pnpm-lock.yaml` |
| **Assessment** | Likely exploitable |

**Description**: tar: node-tar: Denial of Service via crafted gzip bomb

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-59873` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Surface area: None

## Changes
- `package.json`
- `pnpm-lock.yaml`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] Ran pnpm install to regenerate the lockfile — tar@7.5.19 is still resolved everywhere.

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
