### PR TITLE
fix(e2e): bound tools-dev lifecycle to Playwright slots

### DIFF
--- a/e2e/lib/playwright/runtime-identity.ts
+++ b/e2e/lib/playwright/runtime-identity.ts
@@ -1,0 +1,40 @@
+import { randomUUID } from 'node:crypto';
+
+export const PLAYWRIGHT_RUN_NAMESPACE_ENV = 'OD_E2E_RUN_NAMESPACE';
+
+type Environment = Record<string, string | undefined>;
+
+export function initializePlaywrightRunNamespace(
+  env: Environment = process.env,
+  createToken: () => string = () => `${process.pid}-${randomUUID().slice(0, 8)}`,
+): string {
+  const existingNamespace = env[PLAYWRIGHT_RUN_NAMESPACE_ENV]?.trim();
+  if (existingNamespace) return sanitizeSegment(existingNamespace);
+
+  const namespacePrefix = env.OD_E2E_NAMESPACE?.trim() || 'playwright';
+  const namespace = sanitizeSegment(`${namespacePrefix}-${createToken()}`);
+  env[PLAYWRIGHT_RUN_NAMESPACE_ENV] = namespace;
+  return namespace;
+}
+
+export function resolvePlaywrightSlotNamespace(
+  parallelIndex: number,
+  env: Environment = process.env,
+): string {
+  if (!Number.isInteger(parallelIndex) || parallelIndex < 0) {
+    throw new Error(`Playwright parallelIndex must be a non-negative integer, got: ${parallelIndex}`);
+  }
+
+  const namespaceBase = env[PLAYWRIGHT_RUN_NAMESPACE_ENV];
+  if (namespaceBase == null || namespaceBase.trim().length === 0) {
+    throw new Error(
+      `Playwright run namespace is missing; initialize ${PLAYWRIGHT_RUN_NAMESPACE_ENV} in the Playwright config`,
+    );
+  }
+  return `${sanitizeSegment(namespaceBase)}-w${parallelIndex}`;
+}
+
+export function sanitizeSegment(value: string): string {
+  const safe = value.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+  return safe || 'playwright';
+}

--- a/e2e/lib/playwright/runtime-lifecycle.ts
+++ b/e2e/lib/playwright/runtime-lifecycle.ts
@@ -1,0 +1,33 @@
+// Reserve an extra minute beyond start + warmup + stop command budgets so
+// Playwright can finish fixture bookkeeping without cutting teardown short.
+export const PLAYWRIGHT_TOOLS_DEV_FIXTURE_TIMEOUT_MS = 390_000;
+export const PLAYWRIGHT_WEB_WARMUP_TIMEOUT_MS = 120_000;
+
+type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
+export async function warmPlaywrightWebRuntime(
+  url: string,
+  options: {
+    fetch?: FetchLike;
+    timeoutMs?: number;
+  } = {},
+): Promise<void> {
+  const fetchRuntime = options.fetch ?? fetch;
+  const timeoutMs = options.timeoutMs ?? PLAYWRIGHT_WEB_WARMUP_TIMEOUT_MS;
+  const signal = AbortSignal.timeout(timeoutMs);
+
+  let response: Response;
+  try {
+    response = await fetchRuntime(url, { signal });
+  } catch (error) {
+    if (signal.aborted) {
+      throw new Error(`Playwright web warmup timed out after ${timeoutMs}ms`, { cause: error });
+    }
+    throw error;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Playwright web warmup failed with ${response.status} ${response.statusText}`);
+  }
+  await response.arrayBuffer();
+}

--- a/e2e/lib/playwright/suite.ts
+++ b/e2e/lib/playwright/suite.ts
@@ -3,6 +3,11 @@ import { join } from 'node:path';
 
 import { expect, test as base } from '@playwright/test';
 
+import {
+  PLAYWRIGHT_TOOLS_DEV_FIXTURE_TIMEOUT_MS,
+  warmPlaywrightWebRuntime,
+} from './runtime-lifecycle.ts';
+import { resolvePlaywrightSlotNamespace } from './runtime-identity.ts';
 import { createToolsDevSuite, e2eWorkspaceRoot } from '../tools-dev/runtime.ts';
 import type { ToolsDevSuite } from '../tools-dev/types.ts';
 
@@ -21,7 +26,10 @@ type WorkerFixtures = {
 export const test = base.extend<TestFixtures, WorkerFixtures>({
   toolsDev: [
     async ({}, use, workerInfo) => {
-      const suite = await createPlaywrightToolsDevSuite(workerInfo.workerIndex);
+      const suite = await createPlaywrightToolsDevSuite(
+        workerInfo.parallelIndex,
+        workerInfo.workerIndex,
+      );
       let failed = false;
       const toolsDev: PlaywrightToolsDevSuite = Object.assign(suite, {
         markFailed() {
@@ -33,13 +41,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
       let stopError: unknown = null;
       try {
         await toolsDev.startWeb();
-        const warmupResponse = await fetch(toolsDev.url.web('/'));
-        if (!warmupResponse.ok) {
-          throw new Error(
-            `Playwright web warmup failed with ${warmupResponse.status} ${warmupResponse.statusText}`,
-          );
-        }
-        await warmupResponse.arrayBuffer();
+        await warmPlaywrightWebRuntime(toolsDev.url.web('/'));
         await use(toolsDev);
       } catch (error) {
         useError = error;
@@ -60,7 +62,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
         }
       }
     },
-    { scope: 'worker', timeout: 120_000 },
+    { scope: 'worker', timeout: PLAYWRIGHT_TOOLS_DEV_FIXTURE_TIMEOUT_MS },
   ],
 
   baseURL: async ({ toolsDev }, use) => {
@@ -94,24 +96,23 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
 export { expect };
 export type { PlaywrightToolsDevSuite };
 
-async function createPlaywrightToolsDevSuite(workerIndex: number): Promise<ToolsDevSuite> {
-  const namespaceBase = process.env.OD_E2E_NAMESPACE ?? `playwright-${process.pid}`;
-  const namespace = `${sanitizeSegment(namespaceBase)}-w${workerIndex}`;
-  const root = join(e2eWorkspaceRoot(), '.tmp', 'e2e', namespace);
+async function createPlaywrightToolsDevSuite(
+  parallelIndex: number,
+  workerIndex: number,
+): Promise<ToolsDevSuite> {
+  const namespace = resolvePlaywrightSlotNamespace(parallelIndex);
+  const incarnation = `i${workerIndex}-p${process.pid}`;
+  const root = join(e2eWorkspaceRoot(), '.tmp', 'e2e', namespace, incarnation);
   const scratchDir = join(root, 'scratch');
   const suite = createToolsDevSuite({
     codexHomeDir: join(scratchDir, 'codex-home'),
     dataDir: join(scratchDir, 'data'),
     namespace,
+    ownerPid: process.pid,
     root,
     toolsDevRoot: join(scratchDir, 'tools-dev'),
   });
 
   await mkdir(scratchDir, { recursive: true });
   return suite;
-}
-
-function sanitizeSegment(value: string): string {
-  const safe = value.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
-  return safe || 'playwright';
 }

--- a/e2e/lib/tools-dev/cli.ts
+++ b/e2e/lib/tools-dev/cli.ts
@@ -9,11 +9,16 @@ const pnpmCommand = process.env.OD_E2E_PNPM_COMMAND ?? 'pnpm';
 const pnpmExecPath = process.env.npm_execpath;
 const nodeLoadablePackageManagerExtensions = new Set(['.js', '.cjs', '.mjs']);
 
+export type RunToolsDevJsonOptions = {
+  timeoutMs?: number;
+};
+
 export async function runToolsDevJson<T>(
   workspaceRoot: string,
   suite: ToolsDevSuiteSpec,
   args: string[],
   extraEnv: Record<string, string | undefined> = {},
+  options: RunToolsDevJsonOptions = {},
 ): Promise<T> {
   const useNpmExecPathWithNode = process.env.OD_E2E_PNPM_COMMAND == null
     && pnpmExecPath != null
@@ -35,6 +40,7 @@ export async function runToolsDevJson<T>(
     },
     maxBuffer: 20 * 1024 * 1024,
     shell: process.platform === 'win32' && command !== process.execPath,
+    timeout: options.timeoutMs,
   });
   return parseJsonOutput<T>(stdout);
 }

--- a/e2e/lib/tools-dev/runtime.ts
+++ b/e2e/lib/tools-dev/runtime.ts
@@ -1,7 +1,11 @@
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { isToolsDevPortConflict, runToolsDevJson } from './cli.ts';
+import {
+  isToolsDevPortConflict,
+  runToolsDevJson,
+  type RunToolsDevJsonOptions,
+} from './cli.ts';
 import { allocateToolsDevPorts } from './ports.ts';
 import type {
   ToolsDevCheckResult,
@@ -15,44 +19,78 @@ import type {
 
 const e2eRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 const workspaceRoot = dirname(e2eRoot);
+const TOOLS_DEV_START_TIMEOUT_MS = 180_000;
+const TOOLS_DEV_STOP_TIMEOUT_MS = 30_000;
+
+type RunToolsDevJson = <T>(
+  workspaceRoot: string,
+  suite: ToolsDevSuiteSpec,
+  args: string[],
+  extraEnv?: Record<string, string | undefined>,
+  options?: RunToolsDevJsonOptions,
+) => Promise<T>;
+
+export type ToolsDevRuntimeDependencies = {
+  allocatePorts: typeof allocateToolsDevPorts;
+  runJson: RunToolsDevJson;
+};
 
 export function e2eWorkspaceRoot(): string {
   return workspaceRoot;
 }
 
-export function createToolsDevSuite(spec: ToolsDevSuiteSpec): ToolsDevSuite {
+export function createToolsDevSuite(
+  spec: ToolsDevSuiteSpec,
+  dependencies: Partial<ToolsDevRuntimeDependencies> = {},
+): ToolsDevSuite {
+  const allocatePorts = dependencies.allocatePorts ?? allocateToolsDevPorts;
+  const runJson = dependencies.runJson ?? runToolsDevJson;
   let currentPortAllocation: ToolsDevPortAllocation | null = null;
   let currentDaemonUrl: string | null = null;
   let currentWebUrl: string | null = null;
 
-  async function command<T>(args: string[], env?: Record<string, string | undefined>): Promise<T> {
-    return await runToolsDevJson<T>(workspaceRoot, spec, args, env);
+  async function command<T>(
+    args: string[],
+    env?: Record<string, string | undefined>,
+    options?: RunToolsDevJsonOptions,
+  ): Promise<T> {
+    return await runJson<T>(workspaceRoot, spec, args, env, options);
   }
 
   async function startWeb(env: Record<string, string | undefined> = {}): Promise<ToolsDevStartResult> {
+    if (spec.ownerPid != null) {
+      // A Playwright replacement worker reuses the same logical parallel slot.
+      // Clear any previous incarnation before allocating ports or starting new
+      // processes so the declared worker count remains a hard runtime bound.
+      await stopWeb(env);
+    }
+
     let lastError: unknown = null;
     for (let attempt = 1; attempt <= 3; attempt++) {
-      currentPortAllocation = await allocateToolsDevPorts();
+      currentPortAllocation = await allocatePorts();
       try {
         // Keep both ports reserved until immediately before tools-dev starts so
         // parallel workers do not race each other for the same "free" port.
         await currentPortAllocation.release();
-        const result = await command<ToolsDevStartResult>(
-          [
-            'start',
-            'web',
-            '--namespace',
-            spec.namespace,
-            '--tools-dev-root',
-            spec.toolsDevRoot,
-            '--daemon-port',
-            String(currentPortAllocation.daemonPort),
-            '--web-port',
-            String(currentPortAllocation.webPort),
-            '--json',
-          ],
-          env,
-        );
+        const args = [
+          'start',
+          'web',
+          '--namespace',
+          spec.namespace,
+          '--tools-dev-root',
+          spec.toolsDevRoot,
+          '--daemon-port',
+          String(currentPortAllocation.daemonPort),
+          '--web-port',
+          String(currentPortAllocation.webPort),
+          '--json',
+        ];
+        if (spec.ownerPid != null) {
+          args.push('--parent-pid', String(spec.ownerPid));
+        }
+        const result = await command<ToolsDevStartResult>(args, env, {
+          timeoutMs: TOOLS_DEV_START_TIMEOUT_MS,
+        });
         currentDaemonUrl = assertRuntimeUrl(result.daemon?.status.url, 'daemon');
         currentWebUrl = assertRuntimeUrl(result.web?.status.url, 'web');
         return result;
@@ -77,6 +115,7 @@ export function createToolsDevSuite(spec: ToolsDevSuiteSpec): ToolsDevSuite {
         '--json',
       ],
       env,
+      { timeoutMs: TOOLS_DEV_STOP_TIMEOUT_MS },
     );
     currentDaemonUrl = null;
     currentWebUrl = null;

--- a/e2e/lib/tools-dev/types.ts
+++ b/e2e/lib/tools-dev/types.ts
@@ -52,6 +52,7 @@ export type ToolsDevSuiteSpec = {
   codexHomeDir: string;
   dataDir: string;
   namespace: string;
+  ownerPid?: number;
   root: string;
   toolsDevRoot: string;
 };

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig, devices } from '@playwright/test';
 
+import { initializePlaywrightRunNamespace } from './lib/playwright/runtime-identity.ts';
+
+initializePlaywrightRunNamespace();
+
 function parseWorkerCount(value: string | undefined): number {
   if (value == null || value.length === 0) return 2;
   const parsed = Number(value);

--- a/e2e/playwright.visual.config.ts
+++ b/e2e/playwright.visual.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig, devices } from '@playwright/test';
 
+import { initializePlaywrightRunNamespace } from './lib/playwright/runtime-identity.ts';
+
+initializePlaywrightRunNamespace();
+
 function parseWorkerCount(value: string | undefined): number {
   if (value == null || value.length === 0) return 3;
   const parsed = Number(value);

--- a/e2e/tests/playwright-runtime-lifecycle.test.ts
+++ b/e2e/tests/playwright-runtime-lifecycle.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment node
+
+import { describe, expect, test, vi } from 'vitest';
+
+import {
+  initializePlaywrightRunNamespace,
+  PLAYWRIGHT_RUN_NAMESPACE_ENV,
+  resolvePlaywrightSlotNamespace,
+} from '@/playwright/runtime-identity';
+import { warmPlaywrightWebRuntime } from '@/playwright/runtime-lifecycle';
+import type { RunToolsDevJsonOptions } from '@/tools-dev/cli';
+import { createToolsDevSuite } from '@/tools-dev/runtime';
+import type { ToolsDevRuntimeDependencies } from '@/tools-dev/runtime';
+import type { ToolsDevSuiteSpec } from '@/tools-dev/types';
+
+describe('Playwright tools-dev runtime lifecycle', () => {
+  test('keeps a replacement worker on the same logical parallel slot', () => {
+    const env: Record<string, string | undefined> = {};
+    expect(initializePlaywrightRunNamespace(env, () => 'run-token')).toBe('playwright-run-token');
+    expect(env[PLAYWRIGHT_RUN_NAMESPACE_ENV]).toBe('playwright-run-token');
+
+    expect(resolvePlaywrightSlotNamespace(0, env)).toBe('playwright-run-token-w0');
+    expect(resolvePlaywrightSlotNamespace(0, env)).toBe('playwright-run-token-w0');
+    expect(resolvePlaywrightSlotNamespace(1, env)).toBe('playwright-run-token-w1');
+  });
+
+  test('uses the explicit namespace as a prefix while keeping concurrent runs isolated', () => {
+    const env = {
+      OD_E2E_NAMESPACE: 'focused route stress',
+    };
+    expect(initializePlaywrightRunNamespace(env, () => 'run-token')).toBe(
+      'focused-route-stress-run-token',
+    );
+    expect(resolvePlaywrightSlotNamespace(2, env)).toBe('focused-route-stress-run-token-w2');
+  });
+
+  test('preserves an inherited exact run namespace across Playwright processes', () => {
+    const env = {
+      OD_E2E_NAMESPACE: 'ignored-prefix',
+      [PLAYWRIGHT_RUN_NAMESPACE_ENV]: 'generated-run',
+    };
+    expect(initializePlaywrightRunNamespace(env, () => 'unused')).toBe('generated-run');
+    expect(resolvePlaywrightSlotNamespace(2, env)).toBe('generated-run-w2');
+  });
+
+  test('clears the previous slot incarnation before allocating ports and passes its owner pid', async () => {
+    const calls: Array<{ args: string[]; timeoutMs: number | undefined }> = [];
+    const order: string[] = [];
+    const spec: ToolsDevSuiteSpec = {
+      codexHomeDir: '/tmp/codex-home',
+      dataDir: '/tmp/data',
+      namespace: 'playwright-run-w0',
+      ownerPid: 4242,
+      root: '/tmp/root',
+      toolsDevRoot: '/tmp/tools-dev',
+    };
+    const runJson: ToolsDevRuntimeDependencies['runJson'] = async <T>(
+      _workspaceRoot: string,
+      _suite: ToolsDevSuiteSpec,
+      args: string[],
+      _env: Record<string, string | undefined> = {},
+      options?: RunToolsDevJsonOptions,
+    ): Promise<T> => {
+      calls.push({ args, timeoutMs: options?.timeoutMs });
+      order.push(args[0] === 'stop' ? 'stop' : 'start');
+      if (args[0] === 'start') {
+        return {
+          daemon: { status: { url: 'http://127.0.0.1:31001' } },
+          web: { status: { url: 'http://127.0.0.1:31002' } },
+        } as T;
+      }
+      return {} as T;
+    };
+    const suite = createToolsDevSuite(spec, {
+      allocatePorts: async () => {
+        order.push('allocate');
+        return {
+          daemonPort: 31001,
+          webPort: 31002,
+          release: async () => {
+            order.push('release');
+          },
+        };
+      },
+      runJson,
+    });
+
+    await suite.startWeb();
+
+    expect(order).toEqual(['stop', 'allocate', 'release', 'start']);
+    expect(calls[0]?.args.slice(0, 2)).toEqual(['stop', 'web']);
+    expect(calls[0]?.timeoutMs).toBe(30_000);
+    expect(calls[1]?.args).toContain('--parent-pid');
+    expect(calls[1]?.args).toContain('4242');
+    expect(calls[1]?.timeoutMs).toBe(180_000);
+  });
+
+  test('aborts a blocked cold warmup before the fixture teardown budget is consumed', async () => {
+    const blockedFetch = vi.fn((_url: string, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(init.signal?.reason), { once: true });
+      }));
+
+    await expect(
+      warmPlaywrightWebRuntime('http://127.0.0.1:31002/', {
+        fetch: blockedFetch,
+        timeoutMs: 10,
+      }),
+    ).rejects.toThrow('Playwright web warmup timed out after 10ms');
+  });
+});

--- a/tools/dev/src/cli-args.ts
+++ b/tools/dev/src/cli-args.ts
@@ -4,6 +4,7 @@ const OPTIONS_WITH_VALUE = new Set([
   "--env-file",
   "--expr",
   "--namespace",
+  "--parent-pid",
   "--path",
   "--selector",
   "--timeout",

--- a/tools/dev/src/config.ts
+++ b/tools/dev/src/config.ts
@@ -143,6 +143,15 @@ export function parsePortOption(value: number | string | null | undefined, optio
   return parsed;
 }
 
+export function parseParentPidOption(value: number | string | null | undefined): number | null {
+  if (value == null || value === "") return null;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`--parent-pid must be a positive safe integer`);
+  }
+  return parsed;
+}
+
 export function resolveToolDevConfig(options: ToolDevOptions = {}): ToolDevConfig {
   const namespace = resolveNamespace({ namespace: options.namespace, env: process.env, contract: OPEN_DESIGN_SIDECAR_CONTRACT });
   const toolsDevRoot = resolveSidecarBase({

--- a/tools/dev/src/index.ts
+++ b/tools/dev/src/index.ts
@@ -37,6 +37,7 @@ import {
   ALL_APPS,
   DEFAULT_START_APPS,
   DEFAULT_STOP_APPS,
+  parseParentPidOption,
   parsePortOption,
   resolveRunApps,
   resolveStartApps,
@@ -673,6 +674,12 @@ async function startDaemon(
   }
   const daemonTrustedWebOriginPort = existing?.trustedWebOriginPort ?? null;
   if (existing?.url != null && statusMatchesForcedPort(existing.url, daemonPort)) {
+    if (options.parentPid != null) {
+      throw new Error(
+        `${APP_KEYS.DAEMON} is already running in namespace ${config.namespace} at ${existing.url}; ` +
+        `owner-bound starts require a clean namespace, so stop it or choose another namespace`,
+      );
+    }
     if (shouldRefreshWebOrigin && daemonTrustedWebOriginPort !== webPort) {
       if (existingWeb?.url != null) {
         await stopApp(config, APP_KEYS.WEB);
@@ -723,6 +730,12 @@ async function startWeb(config: ToolDevConfig, options: CliOptions) {
   const webPort = parsePortOption(options.webPort, "--web-port");
   const existing = await inspectWebRuntime(runtimeLookup(config));
   if (existing?.url != null && statusMatchesForcedPort(existing.url, webPort)) {
+    if (options.parentPid != null) {
+      throw new Error(
+        `${APP_KEYS.WEB} is already running in namespace ${config.namespace} at ${existing.url}; ` +
+        `owner-bound starts require a clean namespace, so stop it or choose another namespace`,
+      );
+    }
     return { app: APP_KEYS.WEB, created: false, logPath: config.apps.web.latestLogPath, status: existing };
   }
   if (existing?.url != null) {
@@ -755,6 +768,12 @@ async function startWeb(config: ToolDevConfig, options: CliOptions) {
 async function startDesktop(config: ToolDevConfig, options: CliOptions) {
   const existing = await inspectDesktopRuntime(runtimeLookup(config));
   if (existing != null) {
+    if (options.parentPid != null) {
+      throw new Error(
+        `${APP_KEYS.DESKTOP} is already running in namespace ${config.namespace}; ` +
+        `owner-bound starts require a clean namespace, so stop it or choose another namespace`,
+      );
+    }
     return { app: APP_KEYS.DESKTOP, created: false, logPath: config.apps.desktop.latestLogPath, status: existing };
   }
   await assertNoStaleActiveProcess(config, APP_KEYS.DESKTOP);
@@ -1134,19 +1153,29 @@ function addPortOptions(command: ReturnType<typeof cli.command>) {
     .option("--prod", "use production build (requires pnpm --filter @open-design/web build first)");
 }
 
-addPortOptions(addSharedOptions(cli.command("start [app]", "Start daemon, web, desktop, or all when app is omitted"))).action(
-  async (appName: string | undefined, options: CliOptions) => {
-    assertSupportedNodeRuntimeForStart();
-    const config = resolveToolDevConfig(options);
-    const targets = resolveStartApps(appName);
-    await resolveSharedPortsFromRunningState(targets, options, {
-      daemonUrl: async () => (await inspectDaemonRuntime(runtimeLookup(config)))?.url,
-      webUrl: async () => (await inspectWebRuntime(runtimeLookup(config)))?.url,
-    });
-    const result = await runSequential(targets, (target) => startApp(config, target, options, { targets }));
-    printStartResult(result, options);
-  },
-);
+addPortOptions(addSharedOptions(cli.command("start [app]", "Start daemon, web, desktop, or all when app is omitted")))
+  .option("--parent-pid <pid>", "stop started apps when this owner process exits")
+  .action(
+    async (appName: string | undefined, options: CliOptions) => {
+      assertSupportedNodeRuntimeForStart();
+      const parentPid = parseParentPidOption(options.parentPid);
+      if (parentPid != null && !isProcessAlive(parentPid)) {
+        throw new Error(`--parent-pid process is not alive: ${parentPid}`);
+      }
+      const startOptions = parentPid == null ? options : { ...options, parentPid };
+      const config = resolveToolDevConfig(startOptions);
+      const targets = resolveStartApps(appName);
+      await resolveSharedPortsFromRunningState(targets, startOptions, {
+        daemonUrl: async () => (await inspectDaemonRuntime(runtimeLookup(config)))?.url,
+        webUrl: async () => (await inspectWebRuntime(runtimeLookup(config)))?.url,
+      });
+      const result = await runSequential(
+        targets,
+        (target) => startApp(config, target, startOptions, { targets }),
+      );
+      printStartResult(result, startOptions);
+    },
+  );
 
 addPortOptions(addSharedOptions(cli.command("run [app]", "Start apps and keep this command alive until interrupted"))).action(
   async (appName: string | undefined, options: CliOptions) => {

--- a/tools/dev/tests/cli-args.test.ts
+++ b/tools/dev/tests/cli-args.test.ts
@@ -29,6 +29,12 @@ describe("tools-dev CLI argument rewriting", () => {
       "--web-port",
       "17573",
     ]);
+    assert.deepEqual(rewriteCliArgsForDefaultStart(["--parent-pid", "42", "--json"]), [
+      "start",
+      "--parent-pid",
+      "42",
+      "--json",
+    ]);
     assert.deepEqual(rewriteCliArgsForDefaultStart(["--namespace", "demo", "daemon"]), [
       "--namespace",
       "demo",

--- a/tools/dev/tests/parent-pid.test.ts
+++ b/tools/dev/tests/parent-pid.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { parseParentPidOption } from "../src/config.js";
+
+describe("tools-dev parent ownership", () => {
+  it("accepts only positive safe owner process identifiers", () => {
+    assert.equal(parseParentPidOption(undefined), null);
+    assert.equal(parseParentPidOption("42"), 42);
+    assert.equal(parseParentPidOption(42), 42);
+    assert.throws(() => parseParentPidOption("0"), /positive safe integer/);
+    assert.throws(() => parseParentPidOption("-1"), /positive safe integer/);
+    assert.throws(() => parseParentPidOption("1.5"), /positive safe integer/);
+    assert.throws(() => parseParentPidOption("not-a-pid"), /positive safe integer/);
+  });
+});


### PR DESCRIPTION
Fixes #6203

## Why

While investigating a local Electron restart under macOS memory pressure, I traced the dominant amplification path to Playwright worker replacement rather than the Open Cut application flow. The UI suite named tools-dev runtimes with the worker incarnation (`workerIndex` plus worker PID), so a replacement worker could start a new daemon/web tree without reclaiming the prior logical capacity slot. In the observed `--workers=2 --repeat-each=8` run, four generations accounted for roughly 15.45 GiB of resident-page pressure on a 16 GiB host.

This PR makes the configured Playwright worker count a hard bound for suite-owned tools-dev runtime trees and gives cold-start failures a deterministic cleanup path.

## What users will see

Product UI is unchanged. Contributors running Playwright UI suites will see:

- replacement workers reuse the same logical parallel slot instead of expanding the number of tools-dev runtimes;
- daemon/web runtimes exit when their owning Playwright worker dies;
- startup, initial web warmup, and stop failures terminate with explicit time budgets instead of hanging indefinitely;
- descriptive `OD_E2E_NAMESPACE` values remain readable but receive a per-run unique suffix, so concurrent invocations cannot clean each other.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — adds tools-dev `start --parent-pid` and the internal inherited `OD_E2E_RUN_NAMESPACE`
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing product users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; there is no UI change.

## Bug fix verification

- Test path that reproduces the lifecycle invariant: `e2e/tests/playwright-runtime-lifecycle.test.ts`
- Did the test go red on `main` and green on this branch? The new focused helper-level spec does not exist on `main`, so it was not run verbatim there. The baseline source and the captured failing run both used incarnation-scoped namespaces, and the observed process census showed four runtime generations for two configured workers. On this branch, a real `repeat-each=2`, `workers=1` run replaced worker PID `83117` with `83844` while retaining the single stamped slot `guard-review-83109-bf3032af-w0`; the prior tree exited before the replacement started and no processes remained after teardown.
- Forced owner-death verification additionally confirmed that the complete daemon/web tree became idle within two seconds after its owner exited.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/tools-dev test` — 41 passed
- `pnpm --filter @open-design/tools-dev build`
- `pnpm -C e2e exec vitest run -c vitest.config.ts tests/playwright-runtime-lifecycle.test.ts tests/tools-dev/startup-conflicts.test.ts` — 6 passed
- `OD_E2E_NAMESPACE=guard-review pnpm -C e2e exec playwright test -c playwright.config.ts ui/critical-smoke.test.ts --grep "home loads with the primary entry controls" --repeat-each=2 --workers=1` — 2 passed in 45.6s
- full daemon/web parent-death probe — both idle within two seconds
- post-run process inspection — no task-stamped tools-dev runtimes remained
