### PR TITLE
fix(landing): keep Codex Slides gallery within narrow screens

### DIFF
--- a/apps/landing-page/app/pages/codex-slides/index.astro
+++ b/apps/landing-page/app/pages/codex-slides/index.astro
@@ -483,7 +483,7 @@ const studioTiles = copy.inside.map((tile, i) => ({ ...tile, src: STUDIO_SHOTS[i
   /* Studio UI screenshots carry dense product chrome, so they need a bigger
      cell than the simple deck cards — two-up instead of four-up. */
   .ha-showcase-wide {
-    grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 420px), 1fr));
   }
 
   /* ---- Scenario cards ---- */


### PR DESCRIPTION
Fixes #6097

## Problem

The `.ha-showcase-wide` grid on `/codex-slides/` uses `minmax(420px, 1fr)`, causing studio screenshot cards to overflow their container on narrow phones. The global `overflow-x: clip` hides the horizontal scrollbar, making the content loss invisible.

## Solution

Change `minmax(420px, 1fr)` to `minmax(min(100%, 420px), 1fr)`. This ensures the minimum track size never exceeds the container width on narrow screens, while preserving the 420px minimum and two-column layout when enough space exists.