### PR TITLE
fix(packaged): forward OD_ALLOWED_INTERNAL_HOSTS to packaged sidecars

### DIFF
--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -53,6 +53,7 @@ const PACKAGED_CHILD_ENV_ALLOWLIST = [
   "TMPDIR",
   "USER",
   "VP_HOME",
+  "OD_ALLOWED_INTERNAL_HOSTS",
   "all_proxy",
   "http_proxy",
   "https_proxy",


### PR DESCRIPTION
Adds `OD_ALLOWED_INTERNAL_HOSTS` to `PACKAGED_CHILD_ENV_ALLOWLIST` in `apps/packaged/src/sidecars.ts`.

Without this, the Electron desktop app spawns the daemon with the variable stripped, so the daemon never sees it and internal IPs remain blocked for packaged-app users.

Same bug class as #1663 (proxy vars) and #302 (API_KEY vars). Related: #3225, #4250.