### PR TITLE
feat(packaged): ship Workspace Team on production builds

### DIFF
--- a/.github/workflows/notify-release-feishu.yml
+++ b/.github/workflows/notify-release-feishu.yml
@@ -75,14 +75,16 @@ jobs:
       # version). Only set when building from a non-release ref like main, where
       # release-prerelease cannot derive the base version from the branch name.
       release_version: ${{ inputs.release_version }}
-      # Workspace Team gate: the packaged prerelease only enables the vela-cli
-      # transports when a test/feature-test AMR profile is baked in (see
-      # apps/packaged/src/workspace-team.ts + release-prerelease.yml). A manual
-      # dispatch can pass amr_profile explicitly; otherwise release/v0.18.0 — the
-      # workspace-team release cycle — defaults to `test` so its auto push-built
-      # prereleases ship the transport enabled, while every other release branch
-      # stays on prod. Drop the branch default once workspace-team ships to prod.
-      amr_profile: ${{ inputs.amr_profile || (github.ref_name == 'release/v0.18.0' && 'test') || '' }}
+      # Workspace Team profile baked into the packaged build (see
+      # apps/packaged/src/workspace-team.ts + release-prerelease.yml). Release
+      # builds ship `prod`: production's Vela backend now serves the feature, so
+      # a release prerelease points users at the production console rather than
+      # an internal test environment. A manual dispatch can still override to
+      # test / feature-test to cut a build against those backends.
+      #
+      # (This replaces a temporary `test` default on release/v0.18.0 that
+      # existed only while prod's resource-hub storage was unconfigured.)
+      amr_profile: ${{ inputs.amr_profile || 'prod' }}
       # Windows packaged smoke is a hard publish gate (publish needs build_win
       # success) but currently flakes on release/v0.18.0 ("did not reach main app
       # shell"), skip-blocking EVERY platform's publish + the Feishu card. TEMPORARY:

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -123,13 +123,21 @@ env:
   # Workspace Team gate for packaged prerelease builds. tools-pack reads
   # OPEN_DESIGN_AMR_PROFILE and bakes OD_VELA_WEB_URL into open-design-config.json;
   # both are required for the packaged daemon to enable the workspace-team
-  # transport (see apps/packaged/src/workspace-team.ts). Empty amr_profile leaves
-  # the default (prod), which the packaged gate rejects, so the normal push-driven
-  # prerelease pipeline stays unchanged. A test / feature-test dispatch points at
-  # the matching per-profile Vela console origin held in a repository secret.
-  # Secrets read here: VELA_WEB_URL_FEATURE_TEST, VELA_WEB_URL_TEST.
+  # transport (see apps/packaged/src/workspace-team.ts).
+  #
+  # Every profile now resolves an origin, production included: prod's Vela
+  # backend serves the feature (WORKSPACE_TEAM_ENABLED plus a configured
+  # resource-hub blob store), so a prod build ships the transports enabled.
+  # An empty amr_profile still yields no origin, which the packaged gate treats
+  # as dormant — a build that forgets the profile degrades to local-only rather
+  # than pointing at an unknown backend.
+  #
+  # Origins stay in repository secrets rather than literals: the non-prod AMR
+  # environments are internal deployments and this repository is public.
+  # Secrets read here: VELA_WEB_URL_FEATURE_TEST, VELA_WEB_URL_TEST,
+  # VELA_WEB_URL_PROD.
   OPEN_DESIGN_AMR_PROFILE: ${{ inputs.amr_profile }}
-  OD_VELA_WEB_URL: ${{ inputs.amr_profile == 'feature-test' && secrets.VELA_WEB_URL_FEATURE_TEST || inputs.amr_profile == 'test' && secrets.VELA_WEB_URL_TEST || '' }}
+  OD_VELA_WEB_URL: ${{ inputs.amr_profile == 'feature-test' && secrets.VELA_WEB_URL_FEATURE_TEST || inputs.amr_profile == 'test' && secrets.VELA_WEB_URL_TEST || inputs.amr_profile == 'prod' && secrets.VELA_WEB_URL_PROD || '' }}
 jobs:
   metadata:
     name: Prepare prerelease metadata

--- a/apps/packaged/src/workspace-team.ts
+++ b/apps/packaged/src/workspace-team.ts
@@ -1,10 +1,20 @@
 /**
  * AMR profiles whose Vela backend serves the Workspace Team transports.
- * Production deliberately stays outside this allowlist until the feature is
- * released independently of the integration branch.
+ *
+ * Production joined this allowlist once its Vela backend was actually able to
+ * serve the feature: `WORKSPACE_TEAM_ENABLED` (plus the three billing-scope
+ * flags) is true on prod amr-api, and the resource hub it needs for team file
+ * sharing is configured — an S3-backed blob store rather than the chart's mock
+ * default, which would have failed every push with `unsupported protocol
+ * scheme "mock"` while comments (Postgres) kept syncing.
+ *
+ * The second half of the gate below still applies to prod: without an injected
+ * Vela web origin the transports stay dormant, so a build that forgets it
+ * degrades to local-only instead of pointing at an unknown backend.
  */
 const WORKSPACE_TEAM_AMR_PROFILES: ReadonlySet<string> = new Set([
   "feature-test",
+  "prod",
   "test",
 ]);
 

--- a/apps/packaged/tests/sidecars.test.ts
+++ b/apps/packaged/tests/sidecars.test.ts
@@ -634,12 +634,30 @@ describe('buildPackagedDaemonSpawnEnv', () => {
     }
   });
 
-  // The profile allowlist is the load-bearing half of the gate: moving the
-  // origin out of the source tree and into a build-time injection must not
-  // create a path where a `prod` bundle can be handed an origin and quietly
-  // turn the unreleased workspace-team transports on for every stable user.
-  it('never enables the workspace-team transport for a prod build, even with an injected vela web origin', () => {
-    for (const amrProfile of ['prod', 'local', null] as const) {
+  // Workspace Team is released, so a prod bundle handed an origin now turns the
+  // transports on — that is the shipping path for stable users.
+  it('enables the workspace-team transport for a prod build with an injected vela web origin', () => {
+    const env = buildPackagedDaemonSpawnEnv(fakePaths(), {
+      appVersion: null,
+      amrProfile: 'prod',
+      daemonCliEntry: null,
+      legacyDataDir: null,
+      requireDesktopAuth: true,
+      velaWebUrl: 'https://open-design.ai/cloud',
+    });
+    expect(env.OD_WORKSPACE_CONTEXT_SOURCE).toBe('vela');
+    expect(env.OD_TEAM_PROJECTS_TRANSPORT).toBe('vela-cli');
+    expect(env.OD_COLLAB_TRANSPORT).toBe('vela-cli');
+    expect(env.OD_RESOURCE_TRANSPORT).toBe('vela-cli');
+    expect(env.OD_VELA_WEB_URL).toBe('https://open-design.ai/cloud');
+  });
+
+  // The profile allowlist remains the load-bearing half of the gate for every
+  // profile that is NOT a released Vela backend: a `local` or profile-less
+  // bundle handed an origin must still stay dormant rather than point the
+  // transports at a backend that does not serve them.
+  it('never enables the workspace-team transport for a local or profile-less build', () => {
+    for (const amrProfile of ['local', null] as const) {
       const env = buildPackagedDaemonSpawnEnv(fakePaths(), {
         appVersion: null,
         amrProfile,
@@ -654,6 +672,23 @@ describe('buildPackagedDaemonSpawnEnv', () => {
       expect('OD_RESOURCE_TRANSPORT' in env).toBe(false);
       expect('OD_VELA_WEB_URL' in env).toBe(false);
     }
+  });
+
+  // The origin half of the gate is what protects a misconfigured prod build:
+  // no injected origin means dormant, never a guessed backend.
+  it('keeps a prod build dormant when no vela web origin was injected', () => {
+    const env = buildPackagedDaemonSpawnEnv(fakePaths(), {
+      appVersion: null,
+      amrProfile: 'prod',
+      daemonCliEntry: null,
+      legacyDataDir: null,
+      requireDesktopAuth: true,
+    });
+    expect('OD_WORKSPACE_CONTEXT_SOURCE' in env).toBe(false);
+    expect('OD_TEAM_PROJECTS_TRANSPORT' in env).toBe(false);
+    expect('OD_COLLAB_TRANSPORT' in env).toBe(false);
+    expect('OD_RESOURCE_TRANSPORT' in env).toBe(false);
+    expect('OD_VELA_WEB_URL' in env).toBe(false);
   });
 
   it('forwards POSTHOG_KEY/POSTHOG_HOST to the daemon spawn env when baked into the bundle', () => {

--- a/apps/packaged/tests/workspace-team.test.ts
+++ b/apps/packaged/tests/workspace-team.test.ts
@@ -15,8 +15,27 @@ describe('workspaceTeamTransportEnv', () => {
     });
   });
 
-  it('keeps production and an origin-less feature-test dormant', () => {
-    expect(workspaceTeamTransportEnv('prod', 'https://vela.example')).toEqual({});
+  it('enables the transports on production now that its Vela backend serves them', () => {
+    expect(workspaceTeamTransportEnv('prod', 'https://open-design.ai/cloud')).toEqual({
+      OD_WORKSPACE_CONTEXT_SOURCE: 'vela',
+      OD_TEAM_PROJECTS_TRANSPORT: 'vela-cli',
+      OD_COLLAB_TRANSPORT: 'vela-cli',
+      OD_RESOURCE_TRANSPORT: 'vela-cli',
+      OD_VELA_WEB_URL: 'https://open-design.ai/cloud',
+    });
+  });
+
+  it('keeps an origin-less build dormant on every profile', () => {
+    // Half a configuration is the dangerous one: without an injected origin the
+    // packaged daemon would otherwise point Workspace Team at an unknown
+    // backend. Missing origin must degrade to local-only, never to a guess.
     expect(workspaceTeamTransportEnv('feature-test', undefined)).toEqual({});
+    expect(workspaceTeamTransportEnv('prod', undefined)).toEqual({});
+    expect(workspaceTeamTransportEnv('prod', '   ')).toEqual({});
+  });
+
+  it('keeps an unknown profile dormant even with an origin', () => {
+    expect(workspaceTeamTransportEnv('staging', 'https://vela.example')).toEqual({});
+    expect(workspaceTeamTransportEnv(null, 'https://vela.example')).toEqual({});
   });
 });


### PR DESCRIPTION
## Why

We are cutting a release build that should point at the **production** backend. Today a `prod` bundle keeps Workspace Team dormant by design:

```ts
// apps/packaged/src/workspace-team.ts
const WORKSPACE_TEAM_AMR_PROFILES = new Set(['feature-test', 'test']);
// Production deliberately stays outside this allowlist until the feature is
// released independently of the integration branch.
```

That condition is now met. On prod `amr-api`: `WORKSPACE_TEAM_ENABLED` and all three billing-scope flags are `"true"`, and the resource hub backing team file sharing is configured — an S3 blob store (`refly-prod-resource-hub` + IRSA) instead of the chart's `mode: mock` default, which would have failed every `vela resource push` with `unsupported protocol scheme "mock"` while comments (Postgres) kept syncing, i.e. *"comments arrive, files never do"*.

## What

| change | file |
|---|---|
| `prod` joins the profile allowlist | `apps/packaged/src/workspace-team.ts` |
| `OD_VELA_WEB_URL` resolves for `prod` from `secrets.VELA_WEB_URL_PROD` | `.github/workflows/release-prerelease.yml` |
| release builds default to `amr_profile: prod` (drops the temporary `test` default on release/v0.18.0) | `.github/workflows/notify-release-feishu.yml` |

**The origin half of the gate is unchanged and still load-bearing.** A build without an injected origin stays dormant on every profile — a forgotten secret degrades to local-only rather than pointing Workspace Team at an unknown backend.

## ⚠️ Required before merging

`secrets.VELA_WEB_URL_PROD` **must be added to the repository** (value: the production Vela console origin, `https://open-design.ai/cloud`). Without it, prod builds silently fall back to an empty origin and ship with Workspace Team **off** — the quiet failure mode this gate is designed to produce, but not what we want for the release.

## Tests

`apps/packaged`: **286 passed / 22 files**. Two assertions changed semantics deliberately:
- `never enables … for a prod build` → now asserts prod **does** enable with an origin
- the dormancy guarantee is preserved in two narrower specs: `local`/profile-less builds stay dormant, and a prod build **without** an origin stays dormant

`pnpm guard` ✅ · `pnpm typecheck` ✅

## Adjacent (not in this PR)

`win_x64_smoke_mode: skip` still applies on release/v0.18.0. It was added because the packaged win smoke lands on the cloud onboarding shell under a cloud profile — which `prod` also is, so removing it here risks re-blocking publish. Worth fixing properly (teach the smoke the cloud sign-in shell) now that release builds are production-profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)