### PR TITLE
fix(daemon): refresh Claude Code fallback model list to the current generation

### DIFF
--- a/apps/daemon/src/runtimes/defs/claude.ts
+++ b/apps/daemon/src/runtimes/defs/claude.ts
@@ -8,15 +8,18 @@ import type { RuntimeAgentDef } from '../types.js';
 // keep this list in step with the CLI's `--model` help text when Anthropic
 // ships a new family (issue: Opus 5 missing from the picker).
 const CLAUDE_FALLBACK_MODELS = [
+  // Alias order is load-bearing: mmd route ids are spliced in after
+  // `default`, and tests/runtimes/mmd-routes.test.ts pins `sonnet` as the
+  // first alias that follows them.
   DEFAULT_MODEL_OPTION,
-  { id: 'fable', label: 'Fable (alias)' },
-  { id: 'opus', label: 'Opus (alias)' },
   { id: 'sonnet', label: 'Sonnet (alias)' },
+  { id: 'opus', label: 'Opus (alias)' },
   { id: 'haiku', label: 'Haiku (alias)' },
-  { id: 'claude-fable-5', label: 'claude-fable-5' },
+  { id: 'fable', label: 'Fable (alias)' },
   { id: 'claude-opus-5', label: 'claude-opus-5' },
   { id: 'claude-sonnet-5', label: 'claude-sonnet-5' },
   { id: 'claude-haiku-4-5', label: 'claude-haiku-4-5' },
+  { id: 'claude-fable-5', label: 'claude-fable-5' },
   { id: 'claude-opus-4-8', label: 'claude-opus-4-8' },
 ];
 

--- a/apps/daemon/src/runtimes/defs/claude.ts
+++ b/apps/daemon/src/runtimes/defs/claude.ts
@@ -3,14 +3,21 @@ import { DEFAULT_MODEL_OPTION } from './shared.js';
 import { loadMmdRouteModels } from '../mmd-routes.js';
 import type { RuntimeAgentDef } from '../types.js';
 
+// Aliases resolve to the latest model in each family; the explicit ids let a
+// user pin a generation. Both forms are what `claude --model` documents, so
+// keep this list in step with the CLI's `--model` help text when Anthropic
+// ships a new family (issue: Opus 5 missing from the picker).
 const CLAUDE_FALLBACK_MODELS = [
   DEFAULT_MODEL_OPTION,
-  { id: 'sonnet', label: 'Sonnet (alias)' },
+  { id: 'fable', label: 'Fable (alias)' },
   { id: 'opus', label: 'Opus (alias)' },
+  { id: 'sonnet', label: 'Sonnet (alias)' },
   { id: 'haiku', label: 'Haiku (alias)' },
-  { id: 'claude-opus-4-5', label: 'claude-opus-4-5' },
-  { id: 'claude-sonnet-4-5', label: 'claude-sonnet-4-5' },
+  { id: 'claude-fable-5', label: 'claude-fable-5' },
+  { id: 'claude-opus-5', label: 'claude-opus-5' },
+  { id: 'claude-sonnet-5', label: 'claude-sonnet-5' },
   { id: 'claude-haiku-4-5', label: 'claude-haiku-4-5' },
+  { id: 'claude-opus-4-8', label: 'claude-opus-4-8' },
 ];
 
 export const claudeAgentDef = {

--- a/apps/daemon/tests/runtimes/claude-fallback-models.test.ts
+++ b/apps/daemon/tests/runtimes/claude-fallback-models.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from 'vitest';
+
+import { claude } from './helpers/test-helpers.js';
+
+// `claude` ships no list-models subcommand, so the picker falls back to the
+// static list in runtimes/defs/claude.ts whenever no mmd/MMS route file is
+// present. That list is the ONLY source of model options for a default
+// install, which makes it silently rot every time Anthropic ships a new
+// family — it sat on the 4-5 generation long enough that Opus 5 could not be
+// selected at all. These specs pin the shape and flag the staleness.
+
+const ALIAS_IDS = ['fable', 'opus', 'sonnet', 'haiku'];
+
+function modelIds(): string[] {
+  return claude.fallbackModels.map((m) => m.id);
+}
+
+test('claude fallback models offer the family aliases documented by `claude --model`', () => {
+  const ids = modelIds();
+  // `--model` help text: "Provide an alias for the latest model (e.g. 'fable',
+  // 'opus', or 'sonnet') or a model's full name (e.g. 'claude-fable-5')".
+  // Aliases always resolve to the newest model in the family, so they are the
+  // part of this list that cannot go stale — keep them all offered.
+  for (const alias of ALIAS_IDS) {
+    expect(ids).toContain(alias);
+  }
+  expect(ids[0]).toBe('default');
+});
+
+test('claude fallback models offer a current-generation Opus to pin', () => {
+  // Regression guard: the list previously topped out at `claude-opus-4-5`, so
+  // a user who wanted the newest Opus had no explicit id to select and had to
+  // rely on the bare `opus` alias. Bump this id when a newer Opus ships.
+  expect(modelIds()).toContain('claude-opus-5');
+});
+
+test('claude fallback models do not offer superseded 4-5 generation ids', () => {
+  // `claude-haiku-4-5` is deliberately absent from this list: it is still the
+  // current Haiku, unlike the Opus/Sonnet entries it shipped alongside.
+  const ids = modelIds();
+  expect(ids).not.toContain('claude-opus-4-5');
+  expect(ids).not.toContain('claude-sonnet-4-5');
+});
+
+test('claude fallback model ids are unique and well formed', () => {
+  const ids = modelIds();
+  expect(new Set(ids).size).toBe(ids.length);
+  for (const model of claude.fallbackModels) {
+    expect(model.label.trim()).not.toBe('');
+    // Every entry is either the synthetic `default`, a bare family alias, or a
+    // fully-qualified `claude-*` id — anything else would be handed straight
+    // to `claude --model` and rejected at spawn time.
+    const wellFormed =
+      model.id === 'default' ||
+      ALIAS_IDS.includes(model.id) ||
+      /^claude-[a-z0-9-]+$/.test(model.id);
+    expect(wellFormed, `unexpected model id: ${model.id}`).toBe(true);
+  }
+});

--- a/apps/daemon/tests/runtimes/mmd-routes.test.ts
+++ b/apps/daemon/tests/runtimes/mmd-routes.test.ts
@@ -152,7 +152,7 @@ test('mmd route loader uses HOME default path and keeps Claude fallback models',
       'sonnet',
     ]);
     assert.ok(ids?.includes('opus'));
-    assert.ok(ids?.includes('claude-sonnet-4-5'));
+    assert.ok(ids?.includes('claude-sonnet-5'));
     assert.equal(JSON.stringify(models).includes('secret'), false);
   } finally {
     rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Why

**My use case:** I drive Open Design with Claude Code as the local runtime and wanted to run a design session on Claude Opus 5. It wasn't in the model picker — the newest Opus I could select was `claude-opus-4-5`, two generations behind.

**The pain:** `claude` ships no `list-models` subcommand, so `claudeAgentDef` falls back to the static `CLAUDE_FALLBACK_MODELS` array whenever no mmd/MMS route file is present. For a default install that array is the *only* source of model options, and it had drifted to the 4-5 generation. The result is a silent, recurring cliff: every time Anthropic ships a new family, users lose the ability to pin the current model until someone edits this constant. The bare `opus` alias still resolves to the latest, so the failure is easy to miss — you only notice when you go looking for an explicit id.

This is the same class of change as #4376 (tracking a new id in the Kimi runtime list), and a stopgap for #5729, which proposes refreshing local-CLI model lists dynamically instead of relying on hardcoded built-ins. It does **not** close #5729 — the list stays hardcoded here, just current, plus a spec that fails loudly the next time it rots.

## What users will see

With Claude Code selected, the model picker now offers the current generation:

- **New:** `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`, and a `fable` family alias
- **New:** `claude-opus-4-8`, so the previous Opus generation stays pinnable
- **Removed:** `claude-opus-4-5` and `claude-sonnet-4-5`, superseded by their 5-generation counterparts
- **Unchanged:** `default`, the `sonnet` / `opus` / `haiku` aliases, and `claude-haiku-4-5` (still the current Haiku)

The alias and explicit-id forms both mirror what the installed CLI documents for `--model`: *"Provide an alias for the latest model (e.g. 'fable', 'opus', or 'sonnet') or a model's full name (e.g. 'claude-fable-5')."* Verified against `claude` 2.1.220.

Anyone with a stored selection of `claude-opus-4-5` / `claude-sonnet-4-5` keeps working — `buildArgs` passes whatever is configured straight through to `--model`, so the removals only affect what the picker suggests.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [x] **Default behavior change** — the set of models offered for the `claude` runtime changes for existing users without opting in. No stored selection breaks; only the suggested list differs.
- [ ] **None**

No UI code changed — the picker renders whatever `/api/agents` returns, so there is no new entry point to screenshot. The visible delta is the dropdown contents described above.

## Bug fix verification

- **Test path:** `apps/daemon/tests/runtimes/claude-fallback-models.test.ts`
- **Red on `main`, green on this branch?** Yes. Against the pre-fix list, 3 of the 4 specs fail:
  - `expected [ 'default', 'sonnet', 'opus', …(4) ] to include 'fable'`
  - `expected [ 'default', 'sonnet', 'opus', …(4) ] to include 'claude-opus-5'`
  - `expected [ 'default', 'sonnet', 'opus', …(4) ] to not include 'claude-opus-4-5'`

  The fourth spec (ids unique and well-formed) passes on both sides by design — it guards shape rather than contents.

The specs deliberately pin the *aliases* (which never go stale, since they always resolve to the newest model in a family) and one current-generation Opus id as a staleness canary, rather than freezing the whole array.

## Validation

- `pnpm guard` — pass
- `pnpm --filter @open-design/daemon typecheck` — pass (exit 0, includes `tsconfig.tests.json`)
- `pnpm exec vitest run -c vitest.config.ts tests/runtimes/` — **45 files, 650 passed, 1 skipped, 0 failed**

### A note on the third commit

The first pass at this reordered the family aliases to match the CLI help text ordering (`fable` first). That broke three specs in `tests/runtimes/mmd-routes.test.ts`, which pin `sonnet` as the first alias following the spliced-in mmd route ids — the ordering is load-bearing and I hadn't spotted it. The third commit restores the original alias order, appends `fable` after `haiku`, and adds a comment so the constraint isn't rediscovered the hard way.

One assertion in `mmd-routes.test.ts` did have to change: it used `claude-sonnet-4-5` as its probe for "fallback models were appended after the route ids". That id is intentionally gone, so the probe moves to `claude-sonnet-5`. The assertion's intent is unchanged.

A full `apps/daemon` suite run was still in flight when this PR was opened; I'll follow up in a comment with the result and a `main` baseline comparison if anything outside `tests/runtimes/` is red.
