### PR TITLE
fix(web): surface unavailable BYOK credential storage in settings

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -510,6 +510,12 @@ function AppInner() {
     'idle' | 'ok' | 'error'
   >('idle');
   const [mediaProvidersNotice, setMediaProvidersNotice] = useState<string | null>(null);
+  // Mirrors the daemon's `available` bit for the BYOK secure credential store
+  // (false on platforms like Windows with the `unavailable-win32` backend).
+  // Threaded into Settings so the BYOK panel can explain why saving a key
+  // fails instead of silently letting runs fall back to cloud billing.
+  const [byokCredentialStorageUnavailable, setByokCredentialStorageUnavailable] =
+    useState(false);
   // Per-resource loading flags. Each goes false the moment its own fetch
   // resolves so each entry-view tab can render as its data lands instead of
   // every tab waiting on the slowest endpoint (typically `/api/agents`,
@@ -1030,9 +1036,7 @@ function AppInner() {
         fetchDaemonConfig(),
         fetchComposioConfigFromDaemon(),
         fetchMediaProvidersFromDaemon(),
-        migrationBaseConfig.byokProfileId
-          ? fetchByokCredentialProfilesFromDaemon()
-          : Promise.resolve(null),
+        fetchByokCredentialProfilesFromDaemon(),
       ]).then(([
         daemonConfig,
         daemonComposioConfig,
@@ -1040,6 +1044,9 @@ function AppInner() {
         byokCredentialProfiles,
       ]) => {
         if (cancelled) return;
+        setByokCredentialStorageUnavailable(
+          Boolean(byokCredentialProfiles && !byokCredentialProfiles.available),
+        );
         const daemonMediaProvidersLoaded =
           daemonMediaProvidersResult.status === 'ok'
             ? daemonMediaProvidersResult.providers
@@ -2698,6 +2705,7 @@ function AppInner() {
           onDraftChange={handleSettingsDraftChange}
           onPersistComposioKey={handleConfigPersistComposioKey}
           onPersistByokCredential={persistByokCredentialProfileToDaemon}
+          byokCredentialStorageUnavailable={byokCredentialStorageUnavailable}
           onClose={() => {
             // Closing the dialog is the canonical "I'm done" gesture
             // now that there is no global Save button. We mark

--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -456,6 +456,13 @@ interface Props {
   daemonMediaProviders?: AppConfig['mediaProviders'] | null;
   daemonMediaProvidersFetchState?: 'idle' | 'ok' | 'error';
   mediaProvidersNotice?: string | null;
+  /**
+   * True when the daemon reports that its OS-backed secure credential store
+   * is unavailable (e.g. the Windows `unavailable-win32` backend). Surfaces
+   * a persistent notice in the BYOK panel so users are not silently pushed
+   * back to Open Design Cloud billing when they try to save a key.
+   */
+  byokCredentialStorageUnavailable?: boolean;
   onReloadMediaProviders?: () => Promise<AppConfig['mediaProviders'] | null>;
   onProjectsRefresh?: () => Promise<void> | void;
   /** Same channel for skill registry mutations. */
@@ -1482,6 +1489,7 @@ export function SettingsDialog({
   daemonMediaProviders,
   daemonMediaProvidersFetchState = 'idle',
   mediaProvidersNotice,
+  byokCredentialStorageUnavailable,
   onReloadMediaProviders,
   onProjectsRefresh,
   onDesignSystemsChanged,
@@ -5395,6 +5403,16 @@ export function SettingsDialog({
                   onTestProvider={() => handleTestProvider()}
                 />
               </div>
+              {byokCredentialStorageUnavailable ? (
+                <p
+                  className="settings-test-status error"
+                  role="alert"
+                  aria-live="polite"
+                  data-testid="settings-byok-storage-unavailable-notice"
+                >
+                  {t('settings.byokStorageUnavailableNotice')}
+                </p>
+              ) : null}
               {byokActivationPreflightReason ? (
                 <p
                   className="settings-test-status warn"

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -361,6 +361,7 @@ export const ar: Dict = {
   'settings.modeApiMeta': 'BYOK',
   'settings.byokNoFileToolsNotice': 'لا يمكن لـ BYOK قراءة ملفات المشروع أو الكتابة فيها أو تعديلها. استخدم Local CLI عندما تحتاج إلى تغييرات في الكود.',
   'settings.byokDraftNotice': 'يظل هذا الإعداد مسودة حتى تكتمل الحقول المطلوبة. يظل إعداد التنفيذ الحالي نشطًا.',
+  'settings.byokStorageUnavailableNotice': 'تخزين مفاتيح BYOK الآمن غير متاح على هذا النظام، لذا لا يمكن حفظ مفاتيح BYOK هنا. ستتحول عمليات التشغيل إلى فوترة Open Design Cloud.',
   'settings.codeAgent': 'وكيل الكود',
   'settings.codeAgentHint': 'تم اكتشافه عبر مسح PATH الخاص بك. اختر واجهة CLI التي تريد أن تمر الأجيال عبرها.',
   'settings.rescan': '↻ إعادة المسح',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -361,6 +361,7 @@ export const de: Dict = {
   'settings.modeApiMeta': 'BYOK',
   'settings.byokNoFileToolsNotice': 'BYOK kann Projektdateien nicht lesen, schreiben oder bearbeiten. Verwenden Sie die Local CLI, wenn Sie Codeänderungen benötigen.',
   'settings.byokDraftNotice': 'Diese Konfiguration bleibt ein Entwurf, bis alle Pflichtfelder ausgefüllt sind. Die aktuelle Ausführungskonfiguration bleibt aktiv.',
+  'settings.byokStorageUnavailableNotice': 'Der sichere BYOK-Schlüsselspeicher ist auf diesem System nicht verfügbar, daher können BYOK-API-Schlüssel hier nicht gespeichert werden. Ausführungen fallen auf die Open Design Cloud-Abrechnung zurück.',
   'settings.codeAgent': 'Code-Agent',
   'settings.codeAgentHint': 'Durch Scannen Ihres PATH erkannt. Wählen Sie die CLI, über die Generierungen laufen sollen.',
   'settings.rescan': '↻ Neu scannen',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -361,6 +361,7 @@ export const en: Dict = {
   'settings.modeApiMeta': 'BYOK',
   'settings.byokNoFileToolsNotice': 'BYOK can\'t read, write, or edit project files. Use Local CLI when you need code changes.',
   'settings.byokDraftNotice': 'This setup remains a draft until the required fields are complete. Your current execution setup stays active.',
+  'settings.byokStorageUnavailableNotice': 'Secure BYOK credential storage is unavailable on this system, so BYOK API keys can\'t be saved here. Runs will fall back to Open Design Cloud billing.',
   'settings.codeAgent': 'Code agent',
   'settings.codeAgentHint': 'Pick the CLI that runs your prompts.',
   'settings.rescan': '↻ Rescan',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -361,6 +361,7 @@ export const esES: Dict = {
   'settings.modeApiMeta': 'BYOK',
   'settings.byokNoFileToolsNotice': 'BYOK no puede leer, escribir ni editar archivos del proyecto. Usa la CLI local cuando necesites cambios en el código.',
   'settings.byokDraftNotice': 'Esta configuración permanecerá como borrador hasta completar los campos obligatorios. La configuración de ejecución actual seguirá activa.',
+  'settings.byokStorageUnavailableNotice': 'El almacenamiento seguro de claves BYOK no está disponible en este sistema, por lo que no se pueden guardar claves BYOK aquí. Los ejecuciones volverán a la facturación de Open Design Cloud.',
   'settings.codeAgent': 'Agente de código',
   'settings.codeAgentHint': 'Detectado al escanear tu PATH. Elige la CLI por la que quieres que pasen las generaciones.',
   'settings.rescan': '↻ Reescanear',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -361,6 +361,7 @@ export const fa: Dict = {
   'settings.modeApiMeta': 'BYOK',
   'settings.byokNoFileToolsNotice': 'BYOK نمی‌تواند فایل‌های پروژه را بخواند، بنویسد یا ویرایش کند. وقتی به تغییرات کد نیاز دارید از Local CLI استفاده کنید.',
   'settings.byokDraftNotice': 'این پیکربندی تا تکمیل فیلدهای الزامی به‌صورت پیش‌نویس می‌ماند. پیکربندی اجرای فعلی فعال باقی می‌ماند.',
+  'settings.byokStorageUnavailableNotice': 'ذخیره‌سازی امن کلید BYOK در این سیستم در دسترس نیست، بنابراین نمی‌توان کلیدهای BYOK را اینجا ذخیره کرد. اجراها به پرداخت ابری Open Design برمی‌گردند.',
   'settings.codeAgent': 'عامل کد',
   'settings.codeAgentHint': 'با اسکن PATH شما شناسایی شده. CLI مورد نظر برای جریان تولیدات را انتخاب کنید.',
   'settings.rescan': '↻ اسکن مجدد',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -361,6 +361,7 @@ export const fr: Dict = {
   'settings.modeApiMeta': 'BYOK',
   'settings.byokNoFileToolsNotice': 'BYOK ne peut pas lire, écrire ni modifier les fichiers du projet. Utilisez la CLI locale quand vous avez besoin de changements de code.',
   'settings.byokDraftNotice': 'Cette configuration reste un brouillon tant que les champs obligatoires ne sont pas remplis. La configuration d’exécution actuelle reste active.',
+  'settings.byokStorageUnavailableNotice': 'Le stockage sécurisé des clés BYOK n’est pas disponible sur ce système, les clés BYOK ne peuvent donc pas être enregistrées ici. Les exécutions retomberont sur la facturation Open Design Cloud.',
   'settings.codeAgent': 'Agent de code',
   'settings.codeAgentHint': 'Choisissez la CLI par laquelle les générations seront routées.',
   'settings.rescan': '↻ Réanalyser',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -361,6 +361,7 @@ export const hu: Dict = {
   'settings.modeApiMeta': 'BYOK',
   'settings.byokNoFileToolsNotice': 'A BYOK nem tud projektfájlokat olvasni, írni vagy szerkeszteni. Ha kódmódosításra van szüksége, használja a Local CLI-t.',
   'settings.byokDraftNotice': 'Ez a beállítás piszkozat marad, amíg az összes kötelező mezőt ki nem tölti. A jelenlegi végrehajtási beállítás aktív marad.',
+  'settings.byokStorageUnavailableNotice': 'A biztonságos BYOK kulcstároló nem érhető el ezen a rendszeren, ezért a BYOK API-kulcsok nem menthetők itt. A futtatások az Open Design Cloud számlázására esnek vissza.',
   'settings.codeAgent': 'Kód Agent',
   'settings.codeAgentHint': 'A PATH átvizsgálásával észlelve. Válaszd ki a CLI-t, amelyen át a generálásokat szeretnéd futtatni.',
   'settings.rescan': '↻ Újraellenőrzés',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -361,6 +361,7 @@ export const id: Dict = {
   'settings.modeApiMeta': 'BYOK',
   'settings.byokNoFileToolsNotice': 'BYOK tidak dapat membaca, menulis, atau mengedit file proyek. Gunakan Local CLI saat Anda perlu mengubah kode.',
   'settings.byokDraftNotice': 'Konfigurasi ini tetap sebagai draf hingga semua bidang wajib dilengkapi. Konfigurasi eksekusi saat ini tetap aktif.',
+  'settings.byokStorageUnavailableNotice': 'Penyimpanan kunci BYOK yang aman tidak tersedia di sistem ini, sehingga kunci API BYOK tidak dapat disimpan di sini. Eksekusi akan kembali ke penagihan Open Design Cloud.',
   'settings.codeAgent': 'Agent kode',
   'settings.codeAgentHint': 'Terdeteksi dari PATH. Pilih CLI yang ingin dipakai untuk menjalankan generasi.',
   'settings.rescan': 'Pindai ulang',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -361,6 +361,7 @@ export const it: Dict = {
   'settings.modeApiMeta': 'BYOK',
   'settings.byokNoFileToolsNotice': 'BYOK non può leggere, scrivere o modificare i file del progetto. Usa la Local CLI quando hai bisogno di modifiche al codice.',
   'settings.byokDraftNotice': 'Questa configurazione resta una bozza finché i campi obbligatori non sono completi. La configurazione di esecuzione attuale rimane attiva.',
+  'settings.byokStorageUnavailableNotice': 'L\'archiviazione sicura delle chiavi BYOK non è disponibile su questo sistema, quindi le chiavi API BYOK non possono essere salvate qui. Le esecuzioni torneranno alla fatturazione Open Design Cloud.',
   'settings.codeAgent': 'Agente di codice',
   'settings.codeAgentHint': 'Rilevato analizzando il tuo PATH. Scegli la CLI attraverso cui verranno eseguite le generazioni.',
   'settings.rescan': '↻ Rianalizza',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -361,6 +361,7 @@ export const ja: Dict = {
   'settings.modeApiMeta': 'BYOK',
   'settings.byokNoFileToolsNotice': 'BYOK ではプロジェクトファイルの読み取り、書き込み、編集はできません。コードを変更する場合は Local CLI を使用してください。',
   'settings.byokDraftNotice': '必須項目がすべて入力されるまで、この設定は下書きとして保存されます。現在の実行設定は引き続き有効です。',
+  'settings.byokStorageUnavailableNotice': 'このシステムでは安全な BYOK キーストレージが利用できないため、BYOK API キーをここに保存できません。実行は Open Design Cloud 課金にフォールバックします。',
   'settings.codeAgent': 'コードエージェント',
   'settings.codeAgentHint': 'PATH をスキャンして検出されます。生成に使用する CLI を選択してください。',
   'settings.rescan': '↻ 再スキャン',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -361,6 +361,7 @@ export const ko: Dict = {
   'settings.modeApiMeta': 'BYOK',
   'settings.byokNoFileToolsNotice': 'BYOK는 프로젝트 파일을 읽거나 쓰거나 편집할 수 없습니다. 코드 변경이 필요한 경우 Local CLI를 사용하세요.',
   'settings.byokDraftNotice': '필수 항목을 모두 입력할 때까지 이 설정은 초안으로 유지됩니다. 현재 실행 설정은 계속 활성 상태로 유지됩니다.',
+  'settings.byokStorageUnavailableNotice': '이 시스템에서는 안전한 BYOK 키 저장소를 사용할 수 없으므로 여기에 BYOK API 키를 저장할 수 없습니다. 실행은 Open Design Cloud 청구로 대체됩니다.',
   'settings.codeAgent': '코드 에이전트',
   'settings.codeAgentHint': 'PATH 환경 변수 스캔을 통해 감지됩니다. 생성을 처리할 CLI를 선택하세요.',
   'settings.rescan': '↻ 다시 스캔',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -361,6 +361,7 @@ export const pl: Dict = {
   'settings.modeApiMeta': 'BYOK',
   'settings.byokNoFileToolsNotice': 'BYOK nie może odczytywać, zapisywać ani edytować plików projektu. Użyj Local CLI, gdy potrzebujesz zmian w kodzie.',
   'settings.byokDraftNotice': 'Ta konfiguracja pozostanie wersją roboczą do czasu uzupełnienia wymaganych pól. Bieżąca konfiguracja wykonywania pozostanie aktywna.',
+  'settings.byokStorageUnavailableNotice': 'Bezpieczne przechowywanie kluczy BYOK nie jest dostępne w tym systemie, więc klucze API BYOK nie mogą być tutaj zapisane. Uruchomienia wrócą do rozliczeń Open Design Cloud.',
   'settings.codeAgent': 'Agent kodu',
   'settings.codeAgentHint': 'Wykryto poprzez skanowanie PATH. Wybierz CLI, przez które mają przechodzić generacje.',
   'settings.rescan': '↻ Ponów skanowanie',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -361,6 +361,7 @@ export const ptBR: Dict = {
   'settings.modeApiMeta': 'BYOK',
   'settings.byokNoFileToolsNotice': 'O BYOK não consegue ler, gravar ou editar arquivos do projeto. Use o Local CLI quando precisar fazer alterações no código.',
   'settings.byokDraftNotice': 'Esta configuração permanecerá como rascunho até que os campos obrigatórios sejam preenchidos. A configuração de execução atual continuará ativa.',
+  'settings.byokStorageUnavailableNotice': 'O armazenamento seguro de chaves BYOK não está disponível neste sistema, portanto chaves de API BYOK não podem ser salvas aqui. As execuções voltarão para o faturamento do Open Design Cloud.',
   'settings.codeAgent': 'Agente de código',
   'settings.codeAgentHint': 'Detectado ao escanear seu PATH. Escolha a CLI por onde as gerações devem passar.',
   'settings.rescan': '↻ Reescanear',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -361,6 +361,7 @@ export const ru: Dict = {
   'settings.modeApiMeta': 'BYOK',
   'settings.byokNoFileToolsNotice': 'BYOK не может читать, записывать или редактировать файлы проекта. Используйте Local CLI, когда нужны изменения в коде.',
   'settings.byokDraftNotice': 'Эта конфигурация останется черновиком, пока не будут заполнены обязательные поля. Текущая конфигурация запуска останется активной.',
+  'settings.byokStorageUnavailableNotice': 'Безопасное хранилище ключей BYOK недоступно в этой системе, поэтому сохранить ключи API BYOK здесь нельзя. Запуски будут возвращаться к оплате Open Design Cloud.',
   'settings.codeAgent': 'Код-агент',
   'settings.codeAgentHint': 'Определяется сканированием вашего PATH. Выберите CLI, через который будут проходить генерации.',
   'settings.rescan': '↻ Пересканировать',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -361,6 +361,7 @@ export const th: Dict = {
   'settings.modeApiMeta': 'BYOK',
   'settings.byokNoFileToolsNotice': 'BYOK ไม่สามารถอ่าน เขียน หรือแก้ไขไฟล์โปรเจกต์ได้ ใช้ Local CLI เมื่อคุณต้องการเปลี่ยนแปลงโค้ด',
   'settings.byokDraftNotice': 'การตั้งค่านี้จะยังเป็นฉบับร่างจนกว่าจะกรอกช่องที่จำเป็นครบ การตั้งค่าการทำงานปัจจุบันจะยังคงใช้งานอยู่',
+  'settings.byokStorageUnavailableNotice': 'การจัดเก็บคีย์ BYOK อย่างปลอดภัยไม่พร้อมใช้งานในระบบนี้ ดังนั้นจึงไม่สามารถบันทึกคีย์ API BYOK ที่นี่ได้ การทำงานจะกลับไปใช้การเรียกเก็บเงินของ Open Design Cloud',
   'settings.codeAgent': 'เอเจนต์โค้ด',
   'settings.codeAgentHint': 'ตรวจพบจากการสแกน PATH ของคุณ เลือก CLI ที่คุณต้องการให้ระบบใช้งาน',
   'settings.rescan': '↻ สแกนใหม่',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -361,6 +361,7 @@ export const tr: Dict = {
   'settings.modeApiMeta': 'BYOK',
   'settings.byokNoFileToolsNotice': 'BYOK proje dosyalarını okuyamaz, yazamaz veya düzenleyemez. Kod değişiklikleri gerektiğinde Local CLI kullanın.',
   'settings.byokDraftNotice': 'Bu yapılandırma, gerekli alanlar tamamlanana kadar taslak olarak kalır. Mevcut yürütme yapılandırması etkin kalır.',
+  'settings.byokStorageUnavailableNotice': 'Güvenli BYOK anahtar depolaması bu sistemde kullanılamıyor, bu nedenle BYOK API anahtarları buraya kaydedilemez. Çalıştırmalar Open Design Cloud faturalamasına geri döner.',
   'settings.codeAgent': 'Kod ajanı',
   'settings.codeAgentHint': 'Yerel PATH taranarak tespit edildi. Oluşum akışının yaşanacağı CLI aracınızı seçin.',
   'settings.rescan': '↻ Yeniden tara',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -361,6 +361,7 @@ export const uk: Dict = {
   'settings.modeApiMeta': 'BYOK',
   'settings.byokNoFileToolsNotice': 'BYOK не може читати, записувати чи редагувати файли проєкту. Використовуйте Local CLI, коли потрібні зміни в коді.',
   'settings.byokDraftNotice': 'Ця конфігурація залишатиметься чернеткою, доки не буде заповнено обов’язкові поля. Поточна конфігурація виконання залишатиметься активною.',
+  'settings.byokStorageUnavailableNotice': 'Безпечне зберігання ключів BYOK недоступне в цій системі, тому ключі API BYOK тут зберегти неможливо. Запуски повертатимуться до оплати Open Design Cloud.',
   'settings.codeAgent': 'Кодовий агент',
   'settings.codeAgentHint': 'Виявляється за допомогою сканування вашого PATH. Виберіть CLI, через який мають проходити генерації.',
   'settings.rescan': '↻ Переканувати',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -359,6 +359,8 @@ export const zhCN: Dict = {
     "BYOK 无法读写或修改项目文件；需要改代码时请使用本机 CLI。",
   "settings.byokDraftNotice":
     "必填项补全前，此配置只会保存为草稿；当前执行配置将继续保持生效。",
+  "settings.byokStorageUnavailableNotice":
+    "此系统无法使用安全的 BYOK 密钥存储，因此无法在此保存 BYOK API 密钥。运行将回退到 Open Design Cloud 计费。",
   "settings.codeAgent": "代码代理",
   "settings.codeAgentHint": "选择用来运行提示词的 CLI。",
   "settings.rescan": "↻ 重新扫描",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -359,6 +359,8 @@ export const zhTW: Dict = {
     "BYOK 無法讀取、寫入或編輯專案檔案。需要變更程式碼時，請使用 Local CLI。",
   "settings.byokDraftNotice":
     "必填項補齊前，此設定只會儲存為草稿；目前的執行設定將繼續維持生效。",
+  "settings.byokStorageUnavailableNotice":
+    "此系統無法使用安全的 BYOK 金鑰儲存，因此無法在此儲存 BYOK API 金鑰。執行將回退到 Open Design Cloud 計費。",
   "settings.codeAgent": "程式碼代理",
   "settings.codeAgentHint": "選擇用來執行提示詞的 CLI。",
   "settings.rescan": "↻ 重新掃描",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -311,6 +311,7 @@ export interface Dict {
   'settings.modeApiMeta': string;
   'settings.byokNoFileToolsNotice': string;
   'settings.byokDraftNotice': string;
+  'settings.byokStorageUnavailableNotice': string;
   'settings.codeAgent': string;
   'settings.codeAgentHint': string;
   'settings.rescan': string;

--- a/apps/web/tests/components/SettingsDialog.execution.test.tsx
+++ b/apps/web/tests/components/SettingsDialog.execution.test.tsx
@@ -282,6 +282,7 @@ function renderSettingsDialog(
     providerModelsCache?: Record<string, ProviderModelOption[]>;
     welcome?: boolean;
     onSilentUpdatePreferenceChange?: (allowSilentUpdates: boolean) => Promise<void>;
+    byokCredentialStorageUnavailable?: boolean;
   } = {},
 ) {
   const onPersist = vi.fn();
@@ -318,6 +319,7 @@ function renderSettingsDialog(
       onSilentUpdatePreferenceChange={onSilentUpdatePreferenceChange}
       onPersistComposioKey={onPersistComposioKey}
       onPersistByokCredential={onPersistByokCredential}
+      byokCredentialStorageUnavailable={options.byokCredentialStorageUnavailable}
       onClose={onClose}
       onRefreshAgents={onRefreshAgents}
     />,
@@ -757,6 +759,15 @@ describe('SettingsDialog execution settings BYOK interactions', () => {
     renderSettingsDialog({ mode: 'daemon' });
 
     expect(screen.queryByTestId('settings-byok-no-file-tools-notice')).toBeNull();
+  });
+
+  it('surfaces a persistent notice when the daemon reports BYOK credential storage unavailable (issue #6330)', () => {
+    renderSettingsDialog({}, { byokCredentialStorageUnavailable: true });
+
+    const notice = screen.getByTestId('settings-byok-storage-unavailable-notice');
+    expect(notice).toBeTruthy();
+    expect(notice.textContent).toContain('credential storage is unavailable');
+    expect(notice.textContent).toContain('billing');
   });
 
   it('only persists Max tokens overrides within the supported BYOK range', async () => {


### PR DESCRIPTION
Fixes #6330

## Why

On Windows the daemon's secure credential store is fail-closed (`unavailable-win32` backend after the DPAPI backend was withdrawn in #6308). Saving a BYOK key always fails there, but the web app gave no persistent explanation — a configured BYOK profile was silently cleared at boot and runs fell back to Open Design Cloud billing with no signal to the user.

## What users will see

On a system where the daemon reports its secure credential store unavailable (Windows), Settings → Execution mode → BYOK now shows a persistent notice: secure BYOK credential storage is unavailable here, so BYOK API keys can't be saved and runs fall back to Open Design Cloud billing. Previously there was no indication why the key couldn't be saved.

## Surface area

- [x] **UI** — new persistent notice in the BYOK panel of `apps/web` Settings
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added `settings.byokStorageUnavailableNotice` to all 19 locales
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

UI change in `apps/web`; screenshots unavailable from this environment. The notice reuses the existing `settings-test-status error` notice styling already used by the BYOK precondition/draft notices, so no new visual surface is introduced.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/SettingsDialog.execution.test.tsx` → "surfaces a persistent notice when the daemon reports BYOK credential storage unavailable (issue #6330)"
- Did the test go red on `main` and green on this branch? yes — the spec asserted a notice that did not exist on `main` (failed on `getByTestId('settings-byok-storage-unavailable-notice')`) and passed after the source change.

## Validation

- `pnpm --filter @open-design/web test` — focused: `SettingsDialog.execution.test.tsx` (151/151), `SettingsDialog.test.ts` + `tests/state/config.test.ts` (143/143)
- `pnpm --filter @open-design/web typecheck` — clean
- `pnpm guard` — exit 0
- `git diff --check` — clean