### PR TITLE
fix(gh): refuse destructive gh CLI invocations in the generic passthrough

### DIFF
--- a/tools/pr/src/gh.ts
+++ b/tools/pr/src/gh.ts
@@ -21,7 +21,30 @@ import type {
 
 const execFile = promisify(execFileCallback);
 
+// Archive-only doctrine (2026-07-29, Keith — a prior GHL sub-account deletion
+// caused real business damage). gh() is a generic `gh` CLI passthrough; every
+// current call site in this file passes fixed, read-only args, but it's
+// exported and callable with anything. Refuse destructive-shaped invocations
+// unconditionally, no override, before they ever reach execFile.
+const DESTRUCTIVE_GH_ARGS_RE =
+  /^(repo|secret|workflow|release|variable)$/i;
+const DESTRUCTIVE_GH_SUBCOMMAND_RE = /^(delete|remove|disable)$/i;
+
+function looksDestructive(args: string[]): boolean {
+  for (let i = 0; i < args.length - 1; i++) {
+    if (DESTRUCTIVE_GH_ARGS_RE.test(args[i]) && DESTRUCTIVE_GH_SUBCOMMAND_RE.test(args[i + 1])) {
+      return true;
+    }
+  }
+  return args.some((a) => /^--delete$|^-X$|^--method$/i.test(a) && args.includes("DELETE"));
+}
+
 async function ghOnce<T>(args: string[]): Promise<T> {
+  if (looksDestructive(args)) {
+    throw new Error(
+      `Refused: gh ${args.join(" ")} looks destructive. Archive-only doctrine — no override.`,
+    );
+  }
   const { stdout } = await execFile("gh", args, { maxBuffer: 64 * 1024 * 1024 });
   return JSON.parse(stdout) as T;
 }


### PR DESCRIPTION
## Summary
- \`gh()\` in \`tools/pr/src/gh.ts\` is a generic \`gh\` CLI wrapper — every current call site passes fixed, read-only args, so this was latent risk, not active.
- Found during a broader audit of generic API/CLI passthroughs after finding an actively-exploited version of this exact pattern elsewhere (a wrapper that forwarded arbitrary tool names with zero validation, tied to a real prior GHL sub-account deletion).
- Refuses \`repo delete\`, \`secret delete\`, \`workflow disable\`, and \`-X DELETE\`/\`--method DELETE\` invocations unconditionally, before they reach \`execFile\`, with no override.

## Test plan
- [x] Typecheck clean
- [x] Verified against 7 cases (destructive args blocked, safe args like \`pr list\`/\`pr view\`/\`api graphql\` unaffected)

No behavior change for any existing call site in this file — all pass fixed, safe args already.