### PR TITLE
fix(web): use neutral Windows app background

### DIFF
--- a/apps/web/src/styles/app-wash.css
+++ b/apps/web/src/styles/app-wash.css
@@ -72,13 +72,19 @@ body::before {
   background: var(--app-wash);
 }
 
+/* Windows desktop windows are opaque, so blend the existing neutral surfaces
+   instead of painting the web-only pastel wash. Keep this scoped to the
+   native win32 host: browser and macOS surfaces retain their materials. */
+html:has(.workspace-shell--desktop[data-host-platform='win32']) {
+  --app-wash: color-mix(in srgb, var(--bg-panel) 50%, var(--bg-subtle));
+}
+
 /* Desktop shell (Electron on macOS with window vibrancy): the REAL desktop
    wallpaper blurs through the window, so the painted pastel blobs step aside.
    html/body go fully transparent and the wash collapses to a translucent
    cream scrim that keeps content readable over arbitrary wallpapers — the
    Craft look. The desktop and darwin markers come from the host bridge
-   (App.tsx data-client-type/data-host-platform). Windows desktop windows are
-   opaque, so they intentionally keep the normal pastel wash. */
+   (App.tsx data-client-type/data-host-platform). */
 html:has(.workspace-shell--desktop[data-host-platform='darwin']) {
   /* Focused window: a firm scrim so content sits on a mostly solid ground.
      The unfocused state below thins this back to ~21% (0.34 × 62%), which

--- a/apps/web/tests/styles/app-wash-platform.test.ts
+++ b/apps/web/tests/styles/app-wash-platform.test.ts
@@ -7,12 +7,21 @@ const appWashCss = readFileSync(
 );
 
 describe('desktop app wash platform contract', () => {
+  it('uses a neutral token mix only for Windows desktop hosts', () => {
+    expect(appWashCss).toMatch(
+      /html:has\(\.workspace-shell--desktop\[data-host-platform='win32'\]\)\s*{\s*--app-wash:\s*color-mix\(in srgb, var\(--bg-panel\) 50%, var\(--bg-subtle\)\);\s*}/,
+    );
+    expect(appWashCss).toContain('radial-gradient(');
+  });
+
   it('limits window-vibrancy material rules to macOS desktop hosts', () => {
     const macDesktopSelector =
       ":has(.workspace-shell--desktop[data-host-platform='darwin'])";
-    const vibrancySelectors = appWashCss.match(
-      /html(?:\.is-window-blurred)?:has\(\.workspace-shell--desktop[^)]*\)(?: body(?:::before)?)?/g,
-    );
+    const vibrancySelectors = appWashCss
+      .match(
+        /html(?:\.is-window-blurred)?:has\(\.workspace-shell--desktop[^)]*\)(?: body(?:::before)?)?/g,
+      )
+      ?.filter((selector) => !selector.includes("data-host-platform='win32'"));
 
     expect(vibrancySelectors).not.toBeNull();
     expect(vibrancySelectors).not.toHaveLength(0);


### PR DESCRIPTION
## Why

While validating Open Design on Windows, the desktop shell's opaque window made the shared pink-and-blue web wash read as an unintended tinted application background. Windows needs a calmer neutral ground, while the web wash and macOS vibrancy should keep their existing platform-specific appearance.

This change gives the Windows desktop host a token-driven neutral background without changing the browser or macOS material paths.

## What users will see

On Windows desktop, Home and workspace surfaces now sit on a neutral gray app ground of approximately `#f4f4f4` instead of the pink-and-blue pastel wash. Browser users keep the existing wash, and macOS desktop users keep window vibrancy.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

### After — Windows desktop

Screenshot captured from the Windows desktop development runtime; attachment will be added to this draft.

## Bug fix verification

- Test path: `apps/web/tests/styles/app-wash-platform.test.ts`
- Red/green result: the Windows-host assertion failed before the scoped override and passes after the change.
- The contract also verifies that the default web radial wash remains present and all non-Windows desktop material rules remain scoped to macOS.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @open-design/web exec vitest run tests/styles/app-wash-platform.test.ts`
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- `pnpm typecheck`
- Windows desktop live inspection: host platform `win32`; computed app background approximately `#f4f4f4`
