### PR TITLE
fix(release): bake the workspace-team gate into stable and preview builds

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -100,6 +100,22 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  # Workspace Team's four vela transports are gated in the packaged runtime on
+  # BOTH a known AMR profile and a non-empty vela web origin
+  # (workspaceTeamTransportEnv in apps/packaged/src/workspace-team.ts). Neither
+  # has a default in tools-pack, so a lane that omits them ships a client whose
+  # team features are silently dormant: the build succeeds, the app starts, and
+  # the gap only shows up in a user's hands.
+  #
+  # Unlike beta/prerelease these are production channels, so the profile is
+  # pinned rather than taken from an input — there is no legitimate stable or
+  # preview build aimed at the test backend. Naming prod explicitly is a no-op
+  # for AMR itself (apps/daemon/src/integrations/vela-profile.ts already
+  # defaults to prod); it exists to satisfy the first half of the gate. A fork
+  # or PR build without the secret leaves the origin empty, which keeps the
+  # transports dormant rather than half-enabled.
+  OPEN_DESIGN_AMR_PROFILE: prod
+  OD_VELA_WEB_URL: ${{ secrets.VELA_WEB_URL_PROD }}
   OPEN_DESIGN_TELEMETRY_RELAY_URL: ${{ vars.OPEN_DESIGN_TELEMETRY_RELAY_URL }}
   # PostHog product-analytics ingest. Defined as repository secret + var
   # so official builds ship with analytics enabled; PR builds and forks

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -119,6 +119,22 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  # Workspace Team's four vela transports are gated in the packaged runtime on
+  # BOTH a known AMR profile and a non-empty vela web origin
+  # (workspaceTeamTransportEnv in apps/packaged/src/workspace-team.ts). Neither
+  # has a default in tools-pack, so a lane that omits them ships a client whose
+  # team features are silently dormant: the build succeeds, the app starts, and
+  # the gap only shows up in a user's hands.
+  #
+  # Unlike beta/prerelease these are production channels, so the profile is
+  # pinned rather than taken from an input — there is no legitimate stable or
+  # preview build aimed at the test backend. Naming prod explicitly is a no-op
+  # for AMR itself (apps/daemon/src/integrations/vela-profile.ts already
+  # defaults to prod); it exists to satisfy the first half of the gate. A fork
+  # or PR build without the secret leaves the origin empty, which keeps the
+  # transports dormant rather than half-enabled.
+  OPEN_DESIGN_AMR_PROFILE: prod
+  OD_VELA_WEB_URL: ${{ secrets.VELA_WEB_URL_PROD }}
   OPEN_DESIGN_TELEMETRY_RELAY_URL: ${{ vars.OPEN_DESIGN_TELEMETRY_RELAY_URL }}
   # PostHog product-analytics ingest. Defined as repository secret + var
   # so official builds ship with analytics enabled; PR builds and forks

--- a/tools/pack/tests/release-workflows.test.ts
+++ b/tools/pack/tests/release-workflows.test.ts
@@ -394,6 +394,40 @@ describe("release workflows", () => {
     expect(stablePrepare).toContain('setOutput("publish_side_effects_enabled"');
   });
 
+  it("bakes both halves of the workspace-team gate into every shipping lane", async () => {
+    const [beta, preview, prerelease, stable] = await Promise.all([
+      readFile(new URL("../../../.github/workflows/release-beta.yml", import.meta.url), "utf8"),
+      readFile(new URL("../../../.github/workflows/release-preview.yml", import.meta.url), "utf8"),
+      readFile(new URL("../../../.github/workflows/release-prerelease.yml", import.meta.url), "utf8"),
+      readFile(new URL("../../../.github/workflows/release-stable.yml", import.meta.url), "utf8"),
+    ]);
+
+    // workspaceTeamTransportEnv (apps/packaged/src/workspace-team.ts) enables the
+    // four vela transports only when a known AMR profile AND a non-empty vela web
+    // origin are both baked in. A lane that bakes neither still builds, still
+    // installs, and still starts — the gap only surfaces as "Workspace Team does
+    // nothing" once a package reaches a user. So the presence of both halves is
+    // asserted per lane rather than left to the packaging step to notice.
+    for (const workflow of [beta, preview, prerelease, stable]) {
+      expect(workflow).toContain("OPEN_DESIGN_AMR_PROFILE:");
+      expect(workflow).toContain("OD_VELA_WEB_URL:");
+    }
+
+    // beta and prerelease are validation lanes and stay dispatch-driven, so an
+    // operator can aim a build at feature-test or test.
+    expect(beta).toContain("OPEN_DESIGN_AMR_PROFILE: ${{ inputs.amr_profile }}");
+    expect(prerelease).toContain("OPEN_DESIGN_AMR_PROFILE: ${{ inputs.amr_profile }}");
+
+    // preview and stable are production channels by definition. Pinning the pair
+    // instead of accepting an input removes the footgun of publishing a stable
+    // build wired to the test backend — there is no legitimate reason for one.
+    for (const workflow of [preview, stable]) {
+      expect(workflow).toContain("OPEN_DESIGN_AMR_PROFILE: prod");
+      expect(workflow).toContain("OD_VELA_WEB_URL: ${{ secrets.VELA_WEB_URL_PROD }}");
+      expect(workflow).not.toContain("inputs.amr_profile");
+    }
+  });
+
   it("passes launcher version floor repo vars through to metadata publish and verify verbatim", async () => {
     const [beta, betaSelfHosted, preview, prerelease, stable] = await Promise.all([
       readFile(new URL("../../../.github/workflows/release-beta.yml", import.meta.url), "utf8"),


### PR DESCRIPTION
## Why

We are about to cut the first stable release carrying Workspace Team, and the
stable lane would have shipped it turned off.

`release-stable.yml` and `release-preview.yml` never set
`OPEN_DESIGN_AMR_PROFILE` or `OD_VELA_WEB_URL`. Neither has a default in
tools-pack (`tools/pack/src/config.ts:186,232` both return `undefined` for an
unset env), so `velaWebUrl` reaches the packaged config as `undefined`,
`workspaceTeamTransportEnv` (`apps/packaged/src/workspace-team.ts:34`) sees an
empty origin and returns `{}`, and none of `OD_WORKSPACE_CONTEXT_SOURCE`,
`OD_TEAM_PROJECTS_TRANSPORT`, `OD_COLLAB_TRANSPORT`, `OD_RESOURCE_TRANSPORT`
reach the daemon spawn env.

The failure mode is quiet in the worst way: the build succeeds, the installer
works, the app starts, and the only symptom is that team features do nothing
once a package is in a user's hands.

It also puts a hole in the promotion gate. `beta` and `prerelease` inject the
pair from their `amr_profile` input (added in #6435), so
`0.18.0-prerelease.7` really does have Workspace Team — and the stable build
promoted from that validated prerelease would not have. We would have signed
off on an artifact whose shipped counterpart behaves differently.

## What users will see

Nothing changes for anyone on beta or prerelease. On the stable and preview
channels, a client built after this lands can actually reach the production
vela backend: Workspace switcher, team projects, collaboration and shared
resources are live instead of silently absent.

## How

Both channels get the pair in their workflow-level `env`:

```yaml
OPEN_DESIGN_AMR_PROFILE: prod
OD_VELA_WEB_URL: ${{ secrets.VELA_WEB_URL_PROD }}
```

Pinned rather than taken from an input, unlike beta/prerelease. Those are
validation lanes where aiming a build at `feature-test` or `test` is the point;
stable and preview are production channels, and a stable build wired to the
test backend is a footgun with no legitimate use.

Naming `prod` explicitly is a no-op for AMR itself —
`apps/daemon/src/integrations/vela-profile.ts:3` already has
`DEFAULT_PROFILE = 'prod'` with `if (!raw) return DEFAULT_PROFILE`, so the
resolved profile is unchanged. It is there to satisfy the profile half of the
gate. A fork or PR build without the secret leaves the origin empty, which
keeps the transports dormant rather than half-enabled.

`VELA_WEB_URL_PROD` already exists as a repository secret (added for #6435).

## Validation

Red-first, per the bug follow-up workflow:

- Added `bakes both halves of the workspace-team gate into every shipping lane`
  to `tools/pack/tests/release-workflows.test.ts`, which already reads all four
  release workflows. **Red on unmodified `main`** — failed at
  `release-workflows.test.ts:412` on `preview` (beta passed, proving the
  assertion discriminates rather than failing universally). **Green on this
  branch.**
- `pnpm vitest run` in `tools/pack`: 37 files, 270 passed, 8 skipped.
- `pnpm guard`: exit 0.
- Parsed both workflows with a YAML loader to confirm the inserted block sits
  in the workflow-level `env` and the job count is unchanged (stable 9,
  preview 8).

The assertion is written as an invariant over every shipping lane, not as two
string checks against the files I touched, so a future channel that forgets the
pair fails the same test.

## Adjacent issues

Not fixed here, listed for follow-up:

- `notify-release-feishu.yml` still defaults `win_x64_smoke_mode` to `skip` on
  `release/v0.18.0`. Deliberate for now (the smoke does not know about the
  cloud sign-in shell), but it should be taught rather than left skipped.

## Surface area

- [x] CI / GitHub Actions workflows
- [x] Tests

Needs backport to `release/v0.18.0` — that branch's copies of both workflows
are byte-identical to `main`'s, so the patch applies cleanly.
