### PR TITLE
test(e2e): lock the cleared-state invariant for hero pendingPrompt (#2878)

### DIFF
--- a/e2e/ui/entry-chrome-flows.test.ts
+++ b/e2e/ui/entry-chrome-flows.test.ts
@@ -251,6 +251,95 @@ test('[P0] @critical home hero submit creates a project and lands on a usable wo
   await expect(page.getByTestId('file-workspace')).toBeVisible();
 });
 
+test('[P1] hero-created projects clear their pending prompt and never re-seed a later entry', async ({ page }) => {
+  // Regression guard for #2878. The hero writes `pendingPrompt` onto the new
+  // project, and `ProjectView` is the only place that clears it (on mount,
+  // via `onClearPendingPrompt`). This locks the cleared-state invariant so a
+  // refactor that moves or drops that clear cannot silently reintroduce a
+  // prompt carrying over into a reload, the Home hero, or a second project.
+  const ALPHA = 'REGRESSION-ALPHA first hero prompt.';
+  const BETA = 'REGRESSION-BETA second hero prompt.';
+  // Typed but never sent, so the assertions below are not vacuous: the hero
+  // path auto-sends, which leaves the composer empty on its own. Without a
+  // real draft in it there would be nothing available to leak, and every
+  // "composer is empty" assertion would pass for the wrong reason.
+  const GAMMA = 'REGRESSION-GAMMA unsent draft.';
+
+  await page.route('**/api/runs', async (route) => {
+    if (route.request().method() !== 'POST') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 202,
+      contentType: 'application/json',
+      body: '{"runId":"entry-pending-prompt-cleared"}',
+    });
+  });
+  await page.route('**/api/runs/*/events', async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' },
+      body: ['event: end', 'data: {"code":0,"status":"succeeded"}', '', ''].join('\n'),
+    });
+  });
+
+  await gotoEntryHome(page);
+
+  // Arm both waiters before submitting: the clearing PATCH races the redirect.
+  const createRequest = page.waitForRequest(isCreateProjectRequest);
+  const clearRequest = page.waitForRequest(isClearPendingPromptRequest);
+  await page.getByTestId('home-hero-input').fill(ALPHA);
+  await page.getByTestId('home-hero-submit').click();
+
+  expect((await createRequest).postDataJSON()).toMatchObject({ pendingPrompt: ALPHA });
+
+  await expect(page).toHaveURL(/\/projects\//, { timeout: 15_000 });
+  const projectAUrl = page.url();
+  const composer = page.getByTestId('chat-composer-input');
+  await expect(composer).toBeVisible();
+
+  // Mount clears the persisted prompt rather than leaving it on the project.
+  expect((await clearRequest).postDataJSON()).toMatchObject({ pendingPrompt: null });
+
+  // Auto-send consumed the prompt, so it must not also sit in the composer.
+  await expect(composer).toHaveText('');
+
+  // Reloading re-reads the project from the daemon: proves the clear was
+  // persisted, not just applied to in-memory state.
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await expect(composer).toBeVisible({ timeout: T.long });
+  await expect(composer).toHaveText('');
+
+  await composer.click();
+  await composer.fill(GAMMA);
+  await expect(composer).toHaveText(GAMMA);
+
+  // Leaving the project goes through the pinned entry tab, not a back button:
+  // #5517 gave ChatPane's top-left slot to the pane-collapse control and the
+  // `AppChromeHeader` that owned "Back to projects" is no longer mounted, so
+  // that locator only resolves inside the closed avatar popover. Same intent
+  // (leave the project through real chrome), current carrier — this mirrors
+  // `leaveProjectForEntry` in `real-daemon-run.test.ts`.
+  const pinnedEntryTab = page.locator('.workspace-tab.is-pinned');
+  await expect(pinnedEntryTab).toBeVisible();
+  await pinnedEntryTab.locator('.workspace-tab__main').click();
+  const hero = page.getByTestId('home-hero-input');
+  await expect(hero).toBeVisible();
+  await expect(hero).toHaveText('');
+
+  const secondCreateRequest = page.waitForRequest(isCreateProjectRequest);
+  await hero.fill(BETA);
+  await page.getByTestId('home-hero-submit').click();
+  const secondBody = (await secondCreateRequest).postDataJSON() as { pendingPrompt?: string };
+  expect(secondBody.pendingPrompt).toBe(BETA);
+
+  await expect(page).toHaveURL(/\/projects\//, { timeout: 15_000 });
+  await expect.poll(() => page.url()).not.toBe(projectAUrl);
+  await expect(composer).toBeVisible();
+  await expect(composer).toHaveText('');
+});
+
 test('[P1] onboarding lands on the home composer without a recommended-start strip', async ({ page }) => {
   const createdBodies: Array<Record<string, unknown>> = [];
   const runBodies: Array<Record<string, unknown>> = [];
@@ -1669,6 +1758,13 @@ function isCreateProjectRequest(request: Request): boolean {
   return url.pathname === '/api/projects' && request.method() === 'POST';
 }
 
+// The PATCH `ProjectView` issues on mount to wipe the seeded `pendingPrompt`.
+function isClearPendingPromptRequest(request: Request): boolean {
+  const url = new URL(request.url());
+  if (request.method() !== 'PATCH' || !url.pathname.startsWith('/api/projects/')) return false;
+  const body = request.postDataJSON() as { pendingPrompt?: string | null } | null;
+  return Boolean(body) && 'pendingPrompt' in (body as object);
+}
 
 function skillSummary(
   id: string,


### PR DESCRIPTION
Standalone hardening PR for #2878, following @lefarcen's note there: after the second-pass probe showed no active repro on current `main`, turning the probe into a focused regression test in `e2e/ui/entry-chrome-flows.test.ts` was welcomed as a separate PR.

Test-only. No production code changes.

## Why

**Use case.** This fell out of triaging #2878 rather than out of building on top of OD. I went looking for the reported "new session inherits the previous session's prompt" carryover, could not reproduce it on current `main` across two probe passes, and @lefarcen's call on the issue was to treat it as *"no active repro on current main"* and turn the probe into a regression test instead of queueing a fix PR.

**Pain being addressed.** Technical debt, not a live user-facing break. The hero writes `pendingPrompt` onto the newly created project and exactly one place clears it — `ProjectView` on mount. Nothing in the suite pins that down today, so a refactor can drop or relocate the clear and every test stays green. The bug that was reported once has no guard against coming back.

## What users will see

**Nothing.** This adds one `[P1]` end-to-end test and changes no production code, so there is no behavior difference on any surface.

The user-facing value is deferred: if a future change drops the mount-time clear, CI fails instead of shipping a build where starting a new session from the Home hero can land you in a project that still carries the previous prompt.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — tests only (single file, `e2e/ui/entry-chrome-flows.test.ts`, `+96/−0`)

## What it locks

The hero writes `pendingPrompt` onto the newly created project, and `ProjectView` is the only place that clears it — on mount, via `onClearPendingPrompt` (`apps/web/src/components/ProjectView.tsx` → `App.tsx`, which PATCHes `pendingPrompt: null`). Nothing currently pins that clear down, so a refactor could drop or relocate it without a test going red.

The new `[P1]` test walks the real Home hero entry flow and asserts:

1. hero submit sends `pendingPrompt` on `POST /api/projects`;
2. **mount PATCHes `pendingPrompt: null`** — the invariant itself;
3. the composer is empty after landing, after a reload, and in a second project created from a later hero submit, with the second submit carrying only its own prompt.

## Which assertions I actually verified have teeth

I tried three breaks against the test rather than trusting the green run:

| break | result |
|---|---|
| remove `onClearPendingPrompt()` from the auto-send branch | **red** — the PATCH waiter times out |
| same break, with the PATCH assertion disabled | green |
| same break, plus a duplicate-run counter over `POST /api/runs` across the reload | green — the prompt is **not** re-sent |
| force the seed-composer branch instead of auto-send | green — `autoSendSeedRef` still short-circuits the draft seeding |

So, stated plainly: **only assertion (2) is a verified guard.** The observable-state assertions in (3) did not go red under any break I could construct, which is consistent with the finding on the issue — the user-visible carryover does not reproduce on current `main`, because clearing is not the only thing standing between a stale prompt and the UI.

I kept them anyway as documentation of the intended end state, since they are cheap and they pin the surface the original report described. **Happy to strip (3) down to just the PATCH assertion if you'd rather the test only contain things proven to fail** — say the word and I'll push that.

One deliberate detail: the test types an unsent `REGRESSION-GAMMA` draft into the composer before navigating away. The hero path auto-sends, so the composer is empty by construction; without a real draft sitting in it, "the composer is empty" would pass for the wrong reason. That is the same vacuous-green trap from the second probe pass.

## Verification

Rebased onto current `main` (`888e1e802`) and re-run locally, Node 24.14.0 / pnpm 10.33.2:

- `pnpm exec playwright test -c playwright.config.ts ui/entry-chrome-flows.test.ts` — the new test **passes**; whole file **25 passed / 3 failed**
- the 3 failures are pre-existing on this machine and unrelated to this branch: `Settings About reads desktop updater status…`, `Settings About surfaces prerelease updater check failures…`, and `Settings BYOK connection failures…`, all timing out on their own `getByTestId('entry-settings-menu-trigger')`. Their bodies are byte-identical to `main` here and this branch's diff is `+96/−0` (additions only), so nothing in it can reach them
- `pnpm exec tsc -p e2e/tsconfig.json --noEmit` — exit 0

The test uses the same `applyStandardMocks` + `/api/runs` route-mock idiom as the neighbouring `[P0]` hero-submit test; project creation and the clearing PATCH hit the real daemon, so the reload assertion exercises real persistence.

Closes nothing — #2878 stays open pending @AmyShang-alt's confirmation of the original entry point.
