### PR TITLE
fix(platform): discover Nix agent CLIs

### DIFF
--- a/packages/platform/src/toolchain.ts
+++ b/packages/platform/src/toolchain.ts
@@ -3,7 +3,7 @@
  *
  * User-level toolchain bin discovery. Single source of truth for the CLI
  * install locations a GUI-launched daemon must search even under a stripped
- * PATH — npm/pnpm/bun/cargo/deno/go/pyenv prefixes, version-manager shims
+ * PATH — npm/pnpm/bun/cargo/deno/go/pyenv/Nix prefixes, version-manager shims
  * (asdf, volta, mise, nvm, fnm), and per-version Node install roots. Pure path
  * assembly plus best-effort directory probing; no process, command, or proxy
  * concerns.
@@ -16,8 +16,9 @@ export type WellKnownUserToolchainOptions = {
   // Override homedir() so callers in sandboxed tests or namespaced launches
   // can substitute a fixture directory. Falls back to os.homedir().
   home?: string;
-  // Include /opt/homebrew/bin and /usr/local/bin in the result. Defaults to
-  // true on POSIX so GUI-launched processes (which inherit a minimal PATH
+  // Include /opt/homebrew/bin, /usr/local/bin, and
+  // /run/current-system/sw/bin in the result. Defaults to true on POSIX so
+  // GUI-launched processes (which inherit a minimal PATH
   // from launchd / desktop launchers) still see Homebrew-installed CLIs;
   // defaults to false on Windows because those paths are POSIX-only.
   includeSystemBins?: boolean;
@@ -125,6 +126,7 @@ export function wellKnownUserToolchainBins(
     join(home, ".asdf", "shims"),
     join(home, "Library", "pnpm"),
     join(home, ".cargo", "bin"),
+    join(home, ".nix-profile", "bin"),
     // Common user-level npm prefixes for sudo-free global installs.
     // ~/.npm-global is the dominant non-canonical convention shipped
     // in most third-party "fix npm EACCES" tutorials, and
@@ -168,7 +170,7 @@ export function wellKnownUserToolchainBins(
   }
 
   if (includeSystemBins) {
-    dirs.push("/opt/homebrew/bin", "/usr/local/bin");
+    dirs.push("/opt/homebrew/bin", "/usr/local/bin", "/run/current-system/sw/bin");
   }
   // Per-version Node toolchains: scan the install root and surface every
   // version directory's bin folder. Best-effort — missing roots simply

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -799,6 +799,7 @@ describe("wellKnownUserToolchainBins", () => {
       expect(dirs).toContain(join(home, ".asdf", "shims"));
       expect(dirs).toContain(join(home, "Library", "pnpm"));
       expect(dirs).toContain(join(home, ".cargo", "bin"));
+      expect(dirs).toContain(join(home, ".nix-profile", "bin"));
     } finally {
       rmSync(home, { recursive: true, force: true });
     }
@@ -1122,23 +1123,25 @@ describe("wellKnownUserToolchainBins", () => {
     }
   });
 
-  it("includes /opt/homebrew/bin and /usr/local/bin when includeSystemBins is true", () => {
+  it("includes Homebrew, local, and Nix system bins when includeSystemBins is true", () => {
     const home = mkdtempSync(join(tmpdir(), "wkutb-sys-"));
     try {
       const dirs = wellKnownUserToolchainBins({ home, env: {}, includeSystemBins: true });
       expect(dirs).toContain("/opt/homebrew/bin");
       expect(dirs).toContain("/usr/local/bin");
+      expect(dirs).toContain("/run/current-system/sw/bin");
     } finally {
       rmSync(home, { recursive: true, force: true });
     }
   });
 
-  it("omits /opt/homebrew/bin and /usr/local/bin when includeSystemBins is false", () => {
+  it("omits Homebrew, local, and Nix system bins when includeSystemBins is false", () => {
     const home = mkdtempSync(join(tmpdir(), "wkutb-nosys-"));
     try {
       const dirs = wellKnownUserToolchainBins({ home, env: {}, includeSystemBins: false });
       expect(dirs).not.toContain("/opt/homebrew/bin");
       expect(dirs).not.toContain("/usr/local/bin");
+      expect(dirs).not.toContain("/run/current-system/sw/bin");
     } finally {
       rmSync(home, { recursive: true, force: true });
     }


### PR DESCRIPTION
Fixes #6121

## Why

I hit this while launching Open Design 0.16.1 from Finder on macOS with Codex installed through Nix. The CLI resolves normally in an interactive terminal, but the packaged app inherits a stripped launchd PATH and therefore reports the agent as unavailable.

The shared toolchain resolver already compensates for Homebrew and common language/version-manager locations. Adding the standard user and system Nix profile bins closes the same GUI-PATH gap for both daemon executable resolution and the packaged sidecar PATH builder.

## What users will see

Agent CLIs installed in `~/.nix-profile/bin` or `/run/current-system/sw/bin` are discovered automatically by GUI-launched Open Design sessions. Existing search order and non-Nix installs are unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this changes executable discovery without adding or changing UI.

## Bug fix verification

- Red spec: [`packages/platform/tests/index.test.ts`](https://github.com/Pape45/open-design/blob/agent/detect-nix-agent-clis/packages/platform/tests/index.test.ts)
- The assertions for both Nix paths failed on `main` and pass on this branch: yes.

## Validation

- `pnpm --filter @open-design/platform test -- index.test.ts` — 80 passed
- `pnpm --filter @open-design/platform typecheck`
- `pnpm guard`
- `pnpm typecheck`

## Adjacent issues

#6122 is intentionally separate because exposing an unavailable Codex binary override is an independent Settings UI concern.