### PR TITLE
fix(web): restore design kit section spacing

### DIFF
--- a/apps/web/src/components/BrandPreviewCard.module.css
+++ b/apps/web/src/components/BrandPreviewCard.module.css
@@ -451,7 +451,7 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 0;
+  padding: 18px;
   /* No fill — the section reads as a card purely through its standard outline. */
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
@@ -1555,7 +1555,7 @@
 
 .compact .section {
   gap: 8px;
-  padding: 0;
+  padding: 8px;
   border-radius: var(--radius);
 }
 

--- a/apps/web/tests/styles/design-kit-section-spacing.test.ts
+++ b/apps/web/tests/styles/design-kit-section-spacing.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync(
+  new URL('../../src/components/BrandPreviewCard.module.css', import.meta.url),
+  'utf8',
+);
+
+function cssDeclarations(selector: string): string {
+  const blocks: string[] = [];
+  const rulePattern = /([^{}]+)\{([^}]*)\}/g;
+  const cssWithoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  let match: RegExpExecArray | null;
+  while ((match = rulePattern.exec(cssWithoutComments)) !== null) {
+    const selectors = (match[1] ?? '').split(',').map((item) => item.trim());
+    if (selectors.includes(selector)) blocks.push(match[2] ?? '');
+  }
+  if (blocks.length === 0) throw new Error(`Missing CSS block for ${selector}`);
+  return blocks.join('\n');
+}
+
+describe('DesignKitView section spacing', () => {
+  it('keeps full detail modules inset from their card borders', () => {
+    expect(cssDeclarations('.section')).toContain('padding: 18px;');
+  });
+
+  it('keeps compact picker modules inset without collapsing the three-column preview', () => {
+    expect(cssDeclarations('.compact .section')).toContain('padding: 8px;');
+  });
+});


### PR DESCRIPTION
## Why

While validating the workspace design-system flows, the section content in both the project detail view and the compact picker was touching card borders. The shared DesignKit section rule had reset padding to zero, making headings, descriptions, font cards, and image actions look clipped or misaligned.

This restores the intended visual hierarchy without changing the existing card grid or interaction behavior.

## What users will see

- Design-system detail modules have an 18px inner inset from their borders.
- Compact picker modules use an 8px inset so the three-column font preview remains intact.
- Section headings and image actions no longer sit against or overlap card outlines.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Visual verification was captured for both entry points:
- Project detail: every DesignKit section computes to `padding: 18px`.
- Design-system picker: compact sections compute to `padding: 8px`, with the font preview remaining three columns.

The before/after captures are included in the originating Codex task; this draft can be updated with hosted GitHub attachments before marking ready.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/styles/design-kit-section-spacing.test.ts`
- The test went red on the target branch (`feat/workspace-team`) before the source change and green on this branch: yes
- The contract test covers both the full-detail and compact-picker section padding rules.

## Validation

- `corepack pnpm guard`
- `corepack pnpm typecheck`
- `corepack pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/styles/design-kit-section-spacing.test.ts tests/components/DesignKitView.test.tsx tests/components/DesignSystemPicker.brand-preview.test.tsx --maxWorkers=2` (16 passed)
- `git diff --check`
- Live UI verification of computed section padding in both affected entry points
