### PR TITLE
fix(release): allow a skipped windows smoke on the stable lane

### DIFF
--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -1261,7 +1261,15 @@ jobs:
           name: open-design-release-mac-e2e-report
           path: ${{ runner.temp }}/release-report/mac
 
+      # The windows smoke uploads this artifact with `if-no-files-found: warn`,
+      # so a skipped smoke leaves an empty report directory and publishes no
+      # artifact at all. Downloading it unconditionally then fails finalize —
+      # after all three platforms have already built, signed and notarized —
+      # which makes `win_x64_smoke_mode: skip` unusable on the stable lane even
+      # though the input offers it. Guard it the way the linux report is guarded
+      # by its own build result.
       - name: Download windows e2e spec report
+        if: ${{ inputs.win_x64_smoke_mode != 'skip' }}
         uses: actions/download-artifact@v8
         with:
           name: open-design-release-win-e2e-report


### PR DESCRIPTION
## Why

`release-stable.yml` offers `win_x64_smoke_mode: skip`, but picking it makes the release **impossible to finish** — and it fails in the most expensive place possible.

The windows smoke uploads its e2e report with `if-no-files-found: warn`, so a skipped smoke leaves the report directory empty and publishes no artifact at all. The finalize job then downloads that artifact unconditionally and dies. By that point all three platforms have already built, signed and notarized, and the pre-flight tag check has passed — roughly 25 minutes of work thrown away for a report that nothing downstream reads.

Hit while cutting 0.18.0: the P2 windows smoke asserts a fresh install reaches home, which the cloud sign-in onboarding structurally prevents (the sibling P0 case asserts the opposite — that a fresh install *shows* onboarding). `skip` is the documented escape hatch and is exactly what this branch's own `notify-release-feishu` hardcodes, so it needs to actually work.

## What

Guard the download on the same condition that gates the smoke itself:

```yaml
- name: Download windows e2e spec report
  if: ${{ inputs.win_x64_smoke_mode != 'skip' }}
```

This mirrors how the linux report is guarded by its build result. The mac report stays unconditional — the mac smoke has no skip switch.

## Validation

- YAML parsed with a real loader: 9 jobs, guard resolves to `${{ inputs.win_x64_smoke_mode != 'skip' }}`.
- Empirically reproduced three times on run `31020314879`: every platform green, `Pre-flight tag/release check` green, then `Download windows e2e spec report` fails with the artifact missing.
- Nothing in the finalize job reads `release-report/win` after the download — the three report downloads have no consumer in that job.

## Follow-up (not in this PR)

The P2 windows smoke's "must reach home" expectation is stale and contradicts the P0 case. It should be taught about the cloud sign-in shell so Windows regains real smoke coverage instead of living on `skip`.

## Surface area

- [x] CI / GitHub Actions workflows