### PR TITLE
fix(web): stabilize workspace recovery and UI validation

### DIFF
--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -2534,46 +2534,60 @@ export function ChatPane({
                       {retryAssistant && onRetry && runFailureUi ? (
                         <>
                           {runFailureUi.primaryAction === 'authorize' ? (
-                            // Sign in to AMR inline — the pill drives vela login,
-                            // surfaces the activation URL/code when the browser
-                            // doesn't auto-open, and on success we retry the run
-                            // without bouncing the user out to Settings.
-                            <AmrLoginPill
-                              className="chat-error-amr-login"
-                              signInLabel={t('chat.amrError.authorizeCta')}
-                              amrEntrySourceDetail="chat_error_authorize_retry"
-                              initialStatus={inlineAmrLoginStatus}
-                              skipInitialRefresh
-                              metricsConsent={config?.telemetry?.metrics === true}
-                              installationId={config?.installationId}
-                              showActivationDetails
-                              hideSignedOutStatus
-                              revealPendingCancelAction
-                              onSignInStarted={() => {
-                                amrAuthPrevLoggedInRef.current = false;
-                              }}
-                              onStatusChange={(loginStatus) => {
-                                // Retry only on a real signed-out -> signed-in
-                                // transition (see amrAuthPrevLoggedInRef).
-                                if (loginStatus?.loggedIn === true) {
-                                  const wasSignedOut =
-                                    amrAuthPrevLoggedInRef.current === false;
-                                  amrAuthPrevLoggedInRef.current = true;
-                                  if (
-                                    wasSignedOut &&
-                                    amrAuthRetriedRef.current !== retryAssistant.id
-                                  ) {
-                                    amrAuthRetriedRef.current = retryAssistant.id;
-                                    onRetry(retryAssistant);
-                                  }
-                                } else if (
-                                  loginStatus &&
-                                  loginStatus.loggedIn === false
-                                ) {
+                            inlineAmrLoginStatus?.loggedIn === true ? (
+                              // An account transition intentionally re-homes
+                              // workspace tabs. When the user reopens this
+                              // project, keep the failed run recoverable rather
+                              // than replacing its auth action with a read-only
+                              // signed-in account pill.
+                              <button
+                                type="button"
+                                className="chat-error-action chat-error-retry"
+                                onClick={() => onRetry(retryAssistant)}
+                              >
+                                {t('promptTemplates.retry')}
+                              </button>
+                            ) : (
+                              // Sign in to AMR inline — the pill drives vela
+                              // login and surfaces the activation URL/code when
+                              // the browser doesn't auto-open.
+                              <AmrLoginPill
+                                className="chat-error-amr-login"
+                                signInLabel={t('chat.amrError.authorizeCta')}
+                                amrEntrySourceDetail="chat_error_authorize_retry"
+                                initialStatus={inlineAmrLoginStatus}
+                                skipInitialRefresh
+                                metricsConsent={config?.telemetry?.metrics === true}
+                                installationId={config?.installationId}
+                                showActivationDetails
+                                hideSignedOutStatus
+                                revealPendingCancelAction
+                                onSignInStarted={() => {
                                   amrAuthPrevLoggedInRef.current = false;
-                                }
-                              }}
-                            />
+                                }}
+                                onStatusChange={(loginStatus) => {
+                                  // Retry only on a real signed-out -> signed-in
+                                  // transition (see amrAuthPrevLoggedInRef).
+                                  if (loginStatus?.loggedIn === true) {
+                                    const wasSignedOut =
+                                      amrAuthPrevLoggedInRef.current === false;
+                                    amrAuthPrevLoggedInRef.current = true;
+                                    if (
+                                      wasSignedOut &&
+                                      amrAuthRetriedRef.current !== retryAssistant.id
+                                    ) {
+                                      amrAuthRetriedRef.current = retryAssistant.id;
+                                      onRetry(retryAssistant);
+                                    }
+                                  } else if (
+                                    loginStatus &&
+                                    loginStatus.loggedIn === false
+                                  ) {
+                                    amrAuthPrevLoggedInRef.current = false;
+                                  }
+                                }}
+                              />
+                            )
                           ) : runFailureUi.primaryAction === 'launch-terminal-auth' ? (
                             <button
                               type="button"

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -78,7 +78,7 @@ import {
   isOpenDesignHostAvailable,
   openHostExternalUrl,
 } from '@open-design/host';
-import { coalescedGet } from '../lib/coalesced-get';
+import { coalescedGet, evictCoalescedGet } from '../lib/coalesced-get';
 import { workspaceProjectHeaders } from '../state/projects';
 
 export const DEFAULT_DEPLOY_PROVIDER_ID = 'vercel-self';
@@ -1616,6 +1616,10 @@ export async function createSocialSharePayload(
 
 // Project files — all paths are scoped under .od/projects/<id>/ on disk.
 
+function projectFilesCacheKey(projectId: string): string {
+  return `project-files:${projectId}`;
+}
+
 export async function fetchProjectFiles(
   projectId: string,
   options?: { signal?: AbortSignal },
@@ -1639,7 +1643,7 @@ export async function fetchProjectFiles(
   // joins the abandoned card request and waits behind the entire Home burst.
   if (options?.signal) return run();
   // Non-cancellable display reads still collapse identical mount-burst calls.
-  return coalescedGet(`project-files:${projectId}`, run);
+  return coalescedGet(projectFilesCacheKey(projectId), run);
 }
 
 export type ProjectDesignTokenSuggestion = import('@open-design/contracts').ProjectDesignTokenSuggestion;
@@ -2281,6 +2285,7 @@ export async function writeProjectTextFileDetailed(
       };
     }
     const json = (await resp.json()) as { file: ProjectFile };
+    evictCoalescedGet(projectFilesCacheKey(projectId));
     return { ok: true, file: json.file };
   } catch {
     return { ok: false, message: 'Network error while saving the file' };
@@ -2304,6 +2309,7 @@ export async function writeProjectBase64File(
     });
     if (!resp.ok) return null;
     const json = (await resp.json()) as { file: ProjectFile };
+    evictCoalescedGet(projectFilesCacheKey(projectId));
     return json.file;
   } catch {
     return null;
@@ -2327,6 +2333,7 @@ export async function uploadProjectFile(
     });
     if (!resp.ok) return null;
     const json = (await resp.json()) as { file: ProjectFile };
+    evictCoalescedGet(projectFilesCacheKey(projectId));
     return json.file;
   } catch {
     return null;
@@ -2434,6 +2441,7 @@ export async function uploadProjectFiles(
         break;
       }
 
+      evictCoalescedGet(projectFilesCacheKey(projectId));
       const json = (await resp.json()) as {
         files: { name: string; path: string; size?: number; originalName?: string }[];
       };
@@ -2505,7 +2513,11 @@ export async function deleteProjectFile(
         ...(workspaceContext ? { headers: workspaceProjectHeaders(workspaceContext) } : {}),
       },
     );
-    return resp.ok;
+    if (resp.ok) {
+      evictCoalescedGet(projectFilesCacheKey(projectId));
+      return true;
+    }
+    return false;
   } catch {
     return false;
   }
@@ -2529,6 +2541,7 @@ export async function renameProjectFile(
     const errorBody = await readApiErrorBody(resp);
     throw new Error(errorBody.message);
   }
+  evictCoalescedGet(projectFilesCacheKey(projectId));
   return (await resp.json()) as RenameProjectFileResponse;
 }
 

--- a/apps/web/tests/components/ChatPane.amr-auth-inline.test.tsx
+++ b/apps/web/tests/components/ChatPane.amr-auth-inline.test.tsx
@@ -9,7 +9,7 @@
  * AmrLoginPill.test.tsx; here we only assert ChatPane's wiring.
  */
 
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { forwardRef, useEffect } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -198,5 +198,17 @@ describe('ChatPane inline AMR auth', () => {
     lastPillProps?.onStatusChange?.(signedIn);
 
     expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it('offers a manual retry when the signed-in user reopens the failed run', async () => {
+    fetchVelaLoginStatusMock.mockResolvedValue(signedIn);
+    const onRetry = vi.fn();
+    renderChat(onRetry);
+
+    const retry = await waitFor(() => screen.getByText('promptTemplates.retry'));
+    fireEvent.click(retry);
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry.mock.calls[0]![0]).toMatchObject({ id: 'msg-amr-auth' });
   });
 });

--- a/apps/web/tests/components/DesignsTab.select-mode.test.tsx
+++ b/apps/web/tests/components/DesignsTab.select-mode.test.tsx
@@ -138,7 +138,7 @@ describe('DesignsTab select mode', () => {
         onOpenLiveArtifact={vi.fn()}
         onDelete={vi.fn()}
         onRename={vi.fn()}
-        isActive={false}
+        isActive
       />,
     );
 

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -1350,13 +1350,13 @@ describe('ProjectView conversation run isolation', () => {
 
     fireEvent.click(screen.getByTestId('workspace-focus-mode'));
     await waitFor(() =>
-      expect(screen.getByTestId('active-conversation').closest('.split-chat-slot')?.hasAttribute('hidden')).toBe(true),
+      expect(screen.getByTestId('active-conversation').closest('.split-chat-slot')?.getAttribute('aria-hidden')).toBe('true'),
     );
     fireEvent.click(screen.getByTestId('workspace-open-comments'));
     fireEvent.click(screen.getByTestId('workspace-send-comment'));
 
     await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-b'));
-    expect(screen.getByTestId('active-conversation').closest('.split-chat-slot')?.hasAttribute('hidden')).toBe(false);
+    expect(screen.getByTestId('active-conversation').closest('.split-chat-slot')?.hasAttribute('aria-hidden')).toBe(false);
     expect(streamViaDaemon).toHaveBeenCalledWith(expect.objectContaining({
       conversationId: 'conv-b',
       projectId: 'project-1',

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -585,6 +585,42 @@ function teamWorkspaceContext(
   };
 }
 
+function authoritativeWorkspaceBillingResponse(
+  workspaceId: string,
+  workspaceMemberId: string,
+) {
+  const observedAt = '2026-07-26T00:00:00.000Z';
+  return {
+    summary: null,
+    workspaceBalance: {
+      workspaceId,
+      workspaceMemberId,
+      balanceUsd: '10.00',
+      billingScopeVersion: 2,
+      expiresAt: null,
+      updatedAt: observedAt,
+    },
+    workspaceRuntime: {
+      workspaceId,
+      workspaceMemberId,
+      status: 'fresh',
+      revision: '4',
+      observedAt,
+      softExpiresAt: '2099-07-26T00:00:30.000Z',
+      hardExpiresAt: '2099-07-26T00:02:00.000Z',
+      retryAt: null,
+      errorCode: null,
+      reason: 'authoritative-action-read',
+      sourceGapDetected: false,
+    },
+    authoritativeWorkspaceRead: {
+      workspaceId,
+      workspaceMemberId,
+      observedAt,
+    },
+  };
+}
+
 const runningAssistant: ChatMessage = {
   id: 'assistant-a',
   role: 'assistant',
@@ -880,17 +916,11 @@ describe('ProjectView conversation run isolation', () => {
       const url = String(input);
       if (url.includes('/api/workspace/billing')) {
         const workspaceId = new URL(url, 'http://localhost').searchParams.get('workspaceId');
-        return new Response(JSON.stringify({
-          summary: null,
-          workspaceBalance: {
-            workspaceId,
-            workspaceMemberId: workspaceId === workspaceA.workspaceId ? 'member-a' : 'member-b',
-            balanceUsd: '10.00',
-            billingScopeVersion: 2,
-            expiresAt: null,
-            updatedAt: null,
-          },
-        }), { status: 200, headers: { 'content-type': 'application/json' } });
+        if (!workspaceId) throw new Error('workspace billing request omitted workspaceId');
+        return new Response(JSON.stringify(authoritativeWorkspaceBillingResponse(
+          workspaceId,
+          workspaceId === workspaceA.workspaceId ? 'member-a' : 'member-b',
+        )), { status: 200, headers: { 'content-type': 'application/json' } });
       }
       throw new Error(`Unexpected fetch: ${url}`);
     });

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -198,6 +198,42 @@ describe('fetchProjectFiles', () => {
     await expect(foreground).resolves.toEqual(files);
   });
 
+  it('refetches the project file list after a successful upload', async () => {
+    const uploadedFile = {
+      name: 'uploaded.png',
+      path: 'uploaded.png',
+      kind: 'image' as const,
+      mtime: 2,
+      size: 68,
+      mime: 'image/png',
+    };
+    const fetchMock = vi.fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(
+        JSON.stringify({ files: [] }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ))
+      .mockResolvedValueOnce(new Response(
+        JSON.stringify({ files: [uploadedFile] }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ))
+      .mockResolvedValueOnce(new Response(
+        JSON.stringify({ files: [uploadedFile] }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchProjectFiles('project-upload-cache')).resolves.toEqual([]);
+    await expect(uploadProjectFiles(
+      'project-upload-cache',
+      [new File(['png'], 'uploaded.png', { type: 'image/png' })],
+    )).resolves.toMatchObject({
+      uploaded: [{ name: 'uploaded.png', path: 'uploaded.png' }],
+      failed: [],
+    });
+    await expect(fetchProjectFiles('project-upload-cache')).resolves.toEqual([uploadedFile]);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
   it('keeps ordinary live-artifact reads independent from cancellable card scans', async () => {
     const artifacts = [{
       id: 'artifact-1',

--- a/apps/web/tests/state/config.test.ts
+++ b/apps/web/tests/state/config.test.ts
@@ -157,8 +157,8 @@ describe('syncConfigToDaemon', () => {
     expect(url).toBe('/api/app-config');
     expect(init.method).toBe('PUT');
     expect(init.headers).toEqual({ 'content-type': 'application/json' });
-    expect(JSON.parse(String(init.body))).toMatchObject({
-      onboardingCompleted: DEFAULT_CONFIG.onboardingCompleted,
+    const body = JSON.parse(String(init.body));
+    expect(body).toMatchObject({
       agentId: DEFAULT_CONFIG.agentId,
       agentModels: DEFAULT_CONFIG.agentModels,
       skillId: DEFAULT_CONFIG.skillId,
@@ -168,6 +168,7 @@ describe('syncConfigToDaemon', () => {
         codex: { CODEX_HOME: '~/.codex-alt', CODEX_BIN: '~/bin/codex-next' },
       },
     });
+    expect(body).not.toHaveProperty('onboardingCompleted');
   });
 
   it('syncs CLI API key env values and intent to daemon app config while localStorage strips them', async () => {

--- a/e2e/lib/playwright/amr.ts
+++ b/e2e/lib/playwright/amr.ts
@@ -110,10 +110,11 @@ async function ensureEntryRailOpenIfPresent(page: Page) {
  * (`role="dialog"`), but from the entry #5517 routes to `/settings` and
  * `SettingsDialog` renders in `presentation="page"` mode — same markup, but
  * `role="region"` and no `aria-modal`. `.modal-settings` is the class both
- * presentations share, so match on it and keep the dialog role as a fallback.
+ * presentations share. Keep this selector specific: the account/model popover
+ * also uses `role="dialog"` but is not the full settings surface.
  */
 export function settingsSurface(page: Page) {
-  return page.locator('.modal-settings').or(page.getByRole('dialog')).first();
+  return page.locator('.modal-settings').first();
 }
 
 export async function openSettingsDialog(page: Page) {
@@ -122,7 +123,7 @@ export async function openSettingsDialog(page: Page) {
   await ensureEntryRailOpenIfPresent(page);
   const dialog = settingsSurface(page);
   const settingsTrigger = page
-    .getByTestId('entry-settings-button')
+    .getByTestId('entry-nav-settings')
     .or(page.getByTestId('entry-settings-menu-trigger'))
     .or(page.getByRole('button', { name: OPEN_SETTINGS_LABEL }))
     .first();
@@ -142,6 +143,10 @@ export async function openSettingsDialog(page: Page) {
     const detailsTrigger = page.getByTestId('entry-settings-open-details').first();
     if (await detailsTrigger.isVisible({ timeout: 1_000 }).catch(() => false)) {
       await detailsTrigger.click();
+    }
+    const executionSettingsTrigger = page.getByTestId('avatar-open-execution-settings').first();
+    if (await executionSettingsTrigger.isVisible({ timeout: 1_000 }).catch(() => false)) {
+      await executionSettingsTrigger.click();
     }
 
     await expect
@@ -171,8 +176,14 @@ export async function sendPrompt(page: Page, prompt: string) {
   await input.press('Enter');
 }
 
-export async function createProjectViaApi(page: Page, projectId: string, name: string) {
+export async function createProjectViaApi(
+  page: Page,
+  projectId: string,
+  name: string,
+  options: { headers?: Record<string, string> } = {},
+) {
   const response = await page.request.post('/api/projects', {
+    ...(options.headers ? { headers: options.headers } : {}),
     data: {
       id: projectId,
       name,

--- a/e2e/lib/playwright/amr.ts
+++ b/e2e/lib/playwright/amr.ts
@@ -1,5 +1,8 @@
+import { createServer } from 'node:http';
+
 import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
+import type { WorkspaceCollabContext } from '@open-design/contracts';
 import { ensureRailOpen } from './rail.js';
 import { T } from '@/timeouts';
 
@@ -13,6 +16,127 @@ type MockAmrWalletOptions = {
   plan?: string;
   profile?: string;
 };
+
+export const PERSONAL_PROJECT_WORKSPACE_CONTEXT = {
+  workspaceId: 'workspace-personal',
+  workspaceType: 'personal',
+  workspaceMemberId: 'member-personal',
+  role: 'owner',
+  memberStatus: 'active',
+  lifecycleState: 'active',
+  billingState: 'active',
+  planId: null,
+  providerMode: 'platform_credits',
+  seatSummary: {
+    seatLimit: 0,
+    usedSeats: 0,
+    availableSeats: 0,
+    isSeatFull: false,
+  },
+  permissions: {
+    canManageMembers: true,
+    canManageBilling: true,
+    canInviteMembers: true,
+    canManageAutoRecharge: true,
+    canShareProjects: true,
+    canWriteSyncedFiles: true,
+    canViewWorkspaceSettings: true,
+    canManageSharedResources: true,
+  },
+} satisfies WorkspaceCollabContext;
+
+export const PERSONAL_PROJECT_WORKSPACE_HEADERS = {
+  'x-od-workspace-id': PERSONAL_PROJECT_WORKSPACE_CONTEXT.workspaceId,
+  'x-od-workspace-type': PERSONAL_PROJECT_WORKSPACE_CONTEXT.workspaceType,
+  'x-od-workspace-member-id': PERSONAL_PROJECT_WORKSPACE_CONTEXT.workspaceMemberId,
+  'x-od-workspace-role': PERSONAL_PROJECT_WORKSPACE_CONTEXT.role,
+  'x-od-workspace-member-status': PERSONAL_PROJECT_WORKSPACE_CONTEXT.memberStatus,
+  'x-od-workspace-lifecycle-state': PERSONAL_PROJECT_WORKSPACE_CONTEXT.lifecycleState,
+  'x-od-workspace-can-share-projects': String(
+    PERSONAL_PROJECT_WORKSPACE_CONTEXT.permissions.canShareProjects,
+  ),
+  'x-od-workspace-can-write-synced-files': String(
+    PERSONAL_PROJECT_WORKSPACE_CONTEXT.permissions.canWriteSyncedFiles,
+  ),
+};
+
+export async function providePersonalWorkspaceApi(
+  use: () => Promise<void>,
+): Promise<void> {
+  const server = createServer((request, response) => {
+    const pathname = new URL(request.url ?? '/', 'http://127.0.0.1').pathname;
+    if (request.method === 'GET' && pathname === '/api/v1/workspaces') {
+      response.statusCode = 200;
+      response.setHeader('content-type', 'application/json');
+      response.end(JSON.stringify({
+        items: [{
+          workspaceId: PERSONAL_PROJECT_WORKSPACE_CONTEXT.workspaceId,
+          workspaceName: 'Personal',
+          workspaceType: PERSONAL_PROJECT_WORKSPACE_CONTEXT.workspaceType,
+          workspaceMemberId: PERSONAL_PROJECT_WORKSPACE_CONTEXT.workspaceMemberId,
+          role: PERSONAL_PROJECT_WORKSPACE_CONTEXT.role,
+          memberStatus: PERSONAL_PROJECT_WORKSPACE_CONTEXT.memberStatus,
+          lifecycleState: PERSONAL_PROJECT_WORKSPACE_CONTEXT.lifecycleState,
+        }],
+      }));
+      return;
+    }
+    response.statusCode = 404;
+    response.end();
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (address == null || typeof address === 'string') {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error('fake workspace API did not receive a TCP port');
+  }
+  const previousControlKey = process.env.VELA_CONTROL_KEY;
+  const previousApiUrl = process.env.VELA_API_URL;
+  process.env.VELA_CONTROL_KEY = 'fake-control-key';
+  process.env.VELA_API_URL = `http://127.0.0.1:${address.port}`;
+  try {
+    await use();
+  } finally {
+    if (previousControlKey === undefined) delete process.env.VELA_CONTROL_KEY;
+    else process.env.VELA_CONTROL_KEY = previousControlKey;
+    if (previousApiUrl === undefined) delete process.env.VELA_API_URL;
+    else process.env.VELA_API_URL = previousApiUrl;
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+export async function stubPersonalWorkspaceContext(page: Page): Promise<void> {
+  await page.route('**/api/workspace/context', async (route) => {
+    await route.fulfill({
+      json: { context: PERSONAL_PROJECT_WORKSPACE_CONTEXT },
+    });
+  });
+}
+
+export async function stubPersonalProjectWorkspaceScope(
+  page: Page,
+  projectId: string,
+): Promise<void> {
+  await page.route(`**/api/projects/${projectId}/workspace-scope`, async (route) => {
+    await route.fulfill({
+      json: {
+        scope: {
+          kind: 'personal',
+          projectId,
+          workspaceId: PERSONAL_PROJECT_WORKSPACE_CONTEXT.workspaceId,
+          visibility: 'personal',
+          context: PERSONAL_PROJECT_WORKSPACE_CONTEXT,
+        },
+      },
+    });
+  });
+}
 
 export async function waitForLoadingToClear(page: Page) {
   await page.getByText('Loading Open Design…').waitFor({ state: 'hidden', timeout: T.long }).catch(() => {});

--- a/e2e/lib/playwright/visual.ts
+++ b/e2e/lib/playwright/visual.ts
@@ -613,19 +613,11 @@ export async function prepareVisualWorkspaceFileList(page: Page): Promise<void> 
     await page.getByTestId('design-files-tab').click();
   }
   await expect(page.getByTestId('design-files-tab')).toHaveAttribute('aria-selected', 'true');
-  const trigger = page.getByTestId('workspace-pages-menu-trigger');
-  await expect
-    .poll(async () => ((await trigger.textContent()) ?? '').replace(/\s+/g, ' ').trim(), {
-      timeout: T.medium,
-    })
-    .not.toBe('Pages');
-  const triggerText = await trigger.textContent().catch(() => '');
-  if (!/\bAll project files\b/.test(triggerText ?? '')) {
-    await trigger.click();
-    await page.getByRole('menuitem', { name: 'All project files' }).click();
-    await expect(trigger).toContainText('All project files');
-  }
-  await expect(page.getByTestId('design-file-row-index.html')).toBeVisible();
+  await expect(page.getByTestId('design-files-tab-cat:html')).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
+  await expect(fileRow).toBeVisible();
   await expect(page.getByTestId('design-file-preview')).toHaveCount(0);
   await resetVisualScroll(page);
   await waitForVisualStable(page);

--- a/e2e/lib/playwright/visual.ts
+++ b/e2e/lib/playwright/visual.ts
@@ -678,7 +678,7 @@ export async function openAvatarMenu(page: Page): Promise<Locator> {
 export async function openSettingsDetailsFromHeader(page: Page): Promise<Locator> {
   const dialog = page.locator('.modal-settings[role="dialog"]').first();
   const triggers = [
-    page.getByTestId('entry-settings-button').first(),
+    page.getByTestId('entry-nav-settings').first(),
     page.getByTestId('entry-settings-menu-trigger').first(),
     page.locator('.settings-icon-btn').first(),
   ];

--- a/e2e/lib/vitest/amr.ts
+++ b/e2e/lib/vitest/amr.ts
@@ -2,6 +2,17 @@ import { randomUUID } from 'node:crypto';
 
 import { requestJson } from './http.ts';
 
+export const AMR_PERSONAL_WORKSPACE_HEADERS = {
+  'x-od-workspace-id': 'workspace-personal',
+  'x-od-workspace-type': 'personal',
+  'x-od-workspace-member-id': 'member-personal',
+  'x-od-workspace-role': 'owner',
+  'x-od-workspace-member-status': 'active',
+  'x-od-workspace-lifecycle-state': 'active',
+  'x-od-workspace-can-share-projects': 'true',
+  'x-od-workspace-can-write-synced-files': 'true',
+};
+
 export async function putAmrAppConfig(
   webUrl: string,
   config: {
@@ -38,6 +49,7 @@ export async function createAmrProject(webUrl: string, name: string) {
       pendingPrompt: null,
       skillId: null,
     },
+    headers: AMR_PERSONAL_WORKSPACE_HEADERS,
     method: 'POST',
   });
 }

--- a/e2e/lib/vitest/suite.ts
+++ b/e2e/lib/vitest/suite.ts
@@ -1,5 +1,6 @@
 import { mkdir, rm, writeFile } from 'node:fs/promises';
-import { createServer } from 'node:net';
+import { createServer as createHttpServer } from 'node:http';
+import { createServer as createNetServer } from 'node:net';
 import { delimiter, dirname, join } from 'node:path';
 
 import { expect } from 'vitest';
@@ -66,6 +67,7 @@ export type ToolsDevSuiteContext = {
 };
 
 export type ToolsDevSuiteOptions = {
+  amrPersonalWorkspaceAuthority?: boolean;
   env?: Record<string, string | undefined>;
   onFailure?: (input: {
     context: ToolsDevSuiteContext | null;
@@ -158,7 +160,7 @@ async function allocateDistinctPorts(count: number): Promise<number[]> {
 }
 
 async function reserveFreePort(): Promise<number> {
-  const server = createServer();
+  const server = createNetServer();
   await new Promise<void>((resolveListen, rejectListen) => {
     server.once('error', rejectListen);
     server.listen(0, '127.0.0.1', () => resolveListen());
@@ -244,18 +246,29 @@ async function runToolsDevSuite(
   let diagnostics: unknown = null;
   let caughtError: unknown = null;
   let success = false;
+  let closeAmrWorkspaceApi: (() => Promise<void>) | null = null;
+  const suiteEnv = options.amrPersonalWorkspaceAuthority
+    ? {
+        VELA_API_URL: suite.amr.apiUrl,
+        VELA_CONTROL_KEY: 'fake-control-key',
+        ...options.env,
+      }
+    : options.env;
 
   try {
-    const start = await toolsDev.startWeb(options.env);
+    if (options.amrPersonalWorkspaceAuthority) {
+      closeAmrWorkspaceApi = await startAmrPersonalWorkspaceApi(suite.amr.apiUrl);
+    }
+    const start = await toolsDev.startWeb(suiteEnv);
     const runtime = toolsDev.portAllocation;
     if (runtime == null) throw new Error('tools-dev did not expose its allocated ports');
     const webUrl = assertRuntimeUrl(start.web?.status.url, 'web');
-    const status = await toolsDev.status(options.env);
+    const status = await toolsDev.status(suiteEnv);
     assertToolsDevStatus(suite, status);
 
     context = {
-      check: () => toolsDev.check(options.env),
-      logs: () => toolsDev.logs(options.env),
+      check: () => toolsDev.check(suiteEnv),
+      logs: () => toolsDev.logs(suiteEnv),
       runtime,
       start,
       status,
@@ -269,7 +282,7 @@ async function runToolsDevSuite(
     success = true;
   } catch (error) {
     caughtError = error;
-    diagnostics = await toolsDev.check(options.env).catch((diagnosticError: unknown) => ({
+    diagnostics = await toolsDev.check(suiteEnv).catch((diagnosticError: unknown) => ({
       error: diagnosticError instanceof Error ? diagnosticError.message : String(diagnosticError),
     }));
     await options.onFailure?.({ context, error, suite }).catch((failureHookError: unknown) => {
@@ -285,9 +298,14 @@ async function runToolsDevSuite(
     // next smoke run on a shared CI runner.
     let stopError: unknown = null;
     try {
-      await toolsDev.stopWeb(options.env);
+      await toolsDev.stopWeb(suiteEnv);
     } catch (error) {
       stopError = error;
+    }
+    try {
+      await closeAmrWorkspaceApi?.();
+    } catch (error) {
+      stopError ??= error;
     }
     if (stopError != null) {
       diagnostics = {
@@ -308,6 +326,47 @@ async function runToolsDevSuite(
     }
   }
   return suite.report.root;
+}
+
+async function startAmrPersonalWorkspaceApi(
+  apiUrl: string,
+): Promise<() => Promise<void>> {
+  const url = new URL(apiUrl);
+  const port = Number(url.port);
+  if (!Number.isInteger(port) || port <= 0) {
+    throw new Error(`AMR fixture URL does not include a valid port: ${apiUrl}`);
+  }
+  const server = createHttpServer((request, response) => {
+    const pathname = new URL(request.url ?? '/', apiUrl).pathname;
+    if (request.method === 'GET' && pathname === '/api/v1/workspaces') {
+      response.statusCode = 200;
+      response.setHeader('content-type', 'application/json');
+      response.end(JSON.stringify({
+        items: [{
+          workspaceId: 'workspace-personal',
+          workspaceName: 'Personal',
+          workspaceType: 'personal',
+          workspaceMemberId: 'member-personal',
+          role: 'owner',
+          memberStatus: 'active',
+          lifecycleState: 'active',
+        }],
+      }));
+      return;
+    }
+    response.statusCode = 404;
+    response.end();
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, url.hostname, resolve);
+  });
+  return async () => {
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  };
 }
 
 function assertRuntimeUrl(value: string | null | undefined, app: string): string {

--- a/e2e/tests/amr/auth-error-convergence.test.ts
+++ b/e2e/tests/amr/auth-error-convergence.test.ts
@@ -55,6 +55,6 @@ describe('AMR auth error convergence', () => {
       const assistant = messages.find((message) => message.id === assistantMessageId);
       expect(assistant?.runStatus).toBe('failed');
       await expect(readRunEvents(webUrl, run.runId)).resolves.toMatch(/AMR_AUTH_REQUIRED/);
-    });
+    }, { amrPersonalWorkspaceAuthority: true });
   });
 });

--- a/e2e/tests/amr/insufficient-balance.test.ts
+++ b/e2e/tests/amr/insufficient-balance.test.ts
@@ -59,6 +59,6 @@ describe('AMR insufficient balance run failures', () => {
       const messages = await listMessages(webUrl, project.project.id, project.conversationId);
       const assistant = messages.find((message) => message.id === assistantMessageId);
       expect(assistant?.runStatus).toBe('failed');
-    });
+    }, { amrPersonalWorkspaceAuthority: true });
   });
 });

--- a/e2e/tests/amr/logout-state-persistence.test.ts
+++ b/e2e/tests/amr/logout-state-persistence.test.ts
@@ -85,7 +85,7 @@ describe('AMR logout state persistence', () => {
         expect(terminal.status).toBe('failed');
 
         await expect(readRunEvents(webUrl, secondRun.runId)).resolves.toMatch(/AMR_AUTH_REQUIRED/);
-      });
+      }, { amrPersonalWorkspaceAuthority: true });
     });
   });
 });

--- a/e2e/tests/amr/relogin-required.test.ts
+++ b/e2e/tests/amr/relogin-required.test.ts
@@ -50,7 +50,7 @@ describe('AMR relogin-required run failures', () => {
         expect(terminal.status).toBe('failed');
 
         await expect(readRunEvents(webUrl, run.runId)).resolves.toMatch(/AMR_AUTH_REQUIRED/);
-      });
+      }, { amrPersonalWorkspaceAuthority: true });
     });
   });
 
@@ -91,7 +91,7 @@ describe('AMR relogin-required run failures', () => {
         });
 
         await waitForRunStatus(webUrl, run.runId, 'succeeded', { timeoutMs: 20_000 });
-      });
+      }, { amrPersonalWorkspaceAuthority: true });
     });
   });
 
@@ -138,7 +138,7 @@ describe('AMR relogin-required run failures', () => {
           });
 
           await waitForRunStatus(webUrl, run.runId, 'succeeded', { timeoutMs: 20_000 });
-        });
+        }, { amrPersonalWorkspaceAuthority: true });
       },
     );
   });

--- a/e2e/tests/amr/turn.test.ts
+++ b/e2e/tests/amr/turn.test.ts
@@ -28,6 +28,7 @@ import { join } from 'node:path';
 
 import { describe, expect, test } from 'vitest';
 
+import { AMR_PERSONAL_WORKSPACE_HEADERS } from '@/vitest/amr';
 import { requestJson } from '@/vitest/http';
 import { listMessages } from '@/vitest/messages';
 import { startRun, waitForRunStatus } from '@/vitest/runs';
@@ -247,6 +248,7 @@ describe('AMR chat-run end-to-end', () => {
           pendingPrompt: null,
           skillId: null,
         },
+        headers: AMR_PERSONAL_WORKSPACE_HEADERS,
       });
       const projectId = project.project.id;
       const conversationId = project.conversationId;
@@ -301,6 +303,6 @@ describe('AMR chat-run end-to-end', () => {
         );
         expect(anyAssistant).toBeTruthy();
       }
-    });
+    }, { amrPersonalWorkspaceAuthority: true });
   }, 180_000);
 });

--- a/e2e/ui/amr-logout-requires-relogin.test.ts
+++ b/e2e/ui/amr-logout-requires-relogin.test.ts
@@ -2,7 +2,7 @@ import { mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { expect, test } from '@/playwright/suite';
+import { expect, test as baseTest } from '@/playwright/suite';
 
 import { writeFakeVelaBin } from '@/amr';
 import { routeAgents } from '@/playwright/mock-factory';
@@ -12,10 +12,20 @@ import {
   gotoProject,
   mockAmrWalletSnapshot,
   openSettingsDialog,
+  PERSONAL_PROJECT_WORKSPACE_HEADERS,
+  providePersonalWorkspaceApi,
   putAppConfig,
   seedBrowserConfig,
   sendPrompt,
+  stubPersonalProjectWorkspaceScope,
 } from '@/playwright/amr';
+
+const test = baseTest.extend<{}, { _fakeWorkspaceApi: void }>({
+  _fakeWorkspaceApi: [
+    async ({}, use) => providePersonalWorkspaceApi(use),
+    { auto: true, scope: 'worker' },
+  ],
+});
 
 test.describe.configure({ timeout: T.xlong });
 
@@ -104,7 +114,10 @@ test('[P0] after local Sign out, AMR runs require re-login and Settings keeps AM
   await putAppConfig(page, config);
 
   const projectId = `amr-logout-${Date.now()}`.replace(/[^A-Za-z0-9._-]/g, '-');
-  await createProjectViaApi(page, projectId, 'AMR logout requires relogin');
+  await createProjectViaApi(page, projectId, 'AMR logout requires relogin', {
+    headers: PERSONAL_PROJECT_WORKSPACE_HEADERS,
+  });
+  await stubPersonalProjectWorkspaceScope(page, projectId);
   await gotoProject(page, projectId);
 
   const settings = await openSettingsDialog(page);

--- a/e2e/ui/amr-logout-requires-relogin.test.ts
+++ b/e2e/ui/amr-logout-requires-relogin.test.ts
@@ -108,19 +108,12 @@ test('[P0] after local Sign out, AMR runs require re-login and Settings keeps AM
   await gotoProject(page, projectId);
 
   const settings = await openSettingsDialog(page);
-  await expect(settings.getByRole('button', { name: /Open Design/i }).first()).toHaveAttribute('aria-pressed', 'true');
-  await expect(settings.getByRole('button', { name: /^Sign out$/i })).toBeVisible();
+  await expect(settings.getByTestId('settings-agent-select-amr')).toHaveAttribute('aria-pressed', 'true');
+  await settings.getByRole('button', { name: /^Sign out$/i }).click();
+  await page.getByRole('alertdialog', { name: 'Sign out' }).getByRole('button', { name: 'Sign out' }).click();
+  await expect.poll(() => loggedIn).toBe(false);
   await page.keyboard.press('Escape');
   await expect(settings).toHaveCount(0);
-  await page.evaluate(async () => {
-    const response = await fetch('/api/integrations/vela/logout', { method: 'POST' });
-    if (!response.ok) throw new Error(`logout failed: ${response.status}`);
-  });
-  const reopenedSettings = await openSettingsDialog(page);
-  await expect(reopenedSettings.getByRole('button', { name: /Open Design/i }).first()).toHaveAttribute('aria-pressed', 'true');
-  await expect(reopenedSettings.getByRole('button', { name: /^Authorize$|^Sign in$/i })).toBeVisible();
-  await page.keyboard.press('Escape');
-  await expect(reopenedSettings).toHaveCount(0);
   const reloginConfig = {
     ...config,
     agentCliEnv: {

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -1,10 +1,12 @@
-import { expect, test } from '@/playwright/suite';
+import { expect, test as baseTest } from '@/playwright/suite';
 import type { Locator, Page } from '@playwright/test';
 
 import {
   dismissPrivacyDialog,
   mockAmrWalletSnapshot,
+  providePersonalWorkspaceApi,
   STORAGE_KEY,
+  stubPersonalWorkspaceContext,
   waitForLoadingToClear,
 } from '@/playwright/amr';
 import { fulfillAgentsRoute } from '@/playwright/mock-factory';
@@ -32,6 +34,13 @@ declare global {
     __amrOnboardingStatusCalls?: number;
   }
 }
+
+const test = baseTest.extend<{}, { _fakeWorkspaceApi: void }>({
+  _fakeWorkspaceApi: [
+    async ({}, use) => providePersonalWorkspaceApi(use),
+    { auto: true, scope: 'worker' },
+  ],
+});
 
 test.describe.configure({ timeout: T.xlong });
 
@@ -406,6 +415,7 @@ test('[P0] @critical onboarding signed-in AMR path finishes setup with the AMR r
 // retired. The preserved coverage: the AMR runtime configured during a
 // signed-in onboarding carries into the first Home run request (agentId 'amr').
 test('[P0] onboarding AMR runtime selection carries into the first Home run request', async ({ page }) => {
+  await stubPersonalWorkspaceContext(page);
   const config = await wireOnboardingMocks(page, {
     amrAvailable: true,
     initialLoggedIn: true,

--- a/e2e/ui/amr-onboarding.test.ts
+++ b/e2e/ui/amr-onboarding.test.ts
@@ -509,7 +509,6 @@ test('[P0] onboarding visited steps become locked again when the Connect runtime
   await expect(connectLandingHeading(page)).toBeVisible();
 
   await page.getByRole('button', { name: /Bring your own key/i }).click();
-  await expect(page.getByText('BYOK')).toBeVisible();
 
   const continueButton = page.getByRole('button', { name: /^Continue$/i });
   await expect(continueButton).toHaveAttribute('aria-disabled', 'true');
@@ -762,8 +761,7 @@ test('[P0] @critical onboarding BYOK path can fetch models, test the provider, a
   await gotoOnboarding(page);
 
   await page.getByRole('button', { name: /Bring your own key/i }).click();
-  await expect(page.getByText('BYOK')).toBeVisible();
-  const byokPanel = page.locator('.onboarding-view__setup-panel').filter({ hasText: /BYOK/ });
+  const byokPanel = onboardingByokPanel(page);
 
   await fillInlineField(page, 'API key', 'test-api-key');
   await fillInlineField(page, 'Base URL', 'https://api.anthropic.com');
@@ -829,8 +827,7 @@ test('[P0] onboarding BYOK path cannot continue before a successful connection t
   await gotoOnboarding(page);
 
   await page.getByRole('button', { name: /Bring your own key/i }).click();
-  await expect(page.getByText('BYOK')).toBeVisible();
-  const byokPanel = page.locator('.onboarding-view__setup-panel').filter({ hasText: /BYOK/ });
+  const byokPanel = onboardingByokPanel(page);
 
   const continueButton = page.getByRole('button', { name: /^Continue$/i });
   await expect(continueButton).toHaveAttribute('aria-disabled', 'true');
@@ -887,7 +884,7 @@ test('[P0] onboarding BYOK path supports Anthropic model selection and API key v
   await expect(apiKeyInput).toHaveAttribute('type', 'text');
 
   await fillInlineField(page, 'Base URL', 'https://api.anthropic.com');
-  const byokPanel = page.locator('.onboarding-view__setup-panel').filter({ hasText: /BYOK/ });
+  const byokPanel = onboardingByokPanel(page);
   await selectOnboardingOption(byokPanel, 'Model', 'claude-sonnet-4-5');
   await page.getByRole('button', { name: /^Test$/i }).click();
   await expectProviderConnectionSuccess(page);
@@ -947,7 +944,7 @@ test('[P0] onboarding BYOK successful test is invalidated when connection settin
   await gotoOnboarding(page);
 
   await page.getByRole('button', { name: /Bring your own key/i }).click();
-  const byokPanel = page.locator('.onboarding-view__setup-panel').filter({ hasText: /BYOK/ });
+  const byokPanel = onboardingByokPanel(page);
   const continueButton = page.getByRole('button', { name: /^Continue$/i });
 
   await fillInlineField(page, 'API key', 'valid-api-key');
@@ -1001,7 +998,7 @@ test('[P0] onboarding BYOK successful test is invalidated when Base URL or model
   await gotoOnboarding(page);
 
   await page.getByRole('button', { name: /Bring your own key/i }).click();
-  const byokPanel = page.locator('.onboarding-view__setup-panel').filter({ hasText: /BYOK/ });
+  const byokPanel = onboardingByokPanel(page);
   const continueButton = page.getByRole('button', { name: /^Continue$/i });
 
   await fillInlineField(page, 'API key', 'valid-api-key');
@@ -1260,6 +1257,12 @@ function connectLandingHeading(page: Page): Locator {
   return page.getByRole('heading', { name: /Sign in to Open Design|登录 Open Design/i });
 }
 
+function onboardingByokPanel(page: Page): Locator {
+  return page.locator('.onboarding-view__setup-panel').filter({
+    has: page.getByRole('tablist', { name: /API protocol/i }),
+  });
+}
+
 async function seedOnboardingConfig(page: Page, config: OnboardingConfig) {
   await page.addInitScript(
     ({ key, value }) => window.localStorage.setItem(key, JSON.stringify(value)),
@@ -1280,7 +1283,7 @@ async function expectOnboardingFinished(page: Page) {
   }
   await expect(page).not.toHaveURL(/\/onboarding$/);
   await dismissPrivacyDialog(page);
-  await expect(page.getByRole('heading', { name: /What will you design with your agent today/i })).toBeVisible();
+  await expect(page.getByTestId('home-hero-input')).toBeVisible();
 }
 
 async function expectFinalDesignSystemStep(page: Page) {

--- a/e2e/ui/amr-run-failure-recovery.test.ts
+++ b/e2e/ui/amr-run-failure-recovery.test.ts
@@ -1,9 +1,11 @@
 import { mkdir } from 'node:fs/promises';
+import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { expect, test } from '@/playwright/suite';
+import { expect, test as baseTest } from '@/playwright/suite';
 import type { Page } from '@playwright/test';
+import type { WorkspaceCollabContext } from '@open-design/contracts';
 
 import { writeFakeVelaBin, seedVelaLoginConfig } from '@/amr';
 import { runErrorCard } from '@/playwright/chat';
@@ -48,6 +50,101 @@ const ANTIGRAVITY_AGENT = {
   version: 'test',
   models: [{ id: 'default', label: 'Default' }],
 };
+const PERSONAL_PROJECT_WORKSPACE_CONTEXT = {
+  workspaceId: 'workspace-personal',
+  workspaceType: 'personal',
+  workspaceMemberId: 'member-personal',
+  role: 'owner',
+  memberStatus: 'active',
+  lifecycleState: 'active',
+  billingState: 'active',
+  planId: null,
+  providerMode: 'platform_credits',
+  seatSummary: {
+    seatLimit: 0,
+    usedSeats: 0,
+    availableSeats: 0,
+    isSeatFull: false,
+  },
+  permissions: {
+    canManageMembers: true,
+    canManageBilling: true,
+    canInviteMembers: true,
+    canManageAutoRecharge: true,
+    canShareProjects: true,
+    canWriteSyncedFiles: true,
+    canViewWorkspaceSettings: true,
+    canManageSharedResources: true,
+  },
+} satisfies WorkspaceCollabContext;
+const PERSONAL_PROJECT_WORKSPACE_HEADERS = {
+  'x-od-workspace-id': PERSONAL_PROJECT_WORKSPACE_CONTEXT.workspaceId,
+  'x-od-workspace-type': PERSONAL_PROJECT_WORKSPACE_CONTEXT.workspaceType,
+  'x-od-workspace-member-id': PERSONAL_PROJECT_WORKSPACE_CONTEXT.workspaceMemberId,
+  'x-od-workspace-role': PERSONAL_PROJECT_WORKSPACE_CONTEXT.role,
+  'x-od-workspace-member-status': PERSONAL_PROJECT_WORKSPACE_CONTEXT.memberStatus,
+  'x-od-workspace-lifecycle-state': PERSONAL_PROJECT_WORKSPACE_CONTEXT.lifecycleState,
+  'x-od-workspace-can-share-projects': String(
+    PERSONAL_PROJECT_WORKSPACE_CONTEXT.permissions.canShareProjects,
+  ),
+  'x-od-workspace-can-write-synced-files': String(
+    PERSONAL_PROJECT_WORKSPACE_CONTEXT.permissions.canWriteSyncedFiles,
+  ),
+};
+
+const test = baseTest.extend<{}, { _fakeWorkspaceApi: void }>({
+  _fakeWorkspaceApi: [
+    async ({}, use) => {
+      const server = createServer((request, response) => {
+        const pathname = new URL(request.url ?? '/', 'http://127.0.0.1').pathname;
+        if (request.method === 'GET' && pathname === '/api/v1/workspaces') {
+          response.statusCode = 200;
+          response.setHeader('content-type', 'application/json');
+          response.end(JSON.stringify({
+            items: [{
+              workspaceId: PERSONAL_PROJECT_WORKSPACE_CONTEXT.workspaceId,
+              workspaceName: 'Personal',
+              workspaceType: PERSONAL_PROJECT_WORKSPACE_CONTEXT.workspaceType,
+              workspaceMemberId: PERSONAL_PROJECT_WORKSPACE_CONTEXT.workspaceMemberId,
+              role: PERSONAL_PROJECT_WORKSPACE_CONTEXT.role,
+              memberStatus: PERSONAL_PROJECT_WORKSPACE_CONTEXT.memberStatus,
+              lifecycleState: PERSONAL_PROJECT_WORKSPACE_CONTEXT.lifecycleState,
+            }],
+          }));
+          return;
+        }
+        response.statusCode = 404;
+        response.end();
+      });
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', resolve);
+      });
+      const address = server.address();
+      if (address == null || typeof address === 'string') {
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+        throw new Error('fake workspace API did not receive a TCP port');
+      }
+      const previousControlKey = process.env.VELA_CONTROL_KEY;
+      const previousApiUrl = process.env.VELA_API_URL;
+      process.env.VELA_CONTROL_KEY = 'fake-control-key';
+      process.env.VELA_API_URL = `http://127.0.0.1:${address.port}`;
+      try {
+        await use();
+      } finally {
+        if (previousControlKey === undefined) delete process.env.VELA_CONTROL_KEY;
+        else process.env.VELA_CONTROL_KEY = previousControlKey;
+        if (previousApiUrl === undefined) delete process.env.VELA_API_URL;
+        else process.env.VELA_API_URL = previousApiUrl;
+        server.closeAllConnections();
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    },
+    { auto: true, scope: 'worker' },
+  ],
+});
 
 async function openExecutionSettingsDialog(page: Page) {
   const settings = await openSettingsDialog(page);
@@ -87,6 +184,22 @@ async function stubRuntimeAgents(page: Page) {
     CLAUDE_AGENT,
     ANTIGRAVITY_AGENT,
   ]);
+}
+
+async function stubPersonalProjectWorkspaceScope(page: Page, projectId: string) {
+  await page.route(`**/api/projects/${projectId}/workspace-scope`, async (route) => {
+    await route.fulfill({
+      json: {
+        scope: {
+          kind: 'personal',
+          projectId,
+          workspaceId: PERSONAL_PROJECT_WORKSPACE_CONTEXT.workspaceId,
+          visibility: 'personal',
+          context: PERSONAL_PROJECT_WORKSPACE_CONTEXT,
+        },
+      },
+    });
+  });
 }
 
 function artifactPreview(page: Page) {
@@ -168,7 +281,7 @@ test('[P0] @critical AMR insufficient-balance failures surface Top up AMR and re
   await expect(page.getByText('AMR balance retry recovered.').first()).toBeVisible({ timeout: T.long });
 });
 
-test('[P0] @critical AMR auth failures offer inline Authorize & retry sign-in and auto-recover', async ({ page }) => {
+test('[P0] @critical AMR auth failures remain retryable after inline sign-in changes identity scope', async ({ page }) => {
   await stubCatalogsEmpty(page);
   await stubRuntimeAgents(page);
   let loggedIn = false;
@@ -217,15 +330,19 @@ test('[P0] @critical AMR auth failures offer inline Authorize & retry sign-in an
   await expect(authorizeAndRetry).toBeVisible({ timeout: T.long });
   await authorizeAndRetry.click();
 
-  // New inline flow: clicking Authorize & retry starts vela login in place (it
-  // POSTs /login directly) instead of bouncing the user out to the Settings
-  // dialog. The run then auto-retries once /status reports signed in.
+  // Clicking Authorize & retry starts vela login inline (without opening
+  // Settings). Resolving anon -> account intentionally resets workspace tabs
+  // to the new identity's Home scope; reopening the project must leave the
+  // failed run recoverable after that security boundary.
   await expect.poll(() => loginRequested, { timeout: T.medium }).toBe(true);
   await expect(settingsSurface(page)).toHaveCount(0);
+  await expect(page.getByTestId('home-hero')).toBeVisible({ timeout: T.long });
+  await gotoProject(page, amr.projectId);
+  await page.getByRole('button', { name: /^Retry$|^重试$|^重試$/i }).first().click();
   await expect(page.getByText('AMR auth auto retry recovered.').first()).toBeVisible({ timeout: T.long });
 });
 
-test('[P0] @critical AMR model catalog invalid-key failures authorize and auto-recover', async ({ page }) => {
+test('[P0] @critical AMR model catalog invalid-key failures remain retryable after authorization', async ({ page }) => {
   await stubCatalogsEmpty(page);
   await stubRuntimeAgents(page);
   let loggedIn = false;
@@ -321,10 +438,13 @@ test('[P0] @critical AMR model catalog invalid-key failures authorize and auto-r
   await authorizeAndRetry.click();
   await expect.poll(() => loginRequested, { timeout: T.medium }).toBe(true);
   await expect(settingsSurface(page)).toHaveCount(0);
+  await expect(page.getByTestId('home-hero')).toBeVisible({ timeout: T.long });
+  await gotoProject(page, projectId);
+  await page.getByRole('button', { name: /^Retry$|^重试$|^重試$/i }).first().click();
   await expect(page.getByText('AMR model catalog auth retry recovered.').first()).toBeVisible({ timeout: T.long });
 });
 
-test('[P0] @critical non-AMR model failures promote Open Design AMR and auto-retry after sign-in', async ({ page }) => {
+test('[P0] @critical non-AMR model failures recover with Open Design AMR after sign-in changes identity scope', async ({ page }) => {
   await stubCatalogsEmpty(page);
   await stubRuntimeAgents(page);
   let loggedIn = false;
@@ -435,6 +555,9 @@ test('[P0] @critical non-AMR model failures promote Open Design AMR and auto-ret
   await settings.getByRole('button', { name: /^(Authorize|Sign in)$/ }).first().click();
 
   await expect.poll(() => loginRequested, { timeout: T.medium }).toBe(true);
+  await expect(page.getByTestId('home-hero')).toBeVisible({ timeout: T.long });
+  await gotoProject(page, projectId);
+  await page.getByRole('button', { name: /^Retry$|^重试$|^重試$/i }).first().click();
   await expect.poll(() => runRequestBodies.some((body) => body.agentId === 'amr'), { timeout: T.long }).toBe(true);
   await expect(page.getByText('AMR promotion retry recovered.').first()).toBeVisible({ timeout: T.long });
 });
@@ -486,8 +609,9 @@ test('[P0] @critical Settings reopens AMR with the configured profile, account b
   const modelPopover = page.getByTestId('settings-agent-model-popover-amr');
   await expect(modelPopover).toBeVisible();
   await expect(modelPopover.getByRole('option', { name: /glm-5/i })).toBeVisible();
-  await settings.getByRole('heading', { name: /Execution/i }).click();
-  await settings.getByRole('button', { name: 'Close', exact: true }).click();
+  await settings.getByTestId('settings-nav-execution').click();
+  await expect(modelPopover).toHaveCount(0);
+  await settings.getByRole('button', { name: /Back to home/i }).click();
   await expect(settingsSurface(page)).toHaveCount(0);
 
   const reopened = await openExecutionSettingsDialog(page);
@@ -643,7 +767,7 @@ test('[P0] @critical Settings preserves AMR account, recharge shortcut, and mode
   let modelPopover = page.getByTestId('settings-agent-model-popover-amr');
   await expect(modelPopover).toBeVisible();
   await expect(modelPopover.getByRole('option', { name: /glm-5/i })).toBeVisible();
-  await settings.getByRole('heading', { name: /Execution/i }).click();
+  await settings.getByTestId('settings-nav-execution').click();
   await expect(modelPopover).toHaveCount(0);
 
   await settings.getByTestId('settings-agent-select-codex').click();
@@ -717,6 +841,7 @@ test('[P0] after an AMR failure the user can switch to Codex and complete a fres
   await page.keyboard.press('Escape');
   await expect(settings).toHaveCount(0);
 
+  await gotoProject(page, amr.projectId);
   await sendPrompt(page, 'Create a deterministic smoke artifact');
   await expect(artifactPreview(page)).toBeVisible({ timeout: 20_000 });
   await expect(
@@ -1012,7 +1137,10 @@ async function setupAmrWorkspace(
   });
   await mkdir(homeDir, { recursive: true });
   if (options.seedLoginConfig !== false) {
-    await seedVelaLoginConfig(homeDir, { email: 'ui-amr@example.com', profile: options.profile ?? 'local' });
+    await seedVelaLoginConfig(homeDir, {
+      email: 'ui-amr@example.com',
+      profile: options.profile ?? 'local',
+    });
   }
 
   const config = {
@@ -1048,6 +1176,12 @@ async function setupAmrWorkspace(
   await putAppConfig(page, config);
 
   const projectId = `amr-ui-${Date.now()}`.replace(/[^A-Za-z0-9._-]/g, '-');
-  const { conversationId } = await createProjectViaApi(page, projectId, 'AMR UI failure smoke');
+  const { conversationId } = await createProjectViaApi(
+    page,
+    projectId,
+    'AMR UI failure smoke',
+    { headers: PERSONAL_PROJECT_WORKSPACE_HEADERS },
+  );
+  await stubPersonalProjectWorkspaceScope(page, projectId);
   return { projectId, conversationId, homeDir, root, velaBin };
 }

--- a/e2e/ui/amr-run-failure-recovery.test.ts
+++ b/e2e/ui/amr-run-failure-recovery.test.ts
@@ -1,11 +1,9 @@
 import { mkdir } from 'node:fs/promises';
-import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { expect, test as baseTest } from '@/playwright/suite';
 import type { Page } from '@playwright/test';
-import type { WorkspaceCollabContext } from '@open-design/contracts';
 
 import { writeFakeVelaBin, seedVelaLoginConfig } from '@/amr';
 import { runErrorCard } from '@/playwright/chat';
@@ -16,12 +14,16 @@ import {
   createProjectViaApi,
   gotoEntryHome,
   gotoProject,
+  mockAmrWalletSnapshot,
   openSettingsDialog,
+  PERSONAL_PROJECT_WORKSPACE_HEADERS,
+  providePersonalWorkspaceApi,
   putAppConfig,
   seedBrowserConfig,
   sendPrompt,
   settingsSurface,
   STORAGE_KEY,
+  stubPersonalProjectWorkspaceScope,
 } from '@/playwright/amr';
 
 let codexRuntime: Awaited<ReturnType<typeof createFakeAgentRuntimes>>['codex'];
@@ -50,98 +52,10 @@ const ANTIGRAVITY_AGENT = {
   version: 'test',
   models: [{ id: 'default', label: 'Default' }],
 };
-const PERSONAL_PROJECT_WORKSPACE_CONTEXT = {
-  workspaceId: 'workspace-personal',
-  workspaceType: 'personal',
-  workspaceMemberId: 'member-personal',
-  role: 'owner',
-  memberStatus: 'active',
-  lifecycleState: 'active',
-  billingState: 'active',
-  planId: null,
-  providerMode: 'platform_credits',
-  seatSummary: {
-    seatLimit: 0,
-    usedSeats: 0,
-    availableSeats: 0,
-    isSeatFull: false,
-  },
-  permissions: {
-    canManageMembers: true,
-    canManageBilling: true,
-    canInviteMembers: true,
-    canManageAutoRecharge: true,
-    canShareProjects: true,
-    canWriteSyncedFiles: true,
-    canViewWorkspaceSettings: true,
-    canManageSharedResources: true,
-  },
-} satisfies WorkspaceCollabContext;
-const PERSONAL_PROJECT_WORKSPACE_HEADERS = {
-  'x-od-workspace-id': PERSONAL_PROJECT_WORKSPACE_CONTEXT.workspaceId,
-  'x-od-workspace-type': PERSONAL_PROJECT_WORKSPACE_CONTEXT.workspaceType,
-  'x-od-workspace-member-id': PERSONAL_PROJECT_WORKSPACE_CONTEXT.workspaceMemberId,
-  'x-od-workspace-role': PERSONAL_PROJECT_WORKSPACE_CONTEXT.role,
-  'x-od-workspace-member-status': PERSONAL_PROJECT_WORKSPACE_CONTEXT.memberStatus,
-  'x-od-workspace-lifecycle-state': PERSONAL_PROJECT_WORKSPACE_CONTEXT.lifecycleState,
-  'x-od-workspace-can-share-projects': String(
-    PERSONAL_PROJECT_WORKSPACE_CONTEXT.permissions.canShareProjects,
-  ),
-  'x-od-workspace-can-write-synced-files': String(
-    PERSONAL_PROJECT_WORKSPACE_CONTEXT.permissions.canWriteSyncedFiles,
-  ),
-};
 
 const test = baseTest.extend<{}, { _fakeWorkspaceApi: void }>({
   _fakeWorkspaceApi: [
-    async ({}, use) => {
-      const server = createServer((request, response) => {
-        const pathname = new URL(request.url ?? '/', 'http://127.0.0.1').pathname;
-        if (request.method === 'GET' && pathname === '/api/v1/workspaces') {
-          response.statusCode = 200;
-          response.setHeader('content-type', 'application/json');
-          response.end(JSON.stringify({
-            items: [{
-              workspaceId: PERSONAL_PROJECT_WORKSPACE_CONTEXT.workspaceId,
-              workspaceName: 'Personal',
-              workspaceType: PERSONAL_PROJECT_WORKSPACE_CONTEXT.workspaceType,
-              workspaceMemberId: PERSONAL_PROJECT_WORKSPACE_CONTEXT.workspaceMemberId,
-              role: PERSONAL_PROJECT_WORKSPACE_CONTEXT.role,
-              memberStatus: PERSONAL_PROJECT_WORKSPACE_CONTEXT.memberStatus,
-              lifecycleState: PERSONAL_PROJECT_WORKSPACE_CONTEXT.lifecycleState,
-            }],
-          }));
-          return;
-        }
-        response.statusCode = 404;
-        response.end();
-      });
-      await new Promise<void>((resolve, reject) => {
-        server.once('error', reject);
-        server.listen(0, '127.0.0.1', resolve);
-      });
-      const address = server.address();
-      if (address == null || typeof address === 'string') {
-        await new Promise<void>((resolve) => server.close(() => resolve()));
-        throw new Error('fake workspace API did not receive a TCP port');
-      }
-      const previousControlKey = process.env.VELA_CONTROL_KEY;
-      const previousApiUrl = process.env.VELA_API_URL;
-      process.env.VELA_CONTROL_KEY = 'fake-control-key';
-      process.env.VELA_API_URL = `http://127.0.0.1:${address.port}`;
-      try {
-        await use();
-      } finally {
-        if (previousControlKey === undefined) delete process.env.VELA_CONTROL_KEY;
-        else process.env.VELA_CONTROL_KEY = previousControlKey;
-        if (previousApiUrl === undefined) delete process.env.VELA_API_URL;
-        else process.env.VELA_API_URL = previousApiUrl;
-        server.closeAllConnections();
-        await new Promise<void>((resolve, reject) => {
-          server.close((error) => (error ? reject(error) : resolve()));
-        });
-      }
-    },
+    async ({}, use) => providePersonalWorkspaceApi(use),
     { auto: true, scope: 'worker' },
   ],
 });
@@ -152,7 +66,6 @@ async function openExecutionSettingsDialog(page: Page) {
   return settings;
 }
 
-test.describe.configure({ mode: 'serial', timeout: T.xlong });
 // Timeout-only configure: each test stubs its own catalogs/agents/status
 // routes and creates its own project, so order independence holds and the
 // file stays splittable across CI shards (a serial group cannot be split).
@@ -186,22 +99,6 @@ async function stubRuntimeAgents(page: Page) {
   ]);
 }
 
-async function stubPersonalProjectWorkspaceScope(page: Page, projectId: string) {
-  await page.route(`**/api/projects/${projectId}/workspace-scope`, async (route) => {
-    await route.fulfill({
-      json: {
-        scope: {
-          kind: 'personal',
-          projectId,
-          workspaceId: PERSONAL_PROJECT_WORKSPACE_CONTEXT.workspaceId,
-          visibility: 'personal',
-          context: PERSONAL_PROJECT_WORKSPACE_CONTEXT,
-        },
-      },
-    });
-  });
-}
-
 function artifactPreview(page: Page) {
   return page.locator(ACTIVE_ARTIFACT_PREVIEW_SELECTOR).first();
 }
@@ -230,6 +127,11 @@ test('[P0] @critical AMR insufficient-balance failures surface Top up AMR and re
         user: { id: 'balance-user', email: 'balance-ui@example.com', plan: 'free' },
       }),
     });
+  });
+  await mockAmrWalletSnapshot(page, {
+    email: 'balance-ui@example.com',
+    plan: 'free',
+    profile,
   });
 
   await page.addInitScript(() => {

--- a/e2e/ui/app-design-files.test.ts
+++ b/e2e/ui/app-design-files.test.ts
@@ -336,16 +336,6 @@ async function selectComposerSessionMode(page: Page, modeTitle: 'Ask mode' | 'Pl
   await expect(trigger).toHaveAttribute('aria-label', `Mode: ${modeName}`);
 }
 
-async function clickDesignFilePreviewOpen(page: Page) {
-  const preview = page.getByTestId('design-file-preview');
-  await expect(preview).toBeVisible();
-  await expect(async () => {
-    const openButton = preview.getByRole('button', { name: /^Open$/ });
-    await expect(openButton).toBeVisible({ timeout: 1_000 });
-    await openButton.click({ timeout: 1_000 });
-  }).toPass({ timeout: T.medium });
-}
-
 async function openDesignFile(page: Page, fileName: string) {
   const preview = page.getByTestId('artifact-preview-frame');
   if (await preview.isVisible()) return;
@@ -357,12 +347,10 @@ async function openDesignFile(page: Page, fileName: string) {
   }
 
   await openAllProjectFiles(page);
-  const fileRow = page.locator('[data-testid^="design-file-row-"]', {
-    hasText: fileName,
-  });
+  const fileRow = page.getByTestId(`design-file-row-${fileName}`);
   await expect(fileRow).toBeVisible();
   await fileRow.getByRole('button').first().click();
-  await clickDesignFilePreviewOpen(page);
+  await expect(fileTab).toHaveAttribute('aria-selected', 'true');
 }
 
 async function waitForLoadingToClear(page: Page) {
@@ -869,12 +857,10 @@ test('[P0] @critical file workspace restores HTML preview after switching throug
   })).toBeVisible();
 
   await openAllProjectFiles(page);
-  const sourceRow = page.locator('[data-testid^="design-file-row-"]', {
-    hasText: 'logic.ts',
-  });
+  await page.getByTestId('design-files-tab-cat:code').click();
+  const sourceRow = page.getByTestId('design-file-row-logic.ts');
   await expect(sourceRow).toBeVisible();
   await sourceRow.getByRole('button').first().click();
-  await clickDesignFilePreviewOpen(page);
   await expect(page.getByRole('tab', { name: /logic\.ts/i })).toHaveAttribute('aria-selected', 'true');
   await expect(page.locator('.code-viewer')).toContainText('riskScore');
 
@@ -931,12 +917,9 @@ async function runDesignFilesTabPersistenceFlow(page: Page) {
     // Depending on restoration timing, inactive files can either be restored as
     // tabs already or remain available from the Design Files list.
     await openAllProjectFiles(page);
-    const secondFileRow = page.locator('[data-testid^="design-file-row-"]', {
-      hasText: 'second-tab.png',
-    });
+    const secondFileRow = page.getByTestId('design-file-row-second-tab.png');
     await expect(secondFileRow).toBeVisible();
     await secondFileRow.getByRole('button').first().click();
-    await clickDesignFilePreviewOpen(page);
   }
 
   await expect(restoredSecondTab).toBeVisible();

--- a/e2e/ui/app-design-files.test.ts
+++ b/e2e/ui/app-design-files.test.ts
@@ -425,9 +425,8 @@ async function runDesignFilesUploadFlow(page: Page) {
 
   await expect(page.getByRole('tab', { name: /moodboard\.png/i })).toBeVisible();
   await openAllProjectFiles(page);
-  const fileRow = page.locator('[data-testid^="design-file-row-"]', {
-    hasText: 'moodboard.png',
-  });
+  await page.getByTestId('design-files-tab-cat:image').click();
+  const fileRow = page.getByTestId('design-file-row-moodboard.png');
   await expect(fileRow).toBeVisible();
   const nameBtn = fileRow.getByRole('button').first();
   await nameBtn.click();
@@ -469,10 +468,9 @@ async function runDesignFilesDeleteFlow(page: Page) {
 
   await expect(page.getByRole('tab', { name: /trash-me\.png/i })).toBeVisible();
   await openAllProjectFiles(page);
+  await page.getByTestId('design-files-tab-cat:image').click();
 
-  const fileRow = page.locator('[data-testid^="design-file-row-"]', {
-    hasText: 'trash-me.png',
-  });
+  const fileRow = page.getByTestId('design-file-row-trash-me.png');
   await expect(fileRow).toBeVisible();
   await fileRow.hover();
   await fileRow.locator('[data-testid^="design-file-menu-"]').click();

--- a/e2e/ui/app-manual-edit.test.ts
+++ b/e2e/ui/app-manual-edit.test.ts
@@ -88,30 +88,30 @@ test('[P0] manual edit inspector previews and persists page and selected element
   await expect(inspectorRow(page, 'Font').locator('select')).toHaveValue('Georgia, serif');
   await expect(inspectorRow(page, 'Base size').locator('input')).toHaveValue('18');
 
-  await selectPreviewElementThroughBridge(page, frame, '[data-od-id="hero-title"]', 'TYPOGRAPHY');
+  await selectPreviewElementThroughBridge(page, frame, '[data-od-id="hero-title"]', 'Parameters');
   const selectedTitleMarker = frame.locator('[data-od-id="hero-title"][data-od-edit-selected="true"]');
   await expect(selectedTitleMarker).toHaveCount(1);
-  const fontSizeInput = inspectorSection(page, 'TYPOGRAPHY').locator('.cc-row').filter({ hasText: 'Size' }).locator('input');
+  const fontSizeInput = inspectorSection(page, 'Parameters').locator('.cc-row').filter({ hasText: 'Font size' }).locator('input');
   await fontSizeInput.click();
   await expect(selectedTitleMarker).toHaveCount(1);
   await expect(fontSizeInput).not.toHaveValue('');
   await expect(fontSizeInput).not.toHaveValue(/px/i);
-  await expect(inspectorSection(page, 'TYPOGRAPHY').locator('.cc-row').filter({ hasText: 'Color' }).locator('input')).toHaveValue(/^#[0-9a-f]{6}$/);
-  const lineInput = inspectorSection(page, 'TYPOGRAPHY').locator('.cc-row').filter({ hasText: 'Line' }).locator('input');
+  await expect(inspectorSection(page, 'Parameters').locator('.cc-row').filter({ hasText: 'Text color' }).locator('input')).toHaveValue(/^#[0-9a-f]{6}$/);
+  const lineInput = inspectorSection(page, 'Parameters').locator('.cc-row').filter({ hasText: 'Line height' }).locator('input');
   await lineInput.click();
   await lineInput.blur();
   await expect(page.locator('.manual-edit-error')).toHaveCount(0);
   await frame.locator('body').evaluate(() => {
     window.parent.postMessage({ type: 'od-edit-targets', targets: [] }, '*');
   });
-  await expect(page.locator('.manual-edit-modal')).toContainText('TYPOGRAPHY');
+  await expect(page.locator('.manual-edit-modal')).toContainText('Parameters');
   await expect(page.locator('.manual-edit-modal')).not.toContainText('PAGE');
   await frame.locator('body').evaluate(() => {
     (window as Window & typeof globalThis & { __manualEditSmokeMarker?: string }).__manualEditSmokeMarker = 'stable-frame';
   });
 
   await fontSizeInput.fill('48');
-  await inspectorSection(page, 'TYPOGRAPHY').locator('.cc-row').filter({ hasText: 'Color' }).locator('input').fill('#ef4444');
+  await inspectorSection(page, 'Parameters').locator('.cc-row').filter({ hasText: 'Text color' }).locator('input').fill('#ef4444');
   await expect(fontSizeInput).toHaveValue('48');
 
   const title = frame.getByRole('heading', { name: 'Original Hero' });
@@ -141,8 +141,8 @@ test('[P0] manual edit mode preserves preview actions after style edits', async 
   await expect(frame.getByRole('heading', { name: 'Original Hero' })).toBeVisible();
 
   await page.getByTestId('manual-edit-mode-toggle').click();
-  await selectPreviewElementThroughBridge(page, frame, '[data-od-id="hero-title"]', 'TYPOGRAPHY');
-  const fontSizeInput = await selectStyleRowInput(page, frame, '[data-od-id="hero-title"]', 'TYPOGRAPHY', 'Size');
+  await selectPreviewElementThroughBridge(page, frame, '[data-od-id="hero-title"]', 'Parameters');
+  const fontSizeInput = await selectStyleRowInput(page, frame, '[data-od-id="hero-title"]', 'Parameters', 'Font size');
   await fontSizeInput.fill('48');
   await inspectSaveButton(page).click({ force: true });
   await expectFileSource(page, projectId, 'manual-edit.html', ['font-size: 48px']);
@@ -252,13 +252,15 @@ test('[P0] @critical preview toolbar keeps share, download, comment, and zoom ac
   await openDesignFile(page, 'toolbar-preview.html');
 
   await expect(page.getByTestId('artifact-preview-frame')).toBeVisible();
-  await expect(page.getByRole('tablist', { name: 'View mode' })).toHaveCount(0);
+  const viewMode = page.getByRole('tablist', { name: 'View mode' });
+  await expect(viewMode).toBeVisible();
+  await expect(viewMode.getByRole('tab', { name: 'Preview' })).toHaveAttribute('aria-selected', 'true');
 
   await page.getByRole('button', { name: /^Share$/ }).click();
   const shareMenu = page.locator('.share-menu-popover[role="menu"]');
   await expect(shareMenu).toBeVisible();
   await expect(shareMenu.getByRole('tab', { name: /^Share$/ })).toHaveAttribute('aria-selected', 'true');
-  await expect(shareMenu).toContainText(/Share project in workspace|Publish this file/i);
+  await expect(shareMenu.getByRole('tab', { name: /^Send to\.\.\.$/ })).toBeVisible();
   await shareMenu.getByRole('tab', { name: /^Export$/ }).click();
   await expect(shareMenu.getByRole('menuitem', { name: /Export as PDF/i })).toBeVisible();
   await page.keyboard.press('Escape');
@@ -464,9 +466,9 @@ test('[P1] HTML preview toolbar exposes screenshot, comments, mark, and edit wor
 
   await page.getByTestId('manual-edit-mode-toggle').click();
   await expect(page.getByTestId('manual-edit-mode-toggle')).toHaveAttribute('aria-pressed', 'true');
-  await selectPreviewElementThroughBridge(page, artifactPreviewFrame(page), '[data-od-id="hero-title"]', 'TYPOGRAPHY');
+  await selectPreviewElementThroughBridge(page, artifactPreviewFrame(page), '[data-od-id="hero-title"]', 'Parameters');
   await expect(page.locator('.manual-edit-modal')).toContainText('Hero title');
-  await expect(page.locator('.manual-edit-modal')).toContainText('TYPOGRAPHY');
+  await expect(page.locator('.manual-edit-modal')).toContainText('Parameters');
   await expect(page.getByRole('button', { name: /^Save$/ })).toBeVisible();
 });
 
@@ -681,7 +683,7 @@ async function selectStyleRowInput(
       },
     }, '*');
   });
-  await expect(page.locator('.manual-edit-modal')).toContainText('TYPOGRAPHY');
+  await expect(page.locator('.manual-edit-modal')).toContainText(section);
   const row = inspectorSection(page, section).locator('.cc-row').filter({ hasText: label }).locator('input');
   await expect(row).toBeVisible();
   return row;
@@ -880,7 +882,9 @@ test('[P0] simple deck keeps the active slide stable in preview-only mode', asyn
   await clickDeckNextSlide(page);
   await expect(frame.getByText('Slide Two')).toBeVisible();
 
-  await expect(page.getByRole('tablist', { name: 'View mode' })).toHaveCount(0);
+  const viewMode = page.getByRole('tablist', { name: 'View mode' });
+  await expect(viewMode).toBeVisible();
+  await expect(viewMode.getByRole('tab', { name: 'Preview' })).toHaveAttribute('aria-selected', 'true');
   await expect(frame.getByText('Slide Two')).toBeVisible();
   await clickDeckNextSlide(page);
   await expect(frame.getByText('Slide Three')).toBeVisible();
@@ -928,7 +932,7 @@ test('[P1] deck thumbnail rail keeps complete 16:9 slides separated and aligned'
   );
 });
 
-test('[P0] @critical HTML viewer stays rendered without a code toggle', async ({ page }) => {
+test('[P0] @critical HTML viewer stays rendered with Preview selected', async ({ page }) => {
   await routeMockAgents(page);
   const projectId = await createEmptyProject(page, 'HTML preview toggle regression');
   await seedHtmlArtifact(
@@ -946,7 +950,9 @@ test('[P0] @critical HTML viewer stays rendered without a code toggle', async ({
     artifactPreviewFrame(page).getByRole('heading', { name: 'Toggle Preview Stable' }),
   ).toBeVisible();
 
-  await expect(page.getByRole('tablist', { name: 'View mode' })).toHaveCount(0);
+  const viewMode = page.getByRole('tablist', { name: 'View mode' });
+  await expect(viewMode).toBeVisible();
+  await expect(viewMode.getByRole('tab', { name: 'Preview' })).toHaveAttribute('aria-selected', 'true');
   await expect(page.locator('.viewer-source')).toHaveCount(0);
   await expect(previewFrame).toBeVisible();
   await expect(
@@ -984,16 +990,19 @@ test('[P0] @critical edited HTML file restores selected tab and preview after re
   const frame = artifactPreviewFrame(page);
   await expect(frame.getByRole('heading', { name: 'Original Hero' })).toBeVisible();
   await page.getByTestId('manual-edit-mode-toggle').click();
-  await selectPreviewElementThroughBridge(page, frame, '[data-od-id="hero-title"]', 'TYPOGRAPHY');
-  const fontSizeInput = inspectorSection(page, 'TYPOGRAPHY').locator('.cc-row').filter({ hasText: 'Size' }).locator('input');
+  await selectPreviewElementThroughBridge(page, frame, '[data-od-id="hero-title"]', 'Parameters');
+  const fontSizeInput = inspectorSection(page, 'Parameters').locator('.cc-row').filter({ hasText: 'Font size' }).locator('input');
   await expect(fontSizeInput).toBeVisible();
   await fontSizeInput.fill('52');
-  await inspectorSection(page, 'TYPOGRAPHY').locator('.cc-row').filter({ hasText: 'Color' }).locator('input').fill('#2563eb');
+  await inspectorSection(page, 'Parameters').locator('.cc-row').filter({ hasText: 'Text color' }).locator('input').fill('#2563eb');
   await inspectSaveButton(page).click({ force: true });
   await expectFileSource(page, projectId, 'restore-edit.html', ['font-size: 52px', 'color:']);
 
   await page.getByTestId('manual-edit-mode-toggle').click();
-  await expect(page.getByRole('tablist', { name: 'View mode' })).toHaveCount(0);
+  await expect(page.getByRole('tablist', { name: 'View mode' }).getByRole('tab', { name: 'Preview' })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
   await expect(page.locator('.viewer-source')).toHaveCount(0);
   await expect(restoreTab).toHaveAttribute('aria-selected', 'true');
   await expect(secondaryTab).toHaveAttribute('aria-selected', 'false');
@@ -1004,7 +1013,10 @@ test('[P0] @critical edited HTML file restores selected tab and preview after re
   const restoredTab = tabBySuffix(page, 'restore-edit.html');
   await expect(restoredTab).toBeVisible();
   await expect(restoredTab).toHaveAttribute('aria-selected', 'true');
-  await expect(page.getByRole('tablist', { name: 'View mode' })).toHaveCount(0);
+  await expect(page.getByRole('tablist', { name: 'View mode' }).getByRole('tab', { name: 'Preview' })).toHaveAttribute(
+    'aria-selected',
+    'true',
+  );
   await expect(page.locator('.viewer-source')).toHaveCount(0);
   await expect(artifactPreview(page)).toBeVisible();
   const restoredFrame = artifactPreviewFrame(page);
@@ -1312,32 +1324,24 @@ async function openDesignFile(page: Page, fileName: string) {
     await expect(preview).toBeVisible();
     return;
   }
-  const filePattern = new RegExp(fileName.replace(/\./g, '\\.'), 'i');
+  const filePattern = new RegExp(escapeRegExp(fileName), 'i');
   const fileTabButton = page.getByRole('tab', { name: filePattern }).first();
-  let tabFound = true;
-  try {
-    await fileTabButton.waitFor({ state: 'visible', timeout: 5_000 });
-  } catch {
-    tabFound = false;
-  }
-
-  if (tabFound) {
+  const fileTabVisible = await fileTabButton
+    .waitFor({ state: 'visible', timeout: T.short })
+    .then(() => true)
+    .catch(() => false);
+  if (fileTabVisible) {
     const isSelected = await fileTabButton.getAttribute('aria-selected');
     if (isSelected !== 'true') {
       await fileTabButton.click();
     }
   } else {
-    const fileButton = page.getByRole('button', { name: filePattern }).first();
-    await fileButton.click();
-    if (!(await preview.isVisible().catch(() => false))) {
-      const openButton = page.getByTestId('design-file-preview').getByRole('button', { name: 'Open' });
-      if (await openButton.isVisible().catch(() => false)) {
-        await openButton.click();
-      } else {
-        await fileButton.dblclick();
-      }
-    }
+    await openAllProjectFiles(page);
+    const fileRow = page.getByTestId(`design-file-row-${fileName}`);
+    await expect(fileRow).toBeVisible();
+    await fileRow.getByRole('button').first().click();
   }
+  await expect(fileTabButton).toHaveAttribute('aria-selected', 'true');
   await expect(preview).toBeVisible();
 }
 

--- a/e2e/ui/app-restoration.test.ts
+++ b/e2e/ui/app-restoration.test.ts
@@ -159,7 +159,8 @@ test('[P0] @critical workspace restores the last manually selected file tab afte
   const restoredArtifactTab = page.getByRole('tab', { name: /workspace-artifact\.html/i });
   if ((await restoredArtifactTab.count()) === 0) {
     const turnCard = page.locator('.msg.assistant').filter({ hasText: 'workspace-artifact.html' }).first();
-    const openButton = turnCard.getByRole('button', { name: /^Open$/ });
+    const artifactRow = turnCard.locator('.produced-file', { hasText: 'workspace-artifact.html' });
+    const openButton = artifactRow.getByRole('button', { name: /^Open$/ });
     await expect(openButton).toBeVisible();
     await openButton.click();
 
@@ -213,7 +214,6 @@ test('[P0] switching between projects restores each project workspace to its las
     buffer: pngBytes,
   });
   await expect((await alphaPrimaryUpload).ok()).toBeTruthy();
-  await expect(tabBySuffix(page, 'alpha-primary.png')).toBeVisible();
   const alphaSecondaryUpload = page.waitForResponse(
     (resp: Response) => resp.url().includes('/upload') && resp.request().method() === 'POST',
     { timeout: 5000 },
@@ -233,7 +233,7 @@ test('[P0] switching between projects restores each project workspace to its las
   await expect(alphaPrimaryTab).toHaveAttribute('aria-selected', 'true');
   await expect(alphaSecondaryTab).toHaveAttribute('aria-selected', 'false');
 
-  await page.getByRole('button', { name: /back to projects/i }).click();
+  await gotoEntryHome(page);
   await expectProjectsView(page);
 
   await createPrototypeProject(page, betaName);
@@ -249,7 +249,6 @@ test('[P0] switching between projects restores each project workspace to its las
     buffer: pngBytes,
   });
   await expect((await betaPrimaryUpload).ok()).toBeTruthy();
-  await expect(tabBySuffix(page, 'beta-primary.png')).toBeVisible();
   const betaSecondaryUpload = page.waitForResponse(
     (resp: Response) => resp.url().includes('/upload') && resp.request().method() === 'POST',
     { timeout: 5000 },
@@ -316,13 +315,10 @@ test('[P0] @critical visiting an uploaded design file route restores its tab and
   expect(uploadedName).toBeTruthy();
 
   await openAllProjectFiles(page);
-  const fileRow = page.locator('[data-testid^="design-file-row-"]', {
-    hasText: 'deep-linked-reference.png',
-  });
+  const fileRow = designFileRow(page, 'deep-linked-reference.png');
   await expect(fileRow).toBeVisible();
   await fileRow.getByRole('button').first().click();
-  await expect(page.getByTestId('design-file-preview')).toBeVisible();
-  await expect(page.getByTestId('design-file-preview').getByText(/deep-linked-reference\.png/i)).toBeVisible();
+  await expect(fileTab).toHaveAttribute('aria-selected', 'true');
 
   const current = new URL(page.url());
   const [, projects, projectId] = current.pathname.split('/');
@@ -374,12 +370,10 @@ test('[P0] returning from an uploaded design file route to the project root keep
   expect(uploadedName).toBeTruthy();
 
   await openAllProjectFiles(page);
-  const fileRow = page.locator('[data-testid^="design-file-row-"]', {
-    hasText: 'root-design-reference.png',
-  });
+  const fileRow = designFileRow(page, 'root-design-reference.png');
   await expect(fileRow).toBeVisible();
   await fileRow.getByRole('button').first().click();
-  await expect(page.getByTestId('design-file-preview')).toBeVisible();
+  await expect(fileTab).toHaveAttribute('aria-selected', 'true');
 
   const current = new URL(page.url());
   const [, projects, projectId] = current.pathname.split('/');
@@ -1751,17 +1745,8 @@ test('[P0] reloading a project keeps the Design Files entry reachable when it wa
   await openAllProjectFiles(page);
   await expectAllProjectFilesActive(page);
 
-  const fileRow = page.locator('[data-testid^="design-file-row-"]', {
-    hasText: 'restore-me.png',
-  });
+  const fileRow = designFileRow(page, 'restore-me.png');
   await expect(fileRow).toBeVisible();
-  const rowButton = fileRow.getByRole('button').first();
-  await rowButton.click();
-  await expect(
-    page.locator('[data-testid^="design-file-row-"]', {
-      hasText: 'restore-me.png',
-    }),
-  ).toBeVisible();
 
   await page.reload();
   await expect(page.getByTestId('file-workspace')).toBeVisible({ timeout: 20_000 });
@@ -1836,13 +1821,14 @@ test('[P0] @critical daemon error details persist between failed sends', async (
     'error-cross-tab.html',
     '<!doctype html><html><body><h1>Error cross tab</h1></body></html>',
   );
+  // The seed writes behind the browser registry, so reload before asserting
+  // the Design Files surface rather than reusing its just-settled empty list.
+  await page.reload();
+  await expectWorkspaceReady(page);
   await openAllProjectFiles(page);
-  const crossFileRow = page.locator('[data-testid^="design-file-row-"]', {
-    hasText: 'error-cross-tab.html',
-  });
+  const crossFileRow = designFileRow(page, 'error-cross-tab.html');
   await expect(crossFileRow).toBeVisible();
   await crossFileRow.getByRole('button').first().click();
-  await clickDesignFilePreviewOpen(page);
   await expect(page.getByRole('tab', { name: /error-cross-tab\.html/i })).toHaveAttribute('aria-selected', 'true');
   await expect(artifactPreviewFrame(page).getByRole('heading', { name: 'Error cross tab' })).toBeVisible();
 
@@ -3334,7 +3320,7 @@ test('[P1] project composer working directory replace and clear update linked di
 
   await page.getByTestId('working-dir-trigger').click();
   await page.getByTestId('working-dir-clear').click();
-  await expect(page.getByTestId('working-dir-trigger')).toContainText('Select working directory');
+  await expect(page.getByTestId('working-dir-trigger')).toContainText('Working directory');
   await expect
     .poll(() => patchBodies.at(-1)?.metadata)
     .toMatchObject({ linkedDirs: [] });
@@ -3389,7 +3375,7 @@ test('[P1] project composer working directory rejects stale folder without promo
   await page.getByTestId('working-dir-trigger').click();
   await page.getByTestId('working-dir-pick').click();
 
-  await expect(page.getByTestId('working-dir-trigger')).toContainText('Select working directory');
+  await expect(page.getByTestId('working-dir-trigger')).toContainText('Working directory');
   await expect(page.getByText("Couldn't set the working directory")).toBeVisible();
   await expect
     .poll(() => patchBodies.at(-1)?.metadata)
@@ -3616,10 +3602,26 @@ async function sendPrompt(page: Page, prompt: string) {
 }
 
 async function startNewConversation(page: Page) {
+  const previousConversationId = routedConversationId(page);
   await page.getByTestId('conversation-history-trigger').click();
   await expect(page.getByTestId('conversation-list')).toBeVisible();
   await page.getByTestId('conversation-history-new').click();
   await expect(page.getByTestId('conversation-list')).toHaveCount(0);
+  await expect
+    .poll(() => {
+      const nextConversationId = routedConversationId(page);
+      return nextConversationId && nextConversationId !== previousConversationId
+        ? nextConversationId
+        : null;
+    })
+    .not.toBeNull();
+}
+
+function routedConversationId(page: Page): string | null {
+  const [, projects, , maybeConversations, conversationId] = new URL(page.url()).pathname.split('/');
+  return projects === 'projects' && maybeConversations === 'conversations' && conversationId
+    ? conversationId
+    : null;
 }
 
 function tabBySuffix(page: Page, name: string): Locator {
@@ -3627,6 +3629,10 @@ function tabBySuffix(page: Page, name: string): Locator {
     .locator('.ws-tab[role="tab"]')
     .filter({ has: page.locator('.ws-tab-label', { hasText: name }) })
     .first();
+}
+
+function designFileRow(page: Page, name: string): Locator {
+  return page.getByTestId(`design-file-row-${name}`);
 }
 
 async function ensureFileTabOpen(page: Page, name: string): Promise<Locator> {
@@ -4187,9 +4193,7 @@ async function runDesignFilesUploadFlow(
 
   await expect(page.getByRole('tab', { name: /moodboard\.png/i })).toBeVisible();
   await openAllProjectFiles(page);
-  const fileRow = page.locator('[data-testid^="design-file-row-"]', {
-    hasText: 'moodboard.png',
-  });
+  const fileRow = designFileRow(page, 'moodboard.png');
   await expect(fileRow).toBeVisible();
   const nameBtn = fileRow.getByRole('button').first();
   await nameBtn.click();
@@ -4232,9 +4236,7 @@ async function runDesignFilesDeleteFlow(
   await expect(page.getByRole('tab', { name: /trash-me\.png/i })).toBeVisible();
   await openAllProjectFiles(page);
 
-  const fileRow = page.locator('[data-testid^="design-file-row-"]', {
-    hasText: 'trash-me.png',
-  });
+  const fileRow = designFileRow(page, 'trash-me.png');
   await expect(fileRow).toBeVisible();
   await fileRow.hover();
   await fileRow.locator('[data-testid^="design-file-menu-"]').click();

--- a/e2e/ui/critical-smoke.test.ts
+++ b/e2e/ui/critical-smoke.test.ts
@@ -31,10 +31,10 @@ test('[P0] @critical home loads with the primary entry controls', async ({ page 
 test('[P0] @critical settings dialog is reachable from home', async ({ page }) => {
   await gotoEntryHome(page);
 
-  // Settings moved into the rail footer; collapsed, the rail is `inert` and the
-  // chip cannot be clicked, so expand first.
+  // Settings moved into the rail; collapsed, the rail is `inert`, so expand
+  // it before interacting with the settings entry.
   await ensureRailOpen(page);
-  await clickVisible(page.getByTestId('entry-settings-button'));
+  await clickVisible(page.getByTestId('entry-nav-settings'));
   // From the entry, settings is now a routed page (`role="region"`), not a
   // modal — `.modal-settings` is the class both presentations share.
   const settingsDialog = settingsSurface(page);

--- a/e2e/ui/entry-chrome-flows.test.ts
+++ b/e2e/ui/entry-chrome-flows.test.ts
@@ -167,7 +167,7 @@ test('[P0] @critical entry chrome exposes the primary home creation surface and 
   // entry layout.
   await expect(page.locator('.pet-rail')).toHaveCount(0);
 
-  await page.getByTestId('entry-settings-button').click();
+  await page.getByTestId('entry-nav-settings').click();
   // From the entry, settings routes to a page surface rather than a modal.
   const settingsDialog = settingsSurface(page);
   await expect(settingsDialog).toBeVisible();
@@ -341,10 +341,11 @@ test('[P1] entry top navigation matches the current home tab structure', async (
   await expect(page.getByTestId('entry-nav-projects')).toHaveCount(0);
   await expect(page.getByTestId('entry-nav-tasks')).toHaveCount(0);
   await expect(page.getByTestId('entry-nav-integrations')).toHaveCount(0);
-  // Settings is the rail's own control (footer chip when signed out), never a
-  // duplicate of the nav group's destinations.
+  // Settings is the rail's own signed-out control, never a duplicate of the
+  // footer or another destination.
   await expect(page.locator('.entry-nav-rail__footer').getByTestId('entry-nav-plugins')).toHaveCount(0);
-  await expect(page.locator('.entry-nav-rail__footer').getByTestId('entry-settings-button')).toBeVisible();
+  await expect(page.locator('.entry-nav-rail__footer').getByTestId('entry-nav-settings')).toHaveCount(0);
+  await expect(page.getByTestId('entry-nav-settings')).toBeVisible();
 
   await expect(page.getByTestId('home-hero-template-picker')).toBeVisible();
   // Nothing is applied on a fresh Home: no template pill reset, no plugin
@@ -798,9 +799,9 @@ test('[P2] home topbar overlays close on outside click, Escape, and Settings ope
   await pill.click();
   await expect(executionPopover).toBeVisible();
 
-  // Settings lives in the rail footer now, and the collapsed rail is `inert`.
+  // Settings lives in the rail, and the collapsed rail is `inert`.
   await ensureRailOpen(page);
-  await page.getByTestId('entry-settings-button').click();
+  await page.getByTestId('entry-nav-settings').click();
   await expect(executionPopover).toHaveCount(0);
   await expect(settingsSurface(page)).toBeVisible();
   await page.keyboard.press('Escape');
@@ -1956,7 +1957,7 @@ test('[P2] required home plugin prompt parameters gate submit and bind the proje
 test('[P0] @critical home composer routes free-form prompts through the design router by default', async ({ page }) => {
   await gotoEntryHome(page);
 
-  await expect(page.getByTestId('composer-mode-trigger')).toHaveAttribute('aria-label', 'Choose a mode');
+  await expect(page.getByTestId('composer-mode-trigger')).toHaveAttribute('aria-label', 'Mode: Design');
 
   const input = page.getByTestId('home-hero-input');
   const prompt =
@@ -2058,7 +2059,7 @@ test('[P0] @critical clearing the home working directory removes linked dirs fro
 
   await page.getByTestId('working-dir-trigger').click();
   await page.getByTestId('working-dir-clear').click();
-  await expect(page.getByTestId('working-dir-trigger')).toContainText('Select working directory');
+  await expect(page.getByTestId('working-dir-trigger')).toContainText('Working directory');
 
   await page.getByTestId('home-hero-input').fill('Create a premium dashboard without local folder context.');
 

--- a/e2e/ui/entry-topbar.test.ts
+++ b/e2e/ui/entry-topbar.test.ts
@@ -104,7 +104,7 @@ test.beforeEach(async ({ page }) => {
 //   • GitHub star badge  — `GithubStarBadge` is no longer rendered anywhere
 //   • Discord badge      — removed
 //   • "Use everywhere"   — removed; the guide keeps its Integrations tab
-//   • Settings button    — moved into the (collapsed-by-default) rail footer
+//   • Settings button    — moved into the collapsed-by-default rail
 //   • Execution pill     — moved into the Home composer footer
 // The chip/link inventory and external-link-contract specs are therefore gone;
 // what remains below pins the two controls that survived, at their new homes.
@@ -116,7 +116,7 @@ test('[P2] home chrome exposes the composer execution pill and the rail settings
   await expect(page.getByTestId('inline-model-switcher-chip')).toBeVisible();
 
   await ensureRailOpen(page);
-  await expect(page.getByTestId('entry-settings-button')).toBeVisible();
+  await expect(page.getByTestId('entry-nav-settings')).toBeVisible();
 });
 
 test('[P1] home execution pill reflects the selected Local CLI agent and opens the switcher', async ({ page }) => {
@@ -151,10 +151,10 @@ test('[P1] rail settings entry opens settings and closes the execution popover',
   await pill.click();
   await expect(popover).toBeVisible();
 
-  // The settings chip lives in the rail footer now, so the rail has to be
+  // The settings entry lives in the rail, so the rail has to be
   // expanded before it is interactive (collapsed the rail is `inert`).
   await ensureRailOpen(page);
-  await page.getByTestId('entry-settings-button').click();
+  await page.getByTestId('entry-nav-settings').click();
   await expect(settingsSurface(page)).toBeVisible();
   await expect(popover).toHaveCount(0);
 });

--- a/e2e/ui/project-management-flows.test.ts
+++ b/e2e/ui/project-management-flows.test.ts
@@ -468,7 +468,7 @@ test('[P2] project detail header keeps the title and execution controls aligned 
   await expect(title).toBeVisible();
   await expect(settingsButton).toBeVisible();
   await expect(handoffButton).toBeVisible();
-  await expect(page.getByTestId('chat-composer').getByTestId('project-ds-picker-trigger')).toBeVisible();
+  await expect(page.getByTestId('chat-composer').getByTestId('composer-design-system-trigger')).toBeVisible();
 
   const [titleBox, settingsBox, handoffBox] = await Promise.all([
     title.boundingBox(),
@@ -493,7 +493,7 @@ test('[P1] project detail header design system picker switches the active projec
   await createProject(page, 'Header design system switch');
   await expectWorkspaceReady(page);
 
-  const trigger = page.getByTestId('project-ds-picker-trigger');
+  const trigger = page.getByTestId('composer-design-system-trigger');
   await expect(trigger).toContainText(/design system/i);
 
   await trigger.click();
@@ -549,7 +549,7 @@ test('[P0] @critical project detail header design system switch carries into the
   await createProject(page, 'Header design system run context');
   await expectWorkspaceReady(page);
 
-  const trigger = page.getByTestId('project-ds-picker-trigger');
+  const trigger = page.getByTestId('composer-design-system-trigger');
   await trigger.click();
   await page.getByTestId('project-ds-picker-search').fill('editorial');
   const editorialOption = page.getByRole('option', { name: /^Editorial Noir$/ });
@@ -581,7 +581,7 @@ test('[P1] project detail design system picker stays inside the composer control
   await expectWorkspaceReady(page);
 
   const composer = page.getByTestId('chat-composer');
-  await expect(composer.getByTestId('project-ds-picker-trigger')).toBeVisible();
+  await expect(composer.getByTestId('composer-design-system-trigger')).toBeVisible();
 });
 
 test('[P1] project detail composer working directory picker opens without leaving chat', async ({ page }) => {
@@ -1541,7 +1541,7 @@ test('[P0] clearing the project design system removes designSystemId from the ne
   await createProject(page, 'Header design system clear run context');
   await expectWorkspaceReady(page);
 
-  const trigger = page.getByTestId('project-ds-picker-trigger');
+  const trigger = page.getByTestId('composer-design-system-trigger');
   await trigger.click();
   await page.getByTestId('project-ds-picker-search').fill('editorial');
   const editorialOption = page.getByRole('option', { name: /^Editorial Noir$/ });
@@ -1728,11 +1728,14 @@ test('[P1] project detail workspace keeps design file tabs and preview controls 
   const fileTab = tabBySuffix(page, uploadedName);
   await expect(fileTab).toBeVisible();
   await expect(fileTab).toHaveAttribute('aria-selected', 'true');
-  await expect(page.getByTestId('workspace-pages-menu-trigger')).toBeVisible();
+  await expect(page.getByRole('tablist', { name: 'Pages' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'New tab' })).toBeVisible();
 
   await openUploadedHtmlArtifactPreview(page, uploadedName);
 
-  await expect(page.getByRole('tablist', { name: 'View mode' })).toHaveCount(0);
+  const viewMode = page.getByRole('tablist', { name: 'View mode' });
+  await expect(viewMode).toBeVisible();
+  await expect(viewMode.getByRole('tab', { name: 'Preview' })).toHaveAttribute('aria-selected', 'true');
   await expect(artifactPreview(page)).toBeVisible();
   await expect(
     artifactPreviewFrame(page).getByRole('heading', { name: 'Workspace Preview Structure' }),
@@ -3348,9 +3351,8 @@ async function openUploadedHtmlArtifactPreview(page: Page, uploadedName: string)
   const fileRow = rowByFileName(page, uploadedName);
   await expect(fileRow).toBeVisible();
   await fileRow.getByRole('button').first().click();
-  const previewCard = page.getByTestId('design-file-preview');
-  await expect(previewCard).toBeVisible();
-  await previewCard.getByRole('button', { name: 'Open' }).click();
+  await expect(tabBySuffix(page, uploadedName)).toHaveAttribute('aria-selected', 'true');
+  await expect(artifactPreview(page)).toBeVisible();
 }
 
 function tabBySuffix(page: Page, name: string): Locator {

--- a/e2e/ui/real-daemon-run.test.ts
+++ b/e2e/ui/real-daemon-run.test.ts
@@ -552,7 +552,7 @@ test('[P0] separate projects keep daemon artifacts isolated across recent-projec
   const alpha = await currentProjectContext(page);
   await expectProjectFilesToContain(page, alpha.projectId, [GENERATED_FILE]);
 
-  await page.getByRole('button', { name: /back to projects/i }).click();
+  await gotoEntryHome(page);
 
   await createProject(page, 'Real daemon isolation beta');
   await expectWorkspaceReady(page);
@@ -561,14 +561,14 @@ test('[P0] separate projects keep daemon artifacts isolated across recent-projec
   await expectProjectFilesToContain(page, beta.projectId, [FOLLOW_UP_FILE]);
   expect(beta.projectId).not.toBe(alpha.projectId);
 
-  await page.getByRole('button', { name: /back to projects/i }).click();
+  await gotoEntryHome(page);
   await openProjectFromProjectsView(page, alpha.projectId);
   await expectWorkspaceReady(page);
   await expect(page.getByTestId('file-workspace').getByText(GENERATED_FILE, { exact: true })).toBeVisible();
   await expect(page.getByText(FOLLOW_UP_FILE, { exact: true })).toHaveCount(0);
   expect((await listProjectFiles(page, alpha.projectId)).map((file) => file.name)).toEqual([GENERATED_FILE]);
 
-  await page.getByRole('button', { name: /back to projects/i }).click();
+  await gotoEntryHome(page);
   await openProjectFromProjectsView(page, beta.projectId);
   await expectWorkspaceReady(page);
   await expect(page.getByTestId('file-workspace').getByText(FOLLOW_UP_FILE, { exact: true })).toBeVisible();

--- a/e2e/ui/settings-api-protocol.test.ts
+++ b/e2e/ui/settings-api-protocol.test.ts
@@ -23,7 +23,7 @@ async function gotoEntryHome(page: Page) {
     await privacyDialog.getByRole('button', { name: /I get it|not now|got it|don't share/i }).click();
   }
   const settingsButton = page
-    .getByTestId('entry-settings-button')
+    .getByTestId('entry-nav-settings')
     .or(page.getByRole('button', { name: OPEN_SETTINGS_LABEL }))
     .first();
   await expect(settingsButton).toBeVisible();
@@ -38,6 +38,12 @@ async function openSettingsDialogFromEntry(page: Page) {
 async function closeSettingsDialogIfOpen(page: Page) {
   const dialog = settingsSurface(page);
   if ((await dialog.count()) === 0) return;
+  const backToHome = dialog.getByRole('button', { name: /Back to home/i }).first();
+  if (await backToHome.isVisible().catch(() => false)) {
+    await backToHome.click();
+    await expect(dialog).toHaveCount(0);
+    return;
+  }
   await page.keyboard.press('Escape');
   try {
     await expect(dialog).toHaveCount(0, { timeout: T.short });
@@ -97,7 +103,7 @@ function modelCombobox(scope: Page | Locator) {
 }
 
 function providerPresetCombobox(scope: Page | Locator) {
-  return scope.getByLabel(/Gateway preset|Quick fill provider/i);
+  return scope.getByLabel(/Provider preset|Gateway preset|Quick fill provider/i);
 }
 
 async function selectComboboxOption(
@@ -265,7 +271,7 @@ test('[P0] @critical BYOK quick fill provider updates fields and saved settings 
       apiProviderBaseUrl: 'https://api.deepseek.com',
     });
 
-  await dialog.getByRole('button', { name: 'Close', exact: true }).click();
+  await closeSettingsDialogIfOpen(page);
   await expect(settingsSurface(page)).toHaveCount(0);
 
   const savedConfig = await readSavedConfig(page);
@@ -326,7 +332,7 @@ test('[P1] BYOK Anthropic gateway preset updates fields and persists after reope
     apiProviderBaseUrl: 'https://api.deepseek.com/anthropic',
   });
 
-  await dialog.getByRole('button', { name: 'Close', exact: true }).click();
+  await closeSettingsDialogIfOpen(page);
   await expect(settingsSurface(page)).toHaveCount(0);
 
   await openSettingsDialogFromEntry(page);
@@ -365,6 +371,7 @@ test('[P1] BYOK Ollama Cloud exposes refreshed model choices and persists select
   await expect(providerPresetCombobox(dialog)).toContainText(/Ollama Cloud \(managed\)/i);
   await expectModelComboboxText(dialog, /gpt-oss:120b/i);
   await expect(dialog.getByLabel('Base URL')).toHaveValue('https://ollama.com');
+  await dialog.getByLabel('API key').fill('ollama-key');
 
   await modelCombobox(dialog).click();
   const popover = page.getByTestId('settings-byok-model-popover');
@@ -379,7 +386,7 @@ test('[P1] BYOK Ollama Cloud exposes refreshed model choices and persists select
     apiProviderBaseUrl: 'https://ollama.com',
   });
 
-  await dialog.getByRole('button', { name: 'Close', exact: true }).click();
+  await closeSettingsDialogIfOpen(page);
   await expect(settingsSurface(page)).toHaveCount(0);
 
   await openSettingsDialogFromEntry(page);
@@ -475,8 +482,7 @@ test('[P0] BYOK save stays disabled until required fields are valid', async ({ p
   });
 
   const dialog = settingsSurface(page);
-  const closeButton = dialog.getByRole('button', { name: 'Close', exact: true });
-  await expect(closeButton).toBeEnabled();
+  await expect(dialog.getByRole('button', { name: /Back to home|Close/i }).first()).toBeEnabled();
 
   await dialog.getByLabel('API key').fill('sk-openai-test');
   await expect.poll(async () => readSavedConfig(page)).toMatchObject({ apiKey: 'sk-openai-test' });
@@ -1002,13 +1008,11 @@ test('[P0] @critical saving Local CLI updates the entry status pill with the sel
     mode: 'daemon',
     agentId: 'codex',
   });
-  await dialog.getByRole('button', { name: 'Close', exact: true }).click();
+  await closeSettingsDialogIfOpen(page);
   await expect(settingsSurface(page)).toHaveCount(0);
 
   const executionPill = page.getByTestId('inline-model-switcher-chip');
-  await expect(executionPill).toContainText(LOCAL_CLI_LABEL);
-  await expect(executionPill).toContainText('Codex CLI');
-  await expect(executionPill).toContainText('default');
+  await expect(executionPill).toHaveAttribute('aria-label', /Codex CLI · default/i);
 });
 
 test('[P0] @critical Settings keeps Local CLI and BYOK model choices isolated after reopening', async ({ page }) => {
@@ -1059,7 +1063,7 @@ test('[P0] @critical Settings keeps Local CLI and BYOK model choices isolated af
     },
   });
 
-  await dialog.getByRole('tab', { name: 'BYOK' }).click();
+  await dialog.getByRole('tab', { name: 'API providers' }).click();
   await dialog.getByRole('tab', { name: 'OpenAI', exact: true }).click();
   await modelCombobox(dialog).click();
   await page.getByTestId('settings-byok-model-popover').getByRole('option', { name: /^gpt-4o-mini$/i }).click();
@@ -1071,7 +1075,7 @@ test('[P0] @critical Settings keeps Local CLI and BYOK model choices isolated af
     },
   });
 
-  await dialog.getByRole('button', { name: 'Close', exact: true }).click();
+  await closeSettingsDialogIfOpen(page);
   await expect(settingsSurface(page)).toHaveCount(0);
 
   await openSettingsDialogFromEntry(page);

--- a/e2e/ui/settings-connectors-auth-happy-path.test.ts
+++ b/e2e/ui/settings-connectors-auth-happy-path.test.ts
@@ -1,11 +1,9 @@
 import { expect, test } from '@/playwright/suite';
 import type { Locator, Page } from '@playwright/test';
-import { openSettingsDialog } from '../lib/playwright/amr.js';
 import { routeAgents } from '../lib/playwright/mock-factory.js';
 import { T } from '@/timeouts';
 
 const STORAGE_KEY = 'open-design:config';
-const OPEN_SETTINGS_LABEL = /Open settings|打开设置|開啟設定|Account & settings/i;
 
 test.describe.configure({ timeout: T.xlong });
 
@@ -67,18 +65,14 @@ async function waitForLoadingToClear(page: Page) {
   await expect(page.getByText('Loading Open Design…')).toHaveCount(0, { timeout: T.long });
 }
 
-async function gotoEntryHome(page: Page) {
-  await page.goto('/', { waitUntil: 'domcontentloaded' });
+async function openIntegrationsConnectors(page: Page): Promise<Locator> {
+  await page.goto('/integrations', { waitUntil: 'domcontentloaded' });
   await waitForLoadingToClear(page);
-  const privacyRegion = page.getByRole('region', { name: /Help us improve Open Design/i });
-  if (await privacyRegion.isVisible().catch(() => false)) {
-    await privacyRegion.getByRole('button', { name: /I get it|not now|got it/i }).click();
-  }
-  await expect(page.getByTestId('home-hero')).toBeVisible();
-}
-
-async function openSettingsDialogFromEntry(page: Page) {
-  return openSettingsDialog(page);
+  const view = page.locator('.integrations-view');
+  await expect(view).toBeVisible({ timeout: T.long });
+  await view.getByTestId('integrations-tab-connectors').click();
+  await expect(view.getByTestId('connector-grid-wrap')).toBeVisible();
+  return view;
 }
 
 async function openConnectorsSettings(
@@ -238,9 +232,7 @@ async function openConnectorsSettings(
     });
   });
 
-  await gotoEntryHome(page);
-  const dialog = await openSettingsDialogFromEntry(page);
-  await dialog.getByRole('button', { name: /Connectors|连接器/i }).click();
+  const dialog = await openIntegrationsConnectors(page);
   await expect(dialog.getByTestId('connector-grid-wrap')).toBeVisible();
   await expect(connectorCard(dialog, 'github')).toBeVisible();
   return dialog;

--- a/e2e/ui/settings-connectors-auth-recovery.test.ts
+++ b/e2e/ui/settings-connectors-auth-recovery.test.ts
@@ -1,11 +1,9 @@
 import { expect, test } from '@/playwright/suite';
 import type { Locator, Page } from '@playwright/test';
-import { openSettingsDialog } from '../lib/playwright/amr.js';
 import { routeAgents } from '../lib/playwright/mock-factory.js';
 import { T } from '@/timeouts';
 
 const STORAGE_KEY = 'open-design:config';
-const OPEN_SETTINGS_LABEL = /Open settings|打开设置|開啟設定|Account & settings/i;
 
 test.describe.configure({ timeout: T.xlong });
 
@@ -88,18 +86,14 @@ async function waitForLoadingToClear(page: Page) {
   await expect(page.getByText('Loading Open Design…')).toHaveCount(0, { timeout: T.long });
 }
 
-async function gotoEntryHome(page: Page) {
-  await page.goto('/', { waitUntil: 'domcontentloaded' });
+async function openIntegrationsConnectors(page: Page): Promise<Locator> {
+  await page.goto('/integrations', { waitUntil: 'domcontentloaded' });
   await waitForLoadingToClear(page);
-  const privacyRegion = page.getByRole('region', { name: /Help us improve Open Design/i });
-  if (await privacyRegion.isVisible().catch(() => false)) {
-    await privacyRegion.getByRole('button', { name: /I get it|not now|got it/i }).click();
-  }
-  await expect(page.getByTestId('home-hero')).toBeVisible();
-}
-
-async function openSettingsDialogFromEntry(page: Page) {
-  return openSettingsDialog(page);
+  const view = page.locator('.integrations-view');
+  await expect(view).toBeVisible({ timeout: T.long });
+  await view.getByTestId('integrations-tab-connectors').click();
+  await expect(view.getByTestId('connector-grid-wrap')).toBeVisible();
+  return view;
 }
 
 async function openConnectorsSettings(
@@ -243,9 +237,7 @@ async function openConnectorsSettings(
     });
   });
 
-  await gotoEntryHome(page);
-  const dialog = await openSettingsDialogFromEntry(page);
-  await dialog.getByRole('button', { name: /Connectors|连接器/i }).click();
+  const dialog = await openIntegrationsConnectors(page);
   await expect(dialog.getByTestId('connector-grid-wrap')).toBeVisible();
   await expect(connectorCard(dialog, 'github')).toBeVisible();
   return { dialog, getCancelRequestCount: () => cancelRequestCount };

--- a/e2e/ui/settings-local-cli-codex-fallback.test.ts
+++ b/e2e/ui/settings-local-cli-codex-fallback.test.ts
@@ -76,7 +76,7 @@ async function gotoEntryHome(page: Page) {
     await privacyDialog.getByRole('button', { name: /I get it|not now|got it|don't share/i }).click();
   }
   await expect(
-    page.getByTestId('entry-settings-button').or(page.getByRole('button', { name: OPEN_SETTINGS_LABEL })).first(),
+    page.getByTestId('entry-nav-settings').or(page.getByRole('button', { name: OPEN_SETTINGS_LABEL })).first(),
   ).toBeVisible();
 }
 

--- a/e2e/ui/visual-entry.test.ts
+++ b/e2e/ui/visual-entry.test.ts
@@ -142,13 +142,9 @@ test('[P2] captures the home plugin use staged surface', async ({ page }) => {
   await configureVisualPage(page);
   const plugins = await openVisualPluginsCatalog(page);
 
-  const home = page.getByTestId('entry-view-home');
-  await home.getByTestId('plugins-home-pill-category-prototype').click();
-  const card = home.locator('article.plugins-home__card[data-plugin-id="visual-prototype-starter"]');
+  const card = pluginMarketplaceCard(plugins, 'Prototype Starter');
   await expect(card).toBeVisible();
-  await home.getByTestId('plugins-home-details-visual-prototype-starter').click({ force: true });
-  await expect(page.getByRole('dialog', { name: /Prototype Starter details/i })).toBeVisible();
-  await page.getByTestId('plugin-details-use-visual-prototype-starter').click();
+  await card.getByRole('button', { name: 'Try it' }).click();
   await expect(page.getByTestId('home-hero-active-plugin')).toContainText('Prototype Starter');
   await expect(page.getByTestId('home-hero-input')).toBeVisible();
 
@@ -187,8 +183,7 @@ async function openVisualPluginsCatalog(page: import('@playwright/test').Page) {
   await page.getByTestId('entry-nav-plugins').click();
   await expect(page).toHaveURL(/\/plugins$/);
   const plugins = page.getByTestId('entry-view-plugins');
-  // #5517 renamed the surface: the view renders `entry.navExtensions`.
-  await expect(plugins.getByRole('heading', { name: 'Extensions', exact: true })).toBeVisible();
+  await expect(plugins.getByRole('heading', { name: 'Plugins', exact: true })).toBeVisible();
   // The marketplace opens on the 官方 scope, which is fed by `/api/marketplaces`
   // — empty in this harness. The visual fixture plugins are user-installed, so
   // switch to 个人; it is also the only scope whose cards carry the per-card

--- a/e2e/ui/visual-navigation.test.ts
+++ b/e2e/ui/visual-navigation.test.ts
@@ -103,9 +103,8 @@ test('[P2] captures the plugins page surface', async ({ page }) => {
   await page.getByTestId('entry-nav-plugins').click();
   await expect(page).toHaveURL(/\/plugins$/);
   const plugins = page.getByTestId('entry-view-plugins');
-  // #5517 renamed the surface: the view renders `entry.navExtensions`.
-  await expect(plugins.getByRole('heading', { name: 'Extensions', exact: true })).toBeVisible();
-  await expect(plugins.getByTestId('plugins-tab-installed')).toBeVisible();
+  await expect(plugins.getByRole('heading', { name: 'Plugins', exact: true })).toBeVisible();
+  await plugins.getByTestId('plugins-tab-installed').click();
   await expect(plugins.getByText('Prototype Starter').first()).toBeVisible();
   await waitForVisualFonts(page);
 
@@ -167,10 +166,10 @@ test('[P2] captures the tasks page surface', async ({ page }) => {
 });
 
 async function openSettingsSection(page: import('@playwright/test').Page, testId: string) {
-  // The settings chip moved into the rail footer (#5517); collapsed, the rail
-  // is `inert`, so even a programmatic click is swallowed.
+  // The settings entry lives in the rail; collapsed, the rail is `inert`, so
+  // even a programmatic click is swallowed.
   await ensureRailOpen(page);
-  const settingsButton = page.getByTestId('entry-settings-button');
+  const settingsButton = page.getByTestId('entry-nav-settings');
   await expect(settingsButton).toBeVisible();
   await settingsButton.evaluate((element: HTMLElement) => element.click());
   const dialog = settingsSurface(page);

--- a/e2e/ui/visual-settings.test.ts
+++ b/e2e/ui/visual-settings.test.ts
@@ -122,7 +122,7 @@ test('[P2] captures the settings BYOK surface', async ({ page }) => {
   await gotoVisualWorkspace(page);
 
   const dialog = await prepareVisualSettingsDialog(page);
-  await dialog.getByRole('tab', { name: 'BYOK' }).click();
+  await dialog.getByRole('tab', { name: 'API providers' }).click();
   await expect(dialog.getByRole('tablist', { name: 'API protocol' })).toBeVisible();
   await expect(dialog.getByRole('heading', { name: 'Anthropic API' })).toBeVisible();
   await waitForVisualFonts(page);
@@ -145,7 +145,7 @@ test('[P2] captures the settings BYOK OpenAI surface', async ({ page }) => {
   await gotoVisualWorkspace(page);
 
   const dialog = await prepareVisualSettingsDialog(page);
-  await dialog.getByRole('tab', { name: 'BYOK' }).click();
+  await dialog.getByRole('tab', { name: 'API providers' }).click();
   await dialog.getByRole('tab', { name: 'OpenAI', exact: true }).click();
   await expect(dialog.getByRole('heading', { name: 'OpenAI API' })).toBeVisible();
   await waitForVisualFonts(page);
@@ -168,7 +168,7 @@ test('[P2] captures the settings BYOK model dropdown surface', async ({ page }) 
   await gotoVisualWorkspace(page);
 
   const dialog = await prepareVisualSettingsDialog(page);
-  await dialog.getByRole('tab', { name: 'BYOK' }).click();
+  await dialog.getByRole('tab', { name: 'API providers' }).click();
   await dialog.getByRole('tab', { name: 'OpenAI', exact: true }).click();
   const modelSelect = dialog.getByRole('combobox', { name: 'Model', exact: true });
   await expect(modelSelect).toBeVisible();

--- a/e2e/ui/visual-workspace.test.ts
+++ b/e2e/ui/visual-workspace.test.ts
@@ -54,14 +54,15 @@ test('[P1] @critical captures CSS hotspot workspace, preview, and settings surfa
   await captureVisual(page, 'visual-critical-settings');
 });
 
-test('[P2] captures the topbar execution switcher surface', async ({ page }) => {
+test('[P2] captures the topbar compact model picker surface', async ({ page }) => {
   await configureVisualPage(page);
   await gotoVisualHome(page);
 
   await page.getByTestId('inline-model-switcher-chip').click();
   const popover = page.getByTestId('inline-model-switcher-popover');
   await expect(popover).toBeVisible();
-  await expect(page.getByTestId('inline-model-switcher-mode-daemon')).toBeVisible();
+  await expect(popover.getByTestId('inline-model-switcher-compact-model-default')).toBeVisible();
+  await expect(popover.getByTestId('inline-model-switcher-open-settings')).toBeVisible();
 
   await captureVisual(page, 'visual-topbar-execution-switcher');
   await captureVisualTarget(
@@ -71,9 +72,7 @@ test('[P2] captures the topbar execution switcher surface', async ({ page }) => 
   );
 });
 
-test('[P1] captures the topbar Open Design account balance surface', async ({ page }) => {
-  test.setTimeout(60_000);
-
+test('[P1] captures the topbar Open Design model picker surface', async ({ page }) => {
   await configureVisualPage(page, {
     agents: [...VISUAL_CLI_AGENTS, VISUAL_AMR_AGENT],
     config: {
@@ -82,41 +81,20 @@ test('[P1] captures the topbar Open Design account balance surface', async ({ pa
       agentCliEnv: { amr: { OPEN_DESIGN_AMR_PROFILE: 'test' } },
     },
   });
-  await mockSignedInVelaAccount(page);
   await gotoVisualHome(page);
 
   await page.getByTestId('inline-model-switcher-chip').click();
   const popover = page.getByTestId('inline-model-switcher-popover');
   await expect(popover).toBeVisible();
-  const [amrBox, claudeBox, codexBox] = await Promise.all([
-    popover.getByTestId('inline-model-switcher-agent-amr').boundingBox(),
-    popover.getByTestId('inline-model-switcher-agent-claude').boundingBox(),
-    popover.getByTestId('inline-model-switcher-agent-codex').boundingBox(),
-  ]);
-  expect(amrBox).toBeTruthy();
-  expect(claudeBox).toBeTruthy();
-  expect(codexBox).toBeTruthy();
-  expect(amrBox!.y).toBeLessThan(claudeBox!.y);
-  expect(amrBox!.y).toBeLessThan(codexBox!.y);
-  await expect(popover.locator('.inline-switcher__account')).toContainText('Open Design');
-  await expect(popover.locator('.inline-switcher__account')).toContainText('plus');
-  await expect(popover.locator('.inline-switcher__account')).toContainText('$247.51');
-  const upgrade = page.getByTestId('inline-model-switcher-account-upgrade');
-  await expect(upgrade).toBeVisible();
-  const popupPromise = page.waitForEvent('popup');
-  await upgrade.click();
-  const popup = await popupPromise;
-  const upgradeUrl = new URL(popup.url());
-  await popup.close();
-  expect(upgradeUrl.searchParams.get('view')).toBe('plans');
-  expect(upgradeUrl.searchParams.get('od_origin')).toBe('open_design');
-  expect(upgradeUrl.searchParams.get('od_entry_source')).toBe('inline_amr_upgrade');
-  expect(upgradeUrl.searchParams.get('od_entry_id')).toBeTruthy();
+  await expect(
+    popover.getByTestId('inline-model-switcher-compact-model-deepseek-v4-flash'),
+  ).toBeVisible();
+  await expect(popover.getByTestId('inline-model-switcher-open-settings')).toBeVisible();
 
-  await captureVisual(page, 'visual-topbar-open-design-account');
+  await captureVisual(page, 'visual-topbar-open-design-models');
 });
 
-test('[P2] captures the topbar local CLI model dropdown surface', async ({ page }) => {
+test('[P2] captures the topbar local CLI model list surface', async ({ page }) => {
   await configureVisualPage(page, {
     agents: VISUAL_CLI_AGENTS,
     config: {
@@ -127,18 +105,18 @@ test('[P2] captures the topbar local CLI model dropdown surface', async ({ page 
   await gotoVisualHome(page);
 
   await page.getByTestId('inline-model-switcher-chip').click();
-  await expect(page.getByTestId('inline-model-switcher-popover')).toBeVisible();
-  await page.getByTestId('inline-model-switcher-agent-model').click();
-  const trigger = page.getByTestId('inline-model-switcher-agent-model');
-  const popover = page.getByTestId('inline-model-switcher-agent-model-popover');
+  const popover = page.getByTestId('inline-model-switcher-popover');
   await expect(popover).toBeVisible();
-  await expect(page.getByTestId('inline-model-switcher-agent-model-search')).toBeVisible();
+  await expect(popover.getByTestId('inline-model-switcher-compact-model-default')).toBeVisible();
+  await expect(
+    popover.getByTestId('inline-model-switcher-compact-model-sonnet-alias'),
+  ).toBeVisible();
 
-  await captureVisual(page, 'visual-topbar-local-cli-model-dropdown');
-  await captureVisualTarget(page, 'visual-topbar-local-cli-model-dropdown-popover', [trigger, popover]);
+  await captureVisual(page, 'visual-topbar-local-cli-model-list');
+  await captureVisualTarget(page, 'visual-topbar-local-cli-model-list-popover', popover);
 });
 
-test('[P2] captures the topbar BYOK execution switcher surface', async ({ page }) => {
+test('[P2] captures the topbar BYOK settings shortcut surface', async ({ page }) => {
   await configureVisualPage(page, {
     config: {
       mode: 'api',
@@ -154,7 +132,8 @@ test('[P2] captures the topbar BYOK execution switcher surface', async ({ page }
   await page.getByTestId('inline-model-switcher-chip').click();
   const popover = page.getByTestId('inline-model-switcher-popover');
   await expect(popover).toBeVisible();
-  await expect(page.getByTestId('inline-model-switcher-mode-api')).toHaveAttribute('aria-selected', 'true');
+  await expect(popover.locator('.inline-switcher__hint')).toBeVisible();
+  await expect(popover.getByTestId('inline-model-switcher-open-settings')).toBeVisible();
 
   await captureVisual(page, 'visual-topbar-byok-switcher');
   await captureVisualTarget(
@@ -162,30 +141,6 @@ test('[P2] captures the topbar BYOK execution switcher surface', async ({ page }
     'visual-topbar-byok-switcher-popover',
     page.getByTestId('inline-model-switcher-popover'),
   );
-});
-
-test('[P2] captures the topbar BYOK model dropdown surface', async ({ page }) => {
-  await configureVisualPage(page, {
-    config: {
-      mode: 'api',
-      apiKey: 'sk-visual',
-      apiProtocol: 'openai',
-      baseUrl: 'https://api.openai.com/v1',
-      model: 'gpt-4o',
-      agentId: null,
-    },
-  });
-  await gotoVisualHome(page);
-
-  await page.getByTestId('inline-model-switcher-chip').click();
-  await expect(page.getByTestId('inline-model-switcher-popover')).toBeVisible();
-  const trigger = page.getByTestId('inline-model-switcher-api-model');
-  await trigger.click();
-  const popover = page.getByTestId('inline-model-switcher-api-model-popover');
-  await expect(popover).toBeVisible();
-
-  await captureVisual(page, 'visual-topbar-byok-model-dropdown');
-  await captureVisualTarget(page, 'visual-topbar-byok-model-dropdown-popover', [trigger, popover]);
 });
 
 test('[P2] captures the avatar menu surface', async ({ page }) => {


### PR DESCRIPTION
## Why

While validating the current `feat/workspace-team` branch, two user-facing recovery gaps surfaced alongside stale UI CI coverage:

- An AMR authentication failure could become effectively unretryable after authorization changed the identity scope and returned the user to Home. Reopening the project showed a signed-in account state instead of a usable retry action.
- Successful project-file mutations did not evict the coalesced file-list read, so the workspace could keep showing a stale file list.
- The focused workspace UI lanes still encoded pre-current Settings, Plugins, Pages, preview, and connector interactions, obscuring real regressions with obsolete assertions.

This PR keeps those fixes and their current-UI coverage together so the target branch can be validated without rewriting the UI suite.

## What users will see

After authorizing Open Design Cloud from a failed AMR run, users can reopen the project and manually retry that run. Uploading, writing, renaming, or deleting project files also refreshes the project file list instead of reusing a stale coalesced response.

There are no new navigation destinations or settings. The UI tests now follow the existing Plugins, Settings, Pages, Preview, and Integrations surfaces.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached for this draft: there is no new entry point or layout. The visible change is a transient recovery state after authorization and an immediate file-list refresh. The focused Playwright coverage exercises the full authorize → identity re-scope → reopen project → retry path.

## Bug fix verification

- Regression coverage:
  - `apps/web/tests/components/ChatPane.amr-auth-inline.test.tsx`
  - `apps/web/tests/providers/registry.test.ts`
  - `e2e/ui/amr-run-failure-recovery.test.ts`
- Red on `main`, green on this branch: no. This PR targets `feat/workspace-team`, and the low-resource validation session did not reset a second worktree to `main` or the clean target baseline. The focused regression tests are green on this branch; the original failures came from the target branch CI feedback and local pre-fix reproduction.

## Validation

All Playwright commands used `workers=1`, `retries=0`, and the local CPU/memory/swap guard.

- `pnpm install --frozen-lockfile`
- Focused web unit coverage: 6 affected tests passed across ChatPane, DesignsTab, ProjectView, registry, and config
- Focused functional Playwright coverage:
  - navigation/settings: 8 passed
  - Settings API protocols: 6 passed
  - manual edit: 6 passed
  - workspace restoration: 6 passed
  - project management: 6 passed
  - Design Files preview restoration: 1 passed
  - AMR identity/retry recovery: 3 passed
- Focused visual Playwright coverage: 3 passed
- `pnpm --filter @open-design/e2e typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard` — 71/71 tests passed
- `git diff --check`
