### PR TITLE
docs(rfc): storyboard-first canvas evolution + multi-artifact agent execution

### DIFF
--- a/docs/rfc-drafts/multi-artifact-agent-execution.md
+++ b/docs/rfc-drafts/multi-artifact-agent-execution.md
@@ -1,0 +1,130 @@
+# RFC: Multi-artifact agent execution — three lanes and an intent-level session API
+
+**Status:** Draft (umbrella design for review; only slice 1 ships code in the first PR)
+**Author:** @pftom
+**Related:** [`../external-media-orchestration.md`](../external-media-orchestration.md) (this RFC is the "separate owner decision" that note calls for), [`agent-ready.md`](./agent-ready.md) (dual-track law). Companion RFC: [`storyboard-first-canvas.md`](./storyboard-first-canvas.md) (Asset/Node substrate; that one owns *where results live*, this one owns *how agents execute*). Prior art: LibTV `libtv-labs/libtv-skills` (intent-level delegation), Open Design Canvas (command-level contract, durable jobs, gates).
+
+## Summary
+
+Open Design's agent loop was purpose-built for artifacts the agent can *type out*:
+design-system-composed prompt in, streamed HTML out, sandboxed preview, critique. That
+loop is the product's moat — and it does not generalize. Images, video, audio and 3D
+are provider calls, not token streams; workflows and video-editing projects are state
+mutations, not documents. This RFC routes agent execution into **three lanes by
+artifact class**, adds per-lane quality mechanisms, and introduces an **intent-level
+session API** so thin agents get full production capability with one instruction —
+while deep agents keep the typed command contract.
+
+## Problem
+
+- **One pipeline, many physics.** Streaming a deck and rendering a 10-second video
+  share nothing: different failure modes, latency, cost, and verification. Forcing
+  media through the CLI text loop means the local model's media ability caps output
+  quality, and a dropped HTTP connection loses paid work.
+- **Spend is unguarded.** Provider calls can be expensive; today nothing reviews
+  inputs before money is spent, deduplicates retries, or survives a daemon restart.
+- **Quality is unowned for non-HTML artifacts.** The critique loop inspects rendered
+  pages; nothing verifies that a generated image is on-brand or that a video used the
+  intended references.
+- **Breadth vs. depth is unresolved.** 25 wired CLIs could drive rich commands, but
+  most integrations only need "make me a campaign video" to work reliably.
+
+## Prior art (read before judging the design)
+
+**LibTV (`libtv-labs/libtv-skills`)** ships a thin OpenClaw-spec skill: five
+stdlib-Python scripts that send the user's *natural-language intent verbatim* to an
+Agent-IM OpenAPI. Orchestration happens server-side (their agent routes models and
+builds the workflow); the local agent only polls progress, downloads results, and
+receives a `projectUrl` to the visible canvas. Compatibility is maximal (anything that
+runs python3), quality is centrally owned, and the access key anchors billing.
+
+**Open Design Canvas** takes the opposite stance: a 100+-command typed contract that
+local agents drive directly, with durable generation jobs, approved-input gates, and
+full provenance. Depth and auditability are maximal; each agent must understand more.
+
+These are levels, not rivals. This RFC adopts both.
+
+## Design
+
+### Lane A — code-rendered artifacts (unchanged)
+
+Prototype, Deck, dashboards, HyperFrame stay on the existing CLI streaming loop with
+design-system prompt composition and critique. No changes; this lane is the baseline
+other lanes are measured against.
+
+### Lane B — media artifacts (typed tools + durable jobs)
+
+The agent never emits media bytes. It calls typed generation tools that create a
+**durable generation job**: idempotency key, frozen context snapshot, `start / get /
+list / wait / cancel`, restart reconciliation (orphaned jobs marked `interrupted`,
+retryable), artifact + version committed only on success. Provider adapters are
+provider-neutral but **capability-truthful**: each model declares its real input
+contract, and unsupported context is refused with a concrete reason — never silently
+dropped. This slots into the existing `mediaExecution` boundary;
+`external-media-orchestration.md` explicitly defers a provider router to "a separate
+owner decision" — this RFC is that proposal, scoped to job lifecycle + adapters, not a
+provider account pool.
+
+### Lane C — stateful artifacts (serializable commands)
+
+Workflows/toolboxes and video-editing projects are mutated through serializable
+commands over shared state (the Asset/Node substrate from the storyboard-first-canvas
+RFC; one timeline project shared by UI and agent for editing). The agent proposes and
+applies operations; it never regenerates the whole document. Execution over a graph
+scope gets a **free, read-only plan step** (what runs, what's stale, what's blocked)
+before any provider is called.
+
+### Quality mechanisms (per lane)
+
+1. **Kind-locked skills and parameters.** Each artifact kind gets its own skill set
+   and a locked parameter schema (image: aspect/resolution; video: duration/audio; …).
+   No cross-kind switcher.
+2. **`DESIGN.md` extends to media.** The design system contributes brand colors,
+   reference images, and style assets as generation context, so media output is shaped
+   by the same brand contract as HTML. This is the differentiator no model aggregator
+   has.
+3. **Verification per lane.** Lane A: existing critique. Lane B: generate → preview →
+   agent visual check against the brief/design system → bounded retry. Lane C: plan
+   before run; optional **approved-input gate** — when enabled on a generation source,
+   every upstream input must be explicitly approved before any provider spend
+   (fail-closed).
+4. **Spend safety.** Idempotency keys prevent double billing; gates run before
+   provider calls; job history records provider/model/parameters for audit.
+
+### Intent-level session API (breadth lane)
+
+A minimal surface modeled on LibTV's Agent-IM, powered by Open Design's own in-product
+orchestration: `create session → send intent message → poll progress → fetch results`.
+The server-side agent decomposes the intent across lanes A–C. Every response carries a
+**visible project URL** so a browser-capable agent (or human) can watch the work land
+in Studio — make "results link to their visible surface" a contract-level convention
+for all three lanes. This API is intentionally thin enough for a stdlib-script skill,
+and is the natural metering point for Open Design Cloud.
+
+## Options considered → recommendation
+
+1. **Teach CLI agents to produce all media themselves** — quality capped by whichever
+   local model the user runs; no spend control or provenance. **Rejected.**
+2. **Intent-only delegation (pure LibTV model)** — maximal breadth, but forfeits the
+   typed command surface that makes Open Design agent-*operable* rather than
+   agent-*callable*, and conflicts with the dual-track law. **Rejected as the sole model.**
+3. **Dual-level: typed contract for depth + intent sessions for breadth, with lane
+   routing underneath both** (this RFC). **Recommended.**
+
+## Slices
+
+1. **Contracts** (`packages/contracts`): artifact-kind descriptors, media job
+   lifecycle schemas, capability declaration shape. Ships code first, with this RFC.
+2. Durable job engine + first provider adapters behind `mediaExecution`.
+3. Lane C command set (depends on storyboard-first-canvas slices 1b/1c).
+4. Intent session API + `projectUrl` response convention.
+5. Verification loops and gates.
+
+## Open questions
+
+1. Do gates default on for provider calls above a cost threshold, or stay opt-in per
+   source?
+2. Does the intent API live in the daemon or only in Open Design Cloud (local-first
+   users may still want it for thin-agent breadth)?
+3. Minimum viable visual-verification rubric for Lane B before it blocks delivery
+   (hard fail vs. advisory)?

--- a/docs/rfc-drafts/storyboard-first-canvas.md
+++ b/docs/rfc-drafts/storyboard-first-canvas.md
@@ -1,0 +1,117 @@
+# RFC: Storyboard-first evolution of Studio into a production canvas
+
+**Status:** Draft (umbrella design for review; only slice 1a ships code in the first PR)
+**Author:** @pftom
+**Related:** [`agent-ready.md`](./agent-ready.md) — this proposal extends the same UI/CLI dual-track law to artifact and asset operations. Companion RFC: [`multi-artifact-agent-execution.md`](./multi-artifact-agent-execution.md) (that one owns *how agents execute*; this one owns *where results live*). Reference implementation: the Open Design Canvas project (Workspace v2, storyboard/canvas dual views, asset/node object model).
+
+## Summary
+
+Studio's right side today is an artifact tree plus a sandboxed preview: files in, one
+artifact out. This RFC proposes evolving that rail — in three independently shippable
+slices — into a **Storyboard** (a typed, provenance-aware board of everything the
+project has produced) and then unlocking a **Canvas view** over the same data: artifacts
+become placeable nodes with positions and context edges, and a persisted view switch
+toggles between Storyboard and Canvas. Project files gain a curated **Asset** layer so
+reusable materials are first-class without disturbing the daemon-owned file workspace.
+
+The end state is that every coding agent already wired via `od mcp install` can operate
+a persistent multimodal production surface — not just emit one artifact per
+conversation — while existing users experience each step as "Studio got stronger,"
+never "there is a new product to learn."
+
+## Problem
+
+- **Production state is trapped in single artifacts.** A real brief spans several
+  artifacts (design system → images → prototype → deck). Today those are separate
+  outputs in a flat tree; nothing records which inputs, prior artifacts, or design
+  decisions produced which result.
+- **The file workspace conflates three roles.** Source files agents read/write,
+  reusable brand/reference materials, and generated deliverables all live as "files."
+  Reuse means remembering paths; provenance means scrolling chat history.
+- **Agents have no spatial/contextual surface.** The MCP surface can create artifacts
+  but cannot express "this deck derives from these three images and this brief." A
+  context graph is the natural substrate for the multi-step, multi-artifact work the
+  agent-ready RFC anticipates.
+
+## Object model: File ≠ Asset ≠ Node
+
+The one hard rule in this RFC. Collapsing these layers is the failure mode.
+
+| Layer | Owner | What it is | Mutability |
+|---|---|---|---|
+| **File** | daemon file workspace (unchanged) | Real bytes on disk; agents read/write directly | As today |
+| **Asset** | new asset service | Curated, workspace-level reference/snapshot of a file or generated artifact; searchable, reusable | Promote / update / archive; deleting an asset never deletes files or placed nodes |
+| **Node** | canvas state | A placed instance on the canvas: position, edges, versions, run status; records `sourceAssetId` | Independent snapshot; no automatic two-way sync with its source asset |
+
+Generated artifacts are **auto-promoted** to assets (they are the product's output —
+provenance comes free). Ordinary files are promoted **manually**. "Files become canvas
+assets" therefore means a curated layer above files, not a bulk import of every file
+into a library.
+
+## Design
+
+### Slice 1a — Storyboard rail (ships first, view-layer only)
+
+Replace the artifact tree + preview with a Storyboard view:
+
+- Columns exist only for artifact kinds present in the project (Prototype / Deck /
+  Image / HyperFrame / …), each card showing base-vs-generated provenance: design
+  system, primary skill/template, runtime + model, parameters, and version.
+- Opening a card keeps the typed rail visible and swaps only the bounded preview stage;
+  artifact-specific commands sit above the preview.
+- No data-model change: this slice is a unified read model over existing project files,
+  runs, and conversations, plus UI. Independently releasable behind a flag.
+
+### Slice 1b — Asset layer
+
+- `Asset` objects + promote/place/detach/archive commands in `packages/contracts`,
+  daemon routes, `od` CLI subcommands, and MCP tools (dual-track law: every asset
+  operation declares both its `/api/*` route and its `od` subcommand).
+- Library UI: search, favorites, recents, upload, drag-to-place.
+
+### Slice 1c — Canvas view
+
+- Nodes (position + size), context edges, and `@` mentions of upstream nodes; a
+  persisted per-project **Storyboard ⇄ Canvas** switch over the same data.
+- Two invariants, both load-bearing:
+  1. **The view switch adds no execution semantics.** Edges express context and
+     derivation; the canvas as a whole is never a runnable DAG. Explicit sub-graph
+     selection is the only future run boundary (kept out of scope here).
+  2. **The single-artifact flow stays the default.** Storyboard is the default right
+     rail; Canvas is opt-in per project.
+
+### What this unlocks later (out of scope, for orientation)
+
+Once edges exist, follow-up RFCs can attach: approved-input gates (fail-closed input
+review before any provider spend), durable generation jobs, incremental sub-graph
+runs, and publishable workflow apps. None of that is needed to evaluate slices 1a–1c.
+The execution side of that arc is sketched in
+[`multi-artifact-agent-execution.md`](./multi-artifact-agent-execution.md).
+
+## Options considered → recommendation
+
+1. **Separate "Canvas" project type** alongside Studio — clean isolation, but forks the
+   product mental model, duplicates preview/export surfaces, and strands existing
+   projects. **Rejected.**
+2. **Bulk-convert files to canvas assets** — makes the library a mirror of the file
+   tree, burying reusable materials under build output. **Rejected** in favor of the
+   promote layer.
+3. **Storyboard-first evolution of the existing rail** (this RFC) — each slice is
+   independently valuable, existing projects upgrade in place, and the canvas arrives
+   as a view over data users already trust. **Recommended.**
+
+## Compatibility and rollout
+
+- Slice 1a behind a feature flag defaulting on after one release; the legacy tree
+  remains one release as an escape hatch.
+- No migration required until 1b (assets are additive tables/state); 1c stores node
+  layout as per-project view state.
+- The MCP/CLI additions version through `packages/contracts` as usual.
+
+## Open questions
+
+1. Should auto-promotion of generated artifacts be per-project configurable?
+2. Does node layout belong in project state or per-user view state for shared/exported
+   projects?
+3. Minimum provenance schema for 1a cards when a run predates this feature (backfill
+   from run bookkeeping vs. "unknown provenance" badge)?


### PR DESCRIPTION
## What

Two companion **docs-only** RFC drafts under `docs/rfc-drafts/`, proposing how Studio can progressively grow production-canvas capabilities without breaking the single-artifact flow:

1. **`storyboard-first-canvas.md`** — evolve the right rail into a typed, provenance-aware **Storyboard**, add a curated **Asset** layer over project files (File ≠ Asset ≠ Node), then unlock a **Canvas view** (nodes + context edges) over the same data with a persisted view switch. Three independently shippable slices; the view switch adds no execution semantics; single-artifact flow stays the default.

2. **`multi-artifact-agent-execution.md`** — route agent execution into **three lanes by artifact class**: code-rendered artifacts keep the existing CLI streaming loop untouched; media artifacts go through typed tools + durable generation jobs (idempotency, frozen context, cancel/resume, capability-truthful provider adapters); stateful artifacts (workflows, video-editing projects) mutate through serializable commands with a free read-only plan step. Plus an **intent-level session API** (LibTV-style breadth lane) where every response carries a visible project URL.

## Why

- A real brief spans several artifacts, but production state is currently trapped in single artifacts with no provenance or reuse layer.
- `docs/external-media-orchestration.md` explicitly defers a provider router to "a separate owner decision" — the second RFC is that proposal, scoped to job lifecycle + adapters.
- Both RFCs extend the UI/CLI dual-track law from the agent-ready RFC to artifact, asset, and media operations.

## Notes for reviewers

- Format follows the existing `docs/rfc-drafts/` convention: umbrella design for review, genuinely open calls presented as *options considered → recommendation*, and only the first slice of each arc intended to ship code.
- Reference implementation for the object model, durable jobs, gates, and storyboard/canvas dual views exists in the Open Design Canvas project; happy to link specifics or split these into separate PRs/issues if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
