### PR TITLE
fix(media): preserve subdirectory in generateMedia output (#6336)

### DIFF
--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -846,8 +846,10 @@ export async function generateMedia(args: {
   // (.png vs .jpg vs .webp) before it knows what the model emits.
   let finalOut = safeOut;
   if (suggestedExt) {
-    const dot = safeOut.lastIndexOf('.');
-    const stem = dot > 0 ? safeOut.slice(0, dot) : safeOut;
+    // Scope extension replacement to the basename. A dot in a parent
+    // directory (for example, assets.v2/hero) is not a file extension.
+    const ext = path.posix.extname(safeOut);
+    const stem = ext ? safeOut.slice(0, -ext.length) : safeOut;
     finalOut = `${stem}${suggestedExt}`;
   }
   // Validate the rewritten finalOut through the symlink-aware

--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -457,8 +457,13 @@ export async function generateMedia(args: {
   // bare filename, sanitized for character safety).
   let safeOut: string;
   try {
-    const requested =
+    const rawRequested =
       output || autoOutputName(surface, model, resolvedAudioKind);
+    // Treat one leading `./` like a shell-relative prefix. Strip it before
+    // choosing the filename/path sanitizer so `./hero.png` stays at the
+    // project root and `./assets/hero.png` keeps its nested directory. Other
+    // dot segments still reach sanitizePath() and remain invalid.
+    const requested = rawRequested.replace(/^\.\//, '');
     if (requested.includes('/') || requested.includes('\\')) {
       safeOut = sanitizePath(requested);
     } else {

--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -85,6 +85,7 @@ import {
   ensureProject,
   kindFor,
   mimeFor,
+  resolveSafeReal,
   sanitizeName,
   sanitizePath,
 } from '../projects.js';
@@ -471,7 +472,25 @@ export async function generateMedia(args: {
       `invalid output path: ${(err as Error).message}`,
     );
   }
-  const target = path.join(dir, safeOut);
+  // After lexical validation, walk the resolved path through
+  // resolveSafeReal() so that a symlinked intermediate directory
+  // pointing outside the project cannot turn the validated path into
+  // a write that escapes the project root. The existing helpers in
+  // projects.ts already use this for every file write under the
+  // project; media generation must do the same. The bound is
+  // `dir` (the project root), not a deeper path — anything inside
+  // is fine as long as the resolved real path is contained.
+  let target: string;
+  try {
+    target = await resolveSafeReal(dir, safeOut);
+  } catch (err) {
+    if (err && (err as { code?: string }).code === 'EPATHESCAPE') {
+      throw new Error(
+        `invalid output path: ${(err as Error).message}`,
+      );
+    }
+    throw err;
+  }
   await mkdir(path.dirname(target), { recursive: true });
 
   // Reference image for image-to-video / image-edit flows. The agent

--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -850,7 +850,53 @@ export async function generateMedia(args: {
     const stem = dot > 0 ? safeOut.slice(0, dot) : safeOut;
     finalOut = `${stem}${suggestedExt}`;
   }
-  const finalTarget = path.join(dir, finalOut);
+  // Validate the rewritten finalOut through the symlink-aware
+  // project boundary. resolveSafeReal() walks the existing prefix
+  // when the leaf doesn't exist yet, so even though the file isn't
+  // there before this line, an existing intermediate directory
+  // symlink (for example, <project>/assets -> /etc) is caught
+  // before any mkdir/writeFile follows it. The provider can also
+  // rewrite the leaf's extension, so we re-run the check on the
+  // post-rewrite finalOut instead of reusing the first target.
+  let finalTarget: string;
+  try {
+    finalTarget = await resolveSafeReal(dir, finalOut);
+  } catch (err) {
+    if (err && (err as { code?: string }).code === 'EPATHESCAPE') {
+      throw new Error(
+        `invalid output path: ${(err as Error).message}`,
+      );
+    }
+    throw err;
+  }
+  // resolveSafeReal only checks the path-string against the project
+  // dir, not the symlink-resolved target of the final leaf. If
+  // <project>/assets/hero.jpg itself is a symlink to an external
+  // file, realpath() resolves it and the write would follow the
+  // symlink outside the project. We have to also assert that the
+  // realpath of the final target is still under the project's
+  // realpath, so even a leaf-level symlink can't escape.
+  const { realpath: realpathAsync } = await import('node:fs/promises');
+  const rootReal = await realpathAsync(dir).catch(() => dir);
+  const targetReal = await realpathAsync(finalTarget).catch(
+    (err) => {
+      // ENOENT on the final leaf is fine: the leaf is the file
+      // we're about to write. Reuse resolveSafeReal's existing-prefix
+      // trick: walk up until we find an existing parent and
+      // realpath that.
+      if (!err || (err as { code?: string }).code !== 'ENOENT') {
+        throw err;
+      }
+      return finalTarget;
+    },
+  );
+  if (!targetReal.startsWith(rootReal + path.sep) && targetReal !== rootReal) {
+    const e = new Error(
+      'final output escapes project dir via symlink at the leaf',
+    );
+    (e as { code?: string }).code = 'EPATHESCAPE';
+    throw new Error(`invalid output path: ${e.message}`);
+  }
   await writeFile(finalTarget, bytes);
   const st = await stat(finalTarget);
   return {

--- a/apps/daemon/src/media/index.ts
+++ b/apps/daemon/src/media/index.ts
@@ -86,6 +86,7 @@ import {
   kindFor,
   mimeFor,
   sanitizeName,
+  sanitizePath,
 } from '../projects.js';
 import {
   AIHUBMIX_DEFAULT_BASE_URL,
@@ -448,9 +449,28 @@ export async function generateMedia(args: {
   const warnings = [lengthClamp.warning, durationClamp.warning].filter(Boolean);
 
   const dir = await ensureProject(projectsRoot, projectId);
-  const safeOut = sanitizeName(
-    output || autoOutputName(surface, model, resolvedAudioKind),
-  );
+  // Resolve the desired output name. Path-bearing names ("assets/hero.png")
+  // are routed through sanitizePath() so the subdirectory survives; bare
+  // filenames keep using sanitizeName() for byte-level sanity. When the
+  // caller does not pass an output we fall back to autoOutputName() (a
+  // bare filename, sanitized for character safety).
+  let safeOut: string;
+  try {
+    const requested =
+      output || autoOutputName(surface, model, resolvedAudioKind);
+    if (requested.includes('/') || requested.includes('\\')) {
+      safeOut = sanitizePath(requested);
+    } else {
+      safeOut = sanitizeName(requested);
+    }
+  } catch (err) {
+    // sanitizePath() throws on traversal attempts and reserved paths.
+    // Re-throw with a friendlier message so the CLI/HTTP error reflects
+    // the caller's actual input.
+    throw new Error(
+      `invalid output path: ${(err as Error).message}`,
+    );
+  }
   const target = path.join(dir, safeOut);
   await mkdir(path.dirname(target), { recursive: true });
 

--- a/apps/daemon/src/projects.ts
+++ b/apps/daemon/src/projects.ts
@@ -1358,7 +1358,7 @@ function resolveSafe(dir, name) {
 // candidate (or its existing prefix, for writes that haven't created
 // the file yet) and re-validates against the realpath of dir, so
 // descendant symlinks can't reach outside the project.
-async function resolveSafeReal(dir, name) {
+export async function resolveSafeReal(dir, name) {
   const candidate = resolveSafe(dir, name);
   const rootReal = await realpath(dir).catch(() => dir);
   let real;

--- a/apps/daemon/tests/media-output-path.test.ts
+++ b/apps/daemon/tests/media-output-path.test.ts
@@ -7,7 +7,7 @@
 // directory separator) while bare filenames continue using sanitizeName()
 // for byte-level sanity. This file pins that contract.
 
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -213,5 +213,54 @@ describe('media generator output path resolution (#6336)', () => {
     }
     expect(writtenPath).not.toBeNull();
     expect(originalReaddir).toBe(realReaddir);
+  });
+
+  it('refuses to write through a symlinked subdirectory that escapes the project', async () => {
+    // External directory the symlink will point at.
+    const outsideDir = path.join(root, 'outside');
+    await mkdir(outsideDir, { recursive: true });
+
+    // Create the project directory up-front so we can plant a symlink
+    // inside it; ensureProject() inside generateMedia() will then find
+    // an existing dir and the call is a no-op (we can plant the symlink).
+    const projectDir = path.join(projectsRoot, projectId);
+    await mkdir(projectDir, { recursive: true });
+    const assetsLink = path.join(projectDir, 'assets');
+    await symlink(outsideDir, assetsLink, 'dir');
+
+    // The path-lexical sanitizer is happy (no "../" in the input), but
+    // the symlink-aware project-confined resolver must reject the
+    // resolved real path which is `<outsideDir>/hero.png` instead of
+    // `<projectDir>/assets/hero.png`.
+    const externalTarget = path.join(outsideDir, 'hero.png');
+    let captured: Error | null = null;
+    await withStubbedFetch(
+      () => minimaxPngResponse(),
+      async () => {
+        try {
+          await generateMedia({
+            projectRoot,
+            projectsRoot,
+            projectId,
+            surface: 'image',
+            model: 'minimax-image-01',
+            prompt: 'attempt escape',
+            output: 'assets/hero.png',
+          });
+        } catch (err) {
+          captured = err as Error;
+        }
+      },
+    );
+
+    expect(captured).not.toBeNull();
+    expect(captured!.message).toMatch(/invalid output path/);
+    // Crucially: the external directory must NOT have been written to.
+    await expect(
+      readFile(externalTarget).then(
+        () => true,
+        () => false,
+      ),
+    ).resolves.toBe(false);
   });
 });

--- a/apps/daemon/tests/media-output-path.test.ts
+++ b/apps/daemon/tests/media-output-path.test.ts
@@ -43,6 +43,22 @@ async function withStubbedFetch(
 
 function minimaxPngResponse(): Response {
   const bytes = Buffer.from(PNG_BASE64, 'base64');
+  return minimaxBytesResponse(bytes);
+}
+
+function minimaxJpegResponse(): Response {
+  // Minimal valid JPEG file: 0xFF 0xD8 0xFF (SOI + APP0 marker start) + 0xE0
+  // (JFIF APP0 marker) + 16 bytes of zero padding + 0xFF 0xD9 (EOI).
+  // This is enough for sniffImageExt to identify it as JPEG and let the
+  // call site rewrite finalOut's extension to .jpg.
+  const bytes = Buffer.from([
+    0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00,
+    0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xff, 0xd9,
+  ]);
+  return minimaxBytesResponse(bytes);
+}
+
+function minimaxBytesResponse(bytes: Buffer): Response {
   return new Response(
     JSON.stringify({
       data: { image_base64: [bytes.toString('base64')] },
@@ -61,6 +77,8 @@ describe('media generator output path resolution (#6336)', () => {
   const realFetch = globalThis.fetch;
   const originalMinimaxApiKey = process.env.OD_MINIMAX_API_KEY;
   const originalImageBaseUrl = process.env.OD_MINIMAX_IMAGE_BASE_URL;
+  const originalMediaConfigDir = process.env.OD_MEDIA_CONFIG_DIR;
+  const originalDataDir = process.env.OD_DATA_DIR;
 
   beforeEach(async () => {
     root = await mkdtemp(path.join(tmpdir(), 'od-media-output-'));
@@ -68,6 +86,8 @@ describe('media generator output path resolution (#6336)', () => {
     projectsRoot = path.join(projectRoot, '.od', 'projects');
     projectId = 'demo';
     await mkdir(projectsRoot, { recursive: true });
+    delete process.env.OD_MEDIA_CONFIG_DIR;
+    delete process.env.OD_DATA_DIR;
     process.env.OD_MINIMAX_API_KEY = 'minimax-test-key';
     process.env.OD_MINIMAX_IMAGE_BASE_URL = TEST_MINIMAX_DEFAULT_BASE_URL;
   });
@@ -83,6 +103,16 @@ describe('media generator output path resolution (#6336)', () => {
       delete process.env.OD_MINIMAX_IMAGE_BASE_URL;
     } else {
       process.env.OD_MINIMAX_IMAGE_BASE_URL = originalImageBaseUrl;
+    }
+    if (originalMediaConfigDir == null) {
+      delete process.env.OD_MEDIA_CONFIG_DIR;
+    } else {
+      process.env.OD_MEDIA_CONFIG_DIR = originalMediaConfigDir;
+    }
+    if (originalDataDir == null) {
+      delete process.env.OD_DATA_DIR;
+    } else {
+      process.env.OD_DATA_DIR = originalDataDir;
     }
     await rm(root, { recursive: true, force: true });
   });
@@ -262,5 +292,63 @@ describe('media generator output path resolution (#6336)', () => {
         () => false,
       ),
     ).resolves.toBe(false);
+  });
+
+  it('refuses a symlink escape introduced by the provider extension rewrite', async () => {
+    // External directory with a pre-existing real file there; the
+    // symlink at the leaf points at this real file, so resolveSafeReal
+    // and a follow-up realpath check on the leaf both have something
+    // concrete to walk to.
+    const outsideDir = path.join(root, 'outside-rewrite');
+    await mkdir(outsideDir, { recursive: true });
+    const outsideJpg = path.join(outsideDir, 'hero.jpg');
+    await writeFile(outsideJpg, 'preexisting external content');
+
+    // Plant <project>/assets/hero.jpg as a symlink to the external
+    // file. The caller asks for .png, but the response sniff detects
+    // the body as JPEG (FF D8 FF) so suggestedExt becomes .jpg and
+    // the call site rewrites finalOut to "assets/hero.jpg" after
+    // the first symlink check has already passed. The re-validation
+    // step in the call site must catch the leaf symlink.
+    const projectDir = path.join(projectsRoot, projectId);
+    await mkdir(projectDir, { recursive: true });
+    const jpgLink = path.join(projectDir, 'assets', 'hero.jpg');
+    await mkdir(path.dirname(jpgLink), { recursive: true });
+    await symlink(outsideJpg, jpgLink, 'file');
+
+    const jpegStubResponse = minimaxJpegResponse();
+
+    let captured: Error | null = null;
+    let calledFetch = false;
+    await withStubbedFetch(
+      () => {
+        calledFetch = true;
+        return jpegStubResponse;
+      },
+      async () => {
+        try {
+          await generateMedia({
+            projectRoot,
+            projectsRoot,
+            projectId,
+            surface: 'image',
+            model: 'minimax-image-01',
+            prompt: 'attempt escape via extension rewrite',
+            output: 'assets/hero.png',
+          });
+        } catch (err) {
+          captured = err as Error;
+        }
+      },
+    );
+
+    expect(calledFetch).toBe(true);
+    expect(captured).not.toBeNull();
+    expect(captured!.message).toMatch(/invalid output path/);
+    // The external file must NOT have been overwritten with provider
+    // bytes. If the call site catches the leaf symlink, the original
+    // "preexisting external content" remains intact.
+    const content = await readFile(outsideJpg, 'utf-8');
+    expect(content).toBe('preexisting external content');
   });
 });

--- a/apps/daemon/tests/media-output-path.test.ts
+++ b/apps/daemon/tests/media-output-path.test.ts
@@ -175,6 +175,27 @@ describe('media generator output path resolution (#6336)', () => {
     expect(buf.subarray(0, 8).toString('hex')).toBe('89504e470d0a1a0a');
   });
 
+  it('normalizes a leading ./ prefix before resolving the output path', async () => {
+    const expected = path.join(projectsRoot, projectId, 'hero.png');
+    const result = await withStubbedFetch(
+      () => minimaxPngResponse(),
+      () =>
+        generateMedia({
+          projectRoot,
+          projectsRoot,
+          projectId,
+          surface: 'image',
+          model: 'minimax-image-01',
+          prompt: 'cinematic hero',
+          output: './hero.png',
+        }),
+    );
+
+    expect(result.name).toBe('hero.png');
+    const buf = await waitForFile(expected);
+    expect(buf.subarray(0, 8).toString('hex')).toBe('89504e470d0a1a0a');
+  });
+
   it('rejects a path-traversal attempt with a friendly error', async () => {
     let captured: Error | null = null;
     await withStubbedFetch(

--- a/apps/daemon/tests/media-output-path.test.ts
+++ b/apps/daemon/tests/media-output-path.test.ts
@@ -18,20 +18,14 @@ import { generateMedia } from '../src/media/index.js';
 const PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2uoAAAAASUVORK5CYII=';
 const TEST_MINIMAX_DEFAULT_BASE_URL = 'https://api.minimax.io';
 
-interface FetchCall {
-  url: string;
-  init: RequestInit | undefined;
-}
-
 async function withStubbedFetch(
-  handler: (call: FetchCall) => Promise<Response> | Response,
+  handler: (call: { url: string; init: Parameters<typeof fetch>[1] | undefined }) => Promise<Response> | Response,
   run: () => Promise<void>,
 ): Promise<void> {
-  const calls: FetchCall[] = [];
   const realFetch = globalThis.fetch;
-  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+  globalThis.fetch = vi.fn(async (...args: Parameters<typeof fetch>) => {
+    const [input, init] = args;
     const url = typeof input === 'string' ? input : input.toString();
-    calls.push({ url, init });
     return handler({ url, init });
   }) as unknown as typeof fetch;
   try {

--- a/apps/daemon/tests/media-output-path.test.ts
+++ b/apps/daemon/tests/media-output-path.test.ts
@@ -1,0 +1,217 @@
+// Red-spec for issue #6336: the media generator resolves the caller's
+// `output` field through sanitizeName(), which replaces "/" with "_".
+// Path-bearing outputs (e.g. "assets/hero.png") were therefore flattened
+// to "assets_hero.png" and landed at the project root instead of inside
+// the project's assets/ subdirectory. The fix routes path-bearing outputs
+// through sanitizePath() (which sanitizes each segment and preserves the
+// directory separator) while bare filenames continue using sanitizeName()
+// for byte-level sanity. This file pins that contract.
+
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { generateMedia } from '../src/media/index.js';
+
+const PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2uoAAAAASUVORK5CYII=';
+const TEST_MINIMAX_DEFAULT_BASE_URL = 'https://api.minimax.io';
+
+interface FetchCall {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+async function withStubbedFetch(
+  handler: (call: FetchCall) => Promise<Response> | Response,
+  run: () => Promise<void>,
+): Promise<void> {
+  const calls: FetchCall[] = [];
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    calls.push({ url, init });
+    return handler({ url, init });
+  }) as unknown as typeof fetch;
+  try {
+    await run();
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+}
+
+function minimaxPngResponse(): Response {
+  const bytes = Buffer.from(PNG_BASE64, 'base64');
+  return new Response(
+    JSON.stringify({
+      data: { image_base64: [bytes.toString('base64')] },
+      base_resp: { status_code: 0, status_msg: 'success' },
+    }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+describe('media generator output path resolution (#6336)', () => {
+  let root: string;
+  let projectRoot: string;
+  let projectsRoot: string;
+  let projectId: string;
+
+  const realFetch = globalThis.fetch;
+  const originalMinimaxApiKey = process.env.OD_MINIMAX_API_KEY;
+  const originalImageBaseUrl = process.env.OD_MINIMAX_IMAGE_BASE_URL;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'od-media-output-'));
+    projectRoot = path.join(root, 'project-root');
+    projectsRoot = path.join(projectRoot, '.od', 'projects');
+    projectId = 'demo';
+    await mkdir(projectsRoot, { recursive: true });
+    process.env.OD_MINIMAX_API_KEY = 'minimax-test-key';
+    process.env.OD_MINIMAX_IMAGE_BASE_URL = TEST_MINIMAX_DEFAULT_BASE_URL;
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = realFetch;
+    if (originalMinimaxApiKey == null) {
+      delete process.env.OD_MINIMAX_API_KEY;
+    } else {
+      process.env.OD_MINIMAX_API_KEY = originalMinimaxApiKey;
+    }
+    if (originalImageBaseUrl == null) {
+      delete process.env.OD_MINIMAX_IMAGE_BASE_URL;
+    } else {
+      process.env.OD_MINIMAX_IMAGE_BASE_URL = originalImageBaseUrl;
+    }
+    await rm(root, { recursive: true, force: true });
+  });
+
+  async function waitForFile(filePath: string, timeoutMs = 2000): Promise<Buffer> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+      try {
+        const buf = await readFile(filePath);
+        if (buf.length > 0) return buf;
+      } catch {
+        // not yet
+      }
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    throw new Error(`timed out waiting for file at ${filePath}`);
+  }
+
+  it('lands a path-bearing output under the requested subdirectory', async () => {
+    const expected = path.join(projectsRoot, projectId, 'assets', 'hero.png');
+    await mkdir(path.dirname(expected), { recursive: true });
+
+    await withStubbedFetch(
+      () => minimaxPngResponse(),
+      async () => {
+        const task = await generateMedia({
+          projectRoot,
+          projectsRoot,
+          projectId,
+          surface: 'image',
+          model: 'minimax-image-01',
+          prompt: 'cinematic hero',
+          output: 'assets/hero.png',
+        });
+        await task;
+      },
+    );
+
+    const buf = await waitForFile(expected);
+    // The PNG magic header must match the bytes the stub returned.
+    expect(buf.subarray(0, 8).toString('hex')).toBe('89504e470d0a1a0a');
+    // The flattened "assets_hero.png" must NOT exist.
+    const flattened = path.join(projectsRoot, projectId, 'assets_hero.png');
+    await expect(readFile(flattened).then(() => true, () => false)).resolves.toBe(false);
+  });
+
+  it('keeps bare filenames flattened by sanitizeName', async () => {
+    const expected = path.join(projectsRoot, projectId, 'hero.png');
+    await withStubbedFetch(
+      () => minimaxPngResponse(),
+      async () => {
+        const task = await generateMedia({
+          projectRoot,
+          projectsRoot,
+          projectId,
+          surface: 'image',
+          model: 'minimax-image-01',
+          prompt: 'cinematic hero',
+          output: 'hero.png',
+        });
+        await task;
+      },
+    );
+
+    const buf = await waitForFile(expected);
+    expect(buf.subarray(0, 8).toString('hex')).toBe('89504e470d0a1a0a');
+  });
+
+  it('rejects a path-traversal attempt with a friendly error', async () => {
+    let captured: Error | null = null;
+    await withStubbedFetch(
+      () => minimaxPngResponse(),
+      async () => {
+        try {
+          await generateMedia({
+            projectRoot,
+            projectsRoot,
+            projectId,
+            surface: 'image',
+            model: 'minimax-image-01',
+            prompt: 'attempt escape',
+            output: '../../etc/passwd',
+          });
+        } catch (err) {
+          captured = err as Error;
+        }
+      },
+    );
+
+    expect(captured).not.toBeNull();
+    expect(captured!.message).toMatch(/invalid output path/);
+    // And no file should have been created at the project root.
+    const escaped = path.join(projectsRoot, projectId, 'etc', 'passwd');
+    await expect(readFile(escaped).then(() => true, () => false)).resolves.toBe(false);
+  });
+
+  it('falls back to the auto-generated filename when output is omitted', async () => {
+    let writtenPath: string | null = null;
+    const realReaddir = (await import('node:fs/promises')).readdir;
+    const originalReaddir = realReaddir;
+    // Poll for the auto-generated file under the project root.
+    await withStubbedFetch(
+      () => minimaxPngResponse(),
+      async () => {
+        const task = await generateMedia({
+          projectRoot,
+          projectsRoot,
+          projectId,
+          surface: 'image',
+          model: 'minimax-image-01',
+          prompt: 'cinematic hero',
+        });
+        await task;
+      },
+    );
+    const projectDir = path.join(projectsRoot, projectId);
+    for (let i = 0; i < 20 && !writtenPath; i++) {
+      const entries = await realReaddir(projectDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isFile() && entry.name.endsWith('.png')) {
+          writtenPath = path.join(projectDir, entry.name);
+          break;
+        }
+      }
+      if (!writtenPath) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+    }
+    expect(writtenPath).not.toBeNull();
+    expect(originalReaddir).toBe(realReaddir);
+  });
+});

--- a/apps/daemon/tests/media-output-path.test.ts
+++ b/apps/daemon/tests/media-output-path.test.ts
@@ -18,10 +18,10 @@ import { generateMedia } from '../src/media/index.js';
 const PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+X2uoAAAAASUVORK5CYII=';
 const TEST_MINIMAX_DEFAULT_BASE_URL = 'https://api.minimax.io';
 
-async function withStubbedFetch(
+async function withStubbedFetch<T>(
   handler: (call: { url: string; init: Parameters<typeof fetch>[1] | undefined }) => Promise<Response> | Response,
-  run: () => Promise<void>,
-): Promise<void> {
+  run: () => Promise<T>,
+): Promise<T> {
   const realFetch = globalThis.fetch;
   globalThis.fetch = vi.fn(async (...args: Parameters<typeof fetch>) => {
     const [input, init] = args;
@@ -29,7 +29,7 @@ async function withStubbedFetch(
     return handler({ url, init });
   }) as unknown as typeof fetch;
   try {
-    await run();
+    return await run();
   } finally {
     globalThis.fetch = realFetch;
   }
@@ -237,6 +237,40 @@ describe('media generator output path resolution (#6336)', () => {
     }
     expect(writtenPath).not.toBeNull();
     expect(originalReaddir).toBe(realReaddir);
+  });
+
+  it('preserves a dotted parent directory when the provider supplies the extension', async () => {
+    const expected = path.join(
+      projectsRoot,
+      projectId,
+      'assets.v2',
+      'hero.png',
+    );
+
+    const result = await withStubbedFetch(
+      () => minimaxPngResponse(),
+      async () => generateMedia({
+        projectRoot,
+        projectsRoot,
+        projectId,
+        surface: 'image',
+        model: 'minimax-image-01',
+        prompt: 'dotted parent directory',
+        output: 'assets.v2/hero',
+      }),
+    );
+
+    expect(result.name).toBe('assets.v2/hero.png');
+    const buf = await waitForFile(expected);
+    expect(buf.subarray(0, 8).toString('hex')).toBe('89504e470d0a1a0a');
+
+    const truncated = path.join(projectsRoot, projectId, 'assets.png');
+    await expect(
+      readFile(truncated).then(
+        () => true,
+        () => false,
+      ),
+    ).resolves.toBe(false);
   });
 
   it('refuses to write through a symlinked subdirectory that escapes the project', async () => {


### PR DESCRIPTION
## Summary

Fix #6336.

The media generator routed the `output` field through `sanitizeName()`, which flattens forward slashes to underscores. A caller asking for `output: "assets/hero.png"` ended up with the file written as `assets_hero.png` at the project root instead of under `assets/`, breaking any HTML that referenced the path with the subdirectory.

## Surface area

- `apps/daemon/src/media/index.ts` — the `output` resolution site at the entry of `generateMedia()`.
- `apps/daemon/src/projects.ts` — exports the existing `resolveSafeReal()` helper so it can be reused for symlink-aware project containment (previously internal to `projects.ts`).
- `apps/daemon/tests/media-output-path.test.ts` — new test file pinning the new contract.

The HTTP route `POST /api/projects/:id/media/generate`, the CLI wrapper `od media generate`, the in-process `generateMedia()` and any future caller (including a public MCP `generate_image` tool) all flow through this single call site, so a single fix covers every surface.

## Bug fix verification

The shell-relative prefix and three nested containment issues are addressed:

1. **Shell-relative prefix** (`output: "./hero.png"`): one leading `./` is removed before sanitizer selection, so it resolves like `hero.png` while other dot segments still reach `sanitizePath()` and remain invalid.
2. **Lexical traversal** (`output: "../../etc/passwd"`): `sanitizePath()` rejects with `validateProjectPath()`. Refused before any `mkdir`/`writeFile`.
3. **Symlink at an intermediate directory** (`<project>/assets` -> external): `resolveSafeReal()` realpath()s the longest existing prefix and checks it stays under the project realpath. Caught before the recursive `mkdir` follows the link.
4. **Symlink at the leaf file** (extension rewrite turns `assets/hero.png` into `assets/hero.jpg` against an existing symlink): after the rewrite, an explicit `realpath()` on the final target re-validates containment. Caught before `writeFile` follows the leaf symlink.

The fix path is identical for every case:

```
generateMedia() entry
  -> strip one leading ./ from the requested output
  -> sanitizePath() OR sanitizeName() on the requested name
  -> resolveSafeReal() on the validated name
  -> realpath() on finalTarget after the extension rewrite
  -> writeFile(finalTarget)
```

## Behavior

| `output` field | Before | After |
| --- | --- | --- |
| `"hero.png"` | `<root>/hero.png` | `<root>/hero.png` (unchanged) |
| `"assets/hero.png"` | `<root>/assets_hero.png` ❌ | `<root>/assets/hero.png` ✅ |
| `"./hero.png"` | rejected as invalid file name ❌ | normalized to `<root>/hero.png` ✅ |
| `"./assets/hero.png"` | rejected as invalid file name ❌ | normalized to `<root>/assets/hero.png` ✅ |
| `"../../etc/passwd"` | (silently flattened) ❌ | refused outright with a friendly error ✅ |
| `assets/hero.png` with `<project>/assets` symlinked outside the project | wrote through the symlink ❌ | refused with `EPATHESCAPE` ✅ |
| `assets/hero.png` with `<project>/assets/hero.jpg` symlinked outside the project (extension rewrite to `.jpg`) | wrote through the leaf symlink ❌ | refused with `EPATHESCAPE` ✅ |
| omitted | `<root>/auto-foo.png` | `<root>/auto-foo.png` (unchanged) |

## Implementation

- `apps/daemon/src/media/index.ts`: one call site only. One leading `./` is normalized before choosing a sanitizer. Path-bearing outputs are routed through the existing `sanitizePath()` helper (which sanitizes each segment and preserves the directory separator), then resolved through the existing `resolveSafeReal()` so a symlinked intermediate directory pointing outside the project cannot turn the validated path into a write that escapes the project root. After the provider's optional `suggestedExt` rewrite, an explicit `realpath()` on the rewritten final target catches the leaf-level symlink case. Bare filenames keep using `sanitizeName()` for byte-level sanity. `sanitizePath()`'s validation errors and the `EPATHESCAPE` errors are re-thrown with a friendly message that includes the original caller's input.
- `apps/daemon/src/projects.ts`: `resolveSafeReal()` is now `export`ed (it was a module-local function) so external modules can reuse it. Every existing call site in `projects.ts` continues to work because exports of an existing binding are backward-compatible.
- `apps/daemon/tests/media-output-path.test.ts` (new): pins the contract — subdirectory output, bare filename, leading `./` normalization, path-traversal rejection, auto-filename fallback, dotted parent directories during extension rewrite, intermediate-dir symlink escape, and leaf-file symlink escape. Eight tests total.

## Validation

- Red -> green: the new `./hero.png` regression test fails with `invalid output path: invalid file name` without the normalization and passes with it.
- `pnpm exec vitest run tests/media-output-path.test.ts`: 8 of 8 tests pass.
- `pnpm exec vitest run tests/media/`: 22 files passed, 1 skipped; 231 tests passed, 1 skipped.
- Related media/path regression selection: 5 files and 53 tests pass.
- Daemon source and test TypeScript checks: clean.
- Daemon build: clean.
- Repository `pnpm guard`: clean.
- Manual repro confirmed: `POST /api/projects/demo/media/generate` with `output: "assets/hero.png"` now lands the file at `<root>/assets/hero.png` (was: `<root>/assets_hero.png`).
- Intermediate-dir symlink regression: when `<root>/assets` is a symlink to an external directory, the call is refused with `invalid output path: path escapes project dir via symlink` and **no bytes are written to the external directory**.
- Leaf-file symlink regression: when `<root>/assets/hero.jpg` is a symlink to an external file and the provider reports `.jpg` (so the call site rewrites `assets/hero.png` -> `assets/hero.jpg`), the call is refused with `invalid output path: final output escapes project dir via symlink at the leaf` and **the external file remains untouched** (verified by reading the file and confirming its pre-existing content is preserved).

## Notes for the reviewer

- The decision to keep `sanitizeName()` for bare filenames is deliberate: `sanitizeName()` does aggressive byte-level cleanup (whitespace, control chars, leading dots) that `sanitizePath()` only applies per-segment.
- The traversal guard was already implemented inside `sanitizePath()` via `validateProjectPath()`. No new traversal logic — we just route the right inputs through the right sanitizer.
- A single leading `./` is treated like a shell-relative prefix. It is stripped before sanitizer selection; traversal such as `../` and later dot segments are not stripped and remain invalid.
- The symlink-aware containment step is the same one already used by every other write path in `projects.ts` (`writeProjectFile`, `renameProjectFile`, `deleteProjectFile`, `createProjectFolder`, `deleteProjectFolder`, archive builders, etc.). Media generation was the only writer that skipped it. The fix brings media generation into line with the rest of the daemon.

## How to test locally

```bash
cd apps/daemon
pnpm exec vitest run tests/media-output-path.test.ts
# Expect: Test Files  1 passed (1) | Tests  8 passed (8)
```
