### PR TITLE
fix(landing): point Cloud links at the production dashboard

### DIFF
--- a/apps/landing-page/app/_components/header.tsx
+++ b/apps/landing-page/app/_components/header.tsx
@@ -36,7 +36,7 @@ const CLOUD_API_BASE =
 const CLOUD_CONSOLE_URL =
   env.PUBLIC_CLOUD_CONSOLE_URL ??
   env.PUBLIC_AMR_CONSOLE_URL ??
-  'https://open-design.ai/cloud/wallet?source=open_design';
+  'https://open-design.ai/cloud/dashboard?source=open_design';
 
 // Solution → Use cases / Roles. Hrefs mirror upstream main's header 1:1 and
 // pair positionally with the localized `useCaseItems` / `roleItems` tuples.

--- a/apps/landing-page/app/_lib/pricing.ts
+++ b/apps/landing-page/app/_lib/pricing.ts
@@ -80,7 +80,7 @@ export interface PricingContract {
 }
 
 /** Production dashboard that owns the authenticated billing-plan dialog. */
-export const CLOUD_BASE_URL = 'https://vela.powerformer.net/dashboard';
+export const CLOUD_BASE_URL = 'https://open-design.ai/cloud/dashboard';
 
 /** Public pricing contract served by the landing page. */
 export const PLANS_JSON_URL = '/pricing/plans.json';

--- a/apps/landing-page/public/pricing.md
+++ b/apps/landing-page/public/pricing.md
@@ -80,6 +80,6 @@ not required to use Open Design.
 - Overage cloud deploys beyond a tier's monthly limit: $2 each.
 - Intro/promotional pricing and current annual discounts may differ — see the
   live pricing page for the current numbers: https://open-design.ai/pricing/
-- Subscription checkout is handled by the authenticated Vela dashboard:
-  https://vela.powerformer.net/dashboard?billing=plan
+- Subscription checkout is handled by the authenticated Cloud dashboard:
+  https://open-design.ai/cloud/dashboard?billing=plan
 - License: https://www.apache.org/licenses/LICENSE-2.0

--- a/apps/landing-page/tests/pricing-contract.test.ts
+++ b/apps/landing-page/tests/pricing-contract.test.ts
@@ -82,15 +82,15 @@ describe("pricing contract", () => {
   it("uses Vela's stable billing-plan deep link instead of wallet-era aliases", () => {
     assert.equal(
       CLOUD_CONSOLE_URL,
-      "https://vela.powerformer.net/dashboard?billing=plan",
+      "https://open-design.ai/cloud/dashboard?billing=plan",
     );
     assert.equal(
       cloudSubscribeUrl("pro", "yearly"),
-      "https://vela.powerformer.net/dashboard?billing=plan",
+      "https://open-design.ai/cloud/dashboard?billing=plan",
     );
     assert.equal(
       scopedBillingPlanUrl("workspace-a"),
-      "https://vela.powerformer.net/dashboard?billing=plan&workspaceId=workspace-a",
+      "https://open-design.ai/cloud/dashboard?billing=plan&workspaceId=workspace-a",
     );
     assert.equal(scopedBillingPlanUrl("  "), CLOUD_CONSOLE_URL);
   });


### PR DESCRIPTION
## Why

The public pricing page routed subscription checkout to the **internal test console**:

```
CLOUD_BASE_URL = 'https://vela.powerformer.net/dashboard'   ← test env, on the public site
```

Its own docblock says *"Production dashboard that owns the authenticated billing-plan dialog"* — the constant simply never got repointed. Anyone clicking through to subscribe from open-design.ai landed on a non-production environment.

## What

| file | change |
|---|---|
| `_lib/pricing.ts` | `CLOUD_BASE_URL` → `https://open-design.ai/cloud/dashboard` |
| `public/pricing.md` | same, machine-readable pricing contract |
| `_components/header.tsx` | console link `/cloud/wallet` → `/cloud/dashboard` |
| `tests/pricing-contract.test.ts` | assertions updated to lock the production URLs |

**`?billing=plan` is preserved** and verified to be consumed on the destination: vela's `apps/web/src/routes/team-dashboard.tsx` reads `searchParams.get("billing") === "plan"` to open the plan dialog.

**wallet → dashboard**: wallet is the pre-workspace surface being retired; vela already rewrites `/wallet` → `/dashboard` on workspace selection (`lib/workspace-selector.ts`), so this aligns the marketing entry point with where the product now lands users.

## Validation

`pnpm --filter @open-design/landing-page test` → **93 passed, 0 failed**

## Surface area
- [x] Landing page (public marketing site)

🤖 Generated with [Claude Code](https://claude.com/claude-code)