### PR TITLE
fix(web): expose Codex path when unavailable

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -5130,15 +5130,20 @@ export function SettingsDialog({
                   versa), and the section hijacked Settings real estate
                   on every open even though nine in ten users never
                   touch it. Now: filtered to the *currently selected*
-                  agent only, and folded into a collapsed disclosure
-                  that opens to "Advanced: proxy & custom paths" — power
+                  agent, except that CODEX_BIN stays reachable while
+                  Codex is unavailable. The collapsed disclosure opens
+                  to "Advanced: proxy & custom paths" — power
                   users who route through LiteLLM or installed the
                   binary out-of-PATH still have one click access; new
                   users no longer wonder "are these fields I forgot to
                   fill in?".
                 */
                 const cliEnvFields = AGENT_CLI_ENV_FIELDS.filter(
-                  (field) => field.agentId === cfg.agentId,
+                  (field) =>
+                    field.agentId === cfg.agentId ||
+                    (field.agentId === 'codex' &&
+                      field.envKey === 'CODEX_BIN' &&
+                      unavailableAgents.some((agent) => agent.id === 'codex')),
                 );
                 if (cliEnvFields.length === 0) return null;
                 return (

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -3050,6 +3050,43 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     });
   });
 
+  it('exposes the Codex binary override when Codex is unavailable', async () => {
+    const unavailableCodex: AgentInfo = {
+      ...availableAgents[0]!,
+      available: false,
+      version: null,
+    };
+    const onRefreshAgents = vi.fn(async () => [unavailableCodex]);
+    const { onPersist } = renderSettingsDialog(
+      { mode: 'daemon', agentId: null },
+      { agents: [unavailableCodex], onRefreshAgents },
+    );
+
+    fireEvent.change(screen.getByLabelText('Codex executable path'), {
+      target: { value: '/nix/profile/bin/codex' },
+    });
+
+    await waitForPersist(
+      onPersist,
+      expect.objectContaining({
+        agentCliEnv: {
+          codex: { CODEX_BIN: '/nix/profile/bin/codex' },
+        },
+      }),
+      {},
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Rescan/i }));
+    await waitFor(() => {
+      expect(onRefreshAgents).toHaveBeenCalledWith({
+        throwOnError: true,
+        agentCliEnv: {
+          codex: { CODEX_BIN: '/nix/profile/bin/codex' },
+        },
+      });
+    });
+  });
+
   it('autosaves CLI env overrides from the execution form', async () => {
     const { onPersist } = renderSettingsDialog(
       { mode: 'daemon', agentId: 'codex' },


### PR DESCRIPTION
Fixes #6122

## Why

I hit this after Open Design failed to detect my Nix-installed Codex CLI. Settings listed Codex under “Available to install”, but the existing `CODEX_BIN` field was filtered to the selected agent and an unavailable agent cannot be selected. That made the supported recovery override impossible to reach.

The daemon already accepts, validates, persists, and uses `CODEX_BIN`; this PR only closes the Settings UI gap.

## What users will see

When Codex is unavailable, Settings → Execution mode → Local CLI still exposes “Codex executable path” inside the existing Advanced disclosure. Entering an absolute path autosaves it, and Rescan uses that override. Other Codex proxy and credential fields remain hidden until Codex is selected.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

![Codex executable path remains available when Codex is not detected](https://raw.githubusercontent.com/Pape45/open-design/da515c268035cb910438753f83c0d1c6b339d246/pr-assets/pr-6124-codex-bin.png)

Manual verification: in an isolated runtime where Codex initially reported `not-on-path`, entering `/run/current-system/sw/bin/codex` and clicking Rescan detected `codex-cli 0.145.0`.

## Bug fix verification

- Red spec: [`apps/web/tests/components/SettingsDialog.execution.test.tsx`](https://github.com/Pape45/open-design/blob/agent/expose-undetected-codex-path/apps/web/tests/components/SettingsDialog.execution.test.tsx)
- The test failed on `main` because the “Codex executable path” label was absent, then passed on this branch: yes.
- The test also verifies autosave and that Rescan receives the configured `CODEX_BIN`.

## Validation

- Focused red/green SettingsDialog test — 1 passed
- Full `SettingsDialog.execution.test.tsx` — 150 passed
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`

## Adjacent issues

#6121 is intentionally separate because Nix PATH discovery belongs to the shared platform resolver.