### PR TITLE
fix(web): insert reselected skill before project update

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -1448,12 +1448,12 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
     }
 
     async function insertSkillMention(skill: SkillSummary) {
-      const applied = await applyProjectSkill(skill);
-      if (!applied) return;
       // Stage the skill so it rides this turn's skillIds, then insert an
       // atomic `@<name>` pill carrying the skill's real id. The onChange
       // prune keys on `skill:<id>` being present in the editor text, so the
-      // chip survives until the user deletes the pill.
+      // chip survives until the user deletes the pill. Do this before the
+      // project PATCH so a slow persistence request cannot make the picker
+      // look like it ignored the user's selection.
       setStagedSkills((prev) =>
         prev.some((s) => s.id === skill.id) ? prev : [...prev, skill],
       );
@@ -1462,6 +1462,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
         entity: { id: skill.id, kind: 'skill', label: skill.name },
       });
       setMention(null);
+      await applyProjectSkill(skill);
     }
 
     function stageSkillForCurrentTurn(skill: SkillSummary) {

--- a/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
+++ b/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
@@ -256,7 +256,10 @@ beforeEach(() => {
       });
     }
     if (url === '/api/projects/project-1' && init?.method === 'PATCH') {
-      const body = JSON.parse(String(init.body ?? '{}')) as { metadata?: unknown };
+      const body = JSON.parse(String(init.body ?? '{}')) as {
+        metadata?: unknown;
+        skillId?: string | null;
+      };
       if (rejectNextProjectPatch) {
         rejectNextProjectPatch = false;
         return new Response(JSON.stringify({
@@ -277,7 +280,7 @@ beforeEach(() => {
         project: {
           id: 'project-1',
           name: 'Project',
-          skillId: SKILL.id,
+          skillId: body.skillId === undefined ? SKILL.id : body.skillId,
           designSystemId: null,
           createdAt: 1,
           updatedAt: 1,
@@ -1055,6 +1058,40 @@ describe('ChatComposer context pickers', () => {
     fireEvent.click(screen.getByLabelText('Remove Deck Builder'));
     await waitFor(() => expect(composerText().trim()).toBe(''));
     expect(screen.queryByTestId('staged-contexts')).toBeNull();
+  });
+
+  it('inserts a newly selected skill immediately after the previous mention is deleted', async () => {
+    const nextSkill = makeSkill({
+      id: 'prototype-coach',
+      name: 'Prototype Coach',
+      description: 'Guide a product prototype.',
+      triggers: ['prototype'],
+    });
+    skills = [SKILL, nextSkill];
+    renderComposer();
+    await flushMounts();
+
+    await typeAndSettle('@deck');
+    fireEvent.click(await screen.findByText('Deck Builder'));
+    await waitFor(() => expect(composerText()).toBe('@Deck Builder '));
+
+    await typeAndSettle('');
+    await waitFor(() => expect(screen.queryByTestId('staged-contexts')).toBeNull());
+
+    deferNextProjectPatch = true;
+    fireEvent.click(screen.getByTestId('chat-plus-trigger'));
+    fireEvent.click(await screen.findByTestId('composer-plus-skills'));
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Prototype Coach' }));
+
+    await waitFor(() => expect(resolveDeferredProjectPatch).toBeTruthy());
+    const draftBeforeProjectPatchCompletes = composerText();
+    await act(async () => {
+      resolveDeferredProjectPatch?.();
+      await Promise.resolve();
+    });
+
+    expect(draftBeforeProjectPatchCompletes).toBe('@Prototype Coach ');
+    expect(screen.getByTestId('staged-contexts').textContent).toContain('@Prototype Coach');
   });
 
   it('shows all matching skills and ranks exact prefix matches first', async () => {


### PR DESCRIPTION
Fixes #2652

## Why

I picked up #2652 because deleting an inline skill reference and choosing another skill from the composer's bottom Skills menu could look like a no-op. The picker waited for the project skill PATCH before updating the draft, so a slow request left the input empty even though the user had already made a selection.

This keeps per-turn composer feedback responsive while preserving the existing project-skill persistence call.

## What users will see

After deleting an `@skill` mention, selecting another skill from the composer's bottom Skills menu inserts the new mention and context chip immediately. The project skill update continues in the background.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — the composer now reflects a skill selection before project persistence completes
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — this changes async insertion timing in an existing composer menu without changing layout or visual styling. The interaction is covered by the regression test below.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/ChatComposer.context-pickers.test.tsx`
- Did the test go red on `main` and green on this branch? **Yes.** Before the source change, the draft remained empty instead of containing `@Prototype Coach ` while the deliberately deferred project PATCH was pending. The same test passes after the source change.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web test` — 4,763 passed, 7 skipped
- Focused ChatComposer context-picker suite — 33/33 passed
