### PR TITLE
fix(daemon): resolve the AMR scope-telemetry app version in its own scope

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -9258,7 +9258,14 @@ export async function startServer({
             design.analytics.capture({
               eventName: 'amr_workspace_scope_resolved',
               context,
-              appVersion: appVersionForCapture(),
+              // `design.getAppVersion` is the only app-version accessor this
+              // scope can see; the identically-named helper inside
+              // `createFinalizedMessageTelemetryReporter` is a different
+              // function's local and resolving it here threw a ReferenceError
+              // out of the spawn path, failing 100% of AMR runs. That helper's
+              // own last resort is this same accessor, so the value is
+              // unchanged.
+              appVersion: design.getAppVersion?.() ?? 'unknown',
               properties: {
                 page_name: 'chat_panel',
                 area: 'chat_panel',
@@ -9650,12 +9657,14 @@ export async function startServer({
             // Codex P2 on PR #1485: thread the resolved skill id into the
             // orchestrator so the Phase 12 metrics carry the real label
             // instead of falling through to 'unknown' for every live run.
-            // `effectiveSkillId` was already computed above (line ~2951) as
-            // the request skillId with a project-row fallback; pass it
-            // through verbatim, and leave the orchestrator's own default
-            // of 'unknown' for runs that genuinely have no skill assigned.
-            skill: typeof effectiveSkillId === 'string' && effectiveSkillId
-              ? effectiveSkillId
+            // This read `effectiveSkillId`, which is a local of
+            // `composeDaemonSystemPrompt` and has never been in scope here — a
+            // `typeof` guard on an undeclared name does not throw, so the label
+            // silently stayed `undefined` for every run instead. `run.skillId`
+            // is the same request skill id recorded onto the run above, and is
+            // the binding this scope actually has.
+            skill: typeof run.skillId === 'string' && run.skillId
+              ? run.skillId
               : undefined,
             cfg: critiqueCfg,
             db,

--- a/apps/daemon/tests/server-identifier-scope.test.ts
+++ b/apps/daemon/tests/server-identifier-scope.test.ts
@@ -1,0 +1,198 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `src/server.ts` opts out of type checking with `@ts-nocheck`, so the compiler
+ * never reports an identifier that is referenced where its declaration is not in
+ * scope. Nothing else in the toolchain does either: the file is bundled, not
+ * linted for scope, and a bad reference only surfaces as a runtime
+ * `ReferenceError` on whichever request path happens to evaluate it.
+ *
+ * That is how `appVersionForCapture` shipped in 0.16.2-beta.148. The name is a
+ * local of `createFinalizedMessageTelemetryReporter`; #6221 called it ~7,500
+ * lines away inside `startChatRun`'s AMR workspace-scope telemetry, on the spawn
+ * path, so every AMR run died with
+ * `spawn failed: appVersionForCapture is not defined`.
+ *
+ * This suite re-checks the one thing `@ts-nocheck` suppresses and nothing else:
+ * every identifier that survives to runtime resolves to a real binding. It runs
+ * the TypeScript checker over `server.ts` with the pragma stripped, keeps only
+ * "Cannot find name" diagnostics, and drops the ones in type positions (erased
+ * before execution, so they cannot throw — those belong to the separate project
+ * of removing `@ts-nocheck` from this file).
+ *
+ * It is deliberately not a typecheck of `server.ts`. Only unresolvable
+ * value-position identifiers fail it.
+ */
+
+const CANNOT_FIND_NAME = 2304;
+
+const SERVER_TS = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../src/server.ts',
+);
+
+/**
+ * Names TypeScript cannot resolve here only because the scope check runs without
+ * ambient type packages, not because the binding is missing at runtime. Keep
+ * this list to genuine host globals; anything a module has to declare or import
+ * does not belong here.
+ */
+const AMBIENT_RUNTIME_GLOBALS = new Set([
+  'AbortSignal',
+  'Buffer',
+  'NodeJS',
+  'TextDecoder',
+  'TextEncoder',
+  'URL',
+  'URLSearchParams',
+  '__dirname',
+  '__filename',
+  'clearInterval',
+  'clearTimeout',
+  'console',
+  'fetch',
+  'global',
+  'globalThis',
+  'module',
+  'process',
+  'queueMicrotask',
+  'require',
+  'setInterval',
+  'setTimeout',
+  'structuredClone',
+]);
+
+interface UnresolvedReference {
+  readonly name: string;
+  readonly line: number;
+}
+
+/** Strip the blanket opt-out so the checker actually reports on this file. */
+function withoutTsNocheck(source: string): string {
+  return source.replace(/^\s*\/\/\s*@ts-nocheck.*$/m, '// (@ts-nocheck stripped by the scope guard)');
+}
+
+/**
+ * True when the identifier lives inside a type annotation, and so is erased
+ * before the code runs. A value-position `typeof x` is a `TypeOfExpression` and
+ * is NOT covered here on purpose: `typeof` does not throw on an undeclared name,
+ * which is exactly how an out-of-scope reference can hide as a silent
+ * `undefined` rather than a crash.
+ */
+function isErasedTypePosition(node: ts.Node): boolean {
+  for (let current: ts.Node | undefined = node; current; current = current.parent) {
+    if (ts.isTypeNode(current) || ts.isTypeParameterDeclaration(current)) return true;
+    if (ts.isImportTypeNode(current)) return true;
+    if (ts.isStatement(current) || ts.isSourceFile(current)) return false;
+  }
+  return false;
+}
+
+function identifierAt(sourceFile: ts.SourceFile, pos: number): ts.Identifier | null {
+  function visit(node: ts.Node): ts.Identifier | null {
+    if (pos < node.getStart(sourceFile) || pos >= node.getEnd()) return null;
+    for (const child of node.getChildren(sourceFile)) {
+      const found = visit(child);
+      if (found) return found;
+    }
+    return ts.isIdentifier(node) ? node : null;
+  }
+  return visit(sourceFile);
+}
+
+/**
+ * Report every identifier in `source` that reaches runtime without a binding.
+ *
+ * `noResolve` keeps this to one file: imports still declare their names, so an
+ * unresolved module never masquerades as an unresolved identifier, and the whole
+ * dependency graph stays out of the check.
+ */
+function unresolvedRuntimeReferences(source: string, fileName: string): UnresolvedReference[] {
+  const options: ts.CompilerOptions = {
+    allowJs: false,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    noEmit: true,
+    noResolve: true,
+    skipLibCheck: true,
+    target: ts.ScriptTarget.ES2022,
+  };
+
+  const host = ts.createCompilerHost(options, true);
+  const baseGetSourceFile = host.getSourceFile.bind(host);
+  const isTarget = (candidate: string) => path.resolve(candidate) === path.resolve(fileName);
+
+  host.getSourceFile = (candidate, languageVersion, onError, shouldCreate) =>
+    isTarget(candidate)
+      ? ts.createSourceFile(candidate, source, languageVersion, true, ts.ScriptKind.TS)
+      : baseGetSourceFile(candidate, languageVersion, onError, shouldCreate);
+  host.fileExists = (candidate) => isTarget(candidate) || ts.sys.fileExists(candidate);
+  host.readFile = (candidate) => (isTarget(candidate) ? source : ts.sys.readFile(candidate));
+
+  const program = ts.createProgram([fileName], options, host);
+  const sourceFile = program.getSourceFile(fileName);
+  if (!sourceFile) throw new Error(`scope guard could not load ${fileName}`);
+
+  const found: UnresolvedReference[] = [];
+  for (const diagnostic of program.getSemanticDiagnostics(sourceFile)) {
+    if (diagnostic.code !== CANNOT_FIND_NAME) continue;
+    if (diagnostic.start === undefined) continue;
+    const identifier = identifierAt(sourceFile, diagnostic.start);
+    if (!identifier) continue;
+    if (AMBIENT_RUNTIME_GLOBALS.has(identifier.text)) continue;
+    if (isErasedTypePosition(identifier)) continue;
+    found.push({
+      name: identifier.text,
+      line: sourceFile.getLineAndCharacterOfPosition(diagnostic.start).line + 1,
+    });
+  }
+  return found;
+}
+
+describe('server.ts identifier scope', () => {
+  it('reports a helper called from outside the function that declares it', () => {
+    // The shape of the shipped bug, in miniature: a local of one function called
+    // from another. If this stops failing, the guard below has gone vacuous.
+    const reproduction = `export function makeReporter(getAppVersion: () => string) {
+  const appVersionForCapture = () => getAppVersion();
+  return () => ({ appVersion: appVersionForCapture() });
+}
+export function startRun(capture: (payload: unknown) => void) {
+  capture({ appVersion: appVersionForCapture() });
+}
+`;
+    expect(unresolvedRuntimeReferences(reproduction, path.join(path.dirname(SERVER_TS), 'scope-guard-fixture.ts')))
+      .toEqual([{ name: 'appVersionForCapture', line: 6 }]);
+  });
+
+  it('leaves an identifier that a typeof guard hides still reportable', () => {
+    // `typeof missing === 'string'` never throws, so this class of out-of-scope
+    // reference degrades to a silent wrong value instead of a crash. It has to
+    // stay visible to the guard — that is how the `effectiveSkillId` sibling of
+    // the beta.148 bug went unnoticed through a whole release.
+    const reproduction = `export function startRun(fallback: string) {
+  return typeof missingSkillId === 'string' && missingSkillId ? missingSkillId : fallback;
+}
+`;
+    expect(
+      unresolvedRuntimeReferences(reproduction, path.join(path.dirname(SERVER_TS), 'scope-guard-fixture.ts'))
+        .map((reference) => reference.name),
+    ).toEqual(['missingSkillId', 'missingSkillId', 'missingSkillId']);
+  });
+
+  it('has no identifier that reaches runtime unbound', () => {
+    const source = fs.readFileSync(SERVER_TS, 'utf8');
+    expect(source).toMatch(/@ts-nocheck/);
+
+    const unresolved = unresolvedRuntimeReferences(withoutTsNocheck(source), SERVER_TS);
+
+    expect(
+      unresolved.map((reference) => `${reference.name} (line ${reference.line})`),
+    ).toEqual([]);
+  }, 120_000);
+});


### PR DESCRIPTION
## Why

**P0 in a shipped beta.** Every AMR run in `0.16.2-beta.148` dies at spawn:

```
spawn failed: appVersionForCapture is not defined
error_code: AGENT_EXECUTION_FAILED
agent_id: amr
```

`appVersionForCapture` is a local of `createFinalizedMessageTelemetryReporter`
(`server.ts:1708`). The `amr_workspace_scope_resolved` capture added by #6221
calls it from `startChatRun` (`server.ts:9261`) — ~7,500 lines and one function
away, so the name resolves to nothing. `onWorkspaceScopeOutcome` fires while
`openDesignAmrTraceEnvForProject` builds the agent's launch env, which happens
inside the spawn `try`, so the `ReferenceError` is caught by #6221's own
`catch` and reported as a generic spawn failure. Not a subset of runs — the
callback is on the unconditional path, so **100% of AMR runs fail**.

`server.ts` carries `@ts-nocheck`, so nothing in the toolchain objected to an
identifier that does not exist. That is the enabling condition, and it is why
this needs a class-level guard rather than a one-line correction.

## What users will see

AMR runs work again. On `0.16.2-beta.148` every AMR run fails immediately with
"spawn failed"; after this, they start normally. No setting, no migration —
users who had switched away from AMR to work around it can switch back.

Secondary: the critique orchestrator's Phase-12 metrics now carry the real
skill label instead of always `undefined` (see below). Not user-visible.

## Surface area

- [x] **None** — internal fix + test only

## Bug fix verification

- Test path: `apps/daemon/tests/server-identifier-scope.test.ts`
- Red on `origin/feat/workspace-team`, green on this branch: **yes**

Red (unmodified `server.ts`), naming both defects at their exact lines:

```
FAIL  tests/server-identifier-scope.test.ts > has no identifier that reaches runtime unbound
AssertionError: expected [ …(4) ] to deeply equal []
+ [
+   "appVersionForCapture (line 9261)",
+   "effectiveSkillId (line 9657)",
+   "effectiveSkillId (line 9657)",
+   "effectiveSkillId (line 9658)",
+ ]
Tests  1 failed | 2 passed (3)          exit 1
```

Green on this branch: `Tests 3 passed (3)`, **exit 0**.

### Why this layer

The broken callback is defined inline inside `startChatRun`, so a behavioural
test has to boot the real `startServer`, put a fake `vela` on `PATH`, bind a
project to a workspace, set `OD_WORKSPACE_CONTEXT_SOURCE=vela`, and wire a live
analytics service — a full daemon+AMR e2e that would still only cover this one
call site.

Note that the existing `tests/runtimes/project-amr-workspace-proof.test.ts`
already covers the outcome path thoroughly, and passes: it supplies its own
`onWorkspaceScopeOutcome: (outcome) => outcomes.push(outcome)`. It substitutes
the exact callback that was broken. That is precisely how this shipped, and it
is a good argument that more coverage of the *helper* would not have helped.

So the guard checks the one thing `@ts-nocheck` suppresses: it runs the
TypeScript checker over `server.ts` with the pragma stripped, keeps only
"Cannot find name", and drops type-position hits (erased before execution, so
they cannot throw). It is not a typecheck of `server.ts` — only an identifier
that reaches runtime unbound fails it. Runs in <1s.

Two self-checks keep it from going vacuously green: one asserts it still
detects the shipped bug's shape (a local called from another function), the
other that a `typeof`-guarded reference stays reportable. Both were genuinely
useful — they caught a mistake in my own fixtures on the first run.

## The fix

`design.getAppVersion()` is the app-version accessor that scope can see
(`design` is already dereferenced on the line above). It is also the
unreachable helper's own last-resort branch, so the reported value is
unchanged. Considered and rejected: hoisting the telemetry reporter or a shared
helper — a large move in an ~11.8k-line untypechecked file is how this class of
bug gets in.

## Sibling found by the guard, fixed here

The critique orchestrator's `skill` argument (`server.ts:9657`) read
`effectiveSkillId`, a local of `composeDaemonSystemPrompt` — never in scope in
`startChatRun`. It has been wrong since #1485, but `typeof` on an *undeclared*
name does not throw, so instead of crashing it silently evaluated to
`undefined` for every run: the label the comment promises has never once been
emitted. Now reads `run.skillId`, the same request skill id recorded onto the
run 2,700 lines earlier.

This is the more unsettling half of the finding. The crash was loud and got
fixed in hours; this one shipped quietly for months.

## Sweep

`@ts-nocheck` means other out-of-scope identifiers could exist, so rather than
review the five diffs by eye I ran the checker over the whole file. Complete
result for `server.ts`, all 11,809 lines of it as shipped:

| Identifier | Line | Position | Verdict |
|---|---|---|---|
| `appVersionForCapture` | 9261 | value | **Broken** — ReferenceError, P0, fixed |
| `effectiveSkillId` | 9657–9658 | value | **Broken** — silent `undefined`, fixed |
| `PluginShareAction` | 5966 | type | Erased at runtime; cannot throw |
| `BufferedStdoutChunk` | 9709 | type | Erased at runtime; cannot throw |
| `ProjectConversationCreatedSsePayload` | 11332 | type | Erased at runtime; cannot throw |

Both `design.analytics.capture` sites in the file are covered (there are
exactly two: `server.ts:1731` and `server.ts:9258`). No use-before-declaration
diagnostics anywhere in the file.

Per-commit check of everything landed in `server.ts` on 2026-07-29 — ~220 added
lines, all invisible to typecheck:

| Commit | PR | server.ts | Identifiers checked | Verdict |
|---|---|---|---|---|
| `629bf8ba5` | #6221 | +68/-1 | `amrWorkspaceScopeOutcome` (9188, same fn), `design` (4927), `run`, `outcome`, `err.*` (catch param), `createSseErrorPayload` (1950, does take a 3rd `init` arg), **`appVersionForCapture`** | 1 broken, rest resolve |
| `459fd9855` | #6201 | +74/-0 | `bindCreatedProjectToWorkspace`/`createCreatedProjectWorkspaceResolver` (import 323), `ensureWorkspaceProject` (import 569), `getAmbientWorkspace` (2996), `resolveCreatedProjectHome` (3004), `workspaceContext` (2978), `fetchProjectCreationWorkspaceDirectory` (2813) | All resolve — see TDZ note |
| `1b2e87e8b` | #6222 | +51/-0 | `warmActiveWorkspaceDigestFaces` (4026), `activeWorkspace` (2767), `teamProjectsDisplayCache` (3271), `teamMembersCache` (3956); `.invalidate()` exists on both cache primitives | All resolve |
| `885806575` | #6189 | +28/-6 | `SYNC_KEEPS_UPDATED_AT` (import 605), used 3026/3118/3413/3421/3639/3657 | All resolve |
| `1c15574c2` | — | +1/-0 | `isSharedTeamProject` (3492) — already in scope on the adjacent line | All resolve |

I paid particular attention to the error/fallback branches in #6201 and #6222,
since those run on the project-create and workspace-switch hot paths and a
happy-path user never reaches them. They resolve.

**One thing worth a second opinion, not fixed here.** #6201 reads
`getAmbientWorkspace` at `server.ts:2404`, ~590 lines *before* its `const`
declaration at 2996. It is inside a closure, so it is legal exactly as long as
the closure is never invoked before line 2996 executes — which the code's own
comment asserts ("only when a design-system workspace project is actually
created, which is always long after this factory call returns"). I could not
find a startup path that violates it, and nothing flags it. But it is a
temporal invariant defended only by a comment, and if it is ever broken the
symptom is a TDZ `ReferenceError` on project creation — the same failure shape
as this PR. Flagging rather than changing it.

## The guard does not run in CI, and I did not change that

Worth knowing before you rely on it: **CI never runs the daemon test suite.**
`ci.yml`'s "Daemon workspace tests" step is hard-coded to a single file:

```
run: pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/project-watchers.test.ts
```

That is the only daemon vitest invocation in any workflow. Scope detection did
fire correctly on this PR (`daemon_tests_required=true`, matched
`certain-daemon-core` on both changed files), but the step it gates runs
`project-watchers` and nothing else. So all 425 daemon test files, including the
one in this PR, are outside the merge gate.

I did not "fix" this, because it is deliberate and guarded, not an oversight.
`scripts/check-certain-exempt-consumption.ts` pins that exact command string and
`workflowRunsOnlyAllowedDaemonTest()` fails if a second daemon test invocation
appears — `e2e/tests/scripts/scopes.test.ts:744` asserts the enforcement.
The coupling is explicit in the source comment: the narrow command is what makes
`apps/daemon/tests/runtimes/trae-cli.test.ts` tolerable as a conditional
allowlist entry, since it reads `docs/agent-adapters.md`, a certain-exempt file.
Widen the daemon lane and that exception disappears, `pnpm guard` starts failing,
and the fix is either a docs→daemon scope rule or relocating that test to
`e2e/tests/`.

That is a coupled policy change with a documented methodology
(`specs/current/ci.md`) and it does not belong in a P0. **Your call**, and I'd
suggest a follow-up: the guard is cheap (<1s, no daemon, no network) and its
whole value is recurrence prevention, which it cannot deliver from outside the
gate. If you want it enforced sooner and cannot widen the daemon lane, the other
option is porting it to `e2e/tests/`, which does run — it only needs to read
`server.ts` as text, so it has no reason to live in the daemon package.

Until then its green is local-only, recorded above.

## Adjacent issues

- **`@ts-nocheck` on `server.ts`** is the root enabling condition. 29 daemon
  files carry it and `server.ts` is ~11.8k lines, so removing it is its own
  project — explicitly out of scope here. The guard in this PR is the cheap
  stand-in for the part that actually bites.
- The three type-position names above would fail a real typecheck of this file.
  They belong to that project, not this PR.

## Validation

Node 24.18.0. Disk was under 1GB free for most of this, so no `pnpm install`
was run; `node_modules` was symlinked from the main checkout into a sparse
worktree.

- `apps/daemon/tests/server-identifier-scope.test.ts` — 3 passed, **exit 0**;
  1 failed / 2 passed, **exit 1** with `server.ts` reverted to origin
- `tests/runtimes/project-amr-workspace-proof.test.ts`,
  `tests/run-create-workspace-gate.test.ts`, `tests/app-version.test.ts`,
  `tests/server-bootstrap-regression.test.ts` — all passed
- `tsc -p tsconfig.tests.json --noEmit` — zero errors from either changed file
- `tests/chat-route.test.ts` — 14 failed / 63 passed, **identical on
  `origin/feat/workspace-team` with my changes stashed**. Pre-existing, and an
  artifact of the symlinked environment: all 14 are 404s on plugin-authoring
  routes. Same cause as the 6 `tsc` errors I do see, which are all
  `Property 'workspaceName' does not exist on type 'WorkspaceCollabContext'` in
  files this PR does not touch — the main checkout's built
  `@open-design/contracts` `dist` predates that field, while this branch's
  contracts *source* has it. A clean install in CI resolves both.

`pnpm guard` / `pnpm typecheck` at the repo root were not run locally for the
same reason. Leaving those to CI.
