### PR TITLE
add daemon Letta Code ACP runtime

### DIFF
--- a/.github/scripts/scopes.py
+++ b/.github/scripts/scopes.py
@@ -268,8 +268,12 @@ def changed_files_for_environment():
         number = event.get("pull_request", {}).get("number")
         if number is None:
             raise ConfigError("pull_request.number is required")
-        output = run_gh(["api", "--paginate", f"repos/{repository}/pulls/{number}/files", "--jq", ".[] | .filename, (.previous_filename // empty)"])
-        return event_name, output.splitlines(), "medium", "hot", False, True, True
+        try:
+            output = run_gh(["api", "--paginate", f"repos/{repository}/pulls/{number}/files", "--jq", ".[] | .filename, (.previous_filename // empty)"])
+            return event_name, output.splitlines(), "medium", "hot", False, True, True
+        except subprocess.SubprocessError as error:
+            print(f"::warning::pull_request resolution failed; using full plan: {error}", file=sys.stderr)
+            return "pull_request:resolution-error", [], None, "full", True, True, False
     if event_name == "workflow_dispatch":
         mode = event.get("inputs", {}).get("ci_mode", "full")
         if mode not in {"hot", "full"}:

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Inside a project's Studio, the conversation, generated files, and live preview s
 | [Pi Agent](https://github.com/badlogic/pi-mono) | ✅ Supported | `od mcp install pi` |
 | [Mistral Vibe CLI](https://github.com/mistralai/mistral-vibe) | ✅ Supported | `od mcp install vibe` |
 | [Hermes Agent](https://github.com/nousresearch/hermes-agent) | ✅ Supported | `od mcp install hermes` |
+| [Letta Code ACP](https://github.com/letta-ai/letta-acp) | ✅ Supported | ACP runtime with run-scoped MCP |
 
 For DeepSeek Harness, install the official `dsh` CLI first, then select it in OpenDesign or run `od agent setup deepseek-harness` to install/repair OD's connection component. For MCP integrations: `od mcp install <agent> --print` for a dry-run preview · `--uninstall` to remove · full list with `od mcp install --help`.
 

--- a/apps/daemon/src/agent-protocol/acp/session.ts
+++ b/apps/daemon/src/agent-protocol/acp/session.ts
@@ -123,6 +123,9 @@ export interface AttachAcpSessionOptions {
   // `session/new`. The agent verifies the session and, if it is gone, returns a
   // structured `resume_failed` error the caller maps to its reseed path.
   resumeSessionId?: string | null;
+  // ACP adapters such as Letta use the protocol `sessionId` as the durable
+  // conversation handle rather than returning a separate adapter-specific id.
+  sessionIdIsDurable?: boolean;
   // Subsegment timing markers for spawn->first-token attribution (#3408 §4).
   // `onCliReady` fires once on the first well-formed ACP JSON-RPC message
   // (the CLI is up and speaking the protocol); `onSessionInit` fires once when
@@ -176,6 +179,7 @@ export function attachAcpSession({
   modelUnavailableErrorCode,
   completePromptOnTurnEnd = false,
   resumeSessionId,
+  sessionIdIsDurable = false,
   onCliReady,
   onSessionInit,
   onPromptComplete,
@@ -1070,7 +1074,11 @@ export function attachAcpSession({
       sessionId = typeof result.sessionId === 'string' ? result.sessionId : null;
       // The durable handle for resuming this session on the next turn.
       durableSessionId =
-        typeof result.openCodeSessionId === 'string' ? result.openCodeSessionId : null;
+        typeof result.openCodeSessionId === 'string'
+          ? result.openCodeSessionId
+          : sessionIdIsDurable
+            ? sessionId
+            : null;
       // session/new acknowledged with a session id = handshake done (#3408 §4).
       if (sessionId) onSessionInit?.();
       const modelConfig = findModelConfigOption(result.configOptions);

--- a/apps/daemon/src/connectionTest.ts
+++ b/apps/daemon/src/connectionTest.ts
@@ -2121,7 +2121,13 @@ interface AgentSpawnHandle {
 }
 
 function attachAgentStreamHandlers(
-  def: { streamFormat?: string; eventParser?: string; id: string; promptViaStdin?: boolean },
+  def: {
+    streamFormat?: string;
+    eventParser?: string;
+    id: string;
+    promptViaStdin?: boolean;
+    acpSessionIdIsDurable?: boolean;
+  },
   child: ReturnType<typeof spawn>,
   prompt: string,
   cwd: string,
@@ -2175,6 +2181,7 @@ function attachAgentStreamHandlers(
       // so ACP runtimes can use their upstream configured default.
       model: resolveModelForAgent(def as never, model ?? null, modelEnv, liveModelScope),
       mcpServers: [],
+      sessionIdIsDurable: def.acpSessionIdIsDurable === true,
       send,
     });
   } else if (def.streamFormat === 'dsh-profile-jsonl') {

--- a/apps/daemon/src/runtimes/defs/letta.ts
+++ b/apps/daemon/src/runtimes/defs/letta.ts
@@ -1,0 +1,23 @@
+import { DEFAULT_MODEL_OPTION } from './shared.js';
+import type { RuntimeAgentDef } from '../types.js';
+
+// Letta Code exposes its runtime through the standalone `letta-acp` ACP
+// adapter. Do not probe models here: without LETTA_AGENT_ID the adapter can
+// create a local agent while starting a session. Its own LETTA_ACP_MODEL
+// setting remains the source of truth for the default model.
+export const lettaAgentDef = {
+  id: 'letta',
+  name: 'Letta Code',
+  bin: 'letta-acp',
+  versionArgs: ['--version'],
+  fallbackModels: [DEFAULT_MODEL_OPTION],
+  buildArgs: () => [],
+  streamFormat: 'acp-json-rpc',
+  supportsImagePaths: true,
+  mcpDiscovery: 'mature-acp',
+  externalMcpInjection: 'acp-merge',
+  // Letta returns its durable conversation id as ACP's `sessionId`; future
+  // Open Design turns must drive `session/load` with that id.
+  acpSessionIdIsDurable: true,
+  resumesSessionViaAcpLoad: true,
+} satisfies RuntimeAgentDef;

--- a/apps/daemon/src/runtimes/detection.ts
+++ b/apps/daemon/src/runtimes/detection.ts
@@ -747,6 +747,7 @@ function stripFns(
     inactivityTimeoutMs,
     firstOutputTimeoutMs,
     authProbe,
+    acpSessionIdIsDurable,
     ...rest
   } = def;
   return rest;

--- a/apps/daemon/src/runtimes/metadata.ts
+++ b/apps/daemon/src/runtimes/metadata.ts
@@ -31,6 +31,10 @@ const AGENT_INSTALL_LINKS: Record<
     installUrl: 'https://github.com/nexu-io/open-design/blob/main/docs/agent-adapters.md',
     docsUrl: 'https://hermes-agent.nousresearch.com/docs/',
   },
+  letta: {
+    installUrl: 'https://github.com/letta-ai/letta-acp#quick-start',
+    docsUrl: 'https://github.com/letta-ai/letta-acp#configuration',
+  },
   'trae-cli': {
     installUrl: 'https://www.volcengine.com/docs/86677/2227861?lang=zh',
     docsUrl: 'https://www.volcengine.com/docs/86677/2227861?lang=zh',

--- a/apps/daemon/src/runtimes/registry.ts
+++ b/apps/daemon/src/runtimes/registry.ts
@@ -5,6 +5,7 @@ import { devinAgentDef } from './defs/devin.js';
 import { opencodeAgentDef } from './defs/opencode.js';
 import { byokOpenCodeAgentDef } from './defs/byok-opencode.js';
 import { hermesAgentDef } from './defs/hermes.js';
+import { lettaAgentDef } from './defs/letta.js';
 import { traeCliAgentDef } from './defs/trae-cli.js';
 import { grokBuildAgentDef } from './defs/grok-build.js';
 import { kimiAgentDef } from './defs/kimi.js';
@@ -45,6 +46,7 @@ export const SHIPPED_AGENT_DEFS: RuntimeAgentDef[] = [
   opencodeAgentDef,
   byokOpenCodeAgentDef,
   hermesAgentDef,
+  lettaAgentDef,
   traeCliAgentDef,
   grokBuildAgentDef,
   kimiAgentDef,

--- a/apps/daemon/src/runtimes/types.ts
+++ b/apps/daemon/src/runtimes/types.ts
@@ -263,6 +263,10 @@ export type RuntimeAgentDef = {
   // `capturesSessionIdFromStream` because the capture + resume transport is the
   // ACP result, not a `--session-id` flag or a stream `status` event.
   resumesSessionViaAcpLoad?: boolean;
+  // Some ACP adapters use the standard `sessionId` itself as their durable
+  // upstream conversation handle. When enabled, the shared bridge persists
+  // that id if the adapter does not return a separate durable-handle field.
+  acpSessionIdIsDurable?: boolean;
   // Optional name of a daemon-process environment variable that overrides
   // the default model id when the chat run reaches the spawn layer with
   // null or the synthetic 'default'. Used by adapters whose CLI rejects
@@ -346,6 +350,7 @@ export type DetectedAgent = Omit<
   | 'inactivityTimeoutMs'
   | 'firstOutputTimeoutMs'
   | 'authProbe'
+  | 'acpSessionIdIsDurable'
 > & {
   models: RuntimeModelOption[];
   modelsSource: RuntimeModelSource;

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -14383,6 +14383,7 @@ export async function startServer({
         stdioMcpRemovedInVersion: def.acpStdioMcpRemovedInVersion ?? null,
         executionProfile,
         completePromptOnTurnEnd: def.acpTurnEndCompletesPrompt === true,
+        sessionIdIsDurable: def.acpSessionIdIsDurable === true,
         ...(def.id === 'amr' ? { modelUnavailableErrorCode: 'AMR_MODEL_UNAVAILABLE' } : {}),
         // Resume the prior upstream session (drives `session/load`) when the
         // resume-identity guard says it is safe; otherwise a fresh session/new.

--- a/apps/daemon/tests/acp.test.ts
+++ b/apps/daemon/tests/acp.test.ts
@@ -3214,3 +3214,37 @@ test('createJsonLineStream still assembles a legitimate multiline JSON response'
 
   assert.deepEqual(received.map((message) => message.id), [5]);
 });
+
+test('attachAcpSession persists a durable ACP session id and resumes it', () => {
+  const createdChild = new FakeAcpChild();
+  const createdSession = attachAcpSession({
+    child: createdChild as never,
+    prompt: 'first turn',
+    cwd: '/tmp/od-project',
+    sessionIdIsDurable: true,
+    send: () => {},
+  });
+
+  writeAcpResult(createdChild, 1, {});
+  writeAcpResult(createdChild, 2, { sessionId: 'letta-conversation-1' });
+  assert.equal(createdSession.getDurableSessionId(), 'letta-conversation-1');
+
+  const resumedChild = new FakeAcpChild();
+  const writes: string[] = [];
+  resumedChild.stdin.on('data', (chunk) => writes.push(String(chunk)));
+  attachAcpSession({
+    child: resumedChild as never,
+    prompt: 'follow-up turn',
+    cwd: '/tmp/od-project',
+    resumeSessionId: createdSession.getDurableSessionId(),
+    sessionIdIsDurable: true,
+    send: () => {},
+  });
+
+  writeAcpResult(resumedChild, 1, {});
+  const loadRequest = parseRpcWrites(writes).find((entry) => entry.method === 'session/load');
+  assert.deepEqual(loadRequest?.params, {
+    sessionId: 'letta-conversation-1',
+    cwd: path.resolve('/tmp/od-project'),
+  });
+});

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { test } from 'vitest';
 import {
-  AGENT_DEFS, aider, antigravity, assert, claude, codex, copilot, cursorAgent, deepseek, devin, detectAgents, gemini, grokBuild, join, kilo, kimi, kiro, letta, mkdtempSync, opencode, pi, qoder, qwen, rmSync, spawnEnvForAgent, tmpdir, vibe, writeFileSync, chmodSync,
+  AGENT_DEFS, aider, antigravity, assert, claude, codex, copilot, cursorAgent, deepseek, devin, detectAgents, grokBuild, join, kilo, kimi, kiro, letta, mkdtempSync, opencode, pi, qoder, qwen, rmSync, spawnEnvForAgent, tmpdir, vibe, writeFileSync, chmodSync,
 } from './helpers/test-helpers.js';
 import { writeAntigravityModelSelection } from '../../src/runtimes/defs/antigravity.js';
 import { parseOpenCodeModels } from '../../src/runtimes/defs/opencode.js';

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { test } from 'vitest';
 import {
-  AGENT_DEFS, aider, antigravity, assert, claude, codex, copilot, cursorAgent, deepseek, devin, detectAgents, grokBuild, join, kilo, kimi, kiro, mkdtempSync, opencode, pi, qoder, qwen, rmSync, spawnEnvForAgent, tmpdir, vibe, writeFileSync, chmodSync,
+  AGENT_DEFS, aider, antigravity, assert, claude, codex, copilot, cursorAgent, deepseek, devin, detectAgents, gemini, grokBuild, join, kilo, kimi, kiro, letta, mkdtempSync, opencode, pi, qoder, qwen, rmSync, spawnEnvForAgent, tmpdir, vibe, writeFileSync, chmodSync,
 } from './helpers/test-helpers.js';
 import { writeAntigravityModelSelection } from '../../src/runtimes/defs/antigravity.js';
 import { parseOpenCodeModels } from '../../src/runtimes/defs/opencode.js';
@@ -363,6 +363,22 @@ test('devin args use acp subcommand for json-rpc streaming', () => {
     'acp',
   ]);
   assert.equal(devin.streamFormat, 'acp-json-rpc');
+});
+
+test('letta uses the standalone ACP adapter without probing models', () => {
+  assert.equal(letta.name, 'Letta Code');
+  assert.equal(letta.bin, 'letta-acp');
+  assert.deepEqual(letta.versionArgs, ['--version']);
+  assert.deepEqual(letta.buildArgs('', [], [], {}), []);
+  assert.equal(letta.streamFormat, 'acp-json-rpc');
+  assert.equal(letta.fetchModels, undefined);
+  assert.equal(letta.listModels, undefined);
+  assert.equal(letta.fallbackModels?.[0]?.id, 'default');
+  assert.equal(letta.supportsImagePaths, true);
+  assert.equal(letta.mcpDiscovery, 'mature-acp');
+  assert.equal(letta.externalMcpInjection, 'acp-merge');
+  assert.equal(letta.acpSessionIdIsDurable, true);
+  assert.equal(letta.resumesSessionViaAcpLoad, true);
 });
 
 test('pi args use rpc mode without --no-session and append model/thinking options', () => {

--- a/apps/daemon/tests/runtimes/helpers/test-helpers.ts
+++ b/apps/daemon/tests/runtimes/helpers/test-helpers.ts
@@ -76,6 +76,7 @@ export const amp = requireAgent('amp');
 export const claude = requireAgent('claude');
 export const codex = requireAgent('codex');
 export const hermes = requireAgent('hermes');
+export const letta = requireAgent('letta');
 export const kimi = requireAgent('kimi');
 export const copilot = requireAgent('copilot');
 export const cursorAgent = requireAgent('cursor-agent');

--- a/apps/daemon/tests/runtimes/mcp.test.ts
+++ b/apps/daemon/tests/runtimes/mcp.test.ts
@@ -1,6 +1,6 @@
 import { test } from 'vitest';
 import { createLiveArtifactsMcpTools, handleLiveArtifactsMcpRequest } from '../../src/mcp-live-artifacts-server.js';
-import { AGENT_DEFS, assert, buildLiveArtifactsMcpServersForAgent, hermes, kimi } from './helpers/test-helpers.js';
+import { AGENT_DEFS, assert, buildLiveArtifactsMcpServersForAgent, hermes, kimi, letta } from './helpers/test-helpers.js';
 
 test('live artifact MCP discovery is limited to mature ACP agents', () => {
   for (const agent of AGENT_DEFS) {
@@ -30,6 +30,18 @@ test('live artifact MCP discovery is limited to mature ACP agents', () => {
 
 test('live artifact MCP discovery is disabled when run-scoped tool auth is unavailable', () => {
   assert.deepEqual(buildLiveArtifactsMcpServersForAgent(hermes, { enabled: false }), []);
+  assert.deepEqual(buildLiveArtifactsMcpServersForAgent(letta, { enabled: false }), []);
+});
+
+test('Letta receives run-scoped live artifact MCP servers through ACP', () => {
+  assert.deepEqual(buildLiveArtifactsMcpServersForAgent(letta), [
+    {
+      name: 'open-design-live-artifacts',
+      command: 'od',
+      args: ['mcp', 'live-artifacts'],
+      env: [{ name: 'ELECTRON_RUN_AS_NODE', value: '1' }],
+    },
+  ]);
 });
 
 test('Kimi retains ACP live-artifacts and external MCP wiring', () => {

--- a/docs/agent-adapters.md
+++ b/docs/agent-adapters.md
@@ -142,7 +142,7 @@ definitions currently group by transport as follows:
 | `json-event-stream` | `codex`, `cursor-agent`, `opencode`, `mimo`, `byok-opencode` |
 | `copilot-stream-json` | `copilot` |
 | `qoder-stream-json` | `qoder` |
-| `acp-json-rpc` | `amr` (Vela), `devin`, `hermes`, `kimi`, `kiro`, `kilo`, `reasonix`, `trae-cli`, `vibe` |
+| `acp-json-rpc` | `amr` (Vela), `devin`, `hermes`, `kimi`, `kiro`, `kilo`, `letta`, `reasonix`, `trae-cli`, `vibe` |
 | `pi-rpc` | `pi` |
 | `dsh-profile-jsonl` | `deepseek-harness` |
 | `plain` | `aider`, `antigravity`, `atomcode`, `deepseek`, `grok-build`, `qwen` |
@@ -435,6 +435,16 @@ At run completion, the daemon scans the captured plain stdout for `<artifact>` b
 | `text/markdown`, `text/x-markdown`, `markdown`, or `md` | `<identifier>.md` |
 
 The identifier is slugged before use, collisions receive `-2`, `-3`, etc., and outputs without a supported `<artifact>` block are left unchanged. This daemon-side extraction keeps headless runs and web-attached runs aligned: the project file exists even when no browser is present to parse the chat stream.
+
+### 5.13 Letta Code
+
+- Installation: install the standalone ACP adapter with `npm install -g @letta-ai/letta-acp`. Open Design detects the resulting `letta-acp` executable; it neither installs the adapter nor adds it as an application dependency.
+- Invocation and streaming: `letta-acp` speaks ACP JSON-RPC over stdio, so the daemon uses its shared ACP lifecycle for initialization, text and tool-status events, permission requests, cancellation, errors, and image attachments.
+- Models: Open Design deliberately exposes only its `Default` fallback and does not call the adapter's model-discovery path. This avoids a probe creating a local agent when `LETTA_AGENT_ID` is absent. The adapter chooses the model through `LETTA_ACP_MODEL` or its own backend configuration.
+- Configuration: use the existing Settings CLI-environment editor for `LETTA_ACP_BACKEND`, `LETTA_AGENT_ID`, `LETTA_API_KEY`, `LETTA_ACP_MODEL`, and `LETTA_ACP_PERMISSION_MODE`. The adapter supports its documented local default as well as Cloud, OAuth, and remote app-server backends. Credentials stay in Letta's environment/configuration; Open Design does not implement login flows or call Letta's API directly.
+- Persistence: Letta's ACP `sessionId` is its durable conversation id. Open Design persists it per conversation after a successful run and sends it back through `session/load` for the next compatible turn. If a resumed session is unavailable, the normal ACP reseed behavior starts one fresh turn with the rendered transcript.
+- MCP: configured Open Design MCP servers are forwarded in the ACP session descriptor for each run. Do not run `od mcp install letta`: there is no static Letta configuration mutation for this adapter path.
+- Security: local operation executes the installed adapter in the selected project directory under the adapter's own permission mode. Cloud, OAuth, and remote app-server modes can send prompts, files the agent reads, and tool-request metadata to the configured Letta backend; select and secure that endpoint according to your organization's policy.
 
 ## 6. Runtime metadata and UI
 

--- a/e2e/tests/scripts/scopes.test.ts
+++ b/e2e/tests/scripts/scopes.test.ts
@@ -57,6 +57,52 @@ describe("workflow scope planner", () => {
     }
   });
 
+  test("falls back to full validation when fork PR file resolution is unavailable", () => {
+    const temporaryRoot = mkdtempSync(path.join(tmpdir(), "scope-pr-resolution-"));
+    try {
+      const eventPath = path.join(temporaryRoot, "event.json");
+      const githubOutputPath = path.join(temporaryRoot, "github-output.txt");
+      const planPath = path.join(temporaryRoot, "scope-plan.json");
+      const ghPath = path.join(temporaryRoot, "gh.js");
+      writeFileSync(eventPath, JSON.stringify({ pull_request: { number: 6340 } }));
+      writeFileSync(githubOutputPath, "");
+      writeFileSync(ghPath, "process.exit(1);\n");
+
+      const result = spawnSync("python3", [script, "github-output", "--output", planPath], {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          GITHUB_EVENT_NAME: "pull_request",
+          GITHUB_EVENT_PATH: eventPath,
+          GITHUB_OUTPUT: githubOutputPath,
+          GITHUB_REPOSITORY: "nexu-io/open-design",
+          OPEN_DESIGN_GH_NODE_SCRIPT: ghPath,
+        },
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toContain("pull_request resolution failed; using full plan");
+      expect(JSON.parse(readFileSync(planPath, "utf8"))).toMatchObject({
+        source: "pull_request:resolution-error",
+        scopes: { workspace_validation_required: true },
+        enabled: {
+          daemon_unit_tests: true,
+          e2e_vitest: true,
+          playwright_visual: true,
+          preflight: true,
+          ui_p0: true,
+          web_workspace_tests: true,
+          windows_tools_pack_payload_tests: true,
+          workspace_unit_tests: true,
+        },
+        trace: { filesResolved: false },
+      });
+    } finally {
+      rmSync(temporaryRoot, { force: true, recursive: true });
+    }
+  });
+
   test("routes representative PR changes without importing the workspace", () => {
     expect(plan("pr", ["apps/web/src/App.tsx"])).toMatchObject({
       scopes: { web_tests_required: true, ui_p0_validation_required: true, visual_validation_required: true },


### PR DESCRIPTION
Fixes #4829

## Why

Letta now provides an official ACP adapter, so Open Design can support Letta Code through its established stdio ACP runtime path instead of carrying a custom runner or a daemon-owned Letta SDK dependency.

## What users will see

After installing the standalone adapter with npm install -g @letta-ai/letta-acp, the existing Settings agent picker discovers Letta Code as an available runtime. It uses the existing CLI-environment editor for Letta configuration, streams ACP text/tool status, preserves a Letta conversation across compatible Open Design turns, and forwards configured MCP servers only for that ACP session.

## Surface area

- [x] **UI** — the registry-backed Settings agent picker gains Letta Code when the standalone executable is detected; no separate apps/web or apps/desktop component is required
- [ ] **Keyboard shortcut** — none
- [ ] **CLI / env var** — no Open Design command, flag, or OD_* variable added
- [ ] **API / contract** — no endpoint, SSE shape, or contract changed
- [ ] **Extension point** — none
- [ ] **i18n keys** — none
- [ ] **New top-level dependency** — none
- [ ] **Default behavior change** — Letta is opt-in and is only detected when its standalone binary is installed
- [ ] **None** — this adds a daemon runtime integration

## Screenshots

The entry point is the existing registry-driven Settings agent picker. This change adds no source-specific UI component or layout to capture; Letta appears there when its executable is available.

## Bug fix verification

- Not a bug fix. ACP session durability is covered by a regression test that persists a Letta-style sessionId and asserts the next run uses session/load.

## Validation

- Passed after rebasing onto origin/main: corepack pnpm --dir apps/daemon exec vitest run -c vitest.config.ts tests/acp.test.ts tests/runtimes/agent-args.test.ts tests/runtimes/mcp.test.ts (128 tests).
- Passed: git diff --check.
- Checked the official published adapter without adding a project or global dependency: npm exec --yes --package @letta-ai/letta-acp letta-acp --version returned 11.15.0.
- Live session limitation: this environment has no LETTA_* configuration, local Letta backend, or agent identity. An initialization-only ACP smoke attempt did not establish a session within 30 seconds, so this PR does not claim a successful authenticated turn or daemon-log excerpt.
- pnpm guard completed its project checks but fails on current-main CI/config baseline issues: a certain-exempt test/docs consumer, a missing guarded CI command block, and missing apps/telemetry-worker/package.json.
- The daemon typecheck reports current-main missing slide/launcher dependencies and sidecar-proto exports; no Letta-specific TypeScript error is reported.