### PR TITLE
Add Claude Design System plugin

### DIFF
--- a/plugins/community/claude-design-system-ms5r1th0/SKILL.md
+++ b/plugins/community/claude-design-system-ms5r1th0/SKILL.md
@@ -1,0 +1,76 @@
+# Claude Design System
+
+A production-usable design-system package for **Claude** (Anthropic), extracted from [claude.ai](https://claude.ai/) and deepened by a live re-measurement pass (2026-07) against the site's real stylesheets (`data-color-version=v2`, `data-theme=claude`).
+
+## Product Overview
+
+Claude is Anthropic's AI assistant — "built for problem solvers." The product surface is a chat-first web app whose visual identity rests on three measured facts:
+
+1. **A warm neutral palette.** Every gray is tinted (hue 45–60); the canvas is white, the app surface warm ivory `#f9f9f7`, text near-black `#131313`. There are no cold grays anywhere in the system.
+2. **One high-chroma note: clay.** `#d97757` (emphasized `#c6613f`) carries the starburst mark, primary CTAs and loading dots. Blue `#256abf` is reserved for links, violet `#7161e0` for Pro/Max plan cues.
+3. **A serif voice.** Claude speaks in Anthropic Serif; the interface around it is Anthropic Sans; code is Anthropic Mono. The logotype uses Anthropicons-Variable.
+
+## Source Evidence
+
+| Evidence | Where |
+| --- | --- |
+| Captured login page DOM | `prefetch/page.html` |
+| Captured + re-fetched live stylesheets (v2 token blocks, both themes) | `prefetch/styles.css`, re-measured 2026-07 |
+| Programmatic frequency-rank pass (colors/fonts/logo candidates) | `prefetch/material.md` |
+| Setup notes & review contract | `context/source-context.md` |
+
+**Limitations:** the authenticated app could not be crawled — chat-surface component guidance is reconstructed from CSS class evidence (buttons, prose, motion). Voice & tone adjectives are inferred from public meta/login copy. Both are labelled `inferred` where they appear.
+
+## Package Contents
+
+| Path | What it is |
+| --- | --- |
+| `DESIGN.md` | Canonical principles: palette, type, voice, imagery, layout posture, component evidence |
+| `colors_and_type.css` | **Measured source of truth** — full token set (light + dark), `@font-face` bindings to local fonts |
+| `brand.json` | Machine-readable bundle: roles, extended ramps, typography, fonts, imagery, provenance |
+| `guide.md` | One-page quick reference |
+| `SKILL.md` | Agent-facing skill for reusing this system |
+| `fonts/` | Real woff2 binaries: Anthropic Sans/Serif (normal+italic, variable 300–800), Anthropic Mono, Anthropicons-Variable |
+| `logos/` | Starburst SVG (primary vector mark), favicon set, apple-touch-icon, og-image |
+| `imagery/` | Social cover captures |
+| `preview/` | Focused review cards (see manifest below) |
+| `brand.html` | Daemon-rendered brand-kit overview page |
+| `system/` | Engine-derived layer: antd-style tokens (`tokens.*.json`, `variables*.css`, `theme.json`, `seed.json`), component kits (`kit.html`, `kit.dark.html`), gallery (`index.html`), six generated artifacts |
+| `system/artifacts/` | `landing` · `deck` · `poster` · `email` · `newsletter` · `form` |
+
+> The `system/` layer uses antd slot *conventions* (token names, component kits), but every semantic value has been re-aligned to the measured palette in `colors_and_type.css` (2026-07 pass): warm gray ramp, measured status colors (`#009300` / `#a66a00` / `#d03b3b`, dark `#0ca30c` / `#b77700` / `#e34948`), link blue `#256abf`, and `Anthropic Mono` in the code stack. The generic antd hue presets (red/orange/blue/…) remain as utility ramps; the `grey` preset is the measured warm ramp. `colors_and_type.css` stays the source of truth — if you edit `brand.json`, re-apply its values to both layers.
+
+## Preview Manifest
+
+| Card | Focus |
+| --- | --- |
+| `preview/colors-primary.html` | Core roles, functional accents, warm gray ramp, light vs dark side-by-side |
+| `preview/typography-specimens.html` | All four preserved faces at real sizes, measured scale table |
+| `preview/spacing-radius-shadows.html` | Radius scale, 4px spacing unit, shadow elevations, motion specs |
+| `preview/brand-assets.html` | Real preserved files: starburst SVG, favicons, app icon, og-image, covers, font files |
+| `preview/components-buttons.html` | Button system rebuilt from measured CSS (primary/secondary/ghost/clay/danger, dark, press + loading dots) |
+| `preview/components-prose.html` | Claude's reply typography: headings, lists, blockquote, inline code |
+
+## Applied UI Kit
+
+`ui_kits/app/` composes the tokens into a working chat surface (sidebar, chat area, composer, message bubbles) as React + Babel-standalone JSX modules mounted from `ui_kits/app/index.html`. See `ui_kits/app/README.md` for structure, reuse, and the evidence basis (reconstructed from measured CSS; the authenticated app was not crawlable).
+
+## Reuse Workflow
+
+1. Read `DESIGN.md` for principles and posture rules.
+2. Link `colors_and_type.css` (dark: `data-mode="dark"` on `<html>`) — tokens arrive as `--cds-*` custom properties with the real fonts already bound.
+3. Use `brand.json` when you need machine-readable values (extended ramps, provenance flags).
+4. Copy component patterns from `system/kit.html` / `system/kit.dark.html`; full-page patterns from `system/artifacts/`; a composed chat surface from `ui_kits/app/`.
+5. Logo usage: prefer `logos/favicon-0.svg` (clay starburst, transparent); `logos/apple-touch-icon-4.png` for raster contexts.
+6. Icons: 24×24 viewBox, `stroke: currentColor`, stroke-width 1.6, round caps/joins — see `ICON_PATHS` in `brand.html`.
+7. Review against the six `preview/` cards before shipping.
+
+## Verified Rules (enforced on artifacts built with this system)
+
+- Border-radius defaults to 8px.
+- Type uses the Anthropic stacks above (with the declared fallbacks when woff2 can't load).
+- Color comes from the measured palette only; clay is a high-signal accent, never a wash.
+
+## Provenance
+
+Formalized by Open Design from candidate ec04d58b-92c4-4936-aa66-8ff053077646.

--- a/plugins/community/claude-design-system-ms5r1th0/open-design.json
+++ b/plugins/community/claude-design-system-ms5r1th0/open-design.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "claude-design-system-ms5r1th0",
+  "title": "Claude Design System",
+  "version": "0.1.0",
+  "description": "A production-usable design-system package for **Claude** (Anthropic), extracted from [claude.ai](https://claude.ai/) and deepened by a live re-measurement pass (2026-07) against the site's real stylesheets (`data-color-v",
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ]
+  }
+}

--- a/plugins/community/claude-design-system-ms5r1th0/references/provenance.json
+++ b/plugins/community/claude-design-system-ms5r1th0/references/provenance.json
@@ -1,0 +1,26 @@
+{
+  "candidateId": "ec04d58b-92c4-4936-aa66-8ff053077646",
+  "projectId": "brand-claude-58bc94",
+  "runId": "9c6e475e-dc8e-4502-8184-d7b853850b32",
+  "conversationId": "16b36513-6eea-4b2a-b917-729a6f0df144",
+  "provenance": {
+    "summary": "Detected from README.md, SKILL.md after a successful run.",
+    "detectedAt": 1785309249277
+  },
+  "sourceRefs": [
+    {
+      "kind": "file",
+      "value": "README.md",
+      "label": "README.md",
+      "size": 5678,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "SKILL.md",
+      "label": "SKILL.md",
+      "size": 3887,
+      "copied": true
+    }
+  ]
+}

--- a/plugins/community/claude-design-system-ms5r1th0/references/source-1-README.md
+++ b/plugins/community/claude-design-system-ms5r1th0/references/source-1-README.md
@@ -1,0 +1,72 @@
+# Claude Design System
+
+A production-usable design-system package for **Claude** (Anthropic), extracted from [claude.ai](https://claude.ai/) and deepened by a live re-measurement pass (2026-07) against the site's real stylesheets (`data-color-version=v2`, `data-theme=claude`).
+
+## Product Overview
+
+Claude is Anthropic's AI assistant — "built for problem solvers." The product surface is a chat-first web app whose visual identity rests on three measured facts:
+
+1. **A warm neutral palette.** Every gray is tinted (hue 45–60); the canvas is white, the app surface warm ivory `#f9f9f7`, text near-black `#131313`. There are no cold grays anywhere in the system.
+2. **One high-chroma note: clay.** `#d97757` (emphasized `#c6613f`) carries the starburst mark, primary CTAs and loading dots. Blue `#256abf` is reserved for links, violet `#7161e0` for Pro/Max plan cues.
+3. **A serif voice.** Claude speaks in Anthropic Serif; the interface around it is Anthropic Sans; code is Anthropic Mono. The logotype uses Anthropicons-Variable.
+
+## Source Evidence
+
+| Evidence | Where |
+| --- | --- |
+| Captured login page DOM | `prefetch/page.html` |
+| Captured + re-fetched live stylesheets (v2 token blocks, both themes) | `prefetch/styles.css`, re-measured 2026-07 |
+| Programmatic frequency-rank pass (colors/fonts/logo candidates) | `prefetch/material.md` |
+| Setup notes & review contract | `context/source-context.md` |
+
+**Limitations:** the authenticated app could not be crawled — chat-surface component guidance is reconstructed from CSS class evidence (buttons, prose, motion). Voice & tone adjectives are inferred from public meta/login copy. Both are labelled `inferred` where they appear.
+
+## Package Contents
+
+| Path | What it is |
+| --- | --- |
+| `DESIGN.md` | Canonical principles: palette, type, voice, imagery, layout posture, component evidence |
+| `colors_and_type.css` | **Measured source of truth** — full token set (light + dark), `@font-face` bindings to local fonts |
+| `brand.json` | Machine-readable bundle: roles, extended ramps, typography, fonts, imagery, provenance |
+| `guide.md` | One-page quick reference |
+| `SKILL.md` | Agent-facing skill for reusing this system |
+| `fonts/` | Real woff2 binaries: Anthropic Sans/Serif (normal+italic, variable 300–800), Anthropic Mono, Anthropicons-Variable |
+| `logos/` | Starburst SVG (primary vector mark), favicon set, apple-touch-icon, og-image |
+| `imagery/` | Social cover captures |
+| `preview/` | Focused review cards (see manifest below) |
+| `brand.html` | Daemon-rendered brand-kit overview page |
+| `system/` | Engine-derived layer: antd-style tokens (`tokens.*.json`, `variables*.css`, `theme.json`, `seed.json`), component kits (`kit.html`, `kit.dark.html`), gallery (`index.html`), six generated artifacts |
+| `system/artifacts/` | `landing` · `deck` · `poster` · `email` · `newsletter` · `form` |
+
+> The `system/` layer uses antd slot *conventions* (token names, component kits), but every semantic value has been re-aligned to the measured palette in `colors_and_type.css` (2026-07 pass): warm gray ramp, measured status colors (`#009300` / `#a66a00` / `#d03b3b`, dark `#0ca30c` / `#b77700` / `#e34948`), link blue `#256abf`, and `Anthropic Mono` in the code stack. The generic antd hue presets (red/orange/blue/…) remain as utility ramps; the `grey` preset is the measured warm ramp. `colors_and_type.css` stays the source of truth — if you edit `brand.json`, re-apply its values to both layers.
+
+## Preview Manifest
+
+| Card | Focus |
+| --- | --- |
+| `preview/colors-primary.html` | Core roles, functional accents, warm gray ramp, light vs dark side-by-side |
+| `preview/typography-specimens.html` | All four preserved faces at real sizes, measured scale table |
+| `preview/spacing-radius-shadows.html` | Radius scale, 4px spacing unit, shadow elevations, motion specs |
+| `preview/brand-assets.html` | Real preserved files: starburst SVG, favicons, app icon, og-image, covers, font files |
+| `preview/components-buttons.html` | Button system rebuilt from measured CSS (primary/secondary/ghost/clay/danger, dark, press + loading dots) |
+| `preview/components-prose.html` | Claude's reply typography: headings, lists, blockquote, inline code |
+
+## Applied UI Kit
+
+`ui_kits/app/` composes the tokens into a working chat surface (sidebar, chat area, composer, message bubbles) as React + Babel-standalone JSX modules mounted from `ui_kits/app/index.html`. See `ui_kits/app/README.md` for structure, reuse, and the evidence basis (reconstructed from measured CSS; the authenticated app was not crawlable).
+
+## Reuse Workflow
+
+1. Read `DESIGN.md` for principles and posture rules.
+2. Link `colors_and_type.css` (dark: `data-mode="dark"` on `<html>`) — tokens arrive as `--cds-*` custom properties with the real fonts already bound.
+3. Use `brand.json` when you need machine-readable values (extended ramps, provenance flags).
+4. Copy component patterns from `system/kit.html` / `system/kit.dark.html`; full-page patterns from `system/artifacts/`; a composed chat surface from `ui_kits/app/`.
+5. Logo usage: prefer `logos/favicon-0.svg` (clay starburst, transparent); `logos/apple-touch-icon-4.png` for raster contexts.
+6. Icons: 24×24 viewBox, `stroke: currentColor`, stroke-width 1.6, round caps/joins — see `ICON_PATHS` in `brand.html`.
+7. Review against the six `preview/` cards before shipping.
+
+## Verified Rules (enforced on artifacts built with this system)
+
+- Border-radius defaults to 8px.
+- Type uses the Anthropic stacks above (with the declared fallbacks when woff2 can't load).
+- Color comes from the measured palette only; clay is a high-signal accent, never a wash.

--- a/plugins/community/claude-design-system-ms5r1th0/references/source-2-SKILL.md
+++ b/plugins/community/claude-design-system-ms5r1th0/references/source-2-SKILL.md
@@ -1,0 +1,45 @@
+---
+name: claude-design-system
+description: Build artifacts in the Claude (Anthropic) visual language — warm ivory surfaces, near-black text, single clay accent #d97757, Anthropic Serif/Sans/Mono type — using measured tokens, real preserved fonts, logos, and component patterns from claude.ai.
+user-invocable: true
+---
+
+# Claude Design System
+
+## What is inside
+
+- `README.md` — product overview, source evidence, package contents, reuse workflow
+- `DESIGN.md` — canonical visual principles (palette, type, voice, imagery, layout, component evidence)
+- `colors_and_type.css` — measured token source of truth: light + dark themes, `--cds-*` properties, `@font-face` bindings to preserved woff2 files
+- `brand.json` — machine-readable bundle (core roles, extended light/dark scales, typography, fonts, imagery, layout, motion, provenance)
+- `fonts/` — Anthropic Sans, Anthropic Serif (normal + italic, variable 300–800), Anthropic Mono, Anthropicons-Variable
+- `logos/` — clay starburst SVG (primary), favicon set, apple-touch-icon, og-image
+- `imagery/` — social cover captures
+- `preview/` — six focused review cards: primary colors, typography specimens, spacing/radius/shadows, brand assets, buttons, prose
+- `ui_kits/app/` — applied chat-surface kit (React + Babel JSX modules: Sidebar, AssistantsList, ChatArea, MessageBubble, InputBar, App) with its own README
+- `system/` — engine-derived kits (`kit.html`, `kit.dark.html`), antd token files, gallery, and six generated artifacts (landing, deck, poster, email, newsletter, form)
+
+## Source context
+
+Extracted from https://claude.ai/ and re-measured live in 2026-07 against the site's real stylesheets (`data-color-version=v2`, `data-theme=claude`, light + dark blocks). Fonts and logos are the site's own files, preserved locally — never redrawn. The authenticated app was not crawlable; chat-surface guidance is reconstructed from CSS evidence and voice/tone from public copy — both labelled inferred.
+
+## When to use this skill
+
+Any artifact that should look and feel like Claude: product prototypes, marketing pages, decks, dashboards, or components for the Claude ecosystem. Bind it whenever the brief says "Claude", "Anthropic", or references claude.ai.
+
+## How to use
+
+1. Open `README.md` for the workflow and `DESIGN.md` for principles — follow the posture rules (warm ivory surfaces, near-black text, clay once per view, 8px radius, 1px hairlines).
+2. Link `colors_and_type.css` and compose with `--cds-*` tokens; add `data-mode="dark"` for the dark theme. The real fonts load automatically from `fonts/`.
+3. For machine-readable values read `brand.json` (`extended.light` / `extended.dark` hold the full measured scales).
+4. Copy component shapes from `system/kit.html` / `system/kit.dark.html`; full-page layouts from `system/artifacts/`; a composed, working chat surface from `ui_kits/app/` (see its README).
+5. Use `logos/favicon-0.svg` as the mark. Icons: 24×24, `stroke: currentColor`, stroke-width 1.6, round caps/joins.
+6. Review against the six `preview/` cards before shipping.
+
+## Design system highlights
+
+- **Warm, never cold:** every neutral carries a 45–60° hue; canvas `#ffffff`, surface `#f9f9f7`, text `#131313`, muted `#7b7974`, hairline `#e1e0d9`.
+- **One accent:** clay `#d97757` (deep step `#c6613f`) — mark, primary CTA, loading dots. Link blue `#256abf` and Pro violet `#7161e0` are functional, not decorative.
+- **Serif voice:** Anthropic Serif for Claude's words and editorial headlines; Anthropic Sans for UI; Anthropic Mono for code; Anthropicons-Variable for the wordmark.
+- **Soft depth:** shadows at 6–8% black; borders are dark-at-alpha hairlines; hover is a background step (`.15s ease-out`), press is `scale(.96)` on a spring curve.
+- **Restraint:** no gradients, no photography in product chrome, no emoji icons, no cold grays, no pure-black text.


### PR DESCRIPTION
Add Claude Design System (claude-design-system-ms5r1th0) plugin.
Version: 0.1.0
Description: A production-usable design-system package for **Claude** (Anthropic), extracted from [claude.ai](https://claude.ai/) and deepened by a live re-measurement pass (2026-07) against the site's real stylesheets (`data-color-v