### PR TITLE
fix(web): bundle Source Serif 4 with Cyrillic coverage

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next';
 import type { ReactNode } from 'react';
 import { I18nProvider } from '../src/i18n';
 import { AnalyticsProvider } from '../src/analytics/provider';
+import '@fontsource-variable/source-serif-4/wght.css';
 import '@excalidraw/excalidraw/index.css';
 import '../src/index.css';
 import '../src/styles/home/index.css';

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "0.32.1",
     "@excalidraw/excalidraw": "0.18.1",
+    "@fontsource-variable/source-serif-4": "5.3.0",
     "@formkit/auto-animate": "0.9.0",
     "@lexical/react": "0.36.2",
     "@lexical/utils": "0.36.2",

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -83,7 +83,7 @@
   --selected: #2563eb;
   --selected-soft: rgba(37, 99, 235, 0.16);
 
-  --serif: 'Source Serif Pro', 'Source Serif 4', 'Iowan Old Style', 'Apple Garamond', Georgia, 'Times New Roman', serif;
+  --serif: 'Source Serif Pro', 'Source Serif 4 Variable', 'Iowan Old Style', 'Apple Garamond', Georgia, 'Times New Roman', serif;
   --sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Microsoft YaHei UI', 'Noto Sans', Roboto, 'Helvetica Neue', Arial, sans-serif;
   --mono: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Consolas, monospace;
 

--- a/apps/web/tests/source-serif-font.test.ts
+++ b/apps/web/tests/source-serif-font.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+import { describe, expect, it } from 'vitest';
+
+const FONT_PACKAGE = '@fontsource-variable/source-serif-4';
+const FONT_VERSION = '5.3.0';
+const require = createRequire(import.meta.url);
+
+describe('Source Serif 4 web font', () => {
+  it('pins the web dependency to the proven version', () => {
+    // Given
+    const manifest: unknown = JSON.parse(
+      readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+    );
+    const dependencies =
+      typeof manifest === 'object' && manifest !== null && 'dependencies' in manifest
+        ? manifest.dependencies
+        : null;
+
+    // When
+    const version =
+      typeof dependencies === 'object' && dependencies !== null
+        ? Reflect.get(dependencies, FONT_PACKAGE)
+        : undefined;
+
+    // Then
+    expect(version).toBe(FONT_VERSION);
+  });
+
+  it('loads variable WOFF2 faces with Cyrillic and Cyrillic-ext coverage from the global layout', () => {
+    // Given
+    const layout = readFileSync(new URL('../app/layout.tsx', import.meta.url), 'utf8');
+
+    // When
+    const fontImports = Array.from(
+      layout.matchAll(/^import\s+['"](@fontsource-variable\/source-serif-4\/[^'"]+\.css)['"];?$/gm),
+      (match) => match[1] ?? '',
+    ).filter(Boolean);
+
+    // Then
+    expect(fontImports.length).toBeGreaterThan(0);
+
+    const importedCss = fontImports
+      .map((specifier) => readFileSync(require.resolve(specifier), 'utf8'))
+      .join('\n');
+    for (const subset of ['cyrillic', 'cyrillic-ext']) {
+      const face = importedCss.match(
+        new RegExp(
+          String.raw`\/\*\s*source-serif-4-${subset}-wght-normal\s*\*\/\s*@font-face\s*\{([\s\S]*?)\}`,
+        ),
+      )?.[1];
+      expect(face, `${subset} variable font face`).toMatch(
+        /font-family:\s*['"]Source Serif 4 Variable['"][\s\S]*font-weight:\s*200 900[\s\S]*src:\s*url\([^)]*\.woff2\)[\s\S]*unicode-range:\s*U\+/,
+      );
+    }
+  });
+
+  it('keeps the local Pro face before the bundled variable face and system fallbacks', () => {
+    // Given
+    const tokens = readFileSync(new URL('../src/styles/tokens.css', import.meta.url), 'utf8');
+
+    // When
+    const families = tokens
+      .match(/--serif:\s*([^;]+);/)?.[1]
+      ?.split(',')
+      .map((family) => family.trim().replace(/^(['"])(.*)\1$/, '$2'));
+
+    // Then
+    expect(families).toEqual([
+      'Source Serif Pro',
+      'Source Serif 4 Variable',
+      'Iowan Old Style',
+      'Apple Garamond',
+      'Georgia',
+      'Times New Roman',
+      'serif',
+    ]);
+  });
+});

--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -10,5 +10,5 @@
   # 2. Run the relevant nix build/flake check
   # 3. Copy the expected hash printed by Nix into the matching field below
   daemonHash = "sha256-kWSVza0qjeIvD5wVVYP/47fZhe/RBZ0DD6omHB4aIK8=";
-  webHash = "sha256-dHbQvec3qpC+6RgbXUBdI1PpilMdAafpknk46ah5E2U=";
+  webHash = "sha256-S9i8/LD2+38iDaAMXvJJtbxzMKxRQMv+vaYAySZWsKc=";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,6 +309,9 @@ importers:
       '@excalidraw/excalidraw':
         specifier: 0.18.1
         version: 0.18.1(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@fontsource-variable/source-serif-4':
+        specifier: 5.3.0
+        version: 5.3.0
       '@formkit/auto-animate':
         specifier: 0.9.0
         version: 0.9.0
@@ -1607,6 +1610,9 @@ packages:
 
   '@fontsource-variable/playfair-display@5.2.8':
     resolution: {integrity: sha512-ZzVIXPOrL85yyOvZYoBzUszIJM+xKkHqni4IYn2CVLaGQQdJR8sBeC8yFNgjxSJ7ludTwta8qpULeOFuk5X75A==}
+
+  '@fontsource-variable/source-serif-4@5.3.0':
+    resolution: {integrity: sha512-9vch9WqxjaaA+1o9Ur8pOgIGbCYLjRReOUel23A6lOpD1syptgjtkORevvNmldJ5kGXQL29onQUqI5Ltz0s3bQ==}
 
   '@formkit/auto-animate@0.9.0':
     resolution: {integrity: sha512-VhP4zEAacXS3dfTpJpJ88QdLqMTcabMg0jwpOSxZ/VzfQVfl3GkZSCZThhGC5uhq/TxPHPzW0dzr4H9Bb1OgKA==}
@@ -7419,6 +7425,8 @@ snapshots:
   '@fontsource-variable/jetbrains-mono@5.2.8': {}
 
   '@fontsource-variable/playfair-display@5.2.8': {}
+
+  '@fontsource-variable/source-serif-4@5.3.0': {}
 
   '@formkit/auto-animate@0.9.0': {}
 


### PR DESCRIPTION
Fixes #6085

## Why

The web typography token already preferred Source Serif, but the web app did not ship that family. On machines without Source Serif Pro installed, Home and other serif headings therefore fell through to unrelated system serif fonts; Cyrillic users saw especially inconsistent metrics across operating systems.

This change adds the OFL-1.1 `@fontsource-variable/source-serif-4@5.3.0` package to `apps/web`. The production build emits six self-hosted Unicode-range WOFF2 subsets. A Russian Home page requests the matching Latin and Cyrillic files from the local app origin; the Cyrillic-ext face is registered and remains lazily available for extended glyphs, with no font CDN or other external Source Serif request.

## What users will see

Serif headings use the existing local Source Serif Pro preference when it is installed. Otherwise, Open Design now renders them with the same self-hosted Source Serif 4 Variable face, including Cyrillic and Cyrillic-ext coverage, instead of an OS-dependent fallback.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Captured from rebased current head `761feb67e0` using its production build.

**Narrow — 375 × 812 — Russian Home**

![Russian Home at 375 by 812 on head 761feb67e0](https://gist.githubusercontent.com/roian6/7aa28dee622dd69733dd7e65f4b7573e/raw/ebf7d9fe7d80bb959293b04e54f3380d660cb709/home-ru-375x812-761feb67e0.png)

**Desktop — 1280 × 900 — Russian Home**

![Russian Home at 1280 by 900 on head 761feb67e0](https://gist.githubusercontent.com/roian6/7aa28dee622dd69733dd7e65f4b7573e/raw/7f2fe56e72c6d666870b58e26fd718147bd32ec6/home-ru-1280x900-761feb67e0.png)

The full Russian Source Serif heading renders without tofu, clipping, overlap, broken wrapping, or an obvious layout shift. The Cyrillic face is loaded, the Cyrillic-ext face is registered for on-demand glyph loading, and all observed Source Serif WOFF2 requests are served from the local app origin.

## Bug fix verification

- Test path: `apps/web/tests/source-serif-font.test.ts`
- Yes — the three assertions failed on `main` because the dependency, global import, and matching variable-family token were absent, then all three passed after the source change.
- The test resolves the imported Fontsource CSS and checks its actual Cyrillic/Cyrillic-ext variable WOFF2 `@font-face` declarations rather than inferring coverage from the package name.

## Validation

All current-head gates below ran against rebased commit `761feb67e0`:

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts --maxWorkers=2 tests/source-serif-font.test.ts` — 3 passed
- `pnpm guard` — passed
- `pnpm typecheck` — passed
- `pnpm --filter @open-design/web build` — passed; emitted all six local Source Serif 4 WOFF2 subsets
- Repository Nix hash generator in the pinned Nix image — passed; updated only `webHash` for the rebased lockfile
- `nix flake check --print-build-logs --keep-going` — passed on an archive of the exact current head; all checks passed
- Browser QA on the production build at 375×812 and 1280×900 — Cyrillic face loaded, Cyrillic-ext face registered, local WOFF2 requests only, and no external Source Serif requests
