### PR TITLE
fix(deploy): pin the Node base image so rebuilds stay reproducible

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -118,14 +118,15 @@ jobs:
           push: ${{ steps.mode.outputs.publish == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # The in-tree Dockerfile uses node:24-alpine + apk for build
-          # tooling; we keep that default so the workflow doesn't drift
-          # from local builds. Spec §15.1 nominates bookworm-slim as
-          # the canonical base; switching is a follow-up that needs
-          # the Dockerfile's apk lines re-cast for apt.
+          # Mirrors the Dockerfile's pinned default (see the comment there
+          # for why the Node minor is pinned rather than floating) so the
+          # workflow doesn't drift from local builds. Bump both together.
+          # Spec §15.1 nominates bookworm-slim as the canonical base;
+          # switching is a follow-up that needs the Dockerfile's apk lines
+          # re-cast for apt.
           build-args: |
-            NODE_IMAGE=public.ecr.aws/docker/library/node:24-alpine
-            RUNTIME_IMAGE=public.ecr.aws/docker/library/node:24-alpine
+            NODE_IMAGE=public.ecr.aws/docker/library/node:24.18.0-alpine
+            RUNTIME_IMAGE=public.ecr.aws/docker/library/node:24.18.0-alpine
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,5 +1,13 @@
-ARG NODE_IMAGE=docker.io/library/node:24-alpine
-ARG RUNTIME_IMAGE=docker.io/library/node:24-alpine
+# Pin the Node minor rather than tracking the floating `node:24-alpine`, so an
+# image rebuilt from unchanged sources keeps the runtime it was validated on.
+# Under the floating tag the Node version is decided by the build date: a
+# rebuild on 2026-08-04 picked up 24.19.0 (released 08-03) and the daemon began
+# aborting mid-run with a native assertion, while nothing in the error pointed
+# at Node (see #6462). The daemon loads NAN-style `ObjectWrap` addons
+# (better-sqlite3, node-pty), so a Node change can break it without any change
+# here. Bump deliberately and re-validate.
+ARG NODE_IMAGE=docker.io/library/node:24.18.0-alpine
+ARG RUNTIME_IMAGE=docker.io/library/node:24.18.0-alpine
 
 FROM ${NODE_IMAGE} AS build
 

--- a/deploy/scripts/publish-images.sh
+++ b/deploy/scripts/publish-images.sh
@@ -7,8 +7,8 @@ IMAGE_TAG="${IMAGE_TAG:-latest}"
 REGISTRY="${REGISTRY:-ghcr.io}"
 IMAGE_NAMESPACE="${IMAGE_NAMESPACE:-nexu-io}"
 IMAGE_REPOSITORY="${IMAGE_REPOSITORY:-od}"
-NODE_BASE_IMAGE="${NODE_BASE_IMAGE:-docker.io/library/node:24-alpine}"
-RUNTIME_BASE_IMAGE="${RUNTIME_BASE_IMAGE:-docker.io/library/node:24-alpine}"
+NODE_BASE_IMAGE="${NODE_BASE_IMAGE:-docker.io/library/node:24.18.0-alpine}"
+RUNTIME_BASE_IMAGE="${RUNTIME_BASE_IMAGE:-docker.io/library/node:24.18.0-alpine}"
 PUSH_STRATEGY="${PUSH_STRATEGY:-skopeo}"
 PRELOAD_BASE_IMAGES="${PRELOAD_BASE_IMAGES:-1}"
 DRY_RUN="${DRY_RUN:-0}"
@@ -107,8 +107,8 @@ Options:
   --image_namespace <namespace>   default: nexu-io
   --image_repository <name>       default: od
   --image <image-ref>             override full image ref
-  --node_base_image <image-ref>   default: docker.io/library/node:24-alpine
-  --runtime_base_image <image-ref> default: docker.io/library/node:24-alpine
+  --node_base_image <image-ref>   default: docker.io/library/node:24.18.0-alpine
+  --runtime_base_image <image-ref> default: docker.io/library/node:24.18.0-alpine
   --push_strategy <skopeo|buildx> default: skopeo
   --preload_base_images <0|1>     default: 1
   --skopeo_authfile <path>        default: ~/.docker/config.json
@@ -272,14 +272,14 @@ node_local_base_image() {
   local platform="$1"
   local arch
   arch="$(platform_to_arch "$platform")" || die "unsupported platform '$platform'"
-  printf 'open-design-base-node:24-alpine-%s' "$arch"
+  printf 'open-design-base-node:24.18.0-alpine-%s' "$arch"
 }
 
 runtime_local_base_image() {
   local platform="$1"
   local arch
   arch="$(platform_to_arch "$platform")" || die "unsupported platform '$platform'"
-  printf 'open-design-runtime-base:24-alpine-%s' "$arch"
+  printf 'open-design-runtime-base:24.18.0-alpine-%s' "$arch"
 }
 
 node_image_for_platform() {

--- a/e2e/tests/node-base-image-pin.test.ts
+++ b/e2e/tests/node-base-image-pin.test.ts
@@ -1,0 +1,66 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+// The Node base image is pinned to a minor so an image rebuilt from unchanged
+// sources keeps the runtime it was validated on (see the rationale in
+// deploy/Dockerfile, and #6462 for what a floating tag cost).
+//
+// A pin is only worth as much as its least-pinned caller. The Dockerfile's ARG
+// defaults apply only to callers that pass nothing, and both repository-owned
+// publish paths pass their own values — so pinning the Dockerfile alone left
+// the paths that actually publish images still floating. These specs assert all
+// three agree, so the next caller that hardcodes a base image fails here rather
+// than by shipping a Node nobody chose.
+
+const dockerfile = new URL("../../deploy/Dockerfile", import.meta.url);
+const dockerWorkflow = new URL("../../.github/workflows/docker-image.yml", import.meta.url);
+const publishScript = new URL("../../deploy/scripts/publish-images.sh", import.meta.url);
+
+/** Strip `#` comments so prose about the floating tag is not mistaken for a use of it. */
+function withoutComments(content: string): string {
+  return content
+    .split("\n")
+    .map((line) => line.replace(/(^|\s)#.*$/, "$1"))
+    .join("\n");
+}
+
+async function pinnedNodeTag(): Promise<string> {
+  const content = await readFile(dockerfile, "utf8");
+  const matches = [...content.matchAll(/^ARG (?:NODE_IMAGE|RUNTIME_IMAGE)=\S+?:(\S+)$/gm)];
+  expect(matches, "deploy/Dockerfile should declare both base image ARGs").toHaveLength(2);
+  const tags = new Set(matches.map((match) => match[1]!));
+  expect([...tags], "both ARGs should pin the same tag").toHaveLength(1);
+  return [...tags][0]!;
+}
+
+describe("Node base image pin", () => {
+  it("pins a concrete minor rather than a floating major tag", async () => {
+    const tag = await pinnedNodeTag();
+    expect(tag).toMatch(/^\d+\.\d+\.\d+-/);
+  });
+
+  it("is not overridden by the repository-owned build and publish paths", async () => {
+    const tag = await pinnedNodeTag();
+
+    for (const source of [dockerWorkflow, publishScript]) {
+      const content = withoutComments(await readFile(source, "utf8"));
+      const refs = [...content.matchAll(/\bnode:(\S+?)-alpine\b/g)].map((match) => match[1]!);
+      expect(refs.length, `${source.pathname} should reference the Node base image`).toBeGreaterThan(0);
+      for (const ref of refs) {
+        expect(`${ref}-alpine`, `${source.pathname} must use the Dockerfile's pinned tag`).toBe(tag);
+      }
+    }
+  });
+
+  it("leaves no floating `node:24-alpine` reference in those paths", async () => {
+    // Stated separately from the agreement check above because this is the
+    // specific shape the regression took: a caller keeping its own default.
+    for (const source of [dockerfile, dockerWorkflow, publishScript]) {
+      const content = withoutComments(await readFile(source, "utf8"));
+      expect(content, `${source.pathname} should not use a floating major tag`).not.toMatch(
+        /\bnode:\d+-alpine\b/,
+      );
+    }
+  });
+});


### PR DESCRIPTION
Fixes #6462

## Why

**My use case:** I run Open Design self-hosted from `deploy/Dockerfile`. I rebuilt our image on 2026-08-04 to pick up an unrelated change, and the daemon started dying mid-run. It cost a full day to track down, because nothing in the failure points at the thing that actually changed — the OD source was identical, the lockfile was identical, and the only moving part was the Node version the floating base tag happened to resolve to that day.

**The pain:** build output is decided by the build date. `deploy/Dockerfile` tracked `docker.io/library/node:24-alpine` for both stages, so the same commit produced a working image one day and a crash-looping one the next. Anyone rebuilding today gets Node 24.19.0 and hits this; the symptom (intermittent `500`s, runs dying partway) gives no hint that Node is involved, and `--report-on-fatalerror` cannot capture it because the report generation needs the `Environment` that is already gone.

Concretely, on 24.19.0 the daemon aborts with:

```
node[7]: void node::RemoveEnvironmentCleanupHook(...) at src/api/hooks.cc:142
Assertion failed: (env) != nullptr
```

The daemon loads NAN-style `ObjectWrap` addons (`better-sqlite3`, `node-pty`), which is the surface Node 24.19.0's `src: add cleanup hooks to node::ObjectWrap` touches. Per the discussion in #6462 I'm treating that exact teardown path as a **working hypothesis** — what this PR addresses is the reproducibility problem underneath it, which is not in question.

## What users will see

Nothing changes in the app UI. For anyone building or self-hosting from `deploy/Dockerfile`:

- rebuilding unchanged sources now produces the same Node runtime it did last time, instead of silently drifting to whatever `node:24-alpine` points at that day
- rebuilds done today no longer land on Node 24.19.0, so the daemon stops crash-looping mid-run
- upgrading Node becomes a visible, reviewable one-line change rather than a side effect of when you happened to run `docker build`

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — images built from this Dockerfile now run Node 24.18.0 instead of whatever the floating tag resolves to. Both `ARG`s remain overridable (`--build-arg NODE_IMAGE=...`) for anyone who wants a different runtime.
- [ ] **None**

## Screenshots

N/A — no UI surface.

## Bug fix verification

**No red spec.** A falsifiable test here would have to build an image against a specific Node version and run a real agent session against it — that lives outside the test layers this repo has, and I did not want to add a Docker-building test for a one-line default. Flagging it explicitly rather than quietly skipping the step.

What I did instead, on production hardware (Linux/amd64, self-hosted):

- **Before:** base image on Node 24.19.0 — 17 of 21 runs killed (81%), reproducing every 1.5–20 minutes of active run time, across two different agents (`claude` and `codex`), across three different projects
- **After:** same OD source rebuilt with `NODE_IMAGE=node:24.18.0-alpine` — runs that previously died 15-out-of-18 times in one specific project/conversation now complete (`status: succeeded`), and `RestartCount` stays `0`
- Ruled out memory: container at 148MB against a 1024MB heap cap, `OOMKilled=false`, host with 4.4GB free and untouched swap
- Ruled out dependency drift: `better-sqlite3@12.10.0` and `node-pty@1.1.0` are byte-identical between the working and broken builds

## Validation

- `pnpm guard` — passed
- Built both images from this Dockerfile on amd64 and verified the resulting runtime with `docker run --rm --entrypoint node <image> -v` → `v24.18.0`
- Ran the rebuilt daemon in production and confirmed the crash loop is gone (see numbers above)

No source files are touched, so package-scoped tests are unaffected by this change.
