### PR TITLE
ci: route UI P0 jobs onto nexu-runners-xlarge

### DIFF
--- a/.github/scripts/runners.py
+++ b/.github/scripts/runners.py
@@ -10,6 +10,7 @@ WINDOWS_HOSTED = ["windows-latest"]
 NEXU_SMALL = ["nexu-runners-small"]
 NEXU_MEDIUM = ["nexu-runners-medium"]
 NEXU_LARGE = ["nexu-runners-large"]
+NEXU_XLARGE = ["nexu-runners-xlarge"]
 
 
 def compact_json(value):
@@ -27,6 +28,9 @@ def resolve_contract(mode):
     control = GITHUB_HOSTED if mode == "economic" else NEXU_SMALL
     workload = GITHUB_HOSTED if mode == "economic" else NEXU_MEDIUM
     browser_workload = GITHUB_HOSTED if mode == "economic" else NEXU_LARGE
+    # UI P0 is the memory-heavy Playwright domain suite; prefer the dedicated
+    # xlarge class once available so large remains headroom for lighter UI jobs.
+    ui_p0_workload = GITHUB_HOSTED if mode == "economic" else NEXU_XLARGE
 
     return {
         "runs_on": {
@@ -36,6 +40,7 @@ def resolve_contract(mode):
             "windows_tools": WINDOWS_HOSTED,
             "js_hot": workload,
             "ui_hot": browser_workload,
+            "ui_p0": ui_p0_workload,
             "visual_hot": browser_workload,
         },
         "decision": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,7 +477,7 @@ jobs:
     name: UI P0 (${{ matrix.name }})
     needs: [scopes, runners]
     if: ${{ needs.scopes.outputs.run_ui_p0 == 'true' }}
-    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).ui_hot }}
+    runs-on: ${{ fromJSON(needs.runners.outputs.runs_on).ui_p0 }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -494,14 +494,14 @@ jobs:
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
         with:
-          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_hot) }}
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_p0) }}
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
         with:
           package-json-path: e2e/package.json
           install-command: pnpm -C e2e exec playwright install --with-deps chromium
-          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_hot) }}
+          runner-labels: ${{ toJSON(fromJSON(needs.runners.outputs.runs_on).ui_p0) }}
 
       - name: Prebuild workspace type declarations
         run: |

--- a/.github/workflows/ui-extended-main.yml
+++ b/.github/workflows/ui-extended-main.yml
@@ -42,7 +42,7 @@ jobs:
     name: UI P0 (${{ matrix.name }})
     needs: [p0_runners]
     if: ${{ github.repository == 'nexu-io/open-design' && github.event_name == 'workflow_dispatch' && inputs.suite != 'full' }}
-    runs-on: ${{ fromJSON(needs.p0_runners.outputs.runs_on).ui_hot }}
+    runs-on: ${{ fromJSON(needs.p0_runners.outputs.runs_on).ui_p0 }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -67,14 +67,14 @@ jobs:
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
         with:
-          runner-labels: ${{ toJSON(fromJSON(needs.p0_runners.outputs.runs_on).ui_hot) }}
+          runner-labels: ${{ toJSON(fromJSON(needs.p0_runners.outputs.runs_on).ui_p0) }}
 
       - name: Setup Playwright
         uses: ./.github/actions/setup-playwright
         with:
           package-json-path: e2e/package.json
           install-command: pnpm -C e2e exec playwright install --with-deps chromium
-          runner-labels: ${{ toJSON(fromJSON(needs.p0_runners.outputs.runs_on).ui_hot) }}
+          runner-labels: ${{ toJSON(fromJSON(needs.p0_runners.outputs.runs_on).ui_p0) }}
 
       - name: Prebuild workspace type declarations
         run: |

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1153,8 +1153,8 @@ process.stdin.on("end", () => {
     expect(e2eVitest).not.toContain('"od-persistent-ci"');
     expect(preflight).toContain("fromJSON(needs.runners.outputs.runs_on).general_medium");
     expect(preflight).toContain("toJSON(fromJSON(needs.runners.outputs.runs_on).general_medium)");
-    expect(uiP0).toContain("fromJSON(needs.runners.outputs.runs_on).ui_hot");
-    expect(uiP0).toContain("toJSON(fromJSON(needs.runners.outputs.runs_on).ui_hot)");
+    expect(uiP0).toContain("fromJSON(needs.runners.outputs.runs_on).ui_p0");
+    expect(uiP0).toContain("toJSON(fromJSON(needs.runners.outputs.runs_on).ui_p0)");
     expect(uiP0).toContain("include: ${{ fromJSON(needs.scopes.outputs.ui_p0_matrix) }}");
     expect(uiP0CiMatrix.map((entry) => entry.name)).toEqual([
       "entry-settings",
@@ -1247,6 +1247,7 @@ process.stdin.on("end", () => {
     expect(benchmarkWorkflow).toContain("Preserve project-runtime domain artifact");
     expect(benchmarkWorkflow).toContain("--grep-invert '@merge-extra'");
     expect(benchmarkWorkflow).toContain("name: project-workspace");
+    expect(benchmarkWorkflow).toContain("fromJSON(needs.p0_runners.outputs.runs_on).ui_p0");
     expect(fullUi).toContain("fromJSON(needs.p0_runners.outputs.runs_on).ui_hot");
     expect(fullUi).toContain("shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]");
     expect(fullUi).toContain('OD_PLAYWRIGHT_FULLY_PARALLEL: "1"');
@@ -1268,6 +1269,7 @@ process.stdin.on("end", () => {
       "general_medium",
       "js_hot",
       "ui_hot",
+      "ui_p0",
       "visual_hot",
       "windows_tools",
       "workspace_unit",
@@ -1278,6 +1280,7 @@ process.stdin.on("end", () => {
     expect(defaultRunsOn.windows_tools).toEqual(["windows-latest"]);
     expect(defaultRunsOn.js_hot).toEqual(["nexu-runners-medium"]);
     expect(defaultRunsOn.ui_hot).toEqual(["nexu-runners-large"]);
+    expect(defaultRunsOn.ui_p0).toEqual(["nexu-runners-xlarge"]);
     expect(defaultRunsOn.visual_hot).toEqual(["nexu-runners-large"]);
     expect(defaultProfiles).not.toHaveProperty("contabo_control");
     expect(defaultProfiles).not.toHaveProperty("hosted_or_blacksmith");
@@ -1292,6 +1295,7 @@ process.stdin.on("end", () => {
     expect(performanceRunsOn.windows_tools).toEqual(["windows-latest"]);
     expect(performanceRunsOn.js_hot).toEqual(["nexu-runners-medium"]);
     expect(performanceRunsOn.ui_hot).toEqual(["nexu-runners-large"]);
+    expect(performanceRunsOn.ui_p0).toEqual(["nexu-runners-xlarge"]);
     expect(performanceRunsOn.visual_hot).toEqual(["nexu-runners-large"]);
 
     const economicProfiles = await runRunners("economic");
@@ -1303,6 +1307,7 @@ process.stdin.on("end", () => {
     expect(economicRunsOn.windows_tools).toEqual(["windows-latest"]);
     expect(economicRunsOn.js_hot).toEqual(["ubuntu-24.04"]);
     expect(economicRunsOn.ui_hot).toEqual(["ubuntu-24.04"]);
+    expect(economicRunsOn.ui_p0).toEqual(["ubuntu-24.04"]);
     expect(economicRunsOn.visual_hot).toEqual(["ubuntu-24.04"]);
 
     for (const invalidMode of ["Economic", " economic "]) {


### PR DESCRIPTION
## Why

- **Author use case:** UI P0 jobs on `nexu-runners-large` are memory-starved; want them on the new xlarge class from powerformer/apps#312.
- **Pain:** Prometheus on `refly-test-eks` shows UI P0 `project-collab` runner-container working-set p50 ≈ 15.0Gi / p95 = 16.0Gi against a 16Gi limit (24h). Same job success rate ≈ 23% (27 fails / 39 completions). Adjacent OOMKilled evidence already in handoff notes. Headroom is gone.

## What users will see

- No product UI change.
- CI: UI P0 domain jobs (`ci.yml` + `ui-extended-main` p0 suite) schedule on `nexu-runners-xlarge` (12 vCPU / 24Gi request, 24Gi limit per runner container).
- Lighter browser lanes (`playwright_critical`, `playwright_visual`, `ui_full`) stay on `nexu-runners-large`.
- Economic / fork path still uses `ubuntu-24.04`.

## Evidence (refly-test-eks Prometheus, last 24h)

| Job | n | p50 | p95 | max | ≥15Gi | success% |
|---|---:|---:|---:|---:|---:|---:|
| UI P0 (project-collab) | 54 | 15.0 | 16.0 | 16.0 | 27 | 23% |
| UI P0 (entry-settings) | 56 | 12.6 | 13.8 | 16.0 | 2 | 95% |
| UI P0 (workspace-restoration) | 56 | 12.6 | 13.8 | 16.0 | 1 | 93% |
| UI P0 (project-workspace) | 61 | 11.3 | 12.6 | 13.2 | 0 | 68% |
| UI P0 (project-runtime) | 57 | 6.8 | 8.0 | 8.1 | 0 | 88% |
| Playwright visual (×2) | ~45 | ~12.2 | ~13.4 | 16.0 | 1 each | 88–100% |
| Playwright critical | 1–2 | 12–13 | — | 12.8 | 0 | — |

CPU is not the bottleneck (large runner p95 ≈ 5.7 cores). dind is idle (~0.03Gi). `nexu-runners-xlarge` ARS is Running with listener ready; max=8 is enough for the 5-shard UI P0 matrix.

## What

- `.github/scripts/runners.py`: add `NEXU_XLARGE` + `runs_on.ui_p0` profile.
- `ci.yml` / `ui-extended-main.yml`: point `ui_p0` jobs at `.ui_p0` (runs-on + runner-labels).
- Topology tests updated for the new profile.

## Surface area

- [x] CI / GitHub Actions
- [ ] apps/web
- [ ] apps/daemon
- [ ] apps/desktop / packaged
- [ ] packages/contracts
- [ ] CLI (`od`)
- [ ] skills / design-systems / design-templates / craft
- [ ] i18n keys
- [ ] env vars / root package.json deps

## Test plan

- [x] `pnpm --filter @open-design/e2e test tests/packaged-smoke-workflow.test.ts -t runner`
- [x] `actionlint` on `ci.yml` + `ui-extended-main.yml`
- [ ] After merge: confirm UI P0 jobs land on `nexu-runners-xlarge-*` pods and collab working-set stays under ~20Gi

## Notes / non-goals

- Does **not** move visual / critical / full UI suites (xlarge max=8; full suite is 12 shards).
- Does **not** switch P0 to on-demand (Spot interruption is a separate risk).
- xlarge does not fix oversized collab tests long-term; still worth splitting later.