### PR TITLE
fix CI scopes across file renames

### DIFF
--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -206,8 +206,13 @@ async function runScopesPrint(eventName: string, eventPayload: unknown, changedF
   const ghCmdPath = join(tempDir, "gh.cmd");
   await writeFile(eventPath, JSON.stringify(eventPayload));
   const script = `#!/usr/bin/env node
-process.stdout.write(${JSON.stringify(changedFiles.join("\n"))});
-if (${JSON.stringify(changedFiles.length > 0)}) process.stdout.write("\\n");
+const changedFiles = ${JSON.stringify(changedFiles)};
+if (process.argv.includes("--jq")) {
+  process.stdout.write(changedFiles.join("\\n"));
+  if (changedFiles.length > 0) process.stdout.write("\\n");
+} else {
+  process.stdout.write(JSON.stringify({ files: changedFiles.map((filename) => ({ filename })) }));
+}
 `;
   await writeFile(ghPath, script);
   await chmod(ghPath, 0o755);

--- a/e2e/tests/scripts/scopes.test.ts
+++ b/e2e/tests/scripts/scopes.test.ts
@@ -35,6 +35,12 @@ const files = process.env.OD_SCOPES_STUB_FILES ?? "";
 for (const line of files.split("\\n")) {
   if (line.length > 0) console.log(line);
 }
+const previousFilename = process.env.OD_SCOPES_STUB_RENAMED_FROM ?? "";
+const jqIndex = process.argv.indexOf("--jq");
+const jq = jqIndex >= 0 ? process.argv[jqIndex + 1] ?? "" : "";
+if (previousFilename.length > 0 && jq.includes("previous_filename")) {
+  console.log(previousFilename);
+}
 `;
 
 const UI_P0_MATRIX_JSON = JSON.stringify(uiP0CiMatrix);
@@ -530,6 +536,45 @@ test("pull_request changed-file resolution failure still fails the run", () => {
     run.cleanup();
   });
 });
+
+for (const renameCase of [
+  { name: "pull_request", context: PR, filename: "e2e/tests/server-identifier-scope.test.ts", ciMode: "hot" },
+  {
+    name: "workflow_dispatch hot",
+    context: { eventName: "workflow_dispatch", ciMode: "hot" } as const,
+    filename: "e2e/tests/server-identifier-scope.test.ts",
+    ciMode: "hot",
+  },
+  {
+    name: "merge_group",
+    context: { eventName: "merge_group" } as const,
+    filename: "docs/server-identifier-scope.md",
+    ciMode: "full",
+  },
+] as const) {
+  test(`${renameCase.name} rename keeps validation scopes from the previous filename`, () => {
+    const run = runScopes("print", renameCase.context, [renameCase.filename], {
+      OD_SCOPES_STUB_RENAMED_FROM: "apps/daemon/tests/server-identifier-scope.test.ts",
+    });
+    try {
+      assertPlan(
+        JSON.parse(run.stdout) as Record<string, unknown>,
+        expectedPlan({
+          ciMode: renameCase.ciMode,
+          scopes: [
+            "daemon_tests_required",
+            "ui_critical_validation_required",
+            "ui_p0_validation_required",
+            "workspace_validation_required",
+          ],
+          runs: ["run_e2e_vitest", "run_ui_p0"],
+        }),
+      );
+    } finally {
+      run.cleanup();
+    }
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Unit layer: rule-table invariants and evaluator semantics, imported directly.

--- a/e2e/tests/scripts/scopes.test.ts
+++ b/e2e/tests/scripts/scopes.test.ts
@@ -32,12 +32,32 @@ if (process.env.OD_SCOPES_STUB_FAIL === "1") {
   process.exit(1);
 }
 const files = process.env.OD_SCOPES_STUB_FILES ?? "";
-for (const line of files.split("\\n")) {
-  if (line.length > 0) console.log(line);
-}
-const previousFilename = process.env.OD_SCOPES_STUB_RENAMED_FROM ?? "";
+const renameEachFromPrefix = process.env.OD_SCOPES_STUB_RENAME_EACH_FROM_PREFIX ?? "";
 const jqIndex = process.argv.indexOf("--jq");
 const jq = jqIndex >= 0 ? process.argv[jqIndex + 1] ?? "" : "";
+const previousFilename = process.env.OD_SCOPES_STUB_RENAMED_FROM ?? "";
+const fileLines = files.split("\\n").filter((line) => line.length > 0);
+if (jq.length === 0) {
+  console.log(JSON.stringify({
+    files: fileLines.map((filename, index) => ({
+      filename,
+      ...(renameEachFromPrefix.length > 0
+        ? { previous_filename: renameEachFromPrefix + index }
+        : previousFilename.length > 0
+          ? { previous_filename: previousFilename }
+          : {}),
+    })),
+  }));
+  process.exit(0);
+}
+let fileIndex = 0;
+for (const line of fileLines) {
+  console.log(line);
+  if (renameEachFromPrefix.length > 0 && jq.includes("previous_filename")) {
+    console.log(renameEachFromPrefix + fileIndex);
+  }
+  fileIndex += 1;
+}
 if (previousFilename.length > 0 && jq.includes("previous_filename")) {
   console.log(previousFilename);
 }
@@ -525,6 +545,18 @@ test("merge_group compare result at GitHub's 300-file ceiling fails open to the 
   const run = runScopes("print", { eventName: "merge_group" }, files);
   try {
     assertPlan(JSON.parse(run.stdout) as Record<string, unknown>, FULL_PLAN);
+  } finally {
+    run.cleanup();
+  }
+});
+
+test("merge_group counts rename records rather than flattened paths at the 300-file ceiling", () => {
+  const files = Array.from({ length: 150 }, (_, index) => `docs/renamed-${index}.md`);
+  const run = runScopes("print", { eventName: "merge_group" }, files, {
+    OD_SCOPES_STUB_RENAME_EACH_FROM_PREFIX: "docs/original-",
+  });
+  try {
+    assertPlan(JSON.parse(run.stdout) as Record<string, unknown>, expectedPlan({ ciMode: "full" }));
   } finally {
     run.cleanup();
   }

--- a/scripts/scopes.ts
+++ b/scripts/scopes.ts
@@ -811,7 +811,13 @@ function changedPullRequestFiles(): string[] {
     throw new Error("pull_request event payload did not include pull_request.number");
   }
 
-  const stdout = runGh(["api", "--paginate", `repos/${repository}/pulls/${prNumber}/files`, "--jq", ".[].filename"]);
+  const stdout = runGh([
+    "api",
+    "--paginate",
+    `repos/${repository}/pulls/${prNumber}/files`,
+    "--jq",
+    ".[] | .filename, (.previous_filename // empty)",
+  ]);
   return stdout.split(/\r?\n/).filter(Boolean);
 }
 
@@ -825,7 +831,7 @@ function changedManualFiles(): string[] {
     "--paginate",
     `repos/${repository}/compare/main...${sha}`,
     "--jq",
-    "(.files // [])[] | .filename",
+    "(.files // [])[] | .filename, (.previous_filename // empty)",
   ]);
   return stdout.split(/\r?\n/).filter(Boolean);
 }
@@ -844,7 +850,7 @@ function changedMergeGroupFiles(): string[] {
     "--paginate",
     `repos/${repository}/compare/${baseSha}...${headSha}`,
     "--jq",
-    "(.files // [])[] | .filename",
+    "(.files // [])[] | .filename, (.previous_filename // empty)",
   ]);
   const files = stdout.split(/\r?\n/).filter(Boolean);
   // The compare API caps the complete comparison at 300 files, and only the

--- a/scripts/scopes.ts
+++ b/scripts/scopes.ts
@@ -845,22 +845,21 @@ function changedMergeGroupFiles(): string[] {
     throw new Error("merge_group event payload did not include merge_group.base_sha and merge_group.head_sha");
   }
 
-  const stdout = runGh([
-    "api",
-    "--paginate",
-    `repos/${repository}/compare/${baseSha}...${headSha}`,
-    "--jq",
-    "(.files // [])[] | .filename, (.previous_filename // empty)",
-  ]);
-  const files = stdout.split(/\r?\n/).filter(Boolean);
+  const stdout = runGh(["api", `repos/${repository}/compare/${baseSha}...${headSha}`]);
+  const comparison = JSON.parse(stdout) as {
+    files?: Array<{ filename?: unknown; previous_filename?: unknown }>;
+  };
+  const fileRecords = comparison.files ?? [];
   // The compare API caps the complete comparison at 300 files, and only the
-  // first page contains the files array. Exactly 300 names therefore cannot
+  // first page contains the files array. Exactly 300 records therefore cannot
   // prove that the resolution is complete; fail closed before a future
   // certain-confidence rule can trust a truncated merge-group union diff.
-  if (files.length >= 300) {
+  if (fileRecords.length >= 300) {
     throw new Error("merge_group compare result reached GitHub's 300-file ceiling");
   }
-  return files;
+  return fileRecords.flatMap((file) =>
+    [file.filename, file.previous_filename].filter((filename): filename is string => typeof filename === "string"),
+  );
 }
 
 function runGh(args: string[]): string {

--- a/specs/current/ci.md
+++ b/specs/current/ci.md
@@ -17,7 +17,9 @@ Every changed file is classified by the additive rule table in
 `scripts/scopes.ts`: effects union across matched rules, confidence is the
 minimum across matched rules. Each evaluation context brings a trust threshold:
 PR and manual-hot runs believe `medium`, the merge queue believes only
-`certain`, manual-full runs believe nothing. A file below threshold — or
+`certain`, manual-full runs believe nothing. Renames contribute both the
+current and previous filename so moving a file cannot discard the source
+path's validation effects. A file below threshold — or
 matching no rule — escalates fail-closed to the full radius.
 
 The policy floor never moves: `run_preflight` is true in every plan, and its


### PR DESCRIPTION
## Why

#6244 exposed a fail-open gap in CI scope detection. GitHub reports a file move as one `renamed` record with the destination in `filename` and the source in `previous_filename`, but the detector classified only `filename`.

That made a rename out of a scope-arming directory materially weaker than the equivalent delete plus add. In #6244, moving the identifier guard from `apps/daemon/tests/` to `e2e/tests/` erased the daemon rule and skipped E2E Vitest on the PR. More generally, a move from daemon code into a certain-exempt path could also make the merge queue incorrectly drop to the policy floor.

## What users will see

There is no product UI change. Pull requests, manual-hot runs, and merge groups now retain the validation effects of both sides of a rename, so moving a file cannot silently skip the lane that covered its source path.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal CI routing, tests, and documentation only

## Screenshots

Not applicable; this change has no UI surface.

## Bug fix verification

- Test path: `e2e/tests/scripts/scopes.test.ts`
- Red on `feat/workspace-team`: exit 1. All three rename fixtures failed:
  - PR and manual-hot lost `daemon_tests_required`, `ui_p0_validation_required`, and `run_e2e_vitest`.
  - A merge-group rename from `apps/daemon/tests/` into `docs/` incorrectly dropped to the zero-effect policy floor.
- Green on this branch: exit 0, 51/51 tests passed. The same fixtures preserve the daemon-core effects in PR, manual-hot, and merge-group resolution.

## Validation

- `cd e2e && pnpm test tests/scripts/scopes.test.ts`
- `cd e2e && pnpm typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
