### PR TITLE
ci(e2e): split workspace editor P0

### DIFF
--- a/e2e/lib/playwright/suites.ts
+++ b/e2e/lib/playwright/suites.ts
@@ -49,11 +49,22 @@ export const uiP0Groups = {
     workers: 1,
     files: [
       "ui/app.test.ts",
+      "ui/project-management-flows.test.ts",
+      "ui/workspace-keyboard-flows.test.ts",
+    ],
+  },
+  // Keep editor-heavy files on a separate single-worker runtime. Running the
+  // whole workspace domain serially took 11.6 minutes on CI, while enabling a
+  // second worker in one job is unsafe because these flows share Workspace
+  // authority state outside the worker-local daemon. Two runner-isolated jobs
+  // preserve that boundary and balance the historical file timings.
+  "project-workspace-editor": {
+    grep: String.raw`\[P0\]`,
+    workers: 1,
+    files: [
       "ui/app-design-files.test.ts",
       "ui/app-manual-edit.test.ts",
-      "ui/project-management-flows.test.ts",
       "ui/workspace-team-design-system-picker.test.ts",
-      "ui/workspace-keyboard-flows.test.ts",
     ],
   },
   // Split out of "project-workspace" (2026-08-04): the two multi-client collab
@@ -85,6 +96,7 @@ export const uiP0CiMatrix = [
   { name: "entry-settings", shard: "entry-settings" },
   { name: "entry-automations", shard: "entry-automations" },
   { name: "project-workspace", shard: "project-workspace" },
+  { name: "project-workspace-editor", shard: "project-workspace-editor" },
   { name: "project-collab", shard: "project-collab" },
   { name: "project-runtime", shard: "project-runtime" },
   { name: "workspace-restoration", shard: "workspace-restoration" },

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1160,19 +1160,26 @@ process.stdin.on("end", () => {
       "entry-settings",
       "entry-automations",
       "project-workspace",
+      "project-workspace-editor",
       "project-collab",
       "project-runtime",
       "workspace-restoration",
     ]);
     expect(uiP0Groups["project-workspace"].files).toEqual([
       "ui/app.test.ts",
-      "ui/app-design-files.test.ts",
-      "ui/app-manual-edit.test.ts",
       "ui/project-management-flows.test.ts",
-      "ui/workspace-team-design-system-picker.test.ts",
       "ui/workspace-keyboard-flows.test.ts",
     ]);
     expect(uiP0Groups["project-workspace"].workers).toBe(1);
+    expect(uiP0Groups["project-workspace-editor"]).toEqual({
+      grep: String.raw`\[P0\]`,
+      workers: 1,
+      files: [
+        "ui/app-design-files.test.ts",
+        "ui/app-manual-edit.test.ts",
+        "ui/workspace-team-design-system-picker.test.ts",
+      ],
+    });
     expect(uiP0Groups["project-collab"].files).toEqual([
       "ui/workspace-multi-client-collab.test.ts",
     ]);

--- a/e2e/tests/scripts/scopes.test.ts
+++ b/e2e/tests/scripts/scopes.test.ts
@@ -951,6 +951,7 @@ test("runtime-definition shadow fails closed for mixed, unknown, empty, and unre
         "entry-settings",
         "entry-automations",
         "project-workspace",
+        "project-workspace-editor",
         "project-collab",
         "project-runtime",
         "workspace-restoration",

--- a/e2e/ui/app-manual-edit.test.ts
+++ b/e2e/ui/app-manual-edit.test.ts
@@ -815,7 +815,7 @@ test('[P0] @critical edited HTML file restores selected tab and preview after re
   const restoredFrame = artifactPreviewFrame(page);
   const restoredTitle = restoredFrame.getByRole('heading', { name: 'Original Hero' });
   await expect(restoredTitle).toBeVisible();
-  await expect.poll(async () => restoredTitle.evaluate((el) => getComputedStyle(el).fontSize)).toBe('52px');
+  await expect(restoredTitle).toHaveCSS('font-size', '52px');
   await expect(restoredTitle).toHaveCSS('color', 'rgb(37, 99, 235)');
 });
 

--- a/e2e/ui/app.test.ts
+++ b/e2e/ui/app.test.ts
@@ -1500,7 +1500,6 @@ async function runFileUploadSendFlow(
   await expect((await uploadResponse).ok()).toBeTruthy();
 
   await expect(stagedAttachmentName(page, 'reference.txt')).toBeVisible();
-  await expect(page.getByText('reference.txt', { exact: true })).toBeVisible();
 
   await sendPrompt(page, entry.prompt);
   await expect(page.locator('.msg.user').getByText(entry.prompt, { exact: true })).toBeVisible();

--- a/scripts/lib/guard/scope.ts
+++ b/scripts/lib/guard/scope.ts
@@ -19,6 +19,7 @@ const fullMatrixNames = [
   "entry-settings",
   "entry-automations",
   "project-workspace",
+  "project-workspace-editor",
   "project-collab",
   "project-runtime",
   "workspace-restoration",
@@ -41,7 +42,7 @@ function sameValues(actual: readonly string[], expected: readonly string[]): boo
 export function uiP0ShadowContractErrors(): string[] {
   const errors: string[] = [];
   if (!sameValues(matrixNames(uiP0CiMatrix), fullMatrixNames)) {
-    errors.push("the applied UI P0 matrix is no longer the guarded full six-domain matrix");
+    errors.push("the applied UI P0 matrix is no longer the guarded full seven-domain matrix");
   }
 
   const sourceSample = `${DAEMON_RUNTIME_DEFINITION_PREFIXES[0]}example.ts`;


### PR DESCRIPTION
## Why

The `project-workspace` UI P0 job on #6445 passed, but its slowest observed run took 13m12s (11m40s in the serial Playwright step). The #6445 merge-queue run `31024602228` still took 9m26s, including an approximately 56-second first-attempt failure and retry in `project-management-flows.test.ts`.

This stacked PR keeps worker-level Workspace isolation while distributing the historical file timings across two runner-isolated jobs.

## What users will see

No product behavior changes. Contributors should see the workspace P0 gate complete in two balanced jobs instead of one long serial job, with fewer retry-only passes.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this changes test topology and assertion synchronization only.

## Bug fix verification

- The manual-edit CSS assertion now uses Playwright's locator-native `toHaveCSS`, which re-resolves the frame locator across navigation instead of holding a stale iframe execution context.
- The upload flow keeps its staged-attachment assertion and removes a redundant global text assertion that could match both the design-file row and staged filename.
- Hosted run `31064947330` passed both jobs without retries:
  - `project-workspace`: 25/25 tests in 4.0m; full job 5m32s.
  - `project-workspace-editor`: 13/13 tests in 4.4m; full job 5m51s.
- The new longest workspace path is 5m51s: 3m35s (38%) below the 9m26s #6445 merge-queue baseline and 7m21s (56%) below the 13m12s slow sample.

## Validation

- `pnpm --filter @open-design/e2e test tests/packaged-smoke-workflow.test.ts` — 56 passed
- `pnpm --filter @open-design/e2e test tests/scripts/scopes.test.ts` — 52 passed
- `pnpm --filter @open-design/e2e test tests/playwright-runtime-lifecycle.test.ts` — 5 passed
- `pnpm --filter @open-design/e2e typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
- Hosted Actions run `31064947330` — full workflow passed; both workspace UI P0 jobs passed without retries

## Stack

- Base: #6445 (`codex/cleanup-workspace-p0-e2e`)
- Retarget to `main` after #6445 merges.