### PR TITLE
fix(desktop): guard splash updates after teardown

### DIFF
--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -1330,6 +1330,7 @@ export type SplashStageSurface = {
   isDestroyed(): boolean;
   webContents: {
     executeJavaScript(code: string, userGesture?: boolean): Promise<unknown>;
+    isDestroyed(): boolean;
     once(event: "did-finish-load", listener: () => void): void;
   };
 };
@@ -1341,12 +1342,17 @@ type SplashStageState = { ready: boolean; pending: SplashBootStage | null };
 const splashStageState = new WeakMap<SplashStageSurface, SplashStageState>();
 
 function applySplashStage(splash: SplashStageSurface, stage: SplashBootStage): void {
-  void splash.webContents
-    .executeJavaScript(
-      `window.__odSplashSetStage && window.__odSplashSetStage(${JSON.stringify(splashStagePayload(stage))});`,
-      true,
-    )
-    .catch(() => undefined);
+  if (splash.isDestroyed() || splash.webContents.isDestroyed()) return;
+  try {
+    void splash.webContents
+      .executeJavaScript(
+        `window.__odSplashSetStage && window.__odSplashSetStage(${JSON.stringify(splashStagePayload(stage))});`,
+        true,
+      )
+      .catch(() => undefined);
+  } catch (error) {
+    if (!(error instanceof Error) || error.message !== "Object has been destroyed") throw error;
+  }
 }
 
 /**

--- a/apps/desktop/tests/main/splash-stage-replay.test.ts
+++ b/apps/desktop/tests/main/splash-stage-replay.test.ts
@@ -23,19 +23,27 @@ type MockSplash = {
   executed: string[];
   emitDidFinishLoad: () => void;
   destroy: () => void;
+  failNextExecution: (error: Error) => void;
 };
 
 function createMockSplash(): MockSplash {
   const executed: string[] = [];
   let didFinishLoad: (() => void) | null = null;
   let destroyed = false;
+  let nextExecutionError: Error | null = null;
   const surface: SplashStageSurface = {
     isDestroyed: () => destroyed,
     webContents: {
       executeJavaScript: (code: string) => {
+        if (nextExecutionError != null) {
+          const error = nextExecutionError;
+          nextExecutionError = null;
+          throw error;
+        }
         executed.push(code);
         return Promise.resolve(undefined);
       },
+      isDestroyed: () => destroyed,
       once: (event, listener) => {
         if (event === 'did-finish-load') didFinishLoad = listener;
       },
@@ -47,6 +55,9 @@ function createMockSplash(): MockSplash {
     emitDidFinishLoad: () => didFinishLoad?.(),
     destroy: () => {
       destroyed = true;
+    },
+    failNextExecution: (error) => {
+      nextExecutionError = error;
     },
   };
 }
@@ -97,6 +108,26 @@ describe('splash boot-stage replay guard', () => {
     splash.destroy();
 
     setSplashStage(splash.surface, 'engine');
+    expect(splash.executed).toEqual([]);
+  });
+
+  test('does not replay a deferred stage after the splash is destroyed', () => {
+    const splash = createMockSplash();
+    registerSplashStageTracking(splash.surface);
+    setSplashStage(splash.surface, 'engine');
+    splash.destroy();
+
+    splash.emitDidFinishLoad();
+    expect(splash.executed).toEqual([]);
+  });
+
+  test('ignores destruction between the lifecycle check and execution', () => {
+    const splash = createMockSplash();
+    registerSplashStageTracking(splash.surface);
+    splash.emitDidFinishLoad();
+    splash.failNextExecution(new TypeError('Object has been destroyed'));
+
+    expect(() => setSplashStage(splash.surface, 'engine')).not.toThrow();
     expect(splash.executed).toEqual([]);
   });
 


### PR DESCRIPTION
Fixes #6136

## Why

I hit this while running the App Image on Linux. A deferred splash-stage update could run after the splash window had already been destroyed, causing Electron to synchronously throw `Object has been destroyed`.

The existing Promise rejection handler did not catch this because `executeJavaScript` threw before returning a Promise. This race could terminate the packaged desktop process during splash teardown.

This fix guards the final execution boundary and suppresses only Electron's exact teardown error. Unrelated synchronous errors still propagate.

## What users will see

There is no visual change to the splash screen. The desktop app no longer crashes when splash teardown races with a deferred status update.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; there is no visual UI change.

## Bug fix verification

- Test path: `apps/desktop/tests/main/splash-stage-replay.test.ts`
- The tests went red on `main` and green on this branch: yes.
- Coverage reproduces both deferred replay after splash destruction and synchronous destruction between the lifecycle check and `executeJavaScript`.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/main/splash-stage-replay.test.ts` — 7 passed
- `pnpm --filter @open-design/desktop test` — 271 passed
- `pnpm --filter @open-design/desktop typecheck`
- `pnpm --filter @open-design/desktop build`
- `pnpm guard`
- `git diff --check`