### PR TITLE
fix(collab): keep process-local presence alive when the collab transport is off

### DIFF
--- a/apps/daemon/src/routes/collab-presence.ts
+++ b/apps/daemon/src/routes/collab-presence.ts
@@ -32,6 +32,60 @@ export interface RegisterCollabPresenceRoutesDeps {
   cloudAuthorizesProjectPresence?: (projectId: string) => boolean;
 }
 
+/**
+ * The workspace-scoped presence surface of the collab transport, as this route
+ * module needs it. `VelaCliCollabClient` satisfies it structurally.
+ */
+export interface CollabPresenceCloudTransport {
+  heartbeatPresence(
+    projectId: string,
+    input: VelaCliPresenceHeartbeatInput,
+    workspaceId?: string,
+  ): Promise<CollabPresenceMember[]>;
+  listPresence(
+    projectId: string,
+    workspaceId?: string,
+  ): Promise<CollabPresenceMember[]>;
+  leavePresence(
+    projectId: string,
+    input: VelaCliPresenceLeaveInput,
+    workspaceId?: string,
+  ): Promise<CollabPresenceMember[]>;
+}
+
+/**
+ * Bind a collab transport to a per-project workspace scope, producing the
+ * `cloud` dependency below — or nothing when this run has no cloud transport.
+ *
+ * The invariant: **a `cloud` dependency exists if and only if a transport
+ * exists.** Every endpoint below reads a present `cloud` as "the cloud owns
+ * presence for this run" and stops consulting the process-local tracker
+ * entirely. So a relay built over an absent transport is not merely useless —
+ * it turns the in-process fallback into dead code and every gated presence
+ * request into a 502. Returning `null` is what keeps that fallback reachable
+ * for the runs that have no transport, which is every build that has not
+ * opted into the vela-cli collab transport: all stable/prod packaged builds
+ * and every plain `tools-dev` run.
+ *
+ * Callers must route through this rather than assembling an object literal of
+ * arrow functions, because a literal is unconditionally truthy no matter what
+ * the transport turned out to be.
+ */
+export function createCollabPresenceCloudClient(
+  transport: CollabPresenceCloudTransport | null | undefined,
+  workspaceScopeFor: (projectId: string) => string | undefined,
+): CollabPresenceCloudClient | null {
+  if (!transport) return null;
+  return {
+    heartbeatPresence: (projectId, input) =>
+      transport.heartbeatPresence(projectId, input, workspaceScopeFor(projectId)),
+    listPresence: (projectId) =>
+      transport.listPresence(projectId, workspaceScopeFor(projectId)),
+    leavePresence: (projectId, input) =>
+      transport.leavePresence(projectId, input, workspaceScopeFor(projectId)),
+  };
+}
+
 function readHeartbeat(body: unknown): {
   member: PresenceMember;
   clientId?: string;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -672,7 +672,10 @@ import { registerSocialShareRoutes } from './routes/social-share.js';
 import { registerOpenDesignPublicMetadataRoutes } from './routes/open-design-public-metadata.js';
 import { registerWhatsNewRoutes } from './routes/whats-new.js';
 import { registerMemoryRoutes } from './routes/memory.js';
-import { registerCollabPresenceRoutes } from './routes/collab-presence.js';
+import {
+  createCollabPresenceCloudClient,
+  registerCollabPresenceRoutes,
+} from './routes/collab-presence.js';
 import {
   registerCollabSyncRoutes,
   type TeamMirrorPullScope,
@@ -3456,14 +3459,10 @@ export async function startServer({
     }).workspaceId;
   registerCollabPresenceRoutes(app, {
     collab,
-    cloud: {
-      heartbeatPresence: (projectId, input) =>
-        velaCliCollabClient.heartbeatPresence(projectId, input, presenceScopeFor(projectId)),
-      listPresence: (projectId) =>
-        velaCliCollabClient.listPresence(projectId, presenceScopeFor(projectId)),
-      leavePresence: (projectId, input) =>
-        velaCliCollabClient.leavePresence(projectId, input, presenceScopeFor(projectId)),
-    },
+    // Null when this run has no vela-cli collab transport, which is what keeps
+    // the process-local presence fallback reachable. See
+    // `createCollabPresenceCloudClient` for the invariant.
+    cloud: createCollabPresenceCloudClient(velaCliCollabClient, presenceScopeFor),
     isProjectShared: isSharedTeamProject,
     cloudAuthorizesProjectPresence: (projectId) => {
       const workspaceId = findTeamWorkspaceIdForProject(db, projectId)?.trim();

--- a/apps/daemon/tests/collab-presence-routes.test.ts
+++ b/apps/daemon/tests/collab-presence-routes.test.ts
@@ -3,7 +3,10 @@ import express from 'express';
 import http from 'node:http';
 import { createCollabRuntime } from '../src/collab/runtime.js';
 import type { CollabPresenceCloudClient } from '../src/routes/collab-presence.js';
-import { registerCollabPresenceRoutes } from '../src/routes/collab-presence.js';
+import {
+  createCollabPresenceCloudClient,
+  registerCollabPresenceRoutes,
+} from '../src/routes/collab-presence.js';
 
 let server: http.Server | null = null;
 
@@ -209,5 +212,48 @@ describe('collab presence routes', () => {
     expect(heartbeat.status).toBe(200);
     expect(calls).toEqual(['list:p1', 'heartbeat:p1']);
     expect(isProjectShared).not.toHaveBeenCalled();
+  });
+});
+
+describe('createCollabPresenceCloudClient', () => {
+  // The routes read a present `cloud` as "the cloud owns presence", so an
+  // absent transport MUST produce an absent dependency — not a relay that
+  // dereferences nothing. See the factory's docblock.
+  it('is absent when there is no collab transport', () => {
+    expect(createCollabPresenceCloudClient(null, () => undefined)).toBeNull();
+    expect(createCollabPresenceCloudClient(undefined, () => undefined)).toBeNull();
+  });
+
+  it('binds each call to the project workspace scope when a transport exists', async () => {
+    const calls: string[] = [];
+    const transport = {
+      async heartbeatPresence(projectId: string, _input: unknown, workspaceId?: string) {
+        calls.push(`heartbeat:${projectId}:${workspaceId}`);
+        return [];
+      },
+      async listPresence(projectId: string, workspaceId?: string) {
+        calls.push(`list:${projectId}:${workspaceId}`);
+        return [];
+      },
+      async leavePresence(projectId: string, _input: unknown, workspaceId?: string) {
+        calls.push(`leave:${projectId}:${workspaceId}`);
+        return [];
+      },
+    };
+    const cloud = createCollabPresenceCloudClient(
+      transport,
+      (projectId) => `ws-for-${projectId}`,
+    );
+    expect(cloud).not.toBeNull();
+
+    await cloud!.heartbeatPresence('p1', { member: { memberId: 'm1' } });
+    await cloud!.listPresence('p1');
+    await cloud!.leavePresence('p1', { memberId: 'm1' });
+
+    expect(calls).toEqual([
+      'heartbeat:p1:ws-for-p1',
+      'list:p1:ws-for-p1',
+      'leave:p1:ws-for-p1',
+    ]);
   });
 });

--- a/apps/daemon/tests/collab-presence-transport-off.test.ts
+++ b/apps/daemon/tests/collab-presence-transport-off.test.ts
@@ -1,0 +1,368 @@
+import type { Server } from 'node:http';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildWorkspacePermissions,
+  buildWorkspaceSeatSummary,
+  type WorkspaceCollabContext,
+} from '@open-design/contracts';
+
+/**
+ * Presence when the vela-cli collab transport is OFF.
+ *
+ * `createVelaCliCollabClientFromEnv` returns `null` unless this run opted into
+ * the vela-cli collab transport — which is every stable/prod packaged build and
+ * every plain `tools-dev` run. `registerCollabPresenceRoutes` is built to cope
+ * with that: `deps.cloud` is optional and each endpoint falls back to the
+ * process-local presence tracker.
+ *
+ * These tests pin that contract at the real daemon HTTP boundary (the routes are
+ * wired in `server.ts`, so a route-module test cannot see the wiring), and pin
+ * the other direction too: with the transport ON, presence must still relay to
+ * the cloud.
+ */
+
+type StartedServer = {
+  url: string;
+  server: Server;
+  shutdown?: () => Promise<void> | void;
+};
+type ServerModule = {
+  startServer: (options: {
+    port: number;
+    returnServer: boolean;
+  }) => Promise<StartedServer>;
+};
+
+const MANAGED_ENV = [
+  'OD_DATA_DIR',
+  'OD_COLLAB_TRANSPORT',
+  'OD_TEAM_PROJECTS_TRANSPORT',
+  'OD_RESOURCE_TRANSPORT',
+  'OD_WORKSPACE_CONTEXT_SOURCE',
+  'OD_COLLAB_CLOUD_URL',
+  'OD_DEV_WORKSPACE_CONTEXT',
+  'VELA_BIN',
+  'OD_TEST_TEAM_PROJECTS_JSON',
+  'OD_TEST_CLOUD_VIEWERS_JSON',
+  'OD_TEST_VELA_LOG',
+] as const;
+
+let started: StartedServer | null = null;
+let scratch: string | null = null;
+// `startServer` reads the transport env on every call, so one module instance
+// serves every case. Re-importing it would re-register the prom-client metrics.
+let serverModule: ServerModule | null = null;
+const savedEnv = new Map<string, string | undefined>();
+
+afterEach(async () => {
+  await stopServer();
+  if (scratch) await rm(scratch, { recursive: true, force: true });
+  scratch = null;
+  for (const [key, value] of savedEnv) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  savedEnv.clear();
+}, 60_000);
+
+const SHARED_PROJECT = 'presence-transport-off-shared';
+
+describe('collab presence with the vela-cli collab transport off', () => {
+  it('falls back to process-local presence on leave instead of failing', async () => {
+    // The leanest possible reproduction: no cloud transport, no fixtures. `leave`
+    // carries no shared/authorized precondition, so it reaches the cloud branch
+    // on any project id.
+    setEnv({ OD_COLLAB_TRANSPORT: 'off' });
+    const api = await startIsolatedServer();
+
+    const left = await api.post(`/api/projects/any-local-project/presence/leave`, {
+      memberId: 'm1',
+    });
+
+    expect(left.status).toBe(200);
+    expect(left.body).toMatchObject({ ok: true, present: [] });
+  }, 60_000);
+
+  it('serves the process-local present set for a shared project', async () => {
+    // A genuinely shared project clears the presence gate, so heartbeat/list
+    // reach the same cloud branch. With the transport off they must answer from
+    // the in-process tracker.
+    setEnv({
+      OD_COLLAB_TRANSPORT: 'off',
+      OD_TEAM_PROJECTS_TRANSPORT: 'vela-cli',
+      OD_TEST_TEAM_PROJECTS_JSON: JSON.stringify({
+        projects: [
+          {
+            projectId: SHARED_PROJECT,
+            ownerMemberId: 'owner-1',
+            createdAt: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+      }),
+    });
+    await setupVelaStub();
+    const api = await startIsolatedServer();
+
+    const beat = await api.post(`/api/projects/${SHARED_PROJECT}/presence/heartbeat`, {
+      memberId: 'local-member',
+      name: 'Ada',
+      role: 'owner',
+    });
+    expect(beat.status).toBe(200);
+    expect(presentIds(beat.body)).toEqual(['local-member']);
+    // The project really did clear the shared-project gate via the CLI catalog.
+    expect((await velaCalls()).some((call) => call.startsWith('team-projects'))).toBe(true);
+    // ...and no presence call was relayed, because there is no cloud transport.
+    expect(
+      (await velaCalls()).some((call) => call.startsWith('collab presence')),
+    ).toBe(false);
+
+    const list = await api.get(`/api/projects/${SHARED_PROJECT}/presence`);
+    expect(list.status).toBe(200);
+    expect(presentIds(list.body)).toEqual(['local-member']);
+
+    const left = await api.post(`/api/projects/${SHARED_PROJECT}/presence/leave`, {
+      memberId: 'local-member',
+    });
+    expect(left.status).toBe(200);
+    expect(presentIds(left.body)).toEqual([]);
+  }, 60_000);
+});
+
+describe('collab presence with the vela-cli collab transport on', () => {
+  it('still relays presence to the cloud', async () => {
+    setEnv({
+      OD_COLLAB_TRANSPORT: 'vela-cli',
+      OD_TEAM_PROJECTS_TRANSPORT: 'vela-cli',
+      OD_TEST_TEAM_PROJECTS_JSON: JSON.stringify({
+        projects: [
+          {
+            projectId: SHARED_PROJECT,
+            ownerMemberId: 'owner-1',
+            createdAt: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+      }),
+      OD_TEST_CLOUD_VIEWERS_JSON: JSON.stringify([
+        { memberId: 'cloud-member', displayName: 'Cloud Member', role: 'member' },
+      ]),
+    });
+    await setupVelaStub();
+    const api = await startIsolatedServer();
+
+    // The cloud answer wins over anything the in-process tracker holds, which is
+    // how a second daemon's viewer becomes visible here.
+    const beat = await api.post(`/api/projects/${SHARED_PROJECT}/presence/heartbeat`, {
+      memberId: 'local-member',
+      name: 'Ada',
+      role: 'owner',
+    });
+    expect(beat.status).toBe(200);
+    expect(presentIds(beat.body)).toEqual(['cloud-member']);
+
+    const list = await api.get(`/api/projects/${SHARED_PROJECT}/presence`);
+    expect(list.status).toBe(200);
+    expect(presentIds(list.body)).toEqual(['cloud-member']);
+
+    const left = await api.post(`/api/projects/${SHARED_PROJECT}/presence/leave`, {
+      memberId: 'local-member',
+    });
+    expect(left.status).toBe(200);
+    expect(left.body).toMatchObject({ ok: true });
+
+    const calls = await velaCalls();
+    expect(calls).toContain(`collab presence list ${SHARED_PROJECT}`);
+    expect(
+      calls.some((call) => call.startsWith(`collab presence heartbeat ${SHARED_PROJECT}`)),
+    ).toBe(true);
+    expect(
+      calls.some((call) => call.startsWith(`collab presence leave ${SHARED_PROJECT}`)),
+    ).toBe(true);
+  }, 60_000);
+});
+
+function presentIds(body: Record<string, any>): string[] {
+  return ((body.present ?? []) as { memberId: string }[])
+    .map((member) => member.memberId)
+    .sort();
+}
+
+function setEnv(values: Record<string, string>): void {
+  for (const key of MANAGED_ENV) {
+    if (!savedEnv.has(key)) savedEnv.set(key, process.env[key]);
+  }
+  // Start from a clean slate so an ambient transport/context in the developer's
+  // shell cannot decide what this test exercises.
+  for (const key of MANAGED_ENV) delete process.env[key];
+  process.env.OD_DEV_WORKSPACE_CONTEXT = JSON.stringify(devWorkspaceContext());
+  for (const [key, value] of Object.entries(values)) process.env[key] = value;
+}
+
+function devWorkspaceContext(): WorkspaceCollabContext {
+  return {
+    workspaceId: 'ws-transport-off',
+    workspaceType: 'team',
+    teamId: 'team-transport-off',
+    workspaceMemberId: 'local-member',
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+    billingState: 'active',
+    planId: null,
+    providerMode: 'platform_credits',
+    seatSummary: buildWorkspaceSeatSummary({ seatLimit: 5, usedSeats: 1 }),
+    permissions: buildWorkspacePermissions({
+      role: 'owner',
+      lifecycleState: 'active',
+    }),
+  };
+}
+
+/**
+ * A stand-in `vela` on the daemon's normal resolution path (`VELA_BIN`), so the
+ * team-project catalog and the collab presence relay exercise the real
+ * child-process transport rather than an injected fake.
+ */
+async function setupVelaStub(): Promise<void> {
+  const root = await ensureScratch();
+  const script = join(root, 'vela-stub.mjs');
+  await writeFile(
+    script,
+    `import { appendFileSync } from 'node:fs';
+const args = process.argv.slice(2);
+if (process.env.OD_TEST_VELA_LOG) {
+  appendFileSync(process.env.OD_TEST_VELA_LOG, args.join(' ') + '\\n');
+}
+const [group, ...rest] = args;
+const out = (value) => {
+  process.stdout.write(JSON.stringify(value));
+  process.exit(0);
+};
+if (group === 'team-projects') {
+  if (rest[0] === '--help') process.exit(0);
+  const catalog = JSON.parse(process.env.OD_TEST_TEAM_PROJECTS_JSON || '{"projects":[]}');
+  const projects = Array.isArray(catalog.projects) ? catalog.projects : [];
+  if (rest[0] === 'list') out({ projects });
+  if (rest[0] === 'get') {
+    const found = projects.find((project) => project.projectId === rest[1]);
+    if (!found) {
+      process.stderr.write('API request failed with status 404');
+      process.exit(1);
+    }
+    out(found);
+  }
+  out({});
+}
+if (group === 'resource' && rest[0] === 'shared') {
+  // Older CLI builds expose only the resource index; the catalog adapter
+  // probes once per process, so answer both shapes for the same catalog.
+  const catalog = JSON.parse(process.env.OD_TEST_TEAM_PROJECTS_JSON || '{"projects":[]}');
+  const projects = Array.isArray(catalog.projects) ? catalog.projects : [];
+  out({
+    resources: projects.map((project) => ({
+      id: 'project-' + project.projectId,
+      teamId: 'team-transport-off',
+      kind: 'project',
+      ownerMemberId: project.ownerMemberId,
+      createdAt: project.createdAt,
+      metadata: { projectId: project.projectId },
+      deletedAt: null,
+    })),
+  });
+}
+if (group === 'collab' && rest[0] === 'presence') {
+  const viewers = JSON.parse(process.env.OD_TEST_CLOUD_VIEWERS_JSON || '[]');
+  out({ viewers: rest[1] === 'leave' ? [] : viewers });
+}
+out({});
+`,
+    'utf8',
+  );
+  const bin = join(root, 'vela');
+  await writeFile(bin, `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(script)} "$@"\n`, 'utf8');
+  await chmod(bin, 0o755);
+  process.env.VELA_BIN = bin;
+  process.env.OD_TEST_VELA_LOG = join(root, 'vela-calls.log');
+}
+
+async function velaCalls(): Promise<string[]> {
+  const log = process.env.OD_TEST_VELA_LOG;
+  if (!log) return [];
+  try {
+    return (await readFile(log, 'utf8')).split('\n').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+async function ensureScratch(): Promise<string> {
+  scratch ??= await mkdtemp(join(tmpdir(), 'od-presence-transport-off-'));
+  return scratch;
+}
+
+async function startIsolatedServer(): Promise<{
+  get(route: string): Promise<{ status: number; body: Record<string, any> }>;
+  post(
+    route: string,
+    body: unknown,
+  ): Promise<{ status: number; body: Record<string, any> }>;
+}> {
+  const root = await ensureScratch();
+  process.env.OD_DATA_DIR = join(root, 'data');
+  if (!serverModule) {
+    vi.resetModules();
+    serverModule = (await import('../src/server.js')) as unknown as ServerModule;
+  }
+  started = await serverModule.startServer({ port: 0, returnServer: true });
+  const base = started.url;
+  const read = async (response: Response) => ({
+    status: response.status,
+    body: (await response.json()) as Record<string, any>,
+  });
+  return {
+    async get(route: string) {
+      return read(await fetch(`${base}${route}`));
+    },
+    async post(route: string, body: unknown) {
+      return read(
+        await fetch(`${base}${route}`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(body),
+        }),
+      );
+    },
+  };
+}
+
+async function stopServer(): Promise<void> {
+  const current = started;
+  started = null;
+  if (!current) return;
+  await withTimeout(Promise.resolve(current.shutdown?.()), 8_000);
+  if (current.server) {
+    current.server.closeAllConnections?.();
+    current.server.closeIdleConnections?.();
+    await withTimeout(
+      new Promise<void>((resolve) => current.server.close(() => resolve())),
+      8_000,
+    );
+  }
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | undefined> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<undefined>((resolve) => {
+        timer = setTimeout(() => resolve(undefined), ms);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## Why

**Use case.** While reviewing `feat/workspace-team` ahead of PR #6142 landing in `main`, I traced the collab presence wiring and found a null dereference that the branch introduces. `origin/main` has neither `velaCliCollabClient` nor the `cloud:` literal, so this is a branch-local regression that would ship with the workspace-team merge.

**The pain.** `apps/daemon/src/server.ts` builds the presence cloud dependency as an **object literal of arrow functions** closing over `velaCliCollabClient`:

```ts
const velaCliCollabClient = createVelaCliCollabClientFromEnv(process.env, { … }); // VelaCliCollabClient | null
…
cloud: {
  heartbeatPresence: (projectId, input) => velaCliCollabClient.heartbeatPresence(…),
  listPresence:      (projectId)        => velaCliCollabClient.listPresence(…),
  leavePresence:     (projectId, input) => velaCliCollabClient.leavePresence(…),
},
```

The factory returns `null` whenever the run has not opted into the vela-cli collab transport. Two consequences, and the second is the one that bites:

1. **The in-process fallback became dead code.** `registerCollabPresenceRoutes` does `const cloud = deps.cloud ?? null;`. Because a literal is unconditionally truthy, `cloud` was *always* truthy, so `presence.present(...)` / `presence.heartbeat(...)` / `presence.leave(...)` could never run.
2. **Presence requests 502 instead of degrading.** With the transport off, every request that reaches the `if (cloud)` branch dereferences `null`, the `TypeError` is swallowed by the route's `try/catch`, and the caller gets `502 collab_presence_unavailable`.

`POST /api/projects/:id/presence/leave` carries **no** shared-project precondition (unlike GET and heartbeat), so it failed on *any* project id, with no fixtures — in every run without the transport. That includes **every stable/prod packaged build**: `apps/packaged/src/sidecars.ts` gates `OD_COLLAB_TRANSPORT=vela-cli` behind the `feature-test` / `test` AMR profiles, so `prod` builds leave it unset. Plain `tools-dev` runs are affected too.

`apps/daemon/src/server.ts` starts with `// @ts-nocheck`, which is why `pnpm typecheck` was green over a plain null dereference. Typecheck offers zero guarantee for that file.

## What users will see

Nothing changes for anyone on the vela-cli collab transport — presence still relays to the cloud, unchanged.

For everyone else (stable/prod packaged builds, plain `tools-dev` runs), presence endpoints stop returning `502 collab_presence_unavailable` and go back to serving the process-local present set, which is what the route module was always written to do. No UI change: this is daemon-side wiring only.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

No contract change: `packages/contracts` is untouched, and the `/api/projects/:id/presence*` request/response shapes are unchanged.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/collab-presence-transport-off.test.ts`
- Did the test go red before the source change and green after? **yes**

The routes are wired in `server.ts`, so a route-module test cannot see the defect — the new spec boots the **real daemon** via `startServer` against an isolated `OD_DATA_DIR` and drives the actual HTTP boundary. Red output, source tree pristine at `3f6629b9`:

```
 ❯ tests/collab-presence-transport-off.test.ts (3 tests | 2 failed)
   × falls back to process-local presence on leave instead of failing
   × serves the process-local present set for a shared project

AssertionError: expected 502 to be 200   ← POST …/presence/leave
AssertionError: expected 502 to be 200   ← POST …/presence/heartbeat
 Tests  2 failed | 1 passed (3)
```

Green on this branch: `Tests  3 passed (3)`.

Coverage, all three endpoints in both directions:

| Case | Endpoints | Pre-fix |
|---|---|---|
| transport **off**, any project | `leave` | red (502) |
| transport **off**, genuinely shared project | `heartbeat`, `list`, `leave` | red (502) |
| transport **on** (`OD_COLLAB_TRANSPORT=vela-cli`) | `heartbeat`, `list`, `leave` | already green — pinned so the fix can't break the cloud path |

The shared-project case is set up through the production path rather than a source backdoor: `OD_DEV_WORKSPACE_CONTEXT` seeds the workspace principal and `VELA_BIN` points the daemon's normal Vela resolution at a stub CLI, so the team-project catalog and the presence relay both exercise the real child-process transport. The test asserts against the stub's call log that the catalog lookup really happened, that **no** `collab presence` call is relayed when the transport is off, and that all three presence calls **are** relayed when it is on.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass for the changed package (`@open-design/daemon`). Repo-wide typecheck has one **pre-existing** failure on this branch, `apps/web/src/components/useOpenFolderImport.ts(37,11)` TS2322 (`WorkspaceCollabContext` vs `OpenDesignHostWorkspaceContext`), reproduced identically with this PR's changes stashed — unrelated to this daemon-only change.
- `pnpm --filter @open-design/daemon test` — pass, including `collab-presence-routes.test.ts` (12 tests) and the new spec
- Verified the guard is genuinely load-bearing at the type level: deleting `if (!transport) return null;` from the new factory produces three `TS18049 'transport' is possibly 'null' or 'undefined'` errors.

## Note on the fix shape

Rather than repeating `if (velaCliCollabClient)` inside each of the three arrow functions, the dependency is now built by a single named factory, `createCollabPresenceCloudClient`, in the **checked** route module that owns the `cloud` contract. Its docblock states the invariant the call site relies on — *a `cloud` dependency exists if and only if a transport exists* — and explains why an always-truthy literal is the trap.

Placing it in `routes/collab-presence.ts` (no `@ts-nocheck`) means the null branch is now type-enforced, so this bug class cannot return at the construction site even though `server.ts` remains unchecked. Deliberately **not** in scope: removing `@ts-nocheck` from `server.ts`, which is repository-wide technical debt across 29 daemon files.

## Adjacent issues (not fixed here)

Both observed while reading, out of this spec's boundary, no code touched:

- `POST /api/projects/:id/presence/leave` has no `cloudAuthorizesProject` / `projectIsShared` precondition, while `GET …/presence` and `…/presence/heartbeat` both do. That asymmetry is what made the bug reachable with zero fixtures. It may well be intentional (a leave should always be honored), but it is worth a deliberate decision rather than an accident.
- When `OD_COLLAB_CLOUD_URL` is set, `shouldUseVelaCliCollabTransport` returns `false`, so `collabCloudClient` falls back to the HTTP collab-cloud client — but the presence routes are only ever handed the vela-cli client. Presence therefore has no cloud relay at all in that configuration and now degrades to process-local. If the HTTP collab-cloud transport is meant to serve presence, that is a separate wiring gap.
