### PR TITLE
fix(tools-pack): carry workspace build key into tarballs

### DIFF
--- a/tools/pack/CACHE.md
+++ b/tools/pack/CACHE.md
@@ -72,10 +72,11 @@ Re-deriving an upstream node's own inputs is not a substitute: upstream keys
 carry inputs that are not file content (see R3), so re-derivation silently
 drops them.
 
-Existing links: `win.packaged-app` carries `tarballsKey`;
-`win.electron-builder-dir` carries `packagedAppKey` and `resourceTreeKey`;
-`win.nsis-installer` carries `basePayloadKey` and `overlayPayloadKey`;
-`win.launcher-payload` carries `sourceKey`.
+Existing links: `win.workspace-tarballs` carries `workspaceBuildKey`;
+`win.packaged-app` carries `tarballsKey`; `win.electron-builder-dir` carries
+`packagedAppKey` and `resourceTreeKey`; `win.nsis-installer` carries
+`basePayloadKey` and `overlayPayloadKey`; `win.launcher-payload` carries
+`sourceKey`.
 
 **R3 — Build outputs are never direct key inputs.** `hashPackageSourcePath`
 excludes `dist`, `.next`, `out`, `node_modules`, and `.od`. A node that

--- a/tools/pack/src/win/app.ts
+++ b/tools/pack/src/win/app.ts
@@ -146,13 +146,16 @@ async function buildWorkspaceArtifacts(config: ToolPackConfig): Promise<void> {
   await runPnpm(config, ["--filter", "@open-design/packaged", "build"]);
 }
 
-export async function ensureWinWorkspaceBuild(config: ToolPackConfig, cache: ToolPackCache): Promise<void> {
-  await ensureWorkspaceBuildArtifacts(config, cache, async () => {
+export async function ensureWinWorkspaceBuild(config: ToolPackConfig, cache: ToolPackCache): Promise<string> {
+  return ensureWorkspaceBuildArtifacts(config, cache, async () => {
     await buildWorkspaceArtifacts(config);
   });
 }
 
-export async function createWorkspaceTarballsCacheKey(config: ToolPackConfig): Promise<string> {
+export async function createWorkspaceTarballsCacheKey(
+  config: ToolPackConfig,
+  workspaceBuildKey: string,
+): Promise<string> {
   const packageHashes: Record<string, string> = {};
   for (const packageInfo of INTERNAL_PACKAGES) {
     packageHashes[packageInfo.name] = await hashPackageSourcePath(join(config.workspaceRoot, packageInfo.directory));
@@ -167,8 +170,9 @@ export async function createWorkspaceTarballsCacheKey(config: ToolPackConfig): P
     packageManager: rootPackageJson.packageManager,
     pnpmLock: await hashPath(join(config.workspaceRoot, "pnpm-lock.yaml")),
     prebundle: shouldUseWinStandalonePrebundle(config.webOutputMode),
-    schemaVersion: 6,
+    schemaVersion: 7,
     webOutputMode: config.webOutputMode,
+    workspaceBuildKey,
   });
 }
 
@@ -176,8 +180,9 @@ export async function collectWorkspaceTarballs(
   config: ToolPackConfig,
   paths: WinPaths,
   cache: ToolPackCache,
+  workspaceBuildKey: string,
 ): Promise<PackedTarballsCacheResult> {
-  const key = await createWorkspaceTarballsCacheKey(config);
+  const key = await createWorkspaceTarballsCacheKey(config, workspaceBuildKey);
   const node = {
     id: "win.workspace-tarballs",
     key,

--- a/tools/pack/src/win/build.ts
+++ b/tools/pack/src/win/build.ts
@@ -96,16 +96,16 @@ export async function packWin(config: ToolPackConfig): Promise<WinPackResult> {
       await rm(paths.setupZipPath, { force: true });
     }
   });
-  await runPhase("workspace-build", async () => {
-    await ensureWinWorkspaceBuild(config, cache);
-  });
+  const workspaceBuildKey = await runPhase("workspace-build", async () => ensureWinWorkspaceBuild(config, cache));
   const resourceTree = await runPhase("resource-tree", async () =>
     prepareResourceTree(config, paths, cache, { materialize: config.to !== "dir" })
   );
   await runPhase("win-icon", async () => {
     await copyWinIcon(paths);
   });
-  const tarballs = await runPhase("workspace-tarballs", async () => collectWorkspaceTarballs(config, paths, cache));
+  const tarballs = await runPhase("workspace-tarballs", async () =>
+    collectWorkspaceTarballs(config, paths, cache, workspaceBuildKey)
+  );
   const packagedAppKey = await createWinPackagedAppCacheKey(config, tarballs.key, tarballs.tarballs);
   let packagedAppRoot: string | null = null;
   await runPhase("electron-builder", async () => {

--- a/tools/pack/src/workspace-build.ts
+++ b/tools/pack/src/workspace-build.ts
@@ -306,7 +306,7 @@ export async function ensureWorkspaceBuildArtifacts(
   config: ToolPackConfig,
   cache: ToolPackCache,
   build: () => Promise<void>,
-): Promise<void> {
+): Promise<string> {
   const key = await createWorkspaceBuildCacheKey(config);
   const nodeId = `${config.platform}.workspace-build`;
   const artifacts = workspaceBuildArtifacts(config);
@@ -364,4 +364,5 @@ export async function ensureWorkspaceBuildArtifacts(
     },
     seedFrom: versionFamilyAlias == null ? [] : [{ aliasKey: versionFamilyAlias, materialize }],
   });
+  return key;
 }

--- a/tools/pack/tests/win-app.test.ts
+++ b/tools/pack/tests/win-app.test.ts
@@ -58,15 +58,93 @@ function createConfig(root: string, webOutputMode: ToolPackConfig["webOutputMode
 }
 
 describe("createWorkspaceTarballsCacheKey", () => {
+  it("invalidates when any packed package source changes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-app-"));
+
+    try {
+      await writeWorkspace(root);
+      const config = createConfig(root, "server");
+      const baseline = await createWorkspaceTarballsCacheKey(config, "workspace-build");
+
+      for (const directory of PACKAGE_DIRS) {
+        const sourcePath = join(root, directory, "src", "index.ts");
+        await writeFile(sourcePath, "export const value = 2;\n", "utf8");
+        await expect(createWorkspaceTarballsCacheKey(config, "workspace-build")).resolves.not.toBe(baseline);
+        await writeFile(sourcePath, "export const value = 1;\n", "utf8");
+      }
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("invalidates when package manager or lockfile inputs change", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-app-"));
+
+    try {
+      await writeWorkspace(root);
+      const config = createConfig(root, "server");
+      const baseline = await createWorkspaceTarballsCacheKey(config, "workspace-build");
+
+      await writeFile(
+        join(root, "package.json"),
+        `${JSON.stringify({ packageManager: "pnpm@10.34.0" }, null, 2)}\n`,
+        "utf8",
+      );
+      await expect(createWorkspaceTarballsCacheKey(config, "workspace-build")).resolves.not.toBe(baseline);
+
+      await writeFile(
+        join(root, "package.json"),
+        `${JSON.stringify({ packageManager: "pnpm@10.33.2" }, null, 2)}\n`,
+        "utf8",
+      );
+      await writeFile(join(root, "pnpm-lock.yaml"), "lockfileVersion: '9.1'\n", "utf8");
+      await expect(createWorkspaceTarballsCacheKey(config, "workspace-build")).resolves.not.toBe(baseline);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("invalidates when the upstream workspace build key changes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-app-"));
+
+    try {
+      await writeWorkspace(root);
+      const config = createConfig(root, "server");
+      const firstKey = await createWorkspaceTarballsCacheKey(config, "workspace-build-a");
+      const secondKey = await createWorkspaceTarballsCacheKey(config, "workspace-build-b");
+
+      expect(firstKey).not.toBe(secondKey);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
   it("invalidates when the web output mode changes", async () => {
     const root = await mkdtemp(join(tmpdir(), "open-design-win-app-"));
 
     try {
       await writeWorkspace(root);
+      const serverKey = await createWorkspaceTarballsCacheKey(createConfig(root, "server"), "workspace-build");
+      const standaloneKey = await createWorkspaceTarballsCacheKey(createConfig(root, "standalone"), "workspace-build");
 
-      await expect(createWorkspaceTarballsCacheKey(createConfig(root, "server"))).resolves.not.toBe(
-        await createWorkspaceTarballsCacheKey(createConfig(root, "standalone")),
-      );
+      expect(serverKey).not.toBe(standaloneKey);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("ignores packed package build outputs because the upstream key carries their identity", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-app-"));
+
+    try {
+      await writeWorkspace(root);
+      const config = createConfig(root, "server");
+      const baseline = await createWorkspaceTarballsCacheKey(config, "workspace-build");
+
+      await mkdir(join(root, PACKAGE_DIRS[0]!, "dist"), { recursive: true });
+      await writeFile(join(root, PACKAGE_DIRS[0]!, "dist", "index.js"), "export const built = 1;\n", "utf8");
+
+      await expect(createWorkspaceTarballsCacheKey(config, "workspace-build")).resolves.toBe(baseline);
     } finally {
       await rm(root, { force: true, recursive: true });
     }


### PR DESCRIPTION
## Why

While auditing the packaged build cache before broadening the surrounding GitHub Actions restore policy, I found that `win.workspace-tarballs` consumes outputs from `<platform>.workspace-build` without carrying that upstream node's key.

That leaves a reachable stale-cache path: a build-command or Node-version change can alter `dist` / `.next` outputs while package source hashes remain unchanged, so the tarballs node accepts an entry made from the previous workspace build. This violates the R2 Merkle-link rule documented in `tools/pack/CACHE.md` and blocks treating the node as safe for cross-run reuse.

## What users will see

No user-facing change. Packaged Windows builds may rebuild workspace tarballs more often when their upstream workspace build identity changes; those misses are intentional correctness invalidations.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding a new root dependency
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable.

## Bug fix verification

- Test path: `tools/pack/tests/win-app.test.ts` — `invalidates when the upstream workspace build key changes`.
- Red on `main`: yes. Before the source change, the new witness failed because both upstream keys produced the same tarballs key.
- Green on this branch: yes.
- The witness suite also mutates every packed package source, package-manager metadata, the lockfile, web output mode, and the upstream key, while proving a package `dist` tree remains a non-input.

## Validation

- `pnpm --filter @open-design/tools-pack exec vitest run tests/workspace-build.test.ts tests/win-app.test.ts`
- `pnpm --filter @open-design/tools-pack test` — 252 passed, 8 skipped
- `pnpm --filter @open-design/tools-pack typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
