### PR TITLE
Add Douvery Design System plugin

### DIFF
--- a/plugins/community/douvery-design-system-msc0r0zs/SKILL.md
+++ b/plugins/community/douvery-design-system-msc0r0zs/SKILL.md
@@ -1,0 +1,37 @@
+# Douvery Design System
+
+Paquete reutilizable para crear interfaces de comercio claras, confiables y tranquilas.
+
+## Fuente y alcance
+
+- Fuente pública: https://douvery.com/
+- Registro: `user:douvery-com`
+- Paleta principal: `#1F6266` Quiet Teal para acciones y `#006366` Operational Teal para estructura.
+- Estados: éxito `#16A34A`, advertencia `#F59E0B`, error `#EF4444`, información `#3B82F6`, inactivo `#98A2B3`.
+
+## Archivos clave
+
+- `brand.json`: contrato editable y seed persistente.
+- `brand-spec.md`: tokens OKLCH, tipografía y postura resumida.
+- `DESIGN.md`: contrato visual completo.
+- `BRAND.md`: voz, imaginería y reglas de contenido.
+- `SKILL.md`: guía operativa para nuevos diseños.
+- `system/kit.html`: showcase de componentes, estados y densidad.
+- `system/kit.dark.html`: variante oscura.
+- `system/artifacts/`: ejemplos de landing, deck, poster, email, newsletter y formulario.
+
+## Regeneración
+
+Editar `brand.json` y ejecutar `od brand preview douvery-c9ffd9` para revisar. Ejecutar `od brand finalize douvery-c9ffd9` solo cuando los valores estén validados; genera tokens, kits y artefactos en el mismo registro, nunca un duplicado.
+
+## Reglas rápidas
+
+- Una acción principal por sección.
+- No usar emojis en UI ni copy de marca.
+- No usar azul como baño visual; reservar `#0567FF` para señales puntuales.
+- Combinar color con texto, icono o forma para cada estado.
+- Mantener radio 8px, borde 1px y escala de 8px.
+
+## Provenance
+
+Formalized by Open Design from candidate cb921ef7-5233-4a49-b89f-b4ce0b9b5941.

--- a/plugins/community/douvery-design-system-msc0r0zs/open-design.json
+++ b/plugins/community/douvery-design-system-msc0r0zs/open-design.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "douvery-design-system-msc0r0zs",
+  "title": "Douvery Design System",
+  "version": "0.1.0",
+  "description": "Paquete reutilizable para crear interfaces de comercio claras, confiables y tranquilas.",
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ]
+  }
+}

--- a/plugins/community/douvery-design-system-msc0r0zs/references/provenance.json
+++ b/plugins/community/douvery-design-system-msc0r0zs/references/provenance.json
@@ -1,0 +1,26 @@
+{
+  "candidateId": "cb921ef7-5233-4a49-b89f-b4ce0b9b5941",
+  "projectId": "brand-douvery-c9ffd9",
+  "runId": "e159478a-359c-48f5-8a72-f204c0bb7bd3",
+  "conversationId": "b236d581-b239-4fc7-b06d-bde823ec86b5",
+  "provenance": {
+    "summary": "Detected from README.md, SKILL.md after a successful run.",
+    "detectedAt": 1785686590362
+  },
+  "sourceRefs": [
+    {
+      "kind": "file",
+      "value": "README.md",
+      "label": "README.md",
+      "size": 1451,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "SKILL.md",
+      "label": "SKILL.md",
+      "size": 1037,
+      "copied": true
+    }
+  ]
+}

--- a/plugins/community/douvery-design-system-msc0r0zs/references/source-1-README.md
+++ b/plugins/community/douvery-design-system-msc0r0zs/references/source-1-README.md
@@ -1,0 +1,33 @@
+# Douvery Design System
+
+Paquete reutilizable para crear interfaces de comercio claras, confiables y tranquilas.
+
+## Fuente y alcance
+
+- Fuente pública: https://douvery.com/
+- Registro: `user:douvery-com`
+- Paleta principal: `#1F6266` Quiet Teal para acciones y `#006366` Operational Teal para estructura.
+- Estados: éxito `#16A34A`, advertencia `#F59E0B`, error `#EF4444`, información `#3B82F6`, inactivo `#98A2B3`.
+
+## Archivos clave
+
+- `brand.json`: contrato editable y seed persistente.
+- `brand-spec.md`: tokens OKLCH, tipografía y postura resumida.
+- `DESIGN.md`: contrato visual completo.
+- `BRAND.md`: voz, imaginería y reglas de contenido.
+- `SKILL.md`: guía operativa para nuevos diseños.
+- `system/kit.html`: showcase de componentes, estados y densidad.
+- `system/kit.dark.html`: variante oscura.
+- `system/artifacts/`: ejemplos de landing, deck, poster, email, newsletter y formulario.
+
+## Regeneración
+
+Editar `brand.json` y ejecutar `od brand preview douvery-c9ffd9` para revisar. Ejecutar `od brand finalize douvery-c9ffd9` solo cuando los valores estén validados; genera tokens, kits y artefactos en el mismo registro, nunca un duplicado.
+
+## Reglas rápidas
+
+- Una acción principal por sección.
+- No usar emojis en UI ni copy de marca.
+- No usar azul como baño visual; reservar `#0567FF` para señales puntuales.
+- Combinar color con texto, icono o forma para cada estado.
+- Mantener radio 8px, borde 1px y escala de 8px.

--- a/plugins/community/douvery-design-system-msc0r0zs/references/source-2-SKILL.md
+++ b/plugins/community/douvery-design-system-msc0r0zs/references/source-2-SKILL.md
@@ -1,0 +1,29 @@
+# Douvery Design Skill
+
+## Antes de construir
+
+1. Lee `DESIGN.md`, `brand-spec.md` y `BRAND.md`.
+2. Usa Inter y la escala de 8px.
+3. Usa `#1F6266` como acción principal; no sustituyas estados semánticos por el primario.
+4. No uses emojis. Si un estado necesita refuerzo visual, combina icono de interfaz, forma y copy.
+
+## Estados
+
+- Éxito/activo: `#16A34A`.
+- Pendiente/advertencia: `#F59E0B`.
+- Error: `#EF4444`.
+- Información: `#3B82F6`.
+- Inactivo: `#98A2B3`.
+
+Cada estado necesita una explicación breve y una acción o siguiente paso cuando sea relevante.
+
+## Componentes
+
+- Buttons: 32px, 36px y 40px; radio 8px; primario Quiet Teal.
+- Alerts: borde 1px, icono circular, título corto y descripción secundaria.
+- Status chips: variantes default, compact, clear y minimal.
+- Cards: superficies neutrales, bordes discretos y sombra mínima.
+
+## Copy
+
+Escribe en español claro, calmado y directo. Da fechas, estados, políticas y próximos pasos concretos. Evita urgencia artificial, promesas vagas, culpa al usuario y emojis.


### PR DESCRIPTION
Add Douvery Design System (douvery-design-system-msc0r0zs) plugin.
Version: 0.1.0
Description: Paquete reutilizable para crear interfaces de comercio claras, confiables y tranquilas.