### PR TITLE
fix(plugins): carry pure applies into runs and honor grants

### DIFF
--- a/apps/daemon/src/plugins/apply.ts
+++ b/apps/daemon/src/plugins/apply.ts
@@ -33,7 +33,7 @@ import {
   type PluginProjectMetadataPatch,
   type TrustTier,
 } from '@open-design/contracts';
-import { resolveCapabilitiesGranted, requiredCapabilities } from './trust.js';
+import { requiredCapabilities } from './trust.js';
 import {
   deriveAutoOAuthPrompts,
   mergeAutoOAuthPrompts,
@@ -117,7 +117,8 @@ export function applyPlugin(input: ApplyInput): ApplyComputed {
   const { resolved: connectorsResolved, required: connectorsRequired } =
     resolveConnectorBindings(manifest, input.connectorProbe);
   const required = requiredCapabilities(manifest);
-  const granted = resolveCapabilitiesGranted({ manifest, trust });
+  // Persisted grants are authoritative; recomputing defaults here would undo revocations.
+  const granted = Array.from(new Set([...input.plugin.capabilitiesGranted, 'prompt:inject']));
   const taskKind = (manifest.od?.taskKind ?? 'new-generation') as AppliedPluginSnapshot['taskKind'];
 
   // Spec §23.3.3: when the plugin omits `od.pipeline`, fall back to

--- a/apps/daemon/src/plugins/trust.ts
+++ b/apps/daemon/src/plugins/trust.ts
@@ -91,6 +91,7 @@ const KNOWN_TOP_LEVEL_CAPABILITIES = new Set<string>([
   'bash',
   'network',
   'connector',
+  'pipeline:*',
   // Plan §3.K3 / spec §10.3.5 — plugin-bundled React component
   // surfaces require an explicit capability so a restricted plugin
   // cannot smuggle arbitrary UI through the GenUI layer.

--- a/apps/daemon/tests/plugins-apply.test.ts
+++ b/apps/daemon/tests/plugins-apply.test.ts
@@ -103,11 +103,28 @@ describe('applyPlugin', () => {
     expect(result.result.appliedPlugin.query).toBe('生成一份关于 {{topic}} 的简报。');
   });
 
-  it('grants trusted defaults plus required caps for a trusted plugin', () => {
-    const result = applyPlugin({ plugin: pluginFixture(), inputs: { topic: 'design' }, registry: REGISTRY });
-    for (const cap of TRUSTED_DEFAULT_CAPABILITIES) {
-      expect(result.result.capabilitiesGranted).toContain(cap);
-    }
+  it('uses persisted capabilitiesGranted for a restricted plugin', () => {
+    const capabilitiesGranted = ['pipeline:*', 'prompt:inject'];
+    const result = applyPlugin({
+      plugin: pluginFixture({ trust: 'restricted', capabilitiesGranted }),
+      inputs: { topic: 'design' },
+      registry: REGISTRY,
+    });
+
+    expect(result.result.capabilitiesGranted).toEqual(capabilitiesGranted);
+    expect(result.result.appliedPlugin.capabilitiesGranted).toEqual(capabilitiesGranted);
+  });
+
+  it('does not resurrect a persisted capability revoked from a trusted plugin', () => {
+    const capabilitiesGranted = TRUSTED_DEFAULT_CAPABILITIES.filter((cap) => cap !== 'pipeline:*');
+    const result = applyPlugin({
+      plugin: pluginFixture({ capabilitiesGranted }),
+      inputs: { topic: 'design' },
+      registry: REGISTRY,
+    });
+
+    expect(result.result.capabilitiesGranted).not.toContain('pipeline:*');
+    expect(result.result.appliedPlugin.capabilitiesGranted).not.toContain('pipeline:*');
   });
 
   it('emits skill+atom items in resolvedContext.items', () => {

--- a/apps/daemon/tests/plugins-dod-e2e.test.ts
+++ b/apps/daemon/tests/plugins-dod-e2e.test.ts
@@ -219,11 +219,12 @@ describe('Plan §8 e2e — daemon-side anchors', () => {
       '---\nname: connector-plugin\ndescription: requires slack\n---\n# Connector\n',
     );
     // Install as restricted (the GitHub-style default for non-local
-    // sources). We simulate that by overriding sourceKind via the
-    // already-installed registry record.
+    // sources). Simulate that tier and its persisted default grants on
+    // the already-installed registry record.
     await installLocal(folder);
-    db.prepare('UPDATE installed_plugins SET trust = ? WHERE id = ?')
-      .run('restricted', 'connector-plugin');
+    db.prepare(
+      'UPDATE installed_plugins SET trust = ?, capabilities_granted = ? WHERE id = ?',
+    ).run('restricted', JSON.stringify(['prompt:inject']), 'connector-plugin');
     const plugin = getInstalledPlugin(db, 'connector-plugin')!;
 
     // Apply via the resolver — restricted + missing capability →

--- a/apps/daemon/tests/plugins-trust.test.ts
+++ b/apps/daemon/tests/plugins-trust.test.ts
@@ -85,6 +85,13 @@ describe('validateCapabilityList', () => {
     ]);
   });
 
+  it('accepts exact pipeline:* for a persisted grant', () => {
+    expect(validateCapabilityList(['pipeline:*'])).toEqual({
+      accepted: ['pipeline:*'],
+      rejected: [],
+    });
+  });
+
   it('rejects unknown shapes without dropping good entries', () => {
     const { accepted, rejected } = validateCapabilityList([
       'fs:read',

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -7557,6 +7557,8 @@ export function ProjectView({
           sessionMode: runSessionMode,
           appliedPluginSnapshotId:
             meta?.appliedPluginSnapshotId ?? meta?.appliedPluginSnapshot?.snapshotId ?? null,
+          pluginId: meta?.appliedPluginSnapshot?.pluginId,
+          pluginInputs: meta?.appliedPluginSnapshot?.inputs,
           research: meta?.research,
           mediaExecution: mediaExecutionPolicyForProjectMetadata(project.metadata),
           model: daemonByokOpenCode ? config.model : choice?.model ?? null,
@@ -7729,6 +7731,8 @@ export function ProjectView({
           sessionMode: runSessionMode,
           appliedPluginSnapshotId:
             meta?.appliedPluginSnapshotId ?? meta?.appliedPluginSnapshot?.snapshotId ?? null,
+          pluginId: meta?.appliedPluginSnapshot?.pluginId,
+          pluginInputs: meta?.appliedPluginSnapshot?.inputs,
           research: meta?.research,
           mediaExecution: mediaExecutionPolicyForProjectMetadata(project.metadata),
           model: config.model,

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -321,6 +321,8 @@ export interface DaemonStreamOptions {
   research?: ResearchOptions;
   context?: RunContextSelection;
   appliedPluginSnapshotId?: string | null;
+  pluginId?: string;
+  pluginInputs?: Record<string, unknown>;
   mediaExecution?: MediaExecutionPolicy;
   titleGeneration?: { enabled?: boolean };
   locale?: string;
@@ -673,6 +675,8 @@ export async function streamViaDaemon({
   research,
   context,
   appliedPluginSnapshotId,
+  pluginId,
+  pluginInputs,
   mediaExecution,
   titleGeneration,
   locale,
@@ -712,7 +716,11 @@ export async function streamViaDaemon({
     ...(byokProvider ? { byokProvider } : {}),
     ...(byokMediaDefaults ? { byokMediaDefaults } : {}),
     locale,
-    ...(appliedPluginSnapshotId ? { appliedPluginSnapshotId } : {}),
+    ...(appliedPluginSnapshotId
+      ? { appliedPluginSnapshotId }
+      : pluginId
+        ? { pluginId, ...(pluginInputs ? { pluginInputs } : {}) }
+        : {}),
     ...(context ? { context } : {}),
     ...(research ? { research } : {}),
     ...(mediaExecution ? { mediaExecution } : {}),

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -579,6 +579,28 @@ vi.mock('../../src/components/ChatPane', () => ({
         >
           send with context
         </button>
+        <button
+          type="button"
+          data-testid="send-message-with-pure-plugin"
+          onClick={() =>
+            onSend(
+              'use the selected plugin',
+              [],
+              [],
+              {
+                appliedPluginSnapshotId: '',
+                appliedPluginSnapshot: {
+                  snapshotId: '',
+                  pluginId: 'sample-plugin',
+                  inputs: { audience: 'founders' },
+                },
+              },
+            )
+          }
+          disabled={sendDisabled}
+        >
+          send with pure plugin
+        </button>
         <button type="button" data-testid="new-conversation" onClick={onNewConversation}>
           new
         </button>
@@ -1317,6 +1339,30 @@ describe('ProjectView conversation run isolation', () => {
     expect(streamViaDaemon).toHaveBeenCalledWith(
       expect.objectContaining({ workspaceContext: workspaceA }),
     );
+  });
+
+  it('forwards plugin identity and inputs from a pure apply to the daemon run', async () => {
+    conversationAMessages = [];
+    renderProjectView();
+
+    await waitFor(() => expect(screen.getByTestId('active-conversation').textContent).toBe('conv-a'));
+    await waitFor(() =>
+      expect(screen.getByTestId('send-message-with-pure-plugin')).toHaveProperty('disabled', false),
+    );
+
+    fireEvent.click(screen.getByTestId('send-message-with-pure-plugin'));
+
+    await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+    const daemonRun = streamViaDaemon.mock.calls[0]?.[0] as {
+      appliedPluginSnapshotId?: string;
+      pluginId?: string;
+      pluginInputs?: Record<string, unknown>;
+    };
+    expect(daemonRun).toMatchObject({
+      appliedPluginSnapshotId: '',
+      pluginId: 'sample-plugin',
+      pluginInputs: { audience: 'founders' },
+    });
   });
 
   it('submits the live AMR fallback model when the saved AMR model is stale', async () => {

--- a/apps/web/tests/providers/sse.test.ts
+++ b/apps/web/tests/providers/sse.test.ts
@@ -417,6 +417,37 @@ describe('streamViaDaemon', () => {
     expect(body.appliedPluginSnapshotId).toBe('snap-plugin-1');
   });
 
+  it('sends plugin identity and inputs when pure apply has no snapshot id', async () => {
+    const handlers = createDaemonHandlers();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/runs') return jsonResponse({ runId: 'run-1' });
+      if (url === '/api/runs/run-1/events') {
+        return sseResponse('event: end\ndata: {"code":0,"status":"succeeded"}\n\n');
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await streamViaDaemon({
+      agentId: 'mock',
+      history: [{ id: '1', role: 'user', content: 'use the plugin' }],
+      systemPrompt: '',
+      signal: new AbortController().signal,
+      handlers,
+      appliedPluginSnapshotId: '',
+      pluginId: 'sample-plugin',
+      pluginInputs: { audience: 'founders' },
+    });
+
+    const [, createRunInit] = fetchMock.mock.calls[0] as unknown as [RequestInfo | URL, RequestInit];
+    const body = JSON.parse(String(createRunInit.body));
+    expect(body).toMatchObject({
+      pluginId: 'sample-plugin',
+      pluginInputs: { audience: 'founders' },
+    });
+  });
+
   it('drops prior assistant turns from another agent when composing daemon transcript', async () => {
     const handlers = createDaemonHandlers();
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {

--- a/packages/contracts/src/api/chat.ts
+++ b/packages/contracts/src/api/chat.ts
@@ -115,6 +115,8 @@ export interface ChatRequest {
   research?: ResearchOptions;
   context?: RunContextSelection;
   appliedPluginSnapshotId?: string | null;
+  pluginId?: string;
+  pluginInputs?: Record<string, unknown>;
   /**
    * Run-scoped media execution policy. Omitted means current Open Design
    * behavior: media generation is enabled and OD may execute its configured


### PR DESCRIPTION
Fixes #6186

## Why

I hit this while validating a custom pipeline plugin against an imported existing project. Pure apply correctly avoids persistence, but the web send path dropped the plugin identity when its snapshot ID was empty, so the subsequent run could omit the selected plugin or reuse an older project pin.

The same plugin also exposed a capability-state bug: restricted installs could not persist the derived `pipeline:*` requirement, and apply recomputed trust defaults instead of honoring stored grants and revocations.

## What users will see

Selecting a plugin in an existing project now carries that plugin into the next run, where the daemon creates and pins the snapshot. Restricted pipeline plugins can persist `pipeline:*`, and apply respects the stored grant set without restoring revoked capabilities.

## Surface area

- [ ] **UI** - new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** - new or changed
- [ ] **CLI / env var** - new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** - new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** - new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** - added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** - adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** - changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** - internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this changes run transport and capability resolution without visual UI changes.

## Bug fix verification

- Test paths: `apps/web/tests/providers/sse.test.ts`, `apps/web/tests/components/ProjectView.run-isolation.test.tsx`, `apps/daemon/tests/plugins-trust.test.ts`, and `apps/daemon/tests/plugins-apply.test.ts`.
- The focused specs failed on `upstream/main` and pass on this branch: yes.
- An isolated daemon run also installed the real plugin, imported an existing project, persisted and pinned the snapshot, completed with a fake agent, and included the plugin skill in the prompt.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm exec vitest run -c vitest.config.ts tests/providers/sse.test.ts tests/components/ProjectView.run-isolation.test.tsx --maxWorkers=2` from `apps/web` (`126` passed)
- `pnpm exec vitest run -c vitest.config.ts tests/plugins-*.test.ts` from `apps/daemon` (`500` passed)
- `pnpm --filter @open-design/contracts test` (`246` passed)
- `pnpm --filter @open-design/daemon build`
- `pnpm --filter @open-design/web build`
