### PR TITLE
fix(collab): warm the workspace-scoped digest faces on switch and reconnect

### DIFF
--- a/apps/daemon/src/routes/collab-context.ts
+++ b/apps/daemon/src/routes/collab-context.ts
@@ -98,6 +98,18 @@ export interface RegisterCollabContextRoutesDeps {
     set(workspaceId: string): Promise<void>;
     clear(): Promise<void>;
   };
+  /**
+   * Announce that the active workspace just changed to `workspaceId`, after the
+   * switch is confirmed by a matching context read (never for a rejected or
+   * rolled-back switch).
+   *
+   * Every workspace-scoped cache in the daemon is keyed on the active workspace,
+   * so a switch leaves all of them cold and the first consumer pays the refill
+   * on its own request path. This seam lets the owner of those caches warm them
+   * while the user is still looking at the freshly switched view. It is
+   * deliberately fire-and-forget: the switch response must not wait on warming.
+   */
+  onWorkspaceSwitched?: (workspaceId: string) => void;
   /** Injectable for tests; defaults to the Vela workspace directory API. */
   listWorkspaceDirectory?: () => Promise<WorkspaceDirectoryItem[]>;
   /**
@@ -339,6 +351,11 @@ export function registerCollabContextRoutes(app: Express, deps: RegisterCollabCo
       } else await deps.activeWorkspace.clear();
       return res.status(404).json({ error: 'workspace_context_unavailable' });
     }
+    // The switch is confirmed: the backend moved and the context read agrees.
+    // Warm the now-cold workspace-scoped caches before responding to the
+    // browser, but never await them — a slow upstream must not delay the
+    // switch, and a failed warm just leaves the old cold-read behavior.
+    deps.onWorkspaceSwitched?.(workspaceId);
     const body: WorkspaceActiveResponse = { activeWorkspaceId: workspaceId, context };
     res.json(body);
   });

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -3998,9 +3998,51 @@ export async function startServer({
       );
     },
   });
+  /**
+   * Hold the invariant that the two workspace-scoped digest faces — `catalog`
+   * and `members` — have a usable value for the workspace this daemon is
+   * ACTUALLY operating in, rather than only for whichever workspace happened to
+   * be active when a consumer last asked.
+   *
+   * Both caches key on `activeWorkspace.get()`, so the moment the active
+   * workspace changes every entry is a miss and the next consumer refills it
+   * inline on its own request path (`createPersistentSyncCache` fetches
+   * synchronously on a miss). That cost is identical either way — the only
+   * question is who waits for it. A switch is a user action followed by idle
+   * time, so paying it here is free; paying it inside the first project load or
+   * agent run is not.
+   *
+   * Warming MUST go through the cache functions and never their underlying
+   * fetchers: `createSwrCache`'s read returns `entry.inflight ?? refresh(key)`,
+   * so a warm that races the very consumer it is protecting joins that
+   * consumer's request instead of issuing a second one. This adds no request
+   * that would not otherwise have been made.
+   *
+   * `revalidate` is for the reconnect case, where the workspace has NOT changed:
+   * the key is unchanged and a still-fresh entry would make the warm a no-op
+   * handing back exactly the value the disconnect made untrustworthy. Dropping
+   * the entry first is what turns the warm into a real read.
+   */
+  const warmActiveWorkspaceDigestFaces = (
+    workspaceId: string,
+    options: { revalidate?: boolean } = {},
+  ) => {
+    if (!workspaceId || workspaceId !== activeWorkspace.get()?.trim()) return;
+    if (options.revalidate) {
+      teamProjectsDisplayCache.invalidate();
+      teamMembersCache?.invalidate();
+    }
+    void teamProjectsDisplayCache().catch(() => undefined);
+    void teamMembersCache?.().catch(() => undefined);
+  };
   registerCollabContextRoutes(app, {
     workspaceContext: collab.workspaceContext,
     activeWorkspace,
+    // A confirmed switch leaves every workspace-scoped cache cold. Warm the two
+    // digest faces now so the first project load / agent run in the new
+    // workspace does not pay the refill — see
+    // `warmActiveWorkspaceDigestFaces` for why this cannot double-fetch.
+    onWorkspaceSwitched: (workspaceId) => warmActiveWorkspaceDigestFaces(workspaceId),
     billingRuntime: workspaceBillingRuntime,
     // Same directory read the route would have made on its own, wrapped so every
     // workspace type it carries is memoized for the team-share invariant.
@@ -4328,6 +4370,15 @@ export async function startServer({
       // Close the disconnect gap: one catch-up cycle over the same reads the
       // pollers watch, plus a comment pull for open projects.
       if (subscribedWorkspaceId === activeWorkspace.get()?.trim()) {
+        // The catch-up below reads the team-project and member lists THROUGH
+        // the SWR caches, so an entry that settled just before (or during) the
+        // disconnect still counts as fresh and makes the diff conclude "nothing
+        // changed" — the one cycle meant to close the gap then emits nothing and
+        // the client stays stale until an unrelated read happens to miss. Drop
+        // those two entries first so the catch-up compares against the hub's
+        // current truth. `pollOnce` joins the in-flight refresh this starts, so
+        // the pair still costs one fetch per face, exactly as before.
+        warmActiveWorkspaceDigestFaces(subscribedWorkspaceId, { revalidate: true });
         void workspaceInvalidationPoller.pollOnce().catch(() => undefined);
         void collabCloud?.pollOnce().catch(() => undefined);
       }

--- a/apps/daemon/tests/collab/workspace-switch-warms-caches.test.ts
+++ b/apps/daemon/tests/collab/workspace-switch-warms-caches.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import http from 'node:http';
+import { buildWorkspacePermissions, buildWorkspaceSeatSummary } from '@open-design/contracts';
+import type {
+  WorkspaceCollabContext,
+  WorkspaceDirectoryItem,
+} from '@open-design/contracts';
+import {
+  registerCollabContextRoutes,
+  type RegisterCollabContextRoutesDeps,
+} from '../../src/routes/collab-context.js';
+
+// Every workspace-scoped cache in the daemon keys on the active workspace, so a
+// switch leaves all of them cold and the FIRST consumer in the new workspace
+// pays the refill inline on its own request path. `onWorkspaceSwitched` is the
+// seam that lets the owner of those caches warm them during the idle beat right
+// after the user switches.
+//
+// The contract this file pins is deliberately narrow, because getting it wrong
+// is worse than not warming at all: the announcement must fire for a CONFIRMED
+// switch and for nothing else. Warming on a rejected or rolled-back switch would
+// refill the caches against the workspace the daemon just refused to move to.
+
+let server: http.Server | null = null;
+
+afterEach(async () => {
+  if (server) {
+    const toClose = server;
+    server = null;
+    await new Promise<void>((resolve) => toClose.close(() => resolve()));
+  }
+});
+
+const PERSONAL = 'ws-personal';
+const TEAM = 'ws-team';
+
+function directoryItem(workspaceId: string): WorkspaceDirectoryItem {
+  return {
+    workspaceId,
+    workspaceName: workspaceId === TEAM ? 'Acme' : "Ma Shu's workspace",
+    workspaceType: workspaceId === TEAM ? 'team' : 'personal',
+    workspaceMemberId: `wm-${workspaceId}`,
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+  };
+}
+
+function contextFor(workspaceId: string): WorkspaceCollabContext {
+  return {
+    workspaceId,
+    workspaceType: workspaceId === TEAM ? 'team' : 'personal',
+    workspaceMemberId: `wm-${workspaceId}`,
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+    billingState: 'active',
+    planId: null,
+    providerMode: 'platform_credits',
+    seatSummary: buildWorkspaceSeatSummary({ seatLimit: 5, usedSeats: 1 }),
+    permissions: buildWorkspacePermissions({ role: 'owner', lifecycleState: 'active' }),
+  };
+}
+
+/**
+ * A switch harness with an in-memory active-workspace pin, so the rollback path
+ * is exercised through the same store the route mutates rather than a stub that
+ * cannot disagree with itself.
+ */
+async function startSwitchServer(options: {
+  /** What the backend `selectWorkspace` answers. Default: accepts. */
+  selectWorkspace?: (workspaceId: string) => boolean;
+  /** What the follow-up context read answers. Default: agrees with the pin. */
+  currentContext?: (pinned: string | null) => WorkspaceCollabContext | null;
+  initial?: string;
+}) {
+  let pinned: string | null = options.initial ?? PERSONAL;
+  let backendWorkspace = options.initial ?? PERSONAL;
+  const onWorkspaceSwitched = vi.fn<(workspaceId: string) => void>();
+
+  const activeWorkspace: NonNullable<RegisterCollabContextRoutesDeps['activeWorkspace']> = {
+    get: () => pinned,
+    set: async (workspaceId: string) => {
+      pinned = workspaceId;
+    },
+    clear: async () => {
+      pinned = null;
+    },
+  };
+
+  const app = express();
+  app.use(express.json());
+  registerCollabContextRoutes(app, {
+    workspaceContext: {
+      current: async () =>
+        options.currentContext
+          ? options.currentContext(pinned)
+          : pinned
+            ? contextFor(pinned)
+            : null,
+      selectWorkspace: async (workspaceId: string) => {
+        const accepted = options.selectWorkspace ? options.selectWorkspace(workspaceId) : true;
+        if (accepted) backendWorkspace = workspaceId;
+        return accepted;
+      },
+    } as unknown as RegisterCollabContextRoutesDeps['workspaceContext'],
+    activeWorkspace,
+    listWorkspaceDirectory: async () => [directoryItem(PERSONAL), directoryItem(TEAM)],
+    onWorkspaceSwitched,
+  });
+
+  server = http.createServer(app);
+  await new Promise<void>((resolve) => server!.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('server did not bind');
+  const base = `http://127.0.0.1:${address.port}`;
+
+  return {
+    onWorkspaceSwitched,
+    pinnedWorkspace: () => pinned,
+    backendWorkspace: () => backendWorkspace,
+    async switchTo(workspaceId: string) {
+      const response = await fetch(`${base}/api/workspace/active`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ workspaceId }),
+      });
+      return { status: response.status, body: (await response.json()) as Record<string, unknown> };
+    },
+  };
+}
+
+describe('PUT /api/workspace/active announces a confirmed switch for cache warming', () => {
+  it('announces the new workspace exactly once when the switch is confirmed', async () => {
+    const api = await startSwitchServer({});
+
+    const result = await api.switchTo(TEAM);
+
+    expect(result.status).toBe(200);
+    expect(api.pinnedWorkspace()).toBe(TEAM);
+    // The announcement is what lets the daemon refill the `catalog` and
+    // `members` digest faces during the idle beat after the switch, instead of
+    // making the first project load or agent run in the new workspace pay for
+    // it.
+    expect(api.onWorkspaceSwitched).toHaveBeenCalledTimes(1);
+    expect(api.onWorkspaceSwitched).toHaveBeenCalledWith(TEAM);
+  });
+
+  it('stays silent when the backend rejects the switch', async () => {
+    const api = await startSwitchServer({ selectWorkspace: () => false });
+
+    const result = await api.switchTo(TEAM);
+
+    expect(result.status).toBe(502);
+    // Nothing moved, so warming here would refill the caches for a workspace
+    // this daemon is not operating in.
+    expect(api.onWorkspaceSwitched).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when the context read disagrees and the switch is rolled back', async () => {
+    // The backend accepted the move but the follow-up context read still
+    // answers for the old workspace, which is the route's rollback trigger.
+    const api = await startSwitchServer({
+      currentContext: () => contextFor(PERSONAL),
+    });
+
+    const result = await api.switchTo(TEAM);
+
+    expect(result.status).toBe(404);
+    expect(api.pinnedWorkspace()).toBe(PERSONAL);
+    expect(api.onWorkspaceSwitched).not.toHaveBeenCalled();
+  });
+
+  it('stays silent for a workspace the directory does not show', async () => {
+    const api = await startSwitchServer({});
+
+    const result = await api.switchTo('ws-not-mine');
+
+    expect(result.status).toBe(404);
+    expect(api.onWorkspaceSwitched).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Scope — read this first

This PR was scoped from three asks. Their status differs, and the diff alone is misleading, so stating it up front:

| Ask | Status | Where |
|---|---|---|
| **A** — collapsed switcher shows 「Personal workspace」 instead of the real remote name | **Already fixed on this branch by #6199**, before this work started. Verified empirically, not taken on trust. Nothing re-implemented. | `b74646cd6`, landed 2026-07-29 11:37 |
| **B** — warm the cold caches on switch and re-warm on hub reconnect | **Fixed here.** This is the entire diff. | `apps/daemon/**`, `+251/−0` |
| **C** — audit of everything that goes cold on a workspace switch | **Delivered below** as a 17-row table plus reasoning | *Audit* section of this body |

**Why there is no `apps/web` file in this diff:** Part A's fix is already on `feat/workspace-team`. #6199 took exactly the zero-request option — it reads `workspaceName` off the `GET /api/workspace/context` response the shell already fetches at startup, so the label is correct on first paint and no fetch call site was added. Re-implementing it here would be a duplicate change, and the honest report is that the web side needs nothing.

I verified it rather than trusting the commit message. Reverting #6199's one-line consumption in `EntryNavRail.tsx` takes three assertions red with exactly the reported symptom:

```
× shows the remote name on the collapsed control without opening the dropdown
× shows the remote name on the expanded personal row before the directory answers
× derives the avatar initial from the remote name, not the fallback
  AssertionError: expected 'PPersonal workspace' to contain "Ada's workspace"
  AssertionError: expected 'P' to be 'A'
```

Restoring it: `Test Files 1 passed · Tests 3 passed`.

**The performance red line is already asserted upstream, at the fetch layer.** I checked specifically for this rather than assuming, because it is what got an earlier attempt reverted. Two guards exist and both pass on this branch (`Test Files 2 passed · Tests 5 passed`):

| Guard | Assertion | Meaning |
|---|---|---|
| `apps/web/tests/components/EntryNavRail.workspace-name.test.tsx:103` | `expect(net.directoryCalls()).toBe(0)` | the collapsed label renders the real remote name with the directory read **held open forever** — startup issues **zero** `/api/workspace/directory` requests |
| `apps/web/tests/useWorkspaceContext.multi-consumer-dedupe.test.tsx:78` | `expect(contextCalls.length - before).toBe(1)` | one refresh across a dozen mounted consumers collapses to **exactly one** `/api/workspace/context` fetch, not one per consumer |

So the startup request count for the switcher name is **0 new requests, before and after** — the number the red line demanded, already enforced by a test rather than by inference. Adding a third test asserting the same counts would be redundant, so I did not.

## Why

The product owner reported that the sidebar switcher shows 「Personal workspace」 after signing in to AMR and only picks up the real remote name once you open the dropdown, and separately asked for an audit of *everything* that goes cold when the active workspace changes. I went in to fix the first and map the second.

**The reported switcher bug turned out to be already fixed on this branch** by #6199 (`fix(collab): carry B's workspace name for personal workspaces too`), which landed after the checkout I started from. I verified it rather than trusting the commit message: reverting its one-line web consumption takes `EntryNavRail.workspace-name.test.tsx` red with exactly the reported symptom (`expected 'PPersonal workspace' to contain "Ada's workspace"`), and restoring it takes it green. Nothing to redo there, and I deliberately did not re-fix it.

What is *not* fixed is the same root cause one layer down, which is what this PR addresses. Every workspace-scoped cache in the daemon keys on the active workspace, so the instant a user switches, the `catalog` and `members` digest faces are both a miss and the **first** consumer in the new workspace refills them inline on its own request path — `createPersistentSyncCache` fetches synchronously on a miss (`apps/daemon/src/collab/persistent-sync-cache.ts:139`). The cost is identical either way; the only question is who waits for it. A switch is a user action followed by idle time, so paying it there is free. Paying it inside the first project load or agent run is not.

The second half is the disconnect gap in a real user's diagnostics bundle (`0.16.2-beta.146`, Windows, `release-beta-win`): her hub channel disconnected and nothing refreshed until a later read happened to miss. Root cause is precise — the reconnect catch-up reads the team-project and member lists *through* those same SWR caches, so an entry that settled just before or during the disconnect still counts as fresh, the diff concludes "nothing changed", and the one cycle meant to close the gap emits nothing.

## What users will see

Switching workspaces no longer makes the first thing you do in the new workspace pay for the switch. Before this, the first project load / 全部项目 open / agent run after a switch blocked on a fresh round trip to fetch the new workspace's project catalog and member roster; now that fetch happens during the idle beat right after you click, so the first action lands on a warm cache.

After the client's realtime channel drops and reconnects, teammates' shares and roster changes made during the outage now actually show up. Previously the reconnect could conclude nothing had changed and leave the client stale until some unrelated read happened to miss.

No new UI, no new setting. Nothing is added to the startup path.

## Surface area

- [x] **API / contract** — no new endpoint or contract shape; a new internal route dep (`onWorkspaceSwitched`) on `registerCollabContextRoutes`. Flagging the box because `PUT /api/workspace/active` behavior changed (it now announces a confirmed switch).
- [x] **Default behavior change** — a confirmed workspace switch now triggers two background daemon→vela reads it did not make before, and a hub reconnect now always revalidates two faces instead of sometimes reusing a cached value. Both are detailed under *Request-count accounting* below.

## Bug fix verification

- Red spec: `apps/daemon/tests/collab/workspace-switch-warms-caches.test.ts`
- Went red before the source change, green after:

```
# fix reverted (git stash of apps/daemon/src/routes/collab-context.ts)
 × announces the new workspace exactly once when the switch is confirmed
   AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
 Test Files  1 failed (1)   Tests  1 failed | 3 passed (4)

# fix restored
 Test Files  1 passed (1)   Tests  4 passed (4)
```

The three negative cases (backend rejects, context read disagrees → rollback, workspace not in the directory) assert the announcement stays *silent*, so they pass in both states by construction — that is intentional. Warming on a rejected or rolled-back switch would refill the caches against a workspace the daemon just refused to move to, which is worse than not warming at all, so the contract is pinned in both directions.

Part A (the reported switcher bug, already fixed by #6199) was verified the same way — see *Why*. Its guard is `apps/web/tests/components/EntryNavRail.workspace-name.test.tsx`; reverting the fix takes 3 of its assertions red.

## Request-count accounting

This is the constraint that got an earlier attempt at the switcher bug reverted, so it gets its own section. The home page was recently slow because repeated GETs saturated HTTP/1.1's six-connection limit.

**Startup path: zero change.** The diff adds no fetch call site on any client path and touches no client code at all. `git diff --stat` is three files, all under `apps/daemon`. The already-landed switcher fix (#6199) is also zero-request by construction — it reads `workspaceName` off the `GET /api/workspace/context` response the shell already fetches at startup, which is why the label is right on first paint.

| Path | Before | After |
|---|---|---|
| App startup | 1 × `/api/workspace/context` (coalesced, 1s TTL) | **unchanged** |
| Switcher collapsed label | 0 (reads the context above) | **unchanged** |
| Switcher dropdown open | 1 × `/api/workspace/directory` | **unchanged** |
| Confirmed workspace switch | 0 warm reads; first consumer pays 2 inline | 2 warm reads; first consumer pays 0 |
| Rejected / rolled-back switch | 0 | **0** (pinned by test) |
| Hub reconnect | 0 or 2, depending on SWR freshness | always 2 |

**Why the switch row is not a duplicate fetch.** Warming goes through the cache functions, never their underlying fetchers. `createSwrCache`'s read returns `entry.inflight ?? refresh(key)` (`apps/daemon/src/collab/swr-cache.ts:72`, and the same line exists in `teamProjectsDisplayCache`'s hand-rolled equivalent at `apps/daemon/src/server.ts:3338`), so a warm that races the very consumer it is meant to protect **joins** that consumer's request rather than starting a second one. The two reads in that row are the same two the first consumer would have made; they moved off its critical path. Net requests per switch are unchanged.

**The reconnect row is an honest, bounded increase.** Going from "0 or 2" to "always 2" is the fix, not a regression: the cached value being reused was precisely the untrustworthy one. It is bounded by reconnect frequency, not by user activity, and `pollOnce` was already going to read those caches — it now joins the in-flight refresh the revalidate starts, so the pair still costs one fetch per face rather than two.

`apps/web/src/lib/coalesced-get.ts` was not touched, so its 1s TTL and identity-scoped keying are unchanged.

## Audit — what goes cold when the active workspace changes

Requested by the owner. Every row re-verified against this branch's HEAD (`59a2b4579`), not against an older checkout — an earlier pass of this audit was 152 commits stale and got two rows wrong, both of which had since been fixed.

| # | Surface | Reader | What the user sees while cold | Warm at switch? | Cost | Status |
|---|---|---|---|---|---|---|
| 1 | Workspace context + name (`/api/workspace/context`) | whole entry shell via `useWorkspaceContext` | collapsed switcher fell back to a hardcoded English 「Personal workspace」 | No — consume, don't fetch | 0 | **Fixed upstream** (#6199), verified here |
| 2 | Workspace list (`/api/workspace/directory`) | switcher dropdown only, effect gated on `teamOpen` (`EntryNavRail.tsx:754`) | loading row on first dropdown open | **No — deliberately** | would be +1 on every startup | **Won't warm** (reasoning below) |
| 3 | `catalog` digest face | `teamProjectsDisplayCache` → vela catalog | first project load / 全部项目 open blocks on a vela round trip | **Yes** | 2 (moved, not added) | **Fixed here** |
| 4 | `members` digest face | `teamMembersCache` → `collabCloud.listMembers()` | comment authors and shared-project owners render unresolved | **Yes** | shares row 3 | **Fixed here** |
| 5 | All faces after hub reconnect | reconnect catch-up | shares/roster changes from the outage never appear | **Yes** (revalidate) | 0 or +2 per reconnect | **Fixed here** |
| 6 | Project list / recent projects | `App.tsx:1682-1727`, effect keyed on `workspaceId`, one 1200ms retry | 「最近项目」 lags one beat | Already refetches; don't add a third read | 0 | **Recorded** — see below |
| 7 | Design systems (`/api/design-systems`) | `App.tsx:1748-1750`, effect on `workspaceId` | previous workspace's library until the effect fires | Already refetches | 0 | OK |
| 8 | Design systems team-shared ids | `DesignSystemsTab`, coalescing key includes `workspaceId` | — | Already refetches | 0 | OK |
| 9 | Plan / credits nameplate (`/api/workspace/billing`) | `useWorkspaceBillingResponse`, keyed workspace+member+context revision | — | Already forced on switch | 0 | OK — best-scoped read in the repo |
| 10 | Seat / member roster (`/api/workspace/members`) | `useTeamMembers`, key `workspace-members:${workspaceIdentityCacheKey(ctx)}` | — | Already re-reads immediately | 0 | OK — and now hits a warm daemon cache (row 4) |
| 11 | Plugins (`/api/plugins`) | `HomeView` + `PluginsView`, both `[]` deps | nothing — these reads are *unscoped*, so workspace-invariant | No — nothing goes stale | — | **Recorded** (scope asymmetry, below) |
| 12 | Plugins/skills team-shared ids | `/api/workspace/{plugins,skills}/team`, 10s interval + focus, `[]` deps | up to 10s stale after a switch | No — 10s poll already covers it | +2 | **Recorded**, low value |
| 13 | Skills (`/api/skills`) | `App.tsx` calls `fetchSkills()` **headerless** at boot | shell skill list is the unclaimed-only projection and never re-reads | No — warming a wrong-scope read does not help | — | **Recorded** — real defect, own fix |
| 14 | Shared-project catch-up lanes | `proactive-content-pull` | on a *team* switch, a `scope-mismatch` skip schedules no retry | No — needs retry, not warmth | — | **Recorded** — own red spec |
| 15 | Invalidation-poller baselines | `contextSig`/`teamProjectsSig`/`membersSig`, process-scoped | one spurious triple `*-changed` 0–15s after a switch | No — needs workspace-keying | — | **Recorded** |
| 16 | Digest failure cooldown | `sync-digest.ts` `cooldownUntil`, per-reader closure | a failure under workspace A suppresses B's digest for 60s | No — needs per-workspace keying | — | **Recorded** |
| 17 | Presence authority | `authoritativePresenceWorkspaces` | new workspace not authoritative until its `ready` frame | **No** — a correctness gate, not a cache | — | Correct as-is |

### Where warming is the wrong answer

**Row 2, the workspace list — do not warm.** This is the one that looks most tempting and is most clearly wrong. Now that the collapsed label reads the name off the startup context (#6199), nothing outside the open dropdown depends on the directory. Prefetching it would add one GET to every single startup to save a loading row that only appears if the user opens a menu — precisely the pattern that saturated HTTP/1.1's connection limit and made the home page slow.

**Row 17, presence authority — not a cache.** `authoritativePresenceWorkspaces` deletes the old workspace on disconnect and only re-adds on the hub's `ready` frame. That is a fail-closed authorization gate; "warming" it would mean asserting presence authority the hub has not granted.

**Rows 11 and 13, plugins and skills — a scoping bug wearing a caching costume.** Neither refetches on a switch, but the reason is not staleness. `App.tsx` calls `fetchSkills()` with no workspace context at every call site (boot, refresh, skills-changed), and the daemon treats a missing `x-od-workspace-id` as `workspaceId: null`, which still applies the filter and hides every *claimed* skill (`apps/daemon/src/skills.ts:205-213`). So the shell's skill list is the unclaimed-only projection and was never workspace-correct to begin with, while `PluginsView` passes the context and gets a different list. Warming a read that is asking the wrong question does not help; the fix is to pass the scope. Same asymmetry sits inside a single function in `PluginsView.refresh()`, which mixes unscoped `listPlugins()` with scoped `fetchSkills(workspaceContext)`.

### Does this warming subsume the 「最近项目」 one-beat lag? Partly — and the remaining beat is not a cache problem

Answering this directly since it was asked. **Partly, and not the part that matters most.**

What the warming does fix: the hub-backed side. 全部项目 and the shared-project catalog read the `catalog` face, so after this change they land on a warm cache instead of blocking on a vela round trip.

What it does **not** fix: Home's own 「最近项目」 strip is fed by App state from `/api/workspaces/:id/projects`, and that read is gated on an effect keyed on `workspaceContext?.workspaceId` (`apps/web/src/App.tsx:1682-1727`). No amount of daemon-side warmth moves it, because the trigger is not a cache miss — it is a **sequencing** problem. The chain is strictly serial:

```
PUT /api/workspace/active  →  notifyWorkspaceContextRefresh()
  →  GET /api/workspace/context   (round trip #2)
    →  workspaceId changes  →  project re-list  (round trip #3)
```

The lag is one full extra round trip, structurally, and warming a cache cannot remove a dependency edge.

The fix is upstream of all of it and is strictly better than warming: **`PUT /api/workspace/active` already returns the new context in its response body** (`WorkspaceActiveResponse = { activeWorkspaceId, context }`), and the client throws it away, then goes and fetches the same context again. Seeding the client from the response it already holds would delete both the beat *and* a request. I recorded it as adjacent issue 5 rather than doing it here: it is a client-side change with its own regression surface around the identity-scoped caches, and it does not belong in a daemon warming PR. It is the highest-value item on the recorded list.

### On the diagnostics bundle in the report

The log excerpt that motivated the reconnect half deserves a correction, because it does not show the bug it looks like it shows:

```
[od] hub events workspace verified workspaceId=d87ys1jllz9e4lux9ldgmu8f reconnect=false
[od] shared-project content catch-up skipped mode=full lane=broad reason=no-active-team
```

`reason=no-active-team` here is **correct and by design**. The catch-up's identity gate (`activeTeamWorkspaceIdentity`, `apps/daemon/src/collab/proactive-content-pull.ts:50-75`) short-circuits on `workspaceType !== 'team'`, and the user had just switched *into her personal workspace* — the verified `workspaceId` in that line differs from the team workspace named earlier in the same log. Shared-project catch-up is a team-only concern, so skipping it in a personal workspace is the intended outcome, and it is not the cause of the AMR run failure that followed. I have not established what that failure was; it is not claimed as fixed here.

There *is* a real defect adjacent to it, recorded as row 14 and not fixed in this PR: on a switch **into a team workspace**, the hub can verify workspace B while `.current()` still answers A, producing a `scope-mismatch` skip — and a skip returns `retryLane: false` with an empty `retryProjectIds`, so nothing is rescheduled and the next opportunity is the 30s recovery floor. That wants its own red spec around retry behavior, not a warming change.

### Recorded, not fixed — adjacent issues

Kept out of this PR deliberately, per AGENTS.md → *Hold the spec's scope*. Each wants its own red spec.

1. **`cachedWorkspaceDirectory` has no production reset** (`EntryNavRail.tsx:81`; all 24 `resetWorkspaceDirectoryCache` call sites are tests). Sign-out does not clear it, so after signing in as a *different account* the switcher's first open renders the previous account's workspace names — and with no loading row, because the cache is non-null. This is an account-change leak, not a workspace-switch one, which is why it is not in scope here, but it is the most user-visible item on this list.
2. **Poller baselines are not workspace-keyed** (row 15) — carries the old workspace's signatures across a switch, so the first tick emits a spurious triple invalidation. Harmless but wasteful.
3. **Digest failure cooldown is not workspace-keyed** (row 16) — the 60s gate is checked *before* `getWorkspaceId()` is even read, so a failure under one workspace blocks another's digest and forces full catalog + member round trips.
4. **Skills / plugins scope asymmetry** (rows 11, 13) — headerless `fetchSkills()` in `App.tsx` and the mixed-scope `PluginsView.refresh()`.
5. **`WorkspaceActiveResponse` already carries the new context, and the client throws it away.** The switch response returns `{ activeWorkspaceId, context }`, but the web side ignores the `context` and instead broadcasts `notifyWorkspaceContextRefresh()` to trigger a *fresh* `/api/workspace/context` read. That is the structural cause of the 「最近项目」 one-beat lag in row 6: the project re-list cannot start until that second round trip resolves. Seeding the client from the response it already has would remove both the beat and a request — a strictly-better follow-up, but it is a client change with its own regression surface and does not belong in a daemon warming PR.
6. **`'Personal workspace'` is a hardcoded English literal** (`EntryNavRail.tsx:665`) in an otherwise fully localized UI. Now a rare fallback after #6199, so it is polish, and it costs 19 locale files to do properly.

## Validation

Run on Node 24.18.0 (repo target `~24`; the ambient `node` was v22, so the suites were run under an explicit Node 24).

- `pnpm guard` — exit 0
- `pnpm typecheck` — exit 0
- `pnpm --filter @open-design/web test` — 550 files, 5555 passed, 11 skipped, 0 failed
- `apps/web` full vitest suite — 550 files, 5555 passed, 11 skipped, **0 failed**
- Part A's two red-line guards — 2 files, 5 passed (counts quoted in *Scope* above)
- `apps/daemon` full vitest suite — 574 files, **570 passed**, 3 skipped, 1 failed → attributed below
- Red-first evidence — quoted under *Bug fix verification*

**The one daemon failure is a pre-existing load flake, not this change.** `tests/run-retry-runtime.test.ts > retries a transient first-token failure inside the same run` failed in the full-suite run with:

```
AssertionError: expected [ { id: 8, event: 'start', …(2) } ] to have a length of 2 but got 1
```

That is a race on the events log — the retry's `start` had not been flushed when the assertion ran. Attribution, rather than hand-waving it as noise:

1. It **passes in isolation on this branch** (`Test Files 1 passed · Tests 9 passed`), so the change does not break it.
2. It exercises agent first-token retry and touches nothing in the workspace-cache path — no overlap with the two files in this diff.
3. CI's `Workspace unit tests` lane passed.
4. The full-suite run was made on a machine running three other concurrent builds, which is exactly the condition a timing-sensitive flush assertion flakes under.

Ignore the four `UI P0` lanes — they are red on `feat/workspace-team` itself with a byte-identical failure list, i.e. base breakage rather than anything from this branch.

Note that `apps/daemon/src/server.ts` carries `@ts-nocheck`, so a green typecheck does not cover the helper added there; the daemon suite is the real gate for it, which is why it was run in full rather than scoped.

I did not stand up two namespaced runtimes for human comparison on this one: both halves are cache-refill timing with no visual surface, and the observable claim is request counts, which the layer above asserts directly. The already-fixed Part A does have a visual surface and is covered by its own web test.
