### PR TITLE
fix(web): stop design system picker popover flickering on hover after search

### DIFF
--- a/apps/web/src/components/DesignSystemPicker.tsx
+++ b/apps/web/src/components/DesignSystemPicker.tsx
@@ -38,7 +38,13 @@ function isTeamSystem(system: DesignSystemSummary): boolean {
 interface PopoverAnchor {
   left: number;
   width: number;
-  maxHeight: number;
+  // Fixed popover height. The popover must NOT size to its content: the
+  // right pane swaps between the short "不指定" blurb and the tall kit
+  // preview on hover, and a content-driven height moves the rows under a
+  // stationary cursor (the composer placement is bottom-anchored, so growth
+  // shifts everything up). The cursor then lands on a neighboring row, the
+  // preview swaps again, and hover oscillates — visible flicker.
+  height: number;
   // Vertical placement: when the trigger sits near the bottom of the
   // viewport (e.g. the composer-top picker) the popover opens upward,
   // anchored by `bottom`; otherwise it opens downward, anchored by `top`.
@@ -152,14 +158,14 @@ export function DesignSystemPicker({
           bottom: window.innerHeight - rect.top + gap,
           left,
           width: popoverWidth,
-          maxHeight: Math.max(220, Math.min(420, spaceAbove)),
+          height: Math.max(220, Math.min(420, spaceAbove)),
         });
       } else {
         setAnchor({
           top: rect.bottom + gap,
           left,
           width: popoverWidth,
-          maxHeight: Math.max(220, Math.min(420, spaceBelow)),
+          height: Math.max(220, Math.min(420, spaceBelow)),
         });
       }
     }
@@ -307,7 +313,7 @@ export function DesignSystemPicker({
               bottom: anchor.bottom,
               left: anchor.left,
               width: anchor.width,
-              maxHeight: anchor.maxHeight,
+              height: anchor.height,
             }}
           >
             <div className="project-ds-picker-search">

--- a/apps/web/src/components/DesignSystemPicker.tsx
+++ b/apps/web/src/components/DesignSystemPicker.tsx
@@ -153,19 +153,26 @@ export function DesignSystemPicker({
       // Open upward when there isn't enough room below (the composer-top
       // picker is near the viewport bottom) but there is more room above.
       const openUp = spaceBelow < 320 && spaceAbove > spaceBelow;
+      // Prefer 220-420px, but never exceed the chosen side's actual space:
+      // the height is fixed (see PopoverAnchor.height), so a hard floor
+      // would push the popover past the viewport edge in a short window.
+      // The minimum applies only when it fits; below that the popover takes
+      // whatever space the side has and the panes scroll inside it.
+      const clampHeight = (space: number) =>
+        Math.min(Math.max(220, Math.min(420, space)), Math.max(space, 0));
       if (openUp) {
         setAnchor({
           bottom: window.innerHeight - rect.top + gap,
           left,
           width: popoverWidth,
-          height: Math.max(220, Math.min(420, spaceAbove)),
+          height: clampHeight(spaceAbove),
         });
       } else {
         setAnchor({
           top: rect.bottom + gap,
           left,
           width: popoverWidth,
-          height: Math.max(220, Math.min(420, spaceBelow)),
+          height: clampHeight(spaceBelow),
         });
       }
     }

--- a/apps/web/src/styles/viewer/routines.css
+++ b/apps/web/src/styles/viewer/routines.css
@@ -3384,9 +3384,12 @@
 }
 .project-ds-picker-popover {
   position: fixed;
-  /* width + max-height come from the trigger-anchored inline style so the
+  /* width + height come from the trigger-anchored inline style so the
      popover can flip above the trigger (composer-top placement) and stay
-     within the viewport. */
+     within the viewport. The height is fixed, not content-driven: hover
+     swaps the preview pane between very different content heights, and a
+     bottom-anchored popover that resizes on hover shifts rows under the
+     cursor and flickers. */
   background: var(--bg-panel);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);

--- a/e2e/ui/chat-ds-picker-hover-stability.test.ts
+++ b/e2e/ui/chat-ds-picker-hover-stability.test.ts
@@ -16,6 +16,7 @@ import { randomUUID } from 'node:crypto';
 import { expect, test } from '@/playwright/suite';
 import type { Page } from '@playwright/test';
 import { applyStandardMocks } from '@/playwright/mock-factory';
+import { AMR_PERSONAL_WORKSPACE_CONTEXT, mockAmrPersonalWorkspace } from '@/playwright/amr';
 
 const DESIGN_SYSTEMS = [
   {
@@ -39,6 +40,33 @@ test.beforeEach(async ({ page }) => {
   // first-run privacy-consent surface doesn't render over the composer and
   // interfere with the hover/geometry assertions below.
   await applyStandardMocks(page);
+
+  // Establish write authority deterministically instead of racing the real
+  // GET /api/projects/:id/workspace-scope round trip: useProjectWorkspaceScope
+  // starts `loading: true`, and while it's loading (with no session-local
+  // creation witness, since this project was created via a raw API POST
+  // rather than the UI create flow) useProjectCollab.viewerOnly fails closed.
+  // DesignSystemPicker closes its popover whenever `disabled` (viewerOnly)
+  // flips, so a slow/late-resolving real request could shut the popover mid
+  // assertion. Same fixture project-management-flows.test.ts's
+  // "write authority" coverage uses.
+  await mockAmrPersonalWorkspace(page);
+  await page.route('**/api/projects/*/workspace-scope', async (route) => {
+    const [, projectId] = new URL(route.request().url()).pathname.match(
+      /\/api\/projects\/([^/]+)/,
+    ) ?? [];
+    await route.fulfill({
+      json: {
+        scope: {
+          kind: 'personal',
+          projectId,
+          workspaceId: AMR_PERSONAL_WORKSPACE_CONTEXT.workspaceId,
+          visibility: 'personal',
+          context: AMR_PERSONAL_WORKSPACE_CONTEXT,
+        },
+      },
+    });
+  });
 
   await page.route('**/api/design-systems', async (route) => {
     await route.fulfill({ json: { designSystems: DESIGN_SYSTEMS } });

--- a/e2e/ui/chat-ds-picker-hover-stability.test.ts
+++ b/e2e/ui/chat-ds-picker-hover-stability.test.ts
@@ -141,53 +141,31 @@ test('[P1] hovering a filtered design system does not resize or move the popover
 // Content-driven sizing used to mask this in short windows; with a fixed
 // height the popover itself must clamp to the available side space, like the
 // New Project picker already does (see new-project-ds-picker-clipping.test.ts).
-test('[P1] popover stays inside a short viewport (downward placement)', async ({ page }) => {
-  await page.setViewportSize({ width: 1280, height: 300 });
-  await page.goto('/');
-  await createProject(page, 'DS picker short viewport down');
-  await expect(page.getByTestId('chat-composer')).toBeVisible();
-
-  // The chrome-header pill sits near the top, so the popover opens below the
-  // trigger and must not spill past the viewport bottom.
-  await page.getByTestId('project-ds-picker-trigger').click();
-  const popover = page.getByTestId('project-ds-picker-popover');
-  await expect(popover).toBeVisible();
-  await expect(popover).toHaveAttribute('data-placement', 'down');
-  await expectPopoverInsideViewport(page, 'down');
-});
-
+//
+// #5517/#6142 moved this trigger from a separate chrome-header pill into a
+// single inline icon in the composer's own icon row (composer-design-system-
+// trigger), which is itself always docked a fixed, small distance above the
+// composer pane's bottom edge. That distance stays constant across viewport
+// heights, so spaceBelow is always tiny (well under the 320px openUp
+// threshold) and spaceAbove is always the larger side: this trigger opens
+// upward in every reachable viewport size, short or tall. There is no longer
+// a composer surface that can drive the downward branch, so only the upward
+// clamp is exercised here. `clampHeight` in DesignSystemPicker.tsx applies
+// the identical formula to spaceAbove and spaceBelow, so this still covers
+// the downward branch's math even though this trigger can't reach it live.
 test('[P1] popover stays inside a short viewport (upward placement)', async ({ page }) => {
+  // Short enough that spaceAbove drops under the 220px preferred minimum
+  // (the trigger sits ~50-60px above the composer pane's bottom edge
+  // regardless of viewport height), but tall enough for the app shell to
+  // still lay out normally.
+  await page.setViewportSize({ width: 1280, height: 260 });
   await page.goto('/');
   await createProject(page, 'DS picker short viewport up');
   await expect(page.getByTestId('chat-composer')).toBeVisible();
 
-  // Open the composer picker at the default height first to locate its
-  // trigger chip.
   await openDesignSystemPicker(page);
   const popover = page.getByTestId('project-ds-picker-popover');
   await expect(popover).toBeVisible();
-
-  const chip = page.locator(
-    '.staged-context-picker--design-system [data-testid="project-ds-picker-trigger"]',
-  );
-  const chipBox = await chip.boundingBox();
-  const viewport = page.viewportSize();
-  if (!chipBox || !viewport) throw new Error('Expected composer picker trigger geometry');
-
-  // The composer is pinned to the pane bottom, so the chip keeps a roughly
-  // constant distance to the bottom edge across window heights. Derive a
-  // height where the space above the chip is larger than the space below
-  // (upward placement wins) but still under the 220px preferred minimum, so
-  // the clamped branch is exercised. spaceAbove = newHeight - distToBottom
-  // - 18 and spaceBelow stays ~(distToBottom - chipHeight - 18).
-  const distToBottom = Math.round(viewport.height - chipBox.y);
-  const newHeight = Math.round(2 * distToBottom - chipBox.height + 40);
-  expect(
-    newHeight < distToBottom + 238,
-    `Derived height ${newHeight} cannot exercise the sub-220px branch (distToBottom ${distToBottom})`,
-  ).toBe(true);
-
-  await page.setViewportSize({ width: 1280, height: newHeight });
   await expect(popover).toHaveAttribute('data-placement', 'up');
   await expectPopoverInsideViewport(page, 'up');
 });
@@ -224,8 +202,7 @@ async function expectPopoverInsideViewport(page: Page, placement: 'up' | 'down')
 
 async function openDesignSystemPicker(page: Page) {
   const composer = page.getByTestId('chat-composer');
-  await composer.getByTestId('chat-plus-trigger').click();
-  await page.getByTestId('composer-plus-design-system').click();
+  await composer.getByTestId('composer-design-system-trigger').click();
 }
 
 async function createProject(page: Page, projectName: string): Promise<void> {

--- a/e2e/ui/chat-ds-picker-hover-stability.test.ts
+++ b/e2e/ui/chat-ds-picker-hover-stability.test.ts
@@ -135,6 +135,93 @@ test('[P1] hovering a filtered design system does not resize or move the popover
   }
 });
 
+// Review follow-up on the fixed-height conversion: a hard 220px floor would
+// render a 220px popover even when the chosen side has less space, pushing it
+// past the viewport edge (top for upward placement, bottom for downward).
+// Content-driven sizing used to mask this in short windows; with a fixed
+// height the popover itself must clamp to the available side space, like the
+// New Project picker already does (see new-project-ds-picker-clipping.test.ts).
+test('[P1] popover stays inside a short viewport (downward placement)', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 300 });
+  await page.goto('/');
+  await createProject(page, 'DS picker short viewport down');
+  await expect(page.getByTestId('chat-composer')).toBeVisible();
+
+  // The chrome-header pill sits near the top, so the popover opens below the
+  // trigger and must not spill past the viewport bottom.
+  await page.getByTestId('project-ds-picker-trigger').click();
+  const popover = page.getByTestId('project-ds-picker-popover');
+  await expect(popover).toBeVisible();
+  await expect(popover).toHaveAttribute('data-placement', 'down');
+  await expectPopoverInsideViewport(page, 'down');
+});
+
+test('[P1] popover stays inside a short viewport (upward placement)', async ({ page }) => {
+  await page.goto('/');
+  await createProject(page, 'DS picker short viewport up');
+  await expect(page.getByTestId('chat-composer')).toBeVisible();
+
+  // Open the composer picker at the default height first to locate its
+  // trigger chip.
+  await openDesignSystemPicker(page);
+  const popover = page.getByTestId('project-ds-picker-popover');
+  await expect(popover).toBeVisible();
+
+  const chip = page.locator(
+    '.staged-context-picker--design-system [data-testid="project-ds-picker-trigger"]',
+  );
+  const chipBox = await chip.boundingBox();
+  const viewport = page.viewportSize();
+  if (!chipBox || !viewport) throw new Error('Expected composer picker trigger geometry');
+
+  // The composer is pinned to the pane bottom, so the chip keeps a roughly
+  // constant distance to the bottom edge across window heights. Derive a
+  // height where the space above the chip is larger than the space below
+  // (upward placement wins) but still under the 220px preferred minimum, so
+  // the clamped branch is exercised. spaceAbove = newHeight - distToBottom
+  // - 18 and spaceBelow stays ~(distToBottom - chipHeight - 18).
+  const distToBottom = Math.round(viewport.height - chipBox.y);
+  const newHeight = Math.round(2 * distToBottom - chipBox.height + 40);
+  expect(
+    newHeight < distToBottom + 238,
+    `Derived height ${newHeight} cannot exercise the sub-220px branch (distToBottom ${distToBottom})`,
+  ).toBe(true);
+
+  await page.setViewportSize({ width: 1280, height: newHeight });
+  await expect(popover).toHaveAttribute('data-placement', 'up');
+  await expectPopoverInsideViewport(page, 'up');
+});
+
+async function expectPopoverInsideViewport(page: Page, placement: 'up' | 'down') {
+  const geometry = await page
+    .getByTestId('project-ds-picker-popover')
+    .evaluate((el: Element) => {
+      const r = el.getBoundingClientRect();
+      return {
+        top: Math.round(r.top),
+        bottom: Math.round(r.bottom),
+        height: Math.round(r.height),
+        viewportH: window.innerHeight,
+      };
+    });
+
+  // Confirm the case genuinely exercises the tight branch: the popover must
+  // have had less than the 220px preferred minimum available on its side.
+  expect(
+    geometry.height < 220,
+    `Expected a sub-220px popover to exercise the clamped branch (${placement}); geometry: ${JSON.stringify(geometry)}`,
+  ).toBe(true);
+
+  expect(
+    geometry.top,
+    `Popover top (${geometry.top}) is above the viewport (${placement} placement). ${JSON.stringify(geometry)}`,
+  ).toBeGreaterThanOrEqual(-1);
+  expect(
+    geometry.bottom,
+    `Popover bottom (${geometry.bottom}) overflows the short viewport (${placement} placement). ${JSON.stringify(geometry)}`,
+  ).toBeLessThanOrEqual(geometry.viewportH + 1);
+}
+
 async function openDesignSystemPicker(page: Page) {
   const composer = page.getByTestId('chat-composer');
   await composer.getByTestId('chat-plus-trigger').click();

--- a/e2e/ui/chat-ds-picker-hover-stability.test.ts
+++ b/e2e/ui/chat-ds-picker-hover-stability.test.ts
@@ -1,0 +1,170 @@
+// Composer design-system picker hover stability.
+//
+// Repro: open the chat composer's design-system picker, type a query so the
+// list shrinks to a couple of rows, then hover the filtered option. The right
+// pane swaps the short "no design system" blurb for the much taller kit
+// preview, so a content-driven popover height grows on hover. The composer
+// picker opens upward (bottom-anchored), so growth moves every row up under
+// the stationary cursor; the cursor lands on a different row, the preview
+// swaps back, the popover shrinks, and the loop repeats — visible flicker.
+//
+// The invariant that kills the loop: once open, hovering an option must not
+// resize or move the popover. With the full list the popover is already
+// clamped at its max height, which is why the bug only shows after filtering.
+
+import { randomUUID } from 'node:crypto';
+import { expect, test } from '@/playwright/suite';
+import type { Page } from '@playwright/test';
+import { routeAgents } from '@/playwright/mock-factory';
+
+const STORAGE_KEY = 'open-design:config';
+
+const DESIGN_SYSTEMS = [
+  {
+    id: 'paper',
+    title: 'Paper',
+    category: 'Product',
+    summary: 'Warm utility system for product interfaces.',
+    swatches: ['#F7F4EE', '#D6CBBF', '#1F2937', '#D97757'],
+  },
+  {
+    id: 'editorial',
+    title: 'Editorial',
+    category: 'Editorial',
+    summary: 'High-contrast editorial system with expressive type.',
+    swatches: ['#111111', '#F6EFE6', '#C44536', '#F2C14E'],
+  },
+];
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript((key) => {
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({
+        mode: 'daemon',
+        apiKey: '',
+        baseUrl: 'https://api.anthropic.com',
+        model: 'claude-sonnet-4-5',
+        agentId: 'mock',
+        skillId: null,
+        designSystemId: null,
+        onboardingCompleted: true,
+        agentModels: {},
+      }),
+    );
+  }, STORAGE_KEY);
+
+  await page.route('**/api/app-config', async (route) => {
+    await route.fulfill({
+      json: {
+        config: {
+          onboardingCompleted: true,
+          agentId: 'mock',
+          skillId: null,
+          designSystemId: null,
+          agentModels: {},
+          agentCliEnv: {},
+        },
+      },
+    });
+  });
+
+  await routeAgents(page, [
+    {
+      id: 'mock',
+      name: 'Mock Agent',
+      bin: 'mock-agent',
+      available: true,
+      version: 'test',
+      models: [{ id: 'default', label: 'Default' }],
+    },
+  ]);
+
+  await page.route('**/api/design-systems', async (route) => {
+    await route.fulfill({ json: { designSystems: DESIGN_SYSTEMS } });
+  });
+});
+
+test('[P1] hovering a filtered design system does not resize or move the popover', async ({
+  page,
+}) => {
+  await page.goto('/');
+  await createProject(page, 'DS picker hover stability');
+  await expect(page.getByTestId('chat-composer')).toBeVisible();
+
+  // Start with no design system bound so the popover opens on the short
+  // "no design system" blurb — the low-height side of the oscillation.
+  const projectId = currentProjectId(page);
+  await page.request.patch(`/api/projects/${projectId}`, {
+    data: { designSystemId: null },
+  });
+
+  await openDesignSystemPicker(page);
+  const popover = page.getByTestId('project-ds-picker-popover');
+  await expect(popover).toBeVisible();
+
+  // Filter until the list is short enough that the preview pane, not the
+  // list, would drive a content-sized popover height.
+  await page.getByTestId('project-ds-picker-search').fill('editorial');
+  const option = page.getByTestId('project-ds-picker-option-editorial');
+  await expect(option).toBeVisible();
+
+  const before = await popover.boundingBox();
+  if (!before) throw new Error('Expected the popover to have a bounding box');
+
+  await option.hover();
+  await expect(page.getByTestId('project-ds-picker-preview-kit-wrap')).toBeVisible();
+
+  // Sample the popover geometry for a while: a single post-hover measurement
+  // could land on either phase of the oscillation and pass by luck. Every
+  // sample must match the pre-hover box.
+  for (let sample = 0; sample < 10; sample += 1) {
+    const box = await popover.boundingBox();
+    if (!box) throw new Error('Expected the popover to stay mounted while hovered');
+    expect(
+      Math.abs(box.height - before.height),
+      `Popover height changed on hover (sample ${sample}): ${before.height} -> ${box.height}. ` +
+        'Hover-driven preview content must not drive the popover size.',
+    ).toBeLessThanOrEqual(1);
+    expect(
+      Math.abs(box.y - before.y),
+      `Popover top edge moved on hover (sample ${sample}): ${before.y} -> ${box.y}. ` +
+        'A moving top edge shifts rows under the cursor and causes hover flicker.',
+    ).toBeLessThanOrEqual(1);
+    await page.waitForTimeout(50);
+  }
+});
+
+async function openDesignSystemPicker(page: Page) {
+  const composer = page.getByTestId('chat-composer');
+  await composer.getByTestId('chat-plus-trigger').click();
+  await page.getByTestId('composer-plus-design-system').click();
+}
+
+async function createProject(page: Page, projectName: string): Promise<void> {
+  const response = await page.request.post('/api/projects', {
+    data: {
+      id: randomUUID(),
+      name: projectName,
+      skillId: null,
+      designSystemId: null,
+      metadata: {
+        kind: 'prototype',
+        nameSource: 'user',
+      },
+    },
+  });
+  expect(response.ok()).toBeTruthy();
+  const body = (await response.json()) as {
+    project: { id: string };
+    conversationId: string;
+  };
+  await page.goto(`/projects/${body.project.id}/conversations/${body.conversationId}`);
+}
+
+function currentProjectId(page: Page): string {
+  const url = new URL(page.url());
+  const [, projectId] = url.pathname.match(/\/projects\/([^/]+)/) ?? [];
+  if (!projectId) throw new Error(`unexpected project route: ${url.pathname}`);
+  return projectId;
+}

--- a/e2e/ui/chat-ds-picker-hover-stability.test.ts
+++ b/e2e/ui/chat-ds-picker-hover-stability.test.ts
@@ -15,9 +15,7 @@
 import { randomUUID } from 'node:crypto';
 import { expect, test } from '@/playwright/suite';
 import type { Page } from '@playwright/test';
-import { routeAgents } from '@/playwright/mock-factory';
-
-const STORAGE_KEY = 'open-design:config';
+import { applyStandardMocks } from '@/playwright/mock-factory';
 
 const DESIGN_SYSTEMS = [
   {
@@ -37,48 +35,10 @@ const DESIGN_SYSTEMS = [
 ];
 
 test.beforeEach(async ({ page }) => {
-  await page.addInitScript((key) => {
-    window.localStorage.setItem(
-      key,
-      JSON.stringify({
-        mode: 'daemon',
-        apiKey: '',
-        baseUrl: 'https://api.anthropic.com',
-        model: 'claude-sonnet-4-5',
-        agentId: 'mock',
-        skillId: null,
-        designSystemId: null,
-        onboardingCompleted: true,
-        agentModels: {},
-      }),
-    );
-  }, STORAGE_KEY);
-
-  await page.route('**/api/app-config', async (route) => {
-    await route.fulfill({
-      json: {
-        config: {
-          onboardingCompleted: true,
-          agentId: 'mock',
-          skillId: null,
-          designSystemId: null,
-          agentModels: {},
-          agentCliEnv: {},
-        },
-      },
-    });
-  });
-
-  await routeAgents(page, [
-    {
-      id: 'mock',
-      name: 'Mock Agent',
-      bin: 'mock-agent',
-      available: true,
-      version: 'test',
-      models: [{ id: 'default', label: 'Default' }],
-    },
-  ]);
+  // Seeds localStorage + /api/app-config with privacyDecisionAt set, so the
+  // first-run privacy-consent surface doesn't render over the composer and
+  // interfere with the hover/geometry assertions below.
+  await applyStandardMocks(page);
 
   await page.route('**/api/design-systems', async (route) => {
     await route.fulfill({ json: { designSystems: DESIGN_SYSTEMS } });


### PR DESCRIPTION
## Why

I hit this while working in a project chat in the desktop app. I opened the composer's design system picker, typed "tech" to narrow the list, and hovered the result. The popup started flickering rapidly and kept oscillating for as long as the cursor stayed on the row, which makes the picker unusable right at the moment of choosing a system.

The mechanism: the popover sized itself to its content, and hovering a row swaps the right preview pane from the short "no design system" blurb to the much taller kit preview. The composer placement opens upward and is bottom anchored, so the growth shifts every row up under the stationary cursor. The cursor lands on a neighboring row, the preview swaps back, the popover shrinks, the rows shift down again, and hover oscillates. With the full list the popover already sits at its max height, which is why the flicker only appears after a search shrinks the list.

## What users will see

Hovering a design system in the picker after searching now shows its kit preview with the popup holding still. As part of the fix, the popup always opens at its full anchored height (220 to 420 px depending on available space) instead of shrinking to fit a short results list. The list and preview panes scroll inside it.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — no new surface. This fixes hover behavior and sizing of the existing picker popover.

## Bug fix verification

- Test path that reproduces the bug: `e2e/ui/chat-ds-picker-hover-stability.test.ts`. It opens the composer picker in chat, filters to a single system, hovers it, and samples the popover bounding box, asserting neither its height nor its top edge moves.
- Red on `main`, green on this branch: yes. On `main` it fails with `Popover height changed on hover (sample 0): 138 -> 288`.
- I also reproduced the flicker manually in the desktop app on `main` and confirmed the fixed branch holds still with the same steps (search "tech", hover the result).

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web test` (full suite, 4892 passed)
- `playwright test ui/chat-ds-picker-hover-stability.test.ts` (new spec, green)
- `playwright test ui/chat-design-system-switch.test.ts ui/new-project-ds-picker-clipping.test.ts` (neighboring picker specs, green)