### PR TITLE
fix(desktop): cover clear-cache in updater IPC teardown and host bridge guard

### DIFF
--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -283,6 +283,7 @@ const DESIGN_BROWSER_PARTITION = "persist:open-design-design-browser";
 const UPDATER_IPC_CHANNELS = [
   "od:update:status",
   "od:update:check",
+  "od:update:clear-cache",
   "od:update:download",
   "od:update:install",
   "od:update:quit",

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -41,6 +41,7 @@ import {
   type LauncherRuntimeDescriptor,
 } from "@open-design/launcher-proto";
 import {
+  DESKTOP_UPDATE_ACTIONS,
   DESKTOP_UPDATE_CHANNELS,
   DESKTOP_UPDATE_MODES,
   DESKTOP_UPDATE_STATES,
@@ -110,8 +111,7 @@ const DEFAULT_POLL_INITIAL_DELAY_MS = 5000;
 const DEFAULT_POLL_BACKOFF_INITIAL_MS = 60 * 1000;
 const DEFAULT_POLL_BACKOFF_MAX_MS = 30 * 60 * 1000;
 const MIN_SCHEDULED_POLL_DELAY_MS = 1000;
-const MAC_DEFERRED_INSTALLER_TIMEOUT_MS = 10 * 60 * 1000;
-const WINDOWS_DEFERRED_INSTALLER_TIMEOUT_MS = 10 * 60 * 1000;
+const DEFERRED_INSTALLER_TIMEOUT_MS = 10 * 60 * 1000;
 const ARTIFACT_DOWNLOAD_MAX_ATTEMPTS = 3;
 const DESKTOP_UPDATE_CHANNEL_VALUES = new Set<string>(Object.values(DESKTOP_UPDATE_CHANNELS));
 const execFileAsync = promisify(execFile);
@@ -3553,7 +3553,7 @@ export function createDesktopUpdater(
       cwd: config.runtimeBase,
       installerPath: resolvedDownload,
       root: updateRoot,
-      timeoutMs: config.platform === "win32" ? WINDOWS_DEFERRED_INSTALLER_TIMEOUT_MS : MAC_DEFERRED_INSTALLER_TIMEOUT_MS,
+      timeoutMs: DEFERRED_INSTALLER_TIMEOUT_MS,
     });
   }
 
@@ -3579,7 +3579,7 @@ export function createDesktopUpdater(
       ...(delegated == null ? {} : { delegated }),
       launchPath,
       root: updateRoot,
-      timeoutMs: config.platform === "win32" ? WINDOWS_DEFERRED_INSTALLER_TIMEOUT_MS : MAC_DEFERRED_INSTALLER_TIMEOUT_MS,
+      timeoutMs: DEFERRED_INSTALLER_TIMEOUT_MS,
     });
     return { ...result, launchPath };
   }
@@ -3805,15 +3805,15 @@ export function createDesktopUpdater(
     downloadUpdate: () => serialized(downloadUpdate),
     handle(action) {
       switch (action) {
-        case "status":
+        case DESKTOP_UPDATE_ACTIONS.STATUS:
           return this.status();
-        case "check":
+        case DESKTOP_UPDATE_ACTIONS.CHECK:
           return this.checkForUpdates();
-        case "clear-cache":
+        case DESKTOP_UPDATE_ACTIONS.CLEAR_CACHE:
           return this.clearCache();
-        case "download":
+        case DESKTOP_UPDATE_ACTIONS.DOWNLOAD:
           return this.downloadUpdate();
-        case "install":
+        case DESKTOP_UPDATE_ACTIONS.INSTALL:
           return this.installUpdate();
       }
     },

--- a/apps/desktop/tests/main/updater-host-boundary.test.ts
+++ b/apps/desktop/tests/main/updater-host-boundary.test.ts
@@ -24,6 +24,17 @@ describe("desktop updater host boundary", () => {
     expect(runtime).toContain("event.sender !== window.webContents");
   });
 
+  it("lists every registered od:update:* handler in the teardown channel table", () => {
+    const runtime = source("src/main/runtime.ts");
+    const registered = [...runtime.matchAll(/ipcMain\.handle\("(od:update:[^"]+)"/g)].map((match) => match[1]);
+    const tableStart = runtime.indexOf("const UPDATER_IPC_CHANNELS = [");
+    const tableEnd = runtime.indexOf("]", tableStart);
+    expect(tableStart).toBeGreaterThanOrEqual(0);
+    const listed = [...runtime.slice(tableStart, tableEnd).matchAll(/"(od:update:[^"]+)"/g)].map((match) => match[1]);
+    expect(registered.length).toBeGreaterThan(0);
+    expect([...new Set(listed)].sort()).toEqual([...new Set(registered)].sort());
+  });
+
   it("does not turn automatic startup checks into native desktop dialogs", () => {
     const main = source("src/main/index.ts");
     const scheduleStart = main.indexOf("updateScheduler = createDesktopUpdaterScheduler");

--- a/packages/host/src/detection.ts
+++ b/packages/host/src/detection.ts
@@ -66,6 +66,7 @@ export function isOpenDesignHostBridge(value: unknown): value is OpenDesignHostB
     !isRecord(updater) ||
     !hasFunction(updater, "status") ||
     !hasFunction(updater, "check") ||
+    !hasFunction(updater, "clear-cache") ||
     !hasFunction(updater, "download") ||
     !hasFunction(updater, "install") ||
     !hasFunction(updater, "quit") ||

--- a/packages/host/tests/index.test.ts
+++ b/packages/host/tests/index.test.ts
@@ -85,6 +85,11 @@ describe("open-design host contract", () => {
       ...createMockOpenDesignHost(),
       updater: { status: async () => createMockOpenDesignHost().updater.status() },
     })).toBe(false);
+    const { "clear-cache": _clearCache, ...updaterWithoutClearCache } = createMockOpenDesignHost().updater;
+    expect(isOpenDesignHostBridge({
+      ...createMockOpenDesignHost(),
+      updater: updaterWithoutClearCache,
+    })).toBe(false);
   });
 
   it("reads the bridge through the package-owned global accessor", () => {

--- a/tools/pack/AGENTS.md
+++ b/tools/pack/AGENTS.md
@@ -108,7 +108,7 @@ curl.exe --ssl-no-revoke -fsSL https://releases.open-design.ai/beta/latest/metad
 For `release-beta-s`, check the internal feed instead:
 
 ```bash
-curl.exe --ssl-no-revoke -fsSL https://s3.nexu.space/od-releases/beta/latest/metadata.json
+curl.exe --ssl-no-revoke -fsSL https://s3.nexu.space/od-releases/betas/latest/metadata.json
 ```
 
 2. Build a non-portable Windows beta package with the real beta namespace and a version lower than latest:


### PR DESCRIPTION
## Why

While mapping the packaged updater ahead of a mechanical split of `apps/desktop/src/main/updater.ts`, the survey turned up a real teardown defect plus a couple of zero-risk cleanups worth landing before the split starts:

- `od:update:clear-cache` (added in #6032) is registered via `ipcMain.handle` but was missing from `UPDATER_IPC_CHANNELS`, so the pre-registration `removeHandler` sweep never covers it. A second `createDesktopRuntime()` in the same process (dev hot-reload, window recreation, tests) throws "Attempted to register a second handler" on that channel.
- The host bridge structural guard (`packages/host/src/detection.ts`) did not check the `"clear-cache"` method even though `OpenDesignHostBridge` requires it — the same omission pattern, on the renderer side. #6032 added the method to the protocol type and preload but not to the guard; tightening the guard without a version bump follows the existing convention (#5789 did exactly this for `setMenuLabels` / `subscribeOpenDialog`). The practical consequence is confined to the transient historical-outer mixed-generation window, the same behavior class #5789 already accepted.
- Two literal-level cleanups in `updater.ts`: the mac/Windows deferred-installer timeouts were two constants with one value branched on platform, and `handle()` dispatched on raw action strings instead of `DESKTOP_UPDATE_ACTIONS`.
- `tools/pack/AGENTS.md` pointed beta-s acceptance at `beta/latest`, but the `release-beta-s` lane publishes `RELEASE_CHANNEL: betas`, i.e. `betas/latest`.

## What users will see

Nothing user-visible. The clear-cache action itself already worked in a normally-running app; the fix removes a latent double-registration crash and closes the guard gap.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Bug fix verification

- Test paths that reproduce the defect:
  - `apps/desktop/tests/main/updater-host-boundary.test.ts` — "lists every registered od:update:* handler in the teardown channel table" (derives the teardown table from the actual `ipcMain.handle("od:update:...")` registrations, so any future channel omission fails too)
  - `packages/host/tests/index.test.ts` — "rejects legacy or incomplete bridge shapes" gains a case for a bridge whose updater lacks `"clear-cache"`
- Did the tests go red on `main` and green on this branch? **yes** (both were run against the unfixed sources first and failed exactly on the missing channel / accepted-incomplete-bridge, then went green after the fix commits)

## Validation

- `pnpm --filter @open-design/desktop test` (269 passed) and `typecheck` (both tsconfigs)
- `pnpm --filter @open-design/host test` (14 passed) and `typecheck`
- `pnpm --filter @open-design/web test` (full suite, 4924 passed) and `typecheck`
- `pnpm --filter @open-design/tools-serve test` (18 passed)
- `pnpm --filter @open-design/tools-pack test -- tests/win-identity.test.ts tests/win-app.test.ts tests/win-builder.test.ts` (248 passed, 8 skipped)
- `pnpm guard`, `pnpm typecheck`, `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
