### PR TITLE
fix(web): key every workspace read cache on who is asking

### DIFF
--- a/apps/web/src/collab/useProjectWorkspaceScope.ts
+++ b/apps/web/src/collab/useProjectWorkspaceScope.ts
@@ -4,11 +4,17 @@ import type {
   ProjectWorkspaceScopeResponse,
   WorkspaceCollabContext,
 } from '@open-design/contracts';
-import { WORKSPACE_CONTEXT_REFRESH_EVENT } from './useWorkspaceContext';
+import {
+  WORKSPACE_CONTEXT_REFRESH_EVENT,
+  useWorkspaceContext,
+  workspaceIdentityCacheKey,
+  type WorkspaceContextState,
+} from './useWorkspaceContext';
 import {
   forceSharedCancellableGet,
   sharedCancellableGet,
 } from '../lib/shared-cancellable-get';
+import { workspaceProjectHeaders } from '../state/projects';
 import { useWorkspaceInvalidation } from './workspace-events';
 
 const PROJECT_SCOPE_RETRY_MS = 5_000;
@@ -67,8 +73,24 @@ function validScopeForProject(
   );
 }
 
+/**
+ * Whether the caller's own identity is settled enough to ask "what is this
+ * project's scope for ME".
+ *
+ * The daemon resolves an unbound project against the workspace the REQUEST names,
+ * so a read issued before the shell knows who is asking is answered `unbound` and
+ * then immediately re-read once the identity lands — two requests per project
+ * open, the first of them wrong. A context read always settles (success and
+ * failure both clear `loading`), so this can only delay the scope read, never
+ * suppress it.
+ */
+function callerIdentityIsSettled(state: WorkspaceContextState): boolean {
+  return !state.loading || state.context !== null;
+}
+
 async function fetchProjectWorkspaceScope(
   projectId: string,
+  caller: WorkspaceCollabContext | null,
   signal: AbortSignal,
   options?: { fresh?: boolean },
 ): Promise<ProjectWorkspaceScope> {
@@ -77,13 +99,27 @@ async function fetchProjectWorkspaceScope(
   // read is aborted when nobody is left awaiting it. Identity-change
   // revalidations pass `fresh` to evict the burst cache first (once per
   // broadcast burst).
+  //
+  // The key carries the CALLER's identity because the answer now depends on it:
+  // an unbound project resolves to the requesting workspace, and the scope hands
+  // back the `workspaceMemberId` that pays for that project's runs. A shared key
+  // would serve one member the wallet of another — and `forceSharedCancellableGet`
+  // does not save us, since it deliberately treats everything inside its 250ms
+  // burst window as one identity change.
   const get = options?.fresh ? forceSharedCancellableGet : sharedCancellableGet;
   return get(
-    `project-workspace-scope:${projectId}`,
+    `project-workspace-scope:${projectId}:${workspaceIdentityCacheKey(caller)}`,
     async (sharedSignal): Promise<ProjectWorkspaceScope> => {
       const response = await fetch(
         `/api/projects/${encodeURIComponent(projectId)}/workspace-scope`,
-        { cache: 'no-store', signal: sharedSignal },
+        {
+          cache: 'no-store',
+          signal: sharedSignal,
+          // Same headers every other workspace-aware project read sends. Without
+          // them the daemon cannot tell who is asking and answers `unbound` for
+          // an unbound project no matter who reads it.
+          ...(caller ? { headers: workspaceProjectHeaders(caller) } : {}),
+        },
       );
       if (!response.ok) {
         throw new ProjectWorkspaceScopeFetchError(
@@ -112,12 +148,24 @@ export function useProjectWorkspaceScope(projectId: string): ProjectWorkspaceSco
   const epochRef = useRef(0);
   const deferredRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [refreshRevision, setRefreshRevision] = useState(0);
+  const workspaceContextState = useWorkspaceContext();
+  const { context: workspaceContext } = workspaceContextState;
+  // `callerIdentity` is a string digest of every field the request carries, so it
+  // is stable across the context poll's fresh-but-equal objects. Read the context
+  // itself through a ref: depending on the OBJECT would re-run the effect (and
+  // re-read the scope) on every 30s poll for an identity that never changed.
+  const callerContextRef = useRef(workspaceContext);
+  callerContextRef.current = workspaceContext;
+  const callerIdentity = workspaceIdentityCacheKey(workspaceContext);
+  const callerSettled = callerIdentityIsSettled(workspaceContextState);
   const [state, setState] = useState<ProjectWorkspaceScopeState & {
     resolvedRevision: number;
+    resolvedIdentity: string | null;
   }>({
     loading: true,
     scope: null,
     resolvedRevision: -1,
+    resolvedIdentity: null,
   });
 
   const revalidate = useCallback(() => {
@@ -153,6 +201,10 @@ export function useProjectWorkspaceScope(projectId: string): ProjectWorkspaceSco
   }, [revalidate]);
 
   useEffect(() => {
+    // Nothing to ask on behalf of a caller whose own identity has not landed yet.
+    // The hook stays in its loading state and this effect re-runs the moment the
+    // context settles.
+    if (!callerSettled) return;
     const epoch = ++epochRef.current;
     const controller = new AbortController();
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
@@ -164,21 +216,28 @@ export function useProjectWorkspaceScope(projectId: string): ProjectWorkspaceSco
           loading: true,
           scope: null,
           resolvedRevision: refreshRevision,
+          resolvedIdentity: callerIdentity,
         });
         firstAttempt = false;
       }
       try {
-        const scope = await fetchProjectWorkspaceScope(projectId, controller.signal, {
-          // Revision 0 is the initial mount read; anything later is an
-          // explicit revalidation (identity change, reconnect, pageshow,
-          // deferred TTL re-read) and must not be served from the burst cache.
-          fresh: refreshRevision > 0,
-        });
+        const scope = await fetchProjectWorkspaceScope(
+          projectId,
+          callerContextRef.current,
+          controller.signal,
+          {
+            // Revision 0 is the initial mount read; anything later is an
+            // explicit revalidation (identity change, reconnect, pageshow,
+            // deferred TTL re-read) and must not be served from the burst cache.
+            fresh: refreshRevision > 0,
+          },
+        );
         if (controller.signal.aborted || epoch !== epochRef.current) return;
         setState({
           loading: false,
           scope,
           resolvedRevision: refreshRevision,
+          resolvedIdentity: callerIdentity,
         });
         if (scope.kind === 'unavailable') {
           retryTimer = setTimeout(() => void load(), PROJECT_SCOPE_RETRY_MS);
@@ -193,6 +252,7 @@ export function useProjectWorkspaceScope(projectId: string): ProjectWorkspaceSco
           loading: false,
           scope: null,
           resolvedRevision: refreshRevision,
+          resolvedIdentity: callerIdentity,
           failure,
         });
         // An old daemon has no endpoint to recover on a timer. Identity-change
@@ -208,13 +268,17 @@ export function useProjectWorkspaceScope(projectId: string): ProjectWorkspaceSco
       controller.abort();
       if (retryTimer) clearTimeout(retryTimer);
     };
-  }, [projectId, refreshRevision]);
+  }, [projectId, refreshRevision, callerIdentity, callerSettled]);
 
   // React preserves hook state across a ProjectView A→B prop change until the
   // effect above runs. Never expose A's already-resolved scope during that
   // transition frame: it could briefly enable B's composer with A's wallet.
+  // The caller's identity is held to the same rule: a scope resolved for the
+  // workspace the user just left names the wallet they just left with it, and an
+  // ambient context refresh can change the identity without bumping the revision.
   if (
     state.resolvedRevision !== refreshRevision ||
+    state.resolvedIdentity !== callerIdentity ||
     (state.scope !== null && state.scope.projectId !== projectId)
   ) {
     return { loading: true, scope: null };

--- a/apps/web/src/collab/useTeamMembers.ts
+++ b/apps/web/src/collab/useTeamMembers.ts
@@ -5,6 +5,7 @@ import type {
   CollabCloudMembersResponse,
   WorkspaceCollabContext,
 } from '@open-design/contracts';
+import { useWorkspaceContext, workspaceIdentityCacheKey } from './useWorkspaceContext';
 import { useWorkspaceInvalidation } from './workspace-events';
 
 // Poll cadence for the collab-cloud member directory. ~15s is light enough to
@@ -81,28 +82,51 @@ export function useTeamMembers(
 ): TeamMembersState {
   const [members, setMembers] = useState<CollabCloudMemberDirectoryEntry[]>([]);
   const mountedRef = useRef(true);
+  // A workspace switch makes an in-flight roster read describe an identity the
+  // user has left. Ordering is local to this hook instance so the late answer
+  // cannot redefine the roster the newer read already resolved.
+  const requestEpochRef = useRef(0);
+
+  // `GET /api/workspace/members` answers for whichever workspace the DAEMON is
+  // currently active in and reads nothing off the request, so the roster is a
+  // per-workspace answer with no per-workspace URL. The identity therefore has to
+  // live in the cache key, and it has to be reactive: when it changes, the key
+  // changes and this hook re-reads the new workspace's roster immediately instead
+  // of waiting out the 15-60s poll.
+  //
+  // This is not the duplicate GET `currentUserDirectoryEntry` warns about —
+  // `useWorkspaceContext` shares one coalesced request and one module-level cache
+  // across every mounted consumer, and both call sites of this hook already mount
+  // it themselves.
+  const { context: workspaceContext } = useWorkspaceContext();
+  const membersCacheKey = `workspace-members:${workspaceIdentityCacheKey(workspaceContext)}`;
 
   useEffect(() => {
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
+      requestEpochRef.current += 1;
     };
   }, []);
 
   const load = useCallback(async () => {
+    const requestEpoch = ++requestEpochRef.current;
+    const settle = (next: CollabCloudMemberDirectoryEntry[]) => {
+      if (mountedRef.current && requestEpochRef.current === requestEpoch) setMembers(next);
+    };
     try {
-      const members = await coalescedGet('workspace-members', async () => {
+      const members = await coalescedGet(membersCacheKey, async () => {
         const res = await fetch('/api/workspace/members');
         if (!res.ok) throw new Error(`members ${res.status}`);
         const body = (await res.json()) as CollabCloudMembersResponse;
         return body.members ?? [];
       });
-      if (mountedRef.current) setMembers(members);
+      settle(members);
     } catch {
       // Personal / offline / daemon without the collab cloud: no directory.
-      if (mountedRef.current) setMembers([]);
+      settle([]);
     }
-  }, []);
+  }, [membersCacheKey]);
 
   // Collab realtime hop-2: subscribe to the workspace SSE and re-fetch on a
   // pushed `members-changed` (someone joined/left/changed role). The daemon's

--- a/apps/web/src/collab/useWorkspaceContext.ts
+++ b/apps/web/src/collab/useWorkspaceContext.ts
@@ -74,9 +74,82 @@ export function workspaceIdentityCanBillAmr(state: WorkspaceContextState): boole
   return false;
 }
 
-/** Coalescing key for `GET /api/workspace/context`; shared so an identity
- *  change can evict exactly this read instead of the whole cache. */
-const WORKSPACE_CONTEXT_COALESCE_KEY = 'workspace-context';
+/**
+ * The identity a per-caller read cache must be keyed on.
+ *
+ * `coalescedGet` / `sharedCancellableGet` are CACHES (1s share window) as well as
+ * single-flight dedupers, so any read whose answer depends on WHO is asking must
+ * put that identity in its key or the previous identity's answer is served to the
+ * next one.
+ *
+ * This is `listWorkspaceProjectSummaries`' key tuple — workspace, member, role,
+ * member status, lifecycle — plus workspace type and the two permission bits, so
+ * it digests EXACTLY the eight fields `workspaceProjectHeaders` puts on the wire.
+ * A key coarser than the request it caches is the bug this helper exists to
+ * prevent; a key that changes for a field the request does not carry would only
+ * cost a redundant fetch.
+ *
+ * Deliberately excludes the money/plan fields (`planId`, `billingState`,
+ * `seatSummary`, ...): they ride along in the context response but no request is
+ * scoped by them, so keying on them would re-fetch every read on a balance
+ * change. Reads that DO depend on money key themselves (see
+ * `useWorkspaceBillingResponse`'s `billingRequestKey`).
+ *
+ * Returns `'none'` for a caller with no resolved workspace identity, which is a
+ * distinct cache partition from any real one, not a wildcard that matches them.
+ */
+export function workspaceIdentityCacheKey(
+  context: WorkspaceCollabContext | null | undefined,
+): string {
+  if (!context) return 'none';
+  return [
+    context.workspaceId,
+    context.workspaceType,
+    context.workspaceMemberId,
+    context.role,
+    context.memberStatus,
+    context.lifecycleState,
+    String(context.permissions.canShareProjects),
+    String(context.permissions.canWriteSyncedFiles),
+  ].join(':');
+}
+
+/**
+ * `GET /api/workspace/context` is the read that ESTABLISHES the caller's
+ * identity, so — unlike every other workspace read — it cannot be keyed on the
+ * identity it is fetching, and it takes no workspace argument the key could
+ * borrow instead (the switch is a separate `PUT /api/workspace/active`).
+ *
+ * What it CAN be keyed on is which identity generation the caller is asking
+ * about. This token names that generation: it advances once per deliberate
+ * identity change (a workspace switch or a sign-in) and never on ambient
+ * revalidation, so:
+ *
+ *  - Every mounted consumer reacting to ONE broadcast computes the same token
+ *    and shares one request — the thundering herd `forceCoalescedGet` exists to
+ *    prevent stays prevented.
+ *  - Two switches inside that 250ms burst window are two generations, so the
+ *    second is no longer mistaken for a second consumer of the first and served
+ *    the answer fetched for the workspace the user already left.
+ *
+ * Cross-tab, the token is the shared `localStorage` stamp the acting tab wrote,
+ * so every listening consumer in a passive tab advances to the SAME value and
+ * still collapses to one request.
+ */
+let workspaceContextRequestToken = 'initial';
+let localIdentityChangeSeq = 0;
+
+function advanceWorkspaceContextRequestToken(sharedToken?: string | null): void {
+  const next = sharedToken?.trim() || `local:${++localIdentityChangeSeq}`;
+  if (next === workspaceContextRequestToken) return;
+  workspaceContextRequestToken = next;
+}
+
+/** Coalescing key for `GET /api/workspace/context`: this read alone, partitioned
+ *  by the identity generation above. */
+function workspaceContextCoalesceKey(): string {
+  return `workspace-context:${workspaceContextRequestToken}`;
+}
 
 // Last successfully-resolved workspace context, kept at module scope so it
 // survives a component unmount/remount. Returning to the home view remounts the
@@ -91,6 +164,8 @@ let workspaceContextRevision = 0;
 export function resetWorkspaceContextCache(): void {
   cachedWorkspaceContext = null;
   workspaceContextRevision = 0;
+  workspaceContextRequestToken = 'initial';
+  localIdentityChangeSeq = 0;
 }
 
 /**
@@ -190,9 +265,10 @@ export function useWorkspaceContext(): WorkspaceContextState {
       // them to one request. The nav shell tolerates sub-second staleness.
       // An explicit identity-change refresh forces a fresh read instead of
       // sharing a settled answer that predates the change.
+      const coalesceKey = workspaceContextCoalesceKey();
       const body = options.markLoading
-        ? await forceCoalescedGet(WORKSPACE_CONTEXT_COALESCE_KEY, fetchContext)
-        : await coalescedGet(WORKSPACE_CONTEXT_COALESCE_KEY, fetchContext);
+        ? await forceCoalescedGet(coalesceKey, fetchContext)
+        : await coalescedGet(coalesceKey, fetchContext);
       if (!mountedRef.current || requestEpochRef.current !== requestEpoch) return;
       // A successful read is the only thing that redefines "signed in": persist it
       // (including an explicit null for a genuinely signed-out response) so the
@@ -258,7 +334,14 @@ export function useWorkspaceContext(): WorkspaceContextState {
       if (document.visibilityState === 'visible') refresh();
     };
     const onStorage = (event: StorageEvent) => {
-      if (event.key === WORKSPACE_CONTEXT_REFRESH_STORAGE_KEY) refreshAfterIdentityChange();
+      if (event.key !== WORKSPACE_CONTEXT_REFRESH_STORAGE_KEY) return;
+      // The acting tab advanced its own token inside `notifyWorkspaceContextRefresh`;
+      // a passive tab learns of the change only here. Advancing to the stamp the
+      // acting tab WROTE keeps this idempotent across the many mounted consumers
+      // that all hear the same storage event — they converge on one key, so one
+      // change still costs one request.
+      advanceWorkspaceContextRequestToken(event.newValue);
+      refreshAfterIdentityChange();
     };
     window.addEventListener('focus', refresh);
     window.addEventListener('pageshow', refresh);
@@ -286,9 +369,15 @@ const WORKSPACE_CONTEXT_REFRESH_STORAGE_KEY = 'od.workspaceContext.refreshAt';
 
 export function notifyWorkspaceContextRefresh(): void {
   if (typeof window === 'undefined') return;
+  const stamp = String(Date.now());
+  // Advance BEFORE dispatching: this call is the one place that knows a genuine
+  // identity change just happened, and every handler the dispatch below runs must
+  // read the new generation's key. Doing it per handler instead would turn one
+  // change into one request per mounted consumer.
+  advanceWorkspaceContextRequestToken();
   window.dispatchEvent(new Event(WORKSPACE_CONTEXT_REFRESH_EVENT));
   try {
-    window.localStorage.setItem(WORKSPACE_CONTEXT_REFRESH_STORAGE_KEY, String(Date.now()));
+    window.localStorage.setItem(WORKSPACE_CONTEXT_REFRESH_STORAGE_KEY, stamp);
   } catch {
     // The in-window event is enough when localStorage is unavailable.
   }

--- a/apps/web/tests/helpers/workspace-context.ts
+++ b/apps/web/tests/helpers/workspace-context.ts
@@ -1,0 +1,41 @@
+import type { WorkspaceCollabContext } from '@open-design/contracts';
+
+/**
+ * A complete `WorkspaceCollabContext` whose workspace + member identity the
+ * caller chooses and whose remaining fields are valid, uninteresting defaults.
+ *
+ * Specs about identity-scoped read caches only care about which workspace and
+ * which member a read was issued for; spelling the other ~10 contract fields
+ * out per case buries that.
+ */
+export function workspaceContextFixture(
+  overrides: Partial<WorkspaceCollabContext> &
+    Pick<WorkspaceCollabContext, 'workspaceId' | 'workspaceMemberId'>,
+): WorkspaceCollabContext {
+  return {
+    workspaceType: 'team',
+    role: 'member',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+    billingState: 'active',
+    planId: 'team_pro',
+    providerMode: 'platform_credits',
+    seatSummary: {
+      seatLimit: 5,
+      usedSeats: 2,
+      availableSeats: 3,
+      isSeatFull: false,
+    },
+    permissions: {
+      canManageMembers: false,
+      canManageBilling: false,
+      canInviteMembers: false,
+      canManageAutoRecharge: false,
+      canShareProjects: true,
+      canWriteSyncedFiles: true,
+      canViewWorkspaceSettings: true,
+      canManageSharedResources: false,
+    },
+    ...overrides,
+  };
+}

--- a/apps/web/tests/useProjectWorkspaceScope.test.tsx
+++ b/apps/web/tests/useProjectWorkspaceScope.test.tsx
@@ -208,15 +208,34 @@ describe('useProjectWorkspaceScope', () => {
 
   it('revalidates the same project when the signed-in workspace member changes', async () => {
     const memberNew = deferred<Response>();
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(
+    const scopeResponses: (() => Response | Promise<Response>)[] = [
+      () =>
         new Response(
           JSON.stringify(teamScope('project-a', 'workspace-a', 'member-old')),
           { status: 200, headers: { 'content-type': 'application/json' } },
         ),
-      )
-      .mockReturnValueOnce(memberNew.promise);
+      () => memberNew.promise,
+    ];
+    const scopeCalls: string[] = [];
+    const fetchMock = vi.fn((input: RequestInfo | URL): Promise<Response> => {
+      const url = String(input);
+      // The hook resolves the caller's own workspace identity before it can ask
+      // what this project's scope is FOR that caller. This case is about the
+      // scope read, so answer "no workspace" and keep the context read out of
+      // the scope response sequence.
+      if (url.includes('/api/workspace/context')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ context: null }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+        );
+      }
+      scopeCalls.push(url);
+      const next = scopeResponses.shift();
+      if (!next) throw new Error(`Unexpected scope fetch: ${url}`);
+      return Promise.resolve(next());
+    });
     vi.stubGlobal('fetch', fetchMock);
 
     const hook = renderHook(() => useProjectWorkspaceScope('project-a'));
@@ -242,6 +261,6 @@ describe('useProjectWorkspaceScope', () => {
         context: { workspaceMemberId: 'member-new' },
       });
     });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(scopeCalls).toHaveLength(2);
   });
 });

--- a/apps/web/tests/useProjectWorkspaceScope.workspace-identity.test.tsx
+++ b/apps/web/tests/useProjectWorkspaceScope.workspace-identity.test.tsx
@@ -1,0 +1,197 @@
+// @vitest-environment jsdom
+
+// Red spec, two halves of the same read.
+//
+// 1. The read is HEADERLESS. `GET /api/projects/:id/workspace-scope` resolves an
+//    unbound project against the caller's current workspace (#6185), but it can
+//    only do that when the request carries the caller's `x-od-workspace-*`
+//    identity — which this read never sent. The daemon fallback was therefore
+//    unreachable from the product: every unbound project answered `unbound` for
+//    every caller, forever.
+//
+// 2. Once the read IS identity-bearing, its cache key must carry that identity.
+//    `shared-cancellable-get` shares a settled answer for 1s and joins an
+//    in-flight one unconditionally, so a key of `project-workspace-scope:<id>`
+//    alone hands one member's scope — and therefore the `workspaceMemberId` that
+//    pays for the project's runs — to another. Half 2 is a prerequisite for half
+//    1, not a follow-up.
+
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/collab/workspace-events', () => ({
+  useWorkspaceInvalidation: vi.fn(() => ({ connected: false })),
+}));
+
+import { useProjectWorkspaceScope } from '../src/collab/useProjectWorkspaceScope';
+import { notifyWorkspaceContextRefresh } from '../src/collab/useWorkspaceContext';
+import { workspaceContextFixture } from './helpers/workspace-context';
+
+const CONTEXTS = {
+  a: workspaceContextFixture({ workspaceId: 'ws-a', workspaceMemberId: 'mem-a' }),
+  b: workspaceContextFixture({ workspaceId: 'ws-b', workspaceMemberId: 'mem-b' }),
+  c: workspaceContextFixture({ workspaceId: 'ws-c', workspaceMemberId: 'mem-c' }),
+};
+
+const PROJECT_ID = 'project-unbound';
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+/**
+ * Stand in for the daemon's `resolveProjectWorkspaceScopeForCaller`: a project
+ * with no binding of its own resolves to the workspace the REQUEST names, and to
+ * `unbound` when the request names none.
+ */
+function scopeAnswerFor(headers: Headers): unknown {
+  const workspaceId = headers.get('x-od-workspace-id')?.trim() ?? '';
+  const workspaceMemberId = headers.get('x-od-workspace-member-id')?.trim() ?? '';
+  if (!workspaceId || !workspaceMemberId) {
+    return {
+      scope: { kind: 'unbound', projectId: PROJECT_ID, workspaceId: null, context: null },
+    };
+  }
+  return {
+    scope: {
+      kind: 'team',
+      projectId: PROJECT_ID,
+      workspaceId,
+      visibility: 'personal',
+      context: workspaceContextFixture({ workspaceId, workspaceMemberId }),
+    },
+  };
+}
+
+let activeWorkspace: 'a' | 'b' | 'c';
+let scopeReads: {
+  workspaceId: string;
+  headers: Record<string, string>;
+  resolve: (r: Response) => void;
+}[];
+let slowWorkspaceIds: Set<string>;
+
+beforeEach(() => {
+  activeWorkspace = 'a';
+  scopeReads = [];
+  slowWorkspaceIds = new Set();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = String(input);
+      if (url.includes('/api/workspace/context')) {
+        return Promise.resolve(jsonResponse({ context: CONTEXTS[activeWorkspace] }));
+      }
+      if (url.includes('/workspace-scope')) {
+        const headers = new Headers(init?.headers);
+        const workspaceId = headers.get('x-od-workspace-id')?.trim() ?? '';
+        const sent = Object.fromEntries(headers.entries());
+        const answer = jsonResponse(scopeAnswerFor(headers));
+        if (!slowWorkspaceIds.has(workspaceId)) {
+          scopeReads.push({ workspaceId, headers: sent, resolve: () => {} });
+          return Promise.resolve(answer);
+        }
+        let resolve!: (response: Response) => void;
+        const promise = new Promise<Response>((next) => {
+          resolve = next;
+        });
+        scopeReads.push({ workspaceId, headers: sent, resolve });
+        return promise;
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('useProjectWorkspaceScope reads as the caller', () => {
+  it('sends the caller workspace identity so an unbound project resolves', async () => {
+    const hook = renderHook(() => useProjectWorkspaceScope(PROJECT_ID));
+    await waitFor(() => {
+      expect(hook.result.current.loading).toBe(false);
+    });
+
+    expect(hook.result.current.scope).toMatchObject({
+      kind: 'team',
+      projectId: PROJECT_ID,
+      workspaceId: 'ws-a',
+      context: { workspaceId: 'ws-a', workspaceMemberId: 'mem-a' },
+    });
+    expect(scopeReads.map((read) => read.workspaceId)).toEqual(['ws-a']);
+
+    // The full `workspaceProjectHeaders` set, not just the two the daemon needs
+    // to recognise a caller at all: role, lifecycle, member status and the
+    // permission pair are what it judges the request BY, and
+    // `e2e/tests/collab/project-workspace-scope.test.ts` proves the daemon
+    // resolves this exact set. Dropping any of them here would put the two
+    // halves out of step while both stayed green.
+    expect(scopeReads[0]?.headers).toMatchObject({
+      'x-od-workspace-id': 'ws-a',
+      'x-od-workspace-type': 'team',
+      'x-od-workspace-member-id': 'mem-a',
+      'x-od-workspace-role': 'member',
+      'x-od-workspace-lifecycle-state': 'active',
+      'x-od-workspace-member-status': 'active',
+      'x-od-workspace-can-share-projects': 'true',
+      'x-od-workspace-can-write-synced-files': 'true',
+    });
+
+    hook.unmount();
+  });
+
+  it('never serves the previous workspace scope after a switch', async () => {
+    const hook = renderHook(() => useProjectWorkspaceScope(PROJECT_ID));
+    await waitFor(() => {
+      expect(hook.result.current.scope).toMatchObject({ workspaceId: 'ws-a' });
+    });
+
+    // Switch A -> B. This scope read is slow, so it is still in flight below.
+    //
+    // The refresh event also revalidates on the CURRENT identity before the new
+    // context lands (a sign-in can change role/plan without changing workspace,
+    // so that revalidation is not redundant), hence one more `ws-a` read here.
+    // What matters is that the switch produced a read as `ws-b`.
+    slowWorkspaceIds.add('ws-b');
+    activeWorkspace = 'b';
+    act(() => {
+      notifyWorkspaceContextRefresh();
+    });
+    await waitFor(() => {
+      expect(scopeReads.at(-1)?.workspaceId).toBe('ws-b');
+    });
+
+    // Switch B -> C inside the 250ms force-burst window. Keyed without the
+    // identity, this joins B's in-flight read and hands C's member B's scope —
+    // i.e. bills B's wallet for a run C started.
+    activeWorkspace = 'c';
+    act(() => {
+      notifyWorkspaceContextRefresh();
+    });
+
+    await act(async () => {
+      const pending = scopeReads.find((read) => read.workspaceId === 'ws-b');
+      pending?.resolve(jsonResponse(scopeAnswerFor(new Headers({
+        'x-od-workspace-id': 'ws-b',
+        'x-od-workspace-member-id': 'mem-b',
+      }))));
+    });
+
+    await waitFor(() => {
+      expect(hook.result.current.scope).toMatchObject({
+        kind: 'team',
+        workspaceId: 'ws-c',
+        context: { workspaceId: 'ws-c', workspaceMemberId: 'mem-c' },
+      });
+    });
+    expect(hook.result.current.loading).toBe(false);
+
+    hook.unmount();
+  });
+});

--- a/apps/web/tests/useTeamMembers.workspace-identity.test.tsx
+++ b/apps/web/tests/useTeamMembers.workspace-identity.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+
+// Red spec: the member-directory read must be cached per workspace identity.
+//
+// `coalescedGet` is a CACHE with a 1s TTL, not just in-flight dedupe. Keyed on a
+// constant `'workspace-members'`, the roster the client read while standing in
+// workspace A is handed to workspace B for the whole share window — and while
+// A's read is still in flight, B joins it unconditionally, with no window at
+// all.
+//
+// The user-visible symptom is the creator line on project cards:
+// `RecentProjectsStrip.resolveCreator` turns a team-shared project's
+// `ownerMemberId` into a display name through `useTeamMembers().resolve`, so a
+// leaked roster renders the previous workspace's teammate name (or falls back to
+// the generic 团队成员) beside cards in the workspace the user just switched to.
+
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CollabCloudMemberDirectoryEntry } from '@open-design/contracts';
+
+vi.mock('../src/collab/workspace-events', () => ({
+  useWorkspaceInvalidation: vi.fn(() => ({ connected: false })),
+}));
+
+import { useTeamMembers } from '../src/collab/useTeamMembers';
+import { notifyWorkspaceContextRefresh } from '../src/collab/useWorkspaceContext';
+import { workspaceContextFixture } from './helpers/workspace-context';
+
+const CONTEXTS = {
+  a: workspaceContextFixture({ workspaceId: 'ws-a', workspaceMemberId: 'mem-a' }),
+  b: workspaceContextFixture({ workspaceId: 'ws-b', workspaceMemberId: 'mem-b' }),
+};
+
+const ROSTERS: Record<'a' | 'b', CollabCloudMemberDirectoryEntry[]> = {
+  a: [{ memberId: 'mem-a-peer', displayName: 'Workspace A teammate', role: 'owner' }],
+  b: [{ memberId: 'mem-b-peer', displayName: 'Workspace B teammate', role: 'owner' }],
+};
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+type PendingMembersRead = {
+  workspace: 'a' | 'b';
+  resolve: (response: Response) => void;
+};
+
+/** Which workspace the daemon is currently active in. */
+let activeWorkspace: 'a' | 'b';
+/** Every `/api/workspace/members` read the client issued, oldest first. */
+let membersReads: PendingMembersRead[];
+/** Workspaces whose members read is held open instead of answering at once. */
+let slowMembersWorkspaces: Set<'a' | 'b'>;
+
+beforeEach(() => {
+  activeWorkspace = 'a';
+  membersReads = [];
+  slowMembersWorkspaces = new Set();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: RequestInfo | URL): Promise<Response> => {
+      const url = String(input);
+      if (url.includes('/api/workspace/context')) {
+        return Promise.resolve(jsonResponse({ context: CONTEXTS[activeWorkspace] }));
+      }
+      if (url.includes('/api/workspace/members')) {
+        const workspace = activeWorkspace;
+        const answer = jsonResponse({ members: ROSTERS[workspace] });
+        if (!slowMembersWorkspaces.has(workspace)) {
+          membersReads.push({ workspace, resolve: () => {} });
+          return Promise.resolve(answer);
+        }
+        let resolve!: (response: Response) => void;
+        const promise = new Promise<Response>((next) => {
+          resolve = next;
+        });
+        membersReads.push({ workspace, resolve });
+        return promise;
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('useTeamMembers caches the roster per workspace identity', () => {
+  it('never resolves a member against the workspace the user just left', async () => {
+    slowMembersWorkspaces.add('a');
+    const hook = renderHook(() => useTeamMembers());
+    await waitFor(() => {
+      expect(membersReads).toHaveLength(1);
+    });
+    expect(membersReads[0]?.workspace).toBe('a');
+
+    // The user switches workspace: the daemon's active workspace is now B, and
+    // the context read that follows the switch says so. A's roster read is
+    // still in flight, so nothing has evicted it.
+    activeWorkspace = 'b';
+    await act(async () => {
+      notifyWorkspaceContextRefresh();
+    });
+
+    // The roster the hook exposes must describe B. A read keyed without the
+    // identity would instead join (or share) A's read and answer with A's
+    // teammate.
+    await waitFor(() => {
+      expect(hook.result.current.members).toEqual(ROSTERS.b);
+    });
+    expect(hook.result.current.resolve('mem-b-peer')?.displayName).toBe(
+      'Workspace B teammate',
+    );
+
+    // A's read finally lands. It was issued for an identity the user has left,
+    // so it must not define B's roster either.
+    await act(async () => {
+      membersReads[0]?.resolve(jsonResponse({ members: ROSTERS.a }));
+    });
+    expect(hook.result.current.members).toEqual(ROSTERS.b);
+    expect(hook.result.current.resolve('mem-a-peer')).toBeNull();
+
+    hook.unmount();
+  });
+});

--- a/apps/web/tests/useWorkspaceContext.identity-generation.test.tsx
+++ b/apps/web/tests/useWorkspaceContext.identity-generation.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+
+// Red spec: `GET /api/workspace/context` is the read that ESTABLISHES the
+// caller's identity, so its cache key cannot name the identity it is fetching.
+// What it can name is which identity GENERATION the caller is asking about — and
+// a workspace switch defines a new one.
+//
+// Without that, two switches inside `forceCoalescedGet`'s 250ms burst window
+// collapse into one read: the second switch is judged part of the first's
+// broadcast burst, skips the eviction, and is served the answer that was fetched
+// for the workspace the user already left. Nothing re-reads until the next poll
+// (30s connected, 120s on the SSE floor), so the whole shell — rail name, plan
+// nameplate, every permission judgement derived from the context — describes the
+// wrong workspace for that long.
+
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/collab/workspace-events', () => ({
+  useWorkspaceInvalidation: vi.fn(() => ({ connected: false })),
+}));
+
+import {
+  notifyWorkspaceContextRefresh,
+  useWorkspaceContext,
+} from '../src/collab/useWorkspaceContext';
+import { workspaceContextFixture } from './helpers/workspace-context';
+
+const CONTEXTS = {
+  a: workspaceContextFixture({ workspaceId: 'ws-a', workspaceMemberId: 'mem-a' }),
+  b: workspaceContextFixture({ workspaceId: 'ws-b', workspaceMemberId: 'mem-b' }),
+  c: workspaceContextFixture({ workspaceId: 'ws-c', workspaceMemberId: 'mem-c' }),
+};
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+let activeWorkspace: 'a' | 'b' | 'c';
+let contextReads: { workspace: 'a' | 'b' | 'c'; resolve: (r: Response) => void }[];
+let slowWorkspaces: Set<'a' | 'b' | 'c'>;
+
+beforeEach(() => {
+  activeWorkspace = 'a';
+  contextReads = [];
+  slowWorkspaces = new Set();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: RequestInfo | URL): Promise<Response> => {
+      const url = String(input);
+      if (!url.includes('/api/workspace/context')) {
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      }
+      const workspace = activeWorkspace;
+      const answer = jsonResponse({ context: CONTEXTS[workspace] });
+      if (!slowWorkspaces.has(workspace)) {
+        contextReads.push({ workspace, resolve: () => {} });
+        return Promise.resolve(answer);
+      }
+      let resolve!: (response: Response) => void;
+      const promise = new Promise<Response>((next) => {
+        resolve = next;
+      });
+      contextReads.push({ workspace, resolve });
+      return promise;
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('useWorkspaceContext keys its read on the identity generation', () => {
+  it('does not serve the first switch answer to a second switch in the same burst', async () => {
+    const hook = renderHook(() => useWorkspaceContext());
+    await waitFor(() => {
+      expect(hook.result.current.context?.workspaceId).toBe('ws-a');
+    });
+
+    // Switch A -> B. This read is slow (vela-backed context reads take up to
+    // seconds), so it is still in flight when the next switch happens.
+    slowWorkspaces.add('b');
+    activeWorkspace = 'b';
+    act(() => {
+      notifyWorkspaceContextRefresh();
+    });
+    await waitFor(() => {
+      expect(contextReads).toHaveLength(2);
+    });
+    expect(contextReads[1]?.workspace).toBe('b');
+
+    // Switch B -> C, inside the 250ms burst window. This is a SECOND identity
+    // change, not a second consumer reacting to the first one's broadcast, so it
+    // must produce its own read.
+    activeWorkspace = 'c';
+    act(() => {
+      notifyWorkspaceContextRefresh();
+    });
+
+    await act(async () => {
+      contextReads[1]?.resolve(jsonResponse({ context: CONTEXTS.b }));
+    });
+
+    await waitFor(() => {
+      expect(hook.result.current.context?.workspaceId).toBe('ws-c');
+      expect(hook.result.current.context?.workspaceMemberId).toBe('mem-c');
+    });
+    expect(hook.result.current.loading).toBe(false);
+
+    hook.unmount();
+  });
+
+  it('still collapses one broadcast heard by many mounted consumers into one read', async () => {
+    const first = renderHook(() => useWorkspaceContext());
+    const second = renderHook(() => useWorkspaceContext());
+    const third = renderHook(() => useWorkspaceContext());
+    await waitFor(() => {
+      expect(first.result.current.context?.workspaceId).toBe('ws-a');
+      expect(second.result.current.context?.workspaceId).toBe('ws-a');
+      expect(third.result.current.context?.workspaceId).toBe('ws-a');
+    });
+    const readsBeforeSwitch = contextReads.length;
+
+    // ONE switch, heard by three mounted consumers in the same synchronous
+    // dispatch pass. Keying on the generation must not turn that single change
+    // into three requests — that is the thundering herd `forceCoalescedGet`
+    // exists to prevent.
+    activeWorkspace = 'b';
+    await act(async () => {
+      notifyWorkspaceContextRefresh();
+    });
+    await waitFor(() => {
+      expect(first.result.current.context?.workspaceId).toBe('ws-b');
+      expect(second.result.current.context?.workspaceId).toBe('ws-b');
+      expect(third.result.current.context?.workspaceId).toBe('ws-b');
+    });
+    expect(contextReads.length - readsBeforeSwitch).toBe(1);
+
+    first.unmount();
+    second.unmount();
+    third.unmount();
+  });
+});


### PR DESCRIPTION
## Why

**My use case.** After #6185 landed I went back over the neighbouring reads on this branch and found that the fix it shipped is *currently unreachable in the product* — see the fourth bullet below. Pulling that thread turned up a whole class of the same bug, so this PR closes the class rather than the one instance.

**The pain.** `apps/web/src/lib/coalesced-get.ts` (and its cancellable sibling `shared-cancellable-get.ts`) are **caches with a 1s TTL**, not just in-flight dedupers — `DEFAULT_TTL_MS = 1000`, and after a run settles every caller inside that window receives the shared cached result. An **in-flight** entry is worse: it is joined unconditionally, with no window at all. So any key that omits the caller's workspace/member identity hands the previous identity's answer to the new one.

A sibling read already does this right — `state/projects.ts`'s `listWorkspaceProjectSummaries` keys on `workspaceId:workspaceMemberId:role:memberStatus:lifecycleState:workspaceView`. Three reads did not:

1. **`useTeamMembers`** — key `'workspace-members'`, hardcoded. `GET /api/workspace/members` is `app.get(..., async (_req, res) =>` — it reads *nothing* off the request and answers for whichever workspace the **daemon** is active in. So the roster is a per-workspace answer with no per-workspace URL, which is exactly the shape that must live in the key.

2. **`useWorkspaceContext`** — key `'workspace-context'`, hardcoded. Discussed separately below, because this one cannot be keyed on the identity at all.

3. **`useProjectWorkspaceScope`** — key `project-workspace-scope:${projectId}`, no identity. The scope carries `workspaceMemberId`, which is *the wallet that pays for that project's runs*, so a shared key serves one member the billing subject of another.

4. **The follow-on.** #6185 (merged, squash `90dee9476`) added `resolveProjectWorkspaceScopeForCaller` so `GET /api/projects/:id/workspace-scope` resolves an **unbound** project against the caller's current workspace. The route reads that identity through `workspaceProjectContextFromRequest(req)` → the `x-od-workspace-*` headers. But the web client fetched **headerless** (`fetch(url, { cache: 'no-store', signal })`), so the daemon saw `'missing'`, passed `callerWorkspaceId: null`, and returned `unbound` for every caller forever. **That daemon code has been dead since it merged.** This PR wires the headers, which is what makes it fire.

**Ordering:** item 4 depends on item 3. The moment the read becomes identity-bearing, its cache key *must* carry that identity or you cache one member's scope and serve it to another. They must land together, which is why they are one commit.

## What users will see

No new UI. Behaviour that changes:

- **Project cards show the right creator after a workspace switch.** The `{creator}创建` line resolves a team-shared project's `ownerMemberId` through the member directory (`RecentProjectsStrip.resolveCreator` → `useTeamMembers().resolve`). Previously, for up to a second after switching — and indefinitely if the pre-switch roster read was still in flight — cards in the new workspace could render the *previous* workspace's teammate name, or fall back to the generic 团队成员. As a side effect the roster now refreshes immediately on a switch instead of waiting out its 15–60s poll.
- **Switching workspaces twice quickly no longer leaves the shell on the wrong workspace.** Two switches inside `forceCoalescedGet`'s 250ms burst window were treated as one broadcast burst, so the second switch skipped the eviction and was served the answer fetched for the workspace the user had already left. Nothing re-read until the next context poll (30s connected / 120s on the SSE floor), so the rail name, plan nameplate, and every permission judgement derived from the context described the wrong workspace for that long.
- **An unbound (never-claimed) project now resolves to the workspace you are standing in**, which is #6185's intended behaviour finally reaching users.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [x] **Default behavior change** — an unbound project's workspace scope now resolves to the caller's current workspace instead of `unbound`. No new endpoint or contract shape: this is #6185's already-merged daemon behaviour becoming reachable because the client now sends the headers it needs. `useProjectWorkspaceScope` also carries the existing `workspaceProjectHeaders` set on a read that previously sent none.
- [ ] **None** — internal refactor, docs, tests, or translation update only

No CLI counterpart is needed: all three sites are client-side browser cache keys inside `apps/web` hooks. There is no new capability and no new endpoint — the HTTP surface (`/api/workspace/members`, `/api/workspace/context`, `/api/projects/:id/workspace-scope`) is unchanged, and `od project …` already reaches the same daemon routes.

## Screenshots

None — no UI surface is added or restyled. The visible effect (a correct creator name after a switch) is a data-correctness change on existing markup and is pinned by the specs below.

## Bug fix verification

Test paths that reproduce the bugs (all new):

- `apps/web/tests/useTeamMembers.workspace-identity.test.tsx`
- `apps/web/tests/useWorkspaceContext.identity-generation.test.tsx`
- `apps/web/tests/useProjectWorkspaceScope.workspace-identity.test.tsx`

**Did they go red on the base branch and green on this one? Yes.** Each asserts the *cross-identity leak*, not the eventual correct state: read as identity A, switch to B, read the same logical resource while A's read is still in flight (deterministic — an in-flight entry is joined with no TTL involved), and assert B never receives A's answer. The late A answer is then resolved and asserted not to clobber B's.

RED — `feat/workspace-team` source with these specs applied (`git stash push -- apps/web/src`), final spec text:

```
 ❯ tests/useTeamMembers.workspace-identity.test.tsx (1 test | 1 failed)
   × never resolves a member against the workspace the user just left
 ❯ tests/useProjectWorkspaceScope.workspace-identity.test.tsx (2 tests | 2 failed)
   × sends the caller workspace identity so an unbound project resolves
   × never serves the previous workspace scope after a switch
 ❯ tests/useWorkspaceContext.identity-generation.test.tsx (2 tests | 1 failed)
   × does not serve the first switch answer to a second switch in the same burst

AssertionError: expected { kind: 'unbound', …(3) } to match object { kind: 'team', …(3) }
   - "context": { "workspaceId": "ws-a", "workspaceMemberId": "mem-a" },   - "kind": "team",
   + "context": null,                                                     + "kind": "unbound",
AssertionError: expected { kind: 'unbound', …(3) } to match object { workspaceId: 'ws-a' }
AssertionError: expected [] to deeply equal [ { memberId: 'mem-b-peer', …(2) } ]
AssertionError: expected 'ws-b' to be 'ws-c' // Object.is equality

 Test Files  3 failed (3)
      Tests  4 failed | 1 passed (5)
```

The one test green on base is deliberate: `still collapses one broadcast heard by many mounted consumers into one read` is the anti-regression guard for the thundering herd `forceCoalescedGet` exists to prevent. It must pass both before and after, and it does.

GREEN — this branch:

```
 Test Files  3 passed (3)
      Tests  5 passed (5)
```

**Item 4 end-to-end.** The daemon half already has coverage — #6185 shipped `e2e/tests/collab/project-workspace-scope.test.ts`, which pins "unbound + header-bearing request → caller's workspace" and "unbound + no caller identity → still `unbound`", seeded only through production HTTP APIs. Writing a *new* e2e for the same two claims would be green on base and prove nothing, so instead I ran the existing one to confirm the fallback fires, and closed the remaining gap on the client side:

```
 RUN  v4.1.6 .../e2e
 Test Files  1 passed (1)
      Tests  2 passed (2)
   Duration  23.00s
```

The gap that e2e file cannot see is that it builds the eight `x-od-workspace-*` headers by hand rather than through `workspaceProjectHeaders`, so client and daemon could drift while both stayed green. `useProjectWorkspaceScope.workspace-identity.test.tsx` now asserts the full eight-header set the client puts on the wire, matching the set the e2e proves the daemon resolves. The cache-key half is untestable at the HTTP boundary at all — the cache is purely client-side — so `apps/web` is the cheapest layer that can see it, per AGENTS.md → "Try the cheapest layer first".

## Validation

Node 24.18.0 throughout (Node 22 mis-ABIs `better-sqlite3`).

- `pnpm guard` — pass
- `pnpm typecheck` — pass, all 20 packages
- `pnpm --filter @open-design/web test` — **544 files, 5501 passed, 11 skipped, 0 failed.** Includes `useProjectWorkspaceScope.test.tsx`, `single-flight-project-reads.test.tsx`, `FileViewer.test.tsx`, and the `RecentProjectsStrip` suites. `FileWorkspace.design-system.test.tsx` (known flaky at `:707`) passed on both full runs.
- `cd e2e && pnpm test tests/collab/project-workspace-scope.test.ts` — 2 passed
- No daemon source touched, so the daemon suite is not implicated. (Noting for the record that `pnpm --filter @open-design/daemon typecheck` would prove nothing about `server.ts` regardless — it carries `@ts-nocheck`, as do 28 other daemon files.)

### Notes for the reviewer

**Why `useWorkspaceContext` gets a generation token instead of an identity.** This is the read that *establishes* the identity, so it cannot be keyed on the identity it is fetching — and unlike the billing read it takes no workspace argument the key could borrow, because the switch is a separate `PUT /api/workspace/active` and the context read is unparameterised. What is genuinely available at request time is *which identity generation the caller is asking about*, and a deliberate identity change is the one event that defines a new one. So the key is `workspace-context:<token>`, where the token advances exactly once per switch/sign-in and never on ambient revalidation (focus, `pageshow`, visibility, poll — all of which legitimately tolerate sub-second staleness).

Two properties make that safe:

- `notifyWorkspaceContextRefresh()` advances the token *before* dispatching, so all mounted consumers reacting to one broadcast compute the same key and share one request. Advancing per handler instead would produce one request per mounted consumer — the exact herd `forceCoalescedGet` was written to stop. The second spec in that file pins this.
- Cross-tab, a passive tab advances to `event.newValue` — the stamp the acting tab wrote — so the dozen consumers hearing the same `storage` event converge on one key. Using a local counter there would have re-created the herd per tab.

I considered "keep one key and invalidate on switch instead" (the option explicitly left open) and rejected it: that is what the code already did via `forceCoalescedGet`, and it is precisely what fails, because `FORCE_BURST_MS` cannot distinguish "a second consumer of one change" from "a second change". The token makes that distinction explicit rather than timing-based.

**`workspaceIdentityCacheKey` digests eight fields, not five.** It extends `listWorkspaceProjectSummaries`' tuple with `workspaceType` and the two permission bits so it names *exactly* the eight fields `workspaceProjectHeaders` puts on the wire. A key coarser than the request it caches is the bug; a key that changes for a field the request does not carry would only cost a redundant fetch. It deliberately excludes the money/plan fields (`planId`, `billingState`, `seatSummary`) — no request is scoped by them, so keying on them would refetch on every balance change. Reads that *do* depend on money already key themselves (`useWorkspaceBillingResponse`'s `billingRequestKey`).

**Request-count discipline.** This branch cares about the HTTP/1.1 six-connection budget, so:

- `useProjectWorkspaceScope` waits for the caller's own identity to settle (`callerIdentityIsSettled`) before reading. Without that gate a project open would cost a headerless read answered `unbound` plus a corrected one — two requests, the first wrong. A context read always settles (success and failure both clear `loading`), so the gate can only delay the read, never suppress it.
- The caller's context is read through a ref and the effect depends on the *string* digest. Depending on the context object would re-run the effect on every 30s poll, since each successful read produces a fresh-but-equal object.
- `useTeamMembers` and `useProjectWorkspaceScope` now mount `useWorkspaceContext()` internally. This adds no GET: it shares one coalesced request, one module-level cache, and one multiplexed `EventSource` (`useEventStream`) across every consumer, and **both** call sites of each hook already mount it themselves (`RecentProjectsStrip.tsx:327`, `ProjectView.tsx:1542`, and `FileViewer.tsx` in three places). The "don't fetch a context" warning on `currentUserDirectoryEntry` is about duplicate *network* reads and still holds.

**One pre-existing extra request I did not change.** `WORKSPACE_CONTEXT_REFRESH_EVENT` revalidates `useProjectWorkspaceScope` on the *current* identity before the new context lands, so a switch issues one read for the outgoing workspace before the one for the incoming workspace. That is not a regression — the count is the same as before this PR — and the revalidation is not redundant in general, since a sign-in can change role/plan without changing workspace. It is called out in a comment in the spec so the assertion reads honestly rather than over-fitting to a request sequence.

### Out of scope, deliberately

- **The AMR send gate in `ProjectView.tsx`.** #6185's second commit narrowed it and the "send button permanently grey" symptom is fixed. Untouched.
- **`state/projects.ts`'s `'local-projects'` key.** Left alone, and it is safe — but the comment above it is slightly off about *why*, worth knowing if anyone revisits it. It says the key is unreachable once a workspace context exists because the workspace branch returns first. That is true of the function's control flow given a context argument, but two call sites reach it *with* a context in hand simply by not passing one (`ProjectReferenceModal.tsx:51`, `pet/DesktopPetSurface.tsx:51`). It is nevertheless leak-free for a stronger reason: `GET /api/projects` is the **no-scope catalog** — `app.get('/api/projects', async (_req, res) =>`, ignoring the request entirely and returning only `listUnboundProjects`. Its answer does not depend on who is asking, so a constant key cannot serve one identity another's rows. No change needed; #6189 already corrected the misleading part of that comment.
- **UI, copy, i18n keys.** None touched.
