### PR TITLE
fix: od conversation failing fix

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -1809,8 +1809,12 @@ async function structuredHttpFailure(resp, fallbackCode = 'daemon-not-running') 
       data:    structuredErrorData(errorObj),
     });
   }
+  let finalFallbackCode = fallbackCode;
+  if (fallbackCode === 'daemon-not-running') {
+    finalFallbackCode = resp.status === 404 ? 'not-found' : 'http-error';
+  }
   exitWithStructuredError({
-    code:    fallbackCode,
+    code:    finalFallbackCode,
     message: errorObj?.message ?? `HTTP ${resp.status}${raw ? `: ${raw}` : ''}`,
     data:    structuredErrorData(errorObj),
   });
@@ -7268,7 +7272,8 @@ async function runConversation(args) {
                                            --fork-after stops the copy at one
                                            source message.
   od conversation list <projectId>           List conversations in a project.
-  od conversation info <conversationId>      Print one conversation.
+  od conversation info <conversationId> --project <projectId>
+                                             Print one conversation.
 
 Common options:
   --daemon-url <url>   Open Design daemon HTTP base.
@@ -7325,12 +7330,12 @@ Common options:
       return;
     }
     case 'info': {
-      const id = rest.find((a) => !a.startsWith('-'));
-      if (!id) {
-        console.error('Usage: od conversation info <conversationId>');
+      const [id] = positionalArgs(rest, PROJECT_STRING_FLAGS);
+      if (!id || !flags.project) {
+        console.error('Usage: od conversation info <conversationId> --project <projectId>');
         process.exit(2);
       }
-      const resp = await fetch(`${base}/api/conversations/${encodeURIComponent(id)}`);
+      const resp = await fetch(`${base}/api/projects/${encodeURIComponent(flags.project)}/conversations/${encodeURIComponent(id)}`);
       if (!resp.ok) return structuredHttpFailure(resp);
       const data = await resp.json();
       process.stdout.write(JSON.stringify(data, null, 2) + '\n');

--- a/apps/daemon/src/routes/project/conversations.ts
+++ b/apps/daemon/src/routes/project/conversations.ts
@@ -133,6 +133,14 @@ export function registerProjectConversationRoutes(app: Express, ctx: RegisterPro
     res.json({ conversation: conv });
   });
 
+  app.get('/api/projects/:id/conversations/:cid', (req, res) => {
+    const conv = getConversation(db, req.params.cid);
+    if (!conv || conv.projectId !== req.params.id) {
+      return res.status(404).json({ error: 'conversation not found' });
+    }
+    res.json({ conversation: conv });
+  });
+
   app.patch('/api/projects/:id/conversations/:cid', (req, res) => {
     const conv = getConversation(db, req.params.cid);
     if (!conv || conv.projectId !== req.params.id) {

--- a/apps/daemon/tests/cli-conversation-info.test.ts
+++ b/apps/daemon/tests/cli-conversation-info.test.ts
@@ -1,0 +1,211 @@
+import http from 'node:http';
+import { execFile } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve as pathResolve } from 'node:path';
+import { promisify } from 'node:util';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+const execFileP = promisify(execFile);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DAEMON_ROOT = pathResolve(__dirname, '..');
+const REPO_ROOT = pathResolve(__dirname, '../../..');
+const CLI_SRC = pathResolve(__dirname, '../src/cli.ts');
+const TSX_CLI = pathResolve(REPO_ROOT, 'node_modules/tsx/dist/cli.mjs');
+
+interface CapturedRequest {
+  method: string;
+  url: string;
+  body: string;
+}
+
+interface StubServer {
+  baseUrl: string;
+  requests: CapturedRequest[];
+  setResponder: (
+    fn: (req: CapturedRequest) => { status: number; body: unknown } | null,
+  ) => void;
+  close: () => Promise<void>;
+}
+
+async function startStubServer(): Promise<StubServer> {
+  const requests: CapturedRequest[] = [];
+  let responder:
+    | ((req: CapturedRequest) => { status: number; body: unknown } | null)
+    | null = null;
+
+  const server = http.createServer((req, res) => {
+    let raw = '';
+    req.on('data', (chunk) => {
+      raw += chunk;
+    });
+    req.on('end', () => {
+      const captured: CapturedRequest = {
+        method: req.method ?? '',
+        url: req.url ?? '',
+        body: raw,
+      };
+      requests.push(captured);
+      const response = responder?.(captured) ?? { status: 200, body: { ok: true } };
+      res.statusCode = response.status;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify(response.body));
+    });
+  });
+
+  await new Promise<void>((resolveListen) => server.listen(0, '127.0.0.1', resolveListen));
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') throw new Error('stub server has no address');
+  const baseUrl = `http://127.0.0.1:${addr.port}`;
+
+  return {
+    baseUrl,
+    requests,
+    setResponder: (fn) => {
+      responder = fn;
+    },
+    close: () =>
+      new Promise<void>((resolveClose, rejectClose) => {
+        server.close((err) => (err ? rejectClose(err) : resolveClose()));
+      }),
+  };
+}
+
+async function runCli(
+  args: string[],
+  options: { env?: NodeJS.ProcessEnv } = {},
+): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...options.env,
+  };
+  delete env.NODE_OPTIONS;
+  try {
+    const { stdout, stderr } = await execFileP(
+      process.execPath,
+      [TSX_CLI, CLI_SRC, ...args],
+      {
+        cwd: DAEMON_ROOT,
+        env,
+        timeout: 15_000,
+        maxBuffer: 4 * 1024 * 1024,
+      },
+    );
+    return { stdout, stderr, code: 0 };
+  } catch (err) {
+    const failed = err as { stdout?: string; stderr?: string; code?: number | null };
+    return {
+      stdout: failed.stdout ?? '',
+      stderr: failed.stderr ?? '',
+      code: failed.code ?? 1,
+    };
+  }
+}
+
+describe('od conversation info', () => {
+  let stub: StubServer;
+
+  beforeAll(async () => {
+    stub = await startStubServer();
+  });
+
+  afterEach(() => {
+    stub.requests.length = 0;
+    stub.setResponder(() => null);
+  });
+
+  afterAll(async () => {
+    await stub.close();
+  });
+
+  it('fails with usage status 2 if --project is missing', async () => {
+    const { stdout, stderr, code } = await runCli(['conversation', 'info', 'c1']);
+    expect(code).toBe(2);
+    expect(stderr).toMatch(/Usage: od conversation info <conversationId> --project <projectId>/);
+    expect(stub.requests.length).toBe(0);
+  });
+
+  it('reports not-found on 404 rather than daemon-not-running', async () => {
+    stub.setResponder((req) => {
+      if (req.url.includes('/api/projects/p1/conversations/c1')) {
+        return { status: 404, body: { error: 'Not found' } };
+      }
+      return null;
+    });
+
+    const { stdout, stderr, code } = await runCli([
+      'conversation',
+      'info',
+      'c1',
+      '--project',
+      'p1',
+      '--json',
+    ], {
+      env: { OD_DAEMON_URL: stub.baseUrl },
+    });
+
+    // Debug
+    console.log('404 stdout:', stdout);
+    console.log('404 stderr:', stderr);
+
+    expect(code).not.toBe(0);
+    const err = JSON.parse(stdout || stderr);
+    expect(err.error.code).toBe('not-found');
+    expect(stub.requests.length).toBe(1);
+    expect(stub.requests[0]?.url).toBe('/api/projects/p1/conversations/c1');
+  });
+
+  it('prints successful JSON when correct parameters are provided', async () => {
+    const mockConvo = { id: 'c1', title: 'Hello', turns: [] };
+    stub.setResponder((req) => {
+      if (req.url === '/api/projects/p1/conversations/c1' && req.method === 'GET') {
+        return { status: 200, body: { conversation: mockConvo } };
+      }
+      return null;
+    });
+
+    const { stdout, stderr, code } = await runCli([
+      'conversation',
+      'info',
+      'c1',
+      '--project',
+      'p1',
+      '--json',
+    ], {
+      env: { OD_DAEMON_URL: stub.baseUrl },
+    });
+
+    expect(code).toBe(0);
+    const out = JSON.parse(stdout);
+    expect(out.conversation.id).toBe('c1');
+    expect(out.conversation.title).toBe('Hello');
+    expect(stub.requests.length).toBe(1);
+    expect(stub.requests[0]?.url).toBe('/api/projects/p1/conversations/c1');
+  });
+
+  it('reaches /api/projects/p1/conversations/c1 regardless of flag order', async () => {
+    const mockConvo = { id: 'c1', title: 'Flag test', turns: [] };
+    stub.setResponder((req) => {
+      if (req.url === '/api/projects/p1/conversations/c1' && req.method === 'GET') {
+        return { status: 200, body: { conversation: mockConvo } };
+      }
+      return null;
+    });
+
+    const { stdout, stderr, code } = await runCli([
+      'conversation',
+      'info',
+      '--project',
+      'p1',
+      'c1',
+      '--json',
+    ], {
+      env: { OD_DAEMON_URL: stub.baseUrl },
+    });
+
+    expect(code).toBe(0);
+    const out = JSON.parse(stdout);
+    expect(out.conversation.id).toBe('c1');
+    expect(stub.requests.length).toBe(1);
+    expect(stub.requests[0]?.url).toBe('/api/projects/p1/conversations/c1');
+  });
+});

--- a/apps/daemon/tests/routes/projects.test.ts
+++ b/apps/daemon/tests/routes/projects.test.ts
@@ -1841,3 +1841,77 @@ async function withSandboxMode<T>(run: () => Promise<T>): Promise<T> {
     else process.env.OD_SANDBOX_MODE = previous;
   }
 }
+
+describe('GET /api/projects/:id/conversations/:cid', () => {
+  let server: http.Server;
+  let baseUrl: string;
+  const tempDirs: string[] = [];
+
+  beforeAll(async () => {
+    const started = (await startServer({ port: 0, returnServer: true })) as {
+      url: string;
+      server: http.Server;
+    };
+    baseUrl = started.url;
+    server = started.server;
+  });
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  afterAll(() => {
+    return new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  function makeFolder(): string {
+    const d = mkdtempSync(path.join(tmpdir(), 'od-projects-routes-conv-'));
+    tempDirs.push(d);
+    return d;
+  }
+
+  it('succeeds for the owning project and returns 404 for a different project', async () => {
+    const folder1 = makeFolder();
+    await writeFile(path.join(folder1, 'index.html'), '<!doctype html>');
+    const folder2 = makeFolder();
+    await writeFile(path.join(folder2, 'index.html'), '<!doctype html>');
+
+    // 1. Create two projects
+    const p1Resp = await fetch(`${baseUrl}/api/import/folder`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ baseDir: folder1 }),
+    });
+    const p1 = (await p1Resp.json()) as { project: { id: string } };
+
+    const p2Resp = await fetch(`${baseUrl}/api/import/folder`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ baseDir: folder2 }),
+    });
+    const p2 = (await p2Resp.json()) as { project: { id: string } };
+
+    // 2. Create a conversation in Project 1
+    const convResp = await fetch(`${baseUrl}/api/projects/${p1.project.id}/conversations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Test Convo' }),
+    });
+    expect(convResp.status).toBe(200);
+    const conv = (await convResp.json()) as { conversation: { id: string; title: string } };
+    const cid = conv.conversation.id;
+
+    // 3. Fetch from owning project -> 200
+    const get1 = await fetch(`${baseUrl}/api/projects/${p1.project.id}/conversations/${cid}`);
+    expect(get1.status).toBe(200);
+    const get1Body = (await get1.json()) as { conversation: { id: string; title: string } };
+    expect(get1Body.conversation.id).toBe(cid);
+    expect(get1Body.conversation.title).toBe('Test Convo');
+
+    // 4. Fetch from different project -> 404 (not daemon-not-running)
+    const get2 = await fetch(`${baseUrl}/api/projects/${p2.project.id}/conversations/${cid}`);
+    expect(get2.status).toBe(404);
+  });
+});


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #6116 

## Why
od conversation info <conversationId> was failing with a daemon-not-running error despite the daemon running properly
<!-- Why are you opening this PR? Cover two things:
       - Your use case — what made you write this today? Did you hit it yourself
         while building on top of OD, are you scratching an itch for a team, or
         are you speculatively adding for others? All are fine, but say which.
       - The pain being addressed — user-facing problem, technical debt, a prod
         issue, or unblocking another change.
     For non-trivial features, please open a discussion or issue first to align
     on scope and UX before writing code. -->


## What users will see
Running od conversation info <conversationId> now requires the --project <projectId> flag (consistent with od conversation list <projectId>) and correctly fetches and prints the conversation JSON.
<!-- Describe the change from a user's perspective, not in code terms. Examples:
       - "Settings → AI Providers has a new 'Custom endpoint' field, off by default"
       - "Right-clicking a design file shows a new 'Duplicate' option"
       - "Default model changed from X to Y — existing users will notice on first launch"
       - "New `od skills install <name>` subcommand"
     Skip this section only if you check "None" below. -->


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<!-- If you checked "UI" above, attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->


## Bug fix verification
Verified that od conversation info properly asks for --project and fetches the conversation without error.
Verified that all 18 existing CLI templates tests pass, confirming that the change to structuredHttpFailure does not break callers who supply explicit error mappings.
Verified this behaves the same across OS environments (Windows / macOS / Linux).
<!-- Skip if this PR isn't a bug fix.

     Per AGENTS.md → "Bug follow-up workflow", bugs should be encoded as a
     falsifiable test that goes red before the source change. Confirm:
       - Test path that reproduces the bug:
       - Did the test go red on `main` and green on this branch? (yes / no)
       - If a red spec wasn't cheap to write, explain why and what verification
         you did instead. -->

-


## Validation
pnpm guard
pnpm --filter @open-design/daemon test
pnpm typecheck
<!-- What you actually ran. Default minimum: `pnpm guard` + `pnpm typecheck`,
     plus the package-scoped tests/build for the files you changed
     (e.g. `pnpm --filter @open-design/web test`). -->

-
