### PR TITLE
fix(landing): accept signed Vela team plan leads

### DIFF
--- a/apps/landing-page/app/_components/enterprise-lead-form.astro
+++ b/apps/landing-page/app/_components/enterprise-lead-form.astro
@@ -492,7 +492,7 @@ const countryOptions = buildCountryOptions(locale);
 
       const data = new FormData(form);
       // The country select's value is the ISO code; submit the localized
-      // label plus the code (e.g. "中国 (CN)") so the Feishu lead card stays
+      // label plus the code (e.g. "中国 (CN)") so the canonical KV lead stays
       // readable while analytics keep the canonical code.
       const countrySel = fieldInput('country');
       const countryCode = countrySel ? countrySel.value : '';

--- a/apps/landing-page/app/pages/enterprise/index.astro
+++ b/apps/landing-page/app/pages/enterprise/index.astro
@@ -7,9 +7,9 @@
  * edition. Left column: pitch + perks; right column: the shared lead form
  * (`_components/enterprise-lead-form.astro`, copy in
  * `_lib/enterprise-lead-copy.ts`) that POSTs to the `/contact-sales` Pages
- * Function, which fans the lead out to Feishu. The /pricing "Request team
- * access" modal renders the same component, so form changes land on both
- * surfaces at once.
+ * Function, which validates and stores the canonical lead in KV. The /pricing
+ * "Request team access" modal renders the same component, so form changes land
+ * on both surfaces at once.
  *
  * Light Atelier Zero styling in lockstep with the rest of the marketing site
  * (the reference screenshot was dark; we keep the same two-column layout but

--- a/apps/landing-page/functions/contact-sales.ts
+++ b/apps/landing-page/functions/contact-sales.ts
@@ -2,32 +2,48 @@
  * /contact-sales — Workspace-for-Teams lead intake.
  *
  * The /enterprise/ page and the /pricing/ "Request team access" modal (both
- * rendering the shared lead form) POST a lead here; we validate it, fan it out to a
- * Feishu (Lark) custom-bot webhook so the team gets a real-time card, and keep
- * a KV backup so a Feishu outage never silently drops a lead. Mirrors the
- * shape and safety posture of `subscribe.ts` (CORS allowlist, no PII in
- * provider logs, idempotent KV key, delivery on `waitUntil`).
+ * rendering the shared lead form) POST a lead here; Vela also relays signed
+ * Team-plan leads server-to-server. We validate each lead, synchronously persist
+ * it to KV, and fan it out to a Feishu (Lark) custom-bot webhook. Failed Feishu
+ * deliveries remain retryable in KV so an outage never silently drops a lead.
+ * Mirrors the safety posture of `subscribe.ts` (CORS allowlist, no PII in
+ * provider logs, idempotent KV keys, notification delivery on `waitUntil`).
  *
  * Config (Cloudflare Pages env):
  * - FEISHU_CONTACT_WEBHOOK  custom-bot incoming webhook URL (required to notify)
  * - FEISHU_CONTACT_SECRET   optional bot signing secret (set if the bot enforces
  *                           signature verification)
- * - CONTACT_LEADS           optional KV namespace for the durable backup
+ * - CONTACT_SALES_SERVICE_SECRET
+ *                           HMAC secret shared only with trusted Vela callers
+ * - CONTACT_LEADS           required KV namespace for durable acknowledgement
+ *                           and retry state
  */
 type KVNamespace = {
-  put(key: string, value: string): Promise<void>;
   get(key: string): Promise<string | null>;
+  list?(options?: {
+    cursor?: string;
+    limit?: number;
+    prefix?: string;
+  }): Promise<{
+    cursor?: string;
+    keys: Array<{ name: string }>;
+    list_complete: boolean;
+  }>;
+  put(key: string, value: string): Promise<void>;
 };
 
 type PagesFunctionContext<Env> = {
   request: Request & { cf?: Record<string, unknown> };
   env: Env;
   waitUntil(promise: Promise<unknown>): void;
+  /** Test seam; Cloudflare does not provide this field. */
+  now?: () => number;
 };
 
 type PagesFunction<Env> = (context: PagesFunctionContext<Env>) => Response | Promise<Response>;
 
 interface Env {
+  CONTACT_SALES_SERVICE_SECRET?: string;
   CONTACT_LEADS?: KVNamespace;
   FEISHU_CONTACT_WEBHOOK?: string;
   FEISHU_CONTACT_SECRET?: string;
@@ -53,8 +69,25 @@ type ContactLead = {
   pageUrl: string;
   submittedAt: string;
   referer: string | null;
+  billingInterval?: "monthly" | "yearly";
   country?: string;
   region?: string;
+};
+
+type ContactDeliveryStatus =
+  | "dead_letter"
+  | "delivered"
+  | "pending"
+  | "retry";
+
+type ContactDeliveryRecord = {
+  eventId: string;
+  lead: ContactLead;
+  status: ContactDeliveryStatus;
+  attempt: number;
+  nextAttemptAt: string | null;
+  lastError: string | null;
+  updatedAt: string;
 };
 
 const ALLOWED_ORIGINS = [
@@ -84,8 +117,23 @@ const MAX_MESSAGE = 4000;
 // (app/_components/enterprise-lead-form.astro) and submit the same strict
 // contract; only the source differs for attribution. `client` = in-app
 // (reserved; keeps the pre-industry contract with a required name).
-const ALLOWED_SOURCES = new Set(["enterprise", "pricing_team", "client"]);
-const SHARED_LEAD_FORM_SOURCES = new Set(["enterprise", "pricing_team"]);
+const VELA_TEAM_PLAN_SOURCE = "vela_team_plan";
+const ALLOWED_SOURCES = new Set([
+  "enterprise",
+  "pricing_team",
+  "client",
+  VELA_TEAM_PLAN_SOURCE,
+]);
+const SHARED_LEAD_FORM_SOURCES = new Set([
+  "enterprise",
+  "pricing_team",
+  VELA_TEAM_PLAN_SOURCE,
+]);
+const CONTACT_DELIVERY_PREFIX = "contact-delivery:";
+const SERVICE_SIGNATURE_MAX_AGE_MS = 5 * 60 * 1000;
+const DELIVERY_ATTEMPTS_PER_INVOCATION = 3;
+const DELIVERY_MAX_ATTEMPTS = 9;
+const DELIVERY_RETRY_DELAY_MS = 60 * 1000;
 const ALLOWED_TEAM_SIZES = new Set(["1-10", "11-50", "51-200", "200+"]);
 const ALLOWED_BUDGETS = new Set([
   "lt_50",
@@ -228,6 +276,71 @@ async function sha256Hex(value: string): Promise<string> {
   return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
+function base64UrlToBytes(value: string): Uint8Array | null {
+  if (!/^[A-Za-z0-9_-]+$/u.test(value)) return null;
+  const base64 = value.replace(/-/gu, "+").replace(/_/gu, "/");
+  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
+  try {
+    return Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
+  } catch {
+    return null;
+  }
+}
+
+async function verifyServiceSignature(options: {
+  eventId: string;
+  nowMs: number;
+  rawBody: string;
+  request: Request;
+  secret: string;
+}): Promise<
+  | "service_auth_expired"
+  | "service_auth_invalid"
+  | "service_auth_required"
+  | null
+> {
+  const timestampValue = options.request.headers.get("x-od-service-timestamp");
+  const headerEventId = options.request.headers.get("x-od-service-event-id");
+  const signatureValue = options.request.headers.get("x-od-service-signature");
+  if (!timestampValue || !headerEventId || !signatureValue) {
+    return "service_auth_required";
+  }
+  if (
+    headerEventId !== options.eventId ||
+    !/^[A-Za-z0-9._:-]{1,200}$/u.test(headerEventId) ||
+    !/^\d{13}$/u.test(timestampValue)
+  ) {
+    return "service_auth_invalid";
+  }
+  const timestamp = Number(timestampValue);
+  if (
+    !Number.isSafeInteger(timestamp) ||
+    Math.abs(options.nowMs - timestamp) > SERVICE_SIGNATURE_MAX_AGE_MS
+  ) {
+    return "service_auth_expired";
+  }
+
+  const signature = base64UrlToBytes(signatureValue);
+  if (!signature) return "service_auth_invalid";
+  const bodyDigest = await sha256Hex(options.rawBody);
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(options.secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["verify"],
+  );
+  const valid = await crypto.subtle.verify(
+    "HMAC",
+    key,
+    new Uint8Array(signature).buffer,
+    new TextEncoder().encode(
+      `${timestampValue}\n${headerEventId}\n${bodyDigest}`,
+    ),
+  );
+  return valid ? null : "service_auth_invalid";
+}
+
 function bytesToBase64(bytes: Uint8Array): string {
   let binary = "";
   for (const byte of bytes) binary += String.fromCharCode(byte);
@@ -316,11 +429,27 @@ function buildFeishuCard(lead: ContactLead): Record<string, unknown> {
   };
 }
 
-async function notifyFeishu(env: Env, lead: ContactLead): Promise<void> {
+type DeliveryErrorCode =
+  | "feishu_http_failed"
+  | "feishu_rejected"
+  | "feishu_request_failed"
+  | "feishu_unconfigured";
+
+type DeliveryAttemptResult =
+  | { ok: true }
+  | {
+      error: DeliveryErrorCode;
+      ok: false;
+    };
+
+async function notifyFeishu(
+  env: Env,
+  lead: ContactLead,
+): Promise<DeliveryAttemptResult> {
   const webhook = env.FEISHU_CONTACT_WEBHOOK?.trim();
   if (!webhook) {
     console.warn("contact_sales_feishu_unset: FEISHU_CONTACT_WEBHOOK missing; KV only");
-    return;
+    return { ok: false, error: "feishu_unconfigured" };
   }
 
   const body: Record<string, unknown> = {
@@ -343,41 +472,223 @@ async function notifyFeishu(env: Env, lead: ContactLead): Promise<void> {
     });
     if (!res.ok) {
       console.warn("contact_sales_feishu_failed", JSON.stringify({ status: res.status }));
-      return;
+      return { ok: false, error: "feishu_http_failed" };
     }
     // Feishu returns 200 with a JSON body even on logical failure (e.g. bad sign).
-    const data = (await res.json().catch(() => ({}))) as { code?: unknown };
-    if (typeof data.code === "number" && data.code !== 0) {
-      console.warn("contact_sales_feishu_rejected", JSON.stringify({ code: data.code }));
+    const data = (await res.json().catch(() => null)) as {
+      code?: unknown;
+    } | null;
+    if (!data || data.code !== 0) {
+      console.warn(
+        "contact_sales_feishu_rejected",
+        JSON.stringify({
+          code: typeof data?.code === "number" ? data.code : "invalid",
+        }),
+      );
+      return { ok: false, error: "feishu_rejected" };
     }
+    return { ok: true };
   } catch {
     console.warn("contact_sales_feishu_request_failed");
+    return { ok: false, error: "feishu_request_failed" };
   }
 }
 
-async function persistLead(env: Env, lead: ContactLead): Promise<void> {
-  if (env.CONTACT_LEADS) {
-    // Latest submission per email wins; keeps the namespace from growing
-    // unbounded on repeat submits while preserving the freshest details.
-    const key = `lead:${await sha256Hex(lead.email)}`;
-    try {
-      await env.CONTACT_LEADS.put(key, JSON.stringify(lead));
-    } catch {
-      console.warn("contact_sales_kv_write_failed");
+class ContactSalesPersistenceError extends Error {
+  readonly code: "lead_storage_failed" | "lead_storage_unavailable";
+
+  constructor(code: "lead_storage_failed" | "lead_storage_unavailable") {
+    super(code);
+    this.name = "ContactSalesPersistenceError";
+    this.code = code;
+  }
+}
+
+function deliveryKey(eventId: string): string {
+  return `${CONTACT_DELIVERY_PREFIX}${eventId}`;
+}
+
+function parseDeliveryRecord(value: string | null): ContactDeliveryRecord | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as Partial<ContactDeliveryRecord>;
+    if (
+      typeof parsed.eventId !== "string" ||
+      typeof parsed.attempt !== "number" ||
+      typeof parsed.status !== "string" ||
+      !parsed.lead
+    ) {
+      return null;
     }
-  } else {
+    return parsed as ContactDeliveryRecord;
+  } catch {
+    return null;
+  }
+}
+
+async function persistLead(
+  env: Env,
+  lead: ContactLead,
+  eventId: string,
+  nowMs: number,
+): Promise<{
+  duplicate: boolean;
+  key: string;
+  record: ContactDeliveryRecord;
+}> {
+  const kv = env.CONTACT_LEADS;
+  if (!kv) {
     console.warn(
       "contact_sales_kv_unbound: CONTACT_LEADS binding missing; lead not persisted",
       JSON.stringify({ source: lead.source, country: lead.country }),
     );
+    throw new ContactSalesPersistenceError("lead_storage_unavailable");
   }
 
-  await notifyFeishu(env, lead);
+  const key = deliveryKey(eventId);
+  try {
+    const existing = parseDeliveryRecord(await kv.get(key));
+    if (existing?.eventId === eventId) {
+      return { duplicate: true, key, record: existing };
+    }
+
+    const nowIso = new Date(nowMs).toISOString();
+    const record: ContactDeliveryRecord = {
+      eventId,
+      lead,
+      status: "pending",
+      attempt: 0,
+      nextAttemptAt: null,
+      lastError: null,
+      updatedAt: nowIso,
+    };
+    // Latest submission per email remains the operational backup. The
+    // event-scoped record is the durable delivery state and idempotency key.
+    const leadKey = `lead:${await sha256Hex(lead.email)}`;
+    await Promise.all([
+      kv.put(leadKey, JSON.stringify(lead)),
+      kv.put(key, JSON.stringify(record)),
+    ]);
+    return { duplicate: false, key, record };
+  } catch (error) {
+    if (error instanceof ContactSalesPersistenceError) throw error;
+    console.warn("contact_sales_kv_write_failed");
+    throw new ContactSalesPersistenceError("lead_storage_failed");
+  }
+}
+
+function retryIsDue(record: ContactDeliveryRecord, nowMs: number): boolean {
+  if (record.status === "pending") return true;
+  if (record.status !== "retry" || !record.nextAttemptAt) return false;
+  const nextAttemptAt = Date.parse(record.nextAttemptAt);
+  return Number.isFinite(nextAttemptAt) && nextAttemptAt <= nowMs;
+}
+
+function wait(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function deliverRecord(
+  env: Env,
+  kv: KVNamespace,
+  record: ContactDeliveryRecord,
+  nowMs: number,
+): Promise<void> {
+  if (
+    record.status === "delivered" ||
+    record.status === "dead_letter" ||
+    !retryIsDue(record, nowMs)
+  ) {
+    return;
+  }
+
+  let attempt = record.attempt;
+  let lastError: DeliveryErrorCode = "feishu_request_failed";
+  for (
+    let invocationAttempt = 0;
+    invocationAttempt < DELIVERY_ATTEMPTS_PER_INVOCATION &&
+    attempt < DELIVERY_MAX_ATTEMPTS;
+    invocationAttempt += 1
+  ) {
+    attempt += 1;
+    const result = await notifyFeishu(env, record.lead);
+    if (result.ok) {
+      await kv.put(
+        deliveryKey(record.eventId),
+        JSON.stringify({
+          ...record,
+          status: "delivered",
+          attempt,
+          nextAttemptAt: null,
+          lastError: null,
+          updatedAt: new Date(nowMs).toISOString(),
+        } satisfies ContactDeliveryRecord),
+      );
+      return;
+    }
+    if (!("error" in result)) continue;
+    lastError = result.error;
+    // Missing configuration cannot recover within this invocation. Persist it
+    // immediately so operations can repair the binding without losing the lead.
+    if (result.error === "feishu_unconfigured") break;
+    if (
+      invocationAttempt + 1 < DELIVERY_ATTEMPTS_PER_INVOCATION &&
+      attempt < DELIVERY_MAX_ATTEMPTS
+    ) {
+      await wait(invocationAttempt === 0 ? 250 : 1_000);
+    }
+  }
+
+  const exhausted = attempt >= DELIVERY_MAX_ATTEMPTS;
+  await kv.put(
+    deliveryKey(record.eventId),
+    JSON.stringify({
+      ...record,
+      status: exhausted ? "dead_letter" : "retry",
+      attempt,
+      nextAttemptAt: exhausted
+        ? null
+        : new Date(nowMs + DELIVERY_RETRY_DELAY_MS).toISOString(),
+      lastError,
+      updatedAt: new Date(nowMs).toISOString(),
+    } satisfies ContactDeliveryRecord),
+  );
+  console.warn(
+    exhausted
+      ? "contact_sales_delivery_dead_lettered"
+      : "contact_sales_delivery_retry_scheduled",
+    JSON.stringify({ attempt, error: lastError, eventId: record.eventId }),
+  );
+}
+
+async function drainDueDeliveries(
+  env: Env,
+  nowMs: number,
+  excludedKey: string,
+): Promise<void> {
+  const kv = env.CONTACT_LEADS;
+  if (!kv?.list) return;
+  try {
+    const result = await kv.list({
+      limit: 10,
+      prefix: CONTACT_DELIVERY_PREFIX,
+    });
+    for (const item of result.keys) {
+      if (item.name === excludedKey) continue;
+      const record = parseDeliveryRecord(await kv.get(item.name));
+      if (record && retryIsDue(record, nowMs)) {
+        await deliverRecord(env, kv, record, nowMs);
+      }
+    }
+  } catch {
+    console.warn("contact_sales_retry_drain_failed");
+  }
 }
 
 export const onRequest: PagesFunction<Env> = async (context) => {
   const request = context.request;
   const origin = request.headers.get("origin");
+  const nowMs = context.now?.() ?? Date.now();
 
   if (request.method === "OPTIONS") {
     return new Response(null, { status: 204, headers: corsHeaders(origin) });
@@ -386,9 +697,15 @@ export const onRequest: PagesFunction<Env> = async (context) => {
     return json({ ok: false, error: "method_not_allowed" }, 405, origin);
   }
 
+  let rawBody: string;
   let payload: Record<string, unknown>;
   try {
-    payload = (await request.json()) as Record<string, unknown>;
+    rawBody = await request.text();
+    const parsed = JSON.parse(rawBody) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("invalid JSON object");
+    }
+    payload = parsed as Record<string, unknown>;
   } catch {
     return json({ ok: false, error: "invalid_json" }, 400, origin);
   }
@@ -409,6 +726,32 @@ export const onRequest: PagesFunction<Env> = async (context) => {
     return json({ ok: false, error: "invalid_source" }, 400, origin);
   }
 
+  let serviceEventId: string | null = null;
+  if (source === VELA_TEAM_PLAN_SOURCE) {
+    serviceEventId = readString(payload.eventId, 200);
+    const serviceSecret = context.env.CONTACT_SALES_SERVICE_SECRET?.trim();
+    if (!serviceSecret) {
+      console.warn(
+        "contact_sales_service_auth_unconfigured: CONTACT_SALES_SERVICE_SECRET missing",
+      );
+      return json(
+        { ok: false, error: "service_auth_unavailable" },
+        503,
+        origin,
+      );
+    }
+    const authError = await verifyServiceSignature({
+      eventId: serviceEventId,
+      nowMs,
+      rawBody,
+      request,
+      secret: serviceSecret,
+    });
+    if (authError) {
+      return json({ ok: false, error: authError }, 401, origin);
+    }
+  }
+
   // The shared lead form (enterprise + pricing_team) no longer asks for a
   // name (email is the contact handle); every other source still requires one.
   const isSharedLeadForm = SHARED_LEAD_FORM_SOURCES.has(source);
@@ -421,8 +764,15 @@ export const onRequest: PagesFunction<Env> = async (context) => {
   const teamSize = readString(payload.teamSize, MAX_SHORT);
   const budget = readString(payload.budget, MAX_SHORT);
   const seats = readString(payload.seats, MAX_SHORT);
-  const location = readString(payload.location, MAX_SHORT);
-  const useCases = readUseCases(payload.useCases);
+  const location =
+    readString(payload.location, MAX_SHORT) ||
+    (source === VELA_TEAM_PLAN_SOURCE
+      ? readString(payload.country, MAX_SHORT)
+      : "");
+  const useCases =
+    source === VELA_TEAM_PLAN_SOURCE
+      ? readUseCases([payload.useCase])
+      : readUseCases(payload.useCases);
   // Unknown industry codes are dropped rather than persisted; the shared lead
   // form requires a known one below.
   const industryRaw = readString(payload.industry, MAX_SHORT);
@@ -449,6 +799,11 @@ export const onRequest: PagesFunction<Env> = async (context) => {
   }
 
   const cf = request.cf || {};
+  const billingInterval =
+    payload.billingInterval === "monthly" ||
+    payload.billingInterval === "yearly"
+      ? payload.billingInterval
+      : undefined;
   const lead: ContactLead = {
     name,
     email,
@@ -464,19 +819,61 @@ export const onRequest: PagesFunction<Env> = async (context) => {
     source,
     locale: readString(payload.locale, 16) || "en",
     pageUrl: readString(payload.pageUrl, 512),
-    submittedAt: new Date().toISOString(),
+    submittedAt: new Date(nowMs).toISOString(),
     referer: request.headers.get("referer"),
+    billingInterval,
     country: typeof cf.country === "string" ? cf.country : undefined,
     region: typeof cf.region === "string" ? cf.region : undefined,
   };
 
-  context.waitUntil(persistLead(context.env, lead));
+  const eventId =
+    serviceEventId ||
+    (await sha256Hex(
+      `${lead.source}:${lead.email}:${lead.submittedAt}:${rawBody}`,
+    ));
+  let persisted: Awaited<ReturnType<typeof persistLead>>;
+  try {
+    persisted = await persistLead(context.env, lead, eventId, nowMs);
+  } catch (error) {
+    const code =
+      error instanceof ContactSalesPersistenceError
+        ? error.code
+        : "lead_storage_failed";
+    return json({ ok: false, error: code }, 503, origin);
+  }
 
-  return json({ ok: true }, 200, origin);
+  const kv = context.env.CONTACT_LEADS;
+  if (!kv) {
+    // persistLead fails closed when unbound. This guard only keeps the type
+    // refinement explicit for the background delivery task.
+    return json(
+      { ok: false, error: "lead_storage_unavailable" },
+      503,
+      origin,
+    );
+  }
+  context.waitUntil(
+    Promise.all([
+      retryIsDue(persisted.record, nowMs)
+        ? deliverRecord(context.env, kv, persisted.record, nowMs)
+        : Promise.resolve(),
+      drainDueDeliveries(context.env, nowMs, persisted.key),
+    ]),
+  );
+
+  return json(
+    {
+      ok: true,
+      ...(persisted.duplicate ? { duplicate: true } : {}),
+    },
+    200,
+    origin,
+  );
 };
 
 export const __contactSalesTest = {
   corsHeaders,
   buildFeishuCard,
   feishuSignature,
+  verifyServiceSignature,
 };

--- a/apps/landing-page/functions/contact-sales.ts
+++ b/apps/landing-page/functions/contact-sales.ts
@@ -1,53 +1,41 @@
 /*
- * /contact-sales — Workspace-for-Teams lead intake.
+ * /contact-sales — canonical Workspace-for-Teams lead intake.
  *
- * The /enterprise/ page and the /pricing/ "Request team access" modal (both
- * rendering the shared lead form) POST a lead here; Vela also relays signed
- * Team-plan leads server-to-server. We validate each lead, synchronously persist
- * it to KV, and fan it out to a Feishu (Lark) custom-bot webhook. Failed Feishu
- * deliveries remain retryable in KV so an outage never silently drops a lead.
- * Mirrors the safety posture of `subscribe.ts` (CORS allowlist, no PII in
- * provider logs, idempotent KV keys, notification delivery on `waitUntil`).
+ * The /enterprise and /pricing forms submit here from the same origin. Vela
+ * relays Team-plan leads server-to-server with an HMAC signature over the raw
+ * request body. After validation, this function performs exactly one write to
+ * CONTACT_LEADS using lead:<sha256(normalized email)>; a newer submission from
+ * the same email intentionally replaces the previous value. Downstream systems
+ * poll that KV namespace, so this boundary has no outbound notification or
+ * delivery-outbox responsibility.
  *
- * Config (Cloudflare Pages env):
- * - FEISHU_CONTACT_WEBHOOK  custom-bot incoming webhook URL (required to notify)
- * - FEISHU_CONTACT_SECRET   optional bot signing secret (set if the bot enforces
- *                           signature verification)
- * - CONTACT_SALES_SERVICE_SECRET
- *                           HMAC secret shared only with trusted Vela callers
- * - CONTACT_LEADS           required KV namespace for durable acknowledgement
- *                           and retry state
+ * Cloudflare Pages configuration:
+ * - CONTACT_LEADS is a required KV binding. Production and staging use the
+ *   distinct namespace IDs declared in their respective Wrangler files.
+ * - CONTACT_SALES_SERVICE_SECRET is an encrypted secret shared only with Vela.
+ *   Configure it independently on both Pages projects; never commit its value.
  */
 type KVNamespace = {
-  get(key: string): Promise<string | null>;
-  list?(options?: {
-    cursor?: string;
-    limit?: number;
-    prefix?: string;
-  }): Promise<{
-    cursor?: string;
-    keys: Array<{ name: string }>;
-    list_complete: boolean;
-  }>;
   put(key: string, value: string): Promise<void>;
 };
 
 type PagesFunctionContext<Env> = {
   request: Request & { cf?: Record<string, unknown> };
   env: Env;
-  waitUntil(promise: Promise<unknown>): void;
   /** Test seam; Cloudflare does not provide this field. */
   now?: () => number;
 };
 
-type PagesFunction<Env> = (context: PagesFunctionContext<Env>) => Response | Promise<Response>;
+type PagesFunction<Env> = (
+  context: PagesFunctionContext<Env>,
+) => Response | Promise<Response>;
 
 interface Env {
   CONTACT_SALES_SERVICE_SECRET?: string;
   CONTACT_LEADS?: KVNamespace;
-  FEISHU_CONTACT_WEBHOOK?: string;
-  FEISHU_CONTACT_SECRET?: string;
 }
+
+type ContactSource = "enterprise" | "pricing_team" | "vela_team_plan";
 
 type ContactLead = {
   name: string;
@@ -61,44 +49,19 @@ type ContactLead = {
   role: string;
   /** User-entered country / region (distinct from the Cloudflare geo below). */
   location: string;
-  /** Expected seat count (free text, e.g. "20"). */
   seats: string;
   message: string;
-  source: string;
+  source: ContactSource;
   locale: string;
   pageUrl: string;
   submittedAt: string;
   referer: string | null;
+  /** Stable Vela event identifier, present only for server-relayed leads. */
+  eventId?: string;
   billingInterval?: "monthly" | "yearly";
   country?: string;
   region?: string;
 };
-
-type ContactDeliveryStatus =
-  | "dead_letter"
-  | "delivered"
-  | "pending"
-  | "retry";
-
-type ContactDeliveryRecord = {
-  eventId: string;
-  lead: ContactLead;
-  status: ContactDeliveryStatus;
-  attempt: number;
-  nextAttemptAt: string | null;
-  lastError: string | null;
-  updatedAt: string;
-};
-
-const ALLOWED_ORIGINS = [
-  "https://open-design.ai",
-  "https://www.open-design.ai",
-  "https://staging.open-design.ai",
-  "od://app",
-  "tauri://localhost",
-  "http://localhost",
-  "http://127.0.0.1",
-];
 
 // Strict shape, not the loose "no whitespace, one @, a dot" check: the 07-11
 // SQLi scan submitted payloads like `testing@example.com'||dbms_pipe...` that
@@ -112,28 +75,13 @@ const EMAIL_RE =
 const MAX_EMAIL_LENGTH = 254;
 const MAX_SHORT = 200;
 const MAX_MESSAGE = 4000;
-// `enterprise` = the /enterprise page and `pricing_team` = the /pricing
-// "Request team access" modal — both render the same shared lead form
-// (app/_components/enterprise-lead-form.astro) and submit the same strict
-// contract; only the source differs for attribution. `client` = in-app
-// (reserved; keeps the pre-industry contract with a required name).
 const VELA_TEAM_PLAN_SOURCE = "vela_team_plan";
-const ALLOWED_SOURCES = new Set([
-  "enterprise",
-  "pricing_team",
-  "client",
-  VELA_TEAM_PLAN_SOURCE,
-]);
-const SHARED_LEAD_FORM_SOURCES = new Set([
+const ALLOWED_SOURCES = new Set<ContactSource>([
   "enterprise",
   "pricing_team",
   VELA_TEAM_PLAN_SOURCE,
 ]);
-const CONTACT_DELIVERY_PREFIX = "contact-delivery:";
 const SERVICE_SIGNATURE_MAX_AGE_MS = 5 * 60 * 1000;
-const DELIVERY_ATTEMPTS_PER_INVOCATION = 3;
-const DELIVERY_MAX_ATTEMPTS = 9;
-const DELIVERY_RETRY_DELAY_MS = 60 * 1000;
 const ALLOWED_TEAM_SIZES = new Set(["1-10", "11-50", "51-200", "200+"]);
 const ALLOWED_BUDGETS = new Set([
   "lt_50",
@@ -143,25 +91,6 @@ const ALLOWED_BUDGETS = new Set([
   "usd_5k_plus",
   "unsure",
 ]);
-// Both surfaces submit the same canonical budget enum codes; the card maps a
-// known code to a readable label and otherwise shows the raw value.
-const BUDGET_LABELS: Record<string, string> = {
-  lt_50: "每月 $50 以下",
-  usd_50_200: "每月 $50 – $200",
-  usd_200_1k: "每月 $200 – $1,000",
-  usd_1k_5k: "每月 $1,000 – $5,000",
-  usd_5k_plus: "每月 $5,000 以上",
-  unsure: "还不确定",
-};
-// Canonical team-size enum → readable label (shared by both surfaces).
-const TEAM_SIZE_LABELS: Record<string, string> = {
-  "1-10": "1–10 人",
-  "11-50": "11–50 人",
-  "51-200": "51–200 人",
-  "200+": "200 人以上",
-};
-// /enterprise submits expected seats as one of these range codes; the pricing
-// modal still sends free numeric text, so the card falls back to the raw value.
 const ALLOWED_SEATS = new Set([
   "1-5",
   "5-10",
@@ -172,16 +101,6 @@ const ALLOWED_SEATS = new Set([
   "200-500",
   "500+",
 ]);
-const SEAT_LABELS: Record<string, string> = {
-  "1-5": "1–5 个",
-  "5-10": "5–10 个",
-  "10-20": "10–20 个",
-  "20-50": "20–50 个",
-  "50-100": "50–100 个",
-  "100-200": "100–200 个",
-  "200-500": "200–500 个",
-  "500+": "500 个以上",
-};
 const ALLOWED_USE_CASES = new Set([
   "product_design",
   "design_system",
@@ -198,8 +117,7 @@ const ALLOWED_USE_CASES = new Set([
   "game_assets",
   "other",
 ]);
-// Canonical industry enum (required on the shared lead form) → readable card
-// label. Keep in lockstep with `industryOptions` in
+// Keep in lockstep with `industryOptions` in
 // app/_lib/enterprise-lead-copy.ts.
 const ALLOWED_INDUSTRIES = new Set([
   "internet_software",
@@ -214,58 +132,38 @@ const ALLOWED_INDUSTRIES = new Set([
   "government_nonprofit",
   "other",
 ]);
-const INDUSTRY_LABELS: Record<string, string> = {
-  internet_software: "互联网 / 软件",
-  ecommerce_retail: "电商 / 零售",
-  advertising_marketing: "广告 / 营销服务",
-  finance: "金融",
-  education: "教育培训",
-  gaming: "游戏",
-  media_entertainment: "文化传媒 / 娱乐",
-  manufacturing: "制造业 / 硬件",
-  healthcare: "医疗健康",
-  government_nonprofit: "政府 / 非营利",
-  other: "其他",
-};
-const USE_CASE_LABELS: Record<string, string> = {
-  product_design: "产品与应用设计",
-  design_system: "设计系统",
-  prototype: "原型 / 应用 UI",
-  marketing: "营销与落地页",
-  brand: "品牌视觉 / VI",
-  social_media: "社媒内容 / 电商素材",
-  poster_print: "海报 / 印刷物料",
-  deck: "演示文稿 / Deck",
-  video_motion: "视频 / 动效",
-  illustration: "插画 / 图像生成",
-  dashboards: "仪表盘 / 内部工具",
-  education: "教学 / 课件",
-  game_assets: "游戏素材",
-  other: "其他",
-};
 
-function corsHeaders(origin: string | null): Record<string, string> {
-  const allowed =
-    origin &&
-    ALLOWED_ORIGINS.some((o) => origin === o || origin.startsWith(`${o}:`))
-      ? origin
-      : ALLOWED_ORIGINS[0];
-  return {
-    "Access-Control-Allow-Origin": allowed,
+function requestIsSameOrigin(request: Request): boolean {
+  const origin = request.headers.get("origin");
+  if (!origin) return false;
+  try {
+    return new URL(origin).origin === new URL(request.url).origin;
+  } catch {
+    return false;
+  }
+}
+
+function corsHeaders(request: Request): Record<string, string> {
+  const headers: Record<string, string> = {
     "Access-Control-Allow-Methods": "POST, OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type",
     "Access-Control-Max-Age": "86400",
     Vary: "Origin",
   };
+  if (requestIsSameOrigin(request)) {
+    headers["Access-Control-Allow-Origin"] =
+      request.headers.get("origin") as string;
+  }
+  return headers;
 }
 
-function json(body: unknown, status: number, origin: string | null): Response {
+function json(body: unknown, status: number, request: Request): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: {
       "Content-Type": "application/json; charset=utf-8",
       "Cache-Control": "no-store",
-      ...corsHeaders(origin),
+      ...corsHeaders(request),
     },
   });
 }
@@ -273,7 +171,9 @@ function json(body: unknown, status: number, origin: string | null): Response {
 async function sha256Hex(value: string): Promise<string> {
   const data = new TextEncoder().encode(value);
   const digest = await crypto.subtle.digest("SHA-256", data);
-  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 function base64UrlToBytes(value: string): Uint8Array | null {
@@ -281,7 +181,9 @@ function base64UrlToBytes(value: string): Uint8Array | null {
   const base64 = value.replace(/-/gu, "+").replace(/_/gu, "/");
   const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=");
   try {
-    return Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
+    return Uint8Array.from(atob(padded), (character) =>
+      character.charCodeAt(0),
+    );
   } catch {
     return null;
   }
@@ -299,7 +201,9 @@ async function verifyServiceSignature(options: {
   | "service_auth_required"
   | null
 > {
-  const timestampValue = options.request.headers.get("x-od-service-timestamp");
+  const timestampValue = options.request.headers.get(
+    "x-od-service-timestamp",
+  );
   const headerEventId = options.request.headers.get("x-od-service-event-id");
   const signatureValue = options.request.headers.get("x-od-service-signature");
   if (!timestampValue || !headerEventId || !signatureValue) {
@@ -312,6 +216,7 @@ async function verifyServiceSignature(options: {
   ) {
     return "service_auth_invalid";
   }
+
   const timestamp = Number(timestampValue);
   if (
     !Number.isSafeInteger(timestamp) ||
@@ -341,157 +246,23 @@ async function verifyServiceSignature(options: {
   return valid ? null : "service_auth_invalid";
 }
 
-function bytesToBase64(bytes: Uint8Array): string {
-  let binary = "";
-  for (const byte of bytes) binary += String.fromCharCode(byte);
-  return btoa(binary);
-}
-
 function readString(value: unknown, max: number): string {
   return typeof value === "string" ? value.trim().slice(0, max) : "";
 }
 
-// Accept a multi-select use-case array; keep only known, de-duplicated values.
 function readUseCases(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
-  const out: string[] = [];
+  const result: string[] = [];
   for (const item of value) {
-    if (typeof item === "string" && ALLOWED_USE_CASES.has(item) && !out.includes(item)) {
-      out.push(item);
+    if (
+      typeof item === "string" &&
+      ALLOWED_USE_CASES.has(item) &&
+      !result.includes(item)
+    ) {
+      result.push(item);
     }
   }
-  return out;
-}
-
-// Feishu custom-bot signature: base64(HmacSHA256(key = `${timestamp}\n${secret}`, data = "")).
-async function feishuSignature(secret: string, timestamp: number): Promise<string> {
-  const keyBytes = new TextEncoder().encode(`${timestamp}\n${secret}`);
-  const cryptoKey = await crypto.subtle.importKey(
-    "raw",
-    keyBytes,
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
-  const sig = await crypto.subtle.sign("HMAC", cryptoKey, new Uint8Array(0));
-  return bytesToBase64(new Uint8Array(sig));
-}
-
-function buildFeishuCard(lead: ContactLead): Record<string, unknown> {
-  const fieldRow = (label: string, value: string) => ({
-    is_short: true,
-    text: { tag: "lark_md", content: `**${label}**\n${value || "—"}` },
-  });
-  const geo = [lead.country, lead.region].filter(Boolean).join(" / ");
-  return {
-    config: { wide_screen_mode: true },
-    header: {
-      template: "green",
-      title: { tag: "plain_text", content: "🚀 新的「团队版」留资线索" },
-    },
-    elements: [
-      {
-        tag: "div",
-        fields: [
-          fieldRow("姓名", lead.name),
-          fieldRow("企业邮箱", lead.email),
-          fieldRow("公司", lead.company),
-          fieldRow("团队规模", TEAM_SIZE_LABELS[lead.teamSize] ?? lead.teamSize),
-          fieldRow("国家 / 地区", lead.location),
-          fieldRow("预计席位数", SEAT_LABELS[lead.seats] ?? lead.seats),
-          fieldRow("预算", BUDGET_LABELS[lead.budget] ?? lead.budget),
-          fieldRow("所属行业", INDUSTRY_LABELS[lead.industry] ?? lead.industry),
-          fieldRow("使用场景", lead.useCases.map((v) => USE_CASE_LABELS[v] ?? v).join("、")),
-          fieldRow("职位", lead.role),
-          fieldRow("语言", lead.locale),
-        ],
-      },
-      ...(lead.message
-        ? [
-            { tag: "hr" },
-            {
-              tag: "div",
-              text: { tag: "lark_md", content: `**留言**\n${lead.message}` },
-            },
-          ]
-        : []),
-      { tag: "hr" },
-      {
-        tag: "note",
-        elements: [
-          {
-            tag: "plain_text",
-            content: `来源：${lead.source}${geo ? ` · ${geo}` : ""} · ${lead.submittedAt}`,
-          },
-        ],
-      },
-    ],
-  };
-}
-
-type DeliveryErrorCode =
-  | "feishu_http_failed"
-  | "feishu_rejected"
-  | "feishu_request_failed"
-  | "feishu_unconfigured";
-
-type DeliveryAttemptResult =
-  | { ok: true }
-  | {
-      error: DeliveryErrorCode;
-      ok: false;
-    };
-
-async function notifyFeishu(
-  env: Env,
-  lead: ContactLead,
-): Promise<DeliveryAttemptResult> {
-  const webhook = env.FEISHU_CONTACT_WEBHOOK?.trim();
-  if (!webhook) {
-    console.warn("contact_sales_feishu_unset: FEISHU_CONTACT_WEBHOOK missing; KV only");
-    return { ok: false, error: "feishu_unconfigured" };
-  }
-
-  const body: Record<string, unknown> = {
-    msg_type: "interactive",
-    card: buildFeishuCard(lead),
-  };
-
-  const secret = env.FEISHU_CONTACT_SECRET?.trim();
-  if (secret) {
-    const timestamp = Math.floor(Date.now() / 1000);
-    body.timestamp = String(timestamp);
-    body.sign = await feishuSignature(secret, timestamp);
-  }
-
-  try {
-    const res = await fetch(webhook, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    });
-    if (!res.ok) {
-      console.warn("contact_sales_feishu_failed", JSON.stringify({ status: res.status }));
-      return { ok: false, error: "feishu_http_failed" };
-    }
-    // Feishu returns 200 with a JSON body even on logical failure (e.g. bad sign).
-    const data = (await res.json().catch(() => null)) as {
-      code?: unknown;
-    } | null;
-    if (!data || data.code !== 0) {
-      console.warn(
-        "contact_sales_feishu_rejected",
-        JSON.stringify({
-          code: typeof data?.code === "number" ? data.code : "invalid",
-        }),
-      );
-      return { ok: false, error: "feishu_rejected" };
-    }
-    return { ok: true };
-  } catch {
-    console.warn("contact_sales_feishu_request_failed");
-    return { ok: false, error: "feishu_request_failed" };
-  }
+  return result;
 }
 
 class ContactSalesPersistenceError extends Error {
@@ -504,184 +275,22 @@ class ContactSalesPersistenceError extends Error {
   }
 }
 
-function deliveryKey(eventId: string): string {
-  return `${CONTACT_DELIVERY_PREFIX}${eventId}`;
-}
-
-function parseDeliveryRecord(value: string | null): ContactDeliveryRecord | null {
-  if (!value) return null;
-  try {
-    const parsed = JSON.parse(value) as Partial<ContactDeliveryRecord>;
-    if (
-      typeof parsed.eventId !== "string" ||
-      typeof parsed.attempt !== "number" ||
-      typeof parsed.status !== "string" ||
-      !parsed.lead
-    ) {
-      return null;
-    }
-    return parsed as ContactDeliveryRecord;
-  } catch {
-    return null;
-  }
-}
-
-async function persistLead(
-  env: Env,
-  lead: ContactLead,
-  eventId: string,
-  nowMs: number,
-): Promise<{
-  duplicate: boolean;
-  key: string;
-  record: ContactDeliveryRecord;
-}> {
+async function persistLead(env: Env, lead: ContactLead): Promise<void> {
   const kv = env.CONTACT_LEADS;
   if (!kv) {
     console.warn(
       "contact_sales_kv_unbound: CONTACT_LEADS binding missing; lead not persisted",
-      JSON.stringify({ source: lead.source, country: lead.country }),
+      JSON.stringify({ source: lead.source }),
     );
     throw new ContactSalesPersistenceError("lead_storage_unavailable");
   }
 
-  const key = deliveryKey(eventId);
   try {
-    const existing = parseDeliveryRecord(await kv.get(key));
-    if (existing?.eventId === eventId) {
-      return { duplicate: true, key, record: existing };
-    }
-
-    const nowIso = new Date(nowMs).toISOString();
-    const record: ContactDeliveryRecord = {
-      eventId,
-      lead,
-      status: "pending",
-      attempt: 0,
-      nextAttemptAt: null,
-      lastError: null,
-      updatedAt: nowIso,
-    };
-    // Latest submission per email remains the operational backup. The
-    // event-scoped record is the durable delivery state and idempotency key.
     const leadKey = `lead:${await sha256Hex(lead.email)}`;
-    await Promise.all([
-      kv.put(leadKey, JSON.stringify(lead)),
-      kv.put(key, JSON.stringify(record)),
-    ]);
-    return { duplicate: false, key, record };
-  } catch (error) {
-    if (error instanceof ContactSalesPersistenceError) throw error;
+    await kv.put(leadKey, JSON.stringify(lead));
+  } catch {
     console.warn("contact_sales_kv_write_failed");
     throw new ContactSalesPersistenceError("lead_storage_failed");
-  }
-}
-
-function retryIsDue(record: ContactDeliveryRecord, nowMs: number): boolean {
-  if (record.status === "pending") return true;
-  if (record.status !== "retry" || !record.nextAttemptAt) return false;
-  const nextAttemptAt = Date.parse(record.nextAttemptAt);
-  return Number.isFinite(nextAttemptAt) && nextAttemptAt <= nowMs;
-}
-
-function wait(delayMs: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, delayMs));
-}
-
-async function deliverRecord(
-  env: Env,
-  kv: KVNamespace,
-  record: ContactDeliveryRecord,
-  nowMs: number,
-): Promise<void> {
-  if (
-    record.status === "delivered" ||
-    record.status === "dead_letter" ||
-    !retryIsDue(record, nowMs)
-  ) {
-    return;
-  }
-
-  let attempt = record.attempt;
-  let lastError: DeliveryErrorCode = "feishu_request_failed";
-  for (
-    let invocationAttempt = 0;
-    invocationAttempt < DELIVERY_ATTEMPTS_PER_INVOCATION &&
-    attempt < DELIVERY_MAX_ATTEMPTS;
-    invocationAttempt += 1
-  ) {
-    attempt += 1;
-    const result = await notifyFeishu(env, record.lead);
-    if (result.ok) {
-      await kv.put(
-        deliveryKey(record.eventId),
-        JSON.stringify({
-          ...record,
-          status: "delivered",
-          attempt,
-          nextAttemptAt: null,
-          lastError: null,
-          updatedAt: new Date(nowMs).toISOString(),
-        } satisfies ContactDeliveryRecord),
-      );
-      return;
-    }
-    if (!("error" in result)) continue;
-    lastError = result.error;
-    // Missing configuration cannot recover within this invocation. Persist it
-    // immediately so operations can repair the binding without losing the lead.
-    if (result.error === "feishu_unconfigured") break;
-    if (
-      invocationAttempt + 1 < DELIVERY_ATTEMPTS_PER_INVOCATION &&
-      attempt < DELIVERY_MAX_ATTEMPTS
-    ) {
-      await wait(invocationAttempt === 0 ? 250 : 1_000);
-    }
-  }
-
-  const exhausted = attempt >= DELIVERY_MAX_ATTEMPTS;
-  await kv.put(
-    deliveryKey(record.eventId),
-    JSON.stringify({
-      ...record,
-      status: exhausted ? "dead_letter" : "retry",
-      attempt,
-      nextAttemptAt: exhausted
-        ? null
-        : new Date(nowMs + DELIVERY_RETRY_DELAY_MS).toISOString(),
-      lastError,
-      updatedAt: new Date(nowMs).toISOString(),
-    } satisfies ContactDeliveryRecord),
-  );
-  console.warn(
-    exhausted
-      ? "contact_sales_delivery_dead_lettered"
-      : "contact_sales_delivery_retry_scheduled",
-    JSON.stringify({ attempt, error: lastError, eventId: record.eventId }),
-  );
-}
-
-async function drainDueDeliveries(
-  env: Env,
-  nowMs: number,
-  excludedKey: string,
-): Promise<void> {
-  const kv = env.CONTACT_LEADS;
-  if (!kv?.list) return;
-  try {
-    const result = await kv.list({
-      limit: 10,
-      prefix: CONTACT_DELIVERY_PREFIX,
-    });
-    for (const item of result.keys) {
-      if (item.name === excludedKey) continue;
-      const record = parseDeliveryRecord(await kv.get(item.name));
-      if (record && retryIsDue(record, nowMs)) {
-        await deliverRecord(env, kv, record, nowMs);
-      }
-    }
-  } catch {
-    console.warn("contact_sales_retry_drain_failed");
   }
 }
 
@@ -691,10 +300,21 @@ export const onRequest: PagesFunction<Env> = async (context) => {
   const nowMs = context.now?.() ?? Date.now();
 
   if (request.method === "OPTIONS") {
-    return new Response(null, { status: 204, headers: corsHeaders(origin) });
+    if (!requestIsSameOrigin(request)) {
+      return json({ ok: false, error: "origin_not_allowed" }, 403, request);
+    }
+    return new Response(null, { status: 204, headers: corsHeaders(request) });
   }
   if (request.method !== "POST") {
-    return json({ ok: false, error: "method_not_allowed" }, 405, origin);
+    return json({ ok: false, error: "method_not_allowed" }, 405, request);
+  }
+
+  // Browser fetches always carry Origin. Requiring it to match the endpoint URL
+  // keeps the relative /contact-sales forms portable across production,
+  // staging, and preview domains without enabling a cross-origin write API.
+  // Trusted Vela server calls omit Origin and authenticate below instead.
+  if (origin && !requestIsSameOrigin(request)) {
+    return json({ ok: false, error: "origin_not_allowed" }, 403, request);
   }
 
   let rawBody: string;
@@ -707,28 +327,26 @@ export const onRequest: PagesFunction<Env> = async (context) => {
     }
     payload = parsed as Record<string, unknown>;
   } catch {
-    return json({ ok: false, error: "invalid_json" }, 400, origin);
+    return json({ ok: false, error: "invalid_json" }, 400, request);
   }
 
   const email = readString(payload.email, MAX_EMAIL_LENGTH).toLowerCase();
   if (!email || !EMAIL_RE.test(email)) {
-    return json({ ok: false, error: "invalid_email" }, 400, origin);
+    return json({ ok: false, error: "invalid_email" }, 400, request);
   }
 
-  // Reject unrecognized sources up front. This is a public write endpoint, so a
-  // typoed/unknown source must return 400 rather than silently falling through
-  // to the relaxed path and persisting arbitrary leads.
   const source =
-    typeof payload.source === "string" && ALLOWED_SOURCES.has(payload.source)
-      ? payload.source
+    typeof payload.source === "string" &&
+    ALLOWED_SOURCES.has(payload.source as ContactSource)
+      ? (payload.source as ContactSource)
       : null;
   if (!source) {
-    return json({ ok: false, error: "invalid_source" }, 400, origin);
+    return json({ ok: false, error: "invalid_source" }, 400, request);
   }
 
   let serviceEventId: string | null = null;
   if (source === VELA_TEAM_PLAN_SOURCE) {
-    serviceEventId = readString(payload.eventId, 200);
+    serviceEventId = readString(payload.eventId, MAX_SHORT);
     const serviceSecret = context.env.CONTACT_SALES_SERVICE_SECRET?.trim();
     if (!serviceSecret) {
       console.warn(
@@ -737,7 +355,7 @@ export const onRequest: PagesFunction<Env> = async (context) => {
       return json(
         { ok: false, error: "service_auth_unavailable" },
         503,
-        origin,
+        request,
       );
     }
     const authError = await verifyServiceSignature({
@@ -748,16 +366,12 @@ export const onRequest: PagesFunction<Env> = async (context) => {
       secret: serviceSecret,
     });
     if (authError) {
-      return json({ ok: false, error: authError }, 401, origin);
+      return json({ ok: false, error: authError }, 401, request);
     }
-  }
-
-  // The shared lead form (enterprise + pricing_team) no longer asks for a
-  // name (email is the contact handle); every other source still requires one.
-  const isSharedLeadForm = SHARED_LEAD_FORM_SOURCES.has(source);
-  const name = readString(payload.name, MAX_SHORT);
-  if (!name && !isSharedLeadForm) {
-    return json({ ok: false, error: "missing_fields" }, 400, origin);
+  } else if (!origin) {
+    // Public form sources are browser-only. Server relays must use the signed
+    // Vela source instead of bypassing the same-origin browser boundary.
+    return json({ ok: false, error: "origin_required" }, 403, request);
   }
 
   const company = readString(payload.company, MAX_SHORT);
@@ -773,29 +387,18 @@ export const onRequest: PagesFunction<Env> = async (context) => {
     source === VELA_TEAM_PLAN_SOURCE
       ? readUseCases([payload.useCase])
       : readUseCases(payload.useCases);
-  // Unknown industry codes are dropped rather than persisted; the shared lead
-  // form requires a known one below.
   const industryRaw = readString(payload.industry, MAX_SHORT);
   const industry = ALLOWED_INDUSTRIES.has(industryRaw) ? industryRaw : "";
 
-  // Every allowlisted source submits the full contact-form contract: known
-  // team-size/seat-range/budget enums + a use case (company is optional).
-  // Since the /pricing modal now renders the same shared form as /enterprise,
-  // its old relaxed name+email-only path is gone.
   if (
     !ALLOWED_TEAM_SIZES.has(teamSize) ||
     !ALLOWED_SEATS.has(seats) ||
     !ALLOWED_BUDGETS.has(budget) ||
-    (isSharedLeadForm && !location) ||
+    !location ||
+    !industry ||
     useCases.length === 0
   ) {
-    return json({ ok: false, error: "missing_fields" }, 400, origin);
-  }
-
-  // Industry is a required pick on the shared lead form; the reserved in-app
-  // `client` source predates the field and may omit it.
-  if (isSharedLeadForm && !industry) {
-    return json({ ok: false, error: "missing_fields" }, 400, origin);
+    return json({ ok: false, error: "missing_fields" }, 400, request);
   }
 
   const cf = request.cf || {};
@@ -805,7 +408,7 @@ export const onRequest: PagesFunction<Env> = async (context) => {
       ? payload.billingInterval
       : undefined;
   const lead: ContactLead = {
-    name,
+    name: readString(payload.name, MAX_SHORT),
     email,
     company,
     teamSize,
@@ -821,59 +424,27 @@ export const onRequest: PagesFunction<Env> = async (context) => {
     pageUrl: readString(payload.pageUrl, 512),
     submittedAt: new Date(nowMs).toISOString(),
     referer: request.headers.get("referer"),
+    ...(serviceEventId ? { eventId: serviceEventId } : {}),
     billingInterval,
     country: typeof cf.country === "string" ? cf.country : undefined,
     region: typeof cf.region === "string" ? cf.region : undefined,
   };
 
-  const eventId =
-    serviceEventId ||
-    (await sha256Hex(
-      `${lead.source}:${lead.email}:${lead.submittedAt}:${rawBody}`,
-    ));
-  let persisted: Awaited<ReturnType<typeof persistLead>>;
   try {
-    persisted = await persistLead(context.env, lead, eventId, nowMs);
+    await persistLead(context.env, lead);
   } catch (error) {
     const code =
       error instanceof ContactSalesPersistenceError
         ? error.code
         : "lead_storage_failed";
-    return json({ ok: false, error: code }, 503, origin);
+    return json({ ok: false, error: code }, 503, request);
   }
 
-  const kv = context.env.CONTACT_LEADS;
-  if (!kv) {
-    // persistLead fails closed when unbound. This guard only keeps the type
-    // refinement explicit for the background delivery task.
-    return json(
-      { ok: false, error: "lead_storage_unavailable" },
-      503,
-      origin,
-    );
-  }
-  context.waitUntil(
-    Promise.all([
-      retryIsDue(persisted.record, nowMs)
-        ? deliverRecord(context.env, kv, persisted.record, nowMs)
-        : Promise.resolve(),
-      drainDueDeliveries(context.env, nowMs, persisted.key),
-    ]),
-  );
-
-  return json(
-    {
-      ok: true,
-      ...(persisted.duplicate ? { duplicate: true } : {}),
-    },
-    200,
-    origin,
-  );
+  return json({ ok: true }, 200, request);
 };
 
 export const __contactSalesTest = {
   corsHeaders,
-  buildFeishuCard,
-  feishuSignature,
+  requestIsSameOrigin,
   verifyServiceSignature,
 };

--- a/apps/landing-page/tests/contact-sales.test.ts
+++ b/apps/landing-page/tests/contact-sales.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash, createHmac } from "node:crypto";
+import { readFile } from "node:fs/promises";
 import { describe, it } from "node:test";
 
 import { onRequest } from "../functions/contact-sales.ts";
@@ -8,10 +9,12 @@ type StoredValue = { value: string };
 
 class MemoryKV {
   readonly values = new Map<string, StoredValue>();
+  readonly writes: string[] = [];
   failWrites = false;
 
   async put(key: string, value: string): Promise<void> {
     if (this.failWrites) throw new Error("KV unavailable");
+    this.writes.push(key);
     this.values.set(key, { value });
   }
 
@@ -35,6 +38,7 @@ type CallOptions = {
   headers?: Record<string, string>;
   kv?: MemoryKV | null;
   now?: number;
+  url?: string;
 };
 
 // Drive the Pages Function directly with a mock context. Valid calls get a
@@ -46,20 +50,24 @@ async function call(
   options: CallOptions = {},
 ): Promise<{
   status: number;
-  body: { ok: boolean; duplicate?: boolean; error?: string };
+  body: { ok: boolean; error?: string };
   kv: MemoryKV | null;
+  waitUntilCalls: number;
 }> {
   const waited: Promise<unknown>[] = [];
   const kv = options.kv === undefined ? new MemoryKV() : options.kv;
-  const request = new Request("https://open-design.ai/contact-sales", {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      origin,
-      ...options.headers,
+  const request = new Request(
+    options.url ?? "https://open-design.ai/contact-sales",
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin,
+        ...options.headers,
+      },
+      body: JSON.stringify(payload),
     },
-    body: JSON.stringify(payload),
-  });
+  );
   const res = await onRequest({
     request,
     env: {
@@ -75,10 +83,10 @@ async function call(
     status: res.status,
     body: (await res.json()) as {
       ok: boolean;
-      duplicate?: boolean;
       error?: string;
     },
     kv,
+    waitUntilCalls: waited.length,
   };
 }
 
@@ -130,30 +138,20 @@ describe("contact-sales validation", () => {
     assert.equal((await call({ ...ENTERPRISE_OK, email: "rodrigo@linkflow.com.br" })).status, 200);
   });
 
-  it("does not require a name on the shared lead-form sources; the in-app `client` source still does", async () => {
+  it("does not require a name on the shared lead-form sources", async () => {
     // Neither web surface collects a name (email is the contact handle).
     assert.equal((await call(ENTERPRISE_OK)).status, 200);
     assert.equal((await call(PRICING_TEAM_OK)).status, 200);
-    const { status, body } = await call({ ...ENTERPRISE_OK, source: "client" });
-    assert.equal(status, 400);
-    assert.equal(body.error, "missing_fields");
   });
 
-  it("rejects an unrecognized or missing source (no silent relaxed write)", async () => {
+  it("only accepts the canonical enterprise, pricing_team, and signed Vela sources", async () => {
     assert.equal((await call({ name: "Ada", email: "ada@acme.com", source: "bogus" })).body.error, "invalid_source");
     assert.equal((await call({ name: "Ada", email: "ada@acme.com" })).body.error, "invalid_source");
+    assert.equal((await call({ ...ENTERPRISE_OK, source: "client" })).body.error, "invalid_source");
     // An unknown source must not sneak through the name+email-only path.
     const typo = await call({ name: "Ada", email: "ada@acme.com", source: "enterprisee" });
     assert.equal(typo.status, 400);
     assert.equal(typo.body.error, "invalid_source");
-  });
-
-  it("keeps the in-app `client` source strict (name + full enums)", async () => {
-    assert.equal((await call({ name: "Ada", email: "ada@acme.com", source: "client" })).body.error, "missing_fields");
-    // With a name and the full enum contract, client is accepted; industry and
-    // location predate the field there and stay optional.
-    const { industry: _industry, location: _location, ...clientContract } = ENTERPRISE_OK;
-    assert.equal((await call({ ...clientContract, name: "Ada", source: "client" })).status, 200);
   });
 
   it("keeps the shared contract: known team-size/seat-range/budget enums + a use case are required", async () => {
@@ -247,8 +245,8 @@ function velaServiceHeaders(
   };
 }
 
-describe("contact-sales durable delivery", () => {
-  it("does not acknowledge a lead until the KV backup succeeds", async () => {
+describe("contact-sales canonical KV intake", () => {
+  it("does not acknowledge a lead until its canonical KV write succeeds", async () => {
     const missing = await call(ENTERPRISE_OK, "https://open-design.ai", {
       kv: null,
     });
@@ -260,6 +258,56 @@ describe("contact-sales durable delivery", () => {
     const failed = await call(ENTERPRISE_OK, "https://open-design.ai", { kv });
     assert.equal(failed.status, 503);
     assert.equal(failed.body.error, "lead_storage_failed");
+  });
+
+  it("stores only lead:<sha256(email)> and overwrites the same normalized email", async () => {
+    const kv = new MemoryKV();
+    const first = await call(ENTERPRISE_OK, "https://open-design.ai", {
+      kv,
+      now: SERVICE_NOW,
+    });
+    const secondPayload = {
+      ...PRICING_TEAM_OK,
+      email: " ADA@ACME.COM ",
+      company: "Acme Updated",
+    };
+    const second = await call(secondPayload, "https://open-design.ai", {
+      kv,
+      now: SERVICE_NOW + 1_000,
+    });
+
+    assert.equal(first.status, 200);
+    assert.equal(second.status, 200);
+    const key = `lead:${createHash("sha256").update("ada@acme.com").digest("hex")}`;
+    assert.deepEqual([...kv.values.keys()], [key]);
+    assert.deepEqual(kv.writes, [key, key]);
+    const stored = JSON.parse(kv.values.get(key)?.value ?? "{}");
+    assert.equal(stored.email, "ada@acme.com");
+    assert.equal(stored.source, "pricing_team");
+    assert.equal(stored.company, "Acme Updated");
+    assert.equal(stored.submittedAt, "2026-07-29T08:00:01.000Z");
+  });
+
+  it("rejects cross-origin browser submissions while keeping staging and production same-origin", async () => {
+    const crossOrigin = await call(
+      ENTERPRISE_OK,
+      "https://attacker.example",
+    );
+    assert.equal(crossOrigin.status, 403);
+    assert.equal(crossOrigin.body.error, "origin_not_allowed");
+
+    assert.equal(
+      (await call(ENTERPRISE_OK, "https://open-design.ai")).status,
+      200,
+    );
+    assert.equal(
+      (
+        await call(ENTERPRISE_OK, "https://staging.open-design.ai", {
+          url: "https://staging.open-design.ai/contact-sales",
+        })
+      ).status,
+      200,
+    );
   });
 
   it("rejects forged or stale Vela service submissions", async () => {
@@ -292,7 +340,7 @@ describe("contact-sales durable delivery", () => {
     assert.equal(stale.body.error, "service_auth_expired");
   });
 
-  it("accepts a signed Vela lead and preserves the stable event id", async () => {
+  it("accepts a signed Vela server-to-server lead and preserves its source and event id in the canonical record", async () => {
     const result = await call(VELA_TEAM_PLAN_OK, "", {
       env: { CONTACT_SALES_SERVICE_SECRET: SERVICE_SECRET },
       headers: velaServiceHeaders(VELA_TEAM_PLAN_OK),
@@ -301,131 +349,71 @@ describe("contact-sales durable delivery", () => {
 
     assert.equal(result.status, 200);
     assert.equal(result.body.ok, true);
-    const delivery = result.kv?.values.get(
-      `contact-delivery:${VELA_TEAM_PLAN_OK.eventId}`,
-    );
-    assert.ok(delivery);
-    assert.equal(
-      JSON.parse(delivery.value).lead.name,
-      VELA_TEAM_PLAN_OK.name,
-    );
-    assert.equal(
-      JSON.parse(delivery.value).lead.source,
-      VELA_TEAM_PLAN_OK.source,
-    );
+    const key = `lead:${createHash("sha256").update(VELA_TEAM_PLAN_OK.email).digest("hex")}`;
+    assert.deepEqual([...result.kv!.values.keys()], [key]);
+    const stored = JSON.parse(result.kv?.values.get(key)?.value ?? "{}");
+    assert.equal(stored.name, VELA_TEAM_PLAN_OK.name);
+    assert.equal(stored.source, VELA_TEAM_PLAN_OK.source);
+    assert.equal(stored.eventId, VELA_TEAM_PLAN_OK.eventId);
   });
 
-  it("does not notify Feishu twice when Vela retries the same event id", async () => {
+  it("is KV-only: it never fetches externally, schedules delivery, or writes an outbox", async () => {
     const originalFetch = globalThis.fetch;
-    let feishuCalls = 0;
+    let externalFetches = 0;
     globalThis.fetch = async () => {
-      feishuCalls += 1;
-      return new Response(JSON.stringify({ code: 0 }), { status: 200 });
+      externalFetches += 1;
+      throw new Error("contact-sales must not call external services");
     };
     try {
       const kv = new MemoryKV();
-      const env = {
-        CONTACT_SALES_SERVICE_SECRET: SERVICE_SECRET,
-        FEISHU_CONTACT_WEBHOOK: "https://open.feishu.cn/test-webhook",
-      };
-      const headers = velaServiceHeaders(VELA_TEAM_PLAN_OK);
-      const first = await call(VELA_TEAM_PLAN_OK, "", {
-        env,
-        headers,
+      const result = await call(ENTERPRISE_OK, "https://open-design.ai", {
         kv,
-        now: SERVICE_NOW,
-      });
-      const duplicate = await call(VELA_TEAM_PLAN_OK, "", {
-        env,
-        headers,
-        kv,
-        now: SERVICE_NOW,
-      });
-
-      assert.equal(first.status, 200);
-      assert.equal(duplicate.status, 200);
-      assert.equal(duplicate.body.duplicate, true);
-      assert.equal(feishuCalls, 1);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
-  });
-
-  it("keeps a recoverable retry record when Feishu rejects an HTTP 200 body", async () => {
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = async () =>
-      new Response(JSON.stringify({ code: 19021 }), { status: 200 });
-    try {
-      const result = await call(VELA_TEAM_PLAN_OK, "", {
+        // Legacy notification variables must have no effect if they remain
+        // configured on a Cloudflare project during rollout.
         env: {
-          CONTACT_SALES_SERVICE_SECRET: SERVICE_SECRET,
           FEISHU_CONTACT_WEBHOOK: "https://open.feishu.cn/test-webhook",
+          FEISHU_CONTACT_SECRET: "legacy-secret",
         },
-        headers: velaServiceHeaders(VELA_TEAM_PLAN_OK),
-        now: SERVICE_NOW,
       });
 
       assert.equal(result.status, 200);
-      const delivery = result.kv?.values.get(
-        `contact-delivery:${VELA_TEAM_PLAN_OK.eventId}`,
-      );
-      assert.ok(delivery);
-      const stored = JSON.parse(delivery.value);
-      assert.equal(stored.status, "retry");
-      assert.equal(stored.attempt, 3);
-      assert.equal(typeof stored.nextAttemptAt, "string");
-      assert.equal(stored.lastError, "feishu_rejected");
+      assert.equal(externalFetches, 0);
+      assert.equal(result.waitUntilCalls, 0);
+      assert.equal(kv.values.size, 1);
+      assert.ok([...kv.values.keys()].every((key) => key.startsWith("lead:")));
     } finally {
       globalThis.fetch = originalFetch;
     }
   });
 
-  it("recovers a due retry record while accepting a later lead", async () => {
-    const originalFetch = globalThis.fetch;
-    let reject = true;
-    globalThis.fetch = async () =>
-      new Response(JSON.stringify({ code: reject ? 19021 : 0 }), {
-        status: 200,
-      });
-    try {
-      const kv = new MemoryKV();
-      const env = {
-        CONTACT_SALES_SERVICE_SECRET: SERVICE_SECRET,
-        FEISHU_CONTACT_WEBHOOK: "https://open.feishu.cn/test-webhook",
-      };
-      await call(VELA_TEAM_PLAN_OK, "", {
-        env,
-        headers: velaServiceHeaders(VELA_TEAM_PLAN_OK),
-        kv,
-        now: SERVICE_NOW,
-      });
-      const firstKey = `contact-delivery:${VELA_TEAM_PLAN_OK.eventId}`;
-      const first = JSON.parse(kv.values.get(firstKey)?.value ?? "{}");
-      first.nextAttemptAt = new Date(SERVICE_NOW - 1).toISOString();
-      kv.values.set(firstKey, { value: JSON.stringify(first) });
+  it("contains no direct Feishu notifier or delivery outbox implementation", async () => {
+    const source = await readFile(
+      new URL("../functions/contact-sales.ts", import.meta.url),
+      "utf8",
+    );
+    assert.doesNotMatch(source, /FEISHU_CONTACT|notifyFeishu|buildFeishuCard/);
+    assert.doesNotMatch(source, /contact-delivery:|deliverRecord|drainDueDeliveries/);
+    assert.doesNotMatch(source, /\bfetch\s*\(/);
+  });
 
-      reject = false;
-      const laterLead = {
-        ...VELA_TEAM_PLAN_OK,
-        eventId: "evt-vela-team-plan-2",
-        email: "second@example.com",
-      };
-      const later = await call(laterLead, "", {
-        env,
-        headers: velaServiceHeaders(laterLead, {
-          eventId: laterLead.eventId,
-        }),
-        kv,
-        now: SERVICE_NOW,
-      });
-
-      assert.equal(later.status, 200);
-      assert.equal(
-        JSON.parse(kv.values.get(firstKey)?.value ?? "{}").status,
-        "delivered",
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
+  it("keeps production and staging on independent CONTACT_LEADS namespaces with the Vela secret contract documented", async () => {
+    const [production, staging] = await Promise.all([
+      readFile(new URL("../wrangler.toml", import.meta.url), "utf8"),
+      readFile(new URL("../wrangler.staging.toml", import.meta.url), "utf8"),
+    ]);
+    for (const config of [production, staging]) {
+      assert.match(config, /binding = "CONTACT_LEADS"/);
+      assert.match(config, /CONTACT_SALES_SERVICE_SECRET/);
+      assert.doesNotMatch(config, /FEISHU_CONTACT/);
     }
+    const productionId = production.match(
+      /binding = "CONTACT_LEADS"\s+id = "([^"]+)"/,
+    )?.[1];
+    const stagingId = staging.match(
+      /binding = "CONTACT_LEADS"\s+id = "([^"]+)"/,
+    )?.[1];
+    assert.ok(productionId);
+    assert.ok(stagingId);
+    assert.notEqual(productionId, stagingId);
   });
 });

--- a/apps/landing-page/tests/contact-sales.test.ts
+++ b/apps/landing-page/tests/contact-sales.test.ts
@@ -1,29 +1,85 @@
 import assert from "node:assert/strict";
+import { createHash, createHmac } from "node:crypto";
 import { describe, it } from "node:test";
 
 import { onRequest } from "../functions/contact-sales.ts";
 
-// Drive the Pages Function directly with a mock context. No env bindings are
-// provided, so persistLead() takes its unbound path (warns, no network) and the
-// handler still resolves to its JSON response.
+type StoredValue = { value: string };
+
+class MemoryKV {
+  readonly values = new Map<string, StoredValue>();
+  failWrites = false;
+
+  async put(key: string, value: string): Promise<void> {
+    if (this.failWrites) throw new Error("KV unavailable");
+    this.values.set(key, { value });
+  }
+
+  async get(key: string): Promise<string | null> {
+    return this.values.get(key)?.value ?? null;
+  }
+
+  async list(options: { prefix?: string } = {}) {
+    const prefix = options.prefix ?? "";
+    return {
+      keys: [...this.values.keys()]
+        .filter((key) => key.startsWith(prefix))
+        .map((name) => ({ name })),
+      list_complete: true,
+    };
+  }
+}
+
+type CallOptions = {
+  env?: Record<string, unknown>;
+  headers?: Record<string, string>;
+  kv?: MemoryKV | null;
+  now?: number;
+};
+
+// Drive the Pages Function directly with a mock context. Valid calls get a
+// durable in-memory KV by default because production acknowledgements are only
+// allowed after the backup write has succeeded.
 async function call(
   payload: unknown,
   origin = "https://open-design.ai",
-): Promise<{ status: number; body: { ok: boolean; error?: string } }> {
+  options: CallOptions = {},
+): Promise<{
+  status: number;
+  body: { ok: boolean; duplicate?: boolean; error?: string };
+  kv: MemoryKV | null;
+}> {
   const waited: Promise<unknown>[] = [];
+  const kv = options.kv === undefined ? new MemoryKV() : options.kv;
   const request = new Request("https://open-design.ai/contact-sales", {
     method: "POST",
-    headers: { "content-type": "application/json", origin },
+    headers: {
+      "content-type": "application/json",
+      origin,
+      ...options.headers,
+    },
     body: JSON.stringify(payload),
   });
   const res = await onRequest({
     request,
-    env: {},
+    env: {
+      ...(kv ? { CONTACT_LEADS: kv } : {}),
+      ...options.env,
+    },
     waitUntil: (p: Promise<unknown>) => waited.push(p),
+    now: options.now === undefined ? undefined : () => options.now,
     // deno-lint-ignore no-explicit-any
   } as unknown as Parameters<typeof onRequest>[0]);
   await Promise.allSettled(waited);
-  return { status: res.status, body: (await res.json()) as { ok: boolean; error?: string } };
+  return {
+    status: res.status,
+    body: (await res.json()) as {
+      ok: boolean;
+      duplicate?: boolean;
+      error?: string;
+    },
+    kv,
+  };
 }
 
 const ENTERPRISE_OK = {
@@ -149,5 +205,227 @@ describe("contact-sales validation", () => {
     // The old modal collected neither a use case nor an industry:
     assert.equal((await call({ ...PRICING_TEAM_OK, useCases: [] })).body.error, "missing_fields");
     assert.equal((await call({ ...PRICING_TEAM_OK, industry: "" })).body.error, "missing_fields");
+  });
+});
+
+const VELA_TEAM_PLAN_OK = {
+  eventId: "evt-vela-team-plan-1",
+  source: "vela_team_plan",
+  name: "Legacy Contact",
+  email: "buyer@example.com",
+  company: "Acme",
+  teamSize: "11-50",
+  seats: "20-50",
+  budget: "usd_1k_5k",
+  useCase: "design_system",
+  industry: "internet_software",
+  country: "US",
+  role: "Head of Design",
+  message: "We need a shared design system.",
+  locale: "en-US",
+  billingInterval: "yearly",
+};
+
+const SERVICE_SECRET = "landing-service-shared-secret";
+const SERVICE_NOW = Date.parse("2026-07-29T08:00:00.000Z");
+
+function velaServiceHeaders(
+  payload: unknown,
+  options: { eventId?: string; secret?: string; timestamp?: number } = {},
+) {
+  const eventId = options.eventId ?? VELA_TEAM_PLAN_OK.eventId;
+  const timestamp = options.timestamp ?? SERVICE_NOW;
+  const rawBody = JSON.stringify(payload);
+  const digest = createHash("sha256").update(rawBody).digest("hex");
+  const signature = createHmac("sha256", options.secret ?? SERVICE_SECRET)
+    .update(`${timestamp}\n${eventId}\n${digest}`)
+    .digest("base64url");
+  return {
+    "x-od-service-event-id": eventId,
+    "x-od-service-signature": signature,
+    "x-od-service-timestamp": String(timestamp),
+  };
+}
+
+describe("contact-sales durable delivery", () => {
+  it("does not acknowledge a lead until the KV backup succeeds", async () => {
+    const missing = await call(ENTERPRISE_OK, "https://open-design.ai", {
+      kv: null,
+    });
+    assert.equal(missing.status, 503);
+    assert.equal(missing.body.error, "lead_storage_unavailable");
+
+    const kv = new MemoryKV();
+    kv.failWrites = true;
+    const failed = await call(ENTERPRISE_OK, "https://open-design.ai", { kv });
+    assert.equal(failed.status, 503);
+    assert.equal(failed.body.error, "lead_storage_failed");
+  });
+
+  it("rejects forged or stale Vela service submissions", async () => {
+    const env = { CONTACT_SALES_SERVICE_SECRET: SERVICE_SECRET };
+    const unsigned = await call(VELA_TEAM_PLAN_OK, "", {
+      env,
+      now: SERVICE_NOW,
+    });
+    assert.equal(unsigned.status, 401);
+    assert.equal(unsigned.body.error, "service_auth_required");
+
+    const forged = await call(VELA_TEAM_PLAN_OK, "", {
+      env,
+      headers: velaServiceHeaders(VELA_TEAM_PLAN_OK, {
+        secret: "wrong-secret",
+      }),
+      now: SERVICE_NOW,
+    });
+    assert.equal(forged.status, 401);
+    assert.equal(forged.body.error, "service_auth_invalid");
+
+    const stale = await call(VELA_TEAM_PLAN_OK, "", {
+      env,
+      headers: velaServiceHeaders(VELA_TEAM_PLAN_OK, {
+        timestamp: SERVICE_NOW - 10 * 60 * 1000,
+      }),
+      now: SERVICE_NOW,
+    });
+    assert.equal(stale.status, 401);
+    assert.equal(stale.body.error, "service_auth_expired");
+  });
+
+  it("accepts a signed Vela lead and preserves the stable event id", async () => {
+    const result = await call(VELA_TEAM_PLAN_OK, "", {
+      env: { CONTACT_SALES_SERVICE_SECRET: SERVICE_SECRET },
+      headers: velaServiceHeaders(VELA_TEAM_PLAN_OK),
+      now: SERVICE_NOW,
+    });
+
+    assert.equal(result.status, 200);
+    assert.equal(result.body.ok, true);
+    const delivery = result.kv?.values.get(
+      `contact-delivery:${VELA_TEAM_PLAN_OK.eventId}`,
+    );
+    assert.ok(delivery);
+    assert.equal(
+      JSON.parse(delivery.value).lead.name,
+      VELA_TEAM_PLAN_OK.name,
+    );
+    assert.equal(
+      JSON.parse(delivery.value).lead.source,
+      VELA_TEAM_PLAN_OK.source,
+    );
+  });
+
+  it("does not notify Feishu twice when Vela retries the same event id", async () => {
+    const originalFetch = globalThis.fetch;
+    let feishuCalls = 0;
+    globalThis.fetch = async () => {
+      feishuCalls += 1;
+      return new Response(JSON.stringify({ code: 0 }), { status: 200 });
+    };
+    try {
+      const kv = new MemoryKV();
+      const env = {
+        CONTACT_SALES_SERVICE_SECRET: SERVICE_SECRET,
+        FEISHU_CONTACT_WEBHOOK: "https://open.feishu.cn/test-webhook",
+      };
+      const headers = velaServiceHeaders(VELA_TEAM_PLAN_OK);
+      const first = await call(VELA_TEAM_PLAN_OK, "", {
+        env,
+        headers,
+        kv,
+        now: SERVICE_NOW,
+      });
+      const duplicate = await call(VELA_TEAM_PLAN_OK, "", {
+        env,
+        headers,
+        kv,
+        now: SERVICE_NOW,
+      });
+
+      assert.equal(first.status, 200);
+      assert.equal(duplicate.status, 200);
+      assert.equal(duplicate.body.duplicate, true);
+      assert.equal(feishuCalls, 1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("keeps a recoverable retry record when Feishu rejects an HTTP 200 body", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ code: 19021 }), { status: 200 });
+    try {
+      const result = await call(VELA_TEAM_PLAN_OK, "", {
+        env: {
+          CONTACT_SALES_SERVICE_SECRET: SERVICE_SECRET,
+          FEISHU_CONTACT_WEBHOOK: "https://open.feishu.cn/test-webhook",
+        },
+        headers: velaServiceHeaders(VELA_TEAM_PLAN_OK),
+        now: SERVICE_NOW,
+      });
+
+      assert.equal(result.status, 200);
+      const delivery = result.kv?.values.get(
+        `contact-delivery:${VELA_TEAM_PLAN_OK.eventId}`,
+      );
+      assert.ok(delivery);
+      const stored = JSON.parse(delivery.value);
+      assert.equal(stored.status, "retry");
+      assert.equal(stored.attempt, 3);
+      assert.equal(typeof stored.nextAttemptAt, "string");
+      assert.equal(stored.lastError, "feishu_rejected");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("recovers a due retry record while accepting a later lead", async () => {
+    const originalFetch = globalThis.fetch;
+    let reject = true;
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ code: reject ? 19021 : 0 }), {
+        status: 200,
+      });
+    try {
+      const kv = new MemoryKV();
+      const env = {
+        CONTACT_SALES_SERVICE_SECRET: SERVICE_SECRET,
+        FEISHU_CONTACT_WEBHOOK: "https://open.feishu.cn/test-webhook",
+      };
+      await call(VELA_TEAM_PLAN_OK, "", {
+        env,
+        headers: velaServiceHeaders(VELA_TEAM_PLAN_OK),
+        kv,
+        now: SERVICE_NOW,
+      });
+      const firstKey = `contact-delivery:${VELA_TEAM_PLAN_OK.eventId}`;
+      const first = JSON.parse(kv.values.get(firstKey)?.value ?? "{}");
+      first.nextAttemptAt = new Date(SERVICE_NOW - 1).toISOString();
+      kv.values.set(firstKey, { value: JSON.stringify(first) });
+
+      reject = false;
+      const laterLead = {
+        ...VELA_TEAM_PLAN_OK,
+        eventId: "evt-vela-team-plan-2",
+        email: "second@example.com",
+      };
+      const later = await call(laterLead, "", {
+        env,
+        headers: velaServiceHeaders(laterLead, {
+          eventId: laterLead.eventId,
+        }),
+        kv,
+        now: SERVICE_NOW,
+      });
+
+      assert.equal(later.status, 200);
+      assert.equal(
+        JSON.parse(kv.values.get(firstKey)?.value ?? "{}").status,
+        "delivered",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/apps/landing-page/wrangler.staging.toml
+++ b/apps/landing-page/wrangler.staging.toml
@@ -4,6 +4,9 @@ name = "open-design-landing-staging"
 pages_build_output_dir = "out"
 compatibility_date = "2026-05-26"
 
+# Vela's CONTACT_SALES_SERVICE_SECRET is an encrypted Pages secret and must be
+# configured independently on the open-design-landing-staging project before
+# deployment. Never reuse the production secret value here.
 [[kv_namespaces]]
 binding = "CONTACT_LEADS"
 id = "3996bfc7569a41e9a56cfb05cc229519"

--- a/apps/landing-page/wrangler.staging.toml
+++ b/apps/landing-page/wrangler.staging.toml
@@ -5,6 +5,10 @@ pages_build_output_dir = "out"
 compatibility_date = "2026-05-26"
 
 [[kv_namespaces]]
+binding = "CONTACT_LEADS"
+id = "3996bfc7569a41e9a56cfb05cc229519"
+
+[[kv_namespaces]]
 binding = "NEWSLETTER_SUBSCRIBERS"
 id = "3eaa600b0e1a43abbebc6a36252e1474"
 

--- a/apps/landing-page/wrangler.toml
+++ b/apps/landing-page/wrangler.toml
@@ -5,6 +5,9 @@ name = "open-design-landing"
 pages_build_output_dir = "out"
 compatibility_date = "2026-05-04"
 
+# Vela's CONTACT_SALES_SERVICE_SECRET is an encrypted Pages secret and must be
+# configured on the open-design-landing project before deployment. Its value
+# intentionally does not belong in this source-controlled Wrangler file.
 [[kv_namespaces]]
 binding = "CONTACT_LEADS"
 id = "20f7edc0bb0a4b9798437e79f4830501"


### PR DESCRIPTION
## Why

Vela's Team/Enterprise consultation form now relays submissions server-to-server, but the deployed Landing intake still rejects `source=vela_team_plan`. That leaves the Vela form returning `invalid_team_plan_lead`/400 even though the submitted fields are valid.

This PR isolates the already-reviewed signed intake changes onto `main` so Cloudflare can publish a durable per-PR preview for end-to-end acceptance without overwriting shared staging or production.

## What users will see

Vela Team-plan lead submissions can be accepted by the Landing `/contact-sales` intake when they carry the expected HMAC signature. Public Landing forms keep their existing same-origin behavior. Leads are persisted to the canonical `CONTACT_LEADS` KV record only after validation succeeds.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: the user-facing form is unchanged; this fixes its signed server-side persistence path.

## Bug fix verification

- Test path: `apps/landing-page/tests/contact-sales.test.ts`
- Red on `main`: the current deployed intake rejects `vela_team_plan` as `invalid_source`; the new contract cases are absent on `main`.
- Green on this branch: 17/17 focused contact-sales tests pass, including forged/stale signature rejection and signed Vela persistence.

## Validation

- `pnpm --filter @open-design/landing-page exec node --import tsx --test tests/contact-sales.test.ts` — 17/17 pass
- `pnpm --filter @open-design/landing-page typecheck` — 0 errors
- `pnpm guard` — pass
- `git diff --check origin/main...HEAD` — pass
