### PR TITLE
fix(web): scope desktop vibrancy to macOS

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -144,7 +144,7 @@ import type {
   PluginShareProjectOutcome,
   WorkspaceProjectListView,
 } from './state/projects';
-import type { OpenDesignHostProjectImportSuccess } from '@open-design/host';
+import { getOpenDesignHost, type OpenDesignHostProjectImportSuccess } from '@open-design/host';
 import { useI18n } from './i18n';
 import { liveArtifactTabId } from './types';
 import type {
@@ -665,6 +665,7 @@ function AppInner() {
   const { t } = useI18n();
   const iframeKeepAlivePool = useIframeKeepAlivePool();
   const clientType = useMemo(() => detectClientType(), []);
+  const hostPlatform = useMemo(() => getOpenDesignHost()?.client.platform, []);
   useModalWindowDragGuard();
   const workspaceContextState = useWorkspaceContext();
   const {
@@ -716,7 +717,11 @@ function AppInner() {
   // scrim to let the wallpaper show through more clearly; on focus the scrim
   // returns to full strength (app-wash.css keys off this class).
   useEffect(() => {
-    if (clientType !== 'desktop' || typeof window === 'undefined') return undefined;
+    if (
+      clientType !== 'desktop'
+      || hostPlatform !== 'darwin'
+      || typeof window === 'undefined'
+    ) return undefined;
     const root = document.documentElement;
     const sync = () => root.classList.toggle('is-window-blurred', !document.hasFocus());
     sync();
@@ -727,7 +732,7 @@ function AppInner() {
       window.removeEventListener('blur', sync);
       root.classList.remove('is-window-blurred');
     };
-  }, [clientType]);
+  }, [clientType, hostPlatform]);
   const [config, setConfig] = useState<AppConfig>(() => loadConfig());
   const configRef = useRef(config);
   configRef.current = config;
@@ -3497,6 +3502,7 @@ function AppInner() {
       <div
         className={`workspace-shell workspace-shell--${clientType}`}
         data-client-type={clientType}
+        data-host-platform={hostPlatform}
       >
         <WorkspaceTabsBar
           route={route}

--- a/apps/web/src/styles/app-wash.css
+++ b/apps/web/src/styles/app-wash.css
@@ -76,9 +76,10 @@ body::before {
    wallpaper blurs through the window, so the painted pastel blobs step aside.
    html/body go fully transparent and the wash collapses to a translucent
    cream scrim that keeps content readable over arbitrary wallpapers — the
-   Craft look. The .workspace-shell--desktop marker comes from the host
-   bridge (App.tsx data-client-type). Browsers never match this block. */
-html:has(.workspace-shell--desktop) {
+   Craft look. The desktop and darwin markers come from the host bridge
+   (App.tsx data-client-type/data-host-platform). Windows desktop windows are
+   opaque, so they intentionally keep the normal pastel wash. */
+html:has(.workspace-shell--desktop[data-host-platform='darwin']) {
   /* Focused window: a firm scrim so content sits on a mostly solid ground.
      The unfocused state below thins this back to ~21% (0.34 × 62%), which
      preserves the airy see-through look while the window is in the back. */
@@ -88,17 +89,17 @@ html:has(.workspace-shell--desktop) {
   );
   background: transparent;
 }
-html:has(.workspace-shell--desktop) body {
+html:has(.workspace-shell--desktop[data-host-platform='darwin']) body {
   background: transparent;
 }
 /* Focus response: while the window is unfocused (App.tsx toggles
    .is-window-blurred on <html> in desktop mode) the scrim thins out so the
    wallpaper reads clearly through the glass; regaining focus fades it back
    to full strength. Browsers never get the class, so web mode is untouched. */
-html:has(.workspace-shell--desktop) body::before {
+html:has(.workspace-shell--desktop[data-host-platform='darwin']) body::before {
   transition: opacity 240ms cubic-bezier(0.23, 1, 0.32, 1);
 }
-html.is-window-blurred:has(.workspace-shell--desktop) body::before {
+html.is-window-blurred:has(.workspace-shell--desktop[data-host-platform='darwin']) body::before {
   opacity: 0.34;
 }
 /* The top project tab strip stays flush and seamless with the page below it:
@@ -126,8 +127,8 @@ html.is-window-blurred:has(.workspace-shell--desktop) body::before {
     --veil-canvas: var(--bg);
     --veil-panel: var(--bg-panel);
   }
-  html:has(.workspace-shell--desktop),
-  html:has(.workspace-shell--desktop) body {
+  html:has(.workspace-shell--desktop[data-host-platform='darwin']),
+  html:has(.workspace-shell--desktop[data-host-platform='darwin']) body {
     background: var(--bg-app);
   }
 }
@@ -143,8 +144,8 @@ html.is-window-blurred:has(.workspace-shell--desktop) body::before {
     --veil-canvas: var(--bg);
     --veil-panel: var(--bg-panel);
   }
-  html:has(.workspace-shell--desktop),
-  html:has(.workspace-shell--desktop) body {
+  html:has(.workspace-shell--desktop[data-host-platform='darwin']),
+  html:has(.workspace-shell--desktop[data-host-platform='darwin']) body {
     background: var(--bg-app);
   }
 }

--- a/apps/web/tests/components/App.update-dialog.test.tsx
+++ b/apps/web/tests/components/App.update-dialog.test.tsx
@@ -204,6 +204,23 @@ describe('App updater dialog integration', () => {
     vi.clearAllMocks();
   });
 
+  it('exposes the desktop host platform on the workspace shell', () => {
+    restoreHost = installMockOpenDesignHost({
+      host: {
+        client: {
+          platform: 'win32',
+        },
+      },
+    });
+
+    const { container } = render(<App />);
+
+    expect(container.querySelector('.workspace-shell')).toHaveAttribute(
+      'data-host-platform',
+      'win32',
+    );
+  });
+
   it('mounts the updater open-dialog subscription and handles the mac app menu request', async () => {
     let openDialogListener: OpenDesignHostUpdaterOpenDialogListener | null = null;
     const check = vi.fn(async () => idleStatus({ state: 'not-available' }));

--- a/apps/web/tests/styles/app-wash-platform.test.ts
+++ b/apps/web/tests/styles/app-wash-platform.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const appWashCss = readFileSync(
+  new URL('../../src/styles/app-wash.css', import.meta.url),
+  'utf8',
+);
+
+describe('desktop app wash platform contract', () => {
+  it('limits window-vibrancy material rules to macOS desktop hosts', () => {
+    const macDesktopSelector =
+      ":has(.workspace-shell--desktop[data-host-platform='darwin'])";
+    const vibrancySelectors = appWashCss.match(
+      /html(?:\.is-window-blurred)?:has\(\.workspace-shell--desktop[^)]*\)(?: body(?:::before)?)?/g,
+    );
+
+    expect(vibrancySelectors).not.toBeNull();
+    expect(vibrancySelectors).not.toHaveLength(0);
+    expect(vibrancySelectors?.every((selector) => selector.includes(macDesktopSelector))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

While validating the workspace desktop app on Windows, the Home surface lost its pastel blue, pink, and warm wash and rendered as plain white. The regression came from the desktop material rules added in PR #5517: they matched every `.workspace-shell--desktop`, even though Electron only enables transparent window vibrancy on macOS. Windows therefore received a translucent white scrim over an opaque white native window.

This PR fixes the user-visible regression without changing the macOS vibrancy configuration or introducing a Windows-specific color override.

## What users will see

- Windows desktop keeps the normal pastel `--app-wash` gradient instead of a white background.
- macOS desktop continues to use the 62% system-vibrancy scrim, transparent page backgrounds, and the thinner unfocused scrim.
- Web mode is unchanged.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

- macOS runtime validation completed locally: `platform=darwin`, `data-host-platform=darwin`, 62% scrim, transparent `html`/`body`, and unfocused opacity `0.34`.
- Pending before ready: attach the Windows before/after screenshot confirming the restored pastel wash.

## Bug fix verification

- Test paths:
  - `apps/web/tests/styles/app-wash-platform.test.ts`
  - `apps/web/tests/components/App.update-dialog.test.tsx`
- The CSS contract test went red on the pre-fix workspace branch and green after the source change. It was not separately executed against `main`; this PR targets `feat/workspace-team`.
- The tests ensure the host platform reaches the workspace shell and prevent generic desktop selectors from enabling macOS-only material rules again.

## Validation

- `pnpm --filter @open-design/web test` — 532 files passed; 5,436 tests passed; 8 skipped
- `pnpm guard`
- `pnpm typecheck`
- macOS `tools-dev` desktop runtime eval and screenshot validation

Remote CI is pending.