### PR TITLE
fix(docker): ship design-templates in the container image

### DIFF
--- a/apps/daemon/tests/deploy-dockerfile-catalogs.test.ts
+++ b/apps/daemon/tests/deploy-dockerfile-catalogs.test.ts
@@ -1,0 +1,49 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Catalogs the daemon resolves from DAEMON_RESOURCE_ROOT (see the
+ * `resolveDaemonResourceDir` calls in `apps/daemon/src/server.ts`). In a
+ * container the resource root is `/app`, so every one of these has to be
+ * copied into the runtime image — otherwise the directory is simply absent
+ * and the corresponding catalog reads as empty at runtime, with no error.
+ *
+ * `design-templates` was missing here, which is why `/api/design-templates`
+ * returned `[]` on every Docker install while desktop installs were fine.
+ */
+const RESOURCE_CATALOGS = [
+  'skills',
+  'design-systems',
+  'design-templates',
+  'craft',
+  'prompt-templates',
+  'assets/frames',
+  'assets/community-pets',
+  'plugins/_official',
+];
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../../..');
+
+function runtimeStage(dockerfile: string): string {
+  // The runtime stage is the last `FROM` in the file; everything the image
+  // actually ships is copied after it.
+  const lastFrom = dockerfile.lastIndexOf('\nFROM ');
+  expect(lastFrom).toBeGreaterThan(-1);
+  return dockerfile.slice(lastFrom);
+}
+
+describe('deploy/Dockerfile', () => {
+  const dockerfile = fs.readFileSync(path.join(REPO_ROOT, 'deploy', 'Dockerfile'), 'utf8');
+
+  it.each(RESOURCE_CATALOGS)('ships %s into the runtime image', (catalog) => {
+    const stage = runtimeStage(dockerfile);
+    const copiesCatalog = stage
+      .split('\n')
+      .some((line) => line.startsWith('COPY ') && line.trimEnd().endsWith(`./${catalog}`));
+
+    expect(copiesCatalog, `deploy/Dockerfile never copies ${catalog} into the runtime image`).toBe(
+      true,
+    );
+  });
+});

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -74,6 +74,7 @@ RUN pnpm --filter @open-design/daemon build && \
 COPY skills ./skills
 COPY design-systems ./design-systems
 COPY craft ./craft
+COPY design-templates ./design-templates
 COPY prompt-templates ./prompt-templates
 COPY assets ./assets
 COPY plugins/_official ./plugins/_official
@@ -90,6 +91,7 @@ COPY --from=build --chown=open-design:open-design /app/apps/web/out ./apps/web/o
 COPY --from=build --chown=open-design:open-design /app/skills ./skills
 COPY --from=build --chown=open-design:open-design /app/design-systems ./design-systems
 COPY --from=build --chown=open-design:open-design /app/craft ./craft
+COPY --from=build --chown=open-design:open-design /app/design-templates ./design-templates
 COPY --from=build --chown=open-design:open-design /app/prompt-templates ./prompt-templates
 COPY --from=build --chown=open-design:open-design /app/assets/frames ./assets/frames
 COPY --from=build --chown=open-design:open-design /app/assets/community-pets ./assets/community-pets


### PR DESCRIPTION
## Why

Hit this while running OD as a shared design-review server for my team — the template gallery was simply empty in the browser, with nothing in the logs to explain it. Turned out to be Docker-only: `deploy/Dockerfile` copies `skills`, `design-systems`, `craft` and `prompt-templates` into the image but never copies `design-templates`, while the daemon still resolves `DESIGN_TEMPLATES_DIR` to `<resource root>/design-templates`.

A missing `COPY` has no failure mode at runtime — the directory is just absent and the catalog reads as empty — so this fails silently rather than loudly.

## What users will see

Docker and Compose users get the bundled design templates back. Before this change `/api/design-templates` returned `[]` on every container install and the template gallery in the UI was blank; after it, the same install lists the bundled templates (**125** on current `main`), matching what a desktop install of the same version already showed. No change for desktop users, and nothing to opt into.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — packaging fix plus a test; no source or contract change.

The only user-visible effect is that an endpoint which already exists stops returning an empty list on container installs. Image size grows by the size of `design-templates/`.

## Bug fix verification

- Test path: `apps/daemon/tests/deploy-dockerfile-catalogs.test.ts`
- Did it go red on `main` and green on this branch? **yes**

The test asserts that every catalog the daemon resolves from `DAEMON_RESOURCE_ROOT` (`skills`, `design-systems`, `design-templates`, `craft`, `prompt-templates`, `assets/frames`, `assets/community-pets`, `plugins/_official`) is copied into the runtime stage — so the next catalog added to the resolver cannot silently go unshipped either.

With `deploy/Dockerfile` from `main`:

```console
 × ships design-templates into the runtime image
AssertionError: deploy/Dockerfile never copies design-templates into the runtime image
Tests  1 failed | 7 passed (8)
```

With the fix in this branch:

```console
Test Files  1 passed (1)
     Tests  8 passed (8)
```

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/daemon exec vitest run tests/deploy-dockerfile-catalogs.test.ts` — pass (8)
- Built this branch and booted the image, then confirmed end to end:

```console
$ curl -s localhost:7457/api/design-templates | jq ".designTemplates | length"
125
```

Also reproduced the original bug against the published image, so it is not specific to locally built ones:

```console
$ docker run --rm -d -p 7457:7457 -e OD_DISABLE_API_AUTH=1 \
    -e OD_PORT=7457 -e OD_BIND_HOST=0.0.0.0 ghcr.io/nexu-io/od
$ curl -s localhost:7457/api/design-templates
{"designTemplates":[]}
```