### PR TITLE
fix(settings): show resolved model in Local CLI tests

### DIFF
--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -1726,6 +1726,7 @@ interface AgentSink {
   appendRawStdout: (chunk: string) => void;
   getRawStdout: () => string;
   getRawStdoutTail: () => string;
+  getResolvedModel: () => string | null;
   sawTerminalCompletion: () => boolean;
   dispose: () => void;
 }
@@ -1773,6 +1774,7 @@ export function createAgentSink(): AgentSink {
   let stderrTail = '';
   let rawStdout = '';
   let rawStdoutTail = '';
+  let resolvedModel: string | null = null;
   let terminalCompletionSeen = false;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
   let resolveResult!: (value: AgentSinkResult) => void;
@@ -1845,6 +1847,14 @@ export function createAgentSink(): AgentSink {
         publishStreamError(new Error(message));
         return;
       }
+      if (
+        type === 'status' &&
+        data.label === 'initializing' &&
+        typeof data.model === 'string' &&
+        data.model.trim()
+      ) {
+        resolvedModel = data.model.trim();
+      }
       const delta = data.delta;
       const text = data.text;
       if (type === 'text_delta' && typeof delta === 'string') {
@@ -1887,6 +1897,7 @@ export function createAgentSink(): AgentSink {
     appendRawStdout,
     getRawStdout: () => rawStdout,
     getRawStdoutTail: () => rawStdoutTail,
+    getResolvedModel: () => resolvedModel,
     sawTerminalCompletion: () => terminalCompletionSeen,
     dispose: () => {
       if (debounceTimer) {
@@ -2217,6 +2228,7 @@ async function testAgentConnectionInternal(
     const latencyMs = Date.now() - start;
     const rawSample = truncateSample(text);
     const sample = redactSecrets(rawSample);
+    const resolvedModel = sink.getResolvedModel();
     if (rawSample && isLikelyModelErrorText(rawSample)) {
       const detail = redactSecrets(smokeFailureDetail(rawSample));
       console.warn(
@@ -2254,6 +2266,7 @@ async function testAgentConnectionInternal(
       kind: 'success',
       latencyMs,
       model,
+      ...(resolvedModel ? { resolvedModel } : {}),
       agentName: def.name,
       sample,
       diagnostics: buildDiagnostics(

--- a/apps/daemon/tests/connection-test.test.ts
+++ b/apps/daemon/tests/connection-test.test.ts
@@ -3034,6 +3034,48 @@ process.stdin.on('end', () => {
     }
   });
 
+  it('reports the concrete model resolved from a Claude alias', async () => {
+    await withFakeClaude(
+      `
+console.log(JSON.stringify({
+  type: 'system',
+  subtype: 'init',
+  model: 'claude-opus-5',
+  session_id: 'test-session',
+}));
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => { input += chunk; });
+process.stdin.on('end', () => {
+  JSON.parse(input.trim());
+  console.log(JSON.stringify({
+    type: 'assistant',
+    message: {
+      id: 'msg_1',
+      content: [{ type: 'text', text: 'ok' }],
+      stop_reason: 'end_turn',
+    },
+  }));
+});
+`,
+      async () => {
+        const result = await testAgentConnection({
+          agentId: 'claude',
+          model: 'opus',
+        });
+
+        expect(result).toMatchObject({
+          ok: true,
+          kind: 'success',
+          model: 'opus',
+          resolvedModel: 'claude-opus-5',
+          agentName: 'Claude Code',
+          sample: 'ok',
+        });
+      },
+    );
+  });
+
   it('waits for the Codex process before accepting early success text', async () => {
     await withFakeCodex(
       `

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -2814,20 +2814,26 @@ export function SettingsDialog({
       const baseMessage = kindForSuccess === 'api'
         ? t('settings.testSuccessApi', { ms, sample })
         : t('settings.testSuccessCli', { agentName, ms, sample });
+      const successMessage =
+        kindForSuccess === 'cli' &&
+        result.resolvedModel &&
+        result.resolvedModel !== testedModel
+          ? `${baseMessage} ${t('settings.model')}: ${result.resolvedModel}`
+          : baseMessage;
       if (kindForSuccess === 'cli' && cfg.agentId === 'codex') {
         const codexStrings = codexPathStrings(locale);
         if (
           result.usedExecutableSource === 'configured' &&
           result.configuredExecutablePath
         ) {
-          return `${baseMessage} ${codexStrings.configuredSuccess(result.configuredExecutablePath)}`;
+          return `${successMessage} ${codexStrings.configuredSuccess(result.configuredExecutablePath)}`;
         }
         if (
           result.usedExecutableSource === 'fallback_invalid' &&
           result.configuredExecutablePath &&
           result.detectedExecutablePath
         ) {
-          return `${baseMessage} ${codexStrings.invalidFallback(
+          return `${successMessage} ${codexStrings.invalidFallback(
             result.configuredExecutablePath,
             result.detectedExecutablePath,
           )}`;
@@ -2837,13 +2843,13 @@ export function SettingsDialog({
           result.configuredExecutablePath &&
           result.detectedExecutablePath
         ) {
-          return `${baseMessage} ${codexStrings.failedFallback(
+          return `${successMessage} ${codexStrings.failedFallback(
             result.configuredExecutablePath,
             result.detectedExecutablePath,
           )}`;
         }
       }
-      return result.detail ? `${baseMessage} ${result.detail}` : baseMessage;
+      return result.detail ? `${successMessage} ${result.detail}` : successMessage;
     }
     switch (result.kind) {
       case 'auth_failed':

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -3116,6 +3116,60 @@ describe('SettingsDialog execution settings Local CLI interactions', () => {
     expect(screen.getByRole('button', { name: 'Test' })).toBeTruthy();
   });
 
+  it('shows the concrete model reported by a Local CLI connection test', async () => {
+    const claudeAgent: AgentInfo = {
+      id: 'claude',
+      name: 'Claude Code',
+      bin: 'claude',
+      available: true,
+      version: '2.1.220',
+      models: [
+        { id: 'default', label: 'Default' },
+        { id: 'opus', label: 'Opus (alias)' },
+      ],
+    };
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/memory') {
+        return new Response(
+          JSON.stringify({ enabled: true, memories: [], extraction: null }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url === '/api/test/connection') {
+        return new Response(
+          JSON.stringify({
+            ok: true,
+            kind: 'success',
+            latencyMs: 42,
+            model: 'opus',
+            resolvedModel: 'claude-opus-5',
+            agentName: 'Claude Code',
+            sample: 'ok',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }));
+
+    renderSettingsDialog(
+      {
+        mode: 'daemon',
+        agentId: 'claude',
+        agentModels: { claude: { model: 'opus' } },
+      },
+      { agents: [claudeAgent] },
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: /Local CLI.*1 installed/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Test' }));
+
+    expect(
+      await screen.findByText(/Claude Code replied in 42 ms.*Model: claude-opus-5/i),
+    ).toBeTruthy();
+  });
+
   it('renders the AMR local agent without vela branding and with the Local CLI test action', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = input.toString();

--- a/packages/contracts/src/api/connectionTest.ts
+++ b/packages/contracts/src/api/connectionTest.ts
@@ -265,6 +265,8 @@ export interface ConnectionTestResponse {
   latencyMs: number;
   // Model id or CLI default slot that this test exercised.
   model?: string;
+  // Concrete model reported by a local agent when an alias or default slot resolves.
+  resolvedModel?: string;
   // Truncated assistant reply (≤ 120 chars) on success.
   sample?: string;
   // Upstream HTTP status when relevant (provider tests).


### PR DESCRIPTION
## Why

When I selected a rolling Claude Code alias such as `opus` in Settings and clicked **Test**, Open Design only reported that Claude Code replied successfully. That proved connectivity, but not which concrete model actually handled the request.

Claude Code already includes the concrete model in its `system/init` stream event, and Open Design already parses that value. The connection-test sink discarded the status event, however, so the response preserved only the requested slot (`opus` or `default`) and the UI could not show what the alias resolved to.

This addresses the resolved-model transparency portion of #6180. The stale Claude fallback catalog is intentionally not changed here because #6095 already refreshes that list and includes Fable 5/current-generation coverage.

## What users will see

A successful Local CLI connection test now appends the concrete model reported by the agent when it differs from the selected alias/default slot. For example:

> Claude Code replied in 42 ms — 'ok' Model: claude-opus-5

Exact pinned selections are not repeated when the reported model equals the selected model.

## Surface area

- [x] **UI** — the existing Settings → Local CLI test-result message shows the resolved model
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [x] **API / contract** — adds the optional, backwards-compatible `ConnectionTestResponse.resolvedModel` field
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — no new key; the message reuses the existing localized `settings.model` label
- [ ] **New top-level dependency**
- [x] **Default behavior change** — successful alias/default tests show one additional model detail
- [ ] **None**

### CLI parity

This does not add a new connection-test capability or endpoint; it preserves metadata in an existing Settings-only test flow. There is currently no `od` connection-test command to extend. Adding a new CLI command would be a separate user-facing capability and outside this focused bug fix. Any future CLI consumer of `/api/test/connection` will receive the same optional `resolvedModel` field from the shared contract.

## Screenshots

The visible change is a single appended detail in the existing Local CLI test status row:

```text
Before: Claude Code replied in 42 ms — 'ok'
After:  Claude Code replied in 42 ms — 'ok' Model: claude-opus-5
```

The rendered behavior is covered by `apps/web/tests/components/SettingsDialog.execution.test.tsx`. This draft does not include an uploaded screenshot yet.

## Bug fix verification

- Daemon red spec: `apps/daemon/tests/connection-test.test.ts` — `reports the concrete model resolved from a Claude alias`
- UI red spec: `apps/web/tests/components/SettingsDialog.execution.test.tsx` — `shows the concrete model reported by a Local CLI connection test`
- Red on `main`, green on this branch? **Yes.** On `main`, the daemon result lacks `resolvedModel`, and Settings omits the model from the success message. Both focused specs pass after the fix.

## Validation

Passed:

- `pnpm guard`
- `pnpm typecheck` (full workspace)
- `pnpm --filter @open-design/contracts typecheck`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/web typecheck`
- Focused daemon regression: 1 passed
- Focused web regression: 1 passed
- Full web suite: 441 files passed; 4,866 tests passed, 7 skipped

Full daemon suite result on this machine:

- 480 files passed; 6,098 tests passed
- 4 files / 12 tests failed in unrelated environment-sensitive areas: AMR session-resume integration (8), Langfuse/Vela endpoint selection (2), and xAI no-credential expectations (2)
- The two Langfuse failures are the same `main`-baseline failures already documented on #6095. The AMR/xAI failures do not import or exercise the changed contract, Claude connection-test sink, or Settings result rendering. The directly affected connection-test regression is green.

## Implementation

- Capture the existing Claude `status` / `initializing` model in the connection-test sink.
- Preserve both meanings in the response: `model` remains the requested alias/default slot; `resolvedModel` contains the concrete model reported by the CLI.
- Render the concrete model only for successful Local CLI tests and avoid duplicate output for exact pinned IDs.
- Keep the shared contract additive and optional for backwards compatibility.