### PR TITLE
fix(daemon): reclaim run directories when a project is deleted

### DIFF
--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -57,6 +57,7 @@ import { auditDesignSystemPackage } from '../../tools-connectors-cli.js';
 import { parseOrchestratorWorkspace } from '../../workspace-contract.js';
 import { registerProjectConversationRoutes } from './conversations.js';
 import { cancelRunsOwnedBy } from './cancel-owned-runs.js';
+import { removeRunDirsOwnedByProject } from './remove-owned-run-dirs.js';
 
 export interface RegisterProjectRoutesDeps extends RouteDeps<'db' | 'design' | 'http' | 'paths' | 'projectStore' | 'projectFiles' | 'conversations' | 'templates' | 'status' | 'events' | 'ids' | 'telemetry' | 'appConfig' | 'agents' | 'validation'> {}
 
@@ -2278,6 +2279,15 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       await cancelRunsOwnedBy(design.runs, { projectId: req.params.id });
       dbDeleteProject(db, req.params.id);
       await removeProjectDir(PROJECTS_DIR, req.params.id).catch(() => {});
+      // Run event logs live under the runs root keyed by run id, not inside
+      // the project directory, so removeProjectDir does not reach them.
+      // Without this every run a deleted project produced is stranded on
+      // disk permanently — including the prompts and agent output in
+      // events.jsonl, which a user deleting a project expects to be gone.
+      await removeRunDirsOwnedByProject(
+        path.join(ctx.paths.RUNTIME_DATA_DIR, 'runs'),
+        req.params.id,
+      ).catch(() => {});
       /** @type {import('@open-design/contracts').OkResponse} */
       const body = { ok: true };
       res.json(body);

--- a/apps/daemon/src/routes/project/remove-owned-run-dirs.ts
+++ b/apps/daemon/src/routes/project/remove-owned-run-dirs.ts
@@ -1,0 +1,62 @@
+import { readFile, readdir, rm } from 'node:fs/promises';
+import path from 'node:path';
+
+/**
+ * Remove the on-disk run directories owned by a project that is being deleted.
+ *
+ * Each run keeps `<runsDir>/<runId>/{events.jsonl,state.json}`. Those live
+ * outside `PROJECTS_DIR` and are keyed by run id rather than nested under the
+ * project, so `removeProjectDir` never reaches them — deleting a project used
+ * to leave every run it ever produced behind, permanently and unreachable
+ * (there is no project row left to list them from).
+ *
+ * Ownership is read from each run's own `state.json`, NOT from the run
+ * service: `runs.list()` is backed by an in-memory Map that evicts a run as
+ * soon as it reaches a terminal status, so by the time a user deletes a
+ * project its finished runs are long gone from that view. `state.json`
+ * records `projectId` and survives, which makes it the only durable
+ * attribution for a historical run.
+ *
+ * Deliberately conservative: a directory is removed only when its
+ * `state.json` parses AND names this project. An unreadable, malformed, or
+ * absent state file leaves the directory alone — orphaning a few KB is
+ * strictly better than deleting a run that belongs to a project the user is
+ * keeping. Per-entry failures are swallowed so a permissions problem on one
+ * run can never block the delete the user actually asked for.
+ *
+ * Returns the number of directories removed, for logging and tests.
+ */
+export async function removeRunDirsOwnedByProject(
+  runsDir: string,
+  projectId: string,
+): Promise<number> {
+  if (!runsDir || !projectId) return 0;
+  let entries;
+  try {
+    entries = await readdir(runsDir, { withFileTypes: true });
+  } catch {
+    // No runs directory yet (fresh install, or a daemon configured without
+    // run logging) — nothing to reclaim.
+    return 0;
+  }
+  let removed = 0;
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const runDir = path.join(runsDir, entry.name);
+    let owner: unknown;
+    try {
+      const raw = await readFile(path.join(runDir, 'state.json'), 'utf8');
+      owner = (JSON.parse(raw) as { projectId?: unknown }).projectId;
+    } catch {
+      continue; // unattributable — leave it alone
+    }
+    if (owner !== projectId) continue;
+    try {
+      await rm(runDir, { recursive: true, force: true });
+      removed += 1;
+    } catch {
+      // Keep going; one undeletable run must not strand the rest.
+    }
+  }
+  return removed;
+}

--- a/apps/daemon/tests/routes/remove-owned-run-dirs.test.ts
+++ b/apps/daemon/tests/routes/remove-owned-run-dirs.test.ts
@@ -1,0 +1,95 @@
+import { mkdtemp, mkdir, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { removeRunDirsOwnedByProject } from '../../src/routes/project/remove-owned-run-dirs.js';
+
+const created: string[] = [];
+
+async function makeRunsDir(
+  runs: Array<{ id: string; state?: unknown; stateRaw?: string }>,
+): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), 'od-runs-'));
+  created.push(root);
+  for (const run of runs) {
+    const dir = path.join(root, run.id);
+    await mkdir(dir, { recursive: true });
+    await writeFile(path.join(dir, 'events.jsonl'), '{"event":"start"}\n');
+    if (run.stateRaw !== undefined) {
+      await writeFile(path.join(dir, 'state.json'), run.stateRaw);
+    } else if (run.state !== undefined) {
+      await writeFile(path.join(dir, 'state.json'), JSON.stringify(run.state));
+    }
+  }
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    created.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+describe('removeRunDirsOwnedByProject', () => {
+  it('removes only the run directories the deleted project owns', async () => {
+    const runsDir = await makeRunsDir([
+      { id: 'run-a', state: { id: 'run-a', projectId: 'keep-me' } },
+      { id: 'run-b', state: { id: 'run-b', projectId: 'delete-me' } },
+      { id: 'run-c', state: { id: 'run-c', projectId: 'delete-me' } },
+    ]);
+
+    const removed = await removeRunDirsOwnedByProject(runsDir, 'delete-me');
+
+    expect(removed).toBe(2);
+    expect((await readdir(runsDir)).sort()).toEqual(['run-a']);
+  });
+
+  it('leaves directories it cannot attribute alone', async () => {
+    // A run whose state file is missing, unparseable, or has no projectId is
+    // ambiguous. Stranding a few KB beats deleting a run that belongs to a
+    // project the user is keeping, so these must survive.
+    const runsDir = await makeRunsDir([
+      { id: 'no-state' },
+      { id: 'corrupt-state', stateRaw: '{not json' },
+      { id: 'no-project', state: { id: 'no-project', status: 'succeeded' } },
+      { id: 'owned', state: { id: 'owned', projectId: 'delete-me' } },
+    ]);
+
+    const removed = await removeRunDirsOwnedByProject(runsDir, 'delete-me');
+
+    expect(removed).toBe(1);
+    expect((await readdir(runsDir)).sort()).toEqual([
+      'corrupt-state',
+      'no-project',
+      'no-state',
+    ]);
+  });
+
+  it('ignores loose files in the runs root', async () => {
+    const runsDir = await makeRunsDir([
+      { id: 'owned', state: { id: 'owned', projectId: 'delete-me' } },
+    ]);
+    await writeFile(path.join(runsDir, 'stray.log'), 'not a run directory');
+
+    const removed = await removeRunDirsOwnedByProject(runsDir, 'delete-me');
+
+    expect(removed).toBe(1);
+    expect(await readdir(runsDir)).toEqual(['stray.log']);
+  });
+
+  it('is a no-op when the runs root does not exist', async () => {
+    const missing = path.join(tmpdir(), `od-runs-missing-${Date.now()}`);
+    await expect(removeRunDirsOwnedByProject(missing, 'delete-me')).resolves.toBe(0);
+  });
+
+  it('is a no-op without a runs dir or project id', async () => {
+    const runsDir = await makeRunsDir([
+      { id: 'owned', state: { id: 'owned', projectId: 'delete-me' } },
+    ]);
+
+    expect(await removeRunDirsOwnedByProject('', 'delete-me')).toBe(0);
+    expect(await removeRunDirsOwnedByProject(runsDir, '')).toBe(0);
+    expect((await readdir(runsDir)).sort()).toEqual(['owned']);
+  });
+});


### PR DESCRIPTION
Fixes #6117

## Why

**My use case:** I created a throwaway project to smoke-test an agent adapter, deleted it afterwards, and noticed the run directory was still on disk.

**The pain:** run event logs live at `<dataDir>/runs/<runId>/{events.jsonl,state.json}` — keyed by run id, not nested under the project — so `removeProjectDir` never reaches them. Deleting a project stranded every run it had ever produced, permanently: with the project row gone there is nothing left that can list or reclaim them. It is unbounded, and it accumulates fastest for exactly the people who use throwaway projects to try things out.

There is a privacy dimension too. `events.jsonl` contains the prompts and the agent's output. Someone deleting a project reasonably expects that content gone; today it stays.

## What users will see

Deleting a project now also removes that project's run logs. Nothing new in the UI.

## Implementation notes

Two things here are non-obvious enough to be worth calling out, because the naive version of this fix is wrong:

**1. Ownership comes from `state.json`, not from `runs.list()`.** The obvious approach is to reuse the existing `cancelRunsOwnedBy` path, which already enumerates runs by `projectId`. That does not work for this: `runs` is an in-memory `Map` and terminal runs are evicted from it (`runtimes/runs.ts:229` and `:674`), so by the time a user deletes a project its *finished* runs — the ones actually left on disk — are long gone from that view. `runs.list({ projectId })` would return only whatever happened to be in flight, i.e. approximately nothing, and the leak would look fixed while still leaking. Each run's `state.json` records `projectId` and survives eviction, which makes it the only durable attribution for a historical run.

**2. The sweep is deliberately conservative.** A directory is removed only when its `state.json` parses *and* names this project. Missing, unparseable, or `projectId`-less state files are left alone — stranding a few KB is strictly better than deleting a run belonging to a project the user is keeping. Per-entry failures are swallowed so one undeletable run cannot block the delete the user actually asked for, matching the existing `.catch(() => {})` treatment of `removeProjectDir` in the same handler.

The runs root is derived from `ctx.paths.RUNTIME_DATA_DIR` per the daemon data-directory contract in `AGENTS.md`, not recomputed.

## Scope

Deletes on project-delete only. **Not** included: a startup sweep for directories orphaned by earlier versions. That would be the natural companion, but it means deleting user data on upgrade based on a heuristic, and I would rather a maintainer decide that separately than smuggle it into a bug fix. Anyone upgrading keeps their existing orphans until they clear them by hand.

I also did not add a retention window. #6117 raised the question of whether run diagnostics should survive a project deletion briefly; immediate deletion is what the privacy argument points to, and it matches what the user asked for. Happy to change this if you would rather have a grace period.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — `DELETE /api/projects/:id` now also removes the project's run directories. Previously they were retained indefinitely (unintentionally).
- [ ] **None**

## Bug fix verification

- **Test path:** `apps/daemon/tests/routes/remove-owned-run-dirs.test.ts`
- **Red on `main`?** The helper does not exist on `main`, so the spec cannot compile there — the pre-fix behaviour is instead demonstrated by the reproduction in #6117 (create project → run → delete project → `ls .od/runs/<runId>` still lists `events.jsonl` and `state.json`).

Five cases covered: only-owned directories are removed; unattributable directories (no state file, corrupt JSON, no `projectId`) survive; loose files in the runs root are ignored; a missing runs root is a no-op; empty arguments are a no-op.

## Validation

- `pnpm guard` — pass
- `pnpm --filter @open-design/daemon typecheck` — pass (exit 0, includes `tsconfig.tests.json`)
- `pnpm exec vitest run -c vitest.config.ts tests/routes/ tests/project-routes.test.ts` — 11 files, 136 passed, 0 failed
- New spec in isolation — 5 passed

Note for anyone running the full `apps/daemon` suite locally: three tests fail on `main` in my environment (`langfuse-trace.test.ts` ×2, `plugins-headless-run.test.ts` ×1). They look environment-sensitive rather than real, and they are unrelated to this change — flagging so the numbers are not a surprise.
