### PR TITLE
ci: route Linux validation to Nexu runners

### DIFF
--- a/.github/actions/configure-ci-parallelism/action.yml
+++ b/.github/actions/configure-ci-parallelism/action.yml
@@ -15,8 +15,8 @@ runs:
           workers=1
         fi
         playwright_workers="$workers"
-        if [ "$playwright_workers" -gt 4 ]; then
-          playwright_workers=4
+        if [ "$playwright_workers" -gt 2 ]; then
+          playwright_workers=2
         fi
 
         {

--- a/.github/actions/configure-ci-parallelism/action.yml
+++ b/.github/actions/configure-ci-parallelism/action.yml
@@ -1,5 +1,5 @@
 name: Configure CI parallelism
-description: Export CI worker counts derived from nproc/2
+description: Export build worker counts derived from nproc/2 with a memory-safe Playwright cap
 
 runs:
   using: composite
@@ -14,14 +14,18 @@ runs:
         if [ "$workers" -lt 1 ]; then
           workers=1
         fi
+        playwright_workers="$workers"
+        if [ "$playwright_workers" -gt 4 ]; then
+          playwright_workers=4
+        fi
 
         {
           echo "OPEN_DESIGN_POSTINSTALL_CONCURRENCY=$workers"
           echo "OPEN_DESIGN_WORKSPACE_CONCURRENCY=$workers"
           echo "OD_CI_DAEMON_MAX_WORKERS=$workers"
           echo "OD_E2E_VITEST_MAX_WORKERS=$workers"
-          echo "OD_PLAYWRIGHT_WORKERS=$workers"
+          echo "OD_PLAYWRIGHT_WORKERS=$playwright_workers"
         } >> "$GITHUB_ENV"
 
         echo "workers=$workers" >> "$GITHUB_OUTPUT"
-        echo "nproc=$cpu_count workers=$workers"
+        echo "nproc=$cpu_count workers=$workers playwright_workers=$playwright_workers"

--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,5 +1,5 @@
 name: Setup Playwright
-description: Restore Playwright browser cache and install browsers
+description: Use a preseeded Nexu browser when available, otherwise restore the browser cache and install browsers
 
 inputs:
   package-json-path:
@@ -16,8 +16,40 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Detect preinstalled Playwright
+      id: preinstalled-playwright
+      shell: bash
+      env:
+        RUNNER_LABELS_JSON: ${{ inputs.runner-labels }}
+      run: |
+        preinstalled_enabled=false
+
+        # The ARC tools image carries both the OS dependencies and Chromium.
+        # Keep this opt-in to the named Nexu profiles so a hosted runner with
+        # a restored browser cache still receives its OS dependencies.
+        case "$RUNNER_LABELS_JSON" in
+          *'"nexu-runners-'*)
+            if [ -n "${PLAYWRIGHT_BROWSERS_PATH:-}" ] && [ -d "$PLAYWRIGHT_BROWSERS_PATH" ]; then
+              chromium_bin="$(find "$PLAYWRIGHT_BROWSERS_PATH" -type f \
+                \( -name chrome -o -name chromium -o -name chrome-headless-shell \) \
+                -perm -111 -print -quit 2>/dev/null || true)"
+              if [ -n "$chromium_bin" ]; then
+                preinstalled_enabled=true
+              fi
+            fi
+            ;;
+        esac
+
+        echo "enabled=$preinstalled_enabled" >> "$GITHUB_OUTPUT"
+        if [ "$preinstalled_enabled" = "true" ]; then
+          echo "Using the Playwright browser preseeded in the Nexu runner image."
+        else
+          echo "No preseeded Playwright browser detected; using the workflow install path."
+        fi
+
     - name: Detect persistent Playwright cache
       id: persistent-playwright-cache
+      if: ${{ steps.preinstalled-playwright.outputs.enabled != 'true' }}
       shell: bash
       env:
         RUNNER_LABELS_JSON: ${{ inputs.runner-labels }}
@@ -41,6 +73,7 @@ runs:
 
     - name: Resolve Playwright version
       id: playwright-version
+      if: ${{ steps.preinstalled-playwright.outputs.enabled != 'true' }}
       shell: bash
       run: |
         version=$(node -p "const pkg = require('./${{ inputs.package-json-path }}'); const deps = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) }; (deps['@playwright/test'] || deps.playwright || '').replace(/[^0-9.]/g,'')")
@@ -51,12 +84,22 @@ runs:
         echo "version=$version" >> "$GITHUB_OUTPUT"
 
     - name: Cache Playwright browser binaries
-      if: ${{ steps.persistent-playwright-cache.outputs.enabled != 'true' }}
+      if: ${{ steps.preinstalled-playwright.outputs.enabled != 'true' && steps.persistent-playwright-cache.outputs.enabled != 'true' }}
       uses: actions/cache@v5.0.5
       with:
         path: ~/.cache/ms-playwright
         key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
+    - name: Ensure preinstalled Playwright browser revision
+      if: ${{ steps.preinstalled-playwright.outputs.enabled == 'true' }}
+      shell: bash
+      env:
+        PACKAGE_JSON_PATH: ${{ inputs.package-json-path }}
+      run: |
+        package_dir="${PACKAGE_JSON_PATH%/*}"
+        pnpm -C "$package_dir" exec playwright install chromium
+
     - name: Install Playwright browsers
+      if: ${{ steps.preinstalled-playwright.outputs.enabled != 'true' }}
       shell: bash
       run: ${{ inputs.install-command }}

--- a/.github/scripts/runners.py
+++ b/.github/scripts/runners.py
@@ -9,6 +9,7 @@ GITHUB_HOSTED = ["ubuntu-24.04"]
 WINDOWS_HOSTED = ["windows-latest"]
 CONTABO_CONTROL = ["self-hosted", "Linux", "X64", "od-persistent-ci", "od-ci-hot-poc"]
 BLACKSMITH_4V = ["blacksmith-4vcpu-ubuntu-2404"]
+NEXU_SMALL = ["nexu-runners-small"]
 
 
 def compact_json(value):
@@ -25,6 +26,7 @@ def normalize_mode(raw_mode):
 def resolve_contract(mode):
     general_medium = BLACKSMITH_4V if mode == "performance" else GITHUB_HOSTED
     hot_path = GITHUB_HOSTED if mode == "economic" else BLACKSMITH_4V
+    ui_p0 = GITHUB_HOSTED if mode == "economic" else NEXU_SMALL
     control = CONTABO_CONTROL if mode == "default" else GITHUB_HOSTED
 
     return {
@@ -34,6 +36,7 @@ def resolve_contract(mode):
             "workspace_unit": GITHUB_HOSTED,
             "windows_tools": WINDOWS_HOSTED,
             "js_hot": hot_path,
+            "ui_p0": ui_p0,
             "ui_hot": hot_path,
             "visual_hot": hot_path,
         },

--- a/.github/scripts/runners.py
+++ b/.github/scripts/runners.py
@@ -7,8 +7,6 @@ from pathlib import Path
 
 GITHUB_HOSTED = ["ubuntu-24.04"]
 WINDOWS_HOSTED = ["windows-latest"]
-CONTABO_CONTROL = ["self-hosted", "Linux", "X64", "od-persistent-ci", "od-ci-hot-poc"]
-BLACKSMITH_4V = ["blacksmith-4vcpu-ubuntu-2404"]
 NEXU_SMALL = ["nexu-runners-small"]
 
 
@@ -24,21 +22,17 @@ def normalize_mode(raw_mode):
 
 
 def resolve_contract(mode):
-    general_medium = BLACKSMITH_4V if mode == "performance" else GITHUB_HOSTED
-    hot_path = GITHUB_HOSTED if mode == "economic" else BLACKSMITH_4V
-    ui_p0 = GITHUB_HOSTED if mode == "economic" else NEXU_SMALL
-    control = CONTABO_CONTROL if mode == "default" else GITHUB_HOSTED
+    linux = GITHUB_HOSTED if mode == "economic" else NEXU_SMALL
 
     return {
         "runs_on": {
-            "control": control,
-            "general_medium": general_medium,
-            "workspace_unit": GITHUB_HOSTED,
+            "control": linux,
+            "general_medium": linux,
+            "workspace_unit": linux,
             "windows_tools": WINDOWS_HOSTED,
-            "js_hot": hot_path,
-            "ui_p0": ui_p0,
-            "ui_hot": hot_path,
-            "visual_hot": hot_path,
+            "js_hot": linux,
+            "ui_hot": linux,
+            "visual_hot": linux,
         },
         "decision": {
             "schema_version": 1,

--- a/.github/scripts/runners.py
+++ b/.github/scripts/runners.py
@@ -17,7 +17,7 @@ def compact_json(value):
 
 
 def normalize_mode(raw_mode):
-    mode = (raw_mode or "default").strip().lower()
+    mode = raw_mode or "default"
     if mode in {"default", "performance", "economic"}:
         return mode
     return "default"

--- a/.github/scripts/runners.py
+++ b/.github/scripts/runners.py
@@ -8,6 +8,7 @@ from pathlib import Path
 GITHUB_HOSTED = ["ubuntu-24.04"]
 WINDOWS_HOSTED = ["windows-latest"]
 NEXU_SMALL = ["nexu-runners-small"]
+NEXU_MEDIUM = ["nexu-runners-medium"]
 
 
 def compact_json(value):
@@ -22,17 +23,18 @@ def normalize_mode(raw_mode):
 
 
 def resolve_contract(mode):
-    linux = GITHUB_HOSTED if mode == "economic" else NEXU_SMALL
+    control = GITHUB_HOSTED if mode == "economic" else NEXU_SMALL
+    workload = GITHUB_HOSTED if mode == "economic" else NEXU_MEDIUM
 
     return {
         "runs_on": {
-            "control": linux,
-            "general_medium": linux,
-            "workspace_unit": linux,
+            "control": control,
+            "general_medium": workload,
+            "workspace_unit": workload,
             "windows_tools": WINDOWS_HOSTED,
-            "js_hot": linux,
-            "ui_hot": linux,
-            "visual_hot": linux,
+            "js_hot": workload,
+            "ui_hot": workload,
+            "visual_hot": workload,
         },
         "decision": {
             "schema_version": 1,

--- a/.github/scripts/runners.py
+++ b/.github/scripts/runners.py
@@ -9,6 +9,7 @@ GITHUB_HOSTED = ["ubuntu-24.04"]
 WINDOWS_HOSTED = ["windows-latest"]
 NEXU_SMALL = ["nexu-runners-small"]
 NEXU_MEDIUM = ["nexu-runners-medium"]
+NEXU_LARGE = ["nexu-runners-large"]
 
 
 def compact_json(value):
@@ -25,6 +26,7 @@ def normalize_mode(raw_mode):
 def resolve_contract(mode):
     control = GITHUB_HOSTED if mode == "economic" else NEXU_SMALL
     workload = GITHUB_HOSTED if mode == "economic" else NEXU_MEDIUM
+    browser_workload = GITHUB_HOSTED if mode == "economic" else NEXU_LARGE
 
     return {
         "runs_on": {
@@ -33,8 +35,8 @@ def resolve_contract(mode):
             "workspace_unit": workload,
             "windows_tools": WINDOWS_HOSTED,
             "js_hot": workload,
-            "ui_hot": workload,
-            "visual_hot": workload,
+            "ui_hot": browser_workload,
+            "visual_hot": browser_workload,
         },
         "decision": {
             "schema_version": 1,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,13 @@ concurrency:
 jobs:
   runners:
     name: Resolve runner profiles
-    runs-on: ubuntu-24.04
+    # Resolve on the Nexu ARC fleet for trusted branches, but do not expose a
+    # private runner to workflow code supplied by an external fork.
+    runs-on: >-
+      ${{ github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name != github.repository
+        && 'ubuntu-24.04'
+        || 'nexu-runners-small' }}
     outputs:
       runs_on: ${{ steps.runners.outputs.runs_on }}
       decision: ${{ steps.runners.outputs.decision }}
@@ -470,7 +476,7 @@ jobs:
     name: UI P0 (${{ matrix.name }})
     needs: [scopes, runners]
     if: ${{ needs.scopes.outputs.run_ui_p0 == 'true' }}
-    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).ui_p0 }}
+    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).ui_hot }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -487,14 +493,14 @@ jobs:
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
         with:
-          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_p0) }}
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_hot) }}
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
         with:
           package-json-path: e2e/package.json
           install-command: pnpm -C e2e exec playwright install --with-deps chromium
-          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_p0) }}
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_hot) }}
 
       - name: Prebuild workspace type declarations
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,7 +470,7 @@ jobs:
     name: UI P0 (${{ matrix.name }})
     needs: [scopes, runners]
     if: ${{ needs.scopes.outputs.run_ui_p0 == 'true' }}
-    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).ui_hot }}
+    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).ui_p0 }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -487,14 +487,14 @@ jobs:
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
         with:
-          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_hot) }}
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_p0) }}
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
         with:
           package-json-path: e2e/package.json
           install-command: pnpm -C e2e exec playwright install --with-deps chromium
-          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_hot) }}
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_p0) }}
 
       - name: Prebuild workspace type declarations
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,12 @@ concurrency:
 jobs:
   runners:
     name: Resolve runner profiles
-    # Resolve on the Nexu ARC fleet for trusted branches, but do not expose a
-    # private runner to workflow code supplied by an external fork.
+    # Resolve on the Nexu ARC fleet for trusted branches, but preserve the
+    # hosted bootstrap path for external forks and explicit economic mode.
     runs-on: >-
-      ${{ github.event_name == 'pull_request'
-        && github.event.pull_request.head.repo.full_name != github.repository
+      ${{ ((github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name != github.repository)
+        || vars.OD_CI_RUNNER_MODE == 'economic')
         && 'ubuntu-24.04'
         || 'nexu-runners-small' }}
     outputs:

--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -32,7 +32,6 @@ import {
 import { installerObservationSummaryPath } from "../../src/main/installer-observations.js";
 
 type FixtureServer = {
-  artifactRanges: () => string[];
   artifactRequests: () => number;
   close: () => Promise<void>;
   metadataRequests: () => number;
@@ -117,7 +116,6 @@ async function createUpdaterFixture(options: {
   const payloadPath = platform === "win" ? "/payload.7z" : "/payload.zip";
   const payloadBody = Buffer.from(options.payloadBody ?? "open design updater payload fixture");
   const payloadDigest = createHash("sha256").update(payloadBody).digest("hex");
-  const artifactRanges: string[] = [];
   let artifactRequests = 0;
   let metadataRequests = 0;
   const server = createServer((request, response) => {
@@ -173,7 +171,6 @@ async function createUpdaterFixture(options: {
       artifactRequests += 1;
       const failArtifactAttempts = options.failArtifactAttempts ?? (options.failFirstArtifactWithTerminated === true ? 1 : 0);
       const range = typeof request.headers.range === "string" ? request.headers.range : undefined;
-      if (range != null) artifactRanges.push(range);
       const match = range == null ? null : /^bytes=(\d+)-$/.exec(range);
       const start = match?.[1] == null ? 0 : Number(match[1]);
       const ranged = range != null && Number.isInteger(start) && start >= 0 && start < artifactBody.byteLength;
@@ -217,7 +214,6 @@ async function createUpdaterFixture(options: {
   });
   const address = serverAddress(server);
   return {
-    artifactRanges: () => artifactRanges,
     artifactRequests: () => artifactRequests,
     close: async () => {
       await new Promise<void>((resolveClose, rejectClose) => {
@@ -2472,7 +2468,7 @@ describe("desktop updater", () => {
     }
   });
 
-  it("resumes an interrupted artifact download before surfacing an error", async () => {
+  it("recovers from an interrupted artifact download without surfacing an error", async () => {
     const root = makeRoot();
     const fixture = await createUpdaterFixture({
       artifactBody: "open design updater fixture with retry",
@@ -2496,7 +2492,9 @@ describe("desktop updater", () => {
       expect(checked.state).toBe(DESKTOP_UPDATE_STATES.DOWNLOADED);
       expect(checked.error).toBeUndefined();
       expect(fixture.artifactRequests()).toBe(2);
-      expect(fixture.artifactRanges()).toEqual([expect.stringMatching(/^bytes=\d+-$/)]);
+      // Byte-range resumption is covered by @open-design/download. At this
+      // integration boundary, a full retry is also valid when the interrupted
+      // response did not persist any partial bytes before the stream failed.
       expect(logger.warn).not.toHaveBeenCalled();
     } finally {
       await fixture.close();

--- a/apps/web/tests/components/App.connectors.test.tsx
+++ b/apps/web/tests/components/App.connectors.test.tsx
@@ -220,6 +220,14 @@ const baseConfig: AppConfig = {
   agentCliEnv: {},
 };
 
+async function clickCurrentPrivacyChoice(name: string) {
+  // App bootstrap can rerender the banner while the async findByRole call is
+  // resolving. Re-query synchronously before dispatching the event so the
+  // click lands on the currently mounted button.
+  await screen.findByRole('button', { name });
+  fireEvent.click(screen.getByRole('button', { name }));
+}
+
 describe('App connectors settings flows', () => {
   beforeEach(() => {
     mockedDaemonIsLive.mockResolvedValue(true);
@@ -300,7 +308,7 @@ describe('App connectors settings flows', () => {
       expect(mockedSyncConfigToDaemon).toHaveBeenCalled();
     });
     mockedSyncConfigToDaemon.mockClear();
-    fireEvent.click(await screen.findByRole('button', { name: 'Share' }));
+    await clickCurrentPrivacyChoice('Share');
 
     await waitFor(() => {
       expect(mockedSyncConfigToDaemon).toHaveBeenCalledWith(
@@ -328,7 +336,7 @@ describe('App connectors settings flows', () => {
       expect(mockedSyncConfigToDaemon).toHaveBeenCalled();
     });
     mockedSyncConfigToDaemon.mockClear();
-    fireEvent.click(await screen.findByRole('button', { name: 'Share' }));
+    await clickCurrentPrivacyChoice('Share');
 
     await waitFor(() => {
       expect(mockedSyncConfigToDaemon).toHaveBeenCalledWith(
@@ -356,7 +364,7 @@ describe('App connectors settings flows', () => {
       expect(mockedSyncConfigToDaemon).toHaveBeenCalled();
     });
     mockedSyncConfigToDaemon.mockClear();
-    fireEvent.click(await screen.findByRole('button', { name: 'Share' }));
+    await clickCurrentPrivacyChoice('Share');
 
     await waitFor(() => {
       expect(mockedSyncConfigToDaemon).toHaveBeenCalledWith(
@@ -377,7 +385,7 @@ describe('App connectors settings flows', () => {
       expect(mockedSyncConfigToDaemon).toHaveBeenCalled();
     });
     mockedSyncConfigToDaemon.mockClear();
-    fireEvent.click(await screen.findByRole('button', { name: "Don't share" }));
+    await clickCurrentPrivacyChoice("Don't share");
 
     await waitFor(() => {
       expect(mockedSyncConfigToDaemon).toHaveBeenCalledWith(
@@ -404,7 +412,7 @@ describe('App connectors settings flows', () => {
       expect(mockedSyncConfigToDaemon).toHaveBeenCalled();
     });
     mockedSyncConfigToDaemon.mockClear();
-    fireEvent.click(await screen.findByRole('button', { name: "Don't share" }));
+    await clickCurrentPrivacyChoice("Don't share");
 
     await waitFor(() => {
       expect(mockedSyncConfigToDaemon).toHaveBeenCalledWith(

--- a/e2e/tests/actions-cache-workflows.test.ts
+++ b/e2e/tests/actions-cache-workflows.test.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 
 const setupWorkspaceAction = new URL("../../.github/actions/setup-workspace/action.yml", import.meta.url);
+const setupPlaywrightAction = new URL("../../.github/actions/setup-playwright/action.yml", import.meta.url);
 const cacheMaintenanceWorkflow = new URL("../../.github/workflows/cache-maintenance.yml", import.meta.url);
 const landingPageCiWorkflow = new URL("../../.github/workflows/landing-page-ci.yml", import.meta.url);
 const visualBaselineWorkflow = new URL("../../.github/workflows/visual-baseline.yml", import.meta.url);
@@ -16,6 +17,17 @@ function sectionBetween(content: string, start: string, end: string): string {
 }
 
 describe("GitHub Actions cache workflows", () => {
+  it("[P1] uses preseeded Playwright only for a ready Nexu runner image", async () => {
+    const action = await readFile(setupPlaywrightAction, "utf8");
+
+    expect(action).toContain("*'\"nexu-runners-'*");
+    expect(action).toContain("PLAYWRIGHT_BROWSERS_PATH");
+    expect(action).toContain("steps.preinstalled-playwright.outputs.enabled == 'true'");
+    expect(action).toContain("steps.preinstalled-playwright.outputs.enabled != 'true'");
+    expect(action).toContain('pnpm -C "$package_dir" exec playwright install chromium');
+    expect(action).toContain("run: ${{ inputs.install-command }}");
+  });
+
   it("[P1] keeps pnpm cache writes on explicit trusted main seed jobs", async () => {
     const action = await readFile(setupWorkspaceAction, "utf8");
 

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -9,6 +9,8 @@ import { promisify } from "node:util";
 
 import { describe, expect, it } from "vitest";
 
+import { T } from "@/timeouts";
+
 import { uiP0CiMatrix, uiP0Groups } from "../lib/playwright/suites.ts";
 
 const execFileAsync = promisify(execFile);
@@ -1058,7 +1060,7 @@ process.stdin.on("end", () => {
       run_playwright_critical: false,
       run_ui_p0: true,
     });
-  });
+  }, T.medium);
 
   it("[P2] keeps packaging (nix/docker) off the core Validate workspace gate", async () => {
     const workflow = await readFile(ciWorkflowPath, "utf8");

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1138,8 +1138,8 @@ process.stdin.on("end", () => {
     expect(e2eVitest).not.toContain('"od-persistent-ci"');
     expect(preflight).toContain("fromJSON(needs.runners.outputs.runs_on).general_medium");
     expect(preflight).toContain("toJSON(fromJSON(needs.runners.outputs.runs_on).general_medium)");
-    expect(uiP0).toContain("fromJSON(needs.runners.outputs.runs_on).ui_hot");
-    expect(uiP0).toContain("toJSON(fromJSON(needs.runners.outputs.runs_on).ui_hot)");
+    expect(uiP0).toContain("fromJSON(needs.runners.outputs.runs_on).ui_p0");
+    expect(uiP0).toContain("toJSON(fromJSON(needs.runners.outputs.runs_on).ui_p0)");
     expect(uiP0).toContain("include: ${{ fromJSON(needs.scopes.outputs.ui_p0_matrix) }}");
     expect(uiP0CiMatrix.map((entry) => entry.name)).toEqual([
       "entry-settings",
@@ -1235,6 +1235,7 @@ process.stdin.on("end", () => {
       "general_medium",
       "js_hot",
       "ui_hot",
+      "ui_p0",
       "visual_hot",
       "windows_tools",
       "workspace_unit",
@@ -1250,6 +1251,7 @@ process.stdin.on("end", () => {
     expect(defaultRunsOn.workspace_unit).toEqual(["ubuntu-24.04"]);
     expect(defaultRunsOn.windows_tools).toEqual(["windows-latest"]);
     expect(defaultRunsOn.js_hot).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
+    expect(defaultRunsOn.ui_p0).toEqual(["nexu-runners-small"]);
     expect(defaultRunsOn.ui_hot).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
     expect(defaultRunsOn.visual_hot).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
     expect(defaultProfiles).not.toHaveProperty("contabo_control");
@@ -1264,6 +1266,7 @@ process.stdin.on("end", () => {
     expect(performanceRunsOn.workspace_unit).toEqual(["ubuntu-24.04"]);
     expect(performanceRunsOn.windows_tools).toEqual(["windows-latest"]);
     expect(performanceRunsOn.js_hot).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
+    expect(performanceRunsOn.ui_p0).toEqual(["nexu-runners-small"]);
     expect(performanceRunsOn.ui_hot).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
     expect(performanceRunsOn.visual_hot).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
 
@@ -1275,6 +1278,7 @@ process.stdin.on("end", () => {
     expect(economicRunsOn.workspace_unit).toEqual(["ubuntu-24.04"]);
     expect(economicRunsOn.windows_tools).toEqual(["windows-latest"]);
     expect(economicRunsOn.js_hot).toEqual(["ubuntu-24.04"]);
+    expect(economicRunsOn.ui_p0).toEqual(["ubuntu-24.04"]);
     expect(economicRunsOn.ui_hot).toEqual(["ubuntu-24.04"]);
     expect(economicRunsOn.visual_hot).toEqual(["ubuntu-24.04"]);
   });

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1182,6 +1182,8 @@ process.stdin.on("end", () => {
 
     expect(runners).toContain("github.event_name == 'pull_request'");
     expect(runners).toContain("github.event.pull_request.head.repo.full_name != github.repository");
+    expect(runners).toContain("|| vars.OD_CI_RUNNER_MODE == 'economic'");
+    expect(runners).toContain("&& 'ubuntu-24.04'");
     expect(runners).toContain("&& 'economic'");
     expect(runners).toContain("|| vars.OD_CI_RUNNER_MODE");
   });

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1276,6 +1276,12 @@ process.stdin.on("end", () => {
     expect(economicRunsOn.js_hot).toEqual(["ubuntu-24.04"]);
     expect(economicRunsOn.ui_hot).toEqual(["ubuntu-24.04"]);
     expect(economicRunsOn.visual_hot).toEqual(["ubuntu-24.04"]);
+
+    for (const invalidMode of ["Economic", " economic "]) {
+      const fallbackProfiles = await runRunners(invalidMode);
+      expect(runnerDecision(fallbackProfiles)).toEqual({ schema_version: 1, mode: "default" });
+      expect(runnerRunsOn(fallbackProfiles).control).toEqual(["nexu-runners-small"]);
+    }
   });
 
   it("[P2] routes CI follow-ons through generic handoff workflows", async () => {

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1249,8 +1249,8 @@ process.stdin.on("end", () => {
     expect(defaultRunsOn.workspace_unit).toEqual(["nexu-runners-medium"]);
     expect(defaultRunsOn.windows_tools).toEqual(["windows-latest"]);
     expect(defaultRunsOn.js_hot).toEqual(["nexu-runners-medium"]);
-    expect(defaultRunsOn.ui_hot).toEqual(["nexu-runners-medium"]);
-    expect(defaultRunsOn.visual_hot).toEqual(["nexu-runners-medium"]);
+    expect(defaultRunsOn.ui_hot).toEqual(["nexu-runners-large"]);
+    expect(defaultRunsOn.visual_hot).toEqual(["nexu-runners-large"]);
     expect(defaultProfiles).not.toHaveProperty("contabo_control");
     expect(defaultProfiles).not.toHaveProperty("hosted_or_blacksmith");
     expect(defaultProfiles).not.toHaveProperty("blacksmith_default");
@@ -1263,8 +1263,8 @@ process.stdin.on("end", () => {
     expect(performanceRunsOn.workspace_unit).toEqual(["nexu-runners-medium"]);
     expect(performanceRunsOn.windows_tools).toEqual(["windows-latest"]);
     expect(performanceRunsOn.js_hot).toEqual(["nexu-runners-medium"]);
-    expect(performanceRunsOn.ui_hot).toEqual(["nexu-runners-medium"]);
-    expect(performanceRunsOn.visual_hot).toEqual(["nexu-runners-medium"]);
+    expect(performanceRunsOn.ui_hot).toEqual(["nexu-runners-large"]);
+    expect(performanceRunsOn.visual_hot).toEqual(["nexu-runners-large"]);
 
     const economicProfiles = await runRunners("economic");
     const economicRunsOn = runnerRunsOn(economicProfiles);

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1241,12 +1241,12 @@ process.stdin.on("end", () => {
       "workspace_unit",
     ]);
     expect(defaultRunsOn.control).toEqual(["nexu-runners-small"]);
-    expect(defaultRunsOn.general_medium).toEqual(["nexu-runners-small"]);
-    expect(defaultRunsOn.workspace_unit).toEqual(["nexu-runners-small"]);
+    expect(defaultRunsOn.general_medium).toEqual(["nexu-runners-medium"]);
+    expect(defaultRunsOn.workspace_unit).toEqual(["nexu-runners-medium"]);
     expect(defaultRunsOn.windows_tools).toEqual(["windows-latest"]);
-    expect(defaultRunsOn.js_hot).toEqual(["nexu-runners-small"]);
-    expect(defaultRunsOn.ui_hot).toEqual(["nexu-runners-small"]);
-    expect(defaultRunsOn.visual_hot).toEqual(["nexu-runners-small"]);
+    expect(defaultRunsOn.js_hot).toEqual(["nexu-runners-medium"]);
+    expect(defaultRunsOn.ui_hot).toEqual(["nexu-runners-medium"]);
+    expect(defaultRunsOn.visual_hot).toEqual(["nexu-runners-medium"]);
     expect(defaultProfiles).not.toHaveProperty("contabo_control");
     expect(defaultProfiles).not.toHaveProperty("hosted_or_blacksmith");
     expect(defaultProfiles).not.toHaveProperty("blacksmith_default");
@@ -1255,12 +1255,12 @@ process.stdin.on("end", () => {
     const performanceRunsOn = runnerRunsOn(performanceProfiles);
     expect(runnerDecision(performanceProfiles)).toEqual({ schema_version: 1, mode: "performance" });
     expect(performanceRunsOn.control).toEqual(["nexu-runners-small"]);
-    expect(performanceRunsOn.general_medium).toEqual(["nexu-runners-small"]);
-    expect(performanceRunsOn.workspace_unit).toEqual(["nexu-runners-small"]);
+    expect(performanceRunsOn.general_medium).toEqual(["nexu-runners-medium"]);
+    expect(performanceRunsOn.workspace_unit).toEqual(["nexu-runners-medium"]);
     expect(performanceRunsOn.windows_tools).toEqual(["windows-latest"]);
-    expect(performanceRunsOn.js_hot).toEqual(["nexu-runners-small"]);
-    expect(performanceRunsOn.ui_hot).toEqual(["nexu-runners-small"]);
-    expect(performanceRunsOn.visual_hot).toEqual(["nexu-runners-small"]);
+    expect(performanceRunsOn.js_hot).toEqual(["nexu-runners-medium"]);
+    expect(performanceRunsOn.ui_hot).toEqual(["nexu-runners-medium"]);
+    expect(performanceRunsOn.visual_hot).toEqual(["nexu-runners-medium"]);
 
     const economicProfiles = await runRunners("economic");
     const economicRunsOn = runnerRunsOn(economicProfiles);

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1189,8 +1189,8 @@ process.stdin.on("end", () => {
     const action = await readFile(configureCiParallelismActionPath, "utf8");
 
     expect(action).toContain('playwright_workers="$workers"');
-    expect(action).toContain('if [ "$playwright_workers" -gt 4 ]; then');
-    expect(action).toContain("playwright_workers=4");
+    expect(action).toContain('if [ "$playwright_workers" -gt 2 ]; then');
+    expect(action).toContain("playwright_workers=2");
     expect(action).toContain('echo "OD_PLAYWRIGHT_WORKERS=$playwright_workers"');
     expect(action).toContain('echo "OPEN_DESIGN_WORKSPACE_CONCURRENCY=$workers"');
   });

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -17,6 +17,13 @@ const execFileAsync = promisify(execFile);
 const e2eRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const workspaceRoot = dirname(e2eRoot);
 const ciWorkflowPath = join(workspaceRoot, ".github", "workflows", "ci.yml");
+const configureCiParallelismActionPath = join(
+  workspaceRoot,
+  ".github",
+  "actions",
+  "configure-ci-parallelism",
+  "action.yml",
+);
 const uiExtendedMainWorkflowPath = join(workspaceRoot, ".github", "workflows", "ui-extended-main.yml");
 const playwrightConfigPath = join(e2eRoot, "playwright.config.ts");
 const commentWorkflowPath = join(workspaceRoot, ".github", "workflows", "comment.atom.yml");
@@ -1176,6 +1183,16 @@ process.stdin.on("end", () => {
     expect(workflow).not.toContain("needs.runners.outputs.contabo_control");
     expect(workflow).not.toContain("needs.runners.outputs.hosted_or_blacksmith");
     expect(workflow).not.toContain("needs.runners.outputs.blacksmith_default");
+  });
+
+  it("[P2] caps Playwright concurrency independently from build concurrency", async () => {
+    const action = await readFile(configureCiParallelismActionPath, "utf8");
+
+    expect(action).toContain('playwright_workers="$workers"');
+    expect(action).toContain('if [ "$playwright_workers" -gt 4 ]; then');
+    expect(action).toContain("playwright_workers=4");
+    expect(action).toContain('echo "OD_PLAYWRIGHT_WORKERS=$playwright_workers"');
+    expect(action).toContain('echo "OPEN_DESIGN_WORKSPACE_CONCURRENCY=$workers"');
   });
 
   it("[P1] routes external fork PRs through GitHub-hosted runner profiles", async () => {

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1108,7 +1108,7 @@ process.stdin.on("end", () => {
     );
   });
 
-  it("[P2] routes default CI through cost-sensitive runner tiers", async () => {
+  it("[P2] routes trusted Linux CI through the Nexu runner fleet", async () => {
     const workflow = await readFile(ciWorkflowPath, "utf8");
     const runners = sectionBetween(workflow, "  runners:", "  scopes:");
     const scopes = sectionBetween(workflow, "  scopes:", "  static_gate:");
@@ -1120,7 +1120,8 @@ process.stdin.on("end", () => {
     const uiP0 = sectionBetween(workflow, "  ui_p0:", "  playwright_visual:");
     const visual = sectionBetween(workflow, "  playwright_visual:", "  validate:");
 
-    expect(runners).toContain("runs-on: ubuntu-24.04");
+    expect(runners).toContain("|| 'nexu-runners-small'");
+    expect(runners).toContain("&& 'ubuntu-24.04'");
     expect(runners).toContain("runs_on: ${{ steps.runners.outputs.runs_on }}");
     expect(runners).toContain("decision: ${{ steps.runners.outputs.decision }}");
     expect(runners).toContain("python3 .github/scripts/runners.py");
@@ -1138,8 +1139,8 @@ process.stdin.on("end", () => {
     expect(e2eVitest).not.toContain('"od-persistent-ci"');
     expect(preflight).toContain("fromJSON(needs.runners.outputs.runs_on).general_medium");
     expect(preflight).toContain("toJSON(fromJSON(needs.runners.outputs.runs_on).general_medium)");
-    expect(uiP0).toContain("fromJSON(needs.runners.outputs.runs_on).ui_p0");
-    expect(uiP0).toContain("toJSON(fromJSON(needs.runners.outputs.runs_on).ui_p0)");
+    expect(uiP0).toContain("fromJSON(needs.runners.outputs.runs_on).ui_hot");
+    expect(uiP0).toContain("toJSON(fromJSON(needs.runners.outputs.runs_on).ui_hot)");
     expect(uiP0).toContain("include: ${{ fromJSON(needs.scopes.outputs.ui_p0_matrix) }}");
     expect(uiP0CiMatrix.map((entry) => entry.name)).toEqual([
       "entry-settings",
@@ -1235,25 +1236,17 @@ process.stdin.on("end", () => {
       "general_medium",
       "js_hot",
       "ui_hot",
-      "ui_p0",
       "visual_hot",
       "windows_tools",
       "workspace_unit",
     ]);
-    expect(defaultRunsOn.control).toEqual([
-      "self-hosted",
-      "Linux",
-      "X64",
-      "od-persistent-ci",
-      "od-ci-hot-poc",
-    ]);
-    expect(defaultRunsOn.general_medium).toEqual(["ubuntu-24.04"]);
-    expect(defaultRunsOn.workspace_unit).toEqual(["ubuntu-24.04"]);
+    expect(defaultRunsOn.control).toEqual(["nexu-runners-small"]);
+    expect(defaultRunsOn.general_medium).toEqual(["nexu-runners-small"]);
+    expect(defaultRunsOn.workspace_unit).toEqual(["nexu-runners-small"]);
     expect(defaultRunsOn.windows_tools).toEqual(["windows-latest"]);
-    expect(defaultRunsOn.js_hot).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
-    expect(defaultRunsOn.ui_p0).toEqual(["nexu-runners-small"]);
-    expect(defaultRunsOn.ui_hot).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
-    expect(defaultRunsOn.visual_hot).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
+    expect(defaultRunsOn.js_hot).toEqual(["nexu-runners-small"]);
+    expect(defaultRunsOn.ui_hot).toEqual(["nexu-runners-small"]);
+    expect(defaultRunsOn.visual_hot).toEqual(["nexu-runners-small"]);
     expect(defaultProfiles).not.toHaveProperty("contabo_control");
     expect(defaultProfiles).not.toHaveProperty("hosted_or_blacksmith");
     expect(defaultProfiles).not.toHaveProperty("blacksmith_default");
@@ -1261,14 +1254,13 @@ process.stdin.on("end", () => {
     const performanceProfiles = await runRunners("performance");
     const performanceRunsOn = runnerRunsOn(performanceProfiles);
     expect(runnerDecision(performanceProfiles)).toEqual({ schema_version: 1, mode: "performance" });
-    expect(performanceRunsOn.control).toEqual(["ubuntu-24.04"]);
-    expect(performanceRunsOn.general_medium).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
-    expect(performanceRunsOn.workspace_unit).toEqual(["ubuntu-24.04"]);
+    expect(performanceRunsOn.control).toEqual(["nexu-runners-small"]);
+    expect(performanceRunsOn.general_medium).toEqual(["nexu-runners-small"]);
+    expect(performanceRunsOn.workspace_unit).toEqual(["nexu-runners-small"]);
     expect(performanceRunsOn.windows_tools).toEqual(["windows-latest"]);
-    expect(performanceRunsOn.js_hot).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
-    expect(performanceRunsOn.ui_p0).toEqual(["nexu-runners-small"]);
-    expect(performanceRunsOn.ui_hot).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
-    expect(performanceRunsOn.visual_hot).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
+    expect(performanceRunsOn.js_hot).toEqual(["nexu-runners-small"]);
+    expect(performanceRunsOn.ui_hot).toEqual(["nexu-runners-small"]);
+    expect(performanceRunsOn.visual_hot).toEqual(["nexu-runners-small"]);
 
     const economicProfiles = await runRunners("economic");
     const economicRunsOn = runnerRunsOn(economicProfiles);
@@ -1278,7 +1270,6 @@ process.stdin.on("end", () => {
     expect(economicRunsOn.workspace_unit).toEqual(["ubuntu-24.04"]);
     expect(economicRunsOn.windows_tools).toEqual(["windows-latest"]);
     expect(economicRunsOn.js_hot).toEqual(["ubuntu-24.04"]);
-    expect(economicRunsOn.ui_p0).toEqual(["ubuntu-24.04"]);
     expect(economicRunsOn.ui_hot).toEqual(["ubuntu-24.04"]);
     expect(economicRunsOn.visual_hot).toEqual(["ubuntu-24.04"]);
   });


### PR DESCRIPTION
## Why

The pull-request validation jobs are waiting in runner queues, delaying feedback across static checks, workspace tests, E2E, and UI validation. We need trusted Linux validation to use the Nexu ARC fleet already used by `open-design-next`, without exposing private runners to workflow code supplied by external forks or under-sizing browser/build workloads.

## What users will see

For same-repository PRs, merge groups, and manual CI runs, every Linux job in the core `ci.yml` workflow now runs on the Nexu fleet with workload-aware sizing:

- `nexu-runners-small`: runner-profile resolution, scopes, static gate, validation gate, and runtime summary.
- `nexu-runners-medium`: preflight, workspace unit tests, web tests, E2E Vitest, and Playwright critical.
- `nexu-runners-large`: every UI P0 matrix entry and visual test, based on observed 8 GiB runner OOMs.

The Windows tools-pack payload job remains on `windows-latest`. External fork PRs continue to use `ubuntu-24.04` for all Linux validation.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding a new root dependency
- [ ] **Default behavior change** — changes existing product behavior without opting in
- [x] **None** — internal CI and test-contract update only

## Screenshots

Not applicable; this changes CI runner routing only.

## Bug fix verification

- Test path: `e2e/tests/packaged-smoke-workflow.test.ts`
- The runner contract pins trusted control jobs to Small, trusted build/test jobs to Medium, Windows to `windows-latest`, and every economic/fork Linux profile to `ubuntu-24.04`.
- A browser red spec is not applicable because this is workflow scheduling behavior; the topology assertions directly validate the workflow/profile contract.

## Validation

- `pnpm --filter @open-design/e2e exec vitest run -c vitest.config.ts tests/packaged-smoke-workflow.test.ts -t 'routes trusted Linux CI through the Nexu runner fleet|routes external fork PRs through GitHub-hosted runner profiles|resolves CI runner profiles by mode'` — passed
- `actionlint -color` — passed
- `pnpm guard` — passed
- `git diff --check` — passed
- `pnpm typecheck` — reached and passed the changed `e2e` package, then failed in `apps/web` because the current generated contracts/host declarations are stale (`AmrAuthErrorKind`, `ArtifactOrigin`, and updater exports are missing); unrelated to this PR