### PR TITLE
ci: establish guard library boundary

### DIFF
--- a/e2e/tests/scripts/guard-lib.test.ts
+++ b/e2e/tests/scripts/guard-lib.test.ts
@@ -1,0 +1,82 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, test, vi } from "vitest";
+
+import {
+  loadScriptsArchitectureSources,
+  scriptsArchitectureErrors,
+} from "../../../scripts/lib/guard/architecture.ts";
+import { runGuardChecks } from "../../../scripts/lib/guard/core.ts";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+
+describe("scripts guard library", () => {
+  test("the live repository satisfies its layered dependency contract", async () => {
+    const sources = await loadScriptsArchitectureSources(repoRoot);
+    expect(scriptsArchitectureErrors(sources)).toEqual([]);
+  });
+
+  test("scope startup cannot reach guard internals or package dependencies", () => {
+    const sources = new Map([
+      ["scripts/scopes.ts", 'import "./lib/guard/core.ts";\nimport "typescript";'],
+      ["scripts/lib/guard/core.ts", ""],
+      ["scripts/guard.ts", 'import "./lib/guard/core.ts";'],
+      ["e2e/lib/playwright/suites.ts", ""],
+    ]);
+    expect(scriptsArchitectureErrors(sources)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("install-independent scope closure"),
+        expect.stringContaining("must consume guard policy through scripts/guard.ts"),
+      ]),
+    );
+  });
+
+  test("guard internals cannot reverse-depend on the CLI or form cycles", () => {
+    const sources = new Map([
+      ["scripts/scopes.ts", 'import "../e2e/lib/playwright/suites.ts";'],
+      ["scripts/guard.ts", 'import "./lib/guard/core.ts";'],
+      ["scripts/lib/guard/core.ts", 'import "./architecture.ts";'],
+      ["scripts/lib/guard/architecture.ts", 'import "./core.ts";\nimport "../../guard.ts";\nprocess.exitCode = 1;'],
+      ["e2e/lib/playwright/suites.ts", ""],
+    ]);
+    const errors = scriptsArchitectureErrors(sources);
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("must not depend on the guard CLI entrypoint"),
+        expect.stringContaining("contains CLI process control"),
+        expect.stringContaining("module cycle"),
+      ]),
+    );
+  });
+
+  test("the core runs every check and fails closed on exceptions", async () => {
+    const afterFailure = vi.fn(async () => true);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      runGuardChecks(
+        [
+          {
+            name: "broken",
+            run: async () => {
+              throw new Error("boom");
+            },
+          },
+          { name: "after", run: afterFailure },
+        ],
+        { repoRoot },
+      ),
+    ).resolves.toBe(false);
+    expect(afterFailure).toHaveBeenCalledOnce();
+    consoleError.mockRestore();
+  });
+
+  test("the architecture check is registered in the public guard entrypoint", () => {
+    const names = execFileSync("pnpm", ["--silent", "guard", "--list-checks"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    }).trim().split("\n");
+    expect(names).toContain("scripts library architecture");
+  });
+});

--- a/e2e/tests/scripts/scopes.test.ts
+++ b/e2e/tests/scripts/scopes.test.ts
@@ -812,7 +812,7 @@ test("runtime-definition shadow fails closed for mixed, unknown, empty, and unre
 
 test("UI P0 shadow guard pins full applied coverage and closed fallbacks", async () => {
   const { uiP0ShadowContractErrors } = await import(
-    "../../../scripts/check-ui-p0-shadow.ts"
+    "../../../scripts/lib/guard/scope.ts"
   );
   assert.deepEqual(uiP0ShadowContractErrors(), []);
 });

--- a/scripts/guard.ts
+++ b/scripts/guard.ts
@@ -7,7 +7,6 @@ import { checkCertainExemptConsumption } from "./check-certain-exempt-consumptio
 import { checkCrossAppImports } from "./check-cross-app-imports.ts";
 import { checkPackagedLeafBoundary } from "./check-packaged-leaf-boundary.ts";
 import { checkTsNocheckImports } from "./check-ts-nocheck-imports.ts";
-import { checkUiP0ShadowContract } from "./check-ui-p0-shadow.ts";
 import { checkDesignSystemManifests } from "./check-design-system-manifests.ts";
 import { checkDesignSystemPackageQuality } from "./check-design-system-package-quality.ts";
 import { checkDesignSystemComponentFixtureReport } from "./check-components-fixtures.ts";
@@ -25,6 +24,9 @@ import {
 } from "./check-tokens-fixture-sync.ts";
 import { checkCraftReferences } from "./lint-craft-references.ts";
 import { collectCssHardcodedColorMatches, cssWideAndSpecialColorKeywords, realNamedColors } from "./style-policy.ts";
+import { checkScriptsLibraryArchitecture } from "./lib/guard/architecture.ts";
+import { runGuardChecks, type GuardCheck } from "./lib/guard/core.ts";
+import { checkUiP0ShadowContract } from "./lib/guard/scope.ts";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const allowedE2eScripts = new Set([
@@ -32,11 +34,6 @@ const allowedE2eScripts = new Set([
   "e2e/scripts/release-smoke.ts",
   "e2e/scripts/visual-report.ts",
 ]);
-
-type GuardCheck = {
-  name: string;
-  run: () => Promise<boolean>;
-};
 
 function toRepositoryPath(filePath: string): string {
   return path.relative(repoRoot, filePath).split(path.sep).join("/");
@@ -1336,6 +1333,7 @@ const checks: GuardCheck[] = [
   { name: "@ts-nocheck import resolution", run: checkTsNocheckImports },
   { name: "test layout", run: checkTestLayout },
   { name: "scripts test-free", run: checkScriptsTestFree },
+  { name: "scripts library architecture", run: checkScriptsLibraryArchitecture },
   { name: "e2e layout", run: checkE2eLayout },
   { name: "web test layout", run: checkWebTestLayout },
   { name: "web import isolation", run: checkWebImportIsolation },
@@ -1357,21 +1355,6 @@ const checks: GuardCheck[] = [
   { name: "design system component manifest extraction", run: checkComponentsManifestExtraction },
 ];
 
-async function runChecks(): Promise<boolean> {
-  const results: boolean[] = [];
-  for (const check of checks) {
-    try {
-      results.push(await check.run());
-    } catch (error) {
-      console.error(`Guard check failed unexpectedly: ${check.name}`);
-      console.error(error);
-      results.push(false);
-    }
-  }
-
-  return results.every(Boolean);
-}
-
 const isMain = process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false;
 if (isMain) {
   // `--list-checks` is the machine-readable registry of guard check names; the
@@ -1379,7 +1362,7 @@ if (isMain) {
   // against it so a renamed or deleted guard fails CI.
   if (process.argv[2] === "--list-checks") {
     for (const check of checks) console.log(check.name);
-  } else if (!(await runChecks())) {
+  } else if (!(await runGuardChecks(checks, { repoRoot }))) {
     process.exitCode = 1;
   }
 }

--- a/scripts/lib/guard/architecture.ts
+++ b/scripts/lib/guard/architecture.ts
@@ -1,0 +1,193 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import ts from "typescript";
+
+import type { GuardContext } from "./core.ts";
+
+const suiteModule = "e2e/lib/playwright/suites.ts";
+const scopesModule = "scripts/scopes.ts";
+const guardModule = "scripts/guard.ts";
+const guardLibraryPrefix = "scripts/lib/guard/";
+const scopePolicyModule = `${guardLibraryPrefix}scope.ts`;
+const scopeLibraryPrefix = "scripts/lib/scope/";
+
+function repositoryPath(filePath: string): string {
+  return filePath.split(path.sep).join("/");
+}
+
+async function collectTypeScriptSources(
+  root: string,
+  directory = "scripts",
+): Promise<Map<string, string>> {
+  const sources = new Map<string, string>();
+  const entries = await readdir(path.join(root, directory), { withFileTypes: true });
+  for (const entry of entries) {
+    const relativePath = repositoryPath(path.join(directory, entry.name));
+    if (entry.isDirectory()) {
+      for (const [file, source] of await collectTypeScriptSources(root, relativePath)) {
+        sources.set(file, source);
+      }
+    } else if (entry.isFile() && /\.(?:[cm]?ts|tsx)$/.test(entry.name)) {
+      sources.set(relativePath, await readFile(path.join(root, relativePath), "utf8"));
+    }
+  }
+  return sources;
+}
+
+export async function loadScriptsArchitectureSources(repoRoot: string): Promise<Map<string, string>> {
+  const sources = await collectTypeScriptSources(repoRoot);
+  sources.set(suiteModule, await readFile(path.join(repoRoot, suiteModule), "utf8"));
+  return sources;
+}
+
+function importsFrom(source: string): string[] {
+  return ts.preProcessFile(source, true, true).importedFiles.map(({ fileName }) => fileName);
+}
+
+function hasCliProcessControl(source: string): boolean {
+  const sourceFile = ts.createSourceFile("module.ts", source, ts.ScriptTarget.Latest, true);
+  let found = false;
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isPropertyAccessExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "process" &&
+      ["argv", "exit", "exitCode"].includes(node.name.text)
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return found;
+}
+
+function resolveImport(
+  importer: string,
+  specifier: string,
+  sources: ReadonlyMap<string, string>,
+): string | undefined {
+  if (!specifier.startsWith(".")) return undefined;
+  const unresolved = path.posix.normalize(path.posix.join(path.posix.dirname(importer), specifier));
+  const candidates = [
+    unresolved,
+    unresolved.replace(/\.js$/, ".ts"),
+    unresolved.replace(/\.mjs$/, ".mts"),
+    unresolved.replace(/\.cjs$/, ".cts"),
+    `${unresolved}.ts`,
+    `${unresolved}/index.ts`,
+  ];
+  return candidates.find((candidate) => sources.has(candidate)) ?? unresolved;
+}
+
+function cycleErrors(graph: ReadonlyMap<string, readonly string[]>, roots: readonly string[]): string[] {
+  const errors: string[] = [];
+  const visited = new Set<string>();
+  const active = new Set<string>();
+  const stack: string[] = [];
+
+  function visit(module: string): void {
+    if (active.has(module)) {
+      const start = stack.indexOf(module);
+      errors.push(`module cycle: ${[...stack.slice(start), module].join(" -> ")}`);
+      return;
+    }
+    if (visited.has(module)) return;
+    visited.add(module);
+    active.add(module);
+    stack.push(module);
+    for (const dependency of graph.get(module) ?? []) visit(dependency);
+    stack.pop();
+    active.delete(module);
+  }
+
+  for (const root of roots) visit(root);
+  return errors;
+}
+
+export function scriptsArchitectureErrors(sources: ReadonlyMap<string, string>): string[] {
+  const errors: string[] = [];
+  const graph = new Map<string, string[]>();
+
+  for (const [module, source] of sources) {
+    const dependencies: string[] = [];
+    for (const specifier of importsFrom(source)) {
+      const dependency = resolveImport(module, specifier, sources);
+      if (dependency != null) dependencies.push(dependency);
+
+      if (
+        dependency?.startsWith(guardLibraryPrefix) &&
+        module !== guardModule &&
+        !module.startsWith(guardLibraryPrefix)
+      ) {
+        errors.push(`${module} must consume guard policy through ${guardModule}, not ${dependency}`);
+      }
+
+      if (!module.startsWith(guardLibraryPrefix)) continue;
+      if (specifier.startsWith("node:") || specifier === "typescript") continue;
+      if (dependency != null && specifier.startsWith(".") && !sources.has(dependency)) {
+        errors.push(`${module} imports missing module ${dependency}`);
+      }
+      if (
+        dependency == null ||
+        (!dependency.startsWith(guardLibraryPrefix) &&
+          (module !== scopePolicyModule ||
+            (dependency !== scopesModule && dependency !== suiteModule)))
+      ) {
+        errors.push(`${module} imports ${specifier} outside the guard library closure`);
+      }
+      if (dependency === guardModule) {
+        errors.push(`${module} must not depend on the guard CLI entrypoint`);
+      }
+    }
+    graph.set(module, dependencies.filter((dependency) => sources.has(dependency)));
+
+    if (module.startsWith(guardLibraryPrefix) && hasCliProcessControl(source)) {
+      errors.push(`${module} contains CLI process control; keep entrypoint effects in ${guardModule}`);
+    }
+  }
+
+  const scopeClosure = new Set<string>();
+  const visitScope = (module: string): void => {
+    if (scopeClosure.has(module)) return;
+    scopeClosure.add(module);
+    const source = sources.get(module);
+    if (source == null) {
+      errors.push(`${module} is missing from the preinstall scope closure`);
+      return;
+    }
+    for (const specifier of importsFrom(source)) {
+      if (specifier.startsWith("node:")) continue;
+      const dependency = resolveImport(module, specifier, sources);
+      if (
+        dependency == null ||
+        (dependency !== suiteModule && !dependency.startsWith(scopeLibraryPrefix))
+      ) {
+        errors.push(`${module} imports ${specifier} outside the install-independent scope closure`);
+        continue;
+      }
+      visitScope(dependency);
+    }
+  };
+  visitScope(scopesModule);
+
+  errors.push(
+    ...cycleErrors(graph, [
+      scopesModule,
+      ...[...sources.keys()].filter((module) => module.startsWith("scripts/lib/")),
+    ]),
+  );
+  return [...new Set(errors)].sort();
+}
+
+export async function checkScriptsLibraryArchitecture(context: GuardContext): Promise<boolean> {
+  const errors = scriptsArchitectureErrors(await loadScriptsArchitectureSources(context.repoRoot));
+  if (errors.length > 0) {
+    console.error("Scripts library architecture violations found:");
+    for (const error of errors) console.error(`- ${error}`);
+    return false;
+  }
+  console.log("Scripts library architecture check passed: scope startup and guard internals stay layered.");
+  return true;
+}

--- a/scripts/lib/guard/core.ts
+++ b/scripts/lib/guard/core.ts
@@ -1,0 +1,25 @@
+export type GuardContext = {
+  repoRoot: string;
+};
+
+export type GuardCheck = {
+  name: string;
+  run: (context: GuardContext) => boolean | Promise<boolean>;
+};
+
+export async function runGuardChecks(
+  checks: readonly GuardCheck[],
+  context: GuardContext,
+): Promise<boolean> {
+  const results: boolean[] = [];
+  for (const check of checks) {
+    try {
+      results.push(await check.run(context));
+    } catch (error) {
+      console.error(`Guard check failed unexpectedly: ${check.name}`);
+      console.error(error);
+      results.push(false);
+    }
+  }
+  return results.every(Boolean);
+}

--- a/scripts/lib/guard/scope.ts
+++ b/scripts/lib/guard/scope.ts
@@ -1,9 +1,9 @@
-import { uiP0CiMatrix } from "../e2e/lib/playwright/suites.ts";
+import { uiP0CiMatrix } from "../../../e2e/lib/playwright/suites.ts";
 import {
   DAEMON_RUNTIME_DEFINITION_EXACT,
   DAEMON_RUNTIME_DEFINITION_PREFIXES,
   evaluateUiP0Shadow,
-} from "./scopes.ts";
+} from "../../scopes.ts";
 
 const fullMatrixNames = [
   "entry-settings",

--- a/specs/current/ci.md
+++ b/specs/current/ci.md
@@ -27,6 +27,13 @@ may skip only for a merge-queue plan whose certain-tier evaluation claims zero
 validation effects. PR, manual-hot, forced-full, and escalated queue plans keep
 all broad workspace validation.
 
+`scripts/scopes.ts` remains an install-independent preinstall entrypoint.
+`scripts/guard.ts` is the postinstall policy-floor entrypoint and composes its
+shared mechanism and scope contracts from `scripts/lib/guard/`. The
+`scripts library architecture` guard keeps those layers acyclic, prevents
+scope startup from reaching guard or third-party dependencies, and keeps CLI
+process control out of the library closure.
+
 The error cost is asymmetric by tier. A wrong `medium` rule under-arms a PR
 run and gets caught by the merge queue's stricter threshold — cost: one queue
 bounce. A wrong `certain` rule lets an invalid change reach `main` with no
@@ -183,7 +190,7 @@ and model selector. Any empty, unresolved, mixed, unknown, or out-of-surface
 change falls back to the full four-domain matrix and records the reason in
 `trace.uiP0Shadow`.
 
-Guard: `UI P0 shadow contract` (`scripts/check-ui-p0-shadow.ts`). It pins the
+Guard: `UI P0 shadow contract` (`scripts/lib/guard/scope.ts`). It pins the
 applied full matrix, the candidate group set, representative in-bound
 resolution, and full fallback for shared daemon, runtime-composition, web, and
 unresolved inputs. The shadow must accumulate successful paired runs before it


### PR DESCRIPTION
## Why

The CI scope work now has enough guard logic that continuing to add standalone
root scripts would make the dependency shape harder to reason about. This
refactor establishes a small internal guard library before migrating more
checks, while preserving the two public entrypoints and the install-independent
scope startup path.

The pain addressed is architectural drift: without an executable boundary,
shared guard code could accidentally depend on the CLI entrypoint, introduce a
cycle, or pull an installed package into `scripts/scopes.ts`. The new check
makes those failures loud in the policy floor itself.

## What users will see

No user-facing behavior changes. CI scope plans and the existing UI P0 shadow
decision remain unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; there is no UI change.

## Bug fix verification

Not applicable; this is an internal architecture refactor.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/e2e typecheck`
- `pnpm --filter @open-design/e2e test tests/scripts` (13 files, 143 tests)
- `pnpm exec tsc -p scripts/tsconfig.json`
- `node --experimental-strip-types scripts/scopes.ts plan --context pr --files README.md docs/a.md`
- `git diff --check`
