### PR TITLE
fix(prerelease): inject amr_profile so packaged builds can enable Workspace Team transport

### DIFF
--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -12,6 +12,11 @@ on:
         required: false
         type: string
         default: ""
+      amr_profile:
+        description: "Optional AMR profile baked into the build (test or feature-test point the packaged app at that profile's Vela backend and enable the workspace-team transport). Empty leaves the default (prod)."
+        required: false
+        type: string
+        default: ""
       win_x64_smoke_mode:
         description: "Windows x64 smoke coverage."
         required: true
@@ -40,6 +45,11 @@ on:
         default: ""
       release_version:
         description: "Base version (x.y.z). Required when ref is not release/vX.Y.Z."
+        required: false
+        type: string
+        default: ""
+      amr_profile:
+        description: "Optional AMR profile baked into the build (test or feature-test enable the workspace-team transport by pointing at that profile's Vela backend). Empty leaves the default (prod)."
         required: false
         type: string
         default: ""
@@ -110,6 +120,16 @@ env:
   # and the helper still strips .map to keep source out of the installer.
   POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
   POSTHOG_CLI_PROJECT_ID: ${{ vars.POSTHOG_CLI_PROJECT_ID }}
+  # Workspace Team gate for packaged prerelease builds. tools-pack reads
+  # OPEN_DESIGN_AMR_PROFILE and bakes OD_VELA_WEB_URL into open-design-config.json;
+  # both are required for the packaged daemon to enable the workspace-team
+  # transport (see apps/packaged/src/workspace-team.ts). Empty amr_profile leaves
+  # the default (prod), which the packaged gate rejects, so the normal push-driven
+  # prerelease pipeline stays unchanged. A test / feature-test dispatch points at
+  # the matching per-profile Vela console origin held in a repository secret.
+  # Secrets read here: VELA_WEB_URL_FEATURE_TEST, VELA_WEB_URL_TEST.
+  OPEN_DESIGN_AMR_PROFILE: ${{ inputs.amr_profile }}
+  OD_VELA_WEB_URL: ${{ inputs.amr_profile == 'feature-test' && secrets.VELA_WEB_URL_FEATURE_TEST || inputs.amr_profile == 'test' && secrets.VELA_WEB_URL_TEST || '' }}
 jobs:
   metadata:
     name: Prepare prerelease metadata


### PR DESCRIPTION
## Why
The `0.18.0-prerelease.2` build shipped with the Workspace Team transport **dormant**: `apps/packaged/src/workspace-team.ts` gates it behind an AMR profile in {test, feature-test} **and** a non-empty `OD_VELA_WEB_URL`, but `release-prerelease.yml` never injected either — so it fell back to prod (rejected by the gate) and the packaged daemon never turned on `vela-cli` transports. Vela CLI 0.0.28 being present is not enough.

## What
Ports the mechanism already in `release-beta.yml`:
- New `amr_profile` input on both `workflow_dispatch` and `workflow_call`.
- Top-level env injects `OPEN_DESIGN_AMR_PROFILE: ${{ inputs.amr_profile }}` and `OD_VELA_WEB_URL` selected per-profile from `secrets.VELA_WEB_URL_TEST` / `VELA_WEB_URL_FEATURE_TEST`.
- GitHub env inheritance carries both into every tools-pack build step (mac arm64/x64, win, linux) without touching each step.

Empty `amr_profile` (the push-driven default via notify-release-feishu) leaves prod behavior **unchanged**. A `test`/`feature-test` dispatch produces a packaged prerelease whose daemon actually enables Workspace Team against that profile's Vela backend.

## Surface area
- [x] CI / release workflow (`.github/workflows/release-prerelease.yml`)

Backport target for the workspace-team release cycle; will dispatch with `amr_profile=test` after merge.