### PR TITLE
refactor(desktop): extract release-feed interpretation into updater/feed

### DIFF
--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -14,7 +14,7 @@ import {
   stat,
   writeFile,
 } from "node:fs/promises";
-import { dirname, extname, join, relative, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { pipeline } from "node:stream/promises";
 import { promisify } from "node:util";
 
@@ -42,7 +42,6 @@ import {
 } from "@open-design/launcher-proto";
 import {
   DESKTOP_UPDATE_ACTIONS,
-  DESKTOP_UPDATE_CHANNELS,
   DESKTOP_UPDATE_MODES,
   DESKTOP_UPDATE_STATES,
   type DesktopUpdateAction,
@@ -90,11 +89,29 @@ import {
   containsPath,
   createError,
   isRecord,
+  objectField,
   readJson,
   readJsonStrict,
   stringField,
   writeJson,
 } from "./updater/support.js";
+import {
+  artifactFileName,
+  checksumMatchesCandidate,
+  compareVersions,
+  fetchJson,
+  hasValidLauncherPayloadContext,
+  releaseKey,
+  releaseMatchesCandidate,
+  releaseVersionForChannel,
+  remoteRequiresReinstall,
+  resolveChecksum,
+  resolveInstalledOuterVersion,
+  selectUpdateCandidateWithFallback,
+  type UpdateCandidate,
+} from "./updater/feed.js";
+
+export { compareVersions, remoteRequiresReinstall, resolveInstalledOuterVersion } from "./updater/feed.js";
 import {
   BACK_DIR,
   DOWNLOADS_DIR,
@@ -188,16 +205,6 @@ export type DeferredLaunchResult = {
   helperLogPath?: string;
 };
 
-type UpdateCandidate = {
-  arch: string;
-  artifact: DesktopUpdateArtifactSnapshot;
-  checksum: DesktopUpdateChecksumSnapshot;
-  channel: DesktopUpdateChannel;
-  metadata: Record<string, unknown>;
-  platformKey: string;
-  version: string;
-};
-
 type LoadedRelease = {
   path: string;
   ref: UpdateReleaseRef;
@@ -261,405 +268,9 @@ export type DesktopUpdater = {
   subscribe(listener: () => void): () => void;
 };
 
-function numberField(record: Record<string, unknown>, key: string): number | undefined {
-  const value = record[key];
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
-}
-
-function objectField(record: Record<string, unknown>, key: string): Record<string, unknown> | null {
-  const value = record[key];
-  return isRecord(value) ? value : null;
-}
-
-function sanitizePathSegment(value: string): string {
-  return value.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "update";
-}
-
-function extensionForArtifact(name: string | undefined, type: string): string {
-  const ext = name == null ? "" : extname(name).toLowerCase();
-  if (ext === ".7z" || ext === ".dmg" || ext === ".zip" || ext === ".exe" || ext === ".appimage") return ext;
-  if (type === "dmg") return ".dmg";
-  if (type === "zip") return ".zip";
-  if (type === "installer") return ".exe";
-  return ".bin";
-}
-
-function artifactFileName(candidate: UpdateCandidate): string {
-  const ext = extensionForArtifact(candidate.artifact.name, candidate.artifact.type ?? "artifact");
-  return [
-    "open-design",
-    sanitizePathSegment(candidate.version),
-    sanitizePathSegment(candidate.platformKey),
-    sanitizePathSegment(candidate.arch),
-    sanitizePathSegment(candidate.artifact.type ?? "artifact"),
-  ].join("-") + ext;
-}
-
-function releaseKey(candidate: UpdateCandidate, checksum: DesktopUpdateChecksumSnapshot): string {
-  const digest = checksum.value == null ? checksum.url ?? candidate.artifact.url : checksum.value;
-  return [
-    sanitizePathSegment(candidate.version),
-    sanitizePathSegment(candidate.platformKey),
-    sanitizePathSegment(candidate.arch),
-    sanitizePathSegment(createHash("sha256").update(digest).digest("hex").slice(0, 12)),
-  ].join("-");
-}
-
-function releaseMatchesCandidate(
-  saved: UpdateReleaseRef,
-  candidate: UpdateCandidate,
-): boolean {
-  if (saved.channel !== candidate.channel) return false;
-  if (saved.platformKey !== candidate.platformKey) return false;
-  if (saved.arch !== candidate.arch) return false;
-  if (saved.version !== candidate.version) return false;
-  if (saved.artifact.url !== candidate.artifact.url) return false;
-  if (saved.checksum.algorithm !== candidate.checksum.algorithm) return false;
-  if (candidate.checksum.url != null && saved.checksum.url !== candidate.checksum.url) return false;
-  if (candidate.checksum.value != null && saved.checksum.value !== candidate.checksum.value) return false;
-  return true;
-}
-
-export function compareVersions(a: string, b: string): number {
-  return compareLauncherVersions(a, b);
-}
-
-function metadataChannel(metadata: Record<string, unknown>): DesktopUpdateChannel | null {
-  const channel = stringField(metadata, "channel");
-  return isDesktopUpdateChannel(channel) ? channel : null;
-}
-
-function releaseVersionForChannel(metadata: Record<string, unknown>, channel: DesktopUpdateChannel): string | null {
-  if (channel === DESKTOP_UPDATE_CHANNELS.BETA) return stringField(metadata, "releaseVersion") ?? stringField(metadata, "betaVersion");
-  if (channel === DESKTOP_UPDATE_CHANNELS.BETAS) return stringField(metadata, "releaseVersion");
-  if (channel === DESKTOP_UPDATE_CHANNELS.PRERELEASE) return stringField(metadata, "releaseVersion") ?? stringField(metadata, "prereleaseVersion");
-  if (channel === DESKTOP_UPDATE_CHANNELS.PREVIEW) return stringField(metadata, "releaseVersion") ?? stringField(metadata, "previewVersion");
-  return stringField(metadata, "releaseVersion") ?? stringField(metadata, "stableVersion");
-}
-
-function selectedMacPlatformKey(arch: string): string {
-  return arch === "x64" ? "macIntel" : "mac";
-}
-
-function selectedWinPlatformKey(arch: string): string {
-  if (arch === "x64") return "win";
-  if (arch === "arm64") return "winArm64";
-  if (arch === "ia32") return "winIa32";
-  return `win-${sanitizePathSegment(arch)}`;
-}
-
-function selectedPackageLauncherArtifact(config: DesktopUpdaterConfig, preferPayload = false): {
-  artifactKey: "dmg" | "installer" | "payload";
-  artifactType: "dmg" | "installer" | "payload";
-  description: string;
-  platformKey: string;
-} | null {
-  if (config.platform === "darwin") {
-    const platformKey = selectedMacPlatformKey(config.arch);
-    if (preferPayload) {
-      return {
-        artifactKey: "payload",
-        artifactType: "payload",
-        description: "mac launcher payload",
-        platformKey,
-      };
-    }
-    return {
-      artifactKey: "dmg",
-      artifactType: "dmg",
-      description: "mac DMG",
-      platformKey,
-    };
-  }
-  if (config.platform === "win32") {
-    const platformKey = selectedWinPlatformKey(config.arch);
-    if (preferPayload) {
-      return {
-        artifactKey: "payload",
-        artifactType: "payload",
-        description: "Windows launcher payload",
-        platformKey,
-      };
-    }
-    return {
-      artifactKey: "installer",
-      artifactType: "installer",
-      description: "Windows installer",
-      platformKey,
-    };
-  }
-  return null;
-}
-
 function installerObservationArtifactType(value: string | undefined): InstallerObservationArtifactType | null {
   if (value === "dmg" || value === "installer" || value === "payload") return value;
   return null;
-}
-
-function selectUpdateCandidate(
-  metadata: Record<string, unknown>,
-  config: DesktopUpdaterConfig,
-  preferPayload = false,
-): { candidate: UpdateCandidate; ok: true } | { error: DesktopUpdateErrorSnapshot; ok: false; state: DesktopUpdateState } {
-  if (config.mode === DESKTOP_UPDATE_MODES.JS_INCREMENTAL) {
-    return {
-      ok: false,
-      state: DESKTOP_UPDATE_STATES.UNSUPPORTED,
-      error: createError("update-mode-not-implemented", "js-incremental updates are not implemented yet"),
-    };
-  }
-  if (config.mode !== DESKTOP_UPDATE_MODES.PACKAGE_LAUNCHER) {
-    return {
-      ok: false,
-      state: DESKTOP_UPDATE_STATES.UNSUPPORTED,
-      error: createError("update-mode-unsupported", `unsupported update mode: ${config.mode}`),
-    };
-  }
-  const artifactSelection = selectedPackageLauncherArtifact(config, preferPayload);
-  if (artifactSelection == null) {
-    return {
-      ok: false,
-      state: DESKTOP_UPDATE_STATES.UNSUPPORTED,
-      error: createError("unsupported-platform", "package-launcher updates are currently supported on macOS and Windows only"),
-    };
-  }
-
-  const channel = metadataChannel(metadata);
-  if (channel == null) {
-    return {
-      ok: false,
-      state: DESKTOP_UPDATE_STATES.ERROR,
-      error: createError("metadata-channel-unsupported", "release metadata does not include a supported update channel"),
-    };
-  }
-  if (channel !== config.channel) {
-    return {
-      ok: false,
-      state: DESKTOP_UPDATE_STATES.ERROR,
-      error: createError(
-        "metadata-channel-mismatch",
-        `release metadata channel ${channel} does not match configured update channel ${config.channel}`,
-      ),
-    };
-  }
-
-  const platforms = objectField(metadata, "platforms");
-  if (platforms == null) {
-    return {
-      ok: false,
-      state: DESKTOP_UPDATE_STATES.ERROR,
-      error: createError("metadata-missing-platforms", "release metadata does not include platform artifacts"),
-    };
-  }
-  const platformKey = artifactSelection.platformKey;
-  const platform = objectField(platforms, platformKey);
-  if (platform == null || platform.enabled !== true) {
-    return {
-      ok: false,
-      state: DESKTOP_UPDATE_STATES.ERROR,
-      error: createError("no-compatible-artifact", `release metadata does not include an enabled ${platformKey} artifact`),
-    };
-  }
-  const version = releaseVersionForChannel(metadata, config.channel);
-  if (version == null) {
-    return {
-      ok: false,
-      state: DESKTOP_UPDATE_STATES.ERROR,
-      error: createError("metadata-missing-version", `release metadata does not include a ${config.channel} update version`),
-    };
-  }
-  const artifacts = objectField(platform, "artifacts");
-  const artifactRecord = artifacts == null ? null : objectField(artifacts, artifactSelection.artifactKey);
-  const url = artifactRecord == null ? null : stringField(artifactRecord, "url");
-  if (artifactRecord == null || url == null) {
-    return {
-      ok: false,
-      state: DESKTOP_UPDATE_STATES.ERROR,
-      error: createError(
-        "no-compatible-artifact",
-        `release metadata does not include a ${artifactSelection.description} artifact for ${platformKey}`,
-      ),
-    };
-  }
-
-  const artifact: DesktopUpdateArtifactSnapshot = {
-    ...(stringField(artifactRecord, "name") == null ? {} : { name: stringField(artifactRecord, "name") as string }),
-    platformKey,
-    ...(numberField(artifactRecord, "size") == null ? {} : { size: numberField(artifactRecord, "size") }),
-    type: artifactSelection.artifactType,
-    url,
-  };
-  const sha256 = stringField(artifactRecord, "sha256") ?? stringField(artifactRecord, "sha256Digest");
-  const sha512 = stringField(artifactRecord, "sha512") ?? stringField(artifactRecord, "sha512Digest");
-  const checksum: DesktopUpdateChecksumSnapshot =
-    sha512 != null
-      ? { algorithm: "sha512", value: sha512 }
-      : {
-          algorithm: "sha256",
-          ...(sha256 == null ? {} : { value: sha256 }),
-          ...(stringField(artifactRecord, "sha256Url") == null ? {} : { url: stringField(artifactRecord, "sha256Url") as string }),
-        };
-
-  return {
-    ok: true,
-    candidate: {
-      arch: stringField(platform, "arch") ?? config.arch,
-      artifact,
-      checksum,
-      channel: config.channel,
-      metadata,
-      platformKey,
-      version,
-    },
-  };
-}
-
-function selectUpdateCandidateWithFallback(
-  metadata: Record<string, unknown>,
-  config: DesktopUpdaterConfig,
-  preferPayload: boolean,
-): { candidate: UpdateCandidate; ok: true } | { error: DesktopUpdateErrorSnapshot; ok: false; state: DesktopUpdateState } {
-  if (!preferPayload) return selectUpdateCandidate(metadata, config);
-  const payload = selectUpdateCandidate(metadata, config, true);
-  if (payload.ok || payload.error.code !== "no-compatible-artifact") return payload;
-  return selectUpdateCandidate(metadata, config);
-}
-
-function controlLauncherVersion(metadata: Record<string, unknown>): Record<string, unknown> | null {
-  const control = objectField(metadata, "control");
-  const launcher = control == null ? null : objectField(control, "launcher");
-  return launcher == null ? null : objectField(launcher, "version");
-}
-
-function controlLauncherVersionMin(metadata: Record<string, unknown>): string | null {
-  const version = controlLauncherVersion(metadata);
-  return version == null ? null : stringField(version, "min");
-}
-
-function controlLauncherVersionUrl(metadata: Record<string, unknown>): string | null {
-  const version = controlLauncherVersion(metadata);
-  return version == null ? null : stringField(version, "url");
-}
-
-/**
- * Resolve the version of the PHYSICALLY INSTALLED outer package. This is
- * distinct from `config.currentVersion`: after a payload update the running
- * version is the payload's, while the installed outer bundle on disk stays at
- * its install-time version and is the thing an installer reinstall replaces.
- * The outer bundle's own `open-design-config.json` is the only fleet-wide
- * source (every packaged generation ships it), anchored by the launcher
- * launch path from `install.json`. Returns null when unreadable.
- */
-export async function resolveInstalledOuterVersion(config: DesktopUpdaterConfig): Promise<string | null> {
-  if (config.installedVersionOverride != null) return config.installedVersionOverride;
-  if (config.launcherLaunchPath == null) return null;
-  const outerConfigPath =
-    config.platform === "darwin"
-      ? join(config.launcherLaunchPath, "Contents", "Resources", "open-design-config.json")
-      : join(dirname(config.launcherLaunchPath), "resources", "open-design-config.json");
-  try {
-    const raw: unknown = JSON.parse(await readFile(outerConfigPath, "utf8"));
-    if (!isRecord(raw)) return null;
-    return stringField(raw, "appVersion");
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Installed-base escape hatch: decide whether the remote release is beyond what
- * this install can adopt as an in-place payload update, forcing a full
- * installer instead. Two orthogonal guardrails, either of which trips →
- * installer:
- *
- *  - `launcher.schema` (ABI axis): the release declares a launcher-contract schema
- *    number this build cannot interpret (`feed.launcher.schema >
- *    LAUNCHER_SCHEMA_VERSION`). This is the reseed boundary — a pure int compare.
- *  - `control.launcher.version.min` (recency axis): the release requires a
- *    physically installed outer package at least this new (`min >
- *    installedOuterVersion`). Payload updates never touch the outer bundle, so
- *    the comparison basis is the installed outer version, NOT the running
- *    version — a broken outer generation must reach the installer path even
- *    when its payload is current. When min is set but the outer version cannot
- *    be read, the gate trips conservatively: local state that cannot be
- *    identified is itself a reinstall signal.
- *
- * Missing/malformed metadata fields are ignored (fail-open) so older feeds keep
- * updating seamlessly. Returns the reinstall requirement for the status
- * snapshot, or null when an in-place payload update is acceptable.
- */
-export function remoteRequiresReinstall(
-  metadata: Record<string, unknown>,
-  config: DesktopUpdaterConfig,
-  installedOuterVersion: string | null,
-): DesktopUpdateReinstallSnapshot | null {
-  const minVersion = controlLauncherVersionMin(metadata);
-  const url = controlLauncherVersionUrl(metadata);
-  const shared = {
-    ...(minVersion == null ? {} : { minVersion }),
-    ...(url == null ? {} : { url }),
-  };
-  const launcher = objectField(metadata, "launcher");
-  const remoteLauncherSchema = launcher == null ? undefined : numberField(launcher, "schema");
-  if (remoteLauncherSchema != null && remoteLauncherSchema > LAUNCHER_SCHEMA_VERSION) {
-    return {
-      ...(installedOuterVersion == null ? {} : { installedVersion: installedOuterVersion }),
-      reason: "launcher-schema",
-      ...shared,
-    };
-  }
-  if (minVersion == null) return null;
-  if (installedOuterVersion == null) {
-    return { reason: "outer-version-unreadable", ...shared };
-  }
-  if (compareVersions(minVersion, installedOuterVersion) > 0) {
-    return { installedVersion: installedOuterVersion, reason: "outer-below-min", ...shared };
-  }
-  return null;
-}
-
-async function fetchJson(fetchImpl: typeof globalThis.fetch, url: string): Promise<Record<string, unknown>> {
-  const response = await fetchImpl(url);
-  if (!response.ok) throw new Error(`metadata request returned HTTP ${response.status}`);
-  const body = await response.json();
-  if (!isRecord(body)) throw new Error("metadata response was not a JSON object");
-  return body;
-}
-
-async function hasValidLauncherPayloadContext(config: DesktopUpdaterConfig): Promise<boolean> {
-  if (config.launcherRoot == null || config.launcherLaunchPath == null || config.launcherRuntimePath == null || config.namespace == null) {
-    return false;
-  }
-  try {
-    await access(config.launcherLaunchPath);
-    const launcherTarget = await lstat(config.launcherLaunchPath);
-    if (launcherTarget.isSymbolicLink() || (!launcherTarget.isFile() && !launcherTarget.isDirectory())) {
-      return false;
-    }
-    const runtime = await readJsonStrict<LauncherRuntimeDescriptor>(config.launcherRuntimePath);
-    validateLauncherRuntimeDescriptor(runtime, { channel: config.channel, namespace: config.namespace });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function parseChecksumText(text: string, algorithm: "sha256" | "sha512"): string {
-  const length = algorithm === "sha256" ? 64 : 128;
-  const match = text.match(new RegExp(`\\b[0-9a-fA-F]{${length}}\\b`));
-  if (match == null) throw new Error(`checksum file does not include a ${algorithm} digest`);
-  return match[0].toLowerCase();
-}
-
-async function resolveChecksum(fetchImpl: typeof globalThis.fetch, checksum: DesktopUpdateChecksumSnapshot): Promise<DesktopUpdateChecksumSnapshot> {
-  if (checksum.value != null) return checksum;
-  if (checksum.url == null) throw new Error("artifact checksum is missing");
-  const response = await fetchImpl(checksum.url);
-  if (!response.ok) throw new Error(`checksum request returned HTTP ${response.status}`);
-  return {
-    ...checksum,
-    value: parseChecksumText(await response.text(), checksum.algorithm),
-  };
 }
 
 async function hashFile(path: string, algorithm: "sha256" | "sha512"): Promise<string> {
@@ -2238,13 +1849,6 @@ async function loadActiveRelease(
     return { ok: false, error: storeError };
   }
   return { ok: true, active: { path: artifactPath, ref: active } };
-}
-
-function checksumMatchesCandidate(checksum: ResolvedChecksumSnapshot, candidate: UpdateCandidate): boolean {
-  if (checksum.algorithm !== candidate.checksum.algorithm) return false;
-  if (candidate.checksum.url != null && checksum.url !== candidate.checksum.url) return false;
-  if (candidate.checksum.value != null && checksum.value.toLowerCase() !== candidate.checksum.value.toLowerCase()) return false;
-  return true;
 }
 
 async function loadVerifiedReleaseForCandidate(

--- a/apps/desktop/src/main/updater/feed.ts
+++ b/apps/desktop/src/main/updater/feed.ts
@@ -1,0 +1,446 @@
+import { createHash } from "node:crypto";
+import { access, lstat, readFile } from "node:fs/promises";
+import { dirname, extname, join } from "node:path";
+
+import {
+  LAUNCHER_SCHEMA_VERSION,
+  compareLauncherVersions,
+  validateLauncherRuntimeDescriptor,
+  type LauncherRuntimeDescriptor,
+} from "@open-design/launcher-proto";
+import {
+  DESKTOP_UPDATE_CHANNELS,
+  DESKTOP_UPDATE_MODES,
+  DESKTOP_UPDATE_STATES,
+  type DesktopUpdateArtifactSnapshot,
+  type DesktopUpdateChannel,
+  type DesktopUpdateChecksumSnapshot,
+  type DesktopUpdateErrorSnapshot,
+  type DesktopUpdateReinstallSnapshot,
+  type DesktopUpdateState,
+} from "@open-design/sidecar-proto";
+
+import { isDesktopUpdateChannel, type DesktopUpdaterConfig } from "./config.js";
+import type { ResolvedChecksumSnapshot, UpdateReleaseRef } from "./store.js";
+import {
+  createError,
+  isRecord,
+  numberField,
+  objectField,
+  readJsonStrict,
+  stringField,
+} from "./support.js";
+
+/**
+ * @module updater/feed
+ *
+ * Release-feed interpretation for the desktop updater: metadata fetch and
+ * parsing, per-channel version resolution, artifact selection with the
+ * payload-to-installer fallback, checksum resolution, candidate/release
+ * naming, and the installer-reinstall floor. Pure decision logic plus the
+ * two feed HTTP fetches; no store writes.
+ */
+
+export type UpdateCandidate = {
+  arch: string;
+  artifact: DesktopUpdateArtifactSnapshot;
+  checksum: DesktopUpdateChecksumSnapshot;
+  channel: DesktopUpdateChannel;
+  metadata: Record<string, unknown>;
+  platformKey: string;
+  version: string;
+};
+
+export function sanitizePathSegment(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "update";
+}
+
+export function extensionForArtifact(name: string | undefined, type: string): string {
+  const ext = name == null ? "" : extname(name).toLowerCase();
+  if (ext === ".7z" || ext === ".dmg" || ext === ".zip" || ext === ".exe" || ext === ".appimage") return ext;
+  if (type === "dmg") return ".dmg";
+  if (type === "zip") return ".zip";
+  if (type === "installer") return ".exe";
+  return ".bin";
+}
+
+export function artifactFileName(candidate: UpdateCandidate): string {
+  const ext = extensionForArtifact(candidate.artifact.name, candidate.artifact.type ?? "artifact");
+  return [
+    "open-design",
+    sanitizePathSegment(candidate.version),
+    sanitizePathSegment(candidate.platformKey),
+    sanitizePathSegment(candidate.arch),
+    sanitizePathSegment(candidate.artifact.type ?? "artifact"),
+  ].join("-") + ext;
+}
+
+export function releaseKey(candidate: UpdateCandidate, checksum: DesktopUpdateChecksumSnapshot): string {
+  const digest = checksum.value == null ? checksum.url ?? candidate.artifact.url : checksum.value;
+  return [
+    sanitizePathSegment(candidate.version),
+    sanitizePathSegment(candidate.platformKey),
+    sanitizePathSegment(candidate.arch),
+    sanitizePathSegment(createHash("sha256").update(digest).digest("hex").slice(0, 12)),
+  ].join("-");
+}
+
+export function releaseMatchesCandidate(
+  saved: UpdateReleaseRef,
+  candidate: UpdateCandidate,
+): boolean {
+  if (saved.channel !== candidate.channel) return false;
+  if (saved.platformKey !== candidate.platformKey) return false;
+  if (saved.arch !== candidate.arch) return false;
+  if (saved.version !== candidate.version) return false;
+  if (saved.artifact.url !== candidate.artifact.url) return false;
+  if (saved.checksum.algorithm !== candidate.checksum.algorithm) return false;
+  if (candidate.checksum.url != null && saved.checksum.url !== candidate.checksum.url) return false;
+  if (candidate.checksum.value != null && saved.checksum.value !== candidate.checksum.value) return false;
+  return true;
+}
+
+export function compareVersions(a: string, b: string): number {
+  return compareLauncherVersions(a, b);
+}
+
+export function metadataChannel(metadata: Record<string, unknown>): DesktopUpdateChannel | null {
+  const channel = stringField(metadata, "channel");
+  return isDesktopUpdateChannel(channel) ? channel : null;
+}
+
+export function releaseVersionForChannel(metadata: Record<string, unknown>, channel: DesktopUpdateChannel): string | null {
+  if (channel === DESKTOP_UPDATE_CHANNELS.BETA) return stringField(metadata, "releaseVersion") ?? stringField(metadata, "betaVersion");
+  if (channel === DESKTOP_UPDATE_CHANNELS.BETAS) return stringField(metadata, "releaseVersion");
+  if (channel === DESKTOP_UPDATE_CHANNELS.PRERELEASE) return stringField(metadata, "releaseVersion") ?? stringField(metadata, "prereleaseVersion");
+  if (channel === DESKTOP_UPDATE_CHANNELS.PREVIEW) return stringField(metadata, "releaseVersion") ?? stringField(metadata, "previewVersion");
+  return stringField(metadata, "releaseVersion") ?? stringField(metadata, "stableVersion");
+}
+
+export function selectedMacPlatformKey(arch: string): string {
+  return arch === "x64" ? "macIntel" : "mac";
+}
+
+export function selectedWinPlatformKey(arch: string): string {
+  if (arch === "x64") return "win";
+  if (arch === "arm64") return "winArm64";
+  if (arch === "ia32") return "winIa32";
+  return `win-${sanitizePathSegment(arch)}`;
+}
+
+export function selectedPackageLauncherArtifact(config: DesktopUpdaterConfig, preferPayload = false): {
+  artifactKey: "dmg" | "installer" | "payload";
+  artifactType: "dmg" | "installer" | "payload";
+  description: string;
+  platformKey: string;
+} | null {
+  if (config.platform === "darwin") {
+    const platformKey = selectedMacPlatformKey(config.arch);
+    if (preferPayload) {
+      return {
+        artifactKey: "payload",
+        artifactType: "payload",
+        description: "mac launcher payload",
+        platformKey,
+      };
+    }
+    return {
+      artifactKey: "dmg",
+      artifactType: "dmg",
+      description: "mac DMG",
+      platformKey,
+    };
+  }
+  if (config.platform === "win32") {
+    const platformKey = selectedWinPlatformKey(config.arch);
+    if (preferPayload) {
+      return {
+        artifactKey: "payload",
+        artifactType: "payload",
+        description: "Windows launcher payload",
+        platformKey,
+      };
+    }
+    return {
+      artifactKey: "installer",
+      artifactType: "installer",
+      description: "Windows installer",
+      platformKey,
+    };
+  }
+  return null;
+}
+
+export function selectUpdateCandidate(
+  metadata: Record<string, unknown>,
+  config: DesktopUpdaterConfig,
+  preferPayload = false,
+): { candidate: UpdateCandidate; ok: true } | { error: DesktopUpdateErrorSnapshot; ok: false; state: DesktopUpdateState } {
+  if (config.mode === DESKTOP_UPDATE_MODES.JS_INCREMENTAL) {
+    return {
+      ok: false,
+      state: DESKTOP_UPDATE_STATES.UNSUPPORTED,
+      error: createError("update-mode-not-implemented", "js-incremental updates are not implemented yet"),
+    };
+  }
+  if (config.mode !== DESKTOP_UPDATE_MODES.PACKAGE_LAUNCHER) {
+    return {
+      ok: false,
+      state: DESKTOP_UPDATE_STATES.UNSUPPORTED,
+      error: createError("update-mode-unsupported", `unsupported update mode: ${config.mode}`),
+    };
+  }
+  const artifactSelection = selectedPackageLauncherArtifact(config, preferPayload);
+  if (artifactSelection == null) {
+    return {
+      ok: false,
+      state: DESKTOP_UPDATE_STATES.UNSUPPORTED,
+      error: createError("unsupported-platform", "package-launcher updates are currently supported on macOS and Windows only"),
+    };
+  }
+
+  const channel = metadataChannel(metadata);
+  if (channel == null) {
+    return {
+      ok: false,
+      state: DESKTOP_UPDATE_STATES.ERROR,
+      error: createError("metadata-channel-unsupported", "release metadata does not include a supported update channel"),
+    };
+  }
+  if (channel !== config.channel) {
+    return {
+      ok: false,
+      state: DESKTOP_UPDATE_STATES.ERROR,
+      error: createError(
+        "metadata-channel-mismatch",
+        `release metadata channel ${channel} does not match configured update channel ${config.channel}`,
+      ),
+    };
+  }
+
+  const platforms = objectField(metadata, "platforms");
+  if (platforms == null) {
+    return {
+      ok: false,
+      state: DESKTOP_UPDATE_STATES.ERROR,
+      error: createError("metadata-missing-platforms", "release metadata does not include platform artifacts"),
+    };
+  }
+  const platformKey = artifactSelection.platformKey;
+  const platform = objectField(platforms, platformKey);
+  if (platform == null || platform.enabled !== true) {
+    return {
+      ok: false,
+      state: DESKTOP_UPDATE_STATES.ERROR,
+      error: createError("no-compatible-artifact", `release metadata does not include an enabled ${platformKey} artifact`),
+    };
+  }
+  const version = releaseVersionForChannel(metadata, config.channel);
+  if (version == null) {
+    return {
+      ok: false,
+      state: DESKTOP_UPDATE_STATES.ERROR,
+      error: createError("metadata-missing-version", `release metadata does not include a ${config.channel} update version`),
+    };
+  }
+  const artifacts = objectField(platform, "artifacts");
+  const artifactRecord = artifacts == null ? null : objectField(artifacts, artifactSelection.artifactKey);
+  const url = artifactRecord == null ? null : stringField(artifactRecord, "url");
+  if (artifactRecord == null || url == null) {
+    return {
+      ok: false,
+      state: DESKTOP_UPDATE_STATES.ERROR,
+      error: createError(
+        "no-compatible-artifact",
+        `release metadata does not include a ${artifactSelection.description} artifact for ${platformKey}`,
+      ),
+    };
+  }
+
+  const artifact: DesktopUpdateArtifactSnapshot = {
+    ...(stringField(artifactRecord, "name") == null ? {} : { name: stringField(artifactRecord, "name") as string }),
+    platformKey,
+    ...(numberField(artifactRecord, "size") == null ? {} : { size: numberField(artifactRecord, "size") }),
+    type: artifactSelection.artifactType,
+    url,
+  };
+  const sha256 = stringField(artifactRecord, "sha256") ?? stringField(artifactRecord, "sha256Digest");
+  const sha512 = stringField(artifactRecord, "sha512") ?? stringField(artifactRecord, "sha512Digest");
+  const checksum: DesktopUpdateChecksumSnapshot =
+    sha512 != null
+      ? { algorithm: "sha512", value: sha512 }
+      : {
+          algorithm: "sha256",
+          ...(sha256 == null ? {} : { value: sha256 }),
+          ...(stringField(artifactRecord, "sha256Url") == null ? {} : { url: stringField(artifactRecord, "sha256Url") as string }),
+        };
+
+  return {
+    ok: true,
+    candidate: {
+      arch: stringField(platform, "arch") ?? config.arch,
+      artifact,
+      checksum,
+      channel: config.channel,
+      metadata,
+      platformKey,
+      version,
+    },
+  };
+}
+
+export function selectUpdateCandidateWithFallback(
+  metadata: Record<string, unknown>,
+  config: DesktopUpdaterConfig,
+  preferPayload: boolean,
+): { candidate: UpdateCandidate; ok: true } | { error: DesktopUpdateErrorSnapshot; ok: false; state: DesktopUpdateState } {
+  if (!preferPayload) return selectUpdateCandidate(metadata, config);
+  const payload = selectUpdateCandidate(metadata, config, true);
+  if (payload.ok || payload.error.code !== "no-compatible-artifact") return payload;
+  return selectUpdateCandidate(metadata, config);
+}
+
+export function controlLauncherVersion(metadata: Record<string, unknown>): Record<string, unknown> | null {
+  const control = objectField(metadata, "control");
+  const launcher = control == null ? null : objectField(control, "launcher");
+  return launcher == null ? null : objectField(launcher, "version");
+}
+
+export function controlLauncherVersionMin(metadata: Record<string, unknown>): string | null {
+  const version = controlLauncherVersion(metadata);
+  return version == null ? null : stringField(version, "min");
+}
+
+export function controlLauncherVersionUrl(metadata: Record<string, unknown>): string | null {
+  const version = controlLauncherVersion(metadata);
+  return version == null ? null : stringField(version, "url");
+}
+
+/**
+ * Resolve the version of the PHYSICALLY INSTALLED outer package. This is
+ * distinct from `config.currentVersion`: after a payload update the running
+ * version is the payload's, while the installed outer bundle on disk stays at
+ * its install-time version and is the thing an installer reinstall replaces.
+ * The outer bundle's own `open-design-config.json` is the only fleet-wide
+ * source (every packaged generation ships it), anchored by the launcher
+ * launch path from `install.json`. Returns null when unreadable.
+ */
+export async function resolveInstalledOuterVersion(config: DesktopUpdaterConfig): Promise<string | null> {
+  if (config.installedVersionOverride != null) return config.installedVersionOverride;
+  if (config.launcherLaunchPath == null) return null;
+  const outerConfigPath =
+    config.platform === "darwin"
+      ? join(config.launcherLaunchPath, "Contents", "Resources", "open-design-config.json")
+      : join(dirname(config.launcherLaunchPath), "resources", "open-design-config.json");
+  try {
+    const raw: unknown = JSON.parse(await readFile(outerConfigPath, "utf8"));
+    if (!isRecord(raw)) return null;
+    return stringField(raw, "appVersion");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Installed-base escape hatch: decide whether the remote release is beyond what
+ * this install can adopt as an in-place payload update, forcing a full
+ * installer instead. Two orthogonal guardrails, either of which trips →
+ * installer:
+ *
+ *  - `launcher.schema` (ABI axis): the release declares a launcher-contract schema
+ *    number this build cannot interpret (`feed.launcher.schema >
+ *    LAUNCHER_SCHEMA_VERSION`). This is the reseed boundary — a pure int compare.
+ *  - `control.launcher.version.min` (recency axis): the release requires a
+ *    physically installed outer package at least this new (`min >
+ *    installedOuterVersion`). Payload updates never touch the outer bundle, so
+ *    the comparison basis is the installed outer version, NOT the running
+ *    version — a broken outer generation must reach the installer path even
+ *    when its payload is current. When min is set but the outer version cannot
+ *    be read, the gate trips conservatively: local state that cannot be
+ *    identified is itself a reinstall signal.
+ *
+ * Missing/malformed metadata fields are ignored (fail-open) so older feeds keep
+ * updating seamlessly. Returns the reinstall requirement for the status
+ * snapshot, or null when an in-place payload update is acceptable.
+ */
+export function remoteRequiresReinstall(
+  metadata: Record<string, unknown>,
+  config: DesktopUpdaterConfig,
+  installedOuterVersion: string | null,
+): DesktopUpdateReinstallSnapshot | null {
+  const minVersion = controlLauncherVersionMin(metadata);
+  const url = controlLauncherVersionUrl(metadata);
+  const shared = {
+    ...(minVersion == null ? {} : { minVersion }),
+    ...(url == null ? {} : { url }),
+  };
+  const launcher = objectField(metadata, "launcher");
+  const remoteLauncherSchema = launcher == null ? undefined : numberField(launcher, "schema");
+  if (remoteLauncherSchema != null && remoteLauncherSchema > LAUNCHER_SCHEMA_VERSION) {
+    return {
+      ...(installedOuterVersion == null ? {} : { installedVersion: installedOuterVersion }),
+      reason: "launcher-schema",
+      ...shared,
+    };
+  }
+  if (minVersion == null) return null;
+  if (installedOuterVersion == null) {
+    return { reason: "outer-version-unreadable", ...shared };
+  }
+  if (compareVersions(minVersion, installedOuterVersion) > 0) {
+    return { installedVersion: installedOuterVersion, reason: "outer-below-min", ...shared };
+  }
+  return null;
+}
+
+export async function fetchJson(fetchImpl: typeof globalThis.fetch, url: string): Promise<Record<string, unknown>> {
+  const response = await fetchImpl(url);
+  if (!response.ok) throw new Error(`metadata request returned HTTP ${response.status}`);
+  const body = await response.json();
+  if (!isRecord(body)) throw new Error("metadata response was not a JSON object");
+  return body;
+}
+
+export async function hasValidLauncherPayloadContext(config: DesktopUpdaterConfig): Promise<boolean> {
+  if (config.launcherRoot == null || config.launcherLaunchPath == null || config.launcherRuntimePath == null || config.namespace == null) {
+    return false;
+  }
+  try {
+    await access(config.launcherLaunchPath);
+    const launcherTarget = await lstat(config.launcherLaunchPath);
+    if (launcherTarget.isSymbolicLink() || (!launcherTarget.isFile() && !launcherTarget.isDirectory())) {
+      return false;
+    }
+    const runtime = await readJsonStrict<LauncherRuntimeDescriptor>(config.launcherRuntimePath);
+    validateLauncherRuntimeDescriptor(runtime, { channel: config.channel, namespace: config.namespace });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function parseChecksumText(text: string, algorithm: "sha256" | "sha512"): string {
+  const length = algorithm === "sha256" ? 64 : 128;
+  const match = text.match(new RegExp(`\\b[0-9a-fA-F]{${length}}\\b`));
+  if (match == null) throw new Error(`checksum file does not include a ${algorithm} digest`);
+  return match[0].toLowerCase();
+}
+
+export async function resolveChecksum(fetchImpl: typeof globalThis.fetch, checksum: DesktopUpdateChecksumSnapshot): Promise<DesktopUpdateChecksumSnapshot> {
+  if (checksum.value != null) return checksum;
+  if (checksum.url == null) throw new Error("artifact checksum is missing");
+  const response = await fetchImpl(checksum.url);
+  if (!response.ok) throw new Error(`checksum request returned HTTP ${response.status}`);
+  return {
+    ...checksum,
+    value: parseChecksumText(await response.text(), checksum.algorithm),
+  };
+}
+
+export function checksumMatchesCandidate(checksum: ResolvedChecksumSnapshot, candidate: UpdateCandidate): boolean {
+  if (checksum.algorithm !== candidate.checksum.algorithm) return false;
+  if (candidate.checksum.url != null && checksum.url !== candidate.checksum.url) return false;
+  if (candidate.checksum.value != null && checksum.value.toLowerCase() !== candidate.checksum.value.toLowerCase()) return false;
+  return true;
+}
+

--- a/apps/desktop/src/main/updater/support.ts
+++ b/apps/desktop/src/main/updater/support.ts
@@ -57,3 +57,12 @@ export async function directoryIsEmpty(path: string): Promise<boolean> {
   return entries.length === 0;
 }
 
+export function numberField(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+export function objectField(record: Record<string, unknown>, key: string): Record<string, unknown> | null {
+  const value = record[key];
+  return isRecord(value) ? value : null;
+}

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -1173,48 +1173,6 @@ describe("desktop updater", () => {
     }
   });
 
-  it("resolves the installed outer version from the platform bundle layout", async () => {
-    const root = makeRoot();
-    try {
-      const appRoot = join(root, "Open Design.app");
-      await mkdir(join(appRoot, "Contents", "Resources"), { recursive: true });
-      await writeFile(join(appRoot, "Contents", "Resources", "open-design-config.json"), '{"appVersion":"0.7.0"}\n');
-      const macConfig = resolveDesktopUpdaterConfig({
-        env: {},
-        launcherLaunchPath: appRoot,
-        platform: "darwin",
-        source: SIDECAR_SOURCES.PACKAGED,
-      });
-      expect(await resolveInstalledOuterVersion(macConfig)).toBe("0.7.0");
-
-      const winExe = join(root, "win-install", "Open Design Beta.exe");
-      await mkdir(join(root, "win-install", "resources"), { recursive: true });
-      await writeFile(winExe, "");
-      await writeFile(join(root, "win-install", "resources", "open-design-config.json"), '{"appVersion":"0.8.0-beta.2"}\n');
-      const winConfig = resolveDesktopUpdaterConfig({
-        env: {},
-        launcherLaunchPath: winExe,
-        platform: "win32",
-        source: SIDECAR_SOURCES.PACKAGED,
-      });
-      expect(await resolveInstalledOuterVersion(winConfig)).toBe("0.8.0-beta.2");
-
-      const malformedExe = join(root, "broken-install", "Open Design.exe");
-      await mkdir(join(root, "broken-install", "resources"), { recursive: true });
-      await writeFile(malformedExe, "");
-      await writeFile(join(root, "broken-install", "resources", "open-design-config.json"), "not json\n");
-      const malformedConfig = resolveDesktopUpdaterConfig({
-        env: {},
-        launcherLaunchPath: malformedExe,
-        platform: "win32",
-        source: SIDECAR_SOURCES.PACKAGED,
-      });
-      expect(await resolveInstalledOuterVersion(malformedConfig)).toBeNull();
-    } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
-  });
-
   // Stone 3 — manual cache clear: the disaster-recovery action must reset the
   // one-shot updater state (downloaded release, install freeze) and purge the
   // deletable cache domains while never touching retained launcher versions.
@@ -3960,13 +3918,4 @@ describe("desktop updater", () => {
     }
   });
 
-  it("compares stable and prerelease versions", () => {
-    expect(compareVersions("1.0.1", "1.0.0")).toBe(1);
-    expect(compareVersions("1.0.0", "1.0.0")).toBe(0);
-    expect(compareVersions("1.0.0-beta.2", "1.0.0-beta.1")).toBe(1);
-    expect(compareVersions("1.0.0-beta-internal.2", "1.0.0-beta-internal.1")).toBe(1);
-    expect(compareVersions("1.0.0-prerelease.10", "1.0.0-prerelease.2")).toBe(1);
-    expect(compareVersions("1.0.0", "1.0.0-beta.9")).toBe(1);
-    expect(compareVersions("1.0.0-beta.1", "1.0.0")).toBe(-1);
-  });
 });

--- a/apps/desktop/tests/main/updater/feed.test.ts
+++ b/apps/desktop/tests/main/updater/feed.test.ts
@@ -1,0 +1,68 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { SIDECAR_SOURCES } from "@open-design/sidecar-proto";
+import { describe, expect, it } from "vitest";
+
+import { resolveDesktopUpdaterConfig } from "../../../src/main/updater/config.js";
+import { compareVersions, resolveInstalledOuterVersion } from "../../../src/main/updater/feed.js";
+
+function makeRoot(): string {
+  return mkdtempSync(join(tmpdir(), "od-updater-feed-test-"));
+}
+
+describe("desktop updater feed", () => {
+  it("resolves the installed outer version from the platform bundle layout", async () => {
+    const root = makeRoot();
+    try {
+      const appRoot = join(root, "Open Design.app");
+      await mkdir(join(appRoot, "Contents", "Resources"), { recursive: true });
+      await writeFile(join(appRoot, "Contents", "Resources", "open-design-config.json"), '{"appVersion":"0.7.0"}\n');
+      const macConfig = resolveDesktopUpdaterConfig({
+        env: {},
+        launcherLaunchPath: appRoot,
+        platform: "darwin",
+        source: SIDECAR_SOURCES.PACKAGED,
+      });
+      expect(await resolveInstalledOuterVersion(macConfig)).toBe("0.7.0");
+
+      const winExe = join(root, "win-install", "Open Design Beta.exe");
+      await mkdir(join(root, "win-install", "resources"), { recursive: true });
+      await writeFile(winExe, "");
+      await writeFile(join(root, "win-install", "resources", "open-design-config.json"), '{"appVersion":"0.8.0-beta.2"}\n');
+      const winConfig = resolveDesktopUpdaterConfig({
+        env: {},
+        launcherLaunchPath: winExe,
+        platform: "win32",
+        source: SIDECAR_SOURCES.PACKAGED,
+      });
+      expect(await resolveInstalledOuterVersion(winConfig)).toBe("0.8.0-beta.2");
+
+      const malformedExe = join(root, "broken-install", "Open Design.exe");
+      await mkdir(join(root, "broken-install", "resources"), { recursive: true });
+      await writeFile(malformedExe, "");
+      await writeFile(join(root, "broken-install", "resources", "open-design-config.json"), "not json\n");
+      const malformedConfig = resolveDesktopUpdaterConfig({
+        env: {},
+        launcherLaunchPath: malformedExe,
+        platform: "win32",
+        source: SIDECAR_SOURCES.PACKAGED,
+      });
+      expect(await resolveInstalledOuterVersion(malformedConfig)).toBeNull();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("compares stable and prerelease versions", () => {
+    expect(compareVersions("1.0.1", "1.0.0")).toBe(1);
+    expect(compareVersions("1.0.0", "1.0.0")).toBe(0);
+    expect(compareVersions("1.0.0-beta.2", "1.0.0-beta.1")).toBe(1);
+    expect(compareVersions("1.0.0-beta-internal.2", "1.0.0-beta-internal.1")).toBe(1);
+    expect(compareVersions("1.0.0-prerelease.10", "1.0.0-prerelease.2")).toBe(1);
+    expect(compareVersions("1.0.0", "1.0.0-beta.9")).toBe(1);
+    expect(compareVersions("1.0.0-beta.1", "1.0.0")).toBe(-1);
+  });
+});


### PR DESCRIPTION
## Why

Third slice of the mechanical split of `apps/desktop/src/main/updater.ts` (follow-up to #6106 and #6109). This one carves out release-feed interpretation — everything that turns fetched `metadata.json` into an update decision.

## What users will see

Nothing user-visible; pure code motion.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## What moved (mechanically, no behavior change)

- `src/main/updater/feed.ts`: metadata fetch (`fetchJson`) and channel/version parsing, artifact selection with the payload→installer fallback, launcher-context validity, checksum resolution (`sha256Url` sidecar parsing), candidate/release naming + matching, `resolveInstalledOuterVersion`, and the installer-reinstall floor (`remoteRequiresReinstall`) with its docblocks.
- `updater/support.ts` gains `numberField` / `objectField` (parsing primitives next to `stringField`).
- `updater.ts` re-exports `compareVersions`, `resolveInstalledOuterVersion`, `remoteRequiresReinstall`, so all existing import sites (tests included) are unchanged.
- The two pure feed test cases move to `tests/main/updater/feed.test.ts`; integration flows stay put. Desktop total holds at **269 passed** (now 30 files).

Code-motion audit (`git diff --color-moved=dimmed-zebra`): 542 added lines = **441 verbatim moves** + 101 wiring (import/export members, `export ` keyword prefixes, module docblock, test scaffold). Zero logic lines added or changed; 466 deletions = 441 move sources + 25 replaced import/signature originals.

## Validation

- `pnpm --filter @open-design/desktop test` — 30 files, **269 passed** (same total as `main`)
- `pnpm --filter @open-design/desktop typecheck` (both tsconfigs), `pnpm guard`
- e2e Vitest `tests/updater-fixture.test.ts` + `tests/packaged-launcher-update-loop.test.ts` — 4 passed
- `pnpm typecheck` (root) — green after `pnpm --filter @open-design/contracts build` (a stale local contracts `dist` initially reproduced a TS2345 in web that looked like an upstream break; rebuilding cleared it — not a `main` issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
