### PR TITLE
fix(daemon): `od conversation info` 404s on wrong route and reports daemon-not-running

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -7376,13 +7376,18 @@ Common options:
       return;
     }
     case 'info': {
-      const id = rest.find((a) => !a.startsWith('-'));
-      if (!id) {
-        console.error('Usage: od conversation info <conversationId>');
+      const projectId = typeof flags.project === 'string' && flags.project
+        ? flags.project
+        : null;
+      const id = positionalArgs(rest, PROJECT_STRING_FLAGS)[0];
+      if (!projectId || !id) {
+        console.error('Usage: od conversation info --project <projectId> <conversationId>');
         process.exit(2);
       }
-      const resp = await fetch(`${base}/api/conversations/${encodeURIComponent(id)}`);
-      if (!resp.ok) return structuredHttpFailure(resp);
+      const resp = await fetch(
+        `${base}/api/projects/${encodeURIComponent(projectId)}/conversations/${encodeURIComponent(id)}`,
+      );
+      if (!resp.ok) return structuredHttpFailure(resp, resp.status === 404 ? 'not-found' : 'daemon-not-running');
       const data = await resp.json();
       process.stdout.write(JSON.stringify(data, null, 2) + '\n');
       return;

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -7319,7 +7319,8 @@ async function runConversation(args) {
                                            --fork-after stops the copy at one
                                            source message.
   od conversation list <projectId>           List conversations in a project.
-  od conversation info <conversationId>      Print one conversation.
+  od conversation info --project <projectId> <conversationId>
+                                           Print one conversation.
 
 Common options:
   --daemon-url <url>   Open Design daemon HTTP base.

--- a/apps/daemon/src/routes/project/conversations.ts
+++ b/apps/daemon/src/routes/project/conversations.ts
@@ -133,6 +133,17 @@ export function registerProjectConversationRoutes(app: Express, ctx: RegisterPro
     res.json({ conversation: conv });
   });
 
+  app.get('/api/projects/:id/conversations/:cid', (req, res) => {
+    // Project-scoped GET for a single conversation. Previously the
+    // only per-conversation verbs were PATCH/DELETE; `od conversation
+    // info <cid>` therefore had nothing to hit and 404ed (issue #6116).
+    const conv = getConversation(db, req.params.cid);
+    if (!conv || conv.projectId !== req.params.id) {
+      return res.status(404).json({ error: 'not found' });
+    }
+    res.json({ conversation: conv });
+  });
+
   app.patch('/api/projects/:id/conversations/:cid', (req, res) => {
     const conv = getConversation(db, req.params.cid);
     if (!conv || conv.projectId !== req.params.id) {

--- a/apps/daemon/tests/conversation-info-cli.test.ts
+++ b/apps/daemon/tests/conversation-info-cli.test.ts
@@ -140,4 +140,41 @@ describe('od conversation info CLI', () => {
     expect(r.stdout).toContain('od conversation info --project <projectId>');
     expect(r.stdout).not.toContain('od conversation info <conversationId>');
   });
+
+  it('published docs/plugins-spec.md and zh-CN keep `conversation info` in sync with the embedded help block', async () => {
+    // Per #6341 round-2 review (lefarcen, 2026-08-02): the published
+    // command reference under `docs/plugins-spec.md` and
+    // `docs/plugins-spec.zh-CN.md` had drifted to advertise the old
+    // `od conversation info <conversationId>` form while the CLI required
+    // `--project <projectId> <conversationId>`. This guard reads both
+    // markdown files and the embedded help block emitted by the CLI and
+    // asserts that the `conversation info` line stays aligned across all
+    // three surfaces. If you legitimately change the invocation, update
+    // every site in the same change.
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const repoRoot = path.resolve(fileURLToPath(import.meta.url), '../../../..');
+    const enDoc = fs.readFileSync(path.join(repoRoot, 'docs/plugins-spec.md'), 'utf8');
+    const zhDoc = fs.readFileSync(path.join(repoRoot, 'docs/plugins-spec.zh-CN.md'), 'utf8');
+
+    // The new required shape must appear in both docs; the legacy bare
+    // `<conversationId>` invocation must not.
+    expect(enDoc).toContain('od conversation info --project <projectId> <conversationId>');
+    expect(enDoc).not.toMatch(/od conversation info <conversationId>/);
+    expect(zhDoc).toContain('od conversation info --project <projectId> <conversationId>');
+    expect(zhDoc).not.toMatch(/od conversation info <conversationId>/);
+
+    // Reuse the help emitter to anchor the docs against the same source
+    // of truth the help block test above uses.
+    const r = await execFileAsync(
+      process.execPath,
+      ['--import', 'tsx', cliEntry, 'conversation', 'help', '--json'],
+    );
+    const helpBlock = r.stdout;
+    expect(helpBlock).toContain('od conversation info --project <projectId>');
+    // The docs surface the full required form, the help block emits a
+    // shorter hint; both must agree on the `--project` prefix and must
+    // never resurrect the bare `<conversationId>` invocation.
+    expect(helpBlock).not.toContain('od conversation info <conversationId>');
+  });
 });

--- a/apps/daemon/tests/conversation-info-cli.test.ts
+++ b/apps/daemon/tests/conversation-info-cli.test.ts
@@ -19,6 +19,27 @@ import { describe, expect, it } from 'vitest';
 const execFileAsync = promisify(execFile);
 const cliEntry = fileURLToPath(new URL('../src/cli.ts', import.meta.url));
 
+/**
+ * Run an execFile command that is expected to exit non-zero, returning the
+ * typed `NodeJS.ErrnoException` so its `code`, `stderr`, and `stdout`
+ * properties can be inspected. A success-branch result has none of these
+ * properties (promisify's resolved value is only `{ stdout, stderr }`), so
+ * this helper keeps the typecheck narrow rather than threading a union
+ * through each test.
+ */
+async function expectExecFailureAsync(
+  ...args: Parameters<typeof execFileAsync>
+): Promise<NodeJS.ErrnoException & { stdout?: string; stderr?: string }> {
+  try {
+    const success = await execFileAsync(...args);
+    throw new Error(
+      `expectExecFailure: command resolved successfully\nstdout=${success.stdout}\nstderr=${success.stderr}`,
+    );
+  } catch (err) {
+    return err as NodeJS.ErrnoException & { stdout?: string; stderr?: string };
+  }
+}
+
 describe('od conversation info CLI', () => {
   it('hits the project-scoped conversation route and prints the conversation', async () => {
     const seenRequests: Array<{ method: string; url: string }> = [];
@@ -91,7 +112,7 @@ describe('od conversation info CLI', () => {
     const port = address.port;
 
     try {
-      const result = await execFileAsync(
+      const result = await expectExecFailureAsync(
         process.execPath,
         [
           '--import', 'tsx', cliEntry,
@@ -101,7 +122,7 @@ describe('od conversation info CLI', () => {
           '--daemon-url', `http://127.0.0.1:${port}`,
           '--json',
         ],
-      ).catch((err: NodeJS.ErrnoException & { stdout?: string; stderr?: string }) => err);
+      );
 
       // 404 should produce a non-zero exit, AND the structured error
       // payload should use `not-found` rather than the misleading
@@ -117,13 +138,12 @@ describe('od conversation info CLI', () => {
   });
 
   it('prints usage and exits non-zero when --project is missing', async () => {
-    const result = await execFileAsync(
+    const result = await expectExecFailureAsync(
       process.execPath,
       ['--import', 'tsx', cliEntry, 'conversation', 'info', 'conv-9', '--json'],
-    ).catch((err: NodeJS.ErrnoException & { stdout?: string; stderr?: string }) => err);
+    );
     expect(result.code).toBeTruthy();
-    const stderr = (result as { stderr?: string }).stderr ?? '';
-    expect(stderr).toContain('Usage: od conversation info --project <projectId> <conversationId>');
+    expect(result.stderr ?? '').toContain('Usage: od conversation info --project <projectId> <conversationId>');
   });
 
   it('embedded help block advertises the new --project flag for `info`', async () => {
@@ -134,47 +154,12 @@ describe('od conversation info CLI', () => {
     // real invocation required `--project <projectId> <conversationId>`.
     const r = await execFileAsync(
       process.execPath,
-      ['--import', 'tsx', cliEntry, 'conversation', 'help', '--json'],
+      ['--import', 'tsx', cliEntry, 'conversation', 'help'],
     );
-    expect(r.exitCode ?? 0).toBe(0);
+    // The command's resolved promise proves the process exited 0; we do
+    // not read `r.exitCode` because promisify's resolved value does not
+    // expose one (PerishCode review on #6341).
     expect(r.stdout).toContain('od conversation info --project <projectId>');
     expect(r.stdout).not.toContain('od conversation info <conversationId>');
-  });
-
-  it('published docs/plugins-spec.md and zh-CN keep `conversation info` in sync with the embedded help block', async () => {
-    // Per #6341 round-2 review (lefarcen, 2026-08-02): the published
-    // command reference under `docs/plugins-spec.md` and
-    // `docs/plugins-spec.zh-CN.md` had drifted to advertise the old
-    // `od conversation info <conversationId>` form while the CLI required
-    // `--project <projectId> <conversationId>`. This guard reads both
-    // markdown files and the embedded help block emitted by the CLI and
-    // asserts that the `conversation info` line stays aligned across all
-    // three surfaces. If you legitimately change the invocation, update
-    // every site in the same change.
-    const fs = await import('node:fs');
-    const path = await import('node:path');
-    const repoRoot = path.resolve(fileURLToPath(import.meta.url), '../../../..');
-    const enDoc = fs.readFileSync(path.join(repoRoot, 'docs/plugins-spec.md'), 'utf8');
-    const zhDoc = fs.readFileSync(path.join(repoRoot, 'docs/plugins-spec.zh-CN.md'), 'utf8');
-
-    // The new required shape must appear in both docs; the legacy bare
-    // `<conversationId>` invocation must not.
-    expect(enDoc).toContain('od conversation info --project <projectId> <conversationId>');
-    expect(enDoc).not.toMatch(/od conversation info <conversationId>/);
-    expect(zhDoc).toContain('od conversation info --project <projectId> <conversationId>');
-    expect(zhDoc).not.toMatch(/od conversation info <conversationId>/);
-
-    // Reuse the help emitter to anchor the docs against the same source
-    // of truth the help block test above uses.
-    const r = await execFileAsync(
-      process.execPath,
-      ['--import', 'tsx', cliEntry, 'conversation', 'help', '--json'],
-    );
-    const helpBlock = r.stdout;
-    expect(helpBlock).toContain('od conversation info --project <projectId>');
-    // The docs surface the full required form, the help block emits a
-    // shorter hint; both must agree on the `--project` prefix and must
-    // never resurrect the bare `<conversationId>` invocation.
-    expect(helpBlock).not.toContain('od conversation info <conversationId>');
   });
 });

--- a/apps/daemon/tests/conversation-info-cli.test.ts
+++ b/apps/daemon/tests/conversation-info-cli.test.ts
@@ -20,18 +20,29 @@ const execFileAsync = promisify(execFile);
 const cliEntry = fileURLToPath(new URL('../src/cli.ts', import.meta.url));
 
 /**
- * Run an execFile command that is expected to exit non-zero, returning the
- * typed `NodeJS.ErrnoException` so its `code`, `stderr`, and `stdout`
- * properties can be inspected. A success-branch result has none of these
- * properties (promisify's resolved value is only `{ stdout, stderr }`), so
- * this helper keeps the typecheck narrow rather than threading a union
- * through each test.
+ * Run an execFile command (command + args only — no options overload)
+ * that is expected to exit non-zero, returning the typed
+ * `NodeJS.ErrnoException` so its `code`, `stderr`, and `stdout`
+ * properties can be inspected. A success-branch result has none of
+ * these properties (promisify's resolved value is only
+ * `{ stdout, stderr }`), so this helper keeps the typecheck narrow
+ * rather than threading a union through each test.
+ *
+ * Per #6341 review (PerishCode round-4): `Parameters<typeof
+ * execFileAsync>` resolves to the promisified overload with three
+ * required parameters (command, args, options), but the call sites
+ * here pass only two, so the spread binding triggers TS2554. The
+ * helper now declares the two-argument shape explicitly and forwards
+ * into `execFileAsync(command, args)` internally; options stay
+ * optional on the promisified overload, which accepts a two-arg
+ * call without error.
  */
 async function expectExecFailureAsync(
-  ...args: Parameters<typeof execFileAsync>
+  command: string,
+  args: readonly string[],
 ): Promise<NodeJS.ErrnoException & { stdout?: string; stderr?: string }> {
   try {
-    const success = await execFileAsync(...args);
+    const success = await execFileAsync(command, args);
     throw new Error(
       `expectExecFailure: command resolved successfully\nstdout=${success.stdout}\nstderr=${success.stderr}`,
     );

--- a/apps/daemon/tests/conversation-info-cli.test.ts
+++ b/apps/daemon/tests/conversation-info-cli.test.ts
@@ -125,4 +125,19 @@ describe('od conversation info CLI', () => {
     const stderr = (result as { stderr?: string }).stderr ?? '';
     expect(stderr).toContain('Usage: od conversation info --project <projectId> <conversationId>');
   });
+
+  it('embedded help block advertises the new --project flag for `info`', async () => {
+    // Per #6341 review: the help block (printed by `od conversation help`
+    // or any time the subcommand is invoked with --help/-h or no args)
+    // must stay in sync with the actual invocation. Before the fix the
+    // help block said `od conversation info <conversationId>` while the
+    // real invocation required `--project <projectId> <conversationId>`.
+    const r = await execFileAsync(
+      process.execPath,
+      ['--import', 'tsx', cliEntry, 'conversation', 'help', '--json'],
+    );
+    expect(r.exitCode ?? 0).toBe(0);
+    expect(r.stdout).toContain('od conversation info --project <projectId>');
+    expect(r.stdout).not.toContain('od conversation info <conversationId>');
+  });
 });

--- a/apps/daemon/tests/conversation-info-cli.test.ts
+++ b/apps/daemon/tests/conversation-info-cli.test.ts
@@ -1,0 +1,128 @@
+// Regression for `od conversation info` always 404ing (#6116):
+// `case 'info'` used to fetch the unscoped route
+// `/api/conversations/<id>`, but the daemon only serves
+// project-scoped routes (`/api/projects/:id/conversations/…`). The
+// 404 then mapped to `daemon-not-running`, sending users on a wild
+// goose chase checking daemon sockets.
+//
+// Fix:
+//   1. `od conversation info --project <id> <conversationId>` hits
+//      the project-scoped route.
+//   2. 404 now exits with `not-found`, not `daemon-not-running`.
+
+import { execFile } from 'node:child_process';
+import http from 'node:http';
+import { promisify } from 'node:util';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const cliEntry = fileURLToPath(new URL('../src/cli.ts', import.meta.url));
+
+describe('od conversation info CLI', () => {
+  it('hits the project-scoped conversation route and prints the conversation', async () => {
+    const seenRequests: Array<{ method: string; url: string }> = [];
+    const server = http.createServer((req, res) => {
+      let body = '';
+      req.setEncoding('utf8');
+      req.on('data', (chunk) => {
+        body += chunk;
+      });
+      req.on('end', () => {
+        seenRequests.push({ method: req.method ?? '', url: req.url ?? '' });
+        if (req.method === 'GET' && req.url === '/api/projects/proj-1/conversations/conv-9') {
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({
+            conversation: { id: 'conv-9', projectId: 'proj-1', title: 'Demo' },
+            messages: [],
+          }));
+          return;
+        }
+        res.writeHead(404, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('server did not bind');
+    const port = address.port;
+
+    try {
+      let stdout = '';
+      try {
+        const r = await execFileAsync(
+          process.execPath,
+          [
+            '--import',
+            'tsx',
+            cliEntry,
+            'conversation',
+            'info',
+            '--project', 'proj-1',
+            'conv-9',
+            '--daemon-url', `http://127.0.0.1:${port}`,
+            '--json',
+          ],
+        );
+        stdout = r.stdout;
+      } catch (err) {
+        const e = err as NodeJS.ErrnoException & { stdout?: string; stderr?: string };
+        stdout = e.stdout ?? '';
+      }
+      const parsed = JSON.parse(stdout);
+      expect(parsed.conversation.id).toBe('conv-9');
+      // Confirm we hit the project-scoped route, not the broken unscoped one.
+      expect(seenRequests).toContainEqual({ method: 'GET', url: '/api/projects/proj-1/conversations/conv-9' });
+      expect(seenRequests.some((r) => r.url === '/api/conversations/conv-9')).toBe(false);
+    } finally {
+      server.close();
+    }
+  });
+
+  it('exits with `not-found` (not daemon-not-running) when the conversation is missing', async () => {
+    const server = http.createServer((req, res) => {
+      req.resume();
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: 'not found' }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('server did not bind');
+    const port = address.port;
+
+    try {
+      const result = await execFileAsync(
+        process.execPath,
+        [
+          '--import', 'tsx', cliEntry,
+          'conversation', 'info',
+          '--project', 'proj-1',
+          'conv-missing',
+          '--daemon-url', `http://127.0.0.1:${port}`,
+          '--json',
+        ],
+      ).catch((err: NodeJS.ErrnoException & { stdout?: string; stderr?: string }) => err);
+
+      // 404 should produce a non-zero exit, AND the structured error
+      // payload should use `not-found` rather than the misleading
+      // `daemon-not-running` code.
+      expect(result.code).toBeTruthy();
+      const stderr = (result as { stderr?: string }).stderr ?? '';
+      expect(stderr).toContain('"code":');
+      expect(stderr).toContain('"not-found"');
+      expect(stderr).not.toContain('daemon-not-running');
+    } finally {
+      server.close();
+    }
+  });
+
+  it('prints usage and exits non-zero when --project is missing', async () => {
+    const result = await execFileAsync(
+      process.execPath,
+      ['--import', 'tsx', cliEntry, 'conversation', 'info', 'conv-9', '--json'],
+    ).catch((err: NodeJS.ErrnoException & { stdout?: string; stderr?: string }) => err);
+    expect(result.code).toBeTruthy();
+    const stderr = (result as { stderr?: string }).stderr ?? '';
+    expect(stderr).toContain('Usage: od conversation info --project <projectId> <conversationId>');
+  });
+});

--- a/docs/plugins-spec.md
+++ b/docs/plugins-spec.md
@@ -1316,9 +1316,14 @@ od conversation info --project <projectId> <conversationId> [--json]
 `new`: those consume `<projectId>` as the first positional argument, while
 `info` takes it as `--project <projectId>` followed by the `<conversationId>`
 positional. The discrepancy mirrors the embedded `od conversation help` block
-(`apps/daemon/src/cli.ts`) and is asserted by the
-`docs/plugins-spec.md and the embedded help block advertise the new --project flag for info`
-regression in `apps/daemon/tests/conversation-info-cli.test.ts`.
+(`apps/daemon/src/cli.ts`).
+
+NOTE: There is no repository-owned cross-document regression check that
+enforces future drift between this spec section and the `od conversation help`
+block; the prior assertion was lifted out of the daemon test lane (see commit
+9f68de7f7, "fix(#6341): typecheck-safe execFile helper; remove docs-consistency
+test from daemon lane"). Maintain the two surfaces by hand when changing
+`info`'s argument shape.
 
 #### Run / task lifecycle (new)
 

--- a/docs/plugins-spec.md
+++ b/docs/plugins-spec.md
@@ -1309,8 +1309,16 @@ Result of `od project create --json`:
 ```
 od conversation list <projectId> [--json]
 od conversation new  <projectId> [--title "<title>"] [--json]
-od conversation info <conversationId> [--json]
+od conversation info --project <projectId> <conversationId> [--json]
 ```
+
+`od conversation info`'s argument shape is intentionally different from `list` and
+`new`: those consume `<projectId>` as the first positional argument, while
+`info` takes it as `--project <projectId>` followed by the `<conversationId>`
+positional. The discrepancy mirrors the embedded `od conversation help` block
+(`apps/daemon/src/cli.ts`) and is asserted by the
+`docs/plugins-spec.md and the embedded help block advertise the new --project flag for info`
+regression in `apps/daemon/tests/conversation-info-cli.test.ts`.
 
 #### Run / task lifecycle (new)
 

--- a/docs/plugins-spec.zh-CN.md
+++ b/docs/plugins-spec.zh-CN.md
@@ -1304,8 +1304,10 @@ od project open   <id>                                 # opens browser at /proje
 ```
 od conversation list <projectId> [--json]
 od conversation new  <projectId> [--title "<title>"] [--json]
-od conversation info <conversationId> [--json]
+od conversation info --project <projectId> <conversationId> [--json]
 ```
+
+`od conversation info` 的参数形态与 `list` 和 `new` 不同：后两者把 `<projectId>` 作为第一个位置参数，而 `info` 把它放在 `--project <projectId>` 上，再带 `<conversationId>` 位置参数。该差异与 `apps/daemon/src/cli.ts` 中内嵌的 `od conversation help` 文本一致，并由 `apps/daemon/tests/conversation-info-cli.test.ts` 中的 `docs/plugins-spec.md and the embedded help block advertise the new --project flag for info` 回归测试断言，以防文档再次与 CLI drift。
 
 #### Run / task lifecycle（新增）
 

--- a/docs/plugins-spec.zh-CN.md
+++ b/docs/plugins-spec.zh-CN.md
@@ -1307,7 +1307,9 @@ od conversation new  <projectId> [--title "<title>"] [--json]
 od conversation info --project <projectId> <conversationId> [--json]
 ```
 
-`od conversation info` 的参数形态与 `list` 和 `new` 不同：后两者把 `<projectId>` 作为第一个位置参数，而 `info` 把它放在 `--project <projectId>` 上，再带 `<conversationId>` 位置参数。该差异与 `apps/daemon/src/cli.ts` 中内嵌的 `od conversation help` 文本一致，并由 `apps/daemon/tests/conversation-info-cli.test.ts` 中的 `docs/plugins-spec.md and the embedded help block advertise the new --project flag for info` 回归测试断言，以防文档再次与 CLI drift。
+`od conversation info` 的参数形态与 `list` 和 `new` 不同：后两者把 `<projectId>` 作为第一个位置参数，而 `info` 把它放在 `--project <projectId>` 上，再带 `<conversationId>` 位置参数。该差异与 `apps/daemon/src/cli.ts` 中内嵌的 `od conversation help` 文本一致。
+
+注意：当前仓库没有跨文档的回归校验来强制此 spec 与 `od conversation help` 文本保持同步；此前的断言已从 daemon 测试 lane 中移出（见 commit 9f68de7f7 "fix(#6341): typecheck-safe execFile helper; remove docs-consistency test from daemon lane"）。修改 `info` 参数形态时需手工保持两份文档一致。
 
 #### Run / task lifecycle（新增）
 


### PR DESCRIPTION
## What broke

`od conversation info <cid>` always failed with `daemon-not-running` because:
1. The CLI fetched the unscoped route `/api/conversations/<id>`, but the daemon only serves project-scoped routes (`/api/projects/:id/conversations/...`).
2. There was no GET handler for a single conversation — only PATCH and DELETE — so even with the right scope the request would 404.
3. The 404 got mapped to `code: 'daemon-not-running'`, sending users to check daemon sockets when the daemon was actually fine.

## Fix

- Add a GET `/api/projects/:id/conversations/:cid` handler that returns the conversation object.
- `od conversation info` now requires `--project <id> <conversationId>` (consistent with `od conversation list <projectId>`) and hits the project-scoped route through `positionalArgs` so a flag value isn't mistaken for the conversation id.
- On a 404 use `fallbackCode: 'not-found'` instead of the misleading `'daemon-not-running'`. The daemon answered — that's literally what a 404 proves.

## Regression test

`conversation-info-cli.test.ts` uses a stub HTTP server to assert:
- The success path hits the exact scoped URL
- A missing conversation exits `not-found`, never `daemon-not-running`
- Omitting `--project` bails with the new usage line

Closes #6116.