### PR TITLE
fix(workspace): enforce exact project-list scope

### DIFF
--- a/apps/daemon/src/routes/project/index.ts
+++ b/apps/daemon/src/routes/project/index.ts
@@ -2772,8 +2772,24 @@ export function registerProjectRoutes(app: Express, ctx: RegisterProjectRoutesDe
 
   app.get('/api/workspaces/:workspaceId/projects', async (req, res) => {
     try {
-      const ctx = workspaceProjectContext(req, req.params.workspaceId);
-      if (!ctx) return sendMissingWorkspaceContext(res);
+      const authoritativeCtx = await authoritativeWorkspaceProjectContext(
+        req,
+        res,
+        req.params.workspaceId,
+      );
+      if (!authoritativeCtx) return;
+      const assertedCtx = workspaceProjectContextFromRequest(req);
+      const ctx = assertedCtx && assertedCtx !== 'missing'
+        ? {
+            ...authoritativeCtx,
+            // Request capability flags are UI ceilings only: they may hide an
+            // action, but never elevate directory-backed authority.
+            canShareProjects:
+              authoritativeCtx.canShareProjects && assertedCtx.canShareProjects,
+            canWriteSyncedFiles:
+              authoritativeCtx.canWriteSyncedFiles && assertedCtx.canWriteSyncedFiles,
+          }
+        : authoritativeCtx;
       if (ctx.memberStatus === 'removed') {
         /** @type {import('@open-design/contracts').WorkspaceProjectsResponse} */
         const body = { projects: [] };

--- a/apps/daemon/tests/routes/workspace-projects.test.ts
+++ b/apps/daemon/tests/routes/workspace-projects.test.ts
@@ -108,6 +108,29 @@ describe('workspace project routes', () => {
     return project;
   }
 
+  it('rejects a project list when the route Workspace conflicts with the explicit request scope', async () => {
+    const suffix = Date.now();
+    const workspaceA = `${workspaceId}-route-a-${suffix}`;
+    const workspaceB = `${workspaceId}-header-b-${suffix}`;
+    const projectId = `workspace-route-scope-${suffix}`;
+    await createProjectInWorkspace(
+      projectId,
+      'Workspace route scope fixture',
+      'member-route-a',
+      { 'x-od-workspace-id': workspaceA },
+    );
+
+    const response = await fetch(
+      `${baseUrl}/api/workspaces/${workspaceA}/projects?view=all`,
+      { headers: workspaceHeaders(workspaceB, 'member-header-b') },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'WORKSPACE_ACCESS_DENIED' },
+    });
+  });
+
   it('projects legacy rows into a workspace list without assigning ownership to the reader', async () => {
     const projectId = `workspace-list-${Date.now()}`;
     await createProject(projectId, 'Workspace list fixture');


### PR DESCRIPTION
## Why

I found this while auditing the latest Workspace feature branch for exact Workspace scope propagation. The Workspace project-list handler accepted the route Workspace as authority while deriving member and role data from request headers, so an explicit `x-od-workspace-id` for Workspace B could request Workspace A's URL and receive A's local project projection.

That mismatch could expose or adopt project rows under the wrong Workspace scope. The list path must use the same directory-backed, exact-scope authority boundary already used by Workspace project mutations.

## What users will see

Workspace project lists now fail closed with `WORKSPACE_ACCESS_DENIED` when the explicit request Workspace does not match the route Workspace. Valid Workspace lists retain their existing behavior, including restrictive client capability flags that only hide unavailable actions.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [x] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this is a daemon authorization fix with no UI changes.

## Bug fix verification

- Test path: `apps/daemon/tests/routes/workspace-projects.test.ts`
- The new test failed deterministically against target commit `722a1c855f83597db604b9a5e98e91e3ef27163f` (HTTP 200 instead of 403) and passes with this fix. It was not run on `main` because the audited Workspace feature is not present there.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/routes/workspace-projects.test.ts` (48 passed)
- `pnpm exec vitest run -c vitest.config.ts tests/runtimes/project-amr-workspace-proof.test.ts` (10 passed)
- `pnpm exec vitest run -c vitest.config.ts tests/mcp-runs.test.ts -t "start_run selects secure Local BYOK through a profile reference"` (1 passed)
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `git diff --check origin/feat/workspace-team...HEAD`
