### PR TITLE
fix(desktop): sequence updater fixture's simulated disconnect after write flush

### DIFF
--- a/apps/desktop/tests/main/updater.test.ts
+++ b/apps/desktop/tests/main/updater.test.ts
@@ -186,8 +186,13 @@ async function createUpdaterFixture(options: {
       }
       if (artifactRequests <= failArtifactAttempts) {
         const failedChunkLength = Math.max(1, Math.floor(body.byteLength / 2));
-        response.write(body.subarray(0, failedChunkLength));
-        setTimeout(() => response.destroy(new Error("terminated")), 5);
+        // Sequence the destroy after write's flush callback, not concurrently
+        // with it: an unconfirmed write racing an independent timer can fire
+        // the destroy before the chunk reaches the socket, so the client sees
+        // zero bytes and retries without a Range header instead of resuming.
+        response.write(body.subarray(0, failedChunkLength), () => {
+          setTimeout(() => response.destroy(new Error("terminated")), 5);
+        });
         return;
       }
       response.end(body);


### PR DESCRIPTION
## Why

Surfaced while investigating a CI failure on #6407 (routes CI to a new runner fleet): \`Workspace unit tests\` failed with \`apps/desktop/tests/main/updater.test.ts\`'s "resumes an interrupted artifact download before surfacing an error" asserting an empty Range-header array. That PR just changes which runner the job executes on — this fixture race was always there, a different scheduler just gave it a route to actually fire.

**The bug**: the fixture simulates a dropped connection with \`response.write(firstHalf)\` immediately followed by \`setTimeout(() => response.destroy(...), 5)\` on an independent timer. The destroy timer races the write's own flush — if the chunk hasn't reached the socket before the timer fires, the client receives zero bytes, so its retry starts a fresh (non-ranged) request instead of resuming. The test's own \`expect(fixture.artifactRanges()).toEqual([...])\` assertion then fails nondeterministically, depending on host scheduling.

## What users will see

Nothing — this is a test-fixture-only fix, no product code changed.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Bug fix verification

- Test path: \`apps/desktop/tests/main/updater.test.ts\` — "resumes an interrupted artifact download before surfacing an error"
- Red: forced the race by destroying synchronously right after \`write()\` (removing all timing margin) — failed 3/3 with the exact same assertion mismatch seen in CI (\`artifactRanges()\` empty instead of a Range-matching string).
- Green: sequenced the destroy inside \`write\`'s flush callback so the timer only starts once Node confirms the chunk is queued to the transport, keeping the original 5ms grace period. Reran the fixed test 30/30 green; full \`updater.test.ts\` file 74/74 passing.

## Validation

- \`pnpm --filter @open-design/desktop exec vitest run -c vitest.config.ts tests/main/updater.test.ts\` — 74/74 passing
- \`pnpm --filter @open-design/desktop typecheck\` — clean