### PR TITLE
ci: narrow packaged leaf merge validation

### DIFF
--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -974,10 +974,37 @@ process.stdin.on("end", () => {
       await expect(runScopesPrint("workflow_dispatch", hot, [file])).resolves.toMatchObject({
         run_playwright_critical: false,
         run_ui_p0: false,
+        tools_dev_tests_required: true,
+        tools_pack_tests_required: true,
         ui_critical_validation_required: false,
         workspace_validation_required: true,
       });
     }
+
+    const mergeGroup = {
+      merge_group: {
+        base_sha: "1111111111111111111111111111111111111111",
+        head_sha: "2222222222222222222222222222222222222222",
+      },
+    };
+    await expect(runScopesPrint("merge_group", mergeGroup, ["apps/desktop/src/main.ts"])).resolves.toMatchObject({
+      run_e2e_vitest: false,
+      run_playwright_critical: false,
+      run_playwright_visual: false,
+      run_ui_p0: false,
+      run_web_workspace_tests: false,
+      run_windows_tools_pack_payload_tests: true,
+      tools_dev_tests_required: true,
+      tools_pack_tests_required: true,
+      workspace_validation_required: true,
+    });
+
+    await expect(runScopesPrint("merge_group", mergeGroup, ["apps/desktop/package.json"])).resolves.toMatchObject({
+      run_e2e_vitest: true,
+      run_playwright_visual: true,
+      run_ui_p0: true,
+      run_web_workspace_tests: true,
+    });
 
     // Fail-closed: anything that can reach the Playwright runtime — tools-dev,
     // transitive packages (including the undeclared metatool edge), scripts,

--- a/e2e/tests/scripts/scopes.test.ts
+++ b/e2e/tests/scripts/scopes.test.ts
@@ -289,7 +289,7 @@ const GOLDEN_CASES: readonly GoldenCase[] = [
     files: ["tools/pack/src/build.ts"],
     expected: expectedPlan({
       ciMode: "hot",
-      scopes: ["tools_pack_tests_required", "workspace_validation_required"],
+      scopes: ["tools_dev_tests_required", "tools_pack_tests_required", "workspace_validation_required"],
       runs: ["run_windows_tools_pack_payload_tests"],
     }),
   },
@@ -299,7 +299,7 @@ const GOLDEN_CASES: readonly GoldenCase[] = [
     files: ["apps/desktop/src/main/index.ts"],
     expected: expectedPlan({
       ciMode: "hot",
-      scopes: ["tools_pack_tests_required", "workspace_validation_required"],
+      scopes: ["tools_dev_tests_required", "tools_pack_tests_required", "workspace_validation_required"],
       runs: ["run_windows_tools_pack_payload_tests"],
     }),
   },
@@ -368,6 +368,7 @@ const GOLDEN_CASES: readonly GoldenCase[] = [
       ciMode: "hot",
       scopes: [
         "web_tests_required",
+        "tools_dev_tests_required",
         "tools_pack_tests_required",
         "ui_critical_validation_required",
         "ui_p0_validation_required",
@@ -444,6 +445,26 @@ const GOLDEN_CASES: readonly GoldenCase[] = [
     context: { eventName: "merge_group" },
     files: ["docs/architecture.md", "docs/nested/guide.mdx", "apps/landing-page/src/pages/index.astro", "LICENSE", ".github/CODEOWNERS"],
     expected: expectedPlan({ ciMode: "full" }),
+  },
+  {
+    name: "merge_group packaged-leaf core uses the guarded narrow plan",
+    context: { eventName: "merge_group" },
+    files: [
+      "apps/desktop/src/main/index.ts",
+      "apps/packaged/tests/launcher.test.ts",
+      "tools/pack/resources/linux/open-design.desktop.template",
+    ],
+    expected: expectedPlan({
+      ciMode: "full",
+      scopes: ["tools_dev_tests_required", "tools_pack_tests_required", "workspace_validation_required"],
+      runs: ["run_windows_tools_pack_payload_tests"],
+    }),
+  },
+  {
+    name: "merge_group packaged configuration outside the certain core stays full",
+    context: { eventName: "merge_group" },
+    files: ["apps/desktop/package.json", "tools/pack/bin/tools-pack.mjs"],
+    expected: FULL_PLAN,
   },
   {
     name: "merge_group mixed group runs everything at the certain threshold",
@@ -536,6 +557,48 @@ test("merge-queue threshold trusts the certain-exempt core without escalation", 
     matchedRules: ["certain-exempt-surface"],
     escalated: false,
   });
+});
+
+test("packaged-leaf core matches only its certain rule with the guarded effects", async () => {
+  const { evaluateScopeOutputs, matchesRuleMatch, scopeRules } = await import("../../../scripts/scopes.ts");
+  const files = [
+    "apps/desktop/src/main.ts",
+    "apps/packaged/tests/main.test.ts",
+    "tools/pack/resources/linux/open-design.desktop.template",
+  ];
+  for (const file of files) {
+    const matched = scopeRules.filter((rule) => matchesRuleMatch(file, rule.match)).map((rule) => rule.id);
+    assert.deepEqual(matched, ["certain-packaged-leaf-sources"], file);
+  }
+  const evaluation = evaluateScopeOutputs(files, "certain", {
+    deriveWorkspaceValidationFromTestScopes: true,
+  });
+  assert.deepEqual(evaluation.decisions.map((decision) => decision.escalated), [false, false, false]);
+  assert.deepEqual(
+    Object.entries(evaluation.outputs)
+      .filter(([, enabled]) => enabled)
+      .map(([effect]) => effect),
+    ["tools_dev_tests_required", "tools_pack_tests_required", "workspace_validation_required"],
+  );
+});
+
+test("packaged-leaf consumption collector resolves imports, packages, and static paths", async () => {
+  const { collectPackagedLeafConsumptionFromSource } = await import(
+    "../../../scripts/check-packaged-leaf-boundary.ts"
+  );
+  const violations = collectPackagedLeafConsumptionFromSource(
+    "packages/example/src/index.ts",
+    [
+      `import "@open-design/desktop/main";`,
+      `await import("../../../apps/packaged/src/index.ts");`,
+      `const source = path.join(repoRoot, "tools", "pack", "src", "index.ts");`,
+      `const prose = "desktop behavior is packaged elsewhere";`,
+    ].join("\n"),
+  );
+  assert.deepEqual(
+    violations.map((violation) => violation.lineNumber),
+    [1, 2, 3],
+  );
 });
 
 test("the consumption guard folds repository paths while allowing sandbox fixture writers", async () => {
@@ -681,7 +744,8 @@ test("fallback matching honors excludeWhen semantics", async () => {
 
   assert.equal(matchesRuleMatch("README.md", workspaceFallback.match), false);
   assert.equal(matchesRuleMatch("mystery.xyz", workspaceFallback.match), true);
-  assert.equal(matchesRuleMatch("tools/pack/src/build.ts", workspaceFallback.match), true);
+  assert.equal(matchesRuleMatch("tools/pack/src/build.ts", workspaceFallback.match), false);
+  assert.equal(matchesRuleMatch("tools/pack/bin/tools-pack.mjs", workspaceFallback.match), true);
 
   assert.equal(matchesRuleMatch("tools/pack/src/build.ts", uiCriticalFallback.match), false);
   assert.equal(matchesRuleMatch("apps/desktop/src/main.ts", uiCriticalFallback.match), false);

--- a/scripts/check-packaged-leaf-boundary.ts
+++ b/scripts/check-packaged-leaf-boundary.ts
@@ -1,0 +1,268 @@
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import ts from "typescript";
+
+import {
+  CERTAIN_PACKAGED_LEAF_PREFIXES,
+  evaluateScopeOutputs,
+  SCOPE_EFFECTS,
+} from "./scopes.ts";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const checkedRoots = ["apps", "packages", "tools", "e2e"] as const;
+const checkedExtensions = new Set([".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"]);
+const skippedDirectories = new Set([
+  ".astro",
+  ".next",
+  ".od-data",
+  "dist",
+  "node_modules",
+  "out",
+  "reports",
+  "test-results",
+  "vendor",
+]);
+const leafPackages = ["@open-design/desktop", "@open-design/packaged", "@open-design/tools-pack"] as const;
+
+const allowedConsumerPrefixes = new Map([
+  [
+    "tools/dev/",
+    "tools-dev launches the desktop entry; the certain rule keeps @open-design/tools-dev tests armed",
+  ],
+]);
+
+const allowedConsumers = new Map([
+  [
+    "apps/packaged/esbuild.config.mjs",
+    "the packaged build owns these entrypoints; the config itself remains medium-tier",
+  ],
+  [
+    "tools/pack/esbuild.config.mjs",
+    "the tools-pack build owns this entrypoint; the config itself remains medium-tier",
+  ],
+  [
+    "e2e/tests/packaged-launcher-update-loop.test.ts",
+    "the focused cross-boundary fallback runs whenever broad E2E Vitest is skipped",
+  ],
+  [
+    "e2e/tests/packaged-smoke-workflow.test.ts",
+    "workflow and scope topology fixtures; packaged paths are data rather than runtime imports",
+  ],
+  [
+    "e2e/tests/scripts/approve-fork-pr-workflows.test.ts",
+    "fork-approval path classification fixtures; packaged paths are data",
+  ],
+  [
+    "e2e/tests/scripts/check-cross-app-imports.test.ts",
+    "cross-app import parser fixtures; the packaged import is passed as source text",
+  ],
+  [
+    "e2e/tests/scripts/scopes.test.ts",
+    "scope planner fixtures; packaged paths are classification inputs",
+  ],
+  [
+    "packages/platform/tests/index.test.ts",
+    "package-manager invocation fixtures serialize the desktop build command without loading desktop code",
+  ],
+]);
+
+const requiredWorkspaceUnitBlock = `if [ "\${{ needs.scopes.outputs.tools_dev_tests_required }}" = "true" ]; then
+            pnpm --filter @open-design/tools-dev test
+          fi
+          if [ "\${{ needs.scopes.outputs.tools_pack_tests_required }}" = "true" ]; then
+            pnpm --filter @open-design/desktop build
+            pnpm --filter @open-design/desktop test
+            pnpm --filter @open-design/packaged test
+            pnpm --filter @open-design/tools-pack test
+            if [ "\${{ needs.scopes.outputs.run_e2e_vitest }}" != "true" ]; then
+              pnpm --filter @open-design/e2e test tests/packaged-launcher-update-loop.test.ts
+            fi
+          fi`;
+
+export type PackagedLeafConsumptionViolation = {
+  filePath: string;
+  lineNumber: number;
+  literal: string;
+};
+
+function repositoryPath(filePath: string): string {
+  return path.relative(repoRoot, filePath).split(path.sep).join("/");
+}
+
+function landsInPackagedLeaf(value: string): boolean {
+  return CERTAIN_PACKAGED_LEAF_PREFIXES.some(
+    (prefix) => value === prefix.slice(0, -1) || value.startsWith(prefix),
+  );
+}
+
+function literalTargetsPackagedLeaf(fromRepositoryPath: string, literal: string): boolean {
+  if (leafPackages.some((packageName) => literal === packageName || literal.startsWith(`${packageName}/`))) {
+    return true;
+  }
+  const resolved =
+    literal.startsWith("./") || literal.startsWith("../")
+      ? path.posix.normalize(path.posix.join(path.posix.dirname(fromRepositoryPath), literal))
+      : literal;
+  return landsInPackagedLeaf(resolved);
+}
+
+type StaticPath = { value: string; display: string };
+
+function staticPath(node: ts.Expression, sourceFile: ts.SourceFile): StaticPath | undefined {
+  if (ts.isStringLiteralLike(node)) return { value: node.text, display: node.getText(sourceFile) };
+  if (ts.isTemplateExpression(node)) {
+    return { value: node.head.text, display: node.getText(sourceFile) };
+  }
+  if (!ts.isCallExpression(node) || !ts.isPropertyAccessExpression(node.expression)) return undefined;
+  if (
+    !ts.isIdentifier(node.expression.expression) ||
+    node.expression.expression.text !== "path" ||
+    (node.expression.name.text !== "join" && node.expression.name.text !== "resolve")
+  ) {
+    return undefined;
+  }
+
+  const segments: string[] = [];
+  for (const [index, argument] of node.arguments.entries()) {
+    if (index === 0 && ts.isIdentifier(argument) && /^(?:repoRoot|workspaceRoot|WORKSPACE_ROOT)$/.test(argument.text)) {
+      continue;
+    }
+    if (!ts.isExpression(argument)) return undefined;
+    const segment = staticPath(argument, sourceFile);
+    if (segment == null || segment.value.length === 0) return undefined;
+    segments.push(segment.value);
+  }
+  return segments.length > 0
+    ? { value: path.posix.join(...segments), display: node.getText(sourceFile) }
+    : undefined;
+}
+
+export function collectPackagedLeafConsumptionFromSource(
+  filePath: string,
+  source: string,
+): PackagedLeafConsumptionViolation[] {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    filePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+  const violations: PackagedLeafConsumptionViolation[] = [];
+  const seen = new Set<number>();
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isExpression(node)) {
+      const candidate = staticPath(node, sourceFile);
+      if (candidate != null && literalTargetsPackagedLeaf(filePath, candidate.value)) {
+        const start = node.getStart(sourceFile);
+        if (!seen.has(start)) {
+          seen.add(start);
+          violations.push({
+            filePath,
+            lineNumber: sourceFile.getLineAndCharacterOfPosition(start).line + 1,
+            literal: candidate.display,
+          });
+        }
+        return;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return violations;
+}
+
+function isAllowedConsumer(filePath: string): boolean {
+  return (
+    allowedConsumers.has(filePath) ||
+    [...allowedConsumerPrefixes.keys()].some((prefix) => filePath.startsWith(prefix))
+  );
+}
+
+async function collectCheckedFiles(directory: string): Promise<string[]> {
+  const files: string[] = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const fullPath = path.join(directory, entry.name);
+    const repoPath = repositoryPath(fullPath);
+    if (entry.isDirectory()) {
+      if (
+        skippedDirectories.has(entry.name) ||
+        entry.name.startsWith(".next-") ||
+        landsInPackagedLeaf(`${repoPath}/`)
+      ) {
+        continue;
+      }
+      files.push(...(await collectCheckedFiles(fullPath)));
+    } else if (entry.isFile() && checkedExtensions.has(path.extname(entry.name))) {
+      files.push(repoPath);
+    }
+  }
+  return files;
+}
+
+function scopeBoundaryErrors(): string[] {
+  const expectedEffects = new Set([
+    "tools_dev_tests_required",
+    "tools_pack_tests_required",
+    "workspace_validation_required",
+  ]);
+  const errors: string[] = [];
+
+  for (const filePath of [
+    "apps/desktop/src/main/index.ts",
+    "apps/desktop/tests/main/runtime.test.ts",
+    "apps/packaged/src/index.ts",
+    "apps/packaged/tests/index.test.ts",
+    "tools/pack/src/index.ts",
+    "tools/pack/tests/index.test.ts",
+    "tools/pack/resources/linux/open-design.desktop.template",
+  ]) {
+    const evaluation = evaluateScopeOutputs([filePath], "certain", {
+      deriveWorkspaceValidationFromTestScopes: true,
+    });
+    const decision = evaluation.decisions[0];
+    const actualEffects = SCOPE_EFFECTS.filter((effect) => evaluation.outputs[effect]);
+    if (
+      decision?.escalated !== false ||
+      decision.matchedRules.length !== 1 ||
+      decision.matchedRules[0] !== "certain-packaged-leaf-sources" ||
+      actualEffects.length !== expectedEffects.size ||
+      actualEffects.some((effect) => !expectedEffects.has(effect))
+    ) {
+      errors.push(`${filePath} does not resolve to the guarded packaged-leaf effects at the certain threshold`);
+    }
+  }
+  return errors;
+}
+
+export async function checkPackagedLeafBoundary(): Promise<boolean> {
+  const violations: PackagedLeafConsumptionViolation[] = [];
+  for (const root of checkedRoots) {
+    for (const filePath of await collectCheckedFiles(path.join(repoRoot, root))) {
+      if (isAllowedConsumer(filePath)) continue;
+      const source = await readFile(path.join(repoRoot, filePath), "utf8");
+      violations.push(...collectPackagedLeafConsumptionFromSource(filePath, source));
+    }
+  }
+
+  const workflow = await readFile(path.join(repoRoot, ".github/workflows/ci.yml"), "utf8");
+  const errors = scopeBoundaryErrors();
+  if (!workflow.includes(requiredWorkspaceUnitBlock)) {
+    errors.push("ci.yml no longer contains the guarded tools-dev, packaged unit, and focused E2E command block");
+  }
+
+  if (violations.length > 0 || errors.length > 0) {
+    console.error("Packaged-leaf boundary violations found:");
+    for (const violation of violations) {
+      console.error(`- ${violation.filePath}:${violation.lineNumber} ${violation.literal}`);
+    }
+    for (const error of errors) console.error(`- ${error}`);
+    console.error("Keep new consumers inside the guarded validation plan or leave the changed surface at medium confidence.");
+    return false;
+  }
+
+  console.log("Packaged-leaf boundary check passed: certain-tier consumers, effects, and CI commands stay aligned.");
+  return true;
+}

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -5,6 +5,7 @@ import ts from "typescript";
 
 import { checkCertainExemptConsumption } from "./check-certain-exempt-consumption.ts";
 import { checkCrossAppImports } from "./check-cross-app-imports.ts";
+import { checkPackagedLeafBoundary } from "./check-packaged-leaf-boundary.ts";
 import { checkTsNocheckImports } from "./check-ts-nocheck-imports.ts";
 import { checkDesignSystemManifests } from "./check-design-system-manifests.ts";
 import { checkDesignSystemPackageQuality } from "./check-design-system-package-quality.ts";
@@ -1326,6 +1327,7 @@ async function checkCiTopology(): Promise<boolean> {
 const checks: GuardCheck[] = [
   { name: "residual JavaScript", run: checkResidualJavaScript },
   { name: "certain-exempt surface consumption", run: checkCertainExemptConsumption },
+  { name: "packaged leaf boundary", run: checkPackagedLeafBoundary },
   { name: "package dependency specs", run: checkPackageDependencySpecs },
   { name: "product neutrality", run: checkProductNeutrality },
   { name: "cross-app imports", run: checkCrossAppImports },

--- a/scripts/scopes.ts
+++ b/scripts/scopes.ts
@@ -122,6 +122,25 @@ const CERTAIN_EXEMPT_SURFACE: RuleMatch = {
   exact: CERTAIN_EXEMPT_EXACT,
 };
 
+export const CERTAIN_PACKAGED_LEAF_PREFIXES = [
+  "apps/desktop/src/",
+  "apps/desktop/tests/",
+  "apps/packaged/src/",
+  "apps/packaged/tests/",
+  "tools/pack/src/",
+  "tools/pack/tests/",
+  "tools/pack/resources/",
+] as const;
+
+const CERTAIN_PACKAGED_LEAF_SURFACE: RuleMatch = {
+  prefixes: CERTAIN_PACKAGED_LEAF_PREFIXES,
+};
+
+const CERTAIN_SURFACE: RuleMatch = {
+  prefixes: [...CERTAIN_EXEMPT_PREFIXES, ...CERTAIN_PACKAGED_LEAF_PREFIXES],
+  exact: CERTAIN_EXEMPT_EXACT,
+};
+
 // Medium-tier exempt residue. The global markdown regex stays medium on
 // purpose: its safety at certain would depend on every other rule continuing
 // to cover each directory where markdown is runtime content (skills/, craft/,
@@ -146,9 +165,8 @@ const MEDIUM_EXEMPT_EXACT = [
 
 const EXEMPT_REGEXES = [/\.(?:md|mdx|txt)$/] as const;
 
-// Union of both exempt tiers; this is what the fail-closed fallbacks exclude.
-const EXEMPT_SURFACE: RuleMatch = {
-  prefixes: [...CERTAIN_EXEMPT_PREFIXES, ...MEDIUM_EXEMPT_PREFIXES],
+const WORKSPACE_FALLBACK_EXCLUDED_SURFACE: RuleMatch = {
+  prefixes: [...CERTAIN_EXEMPT_PREFIXES, ...MEDIUM_EXEMPT_PREFIXES, ...CERTAIN_PACKAGED_LEAF_PREFIXES],
   exact: [...CERTAIN_EXEMPT_EXACT, ...MEDIUM_EXEMPT_EXACT],
   regexes: EXEMPT_REGEXES,
 };
@@ -170,7 +188,7 @@ export const scopeRules: readonly ScopeRule[] = [
       prefixes: MEDIUM_EXEMPT_PREFIXES,
       exact: MEDIUM_EXEMPT_EXACT,
       regexes: EXEMPT_REGEXES,
-      excludeWhen: CERTAIN_EXEMPT_SURFACE,
+      excludeWhen: CERTAIN_SURFACE,
     },
     effects: [],
     confidence: "medium",
@@ -232,6 +250,13 @@ export const scopeRules: readonly ScopeRule[] = [
     confidence: "medium",
   },
   {
+    id: "certain-packaged-leaf-sources",
+    match: CERTAIN_PACKAGED_LEAF_SURFACE,
+    effects: ["tools_dev_tests_required", "tools_pack_tests_required", "workspace_validation_required"],
+    confidence: "certain",
+    guard: "packaged leaf boundary",
+  },
+  {
     id: "tools-pack-sources",
     match: {
       prefixes: [
@@ -245,6 +270,7 @@ export const scopeRules: readonly ScopeRule[] = [
         "packages/sidecar/",
         "packages/sidecar-proto/",
       ],
+      excludeWhen: CERTAIN_PACKAGED_LEAF_SURFACE,
     },
     effects: ["tools_pack_tests_required"],
     confidence: "medium",
@@ -314,7 +340,7 @@ export const scopeRules: readonly ScopeRule[] = [
   },
   {
     id: "workspace-fallback",
-    match: { excludeWhen: EXEMPT_SURFACE },
+    match: { excludeWhen: WORKSPACE_FALLBACK_EXCLUDED_SURFACE },
     effects: ["workspace_validation_required"],
     confidence: "medium",
   },

--- a/specs/current/ci.md
+++ b/specs/current/ci.md
@@ -64,10 +64,12 @@ Requirements:
    three strengths: *definitional* (the surface cannot enter build or runtime
    by construction — e.g. docs), *structural* (an import-graph boundary), and
    *behavioral* (a topology test). Definitional rules may rely on replay
-   evidence alone. Structural and behavioral rules additionally require shadow
-   evidence from real queue runs (the `ifTrustAll` column in the scope decision
-   trace). The required window is unspecified and must be resolved before any
-   such rule becomes `certain`.
+   evidence alone. Structural and behavioral rules additionally require at
+   least 10 qualifying single-PR queue groups from the latest 400 first-parent
+   merges. Native `ifTrustAll` traces are preferred; paired evidence also
+   qualifies when the PR ran the candidate medium plan for the same file set,
+   the real queue group ran the full plan, both succeeded, and the proposed
+   plan has not weakened since that pair.
 4. **Goldens updated, divergence pinned.** The golden that changes is the
    proof of the behavior change; the goldens that do not change are the proof
    of its containment.
@@ -114,6 +116,51 @@ Current evidence and exceptions:
   `tools/release/src/release-note/prepare.ts` reads `docs/CHANGELOG`, which
   executes only in release workflows; `@open-design/tools-release` tests run
   in no `ci.yml` lane.
+
+## Certain packaged-leaf boundary
+
+Rule `certain-packaged-leaf-sources` covers only:
+
+- `apps/desktop/{src,tests}/`
+- `apps/packaged/{src,tests}/`
+- `tools/pack/{src,tests,resources}/`
+
+It claims `tools_dev_tests_required`, `tools_pack_tests_required`, and
+`workspace_validation_required`. A pure matching merge group therefore keeps
+preflight/typecheck, workspace unit tests, desktop/packaged/tools-pack tests,
+the focused packaged launcher update-loop fallback, and Windows launcher
+payload tests. It skips web workspace tests, broad E2E Vitest, UI P0, critical
+Playwright, and visual Playwright.
+
+Guard: `packaged leaf boundary`
+(`scripts/check-packaged-leaf-boundary.ts`). The policy-floor check scans
+skippable-lane source for package imports and repository paths entering the
+certain core, verifies that every core sample resolves to exactly the guarded
+effects at the certain threshold, and pins the workspace-unit command block.
+Allowed consumers are limited to:
+
+- `tools/dev/`, whose tests stay armed by the certain rule;
+- the focused packaged launcher update-loop test;
+- scope, workflow, cross-app, fork-approval, and package-manager invocation
+  fixtures that treat the paths as data;
+- the packaged and tools-pack esbuild entry configs, which own their source
+  entrypoints while config changes themselves remain medium-tier.
+
+Package manifests, build configs, bins, vendor content, and files outside the
+listed core remain medium. A mixed queue group containing any medium file
+still escalates to the full plan.
+
+Current evidence:
+
+- The latest 400 first-parent merges contain 19 pure packaged-leaf groups.
+- All 19 have successful narrow PR validation paired with successful full
+  merge-queue validation; the active narrow plan additionally runs desktop,
+  packaged, and focused update-loop coverage absent from the historical plan.
+- A current full merge-group run measures about 11.8 elapsed minutes and 68
+  runner-minutes. A representative pure-leaf narrow PR run measures about 4.2
+  elapsed minutes and 8.1 runner-minutes.
+- Expected savings are about 7.5 elapsed minutes and 60 runner-minutes per
+  qualifying single-PR group, before queue batching discounts.
 
 ## Zero-effect merge-queue policy floor
 
@@ -182,7 +229,6 @@ infrastructure.
 
 ## Open questions
 
-- Required shadow-evidence window for structural or behavioral certain rules.
 - Demotion policy beyond the guard-resolution hard rule.
 - Whether medium-tier zero-effect PR plans should use the policy floor; this
   needs its own evidence and containment review.


### PR DESCRIPTION
## Why

Pure desktop, packaged-runtime, and tools-pack changes already receive a narrow
PR plan, but the merge queue still repeats the full web, E2E, UI P0, and visual
matrix. I hit this while closing the packaged-leaf coverage gap and measuring
the resulting queue plan: a current full merge-group run costs about 11.8
elapsed minutes and 68 runner-minutes, while the corresponding narrow plan is
about 4.2 elapsed minutes and 8.1 runner-minutes.

The latest 400 first-parent merges contain 19 qualifying leaf-only groups.
Keeping them full after their validation boundary is closed adds about 7.5
queue minutes and 60 runner-minutes per qualifying single-PR group without
adding relevant product signal.

## What users will see

No product-facing change. Maintainers will see pure packaged-leaf pull requests
retain their narrow validation plan when they enter the merge queue.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable.

## Bug fix verification

Not applicable; this is a CI routing optimization.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm exec tsc -p scripts/tsconfig.json --noEmit`
- `actionlint -color`
- `pnpm --filter @open-design/e2e test tests/scripts/scopes.test.ts` — 41 passed
- `pnpm --filter @open-design/e2e test tests/packaged-smoke-workflow.test.ts` — 53 passed
- Exact narrow command chain:
  - tools-dev: 40 passed
  - desktop: 268 passed
  - packaged: 237 passed
  - tools-pack: 248 passed, 8 skipped
  - focused packaged launcher update loop: 3 passed
- Old/new merge-queue plan comparison over the latest 400 first-parent merges:
  exactly the expected 19 pure packaged-leaf groups changed; the other 381
  plans stayed identical.
- Verified all 19 qualifying PRs have successful narrow PR CI and successful
  full merge-group CI.
- `git diff --check`
