### PR TITLE
feat(contracts): add stable DTCG 2025.10 codec

### DIFF
--- a/packages/contracts/esbuild.config.mjs
+++ b/packages/contracts/esbuild.config.mjs
@@ -17,6 +17,7 @@ await build({
     "./src/runtime/deck-stage-fallback.ts",
     "./src/design-systems/components-manifest.ts",
     "./src/design-systems/derived-token-outputs.ts",
+    "./src/design-systems/dtcg-2025-10.ts",
     "./src/design-systems/token-schema.ts",
     "./src/analytics/index.ts",
   ],

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -58,6 +58,10 @@
       "types": "./dist/design-systems/derived-token-outputs.d.ts",
       "default": "./dist/design-systems/derived-token-outputs.mjs"
     },
+    "./design-systems/dtcg-2025-10": {
+      "types": "./dist/design-systems/dtcg-2025-10.d.ts",
+      "default": "./dist/design-systems/dtcg-2025-10.mjs"
+    },
     "./design-systems/token-schema": {
       "types": "./dist/design-systems/token-schema.d.ts",
       "default": "./dist/design-systems/token-schema.mjs"
@@ -81,6 +85,7 @@
     "zod": "3.25.76"
   },
   "devDependencies": {
+    "ajv": "8.20.0",
     "esbuild": "0.28.0",
     "typescript": "5.9.3",
     "vitest": "4.1.6"

--- a/packages/contracts/src/design-systems/dtcg-2025-10.ts
+++ b/packages/contracts/src/design-systems/dtcg-2025-10.ts
@@ -38,6 +38,7 @@ export type DtcgDiagnosticCode =
   | 'missing-reference'
   | 'missing-type'
   | 'non-normative-schema-property'
+  | 'profile-mismatch'
   | 'reference-type-mismatch'
   | 'schema-divergence'
   | 'unknown-reserved-property';
@@ -349,6 +350,14 @@ function validateGroupStructure(
       if (root && name === '$schema') {
         if (typeof value !== 'string') {
           addDiagnostic(diagnostics, 'error', 'invalid-metadata', [...path, name], '$schema must be a string.');
+        } else if (value !== DTCG_FORMAT_SCHEMA_URL) {
+          addDiagnostic(
+            diagnostics,
+            'error',
+            'profile-mismatch',
+            [...path, name],
+            `Document carries $schema ${value}, which does not identify the stable DTCG 2025.10 Format profile.`,
+          );
         } else {
           addDiagnostic(
             diagnostics,
@@ -1146,9 +1155,18 @@ function validateUnitObject(
 
 function validateFontFamily(value: DtcgJsonValue, path: string[], diagnostics: DtcgDiagnostic[]): boolean {
   if (typeof value === 'string') return true;
-  if (!Array.isArray(value) || value.length === 0 || value.some((family) => typeof family !== 'string')) {
-    invalidValue(diagnostics, path, 'fontFamily must be a string or a non-empty array of strings.');
+  if (!Array.isArray(value) || value.some((family) => typeof family !== 'string')) {
+    invalidValue(diagnostics, path, 'fontFamily must be a string or an array of strings.');
     return false;
+  }
+  if (value.length === 0) {
+    addDiagnostic(
+      diagnostics,
+      'warning',
+      'schema-divergence',
+      path,
+      'The normative report permits an empty fontFamily array, but the official schema requires at least one item.',
+    );
   }
   return true;
 }

--- a/packages/contracts/src/design-systems/dtcg-2025-10.ts
+++ b/packages/contracts/src/design-systems/dtcg-2025-10.ts
@@ -1,0 +1,1506 @@
+export const DTCG_FORMAT_VERSION = '2025.10' as const;
+export const DTCG_FORMAT_SCHEMA_URL = 'https://www.designtokens.org/schemas/2025.10/format.json' as const;
+
+export const DTCG_TOKEN_TYPES = [
+  'color',
+  'dimension',
+  'fontFamily',
+  'fontWeight',
+  'duration',
+  'cubicBezier',
+  'number',
+  'strokeStyle',
+  'border',
+  'transition',
+  'shadow',
+  'gradient',
+  'typography',
+] as const;
+
+export type DtcgTokenType = (typeof DTCG_TOKEN_TYPES)[number];
+export type DtcgDeprecated = boolean | string;
+export type DtcgJsonPrimitive = string | number | boolean | null;
+export type DtcgJsonValue = DtcgJsonPrimitive | DtcgJsonValue[] | { [key: string]: DtcgJsonValue };
+export type DtcgFormatDocument = { [key: string]: DtcgJsonValue };
+
+export type DtcgDiagnosticCode =
+  | 'circular-reference'
+  | 'invalid-document'
+  | 'invalid-extension'
+  | 'invalid-group'
+  | 'invalid-json-pointer'
+  | 'invalid-metadata'
+  | 'invalid-name'
+  | 'invalid-reference'
+  | 'invalid-token'
+  | 'invalid-type'
+  | 'invalid-value'
+  | 'missing-reference'
+  | 'missing-type'
+  | 'non-normative-schema-property'
+  | 'reference-type-mismatch'
+  | 'schema-divergence'
+  | 'unknown-reserved-property';
+
+export type DtcgDiagnostic = {
+  severity: 'error' | 'warning';
+  code: DtcgDiagnosticCode;
+  path: string;
+  message: string;
+};
+
+export type DtcgResolvedToken = {
+  path: readonly string[];
+  pointer: string;
+  sourcePointer: string;
+  type: DtcgTokenType;
+  value: DtcgJsonValue;
+  source: Readonly<Record<string, DtcgJsonValue>>;
+  deprecated?: DtcgDeprecated;
+};
+
+export type DtcgFormatParseResult =
+  | {
+      ok: true;
+      document: DtcgFormatDocument;
+      tokens: readonly DtcgResolvedToken[];
+      diagnostics: readonly DtcgDiagnostic[];
+    }
+  | {
+      ok: false;
+      diagnostics: readonly DtcgDiagnostic[];
+    };
+
+export type SerializeDtcgFormatOptions = {
+  includeSchemaMetadata?: boolean;
+  space?: number;
+  trailingNewline?: boolean;
+};
+
+type JsonRecord = Record<string, DtcgJsonValue>;
+
+type TokenEntry = {
+  path: string[];
+  node: JsonRecord;
+  sourcePath: string[];
+  sourceNode: JsonRecord;
+  inheritedType: DtcgTokenType | undefined;
+  inheritedDeprecated: DtcgDeprecated | undefined;
+};
+
+type ResolvedTokenInternal = DtcgResolvedToken & {
+  path: readonly string[];
+};
+
+const TOKEN_TYPE_SET = new Set<string>(DTCG_TOKEN_TYPES);
+const TOKEN_PROPERTIES = new Set(['$value', '$ref', '$type', '$description', '$extensions', '$deprecated']);
+const GROUP_PROPERTIES = new Set(['$description', '$type', '$extends', '$extensions', '$deprecated', '$root']);
+const FONT_WEIGHT_KEYWORDS = new Set([
+  'thin',
+  'hairline',
+  'extra-light',
+  'ultra-light',
+  'light',
+  'normal',
+  'regular',
+  'book',
+  'medium',
+  'semi-bold',
+  'demi-bold',
+  'bold',
+  'extra-bold',
+  'ultra-bold',
+  'black',
+  'heavy',
+  'extra-black',
+  'ultra-black',
+]);
+const STROKE_STYLE_KEYWORDS = new Set([
+  'solid',
+  'dashed',
+  'dotted',
+  'double',
+  'groove',
+  'ridge',
+  'outset',
+  'inset',
+]);
+const COLOR_SPACES = new Set([
+  'srgb',
+  'srgb-linear',
+  'hsl',
+  'hwb',
+  'lab',
+  'lch',
+  'oklab',
+  'oklch',
+  'display-p3',
+  'a98-rgb',
+  'prophoto-rgb',
+  'rec2020',
+  'xyz-d65',
+  'xyz-d50',
+]);
+
+/**
+ * Parses, validates, and resolves one stable DTCG Format 2025.10 document.
+ * The returned document preserves source references and extensions; resolved
+ * token values are exposed separately through `tokens`.
+ */
+export function parseDtcgFormat2025_10(input: unknown): DtcgFormatParseResult {
+  const diagnostics: DtcgDiagnostic[] = [];
+  validateJsonValue(input, [], diagnostics, new Set<object>());
+  if (hasErrors(diagnostics) || !isRecord(input)) {
+    if (!isRecord(input)) {
+      addDiagnostic(diagnostics, 'error', 'invalid-document', [], 'A DTCG document must be a JSON object.');
+    }
+    return { ok: false, diagnostics: uniqueDiagnostics(diagnostics) };
+  }
+
+  const document = cloneJson(input) as DtcgFormatDocument;
+  validateGroupStructure(document, [], diagnostics, true);
+  if (hasErrors(diagnostics)) return { ok: false, diagnostics: uniqueDiagnostics(diagnostics) };
+
+  const materialized = materializeGroup(document, [], document, diagnostics, new Set<string>());
+  if (materialized === undefined || hasErrors(diagnostics)) {
+    return { ok: false, diagnostics: uniqueDiagnostics(diagnostics) };
+  }
+
+  const entries: TokenEntry[] = [];
+  collectTokenEntries(materialized, [], undefined, undefined, document, entries);
+  const entryByPath = new Map(entries.map((entry) => [pathKey(entry.path), entry]));
+  const resolvedByPath = new Map<string, ResolvedTokenInternal>();
+  const activeTokens: string[] = [];
+
+  const resolveToken = (entry: TokenEntry): ResolvedTokenInternal | undefined => {
+    const key = pathKey(entry.path);
+    const cached = resolvedByPath.get(key);
+    if (cached !== undefined) return cached;
+    const cycleIndex = activeTokens.indexOf(key);
+    if (cycleIndex !== -1) {
+      const cycle = [...activeTokens.slice(cycleIndex), key]
+        .map((cycleKey) => pointerFromPath(JSON.parse(cycleKey) as string[]))
+        .join(' -> ');
+      addDiagnostic(diagnostics, 'error', 'circular-reference', entry.path, `Circular token reference: ${cycle}.`);
+      return undefined;
+    }
+
+    activeTokens.push(key);
+    const explicitType = readTokenType(entry.node.$type);
+    const targetEntry = wholeTokenReferenceTarget(entry.node, materialized, entryByPath, diagnostics, entry.path);
+    const targetToken = targetEntry === undefined ? undefined : resolveToken(targetEntry);
+    let effectiveType = explicitType ?? targetToken?.type ?? entry.inheritedType;
+
+    if (explicitType !== undefined && targetToken !== undefined && explicitType !== targetToken.type) {
+      addDiagnostic(
+        diagnostics,
+        'error',
+        'reference-type-mismatch',
+        [...entry.path, entry.node.$ref === undefined ? '$value' : '$ref'],
+        `Token type ${explicitType} does not match referenced token type ${targetToken.type}.`,
+      );
+    }
+    if (effectiveType === undefined) {
+      addDiagnostic(
+        diagnostics,
+        'error',
+        'missing-type',
+        entry.path,
+        'Token type cannot be determined from $type, a referenced token, or a parent group.',
+      );
+      activeTokens.pop();
+      return undefined;
+    }
+
+    let value: DtcgJsonValue | undefined;
+    if (targetToken !== undefined && isWholeTokenReference(entry.node)) {
+      value = cloneJson(targetToken.value);
+    } else if ('$ref' in entry.node) {
+      const ref = entry.node.$ref;
+      if (typeof ref === 'string') {
+        value = resolveJsonPointerValue(
+          ref,
+          materialized,
+          entryByPath,
+          resolveToken,
+          diagnostics,
+          [...entry.path, '$ref'],
+          new Set<string>(),
+        );
+      }
+    } else {
+      validateNestedReferenceTypes(
+        effectiveType,
+        entry.node.$value,
+        entryByPath,
+        resolveToken,
+        diagnostics,
+        [...entry.path, '$value'],
+      );
+      value = resolveNestedReferences(
+        entry.node.$value,
+        materialized,
+        entryByPath,
+        resolveToken,
+        diagnostics,
+        [...entry.path, '$value'],
+        new Set<string>(),
+        effectiveType === 'gradient' || effectiveType === 'shadow' ? effectiveType : undefined,
+      );
+    }
+
+    if (value !== undefined) {
+      value = validateAndNormalizeTypeValue(effectiveType, value, [...entry.path, '$value'], diagnostics);
+    }
+    if (value === undefined || hasErrorsForPath(diagnostics, entry.path)) {
+      activeTokens.pop();
+      return undefined;
+    }
+
+    const deprecated = readDeprecated(entry.node.$deprecated) ?? entry.inheritedDeprecated;
+    const resolved: ResolvedTokenInternal = {
+      path: [...entry.path],
+      pointer: pointerFromPath(entry.path),
+      sourcePointer: pointerFromPath(entry.sourcePath),
+      type: effectiveType,
+      value,
+      source: entry.sourceNode,
+      ...(deprecated === undefined ? {} : { deprecated }),
+    };
+    resolvedByPath.set(key, resolved);
+    activeTokens.pop();
+    return resolved;
+  };
+
+  for (const entry of entries) resolveToken(entry);
+  const finalDiagnostics = uniqueDiagnostics(diagnostics);
+  if (hasErrors(finalDiagnostics)) return { ok: false, diagnostics: finalDiagnostics };
+
+  const tokens = entries
+    .map((entry) => resolvedByPath.get(pathKey(entry.path)))
+    .filter((token): token is ResolvedTokenInternal => token !== undefined);
+  return { ok: true, document, tokens, diagnostics: finalDiagnostics };
+}
+
+export function serializeDtcgFormat2025_10(
+  document: DtcgFormatDocument,
+  options: SerializeDtcgFormatOptions = {},
+): string {
+  const parsed = parseDtcgFormat2025_10(document);
+  if (!parsed.ok) {
+    const summary = parsed.diagnostics
+      .filter((diagnostic) => diagnostic.severity === 'error')
+      .map((diagnostic) => `${diagnostic.path}: ${diagnostic.message}`)
+      .join('\n');
+    throw new TypeError(`Cannot serialize an invalid DTCG 2025.10 document.\n${summary}`);
+  }
+  const output = cloneJson(parsed.document);
+  if (options.includeSchemaMetadata === true) output.$schema = DTCG_FORMAT_SCHEMA_URL;
+  else delete output.$schema;
+  const space = options.space ?? 2;
+  const serialized = JSON.stringify(sortJson(output), null, space);
+  return options.trailingNewline === false ? serialized : `${serialized}\n`;
+}
+
+function validateJsonValue(
+  value: unknown,
+  path: string[],
+  diagnostics: DtcgDiagnostic[],
+  active: Set<object>,
+): void {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      addDiagnostic(diagnostics, 'error', 'invalid-document', path, 'JSON numbers must be finite.');
+    }
+    return;
+  }
+  if (typeof value !== 'object') {
+    addDiagnostic(diagnostics, 'error', 'invalid-document', path, 'Value is not JSON-serializable.');
+    return;
+  }
+  if (active.has(value)) {
+    addDiagnostic(diagnostics, 'error', 'invalid-document', path, 'JSON input must not contain object cycles.');
+    return;
+  }
+  if (!Array.isArray(value) && !isRecord(value)) {
+    addDiagnostic(diagnostics, 'error', 'invalid-document', path, 'JSON objects must use a plain object prototype.');
+    return;
+  }
+  active.add(value);
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => validateJsonValue(item, [...path, String(index)], diagnostics, active));
+  } else {
+    for (const [key, item] of Object.entries(value)) {
+      validateJsonValue(item, [...path, key], diagnostics, active);
+    }
+  }
+  active.delete(value);
+}
+
+function validateGroupStructure(
+  group: JsonRecord,
+  path: string[],
+  diagnostics: DtcgDiagnostic[],
+  root: boolean,
+): void {
+  for (const [name, value] of Object.entries(group)) {
+    if (name.startsWith('$')) {
+      if (root && name === '$schema') {
+        if (typeof value !== 'string') {
+          addDiagnostic(diagnostics, 'error', 'invalid-metadata', [...path, name], '$schema must be a string.');
+        } else {
+          addDiagnostic(
+            diagnostics,
+            'warning',
+            'non-normative-schema-property',
+            [...path, name],
+            '$schema is schema metadata, not a normative DTCG Format property.',
+          );
+        }
+        continue;
+      }
+      if (!GROUP_PROPERTIES.has(name)) {
+        addDiagnostic(
+          diagnostics,
+          'error',
+          'unknown-reserved-property',
+          [...path, name],
+          `Unknown reserved group property ${name}.`,
+        );
+        continue;
+      }
+      validateGroupProperty(name, value, path, diagnostics);
+      if (name === '$root' && isRecord(value)) validateTokenStructure(value, [...path, '$root'], diagnostics);
+      continue;
+    }
+
+    validateName(name, [...path, name], diagnostics);
+    if (!isRecord(value)) {
+      addDiagnostic(
+        diagnostics,
+        'error',
+        'invalid-group',
+        [...path, name],
+        'Every token or group member must be a JSON object.',
+      );
+      continue;
+    }
+    if (isTokenNode(value)) validateTokenStructure(value, [...path, name], diagnostics);
+    else validateGroupStructure(value, [...path, name], diagnostics, false);
+  }
+}
+
+function validateTokenStructure(token: JsonRecord, path: string[], diagnostics: DtcgDiagnostic[]): void {
+  const hasValue = Object.prototype.hasOwnProperty.call(token, '$value');
+  const hasRef = Object.prototype.hasOwnProperty.call(token, '$ref');
+  if (hasValue === hasRef) {
+    addDiagnostic(
+      diagnostics,
+      'error',
+      'invalid-token',
+      path,
+      'A token must define exactly one of $value or token-level $ref.',
+    );
+  }
+  for (const [name, value] of Object.entries(token)) {
+    if (!name.startsWith('$')) {
+      addDiagnostic(
+        diagnostics,
+        'error',
+        'invalid-token',
+        [...path, name],
+        'A token cannot also contain child tokens or groups.',
+      );
+      continue;
+    }
+    if (!TOKEN_PROPERTIES.has(name)) {
+      addDiagnostic(
+        diagnostics,
+        'error',
+        'unknown-reserved-property',
+        [...path, name],
+        `Unknown reserved token property ${name}.`,
+      );
+      continue;
+    }
+    validateTokenProperty(name, value, path, diagnostics);
+  }
+}
+
+function validateGroupProperty(
+  name: string,
+  value: DtcgJsonValue,
+  path: string[],
+  diagnostics: DtcgDiagnostic[],
+): void {
+  switch (name) {
+    case '$description':
+      if (typeof value !== 'string') invalidMetadata(diagnostics, [...path, name], '$description must be a string.');
+      break;
+    case '$type':
+      validateTypeName(value, [...path, name], diagnostics);
+      break;
+    case '$extends':
+      if (typeof value !== 'string' || (!isCurlyReference(value) && !isJsonPointer(value))) {
+        addDiagnostic(
+          diagnostics,
+          'error',
+          'invalid-reference',
+          [...path, name],
+          '$extends must be a curly-brace group reference or JSON Pointer.',
+        );
+      }
+      break;
+    case '$extensions':
+      if (!isRecord(value)) {
+        addDiagnostic(diagnostics, 'error', 'invalid-extension', [...path, name], '$extensions must be an object.');
+      }
+      break;
+    case '$deprecated':
+      if (typeof value !== 'boolean' && typeof value !== 'string') {
+        invalidMetadata(diagnostics, [...path, name], '$deprecated must be a boolean or string.');
+      }
+      break;
+    case '$root':
+      if (!isRecord(value)) {
+        addDiagnostic(diagnostics, 'error', 'invalid-token', [...path, name], '$root must contain a token object.');
+      }
+      break;
+  }
+}
+
+function validateTokenProperty(
+  name: string,
+  value: DtcgJsonValue,
+  path: string[],
+  diagnostics: DtcgDiagnostic[],
+): void {
+  switch (name) {
+    case '$type':
+      validateTypeName(value, [...path, name], diagnostics);
+      break;
+    case '$description':
+      if (typeof value !== 'string') invalidMetadata(diagnostics, [...path, name], '$description must be a string.');
+      break;
+    case '$extensions':
+      if (!isRecord(value)) {
+        addDiagnostic(diagnostics, 'error', 'invalid-extension', [...path, name], '$extensions must be an object.');
+      }
+      break;
+    case '$deprecated':
+      if (typeof value !== 'boolean' && typeof value !== 'string') {
+        invalidMetadata(diagnostics, [...path, name], '$deprecated must be a boolean or string.');
+      }
+      break;
+    case '$ref':
+      if (typeof value !== 'string' || !isJsonPointer(value)) {
+        addDiagnostic(
+          diagnostics,
+          'error',
+          'invalid-json-pointer',
+          [...path, name],
+          'Token-level $ref must be an RFC 6901 URI-fragment JSON Pointer.',
+        );
+      }
+      break;
+  }
+}
+
+function validateTypeName(value: DtcgJsonValue, path: string[], diagnostics: DtcgDiagnostic[]): void {
+  if (typeof value !== 'string' || !TOKEN_TYPE_SET.has(value)) {
+    addDiagnostic(
+      diagnostics,
+      'error',
+      'invalid-type',
+      path,
+      `$type must be one of: ${DTCG_TOKEN_TYPES.join(', ')}.`,
+    );
+  }
+}
+
+function validateName(name: string, path: string[], diagnostics: DtcgDiagnostic[]): void {
+  if (name.startsWith('$') || /[{}.]/.test(name)) {
+    addDiagnostic(
+      diagnostics,
+      'error',
+      'invalid-name',
+      path,
+      'Token and group names must not start with $ or contain {, }, or periods.',
+    );
+  }
+  if (name.length === 0) {
+    addDiagnostic(
+      diagnostics,
+      'warning',
+      'schema-divergence',
+      path,
+      'The normative report does not forbid an empty name, but the official schema does.',
+    );
+  }
+}
+
+function materializeGroup(
+  group: JsonRecord,
+  path: string[],
+  document: JsonRecord,
+  diagnostics: DtcgDiagnostic[],
+  active: Set<string>,
+): JsonRecord | undefined {
+  const key = pathKey(path);
+  if (active.has(key)) {
+    addDiagnostic(diagnostics, 'error', 'circular-reference', path, 'Circular $extends chain detected.');
+    return undefined;
+  }
+  active.add(key);
+
+  const local = withoutKey(group, '$extends');
+  for (const [name, child] of Object.entries(local)) {
+    if (name.startsWith('$') || !isRecord(child) || isTokenNode(child)) continue;
+    const materializedChild = materializeGroup(child, [...path, name], document, diagnostics, active);
+    if (materializedChild !== undefined) local[name] = materializedChild;
+  }
+
+  let output = local;
+  if (typeof group.$extends === 'string') {
+    const target = resolveGroupReference(group.$extends, document, diagnostics, [...path, '$extends']);
+    if (target !== undefined) {
+      const targetMaterialized = materializeGroup(target.node, target.path, document, diagnostics, active);
+      if (targetMaterialized !== undefined) output = mergeGroups(targetMaterialized, local);
+    }
+  }
+  active.delete(key);
+  return output;
+}
+
+function resolveGroupReference(
+  reference: string,
+  document: JsonRecord,
+  diagnostics: DtcgDiagnostic[],
+  diagnosticPath: string[],
+): { node: JsonRecord; path: string[] } | undefined {
+  let segments: string[] | undefined;
+  if (isCurlyReference(reference)) segments = parseCurlyReference(reference);
+  else segments = parseJsonPointer(reference, diagnostics, diagnosticPath);
+  if (segments === undefined) return undefined;
+  const target = valueAtPath(document, segments);
+  if (!isRecord(target)) {
+    addDiagnostic(diagnostics, 'error', 'missing-reference', diagnosticPath, `Group reference ${reference} was not found.`);
+    return undefined;
+  }
+  if (isTokenNode(target)) {
+    addDiagnostic(diagnostics, 'error', 'invalid-reference', diagnosticPath, '$extends must reference a group, not a token.');
+    return undefined;
+  }
+  return { node: target, path: segments };
+}
+
+function mergeGroups(inherited: JsonRecord, local: JsonRecord): JsonRecord {
+  const output = cloneJson(inherited);
+  for (const [key, localValue] of Object.entries(local)) {
+    const inheritedValue = output[key];
+    if (
+      !key.startsWith('$')
+      && isRecord(inheritedValue)
+      && isRecord(localValue)
+      && !isTokenNode(inheritedValue)
+      && !isTokenNode(localValue)
+    ) {
+      output[key] = mergeGroups(inheritedValue, localValue);
+    } else {
+      output[key] = cloneJson(localValue);
+    }
+  }
+  return output;
+}
+
+function collectTokenEntries(
+  group: JsonRecord,
+  path: string[],
+  parentType: DtcgTokenType | undefined,
+  parentDeprecated: DtcgDeprecated | undefined,
+  sourceDocument: JsonRecord,
+  entries: TokenEntry[],
+): void {
+  const groupType = readTokenType(group.$type) ?? parentType;
+  const groupDeprecated = readDeprecated(group.$deprecated) ?? parentDeprecated;
+  for (const [name, child] of Object.entries(group)) {
+    if (name === '$root' && isRecord(child)) {
+      const tokenPath = [...path, '$root'];
+      const source = sourceTokenForEffectivePath(sourceDocument, tokenPath);
+      entries.push({
+        path: tokenPath,
+        node: child,
+        sourcePath: source?.path ?? tokenPath,
+        sourceNode: source?.node ?? child,
+        inheritedType: groupType,
+        inheritedDeprecated: groupDeprecated,
+      });
+      continue;
+    }
+    if (name.startsWith('$') || !isRecord(child)) continue;
+    if (isTokenNode(child)) {
+      const tokenPath = [...path, name];
+      const source = sourceTokenForEffectivePath(sourceDocument, tokenPath);
+      entries.push({
+        path: tokenPath,
+        node: child,
+        sourcePath: source?.path ?? tokenPath,
+        sourceNode: source?.node ?? child,
+        inheritedType: groupType,
+        inheritedDeprecated: groupDeprecated,
+      });
+    } else {
+      collectTokenEntries(child, [...path, name], groupType, groupDeprecated, sourceDocument, entries);
+    }
+  }
+}
+
+function sourceTokenForEffectivePath(
+  document: JsonRecord,
+  effectivePath: readonly string[],
+): { path: string[]; node: JsonRecord } | undefined {
+  let groupCandidates = sourceGroupLineage(document, [], new Set<string>());
+  for (let index = 0; index < effectivePath.length; index += 1) {
+    const segment = effectivePath[index]!;
+    const last = index === effectivePath.length - 1;
+    const nextGroups: string[][] = [];
+    for (const groupPath of groupCandidates) {
+      const group = valueAtPath(document, groupPath);
+      if (!isRecord(group)) continue;
+      const child = group[segment];
+      const childPath = [...groupPath, segment];
+      if (last && isRecord(child) && isTokenNode(child)) return { path: childPath, node: child };
+      if (!last && isRecord(child) && !isTokenNode(child)) {
+        nextGroups.push(...sourceGroupLineage(document, childPath, new Set<string>()));
+      }
+    }
+    groupCandidates = uniquePaths(nextGroups);
+  }
+  return undefined;
+}
+
+function sourceGroupLineage(document: JsonRecord, path: string[], active: Set<string>): string[][] {
+  const key = pathKey(path);
+  if (active.has(key)) return [];
+  const group = valueAtPath(document, path);
+  if (!isRecord(group) || isTokenNode(group)) return [];
+  active.add(key);
+  const lineage = [[...path]];
+  if (typeof group.$extends === 'string') {
+    const targetPath = referencePath(group.$extends);
+    if (targetPath !== undefined) lineage.push(...sourceGroupLineage(document, targetPath, active));
+  }
+  active.delete(key);
+  return uniquePaths(lineage);
+}
+
+function referencePath(reference: string): string[] | undefined {
+  if (isCurlyReference(reference)) return parseCurlyReference(reference);
+  if (!isJsonPointer(reference)) return undefined;
+  try {
+    const decoded = decodeURIComponent(reference.slice(1));
+    if (decoded === '') return [];
+    if (!decoded.startsWith('/')) return undefined;
+    const segments = decoded.slice(1).split('/');
+    if (segments.some((segment) => /~(?:[^01]|$)/.test(segment))) return undefined;
+    return segments.map((segment) => segment.replace(/~1/g, '/').replace(/~0/g, '~'));
+  } catch {
+    return undefined;
+  }
+}
+
+function uniquePaths(paths: readonly string[][]): string[][] {
+  const seen = new Set<string>();
+  return paths.filter((path) => {
+    const key = pathKey(path);
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function wholeTokenReferenceTarget(
+  token: JsonRecord,
+  document: JsonRecord,
+  entries: Map<string, TokenEntry>,
+  diagnostics: DtcgDiagnostic[],
+  tokenPath: string[],
+): TokenEntry | undefined {
+  if (typeof token.$value === 'string' && looksLikeCurlyReference(token.$value)) {
+    const segments = parseCurlyReference(token.$value);
+    if (segments === undefined) {
+      addDiagnostic(diagnostics, 'error', 'invalid-reference', [...tokenPath, '$value'], 'Malformed curly-brace token reference.');
+      return undefined;
+    }
+    const target = entries.get(pathKey(segments));
+    if (target === undefined) {
+      const raw = valueAtPath(document, segments);
+      addDiagnostic(
+        diagnostics,
+        'error',
+        isRecord(raw) ? 'invalid-reference' : 'missing-reference',
+        [...tokenPath, '$value'],
+        isRecord(raw) ? 'Curly-brace references must target a token.' : `Token reference ${token.$value} was not found.`,
+      );
+    }
+    return target;
+  }
+  if (isRecord(token.$value) && isReferenceObject(token.$value)) {
+    const segments = parseJsonPointer(token.$value.$ref, diagnostics, [...tokenPath, '$value', '$ref']);
+    if (segments === undefined) return undefined;
+    return tokenEntryForWholePointer(segments, entries);
+  }
+  if (typeof token.$ref === 'string') {
+    const segments = parseJsonPointer(token.$ref, diagnostics, [...tokenPath, '$ref']);
+    if (segments === undefined) return undefined;
+    return tokenEntryForWholePointer(segments, entries);
+  }
+  return undefined;
+}
+
+function tokenEntryForWholePointer(segments: string[], entries: Map<string, TokenEntry>): TokenEntry | undefined {
+  const direct = entries.get(pathKey(segments));
+  if (direct !== undefined) return direct;
+  if (segments.at(-1) === '$value') return entries.get(pathKey(segments.slice(0, -1)));
+  return undefined;
+}
+
+function validateNestedReferenceTypes(
+  expectedType: DtcgTokenType,
+  value: DtcgJsonValue | undefined,
+  entries: Map<string, TokenEntry>,
+  resolveToken: (entry: TokenEntry) => ResolvedTokenInternal | undefined,
+  diagnostics: DtcgDiagnostic[],
+  path: string[],
+): void {
+  if (value === undefined) return;
+  const target = nestedReferenceTarget(value, entries, diagnostics, path);
+  if (target !== undefined) {
+    const targetType = resolveToken(target)?.type;
+    if (targetType !== undefined && targetType !== expectedType) {
+      addDiagnostic(
+        diagnostics,
+        'error',
+        'reference-type-mismatch',
+        path,
+        `Expected a ${expectedType} reference, but the target token has type ${targetType}.`,
+      );
+    }
+    return;
+  }
+  if (!isRecord(value) && !Array.isArray(value)) return;
+
+  const check = (type: DtcgTokenType, child: DtcgJsonValue | undefined, childPath: string[]) => {
+    validateNestedReferenceTypes(type, child, entries, resolveToken, diagnostics, childPath);
+  };
+  switch (expectedType) {
+    case 'color':
+      if (isRecord(value)) {
+        if (Array.isArray(value.components)) {
+          value.components.forEach((component, index) => check('number', component, [...path, 'components', String(index)]));
+        }
+        check('number', value.alpha, [...path, 'alpha']);
+      }
+      break;
+    case 'dimension':
+    case 'duration':
+      if (isRecord(value)) check('number', value.value, [...path, 'value']);
+      break;
+    case 'cubicBezier':
+      if (Array.isArray(value)) value.forEach((coordinate, index) => check('number', coordinate, [...path, String(index)]));
+      break;
+    case 'strokeStyle':
+      if (isRecord(value) && Array.isArray(value.dashArray)) {
+        value.dashArray.forEach((dash, index) => check('dimension', dash, [...path, 'dashArray', String(index)]));
+      }
+      break;
+    case 'border':
+      if (isRecord(value)) {
+        check('color', value.color, [...path, 'color']);
+        check('dimension', value.width, [...path, 'width']);
+        check('strokeStyle', value.style, [...path, 'style']);
+      }
+      break;
+    case 'transition':
+      if (isRecord(value)) {
+        check('duration', value.duration, [...path, 'duration']);
+        check('duration', value.delay, [...path, 'delay']);
+        check('cubicBezier', value.timingFunction, [...path, 'timingFunction']);
+      }
+      break;
+    case 'shadow': {
+      const shadows = Array.isArray(value) ? value : [value];
+      shadows.forEach((shadow, index) => {
+        const shadowPath = Array.isArray(value) ? [...path, String(index)] : path;
+        if (isNestedReference(shadow)) {
+          check('shadow', shadow, shadowPath);
+        } else if (isRecord(shadow)) {
+          check('color', shadow.color, [...shadowPath, 'color']);
+          check('dimension', shadow.offsetX, [...shadowPath, 'offsetX']);
+          check('dimension', shadow.offsetY, [...shadowPath, 'offsetY']);
+          check('dimension', shadow.blur, [...shadowPath, 'blur']);
+          check('dimension', shadow.spread, [...shadowPath, 'spread']);
+        }
+      });
+      break;
+    }
+    case 'gradient':
+      if (Array.isArray(value)) {
+        value.forEach((stop, index) => {
+          const stopPath = [...path, String(index)];
+          if (isNestedReference(stop)) check('gradient', stop, stopPath);
+          else if (isRecord(stop)) {
+            check('color', stop.color, [...stopPath, 'color']);
+            check('number', stop.position, [...stopPath, 'position']);
+          }
+        });
+      }
+      break;
+    case 'typography':
+      if (isRecord(value)) {
+        check('fontFamily', value.fontFamily, [...path, 'fontFamily']);
+        check('dimension', value.fontSize, [...path, 'fontSize']);
+        check('fontWeight', value.fontWeight, [...path, 'fontWeight']);
+        check('dimension', value.letterSpacing, [...path, 'letterSpacing']);
+        check('number', value.lineHeight, [...path, 'lineHeight']);
+      }
+      break;
+    case 'fontFamily':
+    case 'fontWeight':
+    case 'number':
+      break;
+  }
+}
+
+function nestedReferenceTarget(
+  value: DtcgJsonValue,
+  entries: Map<string, TokenEntry>,
+  diagnostics: DtcgDiagnostic[],
+  path: string[],
+): TokenEntry | undefined {
+  if (typeof value === 'string' && looksLikeCurlyReference(value)) {
+    const segments = parseCurlyReference(value);
+    return segments === undefined ? undefined : entries.get(pathKey(segments));
+  }
+  if (isRecord(value) && isReferenceObject(value)) {
+    const segments = parseJsonPointer(value.$ref, diagnostics, [...path, '$ref']);
+    return segments === undefined ? undefined : tokenEntryForWholePointer(segments, entries);
+  }
+  return undefined;
+}
+
+function isNestedReference(value: DtcgJsonValue): boolean {
+  return (typeof value === 'string' && looksLikeCurlyReference(value))
+    || (isRecord(value) && isReferenceObject(value));
+}
+
+function resolveNestedReferences(
+  value: DtcgJsonValue | undefined,
+  document: JsonRecord,
+  entries: Map<string, TokenEntry>,
+  resolveToken: (entry: TokenEntry) => ResolvedTokenInternal | undefined,
+  diagnostics: DtcgDiagnostic[],
+  diagnosticPath: string[],
+  activePointers: Set<string>,
+  arrayAliasType?: 'gradient' | 'shadow',
+): DtcgJsonValue | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === 'string' && looksLikeCurlyReference(value)) {
+    const segments = parseCurlyReference(value);
+    if (segments === undefined) {
+      addDiagnostic(diagnostics, 'error', 'invalid-reference', diagnosticPath, 'Malformed curly-brace token reference.');
+      return undefined;
+    }
+    const target = entries.get(pathKey(segments));
+    if (target === undefined) {
+      addDiagnostic(diagnostics, 'error', 'missing-reference', diagnosticPath, `Token reference ${value} was not found.`);
+      return undefined;
+    }
+    return resolveToken(target)?.value;
+  }
+  if (Array.isArray(value)) {
+    const output: DtcgJsonValue[] = [];
+    value.forEach((item, index) => {
+      const itemIsReference = isNestedReference(item);
+      const resolved = resolveNestedReferences(
+        item,
+        document,
+        entries,
+        resolveToken,
+        diagnostics,
+        [...diagnosticPath, String(index)],
+        activePointers,
+      );
+      if (resolved === undefined) return;
+      if (arrayAliasType === 'gradient' && itemIsReference && Array.isArray(resolved)) {
+        // The report forbids array flattening but its normative gradient example
+        // references one-stop gradient tokens as stops. Unwrap only that defined
+        // shape; rejecting multi-stop targets avoids inventing flattening rules.
+        if (resolved.length === 1 && isRecord(resolved[0])) {
+          output.push(resolved[0]);
+        } else {
+          invalidValue(
+            diagnostics,
+            [...diagnosticPath, String(index)],
+            'A gradient array reference must resolve to exactly one gradient stop; multi-stop arrays are not flattened.',
+          );
+        }
+        return;
+      }
+      output.push(resolved);
+    });
+    return output;
+  }
+  if (!isRecord(value)) return value;
+  if (isReferenceObject(value)) {
+    return resolveJsonPointerValue(
+      value.$ref,
+      document,
+      entries,
+      resolveToken,
+      diagnostics,
+      diagnosticPath,
+      activePointers,
+    );
+  }
+  const output: JsonRecord = {};
+  for (const [key, child] of Object.entries(value)) {
+    const resolved = resolveNestedReferences(
+      child,
+      document,
+      entries,
+      resolveToken,
+      diagnostics,
+      [...diagnosticPath, key],
+      activePointers,
+    );
+    if (resolved !== undefined) output[key] = resolved;
+  }
+  return output;
+}
+
+function resolveJsonPointerValue(
+  reference: string,
+  document: JsonRecord,
+  entries: Map<string, TokenEntry>,
+  resolveToken: (entry: TokenEntry) => ResolvedTokenInternal | undefined,
+  diagnostics: DtcgDiagnostic[],
+  diagnosticPath: string[],
+  activePointers: Set<string>,
+): DtcgJsonValue | undefined {
+  const segments = parseJsonPointer(reference, diagnostics, diagnosticPath);
+  if (segments === undefined) return undefined;
+  const pointerKey = `${reference}@${pointerFromPath(diagnosticPath)}`;
+  if (activePointers.has(pointerKey)) {
+    addDiagnostic(diagnostics, 'error', 'circular-reference', diagnosticPath, `Circular JSON Pointer reference ${reference}.`);
+    return undefined;
+  }
+  const targetToken = tokenEntryForWholePointer(segments, entries);
+  if (targetToken !== undefined) return resolveToken(targetToken)?.value;
+
+  const target = valueAtPath(document, segments);
+  if (target === undefined) {
+    addDiagnostic(diagnostics, 'error', 'missing-reference', diagnosticPath, `JSON Pointer ${reference} was not found.`);
+    return undefined;
+  }
+  activePointers.add(pointerKey);
+  const resolved = resolveNestedReferences(
+    target,
+    document,
+    entries,
+    resolveToken,
+    diagnostics,
+    segments,
+    activePointers,
+  );
+  activePointers.delete(pointerKey);
+  return resolved;
+}
+
+function validateAndNormalizeTypeValue(
+  type: DtcgTokenType,
+  value: DtcgJsonValue,
+  path: string[],
+  diagnostics: DtcgDiagnostic[],
+): DtcgJsonValue | undefined {
+  switch (type) {
+    case 'color':
+      return validateColor(value, path, diagnostics) ? value : undefined;
+    case 'dimension':
+      return validateDimension(value, path, diagnostics) ? value : undefined;
+    case 'fontFamily':
+      return validateFontFamily(value, path, diagnostics) ? value : undefined;
+    case 'fontWeight':
+      return validateFontWeight(value, path, diagnostics) ? value : undefined;
+    case 'duration':
+      return validateDuration(value, path, diagnostics) ? value : undefined;
+    case 'cubicBezier':
+      return validateCubicBezier(value, path, diagnostics) ? value : undefined;
+    case 'number':
+      return requireNumber(value, path, diagnostics) ? value : undefined;
+    case 'strokeStyle':
+      return validateStrokeStyle(value, path, diagnostics) ? value : undefined;
+    case 'border':
+      return validateBorder(value, path, diagnostics) ? value : undefined;
+    case 'transition':
+      return validateTransition(value, path, diagnostics) ? value : undefined;
+    case 'shadow':
+      return validateShadow(value, path, diagnostics) ? value : undefined;
+    case 'gradient':
+      return validateGradient(value, path, diagnostics);
+    case 'typography':
+      return validateTypography(value, path, diagnostics) ? value : undefined;
+  }
+}
+
+function validateColor(value: DtcgJsonValue, path: string[], diagnostics: DtcgDiagnostic[]): boolean {
+  if (!requireRecord(value, path, diagnostics)) return false;
+  let valid = exactKeys(value, ['colorSpace', 'components', 'alpha', 'hex'], path, diagnostics);
+  const colorSpace = value.colorSpace;
+  if (typeof colorSpace !== 'string' || !COLOR_SPACES.has(colorSpace)) {
+    invalidValue(diagnostics, [...path, 'colorSpace'], 'Unsupported DTCG 2025.10 color space.');
+    valid = false;
+  }
+  const components = value.components;
+  if (!Array.isArray(components) || components.length !== 3) {
+    invalidValue(diagnostics, [...path, 'components'], 'Color components must be an array of exactly three values.');
+    valid = false;
+  } else if (typeof colorSpace === 'string' && COLOR_SPACES.has(colorSpace)) {
+    components.forEach((component, index) => {
+      if (component === 'none') return;
+      if (typeof component !== 'number' || !colorComponentInRange(colorSpace, index, component)) {
+        invalidValue(
+          diagnostics,
+          [...path, 'components', String(index)],
+          `Color component is outside the valid range for ${colorSpace}.`,
+        );
+        valid = false;
+      }
+    });
+  }
+  if ('alpha' in value && (typeof value.alpha !== 'number' || value.alpha < 0 || value.alpha > 1)) {
+    invalidValue(diagnostics, [...path, 'alpha'], 'Color alpha must be between 0 and 1.');
+    valid = false;
+  }
+  if ('hex' in value && (typeof value.hex !== 'string' || !/^#[0-9a-fA-F]{6}$/.test(value.hex))) {
+    invalidValue(diagnostics, [...path, 'hex'], 'Color hex fallback must contain exactly six hexadecimal digits.');
+    valid = false;
+  }
+  if (!('colorSpace' in value) || !('components' in value)) {
+    invalidValue(diagnostics, path, 'Color values require colorSpace and components.');
+    valid = false;
+  }
+  return valid;
+}
+
+function colorComponentInRange(colorSpace: string, index: number, component: number): boolean {
+  if (['srgb', 'srgb-linear', 'display-p3', 'a98-rgb', 'prophoto-rgb', 'rec2020', 'xyz-d65', 'xyz-d50'].includes(colorSpace)) {
+    return component >= 0 && component <= 1;
+  }
+  if (colorSpace === 'hsl' || colorSpace === 'hwb') {
+    return index === 0 ? component >= 0 && component < 360 : component >= 0 && component <= 100;
+  }
+  if (colorSpace === 'lab') return index === 0 ? component >= 0 && component <= 100 : true;
+  if (colorSpace === 'lch') {
+    if (index === 0) return component >= 0 && component <= 100;
+    if (index === 1) return component >= 0;
+    return component >= 0 && component < 360;
+  }
+  if (colorSpace === 'oklab') return index === 0 ? component >= 0 && component <= 1 : true;
+  if (colorSpace === 'oklch') {
+    if (index === 0) return component >= 0 && component <= 1;
+    if (index === 1) return component >= 0;
+    return component >= 0 && component < 360;
+  }
+  return false;
+}
+
+function validateDimension(value: DtcgJsonValue, path: string[], diagnostics: DtcgDiagnostic[]): boolean {
+  return validateUnitObject(value, path, diagnostics, new Set(['px', 'rem']), 'dimension');
+}
+
+function validateDuration(value: DtcgJsonValue, path: string[], diagnostics: DtcgDiagnostic[]): boolean {
+  return validateUnitObject(value, path, diagnostics, new Set(['ms', 's']), 'duration');
+}
+
+function validateUnitObject(
+  value: DtcgJsonValue,
+  path: string[],
+  diagnostics: DtcgDiagnostic[],
+  units: Set<string>,
+  label: string,
+): boolean {
+  if (!requireRecord(value, path, diagnostics)) return false;
+  let valid = exactKeys(value, ['value', 'unit'], path, diagnostics);
+  if (typeof value.value !== 'number') {
+    invalidValue(diagnostics, [...path, 'value'], `${label} value must be a number.`);
+    valid = false;
+  }
+  if (typeof value.unit !== 'string' || !units.has(value.unit)) {
+    invalidValue(diagnostics, [...path, 'unit'], `${label} unit must be one of: ${[...units].join(', ')}.`);
+    valid = false;
+  }
+  return valid;
+}
+
+function validateFontFamily(value: DtcgJsonValue, path: string[], diagnostics: DtcgDiagnostic[]): boolean {
+  if (typeof value === 'string') return true;
+  if (!Array.isArray(value) || value.length === 0 || value.some((family) => typeof family !== 'string')) {
+    invalidValue(diagnostics, path, 'fontFamily must be a string or a non-empty array of strings.');
+    return false;
+  }
+  return true;
+}
+
+function validateFontWeight(value: DtcgJsonValue, path: string[], diagnostics: DtcgDiagnostic[]): boolean {
+  const valid =
+    (typeof value === 'number' && value >= 1 && value <= 1000)
+    || (typeof value === 'string' && FONT_WEIGHT_KEYWORDS.has(value));
+  if (!valid) invalidValue(diagnostics, path, 'fontWeight must be a number from 1 to 1000 or a defined keyword.');
+  return valid;
+}
+
+function validateCubicBezier(value: DtcgJsonValue, path: string[], diagnostics: DtcgDiagnostic[]): boolean {
+  if (!Array.isArray(value) || value.length !== 4 || value.some((coordinate) => typeof coordinate !== 'number')) {
+    invalidValue(diagnostics, path, 'cubicBezier must contain exactly four numeric coordinates.');
+    return false;
+  }
+  const [x1, , x2] = value as [number, number, number, number];
+  const validX = x1 >= 0 && x1 <= 1 && x2 >= 0 && x2 <= 1;
+  if (!validX) invalidValue(diagnostics, path, 'cubicBezier X coordinates must be between 0 and 1.');
+  return validX;
+}
+
+function validateStrokeStyle(value: DtcgJsonValue, path: string[], diagnostics: DtcgDiagnostic[]): boolean {
+  if (typeof value === 'string') {
+    const valid = STROKE_STYLE_KEYWORDS.has(value);
+    if (!valid) invalidValue(diagnostics, path, 'Unknown strokeStyle keyword.');
+    return valid;
+  }
+  if (!requireRecord(value, path, diagnostics)) return false;
+  let valid = exactKeys(value, ['dashArray', 'lineCap'], path, diagnostics);
+  if (!Array.isArray(value.dashArray)) {
+    invalidValue(diagnostics, [...path, 'dashArray'], 'strokeStyle dashArray must be an array.');
+    valid = false;
+  } else {
+    value.dashArray.forEach((item, index) => {
+      if (!validateDimension(item, [...path, 'dashArray', String(index)], diagnostics)) valid = false;
+    });
+  }
+  if (typeof value.lineCap !== 'string' || !['round', 'butt', 'square'].includes(value.lineCap)) {
+    invalidValue(diagnostics, [...path, 'lineCap'], 'strokeStyle lineCap must be round, butt, or square.');
+    valid = false;
+  }
+  return valid;
+}
+
+function validateBorder(value: DtcgJsonValue, path: string[], diagnostics: DtcgDiagnostic[]): boolean {
+  if (!requireRecord(value, path, diagnostics)) return false;
+  let valid = exactKeys(value, ['color', 'width', 'style'], path, diagnostics);
+  if (!validateColor(value.color as DtcgJsonValue, [...path, 'color'], diagnostics)) valid = false;
+  if (!validateDimension(value.width as DtcgJsonValue, [...path, 'width'], diagnostics)) valid = false;
+  if (!validateStrokeStyle(value.style as DtcgJsonValue, [...path, 'style'], diagnostics)) valid = false;
+  return valid;
+}
+
+function validateTransition(value: DtcgJsonValue, path: string[], diagnostics: DtcgDiagnostic[]): boolean {
+  if (!requireRecord(value, path, diagnostics)) return false;
+  let valid = exactKeys(value, ['duration', 'delay', 'timingFunction'], path, diagnostics);
+  if (!validateDuration(value.duration as DtcgJsonValue, [...path, 'duration'], diagnostics)) valid = false;
+  if (!validateDuration(value.delay as DtcgJsonValue, [...path, 'delay'], diagnostics)) valid = false;
+  if (!validateCubicBezier(value.timingFunction as DtcgJsonValue, [...path, 'timingFunction'], diagnostics)) valid = false;
+  return valid;
+}
+
+function validateShadow(value: DtcgJsonValue, path: string[], diagnostics: DtcgDiagnostic[]): boolean {
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      addDiagnostic(
+        diagnostics,
+        'warning',
+        'schema-divergence',
+        path,
+        'The normative report does not require a non-empty shadow array, but the official schema does.',
+      );
+    }
+    let valid = true;
+    value.forEach((shadow, index) => {
+      if (!validateShadowObject(shadow, [...path, String(index)], diagnostics)) valid = false;
+    });
+    return valid;
+  }
+  return validateShadowObject(value, path, diagnostics);
+}
+
+function validateShadowObject(value: DtcgJsonValue, path: string[], diagnostics: DtcgDiagnostic[]): boolean {
+  if (!requireRecord(value, path, diagnostics)) return false;
+  let valid = exactKeys(value, ['color', 'offsetX', 'offsetY', 'blur', 'spread', 'inset'], path, diagnostics);
+  if (!validateColor(value.color as DtcgJsonValue, [...path, 'color'], diagnostics)) valid = false;
+  for (const field of ['offsetX', 'offsetY', 'blur', 'spread'] as const) {
+    if (!validateDimension(value[field] as DtcgJsonValue, [...path, field], diagnostics)) valid = false;
+  }
+  if ('inset' in value && typeof value.inset !== 'boolean') {
+    invalidValue(diagnostics, [...path, 'inset'], 'shadow inset must be a boolean.');
+    valid = false;
+  }
+  return valid;
+}
+
+function validateGradient(
+  value: DtcgJsonValue,
+  path: string[],
+  diagnostics: DtcgDiagnostic[],
+): DtcgJsonValue | undefined {
+  if (!Array.isArray(value)) {
+    invalidValue(diagnostics, path, 'gradient must be an array of stops.');
+    return undefined;
+  }
+  if (value.length === 0) {
+    addDiagnostic(
+      diagnostics,
+      'warning',
+      'schema-divergence',
+      path,
+      'The normative report does not require a non-empty gradient array, but the official schema does.',
+    );
+  }
+  let valid = true;
+  const normalized = value.map((stop, index) => {
+    const stopPath = [...path, String(index)];
+    if (!requireRecord(stop, stopPath, diagnostics)) {
+      valid = false;
+      return stop;
+    }
+    if (!exactKeys(stop, ['color', 'position'], stopPath, diagnostics)) valid = false;
+    if (!validateColor(stop.color as DtcgJsonValue, [...stopPath, 'color'], diagnostics)) valid = false;
+    if (typeof stop.position !== 'number') {
+      invalidValue(diagnostics, [...stopPath, 'position'], 'gradient position must be a number.');
+      valid = false;
+      return stop;
+    }
+    return { ...stop, position: Math.max(0, Math.min(1, stop.position)) };
+  });
+  return valid ? normalized : undefined;
+}
+
+function validateTypography(value: DtcgJsonValue, path: string[], diagnostics: DtcgDiagnostic[]): boolean {
+  if (!requireRecord(value, path, diagnostics)) return false;
+  let valid = exactKeys(value, ['fontFamily', 'fontSize', 'fontWeight', 'letterSpacing', 'lineHeight'], path, diagnostics);
+  if (!validateFontFamily(value.fontFamily as DtcgJsonValue, [...path, 'fontFamily'], diagnostics)) valid = false;
+  if (!validateDimension(value.fontSize as DtcgJsonValue, [...path, 'fontSize'], diagnostics)) valid = false;
+  if (!validateFontWeight(value.fontWeight as DtcgJsonValue, [...path, 'fontWeight'], diagnostics)) valid = false;
+  if (!validateDimension(value.letterSpacing as DtcgJsonValue, [...path, 'letterSpacing'], diagnostics)) valid = false;
+  if (!requireNumber(value.lineHeight as DtcgJsonValue, [...path, 'lineHeight'], diagnostics)) valid = false;
+  return valid;
+}
+
+function requireNumber(value: DtcgJsonValue, path: string[], diagnostics: DtcgDiagnostic[]): boolean {
+  if (typeof value === 'number') return true;
+  invalidValue(diagnostics, path, 'Value must be a number.');
+  return false;
+}
+
+function requireRecord(
+  value: DtcgJsonValue | undefined,
+  path: string[],
+  diagnostics: DtcgDiagnostic[],
+): value is JsonRecord {
+  if (isRecord(value)) return true;
+  invalidValue(diagnostics, path, 'Value must be an object.');
+  return false;
+}
+
+function exactKeys(
+  value: JsonRecord,
+  allowed: readonly string[],
+  path: string[],
+  diagnostics: DtcgDiagnostic[],
+): boolean {
+  const allowedSet = new Set(allowed);
+  const unexpected = Object.keys(value).filter((key) => !allowedSet.has(key));
+  for (const key of unexpected) invalidValue(diagnostics, [...path, key], `Unexpected value property ${key}.`);
+  const required = allowed.filter((key) => !['alpha', 'hex', 'inset'].includes(key));
+  const missing = required.filter((key) => !(key in value));
+  for (const key of missing) invalidValue(diagnostics, [...path, key], `Missing required value property ${key}.`);
+  return unexpected.length === 0 && missing.length === 0;
+}
+
+function parseCurlyReference(reference: string): string[] | undefined {
+  if (!isCurlyReference(reference)) return undefined;
+  const segments = reference.slice(1, -1).split('.');
+  if (segments.some((segment, index) => segment.length === 0 || /[{}.]/.test(segment) || (segment.startsWith('$') && !(segment === '$root' && index === segments.length - 1)))) {
+    return undefined;
+  }
+  return segments;
+}
+
+function parseJsonPointer(
+  reference: string,
+  diagnostics: DtcgDiagnostic[],
+  diagnosticPath: string[],
+): string[] | undefined {
+  if (!isJsonPointer(reference)) {
+    addDiagnostic(diagnostics, 'error', 'invalid-json-pointer', diagnosticPath, `Invalid JSON Pointer ${reference}.`);
+    return undefined;
+  }
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(reference.slice(1));
+  } catch {
+    addDiagnostic(diagnostics, 'error', 'invalid-json-pointer', diagnosticPath, `Invalid URI encoding in ${reference}.`);
+    return undefined;
+  }
+  if (decoded === '') return [];
+  if (!decoded.startsWith('/')) {
+    addDiagnostic(diagnostics, 'error', 'invalid-json-pointer', diagnosticPath, `Invalid JSON Pointer ${reference}.`);
+    return undefined;
+  }
+  const segments: string[] = [];
+  for (const encodedSegment of decoded.slice(1).split('/')) {
+    if (/~(?:[^01]|$)/.test(encodedSegment)) {
+      addDiagnostic(diagnostics, 'error', 'invalid-json-pointer', diagnosticPath, `Invalid RFC 6901 escape in ${reference}.`);
+      return undefined;
+    }
+    segments.push(encodedSegment.replace(/~1/g, '/').replace(/~0/g, '~'));
+  }
+  return segments;
+}
+
+function valueAtPath(root: DtcgJsonValue, segments: readonly string[]): DtcgJsonValue | undefined {
+  let current: DtcgJsonValue | undefined = root;
+  for (const segment of segments) {
+    if (Array.isArray(current)) {
+      if (!/^(?:0|[1-9]\d*)$/.test(segment)) return undefined;
+      current = current[Number(segment)];
+    } else if (isRecord(current) && Object.prototype.hasOwnProperty.call(current, segment)) {
+      current = current[segment];
+    } else {
+      return undefined;
+    }
+  }
+  return current;
+}
+
+function pointerFromPath(path: readonly string[]): string {
+  return path.length === 0 ? '#' : `#/${path.map((segment) => segment.replace(/~/g, '~0').replace(/\//g, '~1')).join('/')}`;
+}
+
+function pathKey(path: readonly string[]): string {
+  return JSON.stringify(path);
+}
+
+function isTokenNode(value: JsonRecord): boolean {
+  return Object.prototype.hasOwnProperty.call(value, '$value') || Object.prototype.hasOwnProperty.call(value, '$ref');
+}
+
+function isWholeTokenReference(token: JsonRecord): boolean {
+  return typeof token.$ref === 'string'
+    || (typeof token.$value === 'string' && looksLikeCurlyReference(token.$value))
+    || (isRecord(token.$value) && isReferenceObject(token.$value));
+}
+
+function isReferenceObject(value: JsonRecord): value is JsonRecord & { $ref: string } {
+  return Object.keys(value).length === 1 && typeof value.$ref === 'string';
+}
+
+function isCurlyReference(value: string): boolean {
+  return value.startsWith('{') && value.endsWith('}') && parseCurlyReferenceUnchecked(value);
+}
+
+function parseCurlyReferenceUnchecked(value: string): boolean {
+  const segments = value.slice(1, -1).split('.');
+  return segments.every(
+    (segment, index) =>
+      segment.length > 0
+      && !/[{}.]/.test(segment)
+      && (!segment.startsWith('$') || (segment === '$root' && index === segments.length - 1)),
+  );
+}
+
+function looksLikeCurlyReference(value: string): boolean {
+  return value.startsWith('{') && value.endsWith('}');
+}
+
+function isJsonPointer(value: string): boolean {
+  return value === '#' || value.startsWith('#/');
+}
+
+function readTokenType(value: DtcgJsonValue | undefined): DtcgTokenType | undefined {
+  return typeof value === 'string' && TOKEN_TYPE_SET.has(value) ? (value as DtcgTokenType) : undefined;
+}
+
+function readDeprecated(value: DtcgJsonValue | undefined): DtcgDeprecated | undefined {
+  return typeof value === 'boolean' || typeof value === 'string' ? value : undefined;
+}
+
+function withoutKey(record: JsonRecord, key: string): JsonRecord {
+  const output = cloneJson(record);
+  delete output[key];
+  return output;
+}
+
+function cloneJson<T extends DtcgJsonValue>(value: T): T {
+  if (Array.isArray(value)) return value.map((item) => cloneJson(item)) as T;
+  if (isRecord(value)) {
+    return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, cloneJson(item)])) as T;
+  }
+  return value;
+}
+
+function sortJson(value: DtcgJsonValue): DtcgJsonValue {
+  if (Array.isArray(value)) return value.map((item) => sortJson(item));
+  if (!isRecord(value)) return value;
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0))
+      .map((key) => [key, sortJson(value[key]!)]),
+  );
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function addDiagnostic(
+  diagnostics: DtcgDiagnostic[],
+  severity: DtcgDiagnostic['severity'],
+  code: DtcgDiagnosticCode,
+  path: string[],
+  message: string,
+): void {
+  diagnostics.push({ severity, code, path: pointerFromPath(path), message });
+}
+
+function invalidMetadata(diagnostics: DtcgDiagnostic[], path: string[], message: string): void {
+  addDiagnostic(diagnostics, 'error', 'invalid-metadata', path, message);
+}
+
+function invalidValue(diagnostics: DtcgDiagnostic[], path: string[], message: string): void {
+  addDiagnostic(diagnostics, 'error', 'invalid-value', path, message);
+}
+
+function hasErrors(diagnostics: readonly DtcgDiagnostic[]): boolean {
+  return diagnostics.some((diagnostic) => diagnostic.severity === 'error');
+}
+
+function hasErrorsForPath(diagnostics: readonly DtcgDiagnostic[], path: readonly string[]): boolean {
+  const pointer = pointerFromPath(path);
+  return diagnostics.some(
+    (diagnostic) =>
+      diagnostic.severity === 'error'
+      && (diagnostic.path === pointer || diagnostic.path.startsWith(`${pointer}/`)),
+  );
+}
+
+function uniqueDiagnostics(diagnostics: readonly DtcgDiagnostic[]): DtcgDiagnostic[] {
+  const seen = new Set<string>();
+  return diagnostics.filter((diagnostic) => {
+    const key = `${diagnostic.severity}:${diagnostic.code}:${diagnostic.path}:${diagnostic.message}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -45,6 +45,7 @@ export * from './artifacts/od-card.js';
 export * from './runtime/deck-stage-fallback.js';
 export * from './design-systems/components-manifest.js';
 export * from './design-systems/derived-token-outputs.js';
+export * from './design-systems/dtcg-2025-10.js';
 export * from './design-systems/token-schema.js';
 export * from './sse/common.js';
 export * from './sse/chat.js';

--- a/packages/contracts/tests/dtcg-2025-10.test.ts
+++ b/packages/contracts/tests/dtcg-2025-10.test.ts
@@ -414,6 +414,42 @@ describe('DTCG Format 2025.10 codec', () => {
   it('throws when asked to serialize an invalid document', () => {
     expect(() => serializeDtcgFormat2025_10({ bad: { $value: 1 } })).toThrow(/missing.*type|type cannot be determined/i);
   });
+
+  it('rejects documents carrying a $schema that identifies a different profile', () => {
+    expectInvalid(
+      {
+        $schema: 'https://design-tokens.org/schema.json',
+        token: token('number', 1),
+      },
+      'profile-mismatch',
+    );
+    expectInvalid(
+      {
+        $schema: 'https://example.com/unrelated.schema.json',
+        token: token('number', 1),
+      },
+      'profile-mismatch',
+    );
+    const result = parseDtcgFormat2025_10({
+      $schema: DTCG_FORMAT_SCHEMA_URL,
+      token: token('number', 1),
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.diagnostics.map((d) => d.code)).toContain('non-normative-schema-property');
+      expect(result.diagnostics.map((d) => d.code)).not.toContain('profile-mismatch');
+    }
+  });
+
+  it('accepts empty fontFamily arrays per normative report while flagging schema divergence', () => {
+    const result = parseDtcgFormat2025_10({ family: token('fontFamily', []) });
+    expect(result.ok, formatDiagnostics(result)).toBe(true);
+    if (result.ok) {
+      expect(result.diagnostics.map((d) => d.code)).toContain('schema-divergence');
+      expect(result.tokens.map((t) => t.value)).toEqual([[]]);
+    }
+    expectInvalid({ bad: token('fontFamily', [1, 2]) }, 'invalid-value');
+  });
 });
 
 function token(type: string, value: unknown): Record<string, unknown> {

--- a/packages/contracts/tests/dtcg-2025-10.test.ts
+++ b/packages/contracts/tests/dtcg-2025-10.test.ts
@@ -1,0 +1,462 @@
+import { readFileSync } from 'node:fs';
+import Ajv from 'ajv';
+import { describe, expect, it } from 'vitest';
+
+import {
+  DTCG_FORMAT_SCHEMA_URL,
+  DTCG_FORMAT_VERSION,
+  DTCG_TOKEN_TYPES,
+  parseDtcgFormat2025_10,
+  serializeDtcgFormat2025_10,
+  type DtcgDiagnosticCode,
+  type DtcgFormatDocument,
+  type DtcgFormatParseResult,
+} from '../src/design-systems/dtcg-2025-10.js';
+
+describe('DTCG Format 2025.10 codec', () => {
+  it('emits documents accepted by the pinned official 2025.10 schema', () => {
+    const schema = JSON.parse(
+      readFileSync(new URL('./fixtures/dtcg-2025-10/format.schema.json', import.meta.url), 'utf8'),
+    ) as object;
+    const validate = new Ajv({ allErrors: true, strict: false, validateFormats: false }).compile(schema);
+    const parsed = expectValid({
+      palette: {
+        $type: 'color',
+        primary: { $value: color() },
+        secondary: { $value: '{palette.primary}' },
+      },
+      spacing: token('dimension', dimension(1, 'rem')),
+    });
+    const output = JSON.parse(
+      serializeDtcgFormat2025_10(parsed.document, { includeSchemaMetadata: true }),
+    ) as object;
+
+    expect(validate(output), JSON.stringify(validate.errors, null, 2)).toBe(true);
+  });
+
+  it('pins the stable profile and supports all 13 normative token types', () => {
+    expect(DTCG_FORMAT_VERSION).toBe('2025.10');
+    expect(DTCG_FORMAT_SCHEMA_URL).toBe('https://www.designtokens.org/schemas/2025.10/format.json');
+    expect(DTCG_TOKEN_TYPES).toHaveLength(13);
+
+    const result = expectValid({
+      color: token('color', color()),
+      dimension: token('dimension', dimension(16, 'px')),
+      fontFamily: token('fontFamily', ['Inter', 'sans-serif']),
+      fontWeight: token('fontWeight', 'semi-bold'),
+      duration: token('duration', { value: 150, unit: 'ms' }),
+      cubicBezier: token('cubicBezier', [0.2, -0.5, 0.8, 1.5]),
+      number: token('number', -1.25),
+      strokeStyle: token('strokeStyle', {
+        dashArray: [dimension(2, 'px'), dimension(1, 'rem')],
+        lineCap: 'round',
+      }),
+      border: token('border', {
+        color: color(),
+        width: dimension(1, 'px'),
+        style: 'solid',
+      }),
+      transition: token('transition', {
+        duration: { value: 200, unit: 'ms' },
+        delay: { value: -50, unit: 'ms' },
+        timingFunction: [0.2, 0, 0, 1],
+      }),
+      shadow: token('shadow', {
+        color: color(0.5),
+        offsetX: dimension(0, 'px'),
+        offsetY: dimension(2, 'px'),
+        blur: dimension(8, 'px'),
+        spread: dimension(-1, 'px'),
+        inset: false,
+      }),
+      gradient: token('gradient', [
+        { color: color(), position: 0 },
+        { color: color(0.4), position: 1 },
+      ]),
+      typography: token('typography', {
+        fontFamily: ['Inter', 'sans-serif'],
+        fontSize: dimension(1, 'rem'),
+        fontWeight: 550,
+        letterSpacing: dimension(-0.02, 'rem'),
+        lineHeight: 1.5,
+      }),
+    });
+
+    expect(result.tokens.map((entry) => entry.type)).toEqual(DTCG_TOKEN_TYPES);
+  });
+
+  it('validates every stable color space and permits none components', () => {
+    const colorValues = {
+      srgb: [0, 0.5, 1],
+      'srgb-linear': [0, 0.5, 1],
+      hsl: ['none', 100, 50],
+      hwb: [359.9, 0, 100],
+      lab: [50, -200, 200],
+      lch: [50, 230, 359.9],
+      oklab: [0.5, -2, 2],
+      oklch: [0.5, 1.5, 'none'],
+      'display-p3': [0, 0.5, 1],
+      'a98-rgb': [0, 0.5, 1],
+      'prophoto-rgb': [0, 0.5, 1],
+      rec2020: [0, 0.5, 1],
+      'xyz-d65': [0, 0.5, 1],
+      'xyz-d50': [0, 0.5, 1],
+    } as const;
+    const document = Object.fromEntries(
+      Object.entries(colorValues).map(([colorSpace, components]) => [
+        colorSpace,
+        token('color', { colorSpace, components: [...components], alpha: 0, hex: '#00ffAA' }),
+      ]),
+    );
+
+    expect(expectValid(document).tokens).toHaveLength(14);
+  });
+
+  it('resolves inherited types, root tokens, curly aliases, and property references', () => {
+    const result = expectValid({
+      palette: {
+        $type: 'color',
+        accent: {
+          $root: {
+            $value: color(),
+            $description: 'Base accent',
+            $extensions: { 'org.example': { source: 'brand' } },
+          },
+          soft: { $value: color(0.4) },
+        },
+      },
+      semantic: {
+        $deprecated: 'Use component tokens.',
+        action: { $value: '{palette.accent.$root}' },
+      },
+      dimensions: {
+        $type: 'dimension',
+        small: { $value: dimension(4, 'px') },
+      },
+      border: {
+        $type: 'border',
+        focus: {
+          $value: {
+            color: '{palette.accent.$root}',
+            width: { $ref: '#/dimensions/small/$value' },
+            style: 'solid',
+          },
+        },
+      },
+      copiedWidth: {
+        $type: 'dimension',
+        $value: { $ref: '#/dimensions/small/$value' },
+      },
+    });
+
+    expect(findToken(result, '#/semantic/action')).toMatchObject({
+      type: 'color',
+      deprecated: 'Use component tokens.',
+      value: color(),
+    });
+    expect(findToken(result, '#/border/focus').value).toMatchObject({ width: dimension(4, 'px') });
+    expect(findToken(result, '#/copiedWidth')).toMatchObject({ type: 'dimension', value: dimension(4, 'px') });
+    expect(findToken(result, '#/palette/accent/$root').source.$extensions).toEqual({
+      'org.example': { source: 'brand' },
+    });
+  });
+
+  it('accepts token-level JSON Pointer aliases and enforces reference types', () => {
+    const valid = expectValid({
+      base: token('number', 2),
+      alias: { $ref: '#/base' },
+      valueAlias: { $value: { $ref: '#/base/$value' } },
+    });
+    expect(findToken(valid, '#/alias')).toMatchObject({ type: 'number', value: 2 });
+    expect(findToken(valid, '#/valueAlias')).toMatchObject({ type: 'number', value: 2 });
+
+    expectInvalid(
+      {
+        base: token('number', 2),
+        alias: { $type: 'dimension', $value: '{base}' },
+      },
+      'reference-type-mismatch',
+    );
+  });
+
+  it('deep-merges extended groups while replacing complete token definitions', () => {
+    const result = expectValid({
+      base: {
+        $type: 'color',
+        normal: { $value: color() },
+        state: {
+          hover: { $value: color(0.8), $description: 'Inherited description' },
+          active: { $value: color(0.6) },
+        },
+      },
+      primary: {
+        $extends: '{base}',
+        normal: { $value: color(0.7) },
+        state: {
+          hover: { $value: color(0.5) },
+        },
+      },
+    });
+
+    expect(findToken(result, '#/primary/normal').value).toEqual(color(0.7));
+    expect(findToken(result, '#/primary/state/hover').source).not.toHaveProperty('$description');
+    expect(findToken(result, '#/primary/state/active')).toMatchObject({
+      value: color(0.6),
+      sourcePointer: '#/base/state/active',
+    });
+  });
+
+  it('resolves nested extensions before applying outer inherited groups', () => {
+    const result = expectValid({
+      base: {
+        $type: 'number',
+        nested: {
+          value: { $value: 1 },
+          inheritedOnly: { $value: 10 },
+        },
+      },
+      other: {
+        $type: 'number',
+        value: { $value: 2 },
+      },
+      derived: {
+        $extends: '{base}',
+        nested: {
+          $extends: '{other}',
+        },
+      },
+    });
+
+    expect(findToken(result, '#/derived/nested/value')).toMatchObject({
+      value: 2,
+      sourcePointer: '#/other/value',
+    });
+    expect(findToken(result, '#/derived/nested/inheritedOnly')).toMatchObject({
+      value: 10,
+      sourcePointer: '#/base/nested/inheritedOnly',
+    });
+  });
+
+  it('supports RFC 6901 escaping, URI fragments, array indices, and the root pointer', () => {
+    const result = expectValid({
+      'a/b~c': token('number', 4),
+      copied: { $type: 'number', $ref: '#/a~1b~0c/$value' },
+      family: token('fontFamily', ['Inter', 'Mono']),
+      firstFamily: { $type: 'fontFamily', $ref: '#/family/$value/0' },
+      encoded: { $type: 'fontFamily', $ref: '#/family/$value/%31' },
+    });
+
+    expect(findToken(result, '#/copied').value).toBe(4);
+    expect(findToken(result, '#/firstFamily').value).toBe('Inter');
+    expect(findToken(result, '#/encoded').value).toBe('Mono');
+    expectInvalid({ invalid: { $type: 'number', $ref: '#' } }, 'invalid-value');
+  });
+
+  it('reports cycles for aliases and group extension chains', () => {
+    expectInvalid(
+      {
+        a: { $type: 'number', $value: '{b}' },
+        b: { $type: 'number', $value: '{a}' },
+      },
+      'circular-reference',
+    );
+    expectInvalid(
+      {
+        a: { $extends: '{b}' },
+        b: { $extends: '{a}' },
+      },
+      'circular-reference',
+    );
+    expectInvalid(
+      {
+        a: { $type: 'number', $ref: '#/b' },
+        b: { $type: 'number', $ref: '#/a' },
+      },
+      'circular-reference',
+    );
+    expectInvalid(
+      {
+        a: {
+          $type: 'border',
+          $value: {
+            color: { $ref: '#/a/$value/color' },
+            width: dimension(1, 'px'),
+            style: 'solid',
+          },
+        },
+      },
+      'circular-reference',
+    );
+  });
+
+  it('rejects shape-compatible composite references with the wrong token type', () => {
+    expectInvalid(
+      {
+        weight: token('fontWeight', 500),
+        gradient: token('gradient', [{ color: color(), position: '{weight}' }]),
+      },
+      'reference-type-mismatch',
+    );
+    expectInvalid(
+      {
+        scalar: token('number', 2),
+        typography: token('typography', {
+          fontFamily: ['Inter'],
+          fontSize: dimension(16, 'px'),
+          fontWeight: '{scalar}',
+          letterSpacing: dimension(0, 'px'),
+          lineHeight: 1.4,
+        }),
+      },
+      'reference-type-mismatch',
+    );
+  });
+
+  it('unwraps only singleton gradient aliases and never flattens multi-stop arrays', () => {
+    const result = expectValid({
+      start: token('gradient', [{ color: color(), position: 0 }]),
+      end: token('gradient', [{ color: color(0.5), position: 1 }]),
+      combined: token('gradient', ['{start}', { color: color(0.75), position: 0.5 }, '{end}']),
+    });
+    expect(findToken(result, '#/combined').value).toEqual([
+      { color: color(), position: 0 },
+      { color: color(0.75), position: 0.5 },
+      { color: color(0.5), position: 1 },
+    ]);
+
+    expectInvalid(
+      {
+        multiple: token('gradient', [
+          { color: color(), position: 0 },
+          { color: color(0.5), position: 1 },
+        ]),
+        combined: token('gradient', ['{multiple}']),
+      },
+      'invalid-value',
+    );
+  });
+
+  it('does not guess types and rejects invalid names or token/group ambiguity', () => {
+    expectInvalid({ untyped: { $value: 1 } }, 'missing-type');
+    expectInvalid({ 'bad.name': token('number', 1) }, 'invalid-name');
+    expectInvalid({ '$custom': token('number', 1) }, 'unknown-reserved-property');
+    expectInvalid(
+      { ambiguous: { $type: 'number', $value: 1, child: token('number', 2) } },
+      'invalid-token',
+    );
+  });
+
+  it('enforces color, unit, font-weight, cubic-bezier, and composite constraints', () => {
+    expectInvalid({ bad: token('color', { colorSpace: 'srgb', components: [0, 0, 1.1] }) }, 'invalid-value');
+    expectInvalid({ bad: token('color', { colorSpace: 'hsl', components: [360, 50, 50] }) }, 'invalid-value');
+    expectInvalid({ bad: token('color', { colorSpace: 'srgb', components: [0, 0, 0], hex: '#000' }) }, 'invalid-value');
+    expectInvalid({ bad: token('dimension', { value: 1, unit: 'em' }) }, 'invalid-value');
+    expectInvalid({ bad: token('fontWeight', 1001) }, 'invalid-value');
+    expectInvalid({ bad: token('cubicBezier', [-0.1, 0, 1, 1]) }, 'invalid-value');
+    expectInvalid(
+      { bad: token('border', { color: color(), width: dimension(1, 'px'), style: 'solid', extra: true }) },
+      'invalid-value',
+    );
+  });
+
+  it('preserves normative source values while normalizing only the resolved gradient position', () => {
+    const result = expectValid({
+      gradient: token('gradient', [
+        { color: color(), position: -0.25 },
+        { color: color(0.5), position: 1.25 },
+      ]),
+      emptyShadow: token('shadow', []),
+      emptyGradient: token('gradient', []),
+    });
+
+    expect(findToken(result, '#/gradient').value).toEqual([
+      { color: color(), position: 0 },
+      { color: color(0.5), position: 1 },
+    ]);
+    expect((result.document.gradient as { $value: unknown }).$value).toEqual([
+      { color: color(), position: -0.25 },
+      { color: color(0.5), position: 1.25 },
+    ]);
+    expect(result.diagnostics.filter((diagnostic) => diagnostic.code === 'schema-divergence')).toHaveLength(2);
+  });
+
+  it('serializes deterministically and preserves extensions, deprecation, and references', () => {
+    const parsed = expectValid({
+      $schema: DTCG_FORMAT_SCHEMA_URL,
+      z: {
+        $value: '{a}',
+        $deprecated: false,
+        $extensions: { 'org.example': { z: 1, a: ['kept'] } },
+      },
+      a: token('number', 1),
+    });
+
+    const withoutSchema = serializeDtcgFormat2025_10(parsed.document);
+    const withSchema = serializeDtcgFormat2025_10(parsed.document, { includeSchemaMetadata: true });
+    expect(withoutSchema).not.toContain('$schema');
+    expect(withSchema).toContain(`"$schema": "${DTCG_FORMAT_SCHEMA_URL}"`);
+    expect(withSchema.indexOf('"$schema"')).toBeLessThan(withSchema.indexOf('"a"'));
+    expect(withoutSchema).toContain('"$deprecated": false');
+    expect(withoutSchema).toContain('"org.example"');
+    expect(withoutSchema).toContain('"$value": "{a}"');
+
+    const reparsed = expectValid(JSON.parse(withoutSchema));
+    expect(reparsed.document).toEqual({
+      a: token('number', 1),
+      z: {
+        $deprecated: false,
+        $extensions: { 'org.example': { a: ['kept'], z: 1 } },
+        $value: '{a}',
+      },
+    });
+  });
+
+  it('throws when asked to serialize an invalid document', () => {
+    expect(() => serializeDtcgFormat2025_10({ bad: { $value: 1 } })).toThrow(/missing.*type|type cannot be determined/i);
+  });
+});
+
+function token(type: string, value: unknown): Record<string, unknown> {
+  return { $type: type, $value: value };
+}
+
+function dimension(value: number, unit: 'px' | 'rem'): { value: number; unit: 'px' | 'rem' } {
+  return { value, unit };
+}
+
+function color(alpha?: number): Record<string, unknown> {
+  return {
+    colorSpace: 'srgb',
+    components: [0.1, 0.2, 0.3],
+    hex: '#1a334d',
+    ...(alpha === undefined ? {} : { alpha }),
+  };
+}
+
+function expectValid(input: unknown): Extract<DtcgFormatParseResult, { ok: true }> {
+  const result = parseDtcgFormat2025_10(input);
+  expect(result.ok, formatDiagnostics(result)).toBe(true);
+  if (!result.ok) throw new Error(formatDiagnostics(result));
+  return result;
+}
+
+function expectInvalid(input: unknown, code: DtcgDiagnosticCode): void {
+  const result = parseDtcgFormat2025_10(input);
+  expect(result.ok, 'Expected the document to be invalid.').toBe(false);
+  expect(result.diagnostics.map((diagnostic) => diagnostic.code), formatDiagnostics(result)).toContain(code);
+}
+
+function findToken(result: Extract<DtcgFormatParseResult, { ok: true }>, pointer: string) {
+  const found = result.tokens.find((entry) => entry.pointer === pointer);
+  expect(found, `Missing resolved token ${pointer}.`).toBeDefined();
+  return found!;
+}
+
+function formatDiagnostics(result: DtcgFormatParseResult): string {
+  return result.diagnostics
+    .map((diagnostic) => `${diagnostic.severity} ${diagnostic.code} ${diagnostic.path}: ${diagnostic.message}`)
+    .join('\n');
+}
+
+const _typecheckDocument: DtcgFormatDocument = { token: { $type: 'number', $value: 1 } };
+void _typecheckDocument;

--- a/packages/contracts/tests/fixtures/dtcg-2025-10/ATTRIBUTION.md
+++ b/packages/contracts/tests/fixtures/dtcg-2025-10/ATTRIBUTION.md
@@ -1,0 +1,17 @@
+# DTCG 2025.10 schema fixture
+
+`format.schema.json` is a pinned copy of:
+
+https://www.designtokens.org/schemas/2025.10/format.json
+
+SHA-256: `32e93b780e4e4bca778d0780cb797a560deedc470c608af16576223f7e42915f`
+
+The schema is maintained by the W3C Design Tokens Community Group in
+`design-tokens/community-group`. Test suites and other software in that
+repository are licensed under the W3C 3-clause BSD License:
+
+https://www.w3.org/Consortium/Legal/2008/03-bsd-license.html
+
+The normative implementation source remains the stable Final Community Group
+Reports at `https://www.designtokens.org/TR/2025.10/`. This fixture is a
+secondary conformance oracle and is never fetched or loaded by product runtime.

--- a/packages/contracts/tests/fixtures/dtcg-2025-10/format.schema.json
+++ b/packages/contracts/tests/fixtures/dtcg-2025-10/format.schema.json
@@ -1,0 +1,1759 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "title": "DTCG Format Schema",
+  "description": "JSON Schema for the Design Tokens Community Group (DTCG) Format specification.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri-reference",
+      "description": "URI reference to this JSON schema.",
+      "$comment": "$schema is not part of the official DTCG specification."
+    },
+    "$type": {
+      "$ref": "https://www.designtokens.org/schemas/2025.10/format/tokenType.json"
+    },
+    "$description": {
+      "type": "string",
+      "description": "A plain text description of the group"
+    },
+    "$extensions": {
+      "type": "object",
+      "description": "Vendor-specific extensions"
+    },
+    "$extends": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/curlyBraceReference"
+        },
+        {
+          "$ref": "#/definitions/jsonPointerReference"
+        }
+      ],
+      "description": "Reference to another group to inherit tokens and properties from"
+    },
+    "$deprecated": {
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "description": "Whether this group is deprecated"
+    },
+    "$root": {
+      "$ref": "https://www.designtokens.org/schemas/2025.10/format/token.json"
+    }
+  },
+  "patternProperties": {
+    "^[^${}.][^{}.]*$": {
+      "$ref": "https://www.designtokens.org/schemas/2025.10/format/groupOrToken.json"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "tokenOrGroupName": {
+      "title": "Token or Group Name",
+      "type": "string",
+      "pattern": "^[^${}.][^{}.]*$",
+      "description": "Valid token/group names: must not start with $ and must not contain {, }, or ."
+    },
+    "curlyBraceReference": {
+      "title": "Curly Brace Reference",
+      "type": "string",
+      "pattern": "^\\{[^${}.][^{}.]*(\\.[^${}.][^{}.]*)*\\}$",
+      "description": "Curly brace reference (e.g., '{tokenName}' or '{group.nested.token}')"
+    },
+    "jsonPointerReference": {
+      "title": "JSON Pointer Reference",
+      "type": "string",
+      "pattern": "^#/",
+      "format": "json-pointer-uri-fragment",
+      "description": "JSON Pointer reference (RFC 6901) to a location in the document (e.g., '#/path/to/target')"
+    },
+    "jsonPointerReferenceObject": {
+      "title": "JSON Pointer Reference Object",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "$ref": "#/definitions/jsonPointerReference"
+        }
+      },
+      "required": ["$ref"],
+      "additionalProperties": false,
+      "description": "Object containing a JSON Pointer reference for property-level references"
+    },
+    "tokenValueReference": {
+      "title": "Token Value Reference",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/curlyBraceReference"
+        },
+        {
+          "$ref": "#/definitions/jsonPointerReferenceObject"
+        }
+      ],
+      "description": "A reference to a token value using either curly brace syntax or JSON Pointer syntax"
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/tokenType.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/tokenType.json",
+      "title": "TokenType",
+      "description": "A token type in the DTCG specification",
+      "type": "string",
+      "enum": [
+        "color",
+        "dimension",
+        "fontFamily",
+        "fontWeight",
+        "duration",
+        "cubicBezier",
+        "number",
+        "strokeStyle",
+        "border",
+        "transition",
+        "shadow",
+        "gradient",
+        "typography"
+      ]
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/token.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/token.json",
+      "title": "Token",
+      "description": "A token in the DTCG specification",
+      "type": "object",
+      "properties": {
+        "$value": {
+          "description": "The token's value - can be a direct value or a reference to another token using curly brace syntax (e.g., '{token.name}'). Mutually exclusive with $ref."
+        },
+        "$type": {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format/tokenType.json"
+        },
+        "$ref": {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReference"
+        },
+        "$description": {
+          "type": "string",
+          "description": "A plain text description of the token"
+        },
+        "$extensions": {
+          "type": "object",
+          "description": "Vendor-specific extensions"
+        },
+        "$deprecated": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Whether this token is deprecated"
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "description": "Tokens cannot define both $value and $ref; they must choose exactly one form of reference or direct value.",
+          "if": {
+            "required": ["$value"],
+            "properties": {
+              "$value": true
+            }
+          },
+          "then": {
+            "not": {
+              "required": ["$ref"],
+              "properties": {
+                "$ref": true
+              }
+            }
+          },
+          "else": {
+            "required": ["$ref"],
+            "properties": {
+              "$ref": true
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "color"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/color.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "dimension"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "fontFamily"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/fontFamily.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "fontWeight"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/fontWeight.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "duration"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/duration.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "cubicBezier"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/cubicBezier.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "number"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/number.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "strokeStyle"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/strokeStyle.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "border"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/border.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "transition"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/transition.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "shadow"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/shadow.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "gradient"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/gradient.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "typography"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/typography.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "allOf": [
+              {
+                "not": {
+                  "required": ["$type"]
+                }
+              },
+              {
+                "required": ["$value"]
+              },
+              {
+                "properties": {
+                  "$value": {
+                    "not": {
+                      "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/color.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/fontFamily.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/duration.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/cubicBezier.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/strokeStyle.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/border.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/transition.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/shadow.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/gradient.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/typography.json"
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/number.json"
+                      },
+                      {
+                        "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/fontWeight.json"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/color.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/color.json",
+      "title": "Color Value",
+      "description": "Value schema for color type tokens. Represents a color in a specific color space.",
+      "type": "object",
+      "properties": {
+        "colorSpace": {
+          "description": "The color space or color model used to represent the color",
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "srgb",
+                "srgb-linear",
+                "hsl",
+                "hwb",
+                "lab",
+                "lch",
+                "oklab",
+                "oklch",
+                "display-p3",
+                "a98-rgb",
+                "prophoto-rgb",
+                "rec2020",
+                "xyz-d65",
+                "xyz-d50"
+              ]
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "components": {
+          "description": "Array of color components. The number and meaning of components depend on the color space. Each component can be a number or the 'none' keyword.",
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "alpha": {
+          "description": "The alpha (transparency) value of the color. 0 is fully transparent, 1 is fully opaque. If omitted, defaults to 1.",
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "hex": {
+          "description": "Optional fallback value in 6-digit CSS hex color notation (e.g., '#ff00ff'). Must be 6 digits to avoid conflicts with the alpha value.",
+          "$comment": "Only JSON Pointer references (not curly brace references) are allowed for hex because no string token type exists in the specification that could be referenced with curly braces.",
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^#[0-9a-fA-F]{6}$"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        }
+      },
+      "required": ["colorSpace", "components"],
+      "additionalProperties": false,
+      "definitions": {
+        "zeroToOneComponent": {
+          "title": "Zero to One Component",
+          "description": "A color component normalized to the range [0-1] (e.g., RGB values, XYZ values)",
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            {
+              "type": "string",
+              "const": "none"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "hueComponent": {
+          "title": "Hue Component",
+          "description": "Hue angle from 0 up to (but not including) 360 degrees",
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0,
+              "exclusiveMaximum": 360
+            },
+            {
+              "type": "string",
+              "const": "none"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "percentageComponent": {
+          "title": "Percentage Component",
+          "description": "Percentage value from 0 to 100",
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 100
+            },
+            {
+              "type": "string",
+              "const": "none"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "chromaComponent": {
+          "title": "Chroma Component",
+          "description": "Chroma value from 0 to infinity",
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0
+            },
+            {
+              "type": "string",
+              "const": "none"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "unboundedComponent": {
+          "title": "Unbounded Component",
+          "description": "A color component with no numeric bounds (e.g., A and B in LAB/OKLAB color spaces)",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string",
+              "const": "none"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "rgbComponents": {
+          "title": "RGB Components",
+          "description": "Array of RGB color components [Red, Green, Blue], each normalized to the range [0-1]",
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": [
+            {
+              "$ref": "#/definitions/zeroToOneComponent"
+            },
+            {
+              "$ref": "#/definitions/zeroToOneComponent"
+            },
+            {
+              "$ref": "#/definitions/zeroToOneComponent"
+            }
+          ]
+        },
+        "xyzComponents": {
+          "title": "XYZ Components",
+          "description": "Array of XYZ color components [X, Y, Z], each normalized to the range [0-1]",
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": [
+            {
+              "$ref": "#/definitions/zeroToOneComponent"
+            },
+            {
+              "$ref": "#/definitions/zeroToOneComponent"
+            },
+            {
+              "$ref": "#/definitions/zeroToOneComponent"
+            }
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "srgb"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/rgbComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "srgb-linear"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/rgbComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "display-p3"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/rgbComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "a98-rgb"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/rgbComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "prophoto-rgb"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/rgbComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "rec2020"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/rgbComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "xyz-d65"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/xyzComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "xyz-d50"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/xyzComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "hsl"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "type": "array",
+                "minItems": 3,
+                "maxItems": 3,
+                "items": [
+                  {
+                    "$ref": "#/definitions/hueComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/percentageComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/percentageComponent"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "hwb"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "type": "array",
+                "minItems": 3,
+                "maxItems": 3,
+                "items": [
+                  {
+                    "$ref": "#/definitions/hueComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/percentageComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/percentageComponent"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "lab"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "type": "array",
+                "minItems": 3,
+                "maxItems": 3,
+                "items": [
+                  {
+                    "$ref": "#/definitions/percentageComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/unboundedComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/unboundedComponent"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "lch"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "type": "array",
+                "minItems": 3,
+                "maxItems": 3,
+                "items": [
+                  {
+                    "$ref": "#/definitions/percentageComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/chromaComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/hueComponent"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "oklab"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "type": "array",
+                "minItems": 3,
+                "maxItems": 3,
+                "items": [
+                  {
+                    "$ref": "#/definitions/zeroToOneComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/unboundedComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/unboundedComponent"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "oklch"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "type": "array",
+                "minItems": 3,
+                "maxItems": 3,
+                "items": [
+                  {
+                    "$ref": "#/definitions/zeroToOneComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/chromaComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/hueComponent"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json",
+      "title": "Dimension Value",
+      "description": "Value schema for dimension type tokens. Represents an amount of distance in a single dimension in the UI, such as a position, width, height, radius, or thickness.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "An integer or floating-point value representing the numeric value.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "unit": {
+          "description": "Unit of distance. Supported values: 'px' (idealized pixel, equivalent to dp on Android and pt on iOS), 'rem' (multiple of system's default font size).",
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["px", "rem"]
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        }
+      },
+      "required": ["value", "unit"],
+      "additionalProperties": false
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/fontFamily.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/fontFamily.json",
+      "title": "Font Family Value",
+      "description": "Value schema for fontFamily type tokens. Represents a font name or an array of font names (ordered from most to least preferred).",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "A single font name",
+          "not": {
+            "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/curlyBraceReference"
+          }
+        },
+        {
+          "type": "array",
+          "description": "An array of font names, ordered from most to least preferred",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string",
+                "not": {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/curlyBraceReference"
+                }
+              },
+              {
+                "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+              }
+            ]
+          },
+          "minItems": 1
+        }
+      ]
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/fontWeight.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/fontWeight.json",
+      "title": "Font Weight Value",
+      "description": "Value schema for fontWeight type tokens. Represents a font weight as per the OpenType wght tag specification. Lower numbers represent lighter weights, higher numbers represent thicker weights.",
+      "oneOf": [
+        {
+          "type": "number",
+          "description": "Numeric font weight value",
+          "minimum": 1,
+          "maximum": 1000
+        },
+        {
+          "type": "string",
+          "description": "Pre-defined font weight string value",
+          "enum": [
+            "thin",
+            "hairline",
+            "extra-light",
+            "ultra-light",
+            "light",
+            "normal",
+            "regular",
+            "book",
+            "medium",
+            "semi-bold",
+            "demi-bold",
+            "bold",
+            "extra-bold",
+            "ultra-bold",
+            "black",
+            "heavy",
+            "extra-black",
+            "ultra-black"
+          ]
+        }
+      ]
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/duration.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/duration.json",
+      "title": "Duration Value",
+      "description": "Value schema for duration type tokens. Represents the length of time in milliseconds an animation or animation cycle takes to complete.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "An integer or floating-point value representing the numeric value.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "unit": {
+          "description": "Unit of time. Supported values: 'ms' (millisecond), 's' (second).",
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["ms", "s"]
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        }
+      },
+      "required": ["value", "unit"],
+      "additionalProperties": false
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/cubicBezier.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/cubicBezier.json",
+      "title": "Cubic Bezier Value",
+      "description": "Value schema for cubicBezier type tokens. Represents how the value of an animated property progresses towards completion over the duration of an animation, effectively creating visual effects such as acceleration, deceleration, and bounce.",
+      "type": "array",
+      "items": [
+        {
+          "$ref": "#/definitions/xCoordinate"
+        },
+        {
+          "$ref": "#/definitions/yCoordinate"
+        },
+        {
+          "$ref": "#/definitions/xCoordinate"
+        },
+        {
+          "$ref": "#/definitions/yCoordinate"
+        }
+      ],
+      "additionalItems": false,
+      "minItems": 4,
+      "maxItems": 4,
+      "definitions": {
+        "xCoordinate": {
+          "title": "X Coordinate",
+          "description": "X coordinate of control point (must be between 0 and 1)",
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "yCoordinate": {
+          "title": "Y Coordinate",
+          "description": "Y coordinate of control point (can be any real number)",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        }
+      }
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/number.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/number.json",
+      "title": "Number Value",
+      "description": "Value schema for number type tokens. Numbers can be positive, negative and have fractions. Example uses are gradient stop positions or unitless line heights.",
+      "type": "number"
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/strokeStyle.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/strokeStyle.json",
+      "title": "Stroke Style Value",
+      "description": "Value schema for strokeStyle type tokens. Represents the style applied to lines or borders.",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "solid",
+            "dashed",
+            "dotted",
+            "double",
+            "groove",
+            "ridge",
+            "outset",
+            "inset"
+          ],
+          "description": "Pre-defined stroke style values with the same meaning as CSS line style values"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "dashArray": {
+              "description": "Array of dimension values specifying lengths of alternating dashes and gaps",
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+                      },
+                      {
+                        "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                      }
+                    ]
+                  },
+                  "minItems": 1
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+                }
+              ]
+            },
+            "lineCap": {
+              "description": "Line cap style, same meaning as SVG stroke-linecap attribute",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": ["round", "butt", "square"]
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+                }
+              ]
+            }
+          },
+          "required": ["dashArray", "lineCap"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/border.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/border.json",
+      "title": "Border Value",
+      "description": "Value schema for border type tokens. Represents a border style.",
+      "type": "object",
+      "properties": {
+        "color": {
+          "description": "The color of the border",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/color.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "width": {
+          "description": "The width or thickness of the border",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "style": {
+          "description": "The border's style",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/strokeStyle.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        }
+      },
+      "required": ["color", "width", "style"],
+      "additionalProperties": false
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/transition.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/transition.json",
+      "title": "Transition Value",
+      "description": "Value schema for transition type tokens. Represents an animated transition between two states.",
+      "type": "object",
+      "properties": {
+        "duration": {
+          "description": "The duration of the transition",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/duration.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "delay": {
+          "description": "The time to wait before the transition begins",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/duration.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "timingFunction": {
+          "description": "The timing function of the transition",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/cubicBezier.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        }
+      },
+      "required": ["duration", "delay", "timingFunction"],
+      "additionalProperties": false
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/shadow.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/shadow.json",
+      "title": "Shadow Value",
+      "description": "Value schema for shadow type tokens. Represents a shadow style.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/shadowObject"
+        },
+        {
+          "type": "array",
+          "description": "Array of shadow objects and/or references to shadow tokens",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/shadowObject"
+              },
+              {
+                "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+              }
+            ]
+          },
+          "minItems": 1
+        }
+      ],
+      "definitions": {
+        "shadowObject": {
+          "title": "Shadow Object",
+          "type": "object",
+          "properties": {
+            "color": {
+              "description": "The color of the shadow",
+              "oneOf": [
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/color.json"
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                }
+              ]
+            },
+            "offsetX": {
+              "description": "The horizontal offset that shadow has from the element it is applied to",
+              "oneOf": [
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                }
+              ]
+            },
+            "offsetY": {
+              "description": "The vertical offset that shadow has from the element it is applied to",
+              "oneOf": [
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                }
+              ]
+            },
+            "blur": {
+              "description": "The blur radius that is applied to the shadow",
+              "oneOf": [
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                }
+              ]
+            },
+            "spread": {
+              "description": "The amount by which to expand or contract the shadow",
+              "oneOf": [
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                }
+              ]
+            },
+            "inset": {
+              "description": "Whether this shadow is inside the containing shape (inner shadow) rather than a drop shadow (default: false)",
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+                }
+              ]
+            }
+          },
+          "required": ["color", "offsetX", "offsetY", "blur", "spread"],
+          "additionalProperties": false
+        }
+      }
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/gradient.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/gradient.json",
+      "title": "Gradient Value",
+      "description": "Value schema for gradient type tokens. Represents a color gradient.",
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/gradientStop"
+          },
+          {
+            "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+          }
+        ]
+      },
+      "minItems": 1,
+      "definitions": {
+        "gradientStop": {
+          "title": "Gradient Stop",
+          "type": "object",
+          "properties": {
+            "color": {
+              "description": "The color value at the stop's position on the gradient",
+              "oneOf": [
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/color.json"
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                }
+              ]
+            },
+            "position": {
+              "description": "The position of the stop along the gradient's axis (range [0, 1]). Values outside this range are clamped.",
+              "oneOf": [
+                {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 1
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                }
+              ]
+            }
+          },
+          "required": ["color", "position"],
+          "additionalProperties": false
+        }
+      }
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/typography.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/typography.json",
+      "title": "Typography Value",
+      "description": "Value schema for typography type tokens. Represents a typographic style.",
+      "type": "object",
+      "properties": {
+        "fontFamily": {
+          "description": "The typography's font",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/fontFamily.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "fontSize": {
+          "description": "The size of the typography",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "fontWeight": {
+          "description": "The weight of the typography",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/fontWeight.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "letterSpacing": {
+          "description": "The horizontal spacing between characters",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "lineHeight": {
+          "description": "The vertical spacing between lines of typography (interpreted as a multiplier of fontSize)",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/number.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        }
+      },
+      "required": [
+        "fontFamily",
+        "fontSize",
+        "fontWeight",
+        "letterSpacing",
+        "lineHeight"
+      ],
+      "additionalProperties": false
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/groupOrToken.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/groupOrToken.json",
+      "title": "Group or Token",
+      "description": "A group or a token in the DTCG specification. A token is identified by the presence of a $value property, while a group is any object without a $value property.",
+      "oneOf": [
+        {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format/group.json"
+        },
+        {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format/token.json"
+        }
+      ]
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/group.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/group.json",
+      "title": "Group",
+      "description": "A group in the DTCG specification",
+      "type": "object",
+      "properties": {
+        "$type": {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format/tokenType.json"
+        },
+        "$description": {
+          "type": "string",
+          "description": "A plain text description of the group"
+        },
+        "$extensions": {
+          "type": "object",
+          "description": "Vendor-specific extensions"
+        },
+        "$extends": {
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/curlyBraceReference"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReference"
+            }
+          ],
+          "description": "Reference to another group to inherit tokens and properties from"
+        },
+        "$deprecated": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Whether this group is deprecated"
+        },
+        "$root": {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format/token.json"
+        }
+      },
+      "patternProperties": {
+        "^[^${}.][^{}.]*$": {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format/groupOrToken.json"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -510,6 +510,9 @@ importers:
         specifier: 3.25.76
         version: 3.25.76
     devDependencies:
+      ajv:
+        specifier: 8.20.0
+        version: 8.20.0
       esbuild:
         specifier: 0.28.0
         version: 0.28.0


### PR DESCRIPTION
Refs #6228

## Why

I want Open Design design systems to exchange tokens through the stable DTCG format without coupling the protocol to daemon I/O, UI state, or prompt atoms. Today the only structured token document is the proprietary `od-design-tokens/v1` derivative, so later import/export work has no standards-conformant parser, semantic validator, or resolver to build on.

This PR establishes that internal foundation as the first reviewable slice of #6228. It targets only the stable 2025.10 Final Community Group Reports and deliberately excludes project import, export UI, CLI commands, the separate Resolver module, and Penpot/Tokens Studio compatibility.

## What users will see

No user-facing change. This adds an internal `@open-design/contracts/design-systems/dtcg-2025-10` entry point for later import and export slices.

The new pure TypeScript contract:

- parses and deterministically serializes stable Format 2025.10 documents;
- validates all 13 stable token types and all stable Color 2025.10 color spaces;
- resolves group type/deprecation inheritance, `$root`, `$extends`, curly aliases, token-level `$ref`, RFC 6901 JSON Pointers, and property-level references;
- rejects missing targets, wrong reference types, malformed values, and reference/extension cycles with JSON-Pointer-addressed diagnostics;
- keeps the original document, extension metadata, and source references separate from resolved values;
- preserves provenance for tokens inherited through nested group extensions;
- omits non-normative Format `$schema` metadata by default, while allowing the correct versioned schema URL when explicitly requested.

The Format report contains contradictory guidance for gradient references inside arrays: it forbids flattening but demonstrates one-stop gradient tokens as array elements. The codec implements the narrow interoperable interpretation: a referenced one-stop gradient becomes one stop; multi-stop targets are rejected rather than silently flattened.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

Ajv is added only to `packages/contracts` devDependencies. It validates emitted fixtures against a pinned copy of the official versioned schema during tests and contributes no runtime or web bundle bytes. Product runtime performs no schema or reference network requests.

The pinned schema fixture includes source, SHA-256, and W3C 3-clause BSD attribution. Normative report text remains authoritative when it conflicts with the later schema.

## Screenshots

Not applicable; this PR has no UI surface.

## Bug fix verification

- Not a bug fix.

## Validation

- `pnpm --filter @open-design/contracts build`
- `pnpm --filter @open-design/contracts test` (34 files, 246 tests)
- `pnpm --filter @open-design/contracts typecheck`
- `pnpm typecheck`
- `pnpm guard` (78 guard tests)
- `git diff --check origin/main...HEAD`
