### PR TITLE
ci(release): forward-port the four prerelease workflow fixes from release/v0.18.0

### DIFF
--- a/.github/workflows/notify-release-feishu.yml
+++ b/.github/workflows/notify-release-feishu.yml
@@ -36,6 +36,16 @@ on:
         required: false
         type: string
         default: ""
+      amr_profile:
+        description: "Optional AMR profile to bake (test / feature-test enable the Workspace Team transport). Empty uses the per-branch default: test on release/v0.18.0, otherwise prod."
+        required: false
+        type: string
+        default: ""
+      win_x64_smoke_mode:
+        description: "Windows x64 packaged smoke coverage (skip/core/full). Empty uses the per-branch default: skip on release/v0.18.0 to bypass the known packaged-win smoke flake that gates publish, otherwise release-prerelease's own default."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: write
@@ -65,6 +75,21 @@ jobs:
       # version). Only set when building from a non-release ref like main, where
       # release-prerelease cannot derive the base version from the branch name.
       release_version: ${{ inputs.release_version }}
+      # Workspace Team gate: the packaged prerelease only enables the vela-cli
+      # transports when a test/feature-test AMR profile is baked in (see
+      # apps/packaged/src/workspace-team.ts + release-prerelease.yml). A manual
+      # dispatch can pass amr_profile explicitly; otherwise release/v0.18.0 — the
+      # workspace-team release cycle — defaults to `test` so its auto push-built
+      # prereleases ship the transport enabled, while every other release branch
+      # stays on prod. Drop the branch default once workspace-team ships to prod.
+      amr_profile: ${{ inputs.amr_profile || (github.ref_name == 'release/v0.18.0' && 'test') || '' }}
+      # Windows packaged smoke is a hard publish gate (publish needs build_win
+      # success) but currently flakes on release/v0.18.0 ("did not reach main app
+      # shell"), skip-blocking EVERY platform's publish + the Feishu card. TEMPORARY:
+      # skip it on release/v0.18.0 so the workspace-team prerelease can actually
+      # ship its mac/win/linux packages + post its card. Manual dispatch overrides.
+      # Remove this branch default once the win smoke flake root cause is fixed.
+      win_x64_smoke_mode: ${{ inputs.win_x64_smoke_mode || (github.ref_name == 'release/v0.18.0' && 'skip') || '' }}
 
   notify:
     name: Notify Feishu (release)

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -12,6 +12,11 @@ on:
         required: false
         type: string
         default: ""
+      amr_profile:
+        description: "Optional AMR profile baked into the build (test or feature-test point the packaged app at that profile's Vela backend and enable the workspace-team transport). Empty leaves the default (prod)."
+        required: false
+        type: string
+        default: ""
       win_x64_smoke_mode:
         description: "Windows x64 smoke coverage."
         required: true
@@ -40,6 +45,11 @@ on:
         default: ""
       release_version:
         description: "Base version (x.y.z). Required when ref is not release/vX.Y.Z."
+        required: false
+        type: string
+        default: ""
+      amr_profile:
+        description: "Optional AMR profile baked into the build (test or feature-test enable the workspace-team transport by pointing at that profile's Vela backend). Empty leaves the default (prod)."
         required: false
         type: string
         default: ""
@@ -110,6 +120,16 @@ env:
   # and the helper still strips .map to keep source out of the installer.
   POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
   POSTHOG_CLI_PROJECT_ID: ${{ vars.POSTHOG_CLI_PROJECT_ID }}
+  # Workspace Team gate for packaged prerelease builds. tools-pack reads
+  # OPEN_DESIGN_AMR_PROFILE and bakes OD_VELA_WEB_URL into open-design-config.json;
+  # both are required for the packaged daemon to enable the workspace-team
+  # transport (see apps/packaged/src/workspace-team.ts). Empty amr_profile leaves
+  # the default (prod), which the packaged gate rejects, so the normal push-driven
+  # prerelease pipeline stays unchanged. A test / feature-test dispatch points at
+  # the matching per-profile Vela console origin held in a repository secret.
+  # Secrets read here: VELA_WEB_URL_FEATURE_TEST, VELA_WEB_URL_TEST.
+  OPEN_DESIGN_AMR_PROFILE: ${{ inputs.amr_profile }}
+  OD_VELA_WEB_URL: ${{ inputs.amr_profile == 'feature-test' && secrets.VELA_WEB_URL_FEATURE_TEST || inputs.amr_profile == 'test' && secrets.VELA_WEB_URL_TEST || '' }}
 jobs:
   metadata:
     name: Prepare prerelease metadata
@@ -905,10 +925,29 @@ jobs:
       - name: Setup NSIS
         shell: pwsh
         run: |
-          if ((Get-Command makensis.exe -ErrorAction SilentlyContinue) -or (Test-Path "C:\Program Files (x86)\NSIS\makensis.exe")) {
-            exit 0
+          # windows-latest no longer guarantees a preinstalled NSIS, and the
+          # Chocolatey community feed flakes: prerelease.4 hit a silent
+          # "Unable to find package 'nsis'" fetch failure that left this step
+          # green (pwsh -command does not propagate choco's exit code) and let
+          # the build die on makensis half an hour later. Retry the install
+          # and hard-fail HERE, with a clear message, if makensis still cannot
+          # be found — a red Setup NSIS step is diagnosable; a mid-build
+          # makensis error is not.
+          function Test-Makensis {
+            [bool]((Get-Command makensis.exe -ErrorAction SilentlyContinue) -or (Test-Path "C:\Program Files (x86)\NSIS\makensis.exe"))
           }
-          choco install nsis -y --no-progress
+          if (Test-Makensis) { Write-Host "makensis already present"; exit 0 }
+          foreach ($attempt in 1..4) {
+            Write-Host "choco install nsis (attempt $attempt)"
+            choco install nsis -y --no-progress
+            if (Test-Makensis) { break }
+            Start-Sleep -Seconds (15 * $attempt)
+          }
+          if (-not (Test-Makensis)) {
+            Write-Error "NSIS install failed after 4 attempts: makensis absent from PATH and C:\Program Files (x86)\NSIS"
+            exit 1
+          }
+          Write-Host "NSIS ready"
       - name: Build prerelease windows artifacts
         id: win_tools_pack_build
         shell: pwsh


### PR DESCRIPTION
Brings main's release workflows in parity with release/v0.18.0, where four fixes were landed directly during the workspace-team prerelease cycle. Without this, the next release branch cut from main re-inherits every one of these problems:

| fix | landed on release as |
|---|---|
| `amr_profile` input + `OPEN_DESIGN_AMR_PROFILE`/`OD_VELA_WEB_URL` injection in `release-prerelease.yml` (Workspace Team transport gate) | #6435 |
| `notify-release-feishu` forwards `amr_profile`, per-branch default `test` on release/v0.18.0 | #6437 |
| `notify-release-feishu` forwards `win_x64_smoke_mode`, per-branch default `skip` on release/v0.18.0 (unattended win smoke lands on cloud onboarding) | #6447 |
| Setup NSIS: retry choco with backoff + hard-fail loudly (feed flake left the step green and killed the build 30min later) | #6452 |

Verified: `git diff origin/main origin/release/v0.18.0` over these two files contains exactly these changes and nothing else — this PR copies the release versions wholesale. The v0.18.0-specific branch defaults are inert on other branches and documented in-line as temporary.

## Surface area
- [x] CI / release workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)