### PR TITLE
fix(release): ship Linux AppImage

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -106,7 +106,7 @@ on:
         description: "Windows x64 installer download URL."
         value: ${{ jobs.publish.outputs.win_url }}
       linux_url:
-        description: "Linux x64 AppImage download URL (empty if linux disabled)."
+        description: "Linux x64 AppImage download URL."
         value: ${{ jobs.publish.outputs.linux_url }}
 
 permissions:
@@ -927,10 +927,7 @@ jobs:
   build_linux:
     name: Build release linux x64
     needs: [metadata, verify]
-    # Linux AppImage packaging is temporarily excluded from stable releases.
-    # Keep the job definition in place so the Linux lane can be re-enabled once
-    # the containerized pnpm bootstrap is fixed and reviewed.
-    if: ${{ needs.metadata.outputs.run_prepublish_jobs == 'true' && vars.ENABLE_STABLE_LINUX == 'true' }}
+    if: ${{ needs.metadata.outputs.run_prepublish_jobs == 'true' }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
@@ -992,6 +989,7 @@ jobs:
         env:
           OD_PACKAGED_E2E_LINUX_APPIMAGE: "1"
           OD_PACKAGED_E2E_NAMESPACE: ${{ needs.metadata.outputs.linux_namespace }}
+          OD_PACKAGED_NAMESPACE_BASE_ROOT: ${{ runner.temp }}/tools-pack/runtime/linux/namespaces
           OD_PACKAGED_E2E_SCREENSHOT_PATH: ${{ runner.temp }}/release-report/linux/screenshots/open-design-linux-smoke.png
           OD_PACKAGED_E2E_TOOLS_PACK_DIR: ${{ runner.temp }}/tools-pack
         run: |
@@ -1118,7 +1116,7 @@ jobs:
         needs.build_mac.result == 'success' &&
         needs.build_mac_intel.result == 'success' &&
         needs.build_win.result == 'success' &&
-        (needs.build_linux.result == 'success' || needs.build_linux.result == 'skipped')
+        needs.build_linux.result == 'success'
       }}
     runs-on: ubuntu-latest
     outputs:
@@ -1135,7 +1133,7 @@ jobs:
       GITHUB_SHA: ${{ needs.metadata.outputs.commit }}
       BASE_VERSION: ${{ needs.metadata.outputs.base_version }}
       BRANCH_NAME: ${{ needs.metadata.outputs.branch }}
-      ENABLE_LINUX: ${{ needs.build_linux.result == 'success' }}
+      ENABLE_LINUX: "true"
       ENABLE_MAC: "true"
       ENABLE_MAC_INTEL: "true"
       ENABLE_WIN: "true"
@@ -1188,7 +1186,6 @@ jobs:
           path: ${{ runner.temp }}/release-platform-manifests
 
       - name: Download linux publish manifest
-        if: ${{ needs.build_linux.result == 'success' }}
         uses: actions/download-artifact@v8
         with:
           name: open-design-release-linux-x64-publish-manifest
@@ -1226,14 +1223,12 @@ jobs:
           path: ${{ runner.temp }}/release-assets/win
 
       - name: Download linux release bundle
-        if: ${{ needs.build_linux.result == 'success' }}
         uses: actions/download-artifact@v8
         with:
           name: open-design-release-linux-release-assets
           path: ${{ runner.temp }}/release-assets/linux
 
       - name: Download linux e2e spec report
-        if: ${{ needs.build_linux.result == 'success' }}
         uses: actions/download-artifact@v8
         with:
           name: open-design-release-linux-e2e-report
@@ -1253,7 +1248,6 @@ jobs:
 
       - name: Prepare stable GitHub Release asset plan
         env:
-          ENABLE_LINUX_X64: ${{ needs.build_linux.result == 'success' }}
           RELEASE_CHANNEL: ${{ needs.metadata.outputs.channel }}
           RELEASE_GITHUB_ASSETS_DIR: ${{ runner.temp }}/github-release-assets
           RELEASE_GITHUB_ASSETS_SOURCE_DIR: ${{ runner.temp }}/release-assets
@@ -1312,7 +1306,7 @@ jobs:
       - name: Prepare release metadata
         env:
           BASE_VERSION: ${{ needs.metadata.outputs.base_version }}
-          ENABLE_LINUX_X64: ${{ needs.build_linux.result == 'success' }}
+          ENABLE_LINUX_X64: "true"
           ENABLE_MAC_ARM64: "true"
           ENABLE_MAC_X64: "true"
           ENABLE_WIN_X64: "true"
@@ -1360,7 +1354,7 @@ jobs:
 
       - name: Verify release metadata
         env:
-          ENABLE_LINUX_X64: ${{ needs.build_linux.result == 'success' }}
+          ENABLE_LINUX_X64: "true"
           ENABLE_MAC_ARM64: "true"
           ENABLE_MAC_X64: "true"
           ENABLE_WIN_X64: "true"

--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -1330,6 +1330,7 @@ export type SplashStageSurface = {
   isDestroyed(): boolean;
   webContents: {
     executeJavaScript(code: string, userGesture?: boolean): Promise<unknown>;
+    isDestroyed(): boolean;
     once(event: "did-finish-load", listener: () => void): void;
   };
 };
@@ -1341,12 +1342,17 @@ type SplashStageState = { ready: boolean; pending: SplashBootStage | null };
 const splashStageState = new WeakMap<SplashStageSurface, SplashStageState>();
 
 function applySplashStage(splash: SplashStageSurface, stage: SplashBootStage): void {
-  void splash.webContents
-    .executeJavaScript(
-      `window.__odSplashSetStage && window.__odSplashSetStage(${JSON.stringify(splashStagePayload(stage))});`,
-      true,
-    )
-    .catch(() => undefined);
+  if (splash.isDestroyed() || splash.webContents.isDestroyed()) return;
+  try {
+    void splash.webContents
+      .executeJavaScript(
+        `window.__odSplashSetStage && window.__odSplashSetStage(${JSON.stringify(splashStagePayload(stage))});`,
+        true,
+      )
+      .catch(() => undefined);
+  } catch (error) {
+    if (!(error instanceof Error) || error.message !== "Object has been destroyed") throw error;
+  }
 }
 
 /**

--- a/apps/desktop/tests/main/splash-stage-replay.test.ts
+++ b/apps/desktop/tests/main/splash-stage-replay.test.ts
@@ -23,19 +23,27 @@ type MockSplash = {
   executed: string[];
   emitDidFinishLoad: () => void;
   destroy: () => void;
+  failNextExecution: (error: Error) => void;
 };
 
 function createMockSplash(): MockSplash {
   const executed: string[] = [];
   let didFinishLoad: (() => void) | null = null;
   let destroyed = false;
+  let nextExecutionError: Error | null = null;
   const surface: SplashStageSurface = {
     isDestroyed: () => destroyed,
     webContents: {
       executeJavaScript: (code: string) => {
+        if (nextExecutionError != null) {
+          const error = nextExecutionError;
+          nextExecutionError = null;
+          throw error;
+        }
         executed.push(code);
         return Promise.resolve(undefined);
       },
+      isDestroyed: () => destroyed,
       once: (event, listener) => {
         if (event === 'did-finish-load') didFinishLoad = listener;
       },
@@ -47,6 +55,9 @@ function createMockSplash(): MockSplash {
     emitDidFinishLoad: () => didFinishLoad?.(),
     destroy: () => {
       destroyed = true;
+    },
+    failNextExecution: (error) => {
+      nextExecutionError = error;
     },
   };
 }
@@ -97,6 +108,26 @@ describe('splash boot-stage replay guard', () => {
     splash.destroy();
 
     setSplashStage(splash.surface, 'engine');
+    expect(splash.executed).toEqual([]);
+  });
+
+  test('does not replay a deferred stage after the splash is destroyed', () => {
+    const splash = createMockSplash();
+    registerSplashStageTracking(splash.surface);
+    setSplashStage(splash.surface, 'engine');
+    splash.destroy();
+
+    splash.emitDidFinishLoad();
+    expect(splash.executed).toEqual([]);
+  });
+
+  test('ignores destruction between the lifecycle check and execution', () => {
+    const splash = createMockSplash();
+    registerSplashStageTracking(splash.surface);
+    splash.emitDidFinishLoad();
+    splash.failNextExecution(new TypeError('Object has been destroyed'));
+
+    expect(() => setSplashStage(splash.surface, 'engine')).not.toThrow();
     expect(splash.executed).toEqual([]);
   });
 

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1369,6 +1369,8 @@ process.stdin.on("end", () => {
 
   it("[P2] preserves stable linux AppImage smoke reports for release publication", async () => {
     const workflow = await readFile(releaseStableWorkflowPath, "utf8");
+    const linuxJob = sectionBetween(workflow, "  build_linux:", "  publish_docker_image:");
+    const publishJob = sectionBetween(workflow, "  publish:", "  cleanup_partial_release_assets:");
     const linuxBuildStep = workflow.match(
       /- name: Build release linux artifacts\r?\n(?:.+\r?\n)+?(?=\r?\n      - name: Smoke release linux AppImage runtime)/m,
     );
@@ -1382,6 +1384,9 @@ process.stdin.on("end", () => {
     expect(workflow).toContain("Upload linux e2e spec report");
     expect(workflow).toContain("open-design-release-linux-e2e-report");
     expect(workflow).toContain("Download linux e2e spec report");
+    expect(linuxJob).toContain("if: ${{ needs.metadata.outputs.run_prepublish_jobs == 'true' }}");
+    expect(publishJob).toContain("needs.build_linux.result == 'success'");
+    expect(publishJob).not.toContain("needs.build_linux.result == 'skipped'");
     expectReleaseLinuxBuildPreservesEvidence(workflow, "Build release linux artifacts");
     expectReleaseLinuxSmokePreservesEvidenceBeforeApt(workflow, "Smoke release linux AppImage runtime");
   });

--- a/tools/pack/src/linux.ts
+++ b/tools/pack/src/linux.ts
@@ -38,9 +38,7 @@ const execFileAsync = promisify(execFile);
 const PRODUCT_NAME = "Open Design";
 const APP_IMAGE_PRODUCT_NAME = "Open-Design";
 const DESKTOP_LOG_ECHO_ENV = "OD_DESKTOP_LOG_ECHO";
-// The containerized build sets this to the standalone pnpm binary fetched by
-// buildDockerArgs; runProductionInstall reads it to avoid invoking `npm` inside
-// `electronuserland/builder:base`, which strips npm/npx/corepack.
+// Optional override for environments that cannot run npm directly.
 const PRODUCTION_INSTALL_PNPM_BIN_ENV = "OD_TOOLS_PACK_PNPM_BIN";
 const CONTAINER_PNPM_PATH = "/tmp/pnpm";
 const CONTAINER_PNPM_HOME = "/tmp/pnpm-home";
@@ -174,7 +172,8 @@ export function buildDockerArgs(
     `mv ${CONTAINER_PNPM_PATH}.tmp ${CONTAINER_PNPM_PATH} && ` +
     `chmod +x ${CONTAINER_PNPM_PATH} && ` +
     `PNPM_HOME=${CONTAINER_PNPM_HOME} PATH=${CONTAINER_PNPM_HOME}:$PATH ${CONTAINER_PNPM_PATH} env use --global ${CONTAINER_NODE_VERSION} && ` +
-    `export PNPM_HOME=${CONTAINER_PNPM_HOME} PATH=${CONTAINER_PNPM_HOME}:$PATH && ` +
+    `export PNPM_HOME=${CONTAINER_PNPM_HOME} PATH=${CONTAINER_PNPM_HOME}/nodejs/${CONTAINER_NODE_VERSION}/bin:${CONTAINER_PNPM_HOME}:$PATH && ` +
+    `ln -sf ${CONTAINER_PNPM_PATH} ${CONTAINER_PNPM_HOME}/pnpm && ` +
     `command -v node >/dev/null`;
   const pnpmCmd = CONTAINER_PNPM_PATH;
   const innerArgs = [
@@ -212,11 +211,13 @@ export function buildDockerArgs(
     "-e",
     "HOME=/home/builder",
     "-e",
+    "CI=true",
+    "-e",
     "ELECTRON_CACHE=/home/builder/.cache/electron",
     "-e",
     "ELECTRON_BUILDER_CACHE=/home/builder/.cache/electron-builder",
     "-e",
-    `${PRODUCTION_INSTALL_PNPM_BIN_ENV}=${CONTAINER_PNPM_PATH}`,
+    `npm_execpath=${CONTAINER_PNPM_PATH}`,
   ];
   if (config.telemetryRelayUrl != null) {
     dockerArgs.push("-e", `OPEN_DESIGN_TELEMETRY_RELAY_URL=${config.telemetryRelayUrl}`);

--- a/tools/pack/tests/linux.test.ts
+++ b/tools/pack/tests/linux.test.ts
@@ -133,11 +133,14 @@ describe("buildDockerArgs", () => {
     expect(args).toContain("/work/.tmp/tools-pack:/tools-pack");
   });
 
-  it("sets HOME and ELECTRON_CACHE env vars", () => {
+  it("sets the noninteractive container environment", () => {
     const args = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
     expect(args).toContain("HOME=/home/builder");
+    expect(args).toContain("CI=true");
     expect(args).toContain("ELECTRON_CACHE=/home/builder/.cache/electron");
     expect(args).toContain("ELECTRON_BUILDER_CACHE=/home/builder/.cache/electron-builder");
+    expect(args).toContain("npm_execpath=/tmp/pnpm");
+    expect(args).not.toContain("OD_TOOLS_PACK_PNPM_BIN=/tmp/pnpm");
   });
 
   it("passes the telemetry relay URL into containerized builds when configured", () => {
@@ -195,6 +198,8 @@ describe("buildDockerArgs", () => {
     expect(last).toMatch(/mv \/tmp\/pnpm\.tmp \/tmp\/pnpm/);
     expect(last).toMatch(/chmod \+x \/tmp\/pnpm/);
     expect(last).toMatch(/\/tmp\/pnpm env use --global 24\.\d+\.\d+/);
+    expect(last).toContain("PATH=/tmp/pnpm-home/nodejs/24.14.1/bin:/tmp/pnpm-home:$PATH");
+    expect(last).toContain("ln -sf /tmp/pnpm /tmp/pnpm-home/pnpm");
     expect(last).toMatch(/\/tmp\/pnpm install --frozen-lockfile/);
     expect(last).toMatch(/node tools\/pack\/bin\/tools-pack\.mjs linux build --to all --namespace default/);
     expect(last).not.toMatch(/\/tmp\/pnpm tools-pack linux build/);
@@ -315,13 +320,6 @@ describe("buildDockerArgs", () => {
     expect(last).toContain("--app-version '0.5.0-beta.1'\\''quoted'");
   });
 
-  it("exports OD_TOOLS_PACK_PNPM_BIN=/tmp/pnpm so the inner build's production install skips npm", () => {
-    const args = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
-    const envFlagIndex = args.findIndex(
-      (arg, i) => arg === "-e" && args[i + 1] === "OD_TOOLS_PACK_PNPM_BIN=/tmp/pnpm",
-    );
-    expect(envFlagIndex).toBeGreaterThan(-1);
-  });
 });
 
 describe("stopPackedLinuxHeadless", () => {
@@ -641,22 +639,6 @@ describe("resolveProductionInstallCommand", () => {
     });
   });
 
-  it("chains end-to-end with buildDockerArgs: docker exports OD_TOOLS_PACK_PNPM_BIN and the resolver returns the standalone pnpm install for that value", () => {
-    const dockerArgs = buildDockerArgs(makeConfig(), { uid: 1000, gid: 1000 });
-    const envFlagIndex = dockerArgs.findIndex(
-      (arg, i) => arg === "-e" && dockerArgs[i + 1]?.startsWith("OD_TOOLS_PACK_PNPM_BIN="),
-    );
-    expect(envFlagIndex).toBeGreaterThan(-1);
-    const envValue = dockerArgs[envFlagIndex + 1]?.split("=")[1];
-    expect(envValue).toBe("/tmp/pnpm");
-
-    const resolved = resolveProductionInstallCommand({ OD_TOOLS_PACK_PNPM_BIN: envValue });
-    expect(resolved).toEqual({
-      command: "/tmp/pnpm",
-      args: ["install", "--prod", "--no-lockfile", "--config.node-linker=hoisted"],
-    });
-    expect(resolved.command).not.toBe("npm");
-  });
 });
 
 describe("renderDesktopTemplate", () => {

--- a/tools/release/src/storage/prepare-github-assets.ts
+++ b/tools/release/src/storage/prepare-github-assets.ts
@@ -9,7 +9,6 @@ const sourceDir = required("RELEASE_GITHUB_ASSETS_SOURCE_DIR");
 const outputDir = required("RELEASE_GITHUB_ASSETS_DIR");
 const outputsPath = optional("RELEASE_OUTPUTS_PATH", join(dirname(outputDir), "github-assets-outputs.json"));
 const summaryPath = optional("RELEASE_SUMMARY_PATH", join(dirname(outputDir), "github-assets-summary.md"));
-const enableLinux = optional("ENABLE_LINUX_X64") === "true";
 
 if (releaseChannel !== "stable") {
   throw new Error(`prepare-github-assets only supports stable releases; got ${releaseChannel}`);
@@ -52,12 +51,8 @@ const allowedNames = [
   `open-design-${releaseVersion}-mac-x64.dmg.sha256`,
   `open-design-${releaseVersion}-win-x64-setup.exe`,
   `open-design-${releaseVersion}-win-x64-setup.exe.sha256`,
-  ...(enableLinux
-    ? [
-        `open-design-${releaseVersion}-linux-x64.AppImage`,
-        `open-design-${releaseVersion}-linux-x64.AppImage.sha256`,
-      ]
-    : []),
+  `open-design-${releaseVersion}-linux-x64.AppImage`,
+  `open-design-${releaseVersion}-linux-x64.AppImage.sha256`,
 ];
 
 const sourceFiles = listFiles(sourceDir);

--- a/tools/release/tests/github-assets.test.ts
+++ b/tools/release/tests/github-assets.test.ts
@@ -36,9 +36,11 @@ describe("stable GitHub Release asset plan", () => {
         `open-design-${version}-mac-x64.dmg.sha256`,
         `open-design-${version}-win-x64-setup.exe`,
         `open-design-${version}-win-x64-setup.exe.sha256`,
+        `open-design-${version}-linux-x64.AppImage`,
+        `open-design-${version}-linux-x64.AppImage.sha256`,
       ];
       for (const name of allowed) {
-        await writeAsset(source, name.includes("win") ? "win" : name.includes("x64") ? "mac-intel" : "mac", name);
+        await writeAsset(source, name.includes("linux") ? "linux" : name.includes("win") ? "win" : name.includes("x64") ? "mac-intel" : "mac", name);
       }
       for (const name of [
         `open-design-${version}-mac-arm64-payload.zip`,


### PR DESCRIPTION
Fixes #5983

## Why

While building the documented Linux AppImage from a normal, already-installed checkout, the containerized build failed through several package-manager bootstrap and production-install errors. The same build path is used by the stable Linux release lane.

Open Design already had AppImage packaging, checksum generation, lifecycle smoke coverage, metadata, and GitHub asset publication. However, the container build was unreliable and stable releases could skip Linux entirely, leaving Linux users without a downloadable release asset.

This PR fixes the existing container path and makes the Linux x64 AppImage a required stable asset, following the same fail-closed behavior as macOS and Windows.

## What users will see

Future automated stable GitHub Releases include:

- `open-design-<version>-linux-x64.AppImage`
- `open-design-<version>-linux-x64.AppImage.sha256`

The release will not publish if the Linux build or packaged-runtime smoke test fails. Existing releases are not backfilled, and Linux in-app updating remains unsupported.

## Surface area

- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)

## Screenshots

Not applicable; there are no UI changes.

## Bug fix verification

- Reproduction tests:
  - `tools/pack/tests/linux.test.ts`
  - `apps/desktop/tests/main/splash-stage-replay.test.ts`
  - `tools/release/tests/github-assets.test.ts`
  - `e2e/tests/packaged-smoke-workflow.test.ts`
- The focused tests failed against `main` before the implementation and pass on this branch.
- A fresh containerized AppImage was built from the rebased branch and passed the repository-owned install, start, health, screenshot, log, stop, and uninstall lifecycle.

## Validation

- `pnpm guard`
- `pnpm --filter @open-design/desktop typecheck`
- `pnpm --filter @open-design/tools-pack typecheck`
- `pnpm --filter @open-design/tools-release typecheck`
- `pnpm --filter @open-design/e2e typecheck`
- `actionlint -color` using CI-pinned actionlint 1.7.12 and ShellCheck 0.11.0
- Desktop splash regression: 7 passed
- Tools-pack Linux regression: 59 passed
- Stable GitHub asset plan: 1 passed
- Release workflow topology: 53 passed
- Containerized AppImage build: passed
- Exact-artifact Linux lifecycle E2E: 1 passed, 1 unrelated headless test skipped
- Built artifact size: 447,589,784 bytes
- Built artifact SHA-256: `9fb41a78031a15b74321af372185947ccc88a8e6d76d98fdaa7ef34b297df936`