### PR TITLE
fix(desktop): guard splash-stage teardown races (#6136)

### DIFF
--- a/apps/desktop/src/main/runtime.ts
+++ b/apps/desktop/src/main/runtime.ts
@@ -1308,10 +1308,19 @@ function splashStagePayload(stage: SplashBootStage): { step: number; total: numb
  * Narrow view of the splash window that the stage updater needs. A real
  * `BrowserWindow` satisfies this structurally; tests pass a mock so the
  * load-ready/replay logic is exercisable without a live Electron renderer.
+ *
+ * `webContents.isDestroyed()` is part of the contract because Electron can
+ * tear a window's underlying `webContents` down before (or in between) the
+ * `isDestroyed()`-and-`executeJavaScript` boundary in `setSplashStage` /
+ * `applySplashStage`; without that probe, the synchronous
+ * `executeJavaScript` call throws `TypeError("Object has been destroyed")`
+ * — a rejection that escapes the existing `.catch` because no Promise is
+ * returned in the synchronous-throw case. See issue #6136.
  */
 export type SplashStageSurface = {
   isDestroyed(): boolean;
   webContents: {
+    isDestroyed(): boolean;
     executeJavaScript(code: string, userGesture?: boolean): Promise<unknown>;
     once(event: "did-finish-load", listener: () => void): void;
   };
@@ -1324,12 +1333,26 @@ type SplashStageState = { ready: boolean; pending: SplashBootStage | null };
 const splashStageState = new WeakMap<SplashStageSurface, SplashStageState>();
 
 function applySplashStage(splash: SplashStageSurface, stage: SplashBootStage): void {
-  void splash.webContents
-    .executeJavaScript(
-      `window.__odSplashSetStage && window.__odSplashSetStage(${JSON.stringify(splashStagePayload(stage))});`,
-      true,
-    )
-    .catch(() => undefined);
+  // Guard against the teardown race: `setSplashStage` checks
+  // `splash.isDestroyed()` before calling here, but the window can
+  // be destroyed between that check and this call (see #6136).
+  // `webContents.isDestroyed()` covers the case where the renderer
+  // tears down before the wrapper BrowserWindow is reaped.
+  if (splash.isDestroyed() || splash.webContents.isDestroyed()) return;
+  try {
+    void splash.webContents
+      .executeJavaScript(
+        `window.__odSplashSetStage && window.__odSplashSetStage(${JSON.stringify(splashStagePayload(stage))});`,
+        true,
+      )
+      .catch(() => undefined);
+  } catch {
+    // Electron can throw `TypeError("Object has been destroyed")`
+    // synchronously from executeJavaScript in the residual teardown
+    // race not covered by the isDestroyed() checks above. Mirror the
+    // Promise-rejection contract: this path is best-effort, never a
+    // process-killing uncaught exception.
+  }
 }
 
 /**
@@ -1345,6 +1368,11 @@ export function registerSplashStageTracking(splash: SplashStageSurface): void {
   const state: SplashStageState = { ready: false, pending: null };
   splashStageState.set(splash, state);
   splash.webContents.once("did-finish-load", () => {
+    // The splash or its webContents may have been destroyed between
+    // the stage being stashed and the load event firing (race 1).
+    // Bail out early rather than calling executeJavaScript on a
+    // dead renderer.
+    if (splash.isDestroyed() || splash.webContents.isDestroyed()) return;
     state.ready = true;
     if (state.pending != null) {
       const stage = state.pending;

--- a/apps/desktop/tests/main/splash-stage-replay.test.ts
+++ b/apps/desktop/tests/main/splash-stage-replay.test.ts
@@ -29,9 +29,11 @@ function createMockSplash(): MockSplash {
   const executed: string[] = [];
   let didFinishLoad: (() => void) | null = null;
   let destroyed = false;
+  let webContentsDestroyed = false;
   const surface: SplashStageSurface = {
     isDestroyed: () => destroyed,
     webContents: {
+      isDestroyed: () => webContentsDestroyed,
       executeJavaScript: (code: string) => {
         executed.push(code);
         return Promise.resolve(undefined);
@@ -47,6 +49,7 @@ function createMockSplash(): MockSplash {
     emitDidFinishLoad: () => didFinishLoad?.(),
     destroy: () => {
       destroyed = true;
+      webContentsDestroyed = true;
     },
   };
 }
@@ -98,6 +101,45 @@ describe('splash boot-stage replay guard', () => {
 
     setSplashStage(splash.surface, 'engine');
     expect(splash.executed).toEqual([]);
+  });
+
+  // Race 1: stage deferred before load, splash destroyed before did-finish-load.
+  // Without the guard in registerSplashStageTracking, the replay callback
+  // would call applySplashStage and then executeJavaScript on a dead surface.
+  test('is a no-op when the splash is destroyed before did-finish-load', () => {
+    const splash = createMockSplash();
+    registerSplashStageTracking(splash.surface);
+
+    setSplashStage(splash.surface, 'engine');
+    expect(splash.executed).toEqual([]);
+
+    // Destroy the splash after the stage is stashed but before load fires.
+    splash.destroy();
+    splash.emitDidFinishLoad();
+    expect(splash.executed).toEqual([]);
+  });
+
+  // Race 2: the webContents throws `TypeError("Object has been destroyed")`
+  // synchronously (not returning a rejected Promise) during executeJavaScript.
+  // The existing `.catch` only handles Promise rejections — a sync throw
+  // escapes and can crash the process. The try/catch in applySplashStage must
+  // swallow this sync throw, mirroring the existing Promise-rejection contract.
+  test('tolerates a destroyed webContents mid-flight instead of throwing', () => {
+    const surface: SplashStageSurface = {
+      isDestroyed: () => false,
+      webContents: {
+        isDestroyed: () => false,
+        executeJavaScript: () => {
+          // Simulate the teardown race: throw before returning a Promise.
+          throw new TypeError('Object has been destroyed');
+        },
+        once: () => { /* no-op */ },
+      },
+    };
+
+    // No throw — the sync exception is swallowed the same way an
+    // executeJavaScript rejection would be.
+    expect(() => setSplashStage(surface, 'engine')).not.toThrow();
   });
 
   // Slow-cold-boot UX: the splash must tell the user WHICH step of how many is


### PR DESCRIPTION
## What this PR does

Before this PR: a deferred splash-stage update could call `webContents.executeJavaScript` after the splash `BrowserWindow` or its `webContents` had been destroyed. Electron throws `Object has been destroyed` **synchronously** in this teardown path, intersecting **outside** the existing `.catch(() => undefined)` Promise-rejection handler. The uncaught exception could terminate the packaged desktop process under the right race timing.

After this PR: splash-stage updates are a guaranteed no-op once either the splash window or its `webContents` is destroyed, and the residual sync-throw path is swallowed at the `applySplashStage` boundary.

### Why we need it & why it was done this way

#6136 reports the bug, identified two sub-races, both rooted in the same architectural mismatch — the existing `applySplashStage` only handled **Promise rejections** from `executeJavaScript`, while Electron can also produce a **synchronous throw** in the teardown race. A `try/catch` is required in addition to the existing `.catch`.

#### Race 1: pre-load replay destroy

```js
const splash = createSplashWindow();       // registerSplashStageTracking(splash) armed inside
setSplashStage(splash, "engine");          // state.pending = "engine" (page still loading)
splash.destroy();                           // window torn down before load
// later: did-finish-load fires
// → registerSplashStageTracking's listener runs
// → applySplashStage(splash, "engine") on a dead surface
// → executeJavaScript throws TypeError("Object has been destroyed") sync
```

The existing replay callback in `registerSplashStageTracking` did not re-check availability before replaying the deferred stage.

Fix: bail out of the `did-finish-load` replay when `splash.isDestroyed()` OR `splash.webContents.isDestroyed()`.

#### Race 2: check-to-call destroy

```js
setSplashStage(surface, "workspace");      // splash.isDestroyed() === false → proceeds
// ... but window tears down here ...
applySplashStage(surface, "workspace");    // executeJavaScript throws sync
                                            // .catch is never reached (no Promise returned)
```

`splash.isDestroyed()` returning `false` is not a guarantee that the underlying `webContents` is alive. Electron can destroy the renderer thread before the wrapper `BrowserWindow` is collected, so `executeJavaScript` throws synchronously.

Fix:
1. Add `webContents.isDestroyed()` to `SplashStageSurface` so callers can probe renderer readiness explicitly.
2. Short-circuit near the end of the call via the same pattern: `splash.isDestroyed() || splash.webContents.isDestroyed()`.
3. Wrap the `executeJavaScript + .catch` chain in `try/catch` as the residual guard. If `isDestroyed()` returns `false` (control flow proceeds) and `executeJavaScript` still throws sync (Electron internal race), the `catch` swallows it the same way `.catch(() => undefined)` swallows a rejected Promise. No new behavior: this matches the existing "best-effort, never a process-crashing exception" contract that the Promise rejection handler already establishes.

### Tradeoffs

- I did **not** move the `try/catch` only around `executeJavaScript` (leaving `.catch` outside). That would only handle the case where a Promise *was* returned — the existing `.catch(() => undefined)` covers Promise rejections fine. The `try/catch` is preserved specifically to capture the **sync-throw-before-Promise** case, which is the exact shape #6136 describes.
- I did **not** change the public surface of `setSplashStage` (still nullable, still best-effort). Only `SplashStageSurface` widens by adding `webContents.isDestroyed()`, which a real `BrowserWindow` already structurally satisfies — `webContents` on an Electron `BrowserWindow` exposes this method.
- I did **not** add `webContents` readiness tracking to `setSplashStage` itself (the public entry). The central guard belongs in `applySplashStage` because it is the single chokepoint both `setSplashStage` and the replay callback use. Calling `setSplashStage(splash, ...)` after destroy is already a documented no-op via `splash.isDestroyed()`.
- The `webContents.isDestroyed()` short-circuit is a best-effort probe; even with both checks there is a residual race where Electron destroys the renderer between `isDestroyed()` and `executeJavaScript`. The `try/catch` is the only thing that catches that residual case, which is exactly why both halves of the fix coexist.

### Breaking changes

None for production code. The structural `SplashStageSurface` shape gains `webContents.isDestroyed()`, which every production `BrowserWindow` already satisfies via its own `webContents` instance. The two callers (`apps/desktop/src/main/runtime.ts` and `apps/packaged/src/index.ts`) construct a real `BrowserWindow` and pass it directly, so the new field is structurally present without any change there.

The mock in `apps/desktop/tests/main/splash-stage-replay.test.ts` must be widened to satisfy the new `webContents.isDestroyed()` field, which the same patch does.

### How to verify

```bash
pnpm --filter @open-design/desktop exec tsc -p tsconfig.tests.json --noEmit
```

(Pre-existing pre-`download`-package errors in `updater.ts` are unrelated to this change; only `splash-stage-replay.test.ts` / `runtime.ts` need to be clean.)

The two new tests pin both sub-races:
- `is a no-op when the splash is destroyed before did-finish-load` (race 1)
- `tolerates a destroyed webContents mid-flight instead of throwing` (race 2)

Both use the existing structural-mock pattern (no real Electron).

### Reproduction seed in live Electron

Race 1: `setSplashStage(splash, "engine")` then `splash.destroy()` before the page loads (the issue reports this is observed deterministically on Linux when crashing during the splash sequence). Without the fix the `did-finish-load` handler calls `applySplashStage → executeJavaScript` on a dead surface and crashes the packaged app.

Race 2: harder to seed deterministically in live Electron (the check-to-call window is small), but #6136 reports observability through packaged-linux teardown during the same test pass. The `try/catch` in `applySplashStage` is the only thing that catches the residual case.

Fixes #6136
