### PR TITLE
test: cover updater floor and Manual Edit history

### DIFF
--- a/apps/daemon/tests/cli-startup.test.ts
+++ b/apps/daemon/tests/cli-startup.test.ts
@@ -93,7 +93,7 @@ describe('CLI startup boundaries', () => {
     }
   });
 
-  it('reconciles a durable running message after a real daemon process restart', async () => {
+  it('reconciles a durable running message after a real daemon process restart', { timeout: 60_000 }, async () => {
     const root = await mkdtemp(join(tmpdir(), 'od-cli-daemon-restart-'));
     const dataDir = join(root, 'data');
     await mkdir(dataDir);
@@ -196,11 +196,12 @@ describe('CLI startup boundaries', () => {
         const third = spawn(process.execPath, args, { cwd: daemonRoot, env });
         try {
           await waitForStdoutLine(third, /\[od\] listening on (http:\/\/[^\s]+)/u);
-          await new Promise((resolve) => setTimeout(resolve, 250));
-          const replayedState = JSON.parse(await readFile(statePath, 'utf8')) as {
-            analyticsRecovery?: { completedAt?: number };
-          };
-          expect(replayedState.analyticsRecovery?.completedAt).toBe(checkpoint);
+          await waitFor(() => {
+            const replayedState = JSON.parse(readFileSync(statePath, 'utf8')) as {
+              analyticsRecovery?: { completedAt?: number };
+            };
+            return replayedState.analyticsRecovery?.completedAt === checkpoint;
+          });
         } finally {
           await terminateChild(third);
         }

--- a/apps/daemon/tests/cli-startup.test.ts
+++ b/apps/daemon/tests/cli-startup.test.ts
@@ -1,10 +1,13 @@
-import { chmod, mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
 import http from 'node:http';
+import net from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { execFile, spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { promisify } from 'node:util';
+import Database from 'better-sqlite3';
 import { describe, expect, it } from 'vitest';
 
 const execFileAsync = promisify(execFile);
@@ -86,6 +89,126 @@ describe('CLI startup boundaries', () => {
       expect(child.exitCode).toBeNull();
     } finally {
       await terminateChild(child);
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('reconciles a durable running message after a real daemon process restart', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'od-cli-daemon-restart-'));
+    const dataDir = join(root, 'data');
+    await mkdir(dataDir);
+    const port = await findFreePort();
+    const env = {
+      ...process.env,
+      OD_BIND_HOST: '127.0.0.1',
+      OD_DATA_DIR: dataDir,
+      OPEN_DESIGN_VELA_TELEMETRY: 'off',
+      OPEN_DESIGN_TELEMETRY_RELAY_URL: '',
+      LANGFUSE_PUBLIC_KEY: '',
+      LANGFUSE_SECRET_KEY: '',
+    };
+    const args = [
+      '--import', 'tsx', cliEntry,
+      'daemon', 'start', '--headless', '--port', String(port),
+    ];
+    const first = spawn(process.execPath, args, { cwd: daemonRoot, env });
+    const runId = 'run-real-process-restart';
+    const messageId = 'message-real-process-restart';
+    const conversationId = 'conversation-real-process-restart';
+    const projectId = 'project-real-process-restart';
+    const runDir = join(dataDir, 'runs', runId);
+    const statePath = join(runDir, 'state.json');
+
+    try {
+      await waitForStdoutLine(first, /\[od\] listening on (http:\/\/[^\s]+)/u);
+      const db = new Database(join(dataDir, 'app.sqlite'));
+      try {
+        const now = Date.now();
+        db.exec('PRAGMA foreign_keys = ON');
+        db.prepare(
+          `INSERT INTO projects (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)`,
+        ).run(projectId, 'restart fixture', now, now);
+        db.prepare(
+          `INSERT INTO conversations (id, project_id, title, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?)`,
+        ).run(conversationId, projectId, 'restart fixture', now, now);
+        db.prepare(
+          `INSERT INTO messages
+             (id, conversation_id, role, content, run_id, run_status,
+              events_json, position, created_at, started_at)
+           VALUES (?, ?, 'assistant', '', ?, 'running', '[]', 0, ?, ?)`,
+        ).run(messageId, conversationId, runId, now, now);
+      } finally {
+        db.close();
+      }
+      await mkdir(runDir, { recursive: true });
+      await writeFile(statePath, `${JSON.stringify({
+        schemaVersion: 1,
+        id: runId,
+        projectId,
+        conversationId,
+        assistantMessageId: messageId,
+        agentId: 'claude',
+        status: 'running',
+        createdAt: Date.now() - 1_000,
+        updatedAt: Date.now(),
+        analyticsRecovery: {
+          context: {},
+          properties: { project_id: projectId, conversation_id: conversationId, run_id: runId },
+          insertId: 'restart-fixture-created',
+        },
+      })}\n`);
+
+      // SIGKILL models the process-loss case; graceful SIGTERM would run the
+      // normal shutdown path and would not exercise boot reconciliation.
+      first.kill('SIGKILL');
+      await waitForExit(first);
+
+      const second = spawn(process.execPath, args, { cwd: daemonRoot, env });
+      try {
+        const line = await waitForStdoutLine(second, /\[od\] listening on (http:\/\/[^\s]+)/u);
+        expect(line).toContain(`127.0.0.1:${port}`);
+        await waitFor(() => {
+          const state = JSON.parse(readFileSync(statePath, 'utf8')) as { status?: string };
+          const checkDb = new Database(join(dataDir, 'app.sqlite'), { readonly: true });
+          try {
+            const row = checkDb.prepare(`SELECT run_status AS status FROM messages WHERE id = ?`).get(messageId) as { status?: string } | undefined;
+            return state.status === 'failed' && row?.status === 'failed';
+          } finally {
+            checkDb.close();
+          }
+        });
+        const recoveredState = JSON.parse(await readFile(statePath, 'utf8')) as {
+          status: string;
+          errorCode?: string;
+          terminalRecoveryReason?: string;
+          analyticsRecovery?: { completedAt?: number };
+        };
+        expect(recoveredState).toMatchObject({
+          status: 'failed',
+          errorCode: 'DAEMON_RESTARTED',
+          terminalRecoveryReason: 'daemon_restart',
+          analyticsRecovery: { completedAt: expect.any(Number) },
+        });
+
+        const checkpoint = recoveredState.analyticsRecovery?.completedAt;
+        await terminateChild(second);
+        const third = spawn(process.execPath, args, { cwd: daemonRoot, env });
+        try {
+          await waitForStdoutLine(third, /\[od\] listening on (http:\/\/[^\s]+)/u);
+          await new Promise((resolve) => setTimeout(resolve, 250));
+          const replayedState = JSON.parse(await readFile(statePath, 'utf8')) as {
+            analyticsRecovery?: { completedAt?: number };
+          };
+          expect(replayedState.analyticsRecovery?.completedAt).toBe(checkpoint);
+        } finally {
+          await terminateChild(third);
+        }
+      } finally {
+        await terminateChild(second);
+      }
+    } finally {
+      await terminateChild(first);
       await rm(root, { recursive: true, force: true });
     }
   });
@@ -443,6 +566,33 @@ function waitForStdoutLine(
     child.on('error', onError);
     child.on('exit', onExit);
   });
+}
+
+async function findFreePort(): Promise<number> {
+  const server = net.createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address();
+  const port = typeof address === 'object' && address ? address.port : 0;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  if (!port) throw new Error('failed to allocate a free TCP port');
+  return port;
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 10_000): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error('timed out waiting for daemon restart reconciliation');
+}
+
+async function waitForExit(child: ChildProcessWithoutNullStreams): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  await new Promise<void>((resolve) => child.once('exit', () => resolve()));
 }
 
 async function terminateChild(child: ChildProcessWithoutNullStreams): Promise<void> {

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -1006,6 +1006,44 @@ describe('buildTracePayload', () => {
     });
   });
 
+  it('keeps ACP usage on a failed run for post-run diagnostics', () => {
+    const batch = buildTracePayload(
+      makeCtx({
+        run: {
+          runId: 'run-failed-with-usage',
+          status: 'failed',
+          startedAt: 1_700_000_000_000,
+          endedAt: 1_700_000_004_500,
+          failure: {
+            failure_category: 'timeout',
+            failure_detail: 'timeout',
+            failure_stage: 'first_token_wait',
+            retryable: true,
+            user_action: 'retry',
+          },
+        },
+      }),
+    );
+    const trace = (batch[0] as any).body;
+    const generation = bodyOf(batch, 'generation-create', 'llm');
+
+    expect(trace.metadata.tokens).toMatchObject({
+      input: 1234,
+      output: 567,
+      total: 2051,
+      cacheReadInput: 200,
+      cacheCreationInput: 50,
+    });
+    expect(generation.usage).toMatchObject({
+      input: 1484,
+      output: 567,
+      total: 2051,
+      unit: 'TOKENS',
+    });
+    expect(trace.metadata.failure_category).toBe('timeout');
+    expect(trace.metadata.failure_detail).toBe('timeout');
+  });
+
   it('uses conversationId as sessionId when within length limit', () => {
     const batch = buildTracePayload(makeCtx());
     expect((batch[0] as any).body.sessionId).toBe(

--- a/apps/daemon/tests/langfuse-trace.test.ts
+++ b/apps/daemon/tests/langfuse-trace.test.ts
@@ -2614,6 +2614,7 @@ describe('reportRunFeedback', () => {
   });
 
   it('posts feedback scores to Vela when completed-run telemetry uses Vela', async () => {
+    vi.stubEnv('OPEN_DESIGN_VELA_TELEMETRY', 'on');
     vi.stubEnv('VELA_CONTROL_KEY', 'ck_secret');
     vi.stubEnv('VELA_API_URL', 'https://vela.example.test');
     vi.stubEnv(
@@ -2662,6 +2663,7 @@ describe('reportRunFeedback', () => {
   });
 
   it('does not fall back anonymously when Vela rejects feedback auth', async () => {
+    vi.stubEnv('OPEN_DESIGN_VELA_TELEMETRY', 'on');
     vi.stubEnv('VELA_CONTROL_KEY', 'ck_expired');
     vi.stubEnv('VELA_API_URL', 'https://vela.example.test');
     vi.stubEnv(

--- a/apps/daemon/tests/proxy-routes.test.ts
+++ b/apps/daemon/tests/proxy-routes.test.ts
@@ -394,6 +394,14 @@ describe('API proxy routes', () => {
       'https://token-plan-cn.xiaomimimo.com/anthropic',
       'https://token-plan-cn.xiaomimimo.com/anthropic/v1/messages',
     ],
+    [
+      'https://proxy.example.test/v1/',
+      'https://proxy.example.test/v1/messages',
+    ],
+    [
+      'https://proxy.example.test/custom/anthropic/v1/',
+      'https://proxy.example.test/custom/anthropic/v1/messages',
+    ],
   ])('routes Anthropic baseUrl %s to %s', async (input, expected) => {
     const fetchMock = vi.fn((req: FetchInput, init?: FetchInit) => {
       const url = String(req);

--- a/apps/daemon/tests/runtimes/run-terminal-reconciliation.test.ts
+++ b/apps/daemon/tests/runtimes/run-terminal-reconciliation.test.ts
@@ -312,4 +312,63 @@ describe('durable run terminal reconciliation', () => {
     expect(JSON.parse(fs.readFileSync(path.join(runDir, 'state.json'), 'utf8')))
       .not.toHaveProperty('langfuseCompletedAt');
   });
+
+  it('retries an accepted telemetry delivery after a crash before checkpoint', async () => {
+    const runId = 'run-langfuse-crash-window';
+    const runDir = path.join(tmpDir, runId);
+    fs.mkdirSync(runDir, { recursive: true });
+    fs.writeFileSync(path.join(runDir, 'state.json'), JSON.stringify({
+      schemaVersion: 1,
+      id: runId,
+      projectId: 'p1',
+      conversationId: 'c1',
+      assistantMessageId: 'm1',
+      agentId: 'codex',
+      status: 'failed',
+      createdAt: 1_000,
+      updatedAt: 2_000,
+      errorCode: 'AGENT_EXIT_1',
+    }));
+    const calls: Array<Record<string, unknown>> = [];
+    let firstAttempt = true;
+    const reportLangfuse = vi.fn(async (args: Record<string, unknown>) => {
+      calls.push(args);
+      if (firstAttempt) {
+        firstAttempt = false;
+        // The upstream has accepted the request, but the daemon dies before
+        // reconcileDurableRunTerminals can persist langfuseCompletedAt.
+        throw new Error('simulated crash after telemetry acceptance');
+      }
+      return {
+        langfuse_expected: true,
+        langfuse_delivery_status: 'accepted' as const,
+      };
+    });
+    const options = {
+      analytics: { capture: vi.fn() },
+      appVersion: '0.15.1',
+      db,
+      reportLangfuse,
+      runsLogDir: tmpDir,
+    };
+
+    await expect(reconcileDurableRunTerminals(options)).rejects.toThrow(
+      'simulated crash after telemetry acceptance',
+    );
+    expect(JSON.parse(fs.readFileSync(path.join(runDir, 'state.json'), 'utf8')))
+      .not.toHaveProperty('langfuseCompletedAt');
+
+    await expect(reconcileDurableRunTerminals(options)).resolves.toMatchObject({
+      langfuseReplayed: 1,
+    });
+    expect(reportLangfuse).toHaveBeenCalledTimes(2);
+    expect(calls[1]).toMatchObject({
+      run: expect.objectContaining({ id: runId, status: 'failed' }),
+      persistedRunStatus: 'failed',
+      persistedEndedAt: 2_000,
+    });
+    expect(calls[1]?.run).toEqual(calls[0]?.run);
+    expect(JSON.parse(fs.readFileSync(path.join(runDir, 'state.json'), 'utf8')))
+      .toMatchObject({ langfuseCompletedAt: expect.any(Number) });
+  });
 });

--- a/e2e/lib/fake-agents.ts
+++ b/e2e/lib/fake-agents.ts
@@ -156,6 +156,14 @@ async function emitRun(promptText) {
     emitServiceFailure(503);
     return;
   }
+  if (promptText.includes('Return a daemon model-not-found failure')) {
+    emitModelUnavailableFailure();
+    return;
+  }
+  if (promptText.includes('Return a daemon timeout failure')) {
+    emitTimeoutFailure();
+    return;
+  }
   if (promptText.includes('Return a daemon socket-drop failure')) {
     emitSocketDropFailure();
     return;
@@ -690,6 +698,24 @@ function emitServiceFailure(statusCode) {
       process.exitCode = 1;
       exitSoon(1);
   }
+}
+
+function emitModelUnavailableFailure() {
+  const message = 'The selected model is not available for this account: model not found.';
+  writeJson({ type: 'thread.started' });
+  writeJson({ type: 'turn.started' });
+  writeJson({ type: 'turn.failed', error: { message } });
+  process.exitCode = 0;
+  exitSoon(0);
+}
+
+function emitTimeoutFailure() {
+  const message = 'The upstream model request timed out while waiting for a response.';
+  writeJson({ type: 'thread.started' });
+  writeJson({ type: 'turn.started' });
+  writeJson({ type: 'turn.failed', error: { message } });
+  process.exitCode = 0;
+  exitSoon(0);
 }
 
 // Reproduces a connection that dropped mid-response. This shape is NOT guessed:

--- a/e2e/lib/playwright/mock-factory.ts
+++ b/e2e/lib/playwright/mock-factory.ts
@@ -1,5 +1,4 @@
 import { expect, type Page, type Request, type Route } from '@playwright/test';
-import { expectStableCount } from './assertions.js';
 
 export const STORAGE_KEY = 'open-design:config';
 
@@ -287,7 +286,7 @@ function makeRunRequestTracker(bodies: RunRequestBody[]): RunRequestTracker {
     bodies,
     expectCount,
     async expectNone(options = {}) {
-      await expectStableCount(() => bodies.length, 0, {
+      await expectCount(0, {
         timeout: options.timeout ?? 750,
         message: options.message ?? 'expected no POST /api/runs requests during the settled observation window',
       });

--- a/e2e/lib/playwright/mock-factory.ts
+++ b/e2e/lib/playwright/mock-factory.ts
@@ -1,4 +1,5 @@
 import { expect, type Page, type Request, type Route } from '@playwright/test';
+import { expectStableCount } from './assertions.js';
 
 export const STORAGE_KEY = 'open-design:config';
 
@@ -286,7 +287,7 @@ function makeRunRequestTracker(bodies: RunRequestBody[]): RunRequestTracker {
     bodies,
     expectCount,
     async expectNone(options = {}) {
-      await expectCount(0, {
+      await expectStableCount(() => bodies.length, 0, {
         timeout: options.timeout ?? 750,
         message: options.message ?? 'expected no POST /api/runs requests during the settled observation window',
       });

--- a/e2e/tests/amr/turn.test.ts
+++ b/e2e/tests/amr/turn.test.ts
@@ -30,7 +30,7 @@ import { describe, expect, test } from 'vitest';
 
 import { requestJson } from '@/vitest/http';
 import { listMessages } from '@/vitest/messages';
-import { startRun, waitForRunStatus } from '@/vitest/runs';
+import { readRunEvents, startRun, waitForRunStatus } from '@/vitest/runs';
 import { createSmokeSuite } from '@/vitest/suite';
 
 type ProjectResponse = {
@@ -287,6 +287,15 @@ describe('AMR chat-run end-to-end', () => {
         timeoutMs: 30_000,
       });
       expect(finalStatus.status).toBe('succeeded');
+
+      const runEvents = await readRunEvents(webUrl, run.runId);
+      expect(runEvents).toContain('"type":"usage"');
+      expect(runEvents).toContain('input_tokens');
+      expect(runEvents).toContain('output_tokens');
+      // This suite opts out of content telemetry. The ACP transport still
+      // persists the assistant transcript for the product, but the run event
+      // stream must not leak the user's raw prompt to telemetry consumers.
+      expect(runEvents).not.toContain(PROMPT);
 
       const messages = await listMessages(webUrl, projectId, conversationId);
       const assistantMessage = messages.find((m) => m.id === assistantMessageId);

--- a/e2e/tests/dialog/service-error-convergence.test.ts
+++ b/e2e/tests/dialog/service-error-convergence.test.ts
@@ -136,4 +136,89 @@ describe('dialog service error convergence', () => {
       expect(assistant?.runStatus).toBe('failed');
     });
   });
+
+  test('marks a model-not-found failure as MODEL_UNAVAILABLE with switch-model action', { timeout: 180_000 }, async () => {
+    await assertCodexFailureClassification({
+      suiteName: 'dialog-model-unavailable-convergence',
+      prompt: 'Return a daemon model-not-found failure',
+      expectedCategory: 'model_unavailable',
+      expectedDetail: 'model_not_found',
+      expectedMarker: 'retry_suppressed_reason":"non_retryable_category',
+    });
+  });
+
+  test('marks a provider timeout as TIMEOUT with retry action', { timeout: 180_000 }, async () => {
+    await assertCodexFailureClassification({
+      suiteName: 'dialog-timeout-convergence',
+      prompt: 'Return a daemon timeout failure',
+      expectedCategory: 'timeout',
+      expectedDetail: 'timeout',
+      expectedMarker: 'retry_reason":"transient_failure',
+    });
+  });
 });
+
+async function assertCodexFailureClassification(input: {
+  suiteName: string;
+  prompt: string;
+  expectedCategory: string;
+  expectedDetail: string;
+  expectedMarker: string;
+}) {
+  const suite = await createSmokeSuite(input.suiteName);
+
+  await suite.with.toolsDev(async ({ webUrl }) => {
+    const fakeAgents = await createFakeAgentRuntimes({
+      root: join(suite.scratchDir, 'fake-agents'),
+      runtimeIds: ['codex'],
+    });
+
+    await requestJson<{ config: Record<string, unknown> }>(webUrl, '/api/app-config', {
+      body: {
+        agentCliEnv: { codex: fakeAgents.codex.env },
+        agentId: 'codex',
+        agentModels: { codex: { model: 'default', reasoning: 'default' } },
+        designSystemId: null,
+        onboardingCompleted: true,
+        skillId: null,
+        telemetry: { artifactManifest: true, content: false, metrics: false },
+      },
+      method: 'PUT',
+    });
+
+    const project = await requestJson<ProjectResponse>(webUrl, '/api/projects', {
+      body: {
+        designSystemId: null,
+        id: randomUUID(),
+        metadata: { kind: 'prototype' },
+        name: input.suiteName,
+        pendingPrompt: null,
+        skillId: null,
+      },
+    });
+    const assistantMessageId = `assistant-${Date.now()}`;
+    const run = await startRun(webUrl, {
+      agentId: 'codex',
+      assistantMessageId,
+      clientRequestId: `req-${Date.now()}`,
+      conversationId: project.conversationId,
+      designSystemId: null,
+      message: input.prompt,
+      model: 'default',
+      projectId: project.project.id,
+      reasoning: 'default',
+      skillId: null,
+    });
+
+    const terminal = await waitForRunTerminal(webUrl, run.runId, { timeoutMs: 20_000 });
+    expect(terminal.status).toBe('failed');
+    const events = await readRunEvents(webUrl, run.runId);
+    expect(events).toContain(input.expectedCategory);
+    expect(events).toContain(input.expectedDetail);
+    expect(events).toContain(input.expectedMarker);
+
+    const messages = await listMessages(webUrl, project.project.id, project.conversationId);
+    const assistant = messages.find((message) => message.id === assistantMessageId);
+    expect(assistant?.runStatus).toBe('failed');
+  });
+}

--- a/e2e/tests/packaged-launcher-update-loop.test.ts
+++ b/e2e/tests/packaged-launcher-update-loop.test.ts
@@ -32,6 +32,11 @@ type DesktopUpdaterModule = {
     checkForUpdates: () => Promise<{
       artifact?: { type?: string };
       availableVersion?: string;
+      reinstall?: {
+        installedVersion?: string;
+        minVersion?: string;
+        reason?: string;
+      };
       state: string;
     }>;
     installUpdate: () => Promise<{
@@ -39,7 +44,7 @@ type DesktopUpdaterModule = {
       state: string;
     }>;
   };
-  DESKTOP_UPDATE_ENV: Record<"CURRENT_VERSION" | "METADATA_URL" | "PLATFORM", string>;
+  DESKTOP_UPDATE_ENV: Record<"CURRENT_VERSION" | "INSTALLED_VERSION" | "METADATA_URL" | "PLATFORM", string>;
 };
 
 type PackagedPaths = {
@@ -102,6 +107,8 @@ type PlatformCase = {
   payloadPath: string;
   platform: "darwin" | "win32";
   promotedVersion: string;
+  controlLauncherVersionMin?: string;
+  controlLauncherVersionUrl?: string;
   writePayload: (destinationRoot: string, testCase: PlatformCase) => Promise<void>;
 };
 
@@ -145,6 +152,8 @@ function serverAddress(server: Server): string {
 async function createPayloadMetadataFixture(options: PlatformCase): Promise<FixtureServer> {
   const payloadBody = Buffer.from("open design launcher payload update loop fixture");
   const payloadDigest = createHash("sha256").update(payloadBody).digest("hex");
+  const installerBody = Buffer.from("open design installer fixture");
+  const installerDigest = createHash("sha256").update(installerBody).digest("hex");
   const server = createServer((request, response) => {
     const url = request.url ?? "/";
     if (url === "/metadata.json") {
@@ -164,7 +173,7 @@ async function createPayloadMetadataFixture(options: PlatformCase): Promise<Fixt
                 name: options.platform === "win32"
                   ? `open-design-${options.promotedVersion}-win-x64-setup.exe`
                   : `open-design-${options.promotedVersion}-mac-arm64.dmg`,
-                sha256: "unused-full-package-checksum",
+                sha256: installerDigest,
                 url: `http://${serverAddress(server)}/${options.platform === "win32" ? "installer.exe" : "app.dmg"}`,
               },
               payload: {
@@ -176,8 +185,25 @@ async function createPayloadMetadataFixture(options: PlatformCase): Promise<Fixt
             },
           },
         },
+        ...(options.controlLauncherVersionMin != null || options.controlLauncherVersionUrl != null
+          ? {
+              control: {
+                launcher: {
+                  version: {
+                    ...(options.controlLauncherVersionMin == null ? {} : { min: options.controlLauncherVersionMin }),
+                    ...(options.controlLauncherVersionUrl == null ? {} : { url: options.controlLauncherVersionUrl }),
+                  },
+                },
+              },
+            }
+          : {}),
         version: 1,
       }));
+      return;
+    }
+    if (url === (options.platform === "win32" ? "/installer.exe" : "/app.dmg")) {
+      response.setHeader("content-length", String(installerBody.byteLength));
+      response.end(installerBody);
       return;
     }
     if (url === options.payloadPath) {
@@ -208,6 +234,44 @@ async function createPayloadMetadataFixture(options: PlatformCase): Promise<Fixt
         server.close((error) => (error == null ? resolveClose() : rejectClose(error)));
       }),
     metadataUrl: `http://${serverAddress(server)}/metadata.json`,
+  };
+}
+
+async function createFloorUpdater(
+  testCase: PlatformCase,
+  root: string,
+  metadataUrl: string,
+  installedVersion?: string,
+) {
+  const { createDesktopUpdater, DESKTOP_UPDATE_ENV } = await loadDesktopUpdaterModule();
+  const { resolvePackagedNamespacePaths } = await loadPackagedPathsModule();
+  const { resolvePackagedLauncherRuntime } = await loadPackagedLauncherRuntimeModule();
+  const config = fakePackagedConfig(root, testCase);
+  const paths = resolvePackagedNamespacePaths(config);
+  const runtime = await resolvePackagedLauncherRuntime(config, paths);
+  const env: Record<string, string> = {
+    [DESKTOP_UPDATE_ENV.CURRENT_VERSION]: testCase.currentVersion,
+    [DESKTOP_UPDATE_ENV.METADATA_URL]: metadataUrl,
+    [DESKTOP_UPDATE_ENV.PLATFORM]: testCase.platform,
+  };
+  if (installedVersion != null) env[DESKTOP_UPDATE_ENV.INSTALLED_VERSION] = installedVersion;
+  return {
+    paths,
+    updater: createDesktopUpdater({
+      arch: testCase.arch,
+      currentVersion: testCase.currentVersion,
+      downloadRoot: paths.updateRoot,
+      env,
+      launcherRoot: paths.installationRoot,
+      launcherLaunchPath: runtime.installedLaunchPath,
+      launcherRuntimePath: runtime.launcherPaths.runtimePath,
+      namespace: config.namespace,
+      platform: testCase.platform,
+      source: PACKAGED_SOURCE,
+    }, {
+      extractLauncherPayloadArchive: async (input: { destinationRoot: string }) =>
+        await testCase.writePayload(input.destinationRoot, testCase),
+    }),
   };
 }
 
@@ -470,6 +534,174 @@ describe("packaged launcher payload update loop", () => {
       });
       expect(fallback.source).toBe("payload");
       expect(fallback.targetVersion).toBe(testCase.promotedVersion);
+    } finally {
+      await fixture.close();
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it.each([
+    {
+      ...platformCases[0]!,
+      currentVersion: "1.1.0-beta.1",
+      promotedVersion: "2.0.0-beta.1",
+      controlLauncherVersionMin: "2.0.0-beta.1",
+      payloadArchiveName: "open-design-2.0.0-beta.1-win-x64-payload.7z",
+    },
+    {
+      ...platformCases[1]!,
+      currentVersion: "2.0.0-beta.1",
+      promotedVersion: "2.1.0-beta.1",
+      controlLauncherVersionMin: "2.0.0-beta.1",
+      payloadArchiveName: "open-design-2.1.0-beta.1-mac-arm64-payload.zip",
+    },
+  ] as PlatformCase[])(
+    "[P0] applies the launcher floor to $platform across major/minor version boundaries",
+    async (testCase) => {
+      const root = await mkdtemp(join(tmpdir(), "od-packaged-launcher-floor-"));
+      const fixture = await createPayloadMetadataFixture(testCase);
+
+      try {
+        const { createDesktopUpdater, DESKTOP_UPDATE_ENV } = await loadDesktopUpdaterModule();
+        const { resolvePackagedNamespacePaths } = await loadPackagedPathsModule();
+        const { resolvePackagedLauncherRuntime } = await loadPackagedLauncherRuntimeModule();
+        const config = fakePackagedConfig(root, testCase);
+        const paths = resolvePackagedNamespacePaths(config);
+        const runtime = await resolvePackagedLauncherRuntime(config, paths);
+        const updater = createDesktopUpdater({
+          arch: testCase.arch,
+          currentVersion: testCase.currentVersion,
+          downloadRoot: paths.updateRoot,
+          env: {
+            [DESKTOP_UPDATE_ENV.CURRENT_VERSION]: testCase.currentVersion,
+            [DESKTOP_UPDATE_ENV.INSTALLED_VERSION]: testCase.currentVersion,
+            [DESKTOP_UPDATE_ENV.METADATA_URL]: fixture.metadataUrl,
+            [DESKTOP_UPDATE_ENV.PLATFORM]: testCase.platform,
+          },
+          launcherRoot: paths.installationRoot,
+          launcherLaunchPath: runtime.installedLaunchPath,
+          launcherRuntimePath: runtime.launcherPaths.runtimePath,
+          namespace: config.namespace,
+          platform: testCase.platform,
+          source: PACKAGED_SOURCE,
+        }, {
+          extractLauncherPayloadArchive: async (input: { destinationRoot: string }) =>
+            await testCase.writePayload(input.destinationRoot, testCase),
+        });
+
+        const checked = await updater.checkForUpdates();
+        expect(checked.availableVersion).toBe(testCase.promotedVersion);
+        expect(checked.artifact?.type).toBe(
+          testCase.platform === "win32" ? "installer" : "payload",
+        );
+        if (testCase.platform === "win32") {
+          expect(checked.reinstall).toEqual({
+            installedVersion: testCase.currentVersion,
+            minVersion: testCase.controlLauncherVersionMin,
+            reason: "outer-below-min",
+          });
+        } else {
+          expect(checked.reinstall).toBeUndefined();
+        }
+
+      } finally {
+        await fixture.close();
+        await rm(root, { force: true, recursive: true });
+      }
+    },
+  );
+
+  it("[P0] keeps payload updates when the installed outer version meets min", async () => {
+    const testCase: PlatformCase = {
+      ...platformCases[0]!,
+      currentVersion: "2.0.0-beta.1",
+      promotedVersion: "2.1.0-beta.1",
+      controlLauncherVersionMin: "2.0.0-beta.1",
+      payloadArchiveName: "open-design-2.1.0-beta.1-win-x64-payload.7z",
+    };
+    const root = await mkdtemp(join(tmpdir(), "od-packaged-launcher-floor-met-"));
+    const fixture = await createPayloadMetadataFixture(testCase);
+
+    try {
+      const { createDesktopUpdater, DESKTOP_UPDATE_ENV } = await loadDesktopUpdaterModule();
+      const { resolvePackagedNamespacePaths } = await loadPackagedPathsModule();
+      const { resolvePackagedLauncherRuntime } = await loadPackagedLauncherRuntimeModule();
+      const config = fakePackagedConfig(root, testCase);
+      const paths = resolvePackagedNamespacePaths(config);
+      const runtime = await resolvePackagedLauncherRuntime(config, paths);
+      const updater = createDesktopUpdater({
+        arch: testCase.arch,
+        currentVersion: testCase.currentVersion,
+        downloadRoot: paths.updateRoot,
+        env: {
+          [DESKTOP_UPDATE_ENV.CURRENT_VERSION]: testCase.currentVersion,
+          [DESKTOP_UPDATE_ENV.INSTALLED_VERSION]: testCase.currentVersion,
+          [DESKTOP_UPDATE_ENV.METADATA_URL]: fixture.metadataUrl,
+          [DESKTOP_UPDATE_ENV.PLATFORM]: testCase.platform,
+        },
+        launcherRoot: paths.installationRoot,
+        launcherLaunchPath: runtime.installedLaunchPath,
+        launcherRuntimePath: runtime.launcherPaths.runtimePath,
+        namespace: config.namespace,
+        platform: testCase.platform,
+        source: PACKAGED_SOURCE,
+      }, {
+        extractLauncherPayloadArchive: async (input: { destinationRoot: string }) =>
+          await testCase.writePayload(input.destinationRoot, testCase),
+      });
+
+      const checked = await updater.checkForUpdates();
+      expect(checked.availableVersion).toBe(testCase.promotedVersion);
+      expect(checked.artifact?.type).toBe("payload");
+      expect(checked.reinstall).toBeUndefined();
+    } finally {
+      await fixture.close();
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("[P0] routes to installer when the installed outer config cannot be read", async () => {
+    const testCase: PlatformCase = {
+      ...platformCases[0]!,
+      currentVersion: "1.1.0-beta.1",
+      promotedVersion: "2.0.0-beta.1",
+      controlLauncherVersionMin: "1.2.0-beta.1",
+      payloadArchiveName: "open-design-2.0.0-beta.1-win-x64-payload.7z",
+    };
+    const root = await mkdtemp(join(tmpdir(), "od-packaged-launcher-floor-unreadable-"));
+    const fixture = await createPayloadMetadataFixture(testCase);
+
+    try {
+      const { updater } = await createFloorUpdater(testCase, root, fixture.metadataUrl);
+      const checked = await updater.checkForUpdates();
+      expect(checked.availableVersion).toBe(testCase.promotedVersion);
+      expect(checked.artifact?.type).toBe("installer");
+      expect(checked.reinstall).toEqual({
+        minVersion: testCase.controlLauncherVersionMin,
+        reason: "outer-version-unreadable",
+      });
+    } finally {
+      await fixture.close();
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("[P0] suppresses a same-version reinstall when min is above the latest release", async () => {
+    const testCase: PlatformCase = {
+      ...platformCases[0]!,
+      currentVersion: "1.1.0-beta.1",
+      promotedVersion: "1.1.0-beta.1",
+      controlLauncherVersionMin: "3.0.0-beta.1",
+      payloadArchiveName: "open-design-1.1.0-beta.1-win-x64-payload.7z",
+    };
+    const root = await mkdtemp(join(tmpdir(), "od-packaged-launcher-floor-unsatisfiable-"));
+    const fixture = await createPayloadMetadataFixture(testCase);
+
+    try {
+      const { updater } = await createFloorUpdater(testCase, root, fixture.metadataUrl, testCase.currentVersion);
+      const checked = await updater.checkForUpdates();
+      expect(checked.state).toBe("not-available");
+      expect(checked.availableVersion).toBeUndefined();
     } finally {
       await fixture.close();
       await rm(root, { force: true, recursive: true });

--- a/e2e/tests/packaged-launcher-update-loop.test.ts
+++ b/e2e/tests/packaged-launcher-update-loop.test.ts
@@ -629,6 +629,7 @@ describe("packaged launcher payload update loop", () => {
       const config = fakePackagedConfig(root, testCase);
       const paths = resolvePackagedNamespacePaths(config);
       const runtime = await resolvePackagedLauncherRuntime(config, paths);
+      const launchRequests: Array<{ launchPath: string; root: string }> = [];
       const updater = createDesktopUpdater({
         arch: testCase.arch,
         currentVersion: testCase.currentVersion,
@@ -648,12 +649,21 @@ describe("packaged launcher payload update loop", () => {
       }, {
         extractLauncherPayloadArchive: async (input: { destinationRoot: string }) =>
           await testCase.writePayload(input.destinationRoot, testCase),
+        launchAppAfterQuit: async (input: { launchPath: string; root: string }) => {
+          launchRequests.push({ launchPath: input.launchPath, root: input.root });
+          return {};
+        },
       });
 
       const checked = await updater.checkForUpdates();
       expect(checked.availableVersion).toBe(testCase.promotedVersion);
       expect(checked.artifact?.type).toBe("payload");
       expect(checked.reinstall).toBeUndefined();
+
+      const installed = await updater.installUpdate();
+      expect(installed.state).toBe(UPDATE_DOWNLOADED);
+      expect(installed.installResult?.dryRun).toBe(false);
+      expect(launchRequests).toHaveLength(1);
     } finally {
       await fixture.close();
       await rm(root, { force: true, recursive: true });

--- a/e2e/ui/app-manual-edit.test.ts
+++ b/e2e/ui/app-manual-edit.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '@/playwright/suite';
-import { expectStableCount } from '@/playwright/assertions';
 import { openNewProjectModal as openNewProjectModalFromProjects } from '@/playwright/rail';
 import { routeAgents, routeSuccessfulRuns } from '@/playwright/mock-factory';
 import { clickDeckNextSlide, openAllProjectFiles } from '@/playwright/workspace';
@@ -138,6 +137,36 @@ test('[P0] manual edit inspector previews and persists page and selected element
   await expect(page.getByRole('button', { name: /^Comment$/ })).toBeVisible();
   await expect(page.getByRole('button', { name: /^Share$/ })).toBeVisible();
   await expect(page.getByRole('button', { name: /^Download$/ })).toBeVisible();
+});
+
+test('[P0] manual edit undo and redo restore a saved style without reloading the preview', async ({ page }) => {
+  await routeMockAgents(page);
+  const projectId = await createEmptyProject(page, 'Manual edit history smoke');
+  await seedHtmlArtifact(page, projectId, 'manual-edit-history.html', manualEditHtml());
+  await page.goto(`/projects/${projectId}/files/manual-edit-history.html`);
+  await openDesignFile(page, 'manual-edit-history.html');
+
+  await page.getByTestId('manual-edit-mode-toggle').click();
+  const frame = artifactPreviewFrame(page);
+  await selectPreviewElementThroughBridge(page, frame, '[data-od-id="hero-title"]', 'TYPOGRAPHY');
+
+  const fontSizeInput = inspectorSection(page, 'TYPOGRAPHY').locator('.cc-row').filter({ hasText: 'Size' }).locator('input');
+  await fontSizeInput.fill('42');
+  await inspectSaveButton(page).click({ force: true });
+  await expectFileSource(page, projectId, 'manual-edit-history.html', ['font-size: 42px']);
+
+  const undo = page.getByTestId('manual-edit-undo');
+  const redo = page.getByTestId('manual-edit-redo');
+  await expect(undo).toBeVisible();
+  await expect(redo).toBeVisible();
+
+  await undo.click();
+  await expectFileSourceExcludes(page, projectId, 'manual-edit-history.html', ['font-size: 42px']);
+  await expect(frame.getByRole('heading', { name: 'Original Hero' })).toBeVisible();
+
+  await redo.click();
+  await expectFileSource(page, projectId, 'manual-edit-history.html', ['font-size: 42px']);
+  await expect(frame.getByRole('heading', { name: 'Original Hero' })).toBeVisible();
 });
 
 async function selectPreviewElementThroughBridge(
@@ -530,14 +559,15 @@ test('[P1] first-loop onboarding completes once after a successful artifact expo
   const secondHtmlDownload = page.waitForEvent('download');
   await page.locator('.share-menu-popover[role="menu"]').getByRole('menuitem', { name: /Export as standalone HTML/ }).click();
   await secondHtmlDownload;
-  await expectStableCount(
-    () => analyticsBodies.join('\n').match(/onboarding_completed/g)?.length ?? 0,
-    1,
-    {
-      timeout: 750,
-      message: 're-exporting the same first-loop artifact should not emit a duplicate completion event',
-    },
-  );
+  await expect
+    .poll(
+      () => analyticsBodies.join('\n').match(/onboarding_completed/g)?.length ?? 0,
+      {
+        timeout: 750,
+        message: 're-exporting the same first-loop artifact should not emit a duplicate completion event',
+      },
+    )
+    .toBe(1);
 });
 
 test('[P0] manual edit mode keeps deck navigation available for deck-shaped HTML', async ({ page }) => {

--- a/e2e/ui/app-manual-edit.test.ts
+++ b/e2e/ui/app-manual-edit.test.ts
@@ -169,6 +169,230 @@ test('[P0] manual edit undo and redo restore a saved style without reloading the
   await expect(frame.getByRole('heading', { name: 'Original Hero' })).toBeVisible();
 });
 
+test('[P0] manual edit keeps a mixed canvas and speaker-notes history chain', async ({ page }) => {
+  await routeMockAgents(page);
+  const projectId = await createEmptyProject(page, 'Manual edit mixed history');
+  await seedHtmlArtifact(page, projectId, 'manual-edit-history-deck.html', manualEditDeckHtml());
+  await page.goto(`/projects/${projectId}/files/manual-edit-history-deck.html`);
+  await openDesignFile(page, 'manual-edit-history-deck.html');
+
+  const frame = artifactPreviewFrame(page);
+  await expect(frame.getByRole('heading', { name: 'Original Hero' })).toBeVisible();
+  await expect(page.getByTestId('speaker-notes-panel')).toBeVisible();
+  await page.getByTestId('manual-edit-mode-toggle').click();
+
+  const notesPanel = page.getByTestId('speaker-notes-panel');
+  await notesPanel.getByRole('textbox').click();
+  await notesPanel.locator('textarea').fill('Discuss the launch timeline.');
+  await notesPanel.locator('textarea').blur();
+  await expectFileSource(page, projectId, 'manual-edit-history-deck.html', ['Discuss the launch timeline.']);
+
+  await selectPreviewElementThroughBridge(page, frame, '[data-od-id="hero-title"]', 'TYPOGRAPHY');
+  const fontSizeInput = inspectorSection(page, 'TYPOGRAPHY').locator('.cc-row').filter({ hasText: 'Size' }).locator('input');
+  await fontSizeInput.fill('42');
+  await inspectSaveButton(page).click({ force: true });
+  await expectFileSource(page, projectId, 'manual-edit-history-deck.html', [
+    'Discuss the launch timeline.',
+    'font-size: 42px',
+  ]);
+
+  const undo = page.getByTestId('manual-edit-undo');
+  const redo = page.getByTestId('manual-edit-redo');
+  await undo.click();
+  await expectFileSource(page, projectId, 'manual-edit-history-deck.html', ['Discuss the launch timeline.']);
+  await expect(frame.getByRole('heading', { name: 'Original Hero' })).toBeVisible();
+
+  await undo.click();
+  await expectFileSourceExcludes(page, projectId, 'manual-edit-history-deck.html', ['font-size: 42px']);
+  await expectFileSourceExcludes(page, projectId, 'manual-edit-history-deck.html', ['Discuss the launch timeline.']);
+  await expect(frame.getByRole('heading', { name: 'Original Hero' })).toBeVisible();
+
+  await redo.click();
+  await expectFileSource(page, projectId, 'manual-edit-history-deck.html', ['Discuss the launch timeline.']);
+  await redo.click();
+  await expectFileSource(page, projectId, 'manual-edit-history-deck.html', [
+    'Discuss the launch timeline.',
+    'font-size: 42px',
+  ]);
+  await expect(frame.getByRole('heading', { name: 'Original Hero' })).toBeVisible();
+});
+
+test('[P0] manual edit persists direct move and resize gestures without reloading the preview', async ({ page }) => {
+  await routeMockAgents(page);
+  const projectId = await createEmptyProject(page, 'Manual edit gesture history');
+  await seedHtmlArtifact(page, projectId, 'manual-edit-gestures.html', manualEditHtml());
+  await page.goto(`/projects/${projectId}/files/manual-edit-gestures.html`);
+  await openDesignFile(page, 'manual-edit-gestures.html');
+
+  await page.getByTestId('manual-edit-mode-toggle').click();
+  const frame = artifactPreviewFrame(page);
+  await selectPreviewElementWithoutInspector(page, frame, '[data-od-id="hero-image"]');
+  let previewNavigations = 0;
+  page.on('framenavigated', (navigated) => {
+    if (navigated.parentFrame() === page.mainFrame()) previewNavigations += 1;
+  });
+
+  const moveHandle = page.getByTestId('manual-edit-move-handle');
+  const moveBox = await moveHandle.boundingBox();
+  expect(moveBox).not.toBeNull();
+  await page.mouse.move(moveBox!.x + moveBox!.width / 2, moveBox!.y + moveBox!.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(moveBox!.x + moveBox!.width / 2 + 32, moveBox!.y + moveBox!.height / 2 + 18);
+  await page.mouse.up();
+  await expectFileSourceMatches(page, projectId, 'manual-edit-gestures.html', /position:\s*relative[\s\S]*left:\s*\d+(?:\.\d+)?px/);
+
+  const resizeHandle = page.getByTestId('manual-edit-resize-right');
+  const resizeBox = await resizeHandle.boundingBox();
+  expect(resizeBox).not.toBeNull();
+  await page.mouse.move(resizeBox!.x + resizeBox!.width / 2, resizeBox!.y + resizeBox!.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(resizeBox!.x + resizeBox!.width / 2 + 24, resizeBox!.y + resizeBox!.height / 2);
+  await page.mouse.up();
+  await expectFileSourceMatches(page, projectId, 'manual-edit-gestures.html', /width:\s*(?!64px)\d+(?:\.\d+)?px/);
+
+  const undo = page.getByTestId('manual-edit-undo');
+  const redo = page.getByTestId('manual-edit-redo');
+  await undo.click();
+  await expectFileSource(page, projectId, 'manual-edit-gestures.html', ['width: 64px']);
+  await undo.click();
+  await expectFileSourceExcludes(page, projectId, 'manual-edit-gestures.html', ['left:']);
+  await redo.click();
+  await expectFileSourceMatches(page, projectId, 'manual-edit-gestures.html', /left:\s*\d+(?:\.\d+)?px/);
+  await redo.click();
+  await expectFileSourceMatches(page, projectId, 'manual-edit-gestures.html', /width:\s*(?!64px)\d+(?:\.\d+)?px/);
+  expect(previewNavigations).toBe(0);
+});
+
+test('[P0] manual edit text content undo and redo keep the same preview document', async ({ page }) => {
+  await routeMockAgents(page);
+  const projectId = await createEmptyProject(page, 'Manual edit text history');
+  await seedHtmlArtifact(page, projectId, 'manual-edit-text-history.html', manualEditHtml());
+  await page.goto(`/projects/${projectId}/files/manual-edit-text-history.html`);
+  await openDesignFile(page, 'manual-edit-text-history.html');
+
+  await page.getByTestId('manual-edit-mode-toggle').click();
+  const frame = artifactPreviewFrame(page);
+  await selectPreviewElementWithoutInspector(page, frame, '[data-od-id="hero-title"]');
+  let previewNavigations = 0;
+  page.on('framenavigated', (navigated) => {
+    if (navigated.parentFrame() === page.mainFrame()) previewNavigations += 1;
+  });
+
+  const title = frame.locator('[data-od-id="hero-title"]');
+  await title.dblclick();
+  await title.fill('Edited Hero');
+  await title.press('Enter');
+  await expectFileSource(page, projectId, 'manual-edit-text-history.html', ['Edited Hero']);
+  await expect(frame.getByRole('heading', { name: 'Edited Hero' })).toBeVisible();
+
+  await page.getByTestId('manual-edit-undo').click();
+  await expectFileSourceExcludes(page, projectId, 'manual-edit-text-history.html', ['Edited Hero']);
+  await expect(frame.getByRole('heading', { name: 'Original Hero' })).toBeVisible();
+  await page.getByTestId('manual-edit-redo').click();
+  await expectFileSource(page, projectId, 'manual-edit-text-history.html', ['Edited Hero']);
+  await expect(frame.getByRole('heading', { name: 'Edited Hero' })).toBeVisible();
+  expect(previewNavigations).toBe(0);
+});
+
+test('[P1] manual edit replaces and crops an image while preserving selection state', async ({ page }) => {
+  await routeMockAgents(page);
+  const projectId = await createEmptyProject(page, 'Manual edit image operations');
+  const originalSource = 'data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2296%22 height=%2264%22%3E%3Crect width=%2296%22 height=%2264%22 fill=%22%23ef4444%22/%3E%3C/svg%3E';
+  await seedHtmlArtifact(page, projectId, 'manual-edit-image.html', manualEditHtml().replace('src="/hero.png"', `src="${originalSource}"`));
+  await page.goto(`/projects/${projectId}/files/manual-edit-image.html`);
+  await openDesignFile(page, 'manual-edit-image.html');
+
+  await page.getByTestId('manual-edit-mode-toggle').click();
+  const frame = artifactPreviewFrame(page);
+  await selectPreviewElementWithoutInspector(page, frame, '[data-od-id="hero-image"]');
+  const image = frame.locator('[data-od-id="hero-image"]');
+  await expect(image).toBeVisible();
+
+  const replacementBytes = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5W6McAAAAASUVORK5CYII=', 'base64');
+  await page.locator('[data-testid="manual-edit-action-bar"] input[type="file"]').setInputFiles({
+    name: 'replacement.png',
+    mimeType: 'image/png',
+    buffer: replacementBytes,
+  });
+  await expectFileSourceExcludes(page, projectId, 'manual-edit-image.html', [originalSource]);
+  await expect(page.getByTestId('manual-edit-selection-frame')).toBeVisible();
+
+  await page.getByTestId('manual-edit-crop-start').click();
+  await expect(page.getByTestId('manual-edit-crop-overlay')).toBeVisible();
+  const cropHandle = page.locator('[data-testid="manual-edit-crop-overlay"] [class*="cropHandle-se"]');
+  const cropBox = await cropHandle.boundingBox();
+  expect(cropBox).not.toBeNull();
+  await page.mouse.move(cropBox!.x + cropBox!.width / 2, cropBox!.y + cropBox!.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(cropBox!.x + cropBox!.width / 2 - 12, cropBox!.y + cropBox!.height / 2 - 8);
+  await page.mouse.up();
+  await page.getByTestId('manual-edit-crop-apply').click();
+  await expectFileSourceMatches(page, projectId, 'manual-edit-image.html', /-crop-\d+\.png/);
+  await expect(page.getByTestId('manual-edit-selection-frame')).toBeVisible();
+});
+
+test('[P1] manual edit duplicates and deletes a selected element', async ({ page }) => {
+  await routeMockAgents(page);
+  const projectId = await createEmptyProject(page, 'Manual edit structural operations');
+  await seedHtmlArtifact(page, projectId, 'manual-edit-structure.html', manualEditHtml());
+  await page.goto(`/projects/${projectId}/files/manual-edit-structure.html`);
+  await openDesignFile(page, 'manual-edit-structure.html');
+
+  await page.getByTestId('manual-edit-mode-toggle').click();
+  const frame = artifactPreviewFrame(page);
+  await selectPreviewElementWithoutInspector(page, frame, '[data-od-id="hero-image"]');
+
+  await page.getByTestId('manual-edit-duplicate').click();
+  await expectFileSourceMatches(page, projectId, 'manual-edit-structure.html', /<img\b[\s\S]*<img\b/);
+  await page.getByTestId('manual-edit-delete').click();
+  await expectFileSource(page, projectId, 'manual-edit-structure.html', ['src="/hero.png"']);
+  await expectFileSourceCount(page, projectId, 'manual-edit-structure.html', /<img\b/gi, 1);
+});
+
+test('[P1] manual edit copies and pastes a selected element as a new block', async ({ page }) => {
+  await routeMockAgents(page);
+  const projectId = await createEmptyProject(page, 'Manual edit copy paste');
+  await seedHtmlArtifact(page, projectId, 'manual-edit-copy-paste.html', manualEditHtml());
+  await page.goto(`/projects/${projectId}/files/manual-edit-copy-paste.html`);
+  await openDesignFile(page, 'manual-edit-copy-paste.html');
+
+  await page.getByTestId('manual-edit-mode-toggle').click();
+  const frame = artifactPreviewFrame(page);
+  await selectPreviewElementWithoutInspector(page, frame, '[data-od-id="hero-image"]');
+  await frame.locator('body').press('Control+c');
+  await frame.locator('body').press('Control+v');
+  await expectFileSourceMatches(page, projectId, 'manual-edit-copy-paste.html', /<img\b[\s\S]*<img\b/);
+  await page.getByTestId('manual-edit-delete').click();
+  await expectFileSource(page, projectId, 'manual-edit-copy-paste.html', ['src="/hero.png"']);
+  await expectFileSourceCount(page, projectId, 'manual-edit-copy-paste.html', /<img\b/gi, 1);
+});
+
+test('[P1] manual edit pastes a clipboard image as a new project asset', async ({ page }) => {
+  await routeMockAgents(page);
+  const projectId = await createEmptyProject(page, 'Manual edit clipboard image');
+  await seedHtmlArtifact(page, projectId, 'manual-edit-clipboard.html', manualEditHtml());
+  await page.goto(`/projects/${projectId}/files/manual-edit-clipboard.html`);
+  await openDesignFile(page, 'manual-edit-clipboard.html');
+
+  await page.getByTestId('manual-edit-mode-toggle').click();
+  const frame = artifactPreviewFrame(page);
+  await selectPreviewElementWithoutInspector(page, frame, '[data-od-id="hero-image"]');
+  const iframe = await artifactPreview(page).elementHandle();
+  const contentFrame = await iframe?.contentFrame();
+  expect(contentFrame).not.toBeNull();
+  await contentFrame!.evaluate(() => {
+    const bytes = Uint8Array.from([137, 80, 78, 71, 13, 10, 26, 10]);
+    const file = new File([bytes], 'clipboard.png', { type: 'image/png' });
+    const transfer = new DataTransfer();
+    transfer.items.add(file);
+    const event = new Event('paste', { bubbles: true, cancelable: true });
+    Object.defineProperty(event, 'clipboardData', { value: transfer });
+    document.body.dispatchEvent(event);
+  });
+  await expectFileSourceMatches(page, projectId, 'manual-edit-clipboard.html', /clipboard\.png|uploaded|project-files/);
+  await expectFileSourceCount(page, projectId, 'manual-edit-clipboard.html', /<img\b/gi, 2);
+});
+
 async function selectPreviewElementThroughBridge(
   page: Page,
   frame: ReturnType<Page['frameLocator']>,
@@ -192,6 +416,19 @@ async function selectPreviewElementThroughBridge(
   // inspector opens through the action bar's "Edit parameters" button.
   await page.getByTestId('manual-edit-open-inspector').click();
   await expect(page.locator('.manual-edit-modal')).toContainText(section);
+}
+
+async function selectPreviewElementWithoutInspector(
+  page: Page,
+  frame: ReturnType<Page['frameLocator']>,
+  selector: string,
+) {
+  await expect(frame.locator('html[data-od-edit-mode]')).toHaveCount(1);
+  await expect(async () => {
+    await frame.locator(selector).click({ timeout: 5_000 });
+    await expect(frame.locator(`${selector}[data-od-edit-selected="true"]`)).toHaveCount(1, { timeout: 2_000 });
+  }).toPass({ timeout: 30_000 });
+  await expect(page.getByTestId('manual-edit-selection-frame')).toBeVisible();
 }
 
 test('[P0] @critical preview toolbar keeps share, download, comment, and zoom actions reachable', async ({ page }) => {
@@ -969,6 +1206,27 @@ async function expectFileSourceExcludes(page: Page, projectId: string, fileName:
     .toBe(true);
 }
 
+async function expectFileSourceMatches(page: Page, projectId: string, fileName: string, pattern: RegExp) {
+  await expect
+    .poll(async () => {
+      const resp = await page.request.get(`/api/projects/${projectId}/files/${fileName}`);
+      if (!resp.ok()) return false;
+      return pattern.test(await resp.text());
+    })
+    .toBe(true);
+}
+
+async function expectFileSourceCount(page: Page, projectId: string, fileName: string, pattern: RegExp, count: number) {
+  await expect
+    .poll(async () => {
+      const resp = await page.request.get(`/api/projects/${projectId}/files/${fileName}`);
+      if (!resp.ok()) return -1;
+      const source = await resp.text();
+      return source.match(pattern)?.length ?? 0;
+    })
+    .toBe(count);
+}
+
 function inspectorRow(page: Page, label: string) {
   return page.locator('.manual-edit-modal .cc-row').filter({ hasText: label }).first();
 }
@@ -1022,6 +1280,13 @@ function manualEditHtml(): string {
     </main>
   </body>
 </html>`;
+}
+
+function manualEditDeckHtml(): string {
+  return manualEditHtml().replace(
+    '</body>\n</html>',
+    '    <script type="application/json" id="speaker-notes">["Initial note"]</script>\n    <section class="slide" data-od-id="slide-1" hidden></section>\n  </body>\n</html>',
+  );
 }
 
 function deckHtml(): string {

--- a/e2e/ui/app-manual-edit.test.ts
+++ b/e2e/ui/app-manual-edit.test.ts
@@ -150,6 +150,10 @@ test('[P0] manual edit undo and redo restore a saved style without reloading the
   await page.getByTestId('manual-edit-mode-toggle').click();
   const frame = artifactPreviewFrame(page);
   await selectPreviewElementThroughBridge(page, frame, '[data-od-id="hero-title"]', 'TYPOGRAPHY');
+  let previewNavigations = 0;
+  page.on('framenavigated', (navigated) => {
+    if (navigated.parentFrame() === page.mainFrame()) previewNavigations += 1;
+  });
 
   const fontSizeInput = inspectorSection(page, 'TYPOGRAPHY').locator('.cc-row').filter({ hasText: 'Size' }).locator('input');
   await fontSizeInput.fill('42');
@@ -168,6 +172,7 @@ test('[P0] manual edit undo and redo restore a saved style without reloading the
   await redo.click();
   await expectFileSource(page, projectId, 'manual-edit-history.html', ['font-size: 42px']);
   await expect(frame.getByRole('heading', { name: 'Original Hero' })).toBeVisible();
+  expect(previewNavigations).toBe(0);
 });
 
 test('[P0] manual edit keeps a mixed canvas and speaker-notes history chain', async ({ page }) => {

--- a/e2e/ui/app-manual-edit.test.ts
+++ b/e2e/ui/app-manual-edit.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@/playwright/suite';
+import { expectStableCount } from '@/playwright/assertions';
 import { openNewProjectModal as openNewProjectModalFromProjects } from '@/playwright/rail';
 import { routeAgents, routeSuccessfulRuns } from '@/playwright/mock-factory';
 import { clickDeckNextSlide, openAllProjectFiles } from '@/playwright/workspace';
@@ -796,15 +797,14 @@ test('[P1] first-loop onboarding completes once after a successful artifact expo
   const secondHtmlDownload = page.waitForEvent('download');
   await page.locator('.share-menu-popover[role="menu"]').getByRole('menuitem', { name: /Export as standalone HTML/ }).click();
   await secondHtmlDownload;
-  await expect
-    .poll(
-      () => analyticsBodies.join('\n').match(/onboarding_completed/g)?.length ?? 0,
-      {
-        timeout: 750,
-        message: 're-exporting the same first-loop artifact should not emit a duplicate completion event',
-      },
-    )
-    .toBe(1);
+  await expectStableCount(
+    () => analyticsBodies.join('\n').match(/onboarding_completed/g)?.length ?? 0,
+    1,
+    {
+      timeout: 750,
+      message: 're-exporting the same first-loop artifact should not emit a duplicate completion event',
+    },
+  );
 });
 
 test('[P0] manual edit mode keeps deck navigation available for deck-shaped HTML', async ({ page }) => {


### PR DESCRIPTION
## What changed

- Add packaged updater P0 coverage for major/minor launcher-floor boundaries.
- Verify payload updates when the installed outer version meets the minimum.
- Verify installer routing when the installed outer config is unreadable.
- Verify same-version reinstall is suppressed when the minimum exceeds the latest release.
- Add Manual Edit save/undo/redo coverage without preview reload.

## Why

This closes the highest-priority E2E gaps from the 0.17.0 acceptance checklist around `control.launcher.version.min` and reliable Manual Edit history.

## Validation

- `pnpm --filter @open-design/e2e typecheck`
- Targeted packaged updater Vitest: 5 passed
- `git diff --check`

The browser Manual Edit test is added but local Playwright execution is currently blocked by the tools-dev `--parentPid` startup argument issue.