### PR TITLE
fix(web): stop the home model list offering picks the chip cannot honor

### DIFF
--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -7,7 +7,11 @@ import { useT } from '../i18n';
 import { AgentIcon } from './AgentIcon';
 import { modelProviderIconSrc } from './modelProviderIcon';
 import { RemixIcon } from './RemixIcon';
-import { defaultAgentModelId, effectiveAgentModelChoice } from './agentModelSelection';
+import {
+  agentModelIsSelectable,
+  defaultAgentModelId,
+  effectiveAgentModelChoice,
+} from './agentModelSelection';
 import { orderModelOptionsByAvailability } from './modelOptions';
 import type { AgentInfo, AppConfig, ExecMode, ProviderModelOption } from '../types';
 import {
@@ -404,8 +408,14 @@ export function AvatarMenu({
                           : currentAgentModelOptions
                         ).map((model) => {
                           const active = model.id === currentModelId;
-                          const locked =
-                            currentAgent.id === 'amr' && model.enabled === false;
+                          // Same gate the home composer's compact list asks —
+                          // one definition of "locked", derived from what the
+                          // config will actually keep, so the two surfaces
+                          // cannot drift apart again.
+                          const locked = !agentModelIsSelectable(
+                            currentAgent,
+                            model.id,
+                          );
                           return (
                             <button
                               key={model.id}

--- a/apps/web/src/components/InlineModelSwitcher.tsx
+++ b/apps/web/src/components/InlineModelSwitcher.tsx
@@ -19,6 +19,7 @@ import {
   type SetStateAction,
 } from 'react';
 import type { AmrWalletSnapshot } from '@open-design/contracts';
+import { VisuallyHidden } from '@open-design/components';
 import { useT } from '../i18n';
 import {
   agentIdToTracking,
@@ -73,6 +74,7 @@ import {
 } from './amrLoginPolling';
 import { orderAgentsWithOpenDesignFirst } from './agentOrdering';
 import {
+  agentModelIsSelectable,
   defaultAgentModelId,
   effectiveAgentModelChoice,
   normalizeAgentModelChoice,
@@ -579,6 +581,72 @@ export function InlineModelSwitcher({
     if (currentAgent?.id !== 'amr') return models;
     return orderModelOptionsByAvailability(models);
   }, [currentAgent]);
+
+  /**
+   * The ONLY path from a model row to `onAgentModelChange` in this component.
+   * Both model lists (the compact home list and the execution-settings picker)
+   * write through here, so the availability gate cannot be forgotten by a list
+   * added later — there is no second sink to forget it in. Returns false when
+   * the pick was refused, which is the signal a row should not close the panel
+   * or report a selection that did not happen.
+   */
+  const applyAgentModel = useCallback(
+    (modelId: string, extra?: { serviceTier?: string }) => {
+      const agentId = currentAgent?.id;
+      if (!agentId) return false;
+      if (!agentModelIsSelectable(currentAgent, modelId)) return false;
+      onAgentModelChange?.(agentId, { model: modelId, ...extra });
+      return true;
+    },
+    [currentAgent, onAgentModelChange],
+  );
+
+  /**
+   * Compact-list rows carry the same verdict the sink enforces, so a locked row
+   * is rendered as locked instead of as a normal row whose click silently
+   * reverts (issue: clicking a model in the home list did nothing).
+   */
+  const compactModelRows = useMemo(
+    () =>
+      inlineAgentModelOptions.map((model) => ({
+        model,
+        selectable: agentModelIsSelectable(currentAgent, model.id),
+      })),
+    [currentAgent, inlineAgentModelOptions],
+  );
+
+  /** Where a refused model pick sends the user instead — the same plans
+   *  destination the settings picker's upgrade lock already opens. */
+  const openAmrModelUpgrade = useCallback(() => {
+    const attribution = recordAmrEntry(
+      analytics.track,
+      'inline_amr_upgrade',
+      new Date(),
+      { metricsConsent: config.telemetry?.metrics === true },
+    );
+    const deviceId = amrHandoffDeviceId({
+      metricsConsent: config.telemetry?.metrics === true,
+      resolvedDeviceId: getResolvedDeviceId(),
+      installationId: config.installationId,
+    });
+    window.open(
+      attributedAmrUrl(
+        amrPlansUrlForProfile(
+          amrStatus?.profile ?? config.agentCliEnv?.amr?.OPEN_DESIGN_AMR_PROFILE,
+        ),
+        attribution,
+        deviceId,
+      ),
+      '_blank',
+      'noopener,noreferrer',
+    );
+  }, [
+    amrStatus?.profile,
+    analytics.track,
+    config.agentCliEnv?.amr?.OPEN_DESIGN_AMR_PROFILE,
+    config.installationId,
+    config.telemetry?.metrics,
+  ]);
   const amrLoggedIn = amrStatus?.loggedIn === true;
 
   useEffect(() => {
@@ -981,21 +1049,39 @@ export function InlineModelSwitcher({
             // names (no header, no agent icons) — switching agents lives in
             // the execution settings entry below.
             <div className="inline-switcher__row">
-              {currentAgent && (currentAgent.models?.length ?? 0) > 0 ? (
+              {currentAgent && compactModelRows.length > 0 ? (
                 <div className="inline-switcher__agent-grid" role="radiogroup">
-                  {(currentAgent.models ?? []).map((m) => {
+                  {compactModelRows.map(({ model: m, selectable }) => {
                     const active = currentModelId === m.id;
+                    // A model above the caller's plan is shown, but honestly:
+                    // disabled with the reason the settings picker already uses,
+                    // never as a normal row whose click gets reverted.
+                    const lockedHint = selectable
+                      ? null
+                      : t('settings.amrModelUpgradeHint');
                     return (
                       <div key={m.id} className="inline-switcher__agent-row">
                         <button
                           type="button"
                           role="radio"
                           aria-checked={active}
+                          aria-disabled={selectable ? undefined : 'true'}
+                          title={lockedHint ?? undefined}
                           className={
-                            'inline-switcher__agent' + (active ? ' is-active' : '')
+                            'inline-switcher__agent' +
+                            (active ? ' is-active' : '') +
+                            (selectable ? '' : ' is-locked')
                           }
                           data-testid={`inline-model-switcher-compact-model-${m.id}`}
                           onClick={() => {
+                            // The sink is the authority, not the row's styling:
+                            // a refused pick routes to the plans page (same as
+                            // the settings picker's lock) instead of writing a
+                            // choice the config would revert.
+                            if (!applyAgentModel(m.id)) {
+                              if (amrCanUpgrade) openAmrModelUpgrade();
+                              return;
+                            }
                             trackExecutionSettingsPopoverClick(analytics.track, {
                               page_name: 'home',
                               area: 'execution_settings_popover',
@@ -1003,7 +1089,6 @@ export function InlineModelSwitcher({
                               execution_mode: 'local_cli',
                               model_id: modelIdForTracking(m.id),
                             });
-                            onAgentModelChange?.(currentAgent.id, { model: m.id });
                             setOpen(false);
                           }}
                         >
@@ -1028,6 +1113,15 @@ export function InlineModelSwitcher({
                           <span className="inline-switcher__agent-name">
                             {m.label}
                           </span>
+                          {lockedHint ? (
+                            <span
+                              className="inline-switcher__agent-lock"
+                              data-testid={`inline-model-switcher-compact-model-lock-${m.id}`}
+                            >
+                              <Icon name="lock" size={12} />
+                              <VisuallyHidden>{lockedHint}</VisuallyHidden>
+                            </span>
+                          ) : null}
                         </button>
                       </div>
                     );
@@ -1255,16 +1349,21 @@ export function InlineModelSwitcher({
                     groupByCompany={currentAgent?.id === 'amr'}
                     value={currentModelId ?? ''}
                     onChange={(nextValue) => {
+                      // Same sink as the compact list — `serviceTier: undefined`
+                      // is load-bearing here: `mergeAgentModelChoice` reads the
+                      // own property to DROP a stale tier from the previous
+                      // model, so the key must survive the hand-off.
+                      if (
+                        !applyAgentModel(nextValue, { serviceTier: undefined })
+                      ) {
+                        return;
+                      }
                       trackExecutionSettingsPopoverClick(analytics.track, {
                         page_name: 'home',
                         area: 'execution_settings_popover',
                         element: 'model_dropdown',
                         execution_mode: 'local_cli',
                         model_id: modelIdForTracking(nextValue),
-                      });
-                      onAgentModelChange?.(currentAgent.id, {
-                        model: nextValue,
-                        serviceTier: undefined,
                       });
                     }}
                     additionalOptions={
@@ -1289,36 +1388,7 @@ export function InlineModelSwitcher({
                     }
                     onDisabledOptionUpgrade={
                       currentAgent?.id === 'amr'
-                        ? () => {
-                            const attribution = recordAmrEntry(
-                              analytics.track,
-                              'inline_amr_upgrade',
-                              new Date(),
-                              {
-                                metricsConsent:
-                                  config.telemetry?.metrics === true,
-                              },
-                            );
-                            const deviceId = amrHandoffDeviceId({
-                              metricsConsent:
-                                config.telemetry?.metrics === true,
-                              resolvedDeviceId: getResolvedDeviceId(),
-                              installationId: config.installationId,
-                            });
-                            window.open(
-                              attributedAmrUrl(
-                                amrPlansUrlForProfile(
-                                  amrStatus?.profile ??
-                                    config.agentCliEnv?.amr
-                                      ?.OPEN_DESIGN_AMR_PROFILE,
-                                ),
-                                attribution,
-                                deviceId,
-                              ),
-                              '_blank',
-                              'noopener,noreferrer',
-                            );
-                          }
+                        ? openAmrModelUpgrade
                         : undefined
                     }
                   />

--- a/apps/web/src/components/agentModelSelection.ts
+++ b/apps/web/src/components/agentModelSelection.ts
@@ -47,3 +47,38 @@ export function effectiveAgentModelChoice(
 ): AgentModelChoice | undefined {
   return normalizeAgentModelChoice(agent, choice) ?? choice;
 }
+
+/**
+ * Whether `modelId` may be OFFERED to the user as a selectable model.
+ *
+ * This is the single definition of "locked" for every model-list surface — the
+ * home composer's compact list, the execution-settings picker, and the project
+ * composer's `AvatarMenu` list all ask it instead of re-deriving the rule. Only
+ * AMR's catalog carries plan entitlement (`enabled: false` is what `vela model
+ * list --json` reports for a model above the caller's plan); every other agent's
+ * list is its own model ids and stays fully selectable.
+ *
+ * The invariant that makes it safe: this predicate is AT LEAST as strict as
+ * `normalizeAgentModelChoice`. Every model normalization would coerce away is
+ * unselectable here, so a surface that gates its rows on this can never offer a
+ * pick that gets written and then silently reverted — which is exactly what the
+ * compact list shipped with: the click was accepted, re-normalized back to the
+ * default, and the chip snapped to the previous model with no explanation.
+ * `agentModelSelection.test.ts` pins the strictness relation directly, so a
+ * future change to either function that broke it would fail rather than quietly
+ * reopen the silent-revert hole.
+ */
+export function agentModelIsSelectable(
+  agent: AgentModelSource,
+  modelId: string | null | undefined,
+): boolean {
+  if (!modelId) return false;
+  if (agent?.id !== 'amr') return true;
+  if (modelId === 'default') return true;
+  const models = agent.models ?? [];
+  // No catalog yet (vela not queried) — nothing to gate against, and no surface
+  // can render a row for a model it has not been told about.
+  if (models.length === 0) return true;
+  const option = models.find((model) => model.id === modelId) ?? null;
+  return option !== null && option.enabled !== false;
+}

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -1870,13 +1870,29 @@
   background: var(--bg-subtle);
   color: var(--text-strong);
 }
+/* A model above the caller's plan. It stays listed (so the catalog still reads
+   as complete) but must LOOK unavailable: rendering it as a normal row was the
+   whole bug — the click was accepted and then silently reverted. Matches the
+   project composer's `.avatar-model-option.is-locked`. */
+.inline-switcher--compact .inline-switcher__agent.is-locked {
+  color: var(--text-muted);
+  opacity: 0.6;
+}
+.inline-switcher__agent-lock {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-muted);
+}
 /* Each row now leads with the provider logo, so the old leading selection dot
    is dropped — the active row reads from its tinted background alone. */
 /* Hovering an unselected model slides its label forward as a "reach". */
 .inline-switcher--compact .inline-switcher__agent-name {
   transition: transform 160ms cubic-bezier(0.23, 1, 0.32, 1);
 }
-.inline-switcher--compact .inline-switcher__agent:not(.is-active):hover .inline-switcher__agent-name {
+.inline-switcher--compact
+  .inline-switcher__agent:not(.is-active):not(.is-locked):hover
+  .inline-switcher__agent-name {
   transform: translateX(6px);
 }
 @media (prefers-reduced-motion: reduce) {

--- a/apps/web/tests/components/InlineModelSwitcher.compact-model-click.test.tsx
+++ b/apps/web/tests/components/InlineModelSwitcher.compact-model-click.test.tsx
@@ -1,0 +1,279 @@
+// @vitest-environment jsdom
+//
+// Home composer chip → compact model list → click a model. The chip MUST show
+// the clicked model.
+//
+// The reported bug: the owner clicked `claude-opus-4.6` in the compact list and
+// the chip stayed on `deepseek-v4-flash`. The list offered a model that is above
+// the caller's plan (`enabled: false` from `vela model list --json`) as a plain
+// selectable row; the click was accepted, written to config, and then coerced
+// straight back by `normalizeAgentModelChoice` + the re-normalization effect in
+// `InlineModelSwitcher` — so the click read as a no-op.
+//
+// Every assertion here is on the user-visible chip label, never on whether a
+// callback fired: the callback fires today and the chip still does not move.
+// The switcher does not own persistence — `App.handleAgentModelChange` does — so
+// these specs wire the real merge/persist shape around the component and let the
+// new config flow back in as a prop. A bare `vi.fn()` callback would make every
+// case below pass while the real client stayed broken.
+
+import { useRef, useState } from 'react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mergeAgentModelChoice } from '../../src/App';
+import { InlineModelSwitcher } from '../../src/components/InlineModelSwitcher';
+import type { AgentInfo, AppConfig } from '../../src/types';
+
+vi.mock('../../src/providers/provider-models', () => ({
+  fetchProviderModels: vi.fn(async () => ({ ok: false, models: [] })),
+}));
+
+const baseConfig: AppConfig = {
+  mode: 'daemon',
+  apiKey: '',
+  apiProtocol: 'anthropic',
+  apiVersion: '',
+  baseUrl: 'https://api.anthropic.com',
+  model: 'claude-sonnet-4-5',
+  apiProviderBaseUrl: 'https://api.anthropic.com',
+  apiProtocolConfigs: {},
+  agentId: 'amr',
+  skillId: null,
+  designSystemId: null,
+  onboardingCompleted: true,
+  mediaProviders: {},
+  agentModels: {},
+  agentCliEnv: {},
+};
+
+/** The catalog from the bug report: the two DeepSeek tiers are on the caller's
+ *  plan, the Claude tiers are not. `enabled: false` is what `vela model list
+ *  --json` reports for a model above the caller's plan. */
+const amrAgent: AgentInfo = {
+  id: 'amr',
+  name: 'AMR (vela)',
+  bin: 'amr',
+  available: true,
+  version: '1.0.0',
+  models: [
+    { id: 'deepseek-v4-flash', label: 'deepseek-v4-flash', enabled: true, default: true },
+    { id: 'deepseek-v4-pro', label: 'deepseek-v4-pro', enabled: true },
+    { id: 'claude-fable-5', label: 'claude-fable-5', enabled: false },
+    { id: 'claude-opus-4.6', label: 'claude-opus-4.6', enabled: false },
+    { id: 'claude-opus-4.7', label: 'claude-opus-4.7', enabled: false },
+    { id: 'claude-opus-4.8', label: 'claude-opus-4.8', enabled: false },
+  ],
+};
+
+/** Same catalog with every model on-plan — the control case. */
+const amrAgentAllEnabled: AgentInfo = {
+  ...amrAgent,
+  models: (amrAgent.models ?? []).map((model) => ({ ...model, enabled: true })),
+};
+
+/**
+ * Mirrors `App.handleAgentModelChange`: merge into the persisted choice, keep a
+ * ref as the write-through truth source, and re-render the switcher with the new
+ * config. This is the round-trip the chip label actually depends on, and the
+ * same round-trip a page reload replays out of the persisted config.
+ */
+function StatefulSwitcher({
+  agents,
+  initialConfig,
+  compact = true,
+  onPersist,
+}: {
+  agents: AgentInfo[];
+  initialConfig?: Partial<AppConfig>;
+  compact?: boolean;
+  onPersist?: (agentId: string, model: string | undefined) => void;
+}) {
+  const [config, setConfig] = useState<AppConfig>({ ...baseConfig, ...initialConfig });
+  const persistedRef = useRef(config);
+  return (
+    <InlineModelSwitcher
+      config={config}
+      agents={agents}
+      providerModelsCache={{}}
+      compact={compact}
+      daemonLive
+      onModeChange={vi.fn()}
+      onAgentChange={vi.fn()}
+      onAgentModelChange={(agentId, choice) => {
+        const current = persistedRef.current;
+        const merged = mergeAgentModelChoice(
+          current.agentModels?.[agentId] ?? {},
+          choice,
+        );
+        const next: AppConfig = {
+          ...current,
+          agentModels: { ...(current.agentModels ?? {}), [agentId]: merged },
+        };
+        persistedRef.current = next;
+        onPersist?.(agentId, merged.model);
+        setConfig(next);
+      }}
+      onApiProtocolChange={vi.fn()}
+      onApiModelChange={vi.fn()}
+      onOpenSettings={vi.fn()}
+    />
+  );
+}
+
+function chipText(): string {
+  return screen.getByTestId('inline-model-switcher-chip').textContent ?? '';
+}
+
+function openSwitcher(): HTMLElement {
+  fireEvent.click(screen.getByTestId('inline-model-switcher-chip'));
+  return screen.getByTestId('inline-model-switcher-popover');
+}
+
+function compactRow(modelId: string): HTMLElement {
+  return screen.getByTestId(`inline-model-switcher-compact-model-${modelId}`);
+}
+
+function isOffered(row: HTMLElement): boolean {
+  return (
+    !(row as HTMLButtonElement).disabled && row.getAttribute('aria-disabled') !== 'true'
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('compact home model list — a clicked model reaches the chip', () => {
+  it('never offers a model whose click the chip will not honor', () => {
+    // The invariant, stated as the user sees it. Any row the list presents as
+    // clickable must move the chip; a row it will not honor must be presented
+    // as unavailable with a reason. Today `claude-opus-4.6` (and the other
+    // off-plan Claude tiers) are offered as plain rows and clicking them leaves
+    // the chip on `deepseek-v4-flash`.
+    for (const model of amrAgent.models ?? []) {
+      render(<StatefulSwitcher agents={[amrAgent]} />);
+      expect(chipText()).toContain('deepseek-v4-flash');
+
+      openSwitcher();
+      const row = compactRow(model.id);
+      const offered = isOffered(row);
+      fireEvent.click(row);
+
+      if (offered) {
+        expect(chipText(), `${model.id} was offered as selectable`).toContain(
+          model.label,
+        );
+      } else {
+        // Refused is fine — silently refused is not. The row must say why.
+        expect(
+          screen.getByTestId(`inline-model-switcher-compact-model-lock-${model.id}`)
+            .textContent,
+          `${model.id} was refused without a reason`,
+        ).toBeTruthy();
+        expect(chipText()).toContain('deepseek-v4-flash');
+      }
+      cleanup();
+    }
+  });
+
+  it('applies an on-plan model the user clicks', () => {
+    // Control case: this passes on the unfixed code. It is what rules out the
+    // outside-click/`mousedown` close handler as the cause — if that handler
+    // were unmounting the list before the option's click fired, this case would
+    // fail too.
+    render(<StatefulSwitcher agents={[amrAgentAllEnabled]} />);
+    expect(chipText()).toContain('deepseek-v4-flash');
+
+    openSwitcher();
+    fireEvent.click(compactRow('deepseek-v4-pro'));
+
+    expect(chipText()).toContain('deepseek-v4-pro');
+    expect(screen.queryByTestId('inline-model-switcher-popover')).toBeNull();
+  });
+
+  it('lists available models above the ones the plan does not include', () => {
+    // Same ordering the execution-settings picker already applies via
+    // `orderModelOptionsByAvailability`. The compact list was the one surface
+    // rendering the raw catalog order, so off-plan models could sit on top of
+    // the ones the caller can actually pick.
+    const interleaved: AgentInfo = {
+      ...amrAgent,
+      models: [
+        { id: 'claude-opus-4.8', label: 'claude-opus-4.8', enabled: false },
+        { id: 'deepseek-v4-flash', label: 'deepseek-v4-flash', enabled: true, default: true },
+        { id: 'claude-opus-4.6', label: 'claude-opus-4.6', enabled: false },
+        { id: 'deepseek-v4-pro', label: 'deepseek-v4-pro', enabled: true },
+      ],
+    };
+    render(<StatefulSwitcher agents={[interleaved]} />);
+    const popover = openSwitcher();
+    const labels = within(popover)
+      .getAllByRole('radio')
+      .map((row) => row.textContent ?? '');
+
+    expect(labels[0]).toContain('deepseek-v4-flash');
+    expect(labels[1]).toContain('deepseek-v4-pro');
+    expect(labels.slice(2).join('\n')).not.toContain('deepseek');
+  });
+
+  it('writes nothing at all when a refused model is clicked', () => {
+    // The refusal happens BEFORE the write, not after: without the gate the
+    // click lands a locked model in the config (which `saveConfig` persists and
+    // `syncConfigToDaemon` pushes to the daemon) and a second write reverts it.
+    // Two round-trips to store a value the user never gets.
+    const persisted = vi.fn();
+    render(<StatefulSwitcher agents={[amrAgent]} onPersist={persisted} />);
+    openSwitcher();
+    fireEvent.click(compactRow('claude-opus-4.6'));
+
+    expect(persisted).not.toHaveBeenCalled();
+    expect(chipText()).toContain('deepseek-v4-flash');
+  });
+
+  it('re-selecting the already active model closes the list without changing the chip', () => {
+    render(<StatefulSwitcher agents={[amrAgentAllEnabled]} />);
+    openSwitcher();
+    fireEvent.click(compactRow('deepseek-v4-flash'));
+
+    expect(chipText()).toContain('deepseek-v4-flash');
+    expect(screen.queryByTestId('inline-model-switcher-popover')).toBeNull();
+  });
+
+  it('still closes on a click genuinely outside the switcher', () => {
+    render(
+      <div>
+        <StatefulSwitcher agents={[amrAgentAllEnabled]} />
+        <button type="button" data-testid="outside">
+          outside
+        </button>
+      </div>,
+    );
+    openSwitcher();
+    fireEvent.mouseDown(screen.getByTestId('outside'));
+
+    expect(screen.queryByTestId('inline-model-switcher-popover')).toBeNull();
+  });
+
+  it('keeps the execution-settings picker applying a model', () => {
+    // The non-compact surface the existing portal-class exemption protects. It
+    // must keep working: its option list is a `document.body` portal, so its
+    // clicks land outside the switcher's wrapper.
+    render(<StatefulSwitcher agents={[amrAgentAllEnabled]} compact={false} />);
+    openSwitcher();
+
+    fireEvent.click(screen.getByTestId('inline-model-switcher-agent-model'));
+    const modelPopover = screen.getByTestId(
+      'inline-model-switcher-agent-model-popover',
+    );
+    fireEvent.mouseDown(modelPopover);
+    fireEvent.click(
+      within(modelPopover).getByRole('option', { name: /deepseek-v4-pro/ }),
+    );
+
+    expect(chipText()).toContain('deepseek-v4-pro');
+    expect(screen.getByTestId('inline-model-switcher-agent-model')).toHaveTextContent(
+      'deepseek-v4-pro',
+    );
+  });
+});

--- a/apps/web/tests/components/agentModelSelection.test.ts
+++ b/apps/web/tests/components/agentModelSelection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  agentModelIsSelectable,
   defaultAgentModelId,
   effectiveAgentModelChoice,
   normalizeAgentModelChoice,
@@ -73,6 +74,103 @@ describe('agent model selection', () => {
 
     expect(defaultAgentModelId(lockedAmrAgent)).toBeNull();
     expect(effectiveAgentModelChoice(lockedAmrAgent, undefined)).toBeUndefined();
+  });
+
+  // `agentModelIsSelectable` is the gate every model-list surface asks before
+  // offering a row. It is deliberately the exact complement of
+  // `normalizeAgentModelChoice`: offering a model normalization would coerce
+  // away means the click is written and then reverted, which the user reads as
+  // "the picker ignored me".
+  describe('agentModelIsSelectable', () => {
+    const planGatedAmr: AgentInfo = {
+      ...amrAgent,
+      models: [
+        { id: 'deepseek-v4-flash', label: 'deepseek-v4-flash', enabled: true, default: true },
+        { id: 'claude-opus-4.6', label: 'claude-opus-4.6', enabled: false },
+      ],
+    };
+
+    it('refuses a model the caller\'s plan does not include', () => {
+      expect(agentModelIsSelectable(planGatedAmr, 'claude-opus-4.6')).toBe(false);
+      expect(
+        normalizeAgentModelChoice(planGatedAmr, { model: 'claude-opus-4.6' }),
+      ).not.toBeNull();
+    });
+
+    it('allows every on-plan model, plus the default sentinel', () => {
+      expect(agentModelIsSelectable(planGatedAmr, 'deepseek-v4-flash')).toBe(true);
+      expect(agentModelIsSelectable(planGatedAmr, 'default')).toBe(true);
+    });
+
+    it('still refuses every model when the whole catalog is above the plan', () => {
+      // A caller entitled to nothing must be routed to an upgrade, not handed a
+      // pick the gateway would reject on the next run.
+      const allLocked: AgentInfo = {
+        ...amrAgent,
+        models: [
+          { id: 'claude-opus-4.6', label: 'claude-opus-4.6', enabled: false },
+          { id: 'claude-opus-4.8', label: 'claude-opus-4.8', enabled: false },
+        ],
+      };
+      expect(agentModelIsSelectable(allLocked, 'claude-opus-4.6')).toBe(false);
+    });
+
+    it('refuses an AMR id that is not in the catalog at all', () => {
+      expect(agentModelIsSelectable(planGatedAmr, 'gpt-5.4-mini')).toBe(false);
+    });
+
+    it('allows anything while the AMR catalog has not loaded', () => {
+      expect(agentModelIsSelectable({ id: 'amr', models: [] }, 'anything')).toBe(true);
+    });
+
+    it('allows non-AMR agents anything, including custom ids', () => {
+      expect(agentModelIsSelectable(codexAgent, 'custom-codex-model')).toBe(true);
+    });
+
+    it('refuses an empty model id', () => {
+      expect(agentModelIsSelectable(planGatedAmr, '')).toBe(false);
+      expect(agentModelIsSelectable(planGatedAmr, null)).toBe(false);
+    });
+
+    // The load-bearing relation. A surface that offers only selectable rows can
+    // never offer a pick `normalizeAgentModelChoice` would coerce away, so the
+    // silent-revert failure mode is unreachable — that is what makes gating on
+    // this predicate sufficient rather than merely well-intentioned.
+    it('is at least as strict as normalizeAgentModelChoice', () => {
+      const catalogs: AgentInfo[] = [
+        planGatedAmr,
+        amrAgent,
+        codexAgent,
+        {
+          ...amrAgent,
+          models: [
+            { id: 'claude-opus-4.6', label: 'claude-opus-4.6', enabled: false },
+            { id: 'claude-opus-4.8', label: 'claude-opus-4.8', enabled: false },
+          ],
+        },
+        { ...amrAgent, models: [] },
+      ];
+      const probeIds = [
+        'default',
+        'glm-5',
+        'glm-5.1',
+        'deepseek-v4-flash',
+        'claude-opus-4.6',
+        'claude-opus-4.8',
+        'gpt-5.4-mini',
+      ];
+      for (const agent of catalogs) {
+        for (const id of probeIds) {
+          const coerced = normalizeAgentModelChoice(agent, { model: id }) !== null;
+          if (coerced) {
+            expect(
+              agentModelIsSelectable(agent, id),
+              `${agent.id}/${id} would be coerced away, so it must not be offered`,
+            ).toBe(false);
+          }
+        }
+      }
+    });
   });
 
   it('keeps non-AMR custom model choices unchanged', () => {


### PR DESCRIPTION
## Why

Reported from a real client by the product owner: on the Home composer, clicking the model chip opens the compact model list, you click a model, and **nothing happens** — the chip keeps showing the previous model. No error, no explanation.

I could not reproduce it with an arbitrary model, which is what made it worth chasing: it only happens for a model your plan does not include. The compact list rendered `currentAgent.models` raw, so a model above the caller's plan (`enabled: false`, straight from `vela model list --json`) showed up as an ordinary selectable row. Clicking it:

1. wrote the pick into `config.agentModels.amr`,
2. `normalizeAgentModelChoice` (`apps/web/src/components/agentModelSelection.ts:20`) reported the plan fallback instead,
3. the re-normalization effect at `apps/web/src/components/InlineModelSwitcher.tsx:553` persisted that fallback.

So the click was accepted and then quietly undone. Worse than "nothing happened": on the real client it also **overwrites the model you had previously chosen** with the plan default. Verified end-to-end against a running daemon (details under Bug fix verification) — clicking `claude-opus-4.6` while on `deepseek-v4-pro` left the persisted config at `{"model":"deepseek-v4-flash"}`.

The pain is not just the dead click. It's that we already knew this rule: the project composer's model list (`AvatarMenu.tsx:406`) had hand-rolled `currentAgent.id === 'amr' && model.enabled === false` for exactly this case. Copying an invariant per surface is what let the newest list drop it. That's the debt this PR pays down.

## What users will see

- Clicking a model in the Home composer's compact list now actually switches the model — the chip updates immediately and the choice survives a reload.
- Models your plan does not include are still listed (so the catalogue reads as complete) but now **look** unavailable: dimmed, with a lock glyph and the same "Upgrade to use" reason the execution-settings picker already showed. Clicking one opens the plans page instead of appearing to do nothing.
- Available models are sorted above the locked ones, matching the execution-settings picker.
- Nothing changes for users whose whole catalogue is on-plan, or for any non-AMR agent (Claude, Codex, opencode, …) — those lists carry no plan entitlement and stay fully selectable.

## Surface area

- [x] **UI** — Home composer model chip's compact list (`apps/web`); locked-model affordance in the project composer's model list
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (reuses the existing `settings.amrModelUpgradeHint`; no new keys)
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

No CLI counterpart: this is a rendering/affordance defect in one web popover. The underlying capability (choosing an agent model) is already exposed on both surfaces and its HTTP contract is unchanged.

## Screenshots

Both captured on a real client (`tools-dev run web`, daemon serving the reporter's exact catalogue), same runtime, same data, only the branch differs.

**Before — `origin/feat/workspace-team`.** All four Claude tiers render as ordinary rows. Clicking `claude-opus-4.6` leaves the chip on `deepseek-v4-flash`.

> Screenshot on disk (GitHub's image uploader needs a browser session, so these could not be attached programmatically — drag them into this description to inline them):
> `/private/tmp/claude-501/-Users-elian-Documents-open-design/39b39b7e-85a9-4e46-a259-8b0b95c60b83/scratchpad/model-switch-before-base.png`

**After — this branch.** Chip shows `deepseek-v4-pro` (clicked, then survived a full page reload); the four off-plan tiers are dimmed with a lock and sorted below the available ones.

> `/private/tmp/claude-501/-Users-elian-Documents-open-design/39b39b7e-85a9-4e46-a259-8b0b95c60b83/scratchpad/model-switch-after-fix.png`

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/InlineModelSwitcher.compact-model-click.test.tsx`
- Did the test go red on the base branch and green on this branch? **yes** — 3 failures on `origin/feat/workspace-team` (`c27fa2def`), 0 on this branch. Plus 11 failures in `apps/web/tests/components/agentModelSelection.test.ts` for the new gate.

The specs deliberately assert the **user-visible** outcome, not that a callback fired — the callback fires today and the chip still does not move. Because the switcher does not own persistence (`App.handleAgentModelChange` does), the spec wires the real merge/persist shape around the component and lets the new config flow back in as a prop; a bare `vi.fn()` would have made every case pass while the client stayed broken.

Red, on the base source:

```
 ❯ tests/components/InlineModelSwitcher.compact-model-click.test.tsx (7 tests | 3 failed)
     × never offers a model whose click the chip will not honor
     × lists available models above the ones the plan does not include
     × writes nothing at all when a refused model is clicked

AssertionError: claude-fable-5 was offered as selectable: expected 'deepseek-v4-flash' to contain 'claude-fable-5'

AssertionError: expected "vi.fn()" to not be called at all, but actually been called 2 times
  1st vi.fn() call: [ "amr", "claude-opus-4.6" ]
  2nd vi.fn() call: [ "amr", "deepseek-v4-flash" ]
```

That second failure is the whole bug in four lines: one write to store the user's pick, one write to take it away again.

Green, on this branch:

```
 Test Files  2 passed (2)
      Tests  20 passed (20)
```

Also pinned by the same file, so the fix cannot be "make the assertion pass":

- an on-plan model click still applies (**passes on the unfixed source too** — this is the control that rules out the outside-click `mousedown` handler at `InlineModelSwitcher.tsx:403` as the cause; if that were unmounting the list before the option's click fired, this case would fail as well)
- the execution-settings picker's own `SearchableModelSelect` still applies a model (the `document.body`-portal surface the existing close-handler exemption protects)
- a click genuinely outside the switcher still closes it
- re-selecting the already active model is a clean no-op that still closes

Mutation-tested, two ways:

- Remove the gate from the `applyAgentModel` sink → red (`writes nothing at all when a refused model is clicked` reports the same 2 writes as the base branch).
- Keep the sink but render every row as selectable → red (`never offers a model whose click the chip will not honor`).

Real-client acceptance, `pnpm tools-dev run web --namespace model-switch --daemon-port 17690 --web-port 17691` with an isolated `OD_DATA_DIR`, and a stub `vela` on `PATH` speaking the real `model list --format json` / `model preset --format json` contract so the daemon built the catalogue through its normal detection path — no source backdoor. `GET /api/agents` served exactly the reporter's list with real entitlement flags:

```
amr available=True models=[('deepseek-v4-flash', True), ('deepseek-v4-pro', True),
  ('claude-fable-5', False), ('claude-opus-4.6', False),
  ('claude-opus-4.7', False), ('claude-opus-4.8', False)]
```

| | base (`c27fa2def`) | this branch |
|---|---|---|
| `claude-opus-4.6` row | plain row, no `aria-disabled`, no reason | `aria-disabled="true"`, `is-locked`, "Upgrade to use", lock glyph |
| click it, chip | stays put, and the previous pick is overwritten with the default | stays put; panel stays open so you can pick an available one |
| click it, persisted config | overwritten to `{"model":"deepseek-v4-flash"}` | untouched |
| click `deepseek-v4-pro`, chip | — | `deepseek-v4-pro`, panel closes |
| after full page reload | — | `deepseek-v4-pro`, `agentModels.amr = {"model":"deepseek-v4-pro"}` |

### Why a third list surface is covered automatically

The recurrence risk here is not "one class name was missed" — it is that "which models are locked" was re-derived independently in each list. This PR removes that possibility rather than adding another copy of the rule:

1. **One definition, derived from the write path.** `agentModelIsSelectable` is specified to be *at least as strict as* `normalizeAgentModelChoice`, and `agentModelSelection.test.ts` asserts that relation directly over a matrix of catalogues. Since normalization is the thing that actually decides what the config keeps, a row gated on this predicate can never be a pick that gets reverted. A future change to either function that broke the relation fails a test instead of quietly reopening the hole.
2. **One selection sink.** No row handler in `InlineModelSwitcher` calls `onAgentModelChange` any more; both lists go through `applyAgentModel`, which asks the same predicate. A third list added to this component has no second path to write a model, so even if it forgets the visual lock, it cannot produce the silent revert — it gets a refusal it must handle.
3. **The duplicate is gone.** `AvatarMenu` now asks the shared gate instead of its own `agent.id === 'amr' && model.enabled === false`. There is exactly one definition of "locked" in the codebase for someone to find and reuse. That migration also fixes a real divergence: with an all-locked catalogue, `AvatarMenu`'s local check dead-ended the user on every row, while the shared gate is the one place that decision now lives.

### Adjacent issues (not fixed here)

- On a cold load, the chip briefly reads "Default" for ~1s before `/api/agents` lands and the real model label appears. Pre-existing, untouched by this PR, and unrelated to the reported symptom — `chipModel`'s fallback fires while `currentAgent` is still `null`. Left for its own spec and PR.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass (full workspace)
- `pnpm --filter @open-design/web test` — **549 files / 5550 passed, 11 skipped, 0 failed**
- `pnpm --filter @open-design/web typecheck` — pass
- Real-client acceptance on `tools-dev` per the table above, including the reload check
- Node 24.18.0 throughout
