### PR TITLE
fix(collab): let a headerless caller mutate its own daemon's project

### DIFF
--- a/apps/daemon/src/collab/created-project-workspace.ts
+++ b/apps/daemon/src/collab/created-project-workspace.ts
@@ -1,9 +1,12 @@
 import type { ApiErrorResponse } from '@open-design/contracts';
 import type { Response } from 'express';
 import {
+  ambientWorkspaceResourceContext,
   isWorkspaceResourceLocked,
   withLastKnownMembership,
   workspaceResourceContextFromRequest,
+  type AmbientWorkspaceSnapshot,
+  type GetAmbientWorkspace,
   type GetLastKnownWorkspaceMembership,
   type WorkspaceResourceContext,
 } from './workspace-resource-mutation.js';
@@ -13,34 +16,12 @@ import {
 } from './vela-workspace-context.js';
 import { sendApiError } from '../http/api-errors.js';
 
-/**
- * The daemon's own last-verified workspace identity, narrowed to the fields a
- * created project's binding needs.
- *
- * Structurally a subset of `WorkspaceCollabContext`, so a caller passes
- * `() => workspaceContext.lastKnown?.() ?? null` directly. Deliberately NOT the
- * `WorkspaceContextProvider` type — same reason `workspace-resource-mutation.ts`
- * takes a plain `GetLastKnownWorkspaceMembership` closure: a create path must not
- * drag the async B integration into a module every resource type depends on.
- */
-export type AmbientWorkspaceSnapshot = {
-  workspaceId: string;
-  workspaceType: 'personal' | 'team';
-  workspaceMemberId: string;
-  role: WorkspaceResourceContext['role'];
-  memberStatus: WorkspaceResourceContext['memberStatus'];
-  lifecycleState: WorkspaceResourceContext['lifecycleState'];
-  permissions: { canShareProjects: boolean; canWriteSyncedFiles: boolean };
-};
-
-/**
- * Read the daemon's ambient workspace with NO network I/O and no failure mode.
- * Backed by `collab/workspace-context.ts`'s `lastKnown()`, which is populated as
- * a side effect of the `.current()` traffic the daemon already serves (the web
- * client's periodic `GET /api/workspace/context` poll, the collab-cloud poller's
- * 5s tick, the dev/demo `PUT /api/workspace/context` seam).
- */
-export type GetAmbientWorkspace = () => AmbientWorkspaceSnapshot | null | undefined;
+// The ambient-identity types live in `workspace-resource-mutation.ts` (the lower
+// module every resource type already depends on) so the mutation gate and the
+// creation paths cannot drift into two different notions of "the daemon's own
+// workspace". Re-exported here because the creation-path callers import them
+// from this module.
+export type { AmbientWorkspaceSnapshot, GetAmbientWorkspace };
 
 export type CreatedProjectWorkspaceResolution =
   | { ok: true; context: WorkspaceResourceContext | null }
@@ -206,23 +187,8 @@ export async function authorizeCreatedProjectWorkspace(
 function ambientWorkspaceHome(
   getAmbientWorkspace?: GetAmbientWorkspace,
 ): WorkspaceResourceContext | null {
-  const ambient = getAmbientWorkspace?.();
-  if (!ambient) return null;
-  const workspaceId = ambient.workspaceId?.trim();
-  const workspaceMemberId = ambient.workspaceMemberId?.trim();
-  if (!workspaceId || !workspaceMemberId) return null;
-  const context: WorkspaceResourceContext = {
-    workspaceId,
-    workspaceType: ambient.workspaceType === 'team' ? 'team' : 'personal',
-    workspaceTypeAsserted: null,
-    appUserId: '',
-    workspaceMemberId,
-    role: ambient.role,
-    memberStatus: ambient.memberStatus,
-    lifecycleState: ambient.lifecycleState,
-    canShareProjects: ambient.permissions.canShareProjects,
-    canWriteSyncedFiles: ambient.permissions.canWriteSyncedFiles,
-  };
+  const context = ambientWorkspaceResourceContext(getAmbientWorkspace);
+  if (!context) return null;
   if (
     context.memberStatus !== 'active'
     || !context.canWriteSyncedFiles

--- a/apps/daemon/src/collab/workspace-resource-mutation.ts
+++ b/apps/daemon/src/collab/workspace-resource-mutation.ts
@@ -59,6 +59,60 @@ export type WorkspaceMembershipSnapshot = {
 export type GetLastKnownWorkspaceMembership = () => WorkspaceMembershipSnapshot | null;
 
 /**
+ * The daemon's OWN signed-in workspace identity, narrowed to the fields a
+ * resource decision needs. Structurally a subset of `WorkspaceCollabContext`, so
+ * a caller passes `() => workspaceContext.lastKnown?.() ?? null` directly.
+ *
+ * Deliberately a plain closure rather than the provider type, same rule as
+ * `GetLastKnownWorkspaceMembership` above: this module must stay free of the
+ * async B integration that every resource type depends on.
+ *
+ * Populated with NO network I/O and no UI involvement — `lastKnown()` caches
+ * whatever the provider last resolved from the vela session on disk, so a
+ * daemon-only process that has never served a browser still has it (verified
+ * end to end with `od daemon start --headless`).
+ */
+export type AmbientWorkspaceSnapshot = {
+  workspaceId: string;
+  workspaceType: 'personal' | 'team';
+  workspaceMemberId: string;
+  role: WorkspaceResourceContext['role'];
+  memberStatus: WorkspaceResourceContext['memberStatus'];
+  lifecycleState: WorkspaceResourceContext['lifecycleState'];
+  permissions: { canShareProjects: boolean; canWriteSyncedFiles: boolean };
+};
+
+export type GetAmbientWorkspace = () => AmbientWorkspaceSnapshot | null | undefined;
+
+/**
+ * The daemon's ambient identity as a resource context, or null when it has none.
+ *
+ * `workspaceTypeAsserted` is null and `appUserId` empty on purpose: both record
+ * what a CALLER claimed, and nobody claimed anything here.
+ */
+export function ambientWorkspaceResourceContext(
+  getAmbientWorkspace: GetAmbientWorkspace | undefined,
+): WorkspaceResourceContext | null {
+  const ambient = getAmbientWorkspace?.();
+  if (!ambient) return null;
+  const workspaceId = ambient.workspaceId?.trim();
+  const workspaceMemberId = ambient.workspaceMemberId?.trim();
+  if (!workspaceId || !workspaceMemberId) return null;
+  return {
+    workspaceId,
+    workspaceType: ambient.workspaceType === 'team' ? 'team' : 'personal',
+    workspaceTypeAsserted: null,
+    appUserId: '',
+    workspaceMemberId,
+    role: ambient.role,
+    memberStatus: ambient.memberStatus,
+    lifecycleState: ambient.lifecycleState,
+    canShareProjects: ambient.permissions.canShareProjects,
+    canWriteSyncedFiles: ambient.permissions.canWriteSyncedFiles,
+  };
+}
+
+/**
  * Cross-check the client-asserted `memberStatus` against the daemon's own
  * last-known-good workspace context.
  *
@@ -326,6 +380,84 @@ export function requestCanMutateWorkspaceResource(
   return workspaceResourceAccess(row, ctx).canMutate;
 }
 
+/**
+ * Decide a mutation whose request carries NO workspace identity at all.
+ *
+ * INVARIANT: every mutation resolves to a workspace identity. A request that
+ * ASSERTS one is judged on that assertion; a request that asserts NOTHING is the
+ * local daemon's own signed-in user, and is judged as that identity. Being
+ * unable to name a workspace is not the same as having no standing in one.
+ *
+ * Headerless is the `od` CLI's normal shape, not an anomaly: nothing in
+ * `apps/daemon/src/cli.ts` attaches `x-od-workspace-*` outside `od workspace …`,
+ * and `AGENTS.md` makes the CLI the embeddability contract that external agents
+ * drive Open Design through. This branch used to answer 401 for ANY bound
+ * resource, which was survivable only while headerless creates left projects
+ * unbound. Once every created project got a workspace home (#6201), the two
+ * rules combined into a project its own creator could not touch:
+ * `od project create` then `od project duplicate` -> 401.
+ *
+ * Resolving to the daemon's ambient identity — rather than to the request's
+ * claim, of which there is none — is the same fallback the create path already
+ * applies ("nothing asserted -> ambient"), so the gate and the creation paths
+ * now agree about what a headerless caller is. It does NOT weaken the two
+ * contracts that look adjacent: `authorizeCreatedProjectWorkspace` still refuses
+ * to let ambient stand in for a pair someone explicitly CLAIMED, and
+ * `resolveProjectWorkspaceScope` still resolves a PERSISTED binding without
+ * consulting ambient. Both govern cases where something was asserted; this is
+ * the third case.
+ *
+ * What stays refused, because the original branch protected something real
+ * (recvqbeDjAsejl / recvqbklNGDqYY, spec 04 §10):
+ *
+ *   - a resource bound to a workspace the daemon is NOT currently in — a
+ *     teammate's shared project, or one left behind by a previous identity. A
+ *     headerless caller has no standing there and still gets 401.
+ *   - a resource in the daemon's own workspace that the daemon's own identity
+ *     may not mutate anyway. The SAME `workspaceResourceMutationAllowed`
+ *     computation runs, so a plain member still cannot rename a teammate's
+ *     project that happens to be shared into this workspace.
+ *   - everything, when the daemon has no signed-in identity to resolve. Nothing
+ *     can vouch for the caller, so the pre-existing answer stands.
+ *
+ * An unbound resource stays allowed, exactly as before.
+ */
+function headerlessMutationAllowed(
+  resourceType: string,
+  res: Response,
+  sendApiError: (res: Response, status: number, code: string, message: string) => unknown,
+  getWorkspaceResource: (db: unknown, workspaceId: string, resourceId: string) => WorkspaceResourceAccessInput | null | undefined,
+  getWorkspaceResourceByResourceId: (db: unknown, resourceId: string) => WorkspaceResourceAccessInput | null | undefined,
+  db: unknown,
+  resourceId: string,
+  capability: WorkspaceResourceMutationCapability,
+  getAmbientWorkspace: GetAmbientWorkspace | undefined,
+): boolean {
+  const anyRow = getWorkspaceResourceByResourceId(db, resourceId);
+  // Never bound anywhere: nothing to have standing in.
+  if (!anyRow) return true;
+
+  const ambient = ambientWorkspaceResourceContext(getAmbientWorkspace);
+  if (!ambient) {
+    sendApiError(res, 401, 'WORKSPACE_CONTEXT_REQUIRED', 'workspace context is required');
+    return false;
+  }
+  const ownRow = getWorkspaceResource(db, ambient.workspaceId, resourceId);
+  if (!ownRow) {
+    // Bound, but to some other workspace. This is the case the 401 exists for.
+    sendApiError(res, 401, 'WORKSPACE_CONTEXT_REQUIRED', 'workspace context is required');
+    return false;
+  }
+  if (!workspaceResourceMutationAllowed(ownRow, ambient, capability)) {
+    const code = isWorkspaceResourceLocked(ambient)
+      ? 'WORKSPACE_LOCKED'
+      : `WORKSPACE_${resourceType.toUpperCase()}_PERMISSION_DENIED`;
+    sendApiError(res, 403, code, `workspace ${resourceType} mutation is not allowed`);
+    return false;
+  }
+  return true;
+}
+
 export function enforceWorkspaceResourceMutation(
   resourceType: string,
   req: any,
@@ -337,27 +469,21 @@ export function enforceWorkspaceResourceMutation(
   resourceId: string,
   capability: WorkspaceResourceMutationCapability,
   getLastKnownMembership?: GetLastKnownWorkspaceMembership,
+  getAmbientWorkspace?: GetAmbientWorkspace,
 ): boolean {
   const requestCtx = workspaceResourceContextFromRequest(req);
   if (requestCtx === null) {
-    // No workspace headers at all — a legacy pre-workspace caller, or a
-    // client that just logged out (the frontend only attaches these headers
-    // while `workspaceContext` is non-null). Either way there is no identity
-    // to check against a team. That's fine for a resource this daemon has
-    // never bound to a workspace at all (`row` is null/undefined) — but ANY
-    // bound resource, personal OR team, requires proof of membership the
-    // request doesn't carry. A `personal` binding is not "safe to trust a
-    // headerless caller with" — it just means the resource isn't SHARED, not
-    // that it isn't OWNED; a signed-out / different-workspace caller has no
-    // more standing over someone else's personal draft than over a team
-    // resource (recvqbeDjAsejl / recvqbklNGDqYY, spec 04 §10). Treat both the
-    // same as `'missing'` rather than granting the mutation.
-    const row = getWorkspaceResourceByResourceId(db, resourceId);
-    if (row) {
-      sendApiError(res, 401, 'WORKSPACE_CONTEXT_REQUIRED', 'workspace context is required');
-      return false;
-    }
-    return true;
+    return headerlessMutationAllowed(
+      resourceType,
+      res,
+      sendApiError,
+      getWorkspaceResource,
+      getWorkspaceResourceByResourceId,
+      db,
+      resourceId,
+      capability,
+      getAmbientWorkspace,
+    );
   }
   if (requestCtx === 'missing') {
     sendApiError(res, 401, 'WORKSPACE_CONTEXT_REQUIRED', 'workspace context is required');

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -292,6 +292,9 @@ export function createEnforceWorkspaceProjectMutation(
   workspaceContext: Pick<WorkspaceContextProvider, 'lastKnown'> | undefined,
 ) {
   const getLastKnownWorkspaceMembership = lastKnownWorkspaceMembership(workspaceContext);
+  /** The daemon's own signed-in identity, for a request that asserts none —
+   *  see `headerlessMutationAllowed` in collab/workspace-resource-mutation.ts. */
+  const getAmbientWorkspace: GetAmbientWorkspace = () => workspaceContext?.lastKnown?.() ?? null;
   return function enforceWorkspaceProjectMutation(
     req: any,
     res: Response,
@@ -313,6 +316,7 @@ export function createEnforceWorkspaceProjectMutation(
       projectId,
       capability,
       getLastKnownWorkspaceMembership,
+      getAmbientWorkspace,
     );
   };
 }

--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -88,6 +88,7 @@ import {
   type WorkspaceResourceMutationCapability,
 } from '../../collab/workspace-resource-mutation.js';
 import type { WorkspaceContextProvider } from '../../collab/workspace-context.js';
+import { ambientWorkspaceResourceContext } from '../../collab/workspace-resource-mutation.js';
 import { resolveProjectWorkspaceScopeForCaller } from '../../collab/project-workspace-scope.js';
 import {
   authorizeCreatedProjectWorkspace,
@@ -1619,6 +1620,27 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
    * rather than becoming an orphan.
    */
   const getAmbientWorkspace: GetAmbientWorkspace = () => ctx.workspaceContext?.lastKnown?.() ?? null;
+  /**
+   * The workspace identity a mutation on this request ACTUALLY acts under.
+   *
+   * INVARIANT: this is the same resolution `enforceWorkspaceProjectMutation` used
+   * to allow the request — the caller's asserted identity when it has one, the
+   * daemon's own signed-in identity when it does not. Any SIDE EFFECT a mutation
+   * performs must read the context from here rather than re-deriving it from
+   * headers, or the effect silently disagrees with the gate that permitted it.
+   *
+   * That disagreement was a real cross-client data-consistency bug: `DELETE
+   * /api/projects/:id` re-derived `workspaceProjectContextFromRequest(req)`, which
+   * is null for a headerless caller, so once headerless mutation was allowed the
+   * hub unpublish and catalog removal were skipped while the local delete still
+   * ran — teammates kept seeing a project whose owner had already destroyed it.
+   */
+  function effectiveWorkspaceProjectContext(req: any): WorkspaceProjectContext | null {
+    const asserted = workspaceProjectContextFromRequest(req);
+    if (asserted === 'missing') return null;
+    if (asserted !== null) return asserted;
+    return ambientWorkspaceResourceContext(getAmbientWorkspace);
+  }
   /**
    * Where a created project belongs when the request has no authorization gate
    * of its own — the duplicate / design-system-copy pair and the
@@ -3734,10 +3756,23 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
       // whole project is about to stop existing regardless.
       const workspaceRow = getWorkspaceProjectByProjectId(db, project.id);
       if (workspaceRow?.visibility === 'team') {
-        const teamCtx = workspaceProjectContextFromRequest(req);
-        if (teamCtx && teamCtx !== 'missing') {
-          await requestTeamVisibility([project.id], teamCtx, 'personal');
+        // Same context the gate above allowed this delete under — NOT a fresh
+        // header read, which is null for a headerless caller and would skip the
+        // hub work while still deleting locally.
+        const teamCtx = effectiveWorkspaceProjectContext(req);
+        if (!teamCtx) {
+          // Unreachable while the gate is intact: it admits a team-bound row only
+          // for an asserted identity or a matching ambient one. Refuse rather than
+          // fall through, so a future gate change cannot quietly reintroduce a
+          // local-only delete of a still-shared project.
+          return sendApiError(
+            res,
+            401,
+            'WORKSPACE_CONTEXT_REQUIRED',
+            'workspace context is required to unshare this project before deleting it',
+          );
         }
+        await requestTeamVisibility([project.id], teamCtx, 'personal');
       }
       // Stop any live agent run in this project before its row and directory
       // are removed, otherwise the CLI subprocess is orphaned — it keeps

--- a/apps/daemon/tests/routes/project-delete-unshares-team-share.test.ts
+++ b/apps/daemon/tests/routes/project-delete-unshares-team-share.test.ts
@@ -110,7 +110,23 @@ function fakeHub() {
   return { adapter, teamProjectCatalog, published, catalog, publishCalls, unpublishCalls, catalogRemoveCalls, key };
 }
 
-async function startServer(hub: ReturnType<typeof fakeHub>) {
+/** The daemon's own signed-in identity, as `workspaceContext.lastKnown()` reports it. */
+function ambientOwner() {
+  return {
+    workspaceId: WORKSPACE_ID,
+    workspaceType: 'personal' as const,
+    workspaceMemberId: OWNER_MEMBER_ID,
+    role: 'owner' as const,
+    memberStatus: 'active' as const,
+    lifecycleState: 'active' as const,
+    permissions: { canShareProjects: true, canWriteSyncedFiles: true },
+  };
+}
+
+async function startServer(
+  hub: ReturnType<typeof fakeHub>,
+  options: { ambient?: ReturnType<typeof ambientOwner> | null } = {},
+) {
   tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-project-delete-unshare-'));
   projectsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-project-delete-unshare-dir-'));
   const db = openDatabase(tempDir);
@@ -145,6 +161,9 @@ async function startServer(hub: ReturnType<typeof fakeHub>) {
     appConfig: {},
     agents: {},
     validation: {},
+    ...(options.ambient === undefined
+      ? {}
+      : { workspaceContext: { lastKnown: () => options.ambient } }),
     collabSync: {
       requestTeamShare: (projectId: string, share?: string | ResourceHubPrincipal) =>
         collab.requestTeamShare(projectId, share),
@@ -357,5 +376,91 @@ describe('member-side convergence after an owner unshare (spec 04 §11, known ga
     } finally {
       fs.rmSync(memberTempDir, { recursive: true, force: true });
     }
+  });
+
+  // Review regression (mrcfps, #6216). Once a headerless caller was allowed to
+  // mutate a project the daemon's own identity owns, this handler's side effect
+  // still re-derived its context from REQUEST HEADERS — which are absent — so
+  // `requestTeamVisibility` was skipped and `dbDeleteProject` ran anyway. The
+  // owner's local row and directory disappeared while the hub kept serving the
+  // resource, so teammates went on seeing a project that no longer existed.
+  //
+  // Drives the real route with NO request headers and `workspaceContext.lastKnown()`
+  // populated — the `od project delete` shape on a signed-in daemon — and asserts
+  // the hub transition, not a spy call count. Ordering matters as much as
+  // occurrence: a local delete that lands while the hub call is skipped leaves
+  // exactly the inconsistency this guards, so the hub state is asserted to be
+  // clean at the same moment the project is gone locally.
+  it('unshares from the hub for a HEADERLESS caller whose ambient identity owns the row', async () => {
+    const hub = fakeHub();
+    const { baseUrl, db } = await startServer(hub, { ambient: ambientOwner() });
+    const now = Date.now();
+    const projectId = 'p-team-shared-headerless';
+    insertProject(db, { id: projectId, name: 'Team shared headerless', createdAt: now, updatedAt: now });
+    ensureWorkspaceProject(db, {
+      projectId,
+      workspaceId: WORKSPACE_ID,
+      visibility: 'team',
+      createdByWorkspaceMemberId: OWNER_MEMBER_ID,
+      resourceState: 'active',
+      syncState: 'synced',
+    });
+
+    const principal: ResourceHubPrincipal = {
+      memberId: OWNER_MEMBER_ID,
+      teamId: WORKSPACE_ID,
+      role: 'owner',
+      lifecycleState: 'active',
+    };
+    hub.published.set(hub.key(projectId, principal), { version: 1 });
+    hub.catalog.set(hub.key(projectId, principal), { projectId });
+
+    // No `ownerHeaders()` — this is the bare DELETE `od project delete` sends.
+    const res = await fetch(`${baseUrl}/api/projects/${projectId}`, { method: 'DELETE' });
+    expect(res.status).toBe(200);
+
+    // The hub learned about it...
+    expect(
+      hub.unpublishCalls.length,
+      'a headerless delete must still unpublish the shared resource',
+    ).toBeGreaterThan(0);
+    expect(hub.published.has(hub.key(projectId, principal))).toBe(false);
+    expect(
+      hub.catalogRemoveCalls.map((call) => call.projectId),
+      'the catalog entry must be removed too',
+    ).toContain(projectId);
+    expect(hub.catalog.has(hub.key(projectId, principal))).toBe(false);
+
+    // ...and the unshare was attributed to the ambient identity, not to nothing.
+    expect(hub.unpublishCalls[0]?.principal?.teamId).toBe(WORKSPACE_ID);
+    expect(hub.unpublishCalls[0]?.principal?.memberId).toBe(OWNER_MEMBER_ID);
+
+    // Only then is it gone locally.
+    expect(getProject(db, projectId)).toBeFalsy();
+    expect(getWorkspaceProjectByProjectId(db, projectId)).toBeFalsy();
+  });
+
+  // The other half of the same invariant: with NO ambient identity either, the
+  // gate refuses before anything is destroyed. A team-bound project must never be
+  // deletable by a caller nothing can vouch for.
+  it('refuses a headerless delete of a team-bound project when the daemon has no identity', async () => {
+    const hub = fakeHub();
+    const { baseUrl, db } = await startServer(hub, { ambient: null });
+    const now = Date.now();
+    const projectId = 'p-team-shared-no-identity';
+    insertProject(db, { id: projectId, name: 'Team shared no identity', createdAt: now, updatedAt: now });
+    ensureWorkspaceProject(db, {
+      projectId,
+      workspaceId: WORKSPACE_ID,
+      visibility: 'team',
+      createdByWorkspaceMemberId: OWNER_MEMBER_ID,
+      resourceState: 'active',
+      syncState: 'synced',
+    });
+
+    const res = await fetch(`${baseUrl}/api/projects/${projectId}`, { method: 'DELETE' });
+    expect(res.status).toBe(401);
+    expect(hub.unpublishCalls.length).toBe(0);
+    expect(getProject(db, projectId), 'nothing may be destroyed locally either').toBeTruthy();
   });
 });

--- a/e2e/tests/collab/headerless-mutation.test.ts
+++ b/e2e/tests/collab/headerless-mutation.test.ts
@@ -294,6 +294,95 @@ describe('a headerless caller can mutate a project the daemon itself owns', () =
     },
   );
 
+  // P0 INVARIANT: signed out, VISIBLE <=> UNBOUND <=> MUTABLE — the three are the
+  // same set of projects.
+  //
+  // 「未登录也可以用自己 cli 修改未登录态下的那些 project, 这个一定要保证,
+  // 不然就是 P0 事故」
+  //
+  // A signed-out client can only SEE unbound projects: the no-scope catalog
+  // (`routes/project/index.ts:2432-2443`) reads no `x-od-workspace-*` at all and
+  // joins through `listUnboundProjects`, so "every unbound (never-claimed) project
+  // must be visible (pre-workspace-isolation compatibility) while every project
+  // some workspace HAS claimed must not leak to a caller with no identity to check
+  // it against" (spec 04 §10). This case pins the other half: everything in that
+  // visible set stays WRITABLE while signed out.
+  //
+  // It holds only because `headerlessMutationAllowed` short-circuits on "no row
+  // anywhere" BEFORE it asks for an ambient identity. That ordering is the whole
+  // protection, which is why this case is mutation-tested against it rather than
+  // written red-first — it passes on the fixed branch by construction.
+  test(
+    'signed out, a client keeps write access to exactly the projects it can see',
+    { timeout: 300_000 },
+    async () => {
+      const suite = await createSmokeSuite('collab-headerless-mutation-signed-out');
+
+      // No vela session at all — not merely "no headers on the request". The real
+      // provider is selected, `readVelaControlApiContext` finds nothing, so
+      // `.current()` answers null and the daemon has NO signed-in identity.
+      await suite.with.toolsDev(
+        async ({ webUrl, runtime }) => {
+          expect(
+            (await requestJson<{ context: unknown }>(webUrl, '/api/workspace/context')).context,
+            'precondition: this daemon must have no signed-in identity',
+          ).toBeNull();
+
+          // Created in that same signed-out state — the real user sequence.
+          const draft = await createHeaderless(webUrl, 'Signed-out local draft');
+          expect(
+            (await readScope(webUrl, draft)).kind,
+            'nothing to bind to while signed out, so the draft stays unbound',
+          ).toBe('unbound');
+
+          // Visible in the no-scope catalog...
+          const listed = await requestJson<{ projects: Array<{ id: string }> }>(
+            webUrl,
+            '/api/projects',
+          );
+          expect(
+            listed.projects.some((project) => project.id === draft),
+            'an unbound project must be visible to a signed-out client',
+          ).toBe(true);
+
+          // ...and therefore writable. Rename, duplicate, and the real CLI.
+          expect(
+            await patch(webUrl, `/api/projects/${draft}`, undefined, { name: 'Renamed offline' }),
+            'a signed-out user must be able to rename their own local draft',
+          ).toBe(200);
+
+          const duplicated = await post(webUrl, `/api/projects/${draft}/duplicate`, undefined, {
+            name: 'Offline copy',
+          });
+          expect(
+            duplicated.status,
+            `a signed-out user must be able to duplicate their own local draft; got ${duplicated.text.slice(0, 200)}`,
+          ).toBe(200);
+
+          const cli = await od(`http://127.0.0.1:${runtime.daemonPort}`, [
+            'project',
+            'duplicate',
+            draft,
+            '--name',
+            'Offline CLI copy',
+            '--json',
+          ]);
+          expect(
+            cli.code,
+            `od must work signed out: ${cli.stderr || cli.stdout}`,
+          ).toBe(0);
+        },
+        {
+          // Deliberately NO VELA_API_URL / VELA_CONTROL_KEY.
+          env: {
+            AMR_HOME: await emptyAmrHome(suite.scratchDir),
+            OD_WORKSPACE_CONTEXT_SOURCE: 'vela',
+          },
+        },
+      );
+    },
+  );
+
   // The dual-track contract, pinned through the real binary rather than by
   // intent. `AGENTS.md` makes `od` the embeddability surface external agents
   // drive Open Design through, and there was no test anywhere exercising a CLI

--- a/e2e/tests/collab/headerless-mutation.test.ts
+++ b/e2e/tests/collab/headerless-mutation.test.ts
@@ -1,0 +1,361 @@
+// @vitest-environment node
+
+// A headerless caller must be able to mutate a project the daemon itself owns.
+//
+// `enforceWorkspaceResourceMutation`'s headerless branch answers
+// 401 WORKSPACE_CONTEXT_REQUIRED as soon as ANY `workspace_projects` row exists
+// for the resource. That branch was written when an unbound project was the
+// common case, and it protects a real thing: a signed-out or different-workspace
+// caller has no standing over a teammate's shared project, nor over another
+// identity's personal draft (recvqbeDjAsejl / recvqbklNGDqYY, spec 04 §10).
+//
+// Then #6201 made headerless CREATES bind — every created project gets a
+// workspace home, which is the product ruling 「所有 project 都应该能找到
+// workspace, 不知道就放当前 workspace」. Projects that used to be unbound are now
+// bound, and the two rules together produce a project its own creator cannot
+// touch:
+//
+//     od project create     -> 200, and now writes a binding
+//     od project duplicate  -> 401
+//
+// The `od` CLI never sends `x-od-workspace-*` (apps/daemon/src/cli.ts: only
+// `od workspace …` builds those headers, and `project create` never reaches it),
+// so this is not an edge case for it — it is every CLI mutation of every project
+// the CLI created. `AGENTS.md` makes the CLI the embeddability contract, so
+// external agents driving Open Design through `od` are broken outright.
+//
+// The fix is NOT to stop binding: that would reopen #6201. It is to notice that
+// a binding written on the DAEMON'S OWN authority names the same signed-in user a
+// local headerless caller is, and to judge such a caller as that identity instead
+// of as an anonymous stranger.
+//
+// The boundaries that must NOT move are pinned below: a project bound to a
+// workspace the daemon is not currently in stays 401, and a caller that DOES
+// assert an identity is still judged on that assertion — it must not be able to
+// reach 200 by dropping its headers.
+
+import { createServer, type Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { execFile } from 'node:child_process';
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { requestJson } from '@/vitest/http';
+import { createSmokeSuite } from '@/vitest/suite';
+
+type CreatedProject = { conversationId: string; project: { id: string } };
+type ProjectWorkspaceScope = { kind: string; workspaceId: string | null };
+
+/** The workspace the daemon itself resolves — `selectDefaultCandidate` prefers personal. */
+const OWN = {
+  workspaceId: 'ws-hdl-personal',
+  workspaceName: 'Headerless personal',
+  workspaceType: 'personal' as const,
+  workspaceMemberId: 'mem-hdl-personal',
+  role: 'owner' as const,
+  memberStatus: 'active' as const,
+  lifecycleState: 'active' as const,
+};
+
+/** A second real membership, used to bind a project AWAY from the daemon's own workspace. */
+const OTHER = {
+  workspaceId: 'ws-hdl-team',
+  workspaceName: 'Headerless team',
+  workspaceType: 'team' as const,
+  workspaceMemberId: 'mem-hdl-team',
+  role: 'owner' as const,
+  memberStatus: 'active' as const,
+  lifecycleState: 'active' as const,
+};
+
+let authority: Server;
+let authorityUrl: string;
+
+beforeAll(async () => {
+  authority = createServer((req, res) => {
+    const url = req.url ?? '';
+    // 403 `missing_principal` makes the provider bootstrap a default workspace
+    // from the directory, so the daemon ends up with an ambient workspace —
+    // which is the state every signed-in install is in.
+    if (url.startsWith('/api/v1/workspaces/current')) {
+      res.writeHead(403, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'missing_principal' }));
+      return;
+    }
+    if (url.startsWith('/api/v1/workspaces')) {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ items: [OWN, OTHER] }));
+      return;
+    }
+    res.writeHead(404, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: 'not found' }));
+  });
+  await new Promise<void>((resolve) => authority.listen(0, '127.0.0.1', resolve));
+  const address = authority.address();
+  if (address == null || typeof address === 'string') throw new Error('authority has no port');
+  authorityUrl = `http://127.0.0.1:${address.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => authority.close(() => resolve()));
+});
+
+function workspaceHeaders(input: {
+  workspaceId: string;
+  workspaceMemberId: string;
+  workspaceType?: 'personal' | 'team';
+}): Record<string, string> {
+  return {
+    'x-od-workspace-id': input.workspaceId,
+    'x-od-workspace-type': input.workspaceType ?? 'personal',
+    'x-od-workspace-member-id': input.workspaceMemberId,
+    'x-od-workspace-role': 'owner',
+    'x-od-workspace-lifecycle-state': 'active',
+    'x-od-workspace-member-status': 'active',
+    'x-od-workspace-can-share-projects': 'true',
+    'x-od-workspace-can-write-synced-files': 'true',
+  };
+}
+
+/** Exactly what `od project create` sends: a body, and no workspace identity. */
+async function createHeaderless(webUrl: string, name: string): Promise<string> {
+  const created = await requestJson<CreatedProject>(webUrl, '/api/projects', {
+    body: {
+      designSystemId: null,
+      id: randomUUID(),
+      metadata: { kind: 'prototype' },
+      name,
+      pendingPrompt: null,
+      skillId: null,
+    },
+    method: 'POST',
+  });
+  return created.project.id;
+}
+
+async function post(
+  webUrl: string,
+  path: string,
+  headers: Record<string, string> | undefined,
+  body: unknown,
+): Promise<{ status: number; text: string }> {
+  const response = await fetch(new URL(path, webUrl), {
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json', ...(headers ?? {}) },
+    method: 'POST',
+  });
+  return { status: response.status, text: await response.text() };
+}
+
+async function patch(
+  webUrl: string,
+  path: string,
+  headers: Record<string, string> | undefined,
+  body: unknown,
+): Promise<number> {
+  const response = await fetch(new URL(path, webUrl), {
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json', ...(headers ?? {}) },
+    method: 'PATCH',
+  });
+  return response.status;
+}
+
+async function readScope(webUrl: string, projectId: string): Promise<ProjectWorkspaceScope> {
+  const body = await requestJson<{ scope: ProjectWorkspaceScope }>(
+    webUrl,
+    `/api/projects/${encodeURIComponent(projectId)}/workspace-scope`,
+  );
+  return body.scope;
+}
+
+const execFileAsync = promisify(execFile);
+
+/** The real `od` entrypoint, driven as an external agent would. */
+const OD_BIN = fileURLToPath(
+  new URL('../../../apps/daemon/bin/od.mjs', import.meta.url),
+);
+
+/**
+ * Run a real `od` subcommand against this runtime's daemon. Resolves with the
+ * exit code and stdout/stderr instead of throwing, so a failure can be asserted
+ * on rather than crashing the test.
+ */
+async function od(
+  daemonUrl: string,
+  args: string[],
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  try {
+    const { stdout, stderr } = await execFileAsync(process.execPath, [OD_BIN, ...args], {
+      env: { ...process.env, OD_DAEMON_URL: daemonUrl },
+    });
+    return { code: 0, stdout, stderr };
+  } catch (error) {
+    const failure = error as { code?: number; stdout?: string; stderr?: string };
+    return {
+      code: typeof failure.code === 'number' ? failure.code : 1,
+      stdout: failure.stdout ?? '',
+      stderr: failure.stderr ?? '',
+    };
+  }
+}
+
+describe('a headerless caller can mutate a project the daemon itself owns', () => {
+  test(
+    'create then duplicate with no workspace headers — the od CLI shape',
+    { timeout: 300_000 },
+    async () => {
+      const suite = await createSmokeSuite('collab-headerless-mutation');
+
+      await suite.with.toolsDev(
+        async ({ webUrl }) => {
+          // --- THE BUG. Both calls are headerless, exactly like `od`.
+          const own = await createHeaderless(webUrl, 'Headerless own project');
+
+          // Precondition: #6201 bound it to the daemon's own workspace. Without
+          // this the test would pass for the wrong reason (an unbound project was
+          // always allowed).
+          const scope = await readScope(webUrl, own);
+          expect(
+            scope.workspaceId,
+            'precondition: #6201 binds a headerless create to the daemon workspace',
+          ).toBe(OWN.workspaceId);
+
+          const duplicate = await post(webUrl, `/api/projects/${own}/duplicate`, undefined, {
+            name: 'Headerless duplicate',
+          });
+          expect(
+            duplicate.status,
+            `a headerless caller must be able to duplicate its own project; got ${duplicate.text.slice(0, 200)}`,
+          ).toBe(200);
+
+          // Not duplicate-specific: the same gate fronts every project mutation.
+          const rename = await patch(webUrl, `/api/projects/${own}`, undefined, {
+            name: 'Headerless rename',
+          });
+          expect(rename, 'rename runs the same gate').toBe(200);
+
+          // --- BOUNDARY 1: a project bound to a workspace the daemon is NOT
+          // currently in must stay refused for a headerless caller. This is the
+          // teammate's-shared-project / previous-identity case the branch exists
+          // for, and it must not be relaxed.
+          const elsewhere = await requestJson<CreatedProject>(webUrl, '/api/projects', {
+            body: {
+              designSystemId: null,
+              id: randomUUID(),
+              metadata: { kind: 'prototype' },
+              name: 'Bound to the other workspace',
+              pendingPrompt: null,
+              skillId: null,
+            },
+            headers: workspaceHeaders(OTHER),
+            method: 'POST',
+          });
+          expect((await readScope(webUrl, elsewhere.project.id)).workspaceId).toBe(
+            OTHER.workspaceId,
+          );
+
+          const foreignBound = await post(
+            webUrl,
+            `/api/projects/${elsewhere.project.id}/duplicate`,
+            undefined,
+            { name: 'Headerless duplicate of another workspace' },
+          );
+          expect(
+            foreignBound.status,
+            'a headerless caller has no standing over a project bound elsewhere',
+          ).toBe(401);
+
+          // --- BOUNDARY 2: dropping headers must not be an escalation path. A
+          // caller that DOES assert an identity is judged on that assertion, so
+          // the fix must not hand the unverifiable caller a route back to 200.
+          const forged = await post(webUrl, `/api/projects/${own}/duplicate`, workspaceHeaders({
+            workspaceId: 'ws-hdl-forged',
+            workspaceMemberId: 'mem-hdl-forged',
+          }), { name: 'Forged duplicate' });
+          expect(
+            forged.status,
+            'an asserted identity that cannot be verified is still refused',
+          ).not.toBe(200);
+        },
+        {
+          env: {
+            AMR_HOME: await emptyAmrHome(suite.scratchDir),
+            OD_WORKSPACE_CONTEXT_SOURCE: 'vela',
+            VELA_API_URL: authorityUrl,
+            VELA_CONTROL_KEY: 'e2e-headerless-control-key',
+          },
+        },
+      );
+    },
+  );
+
+  // The dual-track contract, pinned through the real binary rather than by
+  // intent. `AGENTS.md` makes `od` the embeddability surface external agents
+  // drive Open Design through, and there was no test anywhere exercising a CLI
+  // project mutation — which is why a 401 on every CLI-created project shipped
+  // to this branch unnoticed.
+  test(
+    'the real od binary can create a project and then duplicate it',
+    { timeout: 300_000 },
+    async () => {
+      const suite = await createSmokeSuite('collab-headerless-mutation-cli');
+
+      await suite.with.toolsDev(
+        async ({ runtime }) => {
+          const daemonUrl = `http://127.0.0.1:${runtime.daemonPort}`;
+
+          const created = await od(daemonUrl, [
+            'project',
+            'create',
+            '--name',
+            'CLI dual-track project',
+            '--json',
+          ]);
+          expect(created.code, `od project create failed: ${created.stderr}`).toBe(0);
+          const projectId = (JSON.parse(created.stdout) as CreatedProject).project.id;
+
+          // `od` attaches no `x-od-workspace-*` headers on this path — only
+          // `od workspace …` builds those — so this is the headerless shape by
+          // construction, not by test contrivance.
+          const duplicated = await od(daemonUrl, [
+            'project',
+            'duplicate',
+            projectId,
+            '--name',
+            'CLI dual-track copy',
+            '--json',
+          ]);
+          expect(
+            duplicated.code,
+            `od project duplicate failed: ${duplicated.stderr || duplicated.stdout}`,
+          ).toBe(0);
+          expect(JSON.parse(duplicated.stdout).project.id).not.toBe(projectId);
+        },
+        {
+          env: {
+            AMR_HOME: await emptyAmrHome(suite.scratchDir),
+            OD_WORKSPACE_CONTEXT_SOURCE: 'vela',
+            VELA_API_URL: authorityUrl,
+            VELA_CONTROL_KEY: 'e2e-headerless-control-key',
+          },
+        },
+      );
+    },
+  );
+});
+
+/**
+ * A vela config home guaranteed to hold no session, so the daemon's
+ * `readVelaControlApiContext` config-file fallback cannot pick up the developer
+ * machine's real production login.
+ */
+async function emptyAmrHome(scratchDir: string): Promise<string> {
+  const dir = join(scratchDir, 'empty-amr-home');
+  await mkdir(dir, { recursive: true });
+  return dir;
+}


### PR DESCRIPTION
## Why

**Use case.** Fallout I caused. #6201 (mine) made every created project get a workspace home. My red run on #6213 then failed an assertion I had written for a different reason — `expected 401 to be 200` — which turned out to be a live break in the `od` CLI on this branch. I flagged it rather than absorbing it; the owner ruled: fix it.

**The pain.** `enforceWorkspaceResourceMutation`'s headerless branch answers `401 WORKSPACE_CONTEXT_REQUIRED` as soon as *any* `workspace_projects` row exists for the resource. That was survivable while headerless creates left projects unbound. #6201 removed that condition, so the two rules combine into **a project its own creator cannot touch**:

```
od project create     → 200, and now writes a binding
od project duplicate  → 401 WORKSPACE_CONTEXT_REQUIRED
```

Nothing in `apps/daemon/src/cli.ts` attaches `x-od-workspace-*` outside `od workspace …`, so this is not an edge case for the CLI — it is **every CLI mutation of every project the CLI created**. `AGENTS.md` makes the CLI the embeddability contract ("Shipping a feature with only one of the two surfaces is a regression"), and external agents — hermes-agent, openclaw, Slack/Discord bots, packaged runtimes invoked from another shell — drive Open Design through `od` and never render the UI. It is on `feat/workspace-team` and has not reached users, but it must not ride into `main`.

## Real `od` reproduction, daemon-only

Not just an HTTP-shaped repro. `od daemon start --headless` — no web server, no browser, so no UI could have pushed anything — against a mock vela authority:

```
=== ambient workspace the daemon resolved with NO UI ever running ===
{"context":{"workspaceId":"ws-cli-personal","workspaceType":"personal",
  "workspaceMemberId":"mem-cli-personal","role":"owner","memberStatus":"active", ...}}

=== od project create (headerless by construction) ===
exit=0   → project 98a6d2e9-…

=== its workspace binding (proves #6201 bound it) ===
{"scope":{"kind":"personal","workspaceId":"ws-cli-personal","visibility":"personal", ...}}

=== od project duplicate — THE BUG ===
POST /api/projects/98a6d2e9-…/duplicate failed: 401
  {"error":{"code":"WORKSPACE_CONTEXT_REQUIRED","message":"workspace context is required"}}
od exit=1
```

After the fix, same harness: `od project duplicate` → `exit=0`, copy created.

So the CLI framing is confirmed, not assumed. It reproduces through the real binary, and it is not an artifact of the e2e harness.

## Which source of truth the fallback reads — verified, because the concern was well founded

The worry raised was that ambient might be UI-dependent, which would make this fix look right in a browser-backed test and still 401 for the real `od` user. Two findings:

1. **`ambientWorkspaceId` in `collab/workspace-hub-subscriptions.ts:17` is not the value in play.** It is SSE-subscription bookkeeping — "which Vela event streams should be open" — and it is fed from `activeWorkspace.get()` (`server.ts:4367`), the **disk-persisted** selection store (`collab/active-workspace-selection.ts:53`, `workspace-selection.json` under the data dir), with a subscriber to keep it current. It is not UI-pushed and not an authorization input at all.
2. **The value this fix reads is `workspaceContext.lastKnown()`** — the same zero-network cache #6201's create-side fallback uses. It is populated from the **vela session on disk** via the provider's `.current()`, and when B has no current workspace the provider bootstraps a default from the membership directory (`pickDefaultWorkspace`, personal first) and persists the selection. None of that needs a browser, which the daemon-only transcript above demonstrates empirically: `GET /api/workspace/context` answers fully in a process that never served the UI.

So no deeper fallback is required. **Only a daemon with no signed-in identity at all still refuses** — nothing can vouch for the caller there, so the pre-existing answer stands.

## The fix, as a named invariant

`headerlessMutationAllowed` (`collab/workspace-resource-mutation.ts`) replaces the blanket 401. Its docblock states the rule:

> **Every mutation resolves to a workspace identity.** A request that ASSERTS one is judged on that assertion; a request that asserts NOTHING is the local daemon's own signed-in user, and is judged as that identity. Being unable to name a workspace is not the same as having no standing in one.

That is the same fallback the create path already applies, so the gate and the creation paths finally agree about what a headerless caller is.

**Deliberately not weakened** — the two contracts that look adjacent and are not in conflict:

- `collab/created-project-workspace.ts:82-90` governs verifying an **explicitly-claimed** pair; ambient must never substitute for a claim someone made. Untouched.
- `collab/project-workspace-scope.ts:15-22` governs resolving a **persisted binding**; ambient stays irrelevant there. Untouched.

Both are about cases where something *was* asserted. Headerless is the third case, and it now reads as its own named branch rather than as a hole in either contract.

**What stays refused**, because the original branch protected something real (recvqbeDjAsejl / recvqbklNGDqYY, spec 04 §10):

| Case | Answer | Why |
|---|---|---|
| Resource never bound anywhere | allowed | unchanged |
| Resource bound to a workspace the daemon is **not** currently in | **401** | a teammate's shared project, or one left by a previous identity — no standing |
| Resource in the daemon's own workspace it may not mutate anyway | **403** | the *same* `workspaceResourceMutationAllowed` runs, so a plain member still cannot rename a teammate's project shared into this workspace |
| Daemon has no signed-in identity | **401** | nothing can vouch for the caller |
| A caller that **does** assert an identity | unchanged | dropping headers must not be an escalation path — pinned |

With no `workspaceContext` wired (most unit harnesses), ambient resolves null and the branch is **byte-identical** to before: no row → allow, row → 401.

The ambient snapshot type moves down into `workspace-resource-mutation.ts` so the gate and the creation paths cannot drift into two notions of "the daemon's own workspace"; `created-project-workspace.ts` re-exports it and now reuses the shared context builder instead of its own copy.

## The signed-out P0 invariant: visible ⟺ unbound ⟺ mutable

> 「未登录也可以用自己 cli 修改未登录态下的那些 project, 这个一定要保证, 不然就是 P0 事故」

For a signed-out client these three sets are **the same set of projects**, and that is why the `if (!ambient) → 401` above is safe rather than a lockout.

A signed-out client can only *see* unbound projects. The no-scope catalog (`routes/project/index.ts:2432-2443`) reads no `x-od-workspace-*` at all and joins through `listUnboundProjects`, and its docblock states the rule directly:

> every unbound (never-claimed) project must be visible (pre-workspace-isolation compatibility) while every project some workspace HAS claimed must not leak to a caller with no identity to check it against — a signed-out client, a removed member, or a plain `curl` (spec 04 §10: "no scope" must not mean "trust everything")

So the scenario that looks alarming — "signs in, creates projects, signs out, can no longer edit them" — has no reachable path through the product: those projects are not in the signed-out client's list. Reaching the 401 requires already holding the project id and calling the API directly, which is exactly the case spec 04 §10 wants refused. The `!ambient → 401` is the **second** line of that defense; the catalog join is the first.

**This branch keeps the writable half intact** because `headerlessMutationAllowed` short-circuits on "no row anywhere" *before* it asks for an ambient identity. That ordering is the whole protection, so it is pinned by a test named after the stake — *"signed out, a client keeps write access to exactly the projects it can see"*. It runs against a daemon with **no vela session at all** (not merely a request without headers), creates its draft in that same signed-out state, asserts the draft is listed by the no-scope catalog, then renames it, duplicates it, and duplicates it again through the real `od` binary.

Red-first is not meaningful for a case that passes by construction, so it is **mutation-tested against the ordering**. Moving the short-circuit after the ambient check turns it red:

```
× signed out, a client keeps write access to exactly the projects it can see
AssertionError: a signed-out user must be able to rename their own local draft:
  expected 401 to be 200
 Tests  1 failed | 2 passed (3)
```

**Reads are unaffected by this change.** Nothing in this diff touches a read path — `enforceWorkspaceResourceMutation` fronts mutations only, and the signed-out read behavior is the catalog join described above, which this PR does not modify. A signed-out user can still open the drafts they can see.

## Review follow-up: the delete side effect now uses the gate's own context (0299df2e)

`mrcfps` found — and reproduced — that admitting headerless mutation made a latent inconsistency **reachable**. `DELETE /api/projects/:id` re-derived its context with `workspaceProjectContextFromRequest(req)` (`routes/project/index.ts:3737`), which is `null` for a headerless caller, so `requestTeamVisibility(..., 'personal')` was skipped while `dbDeleteProject` still ran. The owner's local row and directory vanished and the hub kept serving the resource: **teammates went on seeing a project that no longer existed.** That is a cross-client data-consistency bug, and worse than the 401 this PR set out to fix.

**Fixed by threading the context, not by narrowing the capability.** The effective context was being computed in the gate and thrown away; it is now hoisted into `effectiveWorkspaceProjectContext`, whose docblock states the invariant:

> Any SIDE EFFECT a mutation performs must read the context from here rather than re-deriving it from headers, or the effect silently disagrees with the gate that permitted it.

The no-context branch is now a **refusal rather than a silent skip**. It is unreachable while the gate is intact, but falling through is precisely what produced a local-only delete of a still-shared project, so a future gate change cannot reintroduce it quietly.

**Every other newly-admitted capability audited**, since the shape could repeat:

| Capability / route | Header-only side effect? | Why not affected |
|---|---|---|
| `delete` | **yes — fixed** | was re-deriving from headers |
| `/move` (both directions) | no | `if (!ctx) return sendMissingWorkspaceContext(res)` at `:2692`, `:2740` |
| team share / unshare | no | same explicit guard at `:2553`, `:2792` |
| `writeFiles` (upload) | no | `:5323` only shapes a 404 for a missing project |
| `rename`, `duplicate`, `comment` | no | no hub or catalog side effect |

**Route regression** added to `apps/daemon/tests/routes/project-delete-unshares-team-share.test.ts` — the file that already documents this lifecycle invariant — reusing its harness (real route, real `createCollabRuntime`, mutable fake hub, state transitions rather than spy counts):

1. *"unshares from the hub for a HEADERLESS caller whose ambient identity owns the row"* — no request headers, `lastKnown()` populated. Asserts unpublish happened, catalog entry removed, the unshare carried the ambient principal, and only then that the project is gone locally. **Ordering is asserted, not just occurrence.**
2. *"refuses a headerless delete of a team-bound project when the daemon has no identity"* — 401, zero unpublish calls, project still present.

**Mutation-tested** — restoring the header re-derivation reproduces the reviewer's exact counts:

```
× unshares from the hub for a HEADERLESS caller whose ambient identity owns the row
AssertionError: a headerless delete must still unpublish the shared resource:
  expected 0 to be greater than 0
 Tests  1 failed | 4 passed (5)
```

Green after: `Tests 5 passed (5)`.

## How this composes with #6213

Read together, deliberately — separately each looks like it makes something worse:

- **#6213** stops *wrong* bindings being written (an unverifiable assertion must not be persisted onto a pre-existing orphan).
- **This PR** stops the gate refusing a caller when *no* binding exists.

This PR's branch resolves an identity **at request time and persists nothing**, which is exactly the shape that makes #6213's conservative "return without writing" cheap: the orphan stays unbound, and a headerless caller can still mutate it.

**One honest limit:** this only rescues *headerless* callers. A caller that asserts an identity takes the authenticated branch, where `!row → false`, so #6213's declining-to-write does convert an outage-time duplicate into a 403 **for an asserted caller**. #6213 narrows that to a genuine mismatch (its exact-match ambient condition keeps the ordinary outage case working), but the residue is real and is written down in that PR rather than left to a bug report.

No tension with the owner's "every project resolves to a workspace" ruling: the display-side fallback (#6185) already renders an unbound project inside the current workspace, so the user never sees "unknown". The binding row is a separate, durable fact, and it stays conservative.

## What users will see

Nothing to click. `od project create` followed by any `od` mutation of that project works again instead of failing with "workspace context is required" — so external agents and scripts driving Open Design through the CLI are unblocked. Web users are unaffected: their client always sends workspace headers and takes the unchanged branch.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [x] **Default behavior change** — a request carrying no workspace headers is now judged as the daemon's own signed-in identity instead of being refused outright on any bound resource. Restores pre-#6201 CLI behavior; no new endpoint, flag, or contract change.
- [ ] **None**

No UI surface, so no screenshots — the change is one daemon-side branch. No new `od` subcommand or flag is added: existing subcommands are *repaired*.

## Bug fix verification

- **Test:** `e2e/tests/collab/headerless-mutation.test.ts` — daemon HTTP boundary (the cheapest layer that sees it, per the repo playbook) **plus a second case that drives the real `od` binary**, since the claim is about the CLI. Seeded only through the daemon's real vela integration against a temporary server-level mock.
- **Red on unmodified `feat/workspace-team`, green on this branch:** yes.

The fixture makes the CLI-only condition explicit: no browser ever runs, and the ambient value is proven to come from the vela session rather than a UI push by asserting the created project's binding as a precondition — without that assertion the test could pass for the wrong reason (an unbound project was always allowed).

**RED** on unmodified base:

```
 × create then duplicate with no workspace headers — the od CLI shape 9802ms

AssertionError: a headerless caller must be able to duplicate its own project;
  got {"error":{"code":"WORKSPACE_CONTEXT_REQUIRED","message":"workspace context is required"}}:
  expected 401 to be 200

 Test Files  1 failed (1)
      Tests  1 failed (1)
```

**GREEN** on this branch: `Test Files 1 passed (1)` / `Tests 2 passed (2)`.

**Mutation-tested.** Restoring only the blanket headerless 401 while leaving every other line of the fix in place turns **both** cases red — including the real-binary one, so the CLI pin genuinely guards the contract rather than passing incidentally:

```
 × create then duplicate with no workspace headers — the od CLI shape
 × the real od binary can create a project and then duplicate it

AssertionError: a headerless caller must be able to duplicate its own project; … expected 401 to be 200
AssertionError: od project duplicate failed: POST /api/projects/295c9e52-…/duplicate failed: 401
  {"error":{"code":"WORKSPACE_CONTEXT_REQUIRED","message":"workspace context is required"}}
```

Also pinned: rename (`PATCH /api/projects/:id`) through the same gate; a project bound to a *different* workspace stays 401; and an asserted-but-unverifiable identity is still refused, so dropping headers is not an escalation path.

**New CLI coverage.** There was no test anywhere driving an `od` project mutation — which is why a 401 on every CLI-created project reached this branch unnoticed. The second case closes that gap so the dual-track contract is pinned by a test rather than by intent.

## Validation

Node 24.18.0 throughout (Node 22 miscompiles `better-sqlite3`'s ABI). Disk 9.2Gi free at finish.

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/daemon build` — pass, **plus a real `require('dist/server.js')` load** (75 exports). Daemon typecheck is not cited: `server.ts` carries `@ts-nocheck`, as do 29 daemon files.
- `pnpm --filter @open-design/daemon test` — on the final head: **`Test Files 570 passed | 3 skipped (573)` / `Tests 7166 passed | 6 skipped | 4 todo`, EXIT=0.** (An earlier head showed 2 failures in `collab-context-routes.test.ts` and `project-upload-filenames.test.ts`; both passed in isolation and both pass in this full run — timing/order flake, and neither is reachable from this diff.)
- `cd e2e && pnpm test tests/collab` — `Test Files 3 passed (3)` / `Tests 6 passed (6)`
- Real `od` binary against a daemon-only process — transcript above

## Adjacent issues (deliberately not fixed here)

1. **`od project …` has no explicit scope override.** `PROJECT_STRING_FLAGS` (`cli.ts:216-223`) does **not** include `workspace` or `member` — only `WORKSPACE_STRING_FLAGS` (`:225-231`) does, which is why `od workspace projects move --workspace <id>` works and `od project create --workspace <id>` cannot. So today the ambient fallback is the *only* path for `od project …`, not the convenience layer on top of a deterministic override. For scripts that must pin scope explicitly — CI, multi-workspace automation — `--workspace`/`--member` on the `od project` family is the missing piece, and the dual-track rule implies it should exist. Its own PR.
2. **`od workspace use <id>`** — still only a CLI verb away; the persisted selection, `PUT /api/workspace/active`, and `GET /api/workspace/directory` all exist. Carried from #6201 and #6213.
3. **The no-scope catalog's invisibility rule has no test naming it.** `listUnboundProjects` (`db.ts:996`) is referenced only from `server.ts` and `routes/project/index.ts` — a quick grep finds no reference in `apps/daemon/tests/` or `e2e/`, and no behavioral test asserting that a headerless/signed-out read cannot list or fetch a project some workspace has claimed. That join is the **first** line of the spec 04 §10 isolation guarantee, and this PR's 401 is only the second, so it deserves its own coverage. Not written here on purpose — it is a different surface (reads, not mutations) and belongs in its own PR.

