### PR TITLE
feat(web): support folder attachments from composer

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -145,6 +145,11 @@ type ToolsTab = 'plugins' | 'skills' | 'mcp' | 'import';
 
 type MentionTab = 'all' | 'tabs' | 'files' | 'plugins' | 'skills' | 'mcp' | 'connectors';
 
+const FOLDER_INPUT_PROPS = {
+  webkitdirectory: '',
+  directory: '',
+} satisfies Record<string, string>;
+
 const USER_PLUGIN_SOURCE_KINDS = new Set<PluginSourceKind>([
   'user',
   'project',
@@ -580,6 +585,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       () => (draft ?? '').trim().length > 0,
     );
     const fileInputRef = useRef<HTMLInputElement | null>(null);
+    const folderInputRef = useRef<HTMLInputElement | null>(null);
     // The Lexical editor handle — drives text/mention/clear/focus from the
     // host. Replaces the old textareaRef + manual selection plumbing. IME
     // composition guarding now lives inside the editor's command handlers.
@@ -1715,10 +1721,13 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
 
     async function uploadFiles(files: File[]) {
       if (files.length === 0) return;
-      const id = await ensureProject();
-      if (!id) return;
-      setUploading(true);
       setUploadError(null);
+      const id = await ensureProject();
+      if (!id) {
+        setUploadError('Create or open a project before attaching files.');
+        return;
+      }
+      setUploading(true);
       // Cohort math is identical to the Design Files Upload button; see
       // `analytics/upload-tracking.ts`. v2 doc fires one
       // file_upload_result per surface so this path reports
@@ -2818,6 +2827,19 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                 e.target.value = '';
               }}
             />
+            <input
+              ref={folderInputRef}
+              data-testid="chat-folder-input"
+              type="file"
+              multiple
+              style={{ display: 'none' }}
+              {...FOLDER_INPUT_PROPS}
+              onChange={(e) => {
+                const files = Array.from(e.target.files ?? []);
+                void uploadFiles(files);
+                e.target.value = '';
+              }}
+            />
             <ComposerPlusMenu
               triggerTestId="chat-plus-trigger"
               placementPreference="up"
@@ -2894,6 +2916,14 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
                   element: 'attachment',
                 });
                 fileInputRef.current?.click();
+              }}
+              onAttachFolder={() => {
+                trackChatPanelClick(analytics.track, {
+                  page_name: 'chat_panel',
+                  area: 'chat_panel',
+                  element: 'attachment',
+                });
+                folderInputRef.current?.click();
               }}
               onReferenceProject={() => {
                 trackComposerBar({ element: 'plus_pick', resource_kind: 'workspace', resource_id: 'reference-project' });

--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -63,6 +63,10 @@ import { LibraryPicker } from './LibraryPicker';
 import { FigmaImportModal } from './FigmaImportModal';
 import { FigmaHelpModal } from './FigmaHelpModal';
 import {
+  formatFolderAttachmentSkippedNotice,
+  selectFolderAttachmentFiles,
+} from './folder-attachment-policy';
+import {
   ProjectReferenceModal,
   type ProjectReferenceSelection,
 } from './ProjectReferenceModal';
@@ -1719,8 +1723,16 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
       return onEnsureProject();
     }
 
-    async function uploadFiles(files: File[]) {
-      if (files.length === 0) return;
+    async function uploadFiles(files: File[], skippedFolderFileCount = 0) {
+      const skippedFolderNotice = skippedFolderFileCount > 0
+        ? ` ${formatFolderAttachmentSkippedNotice(skippedFolderFileCount)}`
+        : '';
+      if (files.length === 0) {
+        if (skippedFolderFileCount > 0) {
+          setUploadError(formatFolderAttachmentSkippedNotice(skippedFolderFileCount));
+        }
+        return;
+      }
       setUploadError(null);
       const id = await ensureProject();
       if (!id) {
@@ -1747,10 +1759,12 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
           const detail = result.error ? ` (${result.error})` : '';
           setUploadError(
             uploadedCount > 0
-              ? `Attached ${uploadedCount} file(s), but ${failedCount} failed${detail}.`
-              : `Attachment upload failed for ${failedCount} file(s)${detail}.`,
+              ? `Attached ${uploadedCount} file(s), but ${failedCount} failed${detail}.${skippedFolderNotice}`
+              : `Attachment upload failed for ${failedCount} file(s)${detail}.${skippedFolderNotice}`,
           );
           console.warn('Some attachments failed to upload', result.failed);
+        } else if (skippedFolderFileCount > 0) {
+          setUploadError(`Attached ${result.uploaded.length} file(s).${skippedFolderNotice}`);
         }
         trackFileUploadResult(analytics.track, {
           page_name: 'chat_panel',
@@ -1762,7 +1776,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
         });
       } catch (err) {
         const detail = err instanceof Error ? err.message : String(err);
-        setUploadError(`Attachment upload failed (${detail}).`);
+        setUploadError(`Attachment upload failed (${detail}).${skippedFolderNotice}`);
         trackFileUploadResult(analytics.track, {
           page_name: 'chat_panel',
           area: 'chat_composer',
@@ -2836,7 +2850,8 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
               {...FOLDER_INPUT_PROPS}
               onChange={(e) => {
                 const files = Array.from(e.target.files ?? []);
-                void uploadFiles(files);
+                const { accepted, skippedCount } = selectFolderAttachmentFiles(files);
+                void uploadFiles(accepted, skippedCount);
                 e.target.value = '';
               }}
             />

--- a/apps/web/src/components/ComposerPlusMenu.tsx
+++ b/apps/web/src/components/ComposerPlusMenu.tsx
@@ -175,6 +175,7 @@ export interface ComposerPlusMenuProps {
 
   /** Triggers file attachment (opens the native picker). */
   onAttachFiles: () => void;
+  onAttachFolder?: () => void;
   attachLoading?: boolean;
 
   /** Opens the reference-project picker. */
@@ -291,6 +292,7 @@ export function ComposerPlusMenu({
   onPickMcp,
   onAddMcp,
   onAttachFiles,
+  onAttachFolder,
   attachLoading,
   onReferenceProject,
   onLinkLocalCode,
@@ -605,6 +607,26 @@ export function ComposerPlusMenu({
             />
             <span>{t('chat.plus.attachFiles')}</span>
           </button>
+          {onAttachFolder ? (
+            <button
+              type="button"
+              role="menuitem"
+              className="plus-menu__item"
+              data-testid="composer-plus-attach-folder"
+              disabled={attachLoading}
+              onClick={() => {
+                close();
+                onAttachFolder();
+              }}
+            >
+              <Icon
+                name={attachLoading ? 'spinner' : 'folder'}
+                size={14}
+                className="plus-menu__item-icon"
+              />
+              <span>{t('ds.importFolder')}</span>
+            </button>
+          ) : null}
           {onReferenceProject ? (
             <button
               type="button"

--- a/apps/web/src/components/folder-attachment-policy.ts
+++ b/apps/web/src/components/folder-attachment-policy.ts
@@ -1,0 +1,107 @@
+export const MAX_FOLDER_ATTACHMENT_FILES = 120;
+export const MAX_FOLDER_ATTACHMENT_FILE_BYTES = 1024 * 1024;
+export const MAX_FOLDER_ATTACHMENT_TOTAL_BYTES = 24 * 1024 * 1024;
+
+const FOLDER_ATTACHMENT_SKIP_DIRS = new Set([
+  '.cache',
+  '.git',
+  '.hg',
+  '.next',
+  '.nuxt',
+  '.parcel-cache',
+  '.ssh',
+  '.svn',
+  '.turbo',
+  '.vercel',
+  '.vite',
+  '.yarn',
+  'bower_components',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'out',
+  'target',
+]);
+
+const FOLDER_ATTACHMENT_SECRET_FILES = new Set([
+  '.netrc',
+  '.npmrc',
+  '.pnpmrc',
+  '.pypirc',
+  '.yarnrc',
+  'id_dsa',
+  'id_ecdsa',
+  'id_ed25519',
+  'id_rsa',
+]);
+
+interface FolderAttachmentSelection {
+  readonly accepted: File[];
+  readonly skippedCount: number;
+}
+
+function normalizeFolderAttachmentPath(path: string): string {
+  return path.replace(/\\/g, '/').split('/').filter(Boolean).join('/');
+}
+
+function folderAttachmentRelativePath(file: File): string {
+  return normalizeFolderAttachmentPath(file.webkitRelativePath || file.name);
+}
+
+function folderAttachmentBaseName(path: string): string {
+  return (path.split('/').at(-1) ?? '').toLowerCase();
+}
+
+function isFolderAttachmentCredentialPath(relativePath: string): boolean {
+  const lowerPath = relativePath.toLowerCase();
+  const lowerParts = lowerPath.split('/');
+  const baseName = folderAttachmentBaseName(lowerPath);
+  if (baseName === '.env' || baseName.startsWith('.env.')) return true;
+  if (FOLDER_ATTACHMENT_SECRET_FILES.has(baseName)) return true;
+  if (
+    baseName.endsWith('.key')
+    || baseName.endsWith('.pem')
+    || baseName.endsWith('.p12')
+    || baseName.endsWith('.pfx')
+  ) {
+    return true;
+  }
+  if (baseName === 'credentials' && lowerParts.includes('.aws')) return true;
+  return baseName === 'application_default_credentials.json' && lowerParts.includes('gcloud');
+}
+
+function shouldSkipFolderAttachmentByPath(relativePath: string): boolean {
+  const lowerParts = relativePath.toLowerCase().split('/');
+  return lowerParts.some((part) => FOLDER_ATTACHMENT_SKIP_DIRS.has(part))
+    || isFolderAttachmentCredentialPath(relativePath);
+}
+
+export function selectFolderAttachmentFiles(files: File[]): FolderAttachmentSelection {
+  const accepted: File[] = [];
+  let totalBytes = 0;
+  let skippedCount = 0;
+
+  for (const file of files) {
+    const relativePath = folderAttachmentRelativePath(file);
+    if (
+      !relativePath
+      || shouldSkipFolderAttachmentByPath(relativePath)
+      || file.size > MAX_FOLDER_ATTACHMENT_FILE_BYTES
+      || accepted.length >= MAX_FOLDER_ATTACHMENT_FILES
+      || totalBytes + file.size > MAX_FOLDER_ATTACHMENT_TOTAL_BYTES
+    ) {
+      skippedCount += 1;
+      continue;
+    }
+    accepted.push(file);
+    totalBytes += file.size;
+  }
+
+  return { accepted, skippedCount };
+}
+
+export function formatFolderAttachmentSkippedNotice(skippedCount: number): string {
+  const skippedFiles = skippedCount === 1 ? 'file was' : 'files were';
+  return `${skippedCount} folder ${skippedFiles} skipped because they matched ignored directories, credential files, or upload limits.`;
+}

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -2068,10 +2068,6 @@ export async function importProjectFigma(
   }
 }
 
-// Multi-file project upload used by the chat composer's paste / drop /
-// picker. Each file lands flat in the project folder; the response is
-// reshaped into ChatAttachments so the composer can stage them without a
-// follow-up listFiles round-trip.
 const PROJECT_UPLOAD_BATCH_SIZE = 12;
 
 export interface ProjectUploadFailure {
@@ -2086,6 +2082,49 @@ export interface UploadProjectFilesResult {
   error?: string;
 }
 
+interface ProjectUploadPart {
+  file: File;
+  dir: string;
+  uploadName: string;
+  failureName: string;
+}
+
+function browserRelativePath(file: File): string {
+  if ('webkitRelativePath' in file && typeof file.webkitRelativePath === 'string') {
+    const relativePath = file.webkitRelativePath.trim();
+    if (relativePath) return relativePath;
+  }
+  return file.name;
+}
+
+function uploadPathSegments(file: File): string[] {
+  const parts = browserRelativePath(file)
+    .replace(/\\/g, '/')
+    .split('/')
+    .filter((part) => part.length > 0 && part !== '.' && part !== '..');
+  return parts.length > 0 ? parts : [file.name];
+}
+
+function normalizedUploadDir(dir: string | undefined): string {
+  return (dir ?? '')
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/^\/+|\/+$/g, '');
+}
+
+function uploadPart(file: File, targetDir: string): ProjectUploadPart {
+  const parts = uploadPathSegments(file);
+  const uploadName = parts[parts.length - 1] ?? file.name;
+  const relativeDir = parts.slice(0, -1).join('/');
+  const dir = [targetDir, relativeDir].filter(Boolean).join('/');
+  return {
+    file,
+    dir,
+    uploadName,
+    failureName: dir ? `${dir}/${uploadName}` : uploadName,
+  };
+}
+
 export async function uploadProjectFiles(
   projectId: string,
   files: File[],
@@ -2096,17 +2135,27 @@ export async function uploadProjectFiles(
   const uploaded: ChatAttachment[] = [];
   const failed: ProjectUploadFailure[] = [];
   let error: string | undefined;
-  const targetDir = dir?.trim() ?? '';
+  const targetDir = normalizedUploadDir(dir);
+  const parts = files.map((file) => uploadPart(file, targetDir));
 
-  for (let i = 0; i < files.length; i += PROJECT_UPLOAD_BATCH_SIZE) {
-    const batch = files.slice(i, i + PROJECT_UPLOAD_BATCH_SIZE);
-    const remaining = files.slice(i + PROJECT_UPLOAD_BATCH_SIZE);
+  for (let i = 0; i < parts.length;) {
+    const batchDir = parts[i]?.dir ?? '';
+    let end = i;
+    while (
+      end < parts.length &&
+      parts[end]?.dir === batchDir &&
+      end - i < PROJECT_UPLOAD_BATCH_SIZE
+    ) {
+      end += 1;
+    }
+    const batch = parts.slice(i, end);
+    const remaining = parts.slice(end);
     const form = new FormData();
     // The `dir` field MUST be appended before the file parts: the daemon's
     // multer destination resolver reads req.body.dir as each file streams in,
     // and busboy only exposes fields parsed earlier in the multipart body.
-    if (targetDir) form.append('dir', targetDir);
-    for (const f of batch) form.append('files', f);
+    if (batchDir) form.append('dir', batchDir);
+    for (const part of batch) form.append('files', part.file, part.uploadName);
 
     try {
       const resp = await fetch(
@@ -2119,11 +2168,11 @@ export async function uploadProjectFiles(
           | { code?: string; error?: string }
           | null;
         error = payload?.error ?? `upload failed (${resp.status})`;
-        for (const f of batch) {
-          failed.push({ name: f.name, code: payload?.code, error: error });
+        for (const part of batch) {
+          failed.push({ name: part.failureName, code: payload?.code, error: error });
         }
-        for (const f of remaining) {
-          failed.push({ name: f.name, code: payload?.code, error: error });
+        for (const part of remaining) {
+          failed.push({ name: part.failureName, code: payload?.code, error: error });
         }
         break;
       }
@@ -2143,23 +2192,24 @@ export async function uploadProjectFiles(
       // Server preserves request order; any dropped files are unmatched at the batch tail.
       if (responseFiles.length < batch.length) {
         error ??= 'some files could not be stored';
-        for (const f of batch.slice(responseFiles.length)) {
+        for (const part of batch.slice(responseFiles.length)) {
           failed.push({
-            name: f.name,
+            name: part.failureName,
             error: error ?? 'some files could not be stored',
           });
         }
       }
     } catch {
       error = 'upload request failed';
-      for (const f of batch) {
-        failed.push({ name: f.name, error });
+      for (const part of batch) {
+        failed.push({ name: part.failureName, error });
       }
-      for (const f of remaining) {
-        failed.push({ name: f.name, error });
+      for (const part of remaining) {
+        failed.push({ name: part.failureName, error });
       }
       break;
     }
+    i = end;
   }
 
   return { uploaded, failed, error };

--- a/apps/web/tests/components/ChatComposer.search.test.tsx
+++ b/apps/web/tests/components/ChatComposer.search.test.tsx
@@ -104,6 +104,107 @@ describe('ChatComposer /search command', () => {
     expect(screen.getByTestId('staged-contexts').textContent).toContain('style.css');
   });
 
+  it('filters recursive folder selections and reports skipped files', async () => {
+    const onSend = vi.fn();
+    mockedUploadProjectFiles.mockResolvedValue({
+      uploaded: [
+        { path: 'site/index.html', name: 'index.html', kind: 'file', size: 5 },
+        { path: 'site/src/App.tsx', name: 'App.tsx', kind: 'file', size: 5 },
+      ],
+      failed: [],
+    });
+
+    render(
+      <ChatComposer
+        projectId="project-1"
+        projectFiles={[]}
+        streaming={false}
+        onEnsureProject={async () => 'project-1'}
+        onSend={onSend}
+        onStop={vi.fn()}
+      />,
+    );
+
+    const index = new File(['index'], 'index.html', { type: 'text/html' });
+    const app = new File(['app'], 'App.tsx', { type: 'text/typescript' });
+    const gitConfig = new File(['config'], 'config');
+    const dependency = new File(['pkg'], 'index.js', { type: 'text/javascript' });
+    const buildOutput = new File(['build'], 'bundle.js', { type: 'text/javascript' });
+    const envFile = new File(['SECRET=value'], '.env');
+    const npmrc = new File(['//registry.example/:_authToken=token'], '.npmrc');
+    const oversized = new File([new Uint8Array(1024 * 1024 + 1)], 'large.bin');
+    Object.defineProperty(index, 'webkitRelativePath', { value: 'site/index.html' });
+    Object.defineProperty(app, 'webkitRelativePath', { value: 'site/src/App.tsx' });
+    Object.defineProperty(gitConfig, 'webkitRelativePath', { value: 'site/.git/config' });
+    Object.defineProperty(dependency, 'webkitRelativePath', { value: 'site/node_modules/pkg/index.js' });
+    Object.defineProperty(buildOutput, 'webkitRelativePath', { value: 'site/dist/bundle.js' });
+    Object.defineProperty(envFile, 'webkitRelativePath', { value: 'site/.env' });
+    Object.defineProperty(npmrc, 'webkitRelativePath', { value: 'site/.npmrc' });
+    Object.defineProperty(oversized, 'webkitRelativePath', { value: 'site/assets/large.bin' });
+
+    fireEvent.change(screen.getByTestId('chat-folder-input'), {
+      target: { files: [index, app, gitConfig, dependency, buildOutput, envFile, npmrc, oversized] },
+    });
+
+    await waitFor(() => expect(mockedUploadProjectFiles).toHaveBeenCalledTimes(1));
+    expect(mockedUploadProjectFiles).toHaveBeenCalledWith('project-1', [index, app]);
+    await waitFor(() => expect(screen.getByText(/6 folder files were skipped/u)).toBeTruthy());
+    await waitFor(() => expect(screen.getByTestId('staged-contexts').textContent).toContain('index.html'));
+    expect(screen.getByTestId('staged-contexts').textContent).toContain('App.tsx');
+  });
+
+  it('does not upload a recursive folder selection when every file is skipped', async () => {
+    render(
+      <ChatComposer
+        projectId="project-1"
+        projectFiles={[]}
+        streaming={false}
+        onEnsureProject={async () => 'project-1'}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+      />,
+    );
+
+    const envFile = new File(['SECRET=value'], '.env');
+    const dependency = new File(['pkg'], 'index.js', { type: 'text/javascript' });
+    Object.defineProperty(envFile, 'webkitRelativePath', { value: 'site/.env' });
+    Object.defineProperty(dependency, 'webkitRelativePath', { value: 'site/node_modules/pkg/index.js' });
+
+    fireEvent.change(screen.getByTestId('chat-folder-input'), {
+      target: { files: [envFile, dependency] },
+    });
+
+    expect(mockedUploadProjectFiles).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.getByText(/2 folder files were skipped/u)).toBeTruthy());
+  });
+
+  it('keeps explicit file picker uploads outside the recursive folder policy', async () => {
+    mockedUploadProjectFiles.mockResolvedValue({
+      uploaded: [{ path: '.env', name: '.env', kind: 'file', size: 12 }],
+      failed: [],
+    });
+
+    render(
+      <ChatComposer
+        projectId="project-1"
+        projectFiles={[]}
+        streaming={false}
+        onEnsureProject={async () => 'project-1'}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+      />,
+    );
+
+    const envFile = new File(['SECRET=value'], '.env');
+    fireEvent.change(screen.getByTestId('chat-file-input'), {
+      target: { files: [envFile] },
+    });
+
+    await waitFor(() => expect(mockedUploadProjectFiles).toHaveBeenCalledTimes(1));
+    expect(mockedUploadProjectFiles).toHaveBeenCalledWith('project-1', [envFile]);
+    await waitFor(() => expect(screen.getByTestId('staged-contexts').textContent).toContain('.env'));
+  });
+
   it('shows a clear attachment error when no project can be created yet', async () => {
     render(
       <ChatComposer

--- a/apps/web/tests/components/ChatComposer.search.test.tsx
+++ b/apps/web/tests/components/ChatComposer.search.test.tsx
@@ -68,6 +68,66 @@ describe('ChatComposer /search command', () => {
     );
   });
 
+  it('uploads selected folders from the composer with browser-relative files', async () => {
+    const onSend = vi.fn();
+    mockedUploadProjectFiles.mockResolvedValue({
+      uploaded: [
+        { path: 'site/index.html', name: 'index.html', kind: 'file', size: 5 },
+        { path: 'site/assets/style.css', name: 'style.css', kind: 'file', size: 5 },
+      ],
+      failed: [],
+    });
+
+    render(
+      <ChatComposer
+        projectId="project-1"
+        projectFiles={[]}
+        streaming={false}
+        onEnsureProject={async () => 'project-1'}
+        onSend={onSend}
+        onStop={vi.fn()}
+      />,
+    );
+
+    const index = new File(['index'], 'index.html', { type: 'text/html' });
+    const style = new File(['style'], 'style.css', { type: 'text/css' });
+    Object.defineProperty(index, 'webkitRelativePath', { value: 'site/index.html' });
+    Object.defineProperty(style, 'webkitRelativePath', { value: 'site/assets/style.css' });
+
+    fireEvent.change(screen.getByTestId('chat-folder-input'), {
+      target: { files: [index, style] },
+    });
+
+    await waitFor(() => expect(mockedUploadProjectFiles).toHaveBeenCalledTimes(1));
+    expect(mockedUploadProjectFiles).toHaveBeenCalledWith('project-1', [index, style]);
+    await waitFor(() => expect(screen.getByTestId('staged-contexts').textContent).toContain('index.html'));
+    expect(screen.getByTestId('staged-contexts').textContent).toContain('style.css');
+  });
+
+  it('shows a clear attachment error when no project can be created yet', async () => {
+    render(
+      <ChatComposer
+        projectId={null}
+        projectFiles={[]}
+        streaming={false}
+        onEnsureProject={async () => null}
+        onSend={vi.fn()}
+        onStop={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('chat-folder-input'), {
+      target: {
+        files: [new File(['index'], 'index.html', { type: 'text/html' })],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Create or open a project before attaching files.')).toBeTruthy();
+    });
+    expect(mockedUploadProjectFiles).not.toHaveBeenCalled();
+  });
+
   it('appends uploaded attachments after already staged design-file context', async () => {
     const onSend = vi.fn();
     mockedUploadProjectFiles.mockResolvedValue({

--- a/apps/web/tests/components/ComposerPlusMenu.test.tsx
+++ b/apps/web/tests/components/ComposerPlusMenu.test.tsx
@@ -556,6 +556,7 @@ describe('ComposerPlusMenu module wiring', () => {
 
   it('invokes each Files / Code / Designs row handler', () => {
     const { props } = renderMenu({
+      onAttachFolder: vi.fn(),
       onReferenceProject: vi.fn(),
       onLinkLocalCode: vi.fn(),
       onImportFigma: vi.fn(),
@@ -571,6 +572,9 @@ describe('ComposerPlusMenu module wiring', () => {
 
     clickRow('composer-plus-attach');
     expect(props.onAttachFiles).toHaveBeenCalledTimes(1);
+
+    clickRow('composer-plus-attach-folder');
+    expect(props.onAttachFolder).toHaveBeenCalledTimes(1);
 
     clickRow('composer-plus-reference-project');
     expect(props.onReferenceProject).toHaveBeenCalledTimes(1);

--- a/apps/web/tests/components/folder-attachment-policy.test.ts
+++ b/apps/web/tests/components/folder-attachment-policy.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_FOLDER_ATTACHMENT_FILE_BYTES,
+  MAX_FOLDER_ATTACHMENT_FILES,
+  MAX_FOLDER_ATTACHMENT_TOTAL_BYTES,
+  selectFolderAttachmentFiles,
+} from '../../src/components/folder-attachment-policy';
+
+function fileWithPath(relativePath: string, contents: BlobPart = 'x'): File {
+  const name = relativePath.split('/').at(-1) ?? 'file.txt';
+  const file = new File([contents], name);
+  Object.defineProperty(file, 'webkitRelativePath', { value: relativePath });
+  return file;
+}
+
+describe('folder attachment policy', () => {
+  it('caps recursive folder selections by file count', () => {
+    const files = Array.from(
+      { length: MAX_FOLDER_ATTACHMENT_FILES + 1 },
+      (_, index) => fileWithPath(`site/src/file-${index}.txt`),
+    );
+
+    const result = selectFolderAttachmentFiles(files);
+
+    expect(result.accepted).toHaveLength(MAX_FOLDER_ATTACHMENT_FILES);
+    expect(result.skippedCount).toBe(1);
+  });
+
+  it('caps recursive folder selections by aggregate bytes', () => {
+    const oneMiB = new Uint8Array(MAX_FOLDER_ATTACHMENT_FILE_BYTES);
+    const aggregateQuota = MAX_FOLDER_ATTACHMENT_TOTAL_BYTES / MAX_FOLDER_ATTACHMENT_FILE_BYTES;
+    const files = Array.from(
+      { length: aggregateQuota + 1 },
+      (_, index) => fileWithPath(`site/src/large-${index}.bin`, oneMiB),
+    );
+
+    const result = selectFolderAttachmentFiles(files);
+
+    expect(result.accepted).toHaveLength(aggregateQuota);
+    expect(result.skippedCount).toBe(1);
+  });
+});

--- a/apps/web/tests/providers/registry.test.ts
+++ b/apps/web/tests/providers/registry.test.ts
@@ -834,6 +834,46 @@ describe('uploadProjectFiles', () => {
     expect(result.failed).toHaveLength(1);
     expect(result.failed[0]).toMatchObject({ name: 'c.txt' });
   });
+
+  it('uploads folder files into their browser-relative directories', async () => {
+    const index = new File(['index'], 'wrong-index-name.html', { type: 'text/html' });
+    const style = new File(['style'], 'wrong-style-name.css', { type: 'text/css' });
+    Object.defineProperty(index, 'webkitRelativePath', { value: 'site/index.html' });
+    Object.defineProperty(style, 'webkitRelativePath', { value: 'site/assets/style.css' });
+
+    const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      if (!(init?.body instanceof FormData)) {
+        throw new Error('expected multipart upload body');
+      }
+      const form = init.body;
+      const dir = form.get('dir');
+      if (dir === 'site') {
+        const files = form.getAll('files');
+        expect(files.map((file) => (file instanceof File ? file.name : ''))).toEqual(['index.html']);
+        return new Response(JSON.stringify({
+          files: [{ name: 'index.html', path: 'site/index.html', size: 5, originalName: 'index.html' }],
+        }), { status: 200 });
+      }
+      if (dir === 'site/assets') {
+        const files = form.getAll('files');
+        expect(files.map((file) => (file instanceof File ? file.name : ''))).toEqual(['style.css']);
+        return new Response(JSON.stringify({
+          files: [{ name: 'style.css', path: 'site/assets/style.css', size: 5, originalName: 'style.css' }],
+        }), { status: 200 });
+      }
+      throw new Error(`unexpected upload dir ${String(dir)}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await uploadProjectFiles('project-1', [index, style]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.failed).toEqual([]);
+    expect(result.uploaded.map((file) => file.path)).toEqual([
+      'site/index.html',
+      'site/assets/style.css',
+    ]);
+  });
 });
 
 describe('deploy provider registry helpers', () => {


### PR DESCRIPTION
﻿Fixes #211

## Why

I ran into the existing limitation tracked in #211 while reviewing the composer attachment flow: the project chat could attach individual files, but there was no native browser folder picker path. That made it awkward to bring a small site, asset bundle, or code-style folder into a project without manually recreating the directory structure file by file.

This PR addresses the remaining scope from the issue thread: expose folder selection from the composer, show a clear message when there is not yet a project to receive attachments, and preserve browser-relative paths during upload.

## What users will see

Project chat's plus menu now includes an "Import Folder" entry next to file attachment. Selecting a folder stages its files as attachments while preserving nested paths such as `site/index.html` and `site/assets/style.css`. If a project cannot be created or opened yet, the composer shows a clear attachment error instead of failing silently.

## Surface area

- [x] **UI** - new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** - new or changed
- [ ] **CLI / env var** - new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** - new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** - new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** - added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** - adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [ ] **Default behavior change** - changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** - internal refactor, docs, tests, or translation update only

## Screenshots

Not attached: the changed surface is a native browser directory picker entry, and the behavior is covered by focused component/provider tests that exercise the visible plus-menu row, folder input, staged attachments, and multipart upload grouping.

## Bug fix verification

-

## Validation

- `corepack pnpm --filter @open-design/web exec vitest run tests/providers/registry.test.ts tests/components/ChatComposer.search.test.ts tests/components/ComposerPlusMenu.test.tsx --reporter=verbose` (79 passed)
- `corepack pnpm --filter @open-design/web typecheck`
- `corepack pnpm --filter @open-design/web build`
- `corepack pnpm --filter @open-design/contracts build && corepack pnpm --filter @open-design/registry-protocol build && cd apps/daemon && corepack pnpm exec tsc -p tsconfig.json --noEmit && corepack pnpm exec tsc -p tsconfig.tests.json --noEmit`
- `corepack pnpm guard` currently fails on an unrelated existing rule violation in `apps/daemon/tests/runtimes/trae-cli.test.ts` that is already present on `origin/main`.
- `corepack pnpm typecheck` currently fails on this Windows environment because `apps/daemon` shells to bare `pnpm` and resolves pnpm 11.9.0; the equivalent Corepack daemon typecheck pieces above pass.
