### PR TITLE
fix(daemon): inline shared pipeline atom bodies once across active-stage blocks

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -8668,13 +8668,16 @@ export async function startServer({
         const stages = snap?.pipeline?.stages ?? [];
         if (stages.length > 0) {
           const { loadAtomBodies } = await import('./plugins/atom-bodies.js');
-          const { renderActiveStageBlock } = await import('@open-design/contracts');
-          const blocks = [];
+          const { renderActiveStageBlocks } = await import('@open-design/contracts');
+          const stageViews = [];
           for (const stage of stages) {
             const bodies = await loadAtomBodies(db, stage.atoms ?? []);
-            const block = renderActiveStageBlock({ stageId: stage.id, bodies });
-            if (block.trim().length > 0) blocks.push(block);
+            stageViews.push({ stageId: stage.id, bodies });
           }
+          // Issue #6238 — the builder inlines each atom body exactly
+          // once across the pipeline; stages that re-declare an atom
+          // get a one-line back-reference instead of the full body.
+          const blocks = renderActiveStageBlocks(stageViews);
           if (blocks.length > 0) activeStageBlocks = blocks;
         }
       } catch (err) {

--- a/apps/daemon/tests/plugins-atom-bodies.test.ts
+++ b/apps/daemon/tests/plugins-atom-bodies.test.ts
@@ -15,7 +15,7 @@ import Database from 'better-sqlite3';
 import { migratePlugins } from '../src/plugins/persistence.js';
 import { registerBundledPlugins } from '../src/plugins/bundled.js';
 import { loadAtomBodies } from '../src/plugins/atom-bodies.js';
-import { renderActiveStageBlock } from '@open-design/contracts';
+import { renderActiveStageBlock, renderActiveStageBlocks } from '@open-design/contracts';
 
 const SAMPLE_MANIFEST = (id: string) =>
   JSON.stringify({
@@ -90,5 +90,35 @@ describe('renderActiveStageBlock + loadAtomBodies (end-to-end stage block)', () 
     expect(block).toContain('Ask the user about audience.');
     expect(block).toContain('### todo-write');
     expect(block).toContain('Commit a numbered plan.');
+  });
+});
+
+describe('renderActiveStageBlocks + loadAtomBodies (issue #6238 cross-stage dedup)', () => {
+  it('inlines an atom shared by two stages exactly once, mirroring the server composer loop', async () => {
+    // Same shape as the `activeStageBlocks` build in server.ts and the
+    // od-default pipeline: `discovery-question-form` declared by both
+    // `task-type` and `discovery`.
+    const stages = [
+      { id: 'task-type', atoms: ['discovery-question-form'] },
+      { id: 'discovery', atoms: ['discovery-question-form', 'todo-write'] },
+    ];
+    const stageViews = [];
+    for (const stage of stages) {
+      stageViews.push({ stageId: stage.id, bodies: await loadAtomBodies(db, stage.atoms) });
+    }
+    const blocks = renderActiveStageBlocks(stageViews);
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toContain('## Active stage: task-type');
+    expect(blocks[1]).toContain('## Active stage: discovery');
+    // Full body once, under the first stage only.
+    const joined = blocks.join('\n');
+    expect(joined.split('Ask the user about audience.').length - 1).toBe(1);
+    expect(blocks[0]).toContain('Ask the user about audience.');
+    // Second stage keeps the subsection but points back instead of repeating.
+    expect(blocks[1]).toContain('### discovery-question-form');
+    expect(blocks[1]).toContain('already included');
+    // Unshared atoms are unaffected.
+    expect(blocks[1]).toContain('Commit a numbered plan.');
   });
 });

--- a/packages/contracts/src/prompts/atom-block.ts
+++ b/packages/contracts/src/prompts/atom-block.ts
@@ -37,6 +37,57 @@ export interface AtomBodyEntryView {
  *
  *   The trailing `---` separator is omitted after the last atom.
  */
+export interface StageAtomBodiesView {
+  stageId:    string;
+  bodies:     ReadonlyArray<AtomBodyEntryView>;
+  iteration?: number;
+}
+
+/**
+ * Render every pipeline stage's `## Active stage` block, inlining each
+ * atom's body exactly once across the whole pipeline (issue #6238).
+ *
+ * Invariant: the first stage that carries a non-empty body for an atom
+ * inlines it in full; any later stage that references the same atom
+ * keeps its `### <atomId>` subsection but replaces the body with a
+ * one-line pointer back to the stage that inlined it. Stage headers are
+ * preserved per spec §23.4 (each stage still renders its own block);
+ * only the duplicated body text is collapsed.
+ *
+ * Stages whose atoms all resolve to empty bodies render nothing and are
+ * dropped, matching `renderActiveStageBlock`'s empty-string contract.
+ */
+export function renderActiveStageBlocks(
+  stages: ReadonlyArray<StageAtomBodiesView>,
+): string[] {
+  const inlinedAtomStage = new Map<string, string>();
+  const blocks: string[] = [];
+  for (const stage of stages) {
+    const bodies = stage.bodies
+      .filter((entry) => entry.body && entry.atomId)
+      .map((entry) => {
+        const firstStageId = inlinedAtomStage.get(entry.atomId);
+        if (firstStageId !== undefined) {
+          return {
+            atomId: entry.atomId,
+            body:
+              `Atom \`${entry.atomId}\` — body already included under `
+              + `\`## Active stage: ${firstStageId}\` above; apply it in this stage as well.`,
+          };
+        }
+        inlinedAtomStage.set(entry.atomId, stage.stageId);
+        return entry;
+      });
+    const block = renderActiveStageBlock({
+      stageId: stage.stageId,
+      bodies,
+      ...(stage.iteration !== undefined ? { iteration: stage.iteration } : {}),
+    });
+    if (block.trim().length > 0) blocks.push(block);
+  }
+  return blocks;
+}
+
 export function renderActiveStageBlock(args: {
   stageId:    string;
   bodies:     ReadonlyArray<AtomBodyEntryView>;

--- a/packages/contracts/tests/atom-block.test.ts
+++ b/packages/contracts/tests/atom-block.test.ts
@@ -1,7 +1,10 @@
 // Phase 4 / spec §23.4 — renderActiveStageBlock contract test.
 
 import { describe, expect, it } from 'vitest';
-import { renderActiveStageBlock } from '../src/prompts/atom-block.js';
+import {
+  renderActiveStageBlock,
+  renderActiveStageBlocks,
+} from '../src/prompts/atom-block.js';
 
 describe('renderActiveStageBlock', () => {
   it('returns an empty string when no bodies are supplied', () => {
@@ -50,5 +53,89 @@ describe('renderActiveStageBlock', () => {
       bodies:    [{ atomId: 'critique-theater', body: 'Score 0-5 along 5 axes.' }],
     });
     expect(out).toContain('## Active stage: critique (iteration 2)');
+  });
+});
+
+// Issue #6238 — an atom shared by multiple pipeline stages (od-default
+// declares `discovery-question-form` in both `task-type` and
+// `discovery`) must have its full SKILL.md body inlined exactly once;
+// later stages reference the earlier inline instead of repeating it.
+describe('renderActiveStageBlocks (cross-stage atom dedup)', () => {
+  const questionFormBody = 'Emit a <question-form> artifact to clarify intent.';
+
+  it('inlines a shared atom body only in the first stage that uses it', () => {
+    const blocks = renderActiveStageBlocks([
+      {
+        stageId: 'task-type',
+        bodies:  [{ atomId: 'discovery-question-form', body: questionFormBody }],
+      },
+      {
+        stageId: 'discovery',
+        bodies:  [{ atomId: 'discovery-question-form', body: questionFormBody }],
+      },
+    ]);
+
+    expect(blocks).toHaveLength(2);
+    // Both stages keep their §23.4 headers.
+    expect(blocks[0]).toContain('## Active stage: task-type');
+    expect(blocks[1]).toContain('## Active stage: discovery');
+    // The full body appears exactly once across all blocks.
+    const joined = blocks.join('\n');
+    expect(joined.split(questionFormBody).length - 1).toBe(1);
+    // The first stage carries the inline body …
+    expect(blocks[0]).toContain(questionFormBody);
+    // … and the later stage carries a reference back to it instead.
+    expect(blocks[1]).toContain('### discovery-question-form');
+    expect(blocks[1]).not.toContain(questionFormBody);
+    expect(blocks[1]).toContain('## Active stage: task-type');
+  });
+
+  it('leaves distinct atoms untouched across stages', () => {
+    const blocks = renderActiveStageBlocks([
+      {
+        stageId: 'plan',
+        bodies:  [{ atomId: 'todo-write', body: 'TodoWrite-driven plan.' }],
+      },
+      {
+        stageId: 'critique',
+        bodies:  [{ atomId: 'critique-theater', body: 'Score 0-5 along 5 axes.' }],
+      },
+    ]);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toContain('TodoWrite-driven plan.');
+    expect(blocks[1]).toContain('Score 0-5 along 5 axes.');
+    expect(blocks[1]).not.toContain('already included');
+  });
+
+  it('drops stages whose atoms all resolve to empty bodies', () => {
+    const blocks = renderActiveStageBlocks([
+      { stageId: 'empty', bodies: [{ atomId: 'ghost', body: '' }] },
+      { stageId: 'plan',  bodies: [{ atomId: 'todo-write', body: 'Plan.' }] },
+    ]);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toContain('## Active stage: plan');
+  });
+
+  it('does not treat an empty-body occurrence as the first inline', () => {
+    // If the first stage's copy of the atom failed to load (empty body),
+    // the next stage with a real body must still inline it in full.
+    const blocks = renderActiveStageBlocks([
+      { stageId: 'task-type', bodies: [{ atomId: 'discovery-question-form', body: '' }] },
+      { stageId: 'discovery', bodies: [{ atomId: 'discovery-question-form', body: questionFormBody }] },
+    ]);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toContain('## Active stage: discovery');
+    expect(blocks[0]).toContain(questionFormBody);
+  });
+
+  it('forwards iteration to the per-stage header', () => {
+    const blocks = renderActiveStageBlocks([
+      {
+        stageId:   'critique',
+        iteration: 2,
+        bodies:    [{ atomId: 'critique-theater', body: 'Score.' }],
+      },
+    ]);
+    expect(blocks[0]).toContain('## Active stage: critique (iteration 2)');
   });
 });


### PR DESCRIPTION
Fixes #6238

## Why

Captured first-turn prompts on `main` (via a `CLAUDE_BIN` tee wrapper) show the full `discovery-question-form` SKILL.md body (~70 lines including the `<question-form id="discovery">` example markup) inlined twice — once under `## Active stage: task-type` and again under `## Active stage: discovery`. The bundled `od-default` scenario declares that atom in both stages, and the `activeStageBlocks` build in `apps/daemon/src/server.ts` rendered each stage independently with no cross-stage dedup. Since `od-default` is the hidden fallback for free-form Home prompts, essentially every default run shipped the duplicated instruction text: wasted tokens and a prompt that repeats itself verbatim.

The pain is on the prompt-quality/cost side: duplicated instructions inflate every default run's system prompt and are exactly the kind of drift that makes composed prompts hard to audit.

## What users will see

No visible UI change. Agent runs under a plugin whose pipeline shares an atom across stages (including every default free-form Home run) now receive one copy of each atom body in the system prompt; the later stage carries a one-line back-reference ("body already included under `## Active stage: task-type` above; apply it in this stage as well.") instead of the full duplicate. Both `## Active stage` headers are preserved per spec §23.4.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — new pure helper `renderActiveStageBlocks` (and `StageAtomBodiesView`) exported from `packages/contracts` (`src/prompts/atom-block.ts`); no endpoint or SSE changes
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — the composed system prompt for runs whose applied plugin shares an atom across stages no longer repeats the atom body (no opt-in; `OD_BUNDLED_ATOM_PROMPTS=0` still disables stage blocks entirely, unchanged)
- [ ] **None**

## Screenshots

Not applicable (no UI surface).

## Bug fix verification

- Test path that reproduces the bug: `packages/contracts/tests/atom-block.test.ts` (`renderActiveStageBlocks (cross-stage atom dedup)` describe block — asserts a shared atom body appears exactly once across two stage blocks), plus a daemon-side integration spec mirroring the server composer loop in `apps/daemon/tests/plugins-atom-bodies.test.ts` (`renderActiveStageBlocks + loadAtomBodies (issue #6238 cross-stage dedup)`).
- Did the test go red on `main` and green on this branch? **Yes.** With the `packages/contracts/src/prompts/atom-block.ts` change stashed (i.e. pre-fix source), the contracts suite fails 5 tests and the daemon spec fails 1; with the fix restored, contracts is 251/251 and the daemon file 5/5.
- The dedup invariant lives in the new contracts builder, so the red spec targets it directly at the cheapest layer (pure contracts unit test) per the bug-follow-up playbook; the daemon spec pins the `loadAtomBodies` → builder integration in the same shape as the `server.ts` loop.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass (all workspace projects)
- `pnpm --filter @open-design/contracts build` — pass (esbuild + `tsc --emitDeclarationOnly` under `exactOptionalPropertyTypes`)
- `pnpm --filter @open-design/contracts test` — 251/251 pass
- Daemon, scoped to the touched surface: `pnpm vitest run tests/plugins-atom-bodies.test.ts tests/plugins-bundled-atom-prompts-default.test.ts tests/plugins-pipeline-runner.test.ts tests/plugins-discovery-question-form-contract.test.ts tests/official-system-prompt.test.ts tests/system-prompt-template.test.ts tests/prompt-telemetry.test.ts tests/plugins-apply.test.ts tests/plugins-snapshots.test.ts` — 81/81 pass

## Adjacent issues

- The issue lists two alternative resolutions (expanding only the current stage, or editing the `od-default` manifest). Deliberately not taken here: composition-time dedup is the minimal fix that keeps spec §23.4 stage rendering intact and hardens the composer against **any** plugin that shares atoms, not just the bundled one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
