### PR TITLE
test(e2e): move the server.ts identifier-scope guard into the merge gate

### DIFF
--- a/e2e/tests/server-identifier-scope.test.ts
+++ b/e2e/tests/server-identifier-scope.test.ts
@@ -6,11 +6,11 @@ import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 /**
- * `src/server.ts` opts out of type checking with `@ts-nocheck`, so the compiler
- * never reports an identifier that is referenced where its declaration is not in
- * scope. Nothing else in the toolchain does either: the file is bundled, not
- * linted for scope, and a bad reference only surfaces as a runtime
- * `ReferenceError` on whichever request path happens to evaluate it.
+ * `apps/daemon/src/server.ts` opts out of type checking with `@ts-nocheck`, so
+ * the compiler never reports an identifier that is referenced where its
+ * declaration is not in scope. Nothing else in the toolchain does either: the
+ * file is bundled, not linted for scope, and a bad reference only surfaces as a
+ * runtime `ReferenceError` on whichever request path happens to evaluate it.
  *
  * That is how `appVersionForCapture` shipped in 0.16.2-beta.148. The name is a
  * local of `createFinalizedMessageTelemetryReporter`; #6221 called it ~7,500
@@ -27,14 +27,44 @@ import { describe, expect, it } from 'vitest';
  *
  * It is deliberately not a typecheck of `server.ts`. Only unresolvable
  * value-position identifiers fail it.
+ *
+ * ## Why this lives in `e2e/tests/` and not `apps/daemon/tests/`
+ *
+ * A guard is worth exactly the lane that runs it. `ci.yml`'s daemon lane
+ * executes one file — `tests/project-watchers.test.ts` — and that exclusive
+ * invocation is itself pinned by the certain-exempt consumption guard
+ * (`workflowRunsOnlyAllowedDaemonTest` in
+ * `scripts/check-certain-exempt-consumption.ts`), so widening it is a coupled
+ * policy change, not a lane edit. A daemon-hosted guard therefore protects
+ * nothing on the merge gate.
+ *
+ * `e2e/tests/` closes that gap, and the closure is structural rather than
+ * incidental:
+ *
+ * - Any change under `apps/daemon/src/` matches the `certain-daemon-core` rule
+ *   in `scripts/scopes.ts`, whose effects include `ui_p0_validation_required`;
+ *   `run_e2e_vitest` is `isFull || web_tests_required ||
+ *   ui_p0_validation_required`. So a `server.ts`-only change arms the `E2E
+ *   Vitest` lane even at the merge queue's `certain` threshold — the strictest
+ *   context there is. An unresolved file list escalates fail-closed to full,
+ *   which arms it too.
+ * - That wiring cannot rot silently. The `daemon core boundary` guard
+ *   (`scripts/lib/guard/scope.ts`) asserts `ci.yml` still contains both
+ *   `run_e2e_vitest == 'true'` and `pnpm --filter @open-design/e2e test`, and
+ *   it runs in the always-on policy floor.
+ *
+ * The placement also follows the root `AGENTS.md` boundary rule — cross-app and
+ * repository-resource consistency checks belong here, not inside an app package
+ * — for the same reason `e2e/tests/critique-coverage.test.ts` does: the check
+ * reads another app's tree as a repository resource. Nothing here boots a
+ * daemon or needs a fixture; `server.ts` is only ever read as text.
  */
 
 const CANNOT_FIND_NAME = 2304;
 
-const SERVER_TS = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  '../src/server.ts',
-);
+const REPO_ROOT = fileURLToPath(new URL('../../', import.meta.url));
+
+const SERVER_TS = path.join(REPO_ROOT, 'apps/daemon/src/server.ts');
 
 /**
  * Names TypeScript cannot resolve here only because the scope check runs without


### PR DESCRIPTION
## Why

Today's `0.16.2-beta.148` shipped a `ReferenceError` that killed **every AMR run at spawn**: #6221 called `appVersionForCapture` — a local of `createFinalizedMessageTelemetryReporter`, ~7,500 lines away — from `startChatRun`. It passed four green gate lanes. #6240 fixed the bug and added a guard test that catches exactly this class, `apps/daemon/tests/server-identifier-scope.test.ts`.

The guard protects nothing where it landed, and this PR is only about that.

`ci.yml`'s **"Daemon workspace tests"** step runs exactly one file:

```yaml
run: pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/project-watchers.test.ts
```

That is the **only** daemon vitest invocation in any workflow. Scope detection is not the problem — `daemon_tests_required=true` fires correctly for `apps/daemon/**` — but the step it gates runs one of 576 daemon test files. So the new guard, like the rest of the daemon suite, sits outside every merge-gate lane. Combined with `server.ts` carrying `@ts-nocheck` (11,818 lines, invisible to `typecheck`), an undefined identifier currently has **no** gate that can see it.

The obvious fix is blocked. That exact command string is pinned by `workflowRunsOnlyAllowedDaemonTest` in `scripts/check-certain-exempt-consumption.ts`, which conditions the `trae-cli.test.ts` docs-consumption exception on the daemon lane running nothing else. Widening the invocation un-allowlists that file and breaks `pnpm guard` — a coupled scope-policy change, deliberately out of scope here. Assessment and recommendation for that is in "Adjacent issues" below; it wants its own PR.

So this PR hosts the guard where a lane already runs.

## What users will see

Nothing directly — no product surface changes. Downstream, the class of defect that broke every AMR run in beta.148 now has a merge-gate lane that fails on it instead of reaching a published build.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — moves one test file; no source change.

## What changed

`apps/daemon/tests/server-identifier-scope.test.ts` → `e2e/tests/server-identifier-scope.test.ts`. Git reports it as a rename: the only functional edit is the `server.ts` path (now resolved from the repo root) plus a docblock recording the placement rationale. Both self-checks that keep the guard from going vacuous are preserved verbatim.

### Why `e2e/tests/` is the right home, structurally

Not "a lane that happens to run" — a lane whose arming is itself guarded:

1. **The lane is always armed for the code under guard.** Any change under `apps/daemon/src/` matches `certain-daemon-core` (`scripts/scopes.ts`), whose effects include `ui_p0_validation_required`; `run_e2e_vitest` is `isFull || web_tests_required || ui_p0_validation_required`. Verified at the strictest threshold there is:

   ```
   $ node --experimental-strip-types scripts/scopes.ts plan \
       --context merge-queue --files apps/daemon/src/server.ts
   "ruleHits": { "certain-daemon-core": 1 },  "escalations": [],
   "run_e2e_vitest": true
   ```

   An unresolved file list escalates fail-closed to full, which arms it too.

2. **That wiring cannot rot silently.** The `daemon core boundary` guard (`scripts/lib/guard/scope.ts`) asserts `ci.yml` still contains both `run_e2e_vitest == 'true'` and `pnpm --filter @open-design/e2e test`, and runs in the always-on policy floor. `specs/current/ci.md` lists exactly this among the daemon-core guard's obligations ("the workflow continues to execute E2E Vitest and the full UI P0 matrix").

3. **It is the sanctioned home for this shape of check.** The check only ever reads `server.ts` as text — no daemon boot, no fixtures, no ports. Reading another app's tree as a repository resource is what root `AGENTS.md` routes to `e2e/tests/`, and the daemon-core guard names `e2e/tests/critique-coverage.test.ts` as the authoritative precedent for precisely that.

The guard also uses `noResolve`, so it never loads the dependency graph — an unresolvable *module* can never masquerade as an unresolvable *identifier*.

## Bug fix verification

- Test path: `e2e/tests/server-identifier-scope.test.ts`
- Red on pre-fix code, green on fixed: **yes**

Method — checked out `server.ts` from `d4592d3be^` (the pre-#6240 state, both defects present) into the branch, leaving everything else untouched. Reporting process exit codes, not reporter prose:

**Red** (`PROCESS_EXIT_CODE=1`) — names both real defects at their exact lines:

```
FAIL  tests/server-identifier-scope.test.ts > server.ts identifier scope
      > has no identifier that reaches runtime unbound
AssertionError: expected [ …(4) ] to deeply equal []
+   "appVersionForCapture (line 9261)",
+   "effectiveSkillId (line 9657)",
+   "effectiveSkillId (line 9657)",
+   "effectiveSkillId (line 9658)",
```

`appVersionForCapture` is the shipped P0. `effectiveSkillId` is the silent sibling #6240 also fixed — a `typeof` guard on an undeclared name does not throw, so it degraded to a wrong telemetry label for a whole release rather than crashing.

**Green** after restoring `server.ts` (`PROCESS_EXIT_CODE=0`, `Test Files 1 passed`, `Tests 3 passed`).

Note the two self-checks stayed green across both runs, which is the intended behavior: they assert on inline fixtures, not on `server.ts`, so they prove the checker still detects the bug shape independently of whatever `server.ts` currently contains.

**This PR's own PR run does *not* execute the guard, for a reason worth flagging** (item 2 below): git detects the move as a rename, so GitHub's files API returns a single entry (`status: "renamed"`, `filename` = the new `e2e/` path, `previous_filename` = the old `apps/daemon/` path). Scope detection reads `filename` only, so the daemon-side path never enters the file list — the CI trace shows `fileCount: 1` with `ruleHits: { workspace-fallback: 1, ui-critical-fallback: 1 }` and no `certain-daemon-core`, hence `E2E Vitest: skipping`. The merge queue does run it (`e2e/tests/**` is below the `certain` threshold, so it escalates fail-closed to full).

To get real in-lane evidence before merge rather than at queue time, I dispatched a manual full run on this branch: **[run 30459140053](https://github.com/nexu-io/open-design/actions/runs/30459140053)**. Result recorded in a comment below.

None of this weakens what the guard protects: the arming claim is about **`server.ts` changes**, and those always hit `certain-daemon-core` (verified above at the merge-queue threshold). It only means this particular PR — which touches no daemon source — cannot self-validate on its PR run.

## Validation

- `pnpm guard` → exit 0. Relevant checks green: `Certain-exempt consumption check passed`, `Daemon core boundary check passed`, `E2E layout check passed`, `Test layout check passed`. The consumption guard's conditional `trae-cli.test.ts` exception still holds — this PR does not touch the daemon invocation.
- `pnpm --filter @open-design/e2e typecheck` (`tsc -p tsconfig.json --noEmit`) → exit 0.
- `e2e` script-contract suite (`vitest run tests/scripts`) → exit 0, 13 files / 146 tests passed, so the `scopes.ts` rule-table goldens are unchanged by this PR.
- Guard suite itself: red/green as documented above.
- Scope plans re-derived offline via `scripts/scopes.ts plan` for `--context pr` and `--context merge-queue`.
- No dangling references to the old path (`grep -rn server-identifier-scope` finds only the new file).

## Adjacent issues (deliberately not fixed here)

1. **The daemon lane still gates 1 of 576 files.** This PR rescues one guard; it does not fix the lane. The narrowing was not a considered coverage decision: before #4450 (`Optimize CI runtime topology`, 2026-06-17) the lane was its own `daemon_workspace_tests` job running the **full** suite across a `["1/3","2/3","3/3"]` shard matrix with a `daemon_workspace_gate` aggregator. #4450 was a performance reshape whose own changelog includes "Temporarily narrow CI debug scope" and "Simplify daemon CI topology"; its PR body claims no daemon-coverage change. Six weeks later #6047 (2026-07-27) pinned the resulting one-file command as `DAEMON_LANE_ALLOWED_TEST_COMMAND`, converting an intended-temporary debug narrowing into a policy premise. Two days after that, beta.148 shipped.

   Restoring it is a *job* change, not a step edit — today's step lives inside `workspace_unit_tests`, which shares a single `timeout-minutes: 20` budget with contracts/host/platform/sidecar/sidecar-proto plus conditional desktop/packaged/tools-pack work, and `apps/daemon/vitest.config.ts` sets `fileParallelism: false` on purpose ("these suites mutate process-wide env/PATH and bind real local servers"). So 576 files cannot be dropped into that step; the pre-#4450 sharded job is the shape that fit.

   **Measured cost.** A deterministic stratified sample — every 14th file of the sorted tree, 42 of 576 — runs serially in **122 s** (`exit 0`, 42/42 files, 607/607 tests):

   | | |
   |---|---|
   | per-file mean | 2.90 s |
   | extrapolated full serial | **~27.9 min** |
   | sharded 2× | ~13.9 min/shard |
   | sharded 3× | ~9.3 min/shard |
   | sharded 4× | ~7.0 min/shard |

   Measured on an M-series laptop, so treat ~28 min as a floor for CI hardware. That confirms the shape of the decision: the full suite does **not** fit the existing 20-minute shared step, but at 3× sharding it lands around 9 min/shard — which is exactly why the pre-#4450 topology used `["1/3","2/3","3/3"]` with a 20-minute-per-shard budget. Restoring that topology is a known-good configuration, not a guess.

   **Drift looks small, not scary.** The stratified 42-file sample was 100% green on today's branch. A full local run (which I killed at ~20 min after it began contending for disk) had surfaced 5 failing files by then, and they are mostly not real drift: `media-codex-imagegen-live.test.ts` and `vela-login-activation-e2e.local.test.ts` are environment-gated by name (`-live`, `.local`) and would need CI gating regardless; `plugins-preview-route.test.ts` fails only because my worktree symlinks `node_modules` to a checkout whose `packages/contracts` predates `workspaceName` on `WorkspaceCollabContext`, so its shelled-out `tsc` fails on type skew that does not exist in CI. That leaves `mocks-golden.test.ts` and `project-upload-filenames.test.ts` as the only genuinely unknown ones. A real assessment needs a clean install, which I could not afford on this disk.

   **The decision, stated plainly.** Restoring daemon coverage is one PR that (a) relocates the single `it(...)` out of `trae-cli.test.ts` to discharge the guard exception, (b) restores a `daemon_workspace_tests` job with a 3-shard matrix plus its aggregator gate, (c) triages the handful of environment-gated/drifted files, and (d) updates the `DAEMON_LANE_ALLOWED_TEST_COMMAND` premise and the `certain-daemon-core` evidence in `specs/current/ci.md`. The blocker is not technical difficulty — it is ~28 runner-minutes per armed daemon change (≈3 shards × 9.3 min) that somebody has to agree to spend, and `specs/current/ci.md` requires the certain-tier evidence to be restated when the plan changes. **That is a maintainer call on runner spend, so I am stopping here rather than making it.**

   Notably the un-allowlisting cost is *small*, not the blocker it looks like: `trae-cli.test.ts` has exactly one docs read, in one test case ("exposes public install metadata and docs without internal COCO leakage"), which scans `defs/trae-cli.ts` + `metadata.ts` + `docs/agent-adapters.md` for internal-brand leakage. That is a cross-boundary repository-resource check — the same shape this PR just relocated — so moving that single `it(...)` to `e2e/tests/` discharges the exception exactly as the script's own comment anticipates. The real cost is runner budget and unknown drift across the six ungated weeks, which needs a maintainer decision on runner spend, not a guard edit.

2. **`e2e/tests/**` arms no e2e Vitest lane on PR runs, and a rename hides the old path's rules entirely.** The first half is already recorded in `specs/current/ci.md` → Open questions (`e2e/tests/**` arms no e2e Vitest lane; "the queue is currently their only pre-main execution"). This PR ran into a sharper second half that I did not find documented anywhere:

   **A rename out of a scope-arming directory is invisible to scope detection.** GitHub reports a move as one `status: "renamed"` entry carrying both `filename` and `previous_filename`; the detector consumes `filename` only, so every rule that matched the *old* path is silently dropped. Here that erased `certain-daemon-core` and with it `daemon_tests_required`, `ui_critical_validation_required`, `ui_p0_validation_required`, and `workspace_validation_required` — a PR that git happens to classify as a rename gets a materially weaker plan than the same change split into a delete + an add.

   That generalizes beyond this PR: any move out of `apps/daemon/**` (or any other arming prefix) under-arms its own PR run. It is fail-*open* on the PR side, where the rest of the design is carefully fail-closed. The merge queue still backstops it via below-threshold escalation, so this is a PR-feedback gap rather than a path to `main`. Worth its own small PR — plausibly just feeding `previous_filename` into the changed-file list — and worth a line in `ci.md` next to the existing `e2e/tests/**` entry.

3. **`server.ts`'s `@ts-nocheck`.** This guard re-checks only the one thing the pragma suppresses that can throw. Removing the pragma from an 11,818-line file is its own project; the guard is explicitly not a typecheck of `server.ts`.
