### PR TITLE
fix(UI): resolve requried badge wrap

### DIFF
--- a/apps/web/src/styles/viewer/composio.css
+++ b/apps/web/src/styles/viewer/composio.css
@@ -932,10 +932,14 @@
   font-weight: 500;
   color: var(--text);
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: 4px;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 .qf-required {
+  flex: 0 0 auto;
+  white-space: nowrap;
   color: var(--text-muted);
   border: 1px solid var(--border);
   border-radius: 999px;

--- a/apps/web/tests/styles/question-form-required-badge.test.ts
+++ b/apps/web/tests/styles/question-form-required-badge.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const composioCss = readFileSync(new URL('../../src/styles/viewer/composio.css', import.meta.url), 'utf8');
+
+function declarations(css: string, selector: string): string {
+  const escaped = selector.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+  // Anchor on the start of a rule so `.qf-label` does not match `.qf-field-visual .qf-label`.
+  const match = css.match(new RegExp(`(?:^|[}\\n])\\s*${escaped}\\s*\\{([^}]*)\\}`));
+  if (!match) throw new Error(`Missing CSS block for ${selector}`);
+  return match[1] ?? '';
+}
+
+describe('question form required badge', () => {
+  it('keeps the required badge at its intrinsic size', () => {
+    const required = declarations(composioCss, '.qf-required');
+    expect(required).toContain('flex: 0 0 auto');
+    expect(required).toContain('white-space: nowrap');
+  });
+
+  it('aligns the label row on the text baseline so a wrapped label keeps the badge in line', () => {
+    const label = declarations(composioCss, '.qf-label');
+    expect(label).toContain('align-items: baseline');
+    expect(label).not.toContain('align-items: center');
+  });
+
+  it('lets the label shrink and break so the non-shrinking badge stays inside the card', () => {
+    // Without these the label's min-content width (an unbreakable URL, or wide
+    // non-Latin marker copy) pushes the nowrap badge past the card's right edge.
+    const label = declarations(composioCss, '.qf-label');
+    expect(label).toContain('min-width: 0');
+    expect(label).toContain('overflow-wrap: anywhere');
+  });
+});


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->



## Why

<!-- Why are you opening this PR? Cover two things:
       - Your use case — what made you write this today? Did you hit it yourself
         while building on top of OD, are you scratching an itch for a team, or
         are you speculatively adding for others? All are fine, but say which.
       - The pain being addressed — user-facing problem, technical debt, a prod
         issue, or unblocking another change.
     For non-trivial features, please open a discussion or issue first to align
     on scope and UX before writing code. -->

Fixes https://github.com/nexu-io/open-design/issues/6392

## What users will see

<!-- Describe the change from a user's perspective, not in code terms. Examples:
       - "Settings → AI Providers has a new 'Custom endpoint' field, off by default"
       - "Right-clicking a design file shows a new 'Duplicate' option"
       - "Default model changed from X to Y — existing users will notice on first launch"
       - "New `od skills install <name>` subcommand"
     Skip this section only if you check "None" below. -->

Left is fixed.


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<!-- If you checked "UI" above, attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->

<img width="5070" height="2610" alt="img_v3_02148_731b5c1d-a682-467b-b35a-9b8113a3561g" src="https://github.com/user-attachments/assets/e7a1d48c-16dc-40e7-8ccb-6aa019b15849" />
<img width="3698" height="934" alt="img_v3_02148_645003f5-8f16-4cef-a3ef-81361f683d6g" src="https://github.com/user-attachments/assets/ce5b352d-427f-4d0d-a872-a1fd0bf2b0a8" />
<img width="2726" height="1714" alt="5fbbf471-be28-4065-b599-93e42d390ae9" src="https://github.com/user-attachments/assets/2fcfdab3-101b-4936-bb06-2c5556323da6" />
<img width="2844" height="1680" alt="img_v3_02149_13f7e6f5-51f4-4c11-8c6d-22cd707bebeg" src="https://github.com/user-attachments/assets/f242762c-06a7-4f14-a725-0dac29a0fb8d" />
<img width="2808" height="1808" alt="img_v3_02149_d8bb9ab0-7a15-4ffd-a8b6-0f8090721d6g" src="https://github.com/user-attachments/assets/8adba9c5-7f9d-40a4-b426-46681be1968a" />
<img width="2696" height="1516" alt="img_v3_02149_46391568-d01c-41dd-a781-493d6840b5dg" src="https://github.com/user-attachments/assets/16e1045d-3ad0-401f-874d-0c223dbf362e" />
<img width="2696" height="1644" alt="img_v3_02149_43e094a5-cd5e-4d2c-8ddd-7a271dd4475g" src="https://github.com/user-attachments/assets/856eeadd-6a31-4e8d-b352-75521915c39f" />







## Bug fix verification

- Test path reproducing the bug: `apps/web/tests/styles/question-form-required-badge.test.ts`
- Did it go red on `main` and green on this branch? **Yes** — verified by running it
  against a `main` worktree (`6ce4344f`): **2/2 red**, the two assertions failing on
  `flex: 0 0 auto` and `align-items: baseline` respectively. On this branch: **2/2 green**.
- Note on scope: this is a missing-CSS-declaration defect, so the guard asserts against
  the stylesheet text (same pattern as the existing
  `apps/web/tests/styles/chat-disclosure-accessibility.test.ts`). That pins the
  declarations but does not verify rendered box geometry — layout was confirmed manually,
  see Validation.


## Validation

- `pnpm guard` → exit 0
- `pnpm --filter @open-design/web typecheck` → passes
- `apps/web` package-scoped: `tests/components/QuestionForm.test.tsx` + `tests/styles`
  → 26 files / 98 tests green
- New spec alone (`apps/web/tests/styles/question-form-required-badge.test.ts`)
  → 2/2 green on this branch, 2/2 red on a `main` worktree
- Manual check in a local dev runtime: verified the required badge stays on one line
  at its intrinsic size, and that a long wrapping label keeps the badge aligned to the
  first line's baseline. Both short and long labels are covered in the screenshots above.