### PR TITLE
fix: drop slim turn-1 discovery policy for skipDiscoveryBrief

### DIFF
--- a/apps/daemon/src/prompts/core-slim.ts
+++ b/apps/daemon/src/prompts/core-slim.ts
@@ -187,9 +187,11 @@ export const PLATFORM_CONTRACTS_BLOCK = `## Platform delivery contracts
  */
 export function renderSlimCoreCharter(
   executionProfile: ExecutionProfile = 'filesystem',
+  options: { includeTurnOneDiscoveryPolicy?: boolean } = {},
 ): string {
   const isTextArtifact = executionProfile === 'text_artifact';
-  return SLIM_CORE_CHARTER
+  const includeTurnOneDiscoveryPolicy = options.includeTurnOneDiscoveryPolicy !== false;
+  let charter = SLIM_CORE_CHARTER
     .replace(
       EXECUTION_CONTEXT_PLACEHOLDER,
       isTextArtifact ? TEXT_ARTIFACT_EXECUTION_CONTEXT : FILESYSTEM_EXECUTION_CONTEXT,
@@ -198,4 +200,15 @@ export function renderSlimCoreCharter(
       HANDOFF_PLACEHOLDER,
       isTextArtifact ? TEXT_ARTIFACT_HANDOFF : FILESYSTEM_HANDOFF,
     );
+
+  if (!includeTurnOneDiscoveryPolicy) {
+    charter = charter
+      .replace(
+        /### Turn 1: one line, one form, then stop\n[\s\S]*?### When to skip or inherit the form\n[\s\S]*?(?=### Writing the form — shape & tailoring)/,
+        '',
+      )
+      .replace(/\n{3,}/g, '\n\n');
+  }
+
+  return charter;
 }

--- a/apps/daemon/src/prompts/system.ts
+++ b/apps/daemon/src/prompts/system.ts
@@ -870,6 +870,7 @@ export function composeSystemPrompt({
         ...(streamFormat === 'plain' ? [API_MODE_OVERRIDE, '\n\n---\n\n'] : []),
         renderSlimCoreCharter(
           executionProfile ?? executionProfileFromStreamFormat(streamFormat),
+          { includeTurnOneDiscoveryPolicy: metadata?.skipDiscoveryBrief !== true },
         ),
         '\n\n---\n\n',
       ]

--- a/apps/daemon/tests/prompts/__snapshots__/system-prompt-matrix.test.ts.snap
+++ b/apps/daemon/tests/prompts/__snapshots__/system-prompt-matrix.test.ts.snap
@@ -289,21 +289,6 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
     ],
     "totalChars": 86628,
   },
-  "skip-discovery-brief": {
-    "sections": [
-      "injection-resistance",
-      "skip-discovery-override",
-      "discovery-and-philosophy",
-      "direction-library",
-      "identity-charter",
-      "project-metadata",
-      "media-dispatch-hint",
-      "filesystem-handoff-override",
-      "clarifying-questions",
-      "role-marker-guard",
-    ],
-    "totalChars": 63544,
-  },
   "slim-design-full-stack": {
     "sections": [
       "injection-resistance",
@@ -340,6 +325,17 @@ exports[`composeSystemPrompt — scenario × section golden matrix > keeps the s
       "role-marker-guard",
     ],
     "totalChars": 22982,
+  },
+  "slim-skip-discovery-brief": {
+    "sections": [
+      "injection-resistance",
+      "skip-discovery-override",
+      "slim-core-charter",
+      "project-metadata",
+      "media-dispatch-hint",
+      "role-marker-guard",
+    ],
+    "totalChars": 22358,
   },
 }
 `;

--- a/apps/daemon/tests/prompts/core-slim.test.ts
+++ b/apps/daemon/tests/prompts/core-slim.test.ts
@@ -255,6 +255,21 @@ describe('slim core — moved-out content stays out (ownership)', () => {
   });
 });
 
+describe('renderSlimCoreCharter — skipDiscoveryBrief gating', () => {
+  it('omits only the turn-1 discovery policy when skipDiscoveryBrief disables the first-form flow', () => {
+    const charter = renderSlimCoreCharter('filesystem', {
+      includeTurnOneDiscoveryPolicy: false,
+    });
+
+    expect(charter).not.toContain('### Turn 1: one line, one form, then stop');
+    expect(charter).not.toContain('### When to skip or inherit the form');
+    // The form-authoring contract stays: skipDiscoveryBrief still allows one
+    // concise follow-up if a required detail is impossible to infer safely.
+    expect(charter).toContain('### Writing the form — shape & tailoring');
+    expect(charter).toContain('### Form contract (any form, any turn)');
+  });
+});
+
 describe('composeSystemPrompt — promptCoreVariant switch', () => {
   const base = {
     metadata: { kind: 'prototype' as const },

--- a/apps/daemon/tests/prompts/system-prompt-matrix.test.ts
+++ b/apps/daemon/tests/prompts/system-prompt-matrix.test.ts
@@ -233,8 +233,12 @@ const SCENARIOS: ReadonlyArray<[name: string, input: ComposeInput]> = [
     },
   ],
   [
-    'skip-discovery-brief',
-    { metadata: { kind: 'prototype', skipDiscoveryBrief: true }, executionProfile: 'filesystem' },
+    'slim-skip-discovery-brief',
+    {
+      metadata: { kind: 'prototype', skipDiscoveryBrief: true },
+      executionProfile: 'filesystem',
+      promptCoreVariant: 'slim',
+    },
   ],
   [
     'codex-imagegen',


### PR DESCRIPTION
## Summary
- stop composing the slim charter's turn-1 discovery policy when skipDiscoveryBrief is true
- keep the form-authoring contract intact so one concise follow-up remains available if inference is impossible
- add prompt regression coverage for both the classic and slim skip-discovery paths and update the scenario matrix snapshot

## Surface area
- [x] Slim prompt composition when skipDiscoveryBrief: true
- [x] Classic prompt composition
- [ ] Non-skip discovery flow
- [ ] Runtime / persistence / billing behavior

Impact: localized to prompt composition for automated projects that skip the turn-1 discovery brief.

## Bug-fix verification
- reproduced the contradictory slim path as a prompt-composition issue: the slim charter still carried the turn-1 discovery policy while the skip-discovery override separately instructed the model not to ask the form
- confirmed the fix removes only the turn-1 discovery subsections on the slim skipDiscoveryBrief path while keeping the form-authoring contract and generic non-skip behavior intact
- restored the classic skip-discovery scenario in the prompt matrix so both prompt families stay covered
- ran: pnpm exec vitest run tests/prompts/core-slim.test.ts tests/prompts/system-prompt-matrix.test.ts -u

## Test Plan
- pnpm exec vitest run tests/prompts/core-slim.test.ts tests/prompts/system-prompt-matrix.test.ts -u
- reviewed the diff with Antigravity for default/non-skip behavior and contract preservation

Closes #6246