### PR TITLE
docs(deploy): tell Docker users to browse 127.0.0.1, not localhost

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -109,6 +109,13 @@ OPEN_DESIGN_IMAGE=open-design-local
 docker compose -f docker-compose.yml -f docker-compose.linux.yml up -d --no-build
 ```
 
+Then open **`http://127.0.0.1:7456`** in the browser — not `http://localhost:7456`.
+The Linux override binds the daemon to `127.0.0.1`, which leaves `localhost` as
+the reserved powered-preview origin: a tab on that name has its `/api` requests
+answered with `403 Powered preview origin cannot access this API route`, and the
+project list comes up empty even though the projects exist. `curl` and MCP
+clients are unaffected, since the guard keys off browser `sec-fetch-*` headers.
+
 Common install paths:
 
 | CLI | Default path |

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -81,9 +81,15 @@ Success looks like:
 ## Step 6: Open Open Design in Your Browser
 
 Open:
-- `http://localhost:7456/`
+- `http://127.0.0.1:7456/`
 
 You should see the Open Design interface.
+
+Use `127.0.0.1`, not `localhost`. The daemon reserves whichever of the two
+names it is *not* bound to as the powered-preview origin, so browsing via that
+other name makes the daemon treat the tab as a sandboxed preview and reject its
+`/api` calls with `403`. Both Compose files bind a `127.0.0.1`-equivalent host,
+which leaves `localhost` as the reserved name.
 
 ![Open Design home (desktop)](../screenshots/deployment/docker/01-open-design-home.png)
 ![Open Design home (mobile)](../screenshots/deployment/docker/03-open-design-mobile.png)
@@ -96,3 +102,4 @@ You should see the Open Design interface.
 - `pull access denied` or `authentication required` for `ghcr.io/nexu-io/od`: the GHCR package must be public for anonymous Docker, Compose, and Dokploy pulls. An organization maintainer must open GitHub -> Packages -> `od` -> Package settings and change visibility to Public.
 - reverse proxy + `OD_API_TOKEN`: either inject `Authorization: Bearer <OD_API_TOKEN>` at the proxy, or set `OPEN_DESIGN_DISABLE_API_AUTH=1` only when that proxy already authenticates every request and the daemon is not directly exposed.
 - `Authorization: Bearer <OD_API_TOKEN> required` on macOS: Docker Desktop bridge networking makes the daemon see requests as non-loopback. See [Docker Desktop on macOS](../../deploy/README.md#docker-desktop-on-macos) for the host networking workaround.
+- **Empty project list in the browser while `curl` returns real projects**: you are browsing `http://localhost:7456` instead of `http://127.0.0.1:7456`. The daemon reserves the loopback name it is not bound to for powered previews, so `/api/projects` answers `403 {"error":"Powered preview origin cannot access this API route"}`. `curl` and MCP clients send no `sec-fetch-*` headers and are unaffected, which is why the failure looks like missing data rather than a blocked request. Confirm in DevTools -> Network, then reopen on `127.0.0.1`.


### PR DESCRIPTION
Part of #6263 — this is the docs half, split off as agreed in [this comment](https://github.com/nexu-io/open-design/issues/6263#issuecomment-5150396686). #6302 covers the UI half (surfacing the blocked-origin error instead of the empty state), so neither PR closes the issue on its own.

## Why

I hit this myself while following `docs/deployment/docker.md` end to end on a fresh Docker install. Step 6 tells you to open `http://localhost:7456/`, and that is precisely the URL the origin guard rejects: the daemon reserves whichever loopback name it is *not* bound to as the powered-preview origin, so a browser tab on that name has its `/api` calls answered with `403 {"error":"Powered preview origin cannot access this API route"}` — and `listProjects` swallows that into an empty project list.

The pain is that the walkthrough itself walks users into the failure. Step 5 already uses `127.0.0.1` for the `curl` check, so the doc switches loopback names between the verification step and the browser step, and only the browser step is affected. `curl` and MCP clients send no `sec-fetch-*` headers and pass the guard either way — which is exactly why this reads as "Docker install produced no projects" rather than "my request was blocked".

**It is not Linux-specific.** Worth flagging, because #6263 was filed as a Linux Docker report and I assumed the same when I picked it up. Measured against the guard on `main` (`517f39a`) with the `Host` header as the only variable:

| daemon bind host | `Host: localhost` | `Host: 127.0.0.1` |
|---|---|---|
| `127.0.0.1` — `docker-compose.linux.yml` | **403** | 200 |
| `0.0.0.0` — `docker-compose.yml` (default) | **403** | 200 |

`reportHostForPoweredPreview()` maps `0.0.0.0` to `127.0.0.1`, so `poweredPreviewHost()` returns `localhost` under the default Compose file as well. Both paths land in the same place, which is why this fixes the shared Step 6 rather than adding a Linux-only aside.

## What users will see

- The Docker walkthrough now sends you to `http://127.0.0.1:7456/` in Step 6, consistent with the `curl` in Step 5, with a one-line note on why `localhost` is the reserved name here. Following the doc verbatim now lands on a working project list instead of an empty one.
- A new Common Issues entry keyed to the observable symptom — "empty project list in the browser while `curl` returns real projects" — that names the 403 and the DevTools check, so users who already hit it can search their way out.
- `deploy/README.md`'s Linux host-networking section now states which browser URL to open. It previously covered `network_mode: host` and the CLI mounts but never said the URL.

No behavior change: docs only, nothing shipped or executed changes.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — docs only (`docs/deployment/docker.md`, `deploy/README.md`; +15 / −1)

## Screenshots

N/A — no UI surface touched.

## Bug fix verification

No red spec: the defect is in prose, so there is nothing in the test suite that can go red on `main` and green here. What I did instead is the probe described under **Validation** — it establishes that the URL the doc tells users to open is the one the guard rejects, which is the whole claim this PR rests on.

To be precise about scope: I verified the **guard's behavior**, not a full end-to-end Docker run. The browser-side symptom (empty project list) is the report in #6263; what I added is the measurement showing which loopback name gets the 403 and that it is not Linux-specific.

## Validation

- Drove the guard directly on a worktree at `upstream/main` (`517f39a`) with the `Host` header as the only variable, for both daemon bind hosts — the 403 / 200 matrix under **Why**. `Host: localhost` is rejected with `{"error":"Powered preview origin cannot access this API route"}` in every combination; `Host: 127.0.0.1` returns 200.
- Traced `reportHostForPoweredPreview()` → `poweredPreviewHost()` to confirm `0.0.0.0` (the default `docker-compose.yml` bind) resolves to the same reserved `localhost`, so the default Compose path is affected identically — the reason this edits the shared Step 6 instead of adding a Linux-only aside.
- Cross-checked the two edited files against Step 5's existing `curl` example so the walkthrough no longer switches loopback names mid-flow.
- No `pnpm guard` / `pnpm typecheck` run: the branch changes two Markdown files (+15 / −1) and touches nothing those checks cover. Happy to run them if you'd rather have the clean output on record.

## One thing I did not change, deliberately

`DEFAULT_DAEMON_BIND_HOST` is `127.0.0.1` (`apps/daemon/src/daemon-startup.ts:31`), so `localhost:7456` is the reserved name for **every** install method, not only Docker — and `QUICKSTART.md`, `README.md` and their translations all point users at `localhost:7456`. I have not touched those: it is a much wider change than the docs half of this issue, the non-Docker flows normally auto-open the correct URL so users rarely type the name by hand, and I would rather you decide whether the answer there is a docs sweep or making the guard tolerate both loopback spellings for first-party origins. Happy to do either as a follow-up.

Related: #6263 (original issue context), #6302 (the UI half of the same fix).
