### PR TITLE
fix(web): remove message center entry points

### DIFF
--- a/apps/web/src/components/EntryNavRail.tsx
+++ b/apps/web/src/components/EntryNavRail.tsx
@@ -53,7 +53,6 @@ import { GITHUB_STARS_FALLBACK_LABEL, formatStars, useGithubStars } from './useG
 import { PlanWordmark, planBadgeTierForWorkspace } from './PlanWordmark';
 import { RemixIcon } from './RemixIcon';
 import { InviteDialog } from './InviteDialog';
-import { MessageCenter } from './MessageCenter';
 import type { EntrySettingsSection } from './EntrySettingsMenu';
 import { useI18n } from '../i18n';
 import { useDismissOnOutsideInteraction } from '../hooks/useDismissOnOutsideInteraction';
@@ -624,17 +623,6 @@ export function EntryNavRail({
   });
 
   const [accountOpen, setAccountOpen] = useState(false);
-  // Message-center panel (opened from the account menu's 消息中心 row) and its
-  // unread count, which drives the red dot on the account avatar.
-  const [messageCenterOpen, setMessageCenterOpen] = useState(false);
-  const [messageUnreadCount, setMessageUnreadCount] = useState(0);
-  // Where the message-center panel returns keyboard focus on close. The
-  // signed-in 消息中心 row cannot be it: the account menu unmounts the row before
-  // the panel opens, so the account trigger it hangs off is the stable control.
-  // Signed-out has no menu — the rail item itself stays mounted.
-  const accountTriggerRef = useRef<HTMLButtonElement | null>(null);
-  const messageCenterRailRef = useRef<HTMLButtonElement | null>(null);
-  const messageCenterReturnFocusRef = context ? accountTriggerRef : messageCenterRailRef;
   // Sign-out confirm gate (recvqgMWpJZqhL): the menu item only ARMS the
   // confirmation dialog; the real logout chain runs on explicit confirm.
   const [confirmSignOut, setConfirmSignOut] = useState(false);
@@ -937,7 +925,6 @@ export function EntryNavRail({
               {updaterSlot}
             </div>
             <button
-              ref={accountTriggerRef}
               type="button"
               className="entry-nav-rail__account-trigger"
               onClick={() => setAccountOpen((v) => !v)}
@@ -947,9 +934,6 @@ export function EntryNavRail({
             >
               <span className="entry-nav-rail__account-avatar" aria-hidden>
                 {accountInitial}
-                {messageUnreadCount > 0 ? (
-                  <span className="entry-nav-rail__account-avatar-dot" data-testid="account-avatar-unread-dot" />
-                ) : null}
               </span>
               <span className="entry-nav-rail__account-name">{accountName}</span>
               {/* #5517: the plan badge replaces the chevron when a tier is
@@ -1028,23 +1012,6 @@ export function EntryNavRail({
                     }}
                   >
                     <Icon name="settings" size={15} /> {t('entry.accountSettings')}
-                  </button>
-                  <button
-                    type="button"
-                    className="entry-nav-rail__menu-item"
-                    role="menuitem"
-                    aria-haspopup="dialog"
-                    aria-expanded={messageCenterOpen}
-                    data-testid="account-menu-message-center"
-                    onClick={() => {
-                      setAccountOpen(false);
-                      setMessageCenterOpen(true);
-                    }}
-                  >
-                    <Icon name="bell" size={15} /> {t('messageCenter.title')}
-                    {messageUnreadCount > 0 ? (
-                      <span className="entry-nav-rail__menu-item-dot" aria-hidden />
-                    ) : null}
                   </button>
                   {/* #5517's account menu goes 设置 → GitHub 帮助 → 功能建议 → 社交行,
                       with no theme row, no language submenu, and no divider in
@@ -1398,23 +1365,6 @@ export function EntryNavRail({
             >
               <Icon name="settings" size={16} />
             </NavButton>
-            {/* Signed-out has no account menu (where the 消息中心 row lives when
-                signed in), which left the message panel with no opener at all.
-                It rides here as the rail item under 设置. */}
-            <NavButton
-              ariaLabel={t('messageCenter.title')}
-              label={t('messageCenter.title')}
-              onClick={() => setMessageCenterOpen(true)}
-              testId="entry-nav-message-center"
-              buttonRef={messageCenterRailRef}
-              ariaHasPopup="dialog"
-              ariaExpanded={messageCenterOpen}
-            >
-              <Icon name="bell" size={16} />
-              {messageUnreadCount > 0 ? (
-                <span className="entry-nav-rail__btn-dot" aria-hidden />
-              ) : null}
-            </NavButton>
           </>
         )}
       </div>
@@ -1432,17 +1382,6 @@ export function EntryNavRail({
         </div>
       ) : null}
       </div>
-
-      {/* Panel + unread polling live here (outside the hover menu, which
-          unmounts when closed); the 消息中心 menu row above just opens it. */}
-      <MessageCenter
-        hideTrigger
-        returnFocusRef={messageCenterReturnFocusRef}
-        open={messageCenterOpen}
-        onOpenChange={setMessageCenterOpen}
-        onUnreadCountChange={setMessageUnreadCount}
-        onOpenNotificationSettings={onOpenSettings ? () => onOpenSettings('notifications') : undefined}
-      />
 
       <InviteDialog
         open={inviteOpen}

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -772,25 +772,12 @@
   transition: background-color 120ms var(--ease-out), color 120ms var(--ease-out), border-color 120ms var(--ease-out);
 }
 .entry-nav-rail__btn-icon {
-  /* Anchor for the unread dot (message-center rail item). */
-  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex: 0 0 18px;
   /* Tracks the unselected label tone above. */
   color: color-mix(in srgb, var(--text) 68%, transparent);
-}
-/* Unread marker on a rail item's icon — same 6px red dot as the account
-   menu's `__menu-item-dot`, pinned to the glyph's top-right corner. */
-.entry-nav-rail__btn-dot {
-  position: absolute;
-  top: -2px;
-  right: -2px;
-  width: 6px;
-  height: 6px;
-  border-radius: 999px;
-  background: var(--red);
 }
 .entry-nav-rail__btn-icon > svg {
   width: 18px;
@@ -5465,27 +5452,6 @@
 .entry-nav-rail__account-updater:empty {
   display: none;
 }
-/* Unread-messages red dot riding the account avatar's top-right corner. */
-.entry-nav-rail__account-avatar-dot {
-  position: absolute;
-  top: -2px;
-  right: -2px;
-  width: 8px;
-  height: 8px;
-  border-radius: 999px;
-  background: var(--red);
-  /* Panel-colored ring separates the dot from the avatar artwork. */
-  box-shadow: 0 0 0 2px var(--bg-panel);
-}
-/* Matching dot on the account menu's 消息中心 row, pushed to the far edge. */
-.entry-nav-rail__menu-item-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 999px;
-  background: var(--red);
-  margin-left: auto;
-  flex: 0 0 auto;
-}
 .entry-nav-rail__account-trigger {
   appearance: none;
   border: 0;
@@ -5512,11 +5478,9 @@
   background: color-mix(in srgb, var(--text) 5%, transparent);
 }
 .entry-nav-rail__account-avatar {
-  position: relative;
   width: 25px;
   height: 25px;
-  /* Rounded square (8px), replacing the squircle clip-path — a clip-path
-     would also swallow the unread dot that overflows the top-right corner. */
+  /* Rounded square (8px), replacing the old squircle clip-path. */
   border-radius: 8px;
   background: linear-gradient(135deg, #87ea5c, #0d5400);
   color: #fff;

--- a/apps/web/tests/components/EntryNavRail.message-center-entry.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.message-center-entry.test.tsx
@@ -1,19 +1,12 @@
 // @vitest-environment jsdom
 //
-// The message-center panel moved behind two external openers on the rail (the
-// signed-in account menu's 消息中心 row and the signed-out rail item), with
-// `MessageCenter hideTrigger`. `hideTrigger` leaves the component's internal
-// `triggerRef` unattached, so `closePanel()` had nothing to restore focus to:
-// opening the panel focuses the portaled dialog, and closing it unmounted the
-// focused node and dropped keyboard focus to the document. Both openers also
-// have to advertise the dialog they own (`aria-haspopup="dialog"` plus the
-// `aria-expanded` state) — the built-in bell already did.
-//
-// Focus must return to a control that is still mounted after the close: the
-// signed-in row lives in a hover menu that unmounts before the panel opens, so
-// the account trigger is the stable host control there.
+// Product intentionally does not expose the message center in the web shell.
+// Keep this at the rail boundary so both identity branches stay protected:
+// signed-in users must not get an account-menu entry, and signed-out users
+// must not get a standalone rail entry. The underlying notification settings
+// and message-center client remain available for future product work.
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { WorkspaceCollabContext } from '@open-design/contracts';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -52,24 +45,17 @@ function renderRail(context: WorkspaceCollabContext | null) {
   );
 }
 
-function stubFetch() {
+beforeEach(() => {
+  localStorage.clear();
+  resetWorkspaceDirectoryCache();
   vi.stubGlobal(
     'fetch',
     vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
-      if (url.includes('/messages?')) {
-        return Response.json({ messages: [], nextCursor: null, unreadCount: 0 });
-      }
       if (url.includes('/status')) return Response.json({ loggedIn: false });
       return Response.json({ items: [] });
     }),
   );
-}
-
-beforeEach(() => {
-  localStorage.clear();
-  resetWorkspaceDirectoryCache();
-  stubFetch();
 });
 
 afterEach(() => {
@@ -79,62 +65,21 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe('EntryNavRail message-center openers', () => {
-  it('returns focus to the account trigger when the panel closes with Escape', async () => {
-    renderRail(teamContext());
-    const accountTrigger = screen.getByTestId('entry-nav-account');
-
-    fireEvent.click(accountTrigger);
-    fireEvent.click(screen.getByTestId('account-menu-message-center'));
-    await waitFor(() => expect(screen.getByTestId('message-center-dialog')).toBeTruthy());
-
-    fireEvent.keyDown(document, { key: 'Escape' });
-
-    expect(screen.queryByTestId('message-center-dialog')).toBeNull();
-    expect(document.activeElement).toBe(accountTrigger);
-  });
-
-  it('returns focus to the account trigger when the panel closes via the backdrop', async () => {
-    renderRail(teamContext());
-    const accountTrigger = screen.getByTestId('entry-nav-account');
-
-    fireEvent.click(accountTrigger);
-    fireEvent.click(screen.getByTestId('account-menu-message-center'));
-    const dialog = await waitFor(() => screen.getByTestId('message-center-dialog'));
-
-    fireEvent.mouseDown(screen.getByTestId('message-center-backdrop'));
-
-    expect(dialog.isConnected).toBe(false);
-    expect(document.activeElement).toBe(accountTrigger);
-  });
-
-  it('returns focus to the signed-out rail opener when the panel closes', async () => {
-    renderRail(null);
-    const railOpener = screen.getByTestId('entry-nav-message-center');
-
-    fireEvent.click(railOpener);
-    await waitFor(() => expect(screen.getByTestId('message-center-dialog')).toBeTruthy());
-
-    fireEvent.keyDown(document, { key: 'Escape' });
-
-    expect(screen.queryByTestId('message-center-dialog')).toBeNull();
-    expect(document.activeElement).toBe(railOpener);
-  });
-
-  it('advertises the dialog on both external openers', () => {
-    const signedOut = renderRail(null);
-    const railOpener = screen.getByTestId('entry-nav-message-center');
-    expect(railOpener.getAttribute('aria-haspopup')).toBe('dialog');
-    expect(railOpener.getAttribute('aria-expanded')).toBe('false');
-
-    fireEvent.click(railOpener);
-    expect(screen.getByTestId('entry-nav-message-center').getAttribute('aria-expanded')).toBe('true');
-    signedOut.unmount();
-
+describe('EntryNavRail message-center visibility', () => {
+  it('does not expose a message-center entry for signed-in users', () => {
     renderRail(teamContext());
     fireEvent.click(screen.getByTestId('entry-nav-account'));
-    const menuRow = screen.getByTestId('account-menu-message-center');
-    expect(menuRow.getAttribute('aria-haspopup')).toBe('dialog');
-    expect(menuRow.getAttribute('aria-expanded')).toBe('false');
+
+    expect(screen.queryByTestId('account-menu-message-center')).toBeNull();
+    expect(screen.queryByTestId('message-center-trigger')).toBeNull();
+    expect(screen.queryByTestId('message-center-dialog')).toBeNull();
+  });
+
+  it('does not expose a message-center entry for signed-out users', () => {
+    renderRail(null);
+
+    expect(screen.queryByTestId('entry-nav-message-center')).toBeNull();
+    expect(screen.queryByTestId('message-center-trigger')).toBeNull();
+    expect(screen.queryByTestId('message-center-dialog')).toBeNull();
   });
 });

--- a/apps/web/tests/components/EntryNavRail.updater-above-account-row.test.tsx
+++ b/apps/web/tests/components/EntryNavRail.updater-above-account-row.test.tsx
@@ -171,7 +171,7 @@ describe('updater rocket placement above the rail account row', () => {
     expect(trigger.contains(rocket)).toBe(false);
 
     fireEvent.click(trigger);
-    await waitFor(() => expect(screen.getByTestId('account-menu-message-center')).toBeTruthy());
+    await waitFor(() => expect(screen.getByRole('menu')).toBeTruthy());
     expect(trigger.getAttribute('aria-expanded')).toBe('true');
   });
 


### PR DESCRIPTION
## Why

Product has explicitly decided that the web client should not expose a notification or message-center entry yet. The current workspace shell still showed one in the signed-in account menu and another in the signed-out navigation rail, so users could open an unsupported surface and the rail kept polling message-center data solely for those entry points.

This PR removes that premature web-shell exposure while preserving the standalone message-center implementation, its client/data contracts, notification settings, and daemon capabilities for future product work.

## What users will see

Signed-in users no longer see “Message center” in the account menu. Signed-out users no longer see a message-center item below Settings. The rest of the account menu, signed-out Settings entry, task notification settings, and system notification behavior are unchanged.

## Surface area

- [x] **UI** — removes the message-center menu and rail entries from `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — existing users no longer see these web entry points
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

The changed UI is the absence of two controls. The focused DOM regression test covers both signed-in and signed-out shell branches and is more precise than an empty-space screenshot; no other visual layout is changed.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/EntryNavRail.message-center-entry.test.tsx`
- Red on `origin/feat/workspace-team@4a4dfadd`: yes, both signed-in and signed-out assertions failed because the entries were present.
- Green on this branch: yes, both assertions pass.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/EntryNavRail.message-center-entry.test.tsx --maxWorkers=1` (2/2)
- `pnpm exec vitest run -c vitest.config.ts tests/components/EntryNavRail*.test.ts* tests/components/MessageCenter.test.tsx --maxWorkers=2` from `apps/web` (15 files, 90/90)
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web build`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check origin/feat/workspace-team...HEAD`
