### PR TITLE
fix(web): keep workspace-scoped data fresh across account and workspace changes

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -91,6 +91,7 @@ import {
   beginWorkspaceScopedRead,
   useWorkspaceBilling,
   useWorkspaceContext,
+  workspaceIdentityCacheKey,
 } from './collab/useWorkspaceContext';
 import { resolvePlanTier } from './collab/team-plan';
 import { deriveTabIdentityScope, UNSET_ACCOUNT_BUCKET } from './collab/tab-scope';
@@ -1790,14 +1791,25 @@ function AppInner() {
   // keeps launch at exactly one `/api/skills` request: the boot pass no longer
   // reads skills, this effect performs the first read, and a switch performs
   // one more.
+  // Keyed on the SAME digest the commit guard compares, not just `workspaceId`.
+  // The guard discards a response whenever `workspaceIdentityCacheKey` moves —
+  // which includes member id, role, status, lifecycle and the two permission
+  // bits. A trigger that only watched `workspaceId` would therefore discard a
+  // response without starting its successor: two accounts active in the same
+  // shared team workspace differ only by membership, so A's pending read would
+  // be dropped for B while the workspace id, being unchanged, suppressed B's
+  // replacement read — leaving the functional registry loading forever on
+  // startup, or holding A's list later. "Discarded and never replaced" is a
+  // worse outcome than the staleness it replaced, so every transition that
+  // invalidates a response must also start its successor.
+  const skillsReadIdentity = workspaceIdentityCacheKey(workspaceContext);
   const skillsReadIdentityRef = useRef<string | null>(null);
   useEffect(() => {
     if (workspaceContextLoading) return;
-    const identity = workspaceContext?.workspaceId ?? 'none';
-    if (skillsReadIdentityRef.current === identity) return;
-    skillsReadIdentityRef.current = identity;
+    if (skillsReadIdentityRef.current === skillsReadIdentity) return;
+    skillsReadIdentityRef.current = skillsReadIdentity;
     void refreshSkills();
-  }, [workspaceContextLoading, workspaceContext?.workspaceId, refreshSkills]);
+  }, [workspaceContextLoading, skillsReadIdentity, refreshSkills]);
 
   const refreshTemplates = useCallback(async () => {
     const list = await listTemplates();

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -849,6 +849,19 @@ function AppInner() {
   // view picks the right flag for whichever tab the user is currently on.
   const [agentsLoading, setAgentsLoading] = useState(true);
   const [skillsLoading, setSkillsLoading] = useState(true);
+  // Functional skills and design templates are two independent registry reads
+  // that gate ONE loader: the EntryView must not stop spinning until both have
+  // answered, or whichever tab the user is on renders an incomplete catalog as
+  // if it were final. They are now read from two different places (the boot pass
+  // reads templates; the workspace-keyed effect reads skills once the caller's
+  // identity is known), so the pair of flags lives here rather than inside one
+  // effect's closure.
+  const skillRegistriesReadyRef = useRef({ functional: false, templates: false });
+  const markSkillRegistryReady = useCallback((half: 'functional' | 'templates') => {
+    skillRegistriesReadyRef.current[half] = true;
+    const { functional, templates } = skillRegistriesReadyRef.current;
+    if (functional && templates) setSkillsLoading(false);
+  }, []);
   const [dsLoading, setDsLoading] = useState(true);
   const [projectsLoading, setProjectsLoading] = useState(true);
   // A loaded project list describes exactly ONE workspace identity, so leaving
@@ -1435,23 +1448,18 @@ function AppInner() {
       // gate `skillsLoading` together so the EntryView stops rendering
       // its loader once both registries respond — neither tab would have
       // a complete picture if we cleared the flag on the first reply.
-      let functionalReady = false;
-      let templatesReady = false;
-      const maybeClearLoading = () => {
-        if (functionalReady && templatesReady) setSkillsLoading(false);
-      };
-      void fetchSkills().then((list) => {
-        if (cancelled) return;
-        setSkills(list);
-        functionalReady = true;
-        maybeClearLoading();
-      });
-
+      //
+      // Only the TEMPLATE half is read here. Functional skills are
+      // workspace-scoped on the daemon and must carry the caller's identity
+      // headers, which do not exist until `/api/workspace/context` settles —
+      // so that read belongs to the workspace-keyed effect below, which owns
+      // the `functional` half of this gate. Reading it here as well would
+      // spend a second `/api/skills` request per launch, and the first one
+      // would be the headerless (fail-closed) answer.
       void fetchDesignTemplates().then((list) => {
         if (cancelled) return;
         setDesignTemplates(list);
-        templatesReady = true;
-        maybeClearLoading();
+        markSkillRegistryReady('templates');
       });
 
       void fetchDesignSystems().then((list) => {
@@ -1750,9 +1758,36 @@ function AppInner() {
   }, [workspaceContext?.workspaceId, refreshDesignSystems]);
 
   const refreshSkills = useCallback(async () => {
-    const list = await fetchSkills();
+    // Always scoped. `GET /api/skills` is fail-closed on a missing
+    // `x-od-workspace-id` (`skills.ts`: `if (!scopeId) return !ownerId;`), so a
+    // headerless read is not the "unfiltered" list — it is the list with every
+    // workspace-claimed skill removed, including the ones claimed by the
+    // workspace the user is actually in.
+    const list = await fetchSkills(workspaceContextRef.current);
     setSkills(list);
-  }, []);
+    markSkillRegistryReady('functional');
+  }, [markSkillRegistryReady]);
+
+  // The skills catalog is workspace-scoped on the daemon exactly like the
+  // design-system catalog above, and needs the same workspace-keyed refresh for
+  // the same reason: the switcher lives ON the home view, so `route.kind` stays
+  // 'home' and no route change fires.
+  //
+  // It additionally waits for `workspaceContextLoading` to settle, because
+  // unlike design systems (whose scope the daemon resolves from its own vela
+  // session) this read carries the identity in REQUEST HEADERS — there is
+  // nothing correct to send until the context has resolved. Gating on it also
+  // keeps launch at exactly one `/api/skills` request: the boot pass no longer
+  // reads skills, this effect performs the first read, and a switch performs
+  // one more.
+  const skillsReadIdentityRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (workspaceContextLoading) return;
+    const identity = workspaceContext?.workspaceId ?? 'none';
+    if (skillsReadIdentityRef.current === identity) return;
+    skillsReadIdentityRef.current = identity;
+    void refreshSkills();
+  }, [workspaceContextLoading, workspaceContext?.workspaceId, refreshSkills]);
 
   const refreshTemplates = useCallback(async () => {
     const list = await listTemplates();
@@ -2873,7 +2908,8 @@ function AppInner() {
 
   const handleSkillsChanged = useCallback(
     (affectedSkillId?: string) => {
-      void fetchSkills().then((list) => setSkills(list));
+      // Scoped, like every other app-level skills read — see `refreshSkills`.
+      void fetchSkills(workspaceContextRef.current).then((list) => setSkills(list));
       void fetchDesignTemplates().then((list) => setDesignTemplates(list));
       iframeKeepAlivePool.evictMatching(
         (entry) => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -87,7 +87,11 @@ import {
 } from './providers/daemon';
 import { AMR_LOGIN_STATUS_EVENT } from './components/amrLoginPolling';
 import { CollabDemoView } from './collab/CollabDemoView';
-import { useWorkspaceBilling, useWorkspaceContext } from './collab/useWorkspaceContext';
+import {
+  beginWorkspaceScopedRead,
+  useWorkspaceBilling,
+  useWorkspaceContext,
+} from './collab/useWorkspaceContext';
 import { resolvePlanTier } from './collab/team-plan';
 import { deriveTabIdentityScope, UNSET_ACCOUNT_BUCKET } from './collab/tab-scope';
 import { CommunityView } from './components/CommunityView';
@@ -1763,7 +1767,13 @@ function AppInner() {
     // headerless read is not the "unfiltered" list — it is the list with every
     // workspace-claimed skill removed, including the ones claimed by the
     // workspace the user is actually in.
-    const list = await fetchSkills(workspaceContextRef.current);
+    const read = beginWorkspaceScopedRead(workspaceContextRef.current);
+    const list = await fetchSkills(read.context);
+    // A read for the workspace the user has since LEFT must not restore that
+    // workspace's catalog over the current one — see `beginWorkspaceScopedRead`.
+    // Skipping the gate too is deliberate: this response is not an answer about
+    // the current identity, and the newer read that replaced it will mark it.
+    if (!read.isStillCurrent(workspaceContextRef.current)) return;
     setSkills(list);
     markSkillRegistryReady('functional');
   }, [markSkillRegistryReady]);
@@ -2908,8 +2918,13 @@ function AppInner() {
 
   const handleSkillsChanged = useCallback(
     (affectedSkillId?: string) => {
-      // Scoped, like every other app-level skills read — see `refreshSkills`.
-      void fetchSkills(workspaceContextRef.current).then((list) => setSkills(list));
+      // Scoped AND guarded on commit, like every other app-level skills read —
+      // see `refreshSkills` and `beginWorkspaceScopedRead`.
+      const skillsRead = beginWorkspaceScopedRead(workspaceContextRef.current);
+      void fetchSkills(skillsRead.context).then((list) => {
+        if (!skillsRead.isStillCurrent(workspaceContextRef.current)) return;
+        setSkills(list);
+      });
       void fetchDesignTemplates().then((list) => setDesignTemplates(list));
       iframeKeepAlivePool.evictMatching(
         (entry) => {

--- a/apps/web/src/collab/useWorkspaceContext.ts
+++ b/apps/web/src/collab/useWorkspaceContext.ts
@@ -109,8 +109,16 @@ export function workspaceIdentityCacheKey(
     context.role,
     context.memberStatus,
     context.lifecycleState,
-    String(context.permissions.canShareProjects),
-    String(context.permissions.canWriteSyncedFiles),
+    // Optional-chained deliberately. `permissions` is REQUIRED on the contract,
+    // so an absent one means a partial/malformed context — and this function is
+    // now called on async continuations (see `beginWorkspaceScopedRead`), where
+    // throwing does not surface as a handled error but as an unhandled rejection
+    // from whatever late promise happened to be settling. Computing an identity
+    // must be total: a partial context is simply its own cache partition, never
+    // an exception. `String(undefined)` is `'undefined'`, which is stable and
+    // distinct from both `'true'` and `'false'`.
+    String(context.permissions?.canShareProjects),
+    String(context.permissions?.canWriteSyncedFiles),
   ].join(':');
 }
 

--- a/apps/web/src/collab/useWorkspaceContext.ts
+++ b/apps/web/src/collab/useWorkspaceContext.ts
@@ -115,6 +115,55 @@ export function workspaceIdentityCacheKey(
 }
 
 /**
+ * One workspace-scoped read: the identity it was issued for, plus the check that
+ * must pass before its response may be committed.
+ *
+ * Keying a request (or its `coalescedGet` entry) by identity stops the WRONG
+ * IDENTITY BEING SERVED an answer fetched for someone else. It does nothing
+ * about the other direction: a read issued for identity A resolves later, and by
+ * then the caller may be identity B. Committing that late answer restores A's
+ * data under B — the exact staleness the identity keys exist to prevent,
+ * arriving through the back door. Reverse-order completion is not exotic here;
+ * a workspace switch is precisely when one read is in flight and another starts.
+ *
+ * So every workspace-scoped read follows the same four steps:
+ *
+ *   const read = beginWorkspaceScopedRead(contextRef.current);
+ *   const data = await fetchSomething(read.context);
+ *   if (!read.isStillCurrent(contextRef.current)) return;   // ← the invariant
+ *   commit(data);
+ *
+ * Two rules make it actually hold:
+ *
+ *  1. Request with `read.context`, never with the caller's own variable, so the
+ *     request and the guard can never disagree about whose data was asked for.
+ *  2. Compare against a REF, never a closed-over prop or state value. A closure
+ *     captures the identity the read was issued for, so comparing against it
+ *     always succeeds and guards nothing.
+ *
+ * This is the cross-component form of the `requestEpochRef` ordering guard
+ * `useWorkspaceContext` already applies to its own read; identity is the right
+ * discriminator for reads that are scoped BY identity.
+ */
+export interface WorkspaceScopedRead {
+  /** The context to send with the request — see rule 1 above. */
+  readonly context: WorkspaceCollabContext | null;
+  /** Whether `current` is still the identity this read was issued for. */
+  isStillCurrent(current: WorkspaceCollabContext | null | undefined): boolean;
+}
+
+export function beginWorkspaceScopedRead(
+  context: WorkspaceCollabContext | null | undefined,
+): WorkspaceScopedRead {
+  const issuedFor = context ?? null;
+  const identity = workspaceIdentityCacheKey(issuedFor);
+  return {
+    context: issuedFor,
+    isStillCurrent: (current) => workspaceIdentityCacheKey(current ?? null) === identity,
+  };
+}
+
+/**
  * `GET /api/workspace/context` is the read that ESTABLISHES the caller's
  * identity, so — unlike every other workspace read — it cannot be keyed on the
  * identity it is fetching, and it takes no workspace argument the key could

--- a/apps/web/src/collab/useWorkspaceContext.ts
+++ b/apps/web/src/collab/useWorkspaceContext.ts
@@ -143,6 +143,9 @@ function advanceWorkspaceContextRequestToken(sharedToken?: string | null): void 
   const next = sharedToken?.trim() || `local:${++localIdentityChangeSeq}`;
   if (next === workspaceContextRequestToken) return;
   workspaceContextRequestToken = next;
+  // Any seed belonged to the generation just retired; a later generation must
+  // never adopt it (see `seededWorkspaceContext`).
+  seededWorkspaceContext = null;
 }
 
 /** Coalescing key for `GET /api/workspace/context`: this read alone, partitioned
@@ -166,6 +169,7 @@ export function resetWorkspaceContextCache(): void {
   workspaceContextRevision = 0;
   workspaceContextRequestToken = 'initial';
   localIdentityChangeSeq = 0;
+  seededWorkspaceContext = null;
 }
 
 /**
@@ -327,7 +331,20 @@ export function useWorkspaceContext(): WorkspaceContextState {
     // through onboarding or the rail callout) and is telling us so. Focus and
     // visibility are ambient revalidation and stay silent — only the deliberate
     // signal may blank a stale signed-out answer while the re-read runs (#140).
+    //
+    // When the acting caller published the post-change context with the
+    // broadcast, adopt it instead of re-reading: it came from the response that
+    // changed the identity, so a fetch here would only ask the server to repeat
+    // itself. Bumping the request epoch first retires any ambient read still in
+    // flight from BEFORE the change, which could otherwise land later and
+    // overwrite the new identity with the old one.
     const refreshAfterIdentityChange = () => {
+      const seeded = seededContextForCurrentGeneration();
+      if (seeded) {
+        requestEpochRef.current += 1;
+        if (mountedRef.current) setState({ context: seeded, loading: false });
+        return;
+      }
       void loadContext({ markLoading: true });
     };
     const onVisibilityChange = () => {
@@ -367,7 +384,51 @@ const WORKSPACE_CONTEXT_SSE_FLOOR_MS = 120_000;
 export const WORKSPACE_CONTEXT_REFRESH_EVENT = 'od:workspace-context-refresh';
 const WORKSPACE_CONTEXT_REFRESH_STORAGE_KEY = 'od.workspaceContext.refreshAt';
 
-export function notifyWorkspaceContextRefresh(): void {
+/**
+ * A context the ACTING surface already holds, published alongside the identity-
+ * change broadcast so consumers adopt it instead of re-reading it.
+ *
+ * `PUT /api/workspace/active` returns the post-switch context from the very same
+ * `workspaceContext.current()` call `GET /api/workspace/context` serves, and only
+ * after asserting its `workspaceId` matches the workspace that was requested. So
+ * the switch response IS the next context; making every mounted consumer go and
+ * fetch it again spends a round-trip to learn what request #1 already said, and
+ * makes the UI wait for request #2 to show it.
+ *
+ * Stamped with the identity generation it belongs to. Every mounted consumer
+ * handles one broadcast in the same synchronous pass and each must adopt, so this
+ * is peeked rather than consumed; the next `advanceWorkspaceContextRequestToken`
+ * retires it. A passive TAB cannot be seeded (it learns of the change through the
+ * `localStorage` stamp, which carries no payload) and correctly falls back to a
+ * real read.
+ */
+let seededWorkspaceContext: {
+  token: string;
+  context: WorkspaceCollabContext;
+} | null = null;
+
+/** The seed published for the CURRENT identity generation, if any. */
+function seededContextForCurrentGeneration(): WorkspaceCollabContext | null {
+  if (!seededWorkspaceContext) return null;
+  return seededWorkspaceContext.token === workspaceContextRequestToken
+    ? seededWorkspaceContext.context
+    : null;
+}
+
+/**
+ * Announce a deliberate identity change (a workspace switch or a sign-in).
+ *
+ * Pass `seed` when the caller already holds the post-change context — the
+ * response body that CHANGED it. Consumers then adopt that context instead of
+ * issuing a fresh `GET /api/workspace/context`. Omit it for callers that only
+ * know something changed (sign-in), which keeps the re-read.
+ *
+ * The broadcast fires either way: `useProjectWorkspaceScope` listens to it to
+ * revalidate the project scope, and other tabs need the storage stamp.
+ */
+export function notifyWorkspaceContextRefresh(
+  seed?: { context: WorkspaceCollabContext } | null,
+): void {
   if (typeof window === 'undefined') return;
   const stamp = String(Date.now());
   // Advance BEFORE dispatching: this call is the one place that knows a genuine
@@ -375,6 +436,19 @@ export function notifyWorkspaceContextRefresh(): void {
   // read the new generation's key. Doing it per handler instead would turn one
   // change into one request per mounted consumer.
   advanceWorkspaceContextRequestToken();
+  if (seed?.context) {
+    seededWorkspaceContext = { token: workspaceContextRequestToken, context: seed.context };
+    // Redefine the module cache now, so a consumer that mounts after this
+    // dispatch seeds from the new identity rather than the one just left.
+    if (
+      workspaceContextIdentity(cachedWorkspaceContext) !== workspaceContextIdentity(seed.context)
+    ) {
+      workspaceContextRevision += 1;
+    }
+    cachedWorkspaceContext = seed.context;
+  } else {
+    seededWorkspaceContext = null;
+  }
   window.dispatchEvent(new Event(WORKSPACE_CONTEXT_REFRESH_EVENT));
   try {
     window.localStorage.setItem(WORKSPACE_CONTEXT_REFRESH_STORAGE_KEY, stamp);

--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -58,6 +58,7 @@ import type { EntrySettingsSection } from './EntrySettingsMenu';
 import { useI18n } from '../i18n';
 import { useDismissOnOutsideInteraction } from '../hooks/useDismissOnOutsideInteraction';
 import {
+  beginWorkspaceScopedRead,
   notifyTeamProjectsChanged,
   notifyWorkspaceBillingRefresh,
   notifyWorkspaceContextRefresh,
@@ -681,6 +682,11 @@ export function EntryNavRail({
     setAccountOpen(false);
   });
   const [teamOpen, setTeamOpen] = useState(false);
+  // The LATEST context, for async work to compare against. `loadWorkspaceDirectory`
+  // closes over the render's `context` prop, which is the identity its read was
+  // issued for — so only a ref can answer "has the identity moved since?".
+  const contextRef = useRef(context);
+  contextRef.current = context;
   const [workspaceItems, setWorkspaceItems] = useState<WorkspaceDirectoryItem[]>(
     () => attributableWorkspaceDirectory(context) ?? [],
   );
@@ -748,28 +754,40 @@ export function EntryNavRail({
         : [];
 
   async function loadWorkspaceDirectory() {
+    // Capture the identity this read is FOR, and compare against `contextRef`
+    // (not the closed-over `context`, which is by definition the identity we are
+    // reading for) before committing anything — see `beginWorkspaceScopedRead`.
+    const read = beginWorkspaceScopedRead(contextRef.current);
     // Only show the loading row when there is nothing to show yet. With a warm
     // cache the list is already on screen and this read just revalidates it —
     // but a cache belonging to another account counts as nothing to show.
-    if (attributableWorkspaceDirectory(context) === null) setWorkspaceDirectoryLoading(true);
+    if (attributableWorkspaceDirectory(read.context) === null) {
+      setWorkspaceDirectoryLoading(true);
+    }
     try {
       // The coalescing key carries the caller's identity for the same reason the
       // module cache does: `coalescedGet` shares a settled result for a second,
       // and this read's answer depends on WHO asked.
-      const cacheKey = `workspace-directory:${workspaceIdentityCacheKey(context)}`;
+      const cacheKey = `workspace-directory:${workspaceIdentityCacheKey(read.context)}`;
       const items = await coalescedGet(cacheKey, async () => {
         const response = await fetch('/api/workspace/directory', { cache: 'no-store' });
         if (!response.ok) throw new Error(`directory ${response.status}`);
         const body = (await response.json()) as WorkspaceDirectoryResponse;
         return body.items ?? [];
       });
+      // The account may have changed while this was in flight. Writing here
+      // would repopulate BOTH the module cache and the visible list with the
+      // previous account's names, after the identity-change effect below had
+      // already cleared them — so an abandoned read must leave no trace.
+      if (!read.isStillCurrent(contextRef.current)) return;
       cachedWorkspaceDirectory = items;
       setWorkspaceItems(items);
     } catch {
       // A failed revalidation must not blank a list the user is looking at —
       // keep the last known names and let the next open try again. A list this
       // caller has no claim to is not "a list the user is looking at".
-      if (attributableWorkspaceDirectory(context) === null) setWorkspaceItems([]);
+      if (!read.isStillCurrent(contextRef.current)) return;
+      if (attributableWorkspaceDirectory(read.context) === null) setWorkspaceItems([]);
     } finally {
       setWorkspaceDirectoryLoading(false);
     }

--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -61,6 +61,7 @@ import {
   notifyTeamProjectsChanged,
   notifyWorkspaceBillingRefresh,
   notifyWorkspaceContextRefresh,
+  workspaceIdentityCacheKey,
 } from '../collab/useWorkspaceContext';
 import { canUpgradeFromPlanTier, hasTeamPlan, resolvePlanLabelTier } from '../collab/team-plan';
 import { AMR_CONSOLE_UPGRADE_INTENT, amrPlansUrlForProfile } from '../runtime/amr-guidance';
@@ -78,11 +79,68 @@ const externalLinkProps = { target: '_blank', rel: 'noreferrer noopener' } as co
 // CONCURRENT reads, so without this every open of the switcher started from an
 // empty list and showed a loading row before the same names reappeared. Kept at
 // module scope so it survives the rail unmounting (returning from a project).
+//
+// Read it through `attributableWorkspaceDirectory` — never directly. The cache is
+// deliberately long-lived, which is also what made it outlive the ACCOUNT it was
+// filled under.
 let cachedWorkspaceDirectory: WorkspaceDirectoryItem[] | null = null;
 
 /** Test seam: clear the module-level directory cache between tests. */
 export function resetWorkspaceDirectoryCache(): void {
   cachedWorkspaceDirectory = null;
+}
+
+/**
+ * Whether a directory list may be shown to `context`.
+ *
+ * `GET /api/workspace/directory` answers "which workspaces can the SIGNED-IN
+ * ACCOUNT see", so it is exactly the read `workspaceIdentityCacheKey` warns
+ * about: a cache kept across an identity change answers the next identity with
+ * the previous one's data. Nothing invalidated this one — the only caller of
+ * `resetWorkspaceDirectoryCache` has ever been tests — so signing in as a
+ * different account kept the previous account's workspace names on screen, and
+ * kept them CONFIDENTLY, because a non-empty cache also suppresses the loading
+ * row.
+ *
+ * The context carries no account id to key on. What every directory item DOES
+ * carry is the `workspaceMemberId` of the membership that produced it, and a
+ * membership id names exactly one (account, workspace) pair. So a list is
+ * attributable to `context` precisely when it contains the caller's OWN
+ * membership:
+ *
+ *   • A different account — even one sharing the same team workspace — holds a
+ *     different member id for it, so this returns false. The switcher then falls
+ *     back to the single entry it can still attribute — the active workspace,
+ *     named from the caller's OWN context — until its own read lands. (Not the
+ *     `role="status"` loading row: that only renders when there is no entry at
+ *     all, which cannot happen while a context exists.)
+ *   • The same account moving between its own workspaces still returns true:
+ *     the membership it switched into was already in the list. That is the
+ *     flash-free reopen the cache exists for, and it survives this fix.
+ *
+ * A false positive would require the list to already contain this caller's own
+ * membership — that is, to have been read by this very account.
+ */
+function workspaceDirectoryBelongsTo(
+  items: WorkspaceDirectoryItem[] | null,
+  context: WorkspaceCollabContext | null,
+): boolean {
+  if (!items || items.length === 0 || !context) return false;
+  const memberId = context.workspaceMemberId?.trim();
+  if (!memberId) return false;
+  return items.some(
+    (item) =>
+      item.workspaceId === context.workspaceId && item.workspaceMemberId?.trim() === memberId,
+  );
+}
+
+/** The cached switcher list, or null when it cannot be attributed to `context`. */
+function attributableWorkspaceDirectory(
+  context: WorkspaceCollabContext | null,
+): WorkspaceDirectoryItem[] | null {
+  return workspaceDirectoryBelongsTo(cachedWorkspaceDirectory, context)
+    ? cachedWorkspaceDirectory
+    : null;
 }
 
 // The rail's destination ids are the entry-shell home views (kept in sync with
@@ -624,7 +682,7 @@ export function EntryNavRail({
   });
   const [teamOpen, setTeamOpen] = useState(false);
   const [workspaceItems, setWorkspaceItems] = useState<WorkspaceDirectoryItem[]>(
-    () => cachedWorkspaceDirectory ?? [],
+    () => attributableWorkspaceDirectory(context) ?? [],
   );
   const [workspaceDirectoryLoading, setWorkspaceDirectoryLoading] = useState(false);
   const [workspaceSwitchingId, setWorkspaceSwitchingId] = useState<string | null>(null);
@@ -691,10 +749,15 @@ export function EntryNavRail({
 
   async function loadWorkspaceDirectory() {
     // Only show the loading row when there is nothing to show yet. With a warm
-    // cache the list is already on screen and this read just revalidates it.
-    if (cachedWorkspaceDirectory === null) setWorkspaceDirectoryLoading(true);
+    // cache the list is already on screen and this read just revalidates it —
+    // but a cache belonging to another account counts as nothing to show.
+    if (attributableWorkspaceDirectory(context) === null) setWorkspaceDirectoryLoading(true);
     try {
-      const items = await coalescedGet('workspace-directory', async () => {
+      // The coalescing key carries the caller's identity for the same reason the
+      // module cache does: `coalescedGet` shares a settled result for a second,
+      // and this read's answer depends on WHO asked.
+      const cacheKey = `workspace-directory:${workspaceIdentityCacheKey(context)}`;
+      const items = await coalescedGet(cacheKey, async () => {
         const response = await fetch('/api/workspace/directory', { cache: 'no-store' });
         if (!response.ok) throw new Error(`directory ${response.status}`);
         const body = (await response.json()) as WorkspaceDirectoryResponse;
@@ -704,8 +767,9 @@ export function EntryNavRail({
       setWorkspaceItems(items);
     } catch {
       // A failed revalidation must not blank a list the user is looking at —
-      // keep the last known names and let the next open try again.
-      if (cachedWorkspaceDirectory === null) setWorkspaceItems([]);
+      // keep the last known names and let the next open try again. A list this
+      // caller has no claim to is not "a list the user is looking at".
+      if (attributableWorkspaceDirectory(context) === null) setWorkspaceItems([]);
     } finally {
       setWorkspaceDirectoryLoading(false);
     }
@@ -723,7 +787,13 @@ export function EntryNavRail({
       if (!response.ok) return;
       const body = (await response.json()) as WorkspaceActiveResponse;
       setTeamOpen(false);
-      notifyWorkspaceContextRefresh();
+      // Seed the shell from the switch response rather than making every
+      // consumer re-read it: the daemon builds this `context` from the same
+      // `workspaceContext.current()` call `GET /api/workspace/context` serves,
+      // and only answers 200 once it agrees the active workspace really moved.
+      notifyWorkspaceContextRefresh(
+        body?.context ? { context: body.context } : null,
+      );
       notifyWorkspaceBillingRefresh();
       notifyTeamProjectsChanged();
       selectView('home');
@@ -764,6 +834,28 @@ export function EntryNavRail({
     if (!teamOpen) return;
     void loadWorkspaceDirectory();
   }, [teamOpen]);
+
+  // This rail can outlive the identity that filled its list: an account swap
+  // (sign out, sign in as someone else) does not necessarily unmount it, and
+  // then component state would keep the previous account's names even though the
+  // module cache is re-attributed on every read.
+  //
+  // So on each identity change, re-derive the list from the cache UNDER THE
+  // INCOMING IDENTITY. A list the new identity can claim survives (the common
+  // case: the same account moving between its own workspaces); one it cannot is
+  // dropped, and the next open refetches. Re-deriving on the identity edge — not
+  // on every render where attribution happens to fail — is what keeps a freshly
+  // read list stable afterwards instead of being cleared again on the next pass.
+  const railIdentity = workspaceIdentityCacheKey(context);
+  const lastRailIdentityRef = useRef(railIdentity);
+  useEffect(() => {
+    if (lastRailIdentityRef.current === railIdentity) return;
+    lastRailIdentityRef.current = railIdentity;
+    setWorkspaceItems(attributableWorkspaceDirectory(context) ?? []);
+    // `context` is read only to re-attribute the cache for `railIdentity`, which
+    // is its digest — depending on the object would re-run this on every poll.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [railIdentity]);
 
   return (
     <nav

--- a/apps/web/tests/collab/workspace-identity-key-is-total.test.ts
+++ b/apps/web/tests/collab/workspace-identity-key-is-total.test.ts
@@ -1,0 +1,66 @@
+// Computing a workspace identity must be TOTAL — it may never throw.
+//
+// `workspaceIdentityCacheKey` used to dereference `context.permissions`
+// unguarded. That was survivable while it was only called during render (a throw
+// there fails loudly, in the right place) and inside `fetchSkills`'s own
+// try/catch. It stopped being survivable once `beginWorkspaceScopedRead` put it
+// on ASYNC CONTINUATIONS: a late `isStillCurrent(...)` that throws does not
+// surface as a handled error but as an unhandled rejection from whatever promise
+// happened to be settling — which, in CI, killed the web suite with
+// `TypeError: Cannot read properties of undefined (reading 'canShareProjects')`
+// AFTER all 555 files had passed, so every test was green and the process still
+// exited 1.
+//
+// `permissions` is required on the contract, so an absent one means a partial or
+// malformed context. That is a normal state to be asked about (a signed-out or
+// still-resolving caller, or a partial fixture), and the honest answer is a
+// distinct cache partition — never an exception.
+
+import { describe, expect, it } from 'vitest';
+import type { WorkspaceCollabContext } from '@open-design/contracts';
+
+import {
+  beginWorkspaceScopedRead,
+  workspaceIdentityCacheKey,
+} from '../../src/collab/useWorkspaceContext';
+
+/** A context missing `permissions` entirely — the shape many fixtures build. */
+const partial = { workspaceId: 'ws-1', workspaceMemberId: 'wm-1' } as unknown as
+  WorkspaceCollabContext;
+
+const complete = {
+  workspaceId: 'ws-1',
+  workspaceType: 'team',
+  workspaceMemberId: 'wm-1',
+  role: 'owner',
+  memberStatus: 'active',
+  lifecycleState: 'active',
+  permissions: { canShareProjects: true, canWriteSyncedFiles: true },
+} as unknown as WorkspaceCollabContext;
+
+describe('workspaceIdentityCacheKey is total', () => {
+  it('computes a key for a context with no permissions instead of throwing', () => {
+    expect(() => workspaceIdentityCacheKey(partial)).not.toThrow();
+    expect(typeof workspaceIdentityCacheKey(partial)).toBe('string');
+  });
+
+  it('keeps null, partial and complete contexts in distinct partitions', () => {
+    const none = workspaceIdentityCacheKey(null);
+    expect(none).toBe('none');
+    expect(workspaceIdentityCacheKey(partial)).not.toBe(none);
+    expect(workspaceIdentityCacheKey(partial)).not.toBe(workspaceIdentityCacheKey(complete));
+  });
+
+  // The path that actually broke CI: the guard runs long after the request, so
+  // it must tolerate whatever context is current by then.
+  it('lets a late commit-time guard compare a partial context without throwing', () => {
+    const read = beginWorkspaceScopedRead(complete);
+    expect(() => read.isStillCurrent(partial)).not.toThrow();
+    expect(read.isStillCurrent(partial)).toBe(false);
+    expect(read.isStillCurrent(complete)).toBe(true);
+
+    const fromPartial = beginWorkspaceScopedRead(partial);
+    expect(() => fromPartial.isStillCurrent(undefined)).not.toThrow();
+    expect(fromPartial.isStillCurrent(partial)).toBe(true);
+  });
+});

--- a/apps/web/tests/components/App.skills-workspace-scope.test.tsx
+++ b/apps/web/tests/components/App.skills-workspace-scope.test.tsx
@@ -1,0 +1,244 @@
+// @vitest-environment jsdom
+//
+// The app-level skills list must be read under the caller's workspace identity,
+// and re-read when that identity changes.
+//
+// `fetchSkills(workspaceContext)` exists to attach `workspaceProjectHeaders` so
+// the daemon's `GET /api/skills` can apply `skillVisibleFromWorkspace`. Two
+// callers pass it (SkillsSection, ExtensionsMarketplace); App.tsx's three did
+// not — and the daemon's rule is FAIL-CLOSED on a missing `x-od-workspace-id`
+// (`skills.ts`: `if (!scopeId) return !ownerId;`), not "unfiltered". So a
+// headerless read does not return everything; it returns everything EXCEPT the
+// claimed skills — hiding a skill from the very workspace that claimed it.
+//
+// Second half of the same defect: nothing refetched skills when the active
+// workspace changed. Design systems got exactly this effect (App.tsx, keyed on
+// `workspaceContext?.workspaceId`) because the switcher lives ON the home view,
+// so `route.kind` stays 'home' and no route change fires. Skills never did.
+
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { App } from '../../src/App';
+import type { AppConfig, Project } from '../../src/types';
+import {
+  fetchComposioConfigFromDaemon,
+  fetchDaemonConfig,
+  loadConfig,
+  mergeDaemonConfig,
+} from '../../src/state/config';
+import {
+  daemonIsLive,
+  fetchAgentsStream,
+  fetchAppVersionInfo,
+  fetchDesignSystems,
+  fetchDesignTemplates,
+  fetchPromptTemplates,
+  fetchSkills,
+} from '../../src/providers/registry';
+import { listProjects, listTemplates } from '../../src/state/projects';
+import {
+  notifyWorkspaceContextRefresh,
+  resetTeamProjectsCache,
+  resetWorkspaceContextCache,
+} from '../../src/collab/useWorkspaceContext';
+import { resetCoalescedGet } from '../../src/lib/coalesced-get';
+
+vi.mock('../../src/components/EntryView', () => ({
+  EntryView: () => <main><div data-testid="entry-home-surface" /></main>,
+}));
+
+vi.mock('../../src/components/ProjectView', () => ({
+  ProjectView: () => <main data-testid="project-view" />,
+}));
+
+vi.mock('../../src/components/WorkspaceTabsBar', () => ({
+  WorkspaceTabsBar: () => null,
+  openWorkspaceTab: () => {},
+}));
+
+vi.mock('../../src/components/pet/PetOverlay', () => ({
+  PetOverlay: () => null,
+}));
+
+vi.mock('../../src/components/pet/pets', () => ({
+  migrateCustomPetAtlas: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../../src/components/SettingsDialog', () => ({
+  SettingsDialog: () => null,
+  switchApiProtocolConfig: (config: AppConfig) => config,
+  updateCurrentApiProtocolConfig: (config: AppConfig) => config,
+}));
+
+vi.mock('../../src/providers/registry', async () => {
+  const actual = await vi.importActual<typeof import('../../src/providers/registry')>(
+    '../../src/providers/registry',
+  );
+  return {
+    ...actual,
+    daemonIsLive: vi.fn(),
+    fetchAgentsStream: vi.fn(),
+    fetchAppVersionInfo: vi.fn(),
+    fetchDesignSystems: vi.fn(),
+    fetchDesignTemplates: vi.fn(),
+    fetchPromptTemplates: vi.fn(),
+    fetchSkills: vi.fn(),
+  };
+});
+
+vi.mock('../../src/state/projects', async () => {
+  const actual = await vi.importActual<typeof import('../../src/state/projects')>(
+    '../../src/state/projects',
+  );
+  return {
+    ...actual,
+    listProjects: vi.fn(),
+    listTemplates: vi.fn(),
+  };
+});
+
+vi.mock('../../src/state/config', async () => {
+  const actual = await vi.importActual<typeof import('../../src/state/config')>(
+    '../../src/state/config',
+  );
+  return {
+    ...actual,
+    fetchDaemonConfig: vi.fn().mockResolvedValue({}),
+    fetchComposioConfigFromDaemon: vi.fn().mockResolvedValue(null),
+    loadConfig: vi.fn(),
+    mergeDaemonConfig: vi.fn(),
+    saveConfig: vi.fn(),
+    syncComposioConfigToDaemon: vi.fn().mockResolvedValue(true),
+    syncConfigToDaemon: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+const baseConfig: AppConfig = {
+  mode: 'daemon',
+  apiKey: '',
+  apiProtocol: 'anthropic',
+  apiVersion: '',
+  baseUrl: 'https://api.anthropic.com',
+  model: 'claude-sonnet-4-5',
+  apiProviderBaseUrl: 'https://api.anthropic.com',
+  apiProtocolConfigs: {},
+  agentId: 'codex',
+  skillId: null,
+  designSystemId: null,
+  onboardingCompleted: true,
+  privacyDecisionAt: 1778244000000,
+  mediaProviders: {},
+  composio: {},
+  agentModels: {},
+  agentCliEnv: {},
+};
+
+function workspaceContextPayload(workspaceId: string) {
+  return {
+    context: {
+      workspaceId,
+      workspaceType: 'team',
+      workspaceMemberId: `member-${workspaceId}`,
+      role: 'member',
+      memberStatus: 'active',
+      lifecycleState: 'active',
+      billingState: 'active',
+      planId: null,
+      providerMode: 'platform_credits',
+      seatSummary: { seatLimit: 5, usedSeats: 1, availableSeats: 4, isSeatFull: false },
+      permissions: {
+        canManageMembers: false,
+        canManageBilling: false,
+        canInviteMembers: false,
+        canManageAutoRecharge: false,
+        canShareProjects: true,
+        canWriteSyncedFiles: true,
+        canViewWorkspaceSettings: false,
+        canManageSharedResources: false,
+      },
+      displayName: workspaceId,
+    },
+  };
+}
+
+/** Workspace ids `fetchSkills` was called for, in order. `undefined` marks a
+ *  headerless read — the fail-closed one that hides claimed skills. */
+function skillsReadScopes(): Array<string | undefined> {
+  return vi
+    .mocked(fetchSkills)
+    .mock.calls.map(([context]) => context?.workspaceId ?? undefined);
+}
+
+const projects: Project[] = [];
+
+describe('App skills list — workspace scope', () => {
+  beforeEach(() => {
+    resetWorkspaceContextCache();
+    resetTeamProjectsCache();
+    resetCoalescedGet();
+    window.history.replaceState(null, '', '/');
+    vi.mocked(daemonIsLive).mockResolvedValue(true);
+    vi.mocked(fetchAgentsStream).mockResolvedValue([]);
+    vi.mocked(fetchSkills).mockResolvedValue([]);
+    vi.mocked(fetchDesignTemplates).mockResolvedValue([]);
+    vi.mocked(fetchDesignSystems).mockResolvedValue([]);
+    vi.mocked(fetchPromptTemplates).mockResolvedValue([]);
+    vi.mocked(fetchAppVersionInfo).mockResolvedValue(null);
+    vi.mocked(listProjects).mockResolvedValue(projects);
+    vi.mocked(listTemplates).mockResolvedValue([]);
+    vi.mocked(fetchDaemonConfig).mockResolvedValue({});
+    vi.mocked(fetchComposioConfigFromDaemon).mockResolvedValue(null);
+    vi.mocked(mergeDaemonConfig).mockImplementation((local) => local);
+    vi.mocked(loadConfig).mockReturnValue({ ...baseConfig });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    resetWorkspaceContextCache();
+    resetTeamProjectsCache();
+    resetCoalescedGet();
+  });
+
+  it('reads skills under the active workspace identity, once, and again on a switch', async () => {
+    let activeWorkspaceId = 'ws-a';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const pathname = new URL(String(input), 'http://d.local').pathname;
+        return {
+          ok: true,
+          json: async () =>
+            pathname.endsWith('/workspace/context')
+              ? workspaceContextPayload(activeWorkspaceId)
+              : {},
+        } as Response;
+      }),
+    );
+
+    render(<App />);
+    await waitFor(() => expect(screen.getByTestId('entry-home-surface')).toBeTruthy());
+
+    // Startup: the skills list is read for the workspace that is actually
+    // active — not headerless, which the daemon answers by hiding every
+    // claimed skill.
+    await waitFor(() => expect(skillsReadScopes()).toContain('ws-a'));
+
+    // …and exactly once. A boot read plus a workspace-keyed read would be a
+    // second request on the startup path.
+    expect(skillsReadScopes()).toEqual(['ws-a']);
+
+    // The switch: the switcher lives on the home view, so no route change
+    // fires. Only a workspace-keyed refresh can correct the list.
+    activeWorkspaceId = 'ws-b';
+    await act(async () => {
+      notifyWorkspaceContextRefresh();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(skillsReadScopes()).toContain('ws-b'));
+    expect(skillsReadScopes()).toEqual(['ws-a', 'ws-b']);
+  });
+});

--- a/apps/web/tests/components/App.skills-workspace-scope.test.tsx
+++ b/apps/web/tests/components/App.skills-workspace-scope.test.tsx
@@ -142,12 +142,12 @@ const baseConfig: AppConfig = {
   agentCliEnv: {},
 };
 
-function workspaceContextPayload(workspaceId: string) {
+function workspaceContextPayload(workspaceId: string, workspaceMemberId?: string) {
   return {
     context: {
       workspaceId,
       workspaceType: 'team',
-      workspaceMemberId: `member-${workspaceId}`,
+      workspaceMemberId: workspaceMemberId ?? `member-${workspaceId}`,
       role: 'member',
       memberStatus: 'active',
       lifecycleState: 'active',
@@ -321,6 +321,78 @@ describe('App skills list — workspace scope', () => {
     });
 
     expect(screen.getByTestId('entry-skill-skill-from-b')).toBeTruthy();
+    expect(screen.queryByTestId('entry-skill-skill-from-a')).toBeNull();
+  });
+
+  // A guard that discards without guaranteeing a successor is worse than the
+  // staleness it replaces: the list can be left loading forever.
+  //
+  // The commit guard compares `workspaceIdentityCacheKey`, which includes the
+  // MEMBER id — so two accounts active in the same shared team workspace are two
+  // identities even though `workspaceId` never changes. A trigger keyed only on
+  // `workspaceId` would discard account A's pending response and then suppress
+  // account B's replacement read, because the workspace id it watched did not
+  // move.
+  it('starts and completes a successor read when only the member id changes', async () => {
+    let memberId = 'member-a';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const pathname = new URL(String(input), 'http://d.local').pathname;
+        return {
+          ok: true,
+          json: async () =>
+            pathname.endsWith('/workspace/context')
+              ? workspaceContextPayload('ws-shared-team', memberId)
+              : {},
+        } as Response;
+      }),
+    );
+
+    const readA = deferred<SkillSummary[]>();
+    const readB = deferred<SkillSummary[]>();
+    vi.mocked(fetchSkills).mockImplementation((context) =>
+      context?.workspaceMemberId === 'member-b' ? readB.promise : readA.promise,
+    );
+
+    render(<App />);
+    await waitFor(() =>
+      expect(
+        vi.mocked(fetchSkills).mock.calls.some(
+          ([c]) => c?.workspaceMemberId === 'member-a',
+        ),
+      ).toBe(true),
+    );
+
+    // Same workspace, different account. A's read is still in flight.
+    memberId = 'member-b';
+    await act(async () => {
+      notifyWorkspaceContextRefresh();
+      await Promise.resolve();
+    });
+
+    // A successor read must START for B…
+    await waitFor(() =>
+      expect(
+        vi.mocked(fetchSkills).mock.calls.some(
+          ([c]) => c?.workspaceMemberId === 'member-b',
+        ),
+      ).toBe(true),
+    );
+
+    // …A's late answer is discarded…
+    await act(async () => {
+      readA.resolve([skill('skill-from-a')]);
+      await Promise.resolve();
+    });
+    expect(screen.queryByTestId('entry-skill-skill-from-a')).toBeNull();
+
+    // …and B's answer COMPLETES, so the registry is not left loading forever.
+    await act(async () => {
+      readB.resolve([skill('skill-from-b')]);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(screen.getByTestId('entry-skill-skill-from-b')).toBeTruthy());
     expect(screen.queryByTestId('entry-skill-skill-from-a')).toBeNull();
   });
 });

--- a/apps/web/tests/components/App.skills-workspace-scope.test.tsx
+++ b/apps/web/tests/components/App.skills-workspace-scope.test.tsx
@@ -17,6 +17,7 @@
 // so `route.kind` stays 'home' and no route change fires. Skills never did.
 
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import type { SkillSummary } from '@open-design/contracts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { App } from '../../src/App';
@@ -45,7 +46,14 @@ import {
 import { resetCoalescedGet } from '../../src/lib/coalesced-get';
 
 vi.mock('../../src/components/EntryView', () => ({
-  EntryView: () => <main><div data-testid="entry-home-surface" /></main>,
+  EntryView: ({ skills }: { skills: Array<{ id: string }> }) => (
+    <main>
+      <div data-testid="entry-home-surface" />
+      {skills.map((skill) => (
+        <div key={skill.id} data-testid={`entry-skill-${skill.id}`} />
+      ))}
+    </main>
+  ),
 }));
 
 vi.mock('../../src/components/ProjectView', () => ({
@@ -172,6 +180,25 @@ function skillsReadScopes(): Array<string | undefined> {
 
 const projects: Project[] = [];
 
+function skill(id: string): SkillSummary {
+  return {
+    id,
+    name: id,
+    description: id,
+    triggers: [],
+    mode: 'prototype',
+    source: 'user',
+  } as unknown as SkillSummary;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 describe('App skills list — workspace scope', () => {
   beforeEach(() => {
     resetWorkspaceContextCache();
@@ -240,5 +267,60 @@ describe('App skills list — workspace scope', () => {
 
     await waitFor(() => expect(skillsReadScopes()).toContain('ws-b'));
     expect(skillsReadScopes()).toEqual(['ws-a', 'ws-b']);
+  });
+
+  // Issuing the right request is only half the guarantee. Each read resolves
+  // later, and nothing stopped a read issued FOR the workspace the user has
+  // since left from committing when it finally landed — restoring that
+  // workspace's catalog over the current one, which is the very staleness this
+  // change exists to remove, arriving through the back door.
+  it("discards a slow read belonging to the workspace the user has left", async () => {
+    let activeWorkspaceId = 'ws-a';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const pathname = new URL(String(input), 'http://d.local').pathname;
+        return {
+          ok: true,
+          json: async () =>
+            pathname.endsWith('/workspace/context')
+              ? workspaceContextPayload(activeWorkspaceId)
+              : {},
+        } as Response;
+      }),
+    );
+
+    const readA = deferred<SkillSummary[]>();
+    const readB = deferred<SkillSummary[]>();
+    vi.mocked(fetchSkills).mockImplementation((context) =>
+      context?.workspaceId === 'ws-b' ? readB.promise : readA.promise,
+    );
+
+    render(<App />);
+    await waitFor(() => expect(skillsReadScopes()).toContain('ws-a'));
+
+    // Switch while ws-a's read is still in flight.
+    activeWorkspaceId = 'ws-b';
+    await act(async () => {
+      notifyWorkspaceContextRefresh();
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(skillsReadScopes()).toContain('ws-b'));
+
+    // Reverse order: the workspace the user is actually IN answers first…
+    await act(async () => {
+      readB.resolve([skill('skill-from-b')]);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(screen.getByTestId('entry-skill-skill-from-b')).toBeTruthy());
+
+    // …and the abandoned workspace answers second. It must change nothing.
+    await act(async () => {
+      readA.resolve([skill('skill-from-a')]);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('entry-skill-skill-from-b')).toBeTruthy();
+    expect(screen.queryByTestId('entry-skill-skill-from-a')).toBeNull();
   });
 });

--- a/apps/web/tests/components/EntryNavRail.directory-account-scope.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.directory-account-scope.test.tsx
@@ -16,7 +16,7 @@
 // ACCOUNT see", so it is exactly the class of read `workspaceIdentityCacheKey`
 // warns about: a cache coarser than the identity of the request it holds.
 
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import type { WorkspaceCollabContext } from '@open-design/contracts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -173,6 +173,51 @@ describe('workspace switcher directory — account scope', () => {
     // Once B's read lands, B's own workspaces appear.
     gate.releaseAll();
     await waitFor(() => expect(menu().getByText('Bruno private workspace')).toBeTruthy());
+    expect(menu().queryByText('Ada private workspace')).toBeNull();
+  });
+
+  // The identity-scoped cache key stops a cached answer being SERVED to the
+  // wrong identity. It does nothing about a request already in flight when the
+  // identity moves: that response lands afterwards and used to be written
+  // straight into both the module cache and component state, repopulating
+  // account A's names after the identity-change effect had cleared them.
+  it("discards an in-flight read that lands after the account changed", async () => {
+    const gate = installGatedFetch(() => ACCOUNT_A_DIRECTORY);
+
+    const view = renderRail(contextFor('wm-a-team'));
+    fireEvent.click(screen.getByTestId('workspace-switcher'));
+
+    // A's read is in flight and deliberately NOT released yet. Swap the account
+    // underneath the mounted rail (sign out, sign in as someone else) — no
+    // unmount, which is what leaves the pending request pointing at A.
+    view.rerender(
+      <I18nProvider initial="en">
+        <EntryNavRail
+          view="home"
+          onViewChange={() => {}}
+          onNewProject={() => {}}
+          open
+          context={contextFor('wm-b-team')}
+        />
+      </I18nProvider>,
+    );
+
+    // Now let A's request answer, after the identity has already moved.
+    await act(async () => {
+      gate.releaseAll();
+      await Promise.resolve();
+    });
+
+    // Component state must not have taken A's names.
+    expect(menu().queryByText('Ada private workspace')).toBeNull();
+
+    // …and the module cache must not have taken them either. Observed by
+    // remounting as A with a read that never answers: an abandoned response
+    // leaves no trace, so there is no warm list to serve even to A.
+    view.unmount();
+    installGatedFetch(() => ACCOUNT_A_DIRECTORY);
+    renderRail(contextFor('wm-a-team'));
+    fireEvent.click(screen.getByTestId('workspace-switcher'));
     expect(menu().queryByText('Ada private workspace')).toBeNull();
   });
 

--- a/apps/web/tests/components/EntryNavRail.directory-account-scope.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.directory-account-scope.test.tsx
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+//
+// The workspace switcher's module-level directory cache must never paint one
+// account's workspace names under another account's identity.
+//
+// `cachedWorkspaceDirectory` deliberately survives the rail unmounting, so the
+// switcher does not flash a loading row on every open (see
+// `EntryNavRail.workspace-directory.test.tsx` for the behavior it protects).
+// What it lacked was INVALIDATION: nothing cleared it when the signed-in
+// account changed, and `resetWorkspaceDirectoryCache` had no production caller
+// at all — only tests. So signing out and back in as a different account left
+// the previous account's workspace list on screen, presented confidently (no
+// loading row) because the cache was non-empty.
+//
+// `/api/workspace/directory` answers "which workspaces can the SIGNED-IN
+// ACCOUNT see", so it is exactly the class of read `workspaceIdentityCacheKey`
+// warns about: a cache coarser than the identity of the request it holds.
+
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import type { WorkspaceCollabContext } from '@open-design/contracts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EntryNavRail, resetWorkspaceDirectoryCache } from '../../src/components/EntryNavRail';
+import { I18nProvider } from '../../src/i18n';
+
+/**
+ * Account A sees a shared team workspace plus its own personal one. Every item
+ * carries the `workspaceMemberId` of the membership that produced it — which is
+ * what makes the list attributable to one account.
+ */
+const ACCOUNT_A_DIRECTORY = [
+  {
+    workspaceId: 'ws-shared-team',
+    workspaceName: 'Shared Team',
+    workspaceType: 'team',
+    workspaceMemberId: 'wm-a-team',
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+  },
+  {
+    workspaceId: 'ws-personal-a',
+    workspaceName: 'Ada private workspace',
+    workspaceType: 'personal',
+    workspaceMemberId: 'wm-a-personal',
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+  },
+];
+
+/** Account B is a member of the SAME team workspace, under its own membership. */
+const ACCOUNT_B_DIRECTORY = [
+  {
+    workspaceId: 'ws-shared-team',
+    workspaceName: 'Shared Team',
+    workspaceType: 'team',
+    workspaceMemberId: 'wm-b-team',
+    role: 'member',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+  },
+  {
+    workspaceId: 'ws-personal-b',
+    workspaceName: 'Bruno private workspace',
+    workspaceType: 'personal',
+    workspaceMemberId: 'wm-b-personal',
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+  },
+];
+
+function contextFor(workspaceMemberId: string): WorkspaceCollabContext {
+  return {
+    workspaceId: 'ws-shared-team',
+    workspaceType: 'team',
+    workspaceMemberId,
+    teamName: 'Shared Team',
+    workspaceName: 'Shared Team',
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+    billingState: 'active',
+    seatSummary: { availableSeats: 2 },
+    permissions: {
+      canInviteMembers: true,
+      canManageBilling: true,
+      canViewWorkspaceSettings: true,
+      canShareProjects: true,
+      canWriteSyncedFiles: true,
+    },
+    workspaceSettingsUrl: 'https://example.com/console/settings?workspaceId=ws-shared-team',
+  } as unknown as WorkspaceCollabContext;
+}
+
+const originalFetch = globalThis.fetch;
+
+/** Directory reads resolve only when released, so "before the network answers" is observable. */
+function installGatedFetch(items: () => unknown[]) {
+  const releases: Array<() => void> = [];
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes('/api/workspace/directory')) {
+      await new Promise<void>((resolve) => releases.push(resolve));
+      return new Response(JSON.stringify({ items: items() }), { status: 200 });
+    }
+    return new Response(JSON.stringify({}), { status: 200 });
+  }) as typeof fetch;
+  return {
+    releaseAll: () => {
+      for (const r of releases.splice(0)) r();
+    },
+  };
+}
+
+function menu() {
+  const el = document.querySelector('.entry-nav-rail__team-menu');
+  if (!el) throw new Error('switcher menu is not open');
+  return within(el as HTMLElement);
+}
+
+function renderRail(context: WorkspaceCollabContext) {
+  return render(
+    <I18nProvider initial="en">
+      <EntryNavRail
+        view="home"
+        onViewChange={() => {}}
+        onNewProject={() => {}}
+        open
+        context={context}
+      />
+    </I18nProvider>,
+  );
+}
+
+beforeEach(() => {
+  resetWorkspaceDirectoryCache();
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = originalFetch;
+  resetWorkspaceDirectoryCache();
+  vi.restoreAllMocks();
+});
+
+describe('workspace switcher directory — account scope', () => {
+  it("never paints the previous account's workspaces after an account change", async () => {
+    let directory: unknown[] = ACCOUNT_A_DIRECTORY;
+    const gate = installGatedFetch(() => directory);
+
+    // Account A opens the switcher and the directory lands: the cache is warm.
+    const accountA = renderRail(contextFor('wm-a-team'));
+    fireEvent.click(screen.getByTestId('workspace-switcher'));
+    gate.releaseAll();
+    await waitFor(() => expect(menu().getByText('Ada private workspace')).toBeTruthy());
+
+    // Sign out, sign in as account B. Same shared team workspace, different
+    // membership — the identity the cache was filled under is gone.
+    accountA.unmount();
+    directory = ACCOUNT_B_DIRECTORY;
+    renderRail(contextFor('wm-b-team'));
+    fireEvent.click(screen.getByTestId('workspace-switcher'));
+
+    // Before B's own read answers, the rail must not present A's private
+    // workspace as one of B's. What it falls back to is the one workspace it can
+    // still attribute to B: the active one, named from B's own context.
+    expect(menu().queryByText('Ada private workspace')).toBeNull();
+    expect(menu().getByRole('menuitem', { name: /Shared Team/ })).toBeTruthy();
+    expect(menu().queryAllByRole('menuitem', { name: /workspace$/ })).toHaveLength(0);
+
+    // Once B's read lands, B's own workspaces appear.
+    gate.releaseAll();
+    await waitFor(() => expect(menu().getByText('Bruno private workspace')).toBeTruthy());
+    expect(menu().queryByText('Ada private workspace')).toBeNull();
+  });
+
+  it('still serves the warm list across a same-account workspace switch', async () => {
+    const gate = installGatedFetch(() => ACCOUNT_A_DIRECTORY);
+
+    const first = renderRail(contextFor('wm-a-team'));
+    fireEvent.click(screen.getByTestId('workspace-switcher'));
+    gate.releaseAll();
+    await waitFor(() => expect(menu().getByText('Ada private workspace')).toBeTruthy());
+
+    // The same account moving to its OTHER workspace is not an account change:
+    // its own membership is still in the cached list, so the switcher must keep
+    // showing the names immediately — no loading row. This is the behavior the
+    // module-level cache exists for, and the account fix must not cost it.
+    first.unmount();
+    renderRail({
+      ...contextFor('wm-a-personal'),
+      workspaceId: 'ws-personal-a',
+      workspaceType: 'personal',
+    } as unknown as WorkspaceCollabContext);
+    fireEvent.click(screen.getByTestId('workspace-switcher'));
+
+    expect(menu().getByText('Ada private workspace')).toBeTruthy();
+    expect(menu().queryByRole('status')).toBeNull();
+
+    gate.releaseAll();
+  });
+});

--- a/apps/web/tests/components/EntryNavRail.switch-seeds-context.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.switch-seeds-context.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+//
+// `PUT /api/workspace/active` already returns the new `WorkspaceCollabContext`
+// (`WorkspaceActiveResponse.context`), produced by the very same
+// `workspaceContext.current()` call that `GET /api/workspace/context` serves —
+// and the route only returns 200 after asserting `context.workspaceId` equals
+// the requested workspace. The client parsed that body and threw it away, then
+// called `notifyWorkspaceContextRefresh()` so every mounted consumer went and
+// GET the same data again.
+//
+// Two costs: a wasted round-trip on the switch path, and the extra beat the user
+// sees — the UI waits for request #2 for something request #1 already answered.
+//
+// The fix seeds the shell from the response. The refresh broadcast still fires,
+// because `useProjectWorkspaceScope` listens to it to revalidate the project
+// scope and passive tabs (which cannot be seeded) still need to re-read.
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { WorkspaceCollabContext } from '@open-design/contracts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EntryNavRail, resetWorkspaceDirectoryCache } from '../../src/components/EntryNavRail';
+import {
+  resetWorkspaceContextCache,
+  useWorkspaceContext,
+} from '../../src/collab/useWorkspaceContext';
+import { resetCoalescedGet } from '../../src/lib/coalesced-get';
+import { I18nProvider } from '../../src/i18n';
+
+const DIRECTORY = [
+  {
+    workspaceId: 'ws-a',
+    workspaceName: 'Workspace A',
+    workspaceType: 'team',
+    workspaceMemberId: 'wm-a',
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+  },
+  {
+    workspaceId: 'ws-b',
+    workspaceName: 'Workspace B',
+    workspaceType: 'team',
+    workspaceMemberId: 'wm-b',
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+  },
+];
+
+function contextFor(workspaceId: string, workspaceMemberId: string): WorkspaceCollabContext {
+  return {
+    workspaceId,
+    workspaceType: 'team',
+    workspaceMemberId,
+    workspaceName: workspaceId === 'ws-a' ? 'Workspace A' : 'Workspace B',
+    teamName: workspaceId === 'ws-a' ? 'Workspace A' : 'Workspace B',
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+    billingState: 'active',
+    planId: null,
+    providerMode: 'platform_credits',
+    seatSummary: { seatLimit: 5, usedSeats: 1, availableSeats: 4, isSeatFull: false },
+    permissions: {
+      canManageMembers: true,
+      canManageBilling: true,
+      canInviteMembers: true,
+      canManageAutoRecharge: true,
+      canShareProjects: true,
+      canWriteSyncedFiles: true,
+      canViewWorkspaceSettings: true,
+      canManageSharedResources: true,
+    },
+  } as unknown as WorkspaceCollabContext;
+}
+
+/** Renders what the shell would: a context consumer next to the rail. */
+function Harness() {
+  const { context } = useWorkspaceContext();
+  return (
+    <I18nProvider initial="en">
+      <div data-testid="observed-workspace">{context?.workspaceId ?? 'none'}</div>
+      <EntryNavRail
+        view="home"
+        onViewChange={() => {}}
+        onNewProject={() => {}}
+        open
+        context={contextFor('ws-a', 'wm-a')}
+      />
+    </I18nProvider>
+  );
+}
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  resetWorkspaceDirectoryCache();
+  resetWorkspaceContextCache();
+  resetCoalescedGet();
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = originalFetch;
+  resetWorkspaceDirectoryCache();
+  resetWorkspaceContextCache();
+  resetCoalescedGet();
+  vi.restoreAllMocks();
+});
+
+describe('workspace switch — seeding the context from the PUT response', () => {
+  it('adopts the switch response instead of re-reading the context', async () => {
+    let activeWorkspaceId = 'ws-a';
+    const paths: string[] = [];
+
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(String(input), 'http://d.local');
+      paths.push(`${init?.method ?? 'GET'} ${url.pathname}`);
+      if (url.pathname === '/api/workspace/directory') {
+        return new Response(JSON.stringify({ items: DIRECTORY, activeWorkspaceId }), {
+          status: 200,
+        });
+      }
+      if (url.pathname === '/api/workspace/context') {
+        return new Response(
+          JSON.stringify({ context: contextFor(activeWorkspaceId, `wm-${activeWorkspaceId}`) }),
+          { status: 200 },
+        );
+      }
+      if (url.pathname === '/api/workspace/active') {
+        activeWorkspaceId = 'ws-b';
+        return new Response(
+          JSON.stringify({
+            activeWorkspaceId: 'ws-b',
+            context: contextFor('ws-b', 'wm-b'),
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    }) as typeof fetch;
+
+    render(<Harness />);
+    await waitFor(() =>
+      expect(screen.getByTestId('observed-workspace').textContent).toBe('ws-a'),
+    );
+
+    fireEvent.click(screen.getByTestId('workspace-switcher'));
+    await waitFor(() => expect(screen.getByText('Workspace B')).toBeTruthy());
+
+    const contextGetsBeforeSwitch = paths.filter(
+      (entry) => entry === 'GET /api/workspace/context',
+    ).length;
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Workspace B' }));
+      await Promise.resolve();
+    });
+
+    // The shell must reflect the new workspace — from the PUT body.
+    await waitFor(() =>
+      expect(screen.getByTestId('observed-workspace').textContent).toBe('ws-b'),
+    );
+
+    expect(paths.filter((entry) => entry === 'PUT /api/workspace/active')).toHaveLength(1);
+
+    // …and it must not have spent a second round-trip asking for what the PUT
+    // just returned.
+    const contextGetsAfterSwitch = paths.filter(
+      (entry) => entry === 'GET /api/workspace/context',
+    ).length;
+    expect(contextGetsAfterSwitch).toBe(contextGetsBeforeSwitch);
+  });
+});

--- a/apps/web/tests/components/EntryNavRail.workspace-directory.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.workspace-directory.test.tsx
@@ -12,9 +12,26 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EntryNavRail, resetWorkspaceDirectoryCache } from '../../src/components/EntryNavRail';
 import { I18nProvider } from '../../src/i18n';
 
+// `workspaceMemberId` is required on `WorkspaceDirectoryItem` and every real
+// daemon response carries it. It matters here because the module-level cache is
+// only served to the account it was filled under, and a membership id is what
+// identifies that account (see `workspaceDirectoryBelongsTo`) — so a fixture
+// without it cannot be attributed to `teamContext()` and would never be reused.
 const DIRECTORY = [
-  { workspaceId: 'ws-team', workspaceName: 'OD Feature Team', workspaceType: 'team', role: 'owner' },
-  { workspaceId: 'ws-personal', workspaceName: 'My Workspace2', workspaceType: 'personal', role: 'owner' },
+  {
+    workspaceId: 'ws-team',
+    workspaceName: 'OD Feature Team',
+    workspaceType: 'team',
+    workspaceMemberId: 'wm-1',
+    role: 'owner',
+  },
+  {
+    workspaceId: 'ws-personal',
+    workspaceName: 'My Workspace2',
+    workspaceType: 'personal',
+    workspaceMemberId: 'wm-1-personal',
+    role: 'owner',
+  },
 ];
 
 function teamContext(): WorkspaceCollabContext {


### PR DESCRIPTION
## Why

Three defects found while auditing workspace-scoped reads in `apps/web`, all one family: **data scoped to an account or a workspace goes stale, or is read under the wrong identity.** They share two files, so they ship together rather than as three conflicting PRs.

The pain is the same shape in all three — the client shows data it has no standing to show, or shows the previous scope's data as if it were the current one's. Two of them are silent (nothing errors; the wrong names/list just sit there), which is why they survived this long.

## What users will see

- **Switching accounts no longer leaves the previous account's workspaces in the switcher.** Sign out, sign in as someone else, open the workspace switcher: it used to list the *previous* account's workspaces, with no loading state, until a background read replaced them. Now it shows only the workspace it can actually attribute to you (the active one, from your own context) until your own list lands.
- **The Skills list now reflects the workspace you are in.** Previously a skill imported into your workspace could be *missing* from the Skills list — and switching workspaces never refreshed the list at all, so you kept looking at the previous workspace's catalog until a full reload.
- **Switching workspaces is one beat faster.** The switch used to make a second round-trip to fetch data the switch response already contained. It now uses that response directly.

No layout, styling, or copy changes. No new strings.

### The one loading-state change, called out explicitly

Item ② moves the launch-time `/api/skills` read from the boot pass to a workspace-keyed effect that waits for `/api/workspace/context` to settle — because that read carries the caller's identity in request *headers*, and there is nothing correct to send before the context resolves. So on a cold launch the Skills list can appear slightly later than before (it now waits on the context read the home view already waits on). The trade is that the list is *correct* when it appears, instead of being silently missing every workspace-claimed skill. Flagging this rather than letting it slip through.

## Surface area

- [x] **UI** — `apps/web` workspace switcher + Skills list behavior (no new surfaces; behavior only)
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [x] **Default behavior change** — the app-level `/api/skills` read now carries workspace identity headers, so the list users see is workspace-filtered (it was fail-closed-filtered before, which is why claimed skills were missing)

No new `/api/*` endpoint, no `packages/contracts` shape change — `WorkspaceActiveResponse.context` already existed and was already populated; the client simply discarded it.

## Screenshots

Behavior-only change with no new UI surface; the three behaviors are pinned by the red→green specs below. The switcher and Skills list render exactly the same markup as before — the fix changes *which data* reaches them, and the existing switcher tests (`EntryNavRail.workspace-directory.test.tsx`) still pass to prove the visible list behavior is unchanged for the normal single-account case.

## Bug fix verification

Three independent red→green cycles. Every test was confirmed red against `origin/feat/workspace-team`'s source (source files stashed, new specs kept) and green with the fix, then mutation-tested — reverting one fix turns **only its own** test red.

### ① Account change leaves the previous account's workspace names on screen

`apps/web/tests/components/EntryNavRail.directory-account-scope.test.tsx`

```
RED (baseline source):
  × never paints the previous account's workspaces after an account change
    AssertionError: expected <span>Ada private workspace</span> to be null

GREEN (with fix):  Test Files 1 passed | Tests 2 passed
```

Mutation (disable the attribution rule in `workspaceDirectoryBelongsTo`):
```
× never paints the previous account's workspaces after an account change
  AssertionError: expected <span …(1)></span> to be null
 Test Files  1 failed | 2 passed (3)     ← ② and ③ stay green
```

The second case in that file (`still serves the warm list across a same-account workspace switch`) is the guard against over-fixing: it passes on baseline *and* after, proving the flash-free reopen the cache exists for is preserved.

### ② The skills list never gets the workspace filter

`apps/web/tests/components/App.skills-workspace-scope.test.tsx`

```
RED (baseline source):
  × reads skills under the active workspace identity, once, and again on a switch
    AssertionError: expected [ undefined ] to include 'ws-a'
                             ^^^^^^^^^^^ the headerless (fail-closed) read

GREEN (with fix):  Test Files 1 passed | Tests 1 passed
```

Both halves mutation-tested separately:

| Mutation | Result |
|---|---|
| `fetchSkills()` instead of `fetchSkills(workspaceContextRef.current)` | `× expected [ undefined ] to include 'ws-a'` — only this test red |
| workspace-keyed effect reads once instead of per identity | `× expected [ 'ws-a' ] to include 'ws-b'` — only this test red |

### ③ The switch response body is parsed and thrown away

`apps/web/tests/components/EntryNavRail.switch-seeds-context.test.tsx`

```
RED (baseline source):
  × adopts the switch response instead of re-reading the context
    AssertionError: expected 2 to be 1
                             ^ two GET /api/workspace/context where one suffices

GREEN (with fix):  Test Files 1 passed | Tests 1 passed
```

Mutation (`notifyWorkspaceContextRefresh()` without the seed):
```
× adopts the switch response instead of re-reading the context
  AssertionError: expected 2 to be 1
 Test Files  1 failed | 2 passed (3)     ← ① and ② stay green
```

### Review follow-up — late responses committing unconditionally (886f11b24)

`PerishCode` found that the three fixes above guarantee *the right request is made*, but not *only the right response is committed*. Both findings were the same defect and both were real: a read issued for identity A resolves later, and by then the caller may be identity B — committing that late answer restores A's data under B, i.e. the exact staleness this PR removes, arriving through the back door. A workspace switch is precisely when one read is in flight and another starts, so reverse-order completion is reachable rather than exotic.

**One mechanism for both**, not two ad-hoc guards: `beginWorkspaceScopedRead` in `apps/web/src/collab/useWorkspaceContext.ts`.

```ts
const read = beginWorkspaceScopedRead(contextRef.current);
const data = await fetchSomething(read.context);
if (!read.isStillCurrent(contextRef.current)) return;   // <- the invariant
commit(data);
```

Its docblock names the invariant and the two rules that make it hold: **(1)** request with `read.context`, never the caller's own variable, so the request and the guard cannot disagree about whose data was asked for; **(2)** compare against a **ref**, never a closed-over prop — a closure holds the identity the read was issued for, so comparing against it always succeeds and guards nothing. (That second rule is why `EntryNavRail` gained a `contextRef`: `loadWorkspaceDirectory` closes over the render's `context`, so the obvious guard there would have been a no-op.)

I chose captured-identity over a monotonic token because these reads are scoped *by* identity, so identity is the honest discriminator — and it is the cross-component form of the `requestEpochRef` ordering guard `useWorkspaceContext` already applies to its own read.

Applied to `refreshSkills`, `handleSkillsChanged` (same shape), and `loadWorkspaceDirectory` including its `catch` branch (blanking the list is equally a commit). A discarded skills response deliberately also skips `markSkillRegistryReady('functional')` — it is not an answer about the current identity, and the newer read marks the gate.

| Spec (deferred / reverse-order) | Red on previous head | Mutation: drop just the commit-time check |
|---|---|---|
| `App.skills-workspace-scope.test.tsx` — "discards a slow read belonging to the workspace the user has left" | `× discards a slow read belonging to the workspace the user has left` | that test red, rail test green |
| `EntryNavRail.directory-account-scope.test.tsx` — "discards an in-flight read that lands after the account changed" | `expected <span>Ada private workspace</span> to be null` | that test red, App test green |

The rail spec asserts **both** halves the reviewer named. `workspaceItems`: A's names absent from the open menu after the late release. `cachedWorkspaceDirectory`: observed by remounting as **A** with a read that never answers — a poisoned cache would serve A a warm list instantly; with the guard there is no trace. Deliberately A and not B, because under B the read-side membership attribution masks a poisoned cache and the assertion would pass either way, discriminating nothing.

### Second review round — `6ad38728b`

Two further defects, **both found by `PerishCode`'s review, not by me.**

**(a) The commit guard could throw, and the throw was invisible.** `Web workspace tests` went red on `886f11b24` reporting `Test Files 555 passed (555)` / `Tests 5583 passed` and still `Process completed with exit code 1`. The CI log gives the reason:

```
Unhandled Rejection
TypeError: Cannot read properties of undefined (reading 'canShareProjects')
 ❯ workspaceIdentityCacheKey src/collab/useWorkspaceContext.ts:112:32
 ❯ beginWorkspaceScopedRead src/collab/useWorkspaceContext.ts:159:20
 ❯ src/App.tsx:1770  ❯ src/App.tsx:1799  ❯ commitHookEffectListMount
originating in tests/components/App.amr-plan-tier.test.tsx
     Errors  1 error
```

`workspaceIdentityCacheKey` dereferenced `context.permissions` unguarded. That survived while it was only reached during render (a throw there fails loudly, in the right place) and inside `fetchSkills`'s own try/catch. The commit guard put it inside an `async` function launched as `void refreshSkills()` — which turns a synchronous programming error into an unhandled rejection: invisible to every assertion, fatal to the process. It is a React **passive-effect mount**, not a post-teardown race.

`permissions` is required by the contract, but API JSON reaches these objects through an unchecked cast, so a partial context is reachable at runtime and not only in fixtures. Computing an identity must therefore be **total**: a partial context is its own cache partition, never an exception.

**(b) A guard that discards without guaranteeing a successor** — quoting the reviewer: *"Key this effect by the same full identity used by `beginWorkspaceScopedRead`… this trigger only observes `workspaceId`… line 1776 discards A's response, while this equality check suppresses B's replacement read because the workspace ID did not change. The functional registry can then remain loading indefinitely."* Two accounts in one shared team workspace differ only by membership, so the digest moves while `workspaceId` does not. The trigger now uses `workspaceIdentityCacheKey(workspaceContext)`, so every transition that invalidates a response also starts its successor.

| Item | Red evidence | Mutation |
|---|---|---|
| (a) | Reverting the optional chaining and running CI's own originating file, `App.amr-plan-tier.test.tsx`, gives `EXIT=1` with that exact `Unhandled Rejection`; with the fix `EXIT=0`. Also `tests/collab/workspace-identity-key-is-total.test.ts` (new). | remove `?.` → all 3 cases red, reproducing the CI error string verbatim |
| (b) | `App.skills-workspace-scope.test.tsx` — "starts and completes a successor read when only the member id changes" (deferred, workspace id held constant, member id changed), as the reviewer specified | trigger back to `workspaceId`-only → only that test red, successor never starts |

## Request counts (performance red line)

Measured with a temporary probe that logged every `fetch` path, run against the same tree with and without the source changes. The probe was deleted before commit.

**Switch path** — clicking a workspace in the switcher:

| | Requests | Detail |
|---|---|---|
| Before | **2** | `PUT /api/workspace/active`, `GET /api/workspace/context` |
| After | **1** | `PUT /api/workspace/active` |

**Startup path** — mount through first settled context:

| | Requests | Detail |
|---|---|---|
| Before | **4** | `vela/status`, `github/open-design`, `workspace/context`, `message-center-public/messages` |
| After | **4** | identical list |

**`/api/skills` specifically** (counted via the mocked registry in ②'s spec):

| | Startup | Per switch |
|---|---|---|
| Before | 1 (headerless) | 0 |
| After | 1 (scoped) | 1 |

So: startup is byte-identical at 4 requests — the skills read moved rather than being added. The switch path *drops* the redundant context re-read (2 → 1) and gains the one genuinely-needed scoped skills read, netting **2 → 2 for the full client**, with a redundant round-trip replaced by a correctness-required one. Nothing new lands on the startup path, and nothing was added to the switch path on net.

**Re-measured after the review follow-up (886f11b24): unchanged — startup 4, switch 1.** The commit-time guard discards responses; it does not issue requests.

## Validation

- `pnpm guard` — exit 0
- `pnpm typecheck` — exit 0
- `pnpm --filter @open-design/web test` — **556 files, 5587 passed, 11 skipped, 0 failed**, process exit 0 (verified unpiped; a piped run reports `grep`'s exit code, not vitest's — which is how the `886f11b24` failure escaped local checks)
- Seven red→green cycles + eight isolating mutations (above)
- Node 24.18.0, pnpm 10.33.2

One pre-existing test fixture needed a correction: `EntryNavRail.workspace-directory.test.tsx`'s `DIRECTORY` omitted `workspaceMemberId`, which is a **required** field on `WorkspaceDirectoryItem` and is present in every real daemon response. Once the cache is attributed by membership, a fixture without it can never be attributed, so the fixture now carries the field. No assertion in that file changed — the three cases still pin exactly the warm-cache behavior they always did.

## Adjacent issues (deliberately not fixed here)

Found while verifying; each wants its own red spec and PR.

Per the reviewer's prompt I also audited every other async read for the same unconditional-commit shape. Clean: the ③ seeding path is synchronous and additionally token-stamped plus epoch-bumped, and `loadContext` already had its `requestEpochRef` guard. Sharing the shape but **outside this PR's surface** (pre-existing, not touched here, so each needs its own red spec rather than being smuggled in):

1. **`fetchDesignTemplates` takes no workspace context — and correctly so.** Design templates are *not* workspace-claimable: `TeamResourceKind = 'design-system' | 'plugin' | 'skill'`, `design-template` is not a `workspace_resources` resource type, no share route is mounted for it, and `listAllDesignTemplates()` calls `listSkills` with the scope option omitted entirely. `GET /api/design-templates` returns the same global catalog to every workspace by construction. **Not the same defect** — nothing to fix.
2. **`PluginsView.tsx` (`TeamPanel.refreshTeamPanelShared`) calls `fetchSkills()` unscoped.** It feeds the "which of my skills to share with the team" panel. Because the daemon is fail-closed, that panel likely cannot see a skill already claimed by the current workspace. Different component, different sharing semantics — needs its own judgement call rather than a mechanical scope addition.
3. **`ExtensionsMarketplace`'s refresh effect has `[]` deps** (`PluginsView.tsx`), so it passes the workspace context on its first call but never re-runs on a workspace switch — unlike the sibling `PluginsView` effect, which is keyed on `pluginsWorkspaceContext?.workspaceId`. Same "no refetch on switch" shape as ②, one component over.
4. **The switcher's `role="status"` loading row is unreachable while a context exists.** `visibleWorkspaceItems` always falls back to a synthetic single entry built from `context`, so the `length === 0` guard on that row can never be true for a signed-in user. Harmless today (the fallback is a *better* state than a spinner), but it is dead UI code and the comment above it implies otherwise. Left alone because removing it would be a UI change.
5. **`refreshDesignSystems` (App.tsx) has the identical late-commit race.** `await fetchDesignSystems()` then an unconditional `setDesignSystems(list)`, driven by the same workspace-keyed effect this PR cites as precedent. It predates this PR and I did not touch the function. `beginWorkspaceScopedRead` generalizes to it directly even though `fetchDesignSystems()` takes no context — the daemon resolves that scope from its own session, but the identity to guard the *commit* on is still `workspaceContextRef.current`.
6. **`TeamPanel.refreshTeamPanelShared` and `ExtensionsMarketplace.refresh` (PluginsView.tsx) both commit unconditionally too** — on top of the scope issues already listed in (2) and (3).

