### PR TITLE
fix(prerelease): retry NSIS install; fail Setup NSIS loudly instead of dying mid-build

### DIFF
--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -925,10 +925,29 @@ jobs:
       - name: Setup NSIS
         shell: pwsh
         run: |
-          if ((Get-Command makensis.exe -ErrorAction SilentlyContinue) -or (Test-Path "C:\Program Files (x86)\NSIS\makensis.exe")) {
-            exit 0
+          # windows-latest no longer guarantees a preinstalled NSIS, and the
+          # Chocolatey community feed flakes: prerelease.4 hit a silent
+          # "Unable to find package 'nsis'" fetch failure that left this step
+          # green (pwsh -command does not propagate choco's exit code) and let
+          # the build die on makensis half an hour later. Retry the install
+          # and hard-fail HERE, with a clear message, if makensis still cannot
+          # be found — a red Setup NSIS step is diagnosable; a mid-build
+          # makensis error is not.
+          function Test-Makensis {
+            [bool]((Get-Command makensis.exe -ErrorAction SilentlyContinue) -or (Test-Path "C:\Program Files (x86)\NSIS\makensis.exe"))
           }
-          choco install nsis -y --no-progress
+          if (Test-Makensis) { Write-Host "makensis already present"; exit 0 }
+          foreach ($attempt in 1..4) {
+            Write-Host "choco install nsis (attempt $attempt)"
+            choco install nsis -y --no-progress
+            if (Test-Makensis) { break }
+            Start-Sleep -Seconds (15 * $attempt)
+          }
+          if (-not (Test-Makensis)) {
+            Write-Error "NSIS install failed after 4 attempts: makensis absent from PATH and C:\Program Files (x86)\NSIS"
+            exit 1
+          }
+          Write-Host "NSIS ready"
       - name: Build prerelease windows artifacts
         id: win_tools_pack_build
         shell: pwsh


### PR DESCRIPTION
## Why
prerelease.4's win build died on `makensis is required…` **half an hour after a green Setup NSIS step**. The step's choco install hit a Chocolatey community-feed flake (`Unable to find package 'nsis'… installed 0/0`), and `pwsh -command` does not propagate choco's exit code — so the step passed having installed nothing, and the failure surfaced as an undiagnosable mid-build error.

## What
- Retry `choco install nsis` up to 4 times with linear backoff.
- Hard-verify makensis (PATH or default install dir) after installing; if still absent, **fail the Setup NSIS step itself** with a clear message.

Same detection paths tools-pack checks (`tools/pack/src/win/custom-installer.ts:308-322`). No behavior change when NSIS is already present.

## Surface area
- [x] CI / release workflow (`.github/workflows/release-prerelease.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)