### PR TITLE
fix(collab): give every created project a workspace home

### DIFF
--- a/apps/daemon/src/brand-routes.ts
+++ b/apps/daemon/src/brand-routes.ts
@@ -26,10 +26,7 @@ import {
   listProjectsAwaitingInput,
   type insertProject,
 } from './db.js';
-import {
-  createdProjectWorkspaceHome,
-  type GetAmbientWorkspace,
-} from './collab/created-project-workspace.js';
+import type { CreatedProjectWorkspaceResolver } from './collab/created-project-workspace.js';
 import { resolveProjectDir } from './projects.js';
 import {
   continueBrandExtraction,
@@ -61,11 +58,12 @@ export interface BrandRoutesDeps {
   /** `<dataDir>/projects` — backing brand-extraction projects. */
   projectsRoot: string;
   /**
-   * The workspace this daemon is signed in to, for an extraction request that
-   * carries no workspace identity of its own. See `createdProjectWorkspaceHome`
-   * in `collab/created-project-workspace.ts`.
+   * Where a brand-extraction project belongs. Verifies an asserted workspace
+   * identity, then degrades to the daemon's own signed-in workspace rather than
+   * refusing — see `createdProjectWorkspaceHome` in
+   * `collab/created-project-workspace.ts`.
    */
-  getAmbientWorkspace?: GetAmbientWorkspace;
+  resolveCreatedProjectHome?: CreatedProjectWorkspaceResolver;
   /** Skills root — the agent-driven kit page is rendered from the bundled
    *  `brand-extract` template under here. */
   skillsRoot: string;
@@ -144,8 +142,10 @@ export function registerBrandRoutes(app: Application, deps: BrandRoutesDeps): vo
    * `enforceWorkspaceResourceMutation` already passes straight through (see its
    * `requestCtx === null` branch).
    */
-  function bindBrandProjectIntoRequestWorkspace(req: Request, projectId: string, now: number): void {
-    const ctx = createdProjectWorkspaceHome(req, deps.getAmbientWorkspace);
+  async function bindBrandProjectIntoRequestWorkspace(req: Request, projectId: string, now: number): Promise<void> {
+    const ctx = deps.resolveCreatedProjectHome
+      ? await deps.resolveCreatedProjectHome(req)
+      : null;
     if (!ctx || ctx.memberStatus !== 'active') return;
     ensureWorkspaceProject(db, {
       projectId,
@@ -321,7 +321,7 @@ export function registerBrandRoutes(app: Application, deps: BrandRoutesDeps): vo
       const transcriptAgent = await deps.resolveTranscriptAgent?.().catch(() => null);
       if (transcriptAgent) startOptions.transcriptAgent = transcriptAgent;
       const result = await startBrandExtraction(startOptions);
-      bindBrandProjectIntoRequestWorkspace(req, result.projectId, Date.now());
+      await bindBrandProjectIntoRequestWorkspace(req, result.projectId, Date.now());
       const backgroundExtraction = backgroundExtractionRef.current;
       trackProgrammaticBrandExtraction(result.id, programmaticAbortController, backgroundExtraction);
       res.json(result);

--- a/apps/daemon/src/brand-routes.ts
+++ b/apps/daemon/src/brand-routes.ts
@@ -26,6 +26,10 @@ import {
   listProjectsAwaitingInput,
   type insertProject,
 } from './db.js';
+import {
+  createdProjectWorkspaceHome,
+  type GetAmbientWorkspace,
+} from './collab/created-project-workspace.js';
 import { resolveProjectDir } from './projects.js';
 import {
   continueBrandExtraction,
@@ -41,7 +45,6 @@ import {
   startBrandExtraction,
 } from './brands/index.js';
 import { patchMeta } from './brands/store.js';
-import { headerValue, workspaceResourceContext } from './collab/workspace-resource-mutation.js';
 import type { BrandDetailResponse, BrandMeta, BrandSummary } from '@open-design/contracts';
 
 export interface BrandRoutesDeps {
@@ -57,6 +60,12 @@ export interface BrandRoutesDeps {
   resolveDesignSystemWorkspaceId?: () => Promise<string | null>;
   /** `<dataDir>/projects` — backing brand-extraction projects. */
   projectsRoot: string;
+  /**
+   * The workspace this daemon is signed in to, for an extraction request that
+   * carries no workspace identity of its own. See `createdProjectWorkspaceHome`
+   * in `collab/created-project-workspace.ts`.
+   */
+  getAmbientWorkspace?: GetAmbientWorkspace;
   /** Skills root — the agent-driven kit page is rendered from the bundled
    *  `brand-extract` template under here. */
   skillsRoot: string;
@@ -127,16 +136,16 @@ export function registerBrandRoutes(app: Application, deps: BrandRoutesDeps): vo
    * spec 04 §9.3's asset sync depends on — because their own first chat turn
    * 403s before the agent ever runs.
    *
-   * Scoped to an ACTIVE member only, matching `POST /api/projects`: a caller
-   * with no workspace context at all (signed out / single-player) leaves the
-   * project unbound, exactly as before this fix — unbound-and-headerless is
-   * the case `enforceWorkspaceResourceMutation` already passes straight
-   * through (see its `requestCtx === null` branch).
+   * Scoped to an ACTIVE member only, matching `POST /api/projects`. A request
+   * with no workspace headers falls back to the workspace this daemon is signed
+   * in to; only a daemon that has resolved no workspace at all leaves the
+   * project unbound, which is the honest answer for a signed-out/single-player
+   * install — unbound-and-headerless is the case
+   * `enforceWorkspaceResourceMutation` already passes straight through (see its
+   * `requestCtx === null` branch).
    */
   function bindBrandProjectIntoRequestWorkspace(req: Request, projectId: string, now: number): void {
-    const workspaceIdForCreate = headerValue(req, 'x-od-workspace-id');
-    if (!workspaceIdForCreate) return;
-    const ctx = workspaceResourceContext(req, workspaceIdForCreate);
+    const ctx = createdProjectWorkspaceHome(req, deps.getAmbientWorkspace);
     if (!ctx || ctx.memberStatus !== 'active') return;
     ensureWorkspaceProject(db, {
       projectId,

--- a/apps/daemon/src/collab/created-project-workspace.ts
+++ b/apps/daemon/src/collab/created-project-workspace.ts
@@ -2,7 +2,9 @@ import type { ApiErrorResponse } from '@open-design/contracts';
 import type { Response } from 'express';
 import {
   isWorkspaceResourceLocked,
+  withLastKnownMembership,
   workspaceResourceContextFromRequest,
+  type GetLastKnownWorkspaceMembership,
   type WorkspaceResourceContext,
 } from './workspace-resource-mutation.js';
 import {
@@ -232,30 +234,84 @@ function ambientWorkspaceHome(
 }
 
 /**
- * The workspace a project created by this request belongs to — for a creation
- * path that has NO authorization gate of its own and must never grow one.
+ * Resolve the workspace a created project belongs to, for a creation path that
+ * has NO authorization gate of its own and must never grow one.
  *
- * INVARIANT: this never refuses and never throws. It answers with the caller's
- * own workspace when the request names a usable one, the daemon's ambient
- * workspace when it does not, and null only when neither exists — a genuinely
- * signed-out daemon, where `unbound` is the honest answer and a guard would
- * break the single-player user.
+ * VERIFY, THEN DEGRADE — NEVER REJECT, NEVER TRUST. Three outcomes, in order:
  *
- * Use this instead of `resolveCreatedProjectWorkspace` on paths that were
- * previously binding nothing at all (Orbit and routine projects, the plugin
- * share-project task, the library capture-as-page exit, project-location scan
- * imports, the design-system workspace project). Those paths ship today and
- * return 200 today; turning a header problem into a 4xx there would be a
- * regression, so a partial/denied header identity degrades to the ambient
- * workspace rather than failing.
+ *   1. The request asserts an identity AND it verifies — bind to it.
+ *   2. The request asserts an identity that does NOT verify — unknown
+ *      workspace, member not active, permissions disagree, the daemon's own
+ *      last-known state says that member was removed, or the membership
+ *      authority is unreadable so the claim cannot be confirmed at all — bind
+ *      to the daemon's ambient workspace instead, or leave the project unbound.
+ *      The unverifiable claim is never written.
+ *   3. The request asserts nothing — bind to the ambient workspace, or leave
+ *      the project unbound when the daemon has none either.
+ *
+ * Creation therefore still never returns 4xx (these paths ship today and answer
+ * 200 today, so a header problem must not become a refusal), while an
+ * unverifiable claim degrades to something the daemon can actually vouch for
+ * rather than being persisted as fact. `x-od-workspace-*` headers are an
+ * unauthenticated hint — any local caller (`od` CLI, plain curl, a compromised
+ * page) can assert an arbitrary pair — so writing them unchecked would hand out
+ * a binding into a workspace the caller has no membership in, with a fabricated
+ * `createdByWorkspaceMemberId`.
+ *
+ * Verification is NOT re-implemented here. It is exactly
+ * {@link authorizeCreatedProjectWorkspace} — the same directory lookup
+ * `POST /api/projects` gates on, which also returns the DIRECTORY's
+ * authoritative context rather than the caller's claimed one — plus
+ * `withLastKnownMembership`, the same cross-check the mutation gates apply.
+ * Only the failure behavior differs: they refuse, this degrades. Two notions of
+ * "verified" in one file is how this drifts back apart.
+ *
+ * An absent `fetchWorkspaceDirectory` remains the documented local/dev
+ * compatibility path, identical to `authorizeCreatedProjectWorkspace`'s own
+ * contract — not a second, weaker definition of verified. A directory that is
+ * present but unreadable is "cannot confirm", and degrades.
  */
-export function createdProjectWorkspaceHome(
+export async function createdProjectWorkspaceHome(
   req: unknown,
   getAmbientWorkspace?: GetAmbientWorkspace,
-): WorkspaceResourceContext | null {
-  const claimed = resolveCreatedProjectWorkspace(req);
-  if (claimed.ok && claimed.context !== null) return claimed.context;
-  return ambientWorkspaceHome(getAmbientWorkspace);
+  fetchWorkspaceDirectory?: () => Promise<WorkspaceDirectoryFetchResult>,
+  getLastKnownMembership?: GetLastKnownWorkspaceMembership,
+): Promise<WorkspaceResourceContext | null> {
+  const ambient = () => ambientWorkspaceHome(getAmbientWorkspace);
+  const authorized = await authorizeCreatedProjectWorkspace(
+    req,
+    fetchWorkspaceDirectory,
+  ).catch((): CreatedProjectWorkspaceResolution => ({ ok: true, context: null }));
+  // Asserted but unverifiable (400 incomplete / 403 denied / 503 authority
+  // unavailable). Degrade instead of refusing — and never write the claim.
+  if (!authorized.ok) return ambient();
+  // Nothing asserted at all.
+  if (authorized.context === null) return ambient();
+  const verified = withLastKnownMembership(authorized.context, getLastKnownMembership);
+  if (verified.memberStatus !== 'active') return ambient();
+  return verified;
+}
+
+/**
+ * A `createdProjectWorkspaceHome` bound to one daemon's authorities, so a route
+ * module takes a single dep instead of re-threading three.
+ */
+export type CreatedProjectWorkspaceResolver = (
+  req: unknown,
+) => Promise<WorkspaceResourceContext | null>;
+
+export function createCreatedProjectWorkspaceResolver(deps: {
+  getAmbientWorkspace?: GetAmbientWorkspace;
+  fetchWorkspaceDirectory?: () => Promise<WorkspaceDirectoryFetchResult>;
+  getLastKnownMembership?: GetLastKnownWorkspaceMembership;
+}): CreatedProjectWorkspaceResolver {
+  return (req) =>
+    createdProjectWorkspaceHome(
+      req,
+      deps.getAmbientWorkspace,
+      deps.fetchWorkspaceDirectory,
+      deps.getLastKnownMembership,
+    );
 }
 
 /**

--- a/apps/daemon/src/collab/created-project-workspace.ts
+++ b/apps/daemon/src/collab/created-project-workspace.ts
@@ -11,6 +11,35 @@ import {
 } from './vela-workspace-context.js';
 import { sendApiError } from '../http/api-errors.js';
 
+/**
+ * The daemon's own last-verified workspace identity, narrowed to the fields a
+ * created project's binding needs.
+ *
+ * Structurally a subset of `WorkspaceCollabContext`, so a caller passes
+ * `() => workspaceContext.lastKnown?.() ?? null` directly. Deliberately NOT the
+ * `WorkspaceContextProvider` type — same reason `workspace-resource-mutation.ts`
+ * takes a plain `GetLastKnownWorkspaceMembership` closure: a create path must not
+ * drag the async B integration into a module every resource type depends on.
+ */
+export type AmbientWorkspaceSnapshot = {
+  workspaceId: string;
+  workspaceType: 'personal' | 'team';
+  workspaceMemberId: string;
+  role: WorkspaceResourceContext['role'];
+  memberStatus: WorkspaceResourceContext['memberStatus'];
+  lifecycleState: WorkspaceResourceContext['lifecycleState'];
+  permissions: { canShareProjects: boolean; canWriteSyncedFiles: boolean };
+};
+
+/**
+ * Read the daemon's ambient workspace with NO network I/O and no failure mode.
+ * Backed by `collab/workspace-context.ts`'s `lastKnown()`, which is populated as
+ * a side effect of the `.current()` traffic the daemon already serves (the web
+ * client's periodic `GET /api/workspace/context` poll, the collab-cloud poller's
+ * 5s tick, the dev/demo `PUT /api/workspace/context` seam).
+ */
+export type GetAmbientWorkspace = () => AmbientWorkspaceSnapshot | null | undefined;
+
 export type CreatedProjectWorkspaceResolution =
   | { ok: true; context: WorkspaceResourceContext | null }
   | {
@@ -156,6 +185,100 @@ export async function authorizeCreatedProjectWorkspace(
   return { ok: true, context };
 }
 
+/**
+ * The daemon's ambient workspace as a binding subject, or null when it is not
+ * one this daemon may hand a project to.
+ *
+ * Refused for the same three reasons a header identity is: a removed member, a
+ * member who cannot write synced files, and a locked/deleted workspace. Refusal
+ * means "leave the project unbound", never "fail the create".
+ *
+ * `workspaceTypeAsserted` is null on purpose. That field records what the CALLER
+ * claimed, and an ambient identity is the daemon's own knowledge — nobody claimed
+ * anything, so `team-share-scope.ts` must not read a claim that was never made.
+ *
+ * `appUserId` is empty for the same reason: it mirrors a request header
+ * (`x-od-app-user-id`) this path has none of. Nothing in the binding written
+ * below consumes it.
+ */
+function ambientWorkspaceHome(
+  getAmbientWorkspace?: GetAmbientWorkspace,
+): WorkspaceResourceContext | null {
+  const ambient = getAmbientWorkspace?.();
+  if (!ambient) return null;
+  const workspaceId = ambient.workspaceId?.trim();
+  const workspaceMemberId = ambient.workspaceMemberId?.trim();
+  if (!workspaceId || !workspaceMemberId) return null;
+  const context: WorkspaceResourceContext = {
+    workspaceId,
+    workspaceType: ambient.workspaceType === 'team' ? 'team' : 'personal',
+    workspaceTypeAsserted: null,
+    appUserId: '',
+    workspaceMemberId,
+    role: ambient.role,
+    memberStatus: ambient.memberStatus,
+    lifecycleState: ambient.lifecycleState,
+    canShareProjects: ambient.permissions.canShareProjects,
+    canWriteSyncedFiles: ambient.permissions.canWriteSyncedFiles,
+  };
+  if (
+    context.memberStatus !== 'active'
+    || !context.canWriteSyncedFiles
+    || isWorkspaceResourceLocked(context)
+  ) {
+    return null;
+  }
+  return context;
+}
+
+/**
+ * The workspace a project created by this request belongs to — for a creation
+ * path that has NO authorization gate of its own and must never grow one.
+ *
+ * INVARIANT: this never refuses and never throws. It answers with the caller's
+ * own workspace when the request names a usable one, the daemon's ambient
+ * workspace when it does not, and null only when neither exists — a genuinely
+ * signed-out daemon, where `unbound` is the honest answer and a guard would
+ * break the single-player user.
+ *
+ * Use this instead of `resolveCreatedProjectWorkspace` on paths that were
+ * previously binding nothing at all (Orbit and routine projects, the plugin
+ * share-project task, the library capture-as-page exit, project-location scan
+ * imports, the design-system workspace project). Those paths ship today and
+ * return 200 today; turning a header problem into a 4xx there would be a
+ * regression, so a partial/denied header identity degrades to the ambient
+ * workspace rather than failing.
+ */
+export function createdProjectWorkspaceHome(
+  req: unknown,
+  getAmbientWorkspace?: GetAmbientWorkspace,
+): WorkspaceResourceContext | null {
+  const claimed = resolveCreatedProjectWorkspace(req);
+  if (claimed.ok && claimed.context !== null) return claimed.context;
+  return ambientWorkspaceHome(getAmbientWorkspace);
+}
+
+/**
+ * Write the `workspace_projects` row for a project this daemon just created.
+ *
+ * INVARIANT: a project created while this daemon knows a signed-in workspace
+ * always gets a binding row. A project with no row is not a harmless default —
+ * `GET /api/projects/:id/workspace-scope` answers `unbound` for it, which strips
+ * the workspace off the run request (`ProjectView`'s `projectRunWorkspaceContext`
+ * → an Open Design Cloud run nothing can bill) and blanks the balance/plan area
+ * while that project is open (`AvatarMenu`). It is also denied a run outright by
+ * `enforceWorkspaceResourceMutation` the moment the caller carries any workspace
+ * header, because the two-key lookup comes back empty.
+ *
+ * `context` is the caller's own workspace when the request named one. When it did
+ * not, the binding falls back to the daemon's ambient workspace instead of
+ * leaving an orphan — a headerless create is a caller that COULDN'T say which
+ * workspace it meant (`od project create` and the MCP `create_project` tool mint
+ * no headers; a web create fired before the seconds-long identity read lands
+ * sends none; Orbit and scheduled routines have no request at all), not a caller
+ * asserting there is no workspace. The one case with genuinely no answer — no
+ * request identity and no resolved session — still binds nothing, on purpose.
+ */
 export function bindCreatedProjectToWorkspace(
   ensureWorkspaceProject: (input: {
     projectId: string;
@@ -173,15 +296,17 @@ export function bindCreatedProjectToWorkspace(
   context: WorkspaceResourceContext | null,
   projectId: string,
   now: number,
+  getAmbientWorkspace?: GetAmbientWorkspace,
 ): void {
-  if (!context) return;
+  const home = context ?? ambientWorkspaceHome(getAmbientWorkspace);
+  if (!home) return;
   ensureWorkspaceProject({
     projectId,
-    workspaceId: context.workspaceId,
+    workspaceId: home.workspaceId,
     visibility: 'personal',
     resourceState: 'active',
-    createdByWorkspaceMemberId: context.workspaceMemberId,
-    updatedByWorkspaceMemberId: context.workspaceMemberId,
+    createdByWorkspaceMemberId: home.workspaceMemberId,
+    updatedByWorkspaceMemberId: home.workspaceMemberId,
     syncState: 'local_only',
     resourceHubResourceId: null,
     cloudTombstonedAt: null,

--- a/apps/daemon/src/collab/workspace-resource-mutation.ts
+++ b/apps/daemon/src/collab/workspace-resource-mutation.ts
@@ -77,7 +77,7 @@ export type GetLastKnownWorkspaceMembership = () => WorkspaceMembershipSnapshot 
  * "we don't have cached info yet" into a denial, or every route gated by this
  * check would fail-closed on daemon startup / a workspace switch.
  */
-function withLastKnownMembership(
+export function withLastKnownMembership(
   ctx: WorkspaceResourceContext,
   getLastKnownMembership: GetLastKnownWorkspaceMembership | undefined,
 ): WorkspaceResourceContext {

--- a/apps/daemon/src/design-systems/server-services.ts
+++ b/apps/daemon/src/design-systems/server-services.ts
@@ -63,6 +63,7 @@ export function createDesignSystemServerServices({
   skills,
   designSystems,
   projects,
+  bindProjectToWorkspace,
 }: {
   // Only consulted by `listAllSkills` below for its optional workspace scope
   // filter — every other service in this factory stays filesystem-only. A
@@ -119,6 +120,20 @@ export function createDesignSystemServerServices({
     resolveProjectDir: (projectsDir: string, projectId: string, metadata?: JsonRecord) => string;
     isSafeId: (id: string) => boolean;
   };
+  /**
+   * Give the `ds-*` project that backs a design system's editing workspace a
+   * `workspace_projects` home, the same as any other created project.
+   *
+   * It is a real, run-hosting project — the chat/run prompt-composition path
+   * stands it up on demand (`server.ts`) and the system prompt has a dedicated
+   * `editingOwnDraftDesignSystem` branch for chatting inside it — so an unbound
+   * one is denied its first turn by `enforceWorkspaceResourceMutation` exactly
+   * like any other orphan. This factory has no Express request, so the daemon's
+   * ambient workspace is the only thing that can answer; the injected closure
+   * keeps that resolution in `server.ts` where the provider lives. Absent in
+   * tests that do not exercise the seam.
+   */
+  bindProjectToWorkspace?: (projectId: string, createdAt: number) => void;
 }) {
   /**
    * The functional-skills catalog. `workspaceId` narrows it to the
@@ -337,6 +352,7 @@ export function createDesignSystemServerServices({
           updatedAt: now,
         });
     if (!project) return null;
+    if (!existing) bindProjectToWorkspace?.(projectId, now);
 
     const files = await designSystems.listUserDesignSystemFiles(paths.USER_DESIGN_SYSTEMS_DIR, id);
     if (!files) return null;

--- a/apps/daemon/src/import-export-routes.ts
+++ b/apps/daemon/src/import-export-routes.ts
@@ -26,12 +26,19 @@ import { parseOrchestratorWorkspace } from './workspace-contract.js';
 import {
   authorizeCreatedProjectWorkspace,
   bindCreatedProjectToWorkspace,
+  type GetAmbientWorkspace,
   sendCreatedProjectWorkspaceError,
 } from './collab/created-project-workspace.js';
 import type { WorkspaceDirectoryFetchResult } from './collab/vela-workspace-context.js';
 
 export interface RegisterImportRoutesDeps extends RouteDeps<'db' | 'http' | 'uploads' | 'node' | 'ids' | 'paths' | 'imports' | 'auth' | 'projectStore' | 'conversations' | 'projectFiles' | 'validation'> {
   fetchProjectCreationWorkspaceDirectory?: () => Promise<WorkspaceDirectoryFetchResult>;
+  /**
+   * The workspace this daemon is signed in to, for an import whose request
+   * carries no workspace identity of its own. See `createdProjectWorkspaceHome`
+   * in `collab/created-project-workspace.ts`.
+   */
+  getAmbientWorkspace?: GetAmbientWorkspace;
 }
 
 export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps) {
@@ -138,6 +145,7 @@ export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps
             createWorkspace.context,
             id,
             now,
+            ctx.getAmbientWorkspace,
           );
           return createdProject;
         })();
@@ -463,6 +471,7 @@ export function registerImportRoutes(app: Express, ctx: RegisterImportRoutesDeps
           createWorkspace.context,
           id,
           now,
+          ctx.getAmbientWorkspace,
         );
         return createdProject;
       })();

--- a/apps/daemon/src/routes/library.ts
+++ b/apps/daemon/src/routes/library.ts
@@ -48,6 +48,11 @@ import { reconcileLibrary, type ReconcileLibraryResult } from '../library-sync.j
 import { fetchExternalBrandAsset } from '../brands/safe-fetch.js';
 import { ensureProjectSubdir } from '../projects.js';
 import {
+  bindCreatedProjectToWorkspace,
+  createdProjectWorkspaceHome,
+  type GetAmbientWorkspace,
+} from '../collab/created-project-workspace.js';
+import {
   confirmPairing,
   libraryConnectionStatus,
   startPairing,
@@ -57,7 +62,14 @@ import {
 export interface RegisterLibraryRoutesDeps
   extends RouteDeps<
     'db' | 'http' | 'paths' | 'projectStore' | 'projectFiles' | 'conversations' | 'auth'
-  > {}
+  > {
+  /**
+   * The workspace this daemon is signed in to, so a capture opened as an
+   * editable project gets a home workspace like any other created project. See
+   * `createdProjectWorkspaceHome` in `collab/created-project-workspace.ts`.
+   */
+  getAmbientWorkspace?: GetAmbientWorkspace;
+}
 
 const MAX_REMOTE_BYTES = 25 * 1024 * 1024;
 
@@ -162,7 +174,7 @@ export function registerLibraryRoutes(app: Express, ctx: RegisterLibraryRoutesDe
   const { sendApiError, createSseResponse, requireLocalDaemonRequest, isLocalSameOrigin, resolvedPortRef } =
     ctx.http;
   const { LIBRARY_DIR, PROJECTS_DIR, USER_DESIGN_SYSTEMS_DIR } = ctx.paths;
-  const { getProject, insertProject } = ctx.projectStore;
+  const { getProject, insertProject, ensureWorkspaceProject } = ctx.projectStore;
   const { writeProjectFile } = ctx.projectFiles;
   const { insertConversation } = ctx.conversations;
   const { authorizeToolRequest } = ctx.auth;
@@ -634,6 +646,15 @@ export function registerLibraryRoutes(app: Express, ctx: RegisterLibraryRoutesDe
         createdAt: now,
         updatedAt: now,
       });
+      // A capture opened as an editable page is a project the user will
+      // immediately chat into, so it needs the same home workspace every other
+      // created project gets — an unbound one is denied its first run outright.
+      bindCreatedProjectToWorkspace(
+        (input) => ensureWorkspaceProject(db, input),
+        createdProjectWorkspaceHome(req, ctx.getAmbientWorkspace),
+        projectId,
+        now,
+      );
       // writeProjectFile ensures the project dir; write the capture as the
       // editable entry file. No artifact manifest — a plain HTML file avoids
       // the publication/stub guards (a captured page is arbitrary markup) while

--- a/apps/daemon/src/routes/library.ts
+++ b/apps/daemon/src/routes/library.ts
@@ -49,8 +49,7 @@ import { fetchExternalBrandAsset } from '../brands/safe-fetch.js';
 import { ensureProjectSubdir } from '../projects.js';
 import {
   bindCreatedProjectToWorkspace,
-  createdProjectWorkspaceHome,
-  type GetAmbientWorkspace,
+  type CreatedProjectWorkspaceResolver,
 } from '../collab/created-project-workspace.js';
 import {
   confirmPairing,
@@ -64,11 +63,12 @@ export interface RegisterLibraryRoutesDeps
     'db' | 'http' | 'paths' | 'projectStore' | 'projectFiles' | 'conversations' | 'auth'
   > {
   /**
-   * The workspace this daemon is signed in to, so a capture opened as an
-   * editable project gets a home workspace like any other created project. See
-   * `createdProjectWorkspaceHome` in `collab/created-project-workspace.ts`.
+   * Where a capture opened as an editable project belongs. Verifies an asserted
+   * workspace identity, then degrades to the daemon's own signed-in workspace
+   * rather than refusing — see `createdProjectWorkspaceHome` in
+   * `collab/created-project-workspace.ts`.
    */
-  getAmbientWorkspace?: GetAmbientWorkspace;
+  resolveCreatedProjectHome?: CreatedProjectWorkspaceResolver;
 }
 
 const MAX_REMOTE_BYTES = 25 * 1024 * 1024;
@@ -651,7 +651,7 @@ export function registerLibraryRoutes(app: Express, ctx: RegisterLibraryRoutesDe
       // created project gets — an unbound one is denied its first run outright.
       bindCreatedProjectToWorkspace(
         (input) => ensureWorkspaceProject(db, input),
-        createdProjectWorkspaceHome(req, ctx.getAmbientWorkspace),
+        ctx.resolveCreatedProjectHome ? await ctx.resolveCreatedProjectHome(req) : null,
         projectId,
         now,
       );

--- a/apps/daemon/src/routes/plugins/index.ts
+++ b/apps/daemon/src/routes/plugins/index.ts
@@ -22,6 +22,7 @@ import {
 import {
   authorizeCreatedProjectWorkspace,
   bindCreatedProjectToWorkspace,
+  type GetAmbientWorkspace,
   sendCreatedProjectWorkspaceError,
 } from '../../collab/created-project-workspace.js';
 import type { WorkspaceDirectoryFetchResult } from '../../collab/vela-workspace-context.js';
@@ -143,6 +144,12 @@ export interface RegisterPluginRoutesDeps {
     removeProjectDir(projectsRoot: string, projectId: string): Promise<unknown>;
   };
   fetchProjectCreationWorkspaceDirectory?: () => Promise<WorkspaceDirectoryFetchResult>;
+  /**
+   * The workspace this daemon is signed in to, for a plugin-created project whose
+   * request carries no workspace identity of its own. See
+   * `createdProjectWorkspaceHome` in `collab/created-project-workspace.ts`.
+   */
+  getAmbientWorkspace?: GetAmbientWorkspace;
   conversations: {
     insertConversation(db: SqliteDbLike, conversation: unknown): unknown;
   };
@@ -335,6 +342,7 @@ export function registerPluginRoutes(app: Express, deps: RegisterPluginRoutesDep
           createWorkspace.context,
           projectId,
           now,
+          deps.getAmbientWorkspace,
         );
         return createdProject;
       })();

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -92,7 +92,9 @@ import { resolveProjectWorkspaceScopeForCaller } from '../../collab/project-work
 import {
   authorizeCreatedProjectWorkspace,
   bindCreatedProjectToWorkspace,
+  createdProjectWorkspaceHome,
   sendCreatedProjectWorkspaceError,
+  type GetAmbientWorkspace,
 } from '../../collab/created-project-workspace.js';
 import type { WorkspaceDirectoryFetchResult } from '../../collab/vela-workspace-context.js';
 import { cancelRunsOwnedBy } from './cancel-owned-runs.js';
@@ -1605,6 +1607,14 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
   // them for a mutation — see `createEnforceWorkspaceProjectMutation`'s
   // docblock above for the full rationale.
   const enforceWorkspaceProjectMutation = createEnforceWorkspaceProjectMutation(ctx.workspaceContext);
+  /**
+   * The workspace this daemon is currently signed in to, for creation paths whose
+   * request carries no workspace identity of its own. Zero-network and
+   * synchronous — see `createdProjectWorkspaceHome` in
+   * `collab/created-project-workspace.ts` for why a headerless create binds here
+   * rather than becoming an orphan.
+   */
+  const getAmbientWorkspace: GetAmbientWorkspace = () => ctx.workspaceContext?.lastKnown?.() ?? null;
   function sendMissingWorkspaceContext(res: Response) {
     return sendApiError(res, 401, 'WORKSPACE_CONTEXT_REQUIRED', 'workspace context is required');
   }
@@ -2046,12 +2056,20 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
    * Called only after `enforceWorkspaceProjectMutation` already allowed the
    * duplicate/copy, which is proof `ctx` names an active, write-capable
    * member of the workspace that owns the SOURCE project — exactly the right
-   * home for the copy too. A caller with no workspace context at all (legacy
-   * pre-workspace request) leaves the copy unbound, same as before.
+   * home for the copy too.
+   *
+   * A request with no workspace identity at all falls back to the daemon's
+   * ambient workspace rather than leaving the copy unbound. That case is not
+   * hypothetical: `App.tsx`'s duplicate and design-system-copy handlers pass
+   * `workspaceContextRef.current`, a ref that drops the context's `loading`
+   * flag, so a duplicate clicked in the first seconds after a refresh — before
+   * the vela-backed identity read lands — sends zero headers and used to
+   * produce exactly the orphan `reconcileUnboundProjectBeforeMutation` below
+   * was later written to repair.
    */
   function bindDuplicateIntoRequestWorkspace(req: any, targetProjectId: string, now: number) {
-    const ctx = workspaceProjectContextFromRequest(req);
-    if (ctx === null || ctx === 'missing') return;
+    const ctx = createdProjectWorkspaceHome(req, getAmbientWorkspace);
+    if (ctx === null) return;
     ensureWorkspaceProject(db, {
       projectId: targetProjectId,
       workspaceId: ctx.workspaceId,
@@ -2378,7 +2396,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
     }
   });
 
-  app.post('/api/project-locations/scan', async (_req, res) => {
+  app.post('/api/project-locations/scan', async (req, res) => {
     try {
       const locations = (await configuredProjectLocations()).filter((loc: any) => !loc.builtIn);
       const imported = [];
@@ -2425,6 +2443,18 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
               createdAt: now,
               updatedAt: now,
             });
+            // A project this scan adopts off disk is as much a created project
+            // as one typed into the composer, and needs the same home
+            // workspace. Without this the imported project is an orphan the
+            // moment it appears: denied its first run by
+            // `enforceWorkspaceResourceMutation`, and billing-less on any run
+            // that does get through.
+            bindCreatedProjectToWorkspace(
+              (input) => ensureWorkspaceProject(db, input),
+              createdProjectWorkspaceHome(req, getAmbientWorkspace),
+              manifest.id,
+              now,
+            );
             if (project) imported.push(project);
           } catch (err: any) {
             skipped.push({ path: entry.dir, reason: String(err?.message ?? err) });
@@ -3016,6 +3046,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
             createWorkspace.context,
             id,
             now,
+            getAmbientWorkspace,
           );
           return createdProject;
         })();

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -92,7 +92,7 @@ import { resolveProjectWorkspaceScopeForCaller } from '../../collab/project-work
 import {
   authorizeCreatedProjectWorkspace,
   bindCreatedProjectToWorkspace,
-  createdProjectWorkspaceHome,
+  createCreatedProjectWorkspaceResolver,
   sendCreatedProjectWorkspaceError,
   type GetAmbientWorkspace,
 } from '../../collab/created-project-workspace.js';
@@ -1615,6 +1615,23 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
    * rather than becoming an orphan.
    */
   const getAmbientWorkspace: GetAmbientWorkspace = () => ctx.workspaceContext?.lastKnown?.() ?? null;
+  /**
+   * Where a created project belongs when the request has no authorization gate
+   * of its own — the duplicate / design-system-copy pair and the
+   * project-location scan importer. Verifies an asserted identity through the
+   * SAME directory lookup `POST /api/projects` gates on, then degrades to the
+   * ambient workspace rather than refusing. See
+   * `createdProjectWorkspaceHome`.
+   */
+  const resolveCreatedProjectHome = createCreatedProjectWorkspaceResolver({
+    getAmbientWorkspace,
+    ...(ctx.fetchProjectCreationWorkspaceDirectory
+      ? { fetchWorkspaceDirectory: ctx.fetchProjectCreationWorkspaceDirectory }
+      : {}),
+    ...(lastKnownWorkspaceMembership(ctx.workspaceContext)
+      ? { getLastKnownMembership: lastKnownWorkspaceMembership(ctx.workspaceContext)! }
+      : {}),
+  });
   function sendMissingWorkspaceContext(res: Response) {
     return sendApiError(res, 401, 'WORKSPACE_CONTEXT_REQUIRED', 'workspace context is required');
   }
@@ -2067,8 +2084,8 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
    * produce exactly the orphan `reconcileUnboundProjectBeforeMutation` below
    * was later written to repair.
    */
-  function bindDuplicateIntoRequestWorkspace(req: any, targetProjectId: string, now: number) {
-    const ctx = createdProjectWorkspaceHome(req, getAmbientWorkspace);
+  async function bindDuplicateIntoRequestWorkspace(req: any, targetProjectId: string, now: number) {
+    const ctx = await resolveCreatedProjectHome(req);
     if (ctx === null) return;
     ensureWorkspaceProject(db, {
       projectId: targetProjectId,
@@ -2451,7 +2468,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
             // that does get through.
             bindCreatedProjectToWorkspace(
               (input) => ensureWorkspaceProject(db, input),
-              createdProjectWorkspaceHome(req, getAmbientWorkspace),
+              await resolveCreatedProjectHome(req),
               manifest.id,
               now,
             );
@@ -3229,7 +3246,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
           updatedAt: now,
         });
         insertedProject = true;
-        bindDuplicateIntoRequestWorkspace(req, targetProjectId, now);
+        await bindDuplicateIntoRequestWorkspace(req, targetProjectId, now);
         const conversationId = randomId();
         insertConversation(db, {
           id: conversationId,
@@ -3371,7 +3388,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
           updatedAt: now,
         });
         insertedProject = true;
-        bindDuplicateIntoRequestWorkspace(req, targetProjectId, now);
+        await bindDuplicateIntoRequestWorkspace(req, targetProjectId, now);
         const conversationId = randomId();
         insertConversation(db, {
           id: conversationId,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -321,7 +321,7 @@ import { prepareDesignTokenContractRebuild } from './design-systems/token-contra
 import { registerBrandRoutes } from './brand-routes.js';
 import {
   bindCreatedProjectToWorkspace,
-  createdProjectWorkspaceHome,
+  createCreatedProjectWorkspaceResolver,
   type GetAmbientWorkspace,
 } from './collab/created-project-workspace.js';
 import {
@@ -2994,6 +2994,25 @@ export async function startServer({
    * resolved no workspace at all still binds nothing.
    */
   const getAmbientWorkspace: GetAmbientWorkspace = () => workspaceContext.lastKnown?.() ?? null;
+  /**
+   * Where a created project belongs for the surfaces with no authorization gate
+   * of their own (the plugin share-project task, the library capture-as-page
+   * exit, brand extraction). Verifies an asserted workspace identity through the
+   * SAME directory lookup `POST /api/projects` gates on, then degrades to the
+   * ambient workspace rather than refusing. See `createdProjectWorkspaceHome`.
+   */
+  const resolveCreatedProjectHome = createCreatedProjectWorkspaceResolver({
+    getAmbientWorkspace,
+    ...(fetchProjectCreationWorkspaceDirectory
+      ? { fetchWorkspaceDirectory: fetchProjectCreationWorkspaceDirectory }
+      : {}),
+    getLastKnownMembership: () => {
+      const known = workspaceContext.lastKnown?.() ?? null;
+      return known
+        ? { workspaceId: known.workspaceId, memberStatus: known.memberStatus }
+        : null;
+    },
+  });
   function persistWorkspaceProjectSyncState(
     projectId: string,
     workspaceId: string | null | undefined,
@@ -5324,7 +5343,7 @@ export async function startServer({
     projectFiles: projectFileDeps,
     conversations: conversationDeps,
     auth: authDeps,
-    getAmbientWorkspace,
+    resolveCreatedProjectHome,
   });
   app.post('/api/projects/:id/figma/import', (req, res) => {
     figmaUpload.single('file')(req, res, async (err) => {
@@ -5596,7 +5615,7 @@ export async function startServer({
     generationJobs: designSystemGenerationJobs,
   });
   registerBrandRoutes(app, {
-    getAmbientWorkspace,
+    resolveCreatedProjectHome,
     brandsRoot: BRANDS_DIR,
     userDesignSystemsRoot: USER_DESIGN_SYSTEMS_DIR,
     resolveDesignSystemWorkspaceId: resolveDesignSystemWorkspaceScope,
@@ -5849,7 +5868,7 @@ export async function startServer({
         // user immediately runs. `createPluginShareProject` (apps/web) mints no
         // workspace headers at all, so this was permanently unbound, not merely
         // racy: the very first turn 403s on the workspace gate.
-        bindCreatedProjectToWorkspace((input) => ensureWorkspaceProject(db, input), createdProjectWorkspaceHome(req, getAmbientWorkspace), id, now);
+        bindCreatedProjectToWorkspace((input) => ensureWorkspaceProject(db, input), await resolveCreatedProjectHome(req), id, now);
         const registry = await loadPluginRegistryView(); const connectorProbe = buildConnectorProbe(connectorService); const resolved = resolvePluginSnapshot({ db, body: { pluginId: actionPluginId, pluginInputs: { source_plugin_id: sourcePlugin.id, source_plugin_title: sourcePlugin.title || sourcePlugin.id, source_plugin_version: sourcePlugin.version, source_plugin_path: sourcePlugin.fsPath, plugin_context_path: stagedPath }, locale: typeof body.locale === 'string' ? body.locale : undefined }, projectId: id, conversationId: cid, registry, connectorProbe });
         if (resolved && !resolved.ok) return res.status(resolved.status).json(resolved.body);
         const project = getProject(db, id); if (!project) return sendApiError(res, 500, 'INTERNAL_ERROR', 'created project could not be loaded');

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -320,6 +320,11 @@ import { createDesignSystemServerServices } from './design-systems/server-servic
 import { prepareDesignTokenContractRebuild } from './design-systems/token-contract-rebuild.js';
 import { registerBrandRoutes } from './brand-routes.js';
 import {
+  bindCreatedProjectToWorkspace,
+  createdProjectWorkspaceHome,
+  type GetAmbientWorkspace,
+} from './collab/created-project-workspace.js';
+import {
   applyDiffReviewDecisionToCwd,
   applyPlugin,
   buildConnectorProbe,
@@ -2387,6 +2392,18 @@ export async function startServer({
       resolveProjectDir,
       isSafeId,
     },
+    // Reads `getAmbientWorkspace` (declared below, alongside the provider it
+    // reads) only when a design-system workspace project is actually created,
+    // which is always long after this factory call returns.
+    bindProjectToWorkspace: (projectId, createdAt) => {
+      bindCreatedProjectToWorkspace(
+        (input) => ensureWorkspaceProject(db, input),
+        null,
+        projectId,
+        createdAt,
+        getAmbientWorkspace,
+      );
+    },
   });
   const {
     ensureUserDesignSystemWorkspaceProject,
@@ -2968,6 +2985,15 @@ export async function startServer({
       clearLocalSelection: () => activeWorkspace.clear(),
     }),
   );
+  /**
+   * The workspace this daemon is signed in to right now — zero-network,
+   * synchronous, and never throwing. Every project-creating surface takes this
+   * so a create with no workspace headers of its own still gets a home workspace
+   * instead of becoming an unbound orphan. See `createdProjectWorkspaceHome` in
+   * `collab/created-project-workspace.ts` for why, and for why a daemon that has
+   * resolved no workspace at all still binds nothing.
+   */
+  const getAmbientWorkspace: GetAmbientWorkspace = () => workspaceContext.lastKnown?.() ?? null;
   function persistWorkspaceProjectSyncState(
     projectId: string,
     workspaceId: string | null | undefined,
@@ -5298,6 +5324,7 @@ export async function startServer({
     projectFiles: projectFileDeps,
     conversations: conversationDeps,
     auth: authDeps,
+    getAmbientWorkspace,
   });
   app.post('/api/projects/:id/figma/import', (req, res) => {
     figmaUpload.single('file')(req, res, async (err) => {
@@ -5457,6 +5484,7 @@ export async function startServer({
     projectFiles: projectFileDeps,
     validation: validationDeps,
     fetchProjectCreationWorkspaceDirectory,
+    getAmbientWorkspace,
   });
 
   // Whether the caller may mutate (edit / publish-toggle / delete) a design
@@ -5568,6 +5596,7 @@ export async function startServer({
     generationJobs: designSystemGenerationJobs,
   });
   registerBrandRoutes(app, {
+    getAmbientWorkspace,
     brandsRoot: BRANDS_DIR,
     userDesignSystemsRoot: USER_DESIGN_SYSTEMS_DIR,
     resolveDesignSystemWorkspaceId: resolveDesignSystemWorkspaceScope,
@@ -5816,6 +5845,11 @@ export async function startServer({
         const now = Date.now(); const id = randomId(); const cid = randomId(); const sourceSlug = githubRepoNameFromPluginName(sourcePlugin.id); const stagedPath = `plugin-source/${sourceSlug}`; const prompt = renderPluginSharePrompt({ action, sourcePlugin, stagedPath }); const metadata = { kind: 'prototype' }; const projectRoot = await ensureProject(PROJECTS_DIR, id, metadata); await copyPluginFolderForProjectContext(sourcePlugin.fsPath, path.join(projectRoot, 'plugin-source', sourceSlug));
         insertProject(db, { id, name: `${PLUGIN_SHARE_ACTION_LABELS[action]}: ${sourcePlugin.title || sourcePlugin.id}`, skillId: null, designSystemId: null, pendingPrompt: prompt, metadata, createdAt: now, updatedAt: now });
         insertConversation(db, { id: cid, projectId: id, title: null, createdAt: now, updatedAt: now });
+        // The share task IS a chat project — it opens with a seeded prompt the
+        // user immediately runs. `createPluginShareProject` (apps/web) mints no
+        // workspace headers at all, so this was permanently unbound, not merely
+        // racy: the very first turn 403s on the workspace gate.
+        bindCreatedProjectToWorkspace((input) => ensureWorkspaceProject(db, input), createdProjectWorkspaceHome(req, getAmbientWorkspace), id, now);
         const registry = await loadPluginRegistryView(); const connectorProbe = buildConnectorProbe(connectorService); const resolved = resolvePluginSnapshot({ db, body: { pluginId: actionPluginId, pluginInputs: { source_plugin_id: sourcePlugin.id, source_plugin_title: sourcePlugin.title || sourcePlugin.id, source_plugin_version: sourcePlugin.version, source_plugin_path: sourcePlugin.fsPath, plugin_context_path: stagedPath }, locale: typeof body.locale === 'string' ? body.locale : undefined }, projectId: id, conversationId: cid, registry, connectorProbe });
         if (resolved && !resolved.ok) return res.status(resolved.status).json(resolved.body);
         const project = getProject(db, id); if (!project) return sendApiError(res, 500, 'INTERNAL_ERROR', 'created project could not be loaded');
@@ -5941,6 +5975,7 @@ export async function startServer({
     projectStore: projectStoreDeps,
     conversations: conversationDeps,
     fetchProjectCreationWorkspaceDirectory,
+    getAmbientWorkspace,
     workspaceResources: { getWorkspaceResource, getWorkspaceResourceByResourceId },
     plugins: {
       listInstalledPlugins,
@@ -10912,6 +10947,17 @@ export async function startServer({
       createdAt: now,
       updatedAt: now,
     });
+    // Orbit creates its project from a scheduler tick, so there is no request to
+    // read workspace headers off — the daemon's own signed-in workspace is the
+    // ONLY thing that can answer, and without it every Orbit run is an
+    // unattributed Cloud run.
+    bindCreatedProjectToWorkspace(
+      (input) => ensureWorkspaceProject(db, input),
+      null,
+      projectId,
+      now,
+      getAmbientWorkspace,
+    );
     insertConversation(db, {
       id: conversationId,
       projectId,
@@ -11124,6 +11170,15 @@ export async function startServer({
         createdAt: now,
         updatedAt: now,
       });
+      // Same as Orbit above: a routine fires from cron with no request behind
+      // it, so only the daemon's ambient workspace can own the project it makes.
+      bindCreatedProjectToWorkspace(
+        (input) => ensureWorkspaceProject(db, input),
+        null,
+        projectId,
+        now,
+        getAmbientWorkspace,
+      );
       createdProjectId = projectId;
     };
     if (routine.target.mode === 'reuse') {

--- a/apps/daemon/tests/brand-routes.test.ts
+++ b/apps/daemon/tests/brand-routes.test.ts
@@ -6,6 +6,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { registerBrandRoutes, type BrandRoutesDeps } from '../src/brand-routes.js';
+import { createCreatedProjectWorkspaceResolver } from '../src/collab/created-project-workspace.js';
 import {
   closeDatabase,
   getWorkspaceProjectByProjectId,
@@ -1362,6 +1363,13 @@ describe('brand routes', () => {
       skillsRoot,
       dataDir,
       db,
+      // The same production seam `server.ts` builds. Constructed with no
+      // membership-directory fetcher, which is
+      // `authorizeCreatedProjectWorkspace`'s documented local/dev
+      // compatibility configuration — so a verified header identity still
+      // binds here, while the resolver's verify-then-degrade contract is
+      // covered directly in `tests/collab/created-project-workspace.test.ts`.
+      resolveCreatedProjectHome: createCreatedProjectWorkspaceResolver({}),
       ...extraDeps,
     });
     const server = http.createServer(app);

--- a/apps/daemon/tests/collab/created-project-workspace.test.ts
+++ b/apps/daemon/tests/collab/created-project-workspace.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   authorizeCreatedProjectWorkspace,
+  createdProjectWorkspaceHome,
   type CreatedProjectWorkspaceResolution,
 } from '../../src/collab/created-project-workspace.js';
 
@@ -144,5 +145,129 @@ describe('authorizeCreatedProjectWorkspace', () => {
 
     expectDenied(result, 400, 'WORKSPACE_CONTEXT_INCOMPLETE');
     expect(fetchDirectory).not.toHaveBeenCalled();
+  });
+});
+
+// `x-od-workspace-*` headers are an UNAUTHENTICATED hint. Any local caller — the
+// `od` CLI, a plain curl, a compromised page — can assert an arbitrary
+// workspace/member pair. The creation paths with no authorization gate of their
+// own (duplicate, design-system-copy, project-location scan, the library
+// capture-as-page exit, brand extraction, the plugin share-project task) must
+// therefore VERIFY an asserted identity before persisting it, and must still
+// never answer 4xx — they ship today and answer 200 today.
+//
+// So: verify, then degrade. Never reject, never trust.
+describe('createdProjectWorkspaceHome', () => {
+  const AMBIENT = {
+    workspaceId: 'workspace-ambient',
+    workspaceType: 'personal' as const,
+    workspaceMemberId: 'member-ambient',
+    role: 'owner' as const,
+    memberStatus: 'active' as const,
+    lifecycleState: 'active' as const,
+    permissions: { canShareProjects: true, canWriteSyncedFiles: true },
+  };
+  const ambient = () => AMBIENT;
+  /** Headers naming a workspace/member pair the caller has no membership in. */
+  const FOREIGN_HEADERS: Record<string, string> = {
+    ...ACTIVE_HEADERS,
+    'x-od-workspace-id': 'workspace-foreign',
+    'x-od-workspace-member-id': 'member-foreign',
+  };
+
+  it('binds an asserted identity the directory confirms, using the DIRECTORY context', async () => {
+    const home = await createdProjectWorkspaceHome(request(), ambient, async () => ({
+      ok: true,
+      items: [directoryItem()],
+    }));
+
+    expect(home).toMatchObject({
+      workspaceId: 'workspace-a',
+      workspaceMemberId: 'member-a',
+      memberStatus: 'active',
+    });
+  });
+
+  it('refuses to persist an asserted workspace the caller has no membership in', async () => {
+    const home = await createdProjectWorkspaceHome(
+      request(FOREIGN_HEADERS),
+      ambient,
+      async () => ({ ok: true, items: [directoryItem()] }),
+    );
+
+    // The unverifiable claim is never written...
+    expect(home?.workspaceId).not.toBe('workspace-foreign');
+    expect(home?.workspaceMemberId).not.toBe('member-foreign');
+    // ...and creation is NOT refused: it degrades to what the daemon can vouch for.
+    expect(home).toMatchObject({
+      workspaceId: AMBIENT.workspaceId,
+      workspaceMemberId: AMBIENT.workspaceMemberId,
+    });
+  });
+
+  it('leaves the project unbound when an unverifiable claim has no ambient workspace to fall back to', async () => {
+    const home = await createdProjectWorkspaceHome(
+      request(FOREIGN_HEADERS),
+      () => null,
+      async () => ({ ok: true, items: [directoryItem()] }),
+    );
+
+    // Unbound is strictly better than a fabricated binding.
+    expect(home).toBeNull();
+  });
+
+  it('treats an unreadable membership authority as CANNOT CONFIRM, not as valid', async () => {
+    const home = await createdProjectWorkspaceHome(request(), ambient, async () => ({
+      ok: false,
+      items: [],
+    }));
+
+    expect(home?.workspaceId).not.toBe('workspace-a');
+    expect(home).toMatchObject({ workspaceId: AMBIENT.workspaceId });
+  });
+
+  it('degrades an authority that throws outright, rather than propagating', async () => {
+    const home = await createdProjectWorkspaceHome(request(), ambient, async () => {
+      throw new Error('authority exploded');
+    });
+
+    expect(home).toMatchObject({ workspaceId: AMBIENT.workspaceId });
+  });
+
+  it('does not persist a claim the daemon last-known state says was removed', async () => {
+    const home = await createdProjectWorkspaceHome(
+      request(),
+      ambient,
+      async () => ({ ok: true, items: [directoryItem()] }),
+      () => ({ workspaceId: 'workspace-a', memberStatus: 'removed' }),
+    );
+
+    expect(home?.workspaceId).not.toBe('workspace-a');
+    expect(home).toMatchObject({ workspaceId: AMBIENT.workspaceId });
+  });
+
+  it('binds the ambient workspace when the request asserts nothing at all', async () => {
+    const fetchDirectory = vi.fn(async () => ({ ok: true, items: [directoryItem()] }));
+    const home = await createdProjectWorkspaceHome(request({}), ambient, fetchDirectory);
+
+    expect(home).toMatchObject({ workspaceId: AMBIENT.workspaceId });
+    // A headerless caller asserts nothing, so there is nothing to verify.
+    expect(fetchDirectory).not.toHaveBeenCalled();
+  });
+
+  it('stays unbound for a signed-out daemon with no identity anywhere', async () => {
+    const home = await createdProjectWorkspaceHome(request({}), () => null);
+
+    expect(home).toBeNull();
+  });
+
+  it('never binds an ambient workspace the daemon itself reports as unusable', async () => {
+    for (const broken of [
+      { ...AMBIENT, memberStatus: 'removed' as const },
+      { ...AMBIENT, lifecycleState: 'locked' as const },
+      { ...AMBIENT, permissions: { canShareProjects: true, canWriteSyncedFiles: false } },
+    ]) {
+      expect(await createdProjectWorkspaceHome(request({}), () => broken)).toBeNull();
+    }
   });
 });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2394,7 +2394,19 @@ function AppInner() {
       action: PluginShareAction,
       locale?: string,
     ): Promise<PluginShareProjectOutcome> => {
-      const outcome = await createPluginShareProject(pluginId, action, locale);
+      // Best-effort, NOT `resolvedWorkspaceContextForWrite`: that helper throws
+      // while the identity read is in flight, and refusing this create would be
+      // a new block on a path that works today. Sending the context whenever it
+      // is known is a strict improvement — this call used to send none, ever —
+      // and the daemon binds a headerless create to its own signed-in workspace
+      // (`createdProjectWorkspaceHome`), so the loading window no longer
+      // produces an orphan either way.
+      const outcome = await createPluginShareProject(
+        pluginId,
+        action,
+        locale,
+        workspaceContextStateRef.current.context,
+      );
       if (!outcome.ok) return outcome;
       try {
         window.sessionStorage.setItem(

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -1368,17 +1368,32 @@ export type PluginShareProjectOutcome =
       code?: string;
     };
 
+/**
+ * Start a plugin share task, which stands up a real chat project server-side.
+ *
+ * `workspaceContext` MUST be attached, for the same reason every sibling create
+ * in this file attaches it: the project this endpoint creates gets a
+ * `workspace_projects` binding from the request's own identity, and a headerless
+ * create leaves it unbound — denied its first run by the daemon's workspace gate
+ * and carrying no workspace to bill on any run that does get through. This call
+ * was the one create in this file with no `workspaceContext` parameter at all,
+ * so it was permanently unbound rather than merely racy.
+ */
 export async function createPluginShareProject(
   pluginId: string,
   action: PluginShareAction,
   locale?: string,
+  workspaceContext?: WorkspaceCollabContext | null,
 ): Promise<PluginShareProjectOutcome> {
   try {
     const resp = await fetch(
       `/api/plugins/${encodeURIComponent(pluginId)}/share-project`,
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          ...(workspaceContext ? workspaceProjectHeaders(workspaceContext) : {}),
+        },
         body: JSON.stringify({
           action,
           ...(locale ? { locale } : {}),

--- a/e2e/tests/collab/created-project-binding.test.ts
+++ b/e2e/tests/collab/created-project-binding.test.ts
@@ -1,0 +1,325 @@
+// @vitest-environment node
+
+// INVARIANT UNDER TEST: a project this daemon creates while it knows a
+// signed-in workspace always gets a `workspace_projects` binding row.
+//
+// Every project-creating route resolved its workspace from the REQUEST's
+// `x-od-workspace-*` headers alone (`resolveCreatedProjectWorkspace` ->
+// `bindCreatedProjectToWorkspace`, whose first statement was `if (!context)
+// return;`). A headerless create therefore produced an unbound project and
+// still answered 200, so nothing anywhere surfaced the loss. Three shipped
+// callers are headerless by construction, not by choice:
+//
+//   * `od project create` (apps/daemon/src/cli.ts) and the MCP `create_project`
+//     tool never mint workspace headers at all.
+//   * the web client's duplicate / design-system-copy / plugin-share creates
+//     read a ref that drops the context's `loading` flag, so a create fired
+//     before the (vela-backed, seconds-long) identity read lands sends none.
+//   * daemon-initiated creates — Orbit runs, scheduled routines — have no
+//     request to read headers from in the first place.
+//
+// The damage is billing attribution, not cosmetics. An unbound project makes
+// `GET /api/projects/:id/workspace-scope` answer `unbound`, which
+// `ProjectView`'s `projectRunWorkspaceContext` turns into `null` on the run
+// request — an Open Design Cloud run with no workspace to bill — and which
+// blanks `AvatarMenu`'s balance/plan area while that project is open.
+//
+// The fix resolves a headerless create against the daemon's OWN last-known
+// workspace (`workspaceContext.lastKnown()`, zero-network and synchronous)
+// instead of leaving an orphan. Two boundaries are deliberately NOT that, and
+// are pinned below so nobody later "fixes" them into a block:
+//
+//   * SIGNED OUT is not a bug. A daemon that has resolved no workspace binds
+//     nothing, the create still succeeds, and `unbound` is the honest answer —
+//     the same way the product behaves with no workspace feature at all.
+//   * An explicit header identity still wins over the ambient one. A create
+//     that names a workspace binds to THAT workspace.
+//
+// Seeding is through production HTTP APIs only: `PUT /api/workspace/context`
+// (the daemon's own dev/demo context seam, the same endpoint tools-dev and the
+// demo runtime drive) for the ambient identity, and the real vela integration
+// (`VELA_CONTROL_KEY` + `VELA_API_URL` -> `GET /api/v1/workspaces`) against a
+// temporary server-level mock for the membership directory that turns a
+// binding into a resolvable `personal`/`team` scope. No source-level backdoor.
+
+import { createServer, type Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { requestJson } from '@/vitest/http';
+import { createSmokeSuite } from '@/vitest/suite';
+
+type ProjectWorkspaceScopeBody = {
+  scope: {
+    kind: 'unbound' | 'unavailable' | 'personal' | 'team';
+    projectId: string;
+    workspaceId: string | null;
+    visibility?: 'personal' | 'team';
+    context: { workspaceId: string; workspaceMemberId: string; workspaceType: string } | null;
+  };
+};
+
+type CreatedProject = { conversationId: string; project: { id: string; name: string } };
+type InstalledPlugins = { plugins: Array<{ id: string; title?: string }> };
+
+/** The daemon's ambient signed-in workspace for most of this spec. */
+const AMBIENT = {
+  workspaceId: 'ws-bind-personal',
+  workspaceName: 'Bind personal',
+  workspaceType: 'personal' as const,
+  workspaceMemberId: 'mem-bind-personal',
+  role: 'owner' as const,
+  memberStatus: 'active' as const,
+  lifecycleState: 'active' as const,
+};
+
+/** A second membership, used to prove explicit headers still outrank ambient. */
+const EXPLICIT_TEAM = {
+  workspaceId: 'ws-bind-team',
+  workspaceName: 'Bind team',
+  workspaceType: 'team' as const,
+  workspaceMemberId: 'mem-bind-team',
+  role: 'member' as const,
+  memberStatus: 'active' as const,
+  lifecycleState: 'active' as const,
+};
+
+let directoryServer: Server;
+let directoryUrl: string;
+
+beforeAll(async () => {
+  directoryServer = createServer((req, res) => {
+    if (req.url?.startsWith('/api/v1/workspaces') && req.method === 'GET') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ items: [AMBIENT, EXPLICIT_TEAM] }));
+      return;
+    }
+    res.writeHead(404, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not found' }));
+  });
+  await new Promise<void>((resolve) => directoryServer.listen(0, '127.0.0.1', resolve));
+  const address = directoryServer.address();
+  if (address == null || typeof address === 'string') throw new Error('mock directory has no port');
+  directoryUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => directoryServer.close(() => resolve()));
+});
+
+function workspaceHeaders(input: {
+  workspaceId: string;
+  workspaceMemberId: string;
+  workspaceType: 'personal' | 'team';
+  role?: string;
+}): Record<string, string> {
+  return {
+    'x-od-workspace-id': input.workspaceId,
+    'x-od-workspace-type': input.workspaceType,
+    'x-od-workspace-member-id': input.workspaceMemberId,
+    'x-od-workspace-role': input.role ?? 'owner',
+    'x-od-workspace-lifecycle-state': 'active',
+    'x-od-workspace-member-status': 'active',
+    'x-od-workspace-can-share-projects': 'true',
+    'x-od-workspace-can-write-synced-files': 'true',
+  };
+}
+
+/**
+ * Put the daemon into "a signed-in workspace is known" — the state every real
+ * client reaches within seconds of launch through its own
+ * `GET /api/workspace/context` poll. `null` signs it out again.
+ */
+async function setAmbientWorkspace(
+  webUrl: string,
+  context: Record<string, unknown> | null,
+): Promise<void> {
+  await requestJson(webUrl, '/api/workspace/context', {
+    body: context ?? {},
+    method: 'PUT',
+  });
+}
+
+async function readScope(
+  webUrl: string,
+  projectId: string,
+  headers?: Record<string, string>,
+): Promise<ProjectWorkspaceScopeBody['scope']> {
+  const body = await requestJson<ProjectWorkspaceScopeBody>(
+    webUrl,
+    `/api/projects/${encodeURIComponent(projectId)}/workspace-scope`,
+    headers ? { headers } : {},
+  );
+  return body.scope;
+}
+
+async function createProject(
+  webUrl: string,
+  name: string,
+  headers?: Record<string, string>,
+): Promise<string> {
+  const created = await requestJson<CreatedProject>(webUrl, '/api/projects', {
+    body: {
+      designSystemId: null,
+      id: randomUUID(),
+      metadata: { kind: 'prototype' },
+      name,
+      pendingPrompt: null,
+      skillId: null,
+    },
+    method: 'POST',
+    ...(headers ? { headers } : {}),
+  });
+  return created.project.id;
+}
+
+describe('a created project is bound to the workspace the daemon is signed in to', () => {
+  test(
+    'headerless creates bind to the ambient workspace; signed-out stays unbound and still works',
+    { timeout: 300_000 },
+    async () => {
+      const suite = await createSmokeSuite('collab-created-project-binding');
+
+      await suite.with.toolsDev(
+        async ({ webUrl }) => {
+          await setAmbientWorkspace(webUrl, AMBIENT);
+
+          // --- SOURCE 1: POST /api/projects with no workspace headers. This is
+          // `od project create`, the MCP `create_project` tool, and any web
+          // create that fired before the identity read landed.
+          const plainCreate = await createProject(webUrl, 'Bind plain create');
+          const plainScope = await readScope(webUrl, plainCreate);
+          expect(
+            plainScope.kind,
+            'a headerless create must still bind to the workspace the daemon knows it is in',
+          ).not.toBe('unbound');
+          expect(plainScope.workspaceId).toBe(AMBIENT.workspaceId);
+          expect(plainScope.kind).toBe('personal');
+          // The binding is a private local draft, never a team share.
+          expect(plainScope.visibility).toBe('personal');
+          // The member id is the DIRECTORY's, which is what makes it a usable
+          // billing subject rather than an echo of whatever asked.
+          expect(plainScope.context?.workspaceMemberId).toBe(AMBIENT.workspaceMemberId);
+
+          // --- SOURCE 2: folder import. Same shared helper, its own route.
+          const importedDir = join(suite.scratchDir, 'imported-folder');
+          await mkdir(importedDir, { recursive: true });
+          const imported = await requestJson<CreatedProject>(webUrl, '/api/import/folder', {
+            body: { baseDir: importedDir, name: 'Bind folder import' },
+            method: 'POST',
+          });
+          const importedScope = await readScope(webUrl, imported.project.id);
+          expect(
+            importedScope.kind,
+            'an imported-folder project is still a project and still needs a home workspace',
+          ).not.toBe('unbound');
+          expect(importedScope.workspaceId).toBe(AMBIENT.workspaceId);
+
+          // --- SOURCE 3: plugin-created project. Uses whichever plugin the
+          // daemon registered at startup, so it needs no fixture of its own.
+          const installed = await requestJson<InstalledPlugins>(webUrl, '/api/plugins');
+          expect(
+            installed.plugins.length,
+            'the daemon registers bundled plugins at startup',
+          ).toBeGreaterThan(0);
+          const fromPlugin = await duplicateFirstDuplicablePlugin(
+            webUrl,
+            installed.plugins.map((plugin) => plugin.id),
+          );
+          const pluginScope = await readScope(webUrl, fromPlugin.project.id);
+          expect(
+            pluginScope.kind,
+            'a plugin-created project must not be an orphan either',
+          ).not.toBe('unbound');
+          expect(pluginScope.workspaceId).toBe(AMBIENT.workspaceId);
+
+          // --- BOUNDARY 1: an explicit identity outranks the ambient one. The
+          // ambient workspace is a fallback for callers that cannot say, never
+          // an override for callers that did.
+          const explicit = await createProject(
+            webUrl,
+            'Bind explicit team',
+            workspaceHeaders(EXPLICIT_TEAM),
+          );
+          const explicitScope = await readScope(webUrl, explicit);
+          expect(explicitScope.workspaceId).toBe(EXPLICIT_TEAM.workspaceId);
+          expect(explicitScope.kind).toBe('team');
+
+          // --- BOUNDARY 2: SIGNED OUT. Runs last: it clears the ambient
+          // identity the cases above depend on.
+          //
+          // With no workspace resolved there is nothing to bind to, and
+          // inventing one would be worse than answering "none". The create must
+          // still SUCCEED and the project must still be usable — this is the
+          // product's behavior with no workspace feature at all, and a guard
+          // here would break the signed-out single-player user.
+          await setAmbientWorkspace(webUrl, null);
+          const signedOut = await createProject(webUrl, 'Bind signed out');
+          const signedOutScope = await readScope(webUrl, signedOut);
+          expect(signedOutScope.kind, 'signed out has no workspace to bind to').toBe('unbound');
+          expect(signedOutScope.workspaceId).toBeNull();
+          // Still a real, readable, usable project — not a blocked create.
+          const readBack = await requestJson<{ project: { id: string; name: string } }>(
+            webUrl,
+            `/api/projects/${encodeURIComponent(signedOut)}`,
+          );
+          expect(readBack.project.name).toBe('Bind signed out');
+        },
+        {
+          env: {
+            // The daemon's real vela session inputs, pointed at the mock above.
+            // AMR_HOME redirects the config-file fallback at an empty dir so a
+            // developer machine that IS signed in to production cannot leak in.
+            AMR_HOME: await emptyAmrHome(suite.scratchDir),
+            VELA_API_URL: directoryUrl,
+            VELA_CONTROL_KEY: 'e2e-binding-control-key',
+          },
+        },
+      );
+    },
+  );
+});
+
+/**
+ * Create a project from whichever bundled plugin the daemon can actually
+ * duplicate. Not every plugin exposes a duplicable HTML preview
+ * (`NO_DUPLICABLE_PREVIEW`), and which ones ship is a catalog detail this spec
+ * has no business pinning — so try them in turn and report the refusals if none
+ * works, rather than failing on an unrelated fixture change.
+ */
+async function duplicateFirstDuplicablePlugin(
+  webUrl: string,
+  pluginIds: readonly string[],
+): Promise<CreatedProject> {
+  const refusals: string[] = [];
+  for (const pluginId of pluginIds) {
+    const response = await fetch(
+      new URL(`/api/plugins/${encodeURIComponent(pluginId)}/duplicate-project`, webUrl),
+      {
+        body: JSON.stringify({ name: `Bind plugin project ${pluginId}` }),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+      },
+    );
+    const text = await response.text();
+    if (response.ok) return JSON.parse(text) as CreatedProject;
+    refusals.push(`${pluginId}: ${response.status} ${text.slice(0, 120)}`);
+  }
+  throw new Error(
+    `no bundled plugin could be duplicated into a project:\n${refusals.join('\n')}`,
+  );
+}
+
+/**
+ * A vela config home guaranteed to hold no session, so the daemon's
+ * `readVelaControlApiContext` config-file fallback cannot pick up the developer
+ * machine's real production login.
+ */
+async function emptyAmrHome(scratchDir: string): Promise<string> {
+  const dir = join(scratchDir, 'empty-amr-home');
+  await mkdir(dir, { recursive: true });
+  return dir;
+}

--- a/e2e/tests/collab/created-project-binding.test.ts
+++ b/e2e/tests/collab/created-project-binding.test.ts
@@ -283,6 +283,64 @@ describe('a created project is bound to the workspace the daemon is signed in to
   );
 });
 
+describe('an asserted workspace identity is verified before it is persisted', () => {
+  test(
+    'a create asserting a workspace the caller has no membership in does not bind to it',
+    { timeout: 300_000 },
+    async () => {
+      const suite = await createSmokeSuite('collab-created-project-unverified-claim');
+
+      // `OD_WORKSPACE_CONTEXT_SOURCE=vela` is what makes the daemon's
+      // project-creation membership authority exist at all
+      // (`fetchProjectCreationWorkspaceDirectory` is undefined otherwise — the
+      // documented local/dev compatibility path). The mock directory below lists
+      // AMBIENT and EXPLICIT_TEAM and deliberately does NOT list the foreign
+      // pair the request asserts.
+      await suite.with.toolsDev(
+        async ({ webUrl }) => {
+          const source = await createProject(webUrl, 'Claim source');
+
+          // Duplicate is one of the paths with no authorization gate of its own,
+          // so it is where an unverified header claim used to be written
+          // straight into `workspace_projects`.
+          const copy = await requestJson<CreatedProject>(
+            webUrl,
+            `/api/projects/${encodeURIComponent(source)}/duplicate`,
+            {
+              body: { name: 'Claim copy' },
+              headers: workspaceHeaders({
+                workspaceId: 'ws-bind-foreign',
+                workspaceMemberId: 'mem-bind-foreign',
+                workspaceType: 'team',
+              }),
+              method: 'POST',
+            },
+          );
+
+          const copyScope = await readScope(webUrl, copy.project.id);
+          // The claim is never persisted...
+          expect(
+            copyScope.workspaceId,
+            'an unverifiable header claim must not be written as a binding',
+          ).not.toBe('ws-bind-foreign');
+          // ...and with no ambient workspace behind this daemon there is nothing
+          // to degrade to, so `unbound` is the honest answer. Creation still
+          // returned 200 — the point is that it degrades, never refuses.
+          expect(copyScope.kind).toBe('unbound');
+        },
+        {
+          env: {
+            AMR_HOME: await emptyAmrHome(suite.scratchDir),
+            OD_WORKSPACE_CONTEXT_SOURCE: 'vela',
+            VELA_API_URL: directoryUrl,
+            VELA_CONTROL_KEY: 'e2e-binding-control-key',
+          },
+        },
+      );
+    },
+  );
+});
+
 /**
  * Create a project from whichever bundled plugin the daemon can actually
  * duplicate. Not every plugin exposes a duplicable HTML preview


### PR DESCRIPTION
## Why

**Use case.** Chasing a data-integrity class rather than one report: projects that end up with **no `workspace_projects` binding row**. I went at the `projects` table's writers instead of the reported routes, because the reported routes turned out to be a minority of the problem.

**The pain.** An unbound project makes `GET /api/projects/:id/workspace-scope` answer `unbound`, and two consumers degrade:

- `apps/web/src/components/ProjectView.tsx:1544` — `projectRunWorkspaceContext` feeds the run request (`:6405`, `:6567`). `unbound` → `null` → **an Open Design Cloud run carries no workspace billing attribution.**
- `apps/web/src/components/AvatarMenu.tsx:105` — derives workspace context from the project scope. `unbound` → `null`, and because `projectWorkspaceScope` is itself truthy it does *not* fall back to the ambient context, so the balance/plan area goes blank while that project is open.

The same orphan is *also* denied its first run outright: `enforceWorkspaceResourceMutation`'s two-key lookup comes back empty and short-circuits to `canMutate: false` the moment the caller carries any workspace header. That failure mode is already documented in-tree at `apps/daemon/src/brand-routes.ts:115-131`.

So: money/attribution correctness, not cosmetics.

## Task 1 — the full enumeration

`INSERT INTO projects` exists in exactly one place (`apps/daemon/src/db.ts:1753`, via `insertProject`). It has **15 call sites**. Working from the writer rather than from the reported routes is what surfaced the six that were binding *nothing*.

### A. Server-side creation paths

| # | Writer | Reached by | Reachable today | Bound before this PR | After |
|---|---|---|---|---|---|
| 1 | `routes/project/index.ts:2990` | `POST /api/projects` | yes | only with headers (`bindCreatedProjectToWorkspace`) | + ambient fallback |
| 2 | `routes/project/index.ts:3189` | `POST /api/projects/:id/duplicate` | yes | only with headers (`bindDuplicateIntoRequestWorkspace`) | + verified/ambient fallback |
| 3 | `routes/project/index.ts:3331` | `POST /api/projects/:id/design-system-copy` | yes | only with headers (same helper) | + verified/ambient fallback |
| 4 | `routes/project/index.ts:2405` | `POST /api/project-locations/scan` | yes (Settings → project locations) | **never** | **now binds** |
| 5 | `import-export-routes.ts:113` | `POST /api/import/claude-design` | yes | only with headers | + ambient fallback |
| 6 | `import-export-routes.ts:431` | `POST /api/import/folder` | yes | only with headers | + ambient fallback |
| 7 | `routes/plugins/index.ts:315` | `POST /api/plugins/:id/duplicate-project` | yes | only with headers | + ambient fallback |
| 8 | `server.ts:5817` | `POST /api/plugins/:id/share-project` | yes | **never** (and the web client sent no headers *ever* — see B4) | **now binds, both ends** |
| 9 | `routes/library.ts:619` | `POST /api/library/assets/:id/edit-as-page` (clipper capture → editable project) | yes | **never** | **now binds** |
| 10 | `brands/index.ts:369` | `POST /api/brands` → `startBrandExtraction` | yes | only with headers (`bindBrandProjectIntoRequestWorkspace`) | + verified/ambient fallback |
| 11 | `design-systems/server-services.ts:329` | `POST /api/design-systems/:id/workspace`, **and** the chat/run prompt-composition path (`server.ts:6380`) | yes | **never** | **now binds** (ambient only — no request exists) |
| 12 | `server.ts:3562` | collab pull `register`-on-pull (`collab-sync.ts:897`) and the shared-project placeholder (`:915`) | yes | **never** | **deliberately unchanged — see C** |
| 13 | `collab/team-mirror-materializer.ts:234` | `materializePulledTeamMirror` | yes | yes, `visibility: 'team'` (`:275`) | unchanged |
| 14 | `server.ts:10905` | Orbit run handler → `POST /api/orbit/run` + Orbit scheduler | yes | **never** | **now binds** (ambient only — scheduler tick, no request) |
| 15 | `server.ts:11110` | `createRoutineProject` → `POST /api/routines/:id/run`, `od routine run`, cron | yes | **never** | **now binds** (ambient only) |

### B. Client-side sources of a headerless create

| # | Source | Evidence | Reachable today |
|---|---|---|---|
| B1 | **`od project create`** sends no workspace headers | `apps/daemon/src/cli.ts:6387` — `headers: { 'content-type': 'application/json' }` only. The CLI's *one* workspace-header builder (`cli.ts:6718`) lives inside `od workspace …` and is never reached by `project create`. | yes — **CLI-created projects are unbound in the shipped product today** |
| B2 | **MCP `create_project`** sends no workspace headers | `apps/daemon/src/mcp.ts:1004` | yes |
| B3 | **Client-side race** — the ref drops `loading` | `App.tsx:689` sets `workspaceContextRef.current = workspaceContext`, keeping only `.context` and discarding `loading`. `App.tsx:2345` (design-system-copy) and `App.tsx:2375` (duplicate) pass that ref, so `null` is ambiguous between "anonymous" and "still loading". `useWorkspaceContext.ts:126-128` starts a cold boot at `{ context: null, loading: true }` and only settles at `:205`. Reachable from the Home card menu (`HomeView.tsx:2434` → `DesignsTab.tsx:421`) and `DesignFilesPanel.tsx:1199` — both live before the identity read lands. | yes |
| B4 | **`createPluginShareProject` sends no headers, ever** — not a race | `state/projects.ts:1371` had no `workspaceContext` parameter at all, unlike every sibling create in the same file. Pairs with source #8, which also never bound. | yes — **permanent** |
| B5 | **Signed out / no vela session** | no headers by definition; `lastKnown()` is null | yes — and `unbound` is **correct** here, see Task 2 |
| B6 | **Legacy projects** (pre-workspace-team, restored backup, fresh install) | no creation event to hook at all | yes — see Task 3 |

### C. Ruled out, with reasons

- **#12 collab pull register / shared-project placeholder** — this is a *teammate's* shared project. Its correct binding is `visibility: 'team'`, written by `materializePulledTeamMirror` (#13). Binding it to the reader's ambient workspace as `personal` would misattribute someone else's resource, which is exactly the adoption red line `ensureWorkspaceProjection`'s docblock protects. Left alone on purpose.
- **Imported-folder projects** — `AGENTS.md` names `metadata.baseDir` as the sanctioned exception for the *project root*, not for the workspace binding. Confirmed they should be bound like any other project: #6 already bound with headers, and `POST /api/import/folder` reaches the same shared helper. Now covered.
- **Templates / remix** — no separate writer. `EntryShell.tsx:1616` (community remix) and the template flows all land on `handleCreateProject` → `POST /api/projects` (#1), already gated through `resolvedWorkspaceContextForWrite`.

### D. One shared hole, reached by several routes — verified, not assumed

The framing "all three paths go through that early return" is correct, and it is actually **four** routes plus a fifth helper. `POST /api/projects` (`routes/project/index.ts:2826`), `POST /api/import/claude-design` (`import-export-routes.ts:86`), `POST /api/import/folder` (`:301`), and `POST /api/plugins/:id/duplicate-project` (`routes/plugins/index.ts:281`) each call `authorizeCreatedProjectWorkspace(req, ctx.fetchProjectCreationWorkspaceDirectory)` — **identical upstream resolution** — then the same `bindCreatedProjectToWorkspace`, whose first statement was `if (!context) return;`. I checked each one rather than taking it on faith. Duplicate / design-system-copy and brand extraction resolve their context *differently* (`bindDuplicateIntoRequestWorkspace`, `bindBrandProjectIntoRequestWorkspace`) but had the same hole, so they needed their own fixes.

## Task 2 — plugging the sources

The fix is one named invariant, not scattered `if`s. `apps/daemon/src/collab/created-project-workspace.ts` gains:

- `ambientWorkspaceHome()` — the daemon's own last-verified workspace as a binding subject, refused for the same three reasons a header identity is (removed member, cannot write synced files, locked/deleted workspace). Refusal means "leave unbound", never "fail the create".
- `createdProjectWorkspaceHome(req, ambient, fetchDirectory, lastKnownMembership)` — **never refuses, never throws.**
- `bindCreatedProjectToWorkspace(..., getAmbientWorkspace?)` — `if (!context) return;` became `const home = context ?? ambientWorkspaceHome(...)`, with a docblock stating the invariant.

**Why `lastKnown()` is sound per resource.** It is zero-network, synchronous, and cannot fail or hang — the same source `enforceWorkspaceProjectMutation`'s membership cross-check and `resolveDesignSystemWorkspaceScope` (`server.ts:2875`) already trust. It is populated by traffic the daemon already serves (the web client's `GET /api/workspace/context` poll, the collab-cloud poller's 5s `.current()` tick, the dev/demo `PUT` seam). One daemon process serves one signed-in user, so for a create that names *no* workspace there is nothing else it could sensibly mean. The binding is written `visibility: 'personal'` — a private local draft, matching every other orphan-claiming path (`ensureWorkspaceProjection`, `bindDuplicateIntoRequestWorkspace`, and #6185's read fallback). `ensureWorkspaceProject` is keyed on project id and idempotent (`db.ts:1181`), so nothing already bound is ever re-homed.

**Verify, then degrade — never reject, never trust.** `x-od-workspace-*` headers are an unauthenticated hint: any local caller (`od` CLI, plain curl, a compromised page) can assert an arbitrary workspace/member pair. So `createdProjectWorkspaceHome` has three outcomes, in order:

1. asserted identity that **verifies** → bind to it;
2. asserted identity that **does not verify** — unknown workspace, member not active, permissions disagree, the daemon's last-known state says removed, or the authority is unreadable so it *cannot be confirmed* → the claim is **never written**; bind to the ambient workspace instead, or leave it unbound;
3. **nothing asserted** → ambient.

Verification is not re-implemented: it is `authorizeCreatedProjectWorkspace` — the same directory lookup `POST /api/projects` gates on, which also returns the *directory's* authoritative context rather than the caller's claimed one — plus `withLastKnownMembership`, the same cross-check the mutation gates apply (exported rather than copied). Only the failure behavior differs: they refuse, this degrades. An absent fetcher stays `authorizeCreatedProjectWorkspace`'s own documented local/dev compatibility path, not a second weaker definition of verified. Route modules take a single `CreatedProjectWorkspaceResolver`, so there is one notion of "verified" per daemon.

**No new blocking, anywhere.** No path gains a 400/403/503 it did not already have. The resolver degrades instead of refusing, which is why the six never-bound paths (#4, #8, #9, #11, #14, #15) use it rather than `authorizeCreatedProjectWorkspace` — those ship today and return 200 today.

**Signed out stays `unbound`, on purpose.** Per the product ruling: no workspace resolved → bind nothing → the create still succeeds and the project is fully usable. This is the product's behavior with no workspace feature at all. Pinned by a test case so nobody later "fixes" it into a block.

**Web side.** `createPluginShareProject` now forwards the context when known (`state/projects.ts`, `App.tsx:2397`) — best-effort, **deliberately not** `resolvedWorkspaceContextForWrite`, which throws while the identity read is in flight and would add a new block to a path that works today.

**What I did *not* touch:** `useWorkspaceContext.ts`, `useProjectWorkspaceScope.ts`, and the `coalescedGet` keys — owned by `fix/identity-scoped-read-caches`.

## Task 3 — legacy rows (recommendation only, nothing implemented)

Verified the current state:

- **`reconcileUnboundProjectBeforeMutation`** (`routes/project/index.ts:2104`) has exactly **two** call sites — `:3136` (duplicate) and `:3245` (design-system-copy) — and both act on the *source* project. So a legacy project is adopted only if you happen to duplicate it or make a design system from it.
- **`bindUnboundProjectsToPersonalWorkspace`** (`:2193`) adopts every unbound project on a project-list read, but only when `ctx.workspaceType === 'personal'` (`:2197`). A team-workspace read never adopts.
- Startup runs `reconcileImpossibleTeamShares` and `backfillDesignSystemWorkspaceResources` (`server.ts:3151`, `:3160`) — **there is no project equivalent.** Confirmed.

**Recommendation: do not add a startup project backfill.** Two reasons.

1. **The authorship hazard is real and unresolvable at startup.** `backfillDesignSystemWorkspaceResources` is safe *because* it reads a workspace claim that already exists in `metadata.json` — it never invents one. A project backfill has nothing to read, so it would have to attribute `createdByWorkspaceMemberId` from whichever identity happens to be active at startup. On a shared machine or after an account switch that is simply wrong, and it is the same red line that kept this helper off read paths.
2. **The remaining gap is already covered.** Legacy rows are adopted lazily by `bindUnboundProjectsToPersonalWorkspace` on any personal-workspace list read — and notably with `createdByWorkspaceMemberId: null`, the *safe* authorship answer. For the team-workspace case, #6185's `resolveProjectWorkspaceScopeForCaller` already resolves an unbound project against the caller's current workspace at read time, which removes the user-visible damage without writing a claim at all. That read fallback becomes reachable once `useProjectWorkspaceScope` sends headers (`fix/identity-scoped-read-caches`).

If a backfill is ever wanted anyway, the only shape I would defend is: run it lazily on the first *authenticated mutation* of each project (which is what `reconcileUnboundProjectBeforeMutation` already is), and extend it to more mutation routes rather than to startup. That keeps "an explicit request naming this project" as the ownership signal.

## What users will see

Nothing new to click. Behavior changes that were previously broken:

- A project created from `od project create`, from the MCP tool, or in the first seconds after a refresh now shows the correct workspace balance/plan in the account menu instead of a blank area, and its Cloud runs are billed to that workspace instead of to nothing.
- The plugin "Publish to GitHub" / "Contribute to Open Design" task project, Orbit run projects, scheduled automation projects, a clipper capture opened as an editable page, a project imported by a project-location scan, and a design system's editing workspace can now take their first chat turn instead of being refused by the workspace gate.
- Signed out is unchanged: creating and using a local project works exactly as before, with no workspace attached.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [x] **Default behavior change** — a project created with no workspace headers now binds to the daemon's signed-in workspace instead of staying unbound. No new endpoint, no new flag, no contract change; existing bound projects are untouched (`ensureWorkspaceProject` is idempotent and never re-homes).
- [ ] **None**

No UI surface is checked, so no screenshots: every change is either daemon-side or a header added to an existing request. No new user-facing control, copy, or layout.

**CLI parity note.** No `od` surface is added here, and none is missing for this fix — `od project create` is *fixed* by the daemon-side binding, without needing a new flag. See "Adjacent issues" for the separate CLI capability.

## Bug fix verification

- **Tests:** `e2e/tests/collab/created-project-binding.test.ts` (daemon HTTP boundary, e2e Vitest — the cheapest layer that sees it) and `apps/daemon/tests/collab/created-project-workspace.test.ts` (the resolver's authority contract). Seeded only through production HTTP APIs: `PUT /api/workspace/context` for the ambient identity and the real vela integration (`VELA_CONTROL_KEY` + `VELA_API_URL` → `GET /api/v1/workspaces`) against a temporary server-level mock. No source-level backdoor.
- **Red on base, green on branch:** yes, twice — once for the binding gap, once for the authority boundary the review caught. Both verified by rebuilding the daemon from the prior source with the *final* test files, not earlier drafts.

Covers: normal create, folder import, plugin-created, explicit-headers-still-win, the signed-out case (must still succeed, may legitimately be `unbound`), and the unverified-claim boundary.

### Red→green 1: the binding gap

**RED** (base source, final test file):

```
 ❯ tests/collab/created-project-binding.test.ts (1 test | 1 failed) 8692ms
     × headerless creates bind to the ambient workspace; signed-out stays unbound and still works

AssertionError: a headerless create must still bind to the workspace the daemon knows it is in: expected 'unbound' not to be 'unbound' // Object.is equality
 ❯ tests/collab/created-project-binding.test.ts:198:17

 Test Files  1 failed (1)
      Tests  1 failed (1)
```

Each source was additionally confirmed **independently** red, so none is masked by an earlier assertion failing first:

```
[probe] source 1 plain create kind = unbound
AssertionError: an imported-folder project is still a project and still needs a home workspace: expected 'unbound' not to be 'unbound'
 ❯ tests/collab/created-project-binding.test.ts:208:17
```

```
[probe] source 2 folder import kind = unbound
AssertionError: a plugin-created project must not be an orphan either: expected 'unbound' not to be 'unbound'
 ❯ tests/collab/created-project-binding.test.ts:222:17
```

**GREEN:** `Test Files 1 passed (1) / Tests 1 passed (1)`.

### Red→green 2: the authority boundary (review follow-up)

`PerishCode` correctly caught that the first version of the resolver **persisted the request's self-asserted identity without an authority check**. Fixed in a47f5921.

`apps/daemon/tests/collab/created-project-workspace.test.ts` — **RED** on the reviewed head:

```
× refuses to persist an asserted workspace the caller has no membership in
× leaves the project unbound when an unverifiable claim has no ambient workspace to fall back to
× treats an unreadable membership authority as CANNOT CONFIRM, not as valid
× degrades an authority that throws outright, rather than propagating
× does not persist a claim the daemon last-known state says was removed

AssertionError: expected 'workspace-foreign' not to be 'workspace-foreign'
 Test Files  1 failed (1)
      Tests  5 failed | 12 passed (17)
```

**GREEN:** `Tests 17 passed (17)`.

HTTP boundary, in `OD_WORKSPACE_CONTEXT_SOURCE=vela` so the membership authority is live — `POST /api/projects/:id/duplicate` asserting a foreign pair. **RED:**

```
× a create asserting a workspace the caller has no membership in does not bind to it
AssertionError: an unverifiable header claim must not be written as a binding:
  expected 'ws-bind-foreign' not to be 'ws-bind-foreign'
 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
```

**GREEN:** `Tests 2 passed (2)`.

The signed-out case passes unchanged, and the pre-existing `e2e/tests/collab/project-workspace-scope.test.ts` still passes — including its BOUNDARY 1, which depends on the local/dev compatibility path being preserved.

## Validation

Node 24.18.0 throughout (Node 22 miscompiles `better-sqlite3`'s ABI).

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/daemon build` — pass, **plus a real `require('dist/server.js')` load** (75 exports resolved). `apps/daemon` typecheck is not cited as evidence: `server.ts` carries `@ts-nocheck`, as do 29 daemon files.
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm --filter @open-design/web test` — **541 files, 5496 passed, 11 skipped, 0 failed**
- `pnpm --filter @open-design/daemon test` — **573 files, 7160 passed, 1 failed** on the review-fix commit; the one failure was `brand-routes.test.ts`'s harness missing the new resolver seam, fixed in a4f2b289 (final run in the comments). Earlier flakes in `connectors-routes.test.ts`, `run-resume-on-failure.test.ts`, and `run-retry-runtime.test.ts` were shown to alternate pass/fail on an unchanged commit — see the baseline comment below.
- `cd e2e && pnpm test tests/collab/created-project-binding.test.ts tests/collab/project-workspace-scope.test.ts` — pass

## Adjacent issues (deliberately not fixed here)

Held out of scope per `AGENTS.md` → "Hold the spec's scope":

1. **`od workspace use <id>` — a persisted CLI workspace selection.** It already exists server-side: `createActiveWorkspaceSelectionStore(RUNTIME_DATA_DIR)` (`server.ts:2767`) persists it across restarts, `PUT /api/workspace/active` (`routes/collab-context.ts:305`) switches it with full validation, and `GET /api/workspace/directory` already reports `activeWorkspaceId`. What is missing is only the CLI verb — `od workspace` has `invite`, `billing`, `members`, `team`, `list`, but no `use`/`current`. A genuine dual-track gap, but a **new capability** (`AGENTS.md` → "Capability exposure"), and *not* needed for this bug: `od project create` is fixed by the ambient binding, because `lastKnown()` already honors that persisted pin.
2. **`reconcileUnboundProjectBeforeMutation` has the same trust shape.** `routes/project/index.ts:2104` claims a genuinely unbound project into `workspaceProjectContextFromRequest(req)`'s workspace and stamps `createdByWorkspaceMemberId: ctx.workspaceMemberId`, all parsed from headers with no authority check — exactly the class `PerishCode` flagged, in a helper that predates this PR. Reachable from `POST /api/projects/:id/duplicate` and `/design-system-copy`. The same `createCreatedProjectWorkspaceResolver` would fix it; deliberately held back rather than widening a security change late in review.
3. **The web client-side wait.** The two ref sites (`App.tsx:2345`, `:2375`) still send no headers during the loading window. The daemon now binds those creates correctly regardless, so the remaining benefit is only that the *caller's own* member id is recorded instead of the ambient one. Fixing it properly means reading a durable cached context, and the durable cache does not exist today: `cachedWorkspaceContext` (`useWorkspaceContext.ts:87`, exposed as `lastResolvedWorkspaceContext()` at `:101`) is **module-scope only — it survives a remount, not a page reload**, and there is no localStorage persistence. `WORKSPACE_CONTEXT_COALESCE_KEY` is a 1s-TTL coalescer, not a cache. That work belongs in `useWorkspaceContext.ts`, which `fix/identity-scoped-read-caches` owns.
