### PR TITLE
fix(plugins): add 8 missing bundled design-system manifests

### DIFF
--- a/plugins/_official/design-systems/cisco/DESIGN.md
+++ b/plugins/_official/design-systems/cisco/DESIGN.md
@@ -1,0 +1,201 @@
+# Design System Inspired by Cisco
+
+> Category: Backend & Data
+> Enterprise infrastructure brand. Dark trust surfaces, Cisco Blue signal, technical clarity.
+
+## 1. Visual Theme & Atmosphere
+
+Cisco's current public web presence is enterprise infrastructure rendered with cinematic restraint. The canvas is dark but not pure black: layered navy-charcoal surfaces create depth without resorting to glossy startup gradients. Bright Cisco Blue is used as a precise signal color rather than a wash across the page. The overall impression is "serious global platform" rather than "friendly SaaS app" — large high-confidence headlines, quiet chrome, and product imagery that emphasizes scale, networking, observability, and resilience.
+
+Typography is disciplined and corporate. Cisco's internal and presentation ecosystem points to `CiscoSansTT` as the preferred brand face, while the web experience remains compatible with modern grotesk fallbacks. Headings should feel concise and engineered. Body copy should read clearly and directly, not editorially. Geometrically, the system prefers soft pills for calls to action, rounded-but-not-playful cards, and glass-dark navigation shells floating over large atmospheric sections.
+
+What makes Cisco distinct is the combination of **deep infrastructure darkness** with a **single electric trust signal**. Use blue for the moment that matters: primary action, focus, active tab, chart highlight, or key data edge. Let the rest of the interface stay disciplined.
+
+**Key Characteristics:**
+- Dark navy-charcoal surfaces instead of flat black
+- Cisco Blue (`#049fd9`) as the primary signal color
+- Restrained neutral system built from grays and pale technical whites
+- Enterprise-scale headlines with compact, factual body copy
+- Pill CTAs and rounded control shells, but never toy-like UI
+- Product and platform imagery should suggest networks, telemetry, and systems at scale
+- Motion should feel controlled and infrastructural, not playful
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Cisco Blue** (`#049fd9`): High-signal accent, outline CTA, active state, key link.
+- **Status Blue** (`#64bbe3`): Focus halo, secondary emphasis, lightweight chart signal.
+- **Cisco Indigo** (`#005073`): Filled primary CTA, dense accent, deeper data emphasis.
+- **Dark Blue** (`#2b5592`): Secondary brand accent for graphics, charts, and layered blue compositions.
+
+### Neutral / Surface
+- **Dark Gray 1** (`#39393b`): Mid-dark container surface, panel base, dense modules.
+- **Dark Gray 2** (`#58585b`): Borders, separators, secondary shells.
+- **Medium Gray 2** (`#9e9ea2`): Muted labels and low-emphasis metadata.
+- **Pale Gray 1** (`#e8ebf1`): Light text support, cool technical background tint, separators on dark.
+- **Core White** (`#ffffff`): Primary inverse text, bright UI foreground, light surface content.
+
+### Support
+- **Sage Green** (`#abc233`): Positive outcome or infrastructure-health accent.
+- **Status Green** (`#6cc04a`): Success state.
+- **Status Yellow** (`#ffcc00`): Warning or caution state.
+- **Status Orange** (`#ff7300`): Alert or escalation state.
+- **Status Red** (`#cf2030`): Error or critical state.
+
+### Recommended Surface Roles
+- **Primary canvas**: a blue-black or charcoal blend built around `#0f1720` to `#1b2530` using the Cisco palette as anchor.
+- **Elevated card**: Dark Gray 1 (`#39393b`) or a slightly bluer variant.
+- **Border / outline**: Dark Gray 2 (`#58585b`) with subtle transparency when needed.
+- **Primary text on dark**: Core White (`#ffffff`) or Pale Gray 1 (`#e8ebf1`).
+
+## 3. Typography Rules
+
+### Font Family
+- **Primary**: `CiscoSansTT`, fallbacks: `Inter, Arial, Helvetica Neue, Helvetica, sans-serif`
+- **Mono / Technical**: `IBM Plex Mono`, `SF Mono`, or `ui-monospace` if a code-supporting mono face is needed for metrics and IDs
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Hero Display | CiscoSansTT | 72px | 500 | 1.05 | -1.6px | Large launch/positioning headline |
+| Section Display | CiscoSansTT | 56px | 500 | 1.08 | -1.1px | Major section statement |
+| Heading | CiscoSansTT | 32px | 500 | 1.20 | -0.4px | Feature title, card header |
+| Subheading | CiscoSansTT | 24px | 500 | 1.30 | -0.2px | Supporting header |
+| Body | CiscoSansTT | 16px | 400 | 1.55 | normal | Default body copy |
+| Body Small | CiscoSansTT | 14px | 400 | 1.50 | normal | Metadata, nav, helper text |
+| Label / Eyebrow | CiscoSansTT | 12px | 700 | 1.30 | 0.24px | Tags, overlines, section labels |
+| Button | CiscoSansTT | 16px | 500 | 1.20 | normal | CTA labels |
+
+### Principles
+- Keep display typography decisive and compressed, but not ultra-light or editorial.
+- Body copy should be practical and highly legible, with no clever type effects.
+- Use bold weight mainly for short labels, status tags, and compact emphasis.
+- Favor one-family coherence over showy font mixing.
+
+## 4. Component Stylings
+
+### Buttons
+
+**Primary Action Pill**
+- Background: Cisco Indigo (`#005073`)
+- Text: White (`#ffffff`)
+- Radius: full pill
+- Padding: generous horizontal padding, medium vertical height
+- Hover: Dark Blue (`#2b5592`)
+- Active: a darker indigo tone around `#00364d`
+- Focus ring: 2px outer halo in Status Blue (`#64bbe3`) with a 1px white inner keyline on dark surfaces
+- Use case: high-priority submit, deploy, or "learn more" action on dark Cisco surfaces
+
+**Signal Outline Pill**
+- Background: transparent
+- Text: Cisco Blue (`#049fd9`) on dark surfaces, Cisco Indigo (`#005073`) on light surfaces
+- Border: 1.5px Cisco Blue (`#049fd9`)
+- Radius: full pill
+- Hover: blue-tinted surface fill with the text color preserved
+- Focus ring: same visible halo pairing as the primary button
+- Use case: brand-forward secondary action that keeps Cisco Blue prominent without sacrificing contrast
+
+**Secondary Dark Pill**
+- Background: transparent or dark surface
+- Text: White or Pale Gray 1
+- Border: Dark Gray 2 (`#58585b`)
+- Radius: full pill
+- Purpose: low-noise secondary CTA
+
+### Cards & Containers
+- Background: layered dark surface based on `#39393b` or a cooler navy-charcoal adaptation
+- Border: 1px subtle border using `#58585b`
+- Radius: 16px to 20px
+- Shadow: minimal; depth should come mostly from surface contrast and spacing
+
+### Navigation
+- Dark glass-like masthead or shell over a dark hero
+- Text: White / Pale Gray 1
+- Active state: Cisco Blue underline, chip, or glow
+- Navigation should feel like product chrome, not marketing candy
+
+### Data / Product Modules
+- Charts and diagrams should use Cisco Blue as primary highlight and keep supporting colors minimal
+- Use green/yellow/red only for actual operational meaning
+- Dense technical blocks should still preserve breathing room and hierarchy
+
+### Brand-Specific Recipes
+
+**Network Telemetry Card**
+- Anatomy: eyebrow label, large metric, delta chip, 12-24h sparkline, quiet footer metadata
+- Density: compact but not cramped; 16px-24px padding with clear alignment to chart axes
+- States: normal, selected, degraded, critical, loading skeleton
+- Brand behavior: use Cisco Blue for the selected edge or sparkline, and semantic colors only for health state
+
+**Topology / Product Diagram Module**
+- Anatomy: title, system canvas, node chips, connection lines, side legend
+- Visual rule: dark field first, blue path highlight second, all other nodes muted until active
+- States: idle overview, hovered path, selected node, degraded route
+
+**Dense Control Panel**
+- Anatomy: left nav rail, filter bar, split metric region, log/event table, contextual right rail
+- Control sizing: compact 36px inputs are acceptable on desktop, but action buttons remain 44px minimum height
+- States: quiet default, blue active filter, clear warning/error escalation
+
+## 5. Layout Principles
+
+### Spacing & Grid
+- Base rhythm: 8px
+- Common scale: 8px, 12px, 16px, 24px, 32px, 48px, 64px, 96px
+- Prefer wide desktop containers and large sectional spacing
+- 12-column desktop layout with generous gutters works well for the brand
+- Breakpoints: mobile up to 767px, tablet 768px-1199px, desktop 1200px and above
+
+### Composition
+- Alternate expansive hero/outcome sections with denser information bands
+- Use asymmetry where it serves product imagery or system diagrams
+- Large dark fields with one blue focal point are more on-brand than many small colorful fragments
+- On tablet, reduce wide split layouts to 2-column modules and keep telemetry cards in pairs
+- On mobile, collapse hero side-by-sides to a single column, stack data panels vertically, and convert dense control rows into progressive disclosure panels
+- Navigation should collapse from a full masthead to a compact menu button plus one primary CTA on tablet/mobile
+
+### Accessibility & Responsiveness
+- Minimum touch target: 44px by 44px for any tappable control
+- Keyboard focus must remain visible on every interactive element via the blue outer halo plus white inner keyline pairing
+- Do not rely on hover-only disclosure; show essential state and actions on focus and touch
+- Preserve readable line lengths on desktop and avoid more than 3 cards per row on tablet or 1 card per row on small phones
+
+## 6. Motion & Interaction
+
+- Motion should be controlled, smooth, and systems-like
+- Use fade, rise, subtle slide, and restrained glow
+- Interaction timing: roughly 160ms–260ms for control response, 320ms–500ms for larger section reveals
+- Avoid bouncy springs, elastic easing, or playful overshoot
+- Respect `prefers-reduced-motion`: remove parallax and staged reveals, keep only instant state swaps or short opacity transitions under 120ms
+
+## 7. Voice & Brand
+
+- Voice is confident, technical, and outcome-oriented
+- Headlines should sound like platform positioning or systems value, not consumer lifestyle copy
+- Use language that suggests trust, resilience, infrastructure, AI readiness, and operational scale
+- The brand should feel global, mission-critical, and composed under pressure
+
+## 8. Anti-patterns
+
+- Do not turn Cisco into a generic gradient startup site
+- Do not flood the page with many equally loud accent colors
+- Do not use pastel palettes or lifestyle-illustration aesthetics
+- Do not use overly rounded, bubbly controls
+- Do not rely on pure black alone; use layered charcoals and deep blue-blacks instead
+- Do not make body copy feel whimsical, editorial, or ironic
+
+## 9. Agent Prompt Guide
+
+### Quick Color Reference
+- Primary signal: Cisco Blue (`#049fd9`)
+- Hover / secondary signal: Status Blue (`#64bbe3`)
+- Deep accent: Cisco Indigo (`#005073`)
+- Mid-dark surface: Dark Gray 1 (`#39393b`)
+- Border: Dark Gray 2 (`#58585b`)
+- Inverse text: White (`#ffffff`) or Pale Gray 1 (`#e8ebf1`)
+
+### Example Component Prompts
+- "Create a Cisco-style dark enterprise landing page with layered navy-charcoal surfaces, a bright Cisco Blue primary CTA, and a 72px high-confidence hero headline."
+- "Design a technical dashboard card on a dark surface with a subtle gray border, white text, and Cisco Blue chart highlights."
+- "Build a dark glass navigation bar with restrained white labels and one Cisco Blue active indicator."

--- a/plugins/_official/design-systems/cisco/open-design.json
+++ b/plugins/_official/design-systems/cisco/open-design.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "design-system-cisco",
+  "title": "Cisco",
+  "title_i18n": {
+    "zh-CN": "Cisco",
+    "zh-TW": "Cisco",
+    "ja": "Cisco",
+    "ko": "Cisco",
+    "de": "Cisco",
+    "fr": "Cisco",
+    "ru": "Cisco",
+    "es": "Cisco",
+    "pt-BR": "Cisco",
+    "it": "Cisco",
+    "vi": "Cisco",
+    "pl": "Cisco",
+    "id": "Cisco",
+    "nl": "Cisco",
+    "ar": "Cisco",
+    "tr": "Cisco",
+    "uk": "Cisco",
+    "en": "Cisco"
+  },
+  "version": "0.1.0",
+  "publishedAt": "2026-08-04T09:00:00Z",
+  "description": "Enterprise infrastructure brand. Dark trust surfaces, Cisco Blue signal, technical clarity.",
+  "description_i18n": {
+    "zh-CN": "企业基础设施品牌。深色信任底色、思科蓝信号、技术清晰感。",
+    "zh-TW": "企業基礎設施品牌。深色信任底色、思科藍訊號、技術清晰感。",
+    "ja": "エンタープライズ向けインフラブランド。ダークな信頼感のある面、Cisco Blueの信号、技術的な明瞭さ。",
+    "ko": "엔터프라이즈 인프라 브랜드. 어두운 신뢰 표면, Cisco Blue 시그널, 기술적인 명확함.",
+    "de": "Enterprise-Infrastrukturmarke. Dunkle Vertrauensflächen, Cisco-Blau-Signal, technische Klarheit.",
+    "fr": "Marque d’infrastructure d’entreprise. Surfaces sombres de confiance, signal Cisco Blue, clarté technique.",
+    "ru": "Бренд корпоративной инфраструктуры. Тёмные поверхности доверия, сигнал Cisco Blue, техническая ясность.",
+    "es": "Marca de infraestructura empresarial. Superficies oscuras de confianza, señal Cisco Blue, claridad técnica.",
+    "pt-BR": "Marca de infraestrutura empresarial. Superfícies escuras de confiança, sinal Cisco Blue, clareza técnica.",
+    "it": "Brand di infrastruttura enterprise. Superfici scure di fiducia, segnale Cisco Blue, chiarezza tecnica.",
+    "vi": "Thương hiệu hạ tầng doanh nghiệp. Bề mặt tối mang cảm giác tin cậy, tín hiệu xanh Cisco, rõ ràng về kỹ thuật.",
+    "pl": "Marka infrastruktury enterprise. Ciemne powierzchnie zaufania, sygnał Cisco Blue, techniczna klarowność.",
+    "id": "Merek infrastruktur enterprise. Permukaan gelap yang tepercaya, sinyal Cisco Blue, kejelasan teknis.",
+    "nl": "Enterprise-infrastructuurmerk. Donkere vertrouwensvlakken, Cisco Blue-signaal, technische helderheid.",
+    "ar": "علامة بنية تحتية للمؤسسات. أسطح داكنة توحي بالثقة، إشارة Cisco Blue، وضوح تقني.",
+    "tr": "Kurumsal altyapı markası. Koyu güven yüzeyleri, Cisco Blue sinyali, teknik netlik.",
+    "uk": "Бренд корпоративної інфраструктури. Темні поверхні довіри, сигнал Cisco Blue, технічна ясність.",
+    "en": "Enterprise infrastructure brand. Dark trust surfaces, Cisco Blue signal, technical clarity."
+  },
+  "license": "MIT",
+  "tags": [
+    "design-system",
+    "first-party",
+    "design",
+    "backend-data"
+  ],
+  "od": {
+    "kind": "scenario",
+    "taskKind": "new-generation",
+    "mode": "design-system",
+    "scenario": "design",
+    "surface": "web",
+    "useCase": {
+      "query": {
+        "en": "Generate a {{artifactKind}} using the Cisco design system. Stay faithful to its colour palette, typography, spacing, iconography, and component vocabulary as documented in DESIGN.md.",
+        "zh-CN": "使用这个插件完成以下任务：Generate a {{artifactKind}} using the Cisco design system. Stay faithful to its colour palette, typography, spacing, iconography, and component vocabulary as documented in DESIGN.md."
+      }
+    },
+    "inputs": [
+      {
+        "name": "artifactKind",
+        "label": "Artifact kind",
+        "type": "select",
+        "options": [
+          "landing page",
+          "dashboard",
+          "marketing site",
+          "app screen"
+        ],
+        "default": "landing page"
+      },
+      {
+        "name": "brief",
+        "label": "Brief",
+        "type": "text",
+        "placeholder": "What should the page communicate?"
+      }
+    ],
+    "context": {
+      "designSystem": {
+        "ref": "cisco",
+        "primary": true
+      },
+      "assets": [
+        "./DESIGN.md"
+      ]
+    },
+    "pipeline": {
+      "stages": [
+        {
+          "id": "generate",
+          "atoms": [
+            "file-write",
+            "live-artifact"
+          ]
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject",
+      "fs:write"
+    ]
+  }
+}

--- a/plugins/_official/design-systems/hud/DESIGN.md
+++ b/plugins/_official/design-systems/hud/DESIGN.md
@@ -1,0 +1,173 @@
+# HUD Design System
+
+> Category: Themed & Unique
+> Fighter jet / helicopter head-up display. Phosphor green on near-black, all-caps data overlays, angular geometry. Zero ambiguity at speed and altitude.
+
+## 1. Visual Theme & Atmosphere
+
+A **combat pilot's glass cockpit** — everything readable in a split second, in any light condition, under any G-load. The HUD projects critical flight data directly into the pilot's line of sight so they never have to look down. Translucency and glow replace depth and shadow. Every element is functional or it doesn't exist.
+
+| Element | Hex | Role |
+|---------|-----|------|
+| Background | `#0A0A0A` | Near-black, primary canvas |
+| Surface | `#111316` | Elevated panels, card backgrounds |
+| Border | `#1E2328` | Subtle panel separation |
+| Primary | `#00FF41` | Active readouts, all data values |
+| Secondary | `#7FFF00` | Standby/dimmed values, inactive fields |
+| Tertiary | `#5A9A5A` | Grid lines, tick marks, reference arcs |
+| Warning | `#FFB800` | Caution, system advisories |
+| Alert | `#FF3B3B` | Critical warnings, fault indicators |
+
+*Readings must be unambiguous at 200 knots in Instrument Meteorological Conditions.*
+
+### Use Cases
+
+HUD is purpose-built for:
+- **Flight simulation UIs** — combat sims, civil aviation trainers, helicopter hoist operations
+- **Telemetry dashboards** — real-time velocity, altitude, heading overlays
+- **Command-and-control displays** — drone operator screens, ISR stations
+- **Any high-speed, zero-ambiguity data overlay**
+
+### Prior Art
+
+F-16 Fighting Falcon HUD, Apache AH-64 attack helicopter integrated display, F-35 helmet-mounted display system, Garmin G1000 flight deck. All share: phosphor green primary, decluttered minimalism, and information hierarchy driven by operational urgency.
+
+## 2. Color Palette & Roles
+
+### Surface Palette
+
+| Token | Hex | Usage |
+|-------|-----|-------|
+| Background | `#0A0A0A` | Page canvas, primary depth |
+| Surface | `#111316` | Panels, cards, elevated areas |
+| Border | `#1E2328` | Panel dividers, subtle structure |
+
+### Data Palette
+
+| Token | Hex | Usage |
+|-------|-----|-------|
+| Primary | `#00FF41` | Speed, altitude, heading readouts |
+| Secondary | `#7FFF00` | Standby/dimmed values, inactive fields |
+| Tertiary | `#5A9A5A` | Grid lines, tick marks, reference arcs |
+| Warning | `#FFB800` | Caution, system advisories |
+| Alert | `#FF3B3B` | Critical warnings, fault indicators |
+
+All data colors on `#0A0A0A` pass WCAG AA (minimum 4.5:1).
+
+### Dark Mode
+
+Dark mode is the native and only mode. A HUD is projected in low-light or high-glare cockpit conditions; there is no light mode by design.
+
+```css
+:root {
+  --color-bg: #0A0A0A;
+  --color-surface: #111316;
+  --color-border: #1E2328;
+  --data-primary: #00FF41;
+  --data-secondary: #7FFF00;
+  --data-tertiary: #5A9A5A;
+  --data-warning: #FFB800;
+  --data-alert: #FF3B3B;
+}
+```
+
+## 3. Typography Rules
+
+| Role | Size | Weight | Line Height | Font |
+|------|------|--------|-------------|------|
+| Display | 32px | 700 | 1.0 | JetBrains Mono |
+| Heading | 12px | 700 | 1.0 | Inter, uppercase |
+| Body | 14px | 400 | 1.2 | JetBrains Mono |
+| Label | 10px | 600 | 1.0 | Inter, uppercase |
+| Micro | 8px | 700 | 1.0 | Inter, uppercase |
+
+**Font labels for catalog extraction:**
+
+```
+Display: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace
+Body: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace
+Heading: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+Label: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+Micro: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+Mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace
+```
+
+## 4. Component Stylings
+
+### Data Readout
+
+Displays a single data value with label. Always uses `--data-primary` color.
+
+```css
+.data-readout {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--data-primary);
+  letter-spacing: 0.05em;
+}
+.data-readout-label {
+  font-family: 'Inter', sans-serif;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: var(--data-tertiary);
+  letter-spacing: 0.1em;
+}
+```
+
+### Status Indicator
+
+Dot or bar that reflects system state. Colors map to operational states.
+
+```css
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--data-primary); /* active */
+}
+.status-dot.standby { background: var(--data-secondary); }
+.status-dot.warning { background: var(--data-warning); }
+.status-dot.alert   { background: var(--data-alert); }
+```
+
+### Grid Lines
+
+Reference marks for spatial orientation. Thin lines in `--data-tertiary`.
+
+## 5. Layout Principles
+
+HUDs are overlay systems — they display over a visual field. The layout is absolute-positioned overlays on a transparent or dark background. Information density is high; whitespace is used to separate data clusters, not for aesthetics.
+
+Key structural patterns:
+- Grid lines reference the center of the display (crosshair)
+- Data readouts cluster by update frequency (altitude updates slower than airspeed)
+- Warning states override all other information layers
+
+## 6. Depth & Elevation
+
+HUD overlays use opacity and glow rather than elevation shadows. Panels are distinguished by border color and subtle surface shifts, not drop shadows. The HUD exists in a single visual plane.
+
+## 7. Do's and Don'ts
+
+- Do not use tertiary `#5A9A5A` for body or readout text — only grid lines and reference marks
+- Do not animate elements that do not signal operational state
+- Do not provide a light mode — a HUD only exists in low-light or high-glare conditions
+- Do not use rounded corners greater than 50% (circle reticles only)
+- Do not use gradients — flat color fills only
+- Do not convey information by color alone — reinforce with position and label
+
+## 8. Responsive Behavior
+
+HUD overlays are viewport-relative. On smaller viewports, data clusters compress proportionally. Critical readouts (speed, altitude, heading) remain visible at all sizes; secondary indicators hide or minimize. The layout uses a 12-column grid with absolute-positioned data panels anchored to screen edges.
+
+## 9. Agent Prompt Guide
+
+When generating a HUD-style interface, prompt the model to:
+- Use JetBrains Mono for all data readouts; Inter (uppercase) for labels only
+- Set `--data-primary` to `#00FF41` for all active readouts
+- Apply 150ms ease-out for state transitions, 100ms linear for data value changes
+- Include a status indicator component with active/standby/warning/alert states
+- Ensure all text passes 4.5:1 contrast on `#0A0A0A`
+- Never add decorative animation or light mode variants

--- a/plugins/_official/design-systems/hud/open-design.json
+++ b/plugins/_official/design-systems/hud/open-design.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "design-system-hud",
+  "title": "HUD",
+  "title_i18n": {
+    "zh-CN": "HUD",
+    "zh-TW": "HUD",
+    "ja": "HUD",
+    "ko": "HUD",
+    "de": "HUD",
+    "fr": "HUD",
+    "ru": "HUD",
+    "es": "HUD",
+    "pt-BR": "HUD",
+    "it": "HUD",
+    "vi": "HUD",
+    "pl": "HUD",
+    "id": "HUD",
+    "nl": "HUD",
+    "ar": "HUD",
+    "tr": "HUD",
+    "uk": "HUD",
+    "en": "HUD"
+  },
+  "version": "0.1.0",
+  "publishedAt": "2026-08-04T09:00:00Z",
+  "description": "Fighter-jet head-up display. Phosphor green on near-black, all-caps data overlays, angular geometry.",
+  "description_i18n": {
+    "zh-CN": "战斗机抬头显示风格。近黑底上的磷光绿、全大写数据叠层、棱角几何。",
+    "zh-TW": "戰鬥機抬頭顯示風格。近黑底上的磷光綠、全大寫資料疊層、稜角幾何。",
+    "ja": "戦闘機のヘッドアップディスプレイ。ほぼ黒の上の燐光グリーン、全大文字のデータオーバーレイ、角ばった幾何学。",
+    "ko": "전투기 헤드업 디스플레이. 거의 검은 바탕의 인광 녹색, 대문자 데이터 오버레이, 각진 기하학.",
+    "de": "Kampfjet-Head-up-Display. Phosphorgrün auf Beinahe-Schwarz, Daten-Overlays in Versalien, kantige Geometrie.",
+    "fr": "Affichage tête haute de chasseur. Vert phosphore sur quasi-noir, overlays de données en capitales, géométrie angulaire.",
+    "ru": "ИЛС истребителя. Фосфорно-зелёный на почти чёрном, оверлеи данных капсом, угловатая геометрия.",
+    "es": "HUD de caza. Verde fósforo sobre casi negro, superposiciones de datos en mayúsculas, geometría angular.",
+    "pt-BR": "HUD de caça. Verde fósforo sobre quase preto, overlays de dados em caixa alta, geometria angular.",
+    "it": "HUD da caccia. Verde fosforo su quasi nero, overlay dati in maiuscolo, geometria angolare.",
+    "vi": "HUD kiểu máy bay tiêm kích. Xanh phosphor trên nền gần đen, lớp phủ dữ liệu chữ hoa, hình học góc cạnh.",
+    "pl": "HUD myśliwca. Fosforowa zieleń na niemal czerni, nakładki danych kapitalikami, kanciasta geometria.",
+    "id": "HUD jet tempur. Hijau fosfor di atas hampir hitam, overlay data huruf kapital, geometri bersudut.",
+    "nl": "HUD van een gevechtsvliegtuig. Fosforgroen op bijna-zwart, data-overlays in kapitalen, hoekige geometrie.",
+    "ar": "شاشة عرض علوية لطائرة مقاتلة. أخضر فسفوري على شبه أسود، طبقات بيانات بأحرف كبيرة، هندسة زاوية.",
+    "tr": "Savaş uçağı baş üstü göstergesi. Neredeyse siyah üzerinde fosfor yeşili, büyük harfli veri katmanları, açılı geometri.",
+    "uk": "ІЛС винищувача. Фосфорно-зелений на майже чорному, оверлеї даних капсом, кутаста геометрія.",
+    "en": "Fighter-jet head-up display. Phosphor green on near-black, all-caps data overlays, angular geometry."
+  },
+  "license": "MIT",
+  "tags": [
+    "design-system",
+    "first-party",
+    "design",
+    "themed-unique"
+  ],
+  "od": {
+    "kind": "scenario",
+    "taskKind": "new-generation",
+    "mode": "design-system",
+    "scenario": "design",
+    "surface": "web",
+    "useCase": {
+      "query": {
+        "en": "Generate a {{artifactKind}} using the HUD design system. Stay faithful to its colour palette, typography, spacing, iconography, and component vocabulary as documented in DESIGN.md.",
+        "zh-CN": "使用这个插件完成以下任务：Generate a {{artifactKind}} using the HUD design system. Stay faithful to its colour palette, typography, spacing, iconography, and component vocabulary as documented in DESIGN.md."
+      }
+    },
+    "inputs": [
+      {
+        "name": "artifactKind",
+        "label": "Artifact kind",
+        "type": "select",
+        "options": [
+          "landing page",
+          "dashboard",
+          "marketing site",
+          "app screen"
+        ],
+        "default": "landing page"
+      },
+      {
+        "name": "brief",
+        "label": "Brief",
+        "type": "text",
+        "placeholder": "What should the page communicate?"
+      }
+    ],
+    "context": {
+      "designSystem": {
+        "ref": "hud",
+        "primary": true
+      },
+      "assets": [
+        "./DESIGN.md"
+      ]
+    },
+    "pipeline": {
+      "stages": [
+        {
+          "id": "generate",
+          "atoms": [
+            "file-write",
+            "live-artifact"
+          ]
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject",
+      "fs:write"
+    ]
+  }
+}

--- a/plugins/_official/design-systems/loom/DESIGN.md
+++ b/plugins/_official/design-systems/loom/DESIGN.md
@@ -1,0 +1,201 @@
+# Loom Design System
+
+> Category: Themed & Unique
+> Loom async video. Purple primary, friendly surfaces, video-first layout. Clean and professional without being corporate.
+
+## 1. Visual Theme & Atmosphere
+
+A friendly, fast video-first async communication tool. Loom's design feels like a well-made productivity app — approachable, clean, and professional without being corporate. Purple accent (#625DF5) signals creativity and video without being loud. Information density is moderate, with generous whitespace that lets content breathe.
+
+- **Visual style:** clean, friendly, content-first
+- **Color stance:** bright surfaces with purple accent
+- **Design intent:** keep outputs recognizable to this style family while preserving usability and readability
+
+## 2. Color Palette & Roles
+
+### Surface Palette
+
+| Token | Hex | Usage |
+|-------|-----|-------|
+| Background | `#FFFFFF` | Primary canvas |
+| Surface | `#F7F7F8` | Cards, sidebars, elevated panels |
+| Border | `#E4E4E7` | Dividers, input borders |
+
+### Data Palette
+
+| Token | Hex | Usage |
+|-------|-----|-------|
+| Primary | `#625DF5` | CTAs, active states, video progress |
+| Primary Hover | `#5048E5` | Button hover state |
+| Text | `#1F1F23` | All text |
+| Text Secondary | `#6B6D76` | Timestamps, metadata, captions |
+| Text Tertiary | `#9B9CA3` | Placeholders, disabled states |
+| Error | `#D64770` | Error states |
+| Recording | `#EF440C` | Active recording indicator |
+
+### Light Mode
+
+Default. A content-first tool used in bright office environments.
+
+```css
+:root {
+  --color-bg: #FFFFFF;
+  --color-surface: #F7F7F8;
+  --color-border: #E4E4E7;
+  --color-primary: #625DF5;
+  --color-primary-hover: #5048E5;
+  --color-text: #1F1F23;
+  --color-text-secondary: #6B6D76;
+  --color-text-tertiary: #9B9CA3;
+  --color-error: #D64770;
+  --color-recording: #EF440C;
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  --shadow-card: 0 1px 3px rgba(31, 31, 35, 0.08), 0 4px 12px rgba(31, 31, 35, 0.04);
+  --shadow-card-hover: 0 4px 12px rgba(31, 31, 35, 0.12), 0 8px 24px rgba(31, 31, 35, 0.08);
+  --shadow-overlay: 0 8px 32px rgba(31, 31, 35, 0.16), 0 2px 8px rgba(31, 31, 35, 0.08);
+  --shadow-tooltip: 0 4px 12px rgba(31, 31, 35, 0.12);
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --transition-base: 200ms ease-out;
+  --transition-fast: 100ms ease-out;
+}
+```
+
+## 3. Typography Rules
+
+| Role | Size | Weight | Line Height |
+|------|------|--------|-------------|
+| Display | 28px | 700 | 1.2 |
+| H1 | 22px | 600 | 1.3 |
+| H2 | 18px | 600 | 1.4 |
+| Body | 14px | 400 | 1.5 |
+| Body Small | 13px | 400 | 1.5 |
+| Caption | 12px | 400 | 1.4 |
+| Button | 14px | 500 | 1.2 |
+| Micro | 11px | 500 | 1.2 |
+
+**Font labels for catalog extraction:**
+
+```
+Display: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+H1: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+H2: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+Body: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+Body Small: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+Caption: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+Button: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+Micro: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+Mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace
+```
+
+## 4. Component Stylings
+
+### Video Thumbnail Card
+
+```css
+.thumbnail-card {
+  background: var(--color-bg);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
+  overflow: hidden;
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.thumbnail-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-card-hover);
+}
+
+.thumbnail-card:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+```
+
+### Recording Indicator
+
+```css
+@keyframes recording-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+.recording-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--color-recording);
+  animation: recording-pulse 1.5s ease-in-out infinite;
+}
+```
+
+### Input Field
+
+```css
+.input-field {
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 8px 12px;
+  font-size: 14px;
+  line-height: 1.4;
+  min-height: 44px;
+  min-width: 44px;
+  color: var(--color-text);
+}
+
+.input-field:focus-visible {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(98, 93, 245, 0.15);
+}
+```
+
+### Button Primary
+
+```css
+.btn-primary {
+  background: var(--color-primary);
+  color: #FFFFFF;
+  border-radius: var(--radius-md);
+  padding: 10px 20px;
+  font-size: 14px;
+  font-weight: 500;
+  transition: background var(--transition-fast);
+}
+.btn-primary:hover {
+  background: var(--color-primary-hover);
+}
+```
+
+## 5. Layout Principles
+
+Video-first layout. The video thumbnail dominates; metadata and actions cluster below. Clean horizontal rhythm with consistent 16px gaps between elements. Cards use 8px radius for a friendly but professional feel.
+
+## 6. Depth & Elevation
+
+Elevation is achieved through shadows only. `--shadow-card` for resting state, `--shadow-card-hover` for interactive lift, `--shadow-overlay` for modals and tooltips. No borders on cards — shadow conveys depth.
+
+## 7. Do's and Don'ts
+
+- Do not use Tertiary `#9B9CA3` for body text — timestamps and metadata only
+- Do not use semantic colors directly as text — always pair with a sufficiently contrasting background
+- Do not mix button variants in a single CSS block — use separate selectors
+- Do not use `line-height: 1.0` on buttons — diacritics, emoji, and CJK glyphs clip; use `1.2` minimum
+- Do not use `#D64770` (Error) for small text under 18px on white — it is 4.2:1, below the 4.5:1 AA threshold for normal text (14px). Use `#D64770` only for large text (18px+) or pair with a darker background surface
+- Do not use white text on `#D64770` background for normal text — white on #D64770 is also 4.2:1 (fails AA). Use `#FDECEE` (light pink) background with dark red text instead
+
+## 8. Responsive Behavior
+
+Video-first responsive layout. At narrower breakpoints, the video thumbnail stacks above metadata and actions. At ≥768px, a side-by-side layout (video left, actions right) activates. Touch targets minimum 44×44px at all breakpoints.
+
+## 9. Agent Prompt Guide
+
+When generating a Loom-style interface, prompt the model to:
+- Use Inter for all UI text; ui-monospace for code snippets
+- Apply `--radius-lg` (8px) to cards, `--radius-md` (6px) to buttons, `--radius-sm` (4px) to inputs
+- Use 200ms ease-out for card hover transitions, 100ms for button press
+- Include a recording indicator dot with a 1.5s pulse animation
+- Primary color `#625DF5` for all CTAs and active states
+- Ensure secondary text (#6B6D76) passes 4.5:1 on white before use; tertiary text (#9B9CA3) is for timestamps/metadata only

--- a/plugins/_official/design-systems/loom/open-design.json
+++ b/plugins/_official/design-systems/loom/open-design.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "design-system-loom",
+  "title": "Loom",
+  "title_i18n": {
+    "zh-CN": "Loom",
+    "zh-TW": "Loom",
+    "ja": "Loom",
+    "ko": "Loom",
+    "de": "Loom",
+    "fr": "Loom",
+    "ru": "Loom",
+    "es": "Loom",
+    "pt-BR": "Loom",
+    "it": "Loom",
+    "vi": "Loom",
+    "pl": "Loom",
+    "id": "Loom",
+    "nl": "Loom",
+    "ar": "Loom",
+    "tr": "Loom",
+    "uk": "Loom",
+    "en": "Loom"
+  },
+  "version": "0.1.0",
+  "publishedAt": "2026-08-04T09:00:00Z",
+  "description": "Async video communication. Purple primary, friendly surfaces, video-first layout.",
+  "description_i18n": {
+    "zh-CN": "异步视频沟通。紫色主色、友好表面、视频优先布局。",
+    "zh-TW": "非同步影片溝通。紫色主色、友善表面、影片優先版面。",
+    "ja": "非同期ビデオコミュニケーション。紫のプライマリ、親しみやすい面、ビデオファーストのレイアウト。",
+    "ko": "비동기 비디오 커뮤니케이션. 보라색 프라이머리, 친근한 표면, 비디오 우선 레이아웃.",
+    "de": "Asynchrone Videokommunikation. Lila Primärfarbe, freundliche Flächen, Video-first-Layout.",
+    "fr": "Communication vidéo asynchrone. Primaire violet, surfaces amicales, mise en page video-first.",
+    "ru": "Асинхронная видеосвязь. Фиолетовый primary, дружелюбные поверхности, video-first раскладка.",
+    "es": "Comunicación de vídeo asíncrona. Primario púrpura, superficies amables, layout video-first.",
+    "pt-BR": "Comunicação de vídeo assíncrona. Primária roxa, superfícies amigáveis, layout video-first.",
+    "it": "Comunicazione video asincrona. Primario viola, superfici amichevoli, layout video-first.",
+    "vi": "Giao tiếp video bất đồng bộ. Màu tím chủ đạo, bề mặt thân thiện, bố cục ưu tiên video.",
+    "pl": "Asynchroniczna komunikacja wideo. Fioletowa barwa główna, przyjazne powierzchnie, układ video-first.",
+    "id": "Komunikasi video async. Primer ungu, permukaan ramah, tata letak video-first.",
+    "nl": "Asynchrone videocommunicatie. Paarse primary, vriendelijke vlakken, video-first layout.",
+    "ar": "تواصل فيديو غير متزامن. أساسي بنفسجي، أسطح ودّية، تخطيط يضع الفيديو أولاً.",
+    "tr": "Eşzamansız video iletişimi. Mor birincil renk, samimi yüzeyler, video-öncelikli düzen.",
+    "uk": "Асинхронна відеокомунікація. Фіолетовий primary, дружні поверхні, video-first компонування.",
+    "en": "Async video communication. Purple primary, friendly surfaces, video-first layout."
+  },
+  "license": "MIT",
+  "tags": [
+    "design-system",
+    "first-party",
+    "design",
+    "themed-unique"
+  ],
+  "od": {
+    "kind": "scenario",
+    "taskKind": "new-generation",
+    "mode": "design-system",
+    "scenario": "design",
+    "surface": "web",
+    "useCase": {
+      "query": {
+        "en": "Generate a {{artifactKind}} using the Loom design system. Stay faithful to its colour palette, typography, spacing, iconography, and component vocabulary as documented in DESIGN.md.",
+        "zh-CN": "使用这个插件完成以下任务：Generate a {{artifactKind}} using the Loom design system. Stay faithful to its colour palette, typography, spacing, iconography, and component vocabulary as documented in DESIGN.md."
+      }
+    },
+    "inputs": [
+      {
+        "name": "artifactKind",
+        "label": "Artifact kind",
+        "type": "select",
+        "options": [
+          "landing page",
+          "dashboard",
+          "marketing site",
+          "app screen"
+        ],
+        "default": "landing page"
+      },
+      {
+        "name": "brief",
+        "label": "Brief",
+        "type": "text",
+        "placeholder": "What should the page communicate?"
+      }
+    ],
+    "context": {
+      "designSystem": {
+        "ref": "loom",
+        "primary": true
+      },
+      "assets": [
+        "./DESIGN.md"
+      ]
+    },
+    "pipeline": {
+      "stages": [
+        {
+          "id": "generate",
+          "atoms": [
+            "file-write",
+            "live-artifact"
+          ]
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject",
+      "fs:write"
+    ]
+  }
+}

--- a/plugins/_official/design-systems/slack/DESIGN.md
+++ b/plugins/_official/design-systems/slack/DESIGN.md
@@ -1,0 +1,363 @@
+# Design System Inspired by Slack
+
+> Category: Productivity & SaaS
+> Workplace communication platform. Aubergine-primary, multi-accent logo palette, light surfaces with dark sidebar, warm and approachable.
+
+## 1. Visual Theme & Atmosphere
+
+Slack's identity is built around the idea that work should feel human and even a little fun. The canonical surface is **light** — white content areas with a deep aubergine (`#4A154B`) sidebar — the inverse of dark-first tools. This contrast is intentional: the sidebar is a calm, always-present navigation anchor, while the content area is bright and open.
+
+The logo palette — blue, green, yellow, red — appears primarily in the hashtag icon and marketing contexts, not scattered through the UI. In the product itself, Slack uses a restrained, professional color system with aubergine as the sole brand anchor.
+
+**Key Characteristics:**
+- Light-first content surfaces: white `#FFFFFF` and near-white `#F8F8F8`
+- Deep aubergine `#4A154B` sidebar — the brand's most recognizable UI element
+- Four logo accent colors (blue, green, yellow, red) used sparingly as highlights only
+- Larsseit for headings (marketing), system sans-serif for UI
+- Rounded but not cartoonish: 4–8px radius on most components
+- Dense but breathable: compact message rows with clear thread hierarchy
+- Warm and conversational tone — emojis, reactions, and illustrations are first-class
+
+---
+
+## 2. Color Palette & Roles
+
+### Brand Primary
+| Token | Hex | Role |
+|---|---|---|
+| `--color-aubergine` | `#4A154B` | Sidebar background, primary brand color |
+| `--color-aubergine-dark` | `#350d36` | Hover states on aubergine surfaces |
+| `--color-aubergine-light` | `#611f69` | Active item highlight in sidebar |
+
+### Logo Accent Colors (use sparingly — highlights, icons, marketing only)
+| Token | Hex | Name | Role |
+|---|---|---|---|
+| `--color-blue` | `#36C5F0` | Sky Blue | Channel icons, links, info states |
+| `--color-green` | `#2EB67D` | Teal Green | Online status, success states |
+| `--color-yellow` | `#ECB22E` | Gold | Away status, warnings, highlights |
+| `--color-red` | `#E01E5A` | Ruby | Notifications, errors, mentions badge |
+
+### Surface & Background
+| Token | Hex | Role |
+|---|---|---|
+| `--bg-primary` | `#FFFFFF` | Main message area, modals |
+| `--bg-secondary` | `#F8F8F8` | Thread panels, secondary surfaces |
+| `--bg-tertiary` | `#F1F1F1` | Input backgrounds, hover states |
+| `--bg-sidebar` | `#4A154B` | Left sidebar (aubergine) |
+| `--bg-sidebar-hover` | `rgba(255,255,255,0.1)` | Sidebar item hover |
+| `--bg-sidebar-active` | `rgba(255,255,255,0.2)` | Active sidebar item |
+| `--bg-message-hover` | `#F8F8F8` | Message row hover |
+
+### Text Colors
+| Token | Hex | Role |
+|---|---|---|
+| `--text-primary` | `#1D1C1D` | Primary body text (near-black) |
+| `--text-secondary` | `#616061` | Timestamps, muted labels |
+| `--text-sidebar` | `rgba(255,255,255,0.9)` | Sidebar channel names |
+| `--text-sidebar-muted` | `rgba(255,255,255,0.6)` | Sidebar inactive items |
+| `--text-link` | `#1264A3` | Inline links in messages |
+| `--text-mention` | `#1264A3` | @mention text color |
+
+### Semantic Colors
+| Token | Hex | Role |
+|---|---|---|
+| `--color-success` | `#2EB67D` | Success toasts, positive states |
+| `--color-warning` | `#ECB22E` | Warning states |
+| `--color-danger` | `#E01E5A` | Error states, destructive actions |
+| `--color-info` | `#36C5F0` | Informational highlights |
+
+### Border & Divider
+| Token | Hex | Role |
+|---|---|---|
+| `--border-default` | `#DDDDDD` | Standard dividers, card borders |
+| `--border-subtle` | `#F1F1F1` | Subtle separators between rows |
+| `--border-focus` | `#1264A3` | Focus ring color |
+
+---
+
+## 3. Typography Rules
+
+### Typefaces
+| Role | Official | Web Fallback |
+|---|---|---|
+| Display / Marketing Headings | Larsseit | `'Larsseit', 'Helvetica Neue', Arial, sans-serif` |
+| UI / Body / Chrome | Slack Lato (custom) | `system-ui, -apple-system, BlinkMacSystemFont, sans-serif` |
+| Code / Monospace | — | `'Monaco', 'Menlo', 'Courier New', monospace` |
+
+> Slack uses **Larsseit** for marketing headlines and a custom Lato variant for in-product UI. For web use, `system-ui` is the safest fallback.
+
+### Type Scale
+
+| Level | Size | Weight | Line Height | Letter Spacing | Usage |
+|---|---|---|---|---|---|
+| Display XL | 48px | 800 | 1.1 | -1px | Marketing hero headlines |
+| Display L | 36px | 700 | 1.15 | -0.5px | Section heroes |
+| Heading 1 | 28px | 700 | 1.25 | normal | Modal titles, page headers |
+| Heading 2 | 22px | 700 | 1.3 | normal | Card titles, settings sections |
+| Heading 3 | 18px | 700 | 1.35 | normal | Sub-section headers |
+| Body L | 16px | 400 | 1.5 | normal | Message text, descriptions |
+| Body | 15px | 400 | 1.46667 | normal | Default UI text (Slack's base size) |
+| Body SM | 13px | 400 | 1.38462 | normal | Secondary metadata |
+| Caption | 12px | 400 | 1.33 | normal | Timestamps, hints |
+| Code | 12px | 400 | 1.5 | normal | Inline code, code blocks |
+
+### Type Rules
+- Slack's base body size is **15px** — slightly smaller than 16px for density
+- Unread channels: weight 700 — bold is the primary unread indicator
+- Timestamps: 12px `--text-secondary`, show on hover only
+- Code blocks: background `#F8F8F8`, border `1px solid #DDDDDD`, border-radius 4px
+- Never use font sizes below 12px
+- Marketing headings: letter-spacing `-1px` for large display sizes
+
+---
+
+## 4. Component Stylings
+
+### Buttons
+
+```css
+/* Primary */
+.btn-primary {
+  background: #4A154B;
+  color: #FFFFFF;
+  border-radius: 4px;
+  padding: 0 16px;
+  height: 36px;
+  font-size: 15px;
+  font-weight: 700;
+  border: none;
+}
+.btn-primary:hover { background: #611f69; }
+
+/* Secondary */
+.btn-secondary {
+  background: #FFFFFF;
+  color: #1D1C1D;
+  border: 1px solid #DDDDDD;
+  border-radius: 4px;
+  padding: 0 16px;
+  height: 36px;
+  font-size: 15px;
+  font-weight: 700;
+}
+.btn-secondary:hover { background: #F8F8F8; }
+
+/* Danger */
+.btn-danger {
+  background: #E01E5A;
+  color: #FFFFFF;
+  border-radius: 4px;
+}
+.btn-danger:hover { background: #B3114A; }
+```
+
+### Input Fields
+```css
+.input {
+  background: #FFFFFF;
+  border: 1px solid #DDDDDD;
+  border-radius: 4px;
+  color: #1D1C1D;
+  font-size: 15px;
+  padding: 8px 12px;
+  height: 36px;
+}
+.input:focus {
+  border-color: #1264A3;
+  box-shadow: 0 0 0 2px rgba(18,100,163,0.25);
+  outline: none;
+}
+```
+
+### Sidebar Channel Item
+```css
+.channel-item {
+  height: 28px;
+  padding: 0 16px;
+  border-radius: 6px;
+  color: rgba(255,255,255,0.7);
+  font-size: 15px;
+  font-weight: 400;
+}
+.channel-item:hover {
+  background: rgba(255,255,255,0.1);
+  color: #FFFFFF;
+}
+.channel-item.active {
+  background: rgba(255,255,255,0.2);
+  color: #FFFFFF;
+}
+.channel-item.unread {
+  color: #FFFFFF;
+  font-weight: 700;
+}
+```
+
+### Unread Badge
+```css
+.badge {
+  background: #E01E5A;
+  color: #FFFFFF;
+  border-radius: 8px;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 1px 6px;
+  min-width: 18px;
+}
+```
+
+### Message Attachments / Cards
+```css
+.attachment {
+  border-left: 4px solid #DDDDDD;
+  background: #F8F8F8;
+  border-radius: 0 4px 4px 0;
+  padding: 8px 12px;
+  margin: 4px 0;
+}
+```
+
+### Reactions
+```css
+.reaction {
+  border: 1px solid #DDDDDD;
+  border-radius: 24px;
+  background: #F8F8F8;
+  padding: 2px 8px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.reaction:hover { background: #F1F1F1; }
+.reaction.active {
+  background: rgba(18,100,163,0.1);
+  border-color: #1264A3;
+}
+```
+
+---
+
+## 5. Layout Principles
+
+### Three-Column Layout
+```
+┌──────────────┬──────────────────────────────┬─────────────┐
+│   Sidebar    │        Message Area          │   Thread    │
+│   (240px)    │          (flex: 1)           │  (400px)    │
+│  #4A154B     │          #FFFFFF             │  optional   │
+└──────────────┴──────────────────────────────┴─────────────┘
+```
+
+### Spacing System (4px base)
+| Token | Value | Usage |
+|---|---|---|
+| `--space-1` | 4px | Tight gaps |
+| `--space-2` | 8px | Component padding |
+| `--space-3` | 12px | Input padding |
+| `--space-4` | 16px | Standard padding |
+| `--space-6` | 24px | Card padding |
+| `--space-8` | 32px | Section gaps |
+
+### Sidebar Structure
+```
+[Workspace Name ▼]
+────────────────────
+Threads
+All DMs
+Drafts & Sent
+────────────────────
+▼ Channels
+  # general
+  # random
+  # design  ● (unread)
+────────────────────
+▼ Direct Messages
+  John Doe
+  Jane Smith
+```
+
+### Message Composer
+- Pinned to bottom of message area
+- `border: 1px solid #DDDDDD`, `border-radius: 8px`, `margin: 0 16px 16px`
+- Toolbar: emoji, attach, format, send button
+
+---
+
+## 6. Depth & Elevation
+
+Slack uses light shadows on a light surface:
+
+| Level | Usage | Shadow |
+|---|---|---|
+| Flat | Message rows, sidebar items | none |
+| Low | Cards, inputs | `0 1px 3px rgba(0,0,0,0.08)` |
+| Medium | Dropdowns, popovers | `0 4px 12px rgba(0,0,0,0.12)` |
+| High | Modals, dialogs | `0 8px 24px rgba(0,0,0,0.15)` |
+| Overlay | Modal backdrops | `rgba(0,0,0,0.5)` |
+
+---
+
+## 7. Do's and Don'ts
+
+### ✅ Do
+- Use aubergine `#4A154B` for the sidebar — it is Slack's most iconic UI element
+- Keep the main content area white and light
+- Use `#1D1C1D` (near-black) for all body text, not pure black
+- Bold channel names to show unread status — weight is the indicator
+- Use the four accent colors only for semantic roles (success, warning, danger, info)
+- Apply `border-left: 4px` on message attachments and embeds
+- Show timestamps on hover only
+- Use `#1264A3` for links and focus states
+- Keep sidebar items compact: 28px height, 6px border-radius
+
+### ❌ Don't
+- Don't use a dark main content area — Slack is light-first
+- Don't scatter blue/green/yellow/red as decorative accents
+- Don't use pure black `#000000` for text
+- Don't use speech bubbles — messages are flat rows
+- Don't make buttons large-radius — 4px is standard
+- Don't show timestamps permanently
+- Don't use ALL CAPS for channel names
+- Don't use font sizes below 12px
+
+---
+
+## 8. Responsive Behavior
+
+### Breakpoints
+| Breakpoint | Width | Layout |
+|---|---|---|
+| Mobile | < 768px | Single panel, sidebar as left drawer |
+| Tablet | 768–1024px | Sidebar + message area only |
+| Desktop | > 1024px | Full three-column layout |
+
+### Mobile Adaptations
+- Sidebar: left drawer, swipe right to open
+- Bottom tab bar: Home, DMs, Activity, You
+- Thread panel: full-screen overlay
+- Composer: pinned above keyboard
+- Channel list items: 44px touch target height
+- Aubergine top header bar retained on mobile
+
+---
+
+## 9. Agent Prompt Guide
+
+When generating Slack-styled designs, follow this approach:
+
+**Color application:**
+> Set `background: #FFFFFF` as the main canvas. Use `#4A154B` (aubergine) for the sidebar. All primary text is `#1D1C1D`. Links and focus rings use `#1264A3`. The four logo colors — `#36C5F0`, `#2EB67D`, `#ECB22E`, `#E01E5A` — are semantic only: info, success, warning, danger.
+
+**Typography:**
+> Use `system-ui, -apple-system, sans-serif` for all UI. Base size is 15px. Unread channels: weight 700. Body text: weight 400. Timestamps: 12px `#616061`, hover-only. Code: `Monaco, Menlo, monospace`, 12px, `#F8F8F8` background.
+
+**Layout:**
+> Three columns: 240px aubergine sidebar + flex white message area + optional 400px thread panel. Sidebar items: 28px height, 6px radius, bold when unread. Composer: pinned bottom, `border: 1px solid #DDDDDD`, `border-radius: 8px`.
+
+**Components:**
+> Buttons: 4px radius, 36px height, aubergine primary. Inputs: `1px solid #DDDDDD` border, `#1264A3` focus ring. Message rows: flat, no bubbles, 36px circle avatar. Reactions: pill `border: 1px solid #DDDDDD`, `border-radius: 24px`.
+
+**Tone:**
+> Slack is warm, professional, and human. Empty states use friendly illustrations. CTAs are direct: "Send message", "Get started". Error messages are clear and helpful. Never alarming.
+
+**Anti-patterns to avoid:**
+> No dark content area. No speech bubbles. No pure black text. No scattered multi-color accents. No ALL CAPS channel names. No font below 12px. No large button radius.

--- a/plugins/_official/design-systems/slack/open-design.json
+++ b/plugins/_official/design-systems/slack/open-design.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "design-system-slack",
+  "title": "Slack",
+  "title_i18n": {
+    "zh-CN": "Slack",
+    "zh-TW": "Slack",
+    "ja": "Slack",
+    "ko": "Slack",
+    "de": "Slack",
+    "fr": "Slack",
+    "ru": "Slack",
+    "es": "Slack",
+    "pt-BR": "Slack",
+    "it": "Slack",
+    "vi": "Slack",
+    "pl": "Slack",
+    "id": "Slack",
+    "nl": "Slack",
+    "ar": "Slack",
+    "tr": "Slack",
+    "uk": "Slack",
+    "en": "Slack"
+  },
+  "version": "0.1.0",
+  "publishedAt": "2026-08-04T09:00:00Z",
+  "description": "Workplace communication platform. Aubergine primary, multi-accent logo palette, warm approachable surfaces.",
+  "description_i18n": {
+    "zh-CN": "职场沟通平台。茄紫主色、多强调色 logo 调色板、温暖亲和的表面。",
+    "zh-TW": "職場溝通平台。茄紫主色、多強調色 logo 調色盤、溫暖親和的表面。",
+    "ja": "職場コミュニケーションプラットフォーム。オーベルジーヌのプライマリ、多アクセントのロゴパレット、温かく親しみやすい面。",
+    "ko": "직장 커뮤니케이션 플랫폼. 오베르진 프라이머리, 다중 액센트 로고 팔레트, 따뜻하고 친근한 표면.",
+    "de": "Workplace-Kommunikationsplattform. Aubergine als Primärfarbe, Multi-Akzent-Logo-Palette, warme zugängliche Flächen.",
+    "fr": "Plateforme de communication au travail. Primaire aubergine, palette logo multi-accents, surfaces chaleureuses et accessibles.",
+    "ru": "Платформа рабочей коммуникации. Primary цвета баклажана, многоакцентная палитра логотипа, тёплые дружелюбные поверхности.",
+    "es": "Plataforma de comunicación laboral. Primario berenjena, paleta de logo multiacento, superficies cálidas y cercanas.",
+    "pt-BR": "Plataforma de comunicação no trabalho. Primária berinjela, paleta de logo multiacento, superfícies quentes e acessíveis.",
+    "it": "Piattaforma di comunicazione sul lavoro. Primario aubergine, palette logo multi-accento, superfici calde e accessibili.",
+    "vi": "Nền tảng giao tiếp nơi làm việc. Màu chủ đạo aubergine, bảng màu logo đa điểm nhấn, bề mặt ấm và gần gũi.",
+    "pl": "Platforma komunikacji w pracy. Primary w kolorze bakłażana, wieloakcentowa paleta logo, ciepłe przystępne powierzchnie.",
+    "id": "Platform komunikasi tempat kerja. Primer aubergine, palet logo multi-aksen, permukaan hangat dan ramah.",
+    "nl": "Communicatieplatform voor op het werk. Aubergine primary, multi-accent logo-palet, warme toegankelijke vlakken.",
+    "ar": "منصة تواصل في مكان العمل. أساسي بلون الباذنجان، لوحة شعار متعددة اللمسات، أسطح دافئة وودودة.",
+    "tr": "İş yeri iletişim platformu. Patlıcan birincil renk, çok vurgulu logo paleti, sıcak ve yaklaşılabilir yüzeyler.",
+    "uk": "Платформа робочої комунікації. Primary кольору баклажана, багатоакцентна палітра логотипу, теплі привітні поверхні.",
+    "en": "Workplace communication platform. Aubergine primary, multi-accent logo palette, warm approachable surfaces."
+  },
+  "license": "MIT",
+  "tags": [
+    "design-system",
+    "first-party",
+    "design",
+    "productivity-saas"
+  ],
+  "od": {
+    "kind": "scenario",
+    "taskKind": "new-generation",
+    "mode": "design-system",
+    "scenario": "design",
+    "surface": "web",
+    "useCase": {
+      "query": {
+        "en": "Generate a {{artifactKind}} using the Slack design system. Stay faithful to its colour palette, typography, spacing, iconography, and component vocabulary as documented in DESIGN.md.",
+        "zh-CN": "使用这个插件完成以下任务：Generate a {{artifactKind}} using the Slack design system. Stay faithful to its colour palette, typography, spacing, iconography, and component vocabulary as documented in DESIGN.md."
+      }
+    },
+    "inputs": [
+      {
+        "name": "artifactKind",
+        "label": "Artifact kind",
+        "type": "select",
+        "options": [
+          "landing page",
+          "dashboard",
+          "marketing site",
+          "app screen"
+        ],
+        "default": "landing page"
+      },
+      {
+        "name": "brief",
+        "label": "Brief",
+        "type": "text",
+        "placeholder": "What should the page communicate?"
+      }
+    ],
+    "context": {
+      "designSystem": {
+        "ref": "slack",
+        "primary": true
+      },
+      "assets": [
+        "./DESIGN.md"
+      ]
+    },
+    "pipeline": {
+      "stages": [
+        {
+          "id": "generate",
+          "atoms": [
+            "file-write",
+            "live-artifact"
+          ]
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject",
+      "fs:write"
+    ]
+  }
+}

--- a/plugins/_official/design-systems/tom-modern/DESIGN.md
+++ b/plugins/_official/design-systems/tom-modern/DESIGN.md
@@ -1,0 +1,361 @@
+# Tom Modern Design
+
+> Category: Starter
+> Editorial-technical design system. Neutral canvas, single vermillion accent, sharp corners, Geist typography, hard shadows, structured composition.
+
+## 1. Visual Theme & Atmosphere
+
+Tom Modern Design is an editorial-technical design family: structured, sharp, restrained, premium, intentional, anti-generic. It reads like a deliberate design — not a mass-generated startup template.
+
+The system sits on a near-white neutral canvas (`#fafafa`) with deep ink text (`#27272a`). One primary accent — vermillion (`#ff5a00`) — carries all interactive emphasis. Typography is Geist Sans for body and Geist Mono for labels, metadata, and technical notes. Every corner is sharp (0px radius). Shadows are hard-offset, never soft.
+
+Atmosphere comes from a subtle 30px grid overlay on the page background, structural lines, and the contrast between quiet white zones and dense information bands. The design avoids decorative noise — no blobs, no gradients, no glow effects.
+
+**Key signals:**
+- Neutral near-white canvas with strong ink contrast
+- Single vermillion accent reserved for CTAs, links, and highlights
+- Sharp 0px corners throughout — rectangular silhouette is the brand
+- Hard offset shadows (`8px 8px 0`) for elevation
+- Geist Sans/Mono typography with strong hierarchy
+- Editorial split layouts with asymmetric composition
+- Uppercase compact labels for eyebrows and metadata
+
+**Anti-patterns to avoid:**
+- Generic centered startup heroes
+- Purple gradients by default
+- Rounded cards and buttons
+- Beige or cream backgrounds
+- Blob-based decorative elements
+- Repetitive identical card grids
+
+## 2. Color Palette & Roles
+
+### Primary
+
+| Token | Hex | Role |
+|---|---|---|
+| `--accent` | `#ff5a00` | Primary accent — CTAs, links, interactive highlights, accent words |
+
+### Surfaces
+
+| Token | Hex | Role |
+|---|---|---|
+| `--bg` | `#fafafa` | Page background — neutral near-white, never warm |
+| `--surface` | `#ffffff` | Card and panel surfaces |
+| `--surface-warm` | `var(--surface)` | Alternate surface for section rhythm (aliases to surface) |
+
+### Text
+
+| Token | Hex | Role |
+|---|---|---|
+| `--fg` | `#27272a` | Primary text — headlines, body, buttons |
+| `--fg-2` | `#52525b` | Secondary text — descriptions, lead paragraphs |
+| `--muted` | `#71717a` | Muted text — captions, labels, metadata |
+
+### Borders
+
+| Token | Hex | Role |
+|---|---|---|
+| `--border` | `#969696` | Primary borders — card outlines, structural lines |
+| `--border-soft` | `#d4d4d8` | Muted borders — subtle separators |
+
+### Shadows (brand-specific)
+
+| Token | Value | Role |
+|---|---|---|
+| `--tm-shadow-hard` | `8px 8px 0 rgba(150,150,150,0.12)` | Hard offset shadow — hover states, emphasis |
+| `--tm-shadow-soft` | `4px 4px 0 rgba(150,150,150,0.1)` | Soft offset shadow — default card state |
+
+### Code Window (brand-specific)
+
+| Token | Hex | Role |
+|---|---|---|
+| `--tm-code-bg` | `#111517` | Code window background |
+| `--tm-code-panel` | `#151a1d` | Code window header |
+| `--tm-code-text` | `#d8dee9` | Code text |
+
+### Background Pattern
+
+The page background uses a 30px grid:
+```css
+background-image:
+    linear-gradient(rgba(150, 150, 150, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(150, 150, 150, 0.04) 1px, transparent 1px);
+background-size: 30px 30px;
+```
+
+## 3. Typography Rules
+
+### Font Families
+
+- **Primary:** Geist Sans — body, headlines, buttons, navigation
+- **Mono:** Geist Mono — labels, metadata, code, technical notes
+
+### Hierarchy
+
+| Token | Size | Weight | Line Height | Letter Spacing | Use |
+|---|---|---|---|---|---|
+| Display | `clamp(2.3rem, 5vw, 4.8rem)` | 700 | 0.96 | -0.04em | Hero headlines |
+| Section | `clamp(21px, 2vw, 25px)` | 700 | 1.15 | -0.03em | Section titles |
+| Card | 18px | 700 | 1.38 | -0.03em | Card titles |
+| Body | 14px | 400 | 1.6 | 0 | Body text |
+| Caption | 12px | 400 | 1.4 | 0 | Captions, fine print |
+| Eyebrow | 12px | 700 | 1 | 0.14em | Uppercase labels |
+| Button | 13px | 700 | 1 | 0.08em | Button labels |
+| Mono | 12px | 700 | 1 | 0.14em | Technical labels |
+
+### Principles
+
+- **Geist Sans** runs across every surface — display, body, UI, buttons
+- **Geist Mono** is reserved for labels, metadata, code, and technical microcopy
+- Display headlines use weight 700 with tight line-height (0.96–1.15)
+- Body text uses weight 400 with generous line-height (1.6)
+- Uppercase labels use 0.14em letter-spacing for the "machined" feel
+- One accent word per headline: `<span class="title-highlight">word</span>`
+
+### Font Substitutes
+
+If Geist is unavailable:
+- **Inter** at weights 400/500/600/700 — slightly narrower; bump font-size by ~3%
+- **Manrope** at weights 400/500/600/700 — closer proportion, gentler curves
+- **IBM Plex Sans** at weights 400/500/600/700 — wider, more mechanical feel
+
+## 4. Component Stylings
+
+### Buttons
+
+- **Primary:** Dark fill (`--fg`), white text, 0px radius, hard shadow on hover
+- **Secondary:** Transparent, dark text, 1px border, white fill on hover
+- **Block:** Full-width variant of any button
+
+### Cards
+
+- **Frame:** White surface, 1px border, soft shadow
+- **Panel:** White surface, 1px border, hard shadow, accent top-border (4px)
+- **Feature card:** 2-column grid with optional full-width variant
+- **Feature 3-card:** 3-column grid with icon headers
+
+### Navigation
+
+- **Header:** Sticky, blurred background (`rgba(250,250,250,0.88)`), 1px bottom border
+- **Nav links:** Geist Sans, secondary text color
+- **CTA button:** Dark fill, same as primary button
+
+### Forms
+
+- **Input:** White background, 1px border, 44px height, accent border on focus
+- **Textarea:** Same as input, resizable
+- **Label:** Mono font, uppercase, muted color
+
+### Premium Components
+
+- **Token Card:** Dark gradient (`#14192B` → `#1B2A3D` → `#11393A`), holographic sheen animation, mono typography, perforation line with circular cutouts
+- **Code Window:** Dark background (`#111517`), macOS-style traffic light dots, atmospheric gradient overlay, 7 syntax highlighting tokens
+
+### Tabs
+
+- **Tab nav:** Horizontal, mono font, uppercase, accent bottom-border on active
+- **Tab panel:** Hidden by default, shown with `.is-active` class
+
+### FAQ
+
+- **Item:** Frame with expandable answer
+- **Question:** Full-width button, plus/minus icon
+- **Answer:** Hidden by default, shown when `.is-open`
+
+## 5. Layout Principles
+
+### Container
+
+- Max width: 1240px
+- Padding: `min(100% - 40px, 1240px)`
+- Centered with `margin: 0 auto`
+
+### Section
+
+- Vertical padding: 96px
+- Alternate sections use `rgba(255,255,255,0.72)` background with 1px borders
+
+### Grid System
+
+- **Hero:** 2-column split (0.92fr / 1.08fr) with 42px gap
+- **Feature grid:** 2-column with optional full-width cards
+- **Feature 3-col:** 3-column with icon headers
+- **Updates/Pain:** 3-column grid
+- **Pricing/Contact:** 2-column split
+- **Footer:** 3-column (2fr / 1fr / 1fr)
+
+### Section Rhythm
+
+Sections alternate between:
+1. White background (`--bg`)
+2. Alternate surface (`rgba(255,255,255,0.72)` with borders)
+
+This creates visual rhythm without color changes.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|---|---|---|
+| 0 — Flat | No shadow, no border | Body text, section backgrounds |
+| 1 — Border | 1px `--border` border | Cards, panels, inputs |
+| 2 — Soft shadow | `4px 4px 0 rgba(150,150,150,0.1)` | Default card state |
+| 3 — Hard shadow | `8px 8px 0 rgba(150,150,150,0.12)` | Hover states, emphasis |
+| 4 — Code shadow | `0 28px 90px rgba(22,22,22,0.14)` | Code window only |
+
+The system uses **color contrast** (surface vs. background) rather than shadow depth for hierarchy. Shadows are reserved for interactive feedback and premium components.
+
+## 7. Do's and Don'ts
+
+### Do
+
+- Use `{colors.primary}` for CTAs, links, and interactive highlights — keep it reserved
+- Set display headlines in Geist Sans at weight 700 with tight line-height
+- Keep body copy at weight 400 — the contrast between heavy display and light body is the typographic signature
+- Use `{rounded.none}` (0px) by default — the sharp rectangular silhouette IS the brand
+- Align spacing to `{spacing.section}` (96px) between major bands
+- Frame product photography inside `{rounded.xl}` containers
+- Set button labels in uppercase with 0.08em letter-spacing
+- Use hard shadows for hover effects, soft shadows for default state
+- Use `{typography.button}` for all button labels
+
+### Don't
+
+- Don't introduce accent colors outside the detected palette — the system is closed by design
+- Don't bold body type — body stays at weight 400
+- Don't add soft drop-shadows or atmospheric gradients — the brand uses hard borders and flat fills
+- Don't round buttons above `{rounded.sm}` — a soft button reads as a different brand
+- Don't use beige or cream backgrounds — the canvas must be neutral (`#fafafa`)
+- Don't use decorative motion everywhere — animation must be purposeful
+- Don't drop ink text opacity to create hierarchy — switch surface or shift to `{colors.muted}`
+- Don't use multiple accent words in one heading — one per section maximum
+
+## 8. Responsive Behavior
+
+### Breakpoints
+
+| Name | Width | Key Changes |
+|---|---|---|
+| Mobile | < 560px | Single column, compact padding (24px), smaller type |
+| Tablet | 560–980px | 2-column grids, stacked hero |
+| Desktop | > 980px | Full layout, 1240px max-width |
+
+### Touch Targets
+
+- Minimum 44×44px for all interactive elements
+- Buttons: 44px height + 24px horizontal padding
+- Nav links: extend tap area to full row height
+
+### Collapsing Strategy
+
+- **Hero:** Stacks to single column below 980px
+- **Feature grids:** 2-col → 1-col below 980px
+- **3-col grids:** 3-col → 2-col → 1-col
+- **Footer:** 3-col → 2-col → 1-col
+- **Navigation:** Hamburger menu on mobile (not included in CSS — implement per project)
+
+### Image Behavior
+
+- Hero photography fills full width
+- Product thumbnails maintain aspect ratio
+- Lifestyle photography uses horizontal cropping on mobile
+
+## 9. Agent Prompt Guide
+
+### Quick Color Reference
+
+```
+Background:  #fafafa (neutral near-white)
+Surface:     #ffffff (pure white)
+Text:        #27272a (near-black)
+Secondary:   #52525b
+Muted:       #71717a
+Accent:      #ff5a00 (vermillion)
+Border:      #969696
+Border-muted: #d4d4d8
+```
+
+### Ready-to-Use Prompt
+
+```
+Create a landing page in Tom Modern Design style:
+
+- Background: #fafafa with 30px grid overlay
+- Typography: Geist Sans for body, Geist Mono for labels
+- Colors: #27272a text, #ff5a00 accent, #ffffff surfaces
+- Corners: 0px (sharp, never rounded)
+- Shadows: 8px 8px 0 rgba(150,150,150,0.12) on hover
+- Layout: split hero, 2-col feature grid, structured sections
+- Buttons: uppercase, 0.08em letter-spacing, dark fill primary
+- Cards: white surface, 1px border, soft shadow
+- Sections: alternate between white and rgba(255,255,255,0.72)
+- One accent word per headline using <span class="title-highlight">
+- Eyebrows: uppercase mono labels above section titles
+```
+
+### Required Font Loading
+
+When generating HTML with Tom Modern, load Geist explicitly. `tokens.css`
+declares the `Geist Sans` and `Geist Mono` family names, but generated
+artifacts do not automatically inherit the `@font-face` block from
+`components.html`.
+
+Use this loader before any generated CSS that references `--font-display`,
+`--font-body`, or `--font-mono`:
+
+```css
+@font-face {
+    font-family: 'Geist Sans';
+    src: url('https://cdn.jsdelivr.net/npm/geist@1.7.2/dist/fonts/geist-sans/Geist-Variable.woff2') format('woff2');
+    font-weight: 100 900;
+    font-display: swap;
+}
+
+@font-face {
+    font-family: 'Geist Mono';
+    src: url('https://cdn.jsdelivr.net/npm/geist@1.7.2/dist/fonts/geist-mono/GeistMono-Variable.woff2') format('woff2');
+    font-weight: 100 900;
+    font-display: swap;
+}
+```
+
+If the host project can self-serve fonts, prefer bundling equivalent local
+woff2 files under `fonts/` while keeping the same family names.
+
+### Component Classes
+
+```css
+/* Layout */
+.container          /* max-width 1240px, centered */
+.section            /* 96px vertical padding */
+.section-alt        /* alternate background */
+.frame              /* card with border + shadow */
+
+/* Typography */
+.eyebrow            /* uppercase mono label */
+.title-highlight    /* accent-colored text */
+.section-head       /* section header */
+
+/* Buttons */
+.button             /* base button */
+.button-primary     /* dark filled */
+.button-secondary   /* transparent outlined */
+.button-block       /* full-width */
+
+/* Hero */
+.hero-grid          /* 2-col layout */
+.hero-lead          /* lead paragraph */
+.hero-actions       /* button group */
+
+/* Features */
+.feature-grid       /* 2-col with wide cards */
+.feature-3col       /* 3-col with icons */
+
+/* Interactive */
+.tab-shell          /* tab container */
+.faq-item           /* accordion item */
+
+/* Premium */
+.key-card           /* dark gradient with sheen */
+.tm-code-window     /* code editor display */
+```

--- a/plugins/_official/design-systems/tom-modern/open-design.json
+++ b/plugins/_official/design-systems/tom-modern/open-design.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "design-system-tom-modern",
+  "title": "Tom Modern",
+  "title_i18n": {
+    "zh-CN": "Tom Modern",
+    "zh-TW": "Tom Modern",
+    "ja": "Tom Modern",
+    "ko": "Tom Modern",
+    "de": "Tom Modern",
+    "fr": "Tom Modern",
+    "ru": "Tom Modern",
+    "es": "Tom Modern",
+    "pt-BR": "Tom Modern",
+    "it": "Tom Modern",
+    "vi": "Tom Modern",
+    "pl": "Tom Modern",
+    "id": "Tom Modern",
+    "nl": "Tom Modern",
+    "ar": "Tom Modern",
+    "tr": "Tom Modern",
+    "uk": "Tom Modern",
+    "en": "Tom Modern"
+  },
+  "version": "0.1.0",
+  "publishedAt": "2026-08-04T09:00:00Z",
+  "description": "Editorial-technical starter. Neutral canvas, vermillion accent, sharp corners, Geist type, hard shadows.",
+  "description_i18n": {
+    "zh-CN": "编辑向技术 starter。中性画布、朱红强调、锐角、Geist 字体、硬阴影。",
+    "zh-TW": "編輯向技術 starter。中性畫布、朱紅強調、銳角、Geist 字體、硬陰影。",
+    "ja": "編集的・技術的なスターター。ニュートラルなキャンバス、朱色のアクセント、シャープな角、Geist書体、ハードシャドウ。",
+    "ko": "에디토리얼-테크니컬 스타터. 중립 캔버스, 주홍 액센트, 날카로운 모서리, Geist 타이포, 하드 섀도.",
+    "de": "Editorial-technischer Starter. Neutrale Leinwand, Zinnober-Akzent, scharfe Ecken, Geist-Typo, harte Schatten.",
+    "fr": "Starter éditorial-technique. Toile neutre, accent vermillon, coins nets, typo Geist, ombres dures.",
+    "ru": "Редакционно-технический starter. Нейтральный холст, киноварный акцент, острые углы, шрифт Geist, жёсткие тени.",
+    "es": "Starter editorial-técnico. Lienzo neutro, acento bermellón, esquinas nítidas, tipografía Geist, sombras duras.",
+    "pt-BR": "Starter editorial-técnico. Tela neutra, acento vermelhão, cantos nítidos, tipo Geist, sombras duras.",
+    "it": "Starter editoriale-tecnico. Tela neutra, accento vermiglio, angoli netti, type Geist, ombre dure.",
+    "vi": "Starter biên tập-kỹ thuật. Nền trung tính, điểm nhấn đỏ son, góc sắc, chữ Geist, bóng cứng.",
+    "pl": "Starter editorialno-techniczny. Neutralne płótno, cynobrowy akcent, ostre narożniki, krój Geist, twarde cienie.",
+    "id": "Starter editorial-teknis. Kanvas netral, aksen vermilion, sudut tajam, tipografi Geist, bayangan keras.",
+    "nl": "Editorial-technische starter. Neutraal canvas, vermiljoen accent, scherpe hoeken, Geist-type, harde schaduwen.",
+    "ar": "نظام بداية تحريري-تقني. لوحة محايدة، لمسة قرمزية، زوايا حادة، خط Geist، ظلال قاسية.",
+    "tr": "Editöryal-teknik başlangıç sistemi. Nötr tuval, vermilyon vurgu, keskin köşeler, Geist yazı tipi, sert gölgeler.",
+    "uk": "Редакційно-технічний starter. Нейтральне полотно, кіноварний акцент, гострі кути, шрифт Geist, жорсткі тіні.",
+    "en": "Editorial-technical starter. Neutral canvas, vermillion accent, sharp corners, Geist type, hard shadows."
+  },
+  "license": "MIT",
+  "tags": [
+    "design-system",
+    "first-party",
+    "design",
+    "starter"
+  ],
+  "od": {
+    "kind": "scenario",
+    "taskKind": "new-generation",
+    "mode": "design-system",
+    "scenario": "design",
+    "surface": "web",
+    "useCase": {
+      "query": {
+        "en": "Generate a {{artifactKind}} using the Tom Modern design system. Stay faithful to its colour palette, typography, spacing, iconography, and component vocabulary as documented in DESIGN.md.",
+        "zh-CN": "使用这个插件完成以下任务：Generate a {{artifactKind}} using the Tom Modern design system. Stay faithful to its colour palette, typography, spacing, iconography, and component vocabulary as documented in DESIGN.md."
+      }
+    },
+    "inputs": [
+      {
+        "name": "artifactKind",
+        "label": "Artifact kind",
+        "type": "select",
+        "options": [
+          "landing page",
+          "dashboard",
+          "marketing site",
+          "app screen"
+        ],
+        "default": "landing page"
+      },
+      {
+        "name": "brief",
+        "label": "Brief",
+        "type": "text",
+        "placeholder": "What should the page communicate?"
+      }
+    ],
+    "context": {
+      "designSystem": {
+        "ref": "tom-modern",
+        "primary": true
+      },
+      "assets": [
+        "./DESIGN.md"
+      ]
+    },
+    "pipeline": {
+      "stages": [
+        {
+          "id": "generate",
+          "atoms": [
+            "file-write",
+            "live-artifact"
+          ]
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject",
+      "fs:write"
+    ]
+  }
+}

--- a/plugins/_official/design-systems/trading-terminal/DESIGN.md
+++ b/plugins/_official/design-systems/trading-terminal/DESIGN.md
@@ -1,0 +1,178 @@
+# Trading Terminal Design System
+
+> Category: Themed & Unique
+> Bloomberg-style financial trading terminal. Dark-only, data-dense, cyan/coral buy/sell signals. Everything readable at a glance from two meters away.
+
+## 1. Visual Theme & Atmosphere
+
+A professional-grade financial data terminal. Dense, information-rich layouts designed for traders who need to monitor multiple markets simultaneously. Dark surfaces reduce eye strain during long sessions. Cyan accent (#00D4AA) signals positive/buy, coral (#FF4757) signals negative/sell. Everything readable at a glance from two meters away.
+
+- **Visual style:** dense, data-first, professional
+- **Color stance:** dark surfaces with high-contrast data colors
+- **Design intent:** keep outputs recognizable to this style family while preserving usability and readability
+
+### Prior Art
+
+Bloomberg Terminal, Refinitiv Eikon, FactSet, TradingView Pro. All share: dark-only surfaces, monospace data fonts, tabular layouts with no decorative spacing, and color-coded buy/sell signals.
+
+## 2. Color Palette & Roles
+
+### Surface Palette
+
+| Token | Hex | Usage |
+|-------|-----|-------|
+| Background | `#0D0D0D` | Primary canvas |
+| Surface | `#141414` | Elevated panels, cards |
+| Surface Hover | `#1A1A1A` | Hover state for panels |
+| Border | `#2A2A2A` | Panel separation |
+
+### Data Palette
+
+| Token | Hex | Usage |
+|-------|-----|-------|
+| Primary | `#00D4AA` | Positive values, buy signals, success |
+| Gain | `#00D4AA` | Positive price movement |
+| Loss | `#FF4757` | Negative price movement |
+| Warning | `#FFB800` | Caution alerts, margin warnings |
+| Neutral | `#808086` | Unchanged, secondary data |
+| Text Primary | `#FFFFFF` | High-contrast primary text |
+| Text Secondary | `#AAAAAA` | Labels, metadata |
+| Text Tertiary | `#828282` | Timestamps, grid labels |
+
+### Dark Mode
+
+Default and only mode. Trading terminals operate in dim environments for focus.
+
+```css
+:root {
+  --color-bg: #0D0D0D;
+  --color-surface: #141414;
+  --color-surface-hover: #1A1A1A;
+  --color-border: #2A2A2A;
+  --color-primary: #00D4AA;
+  --color-gain: #00D4AA;
+  --color-loss: #FF4757;
+  --color-warning: #FFB800;
+  --color-text: #FFFFFF;
+  --color-text-secondary: #AAAAAA;
+  --color-text-tertiary: #828282;
+  --space-1: 4px;  --space-2: 8px;  --space-3: 12px; --space-4: 16px;
+  --space-6: 24px; --space-8: 32px; --space-12: 48px;
+}
+```
+
+## 3. Typography Rules
+
+| Role | Size | Weight | Line Height | Font |
+|------|------|--------|-------------|------|
+| Display | 28px | 600 | 1.0 | JetBrains Mono |
+| Heading | 16px | 600 | 1.2 | Inter |
+| Body | 14px | 400 | 1.3 | JetBrains Mono |
+| Label | 12px | 500 | 1.0 | Inter, uppercase |
+| Micro | 10px | 400 | 1.0 | JetBrains Mono |
+
+**Font labels for catalog extraction:**
+
+```
+Display: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace
+Heading: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+Body: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace
+Label: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif
+Micro: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace
+Mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace
+```
+
+## 4. Component Stylings
+
+### Order Book Row
+
+```css
+.order-book-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  padding: var(--space-1) 0;
+  border-bottom: 1px solid var(--color-border);
+}
+.order-book-size { color: var(--color-text-secondary); text-align: right; }
+.order-book-bid  { color: var(--color-gain); text-align: right; }
+.order-book-ask  { color: var(--color-loss); text-align: right; }
+```
+
+### Price Card
+
+```css
+.price-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.price-card-label {
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+  letter-spacing: 0.05em;
+}
+.price-card-value {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--color-text);
+  line-height: 1.0;
+}
+.price-card-change {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 14px;
+}
+.price-card-change.positive { color: var(--color-gain); }
+.price-card-change.negative { color: var(--color-loss); }
+```
+
+### Ticker Bar
+
+Horizontal scrolling single-line ticker for market overview.
+
+```css
+.ticker-bar {
+  display: flex;
+  gap: var(--space-6);
+  overflow-x: auto;
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--color-border);
+}
+```
+
+## 5. Layout Principles
+
+Grid-based dense layout. Multiple data columns visible simultaneously. Panels share borders, not gaps. No rounded corners — sharp edges communicate precision. The layout is tabular: rows of data, columns of similar data.
+
+## 6. Depth & Elevation
+
+Trading terminals use flat design with border-based separation — no shadows. Surface shifts (#141414 vs #0D0D0D) convey elevation. Thin borders (#2A2A2A) define panel boundaries without decorative elements.
+
+## 7. Do's and Don'ts
+
+- Do not use color alone to signal buy/sell — always pair with a directional icon or label
+- Do not animate data values decoratively — traders need instant, stable reads
+- Do not use rounded corners — sharp precision aesthetic only
+- Do not use light mode — trading terminals operate in dim environments
+- Do not show more than 5 price points in a column — cognitive overload reduces decision speed
+- Do not use gradients — flat fills only
+
+## 8. Responsive Behavior
+
+Terminal layouts target desktop-first (1280px+). On narrower viewports, columns collapse from rightmost to leftmost, prioritizing price and change data. Below 768px, single-column stack with horizontal scroll for overflow data. No breakpoints alter the dark-only constraint.
+
+## 9. Agent Prompt Guide
+
+When generating a trading terminal interface, prompt the model to:
+- Use JetBrains Mono for all numeric data; Inter for labels and headings
+- Always show gain/loss values in monospace with color coding (#00D4AA green, #FF4757 red)
+- No rounded corners on any element
+- Use 100ms transitions for price updates, 150ms for hover states
+- Never use light mode or bright backgrounds
+- Include a horizontal ticker bar with scrolling price updates
+- All data changes retain old value briefly before swapping to prevent flash blindness

--- a/plugins/_official/design-systems/trading-terminal/open-design.json
+++ b/plugins/_official/design-systems/trading-terminal/open-design.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "design-system-trading-terminal",
+  "title": "Trading Terminal",
+  "title_i18n": {
+    "zh-CN": "Trading Terminal",
+    "zh-TW": "Trading Terminal",
+    "ja": "Trading Terminal",
+    "ko": "Trading Terminal",
+    "de": "Trading Terminal",
+    "fr": "Trading Terminal",
+    "ru": "Trading Terminal",
+    "es": "Trading Terminal",
+    "pt-BR": "Trading Terminal",
+    "it": "Trading Terminal",
+    "vi": "Trading Terminal",
+    "pl": "Trading Terminal",
+    "id": "Trading Terminal",
+    "nl": "Trading Terminal",
+    "ar": "Trading Terminal",
+    "tr": "Trading Terminal",
+    "uk": "Trading Terminal",
+    "en": "Trading Terminal"
+  },
+  "version": "0.1.0",
+  "publishedAt": "2026-08-04T09:00:00Z",
+  "description": "Bloomberg-style trading terminal. Dark-only, data-dense, cyan/coral buy/sell signals.",
+  "description_i18n": {
+    "zh-CN": "彭博风格交易终端。纯深色、高信息密度、青/珊瑚买卖信号。",
+    "zh-TW": "彭博風格交易終端。純深色、高資訊密度、青/珊瑚買賣訊號。",
+    "ja": "Bloomberg風トレーディングターミナル。ダーク専用、高密度データ、シアン/コーラルの売買シグナル。",
+    "ko": "블룸버그 스타일 트레이딩 터미널. 다크 전용, 고밀도 데이터, 시안/코랄 매수·매도 시그널.",
+    "de": "Bloomberg-artiger Trading-Terminal. Nur dunkel, datendicht, Cyan/Koralle für Kauf/Verkauf.",
+    "fr": "Terminal de trading façon Bloomberg. Dark-only, dense en données, signaux d’achat/vente cyan/corail.",
+    "ru": "Торговый терминал в стиле Bloomberg. Только тёмный, плотные данные, cyan/coral сигналы buy/sell.",
+    "es": "Terminal de trading estilo Bloomberg. Solo oscuro, denso en datos, señales compra/venta cian/coral.",
+    "pt-BR": "Terminal de trading estilo Bloomberg. Apenas escuro, denso em dados, sinais de compra/venda ciano/coral.",
+    "it": "Terminale di trading in stile Bloomberg. Solo scuro, denso di dati, segnali buy/sell ciano/corallo.",
+    "vi": "Terminal giao dịch kiểu Bloomberg. Chỉ tối, dày dữ liệu, tín hiệu mua/bán cyan/coral.",
+    "pl": "Terminal tradingowy w stylu Bloomberg. Tylko ciemny, gęsty w dane, sygnały kupna/sprzedaży cyan/coral.",
+    "id": "Terminal trading bergaya Bloomberg. Hanya gelap, padat data, sinyal beli/jual cyan/coral.",
+    "nl": "Tradingterminal in Bloomberg-stijl. Alleen donker, datadicht, cyan/coral koop-/verkoopsignalen.",
+    "ar": "طرفية تداول بأسلوب Bloomberg. داكن فقط، كثيف البيانات، إشارات شراء/بيع سماوي/مرجاني.",
+    "tr": "Bloomberg tarzı işlem terminali. Yalnızca koyu, veri yoğun, cyan/coral alım/satım sinyalleri.",
+    "uk": "Торговий термінал у стилі Bloomberg. Лише темний, щільні дані, cyan/coral сигнали buy/sell.",
+    "en": "Bloomberg-style trading terminal. Dark-only, data-dense, cyan/coral buy/sell signals."
+  },
+  "license": "MIT",
+  "tags": [
+    "design-system",
+    "first-party",
+    "design",
+    "themed-unique"
+  ],
+  "od": {
+    "kind": "scenario",
+    "taskKind": "new-generation",
+    "mode": "design-system",
+    "scenario": "design",
+    "surface": "web",
+    "useCase": {
+      "query": {
+        "en": "Generate a {{artifactKind}} using the Trading Terminal design system. Stay faithful to its colour palette, typography, spacing, iconography, and component vocabulary as documented in DESIGN.md.",
+        "zh-CN": "使用这个插件完成以下任务：Generate a {{artifactKind}} using the Trading Terminal design system. Stay faithful to its colour palette, typography, spacing, iconography, and component vocabulary as documented in DESIGN.md."
+      }
+    },
+    "inputs": [
+      {
+        "name": "artifactKind",
+        "label": "Artifact kind",
+        "type": "select",
+        "options": [
+          "landing page",
+          "dashboard",
+          "marketing site",
+          "app screen"
+        ],
+        "default": "landing page"
+      },
+      {
+        "name": "brief",
+        "label": "Brief",
+        "type": "text",
+        "placeholder": "What should the page communicate?"
+      }
+    ],
+    "context": {
+      "designSystem": {
+        "ref": "trading-terminal",
+        "primary": true
+      },
+      "assets": [
+        "./DESIGN.md"
+      ]
+    },
+    "pipeline": {
+      "stages": [
+        {
+          "id": "generate",
+          "atoms": [
+            "file-write",
+            "live-artifact"
+          ]
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject",
+      "fs:write"
+    ]
+  }
+}

--- a/plugins/_official/design-systems/webex/DESIGN.md
+++ b/plugins/_official/design-systems/webex/DESIGN.md
@@ -1,0 +1,207 @@
+# Design System Inspired by Webex
+
+> Category: Productivity & SaaS
+> Collaboration platform. Momentum typography, blue action system, multi-user accent spectrum.
+
+## 1. Visual Theme & Atmosphere
+
+Webex is cleaner, friendlier, and more product-led than Cisco corporate while still living inside the same trust-oriented universe. The brand language combines bright white canvases with dark in-product surfaces, then anchors interaction around a precise family of blue action colors drawn from Momentum. The result is a collaboration platform aesthetic: capable, legible, modern, and designed for continuous use rather than one-shot marketing drama.
+
+Typography is driven by the Momentum system, whose primary font stack is `Momentum, Inter, Arial, Helvetica Neue, Helvetica, sans-serif`. This gives Webex a more software-native rhythm than Cisco's broader corporate presence. Headings should be clear and confident, but not monumental. Body copy should feel practical and human. In contrast to Cisco's singular-signal visual system, Webex allows a broader supporting collaboration palette — cobalt, cyan, mint, lime, gold, orange, pink, purple — but these should appear as **secondary accents** for teams, avatars, presence, or workspace state, not as uncontrolled decoration.
+
+What defines Webex is **blue-guided clarity plus collaborative color**. Action is blue. Surfaces are simple. Supporting colors represent people, teams, or activity.
+
+**Key Characteristics:**
+- Momentum typography stack with clean product rhythm
+- Blue action system centered on `#1170cf`, `#0353a8`, and `#063a75`
+- White marketing/product canvases paired with optional charcoal dark-mode surfaces
+- Soft pill geometry for actions and controls
+- Collaboration-spectrum accent colors used sparingly for people/workspaces
+- Product-first clarity over ornamental flourish
+- Motion should feel polished and unobtrusive
+
+## 2. Color Palette & Roles
+
+### Primary Action
+- **Webex Action Blue** (`#1170cf`): Primary buttons, active controls, main links, selected states
+- **Action Blue Hover** (`#0353a8`): Hover and stronger emphasis
+- **Action Blue Pressed** (`#063a75`): Pressed / active interaction state
+- **Accent Light Blue** (`#64b4fa`): Focus ring, bright dark-surface link state, supportive highlight
+
+### Text & Surface
+- **Primary Text (Light Theme)** (`#000000f2`): Main light-surface text
+- **Secondary Text (Light Theme)** (`#000000b3`): Support copy and metadata
+- **Primary Text (Dark Theme)** (`#fffffff2`): Main dark-surface text
+- **Secondary Text (Dark Theme)** (`#ffffffb3`): Support copy on dark
+- **White Canvas** (`#ffffff`): Primary light background
+- **Black Canvas** (`#000000`): Full dark background
+- **Dark Surface 1** (`#1a1a1a`): Dark cards, modals, product chrome
+- **Dark Surface 2** (`#262626`): Elevated dark layers
+
+### Collaboration / Team Spectrum
+- **Team Cobalt** (`#5ebff7`)
+- **Team Cyan** (`#22c7d6`)
+- **Team Mint** (`#30c9b0`)
+- **Team Lime** (`#93c437`)
+- **Team Gold** (`#d6b220`)
+- **Team Orange** (`#fd884e`)
+- **Team Pink** (`#fc97aa`)
+- **Team Purple** (`#f294f1`)
+
+Use these as secondary collaboration accents: avatars, presence markers, workspace labels, chips, or lightweight category signals.
+
+### Semantic
+- **Success** (`#3cc29a`)
+- **Warning** (`#f2990a`)
+- **Danger** (`#fc8b98`)
+
+## 3. Typography Rules
+
+### Font Family
+- **Primary**: `Momentum`, fallbacks: `Inter, Arial, Helvetica Neue, Helvetica, sans-serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Hero Display | Momentum | 64px | 500 | 1.10 | -1px | Marketing hero headline |
+| Section Display | Momentum | 40px | 500 | 1.20 | -0.5px | Section lead |
+| Heading | Momentum | 24px | 500 | 1.33 | normal | Card title, feature title |
+| Body | Momentum | 16px | 400 | 1.50 | normal | Default product/marketing body |
+| Body Small | Momentum | 14px | 400 | 1.43 | normal | Metadata, nav, helper text |
+| Label | Momentum | 12px | 500 | 1.33 | normal | Chips, tags, presence labels |
+| Button | Momentum | 16px | 500 | 1.25 | normal | CTA label |
+
+### Principles
+- Keep typography highly legible and product-oriented.
+- Use medium weight for structural emphasis, not ultra-bold display theatrics.
+- The system should feel modern and easy to scan, especially in dashboard and collaboration contexts.
+- Avoid decorative font mixing unless the artifact explicitly requires a marketing flourish.
+
+## 4. Component Stylings
+
+### Buttons
+
+**Primary Blue Pill**
+- Background: Webex Action Blue (`#1170cf`)
+- Text: White (`#ffffff`)
+- Radius: pill
+- Hover: `#0353a8`
+- Active: `#063a75`
+
+**Secondary Outline / Ghost on Light**
+- Background: transparent or white
+- Text: `#1170cf`
+- Border: subtle dark or blue-tinted alpha border
+- Radius: pill
+- Purpose: secondary CTA on white or light product surfaces
+
+**Secondary Outline / Ghost on Dark**
+- Background: transparent or `#1a1a1a`
+- Text: `#64b4fa` or white for the strongest emphasis
+- Border: 1px white-alpha or Accent Light Blue (`#64b4fa`) depending on emphasis
+- Radius: pill
+- Hover: soft blue-tinted dark fill with the text color preserved
+- Focus ring: 2px Accent Light Blue halo
+- Purpose: dark-surface secondary CTA without dropping below contrast targets
+
+### Cards & Containers
+- Light cards: white fill with subtle outline
+- Dark cards: `#1a1a1a` fill with bright text and light outline
+- Radius: 16px
+- Keep interiors airy; do not over-densify by default
+
+### Inputs & Controls
+- Light surfaces: subtle outline, blue focus
+- Dark surfaces: bright text, soft white-alpha outline, blue focus signal
+- Toggles, tabs, and nav should feel precise and product-native, not ornamental
+
+### Collaboration Tokens
+- Use team-spectrum colors for presence chips, avatar backgrounds, workspace badges, or lightweight categorization
+- Do not assign them to all primary buttons or all large surfaces
+
+### Brand-Specific Recipes
+
+**Meeting Card**
+- Anatomy: title, time block, participant count, host avatar, device or room status, primary join action
+- States: upcoming, live, ended, recording, muted-device warning
+- Brand behavior: primary action stays blue; meeting state uses subtle chips rather than full-surface color fills
+
+**Presence Chip**
+- Anatomy: avatar or initials, user name, compact status dot/chip, optional location/device label
+- Sizes: 24px compact, 32px default, 40px prominent
+- States: available, presenting, in meeting, away, do-not-disturb
+- Color rule: use collaboration colors as supporting identity accents, not as replacements for semantic status
+
+**Workspace Sidebar**
+- Anatomy: workspace switcher, search, primary nav groups, badge counts, pinned spaces, footer utilities
+- Behavior: keep hierarchy obvious and allow badge counts or unread state to read at a glance
+- States: selected item, unread, hovered, collapsed narrow mode
+
+**Roster Row**
+- Anatomy: avatar, display name, role label, mute/video state, hand-raise or reaction slot, overflow actions
+- States: speaking, muted, hand raised, spotlighted, disconnected
+- Density: support both meeting roster density and more spacious messaging/contact density
+
+## 5. Layout Principles
+
+### Spacing & Grid
+- Base rhythm: 8px
+- Common scale: 8px, 12px, 16px, 24px, 32px, 48px, 64px, 88px
+- Use clean marketing bands and product-story sections
+- Prefer simple grids with clear scanning order
+- Breakpoints: mobile up to 767px, tablet 768px-1199px, desktop 1200px and above
+
+### Composition
+- White space is important; the UI should not feel cramped
+- Marketing layouts should balance clarity with product focus
+- Collaboration/product pages may mix white sections with dark embedded product surfaces
+- Blue should lead the eye; collaboration colors should support, not compete
+- On tablet, reduce multi-panel collaboration layouts to two primary regions and preserve a clear action rail
+- On mobile, stack sidebars beneath the main header, collapse meeting side-panels into drawers, and keep call controls centered in a single thumb-reachable row
+- Navigation should shift to a compact app bar plus drawer on smaller screens rather than shrinking labels until they wrap
+
+### Accessibility & Responsiveness
+- Minimum touch target: 44px by 44px for buttons, tabs, roster actions, and call controls
+- Maintain visible keyboard focus with an Accent Light Blue halo on both light and dark surfaces
+- Any hover-revealed affordance must also appear on focus and touch
+- Respect reduced-motion users by replacing staggered entrance motion with instant layout plus subtle opacity changes only
+
+## 6. Motion & Interaction
+
+- Motion should feel polished, calm, and practical
+- Use fade, slide, and soft stagger in the 160ms–280ms range
+- Hover and focus can use gentle blue glow or highlight
+- Avoid loud spring physics or excessive flourish
+- Under `prefers-reduced-motion`, remove stagger choreography and large panel slides; keep state feedback under 120ms with opacity or outline changes only
+
+## 7. Voice & Brand
+
+- Webex voice is practical, clear, and human
+- Headlines should emphasize usefulness, outcomes, and collaborative capability
+- The brand should feel like a trusted workspace platform for meetings, messaging, devices, and shared work
+- It should be warmer than Cisco corporate, but still disciplined
+
+## 8. Anti-patterns
+
+- Do not turn Webex into a rainbow-heavy consumer social product
+- Do not use collaboration colors as primary CTA colors
+- Do not overuse gradients as core brand language
+- Do not make the system overly corporate-dark when the artifact is meant to feel collaborative and accessible
+- Do not use decorative typography that harms scannability
+
+## 9. Agent Prompt Guide
+
+### Quick Color Reference
+- Primary action: `#1170cf`
+- Hover: `#0353a8`
+- Pressed: `#063a75`
+- Focus / bright dark-surface accent: `#64b4fa`
+- Success: `#3cc29a`
+- Warning: `#f2990a`
+- Danger: `#fc8b98`
+
+### Example Component Prompts
+- "Create a Webex-style product landing page with white canvases, Momentum typography, and blue pill CTAs using #1170cf."
+- "Design a collaboration dashboard with clean white cards, one embedded dark product panel, and secondary team-color chips for presence."
+- "Build a settings or admin surface that uses calm spacing, blue action states, and restrained multi-user color accents."

--- a/plugins/_official/design-systems/webex/open-design.json
+++ b/plugins/_official/design-systems/webex/open-design.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "design-system-webex",
+  "title": "Webex",
+  "title_i18n": {
+    "zh-CN": "Webex",
+    "zh-TW": "Webex",
+    "ja": "Webex",
+    "ko": "Webex",
+    "de": "Webex",
+    "fr": "Webex",
+    "ru": "Webex",
+    "es": "Webex",
+    "pt-BR": "Webex",
+    "it": "Webex",
+    "vi": "Webex",
+    "pl": "Webex",
+    "id": "Webex",
+    "nl": "Webex",
+    "ar": "Webex",
+    "tr": "Webex",
+    "uk": "Webex",
+    "en": "Webex"
+  },
+  "version": "0.1.0",
+  "publishedAt": "2026-08-04T09:00:00Z",
+  "description": "Collaboration platform. Momentum typography, blue action system, multi-user accent spectrum.",
+  "description_i18n": {
+    "zh-CN": "协作平台。Momentum 字体、蓝色操作系统、多用户强调色谱。",
+    "zh-TW": "協作平台。Momentum 字體、藍色操作系統、多使用者強調色譜。",
+    "ja": "コラボレーションプラットフォーム。Momentumタイポグラフィ、ブルーのアクションシステム、マルチユーザーのアクセントスペクトル。",
+    "ko": "협업 플랫폼. Momentum 타이포그래피, 블루 액션 시스템, 멀티유저 액센트 스펙트럼.",
+    "de": "Kollaborationsplattform. Momentum-Typografie, blaues Aktionssystem, Multi-User-Akzentspektrum.",
+    "fr": "Plateforme de collaboration. Typographie Momentum, système d’action bleu, spectre d’accents multi-utilisateurs.",
+    "ru": "Платформа для совместной работы. Типографика Momentum, синяя система действий, спектр акцентов для пользователей.",
+    "es": "Plataforma de colaboración. Tipografía Momentum, sistema de acción azul, espectro de acentos multiusuario.",
+    "pt-BR": "Plataforma de colaboração. Tipografia Momentum, sistema de ação azul, espectro de acentos multiusuário.",
+    "it": "Piattaforma di collaborazione. Tipografia Momentum, sistema d’azione blu, spettro di accenti multiutente.",
+    "vi": "Nền tảng cộng tác. Typography Momentum, hệ thống hành động xanh dương, phổ điểm nhấn đa người dùng.",
+    "pl": "Platforma współpracy. Typografia Momentum, niebieski system akcji, spektrum akcentów multi-user.",
+    "id": "Platform kolaborasi. Tipografi Momentum, sistem aksi biru, spektrum aksen multi-pengguna.",
+    "nl": "Samenwerkingsplatform. Momentum-typografie, blauw actiesysteem, multi-user accentspectrum.",
+    "ar": "منصة تعاون. خطوط Momentum، نظام إجراءات أزرق، طيف لمسات متعدد المستخدمين.",
+    "tr": "İş birliği platformu. Momentum tipografisi, mavi eylem sistemi, çok kullanıcılı vurgu spektrumu.",
+    "uk": "Платформа для спільної роботи. Типографіка Momentum, синя система дій, спектр акцентів для користувачів.",
+    "en": "Collaboration platform. Momentum typography, blue action system, multi-user accent spectrum."
+  },
+  "license": "MIT",
+  "tags": [
+    "design-system",
+    "first-party",
+    "design",
+    "productivity-saas"
+  ],
+  "od": {
+    "kind": "scenario",
+    "taskKind": "new-generation",
+    "mode": "design-system",
+    "scenario": "design",
+    "surface": "web",
+    "useCase": {
+      "query": {
+        "en": "Generate a {{artifactKind}} using the Webex design system. Stay faithful to its colour palette, typography, spacing, iconography, and component vocabulary as documented in DESIGN.md.",
+        "zh-CN": "使用这个插件完成以下任务：Generate a {{artifactKind}} using the Webex design system. Stay faithful to its colour palette, typography, spacing, iconography, and component vocabulary as documented in DESIGN.md."
+      }
+    },
+    "inputs": [
+      {
+        "name": "artifactKind",
+        "label": "Artifact kind",
+        "type": "select",
+        "options": [
+          "landing page",
+          "dashboard",
+          "marketing site",
+          "app screen"
+        ],
+        "default": "landing page"
+      },
+      {
+        "name": "brief",
+        "label": "Brief",
+        "type": "text",
+        "placeholder": "What should the page communicate?"
+      }
+    ],
+    "context": {
+      "designSystem": {
+        "ref": "webex",
+        "primary": true
+      },
+      "assets": [
+        "./DESIGN.md"
+      ]
+    },
+    "pipeline": {
+      "stages": [
+        {
+          "id": "generate",
+          "atoms": [
+            "file-write",
+            "live-artifact"
+          ]
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject",
+      "fs:write"
+    ]
+  }
+}

--- a/plugins/_official/design-systems/wechat/DESIGN.md
+++ b/plugins/_official/design-systems/wechat/DESIGN.md
@@ -1,0 +1,302 @@
+# WeChat Design System
+
+> Category: Social & Messaging
+> Brand visual language for WeChat Mini Programs, official accounts, and open ecosystem extensions.
+
+## Brand Identity
+
+WeChat's identity is built on simplicity, cleanness, and trust — reflecting its role as a super-app that connects people, services, and businesses.
+
+---
+
+## Color Palette
+
+### Brand Colors
+
+| Token | Hex | Usage |
+|---|----|----|
+| `--wechat-green` | `#07C160` | Primary brand, CTA buttons, active states |
+| `--wechat-green-light` | `#10B160` | Hover state for primary actions |
+| `--wechat-green-dark` | `#059050` | Pressed/active state |
+
+### Chat Bubble Colors
+
+| Token | Hex | Usage |
+|---|----|----|
+| `--wechat-bubble-self` | `#95EC69` | Outgoing message bubbles |
+| `--wechat-bubble-other` | `#FFFFFF` | Incoming message bubbles |
+| `--wechat-bubble-text` | `#1A1A1A` | Primary text in bubbles |
+
+### UI Neutrals
+
+| Token | Hex | Usage |
+|---|----|----|
+| `--wechat-bg` | `#EDEDED` | Page/app background |
+| `--wechat-surface` | `#F7F7F7` | Card, modal surfaces |
+| `--wechat-border` | `#E0E0E0` | Dividers, borders |
+| `--wechat-ink` | `#1A1A1A` | Primary text |
+| `--wechat-muted` | `#888888` | Secondary text, timestamps |
+
+### Functional Colors
+
+| Token | Hex | Usage |
+|---|----|----|
+| `--wechat-red` | `#FA5151` | Errors, destructive actions |
+| `--wechat-orange` | `#FAB702` | Warnings |
+| `--wechat-blue` | `#576B95` | Links, info states |
+
+---
+
+## Typography
+
+### Font Stack
+
+```
+font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", Helvetica, Arial, sans-serif;
+```
+
+### Type Scale
+
+| Role | Size | Weight | Line Height |
+|---|---|---|---|
+| Page Title | 18px | 600 | 1.3 |
+| Section Header | 16px | 600 | 1.4 |
+| Body Text | 15px | 400 | 1.6 |
+| Secondary Text | 13px | 400 | 1.5 |
+| Caption/Timestamp | 11px | 400 | 1.4 |
+| Button Label | 16px | 500 | 1.0 |
+
+---
+
+## Spacing System
+
+4px base unit.
+
+| Token | Value |
+|---|-----|
+| `--space-xs` | 4px |
+| `--space-sm` | 8px |
+| `--space-md` | 12px |
+| `--space-lg` | 16px |
+| `--space-xl` | 24px |
+| `--space-2xl` | 32px |
+
+### Border Radius
+
+| Token | Value |
+|---|-----|
+| `--radius-sm` | 4px |
+| `--radius-md` | 8px |
+| `--radius-lg` | 16px |
+| `--radius-bubble` | 16px (with directional corner clip) |
+| `--radius-full` | 9999px (avatars, pills) |
+
+---
+
+## Components
+
+### Chat Bubble
+
+```css
+.wechat-bubble {
+  max-width: 70%;
+  padding: 10px 14px;
+  border-radius: var(--radius-bubble);
+  font-size: 15px;
+  line-height: 1.6;
+  position: relative;
+}
+
+.wechat-bubble.self {
+  background: var(--wechat-bubble-self);
+  color: var(--wechat-bubble-text);
+  border-top-right-radius: 4px;
+  margin-left: auto;
+}
+
+.wechat-bubble.other {
+  background: var(--wechat-bubble-other);
+  color: var(--wechat-bubble-text);
+  border-top-left-radius: 4px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+}
+```
+
+### Primary Button (Send / Confirm)
+
+```css
+.btn-wechat-primary {
+  background: var(--wechat-green);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 12px 32px;
+  font-size: 16px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.btn-wechat-primary:hover {
+  background: var(--wechat-green-light);
+}
+
+.btn-wechat-primary:active {
+  background: var(--wechat-green-dark);
+}
+```
+
+### Tab Bar
+
+```css
+.tab-bar {
+  display: flex;
+  background: var(--wechat-surface);
+  border-top: 1px solid var(--wechat-border);
+  padding: 8px 0 calc(8px + env(safe-area-inset-bottom));
+}
+
+.tab-bar-item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  color: var(--wechat-muted);
+  font-size: 10px;
+  cursor: pointer;
+  transition: color 0.15s;
+}
+
+.tab-bar-item.active {
+  color: var(--wechat-green);
+}
+
+.tab-bar-item svg {
+  width: 24px;
+  height: 24px;
+}
+```
+
+### Message Input Bar
+
+```css
+.input-bar {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  padding: 10px 12px calc(10px + env(safe-area-inset-bottom));
+  background: var(--wechat-surface);
+  border-top: 1px solid var(--wechat-border);
+}
+
+.input-bar textarea {
+  flex: 1;
+  min-height: 36px;
+  max-height: 100px;
+  padding: 8px 12px;
+  background: var(--wechat-bg);
+  border: 1px solid var(--wechat-border);
+  border-radius: var(--radius-lg);
+  font-size: 15px;
+  line-height: 1.5;
+  resize: none;
+  outline: none;
+}
+
+.input-bar textarea:focus {
+  border-color: var(--wechat-green);
+}
+```
+
+### Avatar
+
+```css
+.avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-full);
+  object-fit: cover;
+  background: var(--wechat-border);
+}
+
+.avatar.sm { width: 32px; height: 32px; }
+.avatar.lg { width: 56px; height: 56px; }
+```
+
+### Timestamp Badge
+
+```css
+.timestamp {
+  display: inline-block;
+  padding: 4px 8px;
+  background: rgba(0, 0, 0, 0.08);
+  border-radius: var(--radius-sm);
+  font-size: 11px;
+  color: var(--wechat-muted);
+  text-align: center;
+}
+```
+
+---
+
+## Motion & Animation
+
+| Token | Value |
+|---|-----|
+| `--duration-instant` | 100ms |
+| `--duration-fast` | 200ms |
+| `--duration-normal` | 300ms |
+| `--ease-default` | cubic-bezier(0.25, 0.1, 0.25, 1) |
+
+Chat message entry: fade-in + slight slide up, 200ms.
+
+---
+
+## Dark Mode
+
+| Token | Light | Dark |
+|---|---|---|
+| `--wechat-bg` | `#EDEDED` | `#1A1A1A` |
+| `--wechat-surface` | `#F7F7F7` | `#2C2C2C` |
+| `--wechat-ink` | `#1A1A1A` | `#F7F7F7` |
+| `--wechat-bubble-self` | `#95EC69` | `#4CAF50` |
+| `--wechat-bubble-other` | `#FFFFFF` | `#2C2C2C` |
+
+---
+
+## Usage
+
+```css
+:root {
+  --wechat-green: #07C160;
+  --wechat-green-light: #10B160;
+  --wechat-green-dark: #059050;
+  --wechat-bubble-self: #95EC69;
+  --wechat-bubble-other: #FFFFFF;
+  --wechat-bubble-text: #1A1A1A;
+  --wechat-bg: #EDEDED;
+  --wechat-surface: #F7F7F7;
+  --wechat-border: #E0E0E0;
+  --wechat-ink: #1A1A1A;
+  --wechat-muted: #888888;
+  --wechat-red: #FA5151;
+  --wechat-orange: #FAB702;
+  --wechat-blue: #576B95;
+  --space-xs: 4px;
+  --space-sm: 8px;
+  --space-md: 12px;
+  --space-lg: 16px;
+  --space-xl: 24px;
+  --space-2xl: 32px;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 16px;
+  --radius-bubble: 16px;
+  --radius-full: 9999px;
+  --duration-instant: 100ms;
+  --duration-fast: 200ms;
+  --duration-normal: 300ms;
+  --ease-default: cubic-bezier(0.25, 0.1, 0.25, 1);
+}
+```

--- a/plugins/_official/design-systems/wechat/open-design.json
+++ b/plugins/_official/design-systems/wechat/open-design.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "design-system-wechat",
+  "title": "WeChat",
+  "title_i18n": {
+    "zh-CN": "微信",
+    "zh-TW": "微信",
+    "ja": "WeChat",
+    "ko": "WeChat",
+    "de": "WeChat",
+    "fr": "WeChat",
+    "ru": "WeChat",
+    "es": "WeChat",
+    "pt-BR": "WeChat",
+    "it": "WeChat",
+    "vi": "WeChat",
+    "pl": "WeChat",
+    "id": "WeChat",
+    "nl": "WeChat",
+    "ar": "WeChat",
+    "tr": "WeChat",
+    "uk": "WeChat",
+    "en": "WeChat"
+  },
+  "version": "0.1.0",
+  "publishedAt": "2026-08-04T09:00:00Z",
+  "description": "Brand language for WeChat Mini Programs and open ecosystem extensions. Simple, clean, trust-green.",
+  "description_i18n": {
+    "zh-CN": "微信小程序与开放生态扩展的品牌视觉语言。简洁干净，信任绿。",
+    "zh-TW": "微信小程式與開放生態擴充的品牌視覺語言。簡潔乾淨，信任綠。",
+    "ja": "WeChatミニプログラムとオープンエコシステム拡張向けのブランド言語。シンプルでクリーン、信頼のグリーン。",
+    "ko": "WeChat 미니프로그램과 오픈 생태계 확장용 브랜드 언어. 단순하고 깔끔하며 신뢰의 그린.",
+    "de": "Markensprache für WeChat-Mini-Programme und Open-Ecosystem-Erweiterungen. Schlicht, klar, Vertrauensgrün.",
+    "fr": "Langage de marque pour les Mini Programs WeChat et les extensions d’écosystème ouvert. Simple, propre, vert de confiance.",
+    "ru": "Брендовый язык для мини-программ WeChat и расширений открытой экосистемы. Простой, чистый, зелёный доверия.",
+    "es": "Lenguaje de marca para Mini Programs de WeChat y extensiones del ecosistema abierto. Simple, limpio, verde de confianza.",
+    "pt-BR": "Linguagem de marca para Mini Programs do WeChat e extensões do ecossistema aberto. Simples, limpa, verde de confiança.",
+    "it": "Linguaggio di brand per Mini Programs WeChat ed estensioni dell’ecosistema aperto. Semplice, pulito, verde di fiducia.",
+    "vi": "Ngôn ngữ thương hiệu cho Mini Program WeChat và phần mở rộng hệ sinh thái mở. Đơn giản, sạch, xanh tin cậy.",
+    "pl": "Język marki dla Mini Programów WeChat i rozszerzeń otwartego ekosystemu. Prosty, czysty, zaufana zieleń.",
+    "id": "Bahasa merek untuk Mini Program WeChat dan ekstensi ekosistem terbuka. Sederhana, bersih, hijau kepercayaan.",
+    "nl": "Merktaal voor WeChat Mini Programs en open-ecosysteemextensies. Eenvoudig, schoon, vertrouwensgroen.",
+    "ar": "لغة علامة تجارية لبرامج WeChat المصغّرة وامتدادات النظام المفتوح. بسيطة ونظيفة وخضراء تبعث على الثقة.",
+    "tr": "WeChat Mini Programları ve açık ekosistem uzantıları için marka dili. Sade, temiz, güven yeşili.",
+    "uk": "Брендова мова для мініпрограм WeChat і розширень відкритої екосистеми. Проста, чиста, зелень довіри.",
+    "en": "Brand language for WeChat Mini Programs and open ecosystem extensions. Simple, clean, trust-green."
+  },
+  "license": "MIT",
+  "tags": [
+    "design-system",
+    "first-party",
+    "design",
+    "social-messaging"
+  ],
+  "od": {
+    "kind": "scenario",
+    "taskKind": "new-generation",
+    "mode": "design-system",
+    "scenario": "design",
+    "surface": "web",
+    "useCase": {
+      "query": {
+        "en": "Generate a {{artifactKind}} using the WeChat design system. Stay faithful to its colour palette, typography, spacing, iconography, and component vocabulary as documented in DESIGN.md.",
+        "zh-CN": "使用这个插件完成以下任务：Generate a {{artifactKind}} using the WeChat design system. Stay faithful to its colour palette, typography, spacing, iconography, and component vocabulary as documented in DESIGN.md."
+      }
+    },
+    "inputs": [
+      {
+        "name": "artifactKind",
+        "label": "Artifact kind",
+        "type": "select",
+        "options": [
+          "landing page",
+          "dashboard",
+          "marketing site",
+          "app screen"
+        ],
+        "default": "landing page"
+      },
+      {
+        "name": "brief",
+        "label": "Brief",
+        "type": "text",
+        "placeholder": "What should the page communicate?"
+      }
+    ],
+    "context": {
+      "designSystem": {
+        "ref": "wechat",
+        "primary": true
+      },
+      "assets": [
+        "./DESIGN.md"
+      ]
+    },
+    "pipeline": {
+      "stages": [
+        {
+          "id": "generate",
+          "atoms": [
+            "file-write",
+            "live-artifact"
+          ]
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject",
+      "fs:write"
+    ]
+  }
+}

--- a/plugins/registry/official/open-design-marketplace.json
+++ b/plugins/registry/official/open-design-marketplace.json
@@ -12,7 +12,7 @@
     "description": "Official Open Design plugin registry seed. The generated public catalog is served from open-design.ai/marketplace.",
     "version": "0.1.0",
     "generatedFrom": "plugins/_official",
-    "bundledPreinstallCount": 419
+    "bundledPreinstallCount": 420
   },
   "plugins": [
     {
@@ -3294,6 +3294,30 @@
         "fs:write"
       ],
       "description": "Surface: web\nA cosmic-premium, glassmorphic dark system that captures the visceral awe of a solar eclipse — obsidian surfaces, amber \"corona\" highlights, and cyan atmospheric accents.",
+      "tags": [
+        "design-system",
+        "first-party",
+        "design",
+        "themed-unique"
+      ],
+      "license": "MIT",
+      "mode": "design-system",
+      "taskKind": "new-generation"
+    },
+    {
+      "name": "open-design/design-system-trading-terminal",
+      "title": "Trading Terminal",
+      "version": "0.1.0",
+      "source": "github:nexu-io/open-design@main/plugins/_official/design-systems/trading-terminal",
+      "publisher": {
+        "id": "open-design",
+        "url": "https://open-design.ai"
+      },
+      "capabilitiesSummary": [
+        "prompt:inject",
+        "fs:write"
+      ],
+      "description": "Bloomberg-style trading terminal. Dark-only, data-dense, cyan/coral buy/sell signals.",
       "tags": [
         "design-system",
         "first-party",

--- a/plugins/registry/official/open-design-marketplace.json
+++ b/plugins/registry/official/open-design-marketplace.json
@@ -12,7 +12,7 @@
     "description": "Official Open Design plugin registry seed. The generated public catalog is served from open-design.ai/marketplace.",
     "version": "0.1.0",
     "generatedFrom": "plugins/_official",
-    "bundledPreinstallCount": 414
+    "bundledPreinstallCount": 415
   },
   "plugins": [
     {
@@ -563,6 +563,30 @@
         "first-party",
         "design",
         "design-creative"
+      ],
+      "license": "MIT",
+      "mode": "design-system",
+      "taskKind": "new-generation"
+    },
+    {
+      "name": "open-design/design-system-cisco",
+      "title": "Cisco",
+      "version": "0.1.0",
+      "source": "github:nexu-io/open-design@main/plugins/_official/design-systems/cisco",
+      "publisher": {
+        "id": "open-design",
+        "url": "https://open-design.ai"
+      },
+      "capabilitiesSummary": [
+        "prompt:inject",
+        "fs:write"
+      ],
+      "description": "Enterprise infrastructure brand. Dark trust surfaces, Cisco Blue signal, technical clarity.",
+      "tags": [
+        "design-system",
+        "first-party",
+        "design",
+        "backend-data"
       ],
       "license": "MIT",
       "mode": "design-system",

--- a/plugins/registry/official/open-design-marketplace.json
+++ b/plugins/registry/official/open-design-marketplace.json
@@ -12,7 +12,7 @@
     "description": "Official Open Design plugin registry seed. The generated public catalog is served from open-design.ai/marketplace.",
     "version": "0.1.0",
     "generatedFrom": "plugins/_official",
-    "bundledPreinstallCount": 420
+    "bundledPreinstallCount": 421
   },
   "plugins": [
     {
@@ -3539,6 +3539,30 @@
         "first-party",
         "design",
         "developer-tools"
+      ],
+      "license": "MIT",
+      "mode": "design-system",
+      "taskKind": "new-generation"
+    },
+    {
+      "name": "open-design/design-system-webex",
+      "title": "Webex",
+      "version": "0.1.0",
+      "source": "github:nexu-io/open-design@main/plugins/_official/design-systems/webex",
+      "publisher": {
+        "id": "open-design",
+        "url": "https://open-design.ai"
+      },
+      "capabilitiesSummary": [
+        "prompt:inject",
+        "fs:write"
+      ],
+      "description": "Collaboration platform. Momentum typography, blue action system, multi-user accent spectrum.",
+      "tags": [
+        "design-system",
+        "first-party",
+        "design",
+        "productivity-saas"
       ],
       "license": "MIT",
       "mode": "design-system",

--- a/plugins/registry/official/open-design-marketplace.json
+++ b/plugins/registry/official/open-design-marketplace.json
@@ -12,7 +12,7 @@
     "description": "Official Open Design plugin registry seed. The generated public catalog is served from open-design.ai/marketplace.",
     "version": "0.1.0",
     "generatedFrom": "plugins/_official",
-    "bundledPreinstallCount": 415
+    "bundledPreinstallCount": 416
   },
   "plugins": [
     {
@@ -1523,6 +1523,30 @@
         "first-party",
         "design",
         "backend-data"
+      ],
+      "license": "MIT",
+      "mode": "design-system",
+      "taskKind": "new-generation"
+    },
+    {
+      "name": "open-design/design-system-hud",
+      "title": "HUD",
+      "version": "0.1.0",
+      "source": "github:nexu-io/open-design@main/plugins/_official/design-systems/hud",
+      "publisher": {
+        "id": "open-design",
+        "url": "https://open-design.ai"
+      },
+      "capabilitiesSummary": [
+        "prompt:inject",
+        "fs:write"
+      ],
+      "description": "Fighter-jet head-up display. Phosphor green on near-black, all-caps data overlays, angular geometry.",
+      "tags": [
+        "design-system",
+        "first-party",
+        "design",
+        "themed-unique"
       ],
       "license": "MIT",
       "mode": "design-system",

--- a/plugins/registry/official/open-design-marketplace.json
+++ b/plugins/registry/official/open-design-marketplace.json
@@ -12,7 +12,7 @@
     "description": "Official Open Design plugin registry seed. The generated public catalog is served from open-design.ai/marketplace.",
     "version": "0.1.0",
     "generatedFrom": "plugins/_official",
-    "bundledPreinstallCount": 421
+    "bundledPreinstallCount": 422
   },
   "plugins": [
     {
@@ -3587,6 +3587,30 @@
         "first-party",
         "design",
         "design-creative"
+      ],
+      "license": "MIT",
+      "mode": "design-system",
+      "taskKind": "new-generation"
+    },
+    {
+      "name": "open-design/design-system-wechat",
+      "title": "WeChat",
+      "version": "0.1.0",
+      "source": "github:nexu-io/open-design@main/plugins/_official/design-systems/wechat",
+      "publisher": {
+        "id": "open-design",
+        "url": "https://open-design.ai"
+      },
+      "capabilitiesSummary": [
+        "prompt:inject",
+        "fs:write"
+      ],
+      "description": "Brand language for WeChat Mini Programs and open ecosystem extensions. Simple, clean, trust-green.",
+      "tags": [
+        "design-system",
+        "first-party",
+        "design",
+        "social-messaging"
       ],
       "license": "MIT",
       "mode": "design-system",

--- a/plugins/registry/official/open-design-marketplace.json
+++ b/plugins/registry/official/open-design-marketplace.json
@@ -12,7 +12,7 @@
     "description": "Official Open Design plugin registry seed. The generated public catalog is served from open-design.ai/marketplace.",
     "version": "0.1.0",
     "generatedFrom": "plugins/_official",
-    "bundledPreinstallCount": 416
+    "bundledPreinstallCount": 417
   },
   "plugins": [
     {
@@ -1763,6 +1763,30 @@
         "first-party",
         "design",
         "creative-artistic"
+      ],
+      "license": "MIT",
+      "mode": "design-system",
+      "taskKind": "new-generation"
+    },
+    {
+      "name": "open-design/design-system-loom",
+      "title": "Loom",
+      "version": "0.1.0",
+      "source": "github:nexu-io/open-design@main/plugins/_official/design-systems/loom",
+      "publisher": {
+        "id": "open-design",
+        "url": "https://open-design.ai"
+      },
+      "capabilitiesSummary": [
+        "prompt:inject",
+        "fs:write"
+      ],
+      "description": "Async video communication. Purple primary, friendly surfaces, video-first layout.",
+      "tags": [
+        "design-system",
+        "first-party",
+        "design",
+        "themed-unique"
       ],
       "license": "MIT",
       "mode": "design-system",

--- a/plugins/registry/official/open-design-marketplace.json
+++ b/plugins/registry/official/open-design-marketplace.json
@@ -12,7 +12,7 @@
     "description": "Official Open Design plugin registry seed. The generated public catalog is served from open-design.ai/marketplace.",
     "version": "0.1.0",
     "generatedFrom": "plugins/_official",
-    "bundledPreinstallCount": 417
+    "bundledPreinstallCount": 418
   },
   "plugins": [
     {
@@ -2915,6 +2915,30 @@
         "first-party",
         "design",
         "morphism-effects"
+      ],
+      "license": "MIT",
+      "mode": "design-system",
+      "taskKind": "new-generation"
+    },
+    {
+      "name": "open-design/design-system-slack",
+      "title": "Slack",
+      "version": "0.1.0",
+      "source": "github:nexu-io/open-design@main/plugins/_official/design-systems/slack",
+      "publisher": {
+        "id": "open-design",
+        "url": "https://open-design.ai"
+      },
+      "capabilitiesSummary": [
+        "prompt:inject",
+        "fs:write"
+      ],
+      "description": "Workplace communication platform. Aubergine primary, multi-accent logo palette, warm approachable surfaces.",
+      "tags": [
+        "design-system",
+        "first-party",
+        "design",
+        "productivity-saas"
       ],
       "license": "MIT",
       "mode": "design-system",

--- a/plugins/registry/official/open-design-marketplace.json
+++ b/plugins/registry/official/open-design-marketplace.json
@@ -12,7 +12,7 @@
     "description": "Official Open Design plugin registry seed. The generated public catalog is served from open-design.ai/marketplace.",
     "version": "0.1.0",
     "generatedFrom": "plugins/_official",
-    "bundledPreinstallCount": 418
+    "bundledPreinstallCount": 419
   },
   "plugins": [
     {
@@ -3251,6 +3251,30 @@
         "first-party",
         "design",
         "ai-llm"
+      ],
+      "license": "MIT",
+      "mode": "design-system",
+      "taskKind": "new-generation"
+    },
+    {
+      "name": "open-design/design-system-tom-modern",
+      "title": "Tom Modern",
+      "version": "0.1.0",
+      "source": "github:nexu-io/open-design@main/plugins/_official/design-systems/tom-modern",
+      "publisher": {
+        "id": "open-design",
+        "url": "https://open-design.ai"
+      },
+      "capabilitiesSummary": [
+        "prompt:inject",
+        "fs:write"
+      ],
+      "description": "Editorial-technical starter. Neutral canvas, vermillion accent, sharp corners, Geist type, hard shadows.",
+      "tags": [
+        "design-system",
+        "first-party",
+        "design",
+        "starter"
       ],
       "license": "MIT",
       "mode": "design-system",


### PR DESCRIPTION
Fixes #6387

## Why

Claimed #6387: eight bundled design systems already render cards on `/plugins/systems/` from `design-systems/<slug>/`, but they had no `plugins/_official/design-systems/<slug>/open-design.json`, so `detailHrefForSystemSlug()` degraded each card back to the systems index.

That is the documented fallback, not a runtime crash — but it leaves real systems without a detail page. Maintainer confirmed the eight are not staged for removal and preferred one mechanical PR with one commit per system.

## What users will see

On the landing-page systems catalog, cards for **Cisco, HUD, Loom, Slack, Tom Modern, Trading Terminal, Webex, and WeChat** now link to their own `/plugins/design-system-<slug>/` detail pages instead of looping back to `/plugins/systems/`.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [x] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

UI here is the public landing catalog link target (new detail pages generated from manifests). Extension point is `plugins/_official/` + official marketplace seed.

## Screenshots

Data-only; no visual redesign. Verification is the href resolution below.

## Bug fix verification

- Falsifiable check: `detailHrefForSystemSlug('<slug>')` previously returned `null` for the eight; on this branch each resolves to `/plugins/design-system-<slug>/`.
- Confirmed via `pnpm exec tsx` import of `apps/landing-page/app/_lib/bundled-plugins.ts` for all eight slugs.
- Remaining non-plugin folders under `design-systems/` are only `_schema` and `README.md` (intentional).

## Validation

- `pnpm --filter @open-design/landing-page typecheck` — 0 errors
- Runtime: `detailHrefForSystemSlug` for all eight slugs returns dedicated detail hrefs
- Official marketplace `bundledPreinstallCount` 414 → 422 with sorted inserts

Each system is its own commit (Cisco → WeChat), matching the #4833 / maintainer request.


Made with [Cursor](https://cursor.com)