### PR TITLE
fix(collab): verify the asserted workspace before claiming an orphan project

### DIFF
--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -2129,25 +2129,56 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
    * is; this only ever claims a true orphan, matching `ensureWorkspaceProject`'s
    * own idempotency contract.
    *
-   * Attributes `createdByWorkspaceMemberId: ctx.workspaceMemberId`, same as
-   * `bindDuplicateIntoRequestWorkspace` — deliberately NOT the `null` an
-   * ordinary lazy-read projection uses (`ensureWorkspaceProjection`). A
-   * passive list read must not silently hand out ownership just because it
-   * happened to run first; an explicit mutation request naming this exact
-   * project is the "yes, this is mine" signal a read never had.
+   * Attributes an owner, deliberately NOT the `null` an ordinary lazy-read
+   * projection uses (`ensureWorkspaceProjection`). A passive list read must not
+   * silently hand out ownership just because it happened to run first; an
+   * explicit mutation request naming this exact project is the "yes, this is
+   * mine" signal a read never had.
+   *
+   * But that owner is NOT the request's own claim. `workspaceProjectContextFromRequest`
+   * only PARSES `x-od-workspace-*`, which is an unauthenticated hint any local
+   * caller can forge, and this row's `createdByWorkspaceMemberId` is what
+   * `workspaceResourceAccess` turns into `selfCreated` — the bit that grants a
+   * non-privileged member mutation rights over it. Writing the header value
+   * meant a plain curl could claim someone else's orphaned project into a
+   * workspace it has no membership in and install itself as the author.
+   *
+   * So the workspace and the authorship both come from
+   * `resolveCreatedProjectHome` — the same verify-then-degrade resolver every
+   * created-project path uses (`collab/created-project-workspace.ts`):
+   *
+   *   - the asserted identity VERIFIES against the membership directory -> claim
+   *     it, attributed to the DIRECTORY's member id rather than the header's;
+   *   - it does NOT verify — foreign, inactive, permissions disagree, last-known
+   *     says removed, or the authority is unreadable so it cannot be confirmed —
+   *     -> claim the daemon's own ambient workspace instead, attributed to that
+   *     verified session's member id;
+   *   - neither is available -> write nothing, and let the pre-existing gate
+   *     below answer. A caller that cannot prove membership over a project
+   *     nothing has ever claimed is exactly who that gate is for; inventing a
+   *     binding to keep it happy is what this fix removes.
+   *
+   * The `null`/`'missing'` early return is unchanged and load-bearing, and is
+   * why this does not simply use `createdProjectWorkspaceHome`'s own third
+   * branch. `enforceWorkspaceResourceMutation` runs immediately after this and
+   * its HEADERLESS branch answers 401 WORKSPACE_CONTEXT_REQUIRED as soon as ANY
+   * row exists for the resource. Claiming on a request that asserts nothing
+   * would therefore convert a working headerless mutation into a 401.
    */
-  function reconcileUnboundProjectBeforeMutation(req: any, projectId: string) {
-    const ctx = workspaceProjectContextFromRequest(req);
-    if (ctx === null || ctx === 'missing') return;
+  async function reconcileUnboundProjectBeforeMutation(req: any, projectId: string) {
+    const asserted = workspaceProjectContextFromRequest(req);
+    if (asserted === null || asserted === 'missing') return;
     if (getWorkspaceProjectByProjectId(db, projectId)) return;
+    const home = await resolveCreatedProjectHome(req);
+    if (!home) return;
     const now = Date.now();
     ensureWorkspaceProject(db, {
       projectId,
-      workspaceId: ctx.workspaceId,
+      workspaceId: home.workspaceId,
       visibility: 'personal',
       resourceState: 'active',
-      createdByWorkspaceMemberId: ctx.workspaceMemberId,
-      updatedByWorkspaceMemberId: ctx.workspaceMemberId,
+      createdByWorkspaceMemberId: home.workspaceMemberId,
+      updatedByWorkspaceMemberId: home.workspaceMemberId,
       syncState: 'local_only',
       resourceHubResourceId: null,
       cloudTombstonedAt: null,
@@ -3181,7 +3212,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       // finally comes in for it. Claim it into the caller's own workspace
       // first, exactly like this same route already does for the COPY it is
       // about to create.
-      reconcileUnboundProjectBeforeMutation(req, sourceProject.id);
+      await reconcileUnboundProjectBeforeMutation(req, sourceProject.id);
       if (!enforceWorkspaceProjectMutation(
         req,
         res,
@@ -3290,7 +3321,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       // recvqbhor3pai2 — same reasoning as the sibling /duplicate route just
       // above: a never-bound source project must not be permanently
       // un-copyable once a real, authenticated request finally names it.
-      reconcileUnboundProjectBeforeMutation(req, sourceProject.id);
+      await reconcileUnboundProjectBeforeMutation(req, sourceProject.id);
       if (!enforceWorkspaceProjectMutation(
         req,
         res,

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -2151,12 +2151,30 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
    *     it, attributed to the DIRECTORY's member id rather than the header's;
    *   - it does NOT verify — foreign, inactive, permissions disagree, last-known
    *     says removed, or the authority is unreadable so it cannot be confirmed —
-   *     -> claim the daemon's own ambient workspace instead, attributed to that
-   *     verified session's member id;
+   *     -> write NOTHING, unless the degraded (ambient) authority happens to name
+   *     the very pair that was asserted;
    *   - neither is available -> write nothing, and let the pre-existing gate
    *     below answer. A caller that cannot prove membership over a project
    *     nothing has ever claimed is exactly who that gate is for; inventing a
    *     binding to keep it happy is what this fix removes.
+   *
+   * CREATION AND RECONCILIATION ARE NOT THE SAME RISK, which is why the degraded
+   * branch is narrower here than in `createdProjectWorkspaceHome`. Putting a
+   * BRAND-NEW project in the ambient workspace takes nothing from anyone. Putting
+   * a PRE-EXISTING orphan there — because someone asserted an identity that could
+   * not be verified — may take it from the workspace it actually belongs to, and
+   * the `getWorkspaceProjectByProjectId` guard above makes that write STICKY: the
+   * rightful verified workspace can never reconcile it afterwards. A forged
+   * request, or a legitimate one during an authority outage after the active
+   * workspace changed, would permanently mis-file the project.
+   *
+   * So the ambient authority is accepted only when it matches the asserted pair
+   * exactly. That is outage continuity for the ordinary legitimate caller — whose
+   * client took its headers from this same daemon, so the two agree — while a
+   * mismatch writes nothing. Not in tension with 「所有 project 都应该能找到
+   * workspace」: the display-side fallback (#6185) already renders an unbound
+   * project inside the caller's current workspace, so nothing reads as "unknown".
+   * The binding row is a separate, durable fact and stays conservative.
    *
    * The `null`/`'missing'` early return is unchanged and load-bearing, and is
    * why this does not simply use `createdProjectWorkspaceHome`'s own third
@@ -2171,6 +2189,15 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
     if (getWorkspaceProjectByProjectId(db, projectId)) return;
     const home = await resolveCreatedProjectHome(req);
     if (!home) return;
+    // Verified assertions resolve to the pair that was asserted (the directory
+    // lookup is keyed on it), so this admits them and rejects only a degraded
+    // ambient authority that names something else.
+    if (
+      home.workspaceId !== asserted.workspaceId
+      || home.workspaceMemberId !== asserted.workspaceMemberId
+    ) {
+      return;
+    }
     const now = Date.now();
     ensureWorkspaceProject(db, {
       projectId,

--- a/e2e/tests/collab/created-project-binding.test.ts
+++ b/e2e/tests/collab/created-project-binding.test.ts
@@ -303,30 +303,47 @@ describe('an asserted workspace identity is verified before it is persisted', ()
           // Duplicate is one of the paths with no authorization gate of its own,
           // so it is where an unverified header claim used to be written
           // straight into `workspace_projects`.
-          const copy = await requestJson<CreatedProject>(
-            webUrl,
-            `/api/projects/${encodeURIComponent(source)}/duplicate`,
+          //
+          // Deliberately status-agnostic. Once `reconcileUnboundProjectBeforeMutation`
+          // also stopped conjuring a binding from unverified headers, the
+          // pre-existing mutation gate began refusing this forged caller outright
+          // (`workspaceResourceMutationAllowed`'s `!row -> false`) instead of
+          // letting it through on a binding it had just invented for itself. Both
+          // outcomes satisfy the property under test; what must never happen is a
+          // persisted claim to the asserted workspace.
+          const response = await fetch(
+            new URL(`/api/projects/${encodeURIComponent(source)}/duplicate`, webUrl),
             {
-              body: { name: 'Claim copy' },
-              headers: workspaceHeaders({
-                workspaceId: 'ws-bind-foreign',
-                workspaceMemberId: 'mem-bind-foreign',
-                workspaceType: 'team',
-              }),
+              body: JSON.stringify({ name: 'Claim copy' }),
+              headers: {
+                'content-type': 'application/json',
+                ...workspaceHeaders({
+                  workspaceId: 'ws-bind-foreign',
+                  workspaceMemberId: 'mem-bind-foreign',
+                  workspaceType: 'team',
+                }),
+              },
               method: 'POST',
             },
           );
+          const copyId = response.ok
+            ? ((await response.json()) as CreatedProject).project.id
+            : null;
 
-          const copyScope = await readScope(webUrl, copy.project.id);
-          // The claim is never persisted...
+          // The source is never re-homed into the asserted workspace...
+          const sourceScope = await readScope(webUrl, source);
           expect(
-            copyScope.workspaceId,
+            sourceScope.workspaceId,
             'an unverifiable header claim must not be written as a binding',
           ).not.toBe('ws-bind-foreign');
-          // ...and with no ambient workspace behind this daemon there is nothing
-          // to degrade to, so `unbound` is the honest answer. Creation still
-          // returned 200 — the point is that it degrades, never refuses.
-          expect(copyScope.kind).toBe('unbound');
+          expect(sourceScope.kind).toBe('unbound');
+
+          // ...and neither is the copy, when one was produced at all.
+          if (copyId) {
+            const copyScope = await readScope(webUrl, copyId);
+            expect(copyScope.workspaceId).not.toBe('ws-bind-foreign');
+            expect(copyScope.kind).toBe('unbound');
+          }
         },
         {
           env: {

--- a/e2e/tests/collab/reconcile-unbound-authority.test.ts
+++ b/e2e/tests/collab/reconcile-unbound-authority.test.ts
@@ -1,0 +1,354 @@
+// @vitest-environment node
+
+// `reconcileUnboundProjectBeforeMutation` (apps/daemon/src/routes/project/index.ts)
+// claims a project this daemon has never bound to ANY workspace into the current
+// mutating request's workspace, so a true orphan is not denied its first mutation
+// by `enforceWorkspaceResourceMutation`'s `!row -> false` rule (recvqbhor3pai2,
+// "复制的项目再次复制").
+//
+// It resolved that workspace from `workspaceProjectContextFromRequest(req)` —
+// header PARSING with no authority check — and stamped
+// `createdByWorkspaceMemberId: ctx.workspaceMemberId` from the same headers.
+// `x-od-workspace-*` is an unauthenticated hint any local caller can forge, so a
+// plain curl could claim someone else's orphaned project into a workspace it has
+// no membership in AND write itself in as the project's author. Authorship is the
+// dangerous field: `workspaceResourceAccess` derives `selfCreated` from it, which
+// is what grants a non-privileged member mutation rights over the row.
+//
+// Same three-way shape #6201 established for created projects, via the same
+// `createCreatedProjectWorkspaceResolver`:
+//
+//   1. asserted identity VERIFIES              -> claim it, authorship from the
+//                                                 DIRECTORY's member id
+//   2. asserted identity does NOT verify       -> never write that claim; use the
+//      (foreign, inactive, or unconfirmable      daemon's ambient workspace, whose
+//      because the authority is unreadable)      member id is its own verified
+//                                                 session, else write nothing
+//   3. nothing asserted                        -> write nothing (see below)
+//
+// Case 3 deliberately does NOT claim into the ambient workspace, unlike
+// `createdProjectWorkspaceHome`'s third branch. This helper runs immediately
+// before `enforceWorkspaceResourceMutation`, whose HEADERLESS branch reads
+// `getWorkspaceResourceByResourceId` and answers 401 WORKSPACE_CONTEXT_REQUIRED
+// as soon as ANY row exists. Claiming on a headerless request would therefore
+// turn today's working headerless duplicate into a 401 — a new failure on a path
+// that works now. Pinned below.
+//
+// Assertions are on the PERSISTED BINDING (`GET /api/projects/:id/workspace-scope`),
+// never on the mutation's status code: whether the duplicate itself is allowed is
+// the pre-existing gate's business, and it legitimately differs for a caller that
+// cannot prove membership. The security property is that no unverifiable claim is
+// ever written.
+//
+// Runs with `OD_WORKSPACE_CONTEXT_SOURCE=vela` so the membership authority is
+// live, seeded only through the daemon's real vela integration against a
+// temporary server-level mock. No source-level backdoor.
+
+import { createServer, type Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { requestJson } from '@/vitest/http';
+import { createSmokeSuite } from '@/vitest/suite';
+
+type ProjectWorkspaceScope = {
+  kind: 'unbound' | 'unavailable' | 'personal' | 'team';
+  projectId: string;
+  workspaceId: string | null;
+  visibility?: 'personal' | 'team';
+};
+
+type CreatedProject = { conversationId: string; project: { id: string } };
+type WorkspaceProjectsBody = {
+  projects: Array<{ id: string; createdByWorkspaceMemberId: string | null }>;
+};
+
+/** An active membership the mock directory really lists. */
+const MEMBER = {
+  workspaceId: 'ws-rec-personal',
+  workspaceName: 'Reconcile personal',
+  workspaceType: 'personal' as const,
+  workspaceMemberId: 'mem-rec-personal',
+  role: 'owner' as const,
+  memberStatus: 'active' as const,
+  lifecycleState: 'active' as const,
+};
+
+/** A workspace/member pair the signed-in identity has NO membership in. */
+const FOREIGN = {
+  workspaceId: 'ws-rec-foreign',
+  workspaceMemberId: 'mem-rec-foreign',
+};
+
+/**
+ * `/api/v1/workspaces` is the membership directory. `/api/v1/workspaces/current`
+ * decides whether the daemon ends up with an AMBIENT workspace at all:
+ *   - 401 -> "signed out at the vela layer", provider returns null, ambient absent.
+ *   - 403 `missing_principal` -> provider picks a default from the directory,
+ *     so ambient is present.
+ */
+function startDirectoryMock(options: {
+  directoryStatus?: number;
+  currentStatus: 401 | 403;
+}): Promise<{ url: string; close: () => Promise<void> }> {
+  const server: Server = createServer((req, res) => {
+    const url = req.url ?? '';
+    if (url.startsWith('/api/v1/workspaces/current')) {
+      res.writeHead(options.currentStatus, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(options.currentStatus === 403 ? { error: 'missing_principal' } : { error: 'unauthorized' }));
+      return;
+    }
+    if (url.startsWith('/api/v1/workspaces')) {
+      const status = options.directoryStatus ?? 200;
+      res.writeHead(status, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(status === 200 ? { items: [MEMBER] } : { error: 'authority down' }));
+      return;
+    }
+    res.writeHead(404, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not found' }));
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (address == null || typeof address === 'string') throw new Error('mock has no port');
+      resolve({
+        url: `http://127.0.0.1:${address.port}`,
+        close: () => new Promise<void>((done) => server.close(() => done())),
+      });
+    });
+  });
+}
+
+function workspaceHeaders(input: {
+  workspaceId: string;
+  workspaceMemberId: string;
+  workspaceType?: 'personal' | 'team';
+}): Record<string, string> {
+  return {
+    'x-od-workspace-id': input.workspaceId,
+    'x-od-workspace-type': input.workspaceType ?? 'personal',
+    'x-od-workspace-member-id': input.workspaceMemberId,
+    'x-od-workspace-role': 'owner',
+    'x-od-workspace-lifecycle-state': 'active',
+    'x-od-workspace-member-status': 'active',
+    'x-od-workspace-can-share-projects': 'true',
+    'x-od-workspace-can-write-synced-files': 'true',
+  };
+}
+
+/** An unbound project: created headerless while the daemon has no ambient workspace. */
+async function createUnboundProject(webUrl: string, name: string): Promise<string> {
+  const created = await requestJson<CreatedProject>(webUrl, '/api/projects', {
+    body: {
+      designSystemId: null,
+      id: randomUUID(),
+      metadata: { kind: 'prototype' },
+      name,
+      pendingPrompt: null,
+      skillId: null,
+    },
+    method: 'POST',
+  });
+  return created.project.id;
+}
+
+async function readScope(webUrl: string, projectId: string): Promise<ProjectWorkspaceScope> {
+  const body = await requestJson<{ scope: ProjectWorkspaceScope }>(
+    webUrl,
+    `/api/projects/${encodeURIComponent(projectId)}/workspace-scope`,
+  );
+  return body.scope;
+}
+
+/**
+ * Drive a mutation that runs `reconcileUnboundProjectBeforeMutation` on its
+ * SOURCE project. Status-agnostic on purpose — see the file header.
+ */
+async function mutate(
+  webUrl: string,
+  path: string,
+  headers: Record<string, string> | undefined,
+  body: unknown,
+): Promise<number> {
+  const response = await fetch(new URL(path, webUrl), {
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json', ...(headers ?? {}) },
+    method: 'POST',
+  });
+  return response.status;
+}
+
+const duplicatePath = (id: string) => `/api/projects/${encodeURIComponent(id)}/duplicate`;
+const designSystemCopyPath = (id: string) =>
+  `/api/projects/${encodeURIComponent(id)}/design-system-copy`;
+
+let readableAuthority: { url: string; close: () => Promise<void> };
+let unreadableAuthority: { url: string; close: () => Promise<void> };
+
+beforeAll(async () => {
+  readableAuthority = await startDirectoryMock({ currentStatus: 401 });
+  unreadableAuthority = await startDirectoryMock({ currentStatus: 401, directoryStatus: 500 });
+});
+
+afterAll(async () => {
+  await Promise.all([readableAuthority.close(), unreadableAuthority.close()]);
+});
+
+describe('reconciling an unbound project verifies the asserted workspace first', () => {
+  test(
+    'a forged workspace/member pair never becomes a claim, through either entry point',
+    { timeout: 300_000 },
+    async () => {
+      const suite = await createSmokeSuite('collab-reconcile-forged-claim');
+
+      await suite.with.toolsDev(
+        async ({ webUrl }) => {
+          // --- CASE 1: duplicate, asserting a workspace the caller has no
+          // membership in.
+          const viaDuplicate = await createUnboundProject(webUrl, 'Reconcile via duplicate');
+          expect(
+            (await readScope(webUrl, viaDuplicate)).kind,
+            'precondition: the source project is a true orphan',
+          ).toBe('unbound');
+
+          await mutate(webUrl, duplicatePath(viaDuplicate), workspaceHeaders(FOREIGN), {
+            name: 'Forged duplicate',
+          });
+
+          const duplicateScope = await readScope(webUrl, viaDuplicate);
+          expect(
+            duplicateScope.workspaceId,
+            'a forged header pair must never be persisted as this project\'s workspace',
+          ).not.toBe(FOREIGN.workspaceId);
+          // Nothing verified and this daemon has no ambient workspace, so no row
+          // exists at all — which is also the strongest possible statement about
+          // `createdByWorkspaceMemberId`: there is none to forge.
+          expect(duplicateScope.kind).toBe('unbound');
+
+          // --- CASE 2: design-system copy, the other reachable entry point.
+          const viaCopy = await createUnboundProject(webUrl, 'Reconcile via ds copy');
+          expect((await readScope(webUrl, viaCopy)).kind).toBe('unbound');
+
+          await mutate(webUrl, designSystemCopyPath(viaCopy), workspaceHeaders(FOREIGN), {
+            name: 'Forged copy',
+          });
+
+          const copyScope = await readScope(webUrl, viaCopy);
+          expect(
+            copyScope.workspaceId,
+            'design-system-copy reaches the same helper and must refuse the same claim',
+          ).not.toBe(FOREIGN.workspaceId);
+          expect(copyScope.kind).toBe('unbound');
+
+          // --- CASE 4: a legitimate, directory-confirmed identity still claims,
+          // so the recvqbhor3pai2 fix this helper exists for keeps working.
+          const legitimate = await createUnboundProject(webUrl, 'Reconcile legitimate');
+          expect((await readScope(webUrl, legitimate)).kind).toBe('unbound');
+
+          const status = await mutate(
+            webUrl,
+            duplicatePath(legitimate),
+            workspaceHeaders(MEMBER),
+            { name: 'Legitimate duplicate' },
+          );
+          expect(status, 'a verified caller must not be refused').toBe(200);
+
+          const legitimateScope = await readScope(webUrl, legitimate);
+          expect(legitimateScope.kind).toBe('personal');
+          expect(legitimateScope.workspaceId).toBe(MEMBER.workspaceId);
+
+          // --- CASE 6: authorship comes from the AUTHORITY, not the header. The
+          // header and the directory agree on the member id here, so the value
+          // alone cannot distinguish them — what this pins is that the claim is
+          // attributed at all, and to the confirmed member.
+          const listed = await requestJson<WorkspaceProjectsBody>(
+            webUrl,
+            `/api/workspaces/${encodeURIComponent(MEMBER.workspaceId)}/projects`,
+            { headers: workspaceHeaders(MEMBER) },
+          );
+          const claimed = listed.projects.find((project) => project.id === legitimate);
+          expect(claimed?.createdByWorkspaceMemberId).toBe(MEMBER.workspaceMemberId);
+
+          // --- CASE 5: a request that asserts NOTHING must leave the binding
+          // alone, and must keep working. This helper's headerless branch is only
+          // reachable where the daemon has no ambient workspace, because #6201's
+          // create-side binding otherwise claims the project at creation — see
+          // the separate finding in the PR body about headerless mutations of a
+          // BOUND project.
+          const headerless = await createUnboundProject(webUrl, 'Reconcile headerless');
+          expect((await readScope(webUrl, headerless)).kind).toBe('unbound');
+
+          const headerlessStatus = await mutate(
+            webUrl,
+            duplicatePath(headerless),
+            undefined,
+            { name: 'Headerless duplicate' },
+          );
+          expect(headerlessStatus, 'a headerless duplicate of an orphan must keep working').toBe(200);
+          expect(
+            (await readScope(webUrl, headerless)).kind,
+            'nothing was asserted, so nothing may be claimed — a claim here would make the '
+              + 'gate\'s headerless branch answer 401 on the next mutation',
+          ).toBe('unbound');
+        },
+        {
+          env: {
+            AMR_HOME: await emptyAmrHome(suite.scratchDir),
+            OD_WORKSPACE_CONTEXT_SOURCE: 'vela',
+            VELA_API_URL: readableAuthority.url,
+            VELA_CONTROL_KEY: 'e2e-reconcile-control-key',
+          },
+        },
+      );
+    },
+  );
+
+  test(
+    'an unreadable membership authority cannot confirm a claim, so none is written',
+    { timeout: 300_000 },
+    async () => {
+      const suite = await createSmokeSuite('collab-reconcile-authority-down');
+
+      await suite.with.toolsDev(
+        async ({ webUrl }) => {
+          const project = await createUnboundProject(webUrl, 'Reconcile authority down');
+          expect((await readScope(webUrl, project)).kind).toBe('unbound');
+
+          // The asserted pair is the LEGITIMATE one from the directory — but the
+          // directory is down, so nothing can confirm it. "Cannot confirm" is not
+          // "valid": an outage must not become a window for writing claims.
+          await mutate(webUrl, duplicatePath(project), workspaceHeaders(MEMBER), {
+            name: 'Duplicate during outage',
+          });
+
+          const scope = await readScope(webUrl, project);
+          expect(scope.workspaceId).not.toBe(MEMBER.workspaceId);
+          expect(scope.kind).toBe('unbound');
+        },
+        {
+          env: {
+            AMR_HOME: await emptyAmrHome(suite.scratchDir),
+            OD_WORKSPACE_CONTEXT_SOURCE: 'vela',
+            VELA_API_URL: unreadableAuthority.url,
+            VELA_CONTROL_KEY: 'e2e-reconcile-control-key',
+          },
+        },
+      );
+    },
+  );
+
+});
+
+/**
+ * A vela config home guaranteed to hold no session, so the daemon's
+ * `readVelaControlApiContext` config-file fallback cannot pick up the developer
+ * machine's real production login.
+ */
+async function emptyAmrHome(scratchDir: string): Promise<string> {
+  const dir = join(scratchDir, 'empty-amr-home');
+  await mkdir(dir, { recursive: true });
+  return dir;
+}

--- a/e2e/tests/collab/reconcile-unbound-authority.test.ts
+++ b/e2e/tests/collab/reconcile-unbound-authority.test.ts
@@ -93,12 +93,18 @@ const FOREIGN = {
 function startDirectoryMock(options: {
   directoryStatus?: number;
   currentStatus: 401 | 403;
-}): Promise<{ url: string; close: () => Promise<void> }> {
+}): Promise<{
+  url: string;
+  close: () => Promise<void>;
+  /** Flip `/current` so a test can move the daemon from "no ambient" to "ambient". */
+  setCurrentStatus: (status: 401 | 403) => void;
+}> {
+  let currentStatus = options.currentStatus;
   const server: Server = createServer((req, res) => {
     const url = req.url ?? '';
     if (url.startsWith('/api/v1/workspaces/current')) {
-      res.writeHead(options.currentStatus, { 'content-type': 'application/json' });
-      res.end(JSON.stringify(options.currentStatus === 403 ? { error: 'missing_principal' } : { error: 'unauthorized' }));
+      res.writeHead(currentStatus, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(currentStatus === 403 ? { error: 'missing_principal' } : { error: 'unauthorized' }));
       return;
     }
     if (url.startsWith('/api/v1/workspaces')) {
@@ -117,6 +123,9 @@ function startDirectoryMock(options: {
       resolve({
         url: `http://127.0.0.1:${address.port}`,
         close: () => new Promise<void>((done) => server.close(() => done())),
+        setCurrentStatus: (status) => {
+          currentStatus = status;
+        },
       });
     });
   });
@@ -185,16 +194,27 @@ const duplicatePath = (id: string) => `/api/projects/${encodeURIComponent(id)}/d
 const designSystemCopyPath = (id: string) =>
   `/api/projects/${encodeURIComponent(id)}/design-system-copy`;
 
-let readableAuthority: { url: string; close: () => Promise<void> };
-let unreadableAuthority: { url: string; close: () => Promise<void> };
+type DirectoryMock = Awaited<ReturnType<typeof startDirectoryMock>>;
+
+let readableAuthority: DirectoryMock;
+let unreadableAuthority: DirectoryMock;
+/** Directory readable, and `/current` flippable so a test can move the daemon
+ *  from "no ambient" to "ambient" between two phases. */
+let ambientAuthority: DirectoryMock;
 
 beforeAll(async () => {
   readableAuthority = await startDirectoryMock({ currentStatus: 401 });
   unreadableAuthority = await startDirectoryMock({ currentStatus: 401, directoryStatus: 500 });
+  // Starts WITHOUT ambient so a true orphan can be created, then flips.
+  ambientAuthority = await startDirectoryMock({ currentStatus: 401 });
 });
 
 afterAll(async () => {
-  await Promise.all([readableAuthority.close(), unreadableAuthority.close()]);
+  await Promise.all([
+    readableAuthority.close(),
+    unreadableAuthority.close(),
+    ambientAuthority.close(),
+  ]);
 });
 
 describe('reconciling an unbound project verifies the asserted workspace first', () => {
@@ -307,6 +327,84 @@ describe('reconciling an unbound project verifies the asserted workspace first',
   );
 
   test(
+    'a populated but DIFFERENT ambient workspace is not written onto an existing orphan',
+    { timeout: 300_000 },
+    async () => {
+      const suite = await createSmokeSuite('collab-reconcile-ambient-mismatch');
+
+      // The state-integrity case. Unlike the fixtures above, this daemon HAS an
+      // ambient workspace (`/current` answers 403 missing_principal, so the
+      // provider bootstraps a default from the directory).
+      //
+      // A pre-existing orphan is not a new project. Binding a NEW project to the
+      // ambient workspace takes nothing from anyone — that is #6201 and it is
+      // right. Binding an EXISTING orphan there, because someone asserted an
+      // identity that could not be verified, may take it from the workspace it
+      // actually belongs to. Worse, it is sticky: this helper's own
+      // `getWorkspaceProjectByProjectId` guard means the rightful verified
+      // workspace can never reconcile it afterwards. Creation and reconciliation
+      // are not the same risk.
+      //
+      // So a degraded (ambient) authority may only be persisted when it names
+      // the very pair that was asserted — outage continuity for a legitimate
+      // caller whose client is on the same workspace the daemon resolved — and
+      // otherwise nothing is written at all.
+      await suite.with.toolsDev(
+        async ({ webUrl }) => {
+          // PHASE 1 — no ambient yet, so a headerless create leaves a true orphan
+          // (#6201's create-side binding has nothing to bind to).
+          ambientAuthority.setCurrentStatus(401);
+          const orphan = await createUnboundProject(webUrl, 'Ambient mismatch orphan');
+          expect(
+            (await readScope(webUrl, orphan)).kind,
+            'precondition: this must be a true orphan',
+          ).toBe('unbound');
+
+          // PHASE 2 — the daemon now resolves an ambient workspace. Reading
+          // `/api/workspace/context` drives `.current()`, which is what populates
+          // the `lastKnown()` cache the resolver degrades to, so this is
+          // deterministic rather than waiting on a poll tick.
+          ambientAuthority.setCurrentStatus(403);
+          const ambientContext = await waitForAmbientWorkspace(webUrl);
+          expect(
+            ambientContext,
+            'precondition: the daemon must now have an ambient workspace to degrade to',
+          ).toBe(MEMBER.workspaceId);
+
+          // Asserts a pair the directory does NOT list. Verification fails, so the
+          // resolver degrades to ambient — which is a REAL workspace here, and a
+          // different one from what was asserted.
+          await mutate(webUrl, duplicatePath(orphan), workspaceHeaders(FOREIGN), {
+            name: 'Duplicate asserting an unverifiable pair',
+          });
+
+          const after = await readScope(webUrl, orphan);
+          expect(
+            after.workspaceId,
+            'the unverifiable assertion must not be persisted',
+          ).not.toBe(FOREIGN.workspaceId);
+          expect(
+            after.workspaceId,
+            'nor may the ambient workspace be written onto a pre-existing orphan it was never asserted for',
+          ).not.toBe(MEMBER.workspaceId);
+          expect(
+            after.kind,
+            'the orphan stays unbound so the rightful workspace can still reconcile it',
+          ).toBe('unbound');
+        },
+        {
+          env: {
+            AMR_HOME: await emptyAmrHome(suite.scratchDir),
+            OD_WORKSPACE_CONTEXT_SOURCE: 'vela',
+            VELA_API_URL: ambientAuthority.url,
+            VELA_CONTROL_KEY: 'e2e-reconcile-control-key',
+          },
+        },
+      );
+    },
+  );
+
+  test(
     'an unreadable membership authority cannot confirm a claim, so none is written',
     { timeout: 300_000 },
     async () => {
@@ -341,6 +439,24 @@ describe('reconciling an unbound project verifies the asserted workspace first',
   );
 
 });
+
+/**
+ * Drive `.current()` until the daemon reports an ambient workspace, and return
+ * its id. `GET /api/workspace/context` calls the provider directly, so this both
+ * observes and populates the `lastKnown()` cache.
+ */
+async function waitForAmbientWorkspace(webUrl: string): Promise<string | null> {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    const body = await requestJson<{ context: { workspaceId?: string } | null }>(
+      webUrl,
+      '/api/workspace/context',
+    );
+    const workspaceId = body.context?.workspaceId;
+    if (typeof workspaceId === 'string' && workspaceId) return workspaceId;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  return null;
+}
 
 /**
  * A vela config home guaranteed to hold no session, so the daemon's


### PR DESCRIPTION
## Why

**Use case.** Follow-up to #6201. While fixing the created-project trust hole `PerishCode` caught there, I found the same shape in a neighbouring helper and flagged it rather than widening a security change late in review. The owner ruled: fix it.

**The pain.** `reconcileUnboundProjectBeforeMutation` (`apps/daemon/src/routes/project/index.ts:2139`) exists for a good reason — it claims a project this daemon has never bound to *any* workspace into the mutating request's workspace, so a true orphan is not denied its first mutation by `enforceWorkspaceResourceMutation`'s `!row -> false` rule (recvqbhor3pai2, 「复制的项目再次复制」).

But it resolved that workspace from `workspaceProjectContextFromRequest(req)` — header **parsing**, no authority check — and stamped `createdByWorkspaceMemberId: ctx.workspaceMemberId` from the same headers:

```ts
const ctx = workspaceProjectContextFromRequest(req);
if (ctx === null || ctx === 'missing') return;
if (getWorkspaceProjectByProjectId(db, projectId)) return;
ensureWorkspaceProject(db, {
  workspaceId: ctx.workspaceId,                        // unverified
  createdByWorkspaceMemberId: ctx.workspaceMemberId,   // unverified authorship
  ...
});
```

`x-od-workspace-*` is an unauthenticated hint any local caller can forge, so a plain `curl` could claim an orphaned project into a workspace it has no membership in **and install itself as the project's author**. Authorship is the dangerous half: `workspaceResourceAccess` derives `selfCreated` from it, and that bit is what grants a non-privileged member mutation rights over the row. Reachable from `POST /api/projects/:id/duplicate` (`:3215`) and `POST /api/projects/:id/design-system-copy` (`:3324`).

## What changed

Both the workspace **and** the authorship now come from `resolveCreatedProjectHome` — the same `createCreatedProjectWorkspaceResolver` #6201 introduced, so there is still one notion of "verified" per daemon:

| Branch | Workspace written | `createdByWorkspaceMemberId` written | Why |
|---|---|---|---|
| Asserted identity **verifies** against the membership directory | the **directory's** `workspaceId` | the **directory's** `workspaceMemberId` | `authorizeCreatedProjectWorkspace` returns the authoritative directory context, not the caller's claim, so even a truthful header is not the source of record |
| Asserted identity **does not verify** — foreign, member not active, permissions disagree, last-known says removed, or the authority is **unreadable so it cannot be confirmed** | the daemon's **ambient** `workspaceId` (`lastKnown()`), or nothing | the **ambient** session's `workspaceMemberId`, or nothing | the ambient identity is the daemon's own vela-verified session; a header value is never persisted. "Cannot confirm" is not "valid" — an outage must not become a window for writing claims |
| **Nothing asserted** (`null` / `'missing'`) | nothing — unchanged early return | n/a | see below; this is load-bearing |
| Project already bound anywhere | nothing — unchanged | n/a | `getWorkspaceProjectByProjectId` guard, matching `ensureWorkspaceProject`'s idempotency contract |

**Attribution is still non-null on the claiming branches, deliberately.** The original docblock argued that an explicit mutation naming this exact project is the "yes, this is mine" signal a passive read never had, so it uses a member id rather than the `null` a lazy read projection writes. That reasoning is intact — only the *provenance* changes, from "whatever the header said" to "whatever the authority confirmed". So this is not a downgrade to unattributed rows; it is the same attribution from a trustworthy source.

**Why the `null`/`'missing'` early return is kept rather than delegating to `createdProjectWorkspaceHome`'s own third branch.** This helper runs immediately before `enforceWorkspaceResourceMutation`, whose **headerless** branch reads `getWorkspaceResourceByResourceId` and answers `401 WORKSPACE_CONTEXT_REQUIRED` as soon as *any* row exists for the resource. Claiming on a request that asserts nothing would therefore convert a working headerless duplicate into a 401. Pinned by a test case.

## Review follow-up: only an asserted-and-confirmed workspace is persisted (958fc872)

`mrcfps` caught that `resolveCreatedProjectHome` is not a pure verifier — by contract a foreign, inactive, removed, or unconfirmable assertion **degrades to `lastKnown()`** — so the original patch persisted that ambient context onto a **pre-existing orphan**, and the `getWorkspaceProjectByProjectId` guard above makes such a write **sticky**. A forged request, or a legitimate one during an authority outage after the active workspace changed, would permanently mis-file the project with nothing able to correct it.

**Creation and reconciliation are not the same risk.** A brand-new project landing in the ambient workspace takes nothing from anyone (that is #6201, unchanged). A pre-existing orphan landing there may be taken from the workspace it belongs to.

The fix is a single exact-match guard that collapses both of the reviewer's requirements:

```ts
if (
  home.workspaceId !== asserted.workspaceId
  || home.workspaceMemberId !== asserted.workspaceMemberId
) {
  return;
}
```

A verified assertion resolves to the asserted pair by construction (the directory lookup is keyed on it), so every directory-confirmed claim is admitted unchanged; only a *degraded* ambient authority naming something else is rejected. Outage continuity still works for the ordinary legitimate caller, whose client took its headers from this same daemon.

**Not in tension with 「所有 project 都应该能找到 workspace」.** The display-side fallback (#6185) already resolves an unbound project against the caller's current workspace, so a user never sees "unknown" — that ruling is satisfied at read time. The binding row is a separate, durable fact and stays conservative.

**Red→green for the new boundary.** The reviewer's coverage point was correct: both earlier failure-branch cases ran with *no* ambient, so the populated-but-different-ambient path was untested. New case: *"a populated but DIFFERENT ambient workspace is not written onto an existing orphan"*. It needs a two-phase fixture, because post-#6201 a headerless create in a runtime that *has* ambient is no longer an orphan — the mock authority's `/current` is now flippable, so phase 1 creates a true orphan with ambient absent and phase 2 populates ambient deterministically via `GET /api/workspace/context` rather than waiting on a poll tick.

RED on the previous head:

```
× a populated but DIFFERENT ambient workspace is not written onto an existing orphan
AssertionError: nor may the ambient workspace be written onto a pre-existing orphan
  it was never asserted for: expected 'ws-rec-personal' not to be 'ws-rec-personal'
 Tests  1 failed | 2 passed (3)
```

GREEN after: `Tests 3 passed (3)`. **Mutation-tested** — deleting only the exact-match condition turns that case red again and leaves the other two green.

## How this composes with #6216

Deliberately two PRs, cross-linked, because separately each looks like it makes something worse:

- **This PR** stops *wrong* bindings being written.
- **#6216** stops the mutation gate refusing a caller when *no* binding exists (the `od project create` → `od project duplicate` → 401 break).

Together: never mis-file a project, and never refuse someone who can legitimately reach it. #6216 resolves an identity at request time and **persists nothing**, which is what makes this PR's conservative "return without writing" cheap — the orphan stays unbound and a headerless caller can still mutate it.

**The honest residue:** #6216 only rescues *headerless* callers. An **asserted** caller takes the authenticated branch where `!row → false`, so during an authority outage in which ambient no longer matches the asserted pair, a duplicate now 403s rather than silently mis-filing. I believe that is the right trade — mis-filing is invisible and permanent, a 403 is loud and retryable — and the exact-match condition narrows it to a genuine mismatch rather than to every outage. Recorded here rather than left for a bug report.

## Consequence worth reviewing explicitly

A caller asserting an identity that **cannot be verified**, mutating a project nothing has ever claimed, previously got `200` — because this helper invented a binding for it, which then satisfied the gate one line later. It now gets the pre-existing gate's `403 WORKSPACE_PROJECT_PERMISSION_DENIED`.

I believe that is correct rather than a regression, and here is the reasoning I'd want challenged:

- **A verified caller is unaffected.** The claim is written, the gate finds it, `200`. `apps/daemon/tests/routes/workspace-projects.test.ts`'s recvqbhor3pai2 regression case ("allows duplicating a copy that a prior headerless duplicate left unbound") passes **unchanged**, 38/38.
- **A headerless caller is unaffected.** No claim is written, the gate's headerless branch sees no row, `200`. Pinned.
- **A legitimate caller during a transient vela outage is unaffected.** `lastKnown()` survives a transient null by design (`withLastKnownWorkspaceContext`), so ambient is normally still populated — and for a real client the asserted workspace *is* the ambient one, because the client got its headers from this same daemon's `/api/workspace/context`. The claim lands in the right place and the gate passes.
- The `403` therefore requires asserted-workspace ≠ ambient **and** an unverifiable assertion: a forged or badly stale identity. That caller has not proven membership over a project nothing has claimed, and letting it through on a self-issued binding is precisely the hole being closed.

The one residual: a daemon that has resolved **no** workspace this session *and* cannot read the directory, receiving a request that nonetheless carries headers. That client could not have obtained headers from this daemon in that state, so I treat it as unreachable in practice — flagging it rather than hiding it.

## What users will see

Nothing new to click, and nothing changes for a normal signed-in user: duplicate and design-system copy behave exactly as today. What changes is invisible and protective — a forged or unverifiable workspace identity can no longer write itself in as the owner of a project it does not belong to.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [x] **Default behavior change** — a caller whose asserted workspace identity cannot be verified no longer has an orphan project claimed into that workspace on its behalf, and consequently is refused by the pre-existing mutation gate instead of being allowed. Verified callers, headerless callers, and already-bound projects are all unchanged. No new endpoint, flag, or contract change.
- [ ] **None**

No UI surface: the change is a single daemon-side helper. Two test files, one source file.

**CLI parity.** No `od` surface added or needed — this is a hardening change inside an existing endpoint that both surfaces already call. Note the separate CLI finding below, which came out of this work.

## Bug fix verification

- **Test:** `e2e/tests/collab/reconcile-unbound-authority.test.ts` — HTTP boundary, e2e Vitest, running with `OD_WORKSPACE_CONTEXT_SOURCE=vela` so the membership authority is live. Seeded only through the daemon's real vela integration against a temporary server-level mock; no source-level backdoor.
- **Red on unmodified `origin/feat/workspace-team`, green on this branch:** yes.

Assertions are on the **persisted binding** (`GET /api/projects/:id/workspace-scope`), never on the mutation's status code — whether the mutation itself is allowed is the pre-existing gate's business and legitimately differs for a caller that cannot prove membership. The security property is that no unverifiable claim is ever written.

Covers: forged pair via **duplicate** (case 1), forged pair via **design-system copy** (case 2), **unreadable authority** with an otherwise-legitimate pair (case 3), **verified identity still claims** (case 4), **nothing asserted writes nothing and stays 200** (case 5), and `createdByWorkspaceMemberId` (case 6 — see note).

**RED** on unmodified base:

```
 × a forged workspace/member pair never becomes a claim, through either entry point 18488ms
 × an unreadable membership authority cannot confirm a claim, so none is written 15267ms
 × a headerless mutation writes no claim even when an ambient workspace exists 11732ms

AssertionError: a forged header pair must never be persisted as this project's workspace:
  expected 'ws-rec-foreign' not to be 'ws-rec-foreign'
AssertionError: expected 'ws-rec-personal' not to be 'ws-rec-personal'
AssertionError: a headerless duplicate must not become a 401: expected 401 to be 200

 Test Files  1 failed (1)
      Tests  3 failed (3)
```

**GREEN** on this branch:

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

**Mutation-tested**, as requested: restoring *only* the value source (`const home = asserted;`, i.e. the header-parsed context) while leaving every other line of the fix in place turns cases 1 and 2 red again — so the spec is pinning the fix, not incidental behavior:

```
 × a forged workspace/member pair never becomes a claim, through either entry point
 × an unreadable membership authority cannot confirm a claim, so none is written

AssertionError: a forged header pair must never be persisted as this project's workspace:
  expected 'ws-rec-foreign' not to be 'ws-rec-foreign'
AssertionError: expected 'ws-rec-personal' not to be 'ws-rec-personal'
```

Two notes on the test set, both deliberate:

- **The third RED case became unreachable and was folded into case 5.** Its premise was "headerless mutation + ambient workspace present + genuinely unbound source". Post-#6201 that combination cannot exist: with an ambient workspace, the create-side binding claims the project at creation, so it is never unbound. What the red output above actually caught is a **separate pre-existing defect** (see Adjacent issues #1) — a headerless mutation of an *already bound* project 401s. I did not silently absorb that into this PR. Case 5 now pins the reachable property in the no-ambient runtime: a headerless duplicate of a true orphan stays `200` and writes no claim.
- **Case 6 is asserted by absence plus provenance.** In every failure branch no row is written at all, which is the strongest possible statement that no header-supplied authorship was persisted — pinned as `kind === 'unbound'`. On the verified branch, `GET /api/workspaces/:id/projects` is asserted to report `createdByWorkspaceMemberId` equal to the confirmed member. The header and the directory necessarily agree on that value in the verified case, so the assertion pins *that attribution happens and names the confirmed member*, not a byte-level distinction between the two sources; the provenance itself is enforced by construction, since `authorizeCreatedProjectWorkspace` builds its context from the directory item.

**Harness audit** (the `brand-routes.test.ts` lesson from #6201, where a harness missing the resolver seam silently no-op'd the claim instead of failing loudly): I grepped every harness that builds these routes — `delete-cancels-active-runs`, `collab/workspace-projects-reconcile-http`, `collab/workspace-projects-reconcile-membership`, `routes/project-move-owner-conflict`, `routes/project-delete-unshares-team-share`, `routes/project-move-to-personal`, `routes/workspace-projects`. None of them can silently no-op here: `resolveCreatedProjectHome` is constructed *inside* `registerProjectRoutes` from `ctx`, and a harness that omits `fetchProjectCreationWorkspaceDirectory` gets `authorizeCreatedProjectWorkspace`'s documented local/dev compatibility path — i.e. today's behavior — rather than a disabled claim. `workspace-projects.test.ts` is the one harness that actually exercises this helper and it passes unchanged.

## Validation

Node 24.18.0 throughout (Node 22 miscompiles `better-sqlite3`'s ABI).

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/daemon build` — pass, **plus a real `require('dist/server.js')` load** (75 exports resolved). Daemon typecheck is not cited as evidence: `server.ts` carries `@ts-nocheck`, as do 29 daemon files.
- `pnpm --filter @open-design/daemon test` — **`Test Files 570 passed | 3 skipped (573)` / `Tests 7164 passed | 6 skipped | 4 todo`, EXIT=0.** No isolation needed: the known order-dependent `collab-sync-routes.test.ts` case and the alternating `run-retry-runtime.test.ts` both passed in this run.
- `pnpm --filter @open-design/daemon exec vitest run tests/routes/workspace-projects.test.ts` — 38/38, including the recvqbhor3pai2 regression case this helper exists for
- `cd e2e && pnpm test tests/collab` — `Test Files 3 passed (3)` / `Tests 6 passed (6)`

## Adjacent issues (deliberately not fixed here)

1. **A headerless mutation of a BOUND project answers 401 — a live regression from #6201, affecting the `od` CLI.** `enforceWorkspaceResourceMutation`'s headerless branch answers `401 WORKSPACE_CONTEXT_REQUIRED` whenever any `workspace_projects` row exists. #6201 made headerless creates *bind* (to the ambient workspace), so projects that used to be unbound are now bound — and the CLI never sends `x-od-workspace-*` headers (`apps/daemon/src/cli.ts:6387`, and its only header builder lives inside `od workspace …`). Net effect on a signed-in daemon: `od project create` succeeds, then `od project duplicate` on that project **401s**. Caught incidentally by this PR's red run (`expected 401 to be 200`) rather than by design. This is a real dual-track CLI break and wants its own PR — most likely by giving the CLI the workspace headers it already has the endpoints to obtain (`GET /api/workspace/directory` reports `activeWorkspaceId`), which is the same work as the `od workspace use` gap noted in #6201.
2. **`od workspace use <id>`** — still missing, still only a CLI verb away: the persisted selection, the switch endpoint (`PUT /api/workspace/active`), and the read (`GET /api/workspace/directory`) all exist. Carried over from #6201.

