### PR TITLE
fix(ci): route fork PRs to GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,13 @@ jobs:
       - name: Resolve runner profiles
         id: runners
         env:
-          OD_CI_RUNNER_MODE: ${{ vars.OD_CI_RUNNER_MODE }}
+          # Fork PRs cannot rely on repository variables, so keep their required
+          # validation on GitHub-hosted runners even when private pools are down.
+          OD_CI_RUNNER_MODE: >-
+            ${{ github.event_name == 'pull_request'
+              && github.event.pull_request.head.repo.full_name != github.repository
+              && 'economic'
+              || vars.OD_CI_RUNNER_MODE }}
         run: python3 .github/scripts/runners.py
 
   scopes:

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1175,6 +1175,16 @@ process.stdin.on("end", () => {
     expect(workflow).not.toContain("needs.runners.outputs.blacksmith_default");
   });
 
+  it("[P1] routes external fork PRs through GitHub-hosted runner profiles", async () => {
+    const workflow = await readFile(ciWorkflowPath, "utf8");
+    const runners = sectionBetween(workflow, "  runners:", "  scopes:");
+
+    expect(runners).toContain("github.event_name == 'pull_request'");
+    expect(runners).toContain("github.event.pull_request.head.repo.full_name != github.repository");
+    expect(runners).toContain("&& 'economic'");
+    expect(runners).toContain("|| vars.OD_CI_RUNNER_MODE");
+  });
+
   it("[P1] pins ShellCheck for actionlint across runner profiles", async () => {
     const workflow = await readFile(ciWorkflowPath, "utf8");
     const staticGate = sectionBetween(workflow, "  static_gate:", "  preflight:");


### PR DESCRIPTION
## Why

While validating external PR #6379, the core CI jobs stayed queued because fork pull requests cannot rely on repository variables. `vars.OD_CI_RUNNER_MODE` therefore resolves empty, and the existing default runner contract sends control jobs to Contabo and hot-path jobs to Blacksmith. When those private pools are unavailable, required checks never start, and changing the repository variable cannot repair the fork run.

PR #6290 identified the same infrastructure failure and proposed a control-runner fallback. This same-repository CI-only PR makes the fix landable and routes the whole external fork lane through the existing `economic` contract, avoiding both private Linux pools. Thanks @dpeterson01 for the initial diagnosis and fallback work.

## What users will see

External contributors' core PR checks will run on GitHub-hosted Ubuntu runners instead of waiting for Contabo or Blacksmith. Same-repository PRs, merge-queue runs, and manual runs keep using the configured `OD_CI_RUNNER_MODE` behavior.

After this PR merges, already-open fork PRs must update their branches from `main` to trigger the new workflow definition.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this only changes CI runner routing.

## Bug fix verification

- Test path that reproduces the bug: `e2e/tests/packaged-smoke-workflow.test.ts`
- Did the test go red on `main` and green on this branch? Yes. The focused test first failed because the runner job had no fork-event route, then passed after the workflow change.

## Validation

- `corepack pnpm --filter @open-design/e2e exec vitest run -c vitest.config.ts tests/packaged-smoke-workflow.test.ts` (54 passed)
- `actionlint -color` with the workflow-pinned actionlint 1.7.12
- `python3 .github/scripts/handoff.py self-check`
- `corepack pnpm guard`
- `corepack pnpm typecheck`
- `git diff --check`
