### PR TITLE
fix(collab): make the local pin the only workspace-selection truth

### DIFF
--- a/apps/daemon/src/collab/vela-workspace-context.ts
+++ b/apps/daemon/src/collab/vela-workspace-context.ts
@@ -205,30 +205,23 @@ export function createVelaWorkspaceContextProvider(
   type VelaSession = NonNullable<ReturnType<typeof readVelaControlApiContext>>;
   let lastBootstrapFailureAt = 0;
 
-  async function putCurrentWorkspace(
-    session: VelaSession,
-    workspaceId: string,
-  ): Promise<boolean> {
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), timeoutMs);
-    try {
-      const response = await fetchImpl(new URL(WORKSPACE_CURRENT_PATH, session.apiUrl), {
-        method: 'PUT',
-        headers: {
-          authorization: `Bearer ${session.controlKey}`,
-          'content-type': 'application/json',
-        },
-        body: JSON.stringify({ workspaceId }),
-        signal: controller.signal,
-      });
-      return response.ok;
-    } catch {
-      return false;
-    } finally {
-      clearTimeout(timeout);
-    }
-  }
-
+  /**
+   * Read the context for the workspace THIS daemon is pinned to.
+   *
+   * The workspace travels as `x-vela-workspace-id`, which is the per-request
+   * workspace scope B honours across its resource plane, its billing scope
+   * routes and the Link gateway (and which the vela CLI already sends for
+   * scoped commands). A `?workspaceId=` query hint is NOT sent: B's
+   * `GET /workspaces/current` ignores URL hints by design and asserts that in
+   * its own suite, so a query param was only ever dead weight that made this
+   * look scoped when it was not.
+   *
+   * Without the header B answers from the ACCOUNT-LEVEL active workspace,
+   * which is one row per account (`active_workspace_selections` is keyed by
+   * app user) and therefore cannot describe an account whose clients are in
+   * different workspaces. Sending it is what lets two clients of one account
+   * each read their own workspace.
+   */
   async function fetchCurrent(
     session: VelaSession,
     activeWorkspaceId: string | undefined,
@@ -236,11 +229,12 @@ export function createVelaWorkspaceContextProvider(
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      const url = new URL(WORKSPACE_CURRENT_PATH, session.apiUrl);
-      if (activeWorkspaceId) url.searchParams.set('workspaceId', activeWorkspaceId);
-      return await fetchImpl(url, {
+      return await fetchImpl(new URL(WORKSPACE_CURRENT_PATH, session.apiUrl), {
         method: 'GET',
-        headers: { authorization: `Bearer ${session.controlKey}` },
+        headers: {
+          authorization: `Bearer ${session.controlKey}`,
+          ...(activeWorkspaceId ? { 'x-vela-workspace-id': activeWorkspaceId } : {}),
+        },
         signal: controller.signal,
       });
     } finally {
@@ -347,11 +341,6 @@ export function createVelaWorkspaceContextProvider(
   }
 
   return {
-    async selectWorkspace(workspaceId: string): Promise<boolean> {
-      const session = readSession();
-      if (!session || !session.controlKey || !session.apiUrl) return false;
-      return putCurrentWorkspace(session, workspaceId);
-    },
     async current(_req: WorkspaceContextRequest): Promise<WorkspaceCollabContext | null> {
       const session = readSession();
       if (!session || !session.controlKey || !session.apiUrl) return null;

--- a/apps/daemon/src/collab/workspace-context.ts
+++ b/apps/daemon/src/collab/workspace-context.ts
@@ -33,16 +33,6 @@ export interface WorkspaceContextProvider {
    */
   set?(context: WorkspaceCollabContext | null): void;
   /**
-   * Switch the ACCOUNT-LEVEL active workspace on the backend. B's 2026-07-16
-   * deploy moved workspace selection server-side (`GET /workspaces/current`
-   * ignores per-request workspace hints), so a local-only selection leaves
-   * every follow-up read and CLI call scoped to the previous workspace —
-   * which read back as 403 missing_principal on the collab plane. Providers
-   * without a backend (dev) omit this. Resolves false when the backend
-   * refused the switch.
-   */
-  selectWorkspace?(workspaceId: string): Promise<boolean>;
-  /**
    * Synchronous read of the most recently resolved context — NO network I/O,
    * ever. Populated as a side effect of the ordinary `.current()` traffic this
    * provider already serves: the web client's `GET /api/workspace/context`

--- a/apps/daemon/src/routes/collab-context.ts
+++ b/apps/daemon/src/routes/collab-context.ts
@@ -45,6 +45,7 @@ import {
 } from '../integrations/vela-billing.js';
 import {
   listVelaWorkspaceDirectory,
+  workspaceContextFromDirectoryItem,
   type WorkspaceDirectoryFetchResult,
 } from '../collab/vela-workspace-context.js';
 import {
@@ -323,40 +324,44 @@ export function registerCollabContextRoutes(app: Express, deps: RegisterCollabCo
     if (!workspaceId) return res.status(400).json({ error: 'missing_workspace_id' });
 
     const directory = await listWorkspaceDirectory().catch(() => []);
-    if (!directory.some((item) => item.workspaceId === workspaceId)) {
+    const selected = directory.find((item) => item.workspaceId === workspaceId);
+    if (!selected) {
       return res.status(404).json({ error: 'workspace_not_visible' });
     }
 
+    // Choosing a workspace is a LOCAL decision, and this daemon's pin is the
+    // only thing that decides which workspace it operates in. The membership
+    // directory above is the authorization: it answered, and it lists the
+    // caller as holding this workspace. Nothing about that fact lives on the
+    // backend, so there is nothing here that can be "rejected" — the switch
+    // cannot fail once the directory confirms it.
+    //
+    // This used to PUT B's account-level active workspace first and fail the
+    // user's click (502) when that write did not take. That row is keyed by app
+    // user, so it can only ever name ONE workspace for an account whose clients
+    // are in different ones: every switch yanked the other clients' server-side
+    // scope, and the client that did not write it last was answered for someone
+    // else's workspace. Workspace now travels per request on
+    // `x-vela-workspace-id` instead (see `fetchCurrent`), which is what makes
+    // N clients of one account independent.
     const authorization = req.header('authorization') ?? undefined;
-    const previous = deps.activeWorkspace.get();
-    // B moved workspace selection server-side (2026-07-16): the account-level
-    // active workspace must be switched ON THE BACKEND first, or every
-    // follow-up context read and scoped CLI call stays on the old workspace
-    // and the validation below always fails. Local-only providers (dev) have
-    // no selectWorkspace and keep the previous behavior.
-    if (workspaceContext.selectWorkspace) {
-      const switched = await workspaceContext.selectWorkspace(workspaceId).catch(() => false);
-      if (!switched) {
-        return res.status(502).json({ error: 'workspace_switch_rejected' });
-      }
-    }
     await deps.activeWorkspace.set(workspaceId);
     const context = await workspaceContext.current({ authorization }).catch(() => null);
-    if (!context || context.workspaceId !== workspaceId) {
-      if (previous) {
-        await deps.activeWorkspace.set(previous);
-        // Undo the backend-side switch too, or the account stays parked on a
-        // workspace the client just refused.
-        await workspaceContext.selectWorkspace?.(previous).catch(() => false);
-      } else await deps.activeWorkspace.clear();
-      return res.status(404).json({ error: 'workspace_context_unavailable' });
-    }
-    // The switch is confirmed: the backend moved and the context read agrees.
+    // A context read that fails, or that still describes the old workspace, is
+    // an unconfirmed READ — never evidence that the switch was wrong. Answer
+    // from the directory entry already validated above rather than reverting a
+    // choice the user made and the directory allowed. The billing plane is
+    // thinner on that synthesis (no plan id, no seat counts), which the web
+    // closes out on its next context poll.
+    const resolved =
+      context && context.workspaceId === workspaceId
+        ? context
+        : workspaceContextFromDirectoryItem(selected);
     // Warm the now-cold workspace-scoped caches before responding to the
     // browser, but never await them — a slow upstream must not delay the
     // switch, and a failed warm just leaves the old cold-read behavior.
     deps.onWorkspaceSwitched?.(workspaceId);
-    const body: WorkspaceActiveResponse = { activeWorkspaceId: workspaceId, context };
+    const body: WorkspaceActiveResponse = { activeWorkspaceId: workspaceId, context: resolved };
     res.json(body);
   });
 

--- a/apps/daemon/src/routes/collab-context.ts
+++ b/apps/daemon/src/routes/collab-context.ts
@@ -324,7 +324,18 @@ export function registerCollabContextRoutes(app: Express, deps: RegisterCollabCo
     if (!workspaceId) return res.status(400).json({ error: 'missing_workspace_id' });
 
     const directory = await listWorkspaceDirectory().catch(() => []);
-    const selected = directory.find((item) => item.workspaceId === workspaceId);
+    // A directory row only authorizes a switch while it is a LIVE membership.
+    // Matching on the id alone would let a listed-but-removed membership (or a
+    // deleted workspace) through, and this entry is also what gets synthesized
+    // into the response below — so an unfiltered match could describe a
+    // workspace the caller no longer holds. Same predicate the provider's own
+    // `resolvePinnedWorkspace` uses.
+    const selected = directory.find(
+      (item) =>
+        item.workspaceId === workspaceId &&
+        item.memberStatus === 'active' &&
+        item.lifecycleState !== 'deleted',
+    );
     if (!selected) {
       return res.status(404).json({ error: 'workspace_not_visible' });
     }
@@ -347,12 +358,35 @@ export function registerCollabContextRoutes(app: Express, deps: RegisterCollabCo
     const authorization = req.header('authorization') ?? undefined;
     await deps.activeWorkspace.set(workspaceId);
     const context = await workspaceContext.current({ authorization }).catch(() => null);
-    // A context read that fails, or that still describes the old workspace, is
-    // an unconfirmed READ — never evidence that the switch was wrong. Answer
-    // from the directory entry already validated above rather than reverting a
-    // choice the user made and the directory allowed. The billing plane is
-    // thinner on that synthesis (no plan id, no seat counts), which the web
-    // closes out on its next context poll.
+
+    // `current()` is NOT a passive read. The vela provider's
+    // `resolvePinnedWorkspace` does its own FRESH directory lookup, and when
+    // that confirms the pinned workspace is gone (membership removed, workspace
+    // deleted) it clears the pin and re-pins a recovery workspace so a removed
+    // member is not left signed out of everything. The directory read above can
+    // meanwhile have been served from its 5s cache and still list the workspace.
+    //
+    // So the pin — re-read here, after `current()` has had its chance to move
+    // it — is the only thing that can say which workspace this daemon actually
+    // ended up on. Trusting the pre-call snapshot instead would let this route
+    // answer 200 naming a workspace the pin no longer holds: the UI would show
+    // the switch succeeding and then snap back on the next context poll.
+    const pinnedAfterRead = deps.activeWorkspace.get();
+    if (pinnedAfterRead !== workspaceId) {
+      // The provider confirmed the requested workspace is not available to this
+      // member and recovered elsewhere. Report that the requested switch did not
+      // happen, and leave its recovery pin alone — undoing it would restore the
+      // very "signed out of every workspace" state it exists to prevent. The web
+      // picks the recovery workspace up from its next context read.
+      return res.status(404).json({ error: 'workspace_no_longer_available' });
+    }
+
+    // The pin held. A context read that failed, or that still describes the old
+    // workspace, is an unconfirmed READ — never evidence that the switch was
+    // wrong. Answer from the directory entry already validated above rather than
+    // reverting a choice the user made and the directory allowed. The billing
+    // plane is thinner on that synthesis (no plan id, no seat counts), which the
+    // web closes out on its next context poll.
     const resolved =
       context && context.workspaceId === workspaceId
         ? context

--- a/apps/daemon/tests/collab/workspace-multi-client-scope.test.ts
+++ b/apps/daemon/tests/collab/workspace-multi-client-scope.test.ts
@@ -1,22 +1,19 @@
 import { describe, expect, it } from 'vitest';
 import { createVelaWorkspaceContextProvider } from '../../src/collab/vela-workspace-context.js';
 
-// Two clients, ONE account. This suite models B (vela) exactly as its source
-// behaves today, so the account-level Active Workspace can be reasoned about
-// without a live backend:
+// Two OD clients, ONE vela account. These suites model B from its source so the
+// account-level Active Workspace can be reasoned about without a live backend:
 //
 //  - `active_workspace_selections` is keyed by app_user_id ALONE
-//    (db/schema/public.hcl:792 `primary_key { columns = [column.app_user_id] }`),
-//    so the account has exactly one selection — there is no client/device axis.
-//  - `GET /api/v1/workspaces/current` DISCARDS a `?workspaceId=` hint. The
-//    handler never reads the query (services/api/src/workspaces/routes.ts:166-176
-//    only sets workspaceId when team workspaces are DISABLED) and vela locks
-//    that in by name: test "ignores URL workspace hints when resolving
-//    server-owned current context" (services/api/test/workspaces-personal.test.ts:480).
-//  - `PUT /api/v1/workspaces/current` moves that single account-level row.
-//  - `GET /api/v1/workspaces` (the membership directory) is scoped by
-//    app_user_id, NOT by the selection (services/api/src/workspaces/routes.ts:460),
-//    so it answers the same for every client of the account.
+//    (db/schema/public.hcl `primary_key { columns = [column.app_user_id] }`),
+//    so an account has exactly one selection — there is no client axis.
+//  - `GET /api/v1/workspaces` (the membership directory) is scoped by app user,
+//    NOT by that selection, so it answers the same for every client.
+//  - `GET /api/v1/workspaces/current` USED to answer only from that selection.
+//    It now also honours `x-vela-workspace-id`, the per-request workspace scope
+//    B already accepted on its resource plane, its billing scope routes and the
+//    Link gateway. URL query hints stay ignored either way — B asserts that in
+//    its own suite ("ignores URL workspace hints...").
 
 const TEAM = 'ws-team-1';
 const PERSONAL = 'ws-personal-1';
@@ -82,29 +79,41 @@ function jsonResponse(status: number, body: unknown): Response {
   return { ok: status >= 200 && status < 300, status, json: async () => body } as unknown as Response;
 }
 
-/** One vela account: one selection row, shared by every client that signs in. */
-function createOneAccountVela(initialSelection: string) {
-  const bodies: Record<string, unknown> = {
-    [TEAM]: B_TEAM_CONTEXT,
-    [PERSONAL]: B_PERSONAL_CONTEXT,
-  };
-  let selection = initialSelection;
-  let currentReads = 0;
+const BODIES: Record<string, unknown> = {
+  [TEAM]: B_TEAM_CONTEXT,
+  [PERSONAL]: B_PERSONAL_CONTEXT,
+};
+
+/**
+ * One vela account: one account-level selection row, shared by every client
+ * signed into it. `honoursWorkspaceHeader` is the only difference between B
+ * before and after the current-context scoping change.
+ */
+function createOneAccountVela(options: {
+  selection: string;
+  honoursWorkspaceHeader: boolean;
+}) {
+  let selection = options.selection;
   let directoryReads = 0;
+  let putCount = 0;
 
   const fetchImpl = (async (url: URL | string, init?: RequestInit) => {
     const u = String(url);
     const method = init?.method ?? 'GET';
     if (u.includes('/workspaces/current') && method === 'PUT') {
+      putCount += 1;
       const body = JSON.parse(String(init?.body ?? '{}')) as { workspaceId?: string };
       if (body.workspaceId) selection = body.workspaceId;
-      return jsonResponse(200, bodies[selection]);
+      return jsonResponse(200, BODIES[selection]);
     }
     if (u.includes('/workspaces/current') && method === 'GET') {
-      currentReads += 1;
-      // The `?workspaceId=` hint OD appends is dropped on the floor here,
-      // exactly as vela's handler drops it.
-      return jsonResponse(200, bodies[selection]);
+      // A `?workspaceId=` hint is ignored by B in both eras; only the header
+      // can scope this read, and only after the scoping change.
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      const requested = options.honoursWorkspaceHeader
+        ? headers['x-vela-workspace-id']
+        : undefined;
+      return jsonResponse(200, BODIES[requested ?? selection]);
     }
     if (u.endsWith('/api/v1/workspaces') && method === 'GET') {
       directoryReads += 1;
@@ -116,16 +125,16 @@ function createOneAccountVela(initialSelection: string) {
   return {
     fetchImpl,
     selection: () => selection,
-    currentReads: () => currentReads,
     directoryReads: () => directoryReads,
+    putCount: () => putCount,
   };
 }
 
-/** One OD daemon: its own local pin, sharing the account's vela session. */
-function createClient(vela: ReturnType<typeof createOneAccountVela>, pinned: string) {
+/** One OD daemon: its own local pin over the account's shared vela session. */
+function createClient(fetchImpl: typeof fetch, pinned: string) {
   let pin: string | null = pinned;
   const provider = createVelaWorkspaceContextProvider({
-    fetch: vela.fetchImpl,
+    fetch: fetchImpl,
     readSession: () => SESSION,
     getActiveWorkspaceId: () => pin,
     setLocalSelection: (id) => {
@@ -138,115 +147,128 @@ function createClient(vela: ReturnType<typeof createOneAccountVela>, pinned: str
   return {
     pin: () => pin,
     context: () => provider.current({}),
-    /** What OD's PUT /api/workspace/active does: move B, then move the pin. */
-    async switchTo(workspaceId: string) {
-      const switched = await provider.selectWorkspace?.(workspaceId);
-      if (switched) pin = workspaceId;
-      return switched;
+    /**
+     * What `PUT /api/workspace/active` does now: move the LOCAL pin. There is
+     * no backend selection call left to make.
+     */
+    switchTo(workspaceId: string) {
+      pin = workspaceId;
     },
   };
 }
 
-describe('one account, two clients, one account-level Active Workspace', () => {
-  it('does NOT hand a client the other client’s workspace — the local pin holds', async () => {
-    const vela = createOneAccountVela(TEAM);
-    const clientA = createClient(vela, TEAM);
-    const clientB = createClient(vela, PERSONAL);
+describe('one account, two clients, against a B that only knows an account-level workspace', () => {
+  it('holds each client on its own pin rather than following the account row', async () => {
+    const vela = createOneAccountVela({ selection: PERSONAL, honoursWorkspaceHeader: false });
+    const clientA = createClient(vela.fetchImpl, TEAM);
 
-    // Client B switches. This moves the ONE account-level row.
-    expect(await clientB.switchTo(PERSONAL)).toBe(true);
-    expect(vela.selection()).toBe(PERSONAL);
-
-    // Client A reads its context next. B's `current` now answers PERSONAL for
-    // the whole account, but A must stay on its own pinned TEAM scope.
+    // The account row names the OTHER client's workspace. This daemon must not
+    // follow it.
     const a = await clientA.context();
     expect(a?.workspaceId).toBe(TEAM);
     expect(clientA.pin()).toBe(TEAM);
   });
 
-  it('DOES degrade the losing client’s billing/seat context to a directory synthesis', async () => {
-    const vela = createOneAccountVela(TEAM);
-    const clientA = createClient(vela, TEAM);
-    const clientB = createClient(vela, PERSONAL);
-
-    // While the account-level row still points at A's workspace, A gets B's
-    // rich context: real plan id and real seat counts.
-    const enriched = await clientA.context();
+  it('degrades the losing client to a directory synthesis, which reads as seats-full', async () => {
+    const winning = createOneAccountVela({ selection: TEAM, honoursWorkspaceHeader: false });
+    const enriched = await createClient(winning.fetchImpl, TEAM).context();
+    // While the account row happens to name THIS client's workspace, B can
+    // describe it fully.
     expect(enriched?.planId).toBe('team-pro');
-    expect(enriched?.seatSummary).toEqual({
-      seatLimit: 5,
-      usedSeats: 2,
-      availableSeats: 3,
-      isSeatFull: false,
-    });
-    const directoryReadsWhileWinning = vela.directoryReads();
+    expect(enriched?.seatSummary.isSeatFull).toBe(false);
 
-    // Client B switches away. Nothing about A's workspace, membership, plan or
-    // seats changed — only which workspace the ACCOUNT row names.
-    await clientB.switchTo(PERSONAL);
-
+    const losing = createOneAccountVela({ selection: PERSONAL, honoursWorkspaceHeader: false });
+    const clientA = createClient(losing.fetchImpl, TEAM);
     const degraded = await clientA.context();
-    // Same workspace…
+
+    // Same workspace, same membership, same seats in reality...
     expect(degraded?.workspaceId).toBe(TEAM);
-    // …but the billing plane is gone, because B's `current` can only describe
-    // ONE workspace per account and OD must fall back to synthesizing A's
-    // context from the membership directory, which carries no billing data.
+    // ...but the billing plane is gone, because one row cannot describe two
+    // workspaces and OD has to synthesize this one from the directory.
     expect(degraded?.planId).toBeNull();
-    // Worse than merely blank: a 0/0 seat summary derives `isSeatFull: true`,
-    // so the losing client reads its own healthy 3-free-seat workspace as
-    // full. The seat gate is a client-side check (#115), which makes this a
-    // user-visible block on inviting, not just a cosmetic badge.
+    // Worse than blank: a 0/0 seat summary derives isSeatFull, so a workspace
+    // with three free seats reads as full to this client. The seat gate is a
+    // client-side check, so that is a user-visible block on inviting.
     expect(degraded?.seatSummary).toEqual({
       seatLimit: 0,
       usedSeats: 0,
       availableSeats: 0,
       isSeatFull: true,
     });
-    expect(enriched?.seatSummary.isSeatFull).toBe(false);
-    // And it costs an extra round-trip that the winning client never pays.
-    expect(vela.directoryReads()).toBeGreaterThan(directoryReadsWhileWinning);
+    // And it costs a second round-trip the winning client never makes.
+    expect(losing.directoryReads()).toBeGreaterThan(winning.directoryReads());
   });
 
-  it('makes the losing client’s context read depend on a second, fallible call', async () => {
-    // Same setup, but the directory read fails once — a blip that the winning
-    // client would never even notice, because it never makes that call.
-    const vela = createOneAccountVela(PERSONAL);
-    let failDirectory = false;
+  it('leaves the losing client with no context at all when that extra call blips', async () => {
+    const vela = createOneAccountVela({ selection: PERSONAL, honoursWorkspaceHeader: false });
+    let failDirectory = true;
     const fetchImpl = (async (url: URL | string, init?: RequestInit) => {
       if (String(url).endsWith('/api/v1/workspaces') && failDirectory) {
         throw new Error('directory blip');
       }
       return (vela.fetchImpl as unknown as typeof fetch)(url as never, init as never);
     }) as unknown as typeof fetch;
+    const clientA = createClient(fetchImpl, TEAM);
 
-    const clientA = createClient({ ...vela, fetchImpl }, TEAM);
-
-    failDirectory = true;
-    // B's account row says PERSONAL, A is pinned to TEAM, so A can only resolve
-    // its own scope through the directory — and that call just failed.
+    // Pinned to TEAM while the account row says PERSONAL, this client can only
+    // resolve its own scope through the directory — which just failed.
     expect(await clientA.context()).toBeNull();
-    // The pin survives (nothing was confirmed), but this client has NO context
-    // for a full poll tick purely because another client owns the account row.
+    // The pin survives, because nothing was confirmed.
     expect(clientA.pin()).toBe(TEAM);
 
     failDirectory = false;
     expect((await clientA.context())?.workspaceId).toBe(TEAM);
   });
+});
 
-  it('lets each client yank the other’s server-side scope on every switch', async () => {
-    const vela = createOneAccountVela(TEAM);
-    const clientA = createClient(vela, TEAM);
-    const clientB = createClient(vela, PERSONAL);
+describe('one account, two clients, against a B that honours a per-request workspace', () => {
+  it('serves BOTH clients their own workspace, fully enriched', async () => {
+    const vela = createOneAccountVela({ selection: PERSONAL, honoursWorkspaceHeader: true });
+    const clientA = createClient(vela.fetchImpl, TEAM);
+    const clientB = createClient(vela.fetchImpl, PERSONAL);
 
-    await clientB.switchTo(PERSONAL);
+    const a = await clientA.context();
+    const b = await clientB.context();
+
+    expect(a?.workspaceId).toBe(TEAM);
+    expect(b?.workspaceId).toBe(PERSONAL);
+    // Neither client is second-class: the billing plane survives for both,
+    // which is the whole point of scoping the read per request.
+    expect(a?.planId).toBe('team-pro');
+    expect(a?.seatSummary).toEqual({
+      seatLimit: 5,
+      usedSeats: 2,
+      availableSeats: 3,
+      isSeatFull: false,
+    });
+    expect(b?.planId).toBe('personal-pro');
+    // No directory synthesis was needed for either of them.
+    expect(vela.directoryReads()).toBe(0);
+  });
+
+  it('never writes the account-level selection, so no client can yank another', async () => {
+    const vela = createOneAccountVela({ selection: PERSONAL, honoursWorkspaceHeader: true });
+    const clientA = createClient(vela.fetchImpl, TEAM);
+    const clientB = createClient(vela.fetchImpl, PERSONAL);
+
+    clientA.switchTo(PERSONAL);
+    clientA.switchTo(TEAM);
+    await clientA.context();
+    await clientB.context();
+
+    // The account row is never touched — not on a switch, not on a read. This
+    // is the regression guard: reintroducing a server-side selection write
+    // brings back the cross-client yank.
+    expect(vela.putCount()).toBe(0);
     expect(vela.selection()).toBe(PERSONAL);
-
-    // A switches back to its own workspace — a purely local UI action — and in
-    // doing so re-points the account row out from under client B. Whatever on
-    // the vela side still resolves a workspace from that row (rather than from
-    // an explicit parameter) is now aimed at A's workspace for BOTH clients.
-    await clientA.switchTo(TEAM);
-    expect(vela.selection()).toBe(TEAM);
     expect(clientB.pin()).toBe(PERSONAL);
+  });
+
+  it('still ignores a mismatched account row when the header path is available', async () => {
+    // Defence in depth: even if B answered for the wrong workspace, the pin
+    // stays authoritative.
+    const vela = createOneAccountVela({ selection: PERSONAL, honoursWorkspaceHeader: false });
+    const clientA = createClient(vela.fetchImpl, TEAM);
+    expect((await clientA.context())?.workspaceId).toBe(TEAM);
   });
 });

--- a/apps/daemon/tests/collab/workspace-multi-client-scope.test.ts
+++ b/apps/daemon/tests/collab/workspace-multi-client-scope.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from 'vitest';
+import { createVelaWorkspaceContextProvider } from '../../src/collab/vela-workspace-context.js';
+
+// Two clients, ONE account. This suite models B (vela) exactly as its source
+// behaves today, so the account-level Active Workspace can be reasoned about
+// without a live backend:
+//
+//  - `active_workspace_selections` is keyed by app_user_id ALONE
+//    (db/schema/public.hcl:792 `primary_key { columns = [column.app_user_id] }`),
+//    so the account has exactly one selection — there is no client/device axis.
+//  - `GET /api/v1/workspaces/current` DISCARDS a `?workspaceId=` hint. The
+//    handler never reads the query (services/api/src/workspaces/routes.ts:166-176
+//    only sets workspaceId when team workspaces are DISABLED) and vela locks
+//    that in by name: test "ignores URL workspace hints when resolving
+//    server-owned current context" (services/api/test/workspaces-personal.test.ts:480).
+//  - `PUT /api/v1/workspaces/current` moves that single account-level row.
+//  - `GET /api/v1/workspaces` (the membership directory) is scoped by
+//    app_user_id, NOT by the selection (services/api/src/workspaces/routes.ts:460),
+//    so it answers the same for every client of the account.
+
+const TEAM = 'ws-team-1';
+const PERSONAL = 'ws-personal-1';
+
+const B_TEAM_CONTEXT = {
+  userId: 'auth-user-1',
+  appUserId: 'app-user-1',
+  workspaceId: TEAM,
+  workspaceName: 'Team',
+  workspaceType: 'team',
+  workspaceMemberId: 'wm-1',
+  role: 'member',
+  memberStatus: 'active',
+  lifecycleState: 'active',
+  billingState: 'active',
+  planId: 'team-pro',
+  providerMode: 'platform_credits',
+  seatSummary: { seatLimit: 5, usedSeats: 2, availableSeats: 3, isSeatFull: false },
+};
+
+const B_PERSONAL_CONTEXT = {
+  ...B_TEAM_CONTEXT,
+  workspaceId: PERSONAL,
+  workspaceName: 'Personal',
+  workspaceType: 'personal',
+  workspaceMemberId: 'wm-p1',
+  role: 'owner',
+  planId: 'personal-pro',
+};
+
+const DIRECTORY = {
+  items: [
+    {
+      workspaceId: TEAM,
+      workspaceName: 'Team',
+      workspaceType: 'team',
+      workspaceMemberId: 'wm-1',
+      role: 'member',
+      memberStatus: 'active',
+      lifecycleState: 'active',
+    },
+    {
+      workspaceId: PERSONAL,
+      workspaceName: 'Personal',
+      workspaceType: 'personal',
+      workspaceMemberId: 'wm-p1',
+      role: 'owner',
+      memberStatus: 'active',
+      lifecycleState: 'active',
+    },
+  ],
+};
+
+const SESSION = {
+  profile: 'prod',
+  apiUrl: 'https://vela.example',
+  controlKey: 'ck-1',
+  user: null,
+  configMtimeMs: null,
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+  return { ok: status >= 200 && status < 300, status, json: async () => body } as unknown as Response;
+}
+
+/** One vela account: one selection row, shared by every client that signs in. */
+function createOneAccountVela(initialSelection: string) {
+  const bodies: Record<string, unknown> = {
+    [TEAM]: B_TEAM_CONTEXT,
+    [PERSONAL]: B_PERSONAL_CONTEXT,
+  };
+  let selection = initialSelection;
+  let currentReads = 0;
+  let directoryReads = 0;
+
+  const fetchImpl = (async (url: URL | string, init?: RequestInit) => {
+    const u = String(url);
+    const method = init?.method ?? 'GET';
+    if (u.includes('/workspaces/current') && method === 'PUT') {
+      const body = JSON.parse(String(init?.body ?? '{}')) as { workspaceId?: string };
+      if (body.workspaceId) selection = body.workspaceId;
+      return jsonResponse(200, bodies[selection]);
+    }
+    if (u.includes('/workspaces/current') && method === 'GET') {
+      currentReads += 1;
+      // The `?workspaceId=` hint OD appends is dropped on the floor here,
+      // exactly as vela's handler drops it.
+      return jsonResponse(200, bodies[selection]);
+    }
+    if (u.endsWith('/api/v1/workspaces') && method === 'GET') {
+      directoryReads += 1;
+      return jsonResponse(200, DIRECTORY);
+    }
+    throw new Error(`unexpected fetch ${method} ${u}`);
+  }) as unknown as typeof fetch;
+
+  return {
+    fetchImpl,
+    selection: () => selection,
+    currentReads: () => currentReads,
+    directoryReads: () => directoryReads,
+  };
+}
+
+/** One OD daemon: its own local pin, sharing the account's vela session. */
+function createClient(vela: ReturnType<typeof createOneAccountVela>, pinned: string) {
+  let pin: string | null = pinned;
+  const provider = createVelaWorkspaceContextProvider({
+    fetch: vela.fetchImpl,
+    readSession: () => SESSION,
+    getActiveWorkspaceId: () => pin,
+    setLocalSelection: (id) => {
+      pin = id;
+    },
+    clearLocalSelection: () => {
+      pin = null;
+    },
+  });
+  return {
+    pin: () => pin,
+    context: () => provider.current({}),
+    /** What OD's PUT /api/workspace/active does: move B, then move the pin. */
+    async switchTo(workspaceId: string) {
+      const switched = await provider.selectWorkspace?.(workspaceId);
+      if (switched) pin = workspaceId;
+      return switched;
+    },
+  };
+}
+
+describe('one account, two clients, one account-level Active Workspace', () => {
+  it('does NOT hand a client the other client’s workspace — the local pin holds', async () => {
+    const vela = createOneAccountVela(TEAM);
+    const clientA = createClient(vela, TEAM);
+    const clientB = createClient(vela, PERSONAL);
+
+    // Client B switches. This moves the ONE account-level row.
+    expect(await clientB.switchTo(PERSONAL)).toBe(true);
+    expect(vela.selection()).toBe(PERSONAL);
+
+    // Client A reads its context next. B's `current` now answers PERSONAL for
+    // the whole account, but A must stay on its own pinned TEAM scope.
+    const a = await clientA.context();
+    expect(a?.workspaceId).toBe(TEAM);
+    expect(clientA.pin()).toBe(TEAM);
+  });
+
+  it('DOES degrade the losing client’s billing/seat context to a directory synthesis', async () => {
+    const vela = createOneAccountVela(TEAM);
+    const clientA = createClient(vela, TEAM);
+    const clientB = createClient(vela, PERSONAL);
+
+    // While the account-level row still points at A's workspace, A gets B's
+    // rich context: real plan id and real seat counts.
+    const enriched = await clientA.context();
+    expect(enriched?.planId).toBe('team-pro');
+    expect(enriched?.seatSummary).toEqual({
+      seatLimit: 5,
+      usedSeats: 2,
+      availableSeats: 3,
+      isSeatFull: false,
+    });
+    const directoryReadsWhileWinning = vela.directoryReads();
+
+    // Client B switches away. Nothing about A's workspace, membership, plan or
+    // seats changed — only which workspace the ACCOUNT row names.
+    await clientB.switchTo(PERSONAL);
+
+    const degraded = await clientA.context();
+    // Same workspace…
+    expect(degraded?.workspaceId).toBe(TEAM);
+    // …but the billing plane is gone, because B's `current` can only describe
+    // ONE workspace per account and OD must fall back to synthesizing A's
+    // context from the membership directory, which carries no billing data.
+    expect(degraded?.planId).toBeNull();
+    // Worse than merely blank: a 0/0 seat summary derives `isSeatFull: true`,
+    // so the losing client reads its own healthy 3-free-seat workspace as
+    // full. The seat gate is a client-side check (#115), which makes this a
+    // user-visible block on inviting, not just a cosmetic badge.
+    expect(degraded?.seatSummary).toEqual({
+      seatLimit: 0,
+      usedSeats: 0,
+      availableSeats: 0,
+      isSeatFull: true,
+    });
+    expect(enriched?.seatSummary.isSeatFull).toBe(false);
+    // And it costs an extra round-trip that the winning client never pays.
+    expect(vela.directoryReads()).toBeGreaterThan(directoryReadsWhileWinning);
+  });
+
+  it('makes the losing client’s context read depend on a second, fallible call', async () => {
+    // Same setup, but the directory read fails once — a blip that the winning
+    // client would never even notice, because it never makes that call.
+    const vela = createOneAccountVela(PERSONAL);
+    let failDirectory = false;
+    const fetchImpl = (async (url: URL | string, init?: RequestInit) => {
+      if (String(url).endsWith('/api/v1/workspaces') && failDirectory) {
+        throw new Error('directory blip');
+      }
+      return (vela.fetchImpl as unknown as typeof fetch)(url as never, init as never);
+    }) as unknown as typeof fetch;
+
+    const clientA = createClient({ ...vela, fetchImpl }, TEAM);
+
+    failDirectory = true;
+    // B's account row says PERSONAL, A is pinned to TEAM, so A can only resolve
+    // its own scope through the directory — and that call just failed.
+    expect(await clientA.context()).toBeNull();
+    // The pin survives (nothing was confirmed), but this client has NO context
+    // for a full poll tick purely because another client owns the account row.
+    expect(clientA.pin()).toBe(TEAM);
+
+    failDirectory = false;
+    expect((await clientA.context())?.workspaceId).toBe(TEAM);
+  });
+
+  it('lets each client yank the other’s server-side scope on every switch', async () => {
+    const vela = createOneAccountVela(TEAM);
+    const clientA = createClient(vela, TEAM);
+    const clientB = createClient(vela, PERSONAL);
+
+    await clientB.switchTo(PERSONAL);
+    expect(vela.selection()).toBe(PERSONAL);
+
+    // A switches back to its own workspace — a purely local UI action — and in
+    // doing so re-points the account row out from under client B. Whatever on
+    // the vela side still resolves a workspace from that row (rather than from
+    // an explicit parameter) is now aimed at A's workspace for BOTH clients.
+    await clientA.switchTo(TEAM);
+    expect(vela.selection()).toBe(TEAM);
+    expect(clientB.pin()).toBe(PERSONAL);
+  });
+});

--- a/apps/daemon/tests/collab/workspace-switch-warms-caches.test.ts
+++ b/apps/daemon/tests/collab/workspace-switch-warms-caches.test.ts
@@ -64,19 +64,17 @@ function contextFor(workspaceId: string): WorkspaceCollabContext {
 }
 
 /**
- * A switch harness with an in-memory active-workspace pin, so the rollback path
- * is exercised through the same store the route mutates rather than a stub that
- * cannot disagree with itself.
+ * A switch harness with an in-memory active-workspace pin, so the route is
+ * exercised through the same store it mutates rather than a stub that cannot
+ * disagree with itself. There is deliberately no backend-selection seam: the
+ * pin is the only thing a switch moves.
  */
 async function startSwitchServer(options: {
-  /** What the backend `selectWorkspace` answers. Default: accepts. */
-  selectWorkspace?: (workspaceId: string) => boolean;
   /** What the follow-up context read answers. Default: agrees with the pin. */
   currentContext?: (pinned: string | null) => WorkspaceCollabContext | null;
   initial?: string;
 }) {
   let pinned: string | null = options.initial ?? PERSONAL;
-  let backendWorkspace = options.initial ?? PERSONAL;
   const onWorkspaceSwitched = vi.fn<(workspaceId: string) => void>();
 
   const activeWorkspace: NonNullable<RegisterCollabContextRoutesDeps['activeWorkspace']> = {
@@ -91,20 +89,17 @@ async function startSwitchServer(options: {
 
   const app = express();
   app.use(express.json());
+  const workspaceContext = {
+    current: async () =>
+      options.currentContext
+        ? options.currentContext(pinned)
+        : pinned
+          ? contextFor(pinned)
+          : null,
+  };
   registerCollabContextRoutes(app, {
-    workspaceContext: {
-      current: async () =>
-        options.currentContext
-          ? options.currentContext(pinned)
-          : pinned
-            ? contextFor(pinned)
-            : null,
-      selectWorkspace: async (workspaceId: string) => {
-        const accepted = options.selectWorkspace ? options.selectWorkspace(workspaceId) : true;
-        if (accepted) backendWorkspace = workspaceId;
-        return accepted;
-      },
-    } as unknown as RegisterCollabContextRoutesDeps['workspaceContext'],
+    workspaceContext:
+      workspaceContext as unknown as RegisterCollabContextRoutesDeps['workspaceContext'],
     activeWorkspace,
     listWorkspaceDirectory: async () => [directoryItem(PERSONAL), directoryItem(TEAM)],
     onWorkspaceSwitched,
@@ -119,7 +114,8 @@ async function startSwitchServer(options: {
   return {
     onWorkspaceSwitched,
     pinnedWorkspace: () => pinned,
-    backendWorkspace: () => backendWorkspace,
+    /** Proof the route has no backend-selection seam left to call. */
+    hasBackendSelectionSeam: () => 'selectWorkspace' in workspaceContext,
     async switchTo(workspaceId: string) {
       const response = await fetch(`${base}/api/workspace/active`, {
         method: 'PUT',
@@ -147,29 +143,48 @@ describe('PUT /api/workspace/active announces a confirmed switch for cache warmi
     expect(api.onWorkspaceSwitched).toHaveBeenCalledWith(TEAM);
   });
 
-  it('stays silent when the backend rejects the switch', async () => {
-    const api = await startSwitchServer({ selectWorkspace: () => false });
+  // Choosing a workspace is a local decision authorized by the membership
+  // directory, so there is no backend selection to reject and nothing to roll
+  // back. This replaces the old 502 `workspace_switch_rejected` contract: that
+  // gate made a purely local action fail on an account-scoped backend write,
+  // and that write could only ever name ONE workspace per account.
+  it('does not depend on a backend workspace selection at all', async () => {
+    const api = await startSwitchServer({});
 
     const result = await api.switchTo(TEAM);
 
-    expect(result.status).toBe(502);
-    // Nothing moved, so warming here would refill the caches for a workspace
-    // this daemon is not operating in.
-    expect(api.onWorkspaceSwitched).not.toHaveBeenCalled();
+    expect(result.status).toBe(200);
+    expect(api.hasBackendSelectionSeam()).toBe(false);
   });
 
-  it('stays silent when the context read disagrees and the switch is rolled back', async () => {
-    // The backend accepted the move but the follow-up context read still
-    // answers for the old workspace, which is the route's rollback trigger.
-    const api = await startSwitchServer({
-      currentContext: () => contextFor(PERSONAL),
-    });
+  it('keeps the switch when the context read cannot confirm it, answering from the directory', async () => {
+    // An unreadable context is an unconfirmed READ, never evidence that the
+    // user's choice was wrong. Reverting here used to undo a switch the
+    // directory had already authorized, and the user saw their click do nothing.
+    const api = await startSwitchServer({ currentContext: () => null });
 
     const result = await api.switchTo(TEAM);
 
-    expect(result.status).toBe(404);
-    expect(api.pinnedWorkspace()).toBe(PERSONAL);
-    expect(api.onWorkspaceSwitched).not.toHaveBeenCalled();
+    expect(result.status).toBe(200);
+    expect(api.pinnedWorkspace()).toBe(TEAM);
+    expect(result.body.activeWorkspaceId).toBe(TEAM);
+    // Synthesized from the directory entry the route already validated, so the
+    // response still describes the workspace the user picked.
+    expect((result.body.context as { workspaceId?: string }).workspaceId).toBe(TEAM);
+    expect(api.onWorkspaceSwitched).toHaveBeenCalledWith(TEAM);
+  });
+
+  it('keeps the switch when the context read still describes the old workspace', async () => {
+    // A stale/lagging context read is likewise not a refusal. The pin is the
+    // truth; the web closes the billing plane out on its next context poll.
+    const api = await startSwitchServer({ currentContext: () => contextFor(PERSONAL) });
+
+    const result = await api.switchTo(TEAM);
+
+    expect(result.status).toBe(200);
+    expect(api.pinnedWorkspace()).toBe(TEAM);
+    expect((result.body.context as { workspaceId?: string }).workspaceId).toBe(TEAM);
+    expect(api.onWorkspaceSwitched).toHaveBeenCalledWith(TEAM);
   });
 
   it('stays silent for a workspace the directory does not show', async () => {

--- a/apps/daemon/tests/collab/workspace-switch-warms-caches.test.ts
+++ b/apps/daemon/tests/collab/workspace-switch-warms-caches.test.ts
@@ -10,6 +10,11 @@ import {
   registerCollabContextRoutes,
   type RegisterCollabContextRoutesDeps,
 } from '../../src/routes/collab-context.js';
+import {
+  createCachedWorkspaceDirectoryFetcher,
+  createVelaWorkspaceContextProvider,
+  fetchVelaWorkspaceDirectory,
+} from '../../src/collab/vela-workspace-context.js';
 
 // Every workspace-scoped cache in the daemon keys on the active workspace, so a
 // switch leaves all of them cold and the FIRST consumer in the new workspace
@@ -73,6 +78,8 @@ async function startSwitchServer(options: {
   /** What the follow-up context read answers. Default: agrees with the pin. */
   currentContext?: (pinned: string | null) => WorkspaceCollabContext | null;
   initial?: string;
+  /** What the membership directory lists. Default: both workspaces, live. */
+  directory?: WorkspaceDirectoryItem[];
 }) {
   let pinned: string | null = options.initial ?? PERSONAL;
   const onWorkspaceSwitched = vi.fn<(workspaceId: string) => void>();
@@ -101,7 +108,8 @@ async function startSwitchServer(options: {
     workspaceContext:
       workspaceContext as unknown as RegisterCollabContextRoutesDeps['workspaceContext'],
     activeWorkspace,
-    listWorkspaceDirectory: async () => [directoryItem(PERSONAL), directoryItem(TEAM)],
+    listWorkspaceDirectory: async () =>
+      options.directory ?? [directoryItem(PERSONAL), directoryItem(TEAM)],
     onWorkspaceSwitched,
   });
 
@@ -193,6 +201,193 @@ describe('PUT /api/workspace/active announces a confirmed switch for cache warmi
     const result = await api.switchTo('ws-not-mine');
 
     expect(result.status).toBe(404);
+    expect(api.onWorkspaceSwitched).not.toHaveBeenCalled();
+  });
+});
+
+// `workspaceContext.current()` is not a passive read, and that is the whole
+// hazard here. The REAL vela provider's `resolvePinnedWorkspace` does its own
+// FRESH directory lookup and, when that confirms the pinned workspace is gone,
+// clears the pin and re-pins a recovery workspace (so a removed member is not
+// locked out of everything). The route's own directory read can meanwhile be a
+// 5-second cached success that still lists the workspace.
+//
+// These cases wire the production provider against the production cached
+// directory fetcher, sharing ONE pin store exactly as `server.ts` does, so the
+// two reads genuinely disagree instead of a stub pretending they do.
+describe('PUT /api/workspace/active when the context read re-pins the workspace', () => {
+  const B_PERSONAL_CONTEXT = {
+    userId: 'auth-user-1',
+    appUserId: 'app-user-1',
+    workspaceId: PERSONAL,
+    workspaceName: "Ma Shu's workspace",
+    workspaceType: 'personal',
+    workspaceMemberId: `wm-${PERSONAL}`,
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+    billingState: 'active',
+    planId: 'personal-pro',
+    providerMode: 'platform_credits',
+    seatSummary: { seatLimit: 1, usedSeats: 1, availableSeats: 0, isSeatFull: true },
+  };
+
+  function velaDirectoryBody(items: WorkspaceDirectoryItem[]) {
+    return { items };
+  }
+
+  async function startRealProviderServer() {
+    let pinned: string | null = PERSONAL;
+    let directoryCalls = 0;
+    const onWorkspaceSwitched = vi.fn<(workspaceId: string) => void>();
+
+    // Shared pin store — the route writes it, the provider may re-write it.
+    const activeWorkspace: NonNullable<RegisterCollabContextRoutesDeps['activeWorkspace']> = {
+      get: () => pinned,
+      set: async (workspaceId: string) => {
+        pinned = workspaceId;
+      },
+      clear: async () => {
+        pinned = null;
+      },
+    };
+
+    const jsonResponse = (status: number, body: unknown): Response =>
+      ({ ok: status >= 200 && status < 300, status, json: async () => body }) as unknown as Response;
+
+    // Call 1 (the route's read, which gets cached) still lists TEAM.
+    // Call 2+ (the provider's fresh read) no longer does — membership is gone.
+    const fetchImpl = (async (url: URL | string, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? 'GET';
+      if (u.endsWith('/api/v1/workspaces') && method === 'GET') {
+        directoryCalls += 1;
+        return jsonResponse(
+          200,
+          velaDirectoryBody(
+            directoryCalls === 1
+              ? [directoryItem(PERSONAL), directoryItem(TEAM)]
+              : [directoryItem(PERSONAL)],
+          ),
+        );
+      }
+      if (u.includes('/workspaces/current') && method === 'GET') {
+        // TEAM is gone, so B refuses the explicitly scoped read. That is what
+        // sends the provider down `resolvePinnedWorkspace`.
+        const requested = (init?.headers as Record<string, string> | undefined)?.[
+          'x-vela-workspace-id'
+        ];
+        if (requested === TEAM) return jsonResponse(404, { error: 'workspace_member_required' });
+        return jsonResponse(200, B_PERSONAL_CONTEXT);
+      }
+      throw new Error(`unexpected fetch ${method} ${u}`);
+    }) as unknown as typeof fetch;
+
+    const session = {
+      profile: 'prod',
+      apiUrl: 'https://vela.example',
+      controlKey: 'ck-1',
+      user: null,
+      configMtimeMs: null,
+    };
+
+    const workspaceContext = createVelaWorkspaceContextProvider({
+      fetch: fetchImpl,
+      readSession: () => session as never,
+      getActiveWorkspaceId: () => activeWorkspace.get(),
+      setLocalSelection: (workspaceId: string) => activeWorkspace.set(workspaceId),
+      clearLocalSelection: () => activeWorkspace.clear(),
+    });
+
+    // The production cached fetcher: the route's read is served from cache for
+    // 5s, which is precisely how it can disagree with the provider's fresh one.
+    const cachedDirectory = createCachedWorkspaceDirectoryFetcher({
+      fetchDirectory: () => fetchVelaWorkspaceDirectory({ fetch: fetchImpl, readSession: () => session as never }),
+      identityKey: () => 'ck-1',
+    });
+
+    const app = express();
+    app.use(express.json());
+    registerCollabContextRoutes(app, {
+      workspaceContext,
+      activeWorkspace,
+      listWorkspaceDirectory: async () => (await cachedDirectory()).items,
+      onWorkspaceSwitched,
+    } as unknown as RegisterCollabContextRoutesDeps);
+
+    server = http.createServer(app);
+    await new Promise<void>((resolve) => server!.listen(0, resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('server did not bind');
+    const base = `http://127.0.0.1:${address.port}`;
+
+    return {
+      onWorkspaceSwitched,
+      pinnedWorkspace: () => pinned,
+      async switchTo(workspaceId: string) {
+        const response = await fetch(`${base}/api/workspace/active`, {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ workspaceId }),
+        });
+        return {
+          status: response.status,
+          body: (await response.json()) as Record<string, unknown>,
+        };
+      },
+    };
+  }
+
+  it('never claims a workspace the pin no longer holds', async () => {
+    const api = await startRealProviderServer();
+
+    const result = await api.switchTo(TEAM);
+
+    // The provider confirmed TEAM is gone and recovered to PERSONAL. Answering
+    // 200 for TEAM here would make the UI show the switch succeeding and then
+    // snap back on the next context poll — the response must not outrank the pin.
+    expect(api.pinnedWorkspace()).toBe(PERSONAL);
+    expect(result.status).toBe(404);
+    expect(result.body.error).toBe('workspace_no_longer_available');
+    expect(JSON.stringify(result.body)).not.toContain(TEAM);
+    // Nothing moved to TEAM, so warming its caches would be wrong.
+    expect(api.onWorkspaceSwitched).not.toHaveBeenCalled();
+  });
+
+  it("leaves the provider's recovery pin in place rather than reverting it", async () => {
+    const api = await startRealProviderServer();
+
+    await api.switchTo(TEAM);
+
+    // Restoring the pre-switch pin would undo the recovery that exists to stop a
+    // removed member being signed out of every workspace.
+    expect(api.pinnedWorkspace()).toBe(PERSONAL);
+  });
+});
+
+describe('PUT /api/workspace/active authorizes on a live membership', () => {
+  it('refuses a workspace the directory lists with a removed membership', async () => {
+    const api = await startSwitchServer({
+      directory: [directoryItem(PERSONAL), { ...directoryItem(TEAM), memberStatus: 'removed' }],
+    });
+
+    const result = await api.switchTo(TEAM);
+
+    expect(result.status).toBe(404);
+    expect(result.body.error).toBe('workspace_not_visible');
+    expect(api.pinnedWorkspace()).toBe(PERSONAL);
+    expect(api.onWorkspaceSwitched).not.toHaveBeenCalled();
+  });
+
+  it('refuses a workspace the directory lists as deleted', async () => {
+    const api = await startSwitchServer({
+      directory: [directoryItem(PERSONAL), { ...directoryItem(TEAM), lifecycleState: 'deleted' }],
+    });
+
+    const result = await api.switchTo(TEAM);
+
+    expect(result.status).toBe(404);
+    expect(result.body.error).toBe('workspace_not_visible');
     expect(api.onWorkspaceSwitched).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
> ## Dependency — satisfied
>
> This PR deletes OD's workaround for a vela limitation fixed by **[powerformer/vela#1179](https://github.com/powerformer/vela/pull/1179), merged as `1ba3eebcb`**, which taught `GET /api/v1/workspaces/current` to accept an explicit workspace on `x-vela-workspace-id`.
>
> `1ba3eebcb` is vela `main`'s head and **`Deploy API EKS Test` succeeded on it at 09:57Z**, so the parameter this PR relies on is live in the environment we validate against. That ordering mattered: landed before the deploy, this change would have degraded *every* client's context read to a directory synthesis (no plan id, `0/0` seats → reads as seats-full), because nothing would pin vela's account-level row any more while vela still ignored the per-request workspace.
>
> Verified against the deployed test backend rather than inferred from source — see **Live verification** below.

## Why

Picking a workspace in the sidebar is a local action, but `PUT /api/workspace/active` made it depend on mutating **account-scoped** state in vela:

```ts
if (workspaceContext.selectWorkspace) {
  const switched = await workspaceContext.selectWorkspace(workspaceId).catch(() => false);
  if (!switched) {
    return res.status(502).json({ error: 'workspace_switch_rejected' });
  }
}
```

That backend row is keyed by app user alone (`active_workspace_selections`, `primary_key { columns = [column.app_user_id] }`), so it can only ever name **one** workspace for an account. One account routinely has several clients open in different workspaces — that is how this feature is dogfooded. The consequences, all reproduced in this PR's tests:

- **Every switch yanked the other clients' server-side scope.** A purely local UI action in client A re-pointed the account row out from under client B.
- **The client that did not write the row last was answered for the wrong workspace,** so OD had to synthesize its context from the membership directory instead. That synthesis carries no billing plane: `planId: null` and a `0/0` seat summary — and a `0/0` summary derives `isSeatFull: true`, so a workspace with free seats read as **full**. The seat gate is a client-side check, so that was a user-visible block on inviting.
- **It made that client's context read depend on a second, fallible call.** The winning client makes one request; the losing client makes two, and a blip on the extra one left it with *no* context for a poll tick.
- **A local action could fail on a remote write.** On 502 / 404 the web does nothing at all — `switchWorkspace` in `EntryNavRail.tsx` returns early on `!response.ok` with no toast — so the user's click silently did nothing.

vela's own suite asserted the old shape by name (`ignores URL workspace hints when resolving server-owned current context`), so the `?workspaceId=` query param OD had been appending to the context read was dead weight: it made the call *look* scoped when it never was. #1179 added a real per-request scope on `x-vela-workspace-id`, the spelling vela already honoured on its resource plane, its billing scope routes and the Link gateway.

## The user-visible consequence, stated plainly

The degraded context is not cosmetic. `workspaceContextFromDirectoryItem` cannot know seat counts, so it emits `seatSummary` `0/0` — and `0/0` derives **`isSeatFull: true`**. So the client that did not write the account row last was told **"seats full" for a workspace with three free seats**.

That lands on a known weak spot: **the seat gate is client-side only** — the backend does not refuse an over-limit invite. So this misread is load-bearing in both directions: `isSeatFull: true` wrongly *blocks* an owner from inviting, and a wrong `false` would wrongly *permit* an invite nothing downstream rejects.

**Does this PR remove it? Only the common cause, not the derivation.** With the workspace travelling per request, the enriched context comes back for each client's own workspace, so the *multi-client* trigger — the routine, every-day one, guaranteed for any account with two clients open — is gone. But `0/0 → isSeatFull: true` still fires on every other degraded path: a vela `/current` outage while the directory still answers, the fresh-account bootstrap, and this route's own synthesis when a context read fails mid-switch. Making an *unknown* seat summary stop asserting "full" is a separate change (it touches `buildWorkspaceSeatSummary` semantics or the synthesizer's contract) and wants its own PR, especially given the gate has no backend backstop.

## What users will see

Switching workspaces just works, and keeps working with two clients signed into one account:

- Both clients show their own workspace with its real plan badge and real seat counts, instead of one of them dropping to a blank plan and a "seats full" invite button.
- Switching in one client no longer changes what the other client is scoped to.
- A switch to a workspace you're a member of no longer fails silently because a backend write or a follow-up read didn't take.

## What changed

**The workspace now travels per request.** `fetchCurrent` sends `x-vela-workspace-id: <local pin>` and no longer appends the ignored `?workspaceId=` query param.

**The local pin is the only selection truth.** `PUT /api/workspace/active` no longer calls vela at all:
- removed the `selectWorkspace` call and the `502 workspace_switch_rejected` gate,
- removed the rollback that undid *both* the local pin and the backend switch,
- removed `selectWorkspace` from `WorkspaceContextProvider` and its vela implementation (`putCurrentWorkspace` is gone with it).

**The membership directory is the authorization.** The route already reads the directory and refuses a workspace it doesn't list (`404 workspace_not_visible`); that check is unchanged and is what makes the switch safe without a backend round-trip. Once the directory confirms an active membership, a switch cannot fail.

**An unconfirmed read is no longer treated as a refusal.** If the follow-up context read fails or still describes the old workspace, the route answers from the directory entry it already validated instead of reverting the user's choice. This mirrors the invariant `resolvePinnedWorkspace` already follows in the same module ("B unreachable — preserve the pin, confirm nothing"). The billing plane on that synthesis is thinner; the web closes it out on its next context poll.

**Stale comments corrected**, both of which asserted the now-false invariant:
- the `selectWorkspace` docblock in `collab/workspace-context.ts` claiming `GET /workspaces/current` ignores per-request workspace hints (removed with the method),
- the `// B moved workspace selection server-side (2026-07-16)` block at the call site.

**Deliberately NOT changed:** vela's `active_workspace_selections` table and its write path. Deprecating it is a separate product decision, and #1179 kept omitting the header fully backward compatible, so shipped OD clients that send nothing keep working.

## Tests

`apps/daemon/tests/collab/workspace-multi-client-scope.test.ts` (new) models vela from its source — one account-level row keyed by app user, a directory scoped by app user, and `GET /current` either honouring `x-vela-workspace-id` or not — and drives two independent clients over one account:

| Suite | Asserts |
|---|---|
| against a B that only knows an account-level workspace | each client holds its own pin; the losing client degrades to `planId: null` + `0/0` seats → `isSeatFull: true`; that client has **no** context at all when the extra directory call blips |
| against a B that honours a per-request workspace | **both** clients get their own workspace fully enriched, with zero directory synthesis; the account row is **never written** (regression guard against reintroducing the yank) |

`apps/daemon/tests/collab/workspace-switch-warms-caches.test.ts` — the two cases that encoded the removed contract are replaced:

| Was | Now |
|---|---|
| `stays silent when the backend rejects the switch` (502) | `does not depend on a backend workspace selection at all` — 200, and the provider has no `selectWorkspace` seam |
| `stays silent when the context read disagrees and the switch is rolled back` (404) | `keeps the switch when the context read cannot confirm it` and `…when the context read still describes the old workspace` — 200, pin moved, context answered from the directory, cache warming still announced |

The existing "announces exactly once" and "workspace the directory does not show" cases are untouched and still green — the directory refusal is still the gate.

**Review fix — the route must never outrank the pin.** `mrcfps` caught that `workspaceContext.current()` is not a passive read: the provider's `resolvePinnedWorkspace` does its own **fresh** directory lookup and, on a confirmed removal, clears the pin and re-pins a recovery workspace, while this route's directory read may still be the 5-second cached success that lists the workspace. The earlier branch state read that as a merely-unconfirmed context and returned `200` naming the requested workspace while the pin had already become the fallback — shipping this PR's own thesis as a violable invariant, with the switch appearing to succeed and then snapping back on the next poll.

Fixed by re-reading `deps.activeWorkspace.get()` **after** `current()` resolves: if the provider moved it, the route returns `404 workspace_no_longer_available`, never names the requested workspace, and does not warm its caches — and it leaves the recovery pin alone, because reverting it would restore the "signed out of every workspace" state that recovery exists to prevent. The authorizing directory entry now also has to be a **live** membership (`memberStatus === 'active'`, lifecycle not `deleted`), since that same entry is what gets synthesized into the response.

Its regression tests use the shape of his repro rather than a synthetic proxy: the **real** `createVelaWorkspaceContextProvider` against the **real** `createCachedWorkspaceDirectoryFetcher`, sharing one pin store exactly as `server.ts:2980-2985` wires it, so the cached and fresh directory reads genuinely disagree. Verified sensitive by mutation — disabling the pin re-read turns `never claims a workspace the pin no longer holds` red and nothing else:

```
× never claims a workspace the pin no longer holds
Tests  1 failed | 8 passed (9)
```

All collab suites green after the fix: **46 files, 667 tests**.

Validation: `pnpm guard`, `pnpm --filter @open-design/daemon typecheck`, `pnpm --filter @open-design/web typecheck`, and the daemon suite. Note for reviewers running locally in a fresh worktree: `better-sqlite3` must be rebuilt under Node 24 (`pnpm rebuild -r better-sqlite3`) or ~790 unrelated tests fail on an ABI mismatch.

## Live verification (deployed `test` backend, `vela-api.powerformer.net`)

Source reasoning is what got the ordering of this work wrong earlier, so the premise was checked with real calls against the environment running `1ba3eebcb`. Read-only — GETs only, no `PUT`, so no selection was mutated. The signed-in account holds two active team memberships; its account-level row points at `i9rpv…`.

| Request | Result |
|---|---|
| no header | `i9rpv…` (the account-level row), plan `team_max` — **baseline unchanged** |
| `x-vela-workspace-id: br451…` (the *other* workspace) | **200, `br451…`** — an explicit workspace genuinely overrides the account row |
| `x-vela-workspace-id: i9rpv…` | 200, `i9rpv…`, plan `team_max` |
| `x-vela-workspace-id: ws-not-mine-000000000000` | **404 `workspace_member_required`** — authorization enforced, not just plumbed |
| blank/whitespace header | `i9rpv…` — identical to sending nothing |
| `?workspaceId=br451…` (query hint) | `i9rpv…` — **still ignored**, confirming the query param this PR removes was always dead weight |

The second and last rows are the two that matter: the header reaches a *different* workspace than the account row, and the URL hint never did.

## Surface area

- [x] `apps/daemon` — `routes/collab-context.ts`, `collab/vela-workspace-context.ts`, `collab/workspace-context.ts`
- [x] Tests — `apps/daemon/tests/collab/`
- [ ] UI — no web change; `EntryNavRail.switchWorkspace` already only acts on a successful response, and it now gets one.
- [ ] CLI — `od` has no workspace-switch subcommand today, so there is no second surface to mirror. The capability is unchanged, not newly added: this PR removes a failure mode from an existing endpoint rather than adding a capability. Flagging explicitly rather than silently skipping the dual-track rule.
- [ ] Contracts — `WorkspaceActiveResponse` is unchanged (`context` is still non-nullable, which is why an unconfirmed read is answered from the directory rather than with `null`).

## Adjacent issues (not fixed here)

- **`packages/contracts/src/api/collab.ts`** describes `PUT /api/workspace/active` as "Selects OD's local active workspace" — which only becomes true with this PR. Left as-is because it now matches.
- **vela's remaining implicit readers of the account row, ranked by whether a normal user reaches them.** Both are vela-side and out of scope here.

  1. **`evaluateWorkspaceMemberAutoRecharge` (`services/api/src/workspaces/core.ts:3576-3588`) — low reachability, high severity.** It reads `getWorkspaceContext({ appUserId: target.member.appUserId })` with *no* workspace and then throws `workspace_forbidden` "Automatic recharge must use the server Active Workspace" unless that row names the charging workspace and member. Note it reads the **target member's** row, not the actor's — so a member's own client-side workspace choice can fail an owner-initiated top-up. Reaching it needs member-level sponsorship configured *and* a top-up evaluation moment *and* that member's row pointing elsewhere, so it is not on a plain single-client path; a multi-client member supplies the precondition. It fails a **payment** path, which is why it still deserves a fix. The two `/current/auto-recharge-confirmation` routes are the same family: they read the stored row and no workspace parameter exists anywhere up their chain.

  2. **`createWorkspace` / `completeInviteAccept` — correcting an earlier claim of mine: they do NOT re-point the row.** I previously reported these as silently yanking other clients, which would have put the damage squarely inside the "create a team" and "accept an invite" acceptance journeys. Verified against `core.ts:1355-1360` and `core.ts:2297-2302`: when the postgres repository is in play they pass `workspaceId: undefined`, i.e. they **read** the stored row rather than writing it. **Creating a workspace or accepting an invite does not yank other clients.** The only implicit *write* to that row is the fresh-account bootstrap inside `getWorkspaceContext` (`postgres.ts:422-434`), which fires only when the account has no row at all. The residual wrinkle is cosmetic: the create/accept response describes the account row's workspace rather than the workspace just created or joined. **No follow-up needed on the yank grounds.**
- **`vela agent claude` forwards no workspace header** (only the opencode runtime does), so an AMR run on that runtime attributes spend to the account's default workspace. Separate finding, vela-side.
- `x-od-workspace-write-enabled` is read as a legacy fallback in two places but nothing sets it — dead input path, untouched.

This PR does **not** touch `collab/workspace-resource-mutation.ts` or the mutation gate, so it should not collide with the concurrent `WORKSPACE_CONTEXT_REQUIRED` investigation.
