### PR TITLE
test(e2e): remove redundant UI setup

### DIFF
--- a/docs/testing/test-efficiency.zh-CN.md
+++ b/docs/testing/test-efficiency.zh-CN.md
@@ -88,6 +88,9 @@ expect(retry).toHaveBeenCalledTimes(1);
 
 - 每个用例独立建立自己依赖的项目、配置、mock 和运行状态。
 - 不依赖同文件前序用例或同 worker 前序文件遗留的数据。
+- 只有验证首页、项目创建表单或创建后的路由行为时，才通过对应 UI 建立项目。
+  其他浏览器用例应先注入首屏所需配置，通过 API 建立独立项目，再直达目标
+  路由，避免把无关的首页渲染、modal 交互和 reload 纳入每条测试链路。
 - 不为了摊薄启动成本共享可变 daemon、浏览器上下文或数据目录。
 - 不用 serial group 隐藏竞争条件。
 - 嵌套资源按后创建、先关闭的顺序释放：page、browser context 和 browser

--- a/e2e/ui/app.test.ts
+++ b/e2e/ui/app.test.ts
@@ -400,54 +400,7 @@ for (const entry of automatedUiScenarios().filter(
   });
 }
 
-test('[P0] @critical comment attachment flow attaches preview comments to the next run as structured context', async ({ page }) => {
-  test.setTimeout(75_000);
-  const entry = automatedUiScenarios().find((scenario) => scenario.id === 'comment-attachment-flow');
-  if (!entry?.mockArtifact) {
-    throw new Error('comment-attachment-flow scenario fixture is missing');
-  }
-
-  await routeMockAgents(page);
-  await page.route('**/api/runs', async (route) => {
-    await route.fulfill({
-      status: 202,
-      contentType: 'application/json',
-      body: JSON.stringify({ runId: 'comment-attachment-run' }),
-    });
-  });
-  await page.route('**/api/runs/*/events', async (route) => {
-    const body = [
-      'event: start',
-      'data: {"bin":"mock-agent"}',
-      '',
-      'event: end',
-      'data: {"code":0,"status":"succeeded"}',
-      '',
-      '',
-    ].join('\n');
-    await route.fulfill({
-      status: 200,
-      headers: {
-        'content-type': 'text/event-stream',
-        'cache-control': 'no-cache',
-      },
-      body,
-    });
-  });
-
-  const projectId = await createEmptyProject(page, 'Comment attachment flow');
-  await expectWorkspaceReady(page);
-  await seedHtmlArtifact(page, projectId, entry.mockArtifact.fileName, entry.mockArtifact.html);
-  await page.reload();
-  await expectWorkspaceReady(page);
-  await page.goto(`/projects/${projectId}/files/${entry.mockArtifact.fileName}`, { waitUntil: 'domcontentloaded' });
-  await waitForLoadingToClear(page);
-  await expect(artifactPreview(page)).toBeVisible();
-
-  await runCommentAttachmentFlow(page, entry);
-});
-
-test('[P0] sending preview comments opens the refreshed follow-up artifact', async ({ page }) => {
+test('[P0] @critical sending preview comments attaches structured context and opens the refreshed artifact', async ({ page }) => {
   test.setTimeout(75_000);
   const entry = automatedUiScenarios().find((scenario) => scenario.id === 'comment-attachment-flow');
   if (!entry?.mockArtifact) {
@@ -518,6 +471,8 @@ test('[P0] sending preview comments opens the refreshed follow-up artifact', asy
   await page.getByTestId('comment-popover-input').fill('Make the headline more specific.');
   await page.getByTestId('comment-popover-save').click();
   await expect(page.getByTestId('comment-saved-marker-hero-title')).toBeVisible();
+  await expect(page.getByTestId('staged-comment-attachments')).toHaveCount(0);
+  await expect(page.getByTestId('comment-popover')).toHaveCount(0);
 
   const sidePanel = page.getByTestId('comment-side-panel');
   await expect(sidePanel).toBeVisible();
@@ -547,6 +502,7 @@ test('[P0] sending preview comments opens the refreshed follow-up artifact', asy
       filePath?: string;
     }>;
   };
+  expect(body.message ?? '').not.toContain('Apply selected preview comments');
   expect(body.message).toContain('Make the headline more specific.');
   expect(body.commentAttachments).toEqual([
     expect.objectContaining({

--- a/e2e/ui/real-daemon-run.test.ts
+++ b/e2e/ui/real-daemon-run.test.ts
@@ -76,7 +76,6 @@ test.afterEach(async ({ page }) => {
 });
 
 test('[P0] real daemon run streams, persists, and previews an artifact', async ({ page }) => {
-  await page.goto('/');
   await createProject(page, 'Real daemon run smoke');
   await expectWorkspaceReady(page);
 
@@ -106,7 +105,6 @@ test('[P0] real daemon run streams, persists, and previews an artifact', async (
 });
 
 test('[P0] real daemon run persists an artifact streamed across multiple chunks', async ({ page }) => {
-  await page.goto('/');
   await createProject(page, 'Chunked daemon run smoke');
   await expectWorkspaceReady(page);
 
@@ -121,7 +119,6 @@ test('[P0] real daemon run persists an artifact streamed across multiple chunks'
 });
 
 test('[P1] plain stdout daemon runtime persists artifact tags into project files and preview', async ({ page }) => {
-  await page.goto('/');
   await createProject(page, 'Plain stream artifact smoke', 'qwen');
   await expectWorkspaceReady(page);
 
@@ -135,7 +132,6 @@ test('[P1] plain stdout daemon runtime persists artifact tags into project files
 });
 
 test('[P0] real daemon run surfaces process/parser errors in chat', async ({ page }) => {
-  await page.goto('/');
   await createProject(page, 'Daemon error smoke');
   await expectWorkspaceReady(page);
 
@@ -146,7 +142,6 @@ test('[P0] real daemon run surfaces process/parser errors in chat', async ({ pag
 });
 
 test('[P0] real daemon run classifies a Claude mid-stream socket drop as a retryable connection error', async ({ page }) => {
-  await page.goto('/');
   await createProject(page, 'Daemon socket-drop smoke', 'claude');
   await expectWorkspaceReady(page);
 
@@ -162,7 +157,6 @@ test('[P0] real daemon run classifies a Claude mid-stream socket drop as a retry
 });
 
 test('[P0] real daemon run supports a follow-up turn in the same project', async ({ page }) => {
-  await page.goto('/');
   await createProject(page, 'Daemon follow-up smoke');
   await expectWorkspaceReady(page);
 
@@ -182,7 +176,6 @@ test('[P0] real daemon run supports a follow-up turn in the same project', async
 });
 
 test('[P1] real daemon run treats an in-place artifact edit as produced work', async ({ page }) => {
-  await page.goto('/');
   await createProject(page, 'Daemon artifact edit smoke', 'claude');
   await expectWorkspaceReady(page);
 
@@ -222,6 +215,7 @@ test('[P1] real daemon run treats an in-place artifact edit as produced work', a
   await expect(editedHeading).toBeVisible();
   await editedHeading.click();
   await expect(editedHeading).toHaveAttribute('data-od-edit-selected', 'true');
+  await page.getByTestId('manual-edit-open-inspector').click();
   const fontSizeInput = page
     .locator('.manual-edit-modal .cc-section')
     .filter({ hasText: 'TYPOGRAPHY' })
@@ -241,7 +235,6 @@ test('[P1] real daemon run treats an in-place artifact edit as produced work', a
 });
 
 test('[P1] Plan mode daemon run creates, opens, and restores an editable markdown plan', async ({ page }) => {
-  await page.goto('/');
   await createProject(page, 'Plan mode markdown smoke');
   await expectWorkspaceReady(page);
 
@@ -275,7 +268,6 @@ test('[P1] Plan mode daemon run creates, opens, and restores an editable markdow
 // generated HTML instead of staying on the markdown plan.
 test('[P1] Plan mode generation turn auto-opens the generated HTML file', async ({ page }) => {
   test.setTimeout(120_000);
-  await page.goto('/');
   await createProject(page, 'Plan mode html auto-open smoke', 'claude');
   await expectWorkspaceReady(page);
 
@@ -311,7 +303,6 @@ test('[P1] Plan mode generation turn auto-opens the generated HTML file', async 
 // auto-open path cannot mask the turn-end selection.
 test('[P1] Plan mode regeneration re-opens the existing generated HTML file', async ({ page }) => {
   test.setTimeout(120_000);
-  await page.goto('/');
   await createProject(page, 'Plan mode html regen smoke');
   await expectWorkspaceReady(page);
 
@@ -345,7 +336,6 @@ test('[P1] Plan mode regeneration re-opens the existing generated HTML file', as
 });
 
 test('[P0] real daemon run restores a delayed artifact turn after reload', async ({ page }) => {
-  await page.goto('/');
   await createProject(page, 'Delayed daemon reload smoke');
   await expectWorkspaceReady(page);
 
@@ -373,7 +363,6 @@ test('[P0] real daemon run restores a delayed artifact turn after reload', async
 test('[P1] real daemon run reconnects after reload while the run is still active', async ({ page }) => {
   test.setTimeout(90_000);
 
-  await page.goto('/');
   await createProject(page, 'Running daemon reload smoke');
   await expectWorkspaceReady(page);
 
@@ -407,7 +396,6 @@ test('[P1] real daemon run reconnects after reload while the run is still active
 test('[P1] artifact persistence survives page reload during an active real daemon run', async ({ page }) => {
   test.setTimeout(120_000);
 
-  await page.goto('/');
   await createProject(page, 'Running daemon reload smoke');
   await expectWorkspaceReady(page);
 
@@ -476,7 +464,6 @@ test('[P1] artifact persistence survives page reload during an active real daemo
 });
 
 test('[P1] real daemon run survives reload before the create response reaches the browser', async ({ page }) => {
-  await page.goto('/');
   await createProject(page, 'Delayed daemon create-response reload smoke');
   await expectWorkspaceReady(page);
 
@@ -497,7 +484,6 @@ test('[P1] real daemon run survives reload before the create response reaches th
 });
 
 test('[P0] empty daemon output fails cleanly, persists after reload, and does not leave ghost files', async ({ page }) => {
-  await page.goto('/');
   await createProject(page, 'Empty daemon failure smoke');
   await expectWorkspaceReady(page);
 
@@ -522,7 +508,6 @@ test('[P0] empty daemon output fails cleanly, persists after reload, and does no
 });
 
 test('[P1] plain stdout daemon runtime surfaces stderr-only failures without ghost files', async ({ page }) => {
-  await page.goto('/');
   await createProject(page, 'Plain stderr failure smoke', 'qwen');
   await expectWorkspaceReady(page);
 
@@ -545,7 +530,6 @@ test('[P1] plain stdout daemon runtime surfaces stderr-only failures without gho
 });
 
 test('[P0] separate projects keep daemon artifacts isolated across recent-project navigation', async ({ page }) => {
-  await page.goto('/');
   await createProject(page, 'Real daemon isolation alpha');
   await expectWorkspaceReady(page);
   await sendPrompt(page, 'Create a deterministic smoke artifact');
@@ -719,18 +703,17 @@ test('[P0] real daemon run supports fake non-Codex runtime protocols', async ({ 
 async function createProject(page: Page, name: string, agentId: FakeAgentId = 'codex') {
   await configureFakeAgent(page, agentId);
   await installBrowserAgentConfig(page, agentId);
-  await gotoEntryHome(page);
-  await setBrowserAgentConfig(page, agentId);
-  await page.reload({ waitUntil: 'domcontentloaded' });
+  const projectId = `real-daemon-${agentId}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  await createProjectViaApi(page, projectId, name);
+  try {
+    await page.goto(`/projects/${projectId}`, { waitUntil: 'domcontentloaded' });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!/ERR_ABORTED|frame was detached/i.test(message)) throw error;
+  }
   await waitForLoadingToClear(page);
-  await setBrowserAgentConfig(page, agentId);
-  await configureFakeAgent(page, agentId);
   await expectBrowserAgentConfig(page, agentId);
   await dismissPrivacyDialog(page);
-  await openNewProjectModalFromProjects(page);
-  await page.getByTestId('new-project-tab-prototype').click();
-  await page.getByTestId('new-project-name').fill(name);
-  await page.getByTestId('create-project').click();
 }
 
 async function createByokOpenCodeProject(page: Page, name: string) {


### PR DESCRIPTION
## Why

Merge-gated browser tests were repeatedly paying for Home rendering, project-modal interaction, config rewrites, and reloads even when the behavior under test started inside an existing project. The preview-comment lane also ran two overlapping end-to-end journeys for the same attachment handoff.

## What users will see

No product behavior changes. CI reaches the same browser-to-daemon assertions with less unrelated setup work.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable.

## Validation

- `real-daemon-run` P0, 1 worker: 10/10 passed; comparable wall time improved from 122.82s to 83.72s (-31.8%).
- Full `real-daemon-run`: 21/21 passed in 196.96s.
- Fully parallel `real-daemon-run` P0, 2 workers: 10/10 passed.
- Consolidated preview-comment test: 3/3 repeated runs passed.
- Full `app.test.ts` P0: 9/9 passed in 74.66s.
- `pnpm --dir e2e typecheck`
- `pnpm guard`
- `pnpm typecheck`