### PR TITLE
chore(release): bump feat/workspace-team to 0.16.2

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/daemon",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "type": "module",
   "main": "./dist/cli.js",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/desktop",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "type": "module",
   "main": "./dist/main/index.js",

--- a/apps/landing-page/package.json
+++ b/apps/landing-page/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/landing-page",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/packaged/package.json
+++ b/apps/packaged/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/packaged",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/web",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "type": "module",
   "exports": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/e2e",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-design",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "packageManager": "pnpm@10.33.2",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/contracts",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "type": "module",
   "description": "Shared pure TypeScript contracts for the Open Design web/daemon boundary.",

--- a/packages/download/package.json
+++ b/packages/download/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/download",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/host",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "type": "module",
   "description": "Open Design renderer host bridge protocol.",

--- a/packages/launcher-proto/package.json
+++ b/packages/launcher-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/launcher-proto",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/platform",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/release/package.json
+++ b/packages/release/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/release",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "type": "module",
   "description": "Open Design release domain primitives.",

--- a/packages/sidecar-proto/package.json
+++ b/packages/sidecar-proto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar-proto",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/sidecar",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "type": "module",
   "main": "./dist/index.mjs",

--- a/tools/dev/package.json
+++ b/tools/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-dev",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "type": "module",
   "bin": {

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-pack",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "type": "module",
   "bin": {

--- a/tools/release/package.json
+++ b/tools/release/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-design/tools-release",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Why

The beta feed cannot be published to any more. Both attempts tonight died at `Prepare beta metadata`:

```
[release-beta] packaged base version 0.16.1 must be strictly greater than latest stable 0.16.1
[release-beta] beta metadata.json baseVersion 0.16.1 does not match betaVersion 0.16.2-beta.144
```

The first is waivable with `force`. The second is not: this afternoon `0.16.2-beta.144` was published using an explicit `release_version` override while every manifest on this branch still read `0.16.1`, which left the published `metadata.json` self-inconsistent. Any later build validates that file and refuses.

This is my own mistake coming back — the override produced a version number the repo could not substantiate.

## What changed

`0.16.1` → `0.16.2` in the **same 18 manifests** the release bot touched in `23f9fcaac` (`chore(release): bump main to 0.16.2 ahead of stable 0.16.1`). Nothing else. Two test files mention `0.16.1` as fixture data (`WhatsNewPopup.test.tsx`, `packaged-launcher-update-loop.test.ts`); that commit left them alone and so does this one.

After this, `0.16.2-beta.145` is consistent with its own metadata and `force` is no longer needed for the base-version check.

## What users will see

Nothing directly. It unblocks publishing dogfood betas from this branch with a version number that does not go backwards — the auto-resolver currently proposes `0.16.1-beta.1`, which is behind the `0.16.2-beta.144` already circulating.

## Surface area

- [x] Root `package.json` / workspace manifests
- [ ] UI
- [ ] CLI
- [ ] Contracts
- [ ] i18n

## Notes for the reviewer

This raises the branch only; `main` remains at `0.16.1` and is untouched. If the intent is instead to bump `main` on the normal release cadence, close this — but then tonight’s beta cannot be published with a forward-moving version.