### PR TITLE
fix(daemon): split AMR workspace proof failure from proof refusal

### DIFF
--- a/apps/daemon/src/runtimes/project-amr-trace-env.ts
+++ b/apps/daemon/src/runtimes/project-amr-trace-env.ts
@@ -5,17 +5,136 @@ import { openDesignAmrTraceEnv } from './env.js';
 
 type SqliteDb = Parameters<typeof getWorkspaceProjectByProjectId>[0];
 
-export class ProjectWorkspaceScopeUnavailableError extends Error {
+/** Total directory read attempts, i.e. one initial try plus two retries. */
+const DIRECTORY_READ_ATTEMPTS = 3;
+/** Backoff before retry N, bounded so the AMR spawn path stays interactive. */
+const DIRECTORY_RETRY_BACKOFF_MS = [120, 360] as const;
+
+/**
+ * Every way the AMR workspace-binding proof can end, as one closed union.
+ *
+ * This exists because the alternative cost three wrong root causes in a single
+ * day: a full diagnostics export from an affected user could not say which
+ * branch had decided, so each hypothesis had to be argued from source-reading
+ * and then discarded. Two of these kinds used to be one error with one message.
+ *
+ * Keep it a closed union — it is a telemetry grouping key and a log token, so a
+ * reader holding only a run record or only a log must be able to tell the
+ * branches apart without opening this file.
+ */
+export type ProjectWorkspaceScopeOutcomeKind =
+  /** SQLite holds no binding for the project at all. Refused. */
+  | 'refused_no_binding'
+  /** The directory answered and listed no active membership for it. Refused. */
+  | 'refused_no_active_membership'
+  /**
+   * The directory answered with an EMPTY membership list. Vela's
+   * `GET /api/v1/workspaces` runs `ensurePersonalWorkspace` before listing and
+   * applies no type filter, so an authenticated caller structurally always has
+   * at least their personal workspace — an empty list therefore means a
+   * malformed or unexpected body, not a membership fact. Kept distinct from
+   * `refused_no_active_membership` so it can never be read as "you were removed".
+   */
+  | 'refused_directory_empty'
+  /** Every bounded directory read failed. Proceeded on the account wallet. */
+  | 'proceeded_directory_unreadable'
+  /** Proven team binding; the team wallet pays. */
+  | 'resolved_team'
+  /** Proven personal binding; the account wallet pays. */
+  | 'resolved_personal';
+
+/**
+ * Machine-readable record of which branch decided, and on what evidence.
+ * Deliberately carries ids and counts only — never member rows or credentials.
+ */
+export interface ProjectWorkspaceScopeOutcome {
+  kind: ProjectWorkspaceScopeOutcomeKind;
+  projectId: string;
+  /** The workspace the project is pinned to, as persisted. */
+  workspaceId: string | null;
+  /** Whether the final directory read answered; null when none was needed. */
+  directoryOk: boolean | null;
+  /** Active membership entries returned; null when no read was needed. */
+  directoryItemCount: number | null;
+  /** Directory reads spent, including retries; 0 when none was needed. */
+  directoryReadAttempts: number;
+}
+
+/**
+ * The membership authority ANSWERED and the answer was no: the signed-in member
+ * holds no active membership in the workspace this project is pinned to — or the
+ * project carries no binding at all, which SQLite alone already proves.
+ *
+ * This is the one outcome that still fails closed. Spending another team's
+ * wallet is worse than refusing the run, so do not widen this into a fallback.
+ *
+ * `code` and `outcome` are the machine-readable cause. They exist so a run
+ * record alone — `state.json` / `events.jsonl`, the file a user can still hand
+ * over after logs have rotated — identifies the branch without prose parsing.
+ */
+export class ProjectWorkspaceScopeRefusedError extends Error {
+  readonly code = 'PROJECT_WORKSPACE_SCOPE_REFUSED';
+
   constructor(
     readonly projectId: string,
     readonly workspaceId: string | null,
+    readonly outcome: Extract<
+      ProjectWorkspaceScopeOutcomeKind,
+      | 'refused_no_binding'
+      | 'refused_no_active_membership'
+      | 'refused_directory_empty'
+    >,
   ) {
     super(
-      `Cannot authorize project ${projectId}: its persisted workspace ` +
-        `${workspaceId ?? 'binding'} is unavailable for the signed-in member`,
+      `Cannot authorize project ${projectId}: the signed-in member holds no ` +
+        `active membership in its persisted workspace ` +
+        `${workspaceId ?? 'binding'} (${outcome})`,
     );
-    this.name = 'ProjectWorkspaceScopeUnavailableError';
+    this.name = 'ProjectWorkspaceScopeRefusedError';
   }
+}
+
+/**
+ * Read the signed-in member's membership directory, retrying a FAILED read with
+ * bounded backoff before any conclusion is drawn from it.
+ *
+ * The invariant: **this reports `ok: true` only when the authority actually
+ * answered, and `ok: false` only after every bounded attempt failed.** That is
+ * what lets the caller treat an absent membership in an `ok` directory as a
+ * proven refusal instead of confusing it with an authority it never reached. One
+ * slow or dropped response must not be able to move a charge.
+ *
+ * `fetchWorkspaceDirectory` may signal failure either way — the real
+ * `fetchVelaWorkspaceDirectory` swallows missing sessions, non-2xx responses and
+ * network errors into `{ ok: false }`, while an injected or future fetcher may
+ * reject — so both a falsy `ok` and a thrown error count as one failed attempt.
+ */
+async function readWorkspaceDirectoryWithBoundedRetry(deps: {
+  fetchWorkspaceDirectory: () => Promise<WorkspaceDirectoryFetchResult>;
+  sleep?: (ms: number) => Promise<void>;
+  attempts?: number;
+}): Promise<{ result: WorkspaceDirectoryFetchResult; attempts: number }> {
+  const maxAttempts = Math.max(1, deps.attempts ?? DIRECTORY_READ_ATTEMPTS);
+  const sleep =
+    deps.sleep ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  let last: WorkspaceDirectoryFetchResult = { ok: false, items: [] };
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      last = await deps.fetchWorkspaceDirectory();
+    } catch {
+      last = { ok: false, items: [] };
+    }
+    if (last.ok) return { result: last, attempts: attempt };
+    if (attempt < maxAttempts) {
+      const backoff =
+        DIRECTORY_RETRY_BACKOFF_MS[attempt - 1] ??
+        DIRECTORY_RETRY_BACKOFF_MS[DIRECTORY_RETRY_BACKOFF_MS.length - 1] ??
+        0;
+      await sleep(backoff);
+    }
+  }
+  return { result: last, attempts: maxAttempts };
 }
 
 /**
@@ -25,17 +144,42 @@ export class ProjectWorkspaceScopeUnavailableError extends Error {
  *
  * `workspace_projects.visibility` is deliberately not used as a billing-kind
  * discriminator: a private draft can belong to a team workspace and must still
- * spend that team's wallet. If the persisted binding cannot be proven against
- * the current directory, fail closed rather than silently charging the account
- * wallet.
+ * spend that team's wallet.
  *
- * Two regimes, and the split between them is the point:
+ * **Proof refusal and proof failure are different events, and only refusal fails
+ * closed.** The two used to share one error and one outcome, so a momentary
+ * authority outage was indistinguishable from a member genuinely having no
+ * membership — and killed the run either way:
+ *
+ * - **The authority answered and refused** (`ok` directory, no matching active
+ *   membership; or no binding at all). Fail closed with
+ *   {@link ProjectWorkspaceScopeRefusedError}. Charging a team's run to the
+ *   account wallet, or an account's run to a team, is worse than refusing.
+ *
+ * - **The authority could not be asked** (every bounded attempt failed). The run
+ *   PROCEEDS with no workspace, i.e. on the caller's own account wallet.
+ *
+ *   This branch is a deliberate product decision, not an oversight: failing the
+ *   run outright arrived as a production P0, and a hard failure is worse than a
+ *   mis-attributed personal charge. Note the asymmetry that makes it safe — the
+ *   fallback can only ever bill the caller for the caller's own run. The reverse
+ *   direction, charging a personal run to a team wallet, is a genuine breach and
+ *   stays impossible, because no fallback here picks some other workspace. This
+ *   is why the retry is bounded rather than absent: proceeding is the considered
+ *   answer only after the authority has really failed, not after one slow
+ *   response. Please do not "fix" this back to failing closed.
+ *
+ * Every branch reports a {@link ProjectWorkspaceScopeOutcome} through
+ * `onWorkspaceScopeOutcome`, including the successful ones. That is not
+ * bookkeeping for its own sake: this decision was previously invisible in the
+ * daemon log, the run record, and telemetry alike, so a complete diagnostics
+ * bundle could not say why a run had been refused.
+ *
+ * Two regimes, and the split between them is also the point:
  *
  * - **Workspace authority is live** (`isWorkspaceTeamConfigured()` true, i.e.
  *   `OD_WORKSPACE_CONTEXT_SOURCE === 'vela'` in production). Every AMR project
- *   must prove its binding. An unbound or unprovable project fails closed —
- *   charging a team's run to the account wallet, or vice versa, is worse than
- *   refusing it.
+ *   must prove its binding, subject to the refusal/failure split above.
  *
  * - **Workspace authority is not configured.** There is no directory to prove a
  *   binding against and no team wallet to mischarge, so the account wallet is
@@ -64,11 +208,21 @@ export async function openDesignAmrTraceEnvForProject(
     fetchWorkspaceDirectory: () => Promise<WorkspaceDirectoryFetchResult>;
     /**
      * Whether this daemon actually carries workspace authority — see the two
-     * invariants on {@link openDesignAmrTraceEnvForProject}. Defaults to `true`
-     * so a call site that forgets to pass it fails closed rather than silently
-     * billing a team run to the account wallet.
+     * regimes on {@link openDesignAmrTraceEnvForProject}. Defaults to `true` so
+     * a call site that forgets to pass it still holds team runs to the binding
+     * requirement rather than silently skipping the proof.
      */
     isWorkspaceTeamConfigured?: () => boolean;
+    /**
+     * Receives the branch that decided, for the daemon log, the run record and
+     * telemetry. Only ever called for AMR: the non-AMR short-circuit returns
+     * before any of this, so this path stays silent for every other runtime.
+     */
+    onWorkspaceScopeOutcome?: (outcome: ProjectWorkspaceScopeOutcome) => void;
+    /** Injectable for tests so bounded backoff costs no wall-clock time. */
+    sleep?: (ms: number) => Promise<void>;
+    /** Injectable for tests; total directory read attempts. */
+    directoryReadAttempts?: number;
   },
 ): Promise<NodeJS.ProcessEnv> {
   const traceInput = {
@@ -81,28 +235,89 @@ export async function openDesignAmrTraceEnvForProject(
   };
   // Every runtime passes through the server launch env builder, but workspace
   // billing is an AMR-only concern. Non-AMR launches must neither depend on nor
-  // pay latency for the Vela membership directory.
+  // pay latency for the Vela membership directory — nor emit its observability.
   if (input.agentId !== 'amr') return openDesignAmrTraceEnv(traceInput);
 
   const projectId = input.projectId?.trim();
   let workspaceId: string | null = null;
   if (projectId && (deps.isWorkspaceTeamConfigured?.() ?? true)) {
+    const report = (
+      outcome: Omit<ProjectWorkspaceScopeOutcome, 'projectId'>,
+    ): void => {
+      deps.onWorkspaceScopeOutcome?.({ projectId, ...outcome });
+    };
     const binding = getWorkspaceProjectByProjectId(db, projectId);
+    // No binding is a LOCAL, proven fact: SQLite is authoritative for it and no
+    // directory read could change the answer. A refusal, not a failure.
     if (!binding) {
-      throw new ProjectWorkspaceScopeUnavailableError(projectId, null);
+      report({
+        kind: 'refused_no_binding',
+        workspaceId: null,
+        directoryOk: null,
+        directoryItemCount: null,
+        directoryReadAttempts: 0,
+      });
+      throw new ProjectWorkspaceScopeRefusedError(
+        projectId,
+        null,
+        'refused_no_binding',
+      );
     }
-    const directory = await deps.fetchWorkspaceDirectory().catch(
-      (): WorkspaceDirectoryFetchResult => ({ ok: false, items: [] }),
-    );
+    const persistedWorkspaceId =
+      typeof binding.workspaceId === 'string' && binding.workspaceId.trim()
+        ? binding.workspaceId.trim()
+        : null;
+    const { result: directory, attempts } =
+      await readWorkspaceDirectoryWithBoundedRetry({
+        fetchWorkspaceDirectory: deps.fetchWorkspaceDirectory,
+        ...(deps.sleep ? { sleep: deps.sleep } : {}),
+        ...(deps.directoryReadAttempts !== undefined
+          ? { attempts: deps.directoryReadAttempts }
+          : {}),
+      });
+    const evidence = {
+      workspaceId: persistedWorkspaceId,
+      directoryOk: directory.ok,
+      directoryItemCount: directory.items.length,
+      directoryReadAttempts: attempts,
+    };
+    if (!directory.ok) {
+      // Could not ask. Proceed on the caller's own account wallet — see the
+      // product decision in the docblock — but make it countable.
+      report({ kind: 'proceeded_directory_unreadable', ...evidence });
+      return openDesignAmrTraceEnv(traceInput);
+    }
+    // An answer listing NOTHING is not an answer about membership: vela cannot
+    // legitimately return an empty list to an authenticated caller. Refuse, but
+    // under its own name so nobody reads it as "you were removed from the team".
+    if (directory.items.length === 0) {
+      report({ kind: 'refused_directory_empty', ...evidence });
+      throw new ProjectWorkspaceScopeRefusedError(
+        projectId,
+        persistedWorkspaceId,
+        'refused_directory_empty',
+      );
+    }
+    // The directory answered, so from here an absent membership is a proven
+    // refusal rather than an authority we never reached.
     const scope = resolveProjectWorkspaceScope({
       projectId,
       binding,
       directory,
     });
     if (scope.kind === 'unbound' || scope.kind === 'unavailable') {
-      throw new ProjectWorkspaceScopeUnavailableError(projectId, scope.workspaceId);
+      report({ kind: 'refused_no_active_membership', ...evidence });
+      throw new ProjectWorkspaceScopeRefusedError(
+        projectId,
+        scope.workspaceId,
+        'refused_no_active_membership',
+      );
     }
     if (scope.kind === 'team') workspaceId = scope.workspaceId;
+    report({
+      kind: scope.kind === 'team' ? 'resolved_team' : 'resolved_personal',
+      ...evidence,
+    });
   }
   return openDesignAmrTraceEnv({
     ...traceInput,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -9129,6 +9129,11 @@ export async function startServer({
     let acpSession = null;
     let writePromptToChildStdin = false;
     let spawnedAgentEnv = null;
+    // Which branch of the AMR workspace-binding proof decided, so the failure
+    // path can attach a machine-readable cause. Before this, a diagnostics
+    // export could not say why a run was refused — the run record carried only
+    // the generic AGENT_EXECUTION_FAILED plus a prose sentence.
+    let amrWorkspaceScopeOutcome = null;
     let agentStdoutTail = '';
     let agentStderrTail = '';
     const agentStderrFilter = createAgentStderrVisibilityFilter(agentId);
@@ -9179,6 +9184,43 @@ export async function startServer({
           // behavior instead of refusing every unbound project.
           isWorkspaceTeamConfigured: () =>
             process.env.OD_WORKSPACE_CONTEXT_SOURCE?.trim() === 'vela',
+          // Which branch decided, to all three sinks a report can reach us
+          // through: the daemon log (what a diagnostics zip carries), the run
+          // record (what a user can hand over after logs have rotated), and
+          // telemetry (so "how often are we proceeding on an unreachable
+          // directory" is countable rather than anecdotal). Ids, counts and the
+          // branch name only — never member rows or credentials.
+          onWorkspaceScopeOutcome: (outcome) => {
+            amrWorkspaceScopeOutcome = outcome;
+            console.log(
+              `[od] amr workspace scope ${outcome.kind}`
+                + ` project=${outcome.projectId}`
+                + ` workspace=${outcome.workspaceId ?? 'none'}`
+                + ` directoryOk=${outcome.directoryOk ?? 'not-read'}`
+                + ` items=${outcome.directoryItemCount ?? 'not-read'}`
+                + ` attempts=${outcome.directoryReadAttempts}`
+                + ` run=${run.id}`,
+            );
+            const context = run.analyticsContext ?? null;
+            if (!context || !design?.analytics?.capture) return;
+            design.analytics.capture({
+              eventName: 'amr_workspace_scope_resolved',
+              context,
+              appVersion: appVersionForCapture(),
+              properties: {
+                page_name: 'chat_panel',
+                area: 'chat_panel',
+                project_id: outcome.projectId,
+                conversation_id: run.conversationId ?? null,
+                run_id: run.id,
+                workspace_scope_outcome: outcome.kind,
+                workspace_scope_directory_ok: outcome.directoryOk,
+                workspace_scope_directory_item_count:
+                  outcome.directoryItemCount,
+                workspace_scope_read_attempts: outcome.directoryReadAttempts,
+              },
+            });
+          },
         }),
         // OpenCode external-MCP injection (issue #2142). Layered AFTER
         // spawnEnvForAgent / odMediaEnv / configuredAgentEnv so the
@@ -9297,7 +9339,32 @@ export async function startServer({
       cleanupPromptFile();
       revokeToolToken('child_exit');
       unregisterChatAgentEventSink();
-      send('error', createSseErrorPayload('AGENT_EXECUTION_FAILED', `spawn failed: ${err.message}`));
+      // Keep the wire error code stable, but carry the structured cause in
+      // `details` so `state.json` / `events.jsonl` identify the branch without
+      // anyone parsing the prose. `err.code` is set only by
+      // ProjectWorkspaceScopeRefusedError; everything else reports as before.
+      const spawnErrorInit =
+        err?.code === 'PROJECT_WORKSPACE_SCOPE_REFUSED'
+          ? {
+            details: {
+              cause: err.code,
+              workspaceScopeOutcome:
+                err.outcome ?? amrWorkspaceScopeOutcome?.kind ?? null,
+              projectId: err.projectId ?? null,
+              workspaceId: err.workspaceId ?? null,
+              directoryOk: amrWorkspaceScopeOutcome?.directoryOk ?? null,
+              directoryItemCount:
+                amrWorkspaceScopeOutcome?.directoryItemCount ?? null,
+              directoryReadAttempts:
+                amrWorkspaceScopeOutcome?.directoryReadAttempts ?? null,
+            },
+          }
+          : {};
+      send('error', createSseErrorPayload(
+        'AGENT_EXECUTION_FAILED',
+        `spawn failed: ${err.message}`,
+        spawnErrorInit,
+      ));
       design.runs.finish(run, 'failed', 1, null);
       return;
     }

--- a/apps/daemon/tests/runtimes/project-amr-trace-env.test.ts
+++ b/apps/daemon/tests/runtimes/project-amr-trace-env.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../../src/db.js';
 import {
   openDesignAmrTraceEnvForProject,
-  ProjectWorkspaceScopeUnavailableError,
+  ProjectWorkspaceScopeRefusedError,
 } from '../../src/runtimes/project-amr-trace-env.js';
 
 let tempDir: string | null = null;
@@ -64,7 +64,7 @@ describe('openDesignAmrTraceEnvForProject', () => {
     }, {
       fetchWorkspaceDirectory,
     })).rejects.toEqual(expect.objectContaining({
-      name: ProjectWorkspaceScopeUnavailableError.name,
+      name: ProjectWorkspaceScopeRefusedError.name,
       projectId: 'project-unbound',
       workspaceId: null,
     }));
@@ -196,7 +196,12 @@ describe('openDesignAmrTraceEnvForProject', () => {
     expect(env).not.toHaveProperty('OPEN_DESIGN_WORKSPACE_ID');
   });
 
-  it('fails closed when the persisted workspace binding cannot be proven', async () => {
+  // This used to drive the refusal with `{ ok: false }` — an UNREADABLE
+  // directory. That now takes the authorised account-wallet fallback instead
+  // (see `project-amr-workspace-proof.test.ts`), because an authority we could
+  // not reach proved nothing. The refusal this test guards is the one that
+  // survives: the directory ANSWERED, and it does not list the binding.
+  it('fails closed when an answered directory does not prove the persisted binding', async () => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-amr-unavailable-scope-'));
     const db = openDatabase(tempDir);
     const now = Date.now();
@@ -219,9 +224,20 @@ describe('openDesignAmrTraceEnvForProject', () => {
       runAttempt: 0,
       projectId: 'project-unavailable',
     }, {
-      fetchWorkspaceDirectory: async () => ({ ok: false, items: [] }),
+      fetchWorkspaceDirectory: async () => ({
+        ok: true,
+        items: [{
+          workspaceId: 'workspace-other',
+          workspaceName: 'Some other workspace',
+          workspaceType: 'personal',
+          workspaceMemberId: 'member-other',
+          role: 'owner',
+          memberStatus: 'active',
+          lifecycleState: 'active',
+        }],
+      }),
     })).rejects.toEqual(expect.objectContaining({
-      name: ProjectWorkspaceScopeUnavailableError.name,
+      name: ProjectWorkspaceScopeRefusedError.name,
       projectId: 'project-unavailable',
       workspaceId: 'workspace-missing',
     }));
@@ -285,7 +301,7 @@ describe('openDesignAmrTraceEnvForProject', () => {
       fetchWorkspaceDirectory: async () => ({ ok: true, items: [] }),
       isWorkspaceTeamConfigured: () => true,
     })).rejects.toEqual(expect.objectContaining({
-      name: ProjectWorkspaceScopeUnavailableError.name,
+      name: ProjectWorkspaceScopeRefusedError.name,
       projectId: 'project-unbound-live',
       workspaceId: null,
     }));

--- a/apps/daemon/tests/runtimes/project-amr-workspace-proof.test.ts
+++ b/apps/daemon/tests/runtimes/project-amr-workspace-proof.test.ts
@@ -1,0 +1,495 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  closeDatabase,
+  ensureWorkspaceProject,
+  insertProject,
+  openDatabase,
+} from '../../src/db.js';
+import {
+  openDesignAmrTraceEnvForProject,
+  type ProjectWorkspaceScopeOutcome,
+} from '../../src/runtimes/project-amr-trace-env.js';
+
+// Proof REFUSAL and proof FAILURE are different events. These specs pin the
+// split: only a directory that actually answered may refuse a run, an authority
+// that could not be reached must be retried and then reported as its own
+// outcome, and every branch must stay separately identifiable.
+//
+// Asserting on the literal identity strings (rather than importing the error
+// class) is deliberate — it is what makes collapsing the identities back
+// together turn these specs red, which is exactly the regression that cost three
+// wrong root causes in one day.
+const REFUSED = 'ProjectWorkspaceScopeRefusedError';
+const REFUSED_CODE = 'PROJECT_WORKSPACE_SCOPE_REFUSED';
+
+let tempDir: string | null = null;
+
+afterEach(() => {
+  closeDatabase();
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  tempDir = null;
+});
+
+function seedBoundProject(prefix: string, ids: {
+  projectId: string;
+  workspaceId: string;
+  memberId: string;
+}) {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  const db = openDatabase(tempDir);
+  const now = Date.now();
+  insertProject(db, {
+    id: ids.projectId,
+    name: ids.projectId,
+    createdAt: now,
+    updatedAt: now,
+  });
+  ensureWorkspaceProject(db, {
+    projectId: ids.projectId,
+    workspaceId: ids.workspaceId,
+    visibility: 'personal',
+    createdByWorkspaceMemberId: ids.memberId,
+  });
+  return db;
+}
+
+function activeItem(overrides: {
+  workspaceId: string;
+  workspaceType: 'personal' | 'team';
+  workspaceMemberId: string;
+}) {
+  return {
+    workspaceName: `${overrides.workspaceId} name`,
+    role: 'owner' as const,
+    memberStatus: 'active' as const,
+    lifecycleState: 'active' as const,
+    ...overrides,
+  };
+}
+
+describe('AMR workspace-binding proof: refusal vs unreachable authority', () => {
+  it('refuses the run when the directory ANSWERED and the membership is genuinely absent', async () => {
+    // The line the product ruling does not move: someone else's wallet.
+    const db = seedBoundProject('od-amr-proof-refused-', {
+      projectId: 'project-foreign',
+      workspaceId: 'workspace-foreign',
+      memberId: 'member-foreign',
+    });
+    const fetchWorkspaceDirectory = vi.fn(async () => ({
+      ok: true as const,
+      // Answered, and this member's memberships simply do not include it.
+      items: [activeItem({
+        workspaceId: 'workspace-mine',
+        workspaceType: 'personal',
+        workspaceMemberId: 'member-mine',
+      })],
+    }));
+    const outcomes: ProjectWorkspaceScopeOutcome[] = [];
+
+    await expect(openDesignAmrTraceEnvForProject(db, {
+      agentId: 'amr',
+      runId: 'run-foreign',
+      runAttempt: 0,
+      projectId: 'project-foreign',
+    }, {
+      fetchWorkspaceDirectory,
+      isWorkspaceTeamConfigured: () => true,
+      onWorkspaceScopeOutcome: (outcome) => outcomes.push(outcome),
+      sleep: async () => {},
+    })).rejects.toEqual(expect.objectContaining({
+      name: REFUSED,
+      code: REFUSED_CODE,
+      outcome: 'refused_no_active_membership',
+      projectId: 'project-foreign',
+      workspaceId: 'workspace-foreign',
+    }));
+    // An answered directory is conclusive, so there is nothing to retry.
+    expect(fetchWorkspaceDirectory).toHaveBeenCalledTimes(1);
+    expect(outcomes).toEqual([expect.objectContaining({
+      kind: 'refused_no_active_membership',
+      projectId: 'project-foreign',
+      workspaceId: 'workspace-foreign',
+      directoryOk: true,
+      directoryItemCount: 1,
+      directoryReadAttempts: 1,
+    })]);
+  });
+
+  it('retries a failed directory read, then proceeds on the account wallet and reports it', async () => {
+    const db = seedBoundProject('od-amr-proof-unreachable-', {
+      projectId: 'project-blip',
+      workspaceId: 'workspace-blip',
+      memberId: 'member-blip',
+    });
+    // Production shape: fetchVelaWorkspaceDirectory swallows missing sessions,
+    // non-2xx responses and network errors into { ok: false } rather than
+    // rejecting.
+    const fetchWorkspaceDirectory = vi.fn(async () => ({
+      ok: false as const,
+      items: [],
+    }));
+    const outcomes: ProjectWorkspaceScopeOutcome[] = [];
+    const sleep = vi.fn(async () => {});
+
+    const env = await openDesignAmrTraceEnvForProject(db, {
+      agentId: 'amr',
+      runId: 'run-blip',
+      runAttempt: 0,
+      projectId: 'project-blip',
+    }, {
+      fetchWorkspaceDirectory,
+      isWorkspaceTeamConfigured: () => true,
+      onWorkspaceScopeOutcome: (outcome) => outcomes.push(outcome),
+      sleep,
+    });
+
+    // Proceeds — a hard failure here was a production P0.
+    expect(env.OPEN_DESIGN_RUN_ID).toBe('run-blip');
+    // No workspace => the caller pays for the caller's own run. The reverse,
+    // billing a personal run to a team, must stay impossible.
+    expect(env).not.toHaveProperty('OPEN_DESIGN_WORKSPACE_ID');
+    // Bounded retry, not a single shot: one slow response must not move a charge.
+    expect(fetchWorkspaceDirectory.mock.calls.length).toBeGreaterThan(1);
+    expect(sleep).toHaveBeenCalled();
+    // Distinguishable from a refusal, and countable.
+    expect(outcomes).toEqual([expect.objectContaining({
+      kind: 'proceeded_directory_unreadable',
+      projectId: 'project-blip',
+      workspaceId: 'workspace-blip',
+      directoryOk: false,
+    })]);
+    expect(outcomes[0]?.directoryReadAttempts).toBeGreaterThan(1);
+  });
+
+  it('treats a REJECTED directory read as a failed attempt, not as a refusal', async () => {
+    const db = seedBoundProject('od-amr-proof-throw-', {
+      projectId: 'project-throw',
+      workspaceId: 'workspace-throw',
+      memberId: 'member-throw',
+    });
+    const fetchWorkspaceDirectory = vi.fn(async () => {
+      throw new Error('ETIMEDOUT');
+    });
+    const outcomes: ProjectWorkspaceScopeOutcome[] = [];
+
+    const env = await openDesignAmrTraceEnvForProject(db, {
+      agentId: 'amr',
+      runId: 'run-throw',
+      runAttempt: 0,
+      projectId: 'project-throw',
+    }, {
+      fetchWorkspaceDirectory,
+      isWorkspaceTeamConfigured: () => true,
+      onWorkspaceScopeOutcome: (outcome) => outcomes.push(outcome),
+      sleep: async () => {},
+    });
+
+    expect(env).not.toHaveProperty('OPEN_DESIGN_WORKSPACE_ID');
+    expect(fetchWorkspaceDirectory.mock.calls.length).toBeGreaterThan(1);
+    expect(outcomes[0]?.kind).toBe('proceeded_directory_unreadable');
+  });
+
+  it('recovers on retry: a first failed read then a good one resolves normally, no fallback', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-amr-proof-recover-'));
+    const db = openDatabase(tempDir);
+    const now = Date.now();
+    insertProject(db, {
+      id: 'project-recover',
+      name: 'Recover',
+      createdAt: now,
+      updatedAt: now,
+    });
+    ensureWorkspaceProject(db, {
+      projectId: 'project-recover',
+      workspaceId: 'workspace-recover',
+      visibility: 'personal',
+      createdByWorkspaceMemberId: 'member-recover',
+    });
+    const good = {
+      ok: true as const,
+      items: [activeItem({
+        workspaceId: 'workspace-recover',
+        workspaceType: 'team',
+        workspaceMemberId: 'member-recover',
+      })],
+    };
+    let call = 0;
+    const fetchWorkspaceDirectory = vi.fn(async () => {
+      call += 1;
+      if (call === 1) return { ok: false as const, items: [] };
+      return good;
+    });
+    const outcomes: ProjectWorkspaceScopeOutcome[] = [];
+
+    const env = await openDesignAmrTraceEnvForProject(db, {
+      agentId: 'amr',
+      runId: 'run-recover',
+      runAttempt: 0,
+      projectId: 'project-recover',
+    }, {
+      fetchWorkspaceDirectory,
+      isWorkspaceTeamConfigured: () => true,
+      onWorkspaceScopeOutcome: (outcome) => outcomes.push(outcome),
+      sleep: async () => {},
+    });
+
+    // A transient blip must not cost the team binding — a private draft in a
+    // team workspace still spends the team wallet.
+    expect(env.OPEN_DESIGN_WORKSPACE_ID).toBe('workspace-recover');
+    expect(fetchWorkspaceDirectory).toHaveBeenCalledTimes(2);
+    expect(outcomes).toEqual([expect.objectContaining({
+      kind: 'resolved_team',
+      directoryOk: true,
+      directoryReadAttempts: 2,
+    })]);
+  });
+
+  it('refuses an unbound project without reading the directory at all', async () => {
+    // SQLite alone proves this one; no directory read could change the answer,
+    // so it is a refusal and must carry the refusal identity.
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-amr-proof-unbound-'));
+    const db = openDatabase(tempDir);
+    const now = Date.now();
+    insertProject(db, {
+      id: 'project-no-binding',
+      name: 'No binding',
+      createdAt: now,
+      updatedAt: now,
+    });
+    const fetchWorkspaceDirectory = vi.fn(async () => ({
+      ok: true as const,
+      items: [],
+    }));
+    const outcomes: ProjectWorkspaceScopeOutcome[] = [];
+
+    await expect(openDesignAmrTraceEnvForProject(db, {
+      agentId: 'amr',
+      runId: 'run-no-binding',
+      runAttempt: 0,
+      projectId: 'project-no-binding',
+    }, {
+      fetchWorkspaceDirectory,
+      isWorkspaceTeamConfigured: () => true,
+      onWorkspaceScopeOutcome: (outcome) => outcomes.push(outcome),
+    })).rejects.toEqual(expect.objectContaining({
+      name: REFUSED,
+      code: REFUSED_CODE,
+      outcome: 'refused_no_binding',
+      workspaceId: null,
+    }));
+    expect(fetchWorkspaceDirectory).not.toHaveBeenCalled();
+    expect(outcomes).toEqual([expect.objectContaining({
+      kind: 'refused_no_binding',
+      directoryOk: null,
+      directoryItemCount: null,
+      directoryReadAttempts: 0,
+    })]);
+  });
+
+  it('names an EMPTY answered directory separately from a proven non-membership', async () => {
+    // Vela runs ensurePersonalWorkspace before listing and applies no type
+    // filter, so an authenticated caller always has at least their personal
+    // workspace. An empty list is therefore a malformed answer, not "you were
+    // removed" — and a support reader must not confuse the two.
+    const db = seedBoundProject('od-amr-proof-empty-', {
+      projectId: 'project-empty-dir',
+      workspaceId: 'workspace-empty-dir',
+      memberId: 'member-empty-dir',
+    });
+    const outcomes: ProjectWorkspaceScopeOutcome[] = [];
+
+    await expect(openDesignAmrTraceEnvForProject(db, {
+      agentId: 'amr',
+      runId: 'run-empty-dir',
+      runAttempt: 0,
+      projectId: 'project-empty-dir',
+    }, {
+      fetchWorkspaceDirectory: async () => ({ ok: true, items: [] }),
+      isWorkspaceTeamConfigured: () => true,
+      onWorkspaceScopeOutcome: (outcome) => outcomes.push(outcome),
+      sleep: async () => {},
+    })).rejects.toEqual(expect.objectContaining({
+      name: REFUSED,
+      outcome: 'refused_directory_empty',
+    }));
+    expect(outcomes[0]?.kind).toBe('refused_directory_empty');
+  });
+
+  it('reports a proven PERSONAL binding as its own outcome on the account wallet', async () => {
+    // Hypothesis check turned regression guard: the `personal` branch must be
+    // reachable in production. Vela's directory includes personal workspaces
+    // (no type filter) and reports them memberStatus/lifecycleState 'active',
+    // which is exactly what resolveProjectWorkspaceScope's find requires.
+    const db = seedBoundProject('od-amr-proof-personal-', {
+      projectId: 'project-personal-ok',
+      workspaceId: 'workspace-personal-ok',
+      memberId: 'member-personal-ok',
+    });
+    const outcomes: ProjectWorkspaceScopeOutcome[] = [];
+
+    const env = await openDesignAmrTraceEnvForProject(db, {
+      agentId: 'amr',
+      runId: 'run-personal-ok',
+      runAttempt: 0,
+      projectId: 'project-personal-ok',
+    }, {
+      fetchWorkspaceDirectory: async () => ({
+        ok: true,
+        items: [activeItem({
+          workspaceId: 'workspace-personal-ok',
+          workspaceType: 'personal',
+          workspaceMemberId: 'member-personal-ok',
+        })],
+      }),
+      isWorkspaceTeamConfigured: () => true,
+      onWorkspaceScopeOutcome: (outcome) => outcomes.push(outcome),
+    });
+
+    expect(env).not.toHaveProperty('OPEN_DESIGN_WORKSPACE_ID');
+    expect(outcomes[0]?.kind).toBe('resolved_personal');
+  });
+
+  it('stays silent for a non-AMR runtime', async () => {
+    // This path is AMR-only by design; it must not log or count for anyone else.
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-amr-proof-non-amr-'));
+    const db = openDatabase(tempDir);
+    const outcomes: ProjectWorkspaceScopeOutcome[] = [];
+
+    await openDesignAmrTraceEnvForProject(db, {
+      agentId: 'claude',
+      runId: 'run-claude',
+      runAttempt: 0,
+      projectId: 'project-any',
+    }, {
+      fetchWorkspaceDirectory: async () => ({ ok: true, items: [] }),
+      isWorkspaceTeamConfigured: () => true,
+      onWorkspaceScopeOutcome: (outcome) => outcomes.push(outcome),
+    });
+
+    expect(outcomes).toEqual([]);
+  });
+
+  it('keeps every branch separately identifiable', async () => {
+    // The regression that cost today: five causes collapsing into one
+    // indistinguishable error. If two branches ever report the same kind again,
+    // this fails.
+    const seen = new Set<string>();
+    const record = (outcome: ProjectWorkspaceScopeOutcome) => {
+      seen.add(outcome.kind);
+    };
+
+    // refused_no_binding
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'od-amr-proof-matrix-a-'));
+    let db = openDatabase(tempDir);
+    const now = Date.now();
+    insertProject(db, { id: 'p1', name: 'p1', createdAt: now, updatedAt: now });
+    await openDesignAmrTraceEnvForProject(db, {
+      agentId: 'amr', runId: 'r1', runAttempt: 0, projectId: 'p1',
+    }, {
+      fetchWorkspaceDirectory: async () => ({ ok: true, items: [] }),
+      isWorkspaceTeamConfigured: () => true,
+      onWorkspaceScopeOutcome: record,
+    }).catch(() => undefined);
+    closeDatabase();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+
+    // refused_directory_empty
+    db = seedBoundProject('od-amr-proof-matrix-b-', {
+      projectId: 'p2', workspaceId: 'w2', memberId: 'm2',
+    });
+    await openDesignAmrTraceEnvForProject(db, {
+      agentId: 'amr', runId: 'r2', runAttempt: 0, projectId: 'p2',
+    }, {
+      fetchWorkspaceDirectory: async () => ({ ok: true, items: [] }),
+      isWorkspaceTeamConfigured: () => true,
+      onWorkspaceScopeOutcome: record,
+      sleep: async () => {},
+    }).catch(() => undefined);
+    closeDatabase();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+
+    // refused_no_active_membership
+    db = seedBoundProject('od-amr-proof-matrix-c-', {
+      projectId: 'p3', workspaceId: 'w3', memberId: 'm3',
+    });
+    await openDesignAmrTraceEnvForProject(db, {
+      agentId: 'amr', runId: 'r3', runAttempt: 0, projectId: 'p3',
+    }, {
+      fetchWorkspaceDirectory: async () => ({
+        ok: true,
+        items: [activeItem({
+          workspaceId: 'other', workspaceType: 'personal', workspaceMemberId: 'mo',
+        })],
+      }),
+      isWorkspaceTeamConfigured: () => true,
+      onWorkspaceScopeOutcome: record,
+      sleep: async () => {},
+    }).catch(() => undefined);
+    closeDatabase();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+
+    // proceeded_directory_unreadable
+    db = seedBoundProject('od-amr-proof-matrix-d-', {
+      projectId: 'p4', workspaceId: 'w4', memberId: 'm4',
+    });
+    await openDesignAmrTraceEnvForProject(db, {
+      agentId: 'amr', runId: 'r4', runAttempt: 0, projectId: 'p4',
+    }, {
+      fetchWorkspaceDirectory: async () => ({ ok: false, items: [] }),
+      isWorkspaceTeamConfigured: () => true,
+      onWorkspaceScopeOutcome: record,
+      sleep: async () => {},
+    });
+    closeDatabase();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+
+    // resolved_team
+    db = seedBoundProject('od-amr-proof-matrix-e-', {
+      projectId: 'p5', workspaceId: 'w5', memberId: 'm5',
+    });
+    await openDesignAmrTraceEnvForProject(db, {
+      agentId: 'amr', runId: 'r5', runAttempt: 0, projectId: 'p5',
+    }, {
+      fetchWorkspaceDirectory: async () => ({
+        ok: true,
+        items: [activeItem({
+          workspaceId: 'w5', workspaceType: 'team', workspaceMemberId: 'm5',
+        })],
+      }),
+      isWorkspaceTeamConfigured: () => true,
+      onWorkspaceScopeOutcome: record,
+    });
+    closeDatabase();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+
+    // resolved_personal
+    db = seedBoundProject('od-amr-proof-matrix-f-', {
+      projectId: 'p6', workspaceId: 'w6', memberId: 'm6',
+    });
+    await openDesignAmrTraceEnvForProject(db, {
+      agentId: 'amr', runId: 'r6', runAttempt: 0, projectId: 'p6',
+    }, {
+      fetchWorkspaceDirectory: async () => ({
+        ok: true,
+        items: [activeItem({
+          workspaceId: 'w6', workspaceType: 'personal', workspaceMemberId: 'm6',
+        })],
+      }),
+      isWorkspaceTeamConfigured: () => true,
+      onWorkspaceScopeOutcome: record,
+    });
+
+    expect([...seen].sort()).toEqual([
+      'proceeded_directory_unreadable',
+      'refused_directory_empty',
+      'refused_no_active_membership',
+      'refused_no_binding',
+      'resolved_personal',
+      'resolved_team',
+    ]);
+  });
+});


### PR DESCRIPTION
## Why

An AMR run in the packaged test-channel beta (`0.16.2-beta.146`, Windows, namespace `release-beta-win`) died in preflight with a raw internal sentence:

```
spawn failed: Cannot authorize project 270f70da-fd2a-4dde-b927-77cfa89f1222:
its persisted workspace d87ys1jllz9e4lux9ldgmu8f is unavailable for the signed-in member
```

It reached the user as `AGENT_EXECUTION_FAILED` and was escalated as a P0. Two causally unrelated situations were collapsed into that one error and one outcome:

1. the membership directory answered, and genuinely lists no active membership for the bound workspace — failing closed is right, spending another team's wallet is worse;
2. the directory **could not be read at all** — `.catch` swallowed the failure into `{ ok: false, items: [] }`, `resolveProjectWorkspaceScope` reported `unavailable`, and the run died. A transient vela blip made the user's own project unrunnable.

The pain: case 2 is a hard, unretried failure (`retryable=false`, `retry_final_result="not_attempted"`) for something that was nobody's fault and fixes itself seconds later. And because both cases produced byte-identical output, **the failure was unattributable** — three separate root causes were proposed and discarded over one day, each argued from source-reading, because no artifact could say which branch had decided.

## Root cause of this report: case 2, established by elimination

The signed-in account is confirmed as `xab7qkjmyiq0j0aal8vzxsgg` (from the run's own `run_finished` telemetry). Read-only queries against the vela **test** database (`refly-test-eks/nexu`, via an already-running `vela-api` pod; SELECT only, nothing mutated) show:

- Workspace `d87ys1jllz9e4lux9ldgmu8f` **exists**: `type=personal`, `lifecycle_state=active`, `deleted_at=null`, name `"Personal workspace"`, created `2026-07-28T06:41:38Z`.
- Its member list is exactly one row: `app_user_id=xab7qkjmyiq0j0aal8vzxsgg`, `member_id=rj14bnp92qoqp2gfxbwpb0q5`, `role=owner`, `status=active`, `removed_at=null`.
- The reporter's own `workspace_projects` row carries `created_by_workspace_member_id: rj14bnp92qoqp2gfxbwpb0q5` — **the same member id**. The binding was created by this identity's own active owner membership in this very workspace.

So the member *is* an active member, which rules out the `!item` branch:

- **Not "the directory omits personal workspaces."** `listWorkspaceDirectory` (`services/api/src/workspaces/core.ts:1137`) calls `ensurePersonalWorkspace` first, and its SQL (`workspaces/postgres.ts:259`) filters only on `workspace_members.status='active'` and `workspaces.lifecycle_state <> 'deleted'` — **no type filter**; personal workspaces are ordered last but included. The route also returns the personal workspace on the `teamWorkspaceEnabled=false` branch. It requires authentication only, not a selected principal, so `missing_principal` does not apply.
- **Not a `memberStatus` / `lifecycleState` mismatch.** `toDirectoryItem` passes `member.status` and `workspace.lifecycleState` through verbatim, and the row is `active` / `active` — exactly what `resolveProjectWorkspaceScope`'s `find` requires. The `personal` branch **is** reachable in production; there is now a regression test pinning it.
- **Not a stale selection from a previous identity, and not an id mismatch.** `created_by_workspace_member_id` matches the current account's member id in the bound workspace.
- **Not `!binding`.** The row exists.

The timing then makes it decisive. `open_design_run_billing_scopes` holds rows for that exact `(workspace d87ys…, member rj14bnp92qoqp2gfxbwpb0q5)` pair at **07:29:22.627Z** and **07:31:24.951Z**, with the failing run at **07:30:50**. Runs against that workspace and member succeeded 88s before and 34s after the failure. **A permanently unprovable binding cannot do that** — it would have failed all three. The later successful run on the same project (`3937308b-…`) is the same signal.

Conclusion: `directory.ok === false` — a transient directory read failure. **The fallback in this PR is therefore the actual fix for this report**, not a neighbouring improvement.

Two honest limits: I could not capture the failed HTTP request itself (that would need vela's server-side request log for `GET /api/v1/workspaces` at `2026-07-29T07:30:40Z ±10s`), so the *mechanism* is inference from timing plus the elimination above. The `hub events channel disconnected` line immediately after the workspace was verified is a consistent but unproven trigger.

One inference in the original report is unsound and should not be reused: `collab_sync_snapshots` having no row for `(account, d87ys…)`. That table (`apps/daemon/src/collab/sync-snapshot-store.ts`) is a **cache** of a face's last-fetched payload keyed `(face, account_id, workspace_id)`; a missing row means "never fetched-and-cached", and says nothing about membership either way. It also cannot produce an empty-but-`ok` directory: `fetchWorkspaceDirectory` (`server.ts:2802`) wraps `fetchVelaWorkspaceDirectory` in a 5s in-memory TTL that never caches failures, and never consults `collab_sync_snapshots` or `persistent-sync-cache.ts`.

## The observability finding, and why it is a deliverable here

Searching the reporter's complete diagnostics export: the failed run id appears **nowhere** in `logs/daemon/latest.log`; there is **not one line** about a directory fetch, on success or failure; the run's `events.jsonl` has `start` then `error` with only the prose sentence; `state.json` carries the generic `AGENT_EXECUTION_FAILED`.

Telemetry is no better. `RunFinishedProps` has no error-message property at all, and a HogQL scan over **134,608,497 events / 30 days** returns **0** matches for every phrase in the message (control: `AGENT_EXECUTION_FAILED` over 7 days returns 22,768, so the query is sound). Worse, the event actively mislabels the failure: `failure_category=process_exit`, `failure_stage=child_close`, `rpc_close_reason=exit_nonzero` — but **no child was ever spawned**. That comes from the synthetic `finish(run,'failed',1,null)` combined with `isSpawnFailureText`'s `/\bspawn failed: spawn\b/` not matching this message. So it points a reader at the wrong subsystem.

Prevalence, via the tight proxy (`amr` + `AGENT_EXECUTION_FAILED` + `attempt_terminal_phase='prompt_build'`), 90 days: **1 row, 1 distinct user** — this run. But that fingerprint is fragile: with `attempt_terminal_phase` unset, occurrences fall into a bucket holding 263 events / 77 distinct users in 30 days and become unrecoverable.

## What changed

**1. Refusal and failure are now different events, and only refusal fails closed.**
`ProjectWorkspaceScopeUnavailableError` → `ProjectWorkspaceScopeRefusedError`, carrying `code: 'PROJECT_WORKSPACE_SCOPE_REFUSED'` and an `outcome` discriminator. The docblock previously argued the opposite ("fail closed rather than silently charging the account wallet"); it is rewritten to state the actual rule, records that the change is a product decision with its reasoning, and asks a future reader not to "fix" it back.

**2. A transient authority failure no longer kills the run.**
`readWorkspaceDirectoryWithBoundedRetry` is a named invariant: *reports `ok: true` only when the authority actually answered, and `ok: false` only after every bounded attempt failed.* 3 attempts, backoff `[120ms, 360ms]`. Both a falsy `ok` and a thrown error count as a failed attempt — the production fetcher swallows missing sessions, non-2xx and network errors into `{ ok: false }` rather than rejecting, so the old `.catch` was nearly dead code and `ok: false` was the real signal.

**3. Every branch is separately identifiable, in three places.**
One closed union `ProjectWorkspaceScopeOutcomeKind` — `refused_no_binding`, `refused_no_active_membership`, `refused_directory_empty`, `proceeded_directory_unreadable`, `resolved_team`, `resolved_personal` — reported via `onWorkspaceScopeOutcome` to:
- **daemon log** — `[od] amr workspace scope <kind> project=… workspace=… directoryOk=… items=… attempts=… run=…`
- **run record** — the structured cause rides in `ApiError.details` (the sanctioned field), so `state.json` / `events.jsonl` identify the branch. The wire `code` stays `AGENT_EXECUTION_FAILED` deliberately: changing it is a client-visible contract change I did not want to make unilaterally.
- **telemetry** — `amr_workspace_scope_resolved` with `workspace_scope_outcome`, `workspace_scope_directory_ok`, `workspace_scope_directory_item_count`, `workspace_scope_read_attempts`.

Ids, counts and the branch name only — no member rows, no credentials. AMR-only: the non-AMR short-circuit returns before any of it, pinned by a test.

`refused_directory_empty` is new and deliberate. Vela structurally cannot return an empty list to an authenticated caller (`ensurePersonalWorkspace` runs first, no type filter), so an empty list is a malformed answer, not "you were removed". It still refuses — I did not widen the proceed path beyond what was authorised — but it can never be misread as a membership fact. **Open question for the owner:** an empty `ok` payload is arguably "could not ask" and could join the proceed path; that is a billing widening, so it is flagged, not taken.

## Billing decision record

The authorised change is: **directory unreadable after bounded retries → the run proceeds with `workspaceId` null**, i.e. on the caller's own account wallet. The reasoning is that a hard failure is worse than a mis-attributed charge, and this arrived as a P0. The costs: failing closed costs a legitimate user their run for something that was not their fault and self-heals in seconds; proceeding costs, in the rare case where the binding really was a team workspace, one run billed to the person who ran it instead of to their team. Who pays: in every fallback case, **the caller pays for the caller's own run** — that asymmetry is what makes it safe, and it is why the retry is bounded rather than absent, so one slow response cannot move a charge. The reverse direction — a personal run charged to a team wallet — is a genuine breach and stays impossible: no fallback here selects some other workspace, and a proven non-membership still refuses. Two mutation tests guard exactly that line.

## Tests (red-first)

New: `apps/daemon/tests/runtimes/project-amr-workspace-proof.test.ts` (10 specs). They assert on the literal identity strings rather than importing the error class, so recollapsing the identities turns them red.

Red, before any source change (all five behavioural, not import errors):

```
 × refuses the run when the directory ANSWERED and the membership is genuinely absent 39ms
 × retries a failed directory read, then proceeds on the account wallet and reports it 11ms
 × treats a REJECTED directory read as a failed attempt, not as a refusal 11ms
 × recovers on retry: a first failed read then a good one resolves normally, no fallback 12ms
 × refuses an unbound project without reading the directory at all 16ms
 Test Files  1 failed (1)
      Tests  5 failed (5)
```

Green, after:

```
 Test Files  2 passed (2)
      Tests  17 passed (17)
```

**Mutation tests.** Recollapsing the two identities (unreadable directory throws refusal again) → 2 red, both fallback specs. Letting a *proven* refusal proceed → 2 red, both wallet-safety specs, in both test files. The line that protects someone else's wallet is guarded from both directions.

One pre-existing spec changed intentionally: `fails closed when the persisted workspace binding cannot be proven` drove its refusal with `{ ok: false }` — an *unreadable* directory, which now takes the fallback. It is repointed at the refusal that survives (directory answered, binding not listed) and renamed accordingly.

Also run: `pnpm guard` clean, `pnpm typecheck` clean. Note `server.ts` carries `@ts-nocheck`, so typecheck does not cover the call-site edit; it is exercised by `tests/chat-route.test.ts` and the runtimes suite (48 files / 758 tests green).

Full `@open-design/daemon` suite, twice: `570 passed | 1 failed` both times, but **a different file each run** — `tests/project-upload-filenames.test.ts` then `tests/run-retry-runtime.test.ts`. Both pass in isolation on this branch *and* on the baseline commit, and neither has any relation to workspace scope. Suite-parallelism flakes, not regressions from this change.

## Scope held / adjacent issues

Not fixed here, recorded so they are findable:

- **`Error: stale team project pull plan: authorization expired`** on `vela.exe team-projects pull` (Windows).
- **`EPERM: operation not permitted, fsync`** causing `failed to promote authorized team project … reason=promotion-failed` even though the snapshot reported `workspaceAvailable: true, workspaceMatches: true, generationMatches: true`. A Windows file-lock failure that breaks pulling a shared team project — on the exact journey about to be handed to testers.
- **The failure triple mislabels no-child-spawned preflight failures** as `process_exit` / `child_close` / `exit_nonzero`, because `isSpawnFailureText` requires `/\bspawn failed: spawn\b/`. Any preflight throw is filed as a child crash.
- **`resolveProjectWorkspaceScope` still returns one `unavailable` kind** for three distinct conditions (fetch not ok, no matching item, item inconsistent). This PR distinguishes them at the AMR call site where the evidence lives; the shared resolver's contract arm has no reason field.
- **Creation-path binding.** Whether project creation should verify the selected workspace is present-and-active for the current member before binding, and whether a stale binding on a `local_only` / `personal` / unpublished row should be repaired rather than fatal, was raised as a candidate fix. Its premise — a stale binding from a previous identity — is refuted by the evidence above for *this* report, so I did not build it. It may still be worth doing on its own merits, with the line drawn explicitly at shared/synced rows; that needs its own red spec and its own decision.

## Surface area

Daemon only. No UI, no CLI, no contracts, no i18n, no new user-facing strings — the one message change is an internal error sentence, and `ApiError.details` is machine-readable. No new dependencies.

## Note on rollout

The reporter is on `0.16.2-beta.146`. This lands in `.148` or later, so she is not fixed by her current build.
