### PR TITLE
fix(web): lift handoff menu above the sketch canvas toolbar

### DIFF
--- a/apps/web/src/styles/workspace/drawer.css
+++ b/apps/web/src/styles/workspace/drawer.css
@@ -1384,7 +1384,13 @@
   top: 0;
   z-index: 4;
 }
-.ws-tabs-shell:has(.entry-settings-menu__popover) {
+/* The tab shell's own z-index:4 makes it a stacking context, so any popover
+   opened from the right-side action cluster is capped at 4 — the same layer
+   Excalidraw uses for its toolbar (`--zIndex-layerUI: 4`), which paints later
+   in DOM order and therefore wins. Lift the whole shell while a popover is
+   open so these menus clear the sketch canvas chrome. */
+.ws-tabs-shell:has(.entry-settings-menu__popover),
+.ws-tabs-shell:has(.handoff-menu) {
   z-index: 1900;
 }
 .ws-tabs-bar {

--- a/e2e/ui/handoff-menu-sketch-stacking.test.ts
+++ b/e2e/ui/handoff-menu-sketch-stacking.test.ts
@@ -1,0 +1,117 @@
+import { expect, test } from '@/playwright/suite';
+import { routeAgents } from '@/playwright/mock-factory';
+import { openAllProjectFiles } from '@/playwright/workspace';
+import type { Page } from '@playwright/test';
+import { T } from '@/timeouts';
+
+// Regression: with a sketch tab open, the header "open in editor" dropdown
+// painted UNDER the Excalidraw toolbar island. `.ws-tabs-shell` carries
+// `z-index: 4`, which makes it a stacking context, so `.handoff-menu`'s own
+// `z-index: 50` is trapped inside it — and Excalidraw's toolbar layer also
+// sits at 4 (`--zIndex-layerUI`) while painting later in DOM order, so it
+// wins. The fix lifts the tab shell while the handoff menu is open.
+
+const STORAGE_KEY = 'open-design:config';
+
+test.describe.configure({ timeout: T.xlong });
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript((key) => {
+    window.localStorage.setItem(
+      key,
+      JSON.stringify({
+        mode: 'daemon',
+        apiKey: '',
+        baseUrl: 'https://api.anthropic.com',
+        model: 'claude-sonnet-4-5',
+        agentId: 'mock',
+        skillId: null,
+        designSystemId: null,
+        onboardingCompleted: true,
+        agentModels: {},
+        privacyDecisionAt: 1,
+        telemetry: { metrics: false, content: false, artifactManifest: false },
+      }),
+    );
+  }, STORAGE_KEY);
+  await routeAgents(page, [
+    {
+      id: 'mock',
+      name: 'Mock Agent',
+      bin: 'mock-agent',
+      available: true,
+      version: 'test',
+      models: [{ id: 'default', label: 'Default' }],
+    },
+  ]);
+});
+
+test('[P1] handoff dropdown paints above the sketch canvas toolbar', async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+
+  const projectId = `handoff-sketch-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const created = await page.request.post('/api/projects', {
+    data: {
+      id: projectId,
+      name: 'Handoff over sketch',
+      skillId: null,
+      designSystemId: null,
+      pendingPrompt: null,
+      metadata: { kind: 'prototype' },
+    },
+  });
+  expect(created.ok(), `create project: ${await created.text()}`).toBeTruthy();
+
+  await page.goto(`/projects/${projectId}`, { waitUntil: 'domcontentloaded' });
+  await expect(page.getByTestId('file-workspace')).toBeVisible();
+  await openAllProjectFiles(page);
+  await page.getByTestId('design-files-empty-new-sketch').click();
+  await expect(page.getByTestId('sketch-excalidraw-editor')).toBeVisible();
+
+  await page.getByTestId('handoff-caret').click();
+  const menu = page.getByTestId('handoff-menu');
+  await expect(menu).toBeVisible();
+
+  const probe = await probeMenuOverToolbar(page);
+  expect(probe.overlapped, 'handoff menu and sketch toolbar do not overlap — probe is vacuous').toBe(true);
+  expect(
+    probe.leaks,
+    `Sketch toolbar paints over the open handoff menu at: ${JSON.stringify(probe.leaks)}`,
+  ).toEqual([]);
+});
+
+async function probeMenuOverToolbar(page: Page) {
+  return page.evaluate(() => {
+    const menu = document.querySelector('[data-testid="handoff-menu"]');
+    const toolbar =
+      document.querySelector('.excalidraw .App-toolbar') ??
+      document.querySelector('.excalidraw .App-toolbar-content');
+    if (!menu || !toolbar) throw new Error('menu or excalidraw toolbar not found');
+    const m = menu.getBoundingClientRect();
+    const t = toolbar.getBoundingClientRect();
+    const left = Math.max(m.left, t.left);
+    const right = Math.min(m.right, t.right);
+    const top = Math.max(m.top, t.top);
+    const bottom = Math.min(m.bottom, t.bottom);
+    if (right <= left || bottom <= top) return { overlapped: false, leaks: [] };
+    const leaks: Array<{ x: number; y: number; hit: string }> = [];
+    for (const fx of [0.25, 0.5, 0.75]) {
+      for (const fy of [0.35, 0.65]) {
+        const x = Math.round(left + (right - left) * fx);
+        const y = Math.round(top + (bottom - top) * fy);
+        const hit = document.elementFromPoint(x, y);
+        if (!hit?.closest('[data-testid="handoff-menu"]')) {
+          leaks.push({
+            x,
+            y,
+            hit:
+              hit instanceof HTMLElement
+                ? hit.className.toString().slice(0, 60) || hit.tagName
+                : (hit?.tagName ?? 'null'),
+          });
+        }
+      }
+    }
+    return { overlapped: true, leaks };
+  });
+}


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes https://github.com/nexu-io/open-design/issues/6422

## Why

<!-- Why are you opening this PR? Cover two things:
       - Your use case — what made you write this today? Did you hit it yourself
         while building on top of OD, are you scratching an itch for a team, or
         are you speculatively adding for others? All are fine, but say which.
       - The pain being addressed — user-facing problem, technical debt, a prod
         issue, or unblocking another change.
     For non-trivial features, please open a discussion or issue first to align
     on scope and UX before writing code. -->

Hit this while working in a project with a sketch tab open — clicking the
caret next to the editor button in the workspace tab bar opened the hand-off
dropdown *underneath* the Excalidraw toolbar island, which cut through the
"Copy path" row and the top editor entries. The menu was still clickable in
the gaps, but the surface read as broken.

## What users will see

<!-- Describe the change from a user's perspective, not in code terms. Examples:
       - "Settings → AI Providers has a new 'Custom endpoint' field, off by default"
       - "Right-clicking a design file shows a new 'Duplicate' option"
       - "Default model changed from X to Y — existing users will notice on first launch"
       - "New `od skills install <name>` subcommand"
     Skip this section only if you check "None" below. -->


With a sketch tab open, the "open with editor" dropdown in the workspace tab
bar now paints fully above the sketch canvas toolbar instead of being cut
through by it. No change to the menu's contents, position, or behavior — only
its stacking.


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<!-- If you checked "UI" above, attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->

### Before
<img width="2470" height="1452" alt="img_v3_02148_f8aeeec7-9088-4464-8085-10b7277f8c4g" src="https://github.com/user-attachments/assets/f359c22b-fed5-4974-8e09-d2fbd1f75f51" />


### After
<img width="2168" height="1346" alt="img_v3_02149_b4d95a75-4045-4641-941f-88f90982adcg" src="https://github.com/user-attachments/assets/56806c96-17ba-4a06-863c-c25be80d15d4" />

## Bug fix verification

<!-- Skip if this PR isn't a bug fix.

     Per AGENTS.md → "Bug follow-up workflow", bugs should be encoded as a
     falsifiable test that goes red before the source change. Confirm:
       - Test path that reproduces the bug:
       - Did the test go red on `main` and green on this branch? (yes / no)
       - If a red spec wasn't cheap to write, explain why and what verification
         you did instead. -->


- Test path: `e2e/ui/handoff-menu-sketch-stacking.test.ts`
- Red on `main`, green on this branch: **yes**. Verified by stashing only the
  CSS change and re-running — the spec fails with `elementFromPoint` resolving
  to `ToolIcon__keybinding` / `App-toolbar__divider` / `Stack_horizontal`
  inside the menu's own bounds, i.e. the exact reported symptom. With the CSS
  change it passes in 4.5s.
- The spec also asserts the menu and toolbar actually overlap before probing,
  so it fails loudly rather than passing vacuously if the layout shifts.



## Validation

<!-- What you actually ran. Default minimum: `pnpm guard` + `pnpm typecheck`,
     plus the package-scoped tests/build for the files you changed
     (e.g. `pnpm --filter @open-design/web test`). -->


- `pnpm guard` — pass
- `pnpm --filter @open-design/e2e typecheck` (`tsc -p e2e/tsconfig.json --noEmit`) — pass
- `pnpm exec playwright test ui/handoff-menu-sketch-stacking.test.ts` — 1 passed
- `pnpm exec playwright test ui/project-management-flows.test.ts` — 60 passed,
  2 failed (`[P1] BYOK OpenCode …`). Both fail identically on the baseline with
  this branch's changes stashed, so they are pre-existing and unrelated.
- Manual: real `tools-dev` runtime, created a sketch and opened the dropdown —
  screenshot above.