### PR TITLE
fix(web): explain the AMR workspace-scope block instead of a dead send button

### DIFF
--- a/apps/web/src/collab/useProjectWorkspaceScope.ts
+++ b/apps/web/src/collab/useProjectWorkspaceScope.ts
@@ -17,6 +17,13 @@ export interface ProjectWorkspaceScopeState {
   loading: boolean;
   scope: ProjectWorkspaceScope | null;
   failure?: 'unsupported' | 'forbidden' | 'unavailable';
+  /**
+   * Force a fresh read of this project's scope — the same revalidation an
+   * identity change / reconnect / `pageshow` triggers, exposed so a UI that has
+   * to tell the user "we could not resolve this" can also offer them the retry.
+   * Optional so fixtures can describe a state without owning the read.
+   */
+  revalidate?: () => void;
 }
 
 export function projectWorkspaceContext(
@@ -217,11 +224,12 @@ export function useProjectWorkspaceScope(projectId: string): ProjectWorkspaceSco
     state.resolvedRevision !== refreshRevision ||
     (state.scope !== null && state.scope.projectId !== projectId)
   ) {
-    return { loading: true, scope: null };
+    return { loading: true, scope: null, revalidate };
   }
   return {
     loading: state.loading,
     scope: state.scope,
+    revalidate,
     ...(state.failure ? { failure: state.failure } : {}),
   };
 }

--- a/apps/web/src/components/AmrScopeBlockedNotice.module.css
+++ b/apps/web/src/components/AmrScopeBlockedNotice.module.css
@@ -1,0 +1,78 @@
+/* Sits directly above the composer (inside ChatPane's composer node, so it
+   travels with the portaled fixed layer). Shares the inline inset the other
+   composer-adjacent strips use (`.chat-queued-send-strip`) so all three line up,
+   and the amber/attention tone already used for held-back states. */
+.notice {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  box-sizing: border-box;
+  width: calc(100% - (var(--chat-composer-inline-inset, 12px) * 2));
+  min-width: 0;
+  margin: 0 var(--chat-composer-inline-inset, 12px) 4px;
+  padding: 9px 12px;
+  border: 1px solid color-mix(in srgb, var(--amber) 34%, var(--border));
+  border-radius: var(--radius-md, 12px);
+  background: var(--amber-bg);
+  /* The composer is portaled into `.chat-composer-fixed-layer`, which sets
+     `pointer-events: none` and re-enables it only for `.composer`. Without this
+     the remedy button would render but refuse every click in that layout. */
+  pointer-events: auto;
+  animation: amrScopeNoticeIn 200ms var(--ease-out, cubic-bezier(0.23, 1, 0.32, 1));
+}
+
+@keyframes amrScopeNoticeIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .notice {
+    animation: none;
+  }
+}
+
+.icon {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--amber);
+}
+
+.message {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 0;
+  font-size: 12.5px;
+  line-height: 1.45;
+  color: var(--text-strong);
+}
+
+.action {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+}
+
+/* The pill's own root styling assumes a settings row; keep it inline and let
+   the notice own the spacing. */
+.signInPill {
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.retry {
+  min-height: 28px;
+  padding: 0 12px;
+  font-size: 12.5px;
+}

--- a/apps/web/src/components/AmrScopeBlockedNotice.tsx
+++ b/apps/web/src/components/AmrScopeBlockedNotice.tsx
@@ -1,0 +1,86 @@
+import { Button } from '@open-design/components';
+
+import { useT } from '../i18n';
+import type { AmrWorkspaceScopeBlock } from '../runtime/amr-workspace-scope-gate';
+import { AmrLoginPill } from './AmrLoginPill';
+import { Icon } from './Icon';
+import styles from './AmrScopeBlockedNotice.module.css';
+
+interface Props {
+  block: AmrWorkspaceScopeBlock;
+  metricsConsent: boolean;
+  installationId: string | null | undefined;
+  /** Re-read `GET /api/projects/:id/workspace-scope` — the `unresolved` remedy. */
+  onRetryWorkspaceScope?: () => void;
+}
+
+/**
+ * The reason an Open Design Cloud send is held closed, rendered where the user
+ * is already looking: directly above the composer they just typed into.
+ *
+ * It explains, it does not unblock. The send button stays disabled either way —
+ * `ProjectView.currentConversationSendDisabled` owns that, and this notice never
+ * participates in it. Its whole job is to replace a dead grey button with a
+ * sentence plus the one action that clears the block:
+ *
+ *   signed_out  — the same in-app sign-in Home's balance gate uses
+ *                 (`AmrLoginPill` + `chat.amrBalanceGate.signInCta`), so a user
+ *                 who lands here from either surface performs one identical
+ *                 action. Signing in fires the workspace-context refresh, the
+ *                 project scope revalidates, and the composer reopens on its own.
+ *   unresolved  — the session is not the missing piece, so the remedy is a
+ *                 re-read of the project's workspace authority. Offering an
+ *                 account action here would be a guess.
+ *
+ * Deliberately not a dialog: the blocked state persists for as long as the
+ * authority is unknown, and a modal would have to be dismissed before the user
+ * could even see the composer it is talking about.
+ */
+export function AmrScopeBlockedNotice({
+  block,
+  metricsConsent,
+  installationId,
+  onRetryWorkspaceScope,
+}: Props) {
+  const t = useT();
+  const signedOut = block.kind === 'signed_out';
+  return (
+    <div
+      className={styles.notice}
+      data-testid="amr-scope-blocked-notice"
+      role="status"
+    >
+      <span className={styles.icon} aria-hidden>
+        <Icon name="alert-triangle" size={14} />
+      </span>
+      <p className={styles.message}>
+        {signedOut
+          ? t('chat.amrScopeGate.signedOutMessage')
+          : t('chat.amrScopeGate.unresolvedMessage')}
+      </p>
+      <div className={styles.action}>
+        {signedOut ? (
+          <AmrLoginPill
+            className={styles.signInPill}
+            signInLabel={t('chat.amrBalanceGate.signInCta')}
+            amrEntrySourceDetail="chat_balance_gate_sign_in"
+            metricsConsent={metricsConsent}
+            installationId={installationId}
+            showActivationDetails
+            hideSignedOutStatus
+            revealPendingCancelAction
+          />
+        ) : onRetryWorkspaceScope ? (
+          <Button
+            variant="subtle"
+            className={styles.retry}
+            onClick={onRetryWorkspaceScope}
+            data-testid="amr-scope-blocked-retry"
+          >
+            {t('promptTemplates.retry')}
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ChatPane.tsx
+++ b/apps/web/src/components/ChatPane.tsx
@@ -66,6 +66,8 @@ import {
 } from './NextStepActions';
 import { AmrGuidance } from './AmrGuidance';
 import { AmrLoginPill } from './AmrLoginPill';
+import { AmrScopeBlockedNotice } from './AmrScopeBlockedNotice';
+import type { AmrWorkspaceScopeBlock } from '../runtime/amr-workspace-scope-gate';
 import {
   AMR_LOGIN_STATUS_EVENT,
   amrLoginStatusEventReason,
@@ -503,6 +505,13 @@ interface Props {
   hasActiveDesignSystem?: boolean;
   activeDesignSystem?: DesignSystemSummary | null;
   sendDisabled?: boolean;
+  // Why an Open Design Cloud send is held closed, when that is what disabled it.
+  // Non-null renders the composer-adjacent reason + remedy (see
+  // AmrScopeBlockedNotice); it never affects `sendDisabled` itself, which stays
+  // ProjectView's decision.
+  amrScopeBlock?: AmrWorkspaceScopeBlock | null;
+  /** Re-read the project's workspace authority — the `unresolved` remedy. */
+  onRetryWorkspaceScope?: () => void;
   // Read-only viewer of a team-shared project. Beyond `sendDisabled` (which only
   // blocks the send action), this also disables the composer input itself and
   // hides the empty-state starter cards, since a member cannot start a
@@ -823,6 +832,8 @@ export function ChatPane({
   streaming,
   loading = false,
   sendDisabled = false,
+  amrScopeBlock = null,
+  onRetryWorkspaceScope,
   viewerOnly = false,
   queuedItems = [],
   error,
@@ -2198,6 +2209,23 @@ export function ChatPane({
       onShowToast={onShowToast}
     />
   );
+  // The blocked-send reason travels WITH the composer rather than sitting beside
+  // it in the slot: the composer is portaled into a fixed layer whenever the
+  // workspace pane owns the bottom of the screen, and a sibling left behind in
+  // the slot would be stranded under that layer.
+  const composerWithGateNotice = amrScopeBlock ? (
+    <>
+      <AmrScopeBlockedNotice
+        block={amrScopeBlock}
+        metricsConsent={config?.telemetry?.metrics === true}
+        installationId={config?.installationId}
+        onRetryWorkspaceScope={onRetryWorkspaceScope}
+      />
+      {composerNode}
+    </>
+  ) : (
+    composerNode
+  );
   const shouldPortalComposer =
     tab === 'chat'
     && composerPortalTarget !== null
@@ -2801,7 +2829,7 @@ export function ChatPane({
             style={composerSlotStyle}
             aria-hidden={shouldPortalComposer ? true : undefined}
           >
-            {shouldPortalComposer ? null : composerNode}
+            {shouldPortalComposer ? null : composerWithGateNotice}
           </div>
           {shouldPortalComposer && composerPortalTarget && composerPortalRect
             ? createPortal(
@@ -2814,7 +2842,7 @@ export function ChatPane({
                     width: composerPortalRect.width,
                   }}
                 >
-                  {composerNode}
+                  {composerWithGateNotice}
                 </div>,
                 composerPortalTarget,
               )

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -124,6 +124,7 @@ import {
   isAmrBalanceGateScope,
   type AmrBalanceGateScope,
 } from '../runtime/amr-balance-gate';
+import { amrWorkspaceScopeBlock } from '../runtime/amr-workspace-scope-gate';
 import { isPaidAmrPlan, resolveAmrPlan } from '../runtime/amr-low-balance-plan';
 import { AmrBalanceDialog } from './AmrBalanceDialog';
 import { AmrLowBalanceDialog, type AmrLowBalanceDecision } from './AmrLowBalanceDialog';
@@ -1547,6 +1548,15 @@ export function ProjectView({
   const projectRunWorkspaceScopeReady =
     !projectRunRequiresWorkspaceScope ||
     projectWorkspaceScopeAuthorizesAmr(projectWorkspaceScopeState.scope);
+  // Holding the send closed above is deliberate; holding it closed silently is
+  // not. This classifies the block so the composer can name the reason and offer
+  // the remedy that clears it. It never feeds back into
+  // `projectRunWorkspaceScopeReady` — the gate stays exactly as strict.
+  const projectRunAmrScopeBlock = amrWorkspaceScopeBlock({
+    requiresWorkspaceScope: projectRunRequiresWorkspaceScope,
+    projectScope: projectWorkspaceScopeState,
+    workspaceIdentity: workspaceContextState,
+  });
   // Onboarding first-generation funnel (spec §11.1). Consume the pending entry
   // (set by the Home recommendation) exactly once on mount; the refs guard the
   // two lifecycle events so each fires only for the genuine first send / first
@@ -9169,6 +9179,13 @@ export function ProjectView({
               // A read-only viewer of a team-shared project cannot drive artifact
               // changes through chat (comments go through the separate overlay).
               sendDisabled={currentConversationSendDisabled || projectCollab.viewerOnly}
+              // Reason + remedy for a send the AMR workspace-scope gate closed.
+              // Suppressed for a read-only viewer: their composer is disabled by
+              // ownership, and an Open Design Cloud sign-in would not change that.
+              amrScopeBlock={
+                projectCollab.viewerOnly ? null : projectRunAmrScopeBlock
+              }
+              onRetryWorkspaceScope={projectWorkspaceScopeState.revalidate}
               viewerOnly={projectCollab.viewerOnly}
               composerPlaceholder={
                 projectCollab.viewerOnly

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -84,6 +84,8 @@ export const ar: Dict = {
   'chat.amrBalanceGate.signedOutMessage': 'أنت تستخدم وكيل Open Design Cloud — سجّل الدخول وستبدأ هذه المهمة فورًا.',
   'chat.amrBalanceGate.signInCta': 'تسجيل الدخول',
   'chat.amrBalanceGate.watchingWallet': 'سنتابع تلقائيًا فور تحديث رصيدك.',
+  'chat.amrScopeGate.signedOutMessage': 'لم يتم تسجيل الدخول إلى Open Design Cloud، لذا لا توجد مساحة عمل لتشغيل هذا المشروع.',
+  'chat.amrScopeGate.unresolvedMessage': 'لم نتمكن من تأكيد مساحة العمل التي يعمل فيها هذا المشروع، لذا تم إيقاف مهام Open Design Cloud مؤقتًا.',
   'chat.amrLowBalance.title': 'رصيدك على وشك النفاد',
   'chat.amrLowBalance.message': 'لم يتبقَّ سوى {balance} — قد لا يكفي لإتمام هذه المهمة. اشحن أو قم بترقية باقتك أولًا.',
   'chat.amrLowBalance.rechargeCta': 'اشحن الرصيد',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -84,6 +84,8 @@ export const de: Dict = {
   'chat.amrBalanceGate.signedOutMessage': 'Du verwendest den Open Design Cloud-Agenten — melde dich an und diese Aufgabe kann sofort starten.',
   'chat.amrBalanceGate.signInCta': 'Anmelden',
   'chat.amrBalanceGate.watchingWallet': 'Sobald dein Guthaben aktualisiert ist, geht es automatisch weiter.',
+  'chat.amrScopeGate.signedOutMessage': 'Du bist nicht bei Open Design Cloud angemeldet, daher gibt es für dieses Projekt keinen Workspace zum Ausführen.',
+  'chat.amrScopeGate.unresolvedMessage': 'Wir konnten nicht bestätigen, in welchem Workspace dieses Projekt läuft — Open Design Cloud-Aufgaben sind pausiert.',
   'chat.amrLowBalance.title': 'Guthaben wird knapp',
   'chat.amrLowBalance.message': 'Nur noch {balance} übrig — vermutlich nicht genug für diese Aufgabe. Lade vorher auf oder upgrade deinen Plan.',
   'chat.amrLowBalance.rechargeCta': 'Aufladen',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -84,6 +84,8 @@ export const en: Dict = {
   'chat.amrBalanceGate.signedOutMessage': 'You\'re using the Open Design Cloud agent — sign in and this task can start right away.',
   'chat.amrBalanceGate.signInCta': 'Sign in',
   'chat.amrBalanceGate.watchingWallet': 'We\'ll continue automatically once your allowance updates.',
+  'chat.amrScopeGate.signedOutMessage': 'Open Design Cloud isn\'t signed in, so this project has no workspace to run under.',
+  'chat.amrScopeGate.unresolvedMessage': 'We couldn\'t confirm which workspace this project runs under, so Open Design Cloud tasks are paused.',
   'chat.amrLowBalance.title': 'Running low on allowance',
   'chat.amrLowBalance.message': 'Only {balance} of allowance remains — likely not enough to finish this task. Top up or upgrade your plan first.',
   'chat.amrLowBalance.rechargeCta': 'Top up',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -84,6 +84,8 @@ export const esES: Dict = {
   'chat.amrBalanceGate.signedOutMessage': 'Estás usando el agente de Open Design Cloud: inicia sesión y esta tarea podrá empezar de inmediato.',
   'chat.amrBalanceGate.signInCta': 'Iniciar sesión',
   'chat.amrBalanceGate.watchingWallet': 'Continuaremos automáticamente en cuanto se actualice tu saldo.',
+  'chat.amrScopeGate.signedOutMessage': 'No has iniciado sesión en Open Design Cloud, así que este proyecto no tiene ningún espacio de trabajo en el que ejecutarse.',
+  'chat.amrScopeGate.unresolvedMessage': 'No hemos podido confirmar en qué espacio de trabajo se ejecuta este proyecto, así que las tareas de Open Design Cloud están en pausa.',
   'chat.amrLowBalance.title': 'Te quedan pocos créditos',
   'chat.amrLowBalance.message': 'Solo quedan {balance}: probablemente no alcance para terminar esta tarea. Recarga o mejora tu plan primero.',
   'chat.amrLowBalance.rechargeCta': 'Recargar',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -84,6 +84,8 @@ export const fa: Dict = {
   'chat.amrBalanceGate.signedOutMessage': 'شما از ایجنت Open Design Cloud استفاده می‌کنید — وارد شوید تا این وظیفه بلافاصله شروع شود.',
   'chat.amrBalanceGate.signInCta': 'ورود',
   'chat.amrBalanceGate.watchingWallet': 'به‌محض به‌روزرسانی موجودی، به‌طور خودکار ادامه می‌دهیم.',
+  'chat.amrScopeGate.signedOutMessage': 'به Open Design Cloud وارد نشده‌اید، بنابراین فضای کاری‌ای برای اجرای این پروژه وجود ندارد.',
+  'chat.amrScopeGate.unresolvedMessage': 'نتوانستیم تأیید کنیم این پروژه در کدام فضای کاری اجرا می‌شود، بنابراین کارهای Open Design Cloud متوقف شده است.',
   'chat.amrLowBalance.title': 'اعتبار رو به اتمام است',
   'chat.amrLowBalance.message': 'فقط {balance} باقی مانده است — احتمالاً برای اتمام این وظیفه کافی نیست. ابتدا شارژ کنید یا طرح خود را ارتقا دهید.',
   'chat.amrLowBalance.rechargeCta': 'شارژ کنید',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -84,6 +84,8 @@ export const fr: Dict = {
   'chat.amrBalanceGate.signedOutMessage': 'Vous utilisez l’agent Open Design Cloud — connectez-vous et cette tâche pourra démarrer aussitôt.',
   'chat.amrBalanceGate.signInCta': 'Se connecter',
   'chat.amrBalanceGate.watchingWallet': 'Nous continuerons automatiquement dès que votre solde sera mis à jour.',
+  'chat.amrScopeGate.signedOutMessage': 'Vous n\'êtes pas connecté à Open Design Cloud : ce projet n\'a donc aucun espace de travail pour s\'exécuter.',
+  'chat.amrScopeGate.unresolvedMessage': 'Impossible de confirmer l\'espace de travail de ce projet ; les tâches Open Design Cloud sont en pause.',
   'chat.amrLowBalance.title': 'Crédits bientôt épuisés',
   'chat.amrLowBalance.message': 'Il ne reste que {balance} — probablement pas assez pour terminer cette tâche. Rechargez ou passez à une offre supérieure d’abord.',
   'chat.amrLowBalance.rechargeCta': 'Recharger',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -84,6 +84,8 @@ export const hu: Dict = {
   'chat.amrBalanceGate.signedOutMessage': 'Az Open Design Cloud agentet használod — jelentkezz be, és ez a feladat azonnal indulhat.',
   'chat.amrBalanceGate.signInCta': 'Bejelentkezés',
   'chat.amrBalanceGate.watchingWallet': 'Az egyenleg frissülése után automatikusan folytatjuk.',
+  'chat.amrScopeGate.signedOutMessage': 'Nem vagy bejelentkezve az Open Design Cloudba, így ennek a projektnek nincs munkaterülete a futtatáshoz.',
+  'chat.amrScopeGate.unresolvedMessage': 'Nem sikerült megállapítani, melyik munkaterületen fut ez a projekt, ezért az Open Design Cloud feladatok szünetelnek.',
   'chat.amrLowBalance.title': 'Fogytán a kereted',
   'chat.amrLowBalance.message': 'Már csak {balance} maradt — valószínűleg nem elég a feladat befejezéséhez. Előbb tölts fel vagy válts csomagot.',
   'chat.amrLowBalance.rechargeCta': 'Feltöltés',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -84,6 +84,8 @@ export const id: Dict = {
   'chat.amrBalanceGate.signedOutMessage': 'Anda menggunakan agen Open Design Cloud — masuk dan tugas ini bisa langsung dimulai.',
   'chat.amrBalanceGate.signInCta': 'Masuk',
   'chat.amrBalanceGate.watchingWallet': 'Kami akan melanjutkan otomatis begitu saldo Anda diperbarui.',
+  'chat.amrScopeGate.signedOutMessage': 'Anda belum masuk ke Open Design Cloud, jadi proyek ini tidak punya ruang kerja untuk dijalankan.',
+  'chat.amrScopeGate.unresolvedMessage': 'Kami tidak dapat memastikan ruang kerja tempat proyek ini dijalankan, jadi tugas Open Design Cloud dijeda.',
   'chat.amrLowBalance.title': 'Kredit hampir habis',
   'chat.amrLowBalance.message': 'Hanya tersisa {balance} — kemungkinan tidak cukup untuk menyelesaikan tugas ini. Isi ulang atau tingkatkan paket dulu.',
   'chat.amrLowBalance.rechargeCta': 'Isi ulang',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -84,6 +84,8 @@ export const it: Dict = {
   'chat.amrBalanceGate.signedOutMessage': 'Stai usando l’agente Open Design Cloud: accedi e questa attività potrà partire subito.',
   'chat.amrBalanceGate.signInCta': 'Accedi',
   'chat.amrBalanceGate.watchingWallet': 'Continueremo automaticamente non appena il saldo verrà aggiornato.',
+  'chat.amrScopeGate.signedOutMessage': 'Non hai effettuato l\'accesso a Open Design Cloud, quindi questo progetto non ha uno spazio di lavoro in cui essere eseguito.',
+  'chat.amrScopeGate.unresolvedMessage': 'Non è stato possibile confermare in quale spazio di lavoro viene eseguito questo progetto: le attività di Open Design Cloud sono in pausa.',
   'chat.amrLowBalance.title': 'Crediti in esaurimento',
   'chat.amrLowBalance.message': 'Restano solo {balance}: probabilmente non bastano per completare questa attività. Ricarica o aggiorna il piano prima.',
   'chat.amrLowBalance.rechargeCta': 'Ricarica',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -84,6 +84,8 @@ export const ja: Dict = {
   'chat.amrBalanceGate.signedOutMessage': 'Open Design Cloud エージェントを使用中です。サインインすれば、このタスクをすぐに開始できます。',
   'chat.amrBalanceGate.signInCta': 'サインイン',
   'chat.amrBalanceGate.watchingWallet': '残高が反映されると自動的に続行します。',
+  'chat.amrScopeGate.signedOutMessage': 'Open Design Cloud にサインインしていないため、このプロジェクトを実行するワークスペースがありません。',
+  'chat.amrScopeGate.unresolvedMessage': 'このプロジェクトがどのワークスペースで実行されるか確認できないため、Open Design Cloud のタスクを一時停止しています。',
   'chat.amrLowBalance.title': 'クレジット残量が少なくなっています',
   'chat.amrLowBalance.message': '残高はあと {balance} です。このタスクを最後まで実行できない可能性があります。先にチャージまたはプランのアップグレードをおすすめします。',
   'chat.amrLowBalance.rechargeCta': 'チャージする',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -84,6 +84,8 @@ export const ko: Dict = {
   'chat.amrBalanceGate.signedOutMessage': 'Open Design Cloud 에이전트를 사용 중입니다. 로그인하면 이 작업을 바로 시작할 수 있습니다.',
   'chat.amrBalanceGate.signInCta': '로그인',
   'chat.amrBalanceGate.watchingWallet': '잔액이 반영되면 자동으로 계속됩니다.',
+  'chat.amrScopeGate.signedOutMessage': 'Open Design Cloud에 로그인되어 있지 않아 이 프로젝트를 실행할 워크스페이스가 없습니다.',
+  'chat.amrScopeGate.unresolvedMessage': '이 프로젝트가 어느 워크스페이스에서 실행되는지 확인할 수 없어 Open Design Cloud 작업이 일시 중지되었습니다.',
   'chat.amrLowBalance.title': '크레딧이 얼마 남지 않았습니다',
   'chat.amrLowBalance.message': '잔액이 {balance}만 남아 이 작업을 끝내기에 부족할 수 있습니다. 먼저 충전하거나 요금제를 업그레이드하세요.',
   'chat.amrLowBalance.rechargeCta': '충전하기',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -84,6 +84,8 @@ export const pl: Dict = {
   'chat.amrBalanceGate.signedOutMessage': 'Używasz agenta Open Design Cloud — zaloguj się, a to zadanie ruszy od razu.',
   'chat.amrBalanceGate.signInCta': 'Zaloguj się',
   'chat.amrBalanceGate.watchingWallet': 'Będziemy kontynuować automatycznie, gdy saldo się zaktualizuje.',
+  'chat.amrScopeGate.signedOutMessage': 'Nie jesteś zalogowany w Open Design Cloud, więc ten projekt nie ma obszaru roboczego, w którym mógłby działać.',
+  'chat.amrScopeGate.unresolvedMessage': 'Nie udało się potwierdzić, w którym obszarze roboczym działa ten projekt, więc zadania Open Design Cloud są wstrzymane.',
   'chat.amrLowBalance.title': 'Kredyty na wyczerpaniu',
   'chat.amrLowBalance.message': 'Zostało tylko {balance} — prawdopodobnie za mało, by ukończyć to zadanie. Najpierw doładuj lub ulepsz plan.',
   'chat.amrLowBalance.rechargeCta': 'Doładuj',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -84,6 +84,8 @@ export const ptBR: Dict = {
   'chat.amrBalanceGate.signedOutMessage': 'Você está usando o agente Open Design Cloud — entre e esta tarefa pode começar na hora.',
   'chat.amrBalanceGate.signInCta': 'Entrar',
   'chat.amrBalanceGate.watchingWallet': 'Continuaremos automaticamente assim que seu saldo for atualizado.',
+  'chat.amrScopeGate.signedOutMessage': 'Você não está conectado ao Open Design Cloud, então este projeto não tem um espaço de trabalho para ser executado.',
+  'chat.amrScopeGate.unresolvedMessage': 'Não foi possível confirmar em qual espaço de trabalho este projeto é executado, então as tarefas do Open Design Cloud estão pausadas.',
   'chat.amrLowBalance.title': 'Créditos acabando',
   'chat.amrLowBalance.message': 'Restam apenas {balance} — provavelmente não é o bastante para concluir esta tarefa. Recarregue ou faça upgrade antes.',
   'chat.amrLowBalance.rechargeCta': 'Recarregar',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -84,6 +84,8 @@ export const ru: Dict = {
   'chat.amrBalanceGate.signedOutMessage': 'Вы используете агент Open Design Cloud — войдите, и эта задача сразу запустится.',
   'chat.amrBalanceGate.signInCta': 'Войти',
   'chat.amrBalanceGate.watchingWallet': 'Продолжим автоматически, как только баланс обновится.',
+  'chat.amrScopeGate.signedOutMessage': 'Вы не вошли в Open Design Cloud, поэтому для этого проекта нет рабочего пространства для запуска.',
+  'chat.amrScopeGate.unresolvedMessage': 'Не удалось определить, в каком рабочем пространстве выполняется этот проект, поэтому задачи Open Design Cloud приостановлены.',
   'chat.amrLowBalance.title': 'Кредиты заканчиваются',
   'chat.amrLowBalance.message': 'Осталось всего {balance} — вероятно, не хватит, чтобы завершить задачу. Сначала пополните баланс или улучшите тариф.',
   'chat.amrLowBalance.rechargeCta': 'Пополнить',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -84,6 +84,8 @@ export const th: Dict = {
   'chat.amrBalanceGate.signedOutMessage': 'คุณกำลังใช้เอเจนต์ Open Design Cloud — ลงชื่อเข้าใช้แล้วงานนี้จะเริ่มได้ทันที',
   'chat.amrBalanceGate.signInCta': 'ลงชื่อเข้าใช้',
   'chat.amrBalanceGate.watchingWallet': 'เมื่อยอดเงินอัปเดตแล้วจะดำเนินการต่อโดยอัตโนมัติ',
+  'chat.amrScopeGate.signedOutMessage': 'ยังไม่ได้ลงชื่อเข้าใช้ Open Design Cloud จึงไม่มีพื้นที่ทำงานสำหรับรันโปรเจกต์นี้',
+  'chat.amrScopeGate.unresolvedMessage': 'ไม่สามารถยืนยันได้ว่าโปรเจกต์นี้รันอยู่ในพื้นที่ทำงานใด งาน Open Design Cloud จึงถูกหยุดไว้',
   'chat.amrLowBalance.title': 'เครดิตใกล้หมดแล้ว',
   'chat.amrLowBalance.message': 'เหลือเพียง {balance} อาจไม่พอสำหรับงานนี้ แนะนำให้เติมเงินหรืออัปเกรดแพ็กเกจก่อน',
   'chat.amrLowBalance.rechargeCta': 'เติมเงิน',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -84,6 +84,8 @@ export const tr: Dict = {
   'chat.amrBalanceGate.signedOutMessage': 'Open Design Cloud ajanını kullanıyorsunuz — oturum açın, bu görev hemen başlayabilir.',
   'chat.amrBalanceGate.signInCta': 'Oturum aç',
   'chat.amrBalanceGate.watchingWallet': 'Bakiyeniz güncellenince otomatik olarak devam edeceğiz.',
+  'chat.amrScopeGate.signedOutMessage': 'Open Design Cloud\'da oturum açmadınız, bu nedenle bu projenin çalışacağı bir çalışma alanı yok.',
+  'chat.amrScopeGate.unresolvedMessage': 'Bu projenin hangi çalışma alanında çalıştığı doğrulanamadı, bu yüzden Open Design Cloud görevleri duraklatıldı.',
   'chat.amrLowBalance.title': 'Krediniz azalıyor',
   'chat.amrLowBalance.message': 'Yalnızca {balance} kaldı — bu görevi bitirmeye yetmeyebilir. Önce bakiye yükleyin veya planınızı yükseltin.',
   'chat.amrLowBalance.rechargeCta': 'Bakiye yükle',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -84,6 +84,8 @@ export const uk: Dict = {
   'chat.amrBalanceGate.signedOutMessage': 'Ви використовуєте агент Open Design Cloud — увійдіть, і це завдання одразу запуститься.',
   'chat.amrBalanceGate.signInCta': 'Увійти',
   'chat.amrBalanceGate.watchingWallet': 'Продовжимо автоматично, щойно баланс оновиться.',
+  'chat.amrScopeGate.signedOutMessage': 'Ви не увійшли в Open Design Cloud, тож для цього проєкту немає робочого простору для запуску.',
+  'chat.amrScopeGate.unresolvedMessage': 'Не вдалося визначити, у якому робочому просторі виконується цей проєкт, тому завдання Open Design Cloud призупинено.',
   'chat.amrLowBalance.title': 'Кредити закінчуються',
   'chat.amrLowBalance.message': 'Залишилося лише {balance} — ймовірно, не вистачить, щоб завершити завдання. Спершу поповніть баланс або покращте тариф.',
   'chat.amrLowBalance.rechargeCta': 'Поповнити',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -87,6 +87,8 @@ export const zhCN: Dict = {
   "chat.amrBalanceGate.signedOutMessage": "当前使用的是 Open Design Cloud 智能体，登录后这个任务马上就能开始。",
   "chat.amrBalanceGate.signInCta": "立即登录",
   "chat.amrBalanceGate.watchingWallet": "额度更新后将自动继续。",
+  "chat.amrScopeGate.signedOutMessage": "Open Design Cloud 尚未登录，这个项目暂时没有可用的工作区，任务无法开始。",
+  "chat.amrScopeGate.unresolvedMessage": "暂时无法确认这个项目归属哪个工作区，Open Design Cloud 任务已暂停。",
   "chat.amrLowBalance.title": "额度不多了",
   "chat.amrLowBalance.message": "额度仅剩 {balance}，可能不够完成这个任务，建议先充值或升级套餐。",
   "chat.amrLowBalance.rechargeCta": "去充值",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -87,6 +87,8 @@ export const zhTW: Dict = {
   "chat.amrBalanceGate.signedOutMessage": "目前使用的是 Open Design Cloud 智能體，登入後這個任務馬上就能開始。",
   "chat.amrBalanceGate.signInCta": "立即登入",
   "chat.amrBalanceGate.watchingWallet": "額度更新後將自動繼續。",
+  "chat.amrScopeGate.signedOutMessage": "Open Design Cloud 尚未登入，這個專案暫時沒有可用的工作區，任務無法開始。",
+  "chat.amrScopeGate.unresolvedMessage": "暫時無法確認這個專案歸屬哪個工作區，Open Design Cloud 任務已暫停。",
   "chat.amrLowBalance.title": "額度不多了",
   "chat.amrLowBalance.message": "額度僅剩 {balance}，可能不夠完成這個任務，建議先儲值或升級方案。",
   "chat.amrLowBalance.rechargeCta": "去儲值",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -2856,6 +2856,8 @@ export interface Dict {
   'chat.amrBalanceGate.signedOutMessage': string;
   'chat.amrBalanceGate.signInCta': string;
   'chat.amrBalanceGate.watchingWallet': string;
+  'chat.amrScopeGate.signedOutMessage': string;
+  'chat.amrScopeGate.unresolvedMessage': string;
   'chat.amrLowBalance.title': string;
   'chat.amrLowBalance.message': string;
   'chat.amrLowBalance.rechargeCta': string;

--- a/apps/web/src/runtime/amr-workspace-scope-gate.ts
+++ b/apps/web/src/runtime/amr-workspace-scope-gate.ts
@@ -1,0 +1,62 @@
+// Why an Open Design Cloud project run is held closed, and which remedy clears
+// it.
+//
+// The gate itself lives in ProjectView: an AMR run may only start once the
+// daemon has resolved the project's personal/team workspace authority, because
+// that authority is what the final spawn bills against (`21f452ffe`). Failing
+// closed there is deliberate and stays. Failing closed SILENTLY is the bug this
+// module exists to prevent: the send button went dead with no reason on screen
+// and no way out, while Home's equivalent dead end (`checkAmrBalanceGate` ->
+// `AmrBalanceDialog` reason `signed_out`) hands the user an in-app sign-in.
+//
+// This is a classifier, not a second gate: it never decides whether the send is
+// allowed, only how to explain a send that is already blocked.
+
+import type { WorkspaceContextState } from '../collab/useWorkspaceContext';
+import {
+  projectWorkspaceScopeAuthorizesAmr,
+  type ProjectWorkspaceScopeState,
+} from '../collab/useProjectWorkspaceScope';
+
+/**
+ * A blocked AMR composer, tagged by the remedy that clears it.
+ *
+ * `signed_out` — no Open Design Cloud session exists, so no workspace can own
+ *   the run. Cleared by signing in (the same action Home's balance gate uses).
+ * `unresolved` — a session exists (or its existence is itself unknown), but the
+ *   project's workspace authority did not resolve: an old daemon, a revoked
+ *   membership, a workspace-directory outage, or a project with no binding.
+ *   Cleared by re-reading the scope; an account action would be a guess.
+ */
+export type AmrWorkspaceScopeBlock =
+  | { kind: 'signed_out' }
+  | { kind: 'unresolved' };
+
+/**
+ * Classify a held-closed AMR composer, or return `null` when there is nothing
+ * to explain.
+ *
+ * `null` covers three distinct cases on purpose:
+ *   - the run does not need a workspace authority (non-AMR, or non-daemon mode),
+ *   - the authority resolved and the send is genuinely allowed,
+ *   - a read has not settled yet. A pre-answer frame must not accuse the user of
+ *     anything; both reads revalidate on a timer, so an answer always arrives.
+ */
+export function amrWorkspaceScopeBlock(input: {
+  requiresWorkspaceScope: boolean;
+  projectScope: ProjectWorkspaceScopeState;
+  workspaceIdentity: WorkspaceContextState;
+}): AmrWorkspaceScopeBlock | null {
+  const { requiresWorkspaceScope, projectScope, workspaceIdentity } = input;
+  if (!requiresWorkspaceScope) return null;
+  if (projectWorkspaceScopeAuthorizesAmr(projectScope.scope)) return null;
+  if (projectScope.loading) return null;
+  if (workspaceIdentity.loading) return null;
+  // A null context is only "signed out" when the identity read SUCCEEDED and
+  // said so. A null context carrying a failure means the identity is unknown,
+  // and offering a sign-in for an identity nobody read would be a guess — the
+  // 30s context poll settles the failure away and reclassifies this on its own.
+  const signedOut =
+    workspaceIdentity.context === null && workspaceIdentity.failure == null;
+  return signedOut ? { kind: 'signed_out' } : { kind: 'unresolved' };
+}

--- a/apps/web/tests/components/ChatPane.amr-scope-blocked.test.tsx
+++ b/apps/web/tests/components/ChatPane.amr-scope-blocked.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+
+/**
+ * The AMR workspace-scope gate must explain itself in the composer.
+ *
+ * `21f452ffe` disables the send button when an AMR project cannot resolve a
+ * personal/team workspace authority. Keeping it disabled is intended. Being
+ * SILENT about it is not: the user saw a dead grey button with no reason and no
+ * way out, while Home's equivalent dead end (`checkAmrBalanceGate` ->
+ * `AmrBalanceDialog` reason `signed_out`) hands over an in-app sign-in.
+ *
+ * So the blocked composer must render, next to the composer itself:
+ *   - a reason the user can read, and
+ *   - the remedy that actually clears that reason — the SAME `AmrLoginPill`
+ *     sign-in action and copy Home's balance gate uses, or a retry of the
+ *     workspace-scope read when the session is not the missing piece.
+ */
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { forwardRef } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ChatPane } from '../../src/components/ChatPane';
+import type { AmrWorkspaceScopeBlock } from '../../src/runtime/amr-workspace-scope-gate';
+import type { AppConfig } from '../../src/types';
+
+const fetchVelaLoginStatusMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../src/i18n', () => ({
+  useT: () => (key: string) => key,
+  useI18n: () => ({ locale: 'en', setLocale: () => undefined, t: (key: string) => key }),
+}));
+
+vi.mock('../../src/components/ChatComposer', () => ({
+  ChatComposer: forwardRef((_props, _ref) => <div data-testid="composer" />),
+}));
+
+vi.mock('../../src/providers/daemon', () => ({
+  fetchVelaLoginStatus: fetchVelaLoginStatusMock,
+}));
+
+let lastPillProps: {
+  signInLabel?: string;
+  amrEntrySourceDetail?: string;
+  metricsConsent?: boolean;
+  installationId?: string | null;
+  showActivationDetails?: boolean;
+} | null = null;
+vi.mock('../../src/components/AmrLoginPill', () => ({
+  AmrLoginPill: (props: {
+    signInLabel?: string;
+    amrEntrySourceDetail?: string;
+    metricsConsent?: boolean;
+    installationId?: string | null;
+    showActivationDetails?: boolean;
+  }) => {
+    lastPillProps = props;
+    return (
+      <button type="button" data-testid="amr-login-pill">
+        {props.signInLabel}
+      </button>
+    );
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  lastPillProps = null;
+});
+
+beforeEach(() => {
+  fetchVelaLoginStatusMock.mockResolvedValue({
+    loggedIn: false,
+    profile: 'prod',
+    user: null,
+    configPath: '',
+  });
+});
+
+function renderChat(
+  amrScopeBlock: AmrWorkspaceScopeBlock | null,
+  onRetryWorkspaceScope = vi.fn(),
+) {
+  render(
+    <ChatPane
+      messages={[]}
+      streaming={false}
+      error={null}
+      projectId="project-1"
+      projectFiles={[]}
+      onEnsureProject={async () => 'project-1'}
+      onSend={vi.fn()}
+      onStop={vi.fn()}
+      // Mirrors ProjectView: the gate holds the send action closed.
+      sendDisabled={amrScopeBlock != null}
+      amrScopeBlock={amrScopeBlock}
+      onRetryWorkspaceScope={onRetryWorkspaceScope}
+      conversations={[
+        { projectId: 'project-1', id: 'conv-1', title: 'Current', createdAt: 1, updatedAt: 1 },
+      ]}
+      activeConversationId="conv-1"
+      onSelectConversation={vi.fn()}
+      onDeleteConversation={vi.fn()}
+      config={{
+        agentId: 'amr',
+        agentCliEnv: {},
+        installationId: 'install-123',
+        telemetry: { metrics: true },
+      } as unknown as AppConfig}
+    />,
+  );
+  return { onRetryWorkspaceScope };
+}
+
+describe('ChatPane AMR workspace-scope notice', () => {
+  it('renders nothing while the gate is open', () => {
+    renderChat(null);
+
+    expect(screen.queryByTestId('amr-scope-blocked-notice')).toBeNull();
+  });
+
+  it('explains a missing Open Design Cloud session and offers the in-app sign-in', () => {
+    renderChat({ kind: 'signed_out' });
+
+    const notice = screen.getByTestId('amr-scope-blocked-notice');
+    // A reason the user can actually read, not just a dead button.
+    expect(notice.textContent).toContain('chat.amrScopeGate.signedOutMessage');
+    // ...and the remedy: the same sign-in action + copy Home's balance gate uses.
+    expect(screen.getByTestId('amr-login-pill')).toBeTruthy();
+    expect(lastPillProps?.signInLabel).toBe('chat.amrBalanceGate.signInCta');
+    expect(lastPillProps?.amrEntrySourceDetail).toBe('chat_balance_gate_sign_in');
+    expect(lastPillProps?.showActivationDetails).toBe(true);
+    expect(lastPillProps?.metricsConsent).toBe(true);
+    expect(lastPillProps?.installationId).toBe('install-123');
+  });
+
+  it('explains an unresolved workspace authority and offers a re-read of it', () => {
+    const { onRetryWorkspaceScope } = renderChat({ kind: 'unresolved' });
+
+    const notice = screen.getByTestId('amr-scope-blocked-notice');
+    expect(notice.textContent).toContain('chat.amrScopeGate.unresolvedMessage');
+    // Signing in is not the missing piece here, so the remedy is a retry of the
+    // workspace-scope read rather than an account action.
+    expect(screen.queryByTestId('amr-login-pill')).toBeNull();
+    const retry = screen.getByTestId('amr-scope-blocked-retry');
+    retry.click();
+    expect(onRetryWorkspaceScope).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProjectView, mergeSavedPreviewComment } from '../../src/components/ProjectView';
 import type { SettingsSection } from '../../src/components/SettingsDialog';
 import type { ProjectWorkspaceScopeState } from '../../src/collab/useProjectWorkspaceScope';
+import type { AmrWorkspaceScopeBlock } from '../../src/runtime/amr-workspace-scope-gate';
 import type { WorkspaceCollabContext } from '@open-design/contracts';
 import type {
   AgentInfo,
@@ -281,6 +282,7 @@ vi.mock('../../src/components/ChatPane', () => ({
     conversations,
     streaming,
     sendDisabled,
+    amrScopeBlock,
     queuedItems,
     previewComments,
     attachedComments,
@@ -297,6 +299,7 @@ vi.mock('../../src/components/ChatPane', () => ({
     conversations: Conversation[];
     streaming: boolean;
     sendDisabled?: boolean;
+    amrScopeBlock?: AmrWorkspaceScopeBlock | null;
     queuedItems?: Array<{
       id: string;
       prompt: string;
@@ -370,6 +373,7 @@ vi.mock('../../src/components/ChatPane', () => ({
             .join('\n')}
         </output>
         <output data-testid="attached-comment-count">{attached.length}</output>
+        <output data-testid="amr-scope-block">{amrScopeBlock?.kind ?? ''}</output>
         {retryTarget && onRetry ? (
           <button type="button" data-testid="chat-retry" onClick={() => onRetry(retryTarget)}>
             retry
@@ -828,6 +832,110 @@ describe('ProjectView conversation run isolation', () => {
     expect(screen.getByTestId('send-message')).toHaveProperty('disabled', true);
     fireEvent.click(screen.getByTestId('send-message'));
     expect(streamViaDaemon).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      'an unbound project',
+      {
+        loading: false,
+        scope: {
+          kind: 'unbound' as const,
+          projectId: project.id,
+          workspaceId: null,
+          context: null,
+        },
+      },
+    ],
+    [
+      'an old daemon',
+      { loading: false, scope: null, failure: 'unsupported' as const },
+    ],
+    [
+      'a workspace-directory outage',
+      { loading: false, scope: null, failure: 'unavailable' as const },
+    ],
+  ])(
+    'fails closed WITH a reason for AMR with %s, instead of silently',
+    async (_label, projectScope) => {
+      // The fail-closed behavior above is intended. Being silent about it is
+      // the bug: the composer must hand the chat surface a classified reason so
+      // it can explain the disabled send and offer the remedy that clears it.
+      conversationAMessages = [];
+      workspaceScopeMocks.projectScope = projectScope;
+
+      renderProjectView(
+        { ...config, agentId: 'amr' },
+        project,
+        [{
+          id: 'amr',
+          name: 'AMR',
+          bin: 'amr',
+          available: true,
+          models: [{ id: 'glm-5', label: 'GLM 5' }],
+        }],
+      );
+
+      await waitFor(() =>
+        expect(screen.getByTestId('active-conversation').textContent).toBe(
+          'conv-a',
+        ),
+      );
+      expect(screen.getByTestId('send-message')).toHaveProperty('disabled', true);
+      // No ambient workspace identity in this fixture: the account is signed
+      // out, so the reason routes to the in-app sign-in remedy.
+      expect(screen.getByTestId('amr-scope-block').textContent).toBe('signed_out');
+    },
+  );
+
+  it('reports an unresolved authority (not a sign-in prompt) while signed in', async () => {
+    conversationAMessages = [];
+    workspaceScopeMocks.ambientContext = teamWorkspaceContext(
+      'workspace-a',
+      'member-a',
+    );
+    workspaceScopeMocks.projectScope = {
+      loading: false,
+      scope: null,
+      failure: 'unavailable',
+    };
+
+    renderProjectView(
+      { ...config, agentId: 'amr' },
+      project,
+      [{
+        id: 'amr',
+        name: 'AMR',
+        bin: 'amr',
+        available: true,
+        models: [{ id: 'glm-5', label: 'GLM 5' }],
+      }],
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'),
+    );
+    expect(screen.getByTestId('send-message')).toHaveProperty('disabled', true);
+    expect(screen.getByTestId('amr-scope-block').textContent).toBe('unresolved');
+  });
+
+  it('keeps the composer silent for a non-AMR agent that cannot resolve a scope', async () => {
+    conversationAMessages = [];
+    workspaceScopeMocks.projectScope = {
+      loading: false,
+      scope: null,
+      failure: 'unavailable',
+    };
+
+    renderProjectView();
+
+    await waitFor(() =>
+      expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('send-message')).toHaveProperty('disabled', false),
+    );
+    expect(screen.getByTestId('amr-scope-block').textContent).toBe('');
   });
 
   it('uses the project-bound workspace instead of the ambient workspace for run authorization', async () => {

--- a/apps/web/tests/runtime/amr-workspace-scope-gate.test.ts
+++ b/apps/web/tests/runtime/amr-workspace-scope-gate.test.ts
@@ -1,0 +1,187 @@
+/**
+ * The composer's AMR workspace-scope gate must never fail SILENTLY.
+ *
+ * `21f452ffe` made an AMR project run require a resolved personal/team
+ * workspace authority, and correctly fails closed when that authority is
+ * unknown. What it did not do is say so: the send button just goes disabled,
+ * with no reason and no way out. Home has a route out of the same dead end
+ * (`checkAmrBalanceGate` -> the signed-out balance dialog's in-app sign-in);
+ * inside a project the user was stranded.
+ *
+ * This module is the classifier that turns "gate closed" into an explainable
+ * reason plus the remedy that actually clears it. It must classify, never
+ * relax: every case that authorizes AMR keeps returning `null`, and the
+ * disabled send button stays disabled.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type {
+  ProjectWorkspaceScope,
+  WorkspaceCollabContext,
+} from '@open-design/contracts';
+
+import { amrWorkspaceScopeBlock } from '../../src/runtime/amr-workspace-scope-gate';
+import type { ProjectWorkspaceScopeState } from '../../src/collab/useProjectWorkspaceScope';
+import type { WorkspaceContextState } from '../../src/collab/useWorkspaceContext';
+
+const PROJECT_ID = 'project-1';
+
+function collabContext(
+  workspaceId: string,
+  workspaceType: 'personal' | 'team',
+): WorkspaceCollabContext {
+  return {
+    workspaceId,
+    workspaceType,
+    workspaceMemberId: `member-${workspaceId}`,
+  } as WorkspaceCollabContext;
+}
+
+const personalScope: ProjectWorkspaceScope = {
+  kind: 'personal',
+  projectId: PROJECT_ID,
+  workspaceId: 'workspace-personal',
+  visibility: 'personal',
+  context: collabContext('workspace-personal', 'personal') as WorkspaceCollabContext & {
+    workspaceType: 'personal';
+  },
+};
+
+const teamScope: ProjectWorkspaceScope = {
+  kind: 'team',
+  projectId: PROJECT_ID,
+  workspaceId: 'workspace-team',
+  visibility: 'team',
+  context: collabContext('workspace-team', 'team') as WorkspaceCollabContext & {
+    workspaceType: 'team';
+  },
+};
+
+const unboundScope: ProjectWorkspaceScope = {
+  kind: 'unbound',
+  projectId: PROJECT_ID,
+  workspaceId: null,
+  context: null,
+};
+
+const unavailableScope: ProjectWorkspaceScope = {
+  kind: 'unavailable',
+  projectId: PROJECT_ID,
+  workspaceId: 'workspace-team',
+  visibility: 'team',
+  context: null,
+};
+
+function settled(scope: ProjectWorkspaceScope): ProjectWorkspaceScopeState {
+  return { loading: false, scope };
+}
+
+const signedOutIdentity: WorkspaceContextState = { context: null, loading: false };
+const signedInIdentity: WorkspaceContextState = {
+  context: collabContext('workspace-team', 'team'),
+  loading: false,
+};
+
+describe('amrWorkspaceScopeBlock', () => {
+  it('stays silent when the run does not need a workspace authority', () => {
+    expect(
+      amrWorkspaceScopeBlock({
+        requiresWorkspaceScope: false,
+        projectScope: settled(unboundScope),
+        workspaceIdentity: signedOutIdentity,
+      }),
+    ).toBeNull();
+  });
+
+  it.each([
+    ['personal', personalScope],
+    ['team', teamScope],
+  ])('stays silent when the project resolves a %s workspace', (_label, scope) => {
+    expect(
+      amrWorkspaceScopeBlock({
+        requiresWorkspaceScope: true,
+        projectScope: settled(scope),
+        workspaceIdentity: signedInIdentity,
+      }),
+    ).toBeNull();
+  });
+
+  it('stays silent while the scope read is still in flight', () => {
+    // A transient pre-answer frame must not accuse the user of anything.
+    expect(
+      amrWorkspaceScopeBlock({
+        requiresWorkspaceScope: true,
+        projectScope: { loading: true, scope: null },
+        workspaceIdentity: signedOutIdentity,
+      }),
+    ).toBeNull();
+  });
+
+  it('blames the missing Open Design Cloud session when there is no identity', () => {
+    // The reported dead end: signed out -> the daemon resolves no workspace for
+    // the project -> `unbound`. The remedy is the in-app sign-in Home offers.
+    expect(
+      amrWorkspaceScopeBlock({
+        requiresWorkspaceScope: true,
+        projectScope: settled(unboundScope),
+        workspaceIdentity: signedOutIdentity,
+      }),
+    ).toEqual({ kind: 'signed_out' });
+  });
+
+  it('blames the missing session for a bound project whose directory read fails', () => {
+    expect(
+      amrWorkspaceScopeBlock({
+        requiresWorkspaceScope: true,
+        projectScope: settled(unavailableScope),
+        workspaceIdentity: signedOutIdentity,
+      }),
+    ).toEqual({ kind: 'signed_out' });
+  });
+
+  it.each([
+    ['an old daemon', 'unsupported' as const],
+    ['a revoked scope response', 'forbidden' as const],
+    ['a workspace-directory outage', 'unavailable' as const],
+  ])('reports an unresolved authority for %s while signed in', (_label, failure) => {
+    expect(
+      amrWorkspaceScopeBlock({
+        requiresWorkspaceScope: true,
+        projectScope: { loading: false, scope: null, failure },
+        workspaceIdentity: signedInIdentity,
+      }),
+    ).toEqual({ kind: 'unresolved' });
+  });
+
+  it('reports an unresolved authority for an unbound project while signed in', () => {
+    expect(
+      amrWorkspaceScopeBlock({
+        requiresWorkspaceScope: true,
+        projectScope: settled(unboundScope),
+        workspaceIdentity: signedInIdentity,
+      }),
+    ).toEqual({ kind: 'unresolved' });
+  });
+
+  it('reports an unresolved authority when the identity read itself failed', () => {
+    // `context: null` WITH a failure is "unknown", not "signed out": offering a
+    // sign-in for an identity we never actually read would be a guess.
+    expect(
+      amrWorkspaceScopeBlock({
+        requiresWorkspaceScope: true,
+        projectScope: settled(unboundScope),
+        workspaceIdentity: { context: null, loading: false, failure: 'unavailable' },
+      }),
+    ).toEqual({ kind: 'unresolved' });
+  });
+
+  it('stays silent while the identity read has not settled yet', () => {
+    expect(
+      amrWorkspaceScopeBlock({
+        requiresWorkspaceScope: true,
+        projectScope: settled(unboundScope),
+        workspaceIdentity: { context: null, loading: true },
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/tests/useProjectWorkspaceScope.test.tsx
+++ b/apps/web/tests/useProjectWorkspaceScope.test.tsx
@@ -85,6 +85,7 @@ describe('useProjectWorkspaceScope', () => {
         loading: false,
         scope: null,
         failure: 'unsupported',
+        revalidate: expect.any(Function),
       });
     });
     oldDaemon.unmount();
@@ -97,6 +98,7 @@ describe('useProjectWorkspaceScope', () => {
         loading: false,
         scope: null,
         failure: 'forbidden',
+        revalidate: expect.any(Function),
       });
     });
     revoked.unmount();
@@ -109,6 +111,7 @@ describe('useProjectWorkspaceScope', () => {
         loading: false,
         scope: null,
         failure: 'unavailable',
+        revalidate: expect.any(Function),
       });
     });
     outage.unmount();
@@ -203,7 +206,11 @@ describe('useProjectWorkspaceScope', () => {
     });
 
     hook.rerender({ projectId: 'project-b' });
-    expect(hook.result.current).toEqual({ loading: true, scope: null });
+    expect(hook.result.current).toEqual({
+      loading: true,
+      scope: null,
+      revalidate: expect.any(Function),
+    });
   });
 
   it('revalidates the same project when the signed-in workspace member changes', async () => {
@@ -229,7 +236,11 @@ describe('useProjectWorkspaceScope', () => {
     act(() => {
       window.dispatchEvent(new Event(WORKSPACE_CONTEXT_REFRESH_EVENT));
     });
-    expect(hook.result.current).toEqual({ loading: true, scope: null });
+    expect(hook.result.current).toEqual({
+      loading: true,
+      scope: null,
+      revalidate: expect.any(Function),
+    });
 
     await act(async () => {
       memberNew.resolve(new Response(


### PR DESCRIPTION
## Why

**Use case.** Dogfooding `feat/workspace-team` with Open Design Cloud selected inside a project. I signed out (or just landed on a project whose workspace permission had not resolved), went back to the chat composer, and the send button was simply dead. No tooltip, no message, no button to press. I could not tell whether the app was broken, whether my prompt was invalid, or whether I had to do something — and there was nothing on screen to do.

**Pain.** `21f452ffe` (this branch only) added a correct fail-closed gate: an Open Design Cloud run may only start once the daemon has resolved the project's personal/team workspace authority, because that authority is what the final spawn bills against. `projectRunRequiresWorkspaceScope = mode === 'daemon' && agentId === 'amr'`, and only a `personal` / `team` answer from `GET /api/projects/:id/workspace-scope` authorizes the send. That scope resolves through `fetchVelaWorkspaceDirectory()`, which needs a real cloud session — so signed out, the scope is `unbound` (no binding) or `unavailable` (bound project, directory read failed) and `chat-send` is disabled forever.

The disabling is intended and this PR keeps it. What was missing is that the gate never said anything. Home has a route out of the same dead end — `checkAmrBalanceGate` returns `hard/signed_out`, and `AmrBalanceDialog` hands the user an in-app sign-in that resumes the parked task. Inside a project that route is only reachable *by pressing send*, and send is exactly what the gate disabled. `e2e/ui/amr-logout-requires-relogin.test.ts` exists to protect that flow (signed out → send → balance dialog → Sign in), which a permanently-disabled composer can never reach.

## What users will see

With Open Design Cloud selected in a project whose workspace can't be resolved, a short amber notice now appears directly above the message box, explaining why the task can't start — instead of a silently greyed-out send arrow.

- **Not signed in** → the notice says the cloud account isn't signed in, and offers the *same* **Sign in** button Home's balance gate uses (`AmrLoginPill`: spawns `vela login`, surfaces the activation link if the browser doesn't auto-open, polls until done). Signing in fires the workspace-context refresh, the project scope revalidates, and the composer unblocks on its own — no reload, no re-selecting the agent.
- **Signed in, but the workspace permission didn't resolve** (old daemon, revoked membership, workspace-directory outage) → the notice says so and offers **Retry**, which re-reads the project's workspace scope.

The send button itself is unchanged: still disabled, still not clickable, no existing interaction rearranged. This is purely an added explanation plus a reused entry point. Read-only viewers of a shared project don't see the notice (their composer is disabled by ownership, and signing in wouldn't change that).

## Surface area

- [x] **UI** — new composer-adjacent notice in `apps/web` (`AmrScopeBlockedNotice`)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`
- [x] **i18n keys** — 2 new keys × 19 locales
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

### CLI parity

No CLI surface applies, and this is not a "I'll do the CLI later". The PR adds no capability — it adds an explanation for an existing refusal. `od` never renders the composer and never sees a disabled button: the same authority decision already reaches CLI callers as a daemon HTTP answer (`GET /api/projects/:id/workspace-scope`, and `enforceRunWorkspaceMutation` on `POST /api/runs`), which is a machine-readable reason, not silence. There is no UI-only capability introduced here to mirror.

## Screenshots

_Pending a screenshot pass on a real client (signed-out AMR project). See "Adjacent issues" #2 for why no `tools-dev` runtime can currently reach the authorized state, which makes the blocked state the only one reproducible locally._

## Bug fix verification

- Red specs:
  - `apps/web/tests/runtime/amr-workspace-scope-gate.test.ts` (new)
  - `apps/web/tests/components/ChatPane.amr-scope-blocked.test.tsx` (new)
  - `apps/web/tests/components/ProjectView.run-isolation.test.tsx` (3 new cases)
- Did they go red before the source change and green after? **Yes.** Red run with the tests only, no source change, on top of `origin/feat/workspace-team`:
  ```
  FAIL tests/runtime/amr-workspace-scope-gate.test.ts
    Error: Cannot find module '../../src/runtime/amr-workspace-scope-gate'
  FAIL tests/components/ChatPane.amr-scope-blocked.test.tsx > explains a missing Open Design Cloud session and offers the in-app sign-in
  FAIL tests/components/ChatPane.amr-scope-blocked.test.tsx > explains an unresolved workspace authority and offers a re-read of it
  FAIL tests/components/ProjectView.run-isolation.test.tsx > fails closed WITH a reason for AMR with an unbound project, instead of silently
  FAIL tests/components/ProjectView.run-isolation.test.tsx > fails closed WITH a reason for AMR with an old daemon, instead of silently
  FAIL tests/components/ProjectView.run-isolation.test.tsx > fails closed WITH a reason for AMR with a workspace-directory outage, instead of silently
  FAIL tests/components/ProjectView.run-isolation.test.tsx > reports an unresolved authority (not a sign-in prompt) while signed in
   Test Files  3 failed (3)
        Tests  6 failed | 59 passed (65)
  ```
  After the fix, the same three files: `Test Files 3 passed (3) / Tests 77 passed (77)`.
- The pre-existing `'fails closed for AMR with %s'` case that asserts `disabled: true` was **not** touched and stays green. The new cases sit immediately next to it on purpose, so the pair reads as one invariant: *fail closed, and say why.*

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass (repo-wide)
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm --filter @open-design/web test` — `536 files / 5470 passed | 8 skipped`, 0 failures. Baseline measured on `origin/feat/workspace-team` before any edit was `534 files / 5450 passed`, so no pre-existing failure is being masked.
- No Playwright run (product asked for Playwright to stay off; the added coverage is Vitest-only by design).

## Adjacent issues (deliberately not in this PR)

1. **An unbound project blocks its own signed-in owner.** `reconcileUnboundProjectBeforeMutation` is only wired into `apps/daemon/src/routes/project/index.ts:3105` and `:3214` (duplicate / design-system copy). `POST /api/runs` is not — `runs.ts:584` calls `enforceRunWorkspaceMutation` directly, and `workspaceResourceMutationAllowed` returns `false` when the row is missing. So a genuinely unbound project hands a signed-in **owner** the disabled button plus a `403`. That is a daemon-side defect deserving its own red spec and its own PR; this PR only stops it from being silent (such an owner now gets the `unresolved` notice + Retry instead of nothing).
2. **No `tools-dev` runtime can reach the authorized AMR state.** `/api/workspace/context` has a dev stub and a `PUT` override, but `workspace-scope` always goes to vela, so e2e cannot drive this gate to the authorized side. Deliberately **not** stubbed here: stubbing it to `personal` merely trades the disabled button for a `403 WORKSPACE_PROJECT_PERMISSION_DENIED` — green bought with a lie. The test-infra gap needs its own decision.
3. **Chinese copy is provisional.** The two new zh-CN / zh-TW strings are drafted in the style of the neighbouring `chat.amrBalanceGate.*` keys but are not product-approved wording. Flagging for a copy pass before this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qpos7eduo1XJi2FcQNbK8A
