### PR TITLE
refactor(desktop): extract deferred launch and release lifecycle, completing the updater split

### DIFF
--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -3,7 +3,6 @@ import { spawn } from "node:child_process";
 import { createReadStream } from "node:fs";
 import {
   access,
-  chmod,
   lstat,
   mkdir,
   readdir,
@@ -11,7 +10,6 @@ import {
   rename,
   rm,
   stat,
-  writeFile,
 } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 import { pipeline } from "node:stream/promises";
@@ -25,8 +23,6 @@ import {
 } from "@open-design/download";
 import {
   LAUNCHER_SCHEMA_VERSION,
-  buildLauncherAfterQuitArgs,
-  buildLauncherDelegatedArgs,
 } from "@open-design/launcher-proto";
 import {
   DESKTOP_UPDATE_ACTIONS,
@@ -104,9 +100,24 @@ import {
 
 export type { LauncherPayloadExtractInput } from "./updater/payload.js";
 import {
+  DEFERRED_INSTALLER_TIMEOUT_MS,
+  launchMacInstallerAfterQuit,
+  launchPayloadAppAfterQuit,
+  launchWindowsInstallerAfterQuit,
+  type DeferredAppLaunchInput,
+  type DeferredInstallerLaunchInput,
+  type DeferredLaunchResult,
+  type SpawnInstallerHelper,
+} from "./updater/deferred-launch.js";
+
+export type {
+  DeferredAppLaunchInput,
+  DeferredInstallerLaunchInput,
+  DeferredLaunchResult,
+} from "./updater/deferred-launch.js";
+import {
   BACK_DIR,
   DOWNLOADS_DIR,
-  HELPERS_DIR,
   LOCK_OWNER_FILE,
   RELEASES_DIR,
   STAGING_DIR,
@@ -127,7 +138,6 @@ import {
 } from "./updater/store.js";
 
 const RELEASE_CLEANUP_DESCRIPTOR_VERSION = 1;
-const DEFERRED_INSTALLER_TIMEOUT_MS = 10 * 60 * 1000;
 const ARTIFACT_DOWNLOAD_MAX_ATTEMPTS = 3;
 
 export type DesktopUpdaterDeps = {
@@ -145,41 +155,6 @@ export type DesktopUpdaterDeps = {
 };
 
 export type DesktopUpdaterLogger = Pick<Console, "error" | "warn"> & Partial<Pick<Console, "info">>;
-type DetachedProcess = Pick<ReturnType<typeof spawn>, "once" | "unref">;
-type SpawnInstallerHelper = (
-  command: string,
-  args: string[],
-  options: { cwd?: string; detached?: true; stdio: "ignore"; windowsHide: true },
-) => DetachedProcess;
-
-export type DeferredInstallerLaunchInput = {
-  appPid: number;
-  /** Stable namespace root inherited by the installer helper process. */
-  cwd: string;
-  installerPath: string;
-  root: string;
-  timeoutMs: number;
-};
-
-export type DeferredAppLaunchInput = {
-  appPid: number;
-  /** Stable namespace root inherited by the next payload process. */
-  cwd: string;
-  /**
-   * Pointer the activation pre-armed attempt.json for; passed to the spawned
-   * payload as `--od-launcher-delegated-*` so it recognizes that attempt as
-   * its own launch in progress rather than a previous failure.
-   */
-  delegated?: { generation: number; version: string };
-  launchPath: string;
-  root: string;
-  timeoutMs: number;
-};
-
-export type DeferredLaunchResult = {
-  error?: string;
-  helperLogPath?: string;
-};
 
 export type LoadedRelease = {
   path: string;
@@ -290,240 +265,6 @@ function desktopDownloadError(error: unknown): DesktopUpdateErrorSnapshot {
     return createError("download-target-locked", "another update download is already using this target");
   }
   return createError("download-failed", userFacingDownloadErrorMessage(error));
-}
-
-function macDeferredInstallerScript(): string {
-  return `#!/bin/sh
-set -eu
-target_pid="$1"
-installer_path="$2"
-timeout_seconds="$3"
-cleanup() {
-  rm -f "$0"
-}
-trap cleanup EXIT
-deadline=$(($(date +%s) + timeout_seconds))
-while kill -0 "$target_pid" 2>/dev/null; do
-  if [ "$(date +%s)" -ge "$deadline" ]; then
-    exit 1
-  fi
-  sleep 1
-done
-open "$installer_path" >/dev/null 2>&1 &
-exit 0
-`;
-}
-
-function windowsDeferredInstallerScript(): string {
-  return `param(
-  [Parameter(Mandatory = $true)]
-  [int]$TargetPid,
-
-  [Parameter(Mandatory = $true)]
-  [string]$InstallerPath,
-
-  [Parameter(Mandatory = $true)]
-  [int]$TimeoutMs,
-
-  [Parameter(Mandatory = $true)]
-  [string]$LogPath
-)
-
-$ErrorActionPreference = "Stop"
-
-function Write-HelperLog {
-  param([string]$Message)
-  try {
-    Add-Content -LiteralPath $LogPath -Value ("{0:o} {1}" -f (Get-Date), $Message)
-  } catch {
-  }
-}
-
-try {
-  Write-HelperLog ("armed for pid={0} installer={1}" -f $TargetPid, $InstallerPath)
-  $deadline = (Get-Date).AddMilliseconds($TimeoutMs)
-  while ($null -ne (Get-Process -Id $TargetPid -ErrorAction SilentlyContinue)) {
-    if ((Get-Date) -ge $deadline) {
-      throw ("timed out waiting for pid={0}" -f $TargetPid)
-    }
-    Start-Sleep -Milliseconds 250
-  }
-
-  Write-HelperLog ("observed pid={0} exit; opening installer" -f $TargetPid)
-  Write-HelperLog "waiting for launch handoff"
-  Start-Sleep -Milliseconds 1500
-  Start-Process -FilePath $InstallerPath -WorkingDirectory (Split-Path -Parent $InstallerPath)
-  Write-HelperLog "installer launch requested"
-} catch {
-  Write-HelperLog ("failed: {0}" -f $_.Exception.Message)
-  exit 1
-} finally {
-  Remove-Item -LiteralPath $PSCommandPath -Force -ErrorAction SilentlyContinue
-}
-`;
-}
-
-function windowsDeferredInstallerLauncherScript(): string {
-  return `param(
-  [Parameter(Mandatory = $true)]
-  [string]$PowerShellPath,
-
-  [Parameter(Mandatory = $true)]
-  [string]$HelperPath,
-
-  [Parameter(Mandatory = $true)]
-  [int]$TargetPid,
-
-  [Parameter(Mandatory = $true)]
-  [string]$InstallerPath,
-
-  [Parameter(Mandatory = $true)]
-  [int]$TimeoutMs,
-
-  [Parameter(Mandatory = $true)]
-  [string]$LogPath
-)
-
-$ErrorActionPreference = "Stop"
-
-function Quote-WindowsPowerShellArgument {
-  param([string]$Value)
-  return '"' + ($Value -replace '"', '\\"') + '"'
-}
-
-function Write-LauncherLog {
-  param([string]$Message)
-  try {
-    Add-Content -LiteralPath $LogPath -Value ("{0:o} {1}" -f (Get-Date), $Message)
-  } catch {
-  }
-}
-
-try {
-  Write-LauncherLog ("launching helper={0}" -f $HelperPath)
-  $arguments = @(
-    "-NoLogo",
-    "-NoProfile",
-    "-NonInteractive",
-    "-ExecutionPolicy",
-    "Bypass",
-    "-File",
-    (Quote-WindowsPowerShellArgument $HelperPath),
-    "-TargetPid",
-    $TargetPid.ToString(),
-    "-InstallerPath",
-    (Quote-WindowsPowerShellArgument $InstallerPath),
-    "-TimeoutMs",
-    $TimeoutMs.ToString(),
-    "-LogPath",
-    (Quote-WindowsPowerShellArgument $LogPath)
-  ) -join " "
-  Start-Process -FilePath $PowerShellPath -WindowStyle Hidden -ArgumentList $arguments
-  Write-LauncherLog "helper launch requested"
-} catch {
-  Write-LauncherLog ("launcher failed: {0}" -f $_.Exception.Message)
-  exit 1
-} finally {
-  Remove-Item -LiteralPath $PSCommandPath -Force -ErrorAction SilentlyContinue
-}
-`;
-}
-
-function windowsPowerShellCommand(env: NodeJS.ProcessEnv = process.env): string {
-  const systemRoot = env.SystemRoot ?? env.SYSTEMROOT ?? "C:\\Windows";
-  return join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
-}
-
-async function launchMacInstallerAfterQuit(
-  input: DeferredInstallerLaunchInput,
-  deps: { now: () => Date; spawnDetached: SpawnInstallerHelper },
-): Promise<string> {
-  try {
-    const helpersRoot = await ensureOwnedSubdir(input.root, HELPERS_DIR);
-    const suffix = `${deps.now().getTime().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
-    const scriptPath = join(helpersRoot, `open-installer-after-quit-${suffix}.sh`);
-    await writeFile(scriptPath, macDeferredInstallerScript(), { encoding: "utf8", mode: 0o700 });
-    await chmod(scriptPath, 0o700);
-    const timeoutSeconds = Math.max(1, Math.ceil(input.timeoutMs / 1000)).toString();
-    const child = deps.spawnDetached(
-      "/bin/sh",
-      [scriptPath, input.appPid.toString(), input.installerPath, timeoutSeconds],
-      { cwd: input.cwd, detached: true, stdio: "ignore", windowsHide: true },
-    );
-    child.unref();
-    return "";
-  } catch (error) {
-    return error instanceof Error ? error.message : String(error);
-  }
-}
-
-async function launchWindowsInstallerAfterQuit(
-  input: DeferredInstallerLaunchInput,
-  deps: { now: () => Date; spawnDetached: SpawnInstallerHelper },
-): Promise<string> {
-  try {
-    const helpersRoot = await ensureOwnedSubdir(input.root, HELPERS_DIR);
-    const suffix = `${deps.now().getTime().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
-    const scriptPath = join(helpersRoot, `open-installer-after-quit-${suffix}.ps1`);
-    const launcherPath = join(helpersRoot, `open-installer-after-quit-${suffix}.launcher.ps1`);
-    const logPath = join(helpersRoot, `open-installer-after-quit-${suffix}.log`);
-    const powerShellPath = windowsPowerShellCommand();
-    await writeFile(scriptPath, windowsDeferredInstallerScript(), { encoding: "utf8" });
-    await writeFile(launcherPath, windowsDeferredInstallerLauncherScript(), { encoding: "utf8" });
-    const child = deps.spawnDetached(
-      powerShellPath,
-      [
-        "-NoLogo",
-        "-NoProfile",
-        "-NonInteractive",
-        "-ExecutionPolicy",
-        "Bypass",
-        "-File",
-        launcherPath,
-        "-PowerShellPath",
-        powerShellPath,
-        "-HelperPath",
-        scriptPath,
-        "-TargetPid",
-        input.appPid.toString(),
-        "-InstallerPath",
-        input.installerPath,
-        "-TimeoutMs",
-        input.timeoutMs.toString(),
-        "-LogPath",
-        logPath,
-      ],
-      { cwd: input.cwd, detached: true, stdio: "ignore", windowsHide: true },
-    );
-    child.unref();
-    return "";
-  } catch (error) {
-    return error instanceof Error ? error.message : String(error);
-  }
-}
-
-async function launchPayloadAppAfterQuit(
-  input: DeferredAppLaunchInput,
-  deps: { now: () => Date; spawnDetached: SpawnInstallerHelper },
-): Promise<DeferredLaunchResult> {
-  try {
-    const child = deps.spawnDetached(
-      input.launchPath,
-      [
-        ...buildLauncherAfterQuitArgs({ targetPid: input.appPid, timeoutMs: input.timeoutMs }),
-        ...(input.delegated == null ? [] : buildLauncherDelegatedArgs(input.delegated)),
-      ],
-      { cwd: input.cwd, detached: true, stdio: "ignore", windowsHide: true },
-    );
-    await new Promise<void>((resolveSpawn, rejectSpawn) => {
-      child.once("spawn", () => resolveSpawn());
-      child.once("error", rejectSpawn);
-    });
-    child.unref();
-    return {};
-  } catch (error) {
-    return { error: error instanceof Error ? error.message : String(error) };
-  }
 }
 
 async function cleanupBackDirectory(root: string, logger: DesktopUpdaterLogger): Promise<void> {

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -6,7 +6,6 @@ import {
   lstat,
   mkdir,
   readdir,
-  realpath,
   rename,
   rm,
   stat,
@@ -30,10 +29,8 @@ import {
   DESKTOP_UPDATE_STATES,
   type DesktopUpdateAction,
   type DesktopUpdateCacheLifecycleSummary,
-  type DesktopUpdateCacheLifecycleTrigger,
   type DesktopUpdateChecksumSnapshot,
   type DesktopUpdateErrorSnapshot,
-  type DesktopUpdateReleaseLifecycleState,
   type DesktopUpdateProgressSnapshot,
   type DesktopUpdateReinstallSnapshot,
   type DesktopUpdateStatusSnapshot,
@@ -69,7 +66,6 @@ import {
   isRecord,
   readJson,
   readJsonStrict,
-  stringField,
   writeJson,
 } from "./updater/support.js";
 import {
@@ -80,7 +76,6 @@ import {
   hasValidLauncherPayloadContext,
   releaseKey,
   releaseMatchesCandidate,
-  releaseVersionForChannel,
   remoteRequiresReinstall,
   resolveChecksum,
   resolveInstalledOuterVersion,
@@ -116,9 +111,11 @@ export type {
   DeferredLaunchResult,
 } from "./updater/deferred-launch.js";
 import {
-  BACK_DIR,
+  runUpdateReleaseLifecycle,
+  scheduleBackCleanup,
+} from "./updater/release-lifecycle.js";
+import {
   DOWNLOADS_DIR,
-  LOCK_OWNER_FILE,
   RELEASES_DIR,
   STAGING_DIR,
   STORE_METADATA_FILE,
@@ -130,14 +127,12 @@ import {
   logStoreError,
   rebuildOwnedUpdateRootForManualClear,
   storeShapeError,
-  type DesktopUpdaterStoreLayout,
   type IncomingRef,
   type OwnedRoot,
   type UpdateReleaseRef,
   type UpdateStoreMetadata,
 } from "./updater/store.js";
 
-const RELEASE_CLEANUP_DESCRIPTOR_VERSION = 1;
 const ARTIFACT_DOWNLOAD_MAX_ATTEMPTS = 3;
 
 export type DesktopUpdaterDeps = {
@@ -163,39 +158,6 @@ export type LoadedRelease = {
 
 type ActionOptions = {
   autoDownload?: boolean;
-};
-
-type ReleaseCleanupReason =
-  | "cleanup-failed"
-  | "current-version-or-newer"
-  | "manual-clear"
-  | "metadata-invalid"
-  | "metadata-missing"
-  | "older-than-current-version";
-
-type ReleaseCleanupEntry = {
-  currentVersion?: string;
-  deprecatedAt?: string;
-  error?: DesktopUpdateErrorSnapshot;
-  key: string;
-  metadataPath?: string;
-  path: string;
-  readyVersion?: string;
-  reason: ReleaseCleanupReason;
-  removedAt?: string;
-  state: DesktopUpdateReleaseLifecycleState;
-  updatedAt: string;
-  version?: string;
-};
-
-type ReleaseCleanupDescriptor = {
-  currentVersion?: string;
-  platform: string;
-  readyVersion?: string;
-  releases: ReleaseCleanupEntry[];
-  trigger: DesktopUpdateCacheLifecycleTrigger;
-  updatedAt: string;
-  version: typeof RELEASE_CLEANUP_DESCRIPTOR_VERSION;
 };
 
 export type DesktopUpdater = {
@@ -265,470 +227,6 @@ function desktopDownloadError(error: unknown): DesktopUpdateErrorSnapshot {
     return createError("download-target-locked", "another update download is already using this target");
   }
   return createError("download-failed", userFacingDownloadErrorMessage(error));
-}
-
-async function cleanupBackDirectory(root: string, logger: DesktopUpdaterLogger): Promise<void> {
-  const backDir = join(root, BACK_DIR);
-  const entry = await lstat(backDir).catch(() => null);
-  if (entry == null) return;
-  if (!entry.isDirectory() || entry.isSymbolicLink()) {
-    logger.warn("[open-design updater] skipped invalid update backup directory", backDir);
-    return;
-  }
-  const realBackDir = await realpath(backDir).catch(() => null);
-  if (realBackDir == null || !containsPath(root, realBackDir)) {
-    logger.warn("[open-design updater] skipped escaped update backup directory", backDir);
-    return;
-  }
-  const entries = await readdir(backDir);
-  await Promise.all(entries.map(async (entry) => {
-    const path = join(backDir, entry);
-    const resolved = resolve(path);
-    if (!containsPath(root, resolved)) return;
-    const stats = await lstat(resolved).catch(() => null);
-    if (stats == null || stats.isSymbolicLink()) return;
-    if (stats.isDirectory()) {
-      const real = await realpath(resolved).catch(() => null);
-      if (real == null || !containsPath(root, real)) return;
-    }
-    await rm(resolved, { force: true, recursive: true }).catch((error: unknown) => {
-      logger.warn("[open-design updater] failed to clean update backup entry", error);
-    });
-  }));
-}
-
-function scheduleBackCleanup(root: string, logger: DesktopUpdaterLogger): void {
-  void cleanupBackDirectory(root, logger).catch((error: unknown) => {
-    logger.warn("[open-design updater] failed to clean update backup directory", error);
-  });
-}
-
-function isReleaseLifecycleState(value: unknown): value is DesktopUpdateReleaseLifecycleState {
-  return value === "cleanup-deferred" ||
-    value === "cleanup-removed" ||
-    value === "deprecated" ||
-    value === "retained" ||
-    value === "unknown";
-}
-
-function isReleaseCleanupReason(value: unknown): value is ReleaseCleanupReason {
-  return value === "cleanup-failed" ||
-    value === "current-version-or-newer" ||
-    value === "manual-clear" ||
-    value === "metadata-invalid" ||
-    value === "metadata-missing" ||
-    value === "older-than-current-version";
-}
-
-function isDesktopUpdateErrorSnapshot(value: unknown): value is DesktopUpdateErrorSnapshot {
-  if (!isRecord(value)) return false;
-  return stringField(value, "code") != null && stringField(value, "message") != null;
-}
-
-function isReleaseCleanupEntry(value: unknown): value is ReleaseCleanupEntry {
-  if (!isRecord(value)) return false;
-  if (stringField(value, "key") == null) return false;
-  if (stringField(value, "path") == null) return false;
-  if (!isReleaseLifecycleState(value.state)) return false;
-  if (!isReleaseCleanupReason(value.reason)) return false;
-  if (stringField(value, "updatedAt") == null) return false;
-  if (value.currentVersion != null && typeof value.currentVersion !== "string") return false;
-  if (value.deprecatedAt != null && typeof value.deprecatedAt !== "string") return false;
-  if (value.metadataPath != null && typeof value.metadataPath !== "string") return false;
-  if (value.readyVersion != null && typeof value.readyVersion !== "string") return false;
-  if (value.removedAt != null && typeof value.removedAt !== "string") return false;
-  if (value.version != null && typeof value.version !== "string") return false;
-  if (value.error != null && !isDesktopUpdateErrorSnapshot(value.error)) return false;
-  return true;
-}
-
-function isReleaseCleanupDescriptor(value: unknown): value is ReleaseCleanupDescriptor {
-  if (!isRecord(value)) return false;
-  if (value.version !== RELEASE_CLEANUP_DESCRIPTOR_VERSION) return false;
-  if (typeof value.platform !== "string") return false;
-  if (value.trigger !== "cold-start" && value.trigger !== "manual" && value.trigger !== "next-version-ready") return false;
-  if (typeof value.updatedAt !== "string") return false;
-  if (value.currentVersion != null && typeof value.currentVersion !== "string") return false;
-  if (value.readyVersion != null && typeof value.readyVersion !== "string") return false;
-  if (!Array.isArray(value.releases)) return false;
-  return value.releases.every(isReleaseCleanupEntry);
-}
-
-function emptyLifecycleSummary(platform: string): DesktopUpdateCacheLifecycleSummary {
-  return {
-    platform,
-    releases: {
-      cleanupDeferred: 0,
-      cleanupRemoved: 0,
-      deprecated: 0,
-      errors: 0,
-      retained: 0,
-      total: 0,
-      unknown: 0,
-    },
-  };
-}
-
-function summarizeReleaseCleanupDescriptor(
-  descriptor: ReleaseCleanupDescriptor | null,
-  platform: string,
-): DesktopUpdateCacheLifecycleSummary {
-  if (descriptor == null) return emptyLifecycleSummary(platform);
-  const summary = emptyLifecycleSummary(descriptor.platform);
-  summary.lastRunAt = descriptor.updatedAt;
-  summary.lastTrigger = descriptor.trigger;
-  summary.releases.total = descriptor.releases.length;
-  for (const release of descriptor.releases) {
-    if (release.state === "cleanup-deferred") summary.releases.cleanupDeferred += 1;
-    if (release.state === "cleanup-removed") summary.releases.cleanupRemoved += 1;
-    if (release.state === "deprecated") summary.releases.deprecated += 1;
-    if (release.state === "retained") summary.releases.retained += 1;
-    if (release.state === "unknown") summary.releases.unknown += 1;
-    if (release.error != null) summary.releases.errors += 1;
-  }
-  return summary;
-}
-
-async function readReleaseCleanupDescriptor(layout: DesktopUpdaterStoreLayout): Promise<ReleaseCleanupDescriptor | null> {
-  const raw = await readJson<unknown>(layout.cleanupPath);
-  return isReleaseCleanupDescriptor(raw) ? raw : null;
-}
-
-function relativeStorePath(layout: DesktopUpdaterStoreLayout, path: string): string {
-  return relative(layout.root, path);
-}
-
-function releaseCleanupError(code: string, message: string, details?: unknown): DesktopUpdateErrorSnapshot {
-  return createError(code, message, details);
-}
-
-async function withUpdaterLifecycleLock<T>(
-  layout: DesktopUpdaterStoreLayout,
-  logger: DesktopUpdaterLogger,
-  task: () => Promise<T>,
-  options: { reclaimStale?: boolean } = {},
-): Promise<T | null> {
-  await mkdir(layout.stateRoot, { recursive: true });
-  const acquire = async (): Promise<boolean> => {
-    try {
-      await mkdir(layout.lockRoot);
-      return true;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-      return false;
-    }
-  };
-  let acquired = await acquire();
-  if (!acquired && options.reclaimStale === true) {
-    const owner = await readJson<unknown>(join(layout.lockRoot, LOCK_OWNER_FILE));
-    const ownerPid = isRecord(owner) && owner.owner === "open-design-updater-lifecycle"
-      && owner.version === RELEASE_CLEANUP_DESCRIPTOR_VERSION
-      && typeof owner.pid === "number" && Number.isSafeInteger(owner.pid) && owner.pid > 0
-      ? owner.pid
-      : null;
-    let ownerIsDead = false;
-    if (ownerPid != null) {
-      try {
-        process.kill(ownerPid, 0);
-      } catch (error) {
-        ownerIsDead = (error as NodeJS.ErrnoException).code === "ESRCH";
-      }
-    }
-    if (ownerIsDead) {
-      const staleLockRoot = `${layout.lockRoot}.stale-${process.pid}-${Date.now()}`;
-      try {
-        await rename(layout.lockRoot, staleLockRoot);
-        await rm(staleLockRoot, { force: true, recursive: true });
-        acquired = await acquire();
-        if (acquired) {
-          logger.warn("[open-design updater] reclaimed stale updater lifecycle lock", {
-            lockRoot: layout.lockRoot,
-            ownerPid,
-          });
-        }
-      } catch (error) {
-        logger.warn("[open-design updater] failed to reclaim stale updater lifecycle lock", error);
-      }
-    }
-  }
-  if (!acquired) {
-    logger.warn("[open-design updater] skipped release lifecycle because updater lifecycle lock is held", {
-      lockRoot: layout.lockRoot,
-    });
-    return null;
-  }
-  try {
-    await writeJson(join(layout.lockRoot, LOCK_OWNER_FILE), {
-      createdAt: new Date().toISOString(),
-      owner: "open-design-updater-lifecycle",
-      pid: process.pid,
-      version: RELEASE_CLEANUP_DESCRIPTOR_VERSION,
-    });
-    return await task();
-  } finally {
-    await rm(layout.lockRoot, { force: true, recursive: true }).catch((error: unknown) => {
-      logger.warn("[open-design updater] failed to release updater lifecycle lock", error);
-    });
-  }
-}
-
-function mergeExistingReleaseCleanupEntry(
-  existing: ReleaseCleanupEntry | undefined,
-  next: ReleaseCleanupEntry,
-): ReleaseCleanupEntry {
-  if (next.state !== "deprecated" && next.state !== "cleanup-deferred") return next;
-  return {
-    ...next,
-    deprecatedAt: existing?.deprecatedAt ?? next.deprecatedAt,
-  };
-}
-
-async function scanReleaseCleanupEntries(input: {
-  config: DesktopUpdaterConfig;
-  // Manual clear resets the downloaded-update state entirely, so every scanned
-  // release is deprecated regardless of its version relative to the running one.
-  deprecateAll?: boolean;
-  descriptor: ReleaseCleanupDescriptor | null;
-  layout: DesktopUpdaterStoreLayout;
-  nowIso: string;
-  readyVersion?: string;
-}): Promise<ReleaseCleanupEntry[]> {
-  const { config, deprecateAll, descriptor, layout, nowIso, readyVersion } = input;
-  const existing = new Map((descriptor?.releases ?? []).map((entry) => [entry.key, entry] as const));
-  const entries = await readdir(layout.releasesRoot, { withFileTypes: true }).catch(() => []);
-  const nextEntries: ReleaseCleanupEntry[] = [];
-
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const releaseDir = resolve(layout.releasesRoot, entry.name);
-    if (!containsPath(layout.releasesRoot, releaseDir)) {
-      nextEntries.push({
-        currentVersion: config.currentVersion,
-        error: releaseCleanupError("release-path-escaped", "release directory escaped releases root", { path: releaseDir }),
-        key: entry.name,
-        path: relativeStorePath(layout, releaseDir),
-        reason: "metadata-invalid",
-        state: "unknown",
-        updatedAt: nowIso,
-      });
-      continue;
-    }
-    const releaseEntry = await lstat(releaseDir).catch(() => null);
-    if (releaseEntry == null || !releaseEntry.isDirectory() || releaseEntry.isSymbolicLink()) {
-      nextEntries.push({
-        currentVersion: config.currentVersion,
-        error: releaseCleanupError("release-path-invalid", "release entry is not a plain directory", { path: releaseDir }),
-        key: entry.name,
-        path: relativeStorePath(layout, releaseDir),
-        reason: "metadata-invalid",
-        state: "unknown",
-        updatedAt: nowIso,
-      });
-      continue;
-    }
-    const metadataPath = join(releaseDir, "metadata.json");
-    let metadata: unknown;
-    try {
-      metadata = await readJsonStrict<unknown>(metadataPath);
-    } catch (error) {
-      nextEntries.push({
-        currentVersion: config.currentVersion,
-        error: releaseCleanupError("release-metadata-missing", "release metadata.json could not be read", {
-          reason: error instanceof Error ? error.message : String(error),
-        }),
-        key: entry.name,
-        metadataPath: relativeStorePath(layout, metadataPath),
-        path: relativeStorePath(layout, releaseDir),
-        reason: "metadata-missing",
-        state: "unknown",
-        updatedAt: nowIso,
-      });
-      continue;
-    }
-    if (!isRecord(metadata)) {
-      nextEntries.push({
-        currentVersion: config.currentVersion,
-        error: releaseCleanupError("release-metadata-invalid", "release metadata.json is not an object"),
-        key: entry.name,
-        metadataPath: relativeStorePath(layout, metadataPath),
-        path: relativeStorePath(layout, releaseDir),
-        reason: "metadata-invalid",
-        state: "unknown",
-        updatedAt: nowIso,
-      });
-      continue;
-    }
-    const version = releaseVersionForChannel(metadata, config.channel);
-    if (version == null) {
-      nextEntries.push({
-        currentVersion: config.currentVersion,
-        error: releaseCleanupError("release-version-missing", "release metadata does not expose a version for the updater channel", {
-          channel: config.channel,
-        }),
-        key: entry.name,
-        metadataPath: relativeStorePath(layout, metadataPath),
-        path: relativeStorePath(layout, releaseDir),
-        reason: "metadata-invalid",
-        state: "unknown",
-        updatedAt: nowIso,
-      });
-      continue;
-    }
-
-    const deprecated = deprecateAll === true || compareVersions(version, config.currentVersion) < 0;
-    const next: ReleaseCleanupEntry = {
-      currentVersion: config.currentVersion,
-      key: entry.name,
-      metadataPath: relativeStorePath(layout, metadataPath),
-      path: relativeStorePath(layout, releaseDir),
-      ...(readyVersion == null ? {} : { readyVersion }),
-      reason: deprecateAll === true
-        ? "manual-clear"
-        : deprecated
-          ? "older-than-current-version"
-          : "current-version-or-newer",
-      state: deprecated ? "deprecated" : "retained",
-      updatedAt: nowIso,
-      version,
-      ...(deprecated ? { deprecatedAt: nowIso } : {}),
-    };
-    nextEntries.push(mergeExistingReleaseCleanupEntry(existing.get(entry.name), next));
-  }
-
-  for (const previous of descriptor?.releases ?? []) {
-    if (nextEntries.some((entry) => entry.key === previous.key)) continue;
-    if (previous.state === "cleanup-removed") nextEntries.push(previous);
-  }
-
-  nextEntries.sort((left, right) => left.key.localeCompare(right.key));
-  return nextEntries;
-}
-
-async function cleanupDeprecatedReleaseEntries(input: {
-  descriptor: ReleaseCleanupDescriptor;
-  layout: DesktopUpdaterStoreLayout;
-  logger: DesktopUpdaterLogger;
-  nowIso: string;
-}): Promise<ReleaseCleanupDescriptor> {
-  const { descriptor, layout, logger, nowIso } = input;
-  const releases: ReleaseCleanupEntry[] = [];
-  for (const entry of descriptor.releases) {
-    if (entry.state !== "deprecated" && entry.state !== "cleanup-deferred") {
-      releases.push(entry);
-      continue;
-    }
-    const releaseDir = resolve(layout.root, entry.path);
-    if (!containsPath(layout.releasesRoot, releaseDir)) {
-      releases.push({
-        ...entry,
-        error: releaseCleanupError("release-cleanup-path-escaped", "deprecated release path escaped releases root", {
-          path: releaseDir,
-        }),
-        reason: "cleanup-failed",
-        state: "cleanup-deferred",
-        updatedAt: nowIso,
-      });
-      continue;
-    }
-    try {
-      const releaseEntry = await lstat(releaseDir).catch(() => null);
-      if (releaseEntry != null && (!releaseEntry.isDirectory() || releaseEntry.isSymbolicLink())) {
-        throw new Error(`release cleanup target is not a plain directory: ${releaseDir}`);
-      }
-      if (releaseEntry?.isDirectory()) {
-        const realReleaseDir = await realpath(releaseDir);
-        if (!containsPath(layout.releasesRoot, realReleaseDir)) {
-          throw new Error(`release cleanup target escaped releases root: ${realReleaseDir}`);
-        }
-      }
-      await rm(releaseDir, { force: true, recursive: true });
-      releases.push({
-        ...entry,
-        error: undefined,
-        removedAt: entry.removedAt ?? nowIso,
-        state: "cleanup-removed",
-        updatedAt: nowIso,
-      });
-    } catch (error) {
-      logger.warn("[open-design updater] failed to clean deprecated release", {
-        error: error instanceof Error ? error.message : String(error),
-        key: entry.key,
-        path: releaseDir,
-      });
-      releases.push({
-        ...entry,
-        error: releaseCleanupError("release-cleanup-failed", error instanceof Error ? error.message : String(error)),
-        reason: "cleanup-failed",
-        state: "cleanup-deferred",
-        updatedAt: nowIso,
-      });
-    }
-  }
-  return {
-    ...descriptor,
-    releases,
-    updatedAt: nowIso,
-  };
-}
-
-async function runUpdateReleaseLifecycle(input: {
-  config: DesktopUpdaterConfig;
-  layout: DesktopUpdaterStoreLayout;
-  logger: DesktopUpdaterLogger;
-  now: () => Date;
-  reclaimStaleLock?: boolean;
-  readyVersion?: string;
-  trigger: DesktopUpdateCacheLifecycleTrigger;
-}): Promise<DesktopUpdateCacheLifecycleSummary | null> {
-  const { config, layout, logger, now, readyVersion, trigger } = input;
-  return await withUpdaterLifecycleLock(layout, logger, async () => {
-    const startedAt = now().toISOString();
-    const current = await readReleaseCleanupDescriptor(layout);
-    let next: ReleaseCleanupDescriptor;
-    if (trigger === "next-version-ready" || trigger === "manual") {
-      next = {
-        currentVersion: config.currentVersion,
-        platform: config.platform,
-        ...(readyVersion == null ? {} : { readyVersion }),
-        releases: await scanReleaseCleanupEntries({
-          config,
-          deprecateAll: trigger === "manual",
-          descriptor: current,
-          layout,
-          nowIso: startedAt,
-          readyVersion,
-        }),
-        trigger,
-        updatedAt: startedAt,
-        version: RELEASE_CLEANUP_DESCRIPTOR_VERSION,
-      };
-      await writeJson(layout.cleanupPath, next);
-    } else {
-      next = current ?? {
-        currentVersion: config.currentVersion,
-        platform: config.platform,
-        releases: [],
-        trigger,
-        updatedAt: startedAt,
-        version: RELEASE_CLEANUP_DESCRIPTOR_VERSION,
-      };
-    }
-
-    const cleaned = await cleanupDeprecatedReleaseEntries({
-      descriptor: {
-        ...next,
-        currentVersion: config.currentVersion,
-        platform: config.platform,
-        trigger,
-        updatedAt: startedAt,
-      },
-      layout,
-      logger,
-      nowIso: now().toISOString(),
-    });
-    await writeJson(layout.cleanupPath, cleaned);
-    return summarizeReleaseCleanupDescriptor(cleaned, config.platform);
-  }, { reclaimStale: input.reclaimStaleLock });
 }
 
 async function readStoreMetadata(root: OwnedRoot & { ok: true }, logger: DesktopUpdaterLogger): Promise<

--- a/apps/desktop/src/main/updater/deferred-launch.ts
+++ b/apps/desktop/src/main/updater/deferred-launch.ts
@@ -1,0 +1,290 @@
+import { spawn } from "node:child_process";
+import { chmod, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import {
+  buildLauncherAfterQuitArgs,
+  buildLauncherDelegatedArgs,
+} from "@open-design/launcher-proto";
+
+import { HELPERS_DIR, ensureOwnedSubdir } from "./store.js";
+
+/**
+ * @module updater/deferred-launch
+ *
+ * Wait-for-my-pid-to-die launch helpers for the desktop updater: the
+ * embedded mac shell and Windows PowerShell installer-opening scripts, and
+ * the detached spawn of a prepared payload executable in after-quit mode.
+ */
+
+export const DEFERRED_INSTALLER_TIMEOUT_MS = 10 * 60 * 1000;
+
+export type DetachedProcess = Pick<ReturnType<typeof spawn>, "once" | "unref">;
+export type SpawnInstallerHelper = (
+  command: string,
+  args: string[],
+  options: { cwd?: string; detached?: true; stdio: "ignore"; windowsHide: true },
+) => DetachedProcess;
+
+export type DeferredInstallerLaunchInput = {
+  appPid: number;
+  /** Stable namespace root inherited by the installer helper process. */
+  cwd: string;
+  installerPath: string;
+  root: string;
+  timeoutMs: number;
+};
+
+export type DeferredAppLaunchInput = {
+  appPid: number;
+  /** Stable namespace root inherited by the next payload process. */
+  cwd: string;
+  /**
+   * Pointer the activation pre-armed attempt.json for; passed to the spawned
+   * payload as `--od-launcher-delegated-*` so it recognizes that attempt as
+   * its own launch in progress rather than a previous failure.
+   */
+  delegated?: { generation: number; version: string };
+  launchPath: string;
+  root: string;
+  timeoutMs: number;
+};
+
+export type DeferredLaunchResult = {
+  error?: string;
+  helperLogPath?: string;
+};
+
+export function macDeferredInstallerScript(): string {
+  return `#!/bin/sh
+set -eu
+target_pid="$1"
+installer_path="$2"
+timeout_seconds="$3"
+cleanup() {
+  rm -f "$0"
+}
+trap cleanup EXIT
+deadline=$(($(date +%s) + timeout_seconds))
+while kill -0 "$target_pid" 2>/dev/null; do
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    exit 1
+  fi
+  sleep 1
+done
+open "$installer_path" >/dev/null 2>&1 &
+exit 0
+`;
+}
+
+export function windowsDeferredInstallerScript(): string {
+  return `param(
+  [Parameter(Mandatory = $true)]
+  [int]$TargetPid,
+
+  [Parameter(Mandatory = $true)]
+  [string]$InstallerPath,
+
+  [Parameter(Mandatory = $true)]
+  [int]$TimeoutMs,
+
+  [Parameter(Mandatory = $true)]
+  [string]$LogPath
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-HelperLog {
+  param([string]$Message)
+  try {
+    Add-Content -LiteralPath $LogPath -Value ("{0:o} {1}" -f (Get-Date), $Message)
+  } catch {
+  }
+}
+
+try {
+  Write-HelperLog ("armed for pid={0} installer={1}" -f $TargetPid, $InstallerPath)
+  $deadline = (Get-Date).AddMilliseconds($TimeoutMs)
+  while ($null -ne (Get-Process -Id $TargetPid -ErrorAction SilentlyContinue)) {
+    if ((Get-Date) -ge $deadline) {
+      throw ("timed out waiting for pid={0}" -f $TargetPid)
+    }
+    Start-Sleep -Milliseconds 250
+  }
+
+  Write-HelperLog ("observed pid={0} exit; opening installer" -f $TargetPid)
+  Write-HelperLog "waiting for launch handoff"
+  Start-Sleep -Milliseconds 1500
+  Start-Process -FilePath $InstallerPath -WorkingDirectory (Split-Path -Parent $InstallerPath)
+  Write-HelperLog "installer launch requested"
+} catch {
+  Write-HelperLog ("failed: {0}" -f $_.Exception.Message)
+  exit 1
+} finally {
+  Remove-Item -LiteralPath $PSCommandPath -Force -ErrorAction SilentlyContinue
+}
+`;
+}
+
+export function windowsDeferredInstallerLauncherScript(): string {
+  return `param(
+  [Parameter(Mandatory = $true)]
+  [string]$PowerShellPath,
+
+  [Parameter(Mandatory = $true)]
+  [string]$HelperPath,
+
+  [Parameter(Mandatory = $true)]
+  [int]$TargetPid,
+
+  [Parameter(Mandatory = $true)]
+  [string]$InstallerPath,
+
+  [Parameter(Mandatory = $true)]
+  [int]$TimeoutMs,
+
+  [Parameter(Mandatory = $true)]
+  [string]$LogPath
+)
+
+$ErrorActionPreference = "Stop"
+
+function Quote-WindowsPowerShellArgument {
+  param([string]$Value)
+  return '"' + ($Value -replace '"', '\\"') + '"'
+}
+
+function Write-LauncherLog {
+  param([string]$Message)
+  try {
+    Add-Content -LiteralPath $LogPath -Value ("{0:o} {1}" -f (Get-Date), $Message)
+  } catch {
+  }
+}
+
+try {
+  Write-LauncherLog ("launching helper={0}" -f $HelperPath)
+  $arguments = @(
+    "-NoLogo",
+    "-NoProfile",
+    "-NonInteractive",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-File",
+    (Quote-WindowsPowerShellArgument $HelperPath),
+    "-TargetPid",
+    $TargetPid.ToString(),
+    "-InstallerPath",
+    (Quote-WindowsPowerShellArgument $InstallerPath),
+    "-TimeoutMs",
+    $TimeoutMs.ToString(),
+    "-LogPath",
+    (Quote-WindowsPowerShellArgument $LogPath)
+  ) -join " "
+  Start-Process -FilePath $PowerShellPath -WindowStyle Hidden -ArgumentList $arguments
+  Write-LauncherLog "helper launch requested"
+} catch {
+  Write-LauncherLog ("launcher failed: {0}" -f $_.Exception.Message)
+  exit 1
+} finally {
+  Remove-Item -LiteralPath $PSCommandPath -Force -ErrorAction SilentlyContinue
+}
+`;
+}
+
+export function windowsPowerShellCommand(env: NodeJS.ProcessEnv = process.env): string {
+  const systemRoot = env.SystemRoot ?? env.SYSTEMROOT ?? "C:\\Windows";
+  return join(systemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe");
+}
+
+export async function launchMacInstallerAfterQuit(
+  input: DeferredInstallerLaunchInput,
+  deps: { now: () => Date; spawnDetached: SpawnInstallerHelper },
+): Promise<string> {
+  try {
+    const helpersRoot = await ensureOwnedSubdir(input.root, HELPERS_DIR);
+    const suffix = `${deps.now().getTime().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+    const scriptPath = join(helpersRoot, `open-installer-after-quit-${suffix}.sh`);
+    await writeFile(scriptPath, macDeferredInstallerScript(), { encoding: "utf8", mode: 0o700 });
+    await chmod(scriptPath, 0o700);
+    const timeoutSeconds = Math.max(1, Math.ceil(input.timeoutMs / 1000)).toString();
+    const child = deps.spawnDetached(
+      "/bin/sh",
+      [scriptPath, input.appPid.toString(), input.installerPath, timeoutSeconds],
+      { cwd: input.cwd, detached: true, stdio: "ignore", windowsHide: true },
+    );
+    child.unref();
+    return "";
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+}
+
+export async function launchWindowsInstallerAfterQuit(
+  input: DeferredInstallerLaunchInput,
+  deps: { now: () => Date; spawnDetached: SpawnInstallerHelper },
+): Promise<string> {
+  try {
+    const helpersRoot = await ensureOwnedSubdir(input.root, HELPERS_DIR);
+    const suffix = `${deps.now().getTime().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+    const scriptPath = join(helpersRoot, `open-installer-after-quit-${suffix}.ps1`);
+    const launcherPath = join(helpersRoot, `open-installer-after-quit-${suffix}.launcher.ps1`);
+    const logPath = join(helpersRoot, `open-installer-after-quit-${suffix}.log`);
+    const powerShellPath = windowsPowerShellCommand();
+    await writeFile(scriptPath, windowsDeferredInstallerScript(), { encoding: "utf8" });
+    await writeFile(launcherPath, windowsDeferredInstallerLauncherScript(), { encoding: "utf8" });
+    const child = deps.spawnDetached(
+      powerShellPath,
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        launcherPath,
+        "-PowerShellPath",
+        powerShellPath,
+        "-HelperPath",
+        scriptPath,
+        "-TargetPid",
+        input.appPid.toString(),
+        "-InstallerPath",
+        input.installerPath,
+        "-TimeoutMs",
+        input.timeoutMs.toString(),
+        "-LogPath",
+        logPath,
+      ],
+      { cwd: input.cwd, detached: true, stdio: "ignore", windowsHide: true },
+    );
+    child.unref();
+    return "";
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+}
+
+export async function launchPayloadAppAfterQuit(
+  input: DeferredAppLaunchInput,
+  deps: { now: () => Date; spawnDetached: SpawnInstallerHelper },
+): Promise<DeferredLaunchResult> {
+  try {
+    const child = deps.spawnDetached(
+      input.launchPath,
+      [
+        ...buildLauncherAfterQuitArgs({ targetPid: input.appPid, timeoutMs: input.timeoutMs }),
+        ...(input.delegated == null ? [] : buildLauncherDelegatedArgs(input.delegated)),
+      ],
+      { cwd: input.cwd, detached: true, stdio: "ignore", windowsHide: true },
+    );
+    await new Promise<void>((resolveSpawn, rejectSpawn) => {
+      child.once("spawn", () => resolveSpawn());
+      child.once("error", rejectSpawn);
+    });
+    child.unref();
+    return {};
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+}

--- a/apps/desktop/src/main/updater/release-lifecycle.ts
+++ b/apps/desktop/src/main/updater/release-lifecycle.ts
@@ -1,0 +1,535 @@
+import { lstat, mkdir, readdir, realpath, rename, rm } from "node:fs/promises";
+import { join, relative, resolve } from "node:path";
+
+import type {
+  DesktopUpdateCacheLifecycleSummary,
+  DesktopUpdateCacheLifecycleTrigger,
+  DesktopUpdateErrorSnapshot,
+  DesktopUpdateReleaseLifecycleState,
+  DesktopUpdateStatusSnapshot,
+} from "@open-design/sidecar-proto";
+
+import type { DesktopUpdaterConfig } from "./config.js";
+import {
+  BACK_DIR,
+  LOCK_OWNER_FILE,
+  type DesktopUpdaterStoreLayout,
+} from "./store.js";
+import {
+  containsPath,
+  createError,
+  isRecord,
+  readJson,
+  readJsonStrict,
+  stringField,
+  writeJson,
+} from "./support.js";
+import { compareVersions, releaseVersionForChannel } from "./feed.js";
+import type { DesktopUpdaterLogger } from "../updater.js";
+
+/**
+ * @module updater/release-lifecycle
+ *
+ * Release-store cleanup lifecycle: the cleanup.json descriptor with its
+ * guards, deprecate/remove scanning with deferred-failure retry, the
+ * mkdir-based lifecycle lock, and the .back directory sweep.
+ */
+
+export const RELEASE_CLEANUP_DESCRIPTOR_VERSION = 1;
+
+export type ReleaseCleanupReason =
+  | "cleanup-failed"
+  | "current-version-or-newer"
+  | "manual-clear"
+  | "metadata-invalid"
+  | "metadata-missing"
+  | "older-than-current-version";
+
+export type ReleaseCleanupEntry = {
+  currentVersion?: string;
+  deprecatedAt?: string;
+  error?: DesktopUpdateErrorSnapshot;
+  key: string;
+  metadataPath?: string;
+  path: string;
+  readyVersion?: string;
+  reason: ReleaseCleanupReason;
+  removedAt?: string;
+  state: DesktopUpdateReleaseLifecycleState;
+  updatedAt: string;
+  version?: string;
+};
+
+export type ReleaseCleanupDescriptor = {
+  currentVersion?: string;
+  platform: string;
+  readyVersion?: string;
+  releases: ReleaseCleanupEntry[];
+  trigger: DesktopUpdateCacheLifecycleTrigger;
+  updatedAt: string;
+  version: typeof RELEASE_CLEANUP_DESCRIPTOR_VERSION;
+};
+
+export async function cleanupBackDirectory(root: string, logger: DesktopUpdaterLogger): Promise<void> {
+  const backDir = join(root, BACK_DIR);
+  const entry = await lstat(backDir).catch(() => null);
+  if (entry == null) return;
+  if (!entry.isDirectory() || entry.isSymbolicLink()) {
+    logger.warn("[open-design updater] skipped invalid update backup directory", backDir);
+    return;
+  }
+  const realBackDir = await realpath(backDir).catch(() => null);
+  if (realBackDir == null || !containsPath(root, realBackDir)) {
+    logger.warn("[open-design updater] skipped escaped update backup directory", backDir);
+    return;
+  }
+  const entries = await readdir(backDir);
+  await Promise.all(entries.map(async (entry) => {
+    const path = join(backDir, entry);
+    const resolved = resolve(path);
+    if (!containsPath(root, resolved)) return;
+    const stats = await lstat(resolved).catch(() => null);
+    if (stats == null || stats.isSymbolicLink()) return;
+    if (stats.isDirectory()) {
+      const real = await realpath(resolved).catch(() => null);
+      if (real == null || !containsPath(root, real)) return;
+    }
+    await rm(resolved, { force: true, recursive: true }).catch((error: unknown) => {
+      logger.warn("[open-design updater] failed to clean update backup entry", error);
+    });
+  }));
+}
+
+export function scheduleBackCleanup(root: string, logger: DesktopUpdaterLogger): void {
+  void cleanupBackDirectory(root, logger).catch((error: unknown) => {
+    logger.warn("[open-design updater] failed to clean update backup directory", error);
+  });
+}
+
+export function isReleaseLifecycleState(value: unknown): value is DesktopUpdateReleaseLifecycleState {
+  return value === "cleanup-deferred" ||
+    value === "cleanup-removed" ||
+    value === "deprecated" ||
+    value === "retained" ||
+    value === "unknown";
+}
+
+export function isReleaseCleanupReason(value: unknown): value is ReleaseCleanupReason {
+  return value === "cleanup-failed" ||
+    value === "current-version-or-newer" ||
+    value === "manual-clear" ||
+    value === "metadata-invalid" ||
+    value === "metadata-missing" ||
+    value === "older-than-current-version";
+}
+
+export function isDesktopUpdateErrorSnapshot(value: unknown): value is DesktopUpdateErrorSnapshot {
+  if (!isRecord(value)) return false;
+  return stringField(value, "code") != null && stringField(value, "message") != null;
+}
+
+export function isReleaseCleanupEntry(value: unknown): value is ReleaseCleanupEntry {
+  if (!isRecord(value)) return false;
+  if (stringField(value, "key") == null) return false;
+  if (stringField(value, "path") == null) return false;
+  if (!isReleaseLifecycleState(value.state)) return false;
+  if (!isReleaseCleanupReason(value.reason)) return false;
+  if (stringField(value, "updatedAt") == null) return false;
+  if (value.currentVersion != null && typeof value.currentVersion !== "string") return false;
+  if (value.deprecatedAt != null && typeof value.deprecatedAt !== "string") return false;
+  if (value.metadataPath != null && typeof value.metadataPath !== "string") return false;
+  if (value.readyVersion != null && typeof value.readyVersion !== "string") return false;
+  if (value.removedAt != null && typeof value.removedAt !== "string") return false;
+  if (value.version != null && typeof value.version !== "string") return false;
+  if (value.error != null && !isDesktopUpdateErrorSnapshot(value.error)) return false;
+  return true;
+}
+
+export function isReleaseCleanupDescriptor(value: unknown): value is ReleaseCleanupDescriptor {
+  if (!isRecord(value)) return false;
+  if (value.version !== RELEASE_CLEANUP_DESCRIPTOR_VERSION) return false;
+  if (typeof value.platform !== "string") return false;
+  if (value.trigger !== "cold-start" && value.trigger !== "manual" && value.trigger !== "next-version-ready") return false;
+  if (typeof value.updatedAt !== "string") return false;
+  if (value.currentVersion != null && typeof value.currentVersion !== "string") return false;
+  if (value.readyVersion != null && typeof value.readyVersion !== "string") return false;
+  if (!Array.isArray(value.releases)) return false;
+  return value.releases.every(isReleaseCleanupEntry);
+}
+
+export function emptyLifecycleSummary(platform: string): DesktopUpdateCacheLifecycleSummary {
+  return {
+    platform,
+    releases: {
+      cleanupDeferred: 0,
+      cleanupRemoved: 0,
+      deprecated: 0,
+      errors: 0,
+      retained: 0,
+      total: 0,
+      unknown: 0,
+    },
+  };
+}
+
+export function summarizeReleaseCleanupDescriptor(
+  descriptor: ReleaseCleanupDescriptor | null,
+  platform: string,
+): DesktopUpdateCacheLifecycleSummary {
+  if (descriptor == null) return emptyLifecycleSummary(platform);
+  const summary = emptyLifecycleSummary(descriptor.platform);
+  summary.lastRunAt = descriptor.updatedAt;
+  summary.lastTrigger = descriptor.trigger;
+  summary.releases.total = descriptor.releases.length;
+  for (const release of descriptor.releases) {
+    if (release.state === "cleanup-deferred") summary.releases.cleanupDeferred += 1;
+    if (release.state === "cleanup-removed") summary.releases.cleanupRemoved += 1;
+    if (release.state === "deprecated") summary.releases.deprecated += 1;
+    if (release.state === "retained") summary.releases.retained += 1;
+    if (release.state === "unknown") summary.releases.unknown += 1;
+    if (release.error != null) summary.releases.errors += 1;
+  }
+  return summary;
+}
+
+export async function readReleaseCleanupDescriptor(layout: DesktopUpdaterStoreLayout): Promise<ReleaseCleanupDescriptor | null> {
+  const raw = await readJson<unknown>(layout.cleanupPath);
+  return isReleaseCleanupDescriptor(raw) ? raw : null;
+}
+
+export function relativeStorePath(layout: DesktopUpdaterStoreLayout, path: string): string {
+  return relative(layout.root, path);
+}
+
+export function releaseCleanupError(code: string, message: string, details?: unknown): DesktopUpdateErrorSnapshot {
+  return createError(code, message, details);
+}
+
+export async function withUpdaterLifecycleLock<T>(
+  layout: DesktopUpdaterStoreLayout,
+  logger: DesktopUpdaterLogger,
+  task: () => Promise<T>,
+  options: { reclaimStale?: boolean } = {},
+): Promise<T | null> {
+  await mkdir(layout.stateRoot, { recursive: true });
+  const acquire = async (): Promise<boolean> => {
+    try {
+      await mkdir(layout.lockRoot);
+      return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      return false;
+    }
+  };
+  let acquired = await acquire();
+  if (!acquired && options.reclaimStale === true) {
+    const owner = await readJson<unknown>(join(layout.lockRoot, LOCK_OWNER_FILE));
+    const ownerPid = isRecord(owner) && owner.owner === "open-design-updater-lifecycle"
+      && owner.version === RELEASE_CLEANUP_DESCRIPTOR_VERSION
+      && typeof owner.pid === "number" && Number.isSafeInteger(owner.pid) && owner.pid > 0
+      ? owner.pid
+      : null;
+    let ownerIsDead = false;
+    if (ownerPid != null) {
+      try {
+        process.kill(ownerPid, 0);
+      } catch (error) {
+        ownerIsDead = (error as NodeJS.ErrnoException).code === "ESRCH";
+      }
+    }
+    if (ownerIsDead) {
+      const staleLockRoot = `${layout.lockRoot}.stale-${process.pid}-${Date.now()}`;
+      try {
+        await rename(layout.lockRoot, staleLockRoot);
+        await rm(staleLockRoot, { force: true, recursive: true });
+        acquired = await acquire();
+        if (acquired) {
+          logger.warn("[open-design updater] reclaimed stale updater lifecycle lock", {
+            lockRoot: layout.lockRoot,
+            ownerPid,
+          });
+        }
+      } catch (error) {
+        logger.warn("[open-design updater] failed to reclaim stale updater lifecycle lock", error);
+      }
+    }
+  }
+  if (!acquired) {
+    logger.warn("[open-design updater] skipped release lifecycle because updater lifecycle lock is held", {
+      lockRoot: layout.lockRoot,
+    });
+    return null;
+  }
+  try {
+    await writeJson(join(layout.lockRoot, LOCK_OWNER_FILE), {
+      createdAt: new Date().toISOString(),
+      owner: "open-design-updater-lifecycle",
+      pid: process.pid,
+      version: RELEASE_CLEANUP_DESCRIPTOR_VERSION,
+    });
+    return await task();
+  } finally {
+    await rm(layout.lockRoot, { force: true, recursive: true }).catch((error: unknown) => {
+      logger.warn("[open-design updater] failed to release updater lifecycle lock", error);
+    });
+  }
+}
+
+export function mergeExistingReleaseCleanupEntry(
+  existing: ReleaseCleanupEntry | undefined,
+  next: ReleaseCleanupEntry,
+): ReleaseCleanupEntry {
+  if (next.state !== "deprecated" && next.state !== "cleanup-deferred") return next;
+  return {
+    ...next,
+    deprecatedAt: existing?.deprecatedAt ?? next.deprecatedAt,
+  };
+}
+
+export async function scanReleaseCleanupEntries(input: {
+  config: DesktopUpdaterConfig;
+  // Manual clear resets the downloaded-update state entirely, so every scanned
+  // release is deprecated regardless of its version relative to the running one.
+  deprecateAll?: boolean;
+  descriptor: ReleaseCleanupDescriptor | null;
+  layout: DesktopUpdaterStoreLayout;
+  nowIso: string;
+  readyVersion?: string;
+}): Promise<ReleaseCleanupEntry[]> {
+  const { config, deprecateAll, descriptor, layout, nowIso, readyVersion } = input;
+  const existing = new Map((descriptor?.releases ?? []).map((entry) => [entry.key, entry] as const));
+  const entries = await readdir(layout.releasesRoot, { withFileTypes: true }).catch(() => []);
+  const nextEntries: ReleaseCleanupEntry[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const releaseDir = resolve(layout.releasesRoot, entry.name);
+    if (!containsPath(layout.releasesRoot, releaseDir)) {
+      nextEntries.push({
+        currentVersion: config.currentVersion,
+        error: releaseCleanupError("release-path-escaped", "release directory escaped releases root", { path: releaseDir }),
+        key: entry.name,
+        path: relativeStorePath(layout, releaseDir),
+        reason: "metadata-invalid",
+        state: "unknown",
+        updatedAt: nowIso,
+      });
+      continue;
+    }
+    const releaseEntry = await lstat(releaseDir).catch(() => null);
+    if (releaseEntry == null || !releaseEntry.isDirectory() || releaseEntry.isSymbolicLink()) {
+      nextEntries.push({
+        currentVersion: config.currentVersion,
+        error: releaseCleanupError("release-path-invalid", "release entry is not a plain directory", { path: releaseDir }),
+        key: entry.name,
+        path: relativeStorePath(layout, releaseDir),
+        reason: "metadata-invalid",
+        state: "unknown",
+        updatedAt: nowIso,
+      });
+      continue;
+    }
+    const metadataPath = join(releaseDir, "metadata.json");
+    let metadata: unknown;
+    try {
+      metadata = await readJsonStrict<unknown>(metadataPath);
+    } catch (error) {
+      nextEntries.push({
+        currentVersion: config.currentVersion,
+        error: releaseCleanupError("release-metadata-missing", "release metadata.json could not be read", {
+          reason: error instanceof Error ? error.message : String(error),
+        }),
+        key: entry.name,
+        metadataPath: relativeStorePath(layout, metadataPath),
+        path: relativeStorePath(layout, releaseDir),
+        reason: "metadata-missing",
+        state: "unknown",
+        updatedAt: nowIso,
+      });
+      continue;
+    }
+    if (!isRecord(metadata)) {
+      nextEntries.push({
+        currentVersion: config.currentVersion,
+        error: releaseCleanupError("release-metadata-invalid", "release metadata.json is not an object"),
+        key: entry.name,
+        metadataPath: relativeStorePath(layout, metadataPath),
+        path: relativeStorePath(layout, releaseDir),
+        reason: "metadata-invalid",
+        state: "unknown",
+        updatedAt: nowIso,
+      });
+      continue;
+    }
+    const version = releaseVersionForChannel(metadata, config.channel);
+    if (version == null) {
+      nextEntries.push({
+        currentVersion: config.currentVersion,
+        error: releaseCleanupError("release-version-missing", "release metadata does not expose a version for the updater channel", {
+          channel: config.channel,
+        }),
+        key: entry.name,
+        metadataPath: relativeStorePath(layout, metadataPath),
+        path: relativeStorePath(layout, releaseDir),
+        reason: "metadata-invalid",
+        state: "unknown",
+        updatedAt: nowIso,
+      });
+      continue;
+    }
+
+    const deprecated = deprecateAll === true || compareVersions(version, config.currentVersion) < 0;
+    const next: ReleaseCleanupEntry = {
+      currentVersion: config.currentVersion,
+      key: entry.name,
+      metadataPath: relativeStorePath(layout, metadataPath),
+      path: relativeStorePath(layout, releaseDir),
+      ...(readyVersion == null ? {} : { readyVersion }),
+      reason: deprecateAll === true
+        ? "manual-clear"
+        : deprecated
+          ? "older-than-current-version"
+          : "current-version-or-newer",
+      state: deprecated ? "deprecated" : "retained",
+      updatedAt: nowIso,
+      version,
+      ...(deprecated ? { deprecatedAt: nowIso } : {}),
+    };
+    nextEntries.push(mergeExistingReleaseCleanupEntry(existing.get(entry.name), next));
+  }
+
+  for (const previous of descriptor?.releases ?? []) {
+    if (nextEntries.some((entry) => entry.key === previous.key)) continue;
+    if (previous.state === "cleanup-removed") nextEntries.push(previous);
+  }
+
+  nextEntries.sort((left, right) => left.key.localeCompare(right.key));
+  return nextEntries;
+}
+
+export async function cleanupDeprecatedReleaseEntries(input: {
+  descriptor: ReleaseCleanupDescriptor;
+  layout: DesktopUpdaterStoreLayout;
+  logger: DesktopUpdaterLogger;
+  nowIso: string;
+}): Promise<ReleaseCleanupDescriptor> {
+  const { descriptor, layout, logger, nowIso } = input;
+  const releases: ReleaseCleanupEntry[] = [];
+  for (const entry of descriptor.releases) {
+    if (entry.state !== "deprecated" && entry.state !== "cleanup-deferred") {
+      releases.push(entry);
+      continue;
+    }
+    const releaseDir = resolve(layout.root, entry.path);
+    if (!containsPath(layout.releasesRoot, releaseDir)) {
+      releases.push({
+        ...entry,
+        error: releaseCleanupError("release-cleanup-path-escaped", "deprecated release path escaped releases root", {
+          path: releaseDir,
+        }),
+        reason: "cleanup-failed",
+        state: "cleanup-deferred",
+        updatedAt: nowIso,
+      });
+      continue;
+    }
+    try {
+      const releaseEntry = await lstat(releaseDir).catch(() => null);
+      if (releaseEntry != null && (!releaseEntry.isDirectory() || releaseEntry.isSymbolicLink())) {
+        throw new Error(`release cleanup target is not a plain directory: ${releaseDir}`);
+      }
+      if (releaseEntry?.isDirectory()) {
+        const realReleaseDir = await realpath(releaseDir);
+        if (!containsPath(layout.releasesRoot, realReleaseDir)) {
+          throw new Error(`release cleanup target escaped releases root: ${realReleaseDir}`);
+        }
+      }
+      await rm(releaseDir, { force: true, recursive: true });
+      releases.push({
+        ...entry,
+        error: undefined,
+        removedAt: entry.removedAt ?? nowIso,
+        state: "cleanup-removed",
+        updatedAt: nowIso,
+      });
+    } catch (error) {
+      logger.warn("[open-design updater] failed to clean deprecated release", {
+        error: error instanceof Error ? error.message : String(error),
+        key: entry.key,
+        path: releaseDir,
+      });
+      releases.push({
+        ...entry,
+        error: releaseCleanupError("release-cleanup-failed", error instanceof Error ? error.message : String(error)),
+        reason: "cleanup-failed",
+        state: "cleanup-deferred",
+        updatedAt: nowIso,
+      });
+    }
+  }
+  return {
+    ...descriptor,
+    releases,
+    updatedAt: nowIso,
+  };
+}
+
+export async function runUpdateReleaseLifecycle(input: {
+  config: DesktopUpdaterConfig;
+  layout: DesktopUpdaterStoreLayout;
+  logger: DesktopUpdaterLogger;
+  now: () => Date;
+  reclaimStaleLock?: boolean;
+  readyVersion?: string;
+  trigger: DesktopUpdateCacheLifecycleTrigger;
+}): Promise<DesktopUpdateCacheLifecycleSummary | null> {
+  const { config, layout, logger, now, readyVersion, trigger } = input;
+  return await withUpdaterLifecycleLock(layout, logger, async () => {
+    const startedAt = now().toISOString();
+    const current = await readReleaseCleanupDescriptor(layout);
+    let next: ReleaseCleanupDescriptor;
+    if (trigger === "next-version-ready" || trigger === "manual") {
+      next = {
+        currentVersion: config.currentVersion,
+        platform: config.platform,
+        ...(readyVersion == null ? {} : { readyVersion }),
+        releases: await scanReleaseCleanupEntries({
+          config,
+          deprecateAll: trigger === "manual",
+          descriptor: current,
+          layout,
+          nowIso: startedAt,
+          readyVersion,
+        }),
+        trigger,
+        updatedAt: startedAt,
+        version: RELEASE_CLEANUP_DESCRIPTOR_VERSION,
+      };
+      await writeJson(layout.cleanupPath, next);
+    } else {
+      next = current ?? {
+        currentVersion: config.currentVersion,
+        platform: config.platform,
+        releases: [],
+        trigger,
+        updatedAt: startedAt,
+        version: RELEASE_CLEANUP_DESCRIPTOR_VERSION,
+      };
+    }
+
+    const cleaned = await cleanupDeprecatedReleaseEntries({
+      descriptor: {
+        ...next,
+        currentVersion: config.currentVersion,
+        platform: config.platform,
+        trigger,
+        updatedAt: startedAt,
+      },
+      layout,
+      logger,
+      nowIso: now().toISOString(),
+    });
+    await writeJson(layout.cleanupPath, cleaned);
+    return summarizeReleaseCleanupDescriptor(cleaned, config.platform);
+  }, { reclaimStale: input.reclaimStaleLock });
+}


### PR DESCRIPTION
## Why

Final slice of the mechanical split of `apps/desktop/src/main/updater.ts` (follow-up to #6106, #6109, #6113, #6114). Two modules land together to fit the review budget: the deferred launch helpers and the release cleanup lifecycle. This completes the split — `updater.ts` goes from 3971 lines (pre-#6106) to 1370: the assembly layer, the state machine, and download/install orchestration, with eight focused modules under `src/main/updater/`.

## What users will see

Nothing user-visible; pure code motion.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## What moved (mechanically, no behavior change)

- `src/main/updater/deferred-launch.ts` (290 lines): the embedded mac shell and Windows PowerShell wait-for-pid installer-opening scripts, their writers/spawn plumbing, and the payload after-quit launch. Moved as one contiguous span — the PS1 heredocs contain column-zero braces, so a per-function cut would have truncated them.
- `src/main/updater/release-lifecycle.ts` (535 lines): the release `cleanup.json` descriptor types and guards, deprecate/remove scanning with deferred-failure retry, the mkdir-based lifecycle lock, and the `.back` sweep.
- `updater.ts` re-exports the three deferred launch input/result types; the `DesktopUpdater` interface stays put. Orphaned imports pruned (script-verified).
- No test files change: both areas are covered through integration flows; the desktop suite holds at **269 passed** (30 files).

Code-motion audit (`git diff --color-moved=dimmed-zebra`): 845 added lines = **738 verbatim moves** + 107 wiring; zero non-wiring lines. 781 deletions = 738 move sources + 43 replaced import/`export `-prefixed originals.

## Validation

- `pnpm --filter @open-design/desktop test` — 30 files, **269 passed** (same total as `main`)
- `pnpm --filter @open-design/desktop typecheck` (both tsconfigs), `pnpm guard`
- `pnpm --filter @open-design/tools-pack test` — full suite, 248 passed (the cross-package source assertion introduced in #6114's fix keeps passing)
- e2e Vitest `tests/updater-fixture.test.ts` + `tests/packaged-launcher-update-loop.test.ts` — 4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
