### PR TITLE
fix(web): tolerate unnamed workspace directory rows

### DIFF
--- a/apps/web/src/collab/useWorkspaceContext.ts
+++ b/apps/web/src/collab/useWorkspaceContext.ts
@@ -526,7 +526,9 @@ export function useWorkspaceContext(): WorkspaceContextState {
         // (including plugin context defaults) remain compatible. This is display
         // metadata only: authority still comes from the explicit ids above, and
         // no daemon/backend "active workspace" state is consulted or written.
-        const workspaceName = selected.workspaceName.trim();
+        const workspaceName = typeof selected.workspaceName === 'string'
+          ? selected.workspaceName.trim()
+          : '';
         return workspaceName
           ? { context: { ...body.context, workspaceName } }
           : body;

--- a/apps/web/tests/components/App.project-create-race.test.tsx
+++ b/apps/web/tests/components/App.project-create-race.test.tsx
@@ -588,6 +588,7 @@ function workspaceContext(
 ) {
   return {
     workspaceId,
+    workspaceName: workspaceId,
     workspaceType: 'team' as const,
     workspaceMemberId,
     role: 'member' as const,

--- a/apps/web/tests/useWorkspaceContext.cache.test.tsx
+++ b/apps/web/tests/useWorkspaceContext.cache.test.tsx
@@ -101,4 +101,39 @@ describe('useWorkspaceContext module cache', () => {
       });
     });
   });
+
+  it('keeps a verified context when a legacy directory row omits workspaceName', async () => {
+    const legacyContext = workspaceContextFixture({
+      workspaceId: 'ws-legacy-no-name',
+      workspaceMemberId: 'member-legacy-no-name',
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) =>
+        new Response(JSON.stringify(
+          String(input) === '/api/workspace/directory'
+            ? {
+                items: [{
+                  workspaceId: 'ws-legacy-no-name',
+                  workspaceType: 'team',
+                  workspaceMemberId: 'member-legacy-no-name',
+                  role: 'member',
+                  memberStatus: 'active',
+                  lifecycleState: 'active',
+                }],
+                activeWorkspaceId: null,
+              }
+            : { context: legacyContext },
+        ), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ),
+    );
+
+    const result = renderHook(() => useWorkspaceContext());
+    await waitFor(() => expect(result.result.current.loading).toBe(false));
+    expect(result.result.current.context).toEqual(legacyContext);
+    expect(result.result.current.failure).toBeUndefined();
+  });
 });

--- a/apps/web/tests/useWorkspaceContext.sign-in-refresh.test.tsx
+++ b/apps/web/tests/useWorkspaceContext.sign-in-refresh.test.tsx
@@ -29,6 +29,7 @@ const SIGNED_IN = workspaceContextFixture({
   workspaceId: 'ws-1',
   workspaceMemberId: 'member-1',
   teamName: 'Acme',
+  workspaceName: 'Acme',
 });
 
 /** A fetch whose every call resolves only when the test says so. */


### PR DESCRIPTION
## Why

The workspace context backfill added on the feature branch assumed every runtime directory row already included `workspaceName`. Older or incomplete directory payloads can omit that display-only field, causing `trim()` to throw after the explicit Workspace/member selection had already been verified. The hook then reported the workspace service as unavailable, discarded the Team catalog cache path, and regressed project collaboration and creation flows.

This patch preserves the verified explicit Workspace identity while treating a missing legacy display name as non-fatal. It does not infer authority, permissions, or identity from any ambient/active Workspace state.

## What users will see

Users with an older or partially populated Workspace directory can continue opening and creating Team projects without the workspace context unexpectedly becoming unavailable. When the directory includes a name, the existing exact-row name backfill remains unchanged.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable. This is a runtime compatibility fix with no visual surface change.

## Bug fix verification

- Red spec: `apps/web/tests/useWorkspaceContext.cache.test.tsx` — `keeps a verified context when a legacy directory row omits workspaceName`.
- The spec failed on the target base `origin/feat/workspace-team@4a4dfadd`: the valid context became `null` after the missing name threw.
- The spec passes on this branch. The previously failing feature-branch regression set also passes without weakening exact argument assertions.

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts --maxWorkers=2 tests/useWorkspaceContext.cache.test.tsx tests/use-project-collab.context-seed.test.tsx tests/useWorkspaceContext.sign-in-refresh.test.tsx tests/components/App.project-create-race.test.tsx` (63 passed)
- `pnpm --filter @open-design/web test` (578 files; 5,983 passed; 11 skipped)
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web build`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
