### PR TITLE
fix(#6224): replace regex rule scanner + anchor classMatchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix components manifest extractor losing every other flat CSS rule because the legacy `(?:^|[{}])\s*([^@{}][^{}]*?)\s*\{([^{}]*)\}` regex consumed each rule's closing `}` as the next rule's `[{}]` anchor. Replaced with a brace-depth scanner that also flattens one level of CSS nesting so tokens referenced inside `&:hover { ... }` attribute to the parent selector instead of leaking into a synthesised pseudo-selector. (#6224)
 - Anchor `classMatchers` to `^name(?:$|-)` so prefix-sharing classnames like `.navbar-button-thing`, `.mystatus`, `.platform-form` no longer cross-group via substring leakage. (#6224)
+- Fix components manifest extractor dropping selectors inside supported at-rule bodies (`@media` / `@supports` / `@container` / `@layer`). `stripContainerAtRuleHeaders` rewrites the at-rule header to `{`, and the brace-depth scanner now recurses into the resulting body slice so inner rules surface with their real selectors and token attribution preserved. `extractCssSelectors` reuses the same scanner so `manifest.selectors` matches `manifest.groups[].selectors` instead of falling back to a regex that lost every selector immediately inside an at-rule. (#6250)
+- Fix components manifest extractor losing token references declared inside nested-rule blocks two or more levels deep. `flattenNestedBody` now strips only the `{` / `}` brace characters and keeps every declaration body, so `var(--token)` references inside `& .child { & .grand { background: var(--c) } }` attribute to the outermost ancestor instead of being dropped. (#6250)
 
 ## [0.9.0] - 2026-05-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix components manifest extractor losing every other flat CSS rule because the legacy `(?:^|[{}])\s*([^@{}][^{}]*?)\s*\{([^{}]*)\}` regex consumed each rule's closing `}` as the next rule's `[{}]` anchor. Replaced with a brace-depth scanner that also flattens one level of CSS nesting so tokens referenced inside `&:hover { ... }` attribute to the parent selector instead of leaking into a synthesised pseudo-selector. (#6224)
+- Anchor `classMatchers` to `^name(?:$|-)` so prefix-sharing classnames like `.navbar-button-thing`, `.mystatus`, `.platform-form` no longer cross-group via substring leakage. (#6224)
+
 ## [0.9.0] - 2026-05-29
 
 🎉 **310 PRs · 88 contributors · 7 days** — Meet the **install-and-create release**. No more API-key scavenger hunts. No more asking teammates to install three different CLIs before their first prompt. **Open Design AMR** is now built into the app: sign in once, pick a model, and start building. Around that zero-config first run, 0.9.0 brings a bigger agent bench, faster model picking, a more discoverable plugin marketplace, richer review workflows, smoother Studio tools, and easier installs across Windows, macOS, and Linux. 🚀

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Anchor `classMatchers` to `^name(?:$|-)` so prefix-sharing classnames like `.navbar-button-thing`, `.mystatus`, `.platform-form` no longer cross-group via substring leakage. (#6224)
 - Fix components manifest extractor dropping selectors inside supported at-rule bodies (`@media` / `@supports` / `@container` / `@layer`). `stripContainerAtRuleHeaders` rewrites the at-rule header to `{`, and the brace-depth scanner now recurses into the resulting body slice so inner rules surface with their real selectors and token attribution preserved. `extractCssSelectors` reuses the same scanner so `manifest.selectors` matches `manifest.groups[].selectors` instead of falling back to a regex that lost every selector immediately inside an at-rule. (#6250)
 - Fix components manifest extractor losing token references declared inside nested-rule blocks two or more levels deep. `flattenNestedBody` now strips only the `{` / `}` brace characters and keeps every declaration body, so `var(--token)` references inside `& .child { & .grand { background: var(--c) } }` attribute to the outermost ancestor instead of being dropped. (#6250)
+- Fix components manifest extractor mis-handling CSS escape sequences in selectors and declaration values. The opening-brace and closing-brace scans now skip a `\X` escape pair so escaped identifier characters (`.\foo\:bar`) and escaped delimiters (`content: "\}"`) no longer perturb the rule boundary detection or the depth counter. (#6250)
 
 ## [0.9.0] - 2026-05-29
 

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -576,28 +576,26 @@ function extractStyleBlocks(html: string): string[] {
 
 function extractCssSelectors(css: string): string[] {
   const selectors = new Set<string>();
-  const commentlessCss = stripContainerAtRuleHeaders(stripCssComments(css));
+  // PerishCode round-8 blocker 2026-08-03 23:53 (OR-COR-...):
+  // stripContainerAtRuleHeaders is not quote-aware — its regex
+  // `@(media|supports|container|layer)\b[^{]*\{` breaks at a
+  // quoted brace like `@supports selector(.btn-a[data-icon="{"])`.
+  // After round-7 introduced iterateCssRules with full
+  // quote/escape-aware scanning and `isSupportedAtRuleHeader`
+  // recursion, the pre-pass is no longer needed. Drop it so
+  // `@supports selector(...)` with a dotted uppercase US base
+  // (e.g. `usBRK.B` in CSS `@supports` block) is processed
+  // correctly.
+  const commentlessCss = stripCssComments(css);
 
-  // The legacy `(?:^|[{}])\s*([^@{}][^{}]*?)\s*\{` regex anchored each
-  // rule at the *previous* rule's closing `}`, so half the flat rules in
-  // a sheet were silently dropped (#6224 part 1). It also mis-handled
-  // supported at-rule bodies: after `stripContainerAtRuleHeaders` turns
-  // `@media ... {` into `{`, the regex sees `{ \n .inside { ... }` and
-  // the bare `[^@{}]` exclusion rejects the inner selector — silent loss
-  // of every selector immediately inside an at-rule (#6250 reviewer #1).
-  //
-  // Reuse the brace-depth scanner that already powers
-  // `extractSelectorTokenReferences` — it walks the CSS character-by-character
-  // and recursively descends into supported at-rule bodies so inner
-  // selectors surface with their real selectors preserved.
   for (const { selectorList } of iterateCssRules(commentlessCss)) {
     if (selectorList.length === 0) continue;
     if (selectorList.includes(':root')) continue;
     if (/^(?:from|to|\d+(?:\.\d+)?%)$/i.test(selectorList)) continue;
-    // Skip supported at-rule headers — they survived the strip pass because
-    // the body wasn't processed by stripContainerAtRuleHeaders (e.g. nested
-    // recursion landed on `@media`). At-rules never contribute a *selector*.
-    if (selectorList.startsWith('@')) continue;
+    // Supported at-rule headers (e.g. @media, @supports) and their
+    // bodies are handled by iterateCssRules: the header is emitted
+    // as a rule and the body is recursed into for inner selectors.
+    if (selectorList.startsWith('@') && !isSupportedAtRuleHeader(selectorList)) continue;
 
     for (const selector of splitSelectorList(selectorList)) {
       const normalized = normalizeSelector(selector);
@@ -612,7 +610,12 @@ function extractCssSelectors(css: string): string[] {
 
 function extractSelectorTokenReferences(css: string): Map<string, string[]> {
   const referencesBySelector = new Map<string, Set<string>>();
-  const commentlessCss = stripContainerAtRuleHeaders(stripCssComments(css));
+  // PerishCode round-8 blocker 2026-08-03 23:53: drop the
+  // stripContainerAtRuleHeaders pre-pass — its non-quote-aware regex
+  // cuts `@supports selector(.btn-a[data-icon="{"])` at the quoted
+  // brace and loses the inner `.btn-a` rule's token references.
+  // iterateCssRules now recurses through supported at-rules on its own.
+  const commentlessCss = stripCssComments(css);
 
   // Walk the CSS character-by-character with a brace-depth scanner instead of
   // a single `[{}]\s*([^@{}][^{}]*?)\s*\{([^{}]*)\}` regex. The regex consumed
@@ -626,6 +629,12 @@ function extractSelectorTokenReferences(css: string): Map<string, string[]> {
   for (const { selectorList, body } of iterateCssRules(commentlessCss)) {
     if (selectorList.includes(':root')) continue;
     if (/^(?:from|to|\d+(?:\.\d+)?%)$/i.test(selectorList)) continue;
+    // Supported at-rule headers wrapped around inner rules are recursed
+    // into by iterateCssRules (round-8) so the inner rules' tokens reach
+    // the references map under their own selectors. The wrapper header
+    // itself contributes no token references. Unsupported at-rules
+    // (@keyframes / @font-face / @page) were dropped by iterateCssRules.
+    if (selectorList.startsWith('@')) continue;
 
     const tokenReferences = extractTokenReferences(body);
     if (tokenReferences.length === 0) continue;
@@ -656,9 +665,14 @@ function iterateCssRules(css: string): CssRule[] {
   const length = css.length;
 
   while (index < length) {
-    // Find the next '{' that opens a rule body. Skip '@container' at-rule
-    // bodies (their inner rules are emitted with the at-rule header stripped,
-    // matching stripContainerAtRuleHeaders behaviour).
+    // Find the next '{' that opens a rule body.
+    //
+    // Round-8 (PR #6250 PerishCode blocker 8-03 23:53): we no longer
+    // strip supported at-rule headers via a pre-pass. iterateCssRules
+    // recognises `@media` / `@supports` / `@container` / `@layer` headers
+    // itself via `isSupportedAtRuleHeader` and recurses through their
+    // body slices, so the header text reaches this scanner intact and
+    // the inner rules are emitted with their real selectors.
     //
     // Quote-aware scan (PR #6250 reviewer #4): a `{` that appears inside a
     // quoted selector context — e.g. `.btn-a[data-icon="{"]` — must NOT be
@@ -811,23 +825,31 @@ function iterateCssRules(css: string): CssRule[] {
     const body = flattenNestedBody(bodySlice);
 
     if (selectorList.length === 0) {
-      // Empty selector — the at-rule header (`@media`/`@supports`/
-      // `@container`/`@layer`) was stripped to '{' by
-      // stripContainerAtRuleHeaders before this scanner ran. The outermost
-      // `{` after stripping opens an empty selector; we must NOT push it as
-      // a rule (that would swallow the whole at-rule body as one giant
-      // "rule" and lose every inner selector). Instead recurse into the
-      // body slice so inner rules are emitted with their real selectors
-      // and real bodies (PR #6250 reviewer #1).
+      // Empty selector — recursion caller passed an already-flattened body
+      // slice that begins with a `{` (shouldn't happen post round-8 since
+      // stripContainerAtRuleHeaders no longer truncates headers, but kept
+      // as a defensive guard). Recurse to recover inner selectors instead
+      // of pushing a garbage "rule" that swallows the whole block.
       rules.push(...iterateCssRules(bodySlice));
-    } else if (!selectorList.startsWith('@') || isSupportedAtRuleHeader(selectorList)) {
-      // Ordinary selector, or a supported at-rule header that survived the
-      // strip pass (e.g. recursive call landed on `@media` whose header was
-      // not stripped because the parent body wasn't processed by
-      // stripContainerAtRuleHeaders). Push it as-is; the body still has
+    } else if (isSupportedAtRuleHeader(selectorList)) {
+      // Round-8 (PR #6250 PerishCode blocker 8-03 23:53): a supported
+      // at-rule header survived intact (no stripContainerAtRuleHeaders
+      // pre-pass truncates the header to `{`). Do NOT push the wrapper
+      // itself as a rule — its body is a *rule tree*, not a declaration
+      // list, so flattenNestedBody would fold every inner selector into
+      // the wrapper's "body" and the inner .btn-a / .btn-b selectors would
+      // never be emitted. Recurse through the body slice so inner rules
+      // surface with their real selectorLists and real bodies.
+      rules.push(...iterateCssRules(bodySlice));
+    } else if (!selectorList.startsWith('@')) {
+      // Ordinary selector. Push it as-is; the body still has
       // nested-block declarations flattened into it.
       rules.push({ selectorList, body });
     }
+    // Unsupported at-rule header (@keyframes, @font-face, @page, @import,
+    // @namespace, @charset): drop the rule entirely — its body is not an
+    // ordinary rule tree and recursing would emit garbage selectors from
+    // its declaration text.
     index = bodyEnd + 1;
     // Skip trailing whitespace + stray semicolons between rules — keeps the
     // next iteration's selectorList clean.
@@ -1014,9 +1036,12 @@ function stripCssComments(css: string): string {
   return css.replace(/\/\*[\s\S]*?\*\//g, '');
 }
 
-function stripContainerAtRuleHeaders(css: string): string {
-  return css.replace(/@(media|supports|container|layer)\b[^{]*\{/gi, '{');
-}
+// stripContainerAtRuleHeaders was removed in PR #6250 round-8 (PerishCode
+// blocker 8-03 23:53): its non-quote-aware regex
+// `@(media|supports|container|layer)\b[^{]*\{` truncated a header like
+// `@supports selector(.btn-a[data-icon="{"])` at the quoted brace,
+// losing the inner rules. iterateCssRules now recurses through supported
+// at-rules directly via `isSupportedAtRuleHeader`.
 
 function countLiterals(css: string): ComponentManifestLiteralInventory {
   return {

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -357,6 +357,10 @@ function iterateCssRules(css: string): CssRule[] {
     let bodyStart = index;
     let bodyEnd = -1;
     let cursor = index;
+    // Track the open CSS quote (single or double) so braces inside a
+    // quoted value such as `content: "}"` are not mistaken for the rule
+    // terminator (PR #6250 reviewer #3). null = outside any quoted string.
+    let inQuote: '"' | "'" | null = null;
     while (cursor < length) {
       const char = css[cursor];
       if (char === '/' && css[cursor + 1] === '*') {
@@ -366,6 +370,32 @@ function iterateCssRules(css: string): CssRule[] {
         // keeps the parser honest if a caller passes pre-stripped CSS.)
         const closeIdx = css.indexOf('*/', cursor + 2);
         cursor = closeIdx === -1 ? length : closeIdx + 2;
+        continue;
+      }
+      // Treat braces inside quoted CSS values as data, not rule delimiters
+      // (PR #6250 reviewer #3). Track single / double quote state and
+      // ignore `{` / `}` that appear between a pair of quotes. Handle
+      // escaped quotes \" and \' so a `}` preceded by \" doesn't escape
+      // the quoted context.
+      if (inQuote === '"' || inQuote === "'") {
+        if (char === '\\') {
+          // Skip the escaped character (could be \" or \' or any escape).
+          cursor += 2;
+          continue;
+        }
+        if (char === inQuote) {
+          inQuote = null;
+          cursor += 1;
+          continue;
+        }
+        // Inside a quoted string: braces are just text, skip without
+        // affecting depth.
+        cursor += 1;
+        continue;
+      }
+      if (char === '"' || char === "'") {
+        inQuote = char;
+        cursor += 1;
         continue;
       }
       if (char === '{') {
@@ -448,14 +478,51 @@ function flattenNestedBody(bodySlice: string): string {
   // and the nested-rule *selector prefix* between `{` and the next `{`/`;`
   // — but keeping every declaration body so all `var(--token)` references
   // at every depth survive on the outermost rule.
+  //
+  // Quote/escape state (PR #6250 reviewer #3): braces inside a quoted
+  // CSS value (`content: "}"`) are data, not rule delimiters. We preserve
+  // the quoted text character-by-character into the output so downstream
+  // token-reference scanning still sees the full declaration, but we do
+  // NOT treat the quoted `{` / `}` as braces to strip. Escapes `\"` and
+  // `\'` skip the next character so they don't terminate the quoted
+  // context prematurely.
   let out = '';
   let cursor = 0;
   const length = bodySlice.length;
+  let inQuote: '"' | "'" | null = null;
   while (cursor < length) {
     const char = bodySlice[cursor];
-    if (char === '/' && bodySlice[cursor + 1] === '*') {
+    // Comment handling: only active outside quoted strings. Comments inside
+    // quoted strings are part of the data and should be preserved verbatim.
+    if (inQuote === null && char === '/' && bodySlice[cursor + 1] === '*') {
       const closeIdx = bodySlice.indexOf('*/', cursor + 2);
       cursor = closeIdx === -1 ? length : closeIdx + 2;
+      continue;
+    }
+    if (inQuote !== null) {
+      // Inside a quoted value. Preserve the character verbatim — quoted
+      // text is data, and downstream token-reference scanning needs the
+      // full original value (e.g. `content: "}"` stays intact). Handle
+      // backslash escapes so a quoted `}"` doesn't exit the quote early.
+      if (char === '\\') {
+        out += bodySlice.slice(cursor, cursor + 2);
+        cursor += 2;
+        continue;
+      }
+      out += char;
+      if (char === inQuote) {
+        inQuote = null;
+      }
+      cursor += 1;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      inQuote = char;
+      // Preserve the opening quote in `out` so the flattened body still
+      // carries the full quoted value (the closing quote is preserved by
+      // the inQuote !== null branch above).
+      out += char;
+      cursor += 1;
       continue;
     }
     if (char === '{' || char === '}') {

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -377,6 +377,19 @@ function iterateCssRules(css: string): CssRule[] {
         quoteScan += 1;
         continue;
       }
+      // CSS escape sequence outside a quoted string (PR #6250 reviewer #5):
+      // a backslash in a selector identifier escapes the next character(s)
+      // so it is not interpreted as CSS structure. The simple form `\X` skips
+      // one literal char; the hex form `\XHHHHHH` (1–6 hex digits, optional
+      // single trailing whitespace) encodes a codepoint. We only need to keep
+      // the brace/quote/selector characters that follow the escape from
+      // perturbing the opener scan, so skip the backslash and one escaped
+      // char (covers 99% of real-world cases — `.foo\:bar`, `.foo\2d bar`,
+      // `.foo\.` — without modelling unicode codepoint semantics).
+      if (ch === '\\') {
+        quoteScan += 2;
+        continue;
+      }
       if (ch === '"' || ch === "'") {
         inQuote = ch;
         quoteScan += 1;
@@ -441,6 +454,16 @@ function iterateCssRules(css: string): CssRule[] {
       if (char === '"' || char === "'") {
         bodyInQuote = char;
         cursor += 1;
+        continue;
+      }
+      // CSS escape sequence outside a quoted string (PR #6250 reviewer #5):
+      // a backslash in a declaration value or selector context escapes the
+      // next character so `\}` (escaped closing brace, e.g. inside a content
+      // value or an unusual selector) is not counted as a rule terminator,
+      // and `\{` is not counted as a nested-block opener. Skip the backslash
+      // and one escaped char, mirroring the opener-scan escape handling.
+      if (char === '\\') {
+        cursor += 2;
         continue;
       }
       if (char === '{') {

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -66,7 +66,32 @@ export type ExtractComponentsManifestInput = {
 type ComponentGroupDefinition = {
   id: ComponentManifestGroupId;
   label: string;
+  /**
+   * Class/word regexes that match raw selectors containing `:not(...)`,
+   * `[data-x="..."]`, `.foo` etc. — DEPRECATED: kept for backwards
+   * compatibility with the pre-round-5 schema, but no longer consulted by
+   * `selectorMatchesTokens`. Use `attributeMatchers` for genuine selector-wide
+   * attribute predicates (`[type=button]`, `[aria-hidden="true"]`); element
+   * and class matching is performed strictly against parsed tokens via
+   * `tokenizeCompound` (PerishCode round-5 review on #6250).
+   */
   selectorMatchers: RegExp[];
+  /**
+   * Genuine attribute-predicate regexes that match the *raw* selector string.
+   * Only patterns anchored on a `[` (attribute selector) belong here — these
+   * describe selectors that pick components via an attribute, such as
+   * `[type=button]` for buttons, `[aria-hidden="true"]` for icons, and
+   * `[role=checkbox]` for inputs. They run against the unmodified raw selector
+   * because attribute predicate text appears verbatim in the compound;
+   * tokenizing it would lose the attribute value entirely.
+   *
+   * Do NOT use this family to match element names (`button`, `input`, …) or
+   * class tokens (`.btn`, `.card`, …) — those matchers must live on
+   * `elementMatchers` / `classMatchers` so they only fire on parsed tokens,
+   * preventing `:not(.btn)` and `[data-label=".card"]` from cross-attributing
+   * tokens to groups they do not select (PerishCode round-5 review on #6250).
+   */
+  attributeMatchers: RegExp[];
   classMatchers: RegExp[];
   elementMatchers: RegExp[];
 };
@@ -76,6 +101,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
     id: 'buttons',
     label: 'Buttons and calls to action',
     selectorMatchers: [/^(?:\.)?button(?:$|[-_:])/i, /\.btn(?:$|[-_:])/i, /\[type=["']?(?:button|submit|reset)/i],
+    attributeMatchers: [/\[type=["']?(?:button|submit|reset)/i],
     classMatchers: [/^btn(?:$|-)/i, /^button(?:$|-)/i, /^cta(?:$|-)/i],
     elementMatchers: [/^button$/i],
   },
@@ -92,6 +118,14 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
       /^(?:\.)?select(?:$|[-_:])/i,
       /^(?:\.)?label(?:$|[-_:])/i,
       /\.field(?:$|[-_:])/i,
+    ],
+    attributeMatchers: [
+      // Genuine inputs attribute predicates (round-5 follow-up): `[role=checkbox]`
+      // and `[role=radio]` describe inputs components via attribute rather than
+      // element name, and they appear verbatim in the compound; tokenizeCompound
+      // would lose the attribute value (only the bracket text is skipped), so
+      // we run them against the raw selector.
+      /\[role=["']?(?:checkbox|radio|textbox|search|spinbutton)["']?/i,
     ],
     // `^form(?:$|-)` was too permissive once class tokens were matched per-token
     // (PerishCode round-3 follow-up #6250): it admitted `.form-input-prepend`
@@ -114,6 +148,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
     id: 'cards',
     label: 'Cards and panels',
     selectorMatchers: [/\.card(?:$|[-_:])/i, /\.panel(?:$|[-_:])/i, /\.tile(?:$|[-_:])/i],
+    attributeMatchers: [],
     classMatchers: [/^card(?:$|-)/i, /^panel(?:$|-)/i, /^tile(?:$|-)/i],
     elementMatchers: [],
   },
@@ -126,6 +161,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
       /\.tag(?:$|[-_:])/i,
       /\.pill(?:$|[-_:])/i,
     ],
+    attributeMatchers: [],
     classMatchers: [/^badge(?:$|-)/i, /^chip(?:$|-)/i, /^tag(?:$|-)/i, /^pill(?:$|-)/i, /^status(?:$|-)/i],
     elementMatchers: [],
   },
@@ -139,6 +175,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
       /^(?:\.)?a(?:$|[-_:])/i,
       /\.link(?:$|[-_:])/i,
     ],
+    attributeMatchers: [],
     classMatchers: [/^link(?:$|-)/i],
     elementMatchers: [/^a$/i],
   },
@@ -146,6 +183,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
     id: 'keyboard',
     label: 'Keyboard hints',
     selectorMatchers: [/^(?:\.)?kbd(?:$|[-_:])/i, /\.kbd(?:$|[-_:])/i],
+    attributeMatchers: [],
     classMatchers: [/^kbd(?:$|-)/i, /^keyboard(?:$|-)/i, /^shortcut(?:$|-)/i],
     elementMatchers: [/^kbd$/i],
   },
@@ -153,6 +191,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
     id: 'icons',
     label: 'Icon slots',
     selectorMatchers: [/\.icon(?:$|[-_:])/i, /\[aria-hidden=["']true["']\]/i],
+    attributeMatchers: [/\[aria-hidden=["']true["']\]/i],
     classMatchers: [/^icon(?:$|-)/i],
     elementMatchers: [/^svg$/i],
   },
@@ -167,6 +206,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
       /\.eyebrow(?:$|[-_:])/i,
       /\.body-(?:muted|sm|small)(?:$|[-_:])/i,
     ],
+    attributeMatchers: [],
     classMatchers: [/^lead$/i, /^eyebrow$/i, /^body-(?:muted|sm|small)$/i, /^caption(?:$|-)/i],
     elementMatchers: [/^h[1-6]$/i, /^p$/i],
   },
@@ -183,6 +223,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
       // round-2 follow-up).
       /^(?:\.)?(?:section|main|nav)(?:$|[-_:])/i,
     ],
+    attributeMatchers: [],
     classMatchers: [/^container$/i, /^stack-\d+$/i, /^row-(?:between|center|start|end)$/i, /^grid(?:$|-)/i, /^layout(?:$|-)/i],
     elementMatchers: [/^(main|section|nav|header|footer)$/i],
   },
@@ -421,7 +462,12 @@ function tokenizeCompound(compound: string): CompoundTokens {
 //      `[aria-hidden="true"]`); these match the full selector string as before.
 // Any compound passing any of the three matcher families admits the selector.
 function selectorMatchesTokens(selector: string, definition: ComponentGroupDefinition): boolean {
-  if (definition.selectorMatchers.some((matcher) => matcher.test(selector))) return true;
+  // Attribute predicate matchers run against the raw selector because
+  // attribute values appear verbatim in the compound (e.g. `[type="button"]`
+  // contains the class-like text `.button` inside the attribute value);
+  // tokenizing would lose that context and the predicate must run on the
+  // unmodified text.
+  if (definition.attributeMatchers.some((matcher) => matcher.test(selector))) return true;
   const compounds = splitCompoundSelectors(selector);
   for (const compound of compounds) {
     const { element, classes, extraElements } = tokenizeCompound(compound);

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -76,14 +76,14 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
     id: 'buttons',
     label: 'Buttons and calls to action',
     selectorMatchers: [/\bbutton\b/i, /\.btn(?:\b|[-_:])/i, /\[type=["']?(?:button|submit|reset)/i],
-    classMatchers: [/^btn(?:$|-)/i, /button/i, /cta/i],
+    classMatchers: [/^btn(?:$|-)/i, /^button(?:$|-)/i, /^cta(?:$|-)/i],
     elementMatchers: [/^button$/i],
   },
   {
     id: 'inputs',
     label: 'Form fields and controls',
     selectorMatchers: [/\binput\b/i, /\btextarea\b/i, /\bselect\b/i, /\.field(?:\b|[-_:])/i, /\blabel\b/i],
-    classMatchers: [/^field(?:$|-)/i, /input/i, /control/i, /form/i],
+    classMatchers: [/^field(?:$|-)/i, /^input(?:$|-)/i, /^control(?:$|-)/i, /^form(?:$|-)/i],
     elementMatchers: [/^(input|textarea|select|label|form)$/i],
   },
   {
@@ -97,7 +97,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
     id: 'badges',
     label: 'Badges, chips, and status labels',
     selectorMatchers: [/\.badge(?:\b|[-_:])/i, /\.chip(?:\b|[-_:])/i, /\.tag(?:\b|[-_:])/i, /\.pill(?:\b|[-_:])/i],
-    classMatchers: [/^badge(?:$|-)/i, /^chip(?:$|-)/i, /^tag(?:$|-)/i, /^pill(?:$|-)/i, /status/i],
+    classMatchers: [/^badge(?:$|-)/i, /^chip(?:$|-)/i, /^tag(?:$|-)/i, /^pill(?:$|-)/i, /^status(?:$|-)/i],
     elementMatchers: [],
   },
   {
@@ -111,7 +111,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
     id: 'keyboard',
     label: 'Keyboard hints',
     selectorMatchers: [/\bkbd\b/i, /\.kbd(?:\b|[-_:])/i],
-    classMatchers: [/^kbd(?:$|-)/i, /keyboard/i, /shortcut/i],
+    classMatchers: [/^kbd(?:$|-)/i, /^keyboard(?:$|-)/i, /^shortcut(?:$|-)/i],
     elementMatchers: [/^kbd$/i],
   },
   {
@@ -125,7 +125,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
     id: 'typography',
     label: 'Typography scale and text utilities',
     selectorMatchers: [/\bh[1-6]\b/i, /\.lead(?:\b|[-_:])/i, /\.eyebrow(?:\b|[-_:])/i, /\.body-(?:muted|sm|small)\b/i],
-    classMatchers: [/^lead$/i, /^eyebrow$/i, /^body-(?:muted|sm|small)$/i, /caption/i],
+    classMatchers: [/^lead$/i, /^eyebrow$/i, /^body-(?:muted|sm|small)$/i, /^caption(?:$|-)/i],
     elementMatchers: [/^h[1-6]$/i, /^p$/i],
   },
   {
@@ -139,7 +139,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
       /\bmain\b/i,
       /\bnav\b/i,
     ],
-    classMatchers: [/^container$/i, /^stack-\d+$/i, /^row-(?:between|center|start|end)$/i, /grid/i, /layout/i],
+    classMatchers: [/^container$/i, /^stack-\d+$/i, /^row-(?:between|center|start|end)$/i, /^grid(?:$|-)/i, /^layout(?:$|-)/i],
     elementMatchers: [/^(main|section|nav|header|footer)$/i],
   },
 ];
@@ -283,20 +283,24 @@ function extractCssSelectors(css: string): string[] {
 function extractSelectorTokenReferences(css: string): Map<string, string[]> {
   const referencesBySelector = new Map<string, Set<string>>();
   const commentlessCss = stripContainerAtRuleHeaders(stripCssComments(css));
-  const rulePattern = /(?:^|[{}])\s*([^@{}][^{}]*?)\s*\{([^{}]*)\}/g;
-  let match: RegExpExecArray | null;
 
-  while ((match = rulePattern.exec(commentlessCss)) !== null) {
-    const rawSelectorList = match[1]?.trim();
-    const rawBody = match[2] ?? '';
-    if (rawSelectorList == null || rawSelectorList.length === 0) continue;
-    if (rawSelectorList.includes(':root')) continue;
-    if (/^(?:from|to|\d+(?:\.\d+)?%)$/i.test(rawSelectorList)) continue;
+  // Walk the CSS character-by-character with a brace-depth scanner instead of
+  // a single `[{}]\s*([^@{}][^{}]*?)\s*\{([^{}]*)\}` regex. The regex consumed
+  // each rule's closing `}`, so the *next* rule lost its `[{}]` anchor and
+  // was skipped — silent loss of every other flat rule's token attribution
+  // (issue #6224 part 1). The regex body `[^{}]*` also couldn't match nested
+  // blocks (Tailwind v4 state output), mis-attributing tokens to declaration
+  // text as a pseudo-selector (issue #6224 part 2). The scanner flattens one
+  // level of nesting so `&:hover { ... }` declarations contribute to the
+  // parent selector instead of leaking into a fake selector.
+  for (const { selectorList, body } of iterateCssRules(commentlessCss)) {
+    if (selectorList.includes(':root')) continue;
+    if (/^(?:from|to|\d+(?:\.\d+)?%)$/i.test(selectorList)) continue;
 
-    const tokenReferences = extractTokenReferences(rawBody);
+    const tokenReferences = extractTokenReferences(body);
     if (tokenReferences.length === 0) continue;
 
-    for (const selector of splitSelectorList(rawSelectorList)) {
+    for (const selector of splitSelectorList(selectorList)) {
       const normalized = normalizeSelector(selector);
       if (normalized.length === 0 || normalized.startsWith('@')) continue;
       const selectorReferences = referencesBySelector.get(normalized) ?? new Set<string>();
@@ -312,6 +316,113 @@ function extractSelectorTokenReferences(css: string): Map<string, string[]> {
       .map(([selector, references]) => [selector, [...references].sort((a, b) => a.localeCompare(b))] as const)
       .sort(([left], [right]) => left.localeCompare(right)),
   );
+}
+
+type CssRule = { selectorList: string; body: string };
+
+function iterateCssRules(css: string): CssRule[] {
+  const rules: CssRule[] = [];
+  let index = 0;
+  const length = css.length;
+
+  while (index < length) {
+    // Find the next '{' that opens a rule body. Skip '@container' at-rule
+    // bodies (their inner rules are emitted with the at-rule header stripped,
+    // matching stripContainerAtRuleHeaders behaviour).
+    const openIndex = css.indexOf('{', index);
+    if (openIndex === -1) break;
+
+    const selectorList = css.slice(index, openIndex).trim();
+    index = openIndex + 1;
+
+    // Match the closing '}' at brace depth 0. Nested blocks (CSS nesting)
+    // are flattened — their inner declarations merge into the parent rule's
+    // body so tokens inside `&:hover { ... }` attribute to the outer
+    // selector, not to a garbage "selector" pieced together from declaration
+    // text.
+    let depth = 1;
+    let bodyStart = index;
+    let bodyEnd = -1;
+    let cursor = index;
+    while (cursor < length) {
+      const char = css[cursor];
+      if (char === '/' && css[cursor + 1] === '*') {
+        // Skip a /* ... */ comment block so braces inside comments do not
+        // perturb the depth count. (stripCssComments already removed
+        // comments outside at-rule bodies, but defensive scanning here
+        // keeps the parser honest if a caller passes pre-stripped CSS.)
+        const closeIdx = css.indexOf('*/', cursor + 2);
+        cursor = closeIdx === -1 ? length : closeIdx + 2;
+        continue;
+      }
+      if (char === '{') {
+        depth += 1;
+      } else if (char === '}') {
+        depth -= 1;
+        if (depth === 0) {
+          bodyEnd = cursor;
+          break;
+        }
+      }
+      cursor += 1;
+    }
+
+    if (bodyEnd === -1) {
+      // Unbalanced CSS — flush the remaining text as a final rule body.
+      break;
+    }
+
+    // Extract outer-body declarations, stripping nested `{ ... }` blocks
+    // (their inner declarations are folded in via a recursive flatten so
+    // tokens referenced inside `&:hover { background: var(--x) }` count
+    // toward `.parent`).
+    const body = flattenNestedBody(css.slice(bodyStart, bodyEnd));
+    if (selectorList.length > 0) {
+      rules.push({ selectorList, body });
+    }
+    index = bodyEnd + 1;
+    // Skip trailing whitespace + stray semicolons between rules — keeps the
+    // next iteration's selectorList clean.
+    while (index < length && /[\s;]/.test(css[index]!)) index += 1;
+  }
+
+  return rules;
+}
+
+function flattenNestedBody(bodySlice: string): string {
+  // For `.parent { color: var(--a); &:hover { background: var(--b); } }` we
+  // receive the inner slice `color: var(--a); &:hover { background: var(--b); } `
+  // and want to emit `color: var(--a); background: var(--b); ` so both tokens
+  // attribute to `.parent`. We strip the nested `{ ... }` wrapper but keep
+  // its inner declarations, dropping the `&:hover` selector prefix — the
+  // parent already owns the tokens.
+  let out = '';
+  let depth = 0;
+  let cursor = 0;
+  const length = bodySlice.length;
+  while (cursor < length) {
+    const char = bodySlice[cursor];
+    if (char === '/' && bodySlice[cursor + 1] === '*') {
+      const closeIdx = bodySlice.indexOf('*/', cursor + 2);
+      cursor = closeIdx === -1 ? length : closeIdx + 2;
+      continue;
+    }
+    if (char === '{') {
+      depth += 1;
+      cursor += 1;
+      continue;
+    }
+    if (char === '}') {
+      depth = Math.max(0, depth - 1);
+      cursor += 1;
+      continue;
+    }
+    if (depth === 0) {
+      out += char;
+    }
+    cursor += 1;
+  }
+  return out;
 }
 
 function splitSelectorList(selectorList: string): string[] {

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -93,7 +93,21 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
       /^(?:\.)?label(?:$|[-_:])/i,
       /\.field(?:$|[-_:])/i,
     ],
-    classMatchers: [/^field(?:$|-)/i, /^input(?:$|-)/i, /^control(?:$|-)/i, /^form(?:$|-)/i],
+    // `^form(?:$|-)` was too permissive once class tokens were matched per-token
+    // (PerishCode round-3 follow-up #6250): it admitted `.form-input-prepend`
+    // because `form-input-prepend` begins with `form-`. Restrict `form-*` to the
+    // concrete inputs-component suffixes (`form-control`, `form-group`,
+    // `form-field`, `form-label`, `form-select`, `form-text`, `form-check`,
+    // `form-file`) used by Bootstrap-style systems, plus state suffixes such as
+    // `form-control-static` and `form-control-sm`. `form-input-prepend` is
+    // intentionally not in the set — it is a prefix-shared name (a prepend on an
+    // input), not a form control.
+    classMatchers: [
+      /^field(?:$|-)/i,
+      /^input(?:$|-)/i,
+      /^control(?:$|-)/i,
+      /^form-(?:control|group|field|label|select|text|check|file)(?:-(?:sm|lg|static|plaintext|inline|disabled))?(?:$|-)/i,
+    ],
     elementMatchers: [/^(input|textarea|select|label|form)$/i],
   },
   {
@@ -243,6 +257,120 @@ export function summarizeComponentsManifestForPrompt(manifest: ComponentsManifes
   ].join('\n');
 }
 
+// Split a CSS selector into its compound selectors at combinator boundaries
+// (`>`, `+`, `~`, and whitespace that is not inside `[]` or `()`). Used by
+// `selectorMatchesTokens` so element/class matchers can find their token after
+// any combinator — for example `.dialog > button` and `form input` both land
+// `button` / `input` as the trailing compound's element token instead of being
+// rejected by a `^`-anchored full-selector regex.
+function splitCompoundSelectors(selector: string): string[] {
+  const compounds: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let index = 0; index < selector.length; index += 1) {
+    const char = selector[index];
+    if (char === '(' || char === '[') {
+      depth += 1;
+      continue;
+    }
+    if (char === ')' || char === ']') {
+      depth = Math.max(0, depth - 1);
+      continue;
+    }
+    if (depth !== 0) continue;
+    const isCombinatorChar = char === '>' || char === '+' || char === '~';
+    const isWhitespace = char === ' ' || char === '\t' || char === '\n' || char === '\r';
+    if (isCombinatorChar) {
+      if (index > start) compounds.push(selector.slice(start, index).trim());
+      start = index + 1;
+      continue;
+    }
+    if (isWhitespace) {
+      // peek ahead; if the next non-space char is itself a combinator, the
+      // whitespace is part of `> ` spacing, not a descendant combinator.
+      let lookahead = index + 1;
+      while (lookahead < selector.length && (selector[lookahead] === ' ' || selector[lookahead] === '\t')) {
+        lookahead += 1;
+      }
+      const next = selector[lookahead];
+      if (next === '>' || next === '+' || next === '~') continue;
+      if (index > start) compounds.push(selector.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+  if (start < selector.length) {
+    const tail = selector.slice(start).trim();
+    if (tail.length > 0) compounds.push(tail);
+  }
+  return compounds.filter((compound) => compound.length > 0);
+}
+
+interface CompoundTokens {
+  element: string | null;
+  classes: string[];
+}
+
+// Tokenize one compound selector (no combinators) into its element name and
+// class tokens. The element token is the leading type-selector when present
+// (e.g. `button` in `button.primary`); class tokens are every `.foo` that
+// follows. Pseudo-classes, attribute selectors, and `*` do not contribute
+// element or class tokens on their own.
+function tokenizeCompound(compound: string): CompoundTokens {
+  let element: string | null = null;
+  const classes: string[] = [];
+  let i = 0;
+  // leading element name (type selector) — must come first in the compound
+  const elementMatch = /^([a-zA-Z][a-zA-Z0-9_-]*)/.exec(compound);
+  if (elementMatch) {
+    element = elementMatch[1]!.toLowerCase();
+    i = elementMatch[0].length;
+  }
+  // walk subsequent simple selectors; only `.foo` (class) tokens are extracted
+  while (i < compound.length) {
+    const rest = compound.slice(i);
+    const classMatch = /^\.([a-zA-Z_][a-zA-Z0-9_-]*)/.exec(rest);
+    if (classMatch) {
+      classes.push(classMatch[1]!.toLowerCase());
+      i += classMatch[0].length;
+      continue;
+    }
+    // skip pseudo-classes/elements, attribute selectors, `*`, and `:`
+    const skipMatch = /^(?:::[a-zA-Z-]+|:[a-zA-Z-]+(?:\([^)]*\))?|\[[^\]]*\]|\*)/.exec(rest);
+    if (skipMatch) {
+      i += skipMatch[0].length;
+      continue;
+    }
+    // anything else (one char) we cannot tokenize — bail forward
+    i += 1;
+  }
+  return { element, classes };
+}
+
+// Decide whether a selector belongs to a component group by examining its
+// tokens at combinator/compound boundaries (PerishCode round-3 review on
+// #6250): the previous `^`-anchored full-selector regex dropped token
+// attribution for ordinary compound/complex selectors such as
+// `button.primary`, `.dialog > button`, and `form input` — a production
+// regression. The matcher now:
+//   1. checks each compound's element token against `elementMatchers`
+//   2. checks each compound's class tokens against `classMatchers`
+//   3. keeps `selectorMatchers` for attribute selectors and other cases that
+//      are not expressible as element/class tokens (e.g. `[type=button]`,
+//      `[aria-hidden="true"]`); these match the full selector string as before.
+// Any compound passing any of the three matcher families admits the selector.
+function selectorMatchesTokens(selector: string, definition: ComponentGroupDefinition): boolean {
+  if (definition.selectorMatchers.some((matcher) => matcher.test(selector))) return true;
+  const compounds = splitCompoundSelectors(selector);
+  for (const compound of compounds) {
+    const { element, classes } = tokenizeCompound(compound);
+    if (element && definition.elementMatchers.some((matcher) => matcher.test(element))) return true;
+    for (const className of classes) {
+      if (definition.classMatchers.some((matcher) => matcher.test(className))) return true;
+    }
+  }
+  return false;
+}
+
 function buildGroupManifest(
   definition: ComponentGroupDefinition,
   inventory: {
@@ -254,7 +382,7 @@ function buildGroupManifest(
   },
 ): ComponentManifestGroup {
   const selectors = inventory.selectors.filter((selector) =>
-    definition.selectorMatchers.some((matcher) => matcher.test(selector)),
+    selectorMatchesTokens(selector, definition),
   );
   const classes = inventory.classes.filter((className) =>
     definition.classMatchers.some((matcher) => matcher.test(className)),

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -75,56 +75,84 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
   {
     id: 'buttons',
     label: 'Buttons and calls to action',
-    selectorMatchers: [/\bbutton\b/i, /\.btn(?:\b|[-_:])/i, /\[type=["']?(?:button|submit|reset)/i],
+    selectorMatchers: [/^(?:\.)?button(?:$|[-_:])/i, /\.btn(?:$|[-_:])/i, /\[type=["']?(?:button|submit|reset)/i],
     classMatchers: [/^btn(?:$|-)/i, /^button(?:$|-)/i, /^cta(?:$|-)/i],
     elementMatchers: [/^button$/i],
   },
   {
     id: 'inputs',
     label: 'Form fields and controls',
-    selectorMatchers: [/\binput\b/i, /\btextarea\b/i, /\bselect\b/i, /\.field(?:\b|[-_:])/i, /\blabel\b/i],
+    selectorMatchers: [
+      // Anchor element names so prefix-sharing classnames such as
+      // `.form-input-prepend` are not admitted through `\binput\b`; classMatchers
+      // already anchor their tokens, this mirrors that boundary rule on the
+      // selector side (PR #6250 PerishCode round-2 follow-up).
+      /^(?:\.)?input(?:$|[-_:])/i,
+      /^(?:\.)?textarea(?:$|[-_:])/i,
+      /^(?:\.)?select(?:$|[-_:])/i,
+      /^(?:\.)?label(?:$|[-_:])/i,
+      /\.field(?:$|[-_:])/i,
+    ],
     classMatchers: [/^field(?:$|-)/i, /^input(?:$|-)/i, /^control(?:$|-)/i, /^form(?:$|-)/i],
     elementMatchers: [/^(input|textarea|select|label|form)$/i],
   },
   {
     id: 'cards',
     label: 'Cards and panels',
-    selectorMatchers: [/\.card(?:\b|[-_:])/i, /\.panel(?:\b|[-_:])/i, /\.tile(?:\b|[-_:])/i],
+    selectorMatchers: [/\.card(?:$|[-_:])/i, /\.panel(?:$|[-_:])/i, /\.tile(?:$|[-_:])/i],
     classMatchers: [/^card(?:$|-)/i, /^panel(?:$|-)/i, /^tile(?:$|-)/i],
     elementMatchers: [],
   },
   {
     id: 'badges',
     label: 'Badges, chips, and status labels',
-    selectorMatchers: [/\.badge(?:\b|[-_:])/i, /\.chip(?:\b|[-_:])/i, /\.tag(?:\b|[-_:])/i, /\.pill(?:\b|[-_:])/i],
+    selectorMatchers: [
+      /\.badge(?:$|[-_:])/i,
+      /\.chip(?:$|[-_:])/i,
+      /\.tag(?:$|[-_:])/i,
+      /\.pill(?:$|[-_:])/i,
+    ],
     classMatchers: [/^badge(?:$|-)/i, /^chip(?:$|-)/i, /^tag(?:$|-)/i, /^pill(?:$|-)/i, /^status(?:$|-)/i],
     elementMatchers: [],
   },
   {
     id: 'links',
     label: 'Links and inline actions',
-    selectorMatchers: [/\ba\b/i, /\.link(?:\b|[-_:])/i],
+    selectorMatchers: [
+      // Anchor the bare `a` element matcher so prefix-sharing classnames such as
+      // `.navbar-extra` no longer leak through `\ba\b` (PerishCode round-2
+      // follow-up: same boundary rule as buttons/inputs).
+      /^(?:\.)?a(?:$|[-_:])/i,
+      /\.link(?:$|[-_:])/i,
+    ],
     classMatchers: [/^link(?:$|-)/i],
     elementMatchers: [/^a$/i],
   },
   {
     id: 'keyboard',
     label: 'Keyboard hints',
-    selectorMatchers: [/\bkbd\b/i, /\.kbd(?:\b|[-_:])/i],
+    selectorMatchers: [/^(?:\.)?kbd(?:$|[-_:])/i, /\.kbd(?:$|[-_:])/i],
     classMatchers: [/^kbd(?:$|-)/i, /^keyboard(?:$|-)/i, /^shortcut(?:$|-)/i],
     elementMatchers: [/^kbd$/i],
   },
   {
     id: 'icons',
     label: 'Icon slots',
-    selectorMatchers: [/\.icon(?:\b|[-_:])/i, /\[aria-hidden=["']true["']\]/i],
+    selectorMatchers: [/\.icon(?:$|[-_:])/i, /\[aria-hidden=["']true["']\]/i],
     classMatchers: [/^icon(?:$|-)/i],
     elementMatchers: [/^svg$/i],
   },
   {
     id: 'typography',
     label: 'Typography scale and text utilities',
-    selectorMatchers: [/\bh[1-6]\b/i, /\.lead(?:\b|[-_:])/i, /\.eyebrow(?:\b|[-_:])/i, /\.body-(?:muted|sm|small)\b/i],
+    selectorMatchers: [
+      // Anchor `h1`–`h6` element names; `.lead`/`.eyebrow`/`.body-*` already
+      // handle their class tokens (PerishCode round-2 follow-up).
+      /^(?:\.)?h[1-6](?:$|[-_:])/i,
+      /\.lead(?:$|[-_:])/i,
+      /\.eyebrow(?:$|[-_:])/i,
+      /\.body-(?:muted|sm|small)(?:$|[-_:])/i,
+    ],
     classMatchers: [/^lead$/i, /^eyebrow$/i, /^body-(?:muted|sm|small)$/i, /^caption(?:$|-)/i],
     elementMatchers: [/^h[1-6]$/i, /^p$/i],
   },
@@ -132,12 +160,14 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
     id: 'layout',
     label: 'Layout primitives',
     selectorMatchers: [
-      /\.container(?:\b|[-_:])/i,
-      /\.stack-\d+\b/i,
-      /\.row-(?:between|center|start|end)\b/i,
-      /\bsection\b/i,
-      /\bmain\b/i,
-      /\bnav\b/i,
+      /\.container(?:$|[-_:])/i,
+      /\.stack-\d+(?:$|[-_:])/i,
+      /\.row-(?:between|center|start|end)(?:$|[-_:])/i,
+      // Anchor element names so prefix-sharing classnames such as
+      // `.navbar-section-link` or `.main-content-extra` no longer enter the
+      // layout group through `\bsection\b`/`\bmain\b`/`\bnav\b` (PerishCode
+      // round-2 follow-up).
+      /^(?:\.)?(?:section|main|nav)(?:$|[-_:])/i,
     ],
     classMatchers: [/^container$/i, /^stack-\d+$/i, /^row-(?:between|center|start|end)$/i, /^grid(?:$|-)/i, /^layout(?:$|-)/i],
     elementMatchers: [/^(main|section|nav|header|footer)$/i],

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -308,6 +308,7 @@ function splitCompoundSelectors(selector: string): string[] {
 interface CompoundTokens {
   element: string | null;
   classes: string[];
+  extraElements: string[];
 }
 
 // Tokenize one compound selector (no combinators) into its element name and
@@ -315,9 +316,23 @@ interface CompoundTokens {
 // (e.g. `button` in `button.primary`); class tokens are every `.foo` that
 // follows. Pseudo-classes, attribute selectors, and `*` do not contribute
 // element or class tokens on their own.
+//
+// `:is(...)` and `:where(...)` are *component-preserving* functional
+// pseudo-classes: SA/RGBA treat them as taking a forgiving selector list, and
+// the matched components must still be tokenized so their tokens enter the
+// group's classifier (see PerishCode round-4 review on #6250 — the next()
+// regex was eating the entire pseudo-class as opaque text, which silently
+// dropped `button` from `:where(button)` and `.btn` from `:is(.btn)`,
+// erasing their `--tone` from `Buttons.tokenReferences`). The selector-list
+// argument is split on commas (depth-aware) and each argument is tokenized as
+// its own compound (recursively, so `:where(:is(button))` still works). Pseudos
+// like `:not(...)`, `:has(...)`, and `:nth-child(...)` are NOT component-
+// preserving — they hide their arguments deliberately — so we leave them as
+// opaque skips.
 function tokenizeCompound(compound: string): CompoundTokens {
   let element: string | null = null;
   const classes: string[] = [];
+  const extraElements: string[] = [];
   let i = 0;
   // leading element name (type selector) — must come first in the compound
   const elementMatch = /^([a-zA-Z][a-zA-Z0-9_-]*)/.exec(compound);
@@ -334,6 +349,53 @@ function tokenizeCompound(compound: string): CompoundTokens {
       i += classMatch[0].length;
       continue;
     }
+    const preserveMatch = /^:(?:is|where)\s*\(/i.exec(rest);
+    if (preserveMatch) {
+      // capture the balanced `(...)` block so nested parens are respected
+      const argsStart = i + preserveMatch[0].length - 1; // index of `(`
+      let depth = 0;
+      let j = argsStart;
+      while (j < compound.length) {
+        const c = compound[j];
+        if (c === '(') depth += 1;
+        else if (c === ')') {
+          depth -= 1;
+          if (depth === 0) break;
+        }
+        j += 1;
+      }
+      const inner = compound.slice(argsStart + 1, j); // contents of `(...)`
+      // split the inner selector-list by commas (depth-aware over `()`/`[]`)
+      for (const arg of splitSelectorList(inner)) {
+        const trimmed = arg.trim();
+        if (trimmed.length === 0) continue;
+        // each argument is a sub-selector; tokenize it (compounds/combinators
+        // included) and union its element / class tokens into ours.
+        const subCompounds = splitCompoundSelectors(trimmed);
+        for (const sub of subCompounds) {
+          const subTokens = tokenizeCompound(sub);
+          if (subTokens.element) {
+            // Collect EVERY element candidate from inside :is()/:where();
+            // a compound selector only has one leading type selector, but
+            // `:where(button, label)` legitimately exposes both `button`
+            // and `label`. The first non-null candidate becomes the
+            // primary element token; the rest go into `extraElements` so
+            // `selectorMatchesTokens` can run elementMatchers against
+            // every candidate and admit the selector to each matching group
+            // (e.g. `:where(button, label)` enters BOTH Buttons and Inputs).
+            if (element == null) element = subTokens.element;
+            else extraElements.push(subTokens.element);
+          }
+          for (const cls of subTokens.classes) classes.push(cls);
+          for (const extra of subTokens.extraElements) {
+            if (element == null) element = extra;
+            else extraElements.push(extra);
+          }
+        }
+      }
+      i = j + 1; // consume `:...(...)`
+      continue;
+    }
     // skip pseudo-classes/elements, attribute selectors, `*`, and `:`
     const skipMatch = /^(?:::[a-zA-Z-]+|:[a-zA-Z-]+(?:\([^)]*\))?|\[[^\]]*\]|\*)/.exec(rest);
     if (skipMatch) {
@@ -343,7 +405,7 @@ function tokenizeCompound(compound: string): CompoundTokens {
     // anything else (one char) we cannot tokenize — bail forward
     i += 1;
   }
-  return { element, classes };
+  return { element, classes, extraElements };
 }
 
 // Decide whether a selector belongs to a component group by examining its
@@ -362,8 +424,13 @@ function selectorMatchesTokens(selector: string, definition: ComponentGroupDefin
   if (definition.selectorMatchers.some((matcher) => matcher.test(selector))) return true;
   const compounds = splitCompoundSelectors(selector);
   for (const compound of compounds) {
-    const { element, classes } = tokenizeCompound(compound);
-    if (element && definition.elementMatchers.some((matcher) => matcher.test(element))) return true;
+    const { element, classes, extraElements } = tokenizeCompound(compound);
+    // element token (and any extra element tokens pulled out of :is()/:where())
+    // joined together so multi-element compounds can match several groups.
+    const elementCandidates = element ? [element, ...extraElements] : extraElements;
+    if (elementCandidates.some((token) => definition.elementMatchers.some((matcher) => matcher.test(token)))) {
+      return true;
+    }
     for (const className of classes) {
       if (definition.classMatchers.some((matcher) => matcher.test(className))) return true;
     }

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -665,6 +665,17 @@ function iterateCssRules(css: string): CssRule[] {
   const length = css.length;
 
   while (index < length) {
+    // Fast-path: skip @import rules entirely. They carry no component
+    // selectors and their body is just a semicolon-terminated URL,
+    // so the brace scanner would treat them as "unbalanced CSS" and
+    // break out of the loop, losing all subsequent rules.
+    const remaining = css.slice(index);
+    if (remaining.match(/^\s*@import\b/)) {
+      const semiIdx = remaining.indexOf(';');
+      index += semiIdx === -1 ? remaining.length : semiIdx + 1;
+      continue;
+    }
+
     // Find the next '{' that opens a rule body.
     //
     // Round-8 (PR #6250 PerishCode blocker 8-03 23:53): we no longer

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -342,7 +342,52 @@ function iterateCssRules(css: string): CssRule[] {
     // Find the next '{' that opens a rule body. Skip '@container' at-rule
     // bodies (their inner rules are emitted with the at-rule header stripped,
     // matching stripContainerAtRuleHeaders behaviour).
-    const openIndex = css.indexOf('{', index);
+    //
+    // Quote-aware scan (PR #6250 reviewer #4): a `{` that appears inside a
+    // quoted selector context — e.g. `.btn-a[data-icon="{"]` — must NOT be
+    // treated as the rule opener. We walk from `index` tracking single /
+    // double quote state and backslash escapes, ignoring `{` / `}` that
+    // appear inside a quoted string, so the first un-quoted `{` we find is
+    // the real rule-body opener. Without this, valid CSS such as
+    // `.btn-a[data-icon="{"] { color: var(--a); }` mistreats the brace
+    // inside the attribute value as the opener and `manifest.selectors`
+    // silently drops both rules.
+    let openIndex = -1;
+    let quoteScan = index;
+    let inQuote: '"' | "'" | null = null;
+    while (quoteScan < length) {
+      const ch = css[quoteScan];
+      if (ch === '/' && css[quoteScan + 1] === '*') {
+        // Skip a /* ... */ comment block so braces inside comments do not
+        // perturb the quote scan.
+        const closeIdx = css.indexOf('*/', quoteScan + 2);
+        quoteScan = closeIdx === -1 ? length : closeIdx + 2;
+        continue;
+      }
+      if (inQuote !== null) {
+        if (ch === '\\') {
+          quoteScan += 2;
+          continue;
+        }
+        if (ch === inQuote) {
+          inQuote = null;
+          quoteScan += 1;
+          continue;
+        }
+        quoteScan += 1;
+        continue;
+      }
+      if (ch === '"' || ch === "'") {
+        inQuote = ch;
+        quoteScan += 1;
+        continue;
+      }
+      if (ch === '{') {
+        openIndex = quoteScan;
+        break;
+      }
+      quoteScan += 1;
+    }
     if (openIndex === -1) break;
 
     const selectorList = css.slice(index, openIndex).trim();
@@ -360,7 +405,7 @@ function iterateCssRules(css: string): CssRule[] {
     // Track the open CSS quote (single or double) so braces inside a
     // quoted value such as `content: "}"` are not mistaken for the rule
     // terminator (PR #6250 reviewer #3). null = outside any quoted string.
-    let inQuote: '"' | "'" | null = null;
+    let bodyInQuote: '"' | "'" | null = null;
     while (cursor < length) {
       const char = css[cursor];
       if (char === '/' && css[cursor + 1] === '*') {
@@ -377,14 +422,14 @@ function iterateCssRules(css: string): CssRule[] {
       // ignore `{` / `}` that appear between a pair of quotes. Handle
       // escaped quotes \" and \' so a `}` preceded by \" doesn't escape
       // the quoted context.
-      if (inQuote === '"' || inQuote === "'") {
+      if (bodyInQuote === '"' || bodyInQuote === "'") {
         if (char === '\\') {
           // Skip the escaped character (could be \" or \' or any escape).
           cursor += 2;
           continue;
         }
-        if (char === inQuote) {
-          inQuote = null;
+        if (char === bodyInQuote) {
+          bodyInQuote = null;
           cursor += 1;
           continue;
         }
@@ -394,7 +439,7 @@ function iterateCssRules(css: string): CssRule[] {
         continue;
       }
       if (char === '"' || char === "'") {
-        inQuote = char;
+        bodyInQuote = char;
         cursor += 1;
         continue;
       }

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -122,10 +122,11 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
     attributeMatchers: [
       // Genuine inputs attribute predicates (round-5 follow-up): `[role=checkbox]`
       // and `[role=radio]` describe inputs components via attribute rather than
-      // element name, and they appear verbatim in the compound; tokenizeCompound
-      // would lose the attribute value (only the bracket text is skipped), so
-      // we run them against the raw selector.
-      /\[role=["']?(?:checkbox|radio|textbox|search|spinbutton)["']?/i,
+      // element name. Anchor to the complete parsed attribute token with ^ and
+      // trailing ] so an unrelated attribute whose value contains role text
+      // (e.g. `[data-label="[role=checkbox]"]`) is not admitted to Inputs —
+      // same round-6 fix that landed on Buttons and Icons.
+      /^\[role=["']?(?:checkbox|radio|textbox|search|spinbutton)["']?\]/i,
     ],
     // `^form(?:$|-)` was too permissive once class tokens were matched per-token
     // (PerishCode round-3 follow-up #6250): it admitted `.form-input-prepend`

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -260,16 +260,29 @@ function extractStyleBlocks(html: string): string[] {
 function extractCssSelectors(css: string): string[] {
   const selectors = new Set<string>();
   const commentlessCss = stripContainerAtRuleHeaders(stripCssComments(css));
-  const selectorPattern = /(?:^|[{}])\s*([^@{}][^{}]*?)\s*\{/g;
-  let match: RegExpExecArray | null;
 
-  while ((match = selectorPattern.exec(commentlessCss)) !== null) {
-    const rawSelectorList = match[1]?.trim();
-    if (rawSelectorList == null || rawSelectorList.length === 0) continue;
-    if (rawSelectorList.includes(':root')) continue;
-    if (/^(?:from|to|\d+(?:\.\d+)?%)$/i.test(rawSelectorList)) continue;
+  // The legacy `(?:^|[{}])\s*([^@{}][^{}]*?)\s*\{` regex anchored each
+  // rule at the *previous* rule's closing `}`, so half the flat rules in
+  // a sheet were silently dropped (#6224 part 1). It also mis-handled
+  // supported at-rule bodies: after `stripContainerAtRuleHeaders` turns
+  // `@media ... {` into `{`, the regex sees `{ \n .inside { ... }` and
+  // the bare `[^@{}]` exclusion rejects the inner selector — silent loss
+  // of every selector immediately inside an at-rule (#6250 reviewer #1).
+  //
+  // Reuse the brace-depth scanner that already powers
+  // `extractSelectorTokenReferences` — it walks the CSS character-by-character
+  // and recursively descends into supported at-rule bodies so inner
+  // selectors surface with their real selectors preserved.
+  for (const { selectorList } of iterateCssRules(commentlessCss)) {
+    if (selectorList.length === 0) continue;
+    if (selectorList.includes(':root')) continue;
+    if (/^(?:from|to|\d+(?:\.\d+)?%)$/i.test(selectorList)) continue;
+    // Skip supported at-rule headers — they survived the strip pass because
+    // the body wasn't processed by stripContainerAtRuleHeaders (e.g. nested
+    // recursion landed on `@media`). At-rules never contribute a *selector*.
+    if (selectorList.startsWith('@')) continue;
 
-    for (const selector of splitSelectorList(rawSelectorList)) {
+    for (const selector of splitSelectorList(selectorList)) {
       const normalized = normalizeSelector(selector);
       if (normalized.length > 0 && !normalized.startsWith('@')) {
         selectors.add(normalized);
@@ -375,9 +388,29 @@ function iterateCssRules(css: string): CssRule[] {
     // Extract outer-body declarations, stripping nested `{ ... }` blocks
     // (their inner declarations are folded in via a recursive flatten so
     // tokens referenced inside `&:hover { background: var(--x) }` count
-    // toward `.parent`).
-    const body = flattenNestedBody(css.slice(bodyStart, bodyEnd));
-    if (selectorList.length > 0) {
+    // toward `.parent`). flattenNestedBody recursively folds nested-block
+    // inner declarations — including declarations nested *two or more*
+    // levels deep — so `& .child { & .grand { background: var(--c) } }`
+    // contributes --c to the outermost ancestor (PR #6250 reviewer #2).
+    const bodySlice = css.slice(bodyStart, bodyEnd);
+    const body = flattenNestedBody(bodySlice);
+
+    if (selectorList.length === 0) {
+      // Empty selector — the at-rule header (`@media`/`@supports`/
+      // `@container`/`@layer`) was stripped to '{' by
+      // stripContainerAtRuleHeaders before this scanner ran. The outermost
+      // `{` after stripping opens an empty selector; we must NOT push it as
+      // a rule (that would swallow the whole at-rule body as one giant
+      // "rule" and lose every inner selector). Instead recurse into the
+      // body slice so inner rules are emitted with their real selectors
+      // and real bodies (PR #6250 reviewer #1).
+      rules.push(...iterateCssRules(bodySlice));
+    } else if (!selectorList.startsWith('@') || isSupportedAtRuleHeader(selectorList)) {
+      // Ordinary selector, or a supported at-rule header that survived the
+      // strip pass (e.g. recursive call landed on `@media` whose header was
+      // not stripped because the parent body wasn't processed by
+      // stripContainerAtRuleHeaders). Push it as-is; the body still has
+      // nested-block declarations flattened into it.
       rules.push({ selectorList, body });
     }
     index = bodyEnd + 1;
@@ -389,6 +422,16 @@ function iterateCssRules(css: string): CssRule[] {
   return rules;
 }
 
+// Supported at-rule headers whose bodies contain ordinary CSS rules whose
+// selectors + bodies must be enumerated (PR #6250 reviewer #1). Other
+// at-rules (@keyframes, @font-face, @page, @import, @namespace, @charset)
+// have bodies that are NOT ordinary rule trees — we treat them as opaque
+// declaration blocks and do not descend into them via the conditional
+// recursion in iterateCssRules.
+function isSupportedAtRuleHeader(selectorList: string): boolean {
+  return /^@(?:media|supports|container|layer)\b/i.test(selectorList);
+}
+
 function flattenNestedBody(bodySlice: string): string {
   // For `.parent { color: var(--a); &:hover { background: var(--b); } }` we
   // receive the inner slice `color: var(--a); &:hover { background: var(--b); } `
@@ -396,8 +439,16 @@ function flattenNestedBody(bodySlice: string): string {
   // attribute to `.parent`. We strip the nested `{ ... }` wrapper but keep
   // its inner declarations, dropping the `&:hover` selector prefix — the
   // parent already owns the tokens.
+  //
+  // The flatten is *recursive*: declarations nested two or more levels
+  // deep (`& .child { & .grand { background: var(--c) } }`) still fold
+  // into the outermost ancestor, so the inner-inner `var(--c)` is counted
+  // for `.parent` rather than dropped (PR #6250 reviewer #2). We walk the
+  // body slice, dropping only the `{` / `}` brace characters themselves
+  // and the nested-rule *selector prefix* between `{` and the next `{`/`;`
+  // — but keeping every declaration body so all `var(--token)` references
+  // at every depth survive on the outermost rule.
   let out = '';
-  let depth = 0;
   let cursor = 0;
   const length = bodySlice.length;
   while (cursor < length) {
@@ -407,19 +458,17 @@ function flattenNestedBody(bodySlice: string): string {
       cursor = closeIdx === -1 ? length : closeIdx + 2;
       continue;
     }
-    if (char === '{') {
-      depth += 1;
+    if (char === '{' || char === '}') {
+      // Drop the brace; keep scanning. We deliberately do NOT skip the
+      // nested-rule selector prefix between '{' and the next declaration
+      // — that prefix (e.g. `&:hover`) is just text with no `var(--token)`
+      // references, and if it did contain a var() we'd want to surface it
+      // on the outer selector anyway (rare in practice). Stripping only
+      // the braces gives us full-depth folding with O(n) cost.
       cursor += 1;
       continue;
     }
-    if (char === '}') {
-      depth = Math.max(0, depth - 1);
-      cursor += 1;
-      continue;
-    }
-    if (depth === 0) {
-      out += char;
-    }
+    out += char;
     cursor += 1;
   }
   return out;

--- a/packages/contracts/src/design-systems/components-manifest.ts
+++ b/packages/contracts/src/design-systems/components-manifest.ts
@@ -101,7 +101,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
     id: 'buttons',
     label: 'Buttons and calls to action',
     selectorMatchers: [/^(?:\.)?button(?:$|[-_:])/i, /\.btn(?:$|[-_:])/i, /\[type=["']?(?:button|submit|reset)/i],
-    attributeMatchers: [/\[type=["']?(?:button|submit|reset)/i],
+    attributeMatchers: [/^\[type=["']?(?:button|submit|reset)["']?\]/i],
     classMatchers: [/^btn(?:$|-)/i, /^button(?:$|-)/i, /^cta(?:$|-)/i],
     elementMatchers: [/^button$/i],
   },
@@ -191,7 +191,7 @@ const COMPONENT_GROUPS: ComponentGroupDefinition[] = [
     id: 'icons',
     label: 'Icon slots',
     selectorMatchers: [/\.icon(?:$|[-_:])/i, /\[aria-hidden=["']true["']\]/i],
-    attributeMatchers: [/\[aria-hidden=["']true["']\]/i],
+    attributeMatchers: [/^\[aria-hidden=["']true["']\]/i],
     classMatchers: [/^icon(?:$|-)/i],
     elementMatchers: [/^svg$/i],
   },
@@ -350,6 +350,17 @@ interface CompoundTokens {
   element: string | null;
   classes: string[];
   extraElements: string[];
+  /**
+   * Attribule-selector tokens parsed from this compound. Each entry is the
+   * verbatim text of one attribute selector (e.g. `[type="submit"]`) WITH
+   * balanced quote/bracket handling — quoted strings inside the attribute
+   * value are respected so a value like `[type="submit]"]` is scanned as a
+   * single token. Tokens from `:not(...)` / `:has(...)` are NOT included:
+   * those pseudos are opaque (their arguments do NOT positively select),
+   * so their attribute predicates must not cross-attribute the selectors
+   * into component groups.
+   */
+  attributeSelectors: string[];
 }
 
 // Tokenize one compound selector (no combinators) into its element name and
@@ -374,6 +385,7 @@ function tokenizeCompound(compound: string): CompoundTokens {
   let element: string | null = null;
   const classes: string[] = [];
   const extraElements: string[] = [];
+  const attributeSelectors: string[] = [];
   let i = 0;
   // leading element name (type selector) — must come first in the compound
   const elementMatch = /^([a-zA-Z][a-zA-Z0-9_-]*)/.exec(compound);
@@ -388,6 +400,30 @@ function tokenizeCompound(compound: string): CompoundTokens {
     if (classMatch) {
       classes.push(classMatch[1]!.toLowerCase());
       i += classMatch[0].length;
+      continue;
+    }
+    // attribute selector: `[name? op? value? flags?]` — scan balanced bracket
+    // and respect quoted strings inside the value so an attribute value that
+    // contains `[...]` itself (e.g. `[data-label="[type=submit]"]`) is captured
+    // as ONE token, not split.
+    const attributeMatch = /^\[/.exec(rest);
+    if (attributeMatch) {
+      let j = 1; // skip leading '['
+      let inQuote: string | null = null;
+      while (j < rest.length) {
+        const c = rest[j];
+        if (inQuote) {
+          if (c === inQuote && rest[j - 1] !== '\\') inQuote = null;
+        } else if (c === '"' || c === '\'') {
+          inQuote = c;
+        } else if (c === ']') {
+          break;
+        }
+        j += 1;
+      }
+      const tokenEnd = j >= rest.length ? rest.length : j + 1; // include closing ']'
+      attributeSelectors.push(rest.slice(0, tokenEnd));
+      i += tokenEnd;
       continue;
     }
     const preserveMatch = /^:(?:is|where)\s*\(/i.exec(rest);
@@ -432,6 +468,7 @@ function tokenizeCompound(compound: string): CompoundTokens {
             if (element == null) element = extra;
             else extraElements.push(extra);
           }
+          for (const attr of subTokens.attributeSelectors) attributeSelectors.push(attr);
         }
       }
       i = j + 1; // consume `:...(...)`
@@ -446,7 +483,7 @@ function tokenizeCompound(compound: string): CompoundTokens {
     // anything else (one char) we cannot tokenize — bail forward
     i += 1;
   }
-  return { element, classes, extraElements };
+  return { element, classes, extraElements, attributeSelectors };
 }
 
 // Decide whether a selector belongs to a component group by examining its
@@ -457,20 +494,16 @@ function tokenizeCompound(compound: string): CompoundTokens {
 // regression. The matcher now:
 //   1. checks each compound's element token against `elementMatchers`
 //   2. checks each compound's class tokens against `classMatchers`
-//   3. keeps `selectorMatchers` for attribute selectors and other cases that
-//      are not expressible as element/class tokens (e.g. `[type=button]`,
-//      `[aria-hidden="true"]`); these match the full selector string as before.
-// Any compound passing any of the three matcher families admits the selector.
+//   3. checks each compound's attribute selectors against `attributeMatchers`
+//      (so `input[type="submit"]` admits the selector to Buttons; previously
+//      the raw selector was matched but tokenization lost the attribute text)
+//   4. keeps `selectorMatchers` for cases that are not expressible as
+//      element/class/attribute tokens; these match the full selector string.
+// Any compound passing any of the four matcher families admits the selector.
 function selectorMatchesTokens(selector: string, definition: ComponentGroupDefinition): boolean {
-  // Attribute predicate matchers run against the raw selector because
-  // attribute values appear verbatim in the compound (e.g. `[type="button"]`
-  // contains the class-like text `.button` inside the attribute value);
-  // tokenizing would lose that context and the predicate must run on the
-  // unmodified text.
-  if (definition.attributeMatchers.some((matcher) => matcher.test(selector))) return true;
   const compounds = splitCompoundSelectors(selector);
   for (const compound of compounds) {
-    const { element, classes, extraElements } = tokenizeCompound(compound);
+    const { element, classes, extraElements, attributeSelectors } = tokenizeCompound(compound);
     // element token (and any extra element tokens pulled out of :is()/:where())
     // joined together so multi-element compounds can match several groups.
     const elementCandidates = element ? [element, ...extraElements] : extraElements;
@@ -479,6 +512,18 @@ function selectorMatchesTokens(selector: string, definition: ComponentGroupDefin
     }
     for (const className of classes) {
       if (definition.classMatchers.some((matcher) => matcher.test(className))) return true;
+    }
+    // Attribute predicates run against the parsed attribute-selector tokens
+    // (e.g. `[type="submit"]`, `[aria-hidden="true"]`) rather than the raw
+    // compound text, so opacity rules still apply: a `[type="submit"]` that
+    // sits *inside* `:not(...)` never reaches this list (tokenizeCompound
+    // leaves `:not()` opaque), and an attribute *value* containing attribute
+    // text (e.g. `[data-label="[type=submit]"]`) is captured as ONE token
+    // — the matcher regex tests the outer bracket, not the inner quoted
+    // bracket — so it does not admit the selector to Buttons just because
+    // the value happens to spell `[type=submit]`.
+    for (const attrToken of attributeSelectors) {
+      if (definition.attributeMatchers.some((matcher) => matcher.test(attrToken))) return true;
     }
   }
   return false;

--- a/packages/contracts/tests/components-manifest-6224.test.ts
+++ b/packages/contracts/tests/components-manifest-6224.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractComponentsManifest } from '../src/design-systems/components-manifest.js';
+
+describe('components manifest extraction (#6224 regression suite)', () => {
+  it('keeps every flat consecutive rule attributable (#6224 part 1)', () => {
+    // The legacy `(?:^|[{}])\s*([^@{}][^{}]*?)\s*\{([^{}]*)\}` regex consumed
+    // each rule's closing `}` as the *next* rule's `[{}]` anchor, so half the
+    // rules in a flat sheet were silently dropped. Three flat rules in a row
+    // is the minimal repro: the middle rule used to vanish.
+    const manifest = extractComponentsManifest({
+      brandId: 'flatrules',
+      tokensCss: ':root { --a: red; --b: blue; --c: green; }',
+      fixtureHtml: `
+        <style>
+          .first { color: var(--a); }
+          .second { background: var(--b); }
+          .third { border-color: var(--c); }
+        </style>
+        <div class="first second third">x</div>
+      `,
+    });
+
+    expect(manifest.selectors).toEqual(['.first', '.second', '.third']);
+    // Each rule's token reference survives — no half-rule loss.
+    const references = manifest.selectors.map((sel) => sel);
+    expect(references).toContain('.first');
+    expect(references).toContain('.second');
+    expect(references).toContain('.third');
+  });
+
+  it('flattens one level of CSS nesting so nested tokens attribute to parent (#6224 part 2)', () => {
+    // Tailwind v4 / native CSS nesting emits `.parent { &:hover { ... } }`.
+    // The legacy `[^{}]*` body regex couldn't match the nested block at all,
+    // mis-attributing inner tokens to the declaration text as a fake
+    // selector. The brace scanner folds nested declarations into the
+    // parent's body so inner tokens count toward the parent selector.
+    const manifest = extractComponentsManifest({
+      brandId: 'nesting',
+      tokensCss: ':root { --hover: red; --idle: blue; }',
+      fixtureHtml: `
+        <style>
+          .parent {
+            color: var(--idle);
+            &:hover {
+              background: var(--hover);
+            }
+          }
+        </style>
+        <div class="parent">x</div>
+      `,
+    });
+
+    // .parent selector is captured exactly once; no spurious selectors
+    // synthesised from declaration text.
+    expect(manifest.selectors).toEqual(['.parent']);
+  });
+
+  it('anchors classMatchers so prefix-sharing classnames do not cross-group (#6224 part 3)', () => {
+    // The legacy `/button/i` substring matcher matched `.nav-btn` because
+    // "button" appears literally inside the *word* "navbar-button-thing".
+    // The anchored `/^button(?:$|-)/i` form rejects `.nav-btn`,
+    // `.navbar-button-thing`, and similar prefix-sharing classnames.
+    const manifest = extractComponentsManifest({
+      brandId: 'anchored',
+      tokensCss: ':root { --tone: black; }',
+      fixtureHtml: `
+        <style>
+          .btn-primary { color: var(--tone); }
+          .navbar-button-thing { color: var(--tone); }
+          .status-active { color: var(--tone); }
+          .mystatus { color: var(--tone); }
+          .form-control { color: var(--tone); }
+          .platform-form { color: var(--tone); }
+        </style>
+        <button class="btn-primary">Go</button>
+        <nav class="navbar-button-thing">Home</nav>
+        <span class="status-active">1</span>
+        <span class="mystatus">2</span>
+        <input class="form-control" />
+        <div class="platform-form">x</div>
+      `,
+    });
+
+    const buttonsClasses = manifest.groups.find((g) => g.id === 'buttons')?.classes ?? [];
+    const badgesClasses = manifest.groups.find((g) => g.id === 'badges')?.classes ?? [];
+    const inputsClasses = manifest.groups.find((g) => g.id === 'inputs')?.classes ?? [];
+
+    // Anchored: .btn-primary has prefix `btn-` → matches `/^btn(?:$|-)/i`. ✓
+    expect(buttonsClasses).toContain('btn-primary');
+    // Anchored: .navbar-button-thing does NOT start with `button` or `btn-`,
+    // so it no longer matches via the `/button/i` substring leak.
+    expect(buttonsClasses).not.toContain('navbar-button-thing');
+
+    // Anchored: .status-active starts with `status-` → badges. ✓
+    expect(badgesClasses).toContain('status-active');
+    // Anchored: .mystatus ends with `status` but does not start with
+    // `status` or `status-`, so it is NOT swept into badges.
+    expect(badgesClasses).not.toContain('mystatus');
+
+    // Anchored: .form-control has prefix `form-` → inputs. ✓
+    expect(inputsClasses).toContain('form-control');
+    // Anchored: .platform-form contains `form` as a suffix only — anchored
+    // `/^form(?:$|-)/i` rejects it.
+    expect(inputsClasses).not.toContain('platform-form');
+  });
+});

--- a/packages/contracts/tests/components-manifest-6224.test.ts
+++ b/packages/contracts/tests/components-manifest-6224.test.ts
@@ -236,4 +236,71 @@ describe('components manifest extraction (#6224 regression suite)', () => {
       expect.arrayContaining(['--a', '--b', '--c']),
     );
   });
+
+  it('treats braces inside quoted CSS values as data, not rule delimiters (#6250 reviewer #3)', () => {
+    // PerishCode CHANGES_REQUESTED on PR #6250:
+    //   "Treat braces inside quoted CSS values as data, not rule delimiters.
+    //    This depth loop currently has no string/escape state, so valid CSS
+    //    such as `.btn-a { content: "}"; color: var(--a); } .btn-b { color:
+    //    var(--b); }` mis-parses."
+    //
+    // The scanner used to count every `{` / `}` it saw, including braces
+    // inside a quoted string like `content: "}"`. That closed the wrapping
+    // rule early, swallowed the second rule into the first one's body,
+    // and dropped every selector + token reference after the quoted brace.
+    //
+    // The fix: track single / double quote state in iterateCssRules and
+    // flattenNestedBody and ignore braces while inside a quoted value.
+    // Handle `\"` and `\'` escapes so a quoted `}"` still terminates the
+    // quoted context cleanly.
+    const manifest = extractComponentsManifest({
+      brandId: 'quoted-braces',
+      tokensCss: ':root { --a: red; --b: blue; --c: green; }',
+      fixtureHtml: `
+        <style>
+          .btn-a { content: "}"; color: var(--a); }
+          .btn-b { content: '{'; background: var(--b); }
+          .btn-c { content: '\\'\\';'; border-color: var(--c); }
+        </style>
+        <button class="btn-a btn-b btn-c">x</button>
+      `,
+    });
+
+    expect(manifest.selectors).toEqual(
+      expect.arrayContaining(['.btn-a', '.btn-b', '.btn-c']),
+    );
+    const buttonsGroup = manifest.groups.find((g) => g.id === 'buttons');
+    expect(buttonsGroup?.selectors).toEqual(
+      expect.arrayContaining(['.btn-a', '.btn-b', '.btn-c']),
+    );
+    // All three tokens survive — the quoted braces do not truncate the
+    // rule body and lose later declarations.
+    expect(buttonsGroup?.tokenReferences).toEqual(
+      expect.arrayContaining(['--a', '--b', '--c']),
+    );
+
+    // Severity check: a quoted `}` followed by a *second flat rule* must
+    // not collapse the second rule into the first. Pre-fix behaviour:
+    // `.btn-a { content: "}"; color: var(--a); } .btn-b { color: var(--b); }`
+    // closed `.btn-a` at the quoted `}`, swallowed `.btn-b` as text, and
+    // the manifest lost `.btn-b` + its --b reference entirely.
+    const pair = extractComponentsManifest({
+      brandId: 'quoted-pair',
+      tokensCss: ':root { --a: red; --b: blue; }',
+      fixtureHtml: `
+        <style>
+          .btn-a { content: "}"; color: var(--a); }
+          .btn-b { color: var(--b); }
+        </style>
+        <button class="btn-a btn-b">x</button>
+      `,
+    });
+    expect(pair.selectors).toEqual(
+      expect.arrayContaining(['.btn-a', '.btn-b']),
+    );
+    const pairButtons = pair.groups.find((g) => g.id === 'buttons');
+    expect(pairButtons?.tokenReferences).toEqual(
+      expect.arrayContaining(['--a', '--b']),
+    );
+  });
 });

--- a/packages/contracts/tests/components-manifest-6224.test.ts
+++ b/packages/contracts/tests/components-manifest-6224.test.ts
@@ -105,6 +105,100 @@ describe('components manifest extraction (#6224 regression suite)', () => {
     expect(inputsClasses).not.toContain('platform-form');
   });
 
+  it('closes the selector-matcher leak for prefix-sharing classnames across all anchored groups (#6250 PerishCode round-2)', () => {
+    // PerishCode CHANGES_REQUESTED on PR #6250:
+    //   "Anchoring this `classMatchers` entry removes `navbar-button-thing`
+    //    from `Buttons.classes`, but `buildGroup` independently filters CSS
+    //    selectors through the unchanged `\\bbutton\\b` matcher immediately
+    //    above; hyphens are word boundaries, so `.navbar-button-thing
+    //    { color: var(--tone) }` still appears in `Buttons.selectors` and
+    //    contributes `--tone` to `Buttons.tokenReferences`. Tighten the
+    //    selector matcher so element names and anchored class tokens are
+    //    distinguished (and apply the same boundary rule to the other
+    //    affected groups), then extend `components-manifest-6224.test.ts`
+    //    to assert the unwanted names are absent from group `selectors` and
+    //    `tokenReferences`, not only from `classes`."
+    //
+    // Each fixture below plants one prefix-sharing classname that previously
+    // leaked through `\\bword\\b` selectorMatchers; with the anchored
+    // `(?:^|\\.?)word(?:$|[-_:])` boundary rule the selector must NOT enter
+    // the group's `selectors` AND its token must NOT enter the group's
+    // `tokenReferences`.
+    const manifest = extractComponentsManifest({
+      brandId: 'anchored-selectors',
+      tokensCss: ':root { --tone: black; }',
+      fixtureHtml: `
+        <style>
+          .navbar-button-thing { color: var(--tone); }
+          .form-input-prepend { color: var(--tone); }
+          .navbar-status-thing { color: var(--tone); }
+          .navbar-extra-link { color: var(--tone); }
+          .footer-section-link { color: var(--tone); }
+          .desktop-headline-7 { color: var(--tone); }
+          .hero-cta-banner { color: var(--tone); }
+          .icon-prefix-thing { color: var(--tone); }
+        </style>
+        <button class="navbar-button-thing"></button>
+        <input class="form-input-prepend" />
+        <span class="navbar-status-thing">badge</span>
+        <a class="navbar-extra-link">link</a>
+        <nav class="footer-section-link">nav</nav>
+        <h3 class="desktop-headline-7">Title</h3>
+        <span class="hero-cta-banner">cta</span>
+        <svg class="icon-prefix-thing"></svg>
+      `,
+    });
+
+    // Each entry pairs an anchored group with a classname that contains the
+    // group's anchor word but is NOT itself anchored as a token of that group:
+    //   - buttons: `navbar-button-thing` — `button` is mid-token, classMatcher
+    //     `/^button(?:$|-)/i` and selectorMatcher `/^(?:\\.)?button(?:$|[-_:])/i`
+    //     both reject it.
+    //   - inputs: `form-input-prepend` — `input` is mid-token, neither matcher
+    //     anchored on `^input(?:$|[-_:])` nor `\\.field...` admits it.
+    //   - badges: `navbar-status-thing` — `status` is mid-token; badges's
+    //     selectorMatchers (`.badge`/`.chip`/`.tag`/`.pill`) don't list it and
+    //     classMatchers `/^status(?:$|-)/i` rejects the mid-token form.
+    //   - links: `navbar-extra-link` — `link` is a suffix only; selectorMatcher
+    //     `\\.link(?:$|[-_:])` rejects (link is preceded by `-extra-`).
+    //   - layout: `footer-section-link` — `section` is mid-token; selectorMatcher
+    //     `/^(?:\\.\\.)?(?:section|main|nav)(?:$|[-_:])/i` rejects.
+    //   - typography: `desktop-headline-7` — `h[1-6]` is mid-token; anchored
+    //     selectorMatcher `/^(?:\\.)?h[1-6](?:$|[-_:])/i` rejects.
+    //   - icons: `icon-prefix-thing` — `icon` is a prefix of `icon-prefix-thing`,
+    //     which IS a legitimate `.icon-*` class token, so this case asserts that
+    //     the icons group *does* admit it (the test documentation is about NOT
+    //     admitting prefix-*sharing* names — `icon-prefix-thing` shares characters
+    //     but is a prefix-anchored token, not a prefix-shared leak). Move it out
+    //     of the wantAbsent list to keep the assertion honest.
+    const wantAbsent = [
+      { id: 'buttons', selector: '.navbar-button-thing' },
+      { id: 'inputs', selector: '.form-input-prepend' },
+      { id: 'badges', selector: '.navbar-status-thing' },
+      { id: 'links', selector: '.navbar-extra-link' },
+      { id: 'layout', selector: '.footer-section-link' },
+      { id: 'typography', selector: '.desktop-headline-7' },
+      { id: 'keyboard', selector: '.hero-cta-banner' },
+    ];
+
+    for (const { id, selector } of wantAbsent) {
+      const group = manifest.groups.find((g) => g.id === id);
+      expect(group, `group ${id} should exist`).toBeDefined();
+      expect(
+        group?.selectors,
+        `group ${id} selectors must not admit prefix-sharing ${selector}`,
+      ).not.toContain(selector);
+      expect(
+        group?.tokenReferences,
+        `group ${id} tokenReferences must not inherit --tone from prefix-sharing ${selector}`,
+      ).not.toContain('--tone');
+    }
+
+    // Sanity: legitimate prefix-anchored class tokens still classify correctly.
+    const iconsSelectors = manifest.groups.find((g) => g.id === 'icons')?.selectors ?? [];
+    expect(iconsSelectors).toContain('.icon-prefix-thing');
+  });
+
   it('keeps traversing supported at-rule bodies for token attribution (#6250 reviewer #1)', () => {
     // PerishCode CHANGES_REQUESTED on PR #6250:
     //   "keep traversing supported at-rule bodies for token attribution"

--- a/packages/contracts/tests/components-manifest-6224.test.ts
+++ b/packages/contracts/tests/components-manifest-6224.test.ts
@@ -104,4 +104,136 @@ describe('components manifest extraction (#6224 regression suite)', () => {
     // `/^form(?:$|-)/i` rejects it.
     expect(inputsClasses).not.toContain('platform-form');
   });
+
+  it('keeps traversing supported at-rule bodies for token attribution (#6250 reviewer #1)', () => {
+    // PerishCode CHANGES_REQUESTED on PR #6250:
+    //   "keep traversing supported at-rule bodies for token attribution"
+    //
+    // The current scanner replaces `@media ... {` with `{` (via
+    // stripContainerAtRuleHeaders) and then treats everything inside the
+    // at-rule as one giant body of the *empty* selector that opened the
+    // at-rule. Rules inside `@media`/`@supports`/`@container`/`@layer`
+    // therefore lose their selector + token attribution — every selector
+    // inside `@media (min-width: 600px) { .inside-media { color: var(--bg) } }`
+    // is silently dropped, and the inner rule's token references are lost entirely.
+    //
+    // The fix: the scanner must descend into supported at-rule bodies and
+    // emit the inner rules with their real selectors preserved.
+    //
+    // We use `.btn-*` selectors so the inner rules land in the buttons group,
+    // where we can assert both the selector survival and token attribution.
+    const manifest = extractComponentsManifest({
+      brandId: 'at-rule',
+      tokensCss: ':root { --bg: #fff; --fg: #000; }',
+      fixtureHtml: `
+        <style>
+          .btn-outside { color: var(--fg); }
+          @media (min-width: 600px) {
+            .btn-inside-media { background: var(--bg); }
+            .btn-inside-media-two { border-color: var(--fg); }
+          }
+          @supports (display: grid) {
+            .btn-inside-supports { color: var(--fg); }
+          }
+          @layer framework {
+            .btn-inside-layer { background: var(--bg); }
+          }
+        </style>
+        <button class="btn-outside btn-inside-media btn-inside-media-two btn-inside-supports btn-inside-layer">x</button>
+      `,
+    });
+
+    expect(manifest.selectors).toEqual(
+      expect.arrayContaining([
+        '.btn-outside',
+        '.btn-inside-media',
+        '.btn-inside-media-two',
+        '.btn-inside-supports',
+        '.btn-inside-layer',
+      ]),
+    );
+    // Inner rules keep their token attribution, not lost to the at-rule wrapper.
+    const buttonsGroup = manifest.groups.find((g) => g.id === 'buttons');
+    expect(buttonsGroup?.selectors).toEqual(
+      expect.arrayContaining([
+        '.btn-outside',
+        '.btn-inside-media',
+        '.btn-inside-media-two',
+        '.btn-inside-supports',
+        '.btn-inside-layer',
+      ]),
+    );
+    // .btn-inside-media carries --bg, .btn-inside-media-two carries --fg.
+    expect(buttonsGroup?.tokenReferences).toEqual(
+      expect.arrayContaining(['--bg', '--fg']),
+    );
+  });
+
+  it('preserves nested-rule token references so the parent group receives outer and nested tokens (#6250 reviewer #2)', () => {
+    // PerishCode CHANGES_REQUESTED on PR #6250:
+    //   "preserve nested-rule token references so the parent group receives
+    //    both outer and nested tokens"
+    //
+    // When a rule has BOTH outer declarations AND a nested block, the
+    // resulting parent-group entry must include both the outer-body tokens
+    // AND the nested-block tokens (no silent loss of nested-only tokens).
+    // The minimal failing case: `.btn-parent { color: var(--outer); &:focus { background: var(--inner); } }`.
+    // We use `.btn-parent` so the selector lands in the buttons group, where
+    // we can assert both tokens end up on the same group entry.
+    const manifest = extractComponentsManifest({
+      brandId: 'nested-both',
+      tokensCss: ':root { --outer: red; --inner: blue; }',
+      fixtureHtml: `
+        <style>
+          .btn-parent {
+            color: var(--outer);
+            &:focus {
+              background: var(--inner);
+            }
+          }
+        </style>
+        <button class="btn-parent">x</button>
+      `,
+    });
+
+    expect(manifest.selectors).toEqual(['.btn-parent']);
+    const buttonsGroup = manifest.groups.find((g) => g.id === 'buttons');
+    expect(buttonsGroup?.selectors).toContain('.btn-parent');
+    expect(buttonsGroup?.tokenReferences).toEqual(
+      expect.arrayContaining(['--inner', '--outer']),
+    );
+
+    // Deeper nesting: an `.btn-ancestor` rule wraps two levels of CSS nesting.
+    // All three tokens (--a / --b / --c) must end up on the buttons group,
+    // proving nested-rule token references are preserved at every depth —
+    // not just the first nesting level.
+    const deep = extractComponentsManifest({
+      brandId: 'nested-deep',
+      tokensCss: ':root { --a: red; --b: green; --c: blue; }',
+      fixtureHtml: `
+        <style>
+          .btn-ancestor {
+            color: var(--a);
+            & .descendant {
+              color: var(--b);
+              & .granddesc {
+                background: var(--c);
+              }
+            }
+          }
+        </style>
+        <button class="btn-ancestor">
+          <span class="descendant">
+            <span class="granddesc">x</span>
+          </span>
+        </button>
+      `,
+    });
+    expect(deep.selectors).toContain('.btn-ancestor');
+    const deepButtons = deep.groups.find((g) => g.id === 'buttons');
+    expect(deepButtons?.selectors).toContain('.btn-ancestor');
+    expect(deepButtons?.tokenReferences).toEqual(
+      expect.arrayContaining(['--a', '--b', '--c']),
+    );
+  });
 });

--- a/packages/contracts/tests/components-manifest-6250-anchored-selector-matcher.test.ts
+++ b/packages/contracts/tests/components-manifest-6250-anchored-selector-matcher.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { extractComponentsManifest } from '../src/design-systems/components-manifest.js';
+
+function findGroup(manifest: ReturnType<typeof extractComponentsManifest>, id: string) {
+  return manifest.groups.find((group) => group.id === id);
+}
+
+const FIXTURE = `<!doctype html>
+<html>
+<head>
+<style>
+.navbar-button-thing { color: var(--primary); }
+.button { background: var(--accent); }
+.button-primary { background: var(--accent-2); }
+.btn-secondary { color: var(--text); }
+.btn { padding: var(--pad); }
+</style>
+</head>
+<body>
+<button class="button">Save</button>
+<a class="btn">link</a>
+<a class="cta-banner">cta</a>
+<button class="navbar-button-thing"></button>
+</body>
+</html>`;
+
+describe('navbar-button-thing anchored matcher (#6250 PerishCode round-2 reviewer follow-up)', () => {
+  it('does NOT admit .navbar-button-thing into Buttons.selectors via /\\bbutton\\b/i (hyphen word-boundary leak)', () => {
+    const manifest = extractComponentsManifest({ brandId: 'test', fixtureHtml: FIXTURE });
+    const buttons = findGroup(manifest, 'buttons');
+    expect(buttons).toBeDefined();
+    expect(buttons?.selectors).toEqual(
+      expect.arrayContaining(['.button', '.button-primary', '.btn', '.btn-secondary']),
+    );
+    expect(buttons?.selectors).not.toContain('.navbar-button-thing');
+    // --primary leak is the headline bug PerishCode reproduced: the selector brought its tokenReference across the group boundary.
+    expect(buttons?.tokenReferences).not.toContain('--primary');
+  });
+
+  it('preserves Button classMatchers (button, btn, cta-banner still classified; navbar-button-thing NOT)', () => {
+    const manifest = extractComponentsManifest({ brandId: 'test', fixtureHtml: FIXTURE });
+    const buttons = findGroup(manifest, 'buttons');
+    expect(buttons).toBeDefined();
+    // classMatchers anchor with ^btn|^button|^cta — navbar-button-thing doesn't start with any, so it never enters Buttons.classes.
+    expect(buttons?.classes).toEqual(expect.arrayContaining(['button', 'btn', 'cta-banner']));
+    expect(buttons?.classes).not.toContain('navbar-button-thing');
+  });
+});

--- a/packages/contracts/tests/components-manifest-6250-compound-selector-tokens.test.ts
+++ b/packages/contracts/tests/components-manifest-6250-compound-selector-tokens.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { extractComponentsManifest } from '../src/design-systems/components-manifest.js';
+
+function findGroup(
+  manifest: ReturnType<typeof extractComponentsManifest>,
+  id: string,
+) {
+  return manifest.groups.find((group) => group.id === id);
+}
+
+// PerishCode round-3 review on PR #6250: the previous `^`-anchored full-selector
+// regex (e.g. `/^(?:\.)?button(?:$|[-_:])/i`) silently dropped token attribution
+// for ordinary compound and complex CSS selectors such as `button.primary` and
+// `.dialog > button`. The new `selectorMatchesTokens`/`tokenizeCompound`
+// helpers examine element and class tokens at combinator/compound boundaries
+// instead, so these legitimate selectors keep their token references in the
+// manifest while prefix-sharing names (`navbar-button-thing`) remain excluded.
+//
+// This fixture matrix locks both behaviors in:
+//   - positive selectors stay in their group with the right token reference
+//   - the negative prefix-sharing selector is excluded
+const FIXTURE = `<!doctype html>
+<html>
+<head>
+<style>
+:root { --tone-primary: black; --tone-hover: gray; --tone-form: blue; --tone-leak: red; }
+button.primary { color: var(--tone-primary); }
+button.primary:hover { background: var(--tone-hover); }
+.dialog > button { color: var(--tone-hover); }
+form input { color: var(--tone-form); }
+.navbar-button-thing { color: var(--tone-leak); }
+</style>
+</head>
+<body>
+<button class="primary">Save</button>
+<div class="dialog"><button>OK</button></div>
+<form><input /></form>
+<button class="navbar-button-thing"></button>
+</body>
+</html>`;
+
+describe(
+  'selectorMatchesTokens preserves compound/complex selector attribution (#6250 PerishCode round-3)',
+  () => {
+    const manifest = extractComponentsManifest({ brandId: 'matrix-6250-r3', fixtureHtml: FIXTURE });
+
+    it('admits `button.primary` (compound: element + class)', () => {
+      const buttons = findGroup(manifest, 'buttons');
+      expect(buttons).toBeDefined();
+      expect(buttons?.selectors).toContain('button.primary');
+      expect(buttons?.tokenReferences).toContain('--tone-primary');
+    });
+
+    it('admits `button.primary:hover` (compound + pseudo-class)', () => {
+      const buttons = findGroup(manifest, 'buttons');
+      expect(buttons).toBeDefined();
+      expect(buttons?.selectors).toContain('button.primary:hover');
+      expect(buttons?.tokenReferences).toContain('--tone-hover');
+    });
+
+    it('admits `.dialog > button` (descendant combinator + element)', () => {
+      const buttons = findGroup(manifest, 'buttons');
+      expect(buttons).toBeDefined();
+      expect(buttons?.selectors).toContain('.dialog > button');
+      expect(buttons?.tokenReferences).toContain('--tone-hover');
+    });
+
+    it('admits `form input` (descendant combinator across two compounds)', () => {
+      const inputs = findGroup(manifest, 'inputs');
+      expect(inputs).toBeDefined();
+      expect(inputs?.selectors).toContain('form input');
+      expect(inputs?.tokenReferences).toContain('--tone-form');
+    });
+
+    it('still excludes the prefix-sharing `.navbar-button-thing` selector and its token', () => {
+      const buttons = findGroup(manifest, 'buttons');
+      expect(buttons).toBeDefined();
+      expect(buttons?.selectors).not.toContain('.navbar-button-thing');
+      expect(buttons?.tokenReferences).not.toContain('--tone-leak');
+    });
+  },
+);

--- a/packages/contracts/tests/components-manifest-6250-css-escapes.test.ts
+++ b/packages/contracts/tests/components-manifest-6250-css-escapes.test.ts
@@ -3,76 +3,106 @@ import { describe, expect, it } from 'vitest';
 import { extractComponentsManifest } from '../src/design-systems/components-manifest.js';
 
 describe('CSS escapes in selectors and declaration values (#6250 reviewer #5)', () => {
-  it('treats a single-char escape in a class name as data, not as opener', () => {
-    // PerishCode CHANGES_REQUESTED on PR #6250:
-    //   "Selectors with CSS-escaped identifier characters (\\:, \\/, \\-,
-    //    \\2digit hex form) — escaped identifier characters are interpreted
-    //    as structure."
+  it('treats an escaped structural brace at top level as selector data, not as opener', () => {
+    // PerishCode 7-31 09:10 on PR #6250:
+    //   "Exercise an actual outside-quote escaped brace in this regression
+    //    suite. This fixture currently contains `content: "}"`, so the brace
+    //    is protected by the quote-state logic added in the preceding commit;
+    //    it never reaches the new `char === '\\'` branch. Likewise, the first
+    //    test uses `\:` even though a colon cannot be mistaken for a rule
+    //    opener, so neither test would fail if the outside-quote escape
+    //    handling at `iterateCssRules` lines 389 and 465 were removed. That
+    //    leaves the final commit's structural-delimiter fix unprotected
+    //    despite the test names and comments claiming otherwise. Replace or
+    //    extend these fixtures with the reproduced boundary cases — for
+    //    example `.btn-a\{literal { ... }` followed by a flat rule, and an
+    //    unquoted escaped `\}` in a declaration — and assert both selectors
+    //    and both token references survive."
     //
-    // A CSS class name may legally contain an escaped character such as
-    // `.foo\-bar` (escaped `-`) or `.foo\:bar` (escaped `:`). The escape
-    // backslash is *not* a CSS structural character — it modifies the next
-    // byte so the lexer reads `\-` as a literal `-` inside an identifier
-    // and `\:` as a literal `:`. The opening-brace scan therefore must
-    // skip past the `\` and the following character before deciding
-    // whether the next byte is a `{` opener.
+    // This test reproduces that exact case. Without the outside-quote escape
+    // handling in the opener scan (lines 389-392), `.btn-a\{literal` would
+    // parse as `.btn-a\` (broken selector, then an `{` opener at the literal
+    // brace) + `literal { color: var(--a); }` parsed as a *second* rule whose
+    // selector is `literal`. With the fix, `.btn-a\{literal` is consumed as
+    // one selector (the `\{` escape keeps the `{` as identifier data) and the
+    // opener scan finds the *real* opener that follows `literal `.
     //
-    // Without the fix, `.foo\:bar { color: var(--a); }` is split at the
-    // `{` that immediately follows the selector (which is correct), but
-    // a more pathological shape such as `.foo\{not-a-rule { color:
-    // var(--a); }` (escaped brace in a class name, only valid if the
-    // escape is consumed first) would mis-count the brace.
+    // We pair it with an immediately-following flat rule so a regression that
+    // mistreats the escaped brace as the opener also breaks the second rule's
+    // boundaries (because the bogus rule body would eat the rest of the
+    // input). Asserting both selectors + both `--a`/`--b` token references
+    // survive proves the structural-delimiter handling is intact end-to-end.
     const manifest = extractComponentsManifest({
       brandId: 'css-escape-class',
       tokensCss: ':root { --a: red; --b: blue; }',
       fixtureHtml: `
         <style>
-          .btn-foo\\:bar { color: var(--a); }
-          .btn-plain { color: var(--b); }
+          .btn-a\\{literal { color: var(--a); }
+          .btn-b { color: var(--b); }
         </style>
-        <button class="btn-foo:bar btn-plain">x</button>
+        <button class="btn-a{literal btn-b">x</button>
       `,
     });
 
     expect(manifest.selectors).toEqual(
-      expect.arrayContaining(['.btn-foo\\:bar', '.btn-plain']),
+      expect.arrayContaining(['.btn-a\\{literal', '.btn-b']),
     );
     const buttonsGroup = manifest.groups.find((g) => g.id === 'buttons');
     expect(buttonsGroup).toBeDefined();
     expect(buttonsGroup?.selectors).toEqual(
-      expect.arrayContaining(['.btn-foo\\:bar', '.btn-plain']),
+      expect.arrayContaining(['.btn-a\\{literal', '.btn-b']),
     );
     expect(buttonsGroup?.tokenReferences).toEqual(
       expect.arrayContaining(['--a', '--b']),
     );
   });
 
-  it('treats an escaped closing brace in a declaration value as data', () => {
-    // Mirror case for the body scanner: a declaration value may contain a
-    // CSS escape such as `content: "\\}";` where the escaped `}` is the
-    // data, not the rule terminator. The body depth counter must not
-    // decrement on the escaped brace.
+  it('treats an unquoted escaped closing brace in a declaration as data', () => {
+    // PerishCode 7-31 09:10: "an unquoted escaped `\}` in a declaration —
+    // and assert both selectors and both token references survive."
+    //
+    // A CSS declaration value may legally contain an escaped `}` outside
+    // quotes — e.g. `content: \};` (the `\}` is data, not the rule
+    // terminator). Without the outside-quote escape handling in the body
+    // scan (lines 465-468), the parser would treat `\}` as an escape pair
+    // *and* then immediately after, the unescaped `}` that follows would
+    // close the rule — which is correct in this trivial case but breaks
+    // when there's more content after. The interesting boundary is when
+    // the escaped `}` is followed by additional declarations before the
+    // real terminator. Here we assert that `color: var(--a)` after the
+    // escaped `}` is still recorded, and that the second flat rule's
+    // `.btn-plain` selector + `--b` reference both survive.
+    //
+    // Using `attr(data-after, "\\}")` keeps the escape outside any quoted
+    // string — the inner `"\\}"` is purely part of the attr() expression
+    // payload *after* CSS-tokenization, so the opt-in is the literal `\}`
+    // (without surrounding CSS quotes) at the CSS-rule level. To make the
+    // outside-quote guarantee unambiguous, we use `content: "\\}"` *without*
+    // surrounding CSS quotes — i.e. write it as a raw identifier escape,
+    // not a string. That's the only form that actually exercises the
+    // outside-quote escape branch in the body scanner; the previous fixture
+    // (`content: "}"`) was inside a CSS string so the quote-state branch
+    // caught it instead.
     const manifest = extractComponentsManifest({
       brandId: 'css-escape-decl-value',
       tokensCss: ':root { --a: red; --b: blue; }',
       fixtureHtml: `
         <style>
-          .btn-escape::after { content: "}"; color: var(--a); }
+          .btn-escape::after { content: \\}; color: var(--a); }
           .btn-plain { color: var(--b); }
         </style>
         <button class="btn-escape btn-plain">x</button>
       `,
     });
 
-    // The selector with the escape survives intact in the opener scan…
     expect(manifest.selectors).toEqual(
       expect.arrayContaining(['.btn-escape::after', '.btn-plain']),
     );
-    // …and both tokens are recorded because the body loop correctly
-    // identifies the rule boundary at the unescaped `}` that follows
-    // `var(--a);`.
     const buttonsGroup = manifest.groups.find((g) => g.id === 'buttons');
     expect(buttonsGroup).toBeDefined();
+    expect(buttonsGroup?.selectors).toEqual(
+      expect.arrayContaining(['.btn-escape::after', '.btn-plain']),
+    );
     expect(buttonsGroup?.tokenReferences).toEqual(
       expect.arrayContaining(['--a', '--b']),
     );

--- a/packages/contracts/tests/components-manifest-6250-css-escapes.test.ts
+++ b/packages/contracts/tests/components-manifest-6250-css-escapes.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractComponentsManifest } from '../src/design-systems/components-manifest.js';
+
+describe('CSS escapes in selectors and declaration values (#6250 reviewer #5)', () => {
+  it('treats a single-char escape in a class name as data, not as opener', () => {
+    // PerishCode CHANGES_REQUESTED on PR #6250:
+    //   "Selectors with CSS-escaped identifier characters (\\:, \\/, \\-,
+    //    \\2digit hex form) — escaped identifier characters are interpreted
+    //    as structure."
+    //
+    // A CSS class name may legally contain an escaped character such as
+    // `.foo\-bar` (escaped `-`) or `.foo\:bar` (escaped `:`). The escape
+    // backslash is *not* a CSS structural character — it modifies the next
+    // byte so the lexer reads `\-` as a literal `-` inside an identifier
+    // and `\:` as a literal `:`. The opening-brace scan therefore must
+    // skip past the `\` and the following character before deciding
+    // whether the next byte is a `{` opener.
+    //
+    // Without the fix, `.foo\:bar { color: var(--a); }` is split at the
+    // `{` that immediately follows the selector (which is correct), but
+    // a more pathological shape such as `.foo\{not-a-rule { color:
+    // var(--a); }` (escaped brace in a class name, only valid if the
+    // escape is consumed first) would mis-count the brace.
+    const manifest = extractComponentsManifest({
+      brandId: 'css-escape-class',
+      tokensCss: ':root { --a: red; --b: blue; }',
+      fixtureHtml: `
+        <style>
+          .btn-foo\\:bar { color: var(--a); }
+          .btn-plain { color: var(--b); }
+        </style>
+        <button class="btn-foo:bar btn-plain">x</button>
+      `,
+    });
+
+    expect(manifest.selectors).toEqual(
+      expect.arrayContaining(['.btn-foo\\:bar', '.btn-plain']),
+    );
+    const buttonsGroup = manifest.groups.find((g) => g.id === 'buttons');
+    expect(buttonsGroup).toBeDefined();
+    expect(buttonsGroup?.selectors).toEqual(
+      expect.arrayContaining(['.btn-foo\\:bar', '.btn-plain']),
+    );
+    expect(buttonsGroup?.tokenReferences).toEqual(
+      expect.arrayContaining(['--a', '--b']),
+    );
+  });
+
+  it('treats an escaped closing brace in a declaration value as data', () => {
+    // Mirror case for the body scanner: a declaration value may contain a
+    // CSS escape such as `content: "\\}";` where the escaped `}` is the
+    // data, not the rule terminator. The body depth counter must not
+    // decrement on the escaped brace.
+    const manifest = extractComponentsManifest({
+      brandId: 'css-escape-decl-value',
+      tokensCss: ':root { --a: red; --b: blue; }',
+      fixtureHtml: `
+        <style>
+          .btn-escape::after { content: "}"; color: var(--a); }
+          .btn-plain { color: var(--b); }
+        </style>
+        <button class="btn-escape btn-plain">x</button>
+      `,
+    });
+
+    // The selector with the escape survives intact in the opener scan…
+    expect(manifest.selectors).toEqual(
+      expect.arrayContaining(['.btn-escape::after', '.btn-plain']),
+    );
+    // …and both tokens are recorded because the body loop correctly
+    // identifies the rule boundary at the unescaped `}` that follows
+    // `var(--a);`.
+    const buttonsGroup = manifest.groups.find((g) => g.id === 'buttons');
+    expect(buttonsGroup).toBeDefined();
+    expect(buttonsGroup?.tokenReferences).toEqual(
+      expect.arrayContaining(['--a', '--b']),
+    );
+  });
+});

--- a/packages/contracts/tests/components-manifest-6250-functional-pseudo-classes.test.ts
+++ b/packages/contracts/tests/components-manifest-6250-functional-pseudo-classes.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { extractComponentsManifest } from '../src/design-systems/components-manifest.js';
+
+function findGroup(
+  manifest: ReturnType<typeof extractComponentsManifest>,
+  id: string,
+) {
+  return manifest.groups.find((group) => group.id === id);
+}
+
+// PerishCode round-4 review on PR #6250: the tokenizer's pseudo-class skip
+// regex consumed the entire text of `:is(...)` and `:where(...)` as opaque
+// skip text, so component tokens inside those argument lists — e.g. `button`
+// in `:where(button)`, `.btn` in `:is(.btn)` — never reached the
+// `elementMatchers` / `classMatchers` for the Buttons group. As a result
+// `:where(button) { color: var(--tone) }` produced a manifest selector with NO
+// token attribution for `--tone`, a backward-compatibility regression
+// introduced by the round-3 token-level matcher.
+//
+// `:is` and `:where` are component-preserving (their argument list is a
+// forgiving selector list — selectors inside still name components). The
+// tokenizer now recursively splits the inner selector-list by commas and
+// tokenizes each argument as its own compound, unioning element/class tokens
+// back into the outer compound. `:not(...)`, `:has(...)`, `:nth-child(...)`,
+// and other functional pseudo-classes remain opaque skips — they hide their
+// arguments by design.
+const FIXTURE = `<!doctype html>
+<html>
+<head>
+<style>
+:root { --tone-where-element: black; --tone-where-class: red; --tone-is-element: green; --tone-is-class: blue; --tone-where-multi: orange; --tone-not-stays-opaque: gray; --tone-prefix-leak: purple; }
+:where(button) { color: var(--tone-where-element); }
+:is(.btn) { background: var(--tone-where-class); }
+:is(button.primary) { color: var(--tone-is-element); }
+:where(.btn-cta) { background: var(--tone-is-class); }
+:where(button, label) { color: var(--tone-where-multi); }
+button:not(.btn) { color: var(--tone-not-stays-opaque); }
+.navbar-button-thing { color: var(--tone-prefix-leak); }
+</style>
+</head>
+<body>
+<button>Save</button>
+<button class="primary">OK</button>
+<button class="btn">CTA</button>
+<button class="btn-cta">CTA2</button>
+<label>Field</label>
+<button class="navbar-button-thing"></button>
+</body>
+</html>`;
+
+describe(
+  'selectorMatchesTokens preserves component tokens inside :is() and :where() (#6250 PerishCode round-4)',
+  () => {
+    const manifest = extractComponentsManifest({
+      brandId: 'matrix-6250-r4',
+      fixtureHtml: FIXTURE,
+    });
+
+    it('admits `:where(button)` and carries its --tone attribution', () => {
+      const buttons = findGroup(manifest, 'buttons');
+      expect(buttons).toBeDefined();
+      expect(buttons?.selectors).toContain(':where(button)');
+      expect(buttons?.tokenReferences).toContain('--tone-where-element');
+    });
+
+    it('admits `:is(.btn)` (functional + class) and carries its --tone attribution', () => {
+      const buttons = findGroup(manifest, 'buttons');
+      expect(buttons).toBeDefined();
+      expect(buttons?.selectors).toContain(':is(.btn)');
+      expect(buttons?.tokenReferences).toContain('--tone-where-class');
+    });
+
+    it('admits `:is(button.primary)` (functional compound: element + class preserved)', () => {
+      const buttons = findGroup(manifest, 'buttons');
+      expect(buttons).toBeDefined();
+      expect(buttons?.selectors).toContain(':is(button.primary)');
+      expect(buttons?.tokenReferences).toContain('--tone-is-element');
+    });
+
+    it('admits `:where(.btn-cta)` (functional class argument)', () => {
+      const buttons = findGroup(manifest, 'buttons');
+      expect(buttons).toBeDefined();
+      expect(buttons?.selectors).toContain(':where(.btn-cta)');
+      expect(buttons?.tokenReferences).toContain('--tone-is-class');
+    });
+
+    it('admits `:where(button, label)` — both selector-list arguments visible', () => {
+      const buttons = findGroup(manifest, 'buttons');
+      expect(buttons).toBeDefined();
+      expect(buttons?.selectors).toContain(':where(button, label)');
+      expect(buttons?.tokenReferences).toContain('--tone-where-multi');
+      // inputs group should also see the `label` element via inputs.elementMatchers
+      const inputs = findGroup(manifest, 'inputs');
+      expect(inputs?.selectors).toContain(':where(button, label)');
+    });
+
+    it('keeps `:not(...)` opaque — its argument should NOT independently contribute tokens', () => {
+      const buttons = findGroup(manifest, 'buttons');
+      expect(buttons).toBeDefined();
+      // `button:not(.btn)` is admitted via the outer `button` element matcher,
+      // so the selector IS in the Buttons group via the outer element token,
+      // and the surrounding `--tone-not-stays-opaque` flows through.
+      expect(buttons?.selectors).toContain('button:not(.btn)');
+      expect(buttons?.tokenReferences).toContain('--tone-not-stays-opaque');
+      // `.btn` inside `:not(...)` must NOT be tokenized as a class member of
+      // this selector — `:not()` is opaque by design. The `btn` entry that
+      // DOES show up in `Buttons.classes` here comes from the HTML element
+      // `<button class="btn">` (extractHtmlClasses), not from the `:not()`
+      // argument, so it is unrelated to this selector's tokenization.
+      // Sanity: `.btn-cta` from `:where(.btn-cta)` DOES leak into Buttons.classes
+      // because `:where()` is component-preserving.
+      // (No assertion on Buttons.classes here — this test focuses on the
+      // selector-level attribution; the HTML classes live independently.)
+    });
+
+    it('still excludes the prefix-sharing `.navbar-button-thing` selector and its token', () => {
+      const buttons = findGroup(manifest, 'buttons');
+      expect(buttons).toBeDefined();
+      expect(buttons?.selectors).not.toContain('.navbar-button-thing');
+      expect(buttons?.tokenReferences).not.toContain('--tone-prefix-leak');
+    });
+  },
+);

--- a/packages/contracts/tests/components-manifest-6250-not-and-attribute-opacity.test.ts
+++ b/packages/contracts/tests/components-manifest-6250-not-and-attribute-opacity.test.ts
@@ -15,10 +15,10 @@ function findGroup(
 //
 // With the round-3/round-4 implementation, the regex `selectorMatchers` family
 // still ran against the raw selector before tokenizeCompound, so:
-//   - `:not(.btn) { color: var(--tone) }` matched `/\.btn(?:$|[-_:])/i` and
+//   - `:not(.btn) { color: var(--tone) }` matched `/.btn(?:$|[-_:])/i` and
 //     admitted this into Buttons.selectors / Buttons.tokenReferences even
 //     though `:not(.btn)` selects *non*-button elements.
-//   - `[data-label=".card"] { color: var(--tone) }` matched `/\.card(?:$|[-_:])/i`
+//   - `[data-label=".card"] { color: var(--tone) }` matched `/.card(?:$|[-_:])/i`
 //     inside the attribute value and admitted this into Cards even though the
 //     selector targets an element whose `[data-label]` happens to mention a
 //     card name.
@@ -28,6 +28,24 @@ function findGroup(
 // predicates like `[type=button]` / `[aria-hidden="true"]` / `[role=checkbox]`)
 // run against the raw selector; element + class matching happens strictly on
 // parsed tokens via tokenizeCompound (which itself keeps `:not()` *opaque*).
+//
+// Round-6 fixture matrix (PerishCode round-6 blocker):
+// attribute predicates themselves must run on PARSED attribute-selector
+// tokens, NOT on the raw compound string. Same opacity rule that round-5
+// applied to class matchers now applies to attribute matchers:
+//   - `:not([type=submit]) { color: var(--tone) }` must NOT admit to Buttons
+//     even though `[type=submit]` text appears in the raw selector — the
+//     predicate sits inside `:not()` which is component-erasing.
+//   - `[data-label="[type=submit]"] { color: var(--tone) }` must NOT admit to
+//     Buttons even though the attribute VALUE spells `[type=submit]` — it is
+//     a data-label value, not a type attribute. The matcher regex should
+//     run against the outer attribute token `[data-label="[type=submit]"]`,
+//     not the inner quoted bracket.
+//   - `:not([aria-hidden="true"]) { color: var(--tone) }` must NOT admit to
+//     Icons (same logic as the buttons :not case).
+// Positive controls `[type=submit]` and `[aria-hidden="true"]` continue to
+// admit selectors to Buttons / Icons respectively so the matcher pipeline
+// can still see genuine attribute predicates.
 
 describe('#6250 round-5 — :not() and attribute-value opacity', () => {
   const html = `
@@ -36,6 +54,9 @@ describe('#6250 round-5 — :not() and attribute-value opacity', () => {
   [data-label=".card"] { color: var(--tone-card) }
   [type="submit"] { color: var(--tone-button-attr) }
   [aria-hidden="true"] { color: var(--tone-icon) }
+  :not([type="submit"]) { color: var(--tone-button-not-attr) }
+  :not([aria-hidden="true"]) { color: var(--tone-icon-not-attr) }
+  [data-label="[type=submit]"] { color: var(--tone-button-attr-leak) }
 </style>
 <button>real button</button>
 `;
@@ -55,7 +76,7 @@ describe('#6250 round-5 — :not() and attribute-value opacity', () => {
   it(':not(.btn) does not contribute Buttons.tokenReferences either', () => {
     const buttons = findGroup(manifest, 'buttons');
     expect(buttons).toBeDefined();
-    expect(buttons!.tokenReferences.some((r) => r === 'tone-button')).toBe(false);
+    expect(buttons!.tokenReferences.some((r) => r === 'tone-button' || r === '--tone-button')).toBe(false);
   });
 
   it('[data-label=".card"] is NOT admitted to Cards.selectors', () => {
@@ -68,7 +89,7 @@ describe('#6250 round-5 — :not() and attribute-value opacity', () => {
   it('[data-label=".card"] does not contribute Cards.tokenReferences either', () => {
     const cards = findGroup(manifest, 'cards');
     expect(cards).toBeDefined();
-    expect(cards!.tokenReferences.some((r) => r === 'tone-card')).toBe(false);
+    expect(cards!.tokenReferences.some((r) => r === 'tone-card' || r === '--tone-card')).toBe(false);
   });
 
   it('[type="submit"] IS still admitted to Buttons via attributeMatchers', () => {
@@ -81,5 +102,40 @@ describe('#6250 round-5 — :not() and attribute-value opacity', () => {
     const icons = findGroup(manifest, 'icons');
     expect(icons).toBeDefined();
     expect(icons!.selectors.some((s) => s.includes('[aria-hidden="true"]'))).toBe(true);
+  });
+
+  // ----- Round-6: attribute predicate opacity (PerishCode round-6 blocker) -----
+
+  it(':not([type="submit"]) is NOT admitted to Buttons — :not() erases attribute too', () => {
+    const buttons = findGroup(manifest, 'buttons');
+    expect(buttons).toBeDefined();
+    expect(buttons!.selectors.some((s) => s.includes(':not([type="submit"])'))).toBe(false);
+    expect(buttons!.tokenReferences.some((r) => r === 'tone-button-not-attr' || r === '--tone-button-not-attr')).toBe(false);
+  });
+
+  it(':not([aria-hidden="true"]) is NOT admitted to Icons — :not() erases attribute too', () => {
+    const icons = findGroup(manifest, 'icons');
+    expect(icons).toBeDefined();
+    expect(icons!.selectors.some((s) => s.includes(':not([aria-hidden="true"])'))).toBe(false);
+    expect(icons!.tokenReferences.some((r) => r === 'tone-icon-not-attr' || r === '--tone-icon-not-attr')).toBe(false);
+  });
+
+  it('[data-label="[type=submit]"] is NOT admitted to Buttons — value text is not a real predicate', () => {
+    const buttons = findGroup(manifest, 'buttons');
+    expect(buttons).toBeDefined();
+    expect(buttons!.selectors.some((s) => s.includes('[data-label="[type=submit]"]'))).toBe(false);
+    expect(buttons!.tokenReferences.some((r) => r === 'tone-button-attr-leak' || r === '--tone-button-attr-leak')).toBe(false);
+  });
+
+  it('positive control: [type="submit"] still contributes Buttons.tokenReferences', () => {
+    const buttons = findGroup(manifest, 'buttons');
+    expect(buttons).toBeDefined();
+    expect(buttons!.tokenReferences.some((r) => r === '--tone-button-attr')).toBe(true);
+  });
+
+  it('positive control: [aria-hidden="true"] still contributes Icons.tokenReferences', () => {
+    const icons = findGroup(manifest, 'icons');
+    expect(icons).toBeDefined();
+    expect(icons!.tokenReferences.some((r) => r === '--tone-icon')).toBe(true);
   });
 });

--- a/packages/contracts/tests/components-manifest-6250-not-and-attribute-opacity.test.ts
+++ b/packages/contracts/tests/components-manifest-6250-not-and-attribute-opacity.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { extractComponentsManifest } from '../src/design-systems/components-manifest.js';
+
+function findGroup(
+  manifest: ReturnType<typeof extractComponentsManifest>,
+  id: string,
+) {
+  return manifest.groups.find((g) => g.id === id);
+}
+
+// Round-5 fixture matrix for `selectorMatchesTokens` (PR #6250 follow-up):
+// `:not(.btn)` and `[data-label=".card"]` must NOT cross-attribute tokens to
+// the buttons / cards groups even though the raw selector text contains
+// component-name substrings (`PerishCode round-5 blocker`).
+//
+// With the round-3/round-4 implementation, the regex `selectorMatchers` family
+// still ran against the raw selector before tokenizeCompound, so:
+//   - `:not(.btn) { color: var(--tone) }` matched `/\.btn(?:$|[-_:])/i` and
+//     admitted this into Buttons.selectors / Buttons.tokenReferences even
+//     though `:not(.btn)` selects *non*-button elements.
+//   - `[data-label=".card"] { color: var(--tone) }` matched `/\.card(?:$|[-_:])/i`
+//     inside the attribute value and admitted this into Cards even though the
+//     selector targets an element whose `[data-label]` happens to mention a
+//     card name.
+//
+// Round-5 fix: `selectorMatchesTokens` no longer consults the class/word
+// `selectorMatchers` family; only `attributeMatchers` (genuine attribute
+// predicates like `[type=button]` / `[aria-hidden="true"]` / `[role=checkbox]`)
+// run against the raw selector; element + class matching happens strictly on
+// parsed tokens via tokenizeCompound (which itself keeps `:not()` *opaque*).
+
+describe('#6250 round-5 — :not() and attribute-value opacity', () => {
+  const html = `
+<style>
+  :not(.btn) { color: var(--tone-button) }
+  [data-label=".card"] { color: var(--tone-card) }
+  [type="submit"] { color: var(--tone-button-attr) }
+  [aria-hidden="true"] { color: var(--tone-icon) }
+</style>
+<button>real button</button>
+`;
+
+  const manifest = extractComponentsManifest({
+    brandId: 'test-brand',
+    fixtureHtml: html,
+  });
+
+  it(':not(.btn) is NOT admitted to Buttons.selectors — :not() is opaque', () => {
+    const buttons = findGroup(manifest, 'buttons');
+    expect(buttons).toBeDefined();
+    const has = buttons!.selectors.some((s) => s.includes(':not(.btn)'));
+    expect(has).toBe(false);
+  });
+
+  it(':not(.btn) does not contribute Buttons.tokenReferences either', () => {
+    const buttons = findGroup(manifest, 'buttons');
+    expect(buttons).toBeDefined();
+    expect(buttons!.tokenReferences.some((r) => r === 'tone-button')).toBe(false);
+  });
+
+  it('[data-label=".card"] is NOT admitted to Cards.selectors', () => {
+    const cards = findGroup(manifest, 'cards');
+    expect(cards).toBeDefined();
+    const has = cards!.selectors.some((s) => s.includes('[data-label'));
+    expect(has).toBe(false);
+  });
+
+  it('[data-label=".card"] does not contribute Cards.tokenReferences either', () => {
+    const cards = findGroup(manifest, 'cards');
+    expect(cards).toBeDefined();
+    expect(cards!.tokenReferences.some((r) => r === 'tone-card')).toBe(false);
+  });
+
+  it('[type="submit"] IS still admitted to Buttons via attributeMatchers', () => {
+    const buttons = findGroup(manifest, 'buttons');
+    expect(buttons).toBeDefined();
+    expect(buttons!.selectors.some((s) => s.includes('[type="submit"]'))).toBe(true);
+  });
+
+  it('[aria-hidden="true"] IS still admitted to Icons via attributeMatchers', () => {
+    const icons = findGroup(manifest, 'icons');
+    expect(icons).toBeDefined();
+    expect(icons!.selectors.some((s) => s.includes('[aria-hidden="true"]'))).toBe(true);
+  });
+});

--- a/packages/contracts/tests/components-manifest-6250-not-and-attribute-opacity.test.ts
+++ b/packages/contracts/tests/components-manifest-6250-not-and-attribute-opacity.test.ts
@@ -57,8 +57,12 @@ describe('#6250 round-5 — :not() and attribute-value opacity', () => {
   :not([type="submit"]) { color: var(--tone-button-not-attr) }
   :not([aria-hidden="true"]) { color: var(--tone-icon-not-attr) }
   [data-label="[type=submit]"] { color: var(--tone-button-attr-leak) }
+  [role="checkbox"] { color: var(--tone-input-role-attr) }
+  :not([role="checkbox"]) { color: var(--tone-input-role-not-attr) }
+  [data-label="[role=checkbox]"] { color: var(--tone-input-role-attr-leak) }
 </style>
 <button>real button</button>
+<input type="checkbox" />
 `;
 
   const manifest = extractComponentsManifest({
@@ -137,5 +141,28 @@ describe('#6250 round-5 — :not() and attribute-value opacity', () => {
     const icons = findGroup(manifest, 'icons');
     expect(icons).toBeDefined();
     expect(icons!.tokenReferences.some((r) => r === '--tone-icon')).toBe(true);
+  });
+
+  // ----- Round-7: Inputs role attribute predicate opacity (PerishCode round-7 blocker) -----
+
+  it(':not([role="checkbox"]) is NOT admitted to Inputs — :not() erases attribute too', () => {
+    const inputs = findGroup(manifest, 'inputs');
+    expect(inputs).toBeDefined();
+    expect(inputs!.selectors.some((s) => s.includes(':not([role="checkbox"])'))).toBe(false);
+    expect(inputs!.tokenReferences.some((r) => r === 'tone-input-role-not-attr' || r === '--tone-input-role-not-attr')).toBe(false);
+  });
+
+  it('[data-label="[role=checkbox]"] is NOT admitted to Inputs — value text is not a real predicate', () => {
+    const inputs = findGroup(manifest, 'inputs');
+    expect(inputs).toBeDefined();
+    expect(inputs!.selectors.some((s) => s.includes('[data-label="[role=checkbox]"]'))).toBe(false);
+    expect(inputs!.tokenReferences.some((r) => r === 'tone-input-role-attr-leak' || r === '--tone-input-role-attr-leak')).toBe(false);
+  });
+
+  it('positive control: [role="checkbox"] still admits to Inputs and contributes tokenReferences', () => {
+    const inputs = findGroup(manifest, 'inputs');
+    expect(inputs).toBeDefined();
+    expect(inputs!.selectors.some((s) => s.includes('[role="checkbox"]'))).toBe(true);
+    expect(inputs!.tokenReferences.some((r) => r === '--tone-input-role-attr')).toBe(true);
   });
 });

--- a/packages/contracts/tests/components-manifest-6250-quoted-selector.test.ts
+++ b/packages/contracts/tests/components-manifest-6250-quoted-selector.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractComponentsManifest } from '../src/design-systems/components-manifest.js';
+
+describe('quoted braces in selectors (#6250 reviewer #4)', () => {
+  it('treats braces inside quoted attribute selectors as data, not rule openers', () => {
+    // PerishCode CHANGES_REQUESTED on PR #6250:
+    //   "Make the opening-brace search quote-aware too. The new quote state
+    //    begins only after `css.indexOf('{', index)` has already selected an
+    //    opener, so a valid selector such as `.btn-a[data-icon="{"] { color:
+    //    var(--a); }` treats the brace inside the attribute value as the rule
+    //    boundary. ... manifest.selectors is `[]`, and the Buttons group has
+    //    no selectors or token references ..."
+    //
+    // The fix: scan for the opening delimiter with the same single-quote,
+    // double-quote, and escape state used for the closing delimiter. A
+    // `{` / `}` that appears inside a quoted attribute selector (or any
+    // other quoted selector context) must not terminate the selector scan.
+    const manifest = extractComponentsManifest({
+      brandId: 'quoted-selector-brace',
+      tokensCss: ':root { --a: red; --b: blue; }',
+      fixtureHtml: `
+        <style>
+          .btn-a[data-icon="{"] { color: var(--a); }
+          .btn-b { color: var(--b); }
+        </style>
+        <button class="btn-a btn-b">x</button>
+      `,
+    });
+
+    expect(manifest.selectors).toEqual(
+      expect.arrayContaining(['.btn-a[data-icon="{"]', '.btn-b']),
+    );
+    const buttonsGroup = manifest.groups.find((g) => g.id === 'buttons');
+    expect(buttonsGroup?.selectors).toEqual(
+      expect.arrayContaining(['.btn-a[data-icon="{"]', '.btn-b']),
+    );
+    expect(buttonsGroup?.tokenReferences).toEqual(
+      expect.arrayContaining(['--a', '--b']),
+    );
+  });
+
+  it('treats braces inside single-quoted attribute selectors as data', () => {
+    // Same shape, single-quoted variant. Selector `.btn-a[data-icon='{']`
+    // must NOT be split at the `{` inside the attribute.
+    const manifest = extractComponentsManifest({
+      brandId: 'quoted-selector-brace-single',
+      tokensCss: ':root { --a: red; --b: blue; }',
+      fixtureHtml: `
+        <style>
+          .btn-a[data-icon='{'] { color: var(--a); }
+          .btn-b { color: var(--b); }
+        </style>
+        <button class="btn-a btn-b">x</button>
+      `,
+    });
+
+    // The selector is preserved verbatim — single quotes stay single,
+    // double quotes stay double. We assert the single-quoted form here.
+    expect(manifest.selectors).toEqual(
+      expect.arrayContaining([".btn-a[data-icon='{']", '.btn-b']),
+    );
+    const buttonsGroup = manifest.groups.find((g) => g.id === 'buttons');
+    expect(buttonsGroup?.selectors).toEqual(
+      expect.arrayContaining([".btn-a[data-icon='{']", '.btn-b']),
+    );
+    expect(buttonsGroup?.tokenReferences).toEqual(
+      expect.arrayContaining(['--a', '--b']),
+    );
+  });
+});

--- a/packages/contracts/tests/components-manifest-6250-round8.test.ts
+++ b/packages/contracts/tests/components-manifest-6250-round8.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractComponentsManifest } from '../src/design-systems/components-manifest.js';
+
+describe('@supports with quoted braces in selector (#6250 round-8 blocker)', () => {
+  it('survives quoted braces inside @supports selector() wrapper plus trailing rule', () => {
+    // PerishCode CHANGES_REQUESTED on PR #6250 (2026-08-03 23:53):
+    //   "Make the supported-at-rule header rewrite use the same lexical
+    //    rules as this quote-aware scan. Both extractor paths call
+    //    `stripContainerAtRuleHeaders` before reaching `iterateCssRules`,
+    //    and that helper still uses `@(media|supports|container|layer)\b[^{]*\{`;
+    //    therefore a valid wrapper such as
+    //    `@supports selector(.btn-a[data-icon=\"{\"]) { .btn-a { color: var(--a) } }`
+    //    is truncated at the quoted brace before this scanner can protect it.
+    //    I reproduced this through `extractComponentsManifest` with a
+    //    following `.btn-b` rule: `manifest.selectors` and the Buttons group's
+    //    `tokenReferences` are both empty, so the supported at-rule also erases
+    //    the subsequent flat rule."
+    //
+    // Round-8 fix: drop the stripContainerAtRuleHeaders pre-pass and let
+    // iterateCssRules recurse through supported at-rules directly. The
+    // wrapper header must survive intact, its body must be recursed, and
+    // both the inner .btn-a selector and the trailing .btn-b selector (plus
+    // its token reference) must surface.
+    const manifest = extractComponentsManifest({
+      brandId: 'supports-quoted-brace',
+      tokensCss: ':root { --a: red; --b: blue; }',
+      fixtureHtml: `
+        <style>
+          @supports selector(.btn-a[data-icon="{"]) {
+            .btn-a[data-icon="{"] { color: var(--a); }
+          }
+          .btn-b { color: var(--b); }
+        </style>
+        <button class="btn-a btn-b">x</button>
+      `,
+    });
+
+    expect(manifest.selectors).toEqual(
+      expect.arrayContaining(['.btn-a[data-icon="{"]', '.btn-b']),
+    );
+    const buttonsGroup = manifest.groups.find((g) => g.id === 'buttons');
+    expect(buttonsGroup?.selectors).toEqual(
+      expect.arrayContaining(['.btn-a[data-icon="{"]', '.btn-b']),
+    );
+    expect(buttonsGroup?.tokenReferences).toEqual(
+      expect.arrayContaining(['--a', '--b']),
+    );
+  });
+
+  it('preserves trailing flat rules after a supported at-rule with quoted braces', () => {
+    // Regression: before round-8, the non-quote-aware pre-pass truncated
+    // at the quoted brace inside the @supports header, swallowing the
+    // inner .btn-a rule AND the trailing .btn-b rule. Round-8 must not
+    // lose either selector or the trailing rule's token reference.
+    const manifest = extractComponentsManifest({
+      brandId: 'supports-quoted-brace-trailing',
+      tokensCss: ':root { --a: red; --b: blue; --c: green; }',
+      fixtureHtml: `
+        <style>
+          @supports selector(.btn-a[data-icon="{"]) {
+            .btn-a[data-icon="{"] { color: var(--a); }
+          }
+          .btn-b { color: var(--b); }
+          .btn-c { color: var(--c); }
+        </style>
+        <button class="btn-a btn-b btn-c">x</button>
+      `,
+    });
+
+    expect(manifest.selectors).toEqual(
+      expect.arrayContaining(['.btn-a[data-icon="{"]', '.btn-b', '.btn-c']),
+    );
+    const buttonsGroup = manifest.groups.find((g) => g.id === 'buttons');
+    expect(buttonsGroup?.selectors).toEqual(
+      expect.arrayContaining(['.btn-a[data-icon="{"]', '.btn-b', '.btn-c']),
+    );
+    expect(buttonsGroup?.tokenReferences).toEqual(
+      expect.arrayContaining(['--a', '--b', '--c']),
+    );
+  });
+});

--- a/packages/contracts/tests/components-manifest-6250-round8.test.ts
+++ b/packages/contracts/tests/components-manifest-6250-round8.test.ts
@@ -79,4 +79,35 @@ describe('@supports with quoted braces in selector (#6250 round-8 blocker)', () 
       expect.arrayContaining(['--a', '--b', '--c']),
     );
   });
+
+  it('does not lose the first ordinary rule after a top-level @import', () => {
+    // PerishCode round-9 blocker (lefarcen 2026-08-04 02:51):
+    // top-level @import at-rules cause the scanner to fold the
+    // first following rule's selector into the @import prelude,
+    // so the first ordinary selector disappears while the later
+    // one survives. Round-9 fix: skip @import rules entirely.
+    const manifest = extractComponentsManifest({
+      brandId: 'import-selector-loss',
+      tokensCss: ':root { --a: red; --b: blue; }',
+      fixtureHtml: `
+        <style>
+          @import url('https://fonts.googleapis.com/css2?family=Roboto');
+          .btn-a { color: var(--a); }
+          .btn-b { color: var(--b); }
+        </style>
+        <button class="btn-a btn-b">x</button>
+      `,
+    });
+
+    expect(manifest.selectors).toEqual(
+      expect.arrayContaining(['.btn-a', '.btn-b']),
+    );
+    const buttonsGroup = manifest.groups.find((g) => g.id === 'buttons');
+    expect(buttonsGroup?.selectors).toEqual(
+      expect.arrayContaining(['.btn-a', '.btn-b']),
+    );
+    expect(buttonsGroup?.tokenReferences).toEqual(
+      expect.arrayContaining(['--a', '--b']),
+    );
+  });
 });


### PR DESCRIPTION
Closes #6224.

## Why

`extractComponentsManifest` had three correctness gaps in its CSS rule extractor:

1. **Flat consecutive rules were silently dropped.** The legacy regex `(?:^|[{}])\s*([^@{}][^{}]*?)\s*\{([^{}]*)\}` consumed each rule's closing `}` as the next rule's `[{}]` anchor, so every other flat rule in a sheet vanished from `manifest.selectors` and from every group's `selectors` / `tokenReferences`.
2. **CSS nesting tokens leaked.** `[^{}]*` body regex could not match nested blocks at all, so `&:hover { background: var(--x) }` tokens were mis-attributed to declaration text as a pseudo-selector rather than to the parent.
3. **Prefix-sharing classnames cross-group.** `/button/i` substring matching swept `.nav-btn`, `.navbar-button-thing`, `.mystatus`, `.platform-form` into the wrong component groups.

## What users will see

- The Design Systems component manifest accurately reports every selector in a flat CSS sheet — no more silent dropping of every other rule.
- Tailwind v4 / native CSS nesting (`&:hover`, `& .child { & .grand { ... } }`) attribute every `var(--token)` reference — at any nesting depth — to the outermost parent selector that owns it, instead of fabricating fake selectors from declaration text.
- Class matchers (`buttons`, `inputs`, `badges`, `keyboard`, `layout`) only match anchored classnames (`^name(?:$|-)`), so prefix-sharing classnames stay in their real group.
- Braces inside quoted CSS values (`content: "}"`) and inside quoted attribute selectors (`.btn-a[data-icon="{"]`) are parsed as data, not as rule delimiters — valid stylesheets with quoted braces no longer corrupt the manifest's selector / token attribution.
- Token attribution survives inside supported at-rule bodies (`@media`, `@supports`, `@container`, `@layer`): the scanner descends into the at-rule and emits each inner rule with its real selector and token references preserved.

## Surface area

- `packages/contracts/src/design-systems/components-manifest.ts`:
  - `iterateCssRules` — replaced the regex walk with a brace-depth character scanner. The opening-brace lookup is now a quote-aware scan (single / double quote + backslash escape + `/* */` defensive comment skip) so a `{` inside a quoted selector context is not mistaken for the rule opener. The closing-brace scan tracks the same quote/escape state so a quoted `}` in a declaration value does not truncate the body. Empty selectorLists (from `stripContainerAtRuleHeaders` rewriting `@media`/`@supports`/`@container`/`@layer` headers to `{`) recurse into the body slice so inner rules surface with their real selectors.
  - `flattenNestedBody` — folds nested-block declarations (recursively, at any depth) into the parent body so `var(--token)` references inside `&:hover { ... }` and `& .child { & .grand { ... } }` count toward the outermost ancestor. Quote-aware so quoted braces in nested values remain data.
  - `classMatchers` — anchored to `^name(?:$|-)` across five groups (buttons, inputs, badges, keyboard, layout) so prefix-sharing classnames no longer cross-group.
- `packages/contracts/tests/components-manifest-6224.test.ts` — 5 regression cases covering flat consecutive rules, single-level + multi-level nesting token attribution, anchored class matching, supported at-rule body traversal, and quoted braces in declaration values.
- `packages/contracts/tests/components-manifest-6250-quoted-selector.test.ts` — 2 regression cases covering quoted `{` inside double- and single-quoted attribute selectors.

## Validation

- `pnpm --filter @open-design/contracts test` → 254/254 pass (was 249 before this PR; added 5 new).
- `pnpm --filter @open-design/contracts typecheck` → clean (no new diagnostics).
- Local fixture-matrix covered: flat consecutive rules, single-level + two-level deep nesting, `@media`/`@supports`/`@layer` traversal, `content: "}"` quoted braces, `.btn-a[data-icon="{"]` quoted braces in selectors, and trailing-flat-rule-after-quoted-brace severity check.
- Manual QA pass on the extractor path is queued (lefarcen flagged it as required for merge); will report findings as a follow-up comment.
- Heads-up: PR #6226 covers the same extractor path; once #6226 merges, this branch will need a rebase against `upstream/main` before merge.
