### PR TITLE
add OD_CI_CONTROL_FALLBACK escape hatch for the control runner profile

### DIFF
--- a/.github/scripts/runners.py
+++ b/.github/scripts/runners.py
@@ -26,7 +26,11 @@ def normalize_mode(raw_mode):
     return "default"
 
 
-def resolve_contract(mode):
+def is_enabled(raw_value):
+    return (raw_value or "").strip().lower() in {"1", "true", "yes", "on", "hosted"}
+
+
+def resolve_contract(mode, control_fallback=False):
     if mode == "economic":
         control = GITHUB_HOSTED
         workload = GITHUB_HOSTED
@@ -49,6 +53,10 @@ def resolve_contract(mode):
         # memory ceilings and is not covered by the medium right-size evidence.
         ui_p0_workload = NEXU_MEDIUM
         ui_p0_heavy_workload = NEXU_XLARGE
+    # Escape hatch: route control-profile jobs to GitHub-hosted runners when the
+    # self-hosted pool is unavailable, without changing runner mode.
+    if control_fallback:
+        control = GITHUB_HOSTED
 
     return {
         "runs_on": {
@@ -65,12 +73,16 @@ def resolve_contract(mode):
         "decision": {
             "schema_version": 1,
             "mode": mode,
+            "control_fallback": control_fallback,
         },
     }
 
 
 def main():
-    contract = resolve_contract(normalize_mode(os.environ.get("OD_CI_RUNNER_MODE")))
+    contract = resolve_contract(
+        normalize_mode(os.environ.get("OD_CI_RUNNER_MODE")),
+        is_enabled(os.environ.get("OD_CI_CONTROL_FALLBACK")),
+    )
     output_path = os.environ.get("GITHUB_OUTPUT")
     lines = [
         f"{key}={value if isinstance(value, str) else compact_json(value)}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
               && github.event.pull_request.head.repo.full_name != github.repository
               && 'economic'
               || vars.OD_CI_RUNNER_MODE }}
+          OD_CI_CONTROL_FALLBACK: ${{ vars.OD_CI_CONTROL_FALLBACK }}
         run: python3 .github/scripts/runners.py
 
   scopes:

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -255,12 +255,20 @@ if (process.argv.includes("--jq")) {
   }
 }
 
-async function runRunners(mode?: string): Promise<Record<string, string>> {
+async function runRunners(
+  mode?: string,
+  options: { controlFallback?: boolean } = {},
+): Promise<Record<string, string>> {
   const env = { ...process.env };
   if (mode === undefined) {
     delete env.OD_CI_RUNNER_MODE;
   } else {
     env.OD_CI_RUNNER_MODE = mode;
+  }
+  if (options.controlFallback) {
+    env.OD_CI_CONTROL_FALLBACK = "1";
+  } else {
+    delete env.OD_CI_CONTROL_FALLBACK;
   }
   delete env.GITHUB_OUTPUT;
 
@@ -289,8 +297,14 @@ function runnerOutput(profiles: Record<string, string>, key: string): string {
   return value;
 }
 
-function runnerDecision(profiles: Record<string, string>): { schema_version: number; mode: string } {
-  return JSON.parse(runnerOutput(profiles, "decision")) as { schema_version: number; mode: string };
+function runnerDecision(
+  profiles: Record<string, string>,
+): { schema_version: number; mode: string; control_fallback: boolean } {
+  return JSON.parse(runnerOutput(profiles, "decision")) as {
+    schema_version: number;
+    mode: string;
+    control_fallback: boolean;
+  };
 }
 
 function runnerRunsOn(profiles: Record<string, string>): Record<string, string[]> {
@@ -1374,7 +1388,7 @@ process.stdin.on("end", () => {
   it("[P2] resolves CI runner profiles by mode", async () => {
     const defaultProfiles = await runRunners();
     const defaultRunsOn = runnerRunsOn(defaultProfiles);
-    expect(runnerDecision(defaultProfiles)).toEqual({ schema_version: 1, mode: "default" });
+    expect(runnerDecision(defaultProfiles)).toEqual({ schema_version: 1, mode: "default", control_fallback: false });
     expect(Object.keys(defaultRunsOn).sort()).toEqual([
       "control",
       "general_medium",
@@ -1401,7 +1415,7 @@ process.stdin.on("end", () => {
 
     const performanceProfiles = await runRunners("performance");
     const performanceRunsOn = runnerRunsOn(performanceProfiles);
-    expect(runnerDecision(performanceProfiles)).toEqual({ schema_version: 1, mode: "performance" });
+    expect(runnerDecision(performanceProfiles)).toEqual({ schema_version: 1, mode: "performance", control_fallback: false });
     expect(performanceRunsOn.control).toEqual(["nexu-runners-small"]);
     expect(performanceRunsOn.general_medium).toEqual(["nexu-runners-medium"]);
     expect(performanceRunsOn.workspace_unit).toEqual(["nexu-runners-medium"]);
@@ -1414,7 +1428,7 @@ process.stdin.on("end", () => {
 
     const blacksmithProfiles = await runRunners("blacksmith");
     const blacksmithRunsOn = runnerRunsOn(blacksmithProfiles);
-    expect(runnerDecision(blacksmithProfiles)).toEqual({ schema_version: 1, mode: "blacksmith" });
+    expect(runnerDecision(blacksmithProfiles)).toEqual({ schema_version: 1, mode: "blacksmith", control_fallback: false });
     expect(blacksmithRunsOn.control).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
     expect(blacksmithRunsOn.general_medium).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
     expect(blacksmithRunsOn.workspace_unit).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
@@ -1427,7 +1441,7 @@ process.stdin.on("end", () => {
 
     const economicProfiles = await runRunners("economic");
     const economicRunsOn = runnerRunsOn(economicProfiles);
-    expect(runnerDecision(economicProfiles)).toEqual({ schema_version: 1, mode: "economic" });
+    expect(runnerDecision(economicProfiles)).toEqual({ schema_version: 1, mode: "economic", control_fallback: false });
     expect(economicRunsOn.control).toEqual(["ubuntu-24.04"]);
     expect(economicRunsOn.general_medium).toEqual(["ubuntu-24.04"]);
     expect(economicRunsOn.workspace_unit).toEqual(["ubuntu-24.04"]);
@@ -1440,7 +1454,7 @@ process.stdin.on("end", () => {
 
     for (const invalidMode of ["Economic", " economic "]) {
       const fallbackProfiles = await runRunners(invalidMode);
-      expect(runnerDecision(fallbackProfiles)).toEqual({ schema_version: 1, mode: "default" });
+      expect(runnerDecision(fallbackProfiles)).toEqual({ schema_version: 1, mode: "default", control_fallback: false });
       expect(runnerRunsOn(fallbackProfiles).control).toEqual(["nexu-runners-small"]);
     }
   });
@@ -1451,6 +1465,31 @@ process.stdin.on("end", () => {
     });
     expect(stderr).toBe("");
     expect(stdout).toContain("rerun_infra_cancel self-check OK");
+  });
+
+  it("[P2] control fallback routes only the control profile to GitHub-hosted", async () => {
+    const fallbackProfiles = await runRunners(undefined, { controlFallback: true });
+    const fallbackRunsOn = runnerRunsOn(fallbackProfiles);
+    expect(runnerDecision(fallbackProfiles)).toEqual({
+      schema_version: 1,
+      mode: "default",
+      control_fallback: true,
+    });
+    expect(fallbackRunsOn.control).toEqual(["ubuntu-24.04"]);
+    expect(fallbackRunsOn.general_medium).toEqual(["nexu-runners-medium"]);
+    expect(fallbackRunsOn.workspace_unit).toEqual(["nexu-runners-medium"]);
+    expect(fallbackRunsOn.windows_tools).toEqual(["windows-latest"]);
+    expect(fallbackRunsOn.js_hot).toEqual(["nexu-runners-medium"]);
+    expect(fallbackRunsOn.ui_hot).toEqual(["nexu-runners-large"]);
+    expect(fallbackRunsOn.visual_hot).toEqual(["nexu-runners-large"]);
+
+    // A non-default mode still only flips control; the other tiers stay mode-driven.
+    const blacksmithFallbackRunsOn = runnerRunsOn(
+      await runRunners("blacksmith", { controlFallback: true }),
+    );
+    expect(blacksmithFallbackRunsOn.control).toEqual(["ubuntu-24.04"]);
+    expect(blacksmithFallbackRunsOn.general_medium).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
+    expect(blacksmithFallbackRunsOn.js_hot).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
   });
 
   it("[P2] routes CI follow-ons through generic handoff workflows", async () => {


### PR DESCRIPTION
Refs #6289.

## Why

When the self-hosted `control` pool (`od-persistent-ci`) is unavailable, the `control`-profile required checks (`Detect validation scopes`, `Static gate`, `Validate workspace`, `Runtime summary`) stall or cancel and wedge approved PRs (#6076, #6079). Today the only lever is `OD_CI_RUNNER_MODE`, but its non-default modes also move `general_medium` and the hot paths, so there's no clean way to move just `control` to hosted.

## What users will see

No product or end-user change. This adds a maintainer-facing CI control: when the self-hosted `control` runner pool is unavailable, setting the `OD_CI_CONTROL_FALLBACK` repo variable routes the `control`-profile CI jobs to GitHub-hosted runners so PRs stop wedging on cancelled required checks. With the variable unset, CI behaves exactly as it does today.

## What it changes

A dedicated repo variable, `OD_CI_CONTROL_FALLBACK`. When a maintainer sets it truthy (`1`/`true`/`yes`/`on`/`hosted`), `control` jobs run on GitHub-hosted runners. It's off by default and independent of `OD_CI_RUNNER_MODE`, so it touches only the `control` profile. The resolved `decision` output now records `control_fallback` so the choice is visible in logs.

## Decision and rationale: least-privilege, no elevated token permissions

I considered automatic detection (have the resolve job query runner health and self-heal), but listing self-hosted runners requires `GET /repos/{owner}/{repo}/actions/runners`, which needs the `administration` permission. This workflow's token only has `actions: read`. Broadening the CI token would mean a standing privilege escalation on every run and a larger attack surface, so instead this uses a maintainer-flippable repo variable that needs no token permissions at all. If you'd later prefer automatic detection and are fine granting `administration: read`, that's a clean follow-up. I kept this change minimal.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [x] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

The new box is `OD_CI_CONTROL_FALLBACK`, a CI/Actions repo variable read by `.github/scripts/runners.py`.

## Bug fix verification

Ran `runners.py` locally across the relevant cases:
- unset: `control` stays self-hosted (unchanged default)
- `OD_CI_CONTROL_FALLBACK=1`: `control` becomes `ubuntu-24.04`
- `=hosted` with `OD_CI_RUNNER_MODE=performance`: only `control` flips; `general_medium` and the hot paths keep their mode values; `decision.control_fallback` is `true`
- empty string: unchanged

## Validation

Verified `runners.py` across the four cases above, and `ci.yml` parses as valid YAML. There's no test harness for `.github/scripts` today; I'm happy to add one if you have a preferred runner.
