### PR TITLE
test(e2e): parallelize restoration group

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -64,6 +64,10 @@ multi-file groups accumulate carry-over — but only the full pool exercises the
 whole suite interleaved with mid-file shards, so treat it as the acceptance
 gate. New and repaired UI tests must hold the following invariants.
 
+The merge-gated `workspace-restoration` group also runs fully-parallel across
+its two worker-isolated tools-dev runtimes. Its cases must remain independent
+within the file as well as across files.
+
 - **Keep browser witnesses at cross-layer boundaries.** Before adding a UI
   case, identify which assertions already belong to component or runtime tests
   and which transition uniquely requires the running browser product. Extend

--- a/e2e/lib/playwright/suites.ts
+++ b/e2e/lib/playwright/suites.ts
@@ -1,5 +1,6 @@
 export type UiPlaywrightGroup = {
   files: readonly string[];
+  fullyParallel?: boolean;
   grep: string;
   workers?: number;
 };
@@ -21,6 +22,7 @@ export const uiP0Groups = {
     files: ["ui/app.test.ts"],
   },
   "workspace-restoration": {
+    fullyParallel: true,
     grep: String.raw`\[P0\]`,
     files: ["ui/app-restoration.test.ts", "ui/critical-smoke.test.ts"],
   },

--- a/e2e/scripts/playwright.ts
+++ b/e2e/scripts/playwright.ts
@@ -83,6 +83,9 @@ async function runUiGroup(): Promise<void> {
     args.push(`--workers=${group.workers}`);
   }
   const child = spawn('playwright', args, {
+    env: group.fullyParallel
+      ? { ...process.env, OD_PLAYWRIGHT_FULLY_PARALLEL: '1' }
+      : process.env,
     stdio: 'inherit',
     shell: false,
   });

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1161,6 +1161,7 @@ process.stdin.on("end", () => {
       files: ["ui/app.test.ts"],
     });
     expect(uiP0Groups["workspace-restoration"]).toEqual({
+      fullyParallel: true,
       grep: String.raw`\[P0\]`,
       files: ["ui/app-restoration.test.ts", "ui/critical-smoke.test.ts"],
     });

--- a/e2e/ui/app-restoration.test.ts
+++ b/e2e/ui/app-restoration.test.ts
@@ -3155,10 +3155,26 @@ async function sendPrompt(page: Page, prompt: string) {
 }
 
 async function startNewConversation(page: Page) {
+  const previousContext = await getCurrentProjectContext(page);
   await page.getByTestId('conversation-history-trigger').click();
   await expect(page.getByTestId('conversation-list')).toBeVisible();
   await page.getByTestId('conversation-history-new').click();
   await expect(page.getByTestId('conversation-list')).toHaveCount(0);
+  await expect
+    .poll(() => {
+      const current = new URL(page.url());
+      const [, projects, projectId, maybeConversations, conversationId] = current.pathname.split('/');
+      if (
+        projects !== 'projects'
+        || projectId !== previousContext.projectId
+        || maybeConversations !== 'conversations'
+        || conversationId == null
+      ) {
+        return false;
+      }
+      return conversationId !== previousContext.conversationId;
+    }, { timeout: T.medium })
+    .toBe(true);
 }
 
 function tabBySuffix(page: Page, name: string): Locator {

--- a/e2e/ui/app-restoration.test.ts
+++ b/e2e/ui/app-restoration.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@/playwright/suite';
 import { ensureRailOpen, openNewProjectModal as openNewProjectModalFromProjects } from '@/playwright/rail';
 import { runErrorCard } from '@/playwright/chat';
+import { routeMockAgents } from '@/playwright/mock-factory';
 import {
   clickDeckNextSlide,
   clickDeckPreviousSlide,
@@ -82,22 +83,7 @@ test.beforeEach(async ({ page }) => {
   });
 });
 test('[P0] @critical workspace restores the last manually selected file tab after reload instead of jumping back to the generated artifact', async ({ page }) => {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeMockAgents(page);
 
   await page.route('**/api/runs', async (route) => {
     await route.fulfill({
@@ -201,22 +187,7 @@ test('[P0] @critical workspace restores the last manually selected file tab afte
 });
 
 test('[P0] switching between projects restores each project workspace to its last active file tab', async ({ page }) => {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeMockAgents(page);
 
   const pngBytes = Buffer.from(
     'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5W6McAAAAASUVORK5CYII=',
@@ -313,22 +284,7 @@ test('[P0] switching between projects restores each project workspace to its las
 });
 
 test('[P0] @critical visiting an uploaded design file route restores its tab and file workspace surface', async ({ page }) => {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeMockAgents(page);
 
   await gotoEntryHome(page);
   await createPrototypeProject(page, 'Uploaded file deep link');
@@ -375,22 +331,7 @@ test('[P0] @critical visiting an uploaded design file route restores its tab and
 });
 
 test('[P0] returning from an artifact file route to the project root keeps the artifact tab active', async ({ page }) => {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeMockAgents(page);
 
   await page.route('**/api/runs', async (route) => {
     await route.fulfill({
@@ -448,28 +389,15 @@ test('[P0] returning from an artifact file route to the project root keeps the a
 });
 
 test('[P0] @critical switching between conversations keeps the composer usable while navigating history', async ({ page }) => {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeMockAgents(page);
 
+  let conversationDraftRunCount = 0;
   await page.route('**/api/runs', async (route) => {
+    conversationDraftRunCount += 1;
     await route.fulfill({
       status: 202,
       contentType: 'application/json',
-      body: '{"runId":"conversation-draft-run"}',
+      body: JSON.stringify({ runId: `conversation-draft-run-${conversationDraftRunCount}` }),
     });
   });
 
@@ -513,6 +441,13 @@ test('[P0] @critical switching between conversations keeps the composer usable w
   await sendPrompt(page, secondPrompt);
   await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt }).first()).toBeVisible();
   const secondContext = await getCurrentProjectContext(page);
+  await expectConversationMessagePersisted(
+    page,
+    secondContext.projectId,
+    secondContext.conversationId,
+    'user',
+    secondPrompt,
+  );
 
   const composerInput = page.getByTestId('chat-composer-input');
   await composerInput.fill(secondDraft);
@@ -567,28 +502,17 @@ test('[P0] @critical switching between conversations keeps the composer usable w
 });
 
 test('[P0] @critical switching between conversations keeps staged attachments UI available', async ({ page }) => {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeMockAgents(page);
 
+  let conversationAttachmentRunCount = 0;
   await page.route('**/api/runs', async (route) => {
+    conversationAttachmentRunCount += 1;
     await route.fulfill({
       status: 202,
       contentType: 'application/json',
-      body: '{"runId":"conversation-attachment-run"}',
+      body: JSON.stringify({
+        runId: `conversation-attachment-run-${conversationAttachmentRunCount}`,
+      }),
     });
   });
 
@@ -679,28 +603,17 @@ test('[P0] @critical switching between conversations keeps staged attachments UI
 });
 
 test('[P0] @critical reloading an older conversation route keeps the composer available after staging attachments', async ({ page }) => {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeMockAgents(page);
 
+  let conversationAttachmentReloadRunCount = 0;
   await page.route('**/api/runs', async (route) => {
+    conversationAttachmentReloadRunCount += 1;
     await route.fulfill({
       status: 202,
       contentType: 'application/json',
-      body: '{"runId":"conversation-attachment-reload-run"}',
+      body: JSON.stringify({
+        runId: `conversation-attachment-reload-run-${conversationAttachmentReloadRunCount}`,
+      }),
     });
   });
 
@@ -765,22 +678,7 @@ test('[P0] @critical reloading an older conversation route keeps the composer av
 });
 
 test('[P0] @critical reloading the project keeps the latest conversation selected in history', async ({ page }) => {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeMockAgents(page);
 
   let historyReloadRunCount = 0;
   await page.route('**/api/runs', async (route) => {
@@ -864,28 +762,17 @@ test('[P0] @critical deleting the active conversation selects the remaining conv
     await dialog.accept();
   });
 
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeMockAgents(page);
 
+  let conversationHistoryDeleteRunCount = 0;
   await page.route('**/api/runs', async (route) => {
+    conversationHistoryDeleteRunCount += 1;
     await route.fulfill({
       status: 202,
       contentType: 'application/json',
-      body: '{"runId":"conversation-history-delete-run"}',
+      body: JSON.stringify({
+        runId: `conversation-history-delete-run-${conversationHistoryDeleteRunCount}`,
+      }),
     });
   });
 
@@ -928,6 +815,13 @@ test('[P0] @critical deleting the active conversation selects the remaining conv
   await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt }).first()).toBeVisible();
   const secondContext = await getCurrentProjectContext(page);
   expect(secondContext.conversationId).not.toBe(firstContext.conversationId);
+  await expectConversationMessagePersisted(
+    page,
+    secondContext.projectId,
+    secondContext.conversationId,
+    'user',
+    secondPrompt,
+  );
 
   await page.getByTestId('conversation-history-trigger').click();
   const historyList = page.getByTestId('conversation-list');
@@ -951,28 +845,17 @@ test('[P0] @critical deleting the active conversation selects the remaining conv
 });
 
 test('[P0] returning from workspace surfaces keeps the older conversation reachable from history', async ({ page }) => {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeMockAgents(page);
 
+  let conversationHistorySurfaceRunCount = 0;
   await page.route('**/api/runs', async (route) => {
+    conversationHistorySurfaceRunCount += 1;
     await route.fulfill({
       status: 202,
       contentType: 'application/json',
-      body: '{"runId":"conversation-history-surface-run"}',
+      body: JSON.stringify({
+        runId: `conversation-history-surface-run-${conversationHistorySurfaceRunCount}`,
+      }),
     });
   });
 
@@ -1014,6 +897,13 @@ test('[P0] returning from workspace surfaces keeps the older conversation reacha
   await sendPrompt(page, secondPrompt);
   await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt }).first()).toBeVisible();
   const secondContext = await getCurrentProjectContext(page);
+  await expectConversationMessagePersisted(
+    page,
+    secondContext.projectId,
+    secondContext.conversationId,
+    'user',
+    secondPrompt,
+  );
 
   await page.getByTestId('design-files-upload-input').setInputFiles({
     name: 'surface-restore.png',
@@ -1055,22 +945,7 @@ test('[P0] returning from workspace surfaces keeps the older conversation reacha
 });
 
 test('[P0] reloading the project root keeps conversation history accessible', async ({ page }) => {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeMockAgents(page);
 
   let rootReloadRunCount = 0;
   await page.route('**/api/runs', async (route) => {
@@ -1140,28 +1015,17 @@ test('[P0] reloading the project root keeps conversation history accessible', as
 });
 
 test('[P0] opening an uploaded file route keeps the older conversation present in history', async ({ page }) => {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeMockAgents(page);
 
+  let conversationFileSurfaceRunCount = 0;
   await page.route('**/api/runs', async (route) => {
+    conversationFileSurfaceRunCount += 1;
     await route.fulfill({
       status: 202,
       contentType: 'application/json',
-      body: '{"runId":"conversation-file-surface-run"}',
+      body: JSON.stringify({
+        runId: `conversation-file-surface-run-${conversationFileSurfaceRunCount}`,
+      }),
     });
   });
 
@@ -1203,6 +1067,13 @@ test('[P0] opening an uploaded file route keeps the older conversation present i
   await sendPrompt(page, secondPrompt);
   await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt }).first()).toBeVisible();
   const secondContext = await getCurrentProjectContext(page);
+  await expectConversationMessagePersisted(
+    page,
+    secondContext.projectId,
+    secondContext.conversationId,
+    'user',
+    secondPrompt,
+  );
 
   await page.getByTestId('design-files-upload-input').setInputFiles({
     name: 'conversation-surface-reference.png',
@@ -1251,28 +1122,17 @@ test('[P0] opening an uploaded file route keeps the older conversation present i
 });
 
 test('[P0] opening an artifact file route keeps the older conversation present in history', async ({ page }) => {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeMockAgents(page);
 
+  let conversationArtifactSurfaceRunCount = 0;
   await page.route('**/api/runs', async (route) => {
+    conversationArtifactSurfaceRunCount += 1;
     await route.fulfill({
       status: 202,
       contentType: 'application/json',
-      body: '{"runId":"conversation-artifact-surface-run"}',
+      body: JSON.stringify({
+        runId: `conversation-artifact-surface-run-${conversationArtifactSurfaceRunCount}`,
+      }),
     });
   });
 
@@ -1321,6 +1181,13 @@ test('[P0] opening an artifact file route keeps the older conversation present i
   await sendPrompt(page, secondPrompt);
   await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt }).first()).toBeVisible();
   const secondContext = await getCurrentProjectContext(page);
+  await expectConversationMessagePersisted(
+    page,
+    secondContext.projectId,
+    secondContext.conversationId,
+    'user',
+    secondPrompt,
+  );
 
   const artifactTab = page.getByRole('tab', { name: /conversation-surface-artifact\.html/i });
   await expect(artifactTab).toBeVisible();
@@ -1365,28 +1232,17 @@ test('[P0] opening an artifact file route keeps the older conversation present i
 });
 
 test('[P0] returning from a file deep-link to the project root keeps the chosen file tab active', async ({ page }) => {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeMockAgents(page);
 
+  let conversationFileRootRunCount = 0;
   await page.route('**/api/runs', async (route) => {
+    conversationFileRootRunCount += 1;
     await route.fulfill({
       status: 202,
       contentType: 'application/json',
-      body: '{"runId":"conversation-file-root-run"}',
+      body: JSON.stringify({
+        runId: `conversation-file-root-run-${conversationFileRootRunCount}`,
+      }),
     });
   });
 
@@ -1492,22 +1348,7 @@ test('[P0] returning from an artifact deep-link to the project root keeps the ar
 });
 
 test('[P0] a later completed run updates the workspace to the newest artifact tab', async ({ page }) => {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeMockAgents(page);
 
   let runCount = 0;
   await page.route('**/api/runs', async (route) => {
@@ -1606,22 +1447,7 @@ test('[P0] @critical daemon error details persist between failed sends', async (
   const entry = automatedUiScenarios().find((scenario) => scenario.id === 'prototype-basic');
   if (!entry) throw new Error('prototype-basic scenario missing');
 
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeMockAgents(page);
 
   let runCount = 0;
   await page.route('**/api/runs', async (route) => {
@@ -1693,22 +1519,7 @@ test('[P0] @critical daemon error details persist between failed sends', async (
 });
 
 test('[P0] a successful retry after a failed send restores the workspace to a fresh artifact tab', async ({ page }) => {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
+  await routeMockAgents(page);
 
   let runCount = 0;
   await page.route('**/api/runs', async (route) => {
@@ -3156,25 +2967,6 @@ test('[P1] project composer working directory rejects stale folder without promo
     .toMatchObject({ linkedDirs: [staleDir] });
   expect(recentDirPutBodies).toHaveLength(0);
 });
-
-async function routeMockAgents(page: Page) {
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      json: {
-        agents: [
-          {
-            id: 'mock',
-            name: 'Mock Agent',
-            bin: 'mock-agent',
-            available: true,
-            version: 'test',
-            models: [{ id: 'default', label: 'Default' }],
-          },
-        ],
-      },
-    });
-  });
-}
 
 async function routeAppConfig(page: Page, override: Record<string, unknown>) {
   await page.route('**/api/app-config', async (route) => {

--- a/e2e/ui/app-restoration.test.ts
+++ b/e2e/ui/app-restoration.test.ts
@@ -440,11 +440,9 @@ test('[P0] @critical switching between conversations keeps the composer usable w
   await expect(page.getByTestId('chat-composer-input')).toHaveText('');
   await sendPrompt(page, secondPrompt);
   await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt }).first()).toBeVisible();
-  const secondContext = await getCurrentProjectContext(page);
-  await expectConversationMessagePersisted(
+  const secondContext = await findConversationContextByMessage(
     page,
-    secondContext.projectId,
-    secondContext.conversationId,
+    firstContext.projectId,
     'user',
     secondPrompt,
   );
@@ -727,15 +725,13 @@ test('[P0] @critical reloading the project keeps the latest conversation selecte
   await expect(page.getByTestId('chat-composer-input')).toHaveText('');
   await sendPrompt(page, secondPrompt);
   await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt }).first()).toBeVisible();
-  const secondContext = await getCurrentProjectContext(page);
-  expect(secondContext.conversationId).not.toBe(firstContext.conversationId);
-  await expectConversationMessagePersisted(
+  const secondContext = await findConversationContextByMessage(
     page,
-    secondContext.projectId,
-    secondContext.conversationId,
+    firstContext.projectId,
     'user',
     secondPrompt,
   );
+  expect(secondContext.conversationId).not.toBe(firstContext.conversationId);
 
   await page.reload();
   await expect(page.getByTestId('chat-composer')).toBeVisible();
@@ -813,15 +809,13 @@ test('[P0] @critical deleting the active conversation selects the remaining conv
   await expect(page.getByTestId('chat-composer-input')).toHaveText('');
   await sendPrompt(page, secondPrompt);
   await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt }).first()).toBeVisible();
-  const secondContext = await getCurrentProjectContext(page);
-  expect(secondContext.conversationId).not.toBe(firstContext.conversationId);
-  await expectConversationMessagePersisted(
+  const secondContext = await findConversationContextByMessage(
     page,
-    secondContext.projectId,
-    secondContext.conversationId,
+    firstContext.projectId,
     'user',
     secondPrompt,
   );
+  expect(secondContext.conversationId).not.toBe(firstContext.conversationId);
 
   await page.getByTestId('conversation-history-trigger').click();
   const historyList = page.getByTestId('conversation-list');
@@ -896,11 +890,9 @@ test('[P0] returning from workspace surfaces keeps the older conversation reacha
   await expect(page.getByTestId('chat-composer-input')).toHaveText('');
   await sendPrompt(page, secondPrompt);
   await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt }).first()).toBeVisible();
-  const secondContext = await getCurrentProjectContext(page);
-  await expectConversationMessagePersisted(
+  const secondContext = await findConversationContextByMessage(
     page,
-    secondContext.projectId,
-    secondContext.conversationId,
+    firstContext.projectId,
     'user',
     secondPrompt,
   );
@@ -1066,11 +1058,9 @@ test('[P0] opening an uploaded file route keeps the older conversation present i
   await expect(page.getByTestId('chat-composer-input')).toHaveText('');
   await sendPrompt(page, secondPrompt);
   await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt }).first()).toBeVisible();
-  const secondContext = await getCurrentProjectContext(page);
-  await expectConversationMessagePersisted(
+  const secondContext = await findConversationContextByMessage(
     page,
-    secondContext.projectId,
-    secondContext.conversationId,
+    firstContext.projectId,
     'user',
     secondPrompt,
   );
@@ -1180,11 +1170,9 @@ test('[P0] opening an artifact file route keeps the older conversation present i
   await expect(page.getByTestId('chat-composer-input')).toHaveText('');
   await sendPrompt(page, secondPrompt);
   await expect(page.locator('.msg.user .user-text').filter({ hasText: secondPrompt }).first()).toBeVisible();
-  const secondContext = await getCurrentProjectContext(page);
-  await expectConversationMessagePersisted(
+  const secondContext = await findConversationContextByMessage(
     page,
-    secondContext.projectId,
-    secondContext.conversationId,
+    firstContext.projectId,
     'user',
     secondPrompt,
   );
@@ -3554,25 +3542,36 @@ async function listConversationsFromApi(
   return conversations;
 }
 
-async function expectConversationMessagePersisted(
+async function findConversationContextByMessage(
   page: Page,
   projectId: string,
-  conversationId: string,
   role: string,
   content: string,
-) {
+): Promise<{ projectId: string; conversationId: string }> {
+  let conversationId: string | undefined;
   await expect
     .poll(async () => {
-      const response = await page.request.get(
-        `/api/projects/${projectId}/conversations/${conversationId}/messages`,
-      );
-      if (!response.ok()) return false;
-      const { messages } = (await response.json()) as {
-        messages: Array<{ role: string; content: string }>;
-      };
-      return messages.some((message) => message.role === role && message.content === content);
+      const conversations = await listConversationsFromApi(page, projectId);
+      for (const conversation of conversations) {
+        const response = await page.request.get(
+          `/api/projects/${projectId}/conversations/${conversation.id}/messages`,
+        );
+        if (!response.ok()) continue;
+        const { messages } = (await response.json()) as {
+          messages: Array<{ role: string; content: string }>;
+        };
+        if (messages.some((message) => message.role === role && message.content === content)) {
+          conversationId = conversation.id;
+          return conversationId;
+        }
+      }
+      return undefined;
     }, { timeout: T.medium })
-    .toBe(true);
+    .toBeTruthy();
+  if (!conversationId) {
+    throw new Error(`no conversation found for persisted ${role} message in project ${projectId}`);
+  }
+  return { projectId, conversationId };
 }
 
 async function expectPersistedArtifactMessage(


### PR DESCRIPTION
## Why

The merge-gated workspace-restoration group had two Playwright workers but scheduled the 22 app-restoration cases as one serial file unit. In merge-group run 30354315899, those cases occupied one worker for 314.954s while the other worker finished its three smoke cases in 39.678s, leaving most of the second runtime idle.

This change enables the existing fully-parallel execution mode only for that group. Exercising the suite under the intended scheduling also exposed and fixed two hidden fixture defects: agent discovery only mocked JSON while the product also waits on SSE readiness, and several multi-send workflows reused one run ID.

## What users will see

No product behavior changes. Merge-gated workspace restoration coverage completes faster and uses deterministic test fixtures.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable.

## Validation

- Current-main local baseline: exact 25-test group passed without retries in 2.9m
- Initial fully-parallel A/B: exact group passed without retries in 2.5m
- Final implementation: exact group passed twice without retries in 2.0m and 2.2m
- Focused reproduction of the agent-readiness failure: 5/5 fully-parallel passes
- `pnpm test tests/packaged-smoke-workflow.test.ts` — 53/53
- `pnpm typecheck` in `e2e`
- repository-wide `pnpm typecheck`
- `pnpm guard`
- `git diff --check`

The final local wall-time reduction is 24–31% versus the current-main baseline. CI remains the authority for merge-run savings and retry behavior.