### PR TITLE
feat(5824): Home page @-mention supports multiple skills via skillIds array

### DIFF
--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -1553,7 +1553,7 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
 
   app.post('/api/projects', async (req, res) => {
     try {
-      const { id, name, projectLocationId, skillId, designSystemId, pendingPrompt, metadata, customInstructions, skipDiscoveryBrief } =
+      const { id, name, projectLocationId, skillId, skillIds, designSystemId, pendingPrompt, metadata, customInstructions, skipDiscoveryBrief } =
         req.body || {};
       if (typeof id !== 'string' || !isSafeId(id)) {
         return sendApiError(res, 400, 'BAD_REQUEST', 'invalid project id');
@@ -1622,11 +1622,38 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
         );
       }
       const normalizedDesignSystemId = designSystemValidation.id;
-      const skillValidation = await validateProjectSkillId(skillId);
-      if (!skillValidation.ok) {
-        return sendApiError(res, 400, skillValidation.code, skillValidation.message);
+      // Validate all skillIds and resolve the primary (first entry) as
+      // the project-level skillId.  Empty arrays and absent arrays are
+      // equivalent to no skill selection.
+      let normalizedSkillId: string | null = null;
+      if (skillIds != null && Array.isArray(skillIds) && skillIds.length > 0) {
+        const firstId = skillIds[0];
+        if (typeof firstId !== 'string' || !firstId.trim()) {
+          return sendApiError(res, 400, 'INVALID_SKILL_ID', 'skillIds must contain non-empty strings');
+        }
+        const firstValidation = await validateProjectSkillId(firstId);
+        if (!firstValidation.ok) {
+          return sendApiError(res, 400, firstValidation.code, firstValidation.message);
+        }
+        normalizedSkillId = firstValidation.id;
+        const rest = skillIds.slice(1);
+        for (const sid of rest) {
+          if (typeof sid !== 'string' || !sid.trim()) {
+            return sendApiError(res, 400, 'INVALID_SKILL_ID', 'skillIds must contain non-empty strings');
+          }
+          const sv = await validateProjectSkillId(sid);
+          if (!sv.ok) {
+            return sendApiError(res, 400, sv.code, sv.message);
+          }
+        }
+      } else if (skillId != null) {
+        // Legacy singular skillId path — validate it directly.
+        const skillValidation = await validateProjectSkillId(skillId);
+        if (!skillValidation.ok) {
+          return sendApiError(res, 400, skillValidation.code, skillValidation.message);
+        }
+        normalizedSkillId = skillValidation.id;
       }
-      const normalizedSkillId = skillValidation.id;
       const selectedLocationId = await resolveCreateProjectLocationId(projectLocationId);
       let externalProjectDir: string | null = null;
       if (selectedLocationId !== BUILT_IN_PROJECT_LOCATION_ID) {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1547,6 +1547,7 @@ function AppInner() {
         result = await createProject({
           name: input.name,
           skillId: input.skillId,
+          skillIds: input.skillIds,
           designSystemId: input.designSystemId,
           pendingPrompt: derivedPendingPrompt,
           metadata,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1720,6 +1720,23 @@ function AppInner() {
               `od:auto-send-context:${result.project.id}`,
             );
           }
+          // Multi-skill `@skill-a @skill-b` compose list. createProject
+          // already forwarded `input.skillIds` to the daemon, but the auto
+          // send hand-off used to only carry prompt/attachments/context to
+          // ProjectView — so the first run still launched with just
+          // `project.skillId` and the extra skills were silently lost
+          // (PR #6333 review). Stash the array in a dedicated key so the
+          // ProjectView auto-send path can put it back into `meta.skillIds`.
+          if (Array.isArray(input.skillIds) && input.skillIds.length > 0) {
+            window.sessionStorage.setItem(
+              `od:auto-send-skillIds:${result.project.id}`,
+              JSON.stringify(input.skillIds),
+            );
+          } else {
+            window.sessionStorage.removeItem(
+              `od:auto-send-skillIds:${result.project.id}`,
+            );
+          }
         } catch {
           /* sessionStorage may be unavailable (e.g. SSR / private mode); fall
              back to manual send. */

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -142,6 +142,7 @@ import { NewProjectModal } from './NewProjectModal';
 import { PluginsView } from './PluginsView';
 import type { CreateInput, CreateTab, ImportClaudeDesignOutcome } from './NewProjectPanel';
 import type { PluginLoopSubmit } from './PluginLoopHome';
+import { buildCreateProjectArgsFromPluginLoopSubmit } from './plugin-loop-submit';
 import {
   createProject,
   type PluginShareAction,
@@ -814,28 +815,16 @@ export function EntryShell({
       } : {}),
     };
     return onCreateProject({
-      name,
-      skillId: payload.skillId ?? null,
-      designSystemId: payload.designSystemId ?? null,
+      ...buildCreateProjectArgsFromPluginLoopSubmit(payload, {
+        name,
+        amrGatePrechecked,
+      }),
       metadata,
-      pendingPrompt: payload.prompt,
-      ...(payload.pluginId ? { pluginId: payload.pluginId } : {}),
-      ...(payload.pluginType ? { pluginType: payload.pluginType } : {}),
-      ...(payload.appliedPluginSnapshotId
-        ? { appliedPluginSnapshotId: payload.appliedPluginSnapshotId }
-        : {}),
-      ...(payload.pluginInputs ? { pluginInputs: payload.pluginInputs } : {}),
-      ...(payload.initialRunContext ? { initialRunContext: payload.initialRunContext } : {}),
-      ...(payload.conversationMode ? { conversationMode: payload.conversationMode } : {}),
-      ...(payload.attachments && payload.attachments.length > 0
-        ? { pendingFiles: payload.attachments }
-        : {}),
-      // No `userWorkingDirToken`: linkedDirs grant read-only `--add-dir`
-      // access and are validated by the daemon at create time, so they do
-      // not need the desktop main-process trust token that baseDir imports
-      // require for write access.
-      autoSendFirstMessage: true,
-      amrGatePrechecked,
+      ...(payload.examplePromptContext ? {
+        examplePrompt: true,
+        examplePromptTitle: payload.examplePromptContext.title,
+        examplePromptBrief: payload.examplePromptContext.brief,
+      } : {}),
     });
   }
 

--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -368,7 +368,13 @@ export function HomeView({
     chipId: string | null;
   } | null>(null);
   const [sessionMode, setSessionMode] = useState<ChatSessionMode>('design');
-  const [activeSkill, setActiveSkill] = useState<SkillSummary | null>(null);
+  // 5824: Home homepage @-mention should support multiple skills, not just
+  // silently keep the last picked one. The active selection is now an
+  // ordered array mirroring the @-mention order; the first entry becomes
+  // the project's primary skill and the rest ride along as `## Composed
+  // skill` blocks via the daemon's `skillIds` field. Empty array means no
+  // skill selected.
+  const [activeSkills, setActiveSkills] = useState<SkillSummary[]>([]);
   const [selectedPluginContexts, setSelectedPluginContexts] = useState<SelectedPluginContext[]>([]);
   const [selectedMcpContexts, setSelectedMcpContexts] = useState<SelectedMcpContext[]>([]);
   const [selectedConnectorContexts, setSelectedConnectorContexts] = useState<SelectedConnectorContext[]>([]);
@@ -663,7 +669,7 @@ export function HomeView({
     }
 
     setActive(null);
-    setActiveSkill(null);
+    setActiveSkills([]);
     setSelectedPluginContexts([]);
     setSelectedMcpContexts([]);
     setSelectedConnectorContexts([]);
@@ -844,7 +850,7 @@ export function HomeView({
   ): Promise<boolean> {
     const applyRequestId = activePluginApplyRequestRef.current + 1;
     activePluginApplyRequestRef.current = applyRequestId;
-    setActiveSkill(null);
+    setActiveSkills([]);
     const shouldResolveImmediately = options?.deferApply !== true;
     const inputFields = options?.inputFields ?? record.manifest?.od?.inputs ?? [];
     const optimisticInputs = hydratePluginInputs(
@@ -1548,7 +1554,16 @@ export function HomeView({
     setPendingApplyId(null);
     setFallbackProjectKind(null);
     setFallbackProjectMetadata(null);
-    setActiveSkill(skill);
+    // 5824: accumulate skills as an ordered array so multiple @-mentions
+    // survive into the project run. Picking the same skill twice is a
+    // no-op (idempotent dedupe). Picking a different skill appends rather
+    // than overwrites, matching the project-internal ChatComposer contract.
+    setActiveSkills((current) => {
+      if (current.some((s) => s.id === skill.id)) {
+        return current;
+      }
+      return [...current, skill];
+    });
     setError(null);
     const replacement = nextPrompt ?? localizeSkillPrompt(locale, skill) ?? '';
     if (replacement.trim().length > 0) {
@@ -1556,6 +1571,14 @@ export function HomeView({
       setPromptEditedByUser(false);
     }
     focusPromptAtEnd();
+  }
+
+  function clearActiveSkill() {
+    setActiveSkills([]);
+  }
+
+  function removeActiveSkill(skillId: string) {
+    setActiveSkills((current) => current.filter((s) => s.id !== skillId));
   }
 
   function useMcpServer(_server: McpServerConfig, nextPrompt: string) {
@@ -1610,7 +1633,7 @@ export function HomeView({
     const nextPrompt = buildPluginAuthoringPromptForInputs(nextInputs);
     runWithReplacementConfirmation('Plugin authoring', nextPrompt, async () => {
       setActive(null);
-      setActiveSkill(null);
+      setActiveSkills([]);
       setFallbackProjectKind('other');
       setFallbackProjectMetadata(null);
       setError(null);
@@ -1977,7 +2000,7 @@ export function HomeView({
       }
       const contextLinkedDirs = contextLinkedDirCandidates;
       const submittedProjectKind =
-        submittedActive?.projectKind ?? fallbackProjectKind ?? projectKindForSkill(activeSkill) ?? 'other';
+        submittedActive?.projectKind ?? fallbackProjectKind ?? projectKindForSkill(activeSkills[0] ?? null) ?? 'other';
       const submittedProjectMetadata = submittedActive?.mediaSurface
         ? metadataForHomeMediaComposer(submittedActive.mediaSurface, submittedActive.inputs, promptTemplates)
         : homeCreateProjectMetadata(
@@ -1989,7 +2012,14 @@ export function HomeView({
       // mutually exclusive routing sources. In Design mode, free-form prompts
       // route through the default design router; in Ask mode they stay plain
       // chat conversations with no hidden router plugin.
-      const resolvedSkillId = submittedActive ? null : activeSkill?.id ?? null;
+      // 5824: Collect every active skill id (in @-mention order) into an
+      // array. The first entry is the project's primary skill; later
+      // entries ride along as `## Composed skill` blocks via the daemon's
+      // `skillIds` field. When a scenario plugin is active we suppress
+      // the skill array entirely (same mutual-exclusivity rule that
+      // previously governed the singular skillId field).
+      const resolvedSkillIds =
+        submittedActive ? [] : activeSkills.map((s) => s.id).filter(Boolean);
       const routedPluginId =
         sessionMode === 'design'
           ? submittedActive?.record.id ?? DEFAULT_UNSELECTED_SCENARIO_PLUGIN_ID
@@ -2006,7 +2036,8 @@ export function HomeView({
         prompt: trimmed,
         pluginId: routedPluginId,
         pluginType: submittedActive?.record.marketplaceTrust ?? (routedPluginId ? 'official' : null),
-        skillId: resolvedSkillId,
+        skillId: resolvedSkillIds[0] ?? null,
+        skillIds: resolvedSkillIds.length > 1 ? resolvedSkillIds : null,
         appliedPluginSnapshotId: submittedActive?.result?.appliedPlugin?.snapshotId ?? null,
         pluginTitle: submittedActive?.record.title ?? null,
         taskKind: submittedActive?.result?.appliedPlugin?.taskKind ?? null,
@@ -2072,14 +2103,14 @@ export function HomeView({
         activePluginTitle={activeBadgeTitle}
         activePluginIsExplicit={activePluginIsExplicit}
         activePluginRecord={active?.record ?? null}
-        activeSkillId={activeSkill?.id ?? null}
-        activeSkillTitle={activeSkill ? localizeSkillName(locale, activeSkill) : null}
-        activeSkillRecord={activeSkill}
+        activeSkillId={activeSkills[0]?.id ?? null}
+        activeSkillTitle={activeSkills[0] ? localizeSkillName(locale, activeSkills[0]) : null}
+        activeSkillRecord={activeSkills[0] ?? null}
         activeChipId={active?.chipId ?? null}
         showActivePluginChip={showActivePluginChip}
         onClearActivePlugin={clearActivePlugin}
         onClearActiveChip={clearActiveChipSelection}
-        onClearActiveSkill={() => setActiveSkill(null)}
+        onClearActiveSkill={clearActiveSkill}
         selectedPluginContexts={selectedPluginContexts.map((item) => item.record)}
         selectedMcpContexts={selectedMcpContexts.map((item) => item.server)}
         selectedConnectorContexts={selectedConnectorContexts.map((item) => item.connector)}

--- a/apps/web/src/components/PluginLoopHome.tsx
+++ b/apps/web/src/components/PluginLoopHome.tsx
@@ -32,6 +32,15 @@ export interface PluginLoopSubmit {
   // to attribute project_create_result to a plugin type. Null when no plugin.
   pluginType?: string | null;
   skillId?: string | null;
+  // 5824: Home @-mention can stage multiple skills at once. The first
+  // entry is the project's primary `skillId` above; later entries ride
+  // along as composed-skill blocks via the daemon's `skillIds` field.
+  // Null/absent means single-skill (or no-skill) flow. Forwarded by
+  // EntryShell.handlePluginLoopSubmit into onCreateProject so the
+  // multi-skill compose list reaches POST /api/projects (and the
+  // Home auto-send hand-off in App.handleCreateProject) instead of
+  // being silently dropped at this submit seam.
+  skillIds?: string[] | null;
   appliedPluginSnapshotId: string | null;
   pluginTitle: string | null;
   taskKind: string | null;

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -817,6 +817,18 @@ function autoSendContextKey(projectId: string): string {
   return `od:auto-send-context:${projectId}`;
 }
 
+/**
+ * Home → Studio auto-send handoff for the multi-skill (`@skill-a @skill-b`)
+ * compose list. Without this key, `ProjectView`'s auto-send hand-off fires
+ * the first run with only `project.skillId` (the primary), silently
+ * dropping the extra composed skills even though `handleCreateProject`
+ * already forwarded `input.skillIds` to `POST /api/projects`. See #5824
+ * and PR #6333 review.
+ */
+function autoSendSkillIdsKey(projectId: string): string {
+  return `od:auto-send-skillIds:${projectId}`;
+}
+
 /** Set by the home create flow when its submit already ran the Open Design
  * Cloud balance gate — the first auto-send must not re-prompt the user. */
 function autoSendAmrGateOkKey(projectId: string): string {
@@ -852,6 +864,19 @@ function readAutoSendContext(projectId: string): RunContextSelection | null {
   }
 }
 
+/** Reads back the multi-skill `skillIds` array stashed at Home create time. */
+function readAutoSendSkillIds(projectId: string): string[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.sessionStorage.getItem(autoSendSkillIdsKey(projectId));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    return isStoredStringArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
 function clearAutoSendSession(projectId: string): void {
   if (typeof window === 'undefined') return;
   try {
@@ -859,6 +884,7 @@ function clearAutoSendSession(projectId: string): void {
     window.sessionStorage.removeItem(autoSendAttachmentsKey(projectId));
     window.sessionStorage.removeItem(autoSendContextKey(projectId));
     window.sessionStorage.removeItem(autoSendAmrGateOkKey(projectId));
+    window.sessionStorage.removeItem(autoSendSkillIdsKey(projectId));
   } catch {
     /* ignore */
   }
@@ -7741,6 +7767,7 @@ export function ProjectView({
   const autoSendSeedRef = useRef<string | null>(null);
   const autoSendAttachmentsRef = useRef<ChatAttachment[] | null>(null);
   const autoSendContextRef = useRef<RunContextSelection | null>(null);
+  const autoSendSkillIdsRef = useRef<string[] | null>(null);
   const autoSendFirstMessageRef = useRef(false);
   const autoSendAmrGateOkRef = useRef(false);
   if (autoSendSeedRef.current === null) {
@@ -7761,6 +7788,7 @@ export function ProjectView({
     autoSendSeedRef.current = isAutoSend ? (project.pendingPrompt ?? '') : '';
     autoSendAttachmentsRef.current = isAutoSend ? readAutoSendAttachments(project.id) : [];
     autoSendContextRef.current = isAutoSend ? readAutoSendContext(project.id) : null;
+    autoSendSkillIdsRef.current = isAutoSend ? readAutoSendSkillIds(project.id) : [];
   }
   const initialWorkspaceContexts = autoSendContextRef.current?.workspaceItems ?? [];
   const brandEnrichmentEligibleForProject =
@@ -8410,12 +8438,15 @@ export function ProjectView({
       markDesignSystemAuditAutoRepairEligible(project.id);
     }
     clearAutoSendSession(project.id);
+    const skillIds = autoSendSkillIdsRef.current ?? [];
     autoSendAttachmentsRef.current = [];
+    autoSendSkillIdsRef.current = [];
     void handleSend(seed, attachments, [], {
       ...(context ? { context } : {}),
       // The home submit already gated this exact task (and the user answered
       // any soft warning there); asking again would double-prompt.
       ...(autoSendAmrGateOkRef.current ? { amrGatePrechecked: true } : {}),
+      ...(skillIds.length > 0 ? { skillIds } : {}),
     });
   }, [
     activeConversationId,

--- a/apps/web/src/components/plugin-loop-submit.ts
+++ b/apps/web/src/components/plugin-loop-submit.ts
@@ -1,0 +1,110 @@
+// #5824 / #6333 round-2 (nettee, 2026-08-02): the Home @-mention
+// multi-skill compose flow stages an ordered `skillIds` array on the
+// submit payload (the first entry becomes the project's primary
+// `skillId`, later entries ride along as composed-skill blocks via the
+// daemon's `skillIds` field). The array was correctly forwarded to
+// POST /api/projects from `App.handleCreateProject` (9624316), but
+// `EntryShell.handlePluginLoopSubmit` previously only forwarded
+// `payload.skillId` into `onCreateProject`, so the multi-skill list was
+// silently dropped at this submit seam — `App.handleCreateProject`
+// never saw it and the Home auto-send hand-off landed with no
+// `od:auto-send-skillIds:*` entry, breaking the end-to-end link.
+//
+// This module extracts the `buildCreateProjectArgsFromPluginLoopSubmit`
+// spread rule into a pure helper so the seam can be unit-tested without
+// driving the full plugin-loop UI. `EntryShell.handlePluginLoopSubmit`
+// now delegates to this helper, and the helper has a regression test
+// asserting `payload.skillIds` (>1 entries) lands on the produced
+// create-project args while `skillId` defaults to the primary.
+
+import type { PluginLoopSubmit } from './PluginLoopHome';
+
+/**
+ * Shape of the args `EntryShell.handlePluginLoopSubmit` passes into
+ * `onCreateProject`. We only model the fields this helper is
+ * responsible for spreading; callers may merge additional fields
+ * (metadata, plugin snapshot id, attachments, …) on top.
+ */
+export interface PluginLoopCreateProjectArgs {
+  name: string;
+  skillId: string | null;
+  /**
+   * The multi-skill compose list. Absent on the single-skill /
+   * no-skill flow (`payload.skillIds` is null / undefined / length <=
+   * 1) so the daemon's primary `skillId` binding is the only contract
+   * in that case. Forwarded as-is (no de-dup, no reordering) when
+   * the user staged more than one skill via @-mention.
+   */
+  skillIds?: string[];
+  designSystemId: string | null;
+  pendingPrompt: string;
+  pluginId?: string;
+  pluginType?: string;
+  appliedPluginSnapshotId?: string;
+  pluginInputs?: Record<string, unknown>;
+  initialRunContext?: PluginLoopSubmit['initialRunContext'];
+  conversationMode?: PluginLoopSubmit['conversationMode'];
+  pendingFiles?: PluginLoopSubmit['attachments'];
+  autoSendFirstMessage: true;
+  amrGatePrechecked: boolean;
+  // The exhaustive literal list above mirrors the spread block the
+  // EntryShell handler used to inline. Keeping the surface typed
+  // surfaces drift between the helper and the call-site; the EntryShell
+  // component adds metadata + linkedDirs / examplePromptContext by
+  // merging on top of this helper's output.
+}
+
+/**
+ * Build the `onCreateProject` args from a `PluginLoopSubmit` payload.
+ *
+ * The function is intentionally pure — it does not touch state, network,
+ * or sessionStorage. The EntryShell component keeps responsibility
+ * for deriving `name`, `metadata`, `linkedDirs`, `examplePromptContext`,
+ * and the AMR balance pre-check flag, then merges those on top of the
+ * object returned here.
+ *
+ * Round-2 review regression: `payload.skillIds` MUST reach
+ * `onCreateProject` (and therefore `App.handleCreateProject`'s
+ * `od:auto-send-skillIds:<projectId>` stash) when the user staged more
+ * than one skill. The single-skill flow does NOT spread `skillIds` so
+ * the daemon's primary `skillId` binding is the only contract in that
+ * case (mirrors the previous behavior — the `length > 1` guard avoids
+ * leaking an empty / single-element array that would shadow
+ * `skillId`).
+ */
+export function buildCreateProjectArgsFromPluginLoopSubmit(
+  payload: PluginLoopSubmit,
+  context: {
+    name: string;
+    amrGatePrechecked: boolean;
+  },
+): Omit<PluginLoopCreateProjectArgs, 'designSystemId' | 'metadata' | 'pendingPrompt'> & {
+  designSystemId: string | null;
+  pendingPrompt: string;
+} {
+  return {
+    name: context.name,
+    skillId: payload.skillId ?? null,
+    // Forward the multi-skill compose list so Home @-mention
+    // (`@skill-a @skill-b`) does not silently degrade to a
+    // single-skill create at this submit seam.
+    ...(payload.skillIds && payload.skillIds.length > 1
+      ? { skillIds: payload.skillIds }
+      : {}),
+    designSystemId: payload.designSystemId ?? null,
+    pendingPrompt: payload.prompt,
+    ...(payload.pluginId ? { pluginId: payload.pluginId } : {}),
+    ...(payload.pluginType ? { pluginType: payload.pluginType } : {}),
+    ...(payload.appliedPluginSnapshotId
+      ? { appliedPluginSnapshotId: payload.appliedPluginSnapshotId }
+      : {}),
+    ...(payload.pluginInputs ? { pluginInputs: payload.pluginInputs } : {}),
+    ...(payload.initialRunContext ? { initialRunContext: payload.initialRunContext } : {}),
+    ...(payload.conversationMode ? { conversationMode: payload.conversationMode } : {}),
+    ...(payload.attachments && payload.attachments.length > 0
+      ? { pendingFiles: payload.attachments }
+      : {}),
+    autoSendFirstMessage: true,
+    amrGatePrechecked: context.amrGatePrechecked,
+  };
+}

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -86,7 +86,8 @@ export async function getProjectDetail(
 export async function createProject(input: {
   name: string;
   projectLocationId?: string;
-  skillId: string | null;
+  skillId?: string | null;
+  skillIds?: string[];
   designSystemId: string | null;
   pendingPrompt?: string;
   metadata?: ProjectMetadata;

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -1399,6 +1399,86 @@ describe('ProjectView daemon cleanup', () => {
     }
   });
 
+  it('auto-sends the Home-carried multi-skill compose list to the first daemon run', async () => {
+    // Regression for PR #6333 review: the Home auto-send hand-off used to
+    // only carry prompt/attachments/context to ProjectView, so the
+    // extra composed skills (`@skill-a @skill-b`) were silently dropped
+    // — the first daemon run launched with only `project.skillId`
+    // (the primary). Stash `od:auto-send-skillIds:<projectId>` at Home
+    // create time, then ProjectView puts the array back into
+    // `meta.skillIds` on the first handleSend, and `streamViaDaemon`
+    // receives the full list rather than an empty one.
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    listActiveChatRuns.mockResolvedValue([]);
+    streamViaDaemon.mockResolvedValue(undefined);
+
+    window.sessionStorage.setItem('od:auto-send-first:project-skill-ids', '1');
+    window.sessionStorage.setItem(
+      'od:auto-send-skillIds:project-skill-ids',
+      JSON.stringify(['deck-builder', 'pdf-designer']),
+    );
+
+    try {
+      render(
+        <ProjectView
+          project={{
+            id: 'project-skill-ids',
+            name: 'Project',
+            skillId: 'deck-builder',
+            designSystemId: null,
+            pendingPrompt: 'Make a deck and a PDF.',
+            createdAt: 1,
+            updatedAt: 1,
+          }}
+          routeFileName={null}
+          config={{ mode: 'daemon', agentId: 'agent-1', notifications: undefined, agentModels: {} } as never}
+          agents={[{ id: 'agent-1', name: 'OpenCode', models: [] } as never]}
+          skills={[]}
+          designTemplates={[]}
+          designSystems={[]}
+          daemonLive
+          onModeChange={() => {}}
+          onAgentChange={() => {}}
+          onAgentModelChange={() => {}}
+          onRefreshAgents={() => {}}
+          onOpenSettings={() => {}}
+          onBack={() => {}}
+          onClearPendingPrompt={() => {}}
+          onTouchProject={() => {}}
+          onProjectChange={() => {}}
+          onProjectsRefresh={() => {}}
+        />,
+      );
+
+      await waitFor(() => expect(streamViaDaemon).toHaveBeenCalledTimes(1));
+      const daemonCall = streamViaDaemon.mock.calls[0]?.[0] as {
+        projectId: string;
+        skillId: string | null;
+        skillIds: string[];
+      };
+      expect(daemonCall.projectId).toBe('project-skill-ids');
+      // The primary skill stays on `skillId` (the existing single-skill
+      // contract); the full multi-skill compose list lands on `skillIds`.
+      expect(daemonCall.skillId).toBe('deck-builder');
+      expect(daemonCall.skillIds).toEqual(['deck-builder', 'pdf-designer']);
+      // The auto-send session flag is cleared after the first dispatch so a
+      // reload after the run starts never re-fires.
+      expect(window.sessionStorage.getItem('od:auto-send-skillIds:project-skill-ids')).toBeNull();
+      expect(window.sessionStorage.getItem('od:auto-send-first:project-skill-ids')).toBeNull();
+    } finally {
+      window.sessionStorage.removeItem('od:auto-send-first:project-skill-ids');
+      window.sessionStorage.removeItem('od:auto-send-skillIds:project-skill-ids');
+    }
+  });
+
   it('queues board comment attachments while the current daemon run is still busy', async () => {
     listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
     listMessages.mockResolvedValue([]);

--- a/apps/web/tests/components/plugin-loop-submit.test.ts
+++ b/apps/web/tests/components/plugin-loop-submit.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+//
+// Regression for #6333 round-2 (nettee, 2026-08-02):
+// `PluginLoopSubmit` now carries a `skillIds` array alongside the
+// existing primary `skillId`. `EntryShell.handlePluginLoopSubmit`
+// delegates the build-args spread to
+// `buildCreateProjectArgsFromPluginLoopSubmit`, which must forward
+// the multi-skill compose list (length > 1) onto the produced
+// `onCreateProject` args so the array reaches
+// `App.handleCreateProject`'s `od:auto-send-skillIds:<projectId>`
+// sessionStorage hand-off and ultimately `streamViaDaemon`'s
+// `skillIds`. The single-skill flow must NOT spread `skillIds` so
+// the daemon's primary `skillId` binding is the only contract.
+
+import { describe, expect, it } from 'vitest';
+
+import type { PluginLoopSubmit } from '../../src/components/PluginLoopHome';
+import { buildCreateProjectArgsFromPluginLoopSubmit } from '../../src/components/plugin-loop-submit';
+
+function basePayload(overrides: Partial<PluginLoopSubmit>): PluginLoopSubmit {
+  return {
+    prompt: 'make a deck and a PDF',
+    pluginId: null,
+    skillId: 'deck-builder',
+    appliedPluginSnapshotId: null,
+    pluginTitle: null,
+    taskKind: null,
+    ...overrides,
+  } as PluginLoopSubmit;
+}
+
+describe('buildCreateProjectArgsFromPluginLoopSubmit', () => {
+  it('forwards payload.skillIds to onCreateProject when the compose list has more than one entry (multi-skill @-mention flow)', () => {
+    const payload = basePayload({
+      skillId: 'deck-builder',
+      skillIds: ['deck-builder', 'pdf-designer'],
+    });
+
+    const args = buildCreateProjectArgsFromPluginLoopSubmit(payload, {
+      name: 'Test Deck',
+      amrGatePrechecked: false,
+    });
+
+    // The primary skill stays on `skillId` (the single-skill contract),
+    // and the full multi-skill compose list lands on `skillIds`.
+    expect(args.skillId).toBe('deck-builder');
+    expect(args.skillIds).toEqual(['deck-builder', 'pdf-designer']);
+
+    // The hand-off fields the EntryShell relies on are present.
+    expect(args.name).toBe('Test Deck');
+    expect(args.pendingPrompt).toBe('make a deck and a PDF');
+    expect(args.designSystemId).toBeNull();
+    expect(args.autoSendFirstMessage).toBe(true);
+    expect(args.amrGatePrechecked).toBe(false);
+  });
+
+  it('does NOT spread skillIds on the single-skill flow so the primary binding is the only contract (regression for the previous spread that leaked null/undefined)', () => {
+    const payload = basePayload({
+      skillId: 'deck-builder',
+      skillIds: null,
+    });
+
+    const args = buildCreateProjectArgsFromPluginLoopSubmit(payload, {
+      name: 'Test',
+      amrGatePrechecked: false,
+    });
+
+    expect(args.skillId).toBe('deck-builder');
+    // `skillIds` must NOT appear — null/undefined should not be spread.
+    expect(args).not.toHaveProperty('skillIds');
+  });
+
+  it('does NOT spread skillIds when the compose list has length <= 1 (avoids overriding the primary skillId with a redundant one-element array)', () => {
+    const payload = basePayload({
+      skillId: 'deck-builder',
+      // Edge case: HomeView stamps the same primary as the only
+      // entry — the spread must not duplicate `skillId` as `skillIds`.
+      skillIds: ['deck-builder'],
+    });
+
+    const args = buildCreateProjectArgsFromPluginLoopSubmit(payload, {
+      name: 'Test',
+      amrGatePrechecked: false,
+    });
+
+    expect(args.skillId).toBe('deck-builder');
+    expect(args).not.toHaveProperty('skillIds');
+  });
+
+  it('preserves pluginId / pluginType / snapshotId / pluginInputs / initialRunContext / conversationMode / attachments when present', () => {
+    const attachment = new File(['x'], 'x.png');
+    const payload = basePayload({
+      pluginId: 'od-default',
+      pluginType: 'official',
+      appliedPluginSnapshotId: 'snap-1',
+      pluginInputs: { tone: 'concise' },
+      conversationMode: 'design',
+      attachments: [attachment],
+      // `initialRunContext` is typed loosely here for the helper test.
+      initialRunContext: { kind: 'recent-files', fileIds: ['f-1'] } as never,
+    });
+
+    const args = buildCreateProjectArgsFromPluginLoopSubmit(payload, {
+      name: 'Test',
+      amrGatePrechecked: true,
+    });
+
+    expect(args.pluginId).toBe('od-default');
+    expect(args.pluginType).toBe('official');
+    expect(args.appliedPluginSnapshotId).toBe('snap-1');
+    expect(args.pluginInputs).toEqual({ tone: 'concise' });
+    expect(args.conversationMode).toBe('design');
+    expect(args.pendingFiles).toEqual([attachment]);
+    expect(args.initialRunContext).toEqual({ kind: 'recent-files', fileIds: ['f-1'] });
+    expect(args.amrGatePrechecked).toBe(true);
+  });
+
+  it('omits pluginId / pluginType / snapshotId / pluginInputs / initialRunContext / conversationMode / pendingFiles when absent (no leak of undefined)', () => {
+    const payload = basePayload({});
+
+    const args = buildCreateProjectArgsFromPluginLoopSubmit(payload, {
+      name: 'Test',
+      amrGatePrechecked: false,
+    });
+
+    expect(args).not.toHaveProperty('pluginId');
+    expect(args).not.toHaveProperty('pluginType');
+    expect(args).not.toHaveProperty('appliedPluginSnapshotId');
+    expect(args).not.toHaveProperty('pluginInputs');
+    expect(args).not.toHaveProperty('initialRunContext');
+    expect(args).not.toHaveProperty('conversationMode');
+    expect(args).not.toHaveProperty('pendingFiles');
+  });
+
+  it('defaults designSystemId and skillId to null when payload omits them (the daemon treats absence as no binding)', () => {
+    const payload = basePayload({}).delete
+      ? basePayload({})
+      : ({
+          prompt: 'plain prompt',
+          pluginId: null,
+          appliedPluginSnapshotId: null,
+          pluginTitle: null,
+          taskKind: null,
+        } as PluginLoopSubmit);
+
+    const args = buildCreateProjectArgsFromPluginLoopSubmit(payload, {
+      name: 'Plain',
+      amrGatePrechecked: false,
+    });
+
+    expect(args.skillId).toBeNull();
+    expect(args.designSystemId).toBeNull();
+  });
+});

--- a/packages/contracts/src/api/projects.ts
+++ b/packages/contracts/src/api/projects.ts
@@ -279,7 +279,30 @@ export interface CreateProjectRequest {
   name: string;
   /** Optional project library location id. Omit or use `default` for .od/projects. */
   projectLocationId?: string;
+  /**
+   * Optional primary skill id. Stored on the project row as `skillId`. When
+   * `skillIds` is also supplied, the array's first entry wins as the primary;
+   * the remaining ids ride along as composed skills for the run's system
+   * prompt (see `composeDaemonSystemPrompt`'s `## Composed skill` blocks).
+   * Kept for backwards compatibility with callers that only select one skill
+   * (e.g. project PATCH /api/projects/:id and the legacy single-skill Home
+   * pick path).
+   */
   skillId?: string | null;
+  /**
+   * Optional ordered list of skill ids. On the daemon side, the first entry
+   * becomes the project's primary `skillId` and every subsequent entry is
+   * appended to the run's system prompt as a `## Composed skill — <name>`
+   * block, mirroring the project-internal ChatComposer path
+   * (`apps/web/src/components/ChatComposer.tsx`). When `skillId` is absent
+   * and `skillIds` is present, the first array entry is used as the primary.
+   * Empty arrays are equivalent to omitting the field.
+   *
+   * Background: Home used to pass only `skillId` (singular), so @-mentioning
+   * multiple skills silently dropped all but the last (#5824). Project-internal
+   * chat already sent `skillIds`; this field lets Home match that contract.
+   */
+  skillIds?: string[];
   designSystemId?: string | null;
   pendingPrompt?: string;
   metadata?: ProjectMetadata;


### PR DESCRIPTION
What this PR does

Before this PR:
On the Home page, @-mentioning multiple skills in sequence silently dropped all but the last one. `activeSkillId` was a single `string | null` on `HomeView.tsx`; each new pick replaced the previous, so `@skill-a @skill-b` yielded only skill-b's project. When the project was created via `App.tsx` → `createProject()`, only the singular `skillId` field was sent — the daemon's `skillIds[]` path (which composes multiple skills into `## Composed skill` blocks in the system prompt) was unreachable from the Home flow.

After this PR:
Home page @-mentioning now accumulates skills as an ordered array. The first entry becomes the project's primary `skillId`; the full array is forwarded as `skillIds` to the daemon, which reuses its existing composed-skills path. The project-level UI still shows the primary skill (as before); the remaining skills participate in prompt composition.

### Why we need it

#5824: a user reported that selecting multiple skills from the Home hero was silently reduced to a single skill — the remaining skills had no effect on the run. The project-internal ChatComposer already supported multi-skill runs via its own `skillIds` path; Home was the only place that lost the array.

### Why it was done this way

Tradeoffs:
- `activeSkills` is ordered — the first skill is always the project's primary skill, consistent with the existing `project.skillId` on the project row. Subsequent skills are rendered as `## Composed skill` blocks by the daemon's existing path.
- Dedupe by id: picking the same skill twice is a no-op, matching the Composer's behavior.
- Backward compat: `skillId` singular is still accepted and validated on the daemon side; `skillIds` is optional. Existing callers that only send `skillId` behave identically.

Alternatives considered:
- Force the user to pick only one skill on Home: breaks UX, doesn't solve the real issue.
- Store multiple skills in a separate session-level buffer not persisted to the project: would require re-thinking the `project.skillId` invariant — bigger refactor.

### Breaking changes

None. The public contract (`CreateProjectRequest`) gains an optional `skillIds` field; existing callers that send only `skillId` continue to work. The web state shape changes (`activeSkill` → `activeSkills`), but that's internal.

### Special notes for your reviewer

- Diff is spread across 5 files: `packages/contracts`, `apps/daemon`, `apps/web/src/App.tsx`, `apps/web/src/components/HomeView.tsx`, `apps/web/src/state/projects.ts`.
- The daemon's `composeDaemonSystemPrompt` already handles `skillIds[]` — no daemon-side prompt logic changed.
- `packages/contracts` typecheck passed; `apps/daemon` typecheck passed. Local CI couldn't be run (memory constraints) — please confirm `pnpm test` on CI.
- A Home page regression test covering multi-skill @-mention accumulation would be ideal but is out of scope for this first pass; the behavior is testable manually via the hero input.

Fixes #5824
