### PR TITLE
fix(daemon): pass the antigravity prompt as the -p flag value (agy v1.1.7)

### DIFF
--- a/apps/daemon/src/runtimes/defs/antigravity.ts
+++ b/apps/daemon/src/runtimes/defs/antigravity.ts
@@ -203,7 +203,7 @@ export const antigravityAgentDef = {
   // composed in server.ts gives a second line of defense for weak
   // plain-stream models like Gemini 3.5 Flash.
   buildArgs: (
-    _prompt,
+    prompt,
     _imagePaths,
     _extra = [],
     options = {},
@@ -215,18 +215,24 @@ export const antigravityAgentDef = {
         runtimeContext.antigravitySettingsPath,
       );
     }
-    // We invoke agy via `-p -` (print mode + stdin sentinel), NOT
-    // `chat -`. Verified against `agy --help` on v1.0.3 — the
-    // `Available subcommands` list is `changelog / help / install /
-    // plugin / update`, and `chat` is NOT among them. `-p` is the
-    // documented print-mode flag (`Short alias for --print`) and
-    // `agy -p -` reads the prompt from stdin. The looper reviewer
-    // bot's environment runs a different agy build that may have
-    // renamed the entry point; until upstream confirms a stable
-    // headless subcommand (see google-antigravity/antigravity-cli#119)
-    // and the change actually ships in the auto-update channel that
-    // packaged OD users get, `-p -` is the contract that actually
-    // produces a print-mode reply on the installed CLI.
+    // We invoke agy via `-p <prompt>` (print mode, prompt as the flag
+    // value). This changed with the upstream CLI: on v1.0.3 `-p` was a
+    // boolean and a trailing `-` meant "read the prompt from stdin", so
+    // this adapter shipped `-p -` with `promptViaStdin`. On v1.1.7 `-p`
+    // takes the prompt as its argument, stdin is ignored entirely, and
+    // `agy -p -` sends the literal `-` as the whole prompt — the model
+    // answers a non-question with a greeting ("Hello! How can I help you
+    // today?") and the user's actual request never reaches it. Reproduced
+    // outside OD on v1.1.7:
+    //
+    //   $ echo "Reply with exactly: PONG" | agy -p -
+    //   Hello! How can I help you today? …
+    //   $ agy -p "Reply with exactly: PONG"
+    //   PONG
+    //
+    // Bare `-p` with a piped stdin is not a fallback — it exits with
+    // "flag needs an argument: -p". Print mode is argv-only now, hence
+    // `maxPromptArgBytes` below.
     const args: string[] = [];
     // Always opt into `--log-file` when the daemon supplied a path so
     // it can post-exit grep for the actual upstream failure shape
@@ -243,11 +249,15 @@ export const antigravityAgentDef = {
     if (runtimeContext.agentLogFilePath) {
       args.push('--log-file', runtimeContext.agentLogFilePath);
     }
-    args.push('-p');
-    args.push('-');
+    args.push('-p', prompt);
     return args;
   },
-  promptViaStdin: true,
+  // Print mode is argv-only on v1.1.7, so the composed prompt rides in
+  // argv and needs the same budget guard as the other argv-only adapters
+  // (aider / deepseek). On POSIX `checkPromptArgvBudget` raises this to
+  // POSIX_ARGV_PROMPT_BUDGET; the literal value is the Windows
+  // CreateProcess ceiling.
+  maxPromptArgBytes: 30_000,
   streamFormat: 'plain',
   installUrl: 'https://antigravity.google/cli',
   docsUrl: 'https://antigravity.google/docs/cli-overview',

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -534,18 +534,30 @@ test('qwen args check promptViaStdin, base args, model args and exclude `-` sent
 // the daemon would render the resulting empty reply as a "successful"
 // agent response — exactly the failure mode the auth/quota guard at
 // server.ts ~12090 is meant to catch but for the wrong reason.
-test('antigravity pipes prompt via stdin via -p flag (print mode)', () => {
+test('antigravity passes the prompt as the -p flag value (print mode)', () => {
   assert.equal(antigravity.bin, 'agy');
   assert.equal(antigravity.streamFormat, 'plain');
-  assert.equal(antigravity.promptViaStdin, true);
+  // agy v1.1.7 dropped stdin prompt delivery: `-p` takes the prompt as its
+  // argument, and the old `-p -` sentinel is read as a literal `-` prompt,
+  // which the model answers with a generic greeting instead of doing the
+  // work. Print mode is argv-only, so the adapter must NOT set
+  // promptViaStdin and must carry an argv budget guard.
+  assert.equal(antigravity.promptViaStdin, undefined);
+  assert.equal(typeof antigravity.maxPromptArgBytes, 'number');
 
   const args = antigravity.buildArgs('write hello world', [], [], {}, {});
-  assert.deepEqual(args, ['-p', '-']);
+  assert.deepEqual(args, ['-p', 'write hello world']);
+  assert.equal(args.includes('-'), false);
 
   const argsWithLog = antigravity.buildArgs('write hello world', [], [], {}, {
     agentLogFilePath: '/tmp/od-agy-test.log',
   });
-  assert.deepEqual(argsWithLog, ['--log-file', '/tmp/od-agy-test.log', '-p', '-']);
+  assert.deepEqual(argsWithLog, [
+    '--log-file',
+    '/tmp/od-agy-test.log',
+    '-p',
+    'write hello world',
+  ]);
 
   // No `--model` flag exists upstream, so buildArgs argv must stay the
   // same regardless of which label the user picks.
@@ -560,7 +572,12 @@ test('antigravity pipes prompt via stdin via -p flag (print mode)', () => {
       antigravitySettingsPath: join(settingsDir, 'settings.json'),
     });
     assert.equal(withModel.includes('--model'), false);
-    assert.deepEqual(withModel, ['--log-file', '/tmp/od-agy-test.log', '-p', '-']);
+    assert.deepEqual(withModel, [
+      '--log-file',
+      '/tmp/od-agy-test.log',
+      '-p',
+      'hi',
+    ]);
   } finally {
     rmSync(settingsDir, { recursive: true, force: true });
   }
@@ -576,16 +593,14 @@ test('antigravity pipes prompt via stdin via -p flag (print mode)', () => {
   const followUp = antigravity.buildArgs('next message', [], [], {}, {
     hasPriorAssistantTurn: true,
   });
-  assert.deepEqual(followUp, ['-p', '-']);
+  assert.deepEqual(followUp, ['-p', 'next message']);
   assert.equal(followUp.includes('-c'), false);
 
   const firstTurn = antigravity.buildArgs('first', [], [], {}, {
     hasPriorAssistantTurn: false,
   });
-  assert.deepEqual(firstTurn, ['-p', '-']);
+  assert.deepEqual(firstTurn, ['-p', 'first']);
   assert.equal(antigravity.resumesSessionViaCli, undefined);
-
-  assert.equal(antigravity.maxPromptArgBytes, undefined);
 
   // Picker exposes the synthetic Default + the 8 labels agy's TUI
   // Switch-Model surfaces for consumer-tier accounts. The set is small


### PR DESCRIPTION
## Why

**My use case:** I drive Open Design with Antigravity as the local runtime. Asking it to design a login screen came back with `Hello! How can I help you today?`, and replying "design it" came back with `How can I assist you with your coding tasks today?`. Every turn, forever — the agent never sees the request.

**The pain:** `agy` v1.1.7 changed the print-mode contract out from under the adapter. On v1.0.3 `-p` was a boolean and a trailing `-` meant "read the prompt from stdin", so `antigravity.ts` shipped `-p -` together with `promptViaStdin: true`. On v1.1.7 `-p` takes the prompt as its **argument** and stdin is ignored entirely — so `agy -p -` sends the literal string `-` as the whole prompt. The model answers a non-question with a greeting, and because every turn re-sends `-`, the chat looks permanently stuck.

Reproduced outside Open Design on v1.1.7:

```console
$ echo "Reply with exactly: PONG" | agy -p -
Hello! How can I help you today? If you have a coding task, a question,
or a project you'd like to work on, just let me know!

$ agy -p "Reply with exactly: PONG"
PONG
```

Bare `-p` with a piped stdin is not an alternative — it exits with `flag needs an argument: -p`. Print mode is argv-only now.

This is user-visible breakage for anyone on `agy` v1.1.7, which ships through the auto-update channel. The existing comment in `antigravity.ts` anticipated exactly this ("the looper reviewer bot's environment runs a different agy build…", referencing `google-antigravity/antigravity-cli#119`); that change has now landed.

## What users will see

Antigravity runs act on the prompt again instead of replying with a greeting. No settings change, no re-auth, nothing to migrate.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — the antigravity adapter stops delivering the prompt via stdin and passes it in argv. Existing users are currently broken; this restores them.
- [ ] **None**

## Bug fix verification

- **Test path:** `apps/daemon/tests/runtimes/agent-args.test.ts` → `antigravity passes the prompt as the -p flag value (print mode)`
- **Red on `main`, green on this branch?** Yes. On `main` the spec fails on `assert.equal(antigravity.promptViaStdin, undefined)` and on the argv shape (`['-p', '-']` vs `['-p', 'write hello world']`).

The spec pins three things that together prevent a silent recurrence: no `promptViaStdin`, the prompt present as the `-p` value, and a bare `-` absent from argv.

## Validation

- `pnpm guard` — pass
- `pnpm --filter @open-design/daemon typecheck` — pass (exit 0, includes `tsconfig.tests.json`)
- `pnpm exec vitest run -c vitest.config.ts tests/runtimes/` — 44 files, 646 passed, 1 skipped, 0 failed
- Full `apps/daemon` suite on the combined branch: 3 failed / 6039 passed. All 3 are pre-existing on `main` (`langfuse-trace.test.ts` ×2, `plugins-headless-run.test.ts` ×1) — verified by reverting to the merge-base and re-running those two files, which reproduces the same 3 with identical assertions.

### Note on `maxPromptArgBytes`

Because print mode is argv-only now, the composed prompt rides in argv and needs the same guard as the other argv-only adapters (aider, deepseek). Without it a long transcript would surface as a raw `spawn E2BIG` instead of the actionable "prompt too large" message from `checkPromptArgvBudget`.

### Follow-up

v1.1.7 also adds a real `--model` flag, which obsoletes the `settings.json` write plus its lock chain and log-file watcher. That is a separate PR stacked on this one, so this fix can land on its own.
