### PR TITLE
fix(contracts): attribute component-manifest tokens to every CSS rule and anchor group class matchers

### DIFF
--- a/design-systems/agentic/components.manifest.json
+++ b/design-systems/agentic/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/airbnb/components.manifest.json
+++ b/design-systems/airbnb/components.manifest.json
@@ -586,8 +586,6 @@
       "present": true,
       "selectors": [
         ".container",
-        ".nav-logo",
-        ".nav-row",
         ".row-between",
         ".stack-2 > * + *",
         ".stack-3 > * + *",
@@ -608,22 +606,18 @@
         "section"
       ],
       "tokenReferences": [
-        "--accent",
         "--border",
         "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--font-display",
         "--section-y-desktop",
         "--section-y-phone",
         "--section-y-tablet",
         "--space-2",
         "--space-3",
         "--space-4",
-        "--space-6",
-        "--text-lg",
-        "--tracking-display"
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/airbnb/components.manifest.json
+++ b/design-systems/airbnb/components.manifest.json
@@ -379,7 +379,10 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
@@ -388,8 +391,10 @@
         "--font-display",
         "--motion-fast",
         "--radius-lg",
+        "--radius-pill",
         "--radius-sm",
         "--space-2",
+        "--space-3",
         "--surface",
         "--text-base",
         "--text-sm"
@@ -431,12 +436,17 @@
         "--danger",
         "--ease-standard",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
+        "--font-display",
         "--motion-fast",
         "--muted",
         "--radius-sm",
         "--space-2",
         "--surface",
-        "--text-base"
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -470,9 +480,17 @@
       "tokenReferences": [
         "--accent",
         "--accent-on",
+        "--elev-ring",
         "--fg",
+        "--font-display",
         "--radius-md",
-        "--surface-warm"
+        "--radius-pill",
+        "--space-2",
+        "--space-3",
+        "--success",
+        "--surface",
+        "--surface-warm",
+        "--text-xs"
       ]
     },
     {
@@ -508,7 +526,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--fg",
+        "--font-mono",
+        "--radius-sm",
+        "--surface-warm",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -547,11 +572,15 @@
         "p"
       ],
       "tokenReferences": [
+        "--fg",
         "--font-display",
         "--leading-tight",
         "--muted",
+        "--text-2xl",
+        "--text-base",
         "--text-sm",
         "--text-xl",
+        "--text-xs",
         "--tracking-display"
       ]
     },
@@ -572,11 +601,7 @@
         "section + section"
       ],
       "classes": [
-        "booking-grid",
-        "booking-grid-cell",
         "container",
-        "hero-grid",
-        "listings-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -587,13 +612,22 @@
         "section"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--font-display",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-2",
-        "--space-4"
+        "--space-3",
+        "--space-4",
+        "--space-6",
+        "--text-lg",
+        "--tracking-display"
       ]
     }
   ],

--- a/design-systems/airbnb/components.manifest.json
+++ b/design-systems/airbnb/components.manifest.json
@@ -405,8 +405,6 @@
       "label": "Form fields and controls",
       "present": true,
       "selectors": [
-        ".award-label",
-        ".booking-cell-label",
         ".field",
         ".field input",
         ".field input::placeholder",
@@ -416,8 +414,7 @@
         ".field select:focus-visible",
         ".field-error .field-help",
         ".field-error input",
-        ".field-help",
-        ".search-segment-label"
+        ".field-help"
       ],
       "classes": [
         "field",
@@ -438,7 +435,6 @@
         "--fg",
         "--fg-2",
         "--focus-ring",
-        "--font-display",
         "--motion-fast",
         "--muted",
         "--radius-sm",

--- a/design-systems/airtable/components.manifest.json
+++ b/design-systems/airtable/components.manifest.json
@@ -289,9 +289,12 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-sm",
@@ -325,9 +328,17 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--text-base",
         "--text-sm",
         "--text-xs"
       ]
@@ -351,7 +362,15 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--ease-standard",
+        "--elev-raised",
+        "--motion-base",
+        "--radius-md",
+        "--radius-sm",
         "--space-2",
+        "--space-3",
+        "--space-6",
+        "--surface",
         "--text-sm"
       ]
     },
@@ -376,6 +395,7 @@
         "--fg-2",
         "--radius-pill",
         "--space-2",
+        "--success",
         "--text-xs"
       ]
     },
@@ -392,6 +412,7 @@
         "a"
       ],
       "tokenReferences": [
+        "--accent",
         "--accent-hover"
       ]
     },
@@ -406,7 +427,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--fg-2",
+        "--font-mono",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -453,10 +481,15 @@
       "tokenReferences": [
         "--accent",
         "--fg",
+        "--fg-2",
         "--font-display",
         "--leading-tight",
         "--muted",
         "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -476,8 +509,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -492,8 +523,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-4"
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/ant/components.manifest.json
+++ b/design-systems/ant/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/apple/components.manifest.json
+++ b/design-systems/apple/components.manifest.json
@@ -529,12 +529,6 @@
       "present": true,
       "selectors": [
         ".container",
-        ".nav",
-        ".nav-brand",
-        ".nav-inner",
-        ".nav-links",
-        ".nav-links a",
-        ".nav-links a:hover",
         ".row-between",
         ".stack-3 > * + *",
         ".stack-4 > * + *",
@@ -554,24 +548,16 @@
         "section"
       ],
       "tokenReferences": [
-        "--bg",
-        "--border-soft",
         "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--ease-standard",
-        "--fg",
-        "--font-display",
-        "--motion-fast",
         "--section-y-desktop",
         "--section-y-phone",
         "--section-y-tablet",
         "--space-3",
         "--space-4",
-        "--space-6",
-        "--text-base",
-        "--text-sm"
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/apple/components.manifest.json
+++ b/design-systems/apple/components.manifest.json
@@ -311,9 +311,20 @@
         "--accent-active",
         "--accent-hover",
         "--accent-on",
+        "--border",
+        "--ease-standard",
+        "--elev-ring",
+        "--fg",
         "--focus-ring",
+        "--font-body",
         "--meta",
-        "--surface"
+        "--motion-fast",
+        "--radius-pill",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--text-base",
+        "--text-sm"
       ]
     },
     {
@@ -342,10 +353,12 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--bg",
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--meta",
         "--motion-fast",
@@ -353,6 +366,7 @@
         "--radius-sm",
         "--space-2",
         "--text-base",
+        "--text-sm",
         "--text-xs"
       ]
     },
@@ -371,7 +385,18 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--elev-raised"
+        "--bg",
+        "--border",
+        "--border-soft",
+        "--ease-standard",
+        "--elev-raised",
+        "--motion-base",
+        "--radius-lg",
+        "--space-3",
+        "--space-4",
+        "--space-6",
+        "--space-8",
+        "--surface-warm"
       ]
     },
     {
@@ -396,6 +421,7 @@
         "--radius-pill",
         "--space-2",
         "--space-3",
+        "--success",
         "--text-xs"
       ]
     },
@@ -414,7 +440,11 @@
         "a"
       ],
       "tokenReferences": [
-        "--accent-active"
+        "--accent-active",
+        "--ease-standard",
+        "--fg",
+        "--motion-fast",
+        "--text-sm"
       ]
     },
     {
@@ -478,11 +508,18 @@
         "p"
       ],
       "tokenReferences": [
+        "--accent",
         "--fg",
+        "--fg-2",
         "--font-display",
+        "--leading-tight",
         "--muted",
         "--text-2xl",
+        "--text-3xl",
+        "--text-lg",
         "--text-sm",
+        "--text-xl",
+        "--text-xs",
         "--tracking-display"
       ]
     },
@@ -506,8 +543,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -519,12 +554,24 @@
         "section"
       ],
       "tokenReferences": [
+        "--bg",
+        "--border-soft",
         "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--ease-standard",
+        "--fg",
+        "--font-display",
+        "--motion-fast",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-6"
+        "--space-4",
+        "--space-6",
+        "--text-base",
+        "--text-sm"
       ]
     }
   ],

--- a/design-systems/application/components.manifest.json
+++ b/design-systems/application/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/arc/components.manifest.json
+++ b/design-systems/arc/components.manifest.json
@@ -270,10 +270,16 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--ease-standard",
         "--elev-ring",
         "--fg",
         "--focus-ring",
-        "--space-3"
+        "--font-body",
+        "--motion-fast",
+        "--radius-md",
+        "--space-2",
+        "--space-3",
+        "--text-base"
       ]
     },
     {
@@ -301,15 +307,20 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--ease-standard",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--muted",
         "--radius-md",
         "--space-2",
-        "--text-base"
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -354,6 +365,7 @@
         "--accent",
         "--radius-pill",
         "--space-2",
+        "--success",
         "--text-xs"
       ]
     },
@@ -370,7 +382,10 @@
         "a"
       ],
       "tokenReferences": [
-        "--accent-hover"
+        "--accent",
+        "--accent-hover",
+        "--ease-standard",
+        "--motion-fast"
       ]
     },
     {
@@ -384,7 +399,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--fg-2",
+        "--font-mono",
+        "--radius-sm",
+        "--surface-warm",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -427,10 +449,19 @@
         "p"
       ],
       "tokenReferences": [
+        "--fg-2",
+        "--font-body",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
-        "--text-3xl"
+        "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -447,8 +478,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "stack-3",
         "stack-4"
       ],
@@ -462,7 +491,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/artistic/components.manifest.json
+++ b/design-systems/artistic/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/atelier-zero/components.manifest.json
+++ b/design-systems/atelier-zero/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/bento/components.manifest.json
+++ b/design-systems/bento/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/binance/components.manifest.json
+++ b/design-systems/binance/components.manifest.json
@@ -334,8 +334,7 @@
         ".field input::placeholder",
         ".field input:focus-visible",
         ".field label",
-        ".field-help",
-        ".stat-label"
+        ".field-help"
       ],
       "classes": [
         "field",

--- a/design-systems/binance/components.manifest.json
+++ b/design-systems/binance/components.manifest.json
@@ -311,9 +311,17 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
+        "--ease-standard",
         "--focus-ring",
-        "--radius-pill"
+        "--font-body",
+        "--motion-base",
+        "--motion-fast",
+        "--radius-pill",
+        "--space-2",
+        "--text-base"
       ]
     },
     {
@@ -345,14 +353,18 @@
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
+        "--meta",
         "--motion-base",
         "--motion-fast",
         "--muted",
         "--radius-sm",
         "--space-2",
         "--surface-warm",
-        "--text-base"
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -375,12 +387,14 @@
         "--accent",
         "--accent-active",
         "--border",
+        "--border-soft",
         "--ease-standard",
         "--elev-raised",
         "--motion-base",
         "--radius-md",
         "--radius-pill",
         "--space-3",
+        "--space-4",
         "--space-6",
         "--surface"
       ]
@@ -405,9 +419,12 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--danger",
         "--radius-pill",
         "--space-2",
+        "--success",
         "--text-xs"
       ]
     },
@@ -424,7 +441,11 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--accent",
+        "--ease-standard",
+        "--motion-fast"
+      ]
     },
     {
       "id": "keyboard",
@@ -495,8 +516,10 @@
         "--leading-tight",
         "--muted",
         "--text-3xl",
+        "--text-4xl",
         "--text-lg",
         "--text-sm",
+        "--text-xs",
         "--tracking-display"
       ]
     },
@@ -520,24 +543,27 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "stack-3",
         "stack-4",
         "stack-5",
-        "stack-6",
-        "stat-grid"
+        "stack-6"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--accent",
         "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
         "--space-4",
+        "--space-5",
         "--space-6"
       ]
     }

--- a/design-systems/binance/components.manifest.json
+++ b/design-systems/binance/components.manifest.json
@@ -529,11 +529,6 @@
       "selectors": [
         ".container",
         ".row-between",
-        ".section-dark",
-        ".section-dark .body-muted",
-        ".section-dark .eyebrow",
-        ".section-dark .lead",
-        ".section-dark a:hover",
         ".stack-3 > * + *",
         ".stack-4 > * + *",
         ".stack-5 > * + *",
@@ -552,7 +547,6 @@
         "section"
       ],
       "tokenReferences": [
-        "--accent",
         "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",

--- a/design-systems/bmw-m/components.manifest.json
+++ b/design-systems/bmw-m/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -399,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/bmw/components.manifest.json
+++ b/design-systems/bmw/components.manifest.json
@@ -281,9 +281,11 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-sm",
@@ -317,9 +319,17 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--bg",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-base",
         "--text-xs"
       ]
     },
@@ -342,12 +352,15 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--focus-ring",
+        "--font-display",
         "--radius-md",
         "--space-2",
         "--space-4",
         "--space-6",
         "--surface",
+        "--text-2xl",
         "--text-sm"
       ]
     },
@@ -433,7 +446,11 @@
         "--leading-tight",
         "--muted",
         "--text-2xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -453,8 +470,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "stack-4",
         "stack-5"
       ],
@@ -467,7 +482,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
         "--space-4",
+        "--space-5",
         "--space-6"
       ]
     }

--- a/design-systems/bold/components.manifest.json
+++ b/design-systems/bold/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/brutalism/components.manifest.json
+++ b/design-systems/brutalism/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/bugatti/components.manifest.json
+++ b/design-systems/bugatti/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -399,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/cafe/components.manifest.json
+++ b/design-systems/cafe/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/cal/components.manifest.json
+++ b/design-systems/cal/components.manifest.json
@@ -267,11 +267,14 @@
       ],
       "tokenReferences": [
         "--ease-standard",
+        "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-sm",
         "--space-2",
+        "--surface",
         "--text-sm"
       ]
     },
@@ -301,9 +304,17 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--bg",
+        "--border",
+        "--ease-standard",
+        "--fg",
         "--fg-2",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
         "--text-sm",
         "--text-xs"
       ]
@@ -324,7 +335,15 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--ease-standard",
+        "--elev-raised",
+        "--fg-2",
+        "--motion-base",
+        "--radius-md",
+        "--space-3",
+        "--space-6",
+        "--surface"
       ]
     },
     {
@@ -344,7 +363,12 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--success"
+        "--font-body",
+        "--muted",
+        "--radius-pill",
+        "--space-2",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -363,7 +387,8 @@
       ],
       "tokenReferences": [
         "--accent",
-        "--accent-hover"
+        "--accent-hover",
+        "--fg-2"
       ]
     },
     {
@@ -377,7 +402,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--elev-ring",
+        "--font-mono",
+        "--muted",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -423,9 +455,14 @@
         "--fg",
         "--font-body",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -445,8 +482,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -461,7 +496,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/canva/components.manifest.json
+++ b/design-systems/canva/components.manifest.json
@@ -282,7 +282,13 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-on",
+        "--bg",
+        "--border",
         "--ease-standard",
+        "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-sm",
@@ -317,9 +323,18 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--bg",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
+        "--meta",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-base",
         "--text-sm",
         "--text-xs"
       ]
@@ -344,7 +359,17 @@
         "card-thumb-mint"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--bg",
+        "--border",
+        "--ease-standard",
+        "--motion-fast",
+        "--radius-md",
+        "--radius-sm",
+        "--space-2",
+        "--space-3",
+        "--space-6"
+      ]
     },
     {
       "id": "badges",
@@ -363,7 +388,10 @@
         "chip-mint"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--radius-pill",
+        "--text-xs"
+      ]
     },
     {
       "id": "links",
@@ -445,10 +473,16 @@
         "--accent",
         "--fg",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-2xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -466,8 +500,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -482,7 +514,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/cisco/components.manifest.json
+++ b/design-systems/cisco/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -399,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/claude/components.manifest.json
+++ b/design-systems/claude/components.manifest.json
@@ -264,7 +264,10 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
         "--ease-standard",
         "--fg-2",
         "--focus-ring",
@@ -304,13 +307,16 @@
         "--border-soft",
         "--ease-standard",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--meta",
         "--motion-fast",
         "--radius-md",
         "--space-2",
         "--surface",
-        "--text-sm"
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -350,7 +356,13 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--success"
+        "--font-body",
+        "--muted",
+        "--radius-pill",
+        "--space-2",
+        "--space-3",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -366,7 +378,8 @@
         "a"
       ],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--fg-2"
       ]
     },
     {
@@ -380,7 +393,13 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border-soft",
+        "--font-mono",
+        "--muted",
+        "--surface-warm",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -425,10 +444,15 @@
       "tokenReferences": [
         "--font-body",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--meta",
         "--muted",
         "--text-2xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -448,8 +472,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -464,7 +486,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/clay/components.manifest.json
+++ b/design-systems/clay/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/claymorphism/components.manifest.json
+++ b/design-systems/claymorphism/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/clean/components.manifest.json
+++ b/design-systems/clean/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/clickhouse/components.manifest.json
+++ b/design-systems/clickhouse/components.manifest.json
@@ -330,8 +330,7 @@
         ".field input::placeholder",
         ".field input:focus-visible",
         ".field label",
-        ".field-help",
-        ".stat-label"
+        ".field-help"
       ],
       "classes": [
         "field",
@@ -357,7 +356,6 @@
         "--muted",
         "--radius-sm",
         "--space-2",
-        "--space-3",
         "--surface",
         "--text-sm",
         "--text-xs"

--- a/design-systems/clickhouse/components.manifest.json
+++ b/design-systems/clickhouse/components.manifest.json
@@ -305,14 +305,17 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-sm",
         "--space-2",
         "--space-8",
+        "--success",
         "--surface",
         "--text-base"
       ]
@@ -343,16 +346,21 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--meta",
         "--motion-fast",
+        "--muted",
         "--radius-sm",
         "--space-2",
+        "--space-3",
         "--surface",
-        "--text-sm"
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -371,6 +379,7 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--border-soft",
         "--radius-md",
@@ -395,6 +404,7 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--border-soft",
         "--muted",
@@ -438,7 +448,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--fg-2",
+        "--font-mono",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -485,7 +502,12 @@
         "--font-display",
         "--leading-tight",
         "--muted",
-        "--text-2xl"
+        "--text-2xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--tracking-display"
       ]
     },
     {
@@ -504,8 +526,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4",
@@ -521,8 +541,13 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-5"
+        "--space-4",
+        "--space-5",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/cloudflare-kumo/components.manifest.json
+++ b/design-systems/cloudflare-kumo/components.manifest.json
@@ -282,16 +282,21 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
+        "--border-soft",
         "--danger",
         "--fg",
+        "--focus-ring",
         "--motion-base",
+        "--muted",
         "--radius-lg",
         "--radius-pill",
         "--space-2",
         "--space-3",
-        "--surface"
+        "--surface",
+        "--surface-warm"
       ]
     },
     {
@@ -320,10 +325,14 @@
         "--border",
         "--danger",
         "--fg",
+        "--focus-ring",
+        "--muted",
         "--radius-lg",
         "--space-2",
         "--space-3",
-        "--surface"
+        "--surface",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -343,8 +352,12 @@
       "elements": [],
       "tokenReferences": [
         "--border-soft",
+        "--elev-raised",
+        "--elev-ring",
+        "--radius-lg",
         "--space-4",
-        "--space-5"
+        "--space-5",
+        "--surface"
       ]
     },
     {
@@ -369,7 +382,9 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--focus-ring"
+      ]
     },
     {
       "id": "keyboard",
@@ -422,9 +437,12 @@
         "p"
       ],
       "tokenReferences": [
+        "--fg-2",
         "--font-display",
         "--leading-tight",
         "--muted",
+        "--text-3xl",
+        "--text-base",
         "--text-lg",
         "--text-sm",
         "--tracking-display"
@@ -443,7 +461,6 @@
       "classes": [
         "container",
         "layout-grid",
-        "metric-grid",
         "row-between",
         "stack-2",
         "stack-4"
@@ -454,6 +471,9 @@
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
+        "--container-gutter-phone",
+        "--container-max",
         "--space-2",
         "--space-4"
       ]

--- a/design-systems/cohere/components.manifest.json
+++ b/design-systems/cohere/components.manifest.json
@@ -261,8 +261,15 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--ease-standard",
+        "--fg",
         "--fg-2",
-        "--focus-ring"
+        "--focus-ring",
+        "--font-body",
+        "--motion-fast",
+        "--radius-pill",
+        "--space-2",
+        "--text-base"
       ]
     },
     {
@@ -290,8 +297,16 @@
         "label"
       ],
       "tokenReferences": [
+        "--bg",
+        "--border",
+        "--ease-standard",
+        "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
         "--text-sm",
         "--text-xs"
       ]
@@ -307,7 +322,13 @@
         "card"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--bg",
+        "--border-soft",
+        "--radius-md",
+        "--space-3",
+        "--space-6"
+      ]
     },
     {
       "id": "badges",
@@ -329,6 +350,7 @@
         "--muted",
         "--radius-pill",
         "--space-2",
+        "--success",
         "--text-xs"
       ]
     },
@@ -345,6 +367,7 @@
         "a"
       ],
       "tokenReferences": [
+        "--accent",
         "--fg"
       ]
     },
@@ -411,9 +434,11 @@
       "tokenReferences": [
         "--font-body",
         "--font-display",
+        "--font-mono",
         "--leading-body",
         "--leading-tight",
         "--muted",
+        "--text-2xl",
         "--text-4xl",
         "--text-lg",
         "--text-sm",
@@ -436,8 +461,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -452,7 +475,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/coinbase/components.manifest.json
+++ b/design-systems/coinbase/components.manifest.json
@@ -524,14 +524,7 @@
       "selectors": [
         ".container",
         ".row-between",
-        ".section-dark",
-        ".section-dark .body-muted",
-        ".section-dark .lead",
         ".section-dark + section",
-        ".section-dark a",
-        ".section-dark h1",
-        ".section-dark h2",
-        ".section-dark h3",
         ".stack-3 > * + *",
         ".stack-4 > * + *",
         ".stack-5 > * + *",
@@ -551,13 +544,11 @@
         "section"
       ],
       "tokenReferences": [
-        "--accent",
         "--border",
         "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--fg",
         "--section-y-desktop",
         "--section-y-phone",
         "--section-y-tablet",

--- a/design-systems/coinbase/components.manifest.json
+++ b/design-systems/coinbase/components.manifest.json
@@ -315,9 +315,12 @@
         "--accent-hover",
         "--accent-on",
         "--ease-standard",
+        "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--space-2",
+        "--surface",
         "--text-base"
       ]
     },
@@ -348,9 +351,16 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-base",
         "--text-sm"
       ]
     },
@@ -372,11 +382,16 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--bg",
         "--border",
+        "--radius-lg",
         "--radius-md",
         "--radius-pill",
         "--space-3",
-        "--space-6"
+        "--space-4",
+        "--space-6",
+        "--space-8",
+        "--surface"
       ]
     },
     {
@@ -398,9 +413,11 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
         "--muted",
         "--radius-pill",
         "--space-2",
+        "--success",
         "--surface"
       ]
     },
@@ -418,7 +435,10 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--accent",
+        "--focus-ring"
+      ]
     },
     {
       "id": "keyboard",
@@ -485,8 +505,12 @@
         "p"
       ],
       "tokenReferences": [
+        "--fg",
         "--font-body",
+        "--font-display",
+        "--leading-tight",
         "--muted",
+        "--text-2xl",
         "--text-4xl",
         "--text-lg",
         "--text-sm",
@@ -517,8 +541,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4",
@@ -529,14 +551,20 @@
         "section"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
         "--fg",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-5"
+        "--space-4",
+        "--space-5",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/colorful/components.manifest.json
+++ b/design-systems/colorful/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/composio/components.manifest.json
+++ b/design-systems/composio/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -399,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/contemporary/components.manifest.json
+++ b/design-systems/contemporary/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/corporate/components.manifest.json
+++ b/design-systems/corporate/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/cosmic/components.manifest.json
+++ b/design-systems/cosmic/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/creative/components.manifest.json
+++ b/design-systems/creative/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/cursor/components.manifest.json
+++ b/design-systems/cursor/components.manifest.json
@@ -296,12 +296,23 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--danger",
+        "--ease-standard",
+        "--fg",
         "--focus-ring",
+        "--font-display",
+        "--motion-base",
+        "--motion-fast",
         "--muted",
-        "--radius-pill"
+        "--radius-pill",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--surface-warm",
+        "--text-sm"
       ]
     },
     {
@@ -329,11 +340,20 @@
         "label"
       ],
       "tokenReferences": [
+        "--bg",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
         "--font-body",
         "--font-display",
+        "--meta",
+        "--motion-base",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-base",
         "--text-sm"
       ]
     },
@@ -352,7 +372,16 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--elev-raised"
+        "--bg",
+        "--border",
+        "--ease-standard",
+        "--elev-raised",
+        "--motion-base",
+        "--radius-md",
+        "--radius-sm",
+        "--space-3",
+        "--space-5",
+        "--surface"
       ]
     },
     {
@@ -378,10 +407,14 @@
       "tokenReferences": [
         "--fg",
         "--font-display",
+        "--meta",
         "--muted",
         "--radius-pill",
         "--space-2",
         "--space-3",
+        "--success",
+        "--surface",
+        "--text-sm",
         "--text-xs"
       ]
     },
@@ -398,7 +431,8 @@
         "a"
       ],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--meta"
       ]
     },
     {
@@ -461,10 +495,17 @@
         "p"
       ],
       "tokenReferences": [
+        "--font-body",
         "--font-display",
         "--leading-tight",
         "--muted",
-        "--text-3xl"
+        "--text-2xl",
+        "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -482,8 +523,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -498,7 +537,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/dashboard/components.manifest.json
+++ b/design-systems/dashboard/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/default/components.manifest.json
+++ b/design-systems/default/components.manifest.json
@@ -266,7 +266,10 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
         "--border",
         "--ease-standard",
         "--fg",
@@ -274,6 +277,7 @@
         "--motion-fast",
         "--radius-sm",
         "--space-2",
+        "--surface",
         "--text-sm"
       ]
     },
@@ -302,15 +306,18 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--motion-fast",
         "--muted",
         "--radius-sm",
         "--space-2",
         "--surface",
-        "--text-sm"
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -349,7 +356,11 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--success"
+        "--muted",
+        "--radius-pill",
+        "--space-2",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -364,7 +375,9 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--accent"
+      ]
     },
     {
       "id": "keyboard",
@@ -377,7 +390,13 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--font-mono",
+        "--muted",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -424,6 +443,9 @@
         "--leading-tight",
         "--muted",
         "--text-2xl",
+        "--text-3xl",
+        "--text-lg",
+        "--text-sm",
         "--text-xs",
         "--tracking-display"
       ]
@@ -443,8 +465,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -459,7 +479,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/discord/components.manifest.json
+++ b/design-systems/discord/components.manifest.json
@@ -239,8 +239,16 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
         "--accent-hover",
-        "--focus-ring"
+        "--accent-on",
+        "--ease-standard",
+        "--focus-ring",
+        "--font-body",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--text-base"
       ]
     },
     {
@@ -263,8 +271,16 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
+        "--ease-standard",
+        "--fg",
         "--fg-2",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--surface-warm",
+        "--text-base",
         "--text-sm"
       ]
     },
@@ -354,8 +370,13 @@
         "--leading-tight",
         "--meta",
         "--muted",
+        "--text-2xl",
         "--text-3xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -371,8 +392,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "stack-3",
         "stack-4"
       ],
@@ -386,6 +405,10 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
         "--space-4"
       ]
     }

--- a/design-systems/dithered/components.manifest.json
+++ b/design-systems/dithered/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/doodle/components.manifest.json
+++ b/design-systems/doodle/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/dramatic/components.manifest.json
+++ b/design-systems/dramatic/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/duolingo/components.manifest.json
+++ b/design-systems/duolingo/components.manifest.json
@@ -297,12 +297,17 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--bg",
+        "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-display",
         "--meta",
         "--motion-fast",
+        "--muted",
         "--radius-md",
         "--space-2",
         "--space-6",
@@ -337,11 +342,22 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--bg",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
         "--font-display",
         "--meta",
-        "--text-sm"
+        "--motion-fast",
+        "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--space-4",
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -365,19 +381,22 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
         "--accent-on",
         "--bg",
         "--border",
         "--danger",
         "--ease-standard",
         "--elev-raised",
+        "--fg",
         "--font-display",
         "--motion-fast",
         "--radius-md",
         "--radius-pill",
         "--space-3",
         "--space-6",
-        "--text-xl"
+        "--text-xl",
+        "--warn"
       ]
     },
     {
@@ -398,12 +417,17 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent-on",
+        "--border",
         "--fg",
         "--font-display",
+        "--muted",
         "--radius-pill",
         "--space-1",
         "--space-2",
         "--space-3",
+        "--success",
+        "--surface",
         "--text-xs",
         "--warn"
       ]
@@ -420,7 +444,9 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--accent-active"
+      ]
     },
     {
       "id": "keyboard",
@@ -433,7 +459,15 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--bg",
+        "--border",
+        "--font-mono",
+        "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -476,12 +510,22 @@
         "p"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--fg",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
+        "--radius-pill",
+        "--space-1",
+        "--space-3",
         "--text-2xl",
-        "--text-sm"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -500,8 +544,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-2",
         "stack-3",
@@ -518,9 +560,13 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-2",
         "--space-3",
-        "--space-4"
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/editorial/components.manifest.json
+++ b/design-systems/editorial/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/elegant/components.manifest.json
+++ b/design-systems/elegant/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/elevenlabs/components.manifest.json
+++ b/design-systems/elevenlabs/components.manifest.json
@@ -258,10 +258,12 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--bg",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-pill",
@@ -293,16 +295,19 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--bg",
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--muted",
         "--radius-md",
         "--space-2",
-        "--text-sm"
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -341,7 +346,11 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--success"
+        "--muted",
+        "--radius-pill",
+        "--space-2",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -357,6 +366,7 @@
         "a"
       ],
       "tokenReferences": [
+        "--fg",
         "--muted"
       ]
     },
@@ -371,7 +381,13 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--font-mono",
+        "--muted",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -413,9 +429,14 @@
         "--fg-2",
         "--font-body",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-2xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -435,8 +456,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -451,7 +470,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/energetic/components.manifest.json
+++ b/design-systems/energetic/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/enterprise/components.manifest.json
+++ b/design-systems/enterprise/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/expo/components.manifest.json
+++ b/design-systems/expo/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -399,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/expressive/components.manifest.json
+++ b/design-systems/expressive/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/fantasy/components.manifest.json
+++ b/design-systems/fantasy/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/ferrari/components.manifest.json
+++ b/design-systems/ferrari/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -399,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/figma/components.manifest.json
+++ b/design-systems/figma/components.manifest.json
@@ -246,16 +246,11 @@
     {
       "id": "inputs",
       "label": "Form fields and controls",
-      "present": true,
-      "selectors": [
-        ".mono-label"
-      ],
+      "present": false,
+      "selectors": [],
       "classes": [],
       "elements": [],
-      "tokenReferences": [
-        "--fg",
-        "--font-mono"
-      ]
+      "tokenReferences": []
     },
     {
       "id": "cards",

--- a/design-systems/figma/components.manifest.json
+++ b/design-systems/figma/components.manifest.json
@@ -232,7 +232,15 @@
         "button"
       ],
       "tokenReferences": [
-        "--fg"
+        "--accent-on",
+        "--bg",
+        "--ease-standard",
+        "--fg",
+        "--font-display",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--text-base"
       ]
     },
     {
@@ -335,7 +343,12 @@
       "tokenReferences": [
         "--font-display",
         "--leading-tight",
-        "--text-3xl"
+        "--muted",
+        "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-xl",
+        "--tracking-display"
       ]
     },
     {
@@ -352,8 +365,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "stack-3",
         "stack-4"
       ],
@@ -367,7 +378,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/flat/components.manifest.json
+++ b/design-systems/flat/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/framer/components.manifest.json
+++ b/design-systems/framer/components.manifest.json
@@ -277,7 +277,15 @@
         "button"
       ],
       "tokenReferences": [
-        "--fg"
+        "--ease-standard",
+        "--fg",
+        "--focus-ring",
+        "--font-body",
+        "--motion-base",
+        "--motion-fast",
+        "--radius-pill",
+        "--space-2",
+        "--text-base"
       ]
     },
     {
@@ -306,17 +314,21 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--border-soft",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
+        "--meta",
         "--motion-fast",
         "--muted",
         "--radius-sm",
         "--space-2",
         "--surface",
         "--text-base",
+        "--text-sm",
         "--text-xs"
       ]
     },
@@ -335,7 +347,17 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--elev-raised"
+        "--accent",
+        "--ease-standard",
+        "--elev-raised",
+        "--elev-ring",
+        "--font-mono",
+        "--motion-base",
+        "--radius-md",
+        "--space-3",
+        "--space-6",
+        "--surface",
+        "--text-xs"
       ]
     },
     {
@@ -356,6 +378,8 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
+        "--border",
         "--muted",
         "--radius-pill",
         "--space-2",
@@ -443,9 +467,14 @@
         "--fg-2",
         "--font-body",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--tracking-display"
       ]
     },
@@ -465,7 +494,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
         "row-between",
         "stack-4",
         "stack-5",
@@ -481,7 +509,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
         "--space-4",
+        "--space-5",
         "--space-6"
       ]
     }

--- a/design-systems/friendly/components.manifest.json
+++ b/design-systems/friendly/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/futuristic/components.manifest.json
+++ b/design-systems/futuristic/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/github/components.manifest.json
+++ b/design-systems/github/components.manifest.json
@@ -255,10 +255,12 @@
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-sm",
         "--space-2",
+        "--success",
         "--surface",
         "--text-sm"
       ]
@@ -291,6 +293,7 @@
         "--focus-ring",
         "--font-body",
         "--motion-fast",
+        "--muted",
         "--radius-sm",
         "--space-2",
         "--text-sm"
@@ -377,9 +380,12 @@
         "--font-display",
         "--leading-tight",
         "--muted",
+        "--text-4xl",
+        "--text-lg",
         "--text-sm",
         "--text-xl",
-        "--text-xs"
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -395,8 +401,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "stack-3",
         "stack-4"
       ],
@@ -410,7 +414,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-3"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4"
       ]
     }
   ],

--- a/design-systems/glassmorphism/components.manifest.json
+++ b/design-systems/glassmorphism/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/gradient/components.manifest.json
+++ b/design-systems/gradient/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/hashicorp/components.manifest.json
+++ b/design-systems/hashicorp/components.manifest.json
@@ -273,13 +273,20 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
         "--bg",
         "--border",
+        "--ease-standard",
         "--elev-raised",
+        "--fg",
         "--fg-2",
         "--focus-ring",
-        "--radius-sm"
+        "--font-body",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--text-base"
       ]
     },
     {
@@ -307,9 +314,18 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
+        "--ease-standard",
+        "--fg",
         "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--meta",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--text-base",
         "--text-sm",
         "--text-xs"
       ]
@@ -325,7 +341,13 @@
         "card"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border-soft",
+        "--elev-raised",
+        "--radius-md",
+        "--space-6",
+        "--surface"
+      ]
     },
     {
       "id": "badges",
@@ -346,6 +368,7 @@
         "--font-body",
         "--radius-pill",
         "--space-2",
+        "--success",
         "--text-sm"
       ]
     },
@@ -361,7 +384,11 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--accent-hover",
+        "--ease-standard",
+        "--motion-fast"
+      ]
     },
     {
       "id": "keyboard",
@@ -374,7 +401,13 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--fg-2",
+        "--font-mono",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -418,11 +451,18 @@
       ],
       "tokenReferences": [
         "--fg",
+        "--fg-2",
         "--font-display",
         "--leading-tight",
         "--muted",
         "--text-2xl",
-        "--text-3xl"
+        "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -440,8 +480,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -456,7 +494,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/hud/components.manifest.json
+++ b/design-systems/hud/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/huggingface/components.manifest.json
+++ b/design-systems/huggingface/components.manifest.json
@@ -264,8 +264,11 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
         "--accent-hover",
+        "--accent-on",
         "--ease-standard",
+        "--fg",
         "--fg-2",
         "--focus-ring",
         "--font-display",
@@ -300,10 +303,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
         "--font-display",
+        "--motion-fast",
         "--muted",
+        "--radius-md",
+        "--space-2",
+        "--surface",
         "--text-sm",
         "--text-xs"
       ]
@@ -321,7 +331,11 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--border",
+        "--radius-md",
+        "--space-3",
+        "--surface"
       ]
     },
     {
@@ -340,7 +354,14 @@
         "badge-success"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border-soft",
+        "--font-display",
+        "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-xs"
+      ]
     },
     {
       "id": "links",
@@ -354,7 +375,9 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--fg"
+      ]
     },
     {
       "id": "keyboard",
@@ -367,7 +390,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--border-soft",
+        "--font-display",
+        "--muted",
+        "--radius-sm",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -410,10 +440,16 @@
         "p"
       ],
       "tokenReferences": [
+        "--fg-2",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-2xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -433,8 +469,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -449,7 +483,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/ibm/components.manifest.json
+++ b/design-systems/ibm/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -399,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/intercom/components.manifest.json
+++ b/design-systems/intercom/components.manifest.json
@@ -299,9 +299,16 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--ease-standard",
         "--fg",
-        "--focus-ring"
+        "--focus-ring",
+        "--font-body",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--text-base"
       ]
     },
     {
@@ -323,8 +330,7 @@
         "field-help",
         "form",
         "form-actions",
-        "form-row",
-        "messenger-input"
+        "form-row"
       ],
       "elements": [
         "form",
@@ -333,10 +339,20 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
         "--meta",
-        "--text-sm"
+        "--motion-fast",
+        "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -358,12 +374,14 @@
         "--accent",
         "--border",
         "--ease-standard",
+        "--elev-raised",
         "--font-mono",
         "--motion-base",
         "--radius-lg",
         "--space-3",
         "--space-6",
         "--surface-warm",
+        "--text-2xl",
         "--text-xs"
       ]
     },
@@ -381,16 +399,17 @@
       "classes": [
         "badge",
         "badge-dot",
-        "badge-success",
-        "messenger-status"
+        "badge-success"
       ],
       "elements": [],
       "tokenReferences": [
         "--accent",
         "--font-mono",
+        "--muted",
         "--radius-pill",
         "--space-2",
         "--space-3",
+        "--success",
         "--text-xs"
       ]
     },
@@ -407,7 +426,9 @@
         "a"
       ],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--border",
+        "--fg"
       ]
     },
     {
@@ -421,7 +442,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--font-mono",
+        "--muted",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -467,9 +495,17 @@
       "tokenReferences": [
         "--fg",
         "--font-display",
+        "--font-mono",
         "--leading-tight",
         "--muted",
-        "--text-3xl"
+        "--text-2xl",
+        "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -489,8 +525,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "stack-2",
         "stack-3",
         "stack-4",
@@ -507,8 +541,13 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-2",
+        "--space-3",
         "--space-4",
+        "--space-5",
         "--space-6"
       ]
     }

--- a/design-systems/intercom/components.manifest.json
+++ b/design-systems/intercom/components.manifest.json
@@ -322,8 +322,7 @@
         ".field input:focus-visible",
         ".field input:hover",
         ".field label",
-        ".field-help",
-        ".messenger-input"
+        ".field-help"
       ],
       "classes": [
         "field",

--- a/design-systems/kami/components.manifest.json
+++ b/design-systems/kami/components.manifest.json
@@ -299,9 +299,11 @@
         "--accent",
         "--accent-on",
         "--ease-standard",
+        "--elev-raised",
         "--elev-ring",
         "--elev-ring-accent",
         "--fg-2",
+        "--focus-ring",
         "--font-display",
         "--motion-base",
         "--radius-md",
@@ -341,6 +343,7 @@
       "tokenReferences": [
         "--border",
         "--ease-standard",
+        "--elev-raised",
         "--motion-base",
         "--radius-md",
         "--space-3",
@@ -369,6 +372,7 @@
         "--font-display",
         "--radius-sm",
         "--radius-xs",
+        "--tag-bg-faint",
         "--tag-bg-soft",
         "--tag-bg-strong",
         "--text-sm",
@@ -387,7 +391,9 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--accent"
+      ]
     },
     {
       "id": "keyboard",
@@ -432,11 +438,17 @@
       ],
       "tokenReferences": [
         "--font-display",
+        "--leading-display",
         "--leading-tight",
+        "--meta",
         "--muted",
         "--space-6",
         "--text-2xl",
-        "--text-sm"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--tracking-display",
+        "--tracking-eyebrow"
       ]
     },
     {
@@ -453,8 +465,7 @@
         "section + section"
       ],
       "classes": [
-        "container",
-        "features-grid"
+        "container"
       ],
       "elements": [
         "main",
@@ -468,8 +479,12 @@
         "--container-gutter-tablet",
         "--container-max",
         "--font-display",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
         "--space-4",
+        "--space-6",
         "--text-base",
         "--tracking-label"
       ]

--- a/design-systems/kami/components.manifest.json
+++ b/design-systems/kami/components.manifest.json
@@ -451,7 +451,6 @@
       "present": true,
       "selectors": [
         ".container",
-        ".section-num",
         ".stack-3 > * + *",
         ".stack-4 > * + *",
         ".stack-6 > * + *",
@@ -466,21 +465,17 @@
         "section"
       ],
       "tokenReferences": [
-        "--accent",
         "--border",
         "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--font-display",
         "--section-y-desktop",
         "--section-y-phone",
         "--section-y-tablet",
         "--space-3",
         "--space-4",
-        "--space-6",
-        "--text-base",
-        "--tracking-label"
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/kami/components.manifest.json
+++ b/design-systems/kami/components.manifest.json
@@ -316,17 +316,11 @@
     {
       "id": "inputs",
       "label": "Form fields and controls",
-      "present": true,
-      "selectors": [
-        ".metric-label"
-      ],
+      "present": false,
+      "selectors": [],
       "classes": [],
       "elements": [],
-      "tokenReferences": [
-        "--font-display",
-        "--muted",
-        "--text-sm"
-      ]
+      "tokenReferences": []
     },
     {
       "id": "cards",

--- a/design-systems/kraken/components.manifest.json
+++ b/design-systems/kraken/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -399,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/lamborghini/components.manifest.json
+++ b/design-systems/lamborghini/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -399,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/levels/components.manifest.json
+++ b/design-systems/levels/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/linear-app/components.manifest.json
+++ b/design-systems/linear-app/components.manifest.json
@@ -236,8 +236,10 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--ease-standard",
+        "--focus-ring",
         "--font-display",
         "--motion-fast",
         "--radius-sm",
@@ -265,8 +267,16 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
+        "--border",
+        "--ease-standard",
         "--fg-2",
+        "--font-body",
         "--meta",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--text-base",
         "--text-sm"
       ]
     },
@@ -282,7 +292,13 @@
         "card"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--ease-standard",
+        "--motion-base",
+        "--radius-md",
+        "--space-6"
+      ]
     },
     {
       "id": "badges",
@@ -363,7 +379,12 @@
         "--meta",
         "--muted",
         "--text-2xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -380,8 +401,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "stack-3",
         "stack-4"
       ],
@@ -395,7 +414,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/lingo/components.manifest.json
+++ b/design-systems/lingo/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/loom/components.manifest.json
+++ b/design-systems/loom/components.manifest.json
@@ -279,10 +279,14 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--leading-tight",
         "--motion-fast",
@@ -318,18 +322,23 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--bg",
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--leading-tight",
         "--meta",
         "--motion-fast",
+        "--muted",
         "--radius-sm",
         "--space-2",
         "--space-3",
-        "--text-base"
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -373,6 +382,7 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--danger",
         "--muted",
         "--radius-pill",
         "--space-2",
@@ -393,7 +403,8 @@
         "a"
       ],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--accent-hover"
       ]
     },
     {
@@ -457,11 +468,18 @@
         "p"
       ],
       "tokenReferences": [
+        "--accent",
         "--fg",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-2xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
         "--tracking-display"
       ]
     },
@@ -481,8 +499,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -497,8 +513,13 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-2",
-        "--space-4"
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/lovable/components.manifest.json
+++ b/design-systems/lovable/components.manifest.json
@@ -265,8 +265,10 @@
       ],
       "tokenReferences": [
         "--ease-standard",
+        "--fg",
         "--focus-ring",
         "--font-body",
+        "--meta",
         "--motion-fast",
         "--radius-sm",
         "--space-2",
@@ -302,7 +304,20 @@
         "textarea"
       ],
       "tokenReferences": [
+        "--border",
+        "--ease-standard",
+        "--fg",
+        "--focus-ring",
+        "--font-body",
+        "--leading-body",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--space-3",
+        "--space-4",
+        "--surface",
+        "--text-base",
         "--text-sm"
       ]
     },
@@ -318,7 +333,16 @@
         "card"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--ease-standard",
+        "--elev-flat",
+        "--motion-base",
+        "--radius-md",
+        "--space-3",
+        "--space-6",
+        "--surface"
+      ]
     },
     {
       "id": "badges",
@@ -334,7 +358,14 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--border",
+        "--fg",
+        "--radius-pill",
+        "--space-2",
+        "--space-3",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -350,7 +381,8 @@
         "a"
       ],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--fg"
       ]
     },
     {
@@ -364,7 +396,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--font-mono",
+        "--muted",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -411,7 +450,11 @@
         "--leading-tight",
         "--muted",
         "--text-3xl",
-        "--text-sm"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--tracking-display"
       ]
     },
     {
@@ -429,8 +472,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -445,7 +486,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/luxury/components.manifest.json
+++ b/design-systems/luxury/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/mastercard/components.manifest.json
+++ b/design-systems/mastercard/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -399,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/material/components.manifest.json
+++ b/design-systems/material/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/meta/components.manifest.json
+++ b/design-systems/meta/components.manifest.json
@@ -276,10 +276,13 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
         "--bg",
         "--ease-standard",
+        "--fg",
         "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--motion-base",
         "--motion-fast",
@@ -314,9 +317,17 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--bg",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-base",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-base",
         "--text-sm",
         "--text-xs"
       ]
@@ -336,7 +347,16 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--elev-raised"
+        "--bg",
+        "--ease-standard",
+        "--elev-raised",
+        "--elev-ring",
+        "--motion-base",
+        "--radius-lg",
+        "--radius-md",
+        "--space-4",
+        "--space-8",
+        "--surface-warm"
       ]
     },
     {
@@ -359,6 +379,7 @@
         "--muted",
         "--radius-pill",
         "--space-2",
+        "--success",
         "--surface",
         "--text-xs"
       ]
@@ -377,6 +398,7 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--ease-standard",
         "--motion-fast"
       ]
@@ -442,12 +464,17 @@
         "p"
       ],
       "tokenReferences": [
+        "--fg",
         "--fg-2",
+        "--font-display",
+        "--leading-tight",
         "--muted",
         "--text-2xl",
         "--text-3xl",
         "--text-4xl",
         "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -467,8 +494,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4",
@@ -484,7 +509,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
         "--space-4",
+        "--space-6",
         "--space-8"
       ]
     }

--- a/design-systems/minimal/components.manifest.json
+++ b/design-systems/minimal/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/minimax/components.manifest.json
+++ b/design-systems/minimax/components.manifest.json
@@ -292,10 +292,18 @@
         "button"
       ],
       "tokenReferences": [
+        "--bg",
         "--border",
+        "--ease-standard",
         "--fg-2",
         "--focus-ring",
-        "--surface-warm"
+        "--font-body",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--surface-warm",
+        "--text-sm"
       ]
     },
     {
@@ -326,9 +334,20 @@
         "textarea"
       ],
       "tokenReferences": [
+        "--accent",
+        "--bg",
+        "--border",
+        "--ease-standard",
+        "--fg",
         "--fg-2",
+        "--focus-ring",
+        "--font-body",
         "--meta",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-base",
         "--text-sm",
         "--text-xs"
       ]
@@ -355,14 +374,18 @@
         "--bg",
         "--border-soft",
         "--ease-standard",
+        "--elev-raised",
         "--fg-2",
         "--font-display",
+        "--meta",
         "--motion-base",
         "--radius-lg",
         "--radius-md",
+        "--space-2",
         "--space-3",
         "--space-6",
-        "--space-8"
+        "--space-8",
+        "--text-xs"
       ]
     },
     {
@@ -381,6 +404,7 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
         "--muted",
         "--radius-pill",
         "--space-2",
@@ -403,7 +427,15 @@
         "a"
       ],
       "tokenReferences": [
-        "--fg"
+        "--bg",
+        "--ease-standard",
+        "--elev-raised",
+        "--fg",
+        "--fg-2",
+        "--motion-fast",
+        "--muted",
+        "--radius-pill",
+        "--text-sm"
       ]
     },
     {
@@ -471,9 +503,15 @@
         "--fg",
         "--font-body",
         "--font-display",
+        "--leading-body",
+        "--leading-tight",
         "--muted",
         "--text-2xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -491,8 +529,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -509,7 +545,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/mintlify/components.manifest.json
+++ b/design-systems/mintlify/components.manifest.json
@@ -297,9 +297,19 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
         "--accent-hover",
+        "--accent-on",
         "--bg",
-        "--focus-ring"
+        "--ease-standard",
+        "--fg",
+        "--focus-ring",
+        "--font-display",
+        "--motion-fast",
+        "--radius-pill",
+        "--radius-sm",
+        "--space-2",
+        "--surface"
       ]
     },
     {
@@ -329,10 +339,17 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
         "--meta",
-        "--text-sm"
+        "--motion-fast",
+        "--muted",
+        "--radius-pill",
+        "--space-2",
+        "--surface",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -358,9 +375,11 @@
         "--radius-lg",
         "--radius-md",
         "--space-3",
+        "--space-5",
         "--space-6",
         "--space-8",
-        "--surface"
+        "--surface",
+        "--surface-warm"
       ]
     },
     {
@@ -384,12 +403,18 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
+        "--accent-hover",
         "--border",
         "--fg-2",
         "--font-display",
+        "--font-mono",
         "--radius-pill",
+        "--radius-sm",
         "--space-1",
-        "--surface-warm"
+        "--success",
+        "--surface-warm",
+        "--text-xs"
       ]
     },
     {
@@ -406,6 +431,7 @@
         "a"
       ],
       "tokenReferences": [
+        "--accent-hover",
         "--ease-standard",
         "--fg",
         "--focus-ring",
@@ -423,7 +449,13 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--fg-2",
+        "--font-mono",
+        "--surface-warm",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -467,13 +499,18 @@
       ],
       "tokenReferences": [
         "--fg",
+        "--fg-2",
         "--font-display",
         "--font-mono",
         "--leading-tight",
         "--muted",
         "--text-3xl",
+        "--text-4xl",
         "--text-lg",
-        "--text-xs"
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -492,7 +529,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -507,8 +543,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
         "--space-4",
+        "--space-5",
         "--space-6"
       ]
     }

--- a/design-systems/miro/components.manifest.json
+++ b/design-systems/miro/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -399,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/mission-control/components.manifest.json
+++ b/design-systems/mission-control/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/mistral-ai/components.manifest.json
+++ b/design-systems/mistral-ai/components.manifest.json
@@ -263,6 +263,7 @@
       ],
       "tokenReferences": [
         "--ease-standard",
+        "--fg",
         "--focus-ring",
         "--font-body",
         "--motion-fast",
@@ -298,8 +299,16 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--border",
+        "--ease-standard",
+        "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
         "--text-sm",
         "--text-xs"
       ]
@@ -315,7 +324,13 @@
         "card"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--elev-raised",
+        "--radius-sm",
+        "--space-3",
+        "--space-6",
+        "--surface"
+      ]
     },
     {
       "id": "badges",
@@ -337,6 +352,7 @@
         "--muted",
         "--radius-pill",
         "--space-2",
+        "--success",
         "--text-xs"
       ]
     },
@@ -418,10 +434,16 @@
       ],
       "tokenReferences": [
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-3xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-base",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -439,8 +461,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -455,7 +475,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/modern/components.manifest.json
+++ b/design-systems/modern/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/mongodb/components.manifest.json
+++ b/design-systems/mongodb/components.manifest.json
@@ -264,12 +264,21 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
         "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
-        "--surface"
+        "--radius-pill",
+        "--space-2",
+        "--surface",
+        "--text-base"
       ]
     },
     {
@@ -297,16 +306,21 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--ease-standard",
         "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--meta",
         "--motion-fast",
+        "--muted",
         "--radius-sm",
         "--space-2",
         "--surface",
-        "--text-base"
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -346,7 +360,12 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--font-mono",
+        "--muted",
+        "--radius-pill",
+        "--space-2",
+        "--text-xs"
       ]
     },
     {
@@ -361,7 +380,9 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--accent"
+      ]
     },
     {
       "id": "keyboard",
@@ -374,7 +395,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--font-mono",
+        "--muted",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -419,12 +447,16 @@
       "tokenReferences": [
         "--accent",
         "--fg",
+        "--fg-2",
+        "--font-body",
         "--font-display",
         "--font-mono",
         "--leading-tight",
         "--muted",
+        "--text-2xl",
         "--text-3xl",
         "--text-4xl",
+        "--text-lg",
         "--text-sm",
         "--text-xl",
         "--tracking-display"
@@ -445,8 +477,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -461,7 +491,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/mono/components.manifest.json
+++ b/design-systems/mono/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/neobrutalism/components.manifest.json
+++ b/design-systems/neobrutalism/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/neon/components.manifest.json
+++ b/design-systems/neon/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/neumorphism/components.manifest.json
+++ b/design-systems/neumorphism/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/nike/components.manifest.json
+++ b/design-systems/nike/components.manifest.json
@@ -274,15 +274,21 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-base",
         "--motion-fast",
+        "--muted",
         "--radius-pill",
         "--space-2",
+        "--surface",
         "--text-base"
       ]
     },
@@ -312,9 +318,11 @@
         "label"
       ],
       "tokenReferences": [
+        "--bg",
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-base",
         "--motion-fast",
@@ -323,6 +331,7 @@
         "--space-2",
         "--surface",
         "--text-base",
+        "--text-sm",
         "--text-xs"
       ]
     },
@@ -337,7 +346,12 @@
         "card"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--radius-md",
+        "--space-3",
+        "--space-6",
+        "--surface"
+      ]
     },
     {
       "id": "badges",
@@ -361,6 +375,7 @@
         "--radius-pill",
         "--space-2",
         "--space-3",
+        "--success",
         "--surface",
         "--text-xs"
       ]
@@ -379,9 +394,11 @@
         "a"
       ],
       "tokenReferences": [
+        "--bg",
         "--ease-standard",
         "--fg",
-        "--motion-base"
+        "--motion-base",
+        "--muted"
       ]
     },
     {
@@ -446,10 +463,17 @@
       ],
       "tokenReferences": [
         "--fg",
+        "--font-body",
         "--font-display",
+        "--leading-tight",
         "--muted",
         "--text-2xl",
-        "--text-sm"
+        "--text-4xl",
+        "--text-base",
+        "--text-lg",
+        "--text-sm",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -468,8 +492,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4",
@@ -485,8 +507,13 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-6"
+        "--space-4",
+        "--space-6",
+        "--space-8"
       ]
     }
   ],

--- a/design-systems/notion/components.manifest.json
+++ b/design-systems/notion/components.manifest.json
@@ -254,8 +254,12 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
         "--accent-hover",
+        "--accent-on",
         "--ease-standard",
+        "--fg",
+        "--focus-ring",
         "--font-display",
         "--motion-fast",
         "--radius-sm",
@@ -289,10 +293,12 @@
         "--fg",
         "--focus-ring",
         "--font-body",
+        "--meta",
         "--motion-fast",
         "--radius-sm",
         "--space-2",
-        "--text-base"
+        "--text-base",
+        "--text-sm"
       ]
     },
     {
@@ -310,7 +316,14 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--elev-raised"
+        "--bg",
+        "--border",
+        "--ease-standard",
+        "--elev-raised",
+        "--motion-base",
+        "--radius-lg",
+        "--space-6",
+        "--surface"
       ]
     },
     {
@@ -399,7 +412,12 @@
         "--leading-tight",
         "--muted",
         "--text-3xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -417,8 +435,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -433,7 +449,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/nvidia/components.manifest.json
+++ b/design-systems/nvidia/components.manifest.json
@@ -473,12 +473,6 @@
       "selectors": [
         ".container",
         ".row-between",
-        ".section-light",
-        ".section-light .btn-primary",
-        ".section-light .btn-primary:hover",
-        ".section-light .card",
-        ".section-light .eyebrow",
-        ".section-light p",
         ".stack-3 > * + *",
         ".stack-4 > * + *",
         ".stack-6 > * + *",
@@ -496,8 +490,6 @@
         "section"
       ],
       "tokenReferences": [
-        "--accent",
-        "--accent-hover",
         "--border-soft",
         "--container-gutter-desktop",
         "--container-gutter-phone",

--- a/design-systems/nvidia/components.manifest.json
+++ b/design-systems/nvidia/components.manifest.json
@@ -283,8 +283,17 @@
         "--accent",
         "--accent-active",
         "--accent-hover",
+        "--border",
+        "--ease-standard",
         "--fg",
-        "--fg-2"
+        "--fg-2",
+        "--focus-ring",
+        "--font-body",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--text-base"
       ]
     },
     {
@@ -313,9 +322,18 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--border",
+        "--ease-standard",
+        "--fg",
         "--fg-2",
         "--font-body",
         "--meta",
+        "--motion-fast",
+        "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--text-base",
         "--text-sm",
         "--text-xs"
       ]
@@ -334,7 +352,12 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--border-soft",
+        "--elev-raised",
+        "--radius-md",
+        "--space-3",
+        "--surface"
       ]
     },
     {
@@ -353,7 +376,12 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--font-body",
+        "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-xs"
       ]
     },
     {
@@ -424,11 +452,17 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--fg-2",
         "--font-body",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
+        "--text-2xl",
         "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
         "--text-xs"
       ]
     },
@@ -453,8 +487,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -471,7 +503,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/ollama/components.manifest.json
+++ b/design-systems/ollama/components.manifest.json
@@ -485,14 +485,6 @@
       "present": true,
       "selectors": [
         ".container",
-        ".nav",
-        ".nav-actions",
-        ".nav-brand",
-        ".nav-brand svg",
-        ".nav-links",
-        ".nav-links a",
-        ".nav-signin",
-        ".nav-spacer",
         ".stack-3 > * + *",
         ".stack-4 > * + *",
         ".stack-5 > * + *",
@@ -514,19 +506,13 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--fg",
-        "--font-display",
         "--section-y-desktop",
         "--section-y-phone",
         "--section-y-tablet",
-        "--space-2",
         "--space-3",
         "--space-4",
         "--space-5",
-        "--space-6",
-        "--text-base",
-        "--text-lg",
-        "--tracking-display"
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/ollama/components.manifest.json
+++ b/design-systems/ollama/components.manifest.json
@@ -295,11 +295,22 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
         "--bg",
         "--border",
+        "--ease-standard",
+        "--fg",
         "--fg-2",
-        "--focus-ring"
+        "--focus-ring",
+        "--motion-fast",
+        "--radius-pill",
+        "--space-2",
+        "--space-6",
+        "--surface",
+        "--text-base"
       ]
     },
     {
@@ -317,8 +328,7 @@
       ],
       "classes": [
         "field",
-        "field-help",
-        "signup-form"
+        "field-help"
       ],
       "elements": [
         "form",
@@ -330,12 +340,17 @@
         "--border",
         "--ease-standard",
         "--fg",
+        "--fg-2",
         "--focus-ring",
+        "--meta",
         "--motion-fast",
+        "--muted",
         "--radius-pill",
         "--space-2",
         "--space-5",
-        "--text-base"
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -353,6 +368,7 @@
       "tokenReferences": [
         "--bg",
         "--border",
+        "--fg",
         "--radius-md",
         "--space-3",
         "--space-6"
@@ -376,6 +392,7 @@
         "--fg-2",
         "--font-mono",
         "--radius-pill",
+        "--space-2",
         "--space-3",
         "--text-xs"
       ]
@@ -454,6 +471,10 @@
         "--leading-tight",
         "--muted",
         "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -480,7 +501,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
         "stack-4"
       ],
       "elements": [
@@ -495,10 +515,18 @@
         "--container-gutter-tablet",
         "--container-max",
         "--fg",
+        "--font-display",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-2",
+        "--space-3",
         "--space-4",
         "--space-5",
         "--space-6",
-        "--text-base"
+        "--text-base",
+        "--text-lg",
+        "--tracking-display"
       ]
     }
   ],

--- a/design-systems/openai/components.manifest.json
+++ b/design-systems/openai/components.manifest.json
@@ -251,15 +251,19 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--bg",
         "--border",
         "--ease-standard",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-sm",
         "--space-2",
+        "--surface-warm",
         "--text-base"
       ]
     },
@@ -291,10 +295,14 @@
         "--fg",
         "--focus-ring",
         "--font-body",
+        "--meta",
         "--motion-fast",
+        "--muted",
         "--radius-sm",
         "--space-2",
-        "--text-base"
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -313,6 +321,7 @@
         "--bg",
         "--border-soft",
         "--ease-standard",
+        "--elev-raised",
         "--motion-base",
         "--radius-md",
         "--space-6"
@@ -332,6 +341,7 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
         "--muted",
         "--radius-pill",
         "--surface",
@@ -401,6 +411,7 @@
         "--font-display",
         "--leading-tight",
         "--muted",
+        "--text-2xl",
         "--text-4xl",
         "--text-lg",
         "--text-sm",
@@ -422,8 +433,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "stack-3",
         "stack-4"
       ],
@@ -437,7 +446,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/openai/components.manifest.json
+++ b/design-systems/openai/components.manifest.json
@@ -276,8 +276,7 @@
         ".field input",
         ".field input::placeholder",
         ".field input:focus",
-        ".field label",
-        ".label"
+        ".field label"
       ],
       "classes": [
         "field"
@@ -297,12 +296,10 @@
         "--font-body",
         "--meta",
         "--motion-fast",
-        "--muted",
         "--radius-sm",
         "--space-2",
         "--text-base",
-        "--text-sm",
-        "--text-xs"
+        "--text-sm"
       ]
     },
     {

--- a/design-systems/opencode-ai/components.manifest.json
+++ b/design-systems/opencode-ai/components.manifest.json
@@ -268,9 +268,19 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--border",
+        "--ease-standard",
         "--fg",
-        "--surface"
+        "--fg-2",
+        "--focus-ring",
+        "--font-body",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -298,10 +308,18 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--border",
+        "--ease-standard",
+        "--fg",
         "--focus-ring",
         "--font-mono",
         "--meta",
+        "--motion-fast",
         "--muted",
+        "--radius-md",
+        "--space-2",
+        "--surface",
+        "--text-sm",
         "--text-xs"
       ]
     },
@@ -316,7 +334,12 @@
         "card"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--radius-md",
+        "--space-3",
+        "--surface"
+      ]
     },
     {
       "id": "badges",
@@ -345,7 +368,9 @@
         "--font-mono",
         "--radius-sm",
         "--space-2",
-        "--text-xs"
+        "--success",
+        "--text-xs",
+        "--warn"
       ]
     },
     {
@@ -425,10 +450,16 @@
         "p"
       ],
       "tokenReferences": [
+        "--fg-2",
         "--font-display",
         "--font-mono",
+        "--leading-body",
         "--muted",
         "--text-2xl",
+        "--text-3xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs"
       ]
     },
@@ -461,7 +492,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/pacman/components.manifest.json
+++ b/design-systems/pacman/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -399,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/paper/components.manifest.json
+++ b/design-systems/paper/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/perplexity/components.manifest.json
+++ b/design-systems/perplexity/components.manifest.json
@@ -265,9 +265,12 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--border",
         "--border-soft",
         "--ease-standard",
+        "--fg",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -302,11 +305,13 @@
         "--ease-standard",
         "--fg",
         "--font-body",
+        "--meta",
         "--motion-fast",
         "--radius-md",
         "--space-2",
         "--surface",
-        "--text-base"
+        "--text-base",
+        "--text-sm"
       ]
     },
     {
@@ -323,6 +328,7 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--ease-standard",
         "--elev-flat",
         "--motion-fast",
@@ -406,7 +412,12 @@
         "--leading-tight",
         "--muted",
         "--text-2xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -424,8 +435,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "stack-3",
         "stack-4",
         "stack-5"
@@ -440,8 +449,13 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-5"
+        "--space-4",
+        "--space-5",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/perspective/components.manifest.json
+++ b/design-systems/perspective/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/pinterest/components.manifest.json
+++ b/design-systems/pinterest/components.manifest.json
@@ -528,15 +528,6 @@
       "present": true,
       "selectors": [
         ".container",
-        ".nav-cluster",
-        ".nav-logo",
-        ".nav-logo svg",
-        ".nav-row",
-        ".nav-search",
-        ".nav-search input",
-        ".nav-search input::placeholder",
-        ".nav-search svg",
-        ".nav-search:focus-within",
         ".stack-2 > * + *",
         ".stack-3 > * + *",
         ".stack-4 > * + *",
@@ -555,29 +546,18 @@
         "section"
       ],
       "tokenReferences": [
-        "--accent",
         "--border-soft",
         "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--ease-standard",
-        "--fg",
-        "--focus-ring",
-        "--font-display",
-        "--motion-fast",
-        "--muted",
-        "--radius-pill",
         "--section-y-desktop",
         "--section-y-phone",
         "--section-y-tablet",
         "--space-2",
         "--space-3",
         "--space-4",
-        "--space-6",
-        "--surface",
-        "--text-lg",
-        "--tracking-display"
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/pinterest/components.manifest.json
+++ b/design-systems/pinterest/components.manifest.json
@@ -329,11 +329,15 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
         "--border-soft",
         "--ease-standard",
         "--fg",
         "--fg-2",
+        "--focus-ring",
         "--font-display",
         "--motion-fast",
         "--radius-md",
@@ -371,10 +375,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--bg",
+        "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-display",
         "--meta",
+        "--motion-fast",
         "--muted",
+        "--radius-md",
+        "--space-2",
+        "--text-base",
         "--text-sm",
         "--text-xs"
       ]
@@ -413,6 +424,7 @@
         "--radius-pill",
         "--space-2",
         "--space-3",
+        "--success",
         "--surface-warm",
         "--text-xs"
       ]
@@ -431,7 +443,12 @@
         "a"
       ],
       "tokenReferences": [
-        "--fg"
+        "--border",
+        "--ease-standard",
+        "--fg",
+        "--focus-ring",
+        "--motion-fast",
+        "--radius-sm"
       ]
     },
     {
@@ -492,12 +509,16 @@
         "p"
       ],
       "tokenReferences": [
+        "--accent",
         "--fg",
         "--font-display",
         "--leading-tight",
         "--muted",
         "--text-2xl",
+        "--text-4xl",
+        "--text-lg",
         "--text-sm",
+        "--text-xs",
         "--tracking-display"
       ]
     },
@@ -525,8 +546,6 @@
       ],
       "classes": [
         "container",
-        "hero-grid",
-        "pins-grid",
         "stack-3",
         "stack-4"
       ],
@@ -543,12 +562,19 @@
         "--container-gutter-tablet",
         "--container-max",
         "--ease-standard",
+        "--fg",
+        "--focus-ring",
         "--font-display",
         "--motion-fast",
         "--muted",
         "--radius-pill",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-2",
+        "--space-3",
         "--space-4",
+        "--space-6",
         "--surface",
         "--text-lg",
         "--tracking-display"

--- a/design-systems/playstation/components.manifest.json
+++ b/design-systems/playstation/components.manifest.json
@@ -282,8 +282,16 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
-        "--surface"
+        "--ease-standard",
+        "--focus-ring",
+        "--font-body",
+        "--motion-fast",
+        "--radius-pill",
+        "--space-2",
+        "--surface",
+        "--text-base"
       ]
     },
     {
@@ -313,10 +321,12 @@
       "tokenReferences": [
         "--border",
         "--ease-standard",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--space-2",
-        "--text-base"
+        "--text-base",
+        "--text-sm"
       ]
     },
     {
@@ -347,6 +357,8 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
+        "--accent-on",
         "--border-soft",
         "--elev-raised",
         "--radius-lg",
@@ -378,6 +390,9 @@
         "--radius-pill",
         "--space-2",
         "--space-3",
+        "--success",
+        "--surface",
+        "--text-sm",
         "--text-xs"
       ]
     },
@@ -465,12 +480,16 @@
         "p"
       ],
       "tokenReferences": [
+        "--font-display",
         "--leading-body",
+        "--leading-tight",
         "--muted",
+        "--text-2xl",
         "--text-4xl",
         "--text-base",
         "--text-lg",
-        "--text-sm"
+        "--text-sm",
+        "--tracking-display"
       ]
     },
     {
@@ -487,8 +506,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4",
@@ -503,7 +520,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/posthog/components.manifest.json
+++ b/design-systems/posthog/components.manifest.json
@@ -555,12 +555,6 @@
       "present": true,
       "selectors": [
         ".container",
-        ".nav-links",
-        ".nav-links a",
-        ".nav-links a:hover",
-        ".nav-logo",
-        ".nav-logo:hover",
-        ".nav-row",
         ".row-between",
         ".stack-2 > * + *",
         ".stack-3 > * + *",
@@ -582,22 +576,18 @@
         "section"
       ],
       "tokenReferences": [
-        "--accent",
         "--border",
         "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--fg-2",
-        "--font-display",
         "--section-y-desktop",
         "--section-y-phone",
         "--section-y-tablet",
         "--space-2",
         "--space-3",
         "--space-4",
-        "--space-6",
-        "--text-lg"
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/posthog/components.manifest.json
+++ b/design-systems/posthog/components.manifest.json
@@ -323,13 +323,19 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--bg",
         "--border",
         "--ease-standard",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--font-display",
         "--motion-fast",
+        "--radius-md",
         "--radius-sm",
         "--space-2",
+        "--surface",
         "--surface-warm",
         "--text-sm",
         "--warn"
@@ -364,10 +370,20 @@
         "select"
       ],
       "tokenReferences": [
+        "--border",
+        "--ease-standard",
+        "--fg",
         "--fg-2",
+        "--focus-ring",
+        "--font-body",
         "--font-display",
         "--meta",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--text-base",
         "--text-sm",
         "--text-xs"
       ]
@@ -394,11 +410,13 @@
         "--border",
         "--ease-standard",
         "--elev-raised",
+        "--fg",
         "--motion-fast",
         "--radius-md",
         "--space-3",
         "--space-4",
-        "--space-5"
+        "--space-5",
+        "--surface"
       ]
     },
     {
@@ -422,8 +440,14 @@
       "tokenReferences": [
         "--border",
         "--fg-2",
+        "--font-display",
+        "--radius-pill",
+        "--space-2",
+        "--success",
         "--surface",
-        "--surface-warm"
+        "--surface-warm",
+        "--text-xs",
+        "--warn"
       ]
     },
     {
@@ -442,6 +466,7 @@
         "a"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--ease-standard",
         "--fg-2",
@@ -465,8 +490,10 @@
       "tokenReferences": [
         "--border",
         "--fg-2",
+        "--font-mono",
         "--radius-sm",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -515,7 +542,11 @@
         "--leading-tight",
         "--muted",
         "--text-3xl",
-        "--text-sm"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -540,8 +571,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-2",
         "stack-3",
@@ -561,8 +590,14 @@
         "--container-max",
         "--fg-2",
         "--font-display",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-2",
-        "--space-4"
+        "--space-3",
+        "--space-4",
+        "--space-6",
+        "--text-lg"
       ]
     }
   ],

--- a/design-systems/premium/components.manifest.json
+++ b/design-systems/premium/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/professional/components.manifest.json
+++ b/design-systems/professional/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/publication/components.manifest.json
+++ b/design-systems/publication/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/raycast/components.manifest.json
+++ b/design-systems/raycast/components.manifest.json
@@ -254,6 +254,8 @@
       ],
       "tokenReferences": [
         "--ease-standard",
+        "--fg",
+        "--focus-ring",
         "--font-display",
         "--motion-fast",
         "--radius-pill",
@@ -286,10 +288,13 @@
         "--fg",
         "--focus-ring",
         "--font-body",
+        "--meta",
         "--motion-fast",
+        "--muted",
         "--radius-sm",
         "--space-2",
-        "--text-base"
+        "--text-base",
+        "--text-sm"
       ]
     },
     {
@@ -306,7 +311,16 @@
         "card-title"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--ease-standard",
+        "--elev-ring",
+        "--fg",
+        "--motion-base",
+        "--radius-lg",
+        "--space-6",
+        "--surface",
+        "--text-xl"
+      ]
     },
     {
       "id": "badges",
@@ -324,7 +338,11 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--fg-2",
+        "--radius-pill",
+        "--space-2",
+        "--text-xs"
       ]
     },
     {
@@ -352,7 +370,10 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--space-2"
+        "--fg-2",
+        "--font-mono",
+        "--space-2",
+        "--text-xs"
       ]
     },
     {
@@ -390,11 +411,18 @@
       ],
       "tokenReferences": [
         "--fg",
+        "--fg-2",
         "--font-display",
+        "--leading-tight",
         "--meta",
         "--muted",
         "--text-3xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -411,8 +439,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "stack-3",
         "stack-4"
       ],
@@ -426,7 +452,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/refined/components.manifest.json
+++ b/design-systems/refined/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/renault/components.manifest.json
+++ b/design-systems/renault/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/replicate/components.manifest.json
+++ b/design-systems/replicate/components.manifest.json
@@ -262,7 +262,9 @@
         "button"
       ],
       "tokenReferences": [
+        "--bg",
         "--ease-standard",
+        "--fg",
         "--focus-ring",
         "--font-body",
         "--motion-fast",
@@ -298,9 +300,15 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--bg",
+        "--ease-standard",
+        "--fg",
         "--focus-ring",
         "--font-body",
         "--meta",
+        "--motion-fast",
+        "--radius-pill",
+        "--space-2",
         "--text-sm",
         "--text-xs"
       ]
@@ -316,7 +324,13 @@
         "card"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--bg",
+        "--fg",
+        "--radius-md",
+        "--space-3",
+        "--space-6"
+      ]
     },
     {
       "id": "badges",
@@ -339,6 +353,7 @@
         "--radius-pill",
         "--space-2",
         "--space-3",
+        "--success",
         "--text-xs"
       ]
     },
@@ -421,11 +436,17 @@
       "tokenReferences": [
         "--font-body",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--meta",
         "--muted",
         "--text-2xl",
-        "--text-xs"
+        "--text-3xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -443,8 +464,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -459,7 +478,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/resend/components.manifest.json
+++ b/design-systems/resend/components.manifest.json
@@ -302,10 +302,12 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--ease-standard",
         "--fg",
         "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-pill",
@@ -344,6 +346,8 @@
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
+        "--font-body",
         "--motion-fast",
         "--muted",
         "--radius-sm",
@@ -367,7 +371,13 @@
       "elements": [],
       "tokenReferences": [
         "--bg",
-        "--border"
+        "--border",
+        "--ease-standard",
+        "--motion-base",
+        "--radius-lg",
+        "--space-3",
+        "--space-6",
+        "--surface"
       ]
     },
     {
@@ -390,7 +400,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
-        "--success"
+        "--border",
+        "--fg-2",
+        "--font-body",
+        "--radius-pill",
+        "--space-1",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -430,7 +446,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--fg-2",
+        "--font-mono",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -475,13 +498,18 @@
       ],
       "tokenReferences": [
         "--fg",
+        "--fg-2",
+        "--font-body",
         "--font-display",
         "--font-mono",
         "--leading-tight",
         "--muted",
         "--space-6",
         "--text-3xl",
+        "--text-4xl",
         "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -501,7 +529,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -516,8 +543,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-4"
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/retro/components.manifest.json
+++ b/design-systems/retro/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/revolut/components.manifest.json
+++ b/design-systems/revolut/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -399,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/runwayml/components.manifest.json
+++ b/design-systems/runwayml/components.manifest.json
@@ -293,12 +293,16 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--border",
         "--ease-standard",
         "--fg",
         "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
+        "--muted",
         "--radius-sm",
         "--space-2",
         "--text-sm"
@@ -331,9 +335,19 @@
         "label"
       ],
       "tokenReferences": [
+        "--border",
+        "--ease-standard",
+        "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--meta",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--text-base",
         "--text-xs"
       ]
     },
@@ -357,8 +371,14 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--border",
         "--fg",
+        "--radius-md",
+        "--space-3",
         "--space-4",
+        "--space-5",
+        "--space-6",
+        "--surface",
         "--surface-warm",
         "--text-xs"
       ]
@@ -377,7 +397,12 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--radius-pill"
+        "--border",
+        "--muted",
+        "--radius-pill",
+        "--radius-sm",
+        "--space-2",
+        "--text-xs"
       ]
     },
     {
@@ -442,7 +467,6 @@
         "body-muted",
         "body-sm",
         "caption",
-        "hero-frame-caption",
         "lead"
       ],
       "elements": [
@@ -456,7 +480,12 @@
         "--font-display",
         "--leading-tight",
         "--muted",
-        "--text-3xl"
+        "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--tracking-display"
       ]
     },
     {
@@ -475,8 +504,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "stack-3",
         "stack-4"
       ],
@@ -490,8 +517,14 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-2",
         "--space-3",
-        "--space-6"
+        "--space-4",
+        "--space-6",
+        "--space-8"
       ]
     }
   ],

--- a/design-systems/runwayml/components.manifest.json
+++ b/design-systems/runwayml/components.manifest.json
@@ -318,9 +318,7 @@
         ".field input::placeholder",
         ".field input:focus-visible",
         ".field label",
-        ".field-help",
-        ".hero-frame-caption .label",
-        ".label"
+        ".field-help"
       ],
       "classes": [
         "field",

--- a/design-systems/sanity/components.manifest.json
+++ b/design-systems/sanity/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -399,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/sentry/components.manifest.json
+++ b/design-systems/sentry/components.manifest.json
@@ -272,9 +272,17 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--accent-active",
         "--accent-on",
+        "--bg",
+        "--ease-standard",
         "--fg",
-        "--focus-ring"
+        "--focus-ring",
+        "--font-body",
+        "--motion-fast",
+        "--radius-md",
+        "--space-2",
+        "--text-sm"
       ]
     },
     {
@@ -310,7 +318,8 @@
         "--muted",
         "--radius-sm",
         "--space-2",
-        "--text-sm"
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -331,6 +340,7 @@
         "--accent",
         "--border",
         "--elev-raised",
+        "--fg",
         "--radius-lg",
         "--space-3",
         "--space-6",
@@ -357,6 +367,7 @@
         "--muted",
         "--radius-pill",
         "--space-2",
+        "--success",
         "--text-xs"
       ]
     },
@@ -375,7 +386,8 @@
         "a"
       ],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--fg"
       ]
     },
     {
@@ -442,11 +454,19 @@
       ],
       "tokenReferences": [
         "--fg",
+        "--fg-2",
         "--font-body",
+        "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-2xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -464,8 +484,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -480,7 +498,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/shadcn/components.manifest.json
+++ b/design-systems/shadcn/components.manifest.json
@@ -292,12 +292,22 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
+        "--bg",
         "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-display",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
         "--space-3",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -326,9 +336,11 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--motion-fast",
         "--muted",
         "--radius-sm",
@@ -351,7 +363,15 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--fg"
+        "--border",
+        "--ease-standard",
+        "--elev-raised",
+        "--fg",
+        "--motion-base",
+        "--radius-md",
+        "--space-3",
+        "--space-6",
+        "--surface"
       ]
     },
     {
@@ -376,8 +396,14 @@
       "tokenReferences": [
         "--accent",
         "--accent-on",
+        "--bg",
         "--border",
-        "--fg"
+        "--fg",
+        "--font-display",
+        "--radius-pill",
+        "--space-1",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -393,7 +419,12 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--ease-standard",
+        "--fg",
+        "--focus-ring",
+        "--motion-fast"
+      ]
     },
     {
       "id": "keyboard",
@@ -462,9 +493,12 @@
         "--font-mono",
         "--leading-tight",
         "--muted",
+        "--space-4",
         "--text-2xl",
+        "--text-4xl",
         "--text-lg",
         "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -485,7 +519,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -500,7 +533,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-2",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/shopify/components.manifest.json
+++ b/design-systems/shopify/components.manifest.json
@@ -237,6 +237,7 @@
         "--bg",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-display",
         "--motion-base",
         "--radius-sm",
@@ -264,8 +265,19 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
+        "--border-soft",
+        "--ease-standard",
+        "--fg",
+        "--focus-ring",
+        "--font-body",
         "--meta",
+        "--motion-fast",
         "--muted",
+        "--radius-md",
+        "--space-2",
+        "--surface-warm",
+        "--text-base",
         "--text-sm"
       ]
     },
@@ -359,7 +371,10 @@
         "--font-display",
         "--leading-tight",
         "--muted",
-        "--text-3xl"
+        "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-xl"
       ]
     },
     {
@@ -376,10 +391,8 @@
       ],
       "classes": [
         "container",
-        "hero-grid",
         "stack-4",
-        "stack-6",
-        "stats-grid"
+        "stack-6"
       ],
       "elements": [
         "main",
@@ -391,7 +404,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/simple/components.manifest.json
+++ b/design-systems/simple/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/skeumorphism/components.manifest.json
+++ b/design-systems/skeumorphism/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/slack/components.manifest.json
+++ b/design-systems/slack/components.manifest.json
@@ -245,9 +245,22 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
         "--accent-hover",
+        "--accent-on",
+        "--bg",
+        "--border",
+        "--danger",
+        "--ease-standard",
+        "--fg",
         "--focus-ring",
-        "--surface"
+        "--font-body",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--space-4",
+        "--surface",
+        "--text-base"
       ]
     },
     {
@@ -270,8 +283,15 @@
         "label"
       ],
       "tokenReferences": [
+        "--bg",
+        "--border",
+        "--ease-standard",
         "--fg",
+        "--focus-ring",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
         "--text-base"
       ]
     },
@@ -350,7 +370,12 @@
         "--font-display",
         "--leading-tight",
         "--muted",
-        "--text-3xl"
+        "--text-2xl",
+        "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--tracking-display"
       ]
     },
     {
@@ -367,8 +392,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "stack-3",
         "stack-4"
       ],
@@ -382,7 +405,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/sleek/components.manifest.json
+++ b/design-systems/sleek/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/spacex/components.manifest.json
+++ b/design-systems/spacex/components.manifest.json
@@ -271,7 +271,16 @@
         "--accent-active",
         "--accent-hover",
         "--accent-on",
-        "--focus-ring"
+        "--border",
+        "--ease-standard",
+        "--fg",
+        "--focus-ring",
+        "--font-body",
+        "--motion-fast",
+        "--radius-pill",
+        "--space-2",
+        "--space-6",
+        "--text-sm"
       ]
     },
     {
@@ -300,8 +309,17 @@
       ],
       "tokenReferences": [
         "--accent-hover",
+        "--border",
+        "--ease-standard",
+        "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--space-3",
+        "--text-base",
         "--text-xs"
       ]
     },
@@ -336,7 +354,12 @@
         "a"
       ],
       "tokenReferences": [
-        "--accent-hover"
+        "--accent-hover",
+        "--border",
+        "--ease-standard",
+        "--fg",
+        "--motion-fast",
+        "--text-sm"
       ]
     },
     {
@@ -391,10 +414,15 @@
         "p"
       ],
       "tokenReferences": [
+        "--fg",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-2xl",
+        "--text-4xl",
+        "--text-base",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -414,7 +442,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
         "stack-4",
         "stack-6"
       ],
@@ -428,7 +455,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
         "--space-4",
+        "--space-6",
         "--space-8"
       ]
     }

--- a/design-systems/spacious/components.manifest.json
+++ b/design-systems/spacious/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/spotify/components.manifest.json
+++ b/design-systems/spotify/components.manifest.json
@@ -364,9 +364,6 @@
       "present": true,
       "selectors": [
         ".container",
-        ".nav-pill",
-        ".nav-pill:hover",
-        ".nav-pill.active",
         ".stack-3 > * + *",
         ".stack-4 > * + *",
         "section",
@@ -387,17 +384,11 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--ease-standard",
-        "--fg",
-        "--motion-fast",
-        "--radius-sm",
         "--section-y-desktop",
         "--section-y-phone",
         "--section-y-tablet",
         "--space-3",
-        "--space-4",
-        "--surface",
-        "--surface-warm"
+        "--space-4"
       ]
     }
   ],

--- a/design-systems/spotify/components.manifest.json
+++ b/design-systems/spotify/components.manifest.json
@@ -241,8 +241,18 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
         "--accent-hover",
-        "--focus-ring"
+        "--accent-on",
+        "--border",
+        "--ease-standard",
+        "--fg",
+        "--focus-ring",
+        "--font-body",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--surface-warm"
       ]
     },
     {
@@ -267,7 +277,12 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--elev-raised"
+        "--ease-standard",
+        "--elev-raised",
+        "--motion-base",
+        "--radius-md",
+        "--space-4",
+        "--surface"
       ]
     },
     {
@@ -334,10 +349,12 @@
       ],
       "tokenReferences": [
         "--fg",
+        "--font-body",
         "--font-display",
         "--leading-tight",
         "--muted",
         "--text-2xl",
+        "--text-lg",
         "--text-sm"
       ]
     },
@@ -356,9 +373,7 @@
         "section + section"
       ],
       "classes": [
-        "album-grid",
         "container",
-        "hero-grid",
         "stack-3",
         "stack-4"
       ],
@@ -372,7 +387,16 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--ease-standard",
+        "--fg",
+        "--motion-fast",
+        "--radius-sm",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
         "--space-4",
+        "--surface",
         "--surface-warm"
       ]
     }

--- a/design-systems/starbucks/components.manifest.json
+++ b/design-systems/starbucks/components.manifest.json
@@ -286,7 +286,9 @@
       "tokenReferences": [
         "--accent",
         "--accent-hover",
+        "--accent-on",
         "--ease-standard",
+        "--fg",
         "--focus-ring",
         "--font-body",
         "--motion-base",
@@ -294,6 +296,7 @@
         "--radius-pill",
         "--space-2",
         "--text-base",
+        "--text-sm",
         "--tracking-display"
       ]
     },
@@ -323,11 +326,21 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--space-4",
+        "--surface",
+        "--text-base",
         "--text-sm",
-        "--text-xs"
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -345,6 +358,11 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--elev-raised",
+        "--radius-md",
+        "--space-3",
+        "--space-6",
+        "--surface",
         "--text-xs"
       ]
     },
@@ -367,7 +385,13 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--success"
+        "--muted",
+        "--radius-pill",
+        "--space-2",
+        "--space-3",
+        "--success",
+        "--surface-warm",
+        "--text-xs"
       ]
     },
     {
@@ -451,8 +475,12 @@
       "tokenReferences": [
         "--fg",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
+        "--text-3xl",
+        "--text-lg",
+        "--text-sm",
         "--text-xl",
         "--text-xs",
         "--tracking-display"
@@ -472,8 +500,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -487,7 +513,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/storytelling/components.manifest.json
+++ b/design-systems/storytelling/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/stripe/components.manifest.json
+++ b/design-systems/stripe/components.manifest.json
@@ -322,14 +322,17 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-display",
         "--motion-fast",
         "--radius-sm",
         "--space-2",
-        "--text-base"
+        "--text-base",
+        "--text-sm"
       ]
     },
     {
@@ -364,16 +367,20 @@
         "select"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--ease-standard",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--motion-fast",
         "--muted",
         "--radius-sm",
         "--space-2",
         "--surface",
         "--text-base",
-        "--text-sm"
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -394,10 +401,19 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--ease-standard",
+        "--elev-raised",
+        "--fg",
+        "--font-display",
+        "--motion-base",
+        "--radius-lg",
         "--radius-md",
         "--space-3",
+        "--space-4",
         "--space-6",
-        "--surface"
+        "--space-8",
+        "--surface",
+        "--text-xl"
       ]
     },
     {
@@ -420,9 +436,11 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--muted",
         "--radius-sm",
+        "--success",
         "--surface-warm",
         "--text-xs"
       ]
@@ -439,7 +457,9 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--accent"
+      ]
     },
     {
       "id": "keyboard",
@@ -452,7 +472,13 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--fg-2",
+        "--font-mono",
+        "--radius-sm",
+        "--surface-warm"
+      ]
     },
     {
       "id": "icons",
@@ -494,12 +520,16 @@
         "p"
       ],
       "tokenReferences": [
+        "--accent",
         "--fg",
         "--font-display",
         "--leading-tight",
         "--muted",
         "--text-2xl",
+        "--text-4xl",
         "--text-sm",
+        "--text-xl",
+        "--text-xs",
         "--tracking-display"
       ]
     },
@@ -519,9 +549,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "form-grid-2",
-        "pricing-grid",
         "row-between",
         "stack-3",
         "stack-4",
@@ -532,11 +559,18 @@
         "section"
       ],
       "tokenReferences": [
+        "--border",
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
+        "--container-max",
         "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-6"
+        "--space-4",
+        "--space-6",
+        "--space-8"
       ]
     }
   ],

--- a/design-systems/stripe/components.manifest.json
+++ b/design-systems/stripe/components.manifest.json
@@ -349,8 +349,7 @@
         ".field select:focus-visible",
         ".field textarea",
         ".field textarea:focus-visible",
-        ".field-help",
-        ".metric-label"
+        ".field-help"
       ],
       "classes": [
         "field",

--- a/design-systems/supabase/components.manifest.json
+++ b/design-systems/supabase/components.manifest.json
@@ -294,14 +294,18 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-display",
         "--motion-fast",
         "--radius-pill",
+        "--radius-sm",
         "--space-2",
+        "--space-3",
         "--space-8",
         "--surface",
         "--text-sm"
@@ -334,10 +338,20 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--bg",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
         "--meta",
-        "--text-sm"
+        "--motion-fast",
+        "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--space-3",
+        "--space-4",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -353,6 +367,7 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--ease-standard",
         "--motion-base",
@@ -384,12 +399,17 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--accent",
+        "--bg",
         "--border",
         "--fg-2",
         "--font-display",
+        "--font-mono",
         "--radius-pill",
         "--space-1",
+        "--space-2",
         "--space-3",
+        "--success",
         "--surface",
         "--text-xs"
       ]
@@ -408,7 +428,11 @@
         "a"
       ],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--accent-hover",
+        "--ease-standard",
+        "--focus-ring",
+        "--motion-fast"
       ]
     },
     {
@@ -478,8 +502,12 @@
         "--font-mono",
         "--leading-tight",
         "--muted",
+        "--space-5",
         "--text-3xl",
+        "--text-4xl",
         "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -499,7 +527,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
         "row-between",
         "stack-4"
       ],
@@ -513,8 +540,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-4"
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/superhuman/components.manifest.json
+++ b/design-systems/superhuman/components.manifest.json
@@ -283,12 +283,15 @@
         "button"
       ],
       "tokenReferences": [
+        "--bg",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-sm",
         "--space-2",
+        "--space-3",
         "--space-5",
         "--surface-warm",
         "--text-base"
@@ -320,10 +323,20 @@
         "label"
       ],
       "tokenReferences": [
+        "--bg",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
-        "--text-sm"
+        "--radius-sm",
+        "--space-2",
+        "--space-4",
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -343,6 +356,8 @@
       "tokenReferences": [
         "--border",
         "--ease-standard",
+        "--elev-raised",
+        "--fg",
         "--motion-base",
         "--muted",
         "--radius-lg",
@@ -373,7 +388,13 @@
       "tokenReferences": [
         "--accent",
         "--accent-on",
-        "--muted"
+        "--muted",
+        "--radius-pill",
+        "--radius-sm",
+        "--space-2",
+        "--space-3",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -388,7 +409,9 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--fg"
+      ]
     },
     {
       "id": "keyboard",
@@ -455,10 +478,17 @@
         "p"
       ],
       "tokenReferences": [
+        "--fg",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
+        "--text-2xl",
         "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xs",
         "--tracking-display"
       ]
     },
@@ -478,8 +508,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4",
@@ -495,8 +523,13 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-5"
+        "--space-4",
+        "--space-5",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/tesla/components.manifest.json
+++ b/design-systems/tesla/components.manifest.json
@@ -297,8 +297,13 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--bg",
+        "--border",
         "--ease-standard",
+        "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--meta",
         "--motion-base",
@@ -337,10 +342,20 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--bg",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
         "--meta",
-        "--text-base"
+        "--motion-fast",
+        "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--space-4",
+        "--text-base",
+        "--text-sm"
       ]
     },
     {
@@ -368,7 +383,12 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--success"
+        "--font-body",
+        "--radius-pill",
+        "--space-2",
+        "--space-3",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -387,9 +407,12 @@
       ],
       "tokenReferences": [
         "--ease-standard",
+        "--fg",
         "--motion-base",
         "--muted",
-        "--surface"
+        "--radius-sm",
+        "--surface",
+        "--text-base"
       ]
     },
     {
@@ -454,11 +477,16 @@
       ],
       "tokenReferences": [
         "--fg",
+        "--font-body",
         "--font-display",
         "--leading-tight",
         "--muted",
+        "--text-2xl",
         "--text-3xl",
+        "--text-4xl",
         "--text-sm",
+        "--text-xl",
+        "--text-xs",
         "--tracking-display"
       ]
     },
@@ -483,7 +511,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
         "row-between",
         "stack-3",
         "stack-4",
@@ -500,10 +527,22 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--ease-standard",
+        "--fg",
+        "--font-display",
+        "--motion-base",
+        "--radius-sm",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-1",
         "--space-2",
         "--space-3",
+        "--space-4",
         "--space-6",
-        "--surface"
+        "--space-8",
+        "--surface",
+        "--text-base"
       ]
     }
   ],

--- a/design-systems/tesla/components.manifest.json
+++ b/design-systems/tesla/components.manifest.json
@@ -494,12 +494,6 @@
       "present": true,
       "selectors": [
         ".container",
-        ".nav",
-        ".nav-brand",
-        ".nav-inner",
-        ".nav-links",
-        ".nav-links a",
-        ".nav-links a:hover",
         ".row-between",
         ".stack-3 > * + *",
         ".stack-4 > * + *",
@@ -525,22 +519,13 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--ease-standard",
-        "--fg",
-        "--font-display",
-        "--motion-base",
-        "--radius-sm",
         "--section-y-desktop",
         "--section-y-phone",
         "--section-y-tablet",
-        "--space-1",
-        "--space-2",
         "--space-3",
         "--space-4",
         "--space-6",
-        "--space-8",
-        "--surface",
-        "--text-base"
+        "--space-8"
       ]
     }
   ],

--- a/design-systems/tesla/components.manifest.json
+++ b/design-systems/tesla/components.manifest.json
@@ -325,8 +325,7 @@
         ".field input:focus-visible",
         ".field input:hover",
         ".field label",
-        ".field-help",
-        ".hero-canvas-label"
+        ".field-help"
       ],
       "classes": [
         "field",
@@ -353,7 +352,6 @@
         "--muted",
         "--radius-sm",
         "--space-2",
-        "--space-4",
         "--text-base",
         "--text-sm"
       ]

--- a/design-systems/tetris/components.manifest.json
+++ b/design-systems/tetris/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -399,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/theverge/components.manifest.json
+++ b/design-systems/theverge/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -399,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/together-ai/components.manifest.json
+++ b/design-systems/together-ai/components.manifest.json
@@ -451,12 +451,6 @@
       "selectors": [
         ".container",
         ".row-between",
-        ".section-dark",
-        ".section-dark .btn-primary",
-        ".section-dark .btn-primary:hover",
-        ".section-dark .card",
-        ".section-dark .eyebrow",
-        ".section-dark p",
         ".stack-3 > * + *",
         ".stack-4 > * + *",
         ".stack-6 > * + *",
@@ -473,7 +467,6 @@
         "section"
       ],
       "tokenReferences": [
-        "--accent",
         "--border",
         "--container-gutter-desktop",
         "--container-gutter-phone",

--- a/design-systems/together-ai/components.manifest.json
+++ b/design-systems/together-ai/components.manifest.json
@@ -267,7 +267,10 @@
       "tokenReferences": [
         "--accent",
         "--accent-hover",
+        "--accent-on",
+        "--border",
         "--ease-standard",
+        "--fg",
         "--focus-ring",
         "--font-body",
         "--motion-fast",
@@ -303,10 +306,20 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--border",
+        "--ease-standard",
+        "--fg",
         "--focus-ring",
+        "--font-body",
         "--font-mono",
+        "--motion-fast",
         "--muted",
-        "--text-xs"
+        "--radius-sm",
+        "--space-2",
+        "--surface",
+        "--text-base",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -321,7 +334,13 @@
         "card"
       ],
       "elements": [],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--elev-raised",
+        "--radius-md",
+        "--space-3",
+        "--surface"
+      ]
     },
     {
       "id": "badges",
@@ -359,7 +378,10 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--fg",
+        "--tracking-display"
+      ]
     },
     {
       "id": "keyboard",
@@ -408,11 +430,16 @@
         "p"
       ],
       "tokenReferences": [
+        "--fg-2",
         "--font-display",
         "--font-mono",
+        "--leading-body",
         "--leading-tight",
         "--muted",
+        "--text-2xl",
         "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
         "--text-xs",
         "--tracking-display"
       ]
@@ -438,8 +465,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "stack-3",
         "stack-4"
       ],
@@ -454,7 +479,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/totality-festival/components.manifest.json
+++ b/design-systems/totality-festival/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/trading-terminal/components.manifest.json
+++ b/design-systems/trading-terminal/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/uber/components.manifest.json
+++ b/design-systems/uber/components.manifest.json
@@ -241,11 +241,13 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent-hover",
         "--accent-on",
         "--bg",
         "--border-soft",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-sm",
@@ -272,8 +274,16 @@
         "label"
       ],
       "tokenReferences": [
+        "--bg",
+        "--ease-standard",
+        "--fg",
+        "--font-body",
         "--meta",
+        "--motion-fast",
         "--muted",
+        "--radius-md",
+        "--space-2",
+        "--text-base",
         "--text-sm"
       ]
     },
@@ -291,7 +301,11 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--radius-lg"
+        "--bg",
+        "--elev-raised",
+        "--radius-lg",
+        "--radius-md",
+        "--space-6"
       ]
     },
     {
@@ -316,6 +330,7 @@
         "--font-body",
         "--motion-fast",
         "--radius-sm",
+        "--space-2",
         "--text-sm"
       ]
     },
@@ -379,8 +394,11 @@
         "--fg",
         "--font-display",
         "--leading-tight",
+        "--muted",
         "--text-3xl",
-        "--text-sm"
+        "--text-4xl",
+        "--text-sm",
+        "--text-xl"
       ]
     },
     {
@@ -397,8 +415,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "stack-3",
         "stack-4"
       ],
@@ -412,7 +428,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/urdu/components.manifest.json
+++ b/design-systems/urdu/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/vercel/components.manifest.json
+++ b/design-systems/vercel/components.manifest.json
@@ -327,8 +327,7 @@
         ".field input:focus-visible",
         ".field input:hover",
         ".field label",
-        ".field-help",
-        ".metric-label"
+        ".field-help"
       ],
       "classes": [
         "field",
@@ -346,7 +345,6 @@
         "--border",
         "--ease-standard",
         "--fg",
-        "--fg-2",
         "--focus-ring",
         "--meta",
         "--motion-fast",
@@ -354,7 +352,6 @@
         "--radius-sm",
         "--space-2",
         "--surface",
-        "--text-base",
         "--text-sm",
         "--text-xs"
       ]

--- a/design-systems/vercel/components.manifest.json
+++ b/design-systems/vercel/components.manifest.json
@@ -302,13 +302,17 @@
       ],
       "tokenReferences": [
         "--bg",
+        "--border",
         "--ease-standard",
         "--fg",
+        "--fg-2",
         "--focus-ring",
         "--font-display",
         "--motion-fast",
         "--radius-sm",
         "--space-2",
+        "--space-3",
+        "--surface",
         "--text-sm"
       ]
     },
@@ -339,12 +343,20 @@
         "label"
       ],
       "tokenReferences": [
+        "--border",
+        "--ease-standard",
         "--fg",
         "--fg-2",
         "--focus-ring",
         "--meta",
+        "--motion-fast",
+        "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--surface",
         "--text-base",
-        "--text-sm"
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -361,9 +373,11 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--bg",
         "--border",
         "--ease-standard",
         "--elev-raised",
+        "--fg",
         "--motion-base",
         "--radius-lg",
         "--radius-md",
@@ -393,7 +407,15 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
-        "--success"
+        "--bg",
+        "--border",
+        "--fg",
+        "--fg-2",
+        "--font-display",
+        "--radius-pill",
+        "--space-1",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -425,7 +447,13 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--fg-2",
+        "--font-mono",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -472,13 +500,17 @@
       "tokenReferences": [
         "--accent",
         "--fg",
+        "--fg-2",
         "--font-display",
         "--font-mono",
         "--leading-tight",
         "--muted",
         "--space-4",
         "--text-3xl",
+        "--text-4xl",
         "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -498,7 +530,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -513,8 +544,12 @@
         "--container-gutter-tablet",
         "--container-max",
         "--fg",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-3",
-        "--space-4"
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/vibrant/components.manifest.json
+++ b/design-systems/vibrant/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/vintage/components.manifest.json
+++ b/design-systems/vintage/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/vodafone/components.manifest.json
+++ b/design-systems/vodafone/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -399,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/voltagent/components.manifest.json
+++ b/design-systems/voltagent/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/warm-editorial/components.manifest.json
+++ b/design-systems/warm-editorial/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,9 +320,16 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
+        "--muted",
         "--radius-lg",
-        "--surface"
+        "--radius-md",
+        "--space-3",
+        "--space-4",
+        "--space-5",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -382,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -396,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/warp/components.manifest.json
+++ b/design-systems/warp/components.manifest.json
@@ -273,10 +273,18 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
-        "--space-3"
+        "--font-body",
+        "--motion-fast",
+        "--radius-pill",
+        "--space-2",
+        "--space-3",
+        "--space-5"
       ]
     },
     {
@@ -307,13 +315,18 @@
         "--border",
         "--ease-standard",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--font-body",
         "--meta",
         "--motion-fast",
+        "--muted",
         "--radius-sm",
         "--space-2",
         "--space-4",
-        "--surface"
+        "--surface",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -333,6 +346,7 @@
       "tokenReferences": [
         "--border",
         "--ease-standard",
+        "--fg-2",
         "--font-mono",
         "--meta",
         "--motion-base",
@@ -360,7 +374,13 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--success"
+        "--border",
+        "--fg-2",
+        "--radius-pill",
+        "--space-2",
+        "--space-3",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -442,11 +462,17 @@
       ],
       "tokenReferences": [
         "--fg",
+        "--fg-2",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-2xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -465,8 +491,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4",
@@ -482,7 +506,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
         "--space-4",
+        "--space-5",
         "--space-6"
       ]
     }

--- a/design-systems/webex/components.manifest.json
+++ b/design-systems/webex/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -399,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/webflow/components.manifest.json
+++ b/design-systems/webflow/components.manifest.json
@@ -276,8 +276,13 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--bg",
+        "--border",
         "--ease-standard",
+        "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-sm",
@@ -311,9 +316,21 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
+        "--bg",
+        "--border",
+        "--ease-standard",
         "--fg",
+        "--focus-ring",
+        "--font-body",
         "--meta",
-        "--text-sm"
+        "--motion-fast",
+        "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-base",
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -361,7 +378,12 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--font-display",
+        "--radius-sm",
+        "--space-2",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -377,6 +399,7 @@
         "a"
       ],
       "tokenReferences": [
+        "--accent",
         "--accent-hover"
       ]
     },
@@ -391,7 +414,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--font-mono",
+        "--muted",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -436,11 +466,17 @@
       "tokenReferences": [
         "--accent",
         "--fg",
+        "--fg-2",
         "--font-display",
         "--leading-tight",
         "--muted",
         "--text-3xl",
-        "--text-xs"
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -458,8 +494,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "stack-3",
         "stack-4"
       ],
@@ -473,7 +507,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/wechat/components.manifest.json
+++ b/design-systems/wechat/components.manifest.json
@@ -287,9 +287,12 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--border",
         "--ease-standard",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -325,9 +328,19 @@
       ],
       "tokenReferences": [
         "--accent",
+        "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
+        "--font-body",
         "--meta",
+        "--motion-fast",
+        "--muted",
+        "--radius-md",
+        "--space-2",
+        "--space-3",
+        "--surface",
+        "--text-base",
         "--text-sm",
         "--text-xs"
       ]
@@ -349,8 +362,14 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--border-soft",
+        "--elev-raised",
         "--leading-tight",
-        "--radius-md"
+        "--radius-lg",
+        "--radius-md",
+        "--space-3",
+        "--space-6",
+        "--surface"
       ]
     },
     {
@@ -371,8 +390,11 @@
       "elements": [],
       "tokenReferences": [
         "--accent-on",
+        "--muted",
         "--radius-pill",
-        "--success"
+        "--space-2",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -387,7 +409,9 @@
       "elements": [
         "a"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--accent"
+      ]
     },
     {
       "id": "keyboard",
@@ -400,7 +424,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--font-mono",
+        "--muted",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -446,9 +477,15 @@
       "tokenReferences": [
         "--fg",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
+        "--text-xs",
         "--tracking-display"
       ]
     },
@@ -468,8 +505,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4"
@@ -484,8 +519,13 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
         "--space-2",
-        "--space-4"
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/wired/components.manifest.json
+++ b/design-systems/wired/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -399,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/design-systems/wise/components.manifest.json
+++ b/design-systems/wise/components.manifest.json
@@ -273,8 +273,11 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
         "--ease-standard",
+        "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-pill",
@@ -308,8 +311,17 @@
       ],
       "tokenReferences": [
         "--accent-on",
+        "--bg",
+        "--border",
+        "--ease-standard",
+        "--fg",
         "--focus-ring",
+        "--font-body",
+        "--motion-fast",
         "--muted",
+        "--radius-sm",
+        "--space-2",
+        "--text-base",
         "--text-sm",
         "--text-xs"
       ]
@@ -328,6 +340,8 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--bg",
+        "--elev-ring",
         "--radius-md",
         "--space-3",
         "--space-8",
@@ -351,7 +365,13 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--success"
+        "--muted",
+        "--radius-pill",
+        "--space-2",
+        "--space-3",
+        "--success",
+        "--surface",
+        "--text-xs"
       ]
     },
     {
@@ -368,7 +388,8 @@
       ],
       "tokenReferences": [
         "--accent",
-        "--accent-on"
+        "--accent-on",
+        "--fg"
       ]
     },
     {
@@ -382,7 +403,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--font-mono",
+        "--muted",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -427,10 +455,14 @@
       "tokenReferences": [
         "--fg",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--muted",
         "--text-3xl",
+        "--text-4xl",
+        "--text-lg",
         "--text-sm",
+        "--text-xl",
         "--tracking-display"
       ]
     },
@@ -449,8 +481,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "hero-grid",
         "row-between",
         "stack-3",
         "stack-4",
@@ -466,7 +496,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
-        "--space-4"
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-3",
+        "--space-4",
+        "--space-6"
       ]
     }
   ],

--- a/design-systems/x-ai/components.manifest.json
+++ b/design-systems/x-ai/components.manifest.json
@@ -258,9 +258,21 @@
         "button"
       ],
       "tokenReferences": [
+        "--accent",
+        "--accent-active",
         "--accent-hover",
+        "--accent-on",
+        "--ease-standard",
         "--fg",
-        "--focus-ring"
+        "--focus-ring",
+        "--font-display",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--space-3",
+        "--space-6",
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -288,8 +300,20 @@
         "textarea"
       ],
       "tokenReferences": [
+        "--ease-standard",
+        "--fg",
         "--fg-2",
         "--focus-ring",
+        "--font-body",
+        "--leading-body",
+        "--meta",
+        "--motion-fast",
+        "--radius-sm",
+        "--space-2",
+        "--space-3",
+        "--space-4",
+        "--surface",
+        "--text-base",
         "--text-sm"
       ]
     },
@@ -310,9 +334,19 @@
       ],
       "elements": [],
       "tokenReferences": [
+        "--border",
+        "--ease-standard",
+        "--elev-flat",
+        "--fg",
         "--fg-2",
+        "--font-body",
+        "--motion-base",
+        "--radius-md",
+        "--space-6",
+        "--surface",
         "--surface-warm",
-        "--text-base"
+        "--text-base",
+        "--text-xl"
       ]
     },
     {
@@ -334,6 +368,7 @@
         "--radius-sm",
         "--space-1",
         "--space-2",
+        "--space-8",
         "--text-xs"
       ]
     },
@@ -397,11 +432,13 @@
         "--font-display",
         "--leading-tight",
         "--muted",
+        "--text-2xl",
         "--text-4xl",
         "--text-lg",
         "--text-sm",
         "--text-xl",
-        "--text-xs"
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -419,8 +456,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "form-grid",
         "stack-3",
         "stack-4"
       ],
@@ -434,7 +469,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-2",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/xiaohongshu/components.manifest.json
+++ b/design-systems/xiaohongshu/components.manifest.json
@@ -366,8 +366,7 @@
         ".field textarea",
         ".field textarea::placeholder",
         ".field textarea:focus",
-        ".field-help",
-        ".hero-meta-stat-label"
+        ".field-help"
       ],
       "classes": [
         "field",

--- a/design-systems/xiaohongshu/components.manifest.json
+++ b/design-systems/xiaohongshu/components.manifest.json
@@ -337,15 +337,20 @@
       "tokenReferences": [
         "--accent",
         "--accent-active",
+        "--accent-hover",
         "--accent-on",
+        "--border",
         "--border-soft",
         "--ease-standard",
+        "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--muted",
         "--radius-pill",
         "--space-2",
-        "--text-sm"
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -378,15 +383,23 @@
         "textarea"
       ],
       "tokenReferences": [
+        "--bg",
         "--border",
+        "--ease-standard",
         "--fg",
         "--focus-ring",
         "--font-body",
+        "--meta",
+        "--motion-fast",
+        "--muted",
         "--radius-md",
+        "--radius-pill",
+        "--space-2",
         "--space-3",
         "--space-4",
         "--surface",
-        "--text-sm"
+        "--text-sm",
+        "--text-xs"
       ]
     },
     {
@@ -402,7 +415,13 @@
       ],
       "elements": [],
       "tokenReferences": [
-        "--elev-raised"
+        "--ease-standard",
+        "--elev-raised",
+        "--motion-base",
+        "--radius-md",
+        "--space-3",
+        "--space-6",
+        "--surface"
       ]
     },
     {
@@ -422,7 +441,12 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
-        "--accent-on"
+        "--accent-on",
+        "--fg-2",
+        "--radius-pill",
+        "--space-2",
+        "--success",
+        "--text-xs"
       ]
     },
     {
@@ -441,9 +465,15 @@
       ],
       "tokenReferences": [
         "--accent-hover",
+        "--ease-standard",
+        "--fg",
         "--fg-2",
+        "--motion-fast",
+        "--muted",
         "--radius-pill",
-        "--space-3"
+        "--space-2",
+        "--space-3",
+        "--text-sm"
       ]
     },
     {
@@ -457,7 +487,14 @@
       "elements": [
         "kbd"
       ],
-      "tokenReferences": []
+      "tokenReferences": [
+        "--border",
+        "--font-mono",
+        "--muted",
+        "--radius-sm",
+        "--surface",
+        "--text-xs"
+      ]
     },
     {
       "id": "icons",
@@ -476,7 +513,8 @@
         "svg"
       ],
       "tokenReferences": [
-        "--accent"
+        "--accent",
+        "--muted"
       ]
     },
     {
@@ -510,8 +548,13 @@
         "--fg-2",
         "--font-body",
         "--font-display",
+        "--leading-body",
         "--leading-tight",
         "--text-2xl",
+        "--text-4xl",
+        "--text-lg",
+        "--text-sm",
+        "--text-xl",
         "--text-xs",
         "--tracking-display"
       ]
@@ -532,9 +575,6 @@
       ],
       "classes": [
         "container",
-        "features-grid",
-        "feed-grid",
-        "hero-grid",
         "row-between",
         "stack-2",
         "stack-3",
@@ -552,7 +592,12 @@
         "--container-gutter-phone",
         "--container-gutter-tablet",
         "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet",
+        "--space-2",
         "--space-3",
+        "--space-4",
         "--space-6"
       ]
     }

--- a/design-systems/zapier/components.manifest.json
+++ b/design-systems/zapier/components.manifest.json
@@ -254,11 +254,13 @@
       "elements": [],
       "tokenReferences": [
         "--accent",
+        "--accent-hover",
         "--accent-on",
         "--border",
         "--ease-standard",
         "--elev-ring",
         "--fg",
+        "--focus-ring",
         "--font-body",
         "--motion-fast",
         "--radius-md",
@@ -285,13 +287,17 @@
         "label"
       ],
       "tokenReferences": [
+        "--accent",
         "--border",
         "--fg",
+        "--fg-2",
+        "--focus-ring",
         "--radius-sm",
         "--space-2",
         "--space-4",
         "--space-5",
-        "--surface"
+        "--surface",
+        "--text-sm"
       ]
     },
     {
@@ -314,10 +320,14 @@
       "elements": [],
       "tokenReferences": [
         "--border",
+        "--border-soft",
         "--elev-raised",
         "--muted",
         "--radius-lg",
+        "--radius-md",
         "--space-3",
+        "--space-4",
+        "--space-5",
         "--surface",
         "--text-sm"
       ]
@@ -385,9 +395,16 @@
       ],
       "tokenReferences": [
         "--fg-2",
+        "--font-display",
+        "--font-mono",
+        "--leading-tight",
+        "--meta",
+        "--text-3xl",
         "--text-4xl",
         "--text-lg",
-        "--text-xl"
+        "--text-xl",
+        "--text-xs",
+        "--tracking-display"
       ]
     },
     {
@@ -399,17 +416,20 @@
         "section"
       ],
       "classes": [
-        "container",
-        "metric-grid"
+        "container"
       ],
       "elements": [
         "main",
         "section"
       ],
       "tokenReferences": [
+        "--container-gutter-desktop",
         "--container-gutter-phone",
         "--container-gutter-tablet",
-        "--section-y-desktop"
+        "--container-max",
+        "--section-y-desktop",
+        "--section-y-phone",
+        "--section-y-tablet"
       ]
     }
   ],

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -76,14 +76,14 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
     id: 'buttons',
     label: 'Buttons and calls to action',
     selectorMatchers: [/\bbutton\b/i, /\.btn(?:\b|[-_:])/i, /\[type=["']?(?:button|submit|reset)/i],
-    classMatchers: [/^btn(?:$|-)/i, /button/i, /cta/i],
+    classMatchers: [/^btn(?:$|-)/i, /^button(?:$|-)/i, /^cta(?:$|-)/i],
     elementMatchers: [/^button$/i],
   },
   {
     id: 'inputs',
     label: 'Form fields and controls',
-    selectorMatchers: [/\binput\b/i, /\btextarea\b/i, /\bselect\b/i, /\.field(?:\b|[-_:])/i, /\blabel\b/i],
-    classMatchers: [/^field(?:$|-)/i, /input/i, /control/i, /form/i],
+    selectorMatchers: [/\binput\b/i, /\btextarea\b/i, /(?<![\w.#-])select(?![\w-])/i, /\.field(?:\b|[-_:])/i, /\blabel\b/i],
+    classMatchers: [/^field(?:$|-)/i, /^input(?:$|-)/i, /^control(?:$|-)/i, /^form(?:$|-)/i],
     elementMatchers: [/^(input|textarea|select|label|form)$/i],
   },
   {
@@ -97,7 +97,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
     id: 'badges',
     label: 'Badges, chips, and status labels',
     selectorMatchers: [/\.badge(?:\b|[-_:])/i, /\.chip(?:\b|[-_:])/i, /\.tag(?:\b|[-_:])/i, /\.pill(?:\b|[-_:])/i],
-    classMatchers: [/^badge(?:$|-)/i, /^chip(?:$|-)/i, /^tag(?:$|-)/i, /^pill(?:$|-)/i, /status/i],
+    classMatchers: [/^badge(?:$|-)/i, /^chip(?:$|-)/i, /^tag(?:$|-)/i, /^pill(?:$|-)/i, /^status(?:$|-)/i],
     elementMatchers: [],
   },
   {
@@ -111,7 +111,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
     id: 'keyboard',
     label: 'Keyboard hints',
     selectorMatchers: [/\bkbd\b/i, /\.kbd(?:\b|[-_:])/i],
-    classMatchers: [/^kbd(?:$|-)/i, /keyboard/i, /shortcut/i],
+    classMatchers: [/^kbd(?:$|-)/i, /^keyboard(?:$|-)/i, /^shortcut(?:$|-)/i],
     elementMatchers: [/^kbd$/i],
   },
   {
@@ -125,7 +125,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
     id: 'typography',
     label: 'Typography scale and text utilities',
     selectorMatchers: [/\bh[1-6]\b/i, /\.lead(?:\b|[-_:])/i, /\.eyebrow(?:\b|[-_:])/i, /\.body-(?:muted|sm|small)\b/i],
-    classMatchers: [/^lead$/i, /^eyebrow$/i, /^body-(?:muted|sm|small)$/i, /caption/i],
+    classMatchers: [/^lead$/i, /^eyebrow$/i, /^body-(?:muted|sm|small)$/i, /^caption(?:$|-)/i],
     elementMatchers: [/^h[1-6]$/i, /^p$/i],
   },
   {
@@ -139,7 +139,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
       /\bmain\b/i,
       /\bnav\b/i,
     ],
-    classMatchers: [/^container$/i, /^stack-\d+$/i, /^row-(?:between|center|start|end)$/i, /grid/i, /layout/i],
+    classMatchers: [/^container$/i, /^stack-\d+$/i, /^row-(?:between|center|start|end)$/i, /^grid$/i, /^layout(?:$|-)/i],
     elementMatchers: [/^(main|section|nav|header|footer)$/i],
   },
 ];
@@ -259,51 +259,27 @@ function extractStyleBlocks(html: string): string[] {
 
 function extractCssSelectors(css: string): string[] {
   const selectors = new Set<string>();
-  const commentlessCss = stripContainerAtRuleHeaders(stripCssComments(css));
-  const selectorPattern = /(?:^|[{}])\s*([^@{}][^{}]*?)\s*\{/g;
-  let match: RegExpExecArray | null;
-
-  while ((match = selectorPattern.exec(commentlessCss)) !== null) {
-    const rawSelectorList = match[1]?.trim();
-    if (rawSelectorList == null || rawSelectorList.length === 0) continue;
-    if (rawSelectorList.includes(':root')) continue;
-    if (/^(?:from|to|\d+(?:\.\d+)?%)$/i.test(rawSelectorList)) continue;
-
-    for (const selector of splitSelectorList(rawSelectorList)) {
-      const normalized = normalizeSelector(selector);
-      if (normalized.length > 0 && !normalized.startsWith('@')) {
-        selectors.add(normalized);
-      }
+  for (const rule of collectCssRules(css)) {
+    for (const selector of rule.selectors) {
+      selectors.add(selector);
     }
   }
-
   return [...selectors].sort((a, b) => a.localeCompare(b));
 }
 
 function extractSelectorTokenReferences(css: string): Map<string, string[]> {
   const referencesBySelector = new Map<string, Set<string>>();
-  const commentlessCss = stripContainerAtRuleHeaders(stripCssComments(css));
-  const rulePattern = /(?:^|[{}])\s*([^@{}][^{}]*?)\s*\{([^{}]*)\}/g;
-  let match: RegExpExecArray | null;
 
-  while ((match = rulePattern.exec(commentlessCss)) !== null) {
-    const rawSelectorList = match[1]?.trim();
-    const rawBody = match[2] ?? '';
-    if (rawSelectorList == null || rawSelectorList.length === 0) continue;
-    if (rawSelectorList.includes(':root')) continue;
-    if (/^(?:from|to|\d+(?:\.\d+)?%)$/i.test(rawSelectorList)) continue;
-
-    const tokenReferences = extractTokenReferences(rawBody);
+  for (const rule of collectCssRules(css)) {
+    const tokenReferences = extractTokenReferences(rule.declarations);
     if (tokenReferences.length === 0) continue;
 
-    for (const selector of splitSelectorList(rawSelectorList)) {
-      const normalized = normalizeSelector(selector);
-      if (normalized.length === 0 || normalized.startsWith('@')) continue;
-      const selectorReferences = referencesBySelector.get(normalized) ?? new Set<string>();
+    for (const selector of rule.selectors) {
+      const selectorReferences = referencesBySelector.get(selector) ?? new Set<string>();
       for (const token of tokenReferences) {
         selectorReferences.add(token);
       }
-      referencesBySelector.set(normalized, selectorReferences);
+      referencesBySelector.set(selector, selectorReferences);
     }
   }
 
@@ -312,6 +288,113 @@ function extractSelectorTokenReferences(css: string): Map<string, string[]> {
       .map(([selector, references]) => [selector, [...references].sort((a, b) => a.localeCompare(b))] as const)
       .sort(([left], [right]) => left.localeCompare(right)),
   );
+}
+
+type CssRule = {
+  selectors: string[];
+  declarations: string;
+};
+
+const CONDITIONAL_GROUP_AT_RULES = /^@(?:media|supports|container|layer)\b/i;
+
+/**
+ * Brace-depth CSS scanner. Invariant: every rule's own declarations (excluding
+ * nested-block bodies) are attributed to its resolved selector list — including
+ * rules that follow another rule or a `:root` block, and rules using CSS
+ * nesting (`&:hover { ... }`, nested conditional at-rules). Non-conditional
+ * at-rules (`@keyframes`, `@font-face`, ...) and `:root` rules are skipped.
+ */
+function collectCssRules(css: string): CssRule[] {
+  const rules: CssRule[] = [];
+  walkCssBlock(stripCssComments(css), [], rules);
+  return rules;
+}
+
+function walkCssBlock(body: string, selfSelectors: string[], out: CssRule[]): void {
+  let declarations = '';
+  let segment = '';
+  let index = 0;
+
+  while (index < body.length) {
+    const char = body[index];
+    if (char === '{') {
+      const close = findMatchingBrace(body, index);
+      const { leadingDeclarations, prelude } = splitBlockPrelude(segment);
+      declarations += leadingDeclarations;
+      enterCssBlock(prelude.trim(), body.slice(index + 1, close), selfSelectors, out);
+      segment = '';
+      index = close + 1;
+      continue;
+    }
+    if (char === '}') {
+      declarations += segment;
+      segment = '';
+      index += 1;
+      continue;
+    }
+    segment += char;
+    index += 1;
+  }
+
+  declarations += segment;
+  if (selfSelectors.length > 0) {
+    out.push({ selectors: selfSelectors, declarations });
+  }
+}
+
+function enterCssBlock(prelude: string, body: string, parentSelectors: string[], out: CssRule[]): void {
+  if (prelude.length === 0) return;
+  if (prelude.startsWith('@')) {
+    if (CONDITIONAL_GROUP_AT_RULES.test(prelude)) {
+      walkCssBlock(body, parentSelectors, out);
+    }
+    return;
+  }
+  if (prelude.includes(':root')) return;
+
+  const selectors = splitSelectorList(prelude)
+    .map((selector) => normalizeSelector(selector))
+    .filter((selector) => selector.length > 0);
+  const resolved = resolveNestedSelectors(selectors, parentSelectors);
+  if (resolved.length === 0) return;
+  walkCssBlock(body, resolved, out);
+}
+
+function resolveNestedSelectors(selectors: string[], parentSelectors: string[]): string[] {
+  if (parentSelectors.length === 0) return selectors;
+  return parentSelectors.flatMap((parent) =>
+    selectors.map((selector) =>
+      selector.includes('&') ? selector.replaceAll('&', parent) : `${parent} ${selector}`,
+    ),
+  );
+}
+
+function splitBlockPrelude(segment: string): { leadingDeclarations: string; prelude: string } {
+  let depth = 0;
+  let lastSemicolon = -1;
+  for (let index = 0; index < segment.length; index += 1) {
+    const char = segment[index];
+    if (char === '(' || char === '[') depth += 1;
+    else if (char === ')' || char === ']') depth = Math.max(0, depth - 1);
+    else if (char === ';' && depth === 0) lastSemicolon = index;
+  }
+  return {
+    leadingDeclarations: segment.slice(0, lastSemicolon + 1),
+    prelude: segment.slice(lastSemicolon + 1),
+  };
+}
+
+function findMatchingBrace(source: string, openIndex: number): number {
+  let depth = 0;
+  for (let index = openIndex; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === '{') depth += 1;
+    else if (char === '}') {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
+  }
+  return source.length;
 }
 
 function splitSelectorList(selectorList: string): string[] {
@@ -400,10 +483,6 @@ function stripRootBlocks(css: string): string {
 
 function stripCssComments(css: string): string {
   return css.replace(/\/\*[\s\S]*?\*\//g, '');
-}
-
-function stripContainerAtRuleHeaders(css: string): string {
-  return css.replace(/@(media|supports|container|layer)\b[^{]*\{/gi, '{');
 }
 
 function countLiterals(css: string): ComponentManifestLiteralInventory {

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -499,15 +499,24 @@ type CssRule = {
 const TRAVERSABLE_GROUP_AT_RULES = /^@(?:media|supports|container|layer|scope|starting-style)\b/i;
 
 /**
+ * A block prelude that is actually an in-progress custom-property declaration.
+ * Custom properties accept the permissive `<declaration-value>` grammar, which
+ * includes balanced brace blocks (CSS Variables §2.1), so a `{` after
+ * `--name:` opens value text, not a nested rule.
+ */
+const CUSTOM_PROPERTY_DECLARATION_PRELUDE = /^--[-\w\u0080-\uffff]*\s*:/;
+
+/**
  * Brace-depth CSS scanner. Invariant: every rule's own declarations (excluding
  * nested-block bodies) are attributed to its resolved selector list — including
  * rules that follow another rule or a `:root` block, and rules using CSS
  * nesting (`&:hover { ... }`, nested grouping at-rules such as `@media` or
  * `@starting-style`). Braces and quotes inside quoted strings (`content: '{'`),
  * behind CSS escapes (`.content-\[\'x\'\]`), or inside function values
- * (unquoted `url(...)` data URIs) are text, not structure. At-rules whose
- * bodies do not describe the current selector tree (`@keyframes`,
- * `@font-face`, ...) and `:root` rules are skipped.
+ * (unquoted `url(...)` data URIs) are text, not structure, and so are
+ * balanced brace blocks inside custom-property values (`--payload: { ... };`).
+ * At-rules whose bodies do not describe the current selector tree
+ * (`@keyframes`, `@font-face`, ...) and `:root` rules are skipped.
  */
 function collectCssRules(css: string): CssRule[] {
   const rules: CssRule[] = [];
@@ -537,6 +546,11 @@ function walkCssBlock(body: string, selfSelectors: string[], out: CssRule[]): vo
     if (char === '{' && parenDepth === 0) {
       const close = findMatchingBrace(body, index);
       const { leadingDeclarations, prelude } = splitBlockPrelude(segment);
+      if (CUSTOM_PROPERTY_DECLARATION_PRELUDE.test(prelude.trim())) {
+        segment += body.slice(index, close + 1);
+        index = close + 1;
+        continue;
+      }
       declarations += leadingDeclarations;
       enterCssBlock(prelude.trim(), body.slice(index + 1, close), selfSelectors, out);
       segment = '';

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -499,12 +499,28 @@ type CssRule = {
 const TRAVERSABLE_GROUP_AT_RULES = /^@(?:media|supports|container|layer|scope|starting-style)\b/i;
 
 /**
- * A block prelude that is actually an in-progress custom-property declaration.
- * Custom properties accept the permissive `<declaration-value>` grammar, which
- * includes balanced brace blocks (CSS Variables §2.1), so a `{` after
- * `--name:` opens value text, not a nested rule.
+ * True when a block prelude is an in-progress custom-property declaration
+ * (`--<ident>` through its colon). Custom properties accept the permissive
+ * `<declaration-value>` grammar, which includes balanced brace blocks
+ * (CSS Variables §2.1), so a `{` after `--name:` opens value text, not a
+ * nested rule. Property names use the `<ident-token>` grammar, so CSS
+ * escapes inside the name are consumed in full via `cssEscapeEndIndex`.
  */
-const CUSTOM_PROPERTY_DECLARATION_PRELUDE = /^--[-\w\u0080-\uffff]*\s*:/;
+function isCustomPropertyDeclarationPrelude(prelude: string): boolean {
+  if (!prelude.startsWith('--')) return false;
+  let index = 2;
+  while (index < prelude.length) {
+    const char = prelude.charAt(index);
+    if (char === '\\') {
+      index = cssEscapeEndIndex(prelude, index);
+      continue;
+    }
+    if (!SELECTOR_IDENT_CHAR.test(char)) break;
+    index += 1;
+  }
+  while (index < prelude.length && /\s/.test(prelude.charAt(index))) index += 1;
+  return prelude.charAt(index) === ':';
+}
 
 /**
  * Brace-depth CSS scanner. Invariant: every rule's own declarations (excluding
@@ -546,7 +562,7 @@ function walkCssBlock(body: string, selfSelectors: string[], out: CssRule[]): vo
     if (char === '{' && parenDepth === 0) {
       const close = findMatchingBrace(body, index);
       const { leadingDeclarations, prelude } = splitBlockPrelude(segment);
-      if (CUSTOM_PROPERTY_DECLARATION_PRELUDE.test(prelude.trim())) {
+      if (isCustomPropertyDeclarationPrelude(prelude.trim())) {
         segment += body.slice(index, close + 1);
         index = close + 1;
         continue;

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -67,6 +67,13 @@ type ComponentGroupDefinition = {
   id: ComponentManifestGroupId;
   label: string;
   selectorMatchers: RegExp[];
+  /**
+   * Element names matched only where CSS grammar allows a type selector.
+   * Unlike `selectorMatchers`, these never match inside class/ID names,
+   * attribute selectors, or pseudo-element names/arguments — see
+   * `selectorContainsTypeSelector`.
+   */
+  typeSelectorNames?: string[];
   classMatchers: RegExp[];
   elementMatchers: RegExp[];
 };
@@ -82,7 +89,8 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
   {
     id: 'inputs',
     label: 'Form fields and controls',
-    selectorMatchers: [/\binput\b/i, /\btextarea\b/i, /(?:^|[\s>+~,(])select(?:$|[\s>+~,.:#[)])/i, /\.field(?:\b|[-_:])/i, /\blabel\b/i],
+    selectorMatchers: [/\.field(?:\b|[-_:])/i],
+    typeSelectorNames: ['input', 'textarea', 'select', 'label'],
     classMatchers: [/^field(?:$|-)/i, /^input(?:$|-)/i, /^control(?:$|-)/i, /^form(?:$|-)/i],
     elementMatchers: [/^(input|textarea|select|label|form)$/i],
   },
@@ -213,6 +221,118 @@ export function summarizeComponentsManifestForPrompt(manifest: ComponentsManifes
   ].join('\n');
 }
 
+/**
+ * Invariant: a form-control name counts as present in a selector only where
+ * CSS grammar allows a type selector to occur. Class and ID names, attribute
+ * selectors, and pseudo-class/pseudo-element names never contribute matches,
+ * and neither do pseudo-element arguments that name parts rather than
+ * elements (e.g. `::part(select)`). Arguments of functional pseudo-classes
+ * (`:is()`, `:has()`, `:not()`, `:where()`) and of `::slotted()` are real
+ * selectors, so names inside them stay matchable.
+ */
+function selectorContainsTypeSelector(selector: string, name: string): boolean {
+  const masked = maskNonTypeSelectorText(selector);
+  const boundary = new RegExp(`(?:^|[\\s>+~,(])${name}(?:$|[\\s>+~,.:#[)])`, 'i');
+  return boundary.test(masked);
+}
+
+const SELECTOR_IDENT_CHAR = /[-\w\u0080-\uffff]/;
+
+/**
+ * Blanks out every part of a selector where a type selector cannot occur —
+ * class/ID names, attribute blocks, pseudo names, and name-valued
+ * pseudo-element arguments — replacing them with spaces so the surviving
+ * text can be matched for element names with plain boundary checks.
+ * Quotes and CSS escapes inside attribute blocks are honored so a bracket
+ * or quote inside a string never ends the block early.
+ */
+function maskNonTypeSelectorText(selector: string): string {
+  let out = '';
+  let index = 0;
+
+  const maskIdentifier = (): void => {
+    while (index < selector.length) {
+      const char = selector.charAt(index);
+      if (char === '\\') {
+        out += '  ';
+        index += 2;
+        continue;
+      }
+      if (!SELECTOR_IDENT_CHAR.test(char)) break;
+      out += ' ';
+      index += 1;
+    }
+  };
+
+  const maskDelimitedBlock = (open: string, close: string): void => {
+    let depth = 0;
+    while (index < selector.length) {
+      const char = selector.charAt(index);
+      if (char === '\\') {
+        out += '  ';
+        index += 2;
+        continue;
+      }
+      if (char === '"' || char === "'") {
+        out += ' ';
+        index += 1;
+        while (index < selector.length) {
+          const quoted = selector.charAt(index);
+          if (quoted === '\\') {
+            out += '  ';
+            index += 2;
+            continue;
+          }
+          out += ' ';
+          index += 1;
+          if (quoted === char) break;
+        }
+        continue;
+      }
+      if (char === open) depth += 1;
+      if (char === close) depth -= 1;
+      out += ' ';
+      index += 1;
+      if (depth === 0) break;
+    }
+  };
+
+  while (index < selector.length) {
+    const char = selector.charAt(index);
+    if (char === '\\') {
+      out += '  ';
+      index += 2;
+      continue;
+    }
+    if (char === '.' || char === '#') {
+      out += ' ';
+      index += 1;
+      maskIdentifier();
+      continue;
+    }
+    if (char === '[') {
+      maskDelimitedBlock('[', ']');
+      continue;
+    }
+    if (char === ':') {
+      const isPseudoElement = selector.charAt(index + 1) === ':';
+      out += isPseudoElement ? '  ' : ' ';
+      index += isPseudoElement ? 2 : 1;
+      const nameStart = index;
+      maskIdentifier();
+      const pseudoName = selector.slice(nameStart, index).toLowerCase();
+      if (selector.charAt(index) === '(' && isPseudoElement && pseudoName !== 'slotted') {
+        maskDelimitedBlock('(', ')');
+      }
+      continue;
+    }
+    out += char;
+    index += 1;
+  }
+
+  return out;
+}
+
 function buildGroupManifest(
   definition: ComponentGroupDefinition,
   inventory: {
@@ -223,8 +343,10 @@ function buildGroupManifest(
     referencedTokens: string[];
   },
 ): ComponentManifestGroup {
-  const selectors = inventory.selectors.filter((selector) =>
-    definition.selectorMatchers.some((matcher) => matcher.test(selector)),
+  const selectors = inventory.selectors.filter(
+    (selector) =>
+      definition.selectorMatchers.some((matcher) => matcher.test(selector)) ||
+      (definition.typeSelectorNames ?? []).some((name) => selectorContainsTypeSelector(selector, name)),
   );
   const classes = inventory.classes.filter((className) =>
     definition.classMatchers.some((matcher) => matcher.test(className)),

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -82,7 +82,8 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
   {
     id: 'buttons',
     label: 'Buttons and calls to action',
-    selectorMatchers: [/\bbutton\b/i, /\.btn(?:\b|[-_:])/i, /\[type=["']?(?:button|submit|reset)/i],
+    selectorMatchers: [/\.btn(?:\b|[-_:])/i, /\[type=["']?(?:button|submit|reset)/i],
+    typeSelectorNames: ['button'],
     classMatchers: [/^btn(?:$|-)/i, /^button(?:$|-)/i, /^cta(?:$|-)/i],
     elementMatchers: [/^button$/i],
   },
@@ -111,14 +112,16 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
   {
     id: 'links',
     label: 'Links and inline actions',
-    selectorMatchers: [/\ba\b/i, /\.link(?:\b|[-_:])/i],
+    selectorMatchers: [/\.link(?:\b|[-_:])/i],
+    typeSelectorNames: ['a'],
     classMatchers: [/^link(?:$|-)/i],
     elementMatchers: [/^a$/i],
   },
   {
     id: 'keyboard',
     label: 'Keyboard hints',
-    selectorMatchers: [/\bkbd\b/i, /\.kbd(?:\b|[-_:])/i],
+    selectorMatchers: [/\.kbd(?:\b|[-_:])/i],
+    typeSelectorNames: ['kbd'],
     classMatchers: [/^kbd(?:$|-)/i, /^keyboard(?:$|-)/i, /^shortcut(?:$|-)/i],
     elementMatchers: [/^kbd$/i],
   },
@@ -132,21 +135,16 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
   {
     id: 'typography',
     label: 'Typography scale and text utilities',
-    selectorMatchers: [/\bh[1-6]\b/i, /\.lead(?:\b|[-_:])/i, /\.eyebrow(?:\b|[-_:])/i, /\.body-(?:muted|sm|small)\b/i],
+    selectorMatchers: [/\.lead(?:\b|[-_:])/i, /\.eyebrow(?:\b|[-_:])/i, /\.body-(?:muted|sm|small)\b/i],
+    typeSelectorNames: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
     classMatchers: [/^lead$/i, /^eyebrow$/i, /^body-(?:muted|sm|small)$/i, /^caption(?:$|-)/i],
     elementMatchers: [/^h[1-6]$/i, /^p$/i],
   },
   {
     id: 'layout',
     label: 'Layout primitives',
-    selectorMatchers: [
-      /\.container(?:\b|[-_:])/i,
-      /\.stack-\d+\b/i,
-      /\.row-(?:between|center|start|end)\b/i,
-      /\bsection\b/i,
-      /\bmain\b/i,
-      /\bnav\b/i,
-    ],
+    selectorMatchers: [/\.container(?:\b|[-_:])/i, /\.stack-\d+\b/i, /\.row-(?:between|center|start|end)\b/i],
+    typeSelectorNames: ['section', 'main', 'nav'],
     classMatchers: [/^container$/i, /^stack-\d+$/i, /^row-(?:between|center|start|end)$/i, /^grid$/i, /^layout(?:$|-)/i],
     elementMatchers: [/^(main|section|nav|header|footer)$/i],
   },
@@ -222,13 +220,14 @@ export function summarizeComponentsManifestForPrompt(manifest: ComponentsManifes
 }
 
 /**
- * Invariant: a form-control name counts as present in a selector only where
- * CSS grammar allows a type selector to occur. Class and ID names, attribute
+ * Invariant: an element name counts as present in a selector only where CSS
+ * grammar allows a type selector to occur. Class and ID names, attribute
  * selectors, and pseudo-class/pseudo-element names never contribute matches,
- * and neither do pseudo-element arguments that name parts rather than
- * elements (e.g. `::part(select)`). Arguments of functional pseudo-classes
- * (`:is()`, `:has()`, `:not()`, `:where()`) and of `::slotted()` are real
- * selectors, so names inside them stay matchable.
+ * and neither do functional pseudo arguments whose grammar carries values
+ * rather than selectors (e.g. `::part(select)`, `:lang(select)`,
+ * `:state(label)`). Only selector-bearing argument positions stay matchable:
+ * the pseudo-classes in `SELECTOR_BEARING_PSEUDO_CLASSES`, the selector after
+ * `of` in `:nth-child()`/`:nth-last-child()`, and `::slotted()`.
  */
 function selectorContainsTypeSelector(selector: string, name: string): boolean {
   const masked = maskNonTypeSelectorText(selector);
@@ -237,6 +236,9 @@ function selectorContainsTypeSelector(selector: string, name: string): boolean {
 }
 
 const SELECTOR_IDENT_CHAR = /[-\w\u0080-\uffff]/;
+
+/** Functional pseudo-classes whose arguments are themselves selectors. */
+const SELECTOR_BEARING_PSEUDO_CLASSES = new Set(['is', 'where', 'not', 'has', 'host', 'host-context']);
 
 /**
  * Blanks out every part of a selector where a type selector cannot occur —
@@ -297,6 +299,33 @@ function maskNonTypeSelectorText(selector: string): string {
     }
   };
 
+  // An+B text before the `of` keyword is a value, not a selector; the part
+  // after `of` (and the closing paren) returns to the normal selector walk.
+  const maskNthArgsUpToOfKeyword = (): void => {
+    out += ' ';
+    index += 1;
+    while (index < selector.length) {
+      const char = selector.charAt(index);
+      if (char === ')') {
+        out += ' ';
+        index += 1;
+        return;
+      }
+      if (
+        (char === 'o' || char === 'O') &&
+        /f/i.test(selector.charAt(index + 1)) &&
+        !SELECTOR_IDENT_CHAR.test(selector.charAt(index - 1)) &&
+        !SELECTOR_IDENT_CHAR.test(selector.charAt(index + 2))
+      ) {
+        out += '  ';
+        index += 2;
+        return;
+      }
+      out += ' ';
+      index += 1;
+    }
+  };
+
   while (index < selector.length) {
     const char = selector.charAt(index);
     if (char === '\\') {
@@ -321,8 +350,17 @@ function maskNonTypeSelectorText(selector: string): string {
       const nameStart = index;
       maskIdentifier();
       const pseudoName = selector.slice(nameStart, index).toLowerCase();
-      if (selector.charAt(index) === '(' && isPseudoElement && pseudoName !== 'slotted') {
-        maskDelimitedBlock('(', ')');
+      if (selector.charAt(index) === '(') {
+        const argsAreSelectors = isPseudoElement
+          ? pseudoName === 'slotted'
+          : SELECTOR_BEARING_PSEUDO_CLASSES.has(pseudoName);
+        if (!argsAreSelectors) {
+          if (!isPseudoElement && pseudoName.startsWith('nth-')) {
+            maskNthArgsUpToOfKeyword();
+          } else {
+            maskDelimitedBlock('(', ')');
+          }
+        }
       }
       continue;
     }

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -302,10 +302,11 @@ const TRAVERSABLE_GROUP_AT_RULES = /^@(?:media|supports|container|layer|scope|st
  * nested-block bodies) are attributed to its resolved selector list — including
  * rules that follow another rule or a `:root` block, and rules using CSS
  * nesting (`&:hover { ... }`, nested grouping at-rules such as `@media` or
- * `@starting-style`). Braces inside quoted strings (`content: '{'`, data URLs)
- * are text, not structure. At-rules whose bodies do not describe the current
- * selector tree (`@keyframes`, `@font-face`, ...) and `:root` rules are
- * skipped.
+ * `@starting-style`). Braces and quotes inside quoted strings (`content: '{'`),
+ * behind CSS escapes (`.content-\[\'x\'\]`), or inside function values
+ * (unquoted `url(...)` data URIs) are text, not structure. At-rules whose
+ * bodies do not describe the current selector tree (`@keyframes`,
+ * `@font-face`, ...) and `:root` rules are skipped.
  */
 function collectCssRules(css: string): CssRule[] {
   const rules: CssRule[] = [];
@@ -317,16 +318,22 @@ function walkCssBlock(body: string, selfSelectors: string[], out: CssRule[]): vo
   let declarations = '';
   let segment = '';
   let index = 0;
+  let parenDepth = 0;
 
   while (index < body.length) {
     const char = body[index];
+    if (char === '\\') {
+      segment += body.slice(index, index + 2);
+      index += 2;
+      continue;
+    }
     if (char === '"' || char === "'") {
       const end = findStringEnd(body, index);
       segment += body.slice(index, end + 1);
       index = end + 1;
       continue;
     }
-    if (char === '{') {
+    if (char === '{' && parenDepth === 0) {
       const close = findMatchingBrace(body, index);
       const { leadingDeclarations, prelude } = splitBlockPrelude(segment);
       declarations += leadingDeclarations;
@@ -335,12 +342,14 @@ function walkCssBlock(body: string, selfSelectors: string[], out: CssRule[]): vo
       index = close + 1;
       continue;
     }
-    if (char === '}') {
+    if (char === '}' && parenDepth === 0) {
       declarations += segment;
       segment = '';
       index += 1;
       continue;
     }
+    if (char === '(') parenDepth += 1;
+    else if (char === ')') parenDepth = Math.max(0, parenDepth - 1);
     segment += char;
     index += 1;
   }
@@ -372,10 +381,43 @@ function enterCssBlock(prelude: string, body: string, parentSelectors: string[],
 function resolveNestedSelectors(selectors: string[], parentSelectors: string[]): string[] {
   if (parentSelectors.length === 0) return selectors;
   return parentSelectors.flatMap((parent) =>
-    selectors.map((selector) =>
-      selector.includes('&') ? selector.replaceAll('&', parent) : `${parent} ${selector}`,
-    ),
+    selectors.map((selector) => expandNestingSelector(selector, parent) ?? `${parent} ${selector}`),
   );
+}
+
+/**
+ * Expands every nesting-selector `&` into `parent`. Only an unescaped `&`
+ * outside quoted strings is a nesting selector; `&` inside attribute-value
+ * strings (`[data-label="A&B"]`) or escaped as `\&` stays literal. Returns
+ * null when the selector contains no nesting selector.
+ */
+function expandNestingSelector(selector: string, parent: string): string | null {
+  let out = '';
+  let found = false;
+  let index = 0;
+  while (index < selector.length) {
+    const char = selector[index];
+    if (char === '\\') {
+      out += selector.slice(index, index + 2);
+      index += 2;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      const end = findStringEnd(selector, index);
+      out += selector.slice(index, end + 1);
+      index = end + 1;
+      continue;
+    }
+    if (char === '&') {
+      out += parent;
+      found = true;
+      index += 1;
+      continue;
+    }
+    out += char;
+    index += 1;
+  }
+  return found ? out : null;
 }
 
 function splitBlockPrelude(segment: string): { leadingDeclarations: string; prelude: string } {
@@ -395,17 +437,26 @@ function splitBlockPrelude(segment: string): { leadingDeclarations: string; prel
 
 function findMatchingBrace(source: string, openIndex: number): number {
   let depth = 0;
+  let parenDepth = 0;
   let index = openIndex;
   while (index < source.length) {
     const char = source[index];
+    if (char === '\\') {
+      index += 2;
+      continue;
+    }
     if (char === '"' || char === "'") {
       index = findStringEnd(source, index) + 1;
       continue;
     }
-    if (char === '{') depth += 1;
-    else if (char === '}') {
-      depth -= 1;
-      if (depth === 0) return index;
+    if (char === '(') parenDepth += 1;
+    else if (char === ')') parenDepth = Math.max(0, parenDepth - 1);
+    else if (parenDepth === 0) {
+      if (char === '{') depth += 1;
+      else if (char === '}') {
+        depth -= 1;
+        if (depth === 0) return index;
+      }
     }
     index += 1;
   }
@@ -515,6 +566,11 @@ function stripCssComments(css: string): string {
   let index = 0;
   while (index < css.length) {
     const char = css[index];
+    if (char === '\\') {
+      out += css.slice(index, index + 2);
+      index += 2;
+      continue;
+    }
     if (char === '"' || char === "'") {
       const end = findStringEnd(css, index);
       out += css.slice(index, end + 1);

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -237,6 +237,39 @@ function selectorContainsTypeSelector(selector: string, name: string): boolean {
 
 const SELECTOR_IDENT_CHAR = /[-\w\u0080-\uffff]/;
 
+const HEX_DIGIT = /[0-9a-f]/i;
+
+/**
+ * Exclusive end index of the CSS escape starting at `start` (a backslash):
+ * either a single escaped source character, or up to six hex digits plus one
+ * optional whitespace terminator that belongs to the escape, not to the
+ * surrounding selector.
+ */
+function cssEscapeEndIndex(text: string, start: number): number {
+  let index = start + 1;
+  if (index >= text.length) return index;
+  if (!HEX_DIGIT.test(text.charAt(index))) return index + 1;
+  let digits = 0;
+  while (digits < 6 && HEX_DIGIT.test(text.charAt(index))) {
+    index += 1;
+    digits += 1;
+  }
+  if (/[ \t\n\r\f]/.test(text.charAt(index))) index += 1;
+  return index;
+}
+
+/** Decoded character of the escape spanning [start, end); U+FFFD when the code point is invalid. */
+function decodeCssEscape(text: string, start: number, end: number): string {
+  const body = text.slice(start + 1, end);
+  if (body === '') return '\ufffd';
+  if (!HEX_DIGIT.test(body.charAt(0))) return body;
+  const codePoint = Number.parseInt(body.trim(), 16);
+  if (Number.isNaN(codePoint) || codePoint === 0 || codePoint > 0x10ffff || (codePoint >= 0xd800 && codePoint <= 0xdfff)) {
+    return '\ufffd';
+  }
+  return String.fromCodePoint(codePoint);
+}
+
 /** Functional pseudo-classes whose arguments are themselves selectors. */
 const SELECTOR_BEARING_PSEUDO_CLASSES = new Set(['is', 'where', 'not', 'has', 'host', 'host-context']);
 
@@ -246,7 +279,10 @@ const SELECTOR_BEARING_PSEUDO_CLASSES = new Set(['is', 'where', 'not', 'has', 'h
  * pseudo-element arguments — replacing them with spaces so the surviving
  * text can be matched for element names with plain boundary checks.
  * Quotes and CSS escapes inside attribute blocks are honored so a bracket
- * or quote inside a string never ends the block early.
+ * or quote inside a string never ends the block early. Escapes are consumed
+ * in full (hex digits plus the optional whitespace terminator), and escapes
+ * at type-selector positions are decoded so `\\62 utton` reads as `button`
+ * while a decoded non-ident character keeps the identifier glued together.
  */
 function maskNonTypeSelectorText(selector: string): string {
   let out = '';
@@ -256,8 +292,9 @@ function maskNonTypeSelectorText(selector: string): string {
     while (index < selector.length) {
       const char = selector.charAt(index);
       if (char === '\\') {
-        out += '  ';
-        index += 2;
+        const end = cssEscapeEndIndex(selector, index);
+        out += ' '.repeat(end - index);
+        index = end;
         continue;
       }
       if (!SELECTOR_IDENT_CHAR.test(char)) break;
@@ -271,8 +308,9 @@ function maskNonTypeSelectorText(selector: string): string {
     while (index < selector.length) {
       const char = selector.charAt(index);
       if (char === '\\') {
-        out += '  ';
-        index += 2;
+        const end = cssEscapeEndIndex(selector, index);
+        out += ' '.repeat(end - index);
+        index = end;
         continue;
       }
       if (char === '"' || char === "'") {
@@ -281,8 +319,9 @@ function maskNonTypeSelectorText(selector: string): string {
         while (index < selector.length) {
           const quoted = selector.charAt(index);
           if (quoted === '\\') {
-            out += '  ';
-            index += 2;
+            const quotedEnd = cssEscapeEndIndex(selector, index);
+            out += ' '.repeat(quotedEnd - index);
+            index = quotedEnd;
             continue;
           }
           out += ' ';
@@ -329,8 +368,10 @@ function maskNonTypeSelectorText(selector: string): string {
   while (index < selector.length) {
     const char = selector.charAt(index);
     if (char === '\\') {
-      out += '  ';
-      index += 2;
+      const end = cssEscapeEndIndex(selector, index);
+      const decoded = decodeCssEscape(selector, index, end);
+      out += SELECTOR_IDENT_CHAR.test(decoded) ? decoded : '_';
+      index = end;
       continue;
     }
     if (char === '.' || char === '#') {
@@ -585,6 +626,14 @@ function splitBlockPrelude(segment: string): { leadingDeclarations: string; prel
   let lastSemicolon = -1;
   for (let index = 0; index < segment.length; index += 1) {
     const char = segment[index];
+    if (char === '\\') {
+      index += 1;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      index = findStringEnd(segment, index);
+      continue;
+    }
     if (char === '(' || char === '[') depth += 1;
     else if (char === ')' || char === ']') depth = Math.max(0, depth - 1);
     else if (char === ';' && depth === 0) lastSemicolon = index;

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -82,7 +82,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
   {
     id: 'inputs',
     label: 'Form fields and controls',
-    selectorMatchers: [/\binput\b/i, /\btextarea\b/i, /(?<![\w.#-])select(?![\w-])/i, /\.field(?:\b|[-_:])/i, /\blabel\b/i],
+    selectorMatchers: [/\binput\b/i, /\btextarea\b/i, /(?:^|[\s>+~,(])select(?:$|[\s>+~,.:#[)])/i, /\.field(?:\b|[-_:])/i, /\blabel\b/i],
     classMatchers: [/^field(?:$|-)/i, /^input(?:$|-)/i, /^control(?:$|-)/i, /^form(?:$|-)/i],
     elementMatchers: [/^(input|textarea|select|label|form)$/i],
   },
@@ -295,14 +295,17 @@ type CssRule = {
   declarations: string;
 };
 
-const CONDITIONAL_GROUP_AT_RULES = /^@(?:media|supports|container|layer)\b/i;
+const TRAVERSABLE_GROUP_AT_RULES = /^@(?:media|supports|container|layer|scope|starting-style)\b/i;
 
 /**
  * Brace-depth CSS scanner. Invariant: every rule's own declarations (excluding
  * nested-block bodies) are attributed to its resolved selector list — including
  * rules that follow another rule or a `:root` block, and rules using CSS
- * nesting (`&:hover { ... }`, nested conditional at-rules). Non-conditional
- * at-rules (`@keyframes`, `@font-face`, ...) and `:root` rules are skipped.
+ * nesting (`&:hover { ... }`, nested grouping at-rules such as `@media` or
+ * `@starting-style`). Braces inside quoted strings (`content: '{'`, data URLs)
+ * are text, not structure. At-rules whose bodies do not describe the current
+ * selector tree (`@keyframes`, `@font-face`, ...) and `:root` rules are
+ * skipped.
  */
 function collectCssRules(css: string): CssRule[] {
   const rules: CssRule[] = [];
@@ -317,6 +320,12 @@ function walkCssBlock(body: string, selfSelectors: string[], out: CssRule[]): vo
 
   while (index < body.length) {
     const char = body[index];
+    if (char === '"' || char === "'") {
+      const end = findStringEnd(body, index);
+      segment += body.slice(index, end + 1);
+      index = end + 1;
+      continue;
+    }
     if (char === '{') {
       const close = findMatchingBrace(body, index);
       const { leadingDeclarations, prelude } = splitBlockPrelude(segment);
@@ -345,7 +354,7 @@ function walkCssBlock(body: string, selfSelectors: string[], out: CssRule[]): vo
 function enterCssBlock(prelude: string, body: string, parentSelectors: string[], out: CssRule[]): void {
   if (prelude.length === 0) return;
   if (prelude.startsWith('@')) {
-    if (CONDITIONAL_GROUP_AT_RULES.test(prelude)) {
+    if (TRAVERSABLE_GROUP_AT_RULES.test(prelude)) {
       walkCssBlock(body, parentSelectors, out);
     }
     return;
@@ -386,15 +395,35 @@ function splitBlockPrelude(segment: string): { leadingDeclarations: string; prel
 
 function findMatchingBrace(source: string, openIndex: number): number {
   let depth = 0;
-  for (let index = openIndex; index < source.length; index += 1) {
+  let index = openIndex;
+  while (index < source.length) {
     const char = source[index];
+    if (char === '"' || char === "'") {
+      index = findStringEnd(source, index) + 1;
+      continue;
+    }
     if (char === '{') depth += 1;
     else if (char === '}') {
       depth -= 1;
       if (depth === 0) return index;
     }
+    index += 1;
   }
   return source.length;
+}
+
+/** Index of the closing quote for the string opened at `openIndex`, honoring backslash escapes. */
+function findStringEnd(source: string, openIndex: number): number {
+  const quote = source[openIndex];
+  for (let index = openIndex + 1; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === '\\') {
+      index += 1;
+      continue;
+    }
+    if (char === quote) return index;
+  }
+  return source.length - 1;
 }
 
 function splitSelectorList(selectorList: string): string[] {
@@ -482,7 +511,25 @@ function stripRootBlocks(css: string): string {
 }
 
 function stripCssComments(css: string): string {
-  return css.replace(/\/\*[\s\S]*?\*\//g, '');
+  let out = '';
+  let index = 0;
+  while (index < css.length) {
+    const char = css[index];
+    if (char === '"' || char === "'") {
+      const end = findStringEnd(css, index);
+      out += css.slice(index, end + 1);
+      index = end + 1;
+      continue;
+    }
+    if (char === '/' && css[index + 1] === '*') {
+      const close = css.indexOf('*/', index + 2);
+      index = close === -1 ? css.length : close + 2;
+      continue;
+    }
+    out += char;
+    index += 1;
+  }
+  return out;
 }
 
 function countLiterals(css: string): ComponentManifestLiteralInventory {

--- a/packages/contracts/tests/components-manifest.test.ts
+++ b/packages/contracts/tests/components-manifest.test.ts
@@ -143,6 +143,29 @@ describe('components manifest extraction', () => {
     expect(inputs?.tokenReferences).toEqual(['--accent']);
   });
 
+  it('matches form-control names only where a type selector can occur', () => {
+    const manifest = extractComponentsManifest({
+      brandId: 'pr-6226-form-controls',
+      fixtureHtml: `
+        <style>
+          :root { --accent: #05f; --muted: #889; }
+          form > input { color: var(--accent); }
+          :is(select) { color: var(--accent); }
+          .field-row:has(select) { color: var(--accent); }
+          .transition-input { transition: color 120ms; color: var(--muted); }
+          [data-kind="label"] { color: var(--muted); }
+          x-widget::part(select) { color: var(--muted); }
+          ::-webkit-input-placeholder { color: var(--muted); }
+        </style>
+        <div class="field-row transition-input" data-kind="label">x</div>
+      `,
+    });
+
+    const inputs = manifest.groups.find((group) => group.id === 'inputs');
+    expect(inputs?.selectors).toEqual([':is(select)', '.field-row:has(select)', 'form > input']);
+    expect(inputs?.tokenReferences).toEqual(['--accent']);
+  });
+
   it('traverses @scope and @starting-style blocks like other grouping at-rules', () => {
     const manifest = extractComponentsManifest({
       brandId: 'pr-6226',

--- a/packages/contracts/tests/components-manifest.test.ts
+++ b/packages/contracts/tests/components-manifest.test.ts
@@ -166,6 +166,52 @@ describe('components manifest extraction', () => {
     expect(inputs?.tokenReferences).toEqual(['--accent']);
   });
 
+  it('matches group element names only where a type selector can occur', () => {
+    const manifest = extractComponentsManifest({
+      brandId: 'pr-6226-element-groups',
+      fixtureHtml: `
+        <style>
+          :root { --accent: #05f; --muted: #889; }
+          button { color: var(--accent); }
+          section > main { color: var(--accent); }
+          .transition-button { transition: transform 120ms; color: var(--muted); }
+          .foo-section-bar { color: var(--muted); }
+          .nav-link { color: var(--muted); }
+          [data-kind="button"] { color: var(--muted); }
+        </style>
+        <button class="transition-button">x</button>
+      `,
+    });
+
+    const buttons = manifest.groups.find((group) => group.id === 'buttons');
+    expect(buttons?.selectors).toEqual(['button']);
+    expect(buttons?.tokenReferences).toEqual(['--accent']);
+
+    const layout = manifest.groups.find((group) => group.id === 'layout');
+    expect(layout?.selectors).toEqual(['section > main']);
+    expect(layout?.tokenReferences).toEqual(['--accent']);
+  });
+
+  it('masks value-typed pseudo-class arguments but keeps selector-bearing ones matchable', () => {
+    const manifest = extractComponentsManifest({
+      brandId: 'pr-6226-pseudo-args',
+      fixtureHtml: `
+        <style>
+          :root { --accent: #05f; --muted: #889; }
+          li:nth-child(2 of input) { color: var(--accent); }
+          :host(select) { color: var(--accent); }
+          .copy:lang(select) { color: var(--muted); }
+          :state(label) { color: var(--muted); }
+        </style>
+        <input class="copy" />
+      `,
+    });
+
+    const inputs = manifest.groups.find((group) => group.id === 'inputs');
+    expect(inputs?.selectors).toEqual([':host(select)', 'li:nth-child(2 of input)']);
+    expect(inputs?.tokenReferences).toEqual(['--accent']);
+  });
+
   it('traverses @scope and @starting-style blocks like other grouping at-rules', () => {
     const manifest = extractComponentsManifest({
       brandId: 'pr-6226',

--- a/packages/contracts/tests/components-manifest.test.ts
+++ b/packages/contracts/tests/components-manifest.test.ts
@@ -204,6 +204,57 @@ describe('components manifest extraction', () => {
     expect(badges?.tokenReferences).toEqual(['--accent']);
   });
 
+  it('honors CSS escapes so escaped quotes and braces are text, not structure', () => {
+    const manifest = extractComponentsManifest({
+      brandId: 'pr-6226',
+      fixtureHtml: `
+        <style>
+          :root { --accent: #05f; --card-bg: #fff; }
+          .content-\\[\\'x\\'\\]::before { color: var(--accent); }
+          .card { background: var(--card-bg); }
+          .badge-\\{x\\} { color: var(--accent); }
+          .chip { background-image: url(data:image/svg+xml,<svg>{}</svg>); color: var(--accent); }
+          .tag { color: var(--accent); }
+        </style>
+        <button class="btn">x</button>
+      `,
+    });
+
+    expect(manifest.selectors).toEqual([
+      ".badge-\\{x\\}",
+      '.card',
+      '.chip',
+      ".content-\\[\\'x\\'\\]::before",
+      '.tag',
+    ]);
+
+    const cards = manifest.groups.find((group) => group.id === 'cards');
+    expect(cards?.tokenReferences).toEqual(['--card-bg']);
+
+    const badges = manifest.groups.find((group) => group.id === 'badges');
+    expect(badges?.selectors).toEqual([".badge-\\{x\\}", '.chip', '.tag']);
+    expect(badges?.tokenReferences).toEqual(['--accent']);
+  });
+
+  it('expands & only as the nesting selector, never inside quoted attribute values', () => {
+    const manifest = extractComponentsManifest({
+      brandId: 'pr-6226',
+      fixtureHtml: `
+        <style>
+          :root { --accent: #05f; }
+          .btn { &[data-label="A&B"] { color: var(--accent); } }
+        </style>
+        <button class="btn" data-label="A&amp;B">x</button>
+      `,
+    });
+
+    expect(manifest.selectors).toEqual(['.btn', '.btn[data-label="A&B"]']);
+
+    const buttons = manifest.groups.find((group) => group.id === 'buttons');
+    expect(buttons?.selectors).toEqual(['.btn', '.btn[data-label="A&B"]']);
+    expect(buttons?.tokenReferences).toEqual(['--accent']);
+  });
+
   it('can render a concise prompt summary from a manifest', () => {
     const manifest = extractComponentsManifest({
       brandId: 'sample',

--- a/packages/contracts/tests/components-manifest.test.ts
+++ b/packages/contracts/tests/components-manifest.test.ts
@@ -258,6 +258,26 @@ describe('components manifest extraction', () => {
     expect(badges?.tokenReferences).toEqual(['--base', '--hover']);
   });
 
+  it('keeps balanced brace blocks in custom-property values as declaration text', () => {
+    const manifest = extractComponentsManifest({
+      brandId: 'pr-6226-custom-prop-blocks',
+      fixtureHtml: `
+        <style>
+          :root { --accent: #05f; --inside: #f0f; }
+          .btn { --payload: { color: var(--inside); }; color: var(--accent); }
+          .card { background: #fff; }
+        </style>
+        <button class="btn">x</button>
+      `,
+    });
+
+    expect(manifest.selectors).toEqual(['.btn', '.card']);
+
+    const buttons = manifest.groups.find((group) => group.id === 'buttons');
+    expect(buttons?.selectors).toEqual(['.btn']);
+    expect(buttons?.tokenReferences).toEqual(['--accent', '--inside']);
+  });
+
   it('traverses @scope and @starting-style blocks like other grouping at-rules', () => {
     const manifest = extractComponentsManifest({
       brandId: 'pr-6226',

--- a/packages/contracts/tests/components-manifest.test.ts
+++ b/packages/contracts/tests/components-manifest.test.ts
@@ -212,6 +212,52 @@ describe('components manifest extraction', () => {
     expect(inputs?.tokenReferences).toEqual(['--accent']);
   });
 
+  it('consumes full CSS hex escapes and decodes escaped type-selector names', () => {
+    const manifest = extractComponentsManifest({
+      brandId: 'pr-6226-hex-escapes',
+      fixtureHtml: `
+        <style>
+          :root { --accent: #05f; --muted: #889; }
+          \\62 utton { color: var(--accent); }
+          .foo\\20 button { color: var(--muted); }
+          .bar\\2c section { color: var(--muted); }
+        </style>
+        <button class="btn">x</button>
+      `,
+    });
+
+    const buttons = manifest.groups.find((group) => group.id === 'buttons');
+    expect(buttons?.selectors).toEqual(['\\62 utton']);
+    expect(buttons?.tokenReferences).toEqual(['--accent']);
+
+    const layout = manifest.groups.find((group) => group.id === 'layout');
+    expect(layout?.selectors).toEqual([]);
+  });
+
+  it('keeps quoted delimiters in declaration values out of the prelude split', () => {
+    const manifest = extractComponentsManifest({
+      brandId: 'pr-6226-quoted-prelude',
+      fixtureHtml: `
+        <style>
+          :root { --base: #05f; --hover: #04d; }
+          .btn { content: "["; color: var(--base); &:hover { color: var(--hover); } }
+          .chip { content: "("; color: var(--base); &:hover { color: var(--hover); } }
+        </style>
+        <button class="btn">x</button>
+      `,
+    });
+
+    expect(manifest.selectors).toEqual(['.btn', '.btn:hover', '.chip', '.chip:hover']);
+
+    const buttons = manifest.groups.find((group) => group.id === 'buttons');
+    expect(buttons?.selectors).toEqual(['.btn', '.btn:hover']);
+    expect(buttons?.tokenReferences).toEqual(['--base', '--hover']);
+
+    const badges = manifest.groups.find((group) => group.id === 'badges');
+    expect(badges?.selectors).toEqual(['.chip', '.chip:hover']);
+    expect(badges?.tokenReferences).toEqual(['--base', '--hover']);
+  });
+
   it('traverses @scope and @starting-style blocks like other grouping at-rules', () => {
     const manifest = extractComponentsManifest({
       brandId: 'pr-6226',

--- a/packages/contracts/tests/components-manifest.test.ts
+++ b/packages/contracts/tests/components-manifest.test.ts
@@ -61,6 +61,68 @@ describe('components manifest extraction', () => {
     expect(manifest.literals.pixelValues).toBe(1);
   });
 
+  it('attributes token references to every consecutive flat rule', () => {
+    const manifest = extractComponentsManifest({
+      brandId: 'issue-6224',
+      fixtureHtml: `
+        <style>
+          :root { --a: #111; --b: #222; --c: #333; --d: #444; }
+          .btn-a { color: var(--a); }
+          .btn-b { color: var(--b); }
+          .btn-c { color: var(--c); }
+          .btn-d { color: var(--d); }
+        </style>
+        <button class="btn-a">x</button>
+      `,
+    });
+
+    const buttons = manifest.groups.find((group) => group.id === 'buttons');
+    expect(buttons?.selectors).toEqual(['.btn-a', '.btn-b', '.btn-c', '.btn-d']);
+    expect(buttons?.tokenReferences).toEqual(['--a', '--b', '--c', '--d']);
+  });
+
+  it('attributes tokens inside nested rules to real selectors, never to declaration text', () => {
+    const manifest = extractComponentsManifest({
+      brandId: 'issue-6224',
+      fixtureHtml: `
+        <style>
+          :root { --chip-bg: #eee; --chip-hover: #ddd; }
+          .chip-demo { background: var(--chip-bg); &:hover { background: var(--chip-hover); } }
+        </style>
+        <span class="chip-demo">chip</span>
+      `,
+    });
+
+    expect(manifest.selectors).toEqual(['.chip-demo', '.chip-demo:hover']);
+
+    const badges = manifest.groups.find((group) => group.id === 'badges');
+    expect(badges?.selectors).toContain('.chip-demo');
+    expect(badges?.tokenReferences).toEqual(['--chip-bg', '--chip-hover']);
+  });
+
+  it('does not classify utility classes into unrelated groups via substring matches', () => {
+    const manifest = extractComponentsManifest({
+      brandId: 'issue-6224',
+      fixtureHtml: `
+        <style>
+          .card-demo { padding: 1rem; }
+          .select-none { user-select: none; }
+        </style>
+        <div class="card-demo grid-cols-2 transition-transform select-none">x</div>
+      `,
+    });
+
+    const inputs = manifest.groups.find((group) => group.id === 'inputs');
+    expect(inputs?.selectors).toEqual([]);
+    expect(inputs?.present).toBe(false);
+
+    const layout = manifest.groups.find((group) => group.id === 'layout');
+    expect(layout?.present).toBe(false);
+
+    const cards = manifest.groups.find((group) => group.id === 'cards');
+    expect(cards?.present).toBe(true);
+  });
+
   it('can render a concise prompt summary from a manifest', () => {
     const manifest = extractComponentsManifest({
       brandId: 'sample',

--- a/packages/contracts/tests/components-manifest.test.ts
+++ b/packages/contracts/tests/components-manifest.test.ts
@@ -264,7 +264,7 @@ describe('components manifest extraction', () => {
       fixtureHtml: `
         <style>
           :root { --accent: #05f; --inside: #f0f; }
-          .btn { --payload: { color: var(--inside); }; color: var(--accent); }
+          .btn { --payload: { color: var(--inside); }; --pay\\6c oad-b: { color: var(--extra); }; color: var(--accent); }
           .card { background: #fff; }
         </style>
         <button class="btn">x</button>
@@ -275,7 +275,7 @@ describe('components manifest extraction', () => {
 
     const buttons = manifest.groups.find((group) => group.id === 'buttons');
     expect(buttons?.selectors).toEqual(['.btn']);
-    expect(buttons?.tokenReferences).toEqual(['--accent', '--inside']);
+    expect(buttons?.tokenReferences).toEqual(['--accent', '--extra', '--inside']);
   });
 
   it('traverses @scope and @starting-style blocks like other grouping at-rules', () => {

--- a/packages/contracts/tests/components-manifest.test.ts
+++ b/packages/contracts/tests/components-manifest.test.ts
@@ -123,6 +123,87 @@ describe('components manifest extraction', () => {
     expect(cards?.present).toBe(true);
   });
 
+  it('matches select as a type selector, not as literal text in class names or attribute values', () => {
+    const manifest = extractComponentsManifest({
+      brandId: 'pr-6226',
+      fixtureHtml: `
+        <style>
+          :root { --accent: #05f; }
+          select { color: var(--accent); }
+          .foo select:hover { color: var(--accent); }
+          .select-none { user-select: none; }
+          [data-action='select'] { color: var(--accent); }
+        </style>
+        <div data-action="select">x</div>
+      `,
+    });
+
+    const inputs = manifest.groups.find((group) => group.id === 'inputs');
+    expect(inputs?.selectors).toEqual(['.foo select:hover', 'select']);
+    expect(inputs?.tokenReferences).toEqual(['--accent']);
+  });
+
+  it('traverses @scope and @starting-style blocks like other grouping at-rules', () => {
+    const manifest = extractComponentsManifest({
+      brandId: 'pr-6226',
+      fixtureHtml: `
+        <style>
+          :root { --accent: #05f; --pop: #f0f; }
+          @scope (.shell) {
+            .btn { color: var(--accent); }
+          }
+          .card { background: #fff; @starting-style { background: var(--pop); } }
+        </style>
+        <button class="btn">x</button>
+      `,
+    });
+
+    expect(manifest.selectors).toEqual(['.btn', '.card']);
+
+    const buttons = manifest.groups.find((group) => group.id === 'buttons');
+    expect(buttons?.tokenReferences).toEqual(['--accent']);
+
+    const cards = manifest.groups.find((group) => group.id === 'cards');
+    expect(cards?.tokenReferences).toEqual(['--pop']);
+  });
+
+  it('treats braces and comment markers inside CSS strings as text, not structure', () => {
+    const manifest = extractComponentsManifest({
+      brandId: 'pr-6226',
+      fixtureHtml: `
+        <style>
+          :root { --accent: #05f; --card-bg: #fff; }
+          .btn::before { content: '{'; color: var(--accent); }
+          .card { background: var(--card-bg); }
+          .chip::after { content: "}"; color: var(--accent); }
+          .kbd-hint::before { content: 'a\\'{'; color: var(--accent); }
+          .pill { content: '/*'; background-image: url('data:image/svg+xml,<svg>{}</svg>'); } /* real comment */
+          .tag { color: var(--accent); }
+        </style>
+        <button class="btn">x</button>
+      `,
+    });
+
+    expect(manifest.selectors).toEqual([
+      '.btn::before',
+      '.card',
+      '.chip::after',
+      '.kbd-hint::before',
+      '.pill',
+      '.tag',
+    ]);
+
+    const buttons = manifest.groups.find((group) => group.id === 'buttons');
+    expect(buttons?.tokenReferences).toEqual(['--accent']);
+
+    const cards = manifest.groups.find((group) => group.id === 'cards');
+    expect(cards?.tokenReferences).toEqual(['--card-bg']);
+
+    const badges = manifest.groups.find((group) => group.id === 'badges');
+    expect(badges?.selectors).toEqual(['.chip::after', '.pill', '.tag']);
+    expect(badges?.tokenReferences).toEqual(['--accent']);
+  });
+
   it('can render a concise prompt summary from a manifest', () => {
     const manifest = extractComponentsManifest({
       brandId: 'sample',


### PR DESCRIPTION
Fixes #6224

## Why

While packaging a third-party design system for Open Design I ran `extractComponentsManifest` against our fixture and found the component inventory it feeds into the agent's `## Reference component manifest` prompt block was silently wrong (issue #6224). The pain: the agent is told the design system has components it doesn't have (form fields, layout primitives that are really Tailwind utility substrings), and is *not* told about token wiring it does have (every other flat rule and all nested-rule tokens were dropped) — and then follows "Prefer these manifest entries over inventing new component shapes" against bad data.

All three defects live in the same extractor (`packages/contracts/src/design-systems/components-manifest.ts`):

1. The rule regex in `extractSelectorTokenReferences` consumed the closing `}`, so every other consecutive flat rule (and the first rule after a `:root` block) lost its token attribution.
2. The `[^{}]*` body could not represent nested CSS blocks (what Tailwind v4 emits for states), dropping tokens and attributing them to declaration text as a pseudo-selector.
3. Unanchored substring `classMatchers` (`/form/i`, `/grid/i`, `/status/i`, …) misclassified utility classes (`transition-transform` → inputs, `grid-cols-2` → layout), and the `\bselect\b` selector matcher fired on the `.select-none` utility rule.

## What users will see

No UI changes. Users with an active design system get a correct `## Reference component manifest` block in the agent context: token lists now match what a human reads in the fixture CSS (including Tailwind v4 nested state rules), and component groups no longer claim form/layout/badge components that only exist as substrings of utility classes. Agent output should track the actual design system more faithfully.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — behavior change in `packages/contracts` (`extractComponentsManifest`); no shape/type changes
- [x] **Extension point** — all 150 committed `design-systems/*/components.manifest.json` caches regenerated from the fixed extractor (guard enforces byte-parity with the extractor output)
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

Note on the third-party naming contract: class matchers are now anchored to name segments (`^form(?:$|-)`, `^grid$`, …), matching the pattern of the existing `^btn(?:$|-)` matcher. A root class must start with the group's term (e.g. `card-*`, not `rack-card`) — same contract the selector matchers already implied.

## Screenshots

Not applicable (no UI change).

## Bug fix verification

- Test path that reproduces the bug: `packages/contracts/tests/components-manifest.test.ts` — three new specs: "attributes token references to every consecutive flat rule", "attributes tokens inside nested rules to real selectors, never to declaration text", "does not classify utility classes into unrelated groups via substring matches".
- Did the test go red on `main` and green on this branch? **yes** — with the extractor unchanged from `main` the specs failed exactly per the issue (`['--b', '--d']` instead of `['--a', '--b', '--c', '--d']`; `.select-none` in the inputs group; missing `.chip-demo:hover`), and all pass after the fix.

## Validation

- `pnpm --filter @open-design/contracts test` — 249 passed (includes the 3 new red→green specs)
- `pnpm guard` — exit 0 (the design-system manifest byte-parity check drove the regeneration of the 150 `components.manifest.json` caches; component-manifest extraction check passes across all 151 fixtures)
- `pnpm typecheck` — exit 0
- `pnpm --filter @open-design/daemon test` — 6108 passed; 4 failures in `run-retry-runtime`, `run-resume-on-failure`, `langfuse-trace` reproduce identically on a clean `main` worktree (pre-existing/flaky, unrelated to this change)
- `pnpm --filter @open-design/web test` — 4865 passed
- `e2e/tests/scripts/check-design-system-manifests.test.ts` — 16 passed

The regenerated caches diff is large but mechanical: recovered token references (previously ~half were dropped) and removed substring false-positive group memberships (e.g. `metric-grid` no longer classified as a layout class). Spot-checked `design-systems/agentic/components.manifest.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
