### PR TITLE
fix(daemon): continue stalled post-tool sessions

### DIFF
--- a/apps/daemon/src/run-retry-policy.ts
+++ b/apps/daemon/src/run-retry-policy.ts
@@ -13,6 +13,12 @@ import type {
 // with attempt_limit_reached).
 export const DEFAULT_SAFE_RUN_RETRY_MAX_ATTEMPTS = 1;
 export const SAFE_RUN_RETRY_STRATEGY: TrackingRunRetryStrategy = 'same_run_transient';
+export const NATIVE_SESSION_CONTINUE_STRATEGY: TrackingRunRetryStrategy =
+  'native_session_continue';
+export const POST_TOOL_RESUME_CONTINUATION_PROMPT =
+  'Continue the interrupted turn from the current native session. ' +
+  'Treat every tool result already committed in this session as completed and do not repeat those tool calls. ' +
+  'Continue from the latest tool result and finish the original user request.';
 
 // Backoff before a same-run retry restart. An immediate retry of a transient
 // failure — especially a 429 — tends to re-hit the same limit, so the policy
@@ -81,7 +87,7 @@ export type RunRetryPolicyDecision =
       retryAttemptIndex: number;
       retryMaxAttempts: number;
       retryStrategy: TrackingRunRetryStrategy;
-      retryReason: 'transient_failure';
+      retryReason: 'transient_failure' | 'post_tool_resume';
       retryDelayMs: number;
     }
   | {
@@ -91,6 +97,47 @@ export type RunRetryPolicyDecision =
       retryStrategy: TrackingRunRetryStrategy;
       retrySuppressedReason: TrackingRunRetrySuppressedReason;
     };
+
+export interface PostToolResumeRecoveryInput {
+  result: TrackingRunResult;
+  failure?: RunRetryFailureSignal;
+  attemptCount: number;
+  maxAttempts?: number;
+  sideEffects?: RunRetrySideEffectState;
+  supportsNativeSessionContinue: boolean;
+  hasNativeSession: boolean;
+}
+
+export function decidePostToolResumeRecovery(
+  input: PostToolResumeRecoveryInput,
+): Extract<RunRetryPolicyDecision, { shouldRetry: true }> | null {
+  const attemptCount = normalizeAttemptCount(input.attemptCount);
+  const retryMaxAttempts = normalizeMaxAttempts(input.maxAttempts);
+  const failure = input.failure;
+  const sideEffects = input.sideEffects ?? {};
+  if (
+    input.result !== 'failed' ||
+    sideEffects.cancelRequested ||
+    attemptCount >= retryMaxAttempts ||
+    !input.supportsNativeSessionContinue ||
+    !input.hasNativeSession ||
+    !sideEffects.toolCallSeen ||
+    failure?.failure_category !== 'timeout' ||
+    failure.failure_detail !== 'inactivity_timeout' ||
+    failure.failure_stage !== 'post_tool_resume' ||
+    failure.retryable !== true
+  ) {
+    return null;
+  }
+  return {
+    shouldRetry: true,
+    retryAttemptIndex: attemptCount + 1,
+    retryMaxAttempts,
+    retryStrategy: NATIVE_SESSION_CONTINUE_STRATEGY,
+    retryReason: 'post_tool_resume',
+    retryDelayMs: 0,
+  };
+}
 
 function normalizeAttemptCount(attemptCount: number): number {
   if (!Number.isFinite(attemptCount) || attemptCount < 0) return 0;

--- a/apps/daemon/src/run-retry-policy.ts
+++ b/apps/daemon/src/run-retry-policy.ts
@@ -101,7 +101,8 @@ export type RunRetryPolicyDecision =
 export interface PostToolResumeRecoveryInput {
   result: TrackingRunResult;
   failure?: RunRetryFailureSignal;
-  attemptCount: number;
+  continuationAttemptCount: number;
+  totalRetryAttemptCount: number;
   maxAttempts?: number;
   sideEffects?: RunRetrySideEffectState;
   supportsNativeSessionContinue: boolean;
@@ -111,14 +112,19 @@ export interface PostToolResumeRecoveryInput {
 export function decidePostToolResumeRecovery(
   input: PostToolResumeRecoveryInput,
 ): Extract<RunRetryPolicyDecision, { shouldRetry: true }> | null {
-  const attemptCount = normalizeAttemptCount(input.attemptCount);
+  const continuationAttemptCount = normalizeAttemptCount(
+    input.continuationAttemptCount,
+  );
+  const totalRetryAttemptCount = normalizeAttemptCount(
+    input.totalRetryAttemptCount,
+  );
   const retryMaxAttempts = normalizeMaxAttempts(input.maxAttempts);
   const failure = input.failure;
   const sideEffects = input.sideEffects ?? {};
   if (
     input.result !== 'failed' ||
     sideEffects.cancelRequested ||
-    attemptCount >= retryMaxAttempts ||
+    continuationAttemptCount >= retryMaxAttempts ||
     !input.supportsNativeSessionContinue ||
     !input.hasNativeSession ||
     !sideEffects.toolCallSeen ||
@@ -131,8 +137,9 @@ export function decidePostToolResumeRecovery(
   }
   return {
     shouldRetry: true,
-    retryAttemptIndex: attemptCount + 1,
-    retryMaxAttempts,
+    retryAttemptIndex: totalRetryAttemptCount + 1,
+    retryMaxAttempts:
+      totalRetryAttemptCount + retryMaxAttempts - continuationAttemptCount,
     retryStrategy: NATIVE_SESSION_CONTINUE_STRATEGY,
     retryReason: 'post_tool_resume',
     retryDelayMs: 0,

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -165,6 +165,8 @@ export function createChatRunService({
       // compact analytics snapshot on the shared run until terminal telemetry.
       retryOriginFailure: null,
       retryOriginErrorCode: null,
+      retryStrategy: null,
+      nativeSessionContinuePending: null,
       stdinOpen: false,
       // E-lite root-cause telemetry. `stdinBackpressure` records whether the
       // prompt write to the child's stdin was queued (pipe buffer full — a

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -166,6 +166,7 @@ export function createChatRunService({
       retryOriginFailure: null,
       retryOriginErrorCode: null,
       retryStrategy: null,
+      nativeSessionContinueAttemptCount: 0,
       nativeSessionContinuePending: null,
       stdinOpen: false,
       // E-lite root-cause telemetry. `stdinBackpressure` records whether the

--- a/apps/daemon/src/runtimes/runs.ts
+++ b/apps/daemon/src/runtimes/runs.ts
@@ -166,6 +166,7 @@ export function createChatRunService({
       retryOriginFailure: null,
       retryOriginErrorCode: null,
       retryStrategy: null,
+      retryMaxAttempts: null,
       nativeSessionContinueAttemptCount: 0,
       nativeSessionContinuePending: null,
       stdinOpen: false,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5597,10 +5597,8 @@ export async function startServer({
         liveSessionId
       ) {
         run.retryOriginalFailure ??= failure ?? undefined;
-        if ((run.retryAttemptCount ?? 0) === 0) {
-          run.retryOriginFailure = failure ? { ...failure } : null;
-          run.retryOriginErrorCode = errorCode ?? null;
-        }
+        run.retryOriginFailure = failure ? { ...failure } : null;
+        run.retryOriginErrorCode = errorCode ?? null;
         run.retryAttemptCount = postToolResumeDecision.retryAttemptIndex;
         run.nativeSessionContinueAttemptCount =
           (run.nativeSessionContinueAttemptCount ?? 0) + 1;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5498,6 +5498,8 @@ export async function startServer({
           ? {
               ...decision,
               retryAttemptIndex: attemptCount,
+              retryMaxAttempts:
+                run.retryMaxAttempts ?? decision.retryMaxAttempts,
               retryStrategy: run.retryStrategy ?? decision.retryStrategy,
             }
           : decision;
@@ -5602,6 +5604,7 @@ export async function startServer({
         run.retryAttemptCount = postToolResumeDecision.retryAttemptIndex;
         run.nativeSessionContinueAttemptCount =
           (run.nativeSessionContinueAttemptCount ?? 0) + 1;
+        run.retryMaxAttempts = postToolResumeDecision.retryMaxAttempts;
         run.retryStrategy = postToolResumeDecision.retryStrategy;
         run.retryFinalResult = undefined;
         run.retrySuppressedReason = undefined;
@@ -5653,6 +5656,7 @@ export async function startServer({
           run.retryOriginErrorCode = errorCode ?? null;
         }
         run.retryAttemptCount = decision.retryAttemptIndex;
+        run.retryMaxAttempts = decision.retryMaxAttempts;
         run.retryStrategy = decision.retryStrategy;
         run.retryFinalResult = undefined;
         run.retrySuppressedReason = undefined;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5581,7 +5581,9 @@ export async function startServer({
       const postToolResumeDecision = decidePostToolResumeRecovery({
         result,
         failure,
-        attemptCount: run.retryAttemptCount ?? 0,
+        continuationAttemptCount:
+          run.nativeSessionContinueAttemptCount ?? 0,
+        totalRetryAttemptCount: run.retryAttemptCount ?? 0,
         sideEffects,
         supportsNativeSessionContinue: def.resumesSessionViaCli === true,
         hasNativeSession: !!run.conversationId && !!liveSessionId,
@@ -5598,6 +5600,8 @@ export async function startServer({
           run.retryOriginErrorCode = errorCode ?? null;
         }
         run.retryAttemptCount = postToolResumeDecision.retryAttemptIndex;
+        run.nativeSessionContinueAttemptCount =
+          (run.nativeSessionContinueAttemptCount ?? 0) + 1;
         run.retryStrategy = postToolResumeDecision.retryStrategy;
         run.retryFinalResult = undefined;
         run.retrySuppressedReason = undefined;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -389,7 +389,11 @@ import {
 } from './run-lifecycle-tracer.js';
 import { deriveRunErrorCode, runResultFromStatus } from './run-result.js';
 import { classifyRunFailure, isResumableFailure } from './run-failure-classification.js';
-import { decideSafeRunRetry } from './run-retry-policy.js';
+import {
+  POST_TOOL_RESUME_CONTINUATION_PROMPT,
+  decidePostToolResumeRecovery,
+  decideSafeRunRetry,
+} from './run-retry-policy.js';
 import {
   amrUserIdForRunAnalytics,
   scanRunEventsForUsageAnalytics,
@@ -4276,6 +4280,12 @@ export async function startServer({
   const startChatRun = async (chatBody, run) => {
     const lifecycle = createRunLifecycleTracer(run);
     lifecycle.mark('chat_run_started');
+    const pendingNativeSessionContinue =
+      run.nativeSessionContinuePending &&
+      typeof run.nativeSessionContinuePending.sessionId === 'string'
+        ? run.nativeSessionContinuePending
+        : null;
+    run.nativeSessionContinuePending = null;
     /** @type {Partial<ChatRequest> & { imagePaths?: string[] }} */
     chatBody = chatBody || {};
     const {
@@ -4318,7 +4328,12 @@ export async function startServer({
     // into chatBody across the createChatRunService boundary. Each field
     // is optional and only set when the chat body actually carried it.
     const telemetryPrompt = telemetryPromptFromRunRequest(message, currentPrompt);
-    if (typeof telemetryPrompt === 'string') run.userPrompt = telemetryPrompt;
+    if (
+      !pendingNativeSessionContinue &&
+      typeof telemetryPrompt === 'string'
+    ) {
+      run.userPrompt = telemetryPrompt;
+    }
     if (typeof model === 'string' && model) run.model = model;
     if (typeof reasoning === 'string' && reasoning) run.reasoning = reasoning;
     if (typeof serviceTier === 'string' && serviceTier) run.serviceTier = serviceTier;
@@ -4999,7 +5014,7 @@ export async function startServer({
         // the probe failure and applies the identical fallback.
       }
     }
-    const agentResumeCtx =
+    const resolvedAgentResumeCtx =
       agentSupportsSessionResume && run.conversationId
         ? resolveAgentResumeContext(db, {
             conversationId: run.conversationId,
@@ -5009,6 +5024,28 @@ export async function startServer({
             currentAssistantMessageId: run.assistantMessageId ?? null,
           })
         : { storedSessionId: null as string | null, resumeSessionId: null as string | null, newSessionId: undefined as string | undefined, isResuming: false, storedStablePromptHash: null as string | null, storedStableSections: null as StableSectionHashes | null, invalidationReason: null };
+    // A same-run post-tool recovery resumes the exact session id captured from
+    // the interrupted attempt. The ordinary cross-turn cursor guard cannot
+    // admit it yet because the current assistant placeholder is still in
+    // flight, so this daemon-only path supplies the already-validated handle
+    // directly. Public chat requests cannot reach this branch.
+    const forceInternalResume =
+      pendingNativeSessionContinue != null &&
+      def.resumesSessionViaCli === true &&
+      pendingNativeSessionContinue.sessionId.length > 0;
+    const agentResumeCtx = forceInternalResume
+      ? {
+          ...resolvedAgentResumeCtx,
+          storedSessionId: pendingNativeSessionContinue.sessionId,
+          resumeSessionId: pendingNativeSessionContinue.sessionId,
+          isResuming: true,
+          storedStablePromptHash:
+            pendingNativeSessionContinue.stablePromptHash ?? null,
+          storedStableSections:
+            pendingNativeSessionContinue.stablePromptSections ?? null,
+          invalidationReason: null,
+        }
+      : resolvedAgentResumeCtx;
     const publishNativeSessionRecoveryMetadata = () => {
       if (!run.nativeSessionRecovery) return;
       design.runs.emit(run, 'diagnostic', {
@@ -5398,8 +5435,8 @@ export async function startServer({
         startRequestedAt: run.analyticsTelemetry?.startRequestedAt ?? run.createdAt,
       };
     };
-    const spawnRetryAttempt = () => {
-      void startChatRun(chatBody, run).catch((err) => {
+    const spawnRetryAttempt = (retryChatBody = chatBody) => {
+      void startChatRun(retryChatBody, run).catch((err) => {
         const message = err instanceof Error ? err.message : String(err);
         design.runs.emit(
           run,
@@ -5421,17 +5458,17 @@ export async function startServer({
     // or shutdown during the backoff window clears the timer (runtimes/runs.ts)
     // and finalizes the queued run, and the callback re-checks cancel/terminal
     // state in case it fires first.
-    const scheduleRetryRestart = (delayMs) => {
+    const scheduleRetryRestart = (delayMs, retryChatBody = chatBody) => {
       tearDownAttemptForRetry();
       const wait = Number.isFinite(delayMs) && delayMs > 0 ? delayMs : 0;
       if (wait <= 0) {
-        spawnRetryAttempt();
+        spawnRetryAttempt(retryChatBody);
         return;
       }
       run.retryRestartTimer = setTimeout(() => {
         run.retryRestartTimer = null;
         if (run.cancelRequested || design.runs.isTerminal(run.status)) return;
-        spawnRetryAttempt();
+        spawnRetryAttempt(retryChatBody);
       }, wait);
     };
     const finalizeRetryTelemetry = (status, decision, failure, errorCode) => {
@@ -5458,7 +5495,11 @@ export async function startServer({
           : undefined;
       const eventDecision =
         attemptCount > 0
-          ? { ...decision, retryAttemptIndex: attemptCount }
+          ? {
+              ...decision,
+              retryAttemptIndex: attemptCount,
+              retryStrategy: run.retryStrategy ?? decision.retryStrategy,
+            }
           : decision;
       // A successful retry has no current failure classification or error code.
       // Fall back to the failure that caused attempt 0 to be retried so success
@@ -5532,6 +5573,69 @@ export async function startServer({
         ...runSideEffectsForRun(run),
         cancelRequested: !!run.cancelRequested,
       };
+      const liveSessionId = agentResumeCtx.isResuming
+        ? agentResumeCtx.resumeSessionId
+        : agentCapturesSessionId
+          ? capturedSessionId
+          : agentResumeCtx.newSessionId;
+      const postToolResumeDecision = decidePostToolResumeRecovery({
+        result,
+        failure,
+        attemptCount: run.retryAttemptCount ?? 0,
+        sideEffects,
+        supportsNativeSessionContinue: def.resumesSessionViaCli === true,
+        hasNativeSession: !!run.conversationId && !!liveSessionId,
+      });
+      if (
+        postToolResumeDecision?.shouldRetry &&
+        !design.runs.isTerminal(run.status) &&
+        run.conversationId &&
+        liveSessionId
+      ) {
+        run.retryOriginalFailure ??= failure ?? undefined;
+        if ((run.retryAttemptCount ?? 0) === 0) {
+          run.retryOriginFailure = failure ? { ...failure } : null;
+          run.retryOriginErrorCode = errorCode ?? null;
+        }
+        run.retryAttemptCount = postToolResumeDecision.retryAttemptIndex;
+        run.retryStrategy = postToolResumeDecision.retryStrategy;
+        run.retryFinalResult = undefined;
+        run.retrySuppressedReason = undefined;
+        upsertAgentSession(db, {
+          conversationId: run.conversationId,
+          agentId: def.id,
+          sessionId: liveSessionId,
+          stablePromptHash: currentStableHash,
+          stablePromptSections: currentStableSectionsJson,
+          model: safeModel ?? null,
+          cwd: effectiveCwd,
+          lastMessageId: run.assistantMessageId ?? null,
+        });
+        run.nativeSessionRecovery = markNativeSessionCaptured({
+          previous: run.nativeSessionRecovery,
+          agentId: def.id,
+          sessionId: liveSessionId,
+          resumed: agentResumeCtx.isResuming,
+        });
+        publishNativeSessionRecoveryMetadata();
+        design.runs.emit(run, 'run_retry_attempted', {
+          ...retryAnalyticsBase(postToolResumeDecision, failure, errorCode),
+          retry_reason: postToolResumeDecision.retryReason,
+          retry_delay_ms: postToolResumeDecision.retryDelayMs,
+        });
+        run.nativeSessionContinuePending = {
+          sessionId: liveSessionId,
+          stablePromptHash: currentStableHash,
+          stablePromptSections: currentStableSections,
+        };
+        scheduleRetryRestart(postToolResumeDecision.retryDelayMs, {
+          ...chatBody,
+          message: POST_TOOL_RESUME_CONTINUATION_PROMPT,
+          currentPrompt: POST_TOOL_RESUME_CONTINUATION_PROMPT,
+          titleGeneration: undefined,
+        });
+        return true;
+      }
       const decision = decideSafeRunRetry({
         result,
         failure,
@@ -5545,6 +5649,7 @@ export async function startServer({
           run.retryOriginErrorCode = errorCode ?? null;
         }
         run.retryAttemptCount = decision.retryAttemptIndex;
+        run.retryStrategy = decision.retryStrategy;
         run.retryFinalResult = undefined;
         run.retrySuppressedReason = undefined;
         design.runs.emit(run, 'run_retry_attempted', {
@@ -5584,11 +5689,6 @@ export async function startServer({
         sideEffects.artifactWriteSeen ||
         sideEffects.liveArtifactSeen
       );
-      const liveSessionId = agentResumeCtx.isResuming
-        ? agentResumeCtx.resumeSessionId
-        : agentCapturesSessionId
-          ? capturedSessionId
-          : agentResumeCtx.newSessionId;
       const resumableFailure =
         result === 'failed' &&
         def.resumesSessionViaCli === true &&

--- a/apps/daemon/tests/run-retry-policy.test.ts
+++ b/apps/daemon/tests/run-retry-policy.test.ts
@@ -18,7 +18,8 @@ function decidePostToolResume(
 ) {
   return decidePostToolResumeRecovery({
     result: 'failed',
-    attemptCount: 0,
+    continuationAttemptCount: 0,
+    totalRetryAttemptCount: 0,
     failure: {
       failure_category: 'timeout',
       failure_detail: 'inactivity_timeout',
@@ -426,7 +427,16 @@ describe('decidePostToolResumeRecovery', () => {
   });
 
   it('does not loop after the single continuation attempt', () => {
-    expect(decidePostToolResume({ attemptCount: 1 })).toBeNull();
+    expect(decidePostToolResume({ continuationAttemptCount: 1 })).toBeNull();
+  });
+
+  it('keeps the continuation budget independent from prior safe retries', () => {
+    expect(decidePostToolResume({ totalRetryAttemptCount: 1 })).toMatchObject({
+      shouldRetry: true,
+      retryAttemptIndex: 2,
+      retryMaxAttempts: 2,
+      retryStrategy: NATIVE_SESSION_CONTINUE_STRATEGY,
+    });
   });
 });
 

--- a/apps/daemon/tests/run-retry-policy.test.ts
+++ b/apps/daemon/tests/run-retry-policy.test.ts
@@ -5,11 +5,32 @@ import {
   MAX_RETRY_BACKOFF_DELAY_MS,
   RATE_LIMIT_RETRY_BASE_DELAY_MS,
   SAFE_RUN_RETRY_STRATEGY,
+  NATIVE_SESSION_CONTINUE_STRATEGY,
   TRANSIENT_RETRY_BASE_DELAY_MS,
   computeRetryBackoffMs,
+  decidePostToolResumeRecovery,
   decideSafeRunRetry,
   type RunRetryPolicyInput,
 } from '../src/run-retry-policy.js';
+
+function decidePostToolResume(
+  input: Partial<Parameters<typeof decidePostToolResumeRecovery>[0]> = {},
+) {
+  return decidePostToolResumeRecovery({
+    result: 'failed',
+    attemptCount: 0,
+    failure: {
+      failure_category: 'timeout',
+      failure_detail: 'inactivity_timeout',
+      failure_stage: 'post_tool_resume',
+      retryable: true,
+    },
+    sideEffects: { toolCallSeen: true },
+    supportsNativeSessionContinue: true,
+    hasNativeSession: true,
+    ...input,
+  });
+}
 
 function decide(input: Partial<RunRetryPolicyInput> = {}) {
   return decideSafeRunRetry({
@@ -375,6 +396,37 @@ describe('decideSafeRunRetry', () => {
       shouldRetry: true,
       retryDelayMs: TRANSIENT_RETRY_BASE_DELAY_MS / 2,
     });
+  });
+});
+
+describe('decidePostToolResumeRecovery', () => {
+  it('allows one native-session continuation after a completed tool result stalls', () => {
+    expect(decidePostToolResume()).toEqual({
+      shouldRetry: true,
+      retryAttemptIndex: 1,
+      retryMaxAttempts: DEFAULT_SAFE_RUN_RETRY_MAX_ATTEMPTS,
+      retryStrategy: NATIVE_SESSION_CONTINUE_STRATEGY,
+      retryReason: 'post_tool_resume',
+      retryDelayMs: 0,
+    });
+  });
+
+  it('requires the exact post-tool timeout, a native session, and a committed tool call', () => {
+    expect(decidePostToolResume({
+      failure: {
+        failure_category: 'timeout',
+        failure_detail: 'inactivity_timeout',
+        failure_stage: 'tool_outstanding',
+        retryable: true,
+      },
+    })).toBeNull();
+    expect(decidePostToolResume({ supportsNativeSessionContinue: false })).toBeNull();
+    expect(decidePostToolResume({ hasNativeSession: false })).toBeNull();
+    expect(decidePostToolResume({ sideEffects: { toolCallSeen: false } })).toBeNull();
+  });
+
+  it('does not loop after the single continuation attempt', () => {
+    expect(decidePostToolResume({ attemptCount: 1 })).toBeNull();
   });
 });
 

--- a/apps/daemon/tests/run-retry-runtime.test.ts
+++ b/apps/daemon/tests/run-retry-runtime.test.ts
@@ -265,6 +265,73 @@ describe('same-run retry runtime', () => {
     expect(secondAttemptSessionId).not.toBe(firstAttemptSessionId);
   });
 
+  it('continues a stalled post-tool Claude session without replaying the original request', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-run-retry-post-tool-bin-'));
+    const {
+      bin: fakeClaude,
+      argsLogPath,
+      promptLogPath,
+    } = await writePostToolStallingClaude(binDir, 'claude-post-tool-stall');
+
+    delete process.env.POSTHOG_KEY;
+    delete process.env.POSTHOG_HOST;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_BASE_URL;
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS = STALL_WATCHDOG_TIMEOUT_MS;
+
+    started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'claude',
+      agentCliEnv: { claude: { CLAUDE_BIN: fakeClaude } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const originalPrompt = 'perform the original request exactly once';
+    const run = await createAndWaitForRun(started.url, 'claude', originalPrompt);
+    expect(run.status).toBe('succeeded');
+
+    const events = await readRunEvents(run.eventsLogPath);
+    expect(events.filter((event) => event.event === 'start')).toHaveLength(2);
+    expect(events.filter((event) => event.event === 'end')).toHaveLength(1);
+    expect(events.filter((event) => event.event === 'agent' && event.data.type === 'tool_use'))
+      .toHaveLength(1);
+    expect(events.filter((event) => event.event === 'agent' && event.data.type === 'tool_result'))
+      .toHaveLength(1);
+
+    expect(events.find((event) => event.event === 'run_retry_attempted')?.data).toMatchObject({
+      retry_strategy: 'native_session_continue',
+      retry_reason: 'post_tool_resume',
+      failure_category: 'timeout',
+      failure_detail: 'inactivity_timeout',
+      failure_stage: 'post_tool_resume',
+    });
+    expect(events.find((event) => event.event === 'run_retry_finished')?.data).toMatchObject({
+      retry_strategy: 'native_session_continue',
+      retry_result: 'success',
+      failure_category: 'timeout',
+      failure_detail: 'inactivity_timeout',
+      failure_stage: 'post_tool_resume',
+    });
+
+    const attemptArgs = (await readClaudeAttemptArgs(argsLogPath)).filter(
+      (args) => args.includes('--session-id') || args.includes('--resume'),
+    );
+    expect(attemptArgs).toHaveLength(2);
+    const firstSessionId = sessionIdArg(attemptArgs[0] ?? []);
+    expect(firstSessionId).toBeTruthy();
+    expect(attemptArgs[1]).toContain('--resume');
+    expect(resumeSessionIdArg(attemptArgs[1] ?? [])).toBe(firstSessionId);
+    expect(attemptArgs[1]).not.toContain('--session-id');
+
+    const prompts = await readAttemptPrompts(promptLogPath);
+    expect(prompts.get(0)).toContain(originalPrompt);
+    expect(prompts.get(1)).toContain('Continue the interrupted turn');
+    expect(prompts.get(1)).not.toContain(originalPrompt);
+  });
+
   it('does not let a stalled attempt’s forced-shutdown timers kill the healthy retry', async () => {
     binDir = await mkdtemp(path.join(os.tmpdir(), 'od-run-retry-crossgen-bin-'));
     const { bin: fakeClaude } = await writeCrossGenKillClaude(binDir, 'claude-crossgen');
@@ -494,6 +561,9 @@ if (process.argv.includes('--help')) {
   console.log('Usage: claude -p [--include-partial-messages] [--add-dir DIR]');
   process.exit(0);
 }
+if (!process.argv.includes('--session-id') && !process.argv.includes('--resume')) {
+  process.exit(0);
+}
 let attempts = 0;
 try { attempts = Number(fs.readFileSync(counterPath, 'utf8')) || 0; } catch {}
 fs.writeFileSync(counterPath, String(attempts + 1));
@@ -521,6 +591,73 @@ if (attempts === 0) {
   return { bin, argsLogPath };
 }
 
+async function writePostToolStallingClaude(
+  dir: string,
+  name: string,
+): Promise<{ bin: string; argsLogPath: string; promptLogPath: string }> {
+  const bin = path.join(dir, name);
+  const counterPath = path.join(dir, `${name}-attempts`);
+  const argsLogPath = path.join(dir, `${name}-args.jsonl`);
+  const promptLogPath = path.join(dir, `${name}-prompts.jsonl`);
+  await writeFile(bin, `#!/usr/bin/env node
+const fs = require('node:fs');
+const counterPath = ${JSON.stringify(counterPath)};
+const argsLogPath = ${JSON.stringify(argsLogPath)};
+const promptLogPath = ${JSON.stringify(promptLogPath)};
+if (process.argv.includes('--version')) {
+  console.log('claude-code 1.0.0-post-tool-stall');
+  process.exit(0);
+}
+if (process.argv.includes('--help')) {
+  console.log('Usage: claude -p [--include-partial-messages] [--add-dir DIR]');
+  process.exit(0);
+}
+if (!process.argv.includes('--session-id') && !process.argv.includes('--resume')) {
+  process.exit(0);
+}
+let attempts = 0;
+try { attempts = Number(fs.readFileSync(counterPath, 'utf8')) || 0; } catch {}
+fs.writeFileSync(counterPath, String(attempts + 1));
+fs.appendFileSync(argsLogPath, JSON.stringify(process.argv.slice(2)) + '\\n');
+process.stdin.on('data', (chunk) => {
+  fs.appendFileSync(promptLogPath, JSON.stringify({ attempt: attempts, chunk: String(chunk) }) + '\\n');
+});
+if (attempts === 0) {
+  console.log(JSON.stringify({ type: 'system', subtype: 'init', model: 'claude-post-tool-stall' }));
+  console.log(JSON.stringify({
+    type: 'assistant',
+    message: {
+      id: 'msg-post-tool',
+      content: [{ type: 'tool_use', id: 'tool-post-tool', name: 'Read', input: { file_path: 'README.md' } }],
+      stop_reason: 'tool_use'
+    }
+  }));
+  console.log(JSON.stringify({
+    type: 'user',
+    message: {
+      content: [{ type: 'tool_result', tool_use_id: 'tool-post-tool', content: 'completed once', is_error: false }]
+    }
+  }));
+  setTimeout(() => process.exit(0), 60000);
+} else {
+  setTimeout(() => {
+    console.log(JSON.stringify({ type: 'system', subtype: 'init', model: 'claude-post-tool-resumed' }));
+    console.log(JSON.stringify({
+      type: 'assistant',
+      message: {
+        id: 'msg-post-tool-success',
+        content: [{ type: 'text', text: 'Recovered from the existing session.' }],
+        stop_reason: 'end_turn'
+      }
+    }));
+    setTimeout(() => process.exit(0), 20);
+  }, 100);
+}
+`, 'utf8');
+  await chmod(bin, 0o755);
+  return { bin, argsLogPath, promptLogPath };
+}
+
 async function putConfig(url: string, patch: Record<string, unknown>): Promise<void> {
   const response = await fetch(`${url}/api/app-config`, {
     method: 'PUT',
@@ -530,7 +667,11 @@ async function putConfig(url: string, patch: Record<string, unknown>): Promise<v
   expect(response.status).toBe(200);
 }
 
-async function createAndWaitForRun(url: string, agentId = 'claude'): Promise<RunStatus> {
+async function createAndWaitForRun(
+  url: string,
+  agentId = 'claude',
+  prompt = 'please retry a transient runtime failure',
+): Promise<RunStatus> {
   const projectId = `retry_runtime_${randomUUID()}`;
   const projectResponse = await fetch(`${url}/api/projects`, {
     method: 'POST',
@@ -559,8 +700,8 @@ async function createAndWaitForRun(url: string, agentId = 'claude'): Promise<Run
       assistantMessageId,
       clientRequestId: `client_retry_${randomUUID()}`,
       agentId,
-      message: 'please retry a transient runtime failure',
-      currentPrompt: 'please retry a transient runtime failure',
+      message: prompt,
+      currentPrompt: prompt,
     }),
   });
   expect(runResponse.status).toBe(202);
@@ -603,6 +744,21 @@ async function readClaudeAttemptArgs(file: string): Promise<string[][]> {
 function sessionIdArg(args: string[]): string | null {
   const index = args.indexOf('--session-id');
   return index >= 0 ? args[index + 1] ?? null : null;
+}
+
+function resumeSessionIdArg(args: string[]): string | null {
+  const index = args.indexOf('--resume');
+  return index >= 0 ? args[index + 1] ?? null : null;
+}
+
+async function readAttemptPrompts(file: string): Promise<Map<number, string>> {
+  const prompts = new Map<number, string>();
+  const raw = await readFile(file, 'utf8');
+  for (const line of raw.trim().split('\n').filter(Boolean)) {
+    const entry = JSON.parse(line) as { attempt: number; chunk: string };
+    prompts.set(entry.attempt, `${prompts.get(entry.attempt) ?? ''}${entry.chunk}`);
+  }
+  return prompts;
 }
 
 function delay(ms: number): Promise<void> {

--- a/apps/daemon/tests/run-retry-runtime.test.ts
+++ b/apps/daemon/tests/run-retry-runtime.test.ts
@@ -393,6 +393,13 @@ describe('same-run retry runtime', () => {
         stage: 'post_tool_resume',
       },
     ]);
+    expect(events.find((event) => event.event === 'run_retry_finished')?.data)
+      .toMatchObject({
+        retry_attempt_index: 2,
+        retry_max_attempts: 2,
+        retry_strategy: 'native_session_continue',
+        retry_result: 'success',
+      });
 
     const attemptArgs = (await readClaudeAttemptArgs(argsLogPath)).filter(
       (args) => args.includes('--session-id') || args.includes('--resume'),

--- a/apps/daemon/tests/run-retry-runtime.test.ts
+++ b/apps/daemon/tests/run-retry-runtime.test.ts
@@ -399,6 +399,7 @@ describe('same-run retry runtime', () => {
         retry_max_attempts: 2,
         retry_strategy: 'native_session_continue',
         retry_result: 'success',
+        failure_stage: 'post_tool_resume',
       });
 
     const attemptArgs = (await readClaudeAttemptArgs(argsLogPath)).filter(

--- a/apps/daemon/tests/run-retry-runtime.test.ts
+++ b/apps/daemon/tests/run-retry-runtime.test.ts
@@ -332,6 +332,86 @@ describe('same-run retry runtime', () => {
     expect(prompts.get(1)).not.toContain(originalPrompt);
   });
 
+  it('continues a post-tool stall after a first-token retry used the safe retry budget', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-run-retry-mixed-stall-bin-'));
+    const {
+      bin: fakeClaude,
+      argsLogPath,
+      promptLogPath,
+    } = await writePostToolStallingClaude(
+      binDir,
+      'claude-first-token-then-post-tool-stall',
+      true,
+    );
+
+    delete process.env.POSTHOG_KEY;
+    delete process.env.POSTHOG_HOST;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_BASE_URL;
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+    process.env.OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS = STALL_WATCHDOG_TIMEOUT_MS;
+
+    started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'claude',
+      agentCliEnv: { claude: { CLAUDE_BIN: fakeClaude } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const originalPrompt = 'retry before tools, then continue the committed session';
+    const run = await createAndWaitForRun(started.url, 'claude', originalPrompt);
+    expect(run.status).toBe('succeeded');
+
+    const events = await readRunEvents(run.eventsLogPath);
+    expect(events.filter((event) => event.event === 'start')).toHaveLength(3);
+    expect(events.filter((event) => event.event === 'agent' && event.data.type === 'tool_use'))
+      .toHaveLength(1);
+    expect(events.filter((event) => event.event === 'agent' && event.data.type === 'tool_result'))
+      .toHaveLength(1);
+    expect(
+      events
+        .filter((event) => event.event === 'run_retry_attempted')
+        .map((event) => ({
+          index: event.data.retry_attempt_index,
+          strategy: event.data.retry_strategy,
+          reason: event.data.retry_reason,
+          stage: event.data.failure_stage,
+        })),
+    ).toEqual([
+      {
+        index: 1,
+        strategy: 'same_run_transient',
+        reason: 'transient_failure',
+        stage: 'first_token_wait',
+      },
+      {
+        index: 2,
+        strategy: 'native_session_continue',
+        reason: 'post_tool_resume',
+        stage: 'post_tool_resume',
+      },
+    ]);
+
+    const attemptArgs = (await readClaudeAttemptArgs(argsLogPath)).filter(
+      (args) => args.includes('--session-id') || args.includes('--resume'),
+    );
+    expect(attemptArgs).toHaveLength(3);
+    const firstSessionId = sessionIdArg(attemptArgs[0] ?? []);
+    const secondSessionId = sessionIdArg(attemptArgs[1] ?? []);
+    expect(firstSessionId).toBeTruthy();
+    expect(secondSessionId).toBeTruthy();
+    expect(secondSessionId).not.toBe(firstSessionId);
+    expect(resumeSessionIdArg(attemptArgs[2] ?? [])).toBe(secondSessionId);
+
+    const prompts = await readAttemptPrompts(promptLogPath);
+    expect(prompts.get(0)).toContain(originalPrompt);
+    expect(prompts.get(1)).toContain(originalPrompt);
+    expect(prompts.get(2)).toContain('Continue the interrupted turn');
+    expect(prompts.get(2)).not.toContain(originalPrompt);
+  });
+
   it('does not let a stalled attempt’s forced-shutdown timers kill the healthy retry', async () => {
     binDir = await mkdtemp(path.join(os.tmpdir(), 'od-run-retry-crossgen-bin-'));
     const { bin: fakeClaude } = await writeCrossGenKillClaude(binDir, 'claude-crossgen');
@@ -594,6 +674,7 @@ if (attempts === 0) {
 async function writePostToolStallingClaude(
   dir: string,
   name: string,
+  firstTokenStall = false,
 ): Promise<{ bin: string; argsLogPath: string; promptLogPath: string }> {
   const bin = path.join(dir, name);
   const counterPath = path.join(dir, `${name}-attempts`);
@@ -604,6 +685,7 @@ const fs = require('node:fs');
 const counterPath = ${JSON.stringify(counterPath)};
 const argsLogPath = ${JSON.stringify(argsLogPath)};
 const promptLogPath = ${JSON.stringify(promptLogPath)};
+const firstTokenStall = ${JSON.stringify(firstTokenStall)};
 if (process.argv.includes('--version')) {
   console.log('claude-code 1.0.0-post-tool-stall');
   process.exit(0);
@@ -622,7 +704,10 @@ fs.appendFileSync(argsLogPath, JSON.stringify(process.argv.slice(2)) + '\\n');
 process.stdin.on('data', (chunk) => {
   fs.appendFileSync(promptLogPath, JSON.stringify({ attempt: attempts, chunk: String(chunk) }) + '\\n');
 });
-if (attempts === 0) {
+const postToolAttempt = firstTokenStall ? 1 : 0;
+if (firstTokenStall && attempts === 0) {
+  setTimeout(() => process.exit(0), 60000);
+} else if (attempts === postToolAttempt) {
   console.log(JSON.stringify({ type: 'system', subtype: 'init', model: 'claude-post-tool-stall' }));
   console.log(JSON.stringify({
     type: 'assistant',

--- a/packages/contracts/src/analytics/events/result-events.ts
+++ b/packages/contracts/src/analytics/events/result-events.ts
@@ -425,7 +425,7 @@ export interface RunRetryBaseProps {
 }
 
 export interface RunRetryAttemptedProps extends RunRetryBaseProps {
-  retry_reason: 'transient_failure';
+  retry_reason: 'transient_failure' | 'post_tool_resume';
   // Backoff delay (ms) waited before this retry attempt was restarted.
   retry_delay_ms?: number;
 }

--- a/packages/contracts/src/analytics/events/shared-enums.ts
+++ b/packages/contracts/src/analytics/events/shared-enums.ts
@@ -323,7 +323,9 @@ export type TrackingRunFailureUserAction =
   | 'install_cli'
   | 'fix_config'
   | 'none';
-export type TrackingRunRetryStrategy = 'same_run_transient';
+export type TrackingRunRetryStrategy =
+  | 'same_run_transient'
+  | 'native_session_continue';
 export type TrackingRunRetryFinalResult =
   | 'not_attempted'
   | 'success'


### PR DESCRIPTION
## Why

A 0.16.1 reliability investigation found a recurring failure mode where a CLI agent had already completed its tool calls, then stopped emitting output while it should have resumed model generation. The daemon classified the inactivity timeout correctly, but it terminated the run and required a manual continuation even when a native CLI session was available.

Restarting the original request is unsafe after committed tool calls because it can repeat side effects. This PR adds a narrower recovery path that continues the existing native session exactly once.

## What users will see

When a session-resuming CLI agent stalls after all observed tool calls have matching results, Open Design automatically continues the same native session once. The continuation tells the agent to treat completed tool results as committed and finish the original request without repeating those tool calls.

First-token stalls keep using the existing from-scratch retry policy. Outstanding-tool stalls, unsupported runtimes, missing session handles, cancellations, and repeated stalls still fall back to the existing terminal/resumable behavior.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; there is no UI change.

## Bug fix verification

- Red spec: `apps/daemon/tests/run-retry-runtime.test.ts` — “continues a stalled post-tool Claude session without replaying the original request”
- The spec failed on `main` with terminal status `failed`, then passed on this branch.
- The runtime assertion verifies one tool call/result pair, two run attempts, reuse of the same `--resume <session-id>`, and that the continuation stdin excludes the original request.

## Validation

- `corepack pnpm guard`
- `corepack pnpm typecheck`
- `corepack pnpm --filter @open-design/daemon typecheck`
- `corepack pnpm --filter @open-design/contracts test` — 246 passed
- `corepack pnpm --filter @open-design/daemon exec vitest run tests/run-retry-policy.test.ts tests/run-retry-runtime.test.ts` — 34 passed
- Full daemon suite: 6,113 passed; two existing `langfuse-trace.test.ts` feedback-routing assertions fail under the current relay configuration. The unrelated watchdog fixture failure seen in that concurrent run was hardened and passes in the focused 34-test rerun.
