### PR TITLE
fix(web): show Open Design login entry in the project-page agent menu

### DIFF
--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -331,11 +331,16 @@ export function AvatarMenu({
     return () => window.removeEventListener(AMR_LOGIN_STATUS_EVENT, onLoginStatus);
   }, [amrLoginPending, stopAmrLoginPolling]);
 
-  // Clear any in-flight poll on unmount and mark the component as unmounted so
-  // a pending startVelaLogin cannot spawn a new unowned interval.
-  useEffect(() => () => {
-    amrMountedRef.current = false;
-    if (amrLoginPollRef.current) clearInterval(amrLoginPollRef.current);
+  // Track mount state so a pending startVelaLogin cannot spawn a new unowned
+  // interval after the menu tears down. The setup body re-arms the flag so
+  // React Strict Mode's development effect probe (setup → cleanup → setup)
+  // doesn't leave it permanently false and strand the login on "Signing in".
+  useEffect(() => {
+    amrMountedRef.current = true;
+    return () => {
+      amrMountedRef.current = false;
+      if (amrLoginPollRef.current) clearInterval(amrLoginPollRef.current);
+    };
   }, []);
 
   // Resolve the user's model + reasoning pick for the active agent. Falls

--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -5,6 +5,7 @@ import { getResolvedDeviceId } from '../analytics/client';
 import { amrHandoffDeviceId, attributedAmrUrl, recordAmrEntry } from '../analytics/amr-attribution';
 import { useAnalytics } from '../analytics/provider';
 import { useT } from '../i18n';
+import { Button } from '@open-design/components';
 import { AgentIcon } from './AgentIcon';
 import { PlanBadge } from './PlanBadge';
 import { RemixIcon } from './RemixIcon';
@@ -584,8 +585,8 @@ export function AvatarMenu({
                         </a>
                       ) : null}
                       {amrAccount && !amrAccount.loggedIn ? (
-                        <button
-                          type="button"
+                        <Button
+                          variant="ghost"
                           className="avatar-amr-row__signin"
                           data-testid="avatar-amr-row-signin"
                           disabled={amrLoginPending}
@@ -596,7 +597,7 @@ export function AvatarMenu({
                           {amrLoginPending
                             ? t('settings.amrSigningIn')
                             : t('settings.amrSignIn')}
-                        </button>
+                        </Button>
                       ) : null}
                     </div>
                   );

--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type MouseEvent as ReactMouseEvent } from 'react';
 import { createPortal } from 'react-dom';
 import type { AmrWalletSnapshot } from '@open-design/contracts';
 import { getResolvedDeviceId } from '../analytics/client';
@@ -25,8 +25,16 @@ import {
   fetchAmrWalletSnapshot,
   fetchVelaLoginStatus,
   formatVelaBalanceUsd,
+  startVelaLogin,
   type VelaLoginStatus,
 } from '../providers/daemon';
+import {
+  AMR_LOGIN_POLL_INTERVAL_MS,
+  AMR_LOGIN_STATUS_EVENT,
+  amrLoginPollOutcome,
+  amrLoginStatusEventReason,
+  notifyAmrLoginStatusChanged,
+} from './amrLoginPolling';
 import {
   amrPlansUrlForProfile,
 } from '../runtime/amr-guidance';
@@ -249,6 +257,77 @@ export function AvatarMenu({
     event.currentTarget.href = attributedAmrUrl(amrPlansUrl, attribution, deviceId);
     setOpen(false);
   };
+
+  // #5244: the project-page agent menu must expose the same unauthenticated
+  // Open Design login entry the Home-page menu (InlineModelSwitcher) does. When
+  // the account is signed out, the Open Design row shows a sign-in action that
+  // starts the Vela login flow and polls until the account is ready, the
+  // browser window is closed, or the login times out.
+  const [amrLoginPending, setAmrLoginPending] = useState(false);
+  const amrLoginStartedAtRef = useRef<number | null>(null);
+  const amrLoginPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopAmrLoginPolling = useCallback(() => {
+    if (amrLoginPollRef.current) {
+      clearInterval(amrLoginPollRef.current);
+      amrLoginPollRef.current = null;
+    }
+    amrLoginStartedAtRef.current = null;
+    setAmrLoginPending(false);
+  }, []);
+
+  const handleAmrSignIn = useCallback(async () => {
+    if (amrLoginPending) return;
+    const startedAt = Date.now();
+    amrLoginStartedAtRef.current = startedAt;
+    setAmrLoginPending(true);
+    const odDeviceId = amrHandoffDeviceId({
+      metricsConsent: config.telemetry?.metrics === true,
+      resolvedDeviceId: getResolvedDeviceId(),
+      installationId: config.installationId,
+    });
+    const result = await startVelaLogin(null, odDeviceId);
+    if (result.ok || result.alreadyRunning) {
+      notifyAmrLoginStatusChanged('login-started');
+      amrLoginPollRef.current = setInterval(() => {
+        void fetchVelaLoginStatus()
+          .then((status) => {
+            if (status) setAmrAccount(status);
+            const outcome = amrLoginPollOutcome(status, startedAt);
+            if (outcome === 'signed-in') {
+              stopAmrLoginPolling();
+              notifyAmrLoginStatusChanged('status-changed');
+            } else if (outcome === 'stopped' || outcome === 'timed-out') {
+              stopAmrLoginPolling();
+            }
+          })
+          .catch(() => {
+            stopAmrLoginPolling();
+          });
+      }, AMR_LOGIN_POLL_INTERVAL_MS);
+    } else {
+      setAmrLoginPending(false);
+      amrLoginStartedAtRef.current = null;
+    }
+  }, [amrLoginPending, config.installationId, config.telemetry?.metrics, stopAmrLoginPolling]);
+
+  // A login cancelled from another surface (e.g. the Home page) should stop the
+  // poll here too.
+  useEffect(() => {
+    if (!amrLoginPending) return;
+    const onLoginStatus = (event: Event) => {
+      if (amrLoginStatusEventReason(event) === 'login-canceled') {
+        stopAmrLoginPolling();
+      }
+    };
+    window.addEventListener(AMR_LOGIN_STATUS_EVENT, onLoginStatus);
+    return () => window.removeEventListener(AMR_LOGIN_STATUS_EVENT, onLoginStatus);
+  }, [amrLoginPending, stopAmrLoginPolling]);
+
+  // Clear any in-flight poll on unmount.
+  useEffect(() => () => {
+    if (amrLoginPollRef.current) clearInterval(amrLoginPollRef.current);
+  }, []);
 
   // Resolve the user's model + reasoning pick for the active agent. Falls
   // back to the agent's first declared option (`'default'`) when the user
@@ -489,6 +568,21 @@ export function AvatarMenu({
                         >
                           {t('settings.amrUpgrade')}
                         </a>
+                      ) : null}
+                      {amrAccount && !amrAccount.loggedIn ? (
+                        <button
+                          type="button"
+                          className="avatar-amr-row__signin"
+                          data-testid="avatar-amr-row-signin"
+                          disabled={amrLoginPending}
+                          onClick={() => {
+                            void handleAmrSignIn();
+                          }}
+                        >
+                          {amrLoginPending
+                            ? t('settings.amrSigningIn')
+                            : t('settings.amrSignIn')}
+                        </button>
                       ) : null}
                     </div>
                   );

--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -266,6 +266,10 @@ export function AvatarMenu({
   const [amrLoginPending, setAmrLoginPending] = useState(false);
   const amrLoginStartedAtRef = useRef<number | null>(null);
   const amrLoginPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Set false on unmount so an async login that resolves AFTER the menu is torn
+  // down cannot dispatch events or spawn an unowned polling interval (looper
+  // review on #6421).
+  const amrMountedRef = useRef(true);
 
   const stopAmrLoginPolling = useCallback(() => {
     if (amrLoginPollRef.current) {
@@ -287,11 +291,13 @@ export function AvatarMenu({
       installationId: config.installationId,
     });
     const result = await startVelaLogin(null, odDeviceId);
+    if (!amrMountedRef.current) return;
     if (result.ok || result.alreadyRunning) {
       notifyAmrLoginStatusChanged('login-started');
       amrLoginPollRef.current = setInterval(() => {
         void fetchVelaLoginStatus()
           .then((status) => {
+            if (!amrMountedRef.current) return;
             if (status) setAmrAccount(status);
             const outcome = amrLoginPollOutcome(status, startedAt);
             if (outcome === 'signed-in') {
@@ -302,6 +308,7 @@ export function AvatarMenu({
             }
           })
           .catch(() => {
+            if (!amrMountedRef.current) return;
             stopAmrLoginPolling();
           });
       }, AMR_LOGIN_POLL_INTERVAL_MS);
@@ -324,8 +331,10 @@ export function AvatarMenu({
     return () => window.removeEventListener(AMR_LOGIN_STATUS_EVENT, onLoginStatus);
   }, [amrLoginPending, stopAmrLoginPolling]);
 
-  // Clear any in-flight poll on unmount.
+  // Clear any in-flight poll on unmount and mark the component as unmounted so
+  // a pending startVelaLogin cannot spawn a new unowned interval.
   useEffect(() => () => {
+    amrMountedRef.current = false;
     if (amrLoginPollRef.current) clearInterval(amrLoginPollRef.current);
   }, []);
 

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -1263,6 +1263,44 @@
     transform: none;
   }
 }
+.avatar-amr-row__signin,
+.avatar-amr-row__signin:visited {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 10px;
+  border: 1px solid color-mix(in srgb, var(--text-strong) 28%, transparent);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-strong);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  white-space: nowrap;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    transform 150ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+@media (hover: hover) and (pointer: fine) {
+  .avatar-amr-row__signin:not(:disabled):hover {
+    background: color-mix(in srgb, var(--text-strong) 8%, transparent);
+    border-color: color-mix(in srgb, var(--text-strong) 45%, transparent);
+  }
+}
+.avatar-amr-row__signin:active {
+  transform: scale(0.96);
+}
+.avatar-amr-row__signin:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--text-strong) 45%, transparent);
+  outline-offset: 2px;
+}
+.avatar-amr-row__signin:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
 .avatar-item {
   display: flex;
   align-items: center;

--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -1263,43 +1263,15 @@
     transform: none;
   }
 }
-.avatar-amr-row__signin,
-.avatar-amr-row__signin:visited {
+.avatar-amr-row__signin {
   flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
   height: 22px;
   padding: 0 10px;
-  border: 1px solid color-mix(in srgb, var(--text-strong) 28%, transparent);
   border-radius: 999px;
-  background: transparent;
-  color: var(--text-strong);
   font-size: 11px;
   font-weight: 650;
   letter-spacing: 0.02em;
-  text-decoration: none;
   white-space: nowrap;
-  transition:
-    background-color 150ms ease,
-    border-color 150ms ease,
-    transform 150ms cubic-bezier(0.23, 1, 0.32, 1);
-}
-@media (hover: hover) and (pointer: fine) {
-  .avatar-amr-row__signin:not(:disabled):hover {
-    background: color-mix(in srgb, var(--text-strong) 8%, transparent);
-    border-color: color-mix(in srgb, var(--text-strong) 45%, transparent);
-  }
-}
-.avatar-amr-row__signin:active {
-  transform: scale(0.96);
-}
-.avatar-amr-row__signin:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--text-strong) 45%, transparent);
-  outline-offset: 2px;
-}
-.avatar-amr-row__signin:disabled {
-  opacity: 0.6;
-  cursor: default;
 }
 .avatar-item {
   display: flex;

--- a/apps/web/tests/components/AvatarMenu.test.tsx
+++ b/apps/web/tests/components/AvatarMenu.test.tsx
@@ -316,6 +316,74 @@ describe('AvatarMenu', () => {
     });
   });
 
+  it('does not start a polling interval if the menu unmounts before login resolves', async () => {
+    // looper review on #6421: an async login resolving after unmount must not
+    // spawn an unowned interval whose callbacks update stale component state.
+    const amrAgent: AgentInfo = {
+      id: 'amr',
+      name: 'Open Design AMR',
+      bin: 'vela',
+      available: true,
+      models: [{ id: 'default', label: 'Default (CLI config)' }],
+    };
+    let resolveLogin: (value: Response) => void = () => {};
+    const loginPromise = new Promise<Response>((resolve) => {
+      resolveLogin = resolve;
+    });
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/integrations/vela/status') {
+        return new Response(
+          JSON.stringify({
+            loggedIn: false,
+            loginInFlight: false,
+            profile: 'test',
+            user: null,
+            configPath: '/Users/test/.amr/config.json',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url === '/api/integrations/vela/login') return loginPromise;
+      return new Response('{}', { status: 200 });
+    }));
+
+    const view = render(
+      <AvatarMenu
+        config={baseConfig}
+        agents={[codexAgent, claudeAgent, amrAgent]}
+        daemonLive
+        onModeChange={vi.fn()}
+        onAgentChange={vi.fn()}
+        onAgentModelChange={vi.fn()}
+        onOpenSettings={vi.fn()}
+        onRefreshAgents={vi.fn()}
+      />,
+    );
+    openMenu();
+    await waitFor(() => {
+      expect(screen.getByTestId('avatar-amr-row-signin')).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId('avatar-amr-row-signin'));
+
+    // Unmount while the login request is still in flight, then resolve it.
+    view.unmount();
+    resolveLogin(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // No AMR polling interval (AMR_LOGIN_POLL_INTERVAL_MS = 2000) may have
+    // been created after unmount. testing-library's internal waitFor timer uses
+    // a different delay, so filter on our interval's cadence.
+    const amrPollCalls = setIntervalSpy.mock.calls.filter(([, delay]) => delay === 2000);
+    expect(amrPollCalls).toHaveLength(0);
+  });
+
   it('rescans agents and re-renders newly available CLI entries', async () => {
     function Harness() {
       const [agents, setAgents] = useState<AgentInfo[]>([

--- a/apps/web/tests/components/AvatarMenu.test.tsx
+++ b/apps/web/tests/components/AvatarMenu.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import { useState } from 'react';
+import { StrictMode, useState } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AvatarMenu } from '../../src/components/AvatarMenu';
@@ -382,6 +382,73 @@ describe('AvatarMenu', () => {
     // a different delay, so filter on our interval's cadence.
     const amrPollCalls = setIntervalSpy.mock.calls.filter(([, delay]) => delay === 2000);
     expect(amrPollCalls).toHaveLength(0);
+  });
+
+  it('proceeds with the login polling under React StrictMode', async () => {
+    // looper review on #6421: the mounted-flag effect must re-arm its setup
+    // body, or React Strict Mode's dev probe (setup → cleanup → setup) leaves
+    // the flag false and strands the signed-out login on "Signing in".
+    const amrAgent: AgentInfo = {
+      id: 'amr',
+      name: 'Open Design AMR',
+      bin: 'vela',
+      available: true,
+      models: [{ id: 'default', label: 'Default (CLI config)' }],
+    };
+    let resolveLogin: (value: Response) => void = () => {};
+    const loginPromise = new Promise<Response>((resolve) => {
+      resolveLogin = resolve;
+    });
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/integrations/vela/status') {
+        return new Response(
+          JSON.stringify({
+            loggedIn: false,
+            loginInFlight: false,
+            profile: 'test',
+            user: null,
+            configPath: '/Users/test/.amr/config.json',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url === '/api/integrations/vela/login') return loginPromise;
+      return new Response('{}', { status: 200 });
+    }));
+
+    render(
+      <StrictMode>
+        <AvatarMenu
+          config={baseConfig}
+          agents={[codexAgent, claudeAgent, amrAgent]}
+          daemonLive
+          onModeChange={vi.fn()}
+          onAgentChange={vi.fn()}
+          onAgentModelChange={vi.fn()}
+          onOpenSettings={vi.fn()}
+          onRefreshAgents={vi.fn()}
+        />
+      </StrictMode>,
+    );
+    openMenu();
+    await waitFor(() => {
+      expect(screen.getByTestId('avatar-amr-row-signin')).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId('avatar-amr-row-signin'));
+    resolveLogin(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Under StrictMode the mounted flag must be re-armed, so the 2000ms
+    // polling interval IS created (the login path proceeds).
+    const amrPollCalls = setIntervalSpy.mock.calls.filter(([, delay]) => delay === 2000);
+    expect(amrPollCalls.length).toBeGreaterThan(0);
   });
 
   it('rescans agents and re-renders newly available CLI entries', async () => {

--- a/apps/web/tests/components/AvatarMenu.test.tsx
+++ b/apps/web/tests/components/AvatarMenu.test.tsx
@@ -234,6 +234,88 @@ describe('AvatarMenu', () => {
     ]);
   });
 
+  it('shows a sign-in action in the Open Design row when signed out', async () => {
+    // #5244: the project-page agent menu (AvatarMenu) must expose the same
+    // unauthenticated Open Design login entry the Home-page menu does.
+    const amrAgent: AgentInfo = {
+      id: 'amr',
+      name: 'Open Design AMR',
+      bin: 'vela',
+      available: true,
+      models: [{ id: 'default', label: 'Default (CLI config)' }],
+    };
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/integrations/vela/status') {
+        return new Response(
+          JSON.stringify({
+            loggedIn: false,
+            loginInFlight: false,
+            profile: 'test',
+            user: null,
+            configPath: '/Users/test/.amr/config.json',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response('{}', { status: 200 });
+    }));
+
+    renderMenu({ agents: [codexAgent, claudeAgent, amrAgent] });
+    openMenu();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('avatar-agent-option-amr')).toBeTruthy();
+    });
+    expect(screen.getByTestId('avatar-amr-row-signin')).toBeTruthy();
+  });
+
+  it('starts the Open Design login flow when the signed-out sign-in action is clicked', async () => {
+    const amrAgent: AgentInfo = {
+      id: 'amr',
+      name: 'Open Design AMR',
+      bin: 'vela',
+      available: true,
+      models: [{ id: 'default', label: 'Default (CLI config)' }],
+    };
+    const loginCalls: string[] = [];
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === '/api/integrations/vela/status') {
+        return new Response(
+          JSON.stringify({
+            loggedIn: false,
+            loginInFlight: false,
+            profile: 'test',
+            user: null,
+            configPath: '/Users/test/.amr/config.json',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (url === '/api/integrations/vela/login') {
+        loginCalls.push(url);
+        return new Response(
+          JSON.stringify({ ok: true, authAttemptId: 'auth-1' }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response('{}', { status: 200 });
+    }));
+
+    renderMenu({ agents: [codexAgent, claudeAgent, amrAgent] });
+    openMenu();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('avatar-amr-row-signin')).toBeTruthy();
+    });
+    fireEvent.click(screen.getByTestId('avatar-amr-row-signin'));
+
+    await waitFor(() => {
+      expect(loginCalls).toContain('/api/integrations/vela/login');
+    });
+  });
+
   it('rescans agents and re-renders newly available CLI entries', async () => {
     function Harness() {
       const [agents, setAgents] = useState<AgentInfo[]>([


### PR DESCRIPTION
Fixes #5244

## Why

The project-page agent menu (`AvatarMenu`) fetched the Open Design account state but never surfaced a sign-in action when signed out — a logged-out user could only start the Open Design login from the Home-page menu (`InlineModelSwitcher`). From the project page the Open Design row appeared in the list with no clear way to sign in.

## What users will see

When Open Design is signed out, the project-page agent menu's Open Design row now shows a **Sign in** action (mirroring the Home-page menu). Clicking it starts the Open Design login flow, shows signing-in state while the browser login is in flight, and switches to the plan/balance display once signed in. When already signed in, the row is unchanged.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` / `tools-pr` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

None — reuses the existing signed-out affordance pattern from the Home-page menu; the component test asserts the entry point and the login flow.

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/AvatarMenu.test.tsx`
- Did the test go red on `main` and green on this branch? Yes. The signed-out Open Design row had no sign-in action, so the new entry-point test failed (no `avatar-amr-row-signin` element); after the fix it passes. A second flow test clicks the action and asserts the login endpoint (`/api/integrations/vela/login`) is hit.

## Fix shape

- `apps/web/src/components/AvatarMenu.tsx` — when the Open Design row is signed out, render a Sign in action that starts the Vela login flow (`startVelaLogin` + status polling until signed-in / stopped / timed-out, using the shared `amrLoginPollOutcome` helper and `notifyAmrLoginStatusChanged` events), reflecting signing-in state.
- `apps/web/src/styles/shell.css` — `avatar-amr-row__signin` pill style (secondary, distinct from the upgrade CTA).
- Reuses the existing account-state fetch already performed when the popover opens, so no new API surface.

## Validation

- `npx vitest run -c vitest.config.ts tests/components/AvatarMenu.test.tsx tests/components/InlineModelSwitcher.test.tsx tests/components/App.onboarding-amr-e2e.test.tsx tests/components/EntryShell.onboarding.test.tsx tests/components/EntryShell.onboarding-dropdown.test.tsx` — all pass.
- `pnpm --filter @open-design/web typecheck` — passes.
