### PR TITLE
fix(prerelease): auto push prereleases on release/v0.18.0 build with amr_profile=test (Workspace Team)

### DIFF
--- a/.github/workflows/notify-release-feishu.yml
+++ b/.github/workflows/notify-release-feishu.yml
@@ -36,6 +36,11 @@ on:
         required: false
         type: string
         default: ""
+      amr_profile:
+        description: "Optional AMR profile to bake (test / feature-test enable the Workspace Team transport). Empty uses the per-branch default: test on release/v0.18.0, otherwise prod."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: write
@@ -65,6 +70,14 @@ jobs:
       # version). Only set when building from a non-release ref like main, where
       # release-prerelease cannot derive the base version from the branch name.
       release_version: ${{ inputs.release_version }}
+      # Workspace Team gate: the packaged prerelease only enables the vela-cli
+      # transports when a test/feature-test AMR profile is baked in (see
+      # apps/packaged/src/workspace-team.ts + release-prerelease.yml). A manual
+      # dispatch can pass amr_profile explicitly; otherwise release/v0.18.0 — the
+      # workspace-team release cycle — defaults to `test` so its auto push-built
+      # prereleases ship the transport enabled, while every other release branch
+      # stays on prod. Drop the branch default once workspace-team ships to prod.
+      amr_profile: ${{ inputs.amr_profile || (github.ref_name == 'release/v0.18.0' && 'test') || '' }}
 
   notify:
     name: Notify Feishu (release)


### PR DESCRIPTION
Follow-up to #6435. #6435 taught release-prerelease to accept amr_profile, but push-driven prereleases go through notify-release-feishu, which never passed it — so the auto build on release/v0.18.0 still shipped Workspace Team **dormant** (prod default) and posted a misleading card.

This forwards amr_profile from notify-release-feishu to release-prerelease. Manual dispatch overrides; otherwise **release/v0.18.0 defaults to `test`** (the workspace-team cycle) so its auto push-built prerelease enables the vela-cli transports and its Feishu card points at a real, verifiable build. Every other release branch stays on prod. Branch default to be removed once workspace-team ships to prod.

## Surface area
- [x] CI / release workflow (`.github/workflows/notify-release-feishu.yml`)