### PR TITLE
fix(daemon): honor Kiro ACP turn completion

### DIFF
--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -78,6 +78,10 @@ export interface AttachAcpSessionOptions {
   stageTimeoutMs?: number;
   executionProfile?: ExecutionProfile;
   modelUnavailableErrorCode?: 'AMR_MODEL_UNAVAILABLE';
+  // Some ACP adapters expose an explicit `turn_end` session update as their
+  // terminal turn signal instead of returning the pending session/prompt RPC.
+  // Keep this opt-in so standard ACP adapters still require the response.
+  completePromptOnTurnEnd?: boolean;
   // When set, resume an existing upstream session instead of creating a new
   // one: the handshake sends `session/load { sessionId }` (the durable handle
   // captured from a prior run via `getDurableSessionId()`) rather than
@@ -131,6 +135,7 @@ export function attachAcpSession({
   stageTimeoutMs = DEFAULT_STAGE_TIMEOUT_MS,
   executionProfile = 'filesystem',
   modelUnavailableErrorCode,
+  completePromptOnTurnEnd = false,
   resumeSessionId,
   onCliReady,
   onSessionInit,
@@ -629,6 +634,14 @@ export function attachAcpSession({
           elapsedMs: Date.now() - runStartedAt,
         });
         emitAcpRawShapeDiagnostic(update);
+      }
+      if (
+        completePromptOnTurnEnd &&
+        promptRequestId !== null &&
+        update.sessionUpdate === 'turn_end'
+      ) {
+        finishCleanPrompt(update.usage);
+        return;
       }
       if (update.sessionUpdate === 'agent_thought_chunk') {
         emitAcpRawShapeDiagnostic(update);

--- a/apps/daemon/src/runtimes/defs/kiro.ts
+++ b/apps/daemon/src/runtimes/defs/kiro.ts
@@ -17,5 +17,6 @@ export const kiroAgentDef = {
     fallbackModels: [DEFAULT_MODEL_OPTION],
     buildArgs: () => ['acp'],
     streamFormat: 'acp-json-rpc',
+    acpTurnEndCompletesPrompt: true,
     externalMcpInjection: 'acp-merge',
 } satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -224,6 +224,9 @@ export type RuntimeAgentDef = {
   // default. Operators can still override per-process via
   // `OD_CHAT_RUN_INACTIVITY_TIMEOUT_MS` — that env wins.
   inactivityTimeoutMs?: number;
+  // Opt-in compatibility for ACP adapters that terminate a prompt with a
+  // `turn_end` session update rather than a session/prompt RPC response.
+  acpTurnEndCompletesPrompt?: boolean;
   // Declarative authentication probe. When set, detection spawns
   // `<bin> <args>` after the version check and classifies the combined
   // stdout/stderr to derive `authStatus`. This replaces the previous

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -7698,6 +7698,7 @@ export async function startServer({
         mcpServers,
         envFormat: def.acpMcpEnvFormat ?? 'array',
         executionProfile,
+        completePromptOnTurnEnd: def.acpTurnEndCompletesPrompt === true,
         ...(def.id === 'amr' ? { modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE' } : {}),
         // Resume the prior upstream session (drives `session/load`) when the
         // resume-identity guard says it is safe; otherwise a fresh session/new.

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -2059,6 +2059,37 @@ test('attachAcpSession does not double-kill a child that exits cleanly on stdin.
   }
 });
 
+test('attachAcpSession accepts an opted-in ACP turn_end update as prompt completion', () => {
+  const child = new FakeAcpChild();
+  const events: Array<{ event: string; payload: unknown }> = [];
+
+  const session = attachAcpSession({
+    child: child as never,
+    prompt: 'hello',
+    cwd: '/tmp/od-project',
+    model: null,
+    mcpServers: [],
+    completePromptOnTurnEnd: true,
+    send: (event, payload) => events.push({ event, payload }),
+  });
+
+  writeAcpResult(child, 1, {});
+  writeAcpResult(child, 2, { sessionId: 'session-1' });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'agent_message_chunk',
+    content: { type: 'text', text: 'done' },
+  });
+  writeAcpUpdate(child, {
+    sessionUpdate: 'turn_end',
+    usage: { inputTokens: 1, outputTokens: 1 },
+  });
+  child.emit('close', 0, null);
+
+  assert.equal(session.completedSuccessfully(), true);
+  assert.equal(session.hasFatalError(), false);
+  assert.equal(events.some((entry) => entry.event === 'error'), false);
+});
+
 test('attachAcpSession.completedSuccessfully reflects abort and fatal-error states', () => {
   const child = new FakeAcpChild();
 


### PR DESCRIPTION
Fixes #6265

## Why

The 0.16.1 reliability investigation found Kiro runs streaming valid assistant output and then being recorded as `agent_protocol_error`. Kiro exposes an explicit ACP `turn_end` update, but Open Design waited only for the pending `session/prompt` response; when Kiro closed without that response, the bridge converted a completed turn into a failure.

This keeps the compatibility rule adapter-scoped so other ACP agents retain the stricter standard response requirement.

## What users will see

Kiro runs that finish with Kiro's explicit `turn_end` signal complete successfully instead of ending with `ACP session exited before completion`.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is an agent-runtime lifecycle fix with no UI changes.

## Bug fix verification

- Test path: `apps/daemon/tests/acp.test.ts` (`attachAcpSession accepts an opted-in ACP turn_end update as prompt completion`)
- The test failed on `main` because the close path marked the session fatal, then passed on this branch.

## Validation

- `corepack pnpm --filter @open-design/daemon exec vitest run tests/acp.test.ts` (72 passed)
- `corepack pnpm guard`
- `corepack pnpm typecheck`
