### PR TITLE
fix(security): reject loopback for BYOK asset download URLs (#5478)

### DIFF
--- a/apps/daemon/src/byok-tools.ts
+++ b/apps/daemon/src/byok-tools.ts
@@ -15,7 +15,7 @@
 import path from 'node:path';
 import { writeFile, readFile, readdir, stat } from 'node:fs/promises';
 import { randomBytes } from 'node:crypto';
-import { assertExternalAssetUrl, assertAndFetchExternalAsset } from './connectionTest.js';
+import { assertAndFetchExternalAsset } from './connectionTest.js';
 import { resolveProviderConfig } from './media/config.js';
 import { IMAGE_MODELS } from './media/models.js';
 import { ensureProject } from './projects.js';
@@ -693,12 +693,11 @@ export async function executeGenerateImage(
     };
   }
 
-  const imageUrlCheck = await assertExternalAssetUrl(imageUrl);
-  if (!imageUrlCheck.ok) return { ok: false, error: imageUrlCheck.error };
-
   let bytes: Buffer;
   try {
-    const imgResp = await fetch(imageUrl, withToolRequestInit(ctx, { redirect: 'error' }));
+    // Use assertAndFetchExternalAsset (validate + pinned-DNS fetch) so a
+    // malicious gateway can't DNS-rebind into loopback/metadata space.
+    const imgResp = await assertAndFetchExternalAsset(imageUrl, withToolRequestInit(ctx, {}));
     if (!imgResp.ok) {
       return { ok: false, error: `image download ${imgResp.status}` };
     }
@@ -923,15 +922,12 @@ export async function executeGenerateVideo(
   }
 
   // Step 3: download the mp4 bytes and persist into the project folder.
-  // Re-validate the returned URL through validateBaseUrlResolved so a
-  // malicious gateway can't point us at 169.254.169.254 (AWS / Azure
-  // metadata service) or RFC1918 hosts via the response payload.
-  const videoUrlCheck = await assertExternalAssetUrl(videoUrl);
-  if (!videoUrlCheck.ok) return { ok: false, error: videoUrlCheck.error };
+  // Use assertAndFetchExternalAsset (validate + pinned-DNS fetch) so a
+  // malicious gateway can't DNS-rebind into loopback / metadata space.
 
   let bytes: Buffer;
   try {
-    const videoResp = await fetch(videoUrl, withToolRequestInit(ctx, { redirect: 'error' }));
+    const videoResp = await assertAndFetchExternalAsset(videoUrl, withToolRequestInit(ctx, {}));
     if (!videoResp.ok) {
       return { ok: false, error: `video download ${videoResp.status}` };
     }
@@ -1314,10 +1310,9 @@ async function resolveAIHubMixReferenceImage(
   if (typeof imageUrl !== 'string' || !imageUrl.trim()) return null;
   const raw = imageUrl.trim();
   if (/^https?:\/\//i.test(raw)) {
-    const check = await assertExternalAssetUrl(raw);
-    if (!check.ok) return null;
     try {
-      const resp = await fetch(raw, withToolRequestInit(ctx, { redirect: 'error' }));
+      // assertAndFetchExternalAsset validates + pins DNS to prevent rebind.
+      const resp = await assertAndFetchExternalAsset(raw, withToolRequestInit(ctx, {}));
       if (!resp.ok) return null;
       const buf = Buffer.from(await resp.arrayBuffer());
       if (!buf.length) return null;

--- a/apps/daemon/src/byok-tools.ts
+++ b/apps/daemon/src/byok-tools.ts
@@ -447,8 +447,15 @@ export interface BYOKToolContext {
   videoPollIntervalMs?: number;
   /** Optional per-request init copied from the live chat turn. Used to
    *  forward the current proxy dispatcher AND the client-cancellation
-   *  signal into every upstream/download fetch the BYOK tool executor
-   *  performs, so a disconnected client stops the tool loop's paid work. */
+   *  signal into every upstream fetch the BYOK tool executor performs,
+   *  so a disconnected client stops the tool loop's paid work.
+   *
+   *  Exception — asset downloads: when a provider result URL is fetched
+   *  through `assertAndFetchExternalAsset` (connectionTest.ts), that
+   *  helper intentionally OVERRIDES `init.dispatcher` with the shared
+   *  asset-validating dispatcher whose connect-time DNS lookup rejects
+   *  non-public addresses (issue #5478). Asset downloads therefore never
+   *  ride the turn proxy dispatcher; submit/poll hops keep it. */
   requestInit?: Pick<RequestInit, 'dispatcher' | 'signal'>;
 }
 

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -140,7 +140,9 @@ export async function validateBaseUrlResolved(
   if (sync.error || !sync.parsed) return sync;
 
   const hostname = sync.parsed.hostname.toLowerCase();
-  if (isLoopbackApiHost(hostname)) return sync;
+  // When forbidLoopback is set, do NOT short-circuit on loopback — let it
+  // fall through to the block check (issue #5478).
+  if (!options.forbidLoopback && isLoopbackApiHost(hostname)) return sync;
   // Issue #3225 — an operator who trusts this hostname has opted it out of the
   // guard entirely, so skip the resolved-IP block even though it points into
   // private space. The sync check above already honored a literal-IP allowlist
@@ -157,7 +159,18 @@ export async function validateBaseUrlResolved(
 
   for (const addr of addresses) {
     const ip = String(addr.address).toLowerCase();
-    if (isLoopbackApiHost(ip)) continue;
+    // When forbidLoopback is set (asset download URLs from issue #5478),
+    // a DNS name that resolves to loopback is just as dangerous as a
+    // literal loopback host — reject it instead of skipping.
+    if (isLoopbackApiHost(ip)) {
+      if (options.forbidLoopback) {
+        return {
+          error: `DNS-resolved loopback address blocked (${ip})`,
+          forbidden: true,
+        };
+      }
+      continue;
+    }
     // A resolved address the operator explicitly allowlisted (they listed the
     // IP rather than the hostname) is permitted; everything else in private
     // space is still blocked.
@@ -215,7 +228,12 @@ export async function assertExternalAssetUrl(
   if (typeof rawUrl !== 'string' || !rawUrl) {
     return { ok: false, error: 'empty download url' };
   }
-  const validated = await validateBaseUrlResolved(rawUrl);
+  // Asset URLs come from upstream API responses (data.url / data.video_url)
+  // and are attacker-controllable. They MUST NOT point at loopback or
+  // internal addresses, regardless of operator allowlists (issue #5478).
+  const validated = await validateBaseUrlResolved(rawUrl, undefined, {
+    forbidLoopback: true,
+  });
   if (validated.error || !validated.parsed) {
     return {
       ok: false,

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -21,7 +21,7 @@ import { promises as dnsPromises } from 'node:dns';
 import { promises as fsp } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { Agent, EnvHttpProxyAgent, Socks5ProxyAgent } from 'undici';
+import { Agent, EnvHttpProxyAgent, Socks5ProxyAgent, fetch as undiciFetch } from 'undici';
 import type { Dispatcher, Pool } from 'undici';
 import {
   applyAgentLaunchEnv,
@@ -180,7 +180,11 @@ export async function validateBaseUrlResolved(
     }
   }
 
-  return sync;
+  // Attach validated addresses so the caller can pin the actual fetch to them.
+  // This prevents DNS rebinding: without pinning, the attacker's DNS can return
+  // a public IP here and then 127.0.0.1 at fetch time, so the daemon connects
+  // to loopback despite the validation having passed (issue #5478).
+  return { ...sync, resolvedAddresses: addresses };
 }
 
 /**
@@ -221,10 +225,17 @@ export function validateUserProviderBaseUrl(
  * Both hand the URL straight to `fetch(...)` next, so pair this
  * guard with `redirect: 'error'` on the fetch to also block a
  * 3xx hop into private space.
+ *
+ * Returns the DNS-resolved addresses that passed validation on the `ok` branch
+ * so callers (e.g. {@link assertAndFetchExternalAsset}) can pin the actual
+ * connection to those addresses and prevent DNS rebinding (issue #5478).
  */
 export async function assertExternalAssetUrl(
   rawUrl: string,
-): Promise<{ ok: true } | { ok: false; error: string }> {
+): Promise<
+  | { ok: true; resolvedAddresses?: ReadonlyArray<{ address: string; family: number }> }
+  | { ok: false; error: string }
+> {
   if (typeof rawUrl !== 'string' || !rawUrl) {
     return { ok: false, error: 'empty download url' };
   }
@@ -242,18 +253,30 @@ export async function assertExternalAssetUrl(
         : `invalid download url: ${validated.error ?? 'unknown reason'}`,
     };
   }
+  // Only include resolvedAddresses when present — exactOptionalPropertyTypes
+  // forbids assigning `undefined` to an optional property.
+  if (validated.resolvedAddresses) {
+    return { ok: true, resolvedAddresses: validated.resolvedAddresses };
+  }
   return { ok: true };
 }
 
 /**
  * Validate an upstream-controlled asset URL and fetch it with the SSRF guard
- * pinned through redirects. Runs `assertExternalAssetUrl` on the literal URL
- * and forces `redirect: 'error'`, so a validated public URL that 302s into
- * loopback / RFC1918 / metadata space is rejected before any bytes are read.
+ * pinned through redirects **and DNS resolution**. Runs `assertExternalAssetUrl`
+ * on the literal URL, forces `redirect: 'error'` (blocking a 3xx hop into
+ * private space), and — when DNS resolution was used during validation — pins
+ * the Undici dispatcher to the validated IP addresses so that a DNS-rebinding
+ * domain cannot return `127.0.0.1` / `::1` at fetch time (issue #5478).
  *
- * Throws on a blocked host — so the redirect bypass is impossible to forget at
- * call sites — and the platform fetch additionally throws when `redirect:
- * 'error'` encounters a 3xx. Callers keep their own `!resp.ok` HTTP-status
+ * The pinned dispatcher overrides the DNS lookup used by `net.connect` /
+ * `tls.connect`, returning only the addresses from the validation step. The
+ * original hostname is preserved for the `Host` header and TLS SNI, so the
+ * request is identical to a normal fetch except that the TCP connection goes
+ * to the vetted IP.
+ *
+ * Throws on a blocked host — so the redirect/DNS-rebind bypass is impossible
+ * to forget at call sites. Callers keep their own `!resp.ok` HTTP-status
  * handling. The forced `redirect` is spread last so it overrides any value the
  * caller passed in `init`.
  */
@@ -263,6 +286,39 @@ export async function assertAndFetchExternalAsset(
 ): Promise<Response> {
   const check = await assertExternalAssetUrl(url);
   if (!check.ok) throw new Error(check.error);
+
+  // Pin the DNS lookup to the addresses validated above so a DNS-rebinding
+  // domain cannot return a loopback/internal address at fetch time (issue #5478).
+  // When no DNS lookup was performed (IP literal, loopback carve-out for
+  // provider endpoints, or lookup failure), fall back to a normal fetch — the
+  // literal hostname was already validated synchronously.
+  if (check.resolvedAddresses && check.resolvedAddresses.length > 0) {
+    const validatedAddrs = check.resolvedAddresses;
+    const pinnedAgent = new Agent({
+      connect: {
+        // Custom lookup that always returns the DNS-resolved addresses from
+        // the validation step, ignoring any re-resolution attempt. This is
+        // the crux of the DNS-rebinding fix (issue #5478): even if the
+        // attacker's DNS returns 127.0.0.1 at fetch time, the pinned lookup
+        // ignores the hostname and returns only the vetted IPs.
+        lookup: ((_hostname: string, options: unknown, callback: (...args: unknown[]) => void) => {
+          const opts = options as { all?: boolean };
+          if (opts?.all) {
+            callback(null, validatedAddrs.map((a) => ({ address: a.address, family: a.family })));
+          } else {
+            const first = validatedAddrs[0]!;
+            callback(null, first.address, first.family);
+          }
+        }) as never,
+      },
+    });
+    return undiciFetch(url, {
+      ...init,
+      redirect: 'error',
+      dispatcher: pinnedAgent,
+    } as Parameters<typeof undiciFetch>[1]);
+  }
+
   return fetch(url, { ...init, redirect: 'error' });
 }
 

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -321,6 +321,17 @@ const assetDispatcher = new Agent({
 });
 
 /**
+ * Test-visible accessor for the shared asset-validating dispatcher attached by
+ * `assertAndFetchExternalAsset`. Tests key dispatcher assertions on the asset
+ * URL and compare against this exact instance (`toBe`), so a regression that
+ * reverts to forwarding the caller's turn-proxy dispatcher on the asset hop
+ * fails loudly (issue #5478).
+ */
+export function getAssetValidatingDispatcher(): NonNullable<RequestInit['dispatcher']> {
+  return assetDispatcher as unknown as NonNullable<RequestInit['dispatcher']>;
+}
+
+/**
  * Validate an upstream-controlled asset URL and fetch it with the SSRF guard
  * pinned through redirects and DNS resolution. Runs `assertExternalAssetUrl`
  * on the literal URL (fail-closed on DNS errors), forces `redirect: 'error'`

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -17,7 +17,7 @@
 // contracts so Settings and daemon-side checks reject the same hosts.
 
 import { spawn } from 'node:child_process';
-import { promises as dnsPromises } from 'node:dns';
+import { promises as dnsPromises, lookup as dnsLookupCb } from 'node:dns';
 import { promises as fsp } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -154,6 +154,14 @@ export async function validateBaseUrlResolved(
   try {
     addresses = await lookup(hostname);
   } catch {
+    // When forbidLoopback is set (attacker-controllable asset URLs), a DNS
+    // lookup failure must fail closed. An attacker who controls the resolver
+    // can make the validation lookup throw (ENOTFOUND / ETIMEOUT / SERVFAIL)
+    // and then answer loopback for the fetch-time lookup, bypassing the guard.
+    // (issue #5478)
+    if (options.forbidLoopback) {
+      return { error: 'DNS resolution failed for asset URL', forbidden: true };
+    }
     return sync;
   }
 
@@ -262,23 +270,70 @@ export async function assertExternalAssetUrl(
 }
 
 /**
+ * Connection-time DNS validator for asset-download requests. Wraps `dns.lookup`
+ * and rejects any resolved address that is loopback, RFC1918, link-local,
+ * CGNAT, metadata-service, or multicast — the same predicate used during
+ * pre-validation. Installed as the Undici Agent's `connect.lookup` so the
+ * address we validate IS the address the socket connects to, closing the
+ * DNS-rebinding / TOCTOU gap that a separate pre-validation lookup leaves open
+ * (issue #5478). Same pattern as `brands/safe-fetch.ts` and
+ * `plugins/plugin-asset-cache.ts`.
+ *
+ * Exported so the guard can be unit-tested without a live server.
+ */
+export function createAssetValidatingLookup(
+  lookupImpl: typeof dnsLookupCb = dnsLookupCb,
+): (hostname: string, options: unknown, callback: (...args: unknown[]) => void) => void {
+  return (
+    hostname: string,
+    options: unknown,
+    callback: (...args: unknown[]) => void,
+  ): void => {
+    const cb = (typeof options === 'function' ? options : callback) as (
+      err: Error | null,
+      address?: unknown,
+      family?: number,
+    ) => void;
+    const opts = (typeof options === 'function' ? {} : (options ?? {})) as Record<string, unknown>;
+    lookupImpl(hostname, opts as never, (err, address, family) => {
+      if (err) return cb(err);
+      const list = Array.isArray(address) ? address : [{ address, family }];
+      for (const entry of list) {
+        const addr = typeof entry === 'string' ? entry : (entry as { address: string }).address;
+        if (isLoopbackApiHost(String(addr)) || isBlockedExternalApiHostname(String(addr))) {
+          return cb(new Error(`asset host resolves to non-public address: ${addr}`));
+        }
+      }
+      return cb(null, address, family);
+    });
+  };
+}
+
+// Long-lived dispatcher reused across calls. A per-request Agent leaks
+// keep-alive sockets; a shared dispatcher avoids that while still pinning the
+// connection-time validating lookup (same approach as plugin-asset-cache.ts).
+const assetDispatcher = new Agent({
+  connect: { lookup: createAssetValidatingLookup() as never },
+});
+
+/**
  * Validate an upstream-controlled asset URL and fetch it with the SSRF guard
- * pinned through redirects **and DNS resolution**. Runs `assertExternalAssetUrl`
- * on the literal URL, forces `redirect: 'error'` (blocking a 3xx hop into
- * private space), and — when DNS resolution was used during validation — pins
- * the Undici dispatcher to the validated IP addresses so that a DNS-rebinding
- * domain cannot return `127.0.0.1` / `::1` at fetch time (issue #5478).
+ * pinned through redirects and DNS resolution. Runs `assertExternalAssetUrl`
+ * on the literal URL (fail-closed on DNS errors), forces `redirect: 'error'`
+ * (blocking a 3xx hop into private space), and routes the fetch through a
+ * long-lived Undici dispatcher whose connection-time `lookup` rejects any
+ * non-public address — so even if an attacker's DNS returns a public address
+ * during pre-validation and loopback at connect time, the socket is refused
+ * (issue #5478).
  *
- * The pinned dispatcher overrides the DNS lookup used by `net.connect` /
- * `tls.connect`, returning only the addresses from the validation step. The
- * original hostname is preserved for the `Host` header and TLS SNI, so the
- * request is identical to a normal fetch except that the TCP connection goes
- * to the vetted IP.
+ * For non-IP-literal hostnames, if DNS validation did not attach a vetted
+ * address set (e.g., lookup failure), the function throws rather than falling
+ * back to an unpinned fetch. IP literals are safe to fetch unpinned because
+ * they were validated synchronously and have no hostname to rebind.
  *
- * Throws on a blocked host — so the redirect/DNS-rebind bypass is impossible
- * to forget at call sites. Callers keep their own `!resp.ok` HTTP-status
- * handling. The forced `redirect` is spread last so it overrides any value the
- * caller passed in `init`.
+ * Throws on a blocked host or unpinned-fetch refusal. Callers keep their own
+ * `!resp.ok` HTTP-status handling. The forced `redirect` is spread last so it
+ * overrides any value the caller passed in `init`.
  */
 export async function assertAndFetchExternalAsset(
   url: string,
@@ -287,39 +342,34 @@ export async function assertAndFetchExternalAsset(
   const check = await assertExternalAssetUrl(url);
   if (!check.ok) throw new Error(check.error);
 
-  // Pin the DNS lookup to the addresses validated above so a DNS-rebinding
-  // domain cannot return a loopback/internal address at fetch time (issue #5478).
-  // When no DNS lookup was performed (IP literal, loopback carve-out for
-  // provider endpoints, or lookup failure), fall back to a normal fetch — the
-  // literal hostname was already validated synchronously.
-  if (check.resolvedAddresses && check.resolvedAddresses.length > 0) {
-    const validatedAddrs = check.resolvedAddresses;
-    const pinnedAgent = new Agent({
-      connect: {
-        // Custom lookup that always returns the DNS-resolved addresses from
-        // the validation step, ignoring any re-resolution attempt. This is
-        // the crux of the DNS-rebinding fix (issue #5478): even if the
-        // attacker's DNS returns 127.0.0.1 at fetch time, the pinned lookup
-        // ignores the hostname and returns only the vetted IPs.
-        lookup: ((_hostname: string, options: unknown, callback: (...args: unknown[]) => void) => {
-          const opts = options as { all?: boolean };
-          if (opts?.all) {
-            callback(null, validatedAddrs.map((a) => ({ address: a.address, family: a.family })));
-          } else {
-            const first = validatedAddrs[0]!;
-            callback(null, first.address, first.family);
-          }
-        }) as never,
-      },
-    });
-    return undiciFetch(url, {
-      ...init,
-      redirect: 'error',
-      dispatcher: pinnedAgent,
-    } as Parameters<typeof undiciFetch>[1]);
+  // Determine whether the hostname is an IP literal. If so, the synchronous
+  // validation already vetted it — no DNS rebind is possible.
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    throw new Error(`invalid asset url: ${url}`);
+  }
+  const hostname = parsedUrl.hostname.toLowerCase();
+  const isIpLiteral = looksLikeIpLiteral(hostname);
+
+  // For non-IP-literal hostnames, require validated resolved addresses. If
+  // they are missing (DNS lookup failed and was caught → fail-closed in
+  // validateBaseUrlResolved), never fall back to an unpinned fetch — that
+  // would allow the attacker to rebind at fetch time (issue #5478).
+  if (!isIpLiteral && (!check.resolvedAddresses || check.resolvedAddresses.length === 0)) {
+    throw new Error('asset URL hostname was not DNS-validated — refusing unpinned fetch');
   }
 
-  return fetch(url, { ...init, redirect: 'error' });
+  // Route through the long-lived asset dispatcher whose connection-time lookup
+  // rejects non-public addresses. This is defense-in-depth on top of the
+  // pre-validation: even if a rebind slips through, the socket-level check
+  // catches it.
+  return undiciFetch(url, {
+    ...init,
+    redirect: 'error',
+    dispatcher: assetDispatcher,
+  } as Parameters<typeof undiciFetch>[1]);
 }
 
 // Aggressive but not punitive — happy paths usually return in under 2 s.

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -240,6 +240,7 @@ export function validateUserProviderBaseUrl(
  */
 export async function assertExternalAssetUrl(
   rawUrl: string,
+  lookup?: DnsLookupFn,
 ): Promise<
   | { ok: true; resolvedAddresses?: ReadonlyArray<{ address: string; family: number }> }
   | { ok: false; error: string }
@@ -250,7 +251,7 @@ export async function assertExternalAssetUrl(
   // Asset URLs come from upstream API responses (data.url / data.video_url)
   // and are attacker-controllable. They MUST NOT point at loopback or
   // internal addresses, regardless of operator allowlists (issue #5478).
-  const validated = await validateBaseUrlResolved(rawUrl, undefined, {
+  const validated = await validateBaseUrlResolved(rawUrl, lookup, {
     forbidLoopback: true,
   });
   if (validated.error || !validated.parsed) {
@@ -312,6 +313,9 @@ export function createAssetValidatingLookup(
 // Long-lived dispatcher reused across calls. A per-request Agent leaks
 // keep-alive sockets; a shared dispatcher avoids that while still pinning the
 // connection-time validating lookup (same approach as plugin-asset-cache.ts).
+// Used by `createAssetValidatingLookup` consumers in production; the default
+// fetch in `assertAndFetchExternalAsset` is `globalThis.fetch` so test stubs
+// still intercept.
 const assetDispatcher = new Agent({
   connect: { lookup: createAssetValidatingLookup() as never },
 });
@@ -338,8 +342,10 @@ const assetDispatcher = new Agent({
 export async function assertAndFetchExternalAsset(
   url: string,
   init: RequestInit = {},
+  lookup?: DnsLookupFn,
+  fetchImpl: typeof fetch = fetch,
 ): Promise<Response> {
-  const check = await assertExternalAssetUrl(url);
+  const check = await assertExternalAssetUrl(url, lookup);
   if (!check.ok) throw new Error(check.error);
 
   // Determine whether the hostname is an IP literal. If so, the synchronous
@@ -361,15 +367,10 @@ export async function assertAndFetchExternalAsset(
     throw new Error('asset URL hostname was not DNS-validated — refusing unpinned fetch');
   }
 
-  // Route through the long-lived asset dispatcher whose connection-time lookup
-  // rejects non-public addresses. This is defense-in-depth on top of the
-  // pre-validation: even if a rebind slips through, the socket-level check
-  // catches it.
-  return undiciFetch(url, {
-    ...init,
-    redirect: 'error',
-    dispatcher: assetDispatcher,
-  } as Parameters<typeof undiciFetch>[1]);
+  // Use the injected (or default global) fetch so tests can stub it with
+  // vi.stubGlobal('fetch', …). redirect:'error' blocks a 3xx hop into
+  // private space (issue #5478).
+  return fetchImpl(url, { ...init, redirect: 'error' });
 }
 
 // Aggressive but not punitive — happy paths usually return in under 2 s.

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -21,7 +21,7 @@ import { promises as dnsPromises, lookup as dnsLookupCb } from 'node:dns';
 import { promises as fsp } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { Agent, EnvHttpProxyAgent, Socks5ProxyAgent, fetch as undiciFetch } from 'undici';
+import { Agent, EnvHttpProxyAgent, Socks5ProxyAgent } from 'undici';
 import type { Dispatcher, Pool } from 'undici';
 import {
   applyAgentLaunchEnv,
@@ -367,10 +367,15 @@ export async function assertAndFetchExternalAsset(
     throw new Error('asset URL hostname was not DNS-validated — refusing unpinned fetch');
   }
 
-  // Use the injected (or default global) fetch so tests can stub it with
-  // vi.stubGlobal('fetch', …). redirect:'error' blocks a 3xx hop into
-  // private space (issue #5478).
-  return fetchImpl(url, { ...init, redirect: 'error' });
+  // Route through the long-lived asset dispatcher whose connection-time lookup
+  // rejects non-public addresses. The dispatcher is attached to the init object
+  // so injected fetch stubs (vi.stubGlobal) still see redirect:'error' and
+  // can ignore dispatcher, while production globalThis.fetch (Node/undici)
+  // uses it to refuse a connect-time rebind to loopback/metadata (issue #5478).
+  // Same pattern as plugins/plugin-asset-cache.ts safeExternalFetch.
+  const requestInit: RequestInit = { ...init, redirect: 'error' };
+  (requestInit as { dispatcher?: unknown }).dispatcher = assetDispatcher;
+  return fetchImpl(url, requestInit);
 }
 
 // Aggressive but not punitive — happy paths usually return in under 2 s.

--- a/apps/daemon/tests/aihubmix-asset-ssrf.test.ts
+++ b/apps/daemon/tests/aihubmix-asset-ssrf.test.ts
@@ -100,12 +100,12 @@ describe('AIHubMix asset downloads pin redirect:"error"', () => {
         return new Response(
           JSON.stringify({
             status: 'completed',
-            video_url: 'https://cdn.example.test/video/done.mp4',
+            video_url: 'https://93.184.216.34/video/done.mp4',
           }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
-      if (url === 'https://cdn.example.test/video/done.mp4') {
+      if (url === 'https://93.184.216.34/video/done.mp4') {
         downloadInit = init;
         return new Response(mp4Bytes, {
           status: 200,
@@ -128,11 +128,11 @@ describe('AIHubMix asset downloads pin redirect:"error"', () => {
       const url = String(input);
       if (url === 'https://aihubmix.com/v1/images/generations') {
         return new Response(
-          JSON.stringify({ data: [{ url: 'https://cdn.example.test/img/out.png' }] }),
+          JSON.stringify({ data: [{ url: 'https://93.184.216.34/img/out.png' }] }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
-      if (url === 'https://cdn.example.test/img/out.png') {
+      if (url === 'https://93.184.216.34/img/out.png') {
         downloadInit = init;
         return new Response(pngBytes, {
           status: 200,

--- a/apps/daemon/tests/asset-ssrf-loopback.test.ts
+++ b/apps/daemon/tests/asset-ssrf-loopback.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { assertExternalAssetUrl, validateBaseUrlResolved } from '../src/connectionTest.js';
+import type { DnsLookupFn } from '../src/connectionTest.js';
+
+describe('assertExternalAssetUrl — loopback rejection (issue #5478)', () => {
+  it('rejects 127.0.0.1 asset URLs', async () => {
+    const result = await assertExternalAssetUrl('http://127.0.0.1:8080/evil.png');
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.error).toContain('blocked');
+  });
+
+  it('rejects localhost asset URLs', async () => {
+    const result = await assertExternalAssetUrl('http://localhost:3000/image.png');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects ::1 asset URLs', async () => {
+    const result = await assertExternalAssetUrl('http://[::1]:8080/video.mp4');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects 127.x.x.x range (not just 127.0.0.1)', async () => {
+    const result = await assertExternalAssetUrl('http://127.1.2.3:9999/data');
+    expect(result.ok).toBe(false);
+  });
+
+  it('accepts legitimate public CDN asset URLs', async () => {
+    const result = await assertExternalAssetUrl('https://cdn.example.com/image.png');
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts https asset URLs with paths', async () => {
+    const result = await assertExternalAssetUrl('https://api.gateway.com/v1/assets/abc123.png');
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects empty URLs', async () => {
+    const result = await assertExternalAssetUrl('');
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects non-string URLs', async () => {
+    const result = await assertExternalAssetUrl(null as unknown as string);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('validateBaseUrlResolved — DNS-resolved loopback (issue #5478)', () => {
+  // A DNS mock that resolves any hostname to a loopback address
+  const dnsResolvesLoopback: DnsLookupFn = async (_hostname: string) => [
+    { address: '127.0.0.1', family: 4 },
+  ];
+
+  const dnsResolvesMixed: DnsLookupFn = async (_hostname: string) => [
+    { address: '93.184.216.34', family: 4 },  // public IP
+    { address: '127.0.0.1', family: 4 },       // loopback
+  ];
+
+  it('rejects DNS-resolved loopback when forbidLoopback is set', async () => {
+    const result = await validateBaseUrlResolved(
+      'http://attacker-controlled.example.com/evil.png',
+      dnsResolvesLoopback,
+      { forbidLoopback: true },
+    );
+    expect(result.error).toBeDefined();
+    expect(result.forbidden).toBe(true);
+    expect(result.error).toContain('loopback');
+  });
+
+  it('rejects when any resolved address is loopback (mixed results)', async () => {
+    const result = await validateBaseUrlResolved(
+      'http://cdn-lookalike.example.com/data',
+      dnsResolvesMixed,
+      { forbidLoopback: true },
+    );
+    expect(result.forbidden).toBe(true);
+    expect(result.error).toContain('loopback');
+  });
+
+  it('allows DNS-resolved loopback when forbidLoopback is NOT set (provider endpoints)', async () => {
+    // User-configured provider endpoints should still work with local gateways
+    const result = await validateBaseUrlResolved(
+      'http://local-gateway.internal/v1',
+      dnsResolvesLoopback,
+      { forbidLoopback: false },
+    );
+    expect(result.forbidden).toBeUndefined();
+    expect(result.error).toBeUndefined();
+    expect(result.parsed).toBeDefined();
+  });
+
+  it('rejects DNS-resolved ::1 when forbidLoopback is set', async () => {
+    const dnsResolvesV6Loopback: DnsLookupFn = async (_hostname: string) => [
+      { address: '::1', family: 6 },
+    ];
+    const result = await validateBaseUrlResolved(
+      'http://safe-looking.name/video.mp4',
+      dnsResolvesV6Loopback,
+      { forbidLoopback: true },
+    );
+    expect(result.forbidden).toBe(true);
+    expect(result.error).toContain('loopback');
+  });
+});

--- a/apps/daemon/tests/asset-ssrf-loopback.test.ts
+++ b/apps/daemon/tests/asset-ssrf-loopback.test.ts
@@ -348,26 +348,27 @@ describe('assertAndFetchExternalAsset — fail-closed paths (issue #5478)', () =
 });
 
 describe('assertAndFetchExternalAsset — TOCTOU with injectable lookup (issue #5478)', () => {
-  it('rejects when validation lookup returns public but fetch would reach loopback', async () => {
+  it('fetch carries dispatcher so connect-time rebind to loopback is refused', async () => {
     // The validation lookup returns a public IP, so assertExternalAssetUrl passes.
-    // A real attacker would rebind DNS for the fetch lookup. With fail-closed +
-    // injectable fetch, we prove the fetch stub is still called with redirect:'error'
-    // and the validation was done against the right address set.
+    // The fetch stub receives the request init — assert that `dispatcher` is
+    // attached, proving the validating Agent would refuse a connect-time rebind.
     const publicLookup: DnsLookupFn = async () => [{ address: '93.184.216.34', family: 4 }];
-    let fetchCalled = false;
-    const stubFetch = async () => {
-      fetchCalled = true;
+    let capturedInit: RequestInit | undefined;
+    const stubFetch = async (_url: string, init?: RequestInit) => {
+      capturedInit = init;
       return new Response('ok', { status: 200 });
     };
 
-    const resp = await assertAndFetchExternalAsset(
+    await assertAndFetchExternalAsset(
       'http://rebind.example.com/asset.png',
       {},
       publicLookup,
       stubFetch as never,
     );
-    expect(fetchCalled).toBe(true);
-    expect(resp.ok).toBe(true);
+    // The dispatcher must be present so production fetch uses the validating Agent
+    expect(capturedInit).toBeDefined();
+    expect((capturedInit as { dispatcher?: unknown }).dispatcher).toBeDefined();
+    expect(capturedInit?.redirect).toBe('error');
   });
 
   it('rejects without invoking fetch when validation lookup throws', async () => {

--- a/apps/daemon/tests/asset-ssrf-loopback.test.ts
+++ b/apps/daemon/tests/asset-ssrf-loopback.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { assertExternalAssetUrl, validateBaseUrlResolved } from '../src/connectionTest.js';
+import {
+  assertExternalAssetUrl,
+  assertAndFetchExternalAsset,
+  validateBaseUrlResolved,
+  createAssetValidatingLookup,
+} from '../src/connectionTest.js';
 import type { DnsLookupFn } from '../src/connectionTest.js';
 
 describe('assertExternalAssetUrl — loopback rejection (issue #5478)', () => {
@@ -24,13 +29,13 @@ describe('assertExternalAssetUrl — loopback rejection (issue #5478)', () => {
     expect(result.ok).toBe(false);
   });
 
-  it('accepts legitimate public CDN asset URLs', async () => {
-    const result = await assertExternalAssetUrl('https://cdn.example.com/image.png');
+  it('accepts legitimate public IP asset URLs', async () => {
+    const result = await assertExternalAssetUrl('http://93.184.216.34/image.png');
     expect(result.ok).toBe(true);
   });
 
-  it('accepts https asset URLs with paths', async () => {
-    const result = await assertExternalAssetUrl('https://api.gateway.com/v1/assets/abc123.png');
+  it('accepts https asset URLs with paths (IP literal)', async () => {
+    const result = await assertExternalAssetUrl('https://198.51.100.1/v1/assets/abc123.png');
     expect(result.ok).toBe(true);
   });
 
@@ -118,9 +123,6 @@ describe('DNS rebinding — resolved-address pinning (issue #5478)', () => {
   });
 
   it('resolved addresses capture the public IP from the first lookup only', async () => {
-    // Simulate DNS rebinding: first lookup returns a public IP, subsequent
-    // lookups return loopback. The validation step must capture only the
-    // public address so the pinned fetch cannot be rebind-attacked.
     let callCount = 0;
     const rebindDns: DnsLookupFn = async () => {
       callCount++;
@@ -134,18 +136,14 @@ describe('DNS rebinding — resolved-address pinning (issue #5478)', () => {
       { forbidLoopback: true },
     );
 
-    // Validation passed (first lookup returned a public IP)
     expect(result.parsed).toBeDefined();
     expect(result.error).toBeUndefined();
 
-    // Resolved addresses contain only the public IP, NOT the rebind loopback
     const addresses = result.resolvedAddresses!;
     expect(addresses).toHaveLength(1);
     expect(addresses[0]!.address).toBe('93.184.216.34');
     expect(addresses[0]!.address).not.toBe('127.0.0.1');
 
-    // DNS was resolved exactly once during validation — the pinned dispatcher
-    // will reuse these addresses and never trigger the rebind lookup.
     expect(callCount).toBe(1);
   });
 
@@ -169,11 +167,182 @@ describe('DNS rebinding — resolved-address pinning (issue #5478)', () => {
   it('IP-literal URLs do not get resolvedAddresses (no DNS lookup needed)', async () => {
     const result = await validateBaseUrlResolved(
       'http://93.184.216.34/image.png',
-      async () => [{ address: '127.0.0.1', family: 4 }], // would fail if called
+      async () => [{ address: '127.0.0.1', family: 4 }],
       { forbidLoopback: true },
     );
     expect(result.parsed).toBeDefined();
-    // No DNS lookup was performed for an IP literal, so no resolvedAddresses
     expect(result.resolvedAddresses).toBeUndefined();
+  });
+});
+
+describe('DNS lookup failure — fail-closed behavior (issue #5478)', () => {
+  it('validateBaseUrlResolved fails closed when DNS throws and forbidLoopback is true', async () => {
+    const throwingDns: DnsLookupFn = async () => {
+      throw new Error('ENOTFOUND');
+    };
+    const result = await validateBaseUrlResolved(
+      'http://attacker.example.com/image.png',
+      throwingDns,
+      { forbidLoopback: true },
+    );
+    expect(result.forbidden).toBe(true);
+    expect(result.error).toContain('DNS resolution failed');
+  });
+
+  it('validateBaseUrlResolved returns sync result when DNS throws and forbidLoopback is false', async () => {
+    // Provider endpoints should still return success on DNS failure — the
+    // actual fetch will surface the resolution error.
+    const throwingDns: DnsLookupFn = async () => {
+      throw new Error('ENOTFOUND');
+    };
+    const result = await validateBaseUrlResolved(
+      'http://provider.example.com/v1',
+      throwingDns,
+      { forbidLoopback: false },
+    );
+    expect(result.forbidden).toBeUndefined();
+    expect(result.parsed).toBeDefined();
+  });
+
+  it('assertExternalAssetUrl returns ok=false when DNS throws', async () => {
+    // The default DNS lookup will be used and may succeed for example.com,
+    // so test the fail-closed path through validateBaseUrlResolved directly.
+    const throwingDns: DnsLookupFn = async () => {
+      throw new Error('SERVFAIL');
+    };
+    const result = await validateBaseUrlResolved(
+      'http://fail-then-rebind.attacker.test/image.png',
+      throwingDns,
+      { forbidLoopback: true },
+    );
+    expect(result.forbidden).toBe(true);
+    expect(result.error).toContain('DNS resolution failed');
+  });
+});
+
+describe('createAssetValidatingLookup — connect-time guard (issue #5478)', () => {
+  // Mock dns.lookup implementation that returns loopback
+  const lookupReturnsLoopback = (
+    _hostname: string,
+    _opts: unknown,
+    cb: (err: Error | null, address: string, family: number) => void,
+  ): void => {
+    cb(null, '127.0.0.1', 4);
+  };
+
+  // Mock dns.lookup that returns a public address
+  const lookupReturnsPublic = (
+    _hostname: string,
+    _opts: unknown,
+    cb: (err: Error | null, address: string, family: number) => void,
+  ): void => {
+    cb(null, '93.184.216.34', 4);
+  };
+
+  // Mock dns.lookup that returns an RFC1918 address
+  const lookupReturnsInternal = (
+    _hostname: string,
+    _opts: unknown,
+    cb: (err: Error | null, address: string, family: number) => void,
+  ): void => {
+    cb(null, '10.0.0.5', 4);
+  };
+
+  // Mock dns.lookup that returns metadata service IP
+  const lookupReturnsMetadata = (
+    _hostname: string,
+    _opts: unknown,
+    cb: (err: Error | null, address: string, family: number) => void,
+  ): void => {
+    cb(null, '169.254.169.254', 4);
+  };
+
+  it('rejects loopback addresses at connect time', () => {
+    const lookup = createAssetValidatingLookup(
+      lookupReturnsLoopback as never,
+    );
+    return new Promise<void>((resolve) => {
+      lookup('attacker.test', {}, (...args: unknown[]) => {
+        const err = args[0] as Error | null;
+        expect(err).toBeInstanceOf(Error);
+        expect(err!.message).toContain('non-public');
+        resolve();
+      });
+    });
+  });
+
+  it('rejects RFC1918 addresses at connect time', () => {
+    const lookup = createAssetValidatingLookup(
+      lookupReturnsInternal as never,
+    );
+    return new Promise<void>((resolve) => {
+      lookup('internal.test', {}, (...args: unknown[]) => {
+        const err = args[0] as Error | null;
+        expect(err).toBeInstanceOf(Error);
+        expect(err!.message).toContain('non-public');
+        resolve();
+      });
+    });
+  });
+
+  it('rejects cloud metadata service IP (169.254.169.254)', () => {
+    const lookup = createAssetValidatingLookup(
+      lookupReturnsMetadata as never,
+    );
+    return new Promise<void>((resolve) => {
+      lookup('metadata.test', {}, (...args: unknown[]) => {
+        const err = args[0] as Error | null;
+        expect(err).toBeInstanceOf(Error);
+        expect(err!.message).toContain('non-public');
+        resolve();
+      });
+    });
+  });
+
+  it('allows public addresses through', () => {
+    const lookup = createAssetValidatingLookup(
+      lookupReturnsPublic as never,
+    );
+    return new Promise<void>((resolve) => {
+      lookup('cdn.example.com', {}, (...args: unknown[]) => {
+        const err = args[0] as Error | null;
+        const address = args[1];
+        expect(err).toBeNull();
+        expect(address).toBe('93.184.216.34');
+        resolve();
+      });
+    });
+  });
+});
+
+describe('assertAndFetchExternalAsset — fail-closed paths (issue #5478)', () => {
+  it('throws on blocked loopback URL', async () => {
+    await expect(
+      assertAndFetchExternalAsset('http://127.0.0.1:8080/evil.png'),
+    ).rejects.toThrow('blocked');
+  });
+
+  it('throws on blocked localhost URL', async () => {
+    await expect(
+      assertAndFetchExternalAsset('http://localhost:3000/image.png'),
+    ).rejects.toThrow('blocked');
+  });
+
+  it('throws on empty URL', async () => {
+    await expect(
+      assertAndFetchExternalAsset(''),
+    ).rejects.toThrow();
+  });
+
+  it('throws on internal IP URL', async () => {
+    await expect(
+      assertAndFetchExternalAsset('http://10.0.0.5/image.png'),
+    ).rejects.toThrow('blocked');
+  });
+
+  it('throws on metadata service IP URL', async () => {
+    await expect(
+      assertAndFetchExternalAsset('http://169.254.169.254/latest/meta-data/'),
+    ).rejects.toThrow('blocked');
   });
 });

--- a/apps/daemon/tests/asset-ssrf-loopback.test.ts
+++ b/apps/daemon/tests/asset-ssrf-loopback.test.ts
@@ -346,3 +346,69 @@ describe('assertAndFetchExternalAsset — fail-closed paths (issue #5478)', () =
     ).rejects.toThrow('blocked');
   });
 });
+
+describe('assertAndFetchExternalAsset — TOCTOU with injectable lookup (issue #5478)', () => {
+  it('rejects when validation lookup returns public but fetch would reach loopback', async () => {
+    // The validation lookup returns a public IP, so assertExternalAssetUrl passes.
+    // A real attacker would rebind DNS for the fetch lookup. With fail-closed +
+    // injectable fetch, we prove the fetch stub is still called with redirect:'error'
+    // and the validation was done against the right address set.
+    const publicLookup: DnsLookupFn = async () => [{ address: '93.184.216.34', family: 4 }];
+    let fetchCalled = false;
+    const stubFetch = async () => {
+      fetchCalled = true;
+      return new Response('ok', { status: 200 });
+    };
+
+    const resp = await assertAndFetchExternalAsset(
+      'http://rebind.example.com/asset.png',
+      {},
+      publicLookup,
+      stubFetch as never,
+    );
+    expect(fetchCalled).toBe(true);
+    expect(resp.ok).toBe(true);
+  });
+
+  it('rejects without invoking fetch when validation lookup throws', async () => {
+    // Attacker makes the validation lookup throw (ENOTFOUND / SERVFAIL).
+    // assertAndFetchExternalAsset should throw before fetch is ever called.
+    const throwingLookup: DnsLookupFn = async () => {
+      throw new Error('SERVFAIL');
+    };
+    let fetchCalled = false;
+    const stubFetch = async () => {
+      fetchCalled = true;
+      return new Response('should not reach', { status: 200 });
+    };
+
+    await expect(
+      assertAndFetchExternalAsset(
+        'http://fail-then-rebind.example.com/asset.png',
+        {},
+        throwingLookup,
+        stubFetch as never,
+      ),
+    ).rejects.toThrow('blocked');
+
+    expect(fetchCalled).toBe(false);
+  });
+
+  it('IP literal skips DNS validation and calls fetch directly', async () => {
+    let fetchCalled = false;
+    const stubFetch = async (_url: string, init?: RequestInit) => {
+      fetchCalled = true;
+      expect(init?.redirect).toBe('error');
+      return new Response('ok', { status: 200 });
+    };
+
+    const resp = await assertAndFetchExternalAsset(
+      'http://93.184.216.34/asset.png',
+      {},
+      undefined,
+      stubFetch as never,
+    );
+    expect(fetchCalled).toBe(true);
+    expect(resp.ok).toBe(true);
+  });
+});

--- a/apps/daemon/tests/asset-ssrf-loopback.test.ts
+++ b/apps/daemon/tests/asset-ssrf-loopback.test.ts
@@ -102,3 +102,78 @@ describe('validateBaseUrlResolved — DNS-resolved loopback (issue #5478)', () =
     expect(result.error).toContain('loopback');
   });
 });
+
+describe('DNS rebinding — resolved-address pinning (issue #5478)', () => {
+  it('validateBaseUrlResolved attaches validated addresses to the result', async () => {
+    const dns: DnsLookupFn = async () => [{ address: '93.184.216.34', family: 4 }];
+    const result = await validateBaseUrlResolved(
+      'http://cdn.example.com/image.png',
+      dns,
+      { forbidLoopback: true },
+    );
+    expect(result.parsed).toBeDefined();
+    expect(result.resolvedAddresses).toBeDefined();
+    expect(result.resolvedAddresses).toHaveLength(1);
+    expect(result.resolvedAddresses![0]!.address).toBe('93.184.216.34');
+  });
+
+  it('resolved addresses capture the public IP from the first lookup only', async () => {
+    // Simulate DNS rebinding: first lookup returns a public IP, subsequent
+    // lookups return loopback. The validation step must capture only the
+    // public address so the pinned fetch cannot be rebind-attacked.
+    let callCount = 0;
+    const rebindDns: DnsLookupFn = async () => {
+      callCount++;
+      if (callCount <= 1) return [{ address: '93.184.216.34', family: 4 }];
+      return [{ address: '127.0.0.1', family: 4 }];
+    };
+
+    const result = await validateBaseUrlResolved(
+      'http://rebind.attacker.com/image.png',
+      rebindDns,
+      { forbidLoopback: true },
+    );
+
+    // Validation passed (first lookup returned a public IP)
+    expect(result.parsed).toBeDefined();
+    expect(result.error).toBeUndefined();
+
+    // Resolved addresses contain only the public IP, NOT the rebind loopback
+    const addresses = result.resolvedAddresses!;
+    expect(addresses).toHaveLength(1);
+    expect(addresses[0]!.address).toBe('93.184.216.34');
+    expect(addresses[0]!.address).not.toBe('127.0.0.1');
+
+    // DNS was resolved exactly once during validation — the pinned dispatcher
+    // will reuse these addresses and never trigger the rebind lookup.
+    expect(callCount).toBe(1);
+  });
+
+  it('multiple validated addresses are all attached (round-robin DNS)', async () => {
+    const dns: DnsLookupFn = async () => [
+      { address: '93.184.216.34', family: 4 },
+      { address: '93.184.216.35', family: 4 },
+    ];
+    const result = await validateBaseUrlResolved(
+      'http://cdn.example.com/image.png',
+      dns,
+      { forbidLoopback: true },
+    );
+    expect(result.resolvedAddresses).toBeDefined();
+    expect(result.resolvedAddresses).toHaveLength(2);
+    expect(result.resolvedAddresses!.map((a) => a.address)).toEqual(
+      expect.arrayContaining(['93.184.216.34', '93.184.216.35']),
+    );
+  });
+
+  it('IP-literal URLs do not get resolvedAddresses (no DNS lookup needed)', async () => {
+    const result = await validateBaseUrlResolved(
+      'http://93.184.216.34/image.png',
+      async () => [{ address: '127.0.0.1', family: 4 }], // would fail if called
+      { forbidLoopback: true },
+    );
+    expect(result.parsed).toBeDefined();
+    // No DNS lookup was performed for an IP literal, so no resolvedAddresses
+    expect(result.resolvedAddresses).toBeUndefined();
+  });
+});

--- a/apps/daemon/tests/byok-tools.test.ts
+++ b/apps/daemon/tests/byok-tools.test.ts
@@ -83,13 +83,13 @@ describe('executeGenerateImage', () => {
         });
         return new Response(
           JSON.stringify({
-            url: 'https://cdn.example.test/generated/cat.png',
+            url: 'https://93.184.216.34/generated/cat.png',
             base_resp: { status_code: 0, status_msg: 'success' },
           }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
-      if (url === 'https://cdn.example.test/generated/cat.png') {
+      if (url === 'https://93.184.216.34/generated/cat.png') {
         return new Response(pngBytes, {
           status: 200,
           headers: { 'content-type': 'image/png' },
@@ -129,7 +129,7 @@ describe('executeGenerateImage', () => {
       if (url.endsWith('/v1/image/sync')) {
         expect(JSON.parse(String(init?.body)).model).toBe('doubao-seedream-5-0-260128');
         return new Response(
-          JSON.stringify({ url: 'https://cdn.example.test/hi.png' }),
+          JSON.stringify({ url: 'https://93.184.216.34/hi.png' }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
@@ -151,7 +151,7 @@ describe('executeGenerateImage', () => {
       if (url.endsWith('/v1/image/sync')) {
         expect(JSON.parse(String(init?.body)).model).toBe('senseaudio-image-1.0-260319');
         return new Response(
-          JSON.stringify({ url: 'https://cdn.example.test/std.png' }),
+          JSON.stringify({ url: 'https://93.184.216.34/std.png' }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
@@ -174,7 +174,7 @@ describe('executeGenerateImage', () => {
         // Falls through to ctx.defaultImageModel (registry-valid).
         expect(JSON.parse(String(init?.body)).model).toBe('senseaudio-image-1.0-260319');
         return new Response(
-          JSON.stringify({ url: 'https://cdn.example.test/x.png' }),
+          JSON.stringify({ url: 'https://93.184.216.34/x.png' }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
@@ -197,7 +197,7 @@ describe('executeGenerateImage', () => {
         // Registry default is the first SenseAudio entry — 2.0 today.
         expect(JSON.parse(String(init?.body)).model).toBe('senseaudio-image-2.0-260319');
         return new Response(
-          JSON.stringify({ url: 'https://cdn.example.test/d.png' }),
+          JSON.stringify({ url: 'https://93.184.216.34/d.png' }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
@@ -236,7 +236,7 @@ describe('executeGenerateImage', () => {
       if (url.endsWith('/v1/image/sync')) {
         expect(JSON.parse(String(init?.body)).size).toBe('1280x720');
         return new Response(
-          JSON.stringify({ url: 'https://cdn.example.test/wide.png' }),
+          JSON.stringify({ url: 'https://93.184.216.34/wide.png' }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
@@ -259,7 +259,7 @@ describe('executeGenerateImage', () => {
       if (url.endsWith('/v1/image/sync')) {
         expect(JSON.parse(String(init?.body)).size).toBe('1024x1024');
         return new Response(
-          JSON.stringify({ url: 'https://cdn.example.test/square.png' }),
+          JSON.stringify({ url: 'https://93.184.216.34/square.png' }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
@@ -361,7 +361,7 @@ describe('executeGenerateImage', () => {
       const url = String(input);
       if (url.endsWith('/v1/image/sync')) {
         return new Response(
-          JSON.stringify({ url: 'https://cdn.example.test/will-404.png' }),
+          JSON.stringify({ url: 'https://93.184.216.34/will-404.png' }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
@@ -673,14 +673,14 @@ describe('executeGenerateVideo', () => {
           JSON.stringify({
             status: 'completed',
             progress: 100,
-            video_url: 'https://cdn.example.test/video/done.mp4',
+            video_url: 'https://93.184.216.34/video/done.mp4',
             duration: 8,
           }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
 
-      if (url === 'https://cdn.example.test/video/done.mp4') {
+      if (url === 'https://93.184.216.34/video/done.mp4') {
         return new Response(mp4Bytes, {
           status: 200,
           headers: { 'content-type': 'video/mp4' },
@@ -736,7 +736,7 @@ describe('executeGenerateVideo', () => {
         return new Response(
           JSON.stringify({
             status: 'completed',
-            video_url: 'https://cdn.example.test/video/d.mp4',
+            video_url: 'https://93.184.216.34/video/d.mp4',
           }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
@@ -770,7 +770,7 @@ describe('executeGenerateVideo', () => {
         return new Response(
           JSON.stringify({
             status: 'completed',
-            video_url: 'https://cdn.example.test/clamp.mp4',
+            video_url: 'https://93.184.216.34/clamp.mp4',
           }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
@@ -1003,13 +1003,13 @@ describe('executeAIHubMixGenerateVideo', () => {
         return new Response(
           JSON.stringify({
             status: 'completed',
-            video_url: 'https://cdn.example.test/video/done.mp4',
+            video_url: 'https://93.184.216.34/video/done.mp4',
           }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
 
-      if (url === 'https://cdn.example.test/video/done.mp4') {
+      if (url === 'https://93.184.216.34/video/done.mp4') {
         return new Response(mp4Bytes, {
           status: 200,
           headers: { 'content-type': 'video/mp4' },
@@ -1095,11 +1095,11 @@ describe('executeAIHubMixGenerateVideo', () => {
       }
       if (url === 'https://aihubmix.com/v1/videos/v-cdn') {
         return new Response(
-          JSON.stringify({ status: 'completed', video_url: 'https://cdn.example.test/signed.mp4' }),
+          JSON.stringify({ status: 'completed', video_url: 'https://93.184.216.34/signed.mp4' }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
-      if (url === 'https://cdn.example.test/signed.mp4') {
+      if (url === 'https://93.184.216.34/signed.mp4') {
         cdnHeaders = init?.headers ?? {};
         return new Response(Buffer.from([0x01]), { status: 200 });
       }
@@ -1157,7 +1157,7 @@ describe('executeAIHubMixGenerateVideo', () => {
       }
       if (url === 'https://aihubmix.com/v1/videos/v1') {
         return new Response(
-          JSON.stringify({ status: 'completed', url: 'https://cdn.example.test/v.mp4' }),
+          JSON.stringify({ status: 'completed', url: 'https://93.184.216.34/v.mp4' }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
@@ -1186,7 +1186,7 @@ describe('executeAIHubMixGenerateVideo', () => {
         });
       }
       return new Response(
-        JSON.stringify({ status: 'completed', url: 'https://cdn.example.test/v.mp4' }),
+        JSON.stringify({ status: 'completed', url: 'https://93.184.216.34/v.mp4' }),
         { status: 200, headers: { 'content-type': 'application/json' } },
       );
     });
@@ -1208,7 +1208,7 @@ describe('executeAIHubMixGenerateVideo', () => {
         });
       }
       return new Response(
-        JSON.stringify({ status: 'completed', url: 'https://cdn.example.test/v.mp4' }),
+        JSON.stringify({ status: 'completed', url: 'https://93.184.216.34/v.mp4' }),
         { status: 200, headers: { 'content-type': 'application/json' } },
       );
     });
@@ -1254,7 +1254,7 @@ describe('executeAIHubMixGenerateVideo', () => {
         });
       }
       return new Response(
-        JSON.stringify({ status: 'completed', url: 'https://cdn.example.test/v.mp4' }),
+        JSON.stringify({ status: 'completed', url: 'https://93.184.216.34/v.mp4' }),
         { status: 200, headers: { 'content-type': 'application/json' } },
       );
     });
@@ -1292,7 +1292,7 @@ describe('executeAIHubMixGenerateVideo', () => {
       }
       if (url === 'https://aihubmix.com/v1/videos/v-i2v') {
         return new Response(
-          JSON.stringify({ status: 'completed', url: 'https://cdn.example.test/v.mp4' }),
+          JSON.stringify({ status: 'completed', url: 'https://93.184.216.34/v.mp4' }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
@@ -1339,7 +1339,7 @@ describe('executeAIHubMixGenerateVideo', () => {
       }
       if (url === 'https://aihubmix.com/v1/videos/v-i2v2') {
         return new Response(
-          JSON.stringify({ status: 'completed', url: 'https://cdn.example.test/v.mp4' }),
+          JSON.stringify({ status: 'completed', url: 'https://93.184.216.34/v.mp4' }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
@@ -1385,7 +1385,7 @@ describe('executeAIHubMixGenerateVideo', () => {
       }
       if (url === 'https://aihubmix.com/v1/videos/v-t2v') {
         return new Response(
-          JSON.stringify({ status: 'completed', url: 'https://cdn.example.test/v.mp4' }),
+          JSON.stringify({ status: 'completed', url: 'https://93.184.216.34/v.mp4' }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }

--- a/apps/daemon/tests/byok-tools.test.ts
+++ b/apps/daemon/tests/byok-tools.test.ts
@@ -69,7 +69,13 @@ describe('executeGenerateImage', () => {
     const dispatcher = { dispatch: vi.fn() } as unknown as NonNullable<RequestInit['dispatcher']>;
     const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
       const url = String(input);
-      expect(init?.dispatcher).toBe(dispatcher);
+      // Asset downloads route through assertAndFetchExternalAsset which replaces
+      // the caller's dispatcher with a validating one (issue #5478).
+      if (init?.redirect === 'error') {
+        expect(init.dispatcher).toBeDefined();
+      } else {
+        expect(init?.dispatcher).toBe(dispatcher);
+      }
       if (url === 'https://api.senseaudio.cn/v1/image/sync') {
         expect(init?.method).toBe('POST');
         expect(init?.headers).toMatchObject({
@@ -632,7 +638,13 @@ describe('executeGenerateVideo', () => {
     let pollCount = 0;
     const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
       const url = String(input);
-      expect(init?.dispatcher).toBe(dispatcher);
+      // Asset downloads route through assertAndFetchExternalAsset which replaces
+      // the caller's dispatcher with a validating one (issue #5478).
+      if (init?.redirect === 'error') {
+        expect(init.dispatcher).toBeDefined();
+      } else {
+        expect(init?.dispatcher).toBe(dispatcher);
+      }
 
       if (url === 'https://api.senseaudio.cn/v1/video/create') {
         expect(init?.method).toBe('POST');
@@ -962,7 +974,13 @@ describe('executeAIHubMixGenerateVideo', () => {
     let pollCount = 0;
     const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
       const url = String(input);
-      expect(init?.dispatcher).toBe(dispatcher);
+      // Asset downloads route through assertAndFetchExternalAsset which replaces
+      // the caller's dispatcher with a validating one (issue #5478).
+      if (init?.redirect === 'error') {
+        expect(init.dispatcher).toBeDefined();
+      } else {
+        expect(init?.dispatcher).toBe(dispatcher);
+      }
 
       if (url === 'https://aihubmix.com/v1/videos') {
         expect(init?.method).toBe('POST');

--- a/apps/daemon/tests/byok-tools.test.ts
+++ b/apps/daemon/tests/byok-tools.test.ts
@@ -14,6 +14,7 @@ import {
   executeAIHubMixGenerateImage,
   executeAIHubMixGenerateSpeech,
 } from '../src/byok-tools.js';
+import { getAssetValidatingDispatcher } from '../src/connectionTest.js';
 
 describe('BYOK_SENSEAUDIO_TOOLS', () => {
   it('exports an OpenAI-shaped generate_image tool definition', () => {
@@ -69,10 +70,13 @@ describe('executeGenerateImage', () => {
     const dispatcher = { dispatch: vi.fn() } as unknown as NonNullable<RequestInit['dispatcher']>;
     const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
       const url = String(input);
-      // Asset downloads route through assertAndFetchExternalAsset which replaces
-      // the caller's dispatcher with a validating one (issue #5478).
-      if (init?.redirect === 'error') {
-        expect(init.dispatcher).toBeDefined();
+      // Asset downloads route through assertAndFetchExternalAsset which
+      // replaces the caller's dispatcher with the shared validating one
+      // (issue #5478). Keyed on the asset URL — NOT on `redirect: 'error'`,
+      // which other providers also set on submit hops that must keep the
+      // caller dispatcher.
+      if (url === 'https://93.184.216.34/generated/cat.png') {
+        expect(init?.dispatcher).toBe(getAssetValidatingDispatcher());
       } else {
         expect(init?.dispatcher).toBe(dispatcher);
       }
@@ -638,10 +642,12 @@ describe('executeGenerateVideo', () => {
     let pollCount = 0;
     const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
       const url = String(input);
-      // Asset downloads route through assertAndFetchExternalAsset which replaces
-      // the caller's dispatcher with a validating one (issue #5478).
-      if (init?.redirect === 'error') {
-        expect(init.dispatcher).toBeDefined();
+      // Asset downloads route through assertAndFetchExternalAsset which
+      // replaces the caller's dispatcher with the shared validating one
+      // (issue #5478). Keyed on the asset URL — NOT on `redirect: 'error'`,
+      // because submit/poll hops must keep the caller dispatcher.
+      if (url === 'https://93.184.216.34/video/done.mp4') {
+        expect(init?.dispatcher).toBe(getAssetValidatingDispatcher());
       } else {
         expect(init?.dispatcher).toBe(dispatcher);
       }
@@ -974,10 +980,14 @@ describe('executeAIHubMixGenerateVideo', () => {
     let pollCount = 0;
     const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
       const url = String(input);
-      // Asset downloads route through assertAndFetchExternalAsset which replaces
-      // the caller's dispatcher with a validating one (issue #5478).
-      if (init?.redirect === 'error') {
-        expect(init.dispatcher).toBeDefined();
+      // Asset downloads route through assertAndFetchExternalAsset which
+      // replaces the caller's dispatcher with the shared validating one
+      // (issue #5478). Keyed on the asset URL — NOT on `redirect: 'error'`,
+      // because the AIHubMix submit hop itself sets redirect:'error' and
+      // must still keep the caller dispatcher (this was the gap the
+      // redirect heuristic silently hid).
+      if (url === 'https://93.184.216.34/video/done.mp4') {
+        expect(init?.dispatcher).toBe(getAssetValidatingDispatcher());
       } else {
         expect(init?.dispatcher).toBe(dispatcher);
       }

--- a/apps/daemon/tests/media/openai-compatible-providers.test.ts
+++ b/apps/daemon/tests/media/openai-compatible-providers.test.ts
@@ -300,13 +300,13 @@ process.stdin.on('end', () => {
       if (String(input) === 'https://images.example.test/v1/images/generations') {
         expect(init?.dispatcher).toBe(dispatcher);
         return new Response(JSON.stringify({
-          data: [{ url: 'https://cdn.example.test/generated.png' }],
+          data: [{ url: 'https://93.184.216.34/generated.png' }],
         }), {
           status: 200,
           headers: { 'content-type': 'application/json' },
         });
       }
-      expect(String(input)).toBe('https://cdn.example.test/generated.png');
+      expect(String(input)).toBe('https://93.184.216.34/generated.png');
       expect(init?.dispatcher).toBe(dispatcher);
       return new Response(Buffer.from(PNG_BASE64, 'base64'));
     });
@@ -341,13 +341,13 @@ process.stdin.on('end', () => {
       if (String(input) === 'https://images.example.test/v1/images/generations') {
         submitCalls += 1;
         return new Response(JSON.stringify({
-          data: [{ url: 'https://cdn.example.test/generated.png' }],
+          data: [{ url: 'https://93.184.216.34/generated.png' }],
         }), {
           status: 200,
           headers: { 'content-type': 'application/json' },
         });
       }
-      expect(String(input)).toBe('https://cdn.example.test/generated.png');
+      expect(String(input)).toBe('https://93.184.216.34/generated.png');
       return new Response('temporarily unavailable', { status: 503 });
     });
     vi.stubGlobal('fetch', fetchMock);

--- a/apps/daemon/tests/media/senseaudio-image.test.ts
+++ b/apps/daemon/tests/media/senseaudio-image.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { generateMedia } from '../../src/media/index.js';
 
 const TEST_SENSEAUDIO_BASE_URL = 'https://senseaudio-gateway.example.test';
-const TEST_IMAGE_URL = 'https://cdn.example.test/generated/abc.png';
+const TEST_IMAGE_URL = 'https://93.184.216.34/generated/abc.png';
 const TEST_IMAGE_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x01]);
 
 function buildOkResponse(url = TEST_IMAGE_URL) {

--- a/apps/daemon/tests/media/senseaudio.test.ts
+++ b/apps/daemon/tests/media/senseaudio.test.ts
@@ -229,14 +229,14 @@ describe('senseaudio media generation', () => {
       if (String(input) === `${TEST_SENSEAUDIO_BASE_URL}/v1/image/sync`) {
         expect(init?.dispatcher).toBe(dispatcher);
         return new Response(JSON.stringify({
-          url: 'https://cdn.example.test/senseaudio-image.png',
+          url: 'https://93.184.216.34/senseaudio-image.png',
           base_resp: { status_code: 0, status_msg: 'success' },
         }), {
           status: 200,
           headers: { 'content-type': 'application/json' },
         });
       }
-      expect(String(input)).toBe('https://cdn.example.test/senseaudio-image.png');
+      expect(String(input)).toBe('https://93.184.216.34/senseaudio-image.png');
       expect(init?.dispatcher).toBe(dispatcher);
       expect(init?.redirect).toBe('error');
       return new Response(Buffer.from([0x89, 0x50, 0x4e, 0x47]));

--- a/apps/daemon/tests/media/senseaudio.test.ts
+++ b/apps/daemon/tests/media/senseaudio.test.ts
@@ -237,7 +237,9 @@ describe('senseaudio media generation', () => {
         });
       }
       expect(String(input)).toBe('https://93.184.216.34/senseaudio-image.png');
-      expect(init?.dispatcher).toBe(dispatcher);
+      // Asset download goes through assertAndFetchExternalAsset which replaces
+      // the caller's dispatcher with a validating one (issue #5478).
+      expect(init?.dispatcher).toBeDefined();
       expect(init?.redirect).toBe('error');
       return new Response(Buffer.from([0x89, 0x50, 0x4e, 0x47]));
     });

--- a/apps/daemon/tests/proxy-routes.test.ts
+++ b/apps/daemon/tests/proxy-routes.test.ts
@@ -1490,7 +1490,7 @@ describe('API proxy routes', () => {
       if (url === 'https://api.senseaudio.cn/v1/image/sync') {
         return new Response(
           JSON.stringify({
-            url: 'https://cdn.example.test/cat.png',
+            url: 'https://93.184.216.34/cat.png',
             base_resp: { status_code: 0, status_msg: 'success' },
           }),
           { status: 200, headers: { 'content-type': 'application/json' } },
@@ -1498,7 +1498,7 @@ describe('API proxy routes', () => {
       }
 
       // Image bytes download (initiated by the tool, not via the proxy)
-      if (url === 'https://cdn.example.test/cat.png') {
+      if (url === 'https://93.184.216.34/cat.png') {
         return new Response(pngBytes, {
           status: 200,
           headers: { 'content-type': 'image/png' },
@@ -1714,11 +1714,11 @@ describe('API proxy routes', () => {
       if (url.startsWith(baseUrl)) return realFetch(input, init);
       if (url === 'https://api.senseaudio.cn/v1/image/sync') {
         return new Response(
-          JSON.stringify({ url: 'https://cdn.example.test/x.png' }),
+          JSON.stringify({ url: 'https://93.184.216.34/x.png' }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
-      if (url === 'https://cdn.example.test/x.png') {
+      if (url === 'https://93.184.216.34/x.png') {
         return new Response(Buffer.from([0x89, 0x50]), { status: 200 });
       }
       if (url === 'https://api.senseaudio.cn/v1/chat/completions') {
@@ -1765,11 +1765,11 @@ describe('API proxy routes', () => {
       if (url.startsWith(baseUrl)) return realFetch(input, init);
       if (url === 'https://api.senseaudio.cn/v1/image/sync') {
         return new Response(
-          JSON.stringify({ url: 'https://cdn.example.test/served.png' }),
+          JSON.stringify({ url: 'https://93.184.216.34/served.png' }),
           { status: 200, headers: { 'content-type': 'application/json' } },
         );
       }
-      if (url === 'https://cdn.example.test/served.png') {
+      if (url === 'https://93.184.216.34/served.png') {
         return new Response(pngBytes, { status: 200 });
       }
       if (url === 'https://api.senseaudio.cn/v1/chat/completions') {

--- a/packages/contracts/src/api/connectionTest.ts
+++ b/packages/contracts/src/api/connectionTest.ts
@@ -148,6 +148,13 @@ export interface ValidateBaseUrlOptions {
   // from the internal-IP block. Defaults to none, keeping the strict
   // default-deny behavior for every caller that does not opt in.
   allowedInternalHosts?: readonly string[];
+  // When true, loopback hosts (127.0.0.0/8, ::1, localhost) are treated as
+  // forbidden rather than allowed. Used by `assertExternalAssetUrl` for
+  // attacker-controllable asset download URLs (issue #5478), where loopback
+  // must never be reachable regardless of the operator allowlist. Defaults to
+  // false so user-configured provider endpoints (connection test, BYOK chat)
+  // keep working with local gateways.
+  forbidLoopback?: boolean;
 }
 
 export function validateBaseUrl(
@@ -164,6 +171,12 @@ export function validateBaseUrl(
     return { error: 'Only http/https allowed' };
   }
   const hostname = parsed.hostname.toLowerCase();
+  // When forbidLoopback is set (asset download URLs), reject loopback
+  // hosts entirely — they should never be reachable from an
+  // attacker-controllable response field (issue #5478).
+  if (options.forbidLoopback && isLoopbackApiHost(hostname)) {
+    return { error: 'Loopback addresses blocked for asset URLs', forbidden: true };
+  }
   if (
     !isLoopbackApiHost(hostname) &&
     !isAllowlistedInternalHost(hostname, options.allowedInternalHosts) &&

--- a/packages/contracts/src/api/connectionTest.ts
+++ b/packages/contracts/src/api/connectionTest.ts
@@ -9,6 +9,13 @@ export interface BaseUrlValidationResult {
   parsed?: ParsedBaseUrl;
   error?: string;
   forbidden?: boolean;
+  // Addresses resolved by DNS lookup that passed validation. Present when
+  // `validateBaseUrlResolved` performed a DNS lookup and every resolved address
+  // was safe (public, or allowlisted). Callers that fetch the URL (e.g.
+  // `assertAndFetchExternalAsset`) pin the connection to these addresses so
+  // that a DNS-rebinding domain cannot return a different (loopback/internal)
+  // address at fetch time (issue #5478).
+  resolvedAddresses?: ReadonlyArray<{ address: string; family: number }>;
 }
 
 export interface ParsedBaseUrl {


### PR DESCRIPTION
## Summary

assertExternalAssetUrl() previously routed through validateBaseUrlResolved() without forbidLoopback, so asset URLs pointing at 127.0.0.1, localhost, or ::1 passed validation and were fetched by the daemon. PR #5529 fixed library-ingest; this closes the BYOK asset-download path.

Before: asset URLs could point at loopback → daemon fetched them → SSRF seam
After: assertExternalAssetUrl passes forbidLoopback: true → loopback rejected at sync+DNS layers

## Changes
- packages/contracts: add forbidLoopback to ValidateBaseUrlOptions, enforce in validateBaseUrl
- apps/daemon/src/connectionTest.ts: honor forbidLoopback in validateBaseUrlResolved early-return AND resolved-address loop; pass forbidLoopback: true from assertExternalAssetUrl
- apps/daemon/tests/asset-ssrf-loopback.test.ts: 12 test cases covering literal loopback, DNS-resolved loopback (IPv4, IPv6, mixed results), valid public URLs, and provider endpoint exemption

## Surface area

- **Routes**: The BYOK chat tool image/video download paths (`byok-tools.ts`) and the CLI agent media path (`media.ts` `renderSenseAudioImage`)
- **Function**: `assertExternalAssetUrl()` → `validateBaseUrlResolved()` in `apps/daemon/src/connectionTest.ts`
- **Impact**: Any asset URL returned inside an upstream API response (`data.url`, `data.video_url`) is now validated with `forbidLoopback: true`
- **Non-affected**: `validateUserProviderBaseUrl()` — user-configured provider endpoints still allow loopback for local gateways
- **Resolution layer**: Both literal loopback hosts AND DNS names that resolve to loopback addresses are now blocked

## Validation

- Ran `pnpm --filter @open-design/daemon test -- asset-ssrf-loopback` — all 12 test cases pass
- Tested with DNS mock returning loopback addresses:
  - `dnsResolvesLoopback` → rejected ✓
  - `dnsResolvesMixed` (public + loopback) → rejected ✓
  - `dnsResolvesV6Loopback` (::1) → rejected ✓
  - `dnsResolvesLoopback` with `forbidLoopback: false` → allowed (provider endpoint exemption) ✓
- Verified existing connectionTest tests still pass (no regression in user-configured endpoint validation)

Closes #5478