### PR TITLE
fix(manual-edit): keep runtime targets selected when their last style declaration clears

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -204,7 +204,7 @@ import { ManualEditSelectionOverlay, type ManualEditCropRegion } from './ManualE
 import { ManualEditTextToolbar } from './ManualEditTextToolbar';
 import {
   applyManualEditPatch,
-  hasManualEditRuntimeStyleOverride,
+  isManualEditRuntimeRenderedSource,
   isManualEditFullHtmlDocument,
   manualEditTargetHasNestedMarkup,
   readManualEditAttributes,
@@ -8658,10 +8658,13 @@ function HtmlViewer({
     // persists into the runtime override rule, so an empty outer-HTML read
     // alone must not be treated as "target vanished" (that path drops the
     // selection and reloads the canvas the runtime pages must never flash).
+    // Runtime-backed is a property of the document, not of currently owning
+    // an override rule: clearing the last declaration deletes the rule while
+    // the target stays rendered.
     if (
       id !== '__body__'
       && !readManualEditOuterHtml(savedSource, id)
-      && !hasManualEditRuntimeStyleOverride(savedSource, id)
+      && !isManualEditRuntimeRenderedSource(savedSource)
     ) {
       setManualEditError('The selected target no longer exists in the saved source. Refreshing the preview.');
       setSelectedManualEditTarget(null);

--- a/apps/web/src/edit-mode/source-patches.ts
+++ b/apps/web/src/edit-mode/source-patches.ts
@@ -264,6 +264,17 @@ function readElementInlineStyles(el: Element): ManualEditStyles {
   }, {} as ManualEditStyles);
 }
 
+/** Whether SOURCE is a runtime-rendered brand-kit document — the pages whose
+ * manual-edit targets can exist only in the runtime DOM. Saves for such
+ * targets persist through the payload or override rules, so an empty
+ * saved-markup read must never be classified as "target vanished". This is
+ * independent of whether the target currently owns an override rule: clearing
+ * a target's last declaration legitimately deletes its rule. */
+export function isManualEditRuntimeRenderedSource(source: string): boolean {
+  const doc = parseSource(source);
+  return Boolean(doc?.getElementById('od-brand-payload'));
+}
+
 /** Whether SOURCE persists a runtime style-override rule for the target —
  * the persistence a `set-style` save leaves behind when the target has no
  * saved markup (runtime-only brand-kit ids). */

--- a/apps/web/tests/components/FileViewer.manual-edit.test.tsx
+++ b/apps/web/tests/components/FileViewer.manual-edit.test.tsx
@@ -1342,6 +1342,66 @@ describe('FileViewer manual edit regressions', () => {
     expect(frame.srcdoc).toBe(srcdocBefore);
   });
 
+  it('keeps selection and canvas stable when the last runtime style declaration is cleared', async () => {
+    // Clearing a runtime-only target's final declaration (here: toggling the
+    // active alignment back to default) drops its override rule from the
+    // saved source. The reconcile guard must classify the target as
+    // runtime-backed via the brand payload — not via rule ownership — or
+    // this valid, still-rendered target reads as deleted and the debounced
+    // toolbar save drops the selection and reloads the canvas.
+    const source = '<!doctype html><html><head><script id="od-brand-payload" type="application/json">{"status":"ready","brand":{"name":"Acme"}}</script></head><body><div id="root"></div></body></html>';
+    const { fetchMock, savedBodies } = manualEditWriteMock(source);
+    vi.stubGlobal('fetch', fetchMock);
+
+    render(
+      <FileViewer projectId="project-1" projectKind="prototype" file={htmlPreviewFile()}
+        liveHtml={source}
+      />,
+    );
+    clickManualTool('manual-edit-mode-toggle');
+    const frame = await previewFrame();
+    const runtimeTarget = {
+      ...heroTarget(),
+      id: 'brand-name',
+      label: 'Brand name',
+      text: 'Acme',
+      fields: { text: 'Acme' },
+      attributes: { 'data-od-id': 'brand-name' },
+      outerHtml: '<h1 data-od-id="brand-name">Acme</h1>',
+    };
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'od-edit-select', target: runtimeTarget },
+        source: frame.contentWindow,
+      }));
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'od-edit-text-selection', id: 'brand-name', hasRange: true },
+        source: frame.contentWindow,
+      }));
+    });
+    await waitFor(() => expect(screen.getByTestId('manual-edit-text-toolbar')).toBeTruthy());
+    const srcdocBefore = frame.srcdoc;
+
+    fireEvent.click(screen.getByRole('button', { name: 'Align center' }));
+    await waitFor(() => expect(savedBodies).toHaveLength(1), { timeout: 4000 });
+    expect(savedBodies[0]!.content).toContain('text-align: center !important');
+
+    // Toggling the active alignment off emits `textAlign: ''` — this deletes
+    // the rule's last declaration and removes the rule itself.
+    fireEvent.click(screen.getByRole('button', { name: 'Align center' }));
+    await waitFor(() => expect(savedBodies).toHaveLength(2), { timeout: 4000 });
+    expect(savedBodies[1]!.content).not.toContain('text-align: center');
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    // THE regression: the still-rendered runtime target must not be treated
+    // as vanished — no error banner, no selection drop, no canvas reload.
+    expect(screen.queryByText(/no longer exists/)).toBeNull();
+    expect(screen.getByTestId('manual-edit-selection-frame')).toBeTruthy();
+    expect(frame.srcdoc).toBe(srcdocBefore);
+  });
+
   it('persists sanitized inline formatting for runtime-only brand-kit text', async () => {
     const source = '<!doctype html><html><head><script id="od-brand-payload" type="application/json">{"status":"ready","brand":{"name":"Acme"}}</script></head><body><div id="root"></div></body></html>';
     const { fetchMock, savedBodies } = manualEditWriteMock(source);


### PR DESCRIPTION
## Why

Follow-up to #5890. During its final review pass, the reviewer found one remaining reconciliation edge in the new direct-manipulation flow ([review comment](https://github.com/nexu-io/open-design/pull/5890#discussion_r3654325362), marked non-blocking): clearing a runtime-only target's **last** style declaration — for example toggling an already-active alignment back to its default from the text toolbar — legitimately deletes the target's override rule from the saved source, but `reconcileManualEditStyleSave()` used rule ownership (`hasManualEditRuntimeStyleOverride`) to recognize runtime-backed targets. The still-rendered target was therefore classified as "vanished": the save dropped the selection and forced the full-reload canvas flash that the in-place path exists to avoid.

The fix was ready while #5890 sat in the merge queue (branch locked against pushes), so it lands here immediately after the merge, as promised on the review thread.

## What users will see

On runtime-rendered brand pages, removing the last style you applied to an element (e.g. clicking the active "Align center" button again to reset it) now keeps the element selected and the canvas in place. Previously the selection chrome disappeared, an error toast claimed the element no longer existed, and the preview flashed through a full reload.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [x] **Default behavior change** — changes what existing users experience without opting in (fixes the selection-drop/reload behavior on runtime pages)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No new UI surface — this restores the existing selection chrome/canvas stability contract on an edge path. The behavioral states (selection persistence, absence of a reload flash) are covered by the component regression below.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/FileViewer.manual-edit.test.tsx` → `keeps selection and canvas stable when the last runtime style declaration is cleared` (drives the debounced text-toolbar path: align-center a runtime-only `brand-name` target, toggle it back off so the rule's last declaration is deleted, then asserts the selection frame and mounted srcdoc stay stable with no "target no longer exists" error).
- Did the test go red on `main` and green on this branch? Yes — red against the exact source now on `main` (selection frame gone after the clearing save), green with the fix.

## Validation

- `pnpm install`
- `pnpm guard`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/edit-mode/ tests/components/FileViewer.manual-edit.test.tsx tests/components/FileViewer.manual-edit-history.test.tsx tests/components/ManualEditSelectionOverlay.test.tsx` — 229 passed
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
