### PR TITLE
fix(daemon): stop duplicating form answers on the resume (skipTranscript) path

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1787,7 +1787,11 @@ export function composeChatUserRequestForAgent(
   const transition = formAnswerTransitionForCurrentPrompt(currentPrompt);
   if (!transition) return body;
   if (skip) {
-    return [transition, body].join('\n\n');
+    // The transition block already embeds the trimmed `currentPrompt`
+    // (the submitted form answers). On the resume path `body` IS
+    // `currentPrompt`, so appending it would ship the answers twice
+    // (issue #6239); the transition alone carries the whole turn.
+    return transition;
   }
   return [
     transition,

--- a/apps/daemon/tests/telemetry-message-finalization.test.ts
+++ b/apps/daemon/tests/telemetry-message-finalization.test.ts
@@ -183,6 +183,34 @@ describe('Langfuse message finalization gate', () => {
     expect(prompt).not.toContain('## assistant');
   });
 
+  // Issue #6239: the form-answer transition block already embeds the
+  // trimmed `currentPrompt` verbatim, so appending `body = currentPrompt`
+  // after it on the resume (skipTranscript) path shipped the submitted
+  // answers twice in the same `# User request`.
+  it('ships the submitted form answers exactly once on the resume (skipTranscript) path', () => {
+    const currentPrompt = [
+      '[form answers — discovery]',
+      '- output: Dashboard / tool UI',
+      '- brand: Pick a direction for me [value: pick_direction]',
+    ].join('\n');
+    const transcript = [
+      '## user',
+      'initial brief',
+      '',
+      '## assistant',
+      '<question-form id="discovery">…</question-form>',
+      '',
+      '## user',
+      currentPrompt,
+    ].join('\n');
+
+    const prompt = composeChatUserRequestForAgent(transcript, currentPrompt, {
+      skipTranscript: true,
+    });
+
+    expect(prompt.split(currentPrompt).length - 1).toBe(1);
+  });
+
   // The aggressive form-answered OVERRIDE block is what tells weak
   // plain agents (GPT-OSS-120B Medium, Gemini 3.5 Flash) to skip
   // RULE 1's form example on follow-up turns. We pin the trigger


### PR DESCRIPTION
Fixes #6239

## Why

Issue #6239 reports that on the turn after a `<question-form>` submission, resume-capable agents (today: Claude via `--resume`, i.e. the `skipTranscript: true` path) receive the submitted form answers **twice** in the `# User request` block. The transition block built by `formAnswerTransitionForCurrentPrompt(currentPrompt)` already embeds the entire trimmed `currentPrompt`, and the resume branch of `composeChatUserRequestForAgent` then appended `body = currentPrompt` again via `[transition, body].join('\n\n')`.

No functional misbehavior was observed — the model just reads the same answers twice — but it duplicates the full answer block on every post-form turn for resume-capable agents, wasting context and inviting confusion. The issue thread already converged on the narrow fix direction taken here.

## What users will see

Nothing visible changes in the UI. Agents that resume their own CLI session now receive exactly one copy of the submitted form answers on the turn after a form submission, instead of the same block twice.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — no UI change.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/telemetry-message-finalization.test.ts` → `ships the submitted form answers exactly once on the resume (skipTranscript) path`
- Did the test go red on `main` and green on this branch? **yes** — red on `main` (`expected 2 to be 1`, i.e. the answers block appeared twice), green after the one-line fix.

## Validation

- `pnpm guard` — passed
- `pnpm typecheck` — passed
- `pnpm exec vitest run tests/chat-route.test.ts tests/telemetry-message-finalization.test.ts` in `apps/daemon` — 97/97 passed
- Full `@open-design/daemon` vitest suite on Node 24 — see PR checks
