### PR TITLE
fix(web): move the update-ready rocket above the rail account row

### DIFF
--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -112,8 +112,18 @@ interface Props {
   onInvite?: () => void;
   /** Start the cloud sign-in / team flow from the local-state callout. */
   onSignInCloud?: () => void;
-  /** Extra controls pinned to the bottom-left of the rail. */
-  footerExtra?: ReactNode;
+  /**
+   * The update-ready host (`UpdaterPopup`), which renders nothing until the
+   * updater reports a downloaded, unopened installer.
+   *
+   * It rides the RIGHT EDGE OF THE ACCOUNT ROW, on the same line as the name
+   * and plan wordmark (`.entry-nav-rail__account-row`). #5517 parked it in the rail
+   * footer when the entry topbar was removed, which put the rocket on its own
+   * line underneath the account row; product read that as wrong placement.
+   * The footer stays as the fallback home for the signed-out shell, which has
+   * no account row to ride.
+   */
+  updaterSlot?: ReactNode;
   /** Optional notice shown above the footer controls. */
   footerNotice?: ReactNode;
 }
@@ -458,7 +468,7 @@ export function EntryNavRail({
   billing,
   balanceUsd,
   onOpenSettings,
-  footerExtra,
+  updaterSlot,
   footerNotice,
 }: Props) {
   const { t } = useI18n();
@@ -484,6 +494,13 @@ export function EntryNavRail({
   const displayName = context?.displayName?.trim() || '';
   const accountName = displayName || brandLabel;
   const accountInitial = accountName.charAt(0).toUpperCase() || '·';
+
+  // The updater host has exactly one home on screen at a time. The account row
+  // is the preferred one (right edge of the name + plan wordmark line); the
+  // footer only takes it when there is no cloud identity, because the whole
+  // account row is absent then. Deriving both from one expression is what keeps
+  // "exactly one" true — two independent renders would double the rocket.
+  const footerUpdaterSlot = context ? null : updaterSlot;
 
   // Billing chip: prefer the real summary metadata; fall back to the context
   // plan-tier hint when metadata has not loaded. Money is a separate,
@@ -754,27 +771,37 @@ export function EntryNavRail({
             onMouseEnter={cancelAccountClose}
             onMouseLeave={scheduleAccountClose}
           >
-            <button
-              ref={accountTriggerRef}
-              type="button"
-              className="entry-nav-rail__account-trigger"
-              onClick={() => setAccountOpen((v) => !v)}
-              onMouseEnter={openAccountMenu}
-              aria-expanded={accountOpen}
-              data-testid="entry-nav-account"
-            >
-              <span className="entry-nav-rail__account-avatar" aria-hidden>
-                {accountInitial}
-                {messageUnreadCount > 0 ? (
-                  <span className="entry-nav-rail__account-avatar-dot" data-testid="account-avatar-unread-dot" />
-                ) : null}
-              </span>
-              <span className="entry-nav-rail__account-name">{accountName}</span>
-              {/* #5517: the plan badge replaces the chevron when a tier is
-                  known — the standalone credits chip row is gone; credits
-                  live in the account menu's billing card. */}
-              {planTier ? <PlanWordmark tier={planTier} height={17} /> : <Icon name="chevron-down" size={14} />}
-            </button>
+            {/* Identity line: avatar + name + plan wordmark, with the
+                update-ready rocket parked at its right edge. The rocket is a
+                SIBLING of the trigger, never a child — nesting a button inside
+                the account button would make every rocket click also toggle
+                the account menu. */}
+            <div className="entry-nav-rail__account-row" data-testid="entry-nav-account-row">
+              <button
+                ref={accountTriggerRef}
+                type="button"
+                className="entry-nav-rail__account-trigger"
+                onClick={() => setAccountOpen((v) => !v)}
+                onMouseEnter={openAccountMenu}
+                aria-expanded={accountOpen}
+                data-testid="entry-nav-account"
+              >
+                <span className="entry-nav-rail__account-avatar" aria-hidden>
+                  {accountInitial}
+                  {messageUnreadCount > 0 ? (
+                    <span className="entry-nav-rail__account-avatar-dot" data-testid="account-avatar-unread-dot" />
+                  ) : null}
+                </span>
+                <span className="entry-nav-rail__account-name">{accountName}</span>
+                {/* #5517: the plan badge replaces the chevron when a tier is
+                    known — the standalone credits chip row is gone; credits
+                    live in the account menu's billing card. */}
+                {planTier ? <PlanWordmark tier={planTier} height={17} /> : <Icon name="chevron-down" size={14} />}
+              </button>
+              {updaterSlot ? (
+                <div className="entry-nav-rail__account-row-slot">{updaterSlot}</div>
+              ) : null}
+            </div>
             {accountOpen ? (
               <>
                 {/* No backdrop here (unlike the team menu): hover-open relies
@@ -1237,11 +1264,16 @@ export function EntryNavRail({
         )}
       </div>
       {/* Skip the footer entirely when it has nothing to show — an empty
-          shell here read as a dead white strip under the account row. */}
-      {footerNotice || footerExtra ? (
+          shell here read as a dead white strip under the account row.
+          `footerUpdaterSlot` is only ever set in the signed-out shell: with a
+          cloud identity the updater host rides the account row instead (see
+          `updaterSlot`), so the footer must not render a second host. */}
+      {footerNotice || footerUpdaterSlot ? (
         <div className="entry-nav-rail__footer">
           {footerNotice}
-          {footerExtra ? <div className="entry-rail-actions">{footerExtra}</div> : null}
+          {footerUpdaterSlot ? (
+            <div className="entry-rail-actions">{footerUpdaterSlot}</div>
+          ) : null}
         </div>
       ) : null}
       </div>

--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -116,12 +116,12 @@ interface Props {
    * The update-ready host (`UpdaterPopup`), which renders nothing until the
    * updater reports a downloaded, unopened installer.
    *
-   * It rides the RIGHT EDGE OF THE ACCOUNT ROW, on the same line as the name
-   * and plan wordmark (`.entry-nav-rail__account-row`). #5517 parked it in the rail
-   * footer when the entry topbar was removed, which put the rocket on its own
-   * line underneath the account row; product read that as wrong placement.
-   * The footer stays as the fallback home for the signed-out shell, which has
-   * no account row to ride.
+   * It lives in a right-aligned strip IMMEDIATELY ABOVE the account row
+   * (`.entry-nav-rail__account-updater`), per product: 「名字那个横条的上方,
+   * 靠右对齐」. #5517 parked it in the rail footer when the entry topbar was
+   * removed, which put the rocket UNDER the account row instead. The footer
+   * stays as the fallback home for the signed-out shell, which has no account
+   * row to sit above.
    */
   updaterSlot?: ReactNode;
   /** Optional notice shown above the footer controls. */
@@ -495,11 +495,11 @@ export function EntryNavRail({
   const accountName = displayName || brandLabel;
   const accountInitial = accountName.charAt(0).toUpperCase() || '·';
 
-  // The updater host has exactly one home on screen at a time. The account row
-  // is the preferred one (right edge of the name + plan wordmark line); the
-  // footer only takes it when there is no cloud identity, because the whole
-  // account row is absent then. Deriving both from one expression is what keeps
-  // "exactly one" true — two independent renders would double the rocket.
+  // The updater host has exactly one home on screen at a time. The strip above
+  // the account row is the preferred one; the footer only takes it when there is
+  // no cloud identity, because the whole account row is absent then. Deriving
+  // both from one expression is what keeps "exactly one" true — two independent
+  // renders would double the rocket.
   const footerUpdaterSlot = context ? null : updaterSlot;
 
   // Billing chip: prefer the real summary metadata; fall back to the context
@@ -771,37 +771,40 @@ export function EntryNavRail({
             onMouseEnter={cancelAccountClose}
             onMouseLeave={scheduleAccountClose}
           >
-            {/* Identity line: avatar + name + plan wordmark, with the
-                update-ready rocket parked at its right edge. The rocket is a
-                SIBLING of the trigger, never a child — nesting a button inside
-                the account button would make every rocket click also toggle
-                the account menu. */}
-            <div className="entry-nav-rail__account-row" data-testid="entry-nav-account-row">
-              <button
-                ref={accountTriggerRef}
-                type="button"
-                className="entry-nav-rail__account-trigger"
-                onClick={() => setAccountOpen((v) => !v)}
-                onMouseEnter={openAccountMenu}
-                aria-expanded={accountOpen}
-                data-testid="entry-nav-account"
-              >
-                <span className="entry-nav-rail__account-avatar" aria-hidden>
-                  {accountInitial}
-                  {messageUnreadCount > 0 ? (
-                    <span className="entry-nav-rail__account-avatar-dot" data-testid="account-avatar-unread-dot" />
-                  ) : null}
-                </span>
-                <span className="entry-nav-rail__account-name">{accountName}</span>
-                {/* #5517: the plan badge replaces the chevron when a tier is
-                    known — the standalone credits chip row is gone; credits
-                    live in the account menu's billing card. */}
-                {planTier ? <PlanWordmark tier={planTier} height={17} /> : <Icon name="chevron-down" size={14} />}
-              </button>
-              {updaterSlot ? (
-                <div className="entry-nav-rail__account-row-slot">{updaterSlot}</div>
-              ) : null}
+            {/* Right-aligned strip directly above the identity row — the
+                update-ready rocket's home. It is mounted unconditionally so it
+                stays the trigger's immediately-preceding sibling, and it holds
+                no element children until the updater actually has something to
+                show; `:empty { display: none }` is what keeps an idle strip
+                from reserving a row's worth of height above the account.
+
+                The rocket must never be a DESCENDANT of the trigger below:
+                a button inside the account button would be invalid markup and
+                would make every rocket click toggle the account menu too. */}
+            <div className="entry-nav-rail__account-updater" data-testid="entry-nav-account-updater">
+              {updaterSlot}
             </div>
+            <button
+              ref={accountTriggerRef}
+              type="button"
+              className="entry-nav-rail__account-trigger"
+              onClick={() => setAccountOpen((v) => !v)}
+              onMouseEnter={openAccountMenu}
+              aria-expanded={accountOpen}
+              data-testid="entry-nav-account"
+            >
+              <span className="entry-nav-rail__account-avatar" aria-hidden>
+                {accountInitial}
+                {messageUnreadCount > 0 ? (
+                  <span className="entry-nav-rail__account-avatar-dot" data-testid="account-avatar-unread-dot" />
+                ) : null}
+              </span>
+              <span className="entry-nav-rail__account-name">{accountName}</span>
+              {/* #5517: the plan badge replaces the chevron when a tier is
+                  known — the standalone credits chip row is gone; credits
+                  live in the account menu's billing card. */}
+              {planTier ? <PlanWordmark tier={planTier} height={17} /> : <Icon name="chevron-down" size={14} />}
+            </button>
             {accountOpen ? (
               <>
                 {/* No backdrop here (unlike the team menu): hover-open relies

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1263,11 +1263,14 @@ export function EntryShell({
   // #5517: the GitHub/Discord/X/mail badges and the settings chip leave the
   // rail footer. Socials live in the account menu, while settings stays
   // reachable through either the account menu or the signed-out rail item.
-  // The updater host also lives here (the entry topbar is gone — the rail
-  // toggle is the pinned Home tab in the workspace tabs bar), which puts the
-  // bottom-left rocket indicator in this slot; it renders nothing until the
-  // real updater reports a downloaded, unopened installer.
-  const railFooterActions = (
+  //
+  // The updater host has no topbar to live in any more (the rail toggle is the
+  // pinned Home tab in the workspace tabs bar), so the rail owns it: it renders
+  // at the right edge of the account row, falling back to the rail footer in the
+  // signed-out shell. `EntryNavRail` decides which — the shell only supplies the
+  // host, which renders nothing until the real updater reports a downloaded,
+  // unopened installer.
+  const updaterSlot = (
     <UpdaterPopup
       allowSilentUpdates={config.allowSilentUpdates}
       onAllowSilentUpdatesChange={(allowSilentUpdates) =>
@@ -1401,7 +1404,7 @@ export function EntryShell({
           onOpenSettings={onOpenSettings}
           onInvite={() => changeView('members')}
           onSignInCloud={() => navigate({ kind: 'home', view: 'onboarding' })}
-          footerExtra={railFooterActions}
+          updaterSlot={updaterSlot}
           // recvqgpXSYFNTq: `workspaceLoading` is only ever true while
           // `workspaceContext` is null (see `useWorkspaceContext`'s
           // `markLoading`, which promotes "no context" to "loading" and never

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -1266,10 +1266,10 @@ export function EntryShell({
   //
   // The updater host has no topbar to live in any more (the rail toggle is the
   // pinned Home tab in the workspace tabs bar), so the rail owns it: it renders
-  // at the right edge of the account row, falling back to the rail footer in the
-  // signed-out shell. `EntryNavRail` decides which — the shell only supplies the
-  // host, which renders nothing until the real updater reports a downloaded,
-  // unopened installer.
+  // in a right-aligned strip just above the account row, falling back to the
+  // rail footer in the signed-out shell. `EntryNavRail` decides which — the
+  // shell only supplies the host, which renders nothing until the real updater
+  // reports a downloaded, unopened installer.
   const updaterSlot = (
     <UpdaterPopup
       allowSilentUpdates={config.allowSilentUpdates}

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -5264,6 +5264,34 @@
   margin: auto 0 0;
   padding-top: var(--spacing-10);
 }
+/* Identity line inside the account container: the account-menu trigger plus,
+   at its right edge, the update-ready rocket. Both children are globally
+   styled contracts (`.entry-nav-rail__account-trigger` brings its own `flex: 1`,
+   `.entry-updater-menu` is the updater's positioning host), so this wrapper
+   stays a global selector next to them rather than a CSS Module that would need
+   `:global()` escapes to reach either one.
+
+   The rocket used to sit on its own line in `.entry-nav-rail__footer` under
+   this row (#5517 fallout). Riding the row instead also removes the layout
+   jump: the rail no longer grows a 52px footer strip the moment an update
+   lands. */
+.entry-nav-rail__account-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+/* The updater host renders nothing until an installer is downloaded and
+   unopened, so collapse the slot when it is empty — otherwise the row's `gap`
+   would pad its right edge for a control that is not there. */
+.entry-nav-rail__account-row-slot {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+}
+.entry-nav-rail__account-row-slot:empty {
+  display: none;
+}
 /* Unread-messages red dot riding the account avatar's top-right corner. */
 .entry-nav-rail__account-avatar-dot {
   position: absolute;

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -5264,32 +5264,30 @@
   margin: auto 0 0;
   padding-top: var(--spacing-10);
 }
-/* Identity line inside the account container: the account-menu trigger plus,
-   at its right edge, the update-ready rocket. Both children are globally
-   styled contracts (`.entry-nav-rail__account-trigger` brings its own `flex: 1`,
-   `.entry-updater-menu` is the updater's positioning host), so this wrapper
-   stays a global selector next to them rather than a CSS Module that would need
-   `:global()` escapes to reach either one.
+/* Update-ready strip: its own line directly above the identity row, with the
+   rocket pushed to the right edge (`flex-end` rather than a hardcoded side, so
+   RTL follows the writing direction). The rocket used to sit BELOW the account
+   row, in `.entry-nav-rail__footer` (#5517 fallout).
 
-   The rocket used to sit on its own line in `.entry-nav-rail__footer` under
-   this row (#5517 fallout). Riding the row instead also removes the layout
-   jump: the rail no longer grows a 52px footer strip the moment an update
-   lands. */
-.entry-nav-rail__account-row {
+   This stays a global selector next to the rest of the account block rather
+   than a CSS Module: its only child is `.entry-updater-menu`, itself a global
+   positioning contract, so a module would need a `:global()` escape to reach
+   it.
+
+   `:empty` is load-bearing, not tidiness. The strip is mounted unconditionally
+   so it remains the trigger's immediately-preceding sibling, and the updater
+   host renders nothing until an installer is downloaded and unopened — so
+   without this rule an idle rail would reserve a row of height plus the
+   container's 6px `gap` above the account, shifting the whole account area for
+   a control that is not there. `display: none` (not `height: 0`) is what drops
+   it out of flex layout so the `gap` collapses with it. */
+.entry-nav-rail__account-updater {
   display: flex;
   align-items: center;
-  gap: 4px;
+  justify-content: flex-end;
   min-width: 0;
 }
-/* The updater host renders nothing until an installer is downloaded and
-   unopened, so collapse the slot when it is empty — otherwise the row's `gap`
-   would pad its right edge for a control that is not there. */
-.entry-nav-rail__account-row-slot {
-  display: flex;
-  align-items: center;
-  flex: 0 0 auto;
-}
-.entry-nav-rail__account-row-slot:empty {
+.entry-nav-rail__account-updater:empty {
   display: none;
 }
 /* Unread-messages red dot riding the account avatar's top-right corner. */

--- a/apps/web/src/styles/workspace/mention-home.css
+++ b/apps/web/src/styles/workspace/mention-home.css
@@ -358,9 +358,9 @@
   z-index: 80;
   position: absolute;
   /* Anchor the panel's BOTTOM edge to the host, so it grows upward.
-     The host (`.entry-updater-menu`) is pinned to the bottom of the nav rail —
-     it rides the account row, which is the last thing in the rail — so a
-     top-anchored panel grew down past the window edge and the 「更新已就绪」
+     The host (`.entry-updater-menu`) sits near the bottom of the nav rail — in
+     the strip just above the account row, which is the last thing in the rail —
+     so a top-anchored panel grew down past the window edge and the 「更新已就绪」
      copy was clipped mid-sentence. `.entry-help-popover` already anchors this
      way for exactly the same reason. */
   bottom: 0;

--- a/apps/web/src/styles/workspace/mention-home.css
+++ b/apps/web/src/styles/workspace/mention-home.css
@@ -357,7 +357,13 @@
 .updater-popup {
   z-index: 80;
   position: absolute;
-  top: 0;
+  /* Anchor the panel's BOTTOM edge to the host, so it grows upward.
+     The host (`.entry-updater-menu`) is pinned to the bottom of the nav rail —
+     it rides the account row, which is the last thing in the rail — so a
+     top-anchored panel grew down past the window edge and the 「更新已就绪」
+     copy was clipped mid-sentence. `.entry-help-popover` already anchors this
+     way for exactly the same reason. */
+  bottom: 0;
   left: calc(100% + 12px);
   width: min(360px, calc(100vw - var(--entry-rail-width, 56px) - 24px));
   display: flex;

--- a/apps/web/tests/components/EntryNavRail.updater-above-account-row.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.updater-above-account-row.test.tsx
@@ -4,14 +4,20 @@
 //
 // #5517 removed the entry topbar and parked the updater host in the rail
 // footer, which put the rocket on its own line UNDER the account row —
-// bottom-left, detached from the identity it belongs to. Product read that as
-// wrong placement: the rocket belongs on the account row itself, at the right
-// edge of the name + plan wordmark line.
+// bottom-left, detached from the identity it belongs to. Product placed it
+// 「名字那个横条的上方,靠右对齐」: its own right-aligned strip IMMEDIATELY ABOVE
+// the account row.
 //
 // These specs pin the DOM relationship rather than any pixel value: the rocket
-// shares one row element with the account trigger, sits after it in document
-// order, and is NOT nested inside the trigger (which would both be invalid
-// markup and steal the account-menu click target).
+// lives in a strip that is the account trigger's immediately-preceding sibling,
+// inside the same account container. Right-alignment and the strip's
+// zero-height-when-empty behaviour are CSS facts (see
+// `.entry-nav-rail__account-updater` in styles/home/entry-layout.css) and are
+// verified in a real browser, not here — jsdom applies no stylesheets.
+//
+// Being a sibling rather than a descendant of the trigger is load-bearing: a
+// button nested inside the account button would be invalid markup and would
+// make every rocket click also toggle the account menu.
 
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { WorkspaceCollabContext } from '@open-design/contracts';
@@ -123,25 +129,31 @@ async function renderWithDownloadedUpdate(context: WorkspaceCollabContext | null
   return view;
 }
 
-describe('updater rocket placement on the rail account row', () => {
-  it('renders the rocket on the account row, after the name and plan wordmark', async () => {
+describe('updater rocket placement above the rail account row', () => {
+  it('renders the rocket in a strip immediately above the name + plan row', async () => {
     await renderWithDownloadedUpdate();
 
     const rocket = screen.getByTestId('entry-nav-updater');
     const trigger = screen.getByTestId('entry-nav-account');
 
-    // One shared row element owns the trigger and the rocket.
-    const row = rocket.closest('[data-testid="entry-nav-account-row"]');
-    expect(row, 'rocket must live inside the account row').not.toBeNull();
-    expect(row?.contains(trigger)).toBe(true);
+    // Its own strip, not the identity row.
+    const strip = rocket.closest('[data-testid="entry-nav-account-updater"]');
+    expect(strip, 'rocket must live in the updater strip').not.toBeNull();
+    expect(strip?.contains(trigger)).toBe(false);
 
-    // The name + plan wordmark are on that same line, and the rocket follows
-    // them (right edge of the row), not the other way round.
-    const name = row?.querySelector('.entry-nav-rail__account-name');
-    expect(name?.textContent).toBe('XINYU SHANG');
+    // ABOVE the identity row: same account container, and the strip is the
+    // trigger's immediately-preceding sibling — nothing may slip between them.
+    const account = trigger.closest('.entry-nav-rail__account');
+    expect(account?.contains(strip as Node)).toBe(true);
+    expect(trigger.previousElementSibling).toBe(strip);
     expect(
-      trigger.compareDocumentPosition(rocket) & Node.DOCUMENT_POSITION_FOLLOWING,
+      rocket.compareDocumentPosition(trigger) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
+
+    // The identity row itself still carries the name and the plan wordmark.
+    expect(trigger.querySelector('.entry-nav-rail__account-name')?.textContent).toBe(
+      'XINYU SHANG',
+    );
 
     // The rail footer is no longer the rocket's host.
     expect(rocket.closest('.entry-nav-rail__footer')).toBeNull();
@@ -156,13 +168,14 @@ describe('updater rocket placement on the rail account row', () => {
     // Never nested inside the trigger: that would be a button inside a button
     // and every rocket click would also toggle the account menu.
     expect(rocket.closest('[data-testid="entry-nav-account"]')).toBeNull();
+    expect(trigger.contains(rocket)).toBe(false);
 
     fireEvent.click(trigger);
     await waitFor(() => expect(screen.getByTestId('account-menu-message-center')).toBeTruthy());
     expect(trigger.getAttribute('aria-expanded')).toBe('true');
   });
 
-  it('renders no rocket anywhere while no update is in flight', async () => {
+  it('leaves an empty strip above the row while no update is in flight', async () => {
     restoreHost = installMockOpenDesignHost({
       host: { updater: { status: vi.fn(async () => idleStatus()) } },
     });
@@ -176,9 +189,14 @@ describe('updater rocket placement on the rail account row', () => {
     expect(screen.queryByTestId('updater-rocket-glyph')).toBeNull();
     // The account row still renders its identity — only the rocket is absent.
     expect(screen.getByTestId('entry-nav-account')).toBeTruthy();
+    // The strip stays mounted but must hold NO element children, which is what
+    // lets `:empty { display: none }` keep it from reserving vertical space and
+    // shifting the account area. A stray wrapper here would defeat that rule.
+    const strip = screen.getByTestId('entry-nav-account-updater');
+    expect(strip.children.length).toBe(0);
   });
 
-  it('falls back to the rail footer when there is no account row to ride', async () => {
+  it('falls back to the rail footer when there is no account row to sit above', async () => {
     // Local (no cloud identity) shell: the account row is not rendered at all,
     // so the rocket must keep its footer home instead of disappearing.
     await renderWithDownloadedUpdate(null);

--- a/apps/web/tests/components/EntryNavRail.updater-in-account-row.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.updater-in-account-row.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+//
+// Placement contract for the update-ready rocket.
+//
+// #5517 removed the entry topbar and parked the updater host in the rail
+// footer, which put the rocket on its own line UNDER the account row —
+// bottom-left, detached from the identity it belongs to. Product read that as
+// wrong placement: the rocket belongs on the account row itself, at the right
+// edge of the name + plan wordmark line.
+//
+// These specs pin the DOM relationship rather than any pixel value: the rocket
+// shares one row element with the account trigger, sits after it in document
+// order, and is NOT nested inside the trigger (which would both be invalid
+// markup and steal the account-menu click target).
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { WorkspaceCollabContext } from '@open-design/contracts';
+import type { OpenDesignHostUpdaterStatusSnapshot } from '@open-design/host';
+import { installMockOpenDesignHost } from '@open-design/host/testing';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EntryNavRail, resetWorkspaceDirectoryCache } from '../../src/components/EntryNavRail';
+import { UpdaterPopup } from '../../src/components/UpdaterPopup';
+import { I18nProvider } from '../../src/i18n';
+
+function teamContext(): WorkspaceCollabContext {
+  return {
+    workspaceId: 'ws-team',
+    workspaceType: 'team',
+    workspaceMemberId: 'wm-1',
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+    billingState: 'active',
+    planId: 'team_plus',
+    displayName: 'XINYU SHANG',
+    seatSummary: { seatLimit: 5, usedSeats: 1, availableSeats: 4, isSeatFull: false },
+    permissions: { canInviteMembers: true, canViewWorkspaceSettings: true },
+  } as unknown as WorkspaceCollabContext;
+}
+
+function idleStatus(): OpenDesignHostUpdaterStatusSnapshot {
+  return {
+    arch: 'arm64',
+    capabilities: {
+      canApplyInPlace: false,
+      canDownload: true,
+      canOpenInstaller: true,
+      requiresManualInstall: true,
+    },
+    channel: 'beta',
+    currentVersion: '0.16.2-beta.145',
+    enabled: true,
+    mode: 'package-launcher',
+    platform: 'darwin',
+    state: 'idle',
+    supported: true,
+  };
+}
+
+function downloadedStatus(): OpenDesignHostUpdaterStatusSnapshot {
+  return {
+    ...idleStatus(),
+    availableVersion: '0.16.2-beta.146',
+    downloadPath: '/tmp/open-design-updater/Open Design Beta.dmg',
+    state: 'downloaded',
+  };
+}
+
+function renderRail(context: WorkspaceCollabContext | null) {
+  return render(
+    <I18nProvider initial="zh-CN">
+      <EntryNavRail
+        view="home"
+        onViewChange={() => {}}
+        onNewProject={() => {}}
+        open
+        context={context}
+        billing={null}
+        updaterSlot={<UpdaterPopup />}
+      />
+    </I18nProvider>,
+  );
+}
+
+function stubFetch() {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/messages?')) {
+        return Response.json({ messages: [], nextCursor: null, unreadCount: 0 });
+      }
+      if (url.includes('/status')) return Response.json({ loggedIn: false });
+      return Response.json({ items: [] });
+    }),
+  );
+}
+
+let restoreHost: (() => void) | null = null;
+
+beforeEach(() => {
+  localStorage.clear();
+  resetWorkspaceDirectoryCache();
+  stubFetch();
+});
+
+afterEach(() => {
+  cleanup();
+  restoreHost?.();
+  restoreHost = null;
+  resetWorkspaceDirectoryCache();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+async function renderWithDownloadedUpdate(context: WorkspaceCollabContext | null = teamContext()) {
+  restoreHost = installMockOpenDesignHost({
+    host: { updater: { status: vi.fn(async () => downloadedStatus()) } },
+  });
+  const view = renderRail(context);
+  await screen.findByTestId('entry-nav-updater');
+  return view;
+}
+
+describe('updater rocket placement on the rail account row', () => {
+  it('renders the rocket on the account row, after the name and plan wordmark', async () => {
+    await renderWithDownloadedUpdate();
+
+    const rocket = screen.getByTestId('entry-nav-updater');
+    const trigger = screen.getByTestId('entry-nav-account');
+
+    // One shared row element owns the trigger and the rocket.
+    const row = rocket.closest('[data-testid="entry-nav-account-row"]');
+    expect(row, 'rocket must live inside the account row').not.toBeNull();
+    expect(row?.contains(trigger)).toBe(true);
+
+    // The name + plan wordmark are on that same line, and the rocket follows
+    // them (right edge of the row), not the other way round.
+    const name = row?.querySelector('.entry-nav-rail__account-name');
+    expect(name?.textContent).toBe('XINYU SHANG');
+    expect(
+      trigger.compareDocumentPosition(rocket) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    // The rail footer is no longer the rocket's host.
+    expect(rocket.closest('.entry-nav-rail__footer')).toBeNull();
+  });
+
+  it('keeps the account-menu trigger clickable with the rocket present', async () => {
+    await renderWithDownloadedUpdate();
+
+    const rocket = screen.getByTestId('entry-nav-updater');
+    const trigger = screen.getByTestId('entry-nav-account');
+
+    // Never nested inside the trigger: that would be a button inside a button
+    // and every rocket click would also toggle the account menu.
+    expect(rocket.closest('[data-testid="entry-nav-account"]')).toBeNull();
+
+    fireEvent.click(trigger);
+    await waitFor(() => expect(screen.getByTestId('account-menu-message-center')).toBeTruthy());
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('renders no rocket anywhere while no update is in flight', async () => {
+    restoreHost = installMockOpenDesignHost({
+      host: { updater: { status: vi.fn(async () => idleStatus()) } },
+    });
+
+    renderRail(teamContext());
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByTestId('entry-nav-updater')).toBeNull();
+    expect(screen.queryByTestId('updater-rocket-glyph')).toBeNull();
+    // The account row still renders its identity — only the rocket is absent.
+    expect(screen.getByTestId('entry-nav-account')).toBeTruthy();
+  });
+
+  it('falls back to the rail footer when there is no account row to ride', async () => {
+    // Local (no cloud identity) shell: the account row is not rendered at all,
+    // so the rocket must keep its footer home instead of disappearing.
+    await renderWithDownloadedUpdate(null);
+
+    const rocket = screen.getByTestId('entry-nav-updater');
+    expect(screen.queryByTestId('entry-nav-account')).toBeNull();
+    expect(rocket.closest('.entry-nav-rail__footer')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Why

Product reported this from a real client. Their words: 「绿色小火箭位置不对,要放到名字啥的上面的右侧」, clarified on follow-up as 「应该是在名字那个横条的上方,靠右对齐」. And, opening the same report, 「更新弹窗看不到了」.

The green rocket — the update-ready indicator — was sitting at the **bottom-left of the sidebar, on its own line UNDERNEATH the account row**, detached from the identity it belongs to. #5517 removed the entry topbar and parked the updater host in the rail *footer*, which is what put it there. It belongs in its own right-aligned strip **above** the 「XINYU SHANG」 + plan-wordmark row.

The same report showed a second symptom: the 「更新已就绪」 prompt was **clipped at the bottom of the window**, its text cut off mid-sentence. Same root cause — the host is pinned near the bottom of the rail, and the panel was anchored by its `top` edge, so it grew downward off-screen.

## What users will see

- The green rocket now sits in its own line **directly above** the account row, **right-aligned** — its right edge flush with the plan wordmark's. Measured at 1280×900: rocket `right: 215`, account trigger `right: 215`.
- **Nothing shifts when no update is pending.** The strip collapses to zero height, so the rail is pixel-identical to today for every user without a pending update. Verified: the account trigger occupies y `850–884` in *both* states.
- Clicking the rocket opens the 「更新已就绪」 prompt **growing upward**, so the whole card — version line, channel badge, the silent-update checkbox, and both 稍后 / 安装更新 buttons — is inside the window instead of cut off at the bottom edge. Measured: panel `top: 649, bottom: 844` in a 900px viewport, `fullyVisible: true`.
- The rail also stops jumping when an update lands: it used to grow a ~52px footer strip that pushed the account row up.
- Nothing about **when** the rocket appears changed. It still renders only once the real updater reports a downloaded, unopened installer, and it still does the same open-installer → quit handoff. In the signed-out (no cloud identity) shell there is no account row at all, so it keeps its footer home there.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

Placement only — no copy changes, no new i18n keys, no change to the updater's trigger logic or the update flow. Five files, all under `apps/web`. `apps/daemon` untouched.

### Why the mount moved instead of a CSS nudge

`EntryShell` used to hand the rail a `footerExtra` node that happened to be the `UpdaterPopup`. The rail now takes it as `updaterSlot` and decides where it lives:

- signed in → `.entry-nav-rail__account-updater`, a right-aligned strip that is the account trigger's **immediately-preceding sibling** inside `.entry-nav-rail__account`;
- signed out → the rail footer, unchanged, because there is no account row to sit above.

Both homes derive from one expression (`const footerUpdaterSlot = context ? null : updaterSlot`) so "exactly one rocket on screen" is structural rather than something two independent renders have to agree on. Positioning the rocket over a neighbouring container from the footer would have broken the next time either element changed.

Two details are load-bearing rather than cosmetic:

1. **The strip is mounted unconditionally**, so it can't stop being the trigger's preceding sibling. The `UpdaterPopup` inside it returns `null` until there is something to show.
2. **`:empty { display: none }`** — *not* `height: 0`. `display: none` drops the strip out of flex layout entirely, so the account container's `gap: 6px` collapses with it. Without this, every user without a pending update would get a blank 34px row plus 6px of gap pushing the account area up.

The new selector is global, in `styles/home/entry-layout.css` next to the rest of the account block, rather than a CSS Module: its only child is `.entry-updater-menu`, itself a global positioning contract, so a module wrapper would need a `:global()` escape to reach it. `EntryNavRail.module.css` also turns out to be an orphan (nothing has imported it since `0868aea24`), so importing it for one class would have shipped ~200 lines of dead CSS.

## Screenshots

Captured on a real `tools-dev` runtime at 1280×900 (see Validation for how the update state was produced).

| state | what it shows |
| --- | --- |
| `rocket-A-no-update.png` | No update pending — rail identical to today, no reserved strip. |
| `rocket-B-above-row-zoom.png` | Rocket in its own strip above 「XINYU SHANG」 + PLUS, right-aligned. |
| `rocket-C-prompt-open.png` | 「更新已就绪」 fully visible: title, both body lines, Beta channel badge, checkbox, 稍后 + 安装更新. |

Measured geometry from the same run:

```
no update:   strip display:none, height 0, rocket absent
             account trigger  top 850  bottom 884
downloaded:  strip            top 810  bottom 844  right 215  justify-content: flex-end
             rocket           top 810  bottom 844  right 215
             account trigger  top 850  bottom 884   ← unchanged
prompt open: panel  top 649  bottom 844  (viewport 900)  fullyVisible: true
             checkbox bottom 776, 安装更新 bottom 825 — all inside
```

## Bug fix verification

- Test path: `apps/web/tests/components/EntryNavRail.updater-above-account-row.test.tsx`
- Red before the source change, green after? **yes, twice** — the placement was corrected mid-flight, so there are two red/green cycles. Assertions pin the DOM relationship (same account container, strip is the trigger's `previousElementSibling`, rocket not a descendant of the trigger, strip holds zero element children when idle), never a pixel value. Right-alignment and the collapse-when-empty behaviour are CSS facts and are verified in the browser numbers above, not in jsdom.

Cycle 1 — rocket in the footer (pre-change `footerExtra` API). The rocket renders, just not where product wants it:

```
 × renders the rocket … 27ms
AssertionError: rocket must live inside the account row: expected null not to be null
      Tests  1 failed | 3 passed (4)
```

Cycle 2 — after the placement correction, red against the intermediate head that put the rocket *inside* the row:

```
 × renders the rocket in a strip immediately above the name + plan row 28ms
 ✓ keeps the account-menu trigger clickable with the rocket present 11ms
 × leaves an empty strip above the row while no update is in flight 4ms
 ✓ falls back to the rail footer when there is no account row to sit above 3ms

AssertionError: rocket must live in the updater strip: expected null not to be null
TestingLibraryElementError: Unable to find an element by: [data-testid="entry-nav-account-updater"]
      Tests  2 failed | 2 passed (4)
```

Green, final:

```
 ✓ tests/components/EntryNavRail.updater-above-account-row.test.tsx (4 tests) 48ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

## Validation

Node 24.18.0 throughout.

- `pnpm guard` — pass (exit 0).
- `pnpm --filter @open-design/web typecheck` — pass (exit 0).
- `pnpm --filter @open-design/web test` — **549 files passed, 5539 passed / 11 skipped, 0 failed**, run on this head. (`apps/web/tests/components/FileWorkspace.design-system.test.tsx`, flagged as flaky, passed too.)
- Real runtime — `pnpm tools-dev run web --namespace rocket-pos --daemon-port 17700 --web-port 17701`, real daemon, screenshots and geometry above. The rocket only exists in a packaged desktop client, so to reach the state I mocked `GET /api/workspace/context` with a signed-in team identity and injected a `window.__od__` desktop bridge whose updater reports `state: 'downloaded'` — the same shape `e2e/ui/*` uses. Update state was flipped between the two measurements through a `localStorage` flag the injected bridge reads, so both measurements come from one page and are directly comparable.

## Adjacent issues (not fixed here)

1. **The entry topbar's CSS is dead.** Nothing renders `.entry-main__topbar` any more (`e2e/ui/entry-topbar.test.ts` even asserts `toHaveCount(0)`), so `styles/home/entry-layout.css`'s `.entry-main__topbar:has(.updater-popup)` stacking lift and `styles/workspace/mention-home.css`'s two `.entry-main__topbar .entry-updater-menu .updater-popup` overrides are unreachable. Left in place deliberately rather than deleted quietly — the cleanup spans several stylesheets plus two live `querySelector('.entry-main__topbar')` calls in `InlineModelSwitcher.tsx` and two e2e tests, so it wants its own PR.
2. **`e2e/ui/updater-popup-stacking.test.ts` cannot pass on base.** Its fake host bridge omits `updater['clear-cache']`, `updater.setMenuLabels`, and `updater.subscribeOpenDialog`, all of which `isOpenDesignHostBridge` (`packages/host/src/detection.ts`) requires — so `isOpenDesignHostAvailable()` is false and the rocket it clicks can never render. Its `overlapArea > 0` geometry precondition also assumes a topbar-anchored panel that no longer exists. It is in **no CI lane** (`e2e/lib/playwright/suites.ts` lists neither it nor any group containing it), which is presumably why this went unnoticed. That is a genuine test-infrastructure hole, not just a stale fixture.
3. **`.entry-nav-rail__footer .entry-nav-rail__account`** in `entry-layout.css`, and the footer collapse-cascade comment above it, both describe a layout where the account row lived in the footer. It lives in `.entry-nav-rail__group` (`order: 99`) now, so both are stale.
4. **`EntryNavRail.module.css` is an orphan** — added in `0868aea24`, never imported by anything.
5. **`Playwright visual (entry-navigation)` was not run**, so I can't say whether its baseline shifts. It screenshots this exact rail, so it may legitimately need a baseline update — but note it only shifts *if those tests put an update in flight*, and given (2) above they likely cannot make the rocket appear at all. Worth checking rather than assuming either way.

## Notes for anyone else working in a fresh worktree on this repo

Three traps cost most of a session; recording them so they are not rediscovered.

1. **`node_modules` in the main checkout is borrowed from another worktree** (`/Users/elian/Documents/od-wt-console-dashboard`) — its symlinks point out of the repo. A hard-link copy (`cp -al`) into a new worktree happens to resolve because the relative depth matches, but you must then repoint every `od-wt-console-dashboard` symlink at your own worktree, or workspace packages (`@open-design/contracts`, `host`, `components`, …) silently resolve to *that* worktree's source instead of yours.
2. **`better-sqlite3` there is compiled for Node 22** (`NODE_MODULE_VERSION 127`), and `tools-dev` hard-refuses to run under anything but Node 24, so a borrowed `apps/daemon/node_modules/better-sqlite3` deadlocks: Node 24 can't load the binary, Node 22 can't start `tools-dev`. The fix is not a rebuild — a locally-copied `.pnpm/better-sqlite3@12.10.0` already carries a Node-24 binary; only the symlink was pointing at the wrong one.
3. **A fresh worktree needs three builds before `tools-dev` will start**, and the failures are misleading — `Failed to resolve entry for package "@open-design/contracts"`, then `[tools-dev] dist entries not found`:

```bash
pnpm --filter "@open-design/daemon^..." build
pnpm --filter "@open-design/web^..." build
pnpm --filter @open-design/tools-dev build
```

And when faking the desktop host bridge in any test or harness, include `updater['clear-cache']`, `updater.setMenuLabels`, and `updater.subscribeOpenDialog` — see (2) under Adjacent issues.
