### PR TITLE
fix(e2e): converge the visual Design Files prelude instead of clicking once

### DIFF
--- a/e2e/lib/playwright/visual.ts
+++ b/e2e/lib/playwright/visual.ts
@@ -679,12 +679,33 @@ export async function gotoVisualWorkspace(page: Page): Promise<void> {
   await prepareVisualWorkspaceFileList(page);
 }
 
+/**
+ * Drive the workspace onto its Design Files tab, converging on that state
+ * instead of deciding once whether to click.
+ *
+ * `aria-selected` and the design-file rows both come off FileWorkspace's single
+ * `activeTab === DESIGN_FILES_TAB` expression, so probing the rows to decide
+ * whether to click was never asking the wrong question — the problem is that the
+ * answer can still change after the probe. The tab is *persisted*
+ * (`setPersistedActive`) and restored asynchronously, so a restore that lands
+ * after this helper's one click puts another tab back, and a one-shot helper has
+ * nothing left to re-click. Under the visual lane — fully parallel, `retries: 0`
+ * — that surfaced as a single capture timing out for 10s on `aria-selected`
+ * while its siblings, running this identical prelude, all passed.
+ *
+ * Clicking is safe to repeat: the tab's handler just sets the same active id.
+ */
+export async function activateVisualDesignFilesTab(page: Page): Promise<void> {
+  const tab = page.getByTestId('design-files-tab');
+  await expect(tab).toBeVisible({ timeout: T.medium });
+  await expect(async () => {
+    if ((await tab.getAttribute('aria-selected')) !== 'true') await tab.click();
+    await expect(tab).toHaveAttribute('aria-selected', 'true', { timeout: T.short });
+  }).toPass({ timeout: T.long });
+}
+
 export async function prepareVisualWorkspaceFileList(page: Page): Promise<void> {
-  const fileRow = page.getByTestId('design-file-row-index.html');
-  if (!(await fileRow.isVisible().catch(() => false))) {
-    await page.getByTestId('design-files-tab').click();
-  }
-  await expect(page.getByTestId('design-files-tab')).toHaveAttribute('aria-selected', 'true');
+  await activateVisualDesignFilesTab(page);
   // No pages dropdown to drive: 023937ef4 replaced the tab strip's pages
   // menu with a plain Design Files tab (#5517), deleting
   // `workspace-pages-menu-trigger` from the app and this helper alike. The


### PR DESCRIPTION
## Why

Fast-follow on #6162. That PR merged as `e22a2898f` and `Playwright visual (settings-workspace)` went red on the next run — `[P2] captures the settings BYOK surface` ([job 90321509369](https://github.com/nexu-io/open-design/actions/runs/30372896858/job/90321509369)), a 10s `aria-selected` timeout in the shared prelude:

```
Error: expect(locator).toHaveAttribute(expected) failed
Locator:  getByTestId('design-files-tab')
Expected: "true"
Timeout:  10000ms
  23 × locator resolved to <button role="tab" ... aria-selected="false" data-testid="design-files-tab" ...>
     - unexpected value "false"
> 687 |   await expect(page.getByTestId('design-files-tab')).toHaveAttribute('aria-selected', 'true');
```

I own the last commit on #6162, so I picked this up. The lane is not a merge-gate check, which is how it got past the "four required lanes green" bar.

**The defect is in the oracle, not the product.** `prepareVisualWorkspaceFileList` decided **once** whether to click the tab — a single instantaneous `isVisible()` probe of a file row — and then asserted a state that nothing retries. Any interleaving where the workspace's own tab reconciliation lands around that one click leaves the assertion permanently unsatisfiable for that attempt. The lane runs `OD_PLAYWRIGHT_FULLY_PARALLEL=1` with `retries: 0` and `expect.timeout: 10_000`, so such an interleaving reports as a hard failure rather than a flake.

Two details make the guard/assertion mismatch concrete. `FileWorkspace.tsx:3438` (`aria-selected`) and `:3719` (the panel that renders the rows) both derive from one `activeTab === DESIGN_FILES_TAB` expression, so the two conditions are equivalent *in settled DOM* — but the helper's guard read the rows while its assertion demanded the tab, so it could take a branch that its own assertion then contradicted. And the tab is persisted (`setPersistedActive` → `onTabsStateChange`) and reconciled in an effect, so "settled" is not guaranteed at the instant the helper looks.

### Why this is not a product regression from #6162

- Nothing in #6162 touches tab selection, tab persistence, or design-file row visibility. Its only `design-files.css` change deletes the hover cover-zoom (12 lines), which cannot affect visibility.
- `git diff 4a6653186..e22a2898f -- apps/web/src` filtered for `localStorage|activeTab|openTabs|restoreTab` returns nothing.
- 7 of the 8 captures that run this identical prelude passed, including both neighbouring BYOK cases.
- Locally at `--workers=1` the failing test **passes** (37s), confirming it is load-dependent rather than deterministic.
- The lane also failed at `c2352b6bc` and `3f6629b99` for an unrelated cause (the #5971 `BYOK` → `API providers` rename timing out at 2.0m, which #6174 fixed). There is exactly **one** green run — `4a6653186` — between that repair and this failure, so the clean-baseline claim rests on a single data point.

## What users will see

Nothing. Test-harness only.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Bug fix verification

- Failing test: `e2e/ui/visual-settings.test.ts` → `[P2] captures the settings BYOK surface`, via `e2e/lib/playwright/visual.ts` → `prepareVisualWorkspaceFileList`.
- **A deterministic red spec was not cheap to write here.** The failure is a load-dependent interleaving in a Playwright prelude, and it does not reproduce at `--workers=1` — the only configuration I was cleared to run locally (the visual lane had to stay off for disk reasons; I was given a single-lane exception). Reproducing it would mean re-creating the fully-parallel lane under CI-like load, and a synthetic red would have to fake the race by driving the persisted tab state from the test, which asserts the harness rather than the product.
- Instead the red evidence is the CI job above, and the fix removes the unretried branch outright rather than tuning a timeout: the helper now converges on `aria-selected === 'true'`, clicking only while it is not yet true. Repeat clicks are provably safe — the handler is `setPersistedActive(DESIGN_FILES_TAB)`, idempotent.

## Validation

- `pnpm --filter @open-design/e2e typecheck` — pass.
- Full `settings-workspace` lane locally, both files, `--workers=1`: **17 passed, 1 failed**. The previously-failing BYOK capture is green.
- The one local failure is a **different** test — `visual-workspace.test.ts:268 [P1] Avatar menu stays a model picker for a signed-in Open Design account`, failing on `expect(menu).not.toContainText('$247.51')`. I could not clear it, and I am flagging it rather than claiming it away:
  - it cannot plausibly be caused by this change, which only converges the Design Files tab and cannot make the avatar popover render an account row;
  - CI passed this exact test on `e22a2898f` (`✓ 16 … (17.5s)`), i.e. on the very commit this branch is cut from, with the old helper;
  - my local run put all 18 tests of both files through a **single** worker, the maximum cross-file carry-over configuration, which `e2e/AGENTS.md` names as a known hazard and which is *not* how CI runs this lane (fully parallel).
  - An isolated re-run to confirm carry-over failed in `createPlaywrightToolsDevSuite` (runtime would not start) and I stopped there — local disk was down to 4.0Gi against a 3Gi hard floor, so I did not keep spending Playwright runs on it.
- Playwright artifacts cleaned after each run (`scripts/playwright.ts clean` plus the report/result dirs).

## Adjacent issues

- `e2e/lib/playwright/workspace.ts:8` `openAllProjectFiles` has the same click-once-then-assert shape and the same latent race. Deliberately left alone: it feeds the UI P0 lanes currently under separate triage, and changing shared-helper semantics mid-triage would muddy that attribution. Worth a follow-up once those lanes are settled.
- The gap that let this through is that `Playwright visual (settings-workspace)` is not one of the merge-gate checks, so a green "required lanes" read says nothing about it. Worth deciding whether it should gate.
