### PR TITLE
fix(web): draw the team wordmark for every tier of a team plan

### DIFF
--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -50,7 +50,7 @@ import { SignOutConfirmDialog } from './SignOutConfirmDialog';
 import { notifyAmrLoginStatusChanged } from './amrLoginPolling';
 import { Icon } from './Icon';
 import { GITHUB_STARS_FALLBACK_LABEL, formatStars, useGithubStars } from './useGithubStars';
-import { PlanWordmark, planBadgeTierForLabel } from './PlanWordmark';
+import { PlanWordmark, planBadgeTierForWorkspace } from './PlanWordmark';
 import { RemixIcon } from './RemixIcon';
 import { InviteDialog } from './InviteDialog';
 import { MessageCenter } from './MessageCenter';
@@ -523,13 +523,23 @@ export function EntryNavRail({
       : t('entry.billingTierFree');
   const balanceLabel = formatVelaBalanceUsd(balanceUsd);
   // #5517: wordmark badge on the account row (replaces the chevron) and a
-  // small twin inside the menu's billing card. Derive from the raw tier id
-  // first so "team_plus" maps to the plus badge regardless of display label.
-  // Feed the RAW id first: the display label is now a plan-family name
-  // (团队版), which carries no tier word, so deriving the badge from it would
-  // drop the PLUS/PRO/MAX distinction. `rawTier` already prefers billing over
-  // the context hint and is empty only when neither reported one.
-  const planTier = planBadgeTierForLabel(rawTier || tierLabel);
+  // small twin inside the menu's billing card.
+  //
+  // The badge names the plan FAMILY, so a TEAM workspace draws the one `team`
+  // wordmark at every tier — free through max — while the personal ladder keeps
+  // its per-tier glyph (product ruling, see `planBadgeTierForWorkspace`). The
+  // workspace kind is passed because it is the only thing that can name the FREE
+  // team tier: B reports it with a null `planId` and an empty `membershipTier`,
+  // an id no different from a personal free account.
+  //
+  // The tier still leads with the RAW id: `rawTier` prefers billing over the
+  // context hint and is empty only when neither reported one, and the display
+  // label is a plan-family name (团队版) that carries no tier word — so the label
+  // is the last resort, never the first read.
+  const planTier = planBadgeTierForWorkspace({
+    tier: rawTier || tierLabel,
+    workspaceType: context?.workspaceType,
+  });
 
   const [accountOpen, setAccountOpen] = useState(false);
   // Message-center panel (opened from the account menu's 消息中心 row) and its

--- a/apps/web/src/components/PlanWordmark.tsx
+++ b/apps/web/src/components/PlanWordmark.tsx
@@ -1,17 +1,77 @@
-// Wordmark badges for the account membership tier (free / plus / pro / max /
+// Wordmark badges for the plan a workspace is on (free / plus / pro / max /
 // team), shown at the right end of the nav-rail account row in place of the
 // dropdown chevron. Strokes are normalized to currentColor so the badge
 // follows the surrounding icon color.
 
+import { isTeamPlanTier } from '../collab/team-plan';
+
 export type PlanBadgeTier = 'free' | 'plus' | 'pro' | 'max' | 'team';
 
-/** Maps a CreditsInfo tier label (e.g. "免费" / "Plus" / "团队版") to a badge. */
+/** The tier sources a badge can be derived from; pass whichever are in scope. */
+export interface PlanBadgeSources {
+  /**
+   * The resolved raw plan id (`resolvePlanTier`), or — only when no source
+   * reported an id at all — a display label.
+   */
+  tier: string | null | undefined;
+  /** `GET /api/workspace/context`'s `workspaceType`. */
+  workspaceType?: string | null;
+}
+
+/**
+ * The wordmark a workspace's plan should draw.
+ *
+ * The badge names the plan FAMILY, not the tier inside it. Product ruling
+ * (owner): 「团队版的订阅，这里应该都显示 team 的标识」 …… 「产品期望团队从 free
+ * 到 max，徽标都显示 team 的那个，个人的还是维持现状不要动」 — so every tier of a
+ * team subscription draws the one `team` wordmark, and the personal ladder keeps
+ * its per-tier glyph exactly as it is.
+ *
+ * Two independent facts make this a team plan, and either alone is enough:
+ *
+ *  • a team-namespaced plan id — B namespaces ids by workspace kind
+ *    (`team_basic` … `team_max_yearly`, see `collab/team-plan.ts`), so this is a
+ *    positive statement about the SUBSCRIPTION. It settles every PAID team tier,
+ *    including on a personal workspace that holds a team plan: membership is per
+ *    workspace, and a team subscription is a team subscription wherever the user
+ *    is standing.
+ *  • `workspaceType === 'team'` — the only signal left at the FREE team tier,
+ *    where B reports `billingState: 'free'` with a null `planId` and an empty
+ *    `membershipTier`, making the id byte-identical to a personal free account.
+ *
+ * The workspace kind must NOT leak into the plan LABEL rendered beside this
+ * badge: the label answers a subscription question, every user-created workspace
+ * in B is team-typed, and reading one as the other is what labelled a brand-new
+ * unpaid workspace 团队版 (#146). 免费 paired with the `team` wordmark is the
+ * intended reading — the family is team, the subscription is not paid.
+ */
+export function planBadgeTierForWorkspace(sources: PlanBadgeSources): PlanBadgeTier | null {
+  if (sources.workspaceType === 'team') return 'team';
+  return planBadgeTierForLabel(sources.tier ?? '');
+}
+
+/**
+ * Maps a raw plan id (`team_plus`) or a display label (「免费」/「团队版」) to a
+ * badge.
+ *
+ * TEAM IS MATCHED FIRST and that order is load-bearing: B's team ids EMBED the
+ * personal tier word, so asking `plus` / `pro` / `max` first claimed every paid
+ * team plan for the personal ladder and left this branch reachable only from a
+ * bare `team` id — `team_plus` drew the PLUS wordmark.
+ *
+ * Prefer `planBadgeTierForWorkspace`. This label-shaped path survives only for
+ * the caller whose remaining input is a localized display string: the nav rail
+ * falls back to its `tierLabel` when neither billing nor the workspace context
+ * reported a plan id at all, which is why 团队版 / 免费 must keep matching
+ * alongside the raw ids.
+ */
 export function planBadgeTierForLabel(label: string): PlanBadgeTier | null {
-  const normalized = label.toLowerCase();
+  const normalized = label.trim().toLowerCase();
+  const words = normalized.split(/[^a-z0-9]+/).filter(Boolean);
+  if (isTeamPlanTier(normalized) || words.includes('team') || label.includes('团队')) return 'team';
   if (normalized.includes('plus')) return 'plus';
   if (normalized.includes('pro')) return 'pro';
   if (normalized.includes('max')) return 'max';
-  if (normalized.includes('team') || label.includes('团队')) return 'team';
   if (normalized.includes('free') || label.includes('免费')) return 'free';
   return null;
 }

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -160,7 +160,7 @@ import {
   workspaceBillingSummaryForContext,
 } from '../collab/useWorkspaceContext';
 import { canUpgradeFromPlanTier, resolvePlanTier } from '../collab/team-plan';
-import { planBadgeTierForLabel } from './PlanWordmark';
+import { planBadgeTierForWorkspace } from './PlanWordmark';
 import { workspaceUpgradeUrl } from './EntryNavRail';
 import { canShowWorkspaceSettings } from '../collab/settings-access';
 import { ConnectorsBrowser } from './ConnectorsBrowser';
@@ -4629,11 +4629,15 @@ export function SettingsDialog({
                               : null;
                           // vela's `account.plan` is ACCOUNT-scoped, so a member
                           // whose plan is held by the team workspace reads
-                          // `free` there — the workspace context wins. The badge
-                          // is a tier nameplate (free/plus/pro/max), so the
-                          // resolved id maps onto its tier word (`team_plus` →
-                          // Plus) through the same helper the nav-rail account
-                          // row uses; an id outside that set renders verbatim.
+                          // `free` there — the workspace context wins.
+                          //
+                          // The badge names the plan FAMILY, so a TEAM workspace
+                          // reads `team` at every tier — free through max —
+                          // while the personal ladder keeps its tier word
+                          // (product ruling; 「设置中的这里应该一样的逻辑」, so
+                          // this goes through the SAME helper as the nav-rail
+                          // account row and cannot drift from it). An id outside
+                          // the badge set still renders verbatim.
                           const amrCardResolvedPlan =
                             isAmrAgent && active && amrCardStatus?.loggedIn
                               ? resolvePlanTier({
@@ -4643,7 +4647,10 @@ export function SettingsDialog({
                                 })
                               : null;
                           const amrCardPlanLabel = amrCardResolvedPlan
-                            ? planBadgeTierForLabel(amrCardResolvedPlan) ?? amrCardResolvedPlan
+                            ? planBadgeTierForWorkspace({
+                                tier: amrCardResolvedPlan,
+                                workspaceType: workspaceContext?.workspaceType,
+                              }) ?? amrCardResolvedPlan
                             : null;
                           // recvqfYKutwWlQ: a team member without billing
                           // permission (owner-only) can't act on an upgrade

--- a/apps/web/tests/components/EntryNavRail.team-plan-badge.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.team-plan-badge.test.tsx
@@ -1,0 +1,246 @@
+// @vitest-environment jsdom
+//
+// Acceptance: which plan wordmark a TEAM workspace draws on the rail's account
+// row (bottom-left) and on its twin inside the account menu's billing card.
+//
+// Reported (owner, from a real client standing in a team workspace):
+// 「团队版的订阅，这里应该都显示 team 的标识」 …… 「产品期望团队从 free 到 max，
+// 徽标都显示 team 的那个，个人的还是维持现状不要动」
+//
+// So the badge names the plan FAMILY, not the tier inside it: every tier of a
+// team subscription draws the one `team` wordmark, and the personal ladder is
+// untouched. It got this wrong from both ends:
+//
+//   • PAID team tiers — `planBadgeTierForLabel` asked `plus` / `pro` / `max`
+//     BEFORE `team`, and B's team ids EMBED the personal tier word
+//     (`team_plus`, `team_max`), so `team_plus` matched `plus` and the `team`
+//     branch was reachable only from a bare `team` id.
+//   • the FREE team tier — B reports an unsubscribed workspace as
+//     `billingState: 'free'` with a null `planId` and an EMPTY `membershipTier`,
+//     an id indistinguishable from a personal free account, so no id can name
+//     it and only the workspace kind can.
+//
+// The plan LABEL beside the badge is deliberately NOT part of this. The label
+// answers a subscription question, and every user-created workspace in B is
+// team-typed, so labelling one 团队版 off the workspace kind is #146 (covered by
+// `EntryNavRail.billing-card.test.tsx`). 免费 paired with the `team` wordmark is
+// the intended reading: the family is team, the subscription is not paid.
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { WorkspaceBillingSummary, WorkspaceCollabContext } from '@open-design/contracts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EntryNavRail, resetWorkspaceDirectoryCache } from '../../src/components/EntryNavRail';
+import { PlanWordmark, type PlanBadgeTier } from '../../src/components/PlanWordmark';
+import { I18nProvider } from '../../src/i18n';
+
+const originalFetch = globalThis.fetch;
+
+function context(overrides: Partial<WorkspaceCollabContext> = {}): WorkspaceCollabContext {
+  return {
+    workspaceId: 'ws-1',
+    workspaceType: 'team',
+    workspaceMemberId: 'wm-1',
+    teamName: 'OD Feature Team',
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+    billingState: 'active',
+    planId: null,
+    permissions: { canInviteMembers: true, canViewWorkspaceSettings: true },
+    ...overrides,
+  } as unknown as WorkspaceCollabContext;
+}
+
+function billing(overrides: Partial<WorkspaceBillingSummary> = {}): WorkspaceBillingSummary {
+  return {
+    workspaceId: 'ws-1',
+    membershipTier: '',
+    totalAvailableCredits: 0,
+    subscriptionCredits: 0,
+    rechargeCredits: 0,
+    balanceUsd: '0',
+    subscriptionStatus: '',
+    availableActions: [],
+    ...overrides,
+  } as WorkspaceBillingSummary;
+}
+
+function renderRail(props: {
+  context: WorkspaceCollabContext;
+  billing: WorkspaceBillingSummary | null;
+}) {
+  return render(
+    <I18nProvider initial="zh-CN">
+      <EntryNavRail
+        view="home"
+        onViewChange={() => {}}
+        onNewProject={() => {}}
+        open
+        context={props.context}
+        billing={props.billing}
+        balanceUsd="0"
+      />
+    </I18nProvider>,
+  );
+}
+
+const ALL_TIERS: PlanBadgeTier[] = ['free', 'plus', 'pro', 'max', 'team'];
+
+/**
+ * Read back WHICH wordmark a slot is drawing.
+ *
+ * `PlanWordmark` is decorative (`aria-hidden`) and the viewBox is not a unique
+ * key — plus and max are both 114 wide — so the artwork itself is the only
+ * discriminator. The fingerprints are taken FROM the component, never
+ * hard-coded, so redrawing a glyph cannot silently invalidate this test.
+ */
+function wordmarkFingerprint(svg: Element): string {
+  return Array.from(svg.querySelectorAll('path'))
+    .map((path) => path.getAttribute('d') ?? '')
+    .join('|');
+}
+
+let fingerprintIndex: Map<string, PlanBadgeTier> | null = null;
+
+function tierByFingerprint(): Map<string, PlanBadgeTier> {
+  if (fingerprintIndex) return fingerprintIndex;
+  const index = new Map<string, PlanBadgeTier>();
+  for (const tier of ALL_TIERS) {
+    const container = document.createElement('div');
+    const view = render(<PlanWordmark tier={tier} />, { container });
+    const svg = container.querySelector('svg.plan-wordmark');
+    if (!svg) throw new Error(`PlanWordmark rendered no svg for ${tier}`);
+    index.set(wordmarkFingerprint(svg), tier);
+    view.unmount();
+  }
+  fingerprintIndex = index;
+  return index;
+}
+
+function drawnTier(slot: Element | null | undefined): PlanBadgeTier | 'unrecognized' | null {
+  const svg = slot?.querySelector('svg.plan-wordmark');
+  if (!svg) return null;
+  return tierByFingerprint().get(wordmarkFingerprint(svg)) ?? 'unrecognized';
+}
+
+/** The wordmark on the always-visible account row, in place of the chevron. */
+function accountRowTier() {
+  return drawnTier(document.querySelector('.entry-nav-rail__account-trigger'));
+}
+
+/** Its twin inside the account menu's billing card. Opens the menu. */
+function billingCardTier() {
+  fireEvent.click(screen.getByTestId('entry-nav-account'));
+  return drawnTier(document.querySelector('.entry-nav-rail__menu-credits'));
+}
+
+beforeEach(() => {
+  resetWorkspaceDirectoryCache();
+  globalThis.fetch = vi.fn(
+    async () => new Response(JSON.stringify({}), { status: 200 }),
+  ) as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = originalFetch;
+  resetWorkspaceDirectoryCache();
+  vi.restoreAllMocks();
+});
+
+describe('plan wordmark — a team workspace draws `team` at every tier', () => {
+  it.each([
+    // B's report for a workspace nobody has paid for: a positive free
+    // entitlement, no plan id, and an empty tier on the summary.
+    {
+      name: 'free (nothing paid for)',
+      entitlement: { billingState: 'free', planId: null },
+      membershipTier: '',
+    },
+    {
+      name: 'team_basic',
+      entitlement: { billingState: 'active', planId: 'team_basic' },
+      membershipTier: 'team_basic',
+    },
+    {
+      name: 'team_plus',
+      entitlement: { billingState: 'active', planId: 'team_plus' },
+      membershipTier: 'team_plus',
+    },
+    {
+      name: 'team_pro',
+      entitlement: { billingState: 'active', planId: 'team_pro' },
+      membershipTier: 'team_pro',
+    },
+    {
+      name: 'team_max',
+      entitlement: { billingState: 'active', planId: 'team_max' },
+      membershipTier: 'team_max',
+    },
+    // A billing-period suffix is still the same plan family.
+    {
+      name: 'team_max_yearly',
+      entitlement: { billingState: 'active', planId: 'team_max_yearly' },
+      membershipTier: 'team_max_yearly',
+    },
+  ])('draws the team wordmark on $name', ({ entitlement, membershipTier }) => {
+    renderRail({
+      context: context(entitlement as Partial<WorkspaceCollabContext>),
+      billing: billing({ membershipTier }),
+    });
+
+    expect(accountRowTier()).toBe('team');
+  });
+
+  it('draws the same wordmark on the account row and in the billing card', () => {
+    renderRail({
+      context: context({ billingState: 'active', planId: 'team_pro' } as Partial<WorkspaceCollabContext>),
+      billing: billing({ membershipTier: 'team_pro', subscriptionStatus: 'active' }),
+    });
+
+    expect(accountRowTier()).toBe('team');
+    expect(billingCardTier()).toBe('team');
+  });
+
+  // A personal workspace CAN hold a team-namespaced plan — membership is per
+  // workspace, and `workspaceBillingSummaryForContext` deliberately passes a
+  // team tier through on the personal side so `hasTeamPlan` still offers the
+  // team surfaces there. The badge names the SUBSCRIPTION family, and that
+  // subscription is a team one, so it draws `team` too. This is the only case
+  // outside a team workspace whose glyph moves.
+  it('draws the team wordmark for a personal workspace holding a team plan', () => {
+    renderRail({
+      context: context({
+        workspaceType: 'personal',
+        billingState: 'active',
+        planId: 'team_plus',
+      } as unknown as Partial<WorkspaceCollabContext>),
+      billing: billing({ membershipTier: 'team_plus', subscriptionStatus: 'active' }),
+    });
+
+    expect(accountRowTier()).toBe('team');
+  });
+});
+
+describe('plan wordmark — the personal ladder is untouched', () => {
+  // 「个人的还是维持现状不要动」. Each personal tier keeps the glyph it draws
+  // today; a fix that reached for the workspace kind alone, or that matched
+  // `team` too loosely, would show up here.
+  it.each([
+    { plan: 'free', entitlement: { billingState: 'free', planId: null } },
+    { plan: 'plus', entitlement: { billingState: 'active', planId: 'plus' } },
+    { plan: 'pro', entitlement: { billingState: 'active', planId: 'pro' } },
+    { plan: 'max', entitlement: { billingState: 'active', planId: 'max' } },
+  ])('keeps the $plan wordmark for a personal $plan workspace', ({ plan, entitlement }) => {
+    renderRail({
+      context: context({
+        workspaceType: 'personal',
+        ...entitlement,
+      } as unknown as Partial<WorkspaceCollabContext>),
+      billing: billing({ membershipTier: plan, subscriptionStatus: entitlement.billingState }),
+    });
+
+    expect(accountRowTier()).toBe(plan);
+  });
+});

--- a/apps/web/tests/components/EntryShell.workspace-plan-badge-scope.test.tsx
+++ b/apps/web/tests/components/EntryShell.workspace-plan-badge-scope.test.tsx
@@ -339,8 +339,10 @@ describe('account menu plan nameplate follows the selected workspace', () => {
 
   // The A side of the report: the nameplate answers a WORKSPACE question, so a
   // personal Plus subscription must not name a team workspace's plan. The label
-  // names the plan FAMILY (团队版) while the badge keeps the tier word — #5517's
-  // split, so `team_plus` intentionally pairs 团队版 with the PLUS wordmark.
+  // names the plan FAMILY (团队版) and, per the later product ruling, so does the
+  // badge — a team subscription draws the `team` wordmark at every tier. The
+  // account here pays for a personal PLUS, so the PLUS wordmark is exactly the
+  // regression this asserts against.
   it('names the workspace subscription, not the account subscription', async () => {
     const home = await mountHomeShell(PAID_TEAM);
 
@@ -348,7 +350,7 @@ describe('account menu plan nameplate follows the selected workspace', () => {
     const card = home.card();
     expect(card.queryByText('专业版')).toBeNull();
     expect(card.getByText('团队版')).toBeTruthy();
-    expect(accountRowBadgeViewBox()).toBe(BADGE_VIEWBOX_WIDTH.plus);
+    expect(accountRowBadgeViewBox()).toBe(BADGE_VIEWBOX_WIDTH.team);
   });
 
   // The B side: the exact reported sequence. Switching away from a paid
@@ -366,10 +368,16 @@ describe('account menu plan nameplate follows the selected workspace', () => {
     // The plan half must follow it too. Before the fix this still read
     // 专业版 + the PLUS wordmark, because it came from the account summary
     // that cannot change when the workspace does.
+    //
+    // The LABEL is what carries the switch: it is a subscription question, and
+    // this workspace has no subscription (免费). The badge names the plan FAMILY,
+    // which both workspaces share, so it stays on `team` across the switch —
+    // still a live guard on this bug, since the account's own tier is a personal
+    // PLUS and reverting the projection would put that wordmark back here.
     const card = home.card();
     expect(card.queryByText('专业版')).toBeNull();
     expect(card.queryByText('团队版')).toBeNull();
     expect(card.getByText('免费')).toBeTruthy();
-    expect(accountRowBadgeViewBox()).toBe(BADGE_VIEWBOX_WIDTH.free);
+    expect(accountRowBadgeViewBox()).toBe(BADGE_VIEWBOX_WIDTH.team);
   });
 });

--- a/apps/web/tests/components/SettingsDialog.team-plan-badge.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.team-plan-badge.test.tsx
@@ -1,0 +1,249 @@
+// @vitest-environment jsdom
+//
+// Acceptance: the plan pill on Settings → 本机 CLI → Open Design must name the
+// same plan FAMILY as the rail's account-row wordmark.
+//
+// Product ruling (owner): 「团队版的订阅，这里应该都显示 team 的标识」 …… 「产品
+// 期望团队从 free 到 max，徽标都显示 team 的那个，个人的还是维持现状不要动」.
+//
+// This card derives its pill from the same `PlanWordmark` helper the rail uses,
+// so it carried the identical defect: `team_plus` matched the `plus` branch
+// first (B's team ids embed the personal tier word), and a free team workspace
+// resolves to a bare `free` that no id can distinguish from a personal free
+// account. The owner has been explicit that the two surfaces move together —
+// 「设置中的这里应该一样的逻辑」 — so both are covered, in the same shape.
+//
+// See `EntryNavRail.team-plan-badge.test.tsx` for the rail half.
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { WorkspaceCollabContext } from '@open-design/contracts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SettingsDialog } from '../../src/components/SettingsDialog';
+import { I18nProvider } from '../../src/i18n';
+import type { AgentInfo, AppConfig } from '../../src/types';
+
+vi.mock('../../src/providers/registry', async () => {
+  const actual = await vi.importActual<typeof import('../../src/providers/registry')>(
+    '../../src/providers/registry',
+  );
+  return {
+    ...actual,
+    fetchCodexPets: vi.fn(async () => []),
+    syncCommunityPets: vi.fn(async () => []),
+    fetchSkills: vi.fn(async () => []),
+    fetchDesignSystems: vi.fn(async () => []),
+    fetchDesignTemplates: vi.fn(async () => []),
+    fetchConnectors: vi.fn(async () => []),
+    fetchLatestGithubReleaseInfo: vi.fn(async () => null),
+    openExternalUrl: vi.fn(),
+  };
+});
+
+vi.mock('../../src/analytics/provider', () => ({
+  useAnalytics: () => ({
+    track: vi.fn(),
+    setConsent: () => undefined,
+    setIdentity: () => undefined,
+    setConfigureGlobals: () => undefined,
+    anonymousId: 'test-anonymous',
+    sessionId: 'test-session',
+    newRequestId: () => 'test-request',
+  }),
+}));
+
+const originalFetch = globalThis.fetch;
+
+const baseConfig: AppConfig = {
+  mode: 'daemon',
+  apiKey: '',
+  apiProtocol: 'anthropic',
+  apiVersion: '',
+  baseUrl: 'https://api.anthropic.com',
+  model: 'claude-sonnet-4-5',
+  apiProviderBaseUrl: 'https://api.anthropic.com',
+  apiProtocolConfigs: {},
+  agentId: 'amr',
+  skillId: null,
+  designSystemId: null,
+  onboardingCompleted: true,
+  mediaProviders: {},
+  agentModels: {},
+  agentCliEnv: {},
+};
+
+const amrAgent: AgentInfo = {
+  id: 'amr',
+  name: 'AMR (vela)',
+  bin: 'amr',
+  available: true,
+  version: '1.0.0',
+  models: [{ id: 'default', label: 'Default' }],
+  supportsCustomModel: false,
+};
+
+const OWNER_PERMISSIONS = {
+  canManageMembers: true,
+  canManageBilling: true,
+  canInviteMembers: true,
+  canManageAutoRecharge: true,
+  canShareProjects: true,
+  canWriteSyncedFiles: true,
+  canViewWorkspaceSettings: true,
+  canManageSharedResources: true,
+};
+
+function workspaceContext(
+  overrides: Partial<WorkspaceCollabContext> = {},
+): WorkspaceCollabContext {
+  return {
+    workspaceId: 'ws-1',
+    workspaceType: 'team',
+    workspaceMemberId: 'wm-1',
+    teamId: 'team-1',
+    teamName: 'OD Feature Team',
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+    billingState: 'active',
+    planId: null,
+    providerMode: 'workspace_managed',
+    seatSummary: { seatLimit: 5, usedSeats: 2, availableSeats: 3, isSeatFull: false },
+    permissions: OWNER_PERMISSIONS,
+    workspaceSettingsUrl: 'https://web.example.com/console/settings?workspaceId=ws-1',
+    ...overrides,
+  } as unknown as WorkspaceCollabContext;
+}
+
+/**
+ * Stand the CLI tab up for one identity shape.
+ *
+ * `accountPlan` is vela's ACCOUNT-scoped login projection and `context.planId`
+ * is the WORKSPACE plan; they disagree by design for a team member, so a team
+ * case deliberately leaves the account projection on `free`.
+ */
+async function renderCliTab(options: {
+  context: WorkspaceCollabContext;
+  accountPlan: string;
+}) {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = input.toString();
+    if (url.startsWith('/api/workspace/context')) {
+      return new Response(JSON.stringify({ context: options.context }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    if (url.startsWith('/api/workspace/billing')) {
+      // Account metadata outage / not yet reported: the resolved tier then comes
+      // from the workspace context, which carries the same raw plan id.
+      return new Response(JSON.stringify({ summary: null, workspaces: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    if (url.startsWith('/api/integrations/vela/status')) {
+      return new Response(
+        JSON.stringify({
+          loggedIn: true,
+          profile: 'default',
+          user: { id: 'u1', email: 'owner@example.com' },
+          account: { plan: options.accountPlan, balanceUsd: '210.0000' },
+          configPath: '/Users/test/.amr/config.json',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }
+    return new Response(JSON.stringify({}), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  render(
+    <I18nProvider initial="en">
+      <SettingsDialog
+        initial={baseConfig}
+        agents={[amrAgent]}
+        daemonLive
+        appVersionInfo={null}
+        initialSection="execution"
+        onPersist={vi.fn()}
+        onSilentUpdatePreferenceChange={async () => undefined}
+        onPersistComposioKey={vi.fn()}
+        onClose={vi.fn()}
+        onRefreshAgents={vi.fn()}
+      />
+    </I18nProvider>,
+  );
+
+  fireEvent.click(screen.getByRole('tab', { name: /Local CLI.*1 installed/i }));
+  // Both identity reads must land before the pill is meaningful.
+  await waitFor(() => {
+    expect(screen.getByTestId('settings-agent-card-amr')).toBeTruthy();
+    expect(screen.getByText('owner@example.com')).toBeTruthy();
+  });
+}
+
+/** The plan pill's text. Rendered lowercase; CSS capitalizes it. */
+async function planPill(): Promise<string> {
+  const el = await waitFor(() => {
+    const found = document.querySelector('.agent-card-plan-badge');
+    if (!found) throw new Error('plan pill is not rendered');
+    return found;
+  });
+  return el.textContent?.trim() ?? '';
+}
+
+beforeEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe('Settings CLI card — a team workspace reads `team` at every tier', () => {
+  it.each([
+    // B's report for a workspace nobody has paid for: no plan id at all, so the
+    // account projection's `free` is the only tier in scope.
+    { name: 'free (nothing paid for)', planId: null, accountPlan: 'free' },
+    { name: 'team_basic', planId: 'team_basic', accountPlan: 'free' },
+    { name: 'team_plus', planId: 'team_plus', accountPlan: 'free' },
+    { name: 'team_pro', planId: 'team_pro', accountPlan: 'free' },
+    { name: 'team_max', planId: 'team_max', accountPlan: 'free' },
+    { name: 'team_max_yearly', planId: 'team_max_yearly', accountPlan: 'free' },
+  ])('reads team on $name', async ({ planId, accountPlan }) => {
+    await renderCliTab({
+      context: workspaceContext({
+        billingState: planId ? 'active' : 'free',
+        planId,
+      } as unknown as Partial<WorkspaceCollabContext>),
+      accountPlan,
+    });
+
+    expect(await planPill()).toBe('team');
+  });
+});
+
+describe('Settings CLI card — the personal ladder is untouched', () => {
+  it.each(['free', 'plus', 'pro', 'max'])(
+    'keeps %s for a personal workspace on that plan',
+    async (plan) => {
+      await renderCliTab({
+        context: workspaceContext({
+          workspaceType: 'personal',
+          teamId: undefined,
+          teamName: undefined,
+          billingState: plan === 'free' ? 'free' : 'active',
+          planId: null,
+        } as unknown as Partial<WorkspaceCollabContext>),
+        accountPlan: plan,
+      });
+
+      expect(await planPill()).toBe(plan);
+    },
+  );
+});


### PR DESCRIPTION
## Why

A team workspace drew the **personal Plus** wordmark on the rail's account row (bottom-left) and in Settings → Local CLI. Product ruling from the owner, looking at a real client:

> 「团队版的订阅，这里应该都显示 team 的标识」…… 产品期望团队从 free 到 max，徽标都显示 team 的那个，**个人的还是维持现状不要动**

So the badge names the plan **family**, not the tier inside it: every tier of a team subscription draws the one `team` wordmark, and the personal ladder stays exactly as it is today.

This is the glyph-selection half of the nameplate. #6182 fixed *which plan the badge reads* (workspace-scoped instead of account-scoped) and deliberately did not touch `PlanWordmark.tsx`; this PR fixes *which glyph that plan selects*. The `team` artwork was already there — `VIEW_BOX` and `PATHS` both define it — so nothing was missing, it was only unreachable.

**Root cause, and it failed from both ends:**

1. **Every paid team tier.** `planBadgeTierForLabel` asked `plus` / `pro` / `max` **before** `team`, and B namespaces team plan ids by *embedding the personal tier word* — `team_plus`, `team_pro`, `team_max`. So `'team_plus'.includes('plus')` won on the first branch and the `team` branch was reachable only from a bare `team` id. `team_basic` was the one team tier that happened to work, because "basic" collides with nothing.
2. **The free team tier.** B reports an unsubscribed workspace as `billingState: 'free'` with a null `planId` and an empty `membershipTier` — an id byte-identical to a personal free account. No plan id can name it, so nothing but the workspace kind can.

## What users will see

Standing in a team workspace, the plan badge on the account row (and its twin in the account menu's billing card, and the pill on Settings → Local CLI → Open Design) now reads **team** on every tier — free, basic, plus, pro, max — instead of the personal `plus` / `pro` / `max` glyph.

Nothing changes for a personal workspace: free / plus / pro / max keep the glyph they draw today.

The plan **label** next to the badge is untouched. It answers a subscription question, and every user-created workspace in B is team-typed, so labelling one 团队版 off the workspace kind is #146. `免费` sitting beside the `team` wordmark is now the intended pairing: the family is team, the subscription is not paid.

## Surface area

- [x] **UI** — the plan nameplate on the rail account row, the account menu's billing card, and the Settings → Local CLI Open Design card
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys** — none needed; the badge is an SVG glyph and the Settings pill renders the tier token (`team`) that already existed
- [ ] **New top-level dependency**
- [x] **Default behavior change** — a team workspace's badge changes glyph without the user opting in
- [ ] **None**

## Screenshots

Captured from the real rendered rail (Playwright visual lane, browser-side API fixtures — the actual component, the actual CSS), on the same fixture before and after the fix. The entry point is the rail's account row, bottom-left, which is where the owner reported it:

| workspace | before | after |
|---|---|---|
| team workspace on `team_plus` | `Leaf` + **plus** wordmark | `Leaf` + **team** wordmark |
| team workspace, nothing paid for | `Leaf` + **free** wordmark | `Leaf` + **team** wordmark |
| personal workspace on `plus` (control) | `Leaf` + **plus** wordmark | `Leaf` + **plus** wordmark — identical |

PNGs are attached below. To reproduce locally, stub `/api/workspace/context` with `workspaceType: 'team'` + the plan id under test and read `.entry-nav-rail__account-trigger svg.plan-wordmark` — the `viewBox` width tells the tiers apart (`team` 136, `plus`/`max` 114, `pro` 108, `free` 107).

## Bug fix verification

Red-first, per AGENTS.md → *Bug follow-up workflow*.

**Tests that reproduce the bug**

- `apps/web/tests/components/EntryNavRail.team-plan-badge.test.tsx` — the rail account row + its billing-card twin, driven through the real `EntryNavRail`. Reads back *which* wordmark is drawn by fingerprinting the rendered `<path d>` set against the component's own output, because the viewBox is not a unique key (plus and max are both 114 wide) and the badge is `aria-hidden`.
- `apps/web/tests/components/SettingsDialog.team-plan-badge.test.tsx` — the same matrix on the Settings → Local CLI card, through the real `SettingsDialog`.

Both cover a team workspace at **every** tier (free / basic / plus / pro / max, plus `team_max_yearly` for the billing-period suffix) **and** a personal workspace at every tier asserting today's glyph is unchanged.

**Red on unmodified `feat/workspace-team`** (`origin/feat/workspace-team` @ `738bde2f1`, source untouched):

```
 × EntryNavRail.team-plan-badge > draws the team wordmark on 'free (nothing paid for)'   → expected 'team', got 'free'
 ✓ EntryNavRail.team-plan-badge > draws the team wordmark on 'team_basic'
 × EntryNavRail.team-plan-badge > draws the team wordmark on 'team_plus'                 → expected 'team', got 'plus'
 × EntryNavRail.team-plan-badge > draws the team wordmark on 'team_pro'                  → expected 'team', got 'pro'
 × EntryNavRail.team-plan-badge > draws the team wordmark on 'team_max'                  → expected 'team', got 'max'
 × EntryNavRail.team-plan-badge > draws the team wordmark on 'team_max_yearly'           → expected 'team', got 'max'
 × EntryNavRail.team-plan-badge > draws the same wordmark on the account row and in the billing card
 × EntryNavRail.team-plan-badge > draws the team wordmark for a personal workspace holding a team plan
 ✓ EntryNavRail.team-plan-badge > the personal ladder is untouched > keeps the 'free' wordmark
 ✓ EntryNavRail.team-plan-badge > the personal ladder is untouched > keeps the 'plus' wordmark
 ✓ EntryNavRail.team-plan-badge > the personal ladder is untouched > keeps the 'pro' wordmark
 ✓ EntryNavRail.team-plan-badge > the personal ladder is untouched > keeps the 'max' wordmark
 × SettingsDialog.team-plan-badge > reads team on 'free (nothing paid for)'               → expected 'team', got 'free'
 ✓ SettingsDialog.team-plan-badge > reads team on 'team_basic'
 × SettingsDialog.team-plan-badge > reads team on 'team_plus'                             → expected 'team', got 'plus'
 × SettingsDialog.team-plan-badge > reads team on 'team_pro'                              → expected 'team', got 'pro'
 × SettingsDialog.team-plan-badge > reads team on 'team_max'                              → expected 'team', got 'max'
 × SettingsDialog.team-plan-badge > reads team on 'team_max_yearly'                       → expected 'team', got 'max'
 ✓ SettingsDialog.team-plan-badge > the personal ladder is untouched > keeps free
 ✓ SettingsDialog.team-plan-badge > the personal ladder is untouched > keeps plus
 ✓ SettingsDialog.team-plan-badge > the personal ladder is untouched > keeps pro
 ✓ SettingsDialog.team-plan-badge > the personal ladder is untouched > keeps max

 Test Files  2 failed (2)
      Tests  12 failed | 10 passed (22)
```

Note which cases were **already green** on base: every personal tier (proving the personal side does not move) and `team_basic` (proving this was an ordering defect, not a missing glyph).

**Green on this branch** — the two new files plus every neighbouring suite that owns this surface:

```
 Test Files  6 passed (6)
      Tests  71 passed (71)

 tests/team-plan.test.ts                                    26 passed
 tests/components/EntryNavRail.team-plan-badge.test.tsx     12 passed
 tests/components/SettingsDialog.team-plan-badge.test.tsx   10 passed
 tests/components/EntryNavRail.billing-card.test.tsx        11 passed   (#146 label guard, unchanged)
 tests/components/SettingsDialog.top-tier-upgrade.test.tsx  10 passed   (upgrade gate, unchanged)
 tests/components/EntryShell.workspace-plan-badge-scope.test.tsx  2 passed  (#6182, badge assertion updated — see below)
```

**Mutation-tested — each half of the fix is load-bearing:**

| mutation | red |
|---|---|
| M1: restore only the original `plus`/`pro`/`max`-before-`team` ordering | 1 — the personal workspace holding a team plan (the workspace-kind branch masks the rest) |
| M2: remove only the `workspaceType === 'team'` branch | 3 — both free-team cases, plus the #6182 workspace-switch case that lands on a free team |
| M3: revert both (= pre-fix behaviour) | **14 failed \| 10 passed** — the original 12 plus the 2 `EntryShell.workspace-plan-badge-scope` badge assertions, confirming those edits are live assertions and not a rubber stamp |

**One existing test's expectations were updated, deliberately:** `EntryShell.workspace-plan-badge-scope.test.tsx` (#6182) asserted the account row drew `plus` for a `team_plus` workspace and `free` after switching to an unpaid team — both encode the old glyph rule. They now assert `team` in both places. That still guards #6182: the account in that fixture holds a **personal** Plus, so reverting the workspace projection would put the 114-wide PLUS wordmark back on the row. The switch evidence itself moves to the label half (团队版 → 免费), which is where a subscription question belongs. M3 above shows both assertions genuinely go red without the fix.

## Adjacent issues (not fixed here)

- **`PlanBadge.tsx` is clean.** It does no tier derivation at all — it renders whatever `plan` string it is handed, with `data-plan` and CSS `capitalize`. Its styling is tier-agnostic (one `--accent` treatment), so `team` needs no new CSS. Reported because it was worth ruling out.
- **`InlineModelSwitcher.tsx:681` has a *different* defect on the same pill.** `amrPlanLabel = amrStatus?.account?.plan` — vela's **account-scoped** login projection, rendered raw. That is the exact source #6182 and the top-tier-upgrade fix moved off: it reports `free` for a member whose entitlement is held by their team, and it would print a raw snake_case `team_plus` verbatim. Wrong *source* plus no family mapping — a separate red spec and a separate PR, kept out of this one per AGENTS.md → "hold the spec's scope".

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` (root, all packages) — pass
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm --filter @open-design/web test` — pass — **552 files, 5576 passed, 11 skipped**, 0 failed (base had 5565 pre-existing tests; this PR adds 22)
