### PR TITLE
fix(landing): keep Codex Slides gallery within narrow screens

### DIFF
--- a/apps/landing-page/app/pages/codex-slides/index.astro
+++ b/apps/landing-page/app/pages/codex-slides/index.astro
@@ -483,7 +483,7 @@ const studioTiles = copy.inside.map((tile, i) => ({ ...tile, src: STUDIO_SHOTS[i
   /* Studio UI screenshots carry dense product chrome, so they need a bigger
      cell than the simple deck cards — two-up instead of four-up. */
   .ha-showcase-wide {
-    grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 420px), 1fr));
   }
 
   /* ---- Scenario cards ---- */

--- a/apps/landing-page/tests/codex-slides-responsive.test.ts
+++ b/apps/landing-page/tests/codex-slides-responsive.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+
+const pagePath = new URL('../app/pages/codex-slides/index.astro', import.meta.url);
+
+test('keeps the wide studio gallery within narrow containers', async () => {
+  const page = await readFile(pagePath, 'utf8');
+  const wideGalleryRule = page.match(/\.ha-showcase-wide\s*\{(?<body>[^}]*)\}/);
+
+  assert.ok(wideGalleryRule?.groups?.body, 'expected the .ha-showcase-wide CSS rule');
+  assert.match(
+    wideGalleryRule.groups.body,
+    /grid-template-columns:\s*repeat\(auto-fit,\s*minmax\(min\(100%,\s*420px\),\s*1fr\)\);/,
+  );
+});


### PR DESCRIPTION
## Summary

- let the Codex Slides studio gallery shrink to its container on narrow screens
- preserve the existing 420px minimum for wider one- and two-column layouts
- add a focused regression test for the responsive grid contract

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Testing

- `pnpm --filter @open-design/landing-page exec node --import tsx --test tests/codex-slides-responsive.test.ts`
- `pnpm --filter @open-design/landing-page test` — 59 passed; the existing `footer-parity.test.ts` failure also reproduces on the clean base commit
- `pnpm --filter @open-design/landing-page typecheck`
- `pnpm --filter @open-design/landing-page build:static` — 5,247 pages
- `pnpm guard`
- `pnpm typecheck`
- Chromium built-output geometry at 320, 375, 390, 430, 768, and 1280px for both `/codex-slides/` and `/ko/codex-slides/` — zero viewport, container, or document overflow
- Chromium grid boundary probe — 859px remains one column; 860px remains two 420px columns

## Responsive QA evidence

Validated from a fresh static build on current head `74cf53ba706e41f4ca71e09659116fe431479e05` in Chromium.

### Narrow routes — 375px viewport

| English `/codex-slides/` | Korean `/ko/codex-slides/` |
| --- | --- |
| ![English Codex Slides gallery at 375px](https://raw.githubusercontent.com/roian6/open-design/c785c8452afac9bf4d3ad728cfefc5e04b823b49/.github/pr-evidence/6099/open-design-6099-en-375.png) | ![Korean Codex Slides gallery at 375px](https://raw.githubusercontent.com/roian6/open-design/c785c8452afac9bf4d3ad728cfefc5e04b823b49/.github/pr-evidence/6099/open-design-6099-ko-375.png) |

### Grid boundary — gallery width 859px → 860px

The page shell contributes 32px side gutters, so gallery widths 859px and 860px map to browser viewports 923px and 924px respectively.

| 859px gallery / 923px viewport — 1 column | 860px gallery / 924px viewport — 2 columns |
| --- | --- |
| ![Codex Slides gallery at 859px in one column](https://raw.githubusercontent.com/roian6/open-design/c785c8452afac9bf4d3ad728cfefc5e04b823b49/.github/pr-evidence/6099/open-design-6099-boundary-859.png) | ![Codex Slides gallery at 860px in two columns](https://raw.githubusercontent.com/roian6/open-design/c785c8452afac9bf4d3ad728cfefc5e04b823b49/.github/pr-evidence/6099/open-design-6099-boundary-860.png) |

Automated geometry readback for all four captures found 4/4 cards rendered, zero clipped cards, and `html`/`body` scroll widths equal to the viewport width (no horizontal overflow).

Closes #6097
