### PR TITLE
feat(daemon): forward skills[] as skillIds[] on start_run MCP tool

### DIFF
--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -88,7 +88,7 @@ interface ProjectPayload { project?: ProjectSummary; id?: string; name?: string;
 interface ActiveContext { active?: boolean; projectId?: string; projectName?: string | null; fileName?: string | null; ageMs?: number | null }
 type ResolvedProject = { id: string; name: string; source: 'uuid' | 'id' | 'exact' | 'slug' | 'substring' };
 interface ProjectListCache { baseUrl: string; t: number; list: ProjectSummary[] }
-interface McpArgs extends JsonObject { project?: unknown; entry?: unknown; include?: unknown; maxBytes?: unknown; path?: unknown; offset?: unknown; limit?: unknown; since?: unknown; query?: unknown; pattern?: unknown; max?: unknown; name?: unknown; content?: unknown; encoding?: unknown; artifactManifest?: unknown; confirm?: unknown; prompt?: unknown; plugin?: unknown; inputs?: unknown; agent?: unknown; model?: unknown; serviceTier?: unknown; apiKey?: unknown; requestId?: unknown; resume?: unknown; runId?: unknown; id?: unknown; designSystem?: unknown; skill?: unknown; includeUnavailable?: unknown; artifactType?: unknown; projectTitle?: unknown; locale?: unknown; knownAnswers?: unknown; skip?: unknown; briefDraftId?: unknown; nonce?: unknown; answers?: unknown; externalPluginContext?: unknown; pluginWorkflowId?: unknown }
+interface McpArgs extends JsonObject { project?: unknown; entry?: unknown; include?: unknown; maxBytes?: unknown; path?: unknown; offset?: unknown; limit?: unknown; since?: unknown; query?: unknown; pattern?: unknown; max?: unknown; name?: unknown; content?: unknown; encoding?: unknown; artifactManifest?: unknown; confirm?: unknown; prompt?: unknown; plugin?: unknown; inputs?: unknown; agent?: unknown; model?: unknown; serviceTier?: unknown; apiKey?: unknown; requestId?: unknown; resume?: unknown; runId?: unknown; id?: unknown; designSystem?: unknown; skill?: unknown; skills?: string[]; includeUnavailable?: unknown; artifactType?: unknown; projectTitle?: unknown; locale?: unknown; knownAnswers?: unknown; skip?: unknown; briefDraftId?: unknown; nonce?: unknown; answers?: unknown; externalPluginContext?: unknown; pluginWorkflowId?: unknown }
 interface ProjectFileBundleEntry { name: string; mime: string; size: number | null; content: string | null; binary: boolean }
 interface BundleInput { project: ProjectPayload | ProjectSummary; entry: string; files: ProjectFileBundleEntry[]; truncated: boolean; skippedFileCount?: number; active: ActiveContext | null; resolved?: ResolvedProject | null }
 interface ErrorWithCode { message?: string; code?: string; cause?: { code?: string } }
@@ -748,6 +748,11 @@ export const TOOL_DEFS = [
         skill: {
           type: 'string',
           description: 'Skill id from list_skills to drive the run. Optional.',
+        },
+        skills: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Additional skill ids from list_skills to compose into the run alongside skill. Optional; deduped against the primary skill id server-side.',
         },
         plugin: {
           type: 'string',
@@ -2444,6 +2449,7 @@ async function startRun(
     body.currentPrompt = args.prompt;
   }
   if (typeof args.skill === 'string' && args.skill.length > 0) body.skillId = args.skill;
+  if (Array.isArray(args.skills) && args.skills.length > 0) body.skillIds = args.skills;
   if (typeof args.plugin === 'string' && args.plugin.length > 0) body.pluginId = args.plugin;
   if (typeof args.agent === 'string' && args.agent.length > 0) body.agentId = args.agent;
   if (typeof args.model === 'string' && args.model.length > 0) body.model = args.model;

--- a/apps/daemon/tests/mcp-runs.test.ts
+++ b/apps/daemon/tests/mcp-runs.test.ts
@@ -153,6 +153,64 @@ describe('public MCP discovery + generation tools', () => {
     expect(JSON.parse(firstText(result))).toMatchObject({ runId: 'run-55' });
   });
 
+  it('start_run POSTs skills[] as skillIds to /api/runs when skills is provided', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith('/api/projects')) {
+        return new Response(JSON.stringify({ projects: [{ id: 'project-1', name: 'Demo' }] }), { status: 200 });
+      }
+      if (url.endsWith('/api/mcp/install-info')) {
+        return new Response(JSON.stringify({ webBaseUrl: null }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ runId: 'run-56', skillId: 'threejs', skillIds: ['shader-dev', 'frame-liquid-bg-hero'] }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handleMcpToolCall('http://127.0.0.1:17456', 'start_run', {
+      project: 'Demo',
+      prompt: 'Build a 3D hero with shader effects',
+      skill: 'threejs',
+      skills: ['shader-dev', 'frame-liquid-bg-hero'],
+    });
+
+    const runsCall = fetchMock.mock.calls.find(
+      ([url, init]) => String(url).endsWith('/api/runs') && (init as RequestInit)?.method === 'POST',
+    );
+    const postBody = JSON.parse(String(runsCall?.[1]?.body));
+    expect(postBody).toMatchObject({
+      projectId: 'project-1',
+      message: 'Build a 3D hero with shader effects',
+      skillId: 'threejs',
+      skillIds: ['shader-dev', 'frame-liquid-bg-hero'],
+    });
+    expect(JSON.parse(firstText(result))).toMatchObject({ runId: 'run-56' });
+  });
+
+  it('start_run omits skillIds from POST body when skills is not provided', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith('/api/active')) {
+        return new Response(JSON.stringify({ active: true, projectId: 'proj-a', projectName: 'A', fileName: null }), { status: 200 });
+      }
+      if (url.endsWith('/api/mcp/install-info')) {
+        return new Response(JSON.stringify({ webBaseUrl: null }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ runId: 'run-no-skills' }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handleMcpToolCall('http://127.0.0.1:17456', 'start_run', {
+      prompt: 'iterate',
+      skill: 'brand-identity',
+    });
+
+    const runsCall = fetchMock.mock.calls.find(
+      ([url, init]) => String(url).endsWith('/api/runs') && (init as RequestInit)?.method === 'POST',
+    );
+    const postBody = JSON.parse(String(runsCall?.[1]?.body));
+    expect(postBody).toMatchObject({ projectId: 'proj-a', skillId: 'brand-identity' });
+    expect(postBody).not.toHaveProperty('skillIds');
+    expect(JSON.parse(firstText(result))).toMatchObject({ runId: 'run-no-skills' });
+  });
+
   it('start_run omits agentId from POST body when agent arg is not provided', async () => {
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
       if (url.endsWith('/api/active')) {


### PR DESCRIPTION
## Summary

The MCP bridge exposed only a single `skill` on `start_run` — any extra `skills[]` an agent passed was silently stripped (the input schema declares `additionalProperties: false`, and the handler only read `args.skill`). The daemon already composes supplemental skill ids server-side (`POST /api/runs` spreads the raw body; `composeDaemonSystemPrompt` dedupes supplementals against the primary and stages every skill's dir under `.od-skills/`), so this is purely a serialization gap in the bridge.

This patch forwards `skills[]` from the MCP tool as `skillIds[]` on the run body:

- `McpArgs`: add `skills?: string[]`
- `start_run` inputSchema: add `skills` (array of strings, like `skill`)
- `startRun()`: forward `args.skills` as `body.skillIds` (guarded by `Array.isArray`, so callers that don't pass it are unaffected)

## Test plan

- `pnpm --filter @open-design/daemon typecheck` — passes
- `vitest run tests/mcp-runs.test.ts` — 39/39 pass, including 2 new tests:
  - `start_run POSTs skills[] as skillIds to /api/runs when skills is provided`
  - `start_run omits skillIds from POST body when skills is not provided`