### PR TITLE
fix(manual-edit): confirm element deletion

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -8946,6 +8946,12 @@ function HtmlViewer({
   }, []);
   const [manualEditTargets, setManualEditTargets] = useState<ManualEditTarget[]>([]);
   const [selectedManualEditTarget, setSelectedManualEditTarget] = useState<ManualEditTarget | null>(null);
+  const selectedManualEditTargetRef = useRef<ManualEditTarget | null>(null);
+  const [manualEditDeleteConfirmationTargetId, setManualEditDeleteConfirmationTargetId] = useState<string | null>(null);
+  const manualEditDeleteConfirmationTargetIdRef = useRef<string | null>(null);
+  const manualEditDeleteConfirmationFileIdentityRef = useRef<string | null>(null);
+  const manualEditDeleteConfirmationSourceIncarnationRef = useRef<number | null>(null);
+  const manualEditDeleteAuthorizationEpochRef = useRef(0);
   const [manualEditHoverTarget, setManualEditHoverTarget] = useState<ManualEditTarget | null>(null);
   const [manualEditPageStylesOpen, setManualEditPageStylesOpen] = useState(false);
   const [manualEditPanelPosition, setManualEditPanelPosition] = useState<{ left: number; top: number } | null>(null);
@@ -8978,6 +8984,64 @@ function HtmlViewer({
   const manualEditStyleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const manualEditPreviewVersionRef = useRef(0);
   const sourceRef = useRef<string | null>(source);
+  const manualEditFileIdentity = `${sourceAuthorizationScopeKey ?? 'pending'}\0${projectId}\0${file.name}`;
+  const manualEditFileIdentityRef = useRef(manualEditFileIdentity);
+  manualEditFileIdentityRef.current = manualEditFileIdentity;
+  const manualEditModeRef = useRef(manualEditMode);
+  manualEditModeRef.current = manualEditMode;
+  const manualEditWorkspaceActiveRef = useRef(workspaceActive);
+  manualEditWorkspaceActiveRef.current = workspaceActive;
+  const manualEditOwnSourceWriteRef = useRef<string | null>(null);
+  const manualEditOwnRawRefreshPendingRef = useRef(false);
+  const markManualEditOwnSourceWrite = (nextSource: string | null) => {
+    manualEditOwnSourceWriteRef.current = nextSource;
+    manualEditOwnRawRefreshPendingRef.current = nextSource !== null && liveHtml === undefined;
+  };
+  const manualEditSourceSignal = liveHtml === undefined
+    ? `raw:${file.mtime}`
+    : `live:${liveHtml}`;
+  const manualEditSourceSignalRef = useRef(manualEditSourceSignal);
+  const manualEditSourceIncarnationRef = useRef(0);
+  if (manualEditSourceSignalRef.current !== manualEditSourceSignal) {
+    manualEditSourceSignalRef.current = manualEditSourceSignal;
+    const sourceChangeIsOurWrite = manualEditOwnSourceWriteRef.current !== null && (
+      liveHtml === manualEditOwnSourceWriteRef.current
+      || (
+        liveHtml === undefined
+        && manualEditOwnRawRefreshPendingRef.current
+        && sourceRef.current === manualEditOwnSourceWriteRef.current
+      )
+    );
+    if (sourceChangeIsOurWrite && liveHtml === undefined) {
+      manualEditOwnRawRefreshPendingRef.current = false;
+    }
+    if (!sourceChangeIsOurWrite) {
+      manualEditOwnSourceWriteRef.current = null;
+      manualEditSourceIncarnationRef.current += 1;
+    }
+  }
+  const manualEditSourceIncarnation = manualEditSourceIncarnationRef.current;
+  const updateManualEditDeleteConfirmation = useCallback((targetId: string | null) => {
+    manualEditDeleteAuthorizationEpochRef.current += 1;
+    manualEditDeleteConfirmationTargetIdRef.current = targetId;
+    manualEditDeleteConfirmationFileIdentityRef.current = targetId
+      ? manualEditFileIdentityRef.current
+      : null;
+    manualEditDeleteConfirmationSourceIncarnationRef.current = targetId
+      ? manualEditSourceIncarnationRef.current
+      : null;
+    setManualEditDeleteConfirmationTargetId(targetId);
+  }, []);
+  useEffect(() => {
+    updateManualEditDeleteConfirmation(null);
+  }, [manualEditFileIdentity, manualEditSourceIncarnation, updateManualEditDeleteConfirmation]);
+  useEffect(() => () => {
+    manualEditDeleteAuthorizationEpochRef.current += 1;
+    manualEditDeleteConfirmationTargetIdRef.current = null;
+    manualEditDeleteConfirmationFileIdentityRef.current = null;
+    manualEditDeleteConfirmationSourceIncarnationRef.current = null;
+    selectedManualEditTargetRef.current = null;
+  }, []);
   // Holds the last-good source snapshot taken just before reloadHtmlPreview
   // clears source to null on the srcDoc path.  The fetch effect restores this
   // value if fetchProjectFileText returns null (non-2xx / transient network
@@ -9044,6 +9108,8 @@ function HtmlViewer({
     setManualEditModeRaw(false);
     manualEditLiveStylesRef.current.clear();
     manualEditPendingStyleRef.current = null;
+    markManualEditOwnSourceWrite(null);
+    updateManualEditDeleteConfirmation(null);
     manualEditTextSessionIdRef.current = null;
     manualEditTextSessionStartSequenceRef.current = null;
     manualEditTextFinishRef.current = null;
@@ -12161,6 +12227,8 @@ function HtmlViewer({
     setManualEditViewportWidth(null);
     setManualEditTargets([]);
     setSelectedManualEditTarget(null);
+    selectedManualEditTargetRef.current = null;
+    updateManualEditDeleteConfirmation(null);
     setManualEditPanelPosition(null);
     selectedManualEditTargetIdRef.current = null;
     setManualEditDraft(emptyManualEditDraft());
@@ -12170,7 +12238,7 @@ function HtmlViewer({
     setManualEditError(null);
     manualEditPendingStyleRef.current = null;
     clearManualEditStyleTimer();
-  }, [file.name]);
+  }, [file.name, projectId, updateManualEditDeleteConfirmation]);
 
   // Selecting a new file or turning inspect/comment-inspect off resets the panel target.
   useEffect(() => {
@@ -12212,6 +12280,7 @@ function HtmlViewer({
 
   useEffect(() => {
     selectedManualEditTargetIdRef.current = selectedManualEditTarget?.id ?? null;
+    selectedManualEditTargetRef.current = selectedManualEditTarget;
   }, [selectedManualEditTarget?.id]);
 
   useEffect(() => {
@@ -12412,6 +12481,9 @@ function HtmlViewer({
     if (!manualEditMode) {
       setManualEditTargets([]);
       setSelectedManualEditTarget(null);
+      selectedManualEditTargetRef.current = null;
+      updateManualEditDeleteConfirmation(null);
+      markManualEditOwnSourceWrite(null);
       setManualEditHoverTarget(null);
       setManualEditPageStylesOpen(false);
       setManualEditPanelPosition(null);
@@ -12459,6 +12531,10 @@ function HtmlViewer({
       if (data.type === 'od-edit-select') {
         setManualEditHoverTarget(null);
         void selectManualEditTarget(data.target);
+        return;
+      }
+      if (data.type === 'od-edit-delete-request') {
+        requestManualEditTargetDelete(String(data.id));
         return;
       }
       if (data.type === 'od-edit-hover') {
@@ -12564,7 +12640,7 @@ function HtmlViewer({
     }
     window.addEventListener('message', onMessage);
     return () => window.removeEventListener('message', onMessage);
-  }, [isRetainedPreviewIframeSource, manualEditMode, source, workspaceActive]);
+  }, [isRetainedPreviewIframeSource, manualEditMode, source, updateManualEditDeleteConfirmation, workspaceActive]);
 
   function nextManualEditPreviewVersion(): number {
     manualEditPreviewVersionRef.current += 1;
@@ -12835,6 +12911,9 @@ function HtmlViewer({
     return () => onManualEditExitHandlerChange?.(file.name, null);
   }, [file.name, manualEditMode, onManualEditExitHandlerChange]);
   useEffect(() => {
+    if (!workspaceActive || !manualEditMode) updateManualEditDeleteConfirmation(null);
+  }, [manualEditMode, updateManualEditDeleteConfirmation, workspaceActive]);
+  useEffect(() => {
     if (workspaceActive || !manualEditMode) return;
     void requestManualEditSafeExitRef.current();
   }, [manualEditMode, workspaceActive]);
@@ -12851,12 +12930,14 @@ function HtmlViewer({
   }
 
   async function selectManualEditTarget(target: ManualEditTarget) {
+    updateManualEditDeleteConfirmation(null);
     setManualEditPageStylesOpen(false);
     if (manualEditPendingStyleRef.current?.id !== target.id) cancelManualEditStyleDraft();
     const base = sourceRef.current ?? '';
     const nextDraft = manualEditDraftForTarget(target, base);
     selectedManualEditTargetIdRef.current = target.id;
     manualEditSelectionDraftRef.current = { id: target.id, draft: nextDraft };
+    selectedManualEditTargetRef.current = target;
     setSelectedManualEditTarget(target);
     setManualEditDraft(nextDraft);
     setManualEditDraftDirty(false);
@@ -12878,6 +12959,7 @@ function HtmlViewer({
   }
 
   async function clearManualEditTargetSelection() {
+    updateManualEditDeleteConfirmation(null);
     // If an inline edit is still live (e.g. clearing the selection from the
     // panel mid-edit), commit it first so it is not lost. Keep the selection
     // and the error if that commit fails.
@@ -12887,6 +12969,7 @@ function HtmlViewer({
     cancelManualEditStyleDraft();
     selectedManualEditTargetIdRef.current = null;
     manualEditSelectionDraftRef.current = null;
+    selectedManualEditTargetRef.current = null;
     manualEditTextSessionIdRef.current = null;
     manualEditTextSessionStartSequenceRef.current = null;
     setSelectedManualEditTarget(null);
@@ -13064,7 +13147,14 @@ function HtmlViewer({
     }
   }
 
-  async function applyManualEdit(patch: ManualEditPatch, label: string): Promise<boolean> {
+  async function applyManualEdit(
+    patch: ManualEditPatch,
+    label: string,
+    options?: {
+      expectedParentVersionId?: string | null;
+      revalidateBeforeWrite?: () => boolean;
+    },
+  ): Promise<boolean> {
     const startedAt = performance.now();
     let resultTracked = false;
     const finish = (
@@ -13097,11 +13187,19 @@ function HtmlViewer({
       if (!(await confirmManualEditHistorySource(
         baseSource,
         'The file changed outside manual edit mode. Refreshing before applying manual edits.',
+        { failClosedOnUnavailable: patch.kind === 'remove-element' },
       ))) {
         finish('failed', 'source_conflict');
         return false;
       }
       const parentVersionId = await resolveManualEditParentVersionId(baseSource);
+      if (
+        options?.expectedParentVersionId !== undefined
+        && (parentVersionId ?? null) !== options.expectedParentVersionId
+      ) {
+        finish('failed', 'source_conflict');
+        return false;
+      }
       // A committed content patch can notify the file watcher as soon as the
       // write lands. Capture the opaque iframe's exact scroll position before
       // that write so neither the watcher nor our local source update can
@@ -13109,6 +13207,12 @@ function HtmlViewer({
       // live through postMessage and never reload.
       if (patch.kind !== 'set-style') {
         await capturePreviewScrollPosition();
+      }
+      // Keep destructive-action authorization as the final synchronous guard:
+      // the awaited scroll capture above may allow the selection or source to change.
+      if (options?.revalidateBeforeWrite && !options.revalidateBeforeWrite()) {
+        finish('failed', 'source_conflict');
+        return false;
       }
       const saved = await writeProjectTextFileDetailed(projectId, file.name, result.source, {
         artifactManifest: file.artifactManifest,
@@ -13136,6 +13240,7 @@ function HtmlViewer({
       };
       setSource(result.source);
       sourceRef.current = result.source;
+      markManualEditOwnSourceWrite(result.source);
       setInlinedSource(null);
       if (patch.kind !== 'set-style') {
         setManualEditFrozenSource(result.source);
@@ -13165,6 +13270,7 @@ function HtmlViewer({
         }
         selectedManualEditTargetIdRef.current = null;
         manualEditSelectionDraftRef.current = null;
+        selectedManualEditTargetRef.current = null;
         setSelectedManualEditTarget(null);
         setManualEditTargets((current) => current.filter((target) => target.id !== patch.id));
         setManualEditDraft(emptyManualEditDraft(result.source));
@@ -13203,13 +13309,24 @@ function HtmlViewer({
     }
   }
 
-  async function confirmManualEditHistorySource(expectedSource: string, message: string): Promise<boolean> {
+  async function confirmManualEditHistorySource(
+    expectedSource: string,
+    message: string,
+    options?: { failClosedOnUnavailable?: boolean },
+  ): Promise<boolean> {
     const persisted = await fetchProjectFileText(projectId, file.name, {
       cache: 'no-store',
       cacheBustKey: Date.now(),
       workspaceContext,
     });
-    if (persisted == null || persisted === expectedSource) return true;
+    if (persisted == null) {
+      if (options?.failClosedOnUnavailable) {
+        setManualEditError(message);
+        return false;
+      }
+      return true;
+    }
+    if (persisted === expectedSource) return true;
     setSource(persisted);
     sourceRef.current = persisted;
     setInlinedSource(null);
@@ -13220,6 +13337,49 @@ function HtmlViewer({
     setManualEditDraft((current) => ({ ...current, fullSource: persisted }));
     setManualEditError(message);
     return false;
+  }
+
+  async function settleManualEditDeleteBoundary(): Promise<boolean> {
+    if (!(await settlePendingManualEditCommit())) return false;
+    if (!(await flushManualEditStyleSave())) return false;
+    return !manualEditSavingRef.current;
+  }
+
+  async function removeManualEditTarget(id: string) {
+    const fileIdentity = manualEditFileIdentityRef.current;
+    const authorizationEpoch = manualEditDeleteAuthorizationEpochRef.current;
+    const sourceIncarnation = manualEditSourceIncarnationRef.current;
+    const contextIsCurrent = () => (
+      manualEditFileIdentityRef.current === fileIdentity
+      && manualEditDeleteAuthorizationEpochRef.current === authorizationEpoch
+      && manualEditSourceIncarnationRef.current === sourceIncarnation
+      && manualEditModeRef.current
+      && manualEditWorkspaceActiveRef.current
+      && selectedManualEditTargetRef.current?.id === id
+    );
+    if (!(await settleManualEditDeleteBoundary())) return;
+    if (!contextIsCurrent()) return;
+    const baseSource = sourceRef.current;
+    if (baseSource == null) return;
+    const expectedParentVersionId = await resolveManualEditParentVersionId(baseSource) ?? null;
+    const deletionAuthorizationIsCurrent = () => (
+      contextIsCurrent()
+      && sourceRef.current === baseSource
+    );
+    if (!deletionAuthorizationIsCurrent()) return;
+    await applyManualEdit(
+      { id, kind: 'remove-element' },
+      t('manualEdit.deleteElement'),
+      {
+        expectedParentVersionId,
+        revalidateBeforeWrite: deletionAuthorizationIsCurrent,
+      },
+    );
+  }
+
+  function requestManualEditTargetDelete(id: string) {
+    if (selectedManualEditTargetRef.current?.id !== id) return;
+    updateManualEditDeleteConfirmation(id);
   }
 
   function describeManualEditSaveFailure(
@@ -13274,6 +13434,7 @@ function HtmlViewer({
       await capturePreviewScrollPosition();
       setSource(latest.beforeSource);
       sourceRef.current = latest.beforeSource;
+      markManualEditOwnSourceWrite(latest.beforeSource);
       setInlinedSource(null);
       syncRetainedManualEditDocument(
         latest.beforeSource,
@@ -13338,6 +13499,7 @@ function HtmlViewer({
       await capturePreviewScrollPosition();
       setSource(latest.afterSource);
       sourceRef.current = latest.afterSource;
+      markManualEditOwnSourceWrite(latest.afterSource);
       setInlinedSource(null);
       syncRetainedManualEditDocument(
         latest.afterSource,
@@ -15643,6 +15805,20 @@ function HtmlViewer({
       onInvalidStyle={cancelManualEditPendingStyles}
       onApplyPatch={(patch, label) => {
         void applyManualEdit(patch, label);
+      }}
+      deleteConfirmationTargetId={manualEditDeleteConfirmationTargetId}
+      onDeleteConfirmationChange={updateManualEditDeleteConfirmation}
+      onConfirmDelete={(targetId) => {
+        if (
+          manualEditDeleteConfirmationTargetIdRef.current !== targetId
+          || manualEditDeleteConfirmationFileIdentityRef.current !== manualEditFileIdentityRef.current
+          || manualEditDeleteConfirmationSourceIncarnationRef.current !== manualEditSourceIncarnationRef.current
+          || selectedManualEditTargetRef.current?.id !== targetId
+          || !manualEditModeRef.current
+          || !manualEditWorkspaceActiveRef.current
+        ) return;
+        updateManualEditDeleteConfirmation(null);
+        void removeManualEditTarget(targetId);
       }}
       onError={setManualEditError}
       onClearSelection={() => {

--- a/apps/web/src/components/ManualEditPanel.tsx
+++ b/apps/web/src/components/ManualEditPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react';
+import { useCallback, useEffect, useId, useRef, useState, type CSSProperties, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react';
 import type { ProjectDesignTokenSuggestion, ProjectDesignTokenSuggestionProp } from '../providers/registry';
 import { useT } from '../i18n';
 import { emptyManualEditStyles, type ManualEditHistoryEntry, type ManualEditPatch, type ManualEditStyles, type ManualEditTarget } from '../edit-mode/types';
@@ -42,6 +42,9 @@ export function ManualEditPanel({
   onRedo,
   onExit,
   onApplyPatch,
+  deleteConfirmationTargetId,
+  onDeleteConfirmationChange,
+  onConfirmDelete,
   onPickImage,
   tokenSuggestions = [],
   tokenSuggestionsLoading = false,
@@ -69,6 +72,9 @@ export function ManualEditPanel({
   onStyleChange?: (id: string, styles: Partial<ManualEditStyles>, label: string) => void;
   onInvalidStyle?: (id: string, keys: Array<keyof ManualEditStyles>) => void;
   onApplyPatch: (patch: ManualEditPatch, label: string) => void;
+  deleteConfirmationTargetId?: string | null;
+  onDeleteConfirmationChange?: (targetId: string | null) => void;
+  onConfirmDelete?: (targetId: string) => void;
   onPickImage?: (file: File) => Promise<string | null>;
   tokenSuggestions?: ProjectDesignTokenSuggestion[];
   tokenSuggestionsLoading?: boolean;
@@ -92,17 +98,37 @@ export function ManualEditPanel({
 }) {
   const t = useT();
   const [uploadingImage, setUploadingImage] = useState(false);
+  const [localDeleteConfirmationTargetId, setLocalDeleteConfirmationTargetId] = useState<string | null>(null);
   // Pin toggle: draggable (pin pulled out) vs locked/fixed (pin pushed in).
   // The lock lives in the parent so it can ALSO freeze the panel's position —
   // a locked panel never follows the selected element.
   const dragEnabled = !locked;
   const selectedTargetRef = useRef<ManualEditTarget | null>(selectedTarget);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const deleteButtonRef = useRef<HTMLButtonElement | null>(null);
+  const restoreDeleteFocusRef = useRef(false);
+  const deleteConfirmationMessageId = useId();
+  const deleteConfirmationControlled = deleteConfirmationTargetId !== undefined;
+  const confirmDeleteTargetId = deleteConfirmationControlled
+    ? deleteConfirmationTargetId
+    : localDeleteConfirmationTargetId;
+  const updateDeleteConfirmation = useCallback((targetId: string | null) => {
+    if (!deleteConfirmationControlled) setLocalDeleteConfirmationTargetId(targetId);
+    onDeleteConfirmationChange?.(targetId);
+  }, [deleteConfirmationControlled, onDeleteConfirmationChange]);
   const targetForInspector = selectedTarget;
   const panelTitle = targetForInspector ? readableManualEditTargetName(targetForInspector) : t('manualEdit.fallbackTitle');
   useEffect(() => {
     selectedTargetRef.current = selectedTarget;
   }, [selectedTarget]);
+  useEffect(() => {
+    if (!deleteConfirmationControlled) updateDeleteConfirmation(null);
+  }, [selectedTarget?.id, deleteConfirmationControlled, updateDeleteConfirmation]);
+  useEffect(() => {
+    if (confirmDeleteTargetId !== null || !restoreDeleteFocusRef.current) return;
+    restoreDeleteFocusRef.current = false;
+    deleteButtonRef.current?.focus();
+  }, [confirmDeleteTargetId]);
 
   const changeTargetStyle = (key: keyof ManualEditStyles, value: string) => {
     const nextStyles = { ...draft.styles, [key]: value };
@@ -327,55 +353,89 @@ export function ManualEditPanel({
               >
                 <Icon name="redo" size={15} />
               </button>
-              {targetForInspector ? (
+              {targetForInspector && confirmDeleteTargetId === targetForInspector.id ? (
+                <div className="manual-edit-delete-confirm">
+                  <span id={deleteConfirmationMessageId}>{t('manualEdit.deleteElementConfirm')}</span>
+                  <button
+                    type="button"
+                    className="manual-edit-footer-btn danger manual-edit-delete-confirm-action"
+                    aria-describedby={deleteConfirmationMessageId}
+                    autoFocus
+                    disabled={busy}
+                    onClick={() => {
+                      restoreDeleteFocusRef.current = true;
+                      if (onConfirmDelete) {
+                        onConfirmDelete(confirmDeleteTargetId);
+                      } else {
+                        updateDeleteConfirmation(null);
+                        onApplyPatch(
+                          { id: confirmDeleteTargetId, kind: 'remove-element' },
+                          t('manualEdit.deleteElement'),
+                        );
+                      }
+                    }}
+                  >
+                    {t('manualEdit.deleteElement')}
+                  </button>
+                  <button
+                    type="button"
+                    className="manual-edit-footer-btn subtle"
+                    disabled={busy}
+                    onClick={() => {
+                      restoreDeleteFocusRef.current = true;
+                      updateDeleteConfirmation(null);
+                    }}
+                  >
+                    {t('common.cancel')}
+                  </button>
+                </div>
+              ) : targetForInspector ? (
                 <button
+                  ref={deleteButtonRef}
                   type="button"
                   className="manual-edit-delete-btn"
                   aria-label={t('manualEdit.deleteElement')}
                   title={t('manualEdit.deleteElement')}
                   disabled={busy}
-                  onClick={() => {
-                    onApplyPatch(
-                      { id: targetForInspector.id, kind: 'remove-element' },
-                      t('manualEdit.deleteElement'),
-                    );
-                  }}
+                  onClick={() => updateDeleteConfirmation(targetForInspector.id)}
                 >
                   <Icon name="trash" size={15} />
                 </button>
               ) : null}
             </div>
-            <div className="manual-edit-footer-right">
-              {resetAvailable ? (
+            {targetForInspector && confirmDeleteTargetId === targetForInspector.id ? null : (
+              <div className="manual-edit-footer-right">
+                {resetAvailable ? (
+                  <button
+                    type="button"
+                    className="manual-edit-footer-btn subtle"
+                    disabled={busy}
+                    onClick={onResetDraft}
+                  >
+                    {t('ds.reset')}
+                  </button>
+                ) : null}
                 <button
                   type="button"
                   className="manual-edit-footer-btn subtle"
                   disabled={busy}
-                  onClick={onResetDraft}
+                  onClick={onCancelDraft}
                 >
-                  {t('ds.reset')}
+                  {t('common.cancel')}
                 </button>
-              ) : null}
-              <button
-                type="button"
-                className="manual-edit-footer-btn subtle"
-                disabled={busy}
-                onClick={onCancelDraft}
-              >
-                {t('common.cancel')}
-              </button>
-              <button
-                type="button"
-                className="manual-edit-footer-btn primary"
-                disabled={busy}
-                onClick={onSaveDraft}
-              >
-                {t('common.save')}
-              </button>
-            </div>
+                <button
+                  type="button"
+                  className="manual-edit-footer-btn primary"
+                  disabled={busy}
+                  onClick={onSaveDraft}
+                >
+                  {t('common.save')}
+                </button>
+              </div>
+            )}
           </div>
 
-          {error ? <div className="manual-edit-error">{error}</div> : null}
+          {error ? <div className="manual-edit-error" role="alert">{error}</div> : null}
         </div>
       </section>
     </aside>

--- a/apps/web/src/edit-mode/bridge.ts
+++ b/apps/web/src/edit-mode/bridge.ts
@@ -544,7 +544,6 @@ export function buildManualEditBridge(enabled: boolean): string {
     if (layer) return layer;
     layer = document.createElement('div');
     layer.setAttribute('data-od-edit-guides-layer', 'true');
-    layer.setAttribute('aria-hidden', 'true');
     document.body.appendChild(layer);
     return layer;
   }
@@ -555,6 +554,7 @@ export function buildManualEditBridge(enabled: boolean): string {
   function addGuideNode(layer, className, style, text){
     var node = document.createElement('div');
     node.className = className;
+    node.setAttribute('aria-hidden', 'true');
     Object.keys(style || {}).forEach(function(key){ node.style[key] = style[key]; });
     if (text) node.textContent = text;
     layer.appendChild(node);
@@ -589,6 +589,18 @@ export function buildManualEditBridge(enabled: boolean): string {
         top: Math.round(points[i][1]) + 'px'
       });
     }
+    var deleteAction = document.createElement('button');
+    deleteAction.type = 'button';
+    deleteAction.className = 'od-edit-selection-action od-edit-selection-action-danger';
+    deleteAction.setAttribute('data-od-edit-delete-action', target.id);
+    deleteAction.setAttribute('aria-label', 'Delete element');
+    deleteAction.title = 'Delete element';
+    deleteAction.textContent = 'Delete';
+    deleteAction.style.left = Math.max(8, Math.min(window.innerWidth - 76, rect.x + rect.width / 2 - 34)) + 'px';
+    deleteAction.style.top = (rect.y >= 42
+      ? rect.y - 38
+      : Math.min(window.innerHeight - 36, rect.y + rect.height + 8)) + 'px';
+    layer.appendChild(deleteAction);
   }
   function renderSelectedChromeForCurrent(){
     if (!enabled || !guidesEnabled || !selectedTargetId) {
@@ -1046,6 +1058,18 @@ export function buildManualEditBridge(enabled: boolean): string {
   document.addEventListener('click', function(ev){
     if (!enabled) return;
     if (justDragged) { justDragged = false; ev.preventDefault(); ev.stopPropagation(); return; }
+    var deleteAction = ev.target && ev.target.closest
+      ? ev.target.closest('[data-od-edit-delete-action]')
+      : null;
+    if (deleteAction) {
+      ev.preventDefault();
+      ev.stopPropagation();
+      window.parent.postMessage({
+        type: 'od-edit-delete-request',
+        id: deleteAction.getAttribute('data-od-edit-delete-action') || ''
+      }, '*');
+      return;
+    }
     if (ev.target && ev.target.closest && ev.target.closest('[data-od-editing="true"]')) return;
     ev.preventDefault();
     ev.stopPropagation();
@@ -1134,6 +1158,7 @@ export function buildManualEditBridge(enabled: boolean): string {
   }, true);
   document.addEventListener('pointerover', function(ev){
     if (!enabled) return;
+    if (ev.target && ev.target.closest && ev.target.closest('[data-od-edit-delete-action]')) return;
     // A drag in progress owns the overlay (selection chrome only); pointerover
     // must not surface hover reference guides that would clutter the move.
     if (dragPending && dragPending.started) return;
@@ -1157,6 +1182,7 @@ export function buildManualEditBridge(enabled: boolean): string {
   }, true);
   document.addEventListener('pointermove', function(ev){
     if (!enabled) return;
+    if (ev.target && ev.target.closest && ev.target.closest('[data-od-edit-delete-action]')) return;
     // Active/candidate drag takes over pointermove: translate the element live
     // and skip the hover-guides bookkeeping below.
     if (dragPending) {
@@ -1250,6 +1276,18 @@ export function buildManualEditBridge(enabled: boolean): string {
   // is editing a text element.
   var screenshotTap = { at: 0, left: false, right: false };
   document.documentElement.addEventListener('keydown', function(ev){
+    if (!enabled || activeTextEdit || !selectedTargetId) return;
+    if (ev.key !== 'Delete' && ev.key !== 'Backspace') return;
+    var origin = ev.target;
+    if (origin && (
+      origin.isContentEditable
+      || /^(INPUT|TEXTAREA|SELECT)$/.test(String(origin.tagName || ''))
+    )) return;
+    ev.preventDefault();
+    ev.stopPropagation();
+    window.parent.postMessage({ type: 'od-edit-delete-request', id: selectedTargetId }, '*');
+  }, true);
+  document.documentElement.addEventListener('keydown', function(ev){
     if (!enabled) return;
     if (ev.key !== 'Meta') {
       screenshotTap.at = 0;
@@ -1332,6 +1370,24 @@ html[data-od-edit-mode] [data-od-editing="true"] {
   border-radius: 999px;
   background: Canvas;
   box-sizing: border-box;
+}
+[data-od-edit-guides-layer] .od-edit-selection-action {
+  position: fixed;
+  height: 30px;
+  padding: 0 10px;
+  border: 1px solid color-mix(in srgb, CanvasText 18%, transparent);
+  border-radius: 8px;
+  background: Canvas;
+  color: CanvasText;
+  box-shadow: 0 4px 14px color-mix(in srgb, CanvasText 18%, transparent);
+  cursor: pointer !important;
+  font: 600 12px/1 Inter, system-ui, sans-serif;
+  pointer-events: auto;
+}
+[data-od-edit-guides-layer] .od-edit-selection-action-danger:hover {
+  border-color: color-mix(in srgb, #ef4444 45%, transparent);
+  background: color-mix(in srgb, #ef4444 10%, Canvas);
+  color: #dc2626;
 }
 [data-od-edit-guides-layer] .od-edit-guide-line {
   position: fixed;

--- a/apps/web/src/edit-mode/types.ts
+++ b/apps/web/src/edit-mode/types.ts
@@ -178,6 +178,11 @@ export interface ManualEditTextSessionMessage {
   committed?: boolean;
 }
 
+export interface ManualEditDeleteRequestMessage {
+  type: 'od-edit-delete-request';
+  id: string;
+}
+
 /** Free drag-to-reposition finished: the element's new translate() value, to
  *  be committed as a pending style so the panel's Save persists it. */
 export interface ManualEditDragCommitMessage {
@@ -199,6 +204,7 @@ export type ManualEditBridgeMessage =
   | ManualEditPreviewAppliedMessage
   | ManualEditTextCommitMessage
   | ManualEditTextSessionMessage
+  | ManualEditDeleteRequestMessage
   | ManualEditDragCommitMessage;
 
 export const MANUAL_EDIT_STYLE_PROPS: readonly (keyof ManualEditStyles)[] = [

--- a/apps/web/src/styles/viewer/memory.css
+++ b/apps/web/src/styles/viewer/memory.css
@@ -1408,16 +1408,18 @@
 .manual-edit-delete-confirm {
   display: flex;
   align-items: center;
+  flex: 1 1 100%;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 6px;
   min-width: 0;
 }
 .manual-edit-delete-confirm span {
-  max-width: 170px;
-  overflow: hidden;
+  flex: 1 0 100%;
+  min-width: 0;
   color: var(--text-muted);
   font-size: 12px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  line-height: 1.35;
 }
 .manual-edit-floating .manual-edit-titlebar {
   min-height: 48px;

--- a/apps/web/tests/components/FileViewer.manual-edit.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit.test.tsx
@@ -140,6 +140,17 @@ describe('FileViewer manual edit regressions', () => {
     });
   }
 
+  async function requestManualEditDelete(id = 'hero') {
+    const frame = await previewFrame();
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'od-edit-delete-request', id },
+        source: frame.contentWindow,
+      }));
+    });
+    await screen.findByText('Delete selected element? This can be undone with Undo.');
+  }
+
   it('removes invalid fields from pending manual edit style saves without dropping unrelated fields', () => {
     expect(cancelManualEditPendingStyleSnapshot({
       id: 'hero',
@@ -696,6 +707,188 @@ describe('FileViewer manual edit regressions', () => {
     expect(payload.content).not.toContain('<main data-od-id="hero">Hero</main>');
   });
 
+  it('opens confirmation for an iframe Delete request and preserves a dirty draft on cancel', async () => {
+    const source = '<!doctype html><html><body><main data-od-id="hero">Hero</main><footer data-od-id="keep">Keep</footer></body></html>';
+    const savedBodies: Array<{ content: string; versionLabel?: string; versionSource?: string }> = [];
+    vi.stubGlobal('fetch', manualEditDeleteFetch(source, savedBodies));
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={source}
+      />,
+    );
+
+    await enterManualEditMode();
+    await selectManualEditTarget();
+    fireEvent.change(screen.getByLabelText('Text'), { target: { value: 'Unsaved hero draft' } });
+
+    await requestManualEditDelete();
+    expect(savedBodies).toHaveLength(0);
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect((screen.getByLabelText('Text') as HTMLTextAreaElement).value).toBe('Unsaved hero draft');
+    expect(screen.queryByText('Delete selected element? This can be undone with Undo.')).toBeNull();
+    expect(savedBodies).toHaveLength(0);
+  });
+
+  it('routes inspector trash through confirmation before guarded undoable removal', async () => {
+    const source = '<!doctype html><html><body><main data-od-id="hero">Hero</main><footer data-od-id="keep">Keep</footer></body></html>';
+    const savedBodies: Array<{ content: string; versionLabel?: string; versionSource?: string }> = [];
+    vi.stubGlobal('fetch', manualEditDeleteFetch(source, savedBodies));
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={source}
+      />,
+    );
+
+    await enterManualEditMode();
+    await selectManualEditTarget();
+    fireEvent.click(screen.getByLabelText('Delete element'));
+
+    expect(await screen.findByText('Delete selected element? This can be undone with Undo.')).toBeTruthy();
+    expect(savedBodies).toHaveLength(0);
+    fireEvent.click(screen.getByRole('button', { name: 'Delete element' }));
+
+    await waitFor(() => expect(savedBodies).toHaveLength(1));
+    expect(savedBodies[0]!.content).not.toContain('data-od-id="hero"');
+    expect(savedBodies[0]!.content).toContain('data-od-id="keep"');
+    expect(savedBodies[0]!.versionSource).toBe('manual');
+    expect(savedBodies[0]!.versionLabel).toBe('Delete element');
+  });
+
+  it.each(['target', 'file', 'project', 'source incarnation', 'mode', 'lifecycle'] as const)(
+    'invalidates an asynchronous confirmed deletion when the %s changes',
+    async (boundary) => {
+      const source = '<!doctype html><html><body><main data-od-id="hero">Hero</main><footer data-od-id="keep">Keep</footer></body></html>';
+      const replacementSource = '<!doctype html><html><body><main data-od-id="hero">Replacement</main><footer data-od-id="keep">Keep</footer></body></html>';
+      let releaseParentVersion!: () => void;
+      const parentVersionGate = new Promise<void>((resolve) => { releaseParentVersion = resolve; });
+      let parentVersionReads = 0;
+      const savedBodies: Array<{ content: string }> = [];
+      const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+        if (url.includes('/versions')) {
+          parentVersionReads += 1;
+          if (parentVersionReads === 1) await parentVersionGate;
+          return new Response(JSON.stringify({ versions: [] }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        if (url.endsWith('/api/projects/project-1/files') && init?.method === 'POST') {
+          savedBodies.push(JSON.parse(String(init.body)) as { content: string });
+          return new Response(JSON.stringify({ file: htmlPreviewFile() }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        if (url.includes('/raw/')) return new Response(source, { status: 200 });
+        return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+      });
+      vi.stubGlobal('fetch', fetchMock);
+      const initialFile = htmlPreviewFile();
+      const view = render(
+        <FileViewer projectId="project-1" projectKind="prototype" file={initialFile} liveHtml={source} />,
+      );
+
+      await enterManualEditMode();
+      await selectManualEditTarget();
+      await requestManualEditDelete();
+      fireEvent.click(screen.getByRole('button', { name: 'Delete element' }));
+      await waitFor(() => expect(parentVersionReads).toBe(1));
+
+      if (boundary === 'target') {
+        const frame = await previewFrame();
+        act(() => {
+          window.dispatchEvent(new MessageEvent('message', {
+            data: { type: 'od-edit-select', target: footerTarget() },
+            source: frame.contentWindow,
+          }));
+        });
+      } else if (boundary === 'file') {
+        const nextFile = { ...initialFile, name: 'second.html', path: 'second.html' };
+        view.rerender(
+          <FileViewer projectId="project-1" projectKind="prototype" file={nextFile} liveHtml={replacementSource} />,
+        );
+      } else if (boundary === 'project') {
+        view.rerender(
+          <FileViewer projectId="project-2" projectKind="prototype" file={initialFile} liveHtml={replacementSource} />,
+        );
+      } else if (boundary === 'source incarnation') {
+        view.rerender(
+          <FileViewer
+            projectId="project-1"
+            projectKind="prototype"
+            file={{ ...initialFile, mtime: initialFile.mtime + 1 }}
+            liveHtml={replacementSource}
+          />,
+        );
+      } else if (boundary === 'mode') {
+        clickManualTool('manual-edit-mode-toggle');
+        await waitFor(() => {
+          expect(screen.getByTestId('manual-edit-mode-toggle').getAttribute('aria-pressed')).toBe('false');
+        });
+      } else {
+        view.unmount();
+      }
+
+      await act(async () => {
+        releaseParentVersion();
+        await parentVersionGate;
+        await new Promise((resolve) => setTimeout(resolve, 30));
+      });
+
+      expect(savedBodies).toHaveLength(0);
+    },
+  );
+
+  it('invalidates deletion when the current parent version changes before write', async () => {
+    const source = '<!doctype html><html><body><main data-od-id="hero">Hero</main><footer data-od-id="keep">Keep</footer></body></html>';
+    const digest = '630c9db1323ad244aaa91cccecea19c509fc5fb3988831172730e9afe109452a';
+    let versionReads = 0;
+    const savedBodies: Array<{ content: string }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      if (url.includes('/versions')) {
+        versionReads += 1;
+        return new Response(JSON.stringify({
+          versions: [{
+            id: versionReads === 1 ? 'v1' : 'v2',
+            fileName: 'preview.html',
+            version: versionReads,
+            label: 'Current',
+            createdAt: 1,
+            source: 'manual',
+            prompt: null,
+            size: source.length,
+            mime: 'text/html',
+            kind: 'html',
+            current: true,
+            contentDigest: digest,
+          }],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (url.endsWith('/api/projects/project-1/files') && init?.method === 'POST') {
+        savedBodies.push(JSON.parse(String(init.body)) as { content: string });
+        return new Response(JSON.stringify({ file: htmlPreviewFile() }), { status: 200 });
+      }
+      if (url.includes('/raw/')) return new Response(source, { status: 200 });
+      return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }));
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()} liveHtml={source} />,
+    );
+    await enterManualEditMode();
+    await selectManualEditTarget();
+    await requestManualEditDelete();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete element' }));
+
+    await waitFor(() => expect(versionReads).toBe(2));
+    expect(savedBodies).toHaveLength(0);
+  });
+
   it('keeps the preview mounted and does not save when deleting the only rendered root', async () => {
     const source = '<!doctype html><html><body><main data-od-id="app-root">App</main><script>window.bootApp && window.bootApp();</script></body></html>';
     const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
@@ -726,6 +919,8 @@ describe('FileViewer manual edit regressions', () => {
     });
 
     fireEvent.click(screen.getByLabelText('Delete element'));
+    expect(await screen.findByText('Delete selected element? This can be undone with Undo.')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete element' }));
 
     await waitFor(() => {
       expect(screen.getByText('Cannot remove the last rendered element in the document.')).toBeTruthy();
@@ -737,6 +932,38 @@ describe('FileViewer manual edit regressions', () => {
     );
   });
 });
+
+function manualEditDeleteFetch(
+  source: string,
+  savedBodies: Array<{ content: string; versionLabel?: string; versionSource?: string }>,
+) {
+  let persistedSource = source;
+  return vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+    if (url.includes('/versions')) {
+      return new Response(JSON.stringify({ versions: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.endsWith('/api/projects/project-1/files') && init?.method === 'POST') {
+      const body = JSON.parse(String(init.body)) as { content: string; versionLabel?: string; versionSource?: string };
+      savedBodies.push(body);
+      persistedSource = body.content;
+      return new Response(JSON.stringify({ file: htmlPreviewFile() }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.includes('/api/projects/project-1/raw/preview.html')) {
+      return new Response(persistedSource, {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      });
+    }
+    return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+  });
+}
 
 function heroTarget(): ManualEditTarget {
   return {
@@ -752,6 +979,19 @@ function heroTarget(): ManualEditTarget {
     styles: emptyManualEditStyles(),
     isLayoutContainer: false,
     outerHtml: '<main data-od-id="hero">Hero</main>',
+  };
+}
+
+function footerTarget(): ManualEditTarget {
+  return {
+    ...heroTarget(),
+    id: 'keep',
+    kind: 'container',
+    label: 'Footer',
+    tagName: 'footer',
+    text: 'Keep',
+    attributes: { 'data-od-id': 'keep' },
+    outerHtml: '<footer data-od-id="keep">Keep</footer>',
   };
 }
 

--- a/apps/web/tests/components/ManualEditPanel.test.tsx
+++ b/apps/web/tests/components/ManualEditPanel.test.tsx
@@ -32,6 +32,7 @@ type OnDraftChange = (draft: ManualEditDraft) => void;
 type OnStyleChange = (id: string, styles: Partial<ManualEditStyles>, label: string) => void;
 type OnInvalidStyle = (id: string, keys: Array<keyof ManualEditStyles>) => void;
 type OnApplyPatch = (patch: ManualEditPatch, label: string) => void;
+type OnConfirmDelete = (targetId: string) => void;
 type OnError = (message: string) => void;
 type OnClearSelection = () => void;
 type OnSaveDraft = () => void;
@@ -126,21 +127,28 @@ describe('ManualEditPanel', () => {
     expect(footer?.textContent).toContain('Save');
   });
 
-  it('routes delete as a direct icon-only action', () => {
+  it('requires confirmation before deleting an element', () => {
     const onApplyPatch = vi.fn<OnApplyPatch>();
     renderPanel({ onApplyPatch });
 
-    const footer = host.querySelector('.manual-edit-footer');
-    const deleteButton = host.querySelector('button[aria-label="Delete element"]') as HTMLButtonElement | null;
-    if (!deleteButton) throw new Error('Delete button not found');
+    clickDeleteButton();
 
-    act(() => {
-      deleteButton.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
-    });
+    expect(onApplyPatch).not.toHaveBeenCalled();
+    expect(host.querySelector('.manual-edit-delete-confirm')?.textContent).toContain(
+      'Delete selected element? This can be undone with Undo.',
+    );
+    expect(host.textContent).not.toContain('Save');
+  });
 
-    expect(footer?.contains(deleteButton)).toBe(true);
-    expect(deleteButton.textContent).toBe('');
-    expect(deleteButton.className).toContain('manual-edit-delete-btn');
+  it('deletes only after explicit confirmation', () => {
+    const onApplyPatch = vi.fn<OnApplyPatch>();
+    renderPanel({ onApplyPatch });
+    clickDeleteButton();
+
+    const confirmButton = host.querySelector('.manual-edit-delete-confirm-action') as HTMLButtonElement | null;
+    if (!confirmButton) throw new Error('Delete confirmation button not found');
+    act(() => confirmButton.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true })));
+
     expect(onApplyPatch).toHaveBeenCalledWith(
       { id: 'hero-title', kind: 'remove-element' },
       'Delete element',
@@ -165,6 +173,48 @@ describe('ManualEditPanel', () => {
     expect(redo.disabled).toBe(false);
     expect(onUndo).toHaveBeenCalledTimes(1);
     expect(onRedo).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels deletion without applying a patch and restores focus', () => {
+    const onApplyPatch = vi.fn<OnApplyPatch>();
+    renderPanel({ onApplyPatch });
+    const deleteButton = host.querySelector('button[aria-label="Delete element"]') as HTMLButtonElement;
+    deleteButton.focus();
+    clickDeleteButton();
+
+    const confirmation = host.querySelector('.manual-edit-delete-confirm');
+    const cancelButton = Array.from(confirmation?.querySelectorAll('button') ?? [])
+      .find((button) => button.textContent === 'Cancel') as HTMLButtonElement | undefined;
+    if (!cancelButton) throw new Error('Delete cancellation button not found');
+    act(() => cancelButton.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true })));
+
+    expect(onApplyPatch).not.toHaveBeenCalled();
+    expect(host.querySelector('.manual-edit-delete-confirm')).toBeNull();
+    expect(dom.window.document.activeElement).toBe(
+      host.querySelector('button[aria-label="Delete element"]'),
+    );
+  });
+
+  it('preserves a parent-controlled confirmation and delegates confirmation', () => {
+    const onConfirmDelete = vi.fn<OnConfirmDelete>();
+    const onDeleteConfirmationChange = vi.fn<(targetId: string | null) => void>();
+    renderPanel({
+      deleteConfirmationTargetId: target.id,
+      onDeleteConfirmationChange,
+      onConfirmDelete,
+    });
+
+    expect(onDeleteConfirmationChange).not.toHaveBeenCalled();
+    const confirmButton = host.querySelector('.manual-edit-delete-confirm-action') as HTMLButtonElement | null;
+    if (!confirmButton) throw new Error('Delete confirmation button not found');
+    act(() => confirmButton.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true })));
+    expect(onConfirmDelete).toHaveBeenCalledWith(target.id);
+  });
+
+  it('announces manual-edit errors', () => {
+    renderPanel({ error: 'Could not save the edited file.' });
+
+    expect(host.querySelector('[role="alert"]')?.textContent).toBe('Could not save the edited file.');
   });
 
   it('routes footer reset, cancel, and save actions', () => {
@@ -832,6 +882,12 @@ describe('ManualEditPanel', () => {
     return button;
   }
 
+  function clickDeleteButton() {
+    const deleteButton = host.querySelector('button[aria-label="Delete element"]') as HTMLButtonElement | null;
+    if (!deleteButton) throw new Error('Delete button not found');
+    act(() => deleteButton.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true })));
+  }
+
   /** The four-way padding/margin editor, addressed by its collapsible head. */
   function quadRow(label: string): HTMLElement {
     const quad = Array.from(host.querySelectorAll('.cc-quad'))
@@ -852,6 +908,7 @@ describe('ManualEditPanel', () => {
   function renderPanel({
     onDraftChange = vi.fn<OnDraftChange>(),
     onApplyPatch = vi.fn<OnApplyPatch>(),
+    onConfirmDelete,
     onError = vi.fn<OnError>(),
     onStyleChange = vi.fn<OnStyleChange>(),
     onInvalidStyle = vi.fn<OnInvalidStyle>(),
@@ -874,9 +931,13 @@ describe('ManualEditPanel', () => {
     tokenSuggestionsLoading,
     onApplyTokenSuggestion,
     onInspectValueSelect,
+    deleteConfirmationTargetId,
+    onDeleteConfirmationChange,
+    error = null,
   }: {
     onDraftChange?: OnDraftChange;
     onApplyPatch?: OnApplyPatch;
+    onConfirmDelete?: OnConfirmDelete;
     onError?: OnError;
     onStyleChange?: OnStyleChange;
     onInvalidStyle?: OnInvalidStyle;
@@ -899,6 +960,9 @@ describe('ManualEditPanel', () => {
     tokenSuggestionsLoading?: boolean;
     onApplyTokenSuggestion?: (prop: keyof ManualEditStyles, value: string) => void;
     onInspectValueSelect?: (prop: ProjectDesignTokenSuggestionProp, value: string) => void;
+    deleteConfirmationTargetId?: string | null;
+    onDeleteConfirmationChange?: (targetId: string | null) => void;
+    error?: string | null;
   } = {}) {
     const draft = {
       ...emptyManualEditDraft('<html></html>'),
@@ -914,7 +978,7 @@ describe('ManualEditPanel', () => {
           selectedTarget={selectedTarget}
           draft={draft}
           history={[]}
-          error={null}
+          error={error}
           canUndo={canUndo}
           canRedo={canRedo}
           resetAvailable={resetAvailable}
@@ -924,6 +988,9 @@ describe('ManualEditPanel', () => {
           onStyleChange={onStyleChange}
           onInvalidStyle={onInvalidStyle}
           onApplyPatch={onApplyPatch}
+          onConfirmDelete={onConfirmDelete}
+          deleteConfirmationTargetId={deleteConfirmationTargetId}
+          onDeleteConfirmationChange={onDeleteConfirmationChange}
           onError={onError}
           onClearSelection={onClearSelection}
           onCancelDraft={onCancelDraft}

--- a/apps/web/tests/edit-mode/bridge.test.ts
+++ b/apps/web/tests/edit-mode/bridge.test.ts
@@ -621,6 +621,59 @@ describe('manual edit bridge target normalization', () => {
     dom.window.close();
   });
 
+  it('routes the selected-element action through an explicit delete request', () => {
+    const posts: Array<{ type?: string; id?: string }> = [];
+    const dom = new JSDOM(
+      `<main data-od-source-path="path-0"><section data-od-source-path="path-0-0"><div>Delete me</div></section></main>${buildManualEditBridge(true)}`,
+      { runScripts: 'dangerously', url: 'http://localhost' },
+    );
+    const section = dom.window.document.querySelector('section') as HTMLElement;
+    section.getBoundingClientRect = () => ({
+      x: 20, y: 60, width: 180, height: 80, top: 60, right: 200, bottom: 140, left: 20, toJSON: () => ({}),
+    } as DOMRect);
+    dom.window.parent.postMessage = ((message: unknown) => {
+      posts.push(message as { type?: string; id?: string });
+    }) as typeof dom.window.parent.postMessage;
+
+    section.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    posts.length = 0;
+    const action = dom.window.document.querySelector('[data-od-edit-delete-action]') as HTMLButtonElement | null;
+    expect(action?.getAttribute('aria-label')).toBe('Delete element');
+    action?.dispatchEvent(new dom.window.Event('pointerover', { bubbles: true }));
+    action?.dispatchEvent(new dom.window.Event('pointermove', { bubbles: true }));
+    expect(action?.isConnected).toBe(true);
+    action?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+
+    expect(posts).toContainEqual({ type: 'od-edit-delete-request', id: 'path-0-0' });
+    dom.window.close();
+  });
+
+  it.each(['Delete', 'Backspace'])('routes %s through the selected element delete request', (key) => {
+    const posts: Array<{ type?: string; id?: string }> = [];
+    const dom = new JSDOM(
+      `<main data-od-source-path="path-0"><section data-od-source-path="path-0-0"><div>Delete me</div></section></main>${buildManualEditBridge(true)}`,
+      { runScripts: 'dangerously', url: 'http://localhost' },
+    );
+    const section = dom.window.document.querySelector('section') as HTMLElement;
+    section.getBoundingClientRect = () => ({
+      x: 20, y: 60, width: 180, height: 80, top: 60, right: 200, bottom: 140, left: 20, toJSON: () => ({}),
+    } as DOMRect);
+    dom.window.parent.postMessage = ((message: unknown) => {
+      posts.push(message as { type?: string; id?: string });
+    }) as typeof dom.window.parent.postMessage;
+
+    section.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    posts.length = 0;
+    dom.window.document.documentElement.dispatchEvent(new dom.window.KeyboardEvent('keydown', {
+      key,
+      bubbles: true,
+      cancelable: true,
+    }));
+
+    expect(posts).toContainEqual({ type: 'od-edit-delete-request', id: 'path-0-0' });
+    dom.window.close();
+  });
+
   it('clears hover reference guides when the pointer leaves all targets', () => {
     const dom = new JSDOM(
       `<main data-od-source-path="path-0"><h1 data-od-source-path="path-0-0">Plain title</h1></main>${buildManualEditBridge(true)}`,
@@ -886,6 +939,8 @@ describe('manual edit bridge target normalization', () => {
     expect(style).toContain('[data-od-edit-guides-layer] .od-edit-guide-box-selected');
     expect(style).toContain('[data-od-edit-guides-layer] .od-edit-guide-handle');
     expect(style).toContain('[data-od-edit-guides-layer] .od-edit-guide-measure');
+    expect(style).toContain('[data-od-edit-guides-layer] .od-edit-selection-action');
+    expect(style).toContain('pointer-events: auto');
   });
 
   it('moves the runtime selected marker between selected targets', () => {


### PR DESCRIPTION
Fixes #3846

## Why

While rebasing the original deletion-confirmation fix onto the manual-edit work merged in #5890, I found that users could still bypass confirmation from the selection action bar or the canvas keyboard path. A destructive delete could also outlive a target, file, project, source, or viewer-lifecycle change while an asynchronous save or source verification was pending.

## What users will see

Deleting a selected element—whether from the inspector trash action, the selection action bar, or `Delete` / `Backspace` on the canvas—now opens the same inline warning in the inspector. **Cancel** keeps the element and any unsaved inspector draft unchanged; **Delete element** performs the existing guarded, undoable removal.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [x] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`)
- [x] **Default behavior change** — existing destructive deletion paths now require confirmation
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

![Inline delete confirmation](https://github.com/user-attachments/assets/c8cb42f0-11e5-4d2b-87d7-b202da742ea3)

## Bug fix verification

- Test paths that reproduce the bugs:
  - `apps/web/tests/components/FileViewer.manual-edit.test.tsx`
  - `apps/web/tests/components/ManualEditPanel.test.tsx`
  - `apps/web/tests/components/ManualEditSelectionOverlay.test.tsx`
- Did the tests go red on `main` and green on this branch? **Yes.** During the rebase, the focused regressions were first run against `main`'s pre-fix deletion path and failed on direct overlay/iframe deletion, dirty-draft preservation, and stale asynchronous deletion authorization. They pass after this change, including held save/source-verification, file/project/source change, same-ID reselection, and unmount cases.

## Validation

- Focused Vitest: **117 passed** across the three test files above
- Web typecheck: passed
- Root typecheck: passed
- Repository guard: passed
- Web production build: passed
- Independent blocker review of the final authorization and accessibility delta: passed, no PR-introduced blockers

## Implementation notes

- Inspector, selection-overlay, and iframe deletion requests converge on the existing inline confirmation UI.
- The final-root guard and `removeManualEditTarget()` run only after final confirmation.
- Pending deletion is disarmed synchronously on target, file, project, source-incarnation, mode, or lifecycle changes, including while a style save or persisted-source verification is pending.
- #5890's direct-manipulation, in-place DOM update, save, undo, and history behavior remains intact.
