### PR TITLE
fix(collab): harden workspace authority recovery and revocation

### DIFF
--- a/apps/daemon/src/collab/workspace-projects-reconciler.ts
+++ b/apps/daemon/src/collab/workspace-projects-reconciler.ts
@@ -526,11 +526,11 @@ export async function reconcileWorkspaceProjectMetadataWithRemote(
  * Hub → daemon handling for the `team-projects-changed` push (see
  * `startHubEventsSubscriber`'s `onEvent` in server.ts). Sibling of
  * `handleHubWorkspaceContextChanged` just above it in that file: besides
- * refreshing the display cache and sending the thin web signal
- * (`emitTeamProjectsChangedDeduped`), this now ALSO runs a real
- * `workspace_projects` reconciliation pass, so a member whose owner just
- * unshared a project (or who just gained access to a new one) converges
- * immediately instead of waiting for the ~15s poller.
+ * refreshing the display cache, this runs a real `workspace_projects`
+ * reconciliation pass before sending the thin web signal
+ * (`emitTeamProjectsChangedDeduped`), so a member whose owner just unshared a
+ * project (or who just gained access to a new one) converges immediately
+ * instead of waiting for the ~15s poller.
  *
  * Extracted as its own named, exported step for the same reason
  * `handleHubWorkspaceContextChanged` is: directly unit-testable without
@@ -540,8 +540,13 @@ export function handleHubTeamProjectsChanged(
   emitTeamProjectsChangedDeduped: () => void,
   reconcileWorkspaceProjects: () => Promise<unknown>,
 ): void {
-  emitTeamProjectsChangedDeduped();
-  void reconcileWorkspaceProjects().catch(() => undefined);
+  // The web treats this signal as permission to re-read the currently open
+  // project's scope. Emit only after the authoritative catalog diff has been
+  // persisted; an eager signal can race the revoke write, re-confirm the stale
+  // Team binding, and then leave the open page with no durable follow-up.
+  void reconcileWorkspaceProjects()
+    .then(() => emitTeamProjectsChangedDeduped())
+    .catch(() => undefined);
 }
 
 /** Emit immediately for catalog-backed UI, then emit once more only after a
@@ -574,8 +579,11 @@ export function handlePolledWorkspaceInvalidation(
   emit: (payload: WorkspaceInvalidationSsePayload) => void,
   reconcileWorkspaceProjects: () => Promise<unknown>,
 ): void {
-  emit(payload);
-  if (payload.type === 'team-projects-changed') {
-    void reconcileWorkspaceProjects().catch(() => undefined);
+  if (payload.type !== 'team-projects-changed') {
+    emit(payload);
+    return;
   }
+  void reconcileWorkspaceProjects()
+    .then(() => emit(payload))
+    .catch(() => undefined);
 }

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -5024,6 +5024,24 @@ export async function startServer({
           });
           break;
         case 'team-resources-changed': {
+          // Project publish/retract operations are Resource Hub mutations and
+          // therefore arrive on this generic event family. Projects have their
+          // own binding model and non-destructive mirror quarantine; the
+          // generic resource coordinator intentionally handles only design
+          // systems, plugins, and skills.
+          if (event.resourceKind === 'project') {
+            handleHubTeamProjectsChanged(
+              () => emitTeamProjectsChanged(
+                eventWorkspaceId,
+                {
+                  ...(event.projectId ? { projectId: event.projectId } : {}),
+                  kind: 'catalog',
+                },
+              ),
+              () => reconcileWorkspaceProjectsFromRemote(eventWorkspaceId),
+            );
+            break;
+          }
           // A design-system/plugin/skill resource was shared (moved the
           // 'published' ref) or retracted (removed) on the resource hub.
           // `resourceKind` routes to just that kind's reconciler instead of

--- a/apps/daemon/tests/collab/workspace-projects-hub-wiring.test.ts
+++ b/apps/daemon/tests/collab/workspace-projects-hub-wiring.test.ts
@@ -36,12 +36,18 @@ function sseResponse(frames: string[]) {
 }
 
 describe('handleHubTeamProjectsChanged', () => {
-  it('emits the thin display-cache signal AND kicks a reconciliation pass', async () => {
+  it('emits the thin display-cache signal only after reconciliation finishes', async () => {
     const emit = vi.fn();
-    const reconcile = vi.fn(async () => undefined);
+    let finishReconcile!: () => void;
+    const reconcile = vi.fn(() => new Promise<void>((resolve) => {
+      finishReconcile = resolve;
+    }));
     handleHubTeamProjectsChanged(emit, reconcile);
-    expect(emit).toHaveBeenCalledTimes(1);
     expect(reconcile).toHaveBeenCalledTimes(1);
+    expect(emit).not.toHaveBeenCalled();
+
+    finishReconcile();
+    await vi.waitFor(() => expect(emit).toHaveBeenCalledTimes(1));
   });
 
   it('never lets a reconciliation failure throw or reject out of the hub event handler', async () => {
@@ -192,14 +198,25 @@ describe('server.ts wiring (source boundary)', () => {
     return source.slice(switchStart, i + 1);
   }
 
-  it('calls handleHubTeamProjectsChanged from exactly one case: team-projects-changed', () => {
+  it('routes both project catalog event families through project reconciliation', () => {
     const switchBody = extractOnEventSwitchBody();
     const cases = switchBody.split(/(?=case '[a-z-]+':)/g).filter((chunk) => chunk.startsWith("case '"));
     expect(cases.length).toBeGreaterThanOrEqual(7);
 
     const casesCallingReconcile = cases.filter((chunk) => /handleHubTeamProjectsChanged\(/.test(chunk));
     const caseNames = casesCallingReconcile.map((chunk) => chunk.match(/^case '([a-z-]+)':/)?.[1]);
-    expect(caseNames).toEqual(['team-projects-changed']);
+    expect(caseNames).toEqual(['team-projects-changed', 'team-resources-changed']);
+  });
+
+  it('routes project resource retractions through project reconciliation instead of the generic resource lane', () => {
+    const switchBody = extractOnEventSwitchBody();
+    const teamResourcesCase = switchBody
+      .split(/(?=case '[a-z-]+':)/g)
+      .find((chunk) => chunk.startsWith("case 'team-resources-changed':"));
+
+    expect(teamResourcesCase).toContain("event.resourceKind === 'project'");
+    expect(teamResourcesCase).toContain('handleHubTeamProjectsChanged(');
+    expect(teamResourcesCase).toContain('reconcileWorkspaceProjectsFromRemote(');
   });
 
   it('runs targeted metadata reconciliation only from project-metadata-changed', () => {

--- a/apps/daemon/tests/collab/workspace-projects-reconcile-http.test.ts
+++ b/apps/daemon/tests/collab/workspace-projects-reconcile-http.test.ts
@@ -580,8 +580,10 @@ describe('reconcileWorkspaceProjectsWithRemote, verified through the real worksp
     registerProjectRoutes(app, buildProjectRoutesDeps({ list: async () => [] }));
     const routeServer = await listen(app);
     const detailUrl = `${routeServer.url}/api/projects/${projectId}`;
+    const scopeUrl = `${routeServer.url}/api/projects/${projectId}/workspace-scope`;
     const filesUrl = `${routeServer.url}/api/projects/${projectId}/files`;
     const rawUrl = `${routeServer.url}/api/projects/${projectId}/raw/index.html`;
+    const previewUrl = `${routeServer.url}/api/projects/${projectId}/preview-url`;
     expect((await fetch(detailUrl, { headers: readerTeamHeaders() })).status).toBe(200);
 
     // The owner has since unshared (or deleted) the project: the hub's team
@@ -603,8 +605,10 @@ describe('reconcileWorkspaceProjectsWithRemote, verified through the real worksp
       teamMirrorRevokedAt: expect.any(Number),
     });
     expect((await fetch(detailUrl, { headers: readerTeamHeaders() })).status).toBe(403);
+    expect((await fetch(scopeUrl, { headers: readerTeamHeaders() })).status).toBe(403);
     expect((await fetch(filesUrl, { headers: readerTeamHeaders() })).status).toBe(404);
     expect((await fetch(rawUrl, { headers: readerTeamHeaders() })).status).toBe(404);
+    expect((await fetch(previewUrl, { headers: readerTeamHeaders() })).status).toBe(404);
 
     try {
       const teamResp = await fetch(

--- a/apps/web/src/collab/useProjectWorkspaceScope.ts
+++ b/apps/web/src/collab/useProjectWorkspaceScope.ts
@@ -344,7 +344,16 @@ export function useProjectWorkspaceScope(
         : null
       : null;
   const requestAuthorityKey = projectWorkspaceAuthorityKey(requestWorkspaceAuthority);
-  const callerIdentityKey = workspaceIdentityCacheKey(callerWorkspaceContext);
+  // The caller identity is request authority only for an already-bound
+  // project. An unbound project's scope read is deliberately headerless, so a
+  // shell Workspace A -> B change cannot alter that request or invalidate its
+  // answer. Keeping the ambient identity in this key used to abort an in-flight
+  // unbound read and synchronously hide an already-settled unbound scope. The
+  // FileViewer then returned to its fail-closed skeleton even though the
+  // project's resource authority had not changed at all.
+  const callerIdentityKey = boundWorkspaceId
+    ? workspaceIdentityCacheKey(callerWorkspaceContext)
+    : 'none';
   const initialScopeContext = projectWorkspaceContext(initialScope);
   const initialScopeCanSeed = Boolean(
     initialScope

--- a/apps/web/src/collab/useProjectWorkspaceScope.ts
+++ b/apps/web/src/collab/useProjectWorkspaceScope.ts
@@ -412,8 +412,20 @@ export function useProjectWorkspaceScope(
     revalidateInBackground();
   }, [revalidateInBackground]);
 
+  const revalidateOnTeamProjectsChanged = useCallback((payload: {
+    projectId?: string;
+    kind?: 'catalog' | 'metadata';
+  }) => {
+    if (payload.kind === 'metadata') return;
+    if (payload.projectId && payload.projectId !== projectId) return;
+    revalidateInBackground();
+  }, [projectId, revalidateInBackground]);
+
   useWorkspaceInvalidation(
-    { 'workspace-context-changed': revalidateInBackground },
+    {
+      'workspace-context-changed': revalidateInBackground,
+      'team-projects-changed': revalidateOnTeamProjectsChanged,
+    },
     {
       workspaceContext: projectWorkspaceContext(state.scope),
       onActive: revalidateOnActive,

--- a/apps/web/src/components/DesignKitView.tsx
+++ b/apps/web/src/components/DesignKitView.tsx
@@ -30,7 +30,11 @@ import { Button, Textarea } from '@open-design/components';
 import type { WorkspaceCollabContext } from '@open-design/contracts';
 import type { DesignSystemEditClickProps } from '@open-design/contracts/analytics';
 import { useT } from '../i18n';
-import { openExternalUrl, projectRawUrl } from '../providers/registry';
+import {
+  fetchProjectFileText,
+  openExternalUrl,
+  projectRawUrl,
+} from '../providers/registry';
 import { buildSrcdoc } from '../runtime/srcdoc';
 import {
   fontStack,
@@ -174,15 +178,13 @@ export function useBrandFonts(
     let styleEl: HTMLStyleElement | null = null;
     void (async () => {
       try {
-        const resp = await fetch(projectRawUrl(
+        const manifest = await fetchProjectFileText(
           projectId,
           'fonts/manifest.json',
-          workspaceContext,
-        ), {
-          cache: 'no-store',
-        });
-        if (!resp.ok) return;
-        const data = (await resp.json()) as { files?: BrandFontManifestFile[] };
+          { cache: 'no-store', workspaceContext },
+        );
+        if (!manifest) return;
+        const data = JSON.parse(manifest) as { files?: BrandFontManifestFile[] };
         const files = Array.isArray(data?.files) ? data.files : [];
         if (cancelled || files.length === 0) return;
         const css = files

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3296,14 +3296,9 @@ export function ProjectView({
       const cached = htmlContentCacheRef.current.get(name);
       if (cached && cached.mtime === mtime) return cached.text;
       try {
-        const response = await fetch(
-          projectRawUrl(
-            project.id,
-            name,
-            projectRunWorkspaceContextRef.current,
-          ),
-        );
-        const text = response.ok ? await response.text() : null;
+        const text = await fetchProjectFileText(project.id, name, {
+          workspaceContext: projectRunWorkspaceContextRef.current,
+        });
         htmlContentCacheRef.current.set(name, { mtime, text });
         return text;
       } catch {

--- a/apps/web/src/providers/registry.ts
+++ b/apps/web/src/providers/registry.ts
@@ -2898,7 +2898,7 @@ export async function deleteProjectFile(
 ): Promise<boolean> {
   try {
     const resp = await fetch(
-      projectRawUrl(projectId, name),
+      projectRawUrl(projectId, name, workspaceContext),
       {
         method: 'DELETE',
         ...(workspaceContext ? { headers: workspaceProjectHeaders(workspaceContext) } : {}),

--- a/apps/web/tests/components/DesignKitView.test.tsx
+++ b/apps/web/tests/components/DesignKitView.test.tsx
@@ -41,7 +41,7 @@ afterEach(() => {
 });
 
 describe('DesignKitView iframe sandboxing', () => {
-  it('scopes self-hosted font manifest and font URLs to the bound Workspace', async () => {
+  it('uses dual authority for the font fetch and query scope for browser font URLs', async () => {
     const context = {
       workspaceId: 'workspace-team',
       workspaceType: 'team',
@@ -71,7 +71,13 @@ describe('DesignKitView iframe sandboxing', () => {
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
         '/api/projects/project-team/raw/fonts/manifest.json?workspaceId=workspace-team&workspaceMemberId=member-1',
-        { cache: 'no-store' },
+        {
+          cache: 'no-store',
+          headers: expect.objectContaining({
+            'x-od-workspace-id': 'workspace-team',
+            'x-od-workspace-member-id': 'member-1',
+          }),
+        },
       );
       expect(document.head.querySelector('style[data-brand-fonts="project-team"]')?.textContent)
         .toContain(

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -724,6 +724,7 @@ describe('FileViewer preview scale', () => {
     await waitFor(() => {
       expect(rawReads).toHaveLength(1);
       expect(document.querySelector('.viewer-loading')).toBeNull();
+      expect(screen.getByTestId('artifact-preview-frame')).toBeTruthy();
     });
     expect(rawReads[0]?.url).toContain('workspaceId=ws-1');
     expect(rawReads[0]?.url).toContain('workspaceMemberId=wm-1');
@@ -731,6 +732,68 @@ describe('FileViewer preview scale', () => {
       'x-od-workspace-id': 'ws-1',
       'x-od-workspace-member-id': 'wm-1',
     });
+  });
+
+  it('recovers the same preview mount when pending authority settles as local', async () => {
+    const file = baseFile({
+      name: 'local-first-open.html',
+      path: 'local-first-open.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Local first open',
+        entry: 'local-first-open.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    });
+    const rawReads: Array<{ init?: RequestInit; url: string }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('/raw/local-first-open.html')) {
+        rawReads.push({ init, url });
+        return new Response('<html><body>Local materialized</body></html>', { status: 200 });
+      }
+      if (url.endsWith('/files')) {
+        return new Response(JSON.stringify({ files: [file] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ deployments: [] }), { status: 200 });
+    }));
+
+    const { rerender } = render(
+      <CollabProvider value={{
+        ...projectWorkspaceCollabValue(teamWorkspaceContext()),
+        workspaceContextLoading: true,
+        projectResourceAuthority: 'pending',
+      }}>
+        <FileViewer projectId="project-1" projectKind="prototype" file={file} />
+      </CollabProvider>,
+    );
+
+    expect(document.querySelector('.viewer-loading')).not.toBeNull();
+    expect(screen.queryByTestId('artifact-preview-frame')).toBeNull();
+    expect(rawReads).toEqual([]);
+
+    rerender(
+      <CollabProvider value={{
+        ...projectWorkspaceCollabValue(null),
+        workspaceContextLoading: false,
+        projectResourceAuthority: 'local',
+      }}>
+        <FileViewer projectId="project-1" projectKind="prototype" file={file} />
+      </CollabProvider>,
+    );
+
+    await waitFor(() => {
+      expect(rawReads).toHaveLength(1);
+      expect(document.querySelector('.viewer-loading')).toBeNull();
+      expect(screen.getByTestId('artifact-preview-frame')).toBeTruthy();
+    });
+    expect(rawReads[0]?.url).not.toContain('workspaceId=');
+    expect(rawReads[0]?.url).not.toContain('workspaceMemberId=');
+    expect(rawReads[0]?.init?.headers).toBeUndefined();
   });
 
   it('never downgrades denied project resources to local reads', async () => {

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -1803,6 +1803,39 @@ describe('FileViewer SVG artifacts', () => {
     expect(markup).toContain('sandbox="allow-scripts allow-downloads"');
   });
 
+  it('keeps browser-owned URL preview navigation authorized by query scope', () => {
+    const file = baseFile({
+      name: 'team-page.html',
+      path: 'team-page.html',
+      mime: 'text/html',
+      kind: 'html',
+      artifactManifest: {
+        version: 1,
+        kind: 'html',
+        title: 'Team page',
+        entry: 'team-page.html',
+        renderer: 'html',
+        exports: ['html'],
+      },
+    });
+
+    const markup = renderToStaticMarkup(
+      <CollabProvider value={projectWorkspaceCollabValue(teamWorkspaceContext())}>
+        <FileViewer
+          projectId="project-1"
+          projectKind="prototype"
+          file={file}
+          liveHtml="<html><body>team</body></html>"
+        />
+      </CollabProvider>,
+    );
+
+    expect(markup).toContain('data-od-render-mode="url-load" data-od-active="true"');
+    expect(markup).toContain(
+      'src="/api/projects/project-1/raw/team-page.html?workspaceId=ws-1&amp;workspaceMemberId=wm-1&amp;v=1710000000',
+    );
+  });
+
   it('routes brand extraction stop requests from the preview iframe', async () => {
     const file = baseFile({
       name: 'brand.html',

--- a/apps/web/tests/components/ProjectView.run-workspace-identity.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-workspace-identity.test.tsx
@@ -446,7 +446,9 @@ describe('a Home auto-send identifies its caller before the project scope resolv
     );
     mockedListMessages.mockResolvedValue([]);
     mockedFetchPreviewComments.mockResolvedValue([]);
+    mockedFetchProjectFiles.mockResolvedValue([]);
     mockedFetchBrands.mockResolvedValue([]);
+    mockedStreamViaDaemon.mockResolvedValue(undefined);
     mockedCheckAmrBalanceGate.mockResolvedValue({ kind: 'allow' });
     workspaceScopeMocks.projectScope = { loading: true, scope: null };
     workspaceScopeMocks.ambientContext = CALLER_CONTEXT;
@@ -502,6 +504,58 @@ describe('a Home auto-send identifies its caller before the project scope resolv
       'a run POST with no workspace context is refused 401 WORKSPACE_CONTEXT_REQUIRED '
         + 'on a workspace-bound project',
     ).toEqual(CALLER_CONTEXT);
+  });
+
+  it('sends query and headers together for the scoped HTML fetch used by auto-open analysis', async () => {
+    workspaceScopeMocks.projectScope = {
+      loading: false,
+      scope: {
+        kind: 'team',
+        projectId: PROJECT_ID,
+        workspaceId: TEAM_WORKSPACE,
+        visibility: 'team',
+        context: CALLER_CONTEXT as WorkspaceCollabContext & { workspaceType: 'team' },
+      },
+    };
+    mockedFetchProjectFiles.mockResolvedValue([
+      { name: 'index.html', path: 'index.html', kind: 'html', size: 100, mtime: 2 },
+      { name: 'src/app.jsx', path: 'src/app.jsx', kind: 'text', size: 100, mtime: 2 },
+    ] as never);
+    mockedStreamViaDaemon.mockImplementation(async (options) => {
+      options.handlers.onAgentEvent({
+        kind: 'tool_use',
+        id: 'write-jsx',
+        name: 'Write',
+        input: { file_path: 'src/app.jsx', content: 'export default function App() {}' },
+      });
+      options.handlers.onAgentEvent({
+        kind: 'tool_result',
+        toolUseId: 'write-jsx',
+        content: 'written',
+        isError: false,
+      });
+      options.handlers.onDone('done');
+    });
+
+    renderProjectView();
+
+    const fetchMock = vi.mocked(globalThis.fetch);
+    await waitFor(() => {
+      const rawCall = fetchMock.mock.calls.find(([input]) =>
+        String(input).includes(`/api/projects/${PROJECT_ID}/raw/index.html`),
+      );
+      expect(rawCall).toBeDefined();
+      expect(String(rawCall?.[0])).toBe(
+        `/api/projects/${PROJECT_ID}/raw/index.html?workspaceId=${TEAM_WORKSPACE}`
+          + `&workspaceMemberId=${TEAM_MEMBER}`,
+      );
+      expect(rawCall?.[1]).toEqual(expect.objectContaining({
+        headers: expect.objectContaining({
+          'x-od-workspace-id': TEAM_WORKSPACE,
+          'x-od-workspace-member-id': TEAM_MEMBER,
+        }),
+      }));
+    });
   });
 
   it('hydrates the persisted transcript without waiting for preview comments', async () => {

--- a/apps/web/tests/providers/project-workspace-transport-scope.test.ts
+++ b/apps/web/tests/providers/project-workspace-transport-scope.test.ts
@@ -8,6 +8,7 @@ import {
   checkDeploymentLink,
   deleteDesignSystemDraft,
   deleteLiveArtifact,
+  deleteProjectFile,
   deployProjectFile,
   designSystemStaticUrl,
   ensureDesignSystemWorkspace,
@@ -178,6 +179,25 @@ describe('persisted project Workspace transport scope', () => {
       '/api/projects/project-1/files/index.html/versions/version-1',
       expect.objectContaining({
         cache: 'no-store',
+        headers: expect.objectContaining({
+          'x-od-workspace-id': 'workspace-a',
+          'x-od-workspace-member-id': 'member-a',
+        }),
+      }),
+    );
+  });
+
+  it('sends query and headers together when deleting a scoped raw file', async () => {
+    const workspaceA = teamContext('workspace-a', 'member-a');
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(null, { status: 204 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(deleteProjectFile('project-1', 'index.html', workspaceA)).resolves.toBe(true);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/projects/project-1/raw/index.html?workspaceId=workspace-a&workspaceMemberId=member-a',
+      expect.objectContaining({
+        method: 'DELETE',
         headers: expect.objectContaining({
           'x-od-workspace-id': 'workspace-a',
           'x-od-workspace-member-id': 'member-a',

--- a/apps/web/tests/useProjectWorkspaceScope.test.tsx
+++ b/apps/web/tests/useProjectWorkspaceScope.test.tsx
@@ -255,6 +255,53 @@ describe('useProjectWorkspaceScope', () => {
     hook.unmount();
   });
 
+  it('fails closed when a project-catalog event revokes the currently open project', async () => {
+    const initial = teamScope(
+      'project-unshared',
+      'workspace-unshared',
+      'member-reader',
+    );
+    if (initial.scope.kind === 'team') initial.scope.visibility = 'team';
+    const caller = initial.scope.context as WorkspaceCollabContext;
+    const fetchMock = vi.fn(async () => new Response('{}', { status: 403 }));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('EventSource', OpeningEventSource as unknown as typeof EventSource);
+
+    const hook = renderHook(() => useProjectWorkspaceScope(
+      'project-unshared',
+      caller,
+      caller.workspaceId,
+      initial.scope,
+    ));
+
+    expect(hook.result.current).toMatchObject({
+      loading: false,
+      scope: initial.scope,
+    });
+    await act(async () => {
+      for (let turn = 0; turn < 4; turn += 1) await Promise.resolve();
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      OpeningEventSource.instances[0]?.emit('team-projects-changed', {
+        type: 'team-projects-changed',
+        projectId: 'project-unshared',
+        kind: 'catalog',
+      });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => {
+      expect(hook.result.current).toEqual({
+        loading: false,
+        scope: null,
+        failure: 'forbidden',
+      });
+    });
+  });
+
   it('revalidates and hides a stale scope when the same member authority changes', async () => {
     const first = teamScope('project-role', 'workspace-role', 'member-role');
     const second = deferred<Response>();

--- a/apps/web/tests/useProjectWorkspaceScope.workspace-identity.test.tsx
+++ b/apps/web/tests/useProjectWorkspaceScope.workspace-identity.test.tsx
@@ -58,6 +58,14 @@ function jsonResponse(body: unknown): Response {
   });
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
 let scopeReads: Headers[];
 
 beforeEach(() => {
@@ -154,5 +162,100 @@ describe('useProjectWorkspaceScope ignores shell Workspace selection', () => {
         [...headers.keys()].filter((name) => name.startsWith('x-od-workspace-')),
       ).toEqual([]);
     }
+  });
+
+  it('keeps a settled unbound scope while the ambient Team caller changes', async () => {
+    const callerA = workspaceContext('workspace-a', 'member-a');
+    const callerB = workspaceContext('workspace-b', 'member-b');
+    const fetchMock = vi.fn(async () => jsonResponse({
+      scope: {
+        kind: 'unbound',
+        projectId: PROJECT_ID,
+        workspaceId: null,
+        context: null,
+      },
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const hook = renderHook(
+      ({ caller }) => useProjectWorkspaceScope(PROJECT_ID, caller, null),
+      { initialProps: { caller: callerA as WorkspaceCollabContext | null } },
+    );
+    await waitFor(() => expect(hook.result.current).toEqual({
+      loading: false,
+      scope: {
+        kind: 'unbound',
+        projectId: PROJECT_ID,
+        workspaceId: null,
+        context: null,
+      },
+    }));
+
+    hook.rerender({ caller: callerB });
+    expect(hook.result.current).toEqual({
+      loading: false,
+      scope: {
+        kind: 'unbound',
+        projectId: PROJECT_ID,
+        workspaceId: null,
+        context: null,
+      },
+    });
+
+    hook.rerender({ caller: null });
+    expect(hook.result.current).toEqual({
+      loading: false,
+      scope: {
+        kind: 'unbound',
+        projectId: PROJECT_ID,
+        workspaceId: null,
+        context: null,
+      },
+    });
+    await act(async () => {
+      for (let turn = 0; turn < 4; turn += 1) await Promise.resolve();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts the in-flight unbound answer when the ambient Team caller changes', async () => {
+    const callerA = workspaceContext('workspace-a', 'member-a');
+    const callerB = workspaceContext('workspace-b', 'member-b');
+    const firstScope = deferred<Response>();
+    const never = new Promise<Response>(() => {});
+    const fetchMock = vi.fn()
+      .mockImplementationOnce(() => firstScope.promise)
+      .mockImplementation(() => never);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const hook = renderHook(
+      ({ caller }) => useProjectWorkspaceScope(PROJECT_ID, caller, null),
+      { initialProps: { caller: callerA } },
+    );
+    expect(hook.result.current).toEqual({ loading: true, scope: null });
+
+    hook.rerender({ caller: callerB });
+    await act(async () => {
+      firstScope.resolve(jsonResponse({
+        scope: {
+          kind: 'unbound',
+          projectId: PROJECT_ID,
+          workspaceId: null,
+          context: null,
+        },
+      }));
+      await firstScope.promise;
+    });
+
+    await waitFor(() => expect(hook.result.current).toEqual({
+      loading: false,
+      scope: {
+        kind: 'unbound',
+        projectId: PROJECT_ID,
+        workspaceId: null,
+        context: null,
+      },
+    }));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Why

While validating Workspace collaboration end to end, we reproduced three authority gaps on the `feat/workspace-team` integration branch:

- a member could keep reading an already-materialized Team project after the owner revoked sharing;
- an unbound Personal project could lose settled authority when the ambient Workspace shell changed, leaving the same project opening stuck on a skeleton or viewer-only state;
- app-owned raw requests did not consistently pair explicit Workspace query parameters with the matching headers.

These bugs either retain access after revocation or strand authorized users in a stale fail-closed state. This follow-up keeps Team authorization fail-closed while making revocation and recovery converge deterministically.

## What users will see

- After an owner changes a Team project from Workspace-visible to private, members lose access without continuing to see stale files or previews. The local mirror and bytes remain preserved.
- Personal and other unbound projects recover in the same opening after Workspace scope/status resolves, instead of requiring the project to be closed and reopened.
- Scoped raw reads and deletes consistently use the selected Workspace authority; browser-owned iframe, CSS, font, and image navigation remains query-scoped because those navigations cannot attach custom headers.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json`
- [x] **Default behavior change** — authority revocation and recovery now converge without stale content
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

No new visual surface. Real two-account Chrome acceptance is tracked separately for the existing project viewer states.

## Bug fix verification

- Red specs:
  - `apps/daemon/tests/collab/workspace-projects-hub-wiring.test.ts`
  - `apps/daemon/tests/collab/workspace-projects-reconcile-http.test.ts`
  - `apps/web/tests/useProjectWorkspaceScope.test.tsx`
  - `apps/web/tests/useProjectWorkspaceScope.workspace-identity.test.tsx`
  - `apps/web/tests/components/FileViewer.test.tsx`
  - `apps/web/tests/components/DesignKitView.test.tsx`
  - `apps/web/tests/components/ProjectView.run-workspace-identity.test.tsx`
  - `apps/web/tests/providers/project-workspace-transport-scope.test.ts`
- Yes. The new assertions failed on the integration base and pass on this branch. They cover revoke quarantine, same-mount pending-to-authorized recovery, and query/header transport consistency.

## Validation

- Daemon focused tests: 40 passed
- Web focused tests: 320 passed
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard`
- Each source fix was also validated independently with root `pnpm typecheck` and `git diff --check`
- Real two-account Chrome acceptance requested via the team Feishu webhook; results pending
