### PR TITLE
allow custom model entry in the onboarding BYOK model picker

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -4123,11 +4123,11 @@ export function OnboardingDropdown(props: OnboardingDropdownProps) {
     !options.some((option) => option.value.toLowerCase() === normalizedQuery);
   const visibleOptions = canUseCustomValue
     ? [
+        ...filteredOptions,
         {
           value: trimmedQuery,
           label: t('settings.onboardingModelUseCustom', { query: trimmedQuery }),
         },
-        ...filteredOptions,
       ]
     : filteredOptions;
   const emptyMessage = searchable ? t('homeHero.footer.noMatches') : t('settings.fetchModelsEmpty');

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -3813,6 +3813,7 @@ function OnboardingByokSetupPanel({
             placement="top"
             searchable
             searchPlaceholder={t('newproj.modelSearch')}
+            allowCustomValue
           />
         ) : (
           <label className="onboarding-view__inline-field">
@@ -4048,6 +4049,13 @@ type OnboardingDropdownBaseProps = {
   searchPlaceholder?: string;
   sourceTone?: string;
   allowEmptyValue?: boolean;
+  /**
+   * When true (and not multi-select), a typed search query that doesn't match
+   * any existing option is offered as a selectable "Use '<query>'" entry, so
+   * users can pick a value that isn't in the suggested list (e.g. a locally
+   * installed Ollama model).
+   */
+  allowCustomValue?: boolean;
 };
 
 type OnboardingDropdownProps =
@@ -4075,6 +4083,7 @@ export function OnboardingDropdown(props: OnboardingDropdownProps) {
     searchPlaceholder,
     sourceTone,
     allowEmptyValue = false,
+    allowCustomValue = false,
   } = props;
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
@@ -4100,12 +4109,27 @@ export function OnboardingDropdown(props: OnboardingDropdownProps) {
     : undefined;
   const triggerLabel = selectedLabel || placeholder;
   const normalizedQuery = query.trim().toLowerCase();
-  const visibleOptions =
+  const trimmedQuery = query.trim();
+  const filteredOptions =
     searchable && normalizedQuery
       ? options.filter((option) =>
           `${option.label} ${option.value}`.toLowerCase().includes(normalizedQuery),
         )
       : options;
+  const canUseCustomValue =
+    allowCustomValue &&
+    !multiple &&
+    trimmedQuery.length > 0 &&
+    !options.some((option) => option.value.toLowerCase() === normalizedQuery);
+  const visibleOptions = canUseCustomValue
+    ? [
+        {
+          value: trimmedQuery,
+          label: t('settings.onboardingModelUseCustom', { query: trimmedQuery }),
+        },
+        ...filteredOptions,
+      ]
+    : filteredOptions;
   const emptyMessage = searchable ? t('homeHero.footer.noMatches') : t('settings.fetchModelsEmpty');
 
   useLayoutEffect(() => {

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -605,6 +605,7 @@ export const ar: Dict = {
   'settings.modelCustom': 'مخصص (اكتب أدناه)...',
   'settings.modelCustomLabel': 'معرف النموذج المخصص',
   'settings.modelCustomPlaceholder': 'مثلاً: anthropic/claude-sonnet-4-6',
+  'settings.onboardingModelUseCustom': 'Use "{query}"',
   'settings.mediaProviders': 'مزودو الوسائط',
   'settings.mediaProvidersHint': 'مفاتيح API لإنشاء الصور والفيديو والصوت. تخزن محلياً وتزامن مع البرنامج الخفي المحلي.',
   'settings.mcpServerTitle': 'Open Design MCP',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -605,6 +605,7 @@ export const de: Dict = {
   'settings.modelCustom': 'Benutzerdefiniert (unten eingeben)…',
   'settings.modelCustomLabel': 'Benutzerdefinierte Modell-ID',
   'settings.modelCustomPlaceholder': 'z. B. anthropic/claude-sonnet-4-6',
+  'settings.onboardingModelUseCustom': 'Use "{query}"',
   'settings.mediaProviders': 'Medienanbieter',
   'settings.mediaProvidersHint': 'API-Keys für Bild-, Video- und Audiogenerierung. Lokal gespeichert und mit dem lokalen Daemon synchronisiert.',
   'settings.mcpServerTitle': 'Open Design MCP',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -605,6 +605,7 @@ export const en: Dict = {
   'settings.modelCustom': 'Custom (type below)…',
   'settings.modelCustomLabel': 'Custom model id',
   'settings.modelCustomPlaceholder': 'e.g. anthropic/claude-sonnet-4-6',
+  'settings.onboardingModelUseCustom': 'Use "{query}"',
   'settings.mediaProviders': 'Media providers',
   'settings.mediaProvidersHint': 'Connect providers for image, video, audio, and search.',
   'settings.mcpServerTitle': 'Open Design MCP',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -605,6 +605,7 @@ export const esES: Dict = {
   'settings.modelCustom': 'Personalizado (escribe abajo)…',
   'settings.modelCustomLabel': 'Id de modelo personalizado',
   'settings.modelCustomPlaceholder': 'p. ej., anthropic/claude-sonnet-4-6',
+  'settings.onboardingModelUseCustom': 'Use "{query}"',
   'settings.mediaProviders': 'Proveedores de medios',
   'settings.mediaProvidersHint': 'Claves de API para generación de imagen, vídeo y audio. Se guardan localmente y se sincronizan con el daemon local.',
   'settings.mcpServerTitle': 'Open Design MCP',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -605,6 +605,7 @@ export const fa: Dict = {
   'settings.modelCustom': 'سفارشی (در زیر تایپ کنید)…',
   'settings.modelCustomLabel': 'شناسه مدل سفارشی',
   'settings.modelCustomPlaceholder': 'مثلاً anthropic/claude-sonnet-4-6',
+  'settings.onboardingModelUseCustom': 'Use "{query}"',
   'settings.mediaProviders': 'ارائه‌دهندگان رسانه',
   'settings.mediaProvidersHint': 'کلیدهای API برای تولید تصویر، ویدئو و صدا. به صورت محلی ذخیره و با daemon محلی همگام می‌شود.',
   'settings.mcpServerTitle': 'Open Design MCP',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -605,6 +605,7 @@ export const fr: Dict = {
   'settings.modelCustom': 'Personnalisé (saisir ci-dessous)…',
   'settings.modelCustomLabel': 'Identifiant du modèle personnalisé',
   'settings.modelCustomPlaceholder': 'ex. anthropic/claude-sonnet-4-6',
+  'settings.onboardingModelUseCustom': 'Use "{query}"',
   'settings.mediaProviders': 'Fournisseurs de médias',
   'settings.mediaProvidersHint': 'Clés API pour la génération d’images, de vidéos et d’audio.',
   'settings.mcpServerTitle': 'Open Design MCP',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -605,6 +605,7 @@ export const hu: Dict = {
   'settings.modelCustom': 'Egyedi (gépeld be alább)…',
   'settings.modelCustomLabel': 'Egyedi modell-id',
   'settings.modelCustomPlaceholder': 'pl. anthropic/claude-sonnet-4-6',
+  'settings.onboardingModelUseCustom': 'Use "{query}"',
   'settings.mediaProviders': 'Média-szolgáltatók',
   'settings.mediaProvidersHint': 'API-kulcsok kép-, videó- és hanggeneráláshoz. Helyben tárolva, és a helyi daemonnal szinkronizálva.',
   'settings.mcpServerTitle': 'Open Design MCP',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -605,6 +605,7 @@ export const id: Dict = {
   'settings.modelCustom': 'Kustom (isi di bawah)...',
   'settings.modelCustomLabel': 'ID model kustom',
   'settings.modelCustomPlaceholder': 'mis. anthropic/claude-sonnet-4-6',
+  'settings.onboardingModelUseCustom': 'Use "{query}"',
   'settings.mediaProviders': 'Provider media',
   'settings.mediaProvidersHint': 'API key untuk generasi gambar, video, dan audio. Disimpan lokal dan disinkronkan ke daemon lokal.',
   'settings.mcpServerTitle': 'Open Design MCP',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -605,6 +605,7 @@ export const it: Dict = {
   'settings.modelCustom': 'Personalizzato (inserisci sotto)…',
   'settings.modelCustomLabel': 'Identificatore del modello personalizzato',
   'settings.modelCustomPlaceholder': 'es. anthropic/claude-sonnet-4-6',
+  'settings.onboardingModelUseCustom': 'Use "{query}"',
   'settings.mediaProviders': 'Provider di media',
   'settings.mediaProvidersHint': 'Chiavi API per la generazione di immagini, video e audio. Memorizzate localmente e sincronizzate con il daemon locale.',
   'settings.mcpServerTitle': 'Open Design MCP',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -605,6 +605,7 @@ export const ja: Dict = {
   'settings.modelCustom': 'カスタム（下に入力）…',
   'settings.modelCustomLabel': 'カスタムモデル ID',
   'settings.modelCustomPlaceholder': '例: anthropic/claude-sonnet-4-6',
+  'settings.onboardingModelUseCustom': 'Use "{query}"',
   'settings.mediaProviders': 'メディアプロバイダー',
   'settings.mediaProvidersHint': '画像・動画・音声生成のための API キー。ローカルに保存され、ローカルデーモンに同期されます。',
   'settings.mcpServerTitle': 'Open Design MCP',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -605,6 +605,7 @@ export const ko: Dict = {
   'settings.modelCustom': '직접 입력…',
   'settings.modelCustomLabel': '사용자 지정 모델 ID',
   'settings.modelCustomPlaceholder': '예: anthropic/claude-sonnet-4-6',
+  'settings.onboardingModelUseCustom': 'Use "{query}"',
   'settings.mediaProviders': '미디어 프로바이더',
   'settings.mediaProvidersHint': '이미지, 비디오, 오디오 생성을 위한 API 키입니다. 로컬에 저장되며 로컬 데몬과 동기화됩니다.',
   'settings.mcpServerTitle': 'Open Design MCP',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -605,6 +605,7 @@ export const pl: Dict = {
   'settings.modelCustom': 'Własny (wpisz poniżej)…',
   'settings.modelCustomLabel': 'Własne ID modelu',
   'settings.modelCustomPlaceholder': 'np. anthropic/claude-sonnet-4-6',
+  'settings.onboardingModelUseCustom': 'Use "{query}"',
   'settings.mediaProviders': 'Dostawcy multimediów',
   'settings.mediaProvidersHint': 'Klucze API do generowania obrazów, wideo i dźwięku. Przechowywane lokalnie i synchronizowane z lokalnym daemonem.',
   'settings.mcpServerTitle': 'Open Design MCP',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -605,6 +605,7 @@ export const ptBR: Dict = {
   'settings.modelCustom': 'Personalizado (digite abaixo)…',
   'settings.modelCustomLabel': 'Id do modelo personalizado',
   'settings.modelCustomPlaceholder': 'ex.: anthropic/claude-sonnet-4-6',
+  'settings.onboardingModelUseCustom': 'Use "{query}"',
   'settings.mediaProviders': 'Provedores de mídia',
   'settings.mediaProvidersHint': 'Chaves de API para geração de imagem, vídeo e áudio. Salvas localmente e sincronizadas com o daemon local.',
   'settings.mcpServerTitle': 'Open Design MCP',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -605,6 +605,7 @@ export const ru: Dict = {
   'settings.modelCustom': 'Пользовательская (введите ниже)…',
   'settings.modelCustomLabel': 'Пользовательский ID модели',
   'settings.modelCustomPlaceholder': 'например, anthropic/claude-sonnet-4-6',
+  'settings.onboardingModelUseCustom': 'Use "{query}"',
   'settings.mediaProviders': 'Медиа-провайдеры',
   'settings.mediaProvidersHint': 'API-ключи для генерации изображений, видео и аудио. Хранятся локально и синхронизируются с локальным демоном.',
   'settings.mcpServerTitle': 'Open Design MCP',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -605,6 +605,7 @@ export const th: Dict = {
   'settings.modelCustom': 'กำหนดเอง (พิมพ์ด้านล่าง)…',
   'settings.modelCustomLabel': 'ID โมเดลที่กำหนดเอง',
   'settings.modelCustomPlaceholder': 'เช่น anthropic/claude-sonnet-4-6',
+  'settings.onboardingModelUseCustom': 'Use "{query}"',
   'settings.mediaProviders': 'ผู้ให้บริการสื่อ',
   'settings.mediaProvidersHint': 'API keys สำหรับการสร้างภาพ วิดีโอ และเสียง บันทึกในเครื่องและซิงค์กับ local daemon',
   'settings.mcpServerTitle': 'Open Design MCP',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -605,6 +605,7 @@ export const tr: Dict = {
   'settings.modelCustom': 'Özel (aşağıya yazın)…',
   'settings.modelCustomLabel': 'Özel model kimliği',
   'settings.modelCustomPlaceholder': 'örn. anthropic/claude-sonnet-4-6',
+  'settings.onboardingModelUseCustom': 'Use "{query}"',
   'settings.mediaProviders': 'Medya sağlayıcıları',
   'settings.mediaProvidersHint': 'Görsel, video ve ses oluşumu için API anahtarları. Yerel saklanır ve yerel arka plan servisiyle senkronize edilir.',
   'settings.mcpServerTitle': 'Open Design MCP',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -605,6 +605,7 @@ export const uk: Dict = {
   'settings.modelCustom': 'Власна (введіть нижче)…',
   'settings.modelCustomLabel': 'Власне ID моделі',
   'settings.modelCustomPlaceholder': 'напр. anthropic/claude-sonnet-4-6',
+  'settings.onboardingModelUseCustom': 'Use "{query}"',
   'settings.mediaProviders': 'Медіа-провайдери',
   'settings.mediaProvidersHint': 'API-ключі для генерації зображень, відео та аудіо. Зберігаються локально та синхронізуються з локальним фоновим процесом.',
   'settings.mcpServerTitle': 'Open Design MCP',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -610,7 +610,7 @@ export const zhCN: Dict = {
   "settings.modelCustom": "自定义（在下方填写）…",
   "settings.modelCustomLabel": "自定义模型 id",
   "settings.modelCustomPlaceholder": "例如 anthropic/claude-sonnet-4-6",
-  "settings.onboardingModelUseCustom": "Use \"{query}\"",
+  'settings.onboardingModelUseCustom': 'Use "{query}"',
   "settings.mediaProviders": "媒体生成提供商",
   "settings.mediaProvidersHint": "连接图片、视频、音频和搜索提供商。",
   "settings.mcpServerTitle": "Open Design MCP",

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -610,6 +610,7 @@ export const zhCN: Dict = {
   "settings.modelCustom": "自定义（在下方填写）…",
   "settings.modelCustomLabel": "自定义模型 id",
   "settings.modelCustomPlaceholder": "例如 anthropic/claude-sonnet-4-6",
+  "settings.onboardingModelUseCustom": "Use \"{query}\"",
   "settings.mediaProviders": "媒体生成提供商",
   "settings.mediaProvidersHint": "连接图片、视频、音频和搜索提供商。",
   "settings.mcpServerTitle": "Open Design MCP",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -611,6 +611,7 @@ export const zhTW: Dict = {
   "settings.modelCustom": "自訂（在下方填寫）…",
   "settings.modelCustomLabel": "自訂模型 id",
   "settings.modelCustomPlaceholder": "例如 anthropic/claude-sonnet-4-6",
+  "settings.onboardingModelUseCustom": "Use \"{query}\"",
   "settings.mediaProviders": "媒體生成提供商",
   "settings.mediaProvidersHint": "連接圖片、影片、音訊和搜尋供應商。",
   "settings.mcpServerTitle": "Open Design MCP",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -611,7 +611,7 @@ export const zhTW: Dict = {
   "settings.modelCustom": "自訂（在下方填寫）…",
   "settings.modelCustomLabel": "自訂模型 id",
   "settings.modelCustomPlaceholder": "例如 anthropic/claude-sonnet-4-6",
-  "settings.onboardingModelUseCustom": "Use \"{query}\"",
+  'settings.onboardingModelUseCustom': 'Use "{query}"',
   "settings.mediaProviders": "媒體生成提供商",
   "settings.mediaProvidersHint": "連接圖片、影片、音訊和搜尋供應商。",
   "settings.mcpServerTitle": "Open Design MCP",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -573,6 +573,7 @@ export interface Dict {
   'settings.modelCustom': string;
   'settings.modelCustomLabel': string;
   'settings.modelCustomPlaceholder': string;
+  'settings.onboardingModelUseCustom': string;
   'settings.mediaProviders': string;
   'settings.mediaProvidersHint': string;
   'settings.mcpServerTitle': string;

--- a/apps/web/tests/components/EntryShell.onboarding-dropdown.test.tsx
+++ b/apps/web/tests/components/EntryShell.onboarding-dropdown.test.tsx
@@ -205,4 +205,81 @@ describe('OnboardingDropdown', () => {
     expect(option.querySelector('[data-description]')).toBeNull();
     expect(option.querySelector('[data-label]')).toBeNull();
   });
+
+  it('offers a custom-value entry for a non-matching query when allowCustomValue is set', () => {
+    render(
+      <OnboardingDropdown
+        label="Model"
+        placeholder="Select a model"
+        value=""
+        options={[
+          { value: 'gpt-oss:120b', label: 'gpt-oss:120b' },
+          { value: 'qwen3-next:80b', label: 'qwen3-next:80b' },
+        ]}
+        onChange={vi.fn()}
+        searchable
+        searchPlaceholder="Search models"
+        allowCustomValue
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Select a model/ }));
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search models' }), {
+      target: { value: 'llama3.3:70b' },
+    });
+
+    const options = screen.getAllByRole('option');
+    // The custom entry is appended after any real matches, not prepended.
+    const lastOption = options[options.length - 1];
+    expect(lastOption?.textContent).toContain('Use "llama3.3:70b"');
+  });
+
+  it('does not offer a custom entry when the query matches an existing option', () => {
+    render(
+      <OnboardingDropdown
+        label="Model"
+        placeholder="Select a model"
+        value=""
+        options={[{ value: 'gpt-oss:120b', label: 'gpt-oss:120b' }]}
+        onChange={vi.fn()}
+        searchable
+        searchPlaceholder="Search models"
+        allowCustomValue
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Select a model/ }));
+    // Case-insensitive match against an existing option value.
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search models' }), {
+      target: { value: 'GPT-OSS:120B' },
+    });
+
+    expect(screen.queryByText(/^Use "/)).toBeNull();
+    expect(screen.getAllByRole('option')).toHaveLength(1);
+  });
+
+  it('selects the trimmed custom value when the custom entry is clicked', () => {
+    const onChange = vi.fn();
+    render(
+      <OnboardingDropdown
+        label="Model"
+        placeholder="Select a model"
+        value=""
+        options={[{ value: 'gpt-oss:120b', label: 'gpt-oss:120b' }]}
+        onChange={onChange}
+        searchable
+        searchPlaceholder="Search models"
+        allowCustomValue
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Select a model/ }));
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search models' }), {
+      target: { value: '  llama3.3:70b  ' },
+    });
+
+    fireEvent.click(screen.getByRole('option', { name: /Use "llama3.3:70b"/ }));
+
+    expect(onChange).toHaveBeenCalledWith('llama3.3:70b');
+  });
 });


### PR DESCRIPTION
## Why

I hit this myself running Open Design against a local Ollama server through the Docker deployment. I wanted to use a model I already had pulled, `llama3.3:70b`, which isn't in the built-in suggestion list, and there was no way to enter it during onboarding.

The onboarding "Bring your own key" model field only lets you pick from `SUGGESTED_MODELS_BY_PROTOCOL`. There's a free-text `<input>` fallback in the code, but it only renders when the suggestion list is empty, and the Ollama/OpenAI suggestion lists are never empty. So on first run you can't select any model that isn't pre-listed: local Ollama models, self-hosted endpoints, or anything newer than the suggestion list. The Settings dialog already supports custom entry through its searchable picker; onboarding just never got the same treatment.

## What users will see

In the onboarding "Bring your own key" model picker, typing a model id that doesn't match a suggestion now shows a selectable `Use "<what you typed>"` entry at the bottom of the list, after any real matches. Picking it sets that exact model id. If what you type already matches a suggestion (case-insensitive), no duplicate entry appears. Anyone choosing from the preset list sees no change. This mirrors what the Settings model picker already does.

## Surface area

- [x] **UI** — new selectable entry in the onboarding BYOK model picker (`apps/web`)
- [x] **i18n keys** — one new key, `settings.onboardingModelUseCustom`

## Screenshots

Onboarding &rarr; Bring your own key &rarr; Model. Searching `gpt` shows the two real matches plus the `Use "gpt"` custom entry at the bottom of the list:

<img width="1180" height="940" alt="open-design-byok-custom-model" src="https://github.com/user-attachments/assets/66d4dd81-ee0e-4a20-b70b-db4c2583e248" />


## Bug fix verification

- Test path: `apps/web/tests/components/EntryShell.onboarding-dropdown.test.tsx`
- Red on `main`, green on this branch: **yes**. With `main`'s `EntryShell.tsx`, the "offers a custom-value entry" and "selects the trimmed custom value" specs fail (the option never renders, the list shows "No matches"). The third spec, which asserts no custom entry appears when the query matches an existing option, stays green. All three pass on this branch.
- `allowCustomValue` is a new opt-in prop on `OnboardingDropdown`, off by default, enabled only on the onboarding BYOK model field.

## Validation

- `pnpm --filter @open-design/web test` (onboarding-dropdown + i18n locales): 22/22 pass
- `pnpm --filter @open-design/web run typecheck` (`tsc -b --noEmit`): clean
- `pnpm guard`: pass
- `pnpm typecheck` (root, all workspaces): pass
- Full `next build` in the production Docker image, then manually verified in the running container against a local Ollama endpoint

## Notes for the reviewer

- i18n: I seeded the new key with the English string in all 19 locales so `locales.test.ts` (identical key sets plus matching `{query}` placeholder) passes. Happy to route real translations through your locale workflow if you'd prefer.
- Known limitation: `OnboardingDropdown` has no keyboard arrow-nav or Enter-to-select today; it's click-only for every option. The custom entry follows that same model. I kept keyboard nav out of scope so this stays a focused fix.
- Possible follow-up: converge `OnboardingDropdown` with the Settings `SearchableModelSelect` (which uses `CUSTOM_MODEL_SENTINEL`) so there's one picker instead of two. Left out here to keep the change small.
