### PR TITLE
fix: avoid duplicate form answers on resume path

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1465,7 +1465,10 @@ export function composeChatUserRequestForAgent(
   const transition = formAnswerTransitionForCurrentPrompt(currentPrompt);
   if (!transition) return body;
   if (skip) {
-    return [transition, body].join('\n\n');
+    // Resume-capable CLIs already carry the latest user turn in upstream
+    // session memory. The transition block embeds `currentPrompt`, so
+    // appending `body` here duplicates the submitted form answers.
+    return transition;
   }
   return [
     transition,

--- a/apps/daemon/tests/telemetry-message-finalization.test.ts
+++ b/apps/daemon/tests/telemetry-message-finalization.test.ts
@@ -140,8 +140,9 @@ describe('Langfuse message finalization gate', () => {
 
     // The form-answer transition still fires — that drives RULE 2 / 3.
     expect(prompt).toContain('The user has answered the discovery form.');
-    // The latest user turn is preserved verbatim.
-    expect(prompt).toContain(currentPrompt);
+    // The latest user turn should appear only once on the resume path.
+    expect(prompt.match(/\[form answers — discovery\]/g)).toHaveLength(1);
+    expect(prompt.match(/Pick a direction for me \[value: pick_direction\]/g)).toHaveLength(1);
     // The transcript header is dropped — it was misleading because the
     // body underneath is no longer a transcript.
     expect(prompt).not.toContain('## Full conversation transcript');


### PR DESCRIPTION
## Summary
- stop appending the latest user turn twice on the skipTranscript resume path
- keep the form-answer transition block as the single source of the submitted answers
- tighten the regression test so resume prompts assert one copy of the discovery answers

## Surface area
- [x] Resume-capable CLI path (skipTranscript: true)
- [ ] Non-resume transcript path
- [ ] Prompt composition outside form-answer transitions
- [ ] Runtime / billing / persistence behavior

Impact: localized to resumed prompt composition only.

## Bug-fix verification
- confirmed the resume skipTranscript path no longer appends the latest form-answer block twice
- added a regression assertion that the discovery answer markers appear only once on the resume path
- ran: pnpm exec vitest run tests/telemetry-message-finalization.test.ts

## Test Plan
- pnpm exec vitest run tests/telemetry-message-finalization.test.ts
- attempted broader chat-route validation, but local better-sqlite3 / Node ABI mismatch blocks that path in this environment

Closes #6239