### PR TITLE
ci: allow open-design-crew[bot] to apply backport labels

### DIFF
--- a/.github/workflows/backport-label-guard.yml
+++ b/.github/workflows/backport-label-guard.yml
@@ -3,6 +3,8 @@ name: backport-label-guard
 # when someone applies a backport label, verify they have write+ permission (this includes
 # outside collaborators granted write). If not, remove the label and comment. Removing a label
 # fires the "unlabeled" event, not "labeled", so there is no loop.
+# GitHub App bots never appear in the collaborators API (permission reads as "none"), so
+# trusted automation apps are allowlisted by login instead.
 
 on:
   pull_request_target:
@@ -31,6 +33,10 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
+          if [ "$ACTOR" = "open-design-crew[bot]" ]; then
+            echo "Authorized: $ACTOR (allowlisted app)"
+            exit 0
+          fi
           perm=$(gh api "repos/$REPO/collaborators/$ACTOR/permission" --jq '.permission' 2>/dev/null || echo none)
           case "$perm" in
             admin|maintain|write)


### PR DESCRIPTION
## Why

`open-design-crew[bot]` (our PR automation app) applies `backport release/vX.Y.Z` labels on the fix PRs it opens (e.g. #6391), but `backport-label-guard.yml` verifies the labeler through the collaborators permission API. GitHub App bots never appear there, so the check reads `none` and the guard immediately strips the label and posts a "please ask a maintainer" comment — every crew-authored release fix loses its backport label and needs a human to re-apply it.

## What users will see

Backport labels applied by `open-design-crew[bot]` now stick. No more automatic removal + "requires write permission" comment on crew-opened PRs. Labels applied by humans without write access are still removed as before.

## Surface area

- [x] **None** — internal CI automation only

## Bug fix verification

- This is a `pull_request_target` workflow guard; it cannot be exercised by a red spec locally, and the e2e topology suite does not cover `backport-label-guard.yml`. Verified instead via YAML parse + `bash -n` of the guard script, and the failing case is documented on #6391 (label added by crew → removed by release bot within a minute).

## Validation

- `ruby -ryaml` parse of the edited workflow — OK
- `bash -n` on the updated guard script body — OK
- `actionlint` not available locally; change is a single shell `if` short-circuit before the existing permission lookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
