### PR TITLE
fix(web): keep manual edit active across workspace pages

### DIFF
--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -803,6 +803,29 @@ const URL_PREVIEW_SELECTION_BRIDGE = `<script data-od-url-selection-bridge>
   }
   function captureRuntimeState(){
     var entries = [];
+    var roots = [];
+    var rootHtmlLength = 0;
+    var runtimeRoots = document.body
+      ? document.body.querySelectorAll('#app, #root, [data-reactroot]')
+      : [];
+    for (var rootIndex = 0; rootIndex < runtimeRoots.length && roots.length < 64; rootIndex++) {
+      var root = runtimeRoots[rootIndex];
+      var rootTag = String(root.tagName || '').toLowerCase();
+      var rootPath = runtimeStatePath(root);
+      if (!rootPath) continue;
+      var rootHtml = String(root.innerHTML || '');
+      if (rootHtmlLength + rootHtml.length > 2097152) break;
+      var rootEntry = {
+        path: rootPath,
+        tag: rootTag,
+        html: rootHtml
+      };
+      if (root.id) rootEntry.id = String(root.id);
+      var rootOdId = root.getAttribute && root.getAttribute('data-od-id');
+      if (rootOdId) rootEntry.odId = String(rootOdId);
+      roots.push(rootEntry);
+      rootHtmlLength += rootHtml.length;
+    }
     var nodes = document.body ? document.body.querySelectorAll('*') : [];
     var count = Math.min(nodes.length, 3500);
     for (var i = 0; i < count; i++) {
@@ -832,6 +855,7 @@ const URL_PREVIEW_SELECTION_BRIDGE = `<script data-od-url-selection-bridge>
     return {
       version: 1,
       hash: String(window.location.hash || ''),
+      roots: roots,
       htmlAttrs: runtimeStateAttributes(document.documentElement),
       bodyAttrs: runtimeStateAttributes(document.body),
       entries: entries

--- a/apps/daemon/tests/project-file-range.test.ts
+++ b/apps/daemon/tests/project-file-range.test.ts
@@ -371,6 +371,7 @@ describe('GET /api/projects/:id/raw/* range request route', () => {
     expect(html).toContain('data-od-url-selection-bridge');
     expect(html).toContain("type: 'od:comment-target'");
     expect(html).toContain("type: 'od:preview-runtime-state-captured'");
+    expect(html).toContain('roots: roots');
     expect(html).not.toContain('data-od-url-scroll-bridge');
   });
 

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -336,6 +336,8 @@ const PREVIEW_BRIDGE_QUERY = 'odPreviewBridge=scroll&odPreviewBridge=selection&o
 // switch. This preserves the current page of multi-page prototypes while
 // leaving artifact scripts and business state inside their sandboxed frames.
 const PREVIEW_RUNTIME_STATE_MAX_ELEMENTS = 3500;
+const PREVIEW_RUNTIME_STATE_MAX_ROOTS = 64;
+const PREVIEW_RUNTIME_STATE_MAX_ROOT_HTML = 2 * 1024 * 1024;
 type PreviewRuntimeStateEntry = {
   path: number[];
   tag: string;
@@ -348,9 +350,17 @@ type PreviewRuntimeStateEntry = {
   scrollLeft?: number;
   scrollTop?: number;
 };
+type PreviewRuntimeStateRoot = {
+  path: number[];
+  tag: string;
+  id?: string;
+  odId?: string;
+  html: string;
+};
 type PreviewRuntimeState = {
   version: 1;
   hash: string;
+  roots?: PreviewRuntimeStateRoot[];
   htmlAttrs: Record<string, string>;
   bodyAttrs: Record<string, string>;
   entries: PreviewRuntimeStateEntry[];
@@ -378,6 +388,27 @@ function isPreviewRuntimeState(value: unknown): value is PreviewRuntimeState {
     state.version !== 1 ||
     typeof state.hash !== 'string' ||
     state.hash.length > 4096 ||
+    (state.roots !== undefined && (
+      !Array.isArray(state.roots) ||
+      state.roots.length > PREVIEW_RUNTIME_STATE_MAX_ROOTS ||
+      state.roots.reduce((total, root) => total + (
+        root && typeof root === 'object' && typeof root.html === 'string'
+          ? root.html.length
+          : PREVIEW_RUNTIME_STATE_MAX_ROOT_HTML + 1
+      ), 0) > PREVIEW_RUNTIME_STATE_MAX_ROOT_HTML ||
+      !state.roots.every((root) => (
+        !!root &&
+        typeof root === 'object' &&
+        typeof root.tag === 'string' &&
+        root.tag.length <= 32 &&
+        Array.isArray(root.path) &&
+        root.path.length <= 64 &&
+        root.path.every((index) => Number.isInteger(index) && index >= 0 && index <= 100_000) &&
+        (root.id === undefined || (typeof root.id === 'string' && root.id.length <= 4096)) &&
+        (root.odId === undefined || (typeof root.odId === 'string' && root.odId.length <= 4096)) &&
+        typeof root.html === 'string'
+      ))
+    )) ||
     !isPreviewRuntimeAttributeMap(state.htmlAttrs) ||
     !isPreviewRuntimeAttributeMap(state.bodyAttrs) ||
     !Array.isArray(state.entries) ||
@@ -1545,6 +1576,7 @@ export const FileViewer = memo(function FileViewer({
         onSendBoardCommentAttachments={onSendBoardCommentAttachments}
         onFileSaved={onFileSaved}
         onBrandExtractionStopRequest={onBrandExtractionStopRequest}
+        onOpenFileReplacing={onOpenFileReplacing}
         commentPortalId={commentPortalId}
         onCommentModeChange={onCommentModeChange}
         shareRequest={shareRequest}
@@ -6640,6 +6672,7 @@ function HtmlViewer({
   onSendBoardCommentAttachments,
   onFileSaved,
   onBrandExtractionStopRequest,
+  onOpenFileReplacing,
   commentPortalId,
   onCommentModeChange,
   shareRequest,
@@ -6670,6 +6703,7 @@ function HtmlViewer({
   onSendBoardCommentAttachments?: (attachments: ChatCommentAttachment[], images?: File[]) => Promise<boolean | void> | boolean | void;
   onFileSaved?: () => Promise<void> | void;
   onBrandExtractionStopRequest?: () => void;
+  onOpenFileReplacing?: (openName: string, closeName: string) => void;
   commentPortalId?: string;
   onCommentModeChange?: (active: boolean) => void;
   shareRequest?: { nonce: number } | null;
@@ -9075,6 +9109,25 @@ function HtmlViewer({
   }, [isActivePreviewIframeSource, isOurPreviewIframeSource]);
 
   useEffect(() => {
+    function onMessage(ev: MessageEvent) {
+      if (!isActivePreviewIframeSource(ev.source)) return;
+      const data = ev.data as { type?: unknown; fileName?: unknown } | null;
+      if (
+        data?.type !== 'od:preview-open-file' ||
+        typeof data.fileName !== 'string' ||
+        data.fileName.length > 4096 ||
+        !/\.html?$/i.test(data.fileName) ||
+        data.fileName.split('/').some((part) => !part || part === '.' || part === '..')
+      ) {
+        return;
+      }
+      onOpenFileReplacing?.(data.fileName, file.name);
+    }
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, [file.name, isActivePreviewIframeSource, onOpenFileReplacing]);
+
+  useEffect(() => {
     if (!effectiveDeck) {
       setSlideState(null);
       return;
@@ -11355,6 +11408,11 @@ function HtmlViewer({
         closeArtifactToolMenus();
       };
       if (!useUrlLoadPreview) {
+        // A snapshot is only valid for the URL-load -> srcDoc handoff that
+        // captured it. Once srcDoc is already the active transport it owns the
+        // newest in-frame navigation state; retaining a missed/late snapshot
+        // lets syncBridgeModes replay an older page when Edit is toggled again.
+        previewRuntimeStateRef.current = null;
         enterManualEditMode();
         return;
       }

--- a/apps/web/src/edit-mode/bridge.ts
+++ b/apps/web/src/edit-mode/bridge.ts
@@ -914,6 +914,10 @@ export function buildManualEditBridge(enabled: boolean): string {
         finishActiveTextEdit(true);
         clearSelectedTarget();
         clearGuidesLayer();
+        // Re-entering Edit must treat the first pointerover as fresh. Keeping
+        // lastHoverId here made the same element look deduplicated forever
+        // after an exit -> enter cycle, so its green guides never came back.
+        clearHoverTracking();
         guidesMemoryEl = null;
         guidesMemoryId = null;
         guidesMemoryClearedAt = 0;
@@ -1069,6 +1073,50 @@ export function buildManualEditBridge(enabled: boolean): string {
       return;
     }
   }, true);
+  function previewHtmlFileForLink(link){
+    if (!link || link.hasAttribute('download')) return null;
+    var target = String(link.getAttribute('target') || '').toLowerCase();
+    if (target && target !== '_self') return null;
+    var href = link.getAttribute('href');
+    if (!href || href.charAt(0) === '#') return null;
+    try {
+      var baseUrl = new URL(document.baseURI || location.href);
+      var nextUrl = new URL(href, baseUrl);
+      var rawMarker = '/raw/';
+      var rawIndex = baseUrl.pathname.lastIndexOf(rawMarker);
+      if (nextUrl.origin !== baseUrl.origin || rawIndex < 0) return null;
+      var rawRoot = baseUrl.pathname.slice(0, rawIndex + rawMarker.length);
+      if (nextUrl.pathname.indexOf(rawRoot) !== 0) return null;
+      var fileName = decodeURIComponent(nextUrl.pathname.slice(rawRoot.length));
+      if (
+        !fileName ||
+        fileName.charAt(0) === '/' ||
+        fileName.split('/').some(function(part){ return !part || part === '.' || part === '..'; }) ||
+        !/\\.html?$/i.test(fileName)
+      ) return null;
+      return { fileName: fileName, search: nextUrl.search || '', hash: nextUrl.hash || '' };
+    } catch (_) {
+      return null;
+    }
+  }
+  // Once Manual Edit has activated srcDoc, keep same-project HTML navigation
+  // in the host workspace. Letting the iframe navigate itself replaces this
+  // document (and therefore this bridge) with a raw URL response; a later Edit
+  // toggle then looks active in the toolbar but cannot draw/select anything.
+  document.addEventListener('click', function(ev){
+    if (enabled || ev.defaultPrevented || ev.button !== 0 || ev.metaKey || ev.ctrlKey || ev.shiftKey || ev.altKey) return;
+    var origin = ev.target;
+    var link = origin && origin.closest ? origin.closest('a[href]') : null;
+    var destination = previewHtmlFileForLink(link);
+    if (!destination) return;
+    ev.preventDefault();
+    window.parent.postMessage({
+      type: 'od:preview-open-file',
+      fileName: destination.fileName,
+      search: destination.search,
+      hash: destination.hash
+    }, '*');
+  }, true);
   document.addEventListener('pointerover', function(ev){
     if (!enabled) return;
     // A drag in progress owns the overlay (selection chrome only); pointerover
@@ -1146,7 +1194,13 @@ export function buildManualEditBridge(enabled: boolean): string {
     if (!hoveredEl) {
       clearHoverTracking();
       renderSelectedChromeForCurrent();
+      return;
     }
+    // A toolbar toggle or iframe visibility swap can leave the pointer inside
+    // the same DOM element without producing a fresh pointerover. Treat normal
+    // movement as the recovery path; postHoverTarget keeps this cheap through
+    // its stable-id dedupe during ordinary movement.
+    postHoverTarget(hoveredEl);
   }, true);
   window.addEventListener('resize', postTargets);
   var hoverGuidesScrollScheduled = false;

--- a/apps/web/src/runtime/srcdoc.ts
+++ b/apps/web/src/runtime/srcdoc.ts
@@ -2201,6 +2201,20 @@ function meaningfulDomFallbackTarget(el) {
       !Array.isArray(state.entries) ||
       state.entries.length > 3500
     ) return;
+    if (Array.isArray(state.roots) && state.roots.length <= 64) {
+      var rootHtmlLength = 0;
+      for (var r = 0; r < state.roots.length; r++) {
+        var root = state.roots[r];
+        if (!root || typeof root !== 'object' || typeof root.html !== 'string') continue;
+        rootHtmlLength += root.html.length;
+        if (rootHtmlLength > 2097152) break;
+        var currentRoot = runtimeStateElement(root);
+        if (!currentRoot) continue;
+        // Preserve the root node itself: application closures and delegated
+        // listeners frequently retain #app/#root by identity.
+        currentRoot.innerHTML = root.html;
+      }
+    }
     applyRuntimeStateAttributes(document.documentElement, state.htmlAttrs);
     applyRuntimeStateAttributes(document.body, state.bodyAttrs);
     for (var i = 0; i < state.entries.length; i++) {

--- a/apps/web/tests/edit-mode/bridge.test.ts
+++ b/apps/web/tests/edit-mode/bridge.test.ts
@@ -416,6 +416,97 @@ describe('manual edit bridge target normalization', () => {
     dom.window.close();
   });
 
+  it('draws the same element hover guides again after edit mode exits and re-enters', () => {
+    const dom = new JSDOM(
+      `<main data-od-source-path="path-0"><h1 data-od-source-path="path-0-0">Plain title</h1></main>${buildManualEditBridge(true)}`,
+      { runScripts: 'dangerously', url: 'http://localhost' },
+    );
+    const title = dom.window.document.querySelector('h1') as HTMLElement;
+    title.getBoundingClientRect = () => ({
+      x: 10, y: 20, width: 160, height: 36,
+      top: 20, right: 170, bottom: 56, left: 10,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    title.dispatchEvent(new dom.window.Event('pointerover', { bubbles: true }));
+    const layer = dom.window.document.querySelector('[data-od-edit-guides-layer]')!;
+    expect(layer.children.length).toBeGreaterThan(0);
+
+    dom.window.dispatchEvent(new dom.window.MessageEvent('message', {
+      data: { type: 'od-edit-mode', enabled: false },
+    }));
+    dom.window.dispatchEvent(new dom.window.MessageEvent('message', {
+      data: { type: 'od-edit-mode', enabled: true },
+    }));
+    expect(layer.children.length).toBe(0);
+
+    title.dispatchEvent(new dom.window.Event('pointerover', { bubbles: true }));
+    expect(layer.querySelector('.od-edit-guide-box-hover')).not.toBeNull();
+
+    dom.window.close();
+  });
+
+  it('recovers hover guides from pointer movement inside an element after edit mode re-enters', () => {
+    const dom = new JSDOM(
+      `<main data-od-source-path="path-0"><h1 data-od-source-path="path-0-0">Plain title</h1></main>${buildManualEditBridge(true)}`,
+      { runScripts: 'dangerously', url: 'http://localhost' },
+    );
+    const title = dom.window.document.querySelector('h1') as HTMLElement;
+    title.getBoundingClientRect = () => ({
+      x: 10, y: 20, width: 160, height: 36,
+      top: 20, right: 170, bottom: 56, left: 10,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    title.dispatchEvent(new dom.window.Event('pointerover', { bubbles: true }));
+    const layer = dom.window.document.querySelector('[data-od-edit-guides-layer]')!;
+
+    dom.window.dispatchEvent(new dom.window.MessageEvent('message', {
+      data: { type: 'od-edit-mode', enabled: false },
+    }));
+    dom.window.dispatchEvent(new dom.window.MessageEvent('message', {
+      data: { type: 'od-edit-mode', enabled: true },
+    }));
+    expect(layer.children.length).toBe(0);
+
+    // Electron can preserve the iframe's pointer hit target while the toolbar
+    // toggles edit mode. In that case movement within the same element emits
+    // pointermove but no fresh pointerover.
+    title.dispatchEvent(new dom.window.Event('pointermove', { bubbles: true }));
+    expect(layer.querySelector('.od-edit-guide-box-hover')).not.toBeNull();
+
+    dom.window.close();
+  });
+
+  it('hands same-project HTML links to the host instead of losing the srcDoc edit bridge', () => {
+    const posts: Array<{ type?: string; fileName?: string }> = [];
+    const dom = new JSDOM(
+      `<base href="http://localhost/api/projects/project-1/raw/today.html"><main data-od-source-path="path-0"><a href="discover.html?variant=a">Discover</a></main>${buildManualEditBridge(false)}`,
+      { runScripts: 'dangerously', url: 'http://localhost' },
+    );
+    dom.window.parent.postMessage = ((message: unknown) => {
+      posts.push(message as { type?: string; fileName?: string });
+    }) as typeof dom.window.parent.postMessage;
+    const link = dom.window.document.querySelector('a')!;
+    const click = new dom.window.MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    });
+
+    link.dispatchEvent(click);
+
+    expect(click.defaultPrevented).toBe(true);
+    expect(posts).toContainEqual({
+      type: 'od:preview-open-file',
+      fileName: 'discover.html',
+      search: '?variant=a',
+      hash: '',
+    });
+
+    dom.window.close();
+  });
+
   it('drag-repositions an element via pointer drag and posts od-edit-drag-commit', () => {
     const posts: Array<{ type?: string; id?: string; transform?: string }> = [];
     const dom = new JSDOM(

--- a/apps/web/tests/runtime/srcdoc-bridge-empty-targets.test.ts
+++ b/apps/web/tests/runtime/srcdoc-bridge-empty-targets.test.ts
@@ -519,6 +519,39 @@ describe('selection bridge — empty annotation surface (#890)', () => {
     expect(profile.hasAttribute('hidden')).toBe(true);
   });
 
+  it('restores the current page content before manual edit activates', async () => {
+    const { win } = setupBridgeDom(
+      '<main id="app" data-page="today"><h1 data-od-source-path="path-0-0">Today page</h1></main>',
+      'inspect',
+    );
+
+    win.dispatchEvent(
+      new win.MessageEvent('message', {
+        data: {
+          type: 'od:preview-runtime-state-restore',
+          state: {
+            version: 1,
+            hash: '',
+            roots: [{
+              path: [0],
+              tag: 'main',
+              id: 'app',
+              html: '<section data-od-id="profile-screen"><h1>Profile page</h1><p>Current page content</p></section>',
+            }],
+            htmlAttrs: {},
+            bodyAttrs: {},
+            entries: [],
+          },
+        },
+      }),
+    );
+
+    expect(win.document.getElementById('app')?.getAttribute('data-page')).toBe('today');
+    expect(win.document.querySelector('[data-od-id="profile-screen"] h1')?.textContent).toBe('Profile page');
+    expect(win.document.body.textContent).toContain('Current page content');
+    expect(win.document.body.textContent).not.toContain('Today page');
+  });
+
   it('posts od:comment-target for the annotated card when the device-frame iframe is clicked', async () => {
     const { win, parentPostMessage } = setupBridgeDom(
       '<article data-od-id="tablet-card" class="frame-card"><div class="meta">Tablet edition</div><iframe id="f" class="tablet-frame" title="Tablet edition" src="about:blank"></iframe></article>',

--- a/e2e/ui/app-manual-edit.test.ts
+++ b/e2e/ui/app-manual-edit.test.ts
@@ -167,6 +167,7 @@ test('[P0] manual edit mode preserves the current page in a multi-page mobile ap
 
   await page.getByTestId('manual-edit-mode-toggle').click();
   await expect(page.getByTestId('manual-edit-mode-toggle')).toHaveAttribute('aria-pressed', 'false');
+  await expect(preview.locator('html[data-od-edit-mode]')).toHaveCount(0);
   await expect(preview.getByTestId('mobile-page-profile')).toBeVisible();
   await preview.getByRole('button', { name: 'Home' }).click();
   await expect(preview.getByTestId('mobile-page-home')).toBeVisible();
@@ -201,6 +202,102 @@ test('[P0] manual edit mode preserves the current page in a multi-page mobile ap
   await expect(preview.locator('[data-edit-revision="fresh"]')).toBeVisible();
   await expect(preview.getByTestId('mobile-page-home')).toBeVisible();
   await expect(preview.getByTestId('mobile-page-profile')).toBeHidden();
+});
+
+test('[P0] manual edit mode preserves a runtime-rendered mobile app page', async ({ page }) => {
+  await routeMockAgents(page);
+  const projectId = await createEmptyProject(page, 'Runtime-rendered mobile edit');
+  await seedHtmlArtifact(page, projectId, 'mobile-app.html', runtimeRenderedMobileHtml());
+  await page.goto(`/projects/${projectId}/files/mobile-app.html`);
+  await openDesignFile(page, 'mobile-app.html');
+
+  const preview = artifactPreviewFrame(page);
+  await expect(preview.getByTestId('mobile-page-today')).toBeVisible();
+  await page.getByRole('tab', { name: 'Code', exact: true }).click();
+  await page.getByRole('tab', { name: 'Preview', exact: true }).click();
+  await expect(page.frameLocator('iframe[data-testid="artifact-preview-frame-srcdoc"]')
+    .getByTestId('mobile-page-today')).toBeAttached();
+
+  await preview.getByRole('button', { name: 'Profile' }).click();
+  await expect(preview.getByTestId('mobile-page-profile')).toBeVisible();
+  await expect(preview.getByRole('heading', { name: 'Profile page' })).toBeVisible();
+  await expect(preview.getByTestId('mobile-page-today')).toHaveCount(0);
+
+  await page.getByTestId('manual-edit-mode-toggle').click();
+
+  await expect(page.getByTestId('manual-edit-mode-toggle')).toHaveAttribute('aria-pressed', 'true');
+  await expect(preview.getByTestId('mobile-page-profile')).toBeVisible();
+  await expect(preview.getByRole('heading', { name: 'Profile page' })).toBeVisible();
+  await expect(preview.getByRole('heading', { name: 'Today page' })).toHaveCount(0);
+  await expect(preview.getByTestId('mobile-page-today')).toHaveCount(0);
+  await preview.locator('[data-od-id="profile-screen"]').hover();
+  await expect(preview.locator('[data-od-edit-guides-layer]')).toHaveCount(1);
+  await expect(preview.locator('[data-od-edit-guides-layer] > *')).not.toHaveCount(0);
+  await selectPreviewElementThroughBridge(
+    page,
+    preview,
+    '[data-od-id="profile-screen"]',
+    'CONTENT',
+  );
+
+  await page.getByTestId('manual-edit-mode-toggle').click();
+  await expect(page.getByTestId('manual-edit-mode-toggle')).toHaveAttribute('aria-pressed', 'false');
+  await expect(preview.locator('html[data-od-edit-mode]')).toHaveCount(0);
+  await preview.getByRole('button', { name: 'Today' }).click();
+  await expect(preview.getByTestId('mobile-page-today')).toBeVisible();
+  await expect(preview.getByTestId('mobile-page-profile')).toHaveCount(0);
+
+  await page.getByTestId('manual-edit-mode-toggle').click();
+  await expect(page.getByTestId('manual-edit-mode-toggle')).toHaveAttribute('aria-pressed', 'true');
+  await expect(preview.getByTestId('mobile-page-today')).toBeVisible();
+  await expect(preview.getByTestId('mobile-page-profile')).toHaveCount(0);
+  await preview.locator('[data-od-id="today-screen"]').hover();
+  await expect(preview.locator('[data-od-edit-guides-layer] > *')).not.toHaveCount(0);
+});
+
+test('[P0] srcDoc page navigation keeps manual edit hover guides across files and re-entry', async ({ page }) => {
+  await routeMockAgents(page);
+  const projectId = await createEmptyProject(page, 'Cross-file mobile edit');
+  await seedHtmlArtifact(
+    page,
+    projectId,
+    'today.html',
+    linkedMobilePageHtml('Today page', 'today-screen', 'profile.html', 'Profile'),
+  );
+  await seedHtmlArtifact(
+    page,
+    projectId,
+    'profile.html',
+    linkedMobilePageHtml('Profile page', 'profile-screen', 'today.html', 'Today'),
+  );
+  await page.goto(`/projects/${projectId}/files/today.html`);
+  await openDesignFile(page, 'today.html');
+
+  const preview = artifactPreviewFrame(page);
+  await expect(preview.getByRole('heading', { name: 'Today page' })).toBeVisible();
+  await page.getByTestId('manual-edit-mode-toggle').click();
+  await expect(page.getByTestId('manual-edit-mode-toggle')).toHaveAttribute('aria-pressed', 'true');
+  await preview.locator('[data-od-id="today-screen"]').hover();
+  await expect(preview.locator('[data-od-edit-guides-layer] > *')).not.toHaveCount(0);
+
+  await page.getByTestId('manual-edit-mode-toggle').click();
+  await expect(page.getByTestId('manual-edit-mode-toggle')).toHaveAttribute('aria-pressed', 'false');
+  await expect(preview.locator('html[data-od-edit-mode]')).toHaveCount(0);
+  await preview.getByRole('link', { name: 'Profile' }).click();
+
+  await expect(tabBySuffix(page, 'profile.html')).toHaveAttribute('aria-selected', 'true');
+  await expect(preview.getByRole('heading', { name: 'Profile page' })).toBeVisible();
+  await page.getByTestId('manual-edit-mode-toggle').click();
+  await expect(page.getByTestId('manual-edit-mode-toggle')).toHaveAttribute('aria-pressed', 'true');
+  await preview.locator('[data-od-id="profile-screen"]').hover();
+  await expect(preview.locator('[data-od-edit-guides-layer] > *')).not.toHaveCount(0);
+
+  await page.getByTestId('manual-edit-mode-toggle').click();
+  await expect(preview.locator('html[data-od-edit-mode]')).toHaveCount(0);
+  await page.getByTestId('manual-edit-mode-toggle').click();
+  await expect(preview.locator('html[data-od-edit-mode]')).toHaveCount(1);
+  await preview.locator('[data-od-id="profile-screen"]').hover();
+  await expect(preview.locator('[data-od-edit-guides-layer] > *')).not.toHaveCount(0);
 });
 
 async function selectPreviewElementThroughBridge(
@@ -1143,6 +1240,62 @@ function multiPageMobileHtml(): string {
         });
       });
     </script>
+  </body>
+</html>`;
+}
+
+function runtimeRenderedMobileHtml(): string {
+  return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <div id="app"></div>
+    <script>
+      const app = document.querySelector('#app');
+      const renderToday = () => {
+        app.innerHTML =
+          '<main data-testid="mobile-page-today" data-od-id="today-screen">' +
+            '<h1>Today page</h1>' +
+            '<button type="button" data-page-target="profile">Profile</button>' +
+          '</main>';
+      };
+      const renderProfile = () => {
+        app.innerHTML =
+          '<main data-testid="mobile-page-profile" data-od-id="profile-screen">' +
+            '<section><h1>Profile page</h1><p>Current page content</p></section>' +
+            '<button type="button" data-page-target="today">Today</button>' +
+          '</main>';
+      };
+      document.addEventListener('click', (event) => {
+        if (event.target.closest('[data-page-target="profile"]')) renderProfile();
+        if (event.target.closest('[data-page-target="today"]')) renderToday();
+      });
+      renderToday();
+    </script>
+  </body>
+</html>`;
+}
+
+function linkedMobilePageHtml(
+  heading: string,
+  screenId: string,
+  href: string,
+  linkLabel: string,
+): string {
+  return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <main data-od-id="${screenId}">
+      <h1>${heading}</h1>
+      <a href="${href}">${linkLabel}</a>
+    </main>
   </body>
 </html>`;
 }


### PR DESCRIPTION
Follow-up to #6048

## Why

The original #6048 fix preserved enough URL-preview state to keep some multi-page prototypes on their current screen when Edit was first enabled, but the fix did not hold for runtime-rendered apps or subsequent edit sessions.

In the reported mobile app, leaving and re-entering Edit could remove the green element guides, and navigating to another HTML page could leave the toolbar showing Edit while the preview no longer had a working edit bridge. This made page-specific editing unreliable.

There were three interacting causes:

- runtime apps replace the contents of `#app` / `#root`, while the existing snapshot restored attributes, controls, and scroll state but not the rendered root subtree;
- relative HTML navigation inside the `srcDoc` preview replaced the bridge-enabled document with a raw URL document;
- hover dedupe survived an Edit exit, and Electron can resume pointer movement inside the same element without emitting a new `pointerover`.

## What users will see

For multi-page mobile prototypes, entering Edit keeps the currently visible page. Navigating between HTML pages updates the active design-file tab without losing the edit bridge. After leaving Edit, switching pages, or entering Edit again, moving over an element consistently restores the green guides and selection affordance.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — Manual Edit now preserves the current page and remains selectable across page/mode transitions
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No entry point or visual design changes. The existing Edit button and green guide UI are unchanged; this PR restores them after navigation and mode re-entry. The behavior is covered by the red/green Playwright scenarios below and was also verified in the `pnpm tools-dev` Electron client.

## Bug fix verification

- Red specs: `e2e/ui/app-manual-edit.test.ts`, `apps/web/tests/edit-mode/bridge.test.ts`, and `apps/web/tests/runtime/srcdoc-bridge-empty-targets.test.ts`.
- The new current-page, cross-file navigation/re-entry, and pointer-move recovery scenarios failed on the targeted `origin/feat/workspace-team` baseline before the source changes and pass on this branch.
- The live development client was checked through first Edit entry, Edit exit/re-entry, and `profile.html` → `discover.html` navigation followed by Edit. Each path produced the expected `od-edit-hover` event and visible green guides.

## Validation

- `corepack pnpm guard`
- `corepack pnpm --filter @open-design/web typecheck`
- `corepack pnpm --filter @open-design/e2e typecheck`
- `corepack pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/edit-mode/bridge.test.ts tests/runtime/srcdoc-bridge-empty-targets.test.ts --maxWorkers=2` — 65 passed
- focused daemon project-file-range tests — 46 passed
- `corepack pnpm --filter @open-design/e2e exec playwright test ui/app-manual-edit.test.ts --grep 'manual edit mode preserves|srcDoc page navigation' --workers=1` — 3 passed
- Live desktop verification using only `pnpm tools-dev` (daemon 52934, web/desktop 52935)
- `git diff --check`