### PR TITLE
fix(collab): carry B's workspace name for personal workspaces too

### DIFF
--- a/apps/daemon/src/collab/vela-workspace-context.ts
+++ b/apps/daemon/src/collab/vela-workspace-context.ts
@@ -144,6 +144,11 @@ export function mapVelaWorkspaceContext(input: unknown): WorkspaceCollabContext 
     context.teamId = workspaceId;
   }
   const workspaceName = str((raw as { workspaceName?: unknown }).workspaceName);
+  // B names EVERY workspace, personal included, so the name belongs on the
+  // context for both types — that is what lets a surface label the current
+  // workspace off the startup context alone. `teamName` stays team-only: it is
+  // the team switcher's field and doubles as an "is a team" signal.
+  if (workspaceName) context.workspaceName = workspaceName;
   if (workspaceName && workspaceType === 'team') context.teamName = workspaceName;
   const displayName = str((raw as { displayName?: unknown }).displayName);
   if (displayName) context.displayName = displayName;
@@ -435,6 +440,7 @@ export function workspaceContextFromDirectoryItem(
   };
   const settingsUrl = resolveWorkspaceSettingsUrl(item.workspaceId, undefined);
   if (settingsUrl) context.workspaceSettingsUrl = settingsUrl;
+  if (item.workspaceName) context.workspaceName = item.workspaceName;
   if (item.workspaceType === 'team') {
     context.teamId = item.workspaceId;
     context.teamName = item.workspaceName;

--- a/apps/daemon/src/collab/workspace-context.ts
+++ b/apps/daemon/src/collab/workspace-context.ts
@@ -281,6 +281,11 @@ export function parseWorkspaceCollabContext(input: unknown): WorkspaceCollabCont
   if (typeof raw.teamName === 'string' && raw.teamName.trim()) {
     context.teamName = raw.teamName.trim();
   }
+  // Any workspace type may carry a name here — the dev/demo lane must be able
+  // to drive a personal workspace's label the same way B does.
+  if (typeof raw.workspaceName === 'string' && raw.workspaceName.trim()) {
+    context.workspaceName = raw.workspaceName.trim();
+  }
   if (typeof raw.displayName === 'string' && raw.displayName.trim()) {
     context.displayName = raw.displayName.trim();
   }

--- a/apps/daemon/tests/vela-workspace-context.test.ts
+++ b/apps/daemon/tests/vela-workspace-context.test.ts
@@ -3,6 +3,7 @@ import {
   createCachedWorkspaceDirectoryFetcher,
   createVelaWorkspaceContextProvider,
   mapVelaWorkspaceContext,
+  workspaceContextFromDirectoryItem,
 } from '../src/collab/vela-workspace-context.js';
 
 // A well-formed body as B's GET /api/v1/workspaces/current returns it — a team
@@ -63,6 +64,42 @@ describe('mapVelaWorkspaceContext', () => {
     const mapped = mapVelaWorkspaceContext({ ...B_TEAM_CONTEXT, workspaceType: 'personal' });
     expect(mapped?.workspaceType).toBe('personal');
     expect(mapped?.teamId).toBeUndefined();
+  });
+
+  // recvpkuLOujgAm follow-up: B names EVERY workspace, personal included
+  // (vela #964 derives "<owner>'s workspace" for an unnamed personal one, and
+  // an owner may rename it outright). Dropping that name for the personal case
+  // left the switcher's collapsed label with nothing but a hardcoded English
+  // fallback until the user opened the dropdown and the directory read landed.
+  it('carries the workspace name for a personal workspace', () => {
+    const mapped = mapVelaWorkspaceContext({
+      ...B_TEAM_CONTEXT,
+      workspaceType: 'personal',
+      workspaceName: "Ada's workspace",
+    });
+    expect(mapped?.workspaceName).toBe("Ada's workspace");
+    // `teamName` stays team-only — it is the team switcher's field.
+    expect(mapped?.teamName).toBeUndefined();
+  });
+
+  it('carries the workspace name for a team workspace alongside teamName', () => {
+    const mapped = mapVelaWorkspaceContext({ ...B_TEAM_CONTEXT, workspaceName: '1321' });
+    expect(mapped?.workspaceName).toBe('1321');
+    expect(mapped?.teamName).toBe('1321');
+  });
+
+  it('carries a personal workspace name synthesized from a directory item', () => {
+    const context = workspaceContextFromDirectoryItem({
+      workspaceId: 'ws-personal-1',
+      workspaceName: "Ada's workspace",
+      workspaceType: 'personal',
+      workspaceMemberId: 'wm-9',
+      role: 'owner',
+      memberStatus: 'active',
+      lifecycleState: 'active',
+    });
+    expect(context.workspaceName).toBe("Ada's workspace");
+    expect(context.teamName).toBeUndefined();
   });
 
   it('re-derives an inconsistent seat summary from the authoritative counts', () => {

--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -624,8 +624,16 @@ export function EntryNavRail({
   const currentWorkspaceItem = context
     ? workspaceItems.find((item) => item.workspaceId === context.workspaceId) ?? null
     : null;
+  // Name the CURRENT workspace from whatever real source has already answered,
+  // never from a read of our own. `context` is the startup context the shell
+  // already holds, and B populates its `workspaceName` for personal workspaces
+  // too — so a personal workspace is labelled correctly on first paint instead
+  // of sitting on the hardcoded fallback until the user opens this dropdown and
+  // the directory read lands (recvpkuLOujgAm). The directory item stays first:
+  // when it is warm it is the same value, revalidated.
   const workspaceName =
     currentWorkspaceItem?.workspaceName?.trim() ||
+    context?.workspaceName?.trim() ||
     context?.teamName?.trim() ||
     context?.teamId ||
     (context?.workspaceType === 'personal' ? 'Personal workspace' : '');

--- a/apps/web/tests/components/EntryNavRail.workspace-name.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.workspace-name.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+//
+// recvpkuLOujgAm: the personal workspace rendered the hardcoded English
+// "Personal workspace" instead of its real remote name (e.g. "Ada's
+// workspace"). B names every workspace — personal included — and the daemon
+// already fetches that context at startup, so the switcher must never need the
+// dropdown's own directory read to learn the current workspace's name.
+//
+// Both states are pinned here: the COLLAPSED label with the dropdown never
+// opened, and the EXPANDED row for the personal workspace before the directory
+// read answers.
+
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import type { WorkspaceCollabContext } from '@open-design/contracts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EntryNavRail, resetWorkspaceDirectoryCache } from '../../src/components/EntryNavRail';
+import { I18nProvider } from '../../src/i18n';
+
+const REMOTE_PERSONAL_NAME = "Ada's workspace";
+
+/** The context `useWorkspaceContext` already holds at startup, for a PERSONAL workspace. */
+function personalContext(): WorkspaceCollabContext {
+  return {
+    workspaceId: 'ws-personal',
+    workspaceType: 'personal',
+    workspaceMemberId: 'wm-1',
+    // B's `workspaceName` for this workspace. For a personal workspace there is
+    // no `teamName` and no `teamId` — this is the only name the client is given.
+    workspaceName: REMOTE_PERSONAL_NAME,
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+    billingState: 'active',
+    seatSummary: { seatLimit: 1, usedSeats: 1, availableSeats: 0, isSeatFull: true },
+    permissions: {
+      canInviteMembers: true,
+      canManageBilling: true,
+      canViewWorkspaceSettings: true,
+    },
+  } as unknown as WorkspaceCollabContext;
+}
+
+const originalFetch = globalThis.fetch;
+
+/**
+ * Hold the directory read open forever, so "the user never opened the dropdown"
+ * and "the dropdown is open but the list has not landed" are both observable —
+ * and so any name on screen provably came from the startup context, not from a
+ * second request.
+ */
+function installNeverResolvingDirectoryFetch() {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    if (String(input).includes('/api/workspace/directory')) {
+      await new Promise<void>(() => {});
+    }
+    return new Response(JSON.stringify({}), { status: 200 });
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  return {
+    directoryCalls: () =>
+      fetchMock.mock.calls.filter((call) =>
+        String(call[0]).includes('/api/workspace/directory'),
+      ).length,
+  };
+}
+
+function renderRail() {
+  return render(
+    <I18nProvider initial="en">
+      <EntryNavRail
+        view="home"
+        onViewChange={() => {}}
+        onNewProject={() => {}}
+        open
+        context={personalContext()}
+      />
+    </I18nProvider>,
+  );
+}
+
+beforeEach(() => {
+  resetWorkspaceDirectoryCache();
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = originalFetch;
+  resetWorkspaceDirectoryCache();
+  vi.restoreAllMocks();
+});
+
+describe('personal workspace name in the switcher', () => {
+  it('shows the remote name on the collapsed control without opening the dropdown', () => {
+    const net = installNeverResolvingDirectoryFetch();
+
+    renderRail();
+
+    const trigger = screen.getByTestId('workspace-switcher');
+    expect(trigger.textContent).toContain(REMOTE_PERSONAL_NAME);
+    expect(trigger.textContent).not.toContain('Personal workspace');
+    // Nothing was fetched for this label — it came off the startup context.
+    expect(net.directoryCalls()).toBe(0);
+  });
+
+  it('shows the remote name on the expanded personal row before the directory answers', async () => {
+    installNeverResolvingDirectoryFetch();
+
+    renderRail();
+    fireEvent.click(screen.getByTestId('workspace-switcher'));
+
+    await waitFor(() => expect(screen.getByTestId('workspace-switcher-list')).toBeTruthy());
+    const list = within(screen.getByTestId('workspace-switcher-list'));
+    expect(list.getByText(REMOTE_PERSONAL_NAME)).toBeTruthy();
+    expect(list.queryByText('Personal workspace')).toBeNull();
+  });
+
+  it('derives the avatar initial from the remote name, not the fallback', () => {
+    installNeverResolvingDirectoryFetch();
+
+    renderRail();
+
+    const avatar = screen
+      .getByTestId('workspace-switcher')
+      .querySelector('.entry-nav-rail__team-avatar');
+    expect(avatar?.textContent).toBe('A');
+  });
+});

--- a/packages/contracts/src/api/collab.ts
+++ b/packages/contracts/src/api/collab.ts
@@ -276,6 +276,20 @@ export interface WorkspaceCollabContext {
   teamId?: string;
   /** Human-friendly team name for the workspace switcher (falls back to teamId). */
   teamName?: string;
+  /**
+   * B's display name for THIS workspace, whatever its type. Mirrors the
+   * `workspaceName` on B's CurrentWorkspaceContext, which is required there and
+   * is populated for personal workspaces too — vela derives "«owner»'s
+   * workspace" for an unnamed one, and an owner may rename it outright.
+   *
+   * Distinct from `teamName` on purpose: `teamName` is the TEAM switcher's
+   * field and stays absent for a personal workspace, so nothing may read it as
+   * an "is a team" signal. Any surface that just wants to LABEL the current
+   * workspace reads this one, and therefore gets a correct label from the
+   * context the client already fetches at startup — without waiting on the
+   * workspace-directory read that only happens when the switcher is opened.
+   */
+  workspaceName?: string;
   /** Display name for the presence overlay (optional; falls back to the id). */
   displayName?: string;
 }


### PR DESCRIPTION
## Why

**My use case.** The personal workspace in the sidebar switcher was reported as showing the hardcoded English 「Personal workspace」 instead of its real name. I went to fix the reported symptom and found the reported symptom has a different cause than the report assumed — plus a real, adjacent client-side defect that this PR fixes.

**The pain.** B (vela) names *every* workspace, personal included: `CurrentWorkspaceContext.workspaceName` is required (`z.string().min(1)`), vela derives 「«owner»'s workspace」 for an unnamed personal one (vela #964), and an owner can rename a personal workspace outright via `PATCH /api/v1/workspaces/{id}/profile`.

The daemon read that field and then **discarded it** unless the workspace was a team, because the only name on `WorkspaceCollabContext` was `teamName` (team-only by contract). So for a personal workspace the startup context carried *no name at all*, and `EntryNavRail`'s collapsed label had nothing real to fall back to except a hardcoded English string — until the user opened the dropdown and the *separate* `GET /api/workspace/directory` read landed. A user who never opens the switcher never sees their workspace's real name.

**What this PR does not fix (upstream).** The screenshot that prompted this is *not* the client fallback misfiring. Verified against live vela with a real signed-in session: for that account, B's genuine `workspaceName` for the workspace in question **is the literal string `"Personal workspace"`**, and its `workspaceType` is `team`, not `personal`:

```
GET /api/v1/workspaces  →  { "workspaceId": "i9rp…4wko", "workspaceName": "Personal workspace",
                             "workspaceIconKey": "person", "workspaceType": "team", … }
```

Cause: vela's in-place team upgrade (`activateTeamBillingWorkspace`, `services/api/src/billing/infra/postgres.ts`) sets `workspaces.type = 'team'` on the user's **default personal** workspace while leaving `name = 'Personal workspace'` (the value `createDefaultWorkspace` inserts) untouched. After that flip, `workspaceIdentityName` takes its team branch and returns the stored sentinel verbatim, so `personalWorkspaceDisplayName` (vela #964) can never apply again. The client is faithfully rendering B's name. That the string is byte-identical to OD's own fallback is a coincidence that made this look like a client bug.

That half needs a vela-side fix and is **out of scope here**. Deriving 「{name}'s workspace」 locally in the client instead would be a copy/product decision, so it is deliberately not done in this PR.

## What users will see

If your personal workspace has a real name on the server — either one you set yourself, or the 「«your name»'s workspace」 that vela derives — the sidebar workspace control now shows it **immediately on launch**, and its avatar letter comes from that name. Previously it read 「Personal workspace」 with a 「P」 avatar until you clicked the switcher open at least once.

Nothing changes for team workspaces, and no new network request is made: the name comes from the workspace context the app already fetches at startup.

## Surface area

- [x] **UI** — the sidebar workspace switcher's collapsed label, avatar letter, and expanded row for a personal workspace (`apps/web/src/components/EntryNavRail.tsx`)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — `WorkspaceCollabContext.workspaceName` added in `packages/contracts` (optional, additive) and populated by `GET /api/workspace/context`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

No new i18n keys and no copy changes: the existing hardcoded fallback string is left exactly as-is and simply stops being reached when a real name exists.

## Screenshots

Real runtime (`tools-dev`, namespace `ws-name`, ports 17660/17661), signed in, page freshly loaded, **dropdown never opened**:

| | collapsed label | avatar | `/api/workspace/directory` calls |
|---|---|---|---|
| before | `Personal workspace` | `P` | 0 |
| after | `杨瑾龙's workspace` | `杨` | 0 |

After opening the dropdown, the personal row reads `杨瑾龙's workspace` too (avatar `杨`, marked current).

## Bug fix verification

Red-first, per AGENTS.md → "Bug follow-up workflow".

- Test paths that reproduce the bug:
  - `apps/web/tests/components/EntryNavRail.workspace-name.test.tsx` (new) — pins the user-visible label in both states: collapsed control with the dropdown never opened, and the expanded personal row while the directory read is held open forever. The held-open fetch is what proves the name cannot have come from a second request.
  - `apps/daemon/tests/vela-workspace-context.test.ts` (3 cases added) — pins that `mapVelaWorkspaceContext` and `workspaceContextFromDirectoryItem` carry `workspaceName` for a personal workspace, and that `teamName` stays team-only.
- Did the tests go red before the source change and green after? **yes.**

Red (before any source change) — web:

```
FAIL  tests/components/EntryNavRail.workspace-name.test.tsx > shows the remote name on the expanded personal row …
  <span class="entry-nav-rail__workspace-menu-name">Personal workspace</span>
FAIL  tests/components/EntryNavRail.workspace-name.test.tsx > derives the avatar initial from the remote name, not the fallback
  AssertionError: expected 'P' to be 'A'
 Test Files  1 failed (1)
      Tests  3 failed (3)
```

Red — daemon:

```
FAIL  tests/vela-workspace-context.test.ts > carries the workspace name for a personal workspace
  AssertionError: expected undefined to be 'Ada's workspace'
 Test Files  1 failed (1)
      Tests  3 failed | 21 passed (24)
```

Green (after the fix):

```
apps/web    tests/components/EntryNavRail.workspace-name.test.tsx   Test Files 1 passed (1)   Tests 3 passed (3)
apps/daemon tests/vela-workspace-context.test.ts                    Test Files 1 passed (1)   Tests 24 passed (24)
```

## Validation

Node 24.18.0 throughout.

- `pnpm guard` — pass
- `pnpm typecheck` — pass (0 errors)
- `apps/daemon`: `tests/vela-workspace-context.test.ts tests/collab tests/routes/workspace-projects.test.ts tests/workspace-context.test.ts` → **46 files, 705 passed**
- `apps/web`: `tests/components/EntryNavRail*` → **9 files, 42 passed**
- `apps/web`: `tests/collab tests/components/Workspace tests/components/AvatarMenu tests/components/SettingsDialog` → **12 files, 321 passed, 1 skipped**
- Real-runtime acceptance against **live vela with a real signed-in session** (`OD_WORKSPACE_CONTEXT_SOURCE=vela`): `GET /api/workspace/context` now returns `"workspaceName": "Personal workspace"` where it previously omitted the field — the daemon no longer drops B's name.
- Real-runtime acceptance of the personal-workspace path end-to-end through the browser: collapsed label and expanded row both render the remote name, dropdown never opened for the first assertion.
- **No duplicate startup request.** Browser request log on a fresh load, before opening the dropdown: exactly one `GET /api/workspace/context`, zero `GET /api/workspace/directory`. The directory read still happens only on open. The diff adds **zero** `fetch(` call sites (`git diff | grep '^+' | grep -c 'fetch('` → `0`).

## Adjacent issues (not fixed here)

1. **Upstream / vela — the actual reported screenshot.** An in-place team upgrade flips the default personal workspace's `type` to `team` and leaves its name as the `'Personal workspace'` sentinel, permanently bypassing vela's own `personalWorkspaceDisplayName` derivation. This is why the owner remembers it previously reading 「xxx's workspace」 and now does not. Needs a vela fix (either personalize the name at upgrade time, or key the derivation on `is_default` rather than `type`).
2. **`GET /api/v1/workspaces` and `/api/v1/workspaces/current` return 404 on the `prod` vela profile** (`amr-api.open-design.ai`) while `/api/v1/me` and `/api/v1/models` return 200. The workspace routes appear not to be deployed there; the feature currently only answers on the test profile. Flagging as an infra/rollout observation, not touched here.
