### PR TITLE
enable model discovery for local Ollama BYOK providers

### DIFF
--- a/apps/daemon/src/integrations/provider-models.ts
+++ b/apps/daemon/src/integrations/provider-models.ts
@@ -178,6 +178,29 @@ function parseModelCapability(value: unknown): ModelCapability | null {
     : null;
 }
 
+function extractOllamaModels(data: unknown): ProviderModelOption[] {
+  // Ollama's GET /api/tags returns { models: [{ name, model, ... }] } where
+  // `name` is the pullable id (e.g. "llama3.3:70b").
+  const items = (data as { models?: unknown }).models;
+  if (!Array.isArray(items)) return [];
+  return uniqueModels(
+    items
+      .map((item) => {
+        const obj = item && typeof item === 'object'
+          ? (item as { name?: unknown; model?: unknown })
+          : null;
+        const id =
+          typeof obj?.name === 'string' && obj.name.trim()
+            ? obj.name
+            : typeof obj?.model === 'string'
+              ? obj.model
+              : '';
+        return id ? { id, label: id } : null;
+      })
+      .filter((item): item is ProviderModelOption => item != null),
+  );
+}
+
 function extractAnthropicModels(data: unknown): ProviderModelOption[] {
   const items = (data as { data?: unknown }).data;
   if (!Array.isArray(items)) return [];
@@ -252,6 +275,10 @@ function providerModelsUrl(protocol: ConnectionTestProtocol, baseUrl: string, ap
   if (protocol === 'google') {
     return googleProviderModelsUrl(baseUrl, apiKey);
   }
+  if (protocol === 'ollama') {
+    // Ollama lists locally-installed models at GET /api/tags (root path, not /v1).
+    return new URL('/api/tags', baseUrl).toString();
+  }
   throw new Error(`Unsupported protocol: ${protocol}`);
 }
 
@@ -288,6 +315,7 @@ function extractModels(protocol: ConnectionTestProtocol, data: unknown): Provide
   if (protocol === 'openai' || protocol === 'senseaudio') return extractOpenAiModels(data);
   if (protocol === 'anthropic') return extractAnthropicModels(data);
   if (protocol === 'google') return extractGoogleModels(data);
+  if (protocol === 'ollama') return extractOllamaModels(data);
   return [];
 }
 
@@ -320,6 +348,16 @@ export async function listProviderModels(
       latencyMs: Date.now() - start,
       models: BEDROCK_MODEL_OPTIONS,
       detail: 'AWS Bedrock uses a static seed until AWS credential-backed discovery is available.',
+    };
+  }
+  if (input.protocol === 'ollama' && !isLoopbackApiHost(validated.parsed.hostname)) {
+    // Discovery via /api/tags is a local-Ollama capability. Ollama Cloud
+    // (ollama.com) does not expose it, so keep the existing unsupported path.
+    return {
+      ok: false,
+      kind: 'unsupported_protocol',
+      latencyMs: Date.now() - start,
+      detail: 'Ollama model discovery is only available for local (loopback) endpoints.',
     };
   }
 

--- a/apps/daemon/src/routes/chat.ts
+++ b/apps/daemon/src/routes/chat.ts
@@ -32,6 +32,7 @@ import {
 } from '../integrations/aihubmix.js';
 import { isSafeId as isSafeProjectId } from '../projects.js';
 import { projectKindToTracking } from '@open-design/contracts/analytics';
+import { isLoopbackApiHost } from '@open-design/contracts/api/connectionTest';
 import { proxyDispatcherRequestInit, validateUserProviderBaseUrl } from '../connectionTest.js';
 import { resolveModelForServiceTier } from '../runtimes/models.js';
 import { googleStreamGenerateContentUrl } from '../integrations/google-models.js';
@@ -217,9 +218,21 @@ export function registerChatRoutes(app: Express, ctx: RegisterChatRoutesDeps) {
       );
     }
     // AIHubMix's catalogue (GET /api/v1/models?type=llm) is public, so its
-    // model list loads without a key. Every other protocol needs the key to
-    // hit its /v1/models endpoint.
-    const apiKeyRequired = protocol !== 'aihubmix' && protocol !== 'bedrock';
+    // model list loads without a key. Local Ollama (GET /api/tags) is also
+    // unauthenticated. Every other protocol needs the key to hit its
+    // /v1/models endpoint.
+    const isLocalOllamaDiscovery =
+      protocol === 'ollama' &&
+      typeof body.baseUrl === 'string' &&
+      (() => {
+        try {
+          return isLoopbackApiHost(new URL(body.baseUrl).hostname);
+        } catch {
+          return false;
+        }
+      })();
+    const apiKeyRequired =
+      protocol !== 'aihubmix' && protocol !== 'bedrock' && !isLocalOllamaDiscovery;
     if (
       typeof body.baseUrl !== 'string' ||
       typeof body.apiKey !== 'string' ||

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -647,6 +647,83 @@ describe('POST /api/provider/models', () => {
     }
   });
 
+  it('lists local Ollama models from /api/tags', async () => {
+    // Loopback is opted in so the request reaches upstream regardless of the
+    // daemon's internal-host policy.
+    vi.stubEnv('OD_ALLOWED_INTERNAL_HOSTS', '127.0.0.1');
+    const fetchMock = passThroughOrUpstream((url) => {
+      expect(url).toBe('http://127.0.0.1:11434/api/tags');
+      return jsonResponse({
+        models: [
+          { name: 'llama3.3:70b', model: 'llama3.3:70b' },
+          { name: 'qwen3-coder:480b' },
+        ],
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    try {
+      const res = await realFetch(`${baseUrl}/api/provider/models`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          protocol: 'ollama',
+          baseUrl: 'http://127.0.0.1:11434',
+          apiKey: '',
+        }),
+      });
+      const body = (await res.json()) as {
+        ok: boolean;
+        kind: string;
+        models?: Array<Record<string, unknown>>;
+      };
+      expect(body).toMatchObject({
+        ok: true,
+        kind: 'success',
+        models: [
+          { id: 'llama3.3:70b', label: 'llama3.3:70b' },
+          { id: 'qwen3-coder:480b', label: 'qwen3-coder:480b' },
+        ],
+      });
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('rejects Ollama Cloud model discovery without calling upstream fetch', async () => {
+    const dnsSpy = vi
+      .spyOn(dnsPromises, 'lookup')
+      .mockImplementation((async (hostname: string) => {
+        if (hostname === 'ollama.com') {
+          return [{ address: '104.18.0.1', family: 4 }];
+        }
+        const err: NodeJS.ErrnoException = new Error('ENOTFOUND');
+        err.code = 'ENOTFOUND';
+        throw err;
+      }) as unknown as typeof dnsPromises.lookup);
+    const fetchMock = passThroughOrUpstream(() => jsonResponse({ models: [] }));
+    vi.stubGlobal('fetch', fetchMock);
+    try {
+      const res = await realFetch(`${baseUrl}/api/provider/models`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          protocol: 'ollama',
+          baseUrl: 'https://ollama.com',
+          apiKey: 'ollama-key',
+        }),
+      });
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body).toMatchObject({ ok: false, kind: 'unsupported_protocol' });
+      expect(
+        fetchMock.mock.calls.some(
+          ([input]) => !String(input).startsWith(baseUrl),
+        ),
+      ).toBe(false);
+    } finally {
+      dnsSpy.mockRestore();
+    }
+  });
+
   it('reports timeout when model listing is aborted by the probe timer', async () => {
     // The DNS-aware validator runs before the probe timer is installed; stub
     // the resolver so the test doesn't race against real DNS while fake

--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -19,6 +19,7 @@ import {
 } from './providerModelsCache';
 import { KNOWN_PROVIDERS } from '../state/config';
 import { SUGGESTED_MODELS_BY_PROTOCOL } from '../state/apiProtocols';
+import { isLocalOllamaBaseUrl } from '../utils/byokProvider';
 import { fetchProviderModels } from '../providers/provider-models';
 import type { AgentInfo, AppConfig, ExecMode, ProviderModelOption } from '../types';
 import {
@@ -364,11 +365,12 @@ export function AvatarMenu({
   useEffect(() => {
     if (!open || config.mode !== 'api') return;
     if (fetchedByokModels.length > 0) return;
-    if (apiProtocol === 'azure' || apiProtocol === 'ollama') return;
     const baseUrl = config.baseUrl?.trim() ?? '';
+    const isLocalOllama = apiProtocol === 'ollama' && isLocalOllamaBaseUrl(baseUrl);
+    if (apiProtocol === 'azure' || (apiProtocol === 'ollama' && !isLocalOllama)) return;
     if (!/^https?:\/\//i.test(baseUrl)) return;
-    // AIHubMix's catalogue is public; every other protocol needs a key.
-    if (apiProtocol !== 'aihubmix' && !(config.apiKey ?? '').trim()) return;
+    // AIHubMix is public and local Ollama needs no key; other protocols require one.
+    if (apiProtocol !== 'aihubmix' && !isLocalOllama && !(config.apiKey ?? '').trim()) return;
     const key = byokModelsKey;
     let cancelled = false;
     void fetchProviderModels({

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -211,6 +211,7 @@ import {
 import { closeAmrActivationWindowBestEffort } from './AmrLoginPill';
 import { smoothScrollToTop } from '../utils/smoothScrollToTop';
 import { summarizeProjectNameFromPrompt } from '../utils/projectName';
+import { isLocalOllamaBaseUrl } from '../utils/byokProvider';
 import { LIBRARY_UI_VISIBLE } from '../features/libraryUi';
 import {
   providerModelsCacheKey,
@@ -2061,10 +2062,12 @@ function OnboardingView({
     Boolean(config.apiKey.trim()) &&
     Boolean(config.baseUrl.trim()) &&
     Boolean(config.model.trim());
+  const isLocalOllamaProvider =
+    apiProtocol === 'ollama' && isLocalOllamaBaseUrl(config.baseUrl);
   const canFetchProviderModels =
     apiProtocol !== 'azure' &&
-    apiProtocol !== 'ollama' &&
-    Boolean(config.apiKey.trim()) &&
+    (apiProtocol !== 'ollama' || isLocalOllamaProvider) &&
+    (isLocalOllamaProvider || Boolean(config.apiKey.trim())) &&
     Boolean(config.baseUrl.trim()) &&
     isLikelyHttpUrl(config.baseUrl);
   const visibleProviderTestState =

--- a/apps/web/src/components/InlineModelSwitcher.tsx
+++ b/apps/web/src/components/InlineModelSwitcher.tsx
@@ -66,6 +66,7 @@ import {
 import type { AgentInfo, ApiProtocol, AppConfig, ExecMode } from '../types';
 import { apiProtocolLabel } from '../utils/apiProtocol';
 import { isVisibleLocalCliAgent } from '../utils/visibleAgents';
+import { isLocalOllamaBaseUrl } from '../utils/byokProvider';
 import { AgentIcon } from './AgentIcon';
 import { Icon } from './Icon';
 import { modelProviderIconSrc } from './modelProviderIcon';
@@ -986,8 +987,9 @@ export function InlineModelSwitcher({
   // serves both surfaces and replaces any stale slot.
   useEffect(() => {
     if (!open || config.mode !== 'api' || !onProviderModelsCacheChange) return;
-    if (apiProtocol === 'azure' || apiProtocol === 'ollama') return;
-    if (apiProtocol !== 'aihubmix' && !config.apiKey.trim()) return;
+    const isLocalOllama = apiProtocol === 'ollama' && isLocalOllamaBaseUrl(config.baseUrl);
+    if (apiProtocol === 'azure' || (apiProtocol === 'ollama' && !isLocalOllama)) return;
+    if (apiProtocol !== 'aihubmix' && !isLocalOllama && !config.apiKey.trim()) return;
     const baseUrl = config.baseUrl.trim();
     if (!/^https?:\/\//i.test(baseUrl)) return;
     const key = providerModelsKey;

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -134,7 +134,7 @@ import {
 import { MEDIA_PROVIDERS } from '../media/models';
 import { useByokImageModelOptions, useByokVideoModelOptions, useByokSpeechModelOptions } from '../media/aihubmix-image-models';
 import { isVisualStabilityMode } from '../utils/visualStability';
-import { byokProviderRequiresApiKey } from '../utils/byokProvider';
+import { byokProviderRequiresApiKey, isLocalOllamaBaseUrl } from '../utils/byokProvider';
 import { XaiOAuthControl } from './XaiOAuthControl';
 import type { MediaProvider } from '../media/models';
 import { Toast } from './Toast';
@@ -698,11 +698,11 @@ export function canFetchProviderModels(
   config: Pick<AppConfig, 'apiKey' | 'baseUrl'>,
   protocol: ApiProtocol,
 ): boolean {
+  const isLocalOllama = protocol === 'ollama' && isLocalOllamaBaseUrl(config.baseUrl);
   return (
     !isProviderModelDiscoveryUnsupported(protocol, config.baseUrl) &&
     protocol !== 'azure' &&
-    protocol !== 'ollama' &&
-    (protocol === 'bedrock' || Boolean(config.apiKey.trim())) &&
+    (protocol === 'bedrock' || isLocalOllama || Boolean(config.apiKey.trim())) &&
     Boolean(config.baseUrl.trim()) &&
     isValidApiBaseUrl(config.baseUrl)
   );
@@ -712,7 +712,10 @@ export function isProviderModelDiscoveryUnsupported(
   protocol: ApiProtocol,
   baseUrl: string,
 ): boolean {
-  if (protocol === 'azure' || protocol === 'ollama') return true;
+  if (protocol === 'azure') return true;
+  // Ollama model discovery (GET /api/tags) is a local-only capability; Ollama
+  // Cloud (ollama.com) does not expose it.
+  if (protocol === 'ollama') return !isLocalOllamaBaseUrl(baseUrl);
   try {
     const host = new URL(baseUrl).hostname.toLowerCase();
     return host === 'token-plan-cn.xiaomimimo.com';
@@ -1842,7 +1845,7 @@ export function SettingsDialog({
       if (
         initial.mode !== 'api' ||
         protocol === 'azure' ||
-        protocol === 'ollama' ||
+        (protocol === 'ollama' && !isLocalOllamaBaseUrl(initial.baseUrl)) ||
         missingByokModelFetchFields(initial, protocol).length > 0 ||
         !isValidApiBaseUrl(initial.baseUrl)
       ) {
@@ -2733,7 +2736,7 @@ export function SettingsDialog({
       }
       return;
     }
-    if (apiProtocol === 'ollama') {
+    if (apiProtocol === 'ollama' && !isLocalOllamaBaseUrl(cfg.baseUrl)) {
       trackModelsFetchResult({
         result: 'failed',
         error_code: 'unsupported_ollama',
@@ -3514,11 +3517,9 @@ export function SettingsDialog({
   );
   const providerModelDiscoveryUnavailable =
     apiProtocol !== 'azure' &&
-    apiProtocol !== 'ollama' &&
     isProviderModelDiscoveryUnsupported(apiProtocol, cfg.baseUrl);
   const providerModelDiscoverySupported =
     apiProtocol !== 'azure' &&
-    apiProtocol !== 'ollama' &&
     !providerModelDiscoveryUnavailable;
   const fetchedApiModelOptions =
     providerModelDiscoveryUnavailable

--- a/apps/web/tests/components/SettingsDialog.test.ts
+++ b/apps/web/tests/components/SettingsDialog.test.ts
@@ -578,6 +578,25 @@ describe('SettingsDialog provider model fetch helpers', () => {
         'ollama',
       ),
     ).toBe(false);
+    // Local Ollama supports discovery via GET /api/tags and needs no API key.
+    expect(
+      canFetchProviderModels(
+        { apiKey: '', baseUrl: 'http://localhost:11434' },
+        'ollama',
+      ),
+    ).toBe(true);
+    expect(
+      canFetchProviderModels(
+        { apiKey: '', baseUrl: 'http://127.0.0.1:11434' },
+        'ollama',
+      ),
+    ).toBe(true);
+    expect(
+      isProviderModelDiscoveryUnsupported('ollama', 'http://localhost:11434'),
+    ).toBe(false);
+    expect(
+      isProviderModelDiscoveryUnsupported('ollama', 'https://ollama.com'),
+    ).toBe(true);
     expect(
       canFetchProviderModels(
         {


### PR DESCRIPTION
Fixes #6077

## Why

I hit this running Open Design against a local Ollama server through BYOK: every other provider protocol can pull its catalogue with "Fetch models," but Ollama couldn't, even though Ollama exposes a discovery endpoint (`GET /api/tags`). The button was disabled and the daemon returned `unsupported_ollama`, so I had to type each model id by hand.

Per the discussion in #6077 with @lefarcen, this keeps the scope to **local** Ollama only (loopback base URLs). Ollama Cloud (`ollama.com`) keeps its existing "not available" fallback. Remote/LAN and `host.docker.internal` are left as a separate future expansion.

## What users will see

When the Ollama Base URL is a loopback host (`localhost` / `127.0.0.1` / `::1`), the **Fetch models** button is now enabled and populates the model picker from the running Ollama's installed models. No API key is required for local Ollama. Nothing changes for Ollama Cloud, which still shows the existing unsupported message. The behavior is consistent across the surfaces that offer model discovery: onboarding BYOK, Settings, the inline model switcher, and the avatar menu.

## Surface area

- [x] **UI** — the Fetch models control is enabled for local Ollama in onboarding, Settings, the inline switcher, and the avatar menu
- [x] **API / contract** — no new endpoint; reuses `POST /api/provider/models`. The daemon now supports the `ollama` protocol there (loopback-gated) and no longer requires an API key for local Ollama discovery

## Screenshots

Onboarding &rarr; Bring your own key &rarr; Ollama, local base URL. After Fetch models, the picker lists the installed models pulled from `/api/tags`:
<img width="1180" height="940" alt="open-design-ollama-discovery" src="https://github.com/user-attachments/assets/4d45280f-155c-4b16-a50a-2d57cb1a922a" />


## Bug fix verification

Not a bug fix, but the change is covered by falsifiable tests:
- `apps/daemon/tests/connection-test.test.ts`: local Ollama lists models from `/api/tags`; Ollama Cloud is rejected as unsupported without calling upstream fetch.
- `apps/web/tests/components/SettingsDialog.test.ts`: `canFetchProviderModels` / `isProviderModelDiscoveryUnsupported` return the expected results for loopback vs cloud Ollama.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/connection-test.test.ts`: 158/158
- `pnpm --filter @open-design/web test`: 4762 passed, 7 skipped
- `pnpm guard`: pass
- `pnpm typecheck` (root, all workspaces): pass
- Built the production Docker image and manually verified against a real local Ollama: Fetch models returned the installed catalogue and the picker populated.

## Implementation notes

- Daemon (`apps/daemon/src/integrations/provider-models.ts`): added an Ollama `/api/tags` URL, a response parser, and a loopback-only guard so cloud endpoints keep the existing unsupported result.
- Route (`apps/daemon/src/routes/chat.ts`): `POST /api/provider/models` required an API key for every protocol except AIHubMix/Bedrock; local Ollama is now also exempt since `/api/tags` is unauthenticated.
- Frontend gates reuse the existing `isLocalOllamaBaseUrl` helper (`apps/web/src/utils/byokProvider.ts`), so the loopback definition stays in one place.
