### PR TITLE
fix(packaged): restore masked CLI icons in installed apps

### DIFF
--- a/apps/packaged/src/protocol.ts
+++ b/apps/packaged/src/protocol.ts
@@ -389,12 +389,38 @@ export function packagedEntryUrl(): string {
  * renderer request through undici serialized them: a project-open request burst
  * that a browser tab runs in parallel dribbled out over minutes in the packaged
  * app. `net.fetch` gives the packaged client the same concurrency as the
- * browser. Set OD_OD_PROXY_FETCH=undici to force the old path if `net.fetch`
- * ever regresses a streaming/upload edge on a specific Electron/OS combo.
+ * browser.
+ *
+ * Electron can nevertheless reject particular renderer-owned subresource
+ * requests with a generic `net::ERR_FAILED` even while the same URL succeeds
+ * through ordinary fetch and the sidecar returns 200. CSS mask images are one
+ * concrete case: packaged agent icons disappeared while their SVG files were
+ * present and directly readable. For GET/HEAD only, fall back to undici after
+ * that transport-level rejection. Those methods are safe to replay; write
+ * requests deliberately stay on a single transport.
+ *
+ * Set OD_OD_PROXY_FETCH=undici to force the old path for all requests if
+ * `net.fetch` regresses a broader streaming edge on a specific Electron/OS
+ * combo.
  */
 function resolveOdProxyFetch(): OdProtocolFetch {
   if (process.env.OD_OD_PROXY_FETCH === "undici") return fetch;
-  return (request) => net.fetch(request);
+  const undiciFetch = fetch;
+  return async (request) => {
+    try {
+      return await net.fetch(request);
+    } catch (error) {
+      if (!OD_PROXY_RETRYABLE_METHODS.has(request.method) || isClientCancelled(request)) {
+        throw error;
+      }
+      console.warn("[open-design packaged] net.fetch failed; falling back to undici", {
+        message: error instanceof Error ? error.message : String(error),
+        method: request.method,
+        target: request.url,
+      });
+      return await undiciFetch(request);
+    }
+  };
 }
 
 /**

--- a/apps/packaged/tests/protocol.test.ts
+++ b/apps/packaged/tests/protocol.test.ts
@@ -41,6 +41,7 @@ import { handleOdRequest, registerOdProtocol } from '../src/protocol.js';
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe('od:// protocol proxy', () => {
@@ -517,6 +518,43 @@ describe('od:// protocol target resolution', () => {
       'http://127.0.0.1:61424/_next/static/chunk-a.js',
       'http://127.0.0.1:52001/_next/static/chunk-b.js',
     ]);
+  });
+
+  it('falls back to undici when net.fetch rejects a CSS-mask GET', async () => {
+    vi.mocked(net.fetch).mockRejectedValue(new Error('net::ERR_FAILED'));
+    const undiciFetch = vi.fn(async (_input: Request | string | URL) =>
+      new Response('<svg viewBox="0 0 24 24"></svg>', {
+        status: 200,
+        headers: { 'content-type': 'image/svg+xml' },
+      }));
+    vi.stubGlobal('fetch', undiciFetch);
+
+    registerOdProtocol(() => 'http://127.0.0.1:61424/');
+    const handler = registeredHandler();
+    const response = await handler(new Request('od://app/agent-icons/opencode.svg'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('image/svg+xml');
+    expect(await response.text()).toContain('<svg');
+    expect(vi.mocked(net.fetch)).toHaveBeenCalledTimes(1);
+    expect(undiciFetch).toHaveBeenCalledTimes(1);
+    expect((undiciFetch.mock.calls[0]![0] as Request).url)
+      .toBe('http://127.0.0.1:61424/agent-icons/opencode.svg');
+  });
+
+  it('does not replay a non-idempotent request through undici when net.fetch rejects', async () => {
+    vi.mocked(net.fetch).mockRejectedValue(new Error('net::ERR_FAILED'));
+    const undiciFetch = vi.fn(async (_input: Request | string | URL) =>
+      new Response('unexpected', { status: 200 }));
+    vi.stubGlobal('fetch', undiciFetch);
+
+    registerOdProtocol(() => 'http://127.0.0.1:61424/');
+    const handler = registeredHandler();
+    const response = await handler(new Request('od://app/api/projects', { method: 'POST' }));
+
+    expect(response.status).toBe(502);
+    expect(vi.mocked(net.fetch)).toHaveBeenCalledTimes(1);
+    expect(undiciFetch).not.toHaveBeenCalled();
   });
 
   it('answers a missing web runtime address with a structured 503 instead of dialling a placeholder port', async () => {


### PR DESCRIPTION
## Why

Installed Open Design Beta builds could omit several CLI icons even though the same settings screen rendered them correctly under `pnpm tools-dev`. The affected icons use CSS masks, and Electron's `net.fetch` rejected those renderer-owned subresource requests with `net::ERR_FAILED` despite the packaged SVG files being present and directly readable from the web sidecar.

This fixes the packaged-only rendering regression without changing the normal high-concurrency proxy path or replaying write requests.

## What users will see

CLI icons such as OpenCode, Hermes, Grok Build, Cursor Agent, Kilo, and Mimo render normally in installed packaged applications.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — packaged protocol bug fix and regression tests only

## Screenshots

Not applicable; this restores existing icon rendering rather than adding a UI surface.

## Bug fix verification

- Test path: `apps/packaged/tests/protocol.test.ts`
- The CSS-mask GET regression test failed with a 502 before the source fix and passes after it.
- A second regression test confirms rejected POST requests are not replayed through the fallback transport.
- A real isolated packaged `Open Design Beta.app` build was launched through `od://app`; the previously missing OpenCode icon rendered and the packaged logs confirmed successful fallback for the affected mask resources.

## Validation

- `corepack pnpm --filter @open-design/packaged test` — 261 tests passed
- `corepack pnpm --filter @open-design/packaged typecheck`
- `corepack pnpm --filter @open-design/packaged build`
- `corepack pnpm typecheck`
- `corepack pnpm tools-pack mac build --dir <isolated-root> --namespace icon-proxy-fix --to app --app-version 0.16.2-beta.142 --json`
- Real packaged-app launch and settings-page visual verification
- `corepack pnpm guard` was attempted but is currently blocked by the pre-existing missing `apps/telemetry-worker/package.json`, outside this PR's scope.
