### PR TITLE
feat(web): auto-open generated image artifacts in the viewer

### DIFF
--- a/apps/web/src/components/auto-open-file.ts
+++ b/apps/web/src/components/auto-open-file.ts
@@ -102,24 +102,24 @@ function isHtmlPreviewFile(file: CandidateFile): boolean {
   return file.kind === 'html' || /\.html?$/i.test(path);
 }
 
-// Markdown documents (plan.md, report.md, DESIGN.md, …) render inline in the
-// viewer, so a turn that produces one should surface it just like an HTML
-// page. The daemon maps `.md`/`.txt` to the same `kind: 'text'`, so the
-// extension — not `kind` — is the only reliable discriminator: we open
-// markdown but deliberately leave plain `.txt` alone.
 function isMarkdownPreviewFile(file: CandidateFile): boolean {
   const path = file.path ?? file.name;
   return /\.(md|markdown)$/i.test(path);
 }
 
+function isImagePreviewFile(file: CandidateFile): boolean {
+  return file.kind === 'image';
+}
+
 // Auto-open priority for a turn's produced files. Higher wins. HTML is the
 // primary visual deliverable, so when a turn writes both an HTML page and a
-// markdown note (e.g. index.html + README.md) the page takes focus; markdown
-// is the next-best previewable artifact; everything else (decks, images, raw
-// text) has no in-place reshape preview worth stealing focus for and is left
+// markdown note (e.g. index.html + README.md) the page takes focus; images
+// and markdown are the next-best previewable artifacts; decks and raw text
+// have no in-place reshape preview worth stealing focus for and are left
 // for the user to open from the produced-files chips.
 function autoOpenPreviewRank(file: CandidateFile): number {
   if (isHtmlPreviewFile(file)) return 2;
+  if (isImagePreviewFile(file)) return 1;
   if (isMarkdownPreviewFile(file)) return 1;
   return 0;
 }

--- a/apps/web/tests/components/auto-open-file.test.ts
+++ b/apps/web/tests/components/auto-open-file.test.ts
@@ -199,6 +199,32 @@ describe('selectAutoOpenProducedArtifact', () => {
     expect(result).toBeNull();
   });
 
+  it('auto-opens a produced image file when no html or markdown exists', () => {
+    const result = selectAutoOpenProducedArtifact([
+      { name: 'screenshot.png', path: 'screenshot.png', kind: 'image', mtime: 30 },
+    ]);
+
+    expect(result).toBe('screenshot.png');
+  });
+
+  it('prefers html over a produced image when both exist', () => {
+    const result = selectAutoOpenProducedArtifact([
+      { name: 'index.html', path: 'index.html', kind: 'html', mtime: 10 },
+      { name: 'screenshot.png', path: 'screenshot.png', kind: 'image', mtime: 30 },
+    ]);
+
+    expect(result).toBe('index.html');
+  });
+
+  it('prefers the newest image when multiple images are produced', () => {
+    const result = selectAutoOpenProducedArtifact([
+      { name: 'chart.png', path: 'chart.png', kind: 'image', mtime: 10 },
+      { name: 'screenshot.png', path: 'screenshot.png', kind: 'image', mtime: 30 },
+    ]);
+
+    expect(result).toBe('screenshot.png');
+  });
+
   describe('preferSiteEntry (website-clone turns)', () => {
     it('opens the site entry even when subpages were written after it', () => {
       // A clone run writes the entry first and keeps landing subpages and


### PR DESCRIPTION
Fixes #5694

**Why:** After generating an image in a new session, the produced file appears in the chat output card but the user must manually click the Open button to view it in the artifact preview. HTML and Markdown artifacts auto-open after generation, but images were ranked at priority 0 and never auto-opened.

**What users will see:** After asking the agent to generate an image, the image now automatically opens in the artifact preview panel (FileViewer ImageViewer), consistent with the existing behavior for HTML and Markdown artifacts.

**Changes:**
- Added isImagePreviewFile() to auto-open-file.ts and gave images rank 1 in autoOpenPreviewRank (same tier as markdown, below HTML at rank 2)
- Added 3 tests covering: image auto-open, HTML-over-image priority, newest-image tie-break

Surface area checklist:
- [x] Core logic: apps/web/src/components/auto-open-file.ts
- [x] Tests: apps/web/tests/components/auto-open-file.test.ts
- [x] No new dependencies
- [x] No CLI changes needed