### PR TITLE
fix(web): partition the workspace plan nameplate like the wallet

### DIFF
--- a/apps/web/src/collab/team-plan.ts
+++ b/apps/web/src/collab/team-plan.ts
@@ -35,7 +35,17 @@ export function hasTeamPlan(
 
 /** The tier sources a surface may have in scope; pass whichever it holds. */
 export interface PlanTierSources {
-  /** `GET /api/workspace/billing` — the workspace's live subscription. */
+  /**
+   * `GET /api/workspace/billing`, PROJECTED onto the workspace in scope by
+   * `workspaceBillingSummaryForContext` (or `useWorkspaceBilling`).
+   *
+   * The raw `response.summary` is an ACCOUNT read — the contract pins its
+   * `workspaceId` to null and the daemon answers every `?workspaceId=` with the
+   * same unscoped read — so its `membershipTier` is NOT a workspace plan and
+   * must not be passed here. It outranks the context hint below precisely
+   * because a projected summary is the more specific workspace answer; handing
+   * it an account tier inverts that and pins the plan to the account.
+   */
   billing?: WorkspaceBillingSummary | null;
   /** `GET /api/workspace/context` — carries the same raw plan id as billing. */
   context?: WorkspaceCollabContext | null;
@@ -48,11 +58,13 @@ export interface PlanTierSources {
  *
  * Three sources report a tier and they disagree by design. vela's login-status
  * projection is ACCOUNT-scoped, so a user whose entitlements are held by a TEAM
- * workspace reads `free` — or nothing at all — there. The workspace billing
- * summary and the collab context both report the WORKSPACE plan id
+ * workspace reads `free` — or nothing at all — there. The workspace-projected
+ * billing summary and the collab context both report the WORKSPACE plan id
  * (`team_plus`, …), so they win over it, in that order. Reading the account
  * projection as authoritative is what showed free-user surfaces to paid team
  * accounts.
+ *
+ * `sources.billing` must already be workspace-projected — see its field doc.
  *
  * Every step falls through on an EMPTY STRING, not only on null: B reports an
  * empty `membershipTier` for a workspace with no active subscription, and an

--- a/apps/web/src/collab/useWorkspaceContext.ts
+++ b/apps/web/src/collab/useWorkspaceContext.ts
@@ -10,6 +10,7 @@ import type {
   WorkspaceInvalidationSsePayload,
 } from '@open-design/contracts';
 import { coalescedGet, forceCoalescedGet } from '../lib/coalesced-get';
+import { isTeamPlanTier } from './team-plan';
 import { fetchTeamProjectsCatalog } from './team-projects-catalog';
 import { useWorkspaceInvalidation } from './workspace-events';
 import {
@@ -710,61 +711,102 @@ export function useWorkspaceBillingResponse(
 }
 
 /**
- * Compatibility view used by plan/upgrade surfaces. Account wallet metadata
- * remains untouched, while an authorized workspace snapshot overrides only
- * the plan/status fields that are workspace-scoped.
+ * Return the billing summary PROJECTED onto the workspace `context` names.
+ *
+ * `WorkspaceBillingSummary` is an ACCOUNT read: the contract pins its
+ * `workspaceId` to null, and the daemon answers every `?workspaceId=` with the
+ * same unscoped `vela billing summary`. Its `membershipTier` therefore says
+ * what the ACCOUNT subscribes to, never what THIS workspace subscribes to — an
+ * account holding a personal Plus reports `plus` while the user stands in a
+ * brand-new, unpaid team workspace. Handing that field to a workspace surface
+ * produces a nameplate that cannot change when the workspace changes, because
+ * it was never about the workspace: the 专业版 Plus badge on a 免费 workspace,
+ * beside a wallet figure that was correct precisely because money already
+ * routes through `workspaceBillingBalanceUsd`.
+ *
+ * Plan and money are partitioned on the same key — `workspaceId` +
+ * `workspaceMemberId`:
+ *
+ *  • personal workspace — the account IS the scope, so the summary passes
+ *    through untouched. (A team-namespaced tier is deliberately kept here:
+ *    `hasTeamPlan` offers the team surfaces to a personal workspace that holds
+ *    a team plan.)
+ *  • team workspace — the plan comes from the context-authorized snapshot.
+ *    Without one, the account tier may stand in ONLY when it is itself
+ *    team-namespaced (`isTeamPlanTier`), because a personal tier
+ *    (`free`/`plus`/`pro`/`max`) describes the account's own subscription and
+ *    cannot name a team workspace's plan. Anything else becomes `''` — the
+ *    contract's "this source does not know" — so `resolvePlanTier` falls
+ *    through to the workspace-scoped `context.planId` / `context.billingState`
+ *    instead of answering a workspace question with an account tier.
+ *
+ * That fallback is load-bearing, not laxness: `workspaceSnapshot` is an
+ * additive capability, and B omits `planId`/`billingState` from a non-owner's
+ * context, so for a paying MEMBER on an older daemon/CLI a team-namespaced
+ * account tier is the only surviving evidence that their team is paid. Dropping
+ * it flashed the free-tier upsell at Team Plus members (飞书 P0, covered by
+ * `tests/components/App.amr-plan-tier.test.tsx`).
+ *
+ * Money fields are left alone: they are already documented as account metadata
+ * and every workspace surface reads them through `workspaceBillingBalanceUsd`.
  */
-export function useWorkspaceBilling(): WorkspaceBillingSummary | null {
-  const response = useWorkspaceBillingResponse();
-  if (!response) return null;
+export function workspaceBillingSummaryForContext(
+  response: WorkspaceBillingResponse | null | undefined,
+  context: WorkspaceCollabContext | null | undefined,
+): WorkspaceBillingSummary | null {
+  if (!response || !context) return null;
   const summary = response.summary;
-  const snapshot = response.workspaceSnapshot;
-  const runtime = response.workspaceRuntime;
-  if (
-    runtime &&
-    (
-      !workspaceBillingRuntimeProjectionIsUsable(runtime) ||
-      !snapshot ||
-      snapshot.workspaceId !== runtime.workspaceId ||
-      snapshot.workspaceMemberId !== runtime.workspaceMemberId
-    )
-  ) {
-    return null;
-  }
+  if (context.workspaceType !== 'team') return summary ?? null;
+  const snapshot = workspaceBillingSnapshotForContext(response, context);
   const snapshotTier =
     snapshot?.billing.planId?.trim()
     || (snapshot?.billing.billingState === 'free' ? 'free' : '');
-  if (!snapshotTier && !summary) return null;
+  const accountTier = summary?.membershipTier?.trim() ?? '';
+  const teamNamespacedAccountTier = isTeamPlanTier(accountTier) ? accountTier : '';
+  const scopedTier = snapshotTier || teamNamespacedAccountTier;
   if (summary) {
-    return snapshotTier
-      ? {
-          ...summary,
-          membershipTier: snapshotTier,
-          subscriptionStatus:
-            snapshot?.billing.billingState ?? summary.subscriptionStatus,
-        }
-      : summary;
+    return {
+      ...summary,
+      membershipTier: scopedTier,
+      subscriptionStatus: snapshotTier
+        ? snapshot?.billing.billingState ?? ''
+        : scopedTier
+          ? summary.subscriptionStatus
+          : '',
+    };
   }
+  // Account metadata is independently nullable from workspace state, so a
+  // proven workspace plan must survive an account-summary outage.
+  if (!snapshot) return null;
   return {
     workspaceId: null,
     membershipTier: snapshotTier,
     totalAvailableCredits: 0,
     subscriptionCredits: 0,
     rechargeCredits: 0,
-    balanceUsd: snapshot?.wallet.balanceUsd ?? '0',
-    subscriptionStatus: snapshot?.billing.billingState ?? '',
+    balanceUsd: snapshot.wallet.balanceUsd,
+    subscriptionStatus: snapshot.billing.billingState ?? '',
     availableActions: [],
-    workspaceBalance: snapshot
-      ? {
-          workspaceId: snapshot.workspaceId,
-          workspaceMemberId: snapshot.workspaceMemberId,
-          balanceUsd: snapshot.wallet.balanceUsd,
-          billingScopeVersion: 2,
-          expiresAt: snapshot.wallet.expiresAt,
-          updatedAt: snapshot.wallet.updatedAt,
-        }
-      : null,
+    workspaceBalance: {
+      workspaceId: snapshot.workspaceId,
+      workspaceMemberId: snapshot.workspaceMemberId,
+      balanceUsd: snapshot.wallet.balanceUsd,
+      billingScopeVersion: 2,
+      expiresAt: snapshot.wallet.expiresAt,
+      updatedAt: snapshot.wallet.updatedAt,
+    },
   };
+}
+
+/**
+ * The ambient-navigation view used by plan/upgrade surfaces: the billing
+ * summary projected onto the workspace the shell is currently in. See
+ * `workspaceBillingSummaryForContext` for the partition rule.
+ */
+export function useWorkspaceBilling(): WorkspaceBillingSummary | null {
+  const { context } = useWorkspaceContext();
+  const response = useWorkspaceBillingResponse();
+  return workspaceBillingSummaryForContext(response, context);
 }
 
 /**

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -139,6 +139,7 @@ import {
   useWorkspaceBillingResponse,
   useWorkspaceContext,
   workspaceBillingBalanceUsd,
+  workspaceBillingSummaryForContext,
 } from '../collab/useWorkspaceContext';
 import { useWorkspaceInvalidation } from '../collab/workspace-events';
 import {
@@ -588,7 +589,15 @@ export function EntryShell({
   const workspaceContextRef = useRef(workspaceContext);
   workspaceContextRef.current = workspaceContext;
   const workspaceBillingResponse = useWorkspaceBillingResponse();
-  const workspaceBilling = workspaceBillingResponse?.summary ?? null;
+  // Plan and money are both workspace-scoped questions, so both go through a
+  // context-partitioned projection. `response.summary` on its own is an ACCOUNT
+  // read (`workspaceId: null` by contract) — feeding it to the rail's plan
+  // nameplate is what kept a personal Plus badge on a 免费 workspace while the
+  // 额度 row beside it correctly followed the switch.
+  const workspaceBilling = workspaceBillingSummaryForContext(
+    workspaceBillingResponse,
+    workspaceContext,
+  );
   const workspaceBalanceUsd = workspaceBillingBalanceUsd(
     workspaceBillingResponse,
     workspaceContext,

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -158,6 +158,7 @@ import {
   useWorkspaceBillingResponse,
   useWorkspaceContext,
   workspaceBillingBalanceUsd,
+  workspaceBillingSummaryForContext,
 } from '../collab/useWorkspaceContext';
 import { resolvePlanTier } from '../collab/team-plan';
 import { planBadgeTierForLabel } from './PlanWordmark';
@@ -1630,7 +1631,13 @@ export function SettingsDialog({
   // real balance into the number. `useWorkspaceBillingResponse` carries the
   // explicit v2 workspace-wallet source independently from account metadata.
   const workspaceBillingResponse = useWorkspaceBillingResponse();
-  const workspaceBilling = workspaceBillingResponse?.summary ?? null;
+  // Same partition for the plan half: `response.summary` is an ACCOUNT read, so
+  // the AMR card's plan badge and both upgrade routes must consume it projected
+  // onto the selected workspace. See `workspaceBillingSummaryForContext`.
+  const workspaceBilling = workspaceBillingSummaryForContext(
+    workspaceBillingResponse,
+    workspaceContext,
+  );
   const showWorkspaceSettings = canShowWorkspaceSettings(workspaceContext);
   // The 「升级」 buttons on the AMR model card route through
   // `workspaceUpgradeUrl` — the one decision point every upgrade affordance

--- a/apps/web/tests/components/EntryShell.workspace-plan-badge-scope.test.tsx
+++ b/apps/web/tests/components/EntryShell.workspace-plan-badge-scope.test.tsx
@@ -1,0 +1,375 @@
+// @vitest-environment jsdom
+//
+// Switching workspaces must move the PLAN nameplate, not just the money.
+//
+// Reported shape: a workspace Vela Web shows as 免费 (订阅状态:免费, 升级团队套餐
+// CTA, US$0.00) rendered as 专业版 Plus in the client's account menu — while the
+// 额度 row in that same card correctly read $0.00. "为啥额度是对的?" is the whole
+// diagnosis: money and plan travel different paths, and only money is partitioned
+// by workspace.
+//
+// `GET /api/workspace/billing` answers with THREE independently scoped things
+// (packages/contracts/src/api/collab.ts):
+//   • `summary`      — the caller's VELA ACCOUNT billing (`workspaceId: null`
+//                      by contract; the daemon reads it with one unscoped
+//                      `fetchBilling()` regardless of `?workspaceId=`), so it
+//                      is byte-identical for every workspace of one account.
+//   • `workspaceBalance` / `workspaceSnapshot` — one backend-proven projection
+//                      for the exact workspace + member.
+//
+// So an account holding a personal Plus subscription reports
+// `summary.membershipTier === 'plus'` while standing in a brand-new, unpaid team
+// workspace. Any surface that reads the plan off `summary` shows Plus there
+// forever — the value cannot change when the workspace changes, because it was
+// never about the workspace.
+//
+// This test drives the real wiring (EntryShell → EntryNavRail) across a
+// workspace switch and asserts both halves of the card agree on the workspace
+// they are describing.
+
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import {
+  buildWorkspacePermissions,
+  buildWorkspaceSeatSummary,
+  type WorkspaceBillingResponse,
+  type WorkspaceBillingSummary,
+  type WorkspaceCollabContext,
+} from '@open-design/contracts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EntryShell } from '../../src/components/EntryShell';
+import { RAIL_OPEN_STORAGE_KEY } from '../../src/components/entryRailBridge';
+import {
+  notifyWorkspaceContextRefresh,
+  resetTeamProjectsCache,
+  resetWorkspaceBillingCache,
+  resetWorkspaceContextCache,
+} from '../../src/collab/useWorkspaceContext';
+import { resetWorkspaceDirectoryCache } from '../../src/components/EntryNavRail';
+import { resetCoalescedGet } from '../../src/lib/coalesced-get';
+import { I18nProvider } from '../../src/i18n';
+import type { AgentInfo, AppConfig } from '../../src/types';
+
+const originalFetch = globalThis.fetch;
+const originalResizeObserver = globalThis.ResizeObserver;
+
+class ResizeObserverMock {
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+/**
+ * A team workspace as B reports it on `GET /api/workspace/context`. `owner` so
+ * B fills in the per-workspace entitlement fields (`billingState` / `planId`);
+ * it omits them for non-owners.
+ */
+function teamContext(
+  workspaceId: string,
+  entitlement: { billingState: 'active' | 'free'; planId: string | null },
+): WorkspaceCollabContext {
+  const role = 'owner' as const;
+  const lifecycleState = 'active' as const;
+  return {
+    workspaceId,
+    workspaceType: 'team',
+    workspaceMemberId: `member-${workspaceId}`,
+    role,
+    memberStatus: 'active',
+    lifecycleState,
+    billingState: entitlement.billingState,
+    planId: entitlement.planId,
+    providerMode: 'platform_credits',
+    seatSummary: buildWorkspaceSeatSummary({ seatLimit: 5, usedSeats: 1 }),
+    permissions: buildWorkspacePermissions({ role, lifecycleState }),
+    teamName: workspaceId,
+    displayName: 'Plus Account',
+  };
+}
+
+/**
+ * The account-scoped half of the billing response. Identical for every
+ * workspace — that is the point. This account pays for a PERSONAL Plus.
+ */
+const ACCOUNT_PLUS_SUMMARY: WorkspaceBillingSummary = {
+  workspaceId: null,
+  membershipTier: 'plus',
+  totalAvailableCredits: 4_200_000,
+  subscriptionCredits: 4_200_000,
+  rechargeCredits: 0,
+  balanceUsd: '42.00',
+  subscriptionStatus: 'active',
+  availableActions: ['billing_portal'],
+  workspaceBalance: null,
+};
+
+function billingResponse(
+  workspaceId: string,
+  workspacePlan: { billingState: 'active' | 'free'; planId: string | null },
+  walletUsd: string,
+): WorkspaceBillingResponse {
+  const workspaceMemberId = `member-${workspaceId}`;
+  return {
+    summary: { ...ACCOUNT_PLUS_SUMMARY },
+    workspaceBalance: {
+      workspaceId,
+      workspaceMemberId,
+      balanceUsd: walletUsd,
+      billingScopeVersion: 2,
+      expiresAt: null,
+      updatedAt: '2026-07-28T14:30:00.000Z',
+    },
+    workspaceSnapshot: {
+      schemaVersion: 1,
+      workspaceId,
+      workspaceMemberId,
+      billingScopeVersion: 2,
+      billing: workspacePlan,
+      wallet: {
+        balanceUsd: walletUsd,
+        expiresAt: null,
+        updatedAt: '2026-07-28T14:30:00.000Z',
+      },
+      revisions: { billing: `b-${workspaceId}`, wallet: `w-${workspaceId}` },
+    },
+  };
+}
+
+function agent(): AgentInfo {
+  return {
+    id: 'amr',
+    name: 'Open Design AMR',
+    bin: 'amr',
+    available: true,
+    models: [{ id: 'glm-5', label: 'GLM 5' }],
+  };
+}
+
+function config(): AppConfig {
+  return {
+    mode: 'daemon',
+    agentId: 'amr',
+    agentModels: { amr: { model: 'glm-5' } },
+    apiProtocol: 'anthropic',
+    apiProtocolConfigs: {},
+    apiKey: '',
+    baseUrl: '',
+    model: '',
+    skillId: null,
+    designSystemId: null,
+    theme: 'system',
+  };
+}
+
+/**
+ * Scope queries to the open account menu's billing card. A pure read — the
+ * menu is opened once, by hand, and `useDismissOnOutsideInteraction` only
+ * closes it on a pointerdown outside or Escape, so it survives the switch.
+ */
+function billingCard() {
+  const el = document.querySelector('.entry-nav-rail__menu-credits');
+  if (!el) throw new Error('billing card is not rendered');
+  return within(el as HTMLElement);
+}
+
+/**
+ * The tier the nameplate badge is drawing. `PlanWordmark` is decorative
+ * (`aria-hidden`), so the viewBox width is what distinguishes the wordmarks:
+ * free 107, pro 108, plus 114, team 136.
+ */
+const BADGE_VIEWBOX_WIDTH: Record<string, string> = {
+  free: '0 0 107 49',
+  pro: '0 0 108 49',
+  plus: '0 0 114 49',
+  team: '0 0 136 49',
+};
+
+function accountRowBadgeViewBox(): string | null {
+  const badge = document
+    .querySelector('.entry-nav-rail__account-trigger')
+    ?.querySelector('svg.plan-wordmark');
+  return badge?.getAttribute('viewBox') ?? null;
+}
+
+/** A: a team workspace that really holds a Team Plus subscription. */
+const PAID_TEAM = teamContext('workspace-paid', {
+  billingState: 'active',
+  planId: 'team_plus',
+});
+/**
+ * B: the reported workspace — brand new, nothing paid for. B reports an
+ * unsubscribed workspace as `billingState: 'free'` with a null planId.
+ */
+const FREE_TEAM = teamContext('workspace-free', {
+  billingState: 'free',
+  planId: null,
+});
+
+interface Harness {
+  /** Point `/api/workspace/context` at another workspace, then re-read. */
+  switchTo: (context: WorkspaceCollabContext) => Promise<void>;
+  /** The open account menu's billing card. */
+  card: () => ReturnType<typeof within>;
+}
+
+/**
+ * Mount the real home shell against a two-workspace account and open the
+ * account menu. The menu stays open for the rest of the case:
+ * `useDismissOnOutsideInteraction` closes it only on a pointerdown outside or
+ * Escape, neither of which a workspace switch produces.
+ */
+async function mountHomeShell(initial: WorkspaceCollabContext): Promise<Harness> {
+  let currentContext = initial;
+  let contextReads = 0;
+  const billingReads: string[] = [];
+
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.endsWith('/api/workspace/context')) {
+      contextReads += 1;
+      return jsonResponse({ context: currentContext });
+    }
+    if (url.includes('/api/workspace/billing?')) {
+      const workspaceId =
+        new URL(url, 'http://open-design.test').searchParams.get('workspaceId') ?? '';
+      billingReads.push(workspaceId);
+      if (workspaceId === PAID_TEAM.workspaceId) {
+        return jsonResponse(
+          billingResponse(workspaceId, { billingState: 'active', planId: 'team_plus' }, '12.34'),
+        );
+      }
+      if (workspaceId === FREE_TEAM.workspaceId) {
+        return jsonResponse(
+          billingResponse(workspaceId, { billingState: 'free', planId: null }, '0'),
+        );
+      }
+      throw new Error(`unexpected billing scope ${url}`);
+    }
+    if (url.endsWith('/api/workspace/projects/team')) return jsonResponse({ projects: [] });
+    if (url.endsWith('/api/plugins')) return jsonResponse({ plugins: [] });
+    if (url.endsWith('/api/mcp/servers')) return jsonResponse({ servers: [] });
+    if (url.endsWith('/api/community/discord')) return jsonResponse({ stale: true });
+    if (url.endsWith('/api/github/open-design')) return jsonResponse({ stale: true });
+    return jsonResponse({});
+  }) as typeof fetch;
+
+  render(
+    <I18nProvider initial="zh-CN">
+      <EntryShell
+        skills={[]}
+        designTemplates={[]}
+        designSystems={[]}
+        projects={[]}
+        templates={[]}
+        promptTemplates={[]}
+        defaultDesignSystemId={null}
+        connectors={[]}
+        connectorsLoading={false}
+        config={config()}
+        agents={[agent()]}
+        daemonLive
+        onModeChange={vi.fn()}
+        onAgentChange={vi.fn()}
+        onAgentModelChange={vi.fn()}
+        onApiProtocolChange={vi.fn()}
+        onApiModelChange={vi.fn()}
+        onConfigPersist={vi.fn()}
+        onRefreshAgents={vi.fn(() => [agent()])}
+        onCreateProject={vi.fn(async () => true)}
+        onCreatePluginShareProject={vi.fn()}
+        onImportClaudeDesign={vi.fn()}
+        onOpenProject={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDeleteProject={vi.fn()}
+        onRenameProject={vi.fn()}
+        onChangeDefaultDesignSystem={vi.fn()}
+        onPersistComposioKey={vi.fn()}
+        onOpenSettings={vi.fn()}
+        onCompleteOnboarding={vi.fn()}
+      />
+    </I18nProvider>,
+  );
+
+  await waitFor(() => expect(contextReads).toBeGreaterThan(0));
+  await waitFor(() => expect(billingReads).toContain(initial.workspaceId));
+  fireEvent.click(await screen.findByTestId('entry-nav-account'));
+  await waitFor(() => expect(billingCard()).toBeTruthy());
+
+  return {
+    card: billingCard,
+    switchTo: async (next) => {
+      currentContext = next;
+      act(() => notifyWorkspaceContextRefresh());
+      await waitFor(() => expect(billingReads).toContain(next.workspaceId));
+    },
+  };
+}
+
+describe('account menu plan nameplate follows the selected workspace', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/');
+    window.localStorage.setItem(RAIL_OPEN_STORAGE_KEY, 'true');
+    globalThis.ResizeObserver = ResizeObserverMock as typeof ResizeObserver;
+    resetCoalescedGet();
+    resetWorkspaceContextCache();
+    resetWorkspaceBillingCache();
+    resetTeamProjectsCache();
+    resetWorkspaceDirectoryCache();
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.fetch = originalFetch;
+    globalThis.ResizeObserver = originalResizeObserver;
+    window.localStorage.clear();
+    resetCoalescedGet();
+    resetWorkspaceContextCache();
+    resetWorkspaceBillingCache();
+    resetTeamProjectsCache();
+    resetWorkspaceDirectoryCache();
+    vi.restoreAllMocks();
+  });
+
+  // The A side of the report: the nameplate answers a WORKSPACE question, so a
+  // personal Plus subscription must not name a team workspace's plan. The label
+  // names the plan FAMILY (团队版) while the badge keeps the tier word — #5517's
+  // split, so `team_plus` intentionally pairs 团队版 with the PLUS wordmark.
+  it('names the workspace subscription, not the account subscription', async () => {
+    const home = await mountHomeShell(PAID_TEAM);
+
+    await waitFor(() => expect(home.card().getByText('$12.34')).toBeTruthy());
+    const card = home.card();
+    expect(card.queryByText('专业版')).toBeNull();
+    expect(card.getByText('团队版')).toBeTruthy();
+    expect(accountRowBadgeViewBox()).toBe(BADGE_VIEWBOX_WIDTH.plus);
+  });
+
+  // The B side: the exact reported sequence. Switching away from a paid
+  // workspace must move the nameplate, not only the wallet.
+  it('moves both the wallet and the nameplate when the workspace switches', async () => {
+    const home = await mountHomeShell(PAID_TEAM);
+    await waitFor(() => expect(home.card().getByText('$12.34')).toBeTruthy());
+
+    await home.switchTo(FREE_TEAM);
+
+    // The money half already follows the switch — that is the half the reporter
+    // saw working ("但是额度是对的").
+    await waitFor(() => expect(home.card().getByText('$0.00')).toBeTruthy());
+
+    // The plan half must follow it too. Before the fix this still read
+    // 专业版 + the PLUS wordmark, because it came from the account summary
+    // that cannot change when the workspace does.
+    const card = home.card();
+    expect(card.queryByText('专业版')).toBeNull();
+    expect(card.queryByText('团队版')).toBeNull();
+    expect(card.getByText('免费')).toBeTruthy();
+    expect(accountRowBadgeViewBox()).toBe(BADGE_VIEWBOX_WIDTH.free);
+  });
+});

--- a/apps/web/tests/useWorkspaceBilling.scope.test.tsx
+++ b/apps/web/tests/useWorkspaceBilling.scope.test.tsx
@@ -17,6 +17,7 @@ import {
   useWorkspaceBillingResponse,
   workspaceBillingBalanceUsd,
   workspaceBillingSnapshotForContext,
+  workspaceBillingSummaryForContext,
 } from '../src/collab/useWorkspaceContext';
 
 function teamContext(workspaceId: string): WorkspaceCollabContext {
@@ -108,6 +109,99 @@ class MockWorkspaceEventSource {
 
   close(): void {}
 }
+
+describe('workspaceBillingSummaryForContext — plan is partitioned like money', () => {
+  function snapshotFor(
+    workspaceId: string,
+    billing: { billingState: string | null; planId: string | null },
+  ) {
+    return {
+      schemaVersion: 1 as const,
+      workspaceId,
+      workspaceMemberId: `member-${workspaceId}`,
+      billingScopeVersion: 2 as const,
+      billing,
+      wallet: { balanceUsd: '0', expiresAt: null, updatedAt: null },
+      revisions: { billing: 'b', wallet: 'w' },
+    } as unknown as WorkspaceBillingResponse['workspaceSnapshot'];
+  }
+
+  const personalPlusAccount = {
+    ...billingResponse('workspace-a', '0').summary,
+    membershipTier: 'plus',
+  };
+
+  // The reported bug: `summary` is an ACCOUNT read, so a personal Plus cannot
+  // name a team workspace's subscription however many times it is re-fetched.
+  it('never lets a personal account tier name a team workspace plan', () => {
+    const projected = workspaceBillingSummaryForContext(
+      {
+        summary: personalPlusAccount,
+        workspaceBalance: null,
+        workspaceSnapshot: snapshotFor('workspace-a', {
+          billingState: 'free',
+          planId: null,
+        }),
+      } as WorkspaceBillingResponse,
+      teamContext('workspace-a'),
+    );
+    expect(projected?.membershipTier).toBe('free');
+  });
+
+  it('blanks a personal account tier when no authorized snapshot exists', () => {
+    const projected = workspaceBillingSummaryForContext(
+      { summary: personalPlusAccount, workspaceBalance: null } as WorkspaceBillingResponse,
+      teamContext('workspace-a'),
+    );
+    // '' is the contract's "this source does not know", so `resolvePlanTier`
+    // falls through to the workspace-scoped context hint.
+    expect(projected?.membershipTier).toBe('');
+  });
+
+  it('rejects a snapshot proven for a different workspace', () => {
+    const projected = workspaceBillingSummaryForContext(
+      {
+        summary: personalPlusAccount,
+        workspaceBalance: null,
+        workspaceSnapshot: snapshotFor('workspace-b', {
+          billingState: 'active',
+          planId: 'team_max',
+        }),
+      } as WorkspaceBillingResponse,
+      teamContext('workspace-a'),
+    );
+    expect(projected?.membershipTier).toBe('');
+  });
+
+  // 飞书 P0 counterpart: B omits planId/billingState for a non-owner, and
+  // `workspaceSnapshot` is an additive capability, so a team-namespaced account
+  // tier is the only evidence a paying MEMBER's team is subscribed.
+  it('keeps a team-namespaced account tier as the member fallback', () => {
+    const projected = workspaceBillingSummaryForContext(
+      {
+        summary: { ...personalPlusAccount, membershipTier: 'team_plus' },
+        workspaceBalance: null,
+      } as WorkspaceBillingResponse,
+      teamContext('workspace-a'),
+    );
+    expect(projected?.membershipTier).toBe('team_plus');
+  });
+
+  // A personal workspace IS the account scope, and `hasTeamPlan` deliberately
+  // offers team surfaces to a personal workspace holding a team plan.
+  it('passes the account summary through untouched on a personal workspace', () => {
+    const personalContext = {
+      workspaceId: 'personal-a',
+      workspaceType: 'personal',
+      workspaceMemberId: 'member-personal',
+    } as unknown as WorkspaceCollabContext;
+    const projected = workspaceBillingSummaryForContext(
+      { summary: personalPlusAccount, workspaceBalance: null } as WorkspaceBillingResponse,
+      personalContext,
+    );
+    expect(projected?.membershipTier).toBe('plus');
+  });
+});
 
 describe('useWorkspaceBilling explicit scope', () => {
   it.each(['fresh', 'stale', 'refreshing', 'error'] as const)(


### PR DESCRIPTION
## Why

Reported from dogfooding: a workspace that Vela Web shows as **免费** (订阅状态:免费, an 升级团队套餐 CTA, team allowance US$0.00) rendered as **专业版 Plus** in the client's account menu — while the 额度 row in that *same card* correctly read `$0.00`.

The reporter's own question is the diagnosis: 「为啥额度是对的?」 Money and plan travel different data paths, and only money was partitioned by workspace. It reads as "switching workspaces doesn't update the badge", but the badge was never following the workspace at all — it was showing the **account's** subscription the whole time, which happens to look correct in whichever workspace the account paid for.

`GET /api/workspace/billing` returns three independently scoped things (`packages/contracts/src/api/collab.ts`), and only two are about the workspace:

| field | scope | who read it |
| --- | --- | --- |
| `workspaceBalance` / `workspaceSnapshot` | proven for the exact `workspaceId` + `workspaceMemberId` | 额度 row, via `workspaceBillingBalanceUsd` |
| `summary` | **the Vela ACCOUNT** — `workspaceId: null` by contract, and the daemon reads it with one unscoped `fetchBilling()` regardless of `?workspaceId=` (`apps/daemon/src/routes/collab-context.ts:526-530,589`) | plan nameplate + badge |

So `EntryShell.tsx` passed `workspaceBillingResponse?.summary` straight into the rail's plan nameplate. An account holding a personal **Plus** reports `membershipTier: 'plus'` while the user stands in a brand-new unpaid team workspace, and `resolvePlanTier` ranks `billing.membershipTier` *above* the workspace-scoped `context.planId` / `context.billingState`. The result is a value that cannot change when the workspace changes.

Root cause is entirely client-side. Vela's response is correct and correctly labelled; nothing on the vela side needs to change.

## What users will see

Switching workspaces now moves the plan nameplate and its wordmark badge together with the allowance:

- A workspace with no subscription reads **免费** with the FREE badge, instead of inheriting the account's 专业版 Plus.
- A workspace on a real team subscription keeps reading **团队版** with its tier wordmark.
- The 额度 figure is unchanged — it was already right.

Same for the AMR card's plan badge and both 升级 routes in Settings, which read the plan off the same raw account summary.

No interaction, layout, wording, or i18n changes — this is a data-correctness fix only.

## Surface area

- [x] **UI** — the account-menu billing card's plan nameplate/badge and the Settings AMR card plan badge now show workspace-scoped values (no new or moved controls)
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

No CLI counterpart: `od` has no plan-nameplate surface. The daemon HTTP layer and `packages/contracts` are untouched — both surfaces already consume the same `/api/workspace/billing`, and `od amr status` / billing readouts print the daemon's account summary verbatim, which remains correct as an *account* readout.

## Screenshots

Not attached — the change is invisible until you hold two workspaces on different plans, which the red spec below reproduces deterministically. The rendered DOM for both states is in the test output (`专业版` + PLUS wordmark before, `免费` + FREE wordmark after).

Human verification path for a reviewer with two workspaces (one paid, one free): open the account menu, note plan + 额度, switch workspace via the rail's workspace menu, and confirm both halves now describe the new workspace.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/EntryShell.workspace-plan-badge-scope.test.tsx`
- Did the test go red before the source change and green on this branch? **yes**

The spec drives the real wiring (`EntryShell` → `EntryNavRail`) against a two-workspace account whose `summary.membershipTier` is `plus` in both, and asserts both halves of the card agree on which workspace they describe. Red output, verbatim, is at the worktree root as `.red-evidence-before.txt` (source reverted, spec unchanged):

```
 ❯ tests/components/EntryShell.workspace-plan-badge-scope.test.tsx (2 tests | 2 failed)
   × names the workspace subscription, not the account subscription
   × moves both the wallet and the nameplate when the workspace switches

AssertionError: expected <span …(1)>…(1)</span> to be null
+ Received:
<span class="entry-nav-rail__menu-credits-plan">
  专业版
  <svg … viewBox="0 0 114 49" …>   ← the PLUS wordmark
```

Note the second case fails *after* its `$0.00` assertion passes — the wallet followed the switch, the nameplate did not. That is exactly the reported shape.

Green on this branch: both cases pass; `免费` + the FREE wordmark (`viewBox="0 0 107 49"`) after the switch.

## Fix shape

`workspaceBillingSummaryForContext(response, context)` in `apps/web/src/collab/useWorkspaceContext.ts` makes the partition key explicit — the same `workspaceId` + `workspaceMemberId` pair money already keys on — rather than clearing state on switch:

- **personal workspace** — the account IS the scope, so the summary passes through untouched (a team-namespaced tier is deliberately kept: `hasTeamPlan` offers the team surfaces to a personal workspace holding a team plan);
- **team workspace** — the plan comes from the context-authorized snapshot. Without one, the account tier may stand in **only** when it is itself team-namespaced, because a personal tier (`free`/`plus`/`pro`/`max`) describes the account's own subscription and cannot name a team workspace's plan. Anything else becomes `''` — the contract's "this source does not know" — so `resolvePlanTier` falls through to the workspace-scoped context hint.

That last clause is load-bearing rather than laxness, and I found it the hard way: my first pass blanked the account tier for *every* team workspace and turned `tests/components/App.amr-plan-tier.test.tsx` red. B omits `planId`/`billingState` from a non-owner's context and `workspaceSnapshot` is an additive capability, so for a paying **member** on an older daemon/CLI a team-namespaced account tier is the only surviving evidence their team is subscribed. Dropping it would have re-opened the 飞书 P0 「Team plus 还有余额被识别成 free,弹窗要求升级套餐」. The namespace check keeps both fixes true at once.

`useWorkspaceBilling()` is now this projection over the ambient context (its previous hand-rolled variant checked the snapshot against `workspaceRuntime` but never against the *context*), and `EntryShell` / `SettingsDialog` consume it instead of the raw summary. `PlanTierSources.billing` now documents that a raw `response.summary` must never be passed there.

## Adjacent issues (not fixed here)

- `apps/web/src/components/AvatarMenu.tsx:241-251` resolves its own team/personal plan split for the composer model-lock gate. Its team branch reads `snapshot.billing.planId` without mapping `billingState === 'free'` → `'free'`, so a free team workspace yields `null` and falls back to `amrAccount.plan` for the upgrade CTA. Different surface, different symptom (a model lock, not a nameplate) — belongs in its own red spec.
- Whether vela's `billing summary` is purely account-scoped or resolved against vela's own server-side active workspace does not change this fix (either way it is not keyed on the workspace OD asked about), but it is worth confirming before any surface treats that field as workspace state again.

## Validation

- `pnpm guard` — pass
- `pnpm --filter @open-design/web typecheck` (`tsc --noEmit`) — pass
- `pnpm --filter @open-design/web test` — full suite, 540 files / 5487 passed, 11 skipped, 0 failed (post-rebase onto `feat/workspace-team`)
- No Playwright (per current product hold)
