### PR TITLE
test(e2e): unmask the AMR runtime lane and repair the visual settings/workspace captures

### DIFF
--- a/e2e/lib/playwright/visual.ts
+++ b/e2e/lib/playwright/visual.ts
@@ -136,6 +136,16 @@ const VISUAL_PROJECTS = [
 
 type VisualProject = (typeof VISUAL_PROJECTS)[number];
 
+/** The single conversation every workspace capture opens into. */
+const VISUAL_CONVERSATION = {
+  id: 'visual-conversation-launchpad',
+  projectId: 'visual-project-launchpad',
+  title: null,
+  messageCount: 0,
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_050_000,
+} as const;
+
 const VISUAL_PROJECT_FILE_HTML =
   '<!doctype html><html><body><main><h1>Visual CSS Smoke</h1><p>Workspace preview remains framed.</p></main></body></html>';
 
@@ -351,6 +361,42 @@ export async function configureVisualPage(page: Page, options: VisualPageOptions
 
   await page.route('**/api/projects', async (route) => {
     await fulfillGet(route, { projects });
+  });
+
+  // The conversation boundary. `ProjectView` renders `ChatPane` — and therefore
+  // the composer every workspace capture waits for — only once a conversation
+  // resolves (`activeConversationId || conversationLoadError`), and both
+  // `listConversations` and `createConversation` swallow a non-ok response
+  // (`[]` / `null`) rather than surfacing an error. So while the catch-all above
+  // answered `/conversations` with 404, the project opened with no conversation
+  // AND no load error, ChatPane never mounted, and every capture that navigates
+  // into the workspace died on `chat-composer` not existing. The catch-all's own
+  // contract is that "every other daemon-owned request terminates at a
+  // deterministic browser-side boundary" — this is that boundary for
+  // conversations, which the catch-all closed without supplying.
+  await page.route('**/api/projects/*/conversations', async (route) => {
+    const method = route.request().method();
+    if (method === 'GET') {
+      await route.fulfill({ json: { conversations: [VISUAL_CONVERSATION] } });
+      return;
+    }
+    if (method === 'POST') {
+      await route.fulfill({ json: { conversation: VISUAL_CONVERSATION } });
+      return;
+    }
+    await route.fallback();
+  });
+
+  await page.route('**/api/projects/*/conversations/*', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.fulfill({ json: { conversation: VISUAL_CONVERSATION } });
+      return;
+    }
+    await fulfillGet(route, { conversation: VISUAL_CONVERSATION });
+  });
+
+  await page.route('**/api/projects/*/conversations/*/messages', async (route) => {
+    await fulfillGet(route, { messages: [] });
   });
 
   await page.route('**/api/projects/*/files', async (route) => {

--- a/e2e/ui/amr-run-failure-recovery.test.ts
+++ b/e2e/ui/amr-run-failure-recovery.test.ts
@@ -55,10 +55,18 @@ async function openExecutionSettingsDialog(page: Page) {
   return settings;
 }
 
-test.describe.configure({ mode: 'serial', timeout: T.xlong });
 // Timeout-only configure: each test stubs its own catalogs/agents/status
 // routes and creates its own project, so order independence holds and the
 // file stays splittable across CI shards (a serial group cannot be split).
+//
+// This must stay a SINGLE call. `test.describe.configure` only overwrites the
+// keys it is given, so a later `configure({ timeout })` cannot undo an earlier
+// `configure({ mode: 'serial' })` — a second call reading as "timeout-only"
+// left the whole file serial, where one failure skipped the eight cases behind
+// it and reported them as "did not run" rather than as real results.
+// `mode: 'serial'` is also forbidden outright by e2e/AGENTS.md's UI test
+// stability rules (a serial group cannot be split across the sharded full pool
+// and floors its wall time).
 test.describe.configure({ timeout: T.xlong });
 
 async function stubCatalogsEmpty(page: Page) {

--- a/e2e/ui/visual-settings.test.ts
+++ b/e2e/ui/visual-settings.test.ts
@@ -1,3 +1,5 @@
+import type { Locator } from '@playwright/test';
+
 import type { WorkspaceCollabContext } from '@open-design/contracts';
 import { expect, test } from '@/playwright/suite';
 import { T } from '@/timeouts';
@@ -15,6 +17,27 @@ import {
 } from '@/playwright/visual';
 
 test.describe.configure({ timeout: T.xlong });
+
+/**
+ * The BYOK half of Settings' Execution-mode switch.
+ *
+ * #5971 ("Polish Home and Settings terminology") renamed this tab's title from
+ * `BYOK` to `API providers` — on `main` `settings.modeApiMeta` is still
+ * `'BYOK'`, on this branch it is `'API providers'` — so the old
+ * `getByRole('tab', { name: 'BYOK' })` matched nothing and every BYOK capture
+ * below hung on an unactionable click until the test timed out. The product
+ * copy is the acceptance result; the oracle follows it.
+ *
+ * Scoped to the Execution-mode tablist rather than matching the label
+ * repo-wide: the BYOK pane renders its own `API protocol` tablist, and the
+ * media section renders a tab per provider, so an unscoped name match is one
+ * renamed provider away from resolving to the wrong tab.
+ */
+function byokModeTab(dialog: Locator): Locator {
+  return dialog
+    .getByRole('tablist', { name: 'Execution mode' })
+    .getByRole('tab', { name: /API providers/i });
+}
 
 // The auto-provisioned personal workspace every signed-in identity has. Typed
 // against the contract so a new required permission bit or context field fails
@@ -164,7 +187,7 @@ test('[P2] captures the settings BYOK surface', async ({ page }) => {
   await gotoVisualWorkspace(page);
 
   const dialog = await prepareVisualSettingsDialog(page);
-  await dialog.getByRole('tab', { name: 'BYOK' }).click();
+  await byokModeTab(dialog).click();
   await expect(dialog.getByRole('tablist', { name: 'API protocol' })).toBeVisible();
   await expect(dialog.getByRole('heading', { name: 'Anthropic API' })).toBeVisible();
   await waitForVisualFonts(page);
@@ -187,7 +210,7 @@ test('[P2] captures the settings BYOK OpenAI surface', async ({ page }) => {
   await gotoVisualWorkspace(page);
 
   const dialog = await prepareVisualSettingsDialog(page);
-  await dialog.getByRole('tab', { name: 'BYOK' }).click();
+  await byokModeTab(dialog).click();
   await dialog.getByRole('tab', { name: 'OpenAI', exact: true }).click();
   await expect(dialog.getByRole('heading', { name: 'OpenAI API' })).toBeVisible();
   await waitForVisualFonts(page);
@@ -210,7 +233,7 @@ test('[P2] captures the settings BYOK model dropdown surface', async ({ page }) 
   await gotoVisualWorkspace(page);
 
   const dialog = await prepareVisualSettingsDialog(page);
-  await dialog.getByRole('tab', { name: 'BYOK' }).click();
+  await byokModeTab(dialog).click();
   await dialog.getByRole('tab', { name: 'OpenAI', exact: true }).click();
   const modelSelect = dialog.getByRole('combobox', { name: 'Model', exact: true });
   await expect(modelSelect).toBeVisible();

--- a/e2e/ui/visual-workspace.test.ts
+++ b/e2e/ui/visual-workspace.test.ts
@@ -203,6 +203,15 @@ test('[P2] captures the topbar local CLI model list surface', async ({ page }) =
 
 test('[P2] captures the topbar BYOK execution switcher surface', async ({ page }) => {
   await configureVisualPage(page, {
+    // No local agent, which is the premise the popover assertions below already
+    // state ("a BYOK config has no local agent"). `configureVisualPage`
+    // otherwise serves `[MOCK_AGENT]` from `/api/agents`, and an installed
+    // agent wins the popover: it renders that agent's model radiogroup
+    // (`radio "Default"`) instead of the BYOK provider/model rows, so the
+    // `.inline-switcher__hint` this case waits for never exists. The chip still
+    // showed the BYOK glyph and `gpt-4o`, which is why the earlier assertions
+    // passed and only the popover shape disagreed.
+    agents: [],
     config: {
       mode: 'api',
       apiKey: 'sk-visual',


### PR DESCRIPTION
## Why

PR #6142's three Playwright lanes were repaired by source-reading, not by running them. This branch runs them and fixes only what a real run proved broken.

Two of the fixes matter beyond these lanes:

- `amr-run-failure-recovery.test.ts` was still a **serial** group. `test.describe.configure` only overwrites the keys it is given, so the second `configure({ timeout })` — whose comment claimed it was "timeout-only" — never cleared `mode: 'serial'`. One failure therefore skipped the eight cases behind it, and the lane reported them as **"did not run"**. Anyone reading that output would count eight unknowns as fine. `e2e/AGENTS.md` forbids serial groups outright.
- `configureVisualPage`'s `**/api/**` catch-all (added by #6126, which is **on `main`**) answered `/conversations` with 404. `ProjectView` mounts `ChatPane` only once a conversation resolves, and both `listConversations` and `createConversation` swallow a non-ok response, so the project opened with no conversation **and no error**: `ChatPane` never mounted and every capture that enters the workspace died on `chat-composer` not existing. `main` has the same gap.

## What users will see

Nothing — test-only. What maintainers see is honest lane output: no case is hidden behind a serial skip, and the visual lane captures the workspace again instead of dying on the way in.

## Measured effect

| lane | before | after |
| --- | --- | --- |
| `UI P0 (project-runtime)` | 12 passed, 2 failed, **8 did not run** | 14 passed, 8 failed, **0 did not run** |
| `Playwright visual (settings-workspace)` | first 3 of 18 failed on the way into the workspace; run abandoned | 14 passed, 4 failed |

Precisely what was run, so nothing here is inferred:

- `project-runtime`: two full lane runs (before and after the serial fix). The numbers above are both from complete runs.
- `settings-workspace`: one full lane run after the conversation-boundary fix gave **14 passed / 4 failed**. The remaining four were the BYOK-rename and topbar-fixture defects; each was fixed and then **re-run individually to green** (3 settings captures + 1 workspace capture). A full-lane run confirming 18/18 in one pass has **not** been done — treat 18/18 as expected, not measured.

The project-runtime lane's eight unmasked cases are two real passes and six real failures. Those six have two root causes, one of which needs a product decision and is deliberately **not** papered over here.

## Changes

- `e2e/ui/amr-run-failure-recovery.test.ts` — drop `mode: 'serial'`; document why the configure call must stay single.
- `e2e/lib/playwright/visual.ts` — supply the conversation boundary the `**/api/**` catch-all closed without replacing.
- `e2e/ui/visual-settings.test.ts` — the Execution-mode BYOK tab is titled `API providers` since #5971 renamed `settings.modeApiMeta` (`main` still says `BYOK`), so `getByRole('tab', { name: 'BYOK' })` matched nothing and three captures hung until timeout. Scoped to the Execution-mode tablist so a renamed provider can't resolve the wrong tab.
- `e2e/ui/visual-workspace.test.ts` — the topbar BYOK capture left `[MOCK_AGENT]` installed, contradicting its own "a BYOK config has no local agent" premise: an installed agent wins the popover and renders its model radiogroup instead of the BYOK rows.

## Validation

`pnpm guard`, `pnpm typecheck`, `pnpm --filter @open-design/e2e typecheck`, plus the two lanes above run locally on this branch (macOS, `OD_PLAYWRIGHT_WORKERS=1`).

## Surface area

- [x] e2e tests
