### PR TITLE
ci: close packaged leaf test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,7 +304,13 @@ jobs:
             pnpm --filter @open-design/tools-dev test
           fi
           if [ "${{ needs.scopes.outputs.tools_pack_tests_required }}" = "true" ]; then
+            pnpm --filter @open-design/desktop build
+            pnpm --filter @open-design/desktop test
+            pnpm --filter @open-design/packaged test
             pnpm --filter @open-design/tools-pack test
+            if [ "${{ needs.scopes.outputs.run_e2e_vitest }}" != "true" ]; then
+              pnpm --filter @open-design/e2e test tests/packaged-launcher-update-loop.test.ts
+            fi
           fi
 
       - name: Probe watcher environment

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -945,6 +945,21 @@ process.stdin.on("end", () => {
     }
   });
 
+  it("[P2] closes packaged-leaf coverage without duplicating the broad E2E lane", async () => {
+    const workflow = await readFile(ciWorkflowPath, "utf8");
+    const workspaceUnit = sectionBetween(workflow, "  workspace_unit_tests:", "  windows_tools_pack_payload_tests:");
+
+    expect(workspaceUnit).toContain(`if [ "\${{ needs.scopes.outputs.tools_pack_tests_required }}" = "true" ]; then
+            pnpm --filter @open-design/desktop build
+            pnpm --filter @open-design/desktop test
+            pnpm --filter @open-design/packaged test
+            pnpm --filter @open-design/tools-pack test
+            if [ "\${{ needs.scopes.outputs.run_e2e_vitest }}" != "true" ]; then
+              pnpm --filter @open-design/e2e test tests/packaged-launcher-update-loop.test.ts
+            fi
+          fi`);
+  });
+
   it("[P2] skips the critical fallback for pure packaged-leaf changes and stays fail-closed elsewhere", async () => {
     const hot = { inputs: { ci_mode: "hot" } };
 


### PR DESCRIPTION
## Why

Pure changes under `apps/desktop`, `apps/packaged`, and `tools/pack` are routed
through the tools-pack CI scope, but the workspace unit job only ran the
tools-pack suite. This left the existing desktop and packaged unit suites out
of both PR and merge-queue validation for that surface.

This PR closes that correctness gap before any attempt to narrow packaged-leaf
queue validation further. It also keeps one cross-boundary launcher update-loop
test in the leaf path when the broad E2E Vitest lane is not already running.

## What users will see

No product-facing change. Packaged-runtime changes receive more complete CI
coverage.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`)
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; there is no UI change.

## Bug fix verification

Not a product bug fix. The new workflow topology assertion pins the previously
missing package-local and focused cross-boundary commands.

## Validation

- `pnpm --filter @open-design/desktop build`
- `pnpm --filter @open-design/desktop test`
- `pnpm --filter @open-design/packaged test`
- `pnpm --filter @open-design/tools-pack test`
- `pnpm --filter @open-design/e2e test tests/packaged-launcher-update-loop.test.ts`
- `pnpm --filter @open-design/e2e test tests/packaged-smoke-workflow.test.ts`
- `actionlint -color`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
