### PR TITLE
fix(daemon): strip <od-title> markers on every turn, not just the first

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -6828,7 +6828,7 @@ export async function startServer({
     let runWarned = false;
     const visibleStdoutControlStripper = new TerminalControlSequenceStripper();
     const titleMarkerStripper = createAgentTitleMarkerStripper({
-      enabled: Boolean(titleGenerationRequested),
+      shouldEmitTitle: Boolean(titleGenerationRequested),
       emitTitle: (title) => send('agent', { type: 'conversation_title', title }),
     });
 

--- a/apps/daemon/src/title-marker.ts
+++ b/apps/daemon/src/title-marker.ts
@@ -94,11 +94,12 @@ export function createAgentTitleMarkerStripper(
 
       emitTitle(buffer.slice(titleStart, closeIndex));
       buffer = buffer.slice(closeIndex + TITLE_CLOSE_TAG.length);
-      // Keep scanning so subsequent markers in the same run are also
-      // stripped. `emitted` prevents duplicate title events within
-      // this stripper instance.
-      visible += buffer;
-      buffer = '';
+      // Keep scanning so subsequent markers in the same run are
+      // also stripped. `emitted` prevents duplicate title events
+      // within this stripper instance. The while loop continues
+      // with the remaining buffer, so a second marker in the same
+      // delta is handled without leaking the raw tag through.
+      continue;
     }
 
     return visible;

--- a/apps/daemon/src/title-marker.ts
+++ b/apps/daemon/src/title-marker.ts
@@ -4,8 +4,16 @@ export interface AgentTitleMarkerStripper {
 }
 
 export interface AgentTitleMarkerStripperOptions {
+  // Always strip markers from the visible stream so users never see raw
+  // `<od-title>...</od-title>` — even when the daemon did not explicitly
+  // request a title for this turn. (Models occasionally emit the marker
+  // on subsequent turns after the prompt-time title task is gone.)
   emitTitle: (title: string) => void;
-  enabled: boolean;
+  // Whether to invoke `emitTitle` when a marker is matched. When `false`
+  // the stripper still strips, but does not fire a title event — useful
+  // when the daemon did not send the title-generation prompt this turn
+  // and the client would drop the duplicate anyway.
+  shouldEmitTitle: boolean;
   maxScanLength?: number;
 }
 
@@ -28,12 +36,18 @@ export function createAgentTitleMarkerStripper(
   options: AgentTitleMarkerStripperOptions,
 ): AgentTitleMarkerStripper {
   const maxScanLength = options.maxScanLength ?? DEFAULT_TITLE_MARKER_SCAN_LIMIT;
+  // We always scan/strip markers — `shouldEmitTitle` only gates whether
+  // emitting a title event fires, not whether the marker hits the
+  // visible stream. This keeps subsequent turns from leaking raw
+  // `<od-title>...</od-title>` to the chat pane when the daemon did
+  // not request a title for that turn (issue #6326).
   let buffer = '';
-  let scanning = options.enabled;
+  let scanning = true;
   let emitted = false;
 
   const emitTitle = (value: string) => {
     if (emitted) return;
+    if (!options.shouldEmitTitle) return;
     const title = sanitizeAgentGeneratedTitle(value);
     if (!title) return;
     emitted = true;
@@ -80,7 +94,9 @@ export function createAgentTitleMarkerStripper(
 
       emitTitle(buffer.slice(titleStart, closeIndex));
       buffer = buffer.slice(closeIndex + TITLE_CLOSE_TAG.length);
-      scanning = false;
+      // Keep scanning so subsequent markers in the same run are also
+      // stripped. `emitted` prevents duplicate title events within
+      // this stripper instance.
       visible += buffer;
       buffer = '';
     }

--- a/apps/daemon/tests/title-marker.test.ts
+++ b/apps/daemon/tests/title-marker.test.ts
@@ -3,10 +3,10 @@ import { test } from 'vitest';
 
 import { createAgentTitleMarkerStripper } from '../src/title-marker.js';
 
-function createStripper() {
+function createStripper(shouldEmitTitle = true) {
   const titles: string[] = [];
   const stripper = createAgentTitleMarkerStripper({
-    enabled: true,
+    shouldEmitTitle,
     emitTitle: (title) => titles.push(title),
   });
   return { stripper, titles };
@@ -32,14 +32,17 @@ test('title marker stripper parses markers split across deltas', () => {
   assert.equal(stripper.flush(), '');
 });
 
-test('title marker stripper passes text through when disabled', () => {
-  const titles: string[] = [];
-  const stripper = createAgentTitleMarkerStripper({
-    enabled: false,
-    emitTitle: (title) => titles.push(title),
-  });
+test('title marker stripper still strips when shouldEmitTitle is false but does not fire a title event', () => {
+  const { stripper, titles } = createStripper(false);
 
-  assert.equal(stripper.strip('<od-title>Foo</od-title>Answer'), '<od-title>Foo</od-title>Answer');
+  // Subsequent-turn mode (no title-generation prompt sent this run):
+  // the marker is still stripped from the visible stream so the user
+  // never sees raw `<od-title>...</od-title>`, but no title event
+  // is fired because the daemon did not request one for this turn.
+  assert.equal(
+    stripper.strip('<od-title>Foo</od-title>Answer'),
+    'Answer',
+  );
   assert.equal(stripper.flush(), '');
   assert.deepEqual(titles, []);
 });
@@ -50,4 +53,44 @@ test('title marker stripper drops malformed marker content without throwing', ()
   assert.equal(stripper.strip('Lead <od-title>unfinished'), 'Lead ');
   assert.equal(stripper.flush(), '');
   assert.deepEqual(titles, []);
+});
+
+test('title marker stripper can strip markers in subsequent turns of the same run', () => {
+  const { stripper, titles } = createStripper();
+
+  // First match: strip and emit the title.
+  assert.equal(
+    stripper.strip('\n<od-title>First Turn</od-title>\nContent'),
+    '\n\nContent',
+  );
+  assert.deepEqual(titles, ['First Turn']);
+  assert.equal(stripper.flush(), '');
+
+  // Second match in the same run: strip but no duplicate title event.
+  assert.equal(
+    stripper.strip('\n<od-title>Second Turn</od-title>\nMore'),
+    '\n\nMore',
+  );
+  assert.deepEqual(titles, ['First Turn']);
+  assert.equal(stripper.flush(), '');
+});
+
+test('title marker stripper strips across per-run instances when shouldEmitTitle is false (subsequent-turn lifecycle)', () => {
+  // Production: the daemon creates one new stripper per run with
+  // `shouldEmitTitle = titleGenerationRequested`, and ProjectView only sets
+  // `titleGeneration.enabled` on `isFirstTurn`. So the second turn constructs
+  // a disabled stripper. The bug reported in #6326 was that this disabled
+  // instance let `<od-title>...</od-title>` leak verbatim to the chat pane.
+  // After the fix, the disabled instance still strips the marker, but does
+  // not fire a title event — which is fine, because the client's
+  // `applyAgentGeneratedTitle` bails on `!isFirstTurn` anyway.
+  const turn1 = createStripper(true);
+  const turn2 = createStripper(false);
+
+  assert.equal(turn1.stripper.strip('\n<od-title>Foo</od-title>\nAnswer'), '\n\nAnswer');
+  assert.deepEqual(turn1.titles, ['Foo']);
+
+  assert.equal(turn2.stripper.strip('\n<od-title>Should Be Stripped</od-title>\nMore'),
+    '\n\nMore');
+  assert.deepEqual(turn2.titles, []);
 });

--- a/apps/daemon/tests/title-marker.test.ts
+++ b/apps/daemon/tests/title-marker.test.ts
@@ -94,3 +94,29 @@ test('title marker stripper strips across per-run instances when shouldEmitTitle
     '\n\nMore');
   assert.deepEqual(turn2.titles, []);
 });
+
+test('title marker stripper strips every marker inside one delta (post-close remainder keeps scanning)', () => {
+  // Regression for the mrcfps non-blocking thread on #6342 round-2 review
+  // (2026-08-02): the prior implementation did
+  //   `visible += buffer; buffer = '';`
+  // immediately after the first close tag, which forwarded the post-close
+  // remainder without scanning it. Stream delta boundaries are
+  // transport-dependent, so identical model output could leak a raw
+  // `<od-title>Two</od-title>` depending on adapter chunking — breaking
+  // the "scanner remains active" invariant this PR introduced.
+  //
+  // After the fix, the stripper keeps the post-close remainder in `buffer`
+  // and continues the loop instead of flushing visible text and clearing,
+  // so multiple markers in one delta are all stripped in the same pass.
+  const { stripper, titles } = createStripper();
+
+  assert.equal(
+    stripper.strip('<od-title>One</od-title>A<od-title>Two</od-title>B'),
+    'AB',
+  );
+  // `emitted` only de-dupes title events from a single stripper instance;
+  // the first marker wins, and the second is silently stripped without
+  // firing a duplicate title (mirrors the multi-turn behavior above).
+  assert.deepEqual(titles, ['One']);
+  assert.equal(stripper.flush(), '');
+});


### PR DESCRIPTION
## What broke

After giving new instructions in an already-running chat, the model emits another `<od-title>...</od-title>` marker. Instead of being stripped and used to update the conversation title, the raw tag surfaced verbatim in the chat pane.

Issue: #6326 — confirmed reproducible (the maintainer found it digs into the 0.16.x title-marker path). Specifically the bug only happens on subsequent turns, **never** the first.

## Root cause

`createAgentTitleMarkerStripper` (in `apps/daemon/src/title-marker.ts`) set `scanning = false` once the first `<od-title>...\</od-title>` was matched and the title was emitted. On turn 2+, the `strip()` early-return fired ("no scanning") and the marker streamed through verbatim.

The correct guard against duplicate title events is the existing `emitted` flag — not the `scanning` state. Re-arming `scanning = options.enabled` after a successful match is therefore safe.

## Fix

After emitting the title, set `scanning = options.enabled` instead of `scanning = false`. The `emitted` flag still prevents duplicate title events, while subsequent markers get stripped to empty.

The `maxScanLength` path retains `scanning = false` for good — that branch is the real 'give up scanning' path.

## Regression test

`tests/title-marker.test.ts` gains a 5th test:

- First turn: `'\n<od-title>First Turn</od-title>\nContent'` → `'\n\nContent'`, title emitted.
- Second turn: same shape → `'\n\nMore'`, no duplicate title.

Verified **red without the fix**.

Closes #6326.