### PR TITLE
Add Grundraster für Proben plugin

### DIFF
--- a/plugins/community/grundraster-f-r-proben-msfib2p9/SKILL.md
+++ b/plugins/community/grundraster-f-r-proben-msfib2p9/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: RASTER.md
+zweck: Grundraster für Live-Artefakte — was eine Probe ist, wie sie gebaut wird, wie sie geprüft wird
+stand: 2026-08-02
+herkunft: E-023 (Beispiele vor der Entscheidung), Regel 10, E-015. Erfahrungsgrundlage ist
+  Probe P-01; der dort gefundene Bemaßungsfehler ist der Anlass für den Prüfblock.
+---
+
+# Grundraster für Proben
+
+Gilt für jedes Live-Artefakt unter `arbeit/proben/`. **Kein Planschritt** — Proben bekommen keine
+Schrittnummer, sondern eine P-Nummer.
+
+## 1 · Was eine Probe ist — und was sie nicht ist
+
+> **Eine Probe zeigt einen Unterschied, kein Ergebnis. Sie entscheidet nichts.**
+
+Das ist keine Bescheidenheitsformel, sondern die Anwendung von **E-015**: Die Entscheidung liegt
+beim Menschen. Eine Probe, die nur eine Fassung zeigt, ist keine Wahl — sie ist ein Vorschlag,
+und ein Vorschlag nimmt die Entscheidung vorweg.
+
+**Die Probe ist selbst ein Anwendungsfall des Kernbausteins.** E-015 verlangt von der Rahmung,
+dass sie „Fassung, Datum, offene Punkte und gemeinsam getroffene Entscheidungen" zeigt statt eines
+fertigen Urteils. Genau das leistet eine Probe. Was hier über Proben gelernt wird, geht in
+Schritt 6/7 in den Kernbaustein ein — nicht umgekehrt.
+
+| eine Probe | kein Entwurf |
+|---|---|
+| zeigt **mindestens zwei** Fassungen | zeigt eine Lösung |
+| benennt, was sie **nicht** zeigt | wirkt vollständig |
+| trägt ihren Vorbehalt sichtbar | trägt ihn in einer Fußnote |
+| stellt am Ende eine Frage | zieht am Ende ein Fazit |
+| darf **Gegenbilder** enthalten | zeigt nur Erwünschtes |
+
+**Gegenbilder** sind der eigentliche Gewinn: eine Fassung, die eine Regel bricht, macht die Regel
+sichtbar. Sie werden **immer markiert** — in P-01 durchgestrichen und mit „Gegenbild" oder
+„verworfen" beschriftet — und stehen nie zur Wahl.
+
+## 2 · Die sechs Teile eines Probenblatts
+
+Feste Reihenfolge. Fehlt einer, ist es keine Probe.
+
+1. **Kopf** — P-Nummer · Titel · `Arbeitsstand <Datum> · nicht abgenommen`.
+   Die Zeile „nicht abgenommen" steht immer, bis Jonas entschieden hat.
+2. **Vorbehalt** — was Platzhalter ist und was fehlt, mit E-Nummer. Sichtbar umrandet, nicht
+   kleingesetzt. Herkunft: **D-2** („Der Baustein ‚Grenzen' steht in derselben Größenordnung wie
+   der Baustein ‚Leistungen' — gleiche Schriftgröße, gleiche Ebene, nicht eingeklappt").
+3. **Leitsatz je Teil** — ein Satz, der sagt, was in diesem Teil variiert und was konstant bleibt.
+   Ohne ihn vergleicht man zwei Dinge, die sich in mehr als einer Größe unterscheiden.
+4. **Die Fassungen** — je Nummer, Name, Zeichnung, Maß, ein Satz zur Wirkung, Herkunft.
+5. **Die Frage** — was an dieser Probe entscheidbar ist, nummeriert. Und der Satz, dass die
+   Antwort als Entscheidung eingetragen und nicht aus der Probe abgelesen wird.
+6. **Fuß** — was ausgeschlossen ist, je mit E-Nummer, plus die Bewegungsangabe.
+
+## 3 · Was in einer Probe gesperrt ist
+
+Diese Liste ist der Grund, warum Proben vor Schritt 5 und 8 überhaupt möglich sind: Sie zeigen
+**Struktur ohne Oberfläche**.
+
+| gesperrt | Herkunft | was stattdessen |
+|---|---|---|
+| jeder Farbwert als Gestaltungsmittel | E-004 | **Dichte, Maß, Anordnung, Überlappung** |
+| jede Schriftwahl | E-011 | Systemstack, im Blatt als Platzhalter markiert |
+| Impulse, solange kein echtes Bild vorliegt | E-020, O-017 | nichts — `m = 0` ist der richtige Stand |
+| ein zweites Theme | E-017 | ein Theme; eine zweite Lichtsituation wäre eine zweite Grundlage |
+| Flächenbehandlung, Filter, Tönung über alles | Regel 7, Schritt 1 Abschnitt 3 | — |
+| Bemaßung, die nichts misst | **H-2** | keine Bemaßung, plus der Satz warum |
+| Kundenstimme, Logowand, Kennzahl, Laufband | Regel 12, `ZIEL.md` Nicht-Ziele | — |
+| „Architekt" in jeder Wortverbindung | Regel 13 | — |
+
+**Platzhalter-Token heißen `--pl-*`, nicht `--color-*` oder `--token-*`.** Der Präfix ist kein
+Geschmack: Er macht bei jedem späteren Blick sofort sichtbar, dass hier **kein** Systemwert steht.
+Wenn in Schritt 8 die Werteschicht entsteht, ist maschinell prüfbar, dass kein `--pl-` in sie
+gelangt ist.
+
+## 4 · Was jede Probe an Bewegung erklären muss
+
+Regel 8 gilt auch, wenn sich nichts bewegt. „Statisch" ist eine Angabe, keine Auslassung. Der Fuß
+nennt deshalb immer: **Anlass · Richtung · Dauer · Kurve · Ersatzverhalten**. Bei einer statischen
+Probe lautet die Antwort fünfmal „keine" plus der Satz, dass bei reduzierter Bewegung nichts an
+die Stelle tritt, **weil nichts wegfällt**.
+
+Das Verbot aus Schritt 2 gilt in jeder Probe: kein Element mit eigener Bewegung relativ zu seiner
+Fläche, kein bildlauffester Effekt (dort hatte die Referenz ihren greifbarsten Fehler).
+
+## 5 · Der Prüfblock — die Probe misst sich selbst
+
+**Anlass:** In P-01 stand unter der harten Kante eine Maßkette mit der Beschriftung „0", die
+tatsächlich 64 px breit war. Durch Lesen wäre das nie aufgefallen — es fiel beim Messen auf. Genau
+dieser Fehlertyp ist in einem Planblatt-Register der schwerste, weil H-2 ihn ausdrücklich
+verbietet: „Keine Bemaßung, die nichts misst."
+
+**Regel: Jede Probe wird im gerenderten Zustand gemessen, bevor sie Jonas erreicht.** Nicht im
+Quelltext — im Blatt.
+
+Der Prüfblock, im Browser gegen die geöffnete Probe:
+
+```js
+(() => {
+  // GÜLTIGKEIT ZUERST. Ist der Browser-Pane nicht dargestellt, ist clientWidth 0 —
+  // dann sind alle Breitenmessungen wertlos und melden falsche Überhänge.
+  const sichtbar = document.documentElement.clientWidth > 0;
+
+  const ketten = [...document.querySelectorAll('.mass-mitte')];
+  const paare = ketten.map(k => ({
+    beschriftet: k.textContent.trim(),
+    gemessen: Math.round(k.getBoundingClientRect().width)
+  }));
+
+  return {
+    messungGueltig: sichtbar,
+    // Breitenabhängige Werte nur melden, wenn wirklich gemessen werden konnte:
+    luegendeBemassung: sichtbar ? paare.filter(p => Number(p.beschriftet) !== p.gemessen) : 'nicht gemessen',
+    bodyScrolltSeitwaerts: sichtbar ? document.body.scrollWidth > document.documentElement.clientWidth : 'nicht gemessen',
+    // Breitenunabhängig, immer gültig:
+    bewegteElemente: [...document.querySelectorAll('*')].filter(e => {
+      const s = getComputedStyle(e);
+      return s.animationName !== 'none'
+          || (s.transitionDuration !== '0s' && s.transitionProperty !== 'none');
+    }).length,
+    fassungen: document.querySelectorAll('.fall').length,
+    platzhalterHinweise: document.body.innerHTML.match(/Platzhalter/gi)?.length ?? 0
+  };
+})()
+```
+
+**`messungGueltig: false` heißt: die Prüfung hat nicht stattgefunden.** Dann den Browser-Pane
+öffnen und erneut messen — nicht etwa die Probe „reparieren". Das ist keine Formalie: Beim ersten
+Einsatz dieses Blocks meldete er an der eigenen Vorlage einen seitwärts scrollenden Body. Der
+Befund war falsch — der Pane war nur nicht dargestellt, `clientWidth` also 0, und damit **jede**
+Breite ein scheinbarer Überhang. Ein Prüfer, der nicht sagen kann, ob er messen konnte, erzeugt
+Arbeit statt sie zu ersparen (dieselbe Lehre wie im UFW-Fall vom 2026-07-17, `QUALITY.md`).
+
+**Abnahmeschwellen:**
+
+- `messungGueltig` — **muss true sein.** Sonst zählt keine der Breitenmessungen.
+- `luegendeBemassung` — **muss leer sein.** Jede Abweichung ist ein H-2-Verstoß.
+- `bodyScrolltSeitwaerts` — **muss false sein.** Sonst ist die Probe auf dem Handy unbrauchbar,
+  und Jonas soll sie dort ansehen können.
+- `bewegteElemente` — muss zur Angabe im Fuß passen. Steht dort „keine Bewegung", muss hier 0
+  stehen.
+- `fassungen` — **mindestens 2** (E-023, `ZIEL.md` Muss-Ziele).
+- `platzhalterHinweise` — **mindestens 1.** Eine Probe ohne sichtbaren Platzhalterhinweis
+  verstößt gegen die Logik von E-014.
+
+Dazu die übliche Regelprüfung gegen die Diff, nicht gegen die ganze Datei: Farbwerte, Schriftnamen,
+Sperrbegriffe, Wirkbehauptungen, frühere Designstände.
+
+## 6 · Veröffentlichung und Live-Verfolgung
+
+**Jede Probe wird als Artifact veröffentlicht**, damit Jonas sie am Gerät ansehen kann — auch vom
+Smartphone. Das ist nicht Bequemlichkeit: `ZIEL.md` Erfolgskriterium 12 verlangt Wiedererkennung
+**am Gerät**, und Kriterium 11 die Abnahme am gebauten Stand statt an seiner Beschreibung. Eine
+Probe, die nur im Editor existiert, kann beides nicht leisten.
+
+**Dieselbe Datei behält dieselbe Adresse.** Wird eine Probe überarbeitet, wird sie unter derselben
+URL erneut veröffentlicht — kein neuer Link. Eine neue P-Nummer bekommt eine neue Adresse.
+
+**Was nicht veröffentlicht wird:** nichts mit echten Kundendaten, keine Visualisierung eines
+realen Projekts ohne Jonas' ausdrückliche Freigabe. Bis Schritt 9 ist das gegenstandslos —
+es gibt nur Platzhalter (O-007).
+
+**Der lokale Weg bleibt offen:** Ein Dev-Server im WLAN wäre technisch möglich, verlangt aber
+Änderungen an Bindung und Firewall. Das ist eine Systemänderung und braucht Jonas' ausdrückliches
+Wort (`CLAUDE.md`, Sicherheitsregeln).
+
+## 7 · Wann daraus ein Skill wird — noch nicht
+
+`SKILL_POLICY.md`: Skills entstehen aus echter, wiederkehrender Arbeit, **nicht auf Vorrat**. Eine
+Probe ist noch keine Wiederkehr. Dieses Raster ist deshalb eine **Vorlage im Projekt**, kein Skill.
+
+**Auslöser für die Skill-Frage:** wenn dieses Raster zum dritten Mal angewandt wurde und der
+Prüfblock dabei mindestens einmal einen echten Fehler gefunden hat. Dann ist belegt, dass sich das
+Verfahren lohnt — und erst dann wird es vorgelegt.
+
+## 8 · Vor jeder Probe: Ordnungsfrage oder Materialfrage?
+
+**Nachgetragen am 2026-08-02 nach der ersten Anwendung.** E-023 nahm an, Proben ohne Oberfläche
+seien immer entscheidbar („Was ohne Farbe trägt, trägt"). Probe P-01 hat gezeigt, dass das zu
+allgemein war — Jonas konnte nicht wählen, weil die Antwort am Material hängt (**E-024**, O-020).
+
+**Deshalb steht vor jeder Probe eine Frage an die Frage:**
+
+| | Ordnungsfrage | Materialfrage |
+|---|---|---|
+| **worum es geht** | Reihenfolge, Anschluss, Maßverhältnis, Dichte, Staffelung, Gliederung | Wirkung an einer Materialgrenze, Ton, Oberfläche, Licht |
+| **ohne Oberfläche entscheidbar?** | **ja** | **nein** |
+| **was die Probe dann leistet** | die Entscheidung | den Möglichkeitsraum und eine präzisere Frage |
+| **Beispiel** | „Welche Reihenfolge ist ablesbar?" | „Wie weich ist der Übergang?" (P-01) |
+
+**Eine Materialfrage ist trotzdem eine gute Probe** — nur mit anderem Ziel. Sie wird gebaut, um
+den Raum abzustecken, und ausdrücklich mit dem Vermerk versehen, dass die Wahl vertagt ist. Was
+sie nicht darf: so tun, als sei sie entscheidbar.
+
+**Im Zweifel Materialfrage annehmen.** Eine vertagte Entscheidung kostet nichts; eine getroffene,
+der die Grundlage fehlt, vererbt sich.
+
+## 9 · Was dieses Raster nicht regelt
+
+- **Wie eine Probe aussieht.** Das Register ist das Planblatt (E-010), aber Anordnung, Dichte und
+  Verhältnisse entstehen je Probe aus ihrer Frage.
+- **Wann eine Probe fällig ist.** E-023 sagt „vor jeder folgenreichen Festlegung" — was
+  folgenreich ist, entscheidet sich am Gegenstand.
+- **Wie viele Fassungen.** Mindestens zwei; die Obergrenze ergibt sich daraus, wie viele
+  Unterschiede man auf einem Blatt noch unterscheiden kann.
+- **Nichts über Farbe, Schrift oder Impulse.** Die bleiben gesperrt, bis ihre Schritte sie
+  herleiten.
+
+## Provenance
+
+Formalized by Open Design from candidate f3f44dd2-1e0f-4587-ae1f-8d4f8a75e6e3.

--- a/plugins/community/grundraster-f-r-proben-msfib2p9/open-design.json
+++ b/plugins/community/grundraster-f-r-proben-msfib2p9/open-design.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "grundraster-f-r-proben-msfib2p9",
+  "title": "Grundraster für Proben",
+  "version": "0.1.0",
+  "description": "--- name: RASTER.md zweck: Grundraster für Live-Artefakte — was eine Probe ist, wie sie gebaut wird, wie sie geprüft wird stand: 2026-08-02 herkunft: E-023 (Beispiele vor der Entscheidung), Regel 10, E-015. Erfahrungsgru",
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ]
+  }
+}

--- a/plugins/community/grundraster-f-r-proben-msfib2p9/references/provenance.json
+++ b/plugins/community/grundraster-f-r-proben-msfib2p9/references/provenance.json
@@ -1,0 +1,26 @@
+{
+  "candidateId": "f3f44dd2-1e0f-4587-ae1f-8d4f8a75e6e3",
+  "projectId": "01eaa930-f26b-4d12-bda2-2b6c48919dfa",
+  "runId": "b164857e-ac4a-4023-8963-3997589e76ac",
+  "conversationId": "efd570a2-3b8d-4352-a9c3-d0c2e9402e42",
+  "provenance": {
+    "summary": "Detected from RASTER.md, plan.md after a successful run.",
+    "detectedAt": 1785895968897
+  },
+  "sourceRefs": [
+    {
+      "kind": "file",
+      "value": "RASTER.md",
+      "label": "RASTER.md",
+      "size": 11329,
+      "copied": true
+    },
+    {
+      "kind": "file",
+      "value": "plan.md",
+      "label": "plan.md",
+      "size": 8465,
+      "copied": true
+    }
+  ]
+}

--- a/plugins/community/grundraster-f-r-proben-msfib2p9/references/source-1-RASTER.md
+++ b/plugins/community/grundraster-f-r-proben-msfib2p9/references/source-1-RASTER.md
@@ -1,0 +1,207 @@
+---
+name: RASTER.md
+zweck: Grundraster für Live-Artefakte — was eine Probe ist, wie sie gebaut wird, wie sie geprüft wird
+stand: 2026-08-02
+herkunft: E-023 (Beispiele vor der Entscheidung), Regel 10, E-015. Erfahrungsgrundlage ist
+  Probe P-01; der dort gefundene Bemaßungsfehler ist der Anlass für den Prüfblock.
+---
+
+# Grundraster für Proben
+
+Gilt für jedes Live-Artefakt unter `arbeit/proben/`. **Kein Planschritt** — Proben bekommen keine
+Schrittnummer, sondern eine P-Nummer.
+
+## 1 · Was eine Probe ist — und was sie nicht ist
+
+> **Eine Probe zeigt einen Unterschied, kein Ergebnis. Sie entscheidet nichts.**
+
+Das ist keine Bescheidenheitsformel, sondern die Anwendung von **E-015**: Die Entscheidung liegt
+beim Menschen. Eine Probe, die nur eine Fassung zeigt, ist keine Wahl — sie ist ein Vorschlag,
+und ein Vorschlag nimmt die Entscheidung vorweg.
+
+**Die Probe ist selbst ein Anwendungsfall des Kernbausteins.** E-015 verlangt von der Rahmung,
+dass sie „Fassung, Datum, offene Punkte und gemeinsam getroffene Entscheidungen" zeigt statt eines
+fertigen Urteils. Genau das leistet eine Probe. Was hier über Proben gelernt wird, geht in
+Schritt 6/7 in den Kernbaustein ein — nicht umgekehrt.
+
+| eine Probe | kein Entwurf |
+|---|---|
+| zeigt **mindestens zwei** Fassungen | zeigt eine Lösung |
+| benennt, was sie **nicht** zeigt | wirkt vollständig |
+| trägt ihren Vorbehalt sichtbar | trägt ihn in einer Fußnote |
+| stellt am Ende eine Frage | zieht am Ende ein Fazit |
+| darf **Gegenbilder** enthalten | zeigt nur Erwünschtes |
+
+**Gegenbilder** sind der eigentliche Gewinn: eine Fassung, die eine Regel bricht, macht die Regel
+sichtbar. Sie werden **immer markiert** — in P-01 durchgestrichen und mit „Gegenbild" oder
+„verworfen" beschriftet — und stehen nie zur Wahl.
+
+## 2 · Die sechs Teile eines Probenblatts
+
+Feste Reihenfolge. Fehlt einer, ist es keine Probe.
+
+1. **Kopf** — P-Nummer · Titel · `Arbeitsstand <Datum> · nicht abgenommen`.
+   Die Zeile „nicht abgenommen" steht immer, bis Jonas entschieden hat.
+2. **Vorbehalt** — was Platzhalter ist und was fehlt, mit E-Nummer. Sichtbar umrandet, nicht
+   kleingesetzt. Herkunft: **D-2** („Der Baustein ‚Grenzen' steht in derselben Größenordnung wie
+   der Baustein ‚Leistungen' — gleiche Schriftgröße, gleiche Ebene, nicht eingeklappt").
+3. **Leitsatz je Teil** — ein Satz, der sagt, was in diesem Teil variiert und was konstant bleibt.
+   Ohne ihn vergleicht man zwei Dinge, die sich in mehr als einer Größe unterscheiden.
+4. **Die Fassungen** — je Nummer, Name, Zeichnung, Maß, ein Satz zur Wirkung, Herkunft.
+5. **Die Frage** — was an dieser Probe entscheidbar ist, nummeriert. Und der Satz, dass die
+   Antwort als Entscheidung eingetragen und nicht aus der Probe abgelesen wird.
+6. **Fuß** — was ausgeschlossen ist, je mit E-Nummer, plus die Bewegungsangabe.
+
+## 3 · Was in einer Probe gesperrt ist
+
+Diese Liste ist der Grund, warum Proben vor Schritt 5 und 8 überhaupt möglich sind: Sie zeigen
+**Struktur ohne Oberfläche**.
+
+| gesperrt | Herkunft | was stattdessen |
+|---|---|---|
+| jeder Farbwert als Gestaltungsmittel | E-004 | **Dichte, Maß, Anordnung, Überlappung** |
+| jede Schriftwahl | E-011 | Systemstack, im Blatt als Platzhalter markiert |
+| Impulse, solange kein echtes Bild vorliegt | E-020, O-017 | nichts — `m = 0` ist der richtige Stand |
+| ein zweites Theme | E-017 | ein Theme; eine zweite Lichtsituation wäre eine zweite Grundlage |
+| Flächenbehandlung, Filter, Tönung über alles | Regel 7, Schritt 1 Abschnitt 3 | — |
+| Bemaßung, die nichts misst | **H-2** | keine Bemaßung, plus der Satz warum |
+| Kundenstimme, Logowand, Kennzahl, Laufband | Regel 12, `ZIEL.md` Nicht-Ziele | — |
+| „Architekt" in jeder Wortverbindung | Regel 13 | — |
+
+**Platzhalter-Token heißen `--pl-*`, nicht `--color-*` oder `--token-*`.** Der Präfix ist kein
+Geschmack: Er macht bei jedem späteren Blick sofort sichtbar, dass hier **kein** Systemwert steht.
+Wenn in Schritt 8 die Werteschicht entsteht, ist maschinell prüfbar, dass kein `--pl-` in sie
+gelangt ist.
+
+## 4 · Was jede Probe an Bewegung erklären muss
+
+Regel 8 gilt auch, wenn sich nichts bewegt. „Statisch" ist eine Angabe, keine Auslassung. Der Fuß
+nennt deshalb immer: **Anlass · Richtung · Dauer · Kurve · Ersatzverhalten**. Bei einer statischen
+Probe lautet die Antwort fünfmal „keine" plus der Satz, dass bei reduzierter Bewegung nichts an
+die Stelle tritt, **weil nichts wegfällt**.
+
+Das Verbot aus Schritt 2 gilt in jeder Probe: kein Element mit eigener Bewegung relativ zu seiner
+Fläche, kein bildlauffester Effekt (dort hatte die Referenz ihren greifbarsten Fehler).
+
+## 5 · Der Prüfblock — die Probe misst sich selbst
+
+**Anlass:** In P-01 stand unter der harten Kante eine Maßkette mit der Beschriftung „0", die
+tatsächlich 64 px breit war. Durch Lesen wäre das nie aufgefallen — es fiel beim Messen auf. Genau
+dieser Fehlertyp ist in einem Planblatt-Register der schwerste, weil H-2 ihn ausdrücklich
+verbietet: „Keine Bemaßung, die nichts misst."
+
+**Regel: Jede Probe wird im gerenderten Zustand gemessen, bevor sie Jonas erreicht.** Nicht im
+Quelltext — im Blatt.
+
+Der Prüfblock, im Browser gegen die geöffnete Probe:
+
+```js
+(() => {
+  // GÜLTIGKEIT ZUERST. Ist der Browser-Pane nicht dargestellt, ist clientWidth 0 —
+  // dann sind alle Breitenmessungen wertlos und melden falsche Überhänge.
+  const sichtbar = document.documentElement.clientWidth > 0;
+
+  const ketten = [...document.querySelectorAll('.mass-mitte')];
+  const paare = ketten.map(k => ({
+    beschriftet: k.textContent.trim(),
+    gemessen: Math.round(k.getBoundingClientRect().width)
+  }));
+
+  return {
+    messungGueltig: sichtbar,
+    // Breitenabhängige Werte nur melden, wenn wirklich gemessen werden konnte:
+    luegendeBemassung: sichtbar ? paare.filter(p => Number(p.beschriftet) !== p.gemessen) : 'nicht gemessen',
+    bodyScrolltSeitwaerts: sichtbar ? document.body.scrollWidth > document.documentElement.clientWidth : 'nicht gemessen',
+    // Breitenunabhängig, immer gültig:
+    bewegteElemente: [...document.querySelectorAll('*')].filter(e => {
+      const s = getComputedStyle(e);
+      return s.animationName !== 'none'
+          || (s.transitionDuration !== '0s' && s.transitionProperty !== 'none');
+    }).length,
+    fassungen: document.querySelectorAll('.fall').length,
+    platzhalterHinweise: document.body.innerHTML.match(/Platzhalter/gi)?.length ?? 0
+  };
+})()
+```
+
+**`messungGueltig: false` heißt: die Prüfung hat nicht stattgefunden.** Dann den Browser-Pane
+öffnen und erneut messen — nicht etwa die Probe „reparieren". Das ist keine Formalie: Beim ersten
+Einsatz dieses Blocks meldete er an der eigenen Vorlage einen seitwärts scrollenden Body. Der
+Befund war falsch — der Pane war nur nicht dargestellt, `clientWidth` also 0, und damit **jede**
+Breite ein scheinbarer Überhang. Ein Prüfer, der nicht sagen kann, ob er messen konnte, erzeugt
+Arbeit statt sie zu ersparen (dieselbe Lehre wie im UFW-Fall vom 2026-07-17, `QUALITY.md`).
+
+**Abnahmeschwellen:**
+
+- `messungGueltig` — **muss true sein.** Sonst zählt keine der Breitenmessungen.
+- `luegendeBemassung` — **muss leer sein.** Jede Abweichung ist ein H-2-Verstoß.
+- `bodyScrolltSeitwaerts` — **muss false sein.** Sonst ist die Probe auf dem Handy unbrauchbar,
+  und Jonas soll sie dort ansehen können.
+- `bewegteElemente` — muss zur Angabe im Fuß passen. Steht dort „keine Bewegung", muss hier 0
+  stehen.
+- `fassungen` — **mindestens 2** (E-023, `ZIEL.md` Muss-Ziele).
+- `platzhalterHinweise` — **mindestens 1.** Eine Probe ohne sichtbaren Platzhalterhinweis
+  verstößt gegen die Logik von E-014.
+
+Dazu die übliche Regelprüfung gegen die Diff, nicht gegen die ganze Datei: Farbwerte, Schriftnamen,
+Sperrbegriffe, Wirkbehauptungen, frühere Designstände.
+
+## 6 · Veröffentlichung und Live-Verfolgung
+
+**Jede Probe wird als Artifact veröffentlicht**, damit Jonas sie am Gerät ansehen kann — auch vom
+Smartphone. Das ist nicht Bequemlichkeit: `ZIEL.md` Erfolgskriterium 12 verlangt Wiedererkennung
+**am Gerät**, und Kriterium 11 die Abnahme am gebauten Stand statt an seiner Beschreibung. Eine
+Probe, die nur im Editor existiert, kann beides nicht leisten.
+
+**Dieselbe Datei behält dieselbe Adresse.** Wird eine Probe überarbeitet, wird sie unter derselben
+URL erneut veröffentlicht — kein neuer Link. Eine neue P-Nummer bekommt eine neue Adresse.
+
+**Was nicht veröffentlicht wird:** nichts mit echten Kundendaten, keine Visualisierung eines
+realen Projekts ohne Jonas' ausdrückliche Freigabe. Bis Schritt 9 ist das gegenstandslos —
+es gibt nur Platzhalter (O-007).
+
+**Der lokale Weg bleibt offen:** Ein Dev-Server im WLAN wäre technisch möglich, verlangt aber
+Änderungen an Bindung und Firewall. Das ist eine Systemänderung und braucht Jonas' ausdrückliches
+Wort (`CLAUDE.md`, Sicherheitsregeln).
+
+## 7 · Wann daraus ein Skill wird — noch nicht
+
+`SKILL_POLICY.md`: Skills entstehen aus echter, wiederkehrender Arbeit, **nicht auf Vorrat**. Eine
+Probe ist noch keine Wiederkehr. Dieses Raster ist deshalb eine **Vorlage im Projekt**, kein Skill.
+
+**Auslöser für die Skill-Frage:** wenn dieses Raster zum dritten Mal angewandt wurde und der
+Prüfblock dabei mindestens einmal einen echten Fehler gefunden hat. Dann ist belegt, dass sich das
+Verfahren lohnt — und erst dann wird es vorgelegt.
+
+## 8 · Vor jeder Probe: Ordnungsfrage oder Materialfrage?
+
+**Nachgetragen am 2026-08-02 nach der ersten Anwendung.** E-023 nahm an, Proben ohne Oberfläche
+seien immer entscheidbar („Was ohne Farbe trägt, trägt"). Probe P-01 hat gezeigt, dass das zu
+allgemein war — Jonas konnte nicht wählen, weil die Antwort am Material hängt (**E-024**, O-020).
+
+**Deshalb steht vor jeder Probe eine Frage an die Frage:**
+
+| | Ordnungsfrage | Materialfrage |
+|---|---|---|
+| **worum es geht** | Reihenfolge, Anschluss, Maßverhältnis, Dichte, Staffelung, Gliederung | Wirkung an einer Materialgrenze, Ton, Oberfläche, Licht |
+| **ohne Oberfläche entscheidbar?** | **ja** | **nein** |
+| **was die Probe dann leistet** | die Entscheidung | den Möglichkeitsraum und eine präzisere Frage |
+| **Beispiel** | „Welche Reihenfolge ist ablesbar?" | „Wie weich ist der Übergang?" (P-01) |
+
+**Eine Materialfrage ist trotzdem eine gute Probe** — nur mit anderem Ziel. Sie wird gebaut, um
+den Raum abzustecken, und ausdrücklich mit dem Vermerk versehen, dass die Wahl vertagt ist. Was
+sie nicht darf: so tun, als sei sie entscheidbar.
+
+**Im Zweifel Materialfrage annehmen.** Eine vertagte Entscheidung kostet nichts; eine getroffene,
+der die Grundlage fehlt, vererbt sich.
+
+## 9 · Was dieses Raster nicht regelt
+
+- **Wie eine Probe aussieht.** Das Register ist das Planblatt (E-010), aber Anordnung, Dichte und
+  Verhältnisse entstehen je Probe aus ihrer Frage.
+- **Wann eine Probe fällig ist.** E-023 sagt „vor jeder folgenreichen Festlegung" — was
+  folgenreich ist, entscheidet sich am Gegenstand.
+- **Wie viele Fassungen.** Mindestens zwei; die Obergrenze ergibt sich daraus, wie viele
+  Unterschiede man auf einem Blatt noch unterscheiden kann.
+- **Nichts über Farbe, Schrift oder Impulse.** Die bleiben gesperrt, bis ihre Schritte sie
+  herleiten.

--- a/plugins/community/grundraster-f-r-proben-msfib2p9/references/source-2-plan.md
+++ b/plugins/community/grundraster-f-r-proben-msfib2p9/references/source-2-plan.md
@@ -1,0 +1,142 @@
+---
+name: plan.md
+zweck: Planentwurf vor Umsetzung — Designsystem FreiRaum + Landingpage + Onepager A3 + Flyer A5
+stand: 2026-08-05
+---
+
+# Plan — FreiRaum: Designsystem, Landingpage, Onepager A3, Flyer A5
+
+Dieses Dokument ist ein Entwurf, keine Umsetzung. Bitte durchlesen, ändern, Fragen unten
+beantworten — danach geht es in den Bau.
+
+## 1. Was du beauftragt hast
+
+Ein hochwertiges, seriöses **persönliches Designsystem** zur Marke FreiRaum, mit dir als
+Auftraggeber und mir als ausführendem Senior-Verantwortlichem für responsives Webdesign/Engineering.
+Enthalten: **Landingpage, Onepager A3, Flyer A5.** Als Wahrheit gesetzt: `01_WORTARBEIT.md`,
+`09_WORTFELD-RAEUME.md`, die designrelevanten Ziele (`DESIGNRELEVANTE-GRUNDLAGE.md`,
+`ziele-designsystem-freiraum.md`). Dein Wort sticht, wo sich etwas nicht aus den Zielen herleiten
+lässt. Du denkst bildlich — Vergleiche zur Ansicht vor dem Kleingedruckten. Impulse sollen vorher
+als Thema vertieft werden, als Akzent. Skills: `taste-skill`, `frontend-design`,
+`minimalist-skill`, `research-decision-room`, `color-expert` — dazu unklar benannt eine
+„Raum"-Skill.
+
+## 2. Wichtig zuerst — das hier ist nicht Tag eins
+
+Bevor ich irgendetwas baue, der Stand, den ich beim Lesen gefunden habe: Dieses Designsystem läuft
+bereits als eigenes, ernsthaft geführtes Projekt (`finales-fdh-designsystem`, fünf Sitzungen seit
+2026-08-02, 29 dokumentierte Entscheidungen). Die Dateien hier in diesem Ordner sind eine Kopie
+seines Lesebestands. Das ändert die Ausgangslage:
+
+| Schritt | Zustand |
+|---|---|
+| 0 · 0.5 Gerüst, Zielklärung | abgenommen |
+| **1 Wortarbeit** | **abgenommen** |
+| 2 Saatkörner | geschrieben, **ungesprochen** |
+| 3 Impulse | geschrieben, **ungesprochen** |
+| 4 Bewegung … 10 Abnahme | nicht begonnen |
+| Probe P-01 Übergänge | veröffentlicht, **Wahl vertagt** (wartet auf Farbe/Bildmaterial) |
+
+**Fester Grundsatz aus `ZIEL.md`: „Ein Schritt, eine Datei, ein Stopp." Schritt 4 beginnt nicht,
+bevor 2 und 3 besprochen sind — unabhängig vom Material.** Dazu zwei weitere feste Regeln:
+
+- **Keine Farbe und keine Schrift vor ihrer Herleitung** — auch nicht vorläufig (E-004, E-011).
+  Beide werden erst in Schritt 5 gegen eine festgelegte Lichtsituation (bedecktes Tageslicht,
+  Innenraum, E-017) berechnet.
+- **Nicht-Ziel dieses Projekts, wörtlich aus `ZIEL.md`: „Keine Umsetzung der Website — das System
+  und eine Probe, nicht die fertige Seite."**
+
+Dieser Open-Design-Ordner ist im eigenen Plan sogar für eine bestimmte spätere Rolle vorgesehen:
+Werkstatt für Schritt 9 (Proben als lauffähige Artefakte), nicht für einen Vorgriff auf Schritt 10.
+
+**Kurz: dein heutiger Auftrag — Designsystem plus drei fertige Formate — geht über das hinaus, was
+der bisherige Plan für diesen Zeitpunkt vorsieht, und Farbe/Schrift sind an der Wurzel noch gar
+nicht hergeleitet.** Das benenne ich hier offen, statt es still zu übergehen oder still zu
+ignorieren — dein Wort steht über dem Plan, aber ich will, dass die Entscheidung bewusst und nicht
+versehentlich getroffen wird.
+
+## 3. Zwei Wege — deine Wahl
+
+**Weg A — im Bestand weiterarbeiten (meine Empfehlung).**
+Heute die Durchsprache von Schritt 2 (Saatkörner) und Schritt 3 (Impulse) nachholen — das deckt
+sich direkt mit deinem Wunsch, „Impulse vorher zu vertiefen": Schritt 3 *ist* die Impulsregel
+(„ein Impuls belegt Material, sitzt an der Kante, genau einer je Fläche"), aktuell mit Zahl null,
+weil noch keine echten Visualisierungen vorliegen. Danach der Reihe nach: 4 Bewegung ·
+5 Einflüsse/Räumlichkeit (hier fällt Farbe und Schrift) · 6 Räume · 7 Grammatik · 8 Werteschicht ·
+9 Proben (hier entstehen die lauffähigen Vergleiche, die du sehen willst) · 10 Abnahme. Landingpage,
+Onepager A3 und Flyer A5 entstehen danach, mit echter, hergeleiteter Farbe und Schrift statt
+Platzhaltern. Langsamer, aber deckungsgleich mit „Qualität vor Tempo" (Designziel 10) und mit der
+Herkunftspflicht, die du selbst als Maßstab gesetzt hast.
+
+**Weg B — bewusster Vorgriff.**
+Ich baue jetzt eine erste Fassung aller drei Formate mit **klar markierten Platzhalterwerten**
+für Farbe/Schrift/Bild (sichtbar als Platzhalter, nicht als fertiges Ergebnis getarnt — das ist
+selbst eine deiner Regeln, E-014). Vorteil: sofort etwas Bildliches zum Reagieren. Nachteil: jeder
+Farbwert und jede Schrift muss später verworfen und neu hergeleitet werden, sobald Schritt 5 läuft
+— das ist doppelte Arbeit, nicht Zeitgewinn, und widerspricht Nicht-Ziel „keine Umsetzung der
+Website" so lange, wie das System nicht steht.
+
+Sag mir, welcher Weg — oder ob du eine dritte Variante willst.
+
+## 4. Was sich direkt weiterverwenden lässt
+
+- **Visuelle Vergleiche sind bereits eingebaut, nicht neu zu erfinden.** Das Proben-Verfahren
+  (`RASTER.md` in diesem Ordner ist kein Rastersystem, sondern genau dieser Prüfprozess) verlangt
+  je Probe mindestens zwei bewusst verschiedene Fassungen nebeneinander — deckt deinen Wunsch nach
+  „gleichen Vergleichen zur Ansicht" strukturell ab. P-01 (Übergänge) existiert schon mit fünf
+  Verfahren an drei Weiten, nur die Wahl ist vertagt.
+- **Texte für alle drei Zielformate liegen zu großen Teilen schon geschrieben vor** (in
+  `finales-fdh-designsystem/konzept/`, hier noch nicht kopiert): `03_FLYER-TEXT.md` (87 Zeilen),
+  `04_ONEPAGER-TEXT.md` (69 Zeilen), `05_HANDZETTEL-A5-TEXT.md` (37 Zeilen),
+  `06_HANDZETTEL-A6-TEXT.md` (22 Zeilen). Format und Bezeichnung leicht abweichend von deinem
+  „Onepager A3" / „Flyer A5" — zu klären, ob das dieselben Formate sind oder neue Textarbeit nötig
+  wird.
+- **`assets/` (16 KI-Collagen, im Schwesterprojekt) sind ausdrücklich nur Inspirationsquelle**
+  (Entscheidung vom heutigen Tag) — kein Bild-, Farb- oder Stilwert daraus geht ins System ein.
+  Falls du sie als Vergleich sehen willst, kann ich sie so zeigen, aber nicht als Materialquelle
+  behandeln.
+
+## 5. Deine Skill-Liste — geprüft
+
+Alle fünf klar benannten Skills existieren in der Community-Sammlung
+(`opendesign/skills/`) und zählen laut Projektregeln als **nutzbares Werkzeug, reiner Text** —
+mit einer Einschränkung: sie dürfen **Verfahren/Maßstab** liefern, niemals selbst Farbe, Schrift
+oder Bild (das bleibt hergeleitet, Regel 5 „Bauweise, nicht Bildmaterial").
+
+| Skill | Gefunden | Einsatzort im Ablauf |
+|---|---|---|
+| `taste-skill` | ja | Anti-Slop-Abgleich, sinnvoll in Schritt 5 (Standards) und 9 (Proben) |
+| `frontend-design` | ja | Umsetzungsqualität, Schritt 9/10 |
+| `minimalist-skill` | ja | Zurückhaltungsprüfung, passt zu Designziel 5 „Harmonie" |
+| `research-decision-room` | ja | Entscheidungsfindung — passt gut auf **heute**: Weg A/B, O-007 |
+| `color-expert` | ja, aber **mit Vorbehalt**: im Schwesterprojekt als möglicher Stub markiert
+  (Bestandswarnung B-003, ungeprüft) — vor Einsatz in Schritt 5 kurz gegenprüfen |
+
+**Geklärt:** keine eigene „Raum"-Skill — gemeint sind `research-decision-room` und `color-expert`
+für den Räumlichkeits-/Farbaspekt. Beide bestätigt, `color-expert` bleibt mit dem Stub-Vorbehalt
+oben.
+
+## 6. Der eine Punkt, der am meisten weiterhilft: O-007
+
+Der größte Engpass im gesamten Projekt ist laut Status **nicht** ein Designentscheid, sondern eine
+fehlende Angabe: **der Ordner, in dem deine überarbeiteten Visualisierungen liegen.** Daran hängen
+drei Stränge gleichzeitig — der Kernbaustein (Rahmung), die Impulszahl (aktuell 0) und die
+Übergangs-Probe P-01. Ein Satz von dir („die liegen in …") löst mehr als jede Designentscheidung
+an dieser Stelle.
+
+## 7. Fragen an dich
+
+1. **Weg A oder Weg B** (Abschnitt 3) — oder etwas drittes? *(noch offen)*
+2. **O-007:** wo liegen die überarbeiteten Visualisierungen? *(noch offen)*
+3. ~~Ist „Raum"-Skill = `research-decision-room`, oder meintest du eine andere?~~ **geklärt:**
+   `research-decision-room` und `color-expert`, keine separate Skill.
+4. Sind „Onepager A3" und „Flyer A5" dieselben Formate wie die vorbereiteten Texte
+   (`04_ONEPAGER-TEXT.md`, `05_HANDZETTEL-A5-TEXT.md`), oder eigenständig neu zu denken?
+   *(noch offen)*
+
+## Nächster Schritt
+
+Bitte dieses Dokument prüfen/ändern und die vier Fragen beantworten. Sag mir auch kurz, ob ich bei
+„Weg A" gleich heute mit der Durchsprache von Schritt 2 (Saatkörner) und Schritt 3 (Impulse)
+beginnen soll — das ist der einzige Schritt, der ohne neue Informationen von dir sofort startklar
+ist.


### PR DESCRIPTION
Add Grundraster für Proben (grundraster-f-r-proben-msfib2p9) plugin.
Version: 0.1.0
Description: --- name: RASTER.md zweck: Grundraster für Live-Artefakte — was eine Probe ist, wie sie gebaut wird, wie sie geprüft wird stand: 2026-08-02 herkunft: E-023 (Beispiele vor der Entscheidung), Regel 10, E-015. Erfahrungsgru