### PR TITLE
fix(web): count unique produced files in "Files from this turn" header

### DIFF
--- a/apps/web/src/components/FileOpsSummary.tsx
+++ b/apps/web/src/components/FileOpsSummary.tsx
@@ -18,7 +18,7 @@ import { useState } from 'react';
 import { useT } from '../i18n';
 import type { Dict } from '../i18n/types';
 import {
-  countFileOps,
+  countArtifactFileOps,
   type FileOpEntry,
   type FileOpKind,
 } from '../runtime/file-ops';
@@ -66,7 +66,10 @@ export function FileOpsSummary({
     ? entries.slice(0, COLLAPSE_AFTER_ENTRY_COUNT)
     : entries;
 
-  const counts = countFileOps(entries);
+  // Count unique produced files (one row per file), not write operations — a
+  // file touched several times must count once in a "Files from this turn"
+  // header (#5909).
+  const counts = countArtifactFileOps(entries);
   const summaryParts: string[] = [];
   if (counts.write > 0) summaryParts.push(`${t('tool.write')} ${counts.write}`);
   if (counts.edit > 0) summaryParts.push(`${t('tool.edit')} ${counts.edit}`);

--- a/apps/web/src/runtime/file-ops.ts
+++ b/apps/web/src/runtime/file-ops.ts
@@ -162,6 +162,28 @@ export function countFileOps(entries: FileOpEntry[]): FileOpCounts {
   return counts;
 }
 
+export interface ArtifactFileOpCounts {
+  write: number;
+  edit: number;
+}
+
+/**
+ * Count unique produced files for the "Files from this turn" disclosure
+ * header, categorized by each file's primary artifact op (edit > write).
+ * Unlike `countFileOps`, a file written (or edited) several times counts
+ * once — the header must match the number of delivered files, not the number
+ * of write operations (#5909).
+ */
+export function countArtifactFileOps(entries: FileOpEntry[]): ArtifactFileOpCounts {
+  let write = 0;
+  let edit = 0;
+  for (const entry of entries) {
+    if (entry.ops.includes('edit')) edit += 1;
+    else if (entry.ops.includes('write')) write += 1;
+  }
+  return { write, edit };
+}
+
 function extractSimpleBashDeletes(input: unknown): string[] {
   if (!input || typeof input !== 'object') return [];
   const command = (input as { command?: unknown }).command;

--- a/apps/web/tests/components/FileOpsSummary.test.tsx
+++ b/apps/web/tests/components/FileOpsSummary.test.tsx
@@ -55,7 +55,10 @@ describe('FileOpsSummary', () => {
     );
 
     expect(screen.getByText(/Write 2/)).toBeTruthy();
-    expect(screen.getByText(/Edit 4/)).toBeTruthy();
+    // #5909: the "Files from this turn" header counts unique produced files,
+    // not write operations. c.ts was edited three times but is one file, so
+    // the edit total is 2 (a.ts + c.ts), not the op-level count of 4.
+    expect(screen.getByText(/Edit 2/)).toBeTruthy();
     expect(screen.queryByText(/Delete/)).toBeNull();
     expect(screen.queryByText(/Read/)).toBeNull();
     expect(screen.getByTestId('file-ops-row-a.ts')).toBeTruthy();

--- a/apps/web/tests/runtime/file-ops.test.ts
+++ b/apps/web/tests/runtime/file-ops.test.ts
@@ -224,8 +224,9 @@ describe('countArtifactFileOps', () => {
       ok('t3'),
       use('Read', { file_path: '/a.ts' }, 't4'),
       ok('t4'),
-      // b.ts read then edited → one edit (edit beats write).
-      use('Read', { file_path: '/b.ts' }, 't5'),
+      // b.ts written THEN edited (the #5909 repro path: create + edit the same
+      // file) → one edit (edit beats write).
+      use('Write', { file_path: '/b.ts' }, 't5'),
       ok('t5'),
       use('Edit', { file_path: '/b.ts' }, 't6'),
       ok('t6'),
@@ -242,8 +243,8 @@ describe('countArtifactFileOps', () => {
     ];
     const rows = deriveFileOps(events);
     expect(countArtifactFileOps(rows)).toEqual({ write: 1, edit: 2 });
-    // The op-level counter is unchanged: it still sees all three writes.
-    expect(countFileOps(rows).write).toBe(3);
+    // The op-level counter is unchanged: a.ts (3) + b.ts (1) writes.
+    expect(countFileOps(rows).write).toBe(4);
     expect(countFileOps(rows).edit).toBe(4);
   });
 });

--- a/apps/web/tests/runtime/file-ops.test.ts
+++ b/apps/web/tests/runtime/file-ops.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { countFileOps, deriveFileOps } from '../../src/runtime/file-ops';
+import {
+  countArtifactFileOps,
+  countFileOps,
+  deriveFileOps,
+} from '../../src/runtime/file-ops';
 import type { AgentEvent } from '../../src/types';
 
 type ToolUse = Extract<AgentEvent, { kind: 'tool_use' }>;
@@ -205,5 +209,41 @@ describe('countFileOps', () => {
 
   it('returns zeros when there are no entries', () => {
     expect(countFileOps([])).toEqual({ read: 0, write: 0, edit: 0, delete: 0 });
+  });
+});
+
+describe('countArtifactFileOps', () => {
+  it('counts each unique file once by its primary artifact op, not per write operation', () => {
+    const events: AgentEvent[] = [
+      // a.ts written three times + read once → one write.
+      use('Write', { file_path: '/a.ts' }, 't1'),
+      ok('t1'),
+      use('Write', { file_path: '/a.ts' }, 't2'),
+      ok('t2'),
+      use('Write', { file_path: '/a.ts' }, 't3'),
+      ok('t3'),
+      use('Read', { file_path: '/a.ts' }, 't4'),
+      ok('t4'),
+      // b.ts read then edited → one edit (edit beats write).
+      use('Read', { file_path: '/b.ts' }, 't5'),
+      ok('t5'),
+      use('Edit', { file_path: '/b.ts' }, 't6'),
+      ok('t6'),
+      // c.ts edited three times → still one edit.
+      use('Edit', { file_path: '/c.ts' }, 't7'),
+      ok('t7'),
+      use('Edit', { file_path: '/c.ts' }, 't8'),
+      ok('t8'),
+      use('Edit', { file_path: '/c.ts' }, 't9'),
+      ok('t9'),
+      // d.ts only read → not an artifact file, not counted.
+      use('Read', { file_path: '/d.ts' }, 't10'),
+      ok('t10'),
+    ];
+    const rows = deriveFileOps(events);
+    expect(countArtifactFileOps(rows)).toEqual({ write: 1, edit: 2 });
+    // The op-level counter is unchanged: it still sees all three writes.
+    expect(countFileOps(rows).write).toBe(3);
+    expect(countFileOps(rows).edit).toBe(4);
   });
 });


### PR DESCRIPTION
Fixes #5909

## Why

The "Files from this turn" disclosure header (`FileOpsSummary`) summed per-op tool_use counts, so a file written or edited several times inflated the total: the QA report in #5909 shows `Write 9` for a turn that delivered 6 unique files, and the existing component test asserted `Edit 4` for 2 edited files. The disclosure is titled "Files from this turn" and its rows are one-per-file, so a header that counts write *operations* reads as if more files were produced than actually were.

## What users will see

The disclosure header now counts unique produced files: a file written (or edited) three times counts once, categorized by its primary op (edit > write), matching how each row's badge is chosen. In the #5909 repro the header now reads `Write 6` instead of `Write 9`; in the updated test `Edit 2` instead of `Edit 4`.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

None — this changes a count on an existing disclosure card. The component test asserts the rendered header text.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/FileOpsSummary.test.tsx` (the `Edit 4` → `Edit 2` assertion) and `apps/web/tests/runtime/file-ops.test.ts` (`countArtifactFileOps` unit test).
- Did the test go red on `main` and green on this branch? Yes. The existing component assertion encoded the op-level count (`Edit 4`); flipping it to the file-level `Edit 2` went red against the current header, and the fix turns it green. The op-level `countFileOps` contract and its test are untouched.

## Fix shape

- `apps/web/src/runtime/file-ops.ts` — add `countArtifactFileOps`: counts each unique file once by its primary artifact op (edit > write). `countFileOps` (op totals) is unchanged.
- `apps/web/src/components/FileOpsSummary.tsx` — the disclosure header uses `countArtifactFileOps` so "Write N · Edit M" reflects delivered files, not operations.

## Validation

- `npx vitest run -c vitest.config.ts tests/components/FileOpsSummary.test.tsx tests/runtime/file-ops.test.ts tests/components/AssistantMessage.test.tsx` — all pass.
- `pnpm --filter @open-design/web typecheck` — passes.
