### PR TITLE
test: consolidate workspace restoration coverage

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -64,6 +64,14 @@ multi-file groups accumulate carry-over — but only the full pool exercises the
 whole suite interleaved with mid-file shards, so treat it as the acceptance
 gate. New and repaired UI tests must hold the following invariants.
 
+- **Keep browser witnesses at cross-layer boundaries.** Before adding a UI
+  case, identify which assertions already belong to component or runtime tests
+  and which transition uniquely requires the running browser product. Extend
+  an existing browser workflow when it already owns the same project,
+  conversation, file, or retry setup; do not repeat that full setup only to
+  reassert a lower-layer state invariant. Retain one browser witness for each
+  distinct cross-layer transition, and keep its narrower ownership tests
+  explicit enough that future consolidation does not weaken coverage.
 - **Order independence is the contract.** Each test performs its own complete
   setup — whatever that file's model requires — and never relies on a
   predecessor's side effects; any contiguous subset of the suite must pass

--- a/e2e/ui/app-restoration.test.ts
+++ b/e2e/ui/app-restoration.test.ts
@@ -334,6 +334,9 @@ test('[P0] @critical visiting an uploaded design file route restores its tab and
   await createPrototypeProject(page, 'Uploaded file deep link');
   await expectWorkspaceReady(page);
 
+  const uploadResponse = page.waitForResponse(isDesignFileUploadResponse, {
+    timeout: T.short,
+  });
   await page.getByTestId('design-files-upload-input').setInputFiles({
     name: 'deep-linked-reference.png',
     mimeType: 'image/png',
@@ -342,6 +345,7 @@ test('[P0] @critical visiting an uploaded design file route restores its tab and
       'base64',
     ),
   });
+  await expect((await uploadResponse).ok()).toBeTruthy();
   const fileTab = tabBySuffix(page, 'deep-linked-reference.png');
   await expect(fileTab).toBeVisible();
   const uploadedName = await fileTab.getAttribute('title');
@@ -368,69 +372,6 @@ test('[P0] @critical visiting an uploaded design file route restores its tab and
   await expect(fileTab).toBeVisible();
   await expect(fileTab).toHaveAttribute('aria-selected', 'true');
   await expectAllProjectFilesInactive(page);
-});
-
-test('[P0] returning from an uploaded design file route to the project root keeps the uploaded file tab active', async ({ page }) => {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
-
-  await gotoEntryHome(page);
-  await createPrototypeProject(page, 'Uploaded file root route restore');
-  await expectWorkspaceReady(page);
-
-  const uploadResponse = page.waitForResponse(isDesignFileUploadResponse, {
-    timeout: T.short,
-  });
-  await page.getByTestId('design-files-upload-input').setInputFiles({
-    name: 'root-design-reference.png',
-    mimeType: 'image/png',
-    buffer: Buffer.from(
-      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5W6McAAAAASUVORK5CYII=',
-      'base64',
-    ),
-  });
-  await expect((await uploadResponse).ok()).toBeTruthy();
-  const fileTab = tabBySuffix(page, 'root-design-reference.png');
-  await expect(fileTab).toBeVisible();
-  const uploadedName = await fileTab.getAttribute('title');
-  expect(uploadedName).toBeTruthy();
-
-  await openAllProjectFiles(page);
-  const fileRow = page.locator('[data-testid^="design-file-row-"]', {
-    hasText: 'root-design-reference.png',
-  });
-  await expect(fileRow).toBeVisible();
-  await fileRow.getByRole('button').first().click();
-  await expect(page.getByTestId('design-file-preview')).toBeVisible();
-
-  const current = new URL(page.url());
-  const [, projects, projectId] = current.pathname.split('/');
-  if (projects !== 'projects' || !projectId) {
-    throw new Error(`unexpected project route: ${current.pathname}`);
-  }
-
-  await gotoProjectRoute(page, `/projects/${projectId}/files/${encodeURIComponent(uploadedName!)}`);
-  await expect(fileTab).toBeVisible();
-  await expect(fileTab).toHaveAttribute('aria-selected', 'true');
-  await navigateProjectRouteInApp(page, `/projects/${projectId}`);
-
-  await expect(page.getByTestId('file-workspace')).toBeVisible();
-  await expect(fileTab).toBeVisible();
-  await expect(fileTab).toHaveAttribute('aria-selected', 'true');
 });
 
 test('[P0] returning from an artifact file route to the project root keeps the artifact tab active', async ({ page }) => {
@@ -504,83 +445,6 @@ test('[P0] returning from an artifact file route to the project root keeps the a
 
   await expect(page.getByTestId('file-workspace')).toBeVisible();
   await expect(artifactTab).toHaveAttribute('aria-selected', 'true');
-});
-
-test('[P0] @critical returning from an older conversation route to the project root keeps the composer available while the route is selected', async ({ page }) => {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
-
-  await page.route('**/api/runs', async (route) => {
-    await route.fulfill({
-      status: 202,
-      contentType: 'application/json',
-      body: '{"runId":"conversation-root-run"}',
-    });
-  });
-
-  await page.route('**/api/runs/*/events', async (route) => {
-    const body = [
-      'event: start',
-      'data: {"bin":"mock-agent"}',
-      '',
-      'event: end',
-      'data: {"code":0,"status":"succeeded"}',
-      '',
-      '',
-    ].join('\n');
-
-    await route.fulfill({
-      status: 200,
-      headers: {
-        'content-type': 'text/event-stream',
-        'cache-control': 'no-cache',
-      },
-      body,
-    });
-  });
-
-  await gotoEntryHome(page);
-  await createPrototypeProject(page, 'Conversation root route restore');
-  await expectWorkspaceReady(page);
-
-  const firstPrompt = 'First conversation should stay selected';
-  await sendPrompt(page, firstPrompt);
-  await expect(page.locator('.msg.user .user-text').filter({ hasText: firstPrompt }).first()).toBeVisible();
-  const firstContext = await getCurrentProjectContext(page);
-
-  await startNewConversation(page);
-  await expect(page.getByTestId('chat-composer-input')).toBeVisible();
-  await expect(page.getByTestId('chat-composer-input')).toHaveText('');
-
-  const secondPrompt = 'Second conversation should not replace the deep-linked one';
-  await sendPrompt(page, secondPrompt);
-  await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt }).first()).toBeVisible();
-  const secondContext = await getCurrentProjectContext(page);
-  expect(secondContext.conversationId).not.toBe(firstContext.conversationId);
-
-  await gotoProjectRoute(page, `/projects/${firstContext.projectId}/conversations/${firstContext.conversationId}`);
-  await expect(page.getByTestId('chat-composer')).toBeVisible();
-  await page.getByTestId('conversation-history-trigger').click();
-  const routeHistoryList = page.getByTestId('conversation-list');
-  await expect(routeHistoryList).toBeVisible();
-  await expect(routeHistoryList.locator('.chat-conv-item').filter({ hasText: firstPrompt }).first()).toBeVisible();
-
-  await navigateProjectRouteInApp(page, `/projects/${firstContext.projectId}`);
-  await expect(page.getByTestId('chat-composer')).toBeVisible();
 });
 
 test('[P0] @critical switching between conversations keeps the composer usable while navigating history', async ({ page }) => {
@@ -694,89 +558,12 @@ test('[P0] @critical switching between conversations keeps the composer usable w
   await expect(page).toHaveURL(new RegExp(`/projects/${firstContext.projectId}/conversations/${firstContext.conversationId}$`));
   await expect(page.locator('.msg.user .user-text').filter({ hasText: firstPrompt }).first()).toBeVisible();
   await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt })).toHaveCount(0);
-});
 
-test('[P0] @critical reloading an older conversation route keeps the composer visible on that route', async ({ page }) => {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
-
-  await page.route('**/api/runs', async (route) => {
-    await route.fulfill({
-      status: 202,
-      contentType: 'application/json',
-      body: '{"runId":"conversation-reload-draft-run"}',
-    });
-  });
-
-  await page.route('**/api/runs/*/events', async (route) => {
-    const body = [
-      'event: start',
-      'data: {"bin":"mock-agent"}',
-      '',
-      'event: end',
-      'data: {"code":0,"status":"succeeded"}',
-      '',
-      '',
-    ].join('\n');
-
-    await route.fulfill({
-      status: 200,
-      headers: {
-        'content-type': 'text/event-stream',
-        'cache-control': 'no-cache',
-      },
-      body,
-    });
-  });
-
-  await gotoEntryHome(page);
-  await createPrototypeProject(page, 'Conversation reload draft restore');
-  await expectWorkspaceReady(page);
-
-  const firstPrompt = 'Reloaded conversation anchor';
-  const secondPrompt = 'Latest conversation anchor';
-  const restoredDraft = 'Draft that should survive a reload on the older conversation';
-
-  await sendPrompt(page, firstPrompt);
-  await expect(page.locator('.msg.user .user-text').filter({ hasText: firstPrompt }).first()).toBeVisible();
-  const firstContext = await getCurrentProjectContext(page);
-
-  await startNewConversation(page);
-  await expect(page.getByTestId('chat-composer-input')).toBeVisible();
-  await expect(page.getByTestId('chat-composer-input')).toHaveText('');
-  await sendPrompt(page, secondPrompt);
-  await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt }).first()).toBeVisible();
-
-  await gotoProjectRoute(page, `/projects/${firstContext.projectId}/conversations/${firstContext.conversationId}`);
-  const composerInput = page.getByTestId('chat-composer-input');
-  await page.getByTestId('conversation-history-trigger').click();
-  const routeHistoryList = page.getByTestId('conversation-list');
-  await expect(routeHistoryList).toBeVisible();
-  await expect(routeHistoryList.locator('.chat-conv-item').filter({ hasText: firstPrompt }).first()).toBeVisible();
-
-  await composerInput.fill(restoredDraft);
-  await expect(composerInput).toHaveText(restoredDraft);
-
-  await reloadCurrentRoute(page);
+  await navigateProjectRouteInApp(page, `/projects/${firstContext.projectId}`);
   await expect(page.getByTestId('chat-composer')).toBeVisible();
-  await page.getByTestId('conversation-history-trigger').click();
-  const reloadedHistoryList = page.getByTestId('conversation-list');
-  await expect(reloadedHistoryList).toBeVisible();
-  await expect(reloadedHistoryList.locator('.chat-conv-item').filter({ hasText: firstPrompt }).first()).toBeVisible();
+  await expect(page).toHaveURL(new RegExp(`/projects/${firstContext.projectId}$`));
+  await expect(page.locator('.msg.user .user-text').filter({ hasText: firstPrompt }).first()).toBeVisible();
+  await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt })).toHaveCount(0);
 });
 
 test('[P0] @critical switching between conversations keeps staged attachments UI available', async ({ page }) => {
@@ -995,11 +782,13 @@ test('[P0] @critical reloading the project keeps the latest conversation selecte
     });
   });
 
+  let historyReloadRunCount = 0;
   await page.route('**/api/runs', async (route) => {
+    historyReloadRunCount += 1;
     await route.fulfill({
       status: 202,
       contentType: 'application/json',
-      body: '{"runId":"conversation-history-reload-run"}',
+      body: JSON.stringify({ runId: `conversation-history-reload-run-${historyReloadRunCount}` }),
     });
   });
 
@@ -1042,6 +831,13 @@ test('[P0] @critical reloading the project keeps the latest conversation selecte
   await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt }).first()).toBeVisible();
   const secondContext = await getCurrentProjectContext(page);
   expect(secondContext.conversationId).not.toBe(firstContext.conversationId);
+  await expectConversationMessagePersisted(
+    page,
+    secondContext.projectId,
+    secondContext.conversationId,
+    'user',
+    secondPrompt,
+  );
 
   await page.reload();
   await expect(page.getByTestId('chat-composer')).toBeVisible();
@@ -1276,11 +1072,13 @@ test('[P0] reloading the project root keeps conversation history accessible', as
     });
   });
 
+  let rootReloadRunCount = 0;
   await page.route('**/api/runs', async (route) => {
+    rootReloadRunCount += 1;
     await route.fulfill({
       status: 202,
       contentType: 'application/json',
-      body: '{"runId":"conversation-root-reload-run"}',
+      body: JSON.stringify({ runId: `conversation-root-reload-run-${rootReloadRunCount}` }),
     });
   });
 
@@ -1976,80 +1774,6 @@ test('[P0] a successful retry after a failed send restores the workspace to a fr
     'true',
   );
   await expect(page.getByText('retry prompt that succeeds')).toBeVisible();
-});
-
-test('[P0] retrying a failed run does not duplicate the original user message', async ({ page }) => {
-  await routeMockAgents(page);
-
-  let runCount = 0;
-  await page.route('**/api/runs', async (route) => {
-    runCount += 1;
-    await route.fulfill({
-      status: 202,
-      contentType: 'application/json',
-      body: JSON.stringify({ runId: `retry-run-${runCount}` }),
-    });
-  });
-
-  let eventCount = 0;
-  await page.route('**/api/runs/*/events', async (route) => {
-    eventCount += 1;
-    const body =
-      eventCount === 1
-        ? [
-            'event: start',
-            'data: {"bin":"mock-agent"}',
-            '',
-            'event: error',
-            'data: {"message":"connection refused"}',
-            '',
-            '',
-          ].join('\n')
-        : [
-            'event: start',
-            'data: {"bin":"mock-agent"}',
-            '',
-            'event: stdout',
-            `data: ${JSON.stringify({
-              chunk:
-                '<artifact identifier="retry-dedup-artifact" type="text/html" title="Retry Dedup Artifact"><!doctype html><html><body><main><h1>Retry Dedup Artifact</h1></main></body></html></artifact>',
-            })}`,
-            '',
-            'event: end',
-            'data: {"code":0,"status":"succeeded"}',
-            '',
-            '',
-          ].join('\n');
-
-    await route.fulfill({
-      status: 200,
-      headers: {
-        'content-type': 'text/event-stream',
-        'cache-control': 'no-cache',
-      },
-      body,
-    });
-  });
-
-  await createEmptyProject(page, 'Retry dedup restore');
-  await expectWorkspaceReady(page);
-
-  const prompt = 'retry dedup prompt';
-  await sendPrompt(page, prompt);
-  await expect(runErrorCard(page)).toContainText('connection refused');
-  await expect(page.locator('.chat-error-retry')).toBeVisible();
-  await expect(page.locator('.msg.user', { hasText: prompt })).toHaveCount(1);
-
-  await Promise.all([
-    page.waitForResponse((resp) => /\/api\/runs$/.test(new URL(resp.url()).pathname) && resp.request().method() === 'POST'),
-    page.locator('.chat-error-retry').click(),
-  ]);
-
-  await expect(page.getByRole('tab', { name: /retry-dedup-artifact\.html/i })).toHaveAttribute(
-    'aria-selected',
-    'true',
-  );
-  await expect(page.locator('.msg.user', { hasText: prompt })).toHaveCount(1);
 });
 
 test('[P1] chat file links open project files in workspace tabs and keep trailing punctuation out of hrefs', async ({ page }) => {
@@ -4036,6 +3760,27 @@ async function listConversationsFromApi(
     conversations: Array<{ id: string; updatedAt: number }>;
   };
   return conversations;
+}
+
+async function expectConversationMessagePersisted(
+  page: Page,
+  projectId: string,
+  conversationId: string,
+  role: string,
+  content: string,
+) {
+  await expect
+    .poll(async () => {
+      const response = await page.request.get(
+        `/api/projects/${projectId}/conversations/${conversationId}/messages`,
+      );
+      if (!response.ok()) return false;
+      const { messages } = (await response.json()) as {
+        messages: Array<{ role: string; content: string }>;
+      };
+      return messages.some((message) => message.role === role && message.content === content);
+    }, { timeout: T.medium })
+    .toBe(true);
 }
 
 async function expectPersistedArtifactMessage(


### PR DESCRIPTION
## Why

The merge-gated workspace-restoration suite repeated full project and conversation setup for behavior already owned by stronger browser workflows or narrow web component tests. This PR removes that duplicate runner work while preserving the cross-layer witnesses that protect file routing, conversation restoration, and retry behavior.

Repeated full-group validation also exposed two invalid fixed-run mocks and one reload-before-persistence race. The same patch makes those test prerequisites observable instead of relying on optimistic UI timing.

## What users will see

No product behavior changes. Contributors should see a smaller and more reliable workspace-restoration merge lane.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is test-only coverage consolidation.

## Bug fix verification

- Test path: `e2e/ui/app-restoration.test.ts`
- Repeated full-group runs exposed the invalid fixed-run mocks and reload persistence race on this branch before the test fixes. No production source changed.

## Validation

- `pnpm guard`
- `pnpm --filter @open-design/e2e typecheck`
- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts --maxWorkers=2 tests/components/ChatComposer.infinite-render.test.tsx tests/components/ProjectView.api-empty-response.test.tsx` — 22/22
- retained cross-layer witnesses repeated three times — 15/15
- two repaired reload scenarios repeated five times — 10/10
- complete `workspace-restoration` group — 25/25 without retry, latest wall time 2m55s
- fully parallel app-restoration critical lane — 8/8

The diff is 50 additions and 297 deletions, within the approximately 500-line batch budget.