### PR TITLE
fix(web): guard workspace-scoped catalog reads

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1467,8 +1467,12 @@ function AppInner() {
         markSkillRegistryReady('templates');
       });
 
+      const designSystemsRead = beginWorkspaceScopedRead(workspaceContextRef.current);
       void fetchDesignSystems().then((list) => {
-        if (cancelled) return;
+        if (
+          cancelled ||
+          !designSystemsRead.isStillCurrent(workspaceContextRef.current)
+        ) return;
         setDesignSystems(list);
         setDsLoading(false);
       });
@@ -1744,7 +1748,15 @@ function AppInner() {
   ]);
 
   const refreshDesignSystems = useCallback(async () => {
+    // `fetchDesignSystems()` takes no context — the daemon resolves the scope
+    // from its OWN vela session (`resolveWorkspaceScope`), not from request
+    // headers. That makes no difference here: the identity this guard is about
+    // is the COMMIT-time one. The response still describes whichever workspace
+    // was active when the request was issued, so a slow read for the workspace
+    // the user has left would still restore its library over the current one.
+    const read = beginWorkspaceScopedRead(workspaceContextRef.current);
     const list = await fetchDesignSystems();
+    if (!read.isStillCurrent(workspaceContextRef.current)) return;
     setDesignSystems(list);
     // Bootstrap and this workspace-scoped refresh can overlap on launch.
     // Either response is a complete catalog for the active daemon identity,
@@ -2953,7 +2965,7 @@ function AppInner() {
 
   const handleDesignSystemsChanged = useCallback(
     (affectedDesignSystemId?: string) => {
-      void fetchDesignSystems().then((list) => setDesignSystems(list));
+      void refreshDesignSystems();
       iframeKeepAlivePool.evictMatching(
         (entry) => {
           const proj = projectsRef.current.find((p) => p.id === entry.projectId);
@@ -2966,7 +2978,7 @@ function AppInner() {
         { includeActive: true },
       );
     },
-    [iframeKeepAlivePool],
+    [iframeKeepAlivePool, refreshDesignSystems],
   );
   const handleDesignSystemImportRebuildJob = useCallback(
     (designSystemId: string, job: DesignSystemGenerationJob) => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1467,11 +1467,11 @@ function AppInner() {
         markSkillRegistryReady('templates');
       });
 
-      const designSystemsRead = beginWorkspaceScopedRead(workspaceContextRef.current);
+      const designSystemsWorkspaceId = workspaceContextRef.current?.workspaceId ?? null;
       void fetchDesignSystems().then((list) => {
         if (
           cancelled ||
-          !designSystemsRead.isStillCurrent(workspaceContextRef.current)
+          (workspaceContextRef.current?.workspaceId ?? null) !== designSystemsWorkspaceId
         ) return;
         setDesignSystems(list);
         setDsLoading(false);
@@ -1750,13 +1750,13 @@ function AppInner() {
   const refreshDesignSystems = useCallback(async () => {
     // `fetchDesignSystems()` takes no context — the daemon resolves the scope
     // from its OWN vela session (`resolveWorkspaceScope`), not from request
-    // headers. That makes no difference here: the identity this guard is about
-    // is the COMMIT-time one. The response still describes whichever workspace
-    // was active when the request was issued, so a slow read for the workspace
-    // the user has left would still restore its library over the current one.
-    const read = beginWorkspaceScopedRead(workspaceContextRef.current);
+    // headers. The catalog itself is keyed only by workspaceId, so the commit
+    // guard deliberately uses that SAME scope: role/member/permission changes
+    // must not discard a still-valid response without scheduling a successor.
+    // A slow read for a different workspace still cannot restore its library.
+    const issuedWorkspaceId = workspaceContextRef.current?.workspaceId ?? null;
     const list = await fetchDesignSystems();
-    if (!read.isStillCurrent(workspaceContextRef.current)) return;
+    if ((workspaceContextRef.current?.workspaceId ?? null) !== issuedWorkspaceId) return;
     setDesignSystems(list);
     // Bootstrap and this workspace-scoped refresh can overlap on launch.
     // Either response is a complete catalog for the active daemon identity,

--- a/apps/web/src/components/PluginsView.tsx
+++ b/apps/web/src/components/PluginsView.tsx
@@ -18,6 +18,7 @@ import {
   type InstalledPluginRecord,
   type PluginSourceKind,
   type SkillSummary,
+  type WorkspaceCollabContext,
 } from '@open-design/contracts';
 import {
   fetchSkills,
@@ -77,7 +78,11 @@ import { copyToClipboard } from '../lib/copy-to-clipboard';
 import type { PluginUseAction } from './plugins-home/useActions';
 import { AnimatePresence } from 'motion/react';
 import { navigate } from '../router';
-import { useWorkspaceContext } from '../collab/useWorkspaceContext';
+import {
+  beginWorkspaceScopedRead,
+  useWorkspaceContext,
+  workspaceIdentityCacheKey,
+} from '../collab/useWorkspaceContext';
 
 type PluginsTab = 'installed' | 'available' | 'sources' | 'team';
 
@@ -665,7 +670,13 @@ export function PluginsView({
           />
         ) : null}
 
-        {activeTab === 'team' ? <TeamPanel t={t} plugins={userPlugins} /> : null}
+        {activeTab === 'team' ? (
+          <TeamPanel
+            t={t}
+            plugins={userPlugins}
+            workspaceContext={pluginsWorkspaceContext}
+          />
+        ) : null}
       </div>
 
       <AnimatePresence>
@@ -907,7 +918,13 @@ export function ExtensionsMarketplace({
   const { locale, t } = useI18n();
   const analytics = useAnalytics();
   // My own member id, to keep the Personal tab to resources I actually own.
-  const { context: workspaceContext } = useWorkspaceContext();
+  const { context: workspaceContext, loading: workspaceContextLoading } = useWorkspaceContext();
+  // The LATEST context, for `refresh()`'s commit guard. `refresh` is recreated
+  // every render, but the mount effect below captures one closure — so the guard
+  // must compare against a ref, not the captured prop, or it compares the
+  // identity the read was issued for against itself and never fires.
+  const emContextRef = useRef(workspaceContext);
+  emContextRef.current = workspaceContext;
   const myMemberId = workspaceContext?.workspaceMemberId ?? null;
   // The 团队 scope is a team-workspace surface backed by the resource hub: it
   // lists the resources shared into the team and offers a share-to-team action.
@@ -1117,6 +1134,7 @@ export function ExtensionsMarketplace({
   }
 
   async function refresh() {
+    const read = beginWorkspaceScopedRead(emContextRef.current);
     setLoading(true);
     const [rows, allRows, catalogs, skillRows] = await Promise.all([
       listPlugins(),
@@ -1126,8 +1144,13 @@ export function ExtensionsMarketplace({
       // its workspace-scoped filter — mirrors `listPlugins`'s
       // `workspaceContext` in `PluginsView` above (routes/plugins/index.ts's
       // `GET /api/plugins`).
-      fetchSkills(workspaceContext),
+      fetchSkills(read.context),
     ]);
+    // Discard an answer for an identity the user has left. `setLoading(false)` is
+    // deliberately skipped too: a stale response is not evidence that the CURRENT
+    // identity's catalog has arrived, and the successor read the effect below
+    // guarantees for every identity change owns clearing it.
+    if (!read.isStillCurrent(emContextRef.current)) return;
     setPlugins(rows);
     setAllInstalledPlugins(allRows);
     setMarketplaces(catalogs);
@@ -1135,11 +1158,37 @@ export function ExtensionsMarketplace({
     setLoading(false);
   }
 
+  // `open-design:plugins-changed` re-reads on mutation. Re-registered per
+  // identity so the handler always closes over a current `refresh`.
+  const marketplaceIdentity = workspaceIdentityCacheKey(workspaceContext);
   useEffect(() => {
+    const onPluginsChanged = () => {
+      void refresh();
+    };
+    window.addEventListener('open-design:plugins-changed', onPluginsChanged);
+    return () => window.removeEventListener('open-design:plugins-changed', onPluginsChanged);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [marketplaceIdentity]);
+
+  // The initial read waits for the workspace context to SETTLE. This effect used
+  // to have `[]` deps, which meant the mount closure ran with whatever context
+  // existed on the first render — `null` on a cold open, since
+  // `useWorkspaceContext` seeds from a module cache that a fresh load has not
+  // filled yet. So the marketplace asked `GET /api/skills` headerless and the
+  // daemon answered fail-closed, hiding every workspace-claimed skill; and
+  // because the deps were empty, nothing ever re-read it for the real identity.
+  //
+  // Keyed on the identity digest and guarded by a ref, so a cold mount spends
+  // exactly ONE read (once the context lands) rather than one per render, and a
+  // later workspace switch spends exactly one more.
+  const refreshedIdentityRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (workspaceContextLoading) return;
+    if (refreshedIdentityRef.current === marketplaceIdentity) return;
+    refreshedIdentityRef.current = marketplaceIdentity;
     void refresh();
-    window.addEventListener('open-design:plugins-changed', refresh);
-    return () => window.removeEventListener('open-design:plugins-changed', refresh);
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceContextLoading, marketplaceIdentity]);
 
   const refreshSharedResources = useCallback(async () => {
     const loadShared = async (
@@ -3692,11 +3741,24 @@ function normalizePluginName(name: string): string {
 function TeamPanel({
   t,
   plugins,
+  workspaceContext,
 }: {
   t: ReturnType<typeof useI18n>['t'];
   plugins: InstalledPluginRecord[];
+  /** The acting workspace, passed down from `PluginsView` (which already holds
+   *  it) rather than read again here, so this panel and the plugin list it sits
+   *  beside can never disagree about who is asking. */
+  workspaceContext: WorkspaceCollabContext | null;
 }) {
   const { locale } = useI18n();
+  // The LATEST context, for async work to compare against. `refreshTeamPanelShared`
+  // is a `useCallback` with `[]` deps — it closes over the FIRST render's props
+  // forever, so reading `workspaceContext` directly inside it would pin whatever
+  // was there on mount (typically `null`) and a commit guard built on it would
+  // compare that stale value against itself and pass unconditionally.
+  const contextRef = useRef(workspaceContext);
+  contextRef.current = workspaceContext;
+  const workspaceIdentityKey = workspaceIdentityCacheKey(workspaceContext);
   const [skills, setSkills] = useState<SkillSummary[]>([]);
   const [sharedPluginIds, setSharedPluginIds] = useState<ReadonlySet<string>>(() => new Set());
   const [sharedSkillIds, setSharedSkillIds] = useState<ReadonlySet<string>>(() => new Set());
@@ -3704,6 +3766,7 @@ function TeamPanel({
   const [failed, setFailed] = useState(false);
 
   const refreshTeamPanelShared = useCallback(async (cancelled: () => boolean = () => false) => {
+    const read = beginWorkspaceScopedRead(contextRef.current);
     const loadShared = async (
       basePath: string,
       setter: (ids: ReadonlySet<string>) => void,
@@ -3712,15 +3775,27 @@ function TeamPanel({
         const res = await fetch(`/api/workspace/${basePath}/team`, { cache: 'no-store' });
         if (!res.ok) return;
         const body = (await res.json()) as { ids?: unknown };
-        if (!cancelled() && Array.isArray(body.ids)) {
+        if (
+          !cancelled()
+          && read.isStillCurrent(contextRef.current)
+          && Array.isArray(body.ids)
+        ) {
           setter(new Set(body.ids.filter((id): id is string => typeof id === 'string')));
         }
       } catch {
         // Off-team / offline → leave the collection empty.
       }
     };
-    const userSkills = (await fetchSkills()).filter((s) => s.source === 'user');
-    if (!cancelled()) setSkills(userSkills);
+    // Scoped: this list drives which of MY skills can be shared to the team, so
+    // reading it without workspace headers made the daemon answer fail-closed —
+    // `GET /api/skills` hides every workspace-claimed skill from a headerless
+    // reader (`skills.ts`: `if (!scopeId) return !ownerId;`), including skills
+    // claimed by the very workspace being shared into.
+    const userSkills = (await fetchSkills(read.context)).filter((s) => s.source === 'user');
+    // `cancelled()` covers the identity-keyed effect cleanup, but a manual share
+    // refresh uses the default predicate and overlapping refreshes can still
+    // outlive the identity they were issued for.
+    if (!cancelled() && read.isStillCurrent(contextRef.current)) setSkills(userSkills);
     await Promise.all([
       loadShared('plugins', setSharedPluginIds),
       loadShared('skills', setSharedSkillIds),
@@ -3744,7 +3819,7 @@ function TeamPanel({
       window.removeEventListener('pageshow', refreshVisible);
       document.removeEventListener('visibilitychange', refreshVisible);
     };
-  }, [refreshTeamPanelShared]);
+  }, [refreshTeamPanelShared, workspaceIdentityKey]);
 
   async function share(
     basePath: string,

--- a/apps/web/src/components/PluginsView.tsx
+++ b/apps/web/src/components/PluginsView.tsx
@@ -224,6 +224,9 @@ export function PluginsView({
   // not fan out an extra fetch.
   const pluginsWorkspaceContextState = useWorkspaceContext();
   const { context: pluginsWorkspaceContext } = pluginsWorkspaceContextState;
+  const pluginsContextRef = useRef(pluginsWorkspaceContext);
+  pluginsContextRef.current = pluginsWorkspaceContext;
+  const pluginsIdentity = workspaceIdentityCacheKey(pluginsWorkspaceContext);
   const pluginsPageViewFiredRef = useRef(false);
   useEffect(() => {
     if (pluginsPageViewFiredRef.current) return;
@@ -258,12 +261,14 @@ export function PluginsView({
   const [notice, setNotice] = useState<PluginInstallOutcome | { ok: boolean; message: string } | null>(null);
 
   async function refresh() {
+    const read = beginWorkspaceScopedRead(pluginsContextRef.current);
     setLoading(true);
     const [rows, allRows, catalogs] = await Promise.all([
-      listPlugins({ workspaceContext: pluginsWorkspaceContext }),
-      listPlugins({ includeHidden: true, workspaceContext: pluginsWorkspaceContext }),
+      listPlugins({ workspaceContext: read.context }),
+      listPlugins({ includeHidden: true, workspaceContext: read.context }),
       listPluginMarketplaces(),
     ]);
+    if (!read.isStillCurrent(pluginsContextRef.current)) return;
     setPlugins(rows);
     setAllInstalledPlugins(allRows);
     setMarketplaces(catalogs);
@@ -277,7 +282,7 @@ export function PluginsView({
     // Re-run on workspace switch (not just mount) so "installed" reflects the
     // newly active workspace's binding — see `pluginsWorkspaceContext` above.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pluginsWorkspaceContext?.workspaceId]);
+  }, [pluginsIdentity]);
 
   const userPlugins = useMemo(
     () => plugins.filter(isPersonalPluginRecord),
@@ -1191,6 +1196,7 @@ export function ExtensionsMarketplace({
   }, [workspaceContextLoading, marketplaceIdentity]);
 
   const refreshSharedResources = useCallback(async () => {
+    const read = beginWorkspaceScopedRead(emContextRef.current);
     const loadShared = async (
       basePath: string,
       setter: Dispatch<SetStateAction<ReadonlySet<string>>>,
@@ -1200,6 +1206,7 @@ export function ExtensionsMarketplace({
         const res = await fetch(`/api/workspace/${basePath}/team`, { cache: 'no-store' });
         if (!res.ok) return;
         const body = (await res.json()) as { ids?: unknown; resources?: unknown };
+        if (!read.isStillCurrent(emContextRef.current)) return;
         if (Array.isArray(body.ids)) {
           const nextIds = new Set(body.ids.filter((id): id is string => typeof id === 'string'));
           setter((prev) => setsEqual(prev, nextIds) ? prev : nextIds);
@@ -1253,7 +1260,7 @@ export function ExtensionsMarketplace({
       window.removeEventListener('pageshow', refreshVisible);
       document.removeEventListener('visibilitychange', refreshVisible);
     };
-  }, [refreshSharedResources]);
+  }, [refreshSharedResources, marketplaceIdentity]);
 
   const userPlugins = useMemo(
     () => plugins.filter(isPersonalPluginRecord),

--- a/apps/web/tests/components/App.design-systems-loading-race.test.tsx
+++ b/apps/web/tests/components/App.design-systems-loading-race.test.tsx
@@ -315,4 +315,70 @@ describe('App design-system catalog loading race', () => {
     // One request per switch; the guard does not add a retry or another read.
     expect(readPhases.filter((readPhase) => readPhase !== 'startup')).toEqual(['a', 'b']);
   });
+
+  it('keeps an issued catalog read when only membership identity changes', async () => {
+    const pending = deferred<DesignSystemSummary[]>();
+    let activeContext = workspaceContext('ws-initial');
+    let pendingPhase = false;
+    let pendingReads = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const pathname = new URL(String(input), 'http://d.local').pathname;
+        return {
+          ok: true,
+          json: async () =>
+            pathname.endsWith('/workspace/context')
+              ? { context: activeContext }
+              : {},
+        } as Response;
+      }),
+    );
+    notifyWorkspaceContextRefresh({ context: activeContext });
+    vi.mocked(fetchDesignSystems).mockImplementation(() => {
+      if (!pendingPhase) return Promise.resolve([]);
+      pendingReads += 1;
+      return pending.promise;
+    });
+
+    render(<App />);
+    await waitFor(() => expect(fetchDesignSystems).toHaveBeenCalled());
+
+    pendingPhase = true;
+    activeContext = {
+      ...workspaceContext('ws-shared'),
+      workspaceMemberId: 'member-a',
+    };
+    await act(async () => {
+      notifyWorkspaceContextRefresh({ context: activeContext });
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(pendingReads).toBe(1));
+
+    // The daemon's Design Systems catalog is scoped by workspaceId, not by
+    // member/role/permission identity. This transition must neither invalidate
+    // the in-flight answer nor spend a redundant successor request.
+    activeContext = {
+      ...activeContext,
+      workspaceMemberId: 'member-b',
+      permissions: {
+        ...activeContext.permissions,
+        canShareProjects: false,
+      },
+    };
+    await act(async () => {
+      notifyWorkspaceContextRefresh({ context: activeContext });
+      await Promise.resolve();
+    });
+    expect(pendingReads).toBe(1);
+
+    await act(async () => {
+      pending.resolve([designSystem('system-from-shared-workspace')]);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(screen.getByText('system-from-shared-workspace')).toBeTruthy());
+    expect(screen.getByTestId('design-systems-state').dataset.loading).toBe('false');
+    expect(pendingReads).toBe(1);
+  });
 });

--- a/apps/web/tests/components/App.design-systems-loading-race.test.tsx
+++ b/apps/web/tests/components/App.design-systems-loading-race.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
-import type { DesignSystemSummary } from '@open-design/contracts';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import type { DesignSystemSummary, WorkspaceCollabContext } from '@open-design/contracts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { App } from '../../src/App';
@@ -24,6 +24,12 @@ import {
 } from '../../src/state/config';
 import { listProjects, listTemplates } from '../../src/state/projects';
 import type { AppConfig } from '../../src/types';
+import {
+  notifyWorkspaceContextRefresh,
+  resetTeamProjectsCache,
+  resetWorkspaceContextCache,
+} from '../../src/collab/useWorkspaceContext';
+import { resetCoalescedGet } from '../../src/lib/coalesced-get';
 
 vi.mock('../../src/router', () => ({
   navigate: vi.fn(),
@@ -138,7 +144,52 @@ const readySystem: DesignSystemSummary = {
   isEditable: true,
 };
 
+function workspaceContext(workspaceId: string): WorkspaceCollabContext {
+  return {
+    workspaceId,
+    workspaceType: 'team',
+    workspaceMemberId: `member-${workspaceId}`,
+    role: 'member',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+    billingState: 'active',
+    planId: null,
+    providerMode: 'platform_credits',
+    seatSummary: { seatLimit: 5, usedSeats: 1, availableSeats: 4, isSeatFull: false },
+    permissions: {
+      canManageMembers: false,
+      canManageBilling: false,
+      canInviteMembers: false,
+      canManageAutoRecharge: false,
+      canShareProjects: true,
+      canWriteSyncedFiles: true,
+      canViewWorkspaceSettings: false,
+      canManageSharedResources: false,
+    },
+    displayName: workspaceId,
+  };
+}
+
+function designSystem(id: string): DesignSystemSummary {
+  return {
+    ...readySystem,
+    id,
+    title: id,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 beforeEach(() => {
+  resetWorkspaceContextCache();
+  resetTeamProjectsCache();
+  resetCoalescedGet();
   vi.mocked(daemonIsLive).mockResolvedValue(true);
   vi.mocked(fetchAgentsStream).mockResolvedValue([]);
   vi.mocked(fetchAppVersionInfo).mockResolvedValue(null);
@@ -166,6 +217,9 @@ afterEach(() => {
   cleanup();
   vi.clearAllMocks();
   vi.unstubAllGlobals();
+  resetWorkspaceContextCache();
+  resetTeamProjectsCache();
+  resetCoalescedGet();
 });
 
 describe('App design-system catalog loading race', () => {
@@ -188,5 +242,77 @@ describe('App design-system catalog loading race', () => {
     });
 
     expect(screen.getByTestId('design-systems-state').dataset.loading).toBe('false');
+  });
+
+  it('discards a late catalog response for the workspace the user has left', async () => {
+    const readA = deferred<DesignSystemSummary[]>();
+    const readB = deferred<DesignSystemSummary[]>();
+    let activeContext = workspaceContext('ws-initial');
+    type ReadPhase = 'startup' | 'a' | 'b';
+    let phase: ReadPhase = 'startup';
+    const readPhases: ReadPhase[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const pathname = new URL(String(input), 'http://d.local').pathname;
+        return {
+          ok: true,
+          json: async () =>
+            pathname.endsWith('/workspace/context')
+              ? { context: activeContext }
+              : {},
+        } as Response;
+      }),
+    );
+    notifyWorkspaceContextRefresh({ context: activeContext });
+    vi.mocked(fetchDesignSystems).mockImplementation(() => {
+      readPhases.push(phase);
+      if (phase === 'a') return readA.promise;
+      if (phase === 'b') return readB.promise;
+      return Promise.resolve([]);
+    });
+
+    render(<App />);
+
+    // Let every pre-existing launch read settle before creating the race, so
+    // call order among bootstrap and the two home effects is irrelevant.
+    await waitFor(() =>
+      expect(readPhases.filter((readPhase) => readPhase === 'startup').length)
+        .toBeGreaterThanOrEqual(3),
+    );
+
+    phase = 'a';
+    await act(async () => {
+      activeContext = workspaceContext('ws-a');
+      notifyWorkspaceContextRefresh({ context: activeContext });
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(readPhases.filter((readPhase) => readPhase === 'a')).toHaveLength(1));
+
+    phase = 'b';
+    await act(async () => {
+      activeContext = workspaceContext('ws-b');
+      notifyWorkspaceContextRefresh({ context: activeContext });
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(readPhases.filter((readPhase) => readPhase === 'b')).toHaveLength(1));
+
+    // Resolve in reverse order: the active workspace lands first.
+    await act(async () => {
+      readB.resolve([designSystem('system-from-b')]);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(screen.getByText('system-from-b')).toBeTruthy());
+
+    // The abandoned workspace answers last and must not overwrite ws-b.
+    await act(async () => {
+      readA.resolve([designSystem('system-from-a')]);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('system-from-b')).toBeTruthy();
+    expect(screen.queryByText('system-from-a')).toBeNull();
+    // One request per switch; the guard does not add a retry or another read.
+    expect(readPhases.filter((readPhase) => readPhase !== 'startup')).toEqual(['a', 'b']);
   });
 });

--- a/apps/web/tests/components/ExtensionsMarketplace.card-actions.test.tsx
+++ b/apps/web/tests/components/ExtensionsMarketplace.card-actions.test.tsx
@@ -52,7 +52,9 @@ const TEAM_CONTEXT = {
 
 let workspaceContext: unknown = null;
 
-vi.mock('../../src/collab/useWorkspaceContext', () => ({
+// Spread the real module — see the note in ExtensionsMarketplace.team-scope.test.tsx.
+vi.mock('../../src/collab/useWorkspaceContext', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/collab/useWorkspaceContext')>()),
   useWorkspaceContext: () => ({ context: workspaceContext, loading: false, refresh: vi.fn() }),
   useWorkspaceBilling: () => null,
 }));

--- a/apps/web/tests/components/ExtensionsMarketplace.create-dialog-layout.test.tsx
+++ b/apps/web/tests/components/ExtensionsMarketplace.create-dialog-layout.test.tsx
@@ -18,7 +18,9 @@ vi.mock('../../src/analytics/provider', async (importOriginal) => {
   return { ...actual, useAnalytics: () => ({ track: vi.fn() }) };
 });
 
-vi.mock('../../src/collab/useWorkspaceContext', () => ({
+// Spread the real module — see the note in ExtensionsMarketplace.team-scope.test.tsx.
+vi.mock('../../src/collab/useWorkspaceContext', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/collab/useWorkspaceContext')>()),
   useWorkspaceContext: () => ({ context: null, loading: false, refresh: vi.fn() }),
   useWorkspaceBilling: () => null,
 }));

--- a/apps/web/tests/components/ExtensionsMarketplace.plugin-detail-entry.test.tsx
+++ b/apps/web/tests/components/ExtensionsMarketplace.plugin-detail-entry.test.tsx
@@ -20,7 +20,9 @@ vi.mock('../../src/analytics/provider', async (importOriginal) => {
   return { ...actual, useAnalytics: () => ({ track: vi.fn() }) };
 });
 
-vi.mock('../../src/collab/useWorkspaceContext', () => ({
+// Spread the real module — see the note in ExtensionsMarketplace.team-scope.test.tsx.
+vi.mock('../../src/collab/useWorkspaceContext', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/collab/useWorkspaceContext')>()),
   useWorkspaceContext: () => ({ context: null, loading: false, refresh: vi.fn() }),
   useWorkspaceBilling: () => null,
 }));

--- a/apps/web/tests/components/ExtensionsMarketplace.sync-to-team.test.tsx
+++ b/apps/web/tests/components/ExtensionsMarketplace.sync-to-team.test.tsx
@@ -60,7 +60,9 @@ const TEAM_CONTEXT = {
 
 let workspaceContext: unknown = TEAM_CONTEXT;
 
-vi.mock('../../src/collab/useWorkspaceContext', () => ({
+// Spread the real module — see the note in ExtensionsMarketplace.team-scope.test.tsx.
+vi.mock('../../src/collab/useWorkspaceContext', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/collab/useWorkspaceContext')>()),
   useWorkspaceContext: () => ({ context: workspaceContext, loading: false, refresh: vi.fn() }),
   useWorkspaceBilling: () => ({ membershipTier: '' }),
 }));

--- a/apps/web/tests/components/ExtensionsMarketplace.team-scope.test.tsx
+++ b/apps/web/tests/components/ExtensionsMarketplace.team-scope.test.tsx
@@ -12,10 +12,12 @@
 // `workspaceContextHasTeamIdentity`.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { SkillSummary } from '@open-design/contracts';
 
 import { ExtensionsMarketplace } from '../../src/components/PluginsView';
 import { I18nProvider } from '../../src/i18n';
+import { fetchSkills } from '../../src/providers/registry';
 
 vi.mock('../../src/analytics/provider', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../src/analytics/provider')>();
@@ -49,12 +51,26 @@ const PERSONAL_CONTEXT = {
 };
 
 let workspaceContext: unknown = FREE_TEAM_CONTEXT;
+let workspaceContextLoading = false;
 
-vi.mock('../../src/collab/useWorkspaceContext', () => ({
-  useWorkspaceContext: () => ({ context: workspaceContext, loading: false, refresh: vi.fn() }),
+// Spread the real module: this component also calls its PURE helpers
+// (beginWorkspaceScopedRead / workspaceIdentityCacheKey), and a mock that
+// replaces the whole module leaves them undefined at call time.
+vi.mock('../../src/collab/useWorkspaceContext', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/collab/useWorkspaceContext')>()),
+  useWorkspaceContext: () => ({
+    context: workspaceContext,
+    loading: workspaceContextLoading,
+    refresh: vi.fn(),
+  }),
   // Deliberately reports no paid plan — the fix must NOT consult this to decide
   // whether the team scope is offered.
   useWorkspaceBilling: () => ({ membershipTier: '' }),
+}));
+
+vi.mock('../../src/providers/registry', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/providers/registry')>()),
+  fetchSkills: vi.fn(),
 }));
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -65,6 +81,8 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(fetchSkills).mockResolvedValue([]);
   globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
     const url = typeof input === 'string' ? input : input.toString();
     if (url === '/api/skills') return jsonResponse({ skills: [] });
@@ -79,6 +97,7 @@ afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
   workspaceContext = FREE_TEAM_CONTEXT;
+  workspaceContextLoading = false;
 });
 
 function renderMarketplace() {
@@ -94,6 +113,25 @@ function scopeLabels(container: HTMLElement): string[] {
   return [...container.querySelectorAll('.plugin-marketplace__filters button')].map(
     (button) => (button.textContent ?? '').trim(),
   );
+}
+
+function skill(id: string): SkillSummary {
+  return {
+    id,
+    name: id,
+    description: id,
+    triggers: [],
+    mode: 'prototype',
+    source: 'builtin',
+  } as unknown as SkillSummary;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
 }
 
 describe('ExtensionsMarketplace 团队 scope visibility', () => {
@@ -121,5 +159,65 @@ describe('ExtensionsMarketplace 团队 scope visibility', () => {
       expect(container.querySelector('.plugin-marketplace__filters')).toBeTruthy();
     });
     expect(scopeLabels(container)).not.toContain('Team');
+  });
+
+  it('waits for cold-mount identity, then discards the previous workspace response', async () => {
+    const readA = deferred<SkillSummary[]>();
+    const readB = deferred<SkillSummary[]>();
+    workspaceContext = null;
+    workspaceContextLoading = true;
+    vi.mocked(fetchSkills).mockImplementation((context) =>
+      context?.workspaceId === 'ws-b' ? readB.promise : readA.promise,
+    );
+
+    const view = renderMarketplace();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // No headerless cold-mount read: the identity has not settled yet.
+    expect(fetchSkills).not.toHaveBeenCalled();
+
+    workspaceContext = { ...FREE_TEAM_CONTEXT, workspaceId: 'ws-a', teamId: 'ws-a' };
+    workspaceContextLoading = false;
+    view.rerender(
+      <I18nProvider initial="en">
+        <ExtensionsMarketplace onCreatePlugin={vi.fn()} onUsePlugin={vi.fn()} />
+      </I18nProvider>,
+    );
+    await waitFor(() =>
+      expect(
+        vi.mocked(fetchSkills).mock.calls.some(([context]) => context?.workspaceId === 'ws-a'),
+      ).toBe(true),
+    );
+
+    workspaceContext = { ...FREE_TEAM_CONTEXT, workspaceId: 'ws-b', teamId: 'ws-b' };
+    view.rerender(
+      <I18nProvider initial="en">
+        <ExtensionsMarketplace onCreatePlugin={vi.fn()} onUsePlugin={vi.fn()} />
+      </I18nProvider>,
+    );
+    await waitFor(() =>
+      expect(
+        vi.mocked(fetchSkills).mock.calls.some(([context]) => context?.workspaceId === 'ws-b'),
+      ).toBe(true),
+    );
+
+    await act(async () => {
+      readB.resolve([skill('skill-from-b')]);
+      await Promise.resolve();
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Skills' }));
+    await waitFor(() => expect(screen.getByTestId('plugins-card-skill-from-b')).toBeTruthy());
+
+    await act(async () => {
+      readA.resolve([skill('skill-from-a')]);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByTestId('plugins-card-skill-from-b')).toBeTruthy();
+    expect(screen.queryByTestId('plugins-card-skill-from-a')).toBeNull();
+    expect(
+      vi.mocked(fetchSkills).mock.calls.map(([context]) => context?.workspaceId),
+    ).toEqual(['ws-a', 'ws-b']);
   });
 });

--- a/apps/web/tests/components/ExtensionsMarketplace.team-scope.test.tsx
+++ b/apps/web/tests/components/ExtensionsMarketplace.team-scope.test.tsx
@@ -220,4 +220,103 @@ describe('ExtensionsMarketplace 团队 scope visibility', () => {
       vi.mocked(fetchSkills).mock.calls.map(([context]) => context?.workspaceId),
     ).toEqual(['ws-a', 'ws-b']);
   });
+
+  it('replaces shared IDs and metadata on an identity change and discards late results', async () => {
+    const sharedA = {
+      plugins: deferred<Response>(),
+      skills: deferred<Response>(),
+    };
+    const sharedB = {
+      plugins: deferred<Response>(),
+      skills: deferred<Response>(),
+    };
+    const counts = { plugins: 0, skills: 0 };
+    workspaceContext = { ...FREE_TEAM_CONTEXT, workspaceId: 'ws-a', teamId: 'ws-a' };
+    globalThis.fetch = vi.fn((input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.endsWith('/workspace/plugins/team')) {
+        counts.plugins += 1;
+        return counts.plugins === 1 ? sharedA.plugins.promise : sharedB.plugins.promise;
+      }
+      if (url.endsWith('/workspace/skills/team')) {
+        counts.skills += 1;
+        return counts.skills === 1 ? sharedA.skills.promise : sharedB.skills.promise;
+      }
+      if (url.startsWith('/api/plugins')) {
+        return Promise.resolve(jsonResponse({ plugins: [] }));
+      }
+      if (url.startsWith('/api/marketplaces')) {
+        return Promise.resolve(jsonResponse({ marketplaces: [] }));
+      }
+      return Promise.resolve(jsonResponse({}));
+    }) as typeof fetch;
+
+    const view = renderMarketplace();
+    await waitFor(() => expect(counts).toEqual({ plugins: 1, skills: 1 }));
+
+    workspaceContext = { ...FREE_TEAM_CONTEXT, workspaceId: 'ws-b', teamId: 'ws-b' };
+    view.rerender(
+      <I18nProvider initial="en">
+        <ExtensionsMarketplace onCreatePlugin={vi.fn()} onUsePlugin={vi.fn()} />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(counts).toEqual({ plugins: 2, skills: 2 }));
+
+    await act(async () => {
+      sharedB.plugins.resolve(jsonResponse({
+        ids: ['plugin-from-b'],
+        resources: [{
+          id: 'plugin-from-b',
+          title: 'Plugin from B',
+          description: 'Metadata from B',
+          canUnshare: true,
+          ownerMemberId: 'mem-1',
+        }],
+      }));
+      sharedB.skills.resolve(jsonResponse({
+        ids: ['skill-from-b'],
+        resources: [{
+          id: 'skill-from-b',
+          title: 'Skill from B',
+          description: 'Skill metadata from B',
+          canUnshare: true,
+          ownerMemberId: 'mem-1',
+        }],
+      }));
+      await Promise.resolve();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Team' }));
+    await waitFor(() => expect(screen.getByText('Plugin from B')).toBeTruthy());
+    expect(screen.getByText('Metadata from B')).toBeTruthy();
+
+    await act(async () => {
+      sharedA.plugins.resolve(jsonResponse({
+        ids: ['plugin-from-a'],
+        resources: [{
+          id: 'plugin-from-a',
+          title: 'Plugin from A',
+          description: 'Metadata from A',
+          canUnshare: true,
+          ownerMemberId: 'mem-1',
+        }],
+      }));
+      sharedA.skills.resolve(jsonResponse({
+        ids: ['skill-from-a'],
+        resources: [{
+          id: 'skill-from-a',
+          title: 'Skill from A',
+          description: 'Skill metadata from A',
+          canUnshare: true,
+          ownerMemberId: 'mem-1',
+        }],
+      }));
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Plugin from B')).toBeTruthy();
+    expect(screen.queryByText('Plugin from A')).toBeNull();
+    expect(screen.getByText('Metadata from B')).toBeTruthy();
+    expect(screen.queryByText('Metadata from A')).toBeNull();
+  });
 });

--- a/apps/web/tests/components/PluginsView.team-workspace-scope.test.tsx
+++ b/apps/web/tests/components/PluginsView.team-workspace-scope.test.tsx
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
 
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import type { SkillSummary, WorkspaceCollabContext } from '@open-design/contracts';
+import type {
+  InstalledPluginRecord,
+  SkillSummary,
+  WorkspaceCollabContext,
+} from '@open-design/contracts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { PluginsView } from '../../src/components/PluginsView';
@@ -69,6 +73,22 @@ function skill(id: string): SkillSummary {
     mode: 'prototype',
     source: 'user',
   } as unknown as SkillSummary;
+}
+
+function plugin(id: string): InstalledPluginRecord {
+  return {
+    id,
+    title: id,
+    version: '1.0.0',
+    sourceKind: 'local',
+    source: `/local/${id}`,
+    trust: 'restricted',
+    capabilitiesGranted: [],
+    manifest: { name: id, title: id, version: '1.0.0' },
+    fsPath: `/local/${id}`,
+    installedAt: 0,
+    updatedAt: 0,
+  } as InstalledPluginRecord;
 }
 
 function deferred<T>() {
@@ -165,6 +185,53 @@ describe('PluginsView Team panel workspace scope', () => {
     expect(
       vi.mocked(fetchSkills).mock.calls.map(([context]) => context?.workspaceId),
     ).toEqual(['ws-a', 'ws-b']);
+  });
+
+  it('discards late parent plugin rows from the previous workspace', async () => {
+    const readA = deferred<InstalledPluginRecord[]>();
+    const readB = deferred<InstalledPluginRecord[]>();
+    vi.mocked(fetchSkills).mockResolvedValue([]);
+    vi.mocked(listPlugins).mockImplementation((options = {}) =>
+      options.workspaceContext?.workspaceId === 'ws-b' ? readB.promise : readA.promise,
+    );
+
+    const view = renderPluginsView();
+    fireEvent.click(await screen.findByTestId('plugins-tab-team'));
+    await waitFor(() =>
+      expect(
+        vi.mocked(listPlugins).mock.calls.filter(
+          ([options]) => options?.workspaceContext?.workspaceId === 'ws-a',
+        ),
+      ).toHaveLength(2),
+    );
+
+    currentWorkspaceContext = workspaceContext('ws-b');
+    view.rerender(
+      <I18nProvider initial="en">
+        <PluginsView />
+      </I18nProvider>,
+    );
+    await waitFor(() =>
+      expect(
+        vi.mocked(listPlugins).mock.calls.filter(
+          ([options]) => options?.workspaceContext?.workspaceId === 'ws-b',
+        ),
+      ).toHaveLength(2),
+    );
+
+    await act(async () => {
+      readB.resolve([plugin('plugin-from-b')]);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(screen.getByText('plugin-from-b')).toBeTruthy());
+
+    await act(async () => {
+      readA.resolve([plugin('plugin-from-a')]);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('plugin-from-b')).toBeTruthy();
+    expect(screen.queryByText('plugin-from-a')).toBeNull();
   });
 
   it('discards late shared IDs issued for the previous workspace', async () => {

--- a/apps/web/tests/components/PluginsView.team-workspace-scope.test.tsx
+++ b/apps/web/tests/components/PluginsView.team-workspace-scope.test.tsx
@@ -1,0 +1,238 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import type { SkillSummary, WorkspaceCollabContext } from '@open-design/contracts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PluginsView } from '../../src/components/PluginsView';
+import { I18nProvider } from '../../src/i18n';
+import { fetchSkills } from '../../src/providers/registry';
+import { listPluginMarketplaces, listPlugins } from '../../src/state/projects';
+
+vi.mock('../../src/analytics/provider', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/analytics/provider')>();
+  return { ...actual, useAnalytics: () => ({ track: vi.fn() }) };
+});
+
+vi.mock('../../src/collab/useWorkspaceContext', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/collab/useWorkspaceContext')>()),
+  useWorkspaceContext: () => ({
+    context: currentWorkspaceContext,
+    loading: false,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('../../src/providers/registry', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/providers/registry')>()),
+  fetchSkills: vi.fn(),
+}));
+
+vi.mock('../../src/state/projects', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../src/state/projects')>()),
+  listPluginMarketplaces: vi.fn(),
+  listPlugins: vi.fn(),
+}));
+
+function workspaceContext(workspaceId: string): WorkspaceCollabContext {
+  return {
+    workspaceId,
+    workspaceType: 'team',
+    workspaceMemberId: `member-${workspaceId}`,
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+    billingState: 'active',
+    planId: null,
+    providerMode: 'platform_credits',
+    seatSummary: { seatLimit: 5, usedSeats: 1, availableSeats: 4, isSeatFull: false },
+    permissions: {
+      canManageMembers: true,
+      canManageBilling: true,
+      canInviteMembers: true,
+      canManageAutoRecharge: true,
+      canShareProjects: true,
+      canWriteSyncedFiles: true,
+      canViewWorkspaceSettings: true,
+      canManageSharedResources: true,
+    },
+    displayName: workspaceId,
+  };
+}
+
+function skill(id: string): SkillSummary {
+  return {
+    id,
+    name: id,
+    description: id,
+    triggers: [],
+    mode: 'prototype',
+    source: 'user',
+  } as unknown as SkillSummary;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+let currentWorkspaceContext = workspaceContext('ws-a');
+
+function renderPluginsView() {
+  return render(
+    <I18nProvider initial="en">
+      <PluginsView />
+    </I18nProvider>,
+  );
+}
+
+describe('PluginsView Team panel workspace scope', () => {
+  beforeEach(() => {
+    currentWorkspaceContext = workspaceContext('ws-a');
+    vi.mocked(listPlugins).mockResolvedValue([]);
+    vi.mocked(listPluginMarketplaces).mockResolvedValue([]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith('/team')) return jsonResponse({ ids: [] });
+        return jsonResponse({});
+      }),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('scopes each skills read and discards a late response for the previous workspace', async () => {
+    const readA = deferred<SkillSummary[]>();
+    const readB = deferred<SkillSummary[]>();
+    vi.mocked(fetchSkills).mockImplementation((context) =>
+      context?.workspaceId === 'ws-b' ? readB.promise : readA.promise,
+    );
+
+    const view = renderPluginsView();
+    fireEvent.click(await screen.findByTestId('plugins-tab-team'));
+
+    await waitFor(() =>
+      expect(
+        vi.mocked(fetchSkills).mock.calls.some(([context]) => context?.workspaceId === 'ws-a'),
+      ).toBe(true),
+    );
+
+    // Keep ws-a pending and move the mounted panel to ws-b. The identity change
+    // itself must start the successor read; correctness cannot wait for focus
+    // or the 10-second poll.
+    currentWorkspaceContext = workspaceContext('ws-b');
+    view.rerender(
+      <I18nProvider initial="en">
+        <PluginsView />
+      </I18nProvider>,
+    );
+
+    await waitFor(() =>
+      expect(
+        vi.mocked(fetchSkills).mock.calls.some(([context]) => context?.workspaceId === 'ws-b'),
+      ).toBe(true),
+    );
+
+    await act(async () => {
+      readB.resolve([skill('skill-from-b')]);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(screen.getByText('skill-from-b')).toBeTruthy());
+
+    await act(async () => {
+      readA.resolve([skill('skill-from-a')]);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('skill-from-b')).toBeTruthy();
+    expect(screen.queryByText('skill-from-a')).toBeNull();
+    expect(
+      vi.mocked(fetchSkills).mock.calls.map(([context]) => context?.workspaceId),
+    ).toEqual(['ws-a', 'ws-b']);
+  });
+
+  it('discards late shared IDs issued for the previous workspace', async () => {
+    const sharedA = {
+      plugins: deferred<Response>(),
+      skills: deferred<Response>(),
+    };
+    const sharedB = {
+      plugins: deferred<Response>(),
+      skills: deferred<Response>(),
+    };
+    const requestCounts = { plugins: 0, skills: 0 };
+    vi.mocked(fetchSkills).mockImplementation(async (context) => [
+      skill(`skill-from-${context?.workspaceId === 'ws-b' ? 'b' : 'a'}`),
+    ]);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.endsWith('/skills/skill-from-a/share')) {
+          return Promise.resolve(jsonResponse({ shared: true }));
+        }
+        if (url.endsWith('/plugins/team')) {
+          requestCounts.plugins += 1;
+          if (requestCounts.plugins === 1) return Promise.resolve(jsonResponse({ ids: [] }));
+          return requestCounts.plugins === 2 ? sharedA.plugins.promise : sharedB.plugins.promise;
+        }
+        if (url.endsWith('/skills/team')) {
+          requestCounts.skills += 1;
+          if (requestCounts.skills === 1) return Promise.resolve(jsonResponse({ ids: [] }));
+          return requestCounts.skills === 2 ? sharedA.skills.promise : sharedB.skills.promise;
+        }
+        return Promise.resolve(jsonResponse({}));
+      }),
+    );
+
+    const view = renderPluginsView();
+    fireEvent.click(await screen.findByTestId('plugins-tab-team'));
+    const skillFromA = await screen.findByText('skill-from-a');
+    await waitFor(() => expect(requestCounts).toEqual({ plugins: 1, skills: 1 }));
+    fireEvent.click(within(skillFromA.closest('article')!).getByRole('button'));
+    await waitFor(() => expect(requestCounts).toEqual({ plugins: 2, skills: 2 }));
+
+    currentWorkspaceContext = workspaceContext('ws-b');
+    view.rerender(
+      <I18nProvider initial="en">
+        <PluginsView />
+      </I18nProvider>,
+    );
+    await waitFor(() => expect(requestCounts).toEqual({ plugins: 3, skills: 3 }));
+
+    await act(async () => {
+      sharedB.plugins.resolve(jsonResponse({ ids: [] }));
+      sharedB.skills.resolve(jsonResponse({ ids: ['skill-from-b'] }));
+      await Promise.resolve();
+    });
+    const skillFromB = await screen.findByText('skill-from-b');
+    expect(within(skillFromB.closest('article')!).getByText('Team')).toBeTruthy();
+
+    await act(async () => {
+      sharedA.plugins.resolve(jsonResponse({ ids: [] }));
+      sharedA.skills.resolve(jsonResponse({ ids: [] }));
+      await Promise.resolve();
+    });
+
+    expect(within(skillFromB.closest('article')!).getByText('Team')).toBeTruthy();
+    expect(
+      vi.mocked(fetchSkills).mock.calls.map(([context]) => context?.workspaceId),
+    ).toEqual(['ws-a', 'ws-a', 'ws-b']);
+  });
+});


### PR DESCRIPTION
## Why

This is a follow-up to #6225's audit of workspace-scoped reads. While completing that work, we found three remaining catalog paths that could either read without the settled workspace identity or commit a response after the user had already moved to another workspace.

The user-facing failure has one shape: after a cold open or a workspace switch, Design Systems, the Extensions marketplace, or the Team resource panel can show data from the workspace the user just left, hide skills owned by the current workspace, or stay empty until the next focus/10-second poll. These are silent failures—the requests can succeed, but the answer is attributed to the wrong UI identity.

This PR closes the client-side races recorded in Feishu:

- `recvpZVL8IJJyf` — Design Systems can be overwritten by a late response from the previous workspace.
- `recvqLRx8BF79m` — Extensions/TeamPanel can issue the wrong cold-start skills read, miss the immediate successor read on switch, or commit late catalog/shared-ID results.

The separate daemon contract gap `recvqLJYPReomK` is deliberately out of scope. `GET /api/workspace/{plugins,skills}/team` and the corresponding share mutations still have no effective request-scoped workspace contract in the daemon. This PR does not pretend to solve that: it scopes the skills and plugin reads that already support workspace headers and prevents issued client reads from committing after their identity becomes stale. A client-side commit guard does not prove that an unscoped daemon endpoint produced its response from the intended workspace.

## What users will see

- Switching workspaces cannot let a late Design Systems response restore the previous workspace's catalog.
- Extensions waits for workspace context on a cold open, performs one scoped skills read, and refreshes immediately for the next workspace.
- The Team panel refreshes immediately when workspace identity changes instead of waiting for focus or the 10-second poll. Late plugin, skill, shared-ID, and shared-metadata responses from the previous workspace are discarded.

There are no layout, styling, copy, or interaction changes.

Request counts at the affected startup paths remain unchanged:

| Path | Before | After |
|---|---:|---:|
| Design Systems startup read | unchanged | unchanged |
| Extensions cold-start skills read | 1 headerless | 1 scoped |
| Team panel initial skills/shared reads | 1 each | 1 each |

A workspace identity change now starts one correctness-required successor read in PluginsView, Extensions, and TeamPanel; before, the affected surfaces issued zero immediate successor reads or could commit their predecessor after the successor. Commit guards themselves issue no retries or extra requests, and the startup path gains no requests.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — existing catalog surfaces now reject stale workspace responses and refresh on identity changes
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. The rendered markup and visual design are unchanged; the fix changes which workspace's asynchronous result is allowed to reach the existing UI. Deferred reverse-order component specs reproduce that behavior deterministically.

## Bug fix verification

Red-first specs:

- `apps/web/tests/components/App.design-systems-loading-race.test.tsx`
  - Reverse completion A→B, then B resolves before A.
  - Red without the commit guard: A overwrites B.
- `apps/web/tests/components/ExtensionsMarketplace.team-scope.test.tsx`
  - Cold context must issue no headerless read; A→B must issue exactly one scoped read per identity and keep B after late A.
  - Shared IDs and metadata must start a B successor and reject late A.
  - Red when the cold-context gate, catalog commit guard, shared successor, or shared commit guard is removed.
- `apps/web/tests/components/PluginsView.team-workspace-scope.test.tsx`
  - A→B rerender must automatically start B without a focus event; B must survive late A for parent plugin rows, TeamPanel skills, and shared IDs, including a manual share refresh whose cancellation predicate is not effect-owned.
  - Red when the parent or TeamPanel identity-keyed effect, scoped read argument, or commit guard is removed.

All three focused files are green together: 3 files, 11 tests, exit 0.

The five existing Extensions marketplace suites now spread the real `useWorkspaceContext` module from their mocks. This keeps the tests honest after importing the pure identity helpers; no production behavior is mocked away.

### Review follow-up

Looper correctly identified two remaining parent/sibling paths after the first push:

1. `PluginsView.refresh()` could commit A's plugin rows after B and pass them into a B-scoped TeamPanel.
2. `ExtensionsMarketplace.refreshSharedResources()` neither started an identity-keyed successor nor guarded its ID and metadata setters.

Commit `c91d89ef0` applies the same issued-read invariant to both. Two new reverse-order cases were red on the previous implementation. Three isolating mutations—remove only the parent commit guard, remove only the shared successor dependency, or remove only the shared commit guard—each turn the corresponding case red while the other focused cases remain green.

## Validation

- `pnpm --dir apps/web exec vitest run tests/components/App.design-systems-loading-race.test.tsx tests/components/PluginsView.team-workspace-scope.test.tsx tests/components/ExtensionsMarketplace.team-scope.test.tsx` — 3 files, 11 tests, exit 0
- `pnpm --filter @open-design/web typecheck` — exit 0
- `pnpm --filter @open-design/web test` — 557 files passed; 5,600 passed, 11 skipped; exit 0
- `pnpm guard` — exit 0
- `git range-diff` across the initial rebase to `origin/feat/workspace-team@d4592d3be` — original patch unchanged

