### PR TITLE
ci: pin pnpm store path across runner fleets

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -47,7 +47,17 @@ runs:
           echo "enabled=true" >> "$GITHUB_OUTPUT"
           echo "path=$store_dir" >> "$GITHUB_OUTPUT"
         else
+          # Force a stable home store path so actions/cache version hashes match
+          # across fleets (hosted vs Nexu ARC). ARC may copy instead of hardlink;
+          # that is acceptable for cache hit stability.
+          store_dir="$HOME/.pnpm-store"
+          mkdir -p "$store_dir"
+          {
+            echo "NPM_CONFIG_STORE_DIR=$store_dir"
+            echo "npm_config_store_dir=$store_dir"
+          } >> "$GITHUB_ENV"
           echo "enabled=false" >> "$GITHUB_OUTPUT"
+          echo "path=$store_dir" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Setup pnpm
@@ -73,6 +83,8 @@ runs:
       with:
         path: ${{ steps.pnpm-store.outputs.path }}
         key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          pnpm-store-${{ runner.os }}-
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/cache-maintenance.yml
+++ b/.github/workflows/cache-maintenance.yml
@@ -29,6 +29,23 @@ jobs:
         with:
           save-pnpm-cache: 'true'
 
+
+  # GHA actions/cache is repo-scoped and shared across hosted + every Nexu
+  # size (small/medium/large). One Linux seed under the pinned home store path
+  # is enough for the whole fleet; no per-size matrix required.
+  seed-pnpm-linux:
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6.0.2
+
+      - name: Seed Linux pnpm cache
+        uses: ./.github/actions/setup-workspace
+        with:
+          save-pnpm-cache: 'true'
+
   clean-closed-pr-buildkit:
     if: github.event_name == 'pull_request_target' && github.repository == 'nexu-io/open-design'
     runs-on: ubuntu-24.04

--- a/e2e/tests/actions-cache-workflows.test.ts
+++ b/e2e/tests/actions-cache-workflows.test.ts
@@ -80,9 +80,10 @@ describe("GitHub Actions cache workflows", () => {
     expect(saveStep).toContain("github.event_name == 'schedule'");
   });
 
-  it("[P1] seeds Windows from main and deletes only closed-PR BuildKit cache families", async () => {
+  it("[P1] seeds Windows and Linux from main and deletes only closed-PR BuildKit cache families", async () => {
     const workflow = await readFile(cacheMaintenanceWorkflow, "utf8");
-    const seedJob = sectionBetween(workflow, "  seed-pnpm-windows:", "  clean-closed-pr-buildkit:");
+    const windowsSeedJob = sectionBetween(workflow, "  seed-pnpm-windows:", "  seed-pnpm-linux:");
+    const linuxSeedJob = sectionBetween(workflow, "  seed-pnpm-linux:", "  clean-closed-pr-buildkit:");
     const cleanupJob = workflow.slice(workflow.indexOf("  clean-closed-pr-buildkit:"));
 
     expect(workflow).toContain("pull_request_target:");
@@ -93,13 +94,19 @@ describe("GitHub Actions cache workflows", () => {
     expect(workflow).toContain("actions: write");
     expect(workflow).toContain("contents: read");
 
-    expect(seedJob).toContain("github.event_name == 'push'");
-    expect(seedJob).toContain("github.event_name == 'workflow_dispatch'");
-    expect(seedJob).toContain("github.ref == 'refs/heads/main'");
-    expect(seedJob).toContain("runs-on: windows-latest");
-    expect(seedJob).toContain("uses: actions/checkout@v6.0.2");
-    expect(seedJob).toContain("uses: ./.github/actions/setup-workspace");
-    expect(seedJob).toContain("save-pnpm-cache: 'true'");
+    for (const seedJob of [windowsSeedJob, linuxSeedJob]) {
+      expect(seedJob).toContain("github.event_name == 'push'");
+      expect(seedJob).toContain("github.event_name == 'workflow_dispatch'");
+      expect(seedJob).toContain("github.ref == 'refs/heads/main'");
+      expect(seedJob).toContain("uses: actions/checkout@v6.0.2");
+      expect(seedJob).toContain("uses: ./.github/actions/setup-workspace");
+      expect(seedJob).toContain("save-pnpm-cache: 'true'");
+    }
+
+    expect(windowsSeedJob).toContain("runs-on: windows-latest");
+    // One hosted Linux seed is enough: actions/cache is repo-scoped and shared
+    // by every Nexu size (small/medium/large) once the store path is pinned.
+    expect(linuxSeedJob).toContain("runs-on: ubuntu-24.04");
 
     expect(cleanupJob).toContain("github.event_name == 'pull_request_target'");
     expect(cleanupJob).toContain("refs/pull/${{ github.event.pull_request.number }}/merge");
@@ -112,7 +119,8 @@ describe("GitHub Actions cache workflows", () => {
     expect(cleanupJob).not.toContain("github.event.pull_request.head");
   });
 
-  it("[P1] uses the existing main visual baseline as the Linux pnpm seed", async () => {
+
+  it("[P1] keeps visual-baseline as a secondary Linux pnpm seed on main", async () => {
     const workflow = await readFile(visualBaselineWorkflow, "utf8");
     const setupStep = sectionBetween(workflow, "      - name: Setup workspace", "      - name: Setup Playwright");
 
@@ -121,6 +129,7 @@ describe("GitHub Actions cache workflows", () => {
     expect(setupStep).toContain("uses: ./.github/actions/setup-workspace");
     expect(setupStep).toContain("save-pnpm-cache: 'true'");
   });
+
 
   it("[P1] keeps landing preview caches restore-only before merge and seeds them from main", async () => {
     const workflow = await readFile(landingPageCiWorkflow, "utf8");

--- a/e2e/tests/actions-cache-workflows.test.ts
+++ b/e2e/tests/actions-cache-workflows.test.ts
@@ -43,6 +43,33 @@ describe("GitHub Actions cache workflows", () => {
       action.indexOf("uses: actions/cache/save@v5"),
     );
 
+    // Non-persistent branch: pin a stable home store before `pnpm store path`
+    // so actions/cache version hashes match across hosted and Nexu ARC fleets.
+    const detectStep = sectionBetween(
+      action,
+      "- name: Detect persistent pnpm store",
+      "- name: Setup pnpm",
+    );
+    // Isolate the else arm by its home-store pin (not "else"/"fi", which match
+    // substrings like npm_config).
+    const homeStoreIndex = detectStep.indexOf('store_dir="$HOME/.pnpm-store"');
+    expect(homeStoreIndex).toBeGreaterThanOrEqual(0);
+    const nonPersistentBranch = detectStep.slice(homeStoreIndex);
+    expect(nonPersistentBranch).toContain('echo "NPM_CONFIG_STORE_DIR=$store_dir"');
+    expect(nonPersistentBranch).toContain('echo "npm_config_store_dir=$store_dir"');
+    expect(nonPersistentBranch).toContain('echo "enabled=false"');
+    expect(action.indexOf('store_dir="$HOME/.pnpm-store"')).toBeLessThan(
+      action.indexOf('run: echo "path=$(pnpm store path --silent)"'),
+    );
+
+    const restoreStep = sectionBetween(
+      action,
+      "- name: Restore pnpm store",
+      "- name: Install dependencies",
+    );
+    expect(restoreStep).toContain("restore-keys: |");
+    expect(restoreStep).toContain("pnpm-store-${{ runner.os }}-");
+
     const saveStep = action.slice(action.indexOf("- name: Save pnpm store"));
     expect(saveStep).toContain("inputs.save-pnpm-cache == 'true'");
     expect(saveStep).toContain("steps.persistent-pnpm-store.outputs.enabled != 'true'");


### PR DESCRIPTION
## Why

Stacked on #6407 (`agent/route-ui-p0-nexu-runners`).

Nexu ARC CI was missing the pnpm store cache on every job even when the
cache key existed and hosted runners hit it. Root cause: `actions/cache`
versions by path string; ARC resolved store to `/home/runner/_work/.pnpm-store/v10`
while seed/hosted used the home global store.

## What users will see

Faster CI on the default Nexu fleet once reseeds land — each job should stop
full-downloading ~1200 packages (~40s saved per job).

## Surface area

- [x] CI / GitHub Actions
- [ ] Web UI
- [ ] Daemon / API
- [ ] CLI (`od`)
- [ ] Desktop / packaged
- [ ] skills / design-systems / design-templates / craft
- [ ] i18n
- [ ] env vars / flags

## Notes

- After merge to main: dispatch `cache-maintenance` (Windows seed) and/or
  `visual-baseline` (Linux seed via `save-pnpm-cache: true`) so the new
  home-store path is populated. Existing main cache entry is for the old path
  version and will not restore until reseeded.
- ARC persistent volume (`od-persistent-ci`) left for a follow-up infra change;
  short-term pin is enough and does not require powerformer runner edits.
- Windows currently has **no** `pnpm-store-Windows-*` cache entry at all;
  stable path + seed should create one.

## Stack

Base: #6407 → this PR. Sibling stacked PRs will open against the same base
and rebase after #6407 merges.
