### PR TITLE
fix(packaged): recover od:// after web sidecar exits

### DIFF
--- a/apps/packaged/src/index.ts
+++ b/apps/packaged/src/index.ts
@@ -282,7 +282,7 @@ async function main(): Promise<void> {
   // mounting the web bundle (the runtime re-asserts this stage at its reveal
   // gate, which is a no-op when the label is already current).
   setSplashStage(splash.window, "workspace");
-  registerOdProtocol(sidecars.web.url ?? "http://127.0.0.1:0");
+  registerOdProtocol(() => sidecars.currentWebUrl() || "http://127.0.0.1:0");
 
   const { runDesktopMain } = await import("@open-design/desktop/main");
   await runDesktopMain(runtime, {

--- a/apps/packaged/src/protocol.ts
+++ b/apps/packaged/src/protocol.ts
@@ -153,8 +153,19 @@ export function packagedEntryUrl(): string {
   return OD_ENTRY_URL;
 }
 
-export function registerOdProtocol(webRuntimeUrl: string): void {
+/**
+ * Register `od://` as the renderer entry scheme.
+ *
+ * Takes a resolver rather than a URL string because the web sidecar's
+ * port is not stable for the lifetime of the process: the sidecar can
+ * die and be respawned on a fresh ephemeral port (see the restart
+ * supervisor in `./sidecars.ts`). Snapshotting the URL here pinned the
+ * proxy to the dead port for the rest of the session, so every
+ * renderer fetch returned `OD_PROTOCOL_PROXY_FAILED` until the user
+ * quit and relaunched the app.
+ */
+export function registerOdProtocol(resolveWebRuntimeUrl: () => string): void {
   protocol.handle(OD_SCHEME, async (request) => {
-    return await handleOdRequest(request, webRuntimeUrl);
+    return await handleOdRequest(request, resolveWebRuntimeUrl());
   });
 }

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -229,6 +229,62 @@ function baseStatusTimeoutMs(platform: NodeJS.Platform = process.platform): numb
  * @see apps/daemon/src/legacy-data-migrator.ts
  * @see https://github.com/nexu-io/open-design/issues/710
  */
+export type RestartPolicy = { allow(nowMs: number): boolean };
+
+/**
+ * Sliding-window cap on sidecar respawns.
+ *
+ * A sidecar that dies once should come back; a sidecar that crashes
+ * during boot must not respawn forever, because each attempt spends a
+ * full Next.js boot and would pin a core indefinitely.
+ *
+ * ponytail: a plain array of timestamps pruned by filter — the window
+ * holds single digits of entries, so a ring buffer would be more code
+ * for no measurable gain.
+ */
+export function createRestartPolicy(
+  options: { maxRestarts?: number; windowMs?: number } = {},
+): RestartPolicy {
+  const maxRestarts = options.maxRestarts ?? 5;
+  const windowMs = options.windowMs ?? 60_000;
+  let attempts: number[] = [];
+  return {
+    allow(nowMs: number): boolean {
+      attempts = attempts.filter((at) => nowMs - at < windowMs);
+      if (attempts.length >= maxRestarts) return false;
+      attempts.push(nowMs);
+      return true;
+    },
+  };
+}
+
+/**
+ * One policy-gated respawn attempt.
+ *
+ * Split out from the child's `exit` handler so the decision logic is
+ * unit-testable without spawning a real sidecar. Returns the new web
+ * runtime URL, or null when the restart was refused by the policy or
+ * the spawn itself failed — in which case the caller keeps serving the
+ * previous URL and the renderer sees ordinary 502s instead of the app
+ * hanging or crashing.
+ */
+export async function resolveWebRestart(options: {
+  policy: RestartPolicy;
+  nowMs: number;
+  restart: () => Promise<string>;
+}): Promise<string | null> {
+  if (!options.policy.allow(options.nowMs)) {
+    console.error("packaged web sidecar restart budget exhausted; not respawning");
+    return null;
+  }
+  try {
+    return await options.restart();
+  } catch (error: unknown) {
+    console.error("failed to restart packaged web sidecar", error);
+    return null;
+  }
+}
+
 export function resolveDaemonStatusTimeoutMs(
   env: NodeJS.ProcessEnv = process.env,
   platform: NodeJS.Platform = process.platform,

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -96,6 +96,13 @@ function shouldForwardPackagedChildEnv(key: string, includeProviderSecrets = fal
 
 export type PackagedSidecarHandle = {
   close(): Promise<void>;
+  /**
+   * URL of the web sidecar that is live *right now*. `web` below is the
+   * first-boot snapshot and goes stale as soon as the sidecar is
+   * respawned on a fresh ephemeral port, so anything that dials the
+   * sidecar per request must read this instead.
+   */
+  currentWebUrl(): string;
   daemon: DaemonStatusSnapshot;
   web: WebStatusSnapshot;
 };
@@ -809,40 +816,80 @@ export async function startPackagedSidecars(
     // enters its own timed status window.
     await webPrewarm;
 
+    // Resolved out here rather than inside `spawnWeb`: the null check
+    // above narrows `daemonStatus.url` to string, but TypeScript drops
+    // property narrowing inside a closure that could run later.
+    const daemonPort = extractPort(daemonStatus.url);
+
+    const webRestartPolicy = createRestartPolicy();
+    let closing = false;
+    let currentWebUrl = "";
+
+    const spawnWeb = async (): Promise<WebStatusSnapshot> => {
+      const web = await spawnSidecarChild({
+        app: APP_KEYS.WEB,
+        entryPath: webSidecarEntry,
+        env: {
+          [SIDECAR_ENV.DAEMON_PORT]: daemonPort,
+          [SIDECAR_ENV.WEB_PORT]: "0",
+          ...(options.webStandaloneRoot == null ? {} : { OD_WEB_STANDALONE_ROOT: options.webStandaloneRoot }),
+          OD_WEB_OUTPUT_MODE: options.webOutputMode,
+          PORT: "0",
+        },
+        electronNodeCommand: options.electronNodeCommand,
+        nodeCommand: options.nodeCommand,
+        paths,
+        runtime,
+      });
+      children.push(web);
+      const status = await waitForStatus<WebStatusSnapshot>(
+        web.ipcPath,
+        (candidate) => candidate.url != null,
+        // Web has no legacy-migration path, so it uses the plain platform
+        // baseline (still widened on win32, where AV scanning can also slow the
+        // web sidecar's first bind) rather than resolveDaemonStatusTimeoutMs.
+        baseStatusTimeoutMs(),
+        { child: web.child, logPath: logPathFor(paths, APP_KEYS.WEB) },
+      );
+      if (status.url == null) throw new Error("web did not report a URL");
+      await registerPackagedWebUrl(daemon.ipcPath, status.url);
+      currentWebUrl = status.url;
+
+      // Supervise the child. The web sidecar can die on its own — an
+      // unhandled rejection inside Next, an OOM kill, or an update
+      // handoff reaping the previous generation's processes. Nothing
+      // used to notice: `od://` stayed pinned to the dead port and the
+      // whole UI 502'd until the user quit and relaunched the app.
+      web.child.once("exit", () => {
+        if (closing) return;
+        void resolveWebRestart({
+          policy: webRestartPolicy,
+          nowMs: Date.now(),
+          restart: async () => {
+            const next = await spawnWeb();
+            return next.url as string;
+          },
+        });
+      });
+      return status;
+    };
+
+    // Phase callbacks drive the splash screen, so they stay on the
+    // first-boot path only: a mid-session respawn must not rewind the
+    // user's splash back to "web-spawning".
     options.onPhase?.("web-spawning");
-    const web = await spawnSidecarChild({
-      app: APP_KEYS.WEB,
-      entryPath: webSidecarEntry,
-      env: {
-        [SIDECAR_ENV.DAEMON_PORT]: extractPort(daemonStatus.url),
-        [SIDECAR_ENV.WEB_PORT]: "0",
-        ...(options.webStandaloneRoot == null ? {} : { OD_WEB_STANDALONE_ROOT: options.webStandaloneRoot }),
-        OD_WEB_OUTPUT_MODE: options.webOutputMode,
-        PORT: "0",
-      },
-      electronNodeCommand: options.electronNodeCommand,
-      nodeCommand: options.nodeCommand,
-      paths,
-      runtime,
-    });
-    children.push(web);
-    const webStatus = await waitForStatus<WebStatusSnapshot>(
-      web.ipcPath,
-      (status) => status.url != null,
-      // Web has no legacy-migration path, so it uses the plain platform
-      // baseline (still widened on win32, where AV scanning can also slow the
-      // web sidecar's first bind) rather than resolveDaemonStatusTimeoutMs.
-      baseStatusTimeoutMs(),
-      { child: web.child, logPath: logPathFor(paths, APP_KEYS.WEB) },
-    );
-    if (webStatus.url == null) throw new Error("web did not report a URL");
-    await registerPackagedWebUrl(daemon.ipcPath, webStatus.url);
+    const webStatus = await spawnWeb();
     options.onPhase?.("web-ready");
 
     return {
       daemon: daemonStatus,
       web: webStatus,
+      currentWebUrl: () => currentWebUrl,
       async close() {
+        // Set before tearing children down so the exit handler above
+        // does not read an intentional shutdown as a crash and respawn
+        // a sidecar mid-quit.
+        closing = true;
         for (const child of [...children].reverse()) {
           await closeManagedChild(child).catch((error: unknown) => {
             console.error(`failed to close packaged ${child.app} sidecar`, error);

--- a/apps/packaged/src/sidecars.ts
+++ b/apps/packaged/src/sidecars.ts
@@ -266,30 +266,149 @@ export function createRestartPolicy(
 }
 
 /**
- * One policy-gated respawn attempt.
- *
- * Split out from the child's `exit` handler so the decision logic is
- * unit-testable without spawning a real sidecar. Returns the new web
- * runtime URL, or null when the restart was refused by the policy or
- * the spawn itself failed — in which case the caller keeps serving the
- * previous URL and the renderer sees ordinary 502s instead of the app
- * hanging or crashing.
+ * Owns the packaged web sidecar across initial boot, bounded crash recovery,
+ * and shutdown. Dependencies are injected so lifecycle races can be exercised
+ * deterministically without spawning real Electron children in unit tests.
  */
-export async function resolveWebRestart(options: {
-  policy: RestartPolicy;
-  nowMs: number;
-  restart: () => Promise<string>;
-}): Promise<string | null> {
-  if (!options.policy.allow(options.nowMs)) {
-    console.error("packaged web sidecar restart budget exhausted; not respawning");
-    return null;
+export function createWebSidecarSupervisor<
+  TChild,
+  TStatus extends { url: string | null },
+>(options: {
+  closeChild: (child: TChild) => Promise<void>;
+  hasExited: (child: TChild) => boolean;
+  now?: () => number;
+  onExit: (child: TChild, listener: () => void) => void;
+  policy?: RestartPolicy;
+  registerUrl: (url: string) => Promise<void>;
+  spawn: () => Promise<TChild>;
+  waitUntilReady: (child: TChild) => Promise<TStatus>;
+}): {
+  close(): Promise<void>;
+  currentUrl(): string;
+  start(): Promise<TStatus>;
+} {
+  const policy = options.policy ?? createRestartPolicy();
+  const now = options.now ?? Date.now;
+  const children = new Set<TChild>();
+  const closedChildren = new Set<TChild>();
+  let closing = false;
+  let closeTask: Promise<void> | null = null;
+  let currentUrl = "";
+  let pendingExitedChild: TChild | null = null;
+  let restartTask: Promise<void> | null = null;
+
+  const closeChildOnce = async (child: TChild): Promise<void> => {
+    if (closedChildren.has(child)) return;
+    closedChildren.add(child);
+    children.delete(child);
+    await options.closeChild(child);
+  };
+
+  const spawnAndPromote = async (): Promise<TStatus> => {
+    const child = await options.spawn();
+    children.add(child);
+    let promoted = false;
+    let exited = options.hasExited(child);
+
+    // Install supervision before readiness. A replacement that exits during
+    // boot is retried by restartUntilReady below; a promoted child schedules a
+    // fresh restart cycle when it later exits.
+    options.onExit(child, () => {
+      exited = true;
+      if (promoted && !closing) scheduleRestart(child);
+    });
+
+    try {
+      if (closing) throw new Error("packaged web sidecar supervisor is closing");
+      const status = await options.waitUntilReady(child);
+      if (status.url == null) throw new Error("web did not report a URL");
+      if (closing) throw new Error("packaged web sidecar supervisor is closing");
+      if (exited || options.hasExited(child)) {
+        throw new Error("web exited before its ready status could be promoted");
+      }
+
+      await options.registerUrl(status.url);
+      if (closing) throw new Error("packaged web sidecar supervisor is closing");
+      if (exited || options.hasExited(child)) {
+        throw new Error("web exited while its ready status was being registered");
+      }
+
+      // These assignments are synchronous: once promoted is true, any later
+      // exit event schedules another restart instead of being mistaken for a
+      // boot failure owned by the current restart loop.
+      promoted = true;
+      currentUrl = status.url;
+      return status;
+    } catch (error) {
+      await closeChildOnce(child).catch(() => undefined);
+      throw error;
+    }
+  };
+
+  const restartUntilReady = async (): Promise<void> => {
+    while (!closing) {
+      if (!policy.allow(now())) {
+        console.error("packaged web sidecar restart budget exhausted; not respawning");
+        return;
+      }
+      try {
+        await spawnAndPromote();
+        return;
+      } catch (error: unknown) {
+        if (closing) return;
+        console.error("failed to restart packaged web sidecar", error);
+      }
+    }
+  };
+
+  function scheduleRestart(exitedChild: TChild): void {
+    pendingExitedChild = exitedChild;
+    if (restartTask != null || closing) return;
+
+    const task = (async () => {
+      while (!closing && pendingExitedChild != null) {
+        const childToClose = pendingExitedChild;
+        pendingExitedChild = null;
+        await closeChildOnce(childToClose).catch((error: unknown) => {
+          console.error("failed to close exited packaged web sidecar", error);
+        });
+        await restartUntilReady();
+      }
+    })();
+    restartTask = task;
+    void task
+      .finally(() => {
+        if (restartTask === task) restartTask = null;
+        if (!closing && pendingExitedChild != null) scheduleRestart(pendingExitedChild);
+      })
+      .catch((error: unknown) => {
+        console.error("packaged web sidecar supervisor failed", error);
+      });
   }
-  try {
-    return await options.restart();
-  } catch (error: unknown) {
-    console.error("failed to restart packaged web sidecar", error);
-    return null;
-  }
+
+  return {
+    async close(): Promise<void> {
+      if (closeTask != null) return await closeTask;
+      closing = true;
+      pendingExitedChild = null;
+      closeTask = (async () => {
+        // Close children already known to the supervisor first. Then await an
+        // in-flight deferred spawn: spawnAndPromote re-checks closing as soon as
+        // it resolves and closes that late child before returning. The final
+        // pass covers a child added between the first snapshot and the await.
+        for (const child of [...children].reverse()) {
+          await closeChildOnce(child).catch(() => undefined);
+        }
+        await restartTask?.catch(() => undefined);
+        for (const child of [...children].reverse()) {
+          await closeChildOnce(child).catch(() => undefined);
+        }
+      })();
+      return await closeTask;
+    },
+    currentUrl: () => currentUrl,
+    start: spawnAndPromote,
+  };
 }
 
 export function resolveDaemonStatusTimeoutMs(
@@ -738,6 +857,7 @@ export async function startPackagedSidecars(
   await mkdir(paths.electronSessionDataRoot, { recursive: true });
 
   const children: ManagedSidecarChild[] = [];
+  let webSupervisor: { close(): Promise<void> } | null = null;
 
   const daemonSidecarEntry =
     options.daemonSidecarEntry ?? resolveSidecarEntry("@open-design/daemon", "sidecar");
@@ -821,12 +941,12 @@ export async function startPackagedSidecars(
     // property narrowing inside a closure that could run later.
     const daemonPort = extractPort(daemonStatus.url);
 
-    const webRestartPolicy = createRestartPolicy();
-    let closing = false;
-    let currentWebUrl = "";
-
-    const spawnWeb = async (): Promise<WebStatusSnapshot> => {
-      const web = await spawnSidecarChild({
+    const supervisor = createWebSidecarSupervisor<ManagedSidecarChild, WebStatusSnapshot>({
+      closeChild: closeManagedChild,
+      hasExited: (web) => web.child.exitCode !== null || web.child.signalCode !== null,
+      onExit: (web, listener) => web.child.once("exit", listener),
+      registerUrl: async (url) => await registerPackagedWebUrl(daemon.ipcPath, url),
+      spawn: async () => await spawnSidecarChild({
         app: APP_KEYS.WEB,
         entryPath: webSidecarEntry,
         env: {
@@ -840,9 +960,8 @@ export async function startPackagedSidecars(
         nodeCommand: options.nodeCommand,
         paths,
         runtime,
-      });
-      children.push(web);
-      const status = await waitForStatus<WebStatusSnapshot>(
+      }),
+      waitUntilReady: async (web) => await waitForStatus<WebStatusSnapshot>(
         web.ipcPath,
         (candidate) => candidate.url != null,
         // Web has no legacy-migration path, so it uses the plain platform
@@ -850,46 +969,23 @@ export async function startPackagedSidecars(
         // web sidecar's first bind) rather than resolveDaemonStatusTimeoutMs.
         baseStatusTimeoutMs(),
         { child: web.child, logPath: logPathFor(paths, APP_KEYS.WEB) },
-      );
-      if (status.url == null) throw new Error("web did not report a URL");
-      await registerPackagedWebUrl(daemon.ipcPath, status.url);
-      currentWebUrl = status.url;
-
-      // Supervise the child. The web sidecar can die on its own — an
-      // unhandled rejection inside Next, an OOM kill, or an update
-      // handoff reaping the previous generation's processes. Nothing
-      // used to notice: `od://` stayed pinned to the dead port and the
-      // whole UI 502'd until the user quit and relaunched the app.
-      web.child.once("exit", () => {
-        if (closing) return;
-        void resolveWebRestart({
-          policy: webRestartPolicy,
-          nowMs: Date.now(),
-          restart: async () => {
-            const next = await spawnWeb();
-            return next.url as string;
-          },
-        });
-      });
-      return status;
-    };
+      ),
+    });
+    webSupervisor = supervisor;
 
     // Phase callbacks drive the splash screen, so they stay on the
     // first-boot path only: a mid-session respawn must not rewind the
     // user's splash back to "web-spawning".
     options.onPhase?.("web-spawning");
-    const webStatus = await spawnWeb();
+    const webStatus = await supervisor.start();
     options.onPhase?.("web-ready");
 
     return {
       daemon: daemonStatus,
       web: webStatus,
-      currentWebUrl: () => currentWebUrl,
+      currentWebUrl: supervisor.currentUrl,
       async close() {
-        // Set before tearing children down so the exit handler above
-        // does not read an intentional shutdown as a crash and respawn
-        // a sidecar mid-quit.
-        closing = true;
+        await supervisor.close();
         for (const child of [...children].reverse()) {
           await closeManagedChild(child).catch((error: unknown) => {
             console.error(`failed to close packaged ${child.app} sidecar`, error);
@@ -898,6 +994,7 @@ export async function startPackagedSidecars(
       },
     };
   } catch (error) {
+    await webSupervisor?.close().catch(() => undefined);
     for (const child of [...children].reverse()) {
       await closeManagedChild(child).catch(() => undefined);
     }

--- a/apps/packaged/tests/headless-runtime.test.ts
+++ b/apps/packaged/tests/headless-runtime.test.ts
@@ -79,6 +79,7 @@ describe("acquirePackagedHeadlessStartup", () => {
           close: async () => {
             closed.push("sidecars");
           },
+          currentWebUrl: () => "http://127.0.0.1:7456",
           daemon: {
             desktopAuthGateActive: false,
             state: "running" as const,

--- a/apps/packaged/tests/protocol.test.ts
+++ b/apps/packaged/tests/protocol.test.ts
@@ -30,10 +30,13 @@ vi.mock('electron', () => ({
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { handleOdRequest } from '../src/protocol.js';
+import { protocol } from 'electron';
+
+import { handleOdRequest, registerOdProtocol } from '../src/protocol.js';
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe('od:// protocol proxy', () => {
@@ -128,6 +131,47 @@ describe('od:// protocol proxy', () => {
     expect(response.status).toBe(502);
     const body = (await response.json()) as { message: string };
     expect(body.message).toBe('sync timeout');
+  });
+
+  // The web sidecar can die and be respawned on a fresh random port
+  // mid-session (an update handoff reaped it on 2026-07-25). When
+  // `registerOdProtocol` snapshotted the URL, the proxy stayed pinned
+  // to the dead port for the rest of the process lifetime and every
+  // renderer fetch 502'd until the user quit and relaunched the app.
+  // The handler must therefore re-resolve the target on each request.
+  it('resolves the web runtime URL on every request instead of snapshotting it', async () => {
+    const handleMock = vi.mocked(protocol.handle);
+    handleMock.mockClear();
+
+    // `registerOdProtocol` wires the handler to the global fetch, so
+    // stub that rather than probing real ports: a port-based test
+    // would silently pass or fail depending on whatever happens to be
+    // listening on the developer's machine.
+    const targets: string[] = [];
+    vi.stubGlobal('fetch', async (input: Request) => {
+      targets.push(input.url);
+      return new Response('ok', { status: 200 });
+    });
+
+    let current = 'http://127.0.0.1:50401';
+    registerOdProtocol(() => current);
+
+    const handler = handleMock.mock.calls[0]?.[1] as (
+      request: Request,
+    ) => Promise<Response>;
+    expect(handler).toBeTypeOf('function');
+
+    await handler(new Request('od://app/api/runs'));
+
+    // The sidecar dies and comes back on a different ephemeral port.
+    current = 'http://127.0.0.1:59530';
+
+    await handler(new Request('od://app/api/runs'));
+
+    expect(targets).toEqual([
+      'http://127.0.0.1:50401/api/runs',
+      'http://127.0.0.1:59530/api/runs',
+    ]);
   });
 });
 

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -28,12 +28,12 @@ import {
   buildPackagedDaemonSpawnEnv,
   createPackagedSidecarSpawnOptions,
   createRestartPolicy,
+  createWebSidecarSupervisor,
   registerPackagedWebUrl,
   resolveDaemonStatusTimeoutMs,
   resolvePackagedChildBaseEnv,
   resolvePackagedElectronNodeCommand,
   resolvePackagedPathEnv,
-  resolveWebRestart,
   waitForStatus,
 } from '../src/sidecars.js';
 import type { PackagedNamespacePaths } from '../src/paths.js';
@@ -752,53 +752,166 @@ describe('createRestartPolicy', () => {
   });
 });
 
-describe('resolveWebRestart', () => {
-  it('returns the next URL when the policy allows a restart', async () => {
-    const policy = createRestartPolicy({ maxRestarts: 2, windowMs: 60_000 });
-    const started: string[] = [];
-    const restart = async () => {
-      started.push('start');
-      return 'http://127.0.0.1:59530';
+describe('createWebSidecarSupervisor', () => {
+  type SupervisorChild = {
+    exit(): void;
+    exited: boolean;
+    exitListeners: Array<() => void>;
+    name: string;
+  };
+
+  const child = (name: string): SupervisorChild => {
+    const value: SupervisorChild = {
+      exit() {
+        value.exited = true;
+        for (const listener of value.exitListeners.splice(0)) listener();
+      },
+      exited: false,
+      exitListeners: [],
+      name,
     };
+    return value;
+  };
 
-    await expect(
-      resolveWebRestart({ policy, nowMs: 1_000, restart }),
-    ).resolves.toBe('http://127.0.0.1:59530');
-    expect(started).toHaveLength(1);
-  });
+  it('keeps retrying when a replacement exits before readiness', async () => {
+    const initial = child('initial');
+    const failedReplacement = child('failed-replacement');
+    const recovered = child('recovered');
+    const spawnQueue = [initial, failedReplacement, recovered];
+    const closed: string[] = [];
+    const registered: string[] = [];
 
-  it('returns null and does not restart once the policy refuses', async () => {
-    const policy = createRestartPolicy({ maxRestarts: 1, windowMs: 60_000 });
-    await resolveWebRestart({
-      policy,
-      nowMs: 1_000,
-      restart: async () => 'http://127.0.0.1:1',
+    const supervisor = createWebSidecarSupervisor<SupervisorChild, { url: string | null }>({
+      closeChild: async (value) => {
+        closed.push(value.name);
+      },
+      hasExited: (value) => value.exited,
+      onExit: (value, listener) => value.exitListeners.push(listener),
+      policy: createRestartPolicy({ maxRestarts: 5, windowMs: 60_000 }),
+      registerUrl: async (url) => {
+        registered.push(url);
+      },
+      spawn: async () => {
+        const value = spawnQueue.shift();
+        if (value == null) throw new Error('unexpected extra spawn');
+        return value;
+      },
+      waitUntilReady: async (value) => {
+        if (value === failedReplacement) {
+          value.exit();
+          throw new Error('replacement exited during boot');
+        }
+        return {
+          url: value === initial
+            ? 'http://127.0.0.1:61001'
+            : 'http://127.0.0.1:61003',
+        };
+      },
     });
 
-    const started: string[] = [];
-    await expect(
-      resolveWebRestart({
-        policy,
-        nowMs: 2_000,
-        restart: async () => {
-          started.push('start');
-          return 'http://127.0.0.1:2';
-        },
-      }),
-    ).resolves.toBeNull();
-    expect(started).toHaveLength(0);
+    await expect(supervisor.start()).resolves.toEqual({ url: 'http://127.0.0.1:61001' });
+    initial.exit();
+
+    await vi.waitFor(() => {
+      expect(supervisor.currentUrl()).toBe('http://127.0.0.1:61003');
+    });
+    expect(registered).toEqual([
+      'http://127.0.0.1:61001',
+      'http://127.0.0.1:61003',
+    ]);
+    expect(closed).toEqual(['initial', 'failed-replacement']);
+    expect(spawnQueue).toHaveLength(0);
+
+    await supervisor.close();
+    expect(closed).toEqual(['initial', 'failed-replacement', 'recovered']);
   });
 
-  it('returns null when the restart itself throws', async () => {
-    const policy = createRestartPolicy({ maxRestarts: 3, windowMs: 60_000 });
-    await expect(
-      resolveWebRestart({
-        policy,
-        nowMs: 1_000,
-        restart: async () => {
-          throw new Error('spawn failed');
-        },
+  it('stops retrying when boot failures exhaust the restart budget', async () => {
+    const initial = child('initial');
+    const failedOne = child('failed-one');
+    const failedTwo = child('failed-two');
+    const spawnQueue = [initial, failedOne, failedTwo];
+    const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const supervisor = createWebSidecarSupervisor<SupervisorChild, { url: string | null }>({
+      closeChild: async () => undefined,
+      hasExited: (value) => value.exited,
+      onExit: (value, listener) => value.exitListeners.push(listener),
+      policy: createRestartPolicy({ maxRestarts: 2, windowMs: 60_000 }),
+      registerUrl: async () => undefined,
+      spawn: async () => {
+        const value = spawnQueue.shift();
+        if (value == null) throw new Error('unexpected extra spawn');
+        return value;
+      },
+      waitUntilReady: async (value) => {
+        if (value !== initial) {
+          value.exit();
+          throw new Error('replacement exited during boot');
+        }
+        return { url: 'http://127.0.0.1:61501' };
+      },
+    });
+
+    try {
+      await supervisor.start();
+      initial.exit();
+
+      await vi.waitFor(() => {
+        expect(errorLog).toHaveBeenCalledWith(
+          'packaged web sidecar restart budget exhausted; not respawning',
+        );
+      });
+      expect(spawnQueue).toHaveLength(0);
+      expect(supervisor.currentUrl()).toBe('http://127.0.0.1:61501');
+    } finally {
+      await supervisor.close();
+      errorLog.mockRestore();
+    }
+  });
+
+  it('closes a replacement whose deferred spawn resolves after shutdown starts', async () => {
+    const initial = child('initial');
+    const lateReplacement = child('late-replacement');
+    let resolveLateSpawn!: (value: SupervisorChild) => void;
+    const lateSpawn = new Promise<SupervisorChild>((resolve) => {
+      resolveLateSpawn = resolve;
+    });
+    const closed: string[] = [];
+    const registered: string[] = [];
+    let spawnCount = 0;
+
+    const supervisor = createWebSidecarSupervisor<SupervisorChild, { url: string | null }>({
+      closeChild: async (value) => {
+        closed.push(value.name);
+      },
+      hasExited: (value) => value.exited,
+      onExit: (value, listener) => value.exitListeners.push(listener),
+      registerUrl: async (url) => {
+        registered.push(url);
+      },
+      spawn: async () => {
+        spawnCount += 1;
+        return spawnCount === 1 ? initial : await lateSpawn;
+      },
+      waitUntilReady: async (value) => ({
+        url: value === initial
+          ? 'http://127.0.0.1:62001'
+          : 'http://127.0.0.1:62002',
       }),
-    ).resolves.toBeNull();
+    });
+
+    await supervisor.start();
+    initial.exit();
+    await vi.waitFor(() => expect(spawnCount).toBe(2));
+
+    const closePromise = supervisor.close();
+    resolveLateSpawn(lateReplacement);
+    await closePromise;
+
+    expect(registered).toEqual(['http://127.0.0.1:62001']);
+    expect(closed).toEqual(['initial', 'late-replacement']);
+    expect(lateReplacement.exitListeners).toHaveLength(1);
+    expect(supervisor.currentUrl()).toBe('http://127.0.0.1:62001');
   });
 });

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -27,11 +27,13 @@ import { APP_KEYS, OPEN_DESIGN_SIDECAR_CONTRACT } from '@open-design/sidecar-pro
 import {
   buildPackagedDaemonSpawnEnv,
   createPackagedSidecarSpawnOptions,
+  createRestartPolicy,
   registerPackagedWebUrl,
   resolveDaemonStatusTimeoutMs,
   resolvePackagedChildBaseEnv,
   resolvePackagedElectronNodeCommand,
   resolvePackagedPathEnv,
+  resolveWebRestart,
   waitForStatus,
 } from '../src/sidecars.js';
 import type { PackagedNamespacePaths } from '../src/paths.js';
@@ -710,5 +712,93 @@ describe('waitForStatus child-exit fast-fail', () => {
     } finally {
       await server.close();
     }
+  });
+});
+
+/**
+ * The web sidecar used to be spawned once and never watched. When it
+ * died mid-session — observed 2026-07-25 after a 0.15.1 -> 0.16.1
+ * launcher handoff reaped it — nothing respawned it, and the od://
+ * proxy kept forwarding to the dead port until the app was relaunched.
+ *
+ * The supervisor respawns it, but a sidecar that crashes during boot
+ * must not respawn forever: each attempt spends a full Next.js boot.
+ */
+describe('createRestartPolicy', () => {
+  it('allows up to maxRestarts inside the window and refuses the next one', () => {
+    const policy = createRestartPolicy({ maxRestarts: 3, windowMs: 60_000 });
+    expect(policy.allow(1_000)).toBe(true);
+    expect(policy.allow(2_000)).toBe(true);
+    expect(policy.allow(3_000)).toBe(true);
+    expect(policy.allow(4_000)).toBe(false);
+  });
+
+  it('forgets attempts that fell out of the window', () => {
+    const policy = createRestartPolicy({ maxRestarts: 2, windowMs: 10_000 });
+    expect(policy.allow(1_000)).toBe(true);
+    expect(policy.allow(2_000)).toBe(true);
+    expect(policy.allow(3_000)).toBe(false);
+    // 12_001 is more than windowMs after both recorded attempts, so the
+    // window is empty again and a fresh burst is allowed.
+    expect(policy.allow(12_001)).toBe(true);
+  });
+
+  it('defaults to 5 restarts per 60s window', () => {
+    const policy = createRestartPolicy();
+    for (let i = 0; i < 5; i += 1) {
+      expect(policy.allow(1_000 + i)).toBe(true);
+    }
+    expect(policy.allow(1_006)).toBe(false);
+  });
+});
+
+describe('resolveWebRestart', () => {
+  it('returns the next URL when the policy allows a restart', async () => {
+    const policy = createRestartPolicy({ maxRestarts: 2, windowMs: 60_000 });
+    const started: string[] = [];
+    const restart = async () => {
+      started.push('start');
+      return 'http://127.0.0.1:59530';
+    };
+
+    await expect(
+      resolveWebRestart({ policy, nowMs: 1_000, restart }),
+    ).resolves.toBe('http://127.0.0.1:59530');
+    expect(started).toHaveLength(1);
+  });
+
+  it('returns null and does not restart once the policy refuses', async () => {
+    const policy = createRestartPolicy({ maxRestarts: 1, windowMs: 60_000 });
+    await resolveWebRestart({
+      policy,
+      nowMs: 1_000,
+      restart: async () => 'http://127.0.0.1:1',
+    });
+
+    const started: string[] = [];
+    await expect(
+      resolveWebRestart({
+        policy,
+        nowMs: 2_000,
+        restart: async () => {
+          started.push('start');
+          return 'http://127.0.0.1:2';
+        },
+      }),
+    ).resolves.toBeNull();
+    expect(started).toHaveLength(0);
+  });
+
+  it('returns null when the restart itself throws', async () => {
+    const policy = createRestartPolicy({ maxRestarts: 3, windowMs: 60_000 });
+    await expect(
+      resolveWebRestart({
+        policy,
+        nowMs: 1_000,
+        restart: async () => {
+          throw new Error('spawn failed');
+        },
+      }),
+    ).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
## Why

In a packaged desktop session, an unexpected web sidecar exit leaves the `od://` protocol proxy pinned to the sidecar's dead ephemeral port. Every renderer request then returns `OD_PROTOCOL_PROXY_FAILED` / HTTP 502 until the user fully quits and relaunches Open Design, even though the daemon is still healthy.

This main-repository PR supersedes #6078 from @Bassiiiii and the temporary fork-backed replacement #6363 because their fork approval checks are stuck. It preserves Bassi's three original commits and authorship, then adds only the compatibility adjustment required by current `main`.

## What users will see

Normal sessions are unchanged. If the packaged web sidecar exits unexpectedly, Open Design now respawns it under a bounded restart policy, registers the new dynamic URL with the daemon, and lets subsequent `od://` requests recover without a manual relaunch.

The restart budget is capped at five attempts per 60-second window so a sidecar that repeatedly crashes during boot cannot respawn forever.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — the packaged runtime now automatically supervises and restarts an unexpectedly exited web sidecar
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — there is no new UI surface.

## Bug fix verification

- Test paths:
  - `apps/packaged/tests/protocol.test.ts` — resolves the web runtime URL on every request instead of snapshotting it
  - `apps/packaged/tests/sidecars.test.ts` — bounded restart policy and restart behavior
- Red/green result: yes. As recorded in #6078, reverting the protocol half makes the resolver spec fail, while reverting the sidecar supervision half makes the restart specs fail; the complete branch passes the full packaged suite.
- Current-main conflict resolution additionally keeps `registerPackagedWebUrl` inside the spawn path, so both the initial launch and every respawn register the active URL before it is exposed to `od://` consumers.

## Validation

- `pnpm --filter @open-design/packaged exec vitest run -c vitest.config.ts tests/protocol.test.ts tests/sidecars.test.ts tests/headless-runtime.test.ts` — 56 passed
- `pnpm --filter @open-design/packaged test` — 254 passed
- `pnpm --filter @open-design/packaged typecheck` — passed
- `pnpm guard` — passed
- `pnpm typecheck` — passed
