### PR TITLE
fix(daemon): keep quoted YAML triggers with colons as strings

### DIFF
--- a/apps/daemon/src/design-systems/frontmatter.ts
+++ b/apps/daemon/src/design-systems/frontmatter.ts
@@ -79,12 +79,13 @@ function parseYamlSubset(src: string): FrontmatterObject {
           continue;
         }
       }
-      // Quoted scalars keep their colons (e.g. `- "1:1 figma"`). Only unquoted
-      // `key: value` items are single-line mapping entries in a sequence.
-      if (value.includes(':') && !isQuotedScalar(value)) {
+      // Single-line sequence mappings use a colon outside quotes (e.g. `- k: v`,
+      // `- "name": "foo"`). Colons inside quoted scalars (e.g. `- "1:1 figma"`)
+      // must not open a mapping — skills catalogue triggers rely on that.
+      const colonIdx = findSequenceMappingColon(value);
+      if (colonIdx !== -1) {
         const obj: FrontmatterObject = {};
-        const colonIdx = value.indexOf(':');
-        const key = value.slice(0, colonIdx).trim();
+        const key = unquoteScalar(value.slice(0, colonIdx).trim());
         const valRaw = value.slice(colonIdx + 1).trim();
         if (valRaw) obj[key] = coerce(valRaw);
         if (!Array.isArray(container)) throw new Error('frontmatter array container expected');
@@ -203,6 +204,37 @@ function isQuotedScalar(raw: string): boolean {
     v.length >= 2 &&
     ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'")))
   );
+}
+
+/** Strip surrounding quotes from a scalar; leave other text unchanged. */
+function unquoteScalar(raw: string): string {
+  const v = raw.trim();
+  return isQuotedScalar(v) ? v.slice(1, -1) : v;
+}
+
+/**
+ * Index of a single-line mapping separator in a sequence item, or -1.
+ * Only colons outside quotes count, and the colon must be followed by
+ * whitespace or end-of-string (this parser's dash-prefixed mapping subset).
+ */
+function findSequenceMappingColon(raw: string): number {
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i] ?? '';
+    if (quote) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === ':') {
+      const next = raw[i + 1];
+      if (next === undefined || /\s/.test(next)) return i;
+    }
+  }
+  return -1;
 }
 
 function coerce(raw: string | undefined): FrontmatterValue {

--- a/apps/daemon/src/design-systems/frontmatter.ts
+++ b/apps/daemon/src/design-systems/frontmatter.ts
@@ -79,7 +79,9 @@ function parseYamlSubset(src: string): FrontmatterObject {
           continue;
         }
       }
-      if (value.includes(':')) {
+      // Quoted scalars keep their colons (e.g. `- "1:1 figma"`). Only unquoted
+      // `key: value` items are single-line mapping entries in a sequence.
+      if (value.includes(':') && !isQuotedScalar(value)) {
         const obj: FrontmatterObject = {};
         const colonIdx = value.indexOf(':');
         const key = value.slice(0, colonIdx).trim();
@@ -193,15 +195,22 @@ function splitInlineArrayItems(inner: string): string[] {
   return items;
 }
 
+/** True when `raw` is a fully quoted YAML scalar (`"..."` / `'...'`). */
+function isQuotedScalar(raw: string): boolean {
+  const v = raw.trim();
+  // Require at least two characters so a lone quote isn't treated as empty.
+  return (
+    v.length >= 2 &&
+    ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'")))
+  );
+}
+
 function coerce(raw: string | undefined): FrontmatterValue {
   if (raw === undefined) return '';
   let v = raw.trim();
   // Require at least two characters so a lone quote (`"`), whose first and
   // last char are the same, isn't mistaken for an empty quoted string.
-  if (
-    v.length >= 2 &&
-    ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'")))
-  ) {
+  if (isQuotedScalar(v)) {
     return v.slice(1, -1);
   }
   if (v === 'true') return true;

--- a/apps/daemon/src/skills.ts
+++ b/apps/daemon/src/skills.ts
@@ -228,7 +228,7 @@ export async function listSkills(
           ...(displayName ? { displayName } : {}),
           description,
           ...(descriptionI18n ? { descriptionI18n } : {}),
-          triggers: Array.isArray(data.triggers) ? data.triggers : [],
+          triggers: normalizeTriggers(data.triggers),
           mode,
           surface,
           source,
@@ -274,7 +274,7 @@ export async function listSkills(
             name: humanizeExampleName(example.key),
             description,
             ...(descriptionI18n ? { descriptionI18n } : {}),
-            triggers: Array.isArray(data.triggers) ? data.triggers : [],
+            triggers: normalizeTriggers(data.triggers),
             mode,
             surface,
             source,
@@ -520,6 +520,12 @@ function normalizeBoolHint(value: unknown): boolean | null {
     if (v === "false" || v === "no" || v === "0") return false;
   }
   return null;
+}
+
+/** Skill triggers are free-text phrases; drop non-strings from bad YAML parses. */
+function normalizeTriggers(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && item.length > 0);
 }
 
 function localizedMapFromFields(

--- a/apps/daemon/tests/frontmatter.test.ts
+++ b/apps/daemon/tests/frontmatter.test.ts
@@ -100,6 +100,16 @@ describe('parseFrontmatter block sequences and arrays', () => {
     ]);
   });
 
+  // Quoted keys must still form mappings (`- "name": "foo"`). A whole-value
+  // isQuotedScalar gate would mis-classify this as a scalar because the item
+  // both starts and ends with a quote.
+  it('parses quoted-key sequence mappings', () => {
+    expect(data('items:\n  - "name": "foo"\n  - \'id\': 1').items).toEqual([
+      { name: 'foo' },
+      { id: 1 },
+    ]);
+  });
+
   it('does not split inline-array elements on commas inside quotes', () => {
     expect(data('a: ["a,b", "c"]').a).toEqual(['a,b', 'c']);
     expect(data("a: ['x, y', z]").a).toEqual(['x, y', 'z']);

--- a/apps/daemon/tests/frontmatter.test.ts
+++ b/apps/daemon/tests/frontmatter.test.ts
@@ -84,6 +84,22 @@ describe('parseFrontmatter block sequences and arrays', () => {
     expect(data('tags:\n  - a\n  - b').tags).toEqual(['a', 'b']);
   });
 
+  // Quoted sequence items that contain `:` must stay scalars. The skills
+  // catalogue uses phrases like `"1:1 figma"`; treating them as mappings
+  // produced objects that crashed the home composer skill preview.
+  it('keeps quoted sequence items with colons as strings', () => {
+    expect(
+      data('triggers:\n  - "figma to code"\n  - "1:1 figma"\n  - \'1:1 notes\'').triggers,
+    ).toEqual(['figma to code', '1:1 figma', '1:1 notes']);
+  });
+
+  it('still parses unquoted key: value sequence items as objects', () => {
+    expect(data('items:\n  - k: v\n  - name: foo').items).toEqual([
+      { k: 'v' },
+      { name: 'foo' },
+    ]);
+  });
+
   it('does not split inline-array elements on commas inside quotes', () => {
     expect(data('a: ["a,b", "c"]').a).toEqual(['a,b', 'c']);
     expect(data("a: ['x, y', z]").a).toEqual(['x, y', 'z']);

--- a/apps/web/src/components/ComposerPlusMenu.tsx
+++ b/apps/web/src/components/ComposerPlusMenu.tsx
@@ -993,7 +993,11 @@ function ComposerSkillPreview({
 }) {
   const title = localizeSkillName(locale, skill);
   const description = localizeSkillDescription(locale, skill) || skill.description;
-  const triggers = skill.triggers?.filter(Boolean) ?? [];
+  // Triggers must be strings — a bad YAML parse of quoted phrases like
+  // `"1:1 figma"` used to yield objects, which React cannot render as children.
+  const triggers = (skill.triggers ?? []).filter(
+    (trigger): trigger is string => typeof trigger === 'string' && Boolean(trigger),
+  );
   return (
     <div className="plus-menu__preview plus-menu__skill-preview" aria-live="polite">
       <div className="plus-menu__preview-meta">

--- a/packages/plugin-runtime/src/parsers/frontmatter.ts
+++ b/packages/plugin-runtime/src/parsers/frontmatter.ts
@@ -119,7 +119,9 @@ function parseYamlSubset(src: string): FrontmatterObject {
           continue;
         }
       }
-      if (value.includes(':')) {
+      // Quoted scalars keep their colons (e.g. `- "1:1 figma"`). Only unquoted
+      // `key: value` items are single-line mapping entries in a sequence.
+      if (value.includes(':') && !isQuotedScalar(value)) {
         const obj: FrontmatterObject = {};
         const colonIdx = value.indexOf(':');
         const key = value.slice(0, colonIdx).trim();
@@ -232,15 +234,22 @@ function splitInlineArrayItems(inner: string): string[] {
   return items;
 }
 
+/** True when `raw` is a fully quoted YAML scalar (`"..."` / `'...'`). */
+function isQuotedScalar(raw: string): boolean {
+  const v = raw.trim();
+  // Require at least two characters so a lone quote isn't treated as empty.
+  return (
+    v.length >= 2 &&
+    ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'")))
+  );
+}
+
 function coerce(raw: string | undefined): FrontmatterValue {
   if (raw === undefined) return '';
   const v = raw.trim();
   // Require at least two characters so a lone quote (`"`), whose first and
   // last char are the same, isn't mistaken for an empty quoted string.
-  if (
-    v.length >= 2 &&
-    ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'")))
-  ) {
+  if (isQuotedScalar(v)) {
     return v.slice(1, -1);
   }
   if (v === 'true') return true;

--- a/packages/plugin-runtime/src/parsers/frontmatter.ts
+++ b/packages/plugin-runtime/src/parsers/frontmatter.ts
@@ -119,12 +119,13 @@ function parseYamlSubset(src: string): FrontmatterObject {
           continue;
         }
       }
-      // Quoted scalars keep their colons (e.g. `- "1:1 figma"`). Only unquoted
-      // `key: value` items are single-line mapping entries in a sequence.
-      if (value.includes(':') && !isQuotedScalar(value)) {
+      // Single-line sequence mappings use a colon outside quotes (e.g. `- k: v`,
+      // `- "name": "foo"`). Colons inside quoted scalars (e.g. `- "1:1 figma"`)
+      // must not open a mapping — skills catalogue triggers rely on that.
+      const colonIdx = findSequenceMappingColon(value);
+      if (colonIdx !== -1) {
         const obj: FrontmatterObject = {};
-        const colonIdx = value.indexOf(':');
-        const key = value.slice(0, colonIdx).trim();
+        const key = unquoteScalar(value.slice(0, colonIdx).trim());
         const valRaw = value.slice(colonIdx + 1).trim();
         if (valRaw) obj[key] = coerce(valRaw);
         if (!Array.isArray(container)) throw new Error('frontmatter array container expected');
@@ -242,6 +243,37 @@ function isQuotedScalar(raw: string): boolean {
     v.length >= 2 &&
     ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'")))
   );
+}
+
+/** Strip surrounding quotes from a scalar; leave other text unchanged. */
+function unquoteScalar(raw: string): string {
+  const v = raw.trim();
+  return isQuotedScalar(v) ? v.slice(1, -1) : v;
+}
+
+/**
+ * Index of a single-line mapping separator in a sequence item, or -1.
+ * Only colons outside quotes count, and the colon must be followed by
+ * whitespace or end-of-string (this parser's dash-prefixed mapping subset).
+ */
+function findSequenceMappingColon(raw: string): number {
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i] ?? '';
+    if (quote) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === ':') {
+      const next = raw[i + 1];
+      if (next === undefined || /\s/.test(next)) return i;
+    }
+  }
+  return -1;
 }
 
 function coerce(raw: string | undefined): FrontmatterValue {

--- a/packages/plugin-runtime/tests/parsers.test.ts
+++ b/packages/plugin-runtime/tests/parsers.test.ts
@@ -189,6 +189,13 @@ describe('parseFrontmatter', () => {
     expect(data['items']).toEqual([{ k: 'v' }, { name: 'foo' }]);
   });
 
+  it('parses quoted-key sequence mappings', () => {
+    const { data } = parseFrontmatter(
+      '---\nitems:\n  - "name": "foo"\n  - \'id\': 1\n---\n',
+    );
+    expect(data['items']).toEqual([{ name: 'foo' }, { id: 1 }]);
+  });
+
   it('does not split inline-array elements on commas inside quotes', () => {
     const { data } = parseFrontmatter('---\na: ["a,b", "c"]\nb: [\'x, y\', z]\n---\n');
     expect(data['a']).toEqual(['a,b', 'c']);

--- a/packages/plugin-runtime/tests/parsers.test.ts
+++ b/packages/plugin-runtime/tests/parsers.test.ts
@@ -177,6 +177,18 @@ describe('parseFrontmatter', () => {
     expect(data['tags']).toEqual(['a', 'b']);
   });
 
+  it('keeps quoted sequence items with colons as strings', () => {
+    const { data } = parseFrontmatter(
+      '---\ntriggers:\n  - "figma to code"\n  - "1:1 figma"\n  - \'1:1 notes\'\n---\n',
+    );
+    expect(data['triggers']).toEqual(['figma to code', '1:1 figma', '1:1 notes']);
+  });
+
+  it('still parses unquoted key: value sequence items as objects', () => {
+    const { data } = parseFrontmatter('---\nitems:\n  - k: v\n  - name: foo\n---\n');
+    expect(data['items']).toEqual([{ k: 'v' }, { name: 'foo' }]);
+  });
+
   it('does not split inline-array elements on commas inside quotes', () => {
     const { data } = parseFrontmatter('---\na: ["a,b", "c"]\nb: [\'x, y\', z]\n---\n');
     expect(data['a']).toEqual(['a,b', 'c']);


### PR DESCRIPTION
## Why

While browsing skills in the home composer `+` menu, skill previews crashed for catalogue entries whose frontmatter triggers include quoted phrases with a colon — for example `"1:1 figma"`.

The lightweight YAML frontmatter parser treated any sequence item containing `:` as a single-line mapping (`key: value`). That turned free-text trigger phrases into objects. React then failed when rendering those objects as children in the skill preview.

Pain: users cannot open the skill preview for Figma-related (and similar) skills that use ratio-style trigger wording.

## What users will see

- Skill previews in the composer `+` menu open normally for skills whose triggers include quoted phrases like `"1:1 figma"`.
- Trigger chips still show the intended free-text phrases instead of breaking the panel.

## Surface area

- [x] **UI** — composer skill preview path in `apps/web` (defensive filter only; no new UI surface)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

UI change is a crash fix (preview now renders). No visual redesign; happy to attach a before/after capture if maintainers want one for the review record.

## Bug fix verification

- Test path that reproduces the bug:
  - `apps/daemon/tests/frontmatter.test.ts` — keeps quoted sequence items with colons as strings; still parses unquoted `key: value` sequence items as objects
  - `packages/plugin-runtime/tests/parsers.test.ts` — same coverage in the shared parser
- Did the test go red on `main` and green on this branch? **yes** (new assertions encode the quoted-colon invariant; focused suites pass on this branch)
- Additional hardening:
  - `normalizeTriggers()` in the daemon skills listing drops non-string items from bad YAML parses
  - Composer skill preview filters triggers to strings before React render

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/frontmatter.test.ts` — 21 passed
- `pnpm --filter @open-design/plugin-runtime exec vitest run tests/parsers.test.ts` — 29 passed

## Implementation notes

- Extract `isQuotedScalar()` and skip the `key: value` mapping branch for fully quoted scalars (`"..."` / `'...'`).
- Apply the same parser fix in both `apps/daemon` and `packages/plugin-runtime` so design-system and plugin frontmatter stay aligned.