### PR TITLE
Add Source Project Context plugin

### DIFF
--- a/plugins/community/source-project-context-ms4fn3em/SKILL.md
+++ b/plugins/community/source-project-context-ms4fn3em/SKILL.md
@@ -1,0 +1,68 @@
+# Source Project Context
+
+This design-system workspace was created from an existing Open Design project. Treat the copied project files as the primary source evidence for the generated design system.
+
+## Source project
+
+- Source project id: 528b2514-393c-4868-bead-278ab096b20f
+- Source project name: Website Clone
+- New design-system project id: e73c9538-299e-47aa-a0cd-6dd5cd96345f
+- New design-system id: user:website-clone-design-system
+- Source skill id: (none)
+- Source design system id: (none)
+
+## Source metadata
+
+```json
+{
+  "kind": "prototype",
+  "intent": "web-clone",
+  "nameSource": "prompt",
+  "skipDiscoveryBrief": true
+}
+```
+
+## Copied files
+
+- the-compression-company-home-2.html
+- index.html
+- NOTES.md
+- the-compression-company-home.html
+- assets/fonts/fonts.css
+- brand-spec.md
+- assets/fonts/instrument-serif.woff2
+- assets/fonts/instrument-serif-italic.woff2
+- assets/fonts/fragment-mono.woff2
+- assets/fonts/inter-latin.woff2
+- assets/fonts/roboter.woff2
+- assets/icons/cylinder-icon.svg
+- assets/icons/grid-icon.svg
+- assets/icons/buildings-icon.svg
+- assets/icons/press-icon.svg
+- assets/logos/transpose.png
+- assets/logos/ef.png
+- assets/logos/fdvc.svg
+- assets/logos/ludlow.png
+- assets/logos/long-journey.png
+- assets/icons/faq-barcode.svg
+- assets/icons/mac-folder.svg
+- assets/images/team-founders-film.png
+- assets/images/ascii-art.png
+- assets/images/ascii-art.webp
+- assets/benchmarks/q10-thumb.webp
+
+## Skipped files
+
+- (none)
+
+## Generation contract
+
+- Read this file before editing design-system outputs.
+- Read the copied files directly from the project workspace; they are source evidence, not generated design-system output.
+- Preserve high-signal assets, source examples, UI surfaces, copy, tokens, typography, and interaction patterns from the copied project.
+- Generate a reusable Open Design design-system package in this same project: DESIGN.md, README.md, SKILL.md, colors_and_type.css, context/provenance, focused preview cards, preserved assets/build/fonts when available, and ui_kits/app/.
+- Before final response, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every actionable issue.
+
+## Provenance
+
+Formalized by Open Design from candidate 77e84dc9-ee63-471c-8cf2-c3c1576d2233.

--- a/plugins/community/source-project-context-ms4fn3em/SKILL.md
+++ b/plugins/community/source-project-context-ms4fn3em/SKILL.md
@@ -1,15 +1,23 @@
+---
+name: source-project-context-ms4fn3em
+description: >
+  Source evidence for The Compression Company design system (from Open Design
+  Website Clone). Use the shipped references/ files as the only evidence bundle
+  after install — do not look for unshipped workspace paths.
+user-invocable: true
+---
+
 # Source Project Context
 
-This design-system workspace was created from an existing Open Design project. Treat the copied project files as the primary source evidence for the generated design system.
+Plugin evidence for the **Website Clone → The Compression Company** design-system extraction. After install, treat **only the files in this plugin folder** as available evidence. Do not expect original Open Design project paths (`index.html`, `assets/`, `preview/`, etc.) to exist on disk unless the consumer project already has them.
 
 ## Source project
 
-- Source project id: 528b2514-393c-4868-bead-278ab096b20f
+- Source project id: `528b2514-393c-4868-bead-278ab096b20f`
 - Source project name: Website Clone
-- New design-system project id: e73c9538-299e-47aa-a0cd-6dd5cd96345f
-- New design-system id: user:website-clone-design-system
-- Source skill id: (none)
-- Source design system id: (none)
+- Design-system project id: `e73c9538-299e-47aa-a0cd-6dd5cd96345f`
+- Design-system id: `user:website-clone-design-system`
+- Live reference: https://www.thecompressioncompany.com
 
 ## Source metadata
 
@@ -22,47 +30,34 @@ This design-system workspace was created from an existing Open Design project. T
 }
 ```
 
-## Copied files
+## Shipped bundle (authoritative)
 
-- the-compression-company-home-2.html
-- index.html
-- NOTES.md
-- the-compression-company-home.html
-- assets/fonts/fonts.css
-- brand-spec.md
-- assets/fonts/instrument-serif.woff2
-- assets/fonts/instrument-serif-italic.woff2
-- assets/fonts/fragment-mono.woff2
-- assets/fonts/inter-latin.woff2
-- assets/fonts/roboter.woff2
-- assets/icons/cylinder-icon.svg
-- assets/icons/grid-icon.svg
-- assets/icons/buildings-icon.svg
-- assets/icons/press-icon.svg
-- assets/logos/transpose.png
-- assets/logos/ef.png
-- assets/logos/fdvc.svg
-- assets/logos/ludlow.png
-- assets/logos/long-journey.png
-- assets/icons/faq-barcode.svg
-- assets/icons/mac-folder.svg
-- assets/images/team-founders-film.png
-- assets/images/ascii-art.png
-- assets/images/ascii-art.webp
-- assets/benchmarks/q10-thumb.webp
+| Path | Role |
+|------|------|
+| `SKILL.md` | This file — install entry + usage contract |
+| `open-design.json` | Plugin manifest |
+| `references/provenance.json` | Formalization provenance |
+| `references/source-1-source-context.md` | Handoff / source-project note |
+| `references/source-2-DESIGN.md` | Full design-system rules (canonical posture) |
+| `references/source-3-README.md` | Package guide + review workflow (reference-only) |
+| `references/source-4-SKILL.md` | Agent skill contract for the TCC system |
+| `references/source-5-README.md` | Applied UI-kit structure notes |
 
-## Skipped files
+Original workspace HTML clones, fonts, icons, logos, and preview cards were **not** copied into this plugin. Visual rules, tokens, components, and workflows are captured in the markdown references above.
 
-- (none)
+## Generation / usage contract
 
-## Generation contract
-
-- Read this file before editing design-system outputs.
-- Read the copied files directly from the project workspace; they are source evidence, not generated design-system output.
-- Preserve high-signal assets, source examples, UI surfaces, copy, tokens, typography, and interaction patterns from the copied project.
-- Generate a reusable Open Design design-system package in this same project: DESIGN.md, README.md, SKILL.md, colors_and_type.css, context/provenance, focused preview cards, preserved assets/build/fonts when available, and ui_kits/app/.
-- Before final response, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every actionable issue.
+1. Read **this file**, then **`references/source-2-DESIGN.md`** before generating or editing design-system outputs.
+2. Use **only** shipped paths under this plugin (`SKILL.md`, `open-design.json`, `references/*`). Never require unshipped paths such as `colors_and_type.css`, `preview/*.html`, `fonts/`, `assets/`, `examples/`, or `ui_kits/app/` unless they already exist in the **consumer** workspace.
+3. Treat `references/source-2-DESIGN.md` as the canonical rules surface (color, type, spacing, layout, components, motion, voice, anti-patterns).
+4. Treat `references/source-3-README.md` and `references/source-4-SKILL.md` as the human and agent package guides for how to apply those rules.
+5. Treat `references/source-5-README.md` as the applied marketing-kit composition model (shell + modular sections), described in prose — not as live HTML.
+6. When the consumer asks for a full package, **generate** missing artifacts (`DESIGN.md`, `README.md`, `SKILL.md`, `colors_and_type.css`, `preview/`, `ui_kits/app/`, etc.) **into the consumer project**, deriving content from these references. Do not assume those outputs already ship with the plugin.
+7. Preserve posture from the references: black canvas, chalk type, paper bento cells, mono `+` CTAs, sensor accents (coral / tan / green / blue / purple) as high-signal only.
+8. If an audit command is available in the consumer environment, run  
+   `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings`  
+   and fix actionable issues in the **consumer** package — not by inventing files inside this plugin.
 
 ## Provenance
 
-Formalized by Open Design from candidate 77e84dc9-ee63-471c-8cf2-c3c1576d2233.
+Formalized by Open Design from candidate `77e84dc9-ee63-471c-8cf2-c3c1576d2233`. See `references/provenance.json`.

--- a/plugins/community/source-project-context-ms4fn3em/open-design.json
+++ b/plugins/community/source-project-context-ms4fn3em/open-design.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "source-project-context-ms4fn3em",
+  "title": "Source Project Context",
+  "version": "0.1.0",
+  "description": "This design-system workspace was created from an existing Open Design project. Treat the copied project files as the primary source evidence for the generated design system.",
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ]
+  }
+}

--- a/plugins/community/source-project-context-ms4fn3em/references/provenance.json
+++ b/plugins/community/source-project-context-ms4fn3em/references/provenance.json
@@ -1,0 +1,47 @@
+{
+  "candidateId": "77e84dc9-ee63-471c-8cf2-c3c1576d2233",
+  "projectId": "e73c9538-299e-47aa-a0cd-6dd5cd96345f",
+  "runId": "2fbb5d19-d578-4a81-9161-c648e3c74a90",
+  "conversationId": "36c6b04e-7937-45f7-bfeb-ebe05761afb2",
+  "provenance": {
+    "summary": "Detected from context/source-context.md, DESIGN.md, README.md, SKILL.md, ui_kits/app/README.md after a successful run.",
+    "detectedAt": 1785229426713
+  },
+  "sourceRefs": [
+    {
+      "kind": "file",
+      "value": "context/source-context.md",
+      "label": "context/source-context.md",
+      "size": 2199,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "DESIGN.md",
+      "label": "DESIGN.md",
+      "size": 10800,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "README.md",
+      "label": "README.md",
+      "size": 3959,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "SKILL.md",
+      "label": "SKILL.md",
+      "size": 3890,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "ui_kits/app/README.md",
+      "label": "ui_kits/app/README.md",
+      "size": 2072,
+      "copied": true
+    }
+  ]
+}

--- a/plugins/community/source-project-context-ms4fn3em/references/provenance.json
+++ b/plugins/community/source-project-context-ms4fn3em/references/provenance.json
@@ -4,42 +4,42 @@
   "runId": "2fbb5d19-d578-4a81-9161-c648e3c74a90",
   "conversationId": "36c6b04e-7937-45f7-bfeb-ebe05761afb2",
   "provenance": {
-    "summary": "Detected from context/source-context.md, DESIGN.md, README.md, SKILL.md, ui_kits/app/README.md after a successful run.",
+    "summary": "Formalized source evidence as plugin references only: source context, DESIGN, README, TCC SKILL, and ui_kits app README. Unshipped workspace binaries/HTML are not part of the installable bundle.",
     "detectedAt": 1785229426713
   },
   "sourceRefs": [
     {
       "kind": "file",
-      "value": "context/source-context.md",
-      "label": "context/source-context.md",
+      "value": "references/source-1-source-context.md",
+      "label": "source-1-source-context.md (from context/source-context.md)",
       "size": 2199,
       "copied": true
     },
     {
       "kind": "file",
-      "value": "DESIGN.md",
-      "label": "DESIGN.md",
+      "value": "references/source-2-DESIGN.md",
+      "label": "source-2-DESIGN.md (from DESIGN.md)",
       "size": 10800,
       "copied": true
     },
     {
       "kind": "file",
-      "value": "README.md",
-      "label": "README.md",
+      "value": "references/source-3-README.md",
+      "label": "source-3-README.md (from README.md)",
       "size": 3959,
       "copied": true
     },
     {
       "kind": "file",
-      "value": "SKILL.md",
-      "label": "SKILL.md",
+      "value": "references/source-4-SKILL.md",
+      "label": "source-4-SKILL.md (from SKILL.md)",
       "size": 3890,
       "copied": true
     },
     {
       "kind": "file",
-      "value": "ui_kits/app/README.md",
-      "label": "ui_kits/app/README.md",
+      "value": "references/source-5-README.md",
+      "label": "source-5-README.md (from ui_kits/app/README.md)",
       "size": 2072,
       "copied": true
     }

--- a/plugins/community/source-project-context-ms4fn3em/references/source-1-source-context.md
+++ b/plugins/community/source-project-context-ms4fn3em/references/source-1-source-context.md
@@ -1,13 +1,13 @@
 # Source Project Context
 
-This design-system workspace was created from an existing Open Design project. Treat the copied project files as the primary source evidence for the generated design system.
+This note is **source evidence** for the Website Clone → The Compression Company design-system extraction. It ships inside the plugin under `references/`. After install, do not expect the original Open Design workspace file tree to be present.
 
 ## Source project
 
-- Source project id: 528b2514-393c-4868-bead-278ab096b20f
+- Source project id: `528b2514-393c-4868-bead-278ab096b20f`
 - Source project name: Website Clone
-- New design-system project id: e73c9538-299e-47aa-a0cd-6dd5cd96345f
-- New design-system id: user:website-clone-design-system
+- Design-system project id: `e73c9538-299e-47aa-a0cd-6dd5cd96345f`
+- Design-system id: `user:website-clone-design-system`
 - Source skill id: (none)
 - Source design system id: (none)
 
@@ -22,43 +22,28 @@ This design-system workspace was created from an existing Open Design project. T
 }
 ```
 
-## Copied files
+## What was observed in the source workspace (not shipped here)
 
-- the-compression-company-home-2.html
-- index.html
-- NOTES.md
-- the-compression-company-home.html
-- assets/fonts/fonts.css
-- brand-spec.md
-- assets/fonts/instrument-serif.woff2
-- assets/fonts/instrument-serif-italic.woff2
-- assets/fonts/fragment-mono.woff2
-- assets/fonts/inter-latin.woff2
-- assets/fonts/roboter.woff2
-- assets/icons/cylinder-icon.svg
-- assets/icons/grid-icon.svg
-- assets/icons/buildings-icon.svg
-- assets/icons/press-icon.svg
-- assets/logos/transpose.png
-- assets/logos/ef.png
-- assets/logos/fdvc.svg
-- assets/logos/ludlow.png
-- assets/logos/long-journey.png
-- assets/icons/faq-barcode.svg
-- assets/icons/mac-folder.svg
-- assets/images/team-founders-film.png
-- assets/images/ascii-art.png
-- assets/images/ascii-art.webp
-- assets/benchmarks/q10-thumb.webp
+The original project contained homepage HTML clones, brand assets, and self-hosted fonts. Those binary/HTML artifacts are **not** part of this plugin bundle. Their design language is captured in the sibling reference files.
 
-## Skipped files
+| Observed (source workspace) | Captured in plugin as |
+|-----------------------------|------------------------|
+| `context/source-context.md` | This file |
+| `DESIGN.md` | `source-2-DESIGN.md` |
+| `README.md` | `source-3-README.md` |
+| `SKILL.md` (TCC skill) | `source-4-SKILL.md` |
+| `ui_kits/app/README.md` | `source-5-README.md` |
+| HTML clones, fonts, icons, previews | Not shipped — regenerate in consumer if needed |
 
-- (none)
+## Generation contract (plugin-safe)
 
-## Generation contract
+- Read this file and `source-2-DESIGN.md` before editing design-system outputs.
+- Use **only** plugin-shipped `references/*` plus the plugin root `SKILL.md` / `open-design.json`.
+- Do not require `index.html`, `assets/`, `fonts/`, `preview/`, `examples/`, or `colors_and_type.css` to exist inside the plugin.
+- When building a reusable package in a consumer project, generate `DESIGN.md`, `README.md`, `SKILL.md`, tokens CSS, preview cards, and `ui_kits/app/` from these references.
+- Prefer the audit gate in the consumer workspace when available:  
+  `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings`
 
-- Read this file before editing design-system outputs.
-- Read the copied files directly from the project workspace; they are source evidence, not generated design-system output.
-- Preserve high-signal assets, source examples, UI surfaces, copy, tokens, typography, and interaction patterns from the copied project.
-- Generate a reusable Open Design design-system package in this same project: DESIGN.md, README.md, SKILL.md, colors_and_type.css, context/provenance, focused preview cards, preserved assets/build/fonts when available, and ui_kits/app/.
-- Before final response, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every actionable issue.
+## Provenance
+
+See `provenance.json` in this folder.

--- a/plugins/community/source-project-context-ms4fn3em/references/source-1-source-context.md
+++ b/plugins/community/source-project-context-ms4fn3em/references/source-1-source-context.md
@@ -1,0 +1,64 @@
+# Source Project Context
+
+This design-system workspace was created from an existing Open Design project. Treat the copied project files as the primary source evidence for the generated design system.
+
+## Source project
+
+- Source project id: 528b2514-393c-4868-bead-278ab096b20f
+- Source project name: Website Clone
+- New design-system project id: e73c9538-299e-47aa-a0cd-6dd5cd96345f
+- New design-system id: user:website-clone-design-system
+- Source skill id: (none)
+- Source design system id: (none)
+
+## Source metadata
+
+```json
+{
+  "kind": "prototype",
+  "intent": "web-clone",
+  "nameSource": "prompt",
+  "skipDiscoveryBrief": true
+}
+```
+
+## Copied files
+
+- the-compression-company-home-2.html
+- index.html
+- NOTES.md
+- the-compression-company-home.html
+- assets/fonts/fonts.css
+- brand-spec.md
+- assets/fonts/instrument-serif.woff2
+- assets/fonts/instrument-serif-italic.woff2
+- assets/fonts/fragment-mono.woff2
+- assets/fonts/inter-latin.woff2
+- assets/fonts/roboter.woff2
+- assets/icons/cylinder-icon.svg
+- assets/icons/grid-icon.svg
+- assets/icons/buildings-icon.svg
+- assets/icons/press-icon.svg
+- assets/logos/transpose.png
+- assets/logos/ef.png
+- assets/logos/fdvc.svg
+- assets/logos/ludlow.png
+- assets/logos/long-journey.png
+- assets/icons/faq-barcode.svg
+- assets/icons/mac-folder.svg
+- assets/images/team-founders-film.png
+- assets/images/ascii-art.png
+- assets/images/ascii-art.webp
+- assets/benchmarks/q10-thumb.webp
+
+## Skipped files
+
+- (none)
+
+## Generation contract
+
+- Read this file before editing design-system outputs.
+- Read the copied files directly from the project workspace; they are source evidence, not generated design-system output.
+- Preserve high-signal assets, source examples, UI surfaces, copy, tokens, typography, and interaction patterns from the copied project.
+- Generate a reusable Open Design design-system package in this same project: DESIGN.md, README.md, SKILL.md, colors_and_type.css, context/provenance, focused preview cards, preserved assets/build/fonts when available, and ui_kits/app/.
+- Before final response, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every actionable issue.

--- a/plugins/community/source-project-context-ms4fn3em/references/source-2-DESIGN.md
+++ b/plugins/community/source-project-context-ms4fn3em/references/source-2-DESIGN.md
@@ -7,6 +7,9 @@
 
 **System in one sentence:** Black void canvas with chalk-on-ink typography, white paper cards in a tight bento grid, mono uppercase labels, and a five-color sensor palette used only as high-signal accents.
 
+> **Plugin note:** This file is the canonical rules reference inside `source-project-context-ms4fn3em`. Package paths mentioned below (`colors_and_type.css`, `fonts/`, `preview/`, `ui_kits/app/`, etc.) describe a full design-system package to **generate in a consumer project**. They are not required to exist inside this plugin bundle — use sibling `references/source-*.md` files only.
+
+
 ## 1. Product Context & Atmosphere
 
 Deep-tech edge AI for sensor compression — not SaaS purple, not consumer pastel. The page reads as instrument panel meets editorial lab: pure black field, white “paper” cells, hairline chalk rules, stencil display faces, and sparse coral/tan/green/blue/purple signals like sensor channels.
@@ -55,7 +58,7 @@ Deep-tech edge AI for sensor compression — not SaaS purple, not consumer paste
 3. White paper cells use ink type; dark cells use chalk type. Do not invert casually.
 4. Coral banner is a full-width exception: solid `--coral` with ink text.
 
-Bind tokens from `colors_and_type.css`. Prefer `var(--token)` over raw hex in new work.
+Bind the tokens documented in this file (generate `colors_and_type.css` in the consumer if needed). Prefer `var(--token)` over raw hex in new work.
 
 ## 3. Typography
 
@@ -68,7 +71,7 @@ Bind tokens from `colors_and_type.css`. Prefer `var(--token)` over raw hex in ne
 | Body / UI | **Inter** | `--font-sans` | Default body; rarely used for labels |
 | Mono / labels | **Fragment Mono** | `--font-mono` | Uppercase labels, CTAs, telemetry, subtitles |
 
-Load via `fonts/fonts.css` or `assets/fonts/fonts.css`.
+Prefer self-hosted faces when the consumer has font files; otherwise use the declared fallback stacks. Do not require plugin-local font paths.
 
 ### Scale
 
@@ -246,16 +249,16 @@ Prefer semantic deliverables (`homepage-bento.html`, `capabilities-section.html`
 
 ## Package map
 
-| Path | Purpose |
-|------|---------|
-| `DESIGN.md` | This document |
-| `README.md` | Human package overview |
-| `SKILL.md` | Agent usage contract |
-| `colors_and_type.css` | Tokens + type utilities |
-| `fonts/` | Self-hosted faces |
-| `assets/` | Icons, logos, images, benchmarks |
-| `preview/` | Focused review cards |
-| `ui_kits/app/` | Applied interface kit |
-| `examples/` | Preserved full homepage clones |
-| `brand-spec.md` | Compact brand tokens |
-| `context/` | Provenance & source handoff |
+Full-package paths below are **targets to generate in a consumer project**. Inside this plugin, the equivalent evidence is the `references/source-*.md` set (see plugin root `SKILL.md`).
+
+| Full-package path | Purpose | Plugin evidence |
+|------|---------|-----------------|
+| `DESIGN.md` | This document | `source-2-DESIGN.md` |
+| `README.md` | Human package overview | `source-3-README.md` |
+| `SKILL.md` | Agent usage contract | `source-4-SKILL.md` |
+| `colors_and_type.css` | Tokens + type utilities | Generate from this DESIGN |
+| `fonts/` / `assets/` | Faces and brand media | Not shipped in plugin |
+| `preview/` | Focused review cards | Generate in consumer |
+| `ui_kits/app/` | Applied interface kit | Structure in `source-5-README.md` |
+| `examples/` | Full homepage clones | Not shipped in plugin |
+| `brand-spec.md` / `context/` | Compact brand + handoff | `source-1` + `provenance.json` |

--- a/plugins/community/source-project-context-ms4fn3em/references/source-2-DESIGN.md
+++ b/plugins/community/source-project-context-ms4fn3em/references/source-2-DESIGN.md
@@ -1,0 +1,261 @@
+# The Compression Company Design System
+
+> Category: Marketing / product web
+> Surface: responsive web (desktop-first bento → mobile stack)
+> Source: Website Clone of https://www.thecompressioncompany.com
+> Design system id: `user:website-clone-design-system`
+
+**System in one sentence:** Black void canvas with chalk-on-ink typography, white paper cards in a tight bento grid, mono uppercase labels, and a five-color sensor palette used only as high-signal accents.
+
+## 1. Product Context & Atmosphere
+
+Deep-tech edge AI for sensor compression — not SaaS purple, not consumer pastel. The page reads as instrument panel meets editorial lab: pure black field, white “paper” cells, hairline chalk rules, stencil display faces, and sparse coral/tan/green/blue/purple signals like sensor channels.
+
+**Product:** The Compression Company — marketing homepage for an AI codec that compresses high-volume sensor data (earth observation, AVs, robotics, medical imaging) with dual lossy/lossless control. Primary surface is a responsive web bento marketing site extracted from the Website Clone project (`528b2514-393c-4868-bead-278ab096b20f`).
+
+**Feeling:** Precise, dense, technical confidence. Calm black field; information density in bento cells; CTAs are small mono pills with a leading `+`, not large gradient buttons.
+
+## 2. Color
+
+### Semantic core
+
+| Token | OKLch / value | Hex source | Role |
+|-------|---------------|------------|------|
+| `--bg` | `oklch(0% 0 0)` | `#000` | Page canvas |
+| `--surface` | `oklch(17% 0 0)` | `#2a2a2a` | Dark cards (benchmark, strip, code) |
+| `--fg` | `oklch(100% 0 0 / 0.98)` | chalk-hi | Primary light text |
+| `--muted` | `oklch(100% 0 0 / 0.4)` | chalk-soft | Secondary light text |
+| `--border` | `oklch(100% 0 0 / 0.06)` | chalk-border | Hairline on dark |
+| `--accent` | `oklch(76% 0.09 230)` | `#64bce8` | Primary CTA / blue |
+
+### Extended brand solids
+
+| Token | Hex | Use |
+|-------|-----|-----|
+| `--coral` | `#e16051` | Banner wash, sensor channel, timeline stop |
+| `--tan` | `#f9d97a` | Sensor channel only |
+| `--green` | `#7fdd84` | Positive list markers, POV kicker, PSNR ring |
+| `--blue` | `#64bce8` | Primary filled CTAs, accent |
+| `--purple` | `#8e6bb3` | Sensor channel, soft radial glows |
+| `--white` | `#fff` | Paper cells, nav, light sections |
+| `--surface-dark` | `#111` | Platform tile rail |
+| `--surface-light` | `#f5f5f5` | Compare graphics |
+| `--gray-light` | `#e0e0e0` | PSNR sidebar cell |
+
+### Chalk / ink opacity ramps
+
+**On black:** `--chalk-hi` → `--chalk` → `--chalk-mid` → `--chalk-soft` → `--chalk-faint` → `--chalk-border` → `--chalk-ghost`.
+
+**On paper:** `--ink` (`#000000d9`), `--ink-faint`, `--ink-rule` for hairlines and secondary copy.
+
+### Rules
+
+1. Page background is always black (`--bg`). Never beige, cream, or light gray page shell.
+2. Accents are high-signal only — strip cards, timeline dots, telemetry dots, one CTA fill. Never full-page gradient washes of blue/purple.
+3. White paper cells use ink type; dark cells use chalk type. Do not invert casually.
+4. Coral banner is a full-width exception: solid `--coral` with ink text.
+
+Bind tokens from `colors_and_type.css`. Prefer `var(--token)` over raw hex in new work.
+
+## 3. Typography
+
+### Families (self-hosted in `fonts/` and `assets/fonts/`)
+
+| Role | Family | CSS token | Notes |
+|------|--------|-----------|-------|
+| Display / stencil | **roboter** → Inter | `--font-stencil` | Hero, section titles, card titles; weight 400–500 |
+| Editorial italic | **Instrument Serif** | `--font-serif` | `em` inside hero/section, funnel italic word |
+| Body / UI | **Inter** | `--font-sans` | Default body; rarely used for labels |
+| Mono / labels | **Fragment Mono** | `--font-mono` | Uppercase labels, CTAs, telemetry, subtitles |
+
+Load via `fonts/fonts.css` or `assets/fonts/fonts.css`.
+
+### Scale
+
+| Token | Approx range | Use |
+|-------|--------------|-----|
+| `--text-xs` | 8–9px | Dataset labels, meta, chip text |
+| `--text-base` | 10–11px | Nav CTAs, ticker, mono buttons |
+| `--text-body` | 12–13px | Body mono prose, list items |
+| `--text-lg` | 13–15px | Sensor titles, ICP labels |
+| `--text-2xl` | 16–20px | FAQ questions, strip titles |
+| `--text-section` | 20–44px | Section headlines |
+| `--text-hero` | 40–60px | Hero |
+| `--text-cta` | 32–56px | Funnel / FAQ display |
+
+### Tracking & leading
+
+- Hero: leading `0.95`, tracking `-0.03em`; italic em scale `1.21em`
+- Section: leading `1.05`, tracking `-0.02em`
+- Labels: uppercase + `0.03em`–`0.06em` tracking
+- Mono prose: slight negative tracking `-0.01em`
+
+### Hierarchy pattern
+
+Stencil headline → optional Instrument Serif italic fragment → Fragment Mono uppercase kicker/label → mono or stencil body.
+
+## 4. Spacing
+
+Fluid clamp scale from source:
+
+| Token | Role |
+|-------|------|
+| `--space-2xs` … `--space-3xl` | Component padding ladder |
+| `--gap` | Bento gutter (~3–5px) — signature density |
+| `--pad-inline` | Section horizontal pad |
+| `--pad-block` | Section vertical pad |
+| `--nav-height` | Sticky nav bar |
+
+**Density:** Marketing bento is intentionally tight. Prefer `--gap` between cells over large empty bands. Section blocks use `--pad-block` / `--pad-inline` inside white or dark cells.
+
+**Radius:** `--radius: 10px` for cells/cards; `--radius-sm: 6px` for image wells; `--radius-pill: 9999px` for CTAs, chips, nav toggle.
+
+**Shadows:** Minimal. Prefer `box-shadow: 0 0 0 1px var(--ink-rule)` hairline rings and soft radial glows (`color-mix` with blue/purple) over Material elevation.
+
+## 5. Layout & Composition
+
+### Bento grid
+
+```
+grid-template-columns: 1fr 1fr 1fr minmax(0, calc(25% + 2.2vw));
+gap: var(--gap);
+padding: var(--gap);
+```
+
+- Nav: full width, sticky, white paper
+- Hero: cols 1–3 + right column (benchmark + PSNR)
+- Subsequent sections: full-width cells (headline, strip, compare, banner, ICP, features, timeline, funnel, FAQ)
+
+### Responsive
+
+- ~1100px: collapse to 2-col; hero and right-col stack
+- ~720px: 1-col; hide desktop nav, show drawer; hide funnel telemetry corners; marquee animations off under `prefers-reduced-motion`
+
+### Page spine (homepage)
+
+1. Sticky nav  
+2. Hero + benchmark + PSNR  
+3. Feature ticker  
+4. Edge headline + platform carousel  
+5. Legacy vs bespoke compare  
+6. Coral banner + POV  
+7. Modalities ICP list + detail card  
+8. Features / founders photo + backer logos  
+9. Timeline (how it works)  
+10. Company strip cards (colored)  
+11. Funnel CTA  
+12. FAQ accordion  
+
+## 6. Components
+
+### Buttons / CTAs (`.hero-nav-btn`, `.funnel-btn`, `.tl-btn`)
+
+- Mono, uppercase, pill radius, leading `+` in label copy
+- **Filled:** `background: var(--blue)`, ink text; hover → white fill
+- **Outline:** transparent, grey-light border, ink text; hover → black fill + white text
+- Heights: ~34px primary, ~22px micro (timeline)
+
+### Nav (`.bento-nav`)
+
+White sticky cell; brand mark SVG + stencil name; desktop outline/filled pills; mobile `+` circular toggle opens drawer.
+
+### Bento cell (`.bento-cell`)
+
+`border-radius: var(--radius)`; backgrounds white / surface-card / surface-dark / coral / bg depending on section.
+
+### Ticker (`.ticker`)
+
+Horizontal marquee of mono uppercase items with `[ brackets ]` and `•` separators; 40s linear loop.
+
+### Platform cards
+
+Dark cards 200×140 with name + vendor mono; label cards dashed border + chip text.
+
+### Benchmark panel
+
+Dark cell: mono dataset label, stencil sensor title, image well, range slider (lossless ↔ max lossy), dual stats (original / compressed).
+
+### PSNR sidebar
+
+Light gray cell: mono label, huge stencil number + unit, green conic ring, mono note.
+
+### Compare block
+
+Two columns (legacy vs bespoke) with graphic, mono heading, stencil list (`–` vs green `+`).
+
+### ICP modality list
+
+Numbered rows; active/hover chalk-ghost fill; detail card with gradient, mono label, stencil tagline, chips.
+
+### FAQ accordion
+
+Stencil question + rotating `+` icon; grid reveal for answer; chalk-faint rules.
+
+### Company strip cards
+
+225×225 colored tiles (coral/tan/green/blue/purple) with stencil title, mono subtitle, line art icon.
+
+### Funnel CTA
+
+Centered stencil/serif hybrid headline, mono subtitle, blue pill CTA; corner telemetry (sensor dots + UTC clock).
+
+## 7. Motion & Interaction
+
+| Pattern | Spec |
+|---------|------|
+| Hover CTAs | `.25s` background / color / border |
+| ICP list | `.3s` background + color |
+| FAQ open | icon rotate 45°, answer grid-rows 0fr → 1fr |
+| Tickers | CSS `translateX` 30–55s linear infinite |
+| Benchmark slider | Instant label/stat update (no image swap in clone) |
+| Reduced motion | Kill ticker/platform/backer/strip animations |
+
+No Lenis smooth-scroll or scroll-triggered banner choreography in this system (known gap vs live site).
+
+## 8. Voice & Brand
+
+**Tone:** Technical, plainspoken, product-led. Compression, edge, sensor, codec, lossless/lossy, PSNR, downstream utility — not hype AI magic.
+
+**Copy patterns:**
+
+- Headlines: short stencil lines; one italic serif fragment for emphasis (*compress data*, *at the edge*)
+- Labels: ALL CAPS mono with brackets in tickers: `[ AI CODEC FOR SENSOR DATA ]`
+- CTAs: `+ Contact`, `+ Capabilities`, `+ Book a demo`
+- Metrics: real-looking units (MB, dB) — use labelled placeholders if unknown; never invent traction stats
+
+**Capitalization:** Sentence case for headlines; uppercase for mono labels and pills.
+
+## 9. Anti-patterns
+
+Do **not**:
+
+1. Purple gradient page washes or multi-color full-bleed backgrounds  
+2. Emoji as feature icons (use line SVGs: cylinder, grid, buildings, press, barcode)  
+3. Soft SaaS cards with left accent borders  
+4. Inter/Roboto as display faces (Inter is body only; display is Roboter)  
+5. Large rounded 24px+ marketing cards (stay near 10px)  
+6. Warm cream/beige canvases  
+7. Accent as large surface fills except coral banner and strip tiles  
+8. Drop shadows / neumorphism as primary depth  
+9. Invented metrics or fake customer quotes  
+10. Crowded multi-logo hero collages without the strip/marquee pattern  
+
+## Semantic file names
+
+Prefer semantic deliverables (`homepage-bento.html`, `capabilities-section.html`) over defaulting every file to `index.html`. Reserve `index.html` for launchers and `ui_kits/app/index.html`.
+
+## Package map
+
+| Path | Purpose |
+|------|---------|
+| `DESIGN.md` | This document |
+| `README.md` | Human package overview |
+| `SKILL.md` | Agent usage contract |
+| `colors_and_type.css` | Tokens + type utilities |
+| `fonts/` | Self-hosted faces |
+| `assets/` | Icons, logos, images, benchmarks |
+| `preview/` | Focused review cards |
+| `ui_kits/app/` | Applied interface kit |
+| `examples/` | Preserved full homepage clones |
+| `brand-spec.md` | Compact brand tokens |
+| `context/` | Provenance & source handoff |

--- a/plugins/community/source-project-context-ms4fn3em/references/source-3-README.md
+++ b/plugins/community/source-project-context-ms4fn3em/references/source-3-README.md
@@ -1,0 +1,80 @@
+# The Compression Company — Design System
+
+Reusable Open Design / Claude Design package extracted from the **Website Clone** project (homepage fidelity clone of [thecompressioncompany.com](https://www.thecompressioncompany.com)).
+
+**id:** `user:website-clone-design-system`  
+**Mood:** Black canvas · chalk type · paper bento cells · sensor accent palette  
+**Surface:** Responsive marketing web
+
+## Product Overview
+
+The Compression Company is an edge-AI compression product for high-volume **sensor data** (earth observation, AVs, robotics, medical imaging). This design system packages the marketing homepage language: a black bento grid, white paper cells, stencil display type, mono telemetry labels, and a five-color sensor palette used only as high-signal accents. The primary surface is a responsive web marketing site with sticky nav, hero + benchmark panels, tickers, modality switchers, FAQ, and funnel CTAs. The package enables agents and designers to build matching prototypes, section artifacts, and applied UI kits without re-deriving tokens from the live site.
+
+## Source Context
+
+| Item | Value |
+|------|--------|
+| Source project | Website Clone (`528b2514-393c-4868-bead-278ab096b20f`) |
+| Live reference | https://www.thecompressioncompany.com |
+| Evidence | `context/source-context.md`, `context/provenance.md`, `NOTES.md`, `brand-spec.md` |
+| HTML clones | root `index.html`, `examples/homepage-*.html` |
+| Assets preserved | `assets/` icons, logos, images, benchmarks; `fonts/` faces |
+
+Source-backed tokens and components were extracted from the copied homepage HTML and brand-spec (2026-07-28), not invented.
+
+## Package Contents
+
+| Path | Purpose |
+|------|---------|
+| `DESIGN.md` | Authoritative visual rules |
+| `README.md` | This package guide |
+| `SKILL.md` | Agent skill contract |
+| `colors_and_type.css` | Color, type, spacing, radius tokens |
+| `brand-spec.md` | Compact brand extract |
+| `fonts/` | Self-hosted Roboter, Inter, Fragment Mono, Instrument Serif |
+| `assets/` | Preserved brand icons, logos, imagery, benchmarks |
+| `preview/` | Focused review HTML cards |
+| `ui_kits/app/` | Applied interface kit |
+| `examples/` | Preserved full homepage source examples |
+| `context/` | Handoff + provenance notes |
+
+Preserved runtime brand assets and fonts live under `assets/` and `fonts/` (source-backed), not only in prose.
+
+## Preview Manifest
+
+Inspect these focused cards in the Design System tab:
+
+1. `preview/colors-primary.html` — semantic + sensor palette  
+2. `preview/typography-specimens.html` — stencil / serif / mono / sans  
+3. `preview/spacing-tokens.html` — fluid space, bento gap, radius  
+4. `preview/radius-shadows.html` — hairlines, glows, rings  
+5. `preview/components-buttons.html` — pill CTAs  
+6. `preview/components-cards.html` — platform, strip, benchmark  
+7. `preview/brand-assets.html` — logos, icons, photography  
+8. `preview/applied-surface.html` — mini bento marketing surface  
+
+## Review Workflow
+
+1. Open **preview/colors-primary.html** and **preview/typography-specimens.html** to lock palette and type.  
+2. Read **DESIGN.md** anti-patterns and component rules.  
+3. Load **colors_and_type.css** + **fonts/fonts.css** into new artifacts.  
+4. Compose from **ui_kits/app/index.html** and modular **ui_kits/app/components/**.  
+5. Reuse **assets/** and **fonts/** by relative path; inspect **examples/** for full-page density.  
+6. Review applied kit, then ship semantic filenames (not always `index.html`).
+
+## How to use
+
+```html
+<link rel="stylesheet" href="fonts/fonts.css" />
+<link rel="stylesheet" href="colors_and_type.css" />
+```
+
+Copy component markup from `ui_kits/app/` or `preview/`. Bind only documented tokens.
+
+## Voice (one line)
+
+Technical, product-led compression language; mono `+` CTAs; no hype gradients.
+
+## Provenance
+
+See `context/provenance.md`. Clone is for local learning/prototype use; replace brand assets before public redistribute.

--- a/plugins/community/source-project-context-ms4fn3em/references/source-3-README.md
+++ b/plugins/community/source-project-context-ms4fn3em/references/source-3-README.md
@@ -1,14 +1,16 @@
-# The Compression Company — Design System
+# The Compression Company — Design System (reference guide)
 
-Reusable Open Design / Claude Design package extracted from the **Website Clone** project (homepage fidelity clone of [thecompressioncompany.com](https://www.thecompressioncompany.com)).
+Reusable design language extracted from the **Website Clone** project (homepage fidelity clone of [thecompressioncompany.com](https://www.thecompressioncompany.com)).
 
 **id:** `user:website-clone-design-system`  
 **Mood:** Black canvas · chalk type · paper bento cells · sensor accent palette  
 **Surface:** Responsive marketing web
 
+> **Plugin note:** This file is a **shipped reference** inside `source-project-context-ms4fn3em`. Paths below describe the *intended full package layout* when you materialize the system in a consumer project. Inside this plugin, use only the sibling `references/source-*.md` files plus the plugin root `SKILL.md`.
+
 ## Product Overview
 
-The Compression Company is an edge-AI compression product for high-volume **sensor data** (earth observation, AVs, robotics, medical imaging). This design system packages the marketing homepage language: a black bento grid, white paper cells, stencil display type, mono telemetry labels, and a five-color sensor palette used only as high-signal accents. The primary surface is a responsive web marketing site with sticky nav, hero + benchmark panels, tickers, modality switchers, FAQ, and funnel CTAs. The package enables agents and designers to build matching prototypes, section artifacts, and applied UI kits without re-deriving tokens from the live site.
+The Compression Company is an edge-AI compression product for high-volume **sensor data** (earth observation, AVs, robotics, medical imaging). This design system packages the marketing homepage language: a black bento grid, white paper cells, stencil display type, mono telemetry labels, and a five-color sensor palette used only as high-signal accents. The primary surface is a responsive web marketing site with sticky nav, hero + benchmark panels, tickers, modality switchers, FAQ, and funnel CTAs.
 
 ## Source Context
 
@@ -16,60 +18,43 @@ The Compression Company is an edge-AI compression product for high-volume **sens
 |------|--------|
 | Source project | Website Clone (`528b2514-393c-4868-bead-278ab096b20f`) |
 | Live reference | https://www.thecompressioncompany.com |
-| Evidence | `context/source-context.md`, `context/provenance.md`, `NOTES.md`, `brand-spec.md` |
-| HTML clones | root `index.html`, `examples/homepage-*.html` |
-| Assets preserved | `assets/` icons, logos, images, benchmarks; `fonts/` faces |
+| Plugin evidence | `source-1-source-context.md`, `source-2-DESIGN.md`, this file, `source-4-SKILL.md`, `source-5-README.md`, `provenance.json` |
+| Rules surface | `source-2-DESIGN.md` (canonical) |
 
 Source-backed tokens and components were extracted from the copied homepage HTML and brand-spec (2026-07-28), not invented.
 
-## Package Contents
+## Evidence map (this plugin)
+
+| Shipped reference | Maps to full-package role |
+|-------------------|---------------------------|
+| `source-2-DESIGN.md` | `DESIGN.md` — authoritative visual rules |
+| `source-3-README.md` | `README.md` — this package guide |
+| `source-4-SKILL.md` | `SKILL.md` — agent skill contract |
+| `source-5-README.md` | `ui_kits/app/README.md` — applied kit notes |
+| `source-1-source-context.md` | `context/source-context.md` — handoff |
+
+Not shipped in the plugin (generate in the consumer when needed): `colors_and_type.css`, `fonts/`, `assets/`, `preview/*.html`, `examples/`, live `ui_kits/app/*.html`.
+
+## Review workflow (plugin-safe)
+
+1. Read **`source-2-DESIGN.md`** for palette, type, spacing, components, and anti-patterns.  
+2. Read **`source-4-SKILL.md`** for agent usage order and build checklist.  
+3. Read **`source-5-README.md`** for marketing-shell composition (nav, hero/benchmark, strip, funnel, FAQ).  
+4. When generating consumer artifacts, **emit** tokens CSS, preview cards, and kit HTML from those rules — do not look for them inside the plugin folder.  
+5. Prefer semantic deliverable filenames; reserve `index.html` for launchers and kit entry points.
+
+## Full-package contents (when materializing)
 
 | Path | Purpose |
 |------|---------|
-| `DESIGN.md` | Authoritative visual rules |
-| `README.md` | This package guide |
-| `SKILL.md` | Agent skill contract |
-| `colors_and_type.css` | Color, type, spacing, radius tokens |
-| `brand-spec.md` | Compact brand extract |
-| `fonts/` | Self-hosted Roboter, Inter, Fragment Mono, Instrument Serif |
-| `assets/` | Preserved brand icons, logos, imagery, benchmarks |
-| `preview/` | Focused review HTML cards |
-| `ui_kits/app/` | Applied interface kit |
-| `examples/` | Preserved full homepage source examples |
-| `context/` | Handoff + provenance notes |
-
-Preserved runtime brand assets and fonts live under `assets/` and `fonts/` (source-backed), not only in prose.
-
-## Preview Manifest
-
-Inspect these focused cards in the Design System tab:
-
-1. `preview/colors-primary.html` — semantic + sensor palette  
-2. `preview/typography-specimens.html` — stencil / serif / mono / sans  
-3. `preview/spacing-tokens.html` — fluid space, bento gap, radius  
-4. `preview/radius-shadows.html` — hairlines, glows, rings  
-5. `preview/components-buttons.html` — pill CTAs  
-6. `preview/components-cards.html` — platform, strip, benchmark  
-7. `preview/brand-assets.html` — logos, icons, photography  
-8. `preview/applied-surface.html` — mini bento marketing surface  
-
-## Review Workflow
-
-1. Open **preview/colors-primary.html** and **preview/typography-specimens.html** to lock palette and type.  
-2. Read **DESIGN.md** anti-patterns and component rules.  
-3. Load **colors_and_type.css** + **fonts/fonts.css** into new artifacts.  
-4. Compose from **ui_kits/app/index.html** and modular **ui_kits/app/components/**.  
-5. Reuse **assets/** and **fonts/** by relative path; inspect **examples/** for full-page density.  
-6. Review applied kit, then ship semantic filenames (not always `index.html`).
-
-## How to use
-
-```html
-<link rel="stylesheet" href="fonts/fonts.css" />
-<link rel="stylesheet" href="colors_and_type.css" />
-```
-
-Copy component markup from `ui_kits/app/` or `preview/`. Bind only documented tokens.
+| `DESIGN.md` | Authoritative visual rules (from `source-2-DESIGN.md`) |
+| `README.md` | Human package overview (from this file) |
+| `SKILL.md` | Agent skill contract (from `source-4-SKILL.md`) |
+| `colors_and_type.css` | Color, type, spacing, radius tokens — generate from DESIGN |
+| `fonts/` / `assets/` | Self-hosted faces and brand media — only if consumer has them |
+| `preview/` | Focused review HTML cards — generate as needed |
+| `ui_kits/app/` | Applied interface kit — structure in `source-5-README.md` |
+| `context/` | Handoff + provenance |
 
 ## Voice (one line)
 
@@ -77,4 +62,4 @@ Technical, product-led compression language; mono `+` CTAs; no hype gradients.
 
 ## Provenance
 
-See `context/provenance.md`. Clone is for local learning/prototype use; replace brand assets before public redistribute.
+See `provenance.json`. Clone evidence is for local learning/prototype use; replace brand assets before public redistribute.

--- a/plugins/community/source-project-context-ms4fn3em/references/source-4-SKILL.md
+++ b/plugins/community/source-project-context-ms4fn3em/references/source-4-SKILL.md
@@ -8,59 +8,59 @@ description: >
 user-invocable: true
 ---
 
-# The Compression Company — Agent Skill
+# The Compression Company — Agent Skill (reference)
 
-Reusable Claude Design–style package for The Compression Company marketing web. Bind tokens from `colors_and_type.css`, follow `DESIGN.md`, and compose from `ui_kits/app/` plus focused `preview/` cards.
+Reusable Claude Design–style skill text for The Compression Company marketing web.
 
-## What's inside
+> **Plugin note:** This file ships under `references/`. Bind rules from **`source-2-DESIGN.md`** in this same folder. Do not require unshipped package paths (`colors_and_type.css`, `preview/`, `fonts/`, `assets/`, `ui_kits/app/*.html`) to exist inside the plugin — generate them in the consumer workspace when the task needs them.
 
-- **DESIGN.md** — canonical posture, components, motion, voice, anti-patterns
-- **colors_and_type.css** — semantic + sensor color tokens, type stacks, spacing, radius
-- **fonts/** — Roboter, Inter, Fragment Mono, Instrument Serif (woff2 + fonts.css)
-- **assets/** — logos, line icons, ascii hero cloud, founders still, benchmark thumb
-- **preview/** — focused review cards (colors, type, spacing, components, brand, applied)
-- **ui_kits/app/** — applied marketing shell + modular component HTML
-- **examples/** — preserved full homepage clones
-- **brand-spec.md** / **context/** — compact brand extract and provenance
+## What's inside (plugin evidence)
+
+- **`source-2-DESIGN.md`** — canonical posture, components, motion, voice, anti-patterns  
+- **`source-3-README.md`** — package guide + plugin-safe review workflow  
+- **`source-5-README.md`** — applied marketing kit structure (prose)  
+- **`source-1-source-context.md`** / **`provenance.json`** — handoff and formalization  
+
+When a full package is materialized in a consumer project, also expect generated: `colors_and_type.css`, optional `fonts/` + `assets/`, `preview/` cards, `ui_kits/app/` HTML, and `examples/`.
 
 ## Source context
 
-Based on the Open Design **Website Clone** project (`528b2514-393c-4868-bead-278ab096b20f`), a high-fidelity homepage clone of https://www.thecompressioncompany.com. Evidence: computed CSS variables, self-hosted fonts, icons, logos, imagery, and full HTML implementations copied into this workspace (see `context/source-context.md`, `context/provenance.md`, `NOTES.md`).
+Based on the Open Design **Website Clone** project (`528b2514-393c-4868-bead-278ab096b20f`), a high-fidelity homepage clone of https://www.thecompressioncompany.com. Evidence for agents using this plugin is the markdown under `references/`, not remote workspace binaries.
 
 ## When to use
 
 Use this skill when building:
 
-- TCC marketing pages, section prototypes, or landing artifacts
-- Edge-AI / sensor-compression product interfaces that must match this brand
-- Design-system previews, investor one-pagers, or UI kits in this visual language
-- Any production-style mock that should look like the black bento homepage
+- TCC marketing pages, section prototypes, or landing artifacts  
+- Edge-AI / sensor-compression product interfaces that must match this brand  
+- Design-system previews, investor one-pagers, or UI kits in this visual language  
+- Any production-style mock that should look like the black bento homepage  
 
-## How to use
+## How to use (plugin-safe)
 
-1. Read **DESIGN.md** for non-negotiable posture and anti-patterns.  
-2. Load **fonts/fonts.css**, then bind **colors_and_type.css** (or paste its `:root` into the artifact `<style>`).  
-3. Inspect **preview/** cards and compose from **ui_kits/app/** (index + `components/`).  
-4. Reuse preserved **assets/** and **fonts/** by relative path — do not hot-link remote brand files.  
-5. For full-page composition reference, open **examples/homepage-full.html**.  
-6. Prefer semantic deliverable filenames; reserve `index.html` for launchers and `ui_kits/app/index.html`.
+1. Read **`source-2-DESIGN.md`** for non-negotiable posture and anti-patterns.  
+2. Apply tokens described there (semantic core + sensor accents + type stacks) — paste into artifact CSS or generate `colors_and_type.css` in the consumer project.  
+3. Follow composition notes in **`source-5-README.md`** (shell, benchmark, strip, FAQ, funnel).  
+4. Use **`source-3-README.md`** for the human review order when materializing a full package.  
+5. Prefer semantic deliverable filenames; reserve `index.html` for launchers and kit entry points.  
+6. Do **not** hot-link remote brand files; only use assets the consumer already has or generates.
 
-**How to use:** Start with DESIGN.md + colors_and_type.css, then copy patterns from preview/ and ui_kits/app/.
+**How to use:** Start with `source-2-DESIGN.md`, then compose from `source-5-README.md` patterns.
 
 ## Design system highlights
 
-- **Colors:** Black `--bg`, chalk type, paper white cells; accents coral / tan / green / blue / purple as high-signal only; primary CTA blue `#64bce8`
-- **Typography:** Roboter stencil display, Instrument Serif italic emphasis, Inter body, Fragment Mono uppercase labels
-- **Spacing & radius:** Fluid space scale; bento `--gap` ~3–5px; cell radius 10px; pill CTAs
-- **Layout:** Sticky white nav + dense 4-col bento collapsing to 2 then 1 column
-- **Interaction:** Pill hover fills, FAQ accordion, modality list, marquee tickers (disabled under reduced motion)
-- **Icons:** Line SVGs (cylinder, grid, buildings, press, barcode) — never emoji
+- **Colors:** Black `--bg`, chalk type, paper white cells; accents coral / tan / green / blue / purple as high-signal only; primary CTA blue `#64bce8`  
+- **Typography:** Roboter stencil display, Instrument Serif italic emphasis, Inter body, Fragment Mono uppercase labels  
+- **Spacing & radius:** Fluid space scale; bento `--gap` ~3–5px; cell radius 10px; pill CTAs  
+- **Layout:** Sticky white nav + dense 4-col bento collapsing to 2 then 1 column  
+- **Interaction:** Pill hover fills, FAQ accordion, modality list, marquee tickers (disabled under reduced motion)  
+- **Icons:** Line SVGs (cylinder, grid, buildings, press, barcode) — never emoji  
 
 ## Build checklist
 
-- [ ] Fonts + `colors_and_type.css` bound  
+- [ ] Tokens from `source-2-DESIGN.md` bound in the artifact or consumer CSS  
 - [ ] Black page canvas; paper or dark cells only  
-- [ ] Display = Roboter; mono labels uppercase  
+- [ ] Display = Roboter (or declared stencil stack); mono labels uppercase  
 - [ ] Primary CTA = blue pill with leading `+`  
 - [ ] Accents not used as page washes (except coral banner / strip tiles)  
 - [ ] No invented metrics; honest placeholders if unknown  

--- a/plugins/community/source-project-context-ms4fn3em/references/source-4-SKILL.md
+++ b/plugins/community/source-project-context-ms4fn3em/references/source-4-SKILL.md
@@ -1,0 +1,70 @@
+---
+name: the-compression-company
+description: >
+  Design system for The Compression Company marketing web — black bento canvas,
+  chalk typography, paper cells, mono + CTAs, sensor accent palette. Use when
+  building TCC-branded pages, edge-AI compression marketing, or matching the
+  Website Clone homepage system (user:website-clone-design-system).
+user-invocable: true
+---
+
+# The Compression Company — Agent Skill
+
+Reusable Claude Design–style package for The Compression Company marketing web. Bind tokens from `colors_and_type.css`, follow `DESIGN.md`, and compose from `ui_kits/app/` plus focused `preview/` cards.
+
+## What's inside
+
+- **DESIGN.md** — canonical posture, components, motion, voice, anti-patterns
+- **colors_and_type.css** — semantic + sensor color tokens, type stacks, spacing, radius
+- **fonts/** — Roboter, Inter, Fragment Mono, Instrument Serif (woff2 + fonts.css)
+- **assets/** — logos, line icons, ascii hero cloud, founders still, benchmark thumb
+- **preview/** — focused review cards (colors, type, spacing, components, brand, applied)
+- **ui_kits/app/** — applied marketing shell + modular component HTML
+- **examples/** — preserved full homepage clones
+- **brand-spec.md** / **context/** — compact brand extract and provenance
+
+## Source context
+
+Based on the Open Design **Website Clone** project (`528b2514-393c-4868-bead-278ab096b20f`), a high-fidelity homepage clone of https://www.thecompressioncompany.com. Evidence: computed CSS variables, self-hosted fonts, icons, logos, imagery, and full HTML implementations copied into this workspace (see `context/source-context.md`, `context/provenance.md`, `NOTES.md`).
+
+## When to use
+
+Use this skill when building:
+
+- TCC marketing pages, section prototypes, or landing artifacts
+- Edge-AI / sensor-compression product interfaces that must match this brand
+- Design-system previews, investor one-pagers, or UI kits in this visual language
+- Any production-style mock that should look like the black bento homepage
+
+## How to use
+
+1. Read **DESIGN.md** for non-negotiable posture and anti-patterns.  
+2. Load **fonts/fonts.css**, then bind **colors_and_type.css** (or paste its `:root` into the artifact `<style>`).  
+3. Inspect **preview/** cards and compose from **ui_kits/app/** (index + `components/`).  
+4. Reuse preserved **assets/** and **fonts/** by relative path — do not hot-link remote brand files.  
+5. For full-page composition reference, open **examples/homepage-full.html**.  
+6. Prefer semantic deliverable filenames; reserve `index.html` for launchers and `ui_kits/app/index.html`.
+
+**How to use:** Start with DESIGN.md + colors_and_type.css, then copy patterns from preview/ and ui_kits/app/.
+
+## Design system highlights
+
+- **Colors:** Black `--bg`, chalk type, paper white cells; accents coral / tan / green / blue / purple as high-signal only; primary CTA blue `#64bce8`
+- **Typography:** Roboter stencil display, Instrument Serif italic emphasis, Inter body, Fragment Mono uppercase labels
+- **Spacing & radius:** Fluid space scale; bento `--gap` ~3–5px; cell radius 10px; pill CTAs
+- **Layout:** Sticky white nav + dense 4-col bento collapsing to 2 then 1 column
+- **Interaction:** Pill hover fills, FAQ accordion, modality list, marquee tickers (disabled under reduced motion)
+- **Icons:** Line SVGs (cylinder, grid, buildings, press, barcode) — never emoji
+
+## Build checklist
+
+- [ ] Fonts + `colors_and_type.css` bound  
+- [ ] Black page canvas; paper or dark cells only  
+- [ ] Display = Roboter; mono labels uppercase  
+- [ ] Primary CTA = blue pill with leading `+`  
+- [ ] Accents not used as page washes (except coral banner / strip tiles)  
+- [ ] No invented metrics; honest placeholders if unknown  
+
+## Anti-patterns (hard fail)
+
+Purple gradient washes · emoji icons · left-border accent cards · Inter as display · cream canvas · fake stats.

--- a/plugins/community/source-project-context-ms4fn3em/references/source-5-README.md
+++ b/plugins/community/source-project-context-ms4fn3em/references/source-5-README.md
@@ -1,8 +1,10 @@
-# Applied UI kit — The Compression Company
+# Applied UI kit — The Compression Company (reference)
 
-Marketing-web kit distilled from the homepage clone. Use these surfaces when generating new TCC pages or sections; do not treat this folder as a generic admin mock.
+Marketing-web kit distilled from the homepage clone. Use these surfaces when generating new TCC pages or sections; do not treat this as a generic admin mock.
 
-## Structure
+> **Plugin note:** This is **prose structure evidence**. Live `index.html` / `components/*.html` files are **not** shipped in the plugin. Generate kit HTML in the consumer project from this outline + `source-2-DESIGN.md`.
+
+## Structure (when materializing `ui_kits/app/`)
 
 | File | Role |
 |------|------|
@@ -12,28 +14,27 @@ Marketing-web kit distilled from the homepage clone. Use these surfaces when gen
 | `components/strip-cards.html` | Colored company strip tiles |
 | `components/benchmark.html` | Dark benchmark panel + PSNR sidebar |
 
-`index.html` links to the modular files under `components/` so reviewers can open each surface from the kit entry.
+## Usage (plugin-safe)
 
-## Usage
-
-1. Open `index.html` to inspect the composed marketing shell.  
-2. Copy markup from `components/*.html` when you build new section artifacts.  
-3. Link `../../fonts/fonts.css` and `../../colors_and_type.css` (already set in kit HTML).  
-4. Import patterns into semantic deliverables (`capabilities-section.html`, etc.).  
-5. Create new variants by composing nav + hero + strip + FAQ rather than inventing SaaS layouts.
+1. Read this file for the composition model.  
+2. Read **`source-2-DESIGN.md`** for tokens, type, and component specs.  
+3. Generate kit HTML in the **consumer** project; link consumer-local tokens CSS / fonts when those files exist.  
+4. Compose nav + hero + strip + FAQ rather than inventing SaaS layouts.  
+5. Related plugin evidence: `source-3-README.md` (package guide), `source-4-SKILL.md` (agent checklist).
 
 ## Design Notes
 
 - **Source basis:** Website Clone homepage (thecompressioncompany.com tokens and bento layout).  
 - **Layout:** Black canvas, white paper cells, ~3–5px gutters, 10px radius.  
-- **Colors / tokens:** Bound only through `colors_and_type.css` (chalk/ink, sensor accents, blue primary CTA).  
+- **Colors / tokens:** Semantic + sensor tokens as specified in `source-2-DESIGN.md`.  
 - **Typography:** Roboter display, Instrument Serif italic, Fragment Mono labels.  
-- **Components:** `buttons`, `faq`, `strip-cards`, and `benchmark` mirror production homepage patterns (nav pills, accordion, colored strip, PSNR panel).  
-- **Composition model:** Treat `index.html` as the App shell; the benchmark column as a Sidebar panel; strip tiles and FAQ rows as PreviewCard blocks; the funnel CTA as a Composer action strip.
+- **Components:** `buttons`, `faq`, `strip-cards`, and `benchmark` mirror production homepage patterns.  
+- **Composition model:** Treat the shell as App; the benchmark column as Sidebar; strip tiles and FAQ rows as PreviewCard blocks; the funnel CTA as a Composer action strip.
 
-## Related package paths
+## Related plugin paths
 
-- Rules: `../../DESIGN.md`  
-- Previews: `../../preview/`  
-- Full example: `../../examples/homepage-full.html`  
-- Brand assets: `../../assets/`
+- Rules: `source-2-DESIGN.md`  
+- Package guide: `source-3-README.md`  
+- Agent skill: `source-4-SKILL.md`  
+- Handoff: `source-1-source-context.md`  
+- Provenance: `provenance.json`  

--- a/plugins/community/source-project-context-ms4fn3em/references/source-5-README.md
+++ b/plugins/community/source-project-context-ms4fn3em/references/source-5-README.md
@@ -1,0 +1,39 @@
+# Applied UI kit — The Compression Company
+
+Marketing-web kit distilled from the homepage clone. Use these surfaces when generating new TCC pages or sections; do not treat this folder as a generic admin mock.
+
+## Structure
+
+| File | Role |
+|------|------|
+| `index.html` | Shell entry: sticky nav, hero + benchmark, ticker, strip, funnel, FAQ |
+| `components/buttons.html` | Pill CTAs (outline / filled / micro) |
+| `components/faq.html` | Accordion FAQ with barcode mark |
+| `components/strip-cards.html` | Colored company strip tiles |
+| `components/benchmark.html` | Dark benchmark panel + PSNR sidebar |
+
+`index.html` links to the modular files under `components/` so reviewers can open each surface from the kit entry.
+
+## Usage
+
+1. Open `index.html` to inspect the composed marketing shell.  
+2. Copy markup from `components/*.html` when you build new section artifacts.  
+3. Link `../../fonts/fonts.css` and `../../colors_and_type.css` (already set in kit HTML).  
+4. Import patterns into semantic deliverables (`capabilities-section.html`, etc.).  
+5. Create new variants by composing nav + hero + strip + FAQ rather than inventing SaaS layouts.
+
+## Design Notes
+
+- **Source basis:** Website Clone homepage (thecompressioncompany.com tokens and bento layout).  
+- **Layout:** Black canvas, white paper cells, ~3–5px gutters, 10px radius.  
+- **Colors / tokens:** Bound only through `colors_and_type.css` (chalk/ink, sensor accents, blue primary CTA).  
+- **Typography:** Roboter display, Instrument Serif italic, Fragment Mono labels.  
+- **Components:** `buttons`, `faq`, `strip-cards`, and `benchmark` mirror production homepage patterns (nav pills, accordion, colored strip, PSNR panel).  
+- **Composition model:** Treat `index.html` as the App shell; the benchmark column as a Sidebar panel; strip tiles and FAQ rows as PreviewCard blocks; the funnel CTA as a Composer action strip.
+
+## Related package paths
+
+- Rules: `../../DESIGN.md`  
+- Previews: `../../preview/`  
+- Full example: `../../examples/homepage-full.html`  
+- Brand assets: `../../assets/`


### PR DESCRIPTION
## Why

Open Design formalized a design-system run from the **Website Clone** project (The Compression Company homepage) into a portable **Source Project Context** skill. Publishing it as a community plugin lets other agents reuse the extracted evidence (rules, package guide, skill contract, kit structure) without re-deriving the brand from the live site.

## What users will see

After install, agents get a skill that injects:

- Source project metadata (Website Clone → `user:website-clone-design-system`)
- Canonical design rules (black bento canvas, chalk type, sensor accents)
- Plugin-safe usage contracts that only reference **shipped** `references/*` files
- Guidance to **generate** full package artifacts (`colors_and_type.css`, previews, UI kit HTML) in the consumer project when needed

## Surface area

| Path | Role |
|------|------|
| `plugins/community/source-project-context-ms4fn3em/SKILL.md` | Install entry + usage contract |
| `open-design.json` | Plugin manifest (`prompt:inject`) |
| `references/source-1-source-context.md` | Handoff note |
| `references/source-2-DESIGN.md` | Full design-system rules |
| `references/source-3-README.md` | Package guide |
| `references/source-4-SKILL.md` | TCC agent skill text |
| `references/source-5-README.md` | Applied kit structure (prose) |
| `references/provenance.json` | Formalization provenance |

No runtime code, workflows, or binary assets.

## Validation

- Manual: every instruction path after install resolves to a file in this plugin folder.
- Generation contract no longer requires unshipped workspace paths (`preview/`, `fonts/`, `assets/`, live kit HTML).
- Full-package paths are labeled as **consumer generation targets**, not plugin contents.

## Related

Same plugin-family shape as #5973, #5933, #5929 — this head is the ms4fn3em candidate for Website Clone / Compression Company evidence. Happy to consolidate if maintainers pick a single plugin id.

Version: 0.1.0
