### PR TITLE
fix(daemon): hide Windows agent console windows

### DIFF
--- a/apps/daemon/src/runtimes/invocation.ts
+++ b/apps/daemon/src/runtimes/invocation.ts
@@ -1,10 +1,44 @@
-import { execFile } from 'node:child_process';
+import {
+  execFile,
+  spawn,
+  type ChildProcess,
+  type SpawnOptions,
+} from 'node:child_process';
 import os from 'node:os';
 import { promisify } from 'node:util';
 import { createCommandInvocation } from '@open-design/platform';
 import type { RuntimeExecOptions } from './types.js';
 
 const execFileP = promisify(execFile);
+
+/**
+ * Spawn a long-running agent process through the cross-platform invocation
+ * wrapper, keeping Windows CLI subprocesses attached without showing a
+ * transient console window.
+ */
+export function spawnAgentFile(
+  command: string,
+  args: string[],
+  options: SpawnOptions = {},
+): ChildProcess {
+  const invocation = createCommandInvocation(
+    options.env
+      ? {
+          command,
+          args,
+          env: options.env,
+        }
+      : {
+          command,
+          args,
+        },
+  );
+  return spawn(invocation.command, invocation.args, {
+    ...options,
+    windowsHide: process.platform === 'win32',
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+  });
+}
 
 // Agent probes (model-list / version / help / auth-status) are short read-only
 // metadata calls that never need the caller's project files. Default them to a
@@ -37,6 +71,7 @@ export function execAgentFile(
   return execFileP(invocation.command, invocation.args, {
     ...options,
     cwd: options.cwd ?? os.tmpdir(),
+    windowsHide: process.platform === 'win32',
     windowsVerbatimArguments: invocation.windowsVerbatimArguments,
   });
 }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -10,7 +10,7 @@ import type {
 import express from 'express';
 import multer from 'multer';
 import JSZip from 'jszip';
-import { execFile, spawn } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
@@ -180,7 +180,6 @@ export {
 } from './runtimes/run-lifecycle-analytics.js';
 
 export { resolveProjectRoot };
-import { createCommandInvocation } from '@open-design/platform';
 import { SIDECAR_ENV } from '@open-design/sidecar-proto';
 import {
   buildLiveArtifactsMcpServersForAgent,
@@ -206,6 +205,7 @@ import {
   resolveModelForServiceTier,
 } from './runtimes/models.js';
 import { loadMmdRouteLaunchEnv } from './runtimes/mmd-routes.js';
+import { spawnAgentFile } from './runtimes/invocation.js';
 import { preflightCodexDefaultModel } from './runtimes/codex-model-preflight.js';
 import { preparePromptFileForAgent } from './runtimes/prompt-file.js';
 import { TerminalControlSequenceStripper } from './runtimes/terminal-control.js';
@@ -6592,23 +6592,14 @@ export async function startServer({
           : {}),
       }, agentLaunch);
       spawnedAgentEnv = env;
-      const invocation = createCommandInvocation({
-        command: agentLaunch.launchPath,
-        args,
-        env,
-      });
       lifecycle.mark('launch_preflight_end');
       lifecycle.mark('process_spawn_start');
-      child = spawn(invocation.command, invocation.args, {
+      child = spawnAgentFile(agentLaunch.launchPath, args, {
         env,
         stdio: [stdinMode, 'pipe', 'pipe'],
         cwd: effectiveCwd,
         shell: false,
         detached: process.platform !== 'win32',
-        // Required when invocation wraps a Windows .cmd/.bat shim through
-        // cmd.exe; without this, Node re-escapes the inner command line and
-        // breaks paths containing spaces (issue #315).
-        windowsVerbatimArguments: invocation.windowsVerbatimArguments,
       });
       lifecycle.mark('process_spawned');
       run.child = child;

--- a/apps/daemon/tests/runtimes/agent-process-windows-hide.test.ts
+++ b/apps/daemon/tests/runtimes/agent-process-windows-hide.test.ts
@@ -1,0 +1,118 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const childProcessMocks = vi.hoisted(() => ({
+  execFile: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    execFile: childProcessMocks.execFile,
+    spawn: childProcessMocks.spawn,
+  };
+});
+
+import { execAgentFile, spawnAgentFile } from '../../src/runtimes/invocation.js';
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', {
+    configurable: true,
+    value: platform,
+  });
+}
+
+function execOptions(): Record<string, unknown> {
+  return childProcessMocks.execFile.mock.calls.at(-1)?.[2] ?? {};
+}
+
+function spawnOptions(): Record<string, unknown> {
+  return childProcessMocks.spawn.mock.calls.at(-1)?.[2] ?? {};
+}
+
+describe('agent subprocess window policy', () => {
+  beforeEach(() => {
+    childProcessMocks.execFile.mockImplementation(
+      (
+        _command: string,
+        _args: string[],
+        _options: Record<string, unknown>,
+        callback: (error: null, stdout: string, stderr: string) => void,
+      ) => {
+        callback(null, '', '');
+      },
+    );
+    childProcessMocks.spawn.mockReturnValue(new EventEmitter());
+  });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+    vi.clearAllMocks();
+  });
+
+  it('hides probe and chat subprocess windows on Windows', async () => {
+    setPlatform('win32');
+
+    await execAgentFile('agent.exe', ['--version'], {
+      cwd: 'C:\\work',
+      env: { PATH: 'C:\\tools' },
+      windowsHide: false,
+    });
+    spawnAgentFile('agent.exe', ['run'], {
+      cwd: 'C:\\work',
+      detached: false,
+      env: { PATH: 'C:\\tools' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: false,
+    });
+
+    expect(execOptions()).toMatchObject({
+      cwd: 'C:\\work',
+      env: { PATH: 'C:\\tools' },
+      windowsHide: true,
+    });
+    expect(spawnOptions()).toMatchObject({
+      cwd: 'C:\\work',
+      detached: false,
+      env: { PATH: 'C:\\tools' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+  });
+
+  it.each(['linux', 'darwin'] as const)(
+    'does not request hidden subprocess windows on %s',
+    async (platform) => {
+      setPlatform(platform);
+
+      await execAgentFile('/usr/bin/agent', ['--version'], { windowsHide: true });
+      spawnAgentFile('/usr/bin/agent', ['run'], { windowsHide: true });
+
+      expect(execOptions().windowsHide).toBe(false);
+      expect(spawnOptions().windowsHide).toBe(false);
+    },
+  );
+
+  it('preserves Windows cmd shim quoting alongside the hidden-window policy', async () => {
+    setPlatform('win32');
+
+    await execAgentFile('C:\\Program Files\\agent.cmd', ['--version']);
+    spawnAgentFile('C:\\Program Files\\agent.cmd', ['run'], {
+      shell: false,
+    });
+
+    expect(execOptions()).toMatchObject({
+      windowsHide: true,
+      windowsVerbatimArguments: true,
+    });
+    expect(spawnOptions()).toMatchObject({
+      shell: false,
+      windowsHide: true,
+      windowsVerbatimArguments: true,
+    });
+  });
+});


### PR DESCRIPTION
## Why

While validating Open Design from a native Windows build, I observed that local-agent discovery and chat runs repeatedly opened `cmd.exe` windows and left many of them visible. This made the packaged app disruptive to use even when the agent itself continued running correctly.

Both short-lived agent probes and long-running chat processes use Node child-process APIs. On Windows, npm-installed agent shims can be routed through `cmd.exe`; because those process launches did not set `windowsHide`, every probe or run could surface another console window. This change centralizes the spawn policy while preserving the existing Windows `.cmd`/`.bat` quoting behavior.

## What users will see

On Windows, discovering or running local CLI agents no longer opens transient or persistent `cmd.exe` windows. Agent output and streaming behavior are unchanged, and macOS/Linux process behavior remains unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this changes native process-window behavior rather than an Open Design UI surface.

## Bug fix verification

- Test path: `apps/daemon/tests/runtimes/agent-process-windows-hide.test.ts`
- The regression test went red on `main` and green on this branch (4 tests passed).
- Manual Windows verification: before the change, local-agent use created many `cmd.exe` windows that remained visible; after the change, the same workflow created no visible console windows.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/daemon test -- tests/runtimes/agent-process-windows-hide.test.ts` — 4 passed
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/daemon build`
- `pnpm tools-pack win build --namespace smoke --to dir --json`
- `pnpm tools-pack win build --namespace smoke --to nsis --json`
- Manual launch of the unpacked Windows app and local-agent workflow
- `git diff --check`
