### PR TITLE
fix(web): stop offering 升级 at the top plan tier (team_max)

### DIFF
--- a/apps/web/src/collab/team-plan.ts
+++ b/apps/web/src/collab/team-plan.ts
@@ -108,6 +108,56 @@ export function resolvePlanLabelTier(sources: PlanTierSources): string | null {
 }
 
 /**
+ * Whether a resolved plan id is the TOP tier the product sells — the one with
+ * nothing above it to upgrade to.
+ *
+ * Team and personal tiers are two separate ladders, not one: `team_max` is the
+ * top of everything, while personal `max` is only the top of the PERSONAL
+ * ladder and still has the whole team ladder above it (vela #1146 deliberately
+ * routes a personal Max user's upgrade click to the Team upgrade dialog for
+ * exactly that reason). Product ruling: 「个人档位都是要显示可升级的, 最顶的就是
+ * 团队 max」.
+ *
+ * So the answer must be read off the team-namespaced id as a whole. Stripping
+ * the `team_` prefix and asking a personal-ladder question — which is how the
+ * AMR model-row gate still phrases it — collapses the two ladders and cannot
+ * tell personal `max` from `team_max`.
+ *
+ * Segment matching rather than an exact `=== 'team_max'` so a billing-period
+ * suffix (`team_max_yearly`) still reads as the top tier, matching how the
+ * PlanWordmark badge next to these surfaces already derives MAX from the raw id.
+ */
+export function isTopPlanTier(tier: string | null | undefined): boolean {
+  const normalized = tier?.trim().toLowerCase() ?? '';
+  if (!isTeamPlanTier(normalized)) return false;
+  return normalized.split(/[_-]+/).filter(Boolean).includes('max');
+}
+
+/**
+ * Whether an 「升级」 affordance has anywhere left to send this plan tier, and
+ * may therefore be rendered at all.
+ *
+ * The single tier rule behind every upgrade entry point, so the account menu's
+ * billing card and the Settings AMR card cannot drift apart again — they used
+ * to hold two different rules (one had no tier check at all, the other asked a
+ * personal-ladder question about an account-scoped tier) and disagreed with
+ * each other and with the tier badge they render alongside.
+ *
+ * Fails closed on an UNKNOWN tier: a billing read that has not resolved yet
+ * knows nothing, and flashing an upgrade CTA that then disappears is worse than
+ * showing it one paint later. Callers pass the same resolved tier they LABEL,
+ * so the button and the nameplate can never contradict each other.
+ *
+ * This is only about whether the affordance exists. Where it points stays with
+ * `workspaceUpgradeUrl`.
+ */
+export function canUpgradeFromPlanTier(tier: string | null | undefined): boolean {
+  const normalized = tier?.trim().toLowerCase() ?? '';
+  if (!normalized) return false;
+  return !isTopPlanTier(normalized);
+}
+
+/**
  * Whether free-tier surfaces (upgrade banners, plan gates, the free nameplate)
  * may be shown for a resolved plan id.
  *

--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -62,7 +62,7 @@ import {
   notifyWorkspaceBillingRefresh,
   notifyWorkspaceContextRefresh,
 } from '../collab/useWorkspaceContext';
-import { hasTeamPlan, resolvePlanLabelTier } from '../collab/team-plan';
+import { canUpgradeFromPlanTier, hasTeamPlan, resolvePlanLabelTier } from '../collab/team-plan';
 import { AMR_CONSOLE_UPGRADE_INTENT, amrPlansUrlForProfile } from '../runtime/amr-guidance';
 import type { EntryHomeView } from '../router';
 
@@ -620,7 +620,16 @@ export function EntryNavRail({
   // Product decision: plan selection / payment lives in Vela Web. The local
   // client opens that billing surface, then refreshes billing + context when
   // focus returns so direct web upgrades sync plan, credits, seats and gates.
-  const canUpgrade = Boolean(billingUpgradeUrl && permissions?.canManageBilling);
+  //
+  // The gate needs all three answers, and used to ask only the last two: a
+  // destination exists, the caller may act on billing, AND the tier actually has
+  // somewhere to go. Without the tier question a 团队版 Max owner — the top tier,
+  // nothing above it — was offered 升级 that could only reopen the plan they
+  // already hold. It reads the tier the card LABELS, so the button and the
+  // nameplate next to it can never disagree.
+  const canUpgrade =
+    Boolean(billingUpgradeUrl && permissions?.canManageBilling)
+    && canUpgradeFromPlanTier(labelTier);
   const currentWorkspaceItem = context
     ? workspaceItems.find((item) => item.workspaceId === context.workspaceId) ?? null
     : null;

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -48,7 +48,6 @@ import {
   amrLoginStatusEventReason,
 } from './amrLoginPolling';
 import {
-  canUpgradeVelaPlan,
   fetchAmrWalletSnapshot,
   fetchVelaLoginStatus,
   formatVelaBalanceUsd,
@@ -160,7 +159,7 @@ import {
   workspaceBillingBalanceUsd,
   workspaceBillingSummaryForContext,
 } from '../collab/useWorkspaceContext';
-import { resolvePlanTier } from '../collab/team-plan';
+import { canUpgradeFromPlanTier, resolvePlanTier } from '../collab/team-plan';
 import { planBadgeTierForLabel } from './PlanWordmark';
 import { workspaceUpgradeUrl } from './EntryNavRail';
 import { canShowWorkspaceSettings } from '../collab/settings-access';
@@ -4653,9 +4652,21 @@ export function SettingsDialog({
                           // workspaces always resolve `canManageBilling` true
                           // (the user is their own owner), so this does not
                           // affect the personal-workspace upgrade path.
+                          //
+                          // The TIER half asks `canUpgradeFromPlanTier` — the
+                          // one rule the account menu's billing card shares —
+                          // about `amrCardResolvedPlan`, the SAME resolved tier
+                          // the badge above renders. It used to ask a
+                          // personal-ladder question about
+                          // `account.plan` instead: that projection is
+                          // ACCOUNT-scoped and reports `free` for a user whose
+                          // entitlement is held by a team workspace, so a
+                          // 团队版 Max owner was measured as "free" and offered
+                          // an upgrade to the top tier they already hold, while
+                          // the badge beside it correctly read Max.
                           const amrCardCanUpgrade =
                             isAmrAgent && active && amrCardStatus?.loggedIn
-                              ? canUpgradeVelaPlan(amrCardStatus.account?.plan) &&
+                              ? canUpgradeFromPlanTier(amrCardResolvedPlan) &&
                                 Boolean(workspaceContext?.permissions?.canManageBilling)
                               : false;
                           const amrRevealPendingCancelAction =

--- a/apps/web/tests/components/EntryNavRail.top-tier-upgrade.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.top-tier-upgrade.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+//
+// Acceptance: the account menu's billing card must not offer 「升级」 to a
+// workspace that is already on the TOP plan tier there is.
+//
+// Product ruling (owner, from a real packaged client on Team Max):
+// 「个人档位都是要显示可升级的, 最顶的就是团队 max」 — every PERSONAL tier still
+// has somewhere to go (a personal Max user can still move onto a team plan, and
+// vela #1146 deliberately routes their click to the Team upgrade dialog), and
+// every team tier BELOW max can still change plan. `team_max` is the one tier
+// with nothing above it, so it is the one tier that hides the affordance.
+//
+// The bug: this rail's gate was `billingUpgradeUrl && canManageBilling` — a
+// destination check and a permission check, with no TIER check at all — so
+// 团队版 Max owners were shown an 升级 button that could only ever reopen the
+// plan they already hold.
+
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import type { WorkspaceBillingSummary, WorkspaceCollabContext } from '@open-design/contracts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EntryNavRail, resetWorkspaceDirectoryCache } from '../../src/components/EntryNavRail';
+import { I18nProvider } from '../../src/i18n';
+
+const originalFetch = globalThis.fetch;
+
+const OWNER_PERMISSIONS = {
+  canInviteMembers: true,
+  canManageBilling: true,
+  canViewWorkspaceSettings: true,
+};
+
+const MEMBER_PERMISSIONS = {
+  canInviteMembers: false,
+  canManageBilling: false,
+  canViewWorkspaceSettings: true,
+};
+
+function context(overrides: Partial<WorkspaceCollabContext> = {}): WorkspaceCollabContext {
+  return {
+    workspaceId: 'ws-1',
+    workspaceType: 'team',
+    workspaceMemberId: 'wm-1',
+    teamName: 'OD Feature Team',
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+    billingState: 'active',
+    planId: null,
+    permissions: OWNER_PERMISSIONS,
+    workspaceSettingsUrl: 'https://web.example.com/console/settings?workspaceId=ws-1',
+    ...overrides,
+  } as unknown as WorkspaceCollabContext;
+}
+
+function billing(overrides: Partial<WorkspaceBillingSummary> = {}): WorkspaceBillingSummary {
+  return {
+    workspaceId: 'ws-1',
+    membershipTier: '',
+    totalAvailableCredits: 0,
+    subscriptionCredits: 0,
+    rechargeCredits: 0,
+    balanceUsd: '210',
+    subscriptionStatus: 'active',
+    availableActions: [],
+    ...overrides,
+  } as WorkspaceBillingSummary;
+}
+
+function renderRail(props: {
+  context: WorkspaceCollabContext;
+  billing: WorkspaceBillingSummary | null;
+}) {
+  return render(
+    <I18nProvider initial="zh-CN">
+      <EntryNavRail
+        view="home"
+        onViewChange={() => {}}
+        onNewProject={() => {}}
+        open
+        context={props.context}
+        billing={props.billing}
+        balanceUsd="210"
+      />
+    </I18nProvider>,
+  );
+}
+
+/** Open the account menu and scope queries to its billing card. */
+function billingCard() {
+  fireEvent.click(screen.getByTestId('entry-nav-account'));
+  const el = document.querySelector('.entry-nav-rail__menu-credits');
+  if (!el) throw new Error('billing card is not rendered');
+  return within(el as HTMLElement);
+}
+
+beforeEach(() => {
+  resetWorkspaceDirectoryCache();
+  globalThis.fetch = vi.fn(
+    async () => new Response(JSON.stringify({}), { status: 200 }),
+  ) as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = originalFetch;
+  resetWorkspaceDirectoryCache();
+  vi.restoreAllMocks();
+});
+
+describe('account menu billing card — 升级 at the top plan tier', () => {
+  // (1) The reported bug. Nothing above team_max, so nothing to offer.
+  it('hides 升级 for a team_max owner', () => {
+    renderRail({
+      context: context({ planId: 'team_max' } as Partial<WorkspaceCollabContext>),
+      billing: billing({ membershipTier: 'team_max' }),
+    });
+
+    const card = billingCard();
+    // The card itself still renders, still labelled 团队版 — only the button goes.
+    expect(card.getByText('团队版')).toBeTruthy();
+    expect(card.queryByRole('button', { name: '升级' })).toBeNull();
+  });
+
+  // (2) Team tiers below max can still change plan.
+  it.each(['team_basic', 'team_plus', 'team_pro'])(
+    'keeps 升级 for a %s owner',
+    (tier) => {
+      renderRail({
+        context: context({ planId: tier } as Partial<WorkspaceCollabContext>),
+        billing: billing({ membershipTier: tier }),
+      });
+
+      expect(billingCard().getByRole('button', { name: '升级' })).toBeTruthy();
+    },
+  );
+
+  // (3) The case a careless fix breaks: personal Max is NOT the top of the
+  // ladder — that user can still move onto a team plan.
+  it('keeps 升级 for a personal max owner', () => {
+    renderRail({
+      context: context({
+        workspaceType: 'personal',
+        planId: 'max',
+      } as Partial<WorkspaceCollabContext>),
+      billing: billing({ membershipTier: 'max' }),
+    });
+
+    expect(billingCard().getByRole('button', { name: '升级' })).toBeTruthy();
+  });
+
+  // (4) Every other personal tier keeps it too.
+  it.each(['free', 'plus', 'pro'])('keeps 升级 for a personal %s owner', (tier) => {
+    renderRail({
+      context: context({
+        workspaceType: 'personal',
+        billingState: tier === 'free' ? 'free' : 'active',
+        planId: tier,
+      } as Partial<WorkspaceCollabContext>),
+      billing: billing({ membershipTier: tier }),
+    });
+
+    expect(billingCard().getByRole('button', { name: '升级' })).toBeTruthy();
+  });
+
+  // (5) Existing behavior that must not regress: billing is owner-only, so a
+  // member never sees the affordance even on an upgradeable tier.
+  it('still hides 升级 for a team_pro member without canManageBilling', () => {
+    renderRail({
+      context: context({
+        role: 'member',
+        planId: 'team_pro',
+        permissions: MEMBER_PERMISSIONS,
+      } as unknown as Partial<WorkspaceCollabContext>),
+      billing: billing({ membershipTier: 'team_pro' }),
+    });
+
+    expect(billingCard().queryByRole('button', { name: '升级' })).toBeNull();
+  });
+});

--- a/apps/web/tests/components/SettingsDialog.top-tier-upgrade.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.top-tier-upgrade.test.tsx
@@ -1,0 +1,284 @@
+// @vitest-environment jsdom
+//
+// Acceptance: the Settings → 本机 CLI → Open Design card must not offer 「升级」
+// to a workspace that is already on the TOP plan tier there is.
+//
+// Product ruling (owner, from a real packaged client on Team Max):
+// 「个人档位都是要显示可升级的, 最顶的就是团队 max」 — `team_max` is the one tier
+// with nothing above it. Every personal tier (personal `max` included: that user
+// can still move onto a team plan, and vela #1146 deliberately routes their
+// click to the Team upgrade dialog) and every team tier below max keep the
+// affordance.
+//
+// The bug: this card judged the tier from `amrCardStatus.account.plan` — vela's
+// ACCOUNT-scoped login projection, which reports `free` for a user whose
+// entitlement is held by a team workspace. So a 团队版 Max owner was measured as
+// "free" and shown 升级, while the badge right next to it correctly read Max off
+// the workspace-resolved tier. Both must read the SAME resolved tier.
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { WorkspaceCollabContext } from '@open-design/contracts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SettingsDialog } from '../../src/components/SettingsDialog';
+import { I18nProvider } from '../../src/i18n';
+import type { AgentInfo, AppConfig } from '../../src/types';
+
+vi.mock('../../src/providers/registry', async () => {
+  const actual = await vi.importActual<typeof import('../../src/providers/registry')>(
+    '../../src/providers/registry',
+  );
+  return {
+    ...actual,
+    fetchCodexPets: vi.fn(async () => []),
+    syncCommunityPets: vi.fn(async () => []),
+    fetchSkills: vi.fn(async () => []),
+    fetchDesignSystems: vi.fn(async () => []),
+    fetchDesignTemplates: vi.fn(async () => []),
+    fetchConnectors: vi.fn(async () => []),
+    fetchLatestGithubReleaseInfo: vi.fn(async () => null),
+    openExternalUrl: vi.fn(),
+  };
+});
+
+vi.mock('../../src/analytics/provider', () => ({
+  useAnalytics: () => ({
+    track: vi.fn(),
+    setConsent: () => undefined,
+    setIdentity: () => undefined,
+    setConfigureGlobals: () => undefined,
+    anonymousId: 'test-anonymous',
+    sessionId: 'test-session',
+    newRequestId: () => 'test-request',
+  }),
+}));
+
+const originalFetch = globalThis.fetch;
+
+const baseConfig: AppConfig = {
+  mode: 'daemon',
+  apiKey: '',
+  apiProtocol: 'anthropic',
+  apiVersion: '',
+  baseUrl: 'https://api.anthropic.com',
+  model: 'claude-sonnet-4-5',
+  apiProviderBaseUrl: 'https://api.anthropic.com',
+  apiProtocolConfigs: {},
+  agentId: 'amr',
+  skillId: null,
+  designSystemId: null,
+  onboardingCompleted: true,
+  mediaProviders: {},
+  agentModels: {},
+  agentCliEnv: {},
+};
+
+const amrAgent: AgentInfo = {
+  id: 'amr',
+  name: 'AMR (vela)',
+  bin: 'amr',
+  available: true,
+  version: '1.0.0',
+  models: [{ id: 'default', label: 'Default' }],
+  supportsCustomModel: false,
+};
+
+const OWNER_PERMISSIONS = {
+  canManageMembers: true,
+  canManageBilling: true,
+  canInviteMembers: true,
+  canManageAutoRecharge: true,
+  canShareProjects: true,
+  canWriteSyncedFiles: true,
+  canViewWorkspaceSettings: true,
+  canManageSharedResources: true,
+};
+
+const MEMBER_PERMISSIONS = {
+  ...OWNER_PERMISSIONS,
+  canManageMembers: false,
+  canManageBilling: false,
+  canInviteMembers: false,
+  canManageAutoRecharge: false,
+  canManageSharedResources: false,
+};
+
+function workspaceContext(
+  overrides: Partial<WorkspaceCollabContext> = {},
+): WorkspaceCollabContext {
+  return {
+    workspaceId: 'ws-1',
+    workspaceType: 'team',
+    workspaceMemberId: 'wm-1',
+    teamId: 'team-1',
+    teamName: 'OD Feature Team',
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+    billingState: 'active',
+    planId: null,
+    providerMode: 'workspace_managed',
+    seatSummary: { seatLimit: 5, usedSeats: 2, availableSeats: 3, isSeatFull: false },
+    permissions: OWNER_PERMISSIONS,
+    workspaceSettingsUrl: 'https://web.example.com/console/settings?workspaceId=ws-1',
+    ...overrides,
+  } as unknown as WorkspaceCollabContext;
+}
+
+/**
+ * Stand the CLI tab up for one identity shape.
+ *
+ * `accountPlan` is vela's ACCOUNT-scoped login projection and `context.planId`
+ * is the WORKSPACE plan — the two disagree by design for a team member, which
+ * is exactly the axis this bug sat on.
+ */
+async function renderCliTab(options: {
+  context: WorkspaceCollabContext;
+  accountPlan: string;
+}) {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = input.toString();
+    if (url.startsWith('/api/workspace/context')) {
+      return new Response(JSON.stringify({ context: options.context }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    if (url.startsWith('/api/workspace/billing')) {
+      // Account metadata outage / not yet reported: the resolved tier then comes
+      // from the workspace context, which carries the same raw plan id.
+      return new Response(JSON.stringify({ summary: null, workspaces: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    if (url.startsWith('/api/integrations/vela/status')) {
+      return new Response(
+        JSON.stringify({
+          loggedIn: true,
+          profile: 'default',
+          user: { id: 'u1', email: '935902669@qq.com' },
+          account: { plan: options.accountPlan, balanceUsd: '210.0000' },
+          configPath: '/Users/test/.amr/config.json',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }
+    return new Response(JSON.stringify({}), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  render(
+    <I18nProvider initial="en">
+      <SettingsDialog
+        initial={baseConfig}
+        agents={[amrAgent]}
+        daemonLive
+        appVersionInfo={null}
+        initialSection="execution"
+        onPersist={vi.fn()}
+        onSilentUpdatePreferenceChange={async () => undefined}
+        onPersistComposioKey={vi.fn()}
+        onClose={vi.fn()}
+        onRefreshAgents={vi.fn()}
+      />
+    </I18nProvider>,
+  );
+
+  fireEvent.click(screen.getByRole('tab', { name: /Local CLI.*1 installed/i }));
+  // Both identity reads must land before the gate is meaningful: the card is
+  // deliberately fail-closed while the tier is unknown.
+  await waitFor(() => {
+    expect(screen.getByTestId('settings-agent-card-amr')).toBeTruthy();
+    expect(screen.getByText('935902669@qq.com')).toBeTruthy();
+  });
+}
+
+function upgradePill(): HTMLElement | null {
+  return screen.queryByTestId('settings-agent-card-amr-upgrade');
+}
+
+beforeEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('Settings CLI card — 升级 at the top plan tier', () => {
+  // (1) The reported bug. The account projection says `free` for this user;
+  // the workspace they are actually in is on team_max.
+  it('hides 升级 for a team_max owner', async () => {
+    await renderCliTab({
+      context: workspaceContext({ planId: 'team_max' } as Partial<WorkspaceCollabContext>),
+      accountPlan: 'free',
+    });
+
+    expect(upgradePill()).toBeNull();
+  });
+
+  // (2) Team tiers below max can still change plan.
+  it.each(['team_basic', 'team_plus', 'team_pro'])(
+    'keeps 升级 for a %s owner',
+    async (tier) => {
+      await renderCliTab({
+        context: workspaceContext({ planId: tier } as Partial<WorkspaceCollabContext>),
+        accountPlan: 'free',
+      });
+
+      expect(upgradePill()).toBeTruthy();
+    },
+  );
+
+  // (3) The case a careless fix breaks: personal Max is NOT the top of the
+  // ladder — that user can still move onto a team plan.
+  it('keeps 升级 for a personal max owner', async () => {
+    await renderCliTab({
+      context: workspaceContext({
+        workspaceType: 'personal',
+        teamId: undefined,
+        teamName: undefined,
+        planId: null,
+      } as unknown as Partial<WorkspaceCollabContext>),
+      accountPlan: 'max',
+    });
+
+    expect(upgradePill()).toBeTruthy();
+  });
+
+  // (4) Every other personal tier keeps it too.
+  it.each(['free', 'plus', 'pro'])('keeps 升级 for a personal %s owner', async (tier) => {
+    await renderCliTab({
+      context: workspaceContext({
+        workspaceType: 'personal',
+        teamId: undefined,
+        teamName: undefined,
+        planId: null,
+      } as unknown as Partial<WorkspaceCollabContext>),
+      accountPlan: tier,
+    });
+
+    expect(upgradePill()).toBeTruthy();
+  });
+
+  // (5) Existing behavior that must not regress (recvqfYKutwWlQ): billing is
+  // owner-only, so a member never sees the affordance even on an upgradeable
+  // tier.
+  it('still hides 升级 for a team_pro member without canManageBilling', async () => {
+    await renderCliTab({
+      context: workspaceContext({
+        role: 'member',
+        planId: 'team_pro',
+        permissions: MEMBER_PERMISSIONS,
+      } as unknown as Partial<WorkspaceCollabContext>),
+      accountPlan: 'free',
+    });
+
+    expect(upgradePill()).toBeNull();
+  });
+});

--- a/apps/web/tests/team-plan.test.ts
+++ b/apps/web/tests/team-plan.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest';
 import type { WorkspaceBillingSummary, WorkspaceCollabContext } from '@open-design/contracts';
 
 import {
+  canUpgradeFromPlanTier,
   hasTeamPlan,
   isFreePlanTier,
   isTeamPlanTier,
+  isTopPlanTier,
   resolvePlanLabelTier,
   resolvePlanTier,
 } from '../src/collab/team-plan';
@@ -170,6 +172,68 @@ describe('isFreePlanTier', () => {
   it('rejects the personal paid tiers', () => {
     for (const tier of ['pro', 'plus', 'max']) {
       expect(isFreePlanTier(tier)).toBe(false);
+    }
+  });
+});
+
+// Product ruling (owner, from a real packaged client on Team Max):
+// 「个人档位都是要显示可升级的, 最顶的就是团队 max」. Team and personal tiers are
+// two ladders — personal `max` tops only the personal one and still has the
+// whole team ladder above it.
+describe('isTopPlanTier', () => {
+  it('recognises the team ladder’s max, including a billing-period suffix', () => {
+    for (const tier of ['team_max', 'TEAM_MAX', 'team-max', ' team_max ', 'team_max_yearly']) {
+      expect(isTopPlanTier(tier)).toBe(true);
+    }
+  });
+
+  it('never reads a PERSONAL max as the top tier', () => {
+    for (const tier of ['max', 'MAX', ' max ']) {
+      expect(isTopPlanTier(tier)).toBe(false);
+    }
+  });
+
+  it('rejects team tiers below max', () => {
+    for (const tier of ['team', 'team_basic', 'team_plus', 'team_pro']) {
+      expect(isTopPlanTier(tier)).toBe(false);
+    }
+  });
+
+  it('rejects an unknown or empty tier', () => {
+    for (const tier of ['', '   ', null, undefined]) {
+      expect(isTopPlanTier(tier)).toBe(false);
+    }
+  });
+});
+
+describe('canUpgradeFromPlanTier', () => {
+  it('offers an upgrade for every tier that has one above it', () => {
+    for (const tier of [
+      'free',
+      'plus',
+      'pro',
+      // The case a careless fix breaks: a personal Max user can still move onto
+      // a team plan (vela #1146 routes their click to the Team upgrade dialog).
+      'max',
+      'team',
+      'team_basic',
+      'team_plus',
+      'team_pro',
+    ]) {
+      expect(canUpgradeFromPlanTier(tier)).toBe(true);
+    }
+  });
+
+  it('offers nothing at the top tier', () => {
+    for (const tier of ['team_max', 'TEAM_MAX', 'team-max', 'team_max_yearly']) {
+      expect(canUpgradeFromPlanTier(tier)).toBe(false);
+    }
+  });
+
+  // Fails closed while billing is unresolved, so a slow read cannot flash a CTA.
+  it('offers nothing for an unknown tier', () => {
+    for (const tier of ['', '   ', null, undefined]) {
+      expect(canUpgradeFromPlanTier(tier)).toBe(false);
     }
   });
 });


### PR DESCRIPTION
## Why

Reported by the product owner from a real packaged client: on **Team Max** — the top team tier, with nothing above it — the client still shows an 「升级」 button in two places. Clicking it can only reopen the plan they already hold.

I picked this up as a bug follow-up, not a feature. The pain is a dead-end CTA on the highest-paying tier: it reads as "there is more to buy" to exactly the customers for whom there isn't, and on the Settings card it directly contradicts the `Max` badge sitting next to it.

The two surfaces got there two different ways, and neither shared a rule with the other — which is the real debt here. A tier rule duplicated per entry point is how this recurs.

- **Account menu** (`EntryNavRail.tsx`) gated on `billingUpgradeUrl && canManageBilling` — a destination check and a permission check, with **no tier check at all**. Every tier saw the button.
- **Settings → 本机 CLI → Open Design card** (`SettingsDialog.tsx`) asked a personal-ladder question (`canUpgradeVelaPlan`) about `amrCardStatus.account.plan` — vela's **ACCOUNT-scoped** login projection, which reports `free` for a user whose entitlement is held by a team workspace. So a `team_max` owner measured as "free" and got the button, while the `PlanBadge` beside it correctly read `Max` off the workspace-resolved tier.

Both now ask one predicate, `canUpgradeFromPlanTier`, about the same resolved tier each surface already **labels** — so the button can never contradict the nameplate next to it.

Team and personal tiers are two ladders, so the new predicate reads the team-namespaced id whole instead of stripping the `team_` prefix and asking a personal-ladder question (which cannot tell personal `max` from `team_max`). Per the product ruling — 「个人档位都是要显示可升级的, 最顶的就是团队 max」 — personal `max` **keeps** the affordance: that user can still move onto a team plan, and vela #1146 deliberately routes their click to the Team upgrade dialog for exactly that reason. Only `team_max` loses it.

## What users will see

- On **Team Max**, the 「升级」 button is gone from the account menu's plan row and from the Open Design card in Settings → 本机 CLI. Everything else on both surfaces is unchanged — the 团队版 Max label, the `Max` badge, 额度, and the balance row all stay.
- Everyone else sees no change. All personal tiers (`free` / `plus` / `pro` / **`max`**) and all team tiers below max (`team_basic` / `team_plus` / `team_pro`) keep the button, and it still goes exactly where it went before.
- Team members without billing permission still don't see it, as before.

## Surface area

- [x] **UI** — the 「升级」 affordance no longer renders on the top tier, in the account menu and the Settings local-CLI card
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (no copy change; hiding a button needs none)
- [ ] **New top-level dependency**
- [x] **Default behavior change** — `team_max` users lose an affordance they previously had, without opting in
- [ ] **None**

No CLI counterpart: this changes only whether an existing web affordance renders. It adds no capability, no endpoint, and no state — there is nothing for `od` to expose.

## Screenshots

Both entry points as reported, on Team Max (a real packaged client, account on 团队版 Max with $210.00 额度). The 「升级」 button in each is what this PR removes; nothing else on either surface changes.

> The two "before" screenshots are the ones in the owner's original report — I can't upload binary attachments through `gh`, so they need dragging in from the report. Described precisely below so the entry points are unambiguous either way.

**1. Account menu** (entry point: click the account row at the top of the left nav rail) — the billing card's first row reads 「团队版」 + the `Max` wordmark, with 「升级」 as a white pill on the right, above the 「额度 $210.00 ›」 row. **After:** that row keeps 团队版 + `Max` and loses only the pill; 额度 is untouched.

**2. Settings → 本机 CLI → the Open Design card** (entry point: 设置 in the account menu, then the 本机 CLI tab, first card in 你的 CLI) — the card header reads `Open Design` / `935902669@qq.com` `Max` `TEST` / 额度 $210.00, with a black 「✦ 升级」 pill to the left of 「Open Design Cloud 管理」. **After:** the pill is gone; the `Max` badge, `TEST` profile badge, 额度 and the 管理 button all stay put.

## Bug fix verification

Red spec first, per AGENTS.md → "Bug follow-up workflow". Five cases, in **both** surfaces:

| # | Case | Expected |
|---|---|---|
| 1 | `team_max` | button **absent** |
| 2 | `team_basic` / `team_plus` / `team_pro` | present |
| 3 | personal `max` | **present** (the case a careless fix breaks) |
| 4 | personal `free` / `plus` / `pro` | present |
| 5 | member without `canManageBilling` | absent (existing behavior) |

- Test paths:
  - `apps/web/tests/components/EntryNavRail.top-tier-upgrade.test.tsx` (account menu)
  - `apps/web/tests/components/SettingsDialog.top-tier-upgrade.test.tsx` (Settings CLI card)
  - `apps/web/tests/team-plan.test.ts` (the predicate itself)
- Red before the source change, green after: **yes**. Base is `feat/workspace-team` (this PR's target), not `main`.

**Red on base** — 3 failures, each the real defect:

```
 ❯ tests/components/EntryNavRail.top-tier-upgrade.test.tsx (9 tests | 1 failed)
     × hides 升级 for a team_max owner
AssertionError: expected <button type="button" …(1)></button> to be null
      Tests  1 failed | 8 passed (9)

 ❯ tests/components/SettingsDialog.top-tier-upgrade.test.tsx (9 tests | 2 failed)
     × hides 升级 for a team_max owner
AssertionError: expected <button class="agent-card-amr-upgrade" …>Upgrade</button> to be null
     × keeps 升级 for a personal max owner
AssertionError: expected null to be truthy
      Tests  2 failed | 7 passed (9)
```

Note the second Settings failure: on base, personal `max` was *already* wrongly hidden there (`canUpgradeVelaPlan('max') === false`), so this PR restores it per the ruling.

**Green on this branch** — 18/18:

```
 ✓ EntryNavRail.top-tier-upgrade > hides 升级 for a team_max owner
 ✓ EntryNavRail.top-tier-upgrade > keeps 升级 for a team_basic owner
 ✓ EntryNavRail.top-tier-upgrade > keeps 升级 for a team_plus owner
 ✓ EntryNavRail.top-tier-upgrade > keeps 升级 for a team_pro owner
 ✓ EntryNavRail.top-tier-upgrade > keeps 升级 for a personal max owner
 ✓ EntryNavRail.top-tier-upgrade > keeps 升级 for a personal free owner
 ✓ EntryNavRail.top-tier-upgrade > keeps 升级 for a personal plus owner
 ✓ EntryNavRail.top-tier-upgrade > keeps 升级 for a personal pro owner
 ✓ EntryNavRail.top-tier-upgrade > still hides 升级 for a team_pro member without canManageBilling
 ✓ SettingsDialog.top-tier-upgrade > hides 升级 for a team_max owner
 ✓ SettingsDialog.top-tier-upgrade > keeps 升级 for a team_basic owner
 ✓ SettingsDialog.top-tier-upgrade > keeps 升级 for a team_plus owner
 ✓ SettingsDialog.top-tier-upgrade > keeps 升级 for a team_pro owner
 ✓ SettingsDialog.top-tier-upgrade > keeps 升级 for a personal max owner
 ✓ SettingsDialog.top-tier-upgrade > keeps 升级 for a personal free owner
 ✓ SettingsDialog.top-tier-upgrade > keeps 升级 for a personal plus owner
 ✓ SettingsDialog.top-tier-upgrade > keeps 升级 for a personal pro owner
 ✓ SettingsDialog.top-tier-upgrade > still hides 升级 for a team_pro member without canManageBilling

 Test Files  2 passed (2)
      Tests  18 passed (18)
```

**Mutation-tested the guard**, so the specs are known to bite:

- *Collapse the two ladders* (drop the `isTeamPlanTier` check — i.e. "max is the top wherever it sits", the careless fix): **case 3 dies in both surfaces** plus 2 predicate unit tests — 4 failed / 40 passed.
- *Invert the guard* (`return isTopPlanTier(...)`): **cases 1, 2, 3 and 4 die in both surfaces** — 16 failed / 2 passed. Only case 5 survives, correctly, since permission is gated independently of tier.

## Validation

Node 24.18.0 throughout.

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/web test` — **543 files, 5521 passed, 11 skipped, 0 failed** (includes the pre-existing neighbours `EntryNavRail.billing-card.test.tsx`, `SettingsDialog.execution.test.tsx`'s two `recvqfYKutwWlQ` upgrade-permission cases, and `providers/daemon-amr-models.test.ts`)

## Adjacent issues (not fixed here — deliberately out of scope)

1. **Two more copies of the tier rule** still strip the `team_` prefix and ask the personal-ladder question: `AvatarMenu.tsx` (`amrCanUpgrade`, ~line 264) and `InlineModelSwitcher.tsx` (~line 645). Neither renders an 「升级」 button — they decide whether a **plan-gated model row** routes to the plans page — so they are a different affordance with a different product question, and for team tiers they happen to land on the right answer today (`team_max` → hidden, `team_pro` → shown). They *do* diverge from this ruling for personal `max` (hidden there). Left alone rather than silently changing a surface the owner didn't report; worth its own decision + red spec.
2. **`Max` vs `团队版 Max` badge**: not a tier-source bug. Both read the same **workspace-level** tier — Settings via `resolvePlanTier({ billing: workspaceBilling, context, accountPlan })` (workspace-projected billing and context outrank the account plan) and the account menu via `billing.membershipTier || context.planId`. The difference is purely presentational: the account menu renders a plan-**family** label (`团队版`) alongside the wordmark, the Settings card renders only the badge next to the email. The account-scoped read was in the *gate*, not the badge, and that is what this PR removes.
