### PR TITLE
docs(release): add 0.18.0 release notes

### DIFF
--- a/docs/CHANGELOG/v0.18.0/en.md
+++ b/docs/CHANGELOG/v0.18.0/en.md
@@ -1,11 +1,11 @@
 ---
 title: Open Design 0.18.0
-description: Workspace Team goes live on production builds — team workspaces, shared projects and toolkits, workspace-scoped billing, and a redesigned home, all through one Open Design Cloud sign-in.
+description: Open Design 0.18.0 introduces Team Workspace—a shared home where design teams can share projects, review updates, comment in context, and reuse the same design systems, plugins, and skills. With the new Open Design plugin for Codex, that collaborative workspace now extends directly into Codex.
 ---
 
-### 🌟 Codename: *The World's First Design Agent for Teams*
+### 🌟 Codename: *Design Team Workspace. Now in Codex.*
 
-🤝 **`115 PRs` · `22 contributors` · `2 days`** — **Meet the world's first design agent built for teams.** Your best work used to leave the app the moment you wanted a teammate's eyes on it — exports, screenshots, "is this the latest version?". 0.18.0 lands just two days after 0.17.0, because its cargo has been boarding for a month behind a build-time gate: team workspaces, shared projects, a shared team toolkit, workspace billing, and a redesigned home. The agent you design with is now a workspace your whole team designs in. 🚀
+🤝 **`115 PRs` · `22 contributors` · `2 days`** — Open Design 0.18.0 introduces Team Workspace—a shared home where design teams can share projects, review updates, comment in context, and reuse the same design systems, plugins, and skills. With the new Open Design plugin for Codex, that collaborative workspace now extends directly into Codex. 🚀
 
 ## 🔥 Highlights
 

--- a/docs/CHANGELOG/v0.18.0/en.md
+++ b/docs/CHANGELOG/v0.18.0/en.md
@@ -1,0 +1,68 @@
+---
+title: Open Design 0.18.0
+description: Workspace Team goes live on production builds — team workspaces, shared projects and toolkits, workspace-scoped billing, and a redesigned home, all through one Open Design Cloud sign-in.
+---
+
+### 🌟 Codename: *The World's First Design Agent for Teams*
+
+🤝 **`115 PRs` · `22 contributors` · `2 days`** — **Meet the world's first design agent built for teams.** Your best work used to leave the app the moment you wanted a teammate's eyes on it — exports, screenshots, "is this the latest version?". 0.18.0 lands just two days after 0.17.0, because its cargo has been boarding for a month behind a build-time gate: team workspaces, shared projects, a shared team toolkit, workspace billing, and a redesigned home. The agent you design with is now a workspace your whole team designs in. 🚀
+
+## 🔥 Highlights
+
+- 🤝 **Team workspaces — your team gets a home.** *Collaboration used to mean leaving Open Design: export the file, paste the screenshot, chase the latest copy.* Now a **Team workspace** lives right next to your personal one. Create it, switch into it, and invite colleagues with a role through a seat-aware invite flow — everyone lands in the same place, signed in through one Open Design Cloud account. (#6142, #6459)
+
+- 🚀 **Open Design for Codex — in case you missed 0.17.0.** *The last release lived for exactly two days, so its headline rides again:* Codex Desktop and CLI can call Open Design as a complete creative engine. Confirm a visual brief, choose Open Design Cloud or a supported local runtime, and receive a real Preview or Studio result. The signed Open Design runtime starts headlessly when needed, so there is no second app to keep open and no stack to wire together by hand. Upgrading from 0.16.x? This one is new to you too. (#6055, #6273, #6362 — shipped in [0.17.0](https://github.com/nexu-io/open-design/releases/tag/open-design-v0.17.0))
+
+- 🔌 **And Codex doesn't lose Open Design anymore.** External MCP hosts — Codex and friends — used to go dark if Open Design's local service came back on a different port after a restart. The connection now finds its way home on its own, so `@open-design` keeps working across restarts without re-setup. (#6391)
+
+- 📁 **Shared projects that stay current on their own.** Move a project into the team space and every member gets a live read-only mirror: content auto-pulls as the owner works, presence avatars show who's looking, transfer progress is visible, and comments flow both ways — including from viewers in read-only mode. Nobody re-sends anything, and "is this the latest?" stops being a question. (#5281, #5283, #5395, #6294)
+
+- 🧰 **Share the toolkit, not just the files.** Design systems, plugins, and skills can now be shared to the team, so the house style and the house tricks travel together — a teammate picks up the same brand kit and the same workflows without a setup call. (#5242, #5250, #5551) Thanks @PerishCode.
+
+- 💳 **Billing that follows the workspace.** Balances, top-ups, and run charges are attributed to the active workspace instead of your personal account — team work bills the team, personal work stays personal, and the plan nameplate always tells you which pocket you're spending from. (#6067, #6182, #6219)
+
+- 🎨 **A home worth coming home to.** The workspace redesign lands across the home hero, rail, tabs, and template/plugin detail surfaces — joined by a message center, a What's-new panel fed by real release data, and a quieter, restyled update reminder. (#6156, #6162, #6281) Thanks @wangchenglong0001.
+
+- 🏁 **Agents finish what they start.** Sessions that stalled right after a tool call now pick themselves back up, Kiro runs complete their turns cleanly instead of hanging at the finish line, and when an AMR run genuinely stalls, the app can finally tell you why instead of shrugging. (#6237, #6268, #6040) Thanks @Siri-Ray.
+
+- 🙋 **A required question is no longer a locked door.** When the agent asks something you can't or don't want to answer, skip it and keep moving — the agent works with what it has instead of holding your run hostage. (#6177)
+
+- 🕵️ **Clone Audit — know a clone is safe before you ship it.** The new community plugin inspects a cloned site the way a reviewer would: visual fidelity, leftover tracking scripts, source-brand and language residue, placeholders, and risky external dependencies — then hands you an evidence-based report with file-and-line receipts and a clear deployment verdict. (#5687) Thanks @bestthanapon.
+
+> 📥 **Download:** Tag `open-design-v0.18.0`.
+>
+> | Platform | Architecture | Asset |
+> |---|---|---|
+> | macOS | Apple Silicon (arm64) | [open-design-0.18.0-mac-arm64.dmg](https://github.com/nexu-io/open-design/releases/download/open-design-v0.18.0/open-design-0.18.0-mac-arm64.dmg) |
+> | macOS | Intel (x64) | [open-design-0.18.0-mac-x64.dmg](https://github.com/nexu-io/open-design/releases/download/open-design-v0.18.0/open-design-0.18.0-mac-x64.dmg) |
+> | Windows | x64 | [open-design-0.18.0-win-x64-setup.exe](https://github.com/nexu-io/open-design/releases/download/open-design-v0.18.0/open-design-0.18.0-win-x64-setup.exe) |
+
+## ✨ Added
+
+### 🏠 Home, projects & landing
+
+- **The plugin catalog has a front door.** A dedicated landing page introduces Open Design plugins to newcomers before they ever install the app. (#6241) Thanks @joeylee12629-star.
+
+- **The Codex agent page now answers the question people actually ask.** Sharper positioning and content for anyone searching for a Codex UI. (#6200) Thanks @joeylee12629-star.
+
+## 🔁 Changed
+
+- **Open Design ships light-first.** The new workspace surfaces are tuned for the light appearance, so the theme setting is retired for now and every install returns to light. (#6168)
+
+## 🐛 Fixed
+
+### 🎨 Studio & interface
+
+- **The in-app browser preview remembers your viewport.** Pick a device size once and it stays picked, instead of resetting between sessions. (#4899) Thanks @HD-L.
+
+- **Deleted projects no longer haunt your tabs.** Removing a project also clears its saved tab layout, so stale workspace state stops resurfacing. (#5761) Thanks @EthanGuo-coder.
+
+- **Azure deployment names are editable again.** BYOK users on Azure can correct a deployment name without fighting the form. (#6034) Thanks @mturac.
+
+### ☁️ Cloud & reliability
+
+- **Billing checks back off instead of hammering.** When the Cloud billing endpoint is unreachable, the app now retries politely on a backoff curve rather than flooding a failing connection. (#6446)
+
+## 🙏 Thanks to everyone who shipped 0.18.0
+
+@AmyShang-alt · Bassi · @bestthanapon · @bone3deep1962-collab · @crumgary · @elifive555555 · @EthanGuo-coder · @hanyuanxi · @HD-L · @itscheems · @joeylee12629-star · @lefarcen · @mrcfps · @mturac · @nettee · @PerishCode · @shangxinyu1 · @Siri-Ray · @wangchenglong0001 · @xiaoche-hub · @xne998808-ai · @xxiaoxiong

--- a/docs/CHANGELOG/v0.18.0/zh-CN.md
+++ b/docs/CHANGELOG/v0.18.0/zh-CN.md
@@ -1,0 +1,68 @@
+---
+title: Open Design 0.18.0
+description: Workspace Team 在正式版构建中上线——团队工作区、共享项目与工具集、按工作区计费、全新首页设计，一个 Open Design Cloud 账号全部搞定。
+---
+
+### 🌟 Codename: *The World's First Design Agent for Teams*
+
+🤝 **`115 个 PR` · `22 位贡献者` · `2 天`** — **全球首个为团队而生的设计 Agent，来了。** 过去，你的作品只要想让同事看一眼，就得离开应用——导出、截图、追问"这是最新版吗？"。0.18.0 在 0.17.0 之后仅两天就抵达，因为它的货舱已经在构建开关后面装了整整一个月：团队工作区、共享项目、共享团队工具集、按工作区计费、全新首页。与你并肩设计的 Agent，现在是全团队共同创作的工作区。🚀
+
+## 🔥 亮点
+
+- 🤝 **团队工作区——团队有了自己的家。** *过去协作意味着离开 Open Design：导出文件、贴截图、追最新版。* 现在，**团队工作区**就在个人工作区旁边。创建、切换、按角色邀请同事，席位感知的邀请流程让每个人落到同一个地方——用同一个 Open Design Cloud 账号登录。 (#6142, #6459)
+
+- 🚀 **Codex 中的 Open Design——错过了 0.17.0？再看一次。** *上个版本只存在了整整两天，所以它的头条值得再讲一遍：* Codex Desktop 和 CLI 可以把 Open Design 当作一套完整的创作引擎：确认视觉 brief，选择 Open Design Cloud 或受支持的本地执行方式，并获得真实的 Preview 或 Studio 结果。需要时，已签名的 Open Design runtime 会在后台启动，无需一直开着第二个应用，也无需手工拼接整套工具。从 0.16.x 升级上来？这对你也是新功能。 (#6055, #6273, #6362 — 随 [0.17.0](https://github.com/nexu-io/open-design/releases/tag/open-design-v0.17.0) 发布)
+
+- 🔌 **而且 Codex 不会再弄丢 Open Design。** 外部 MCP 宿主（Codex 等）过去在 Open Design 本地服务重启换端口后会彻底失联。现在连接会自己找到回家的路，`@open-design` 跨重启持续可用，无需重新配置。 (#6391)
+
+- 📁 **共享项目自己保持最新。** 把项目移入团队空间，每位成员都会得到一份实时只读镜像：所有者工作时内容自动拉取，在线头像显示谁正在看，传输进度清晰可见，评论双向流动——只读访客也能评论。没有人需要重发任何东西，"这是最新版吗？"从此不再是问题。 (#5281, #5283, #5395, #6294)
+
+- 🧰 **共享的不只是文件，还有整套工具。** 设计体系、插件和技能现在都可以共享给团队，让品牌风格和独门技巧一起随行——同事拿到同样的品牌套件和同样的工作流，不需要再打一通设置电话。 (#5242, #5250, #5551) 感谢 @PerishCode。
+
+- 💳 **计费跟着工作区走。** 余额、充值和运行消耗记在当前工作区名下，而不是你的个人账户——团队的工作由团队买单，个人的工作留在个人，套餐铭牌始终告诉你花的是哪个口袋的钱。 (#6067, #6182, #6219)
+
+- 🎨 **一个值得回来的首页。** 工作区重设计覆盖首页 hero、侧栏、标签页和模板/插件详情页——还带来了消息中心、基于真实发布数据的 What's-new 面板，以及更安静、重新设计的更新提醒。 (#6156, #6162, #6281) 感谢 @wangchenglong0001。
+
+- 🏁 **Agent 有始有终。** 工具调用后卡住的会话现在会自己恢复，Kiro 运行会干净地完成回合而不是停在终点线前；当 AMR 运行真的卡住时，应用终于能告诉你原因，而不是耸耸肩。 (#6237, #6268, #6040) 感谢 @Siri-Ray。
+
+- 🙋 **必答题不再是一扇锁死的门。** 当 Agent 问了你无法回答或不想回答的问题，跳过它继续前进——Agent 会基于已有信息工作，而不是扣住你的运行。 (#6177)
+
+- 🕵️ **Clone Audit——上线克隆站之前，先确认它安不安全。** 新的社区插件会像评审者一样检查克隆站点：视觉还原度、残留的追踪脚本、源品牌与语言残留、占位符、有风险的外部依赖——然后交给你一份带文件行号实证的报告和明确的部署结论。 (#5687) 感谢 @bestthanapon。
+
+> 📥 **下载：** Tag `open-design-v0.18.0`。
+>
+> | 平台 | 架构 | 安装包 |
+> |---|---|---|
+> | macOS | Apple Silicon (arm64) | [open-design-0.18.0-mac-arm64.dmg](https://github.com/nexu-io/open-design/releases/download/open-design-v0.18.0/open-design-0.18.0-mac-arm64.dmg) |
+> | macOS | Intel (x64) | [open-design-0.18.0-mac-x64.dmg](https://github.com/nexu-io/open-design/releases/download/open-design-v0.18.0/open-design-0.18.0-mac-x64.dmg) |
+> | Windows | x64 | [open-design-0.18.0-win-x64-setup.exe](https://github.com/nexu-io/open-design/releases/download/open-design-v0.18.0/open-design-0.18.0-win-x64-setup.exe) |
+
+## ✨ 新增
+
+### 🏠 首页、项目与官网
+
+- **插件目录有了自己的门面。** 专门的落地页向新用户介绍 Open Design 插件，无需先安装应用。 (#6241) 感谢 @joeylee12629-star。
+
+- **Codex agent 页面现在回答人们真正在问的问题。** 为搜索 Codex UI 的用户带来更清晰的定位与内容。 (#6200) 感谢 @joeylee12629-star。
+
+## 🔁 变更
+
+- **Open Design 以明亮主题交付。** 新工作区界面为明亮外观调校，主题设置暂时下线，所有安装恢复为明亮主题。 (#6168)
+
+## 🐛 修复
+
+### 🎨 Studio 与界面
+
+- **内置浏览器预览会记住你的视口。** 设备尺寸选一次就一直生效，不再在会话之间被重置。 (#4899) 感谢 @HD-L。
+
+- **删除的项目不再纠缠你的标签页。** 移除项目会同时清掉它保存的标签页布局，陈旧的工作区状态不再复现。 (#5761) 感谢 @EthanGuo-coder。
+
+- **Azure 部署名称可以再次编辑。** Azure 上的 BYOK 用户可以直接改正部署名称，不用再和表单搏斗。 (#6034) 感谢 @mturac。
+
+### ☁️ Cloud 与可靠性
+
+- **计费检查学会了退避。** Cloud 计费端点不可达时，应用按退避曲线礼貌重试，而不是持续冲击一个失败中的连接。 (#6446)
+
+## 🙏 感谢所有为 0.18.0 出力的人
+
+@AmyShang-alt · Bassi · @bestthanapon · @bone3deep1962-collab · @crumgary · @elifive555555 · @EthanGuo-coder · @hanyuanxi · @HD-L · @itscheems · @joeylee12629-star · @lefarcen · @mrcfps · @mturac · @nettee · @PerishCode · @shangxinyu1 · @Siri-Ray · @wangchenglong0001 · @xiaoche-hub · @xne998808-ai · @xxiaoxiong

--- a/docs/CHANGELOG/v0.18.0/zh-CN.md
+++ b/docs/CHANGELOG/v0.18.0/zh-CN.md
@@ -1,11 +1,11 @@
 ---
 title: Open Design 0.18.0
-description: Workspace Team 在正式版构建中上线——团队工作区、共享项目与工具集、按工作区计费、全新首页设计，一个 Open Design Cloud 账号全部搞定。
+description: Open Design 0.18.0 带来 Team Workspace——设计团队共同的家：共享项目、查看更新、在上下文中评论，并复用同一套设计体系、插件与技能；协作工作区现已直接延伸进 Codex。
 ---
 
-### 🌟 Codename: *The World's First Design Agent for Teams*
+### 🌟 Codename: *Design Team Workspace. Now in Codex.*
 
-🤝 **`115 个 PR` · `22 位贡献者` · `2 天`** — **全球首个为团队而生的设计 Agent，来了。** 过去，你的作品只要想让同事看一眼，就得离开应用——导出、截图、追问"这是最新版吗？"。0.18.0 在 0.17.0 之后仅两天就抵达，因为它的货舱已经在构建开关后面装了整整一个月：团队工作区、共享项目、共享团队工具集、按工作区计费、全新首页。与你并肩设计的 Agent，现在是全团队共同创作的工作区。🚀
+🤝 **`115 个 PR` · `22 位贡献者` · `2 天`** — Open Design 0.18.0 带来 Team Workspace——设计团队共同的家：在这里共享项目、查看更新、在上下文中直接评论，并复用同一套设计体系、插件与技能。借助全新的 Open Design plugin for Codex，这个协作工作区现在直接延伸进 Codex。🚀
 
 ## 🔥 亮点
 


### PR DESCRIPTION
## Why

The stable promotion gate for 0.18.0 requires release notes before it will publish: the `metadata` dry-run of `release-stable` failed at *Validate stable release note policy* with `release notes are required for stable releases` ([run 31001593001](https://github.com/nexu-io/open-design/actions/runs/31001593001)). `tools-release` discovers notes under `docs/CHANGELOG/v{version}/` and stable requires both `en` and `zh-CN` locales; neither existed for 0.18.0 yet.

The note content itself was drafted and reviewed in #6464 (Workspace Team GA as the flagship, plus an ICYMI recap of 0.17.0's Codex plugin since that release lived only two days).

## What users will see

The 0.18.0 release notes (English and Simplified Chinese) in every surface that reads release data: the GitHub Release body, the in-app What's-new panel, and the landing changelog.

## Surface area

- [x] **None** — internal refactor, docs, tests, or translation update only

## Verification

Red: the gate run above failed on the missing notes. Green: from this branch,

```
RELEASE_CHANNEL=stable RELEASE_VERSION=0.18.0 pnpm exec tools-release prepare-release-note
# → prepared stable 0.18.0 release notes: en, zh-CN (plan state: ready)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
