### PR TITLE
fix daemon critique labels for project skills

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -7068,6 +7068,11 @@ export async function startServer({
       typeof projectId === 'string' && projectId
         ? getProject(db, projectId)
         : null;
+    const effectiveRunSkillId = resolveSkillId(
+      typeof skillId === 'string' && skillId
+        ? skillId
+        : projectRecord?.skillId,
+    );
     const runContextPrompt = renderRunContextPrompt(context, projectRecord?.metadata);
     const linkedDirs = (() => {
       if (!Array.isArray(projectRecord?.metadata?.linkedDirs)) return [];
@@ -9654,17 +9659,10 @@ export async function startServer({
             artifactId: critiqueRunId,
             artifactDir: critiqueArtifactDir,
             adapter: typeof agentId === 'string' ? agentId : 'unknown',
-            // Codex P2 on PR #1485: thread the resolved skill id into the
-            // orchestrator so the Phase 12 metrics carry the real label
-            // instead of falling through to 'unknown' for every live run.
-            // This read `effectiveSkillId`, which is a local of
-            // `composeDaemonSystemPrompt` and has never been in scope here — a
-            // `typeof` guard on an undeclared name does not throw, so the label
-            // silently stayed `undefined` for every run instead. `run.skillId`
-            // is the same request skill id recorded onto the run above, and is
-            // the binding this scope actually has.
-            skill: typeof run.skillId === 'string' && run.skillId
-              ? run.skillId
+            // startChatRun resolves this once after loading the project:
+            // request-level skill first, persisted project skill second.
+            skill: typeof effectiveRunSkillId === 'string' && effectiveRunSkillId
+              ? effectiveRunSkillId
               : undefined,
             cfg: critiqueCfg,
             db,

--- a/apps/daemon/tests/chat-project-skill-critique-label.test.ts
+++ b/apps/daemon/tests/chat-project-skill-critique-label.test.ts
@@ -1,0 +1,118 @@
+import type http from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { delimiter, join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+describe('project skill critique label', () => {
+  let server: http.Server;
+  let baseUrl: string;
+  let fakeBinDir: string;
+  const originalPath = process.env.PATH;
+  const originalCritiqueEnabled = process.env.OD_CRITIQUE_ENABLED;
+
+  beforeAll(async () => {
+    process.env.OD_CRITIQUE_ENABLED = '1';
+    fakeBinDir = await mkdtemp(join(tmpdir(), 'od-project-skill-critique-'));
+    const fakeQwenPath = join(fakeBinDir, 'qwen');
+    await writeFile(
+      fakeQwenPath,
+      `#!/usr/bin/env node
+process.stdin.resume();
+process.stdout.write(\`<CRITIQUE_RUN version="1" maxRounds="3" threshold="8.0" scale="10">
+  <ROUND n="1">
+    <PANELIST role="designer">
+      <NOTES>fixture</NOTES>
+      <ARTIFACT mime="text/html"><![CDATA[<html></html>]]></ARTIFACT>
+    </PANELIST>
+    <PANELIST role="critic" score="9.0"><DIM name="h" score="9">ok</DIM></PANELIST>
+    <PANELIST role="brand" score="9.0"><DIM name="v" score="9">ok</DIM></PANELIST>
+    <PANELIST role="a11y" score="9.0"><DIM name="c" score="9">ok</DIM></PANELIST>
+    <PANELIST role="copy" score="9.0"><DIM name="cl" score="9">ok</DIM></PANELIST>
+    <ROUND_END n="1" composite="9.0" must_fix="0" decision="ship">
+      <REASON>Ship fixture.</REASON>
+    </ROUND_END>
+  </ROUND>
+  <SHIP round="1" composite="9.0" status="shipped">
+    <ARTIFACT mime="text/html"><![CDATA[<html></html>]]></ARTIFACT>
+    <SUMMARY>Shipped.</SUMMARY>
+  </SHIP>
+</CRITIQUE_RUN>
+\`);
+setTimeout(() => process.exit(0), 250);
+`,
+      { mode: 0o755 },
+    );
+    process.env.PATH = `${fakeBinDir}${delimiter}${originalPath ?? ''}`;
+
+    const { startServer } = await import('../src/server.js');
+    const started = await startServer({ port: 0, returnServer: true }) as {
+      url: string;
+      server: http.Server;
+    };
+    baseUrl = started.url;
+    server = started.server;
+  });
+
+  afterAll(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+    await rm(fakeBinDir, { recursive: true, force: true });
+    if (originalPath == null) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+    if (originalCritiqueEnabled == null) delete process.env.OD_CRITIQUE_ENABLED;
+    else process.env.OD_CRITIQUE_ENABLED = originalCritiqueEnabled;
+  });
+
+  it('labels critique with the canonical project skill when the request omits skillId', async () => {
+    const projectId = `project-skill-label-${randomUUID()}`;
+    const createResponse = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: projectId,
+        name: 'Project skill critique label fixture',
+        skillId: 'open-design-landing-deck',
+        designSystemId: 'sleek',
+        metadata: { critiqueTheaterEnabled: true },
+      }),
+    });
+    expect(createResponse.ok).toBe(true);
+
+    // Simulate a legacy project row that predates skill-id canonicalization.
+    // The chat request intentionally carries no request-level skillId.
+    const dataDir = process.env.OD_DATA_DIR;
+    if (!dataDir) throw new Error('OD_DATA_DIR is required for this fixture');
+    const { openDatabase } = await import('../src/db.js');
+    const db = openDatabase(process.cwd(), { dataDir });
+    db.prepare('UPDATE projects SET skill_id = ? WHERE id = ?')
+      .run('editorial-collage-deck', projectId);
+
+    const { __resetCritiqueMetricsForTests } = await import('../src/metrics/index.js');
+    __resetCritiqueMetricsForTests();
+
+    const chatResponse = await fetch(`${baseUrl}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agentId: 'qwen',
+        projectId,
+        designSystemId: 'sleek',
+        message: 'Create the landing page.',
+      }),
+    });
+    expect(chatResponse.ok).toBe(true);
+    const chatBody = await chatResponse.text();
+    expect(chatBody).toContain('critique.run_started');
+
+    const metricsResponse = await fetch(`${baseUrl}/api/metrics`);
+    const metrics = await metricsResponse.text();
+    expect(metrics).toContain(
+      'open_design_critique_runs_total{status="shipped",adapter="qwen",skill="open-design-landing-deck"} 1',
+    );
+    expect(metrics).not.toContain('skill="unknown"');
+    expect(metrics).not.toContain('skill="editorial-collage-deck"');
+  });
+});


### PR DESCRIPTION
## Why

This is the requested telemetry follow-up to #6240. While validating Critique Theater metrics, a project configured with a skill but started without a request-level `skillId` still produced `skill="unknown"`.

That makes project-driven critique traffic indistinguishable in dashboards and traces, even though the daemon has already resolved the effective skill for the prompt. The fix keeps request precedence, falls back to the persisted project row, and canonicalizes legacy aliases without changing the run object or multi-skill behavior.

## What users will see

There is no UI or interaction change. Operators inspecting Critique Theater metrics and traces will see the canonical project skill label instead of `unknown` when the request omits `skillId`.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this change has no UI surface.

## Bug fix verification

- Test path: `apps/daemon/tests/chat-project-skill-critique-label.test.ts`
- The focused fixture went red on the target base `feat/workspace-team`: the real `/api/chat` → `startChatRun` → `runOrchestrator` path shipped successfully but exposed `skill="unknown"`.
- The same fixture is green on this branch and records `skill="open-design-landing-deck"` for a legacy project alias with no request-level `skillId`.

## Validation

- `cd apps/daemon && npx vitest run -c vitest.config.ts tests/chat-project-skill-critique-label.test.ts`
- `cd e2e && pnpm test tests/server-identifier-scope.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm typecheck`
- Full daemon suite was also executed directly: 563 files passed, 11 failed, exit 1. The failures were concentrated in unrelated timeout/order-sensitive suites. The potentially adjacent runtime pair was A/B tested with and without this patch, and the same `run-retry-runtime` assertion failed on the unmodified target base.
