### PR TITLE
fix(daemon): resolve an unbound project against the caller's current workspace

### DIFF
--- a/apps/daemon/src/collab/project-workspace-scope.ts
+++ b/apps/daemon/src/collab/project-workspace-scope.ts
@@ -83,3 +83,52 @@ export function resolveProjectWorkspaceScope(input: {
     context: { ...context, workspaceType: 'personal' },
   };
 }
+
+/**
+ * Resolve one project's workspace scope for a SPECIFIC caller.
+ *
+ * Every project resolves to a workspace, and when the project itself does not
+ * name one the answer is the workspace the caller is currently acting in —
+ * there is nothing else an unbound project could sensibly belong to. Answering
+ * `unbound` instead makes `projectWorkspaceScopeAuthorizesAmr` false, which
+ * disables the chat composer's send button for an AMR run on that project
+ * permanently, with nothing the user can do to clear it.
+ *
+ * A project that IS bound is resolved by {@link resolveProjectWorkspaceScope}
+ * alone and the caller's own workspace is irrelevant to it. That asymmetry is
+ * the billing-integrity rule, not an oversight: the scope carries
+ * `workspaceMemberId`, which is the wallet that pays for the project's runs, so
+ * a project pinned to workspace X read by a member of Y must answer X — or
+ * `unavailable` — and never Y.
+ *
+ * The fallback resolves THROUGH the membership directory, so the
+ * `workspaceMemberId` it hands back is always B's for that workspace and never
+ * the request header's. A caller can therefore only select among workspaces
+ * their signed-in identity is genuinely an active member of. Anything the
+ * directory cannot confirm — B unreachable, the claimed workspace not an active
+ * membership, or no caller identity at all — stays `unbound`: reporting "no
+ * workspace" is strictly better than inventing a billing subject.
+ */
+export function resolveProjectWorkspaceScopeForCaller(input: {
+  projectId: string;
+  binding: ProjectWorkspaceBinding | null | undefined;
+  directory: WorkspaceDirectoryFetchResult;
+  /** The caller's current workspace, or null when the request carries no workspace identity. */
+  callerWorkspaceId: string | null | undefined;
+}): ProjectWorkspaceScope {
+  const bound = resolveProjectWorkspaceScope(input);
+  if (bound.kind !== 'unbound') return bound;
+  const callerWorkspaceId =
+    typeof input.callerWorkspaceId === 'string' ? input.callerWorkspaceId.trim() : '';
+  if (!callerWorkspaceId) return bound;
+  const fallback = resolveProjectWorkspaceScope({
+    projectId: input.projectId,
+    // An unbound project is a private local draft. It is not shared with the
+    // team even when the workspace hosting it is one — the same `personal`
+    // visibility every other "claim this orphan into the current workspace"
+    // path writes (`ensureWorkspaceProjection`, `bindDuplicateIntoRequestWorkspace`).
+    binding: { workspaceId: callerWorkspaceId, visibility: 'personal' },
+    directory: input.directory,
+  });
+  return fallback.kind === 'personal' || fallback.kind === 'team' ? fallback : bound;
+}

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -87,7 +87,7 @@ import {
   type WorkspaceResourceMutationCapability,
 } from '../../collab/workspace-resource-mutation.js';
 import type { WorkspaceContextProvider } from '../../collab/workspace-context.js';
-import { resolveProjectWorkspaceScope } from '../../collab/project-workspace-scope.js';
+import { resolveProjectWorkspaceScopeForCaller } from '../../collab/project-workspace-scope.js';
 import {
   authorizeCreatedProjectWorkspace,
   bindCreatedProjectToWorkspace,
@@ -3431,10 +3431,17 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
           (): WorkspaceDirectoryFetchResult => ({ ok: false, items: [] }),
         )
       : { ok: false, items: [] };
-    const scope = resolveProjectWorkspaceScope({
+    // A project with no binding of its own resolves to the workspace THIS
+    // caller is acting in, read the same sanctioned way every neighbouring
+    // handler reads it. A bound project ignores the caller entirely — see
+    // `resolveProjectWorkspaceScopeForCaller`.
+    const callerCtx = workspaceProjectContextFromRequest(req);
+    const scope = resolveProjectWorkspaceScopeForCaller({
       projectId: project.id,
       binding,
       directory,
+      callerWorkspaceId:
+        callerCtx === null || callerCtx === 'missing' ? null : callerCtx.workspaceId,
     });
     /** @type {import('@open-design/contracts').ProjectWorkspaceScopeResponse} */
     const body = { scope };

--- a/apps/daemon/tests/collab/project-workspace-scope.test.ts
+++ b/apps/daemon/tests/collab/project-workspace-scope.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveProjectWorkspaceScope } from '../../src/collab/project-workspace-scope.js';
+import {
+  resolveProjectWorkspaceScope,
+  resolveProjectWorkspaceScopeForCaller,
+} from '../../src/collab/project-workspace-scope.js';
 
 const directoryItems = [
   {
@@ -135,5 +138,122 @@ describe('resolveProjectWorkspaceScope', () => {
       workspaceId: null,
       context: null,
     });
+  });
+});
+
+describe('resolveProjectWorkspaceScopeForCaller', () => {
+  it('resolves an unbound project against the caller current workspace', () => {
+    const scope = resolveProjectWorkspaceScopeForCaller({
+      projectId: 'project-unbound',
+      binding: null,
+      directory: { ok: true, items: directoryItems },
+      callerWorkspaceId: 'workspace-b',
+    });
+
+    expect(scope).toMatchObject({
+      kind: 'team',
+      projectId: 'project-unbound',
+      workspaceId: 'workspace-b',
+      // An unbound project is a private local draft even inside a team.
+      visibility: 'personal',
+      context: {
+        workspaceId: 'workspace-b',
+        workspaceType: 'team',
+        workspaceMemberId: 'member-b',
+      },
+    });
+  });
+
+  it('never lets the caller workspace override a project already pinned elsewhere', () => {
+    const scope = resolveProjectWorkspaceScopeForCaller({
+      projectId: 'project-pinned',
+      binding: { workspaceId: 'workspace-gone', visibility: 'team' },
+      directory: { ok: true, items: directoryItems },
+      callerWorkspaceId: 'workspace-b',
+    });
+
+    // `workspaceMemberId` is the billing subject, so borrowing the caller's
+    // would bill their wallet for another workspace's project.
+    expect(scope).toEqual({
+      kind: 'unavailable',
+      projectId: 'project-pinned',
+      workspaceId: 'workspace-gone',
+      visibility: 'team',
+      context: null,
+    });
+  });
+
+  it('leaves a pinned project unavailable when the directory could not be read either', () => {
+    const scope = resolveProjectWorkspaceScopeForCaller({
+      projectId: 'project-pinned',
+      binding: { workspaceId: 'workspace-b', visibility: 'personal' },
+      directory: { ok: false, items: [] },
+      callerWorkspaceId: 'workspace-b',
+    });
+
+    // The caller names the very workspace the project is pinned to, but nothing
+    // confirmed it. `unavailable` keeps its exact pre-existing behavior; the
+    // caller's claim is not a substitute for the membership directory.
+    expect(scope).toEqual({
+      kind: 'unavailable',
+      projectId: 'project-pinned',
+      workspaceId: 'workspace-b',
+      visibility: 'personal',
+      context: null,
+    });
+  });
+
+  it('keeps an unbound project unbound when the caller has no workspace identity', () => {
+    const scope = resolveProjectWorkspaceScopeForCaller({
+      projectId: 'project-anonymous',
+      binding: null,
+      directory: { ok: true, items: directoryItems },
+      callerWorkspaceId: null,
+    });
+
+    expect(scope).toEqual({
+      kind: 'unbound',
+      projectId: 'project-anonymous',
+      workspaceId: null,
+      context: null,
+    });
+  });
+
+  it('keeps an unbound project unbound when the claimed workspace is not an active membership', () => {
+    const unconfirmed = resolveProjectWorkspaceScopeForCaller({
+      projectId: 'project-unconfirmed',
+      binding: null,
+      directory: { ok: true, items: directoryItems },
+      callerWorkspaceId: 'workspace-not-mine',
+    });
+    const outage = resolveProjectWorkspaceScopeForCaller({
+      projectId: 'project-outage',
+      binding: null,
+      directory: { ok: false, items: [] },
+      callerWorkspaceId: 'workspace-b',
+    });
+
+    // The fallback resolves THROUGH the directory, so the member id it returns
+    // is always B's and never the request header's. An unconfirmable claim must
+    // degrade to "no workspace", never to `unavailable` on a workspace the
+    // project was never bound to.
+    expect(unconfirmed.kind).toBe('unbound');
+    expect(unconfirmed.workspaceId).toBeNull();
+    expect(outage.kind).toBe('unbound');
+    expect(outage.workspaceId).toBeNull();
+  });
+
+  it('keeps an unbound project unbound when the caller membership is revoked', () => {
+    const scope = resolveProjectWorkspaceScopeForCaller({
+      projectId: 'project-revoked',
+      binding: null,
+      directory: {
+        ok: true,
+        items: [{ ...directoryItems[0]!, memberStatus: 'removed' as const }],
+      },
+      callerWorkspaceId: 'workspace-b',
+    });
+
+    expect(scope.kind).toBe('unbound');
   });
 });

--- a/apps/web/src/collab/useWorkspaceContext.ts
+++ b/apps/web/src/collab/useWorkspaceContext.ts
@@ -40,6 +40,40 @@ export interface WorkspaceContextState {
   failure?: 'unsupported' | 'unavailable';
 }
 
+/**
+ * Whether an Open Design Cloud (AMR) run has a cloud identity that could pay
+ * for it.
+ *
+ * AMR bills the caller's OWN wallet — their current workspace. The only state
+ * in which it genuinely cannot run is "there is no cloud identity at all": a
+ * settled, authoritative read that came back with no workspace. Every other
+ * state is the user spending their own quota, and whether they may is the
+ * server's call — the daemon's `WORKSPACE_CONTEXT_REQUIRED` 401 and vela's
+ * own billing check are the enforcement points. A client-side veto on a
+ * weaker signal cannot add safety; it can only turn a request the server
+ * would have answered into a dead, unexplained button.
+ *
+ * Deliberately NOT treated as "cannot be billed":
+ *
+ * - `loading` — the read holds no answer yet. Reporting "signed out" on a
+ *   frame that has not heard back is the bug shape this replaces.
+ * - `failure: 'unavailable'` — a transient outage. Offline, a 504, and a
+ *   timeout all collapse into one `ok: false` upstream, so nothing was
+ *   learned about the user's identity.
+ * - `failure: 'unsupported'` — an old daemon with no workspace endpoint,
+ *   which keeps its legal pre-workspace behavior.
+ *
+ * Note this asks about the CALLER's identity, not about the project. A
+ * project whose own workspace scope is `unbound` or `unavailable` says
+ * nothing about whether the signed-in user has a wallet.
+ */
+export function workspaceIdentityCanBillAmr(state: WorkspaceContextState): boolean {
+  if (state.context !== null) return true;
+  if (state.loading) return true;
+  if (state.failure) return true;
+  return false;
+}
+
 /** Coalescing key for `GET /api/workspace/context`; shared so an identity
  *  change can evict exactly this read instead of the whole cache. */
 const WORKSPACE_CONTEXT_COALESCE_KEY = 'workspace-context';

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -229,7 +229,10 @@ import { localizePluginTitle } from './plugins-home/localization';
 import { DesignSystemPicker } from './DesignSystemPicker';
 import { PresenceBar } from '../collab/PresenceBar';
 import { useProjectCollab } from '../collab/useProjectCollab';
-import { useWorkspaceContext } from '../collab/useWorkspaceContext';
+import {
+  useWorkspaceContext,
+  workspaceIdentityCanBillAmr,
+} from '../collab/useWorkspaceContext';
 import {
   projectWorkspaceContext,
   projectWorkspaceScopeAuthorizesAmr,
@@ -1544,8 +1547,28 @@ export function ProjectView({
   );
   const projectRunRequiresWorkspaceScope =
     config.mode === 'daemon' && config.agentId === 'amr';
-  const projectRunWorkspaceScopeReady =
+  // An Open Design Cloud run needs a wallet, and the ONLY client-side veto is
+  // "there is no billing principal at all". Either witness suffices: the
+  // caller's own cloud identity, or a project scope that already names an
+  // explicit personal/team principal.
+  //
+  // What this deliberately stops doing is requiring the PROJECT's scope to
+  // resolve. An `unbound` project, or one whose membership-directory read
+  // transiently failed (offline / 504 / timeout, all collapsed into one
+  // `ok: false` upstream), or one pinned to a team the caller has left, says
+  // nothing about whether the signed-in user can pay — they are spending their
+  // own quota. Withholding the send on those turned a request the server would
+  // have answered into a dead, unexplained button (21f452ffe, which landed as
+  // a defensive default with no stated product requirement). Whether the run is
+  // actually permitted stays the server's call: the daemon's
+  // `WORKSPACE_CONTEXT_REQUIRED` 401 plus vela's own billing check are the
+  // enforcement points, and an honest server error beats a dead button.
+  //
+  // Strictly a widening: every state this admits was previously blocked, and
+  // nothing previously admitted becomes blocked.
+  const projectRunHasBillableAmrPrincipal =
     !projectRunRequiresWorkspaceScope ||
+    workspaceIdentityCanBillAmr(workspaceContextState) ||
     projectWorkspaceScopeAuthorizesAmr(projectWorkspaceScopeState.scope);
   // Onboarding first-generation funnel (spec §11.1). Consume the pending entry
   // (set by the Home recommendation) exactly once on mount; the refs guard the
@@ -2127,7 +2150,7 @@ export function ProjectView({
     currentConversationHasActiveRun
     && !currentConversationStreaming
     && !currentConversationHasProgrammaticBrandExtractionRun;
-  const currentConversationSendDisabled = !projectRunWorkspaceScopeReady
+  const currentConversationSendDisabled = !projectRunHasBillableAmrPrincipal
     || currentConversationLoading
     || failedMessagesConversationId === activeConversationId
     || currentConversationAwaitingActiveRunAttach;
@@ -5296,7 +5319,7 @@ export function ProjectView({
       // run can start. Local CLI and BYOK runtimes do not consume the Vela
       // wallet, so old daemons without this endpoint and directory outages
       // must not disable those runtimes.
-      if (!projectRunWorkspaceScopeReady) return false;
+      if (!projectRunHasBillableAmrPrincipal) return false;
       const effectiveAttachments = mergeChatAttachments(
         attachments,
         ...commentAttachments.map((attachment) =>
@@ -6674,7 +6697,7 @@ export function ProjectView({
       byokVideoModelOptionsPV,
       byokSpeechModelOptionsPV,
       projectRunWorkspaceContext,
-      projectRunWorkspaceScopeReady,
+      projectRunHasBillableAmrPrincipal,
     ],
   );
 
@@ -8986,7 +9009,7 @@ export function ProjectView({
   useEffect(() => {
     if (autoSentRef.current) return;
     if (!activeConversationId) return;
-    if (!projectRunWorkspaceScopeReady) return;
+    if (!projectRunHasBillableAmrPrincipal) return;
     // Wait for the initial listMessages DB read to land. Without this gate
     // the auto-send fires before the in-flight DB response, which then
     // arrives with `setMessages([])` and wipes the freshly-pushed user +
@@ -9051,7 +9074,7 @@ export function ProjectView({
     project.metadata,
     initialDraft,
     project.pendingPrompt,
-    projectRunWorkspaceScopeReady,
+    projectRunHasBillableAmrPrincipal,
     handleSend,
   ]);
 

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -47,6 +47,8 @@ const showCompletionNotification = vi.fn();
 const analyticsTrackMock = vi.fn();
 const workspaceScopeMocks = vi.hoisted(() => ({
   ambientContext: null as WorkspaceCollabContext | null,
+  ambientLoading: false,
+  ambientFailure: null as 'unsupported' | 'unavailable' | null,
   projectScope: {
     loading: false,
     scope: {
@@ -85,8 +87,18 @@ vi.mock('../../src/providers/anthropic', () => ({
 vi.mock('../../src/collab/useWorkspaceContext', () => ({
   useWorkspaceContext: () => ({
     context: workspaceScopeMocks.ambientContext,
-    loading: false,
+    loading: workspaceScopeMocks.ambientLoading,
+    ...(workspaceScopeMocks.ambientFailure
+      ? { failure: workspaceScopeMocks.ambientFailure }
+      : {}),
   }),
+  // Mirrors the real predicate: only a settled, authoritative "no workspace"
+  // read means AMR has no wallet.
+  workspaceIdentityCanBillAmr: (state: {
+    context: unknown;
+    loading: boolean;
+    failure?: string;
+  }) => state.context !== null || state.loading || Boolean(state.failure),
   useWorkspaceBilling: () => null,
 }));
 
@@ -651,6 +663,8 @@ describe('ProjectView conversation run isolation', () => {
   beforeEach(() => {
     window.localStorage.clear();
     workspaceScopeMocks.ambientContext = null;
+    workspaceScopeMocks.ambientLoading = false;
+    workspaceScopeMocks.ambientFailure = null;
     workspaceScopeMocks.projectScope = {
       loading: false,
       scope: {
@@ -783,6 +797,133 @@ describe('ProjectView conversation run isolation', () => {
     await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
   });
 
+  // An Open Design Cloud run is billed to the CALLER's own wallet. The gate must
+  // therefore ask about the caller's identity, not about this project's
+  // workspace scope — a project whose scope is unresolved says nothing about
+  // whether the signed-in user can pay, and holding the send closed there just
+  // produced a dead button (21f452ffe). Cases below pin the narrowed rule.
+  const amrAgents = [{
+    id: 'amr',
+    name: 'AMR',
+    bin: 'amr',
+    available: true,
+    models: [{ id: 'glm-5', label: 'GLM 5' }],
+  }];
+
+  it.each([
+    [
+      'an unbound project',
+      {
+        loading: false,
+        scope: {
+          kind: 'unbound' as const,
+          projectId: project.id,
+          workspaceId: null,
+          context: null,
+        },
+      },
+    ],
+    [
+      'a project pinned to a workspace the caller is not in',
+      {
+        loading: false,
+        scope: {
+          kind: 'unavailable' as const,
+          projectId: project.id,
+          workspaceId: 'workspace-elsewhere',
+          visibility: 'personal' as const,
+          context: null,
+        },
+      },
+    ],
+    [
+      'a workspace-directory outage',
+      { loading: false, scope: null, failure: 'unavailable' as const },
+    ],
+  ])(
+    'lets a signed-in user send an AMR run with %s — they are spending their own quota',
+    async (_label, projectScope) => {
+      conversationAMessages = [];
+      // Signed in: there IS a wallet. This is the whole difference from the
+      // signed-out case below.
+      workspaceScopeMocks.ambientContext = teamWorkspaceContext(
+        'workspace-team',
+        'member-team',
+      );
+      workspaceScopeMocks.projectScope = projectScope;
+
+      renderProjectView({ ...config, agentId: 'amr' }, project, amrAgents);
+
+      await waitFor(() =>
+        expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'),
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId('send-message')).toHaveProperty('disabled', false),
+      );
+      fireEvent.click(screen.getByTestId('send-message'));
+      await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    },
+  );
+
+  it('still blocks an AMR run for a genuinely signed-out caller', async () => {
+    conversationAMessages = [];
+    // A settled, authoritative read that came back with no workspace: there is
+    // no wallet at all, so the run cannot be billed and cannot succeed.
+    workspaceScopeMocks.ambientContext = null;
+    workspaceScopeMocks.ambientLoading = false;
+    workspaceScopeMocks.ambientFailure = null;
+    workspaceScopeMocks.projectScope = {
+      loading: false,
+      scope: {
+        kind: 'unbound',
+        projectId: project.id,
+        workspaceId: null,
+        context: null,
+      },
+    };
+
+    renderProjectView({ ...config, agentId: 'amr' }, project, amrAgents);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'),
+    );
+    expect(screen.getByTestId('send-message')).toHaveProperty('disabled', true);
+    fireEvent.click(screen.getByTestId('send-message'));
+    expect(streamViaDaemon).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['an identity read still in flight', { loading: true, failure: null }],
+    ['a transient identity outage', { loading: false, failure: 'unavailable' as const }],
+    ['an old daemon with no workspace endpoint', { loading: false, failure: 'unsupported' as const }],
+  ])(
+    'does not disable the AMR send on %s — an unsettled read is not a signed-out user',
+    async (_label, identity) => {
+      conversationAMessages = [];
+      workspaceScopeMocks.ambientContext = null;
+      workspaceScopeMocks.ambientLoading = identity.loading;
+      workspaceScopeMocks.ambientFailure = identity.failure;
+      workspaceScopeMocks.projectScope = {
+        loading: false,
+        scope: {
+          kind: 'unbound',
+          projectId: project.id,
+          workspaceId: null,
+          context: null,
+        },
+      };
+
+      renderProjectView({ ...config, agentId: 'amr' }, project, amrAgents);
+
+      await waitFor(() =>
+        expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'),
+      );
+      await waitFor(() =>
+        expect(screen.getByTestId('send-message')).toHaveProperty('disabled', false),
+      );
+    },
+  );
+
   it.each([
     [
       'an unbound project',
@@ -804,8 +945,12 @@ describe('ProjectView conversation run isolation', () => {
       'a workspace-directory outage',
       { loading: false, scope: null, failure: 'unavailable' as const },
     ],
-  ])('fails closed for AMR with %s', async (_label, projectScope) => {
+  ])(
+    'fails closed for a SIGNED-OUT AMR caller with %s',
+    async (_label, projectScope) => {
     conversationAMessages = [];
+    // `ambientContext` stays null from beforeEach: no cloud identity, so no
+    // wallet. The project's own scope is not what closes the gate here.
     workspaceScopeMocks.projectScope = projectScope;
 
     renderProjectView(
@@ -828,7 +973,8 @@ describe('ProjectView conversation run isolation', () => {
     expect(screen.getByTestId('send-message')).toHaveProperty('disabled', true);
     fireEvent.click(screen.getByTestId('send-message'));
     expect(streamViaDaemon).not.toHaveBeenCalled();
-  });
+  },
+  );
 
   it('uses the project-bound workspace instead of the ambient workspace for run authorization', async () => {
     conversationAMessages = [];

--- a/e2e/tests/collab/project-workspace-scope.test.ts
+++ b/e2e/tests/collab/project-workspace-scope.test.ts
@@ -1,0 +1,304 @@
+// @vitest-environment node
+
+// Every project must resolve to a workspace. When the project itself carries no
+// `workspace_projects` binding, the workspace it resolves to is the CALLER'S
+// CURRENT one — there is nothing else it could sensibly be.
+//
+// The concrete bug: `unbound` makes `projectWorkspaceScopeAuthorizesAmr` false,
+// which disables the chat composer's SEND BUTTON for an AMR run on that project,
+// permanently, with nothing the user can do to clear it.
+//
+// `GET /api/projects/:id/workspace-scope` used to read only the persisted
+// binding and the membership directory; it never looked at the request's
+// `x-od-workspace-*` identity at all, so an unbound project answered `unbound`
+// for every caller forever.
+//
+// Two cases are deliberately NOT the current workspace and are pinned here:
+//
+//   * `unavailable` — a project pinned to workspace X, read by a caller whose
+//     current workspace is Y, must keep answering X/`unavailable`. The scope
+//     carries `workspaceMemberId`, which is the billing subject; resolving it
+//     to Y would bill Y's wallet for X's project. All three of its return sites
+//     keep today's exact behavior, and the two that differ in cause — the
+//     directory was never read, versus it was read and does not list this
+//     membership — are both pinned below. Neither gains a fallback.
+//   * a caller with NO workspace identity (signed out, plain curl) has no
+//     current workspace to fall back to, so an unbound project stays `unbound`.
+//     Inventing a workspace is worse than answering "none".
+//
+// The membership directory is seeded through the daemon's real vela integration
+// (`VELA_CONTROL_KEY` + `VELA_API_URL` -> `GET /api/v1/workspaces`) against a
+// temporary server-level mock, and every project is created through
+// `POST /api/projects`. No source-level test backdoor.
+
+import { createServer, type Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { requestJson } from '@/vitest/http';
+import { createSmokeSuite } from '@/vitest/suite';
+
+type ProjectWorkspaceScopeBody = {
+  scope: {
+    kind: 'unbound' | 'unavailable' | 'personal' | 'team';
+    projectId: string;
+    workspaceId: string | null;
+    visibility?: 'personal' | 'team';
+    context: { workspaceId: string; workspaceMemberId: string; workspaceType: string } | null;
+  };
+};
+
+type CreatedProject = { conversationId: string; project: { id: string; name: string } };
+
+const PERSONAL = {
+  workspaceId: 'ws-scope-personal',
+  workspaceName: 'Scope personal',
+  workspaceType: 'personal' as const,
+  workspaceMemberId: 'mem-scope-personal',
+  role: 'owner' as const,
+  memberStatus: 'active' as const,
+  lifecycleState: 'active' as const,
+};
+
+const TEAM = {
+  workspaceId: 'ws-scope-team',
+  workspaceName: 'Scope team',
+  workspaceType: 'team' as const,
+  workspaceMemberId: 'mem-scope-team',
+  role: 'member' as const,
+  memberStatus: 'active' as const,
+  lifecycleState: 'active' as const,
+};
+
+/** A workspace the signed-in identity is NOT a member of. */
+const FOREIGN_WORKSPACE_ID = 'ws-scope-foreign';
+const FOREIGN_MEMBER_ID = 'mem-scope-foreign';
+
+let directoryServer: Server;
+let directoryUrl: string;
+
+beforeAll(async () => {
+  directoryServer = createServer((req, res) => {
+    if (req.url?.startsWith('/api/v1/workspaces') && req.method === 'GET') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ items: [PERSONAL, TEAM] }));
+      return;
+    }
+    res.writeHead(404, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not found' }));
+  });
+  await new Promise<void>((resolve) => directoryServer.listen(0, '127.0.0.1', resolve));
+  const address = directoryServer.address();
+  if (address == null || typeof address === 'string') throw new Error('mock directory has no port');
+  directoryUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => directoryServer.close(() => resolve()));
+});
+
+function workspaceHeaders(input: {
+  workspaceId: string;
+  workspaceMemberId: string;
+  workspaceType: 'personal' | 'team';
+  role?: string;
+}): Record<string, string> {
+  return {
+    'x-od-workspace-id': input.workspaceId,
+    'x-od-workspace-type': input.workspaceType,
+    'x-od-workspace-member-id': input.workspaceMemberId,
+    'x-od-workspace-role': input.role ?? 'owner',
+    'x-od-workspace-lifecycle-state': 'active',
+    'x-od-workspace-member-status': 'active',
+    'x-od-workspace-can-share-projects': 'true',
+    'x-od-workspace-can-write-synced-files': 'true',
+  };
+}
+
+async function createProject(
+  webUrl: string,
+  name: string,
+  headers?: Record<string, string>,
+): Promise<string> {
+  const created = await requestJson<CreatedProject>(webUrl, '/api/projects', {
+    body: {
+      designSystemId: null,
+      id: randomUUID(),
+      metadata: { kind: 'prototype' },
+      name,
+      pendingPrompt: null,
+      skillId: null,
+    },
+    method: 'POST',
+    ...(headers ? { headers } : {}),
+  });
+  return created.project.id;
+}
+
+async function readScope(
+  webUrl: string,
+  projectId: string,
+  headers?: Record<string, string>,
+): Promise<ProjectWorkspaceScopeBody['scope']> {
+  const body = await requestJson<ProjectWorkspaceScopeBody>(
+    webUrl,
+    `/api/projects/${encodeURIComponent(projectId)}/workspace-scope`,
+    headers ? { headers } : {},
+  );
+  return body.scope;
+}
+
+describe('project workspace scope resolves an unbound project against the caller', () => {
+  test(
+    'an unbound project resolves to the caller current workspace, and pinned/anonymous cases do not',
+    { timeout: 240_000 },
+    async () => {
+      const suite = await createSmokeSuite('collab-project-workspace-scope');
+
+      await suite.with.toolsDev(
+        async ({ webUrl }) => {
+          // --- The bug: unbound project, caller acting in their TEAM workspace.
+          const unboundForTeam = await createProject(webUrl, 'Scope unbound for team');
+          expect(
+            (await readScope(webUrl, unboundForTeam)).kind,
+            'created headerless, so the daemon has no binding for it',
+          ).toBe('unbound');
+
+          const teamScope = await readScope(
+            webUrl,
+            unboundForTeam,
+            workspaceHeaders(TEAM),
+          );
+          expect(teamScope.kind).toBe('team');
+          expect(teamScope.workspaceId).toBe(TEAM.workspaceId);
+          expect(teamScope.visibility).toBe('personal');
+          expect(teamScope.context?.workspaceMemberId).toBe(TEAM.workspaceMemberId);
+          expect(teamScope.context?.workspaceType).toBe('team');
+
+          // --- Same shape for a personal current workspace.
+          const unboundForPersonal = await createProject(webUrl, 'Scope unbound for personal');
+          const personalScope = await readScope(
+            webUrl,
+            unboundForPersonal,
+            workspaceHeaders(PERSONAL),
+          );
+          expect(personalScope.kind).toBe('personal');
+          expect(personalScope.workspaceId).toBe(PERSONAL.workspaceId);
+          expect(personalScope.context?.workspaceMemberId).toBe(PERSONAL.workspaceMemberId);
+
+          // --- BOUNDARY 1: a project pinned to a workspace the caller is not a
+          // member of stays `unavailable` on that workspace. It must never
+          // borrow the caller's workspace or member id — that member id is the
+          // billing subject.
+          const pinnedElsewhere = await createProject(
+            webUrl,
+            'Scope pinned elsewhere',
+            workspaceHeaders({
+              workspaceId: FOREIGN_WORKSPACE_ID,
+              workspaceMemberId: FOREIGN_MEMBER_ID,
+              workspaceType: 'team',
+            }),
+          );
+          const pinnedScope = await readScope(webUrl, pinnedElsewhere, workspaceHeaders(TEAM));
+          expect(pinnedScope.kind).toBe('unavailable');
+          expect(pinnedScope.workspaceId).toBe(FOREIGN_WORKSPACE_ID);
+          // The directory WAS readable here and does not list this membership:
+          // the genuine cross-workspace case, and the one the billing rule
+          // protects. Unchanged by this fix.
+          expect(pinnedScope.context).toBeNull();
+
+          // --- BOUNDARY 2: unbound + no caller identity has no workspace to
+          // fall back to.
+          const unboundAnonymous = await createProject(webUrl, 'Scope unbound anonymous');
+          const anonymousScope = await readScope(webUrl, unboundAnonymous);
+          expect(anonymousScope.kind).toBe('unbound');
+          expect(anonymousScope.workspaceId).toBeNull();
+          expect(anonymousScope.context).toBeNull();
+
+          // --- BOUNDARY 3: a caller whose claimed current workspace is not an
+          // active membership cannot conjure one. The fallback resolves through
+          // the membership directory, so the resulting member id is always B's,
+          // never the request header's.
+          const unboundUnconfirmed = await createProject(webUrl, 'Scope unbound unconfirmed');
+          const unconfirmedScope = await readScope(
+            webUrl,
+            unboundUnconfirmed,
+            workspaceHeaders({
+              workspaceId: FOREIGN_WORKSPACE_ID,
+              workspaceMemberId: FOREIGN_MEMBER_ID,
+              workspaceType: 'team',
+            }),
+          );
+          expect(unconfirmedScope.kind).toBe('unbound');
+          expect(unconfirmedScope.workspaceId).toBeNull();
+        },
+        {
+          env: {
+            // The daemon's real vela session inputs, pointed at the mock above.
+            // `readVelaControlApiContext` takes the env branch first, and
+            // AMR_HOME redirects the config-file fallback at an empty dir, so a
+            // developer machine that IS signed in to production cannot leak into
+            // this run.
+            AMR_HOME: await emptyAmrHome(suite.scratchDir),
+            VELA_API_URL: directoryUrl,
+            VELA_CONTROL_KEY: 'e2e-scope-control-key',
+          },
+        },
+      );
+    },
+  );
+
+  test(
+    'a bound project stays unavailable when the membership directory cannot be read at all',
+    { timeout: 240_000 },
+    async () => {
+      const suite = await createSmokeSuite('collab-project-scope-directory-unreadable');
+
+      // No VELA session at all — the daemon's `fetchWorkspaceDirectory()` never
+      // reaches an authority. This is the steady state of a signed-out client
+      // and of every tools-dev runtime, so it is the COMMON `unavailable`, not
+      // an exotic one, and it says nothing about who owns the project.
+      await suite.with.toolsDev(
+        async ({ webUrl }) => {
+          const bound = await createProject(
+            webUrl,
+            'Scope directory unreadable',
+            workspaceHeaders(TEAM),
+          );
+          const scope = await readScope(webUrl, bound, workspaceHeaders(TEAM));
+
+          // The caller names the very workspace this project is pinned to, and
+          // it STILL does not resolve: nothing confirmed the membership. This
+          // is `unavailable`'s other cause, and the fix leaves it alone.
+          expect(scope.kind).toBe('unavailable');
+          expect(scope.workspaceId).toBe(TEAM.workspaceId);
+          expect(scope.context).toBeNull();
+
+          // An UNBOUND project in the same outage still has nowhere to fall
+          // back to: an unreadable directory cannot confirm the caller's own
+          // workspace either, so it stays `unbound` rather than becoming
+          // `unavailable` on a workspace it was never bound to.
+          const unbound = await createProject(webUrl, 'Scope unbound during outage');
+          const unboundScope = await readScope(webUrl, unbound, workspaceHeaders(TEAM));
+          expect(unboundScope.kind).toBe('unbound');
+          expect(unboundScope.workspaceId).toBeNull();
+        },
+        { env: { AMR_HOME: await emptyAmrHome(suite.scratchDir) } },
+      );
+    },
+  );
+});
+
+/**
+ * A vela config home guaranteed to hold no session, so the daemon's
+ * `readVelaControlApiContext` config-file fallback cannot pick up the developer
+ * machine's real production login.
+ */
+async function emptyAmrHome(scratchDir: string): Promise<string> {
+  const dir = join(scratchDir, 'empty-amr-home');
+  await mkdir(dir, { recursive: true });
+  return dir;
+}


### PR DESCRIPTION
<!-- No issue to close; this is the resolver fix behind the reverted #6178 notice. -->

Two commits, deliberately separable — the second can be dropped without
disturbing the first:

1. `95c280e` daemon — an unbound project resolves against the caller's current workspace.
2. `e09e6f9` web — stop pre-emptively blocking an AMR send that already has a wallet.

Rebased onto #6184 (`613cd51`), so the reverted #6178 notice is already gone from
the base and this diff no longer carries any of it.

They are two halves of one behavior: make the project resolve to a workspace, and
stop vetoing sends on the states where it still does not.

## Why

**Use case.** I went to read what #6178 shipped for "an Open Design Cloud run on
a project with no workspace has no way forward" and found it had written
explanatory copy for the dead end instead of removing it (reverted in #6184).
This PR removes the dead end.

**The product ruling, in the owner's terms:** *every project must resolve to a
workspace; when the project itself has no binding, use the current workspace.*
And on the gate: 「他用他自己 amr 额度,爱编辑啥编辑啥呗?」

### Half 1 — an unbound project can never resolve

`GET /api/projects/:id/workspace-scope` reads exactly two things: the project's
persisted `workspace_projects` row, and the membership directory. It **never
looks at the request's `x-od-workspace-*` identity at all**, so a project with no
row answers `kind: 'unbound'` for every caller, forever. Re-reading cannot help —
the answer is a function of inputs the request never carries.

### Half 2 — the gate blocked users who plainly have a wallet

`ProjectRunWorkspaceScopeReady` required **this project's** scope to resolve
before it would let an AMR send through. A signed-in user was blocked when the
project was `unbound`, when the membership-directory read transiently failed
(offline / 504 / timeout — all collapsed into a single `ok: false` by the
`catch {}` in `collab/vela-workspace-context.ts`), when their workspace was
`billing_past_due`/`locked`, or when they had left the team the project is pinned
to. In every one of those they are spending **their own** quota.

It is also not the enforcement point. Real enforcement is server-side: the
daemon's `WORKSPACE_CONTEXT_REQUIRED` 401 plus vela's own billing check. A client
veto can only convert a request the server would have answered into a dead,
unexplained button — strictly worse than an honest server error. The gate arrived
as `21f452ffe`, whose entire commit message is `fix: fail closed on unresolved
workspace authority` — no body, no stated product requirement. A defensive
default, now ruled against.

## What users will see

- Opening a project that was never bound to any workspace, while signed in, now
  resolves to **the workspace you are currently in** instead of "no workspace".
- The AMR send button is no longer dead when the project's workspace cannot be
  resolved but you are signed in. If the run is not permitted, the server says
  so, instead of the button silently refusing to be pressed.
- A genuinely signed-out user still cannot start an AMR run: there is no wallet,
  so it cannot be billed and cannot succeed.

No notice, banner, tooltip, or copy is added anywhere. #6178's mistake was
writing copy for a resolution bug rather than resolving it.

## Deliberately not in this PR

- **`kind: 'unavailable'` is untouched — all three of its return sites.** Only
  `unbound` gets the current-workspace fallback. The scope carries
  `workspaceMemberId`, the wallet that pays for the project's runs, so a project
  pinned to workspace X and read by a member of Y must answer X, never Y —
  otherwise Y gets billed for X's project. Reachable in practice:
  `GET /api/projects/:id` has no workspace gate (only
  `projectVisibleForLocations`), so a deep link or an already-open project
  surviving a workspace switch lands there.
- **An unbound project + a caller with no workspace identity still resolves
  `unbound`.** There is no current workspace to fall back to, and inventing one
  is worse than answering "none".
- **No `packages/contracts` change.** Every response still matches the existing
  `ProjectWorkspaceScope` union. An earlier draft added a `reason` discriminator
  to `unavailable`; it was cut because it would have had zero consumers — the
  client gates exactly one thing on this scope, and no UI may render it.
- **No new i18n keys, no UI component.**

## How

### Half 1

`resolveProjectWorkspaceScopeForCaller` wraps the existing resolver instead of
branching inside it, so `resolveProjectWorkspaceScope` stays byte-identical to
base and the bound path is provably untouched. The fallback re-enters that
resolver with a synthetic binding naming the caller's own workspace, which buys:

- The resulting `workspaceMemberId` comes from **the membership directory, never
  the request header**. A caller can only select among workspaces their signed-in
  identity is genuinely an active member of; a forged header cannot inject an
  arbitrary billing subject.
- Anything the directory cannot confirm — authority unreachable, workspace not an
  active membership, membership revoked — degrades back to `unbound`, never to
  `unavailable` on a workspace the project was never bound to.
- `visibility: 'personal'`, matching every other "claim this orphan into the
  current workspace" path (`ensureWorkspaceProjection`,
  `bindDuplicateIntoRequestWorkspace`). An unbound project is a private draft
  even inside a team.

The route reads the caller through `workspaceProjectContextFromRequest`, the
existing sanctioned helper its neighbouring handlers already use — no new
header-reading convention.

#### Why this does not route through `reconcileUnboundProjectBeforeMutation`

Persisting the binding through the existing reconcile helper was the preferred
shape going in, and it is wrong here. That helper's own docblock says why:

> Attributes `createdByWorkspaceMemberId: ctx.workspaceMemberId` … deliberately
> NOT the `null` an ordinary lazy-read projection uses. **A passive list read must
> not silently hand out ownership just because it happened to run first; an
> explicit mutation request naming this exact project is the "yes, this is mine"
> signal a read never had.**

This endpoint is a GET. Writing a `workspace_projects` row from it would make
whichever workspace happened to open the project first its permanent owner — with
`createdByWorkspaceMemberId` set, i.e. claiming authorship — on no user intent at
all, and would race two clients in different workspaces. So the resolution is
computed per-read; the binding is still written only by a real mutation.

### Half 2

`workspaceIdentityCanBillAmr(state)` names the invariant on the identity read:
only a **settled, authoritative** read that came back with no workspace means "no
wallet". `loading` (no answer yet), `failure: 'unavailable'` (transient outage),
and `failure: 'unsupported'` (old daemon) are all explicitly *not* "signed out" —
reporting signed-out on a frame that has not heard back is the bug shape this
replaces.

The gate then admits **either** witness of a billing principal: that identity, or
a project scope that already resolves to an explicit personal/team principal. It
is strictly a widening — every state it newly admits was previously blocked, and
nothing previously admitted becomes blocked. Both witnesses are needed: a
resolved project scope is itself proof of a cloud identity, and an identity-only
gate regressed every existing AMR test whose fixture carries a resolved project
scope with no ambient context — a fixture shape, but the same combination is
reachable whenever the two reads settle out of order.

All five consumer sites move together via the single renamed
`projectRunHasBillableAmrPrincipal`, so none can be left failing closed.

## Surface area

- [ ] **UI** — no new component, panel, notice, or copy. `ProjectView`'s existing send-disabled predicate is narrowed.
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — `GET /api/projects/:id/workspace-scope` now honors the caller's `x-od-workspace-*` identity when the project has no binding of its own. No `packages/contracts` shape change.
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — an unbound project resolves to the caller's current workspace instead of `unbound`; the AMR send is no longer withheld from a signed-in user whose project scope is unresolved.
- [ ] **None**

## Screenshots

No new UI surface. The visible change is an existing button no longer being
permanently disabled; there is nothing new to point at.

## Bug fix verification

Red-first on both halves. Base is `origin/feat/workspace-team` @ `001426285` —
this stack targets that branch, not `main`.

### Half 1 — `e2e/tests/collab/project-workspace-scope.test.ts`

e2e Vitest at the real daemon HTTP boundary, the cheapest layer that can see "the
endpoint ignores the caller's workspace". Red with the source changes stashed:

```
 ❯ tests/collab/project-workspace-scope.test.ts (2 tests | 2 failed) 15089ms
     × an unbound project resolves to the caller current workspace, and pinned/anonymous cases do not
     × a bound project stays unavailable when the membership directory cannot be read at all

AssertionError: expected 'unbound' to be 'team' // Object.is equality
 ❯ tests/collab/project-workspace-scope.test.ts:175:34
    175|           expect(teamScope.kind).toBe('team');

 Test Files  1 failed (1)
      Tests  2 failed (2)
```

Green with the fix:

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Cases pinned, all through the real daemon HTTP boundary, data seeded only via
`POST /api/projects`:

| Case | Expected |
| --- | --- |
| unbound + caller in a team workspace | `team`, that workspace, `visibility: 'personal'`, member id from the directory |
| unbound + caller in a personal workspace | `personal`, that workspace |
| **bound to a workspace the caller is not a member of** | `unavailable`, the *project's* workspace, `context: null` — unchanged |
| **bound + directory unreadable, caller naming that same workspace** | `unavailable`, the project's workspace, `context: null` — unchanged |
| **unbound + no caller identity at all** | `unbound`, `workspaceId: null` |
| unbound + claimed workspace not an active membership | `unbound` — a header alone cannot conjure one |
| unbound + directory unreadable | `unbound`, not `unavailable` |

The last four are the boundary the fix must not cross. The two `unavailable` rows
cover both of its distinct causes (directory never read; directory read and does
not list the membership) so neither can drift into a fallback unnoticed.

The membership directory is seeded through the daemon's **real** vela integration
(`VELA_CONTROL_KEY` + `VELA_API_URL` → `GET /api/v1/workspaces`) against a
temporary server-level mock, per `e2e/AGENTS.md`. `AMR_HOME` is redirected at an
empty scratch dir so a developer machine signed in to production cannot leak into
the run. No source-level test backdoor.

Unit coverage: `apps/daemon/tests/collab/project-workspace-scope.test.ts`,
11 passed.

### Half 2 — `apps/web/tests/components/ProjectView.run-isolation.test.tsx`

An app-local Vitest is the right layer: this file's `ChatPane` mock already
exposes `sendDisabled`, so the gate is directly observable without Playwright.

Red with `apps/web/src` stashed:

```
 FAIL  … > lets a signed-in user send an AMR run with an unbound project — they are spending their own quota
 FAIL  … > lets a signed-in user send an AMR run with a project pinned to a workspace the caller is not in — they are spending their own quota
 FAIL  … > lets a signed-in user send an AMR run with a workspace-directory outage — they are spending their own quota
 FAIL  … > does not disable the AMR send on an identity read still in flight — an unsettled read is not a signed-out user
 FAIL  … > does not disable the AMR send on a transient identity outage — an unsettled read is not a signed-out user
 FAIL  … > does not disable the AMR send on an old daemon with no workspace endpoint — an unsettled read is not a signed-out user
      Tests  6 failed | 58 passed (64)
```

Green with the fix:

```
      Tests  64 passed (64)
```

That covers all four required cases: (1) blocked today for a signed-in user whose
project scope is unresolved, (2) passing after, (3) a genuinely signed-out caller
is **still blocked** (`still blocks an AMR run for a genuinely signed-out
caller`), (4) an in-flight identity read does **not** disable the button.

One pre-existing test was relabeled — `fails closed for AMR with %s` became
`fails closed for a SIGNED-OUT AMR caller with %s`, because with the gate
narrowed it now passes for that reason and the old name would have been a lie.

## Validation

Node 24.18.0, on this branch (post-rebase unless noted):

- `pnpm guard` — pass.
- `pnpm typecheck` — pass, every workspace project `Done`.
- `pnpm --filter @open-design/web test tests/components/ProjectView.run-isolation.test.tsx`
  — 64 passed; 6 failed when the two `apps/web/src` files are reverted to base.
- `pnpm --filter @open-design/daemon test tests/collab/project-workspace-scope.test.ts`
  — 11 passed.
- `cd e2e && pnpm test tests/collab/project-workspace-scope.test.ts` — 2 failed on
  base, 2 passed here.

The two daemon/e2e runs above were taken before the rebase onto #6184; the rebase
touched only commit 2's three `apps/web` files, so commit 1's evidence carries
over unchanged.

Full suites, post-rebase: `pnpm --filter @open-design/web test` — 540 files /
5494 passed, 11 skipped, **0 failures**. CI's `Web workspace tests` and
`Workspace unit tests` lanes are both green on this PR.

Two locally-flaky tests are worth flagging so nobody mistakes them for fallout,
neither touched by this diff:

- `tests/components/FileWorkspace.design-system.test.tsx:707` — failed on two
  earlier local runs (including on unmodified base, same line, same diff) and
  passed on two later ones. Order/timing-dependent, not a real base failure.
- `apps/daemon/tests/collab-sync-routes.test.ts` "coalesces direct, targeted, and
  broad recovery onto one stable authorized promotion" — failed once under the
  full daemon suite with `authorized pull receipt is stale`, then passed 94/94 in
  isolation. Adjacent to `a3040c94d fix(collab): coalesce cross-lane project
  pulls`, nowhere near this diff.

Note for reviewers: `pnpm --filter @open-design/daemon typecheck` proves nothing
about `apps/daemon/src/server.ts`, which carries `@ts-nocheck`. Both daemon files
changed here (`src/collab/project-workspace-scope.ts`,
`src/routes/project/index.ts`) are type-checked, so it is genuine coverage for
this diff.

## The permanently-red `UI P0 (project-runtime)` lane — confirmed cause, NOT fixed here

Confirmed that this gate is what reddens the lane. From base run
`30372896858`, job `90321507478`:

```
✘ 3 [chromium] › ui/amr-run-failure-recovery.test.ts:113:1 › [P0] @critical AMR insufficient-balance failures surface Top up AMR and recover after manual Retry
  Error: expect(locator).toBeEnabled() failed
  Locator:  getByTestId('chat-send')
  Expected: enabled
  Received: disabled
    24 × locator resolved to <button disabled title="Send" … data-testid="chat-send" …>
```

That is the dead send button, exactly.

**But this PR does not fix that lane, and I want to be explicit about it.** In a
tools-dev runtime the daemon uses the dev workspace-context stub and nothing in
`tools-dev`, `e2e/`, or `.github/workflows/` ever sets `OD_DEV_WORKSPACE_CONTEXT`
— so `/api/workspace/context` returns `{ context: null }`, settled and without
failure, which is precisely the one state that still (correctly) blocks. And the
web client, having no workspace context, creates projects headerlessly, so their
scope is `unbound` rather than `unavailable`; the second witness does not fire
either. Unblocking that lane needs the harness to seed a workspace identity
(`OD_DEV_WORKSPACE_CONTEXT`, or a fake vela directory as this PR's e2e spec does).
Deliberately out of scope.

**This PR's own CI run confirms both halves of that.** Job `90355722079` on run
`30383056489` fails with the byte-identical signature — same two test files, same
`24 × locator resolved to <button disabled … data-testid="chat-send">` — so the
narrowing provably does not unblock the lane, and equally provably does not
change it for the worse.

For the record, `UI P0 (project-runtime)`, `UI P0 (project-workspace)`, and
`UI P0 (workspace-restoration)` are all **already failing on base**, and fail
identically here, so none of the three is a signal introduced by this PR. The
merged revert #6184 shows the same three. No lane is green on base and red on
this PR.

## Adjacent issues (not fixed here)

- `apps/web/src/collab/useProjectWorkspaceScope.ts` sends no workspace headers on
  the scope read, so half 1 is inert in the shipped client until that read
  carries the caller's identity. Half 2 is what actually unblocks the user today;
  half 1 makes the scope correct for whoever wires the headers next. Wiring them
  needs the shared-request cache key and the transition-frame guard to become
  identity-scoped, which is its own change.
- `GET /api/projects/:id` has no workspace gate. That is what makes the
  cross-workspace `unavailable` case reachable at all.
- Half 2 removes the last consumer of `projectWorkspaceScopeAuthorizesAmr`'s
  strict reading, but the predicate itself is still used (as the second witness)
  and still unit-tested, so nothing is left dead.
