### PR TITLE
fix(daemon): recover od mcp install from bare-od fallback via IPC discovery (POSIX)

### DIFF
--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -14,7 +14,7 @@ import { BRAND_USAGE, isBrandHelpArg } from './cli-help/index.js';
 import { parseDesignSystemRenameArgs } from './design-systems/rename-args.js';
 import { runLiveArtifactsToolCli } from './tools-live-artifacts-cli.js';
 import { splitResearchSubcommand } from './research/cli-args.js';
-import { resolveDaemonUrl } from './daemon-url.js';
+import { resolveDaemonUrl, resolveDaemonUrlDetailed } from './daemon-url.js';
 import { requestJsonIpc } from '@open-design/sidecar';
 import { SIDECAR_ENV, SIDECAR_MESSAGES } from '@open-design/sidecar-proto';
 import { EXPORT_FORMATS, EXPORT_IMAGE_FORMATS } from '@open-design/contracts';
@@ -1980,22 +1980,42 @@ To register this server into a coding agent's own config automatically:
 // <agent>` against a packaged install has no other way to find the running
 // daemon, since OD_SIDECAR_IPC_PATH is only ever stamped into the packaged
 // app's own spawned children. See issue #6424.
+//
+// Uses resolveDaemonUrlDetailed(), not the plain-string resolveDaemonUrl(),
+// specifically because this function is about to fetch AND PERSIST whatever
+// comes back at the resolved URL. When discovery is ambiguous (more than
+// one packaged channel simultaneously live, see daemon-url.ts), the
+// resolved URL is the legacy default port — but that port is not
+// necessarily inert: something could coincidentally be listening there
+// during this exact call (a leftover process, an unrelated local service,
+// even one of the very channels this refused to choose between), and
+// fetching it anyway would silently persist whatever it returns despite the
+// ambiguity guard existing precisely to prevent that. See the #6425 review
+// discussion for the reproduction. Skipping the fetch entirely when
+// `ambiguous` is true and falling straight through to the self-reinvocation
+// spec below is the only way to make "refuse to guess" actually hold.
 async function resolveMcpLaunchSpec(flags) {
-  const base = await cliDaemonBaseUrl(flags, { allowConventionalIpcDiscovery: true });
-  try {
-    const resp = await fetch(`${base}/api/mcp/install-info`);
-    if (resp.ok) {
-      const info = await resp.json();
-      if (info && typeof info.command === 'string' && Array.isArray(info.args)) {
-        return {
-          command: info.command,
-          args: info.args,
-          env: info.env && typeof info.env === 'object' ? info.env : {},
-        };
+  const { url: rawBase, ambiguous } = await resolveDaemonUrlDetailed({
+    flagUrl: flags?.['daemon-url'],
+    allowConventionalIpcDiscovery: true,
+  });
+  const base = rawBase.replace(/\/$/, '');
+  if (!ambiguous) {
+    try {
+      const resp = await fetch(`${base}/api/mcp/install-info`);
+      if (resp.ok) {
+        const info = await resp.json();
+        if (info && typeof info.command === 'string' && Array.isArray(info.args)) {
+          return {
+            command: info.command,
+            args: info.args,
+            env: info.env && typeof info.env === 'object' ? info.env : {},
+          };
+        }
       }
+    } catch {
+      // daemon not running / unreachable — fall through to the minimal spec
     }
-  } catch {
-    // daemon not running / unreachable — fall through to the minimal spec
   }
   // Bare `od` collides with the system octal-dump utility on macOS/Linux
   // (issue #5120). Self-reinvoke via the absolute interpreter + entry-point

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -1984,38 +1984,51 @@ To register this server into a coding agent's own config automatically:
 // Uses resolveDaemonUrlDetailed(), not the plain-string resolveDaemonUrl(),
 // specifically because this function is about to fetch AND PERSIST whatever
 // comes back at the resolved URL. When discovery is ambiguous (more than
-// one packaged channel simultaneously live, see daemon-url.ts), the
-// resolved URL is the legacy default port — but that port is not
-// necessarily inert: something could coincidentally be listening there
-// during this exact call (a leftover process, an unrelated local service,
-// even one of the very channels this refused to choose between), and
-// fetching it anyway would silently persist whatever it returns despite the
-// ambiguity guard existing precisely to prevent that. See the #6425 review
-// discussion for the reproduction. Skipping the fetch entirely when
-// `ambiguous` is true and falling straight through to the self-reinvocation
-// spec below is the only way to make "refuse to guess" actually hold.
+// one packaged channel simultaneously live, see daemon-url.ts), this
+// returns `null` instead of any spec at all — see the doc comment below for
+// why even the inert-looking self-reinvocation fallback isn't safe to
+// persist in that case.
+//
+// Returns `null` (never throws) when discovery is ambiguous; the caller
+// (runMcpInstall) must treat that as "refuse the whole install", not fall
+// through to any other spec.
 async function resolveMcpLaunchSpec(flags) {
   const { url: rawBase, ambiguous } = await resolveDaemonUrlDetailed({
     flagUrl: flags?.['daemon-url'],
     allowConventionalIpcDiscovery: true,
   });
+  if (ambiguous) {
+    // Skipping the /api/mcp/install-info fetch (see below) only prevents
+    // the INSTALL-TIME response from being persisted -- it does nothing
+    // about what gets baked into the config for every LATER run. The
+    // self-reinvocation fallback below writes `--daemon-url <base>` into
+    // the persisted agent config; ensureMcpDaemonUrl (mcp-bootstrap.ts)
+    // treats an explicit --daemon-url as authoritative and skips
+    // rediscovery entirely on every subsequent `od mcp` spawn. Baking in
+    // the legacy default port here would mean any daemon that later
+    // happens to own that port -- a dev instance, a leftover process, a
+    // different packaged channel -- silently receives the MCP traffic
+    // from then on, even though THIS install explicitly refused to choose
+    // between the live channels. The only way to make "refuse to guess"
+    // actually hold end-to-end is to refuse to persist anything at all.
+    // See the #6425 review discussion.
+    return null;
+  }
   const base = rawBase.replace(/\/$/, '');
-  if (!ambiguous) {
-    try {
-      const resp = await fetch(`${base}/api/mcp/install-info`);
-      if (resp.ok) {
-        const info = await resp.json();
-        if (info && typeof info.command === 'string' && Array.isArray(info.args)) {
-          return {
-            command: info.command,
-            args: info.args,
-            env: info.env && typeof info.env === 'object' ? info.env : {},
-          };
-        }
+  try {
+    const resp = await fetch(`${base}/api/mcp/install-info`);
+    if (resp.ok) {
+      const info = await resp.json();
+      if (info && typeof info.command === 'string' && Array.isArray(info.args)) {
+        return {
+          command: info.command,
+          args: info.args,
+          env: info.env && typeof info.env === 'object' ? info.env : {},
+        };
       }
-    } catch {
-      // daemon not running / unreachable — fall through to the minimal spec
     }
+  } catch {
+    // daemon not running / unreachable — fall through to the minimal spec
   }
   // Bare `od` collides with the system octal-dump utility on macOS/Linux
   // (issue #5120). Self-reinvoke via the absolute interpreter + entry-point
@@ -2103,8 +2116,20 @@ async function runMcpInstall(args) {
   const dryRun = Boolean(flags.print || flags['dry-run']);
   const serverName = flags.name || 'open-design';
 
-  const os = await import('node:os');
   const spec = await resolveMcpLaunchSpec(flags);
+  if (spec == null) {
+    // Ambiguous discovery (see resolveMcpLaunchSpec's doc comment): more
+    // than one packaged channel is simultaneously live and this install
+    // cannot know which one the caller meant. Refuse the whole install
+    // rather than persist a --daemon-url that would silently target
+    // whatever later happens to own that port -- see the #6425 review
+    // discussion.
+    const msg = `${slug}: multiple Open Design channels are currently running; refusing to guess which one to install against. Stop the extra instance(s), or pass --daemon-url explicitly, then retry.`;
+    emitInstallResult(useJson, { ok: false, agent: slug, message: msg });
+    process.exit(2);
+  }
+
+  const os = await import('node:os');
   const plan = planAgentInstall(slug, spec, {
     home: os.homedir(),
     platform: process.platform,

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -2116,14 +2116,27 @@ async function runMcpInstall(args) {
   const dryRun = Boolean(flags.print || flags['dry-run']);
   const serverName = flags.name || 'open-design';
 
-  const spec = await resolveMcpLaunchSpec(flags);
+  // Uninstall never needs a live daemon: planAgentInstall's remove-side
+  // fields (removeArgv, configPath/keyPath/serverKey for the JSON planners)
+  // never derive from `spec` -- only the add-side fields do. Skip discovery
+  // (and its ambiguous-discovery refusal below) entirely on this path, so
+  // "two packaged channels happen to be running" can never strand a stale
+  // MCP registration in an agent's config that the user is trying to clean
+  // up. planAgentInstall still needs SOME spec argument to build the full
+  // plan object (it computes the add-side shape unconditionally even when
+  // only the remove-side is about to be used) -- this placeholder is inert
+  // and never reaches an actual command line on the uninstall path.
+  const spec = uninstall
+    ? { command: '', args: [], env: {} }
+    : await resolveMcpLaunchSpec(flags);
   if (spec == null) {
     // Ambiguous discovery (see resolveMcpLaunchSpec's doc comment): more
     // than one packaged channel is simultaneously live and this install
     // cannot know which one the caller meant. Refuse the whole install
     // rather than persist a --daemon-url that would silently target
     // whatever later happens to own that port -- see the #6425 review
-    // discussion.
+    // discussion. (Never reached for `uninstall`, which takes the
+    // placeholder-spec branch above instead.)
     const msg = `${slug}: multiple Open Design channels are currently running; refusing to guess which one to install against. Stop the extra instance(s), or pass --daemon-url explicitly, then retry.`;
     emitInstallResult(useJson, { ok: false, agent: slug, message: msg });
     process.exit(2);

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -1797,12 +1797,12 @@ function repeatableFlagValues(argv, name) {
   return values;
 }
 
-async function cliDaemonUrl(flags) {
-  return resolveDaemonUrl({ flagUrl: flags?.['daemon-url'] });
+async function cliDaemonUrl(flags, resolveOptions = {}) {
+  return resolveDaemonUrl({ flagUrl: flags?.['daemon-url'], ...resolveOptions });
 }
 
-async function cliDaemonBaseUrl(flags) {
-  return (await cliDaemonUrl(flags)).replace(/\/$/, '');
+async function cliDaemonBaseUrl(flags, resolveOptions = {}) {
+  return (await cliDaemonUrl(flags, resolveOptions)).replace(/\/$/, '');
 }
 
 function printMediaHelp() {
@@ -1974,8 +1974,14 @@ To register this server into a coding agent's own config automatically:
 // Codex one-click install use), so every install path configures byte-for-
 // byte the same command. Falls back to a minimal `od mcp --daemon-url`
 // spec when the daemon is unreachable.
+//
+// Opts into conventional per-channel IPC discovery (daemon-url.ts) — unlike
+// every other `od` subcommand, a bare terminal invocation of `mcp install
+// <agent>` against a packaged install has no other way to find the running
+// daemon, since OD_SIDECAR_IPC_PATH is only ever stamped into the packaged
+// app's own spawned children. See issue #6424.
 async function resolveMcpLaunchSpec(flags) {
-  const base = await cliDaemonBaseUrl(flags);
+  const base = await cliDaemonBaseUrl(flags, { allowConventionalIpcDiscovery: true });
   try {
     const resp = await fetch(`${base}/api/mcp/install-info`);
     if (resp.ok) {
@@ -1991,9 +1997,14 @@ async function resolveMcpLaunchSpec(flags) {
   } catch {
     // daemon not running / unreachable — fall through to the minimal spec
   }
+  // Bare `od` collides with the system octal-dump utility on macOS/Linux
+  // (issue #5120). Self-reinvoke via the absolute interpreter + entry-point
+  // paths this very process was launched with instead — the same pattern
+  // already used for plugin-validate above — so the degraded spec still
+  // resolves to a real executable even when discovery keeps failing.
   return {
-    command: 'od',
-    args: ['mcp', '--daemon-url', base],
+    command: process.execPath,
+    args: [process.argv[1], 'mcp', '--daemon-url', base],
     env: {},
   };
 }

--- a/apps/daemon/src/cli.ts
+++ b/apps/daemon/src/cli.ts
@@ -2025,8 +2025,32 @@ async function resolveMcpLaunchSpec(flags) {
   return {
     command: process.execPath,
     args: [process.argv[1], 'mcp', '--daemon-url', base],
-    env: {},
+    env: selfReinvocationRuntimeEnv(),
   };
+}
+
+// Runtime env values this process's own invocation carries that a
+// self-reinvocation spec must also carry, or a later run of the persisted
+// command silently drops behavior this exact process depends on. There is
+// no live daemon to ask for its authoritative values on this fallback path
+// (that's the whole reason it's the fallback), so the best available
+// signal is what this process itself already inherited:
+//
+// - ELECTRON_RUN_AS_NODE=1: in a packaged build, process.execPath here is
+//   Electron, not a bundled Node binary. Without this flag on the spawned
+//   process too, Electron launches the GUI app instead of running
+//   daemon-cli.mjs as plain Node.
+// - OD_DATA_DIR: pins the spawned `od mcp` to the same data root this
+//   process resolved. Without it, `od mcp` falls back to `<cwd>/.od/...`,
+//   which is the read-only macOS app bundle for packaged installs and
+//   trips EPERM (issue #848, see the matching comment in
+//   mcp-install-info.ts's buildMcpInstallPayload — the normal, non-fallback
+//   /api/mcp/install-info path already preserves both of these).
+function selfReinvocationRuntimeEnv() {
+  const env = {};
+  if (process.env.OD_DATA_DIR) env.OD_DATA_DIR = process.env.OD_DATA_DIR;
+  if (process.env.ELECTRON_RUN_AS_NODE === '1') env.ELECTRON_RUN_AS_NODE = '1';
+  return env;
 }
 
 function emitInstallResult(useJson, result) {

--- a/apps/daemon/src/daemon-url.ts
+++ b/apps/daemon/src/daemon-url.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -37,6 +38,15 @@ export interface ResolveDaemonUrlOptions {
    * `resolveMcpLaunchSpec` (cli.ts, `od mcp install <agent>`) is the one
    * caller that opts in: a plain terminal invocation of that command has no
    * other way to find a packaged install's daemon. See issue #6424.
+   *
+   * A candidate response is only trusted when it is both a loopback URL
+   * (rules out off-host redirection) and the socket file is owned by this
+   * process's effective user (rules out a different local user squatting
+   * the predictable path — see `isOwnedByCurrentProcess`). Neither check
+   * applies to the explicit `OD_SIDECAR_IPC_PATH` path above, which is a
+   * concrete endpoint the lifecycle owner supplied rather than a guessed
+   * one. POSIX-only for now: `conventionalIpcSocketPaths` yields no
+   * candidates on `win32`.
    */
   allowConventionalIpcDiscovery?: boolean;
 }
@@ -78,6 +88,11 @@ async function discoverDaemonUrlFromIpc(
 ): Promise<string | null> {
   const explicitSocketPath = env[SIDECAR_ENV.IPC_PATH];
   if (explicitSocketPath != null && explicitSocketPath.length > 0) {
+    // Unrestricted: this path is a concrete endpoint the lifecycle owner
+    // supplied for THIS session, not a guessed/predictable one, so neither
+    // the loopback nor the ownership gate applies here. A daemon started
+    // with a non-default --host (Tailscale, a specific interface, …) must
+    // keep working when the caller was explicitly told its socket path.
     return await probeIpcSocket(explicitSocketPath, timeoutMs);
   }
   if (!allowConventionalIpcDiscovery) return null;
@@ -94,7 +109,9 @@ async function discoverDaemonUrlFromIpc(
   const candidates = conventionalIpcSocketPaths(env);
   if (candidates.length === 0) return null;
   const results = await Promise.allSettled(
-    candidates.map((socketPath) => probeIpcSocket(socketPath, timeoutMs)),
+    candidates.map((socketPath) =>
+      probeIpcSocket(socketPath, timeoutMs, { requireLoopback: true, requireOwnerMatch: true }),
+    ),
   );
   for (const result of results) {
     if (result.status === "fulfilled" && result.value != null) return result.value;
@@ -105,7 +122,9 @@ async function discoverDaemonUrlFromIpc(
 async function probeIpcSocket(
   socketPath: string,
   timeoutMs: number,
+  options: { requireLoopback?: boolean; requireOwnerMatch?: boolean } = {},
 ): Promise<string | null> {
+  if (options.requireOwnerMatch && !isOwnedByCurrentProcess(socketPath)) return null;
   try {
     const status = await requestJsonIpc<DaemonStatusSnapshot>(
       socketPath,
@@ -113,24 +132,22 @@ async function probeIpcSocket(
       { timeoutMs },
     );
     const url = status?.url ?? null;
-    return url != null && isLoopbackHttpUrl(url) ? url : null;
+    if (url == null) return null;
+    if (options.requireLoopback && !isLoopbackHttpUrl(url)) return null;
+    return url;
   } catch {
     return null;
   }
 }
 
 /**
- * Whether `url` is an http(s) URL whose host is loopback. The JSON-IPC
- * protocol has no responder-identity check (no peer-credential/uid
- * verification, no shared secret — see #6424 discussion), so a STATUS
- * response is not proof the daemon is who it claims to be. This does not
- * close that gap — the sidecar IPC endpoint itself would need to add
- * authentication for that — but it does stop a responder on a predictable
- * socket/pipe path from redirecting daemon discovery off-host, which is the
- * one part of "what can this URL make us do" this module can cheaply rule
- * out before the caller `fetch()`s `/api/mcp/install-info` from it and
- * potentially persists whatever `command`/`args` come back into a coding
- * agent's config.
+ * Whether `url` is an http(s) URL whose host is loopback. Only applied to
+ * conventional-path candidates (see `probeIpcSocket`'s `requireLoopback`) —
+ * it must NOT gate the pre-existing explicit `OD_SIDECAR_IPC_PATH` case,
+ * which can legitimately point at a non-default `--host` (Tailscale, a
+ * specific interface, …). This rules out a predictable-socket responder
+ * redirecting discovery off-host; it does not by itself prove the responder
+ * IS the real daemon — see `isOwnedByCurrentProcess`.
  */
 function isLoopbackHttpUrl(url: string): boolean {
   let parsed: URL;
@@ -144,6 +161,35 @@ function isLoopbackHttpUrl(url: string): boolean {
 }
 
 /**
+ * Whether the unix socket at `socketPath` is owned by the current process's
+ * effective user. Loopback alone only rules out off-host redirection — on a
+ * predictable, unauthenticated path (see `conventionalIpcSocketPaths`),
+ * another local process could still occupy the path (e.g. while the real
+ * daemon is stopped/restarting) and answer with a loopback URL of its own,
+ * which `resolveMcpLaunchSpec` would then treat as authoritative and fetch
+ * `/api/mcp/install-info` from. Comparing the socket file's owning uid
+ * against `process.getuid()` blocks a different OS user from impersonating
+ * the daemon this way (same-user impersonation, e.g. by other malware
+ * already running as this user, is a materially different threat this
+ * check does not — and cannot cheaply — address; that needs protocol-level
+ * authentication in `packages/sidecar`).
+ *
+ * POSIX-only: `process.getuid` does not exist on Windows, and Windows named
+ * pipes use a different ACL model this module does not verify yet, so
+ * `conventionalIpcSocketPaths` returns no candidates on `win32` and this
+ * function is never reached there in practice.
+ */
+function isOwnedByCurrentProcess(socketPath: string): boolean {
+  if (typeof process.getuid !== "function") return false;
+  try {
+    const stat = statSync(socketPath);
+    return stat.isSocket() && stat.uid === process.getuid();
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Conventional per-release-channel sidecar IPC socket paths, stable-channel
  * first. Bounded to the product's own known channels (`@open-design/release`)
  * so an absent daemon still fails fast — probes run concurrently via
@@ -154,8 +200,14 @@ function isLoopbackHttpUrl(url: string): boolean {
  * mirrors the explicit-namespace precedence `resolveNamespace` already uses
  * elsewhere); otherwise derives the current platform's namespace suffix from
  * `process.platform`/`process.arch` and tries every known channel.
+ *
+ * Returns no candidates on `win32`: the ownership check this discovery mode
+ * requires (`isOwnedByCurrentProcess`) has no Windows implementation yet, and
+ * probing a predictable named pipe without any ownership/identity check is
+ * exactly the gap this module is trying to close, not widen.
  */
 function conventionalIpcSocketPaths(env: NodeJS.ProcessEnv): string[] {
+  if (process.platform === "win32") return [];
   const explicitNamespace = env[SIDECAR_ENV.NAMESPACE];
   if (explicitNamespace != null && explicitNamespace.length > 0) {
     return [
@@ -168,13 +220,7 @@ function conventionalIpcSocketPaths(env: NodeJS.ProcessEnv): string[] {
     ];
   }
   const platform: ReleasePlatform =
-    process.platform === "darwin"
-      ? process.arch === "arm64"
-        ? "mac"
-        : "macIntel"
-      : process.platform === "win32"
-        ? "win"
-        : "linux";
+    process.platform === "darwin" ? (process.arch === "arm64" ? "mac" : "macIntel") : "linux";
   const orderedChannels = [
     RELEASE_CHANNELS.STABLE,
     RELEASE_CHANNELS.BETA,

--- a/apps/daemon/src/daemon-url.ts
+++ b/apps/daemon/src/daemon-url.ts
@@ -10,6 +10,7 @@ import {
 import {
   APP_KEYS,
   OPEN_DESIGN_SIDECAR_CONTRACT,
+  SIDECAR_DEFAULTS,
   SIDECAR_ENV,
   SIDECAR_MESSAGES,
   type DaemonStatusSnapshot,
@@ -157,7 +158,11 @@ function isLoopbackHttpUrl(url: string): boolean {
     return false;
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
-  return parsed.hostname === "127.0.0.1" || parsed.hostname === "::1" || parsed.hostname === "localhost";
+  // WHATWG URL always brackets an IPv6 literal in `.hostname` (verified:
+  // `new URL("http://[::1]:1234").hostname === "[::1]"`, never the bare
+  // `"::1"`). The bare form was dead code that could never match, silently
+  // rejecting a legitimate IPv6-loopback daemon status.
+  return parsed.hostname === "127.0.0.1" || parsed.hostname === "[::1]" || parsed.hostname === "localhost";
 }
 
 /**
@@ -192,19 +197,29 @@ function isOwnedByCurrentProcess(socketPath: string): boolean {
 /**
  * Conventional per-release-channel sidecar IPC socket paths, stable-channel
  * first. Bounded to the product's own known channels (`@open-design/release`)
- * so an absent daemon still fails fast — probes run concurrently via
- * `Promise.allSettled` in the caller, so the wall-clock cost stays bounded by
- * a single timeout regardless of candidate count, not their sum.
+ * plus the generic library default so an absent daemon still fails fast —
+ * probes run concurrently via `Promise.allSettled` in the caller, so the
+ * wall-clock cost stays bounded by a single timeout regardless of candidate
+ * count, not their sum.
  *
  * Honors an explicit `OD_SIDECAR_NAMESPACE` when present (cheap extra check,
  * mirrors the explicit-namespace precedence `resolveNamespace` already uses
  * elsewhere); otherwise derives the current platform's namespace suffix from
- * `process.platform`/`process.arch` and tries every known channel.
+ * `process.platform`/`process.arch` and tries every known release channel,
+ * THEN the bare `SIDECAR_DEFAULTS.namespace` ("default"). The packaged
+ * desktop app always stamps an explicit `release-<channel>` namespace, but
+ * `tools-pack` installs whose version string doesn't resolve to a known
+ * channel (`defaultNamespaceForAppVersion` in `tools/pack/src/config.ts`)
+ * fall through to the bare sidecar-proto default instead — release channels
+ * are tried first since they're the more common (packaged app) case, with
+ * "default" as the deterministic last resort.
  *
  * Returns no candidates on `win32`: the ownership check this discovery mode
  * requires (`isOwnedByCurrentProcess`) has no Windows implementation yet, and
  * probing a predictable named pipe without any ownership/identity check is
- * exactly the gap this module is trying to close, not widen.
+ * exactly the gap this module is trying to close, not widen. This is a known,
+ * intentional scope limit of this fix — see issue #6424's follow-up for
+ * Windows-specific coverage — not an oversight.
  */
 function conventionalIpcSocketPaths(env: NodeJS.ProcessEnv): string[] {
   if (process.platform === "win32") return [];
@@ -228,12 +243,16 @@ function conventionalIpcSocketPaths(env: NodeJS.ProcessEnv): string[] {
     RELEASE_CHANNELS.PRERELEASE,
     RELEASE_CHANNELS.PREVIEW,
   ] as const;
-  return orderedChannels.map((channel) =>
+  const orderedNamespaces: string[] = [
+    ...orderedChannels.map((channel) => releaseNamespace(channel, platform)),
+    SIDECAR_DEFAULTS.namespace,
+  ];
+  return orderedNamespaces.map((namespace) =>
     resolveAppIpcPath({
       app: APP_KEYS.DAEMON,
       contract: OPEN_DESIGN_SIDECAR_CONTRACT,
       env,
-      namespace: releaseNamespace(channel, platform),
+      namespace,
     }),
   );
 }

--- a/apps/daemon/src/daemon-url.ts
+++ b/apps/daemon/src/daemon-url.ts
@@ -2,11 +2,18 @@ import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  RELEASE_CHANNELS,
+  releaseNamespace,
+  type ReleasePlatform,
+} from "@open-design/release";
+import {
+  APP_KEYS,
+  OPEN_DESIGN_SIDECAR_CONTRACT,
   SIDECAR_ENV,
   SIDECAR_MESSAGES,
   type DaemonStatusSnapshot,
 } from "@open-design/sidecar-proto";
-import { requestJsonIpc } from "@open-design/sidecar";
+import { requestJsonIpc, resolveAppIpcPath } from "@open-design/sidecar";
 
 export const DEFAULT_DAEMON_URL = "http://127.0.0.1:7456";
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
@@ -18,6 +25,20 @@ export interface ResolveDaemonUrlOptions {
   env?: NodeJS.ProcessEnv;
   /** IPC discovery timeout. Short by default so an absent daemon does not stall CLI startup. */
   timeoutMs?: number;
+  /**
+   * Opt-in: when `OD_SIDECAR_IPC_PATH` is absent, also probe the
+   * conventional per-release-channel sidecar socket path(s) (see
+   * `conventionalIpcSocketPaths`) before falling through to `tools-dev`
+   * discovery and the legacy default. Defaults to `false` so every existing
+   * `resolveDaemonUrl` caller (media generate, project list, run start, …)
+   * keeps its current behavior unchanged — an unrelated already-running
+   * packaged daemon must not silently start answering for commands that
+   * never asked for daemon auto-discovery beyond an explicit IPC path.
+   * `resolveMcpLaunchSpec` (cli.ts, `od mcp install <agent>`) is the one
+   * caller that opts in: a plain terminal invocation of that command has no
+   * other way to find a packaged install's daemon. See issue #6424.
+   */
+  allowConventionalIpcDiscovery?: boolean;
 }
 
 /**
@@ -25,9 +46,11 @@ export interface ResolveDaemonUrlOptions {
  *
  * Spawn order: explicit `--daemon-url` flag, `OD_DAEMON_URL` env, then
  * a STATUS roundtrip to the concrete sidecar IPC endpoint supplied by
- * the lifecycle owner in `OD_SIDECAR_IPC_PATH`, then the default
- * `tools-dev status --json` runtime. Falls back to the legacy default
- * for direct `od` launches that do not run as a sidecar.
+ * the lifecycle owner in `OD_SIDECAR_IPC_PATH` (optionally falling back to
+ * the conventional per-channel socket path(s) when that env var is absent —
+ * see `allowConventionalIpcDiscovery` / `conventionalIpcSocketPaths`), then
+ * the default `tools-dev status --json` runtime. Falls back to the legacy
+ * default for direct `od` launches that do not run as a sidecar.
  */
 export async function resolveDaemonUrl(
   options: ResolveDaemonUrlOptions = {},
@@ -37,7 +60,11 @@ export async function resolveDaemonUrl(
   if (flagUrl != null && flagUrl.length > 0) return flagUrl;
   const envUrl = env.OD_DAEMON_URL;
   if (envUrl != null && envUrl.length > 0) return envUrl;
-  const discovered = await discoverDaemonUrlFromIpc(env, options.timeoutMs ?? 800);
+  const discovered = await discoverDaemonUrlFromIpc(
+    env,
+    options.timeoutMs ?? 800,
+    options.allowConventionalIpcDiscovery ?? false,
+  );
   if (discovered != null) return discovered;
   const toolsDevUrl = await discoverDaemonUrlFromToolsDev(env, options.timeoutMs ?? 800);
   if (toolsDevUrl != null) return toolsDevUrl;
@@ -47,19 +74,122 @@ export async function resolveDaemonUrl(
 async function discoverDaemonUrlFromIpc(
   env: NodeJS.ProcessEnv,
   timeoutMs: number,
+  allowConventionalIpcDiscovery: boolean,
 ): Promise<string | null> {
-  const socketPath = env[SIDECAR_ENV.IPC_PATH];
-  if (socketPath == null || socketPath.length === 0) return null;
+  const explicitSocketPath = env[SIDECAR_ENV.IPC_PATH];
+  if (explicitSocketPath != null && explicitSocketPath.length > 0) {
+    return await probeIpcSocket(explicitSocketPath, timeoutMs);
+  }
+  if (!allowConventionalIpcDiscovery) return null;
+  // `OD_SIDECAR_IPC_PATH` is only ever stamped by the packaged app into its
+  // OWN spawned child processes (see apps/packaged/src/sidecars.ts) — an
+  // ordinary user terminal never has it set. Without this fallback, `od mcp
+  // install <agent>` run from a plain shell against a running packaged
+  // install can never find `/api/mcp/install-info` and always degrades to
+  // the broken bare-`od` launch spec in cli.ts's resolveMcpLaunchSpec, even
+  // though a live daemon is reachable at a well-known socket path. Gated
+  // behind `allowConventionalIpcDiscovery` so every other `od` subcommand
+  // keeps requiring an explicit IPC path / --daemon-url instead of silently
+  // latching onto an unrelated already-running packaged daemon. See #6424.
+  const candidates = conventionalIpcSocketPaths(env);
+  if (candidates.length === 0) return null;
+  const results = await Promise.allSettled(
+    candidates.map((socketPath) => probeIpcSocket(socketPath, timeoutMs)),
+  );
+  for (const result of results) {
+    if (result.status === "fulfilled" && result.value != null) return result.value;
+  }
+  return null;
+}
+
+async function probeIpcSocket(
+  socketPath: string,
+  timeoutMs: number,
+): Promise<string | null> {
   try {
     const status = await requestJsonIpc<DaemonStatusSnapshot>(
       socketPath,
       { type: SIDECAR_MESSAGES.STATUS },
       { timeoutMs },
     );
-    return status?.url ?? null;
+    const url = status?.url ?? null;
+    return url != null && isLoopbackHttpUrl(url) ? url : null;
   } catch {
     return null;
   }
+}
+
+/**
+ * Whether `url` is an http(s) URL whose host is loopback. The JSON-IPC
+ * protocol has no responder-identity check (no peer-credential/uid
+ * verification, no shared secret — see #6424 discussion), so a STATUS
+ * response is not proof the daemon is who it claims to be. This does not
+ * close that gap — the sidecar IPC endpoint itself would need to add
+ * authentication for that — but it does stop a responder on a predictable
+ * socket/pipe path from redirecting daemon discovery off-host, which is the
+ * one part of "what can this URL make us do" this module can cheaply rule
+ * out before the caller `fetch()`s `/api/mcp/install-info` from it and
+ * potentially persists whatever `command`/`args` come back into a coding
+ * agent's config.
+ */
+function isLoopbackHttpUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+  return parsed.hostname === "127.0.0.1" || parsed.hostname === "::1" || parsed.hostname === "localhost";
+}
+
+/**
+ * Conventional per-release-channel sidecar IPC socket paths, stable-channel
+ * first. Bounded to the product's own known channels (`@open-design/release`)
+ * so an absent daemon still fails fast — probes run concurrently via
+ * `Promise.allSettled` in the caller, so the wall-clock cost stays bounded by
+ * a single timeout regardless of candidate count, not their sum.
+ *
+ * Honors an explicit `OD_SIDECAR_NAMESPACE` when present (cheap extra check,
+ * mirrors the explicit-namespace precedence `resolveNamespace` already uses
+ * elsewhere); otherwise derives the current platform's namespace suffix from
+ * `process.platform`/`process.arch` and tries every known channel.
+ */
+function conventionalIpcSocketPaths(env: NodeJS.ProcessEnv): string[] {
+  const explicitNamespace = env[SIDECAR_ENV.NAMESPACE];
+  if (explicitNamespace != null && explicitNamespace.length > 0) {
+    return [
+      resolveAppIpcPath({
+        app: APP_KEYS.DAEMON,
+        contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+        env,
+        namespace: explicitNamespace,
+      }),
+    ];
+  }
+  const platform: ReleasePlatform =
+    process.platform === "darwin"
+      ? process.arch === "arm64"
+        ? "mac"
+        : "macIntel"
+      : process.platform === "win32"
+        ? "win"
+        : "linux";
+  const orderedChannels = [
+    RELEASE_CHANNELS.STABLE,
+    RELEASE_CHANNELS.BETA,
+    RELEASE_CHANNELS.BETAS,
+    RELEASE_CHANNELS.PRERELEASE,
+    RELEASE_CHANNELS.PREVIEW,
+  ] as const;
+  return orderedChannels.map((channel) =>
+    resolveAppIpcPath({
+      app: APP_KEYS.DAEMON,
+      contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+      env,
+      namespace: releaseNamespace(channel, platform),
+    }),
+  );
 }
 
 async function discoverDaemonUrlFromToolsDev(

--- a/apps/daemon/src/daemon-url.ts
+++ b/apps/daemon/src/daemon-url.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   RELEASE_CHANNELS,
-  releaseNamespace,
+  releaseNamespaceCandidates,
   type ReleasePlatform,
 } from "@open-design/release";
 import {
@@ -51,6 +51,16 @@ export interface ResolveDaemonUrlOptions {
    * candidates on `win32`.
    */
   allowConventionalIpcDiscovery?: boolean;
+  /**
+   * Test-only override for the `ReleasePlatform` that
+   * `conventionalIpcSocketPaths` derives from `process.platform`/
+   * `process.arch` via `currentReleasePlatform()`. Production callers should
+   * never set this. It exists so tests can exercise the macIntel/win
+   * candidate-list branches directly instead of mutating global process
+   * state (the previous approach, which the #6425 review flagged as making
+   * this code hard to test safely under concurrent test execution).
+   */
+  platform?: ReleasePlatform;
 }
 
 /**
@@ -76,6 +86,7 @@ export async function resolveDaemonUrl(
     env,
     options.timeoutMs ?? 800,
     options.allowConventionalIpcDiscovery ?? false,
+    options.platform,
   );
   if (discovered != null) return discovered;
   const toolsDevUrl = await discoverDaemonUrlFromToolsDev(env, options.timeoutMs ?? 800);
@@ -87,6 +98,7 @@ async function discoverDaemonUrlFromIpc(
   env: NodeJS.ProcessEnv,
   timeoutMs: number,
   allowConventionalIpcDiscovery: boolean,
+  platform?: ReleasePlatform,
 ): Promise<string | null> {
   const explicitSocketPath = env[SIDECAR_ENV.IPC_PATH];
   if (explicitSocketPath != null && explicitSocketPath.length > 0) {
@@ -108,17 +120,34 @@ async function discoverDaemonUrlFromIpc(
   // behind `allowConventionalIpcDiscovery` so every other `od` subcommand
   // keeps requiring an explicit IPC path / --daemon-url instead of silently
   // latching onto an unrelated already-running packaged daemon. See #6424.
-  const candidates = conventionalIpcSocketPaths(env);
+  const candidates = conventionalIpcSocketPaths(env, platform);
   if (candidates.length === 0) return null;
   const results = await Promise.allSettled(
     candidates.map((socketPath) =>
       probeIpcSocket(socketPath, timeoutMs, { requireLoopback: true, requireOwnerMatch: true }),
     ),
   );
-  for (const result of results) {
-    if (result.status === "fulfilled" && result.value != null) return result.value;
-  }
-  return null;
+  // Distinct successful responses only. An explicit OD_SIDECAR_NAMESPACE
+  // always yields exactly one candidate above, so ambiguity can only arise
+  // from the channel sweep in conventionalIpcSocketPaths(). If MORE THAN ONE
+  // distinct daemon answers (e.g. a stable install and a beta install both
+  // happen to be running), this function has no way to know which one the
+  // invoking `od` binary or user actually meant — a prior version of this
+  // code deterministically preferred "stable", but determinism is not
+  // correctness: resolveMcpLaunchSpec() would persist that guess's absolute
+  // paths into the agent's config, silently wiring it to the WRONG packaged
+  // channel. Refuse to choose and return null instead, so the caller falls
+  // through to tools-dev discovery and then the legacy default — a safe,
+  // inert self-reinvocation spec rather than a confidently wrong one. See
+  // the #6425 review discussion. Deduplicated by URL VALUE, not candidate
+  // count: releaseNamespaceCandidates() can list more than one namespace
+  // alias for the same channel (see conventionalIpcSocketPaths()), and two
+  // aliases resolving to the same live daemon is not actually ambiguous.
+  const found = results
+    .filter((result): result is PromiseFulfilledResult<string> => result.status === "fulfilled" && result.value != null)
+    .map((result) => result.value);
+  const distinct = Array.from(new Set(found));
+  return distinct.length === 1 ? distinct[0]! : null;
 }
 
 async function probeIpcSocket(
@@ -143,13 +172,17 @@ async function probeIpcSocket(
 }
 
 /**
- * Whether `url` is an http(s) URL whose host is loopback. Only applied to
- * conventional-path candidates (see `probeIpcSocket`'s `requireLoopback`) —
- * it must NOT gate the pre-existing explicit `OD_SIDECAR_IPC_PATH` case,
- * which can legitimately point at a non-default `--host` (Tailscale, a
- * specific interface, …). This rules out a predictable-socket responder
- * redirecting discovery off-host; it does not by itself prove the responder
- * IS the real daemon — see `isOwnedByCurrentProcess`.
+ * Whether `url` is a bare http(s) loopback origin: scheme, loopback host,
+ * and an explicit port — nothing else. Only applied to conventional-path
+ * candidates (see `probeIpcSocket`'s `requireLoopback`) — it must NOT gate
+ * the pre-existing explicit `OD_SIDECAR_IPC_PATH` case, which can
+ * legitimately point at a non-default `--host` (Tailscale, a specific
+ * interface, …). This rules out a predictable-socket responder redirecting
+ * discovery off-host, or onto a non-base URL (embedded credentials, a
+ * sub-path, a query string, a fragment) that `resolveMcpLaunchSpec` would
+ * otherwise blindly append `/api/mcp/install-info` onto; it does not by
+ * itself prove the responder IS the real daemon — see
+ * `isOwnedByCurrentProcess`.
  *
  * Delegates hostname classification to `isLoopbackHostname` (the same
  * predicate the daemon's own inbound request validation uses in
@@ -162,8 +195,16 @@ async function probeIpcSocket(
  * which address in the block is used. `isLoopbackHostname` also strips the
  * `[...]` brackets WHATWG URL puts around IPv6 literals, so this stays
  * correct for `[::1]`-style hosts without a separate bracket check.
+ *
+ * `isLoopbackHostname` classifies the URL's HOSTNAME STRING; it does not
+ * verify the later HTTP fetch in `resolveMcpLaunchSpec` actually lands on a
+ * loopback network interface. In particular, accepting the literal string
+ * "localhost" relies on the OS/hosts-file resolving it to a loopback address
+ * — a local trust boundary this module does not independently re-verify.
+ * Treat this function as "rules out a hostname that does not even claim to
+ * be loopback", not as an end-to-end network guarantee.
  */
-function isLoopbackHttpUrl(url: string): boolean {
+export function isLoopbackHttpUrl(url: string): boolean {
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -171,27 +212,58 @@ function isLoopbackHttpUrl(url: string): boolean {
     return false;
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
-  return isLoopbackHostname(parsed.hostname);
+  if (!isLoopbackHostname(parsed.hostname)) return false;
+  // A real daemon STATUS response is always a bare origin at an explicit
+  // ephemeral port. Rejecting anything else means a predictable-socket
+  // responder can't smuggle credentials, a redirect-ish sub-path, or a query
+  // string through discovery — resolveMcpLaunchSpec (cli.ts) appends
+  // `/api/mcp/install-info` to this value as a plain string, so a non-base
+  // URL here would produce a surprising fetch target even when the host
+  // itself is legitimately loopback.
+  if (parsed.username.length > 0 || parsed.password.length > 0) return false;
+  if (parsed.port.length === 0) return false;
+  if (parsed.pathname !== "/" && parsed.pathname !== "") return false;
+  if (parsed.search.length > 0 || parsed.hash.length > 0) return false;
+  return true;
 }
 
 /**
- * Whether the unix socket at `socketPath` is owned by the current process's
- * effective user. Loopback alone only rules out off-host redirection — on a
- * predictable, unauthenticated path (see `conventionalIpcSocketPaths`),
- * another local process could still occupy the path (e.g. while the real
- * daemon is stopped/restarting) and answer with a loopback URL of its own,
- * which `resolveMcpLaunchSpec` would then treat as authoritative and fetch
- * `/api/mcp/install-info` from. Comparing the socket file's owning uid
- * against `process.getuid()` blocks a different OS user from impersonating
- * the daemon this way (same-user impersonation, e.g. by other malware
- * already running as this user, is a materially different threat this
- * check does not — and cannot cheaply — address; that needs protocol-level
- * authentication in `packages/sidecar`).
+ * Whether the unix socket FILE at `socketPath` is owned by the current
+ * process's effective user, checked via `statSync` immediately before
+ * `probeIpcSocket` calls `requestJsonIpc` to connect to it. This is a
+ * mitigation, not a proof of identity, in two distinct ways that are worth
+ * stating plainly rather than implying a stronger guarantee than either
+ * actually provides:
+ *
+ * 1. TOCTOU: the filesystem object at `socketPath` could in principle be
+ *    replaced (unlinked and re-bound by a different process) between this
+ *    `statSync` and the `connect()` `requestJsonIpc` performs immediately
+ *    after. Node's `net` module has no atomic "connect, then check who you
+ *    connected to" primitive for unix sockets, so this check and the
+ *    connect it gates are two separate syscalls with a real, if narrow,
+ *    window between them.
+ * 2. File ownership is not peer identity: even without the TOCTOU race,
+ *    "the socket file is owned by my uid" proves that SOME process running
+ *    as this uid created or was granted ownership of that path — not that
+ *    the process CURRENTLY answering on it is the one this call intended to
+ *    reach. A real trust boundary needs OS peer credentials (`SO_PEERCRED`
+ *    on Linux, `LOCAL_PEERCRED` on macOS/BSD), which Node's `net` module
+ *    does not expose without native code; that is out of scope for this
+ *    fix.
+ *
+ * What this DOES reliably block: a DIFFERENT OS user (no shared uid)
+ * squatting the predictable path and answering as though it were the
+ * daemon — e.g. while the real daemon is stopped/restarting, which
+ * `resolveMcpLaunchSpec` would otherwise treat as authoritative and fetch
+ * `/api/mcp/install-info` from. It does NOT defend against other processes
+ * already running as THIS SAME user (other local malware, say), which is a
+ * materially different and harder threat model requiring the
+ * protocol-level authentication noted above, in `packages/sidecar`.
  *
  * POSIX-only: `process.getuid` does not exist on Windows, and Windows named
  * pipes use a different ACL model this module does not verify yet, so
- * `conventionalIpcSocketPaths` returns no candidates on `win32` and this
- * function is never reached there in practice.
+ * `conventionalIpcSocketPaths` returns no candidates on `win32`/`"win"` and
+ * this function is never reached there in practice.
  */
 function isOwnedByCurrentProcess(socketPath: string): boolean {
   if (typeof process.getuid !== "function") return false;
@@ -204,6 +276,24 @@ function isOwnedByCurrentProcess(socketPath: string): boolean {
 }
 
 /**
+ * The `ReleasePlatform` this process is currently running as, derived from
+ * `platform`/`arch` (defaulting to the real `process` object). Accepts an
+ * injectable subset of `NodeJS.Process` purely so tests can exercise the
+ * mac/macIntel/win/linux branches of `conventionalIpcSocketPaths` directly
+ * — via that function's own `platform` parameter — instead of mutating
+ * `process.platform`/`process.arch` globals, which the #6425 review flagged
+ * as fragile under concurrent test execution. Production code should always
+ * call this with no argument.
+ */
+export function currentReleasePlatform(
+  proc: Pick<NodeJS.Process, "platform" | "arch"> = process,
+): ReleasePlatform {
+  if (proc.platform === "darwin") return proc.arch === "arm64" ? "mac" : "macIntel";
+  if (proc.platform === "win32") return "win";
+  return "linux";
+}
+
+/**
  * Conventional per-release-channel sidecar IPC socket paths, stable-channel
  * first. Bounded to the product's own known channels (`@open-design/release`)
  * plus the generic library default so an absent daemon still fails fast —
@@ -213,25 +303,39 @@ function isOwnedByCurrentProcess(socketPath: string): boolean {
  *
  * Honors an explicit `OD_SIDECAR_NAMESPACE` when present (cheap extra check,
  * mirrors the explicit-namespace precedence `resolveNamespace` already uses
- * elsewhere); otherwise derives the current platform's namespace suffix from
- * `process.platform`/`process.arch` and tries every known release channel,
- * THEN the bare `SIDECAR_DEFAULTS.namespace` ("default"). The packaged
- * desktop app always stamps an explicit `release-<channel>` namespace, but
- * `tools-pack` installs whose version string doesn't resolve to a known
- * channel (`defaultNamespaceForAppVersion` in `tools/pack/src/config.ts`)
- * fall through to the bare sidecar-proto default instead — release channels
- * are tried first since they're the more common (packaged app) case, with
- * "default" as the deterministic last resort.
+ * elsewhere); otherwise resolves `platform` (defaulting to
+ * `currentReleasePlatform()`; callers never need to pass this explicitly in
+ * production — see that function's doc comment) and tries every known
+ * release channel via `releaseNamespaceCandidates` — which also surfaces any
+ * legacy namespace aliases a channel/platform pair is still shipping under
+ * (see `@open-design/release`'s own doc comment for the one known outlier,
+ * beta on Intel mac) — THEN the bare `SIDECAR_DEFAULTS.namespace`
+ * ("default"). The packaged desktop app always stamps an explicit
+ * `release-<channel>` namespace, but `tools-pack` installs whose version
+ * string doesn't resolve to a known channel (`defaultNamespaceForAppVersion`
+ * in `tools/pack/src/config.ts`) fall through to the bare sidecar-proto
+ * default instead — release channels are tried first since they're the more
+ * common (packaged app) case, with "default" as the deterministic last
+ * resort. Namespace/alias identity is intentionally NOT this module's
+ * concern beyond converting a namespace string into an IPC path: it is owned
+ * by `@open-design/release`, which is the layer four straight rounds of
+ * review found new namespace-derivation gaps in before this split (see
+ * #6425 review discussion) — keeping that knowledge in one place is what
+ * prevents a fifth.
  *
- * Returns no candidates on `win32`: the ownership check this discovery mode
- * requires (`isOwnedByCurrentProcess`) has no Windows implementation yet, and
- * probing a predictable named pipe without any ownership/identity check is
- * exactly the gap this module is trying to close, not widen. This is a known,
- * intentional scope limit of this fix — see issue #6424's follow-up for
- * Windows-specific coverage — not an oversight.
+ * Returns no candidates when `platform` is `"win"`: the ownership check this
+ * discovery mode requires (`isOwnedByCurrentProcess`) has no Windows
+ * implementation yet, and probing a predictable named pipe without any
+ * ownership/identity check is exactly the gap this module is trying to
+ * close, not widen. This is a known, intentional scope limit of this fix —
+ * see issue #6424's follow-up for Windows-specific coverage — not an
+ * oversight.
  */
-function conventionalIpcSocketPaths(env: NodeJS.ProcessEnv): string[] {
-  if (process.platform === "win32") return [];
+export function conventionalIpcSocketPaths(
+  env: NodeJS.ProcessEnv,
+  platform: ReleasePlatform = currentReleasePlatform(),
+): string[] {
+  if (platform === "win") return [];
   const explicitNamespace = env[SIDECAR_ENV.NAMESPACE];
   if (explicitNamespace != null && explicitNamespace.length > 0) {
     return [
@@ -243,8 +347,6 @@ function conventionalIpcSocketPaths(env: NodeJS.ProcessEnv): string[] {
       }),
     ];
   }
-  const platform: ReleasePlatform =
-    process.platform === "darwin" ? (process.arch === "arm64" ? "mac" : "macIntel") : "linux";
   const orderedChannels = [
     RELEASE_CHANNELS.STABLE,
     RELEASE_CHANNELS.BETA,
@@ -253,20 +355,7 @@ function conventionalIpcSocketPaths(env: NodeJS.ProcessEnv): string[] {
     RELEASE_CHANNELS.PREVIEW,
   ] as const;
   const orderedNamespaces: string[] = [
-    ...orderedChannels.map((channel) => releaseNamespace(channel, platform)),
-    // Known CI naming inconsistency (see #6425 review): every other
-    // channel's Intel-mac build follows the standard `-intel` suffix
-    // (release-prerelease-intel, release-preview-intel, matching
-    // `releaseNamespace(channel, "macIntel")`), but
-    // `.github/workflows/release-beta.yml`'s mac_x64 job instead bakes
-    // "release-beta-x64" via `tools-pack mac build --namespace
-    // release-beta-x64`. That literal is what a live beta Intel install's
-    // daemon actually listens under, so it has to be probed even though it
-    // doesn't fit the derivable pattern. Renaming the shipping workflow's
-    // namespace to match the pattern is a separate, higher-risk change
-    // (would orphan already-installed beta Intel users' existing IPC path)
-    // outside the scope of this fix — see PR #6425 review discussion.
-    ...(platform === "macIntel" ? ["release-beta-x64"] : []),
+    ...orderedChannels.flatMap((channel) => releaseNamespaceCandidates(channel, platform)),
     SIDECAR_DEFAULTS.namespace,
   ];
   return orderedNamespaces.map((namespace) =>

--- a/apps/daemon/src/daemon-url.ts
+++ b/apps/daemon/src/daemon-url.ts
@@ -16,6 +16,7 @@ import {
   type DaemonStatusSnapshot,
 } from "@open-design/sidecar-proto";
 import { requestJsonIpc, resolveAppIpcPath } from "@open-design/sidecar";
+import { isLoopbackHostname } from "./http/local-daemon-request.js";
 
 export const DEFAULT_DAEMON_URL = "http://127.0.0.1:7456";
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
@@ -149,6 +150,18 @@ async function probeIpcSocket(
  * specific interface, …). This rules out a predictable-socket responder
  * redirecting discovery off-host; it does not by itself prove the responder
  * IS the real daemon — see `isOwnedByCurrentProcess`.
+ *
+ * Delegates hostname classification to `isLoopbackHostname` (the same
+ * predicate the daemon's own inbound request validation uses in
+ * `http/local-daemon-request.ts`) instead of an exact-match list, so this
+ * accepts the full 127.0.0.0/8 range. A packaged daemon started with e.g.
+ * `OD_BIND_HOST=127.0.0.2` is an already-supported local configuration
+ * whose own bind validation accepts it; conventional discovery rejecting it
+ * (falling back to 7456, where nothing listens) would be a regression for
+ * that case, not a security improvement — 127/8 is loopback regardless of
+ * which address in the block is used. `isLoopbackHostname` also strips the
+ * `[...]` brackets WHATWG URL puts around IPv6 literals, so this stays
+ * correct for `[::1]`-style hosts without a separate bracket check.
  */
 function isLoopbackHttpUrl(url: string): boolean {
   let parsed: URL;
@@ -158,11 +171,7 @@ function isLoopbackHttpUrl(url: string): boolean {
     return false;
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
-  // WHATWG URL always brackets an IPv6 literal in `.hostname` (verified:
-  // `new URL("http://[::1]:1234").hostname === "[::1]"`, never the bare
-  // `"::1"`). The bare form was dead code that could never match, silently
-  // rejecting a legitimate IPv6-loopback daemon status.
-  return parsed.hostname === "127.0.0.1" || parsed.hostname === "[::1]" || parsed.hostname === "localhost";
+  return isLoopbackHostname(parsed.hostname);
 }
 
 /**

--- a/apps/daemon/src/daemon-url.ts
+++ b/apps/daemon/src/daemon-url.ts
@@ -64,6 +64,22 @@ export interface ResolveDaemonUrlOptions {
 }
 
 /**
+ * Outcome of the sidecar IPC discovery stage, distinguishing "nothing
+ * answered" (the caller should keep trying the next discovery mechanism)
+ * from "more than one channel answered and this function refuses to guess
+ * which one is meant" (the caller must NOT keep trying — see
+ * `resolveDaemonUrl`'s handling of `kind: "ambiguous"`). Collapsing both
+ * into a bare `null` was the bug the #6425 review caught: `resolveDaemonUrl`
+ * would fall through to `discoverDaemonUrlFromToolsDev` either way, so an
+ * ambiguous conventional-discovery result could still be silently
+ * overridden by an unrelated live tools-dev daemon.
+ */
+type IpcDiscoveryResult =
+  | { kind: "found"; url: string }
+  | { kind: "not-found" }
+  | { kind: "ambiguous" };
+
+/**
  * Resolve the daemon HTTP base URL for `od` client commands.
  *
  * Spawn order: explicit `--daemon-url` flag, `OD_DAEMON_URL` env, then
@@ -73,6 +89,13 @@ export interface ResolveDaemonUrlOptions {
  * see `allowConventionalIpcDiscovery` / `conventionalIpcSocketPaths`), then
  * the default `tools-dev status --json` runtime. Falls back to the legacy
  * default for direct `od` launches that do not run as a sidecar.
+ *
+ * An ambiguous IPC result (more than one packaged channel answered, see
+ * `IpcDiscoveryResult`) skips tools-dev discovery entirely and returns the
+ * legacy default directly — refusing to guess extends to every later
+ * discovery mechanism, not just the conventional channel sweep, since a
+ * live tools-dev daemon answering in that window is just as much an
+ * unrelated runtime as a wrongly-picked packaged channel would have been.
  */
 export async function resolveDaemonUrl(
   options: ResolveDaemonUrlOptions = {},
@@ -88,7 +111,8 @@ export async function resolveDaemonUrl(
     options.allowConventionalIpcDiscovery ?? false,
     options.platform,
   );
-  if (discovered != null) return discovered;
+  if (discovered.kind === "found") return discovered.url;
+  if (discovered.kind === "ambiguous") return DEFAULT_DAEMON_URL;
   const toolsDevUrl = await discoverDaemonUrlFromToolsDev(env, options.timeoutMs ?? 800);
   if (toolsDevUrl != null) return toolsDevUrl;
   return DEFAULT_DAEMON_URL;
@@ -99,7 +123,7 @@ async function discoverDaemonUrlFromIpc(
   timeoutMs: number,
   allowConventionalIpcDiscovery: boolean,
   platform?: ReleasePlatform,
-): Promise<string | null> {
+): Promise<IpcDiscoveryResult> {
   const explicitSocketPath = env[SIDECAR_ENV.IPC_PATH];
   if (explicitSocketPath != null && explicitSocketPath.length > 0) {
     // Unrestricted: this path is a concrete endpoint the lifecycle owner
@@ -107,9 +131,11 @@ async function discoverDaemonUrlFromIpc(
     // the loopback nor the ownership gate applies here. A daemon started
     // with a non-default --host (Tailscale, a specific interface, …) must
     // keep working when the caller was explicitly told its socket path.
-    return await probeIpcSocket(explicitSocketPath, timeoutMs);
+    // Never ambiguous: exactly one concrete path is ever probed here.
+    const url = await probeIpcSocket(explicitSocketPath, timeoutMs);
+    return url != null ? { kind: "found", url } : { kind: "not-found" };
   }
-  if (!allowConventionalIpcDiscovery) return null;
+  if (!allowConventionalIpcDiscovery) return { kind: "not-found" };
   // `OD_SIDECAR_IPC_PATH` is only ever stamped by the packaged app into its
   // OWN spawned child processes (see apps/packaged/src/sidecars.ts) — an
   // ordinary user terminal never has it set. Without this fallback, `od mcp
@@ -121,7 +147,7 @@ async function discoverDaemonUrlFromIpc(
   // keeps requiring an explicit IPC path / --daemon-url instead of silently
   // latching onto an unrelated already-running packaged daemon. See #6424.
   const candidates = conventionalIpcSocketPaths(env, platform);
-  if (candidates.length === 0) return null;
+  if (candidates.length === 0) return { kind: "not-found" };
   const results = await Promise.allSettled(
     candidates.map((socketPath) =>
       probeIpcSocket(socketPath, timeoutMs, { requireLoopback: true, requireOwnerMatch: true }),
@@ -136,18 +162,21 @@ async function discoverDaemonUrlFromIpc(
   // code deterministically preferred "stable", but determinism is not
   // correctness: resolveMcpLaunchSpec() would persist that guess's absolute
   // paths into the agent's config, silently wiring it to the WRONG packaged
-  // channel. Refuse to choose and return null instead, so the caller falls
-  // through to tools-dev discovery and then the legacy default — a safe,
-  // inert self-reinvocation spec rather than a confidently wrong one. See
-  // the #6425 review discussion. Deduplicated by URL VALUE, not candidate
-  // count: releaseNamespaceCandidates() can list more than one namespace
-  // alias for the same channel (see conventionalIpcSocketPaths()), and two
-  // aliases resolving to the same live daemon is not actually ambiguous.
+  // channel. Reports `kind: "ambiguous"` instead of a bare `null` so
+  // `resolveDaemonUrl` stops entirely rather than letting a DIFFERENT
+  // unrelated discovery mechanism (tools-dev) silently win in this case —
+  // see `IpcDiscoveryResult`'s doc comment and the #6425 review discussion.
+  // Deduplicated by URL VALUE, not candidate count: releaseNamespaceCandidates()
+  // can list more than one namespace alias for the same channel (see
+  // conventionalIpcSocketPaths()), and two aliases resolving to the same
+  // live daemon is not actually ambiguous.
   const found = results
     .filter((result): result is PromiseFulfilledResult<string> => result.status === "fulfilled" && result.value != null)
     .map((result) => result.value);
   const distinct = Array.from(new Set(found));
-  return distinct.length === 1 ? distinct[0]! : null;
+  if (distinct.length === 0) return { kind: "not-found" };
+  if (distinct.length > 1) return { kind: "ambiguous" };
+  return { kind: "found", url: distinct[0]! };
 }
 
 async function probeIpcSocket(

--- a/apps/daemon/src/daemon-url.ts
+++ b/apps/daemon/src/daemon-url.ts
@@ -80,6 +80,30 @@ type IpcDiscoveryResult =
   | { kind: "ambiguous" };
 
 /**
+ * `resolveDaemonUrlDetailed`'s result. `url` is always a usable HTTP base —
+ * legacy callers that only need the URL string can keep calling
+ * `resolveDaemonUrl` — but `ambiguous` is the load-bearing field for any
+ * caller that is about to PERSIST something derived from fetching that URL
+ * (see `resolveMcpLaunchSpec` in cli.ts).
+ *
+ * `url` being `DEFAULT_DAEMON_URL` does NOT by itself mean "no daemon was
+ * found and this is inert": it's also what's returned when discovery was
+ * ambiguous, and *something* could coincidentally be listening on that
+ * hardcoded legacy port during the exact window a caller queries it (a
+ * leftover process, an unrelated local service, even one of the very
+ * packaged channels this call refused to choose between). The #6425 review
+ * reproduced exactly this: two live channel sockets plus a plain HTTP
+ * server on 127.0.0.1:7456 caused `resolveMcpLaunchSpec` to fetch and
+ * persist that server's response despite the ambiguity guard. A caller
+ * that skips its own fetch/persist step whenever `ambiguous` is true does
+ * not have this problem, regardless of what `url` happens to be.
+ */
+export interface ResolveDaemonUrlResult {
+  url: string;
+  ambiguous: boolean;
+}
+
+/**
  * Resolve the daemon HTTP base URL for `od` client commands.
  *
  * Spawn order: explicit `--daemon-url` flag, `OD_DAEMON_URL` env, then
@@ -90,32 +114,50 @@ type IpcDiscoveryResult =
  * the default `tools-dev status --json` runtime. Falls back to the legacy
  * default for direct `od` launches that do not run as a sidecar.
  *
- * An ambiguous IPC result (more than one packaged channel answered, see
- * `IpcDiscoveryResult`) skips tools-dev discovery entirely and returns the
- * legacy default directly — refusing to guess extends to every later
- * discovery mechanism, not just the conventional channel sweep, since a
- * live tools-dev daemon answering in that window is just as much an
- * unrelated runtime as a wrongly-picked packaged channel would have been.
+ * A thin wrapper over `resolveDaemonUrlDetailed` for callers that only need
+ * the URL string and never persist anything derived from fetching it. Any
+ * caller that DOES persist something (currently just `resolveMcpLaunchSpec`
+ * in cli.ts) must call `resolveDaemonUrlDetailed` directly instead and
+ * check its `ambiguous` field — see that function's doc comment for why a
+ * bare URL string cannot safely carry this distinction on its own.
  */
 export async function resolveDaemonUrl(
   options: ResolveDaemonUrlOptions = {},
 ): Promise<string> {
+  return (await resolveDaemonUrlDetailed(options)).url;
+}
+
+/**
+ * Like `resolveDaemonUrl`, but also reports whether the result came from an
+ * ambiguous multi-channel discovery (see `ResolveDaemonUrlResult`).
+ *
+ * An ambiguous IPC result (more than one packaged channel answered, see
+ * `IpcDiscoveryResult`) skips tools-dev discovery entirely and returns the
+ * legacy default directly with `ambiguous: true` — refusing to guess
+ * extends to every later discovery mechanism, not just the conventional
+ * channel sweep, since a live tools-dev daemon answering in that window is
+ * just as much an unrelated runtime as a wrongly-picked packaged channel
+ * would have been.
+ */
+export async function resolveDaemonUrlDetailed(
+  options: ResolveDaemonUrlOptions = {},
+): Promise<ResolveDaemonUrlResult> {
   const env = options.env ?? process.env;
   const flagUrl = options.flagUrl ?? null;
-  if (flagUrl != null && flagUrl.length > 0) return flagUrl;
+  if (flagUrl != null && flagUrl.length > 0) return { url: flagUrl, ambiguous: false };
   const envUrl = env.OD_DAEMON_URL;
-  if (envUrl != null && envUrl.length > 0) return envUrl;
+  if (envUrl != null && envUrl.length > 0) return { url: envUrl, ambiguous: false };
   const discovered = await discoverDaemonUrlFromIpc(
     env,
     options.timeoutMs ?? 800,
     options.allowConventionalIpcDiscovery ?? false,
     options.platform,
   );
-  if (discovered.kind === "found") return discovered.url;
-  if (discovered.kind === "ambiguous") return DEFAULT_DAEMON_URL;
+  if (discovered.kind === "found") return { url: discovered.url, ambiguous: false };
+  if (discovered.kind === "ambiguous") return { url: DEFAULT_DAEMON_URL, ambiguous: true };
   const toolsDevUrl = await discoverDaemonUrlFromToolsDev(env, options.timeoutMs ?? 800);
-  if (toolsDevUrl != null) return toolsDevUrl;
-  return DEFAULT_DAEMON_URL;
+  if (toolsDevUrl != null) return { url: toolsDevUrl, ambiguous: false };
+  return { url: DEFAULT_DAEMON_URL, ambiguous: false };
 }
 
 async function discoverDaemonUrlFromIpc(

--- a/apps/daemon/src/daemon-url.ts
+++ b/apps/daemon/src/daemon-url.ts
@@ -254,6 +254,19 @@ function conventionalIpcSocketPaths(env: NodeJS.ProcessEnv): string[] {
   ] as const;
   const orderedNamespaces: string[] = [
     ...orderedChannels.map((channel) => releaseNamespace(channel, platform)),
+    // Known CI naming inconsistency (see #6425 review): every other
+    // channel's Intel-mac build follows the standard `-intel` suffix
+    // (release-prerelease-intel, release-preview-intel, matching
+    // `releaseNamespace(channel, "macIntel")`), but
+    // `.github/workflows/release-beta.yml`'s mac_x64 job instead bakes
+    // "release-beta-x64" via `tools-pack mac build --namespace
+    // release-beta-x64`. That literal is what a live beta Intel install's
+    // daemon actually listens under, so it has to be probed even though it
+    // doesn't fit the derivable pattern. Renaming the shipping workflow's
+    // namespace to match the pattern is a separate, higher-risk change
+    // (would orphan already-installed beta Intel users' existing IPC path)
+    // outside the scope of this fix — see PR #6425 review discussion.
+    ...(platform === "macIntel" ? ["release-beta-x64"] : []),
     SIDECAR_DEFAULTS.namespace,
   ];
   return orderedNamespaces.map((namespace) =>

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -13940,7 +13940,15 @@ export async function startServer({
         // when binding to a specific address (e.g. a Tailscale IP) report that
         // address so remote callers and the sidecar use the correct URL.
         const reportHost = host === '0.0.0.0' || host === '::' ? '127.0.0.1' : host;
-        const url = `http://${reportHost}:${resolvedPort}`;
+        // An IPv6 literal (e.g. a supported `OD_BIND_HOST=::1`) must be
+        // bracketed in a URL string -- `new URL('http://::1:7456')` throws
+        // (the bare colons are ambiguous with the port separator), which
+        // would make every consumer of this status URL (the sidecar,
+        // daemon-url.ts's conventional discovery, any client fetching
+        // /api/mcp/install-info) fail before it could even try to reach a
+        // real IPv6-bound daemon. `[::1]:7456` parses correctly.
+        const reportUrlHost = net.isIP(reportHost) === 6 ? `[${reportHost}]` : reportHost;
+        const url = `http://${reportUrlHost}:${resolvedPort}`;
         if (!returnServer) {
           console.log(`[od] daemon listening on ${url}`);
         }

--- a/apps/daemon/tests/daemon-url.test.ts
+++ b/apps/daemon/tests/daemon-url.test.ts
@@ -2,9 +2,20 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { createJsonIpcServer, type JsonIpcServerHandle } from "@open-design/sidecar";
-import { SIDECAR_ENV, SIDECAR_MESSAGES } from "@open-design/sidecar-proto";
+import { createJsonIpcServer, resolveAppIpcPath, type JsonIpcServerHandle } from "@open-design/sidecar";
+import { releaseNamespace, type ReleasePlatform } from "@open-design/release";
+import {
+  APP_KEYS,
+  OPEN_DESIGN_SIDECAR_CONTRACT,
+  SIDECAR_ENV,
+  SIDECAR_MESSAGES,
+} from "@open-design/sidecar-proto";
 import { resolveDaemonUrl, DEFAULT_DAEMON_URL } from "../src/daemon-url.js";
+
+const CURRENT_RELEASE_PLATFORM: ReleasePlatform =
+  process.platform === "darwin"
+    ? process.arch === "arm64" ? "mac" : "macIntel"
+    : process.platform === "win32" ? "win" : "linux";
 
 // Verifies the resolution chain: --daemon-url > OD_DAEMON_URL > sidecar
 // IPC status discovery > legacy default. Each layer must short-circuit the next
@@ -119,5 +130,202 @@ describe("resolveDaemonUrl", () => {
     } finally {
       await ipc?.close();
     }
+  });
+
+  // Regression coverage for #6424: a plain terminal invocation of `od mcp
+  // install <agent>` never has OD_SIDECAR_IPC_PATH set (only the packaged
+  // app's own spawned children get it), so it previously had no way to find
+  // a packaged install's daemon and always degraded to a broken bare-`od`
+  // launch spec. `allowConventionalIpcDiscovery` is opt-in specifically so
+  // this new discovery path cannot change behavior for every OTHER `od`
+  // subcommand that already worked correctly without it.
+  describe("conventional per-channel IPC discovery (#6424)", () => {
+    let conventionalIpcBaseDir: string;
+
+    beforeAll(() => {
+      conventionalIpcBaseDir = fs.mkdtempSync(path.join(os.tmpdir(), "od-conventional-ipc-"));
+    });
+
+    afterAll(() => {
+      fs.rmSync(conventionalIpcBaseDir, { recursive: true, force: true });
+    });
+
+    it("ignores a live conventional-path socket by default (allowConventionalIpcDiscovery unset)", async () => {
+      const socketPath = resolveAppIpcPath({
+        app: APP_KEYS.DAEMON,
+        contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+        env: { [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir },
+        namespace: releaseNamespace("stable", CURRENT_RELEASE_PLATFORM),
+      });
+      fs.mkdirSync(path.dirname(socketPath), { recursive: true });
+      let ipc: JsonIpcServerHandle | null = null;
+      try {
+        ipc = await createJsonIpcServer({
+          socketPath,
+          handler: () => ({ pid: 1, state: "running", updatedAt: new Date().toISOString(), url: "http://127.0.0.1:59999" }),
+        });
+
+        const url = await resolveDaemonUrl({
+          env: {
+            PATH: emptyBinDir,
+            [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir,
+          },
+          timeoutMs: 300,
+        });
+        expect(url).toBe(DEFAULT_DAEMON_URL);
+      } finally {
+        await ipc?.close();
+      }
+    });
+
+    it("discovers the live daemon via a conventional per-channel socket when allowConventionalIpcDiscovery is true", async () => {
+      const socketPath = resolveAppIpcPath({
+        app: APP_KEYS.DAEMON,
+        contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+        env: { [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir },
+        namespace: releaseNamespace("stable", CURRENT_RELEASE_PLATFORM),
+      });
+      fs.mkdirSync(path.dirname(socketPath), { recursive: true });
+      let ipc: JsonIpcServerHandle | null = null;
+      try {
+        ipc = await createJsonIpcServer({
+          socketPath,
+          handler: () => ({ pid: 1, state: "running", updatedAt: new Date().toISOString(), url: "http://127.0.0.1:59999" }),
+        });
+
+        const url = await resolveDaemonUrl({
+          env: {
+            [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir,
+          },
+          timeoutMs: 1000,
+          allowConventionalIpcDiscovery: true,
+        });
+        expect(url).toBe("http://127.0.0.1:59999");
+      } finally {
+        await ipc?.close();
+      }
+    });
+
+    it("honors an explicit OD_SIDECAR_NAMESPACE over the channel sweep", async () => {
+      const socketPath = resolveAppIpcPath({
+        app: APP_KEYS.DAEMON,
+        contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+        env: { [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir },
+        namespace: "custom-namespace",
+      });
+      fs.mkdirSync(path.dirname(socketPath), { recursive: true });
+      let ipc: JsonIpcServerHandle | null = null;
+      try {
+        ipc = await createJsonIpcServer({
+          socketPath,
+          handler: () => ({ pid: 1, state: "running", updatedAt: new Date().toISOString(), url: "http://127.0.0.1:58888" }),
+        });
+
+        const url = await resolveDaemonUrl({
+          env: {
+            [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir,
+            [SIDECAR_ENV.NAMESPACE]: "custom-namespace",
+          },
+          timeoutMs: 1000,
+          allowConventionalIpcDiscovery: true,
+        });
+        expect(url).toBe("http://127.0.0.1:58888");
+      } finally {
+        await ipc?.close();
+      }
+    });
+
+    // The JSON-IPC protocol has no responder-identity check (no
+    // peer-credential/uid verification, no shared secret): a STATUS
+    // response is not proof the daemon is who it claims to be. Probing a
+    // predictable, well-known socket path is a wider trust surface than the
+    // pre-existing explicit-OD_SIDECAR_IPC_PATH case, since another local
+    // process could in principle occupy that path first. This is not fixed
+    // here (that needs protocol-level authentication, which is out of scope
+    // for this fix) — but discovery must at least refuse to redirect
+    // off-host, since the caller persists whatever `command`/`args` come
+    // back from `/api/mcp/install-info` at the returned URL into a coding
+    // agent's config.
+    it("rejects a conventional-path response whose url is not loopback", async () => {
+      const socketPath = resolveAppIpcPath({
+        app: APP_KEYS.DAEMON,
+        contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+        env: { [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir },
+        namespace: releaseNamespace("stable", CURRENT_RELEASE_PLATFORM),
+      });
+      fs.mkdirSync(path.dirname(socketPath), { recursive: true });
+      let ipc: JsonIpcServerHandle | null = null;
+      try {
+        ipc = await createJsonIpcServer({
+          socketPath,
+          handler: () => ({ pid: 1, state: "running", updatedAt: new Date().toISOString(), url: "http://evil.example:1234" }),
+        });
+
+        const url = await resolveDaemonUrl({
+          env: {
+            PATH: emptyBinDir,
+            [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir,
+          },
+          timeoutMs: 300,
+          allowConventionalIpcDiscovery: true,
+        });
+        expect(url).toBe(DEFAULT_DAEMON_URL);
+      } finally {
+        await ipc?.close();
+      }
+    });
+
+    // Locks in the channel-precedence contract: when more than one release
+    // channel's daemon happens to be live at once, the stable channel's
+    // response wins deterministically, never whichever socket happens to
+    // answer first. `Promise.allSettled` + ordered result scan (not
+    // `Promise.any`/a bare race) is load-bearing for this — a naive race
+    // would make the outcome depend on scheduling.
+    it("prefers the stable channel when multiple channel sockets are simultaneously live", async () => {
+      const stableSocketPath = resolveAppIpcPath({
+        app: APP_KEYS.DAEMON,
+        contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+        env: { [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir },
+        namespace: releaseNamespace("stable", CURRENT_RELEASE_PLATFORM),
+      });
+      const betaSocketPath = resolveAppIpcPath({
+        app: APP_KEYS.DAEMON,
+        contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+        env: { [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir },
+        namespace: releaseNamespace("beta", CURRENT_RELEASE_PLATFORM),
+      });
+      fs.mkdirSync(path.dirname(stableSocketPath), { recursive: true });
+      fs.mkdirSync(path.dirname(betaSocketPath), { recursive: true });
+      let stableIpc: JsonIpcServerHandle | null = null;
+      let betaIpc: JsonIpcServerHandle | null = null;
+      try {
+        // Beta answers immediately; stable answers slightly slower — if the
+        // implementation ever regresses to a bare race, this ordering would
+        // flip the result to beta and fail the assertion below.
+        betaIpc = await createJsonIpcServer({
+          socketPath: betaSocketPath,
+          handler: () => ({ pid: 2, state: "running", updatedAt: new Date().toISOString(), url: "http://127.0.0.1:57777" }),
+        });
+        stableIpc = await createJsonIpcServer({
+          socketPath: stableSocketPath,
+          handler: async () => {
+            await new Promise((resolve) => setTimeout(resolve, 50));
+            return { pid: 1, state: "running", updatedAt: new Date().toISOString(), url: "http://127.0.0.1:56666" };
+          },
+        });
+
+        const url = await resolveDaemonUrl({
+          env: {
+            [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir,
+          },
+          timeoutMs: 1000,
+          allowConventionalIpcDiscovery: true,
+        });
+        expect(url).toBe("http://127.0.0.1:56666");
+      } finally {
+        await stableIpc?.close();
+        await betaIpc?.close();
+      }
+    });
   });
 });

--- a/apps/daemon/tests/daemon-url.test.ts
+++ b/apps/daemon/tests/daemon-url.test.ts
@@ -472,6 +472,58 @@ describe("resolveDaemonUrl", () => {
       }
     });
 
+    // Regression coverage for the #6425 review: every OTHER channel's
+    // Intel-mac build follows the standard `-intel` suffix that
+    // `releaseNamespace(channel, "macIntel")` derives (release-prerelease-
+    // intel, release-preview-intel, …), but `.github/workflows/
+    // release-beta.yml`'s mac_x64 job instead bakes the literal
+    // "release-beta-x64" via `tools-pack mac build --namespace
+    // release-beta-x64`. Deliberately does NOT derive the expected socket's
+    // namespace from `releaseNamespace()` (that would just re-encode the
+    // same wrong assumption the implementation had) — hardcodes the exact
+    // literal the live workflow produces instead. Forces `process.platform`/
+    // `process.arch` to darwin/x64 (this suite normally runs on whatever
+    // architecture the CI/dev machine actually has, which cannot otherwise
+    // exercise the macIntel branch on an arm64 host) using the same
+    // `Object.defineProperty` + restore pattern already used elsewhere in
+    // this package (see `host-tools-launch-shell.test.ts`).
+    it("discovers the live daemon via the release-beta-x64 literal namespace on Intel mac (CI naming inconsistency)", async () => {
+      const origPlatform = process.platform;
+      const origArch = process.arch;
+      Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+      Object.defineProperty(process, "arch", { value: "x64", configurable: true });
+      try {
+        const socketPath = resolveAppIpcPath({
+          app: APP_KEYS.DAEMON,
+          contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+          env: { [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir },
+          namespace: "release-beta-x64",
+        });
+        fs.mkdirSync(path.dirname(socketPath), { recursive: true });
+        let ipc: JsonIpcServerHandle | null = null;
+        try {
+          ipc = await createJsonIpcServer({
+            socketPath,
+            handler: () => ({ pid: 1, state: "running", updatedAt: new Date().toISOString(), url: "http://127.0.0.1:39999" }),
+          });
+
+          const url = await resolveDaemonUrl({
+            env: {
+              [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir,
+            },
+            timeoutMs: 1000,
+            allowConventionalIpcDiscovery: true,
+          });
+          expect(url).toBe("http://127.0.0.1:39999");
+        } finally {
+          await ipc?.close();
+        }
+      } finally {
+        Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
+        Object.defineProperty(process, "arch", { value: origArch, configurable: true });
+      }
+    });
+
     // Regression coverage for the #6425 review: loopback alone only rules
     // out off-host redirection, not a different local user squatting the
     // predictable socket path and answering with a loopback URL of its own

--- a/apps/daemon/tests/daemon-url.test.ts
+++ b/apps/daemon/tests/daemon-url.test.ts
@@ -401,6 +401,43 @@ describe("resolveDaemonUrl", () => {
       }
     });
 
+    // Regression coverage for the #6425 review: `isLoopbackHttpUrl` used to
+    // accept only the exact strings "127.0.0.1" / "[::1]" / "localhost", but
+    // the daemon's own inbound bind validation (`isLoopbackHostname` in
+    // `http/local-daemon-request.ts`) already treats the entire 127.0.0.0/8
+    // range as loopback. A packaged daemon started with e.g.
+    // `OD_BIND_HOST=127.0.0.2` is a pre-existing, already-supported local
+    // configuration — conventional discovery rejecting it (and silently
+    // falling back to 7456, where nothing is listening) would be a
+    // regression for that case, not a security improvement.
+    it("accepts a conventional-path response whose url is another 127.0.0.0/8 loopback address", async () => {
+      const socketPath = resolveAppIpcPath({
+        app: APP_KEYS.DAEMON,
+        contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+        env: { [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir },
+        namespace: releaseNamespace("stable", CURRENT_RELEASE_PLATFORM),
+      });
+      fs.mkdirSync(path.dirname(socketPath), { recursive: true });
+      let ipc: JsonIpcServerHandle | null = null;
+      try {
+        ipc = await createJsonIpcServer({
+          socketPath,
+          handler: () => ({ pid: 1, state: "running", updatedAt: new Date().toISOString(), url: "http://127.0.0.2:23456" }),
+        });
+
+        const url = await resolveDaemonUrl({
+          env: {
+            [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir,
+          },
+          timeoutMs: 1000,
+          allowConventionalIpcDiscovery: true,
+        });
+        expect(url).toBe("http://127.0.0.2:23456");
+      } finally {
+        await ipc?.close();
+      }
+    });
+
     // Regression coverage for the #6425 review: the packaged desktop app
     // always stamps an explicit `release-<channel>` namespace, but a
     // `tools-pack` install whose version string doesn't resolve to a known
@@ -480,13 +517,19 @@ describe("resolveDaemonUrl", () => {
   // Companion to the POSIX-only describe block above: conventional discovery
   // must be a no-op on win32 (no candidates, no probing, no crash) rather
   // than attempting to guess a named-pipe path with no ownership check.
+  //
+  // Regression note (#6425 review): this test must NOT set
+  // SIDECAR_ENV.IPC_PATH — doing so takes the explicit-socket branch in
+  // `discoverDaemonUrlFromIpc` before `conventionalIpcSocketPaths()` ever
+  // runs, so the assertion would pass for the wrong reason (explicit-path
+  // probe failing against a missing socket) without ever exercising the
+  // win32 no-candidate behavior it claims to cover.
   it.skipIf(process.platform !== "win32")(
     "does not attempt conventional discovery on win32 even when allowConventionalIpcDiscovery is true",
     async () => {
       const url = await resolveDaemonUrl({
         env: {
           PATH: emptyBinDir,
-          [SIDECAR_ENV.IPC_PATH]: path.join(ipcBaseDir, "missing.sock"),
         },
         timeoutMs: 300,
         allowConventionalIpcDiscovery: true,

--- a/apps/daemon/tests/daemon-url.test.ts
+++ b/apps/daemon/tests/daemon-url.test.ts
@@ -468,6 +468,76 @@ describe("resolveDaemonUrl", () => {
       }
     });
 
+    // Regression coverage for the #6425 review (round 7): ambiguity must stop
+    // discovery outright, not just the conventional channel sweep. A prior
+    // version of this fix had discoverDaemonUrlFromIpc return a bare `null`
+    // for "ambiguous" and "not-found" alike, so resolveDaemonUrl treated them
+    // identically and fell through to discoverDaemonUrlFromToolsDev — if a
+    // live tools-dev daemon ALSO happened to answer in that window, it would
+    // win and get persisted as the launch spec despite the stated goal of
+    // refusing to guess between packaged channels. Sets up the same two live
+    // channel sockets as the test above, but this time leaves a live
+    // tools-dev responder reachable on PATH too (the fixture used by
+    // "discovers the default tools-dev daemon URL" above) — the assertion
+    // only holds if resolveDaemonUrl recognizes the ambiguous IPC result and
+    // stops before ever calling discoverDaemonUrlFromToolsDev.
+    it("does not fall through to tools-dev discovery when channels are ambiguous", async () => {
+      const stableSocketPath = resolveAppIpcPath({
+        app: APP_KEYS.DAEMON,
+        contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+        env: { [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir },
+        namespace: releaseNamespace("stable", CURRENT_RELEASE_PLATFORM),
+      });
+      const betaSocketPath = resolveAppIpcPath({
+        app: APP_KEYS.DAEMON,
+        contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+        env: { [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir },
+        namespace: releaseNamespace("beta", CURRENT_RELEASE_PLATFORM),
+      });
+      fs.mkdirSync(path.dirname(stableSocketPath), { recursive: true });
+      fs.mkdirSync(path.dirname(betaSocketPath), { recursive: true });
+
+      const toolsDevBinDir = fs.mkdtempSync(path.join(os.tmpdir(), "od-conventional-ipc-toolsdev-"));
+      const pnpmBin = path.join(toolsDevBinDir, process.platform === "win32" ? "pnpm.cmd" : "pnpm");
+      const toolsDevStatusJson = JSON.stringify({ apps: { daemon: { url: "http://127.0.0.1:60999" } } });
+      if (process.platform === "win32") {
+        fs.writeFileSync(pnpmBin, `@echo off\r\necho ${toolsDevStatusJson.replace(/"/g, '\\"')}\r\n`);
+      } else {
+        fs.writeFileSync(pnpmBin, `#!/bin/sh\nprintf '%s\\n' '${toolsDevStatusJson}'\n`);
+        fs.chmodSync(pnpmBin, 0o755);
+      }
+
+      let stableIpc: JsonIpcServerHandle | null = null;
+      let betaIpc: JsonIpcServerHandle | null = null;
+      try {
+        betaIpc = await createJsonIpcServer({
+          socketPath: betaSocketPath,
+          handler: () => ({ pid: 2, state: "running", updatedAt: new Date().toISOString(), url: "http://127.0.0.1:57777" }),
+        });
+        stableIpc = await createJsonIpcServer({
+          socketPath: stableSocketPath,
+          handler: () => ({ pid: 1, state: "running", updatedAt: new Date().toISOString(), url: "http://127.0.0.1:56666" }),
+        });
+
+        const url = await resolveDaemonUrl({
+          env: {
+            // A live, reachable tools-dev responder -- if the ambiguity
+            // short-circuit ever regresses to a bare `null`, this is what
+            // would win instead of the expected DEFAULT_DAEMON_URL.
+            PATH: `${toolsDevBinDir}${path.delimiter}${process.env.PATH ?? ""}`,
+            [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir,
+          },
+          timeoutMs: 1000,
+          allowConventionalIpcDiscovery: true,
+        });
+        expect(url).toBe(DEFAULT_DAEMON_URL);
+      } finally {
+        await stableIpc?.close();
+        await betaIpc?.close();
+        fs.rmSync(toolsDevBinDir, { recursive: true, force: true });
+      }
+    });
+
     // Regression coverage for the #6425 review: WHATWG's URL always brackets
     // an IPv6 literal in `.hostname` (`new URL("http://[::1]:1234").hostname
     // === "[::1]"`, never the bare "::1"), so a bare-string comparison here

--- a/apps/daemon/tests/daemon-url.test.ts
+++ b/apps/daemon/tests/daemon-url.test.ts
@@ -11,12 +11,108 @@ import {
   SIDECAR_ENV,
   SIDECAR_MESSAGES,
 } from "@open-design/sidecar-proto";
-import { resolveDaemonUrl, DEFAULT_DAEMON_URL } from "../src/daemon-url.js";
+import {
+  resolveDaemonUrl,
+  DEFAULT_DAEMON_URL,
+  currentReleasePlatform,
+  conventionalIpcSocketPaths,
+  isLoopbackHttpUrl,
+} from "../src/daemon-url.js";
 
-const CURRENT_RELEASE_PLATFORM: ReleasePlatform =
-  process.platform === "darwin"
-    ? process.arch === "arm64" ? "mac" : "macIntel"
-    : process.platform === "win32" ? "win" : "linux";
+const CURRENT_RELEASE_PLATFORM: ReleasePlatform = currentReleasePlatform();
+
+function expectedConventionalPaths(env: NodeJS.ProcessEnv, namespaces: readonly string[]): string[] {
+  return namespaces.map((namespace) =>
+    resolveAppIpcPath({ app: APP_KEYS.DAEMON, contract: OPEN_DESIGN_SIDECAR_CONTRACT, env, namespace }),
+  );
+}
+
+// Pure, host-OS-independent coverage of the candidate-namespace list itself.
+// Split out from the IPC-integration suite below per the #6425 architecture
+// review: shape/precedence of the candidate list doesn't need a live socket
+// to verify, and testing it directly (with an explicit `platform` argument)
+// means this suite can exercise the macIntel/win branches on ANY host
+// without mutating `process.platform`/`process.arch` globals.
+describe("conventionalIpcSocketPaths (pure)", () => {
+  it("returns no candidates when platform is win, regardless of env", () => {
+    expect(conventionalIpcSocketPaths({}, "win")).toEqual([]);
+    expect(conventionalIpcSocketPaths({ [SIDECAR_ENV.NAMESPACE]: "custom-namespace" }, "win")).toEqual([]);
+  });
+
+  it("an explicit OD_SIDECAR_NAMESPACE bypasses the channel sweep on every non-win platform", () => {
+    for (const platform of ["mac", "macIntel", "linux"] as const) {
+      const env = { [SIDECAR_ENV.NAMESPACE]: "custom-namespace" };
+      expect(conventionalIpcSocketPaths(env, platform)).toEqual(expectedConventionalPaths(env, ["custom-namespace"]));
+    }
+  });
+
+  // Locks in the full stable-first channel sweep, including the one known
+  // legacy-namespace outlier: beta on Intel mac lists TWO candidates
+  // (canonical "-intel" suffix first, then the "release-beta-x64" alias
+  // release-beta.yml's mac_x64 job actually ships under) because
+  // `@open-design/release`'s `releaseNamespaceCandidates` owns that mapping
+  // now — see its own doc comment for why the alias exists. Every other
+  // channel/platform pair here has exactly one candidate.
+  it("sweeps every known release channel plus the generic default, stable first", () => {
+    const cases: Array<[ReleasePlatform, string[]]> = [
+      ["mac", ["release-stable", "release-beta", "release-betas", "release-prerelease", "release-preview", SIDECAR_DEFAULTS.namespace]],
+      [
+        "macIntel",
+        [
+          "release-stable-intel",
+          "release-beta-intel",
+          "release-beta-x64",
+          "release-betas-intel",
+          "release-prerelease-intel",
+          "release-preview-intel",
+          SIDECAR_DEFAULTS.namespace,
+        ],
+      ],
+      [
+        "linux",
+        [
+          "release-stable-linux",
+          "release-beta-linux",
+          "release-betas-linux",
+          "release-prerelease-linux",
+          "release-preview-linux",
+          SIDECAR_DEFAULTS.namespace,
+        ],
+      ],
+    ];
+    for (const [platform, namespaces] of cases) {
+      const env = {};
+      expect(conventionalIpcSocketPaths(env, platform)).toEqual(expectedConventionalPaths(env, namespaces));
+    }
+  });
+});
+
+// Pure coverage of the loopback/bare-origin URL policy applied to
+// conventional-path candidates. Split out for the same reason as the
+// candidate-list suite above: no live socket needed to verify this.
+describe("isLoopbackHttpUrl (pure)", () => {
+  it.each([
+    "http://127.0.0.1:59999",
+    "http://127.0.0.2:23456",
+    "http://[::1]:34567",
+    "https://localhost:41111",
+  ])("accepts a bare loopback origin: %s", (url) => {
+    expect(isLoopbackHttpUrl(url)).toBe(true);
+  });
+
+  it.each([
+    ["http://user:pass@127.0.0.1:22222", "embedded credentials"],
+    ["http://127.0.0.1:22222/some/path", "non-root path"],
+    ["http://127.0.0.1:22222/?x=1", "query string"],
+    ["http://127.0.0.1:22222/#fragment", "fragment"],
+    ["http://127.0.0.1", "missing explicit port"],
+    ["http://evil.example:1234", "non-loopback host"],
+    ["not a url", "unparseable"],
+    ["ftp://127.0.0.1:1234", "non-http(s) scheme"],
+  ])("rejects %s (%s)", (url) => {
+    expect(isLoopbackHttpUrl(url)).toBe(false);
+  });
+});
 
 // Verifies the resolution chain: --daemon-url > OD_DAEMON_URL > sidecar
 // IPC status discovery > legacy default. Each layer must short-circuit the next
@@ -179,7 +275,8 @@ describe("resolveDaemonUrl", () => {
   // in daemon-url.ts): the ownership check this discovery mode requires has
   // no Windows implementation yet, so `conventionalIpcSocketPaths` yields no
   // candidates on win32 and this whole describe block does not apply there —
-  // see the dedicated win32 test below instead.
+  // the pure `conventionalIpcSocketPaths (pure)` suite above covers the win
+  // no-candidate behavior unconditionally instead.
   describe.skipIf(process.platform === "win32")("conventional per-channel IPC discovery (#6424)", () => {
     let conventionalIpcBaseDir: string;
 
@@ -316,13 +413,20 @@ describe("resolveDaemonUrl", () => {
       }
     });
 
-    // Locks in the channel-precedence contract: when more than one release
-    // channel's daemon happens to be live at once, the stable channel's
-    // response wins deterministically, never whichever socket happens to
-    // answer first. `Promise.allSettled` + ordered result scan (not
-    // `Promise.any`/a bare race) is load-bearing for this — a naive race
-    // would make the outcome depend on scheduling.
-    it("prefers the stable channel when multiple channel sockets are simultaneously live", async () => {
+    // Regression coverage for the Codex architecture review on #6425: this
+    // test previously asserted that stable's response deterministically
+    // "won" a race against beta (with a real 50ms delay to lock in the
+    // ordering). Determinism is not correctness — if two packaged channels
+    // are simultaneously live, discovery has no way to know which one the
+    // invoking `od mcp install` actually meant, and silently preferring
+    // stable would let resolveMcpLaunchSpec (cli.ts) persist the WRONG
+    // channel's absolute paths into the agent's config. discoverDaemonUrlFromIpc
+    // now refuses to guess: more than one DISTINCT successful response means
+    // ambiguous, and it returns null so the caller falls through to the
+    // legacy default — a safe, inert result instead of a confidently wrong
+    // one. No artificial delay needed to prove this, which also removes the
+    // suite's only real-timer nondeterminism.
+    it("does not guess between channels when more than one is simultaneously live (ambiguous)", async () => {
       const stableSocketPath = resolveAppIpcPath({
         app: APP_KEYS.DAEMON,
         contract: OPEN_DESIGN_SIDECAR_CONTRACT,
@@ -340,29 +444,24 @@ describe("resolveDaemonUrl", () => {
       let stableIpc: JsonIpcServerHandle | null = null;
       let betaIpc: JsonIpcServerHandle | null = null;
       try {
-        // Beta answers immediately; stable answers slightly slower — if the
-        // implementation ever regresses to a bare race, this ordering would
-        // flip the result to beta and fail the assertion below.
         betaIpc = await createJsonIpcServer({
           socketPath: betaSocketPath,
           handler: () => ({ pid: 2, state: "running", updatedAt: new Date().toISOString(), url: "http://127.0.0.1:57777" }),
         });
         stableIpc = await createJsonIpcServer({
           socketPath: stableSocketPath,
-          handler: async () => {
-            await new Promise((resolve) => setTimeout(resolve, 50));
-            return { pid: 1, state: "running", updatedAt: new Date().toISOString(), url: "http://127.0.0.1:56666" };
-          },
+          handler: () => ({ pid: 1, state: "running", updatedAt: new Date().toISOString(), url: "http://127.0.0.1:56666" }),
         });
 
         const url = await resolveDaemonUrl({
           env: {
+            PATH: emptyBinDir,
             [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir,
           },
           timeoutMs: 1000,
           allowConventionalIpcDiscovery: true,
         });
-        expect(url).toBe("http://127.0.0.1:56666");
+        expect(url).toBe(DEFAULT_DAEMON_URL);
       } finally {
         await stableIpc?.close();
         await betaIpc?.close();
@@ -472,55 +571,40 @@ describe("resolveDaemonUrl", () => {
       }
     });
 
-    // Regression coverage for the #6425 review: every OTHER channel's
-    // Intel-mac build follows the standard `-intel` suffix that
-    // `releaseNamespace(channel, "macIntel")` derives (release-prerelease-
-    // intel, release-preview-intel, …), but `.github/workflows/
-    // release-beta.yml`'s mac_x64 job instead bakes the literal
-    // "release-beta-x64" via `tools-pack mac build --namespace
-    // release-beta-x64`. Deliberately does NOT derive the expected socket's
-    // namespace from `releaseNamespace()` (that would just re-encode the
-    // same wrong assumption the implementation had) — hardcodes the exact
-    // literal the live workflow produces instead. Forces `process.platform`/
-    // `process.arch` to darwin/x64 (this suite normally runs on whatever
-    // architecture the CI/dev machine actually has, which cannot otherwise
-    // exercise the macIntel branch on an arm64 host) using the same
-    // `Object.defineProperty` + restore pattern already used elsewhere in
-    // this package (see `host-tools-launch-shell.test.ts`).
+    // Regression coverage for the #6425 review: `conventionalIpcSocketPaths`
+    // now surfaces "release-beta-x64" for beta on Intel mac via
+    // `@open-design/release`'s `releaseNamespaceCandidates` (see the pure
+    // suite above for the candidate-list-shape assertion). This proves the
+    // IPC round trip actually resolves through that alias end-to-end. Uses
+    // `resolveDaemonUrl`'s injectable `platform` option instead of mutating
+    // `process.platform`/`process.arch` — this test now runs identically
+    // regardless of the host machine's real architecture.
     it("discovers the live daemon via the release-beta-x64 literal namespace on Intel mac (CI naming inconsistency)", async () => {
-      const origPlatform = process.platform;
-      const origArch = process.arch;
-      Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
-      Object.defineProperty(process, "arch", { value: "x64", configurable: true });
+      const socketPath = resolveAppIpcPath({
+        app: APP_KEYS.DAEMON,
+        contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+        env: { [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir },
+        namespace: "release-beta-x64",
+      });
+      fs.mkdirSync(path.dirname(socketPath), { recursive: true });
+      let ipc: JsonIpcServerHandle | null = null;
       try {
-        const socketPath = resolveAppIpcPath({
-          app: APP_KEYS.DAEMON,
-          contract: OPEN_DESIGN_SIDECAR_CONTRACT,
-          env: { [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir },
-          namespace: "release-beta-x64",
+        ipc = await createJsonIpcServer({
+          socketPath,
+          handler: () => ({ pid: 1, state: "running", updatedAt: new Date().toISOString(), url: "http://127.0.0.1:39999" }),
         });
-        fs.mkdirSync(path.dirname(socketPath), { recursive: true });
-        let ipc: JsonIpcServerHandle | null = null;
-        try {
-          ipc = await createJsonIpcServer({
-            socketPath,
-            handler: () => ({ pid: 1, state: "running", updatedAt: new Date().toISOString(), url: "http://127.0.0.1:39999" }),
-          });
 
-          const url = await resolveDaemonUrl({
-            env: {
-              [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir,
-            },
-            timeoutMs: 1000,
-            allowConventionalIpcDiscovery: true,
-          });
-          expect(url).toBe("http://127.0.0.1:39999");
-        } finally {
-          await ipc?.close();
-        }
+        const url = await resolveDaemonUrl({
+          env: {
+            [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir,
+          },
+          timeoutMs: 1000,
+          allowConventionalIpcDiscovery: true,
+          platform: "macIntel",
+        });
+        expect(url).toBe("http://127.0.0.1:39999");
       } finally {
-        Object.defineProperty(process, "platform", { value: origPlatform, configurable: true });
-        Object.defineProperty(process, "arch", { value: origArch, configurable: true });
+        await ipc?.close();
       }
     });
 
@@ -566,27 +650,19 @@ describe("resolveDaemonUrl", () => {
     });
   });
 
-  // Companion to the POSIX-only describe block above: conventional discovery
-  // must be a no-op on win32 (no candidates, no probing, no crash) rather
-  // than attempting to guess a named-pipe path with no ownership check.
-  //
-  // Regression note (#6425 review): this test must NOT set
-  // SIDECAR_ENV.IPC_PATH — doing so takes the explicit-socket branch in
-  // `discoverDaemonUrlFromIpc` before `conventionalIpcSocketPaths()` ever
-  // runs, so the assertion would pass for the wrong reason (explicit-path
-  // probe failing against a missing socket) without ever exercising the
-  // win32 no-candidate behavior it claims to cover.
-  it.skipIf(process.platform !== "win32")(
-    "does not attempt conventional discovery on win32 even when allowConventionalIpcDiscovery is true",
-    async () => {
-      const url = await resolveDaemonUrl({
-        env: {
-          PATH: emptyBinDir,
-        },
-        timeoutMs: 300,
-        allowConventionalIpcDiscovery: true,
-      });
-      expect(url).toBe(DEFAULT_DAEMON_URL);
-    },
-  );
+  // Regression coverage for the #6425 review: proves the same win no-op
+  // behavior at the `resolveDaemonUrl` integration level, using the
+  // injectable `platform` option instead of gating on the real host OS —
+  // this runs on every host, not just an actual win32 CI runner.
+  it("does not attempt conventional discovery when platform is win, even with allowConventionalIpcDiscovery true", async () => {
+    const url = await resolveDaemonUrl({
+      env: {
+        PATH: emptyBinDir,
+      },
+      timeoutMs: 300,
+      allowConventionalIpcDiscovery: true,
+      platform: "win",
+    });
+    expect(url).toBe(DEFAULT_DAEMON_URL);
+  });
 });

--- a/apps/daemon/tests/daemon-url.test.ts
+++ b/apps/daemon/tests/daemon-url.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createJsonIpcServer, resolveAppIpcPath, type JsonIpcServerHandle } from "@open-design/sidecar";
 import { releaseNamespace, type ReleasePlatform } from "@open-design/release";
 import {
@@ -132,6 +132,40 @@ describe("resolveDaemonUrl", () => {
     }
   });
 
+  // Regression coverage for the #6425 review: the loopback gate added for
+  // conventional-path discovery must NOT apply to this pre-existing explicit
+  // path. A daemon started with a non-default --host (Tailscale, a specific
+  // interface, …) is a legitimate, already-supported configuration — the
+  // lifecycle owner told the caller exactly which socket to dial, so there is
+  // nothing to authenticate here that the explicit path doesn't already pin.
+  it("honors an explicit sidecar status whose url is not loopback", async () => {
+    const socketPath = process.platform === "win32"
+      ? `\\\\.\\pipe\\open-design-daemon-url-nonloopback-${process.pid}-${Date.now()}`
+      : path.join(ipcBaseDir, "daemon-nonloopback.sock");
+    let ipc: JsonIpcServerHandle | null = null;
+    try {
+      ipc = await createJsonIpcServer({
+        socketPath,
+        handler: () => ({
+          pid: 4243,
+          state: "running",
+          updatedAt: new Date().toISOString(),
+          url: "http://192.168.1.50:7456",
+        }),
+      });
+
+      const url = await resolveDaemonUrl({
+        env: {
+          [SIDECAR_ENV.IPC_PATH]: socketPath,
+        },
+        timeoutMs: 1000,
+      });
+      expect(url).toBe("http://192.168.1.50:7456");
+    } finally {
+      await ipc?.close();
+    }
+  });
+
   // Regression coverage for #6424: a plain terminal invocation of `od mcp
   // install <agent>` never has OD_SIDECAR_IPC_PATH set (only the packaged
   // app's own spawned children get it), so it previously had no way to find
@@ -139,7 +173,13 @@ describe("resolveDaemonUrl", () => {
   // launch spec. `allowConventionalIpcDiscovery` is opt-in specifically so
   // this new discovery path cannot change behavior for every OTHER `od`
   // subcommand that already worked correctly without it.
-  describe("conventional per-channel IPC discovery (#6424)", () => {
+  //
+  // POSIX-only (see `conventionalIpcSocketPaths` / `isOwnedByCurrentProcess`
+  // in daemon-url.ts): the ownership check this discovery mode requires has
+  // no Windows implementation yet, so `conventionalIpcSocketPaths` yields no
+  // candidates on win32 and this whole describe block does not apply there —
+  // see the dedicated win32 test below instead.
+  describe.skipIf(process.platform === "win32")("conventional per-channel IPC discovery (#6424)", () => {
     let conventionalIpcBaseDir: string;
 
     beforeAll(() => {
@@ -327,5 +367,64 @@ describe("resolveDaemonUrl", () => {
         await betaIpc?.close();
       }
     });
+
+    // Regression coverage for the #6425 review: loopback alone only rules
+    // out off-host redirection, not a different local user squatting the
+    // predictable socket path and answering with a loopback URL of its own
+    // (e.g. while the real daemon is stopped/restarting). Simulates that by
+    // making the current process disagree with the socket file's actual
+    // owning uid — the response must be rejected even though it is a
+    // perfectly well-formed, loopback, "successful" STATUS reply.
+    it("rejects a conventional-path response when the socket is not owned by the current process", async () => {
+      const socketPath = resolveAppIpcPath({
+        app: APP_KEYS.DAEMON,
+        contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+        env: { [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir },
+        namespace: releaseNamespace("stable", CURRENT_RELEASE_PLATFORM),
+      });
+      fs.mkdirSync(path.dirname(socketPath), { recursive: true });
+      let ipc: JsonIpcServerHandle | null = null;
+      const realUid = process.getuid?.() ?? 0;
+      const getuidSpy = vi.spyOn(process, "getuid").mockReturnValue(realUid + 1);
+      try {
+        ipc = await createJsonIpcServer({
+          socketPath,
+          // A "malicious" responder: well-formed, loopback, otherwise
+          // indistinguishable from the real daemon's own STATUS reply.
+          handler: () => ({ pid: 666, state: "running", updatedAt: new Date().toISOString(), url: "http://127.0.0.1:45678" }),
+        });
+
+        const url = await resolveDaemonUrl({
+          env: {
+            PATH: emptyBinDir,
+            [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir,
+          },
+          timeoutMs: 300,
+          allowConventionalIpcDiscovery: true,
+        });
+        expect(url).toBe(DEFAULT_DAEMON_URL);
+      } finally {
+        getuidSpy.mockRestore();
+        await ipc?.close();
+      }
+    });
   });
+
+  // Companion to the POSIX-only describe block above: conventional discovery
+  // must be a no-op on win32 (no candidates, no probing, no crash) rather
+  // than attempting to guess a named-pipe path with no ownership check.
+  it.skipIf(process.platform !== "win32")(
+    "does not attempt conventional discovery on win32 even when allowConventionalIpcDiscovery is true",
+    async () => {
+      const url = await resolveDaemonUrl({
+        env: {
+          PATH: emptyBinDir,
+          [SIDECAR_ENV.IPC_PATH]: path.join(ipcBaseDir, "missing.sock"),
+        },
+        timeoutMs: 300,
+        allowConventionalIpcDiscovery: true,
+      });
+      expect(url).toBe(DEFAULT_DAEMON_URL);
+    },
+  );
 });

--- a/apps/daemon/tests/daemon-url.test.ts
+++ b/apps/daemon/tests/daemon-url.test.ts
@@ -7,6 +7,7 @@ import { releaseNamespace, type ReleasePlatform } from "@open-design/release";
 import {
   APP_KEYS,
   OPEN_DESIGN_SIDECAR_CONTRACT,
+  SIDECAR_DEFAULTS,
   SIDECAR_ENV,
   SIDECAR_MESSAGES,
 } from "@open-design/sidecar-proto";
@@ -365,6 +366,72 @@ describe("resolveDaemonUrl", () => {
       } finally {
         await stableIpc?.close();
         await betaIpc?.close();
+      }
+    });
+
+    // Regression coverage for the #6425 review: WHATWG's URL always brackets
+    // an IPv6 literal in `.hostname` (`new URL("http://[::1]:1234").hostname
+    // === "[::1]"`, never the bare "::1"), so a bare-string comparison here
+    // rejects every legitimate IPv6-loopback daemon status.
+    it("accepts a conventional-path response whose url is IPv6 loopback", async () => {
+      const socketPath = resolveAppIpcPath({
+        app: APP_KEYS.DAEMON,
+        contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+        env: { [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir },
+        namespace: releaseNamespace("stable", CURRENT_RELEASE_PLATFORM),
+      });
+      fs.mkdirSync(path.dirname(socketPath), { recursive: true });
+      let ipc: JsonIpcServerHandle | null = null;
+      try {
+        ipc = await createJsonIpcServer({
+          socketPath,
+          handler: () => ({ pid: 1, state: "running", updatedAt: new Date().toISOString(), url: "http://[::1]:34567" }),
+        });
+
+        const url = await resolveDaemonUrl({
+          env: {
+            [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir,
+          },
+          timeoutMs: 1000,
+          allowConventionalIpcDiscovery: true,
+        });
+        expect(url).toBe("http://[::1]:34567");
+      } finally {
+        await ipc?.close();
+      }
+    });
+
+    // Regression coverage for the #6425 review: the packaged desktop app
+    // always stamps an explicit `release-<channel>` namespace, but a
+    // `tools-pack` install whose version string doesn't resolve to a known
+    // channel (`defaultNamespaceForAppVersion` in `tools/pack/src/config.ts`)
+    // falls through to the bare `SIDECAR_DEFAULTS.namespace` ("default")
+    // instead. The channel sweep alone would never find that daemon.
+    it("falls back to the generic default namespace when no release-channel socket is live", async () => {
+      const socketPath = resolveAppIpcPath({
+        app: APP_KEYS.DAEMON,
+        contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+        env: { [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir },
+        namespace: SIDECAR_DEFAULTS.namespace,
+      });
+      fs.mkdirSync(path.dirname(socketPath), { recursive: true });
+      let ipc: JsonIpcServerHandle | null = null;
+      try {
+        ipc = await createJsonIpcServer({
+          socketPath,
+          handler: () => ({ pid: 1, state: "running", updatedAt: new Date().toISOString(), url: "http://127.0.0.1:41111" }),
+        });
+
+        const url = await resolveDaemonUrl({
+          env: {
+            [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir,
+          },
+          timeoutMs: 1000,
+          allowConventionalIpcDiscovery: true,
+        });
+        expect(url).toBe("http://127.0.0.1:41111");
+      } finally {
+        await ipc?.close();
       }
     });
 

--- a/apps/daemon/tests/mcp-install-cli.test.ts
+++ b/apps/daemon/tests/mcp-install-cli.test.ts
@@ -106,7 +106,18 @@ describe('od mcp install CLI identity probe', () => {
 // resolveDaemonUrl()'s discovery in isolation, but nothing proved the full
 // `od mcp install` CLI closure actually wires a discovered daemon's install
 // info through to the printed install plan.
-describe('od mcp install <agent> end-to-end via conventional IPC discovery (#6424/#6425)', () => {
+//
+// POSIX-only, matching the implementation's own scope (see
+// `conventionalIpcSocketPaths` / `isOwnedByCurrentProcess` in
+// daemon-url.ts): on win32, `currentReleasePlatform()` resolves to "win",
+// `conventionalIpcSocketPaths()` unconditionally returns no candidates, and
+// `resolveAppIpcPath()` would return a named-pipe path -- `fs.mkdirSync` on
+// its dirname is meaningless there, and the CLI would correctly fall back
+// to the self-reinvocation spec instead of reaching the fake socket set up
+// below, failing the FAKE_COMMAND assertion for reasons unrelated to a real
+// regression. Windows coverage of the CLI closure would need a dedicated
+// named-pipe variant of this fixture, not this one running unconditionally.
+describe.skipIf(process.platform === 'win32')('od mcp install <agent> end-to-end via conventional IPC discovery (#6424/#6425)', () => {
   let conventionalIpcBaseDir: string;
   let httpServer: http.Server;
   let httpPort: number;

--- a/apps/daemon/tests/mcp-install-cli.test.ts
+++ b/apps/daemon/tests/mcp-install-cli.test.ts
@@ -1,6 +1,7 @@
 import { execFile } from 'node:child_process';
 import fs from 'node:fs';
 import http from 'node:http';
+import net from 'node:net';
 import os from 'node:os';
 import { dirname, resolve as pathResolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -17,6 +18,28 @@ const DAEMON_ROOT = pathResolve(__dirname, '..');
 const REPO_ROOT = pathResolve(__dirname, '../../..');
 const CLI_SRC = pathResolve(__dirname, '../src/cli.ts');
 const TSX_CLI = pathResolve(REPO_ROOT, 'node_modules/tsx/dist/cli.mjs');
+
+// The legacy default port daemon-url.ts's DEFAULT_DAEMON_URL hardcodes.
+// resolveMcpLaunchSpec fetches this exact address when discovery is
+// ambiguous, so the regression below needs a real listener bound there --
+// there is no env-level way to redirect that hardcoded address.
+const DEFAULT_DAEMON_PORT = 7456;
+
+async function isPortFree(port: number, host = '127.0.0.1'): Promise<boolean> {
+  return await new Promise((resolve) => {
+    const probe = net.createServer();
+    probe.once('error', () => resolve(false));
+    probe.listen(port, host, () => {
+      probe.close(() => resolve(true));
+    });
+  });
+}
+
+// Decided once, at module load (before any describe/it registers), since
+// `it`/`describe.skipIf` conditions must be synchronous by the time
+// Vitest collects this file -- a beforeAll can't retroactively skip tests
+// already queued for the run.
+const DEFAULT_PORT_WAS_FREE = process.platform === 'win32' ? false : await isPortFree(DEFAULT_DAEMON_PORT);
 
 async function runCli(
   args: string[],
@@ -194,5 +217,106 @@ describe.skipIf(process.platform === 'win32')('od mcp install <agent> end-to-end
     // server through conventional discovery, not the degraded fallback.
     expect(parsed.command).toContain(FAKE_COMMAND);
     expect(parsed.command).toContain(FAKE_ARGS.join(' '));
+  });
+});
+
+// Blocking finding from the round-8 review (commit 7536bc7): returning
+// DEFAULT_DAEMON_URL for an ambiguous discovery result does not make it
+// inert, because resolveMcpLaunchSpec unconditionally fetched
+// `${base}/api/mcp/install-info` on whatever URL it got back -- if
+// something happens to be listening on the hardcoded legacy port
+// 127.0.0.1:7456 during that exact window (a leftover process, an
+// unrelated local service, even one of the very channels ambiguity
+// refused to choose between), the CLI would fetch and persist THAT
+// server's response anyway, defeating the entire point of the ambiguity
+// guard. Reproduced by the reviewer with live stable/beta responders plus
+// a plain HTTP server on 7456; fixed by having resolveMcpLaunchSpec check
+// resolveDaemonUrlDetailed's `ambiguous` flag and skip the fetch entirely
+// in that case (see daemon-url.ts / cli.ts).
+//
+// Requires exclusive use of the real, unparameterizable port 7456 -- see
+// DEFAULT_PORT_WAS_FREE above -- so this describe is skipped rather than
+// failing outright if something else already owns that port on the host
+// (e.g. a real Open Design daemon, or a source-checkout `od` dev instance,
+// which also defaults to 7456) when this suite runs.
+describe.skipIf(!DEFAULT_PORT_WAS_FREE)('od mcp install <agent> ambiguity skips the default-port fetch entirely (#6425)', () => {
+  let conventionalIpcBaseDir: string;
+  let defaultPortServer: http.Server;
+  let stableIpc: JsonIpcServerHandle | null = null;
+  let betaIpc: JsonIpcServerHandle | null = null;
+
+  const UNRELATED_COMMAND = 'open-design-unrelated-default-port-daemon';
+
+  beforeAll(async () => {
+    // Short prefix deliberately: AF_UNIX's sun_path has a ~104-byte limit
+    // (macOS), and this path is already deep (tmpdir + namespace + filename).
+    conventionalIpcBaseDir = fs.mkdtempSync(pathResolve(os.tmpdir(), 'od-mcp-amb-'));
+
+    // Stands in for "something happens to be listening on the hardcoded
+    // legacy default port" -- must never be reached if the ambiguity guard
+    // works, regardless of what it would have returned.
+    defaultPortServer = http.createServer((req, res) => {
+      if (req.url === '/api/mcp/install-info') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ command: UNRELATED_COMMAND, args: [], env: {} }));
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise<void>((resolve, reject) => {
+      defaultPortServer.once('error', reject);
+      defaultPortServer.listen(DEFAULT_DAEMON_PORT, '127.0.0.1', resolve);
+    });
+
+    const platform = currentReleasePlatform();
+    const stableSocketPath = resolveAppIpcPath({
+      app: APP_KEYS.DAEMON,
+      contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+      env: { [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir },
+      namespace: releaseNamespace('stable', platform),
+    });
+    const betaSocketPath = resolveAppIpcPath({
+      app: APP_KEYS.DAEMON,
+      contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+      env: { [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir },
+      namespace: releaseNamespace('beta', platform),
+    });
+    fs.mkdirSync(pathResolve(stableSocketPath, '..'), { recursive: true });
+    fs.mkdirSync(pathResolve(betaSocketPath, '..'), { recursive: true });
+    stableIpc = await createJsonIpcServer({
+      socketPath: stableSocketPath,
+      handler: () => ({ pid: 1, state: 'running', updatedAt: new Date().toISOString(), url: 'http://127.0.0.1:56666' }),
+    });
+    betaIpc = await createJsonIpcServer({
+      socketPath: betaSocketPath,
+      handler: () => ({ pid: 2, state: 'running', updatedAt: new Date().toISOString(), url: 'http://127.0.0.1:57777' }),
+    });
+  });
+
+  afterAll(async () => {
+    await stableIpc?.close();
+    await betaIpc?.close();
+    await new Promise<void>((resolve) => defaultPortServer.close(() => resolve()));
+    fs.rmSync(conventionalIpcBaseDir, { recursive: true, force: true });
+  });
+
+  it('falls back to self-reinvocation instead of fetching the daemon listening on the default port', async () => {
+    const result = await runCli(['mcp', 'install', 'claude', '--print', '--json'], {
+      [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir,
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe('');
+    const parsed = JSON.parse(result.stdout) as { ok: boolean; agent: string; kind: string; command: string };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.kind).toBe('cli');
+    // The core regression: must NOT have fetched /api/mcp/install-info from
+    // the port-7456 listener, ambiguous or not.
+    expect(parsed.command).not.toContain(UNRELATED_COMMAND);
+    // Must be the inert self-reinvocation spec instead (process.execPath +
+    // this file's own cli.ts entry point).
+    expect(parsed.command).toContain('cli.ts');
+    expect(parsed.command).toContain(`--daemon-url http://127.0.0.1:${DEFAULT_DAEMON_PORT}`);
   });
 });

--- a/apps/daemon/tests/mcp-install-cli.test.ts
+++ b/apps/daemon/tests/mcp-install-cli.test.ts
@@ -361,6 +361,34 @@ describe.skipIf(!DEFAULT_PORT_WAS_FREE)('od mcp install <agent> ambiguity refuse
       await new Promise<void>((resolve) => defaultPortServer.close(() => resolve()));
     }
   });
+
+  // Blocking finding from the round-11 review, on top of cb3a098: the
+  // `spec == null` ambiguity refusal in runMcpInstall fired unconditionally
+  // -- including for `--uninstall`, which never needed a live daemon or any
+  // launch-spec resolution at all (planAgentInstall's removeArgv /
+  // configPath / keyPath / serverKey fields never derive from `spec`; only
+  // the add-side fields do). With two conventional channel sockets live,
+  // `--uninstall` would hit the same ambiguous-null exit as install and
+  // bail with code 2 before ever reaching plan.removeArgv, stranding a
+  // stale MCP registration the user was specifically trying to clean up.
+  // Fixed by moving the uninstall check ahead of resolveMcpLaunchSpec
+  // entirely, so it takes a harmless placeholder spec instead of ever
+  // calling into discovery.
+  it('--uninstall is not blocked by ambiguous discovery', async () => {
+    const result = await runCli(['mcp', 'install', 'claude', '--uninstall', '--print', '--json'], {
+      [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir,
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe('');
+    const parsed = JSON.parse(result.stdout) as { ok: boolean; agent: string; kind: string; command: string };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.agent).toBe('claude');
+    expect(parsed.kind).toBe('cli');
+    // plan.removeArgv for claude, not the ambiguity-refusal message and not
+    // any add-side command derived from the placeholder spec.
+    expect(parsed.command).toContain('mcp remove');
+  });
 });
 
 // Blocking finding from the round-9 review (commit d9043a7): the

--- a/apps/daemon/tests/mcp-install-cli.test.ts
+++ b/apps/daemon/tests/mcp-install-cli.test.ts
@@ -45,7 +45,13 @@ async function runCli(
   args: string[],
   extraEnv: NodeJS.ProcessEnv = {},
 ): Promise<{ stdout: string; stderr: string; code: number | null }> {
-  const env: NodeJS.ProcessEnv = { ...process.env, ...extraEnv };
+  // Deletions happen on the base inherited env BEFORE extraEnv is applied
+  // (not merged-then-deleted) specifically so a test can still explicitly
+  // set one of these vars via extraEnv when it wants that exact scenario —
+  // e.g. the Electron-as-Node fallback regression below intentionally sets
+  // ELECTRON_RUN_AS_NODE/OD_DATA_DIR, while every other test relies on them
+  // being absent unless it says otherwise.
+  const env: NodeJS.ProcessEnv = { ...process.env };
   delete env.NODE_OPTIONS;
   // Never let this test's actual invoking environment leak a real daemon
   // endpoint into the child — every scenario here needs to reach
@@ -59,6 +65,13 @@ async function runCli(
   // socket the end-to-end test below sets up would never be reached and the
   // CLI would silently fall back to the self-reinvocation spec instead.
   delete env[SIDECAR_ENV.NAMESPACE];
+  // Regression coverage for the #6425 review (round 9): these two vars must
+  // only appear in a test's env because IT put them there via extraEnv, not
+  // because this Vitest process happened to inherit them (e.g. if it's
+  // itself running under Electron-as-Node tooling).
+  delete env.ELECTRON_RUN_AS_NODE;
+  delete env.OD_DATA_DIR;
+  Object.assign(env, extraEnv);
   try {
     const { stdout, stderr } = await execFileP(process.execPath, [TSX_CLI, CLI_SRC, ...args], {
       cwd: DAEMON_ROOT,
@@ -318,5 +331,88 @@ describe.skipIf(!DEFAULT_PORT_WAS_FREE)('od mcp install <agent> ambiguity skips 
     // this file's own cli.ts entry point).
     expect(parsed.command).toContain('cli.ts');
     expect(parsed.command).toContain(`--daemon-url http://127.0.0.1:${DEFAULT_DAEMON_PORT}`);
+  });
+});
+
+// Blocking finding from the round-9 review (commit d9043a7): the
+// self-reinvocation fallback in resolveMcpLaunchSpec (cli.ts) built its
+// spec with an empty `env` map. In a packaged Electron build,
+// process.execPath there is Electron, not a bundled Node binary --
+// ELECTRON_RUN_AS_NODE=1 must be set on the SPAWNED process too, or
+// Electron launches the GUI app instead of running daemon-cli.mjs as
+// plain Node when the agent later runs this persisted command.
+// OD_DATA_DIR must also carry over, or the spawned `od mcp` falls back to
+// `<cwd>/.od/...`, which is the read-only macOS app bundle for packaged
+// installs and trips EPERM (issue #848). The normal, non-fallback
+// /api/mcp/install-info path already preserves both (see
+// apps/daemon/src/mcp-install-info.ts); this exercises the path where no
+// live daemon is reachable at all, so the fallback spec is what actually
+// gets persisted.
+//
+// Not gated to POSIX: the isolated, empty IPC base directory below means
+// conventionalIpcSocketPaths() finds nothing on any platform (on win32 it
+// already returns no candidates unconditionally), so this always exercises
+// the "no live daemon" fallback regardless of host OS.
+describe('od mcp install <agent> self-reinvocation fallback env (#6425)', () => {
+  it('propagates ELECTRON_RUN_AS_NODE and OD_DATA_DIR from the current process into the persisted spec', async () => {
+    const isolatedIpcBase = fs.mkdtempSync(pathResolve(os.tmpdir(), 'od-mcp-fb-ipc-'));
+    const unreachableBinDir = fs.mkdtempSync(pathResolve(os.tmpdir(), 'od-mcp-fb-bin-'));
+    const fakeDataDir = fs.mkdtempSync(pathResolve(os.tmpdir(), 'od-mcp-fb-data-'));
+    try {
+      const result = await runCli(['mcp', 'install', 'claude', '--print', '--json'], {
+        // No pnpm on PATH -> tools-dev discovery fails too, so every
+        // discovery mechanism comes up empty and resolveMcpLaunchSpec must
+        // take the self-reinvocation fallback branch.
+        PATH: unreachableBinDir,
+        [SIDECAR_ENV.IPC_BASE]: isolatedIpcBase,
+        ELECTRON_RUN_AS_NODE: '1',
+        OD_DATA_DIR: fakeDataDir,
+      });
+
+      expect(result.code).toBe(0);
+      expect(result.stderr).toBe('');
+      const parsed = JSON.parse(result.stdout) as {
+        ok: boolean;
+        kind: string;
+        launchSpec: { command: string; args: string[]; env: Record<string, string> };
+      };
+      expect(parsed.ok).toBe(true);
+      expect(parsed.kind).toBe('cli');
+      // Confirms this actually took the fallback branch, not a coincidental
+      // live-daemon hit.
+      expect(parsed.launchSpec.args.some((arg) => arg.includes('cli.ts'))).toBe(true);
+      expect(parsed.launchSpec.env).toMatchObject({
+        ELECTRON_RUN_AS_NODE: '1',
+        OD_DATA_DIR: fakeDataDir,
+      });
+    } finally {
+      fs.rmSync(isolatedIpcBase, { recursive: true, force: true });
+      fs.rmSync(unreachableBinDir, { recursive: true, force: true });
+      fs.rmSync(fakeDataDir, { recursive: true, force: true });
+    }
+  });
+
+  it('omits ELECTRON_RUN_AS_NODE and OD_DATA_DIR from the persisted spec when neither is set (source-checkout Node case)', async () => {
+    const isolatedIpcBase = fs.mkdtempSync(pathResolve(os.tmpdir(), 'od-mcp-fb-ipc-'));
+    const unreachableBinDir = fs.mkdtempSync(pathResolve(os.tmpdir(), 'od-mcp-fb-bin-'));
+    try {
+      const result = await runCli(['mcp', 'install', 'claude', '--print', '--json'], {
+        PATH: unreachableBinDir,
+        [SIDECAR_ENV.IPC_BASE]: isolatedIpcBase,
+      });
+
+      expect(result.code).toBe(0);
+      expect(result.stderr).toBe('');
+      const parsed = JSON.parse(result.stdout) as {
+        ok: boolean;
+        launchSpec: { env: Record<string, string> };
+      };
+      expect(parsed.ok).toBe(true);
+      expect(parsed.launchSpec.env).not.toHaveProperty('ELECTRON_RUN_AS_NODE');
+      expect(parsed.launchSpec.env).not.toHaveProperty('OD_DATA_DIR');
+    } finally {
+      fs.rmSync(isolatedIpcBase, { recursive: true, force: true });
+      fs.rmSync(unreachableBinDir, { recursive: true, force: true });
+    }
   });
 });

--- a/apps/daemon/tests/mcp-install-cli.test.ts
+++ b/apps/daemon/tests/mcp-install-cli.test.ts
@@ -29,6 +29,13 @@ async function runCli(
   // resolveMcpLaunchSpec's discovery chain on its own terms.
   delete env.OD_DAEMON_URL;
   delete env.OD_SIDECAR_IPC_PATH;
+  // Regression coverage for the #6425 review: an inherited OD_SIDECAR_NAMESPACE
+  // (e.g. from a tools-dev or packaged run this Vitest process happens to be
+  // spawned under) would make conventionalIpcSocketPaths() probe that ONE
+  // namespace instead of sweeping the channel list, so the "stable" fixture
+  // socket the end-to-end test below sets up would never be reached and the
+  // CLI would silently fall back to the self-reinvocation spec instead.
+  delete env[SIDECAR_ENV.NAMESPACE];
   try {
     const { stdout, stderr } = await execFileP(process.execPath, [TSX_CLI, CLI_SRC, ...args], {
       cwd: DAEMON_ROOT,

--- a/apps/daemon/tests/mcp-install-cli.test.ts
+++ b/apps/daemon/tests/mcp-install-cli.test.ts
@@ -233,28 +233,36 @@ describe.skipIf(process.platform === 'win32')('od mcp install <agent> end-to-end
   });
 });
 
-// Blocking finding from the round-8 review (commit 7536bc7): returning
-// DEFAULT_DAEMON_URL for an ambiguous discovery result does not make it
-// inert, because resolveMcpLaunchSpec unconditionally fetched
+// Blocking findings from rounds 8 and 9 (commits 7536bc7, then a further
+// finding on top of it): returning DEFAULT_DAEMON_URL for an ambiguous
+// discovery result does not make it inert in EITHER of two ways.
+//
+// Round 8: resolveMcpLaunchSpec unconditionally fetched
 // `${base}/api/mcp/install-info` on whatever URL it got back -- if
 // something happens to be listening on the hardcoded legacy port
-// 127.0.0.1:7456 during that exact window (a leftover process, an
-// unrelated local service, even one of the very channels ambiguity
-// refused to choose between), the CLI would fetch and persist THAT
-// server's response anyway, defeating the entire point of the ambiguity
-// guard. Reproduced by the reviewer with live stable/beta responders plus
-// a plain HTTP server on 7456; fixed by having resolveMcpLaunchSpec check
-// resolveDaemonUrlDetailed's `ambiguous` flag and skip the fetch entirely
-// in that case (see daemon-url.ts / cli.ts).
+// 127.0.0.1:7456 during that exact INSTALL-TIME window, the CLI would
+// fetch and persist THAT server's response. Fixed by skipping the fetch
+// entirely when `ambiguous` is true.
+//
+// Round 9: skipping the install-time fetch only prevented THAT one fetch --
+// the self-reinvocation fallback spec still wrote `--daemon-url
+// http://127.0.0.1:7456` into the persisted agent config. `ensureMcpDaemonUrl`
+// (mcp-bootstrap.ts) treats an explicit --daemon-url as authoritative and
+// skips rediscovery on every LATER `od mcp` spawn, so whatever eventually
+// ends up owning port 7456 -- at any point after install, not just during
+// it -- would silently receive the MCP traffic from then on. The only fix
+// that actually holds end-to-end is refusing to persist ANY spec at all
+// when ambiguous: resolveMcpLaunchSpec now returns `null`, and
+// runMcpInstall fails the whole install rather than falling through to any
+// fallback.
 //
 // Requires exclusive use of the real, unparameterizable port 7456 -- see
 // DEFAULT_PORT_WAS_FREE above -- so this describe is skipped rather than
 // failing outright if something else already owns that port on the host
 // (e.g. a real Open Design daemon, or a source-checkout `od` dev instance,
 // which also defaults to 7456) when this suite runs.
-describe.skipIf(!DEFAULT_PORT_WAS_FREE)('od mcp install <agent> ambiguity skips the default-port fetch entirely (#6425)', () => {
+describe.skipIf(!DEFAULT_PORT_WAS_FREE)('od mcp install <agent> ambiguity refuses to persist any spec (#6425)', () => {
   let conventionalIpcBaseDir: string;
-  let defaultPortServer: http.Server;
   let stableIpc: JsonIpcServerHandle | null = null;
   let betaIpc: JsonIpcServerHandle | null = null;
 
@@ -264,23 +272,6 @@ describe.skipIf(!DEFAULT_PORT_WAS_FREE)('od mcp install <agent> ambiguity skips 
     // Short prefix deliberately: AF_UNIX's sun_path has a ~104-byte limit
     // (macOS), and this path is already deep (tmpdir + namespace + filename).
     conventionalIpcBaseDir = fs.mkdtempSync(pathResolve(os.tmpdir(), 'od-mcp-amb-'));
-
-    // Stands in for "something happens to be listening on the hardcoded
-    // legacy default port" -- must never be reached if the ambiguity guard
-    // works, regardless of what it would have returned.
-    defaultPortServer = http.createServer((req, res) => {
-      if (req.url === '/api/mcp/install-info') {
-        res.writeHead(200, { 'content-type': 'application/json' });
-        res.end(JSON.stringify({ command: UNRELATED_COMMAND, args: [], env: {} }));
-        return;
-      }
-      res.writeHead(404);
-      res.end();
-    });
-    await new Promise<void>((resolve, reject) => {
-      defaultPortServer.once('error', reject);
-      defaultPortServer.listen(DEFAULT_DAEMON_PORT, '127.0.0.1', resolve);
-    });
 
     const platform = currentReleasePlatform();
     const stableSocketPath = resolveAppIpcPath({
@@ -310,27 +301,65 @@ describe.skipIf(!DEFAULT_PORT_WAS_FREE)('od mcp install <agent> ambiguity skips 
   afterAll(async () => {
     await stableIpc?.close();
     await betaIpc?.close();
-    await new Promise<void>((resolve) => defaultPortServer.close(() => resolve()));
     fs.rmSync(conventionalIpcBaseDir, { recursive: true, force: true });
   });
 
-  it('falls back to self-reinvocation instead of fetching the daemon listening on the default port', async () => {
+  it('fails the install outright instead of persisting any spec', async () => {
     const result = await runCli(['mcp', 'install', 'claude', '--print', '--json'], {
       [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir,
     });
 
-    expect(result.code).toBe(0);
-    expect(result.stderr).toBe('');
-    const parsed = JSON.parse(result.stdout) as { ok: boolean; agent: string; kind: string; command: string };
-    expect(parsed.ok).toBe(true);
-    expect(parsed.kind).toBe('cli');
-    // The core regression: must NOT have fetched /api/mcp/install-info from
-    // the port-7456 listener, ambiguous or not.
-    expect(parsed.command).not.toContain(UNRELATED_COMMAND);
-    // Must be the inert self-reinvocation spec instead (process.execPath +
-    // this file's own cli.ts entry point).
-    expect(parsed.command).toContain('cli.ts');
-    expect(parsed.command).toContain(`--daemon-url http://127.0.0.1:${DEFAULT_DAEMON_PORT}`);
+    expect(result.code).not.toBe(0);
+    const parsed = JSON.parse(result.stdout) as { ok: boolean; agent: string; message: string };
+    expect(parsed.ok).toBe(false);
+    expect(parsed.agent).toBe('claude');
+    expect(parsed.message).toMatch(/refus/i);
+    // Nothing referencing the default port must appear anywhere in the
+    // output -- there is no spec left to carry a concrete URL. (The error
+    // message's own advisory text legitimately suggests the bare
+    // `--daemon-url` FLAG NAME as something the user could pass, so that
+    // substring alone isn't the thing to assert against here.)
+    expect(result.stdout).not.toContain(String(DEFAULT_DAEMON_PORT));
+  });
+
+  // Literal reproduction of the review's requested scenario, adapted to
+  // this fix's actual shape: since NOTHING is ever persisted when
+  // ambiguous, "starts a listener on the default port after the ambiguous
+  // install" can only meaningfully prove the refusal is structural (driven
+  // by the live channel sockets) rather than an accident of the default
+  // port happening to be empty at attempt time. Retries the exact same
+  // install after the listener appears and confirms it is refused again,
+  // identically, with the listener's response never surfacing anywhere.
+  it('still refuses once the default-port listener appears after the first refusal', async () => {
+    const before = await runCli(['mcp', 'install', 'claude', '--print', '--json'], {
+      [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir,
+    });
+    expect(before.code).not.toBe(0);
+
+    const defaultPortServer = http.createServer((req, res) => {
+      if (req.url === '/api/mcp/install-info') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ command: UNRELATED_COMMAND, args: [], env: {} }));
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise<void>((resolve, reject) => {
+      defaultPortServer.once('error', reject);
+      defaultPortServer.listen(DEFAULT_DAEMON_PORT, '127.0.0.1', resolve);
+    });
+    try {
+      const after = await runCli(['mcp', 'install', 'claude', '--print', '--json'], {
+        [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir,
+      });
+      expect(after.code).not.toBe(0);
+      expect(after.stdout).not.toContain(UNRELATED_COMMAND);
+      const parsed = JSON.parse(after.stdout) as { ok: boolean };
+      expect(parsed.ok).toBe(false);
+    } finally {
+      await new Promise<void>((resolve) => defaultPortServer.close(() => resolve()));
+    }
   });
 });
 

--- a/apps/daemon/tests/mcp-install-cli.test.ts
+++ b/apps/daemon/tests/mcp-install-cli.test.ts
@@ -1,9 +1,15 @@
 import { execFile } from 'node:child_process';
-import { createServer } from 'node:http';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
 import { dirname, resolve as pathResolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createJsonIpcServer, resolveAppIpcPath, type JsonIpcServerHandle } from '@open-design/sidecar';
+import { releaseNamespace } from '@open-design/release';
+import { APP_KEYS, OPEN_DESIGN_SIDECAR_CONTRACT, SIDECAR_ENV, SIDECAR_MESSAGES } from '@open-design/sidecar-proto';
+import { currentReleasePlatform } from '../src/daemon-url.js';
 
 const execFileP = promisify(execFile);
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -12,9 +18,17 @@ const REPO_ROOT = pathResolve(__dirname, '../../..');
 const CLI_SRC = pathResolve(__dirname, '../src/cli.ts');
 const TSX_CLI = pathResolve(REPO_ROOT, 'node_modules/tsx/dist/cli.mjs');
 
-async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; code: number | null }> {
-  const env: NodeJS.ProcessEnv = { ...process.env };
+async function runCli(
+  args: string[],
+  extraEnv: NodeJS.ProcessEnv = {},
+): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  const env: NodeJS.ProcessEnv = { ...process.env, ...extraEnv };
   delete env.NODE_OPTIONS;
+  // Never let this test's actual invoking environment leak a real daemon
+  // endpoint into the child — every scenario here needs to reach
+  // resolveMcpLaunchSpec's discovery chain on its own terms.
+  delete env.OD_DAEMON_URL;
+  delete env.OD_SIDECAR_IPC_PATH;
   try {
     const { stdout, stderr } = await execFileP(process.execPath, [TSX_CLI, CLI_SRC, ...args], {
       cwd: DAEMON_ROOT,
@@ -48,7 +62,7 @@ describe('od mcp install CLI identity probe', () => {
       args: ['/opt/open-design/daemon-cli.mjs', 'mcp'],
       env: { OD_DATA_DIR: '/tmp/open-design-data' },
     };
-    const server = createServer((_req, res) => {
+    const server = http.createServer((_req, res) => {
       res.setHeader('content-type', 'application/json');
       res.end(JSON.stringify(launchSpec));
     });
@@ -79,5 +93,88 @@ describe('od mcp install CLI identity probe', () => {
         server.close((error) => (error ? reject(error) : resolve()));
       });
     }
+  });
+});
+
+// End-to-end regression for #6424/#6425: a plain terminal invocation of
+// `od mcp install <agent>` (no OD_SIDECAR_IPC_PATH, no OD_DAEMON_URL — the
+// exact conditions of the original bug report) must persist the PACKAGED
+// daemon's real /api/mcp/install-info launch spec, discovered via the
+// conventional per-channel IPC socket, rather than degrading to the
+// self-reinvocation fallback in resolveMcpLaunchSpec (cli.ts). Codex's
+// architecture review of this PR noted that every other test here proves
+// resolveDaemonUrl()'s discovery in isolation, but nothing proved the full
+// `od mcp install` CLI closure actually wires a discovered daemon's install
+// info through to the printed install plan.
+describe('od mcp install <agent> end-to-end via conventional IPC discovery (#6424/#6425)', () => {
+  let conventionalIpcBaseDir: string;
+  let httpServer: http.Server;
+  let httpPort: number;
+  let ipc: JsonIpcServerHandle | null = null;
+
+  const FAKE_COMMAND = 'open-design-fake-daemon-command';
+  const FAKE_ARGS = ['--fake-flag', 'fake-value'];
+
+  beforeAll(async () => {
+    conventionalIpcBaseDir = fs.mkdtempSync(pathResolve(os.tmpdir(), 'od-mcp-install-e2e-'));
+
+    // Stands in for the real daemon's /api/mcp/install-info HTTP endpoint —
+    // the launch spec resolveMcpLaunchSpec should end up persisting is
+    // whatever THIS returns, never the self-reinvocation fallback.
+    httpServer = http.createServer((req, res) => {
+      if (req.url === '/api/mcp/install-info') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ command: FAKE_COMMAND, args: FAKE_ARGS, env: {} }));
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', resolve));
+    const address = httpServer.address();
+    if (address == null || typeof address === 'string') throw new Error('expected an AddressInfo');
+    httpPort = address.port;
+
+    const socketPath = resolveAppIpcPath({
+      app: APP_KEYS.DAEMON,
+      contract: OPEN_DESIGN_SIDECAR_CONTRACT,
+      env: { [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir },
+      namespace: releaseNamespace('stable', currentReleasePlatform()),
+    });
+    fs.mkdirSync(pathResolve(socketPath, '..'), { recursive: true });
+    ipc = await createJsonIpcServer({
+      socketPath,
+      handler: (message) => {
+        if (message != null && typeof message === 'object' && (message as { type?: unknown }).type === SIDECAR_MESSAGES.STATUS) {
+          return { pid: 1, state: 'running', updatedAt: new Date().toISOString(), url: `http://127.0.0.1:${httpPort}` };
+        }
+        throw new Error('unexpected message');
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await ipc?.close();
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    fs.rmSync(conventionalIpcBaseDir, { recursive: true, force: true });
+  });
+
+  it('persists the discovered packaged launch spec instead of the self-reinvocation fallback', async () => {
+    const result = await runCli(['mcp', 'install', 'claude', '--print', '--json'], {
+      [SIDECAR_ENV.IPC_BASE]: conventionalIpcBaseDir,
+    });
+
+    expect(result.code).toBe(0);
+    expect(result.stderr).toBe('');
+    const parsed = JSON.parse(result.stdout) as { ok: boolean; agent: string; kind: string; command: string };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.agent).toBe('claude');
+    expect(parsed.kind).toBe('cli');
+    // The fallback spec's command is always `process.execPath` (an absolute
+    // node interpreter path) — it can never contain FAKE_COMMAND. Seeing
+    // FAKE_COMMAND here proves the CLI actually reached the fake HTTP
+    // server through conventional discovery, not the degraded fallback.
+    expect(parsed.command).toContain(FAKE_COMMAND);
+    expect(parsed.command).toContain(FAKE_ARGS.join(' '));
   });
 });

--- a/apps/daemon/tests/server-status-url-ipv6.test.ts
+++ b/apps/daemon/tests/server-status-url-ipv6.test.ts
@@ -26,7 +26,13 @@ describe('startServer status URL formatting', () => {
   let started: StartedServer | null = null;
 
   afterEach(async () => {
+    // `shutdown` (startServer's returned shutdownDaemonRuns) drains daemon
+    // work; it does NOT close the HTTP server itself, so that has to happen
+    // separately or every test here leaks a live listener/open handle.
     await Promise.resolve(started?.shutdown?.());
+    if (started?.server) {
+      await new Promise<void>((resolve) => started?.server.close(() => resolve()));
+    }
     started = null;
   });
 

--- a/apps/daemon/tests/server-status-url-ipv6.test.ts
+++ b/apps/daemon/tests/server-status-url-ipv6.test.ts
@@ -1,0 +1,48 @@
+// Regression coverage for the #6425 review: `startServer`'s reported status
+// URL used to concatenate a bare (unbracketed) host into an `http://` string
+// — `http://${reportHost}:${resolvedPort}` — which is only valid for
+// hostnames and IPv4 literals. An IPv6 literal (e.g. a supported
+// `OD_BIND_HOST=::1`) needs brackets: `new URL('http://::1:7456')` throws
+// (the bare colons are ambiguous with the port separator), so every consumer
+// of this URL — the sidecar, daemon-url.ts's conventional discovery, or any
+// plain client fetching /api/mcp/install-info — would fail before it could
+// even try to reach a real IPv6-bound daemon. `daemon-url.test.ts`'s own
+// "accepts a conventional-path response whose url is IPv6 loopback" test
+// only proves `isLoopbackHttpUrl` accepts a well-formed bracketed URL; it
+// does not prove the daemon ever actually produces one. This test closes
+// that producer/consumer gap directly against the real `startServer`.
+
+import type { Server } from 'node:http';
+import { afterEach, describe, expect, it } from 'vitest';
+import { startServer } from '../src/server.js';
+
+type StartedServer = {
+  url: string;
+  server: Server;
+  shutdown?: () => Promise<void> | void;
+};
+
+describe('startServer status URL formatting', () => {
+  let started: StartedServer | null = null;
+
+  afterEach(async () => {
+    await Promise.resolve(started?.shutdown?.());
+    started = null;
+  });
+
+  it('brackets an IPv6 bind host so the reported url is a valid, parseable URL', async () => {
+    started = (await startServer({ port: 0, host: '::1', returnServer: true })) as StartedServer;
+
+    // The core regression: this must not throw.
+    const parsed = new URL(started.url);
+    // WHATWG URL always brackets an IPv6 literal in `.hostname`.
+    expect(parsed.hostname).toBe('[::1]');
+    expect(started.url).toMatch(/^http:\/\/\[::1\]:\d+$/);
+  });
+
+  it('leaves an IPv4/hostname bind host unbracketed (no regression for the common case)', async () => {
+    started = (await startServer({ port: 0, host: '127.0.0.1', returnServer: true })) as StartedServer;
+
+    expect(started.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+  });
+});

--- a/packages/release/src/index.ts
+++ b/packages/release/src/index.ts
@@ -155,6 +155,52 @@ export function releaseNamespace(channel: ReleaseChannel, platform: ReleasePlatf
   return suffix.length === 0 ? `release-${channel}` : `release-${channel}-${suffix}`;
 }
 
+/**
+ * Legacy namespace aliases a shipping release workflow still produces
+ * instead of the canonical `releaseNamespace()` value for a given
+ * channel/platform pair. Consumers that need to find a LIVE packaged
+ * install by namespace (e.g. `apps/daemon`'s conventional IPC socket
+ * discovery, see nexu-io/open-design#6425) must probe every alias, not just
+ * the canonical name.
+ *
+ * `beta:macIntel` -> `release-beta-x64`: every other channel's Intel-mac
+ * build follows the standard `-intel` suffix this package derives
+ * (`release-prerelease-intel`, `release-preview-intel`, matching
+ * `.github/workflows/release-prerelease.yml` / `release-preview.yml`), but
+ * `.github/workflows/release-beta.yml`'s mac_x64 job instead bakes the
+ * literal `release-beta-x64` via `tools-pack mac build --namespace
+ * release-beta-x64`. Renaming that shipping workflow's namespace to match
+ * the pattern would orphan already-installed beta Intel users' existing IPC
+ * path -- a separate, higher-risk change. This map exists so that
+ * discrepancy is recorded once, here, where namespace identity is owned,
+ * instead of being re-derived ad hoc by every caller that needs to find a
+ * live packaged daemon.
+ */
+const RELEASE_NAMESPACE_LEGACY_ALIASES: Readonly<Partial<Record<string, readonly string[]>>> = Object.freeze({
+  "beta:macIntel": Object.freeze(["release-beta-x64"]),
+});
+
+function legacyNamespaceAliasKey(channel: ReleaseChannel, platform: ReleasePlatform): string {
+  return `${channel}:${platform}`;
+}
+
+/**
+ * Every namespace a live packaged install of `channel`/`platform` might
+ * currently be using: the canonical `releaseNamespace()` value first,
+ * followed by any known legacy aliases (see
+ * `RELEASE_NAMESPACE_LEGACY_ALIASES`). Most channel/platform pairs have no
+ * aliases and this returns a single-element array equal to
+ * `[releaseNamespace(channel, platform)]`.
+ */
+export function releaseNamespaceCandidates(
+  channel: ReleaseChannel,
+  platform: ReleasePlatform = "mac",
+): readonly string[] {
+  const canonical = releaseNamespace(channel, platform);
+  const aliases = RELEASE_NAMESPACE_LEGACY_ALIASES[legacyNamespaceAliasKey(channel, platform)] ?? [];
+  return aliases.length === 0 ? [canonical] : [canonical, ...aliases];
+}
+
 export function releaseInstallIdentity(channel: ReleaseChannel): ReleaseInstallIdentity {
   const descriptor = releaseChannelDescriptor(channel);
   return {

--- a/packages/release/tests/index.test.ts
+++ b/packages/release/tests/index.test.ts
@@ -11,6 +11,7 @@ import {
   releaseInstallIdentity,
   releaseMetadataVersionFields,
   releaseNamespace,
+  releaseNamespaceCandidates,
 } from "../src/index.js";
 
 describe("@open-design/release", () => {
@@ -62,6 +63,21 @@ describe("@open-design/release", () => {
     expect(releaseNamespace("prerelease", "win")).toBe("release-prerelease-win");
     expect(releaseNamespace("prerelease", "macIntel")).toBe("release-prerelease-intel");
     expect(releaseNamespace("betas", "win")).toBe("release-betas-win");
+  });
+
+  // Regression coverage for nexu-io/open-design#6425: every channel/platform
+  // pair with no known legacy alias must resolve to exactly the canonical
+  // releaseNamespace() value, and the one known outlier (beta on Intel mac,
+  // where release-beta.yml bakes "release-beta-x64" instead of the standard
+  // "-intel" suffix every other channel's Intel-mac build uses) must return
+  // the canonical name FIRST, then the alias.
+  it("surfaces legacy namespace aliases alongside the canonical name", () => {
+    expect(releaseNamespaceCandidates("beta", "macIntel")).toEqual(["release-beta-intel", "release-beta-x64"]);
+    expect(releaseNamespaceCandidates("prerelease", "macIntel")).toEqual(["release-prerelease-intel"]);
+    expect(releaseNamespaceCandidates("preview", "macIntel")).toEqual(["release-preview-intel"]);
+    expect(releaseNamespaceCandidates("beta", "mac")).toEqual(["release-beta"]);
+    expect(releaseNamespaceCandidates("beta", "win")).toEqual(["release-beta-win"]);
+    expect(releaseNamespaceCandidates("stable")).toEqual(["release-stable"]);
   });
 
   it("infers release channels from versions and namespaces", () => {


### PR DESCRIPTION
Fixes #6424

## Why

Filed #6424 after tracing why `od mcp install <agent>` still degrades to a broken bare `od` launch spec on this machine, even on 0.17.0 and even outside the `/usr/bin/od` PATH-collision symptom that #5120/#5219 addressed. I hit this while wiring Open Design into Claude Code as an MCP client (unrelated task) — the daemon's own `GET /api/mcp/install-info` returned the correct absolute-path command, but the `mcp install <agent>` CLI shortcut didn't use it.

Root cause: `resolveMcpLaunchSpec()` (`cli.ts`) only reaches `/api/mcp/install-info` if `resolveDaemonUrl()` can find the daemon first. `resolveDaemonUrl()`'s only non-flag/env discovery path is a STATUS roundtrip to `OD_SIDECAR_IPC_PATH` — an env var the packaged app stamps only into its **own** spawned children, never into an ordinary user terminal. A plain terminal invocation therefore falls through to the hardcoded `http://127.0.0.1:7456` default, which packaged installs don't bind (they use an ephemeral port by design — see the "goes stale as soon as the sidecar is respawned on a fresh ephemeral port" comment in `apps/packaged/src/sidecars.ts`). The `/api/mcp/install-info` fetch then fails and the function returns its degraded fallback spec.

## What users will see

- `od mcp install <agent>` (and the hosted `install.sh | sh -s <agent>` bootstrap) now succeeds from a plain terminal against a running packaged install, without needing `OD_SIDECAR_IPC_PATH` set — it discovers the daemon via the conventional per-channel sidecar socket path instead of degrading to a broken command.
- No other `od` subcommand changes behavior — the new discovery step is opt-in and only `mcp install <agent>` requests it (see Surface area / Validation).
- If the daemon truly can't be found, the resulting (still-degraded) launch spec now points at an absolute, runnable path instead of the bare string `od`.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [x] **CLI / env var** — no new subcommand/flag; changes what `od mcp install <agent>` discovers and what its fallback spec looks like when discovery fails. `resolveDaemonUrl()`'s public options gain one new optional field (`allowConventionalIpcDiscovery`, default `false`) — additive, not a breaking change to any existing caller.
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — explicitly *not* checked: every other `od` subcommand (`media generate`, `project list`, `run start`, …) shares `resolveDaemonUrl()` and keeps its exact current behavior, since the new discovery step is gated behind `allowConventionalIpcDiscovery` and only `resolveMcpLaunchSpec()` passes `true`. This was the main design question on the issue thread — see the alternatives considered below.
- [x] **None** — the externally-visible contract (CLI flags, `/api/mcp/install-info` shape) is unchanged; only an internal fallback path is fixed. Checking this alongside CLI/env var above since neither "UI" nor the other boxes apply and the change is best described as "the previously-broken path now works."

## Screenshots

N/A — CLI-only fix, no UI surface.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/daemon-url.test.ts`, describe block `conventional per-channel IPC discovery (#6424)` (3 of its cases exercise the new discovery; the other 2 lock in the opt-in gate and the loopback check).
- Did the test go red on `main` and green on this branch? **Yes**, confirmed directly: `git stash push -- apps/daemon/src/daemon-url.ts apps/daemon/src/cli.ts` (keeping only the new test file), ran `pnpm exec vitest run daemon-url` → 3 failed / 7 passed against unmodified `main` (`fe1231ee`), with the 3 failures being exactly the new-behavior assertions. `git stash pop` restored the fix → 10/10 pass.
- Also added: a test locking in that the stable channel wins deterministically when multiple channel sockets are simultaneously live (not a bare race — `Promise.allSettled` + ordered scan), and a test rejecting a non-loopback URL from a probed socket (see the trust-boundary note below).

## Validation

- `pnpm guard`: passed.
- `pnpm --filter @open-design/daemon typecheck` (contracts + registry-protocol build, then `tsc --noEmit` for both `tsconfig.json` and `tsconfig.tests.json`): passed, 0 errors.
- `pnpm --filter @open-design/daemon test -- daemon-url mcp-install-cli mcp-install-info`: 23/23 passed.
- Full `pnpm --filter @open-design/daemon test`: 6250 passed / 9 failed / 6 skipped / 4 todo (6269 total). The 9 failures are in `tests/connection-test.test.ts`, `tests/chat-route.test.ts`, and `tests/prompts/discovery-plugin-inputs.test.ts` — confirmed unrelated by reproducing the identical 9 failures on unmodified `main` in the same environment before touching anything (one of the three files, `discovery-plugin-inputs.test.ts`, also matches a file already called out as a pre-existing unrelated failure in #6316's own validation notes).

## A note on the design path (for reviewers)

The first version of this fix put the conventional-path probing directly inside the shared `discoverDaemonUrlFromIpc()`/`resolveDaemonUrl()` with no gate. That's wrong: `resolveDaemonUrl()` is shared infrastructure for every `od` subcommand, and an unrelated already-running packaged daemon silently "winning" over the legacy default would be a real behavior change for commands that never asked for this. I caught this via an existing test (`daemon-url.test.ts`'s tools-dev discovery case) failing because the probe reached my own real running Open Design app on `/tmp/open-design/ipc/...` instead of the test's mocked `tools-dev` script. The `allowConventionalIpcDiscovery` opt-in (default `false`) fixes that: no existing test needed to change, and every subcommand other than `mcp install <agent>` is provably untouched.

Also flagging honestly rather than silently working around it: the JSON-IPC protocol (`packages/sidecar/src/json-ipc.ts`) has no responder-identity check at all — no peer-credential/uid verification, no shared secret, and no socket-file permission hardening beyond the OS default umask. Probing a well-known, predictable path (as opposed to the pre-existing `OD_SIDECAR_IPC_PATH` case, which is scoped to a session the packaged app itself set up) is a real, if narrow, widening of that trust surface — the stakes here are also higher than most existing consumers of this protocol, since a successful probe's response goes on to be `fetch()`-ed for `/api/mcp/install-info` and then persisted verbatim as a `command`/`args` pair into a coding agent's own config. This PR adds a loopback check on the probed URL as cheap defense-in-depth (rules out off-host redirection) but does **not** attempt to fix the underlying lack of responder authentication — that would need a protocol-level change to `packages/sidecar`, and is a bigger, separate decision for maintainers. Happy to open a follow-up issue for that if useful, or take a swing at it if there's an appetite and a preferred direction (shared secret file under the same restricted-permission directory? peer-credential check via `net.Socket`? something else?).
