### PR TITLE
fix(daemon): list dot-prefixed user content in managed projects

### DIFF
--- a/apps/daemon/src/live-artifacts/schema.ts
+++ b/apps/daemon/src/live-artifacts/schema.ts
@@ -1,3 +1,5 @@
+import { isReservedProjectFilePath } from '../projects.js';
+
 // Runtime validation lives in the daemon. These mirror the shared DTOs in
 // packages/contracts/src/api/live-artifacts.ts without importing daemon internals
 // into contracts or forcing the daemon to compile contract source files.
@@ -329,24 +331,21 @@ function validateRelativePath(value: string, path: string, issues: LiveArtifactV
   }
 }
 
-// Reserved project path segments rejected by validateProjectPath() in projects.ts.
-// Mirrored here (kept in sync with RESERVED_PROJECT_FILE_SEGMENTS) so schema-side
-// acceptance stays a subset of what a refresh can actually read.
-const RESERVED_READ_JSON_SEGMENTS = new Set(['.live-artifacts']);
-
 // project_files.read_json resolves a selector, feeds it to validateProjectPath()
 // (refresh.ts → projects.ts), and then requires a .json extension. validateRelativePath
 // alone misses single-dot segments, reserved segments, and the extension, so mirror the
 // remaining static rules here — otherwise sources like { path: './report.json' } or
 // { file: '.live-artifacts/cache.json' } pass creation yet fail every refresh, recreating
 // the persisted-but-unrefreshable artifact class this validation exists to prevent.
+// The reserved-path predicate is shared with runtime reads so exact, prefix, and
+// case-insensitive aliases cannot drift between registration and refresh.
 function validateReadJsonSelector(value: string, path: string, issues: LiveArtifactValidationIssue[]): void {
   validateRelativePath(value, path, issues); // absolute / .. / null-byte / length
   const segments = value.replace(/\\/g, '/').split('/').filter((part) => part.length > 0);
   if (segments.some((part) => part === '.')) {
     issues.push({ path, message: `${path} cannot contain '.' path segments` });
   }
-  if (segments.some((part) => RESERVED_READ_JSON_SEGMENTS.has(part))) {
+  if (isReservedProjectFilePath(value)) {
     issues.push({ path, message: `${path} cannot reference a reserved project path` });
   }
   // Case-sensitive to match executeProjectFilesReadJson's `endsWith('.json')` exactly;

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -368,6 +368,16 @@ export async function buildProjectArchive(projectsRoot, projectId, root, metadat
     // collectArchiveEntries() / readFile() would follow the symlink at
     // open() time and zip files outside the project tree.
     archiveRoot = await resolveSafeReal(projectRoot, root);
+    const projectRootReal = await realpath(projectRoot).catch(() => projectRoot);
+    const resolvedRootSegments = path
+      .relative(projectRootReal, archiveRoot)
+      .split(path.sep)
+      .filter(Boolean);
+    if (resolvedRootSegments.some((segment) => isListingSkippedDirName(segment))) {
+      const err = new Error('archive root is ignored or reserved');
+      err.code = 'BAD_REQUEST';
+      throw err;
+    }
     archiveBaseName = path.basename(archiveRoot);
   }
 

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -373,6 +373,7 @@ export async function buildProjectArchive(projectsRoot, projectId, root, metadat
       .relative(projectRootReal, archiveRoot)
       .split(path.sep)
       .filter(Boolean);
+    assertVisibleForImportedProject(resolvedRootSegments.join('/'), metadata);
     if (resolvedRootSegments.some((segment) => isListingSkippedDirName(segment))) {
       const err = new Error('archive root is ignored or reserved');
       err.code = 'BAD_REQUEST';

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -35,13 +35,33 @@ import {
 import { isOrchestratorScratchWorkspace } from './workspace-contract.js';
 
 const FORBIDDEN_SEGMENT = /^$|^\.\.?$/;
-const RESERVED_PROJECT_FILE_SEGMENTS = new Set(['.file-versions', '.live-artifacts']);
+const RESERVED_PROJECT_FILE_SEGMENTS = new Set([
+  '.amr-attachments',
+  '.file-versions',
+  '.finalize.lock',
+  '.live-artifacts',
+  '.mcp.json',
+  '.od-skills',
+  '.open-design',
+  '.pi',
+  '.transcript.jsonl',
+  '.transcript.lock',
+]);
+const RESERVED_PROJECT_FILE_PREFIXES = ['.od-rename-', '.transcript.jsonl.tmp.'];
+
+function isReservedProjectFileSegment(name: string): boolean {
+  const normalized = name.toLowerCase();
+  return (
+    RESERVED_PROJECT_FILE_SEGMENTS.has(normalized) ||
+    RESERVED_PROJECT_FILE_PREFIXES.some((prefix) => normalized.startsWith(prefix))
+  );
+}
 
 // Listing skips both the generated/installed trees from the shared ignore
 // list and the daemon's reserved state directories — the latter must never
 // surface even now that other dot-prefixed user content is listed (#6175).
 function isListingSkippedDirName(name: string): boolean {
-  return isIgnoredProjectDirName(name) || RESERVED_PROJECT_FILE_SEGMENTS.has(name);
+  return isIgnoredProjectDirName(name) || isReservedProjectFileSegment(name);
 }
 const DESIGN_HANDOFF_FILENAME = 'DESIGN-HANDOFF.md';
 const DESIGN_MANIFEST_FILENAME = 'DESIGN-MANIFEST.json';
@@ -152,7 +172,7 @@ export async function listFiles(projectsRoot, projectId, opts = {}) {
   // managed projects (#6175); imported folders keep hiding dot entries to
   // stay consistent with assertVisibleForImportedProject, which refuses to
   // serve hidden path segments from a user's own directory. Reserved daemon
-  // directories (.live-artifacts, .file-versions) stay hidden everywhere.
+  // state files and directories stay hidden everywhere.
   const skipHidden = hasExternalProjectRoot(metadata);
   await collectFiles(dir, '', out, isListingSkippedDirName, dir, skipHidden);
   // Newest first — matches the visual order users expect after generating.
@@ -300,6 +320,7 @@ async function collectFiles(
   }
   for (const e of entries) {
     if (skipHidden && e.name.startsWith('.')) continue;
+    if (isReservedProjectFileSegment(e.name)) continue;
     const rel = relDir ? `${relDir}/${e.name}` : e.name;
     const full = path.join(dir, e.name);
     if (e.isDirectory()) {
@@ -531,6 +552,7 @@ async function collectArchiveEntries(dir, relDir, out, skipHidden = false) {
   }
   for (const e of entries) {
     if (skipHidden && e.name.startsWith('.')) continue;
+    if (isReservedProjectFileSegment(e.name)) continue;
     if (!e.isDirectory() && !e.isFile()) continue;
     const rel = relDir ? `${relDir}/${e.name}` : e.name;
     const full = path.join(dir, e.name);
@@ -1487,7 +1509,7 @@ export function validateProjectPath(raw) {
   if (parts.length === 0 || parts.some((p) => FORBIDDEN_SEGMENT.test(p))) {
     throw new Error('invalid file name');
   }
-  if (parts.some((part) => RESERVED_PROJECT_FILE_SEGMENTS.has(part))) {
+  if (parts.some((part) => isReservedProjectFileSegment(part))) {
     throw new Error('reserved project path');
   }
   return parts.join('/');
@@ -1496,7 +1518,7 @@ export function validateProjectPath(raw) {
 export function isReservedProjectFilePath(raw) {
   try {
     const normalized = String(raw ?? '').replace(/\\/g, '/');
-    return normalized.split('/').filter(Boolean).some((part) => RESERVED_PROJECT_FILE_SEGMENTS.has(part));
+    return normalized.split('/').filter(Boolean).some((part) => isReservedProjectFileSegment(part));
   } catch {
     return false;
   }

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -36,6 +36,13 @@ import { isOrchestratorScratchWorkspace } from './workspace-contract.js';
 
 const FORBIDDEN_SEGMENT = /^$|^\.\.?$/;
 const RESERVED_PROJECT_FILE_SEGMENTS = new Set(['.file-versions', '.live-artifacts']);
+
+// Listing skips both the generated/installed trees from the shared ignore
+// list and the daemon's reserved state directories — the latter must never
+// surface even now that other dot-prefixed user content is listed (#6175).
+function isListingSkippedDirName(name: string): boolean {
+  return isIgnoredProjectDirName(name) || RESERVED_PROJECT_FILE_SEGMENTS.has(name);
+}
 const DESIGN_HANDOFF_FILENAME = 'DESIGN-HANDOFF.md';
 const DESIGN_MANIFEST_FILENAME = 'DESIGN-MANIFEST.json';
 export const RUN_ARTIFACT_RECONCILE_MTIME_GRACE_MS = 1000;
@@ -141,7 +148,13 @@ export async function listFiles(projectsRoot, projectId, opts = {}) {
   // Skip generated dependency/build trees for all project roots. Standard OD
   // projects can contain framework installs too; surfacing package HTML like
   // node_modules/tslib/*.html as artifacts produces blank previews.
-  await collectFiles(dir, '', out, isIgnoredProjectDirName, dir);
+  // Dot-prefixed user content (.github/, .vscode/, .notes.md) is listed for
+  // managed projects (#6175); imported folders keep hiding dot entries to
+  // stay consistent with assertVisibleForImportedProject, which refuses to
+  // serve hidden path segments from a user's own directory. Reserved daemon
+  // directories (.live-artifacts, .file-versions) stay hidden everywhere.
+  const skipHidden = hasExternalProjectRoot(metadata);
+  await collectFiles(dir, '', out, isListingSkippedDirName, dir, skipHidden);
   // Newest first — matches the visual order users expect after generating.
   out.sort((a, b) => b.mtime - a.mtime);
   const since = Number(opts.since);
@@ -155,12 +168,20 @@ export async function listProjectFolders(projectsRoot, projectId, opts = {}) {
   const metadata = opts?.metadata;
   const dir = resolveProjectDir(projectsRoot, projectId, metadata);
   const out = [];
-  await collectFolders(dir, '', out, isIgnoredProjectDirName);
+  // Same hidden-entry policy as listFiles (#6175).
+  const skipHidden = hasExternalProjectRoot(metadata);
+  await collectFolders(dir, '', out, isListingSkippedDirName, skipHidden);
   out.sort((a, b) => a.name.localeCompare(b.name));
   return out;
 }
 
-async function collectFolders(dir, relDir, out, shouldSkipDir?: (name: string) => boolean) {
+async function collectFolders(
+  dir,
+  relDir,
+  out,
+  shouldSkipDir?: (name: string) => boolean,
+  skipHidden = false,
+) {
   let entries = [];
   try {
     entries = await readdir(dir, { withFileTypes: true });
@@ -170,7 +191,7 @@ async function collectFolders(dir, relDir, out, shouldSkipDir?: (name: string) =
   }
   for (const e of entries) {
     if (!e.isDirectory()) continue;
-    if (e.name.startsWith('.')) continue;
+    if (skipHidden && e.name.startsWith('.')) continue;
     if (shouldSkipDir?.(e.name)) continue;
     const rel = relDir ? `${relDir}/${e.name}` : e.name;
     const full = path.join(dir, e.name);
@@ -182,7 +203,7 @@ async function collectFolders(dir, relDir, out, shouldSkipDir?: (name: string) =
       size: 0,
       mtime: st.mtimeMs,
     });
-    await collectFolders(full, rel, out, shouldSkipDir);
+    await collectFolders(full, rel, out, shouldSkipDir, skipHidden);
   }
 }
 
@@ -262,7 +283,14 @@ export async function detectEntryFile(dir: string): Promise<string | null> {
   return null;
 }
 
-async function collectFiles(dir, relDir, out, shouldSkipDir?: (name: string) => boolean, projectRoot = dir) {
+async function collectFiles(
+  dir,
+  relDir,
+  out,
+  shouldSkipDir?: (name: string) => boolean,
+  projectRoot = dir,
+  skipHidden = false,
+) {
   let entries = [];
   try {
     entries = await readdir(dir, { withFileTypes: true });
@@ -271,12 +299,12 @@ async function collectFiles(dir, relDir, out, shouldSkipDir?: (name: string) => 
     throw err;
   }
   for (const e of entries) {
-    if (e.name.startsWith('.')) continue;
+    if (skipHidden && e.name.startsWith('.')) continue;
     const rel = relDir ? `${relDir}/${e.name}` : e.name;
     const full = path.join(dir, e.name);
     if (e.isDirectory()) {
       if (shouldSkipDir?.(e.name)) continue;
-      await collectFiles(full, rel, out, shouldSkipDir, projectRoot);
+      await collectFiles(full, rel, out, shouldSkipDir, projectRoot, skipHidden);
       continue;
     }
     if (!e.isFile()) continue;

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -327,16 +327,19 @@ async function collectFiles(
 }
 
 // Build a ZIP of every file under the project directory (or under `root`,
-// if it points at a subdirectory). Mirrors listFiles' filtering — dotfiles
-// and `.artifact.json` sidecars are excluded — so the archive matches what
-// the user sees in the file panel. Used by the "Download as .zip" share
-// menu item, which exports the user's actual project tree (e.g. the
-// uploaded `ui-design/` folder), not just the rendered HTML.
+// if it points at a subdirectory). Mirrors listFiles' filtering: managed
+// projects keep user-owned dotfiles, imported folders keep hiding all hidden
+// segments, and ignored/reserved trees plus `.artifact.json` sidecars stay
+// excluded everywhere. Used by the "Download as .zip" share menu item, which
+// exports the user's actual project tree (e.g. the uploaded `ui-design/`
+// folder), not just the rendered HTML.
 export async function buildProjectArchive(projectsRoot, projectId, root, metadata?) {
   const projectRoot = resolveProjectDir(projectsRoot, projectId, metadata);
+  const skipHidden = hasExternalProjectRoot(metadata);
   let archiveRoot = projectRoot;
   let archiveBaseName = '';
   if (typeof root === 'string' && root.trim().length > 0) {
+    assertVisibleForImportedProject(root, metadata);
     // Use the symlink-aware resolver so that an imported folder containing
     // e.g. `docs -> /Users/me/.ssh` cannot exfiltrate via
     // GET /api/projects/:id/archive?root=docs. resolveSafe()'s string
@@ -369,7 +372,7 @@ export async function buildProjectArchive(projectsRoot, projectId, root, metadat
   }
 
   const entries = [];
-  await collectArchiveEntries(archiveRoot, '', entries);
+  await collectArchiveEntries(archiveRoot, '', entries, skipHidden);
   if (entries.length === 0) {
     const err = new Error('archive root is empty');
     err.code = 'ENOENT';
@@ -414,18 +417,21 @@ export async function buildBatchArchive(projectsRoot, projectId, fileNames, meta
     }
 
     // Mirror the visible-file allowlist from collectFiles/collectArchiveEntries:
-    // reject any hidden segment, .artifact.json sidecars, and symlinks at any
-    // level of the path (not just the final basename).
+    // imported folders reject every hidden segment; managed projects allow
+    // user dotfiles but still reject ignored/reserved trees. Sidecars and
+    // symlinks remain ineligible everywhere.
     const relSegments = path.relative(projectRoot, filePath).split(path.sep);
-    let hidden = false;
-    for (const seg of relSegments) {
-      if (seg.startsWith('.')) {
-        hidden = true;
-        break;
-      }
-    }
-    if (hidden) {
+    const importedHidden =
+      hasExternalProjectRoot(metadata) && relSegments.some((seg) => seg.startsWith('.'));
+    if (importedHidden) {
       rejected.push({ name, reason: 'hidden segments are not eligible for archive' });
+      continue;
+    }
+    // Only directory segments participate in the shared directory ignore
+    // policy. A regular user file may legitimately be named `build` or
+    // `vendor`; validateProjectPath() already rejects reserved state segments.
+    if (relSegments.slice(0, -1).some((seg) => isIgnoredProjectDirName(seg))) {
+      rejected.push({ name, reason: 'ignored directory segments are not eligible for archive' });
       continue;
     }
     if (path.basename(filePath).endsWith('.artifact.json')) {
@@ -515,7 +521,7 @@ export async function buildBatchArchive(projectsRoot, projectId, fileNames, meta
   return { buffer, baseName: '' };
 }
 
-async function collectArchiveEntries(dir, relDir, out) {
+async function collectArchiveEntries(dir, relDir, out, skipHidden = false) {
   let entries = [];
   try {
     entries = await readdir(dir, { withFileTypes: true });
@@ -524,13 +530,13 @@ async function collectArchiveEntries(dir, relDir, out) {
     throw err;
   }
   for (const e of entries) {
-    if (e.name.startsWith('.')) continue;
+    if (skipHidden && e.name.startsWith('.')) continue;
     if (!e.isDirectory() && !e.isFile()) continue;
     const rel = relDir ? `${relDir}/${e.name}` : e.name;
     const full = path.join(dir, e.name);
     if (e.isDirectory()) {
-      if (isIgnoredProjectDirName(e.name)) continue;
-      await collectArchiveEntries(full, rel, out);
+      if (isListingSkippedDirName(e.name)) continue;
+      await collectArchiveEntries(full, rel, out, skipHidden);
       continue;
     }
     if (e.name.endsWith('.artifact.json')) continue;

--- a/apps/daemon/tests/live-artifacts-schema.test.ts
+++ b/apps/daemon/tests/live-artifacts-schema.test.ts
@@ -385,10 +385,17 @@ describe('live artifact schema validation', () => {
 
   it('rejects single-dot and reserved-path read_json selectors across every alias', () => {
     // validateProjectPath (refresh.ts → projects.ts) rejects '.' segments and the
-    // reserved '.live-artifacts' segment; the executor also requires a .json file.
+    // shared reserved-path policy; the executor also requires a .json file.
     // Schema acceptance must stay a subset of that, or the source persists yet
     // fails every refresh with "invalid file name" / "reserved project path".
-    const badValues = ['./report.json', '.live-artifacts/cache.json', 'nested/./report.json', 'reports/notes.txt'];
+    const badValues = [
+      './report.json',
+      '.live-artifacts/cache.json',
+      '.MCP.JSON/config.json',
+      '.OD-RENAME-123.json',
+      'nested/./report.json',
+      'reports/notes.txt',
+    ];
     for (const alias of ['path', 'file', 'name'] as const) {
       for (const value of badValues) {
         const result = validateLiveArtifactCreateInput({

--- a/apps/daemon/tests/project-archive.test.ts
+++ b/apps/daemon/tests/project-archive.test.ts
@@ -36,7 +36,14 @@ describe('buildProjectArchive', () => {
       .filter((entry) => !entry.dir)
       .map((entry) => entry.name)
       .sort();
-    expect(fileEntries).toEqual(['DESIGN-HANDOFF.md', 'DESIGN-MANIFEST.json', 'frames/phone.html', 'index.html', 'src/app.css']);
+    expect(fileEntries).toEqual([
+      '.hidden',
+      'DESIGN-HANDOFF.md',
+      'DESIGN-MANIFEST.json',
+      'frames/phone.html',
+      'index.html',
+      'src/app.css',
+    ]);
   });
 
   it('zips the whole project when no root is given', async () => {
@@ -49,10 +56,11 @@ describe('buildProjectArchive', () => {
     expect(fileEntries).toContain('DESIGN-HANDOFF.md');
     expect(fileEntries).toContain('DESIGN-MANIFEST.json');
     expect(fileEntries).toContain('README.md');
+    expect(fileEntries).toContain('ui-design/.hidden');
     expect(fileEntries).toContain('ui-design/index.html');
     expect(fileEntries).toContain('ui-design/src/app.css');
-    // dotfiles and .artifact.json sidecars are filtered, matching listFiles
-    expect(fileEntries.find((n) => n.includes('.hidden'))).toBeUndefined();
+    // Invariant: managed-project archives match listFiles and keep user
+    // dotfiles, while generated .artifact.json sidecars remain excluded.
     expect(fileEntries.find((n) => n.endsWith('.artifact.json'))).toBeUndefined();
   });
 

--- a/apps/daemon/tests/project-hidden-files.test.ts
+++ b/apps/daemon/tests/project-hidden-files.test.ts
@@ -259,6 +259,19 @@ describe('dot-prefixed entries in imported folders stay hidden (#6175)', () => {
     ).rejects.toThrow(/hidden path segments/);
   });
 
+  it('rejects visible archive-root aliases that resolve to hidden imported directories', async () => {
+    await mkdir(path.join(baseDir, '.private'));
+    await writeFile(path.join(baseDir, '.private', 'secret.txt'), 'private');
+    await symlink('.private', path.join(baseDir, 'public-alias'), 'dir');
+
+    await expect(
+      buildProjectArchive('/unused/projects', 'unused-id', 'public-alias', {
+        kind: 'prototype',
+        baseDir,
+      }),
+    ).rejects.toThrow(/hidden path segments/);
+  });
+
   it('keeps rejecting hidden segments in batch archives for external baseDir projects', async () => {
     await expect(
       buildBatchArchive('/unused/projects', 'unused-id', ['.github/workflows/ci.yml'], {

--- a/apps/daemon/tests/project-hidden-files.test.ts
+++ b/apps/daemon/tests/project-hidden-files.test.ts
@@ -10,6 +10,8 @@ import {
   buildProjectArchive,
   listFiles,
   listProjectFolders,
+  readProjectFile,
+  validateProjectPath,
 } from '../src/projects.js';
 
 // Regression tests for #6175: the file/folder listing helpers used a blanket
@@ -30,6 +32,7 @@ async function seedProjectTree(root: string): Promise<void> {
   await mkdir(path.join(root, '.storybook'));
   await writeFile(path.join(root, '.storybook', 'main.ts'), '{}');
   await writeFile(path.join(root, '.notes.md'), '# notes');
+  await writeFile(path.join(root, '.ProjectNotes'), '# mixed-case user file');
   await writeFile(path.join(root, 'index.html'), '<!doctype html>');
   await mkdir(path.join(root, 'src'));
   await writeFile(path.join(root, 'src', 'app.ts'), 'export {}');
@@ -43,7 +46,41 @@ async function seedProjectTree(root: string): Promise<void> {
   await writeFile(path.join(root, '.live-artifacts', 'artifact-1', 'index.html'), '<!doctype html>');
   await mkdir(path.join(root, '.file-versions'));
   await writeFile(path.join(root, '.file-versions', 'v1.json'), '{}');
+  await writeFile(path.join(root, '.transcript.jsonl'), '{"role":"user","content":"private"}\n');
+  await writeFile(path.join(root, '.transcript.jsonl.tmp.123.abcd'), 'partial transcript');
+  await writeFile(path.join(root, '.transcript.lock'), '123');
+  await writeFile(path.join(root, '.finalize.lock'), '123');
+  await writeFile(path.join(root, '.mcp.json'), '{"mcpServers":{}}');
+  await mkdir(path.join(root, '.amr-attachments'));
+  await writeFile(path.join(root, '.amr-attachments', 'upload.png'), 'staged image');
+  await mkdir(path.join(root, '.od-skills', 'demo'), { recursive: true });
+  await writeFile(path.join(root, '.od-skills', 'demo', 'SKILL.md'), '# staged skill');
+  await mkdir(path.join(root, '.open-design'));
+  await writeFile(path.join(root, '.open-design', 'project.json'), '{}');
+  await mkdir(path.join(root, '.pi', 'sessions'), { recursive: true });
+  await writeFile(path.join(root, '.pi', 'sessions', 'session.jsonl'), '{}\n');
+  await writeFile(path.join(root, '.od-rename-123-456-0-index.html.tmp'), 'temporary rename');
 }
+
+const reservedFiles = [
+  '.transcript.jsonl',
+  '.transcript.jsonl.tmp.123.abcd',
+  '.transcript.lock',
+  '.finalize.lock',
+  '.mcp.json',
+  '.amr-attachments/upload.png',
+  '.od-skills/demo/SKILL.md',
+  '.open-design/project.json',
+  '.pi/sessions/session.jsonl',
+  '.od-rename-123-456-0-index.html.tmp',
+];
+
+const reservedFolders = [
+  '.amr-attachments',
+  '.od-skills',
+  '.open-design',
+  '.pi',
+];
 
 describe('dot-prefixed user content in managed projects (#6175)', () => {
   let projectsRoot = '';
@@ -65,12 +102,14 @@ describe('dot-prefixed user content in managed projects (#6175)', () => {
     expect(paths).toContain('.github/workflows/ci.yml');
     expect(paths).toContain('.storybook/main.ts');
     expect(paths).toContain('.notes.md');
+    expect(paths).toContain('.ProjectNotes');
     expect(paths).toContain('index.html');
     expect(paths.some((p) => p.startsWith('.git/'))).toBe(false);
     expect(paths.some((p) => p.startsWith('.od/'))).toBe(false);
     expect(paths.some((p) => p.startsWith('node_modules/'))).toBe(false);
     expect(paths.some((p) => p.startsWith('.live-artifacts/'))).toBe(false);
     expect(paths.some((p) => p.startsWith('.file-versions/'))).toBe(false);
+    for (const reserved of reservedFiles) expect(paths).not.toContain(reserved);
   });
 
   it('lists dot-prefixed folders while still skipping the ignore list', async () => {
@@ -85,6 +124,7 @@ describe('dot-prefixed user content in managed projects (#6175)', () => {
     expect(names).not.toContain('node_modules');
     expect(names).not.toContain('.live-artifacts');
     expect(names).not.toContain('.file-versions');
+    for (const reserved of reservedFolders) expect(names).not.toContain(reserved);
   });
 
   it('includes visible dot-prefixed user content in full project archives', async () => {
@@ -95,11 +135,22 @@ describe('dot-prefixed user content in managed projects (#6175)', () => {
     expect(paths).toContain('.github/workflows/ci.yml');
     expect(paths).toContain('.storybook/main.ts');
     expect(paths).toContain('.notes.md');
+    expect(paths).toContain('.ProjectNotes');
     expect(paths.some((p) => p.startsWith('.git/'))).toBe(false);
     expect(paths.some((p) => p.startsWith('.od/'))).toBe(false);
     expect(paths.some((p) => p.startsWith('node_modules/'))).toBe(false);
     expect(paths.some((p) => p.startsWith('.live-artifacts/'))).toBe(false);
     expect(paths.some((p) => p.startsWith('.file-versions/'))).toBe(false);
+    for (const reserved of reservedFiles) expect(paths).not.toContain(reserved);
+  });
+
+  it('rejects reserved daemon directories as explicit archive roots', async () => {
+    const paths = ['.live-artifacts', '.file-versions', ...reservedFolders];
+    for (const reserved of paths) {
+      await expect(
+        buildProjectArchive(projectsRoot, projectId, reserved),
+      ).rejects.toThrow(/reserved project path/);
+    }
   });
 
   it('includes visible dot-prefixed user content in batch archives', async () => {
@@ -107,22 +158,51 @@ describe('dot-prefixed user content in managed projects (#6175)', () => {
     const { buffer } = await buildBatchArchive(projectsRoot, projectId, [
       '.github/workflows/ci.yml',
       '.notes.md',
+      '.ProjectNotes',
       'build',
     ]);
     const zip = await JSZip.loadAsync(buffer);
 
     expect(Object.keys(zip.files)).toEqual(
-      expect.arrayContaining(['.github/workflows/ci.yml', '.notes.md', 'build']),
+      expect.arrayContaining(['.github/workflows/ci.yml', '.notes.md', '.ProjectNotes', 'build']),
     );
   });
 
+  it('rejects mixed-case aliases to reserved daemon state', async () => {
+    const paths = [
+      '.MCP.JSON',
+      '.TRANSCRIPT.JSONL',
+      '.TRANSCRIPT.JSONL.TMP.123.ABCD',
+      '.PI/sessions/session.jsonl',
+      '.OD-RENAME-123-456-0-index.html.tmp',
+    ];
+
+    for (const reserved of paths) {
+      expect(() => validateProjectPath(reserved)).toThrow(/reserved project path/);
+      await expect(
+        buildBatchArchive(projectsRoot, projectId, [reserved]),
+      ).rejects.toThrow(/ineligible for archive/);
+    }
+
+    await expect(
+      readProjectFile(projectsRoot, projectId, '.MCP.JSON'),
+    ).rejects.toThrow(/reserved project path/);
+    await expect(
+      buildProjectArchive(projectsRoot, projectId, '.PI'),
+    ).rejects.toThrow(/reserved project path/);
+  });
+
   it('batch archive keeps rejecting reserved daemon state', async () => {
-    await expect(
-      buildBatchArchive(projectsRoot, projectId, ['.live-artifacts/artifact-1/index.html']),
-    ).rejects.toThrow(/ineligible for archive/);
-    await expect(
-      buildBatchArchive(projectsRoot, projectId, ['.file-versions/v1.json']),
-    ).rejects.toThrow(/ineligible for archive/);
+    const paths = [
+      '.live-artifacts/artifact-1/index.html',
+      '.file-versions/v1.json',
+      ...reservedFiles,
+    ];
+    for (const reserved of paths) {
+      await expect(
+        buildBatchArchive(projectsRoot, projectId, [reserved]),
+      ).rejects.toThrow(/ineligible for archive/);
+    }
   });
 });
 

--- a/apps/daemon/tests/project-hidden-files.test.ts
+++ b/apps/daemon/tests/project-hidden-files.test.ts
@@ -1,0 +1,133 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { buildBatchArchive, listFiles, listProjectFolders } from '../src/projects.js';
+
+// Regression tests for #6175: the file/folder listing helpers used a blanket
+// `startsWith('.')` filter, so legitimate dot-prefixed user content
+// (.github/, .storybook/, .notes.md) never appeared in @-mention autocomplete or
+// project search. The intended policy is the explicit ignore list in
+// project-ignored-dirs.ts (.git, .od, node_modules, ...), not "every dotfile".
+//
+// Imported folders (metadata.baseDir) are the exception: hidden path segments
+// there are blocked from read/write/delete by assertVisibleForImportedProject
+// to keep credential dotfiles (.ssh, .aws) out of reach, so the listing must
+// stay consistent and keep hiding them — suggesting a path the file API then
+// refuses to serve would be worse than not suggesting it.
+
+async function seedProjectTree(root: string): Promise<void> {
+  await mkdir(path.join(root, '.github', 'workflows'), { recursive: true });
+  await writeFile(path.join(root, '.github', 'workflows', 'ci.yml'), 'on: push');
+  await mkdir(path.join(root, '.storybook'));
+  await writeFile(path.join(root, '.storybook', 'main.ts'), '{}');
+  await writeFile(path.join(root, '.notes.md'), '# notes');
+  await writeFile(path.join(root, 'index.html'), '<!doctype html>');
+  await mkdir(path.join(root, 'src'));
+  await writeFile(path.join(root, 'src', 'app.ts'), 'export {}');
+  await mkdir(path.join(root, '.git'));
+  await writeFile(path.join(root, '.git', 'HEAD'), 'ref: refs/heads/main');
+  await mkdir(path.join(root, '.od', 'runs'), { recursive: true });
+  await writeFile(path.join(root, '.od', 'runs', 'state.json'), '{}');
+  await mkdir(path.join(root, 'node_modules', 'pkg'), { recursive: true });
+  await writeFile(path.join(root, 'node_modules', 'pkg', 'index.js'), '');
+  await mkdir(path.join(root, '.live-artifacts', 'artifact-1'), { recursive: true });
+  await writeFile(path.join(root, '.live-artifacts', 'artifact-1', 'index.html'), '<!doctype html>');
+  await mkdir(path.join(root, '.file-versions'));
+  await writeFile(path.join(root, '.file-versions', 'v1.json'), '{}');
+}
+
+describe('dot-prefixed user content in managed projects (#6175)', () => {
+  let projectsRoot = '';
+  const projectId = 'proj1';
+
+  beforeEach(async () => {
+    projectsRoot = mkdtempSync(path.join(tmpdir(), 'od-hidden-'));
+    await mkdir(path.join(projectsRoot, projectId), { recursive: true });
+    await seedProjectTree(path.join(projectsRoot, projectId));
+  });
+
+  afterEach(() => {
+    if (projectsRoot) rmSync(projectsRoot, { recursive: true, force: true });
+  });
+
+  it('lists dot-prefixed files while still skipping the ignore list', async () => {
+    const files = await listFiles(projectsRoot, projectId);
+    const paths = files.map((f) => f.path);
+    expect(paths).toContain('.github/workflows/ci.yml');
+    expect(paths).toContain('.storybook/main.ts');
+    expect(paths).toContain('.notes.md');
+    expect(paths).toContain('index.html');
+    expect(paths.some((p) => p.startsWith('.git/'))).toBe(false);
+    expect(paths.some((p) => p.startsWith('.od/'))).toBe(false);
+    expect(paths.some((p) => p.startsWith('node_modules/'))).toBe(false);
+    expect(paths.some((p) => p.startsWith('.live-artifacts/'))).toBe(false);
+    expect(paths.some((p) => p.startsWith('.file-versions/'))).toBe(false);
+  });
+
+  it('lists dot-prefixed folders while still skipping the ignore list', async () => {
+    const folders = await listProjectFolders(projectsRoot, projectId);
+    const names = folders.map((f) => f.path);
+    expect(names).toContain('.github');
+    expect(names).toContain('.github/workflows');
+    expect(names).toContain('.storybook');
+    expect(names).toContain('src');
+    expect(names).not.toContain('.git');
+    expect(names).not.toContain('.od');
+    expect(names).not.toContain('node_modules');
+    expect(names).not.toContain('.live-artifacts');
+    expect(names).not.toContain('.file-versions');
+  });
+
+  it('batch archive keeps rejecting reserved daemon state', async () => {
+    await expect(
+      buildBatchArchive(projectsRoot, projectId, ['.live-artifacts/artifact-1/index.html']),
+    ).rejects.toThrow(/ineligible for archive/);
+    await expect(
+      buildBatchArchive(projectsRoot, projectId, ['.file-versions/v1.json']),
+    ).rejects.toThrow(/ineligible for archive/);
+  });
+});
+
+describe('dot-prefixed entries in imported folders stay hidden (#6175)', () => {
+  let baseDir = '';
+
+  beforeEach(async () => {
+    baseDir = mkdtempSync(path.join(tmpdir(), 'od-hidden-ext-'));
+    await seedProjectTree(baseDir);
+  });
+
+  afterEach(() => {
+    if (baseDir) rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  it('keeps hiding dot-prefixed files for external baseDir projects', async () => {
+    const files = await listFiles('/unused/projects', 'unused-id', {
+      metadata: { kind: 'prototype', baseDir },
+    });
+    const paths = files.map((f) => f.path);
+    expect(paths).toContain('index.html');
+    expect(paths).toContain('src/app.ts');
+    expect(paths.some((p) => p.startsWith('.'))).toBe(false);
+  });
+
+  it('keeps hiding dot-prefixed folders for external baseDir projects', async () => {
+    const folders = await listProjectFolders('/unused/projects', 'unused-id', {
+      metadata: { kind: 'prototype', baseDir },
+    });
+    const names = folders.map((f) => f.path);
+    expect(names).toContain('src');
+    expect(names.some((p) => p.startsWith('.'))).toBe(false);
+  });
+
+  it('keeps rejecting hidden segments in batch archives for external baseDir projects', async () => {
+    await expect(
+      buildBatchArchive('/unused/projects', 'unused-id', ['.github/workflows/ci.yml'], {
+        kind: 'prototype',
+        baseDir,
+      }),
+    ).rejects.toThrow(/ineligible for archive/);
+  });
+});

--- a/apps/daemon/tests/project-hidden-files.test.ts
+++ b/apps/daemon/tests/project-hidden-files.test.ts
@@ -1,5 +1,5 @@
 import { mkdtempSync, rmSync } from 'node:fs';
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import JSZip from 'jszip';
@@ -151,6 +151,19 @@ describe('dot-prefixed user content in managed projects (#6175)', () => {
         buildProjectArchive(projectsRoot, projectId, reserved),
       ).rejects.toThrow(/reserved project path/);
     }
+  });
+
+  it('rejects ignored directories as explicit archive roots, including resolved symlink aliases', async () => {
+    for (const ignored of ['.git', '.od', 'node_modules']) {
+      await expect(
+        buildProjectArchive(projectsRoot, projectId, ignored),
+      ).rejects.toThrow(/ignored or reserved/);
+    }
+
+    await symlink('.git', path.join(projectsRoot, projectId, 'git-alias'), 'dir');
+    await expect(
+      buildProjectArchive(projectsRoot, projectId, 'git-alias'),
+    ).rejects.toThrow(/ignored or reserved/);
   });
 
   it('includes visible dot-prefixed user content in batch archives', async () => {

--- a/apps/daemon/tests/project-hidden-files.test.ts
+++ b/apps/daemon/tests/project-hidden-files.test.ts
@@ -2,9 +2,15 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import JSZip from 'jszip';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { buildBatchArchive, listFiles, listProjectFolders } from '../src/projects.js';
+import {
+  buildBatchArchive,
+  buildProjectArchive,
+  listFiles,
+  listProjectFolders,
+} from '../src/projects.js';
 
 // Regression tests for #6175: the file/folder listing helpers used a blanket
 // `startsWith('.')` filter, so legitimate dot-prefixed user content
@@ -81,6 +87,35 @@ describe('dot-prefixed user content in managed projects (#6175)', () => {
     expect(names).not.toContain('.file-versions');
   });
 
+  it('includes visible dot-prefixed user content in full project archives', async () => {
+    const { buffer } = await buildProjectArchive(projectsRoot, projectId, '');
+    const zip = await JSZip.loadAsync(buffer);
+    const paths = Object.keys(zip.files);
+
+    expect(paths).toContain('.github/workflows/ci.yml');
+    expect(paths).toContain('.storybook/main.ts');
+    expect(paths).toContain('.notes.md');
+    expect(paths.some((p) => p.startsWith('.git/'))).toBe(false);
+    expect(paths.some((p) => p.startsWith('.od/'))).toBe(false);
+    expect(paths.some((p) => p.startsWith('node_modules/'))).toBe(false);
+    expect(paths.some((p) => p.startsWith('.live-artifacts/'))).toBe(false);
+    expect(paths.some((p) => p.startsWith('.file-versions/'))).toBe(false);
+  });
+
+  it('includes visible dot-prefixed user content in batch archives', async () => {
+    await writeFile(path.join(projectsRoot, projectId, 'build'), 'plain user file');
+    const { buffer } = await buildBatchArchive(projectsRoot, projectId, [
+      '.github/workflows/ci.yml',
+      '.notes.md',
+      'build',
+    ]);
+    const zip = await JSZip.loadAsync(buffer);
+
+    expect(Object.keys(zip.files)).toEqual(
+      expect.arrayContaining(['.github/workflows/ci.yml', '.notes.md', 'build']),
+    );
+  });
+
   it('batch archive keeps rejecting reserved daemon state', async () => {
     await expect(
       buildBatchArchive(projectsRoot, projectId, ['.live-artifacts/artifact-1/index.html']),
@@ -120,6 +155,15 @@ describe('dot-prefixed entries in imported folders stay hidden (#6175)', () => {
     const names = folders.map((f) => f.path);
     expect(names).toContain('src');
     expect(names.some((p) => p.startsWith('.'))).toBe(false);
+  });
+
+  it('keeps rejecting hidden archive roots for external baseDir projects', async () => {
+    await expect(
+      buildProjectArchive('/unused/projects', 'unused-id', '.github', {
+        kind: 'prototype',
+        baseDir,
+      }),
+    ).rejects.toThrow(/hidden path segments/);
   });
 
   it('keeps rejecting hidden segments in batch archives for external baseDir projects', async () => {


### PR DESCRIPTION
Fixes #6175

## Why

Hit this while keeping project notes in a `.notes.md` file: `@`-mentioning it from the chat composer silently finds nothing, and the same happens for `.github/` or `.vscode/` content. The file and folder listing helpers in `apps/daemon/src/projects.ts` apply a blanket `startsWith('.')` filter, so every dot-prefixed entry is invisible to mention autocomplete and project search, not just the internal directories the filter was meant to hide.

## What users will see

In managed projects, `@`-mention autocomplete and project search now find dot-prefixed user content such as `.github/workflows/ci.yml`, `.vscode/settings.json`, or `.notes.md`. Managed full and batch archives follow the same visibility policy. Internal directories (`.git`, `.od`, `.live-artifacts`, `.file-versions`, `node_modules`, etc.) stay hidden. Imported folders (external `baseDir`) are unchanged: hidden entries remain unlisted and unavailable to archive requests, consistent with the existing hidden-path guard for user-owned directories.

## Surface area

- [x] **Default behavior change**: dot-prefixed user files become visible in listing, search, and archives for managed projects. They were previously always hidden.

## Bug fix verification

- Test path: `apps/daemon/tests/project-hidden-files.test.ts`
- Red on `main`, green on this branch: **yes**. Two managed-listing cases failed on `main`; the focused cases pass with the fix.

## Validation

- `vitest run tests/project-hidden-files.test.ts tests/live-artifacts-store.test.ts tests/project-archive.test.ts tests/folder-import-projects.test.ts tests/projects-list-files.test.ts tests/project-watchers.test.ts tests/project-file-rename.test.ts`: 103 passed.
- `tsc -p tsconfig.json --noEmit && tsc -p tsconfig.tests.json --noEmit`: clean.
- `pnpm guard`: passed.
- QA accepted head `8827edc0` after verifying managed dotfile listing, search, mention autocomplete, full archives, and batch archives in the real Web runtime. Imported-folder hidden paths remained blocked.

Windows-native UI smoke testing was not included in the QA pass.
