### PR TITLE
fix(web): keep home creation types ready after project return

### DIFF
--- a/apps/web/src/components/HomeView.tsx
+++ b/apps/web/src/components/HomeView.tsx
@@ -41,6 +41,7 @@ import {
   duplicatePluginAsProject,
   listPlugins,
   listPluginsFresh,
+  readCachedVisiblePlugins,
   patchProject,
   resolvedWorkspaceContextForWrite,
   renderPluginBriefTemplate,
@@ -444,14 +445,18 @@ export function HomeView({
     homePageViewFiredRef.current = true;
     trackPageView(analytics.track, { page_name: 'home' });
   }, [analytics.track]);
-  // Start empty + loading (cheap first render — seeding the full list here made
-  // the mount do all plugin-dependent render work on the click's critical path,
-  // a visible freeze). The effect below uses the cache-aware loader, which on a
-  // warm cache resolves on a microtask, so `pluginsLoading` clears within a
-  // frame without the heavy `/api/plugins` re-fetch that greyed the rail for
-  // 1-2s on every Home remount.
-  const [plugins, setPlugins] = useState<InstalledPluginRecord[]>([]);
-  const [pluginsLoading, setPluginsLoading] = useState(true);
+  // A project route fully unmounts HomeView. Restore the last successful
+  // catalog synchronously when Home mounts again so known creation actions do
+  // not become disabled merely because the 10-second refresh TTL elapsed while
+  // the user was in a project. The effect below still revalidates an expired
+  // catalog; only a true cold start (no successful catalog yet) stays guarded.
+  const initialPluginsRef = useRef<InstalledPluginRecord[] | null>(readCachedVisiblePlugins());
+  const [plugins, setPlugins] = useState<InstalledPluginRecord[]>(
+    () => initialPluginsRef.current ?? [],
+  );
+  const [pluginsLoading, setPluginsLoading] = useState(
+    () => initialPluginsRef.current === null,
+  );
   const [pendingApplyId, setPendingApplyId] = useState<string | null>(null);
   const [pendingChipId, setPendingChipId] = useState<string | null>(null);
   const [pendingAuthoringChipId, setPendingAuthoringChipId] = useState<string | null>(null);

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -1308,6 +1308,18 @@ export async function listPluginsFresh(): Promise<InstalledPluginRecord[]> {
   return listPlugins();
 }
 
+/**
+ * Return the last successful unscoped plugin catalog regardless of its refresh
+ * age. Frequently remounted surfaces use this snapshot for their first render
+ * while `listPluginsFresh()` revalidates an expired catalog in the background.
+ * A null result is the only state that still requires the cold-start loading
+ * guard: once a catalog has loaded, network latency must not make known plugin
+ * actions temporarily unactionable again.
+ */
+export function readCachedVisiblePlugins(): InstalledPluginRecord[] | null {
+  return cachedVisiblePlugins;
+}
+
 // Test-only: drop the warm visible-plugins cache so each case starts cold. The
 // module-level cache intentionally survives Home remounts in the app, but that
 // same persistence leaks across test cases in a worker (a case's mocked

--- a/apps/web/tests/components/HomeView.prefill.test.tsx
+++ b/apps/web/tests/components/HomeView.prefill.test.tsx
@@ -496,6 +496,71 @@ describe('HomeView prompt handoff', () => {
     window.sessionStorage.clear();
   });
 
+  it('keeps creation types actionable while an expired plugin cache refreshes after a project round trip', async () => {
+    let resolveRefresh: (response: Response) => void = () => undefined;
+    const refreshResponse = new Promise<Response>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    let pluginListReads = 0;
+    const pluginResponse = () => new Response(
+      JSON.stringify({ plugins: [WEB_PROTOTYPE_PLUGIN] }),
+      {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      },
+    );
+    const fetchMock = vi.fn<typeof fetch>(async (url) => {
+      if (typeof url === 'string' && url === '/api/plugins') {
+        pluginListReads += 1;
+        return pluginListReads === 1 ? pluginResponse() : refreshResponse;
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    stubAnimationFrame();
+
+    const firstHome = render(
+      <HomeView
+        projects={[]}
+        onSubmit={() => undefined}
+        onOpenProject={() => undefined}
+        onViewAllProjects={() => undefined}
+      />,
+    );
+    const firstTrigger = await screen.findByTestId('home-hero-template-trigger');
+    await waitFor(() => expect((firstTrigger as HTMLButtonElement).disabled).toBe(false));
+    firstHome.unmount();
+
+    // Project pages commonly stay open longer than the plugin cache TTL. Model
+    // that route round trip without a real sleep, then hold the background
+    // refresh open so actionability cannot accidentally depend on network time.
+    const now = Date.now();
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(now + 10_001);
+    try {
+      const returnedHome = render(
+        <HomeView
+          projects={[]}
+          onSubmit={() => undefined}
+          onOpenProject={() => undefined}
+          onViewAllProjects={() => undefined}
+        />,
+      );
+
+      expect(pluginListReads).toBe(2);
+      expect(
+        (screen.getByTestId('home-hero-template-trigger') as HTMLButtonElement).disabled,
+      ).toBe(false);
+
+      await act(async () => {
+        resolveRefresh(pluginResponse());
+        await refreshResponse;
+      });
+      returnedHome.unmount();
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
   it('consumes a plugin authoring handoff once and focuses the textarea', async () => {
     let resolveApply: (response: Response) => void = () => undefined;
     const applyResponse = new Promise<Response>((resolve) => {


### PR DESCRIPTION
## Why

Returning from a project to Home after more than ten seconds made the creation-type picker stay disabled until the full plugin catalog finished downloading and parsing. The Home view remounts after a project route, but it always restarted from an empty catalog even when the session already had a successful catalog snapshot. On slower local runtimes this turned a routine navigation into a multi-second dead control.

This keeps the true cold-start safety guard while removing network latency from repeat navigation.

## What users will see

After returning from a project, Home's creation-type picker is actionable immediately. If the cached plugin catalog is old, it refreshes in the background without greying out already-known creation actions.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Before: the Home creation-type trigger remained greyed out after navigating back from a project while `/api/plugins` was pending.

After: the same trigger is enabled on the first returned Home render; an expired catalog refresh remains in flight without blocking it. The deterministic regression test holds that refresh promise open to verify the visible state.

## Bug fix verification

- Test path: `apps/web/tests/components/HomeView.prefill.test.tsx` — `keeps creation types actionable while an expired plugin cache refreshes after a project round trip`
- Red on `origin/feat/workspace-team`: yes (`disabled === true` while the refresh promise was unresolved).
- Green on this branch: yes (`disabled === false` before resolving the refresh).

## Validation

- `pnpm --filter @open-design/web exec vitest run -c vitest.config.ts tests/components/HomeView.prefill.test.tsx --maxWorkers=1` (25/25)
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
