### PR TITLE
fix(#6117): 删除项目时清理残留 run 目录

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [fix] 删除项目时清理 `<RUNTIME_DATA_DIR>/runs/<runId>/` 下归属于该项目的孤立 run 目录,而非仅取消活跃 run。Run service 在 ~30 分钟 TTL 后从内存 map 移除已终止 run,但磁盘上的 `state.json`/`events.jsonl` 超出该窗口仍然残留;此前 delete project 会泄漏该项目所有已结束 run 的目录。新 helper `removeProjectRunDirs(runsDir, projectId)` 在 cancel + removeProjectDir 之后以 best-effort 方式扫描并清理。(#6117)
+- [fix] 删除项目时清理 `<RUNTIME_DATA_DIR>/runs/<runId>/` 下归属于该项目的孤立 run 目录,而非仅取消活跃 run。Run service 在 ~30 分钟 TTL 后从内存 map 移除已终止 run,但磁盘上的 `state.json`/`events.jsonl` 超出该窗口仍然残留;此前 delete project 会泄漏该项目所有已结束 run 的目录。新 helper `removeProjectRunDirs(runsDir, projectId)` 在 cancel + removeProjectDir 之后以 best-effort 方式扫描并清理。`purgeRunsForProject` 现在返回 `{ tombstoned, protectedRunIds }` 结构化结果,`removeProjectRunDirs` 接受可选的 `shouldSkip(runId)` 回调,DELETE handler 通过 `design.runs.isLiveRun(runId)` 跳过仍在内存 map 中的活跃 run,避免在 purge 之后、sweep 之前出现的窗口里被创建的新 run 被误删;修复 PR #6202 @mrcfps 评审指出的第二个 race condition。(#6117, #6202)
 
 ## [0.9.0] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [fix] 删除项目时清理 `<RUNTIME_DATA_DIR>/runs/<runId>/` 下归属于该项目的孤立 run 目录,而非仅取消活跃 run。Run service 在 ~30 分钟 TTL 后从内存 map 移除已终止 run,但磁盘上的 `state.json`/`events.jsonl` 超出该窗口仍然残留;此前 delete project 会泄漏该项目所有已结束 run 的目录。新 helper `removeProjectRunDirs(runsDir, projectId)` 在 cancel + removeProjectDir 之后以 best-effort 方式扫描并清理。(#6117)
+
 ## [0.9.0] - 2026-05-29
 
 🎉 **310 PRs · 88 contributors · 7 days** — Meet the **install-and-create release**. No more API-key scavenger hunts. No more asking teammates to install three different CLIs before their first prompt. **Open Design AMR** is now built into the app: sign in once, pick a model, and start building. Around that zero-config first run, 0.9.0 brings a bigger agent bench, faster model picking, a more discoverable plugin marketplace, richer review workflows, smoother Studio tools, and easier installs across Windows, macOS, and Linux. 🚀

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -1358,11 +1358,23 @@ export async function removeProjectDir(projectsRoot, projectId) {
  *
  * @param {string} runsDir Absolute path to the runtime `runs` directory.
  * @param {string} projectId The project id whose run directories to remove.
+ * @param {{ shouldSkip?: (runId: string) => boolean }} [opts] Optional
+ *   per-entry guard. When `shouldSkip(runId)` returns true, the directory is
+ *   left alone — used to protect runs that legitimately still own their
+ *   on-disk directory at sweep time (e.g. a run created for this project
+ *   during the cancel-await window of a project-delete — its state.json
+ *   references the deleted project, but it's mid-flight and would otherwise
+ *   be wiped out from under itself). See #6202 @mrcfps follow-up.
  * @returns {Promise<number>} Number of run directories removed. Resolves to 0
  *   when `runsDir` does not exist (fresh install, no runs yet).
  */
-export async function removeProjectRunDirs(runsDir, projectId) {
+export async function removeProjectRunDirs(
+  runsDir: string,
+  projectId: string,
+  opts: { shouldSkip?: (runId: string) => boolean } = {},
+): Promise<number> {
   if (!isSafeId(projectId)) return 0;
+  const shouldSkip = opts.shouldSkip;
   let entries: import('node:fs').Dirent[];
   try {
     entries = await readdir(runsDir, { withFileTypes: true });
@@ -1376,6 +1388,13 @@ export async function removeProjectRunDirs(runsDir, projectId) {
       .filter((entry) => entry.isDirectory())
       .map(async (entry) => {
         const runDir = path.join(runsDir, entry.name);
+        const runId = entry.name;
+        // Consult the live-run guard before touching the disk so a
+        // mid-flight run created during a concurrent delete-project can't
+        // have its state.json wiped out from under itself. Should be a
+        // cheap synchronous check (in-memory map lookup); see
+        // `runService.isLiveRun` in runs.ts.
+        if (shouldSkip && shouldSkip(runId)) return;
         try {
           const stateRaw = await readFile(path.join(runDir, 'state.json'), 'utf8');
           const state = JSON.parse(stateRaw);

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -1341,6 +1341,55 @@ export async function removeProjectDir(projectsRoot, projectId) {
   await rm(dir, { recursive: true, force: true });
 }
 
+/**
+ * Remove orphaned per-run directories under `runsDir` that belong to a project
+ * being deleted. The run service holds non-terminal runs in an in-memory map
+ * and drops them once they go terminal + ttl (~30 min), but the on-disk state
+ * `runsDir/<runId>/state.json` outlives that map — so a delete-project that
+ * only cancels live runs leaks every prior run's directory for that project
+ * (#6117).
+ *
+ * Walks `runsDir` one level deep, reads `<runId>/state.json` for each entry,
+ * and recursively removes the entries whose `projectId` matches. `state.json`
+ * may be missing or unreadable (legacy/in-progress run dir); such entries are
+ * skipped to avoid wiping unrelated state. Failures during the walk are
+ * swallowed per-entry so a single bad directory never blocks the project
+ * delete the user asked for — same best-effort posture as `removeProjectDir`.
+ *
+ * @param {string} runsDir Absolute path to the runtime `runs` directory.
+ * @param {string} projectId The project id whose run directories to remove.
+ * @returns {Promise<number>} Number of run directories removed. Resolves to 0
+ *   when `runsDir` does not exist (fresh install, no runs yet).
+ */
+export async function removeProjectRunDirs(runsDir, projectId) {
+  if (!isSafeId(projectId)) return 0;
+  let entries: import('node:fs').Dirent[];
+  try {
+    entries = await readdir(runsDir, { withFileTypes: true });
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') return 0;
+    throw err;
+  }
+  let removed = 0;
+  await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory())
+      .map(async (entry) => {
+        const runDir = path.join(runsDir, entry.name);
+        try {
+          const stateRaw = await readFile(path.join(runDir, 'state.json'), 'utf8');
+          const state = JSON.parse(stateRaw);
+          if (state?.projectId !== projectId) return;
+          await rm(runDir, { recursive: true, force: true });
+          removed += 1;
+        } catch {
+          // state.json missing, unreadable, or malformed — leave the dir alone.
+        }
+      }),
+  );
+  return removed;
+}
+
 function resolveSafe(dir, name) {
   const safePath = validateProjectPath(name);
   const target = path.resolve(dir, safePath);

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -43,7 +43,7 @@ import {
 import { connectorService } from '../../connectors/service.js';
 import type { RouteDeps } from '../../server-context.js';
 import { listSkills } from '../../skills.js';
-import { isSafeId } from '../../projects.js';
+import { isSafeId, removeProjectRunDirs } from '../../projects.js';
 import {
   BUILT_IN_PROJECT_LOCATION_ID,
   allProjectLocations,
@@ -2277,6 +2277,13 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       await cancelRunsOwnedBy(design.runs, { projectId: req.params.id });
       dbDeleteProject(db, req.params.id);
       await removeProjectDir(PROJECTS_DIR, req.params.id).catch(() => {});
+      // The run service keeps non-terminal runs in memory and drops them
+      // after a ~30 min TTL, but `<RUNTIME_DATA_DIR>/runs/<runId>/state.json`
+      // outlives that map. Sweep the runs dir for orphaned entries whose
+      // state.json still references this project so delete doesn't leak
+      // every prior run's directory (#6117). Best-effort — same posture as
+      // removeProjectDir above.
+      await removeProjectRunDirs(path.join(ctx.paths.RUNTIME_DATA_DIR, 'runs'), req.params.id).catch(() => {});
       /** @type {import('@open-design/contracts').OkResponse} */
       const body = { ok: true };
       res.json(body);

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -2271,18 +2271,22 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
 
   app.delete('/api/projects/:id', async (req, res) => {
     try {
-      // Stop any live agent run in this project before its row and directory
-      // are removed, otherwise the CLI subprocess is orphaned — it keeps
-      // billing and writes into a directory that no longer exists (#5468).
-      await cancelRunsOwnedBy(design.runs, { projectId: req.params.id });
+      // Tombstone + cancel every run owned by this project *before* the on-disk
+      // sweep, so async terminal telemetry callbacks (markAnalyticsCompleted /
+      // markLangfuseCompleted via persistState -> atomicWriteJson) cannot
+      // recreate the run dir after we delete it. atomicWriteJson mkdirs the
+      // parent dir, so without the tombstone any run whose project was deleted
+      // while it was still alive would leak its dir back onto disk the moment
+      // the analytics/langfuse completion resolved (#6117 race @mrcfps on #6202).
+      // Also cancels live runs (#5468 supersedes the bare cancelRunsOwnedBy).
+      await design.runs.purgeRunsForProject(req.params.id).catch(() => {});
       dbDeleteProject(db, req.params.id);
       await removeProjectDir(PROJECTS_DIR, req.params.id).catch(() => {});
-      // The run service keeps non-terminal runs in memory and drops them
-      // after a ~30 min TTL, but `<RUNTIME_DATA_DIR>/runs/<runId>/state.json`
-      // outlives that map. Sweep the runs dir for orphaned entries whose
-      // state.json still references this project so delete doesn't leak
-      // every prior run's directory (#6117). Best-effort — same posture as
-      // removeProjectDir above.
+      // Backstop: sweep any on-disk run dir whose state.json still references
+      // this project. purgeRunsForProject handles runs known to the in-memory
+      // map; this catches runs whose TTL has already expired out of the map
+      // (their state.json lingers on disk until now). Best-effort — same
+      // posture as removeProjectDir above.
       await removeProjectRunDirs(path.join(ctx.paths.RUNTIME_DATA_DIR, 'runs'), req.params.id).catch(() => {});
       /** @type {import('@open-design/contracts').OkResponse} */
       const body = { ok: true };

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -2279,6 +2279,13 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       // while it was still alive would leak its dir back onto disk the moment
       // the analytics/langfuse completion resolved (#6117 race @mrcfps on #6202).
       // Also cancels live runs (#5468 supersedes the bare cancelRunsOwnedBy).
+      // The returned `protectedRunIds` are runs that entered the in-memory
+      // registry during the cancellation await — their state.json still
+      // references this project but the runs are mid-flight and must be left
+      // alone. The `isLiveRun` guard re-checks the in-memory map at sweep
+      // time so even later concurrent creates (after `purgeRunsForProject`
+      // returns but before `removeProjectRunDirs` runs) are protected
+      // (#6202 @mrcfps non-blocking follow-up).
       await design.runs.purgeRunsForProject(req.params.id).catch(() => {});
       dbDeleteProject(db, req.params.id);
       await removeProjectDir(PROJECTS_DIR, req.params.id).catch(() => {});
@@ -2287,7 +2294,11 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       // map; this catches runs whose TTL has already expired out of the map
       // (their state.json lingers on disk until now). Best-effort — same
       // posture as removeProjectDir above.
-      await removeProjectRunDirs(path.join(ctx.paths.RUNTIME_DATA_DIR, 'runs'), req.params.id).catch(() => {});
+      await removeProjectRunDirs(
+        path.join(ctx.paths.RUNTIME_DATA_DIR, 'runs'),
+        req.params.id,
+        { shouldSkip: (runId) => design.runs.isLiveRun(runId) },
+      ).catch(() => {});
       /** @type {import('@open-design/contracts').OkResponse} */
       const body = { ok: true };
       res.json(body);

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -155,26 +155,43 @@ function readDurableRunEvents(eventsLogPath) {
   }
 }
 
+// Explicit options type so importing test files (typed under
+// `tsconfig.tests.json`) do not have to rely on TypeScript inferring the
+// `@ts-nocheck`-guarded destructured defaults. Without this surface the
+// defaulted `runsLogDir = null` infers as `null | undefined` only, and a
+// test passing an absolute `string` path widens to TS2322. Keep the
+// runtime behaviour unchanged — defaults still match the destructure
+// above — but type `runsLogDir` as `string | null` so call-sites can
+// supply either shape.
+export interface ChatRunServiceOptions {
+  createSseResponse: (res: unknown, init?: unknown) => unknown;
+  createSseErrorPayload: (code: string, message: string, init?: unknown) => unknown;
+  maxEvents?: number;
+  ttlMs?: number;
+  shutdownGraceMs?: number;
+  /** Absolute directory under which per-run event JSONL logs are written
+   * (one file per run at `<runsLogDir>/<runId>/events.jsonl`). When null,
+   * event persistence is disabled and `statusBody.eventsLogPath = null` —
+   * legacy behavior. The path is surfaced through MCP get_run so an
+   * external coding agent can tail the file in its own shell during a long
+   * OD generation, instead of polling blindly and giving up. */
+  runsLogDir?: string | null;
+  /** Optional observer invoked for every emitted event BEFORE the in-memory
+   * ring buffer is truncated. The daemon uses it to fold committed side
+   * effects (tool calls, artifact writes) into a per-run accumulator that
+   * outlives buffer truncation. */
+  onEventEmitted?: ((run: unknown, record: unknown) => void) | null;
+}
+
 export function createChatRunService({
   createSseResponse,
   createSseErrorPayload,
   maxEvents = 2_000,
   ttlMs = 30 * 60 * 1000,
   shutdownGraceMs = 3_000,
-  // Absolute directory under which per-run event JSONL logs are written
-  // (one file per run at <runsLogDir>/<runId>/events.jsonl). When null,
-  // event persistence is disabled and statusBody.eventsLogPath = null —
-  // legacy behavior. The path is surfaced through MCP get_run so an
-  // external coding agent can `tail` the file in its own shell during
-  // a long OD generation, instead of polling blindly and giving up.
   runsLogDir = null,
-  // Optional observer invoked for every emitted event BEFORE the in-memory
-  // ring buffer is truncated. The daemon uses it to fold committed side
-  // effects (tool calls, artifact writes) into a per-run accumulator that
-  // outlives buffer truncation. Kept generic here: this service does not
-  // interpret event semantics, it just hands each record to the observer.
   onEventEmitted = null,
-}) {
+}: ChatRunServiceOptions) {
   const runs = new Map();
   const runIdsByClientRequestId = new Map();
   const runIdsByPluginWorkflowId = new Map();

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -1076,14 +1076,23 @@ export function createChatRunService({
    *     child is reaped) — terminal runs are left alone status-wise, only
    *     tombstoned on disk.
    *
-   * Returns the list of run ids that were tombstoned, so the caller can
-   * additionally remove their on-disk run directories after this resolves.
+   * Returns `{ tombstoned, protectedRunIds }`:
+   *   - `tombstoned` lists the run ids that were tombstoned (already disabled
+   *     and cancel-awaited) so the caller can additionally remove their
+   *     on-disk run directories after this resolves.
+   *   - `protectedRunIds` lists runs that *entered the in-memory registry
+   *     after the initial snapshot* — i.e. were created for this project
+   *     during the await-cancellation window. These are live runs the sweep
+   *     must NOT delete (their state.json still references the deleted
+   *     project, but the run is mid-flight and owns that dir legitimately).
+   *     See #6202 @mrcfps non-blocking follow-up.
+   *
    * Cancellation failures are swallowed per-run so a single bad run never
    * blocks the project delete the user asked for — same posture as
    * `cancelRunsOwnedBy` for #5468.
    */
   const purgeRunsForProject = async (projectId) => {
-    if (typeof projectId !== 'string' || !projectId) return [];
+    if (typeof projectId !== 'string' || !projectId) return { tombstoned: [], protectedRunIds: [] };
     const owned = Array.from(runs.values()).filter((run) => run.projectId === projectId);
     const tombstoned = [];
     // Order matters (#6117 race): disablePersist MUST run before cancel,
@@ -1101,7 +1110,33 @@ export function createChatRunService({
         }
       }),
     );
-    return tombstoned;
+    // Re-snapshot after the await window. A run created for this project
+    // during the cancellation await is *not* in `owned` and therefore not
+    // tombstoned above; its state.json still references the soon-to-be
+    // deleted project, so the on-disk sweep would otherwise remove it
+    // mid-flight. Track it as protected so the caller can skip its dir.
+    // (Live runs whose project is gone will eventually go terminal + TTL out
+    // of the in-memory map; the next delete-project call's sweep will catch
+    // their then-orphaned state.json. That's the same backstop posture
+    // already used for runs that TTL-expire out before delete-project.)
+    const protectedRunIds = Array.from(runs.values())
+      .filter((run) => run.projectId === projectId && !run.persistsDisabled)
+      .map((run) => run.id);
+    return { tombstoned, protectedRunIds };
+  };
+
+  /**
+   * Live-run guard for the on-disk sweep. Returns true if `runId` is currently
+   * registered in the in-memory run map AND has not been tombstoned (i.e. its
+   * `persistsDisabled` flag is still false). Callers that walk `runsDir` to
+   * remove orphaned run directories use this to skip directories owned by runs
+   * that legitimately still own them — e.g. a run created for the project
+   * during the cancel-await window of a project-delete (#6202 @mrcfps follow-up).
+   */
+  const isLiveRun = (runId) => {
+    if (typeof runId !== 'string' || !runId) return false;
+    const run = runs.get(runId);
+    return !!run && !run.persistsDisabled;
   };
 
   // Drop a run from the in-memory registry without emitting any terminal
@@ -1175,6 +1210,7 @@ export function createChatRunService({
     fail,
     drop,
     purgeRunsForProject,
+    isLiveRun,
     signalChild: killChild,
     reapProcessGroup,
     signalProcessGroup,

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -444,7 +444,37 @@ export function createChatRunService({
   };
 
   const persistState = (run) => {
+    // Once a run has been swept as part of a project delete (or explicitly
+    // tombstoned), its on-disk state must never be recreated — even by a
+    // terminal telemetry callback (markAnalyticsCompleted/markLangfuseCompleted)
+    // that resolves after the sweep deleted <runDir>/state.json. atomicWriteJson
+    // mkdirs the parent dir, so without this guard any run whose project was
+    // deleted while it was still alive would leak its dir back onto disk the
+    // moment the analytics/langfuse completion resolved (#6117 regression).
+    if (run?.persistsDisabled) return;
     if (run?.statePath) atomicWriteJson(run.statePath, durableRunState(run));
+  };
+
+  /**
+   * Disable further durable state writes for a run and unlink its on-disk
+   * artifacts if present. Used by project-delete to tombstone every run owned
+   * by the deleted project before the on-disk sweep runs, so the async
+   * terminal telemetry callbacks that resolve *after* the sweep can't
+   * recreate the directory (#6117).
+   *
+   * Removes the run's per-run directory (`<runsLogDir>/<runId>/`) entirely
+   * — `state.json`, `events.jsonl`, and any siblings — so callers scanning
+   * the runs dir for stragglers don't double-process this run. Safe to call
+   * on a live or terminal run. Idempotent. Does not touch the in-memory run
+   * record beyond flipping the flag.
+   */
+  const disablePersist = (run) => {
+    if (!run) return;
+    run.persistsDisabled = true;
+    if (run.statePath) {
+      const runDir = path.dirname(run.statePath);
+      try { fs.rmSync(runDir, { recursive: true, force: true }); } catch { /* best-effort */ }
+    }
   };
 
   const setAnalyticsRecovery = (run, recovery) => {
@@ -570,6 +600,12 @@ export function createChatRunService({
     // memory + SSE clients below; we just stop persisting them to the closed
     // log. (#3408 P1 FD-leak fix; cf. #4163.)
     if (run.eventsLogClosed) return null;
+    // Tombstoned runs (#6117): the project was deleted out from under us,
+    // and the run's on-disk dir has already been removed by disablePersist.
+    // Reopening the log stream here would mkdir the directory back — the
+    // exact leak the tombstone prevents. Treat like eventsLogClosed: late
+    // events still reach memory + SSE clients, just don't hit disk.
+    if (run.persistsDisabled) return null;
     try {
       fs.mkdirSync(path.dirname(run.eventsLogPath), { recursive: true });
       run.eventsLogStream = fs.createWriteStream(run.eventsLogPath, { flags: 'a' });
@@ -1010,6 +1046,47 @@ export function createChatRunService({
     return new Promise((resolve) => run.waiters.add(resolve));
   };
 
+  /**
+   * Tombstone every run owned by a project so the on-disk state for those
+   * runs cannot be recreated by an async terminal telemetry callback that
+   * resolves *after* the project delete handler has already swept the runs
+   * dir (#6117 race condition surfaced by @mrcfps on PR #6202).
+   *
+   * For every run whose projectId matches:
+   *   - flip `run.persistsDisabled = true` so `persistState` becomes a no-op;
+   *   - unlink the run's current state.json / events.jsonl if present;
+   *   - if the run is still active, cancel it (so its waiters resolve and the
+   *     child is reaped) — terminal runs are left alone status-wise, only
+   *     tombstoned on disk.
+   *
+   * Returns the list of run ids that were tombstoned, so the caller can
+   * additionally remove their on-disk run directories after this resolves.
+   * Cancellation failures are swallowed per-run so a single bad run never
+   * blocks the project delete the user asked for — same posture as
+   * `cancelRunsOwnedBy` for #5468.
+   */
+  const purgeRunsForProject = async (projectId) => {
+    if (typeof projectId !== 'string' || !projectId) return [];
+    const owned = Array.from(runs.values()).filter((run) => run.projectId === projectId);
+    const tombstoned = [];
+    // Order matters (#6117 race): disablePersist MUST run before cancel,
+    // because cancel -> finish -> emit('end') -> persistState -> atomicWriteJson
+    // mkdirs the runDir we just removed. With persistsDisabled flipped first,
+    // the late persistState is a no-op and the directory stays gone. disablePersist
+    // also synchronously rm -rf's the run dir, so a delayed markAnalyticsCompleted /
+    // markLangfuseCompleted callback resolving after this cannot recreate it either.
+    await Promise.all(
+      owned.map(async (run) => {
+        disablePersist(run);
+        tombstoned.push(run.id);
+        if (!TERMINAL_RUN_STATUSES.has(run.status)) {
+          try { await cancel(run); } catch { /* best-effort, like cancelRunsOwnedBy */ }
+        }
+      }),
+    );
+    return tombstoned;
+  };
+
   // Drop a run from the in-memory registry without emitting any terminal
   // event. Used by callers that prepared a run optimistically (created the
   // record before some external precondition was checked) and need to undo
@@ -1072,6 +1149,7 @@ export function createChatRunService({
     wait,
     emit,
     persistState,
+    disablePersist,
     setAnalyticsRecovery,
     markAnalyticsCompleted,
     markLangfuseCompleted,
@@ -1079,6 +1157,7 @@ export function createChatRunService({
     finish,
     fail,
     drop,
+    purgeRunsForProject,
     signalChild: killChild,
     reapProcessGroup,
     signalProcessGroup,

--- a/apps/daemon/tests/delete-sweeps-orphaned-run-dirs.test.ts
+++ b/apps/daemon/tests/delete-sweeps-orphaned-run-dirs.test.ts
@@ -225,4 +225,56 @@ describe('DELETE project sweeps orphaned run dirs (#6117)', () => {
     }
     expect(getProject(db, 'p1')).toBeNull();
   });
+
+  it('does not let a delayed terminal telemetry callback recreate the swept run dir (#6117 race)', async () => {
+    // Reproduces the race @mrcfps called out on PR #6202:
+    //   1. A live run is created with a real on-disk state.json path.
+    //   2. The handler cancels+tombstones it (purgeRunsForProject) and sweeps
+    //      its run dir.
+    //   3. After the sweep, a delayed terminal telemetry callback fires
+    //      `markAnalyticsCompleted(run)` — which previously called persistState
+    //      -> atomicWriteJson -> mkdir parent + write state.json, recreating
+    //      exactly the orphaned dir this PR promises to eliminate.
+    // After the fix, persistState is a no-op on tombstoned runs.
+    const runsDir = path.join(tempDir, 'runs');
+    mkdirSync(runsDir, { recursive: true });
+    const runs = createChatRunService({
+      createSseResponse: () => ({ send: vi.fn(() => true), end: vi.fn(), cleanup: vi.fn() }),
+      createSseErrorPayload: (code: string, message: string) => ({ error: { code, message } }),
+      shutdownGraceMs: 10,
+      ttlMs: 60_000,
+      runsLogDir: runsDir,
+    });
+
+    const run = runs.create({ projectId: 'p1', conversationId: null });
+    // Simulate analytics recovery so markAnalyticsCompleted has work to do.
+    runs.setAnalyticsRecovery?.(run, {
+      context: { page_name: 'test' },
+      properties: { a: 1 },
+      insertId: 'test-insert',
+    });
+    const runDir = path.join(runsDir, run.id);
+    // Service should have written state.json on create.
+    expect(existsSync(path.join(runDir, 'state.json'))).toBe(true);
+
+    const app = await mountProjectApp(db, runs, tempDir);
+    try {
+      const res = await fetch(`${app.base}/api/projects/p1`, { method: 'DELETE' });
+      expect(res.status).toBe(200);
+    } finally {
+      await app.close();
+    }
+
+    // Sweep has happened: dir is gone.
+    expect(existsSync(runDir)).toBe(false);
+
+    // Now release the delayed telemetry callback. Before the tombstone fix
+    // this would mkdir the runDir back and write a fresh state.json — the
+    // exact regression #6117 describes.
+    runs.markAnalyticsCompleted?.(run);
+    runs.markLangfuseCompleted?.(run);
+    runs.persistState?.(run);
+
+    expect(existsSync(runDir)).toBe(false);
+  });
 });

--- a/apps/daemon/tests/delete-sweeps-orphaned-run-dirs.test.ts
+++ b/apps/daemon/tests/delete-sweeps-orphaned-run-dirs.test.ts
@@ -246,7 +246,7 @@ describe('DELETE project sweeps orphaned run dirs (#6117)', () => {
       runsLogDir: runsDir,
     });
 
-    const run = runs.create({ projectId: 'p1', conversationId: null });
+    const run = runs.create({ projectId: 'p1' });
     // Simulate analytics recovery so markAnalyticsCompleted has work to do.
     runs.setAnalyticsRecovery?.(run, {
       context: { page_name: 'test' },

--- a/apps/daemon/tests/delete-sweeps-orphaned-run-dirs.test.ts
+++ b/apps/daemon/tests/delete-sweeps-orphaned-run-dirs.test.ts
@@ -277,4 +277,119 @@ describe('DELETE project sweeps orphaned run dirs (#6117)', () => {
 
     expect(existsSync(runDir)).toBe(false);
   });
+
+  it('does not sweep a run dir for a run still live in the in-memory map (#6202 @mrcfps follow-up)', async () => {
+    // Reproduces the second race @mrcfps flagged on PR #6202 (non-blocking
+    // follow-up): purgeRunsForProject snapshots the in-memory runs once, then
+    // awaits per-run cancellations. A run that is created for the same project
+    // during that await window is NOT in the snapshot, so it is not tombstoned;
+    // its state.json still references the soon-to-be-deleted project. If the
+    // on-disk sweep (removeProjectRunDirs) only filters by `state.projectId`,
+    // it wipes the new run's dir out from under itself — the run keeps running
+    // but its state file is gone, and any later persistState mkdirs the dir
+    // back, recreating the orphan we just swept.
+    //
+    // After the fix:
+    //   - removeProjectRunDirs takes a `shouldSkip(runId)` callback that
+    //     consults the in-memory run map.
+    //   - The DELETE handler passes `(runId) => design.runs.isLiveRun(runId)`.
+    //   - A run that is currently in the in-memory map AND not tombstoned is
+    //     left alone even if its state.json projectId matches the sweep target.
+    //
+    // This test exercises the sweep with a controlled shouldSkip that mirrors
+    // the production wiring (isLiveRun) and asserts the live run's dir survives
+    // the sweep even though its state.json projectId matches the sweep target.
+    const runsDir = path.join(tempDir, 'runs');
+    mkdirSync(runsDir, { recursive: true });
+    const runs = createChatRunService({
+      createSseResponse: () => ({ send: vi.fn(() => true), end: vi.fn(), cleanup: vi.fn() }),
+      createSseErrorPayload: (code: string, message: string) => ({ error: { code, message } }),
+      shutdownGraceMs: 10,
+      ttlMs: 60_000,
+      runsLogDir: runsDir,
+    });
+
+    // Seed one orphaned run dir that DOES belong to p1 and is NOT in the
+    // in-memory map (simulates a TTL-expired prior run). The sweep should
+    // catch this one.
+    const orphanRunId = 'orphan-' + Math.random().toString(36).slice(2);
+    const orphanDir = path.join(runsDir, orphanRunId);
+    mkdirSync(orphanDir, { recursive: true });
+    writeFileSync(path.join(orphanDir, 'state.json'), JSON.stringify({ projectId: 'p1' }));
+
+    // And create a live run for p1 that IS in the in-memory map. The sweep
+    // must skip its directory because the production shouldSkip guard
+    // (design.runs.isLiveRun) returns true for it.
+    const liveRun = runs.create({ projectId: 'p1' });
+    const liveRunDir = path.join(runsDir, liveRun.id);
+    expect(existsSync(path.join(liveRunDir, 'state.json'))).toBe(true);
+
+    // Mount and DELETE the project. The DELETE handler will:
+    //   1. purgeRunsForProject('p1') — tombstones liveRun (it is in the
+    //      snapshot, because we created it before the request). liveRun is
+    //      now persistsDisabled=true and its dir is removed by disablePersist.
+    //   2. removeProjectRunDirs with shouldSkip = (id) => isLiveRun(id).
+    //      liveRun is no longer "live" (persistsDisabled=true), so its dir
+    //      isn't expected to survive — but we want to verify the production
+    //      path end-to-end against a "truly live" run.
+    //
+    // To exercise the race scenario end-to-end (a run created DURING the
+    // cancel await window, which is NOT in the snapshot), we mount the app
+    // but hold the DELETE back: we pre-await a manual `purgeRunsForProject`
+    // that tombstones liveRun, then create a second live run that is NOT
+    // tombstoned, then invoke the on-disk sweep directly with the production
+    // shouldSkip guard.
+    //
+    // Step 1: tombstone the first liveRun via purgeRunsForProject.
+    const firstPurge = await runs.purgeRunsForProject('p1');
+    expect(firstPurge.tombstoned).toEqual(expect.arrayContaining([liveRun.id]));
+    expect(existsSync(liveRunDir)).toBe(false);
+    expect(runs.isLiveRun(liveRun.id)).toBe(false);
+
+    // Step 2: create a new run for p1 — this one is "mid-flight" relative to
+    // the original DELETE, i.e. not in any snapshot yet. Its state.json
+    // projectId matches p1.
+    const lateRun = runs.create({ projectId: 'p1' });
+    const lateRunDir = path.join(runsDir, lateRun.id);
+    expect(existsSync(path.join(lateRunDir, 'state.json'))).toBe(true);
+    expect(runs.isLiveRun(lateRun.id)).toBe(true);
+
+    // Also re-seed an orphan dir with state.json projectId=p1 (the sweep's
+    // primary target).
+    const orphan2Dir = path.join(runsDir, 'orphan2-' + Math.random().toString(36).slice(2));
+    mkdirSync(orphan2Dir, { recursive: true });
+    writeFileSync(path.join(orphan2Dir, 'state.json'), JSON.stringify({ projectId: 'p1' }));
+
+    // Step 3: invoke the on-disk sweep with the production shouldSkip guard,
+    // exactly as the DELETE handler does.
+    const { removeProjectRunDirs } = await import('../src/projects.js');
+    const removed = await removeProjectRunDirs(runsDir, 'p1', {
+      shouldSkip: (runId) => runs.isLiveRun(runId),
+    });
+    // The orphan dirs (no in-memory run) are swept.
+    expect(removed).toBe(2);
+    expect(existsSync(orphanDir)).toBe(false);
+    expect(existsSync(orphan2Dir)).toBe(false);
+    // The late run's dir is untouched — the shouldSkip guard caught it.
+    expect(existsSync(lateRunDir)).toBe(true);
+    expect(existsSync(path.join(lateRunDir, 'state.json'))).toBe(true);
+
+    // The new helper is exposed for callers that want to query the live-run
+    // state directly (e.g. future sweep callers).
+    expect(runs.isLiveRun(lateRun.id)).toBe(true);
+    expect(runs.isLiveRun('orphanRunId-not-in-map')).toBe(false);
+    expect(runs.isLiveRun('')).toBe(false);
+
+    // And purgeRunsForProject now returns a structured result so callers can
+    // destructure safely instead of treating the return as a bare array.
+    const result = await runs.purgeRunsForProject('p1');
+    expect(result).toEqual({ tombstoned: expect.arrayContaining([lateRun.id]), protectedRunIds: [] });
+    expect(existsSync(lateRunDir)).toBe(false);
+    expect(runs.isLiveRun(lateRun.id)).toBe(false);
+
+    // Empty/invalid project id is a no-op and returns the empty structured
+    // shape (not a bare array, so callers can destructure safely).
+    await expect(runs.purgeRunsForProject('')).resolves.toEqual({ tombstoned: [], protectedRunIds: [] });
+    await expect(runs.purgeRunsForProject(undefined as unknown as string)).resolves.toEqual({ tombstoned: [], protectedRunIds: [] });
+  });
 });

--- a/apps/daemon/tests/delete-sweeps-orphaned-run-dirs.test.ts
+++ b/apps/daemon/tests/delete-sweeps-orphaned-run-dirs.test.ts
@@ -1,0 +1,228 @@
+// Regression for #6117: deleting a project must also sweep the on-disk run
+// directories that belong to it. The run service holds non-terminal runs in
+// an in-memory map and drops them after a ~30 min TTL, but
+// `<RUNTIME_DATA_DIR>/runs/<runId>/state.json` outlives that map. Before the
+// fix, DELETE /api/projects/:id only canceled the live runs and removed the
+// project row + project dir, leaking every prior run's directory for that
+// project on disk forever.
+//
+// This exercises the real HTTP boundary against a real runs dir layout:
+// before delete, two orphaned run dirs exist on disk (one for the project
+// being deleted, one for a bystander). After delete only the bystander
+// remains.
+
+import express from 'express';
+import type { Response } from 'express';
+import type { AddressInfo } from 'node:net';
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  closeDatabase,
+  deleteProject as dbDeleteProject,
+  getProject,
+  insertProject,
+  openDatabase,
+  updateProject,
+} from '../src/db.js';
+import { createChatRunService } from '../src/runtimes/runs.js';
+import {
+  registerProjectRoutes,
+  type RegisterProjectRoutesDeps,
+} from '../src/routes/project/index.js';
+
+type Db = ReturnType<typeof openDatabase>;
+
+function makeRunService() {
+  return createChatRunService({
+    createSseResponse: () => ({ send: vi.fn(() => true), end: vi.fn(), cleanup: vi.fn() }),
+    createSseErrorPayload: (code: string, message: string) => ({ error: { code, message } }),
+    shutdownGraceMs: 10,
+    ttlMs: 60_000,
+  });
+}
+
+async function mountProjectApp(
+  db: Db,
+  runs: ReturnType<typeof createChatRunService>,
+  tempDir: string,
+) {
+  const app = express();
+  app.use(express.json());
+  const noop = vi.fn();
+  registerProjectRoutes(app, {
+    db,
+    design: { runs },
+    http: {
+      sendApiError: (res: Response, status: number, code: string, message: string) =>
+        res.status(status).json({ error: { code, message } }),
+      createSseResponse: () => ({ send: vi.fn(() => true), end: vi.fn(), cleanup: vi.fn() }),
+    },
+    paths: {
+      BRANDS_DIR: tempDir,
+      DESIGN_SYSTEMS_DIR: tempDir,
+      PROJECTS_DIR: tempDir,
+      RUNTIME_DATA_DIR: tempDir,
+      RUNTIME_DATA_DIR_CANONICAL: tempDir,
+      SKILLS_DIR: tempDir,
+      USER_DESIGN_SYSTEMS_DIR: tempDir,
+    },
+    projectStore: {
+      insertProject,
+      getProject,
+      updateProject,
+      dbDeleteProject,
+      removeProjectDir: vi.fn(async () => {}),
+      validateLinkedDirs: vi.fn(() => ({ dirs: [], error: null })),
+    },
+    projectFiles: {
+      ensureProject: noop,
+      listFiles: noop,
+      listTabs: vi.fn(() => ({ tabs: [] })),
+      setTabs: noop,
+      readProjectFile: noop,
+      writeProjectFile: noop,
+      resolveProjectDir: (_projectsRoot: string, projectId: string) =>
+        path.join(tempDir, projectId),
+    },
+    conversations: {
+      insertConversation: noop,
+      getConversation: noop,
+      listConversations: vi.fn(() => []),
+      updateConversation: noop,
+      deleteConversation: noop,
+      listMessages: vi.fn(() => []),
+      upsertMessage: noop,
+    },
+    templates: {
+      getTemplate: noop,
+      listTemplates: vi.fn(() => []),
+      deleteTemplate: noop,
+      insertTemplate: noop,
+      findTemplateByNameAndProject: noop,
+      updateTemplate: noop,
+    },
+    status: {
+      listLatestProjectRunStatuses: vi.fn(() => []),
+      listProjectsAwaitingInput: vi.fn(() => new Set()),
+      normalizeProjectDisplayStatus: noop,
+      composeProjectDisplayStatus: noop,
+      listProjects: vi.fn(() => []),
+    },
+    events: {
+      subscribeFileEvents: noop,
+      activeProjectEventSinks: new Map(),
+    },
+    ids: { randomId: () => 'rid-' + Math.random().toString(36).slice(2) },
+    telemetry: {},
+    appConfig: {
+      readAppConfig: async () => ({}),
+      writeAppConfig: noop,
+    },
+    agents: { getAgentDef: () => null },
+    validation: {
+      validateProjectDesignSystemId: noop,
+      validateProjectSkillId: noop,
+    },
+  } as unknown as RegisterProjectRoutesDeps);
+
+  const server = app.listen(0, '127.0.0.1');
+  await new Promise<void>((resolve) => server.once('listening', () => resolve()));
+  const base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  return {
+    base,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+function writeRunState(runsDir: string, runId: string, projectId: string) {
+  const runDir = path.join(runsDir, runId);
+  mkdirSync(runDir, { recursive: true });
+  writeFileSync(
+    path.join(runDir, 'state.json'),
+    JSON.stringify({ id: runId, projectId, status: 'succeeded' }),
+  );
+  return runDir;
+}
+
+describe('DELETE project sweeps orphaned run dirs (#6117)', () => {
+  let tempDir: string;
+  let db: Db;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), 'od-6117-'));
+    db = openDatabase(tempDir, { dataDir: tempDir });
+    const now = Date.now();
+    insertProject(db, { id: 'p1', name: 'Project 1', createdAt: now, updatedAt: now });
+    insertProject(db, { id: 'p2', name: 'Project 2', createdAt: now, updatedAt: now });
+  });
+
+  afterEach(() => {
+    closeDatabase();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('removes on-disk run directories whose state.json belongs to the deleted project', async () => {
+    const runsDir = path.join(tempDir, 'runs');
+    mkdirSync(runsDir, { recursive: true });
+    const doomedRunDir = writeRunState(runsDir, 'r-doomed', 'p1');
+    const bystanderRunDir = writeRunState(runsDir, 'r-bystander', 'p2');
+
+    const runs = makeRunService();
+    const app = await mountProjectApp(db, runs, tempDir);
+    try {
+      const res = await fetch(`${app.base}/api/projects/p1`, { method: 'DELETE' });
+      expect(res.status).toBe(200);
+    } finally {
+      await app.close();
+    }
+
+    expect(getProject(db, 'p1')).toBeNull();
+    // Orphaned dir for p1 has been swept.
+    expect(existsSync(doomedRunDir)).toBe(false);
+    // Bystander dir for p2 is untouched.
+    expect(existsSync(bystanderRunDir)).toBe(true);
+    expect(readdirSync(bystanderRunDir, { withFileTypes: true }).map((e) => e.name)).toEqual([
+      'state.json',
+    ]);
+  });
+
+  it('leaves run dirs with missing state.json in place', async () => {
+    const runsDir = path.join(tempDir, 'runs');
+    mkdirSync(runsDir, { recursive: true });
+    const legacyRunDir = path.join(runsDir, 'r-legacy');
+    mkdirSync(legacyRunDir, { recursive: true });
+    writeFileSync(path.join(legacyRunDir, 'events.jsonl'), '{"x":1}\n');
+
+    const runs = makeRunService();
+    const app = await mountProjectApp(db, runs, tempDir);
+    try {
+      const res = await fetch(`${app.base}/api/projects/p1`, { method: 'DELETE' });
+      expect(res.status).toBe(200);
+    } finally {
+      await app.close();
+    }
+
+    // No state.json -> we cannot prove ownership, so the dir stays.
+    expect(readdirSync(legacyRunDir, { withFileTypes: true }).map((e) => e.name)).toEqual([
+      'events.jsonl',
+    ]);
+  });
+
+  it('is a no-op when the runs dir does not exist yet', async () => {
+    // Fresh install with no runs at all — the runs dir is absent. The delete
+    // handler must not blow up just because removeProjectRunDirs has nothing
+    // to walk.
+    const runs = makeRunService();
+    const app = await mountProjectApp(db, runs, tempDir);
+    try {
+      const res = await fetch(`${app.base}/api/projects/p1`, { method: 'DELETE' });
+      expect(res.status).toBe(200);
+    } finally {
+      await app.close();
+    }
+    expect(getProject(db, 'p1')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

issue #6117 报告:删除项目后,该项目下过往所有已结束 run 的目录仍然残留在磁盘的 `.od/runs/<runId>/` 下,从未被清理。

根因:Run service 只在内存里持有非终止 run,run 进入终止状态后约 30 分钟 TTL 才从内存 map 移除。但磁盘上的 `runsDir/<runId>/state.json` + `events.jsonl` 完全超出该窗口,delete-project handler 只做两件事:

1. cancelRunsOwnedBy 取消活跃 run
2. dbDeleteProject + removeProjectDir 删项目行 + 项目目录

—— 所有已结束 run 的目录就永远漏在 disk 上。

## What users will see

删除项目后 `.od/runs/` 下属于该项目的所有 run 子目录(含 `state.json`、`events.jsonl` 及其余副产物)被一并清扫,不再长期占用磁盘。其他项目的 run 目录、以及没有 `state.json` 的 legacy 目录保持不动。

## Surface area

- `apps/daemon/src/projects.ts`:新增 export `removeProjectRunDirs(runsDir, projectId)`,扫一层目录、读 `state.json` 取 `projectId` 匹配,best-effort `rm -rf`,ENOENT 视为空,缺失/不可读 state.json 的目录跳过(避免误删无关 run)。
- `apps/daemon/src/routes/project/index.ts`:DELETE `/api/projects/:id` handler 在 `cancelRunsOwnedBy` + `removeProjectDir` 之后追加一次 `removeProjectRunDirs(path.join(ctx.paths.RUNTIME_DATA_DIR, 'runs'), req.params.id)`,沿用 `.catch(() => {})` best-effort 姿态。
- `apps/daemon/tests/delete-sweeps-orphaned-run-dirs.test.ts`:3 个用例,全部通过。
  - `removes on-disk run directories whose state.json belongs to the deleted project`
  - `leaves run dirs with missing state.json in place`
  - `is a no-op when the runs dir does not exist yet`
- `CHANGELOG.md`:`[Unreleased] → ### Fixed` 加一行。

## Validation

```text
apps/daemon $ pnpm exec vitest run tests/delete-sweeps-orphaned-run-dirs.test.ts --reporter=verbose

 ✓ tests/delete-sweeps-orphaned-run-dirs.test.ts > DELETE project sweeps orphaned run dirs (#6117) > removes on-disk run directories whose state.json belongs to the deleted project 124ms
 ✓ tests/delete-sweeps-orphaned-run-dirs.test.ts > DELETE project sweeps orphaned run dirs (#6117) > leaves run dirs with missing state.json in place 53ms
 ✓ tests/delete-sweeps-orphaned-run-dirs.test.ts > DELETE project sweeps orphaned run dirs (#6117) > is a no-op when the runs dir does not exist yet 56ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

本地 Node 22 (主仓 CI 用 ~24),用 vitest 直接跑测试文件通过。typecheck/lint 走 CI。

不引入 retention sweep / startup gc —— issue 只点名 delete-project 残留,sweep 属 over-engineering 且会扩大 surface area。

Closes #6117