### PR TITLE
fix daemon Langfuse tool status noise

### DIFF
--- a/apps/daemon/src/langfuse-bridge.ts
+++ b/apps/daemon/src/langfuse-bridge.ts
@@ -552,6 +552,7 @@ function collectAgentEvents(
         typeof data.label === 'string' && data.label.length > 0
           ? data.label
           : 'working';
+      if (label === 'tool_call' || label === 'tool_call_update') continue;
       const index = statusCounts.get(label) ?? 0;
       statusCounts.set(label, index + 1);
       out.push({

--- a/apps/daemon/tests/langfuse-bridge.test.ts
+++ b/apps/daemon/tests/langfuse-bridge.test.ts
@@ -464,6 +464,87 @@ describe('langfuse-bridge.reportRunCompletedFromDaemon', () => {
     });
   });
 
+  it('keeps canonical tool spans without projecting ACP tool snapshot statuses', async () => {
+    await writeAppCfg({
+      installationId: 'install-uuid-1',
+      telemetry: { metrics: true, content: true, artifactManifest: false },
+    });
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(new Response('{}', { status: 207 }));
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk';
+    process.env.LANGFUSE_SECRET_KEY = 'sk';
+    try {
+      await reportRunCompletedFromDaemon({
+        db: makeDbWithListMessages({
+          'conv-1': [
+            {
+              id: 'msg-1',
+              role: 'assistant',
+              content: '',
+              producedFiles: [],
+            },
+          ],
+        }),
+        dataDir,
+        run: makeRun({
+          agentId: 'amr',
+          events: [
+            {
+              id: 1,
+              event: 'agent',
+              data: { type: 'status', label: 'initializing' },
+            },
+            {
+              id: 2,
+              event: 'agent',
+              data: { type: 'status', label: 'tool_call' },
+            },
+            {
+              id: 3,
+              event: 'agent',
+              data: {
+                type: 'tool_use',
+                id: 'call-1',
+                name: 'Bash',
+                input: { command: 'pwd' },
+              },
+            },
+            {
+              id: 4,
+              event: 'agent',
+              data: { type: 'status', label: 'tool_call_update' },
+            },
+            {
+              id: 5,
+              event: 'agent',
+              data: {
+                type: 'tool_result',
+                toolUseId: 'call-1',
+                content: '/tmp',
+                isError: false,
+              },
+            },
+          ] as any,
+        }) as any,
+        fetchImpl: fetchSpy as any,
+      });
+    } finally {
+      delete process.env.LANGFUSE_PUBLIC_KEY;
+      delete process.env.LANGFUSE_SECRET_KEY;
+    }
+
+    const init = fetchSpy.mock.calls[0]![1] as RequestInit;
+    const batch = JSON.parse(init.body as string).batch as any[];
+    expect(bodyOf(batch, 'span-create', 'tool:Bash')).toBeTruthy();
+    expect(bodyOf(batch, 'event-create', 'agent-status:initializing')).toBeTruthy();
+    const names = batch
+      .filter((item) => item.type === 'event-create')
+      .map((item) => item.body.name);
+    expect(names).not.toContain('agent-status:tool_call');
+    expect(names).not.toContain('agent-status:tool_call_update');
+  });
+
   it('marks trace-safe object manifests partial when object accounting is incomplete', async () => {
     await writeAppCfg({
       installationId: 'install-uuid-1',


### PR DESCRIPTION
## Why

While investigating an AMR `request_too_large` failure, one run produced hundreds of Langfuse agent events for `tool_call` and `tool_call_update`. These are ACP transport snapshot labels, while the same executions are already represented by canonical tool spans.

The duplicate projection makes traces much larger and obscures the useful lifecycle events needed for incident diagnosis.

## What users will see

There is no UI change. Langfuse traces keep canonical tool spans and useful agent statuses, but no longer include `agent-status:tool_call` or `agent-status:tool_call_update` events.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this changes internal observability projection only.

## Bug fix verification

- Test path: `apps/daemon/tests/langfuse-bridge.test.ts`
- The regression spec failed before the source change and passes on this branch.
- The spec also verifies that canonical `tool:Bash` spans remain present.

## Validation

- `corepack pnpm --filter @open-design/daemon exec vitest run tests/langfuse-bridge.test.ts tests/langfuse-trace.test.ts` — 122 tests passed
- `corepack pnpm guard`
- `corepack pnpm typecheck`
