### PR TITLE
ci(e2e): split UI P0 workspace shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,15 +515,62 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+      - name: Upload Playwright debug artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ui-p0-ci-${{ github.run_id }}-${{ matrix.name }}
+          path: |
+            e2e/ui/reports/playwright-html-report
+            e2e/ui/reports/test-results
+            e2e/ui/reports/results.json
+            e2e/ui/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
+  ui_critical_extras:
+    name: UI critical extras
+    needs: [scopes, runners]
+    if: ${{ needs.scopes.outputs.run_ui_p0 == 'true' }}
+    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).ui_hot }}
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Configure CI parallelism
+        uses: ./.github/actions/configure-ci-parallelism
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
+        with:
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_hot) }}
+
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
+        with:
+          package-json-path: e2e/package.json
+          install-command: pnpm -C e2e exec playwright install --with-deps chromium
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_hot) }}
+
+      - name: Prebuild workspace type declarations
+        run: |
+          pnpm --filter @open-design/daemon build
+          pnpm --filter @open-design/desktop build
+          pnpm --filter @open-design/web build:sidecar
+
+      - name: Clean Playwright state
+        run: pnpm -C e2e exec tsx scripts/playwright.ts clean
+
       - name: Run UI critical extras
-        if: ${{ matrix.shard == 'project-runtime' }}
         run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group critical-extras
 
       - name: Upload Playwright debug artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ui-p0-ci-${{ github.run_id }}-${{ matrix.name }}
+          name: ui-critical-extras-ci-${{ github.run_id }}
           path: |
             e2e/ui/reports/playwright-html-report
             e2e/ui/reports/test-results
@@ -634,6 +681,7 @@ jobs:
       - e2e_vitest
       - playwright_critical
       - ui_p0
+      - ui_critical_extras
       - playwright_visual
     if: ${{ always() }}
     runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).control }}
@@ -679,7 +727,7 @@ jobs:
               + when($out.run_web_workspace_tests == "true"; ["web_workspace_tests"])
               + when($out.run_e2e_vitest == "true"; ["e2e_vitest"])
               + when($out.run_playwright_critical == "true"; ["playwright_critical"])
-              + when($out.run_ui_p0 == "true"; ["ui_p0"])
+              + when($out.run_ui_p0 == "true"; ["ui_p0", "ui_critical_extras"])
               + when($out.run_playwright_visual == "true"; ["playwright_visual"])
             )[]
             | select(($needs[.].result // "missing") != "success")

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -50,8 +50,12 @@ jobs:
         include:
           - name: entry-settings
             shard: entry-settings
-          - name: project-workspace
-            shard: project-workspace
+          - name: project-workspace-core
+            shard: project-workspace-core
+          - name: project-workspace-collab
+            shard: project-workspace-collab
+          - name: project-workspace-team-sync
+            shard: project-workspace-team-sync
           - name: project-runtime
             shard: project-runtime
           - name: workspace-restoration
@@ -101,15 +105,62 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
+      - name: Upload Playwright debug artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ui-extended-main-${{ github.run_id }}-p0-${{ matrix.name }}
+          path: |
+            e2e/ui/reports/playwright-html-report
+            e2e/ui/reports/test-results
+            e2e/ui/reports/results.json
+            e2e/ui/test-results
+          if-no-files-found: ignore
+          retention-days: 7
+
+  ui_critical_extras:
+    name: UI critical extras
+    needs: [p0_runners]
+    if: ${{ github.repository == 'nexu-io/open-design' && github.event_name == 'workflow_dispatch' && inputs.suite != 'full' }}
+    runs-on: ${{ fromJSON(needs.p0_runners.outputs.runs_on).ui_hot }}
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+
+      - name: Configure CI parallelism
+        uses: ./.github/actions/configure-ci-parallelism
+
+      - name: Setup workspace
+        uses: ./.github/actions/setup-workspace
+        with:
+          runner-labels: ${{ toJSON(fromJSON(needs.p0_runners.outputs.runs_on).ui_hot) }}
+
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
+        with:
+          package-json-path: e2e/package.json
+          install-command: pnpm -C e2e exec playwright install --with-deps chromium
+          runner-labels: ${{ toJSON(fromJSON(needs.p0_runners.outputs.runs_on).ui_hot) }}
+
+      - name: Prebuild workspace type declarations
+        run: |
+          pnpm --filter @open-design/daemon build
+          pnpm --filter @open-design/desktop build
+          pnpm --filter @open-design/web build:sidecar
+
+      - name: Clean Playwright state
+        run: pnpm -C e2e exec tsx scripts/playwright.ts clean
+
       - name: Run UI critical extras
-        if: ${{ matrix.shard == 'project-runtime' }}
         run: pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group critical-extras
 
       - name: Upload Playwright debug artifact
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: ui-extended-main-${{ github.run_id }}-p0-${{ matrix.name }}
+          name: ui-extended-main-${{ github.run_id }}-critical-extras
           path: |
             e2e/ui/reports/playwright-html-report
             e2e/ui/reports/test-results

--- a/e2e/lib/playwright/suites.ts
+++ b/e2e/lib/playwright/suites.ts
@@ -39,7 +39,7 @@ export const uiP0Groups = {
       "ui/workspace-team-interactions.test.ts",
     ],
   },
-  "project-workspace": {
+  "project-workspace-core": {
     grep: String.raw`\[P0\]`,
     workers: 1,
     files: [
@@ -47,10 +47,18 @@ export const uiP0Groups = {
       "ui/app-design-files.test.ts",
       "ui/app-manual-edit.test.ts",
       "ui/project-management-flows.test.ts",
-      "ui/workspace-multi-client-collab.test.ts",
-      "ui/workspace-team-design-system-picker.test.ts",
       "ui/workspace-keyboard-flows.test.ts",
     ],
+  },
+  "project-workspace-collab": {
+    grep: String.raw`\[P0\]`,
+    workers: 1,
+    files: ["ui/workspace-multi-client-collab.test.ts"],
+  },
+  "project-workspace-team-sync": {
+    grep: String.raw`\[P0\]`,
+    workers: 1,
+    files: ["ui/workspace-team-design-system-picker.test.ts"],
   },
   "project-runtime": {
     grep: String.raw`\[P0\]`,
@@ -68,7 +76,9 @@ export type UiP0GroupName = keyof typeof uiP0Groups;
 
 export const uiP0CiMatrix = [
   { name: "entry-settings", shard: "entry-settings" },
-  { name: "project-workspace", shard: "project-workspace" },
+  { name: "project-workspace-core", shard: "project-workspace-core" },
+  { name: "project-workspace-collab", shard: "project-workspace-collab" },
+  { name: "project-workspace-team-sync", shard: "project-workspace-team-sync" },
   { name: "project-runtime", shard: "project-runtime" },
   { name: "workspace-restoration", shard: "workspace-restoration" },
 ] as const satisfies readonly UiP0CiMatrixEntry[];
@@ -114,7 +124,10 @@ export function validatePlaywrightSuiteTopology(): string[] {
   const errors: string[] = [];
   const knownGroups = new Set(Object.keys(uiP0Groups));
   const coverageFiles = sortedUnique(uiP0CoverageFiles);
-  const ciFiles = filesForUiP0Groups(uiP0CiMatrix.map((entry) => entry.shard));
+  const ciFileAssignments = uiP0CiMatrix.flatMap(
+    (entry) => uiP0Groups[entry.shard as UiP0GroupName]?.files ?? [],
+  );
+  const ciFiles = sortedUnique(ciFileAssignments);
 
   for (const entry of uiP0CiMatrix) {
     if (!knownGroups.has(entry.shard)) {
@@ -130,6 +143,14 @@ export function validatePlaywrightSuiteTopology(): string[] {
     errors.push(`UI P0 CI matrix unexpectedly covers ${file}`);
   }
 
+  const seenFiles = new Set<string>();
+  for (const file of ciFileAssignments) {
+    if (seenFiles.has(file)) {
+      errors.push(`UI P0 CI matrix covers ${file} more than once`);
+    }
+    seenFiles.add(file);
+  }
+
   for (const entry of visualCiMatrix) {
     if (entry.files.trim().length === 0) {
       errors.push(`Visual CI matrix entry ${entry.name} has no files`);
@@ -137,10 +158,6 @@ export function validatePlaywrightSuiteTopology(): string[] {
   }
 
   return errors;
-}
-
-function filesForUiP0Groups(names: readonly string[]): string[] {
-  return sortedUnique(names.flatMap((name) => uiP0Groups[name as UiP0GroupName]?.files ?? []));
 }
 
 function difference(left: readonly string[], right: readonly string[]): string[] {

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -911,7 +911,7 @@ process.stdin.on("end", () => {
     expect(scopes).toContain("ui_p0_validation_required: ${{ steps.detect.outputs.ui_p0_validation_required }}");
     expect(scopes).toContain("run_ui_p0: ${{ steps.detect.outputs.run_ui_p0 }}");
     expect(workflow).toContain("needs.scopes.outputs.run_ui_p0 == 'true'");
-    expect(validate).toContain('when($out.run_ui_p0 == "true"; ["ui_p0"])');
+    expect(validate).toContain('when($out.run_ui_p0 == "true"; ["ui_p0", "ui_critical_extras"])');
 
     await expect(runScopesPrint("workflow_dispatch", { inputs: { ci_mode: "hot" } }, ["apps/web/src/app/page.tsx"])).resolves.toMatchObject({
       ci_mode: "hot",
@@ -1122,7 +1122,8 @@ process.stdin.on("end", () => {
     const webWorkspaceTests = sectionBetween(workflow, "  web_workspace_tests:", "  e2e_vitest:");
     const e2eVitest = sectionBetween(workflow, "  e2e_vitest:", "  playwright_critical:");
     const preflight = sectionBetween(workflow, "  preflight:", "  workspace_unit_tests:");
-    const uiP0 = sectionBetween(workflow, "  ui_p0:", "  playwright_visual:");
+    const uiP0 = sectionBetween(workflow, "  ui_p0:", "  ui_critical_extras:");
+    const uiCriticalExtras = sectionBetween(workflow, "  ui_critical_extras:", "  playwright_visual:");
     const visual = sectionBetween(workflow, "  playwright_visual:", "  validate:");
 
     expect(runners).toContain("runs-on: ubuntu-24.04");
@@ -1148,20 +1149,32 @@ process.stdin.on("end", () => {
     expect(uiP0).toContain("include: ${{ fromJSON(needs.scopes.outputs.ui_p0_matrix) }}");
     expect(uiP0CiMatrix.map((entry) => entry.name)).toEqual([
       "entry-settings",
-      "project-workspace",
+      "project-workspace-core",
+      "project-workspace-collab",
+      "project-workspace-team-sync",
       "project-runtime",
       "workspace-restoration",
     ]);
-    expect(uiP0Groups["project-workspace"].files).toEqual([
+    expect(uiP0Groups["project-workspace-core"].files).toEqual([
       "ui/app.test.ts",
       "ui/app-design-files.test.ts",
       "ui/app-manual-edit.test.ts",
       "ui/project-management-flows.test.ts",
-      "ui/workspace-multi-client-collab.test.ts",
-      "ui/workspace-team-design-system-picker.test.ts",
       "ui/workspace-keyboard-flows.test.ts",
     ]);
-    expect(uiP0Groups["project-workspace"].workers).toBe(1);
+    expect(uiP0Groups["project-workspace-core"].workers).toBe(1);
+    expect(uiP0Groups["project-workspace-collab"]).toEqual({
+      grep: String.raw`\[P0\]`,
+      workers: 1,
+      files: ["ui/workspace-multi-client-collab.test.ts"],
+    });
+    expect(uiP0Groups["project-workspace-team-sync"]).toEqual({
+      grep: String.raw`\[P0\]`,
+      workers: 1,
+      files: ["ui/workspace-team-design-system-picker.test.ts"],
+    });
+    const uiP0FileAssignments = uiP0CiMatrix.flatMap((entry) => uiP0Groups[entry.shard].files);
+    expect(new Set(uiP0FileAssignments).size).toBe(uiP0FileAssignments.length);
     expect(uiP0Groups["critical-extras"]).toEqual({
       grep: "@merge-extra",
       workers: 1,
@@ -1173,8 +1186,11 @@ process.stdin.on("end", () => {
       files: ["ui/app-restoration.test.ts", "ui/critical-smoke.test.ts"],
     });
     expect(workflow).not.toContain("  ui_p0_smoke:");
-    expect(uiP0).toContain("run-ui-group critical-extras");
+    expect(uiP0).not.toContain("run-ui-group critical-extras");
     expect(uiP0).toContain("Preserve project-runtime domain artifact");
+    expect(uiCriticalExtras).toContain("needs.scopes.outputs.run_ui_p0 == 'true'");
+    expect(uiCriticalExtras).toContain("fromJSON(needs.runners.outputs.runs_on).ui_hot");
+    expect(uiCriticalExtras).toContain("run-ui-group critical-extras");
     expect(visual).toContain("fromJSON(needs.runners.outputs.runs_on).visual_hot");
     expect(visual).toContain("toJSON(fromJSON(needs.runners.outputs.runs_on).visual_hot)");
     expect(workflow).not.toContain("needs.runners.outputs.contabo_control");
@@ -1210,7 +1226,9 @@ process.stdin.on("end", () => {
     expect(benchmarkWorkflow).toContain("run-ui-group critical-extras");
     expect(benchmarkWorkflow).toContain("Preserve project-runtime domain artifact");
     expect(benchmarkWorkflow).toContain("--grep-invert '@merge-extra'");
-    expect(benchmarkWorkflow).toContain("name: project-workspace");
+    expect(benchmarkWorkflow).toContain("name: project-workspace-core");
+    expect(benchmarkWorkflow).toContain("name: project-workspace-collab");
+    expect(benchmarkWorkflow).toContain("name: project-workspace-team-sync");
     expect(fullUi).toContain("fromJSON(needs.p0_runners.outputs.runs_on).ui_hot");
     expect(fullUi).toContain("shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]");
     expect(fullUi).toContain('OD_PLAYWRIGHT_FULLY_PARALLEL: "1"');

--- a/e2e/tests/scripts/scopes.test.ts
+++ b/e2e/tests/scripts/scopes.test.ts
@@ -919,7 +919,7 @@ test("merge-queue threshold escalates medium-confidence files to the full radius
   });
 });
 
-test("runtime-definition changes produce only a three-domain UI P0 shadow candidate", async () => {
+test("runtime-definition changes produce only a five-shard UI P0 shadow candidate", async () => {
   const { evaluateUiP0Shadow } = await import("../../../scripts/scopes.ts");
   const decision = evaluateUiP0Shadow([
     "apps/daemon/src/runtimes/defs/atomcode.ts",
@@ -930,7 +930,13 @@ test("runtime-definition changes produce only a three-domain UI P0 shadow candid
   assert.equal(decision.capability, "daemon-runtime-definition");
   assert.deepEqual(
     decision.matrix.map((entry) => entry.name),
-    ["entry-settings", "project-workspace", "project-runtime"],
+    [
+      "entry-settings",
+      "project-workspace-core",
+      "project-workspace-collab",
+      "project-workspace-team-sync",
+      "project-runtime",
+    ],
   );
   assert.deepEqual(decision.outsideCapabilityFiles, []);
 });
@@ -947,7 +953,14 @@ test("runtime-definition shadow fails closed for mixed, unknown, empty, and unre
     assert.equal(decision.mode, "full-fallback", files.join(", "));
     assert.deepEqual(
       decision.matrix.map((entry) => entry.name),
-      ["entry-settings", "project-workspace", "project-runtime", "workspace-restoration"],
+      [
+        "entry-settings",
+        "project-workspace-core",
+        "project-workspace-collab",
+        "project-workspace-team-sync",
+        "project-runtime",
+        "workspace-restoration",
+      ],
     );
   }
   assert.equal(evaluateUiP0Shadow([], false).reason, "files-unresolved");
@@ -997,7 +1010,13 @@ test("plan trace reports the runtime-definition UI P0 shadow without changing th
   assert.equal(result.trace.uiP0Shadow.mode, "candidate");
   assert.deepEqual(
     result.trace.uiP0Shadow.matrix.map((entry) => entry.name),
-    ["entry-settings", "project-workspace", "project-runtime"],
+    [
+      "entry-settings",
+      "project-workspace-core",
+      "project-workspace-collab",
+      "project-workspace-team-sync",
+      "project-runtime",
+    ],
   );
 });
 

--- a/scripts/lib/guard/scope.ts
+++ b/scripts/lib/guard/scope.ts
@@ -17,13 +17,17 @@ import type { GuardContext } from "./core.ts";
 
 const fullMatrixNames = [
   "entry-settings",
-  "project-workspace",
+  "project-workspace-core",
+  "project-workspace-collab",
+  "project-workspace-team-sync",
   "project-runtime",
   "workspace-restoration",
 ] as const;
 const candidateMatrixNames = [
   "entry-settings",
-  "project-workspace",
+  "project-workspace-core",
+  "project-workspace-collab",
+  "project-workspace-team-sync",
   "project-runtime",
 ] as const;
 
@@ -38,7 +42,7 @@ function sameValues(actual: readonly string[], expected: readonly string[]): boo
 export function uiP0ShadowContractErrors(): string[] {
   const errors: string[] = [];
   if (!sameValues(matrixNames(uiP0CiMatrix), fullMatrixNames)) {
-    errors.push("the applied UI P0 matrix is no longer the guarded full four-domain matrix");
+    errors.push("the applied UI P0 matrix is no longer the guarded full six-shard matrix");
   }
 
   const sourceSample = `${DAEMON_RUNTIME_DEFINITION_PREFIXES[0]}example.ts`;
@@ -49,7 +53,7 @@ export function uiP0ShadowContractErrors(): string[] {
     candidate.capability !== "daemon-runtime-definition" ||
     !sameValues(matrixNames(candidate.matrix), candidateMatrixNames)
   ) {
-    errors.push("the runtime-definition shadow no longer resolves to the guarded three-domain candidate");
+    errors.push("the runtime-definition shadow no longer resolves to the guarded five-shard candidate");
   }
 
   for (const outsideFile of [

--- a/scripts/scopes.ts
+++ b/scripts/scopes.ts
@@ -73,7 +73,9 @@ export const DAEMON_RUNTIME_DEFINITION_EXACT = [
 
 const DAEMON_RUNTIME_DEFINITION_MATRIX_NAMES = [
   "entry-settings",
-  "project-workspace",
+  "project-workspace-core",
+  "project-workspace-collab",
+  "project-workspace-team-sync",
   "project-runtime",
 ] as const;
 

--- a/specs/current/ci.md
+++ b/specs/current/ci.md
@@ -180,7 +180,7 @@ configuration, bins, the packaged sidecar compatibility bridge, and runtime
 definition source/companion tests stay medium-tier.
 
 A pure matching merge group keeps preflight and workspace typecheck, workspace
-unit coverage, broad E2E Vitest, and the complete four-domain UI P0 matrix. It
+unit coverage, broad E2E Vitest, and the complete six-shard UI P0 matrix. It
 skips web workspace tests, visual Playwright, Windows launcher-payload tests,
 and tools-dev/tools-pack unit coverage. The retained plan therefore continues
 to exercise daemon buildability, user-level API/runtime behavior, and every
@@ -212,7 +212,7 @@ guarded plan; UI P0 remains the critical path.
 ## Daemon UI P0 capability shadow
 
 The UI P0 capability shadow is evidence-only. The applied `ui_p0_matrix`
-remains the full four-domain matrix in PR and merge-queue plans; no job reads
+remains the full six-shard matrix in PR and merge-queue plans; no job reads
 the shadow candidate as an execution input.
 
 The `daemon-runtime-definition` capability matches changes confined to:
@@ -223,12 +223,12 @@ The `daemon-runtime-definition` capability matches changes confined to:
 - the explicit companion-test list in
   `DAEMON_RUNTIME_DEFINITION_EXACT` (`scripts/scopes.ts`).
 
-Its candidate keeps `entry-settings`, `project-workspace`, and
-`project-runtime`, and omits only `workspace-restoration`. The project
-workspace remains included because its P0 coverage contains the local-agent
-and model selector. Any empty, unresolved, mixed, unknown, or out-of-surface
-change falls back to the full four-domain matrix and records the reason in
-`trace.uiP0Shadow`.
+Its candidate keeps `entry-settings`, all three `project-workspace-*` shards,
+and `project-runtime`, and omits only `workspace-restoration`. The project
+workspace shards remain included because their combined P0 coverage contains
+the local-agent and model selector. Any empty, unresolved, mixed, unknown, or
+out-of-surface change falls back to the full six-shard matrix and records the
+reason in `trace.uiP0Shadow`.
 
 Guard: `UI P0 shadow contract` (`scripts/lib/guard/scope.ts`). It pins the
 applied full matrix, the candidate group set, representative in-bound


### PR DESCRIPTION
## Why

While diagnosing the merge-gated UI P0 runtime, the existing four-job matrix showed a heavily imbalanced critical path: stateful project workspace and collaboration coverage ran serially in one job, while shorter groups finished much earlier. This change keeps every currently merge-gated P0 file while reducing the longest shard and moving the P1 merge extras off the project-runtime critical path.

## What users will see

No product behavior changes. Pull requests and merge-queue runs will report six smaller UI P0 jobs, plus a separate UI critical extras job, so CI feedback should arrive sooner and failures should point to a narrower capability area.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this changes CI topology only.

## Bug fix verification

Not applicable; this is a CI runtime/topology optimization.

## Validation

- `PATH=/opt/homebrew/bin:/usr/bin:/bin:$PATH pnpm --filter @open-design/e2e test tests/packaged-smoke-workflow.test.ts tests/scripts/scopes.test.ts` — 106 passed
- `pnpm --filter @open-design/e2e typecheck`
- `pnpm guard`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color`
- `git diff --check`
- Verified the six-shard matrix assigns all 21 merge-gated P0 files exactly once
- Full browser execution of all six Playwright shards was not run locally; CI will provide that end-to-end confirmation
