### PR TITLE
fix(collab): keep a project's "last changed" time out of sync's hands

### DIFF
--- a/apps/daemon/src/collab/team-mirror-materializer.ts
+++ b/apps/daemon/src/collab/team-mirror-materializer.ts
@@ -261,6 +261,13 @@ export function materializePulledTeamMirror(
       resourceHubResourceId,
       cloudTombstonedAt: null,
       syncState: 'synced' as const,
+      // The ORIGIN's content time, exactly like the project row above — never
+      // this pull's clock. The project list answers a card's one relative time
+      // as `MAX(p.updated_at, wp.updated_at)`, so carrying the origin into the
+      // project row alone was not enough: the binding written in this same
+      // transaction defaulted to `Date.now()` and `MAX` surfaced it, which is
+      // why a member's card read 「刚刚更新」 hours after a background pull.
+      updatedAt: input.updatedAt,
     };
     if (existingBinding) {
       rebindWorkspaceProject(db, input.id, patch);

--- a/apps/daemon/src/db.ts
+++ b/apps/daemon/src/db.ts
@@ -1126,6 +1126,42 @@ export function getWorkspaceProjectByProjectId(db: SqliteDb, projectId: string) 
 }
 
 /**
+ * The `updatedAt` a writer passes when its write is SYNC, not a local person's
+ * change: keep the row's existing answer instead of stamping "now".
+ *
+ * A project's `updated_at` answers exactly one question for the UI — when did a
+ * person last change this project's conversations, files, or name? The project
+ * card renders it as one relative time and the list sorts by it, folding the
+ * project row and its `workspace_projects` binding together with
+ * `MAX(p.updated_at, wp.updated_at)` (see `listWorkspaceProjects` below and
+ * `normalizeWorkspaceProjectRow` in routes/project/index.ts). So BOTH rows have
+ * to answer it, and only a local action may answer it with `Date.now()`.
+ *
+ * Sync writes rows without anything having changed: materializing a teammate's
+ * pulled content, clearing a revocation or placeholder flag once that pull
+ * lands, advancing `sync_state` after a background upload, reconciling a
+ * binding against the team catalog. A writer on one of those paths must either
+ * carry the ORIGIN's timestamp when it has one (as `materializePulledTeamMirror`
+ * does) or pass this marker. Letting them fall through to "now" is what made a
+ * member's card read 「刚刚更新」 hours after a background pull they never asked
+ * for — the reported bug.
+ */
+export const SYNC_KEEPS_UPDATED_AT = '__od.sync-keeps-updated-at__' as const;
+
+/**
+ * Resolve a patch's `updatedAt` for a row that already exists: an explicit
+ * number wins, {@link SYNC_KEEPS_UPDATED_AT} keeps `existing`, and anything
+ * else (a patch that simply omits it) stamps now.
+ */
+function nextUpdatedAt(patched: unknown, existing: unknown): number {
+  if (typeof patched === 'number') return patched;
+  if (patched === SYNC_KEEPS_UPDATED_AT && typeof existing === 'number') {
+    return existing;
+  }
+  return Date.now();
+}
+
+/**
  * Bind a project to a workspace, or return the binding it already has.
  *
  * Deliberately keyed on the PROJECT, not on `(workspace, project)`: a project
@@ -1134,11 +1170,24 @@ export function getWorkspaceProjectByProjectId(db: SqliteDb, projectId: string) 
  * of one back-fill per workspace visited — and it is also what the narrowed
  * primary key now enforces, so an accidental second insert throws instead of
  * silently duplicating.
+ *
+ * A fresh binding's `updated_at` falls back to the PROJECT's own `updated_at`,
+ * not to now: the project list reports `MAX(p.updated_at, wp.updated_at)` as one
+ * "last changed" time, so a binding written while syncing an old project must
+ * not claim the project just changed (see {@link SYNC_KEEPS_UPDATED_AT}). A
+ * caller that genuinely means "now" — a brand-new project — gets the same answer
+ * either way, because its project row was stamped now a moment ago.
  */
 export function ensureWorkspaceProject(db: SqliteDb, input: DbRow) {
   const now = Date.now();
   const existing = getWorkspaceProjectByProjectId(db, input.projectId);
   if (existing) return existing;
+  const boundProjectUpdatedAt = getProject(db, input.projectId)?.updatedAt;
+  const insertedUpdatedAt = typeof input.updatedAt === 'number'
+    ? input.updatedAt
+    : typeof boundProjectUpdatedAt === 'number'
+      ? boundProjectUpdatedAt
+      : now;
   db.prepare(
     `INSERT INTO workspace_projects
        (project_id, workspace_id, visibility, resource_state,
@@ -1158,7 +1207,7 @@ export function ensureWorkspaceProject(db: SqliteDb, input: DbRow) {
     input.syncState ?? 'local_only',
     input.version ?? 1,
     input.createdAt ?? now,
-    input.updatedAt ?? now,
+    insertedUpdatedAt,
   );
   return getWorkspaceProject(db, input.workspaceId, input.projectId);
 }
@@ -1175,7 +1224,7 @@ export function updateWorkspaceProject(db: SqliteDb, workspaceId: string, projec
     cloudTombstonedAt: patch.cloudTombstonedAt === undefined
       ? existing.cloudTombstonedAt
       : patch.cloudTombstonedAt,
-    updatedAt: typeof patch.updatedAt === 'number' ? patch.updatedAt : Date.now(),
+    updatedAt: nextUpdatedAt(patch.updatedAt, existing.updatedAt),
   };
   db.prepare(
     `UPDATE workspace_projects
@@ -1239,7 +1288,7 @@ export function rebindWorkspaceProject(db: SqliteDb, projectId: string, patch: D
     cloudTombstonedAt: patch.cloudTombstonedAt === undefined
       ? existing.cloudTombstonedAt
       : patch.cloudTombstonedAt,
-    updatedAt: typeof patch.updatedAt === 'number' ? patch.updatedAt : Date.now(),
+    updatedAt: nextUpdatedAt(patch.updatedAt, existing.updatedAt),
   };
   db.prepare(
     `UPDATE workspace_projects
@@ -1725,7 +1774,7 @@ export function updateProject(db: SqliteDb, id: string, patch: DbRow) {
   const merged = {
     ...existing,
     ...patch,
-    updatedAt: typeof patch.updatedAt === 'number' ? patch.updatedAt : Date.now(),
+    updatedAt: nextUpdatedAt(patch.updatedAt, existing.updatedAt),
   };
   db.prepare(
     `UPDATE projects

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -50,6 +50,7 @@ import { connectorService } from '../../connectors/service.js';
 import type { RouteDeps } from '../../server-context.js';
 import { listSkills } from '../../skills.js';
 import { isSafeId } from '../../projects.js';
+import { SYNC_KEEPS_UPDATED_AT } from '../../db.js';
 import {
   BUILT_IN_PROJECT_LOCATION_ID,
   allProjectLocations,
@@ -1869,6 +1870,10 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
         resourceHubResourceId: remote.resourceId,
         cloudTombstonedAt: null,
         syncState: 'synced',
+        // This runs INSIDE the list read, against B's catalog — nobody changed
+        // the project, so it must not restamp `lastActivityAt` below (which is
+        // `MAX(p.updated_at, wp.updated_at)`). See SYNC_KEEPS_UPDATED_AT.
+        updatedAt: SYNC_KEEPS_UPDATED_AT,
       });
       return;
     }
@@ -1889,6 +1894,8 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       updatedByWorkspaceMemberId: ctx.workspaceMemberId,
       resourceHubResourceId: remote.resourceId,
       syncState: 'synced',
+      // Same reason as the canEdit branch above: reconciliation, not activity.
+      updatedAt: SYNC_KEEPS_UPDATED_AT,
     });
   }
   /**

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -597,6 +597,7 @@ import {
   openDatabase,
   reorderPreviewComment,
   setTabs,
+  SYNC_KEEPS_UPDATED_AT,
   updateConversation,
   updatePreviewCommentAnchor,
   updatePreviewCommentStatus,
@@ -2973,7 +2974,12 @@ export async function startServer({
     syncState: 'synced' | 'sync_failed',
   ) {
     if (!workspaceId) return;
-    updateWorkspaceProject(db, workspaceId, projectId, { syncState });
+    // Where a background upload got to is sync bookkeeping, not a change to the
+    // project — see SYNC_KEEPS_UPDATED_AT.
+    updateWorkspaceProject(db, workspaceId, projectId, {
+      syncState,
+      updatedAt: SYNC_KEEPS_UPDATED_AT,
+    });
   }
   function persistWorkspaceProjectVisibility(
     input: {
@@ -3109,6 +3115,9 @@ export async function startServer({
         resourceHubResourceId: null,
         cloudTombstonedAt: null,
         syncState: 'local_only',
+        // A startup heal of a row that was never valid; nobody changed the
+        // project — see SYNC_KEEPS_UPDATED_AT.
+        updatedAt: SYNC_KEEPS_UPDATED_AT,
       });
     }
     return broken.length;
@@ -3401,10 +3410,17 @@ export async function startServer({
         // has never locally bound at all needs `ensureWorkspaceProject`
         // instead, seeded with the same patch so the fresh row is correct on
         // arrival.
-        if (rebindWorkspaceProject(db, projectId, patch)) return;
-        ensureWorkspaceProject(db, { projectId, ...patch });
+        //
+        // Reconciling a binding against B's catalog changes no project content,
+        // so it must not restamp "last changed" — see SYNC_KEEPS_UPDATED_AT.
+        const synced = { ...patch, updatedAt: SYNC_KEEPS_UPDATED_AT };
+        if (rebindWorkspaceProject(db, projectId, synced)) return;
+        ensureWorkspaceProject(db, { projectId, ...synced });
       },
-      applyDemote: (workspaceId, projectId, patch) => updateWorkspaceProject(db, workspaceId, projectId, patch),
+      applyDemote: (workspaceId, projectId, patch) => updateWorkspaceProject(db, workspaceId, projectId, {
+        ...patch,
+        updatedAt: SYNC_KEEPS_UPDATED_AT,
+      }),
       onError: (error) => console.warn('[od] workspace-projects reconciliation error:', error),
     });
   const resolveSharedProject = async (
@@ -3619,7 +3635,9 @@ export async function startServer({
         if (!metadata.teamMirrorRevokedAt) return;
         delete metadata.teamMirrorRevokedAt;
       }
-      updateProject(db, projectId, { metadata });
+      // A revocation flag the pull gate raises/lowers on this daemon's behalf;
+      // the project's own content is untouched — see SYNC_KEEPS_UPDATED_AT.
+      updateProject(db, projectId, { metadata, updatedAt: SYNC_KEEPS_UPDATED_AT });
     },
     // Set/clear the unmaterialized shared-project placeholder stamp (the
     // recvqzaDvUU6B3 fresh-install wipe guard) — same non-destructive
@@ -3635,7 +3653,11 @@ export async function startServer({
         if (!metadata[SHARED_PROJECT_PLACEHOLDER_METADATA_KEY]) return;
         delete metadata[SHARED_PROJECT_PLACEHOLDER_METADATA_KEY];
       }
-      updateProject(db, projectId, { metadata });
+      // Raised on placeholder registration and lowered the moment a pull
+      // materializes real content. Both are sync steps on someone else's
+      // project — see SYNC_KEEPS_UPDATED_AT. This is the flag that made a
+      // member's very first open of a shared project read 「刚刚更新」.
+      updateProject(db, projectId, { metadata, updatedAt: SYNC_KEEPS_UPDATED_AT });
     },
     // Retracted-share heal (飞书 recvqA6qhV7St1): delete a placeholder record
     // whose backing hub resource turned out to be tombstoned. Re-checks the

--- a/apps/daemon/tests/collab/team-mirror-materializer.test.ts
+++ b/apps/daemon/tests/collab/team-mirror-materializer.test.ts
@@ -3,7 +3,12 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { closeDatabase, getProject, openDatabase } from '../../src/db.js';
+import {
+  closeDatabase,
+  getProject,
+  listWorkspaceProjects,
+  openDatabase,
+} from '../../src/db.js';
 import {
   getTeamProjectMaterialization,
   latestTeamProjectMaterializationVersion,
@@ -191,5 +196,54 @@ describe('authorized team mirror SQLite materialization', () => {
     ).toThrow('receipt resource conflict');
 
     expect(getProject(db, input.id)).toBeNull();
+  });
+});
+
+/**
+ * The project card's time. `RecentProjectsStrip` renders one relative time per
+ * card and `GET /api/workspaces/:id/projects` answers it as
+ * `MAX(p.updated_at, wp.updated_at)` (see `normalizeWorkspaceProjectRow`'s
+ * `lastActivityAt` in routes/project/index.ts, and `listWorkspaceProjects`'
+ * own `ORDER BY` in db.ts). So BOTH halves have to answer "when did a person
+ * last change this project's content" — a pull that stamps either one with
+ * `Date.now()` is indistinguishable from a real edit.
+ *
+ * Reported by the owner: a member who opens the client hours later and pulls a
+ * shared project sees 「刚刚更新」 on a project nobody touched. Materialization
+ * already carries the origin's `updatedAt` into `projects`; the
+ * `workspace_projects` binding written in the same transaction did not, and
+ * `MAX` then surfaced the pull's own clock.
+ */
+describe('a team-mirror pull reports the origin content time, not the pull clock', () => {
+  /** What the client renders for this project's card. */
+  function displayedUpdatedAt(db: Awaited<ReturnType<typeof database>>) {
+    const row = listWorkspaceProjects(db, scope.workspaceId).find(
+      (candidate) => candidate.id === input.id,
+    ) as { updatedAt: number; workspaceUpdatedAt: number | null } | undefined;
+    if (!row) throw new Error('project is not listed in the workspace');
+    return Math.max(row.updatedAt, row.workspaceUpdatedAt ?? 0);
+  }
+
+  it('does not advance the card time on a first pull', async () => {
+    const db = await database();
+
+    materializePulledTeamMirror(db, input, scope, receipt());
+
+    expect(getProject(db, input.id)?.updatedAt).toBe(input.updatedAt);
+    expect(displayedUpdatedAt(db)).toBe(input.updatedAt);
+  });
+
+  it('does not advance the card time on a re-pull of an already-bound mirror', async () => {
+    const db = await database();
+
+    materializePulledTeamMirror(db, input, scope, receipt());
+    materializePulledTeamMirror(db, input, scope, {
+      ...receipt(),
+      version: 8,
+      versionId: 'version-8',
+    });
+
+    expect(getProject(db, input.id)?.updatedAt).toBe(input.updatedAt);
+    expect(displayedUpdatedAt(db)).toBe(input.updatedAt);
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -300,10 +300,20 @@ type ProjectListRequest = {
   scopeKey: string;
 };
 
+/**
+ * The scope key for a caller with NO resolved workspace identity — either the
+ * context has not landed yet (every fresh boot passes through this) or the
+ * daemon has no workspace plane at all. It is deliberately NOT treated as "a
+ * workspace you left": a boot that lists projects before the context resolves
+ * did not read another workspace's data, so promoting `local` → `ws:member`
+ * must not discard the list it just loaded.
+ */
+const UNRESOLVED_PROJECT_LIST_SCOPE = 'local';
+
 function projectListScopeKey(context: WorkspaceCollabContext | null): string {
   return context
     ? `${context.workspaceId}:${context.workspaceMemberId}`
-    : 'local';
+    : UNRESOLVED_PROJECT_LIST_SCOPE;
 }
 
 export function projectViewAuthorizationLifetimeKey(
@@ -841,6 +851,34 @@ function AppInner() {
   const [skillsLoading, setSkillsLoading] = useState(true);
   const [dsLoading, setDsLoading] = useState(true);
   const [projectsLoading, setProjectsLoading] = useState(true);
+  // A loaded project list describes exactly ONE workspace identity, so leaving
+  // that workspace INVALIDATES it — it does not merely make it stale.
+  //
+  // Everything downstream of `projects` (the home 最近项目 strip, the 全部项目 and
+  // 草稿 grids) renders whatever this array holds, and the re-list on switch is
+  // an effect: effects run after the commit, so the browser paints the previous
+  // workspace's cards under the new workspace's identity first and only swaps
+  // them when the new list lands. That is the reported 「总是要慢一拍」 — the
+  // strip presenting one workspace's projects as another's, which is worse than
+  // showing nothing. Dropping the list here, during the render that first
+  // observes the new scope, means no frame ever shows the wrong workspace's
+  // data. (`reconcileFetchedProjects` already refuses to APPLY a response whose
+  // scope has moved on; the missing half was discarding what is already on
+  // screen.)
+  //
+  // Nothing is refetched: the switch effect below owns that, and its request is
+  // already keyed on the resolved workspace, so this is not a backend problem
+  // and needs no extra round-trip.
+  const projectListScopeRef = useRef(currentProjectListScope);
+  if (projectListScopeRef.current !== currentProjectListScope) {
+    const leftAResolvedWorkspace =
+      projectListScopeRef.current !== UNRESOLVED_PROJECT_LIST_SCOPE;
+    projectListScopeRef.current = currentProjectListScope;
+    if (leftAResolvedWorkspace) {
+      setProjects([]);
+      setProjectsLoading(true);
+    }
+  }
   const [promptTemplatesLoading, setPromptTemplatesLoading] = useState(true);
   // Goes true once the daemon-persisted config (agentId/designSystemId/etc.)
   // has merged into local state. Auto-selection effects below wait on this

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -184,9 +184,14 @@ export async function listProjects(options?: {
       return [project];
     });
   }
-  // Coalesce identical in-flight reads: a burst of tab switches or several
-  // separately-mounted grids asking for the same workspace+view collapses to a
-  // single vela-backed request instead of spawning one CLI subprocess each.
+  // No resolved workspace identity at all — either the context has not landed
+  // yet or this daemon has no workspace plane. The key is a constant on
+  // purpose: it caches the ONE unscoped `/api/projects` answer, and it is
+  // unreachable once a context exists (the workspace branch above returns
+  // first), so it can never serve one workspace's rows to another. The
+  // workspace-scoped read's own key is built in
+  // `listWorkspaceProjectSummaries` below and carries workspace + member +
+  // role + status + lifecycle + view.
   try {
     return await coalescedGet('local-projects', async () => {
       const resp = await fetch('/api/projects');

--- a/apps/web/tests/components/App.workspace-switch-project-list.test.tsx
+++ b/apps/web/tests/components/App.workspace-switch-project-list.test.tsx
@@ -1,0 +1,284 @@
+// @vitest-environment jsdom
+//
+// Switching workspaces must not leave the previous workspace's projects on
+// screen.
+//
+// Reported shape (owner, packaged client): 「在切换 workspace 时, 首页的"最近项目"
+// 总是要慢一拍, 我切换过去后 首页下面的最近项目会继续显示我上个 workspace 的项目,
+// 然后过一会儿再变」. The strip keeps rendering workspace A's cards under
+// workspace B's identity for as long as B's list takes to arrive — which is
+// worse than a spinner, because another workspace's data is presented as this
+// one's.
+//
+// It is NOT a request-cache problem, and this test is what rules that out: it
+// mocks `listProjects` outright, so `coalescedGet` never runs, and the previous
+// workspace's card still rendered. The read the home strip goes through is
+// `App.projects` ← `reconcileFetchedProjects` ← `listCurrentWorkspaceProjects`
+// ← `listProjects({ workspaceContext })` → `listWorkspaceProjectSummaries`,
+// whose coalesce key already carries workspaceId + memberId + role +
+// memberStatus + lifecycleState + view (state/projects.ts). The hardcoded
+// `'local-projects'` key sits on the other branch, unreachable once a context
+// exists, so it cannot answer workspace B with workspace A's rows either.
+//
+// What was missing is simpler: `reconcileFetchedProjects` refuses to APPLY a
+// response whose scope has moved on, but nothing DISCARDED the rows already on
+// screen, and the re-list runs in an effect — i.e. after the commit the browser
+// has already painted. So the fix is client-side state, not a request: no extra
+// backend round-trip, and no dependency on a workspace-invalidation SSE event
+// (a local switch must correct itself locally).
+
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { App } from '../../src/App';
+import type { AppConfig, Project } from '../../src/types';
+import {
+  fetchComposioConfigFromDaemon,
+  fetchDaemonConfig,
+  loadConfig,
+  mergeDaemonConfig,
+} from '../../src/state/config';
+import {
+  daemonIsLive,
+  fetchAgentsStream,
+  fetchAppVersionInfo,
+  fetchDesignSystems,
+  fetchDesignTemplates,
+  fetchPromptTemplates,
+  fetchSkills,
+} from '../../src/providers/registry';
+import { listProjects, listTemplates } from '../../src/state/projects';
+import {
+  notifyWorkspaceContextRefresh,
+  resetTeamProjectsCache,
+  resetWorkspaceContextCache,
+} from '../../src/collab/useWorkspaceContext';
+import { resetCoalescedGet } from '../../src/lib/coalesced-get';
+
+vi.mock('../../src/components/EntryView', () => ({
+  EntryView: ({ projects }: { projects: Project[] }) => (
+    <main>
+      <div data-testid="entry-home-surface" />
+      {projects.map((project) => (
+        <div key={project.id} data-testid={`entry-project-${project.id}`}>
+          {project.name}
+        </div>
+      ))}
+    </main>
+  ),
+}));
+
+vi.mock('../../src/components/ProjectView', () => ({
+  ProjectView: () => <main data-testid="project-view" />,
+}));
+
+vi.mock('../../src/components/WorkspaceTabsBar', () => ({
+  WorkspaceTabsBar: () => null,
+  openWorkspaceTab: () => {},
+}));
+
+vi.mock('../../src/components/pet/PetOverlay', () => ({
+  PetOverlay: () => null,
+}));
+
+vi.mock('../../src/components/pet/pets', () => ({
+  migrateCustomPetAtlas: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../../src/components/SettingsDialog', () => ({
+  SettingsDialog: () => null,
+  switchApiProtocolConfig: (config: AppConfig) => config,
+  updateCurrentApiProtocolConfig: (config: AppConfig) => config,
+}));
+
+vi.mock('../../src/providers/registry', async () => {
+  const actual = await vi.importActual<typeof import('../../src/providers/registry')>(
+    '../../src/providers/registry',
+  );
+  return {
+    ...actual,
+    daemonIsLive: vi.fn(),
+    fetchAgentsStream: vi.fn(),
+    fetchAppVersionInfo: vi.fn(),
+    fetchDesignSystems: vi.fn(),
+    fetchDesignTemplates: vi.fn(),
+    fetchPromptTemplates: vi.fn(),
+    fetchSkills: vi.fn(),
+  };
+});
+
+vi.mock('../../src/state/projects', async () => {
+  const actual = await vi.importActual<typeof import('../../src/state/projects')>(
+    '../../src/state/projects',
+  );
+  return {
+    ...actual,
+    listProjects: vi.fn(),
+    listTemplates: vi.fn(),
+  };
+});
+
+vi.mock('../../src/state/config', async () => {
+  const actual = await vi.importActual<typeof import('../../src/state/config')>(
+    '../../src/state/config',
+  );
+  return {
+    ...actual,
+    fetchDaemonConfig: vi.fn().mockResolvedValue({}),
+    fetchComposioConfigFromDaemon: vi.fn().mockResolvedValue(null),
+    loadConfig: vi.fn(),
+    mergeDaemonConfig: vi.fn(),
+    saveConfig: vi.fn(),
+    syncComposioConfigToDaemon: vi.fn().mockResolvedValue(true),
+    syncConfigToDaemon: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+const baseConfig: AppConfig = {
+  mode: 'daemon',
+  apiKey: '',
+  apiProtocol: 'anthropic',
+  apiVersion: '',
+  baseUrl: 'https://api.anthropic.com',
+  model: 'claude-sonnet-4-5',
+  apiProviderBaseUrl: 'https://api.anthropic.com',
+  apiProtocolConfigs: {},
+  agentId: 'codex',
+  skillId: null,
+  designSystemId: null,
+  onboardingCompleted: true,
+  privacyDecisionAt: 1778244000000,
+  mediaProviders: {},
+  composio: {},
+  agentModels: {},
+  agentCliEnv: {},
+};
+
+function project(id: string, name: string): Project {
+  return {
+    id,
+    name,
+    skillId: null,
+    designSystemId: null,
+    createdAt: 1778244000000,
+    updatedAt: 1778244000000,
+    metadata: { kind: 'prototype' },
+  };
+}
+
+const WORKSPACE_A_PROJECT = project('project-in-a', 'Workspace A project');
+const WORKSPACE_B_PROJECT = project('project-in-b', 'Workspace B project');
+
+function workspaceContextPayload(workspaceId: string) {
+  return {
+    context: {
+      workspaceId,
+      workspaceType: 'team',
+      workspaceMemberId: `member-${workspaceId}`,
+      role: 'member',
+      memberStatus: 'active',
+      lifecycleState: 'active',
+      billingState: 'active',
+      planId: null,
+      providerMode: 'platform_credits',
+      seatSummary: { seatLimit: 5, usedSeats: 1, availableSeats: 4 },
+      permissions: { canCreateProjects: true, canWriteSyncedFiles: true },
+      displayName: workspaceId,
+    },
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe('App project list across a workspace switch', () => {
+  beforeEach(() => {
+    resetWorkspaceContextCache();
+    resetTeamProjectsCache();
+    resetCoalescedGet();
+    window.history.replaceState(null, '', '/');
+    vi.mocked(daemonIsLive).mockResolvedValue(true);
+    vi.mocked(fetchAgentsStream).mockResolvedValue([]);
+    vi.mocked(fetchSkills).mockResolvedValue([]);
+    vi.mocked(fetchDesignTemplates).mockResolvedValue([]);
+    vi.mocked(fetchDesignSystems).mockResolvedValue([]);
+    vi.mocked(fetchPromptTemplates).mockResolvedValue([]);
+    vi.mocked(fetchAppVersionInfo).mockResolvedValue(null);
+    vi.mocked(listTemplates).mockResolvedValue([]);
+    vi.mocked(fetchDaemonConfig).mockResolvedValue({});
+    vi.mocked(fetchComposioConfigFromDaemon).mockResolvedValue(null);
+    vi.mocked(mergeDaemonConfig).mockImplementation((local) => local);
+    vi.mocked(loadConfig).mockReturnValue({ ...baseConfig });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    resetWorkspaceContextCache();
+    resetTeamProjectsCache();
+    resetCoalescedGet();
+  });
+
+  it('never renders the previous workspace\'s projects while the new list is in flight', async () => {
+    let activeWorkspaceId = 'ws-a';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const pathname = new URL(String(input), 'http://d.local').pathname;
+        return {
+          ok: true,
+          json: async () =>
+            pathname.endsWith('/workspace/context')
+              ? workspaceContextPayload(activeWorkspaceId)
+              : {},
+        } as Response;
+      }),
+    );
+
+    const workspaceB = deferred<Project[]>();
+    vi.mocked(listProjects).mockImplementation(async (options) => {
+      const workspaceId = options?.workspaceContext?.workspaceId ?? null;
+      if (workspaceId === 'ws-b') return workspaceB.promise;
+      return [WORKSPACE_A_PROJECT];
+    });
+
+    render(<App />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId(`entry-project-${WORKSPACE_A_PROJECT.id}`)).toBeTruthy(),
+    );
+
+    // The switch itself: B's context resolves, B's project list has NOT.
+    activeWorkspaceId = 'ws-b';
+    await act(async () => {
+      notifyWorkspaceContextRefresh();
+      await Promise.resolve();
+    });
+    await waitFor(() =>
+      expect(
+        vi.mocked(listProjects).mock.calls.some(
+          ([options]) => options?.workspaceContext?.workspaceId === 'ws-b',
+        ),
+      ).toBe(true),
+    );
+
+    // Workspace B is the active identity now. Whatever the strip shows must
+    // belong to B — an empty strip is fine, A's project is not.
+    expect(screen.queryByTestId(`entry-project-${WORKSPACE_A_PROJECT.id}`)).toBeNull();
+
+    await act(async () => {
+      workspaceB.resolve([WORKSPACE_B_PROJECT]);
+      await workspaceB.promise;
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId(`entry-project-${WORKSPACE_B_PROJECT.id}`)).toBeTruthy(),
+    );
+    expect(screen.queryByTestId(`entry-project-${WORKSPACE_A_PROJECT.id}`)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

Two bugs the product owner hit tonight on a real packaged client, in the same
area (the project card on Home) but with independent causes.

**The project card's time was being moved by sync, not by people.** The owner:
「这里这个时间, 好像获取的不是最初这个 project 内部 owner 实际修改的时间, 每次拉下来同步文件好像也会被当做有更新... 即使我是 member 过了好几个小时再打开的客户端拉取的, 还是会显示刚刚更新」. The card is meant to show the last update to the
project's internal conversations, files, or name (product ruling: 「这个时间就是期望显示的内部对话或者文件或者项目名更新时间」). Instead, a member who opened the client
hours later and pulled a shared project read 「刚刚更新」 on a project nobody had
touched. That makes both the list order and the card time untrustworthy for the
exact case team collaboration exists for.

**Switching workspaces left the previous workspace's projects on screen.** The
owner: 「在切换 workspace 时, 首页的"最近项目" 总是要慢一拍, 我切换过去后 首页下面的最近项目会继续显示我上个 workspace 的项目, 然后过一会儿再变」. That is worse than a
spinner — one workspace's data is presented as another's, and on a shared
machine it reads as a leak.

Not speculative: both came out of dogfooding, and the timestamp one directly
undermines trust in team collaboration.

## What users will see

- A shared project's card keeps the time the **owner** last changed it. Opening
  the client and letting it sync no longer makes every pulled project claim it
  changed just now, and the 最近项目 order stops reshuffling on background sync.
- Right after switching workspaces, 最近项目 (and 全部项目 / 草稿) go briefly empty
  and then fill with the new workspace's projects. They never show the previous
  workspace's projects under the new workspace's name.

No copy changes, no new settings, no new i18n keys. The card's label and the
field it renders are unchanged — per the product ruling those were already
correct (「我创建」 is attribution; the time is last-updated).

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [x] **Default behavior change** — changes what existing users experience without opting in

**Default behavior change, in detail.** No schema change — no new column, no
migration. Two existing values change what they mean in practice:

1. `projects.updated_at` / `workspace_projects.updated_at` are no longer stamped
   by sync paths. Rows already stamped by a past sync keep their wrong value
   until the next real change or the next pull — and a pull now rewrites the
   binding with the origin's time, so team-shared projects self-heal on their
   next pull.
2. `ensureWorkspaceProject` seeds a fresh binding's `updated_at` from the
   project's own `updated_at` instead of `Date.now()`. For a brand-new project
   the two are the same instant; for a binding created while syncing an old
   project it is the whole point.

## Screenshots

n/a — no new or moved UI surface. The visible difference is a relative time
reading correctly, and a strip that is briefly empty instead of briefly wrong.
Reproducing it needs two clients and a real hub — see "Human verification".

## Bug fix verification

Red before the source change, green after. Both captured on this branch with the
new tests present and only the source files reverted (`git stash push -- <src>`),
under Node 24.

### Bug A — sync moves the card's time

Test: `apps/daemon/tests/collab/team-mirror-materializer.test.ts` →
`a team-mirror pull reports the origin content time, not the pull clock`

The origin's `updatedAt` is `2`; the pull's clock is `Date.now()`.

RED (source reverted):

```
 ❯ tests/collab/team-mirror-materializer.test.ts (10 tests | 2 failed) 41ms
     × does not advance the card time on a first pull 9ms
     × does not advance the card time on a re-pull of an already-bound mirror 7ms

 FAIL  … > does not advance the card time on a first pull
AssertionError: expected 1785271717180 to be 2 // Object.is equality
- Expected
+ Received
- 2
+ 1785271717180
 ❯ tests/collab/team-mirror-materializer.test.ts:233:36
    232|     expect(getProject(db, input.id)?.updatedAt).toBe(input.updatedAt);
    233|     expect(displayedUpdatedAt(db)).toBe(input.updatedAt);

 FAIL  … > does not advance the card time on a re-pull of an already-bound mirror
AssertionError: expected 1785271717189 to be 2 // Object.is equality

 Test Files  1 failed (1)
      Tests  2 failed | 8 passed (10)
```

Note *which* assertion fails: `getProject(...).updatedAt` (line 232) passes — the
project row already carried the origin's time. Only `displayedUpdatedAt` fails,
and that is `MAX(p.updated_at, wp.updated_at)`, i.e. the `workspace_projects`
binding written in the same transaction.

GREEN (source restored):

```
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

### Bug B — workspace switch shows the previous workspace's projects

Test: `apps/web/tests/components/App.workspace-switch-project-list.test.tsx`

The assertion is on the intermediate frame — workspace B's context has resolved,
B's list has NOT — so a test that only waited for the correct end state would
pass on base and prove nothing.

RED (source reverted):

```
 ❯ tests/components/App.workspace-switch-project-list.test.tsx (1 test | 1 failed) 31ms
     × never renders the previous workspace's projects while the new list is in flight 30ms

 FAIL  … > never renders the previous workspace's projects while the new list is in flight
AssertionError: expected <div …(1)></div> to be null

- Expected:
null

+ Received:
<div
  data-testid="entry-project-project-in-a"
>
  Workspace A project
</div>

 ❯ tests/components/App.workspace-switch-project-list.test.tsx:273:77

 Test Files  1 failed (1)
      Tests  1 failed (1)
```

GREEN (source restored):

```
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

## What changed, and why, per call site

`SYNC_KEEPS_UPDATED_AT` (`apps/daemon/src/db.ts`) names the invariant instead of
threading a parameter through five call sites with no stated rule: *a project's
`updated_at` answers when a person last changed its conversations, files, or
name; only a local action may answer it with `Date.now()`; a sync writer either
carries the origin's timestamp or keeps the row's existing answer.* It is
honoured by `updateProject`, `updateWorkspaceProject`, and
`rebindWorkspaceProject`.

Every writer of `projects.updated_at` / `workspace_projects.updated_at` was
classified by one question: **can this fire while materializing content the local
user did not author?**

Changed — yes, it can:

| Site | What it is | Fix |
|---|---|---|
| `collab/team-mirror-materializer.ts:264` | the binding written by **every** team-mirror pull | carry `input.updatedAt` (the origin's time), matching what the project row at `:245` already did |
| `server.ts` `markSharedProjectPlaceholder` | placeholder stamp raised on discovery, cleared when a pull materializes real content | `SYNC_KEEPS_UPDATED_AT` |
| `server.ts` `markTeamProjectRevoked` | revocation flag the pull gate raises/lowers | `SYNC_KEEPS_UPDATED_AT` |
| `server.ts` `persistWorkspaceProjectSyncState` | where a background upload got to | `SYNC_KEEPS_UPDATED_AT` |
| `server.ts` reconciler `applyBind` / `applyDemote` | binding reconciled against the team catalog | `SYNC_KEEPS_UPDATED_AT` |
| `server.ts` `reconcileImpossibleTeamShares` | startup heal of a row that was never valid | `SYNC_KEEPS_UPDATED_AT` |
| `routes/project/index.ts` `reconcileLocalRowWithRemoteTeamAccess` (both branches) | runs **inside** `GET /api/workspaces/:id/projects`, so merely listing could bump the time | `SYNC_KEEPS_UPDATED_AT` |

Left alone — no, it cannot; local action only. Each verified by tracing every
caller, not by reading the route name:

| Site | Why it stays |
|---|---|
| `routes/project/conversations.ts:228` (`PUT …/messages/:mid`) | message writes reach it only from this daemon's own run/chat paths; conversations and messages do not sync cross-daemon |
| `routes/project/comments.ts:218,263,365` (create/edit, status, delete) | local HTTP only. Inbound teammate comments arrive through `mergeSyncedPreviewComment` (`db.ts`, driven by the collab-cloud poller), which does not touch `projects.updated_at` at all |
| `routes/live-artifact.ts:267` (DELETE) | only `updateLiveArtifact`/`deleteLiveArtifact` write live artifacts, both from local routes; a pull replaces the directory instead |
| `routes/project/index.ts:3632` (`PATCH /api/projects/:id`) | rename / metadata edit by the local user — one of the three things that *should* bump |
| `routes/runs.ts:894` | a design-system enrichment run the local user started |
| `import-export-routes.ts:283` | folder import re-point, local |
| `brands/index.ts` (6 sites) | brand-extraction flows, local |
| `server.ts:3557` (`projectStore.update`, register-on-pull) | already passes `updatedAt: input.updatedAt` |
| `design-systems/server-services.ts:323` | already passes an explicit `updatedAt` |
| `server.ts` `persistWorkspaceProjectVisibility` / `workspaceProjectMovePatch` | a share / move / unshare **is** a person's action, and `normalizeWorkspaceProjectRow`'s existing doc comment records the deliberate decision that it should surface as recent activity. See "Adjacent issues" |

**Bug B needed no backend work.** The Home strip's read is
`App.projects` ← `reconcileFetchedProjects` ← `listCurrentWorkspaceProjects`
← `listProjects({ workspaceContext })` → `listWorkspaceProjectSummaries`, whose
`coalescedGet` key already carries workspace + member + role + status +
lifecycle + view; the hardcoded `'local-projects'` key is on the other branch and
is unreachable once a context exists. `reconcileFetchedProjects` already refused
to *apply* a response whose scope had moved on. The missing half was discarding
what was already on screen — and because the re-list lives in an effect (which
runs after the commit), the browser painted the stale rows first. Dropping the
list during the render that first observes the new scope fixes it with no extra
request and no dependency on a workspace-invalidation SSE event (a local switch
must correct itself locally). `UNRESOLVED_PROJECT_LIST_SCOPE` keeps boot out of
it: promoting `local` → `ws:member` on first launch is not "a workspace you
left", so it does not throw away the list boot just loaded.

## Human verification

Green specs are not acceptance for either of these — one needs two clients and a
real hub, the other is a frame-timing artifact. Suggested drive:

1. Two isolated clients, owner + member, on the same team workspace
   (owner 17590/17591, member 17592/17593).
2. Owner edits a project, then leaves it alone for a few minutes.
3. Member's client: quit, wait, relaunch, let it sync, open Home. The card should
   read the owner's edit time — on base it reads 「刚刚更新」.
4. Member's client: switch workspaces back and forth, watching 最近项目. It should
   go empty → correct, never previous → correct.

## Validation

Node 24.18.0 (`nvm use 24` + `better-sqlite3` rebuild; the repo requires Node ~24
and `tools-dev` refuses to start otherwise).

- `pnpm guard` — exit 0
- `pnpm typecheck` — exit 0
- `pnpm --filter @open-design/daemon build` — exit 0, and
  `require('apps/daemon/dist/server.js')` loads. Deliberate: `server.ts` carries
  `@ts-nocheck`, so `typecheck` proves nothing about the new import there.
- `pnpm --filter @open-design/web test` — **541 files, 5496 passed, 11 skipped, 0 failed**
- `pnpm --filter @open-design/daemon exec vitest run tests/collab tests/collab-sync-routes.test.ts tests/collab-team-projects-routes.test.ts tests/collab-fresh-install-placeholder-guard.test.ts tests/team-mirror-read-revocation.test.ts` — 45 files, 644 passed
- `pnpm --filter @open-design/daemon test` (full) — **570 files, 7152 passed, 6 skipped, 4 todo, 0 failed**
- `cd e2e && pnpm exec vitest run tests/collab/project-workspace-scope.test.ts` — 2 passed

Both full suites are clean on the supported runtime. An earlier pass on Node 22
(before rebuilding `better-sqlite3`) showed three failures —
`apps/web/tests/components/FileWorkspace.design-system.test.tsx`,
`apps/daemon/tests/integrations/vela.routes.test.ts` (`ENOTEMPTY: rmdir …/.grok`
in its own `afterAll`), and one order-dependent `apps/daemon/tests/mcp-spawn.test.ts`.
All three were diffed against base (`git stash` → run → `git stash pop`) and
reproduce there: the `vela.routes` one failed in 2 of 4 clean-base runs, the
`FileWorkspace` one failed on clean base, and `mcp-spawn` passes in isolation.
None of them appear on Node 24.

## Adjacent issues (follow-ups, deliberately not in this PR)

1. **A file change does not bump `projects.updated_at` at all.** `POST/DELETE
   /api/projects/:id/files` and the rename route never call `updateProject`, so
   the card's time misses one of the three things the product ruling says it
   should track. This PR only stops the *over*-stamping; the under-stamping is
   its own change, with its own decision about whether an agent-authored file
   write counts as a person's change.
2. **Two `coalescedGet` keys are not identity-scoped.**
   `'workspace-team-projects'` (`collab/team-projects-catalog.ts:34`) and
   `'workspace-members'` (`collab/useTeamMembers.ts:94`) are constants with a 1s
   shared-result TTL, so for up to a second after a switch a card can be
   attributed to the previous workspace's member directory. Different symptom
   (wrong creator name, not wrong projects), so out of scope here — but the same
   class of bug.
3. **A share / move / unshare bumps the card time.** `workspaceProjectMovePatch`
   deliberately stamps now, and `normalizeWorkspaceProjectRow` documents that as
   intended. Under the new ruling (conversations / files / name) it arguably
   should not. Left as-is because reversing a documented decision needs a product
   call, not a drive-by.
4. **`server.ts`'s sync flag toggles are untestable in isolation.**
   `markSharedProjectPlaceholder` / `markTeamProjectRevoked` are closures inside
   an 11.6k-line `@ts-nocheck` file with no injectable seam, so they are covered
   by the invariant rather than their own red spec. Extracting them next to
   `collab/shared-project-placeholder.ts` would make them directly testable.
