### PR TITLE
fix(contracts): enforce totalTimeoutMs >= perRoundTimeoutMs in CritiqueConfigSchema refine

### DIFF
--- a/packages/contracts/src/critique.ts
+++ b/packages/contracts/src/critique.ts
@@ -51,6 +51,9 @@ export const CritiqueConfigSchema = z.object({
   // semantic check is "threshold cannot meaningfully exceed scale".
   (cfg) => cfg.scoreThreshold <= cfg.scoreScale + 1e-9,
   { message: 'scoreThreshold must be <= scoreScale' },
+).refine(
+  (cfg) => cfg.totalTimeoutMs >= cfg.perRoundTimeoutMs,
+  { message: 'totalTimeoutMs must be >= perRoundTimeoutMs' },
 );
 
 export type CritiqueConfig = z.infer<typeof CritiqueConfigSchema>;


### PR DESCRIPTION
## Description
This PR updates `CritiqueConfigSchema` in `packages/contracts/src/critique.ts`.

## Surface Area
- `packages/contracts/src/critique.ts`

## Details
- Adds a Zod refinement to ensure `totalTimeoutMs >= perRoundTimeoutMs` to prevent invalid critique configuration states.

## Validation Details
- Verified Zod schema refinement logic for `CritiqueConfigSchema`.