### PR TITLE
fix(web): preserve Cloud sign-in during outages

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3572,6 +3572,7 @@ function AppInner() {
         defaultDesignSystemId={config.designSystemId}
         agents={agents}
         agentsLoading={agentsLoading}
+        amrLoggedIn={amrLoginStatus?.loggedIn ?? null}
         config={config}
         providerModelsCache={providerModelsCache}
         onProviderModelsCacheChange={setProviderModelsCache}

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -96,6 +96,7 @@ import { BrandsTab } from './BrandsTab';
 import { EntryNavRail, type EntryView as EntryViewKind } from './EntryNavRail';
 import { ProjectSearchModal } from './ProjectSearchModal';
 import { CloudSignInTip, RailAccountSyncTip } from './CloudSignInTip';
+import { resolveEntryRailAccountFooterState } from './entry-rail-account-state';
 import { LibrarySection } from './LibrarySection';
 import { UpdaterPopup } from './UpdaterPopup';
 import { WhatsNewPopup } from './WhatsNewPopup';
@@ -416,6 +417,10 @@ interface Props {
   // uses this to show the AMR cloud card in a detecting/skeleton state
   // instead of hiding it during the seconds AMR's probe takes to settle.
   agentsLoading?: boolean;
+  // Local credential state is independent from the remote workspace read.
+  // During a transient Cloud outage it prevents the rail from presenting a
+  // still-signed-in user as signed out.
+  amrLoggedIn?: boolean | null;
   daemonLive: boolean;
   onModeChange: (mode: ExecMode) => void;
   onAgentChange: (id: string) => void;
@@ -540,6 +545,7 @@ export function EntryShell({
   onProviderModelsCacheChange,
   agents,
   agentsLoading = false,
+  amrLoggedIn = null,
   daemonLive,
   onModeChange,
   onAgentChange,
@@ -586,6 +592,10 @@ export function EntryShell({
   // unresolved or unavailable authority into an anonymous, unbound create.
   const workspaceContextState = useWorkspaceContext();
   const { context: workspaceContext, loading: workspaceLoading } = workspaceContextState;
+  const accountFooterState = resolveEntryRailAccountFooterState(
+    workspaceContextState,
+    amrLoggedIn,
+  );
   const workspaceContextRef = useRef(workspaceContext);
   workspaceContextRef.current = workspaceContext;
   const workspaceBillingResponse = useWorkspaceBillingResponse();
@@ -1405,18 +1415,16 @@ export function EntryShell({
           onInvite={() => changeView('members')}
           onSignInCloud={() => navigate({ kind: 'home', view: 'onboarding' })}
           updaterSlot={updaterSlot}
-          // recvqgpXSYFNTq: `workspaceLoading` is only ever true while
-          // `workspaceContext` is null (see `useWorkspaceContext`'s
-          // `markLoading`, which promotes "no context" to "loading" and never
-          // touches an already-resolved context) — so this is the exact
-          // window between a just-finished sign-in and the re-read landing.
-          // Swap the callout for a same-slot loading state there instead of
-          // rendering nothing, which used to read as the rail silently
-          // forgetting the user just signed in.
+          // A loading or unavailable workspace read is not proof of sign-out.
+          // Keep the account slot neutral until Cloud answers successfully;
+          // only a successful null context (or known local sign-out) may show
+          // the sign-in card.
           footerNotice={
-            !workspaceContext ? (
-              workspaceLoading ? <RailAccountSyncTip /> : <CloudSignInTip />
-            ) : null
+            accountFooterState === 'syncing'
+              ? <RailAccountSyncTip />
+              : accountFooterState === 'sign-in'
+                ? <CloudSignInTip />
+                : null
           }
         />
         {projectSearchOpen ? (

--- a/apps/web/src/components/EntryView.tsx
+++ b/apps/web/src/components/EntryView.tsx
@@ -77,6 +77,7 @@ interface Props {
   // Forwarded to EntryShell → OnboardingView so the AMR cloud card can show a
   // detecting/skeleton state while the cold-start agent stream is in flight.
   agentsLoading?: boolean;
+  amrLoggedIn?: boolean | null;
   // Execution / model-switching context forwarded to the EntryShell so the
   // sticky top-bar can expose the active CLI/BYOK + model and persist
   // changes through the same channels as the project view.
@@ -247,6 +248,7 @@ export function EntryView({
   defaultDesignSystemId,
   agents,
   agentsLoading,
+  amrLoggedIn,
   config,
   providerModelsCache,
   onProviderModelsCacheChange,
@@ -374,6 +376,7 @@ export function EntryView({
       onProviderModelsCacheChange={onProviderModelsCacheChange}
       agents={agents}
       {...(agentsLoading !== undefined ? { agentsLoading } : {})}
+      {...(amrLoggedIn !== undefined ? { amrLoggedIn } : {})}
       daemonLive={daemonLive}
       onModeChange={onModeChange}
       onAgentChange={onAgentChange}

--- a/apps/web/src/components/entry-rail-account-state.ts
+++ b/apps/web/src/components/entry-rail-account-state.ts
@@ -1,0 +1,28 @@
+import type { WorkspaceContextState } from '../collab/useWorkspaceContext';
+
+export type EntryRailAccountFooterState = 'hidden' | 'syncing' | 'sign-in';
+
+/**
+ * Decide what the rail may claim about the Cloud account.
+ *
+ * A successful workspace response with `context: null` is authoritative:
+ * Cloud is reachable and says there is no active workspace identity, so the
+ * sign-in entry belongs on screen. A transient outage is not an identity
+ * answer. While Cloud is unreachable, keep the last resolved workspace (the
+ * hook does this when one exists) or show the neutral syncing placeholder for
+ * a locally signed-in/unknown account instead of falsely claiming sign-out.
+ */
+export function resolveEntryRailAccountFooterState(
+  workspaceState: WorkspaceContextState,
+  amrLoggedIn: boolean | null | undefined,
+): EntryRailAccountFooterState {
+  if (workspaceState.context) return 'hidden';
+  if (workspaceState.loading) return 'syncing';
+  if (
+    workspaceState.failure === 'unavailable'
+    && amrLoggedIn !== false
+  ) {
+    return 'syncing';
+  }
+  return 'sign-in';
+}

--- a/apps/web/tests/components/EntryShell.amr-workspace-race.test.tsx
+++ b/apps/web/tests/components/EntryShell.amr-workspace-race.test.tsx
@@ -115,6 +115,74 @@ describe('EntryShell AMR workspace precheck race', () => {
     resetTeamProjectsCache();
   });
 
+  it('keeps a locally signed-in account in syncing state while Cloud is unavailable', async () => {
+    window.history.replaceState(null, '', '/');
+    const contextFailure = deferred<Response>();
+    let contextReads = 0;
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/api/workspace/context')) {
+        contextReads += 1;
+        return contextFailure.promise;
+      }
+      if (url.endsWith('/api/plugins')) return jsonResponse({ plugins: [] });
+      if (url.endsWith('/api/mcp/servers')) return jsonResponse({ servers: [] });
+      if (url.endsWith('/api/community/discord')) return jsonResponse({ stale: true });
+      if (url.endsWith('/api/github/open-design')) return jsonResponse({ stale: true });
+      return jsonResponse({});
+    }) as typeof fetch;
+
+    render(
+      <I18nProvider initial="en">
+        <EntryShell
+          skills={[]}
+          designTemplates={[]}
+          designSystems={[]}
+          projects={[]}
+          templates={[]}
+          promptTemplates={[]}
+          defaultDesignSystemId={null}
+          connectors={[]}
+          connectorsLoading={false}
+          config={amrConfig()}
+          agents={[amrAgent()]}
+          amrLoggedIn
+          daemonLive
+          onModeChange={vi.fn()}
+          onAgentChange={vi.fn()}
+          onAgentModelChange={vi.fn()}
+          onApiProtocolChange={vi.fn()}
+          onApiModelChange={vi.fn()}
+          onConfigPersist={vi.fn()}
+          onRefreshAgents={vi.fn(() => [amrAgent()])}
+          onCreateProject={vi.fn()}
+          onCreatePluginShareProject={vi.fn()}
+          onImportClaudeDesign={vi.fn()}
+          onOpenProject={vi.fn()}
+          onOpenLiveArtifact={vi.fn()}
+          onDeleteProject={vi.fn()}
+          onRenameProject={vi.fn()}
+          onChangeDefaultDesignSystem={vi.fn()}
+          onPersistComposioKey={vi.fn()}
+          onOpenSettings={vi.fn()}
+          onCompleteOnboarding={vi.fn()}
+        />
+      </I18nProvider>,
+    );
+
+    expect(await screen.findByTestId('entry-rail-account-sync-tip')).toBeTruthy();
+    expect(contextReads).toBe(1);
+
+    await act(async () => {
+      contextFailure.resolve(new Response(null, { status: 503 }));
+      await contextFailure.promise;
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByTestId('entry-cloud-signin-tip')).toBeNull();
+    expect(screen.getByTestId('entry-rail-account-sync-tip')).toBeTruthy();
+  });
+
   it('rechecks workspace B when the workspace switches after workspace A passes the gate', async () => {
     window.history.replaceState(null, '', '/');
     const workspaceA = teamContext('workspace-a', 'member-a');

--- a/apps/web/tests/components/entry-rail-account-state.test.ts
+++ b/apps/web/tests/components/entry-rail-account-state.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  resolveEntryRailAccountFooterState,
+} from '../../src/components/entry-rail-account-state';
+import type { WorkspaceContextState } from '../../src/collab/useWorkspaceContext';
+
+const SIGNED_IN_CONTEXT = {
+  workspaceId: 'workspace-1',
+} as WorkspaceContextState['context'];
+
+describe('resolveEntryRailAccountFooterState', () => {
+  it('keeps the resolved account row when a workspace context exists', () => {
+    expect(resolveEntryRailAccountFooterState({
+      context: SIGNED_IN_CONTEXT,
+      loading: false,
+      failure: 'unavailable',
+    }, true)).toBe('hidden');
+  });
+
+  it('shows the neutral syncing state while the workspace identity is loading', () => {
+    expect(resolveEntryRailAccountFooterState({
+      context: null,
+      loading: true,
+    }, null)).toBe('syncing');
+  });
+
+  it.each([true, null] as const)(
+    'does not claim sign-out during an outage when local login is %s',
+    (amrLoggedIn) => {
+      expect(resolveEntryRailAccountFooterState({
+        context: null,
+        loading: false,
+        failure: 'unavailable',
+      }, amrLoggedIn)).toBe('syncing');
+    },
+  );
+
+  it('still offers sign-in during an outage after an explicit local logout', () => {
+    expect(resolveEntryRailAccountFooterState({
+      context: null,
+      loading: false,
+      failure: 'unavailable',
+    }, false)).toBe('sign-in');
+  });
+
+  it('accepts the next successful null response as authoritative sign-out', () => {
+    expect(resolveEntryRailAccountFooterState({
+      context: null,
+      loading: false,
+    }, true)).toBe('sign-in');
+  });
+
+  it('preserves the legacy unsupported-daemon behavior', () => {
+    expect(resolveEntryRailAccountFooterState({
+      context: null,
+      loading: false,
+      failure: 'unsupported',
+    }, true)).toBe('sign-in');
+  });
+});


### PR DESCRIPTION
## Why

While dogfooding the Beta desktop client, a transient timeout from the Cloud workspace API made the home rail show the Open Design Cloud sign-in card even though the local Vela credential was still present. The account had not actually signed out; the UI was collapsing "workspace identity temporarily unavailable" into "signed out."

This was especially confusing on weak or tunneled networks because the sign-in card could appear shortly after launch and disappear again once the next workspace poll succeeded, making Cloud login look unreliable.

## What users will see

When the Cloud workspace request times out or returns a transient availability error, signed-in users keep their existing account row. If the app has not resolved the workspace details yet, the same account slot shows its neutral syncing placeholder instead of asking the user to sign in again.

The app continues its existing background retries. A successful response restores the real workspace row; the sign-in card only returns after a successful response explicitly reports no workspace identity, or after the user signs out locally.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

The visible change is limited to a transient failure state: the existing account-row syncing placeholder remains in place instead of being replaced by the Cloud sign-in card. The red/green component regression below captures that exact swap deterministically.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/EntryShell.amr-workspace-race.test.tsx`
- Did the test go red on the target branch and green on this branch? **Yes.** With the previous footer condition restored, the test failed because `entry-cloud-signin-tip` appeared after the 503 response. With this change, the syncing account slot remains and the test passes.
- The pure state projection is additionally covered by `apps/web/tests/components/entry-rail-account-state.test.ts`.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts --maxWorkers=2 tests/components/EntryShell.amr-workspace-race.test.tsx tests/components/entry-rail-account-state.test.ts tests/useWorkspaceContext.sign-in-refresh.test.tsx tests/components/CloudSignInTip.test.tsx` — 4 files, 19 tests passed
- `pnpm guard` — passed
- `git diff --check` — passed
- `pnpm --filter @open-design/web typecheck` — target-branch baseline failure remains at `apps/web/src/components/EntryNavRail.tsx:761` (`WorkspaceCollabContext.workspaceName` is missing from the current contract type); this PR does not touch that file or contract
