### PR TITLE
feat(web): add syntax highlighting to source viewers

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -969,7 +969,7 @@ function HighlightedCode({
       .then(({ highlightCodeTokens }) => highlightCodeTokens(text, language))
       .then((lines) => {
         if (cancelled) return;
-        if (lines.length === 0 || highlightedCodeText(lines) !== text.replace(/\r\n/g, '\n')) {
+        if (lines.length === 0 || highlightedCodeText(lines) !== text.replaceAll('\r\n', '\n')) {
           setHighlighted(null);
           return;
         }

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -152,6 +152,7 @@ import {
 } from '../runtime/exports';
 import { copyToClipboard } from '../lib/copy-to-clipboard';
 import { buildReactComponentSrcdoc } from '../runtime/react-component';
+import type { HighlightedCodeToken } from '../runtime/shiki';
 import { shouldConsumeSlideNav } from '../runtime/slide-nav';
 import { findHtmlEntriesReferencing } from '../runtime/jsx-module-refs';
 import {
@@ -872,6 +873,140 @@ async function highlightMarkdownCodeBlocks(html: string): Promise<string> {
     changed = true;
   }));
   return changed ? root.innerHTML : html;
+}
+
+const MAX_HIGHLIGHT_SOURCE_CHARS = 100_000;
+const SYNTAX_LANGUAGE_BY_EXTENSION: Record<string, string> = {
+  cjs: 'javascript',
+  css: 'css',
+  cts: 'typescript',
+  htm: 'html',
+  html: 'html',
+  js: 'javascript',
+  jsx: 'jsx',
+  json: 'json',
+  mjs: 'javascript',
+  mts: 'typescript',
+  svg: 'xml',
+  ts: 'typescript',
+  tsx: 'tsx',
+  xhtml: 'html',
+};
+const SYNTAX_LANGUAGE_BY_MIME: Record<string, string> = {
+  'application/ecmascript': 'javascript',
+  'application/javascript': 'javascript',
+  'application/json': 'json',
+  'application/typescript': 'typescript',
+  'application/xhtml+xml': 'html',
+  'image/svg+xml': 'xml',
+  'text/css': 'css',
+  'text/html': 'html',
+  'text/javascript': 'javascript',
+  'text/jsx': 'jsx',
+  'text/json': 'json',
+  'text/tsx': 'tsx',
+  'text/typescript': 'typescript',
+};
+
+export function syntaxLanguageForFile(
+  file: Pick<ProjectFile, 'name' | 'mime'>,
+): string | null {
+  const extension = file.name.toLowerCase().match(/\.([^.]+)$/)?.[1] ?? '';
+  if (extension && SYNTAX_LANGUAGE_BY_EXTENSION[extension]) {
+    return SYNTAX_LANGUAGE_BY_EXTENSION[extension];
+  }
+  const mime = file.mime.toLowerCase().split(';', 1)[0]?.trim() ?? '';
+  return SYNTAX_LANGUAGE_BY_MIME[mime] ?? null;
+}
+
+function useHighlightThemeRevision(): number {
+  const [revision, setRevision] = useState(0);
+  useEffect(() => {
+    const bump = () => setRevision((current) => current + 1);
+    const observer = new MutationObserver(bump);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    });
+    const media = window.matchMedia?.('(prefers-color-scheme: dark)');
+    media?.addEventListener('change', bump);
+    return () => {
+      observer.disconnect();
+      media?.removeEventListener('change', bump);
+    };
+  }, []);
+  return revision;
+}
+
+function highlightedCodeText(lines: HighlightedCodeToken[][]): string {
+  return lines
+    .map((line) => line.map((token) => token.content).join(''))
+    .join('\n');
+}
+
+function HighlightedCode({
+  text,
+  language,
+}: {
+  text: string;
+  language: string | null;
+}) {
+  const themeRevision = useHighlightThemeRevision();
+  const [highlighted, setHighlighted] = useState<{
+    text: string;
+    language: string;
+    themeRevision: number;
+    lines: HighlightedCodeToken[][];
+  } | null>(null);
+
+  useEffect(() => {
+    if (!language || text.length > MAX_HIGHLIGHT_SOURCE_CHARS) {
+      setHighlighted(null);
+      return undefined;
+    }
+    let cancelled = false;
+    void import('../runtime/shiki')
+      .then(({ highlightCodeTokens }) => highlightCodeTokens(text, language))
+      .then((lines) => {
+        if (cancelled) return;
+        if (lines.length === 0 || highlightedCodeText(lines) !== text.replace(/\r\n/g, '\n')) {
+          setHighlighted(null);
+          return;
+        }
+        setHighlighted({ text, language, themeRevision, lines });
+      })
+      .catch(() => {
+        if (!cancelled) setHighlighted(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [language, text, themeRevision]);
+
+  const lines =
+    highlighted?.text === text &&
+    highlighted.language === language &&
+    highlighted.themeRevision === themeRevision
+      ? highlighted.lines
+      : null;
+  if (!lines) return text;
+
+  const nodes: ReactNode[] = [];
+  const lineBreaks = text.match(/\r\n|\n/g) ?? [];
+  lines.forEach((line, lineIndex) => {
+    line.forEach((token, tokenIndex) => {
+      nodes.push(
+        <span
+          key={`${lineIndex}:${tokenIndex}`}
+          style={token.color ? { color: token.color } : undefined}
+        >
+          {token.content}
+        </span>,
+      );
+    });
+    if (lineIndex < lines.length - 1) nodes.push(lineBreaks[lineIndex] ?? '\n');
+  });
+  return nodes;
 }
 
 function rewriteMarkdownImageSources(
@@ -6962,7 +7097,7 @@ function ReactComponentViewer({
             />
           </PreviewDrawOverlay>
         ) : (
-          <CodeWithLines text={source} />
+          <CodeWithLines text={source} language={syntaxLanguageForFile(file)} />
         )}
       </div>
     </div>
@@ -15723,7 +15858,9 @@ function HtmlViewer({
             ) : null}
           </div>
         ) : (
-          <pre className="viewer-source">{source}</pre>
+          <pre className="viewer-source">
+            <HighlightedCode text={source ?? ''} language={syntaxLanguageForFile(file)} />
+          </pre>
         )}
       </div>
       {speakerNotesPanel}
@@ -16932,7 +17069,7 @@ function TextViewer({
         {text === null ? (
           <div className="viewer-empty">{t('fileViewer.loading')}</div>
         ) : displayText !== null && lineCount > 0 ? (
-          <CodeWithLines text={displayText} />
+          <CodeWithLines text={displayText} language={syntaxLanguageForFile(file)} />
         ) : (
           <pre className="viewer-source">{displayText}</pre>
         )}
@@ -17095,7 +17232,7 @@ function MarkdownViewer({
   const [saveState, setSaveState] = useState<MarkdownSaveState>('idle');
   const [savedAt, setSavedAt] = useState<number | null>(null);
   const [highlightedHtml, setHighlightedHtml] = useState<{ source: string; html: string; themeRevision: number } | null>(null);
-  const [highlightThemeRevision, setHighlightThemeRevision] = useState(0);
+  const highlightThemeRevision = useHighlightThemeRevision();
   const [, bumpSavedRevision] = useState(0);
   const editorRef = useRef<HTMLTextAreaElement | null>(null);
   const markdownPreviewPaneRef = useRef<HTMLElement | null>(null);
@@ -17294,19 +17431,6 @@ function MarkdownViewer({
       }
     };
   }, [saveMarkdownText, text, viewerOnly]);
-
-  useEffect(() => {
-    const root = document.documentElement;
-    const bump = () => setHighlightThemeRevision((revision) => revision + 1);
-    const observer = new MutationObserver(bump);
-    observer.observe(root, { attributes: true, attributeFilter: ['data-theme'] });
-    const media = window.matchMedia?.('(prefers-color-scheme: dark)');
-    media?.addEventListener('change', bump);
-    return () => {
-      observer.disconnect();
-      media?.removeEventListener('change', bump);
-    };
-  }, []);
 
   async function copy() {
     if (text == null) return;
@@ -17786,7 +17910,13 @@ function markdownImageAlt(name: string): string {
     .trim() || 'image';
 }
 
-function CodeWithLines({ text }: { text: string }) {
+function CodeWithLines({
+  text,
+  language = null,
+}: {
+  text: string;
+  language?: string | null;
+}) {
   const lines = text.split('\n');
   // Trailing newline produces a phantom empty line — keep gutter aligned.
   const gutter = lines.map((_, i) => `${i + 1}`).join('\n');
@@ -17795,7 +17925,9 @@ function CodeWithLines({ text }: { text: string }) {
       <code className="gutter" aria-hidden>
         {gutter}
       </code>
-      <code className="lines">{text}</code>
+      <code className="lines">
+        <HighlightedCode text={text} language={language} />
+      </code>
     </pre>
   );
 }

--- a/apps/web/src/runtime/shiki.ts
+++ b/apps/web/src/runtime/shiki.ts
@@ -3,7 +3,25 @@ import type { HighlighterGeneric } from 'shiki';
 let highlighterPromise: Promise<HighlighterGeneric<any, any>> | null = null;
 
 const cache = new Map<string, string>();
+const tokenCache = new Map<string, HighlightedCodeToken[][]>();
+const languageLoadPromises = new Map<string, Promise<void>>();
 const CACHE_MAX = 128;
+const TOKEN_CACHE_MAX = 16;
+const TOKEN_RENDER_MAX = 20_000;
+const LAZY_LANGUAGE_LOADERS = {
+  diff: () => import('shiki/langs/diff.mjs').then((module) => module.default),
+  dockerfile: () => import('shiki/langs/dockerfile.mjs').then((module) => module.default),
+  go: () => import('shiki/langs/go.mjs').then((module) => module.default),
+  ruby: () => import('shiki/langs/ruby.mjs').then((module) => module.default),
+  rust: () => import('shiki/langs/rust.mjs').then((module) => module.default),
+  swift: () => import('shiki/langs/swift.mjs').then((module) => module.default),
+  toml: () => import('shiki/langs/toml.mjs').then((module) => module.default),
+};
+
+export type HighlightedCodeToken = {
+  content: string;
+  color?: string;
+};
 
 function getHighlighter(): Promise<HighlighterGeneric<any, any>> {
   if (!highlighterPromise) {
@@ -12,9 +30,8 @@ function getHighlighter(): Promise<HighlighterGeneric<any, any>> {
         themes: ['github-light-default', 'github-dark-default'],
         langs: [
           'javascript', 'typescript', 'tsx', 'jsx', 'html', 'css', 'json',
-          'python', 'bash', 'shell', 'markdown', 'yaml', 'sql', 'rust',
-          'go', 'java', 'c', 'cpp', 'swift', 'ruby', 'php', 'diff',
-          'toml', 'xml', 'graphql', 'dockerfile',
+          'python', 'bash', 'shell', 'markdown', 'yaml', 'sql', 'java',
+          'c', 'cpp', 'php', 'xml', 'graphql',
         ],
       }),
     );
@@ -30,6 +47,41 @@ function isDarkMode(): boolean {
   return window.matchMedia('(prefers-color-scheme: dark)').matches;
 }
 
+function setBoundedCache<T>(
+  target: Map<string, T>,
+  key: string,
+  value: T,
+  maxEntries = CACHE_MAX,
+): void {
+  if (target.size >= maxEntries) {
+    const first = target.keys().next().value;
+    if (first !== undefined) target.delete(first);
+  }
+  target.set(key, value);
+}
+
+async function ensureLanguageLoaded(
+  highlighter: HighlighterGeneric<any, any>,
+  lang: string,
+): Promise<boolean> {
+  if (highlighter.getLoadedLanguages().includes(lang as any)) return true;
+  const loader = LAZY_LANGUAGE_LOADERS[lang as keyof typeof LAZY_LANGUAGE_LOADERS];
+  if (!loader) return false;
+
+  let loadPromise = languageLoadPromises.get(lang);
+  if (!loadPromise) {
+    loadPromise = loader().then((registrations) => highlighter.loadLanguage(...registrations));
+    languageLoadPromises.set(lang, loadPromise);
+  }
+  try {
+    await loadPromise;
+  } catch (error) {
+    languageLoadPromises.delete(lang);
+    throw error;
+  }
+  return highlighter.getLoadedLanguages().includes(lang as any);
+}
+
 export async function highlightCode(code: string, lang: string): Promise<string> {
   const dark = isDarkMode();
   const cacheKey = `${dark ? 'd' : 'l'}:${lang}:${code}`;
@@ -37,20 +89,39 @@ export async function highlightCode(code: string, lang: string): Promise<string>
   if (cached) return cached;
 
   const highlighter = await getHighlighter();
-  const loadedLangs = highlighter.getLoadedLanguages();
-  if (!loadedLangs.includes(lang as any)) {
-    return '';
-  }
+  if (!(await ensureLanguageLoaded(highlighter, lang))) return '';
 
   const html = highlighter.codeToHtml(code, {
     lang,
     theme: dark ? 'github-dark-default' : 'github-light-default',
   });
 
-  if (cache.size >= CACHE_MAX) {
-    const first = cache.keys().next().value;
-    if (first !== undefined) cache.delete(first);
-  }
-  cache.set(cacheKey, html);
+  setBoundedCache(cache, cacheKey, html);
   return html;
+}
+
+export async function highlightCodeTokens(
+  code: string,
+  lang: string,
+): Promise<HighlightedCodeToken[][]> {
+  const dark = isDarkMode();
+  const cacheKey = `${dark ? 'd' : 'l'}:${lang}:${code}`;
+  const cached = tokenCache.get(cacheKey);
+  if (cached) return cached;
+
+  const highlighter = await getHighlighter();
+  if (!(await ensureLanguageLoaded(highlighter, lang))) return [];
+
+  const result = highlighter.codeToTokens(code, {
+    lang,
+    theme: dark ? 'github-dark-default' : 'github-light-default',
+  });
+  const tokens = result.tokens.map((line) =>
+    line.map(({ content, color }) => ({ content, color })),
+  );
+  const tokenCount = tokens.reduce((count, line) => count + line.length, 0);
+  if (tokenCount > TOKEN_RENDER_MAX) return [];
+
+  setBoundedCache(tokenCache, cacheKey, tokens, TOKEN_CACHE_MAX);
+  return tokens;
 }

--- a/apps/web/tests/components/FileViewer.syntax-highlighting.test.tsx
+++ b/apps/web/tests/components/FileViewer.syntax-highlighting.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FileViewer } from '../../src/components/FileViewer';
+import type { ProjectFile } from '../../src/types';
+
+const { highlightCodeTokensMock } = vi.hoisted(() => ({
+  highlightCodeTokensMock: vi.fn(),
+}));
+
+vi.mock('../../src/runtime/shiki', () => ({
+  highlightCode: vi.fn(async () => ''),
+  highlightCodeTokens: highlightCodeTokensMock,
+}));
+
+function sourceFile(overrides: Partial<ProjectFile>): ProjectFile {
+  return {
+    name: 'index.html',
+    path: 'index.html',
+    type: 'file',
+    size: 1024,
+    mtime: 1710000000,
+    kind: 'html',
+    mime: 'text/html',
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  highlightCodeTokensMock.mockReset();
+  document.documentElement.removeAttribute('data-theme');
+});
+
+describe('FileViewer source syntax highlighting', () => {
+  it('highlights HTML source and refreshes its colors when the app theme changes', async () => {
+    const source = [
+      '<!doctype html>',
+      '<style>body { color: tomato; }</style>',
+      '<script>document.body.dataset.ready = "true";</script>',
+    ].join('\n');
+    highlightCodeTokensMock.mockImplementation(async (code: string) => [
+      [{ content: code, color: '#ff7b72' }],
+    ]);
+
+    const { container } = render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={sourceFile({
+          artifactManifest: {
+            version: 1,
+            kind: 'html',
+            title: 'Page',
+            entry: 'index.html',
+            renderer: 'html',
+            exports: ['html'],
+          },
+        })}
+        liveHtml={source}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^code$/i }));
+
+    await waitFor(() => {
+      expect(highlightCodeTokensMock).toHaveBeenCalledWith(source, 'html');
+    });
+    const sourceView = container.querySelector('.viewer-source');
+    expect(sourceView?.textContent).toBe(source);
+    expect(sourceView?.querySelector('span[style*="color"]')).not.toBeNull();
+
+    document.documentElement.setAttribute('data-theme', 'dark');
+    await waitFor(() => {
+      expect(highlightCodeTokensMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it.each([
+    ['styles.css', 'text/css', 'body { color: tomato; }', 'css'],
+    ['app.js', 'text/javascript', 'const ready = true;', 'javascript'],
+  ])('highlights %s while preserving its text and line gutter', async (name, mime, source, language) => {
+    highlightCodeTokensMock.mockImplementation(async (code: string) => [
+      [{ content: code, color: '#79c0ff' }],
+    ]);
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(source, { status: 200 })));
+
+    const { container } = render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={sourceFile({ name, path: name, mime, kind: 'code' })}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(highlightCodeTokensMock).toHaveBeenCalledWith(source, language);
+    });
+    expect(container.querySelector('.code-viewer .lines')?.textContent).toBe(source);
+    expect(container.querySelector('.code-viewer .gutter')?.textContent).toBe('1');
+    expect(container.querySelector('.code-viewer .lines span[style*="color"]')).not.toBeNull();
+  });
+
+  it('preserves CRLF line endings while highlighting', async () => {
+    const source = 'const first = true;\r\nconst second = true;';
+    highlightCodeTokensMock.mockResolvedValue([
+      [{ content: 'const first = true;', color: '#79c0ff' }],
+      [{ content: 'const second = true;', color: '#79c0ff' }],
+    ]);
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(source, { status: 200 })));
+
+    const { container } = render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={sourceFile({
+          name: 'windows.js',
+          path: 'windows.js',
+          mime: 'text/javascript',
+          kind: 'code',
+        })}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('.code-viewer .lines span[style*="color"]')).not.toBeNull();
+    });
+    expect(container.querySelector('.code-viewer .lines')?.textContent).toBe(source);
+    expect(container.querySelector('.code-viewer .gutter')?.textContent).toBe('1\n2');
+  });
+
+  it('leaves large source files as plain text', async () => {
+    const source = `<main>${'x'.repeat(100_000)}</main>`;
+    const { container } = render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={sourceFile({
+          size: source.length,
+          artifactManifest: {
+            version: 1,
+            kind: 'html',
+            title: 'Large page',
+            entry: 'index.html',
+            renderer: 'html',
+            exports: ['html'],
+          },
+        })}
+        liveHtml={source}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^code$/i }));
+
+    await waitFor(() => {
+      expect(container.querySelector('.viewer-source')?.textContent).toBe(source);
+    });
+    expect(highlightCodeTokensMock).not.toHaveBeenCalled();
+    expect(container.querySelector('.viewer-source span')).toBeNull();
+  });
+});

--- a/apps/web/tests/components/FileViewer.syntax-highlighting.test.tsx
+++ b/apps/web/tests/components/FileViewer.syntax-highlighting.test.tsx
@@ -64,7 +64,7 @@ describe('FileViewer source syntax highlighting', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /^code$/i }));
+    fireEvent.click(screen.getByRole('tab', { name: /^code$/i }));
 
     await waitFor(() => {
       expect(highlightCodeTokensMock).toHaveBeenCalledWith(source, 'html');
@@ -154,7 +154,7 @@ describe('FileViewer source syntax highlighting', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /^code$/i }));
+    fireEvent.click(screen.getByRole('tab', { name: /^code$/i }));
 
     await waitFor(() => {
       expect(container.querySelector('.viewer-source')?.textContent).toBe(source);

--- a/apps/web/tests/components/FileViewer.syntax-highlighting.test.tsx
+++ b/apps/web/tests/components/FileViewer.syntax-highlighting.test.tsx
@@ -105,10 +105,11 @@ describe('FileViewer source syntax highlighting', () => {
   });
 
   it('preserves CRLF line endings while highlighting', async () => {
-    const source = 'const first = true;\r\nconst second = true;';
+    const source = 'const first = true;\r\nconst second = true;\r\nconst third = true;';
     highlightCodeTokensMock.mockResolvedValue([
       [{ content: 'const first = true;', color: '#79c0ff' }],
       [{ content: 'const second = true;', color: '#79c0ff' }],
+      [{ content: 'const third = true;', color: '#79c0ff' }],
     ]);
     vi.stubGlobal('fetch', vi.fn(async () => new Response(source, { status: 200 })));
 
@@ -129,7 +130,7 @@ describe('FileViewer source syntax highlighting', () => {
       expect(container.querySelector('.code-viewer .lines span[style*="color"]')).not.toBeNull();
     });
     expect(container.querySelector('.code-viewer .lines')?.textContent).toBe(source);
-    expect(container.querySelector('.code-viewer .gutter')?.textContent).toBe('1\n2');
+    expect(container.querySelector('.code-viewer .gutter')?.textContent).toBe('1\n2\n3');
   });
 
   it('leaves large source files as plain text', async () => {

--- a/apps/web/tests/runtime/shiki.test.ts
+++ b/apps/web/tests/runtime/shiki.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { highlightCode, highlightCodeTokens } from '../../src/runtime/shiki';
+
+describe('highlightCodeTokens', () => {
+  it('colors mixed HTML source without changing its text', async () => {
+    const source = [
+      '<!doctype html>',
+      '<style>body { color: tomato; }</style>',
+      '<script>document.body.dataset.ready = "true";</script>',
+    ].join('\n');
+
+    const lines = await highlightCodeTokens(source, 'html');
+
+    expect(lines.map((line) => line.map((token) => token.content).join('')).join('\n')).toBe(source);
+    expect(lines.flat().some((token) => Boolean(token.color))).toBe(true);
+  });
+
+  it('returns no tokens for unsupported languages', async () => {
+    await expect(highlightCodeTokens('hello', 'not-a-language')).resolves.toEqual([]);
+  });
+
+  it('loads configured languages that are outside the web bundle on demand', async () => {
+    await expect(highlightCode('fn main() {}', 'rust')).resolves.toContain('class="shiki');
+  });
+});


### PR DESCRIPTION
Fixes #6301

## Why

Generated HTML, CSS, and JavaScript files were rendered as monochrome text in the source viewer, making larger artifacts difficult to scan. This change addresses the issue reported from the Open Design desktop app while reusing the project’s existing Shiki runtime.

## What users will see

Supported source files now use theme-aware syntax colors in the existing viewer. Line numbers and exact source text are preserved, with plain-text fallback for unsupported, oversized, or unusually token-dense files.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

| Before | After — HTML |
| --- | --- |
| ![Monochrome source viewer before this change](https://raw.githubusercontent.com/Nameless-Monster-Nerd/open-design/7ae86dbbd760d2268f405a88f6ff6e18009fdf3e/6303/before.png) | ![Theme-aware HTML syntax highlighting](https://raw.githubusercontent.com/Nameless-Monster-Nerd/open-design/7ae86dbbd760d2268f405a88f6ff6e18009fdf3e/6303/html-after.png) |

| CSS | JavaScript |
| --- | --- |
| ![Theme-aware CSS syntax highlighting](https://raw.githubusercontent.com/Nameless-Monster-Nerd/open-design/7ae86dbbd760d2268f405a88f6ff6e18009fdf3e/6303/css-after.png) | ![Theme-aware JavaScript syntax highlighting](https://raw.githubusercontent.com/Nameless-Monster-Nerd/open-design/7ae86dbbd760d2268f405a88f6ff6e18009fdf3e/6303/javascript-after.png) |

## Bug fix verification

- Test path: `apps/web/src/components/__tests__/FileViewer.syntax-highlight.test.tsx`
- The regression test failed on `main` because the viewer never called Shiki for HTML/CSS/JavaScript, then passed on this branch.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web test` — 4,909 passed, 7 skipped
- `pnpm --filter @open-design/web build`
- Manual dark-theme verification for HTML, CSS, and JavaScript; exact source and line gutters preserved
