### PR TITLE
fix(daemon): classify model failures and timeout stages

### DIFF
--- a/apps/daemon/src/run-diagnostics.ts
+++ b/apps/daemon/src/run-diagnostics.ts
@@ -57,6 +57,12 @@ export interface RunDiagnosticsAnalytics {
   resume_auto_reseeded: boolean;
 }
 
+export interface RunToolProgress {
+  toolCallSeen: boolean;
+  toolResultSent: boolean;
+  hasOutstandingTool: boolean;
+}
+
 export interface StreamTailSummary {
   tail: string;
   lineCount: number;
@@ -68,6 +74,44 @@ export type StdoutTailSummary = StreamTailSummary;
 
 const STDERR_TAIL_MAX_LINES = 20;
 const STDERR_TAIL_MAX_BYTES = 4 * 1024;
+
+export function summarizeRunToolProgress(
+  events: RunEventForDiagnostics[] = [],
+): RunToolProgress {
+  // Pair normal events by id. Some degraded provider streams omit ids on both
+  // sides, so pair those by count rather than treating every result as global.
+  const outstandingToolUseIds = new Set<string>();
+  let idlessToolUses = 0;
+  let idlessToolResults = 0;
+  let toolCallSeen = false;
+
+  for (const event of events) {
+    const data = event.data && typeof event.data === 'object'
+      ? event.data as Record<string, unknown>
+      : {};
+    if (data.type === 'tool_use') {
+      toolCallSeen = true;
+      if (typeof data.id === 'string') outstandingToolUseIds.add(data.id);
+      else idlessToolUses += 1;
+    }
+    if (data.type === 'tool_result') {
+      if (typeof data.toolUseId === 'string') {
+        outstandingToolUseIds.delete(data.toolUseId);
+      } else {
+        idlessToolResults += 1;
+      }
+    }
+  }
+
+  const hasOutstandingTool =
+    outstandingToolUseIds.size > 0 ||
+    idlessToolResults < idlessToolUses;
+  return {
+    toolCallSeen,
+    toolResultSent: toolCallSeen && !hasOutstandingTool,
+    hasOutstandingTool,
+  };
+}
 
 function readStderrChunk(data: unknown): string | null {
   if (typeof data === 'string') return data;
@@ -165,25 +209,10 @@ export function summarizeRunDiagnosticsForAnalytics(args: {
   liveArtifactSeen?: boolean;
 }): RunDiagnosticsAnalytics {
   const events = args.events ?? [];
+  const toolProgress = summarizeRunToolProgress(events);
   let stderr = '';
   let stdout = '';
   let userVisibleOutputSeen = false;
-  let toolCallSeen = false;
-  // `tool_result_sent` = EVERY committed tool_use received a matching tool_result.
-  // Paired by id (`tool_use.id` <-> `tool_result.toolUseId`, the same pairing
-  // summarizeRunTimingAnalytics uses), because a plain "any tool_result after a
-  // tool_use" flag reports delivered for a parallel turn like tool_use(A),
-  // tool_use(B), tool_result(A) where B is still outstanding.
-  //
-  // Degraded provider events carry NO id, symmetrically on both sides — see
-  // `agent-protocol/pi-rpc/events.ts` and `copilot-stream.ts`, which both emit
-  // `toolCallId ?? null` for tool_use.id AND tool_result.toolUseId. Those are
-  // paired by count instead; skipping them would let an unpaired id-less tool
-  // call fall through to "delivered" and mask exactly the stall we're attributing.
-  const outstandingToolUseIds = new Set<string>();
-  let idlessToolUses = 0;
-  let idlessToolResults = 0;
-  let sawAnyToolUse = false;
   let approvalRequested = false;
   let artifactWriteSeen = args.artifactWriteSeen === true;
   let liveArtifactSeen = args.liveArtifactSeen === true;
@@ -207,16 +236,6 @@ export function summarizeRunDiagnosticsForAnalytics(args: {
     if (data.type === 'text_delta' || data.type === 'thinking_delta') {
       const delta = typeof data.delta === 'string' ? data.delta : '';
       if (delta.length > 0) userVisibleOutputSeen = true;
-    }
-    if (data.type === 'tool_use') {
-      toolCallSeen = true;
-      sawAnyToolUse = true;
-      if (typeof data.id === 'string') outstandingToolUseIds.add(data.id);
-      else idlessToolUses += 1;
-    }
-    if (data.type === 'tool_result') {
-      if (typeof data.toolUseId === 'string') outstandingToolUseIds.delete(data.toolUseId);
-      else idlessToolResults += 1;
     }
     if (data.type === 'diagnostic' && data.name === 'acp_approval_request') {
       approvalRequested = true;
@@ -290,11 +309,8 @@ export function summarizeRunDiagnosticsForAnalytics(args: {
     rpc_close_reason: rpcCloseReason,
     first_token_seen: args.firstTokenSeen === true,
     user_visible_output_seen: userVisibleOutputSeen,
-    tool_call_seen: toolCallSeen,
-    tool_result_sent:
-      sawAnyToolUse &&
-      outstandingToolUseIds.size === 0 &&
-      idlessToolResults >= idlessToolUses,
+    tool_call_seen: toolProgress.toolCallSeen,
+    tool_result_sent: toolProgress.toolResultSent,
     approval_requested: approvalRequested,
     artifact_write_seen: artifactWriteSeen,
     live_artifact_seen: liveArtifactSeen,

--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -6,6 +6,7 @@ import type {
 } from '@open-design/contracts/analytics';
 
 import { classifyAmrAccountFailure } from './integrations/vela-errors.js';
+import { summarizeRunToolProgress } from './run-diagnostics.js';
 import { classifyAgentServiceFailure } from './runtimes/auth.js';
 import type { RunResult, RunStatusForAnalytics } from './run-result.js';
 
@@ -103,10 +104,8 @@ function inferFailureStageFromEvents(
   fallback: TrackingRunFailureStage,
 ): TrackingRunFailureStage {
   let sawFirstToken = false;
-  let sawToolUse = false;
-  let sawOpenTool = false;
   let sawArtifact = false;
-  const openTools = new Set<string>();
+  const toolProgress = summarizeRunToolProgress(events);
 
   for (const rec of events ?? []) {
     if (rec.event === 'live_artifact') sawArtifact = true;
@@ -120,18 +119,11 @@ function inferFailureStageFromEvents(
     if (data.type === 'artifact' || data.type === 'live_artifact') {
       sawArtifact = true;
     }
-    if (data.type === 'tool_use' && typeof data.id === 'string') {
-      sawToolUse = true;
-      openTools.add(data.id);
-    }
-    if (data.type === 'tool_result' && typeof data.toolUseId === 'string') {
-      openTools.delete(data.toolUseId);
-    }
   }
 
-  sawOpenTool = openTools.size > 0;
   if (sawArtifact) return 'artifact_write';
-  if (sawOpenTool || sawToolUse) return 'tool_execution';
+  if (toolProgress.hasOutstandingTool) return 'tool_outstanding';
+  if (toolProgress.toolCallSeen) return 'post_tool_resume';
   if (sawFirstToken) return 'child_close';
   return fallback;
 }
@@ -344,7 +336,7 @@ function modelUnavailableDetail(text: string): TrackingRunFailureDetail | null {
   if (/\b(no endpoints found that support tool use|provider routing)\b/i.test(text)) {
     return 'provider_routing_error';
   }
-  if (/\b(model .*not supported|not supported model\b|requested model is not supported|supported api model names|not supported when using codex)\b/i.test(text)) {
+  if (/\b(unsupported model\b|model .*not supported|not supported model\b|requested model is not supported|supported api model names|not supported when using codex)\b/i.test(text)) {
     return 'model_not_supported';
   }
   if (/\b(model (?:is )?(?:unavailable|not available|unsupported|not found)|selected model is not available|not have access|no access|model .*not found|no healthy deployments|model .*not in (?:the )?allowed list)\b/i.test(text)) {

--- a/apps/daemon/tests/run-failure-classification.test.ts
+++ b/apps/daemon/tests/run-failure-classification.test.ts
@@ -167,7 +167,7 @@ describe('classifyRunFailure', () => {
       }),
     ).toMatchObject({
       failure_category: 'user_cancel',
-      failure_stage: 'tool_execution',
+      failure_stage: 'tool_outstanding',
     });
   });
 
@@ -254,6 +254,35 @@ describe('classifyRunFailure', () => {
     ).toMatchObject({
       failure_category: 'model_unavailable',
       failure_detail: 'model_not_found',
+      failure_stage: 'model_select',
+      retryable: false,
+      user_action: 'switch_model',
+    });
+  });
+
+  it('classifies provider "Unsupported model" responses before stream-close fallback', () => {
+    const message = [
+      'Bad Request: {',
+      '  "error": {',
+      '    "code": "400",',
+      '    "message": "Unsupported model claude-sonnet-4-5"',
+      '  }',
+      '}',
+    ].join('\n');
+
+    expect(
+      classifyForAgent(
+        'byok-opencode',
+        'AGENT_EXECUTION_FAILED',
+        message,
+        [
+          errorEvent('AGENT_EXECUTION_FAILED', message, true),
+          runtimeCloseEvent('stream_error'),
+        ],
+      ),
+    ).toMatchObject({
+      failure_category: 'model_unavailable',
+      failure_detail: 'model_not_supported',
       failure_stage: 'model_select',
       retryable: false,
       user_action: 'switch_model',
@@ -534,6 +563,53 @@ describe('classifyRunFailure', () => {
     });
   });
 
+  it('separates outstanding tools from post-tool resume stalls', () => {
+    const timeoutMessage = 'Agent stalled without emitting any new output for 600s.';
+
+    expect(
+      classify('TIMEOUT', timeoutMessage, [
+        { event: 'agent', data: { type: 'text_delta', delta: 'Working.' } },
+        { event: 'agent', data: { type: 'tool_use', id: 'tool-1', name: 'Read' } },
+        errorEvent('TIMEOUT', timeoutMessage, true),
+      ]),
+    ).toMatchObject({
+      failure_category: 'timeout',
+      failure_detail: 'inactivity_timeout',
+      failure_stage: 'tool_outstanding',
+    });
+
+    expect(
+      classify('TIMEOUT', timeoutMessage, [
+        { event: 'agent', data: { type: 'text_delta', delta: 'Working.' } },
+        { event: 'agent', data: { type: 'tool_use', id: 'tool-1', name: 'Read' } },
+        { event: 'agent', data: { type: 'tool_result', toolUseId: 'tool-1' } },
+        errorEvent('TIMEOUT', timeoutMessage, true),
+      ]),
+    ).toMatchObject({
+      failure_category: 'timeout',
+      failure_detail: 'inactivity_timeout',
+      failure_stage: 'post_tool_resume',
+    });
+  });
+
+  it('separates id-less outstanding tools from resolved post-tool stalls', () => {
+    const timeoutMessage = 'Agent stalled without emitting any new output for 600s.';
+    const classifyIdless = (withResult: boolean) =>
+      classify('TIMEOUT', timeoutMessage, [
+        { event: 'agent', data: { type: 'tool_use', id: null, name: 'Read' } },
+        ...(withResult
+          ? [{ event: 'agent', data: { type: 'tool_result', toolUseId: null } }]
+          : []),
+        errorEvent('TIMEOUT', timeoutMessage, true),
+      ]);
+
+    expect(classifyIdless(false)).toMatchObject({
+      failure_stage: 'tool_outstanding',
+    });
+    expect(classifyIdless(true)).toMatchObject({
+      failure_stage: 'post_tool_resume',
+    });
+  });
 
   it('honors the latest explicit non-retryable hint for timeout failures', () => {
     expect(

--- a/apps/daemon/tests/run-retry-policy.test.ts
+++ b/apps/daemon/tests/run-retry-policy.test.ts
@@ -181,6 +181,22 @@ describe('decideSafeRunRetry', () => {
       shouldRetry: false,
       retrySuppressedReason: 'unsafe_failure_stage',
     });
+
+    for (const failure_stage of ['tool_outstanding', 'post_tool_resume'] as const) {
+      expect(
+        decide({
+          failure: {
+            failure_category: 'timeout',
+            failure_detail: 'inactivity_timeout',
+            failure_stage,
+            retryable: true,
+          },
+        }),
+      ).toMatchObject({
+        shouldRetry: false,
+        retrySuppressedReason: 'unsafe_failure_stage',
+      });
+    }
   });
 
   it('does not retry successful or cancelled terminal results', () => {

--- a/packages/contracts/src/analytics/events/shared-enums.ts
+++ b/packages/contracts/src/analytics/events/shared-enums.ts
@@ -274,6 +274,8 @@ export type TrackingRunFailureStage =
   | 'prompt_send'
   | 'first_token_wait'
   | 'tool_execution'
+  | 'tool_outstanding'
+  | 'post_tool_resume'
   | 'artifact_write'
   | 'child_close'
   | 'finalize';

--- a/packages/contracts/tests/analytics-run-finished-contract.test.ts
+++ b/packages/contracts/tests/analytics-run-finished-contract.test.ts
@@ -165,6 +165,25 @@ describe('analytics run_finished contract', () => {
     expect(finished.props.retry_suppressed_reason).toBe('tool_call_seen');
   });
 
+  it.each(['tool_outstanding', 'post_tool_resume'] as const)(
+    'accepts the %s failure stage for run outcomes',
+    (failureStage) => {
+      const payload = {
+        event: 'run_finished',
+        props: {
+          ...makeBaseRunFinishedProps(),
+          failure_category: 'timeout',
+          failure_detail: 'inactivity_timeout',
+          failure_stage: failureStage,
+          retryable: true,
+          user_action: 'retry',
+        },
+      } satisfies Extract<AnalyticsEventPayload, { event: 'run_finished' }>;
+
+      expect(payload.props.failure_stage).toBe(failureStage);
+    },
+  );
+
   it('accepts Langfuse report result events for actual delivery monitoring', () => {
     const payload = {
       event: 'langfuse_report_result',


### PR DESCRIPTION
## Why

The 0.16.1 reliability investigation found two failure-attribution gaps in the agent runtime:

- Provider responses such as `400 Unsupported model claude-sonnet-4-5` fell through to the generic stream-close classifier, making a deterministic model-selection error look retryable.
- A timeout after a tool call was always recorded as `tool_execution`, so we could not distinguish a tool that never returned from a model that failed to resume after receiving the tool result.

These gaps make production diagnosis noisy and can trigger futile retries for unsupported models.

## What users will see

Unsupported-model failures are now treated as non-retryable and direct the user to switch models. Timeout telemetry now distinguishes `tool_outstanding` from `post_tool_resume`, while both stages remain protected from automatic retry because tool side effects may already have occurred.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; no UI surface changed.

## Bug fix verification

- Test paths: `apps/daemon/tests/run-failure-classification.test.ts`, `apps/daemon/tests/run-retry-policy.test.ts`, and `packages/contracts/tests/analytics-run-finished-contract.test.ts`.
- Yes. The new classification specs went red before the source change (3 failures: unsupported model fell through to the generic stream error, and resolved/unresolved tool stages were not distinguished) and are green on this branch.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm guard`
- `corepack pnpm typecheck`
- `corepack pnpm exec vitest run -c vitest.config.ts tests/run-failure-classification.test.ts tests/run-diagnostics.test.ts tests/run-retry-policy.test.ts` — 134 passed
- `corepack pnpm --filter @open-design/contracts exec vitest run tests/analytics-run-finished-contract.test.ts` — 7 passed
- `corepack pnpm --filter @open-design/contracts test` — 250 passed
- `corepack pnpm --filter @open-design/daemon test` — relevant suites passed; the full local run retained 8 unrelated machine-environment failures (7 proxy-dispatcher expectations due the active `127.0.0.1:7897` system proxy and 1 real-chokidar file-descriptor bound assertion).