### PR TITLE
fix(platform): surface Nix-managed agent CLI install paths

### DIFF
--- a/packages/platform/src/toolchain.ts
+++ b/packages/platform/src/toolchain.ts
@@ -135,11 +135,15 @@ export function wellKnownUserToolchainBins(
     join(home, ".npm-packages", "bin"),
     // Other common user-level toolchains that install CLI shims outside the
     // Node ecosystem but still ship agent CLIs (or their dependencies):
-    // Deno's install root, Go's default GOBIN, and pyenv's shim dir. All are
-    // best-effort — a missing dir contributes nothing.
+    // Deno's install root, Go's default GOBIN, pyenv's shim dir, and the
+    // per-user Nix profile. All are best-effort — a missing dir contributes
+    // nothing. The Nix profile covers `nix profile install`'d CLIs for hosts
+    // (single-user installs or HOME-managed profiles) without
+    // /run/current-system/sw/bin.
     join(home, ".deno", "bin"),
     join(home, "go", "bin"),
     join(home, ".pyenv", "shims"),
+    join(home, ".nix-profile", "bin"),
   );
 
   // Windows-only user install roots that GUI launches miss. Scoop drops
@@ -167,7 +171,15 @@ export function wellKnownUserToolchainBins(
   }
 
   if (includeSystemBins) {
-    dirs.push("/opt/homebrew/bin", "/usr/local/bin");
+    dirs.push(
+      "/opt/homebrew/bin",
+      "/usr/local/bin",
+      // NixOS and nix-darwin expose system-installed CLIs here.
+      // GUI-launched daemons inherit a minimal PATH that omits
+      // this path even though user-installed agent CLIs (codex,
+      // claude, gemini, …) live here.
+      "/run/current-system/sw/bin",
+    );
   }
   // Per-version Node toolchains: scan the install root and surface every
   // version directory's bin folder. Best-effort — missing roots simply

--- a/packages/platform/tests/index.test.ts
+++ b/packages/platform/tests/index.test.ts
@@ -805,15 +805,17 @@ describe("wellKnownUserToolchainBins", () => {
   });
 
   // Non-Node user toolchains that still ship agent CLIs (or their deps):
-  // Deno's install root, Go's default GOBIN, and pyenv's shim dir. GUI
-  // launches inherit a stripped PATH, so these must be searched explicitly.
-  it("includes Deno, Go, and pyenv user toolchain dirs", () => {
+  // Deno's install root, Go's default GOBIN, pyenv's shim dir, and the
+  // per-user Nix profile. GUI launches inherit a stripped PATH, so these
+  // must be searched explicitly.
+  it("includes Deno, Go, pyenv, and ~/.nix-profile/bin user toolchain dirs", () => {
     const home = mkdtempSync(join(tmpdir(), "wkutb-extra-"));
     try {
       const dirs = wellKnownUserToolchainBins({ home, env: {}, includeSystemBins: false });
       expect(dirs).toContain(join(home, ".deno", "bin"));
       expect(dirs).toContain(join(home, "go", "bin"));
       expect(dirs).toContain(join(home, ".pyenv", "shims"));
+      expect(dirs).toContain(join(home, ".nix-profile", "bin"));
     } finally {
       rmSync(home, { recursive: true, force: true });
     }
@@ -1112,23 +1114,25 @@ describe("wellKnownUserToolchainBins", () => {
     }
   });
 
-  it("includes /opt/homebrew/bin and /usr/local/bin when includeSystemBins is true", () => {
+  it("includes /opt/homebrew/bin and /usr/local/bin and /run/current-system/sw/bin when includeSystemBins is true", () => {
     const home = mkdtempSync(join(tmpdir(), "wkutb-sys-"));
     try {
       const dirs = wellKnownUserToolchainBins({ home, env: {}, includeSystemBins: true });
       expect(dirs).toContain("/opt/homebrew/bin");
       expect(dirs).toContain("/usr/local/bin");
+      expect(dirs).toContain("/run/current-system/sw/bin");
     } finally {
       rmSync(home, { recursive: true, force: true });
     }
   });
 
-  it("omits /opt/homebrew/bin and /usr/local/bin when includeSystemBins is false", () => {
+  it("omits /opt/homebrew/bin, /usr/local/bin, and /run/current-system/sw/bin when includeSystemBins is false", () => {
     const home = mkdtempSync(join(tmpdir(), "wkutb-nosys-"));
     try {
       const dirs = wellKnownUserToolchainBins({ home, env: {}, includeSystemBins: false });
       expect(dirs).not.toContain("/opt/homebrew/bin");
       expect(dirs).not.toContain("/usr/local/bin");
+      expect(dirs).not.toContain("/run/current-system/sw/bin");
     } finally {
       rmSync(home, { recursive: true, force: true });
     }


### PR DESCRIPTION
## What this PR does

Before this PR:
The packaged macOS (and Linux) Desktop app did not discover agent CLIs installed through nix-darwin `environment.systemPackages` or per-user `nix profile install`. After launching the app normally from Finder/Applications and rescanning Local CLI agents, Codex, Claude Code, and Gemini were reported as not found on `PATH`, even though `command -v codex` / `claude` / `gemini` resolved cleanly from a terminal.

After this PR:
Those same Nix-installed CLIs are detected after the next rescan. No user action beyond the standard rescan flow is required.

### Why we need it & why it was done this way

#6121 reports the bug. The root cause is architectural, not a typo: in a GUI-launched Electron process the inherited `PATH` is minimal (launchd does not source the user's shell rc), so CLI discovery relies on `wellKnownUserToolchainBins` in `packages/platform/src/toolchain.ts` to surmise the canonical install locations for every popular package manager.

That helper already covered Homebrew, npm/nvm/fnm/mise/asdf, Deno, Go, pyenv, Scoop, Volta, Vite+, Kimi, Bun, Cargo and the system Homebrew locations — but did not include the standard Nix install roots. Per the [Nix manual], the canonical locations for user-installed / system-installed CLIs are:

- `/run/current-system/sw/bin` — system profile on NixOS / nix-darwin. `environment.systemPackages` entries land here.
- `~/.nix-profile/bin` — per-user Nix profile. `nix profile install` entries land here.

[Nix manual]: https://nixos.org/manual/nix/stable/command-ref/nix-profile.html

The fix reuses the existing two-tier structure of `wellKnownUserToolchainBins`:
- `~/.nix-profile/bin` joins the user-level list (alongside `~/.deno/bin`, `~/go/bin`, `~/.pyenv/shims`). It is `includeSystemBins`-independent, mirroring how those sibling user-managed toolchain dirs are surfaced unconditionally.
- `/run/current-system/sw/bin` joins the `includeSystemBins`-gated block, next to `/opt/homebrew/bin` and `/usr/local/bin`, because it is a system-installed-binaries location. Same `includeSystemBins` semantics: still emitted in the default `process.platform !== "win32"` path, still configurable via the `includeSystemBins` opt-in flag.

This matches `packages/AGENTS.md`: `platform`'s toolchain helper is the single source of truth shared by the daemon agent resolver (`apps/daemon/src/agents.ts`) and the packaged sidecar PATH builder (`apps/packaged/src/sidecars.ts`). Both consumers automatically pick up the new entries; neither needs its own change.

### Tradeoffs

- `/nix/var/nix/profiles/default/bin` is omitted. This is the system-default profile on multi-user NixOS installs. The reported bug (#6121) only references `/run/current-system/sw/bin` and `~/.nix-profile/bin`, so I kept the diff to the two paths the issue named and that the Nix manual documents as the canonical user/system profile roots. Adding `/nix/var/nix/profiles/default/bin` is a one-line follow-up if a maintainer wants the explicit full set; the existing list is already a pragmatic subset of well-known locations, not an exhaustive enumeration.
- I did not move `/run/current-system/sw/bin` ahead of `/opt/homebrew/bin`. Existing precedence ordering in the system block (`homebrew` wins for the macOS "first via Homebrew" convention) is preserved; Nix users who also have Homebrew-installed CLIs with the same name will keep seeing the Homebrew shim. A different ordering is a behavior change beyond this issue's scope.
- `~/.nix-profile/bin` is added to the *user-level* CLI list (`includeSystemBins: false` path), not gated. This is intentional and matches siblings (`~/.deno/bin`, `~/go/bin`, `~/.pyenv/shims`) — Nix users should not have to flip a system-bins flag to have their user-installed Nix CLIs discovered.

### Breaking changes

None. Additive only — two new entries in the well-known list. Existing entries and ordering unchanged. `wellKnownUserToolchainBins` returns the same set of paths for all existing inputs, plus the new entries when they exist on disk (best-effort, missing dirs contribute nothing).

### How to verify

```bash
pnpm --filter @open-design/platform typecheck
pnpm --filter @open-design/platform test
```

Both pass on this branch. The two existing `wellKnownUserToolchainBins` tests have been extended by one assertion each (the `Deno`, Go, pyenv test now also asserts `~/.nix-profile/bin`; the `includeSystemBins` true/false tests now also assert `/run/current-system/sw/bin`). No new test cases were added to avoid duplication — the two existing tests already cover the code paths being changed.

On a NixOS / nix-darwin machine, install any agent CLI through `environment.systemPackages` or `nix profile install`, launch the packaged Desktop app from Finder/Applications, then Settings → Local CLI agents → Rescan. The previously-missing CLI now appears.

Fixes #6121
