### PR TITLE
fix(web): keep Send alive after using a community template

### DIFF
--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -76,7 +76,11 @@ import type {
 } from '../types';
 import { inlineMentionToken, mentionTokenPresent } from '../utils/inlineMentions';
 import { smoothScrollToTop } from '../utils/smoothScrollToTop';
-import { missingRequiredInputs, pluginInputsAreValid } from '../utils/pluginRequiredInputs';
+import {
+  missingRequiredInputs,
+  pluginInputsAreValid,
+  requiredInputsAreUserFillable,
+} from '../utils/pluginRequiredInputs';
 import { HomeHero, type ExamplePromptInfo, type HomeHeroHandle } from './HomeHero';
 import { AppWashKineticGrid } from './AppWashKineticGrid';
 import { findChip, HOME_HERO_CHIPS, type HomeHeroChip } from './home-hero/chips';
@@ -2092,15 +2096,18 @@ export function HomeView({
       element: 'send_button',
     });
     let submittedActive = active;
-    if (submittedActive && !submittedActive.inputsValid) {
-      const missing = missingRequiredInputs(
-        submittedActive.inputFields,
-        submittedActive.inputs,
-      );
+    // Pre-empt the run only when the user could actually fix it here. On the
+    // seeded-brief 「使用」 path there is no field to fill, so we let the send
+    // through and report whatever the daemon decides (below).
+    if (
+      submittedActive &&
+      !submittedActive.inputsValid &&
+      requiredInputsAreUserFillable(submittedActive)
+    ) {
       setError(
-        missing.length > 0
-          ? `Fill the required plugin ${missing.length === 1 ? 'parameter' : 'parameters'} before running: ${missing.join(', ')}.`
-          : 'Fill the required plugin parameters before running.',
+        missingRequiredInputsMessage(
+          missingRequiredInputs(submittedActive.inputFields, submittedActive.inputs),
+        ),
       );
       return;
     }
@@ -2139,7 +2146,16 @@ export function HomeView({
       if (submittedActive && (!submittedActive.result || activeInputsChangedForSubmit)) {
         const result = await resolveActivePlugin(submittedActive.record, submittedPluginInputs);
         if (!result) {
-          setError(`Failed to apply ${submittedActive.record.title}. Check the plugin parameters and try again.`);
+          // The daemon is the authority on required inputs, and it rejects a
+          // missing one with MissingInputError. Name the fields it would have
+          // named instead of the generic apply failure, so the seeded-brief path
+          // (which no longer pre-empts the send) fails legibly.
+          const missing = missingRequiredInputs(submittedActive.inputFields, submittedPluginInputs);
+          setError(
+            missing.length > 0
+              ? missingRequiredInputsMessage(missing)
+              : `Failed to apply ${submittedActive.record.title}. Check the plugin parameters and try again.`,
+          );
           return;
         }
         submittedActive = { ...submittedActive, result, inputs: submittedPluginInputs };
@@ -2354,7 +2370,10 @@ export function HomeView({
         submitDisabled={
           Boolean(pendingApplyId) ||
           Boolean(pendingAuthoringChipId) ||
-          Boolean(active && !active.inputsValid)
+          // Only let missing required inputs disable Send where the user has a
+          // surface to fill them; otherwise a seeded 「使用」 brief would sit next
+          // to a permanently dead button (see requiredInputsAreUserFillable).
+          Boolean(active && !active.inputsValid && requiredInputsAreUserFillable(active))
         }
         onPickPlugin={(record, nextPrompt) => addPluginContext(record, nextPrompt)}
         onPickExamplePlugin={useExamplePlugin}
@@ -2847,6 +2866,16 @@ function estimatePluginContextItemCount(
   const atomCount = context.atoms?.length ?? 0;
   const craftCount = context.craft?.length ?? 0;
   return assetCount + mcpCount + claudePluginCount + atomCount + craftCount;
+}
+
+// Single wording for "these required plugin fields are still empty", shared by
+// the pre-submit gate and the daemon-rejection path so both read identically.
+// Wording is unchanged from the original pre-submit gate — see the PR's copy
+// follow-up note: this string is hardcoded English and has no i18n key yet.
+function missingRequiredInputsMessage(missing: string[]): string {
+  return missing.length > 0
+    ? `Fill the required plugin ${missing.length === 1 ? 'parameter' : 'parameters'} before running: ${missing.join(', ')}.`
+    : 'Fill the required plugin parameters before running.';
 }
 
 function hydratePluginInputs(

--- a/apps/web/src/utils/pluginRequiredInputs.ts
+++ b/apps/web/src/utils/pluginRequiredInputs.ts
@@ -14,6 +14,16 @@ function hasValue(value: unknown): boolean {
   return value !== undefined && value !== null && value !== '';
 }
 
+/** Required fields with neither a provided value nor a usable default. */
+function unsatisfiedRequiredFields(
+  fields: InputFieldSpec[],
+  values: Record<string, unknown>,
+): InputFieldSpec[] {
+  return fields.filter((field) => (
+    field.required === true && !hasValue(values[field.name]) && !hasValue(field.default)
+  ));
+}
+
 /**
  * Names of required fields that have neither a provided value nor a usable
  * default. Field labels are preferred over names for user-facing messages.
@@ -22,14 +32,9 @@ export function missingRequiredInputs(
   fields: InputFieldSpec[],
   values: Record<string, unknown>,
 ): string[] {
-  const missing: string[] = [];
-  for (const field of fields) {
-    if (field.required !== true) continue;
-    if (hasValue(values[field.name])) continue;
-    if (hasValue(field.default)) continue;
-    missing.push(field.label?.trim() || field.name);
-  }
-  return missing;
+  return unsatisfiedRequiredFields(fields, values).map(
+    (field) => field.label?.trim() || field.name,
+  );
 }
 
 /** True when every required field is satisfied by a value or a default. */
@@ -38,4 +43,48 @@ export function pluginInputsAreValid(
   values: Record<string, unknown>,
 ): boolean {
   return missingRequiredInputs(fields, values).length === 0;
+}
+
+/** True when `{{name}}` appears in the tracked query template. */
+function templateReferencesInput(template: string, name: string): boolean {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\-]/g, '\\$&');
+  return new RegExp(`\\{\\{\\s*${escaped}\\s*\\}\\}`).test(template);
+}
+
+/**
+ * True when every still-unsatisfied required input has somewhere the user can
+ * actually type it — the only condition under which gating Send on those inputs
+ * is a guard rather than a dead end.
+ *
+ * Two surfaces can fill a required field on Home:
+ *  - `mediaSurface`: the media composer renders its fields as real controls, so a
+ *    blanked required field is one edit away from valid.
+ *  - a tracked `queryTemplate` that actually contains the field as a
+ *    `{{placeholder}}`: editing the hydrated value in the composer writes back
+ *    into `inputs` (see `extractPluginInputsFromPrompt`). A template that never
+ *    mentions the field cannot fill it, no matter how much the user types — which
+ *    is why this checks the placeholders rather than merely that a template
+ *    exists.
+ *
+ * Otherwise the fields are unreachable. This composer has no inline
+ * plugin-inputs form (removed in #3645, see the note above), so a template whose
+ * `od.useCase.query` carries no `{{...}}` placeholders — the 「使用」 path, where a
+ * complete self-contained brief is already seeded — leaves the user with nothing
+ * to edit and Send permanently dead under a tooltip telling them to type
+ * something. The gate stands down there and the daemon stays the authority
+ * (`validateInputs` in apps/daemon/src/plugins/apply.ts still throws
+ * MissingInputError), so the failure is reported rather than pre-empted.
+ */
+export function requiredInputsAreUserFillable(active: {
+  mediaSurface: unknown;
+  queryTemplate: string | null;
+  inputFields: InputFieldSpec[];
+  inputs: Record<string, unknown>;
+}): boolean {
+  if (active.mediaSurface !== null) return true;
+  const template = active.queryTemplate;
+  if (!template) return false;
+  return unsatisfiedRequiredFields(active.inputFields, active.inputs).every((field) =>
+    templateReferencesInput(template, field.name),
+  );
 }

--- a/apps/web/tests/components/HomeView.template-use-send-enabled.test.tsx
+++ b/apps/web/tests/components/HomeView.template-use-send-enabled.test.tsx
@@ -1,0 +1,378 @@
+// @vitest-environment jsdom
+
+// Community-template "Use" must land the composer in a sendable state.
+//
+// Clicking 「使用」 on a community template detail dialog routes through
+// HomeView.routePluginUse('use-with-query'), which seeds the composer with the
+// template's own brief and binds the template as the run's driver. For a
+// template whose `od.inputs` are `required: true` with no `default` (the real
+// `example-html-ppt-pitch-deck` ships three such fields) the bind left
+// `active.inputsValid === false`, and `submitDisabled` folded that into the
+// send button — so the user saw a full prompt next to a permanently dead Send
+// whose tooltip still read "Type something to run". Typing did not help: the
+// gate was never about the prompt.
+//
+// The fields have no input surface on that path at all. #3645 removed the Home
+// composer's inline plugin-inputs form, and a template whose query carries no
+// `{{...}}` placeholders has no prompt -> inputs write-back either, so the gate
+// asked for values the user could not supply anywhere. It now stands down
+// exactly there, and stays where it is still meaningful (a tracked
+// `queryTemplate`, or the media composer's own fields). The daemon remains the
+// authority — `validateInputs` still throws MissingInputError — so these specs
+// also pin that a daemon rejection reads as the missing fields rather than a
+// generic apply failure.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { HomeView } from '../../src/components/HomeView';
+import { createPluginUseHandoff } from '../../src/components/home-hero/plugin-authoring';
+import { I18nProvider } from '../../src/i18n';
+import { writeHomeGuideStage } from '../../src/components/home-hero/firstRunGuide';
+
+const BASE = {
+  version: '0.1.0',
+  trust: 'bundled' as const,
+  sourceKind: 'bundled' as const,
+  capabilitiesGranted: ['prompt:inject'],
+  installedAt: 0,
+  updatedAt: 0,
+};
+
+// Shaped after plugins/_official/examples/html-ppt-pitch-deck/open-design.json:
+// three required fields with a `placeholder` but no `default`, and a useCase
+// query that carries no `{{...}}` placeholders (so the seed comes from the
+// description and no queryTemplate is tracked -> no write-back surface).
+const PITCH_DECK = {
+  ...BASE,
+  id: 'example-html-ppt-pitch-deck',
+  title: 'Write a Demo Day Pitch like a Top Accelerator Partner',
+  source: '/tmp/pitch-deck',
+  fsPath: '/tmp/pitch-deck',
+  manifest: {
+    name: 'example-html-ppt-pitch-deck',
+    title: 'Write a Demo Day Pitch like a Top Accelerator Partner',
+    version: '0.1.0',
+    description: 'A decision-grade fundraising pitch deck for accelerator partners and angels.',
+    od: {
+      kind: 'scenario',
+      mode: 'deck',
+      taskKind: 'new-generation',
+      useCase: {
+        query:
+          'Write a Demo Day pitch as a decision-grade fundraising deck. Confirm the essentials first, then produce the slide plan.',
+      },
+      inputs: [
+        {
+          name: 'one_line_pitch',
+          label: 'Name + one-line pitch',
+          type: 'text',
+          required: true,
+          placeholder: 'Company name and one sentence explaining what it does',
+        },
+        {
+          name: 'key_traction_numbers',
+          label: 'Key traction numbers',
+          type: 'text',
+          required: true,
+          placeholder: 'Revenue, growth, users, pilots, retention, pipeline',
+        },
+        {
+          name: 'ask_and_use_of_funds',
+          label: 'Ask + use of funds',
+          type: 'text',
+          required: true,
+          placeholder: 'Round size and how the capital will be used',
+        },
+      ],
+    },
+  },
+};
+
+// A second unfillable template, so "two Use in a row" swaps an unfillable bind
+// for another unfillable bind.
+const DESIGN_BRIEF = {
+  ...PITCH_DECK,
+  id: 'example-design-brief',
+  title: 'Write a Design Brief like a Studio Principal',
+  source: '/tmp/design-brief',
+  fsPath: '/tmp/design-brief',
+  manifest: {
+    ...PITCH_DECK.manifest,
+    name: 'example-design-brief',
+    title: 'Write a Design Brief like a Studio Principal',
+    description: 'A decision-grade design brief for studio engagements.',
+    od: {
+      ...PITCH_DECK.manifest.od,
+      inputs: [
+        {
+          name: 'brief',
+          label: 'Brief',
+          type: 'text',
+          required: true,
+          placeholder: 'What is being designed and why',
+        },
+      ],
+    },
+  },
+};
+
+// Control: shaped after example-fs-electric-studio — required fields that all
+// carry a `default`, so the gate is satisfied at bind time and Send was never
+// blocked. Must keep working untouched.
+const CONTROL_DECK = {
+  ...BASE,
+  id: 'example-fs-electric-studio',
+  title: 'Write a B2B SaaS Sales Proposal like a Tier-1 Enterprise AE',
+  source: '/tmp/electric-studio',
+  fsPath: '/tmp/electric-studio',
+  manifest: {
+    name: 'example-fs-electric-studio',
+    title: 'Write a B2B SaaS Sales Proposal like a Tier-1 Enterprise AE',
+    version: '0.1.0',
+    description: 'A decision-grade B2B sales deck.',
+    od: {
+      kind: 'scenario',
+      mode: 'deck',
+      taskKind: 'new-generation',
+      useCase: { query: 'Write a B2B SaaS sales proposal as a decision-grade deck.' },
+      inputs: [
+        { name: 'deckType', type: 'text', required: true, default: 'studio / agency capabilities deck' },
+        { name: 'topic', type: 'text', required: true, default: "the user's brief" },
+        { name: 'audience', type: 'text', required: true, default: 'a general professional audience' },
+      ],
+    },
+  },
+};
+
+// The gate must SURVIVE where the user can still act: this query carries a
+// `{{topic}}` placeholder, so examplePresetSeedPrompt returns the rendered query
+// and HomeView tracks its `queryTemplate` — editing the hydrated value in the
+// composer writes back into `active.inputs`. Required-and-blank must keep
+// blocking Send here.
+const WRITE_BACK_PLUGIN = {
+  ...BASE,
+  id: 'write-back-plugin',
+  title: 'Write Back Plugin',
+  source: '/tmp/write-back',
+  fsPath: '/tmp/write-back',
+  manifest: {
+    name: 'write-back-plugin',
+    title: 'Write Back Plugin',
+    version: '0.1.0',
+    description: '',
+    od: {
+      kind: 'scenario',
+      taskKind: 'new-generation',
+      useCase: { query: 'Build a landing page about {{topic}}.' },
+      inputs: [{ name: 'topic', type: 'text', required: true }],
+    },
+  },
+};
+
+// A tracked queryTemplate is NOT by itself an input surface. With no description
+// the seed falls through to the rendered query, so HomeView tracks that query as
+// the write-back template — but the query names no `{{...}}` placeholder, so
+// editing the composer can never reach `brief`. This is also the shape a reload
+// lands in: re-applying a plugin without an explicit queryTemplate derives one
+// from the manifest (HomeView usePlugin), placeholders or not.
+const NO_PLACEHOLDER_QUERY = {
+  ...BASE,
+  id: 'example-live-dashboard',
+  title: 'Live Dashboard',
+  source: '/tmp/live-dashboard',
+  fsPath: '/tmp/live-dashboard',
+  manifest: {
+    name: 'example-live-dashboard',
+    title: 'Live Dashboard',
+    version: '0.1.0',
+    description: '',
+    od: {
+      kind: 'scenario',
+      taskKind: 'new-generation',
+      useCase: { query: 'Build a live operations dashboard with a decision-grade layout.' },
+      inputs: [
+        { name: 'brief', label: 'Brief', type: 'text', required: true, placeholder: 'What to build' },
+      ],
+    },
+  },
+};
+
+const ALL = [PITCH_DECK, DESIGN_BRIEF, CONTROL_DECK, WRITE_BACK_PLUGIN, NO_PLACEHOLDER_QUERY];
+
+function hasValue(value: unknown): boolean {
+  return value !== undefined && value !== null && value !== '';
+}
+
+// Mirrors the daemon: apps/daemon/src/plugins/apply.ts validateInputs rejects a
+// required field with neither a posted value nor a default.
+function stubFetch() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+      const href = typeof url === 'string' ? url : String(url);
+      const json = (body: unknown, status = 200) =>
+        new Response(JSON.stringify(body), {
+          status,
+          headers: { 'content-type': 'application/json' },
+        });
+      if (href === '/api/plugins') return json({ plugins: ALL });
+      const applyMatch = /^\/api\/plugins\/([^/]+)\/apply$/.exec(href);
+      if (applyMatch) {
+        const record = ALL.find((entry) => entry.id === decodeURIComponent(applyMatch[1]!));
+        const posted = (JSON.parse(String(init?.body ?? '{}')) as { inputs?: Record<string, unknown> })
+          .inputs ?? {};
+        const fields = record?.manifest.od.inputs ?? [];
+        const missing = fields
+          .filter((field) => field.required === true)
+          .filter((field) => !hasValue(posted[field.name]) && !hasValue((field as { default?: unknown }).default))
+          .map((field) => field.name);
+        if (missing.length > 0) return json({ error: 'missing_inputs', fields: missing }, 400);
+        return json({
+          ok: true,
+          snapshotId: `snap-${record?.id}`,
+          appliedPlugin: { id: record?.id, title: record?.title, inputs: posted },
+          inputs: fields,
+          contextItems: [],
+        });
+      }
+      return json({});
+    }),
+  );
+}
+
+function renderHome(handoffId: number, pluginId: string) {
+  return render(
+    <I18nProvider initial="en">
+      <HomeView
+        projects={[]}
+        onSubmit={() => undefined}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+        promptHandoff={createPluginUseHandoff(handoffId, pluginId, { action: 'use-with-query' })}
+      />
+    </I18nProvider>,
+  );
+}
+
+// The reported state was permanent ("等半天了都发送不了"), so every assertion
+// below is taken after the bind has settled AND after a further quiet period —
+// an early frame would prove nothing either way.
+async function settle(ms = 400) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function boundSubmit() {
+  const submit = (await screen.findByTestId('home-hero-submit')) as HTMLButtonElement;
+  await waitFor(() => {
+    expect(screen.getByTestId('home-hero-active-plugin')).toBeTruthy();
+  });
+  await settle();
+  return submit;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  cleanup();
+  window.localStorage.clear();
+});
+
+describe('community template Use lands a sendable composer', () => {
+  it('enables Send after Use on a template whose required inputs have no default', async () => {
+    writeHomeGuideStage('done');
+    stubFetch();
+
+    renderHome(1, PITCH_DECK.id);
+    const submit = await boundSubmit();
+
+    // The brief really is in the composer, so the send has content.
+    expect(screen.getByTestId('home-hero-active-plugin').textContent).toContain(
+      'Write a Demo Day Pitch',
+    );
+    expect(submit.disabled).toBe(false);
+    expect(submit.getAttribute('data-tooltip')).not.toBe('Type something to run');
+    expect(submit.getAttribute('data-tooltip')).toBe('Run');
+  });
+
+  it('stays sendable across two Use clicks with different templates', async () => {
+    writeHomeGuideStage('done');
+    stubFetch();
+
+    const view = renderHome(1, PITCH_DECK.id);
+    await boundSubmit();
+
+    view.rerender(
+      <I18nProvider initial="en">
+        <HomeView
+          projects={[]}
+          onSubmit={() => undefined}
+          onOpenProject={() => undefined}
+          onViewAllProjects={() => undefined}
+          promptHandoff={createPluginUseHandoff(2, DESIGN_BRIEF.id, { action: 'use-with-query' })}
+        />
+      </I18nProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('home-hero-active-plugin').textContent).toContain(
+        'Write a Design Brief',
+      );
+    });
+    await settle();
+    const submit = screen.getByTestId('home-hero-submit') as HTMLButtonElement;
+    expect(submit.disabled).toBe(false);
+  });
+
+  it('keeps the control template (required inputs with defaults) sendable', async () => {
+    writeHomeGuideStage('done');
+    stubFetch();
+
+    renderHome(1, CONTROL_DECK.id);
+    const submit = await boundSubmit();
+    expect(submit.disabled).toBe(false);
+  });
+
+  it('enables Send when a template is tracked but names no fillable placeholder', async () => {
+    writeHomeGuideStage('done');
+    stubFetch();
+
+    // A queryTemplate exists here, so "a template is tracked" is not enough to
+    // call the required field fillable — the template must actually mention it.
+    renderHome(1, NO_PLACEHOLDER_QUERY.id);
+    const submit = await boundSubmit();
+    expect(submit.disabled).toBe(false);
+  });
+});
+
+describe('required-input gate survives where the user can still fill it', () => {
+  it('keeps Send blocked while a write-back placeholder is required and blank', async () => {
+    writeHomeGuideStage('done');
+    stubFetch();
+
+    renderHome(1, WRITE_BACK_PLUGIN.id);
+    const submit = await boundSubmit();
+
+    // This template's query carries {{topic}}, so HomeView tracks a
+    // queryTemplate and editing the composer flows back into `inputs` — the
+    // gate is actionable here and must stay.
+    expect(submit.disabled).toBe(true);
+  });
+});
+
+describe('daemon rejection is legible', () => {
+  it('names the missing fields instead of a generic apply failure', async () => {
+    writeHomeGuideStage('done');
+    stubFetch();
+
+    renderHome(1, PITCH_DECK.id);
+    const submit = await boundSubmit();
+    expect(submit.disabled).toBe(false);
+
+    fireEvent.click(submit);
+
+    const alert = await waitFor(() => screen.getByRole('alert'));
+    expect(alert.textContent).toContain('Name + one-line pitch');
+    expect(alert.textContent).toContain('Key traction numbers');
+    expect(alert.textContent).toContain('Ask + use of funds');
+    expect(alert.textContent).not.toContain('Failed to apply');
+  });
+});


### PR DESCRIPTION
## Why

Reported by the product owner from a real packaged client: on the Home hero, open a community template's detail dialog and click 「使用」. The composer fills with the template's brief, a template chip appears — and the send button is permanently disabled with the tooltip 「输入内容后运行」 ("type something to run"). Their words: 「不是短暂窗口, 等半天了都发送不了」. Typing does not help, because the gate was never about the prompt.

The pain is a hard dead end on the primary discovery path. 「使用」 is how users start from a community template, and for the affected templates it cannot be recovered from inside the composer — the only escape is clearing the chip, which also discards the seeded brief.

Root cause: `plugins/_official/examples/html-ppt-pitch-deck/open-design.json` declares three inputs (`one_line_pitch`, `key_traction_numbers`, `ask_and_use_of_funds`) as `required: true` with **no `default`** — only a `placeholder`, which is a hint, not a value. Binding via 「使用」 leaves `active.inputsValid` false (`HomeView.tsx:1016`, `:1074-1079`), and `submitDisabled` folded that straight into the send button (`HomeView.tsx:2354-2358`), so `canSubmit` (`HomeHero.tsx:419-420`) was false no matter what the user typed.

Two facts make this a dead end rather than a guard, and they are the whole justification for the change:

1. **The fields have no input surface anywhere on this path.** #3645 (`8920577f4`) removed the Home composer's inline plugin-inputs form — its own docblock in `apps/web/src/utils/pluginRequiredInputs.ts` says so — and the template's `od.useCase.query` carries no `{{...}}` placeholders, so the prompt→inputs write-back (`extractPluginInputsFromPrompt`) can never fill them either. The owner's reaction: 「界面上有什么地方能输入的吗? 界面上不就一个输入框吗?」
2. **The prompt is already complete and self-contained.** Measured on a live runtime: the composer text equals the template's own brief and matches the chip. The send has real content; only the unfillable check blocked it.

Worth noting what this is *not*: the placeholder carousel is not involved. `使用` passes `explicitPick: true` (`HomeView.tsx:1277`) → `activePluginIsExplicit` (`:910-923`) → `carouselActive` false (`HomeHero.tsx:477-486`), so the carousel is unmounted and its pool-membership check never runs.

## What users will see

Clicking 「使用」 on a community template now leaves the send button live, so the seeded brief can actually be sent. Previously it sat dead under a tooltip telling users to type something, and typing changed nothing.

Where a template genuinely needs facts the platform cannot infer, pressing Send now names them — "Fill the required plugin parameters before running: Name + one-line pitch, Key traction numbers, Ask + use of funds." — instead of the previous generic "Failed to apply …". So the block is legible and tells the user what is missing.

Nothing changes for templates that already worked, and the plugin form flow still refuses to run with a required field empty.

Affected templates (13 of 460 installed plugins have required inputs with no default; 5 are user-facing): `example-html-ppt-pitch-deck`, `example-design-brief`, `example-live-dashboard`, `example-saas-landing`, `example-waitlist-page`. The remaining 8 are internal `od-*` routers that receive their inputs from type chips.

**Honest limitation — please read.** This removes the dead button and makes the failure legible; it does not make the pitch-deck template *complete a run*. The daemon still rejects the apply (verified below: HTTP 422 `missing_inputs`), because `validateInputs` remains the authority as ruled. Finishing the job needs either defaults in those manifests or a surface that collects the three facts — both deliberately out of scope here.

## Surface area

- [x] **UI** — Home composer send-button enablement and the submit error text it surfaces
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — a bound template with unfillable required inputs no longer disables Send; the pre-submit gate now applies only where the user can act on it
- [ ] **None**

## Screenshots

Live runtime (`tools-dev`, `--namespace tpl-send`, zh-CN), same path as the owner's report — community 融资路演 → first card → 「使用」:

**Before** (on base) — prompt seeded, chip bound, Send dead:

```
submitDisabled : true
submitTooltip  : 输入内容后运行
chipText       : 像顶级加速器合伙人一样写 Demo Day 路演
editorText     : 像顶级加速器合伙人一样写 Demo Day 路演——一份可商业交付的融资路演 Deck，围绕真实主题、证据链与决策目标组织。
carouselPresent: false
```

Typing real content did not help, which is the part that cost the owner an afternoon:

```
editorText    : ...决策目标组织。 我要做一个给投资人看的路演
submitDisabled: true
submitTooltip : 输入内容后运行
```

**After** (this branch), same click:

```
submitDisabled : false
tooltip        : 运行
chip           : 像顶级加速器合伙人一样写 Demo Day 路演
text           : 像顶级加速器合伙人一样写 Demo Day 路演——一份可商业交付的融资路演 Deck，围绕真实主题、证据链与决策目标组织。
```

I did not attach a PNG: the dialog and composer are unchanged visually, and the whole delta is the button's disabled state plus the error string, which the captured DOM state above shows precisely. Happy to add one if a reviewer prefers.

## Bug fix verification

- Test path: `apps/web/tests/components/HomeView.template-use-send-enabled.test.tsx`
- Red before the source change, green after: **yes**. Written first and run against unmodified source.

Red run (before any source edit) — exactly the three specs that should fail did, all on `submit.disabled`:

```
FAIL > enables Send after Use on a template whose required inputs have no default
  AssertionError: expected true to be false
  ❯ 263:  expect(submit.disabled).toBe(false);
FAIL > stays sendable across two Use clicks with different templates
  ❯ 294:  expect(submit.disabled).toBe(false);
FAIL > names the missing fields instead of a generic apply failure
  ❯ 329:  expect(submit.disabled).toBe(false);

Test Files  1 failed | 541 passed (542)
     Tests  3 failed | 5498 passed | 11 skipped (5512)
```

The control-template and gate-survives specs **passed in the red run** — they pin behaviour that must not change, so the fix could not be "delete the check".

Green after the fix:

```
Test Files  542 passed (542)
     Tests  5502 passed | 11 skipped (5513)
```

Coverage, mapped to the ruling:

1. 「使用」 on a pitch-deck-shaped template → Send enabled and tooltip is `Run`, not `Type something to run`. Asserted after the bind settles **and** a further quiet period, since the reported state was permanent.
2. Two 「使用」 in a row with different templates → still sendable.
3. Control template (required inputs *with* defaults, shaped after `example-fs-electric-studio`) → still sendable.
4. Gate survives where it is meaningful: a template whose query carries `{{topic}}` keeps Send blocked while `topic` is required and blank — editing the prompt writes back there, so the gate is actionable.
5. A daemon rejection surfaces the missing field labels, not a generic apply failure.
6. A tracked query template that names no fillable placeholder is still sendable (the reload / plugin-only-Use shape, see below).

**Mutation tests.** Both halves of the discriminator are load-bearing:

- Mutation A — revert the whole narrowing (`return true`): specs 1, 2, 5, 6 go red; the two guard specs stay green.
- Mutation B — treat a merely-tracked template as fillable: **only** spec 6 goes red, isolating the placeholder refinement.

**A hole I found in my own first attempt, worth calling out.** My initial discriminator was "a `queryTemplate` is tracked". Real-client testing caught that this is wrong: on reload the plugin is re-applied without an explicit template, so `HomeView.tsx:1021-1024` derives one from the manifest — non-null, but containing no `{{...}}` placeholders. Send was still dead after a reload. The final check therefore verifies the template actually *names* each unsatisfied field. Spec 6 pins it.

**Existing test at `HomeView.prompt-example-send-pulse.test.tsx:98`.** It asserts Send stays disabled for a required-input plugin, and I deliberately left it **unchanged** — it still passes. Its fixture ships `useCase: { query: 'Build a landing page about {{topic}}.' }`, so a template is tracked *and* names the missing field: editing the composer writes back, the gate is actionable, and disabling Send remains correct there. The narrowing is precise enough that no edit was needed, which is a better outcome than rewriting the assertion.

## Validation

- `pnpm guard` — exit 0
- `pnpm typecheck` — exit 0
- `pnpm --filter @open-design/web test` — exit 0, 542 files / 5502 passed / 11 skipped
- Node 24.18.0 throughout (Node 22 miscompiles `better-sqlite3`)
- Not cited as evidence: `pnpm --filter @open-design/daemon typecheck` (`server.ts` is `@ts-nocheck`)

**Real-client acceptance** on `tools-dev run web --daemon-port 17670 --web-port 17671 --namespace tpl-send`, driving the real UI in zh-CN:

- 「使用」 on the Demo Day template → Send clickable, tooltip 「运行」, chip and prompt agree.
- Pressing Send — what the daemon actually returned:
  ```
  POST /api/plugins/example-html-ppt-pitch-deck/apply
    sent   : {"inputs":{},"grantCaps":[],"locale":"zh-CN"}
    status : 422
    body   : {"error":"missing_inputs","fields":["one_line_pitch","key_traction_numbers","ask_and_use_of_funds"]}
  ```
  and the composer showed: `Fill the required plugin parameters before running: Name + one-line pitch, Key traction numbers, Ask + use of funds.` — server-side validation intact, failure legible, labels rather than raw field names.
- Two 「使用」 in a row with different templates → Send stays enabled.
- Control template end-to-end: apply `200` → project created (`Write a B2B SaaS Sales Proposal like a Tier-1 Enterprise AE`) → conversation created → Claude run started. No regression.
- Reload with a template bound → Send enabled (the hole described above).

## Follow-ups for maintainer ruling

1. **Copy gap (no new keys added here, per instruction).** The missing-fields message is hardcoded English with no i18n key, and now reaches users on a path where it previously could not. It needs a key across the 19 locales, and probably better wording than "Fill the required plugin parameters before running" for a composer that has no parameter fields.
2. **The tooltip is still wrong in the narrow case where Send is legitimately disabled** — 「输入内容后运行」 is right for an empty composer, but the plugin-form case shows it too. Wording is the owner's call.
3. **The 5 user-facing templates still cannot complete a run** until the required facts are collectable or defaulted. That is the substantive remainder of this bug.
4. **Adjacent, not fixed here:** `use-with-query` *appends* the new template's brief to whatever is in the composer (`HomeView.tsx:1219-1221`, `:1250-1256`), so after two 「使用」 the prompt holds both briefs while the chip names only the second. This is what produced the chip/text mismatch in the original report, and it means a run can be sent with a prompt whose leading paragraph belongs to a template that is no longer bound. Own red spec, own PR.
