### PR TITLE
perf(ci): narrow zero-effect queue validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
       run_playwright_critical: ${{ steps.detect.outputs.run_playwright_critical }}
       run_playwright_visual: ${{ steps.detect.outputs.run_playwright_visual }}
       run_preflight: ${{ steps.detect.outputs.run_preflight }}
+      run_preflight_typecheck: ${{ steps.detect.outputs.run_preflight_typecheck }}
       run_ui_p0: ${{ steps.detect.outputs.run_ui_p0 }}
       run_web_workspace_tests: ${{ steps.detect.outputs.run_web_workspace_tests }}
       run_windows_tools_pack_payload_tests: ${{ steps.detect.outputs.run_windows_tools_pack_payload_tests }}
@@ -255,12 +256,14 @@ jobs:
       # If postinstall grows a targeted app type-generation phase covering these
       # three exports without broad app builds, this CI prebuild can be removed.
       - name: Prebuild workspace type declarations
+        if: ${{ needs.scopes.outputs.run_preflight_typecheck == 'true' }}
         run: |
           pnpm --filter @open-design/daemon build
           pnpm --filter @open-design/desktop build
           pnpm --filter @open-design/web build:sidecar
 
       - name: Typecheck workspaces
+        if: ${{ needs.scopes.outputs.run_preflight_typecheck == 'true' }}
         run: |
           pnpm -r --filter '!open-design' --filter '!@open-design/landing-page' --workspace-concurrency="${OPEN_DESIGN_WORKSPACE_CONCURRENCY:-1}" --if-present run typecheck
           pnpm exec tsc -p scripts/tsconfig.json --noEmit

--- a/e2e/tests/scripts/scopes.test.ts
+++ b/e2e/tests/scripts/scopes.test.ts
@@ -136,15 +136,17 @@ function expectedPlan(opts: {
   const runs = new Set<RunKey>(opts.runs ?? []);
   const plan: Record<string, unknown> = {};
   for (const key of SCOPE_KEYS) plan[key] = scopes.has(key);
+  const runBroadWorkspaceValidation = opts.ciMode === "hot" || scopes.size > 0;
   plan["ci_mode"] = opts.ciMode;
   plan["run_e2e_vitest"] = runs.has("run_e2e_vitest");
   plan["run_playwright_critical"] = runs.has("run_playwright_critical");
   plan["run_playwright_visual"] = runs.has("run_playwright_visual");
   plan["run_preflight"] = true;
+  plan["run_preflight_typecheck"] = runBroadWorkspaceValidation;
   plan["run_ui_p0"] = runs.has("run_ui_p0");
   plan["run_web_workspace_tests"] = runs.has("run_web_workspace_tests");
   plan["run_windows_tools_pack_payload_tests"] = runs.has("run_windows_tools_pack_payload_tests");
-  plan["run_workspace_unit_tests"] = true;
+  plan["run_workspace_unit_tests"] = runBroadWorkspaceValidation;
   plan["ui_p0_matrix"] = UI_P0_MATRIX_JSON;
   plan["visual_matrix"] = VISUAL_MATRIX_JSON;
   return plan;
@@ -435,10 +437,10 @@ const GOLDEN_CASES: readonly GoldenCase[] = [
   {
     // The first certain-tier promotion: a group confined to the certain-exempt
     // core (docs/, landing-page, editor configs, LICENSE/CODEOWNERS) drops to
-    // the unconditional floor lanes instead of running everything. Guarded by
+    // the preflight policy floor instead of running everything. Guarded by
     // the "certain-exempt surface consumption" guard check; methodology in
     // specs/current/ci.md.
-    name: "merge_group certain-exempt core group drops to the floor lanes",
+    name: "merge_group certain-exempt core group drops to the policy floor",
     context: { eventName: "merge_group" },
     files: ["docs/architecture.md", "docs/nested/guide.mdx", "apps/landing-page/src/pages/index.astro", "LICENSE", ".github/CODEOWNERS"],
     expected: expectedPlan({ ciMode: "full" }),

--- a/scripts/check-certain-exempt-consumption.ts
+++ b/scripts/check-certain-exempt-consumption.ts
@@ -24,9 +24,9 @@ import { CERTAIN_EXEMPT_EXACT, CERTAIN_EXEMPT_PREFIXES } from "./scopes.ts";
 //   enters an exempt directory: flagged as the same repository dependency.
 //
 // Deliberately outside the checked surface:
-// - root `scripts/` — floor-owned code. Preflight and workspace unit tests are
-//   unconditionally armed on every plan, so floor checks may read the exempt
-//   surface (product neutrality validates docs/ prose on every run).
+// - root `scripts/` — policy-floor code. Preflight is armed on every plan, so
+//   its guard checks may read the exempt surface (product neutrality validates
+//   docs/ prose on every run).
 // - `apps/landing-page/` — it IS the exempt surface; landing-page CI owns it.
 
 const repoRoot = path.resolve(import.meta.dirname, "..");

--- a/scripts/scopes.ts
+++ b/scripts/scopes.ts
@@ -74,6 +74,7 @@ type ScopePlan = ScopeOutputs & {
   run_playwright_critical: boolean;
   run_playwright_visual: boolean;
   run_preflight: boolean;
+  run_preflight_typecheck: boolean;
   run_ui_p0: boolean;
   run_web_workspace_tests: boolean;
   run_windows_tools_pack_payload_tests: boolean;
@@ -100,10 +101,10 @@ type GitHubEvent = {
 // ---------------------------------------------------------------------------
 
 // Certain-tier exempt core: surfaces whose "cannot affect gate validation"
-// invariant is definitional and enforced by the named guard check. Floor lanes
-// (preflight and workspace unit tests, both unconditionally armed) still run
-// for these files, so floor-owned checks that read them — e.g. product
-// neutrality over docs/ — keep validating them on every plan.
+// invariant is definitional and enforced by the named guard check. The
+// preflight policy floor still runs for these files, so floor-owned checks
+// that read them — e.g. product neutrality over docs/ — keep validating them
+// on every plan.
 export const CERTAIN_EXEMPT_PREFIXES = [
   ".vscode/",
   ".idea/",
@@ -457,6 +458,11 @@ function createRunPlan(
   fullLanes: boolean = ciMode === "full",
 ): Omit<ScopePlan, keyof ScopeOutputs | "ui_p0_matrix" | "visual_matrix"> {
   const isFull = fullLanes;
+  const hasValidationScope = SCOPE_EFFECTS.some((effect) => outputs[effect]);
+  // Preserve every PR/manual-hot signal. Only a merge-queue plan whose
+  // certain-tier rules claim zero validation effects may skip broad workspace
+  // work; preflight itself stays armed as the always-run policy floor.
+  const runBroadWorkspaceValidation = isFull || ciMode === "hot" || hasValidationScope;
   const runUiP0 = isFull || outputs.ui_p0_validation_required;
 
   return {
@@ -465,10 +471,11 @@ function createRunPlan(
     run_playwright_critical: outputs.ui_critical_validation_required && !runUiP0,
     run_playwright_visual: isFull || outputs.visual_validation_required,
     run_preflight: true,
+    run_preflight_typecheck: runBroadWorkspaceValidation,
     run_ui_p0: runUiP0,
     run_web_workspace_tests: isFull || outputs.web_tests_required,
     run_windows_tools_pack_payload_tests: isFull || outputs.tools_pack_tests_required,
-    run_workspace_unit_tests: true,
+    run_workspace_unit_tests: runBroadWorkspaceValidation,
   };
 }
 
@@ -571,7 +578,7 @@ function createEnvScopePlan(): PlanWithTrace {
     // The merge queue evaluates the whole queued group's union diff at the
     // "certain" threshold. Files matching only certain-tier rules contribute
     // their claimed radius (for the certain-exempt core: none — a pure-docs
-    // group drops to the unconditional floor lanes); every other file
+    // group drops to the preflight policy floor); every other file
     // escalates and keeps the plan full. The trace's ifTrustAll shadow column
     // is the evidence stream for future promotions. Resolution anomalies fail
     // open to the full plan: queue throughput must never depend on this

--- a/specs/current/ci.md
+++ b/specs/current/ci.md
@@ -1,10 +1,15 @@
 # CI scope confidence methodology
 
-This is the living framework for how trust in CI scope rules evolves. It owns
-confidence-tier changes in `scripts/scopes.ts` (promotions, demotions, guard
-requirements) and the evidence recipes behind them. Workflow topology and the
-capability/handoff architecture stay owned by `.github/AGENTS.md`; do not
-restate them here.
+This is the current authority for CI scope confidence rules in
+`scripts/scopes.ts`, their guard requirements, and their evidence recipes.
+Workflow topology and the capability/handoff architecture stay owned by
+`.github/AGENTS.md`; do not restate them here.
+
+This document records current state only. State active rules, boundaries,
+invariants, evidence, and unresolved questions directly; do not add dated or
+numbered rollout stages, before/after narratives, or a history of how the
+current design was reached. Git history, pull requests, and task records own
+that change history.
 
 ## The model in three paragraphs
 
@@ -28,7 +33,7 @@ bounce. A wrong `certain` rule lets an invalid change reach `main` with no
 automatic detection behind it. That asymmetry is why the two tiers have
 different iteration rules below.
 
-## Medium-tier iteration (cheap loop)
+## Medium-tier requirements
 
 Adding or refining a `medium` rule needs: the rule-table diff, updated goldens
 in `e2e/tests/scripts/scopes.test.ts`, and a tonnage estimate from the replay
@@ -37,11 +42,11 @@ surfaces nobody touches; candidates come from measurement, not from reading
 the rule table for imperfections (measured imperfection lists and
 frequency-weighted tonnage lists barely intersect).
 
-## Certain-tier promotion (deliberate loop)
+## Certain-tier requirements
 
-A promotion PR must be statable in three sentences: which rule, what guard,
-how much tonnage. Anything that cannot fit that statement is riding along and
-must be split out.
+A PR that makes a rule `certain` must be statable in three sentences: which
+rule, what guard, how much tonnage. Anything that cannot fit that statement is
+riding along and must be split out.
 
 Requirements:
 
@@ -58,11 +63,11 @@ Requirements:
 3. **Evidence proportional to the guard's strength.** Guard invariants come in
    three strengths: *definitional* (the surface cannot enter build or runtime
    by construction — e.g. docs), *structural* (an import-graph boundary), and
-   *behavioral* (a topology test). Definitional promotions may rely on replay
-   evidence alone. Structural and behavioral promotions additionally require
-   shadow evidence from real queue runs (the `ifTrustAll` column in the scope
-   decision trace); the required window is an open question until the first
-   such proposal exists.
+   *behavioral* (a topology test). Definitional rules may rely on replay
+   evidence alone. Structural and behavioral rules additionally require shadow
+   evidence from real queue runs (the `ifTrustAll` column in the scope decision
+   trace). The required window is unspecified and must be resolved before any
+   such rule becomes `certain`.
 4. **Goldens updated, divergence pinned.** The golden that changes is the
    proof of the behavior change; the goldens that do not change are the proof
    of its containment.
@@ -83,13 +88,12 @@ Requirements:
    `scripts/check-certain-exempt-consumption.ts`); widening the lane revives
    the violation and forces reclassification.
 
-Demotion is not yet codified (open question), with one hard rule already in
-force: if a guard check is deleted or renamed, the rule-table invariant test
-fails CI — a certain rule can never silently outlive its guard. Rule five is
-the same principle one level down: an exception can never silently outlive
-its premise.
+No general demotion policy is defined. One hard rule is active: if a guard
+check is deleted or renamed, the rule-table invariant test fails CI — a
+certain rule can never silently outlive its guard. Rule five is the same
+principle one level down: an exception can never silently outlive its premise.
 
-## Promotion #1 (2026-07): the certain-exempt core
+## Certain-exempt boundary
 
 Rule `certain-exempt-surface`: prefixes `docs/`, `apps/landing-page/`,
 `.vscode/`, `.idea/`, `.github/ISSUE_TEMPLATE/` plus exacts `LICENSE`,
@@ -99,40 +103,39 @@ reference a certain-exempt path; policy-floor code (root `scripts/`) is exempt
 from the scan because preflight always runs and may validate docs content
 (product neutrality does).
 
-Evidence, from replaying the 398 first-parent merges before the promotion:
+Current evidence and exceptions:
 
-- 56 merges (14.1%) touched only the exempt surface; under the promoted core
-  49 (12.3%) stay pure. The 7 lost are mostly root markdown (`README.md`),
-  deliberately left medium.
-- Each pure-core queue run originally dropped from the full lane set to
-  preflight + workspace unit; optimization #2 below narrows that further to
-  the preflight policy floor.
-- Known true consumer found and allowlisted with rationale:
+- A replay of 398 first-parent merges ending at `b99a9fdc3` produces 46
+  certain, zero-effect plans (11.6%).
+- Root markdown such as `README.md` remains medium because bare filename
+  literals are widespread as project-fixture data and are not locally
+  distinguishable from repository-root reads.
+- Allowlisted true consumer:
   `tools/release/src/release-note/prepare.ts` reads `docs/CHANGELOG`, which
   executes only in release workflows; `@open-design/tools-release` tests run
   in no `ci.yml` lane.
 
-## Optimization #2 (2026-07): zero-effect queue policy floor
+## Zero-effect merge-queue policy floor
 
 A merge-queue plan that trusts every changed file at `certain` and receives no
 scope effects keeps preflight setup, `pnpm guard`, and the i18n structure check,
 but skips preflight's app prebuild/typecheck steps and the workspace-unit job.
-The predicate is deliberately queue-only: PR/manual-hot retain their previous
-validation even when the medium-tier plan has no effects, and forced-full or
-escalated queue plans still run everything.
+The predicate is queue-only: PR/manual-hot run broad validation even when the
+medium-tier plan has no effects, and forced-full or escalated queue plans run
+everything.
 
-Safety comes from promotion #1's existing boundary rather than a new rule:
-the certain-exempt consumption guard still executes in preflight, and
-`pnpm guard` still sees every changed path (including a misleading executable
-such as `docs/example.js`). The skipped workspace-unit job does not own
-landing-page validation, and the broad workspace typecheck already excludes
+The certain-exempt consumption guard executes in preflight, and `pnpm guard`
+sees every changed path (including a misleading executable such as
+`docs/example.js`). The workspace-unit job does not own landing-page
+validation, and the broad workspace typecheck excludes
 `@open-design/landing-page`.
 
-Evidence from the 398-merge replay ending at `b99a9fdc3` found 46 qualifying
-queue plans (11.6%). Across 12 recent successful merge-group runs, the skipped
-prebuild/typecheck work cost about 1.95 runner-min and the workspace-unit job
-about 1.6 runner-min, for roughly 3.6 runner-min and 2.1 critical-path minutes
-saved per qualifying run (~166 runner-min over the replay window).
+The 398-merge replay ending at `b99a9fdc3` contains 46 qualifying queue plans
+(11.6%). A sample of 12 successful merge-group runs measures broad prebuild
+and typecheck at about 1.95 runner-min and workspace unit at about 1.6
+runner-min. The policy floor therefore avoids roughly 3.6 runner-min and 2.1
+critical-path minutes per qualifying run (~166 runner-min across the replay
+window).
 
 ## Evidence recipes
 
@@ -159,7 +162,7 @@ node --experimental-strip-types scripts/scopes.ts plan --context pr \
   --files apps/web/src/App.tsx docs/architecture.md
 ```
 
-Pull the shadow column from a real queue run (the promotion evidence stream
+Pull the shadow column from a real queue run (the certain-rule evidence stream
 for structural/behavioral proposals; prefer job logs — do not rely on
 artifacts):
 
@@ -170,23 +173,20 @@ gh run view <run-id> --log | sed -n '/scope decision trace:/,/^}/p'
 Each recipe's sanity check: the replay loop must print only `PURE`/`ESCALATED`
 counts; `plan` must print JSON with a `trace.threshold` matching the context.
 
-## Tooling graduation
+## Evidence tooling policy
 
-These recipes stay recipes. A recipe graduates into a checked-in script only
-when a promotion proposal needs evidence beyond the CI log retention window,
-or the recipe is being re-run often enough that copy errors have actually
-bitten. Infrastructure here follows the same rule as confidence: earned by
-evidence, not provisioned in advance.
+Keep these commands as recipes. Check in a script only when a certain-rule
+evaluation needs evidence beyond the CI log retention window, or repeated
+manual execution has produced copy errors. Evidence must justify additional
+infrastructure.
 
 ## Open questions
 
-- Shadow-evidence window for the first structural promotion (define N when
-  that proposal exists).
+- Required shadow-evidence window for structural or behavioral certain rules.
 - Demotion policy beyond the guard-resolution hard rule.
-- PR-side zero-effect conditionalization: optimization #2 intentionally
-  changes only queue-trusted plans. Extending it to medium-tier PR plans needs
-  its own evidence and containment review.
-- Queue batching discount: the 12.3% figure assumes single-PR queue groups; a
+- Whether medium-tier zero-effect PR plans should use the policy floor; this
+  needs its own evidence and containment review.
+- Queue batching discount: the 11.6% figure assumes single-PR queue groups; a
   mixed group loses the benefit file-by-file. Check real `merge_group` traces
   once a few have accumulated.
 - Adjacent medium-tier gaps (each is its own small PR): `e2e/tests/**` arms no

--- a/specs/current/ci.md
+++ b/specs/current/ci.md
@@ -15,10 +15,12 @@ PR and manual-hot runs believe `medium`, the merge queue believes only
 `certain`, manual-full runs believe nothing. A file below threshold — or
 matching no rule — escalates fail-closed to the full radius.
 
-Two floors never move: `run_preflight` and `run_workspace_unit_tests` are
-unconditionally true in every plan. Preflight runs `pnpm guard` and the
-workspace typecheck, so guard checks execute on every run of every plan —
-including runs where a certain-tier rule skipped everything else.
+The policy floor never moves: `run_preflight` is true in every plan, and its
+workspace setup, `pnpm guard`, and i18n structure check always execute. Broad
+app declaration builds, workspace typecheck, and `run_workspace_unit_tests`
+may skip only for a merge-queue plan whose certain-tier evaluation claims zero
+validation effects. PR, manual-hot, forced-full, and escalated queue plans keep
+all broad workspace validation.
 
 The error cost is asymmetric by tier. A wrong `medium` rule under-arms a PR
 run and gets caught by the merge queue's stricter threshold — cost: one queue
@@ -51,7 +53,7 @@ Requirements:
 2. **A guard that resolves.** The rule's `guard` field must name a live
    `scripts/guard.ts` check (`pnpm --silent guard --list-checks` is the
    registry; the rule-table invariant test enforces resolution). Guards for
-   certain rules must run in a floor lane — `pnpm guard` in preflight
+   certain rules must run in the policy floor — `pnpm guard` in preflight
    qualifies — so the check that justifies skipping always itself runs.
 3. **Evidence proportional to the guard's strength.** Guard invariants come in
    three strengths: *definitional* (the surface cannot enter build or runtime
@@ -93,8 +95,8 @@ Rule `certain-exempt-surface`: prefixes `docs/`, `apps/landing-page/`,
 `.vscode/`, `.idea/`, `.github/ISSUE_TEMPLATE/` plus exacts `LICENSE`,
 `.github/CODEOWNERS`. Guard: `certain-exempt surface consumption`
 (`scripts/check-certain-exempt-consumption.ts`) — no skippable-lane source may
-reference a certain-exempt path; floor-owned code (root `scripts/`) is exempt
-from the scan because floor lanes always run and may validate docs content
+reference a certain-exempt path; policy-floor code (root `scripts/`) is exempt
+from the scan because preflight always runs and may validate docs content
 (product neutrality does).
 
 Evidence, from replaying the 398 first-parent merges before the promotion:
@@ -102,11 +104,35 @@ Evidence, from replaying the 398 first-parent merges before the promotion:
 - 56 merges (14.1%) touched only the exempt surface; under the promoted core
   49 (12.3%) stay pure. The 7 lost are mostly root markdown (`README.md`),
   deliberately left medium.
-- Each pure-core queue run drops from the full lane set to the two floors.
+- Each pure-core queue run originally dropped from the full lane set to
+  preflight + workspace unit; optimization #2 below narrows that further to
+  the preflight policy floor.
 - Known true consumer found and allowlisted with rationale:
   `tools/release/src/release-note/prepare.ts` reads `docs/CHANGELOG`, which
   executes only in release workflows; `@open-design/tools-release` tests run
   in no `ci.yml` lane.
+
+## Optimization #2 (2026-07): zero-effect queue policy floor
+
+A merge-queue plan that trusts every changed file at `certain` and receives no
+scope effects keeps preflight setup, `pnpm guard`, and the i18n structure check,
+but skips preflight's app prebuild/typecheck steps and the workspace-unit job.
+The predicate is deliberately queue-only: PR/manual-hot retain their previous
+validation even when the medium-tier plan has no effects, and forced-full or
+escalated queue plans still run everything.
+
+Safety comes from promotion #1's existing boundary rather than a new rule:
+the certain-exempt consumption guard still executes in preflight, and
+`pnpm guard` still sees every changed path (including a misleading executable
+such as `docs/example.js`). The skipped workspace-unit job does not own
+landing-page validation, and the broad workspace typecheck already excludes
+`@open-design/landing-page`.
+
+Evidence from the 398-merge replay ending at `b99a9fdc3` found 46 qualifying
+queue plans (11.6%). Across 12 recent successful merge-group runs, the skipped
+prebuild/typecheck work cost about 1.95 runner-min and the workspace-unit job
+about 1.6 runner-min, for roughly 3.6 runner-min and 2.1 critical-path minutes
+saved per qualifying run (~166 runner-min over the replay window).
 
 ## Evidence recipes
 
@@ -157,10 +183,9 @@ evidence, not provisioned in advance.
 - Shadow-evidence window for the first structural promotion (define N when
   that proposal exists).
 - Demotion policy beyond the guard-resolution hard rule.
-- Floor conditionalization: pure certain-core changes still pay preflight +
-  workspace unit tests; skipping the floors is the natural second certain-tier
-  proposal and must confront the "docs/ can hide a `.js` file from guard"
-  class of questions.
+- PR-side zero-effect conditionalization: optimization #2 intentionally
+  changes only queue-trusted plans. Extending it to medium-tier PR plans needs
+  its own evidence and containment review.
 - Queue batching discount: the 12.3% figure assumes single-PR queue groups; a
   mixed group loses the benefit file-by-file. Check real `merge_group` traces
   once a few have accumulated.


### PR DESCRIPTION
## Why

The first certain-tier CI scope promotion lets pure docs and other proven
non-runtime changes reach the merge queue with zero validation effects, but
those plans still paid for broad workspace typechecking and workspace unit
tests. Replay and live-run measurements show that narrowing this queue-only
floor can save about 3.6 runner-minutes and 2.1 critical-path minutes per
qualifying run without weakening the guard that justifies the skip.

`specs/current/ci.md` now explicitly records current state only and states the
active boundary, policy floor, and evidence without dated rollout history.
Git, pull requests, and task records remain the history surfaces.

## What users will see

No user-facing product change. Certain, zero-effect merge-queue groups finish
CI sooner; pull requests, manual hot/full runs, and escalated queue plans retain
their existing validation.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable.

## Bug fix verification

Not a bug fix.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/e2e test tests/scripts/scopes.test.ts`
- `pnpm exec tsc -p scripts/tsconfig.json --noEmit`
- `actionlint -color`
- Direct plan checks for PR docs, merge-queue docs, manual-full docs, and an
  escalated merge-queue path
