### PR TITLE
fix(daemon): stop reading our own empty-output fallback as a hard quota

### DIFF
--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -9,7 +9,10 @@ import type {
 
 import { classifyAmrAccountFailure } from './integrations/vela-errors.js';
 import { summarizeRunToolProgress } from './run-diagnostics.js';
-import { classifyAgentServiceFailure } from './runtimes/auth.js';
+import {
+  classifyAgentServiceFailure,
+  type AgentServiceFailureCode,
+} from './runtimes/auth.js';
 import type { RunResult, RunStatusForAnalytics } from './run-result.js';
 
 export interface RunEventForFailureClassification {
@@ -216,6 +219,46 @@ function isHardQuotaFragment(text: string): boolean {
 
 function isHardQuotaText(parts: string[]): boolean {
   return parts.some(isHardQuotaFragment);
+}
+
+// Same fragment scoping for the shared agent-service classifier. It is a
+// whole-text matcher, but the text handed to it here is up to 24 unrelated
+// messages joined with '\n', so running it on the join lets one message vouch
+// for a signal sitting in another — a `payment` in an unrelated event turning
+// the empty-output fallback's `quota` into a rate limit. Classify each fragment
+// on its own and fold with the precedence `classifyAgentServiceFailure` itself
+// uses, so a `401` in any message still outranks a `429` in another.
+const SERVICE_FAILURE_PRECEDENCE = [
+  'AGENT_AUTH_REQUIRED',
+  'RATE_LIMITED',
+  'UPSTREAM_UNAVAILABLE',
+] as const satisfies readonly AgentServiceFailureCode[];
+
+function classifyServiceFailureParts(
+  parts: string[],
+): AgentServiceFailureCode | null {
+  const found = new Set<AgentServiceFailureCode>();
+  for (const part of parts) {
+    const code = classifyAgentServiceFailure(part);
+    if (code) found.add(code);
+  }
+  return SERVICE_FAILURE_PRECEDENCE.find((code) => found.has(code)) ?? null;
+}
+
+// The vela detector already applies the corroboration rule this fix is built
+// on (`quota` plus wallet/balance/credit/billing/funds), but it too was handed
+// the joined text — so an unrelated fragment mentioning a billing period could
+// corroborate the fallback's `quota` and report the account as out of balance.
+// Same scoping, same reason. The status error is the first fragment, so
+// first-match order keeps the most authoritative message in front.
+function classifyAmrAccountParts(
+  parts: string[],
+): ReturnType<typeof classifyAmrAccountFailure> {
+  for (const part of parts) {
+    const failure = classifyAmrAccountFailure(part);
+    if (failure) return failure;
+  }
+  return null;
 }
 
 // A transient, retryable rate limit (distinct from a hard quota). vela/upstream
@@ -717,7 +760,7 @@ function classifyRunFailureBase(
   const parts = collectFailureParts({ ...input, events });
   const text = parts.join('\n');
   const retryableHint = latestRetryable(events);
-  const amrFailure = classifyAmrAccountFailure(text);
+  const amrFailure = classifyAmrAccountParts(parts);
   const byokOpenCodeProviderNotFound = isByokOpenCodeProviderNotFoundText(
     input.agentId,
     text,
@@ -878,7 +921,7 @@ function classifyRunFailureBase(
     );
   }
 
-  const serviceFailure = classifyAgentServiceFailure(text);
+  const serviceFailure = classifyServiceFailureParts(parts);
   if (serviceFailure === 'AGENT_AUTH_REQUIRED' || isAuthDetailText(text)) {
     return classification(
       'auth',

--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -169,9 +169,27 @@ function collectFailureText(input: RunFailureClassificationInput): string {
   return parts.join('\n');
 }
 
+// A bare `quota` alternative used to live in the alternation below, which made
+// this matcher fire on our *own* generic empty-output fallback (server.ts:
+// "...then try re-authenticating the agent, checking quota, or switching
+// models."). The quota branch is evaluated before `isEmptyOutputText`, so every
+// output-less run — for any reason — was reported as an exhausted quota, and
+// run-retry-policy suppresses retries outright on `hard_quota`. That is the
+// misclassification behind #6143: third-party API runs failed permanently while
+// the provider still had quota.
+//
+// So `quota` on its own is not a signal; it needs a corroborating word. This
+// mirrors the detector that already got it right —
+// integrations/vela-errors.ts requires one of wallet/balance/credit/billing/funds
+// alongside `quota`. Phrases that are unambiguous on their own (session limit,
+// insufficient quota, exceeded your current quota…) keep matching directly.
 function isHardQuotaText(text: string): boolean {
-  return /\b(session limit|usage limit|limit reached|quota|billing (?:hard )?limit|insufficient[ _-]?(?:quota|credit|credits|funds)|exceeded your current quota|out of credits|no payment method|requires more credits|can only afford)\b|DAILY_LIMIT_EXCEEDED|用户额度不足|额度不足|预扣费额度失败/i
-    .test(text);
+  if (/\b(session limit|usage limit|limit reached|billing (?:hard )?limit|insufficient[ _-]?(?:quota|credit|credits|funds)|exceeded your current quota|out of credits|no payment method|requires more credits|can only afford)\b|DAILY_LIMIT_EXCEEDED|用户额度不足|额度不足|预扣费额度失败/i
+    .test(text)) {
+    return true;
+  }
+  return /\bquota\b/i.test(text) &&
+    /\b(wallet|balance|credits?|billing|funds?|payment|plan)\b/i.test(text);
 }
 
 // A transient, retryable rate limit (distinct from a hard quota). vela/upstream

--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -151,7 +151,7 @@ function inferFailureStageFromEvents(
   return fallback;
 }
 
-function collectFailureText(input: RunFailureClassificationInput): string {
+function collectFailureParts(input: RunFailureClassificationInput): string[] {
   const parts: string[] = [];
   const statusError = readString(input.status.error);
   if (statusError) parts.push(statusError);
@@ -166,7 +166,11 @@ function collectFailureText(input: RunFailureClassificationInput): string {
       parts.push(...eventStderrText(rec.data));
     }
   }
-  return parts.join('\n');
+  return parts;
+}
+
+function collectFailureText(input: RunFailureClassificationInput): string {
+  return collectFailureParts(input).join('\n');
 }
 
 // A bare `quota` alternative used to live in the alternation below, which made
@@ -183,7 +187,14 @@ function collectFailureText(input: RunFailureClassificationInput): string {
 // integrations/vela-errors.ts requires one of wallet/balance/credit/billing/funds
 // alongside `quota`. Phrases that are unambiguous on their own (session limit,
 // insufficient quota, exceeded your current quota…) keep matching directly.
-function isHardQuotaText(text: string): boolean {
+//
+// Evaluated per collected fragment, never over the joined text. `collectFailureText`
+// concatenates up to 24 unrelated messages with '\n', so whole-text corroboration
+// would let *any* fragment mentioning a plan or payment vouch for a bare `quota`
+// sitting in a different one — which is precisely how the empty-output fallback
+// would find its way back to `hard_quota`. Fragment scope also keeps the `\s+`
+// in the adjacency patterns below from bridging two messages across the join.
+function isHardQuotaFragment(text: string): boolean {
   if (/\b(session limit|usage limit|limit reached|billing (?:hard )?limit|insufficient[ _-]?(?:quota|credit|credits|funds)|exceeded your current quota|out of credits|no payment method|requires more credits|can only afford)\b|DAILY_LIMIT_EXCEEDED|用户额度不足|额度不足|预扣费额度失败/i
     .test(text)) {
     return true;
@@ -201,6 +212,10 @@ function isHardQuotaText(text: string): boolean {
   }
   return /\bquota\b/i.test(text) &&
     /\b(wallet|balance|credits?|billing|funds?|payment|plan)\b/i.test(text);
+}
+
+function isHardQuotaText(parts: string[]): boolean {
+  return parts.some(isHardQuotaFragment);
 }
 
 // A transient, retryable rate limit (distinct from a hard quota). vela/upstream
@@ -696,7 +711,11 @@ function classifyRunFailureBase(
   }
 
   const errorCode = normalizeCode(input.errorCode ?? input.status.errorCode);
-  const text = collectFailureText({ ...input, events });
+  // `events` is the attempt-scoped view (#6598), so the fragments are collected
+  // from it rather than from `input.events` — the quota matcher below runs per
+  // fragment and must see the same attempt the rest of this call classifies.
+  const parts = collectFailureParts({ ...input, events });
+  const text = parts.join('\n');
   const retryableHint = latestRetryable(events);
   const amrFailure = classifyAmrAccountFailure(text);
   const byokOpenCodeProviderNotFound = isByokOpenCodeProviderNotFoundText(
@@ -870,8 +889,8 @@ function classifyRunFailureBase(
     );
   }
 
-  if (errorCode === 'RATE_LIMITED' || serviceFailure === 'RATE_LIMITED' || isHardQuotaText(text) || isRateLimitText(text)) {
-    const hardQuota = isHardQuotaText(text);
+  const hardQuota = isHardQuotaText(parts);
+  if (errorCode === 'RATE_LIMITED' || serviceFailure === 'RATE_LIMITED' || hardQuota || isRateLimitText(text)) {
     const workspaceCredits = isWorkspaceCreditsText(text);
     const retryable = hardQuota ? false : (retryableHint ?? true);
     return classification(

--- a/apps/daemon/src/run-failure-classification.ts
+++ b/apps/daemon/src/run-failure-classification.ts
@@ -188,6 +188,17 @@ function isHardQuotaText(text: string): boolean {
     .test(text)) {
     return true;
   }
+  // `quota` next to an exhaustion word is unambiguous on its own — no wallet or
+  // balance needed. `quota exhausted` is a real upstream payload in this repo
+  // (tests/byok-tools.test.ts: `status_msg: 'quota exhausted'`); requiring
+  // corroboration for it would turn a terminal failure into a retry candidate
+  // (and under RATE_LIMITED, a retryable `rate_limit_429`), which is the exact
+  // inverse of the misclassification this function is being fixed for.
+  if (/\bquota\s+(?:exceeded|exhausted|depleted|reached|used\s+up)\b/i.test(text)
+    || /\b(?:exceeded|exhausted|out\s+of|ran\s+out\s+of|no\s+remaining)\s+(?:\w+\s+){0,3}quota\b/i
+      .test(text)) {
+    return true;
+  }
   return /\bquota\b/i.test(text) &&
     /\b(wallet|balance|credits?|billing|funds?|payment|plan)\b/i.test(text);
 }

--- a/apps/daemon/src/runtimes/auth.ts
+++ b/apps/daemon/src/runtimes/auth.ts
@@ -239,10 +239,44 @@ const AGENT_AUTH_FAILURE_RE = new RegExp(
 );
 
 // Quota / rate limit / billing balance — the wall the hosted gateway avoids.
+// A bare `quota` alternative used to live in this alternation. It made the
+// matcher fire on the daemon's *own* generic empty-output fallback (server.ts:
+// "...then try re-authenticating the agent, checking quota, or switching
+// models."), so an output-less run — for any reason — was reported as a
+// provider rate limit. That is the misclassification behind #6143, and dropping
+// the bare alternative from `run-failure-classification`'s local matcher alone
+// was not enough: `classifyRunFailure` also reaches its rate-limit branch
+// through this shared classifier. Quota now goes through
+// `isCorroboratedQuotaText` below.
 const AGENT_RATE_FAILURE_RE = new RegExp(
-  `(\\b(rate[ _-]?limit|too many requests|quota|insufficient[ _-]?(?:quota|balance|credit|funds)|credit balance is too low|exceeded your current quota|usage limit|session limit|limit reached|billing (?:hard )?limit)\\b|${STATUS_CTX}429\\b)`,
+  `(\\b(rate[ _-]?limit|too many requests|insufficient[ _-]?(?:quota|balance|credit|funds)|credit balance is too low|exceeded your current quota|usage limit|session limit|limit reached|billing (?:hard )?limit)\\b|${STATUS_CTX}429\\b)`,
   'i',
 );
+
+// `quota` on its own is not a signal; it counts when the message either phrases
+// it as exhaustion, or carries a money/plan word corroborating it. This mirrors
+// `isHardQuotaFragment` in run-failure-classification.ts, which applies the same
+// rule to the daemon's own failure text; both are covered by tests so the two
+// cannot silently drift apart again.
+//
+// This is a per-message predicate. Corroboration evaluated across concatenated,
+// unrelated messages is precisely how a bare `quota` gets vouched for by a
+// `plan` or `payment` that has nothing to do with it.
+const QUOTA_RE = /\bquota\b/i;
+// Unambiguous on its own — no wallet or balance needed. `quota exhausted` is a
+// real upstream payload in this repo (tests/byok-tools.test.ts:
+// `status_msg: 'quota exhausted'`); requiring corroboration for it would turn a
+// terminal quota failure into a retry candidate.
+const QUOTA_EXHAUSTION_RE =
+  /\bquota\s+(?:exceeded|exhausted|depleted|reached|used\s+up)\b|\b(?:exceeded|exhausted|out\s+of|ran\s+out\s+of|no\s+remaining)\s+(?:\w+\s+){0,3}quota\b/i;
+const QUOTA_CORROBORATION_RE =
+  /\b(wallet|balance|credits?|billing|funds?|payment|plan)\b/i;
+
+function isCorroboratedQuotaText(text: string): boolean {
+  const value = String(text || '');
+  if (QUOTA_EXHAUSTION_RE.test(value)) return true;
+  return QUOTA_RE.test(value) && QUOTA_CORROBORATION_RE.test(value);
+}
 
 // Upstream model/provider problems: overloaded, 5xx, temporarily unavailable.
 const AGENT_UPSTREAM_FAILURE_RE = new RegExp(
@@ -261,7 +295,9 @@ export function classifyAgentServiceFailure(
   const value = String(text || '');
   if (!value.trim()) return null;
   if (AGENT_AUTH_FAILURE_RE.test(value)) return 'AGENT_AUTH_REQUIRED';
-  if (AGENT_RATE_FAILURE_RE.test(value)) return 'RATE_LIMITED';
+  if (AGENT_RATE_FAILURE_RE.test(value) || isCorroboratedQuotaText(value)) {
+    return 'RATE_LIMITED';
+  }
   if (AGENT_UPSTREAM_FAILURE_RE.test(value)) return 'UPSTREAM_UNAVAILABLE';
   return null;
 }

--- a/apps/daemon/tests/run-failure-classification.real-deps.test.ts
+++ b/apps/daemon/tests/run-failure-classification.real-deps.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+
+// Refs #6143. The sibling suite (`run-failure-classification.test.ts`) mocks
+// `runtimes/auth.js` and `integrations/vela-errors.js` so it can pin one branch
+// at a time. That isolation hid a production path: `classifyRunFailure` reaches
+// the rate-limit branch through `classifyAgentServiceFailure`, whose matcher
+// carried its own bare `quota` alternative — so the daemon's empty-output
+// fallback still came back as a retryable `rate_limit / rate_limit_429` even
+// after the local `isHardQuotaText` stopped matching it.
+//
+// This file therefore imports the real classifier with no `vi.mock` at all. Its
+// job is to hold the *cross-module* contract; per-branch behaviour stays in the
+// mocked suite.
+import {
+  classifyRunFailure,
+  type RunEventForFailureClassification,
+} from '../src/run-failure-classification.js';
+
+function errorEvent(
+  code: string,
+  message: string,
+  retryable?: boolean,
+): RunEventForFailureClassification {
+  return {
+    event: 'error',
+    data: {
+      message,
+      error: {
+        code,
+        message,
+        ...(retryable !== undefined ? { retryable } : {}),
+      },
+    },
+  };
+}
+
+function classify(
+  code: string | null,
+  message = '',
+  events: RunEventForFailureClassification[] = code
+    ? [errorEvent(code, message)]
+    : [],
+) {
+  return classifyRunFailure({
+    result: 'failed',
+    status: {
+      status: 'failed',
+      error: message || null,
+      errorCode: code,
+      exitCode: 1,
+      signal: null,
+    },
+    ...(code ? { errorCode: code } : {}),
+    agentId: 'claude',
+    events,
+  });
+}
+
+// Verbatim copy of the daemon's generic fallback (apps/daemon/src/server.ts).
+const EMPTY_OUTPUT_FALLBACK =
+  'Agent completed without producing any output. The model or provider may ' +
+  'have returned an empty response. Check the agent logs for upstream ' +
+  'errors, then try re-authenticating the agent, checking quota, or ' +
+  'switching models.';
+
+describe('classifyRunFailure with real service-failure classifier', () => {
+  it('classifies the daemon empty-output fallback as empty output, not a rate limit', () => {
+    expect(
+      classify('AGENT_EXECUTION_FAILED', EMPTY_OUTPUT_FALLBACK),
+    ).toMatchObject({
+      failure_category: 'empty_output',
+      failure_detail: 'empty_output',
+      retryable: true,
+    });
+  });
+
+  it('keeps the fallback as empty output when an unrelated fragment mentions money', () => {
+    for (const unrelated of [
+      'Switched to the fallback plan for this workspace.',
+      'Your payment details were updated 3 days ago.',
+      'Restored session from the previous billing period snapshot.',
+      'Failed to load plan',
+    ]) {
+      expect(
+        classify('AGENT_EXECUTION_FAILED', EMPTY_OUTPUT_FALLBACK, [
+          errorEvent('AGENT_EXECUTION_FAILED', EMPTY_OUTPUT_FALLBACK),
+          errorEvent('AGENT_EXECUTION_FAILED', unrelated),
+        ]),
+        unrelated,
+      ).toMatchObject({
+        failure_category: 'empty_output',
+        failure_detail: 'empty_output',
+      });
+    }
+  });
+
+  it('still reports explicit quota exhaustion as a non-retryable hard quota', () => {
+    for (const text of [
+      'quota exhausted',
+      'quota exceeded',
+      'Quota depleted for this account.',
+      'You have exceeded your monthly quota.',
+    ]) {
+      expect(classify('AGENT_EXECUTION_FAILED', text), text).toMatchObject({
+        failure_category: 'rate_limit',
+        failure_detail: 'hard_quota',
+        retryable: false,
+      });
+      // Under RATE_LIMITED the stakes are higher: losing the phrase match turns
+      // a terminal quota failure into a retryable `rate_limit_429`.
+      expect(
+        classify('RATE_LIMITED', text),
+        `RATE_LIMITED ${text}`,
+      ).toMatchObject({
+        failure_detail: 'hard_quota',
+        retryable: false,
+      });
+    }
+  });
+
+  it('keeps a genuinely corroborated quota fragment classified alongside the fallback', () => {
+    // With the real vela detector in play, this wording is routed to the more
+    // specific balance category before the quota branch is reached. Either way
+    // it must stay non-retryable — what the fallback must not do is *become*
+    // this.
+    expect(
+      classify('AGENT_EXECUTION_FAILED', EMPTY_OUTPUT_FALLBACK, [
+        errorEvent('AGENT_EXECUTION_FAILED', EMPTY_OUTPUT_FALLBACK),
+        errorEvent(
+          'AGENT_EXECUTION_FAILED',
+          'You exceeded your current quota, please check your plan and billing details.',
+        ),
+      ]),
+    ).toMatchObject({
+      failure_category: 'insufficient_balance',
+      retryable: false,
+    });
+
+    // A quota fragment that corroborates itself without tripping the vela
+    // detector still lands on the hard-quota path.
+    expect(
+      classify('AGENT_EXECUTION_FAILED', EMPTY_OUTPUT_FALLBACK, [
+        errorEvent('AGENT_EXECUTION_FAILED', EMPTY_OUTPUT_FALLBACK),
+        errorEvent(
+          'AGENT_EXECUTION_FAILED',
+          'Your plan has no quota left for this model.',
+        ),
+      ]),
+    ).toMatchObject({
+      failure_category: 'rate_limit',
+      failure_detail: 'hard_quota',
+      retryable: false,
+    });
+  });
+
+  it('still recognises ordinary rate limits and auth failures through the real classifier', () => {
+    expect(
+      classify('AGENT_EXECUTION_FAILED', 'HTTP 429 Too Many Requests'),
+    ).toMatchObject({
+      failure_category: 'rate_limit',
+      failure_detail: 'rate_limit_429',
+      retryable: true,
+    });
+    expect(
+      classify('AGENT_EXECUTION_FAILED', 'HTTP 401 Unauthorized'),
+    ).toMatchObject({
+      failure_category: 'auth',
+    });
+  });
+});

--- a/apps/daemon/tests/run-failure-classification.test.ts
+++ b/apps/daemon/tests/run-failure-classification.test.ts
@@ -374,6 +374,59 @@ describe('classifyRunFailure', () => {
     });
   });
 
+  it('does not let an unrelated fragment corroborate the fallback back into a hard quota', () => {
+    // `collectFailureText` joins up to 24 unrelated messages with '\n'. If the
+    // corroboration rule is applied to that joined string, any *other* fragment
+    // mentioning a plan or a payment vouches for the bare `quota` sitting in the
+    // empty-output fallback — and the run is suppressed from retrying again.
+    // Corroboration has to hold within a single collected fragment.
+    for (const unrelated of [
+      'Switched to the fallback plan for this workspace.',
+      'Your payment details were updated 3 days ago.',
+      'Restored session from the previous billing period snapshot.',
+    ]) {
+      expect(
+        classify('AGENT_EXECUTION_FAILED', EMPTY_OUTPUT_FALLBACK, [
+          errorEvent('AGENT_EXECUTION_FAILED', EMPTY_OUTPUT_FALLBACK),
+          errorEvent('AGENT_EXECUTION_FAILED', unrelated),
+        ]),
+        unrelated,
+      ).toMatchObject({
+        failure_category: 'empty_output',
+        failure_detail: 'empty_output',
+      });
+    }
+
+    // Same boundary for the exhaustion collocations: `\s+` matches the '\n' the
+    // fragments are joined with, so a message ending in `quota` must not pair up
+    // with the next message starting in `exceeded`.
+    expect(
+      classify('AGENT_EXECUTION_FAILED', EMPTY_OUTPUT_FALLBACK, [
+        errorEvent('AGENT_EXECUTION_FAILED', 'Reported usage against the quota'),
+        errorEvent('AGENT_EXECUTION_FAILED', 'exceeded the configured step budget'),
+      ]),
+    ).toMatchObject({
+      failure_category: 'empty_output',
+      failure_detail: 'empty_output',
+    });
+
+    // …while a fragment that corroborates *itself* still classifies, even when
+    // it arrives alongside the fallback.
+    expect(
+      classify('AGENT_EXECUTION_FAILED', EMPTY_OUTPUT_FALLBACK, [
+        errorEvent('AGENT_EXECUTION_FAILED', EMPTY_OUTPUT_FALLBACK),
+        errorEvent(
+          'AGENT_EXECUTION_FAILED',
+          'You exceeded your current quota, please check your plan and billing details.',
+        ),
+      ]),
+    ).toMatchObject({
+      failure_category: 'rate_limit',
+      failure_detail: 'hard_quota',
+      retryable: false,
+    });
+  });
+
   it('still treats a real quota exhaustion as a hard quota', () => {
     // The word `quota` alone must not be the trigger, but a corroborated quota
     // message still has to classify — otherwise this fix trades one silent

--- a/apps/daemon/tests/run-failure-classification.test.ts
+++ b/apps/daemon/tests/run-failure-classification.test.ts
@@ -353,6 +353,49 @@ describe('classifyRunFailure', () => {
     });
   });
 
+  // Refs #6143. The daemon's own generic empty-output fallback (server.ts) ends
+  // with "...then try re-authenticating the agent, checking quota, or switching
+  // models." `isHardQuotaText` used to carry a bare `quota` alternative, so the
+  // daemon read its own message back and concluded the user was out of quota.
+  //
+  // That is not cosmetic: run-retry-policy suppresses retries outright on
+  // `hard_quota`, which is why the reporter saw every third-party-API run fail
+  // permanently while the provider itself had quota left.
+  const EMPTY_OUTPUT_FALLBACK =
+    'Agent completed without producing any output. The model or provider may ' +
+    'have returned an empty response. Check the agent logs for upstream ' +
+    'errors, then try re-authenticating the agent, checking quota, or ' +
+    'switching models.';
+
+  it('does not read its own empty-output fallback as a hard quota', () => {
+    expect(classify('AGENT_EXECUTION_FAILED', EMPTY_OUTPUT_FALLBACK)).toMatchObject({
+      failure_category: 'empty_output',
+      failure_detail: 'empty_output',
+    });
+  });
+
+  it('still treats a real quota exhaustion as a hard quota', () => {
+    // The word `quota` alone must not be the trigger, but a corroborated quota
+    // message still has to classify — otherwise this fix trades one silent
+    // misclassification for another.
+    for (const text of [
+      'You exceeded your current quota, please check your plan and billing details.',
+      'Insufficient quota for the current billing period.',
+    ]) {
+      expect(classify('AGENT_EXECUTION_FAILED', text), text).toMatchObject({
+        failure_category: 'rate_limit',
+        failure_detail: 'hard_quota',
+        retryable: false,
+      });
+    }
+    // The Chinese vela pre-charge text has its own, more specific detail and
+    // must keep it — it is routed before the quota branch.
+    expect(classify('AGENT_EXECUTION_FAILED', '用户额度不足')).toMatchObject({
+      failure_detail: 'amr_insufficient_balance',
+      retryable: false,
+    });
+  });
+
   it('maps upstream failures to retry guidance', () => {
     expect(classify('UPSTREAM_UNAVAILABLE', 'HTTP 503 upstream unavailable')).toMatchObject({
       failure_category: 'upstream_unavailable',

--- a/apps/daemon/tests/run-failure-classification.test.ts
+++ b/apps/daemon/tests/run-failure-classification.test.ts
@@ -388,6 +388,29 @@ describe('classifyRunFailure', () => {
         retryable: false,
       });
     }
+    // Explicit exhaustion collocations must survive the corroboration rule.
+    // `quota exhausted` is a real upstream payload in this repo
+    // (tests/byok-tools.test.ts: `status_msg: 'quota exhausted'`), and dropping
+    // it would turn a terminal quota failure into a retry candidate — the exact
+    // inverse of the bug this PR fixes.
+    for (const text of [
+      'quota exhausted',
+      'quota exceeded',
+      'Quota depleted for this account.',
+      'You have exceeded your monthly quota.',
+      'HTTP 429: out of quota',
+    ]) {
+      expect(classify('AGENT_EXECUTION_FAILED', text), text).toMatchObject({
+        failure_detail: 'hard_quota',
+        retryable: false,
+      });
+      // With RATE_LIMITED the stakes are higher: without the phrase match this
+      // becomes a retryable rate_limit_429 and the suppression contract breaks.
+      expect(classify('RATE_LIMITED', text), `RATE_LIMITED ${text}`).toMatchObject({
+        failure_detail: 'hard_quota',
+        retryable: false,
+      });
+    }
     // The Chinese vela pre-charge text has its own, more specific detail and
     // must keep it — it is routed before the quota branch.
     expect(classify('AGENT_EXECUTION_FAILED', '用户额度不足')).toMatchObject({

--- a/apps/daemon/tests/runtimes/service-failure-classification.test.ts
+++ b/apps/daemon/tests/runtimes/service-failure-classification.test.ts
@@ -25,6 +25,37 @@ describe('classifyAgentServiceFailure', () => {
     }
   });
 
+  // Refs #6143. A bare `quota` alternative used to sit in the rate matcher, so
+  // this classifier reported the daemon's own generic empty-output fallback as
+  // a provider rate limit — on every surface that consumes it (chat error text,
+  // connection test, opencode log parsing, and `classifyRunFailure`).
+  it('does not treat a bare, uncorroborated `quota` mention as a rate limit', () => {
+    for (const text of [
+      // The daemon's fallback, verbatim (apps/daemon/src/server.ts).
+      'Agent completed without producing any output. The model or provider may ' +
+        'have returned an empty response. Check the agent logs for upstream ' +
+        'errors, then try re-authenticating the agent, checking quota, or ' +
+        'switching models.',
+      'Run `agent quota` to see current usage.',
+      'quota.ts:42 TypeError: cannot read properties of undefined',
+    ]) {
+      expect(classifyAgentServiceFailure(text), text).toBeNull();
+    }
+  });
+
+  it('still classifies quota mentions that are exhaustion phrases or corroborated', () => {
+    for (const text of [
+      'quota exhausted',
+      'quota exceeded',
+      'Quota depleted for this account.',
+      'You have exceeded your monthly quota.',
+      'Your plan has no quota left for this model.',
+      'Wallet quota unavailable — top up to continue.',
+    ]) {
+      expect(classifyAgentServiceFailure(text), text).toBe('RATE_LIMITED');
+    }
+  });
+
   it('classifies upstream/provider failures', () => {
     for (const text of [
       'Error: 529 {"type":"overloaded_error"}',


### PR DESCRIPTION
Refs #6143 — item (1) only, as scoped in [the thread](https://github.com/nexu-io/open-design/issues/6143).

## The misclassification is self-inflicted

`apps/daemon/src/server.ts` emits a generic fallback when a run produces no output:

> Agent completed without producing any output. … then try re-authenticating the agent, **checking quota**, or switching models.

`isHardQuotaText` carried a bare `quota` alternative, so it matched that sentence. And the quota branch is evaluated **before** `isEmptyOutputText`, so `empty_output` was unreachable for this text.

Downstream, `run-retry-policy.ts` does `if (failure?.failure_detail === 'hard_quota') return suppress('hard_quota')` — which is why the reporter saw it stick permanently rather than retry, on providers that had quota left. `inputTokens`/`outputTokens` being 0 with no upstream status line fits exactly.

## The fix follows a pattern already in this repo

`apps/daemon/src/integrations/vela-errors.ts` already gets this right — it requires a corroborating word:

```js
return value.includes('quota') && /\b(wallet|balance|credit|billing|funds?)\b/.test(value);
```

`isHardQuotaText` now does the same: `quota` on its own is not a signal, it needs one of wallet/balance/credits/billing/funds/payment/plan. Phrases that are unambiguous on their own keep matching directly — `session limit`, `usage limit`, `insufficient quota`, `exceeded your current quota`, `out of credits`, `DAILY_LIMIT_EXCEEDED`, and the Chinese vela pre-charge texts.

## Tests

Red-then-green in `apps/daemon/tests/run-failure-classification.test.ts`, feeding the **exact** `server.ts` fallback string:

- the fallback now lands on `empty_output` / `empty_output` (was `rate_limit` / `hard_quota`)
- corroborated quota messages still classify `hard_quota`, `retryable: false` — so this doesn't trade one silent misclassification for another
- `用户额度不足` keeps its more specific `amr_insufficient_balance` detail

`run-failure-classification.test.ts`: **102 passed**. `pnpm typecheck`: clean.

Full `@open-design/daemon` suite: 6104 passed, 10 failed — **all 10 pre-exist on unmodified `upstream/main`** (`tests/amr-session-resume.test.ts`, `tests/langfuse-trace.test.ts`; verified with a stash A/B on the same machine: 10 failed / 89 passed either way).

## Scope

Deliberately item (1) only. Items (2)/(3) from the thread (the BYOK path itself and the diagnostics wording) are untouched, so the issue should stay open. Happy to take the retest offer on `openai.mozhevip.top` once this is buildable.