### PR TITLE
test(web): update ProjectView comment-status suites to the workspace-scoped signature

### DIFF
--- a/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
+++ b/apps/web/tests/components/ProjectView.api-empty-response.test.tsx
@@ -465,11 +465,17 @@ describe('ProjectView API empty response handling', () => {
     await sendTestPrompt();
 
     await waitFor(() => {
+      // `patchPreviewCommentStatus` takes the acting workspace context as a
+      // fifth argument (1c15574c2), so the daemon can authorize the comment
+      // mutation. This harness has no cloud identity, so it is `null` — but the
+      // argument must still be matched: a four-argument matcher cannot match a
+      // five-argument call at all.
       expect(mockedPatchPreviewCommentStatus).toHaveBeenCalledWith(
         project.id,
         'conv-project-1',
         'comment-1',
         'failed',
+        null,
       );
     });
     await waitFor(() => {

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -3766,6 +3766,7 @@ describe('ProjectView daemon cleanup', () => {
         'conv-1',
         'comment-1',
         'needs_review',
+        null,
       );
     });
   });

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -1726,6 +1726,7 @@ describe('ProjectView conversation run isolation', () => {
         'conv-a',
         previewComment.id,
         'applying',
+        null,
       ),
     );
     patchPreviewCommentStatus.mockClear();
@@ -1740,11 +1741,15 @@ describe('ProjectView conversation run isolation', () => {
     await waitFor(() => expect(screen.getByTestId('streaming-state').textContent).toBe('streaming'));
     expect(screen.getByTestId('workspace-streaming-state').textContent).toBe('streaming');
     expect(screen.getByTestId('conversation-latest-runs').textContent).toContain('conv-a:running');
+    // The workspace-context argument matters MOST on a negative assertion: a
+    // four-argument matcher can never match the real five-argument call, so
+    // omitting it would make this pass no matter what the code did.
     expect(patchPreviewCommentStatus).not.toHaveBeenCalledWith(
       'project-1',
       'conv-a',
       previewComment.id,
       'needs_review',
+      null,
     );
     expect(fetchProjectFiles).not.toHaveBeenCalled();
     expect(streamViaDaemon).toHaveBeenLastCalledWith(expect.objectContaining({
@@ -1973,6 +1978,9 @@ describe('ProjectView conversation run isolation', () => {
         expect.anything(),
         previewComment.id,
         'applying',
+        // Explicit `null`, not `expect.anything()`: that matcher rejects
+        // null/undefined, so it would never match this harness's context.
+        null,
       ),
     );
     await waitFor(() => expect(screen.getByTestId('send-queued-0')).toBeTruthy());
@@ -1986,11 +1994,13 @@ describe('ProjectView conversation run isolation', () => {
     fireEvent.click(screen.getByTestId('send-queued-0'));
     await waitFor(() => expect(streamViaDaemon).toHaveBeenCalled());
 
+    // Arity matters on the negative assertion — see the note above.
     expect(patchPreviewCommentStatus).not.toHaveBeenCalledWith(
       expect.anything(),
       expect.anything(),
       previewComment.id,
       'open',
+      null,
     );
   });
 


### PR DESCRIPTION
## Why

`feat/workspace-team` has a red `Web workspace tests` lane: 3 files / 4 tests failing, all comment-status assertions. It is not a flake and not attributable to any open PR — the branch tip itself fails.

I hit the cost of this directly: while landing #6225 I had to prove, twice, that a red lane on my PR was inherited rather than mine (byte-identical failure lists against the base tip). A base whose gate lane is red makes every downstream PR's signal unreadable, and there is a beta build waiting behind it.

Cause: two commits landed together —

- `1c15574c2 fix(comments): preserve rejected mutations`
- `6414247e0 fix(comments): preserve partial send results`

They rewrote `ProjectView.tsx` comment-status handling and `comment-send-result.ts`, and added `patchPreviewCommentStatus`'s **fifth argument, the acting workspace context**, so the daemon can authorize the mutation (`apps/daemon/src/routes/project/comments.ts` in the same commit). They updated `FileViewer.test.tsx` and added new `registry.test.ts` coverage, but left three `ProjectView.*` suites on the old four-argument signature.

## The tests were stale, not the code

I checked this before touching anything, because "update the tests" is the wrong move if the assertions were right.

**The code is correct.** Three independent pieces of evidence:

1. **Every asserted call still happens, unchanged.** The failures are pure arity mismatches — e.g. `api-empty-response` expects `(…, 'comment-1', 'failed')` and the received 2nd call is `(…, 'comment-1', 'failed', null)`. Same for `needs_review` in `run-cleanup` (received as the 4th call) and `applying` in `run-isolation`. No status transition changed; only the signature grew.
2. **`1c15574c2` shipped the new contract with its own tests** — `apps/web/tests/providers/registry.test.ts` gained `describe('preview comment scoped mutations')` with `it('attaches workspace identity headers to status updates')` asserting `x-od-workspace-id` / `x-od-workspace-member-id` reach the PATCH. The fifth argument is deliberate and covered.
3. **The signature is explicitly optional and additive**: `patchPreviewCommentStatus(projectId, conversationId, commentId, status, workspaceContext?)`, spreading `workspaceProjectHeaders(workspaceContext)` only when present.

So this PR updates the three suites to the new contract. **No source file is touched.**

## Two `not.toHaveBeenCalledWith` assertions had gone silently vacuous

Worth calling out, because it is the part that was actively losing coverage rather than merely failing.

`ProjectView.run-isolation.test.tsx` has two negative assertions. A four-argument matcher **cannot match a five-argument call**, so once the signature grew they could never match anything and passed unconditionally — they would not have caught the regressions they exist to catch. Restoring their arity makes them live again.

Both pass with the correct arity, which is itself the answer to "is the new code wrong?": the code genuinely does not write `needs_review` after a canceled+done run, and does not reset a queued send's own comment to `open`.

The fifth argument is matched as an explicit `null` rather than `expect.anything()` throughout, because `expect.anything()` rejects `null`/`undefined` — using it would have re-broken the positive assertions and re-vacuated the negative ones. These harnesses have no cloud identity, so `null` is the true value.

## What users will see

Nothing. Test-only change; no source, no behaviour, no UI.

## Surface area

- [ ] UI
- [ ] Keyboard shortcut
- [ ] CLI / env var
- [ ] API / contract
- [ ] Extension point
- [ ] i18n keys
- [ ] New top-level dependency
- [ ] Default behavior change
- [x] **None** — tests only (three `ProjectView.*` suites, +17 lines, no source changes)

## Bug fix verification

Red before, green after, on the branch tip itself:

```
BEFORE (feat/workspace-team @ f1c8ba8e5)
  EXIT=1
  Test Files  3 failed (3)
  Tests  4 failed | 143 passed (147)

  FAIL ProjectView.api-empty-response > marks attached saved comments as failed when an API completion has no output
  FAIL ProjectView.run-cleanup        > restores attached comment statuses when a live generic disconnect later proves succeeded
  FAIL ProjectView.run-isolation      > ignores completion side effects when the interrupted run reports canceled and done late
  FAIL ProjectView.run-isolation      > does not reset a queued send's own comment status when send-now flushes it

AFTER
  EXIT=0
  Test Files  3 passed (3)
  Tests  147 passed (147)
```

Arity is what carries the fix: the same real calls fail a four-argument matcher and pass a five-argument one. That is also precisely why the two negative assertions were dead and are now live.

## Validation

- The three suites individually: **147/147, exit 0** (was 4 failed / 143 passed)
- `pnpm --filter @open-design/web typecheck` — **exit 0**
- `pnpm guard` — **exit 0**
- `pnpm --filter @open-design/web test` — full suite; exit codes captured **unpiped**, since a piped run reports the last pipeline stage's status rather than vitest's

One caveat recorded for honesty: on a sandboxed runner the full suite also reports two failures in `tests/sidecar-proxy.test.ts` with `listen EPERM: operation not permitted 127.0.0.1`, and `pnpm guard` fails there with `listen EPERM … tsx-501/…​.pipe`. Both are the sandbox refusing to bind sockets/named pipes, not this change: that file passes **21/21 in isolation**, `guard` exits **0** unsandboxed, and neither touches comment code. Flagged rather than omitted so the numbers can be reconciled if CI's runner behaves the same way.

## Scope

Deliberately limited to the three suites the two commits left behind. I did not touch `ProjectView.tsx`, `comment-send-result.ts`, `providers/registry.ts`, or any daemon file — the source behaviour is correct and re-litigating it here would widen a gate-unblocking fix into a behaviour review.
