### PR TITLE
fix(e2e): let the Windows packaged smoke settle on the cloud sign-in landing

### DIFF
--- a/e2e/lib/vitest/packaged-app-shell.ts
+++ b/e2e/lib/vitest/packaged-app-shell.ts
@@ -127,6 +127,28 @@ export function packagedAppShellState(value: unknown): PackagedAppShellState | n
   return null;
 }
 
+export type PackagedAppShellPolicyInput = {
+  /**
+   * What the daemon itself reports for `onboardingCompleted`, read from
+   * `GET /api/app-config` — which serves `readAppConfig(RUNTIME_DATA_DIR)`, the
+   * daemon's own resolved data root.
+   */
+  readonly daemonOnboardingCompleted: boolean;
+  /** Whether the run is the core smoke profile. */
+  readonly coreProfile: boolean;
+};
+
+/**
+ * Which terminal states this run may settle on.
+ *
+ * Currently keyed off the smoke profile alone.
+ */
+export function packagedAppShellPolicy(
+  input: PackagedAppShellPolicyInput,
+): { readonly acceptOnboardingLanding: boolean } {
+  return { acceptOnboardingLanding: input.coreProfile };
+}
+
 /**
  * Whether the renderer has reached a surface the caller can proceed from.
  *

--- a/e2e/lib/vitest/packaged-app-shell.ts
+++ b/e2e/lib/vitest/packaged-app-shell.ts
@@ -394,9 +394,11 @@ export async function runPackagedAppShellPhase(options: {
   readonly timeoutMs?: number;
 }): Promise<{ appShell: PackagedAppShellState; onboardingCompleted: boolean }> {
   const onboardingCompleted = await options.readOnboardingCompleted();
-  // The smoke seeds completion unconditionally (win.spec.ts), so every phase is
-  // a completed-user phase.
-  const seededOnboardingCompleted = true;
+  // Only a completed-user phase carries a seed to hold across the transition. A
+  // first-run phase deliberately has none, so `false` there is the fact under
+  // test rather than a loss — which is why the scenario has to be declared by
+  // the caller instead of inferred from the reading.
+  const seededOnboardingCompleted = options.scenario === 'completed-user';
   assertSeededOnboardingRetained({ daemonOnboardingCompleted: onboardingCompleted, seededOnboardingCompleted });
   const policy = packagedAppShellPolicy({
     coreProfile: options.coreProfile,

--- a/e2e/lib/vitest/packaged-app-shell.ts
+++ b/e2e/lib/vitest/packaged-app-shell.ts
@@ -141,30 +141,39 @@ const PACKAGED_ONBOARDING_CONFIG_PROBE = `
     try {
       const response = await fetchImpl('/api/app-config');
       const status = typeof response.status === 'number' ? response.status : null;
-      if (!response.ok) return { error: 'daemon returned HTTP ' + status, ok: false, status };
+      if (!response.ok) return { error: 'daemon returned HTTP ' + status, kind: 'http-error', ok: false, status };
       const body = await response.json();
       const config = body == null ? null : body.config;
       if (config == null || typeof config !== 'object' || Array.isArray(config)) {
-        return { error: 'daemon response carried no config object', ok: false, status };
+        return { error: 'daemon response carried no config object', kind: 'no-config', ok: false, status };
+      }
+      // Absent is not malformed. A daemon whose app-config.json does not exist
+      // returns {} plus telemetry defaults, so the key is simply missing — a
+      // legitimate reading of a fresh install. A key present with the wrong type
+      // is corruption. They get different outcomes because different scenarios
+      // may accept them.
+      if (!('onboardingCompleted' in config)) {
+        return { kind: 'absent', ok: false, status };
       }
       // Require the type before reading it. Coercing here (\`x === true\`) would
-      // manufacture a boolean out of a missing key, a null, or the string
-      // "false" — and the manufactured value is \`false\`, which is exactly the
-      // reading that permits the onboarding landing. "The daemon did not tell
-      // me" must never arrive as "the daemon told me false".
+      // manufacture a boolean out of a null or the string "false" — and the
+      // manufactured value is \`false\`, which is exactly the reading that
+      // permits the onboarding landing.
       if (typeof config.onboardingCompleted !== 'boolean') {
         return {
-          error: 'daemon config carried no boolean onboardingCompleted (got '
-            + (config.onboardingCompleted === undefined ? 'undefined' : typeof config.onboardingCompleted)
+          error: 'daemon config carried a non-boolean onboardingCompleted (got '
+            + (config.onboardingCompleted === null ? 'null' : typeof config.onboardingCompleted)
             + ')',
+          kind: 'malformed',
           ok: false,
           status,
         };
       }
-      return { ok: true, onboardingCompleted: config.onboardingCompleted, status };
+      return { kind: 'reading', ok: true, onboardingCompleted: config.onboardingCompleted, status };
     } catch (error) {
       return {
         error: error instanceof Error ? error.message : String(error),
+        kind: 'transport-failure',
         ok: false,
         status: null,
       };
@@ -207,35 +216,115 @@ export class PackagedOnboardingConfigError extends Error {
  *
  * Never returns a default. An unestablished fact must not become a permission.
  */
-export function packagedOnboardingCompletedFromProbe(value: unknown): boolean {
+/**
+ * The complete set of distinct outcomes this probe can produce, and which
+ * scenario may accept each. Seven review rounds on #6481 each found a defect of
+ * one family: a *fault* and an *absence* sharing a representation. This table is
+ * the fix for the family rather than for any one instance.
+ *
+ * | outcome            | meaning                                    | first-run | completed-user |
+ * |--------------------|--------------------------------------------|-----------|----------------|
+ * | `transport-failure`| fetch rejected; daemon unreachable         | reject    | reject         |
+ * | `http-error`       | non-2xx from `/api/app-config`             | reject    | reject         |
+ * | `no-config`        | 200 whose body carried no `config` object  | reject    | reject         |
+ * | `absent`           | 200, `config` present, key never written   | **accept**| reject         |
+ * | `malformed`        | key present but not a boolean              | reject    | reject         |
+ * | `reading`          | key present and boolean                    | accept    | accept if true |
+ *
+ * `absent` is the only asymmetric row, and it is asymmetric for a reason: a key
+ * that was never written is the honest state of a fresh install, whereas in a
+ * run that seeded completion its disappearance means the seed vanished.
+ */
+export type PackagedOnboardingConfigOutcomeKind =
+  | 'absent'
+  | 'http-error'
+  | 'malformed'
+  | 'no-config'
+  | 'reading'
+  | 'transport-failure';
+
+export type PackagedOnboardingConfigOutcome = {
+  readonly error: string | null;
+  readonly kind: PackagedOnboardingConfigOutcomeKind;
+  readonly onboardingCompleted: boolean | null;
+  readonly status: number | null;
+};
+
+const PACKAGED_ONBOARDING_OUTCOME_KINDS: readonly PackagedOnboardingConfigOutcomeKind[] = [
+  'absent',
+  'http-error',
+  'malformed',
+  'no-config',
+  'reading',
+  'transport-failure',
+];
+
+/**
+ * Classifies a probe result. Raises only when the probe itself produced
+ * something unusable — never to express a daemon-side fault, which is a value.
+ */
+export function packagedOnboardingOutcomeFromProbe(value: unknown): PackagedOnboardingConfigOutcome {
   if (typeof value !== 'object' || value == null || Array.isArray(value)) {
     throw new PackagedOnboardingConfigError(
       `the probe returned no result (${JSON.stringify(value) ?? 'undefined'})`,
     );
   }
   const candidate = value as Record<string, unknown>;
+  const kind = candidate.kind;
+  if (typeof kind !== 'string' || !PACKAGED_ONBOARDING_OUTCOME_KINDS.includes(kind as PackagedOnboardingConfigOutcomeKind)) {
+    throw new PackagedOnboardingConfigError(`the probe returned no recognisable outcome (${JSON.stringify(candidate)})`);
+  }
   const status = typeof candidate.status === 'number' ? candidate.status : null;
-  const reason = typeof candidate.error === 'string' ? candidate.error : null;
+  if (kind === 'reading') {
+    if (status !== 200 || typeof candidate.onboardingCompleted !== 'boolean') {
+      throw new PackagedOnboardingConfigError(
+        `the probe claimed a reading without one (${JSON.stringify(candidate)})`,
+      );
+    }
+    return { error: null, kind, onboardingCompleted: candidate.onboardingCompleted, status };
+  }
+  return {
+    error: typeof candidate.error === 'string' ? candidate.error : null,
+    kind: kind as PackagedOnboardingConfigOutcomeKind,
+    onboardingCompleted: null,
+    status,
+  };
+}
 
-  // `status` is load-bearing, not decorative: only a 200 that actually carried a
-  // config object may produce a reading. Everything else — a transport failure,
-  // a non-2xx, a body without `config` — is an unestablished fact and must
-  // raise, because the only alternative reading (`false`) is precisely the one
-  // that would permit the onboarding landing.
-  if (candidate.ok !== true) {
-    throw new PackagedOnboardingConfigError(
-      `${reason ?? 'the probe reported failure'} (status=${status ?? 'none'})`,
+/**
+ * Applies the table above: the daemon's onboarding fact for this scenario, or an
+ * error naming what could not be established.
+ */
+export function packagedOnboardingCompletedForScenario(
+  outcome: PackagedOnboardingConfigOutcome,
+  scenario: PackagedLaunchScenario,
+): boolean {
+  if (outcome.kind === 'reading') {
+    if (outcome.onboardingCompleted == null) {
+      throw new PackagedOnboardingConfigError('the reading carried no value');
+    }
+    return outcome.onboardingCompleted;
+  }
+  if (outcome.kind === 'absent') {
+    // A fresh install has never written the key; that IS "not completed".
+    if (scenario === 'first-run') return false;
+    // In a seeded run the key must exist. Its absence means the seed vanished,
+    // which is the round-5 regression, so raise that cause rather than this one.
+    throw new PackagedOnboardingSeedError(
+      'the relaunched daemon has no onboardingCompleted at all, so the seeded state is gone — check that the protocol cold launch still resolves the tools-pack runtime data root',
     );
   }
-  if (status !== 200) {
-    throw new PackagedOnboardingConfigError(`the daemon answered with status=${status ?? 'none'}`);
-  }
-  if (typeof candidate.onboardingCompleted !== 'boolean') {
-    throw new PackagedOnboardingConfigError(
-      `the daemon answered 200 without a usable reading (${JSON.stringify(candidate)})`,
-    );
-  }
-  return candidate.onboardingCompleted;
+  throw new PackagedOnboardingConfigError(
+    `${outcome.error ?? outcome.kind} (status=${outcome.status ?? 'none'})`,
+  );
+}
+
+/**
+ * Back-compat reader for call sites that already know they are in a seeded
+ * (completed-user) run, where every non-reading outcome is a fault.
+ */
+export function packagedOnboardingCompletedFromProbe(value: unknown): boolean {
+  return packagedOnboardingCompletedForScenario(packagedOnboardingOutcomeFromProbe(value), 'completed-user');
 }
 
 export type PackagedAppShellPolicyInput = {
@@ -393,7 +482,10 @@ export async function runPackagedAppShellPhase(options: {
   readonly sleep?: (ms: number) => Promise<void>;
   readonly timeoutMs?: number;
 }): Promise<{ appShell: PackagedAppShellState; onboardingCompleted: boolean }> {
-  const onboardingCompleted = packagedOnboardingCompletedFromProbe(await options.readOnboardingConfig());
+  const onboardingCompleted = packagedOnboardingCompletedForScenario(
+    packagedOnboardingOutcomeFromProbe(await options.readOnboardingConfig()),
+    options.scenario,
+  );
   // Only a completed-user phase carries a seed to hold across the transition. A
   // first-run phase deliberately has none, so `false` there is the fact under
   // test rather than a loss — which is why the scenario has to be declared by

--- a/e2e/lib/vitest/packaged-app-shell.ts
+++ b/e2e/lib/vitest/packaged-app-shell.ts
@@ -388,12 +388,12 @@ export async function runPackagedAppShellPhase(options: {
   readonly describeLast?: (value: unknown) => string;
   readonly now?: () => number;
   readonly observe: () => Promise<unknown>;
-  readonly readOnboardingCompleted: () => Promise<boolean>;
+  readonly readOnboardingConfig: () => Promise<unknown>;
   readonly scenario: PackagedLaunchScenario;
   readonly sleep?: (ms: number) => Promise<void>;
   readonly timeoutMs?: number;
 }): Promise<{ appShell: PackagedAppShellState; onboardingCompleted: boolean }> {
-  const onboardingCompleted = await options.readOnboardingCompleted();
+  const onboardingCompleted = packagedOnboardingCompletedFromProbe(await options.readOnboardingConfig());
   // Only a completed-user phase carries a seed to hold across the transition. A
   // first-run phase deliberately has none, so `false` there is the fact under
   // test rather than a loss — which is why the scenario has to be declared by

--- a/e2e/lib/vitest/packaged-app-shell.ts
+++ b/e2e/lib/vitest/packaged-app-shell.ts
@@ -274,12 +274,51 @@ export type PackagedAppShellPolicyInput = {
 export function packagedAppShellPolicy(
   input: PackagedAppShellPolicyInput,
 ): { readonly acceptOnboardingLanding: boolean } {
+  // A run that seeded completion and saw the daemon confirm it may never accept
+  // the landing, whatever a later reading says. Losing the seed across a
+  // relaunch is a regression, not a downgrade to "genuine first run" — see
+  // `assertSeededOnboardingRetained`, which is what turns that loss into a
+  // named failure rather than merely a stricter expectation here.
+  if (input.seededOnboardingCompleted !== false) return { acceptOnboardingLanding: false };
   // Only an explicit `false` — a daemon that positively said "not completed" —
   // buys permission. Testing for truthiness instead would let any non-boolean
   // that leaked past the type fall through to the permissive branch, which is
   // the same shape of defect as coercing the reading in the first place.
   if (input.daemonOnboardingCompleted !== false) return { acceptOnboardingLanding: false };
   return { acceptOnboardingLanding: input.coreProfile === true };
+}
+
+/**
+ * Raised when a run that seeded onboarding completion, and saw the daemon
+ * confirm it, later observes it gone.
+ */
+export class PackagedOnboardingSeedError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = 'PackagedOnboardingSeedError';
+  }
+}
+
+/**
+ * Holds the run's own seeded state across a process transition.
+ *
+ * Once this run has seeded completion and observed `true`, a later `false` is a
+ * regression in the packaged runtime, never new information about the user. The
+ * core profile stops the app and relaunches it through the OS protocol handler,
+ * which inherits none of this process's environment — so if that cold launch
+ * resolves a different data root, the seeded config disappears. This is the
+ * point where that loss becomes a failure with a cause attached, instead of
+ * being absorbed as a first run.
+ */
+export function assertSeededOnboardingRetained(input: {
+  readonly daemonOnboardingCompleted: boolean;
+  readonly seededOnboardingCompleted: boolean;
+}): void {
+  if (input.seededOnboardingCompleted !== true) return;
+  if (input.daemonOnboardingCompleted === true) return;
+  throw new PackagedOnboardingSeedError(
+    'the relaunched daemon lost the seeded onboarding state — check that the protocol cold launch still resolves the tools-pack runtime data root',
+  );
 }
 
 /**

--- a/e2e/lib/vitest/packaged-app-shell.ts
+++ b/e2e/lib/vitest/packaged-app-shell.ts
@@ -144,10 +144,24 @@ const PACKAGED_ONBOARDING_CONFIG_PROBE = `
       if (!response.ok) return { error: 'daemon returned HTTP ' + status, ok: false, status };
       const body = await response.json();
       const config = body == null ? null : body.config;
-      if (config == null || typeof config !== 'object') {
+      if (config == null || typeof config !== 'object' || Array.isArray(config)) {
         return { error: 'daemon response carried no config object', ok: false, status };
       }
-      return { ok: true, onboardingCompleted: config.onboardingCompleted === true, status };
+      // Require the type before reading it. Coercing here (\`x === true\`) would
+      // manufacture a boolean out of a missing key, a null, or the string
+      // "false" — and the manufactured value is \`false\`, which is exactly the
+      // reading that permits the onboarding landing. "The daemon did not tell
+      // me" must never arrive as "the daemon told me false".
+      if (typeof config.onboardingCompleted !== 'boolean') {
+        return {
+          error: 'daemon config carried no boolean onboardingCompleted (got '
+            + (config.onboardingCompleted === undefined ? 'undefined' : typeof config.onboardingCompleted)
+            + ')',
+          ok: false,
+          status,
+        };
+      }
+      return { ok: true, onboardingCompleted: config.onboardingCompleted, status };
     } catch (error) {
       return {
         error: error instanceof Error ? error.message : String(error),
@@ -254,8 +268,12 @@ export type PackagedAppShellPolicyInput = {
 export function packagedAppShellPolicy(
   input: PackagedAppShellPolicyInput,
 ): { readonly acceptOnboardingLanding: boolean } {
-  if (input.daemonOnboardingCompleted) return { acceptOnboardingLanding: false };
-  return { acceptOnboardingLanding: input.coreProfile };
+  // Only an explicit `false` — a daemon that positively said "not completed" —
+  // buys permission. Testing for truthiness instead would let any non-boolean
+  // that leaked past the type fall through to the permissive branch, which is
+  // the same shape of defect as coercing the reading in the first place.
+  if (input.daemonOnboardingCompleted !== false) return { acceptOnboardingLanding: false };
+  return { acceptOnboardingLanding: input.coreProfile === true };
 }
 
 /**
@@ -270,7 +288,8 @@ export function packagedAppShellSettled(
 ): boolean {
   const state = packagedAppShellState(value);
   if (state === 'home') return true;
-  return state === 'onboarding-landing' && options.acceptOnboardingLanding;
+  // Explicit permission only, for the same reason as `packagedAppShellPolicy`.
+  return state === 'onboarding-landing' && options.acceptOnboardingLanding === true;
 }
 
 /**

--- a/e2e/lib/vitest/packaged-app-shell.ts
+++ b/e2e/lib/vitest/packaged-app-shell.ts
@@ -141,11 +141,23 @@ export type PackagedAppShellPolicyInput = {
 /**
  * Which terminal states this run may settle on.
  *
- * Currently keyed off the smoke profile alone.
+ * Derived from the daemon's own `onboardingCompleted`, never from the smoke
+ * profile, so a run's setup and its accepted terminal state cannot disagree.
+ * The smoke seeds `onboardingCompleted: true` before start; if the daemon
+ * confirms it, the renderer must honour it and home is the only acceptable
+ * outcome — that is what keeps a broken completed-onboarding boot path
+ * detectable on the core release lane. Only a run whose daemon reports
+ * onboarding as *not* completed is a genuine first run, and only then is the
+ * cloud sign-in landing a legitimate place to stop.
+ *
+ * `coreProfile` still narrows it: the full profile goes on to drive the entry
+ * rail, which `clickUpdaterRailExpression` refuses while onboarding is up, so
+ * it needs home either way.
  */
 export function packagedAppShellPolicy(
   input: PackagedAppShellPolicyInput,
 ): { readonly acceptOnboardingLanding: boolean } {
+  if (input.daemonOnboardingCompleted) return { acceptOnboardingLanding: false };
   return { acceptOnboardingLanding: input.coreProfile };
 }
 

--- a/e2e/lib/vitest/packaged-app-shell.ts
+++ b/e2e/lib/vitest/packaged-app-shell.ts
@@ -247,7 +247,13 @@ export type PackagedAppShellPolicyInput = {
   readonly daemonOnboardingCompleted: boolean;
   /** Whether the run is the core smoke profile. */
   readonly coreProfile: boolean;
+  /**
+   * Whether this run seeded onboarding completion and observed the daemon
+   * confirm it earlier, before any relaunch.
+   */
+  readonly seededOnboardingCompleted: boolean;
 };
+
 
 /**
  * Which terminal states this run may settle on.

--- a/e2e/lib/vitest/packaged-app-shell.ts
+++ b/e2e/lib/vitest/packaged-app-shell.ts
@@ -1,0 +1,149 @@
+/**
+ * The packaged Windows smoke's app-shell probe and the rule that reads it.
+ *
+ * `specs/win.spec.ts` only executes on a Windows runner that has a packaged
+ * build installed, and the probe below reaches the packaged renderer as a
+ * plain string through `tools-pack inspect --expr` — so neither the compiler
+ * nor any cross-platform suite ever sees it. Keeping the probe text and the
+ * terminal-state rule that consumes its result in one pure module lets
+ * `tests/packaged/app-shell.test.ts` hold both to a contract from any platform.
+ */
+
+/**
+ * Runs inside the packaged renderer. Written as a two-argument arrow function
+ * rather than an IIFE so the exact same text can be evaluated in Node against a
+ * fixture document (see `evaluatePackagedAppShellProbe`); in the renderer both
+ * arguments are the ordinary globals.
+ */
+const PACKAGED_APP_SHELL_PROBE = `
+  (doc, ElementCtor) => {
+    const home = doc.querySelector('[data-testid="entry-nav-home"]');
+    const onboardingShell = doc.querySelector('.entry-shell--onboarding, .entry-onboarding-modal');
+    const cloudSignIn = doc.querySelector('.onboarding-cloud__primary');
+    const secondaryLinks = Array.from(doc.querySelectorAll('.onboarding-cloud__secondary'));
+    return {
+      byokLinkVisible: secondaryLinks[1] instanceof ElementCtor,
+      cloudSignInVisible: cloudSignIn instanceof ElementCtor,
+      homeVisible: home instanceof ElementCtor && home.getClientRects().length > 0,
+      localLinkVisible: secondaryLinks[0] instanceof ElementCtor,
+      onboardingVisible: onboardingShell instanceof ElementCtor,
+      text: doc.body?.textContent?.trim().slice(0, 300) ?? '',
+      title: doc.title,
+    };
+  }
+`;
+
+export const packagedAppShellExpression = `(${PACKAGED_APP_SHELL_PROBE})(document, HTMLElement)`;
+
+export type PackagedAppShellSnapshot = {
+  byokLinkVisible: boolean;
+  cloudSignInVisible: boolean;
+  homeVisible: boolean;
+  localLinkVisible: boolean;
+  onboardingVisible: boolean;
+  text: string;
+  title: string;
+};
+
+export type PackagedAppShellProbeElement = {
+  getClientRects(): ArrayLike<unknown>;
+};
+
+export type PackagedAppShellProbeDocument = {
+  body: { textContent: string | null } | null;
+  querySelector(selectors: string): PackagedAppShellProbeElement | null;
+  querySelectorAll(selectors: string): Iterable<PackagedAppShellProbeElement>;
+  title: string;
+};
+
+/**
+ * Evaluates the shipped probe text against a fixture document.
+ *
+ * The probe is a string, so nothing in the normal build checks it. Running the
+ * identical text here is the only way a non-Windows machine can prove that the
+ * selectors, the `getClientRects` visibility rule, and the reported field set
+ * still behave as the smoke expects.
+ */
+export function evaluatePackagedAppShellProbe(
+  document: PackagedAppShellProbeDocument,
+  elementConstructor: new (...args: never[]) => PackagedAppShellProbeElement,
+): unknown {
+  // Parenthesized deliberately: the probe text opens with a newline, and a bare
+  // `return` followed by one gets an automatic semicolon.
+  const probe = new Function(`return (${PACKAGED_APP_SHELL_PROBE});`)() as (
+    document: PackagedAppShellProbeDocument,
+    elementConstructor: unknown,
+  ) => unknown;
+  return probe(document, elementConstructor);
+}
+
+export function asPackagedAppShellSnapshot(value: unknown): PackagedAppShellSnapshot | null {
+  if (typeof value !== 'object' || value == null || Array.isArray(value)) return null;
+  const candidate = value as Partial<PackagedAppShellSnapshot>;
+  if (
+    typeof candidate.byokLinkVisible !== 'boolean' ||
+    typeof candidate.cloudSignInVisible !== 'boolean' ||
+    typeof candidate.homeVisible !== 'boolean' ||
+    typeof candidate.localLinkVisible !== 'boolean' ||
+    typeof candidate.onboardingVisible !== 'boolean' ||
+    typeof candidate.text !== 'string' ||
+    typeof candidate.title !== 'string'
+  ) {
+    return null;
+  }
+  return candidate as PackagedAppShellSnapshot;
+}
+
+/**
+ * A surface the packaged app can legitimately come to rest on.
+ *
+ * `home` is the signed-in/seeded main shell. `onboarding-landing` is the cloud
+ * sign-in landing a first run stops at.
+ */
+export type PackagedAppShellState = 'home' | 'onboarding-landing';
+
+/**
+ * Which settled surface the renderer is showing, or `null` while it is showing
+ * neither — a blank window, a crashed renderer, a boot still on the loader, or
+ * a half-rendered onboarding shell all fall through to `null`.
+ */
+export function packagedAppShellState(value: unknown): PackagedAppShellState | null {
+  const snapshot = asPackagedAppShellSnapshot(value);
+  if (snapshot == null) return null;
+  if (snapshot.homeVisible) return 'home';
+  return null;
+}
+
+/**
+ * Whether the renderer has reached a surface the caller can proceed from.
+ *
+ * `acceptOnboardingLanding` belongs to the caller because the answer depends on
+ * what the smoke does next, not on what the app is allowed to show.
+ */
+export function packagedAppShellSettled(
+  value: unknown,
+  options: { readonly acceptOnboardingLanding: boolean },
+): boolean {
+  const state = packagedAppShellState(value);
+  if (state === 'home') return true;
+  return state === 'onboarding-landing' && options.acceptOnboardingLanding;
+}
+
+/**
+ * A named cause for the timeout, so a failed run points at a layer instead of
+ * dumping an opaque snapshot.
+ */
+export function packagedAppShellFailureReason(
+  value: unknown,
+  options: { readonly acceptOnboardingLanding: boolean },
+): string {
+  const snapshot = asPackagedAppShellSnapshot(value);
+  if (snapshot == null) return 'the packaged renderer returned no app-shell snapshot';
+  if (packagedAppShellState(value) === 'onboarding-landing' && !options.acceptOnboardingLanding) {
+    return 'the packaged renderer stopped on the onboarding cloud sign-in landing, but this smoke profile has to drive the entry rail and needs home';
+  }
+  if (snapshot.onboardingVisible) {
+    return 'the onboarding shell mounted but its cloud sign-in landing did not render (no sign-in CTA, or fewer than two runtime links)';
+  }
+  return 'neither the home nav rail nor the onboarding cloud sign-in landing rendered';
+}

--- a/e2e/lib/vitest/packaged-app-shell.ts
+++ b/e2e/lib/vitest/packaged-app-shell.ts
@@ -106,11 +106,24 @@ export type PackagedAppShellState = 'home' | 'onboarding-landing';
  * Which settled surface the renderer is showing, or `null` while it is showing
  * neither — a blank window, a crashed renderer, a boot still on the loader, or
  * a half-rendered onboarding shell all fall through to `null`.
+ *
+ * The landing is recognised positively, from the same three affordances the
+ * `[P0]` onboarding smoke asserts: the sign-in CTA plus both runtime links. A
+ * bare `onboardingVisible` would degrade this into "anything that is not home"
+ * and stop failing on a renderer that mounted the shell and then died.
  */
 export function packagedAppShellState(value: unknown): PackagedAppShellState | null {
   const snapshot = asPackagedAppShellSnapshot(value);
   if (snapshot == null) return null;
   if (snapshot.homeVisible) return 'home';
+  if (
+    snapshot.onboardingVisible &&
+    snapshot.cloudSignInVisible &&
+    snapshot.localLinkVisible &&
+    snapshot.byokLinkVisible
+  ) {
+    return 'onboarding-landing';
+  }
   return null;
 }
 

--- a/e2e/lib/vitest/packaged-app-shell.ts
+++ b/e2e/lib/vitest/packaged-app-shell.ts
@@ -138,12 +138,23 @@ export function packagedAppShellState(value: unknown): PackagedAppShellState | n
  */
 const PACKAGED_ONBOARDING_CONFIG_PROBE = `
   (async (fetchImpl) => {
-    const response = await fetchImpl('/api/app-config');
-    const body = response.ok ? await response.json() : null;
-    return {
-      onboardingCompleted: body?.config?.onboardingCompleted === true,
-      status: response.status,
-    };
+    try {
+      const response = await fetchImpl('/api/app-config');
+      const status = typeof response.status === 'number' ? response.status : null;
+      if (!response.ok) return { error: 'daemon returned HTTP ' + status, ok: false, status };
+      const body = await response.json();
+      const config = body == null ? null : body.config;
+      if (config == null || typeof config !== 'object') {
+        return { error: 'daemon response carried no config object', ok: false, status };
+      }
+      return { ok: true, onboardingCompleted: config.onboardingCompleted === true, status };
+    } catch (error) {
+      return {
+        error: error instanceof Error ? error.message : String(error),
+        ok: false,
+        status: null,
+      };
+    }
   })
 `;
 
@@ -184,11 +195,31 @@ export class PackagedOnboardingConfigError extends Error {
  */
 export function packagedOnboardingCompletedFromProbe(value: unknown): boolean {
   if (typeof value !== 'object' || value == null || Array.isArray(value)) {
-    throw new PackagedOnboardingConfigError(`probe returned no result (${JSON.stringify(value) ?? 'undefined'})`);
+    throw new PackagedOnboardingConfigError(
+      `the probe returned no result (${JSON.stringify(value) ?? 'undefined'})`,
+    );
   }
   const candidate = value as Record<string, unknown>;
+  const status = typeof candidate.status === 'number' ? candidate.status : null;
+  const reason = typeof candidate.error === 'string' ? candidate.error : null;
+
+  // `status` is load-bearing, not decorative: only a 200 that actually carried a
+  // config object may produce a reading. Everything else — a transport failure,
+  // a non-2xx, a body without `config` — is an unestablished fact and must
+  // raise, because the only alternative reading (`false`) is precisely the one
+  // that would permit the onboarding landing.
+  if (candidate.ok !== true) {
+    throw new PackagedOnboardingConfigError(
+      `${reason ?? 'the probe reported failure'} (status=${status ?? 'none'})`,
+    );
+  }
+  if (status !== 200) {
+    throw new PackagedOnboardingConfigError(`the daemon answered with status=${status ?? 'none'}`);
+  }
   if (typeof candidate.onboardingCompleted !== 'boolean') {
-    throw new PackagedOnboardingConfigError(`probe returned no reading (${JSON.stringify(candidate)})`);
+    throw new PackagedOnboardingConfigError(
+      `the daemon answered 200 without a usable reading (${JSON.stringify(candidate)})`,
+    );
   }
   return candidate.onboardingCompleted;
 }

--- a/e2e/lib/vitest/packaged-app-shell.ts
+++ b/e2e/lib/vitest/packaged-app-shell.ts
@@ -289,6 +289,50 @@ export function packagedAppShellPolicy(
 }
 
 /**
+ * Polls an observation until the renderer settles on a state the policy allows.
+ *
+ * The clock and sleep are injectable so the transition can be driven without
+ * waiting out a real timeout.
+ */
+export async function settlePackagedAppShell(options: {
+  readonly describeLast?: (value: unknown) => string;
+  readonly now?: () => number;
+  readonly observe: () => Promise<unknown>;
+  readonly policy: { readonly acceptOnboardingLanding: boolean };
+  readonly sleep?: (ms: number) => Promise<void>;
+  readonly timeoutMs?: number;
+}): Promise<PackagedAppShellState> {
+  const now = options.now ?? (() => Date.now());
+  const sleep = options.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const timeoutMs = options.timeoutMs ?? 45_000;
+  const startedAt = now();
+  let lastResult: unknown = null;
+  let lastValue: unknown = null;
+
+  while (now() - startedAt < timeoutMs) {
+    try {
+      const observed = await options.observe();
+      lastResult = observed;
+      lastValue = observed;
+      if (packagedAppShellSettled(lastValue, options.policy)) {
+        const state = packagedAppShellState(lastValue);
+        if (state != null) return state;
+      }
+    } catch (error) {
+      lastResult = error;
+    }
+    await sleep(750);
+  }
+
+  throw new Error(
+    [
+      `packaged windows runtime did not reach a usable app shell: ${packagedAppShellFailureReason(lastValue, options.policy)}`,
+      options.describeLast?.(lastResult) ?? String(lastResult),
+    ].join('\n'),
+  );
+}
+
+/**
  * Raised when a run that seeded onboarding completion, and saw the daemon
  * confirm it, later observes it gone.
  */
@@ -319,6 +363,55 @@ export function assertSeededOnboardingRetained(input: {
   throw new PackagedOnboardingSeedError(
     'the relaunched daemon lost the seeded onboarding state — check that the protocol cold launch still resolves the tools-pack runtime data root',
   );
+}
+
+/**
+ * The two launch scenarios the packaged app legitimately has.
+ *
+ * Both are real product behaviour, not a contradiction.
+ * `shouldRouteToFirstRunOnboarding` (apps/web/src/App.tsx) keys purely on
+ * `onboardingCompleted`, and `connectStepRuntimeReady` (EntryShell.tsx) lets
+ * onboarding complete through cloud sign-in *or* a local CLI *or* a verified
+ * BYOK key. So "completed setup, currently signed out -> home" and "never
+ * completed -> cloud sign-in landing" are both correct.
+ */
+export type PackagedLaunchScenario = 'completed-user' | 'first-run';
+
+/**
+ * Walks one launch scenario: read the daemon's onboarding fact, hold the run's
+ * own seeded state across the transition, derive the policy, and settle.
+ *
+ * Returns the reading alongside the state so the caller can record both.
+ */
+export async function runPackagedAppShellPhase(options: {
+  readonly coreProfile: boolean;
+  readonly describeLast?: (value: unknown) => string;
+  readonly now?: () => number;
+  readonly observe: () => Promise<unknown>;
+  readonly readOnboardingCompleted: () => Promise<boolean>;
+  readonly scenario: PackagedLaunchScenario;
+  readonly sleep?: (ms: number) => Promise<void>;
+  readonly timeoutMs?: number;
+}): Promise<{ appShell: PackagedAppShellState; onboardingCompleted: boolean }> {
+  const onboardingCompleted = await options.readOnboardingCompleted();
+  // The smoke seeds completion unconditionally (win.spec.ts), so every phase is
+  // a completed-user phase.
+  const seededOnboardingCompleted = true;
+  assertSeededOnboardingRetained({ daemonOnboardingCompleted: onboardingCompleted, seededOnboardingCompleted });
+  const policy = packagedAppShellPolicy({
+    coreProfile: options.coreProfile,
+    daemonOnboardingCompleted: onboardingCompleted,
+    seededOnboardingCompleted,
+  });
+  const appShell = await settlePackagedAppShell({
+    ...(options.describeLast == null ? {} : { describeLast: options.describeLast }),
+    ...(options.now == null ? {} : { now: options.now }),
+    observe: options.observe,
+    policy,
+    ...(options.sleep == null ? {} : { sleep: options.sleep }),
+    ...(options.timeoutMs == null ? {} : { timeoutMs: options.timeoutMs }),
+  });
+  return { appShell, onboardingCompleted };
 }
 
 /**

--- a/e2e/lib/vitest/packaged-app-shell.ts
+++ b/e2e/lib/vitest/packaged-app-shell.ts
@@ -127,6 +127,72 @@ export function packagedAppShellState(value: unknown): PackagedAppShellState | n
   return null;
 }
 
+/**
+ * Reads the daemon's own onboarding-completion fact inside the packaged
+ * renderer. `GET /api/app-config` serves `readAppConfig(RUNTIME_DATA_DIR)`, so
+ * this reports what the running daemon resolved.
+ *
+ * `fetch` is taken as an argument (and wrapped at the call site, since an
+ * unbound `fetch` throws in a browser) so the same text can be driven against a
+ * fake in Node.
+ */
+const PACKAGED_ONBOARDING_CONFIG_PROBE = `
+  (async (fetchImpl) => {
+    const response = await fetchImpl('/api/app-config');
+    const body = response.ok ? await response.json() : null;
+    return {
+      onboardingCompleted: body?.config?.onboardingCompleted === true,
+      status: response.status,
+    };
+  })
+`;
+
+export const packagedOnboardingConfigExpression = `(${PACKAGED_ONBOARDING_CONFIG_PROBE})((input) => fetch(input))`;
+
+export type PackagedOnboardingConfigFetch = (input: string) => Promise<{
+  json(): Promise<unknown>;
+  ok: boolean;
+  status: number;
+}>;
+
+export function evaluatePackagedOnboardingConfigProbe(
+  fetchImpl: PackagedOnboardingConfigFetch,
+): Promise<unknown> {
+  const probe = new Function(`return (${PACKAGED_ONBOARDING_CONFIG_PROBE});`)() as (
+    fetchImpl: PackagedOnboardingConfigFetch,
+  ) => Promise<unknown>;
+  return probe(fetchImpl);
+}
+
+/**
+ * Raised when the daemon's onboarding-completion fact could not be established.
+ *
+ * Its own type so a caller can never mistake "we could not find out" for a
+ * `false` reading.
+ */
+export class PackagedOnboardingConfigError extends Error {
+  constructor(reason: string) {
+    super(`packaged windows daemon onboarding config could not be established: ${reason}`);
+    this.name = 'PackagedOnboardingConfigError';
+  }
+}
+
+/**
+ * The daemon's `onboardingCompleted`, or an error.
+ *
+ * Never returns a default. An unestablished fact must not become a permission.
+ */
+export function packagedOnboardingCompletedFromProbe(value: unknown): boolean {
+  if (typeof value !== 'object' || value == null || Array.isArray(value)) {
+    throw new PackagedOnboardingConfigError(`probe returned no result (${JSON.stringify(value) ?? 'undefined'})`);
+  }
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate.onboardingCompleted !== 'boolean') {
+    throw new PackagedOnboardingConfigError(`probe returned no reading (${JSON.stringify(candidate)})`);
+  }
+  return candidate.onboardingCompleted;
+}
+
 export type PackagedAppShellPolicyInput = {
   /**
    * What the daemon itself reports for `onboardingCompleted`, read from

--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -13,6 +13,7 @@ import { describe, expect, test } from 'vitest';
 import {
   packagedAppShellExpression,
   packagedAppShellFailureReason,
+  packagedAppShellPolicy,
   packagedAppShellSettled,
   packagedAppShellState,
   type PackagedAppShellState,
@@ -238,6 +239,20 @@ const clickUpdaterRailExpression = `
     if (button.getAttribute('aria-disabled') === 'true') return { clicked: false, hostStatus, reason: 'updater-rail-disabled' };
     button.click();
     return { clicked: true, hostStatus };
+  })()
+`;
+// The daemon's own view of onboarding completion, read through the production
+// HTTP path from the packaged renderer. `GET /api/app-config` serves
+// `readAppConfig(RUNTIME_DATA_DIR)`, so this reports what the running daemon
+// resolved — not what the seed hoped it wrote.
+const packagedOnboardingCompletedExpression = `
+  (async () => {
+    const response = await fetch('/api/app-config');
+    const body = response.ok ? await response.json() : null;
+    return {
+      onboardingCompleted: body?.config?.onboardingCompleted === true,
+      status: response.status,
+    };
   })()
 `;
 const packagedOnboardingExpression = `
@@ -531,6 +546,8 @@ winDescribe('packaged windows runtime smoke', () => {
     let passed = false;
     const timings: SmokeTiming[] = [];
     let appShell: PackagedAppShellState | 'skipped' = 'skipped';
+    let seededOnboardingCompleted: boolean | 'skipped' = 'skipped';
+    let onboardingCompleted: boolean | 'skipped' = 'skipped';
     let intermediatePayloadUpdate: PayloadUpdateSummary | { skipped: true } = { skipped: true };
     let payloadUpdate: InstallerFallbackSummary | PayloadUpdateSummary | { skipped: true } = { skipped: true };
     let updaterRecovery: UpdaterRecoverySummary | { skipped: true } = { skipped: true };
@@ -658,6 +675,23 @@ winDescribe('packaged windows runtime smoke', () => {
       assertLauncherPointer(inspect.launcher.active, updateScenario.expectedCurrentVersion, 0, 'initial active');
       assertLauncherPointer(inspect.launcher.lastSuccessful, updateScenario.expectedCurrentVersion, 0, 'initial lastSuccessful');
 
+      // The seed's postcondition, asserted where it must hold: this process was
+      // started by `tools-pack win start`, which points the packaged runtime at
+      // the same data root `seedPackagedOnboardingComplete` wrote. If the daemon
+      // does not see it here, the completed-onboarding boot path is broken —
+      // the #4389-era failure where the seed landed in the AppData fallback and
+      // the daemon never read it. Fail with that named cause instead of letting
+      // it surface later as an unexplained onboarding screen.
+      if (!inspect.desktopIpcUnavailable) {
+        seededOnboardingCompleted = await measureSmokeStep(timings, 'verify seeded onboarding config', async () =>
+          readPackagedOnboardingCompleted(),
+        );
+        expect(
+          seededOnboardingCompleted,
+          'daemon did not read the seeded onboardingCompleted config; check that the packaged data root still resolves to the tools-pack runtime namespace root',
+        ).toBe(true);
+      }
+
       // Runtime registration must preserve the stable installed outer path;
       // pointing at a versioned payload would break the scheme after cleanup.
       await assertWindowsInviteProtocolRegistration(install.installDir);
@@ -699,14 +733,24 @@ winDescribe('packaged windows runtime smoke', () => {
       }
 
       if (!inspect.desktopIpcUnavailable) {
-        // The core profile only screenshots from here, so a first run resting
-        // on the cloud sign-in landing is a legitimate place to stop. The full
-        // profile goes on to click `entry-nav-updater`, which
-        // `clickUpdaterRailExpression` refuses while onboarding is up — so it
-        // keeps demanding home and fails here, with a named cause, rather than
-        // later with a bare `onboarding-visible`.
+        // Re-read rather than reusing the value from the seeded start: the core
+        // profile stopped the app above and relaunched it through the OS
+        // protocol handler, and that cold start carries none of this process's
+        // environment — so it is a different daemon, and only it can say what
+        // config the surface being asserted on is actually running under.
+        const daemonOnboardingCompleted = await measureSmokeStep(
+          timings,
+          'read onboarding config for app shell',
+          async () => readPackagedOnboardingCompleted(),
+        );
+        onboardingCompleted = daemonOnboardingCompleted;
+        // Setup and expectation come from the same fact. A daemon that confirms
+        // onboarding is completed must produce home; only a daemon that reports
+        // a genuine first run may settle on the cloud sign-in landing.
         appShell = await measureSmokeStep(timings, 'ensure packaged app shell', async () =>
-          ensurePackagedAppShell({ acceptOnboardingLanding: verifyCoreOnly }),
+          ensurePackagedAppShell(
+            packagedAppShellPolicy({ coreProfile: verifyCoreOnly, daemonOnboardingCompleted }),
+          ),
         );
 
         if (verifyUpgradePersistence) {
@@ -892,6 +936,7 @@ winDescribe('packaged windows runtime smoke', () => {
       await assertWindowsInviteProtocolRemoved();
       await report.saveSummary({
         appShell,
+        onboarding: { atAppShell: onboardingCompleted, afterSeed: seededOnboardingCompleted },
         health: value,
         install: {
           desktopShortcutExists: install.desktopShortcutExists,
@@ -2036,6 +2081,30 @@ async function fetchPackagedHealth(daemonUrl: string): Promise<HealthEvalValue> 
   } finally {
     clearTimeout(timeout);
   }
+}
+
+/**
+ * What the running daemon reports for `onboardingCompleted`.
+ *
+ * This is the seed's actual postcondition. `seedPackagedOnboardingComplete`
+ * writes `<runtimeNamespaceRoot>/data/app-config.json`, and on a
+ * `tools-pack win start` the daemon resolves the same path — `tools-pack`
+ * rewrites the launch config's `namespaceBaseRoot` to the tools-pack runtime
+ * root (tools/pack/src/win/lifecycle.ts) and `apps/packaged/src/paths.ts`
+ * derives `join(namespaceBaseRoot, namespace, 'data')` from it. So a healthy
+ * seeded start MUST report true, and anything else is a real data-root
+ * regression rather than a test-fixture detail.
+ */
+async function readPackagedOnboardingCompleted(): Promise<boolean> {
+  const inspect = await runToolsPackJson<WinInspectResult>('inspect', [
+    '--expr',
+    packagedOnboardingCompletedExpression,
+  ]);
+  const value = inspect.eval?.value;
+  if (!isRecord(value) || typeof value.onboardingCompleted !== 'boolean') {
+    throw new Error(`packaged windows daemon did not report app config: ${formatUnknown(inspect)}`);
+  }
+  return value.onboardingCompleted;
 }
 
 /**

--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -699,8 +699,14 @@ winDescribe('packaged windows runtime smoke', () => {
       }
 
       if (!inspect.desktopIpcUnavailable) {
+        // The core profile only screenshots from here, so a first run resting
+        // on the cloud sign-in landing is a legitimate place to stop. The full
+        // profile goes on to click `entry-nav-updater`, which
+        // `clickUpdaterRailExpression` refuses while onboarding is up — so it
+        // keeps demanding home and fails here, with a named cause, rather than
+        // later with a bare `onboarding-visible`.
         appShell = await measureSmokeStep(timings, 'ensure packaged app shell', async () =>
-          ensurePackagedAppShell({ acceptOnboardingLanding: false }),
+          ensurePackagedAppShell({ acceptOnboardingLanding: verifyCoreOnly }),
         );
 
         if (verifyUpgradePersistence) {

--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -12,14 +12,10 @@ import { describe, expect, test } from 'vitest';
 
 import {
   packagedAppShellExpression,
-  packagedAppShellFailureReason,
-  assertSeededOnboardingRetained,
-  packagedAppShellPolicy,
-  packagedAppShellSettled,
-  packagedAppShellState,
   PackagedOnboardingConfigError,
   packagedOnboardingCompletedFromProbe,
   packagedOnboardingConfigExpression,
+  runPackagedAppShellPhase,
   type PackagedAppShellState,
 } from '@/vitest/packaged-app-shell';
 import { createPackagedSmokeReport } from '@/vitest/packaged-report';
@@ -536,6 +532,7 @@ winDescribe('packaged windows runtime smoke', () => {
     let passed = false;
     const timings: SmokeTiming[] = [];
     let appShell: PackagedAppShellState | 'skipped' = 'skipped';
+    let firstRunAppShell: PackagedAppShellState | 'skipped' = 'skipped';
     let seededOnboardingCompleted: boolean | 'skipped' = 'skipped';
     let onboardingCompleted: boolean | 'skipped' = 'skipped';
     let intermediatePayloadUpdate: PayloadUpdateSummary | { skipped: true } = { skipped: true };
@@ -589,6 +586,51 @@ winDescribe('packaged windows runtime smoke', () => {
             `top-level payload=${JSON.stringify(install.installPayload.topLevel.slice(0, 8))}`,
           ].join('\n'),
         );
+      }
+
+      // Phase 1 — the genuine first run. A packaged install nobody has signed
+      // into is real product behaviour, not a broken state: since
+      // `shouldRouteToFirstRunOnboarding` keys purely on `onboardingCompleted`,
+      // the cloud sign-in landing is its correct terminal surface, and it is
+      // accepted only when it actually rendered its sign-in CTA and both runtime
+      // links. Core-only on purpose — every release workflow defaults there, and
+      // the full profile needs its controlled updater environment from first
+      // launch, which a plain start before the fixture is wired would bypass.
+      if (verifyCoreOnly) {
+        await resetPackagedRuntimeDataRoot();
+        const firstRunStart = await measureSmokeStep(timings, 'start unseeded first run', async () =>
+          runToolsPackJson<WinStartResult>('start'),
+        );
+        started = true;
+        expect(firstRunStart.source).toBe('installed');
+        const firstRunInspect = await measureSmokeStep(timings, 'wait healthy unseeded first run', async () =>
+          waitForHealthyDesktop(),
+        );
+        expect(firstRunInspect.status?.state).toBe('running');
+        if (!firstRunInspect.desktopIpcUnavailable) {
+          const firstRunPhase = await measureSmokeStep(timings, 'ensure first-run app shell', async () =>
+            runPackagedAppShellPhase({
+              coreProfile: verifyCoreOnly,
+              describeLast: formatUnknown,
+              observe: observePackagedAppShell,
+              readOnboardingCompleted: readPackagedOnboardingCompleted,
+              scenario: 'first-run',
+            }),
+          );
+          expect(firstRunPhase.onboardingCompleted).toBe(false);
+          expect(firstRunPhase.appShell).toBe('onboarding-landing');
+          firstRunAppShell = firstRunPhase.appShell;
+        }
+        const firstRunStop = await measureSmokeStep(timings, 'stop unseeded first run', async () =>
+          runToolsPackJson<WinStopResult>('stop'),
+        );
+        started = false;
+        expect(firstRunStop.status).not.toBe('partial');
+        expect(firstRunStop.remainingPids).toEqual([]);
+        // Clear both the daemon data root and the Electron user-data partition
+        // so phase 2's seed lands on a true clean slate and no localStorage
+        // residue from this phase can ratchet into it.
+        await resetPackagedRuntimeDataRoot();
       }
 
       await seedPackagedOnboardingComplete();
@@ -728,36 +770,24 @@ winDescribe('packaged windows runtime smoke', () => {
         // protocol handler, and that cold start carries none of this process's
         // environment — so it is a different daemon, and only it can say what
         // config the surface being asserted on is actually running under.
-        const daemonOnboardingCompleted = await measureSmokeStep(
-          timings,
-          'read onboarding config for app shell',
-          async () => readPackagedOnboardingCompleted(),
-        );
-        onboardingCompleted = daemonOnboardingCompleted;
-        // The seeded observation must exist by now — both blocks share the same
-        // `desktopIpcUnavailable` guard. Assert it rather than coercing
-        // `'skipped'`, which would silently read as "never seeded" and hand the
-        // permissive branch exactly the input it must not get.
-        if (seededOnboardingCompleted === 'skipped') {
-          throw new Error('reached the app-shell check without observing the seeded onboarding state');
+        // Phase 2 — the completed user. The seed must have been confirmed before
+        // this point; anything else means the run never established the fact
+        // this phase depends on.
+        if (seededOnboardingCompleted !== true) {
+          throw new Error('reached the completed-user app-shell check without a confirmed seeded onboarding state');
         }
-        // This run seeded completion and saw the daemon confirm it. If the
-        // protocol cold relaunch above lost that state, it is a packaged-runtime
-        // regression — fail with the cause named, never absorb it as a first run.
-        const seededObserved: boolean = seededOnboardingCompleted;
-        assertSeededOnboardingRetained({ daemonOnboardingCompleted, seededOnboardingCompleted: seededObserved });
-        // Setup and expectation come from the same fact. A daemon that confirms
-        // onboarding is completed must produce home; only a run that never
-        // seeded completion may settle on the cloud sign-in landing.
-        appShell = await measureSmokeStep(timings, 'ensure packaged app shell', async () =>
-          ensurePackagedAppShell(
-            packagedAppShellPolicy({
-              coreProfile: verifyCoreOnly,
-              daemonOnboardingCompleted,
-              seededOnboardingCompleted: seededObserved,
-            }),
-          ),
+        const completedUser = await measureSmokeStep(timings, 'ensure completed-user app shell', async () =>
+          runPackagedAppShellPhase({
+            coreProfile: verifyCoreOnly,
+            describeLast: formatUnknown,
+            observe: observePackagedAppShell,
+            readOnboardingCompleted: readPackagedOnboardingCompleted,
+            scenario: 'completed-user',
+          }),
         );
+        onboardingCompleted = completedUser.onboardingCompleted;
+        appShell = completedUser.appShell;
+        expect(appShell).toBe('home');
 
         if (verifyUpgradePersistence) {
           const seedInspect = await measureSmokeStep(timings, 'seed pre-update persistence project', async () =>
@@ -942,7 +972,11 @@ winDescribe('packaged windows runtime smoke', () => {
       await assertWindowsInviteProtocolRemoved();
       await report.saveSummary({
         appShell,
-        onboarding: { atAppShell: onboardingCompleted, afterSeed: seededOnboardingCompleted },
+        onboarding: {
+          afterSeed: seededOnboardingCompleted,
+          atAppShell: onboardingCompleted,
+          firstRunAppShell,
+        },
         health: value,
         install: {
           desktopShortcutExists: install.desktopShortcutExists,
@@ -2118,41 +2152,17 @@ async function readPackagedOnboardingCompleted(): Promise<boolean> {
 }
 
 /**
- * Waits until the packaged renderer settles on a surface this smoke can act on,
- * and reports which one it was.
+ * One reading of the packaged renderer's app shell.
  *
- * `acceptOnboardingLanding` is the caller's call, because the answer depends on
- * what the smoke does next rather than on what the app is allowed to show. The
- * rule itself lives in `@/vitest/packaged-app-shell` so a non-Windows machine
- * can hold it — and the DOM probe it reads — to a contract.
+ * Throws on an eval that did not run, so the settle loop records the whole
+ * inspect payload as the failure cause rather than an empty observation.
  */
-async function ensurePackagedAppShell(
-  options: { readonly acceptOnboardingLanding: boolean },
-  timeoutMs = 45_000,
-): Promise<PackagedAppShellState> {
-  const startedAt = Date.now();
-  let lastResult: unknown = null;
-  let lastValue: unknown = null;
-  while (Date.now() - startedAt < timeoutMs) {
-    try {
-      const inspect = await runToolsPackJson<WinInspectResult>('inspect', ['--expr', packagedAppShellExpression]);
-      lastResult = inspect;
-      lastValue = inspect.eval?.value;
-      if (packagedAppShellSettled(lastValue, options)) {
-        const state = packagedAppShellState(lastValue);
-        if (state != null) return state;
-      }
-    } catch (error) {
-      lastResult = error;
-    }
-    await delay(750);
+async function observePackagedAppShell(): Promise<unknown> {
+  const inspect = await runToolsPackJson<WinInspectResult>('inspect', ['--expr', packagedAppShellExpression]);
+  if (inspect.eval?.ok !== true) {
+    throw new Error(`packaged windows renderer could not evaluate the app-shell probe: ${formatUnknown(inspect)}`);
   }
-  throw new Error(
-    [
-      `packaged windows runtime did not reach a usable app shell: ${packagedAppShellFailureReason(lastValue, options)}`,
-      formatUnknown(lastResult),
-    ].join('\n'),
-  );
+  return inspect.eval.value;
 }
 
 async function waitForHealthyDesktopVersion(

--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -13,6 +13,7 @@ import { describe, expect, test } from 'vitest';
 import {
   packagedAppShellExpression,
   packagedAppShellFailureReason,
+  assertSeededOnboardingRetained,
   packagedAppShellPolicy,
   packagedAppShellSettled,
   packagedAppShellState,
@@ -733,12 +734,28 @@ winDescribe('packaged windows runtime smoke', () => {
           async () => readPackagedOnboardingCompleted(),
         );
         onboardingCompleted = daemonOnboardingCompleted;
+        // The seeded observation must exist by now — both blocks share the same
+        // `desktopIpcUnavailable` guard. Assert it rather than coercing
+        // `'skipped'`, which would silently read as "never seeded" and hand the
+        // permissive branch exactly the input it must not get.
+        if (seededOnboardingCompleted === 'skipped') {
+          throw new Error('reached the app-shell check without observing the seeded onboarding state');
+        }
+        // This run seeded completion and saw the daemon confirm it. If the
+        // protocol cold relaunch above lost that state, it is a packaged-runtime
+        // regression — fail with the cause named, never absorb it as a first run.
+        const seededObserved: boolean = seededOnboardingCompleted;
+        assertSeededOnboardingRetained({ daemonOnboardingCompleted, seededOnboardingCompleted: seededObserved });
         // Setup and expectation come from the same fact. A daemon that confirms
-        // onboarding is completed must produce home; only a daemon that reports
-        // a genuine first run may settle on the cloud sign-in landing.
+        // onboarding is completed must produce home; only a run that never
+        // seeded completion may settle on the cloud sign-in landing.
         appShell = await measureSmokeStep(timings, 'ensure packaged app shell', async () =>
           ensurePackagedAppShell(
-            packagedAppShellPolicy({ coreProfile: verifyCoreOnly, daemonOnboardingCompleted }),
+            packagedAppShellPolicy({
+              coreProfile: verifyCoreOnly,
+              daemonOnboardingCompleted,
+              seededOnboardingCompleted: seededObserved,
+            }),
           ),
         );
 

--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -10,6 +10,13 @@ import { promisify } from 'node:util';
 
 import { describe, expect, test } from 'vitest';
 
+import {
+  packagedAppShellExpression,
+  packagedAppShellFailureReason,
+  packagedAppShellSettled,
+  packagedAppShellState,
+  type PackagedAppShellState,
+} from '@/vitest/packaged-app-shell';
 import { createPackagedSmokeReport } from '@/vitest/packaged-report';
 import {
   assertPackagedPtySmokeResult,
@@ -231,23 +238,6 @@ const clickUpdaterRailExpression = `
     if (button.getAttribute('aria-disabled') === 'true') return { clicked: false, hostStatus, reason: 'updater-rail-disabled' };
     button.click();
     return { clicked: true, hostStatus };
-  })()
-`;
-const ensureMainAppShellExpression = `
-  (() => {
-    const onboarding = document.querySelector('.entry-shell--onboarding, .entry-onboarding-modal');
-    const home = document.querySelector('[data-testid="entry-nav-home"]');
-    const homeVisible = home instanceof HTMLElement && home.getClientRects().length > 0;
-    if (homeVisible) {
-      return { homeVisible: true, onboardingVisible: false, skipped: false };
-    }
-    return {
-      homeVisible: false,
-      onboardingVisible: onboarding instanceof HTMLElement,
-      skipped: false,
-      title: document.title,
-      text: document.body?.textContent?.trim().slice(0, 300) ?? '',
-    };
   })()
 `;
 const packagedOnboardingExpression = `
@@ -540,6 +530,7 @@ winDescribe('packaged windows runtime smoke', () => {
     const report = await createPackagedSmokeReport('win');
     let passed = false;
     const timings: SmokeTiming[] = [];
+    let appShell: PackagedAppShellState | 'skipped' = 'skipped';
     let intermediatePayloadUpdate: PayloadUpdateSummary | { skipped: true } = { skipped: true };
     let payloadUpdate: InstallerFallbackSummary | PayloadUpdateSummary | { skipped: true } = { skipped: true };
     let updaterRecovery: UpdaterRecoverySummary | { skipped: true } = { skipped: true };
@@ -708,7 +699,9 @@ winDescribe('packaged windows runtime smoke', () => {
       }
 
       if (!inspect.desktopIpcUnavailable) {
-        await measureSmokeStep(timings, 'ensure main app shell', async () => ensureMainAppShell());
+        appShell = await measureSmokeStep(timings, 'ensure packaged app shell', async () =>
+          ensurePackagedAppShell({ acceptOnboardingLanding: false }),
+        );
 
         if (verifyUpgradePersistence) {
           const seedInspect = await measureSmokeStep(timings, 'seed pre-update persistence project', async () =>
@@ -892,6 +885,7 @@ winDescribe('packaged windows runtime smoke', () => {
       expect(uninstall.residueObservation?.userDesktopShortcutExists).toBe(false);
       await assertWindowsInviteProtocolRemoved();
       await report.saveSummary({
+        appShell,
         health: value,
         install: {
           desktopShortcutExists: install.desktopShortcutExists,
@@ -2038,21 +2032,42 @@ async function fetchPackagedHealth(daemonUrl: string): Promise<HealthEvalValue> 
   }
 }
 
-async function ensureMainAppShell(timeoutMs = 45_000): Promise<void> {
+/**
+ * Waits until the packaged renderer settles on a surface this smoke can act on,
+ * and reports which one it was.
+ *
+ * `acceptOnboardingLanding` is the caller's call, because the answer depends on
+ * what the smoke does next rather than on what the app is allowed to show. The
+ * rule itself lives in `@/vitest/packaged-app-shell` so a non-Windows machine
+ * can hold it — and the DOM probe it reads — to a contract.
+ */
+async function ensurePackagedAppShell(
+  options: { readonly acceptOnboardingLanding: boolean },
+  timeoutMs = 45_000,
+): Promise<PackagedAppShellState> {
   const startedAt = Date.now();
   let lastResult: unknown = null;
+  let lastValue: unknown = null;
   while (Date.now() - startedAt < timeoutMs) {
     try {
-      const inspect = await runToolsPackJson<WinInspectResult>('inspect', ['--expr', ensureMainAppShellExpression]);
+      const inspect = await runToolsPackJson<WinInspectResult>('inspect', ['--expr', packagedAppShellExpression]);
       lastResult = inspect;
-      const value = inspect.eval?.value;
-      if (isRecord(value) && value.homeVisible === true) return;
+      lastValue = inspect.eval?.value;
+      if (packagedAppShellSettled(lastValue, options)) {
+        const state = packagedAppShellState(lastValue);
+        if (state != null) return state;
+      }
     } catch (error) {
       lastResult = error;
     }
     await delay(750);
   }
-  throw new Error(`packaged windows runtime did not reach main app shell: ${formatUnknown(lastResult)}`);
+  throw new Error(
+    [
+      `packaged windows runtime did not reach a usable app shell: ${packagedAppShellFailureReason(lastValue, options)}`,
+      formatUnknown(lastResult),
+    ].join('\n'),
+  );
 }
 
 async function waitForHealthyDesktopVersion(

--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -16,6 +16,9 @@ import {
   packagedAppShellPolicy,
   packagedAppShellSettled,
   packagedAppShellState,
+  PackagedOnboardingConfigError,
+  packagedOnboardingCompletedFromProbe,
+  packagedOnboardingConfigExpression,
   type PackagedAppShellState,
 } from '@/vitest/packaged-app-shell';
 import { createPackagedSmokeReport } from '@/vitest/packaged-report';
@@ -239,20 +242,6 @@ const clickUpdaterRailExpression = `
     if (button.getAttribute('aria-disabled') === 'true') return { clicked: false, hostStatus, reason: 'updater-rail-disabled' };
     button.click();
     return { clicked: true, hostStatus };
-  })()
-`;
-// The daemon's own view of onboarding completion, read through the production
-// HTTP path from the packaged renderer. `GET /api/app-config` serves
-// `readAppConfig(RUNTIME_DATA_DIR)`, so this reports what the running daemon
-// resolved — not what the seed hoped it wrote.
-const packagedOnboardingCompletedExpression = `
-  (async () => {
-    const response = await fetch('/api/app-config');
-    const body = response.ok ? await response.json() : null;
-    return {
-      onboardingCompleted: body?.config?.onboardingCompleted === true,
-      status: response.status,
-    };
   })()
 `;
 const packagedOnboardingExpression = `
@@ -2098,13 +2087,17 @@ async function fetchPackagedHealth(daemonUrl: string): Promise<HealthEvalValue> 
 async function readPackagedOnboardingCompleted(): Promise<boolean> {
   const inspect = await runToolsPackJson<WinInspectResult>('inspect', [
     '--expr',
-    packagedOnboardingCompletedExpression,
+    packagedOnboardingConfigExpression,
   ]);
-  const value = inspect.eval?.value;
-  if (!isRecord(value) || typeof value.onboardingCompleted !== 'boolean') {
-    throw new Error(`packaged windows daemon did not report app config: ${formatUnknown(inspect)}`);
+  if (inspect.eval?.ok !== true) {
+    throw new PackagedOnboardingConfigError(`the renderer could not evaluate the probe: ${formatUnknown(inspect)}`);
   }
-  return value.onboardingCompleted;
+  // Raises rather than defaulting. There is deliberately no fallback and no
+  // retry: `waitForHealthyDesktop` has already proven this daemon answers
+  // `/api/health` with 200 through the same renderer, so a failure here is a
+  // real fault, and the only fallback value available would be the one that
+  // permits the onboarding landing.
+  return packagedOnboardingCompletedFromProbe(inspect.eval.value);
 }
 
 /**

--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -613,7 +613,7 @@ winDescribe('packaged windows runtime smoke', () => {
               coreProfile: verifyCoreOnly,
               describeLast: formatUnknown,
               observe: observePackagedAppShell,
-              readOnboardingCompleted: readPackagedOnboardingCompleted,
+              readOnboardingConfig: readPackagedOnboardingConfig,
               scenario: 'first-run',
             }),
           );
@@ -716,7 +716,7 @@ winDescribe('packaged windows runtime smoke', () => {
       // it surface later as an unexplained onboarding screen.
       if (!inspect.desktopIpcUnavailable) {
         seededOnboardingCompleted = await measureSmokeStep(timings, 'verify seeded onboarding config', async () =>
-          readPackagedOnboardingCompleted(),
+          packagedOnboardingCompletedFromProbe(await readPackagedOnboardingConfig()),
         );
         expect(
           seededOnboardingCompleted,
@@ -781,7 +781,7 @@ winDescribe('packaged windows runtime smoke', () => {
             coreProfile: verifyCoreOnly,
             describeLast: formatUnknown,
             observe: observePackagedAppShell,
-            readOnboardingCompleted: readPackagedOnboardingCompleted,
+            readOnboardingConfig: readPackagedOnboardingConfig,
             scenario: 'completed-user',
           }),
         );
@@ -2135,7 +2135,7 @@ async function fetchPackagedHealth(daemonUrl: string): Promise<HealthEvalValue> 
  * seeded start MUST report true, and anything else is a real data-root
  * regression rather than a test-fixture detail.
  */
-async function readPackagedOnboardingCompleted(): Promise<boolean> {
+async function readPackagedOnboardingConfig(): Promise<unknown> {
   const inspect = await runToolsPackJson<WinInspectResult>('inspect', [
     '--expr',
     packagedOnboardingConfigExpression,
@@ -2143,12 +2143,10 @@ async function readPackagedOnboardingCompleted(): Promise<boolean> {
   if (inspect.eval?.ok !== true) {
     throw new PackagedOnboardingConfigError(`the renderer could not evaluate the probe: ${formatUnknown(inspect)}`);
   }
-  // Raises rather than defaulting. There is deliberately no fallback and no
-  // retry: `waitForHealthyDesktop` has already proven this daemon answers
-  // `/api/health` with 200 through the same renderer, so a failure here is a
-  // real fault, and the only fallback value available would be the one that
-  // permits the onboarding landing.
-  return packagedOnboardingCompletedFromProbe(inspect.eval.value);
+  // Returns the raw probe outcome. Interpretation belongs to the scenario, not
+  // to the reader: an absent key means different things to a first run and to a
+  // run that seeded completion.
+  return inspect.eval.value;
 }
 
 /**

--- a/e2e/tests/packaged/app-shell.test.ts
+++ b/e2e/tests/packaged/app-shell.test.ts
@@ -237,22 +237,22 @@ describe('packaged app-shell terminal state', () => {
 describe('packaged app-shell policy', () => {
   it('requires home once the daemon confirms onboarding is completed', () => {
     expect(
-      packagedAppShellPolicy({ coreProfile: true, daemonOnboardingCompleted: true }),
+      packagedAppShellPolicy({ coreProfile: true, daemonOnboardingCompleted: true, seededOnboardingCompleted: false }),
     ).toEqual({ acceptOnboardingLanding: false });
     expect(
-      packagedAppShellPolicy({ coreProfile: false, daemonOnboardingCompleted: true }),
+      packagedAppShellPolicy({ coreProfile: false, daemonOnboardingCompleted: true, seededOnboardingCompleted: false }),
     ).toEqual({ acceptOnboardingLanding: false });
   });
 
   it('accepts the landing only when the daemon reports onboarding is not completed', () => {
     expect(
-      packagedAppShellPolicy({ coreProfile: true, daemonOnboardingCompleted: false }),
+      packagedAppShellPolicy({ coreProfile: true, daemonOnboardingCompleted: false, seededOnboardingCompleted: false }),
     ).toEqual({ acceptOnboardingLanding: true });
   });
 
   it('keeps a seeded run failing when the app ignores completed onboarding', () => {
     const landing = probe(renderFixture(CLOUD_SIGN_IN_LANDING));
-    const policy = packagedAppShellPolicy({ coreProfile: true, daemonOnboardingCompleted: true });
+    const policy = packagedAppShellPolicy({ coreProfile: true, daemonOnboardingCompleted: true, seededOnboardingCompleted: false });
 
     expect(packagedAppShellSettled(landing, policy)).toBe(false);
     expect(packagedAppShellFailureReason(landing, policy)).toContain('needs home');
@@ -270,6 +270,7 @@ describe('packaged app-shell policy', () => {
         packagedAppShellPolicy({
           coreProfile: true,
           daemonOnboardingCompleted: daemonOnboardingCompleted as unknown as boolean,
+          seededOnboardingCompleted: false,
         }),
         `reading ${JSON.stringify(daemonOnboardingCompleted)}`,
       ).toEqual({ acceptOnboardingLanding: false });
@@ -289,15 +290,44 @@ describe('packaged app-shell policy', () => {
     }
   });
 
+  // PerishCode's fifth review on #6481, the same family one level out: at the
+  // level of the scenario rather than a single expression. This run seeds
+  // `onboardingCompleted: true` and observes the daemon confirm it, then stops
+  // the app and relaunches it through the OS protocol handler — which inherits
+  // none of the test process's environment. If that cold launch resolves a
+  // different data root, the seeded config is gone, the fresh reading is
+  // `false`, and "we lost the seed" is absorbed as "genuine first run". The
+  // smoke would then pass while blind to the regression it exists to catch.
+  it('never downgrades a lost seed to a genuine first run', () => {
+    expect(
+      packagedAppShellPolicy({
+        coreProfile: true,
+        daemonOnboardingCompleted: false,
+        seededOnboardingCompleted: true,
+      }),
+    ).toEqual({ acceptOnboardingLanding: false });
+  });
+
+  it('keeps a lost seed failing at the shell check', () => {
+    const landing = probe(renderFixture(CLOUD_SIGN_IN_LANDING));
+    const policy = packagedAppShellPolicy({
+      coreProfile: true,
+      daemonOnboardingCompleted: false,
+      seededOnboardingCompleted: true,
+    });
+
+    expect(packagedAppShellSettled(landing, policy)).toBe(false);
+  });
+
   it('lets an unseeded run settle on the landing', () => {
     const landing = probe(renderFixture(CLOUD_SIGN_IN_LANDING));
-    const policy = packagedAppShellPolicy({ coreProfile: true, daemonOnboardingCompleted: false });
+    const policy = packagedAppShellPolicy({ coreProfile: true, daemonOnboardingCompleted: false, seededOnboardingCompleted: false });
 
     expect(packagedAppShellSettled(landing, policy)).toBe(true);
   });
 
   it('still requires a real surface when onboarding is not completed', () => {
-    const policy = packagedAppShellPolicy({ coreProfile: true, daemonOnboardingCompleted: false });
+    const policy = packagedAppShellPolicy({ coreProfile: true, daemonOnboardingCompleted: false, seededOnboardingCompleted: false });
 
     expect(packagedAppShellSettled(probe(renderFixture([])), policy)).toBe(false);
   });

--- a/e2e/tests/packaged/app-shell.test.ts
+++ b/e2e/tests/packaged/app-shell.test.ts
@@ -5,6 +5,7 @@ import {
   evaluatePackagedAppShellProbe,
   packagedAppShellExpression,
   packagedAppShellFailureReason,
+  packagedAppShellPolicy,
   packagedAppShellSettled,
   packagedAppShellState,
   type PackagedAppShellProbeDocument,
@@ -214,6 +215,60 @@ describe('packaged app-shell terminal state', () => {
   });
 
   it('rejects a snapshot the renderer could not produce', () => {
+    expect(packagedAppShellState(null)).toBeNull();
+    expect(packagedAppShellState({ homeVisible: true })).toBeNull();
+    expect(packagedAppShellSettled(undefined, { acceptOnboardingLanding: true })).toBe(false);
+    expect(packagedAppShellFailureReason(null, { acceptOnboardingLanding: true })).toContain(
+      'no app-shell snapshot',
+    );
+  });
+});
+
+// The postcondition PerishCode's review on #6481 asked to keep: a run that
+// seeds onboarding as completed must still notice when the app ignores it.
+// The setup's claim and the accepted terminal state have to come from the same
+// fact, so the policy reads the daemon's own `onboardingCompleted` (served from
+// `readAppConfig(RUNTIME_DATA_DIR)`) rather than the smoke profile.
+describe('packaged app-shell policy', () => {
+  it('requires home once the daemon confirms onboarding is completed', () => {
+    expect(
+      packagedAppShellPolicy({ coreProfile: true, daemonOnboardingCompleted: true }),
+    ).toEqual({ acceptOnboardingLanding: false });
+    expect(
+      packagedAppShellPolicy({ coreProfile: false, daemonOnboardingCompleted: true }),
+    ).toEqual({ acceptOnboardingLanding: false });
+  });
+
+  it('accepts the landing only when the daemon reports onboarding is not completed', () => {
+    expect(
+      packagedAppShellPolicy({ coreProfile: true, daemonOnboardingCompleted: false }),
+    ).toEqual({ acceptOnboardingLanding: true });
+  });
+
+  it('keeps a seeded run failing when the app ignores completed onboarding', () => {
+    const landing = probe(renderFixture(CLOUD_SIGN_IN_LANDING));
+    const policy = packagedAppShellPolicy({ coreProfile: true, daemonOnboardingCompleted: true });
+
+    expect(packagedAppShellSettled(landing, policy)).toBe(false);
+    expect(packagedAppShellFailureReason(landing, policy)).toContain('needs home');
+  });
+
+  it('lets an unseeded run settle on the landing', () => {
+    const landing = probe(renderFixture(CLOUD_SIGN_IN_LANDING));
+    const policy = packagedAppShellPolicy({ coreProfile: true, daemonOnboardingCompleted: false });
+
+    expect(packagedAppShellSettled(landing, policy)).toBe(true);
+  });
+
+  it('still requires a real surface when onboarding is not completed', () => {
+    const policy = packagedAppShellPolicy({ coreProfile: true, daemonOnboardingCompleted: false });
+
+    expect(packagedAppShellSettled(probe(renderFixture([])), policy)).toBe(false);
+  });
+});
+
+describe('packaged app-shell snapshot guards', () => {
+  it('rejects a malformed snapshot', () => {
     expect(packagedAppShellState(null)).toBeNull();
     expect(packagedAppShellState({ homeVisible: true })).toBeNull();
     expect(packagedAppShellSettled(undefined, { acceptOnboardingLanding: true })).toBe(false);

--- a/e2e/tests/packaged/app-shell.test.ts
+++ b/e2e/tests/packaged/app-shell.test.ts
@@ -543,7 +543,7 @@ describe('packaged launch scenarios', () => {
       coreProfile: true,
       now: clock.now,
       observe: async () => landing,
-      readOnboardingCompleted: async () => false,
+      readOnboardingConfig: async () => ({ ok: true, onboardingCompleted: false, status: 200 }),
       scenario: 'first-run',
       sleep: clock.sleep,
     });
@@ -559,7 +559,7 @@ describe('packaged launch scenarios', () => {
       coreProfile: true,
       now: clock.now,
       observe: async () => home,
-      readOnboardingCompleted: async () => true,
+      readOnboardingConfig: async () => ({ ok: true, onboardingCompleted: true, status: 200 }),
       scenario: 'completed-user',
       sleep: clock.sleep,
     });
@@ -576,7 +576,7 @@ describe('packaged launch scenarios', () => {
         coreProfile: true,
         now: clock.now,
         observe: async () => landing,
-        readOnboardingCompleted: async () => true,
+        readOnboardingConfig: async () => ({ ok: true, onboardingCompleted: true, status: 200 }),
         scenario: 'completed-user',
         sleep: clock.sleep,
       }),
@@ -592,7 +592,7 @@ describe('packaged launch scenarios', () => {
         coreProfile: true,
         now: clock.now,
         observe: async () => landing,
-        readOnboardingCompleted: async () => false,
+        readOnboardingConfig: async () => ({ ok: true, onboardingCompleted: false, status: 200 }),
         scenario: 'completed-user',
         sleep: clock.sleep,
       }),
@@ -608,10 +608,98 @@ describe('packaged launch scenarios', () => {
         coreProfile: true,
         now: clock.now,
         observe: async () => blank,
-        readOnboardingCompleted: async () => false,
+        readOnboardingConfig: async () => ({ ok: true, onboardingCompleted: false, status: 200 }),
         scenario: 'first-run',
         sleep: clock.sleep,
       }),
     ).rejects.toThrow(/neither the home nav rail nor the onboarding cloud sign-in landing rendered/);
+  });
+});
+
+// PerishCode's seventh review on #6481. Round 4 made a missing
+// `onboardingCompleted` fail closed; round 6 then added a scenario that
+// produces exactly that, and they collide. `resetPackagedRuntimeDataRoot()`
+// deletes `app-config.json`; `readAppConfig` returns `{}` on ENOENT and adds
+// only telemetry defaults, so a fresh install's `/api/app-config` OMITS the key
+// rather than reporting `false`. **Absent is not malformed.**
+describe('real fresh-install app-config response', () => {
+  // Byte-shaped like the daemon's actual fresh reply: `readAppConfig` ->
+  // `applyTelemetryDefaults({})`.
+  const FRESH_INSTALL_BODY = { config: { telemetry: { content: true, metrics: true } } };
+
+  const virtualClock = () => {
+    let t = 0;
+    return { now: () => t, sleep: async (ms: number) => { t += ms; } };
+  };
+
+  it('settles a first run whose daemon never wrote the key', async () => {
+    const clock = virtualClock();
+    const landing = probe(renderFixture(CLOUD_SIGN_IN_LANDING));
+
+    const result = await runPackagedAppShellPhase({
+      coreProfile: true,
+      now: clock.now,
+      observe: async () => landing,
+      readOnboardingConfig: async () =>
+        evaluatePackagedOnboardingConfigProbe(fakeConfigFetch({ body: FRESH_INSTALL_BODY })),
+      scenario: 'first-run',
+      sleep: clock.sleep,
+    });
+
+    expect(result).toEqual({ appShell: 'onboarding-landing', onboardingCompleted: false });
+  });
+
+  it('still fails a completed user whose key went missing', async () => {
+    const clock = virtualClock();
+    const landing = probe(renderFixture(CLOUD_SIGN_IN_LANDING));
+
+    await expect(
+      runPackagedAppShellPhase({
+        coreProfile: true,
+        now: clock.now,
+        observe: async () => landing,
+        readOnboardingConfig: async () =>
+          evaluatePackagedOnboardingConfigProbe(fakeConfigFetch({ body: FRESH_INSTALL_BODY })),
+        scenario: 'completed-user',
+        sleep: clock.sleep,
+      }),
+    ).rejects.toThrow(PackagedOnboardingSeedError);
+  });
+
+  it('keeps a wrong-typed key a fault even for a first run', async () => {
+    const clock = virtualClock();
+    const landing = probe(renderFixture(CLOUD_SIGN_IN_LANDING));
+
+    await expect(
+      runPackagedAppShellPhase({
+        coreProfile: true,
+        now: clock.now,
+        observe: async () => landing,
+        readOnboardingConfig: async () =>
+          evaluatePackagedOnboardingConfigProbe(
+            fakeConfigFetch({ body: { config: { onboardingCompleted: 'false' } } }),
+          ),
+        scenario: 'first-run',
+        sleep: clock.sleep,
+      }),
+    ).rejects.toThrow(PackagedOnboardingConfigError);
+  });
+
+  it('keeps transport and HTTP faults closed for a first run', async () => {
+    const clock = virtualClock();
+    const landing = probe(renderFixture(CLOUD_SIGN_IN_LANDING));
+
+    for (const failure of [fakeConfigFetch({ ok: false, status: 500 }), fakeConfigFetch({ throws: true })]) {
+      await expect(
+        runPackagedAppShellPhase({
+          coreProfile: true,
+          now: clock.now,
+          observe: async () => landing,
+          readOnboardingConfig: async () => evaluatePackagedOnboardingConfigProbe(failure),
+          scenario: 'first-run',
+          sleep: clock.sleep,
+        }),
+      ).rejects.toThrow(PackagedOnboardingConfigError);
+    }
   });
 });

--- a/e2e/tests/packaged/app-shell.test.ts
+++ b/e2e/tests/packaged/app-shell.test.ts
@@ -348,6 +348,42 @@ describe('packaged daemon onboarding config probe', () => {
     );
   });
 
+  // Round 3 fixed the transport half but left the payload half coerced:
+  // `config.onboardingCompleted === true` turns a missing key, a null, or the
+  // string "false" into a well-formed `false`, which the reader then accepts as
+  // a real reading. "The daemon did not tell me" must never arrive as "the
+  // daemon told me false".
+  it('refuses to answer when a 200 carries no onboardingCompleted field', async () => {
+    const value = await evaluatePackagedOnboardingConfigProbe(fakeConfigFetch({ body: { config: {} } }));
+
+    expect(value).toMatchObject({ ok: false });
+    expect(() => packagedOnboardingCompletedFromProbe(value)).toThrow(
+      PackagedOnboardingConfigError,
+    );
+  });
+
+  it('refuses to answer when onboardingCompleted is the wrong type', async () => {
+    for (const onboardingCompleted of ['false', 'true', 0, 1, null, {}, []]) {
+      const value = await evaluatePackagedOnboardingConfigProbe(
+        fakeConfigFetch({ body: { config: { onboardingCompleted } } }),
+      );
+
+      expect(value, `payload ${JSON.stringify(onboardingCompleted)}`).toMatchObject({ ok: false });
+      expect(() => packagedOnboardingCompletedFromProbe(value)).toThrow(
+        PackagedOnboardingConfigError,
+      );
+    }
+  });
+
+  it('refuses to answer when config is an array rather than an object', async () => {
+    const value = await evaluatePackagedOnboardingConfigProbe(fakeConfigFetch({ body: { config: [] } }));
+
+    expect(value).toMatchObject({ ok: false });
+    expect(() => packagedOnboardingCompletedFromProbe(value)).toThrow(
+      PackagedOnboardingConfigError,
+    );
+  });
+
   it('names the status so a failure says what could not be established', async () => {
     const value = await evaluatePackagedOnboardingConfigProbe(
       fakeConfigFetch({ ok: false, status: 503 }),

--- a/e2e/tests/packaged/app-shell.test.ts
+++ b/e2e/tests/packaged/app-shell.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it } from 'vitest';
 import {
   asPackagedAppShellSnapshot,
   evaluatePackagedAppShellProbe,
+  evaluatePackagedOnboardingConfigProbe,
+  PackagedOnboardingConfigError,
   packagedAppShellExpression,
+  packagedOnboardingCompletedFromProbe,
+  packagedOnboardingConfigExpression,
+  type PackagedOnboardingConfigFetch,
   packagedAppShellFailureReason,
   packagedAppShellPolicy,
   packagedAppShellSettled,
@@ -264,6 +269,116 @@ describe('packaged app-shell policy', () => {
     const policy = packagedAppShellPolicy({ coreProfile: true, daemonOnboardingCompleted: false });
 
     expect(packagedAppShellSettled(probe(renderFixture([])), policy)).toBe(false);
+  });
+});
+
+/**
+ * A fake `/api/app-config`. `throws` models a renderer whose fetch rejects
+ * outright (daemon socket gone); the rest model real HTTP answers.
+ */
+function fakeConfigFetch(options: {
+  body?: unknown;
+  ok?: boolean;
+  status?: number;
+  throws?: boolean;
+}): PackagedOnboardingConfigFetch {
+  return async () => {
+    if (options.throws === true) throw new Error('fetch failed');
+    return {
+      json: async () => options.body,
+      ok: options.ok ?? true,
+      status: options.status ?? 200,
+    };
+  };
+}
+
+// PerishCode's second review on #6481: the probe converted an HTTP failure into
+// `onboardingCompleted: false`, which is the exact branch that permits the
+// onboarding landing. The fact the shell policy depends on could fail to be
+// established and the smoke would pass anyway. An unestablished fact must be an
+// error, never a permission.
+describe('packaged daemon onboarding config probe', () => {
+  it('reads a real completed config', async () => {
+    const value = await evaluatePackagedOnboardingConfigProbe(
+      fakeConfigFetch({ body: { config: { onboardingCompleted: true } } }),
+    );
+
+    expect(packagedOnboardingCompletedFromProbe(value)).toBe(true);
+  });
+
+  it('reads a real first-run config', async () => {
+    const value = await evaluatePackagedOnboardingConfigProbe(
+      fakeConfigFetch({ body: { config: { onboardingCompleted: false } } }),
+    );
+
+    expect(packagedOnboardingCompletedFromProbe(value)).toBe(false);
+  });
+
+  it('refuses to answer when the daemon returns a server error', async () => {
+    const value = await evaluatePackagedOnboardingConfigProbe(
+      fakeConfigFetch({ ok: false, status: 500 }),
+    );
+
+    expect(() => packagedOnboardingCompletedFromProbe(value)).toThrow(/500/);
+  });
+
+  it('refuses to answer when the route is missing', async () => {
+    const value = await evaluatePackagedOnboardingConfigProbe(
+      fakeConfigFetch({ ok: false, status: 404 }),
+    );
+
+    expect(() => packagedOnboardingCompletedFromProbe(value)).toThrow(
+      PackagedOnboardingConfigError,
+    );
+  });
+
+  it('refuses to answer when the daemon is not reachable at all', async () => {
+    const value = await evaluatePackagedOnboardingConfigProbe(fakeConfigFetch({ throws: true }));
+
+    expect(() => packagedOnboardingCompletedFromProbe(value)).toThrow(
+      PackagedOnboardingConfigError,
+    );
+  });
+
+  it('refuses to answer when the response carries no config', async () => {
+    const value = await evaluatePackagedOnboardingConfigProbe(fakeConfigFetch({ body: {} }));
+
+    expect(() => packagedOnboardingCompletedFromProbe(value)).toThrow(
+      PackagedOnboardingConfigError,
+    );
+  });
+
+  it('names the status so a failure says what could not be established', async () => {
+    const value = await evaluatePackagedOnboardingConfigProbe(
+      fakeConfigFetch({ ok: false, status: 503 }),
+    );
+
+    expect(() => packagedOnboardingCompletedFromProbe(value)).toThrow(
+      /onboarding config could not be established.*503/s,
+    );
+  });
+
+  // The load-bearing one: a failed probe must never reach the policy at all, so
+  // it can never be the thing that permits the landing.
+  it('never lets a failed probe become permission to accept the landing', async () => {
+    const failures = [
+      fakeConfigFetch({ ok: false, status: 500 }),
+      fakeConfigFetch({ ok: false, status: 404 }),
+      fakeConfigFetch({ throws: true }),
+      fakeConfigFetch({ body: null }),
+    ];
+
+    for (const failure of failures) {
+      const value = await evaluatePackagedOnboardingConfigProbe(failure);
+      expect(() => packagedOnboardingCompletedFromProbe(value)).toThrow(
+        PackagedOnboardingConfigError,
+      );
+    }
+  });
+
+  it('ships an expression that binds fetch for the renderer', () => {
+    expect(packagedOnboardingConfigExpression).toContain("fetch(input)");
+    expect(packagedOnboardingConfigExpression).toContain('/api/app-config');
   });
 });
 

--- a/e2e/tests/packaged/app-shell.test.ts
+++ b/e2e/tests/packaged/app-shell.test.ts
@@ -258,6 +258,37 @@ describe('packaged app-shell policy', () => {
     expect(packagedAppShellFailureReason(landing, policy)).toContain('needs home');
   });
 
+  // Swept alongside the probe fix: both of these read their input for
+  // truthiness, so anything that is not a real boolean falls through to the
+  // permissive branch. TypeScript forbids it today and the sole producer is
+  // validated, but the closed direction should be structural rather than
+  // dependent on a caller staying honest — only an explicit `false` may buy
+  // permission.
+  it('requires home for any onboarding reading that is not an explicit false', () => {
+    for (const daemonOnboardingCompleted of [undefined, null, '', 0, NaN, 'false']) {
+      expect(
+        packagedAppShellPolicy({
+          coreProfile: true,
+          daemonOnboardingCompleted: daemonOnboardingCompleted as unknown as boolean,
+        }),
+        `reading ${JSON.stringify(daemonOnboardingCompleted)}`,
+      ).toEqual({ acceptOnboardingLanding: false });
+    }
+  });
+
+  it('requires an explicit permission before accepting the landing', () => {
+    const landing = probe(renderFixture(CLOUD_SIGN_IN_LANDING));
+
+    for (const acceptOnboardingLanding of [undefined, null, 1, 'yes']) {
+      expect(
+        packagedAppShellSettled(landing, {
+          acceptOnboardingLanding: acceptOnboardingLanding as unknown as boolean,
+        }),
+        `permission ${JSON.stringify(acceptOnboardingLanding)}`,
+      ).toBe(false);
+    }
+  });
+
   it('lets an unseeded run settle on the landing', () => {
     const landing = probe(renderFixture(CLOUD_SIGN_IN_LANDING));
     const policy = packagedAppShellPolicy({ coreProfile: true, daemonOnboardingCompleted: false });

--- a/e2e/tests/packaged/app-shell.test.ts
+++ b/e2e/tests/packaged/app-shell.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  asPackagedAppShellSnapshot,
+  evaluatePackagedAppShellProbe,
+  packagedAppShellExpression,
+  packagedAppShellFailureReason,
+  packagedAppShellSettled,
+  packagedAppShellState,
+  type PackagedAppShellProbeDocument,
+  type PackagedAppShellProbeElement,
+  type PackagedAppShellSnapshot,
+} from '@/vitest/packaged-app-shell';
+
+/**
+ * A fixture element the probe can `instanceof`-check and measure. `rects` is
+ * the `getClientRects().length` the real renderer reports: zero means the node
+ * is in the tree but paints nothing (display:none, detached subtree), which the
+ * probe must not read as a visible home rail.
+ */
+class FixtureElement implements PackagedAppShellProbeElement {
+  constructor(
+    readonly classes: readonly string[],
+    readonly attributes: Readonly<Record<string, string>>,
+    private readonly rects: number,
+  ) {}
+
+  getClientRects(): ArrayLike<unknown> {
+    return Array.from({ length: this.rects }, () => ({}));
+  }
+}
+
+type FixtureNode = {
+  attributes?: Record<string, string>;
+  classes?: string[];
+  rects?: number;
+};
+
+/**
+ * Enough of `querySelector` for the four selectors the probe uses: class
+ * selectors, `[attr="value"]` selectors, and comma-separated groups. Document
+ * order is the fixture array order, which is what makes the "second
+ * `.onboarding-cloud__secondary` is the BYOK link" reading testable.
+ */
+function matchesSelector(element: FixtureElement, selector: string): boolean {
+  return selector
+    .split(',')
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+    .some((simple) => {
+      if (simple.startsWith('.')) return element.classes.includes(simple.slice(1));
+      const attribute = /^\[([^=\]]+)="([^"]*)"\]$/.exec(simple);
+      if (attribute?.[1] != null && attribute[2] != null) {
+        return element.attributes[attribute[1]] === attribute[2];
+      }
+      throw new Error(`fixture selector engine does not support ${JSON.stringify(simple)}`);
+    });
+}
+
+function renderFixture(
+  nodes: readonly FixtureNode[],
+  options: { bodyText?: string; title?: string } = {},
+): PackagedAppShellProbeDocument {
+  const elements = nodes.map(
+    (node) => new FixtureElement(node.classes ?? [], node.attributes ?? {}, node.rects ?? 1),
+  );
+  return {
+    body: { textContent: options.bodyText ?? '' },
+    querySelector: (selectors) => elements.find((element) => matchesSelector(element, selectors)) ?? null,
+    querySelectorAll: (selectors) => elements.filter((element) => matchesSelector(element, selectors)),
+    title: options.title ?? 'Open Design',
+  };
+}
+
+function probe(document: PackagedAppShellProbeDocument): PackagedAppShellSnapshot {
+  const value = evaluatePackagedAppShellProbe(document, FixtureElement);
+  const snapshot = asPackagedAppShellSnapshot(value);
+  if (snapshot == null) throw new Error(`probe returned an unusable snapshot: ${JSON.stringify(value)}`);
+  return snapshot;
+}
+
+// The surface a signed-in or onboarding-seeded packaged app comes up on.
+const HOME_SHELL: readonly FixtureNode[] = [
+  { classes: ['entry-shell'] },
+  { attributes: { 'data-testid': 'entry-nav-home' }, classes: ['entry-nav__item'] },
+  { attributes: { 'data-testid': 'entry-nav-updater' }, classes: ['entry-nav__item'] },
+];
+
+// The surface a fresh packaged install comes up on since the #4513 cloud
+// sign-in redesign: EntryShell's onboarding shell wrapping OnboardingView's
+// cloud landing (primary CTA + the Local CLI and BYOK secondary links). This is
+// the same DOM the [P0] onboarding smoke asserts against in win.spec.ts.
+const CLOUD_SIGN_IN_LANDING: readonly FixtureNode[] = [
+  { classes: ['entry-shell', 'entry-shell--no-header', 'entry-shell--onboarding'] },
+  { classes: ['entry-onboarding-modal'] },
+  { classes: ['onboarding-view', 'onboarding-view--cloud'] },
+  { classes: ['onboarding-cloud__primary'] },
+  { classes: ['onboarding-cloud__secondary'] },
+  { classes: ['onboarding-cloud__secondary'] },
+];
+
+describe('packaged app-shell probe', () => {
+  it('ships a self-contained expression that reads the globals the renderer has', () => {
+    expect(packagedAppShellExpression).toContain('(document, HTMLElement)');
+    expect(packagedAppShellExpression).toContain('[data-testid="entry-nav-home"]');
+    expect(packagedAppShellExpression).toContain('.onboarding-cloud__primary');
+  });
+
+  it('reports home for the main shell', () => {
+    expect(probe(renderFixture(HOME_SHELL))).toMatchObject({
+      cloudSignInVisible: false,
+      homeVisible: true,
+      onboardingVisible: false,
+    });
+  });
+
+  it('reports the cloud sign-in landing with both runtime links', () => {
+    expect(probe(renderFixture(CLOUD_SIGN_IN_LANDING))).toMatchObject({
+      byokLinkVisible: true,
+      cloudSignInVisible: true,
+      homeVisible: false,
+      localLinkVisible: true,
+      onboardingVisible: true,
+    });
+  });
+
+  it('does not read an unpainted home rail as visible', () => {
+    expect(
+      probe(renderFixture([{ attributes: { 'data-testid': 'entry-nav-home' }, rects: 0 }])).homeVisible,
+    ).toBe(false);
+  });
+
+  it('reports nothing for a blank window', () => {
+    expect(probe(renderFixture([], { title: '' }))).toMatchObject({
+      cloudSignInVisible: false,
+      homeVisible: false,
+      onboardingVisible: false,
+    });
+  });
+});
+
+describe('packaged app-shell terminal state', () => {
+  it('settles on home for every profile', () => {
+    const snapshot = probe(renderFixture(HOME_SHELL));
+
+    expect(packagedAppShellState(snapshot)).toBe('home');
+    expect(packagedAppShellSettled(snapshot, { acceptOnboardingLanding: false })).toBe(true);
+    expect(packagedAppShellSettled(snapshot, { acceptOnboardingLanding: true })).toBe(true);
+  });
+
+  // The bug this file exists for. A packaged first run that nobody signs in to
+  // comes to rest on the cloud sign-in landing — `connectStepRuntimeReady` in
+  // EntryShell.tsx will not advance without a signed-in cloud account, an
+  // installed local CLI, or a verified BYOK key, none of which a release runner
+  // has. Treating that as "not settled" made the Windows smoke wait 45s for a
+  // home shell that can never arrive, which is why the 0.18.0 stable cut had to
+  // fall back to `win_x64_smoke_mode: skip`.
+  it('settles on the cloud sign-in landing when the profile only needs a rendered surface', () => {
+    const snapshot = probe(renderFixture(CLOUD_SIGN_IN_LANDING));
+
+    expect(packagedAppShellState(snapshot)).toBe('onboarding-landing');
+    expect(packagedAppShellSettled(snapshot, { acceptOnboardingLanding: true })).toBe(true);
+  });
+
+  it('still requires home when the profile has to drive the entry rail', () => {
+    const snapshot = probe(renderFixture(CLOUD_SIGN_IN_LANDING));
+
+    expect(packagedAppShellSettled(snapshot, { acceptOnboardingLanding: false })).toBe(false);
+    expect(packagedAppShellFailureReason(snapshot, { acceptOnboardingLanding: false })).toContain(
+      'needs home',
+    );
+  });
+
+  it('rejects a blank window under every profile', () => {
+    const snapshot = probe(renderFixture([]));
+
+    expect(packagedAppShellState(snapshot)).toBeNull();
+    expect(packagedAppShellSettled(snapshot, { acceptOnboardingLanding: true })).toBe(false);
+    expect(packagedAppShellFailureReason(snapshot, { acceptOnboardingLanding: true })).toContain(
+      'neither the home nav rail nor the onboarding cloud sign-in landing rendered',
+    );
+  });
+
+  // A renderer that mounted the onboarding shell and then died mid-render is a
+  // real failure, not a gated first run: accepting bare `onboardingVisible`
+  // would have turned this check into "anything that is not home".
+  it('rejects an onboarding shell that never rendered its landing', () => {
+    const snapshot = probe(
+      renderFixture([
+        { classes: ['entry-shell', 'entry-shell--onboarding'] },
+        { classes: ['entry-onboarding-modal'] },
+      ]),
+    );
+
+    expect(packagedAppShellState(snapshot)).toBeNull();
+    expect(packagedAppShellSettled(snapshot, { acceptOnboardingLanding: true })).toBe(false);
+    expect(packagedAppShellFailureReason(snapshot, { acceptOnboardingLanding: true })).toContain(
+      'cloud sign-in landing did not render',
+    );
+  });
+
+  it('rejects a landing that lost one of its runtime links', () => {
+    const snapshot = probe(
+      renderFixture([
+        { classes: ['entry-shell', 'entry-shell--onboarding'] },
+        { classes: ['entry-onboarding-modal'] },
+        { classes: ['onboarding-cloud__primary'] },
+        { classes: ['onboarding-cloud__secondary'] },
+      ]),
+    );
+
+    expect(snapshot.byokLinkVisible).toBe(false);
+    expect(packagedAppShellSettled(snapshot, { acceptOnboardingLanding: true })).toBe(false);
+  });
+
+  it('rejects a snapshot the renderer could not produce', () => {
+    expect(packagedAppShellState(null)).toBeNull();
+    expect(packagedAppShellState({ homeVisible: true })).toBeNull();
+    expect(packagedAppShellSettled(undefined, { acceptOnboardingLanding: true })).toBe(false);
+    expect(packagedAppShellFailureReason(null, { acceptOnboardingLanding: true })).toContain(
+      'no app-shell snapshot',
+    );
+  });
+});

--- a/e2e/tests/packaged/app-shell.test.ts
+++ b/e2e/tests/packaged/app-shell.test.ts
@@ -9,7 +9,9 @@ import {
   PackagedOnboardingConfigError,
   packagedAppShellExpression,
   packagedOnboardingCompletedFromProbe,
+  packagedOnboardingCompletedForScenario,
   packagedOnboardingConfigExpression,
+  packagedOnboardingOutcomeFromProbe,
   runPackagedAppShellPhase,
   type PackagedOnboardingConfigFetch,
   packagedAppShellFailureReason,
@@ -447,13 +449,15 @@ describe('packaged daemon onboarding config probe', () => {
   // string "false" into a well-formed `false`, which the reader then accepts as
   // a real reading. "The daemon did not tell me" must never arrive as "the
   // daemon told me false".
-  it('refuses to answer when a 200 carries no onboardingCompleted field', async () => {
+  // Absent, not malformed: the daemon never wrote the key. A seeded run must
+  // still reject it — there the absence means the seed vanished — but it is the
+  // one outcome a declared first run legitimately accepts.
+  it('classifies a 200 with no onboardingCompleted field as absent', async () => {
     const value = await evaluatePackagedOnboardingConfigProbe(fakeConfigFetch({ body: { config: {} } }));
 
-    expect(value).toMatchObject({ ok: false });
-    expect(() => packagedOnboardingCompletedFromProbe(value)).toThrow(
-      PackagedOnboardingConfigError,
-    );
+    expect(packagedOnboardingOutcomeFromProbe(value).kind).toBe('absent');
+    expect(packagedOnboardingCompletedForScenario(packagedOnboardingOutcomeFromProbe(value), 'first-run')).toBe(false);
+    expect(() => packagedOnboardingCompletedFromProbe(value)).toThrow(PackagedOnboardingSeedError);
   });
 
   it('refuses to answer when onboardingCompleted is the wrong type', async () => {
@@ -543,7 +547,7 @@ describe('packaged launch scenarios', () => {
       coreProfile: true,
       now: clock.now,
       observe: async () => landing,
-      readOnboardingConfig: async () => ({ ok: true, onboardingCompleted: false, status: 200 }),
+      readOnboardingConfig: async () => ({ kind: 'reading', ok: true, onboardingCompleted: false, status: 200 }),
       scenario: 'first-run',
       sleep: clock.sleep,
     });
@@ -559,7 +563,7 @@ describe('packaged launch scenarios', () => {
       coreProfile: true,
       now: clock.now,
       observe: async () => home,
-      readOnboardingConfig: async () => ({ ok: true, onboardingCompleted: true, status: 200 }),
+      readOnboardingConfig: async () => ({ kind: 'reading', ok: true, onboardingCompleted: true, status: 200 }),
       scenario: 'completed-user',
       sleep: clock.sleep,
     });
@@ -576,7 +580,7 @@ describe('packaged launch scenarios', () => {
         coreProfile: true,
         now: clock.now,
         observe: async () => landing,
-        readOnboardingConfig: async () => ({ ok: true, onboardingCompleted: true, status: 200 }),
+        readOnboardingConfig: async () => ({ kind: 'reading', ok: true, onboardingCompleted: true, status: 200 }),
         scenario: 'completed-user',
         sleep: clock.sleep,
       }),
@@ -592,7 +596,7 @@ describe('packaged launch scenarios', () => {
         coreProfile: true,
         now: clock.now,
         observe: async () => landing,
-        readOnboardingConfig: async () => ({ ok: true, onboardingCompleted: false, status: 200 }),
+        readOnboardingConfig: async () => ({ kind: 'reading', ok: true, onboardingCompleted: false, status: 200 }),
         scenario: 'completed-user',
         sleep: clock.sleep,
       }),
@@ -608,7 +612,7 @@ describe('packaged launch scenarios', () => {
         coreProfile: true,
         now: clock.now,
         observe: async () => blank,
-        readOnboardingConfig: async () => ({ ok: true, onboardingCompleted: false, status: 200 }),
+        readOnboardingConfig: async () => ({ kind: 'reading', ok: true, onboardingCompleted: false, status: 200 }),
         scenario: 'first-run',
         sleep: clock.sleep,
       }),

--- a/e2e/tests/packaged/app-shell.test.ts
+++ b/e2e/tests/packaged/app-shell.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  assertSeededOnboardingRetained,
   asPackagedAppShellSnapshot,
+  PackagedOnboardingSeedError,
   evaluatePackagedAppShellProbe,
   evaluatePackagedOnboardingConfigProbe,
   PackagedOnboardingConfigError,
@@ -317,6 +319,36 @@ describe('packaged app-shell policy', () => {
     });
 
     expect(packagedAppShellSettled(landing, policy)).toBe(false);
+  });
+
+  it('fails a lost seed with a cause that names the cold launch', () => {
+    expect(() =>
+      assertSeededOnboardingRetained({
+        daemonOnboardingCompleted: false,
+        seededOnboardingCompleted: true,
+      }),
+    ).toThrow(PackagedOnboardingSeedError);
+    expect(() =>
+      assertSeededOnboardingRetained({
+        daemonOnboardingCompleted: false,
+        seededOnboardingCompleted: true,
+      }),
+    ).toThrow(/lost the seeded onboarding state.*tools-pack runtime data root/s);
+  });
+
+  it('passes a retained seed and an honestly unseeded run', () => {
+    expect(() =>
+      assertSeededOnboardingRetained({
+        daemonOnboardingCompleted: true,
+        seededOnboardingCompleted: true,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertSeededOnboardingRetained({
+        daemonOnboardingCompleted: false,
+        seededOnboardingCompleted: false,
+      }),
+    ).not.toThrow();
   });
 
   it('lets an unseeded run settle on the landing', () => {

--- a/e2e/tests/packaged/app-shell.test.ts
+++ b/e2e/tests/packaged/app-shell.test.ts
@@ -10,6 +10,7 @@ import {
   packagedAppShellExpression,
   packagedOnboardingCompletedFromProbe,
   packagedOnboardingConfigExpression,
+  runPackagedAppShellPhase,
   type PackagedOnboardingConfigFetch,
   packagedAppShellFailureReason,
   packagedAppShellPolicy,
@@ -519,5 +520,98 @@ describe('packaged app-shell snapshot guards', () => {
     expect(packagedAppShellFailureReason(null, { acceptOnboardingLanding: true })).toContain(
       'no app-shell snapshot',
     );
+  });
+});
+
+// PerishCode's sixth review on #6481: the unit fixtures prove the rule, but the
+// release smoke seeds unconditionally, so `seededObserved` is always true at the
+// only policy call site and the unseeded cases exercise a state the smoke can
+// never enter. These drive the smoke's own transition — read the daemon fact,
+// hold the seeded state across it, derive the policy, settle — with only the
+// I/O faked, for both scenarios the packaged app legitimately has.
+describe('packaged launch scenarios', () => {
+  const virtualClock = () => {
+    let t = 0;
+    return { now: () => t, sleep: async (ms: number) => { t += ms; } };
+  };
+
+  it('settles a genuine first run on the cloud sign-in landing', async () => {
+    const clock = virtualClock();
+    const landing = probe(renderFixture(CLOUD_SIGN_IN_LANDING));
+
+    const result = await runPackagedAppShellPhase({
+      coreProfile: true,
+      now: clock.now,
+      observe: async () => landing,
+      readOnboardingCompleted: async () => false,
+      scenario: 'first-run',
+      sleep: clock.sleep,
+    });
+
+    expect(result).toEqual({ appShell: 'onboarding-landing', onboardingCompleted: false });
+  });
+
+  it('settles a completed user on home', async () => {
+    const clock = virtualClock();
+    const home = probe(renderFixture(HOME_SHELL));
+
+    const result = await runPackagedAppShellPhase({
+      coreProfile: true,
+      now: clock.now,
+      observe: async () => home,
+      readOnboardingCompleted: async () => true,
+      scenario: 'completed-user',
+      sleep: clock.sleep,
+    });
+
+    expect(result).toEqual({ appShell: 'home', onboardingCompleted: true });
+  });
+
+  it('fails a completed user that lands on onboarding instead of home', async () => {
+    const clock = virtualClock();
+    const landing = probe(renderFixture(CLOUD_SIGN_IN_LANDING));
+
+    await expect(
+      runPackagedAppShellPhase({
+        coreProfile: true,
+        now: clock.now,
+        observe: async () => landing,
+        readOnboardingCompleted: async () => true,
+        scenario: 'completed-user',
+        sleep: clock.sleep,
+      }),
+    ).rejects.toThrow(/needs home/);
+  });
+
+  it('fails a completed user whose seeded state was lost across the relaunch', async () => {
+    const clock = virtualClock();
+    const landing = probe(renderFixture(CLOUD_SIGN_IN_LANDING));
+
+    await expect(
+      runPackagedAppShellPhase({
+        coreProfile: true,
+        now: clock.now,
+        observe: async () => landing,
+        readOnboardingCompleted: async () => false,
+        scenario: 'completed-user',
+        sleep: clock.sleep,
+      }),
+    ).rejects.toThrow(PackagedOnboardingSeedError);
+  });
+
+  it('fails a first run whose renderer never painted either surface', async () => {
+    const clock = virtualClock();
+    const blank = probe(renderFixture([]));
+
+    await expect(
+      runPackagedAppShellPhase({
+        coreProfile: true,
+        now: clock.now,
+        observe: async () => blank,
+        readOnboardingCompleted: async () => false,
+        scenario: 'first-run',
+        sleep: clock.sleep,
+      }),
+    ).rejects.toThrow(/neither the home nav rail nor the onboarding cloud sign-in landing rendered/);
   });
 });


### PR DESCRIPTION
<!-- No linked issue: this came out of the 0.18.0 stable cut, not the tracker. -->

## Why

**The trigger.** Cutting 0.18.0 stable, the `Build release win x64` job failed on the packaged smoke and the lane had to be re-run with `win_x64_smoke_mode: skip`. That drops *all* Windows smoke coverage — install, launch, health, PTY, invite protocol, uninstall residue — for a flagship release. Run [`31012989233`](https://github.com/nexu-io/open-design/actions/runs/31012989233):

```
Error: packaged windows runtime did not reach main app shell: {
  "daemonStatus": { "state": "running", "desktopAuthGateActive": true, ... },
  "eval": { "ok": true, "value": {
      "homeVisible": false, "onboardingVisible": true, "skipped": false, "title": "Open Design" } }
}
```

Nothing there is broken. The daemon is running, the window is loaded, `eval` answers. The app is simply sitting on onboarding, and the smoke was waiting for it to leave on its own.

**The underlying pain.** `ensureMainAppShell` in `e2e/specs/win.spec.ts` was born as an *actor*: commit `f8982fc83c` had it click `.onboarding-view__secondary` (Skip) and then wait for home. #4389 removed the Skip affordance, and #4322 stripped the click out of the expression — leaving a pure observer polling for a home shell that nothing will ever produce. Since the #4513 cloud sign-in redesign, a fresh packaged install lands on the cloud sign-in landing and stays there: `connectStepRuntimeReady` (`apps/web/src/components/EntryShell.tsx`) only advances for a signed-in cloud account, an available local CLI agent, or a BYOK provider whose connection test passed. A release runner has none of the three — per `e2e/AGENTS.md`, "CI runners have no host binaries and no provider accounts". So the assertion cannot pass unattended, by construction.

It also contradicts its own sibling. `[P0] @electron-smoke starts a fresh packaged Windows app on onboarding with AMR, Local CLI, and BYOK visible`, in the same file, asserts that a fresh install *does* show onboarding. P0 only runs when `OD_PACKAGED_E2E_WIN_ONBOARDING_SMOKE=1`, which `release-stable.yml` sets for the nightly channel only — so on the stable channel P0 is skipped and P2's contradictory expectation is the only one left standing.

`.github/workflows/release-stable.yml` gained a `win_x64_smoke_mode != 'skip'` guard on the Windows e2e report download in #6480, which stopped `skip` from failing the lane outright. This change is what lets the lane stop needing `skip` at all.

## What users will see

Nothing — this is release-lane test infrastructure. The visible effect is that Windows packaged smoke coverage comes back for stable releases instead of being switched off.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — e2e test only.

## What changed, and why this shape

Two options were on the table.

**Rejected — drive through onboarding.** Restoring the original actor behaviour by clicking the Local CLI or BYOK secondary link cannot work hermetically. The gate is `connectStepRuntimeReady`: local needs `selectedAgent !== null` from `agents.filter(a => a.available)`, BYOK needs `visibleProviderTestState.status === 'done' && result.ok`, cloud needs a real signed-in account. Clicking a secondary link only expands a setup panel — exactly what the `[P0]` smoke already proves — and there are three more steps behind step 0 before `onboardingFinish`. Reaching home would require shipping a real agent binary or a real API key onto the release runner.

**Chosen — derive the accepted terminal state from the daemon, and assert the landing positively.** `ensureMainAppShell` becomes `ensurePackagedAppShell(...)`, and the rule it applies moved into a pure module, `e2e/lib/vitest/packaged-app-shell.ts`.

### Review round 1 — keeping the seeded-onboarding postcondition

The first revision accepted the landing whenever the profile was `core`. PerishCode's review pointed out that the same run calls `seedPackagedOnboardingComplete()` first, so setup said "onboarding is done" while the expectation said "onboarding is fine" — a broken completed-onboarding boot path would pass silently. That was a real loss of coverage, and it is fixed here. [Full reply with the source trace.](https://github.com/nexu-io/open-design/pull/6481#discussion_r3725740474)

Before changing anything I ruled out the competing root cause — that a launcher-managed (channel) install resolves its data root under the channel-scoped path in the failure snapshot, which would mean the seed has always been a no-op on the stable lane and the fix belongs in the seed instead. **It does not:**

- `tools/pack/src/win/lifecycle.ts:216-227` — every installed start rewrites the launch config's `namespaceBaseRoot` to `config.roots.runtime.namespaceBaseRoot` and passes it as `OD_PACKAGED_CONFIG_PATH`.
- `tools/pack/src/config.ts:359` — that is `join(toolPackRoot, "runtime", "win", "namespaces")`.
- `apps/packaged/src/config.ts:96` — `OD_PACKAGED_CONFIG_PATH` wins over the baked resources config.
- `apps/packaged/src/paths.ts:97` → `join(namespaceBaseRoot, namespace, "data")`, handed to the daemon as `OD_DATA_DIR` at `apps/packaged/src/sidecars.ts:589`.
- `e2e/specs/win.spec.ts:56` + the seed helper write exactly that path.
- `apps/packaged/src/payload-desktop-launch.ts:85-90` — the launcher's payload delegation spawns with **no `env` override**, so payload processes inherit the same config path.
- The channel-scoped root in the snapshot is the launcher's own version-pointer state (`resolveToolPackLauncherRoot` = `dirname(namespaceBaseRoot)`, `tools/pack/src/launcher-layout.ts:45`) — a sibling tree, not a data root.

So the seed targets what the runtime resolves, and with `shouldRouteToFirstRunOnboarding` (`apps/web/src/App.tsx:259`) short-circuiting on `onboardingCompleted === true`, a seeded start *should* reach home. Requiring home is legitimate.

What the change does, therefore, is stop guessing and **measure it**. `packagedAppShellPolicy` derives the accepted terminal state from the daemon's own `onboardingCompleted`, read through `GET /api/app-config` (which serves `readAppConfig(RUNTIME_DATA_DIR)`), never from the smoke profile:

- daemon confirms completion → **home is the only acceptable outcome**, on `core` as well as `full`. Every release workflow defaults `win_x64_smoke_mode` to `core`, so parking this postcondition in `full` would have deleted it from routine coverage.
- daemon reports a genuine first run → the cloud sign-in landing is correct, and is accepted only when it actually rendered its sign-in CTA and both runtime links.

Setup and expectation can no longer disagree, because the expectation is a function of the observed setup.

The seed's postcondition is additionally asserted directly, right after the seeded `tools-pack win start` where the chain above proves it must hold. A daemon that does not see it there is a real data-root regression — the #4389-era failure where the seed landed in the AppData fallback — and now fails with that named cause. The app-shell reading is deliberately taken *again* rather than reused, because in `core` the app was stopped and relaunched through the OS protocol handler, which inherits none of the test runner's environment and is therefore a different daemon.

The landing itself is still recognised positively, from the same three affordances the `[P0]` onboarding smoke asserts — `.onboarding-cloud__primary` plus both `.onboarding-cloud__secondary` links inside `.entry-shell--onboarding` / `.entry-onboarding-modal`. Bare `onboardingVisible` is rejected, so a blank window, a crashed renderer, a boot still on `CenteredLoader`, an onboarding shell that mounted and then died, and a landing missing a runtime link all still fail — each with a named cause, per `e2e/AGENTS.md` → "Name your failure causes". The settled state and both onboarding readings are recorded in the packaged smoke report summary.

**Rejected — drive through onboarding.** Restoring the original actor behaviour by clicking the Local CLI or BYOK secondary link cannot work hermetically. The gate is `connectStepRuntimeReady`: local needs `selectedAgent !== null` from `agents.filter(a => a.available)`, BYOK needs `visibleProviderTestState.status === 'done' && result.ok`, cloud needs a real signed-in account. Clicking a secondary link only expands a setup panel — exactly what the `[P0]` smoke already proves — and there are three more steps behind step 0 before `onboardingFinish`. Reaching home would require shipping a real agent binary or a real API key onto the release runner.

## Bug fix verification

- Red spec: `e2e/tests/packaged/app-shell.test.ts`
- Went red before the fix, green after: **yes**

`main`'s rule is inline in `e2e/specs/win.spec.ts`, which cannot execute anywhere but a Windows runner with a packaged build installed — and the DOM probe it reads reaches the renderer as a plain string through `tools-pack inspect --expr`, so nothing type-checks it either. So the red was produced by first extracting the probe and `main`'s rule verbatim into a pure module and covering both from macOS. That extraction is commit `a791b2251c`, on this branch, checkout-able: the rule there accepts only `homeVisible === true`, exactly as `ensureMainAppShell` does on `main`.

Red — `pnpm exec vitest run -c vitest.config.ts tests/packaged/app-shell.test.ts` at `a791b2251c`:

```
 RUN  v4.1.6 /private/tmp/od-wt-winsmoke/e2e

 ❯ tests/packaged/app-shell.test.ts (12 tests | 2 failed) 6ms
     × settles on the cloud sign-in landing when the profile only needs a rendered surface 2ms
     × still requires home when the profile has to drive the entry rail 1ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  tests/packaged/app-shell.test.ts > packaged app-shell terminal state > settles on the cloud sign-in landing when the profile only needs a rendered surface
AssertionError: expected null to be 'onboarding-landing' // Object.is equality

- Expected:
"onboarding-landing"

+ Received:
null

 ❯ tests/packaged/app-shell.test.ts:161:45
    159|     const snapshot = probe(renderFixture(CLOUD_SIGN_IN_LANDING));
    160|
    161|     expect(packagedAppShellState(snapshot)).toBe('onboarding-landing');
       |                                             ^
    162|     expect(packagedAppShellSettled(snapshot, { acceptOnboardingLanding…
    163|   });

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

 FAIL  tests/packaged/app-shell.test.ts > packaged app-shell terminal state > still requires home when the profile has to drive the entry rail
AssertionError: expected 'the onboarding shell mounted but its …' to contain 'needs home'

Expected: "needs home"
Received: "the onboarding shell mounted but its cloud sign-in landing did not render (no sign-in CTA, or fewer than two runtime links)"

 ❯ tests/packaged/app-shell.test.ts:169:89
    167|
    168|     expect(packagedAppShellSettled(snapshot, { acceptOnboardingLanding…
    169|     expect(packagedAppShellFailureReason(snapshot, { acceptOnboardingL…
       |                                                                                         ^
    170|       'needs home',
    171|     );

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/2]⎯


 Test Files  1 failed (1)
      Tests  2 failed | 10 passed (12)
   Start at  00:33:13
   Duration  92ms (transform 19ms, setup 0ms, import 24ms, tests 6ms, environment 0ms)
```

The 10 that passed are the probe itself: it already reports the cloud landing correctly. Only the acceptance rule was wrong.

Green — same command at `523b82c6fb`:

```
 RUN  v4.1.6 /private/tmp/od-wt-winsmoke/e2e


 Test Files  1 passed (1)
      Tests  12 passed (12)
   Start at  00:34:00
   Duration  87ms (transform 19ms, setup 0ms, import 24ms, tests 3ms, environment 0ms)
```

The fixtures are Node-only (`e2e/AGENTS.md` forbids jsdom under `specs/`/`tests/`): a small selector engine over declared nodes, driving the *exact* probe text that ships to the renderer via `new Function`. That covers the selectors, the `getClientRects()` visibility rule, and the reported field set — none of which anything checked before.

### Round 7 red -> green — absent is not malformed

Round 4 made a missing `onboardingCompleted` fail closed; round 6 added a scenario that produces exactly that. They collided. `resetPackagedRuntimeDataRoot()` deletes `app-config.json`; `readAppConfig` returns `{}` on ENOENT (`app-config.ts:769`) and adds only telemetry defaults, so a fresh install's `/api/app-config` serves `{ config: { telemetry: {...} } }` — the key is **absent**, not `false` — and the probe classified that as corruption, so the first-run phase could never reach the landing it was added to assert. [Full reply.](https://github.com/nexu-io/open-design/pull/6481#discussion_r3726491118)

**The recurring root across all seven rounds is that a *fault* and an *absence* kept getting the same representation.** Each round patched one instance; none named the family. So the complete outcome set is now a docblock table on `packagedOnboardingOutcomeFromProbe`:

| outcome | meaning | first-run | completed-user |
|---|---|---|---|
| `transport-failure` | fetch rejected; daemon unreachable | reject | reject |
| `http-error` | non-2xx from `/api/app-config` | reject | reject |
| `no-config` | 200 whose body carried no `config` object | reject | reject |
| `absent` | 200, `config` present, key never written | **accept → `false`** | reject → seed error |
| `malformed` | key present but not a boolean | reject | reject |
| `reading` | key present and boolean | accept | accept iff `true` |

`absent` is the only asymmetric row, deliberately: a key never written is the honest state of a fresh install, while in a seeded run its disappearance means the seed vanished — so there it raises `PackagedOnboardingSeedError` naming the cold launch, not a generic config fault.

**Shape chosen: represent absence as its own outcome**, rather than having the first-run phase write an explicit `onboardingCompleted: false`. Writing one would make the phase assert against a state a real fresh install never has — the same flaw round 6 just corrected, one layer down — and would leave the probe permanently unable to tell a fresh install from a corrupt config. Interpretation also moved off the reader and onto the declared scenario, since "absent" genuinely means different things to the two scenarios.

`427c779aa2` adds a fixture whose body matches the daemon's real fresh reply, with round 4's interpretation still in place:

```
 ❯ tests/packaged/app-shell.test.ts (45 tests | 2 failed) 10ms
     × settles a first run whose daemon never wrote the key 2ms
     × still fails a completed user whose key went missing 1ms

PackagedOnboardingConfigError: packaged windows daemon onboarding config could not be established: daemon config carried no boolean onboardingCompleted (got undefined) (status=200)

 Test Files  1 failed (1)
      Tests  2 failed | 43 passed (45)
```

`7ccf5c103b` separates the outcomes: `Tests 45 passed (45)`.

### Round 6 red -> green — two real scenarios, both exercised in `core`

Review round 6 caught the consequence of rounds 1-5: the run seeds unconditionally, requires the first reading `true`, and round 5 requires that seed to survive — so the seeded observation is always `true` at the only policy call site, the policy can only return `acceptOnboardingLanding: false`, and the unseeded unit cases exercised a state the release smoke can never enter. The head produced a better error and still needed `skip`. [Full reply.](https://github.com/nexu-io/open-design/pull/6481#discussion_r3726431866)

**This is not a contradiction in the product, which is what makes two scenarios the right answer rather than a compromise.** `shouldRouteToFirstRunOnboarding` (`apps/web/src/App.tsx:255`) keys purely on `onboardingCompleted`, and `connectStepRuntimeReady` (`EntryShell.tsx:2139`) lets onboarding complete through cloud sign-in **or** a local CLI **or** a verified BYOK key. So a user who finished setup and is merely signed out belongs on **home**, while a run that never completed onboarding belongs on the **cloud sign-in landing**. Both are correct behaviour and the smoke now covers both.

**Shape: separately asserted phases**, not a second `test(...)`. A second test needs its own install and uninstall on the release critical path (where `maxInstallDurationMs` is already a budgeted 120s); phases reuse the single install for one extra start/stop, and keeping both scenarios adjacent makes the contrast legible — the seed is the only thing that differs. Phase 1 runs before the seed: reset the daemon data root *and* the Electron user-data partition (localStorage carries `onboardingCompleted` too), start, assert the daemon reports `false`, require `onboarding-landing`, stop, reset both again so phase 2's seed lands clean. It is **core-only** on purpose — every release workflow defaults there — and not extended to `full`, whose updater fixture environment is wired between the seed and the first start.

The settle loop and the phase around it also moved into the pure module, so the **transition** is covered rather than only the policy input: `runPackagedAppShellPhase` performs read → hold seeded state → derive policy → settle, with the spec supplying real readers and the tests supplying fakes and a virtual clock.

`e38dfd4484` adds both scenarios but leaves the phase hardcoding the seeded assumption, so a genuine first run fails with entirely the wrong error:

```
 ❯ tests/packaged/app-shell.test.ts (41 tests | 2 failed) 8ms
     × settles a genuine first run on the cloud sign-in landing 2ms
     × fails a first run whose renderer never painted either surface 1ms

PackagedOnboardingSeedError: the relaunched daemon lost the seeded onboarding state — check that the protocol cold launch still resolves the tools-pack runtime data root

 Test Files  1 failed (1)
      Tests  2 failed | 39 passed (41)
```

`3de360a233` derives the seeded expectation from the declared scenario and adds the first-run phase: `Tests 41 passed (41)`.

**Will this make the lane green? Partly, stated honestly.** The **first-run phase** needs no seed and asserts the surface a fresh packaged install genuinely produces, so it should pass; if it fails it fails on something real. The **completed-user phase still depends on the round-2 question** — the protocol cold relaunch inherits none of the test process's environment, and if it resolves a different data root the seed is gone and the phase fails with `PackagedOnboardingSeedError`. That remains unverifiable from macOS. If it does fail, the error names the cause and the fix belongs in the packaged runtime or the protocol handler registration, not in loosening the check.

### Round 5 red -> green — a lost seed is a regression, not a first run

Review round 5 found the same family one level further out, at the scenario rather than a single expression — and on the exact divergence this PR flagged as unverified in round 2, then built a policy that absorbed. The run seeds `onboardingCompleted: true` and asserts the seeded daemon reads it back; the core profile then stops the app and relaunches it through the OS protocol handler, which inherits none of the test process's environment. If that cold launch resolves a different data root, the fresh reading is `false`, the policy called it a genuine first run, and the smoke passed **while blind to the regression it exists to catch**. [Full reply, including the transition enumeration.](https://github.com/nexu-io/open-design/pull/6481#discussion_r3726173395)

**Shape chosen: seed-authoritative.** The alternative — making the core scenario unseeded — discards the completed-onboarding boot path, which is what review round 1 said not to lose, and every release workflow defaults `win_x64_smoke_mode` to `core`, so that path would be exercised in no routine run at all. So once this run has seeded completion and observed it confirmed, a later `false` is a regression: `assertSeededOnboardingRetained` raises `PackagedOnboardingSeedError` naming the cold launch and the data root to check, and `packagedAppShellPolicy` additionally refuses permission for any run whose seeded observation is not an explicit `false`, so the loss cannot buy the landing even if the assertion were bypassed.

I also enumerated every state transition in the spec (relaunch, reinstall, update, stop/start) and classified whether a change there fails or is absorbed. Exactly one sits between the seed observation and the policy decision — the protocol cold relaunch, fixed here. One other post-seed process replacement (the core-only direct reinstall at line 867) lands *after* the decision with nothing downstream depending on onboarding; flagged, deliberately unguarded until it has a consumer.

`88b54f6c1c` gives the policy the seeded observation and leaves the implementation ignoring it:

```
 ❯ tests/packaged/app-shell.test.ts (34 tests | 2 failed) 8ms
     × never downgrades a lost seed to a genuine first run 3ms
     × keeps a lost seed failing at the shell check 0ms

AssertionError: expected { acceptOnboardingLanding: true } to deeply equal { acceptOnboardingLanding: false }

 Test Files  1 failed (1)
      Tests  2 failed | 32 passed (34)
```

`814a75b2e2` makes the seed authoritative: `Tests 36 passed (36)`.

**This may surface a real packaged-runtime bug.** The round-2 note about the protocol relaunch inheriting no environment is now load-bearing rather than a footnote. If that cold launch does resolve a different data root, the seed is genuinely gone and the next Windows release run will fail with `PackagedOnboardingSeedError` instead of passing. **That is the correct outcome** — the fix would then belong in the packaged runtime or the protocol handler registration, not in loosening this check or going back to accepting the landing.

### Round 4 red -> green — no coercion may synthesize the reading

Review round 3 found the same defect class a third time, now in the round-3 fix: `config.onboardingCompleted === true` turns **anything** into a valid boolean, so a 200 carrying `{ config: {} }` or `{ config: { onboardingCompleted: "false" } }` produced `{ ok: true, onboardingCompleted: false, status: 200 }` — and `false` is the reading that permits the landing. The round-3 claim that the reader requires "a boolean reading present" was **vacuous as written**: the presence check ran after `=== true` had already synthesized one. [Full reply, including the sweep.](https://github.com/nexu-io/open-design/pull/6481#discussion_r3726123902)

The probe now requires `typeof config.onboardingCompleted === 'boolean'` and returns `{ ok: false, error, status }` otherwise, plus `Array.isArray` rejection for an array `config` that `typeof === 'object'` let through.

I then swept the whole diff for the same class — `??`, `||`, `=== true`, `Boolean(...)`, `?.` chains ending in a default, `as` casts — and classified each by whether it can turn *unknown* into *permitted*. Two more truthiness reads could: `packagedAppShellPolicy` now requires an explicit `false` before granting permission, and `packagedAppShellSettled` requires `acceptOnboardingLanding === true`. Seven other sites already failed closed (the `instanceof` flags must all be positively true to settle; `asPackagedAppShellSnapshot` type-checks before use; the `status`/`ok` guards can only reject). One pre-existing site is flagged and deliberately unchanged: `OD_PACKAGED_E2E_WIN_SMOKE_PROFILE ?? 'core'` defaults to the permissive profile, which matches every workflow's declared `default: core`.

`cb3d87c243` adds the malformed-payload fixtures against the shipped expression text:

```
 ❯ tests/packaged/app-shell.test.ts (30 tests | 3 failed) 8ms
     × refuses to answer when a 200 carries no onboardingCompleted field 3ms
     × refuses to answer when onboardingCompleted is the wrong type 0ms
     × refuses to answer when config is an array rather than an object 0ms

AssertionError: expected { ok: true, …(2) } to match object { ok: false }

 Test Files  1 failed (1)
      Tests  3 failed | 27 passed (30)
```

`a9c474f99c` fixes the probe and the two swept sites:

```
 Test Files  1 passed (1)
      Tests  32 passed (32)
```

### Round 3 red -> green — failing closed on the config probe

Review round 2 caught a fail-open **in the round-1 fix**: the daemon-config probe mapped every non-2xx to `body = null`, so `body?.config?.onboardingCompleted === true` produced a well-formed `false` — the exact branch that permits the onboarding landing — while `status` was returned and read by nobody. A 500, a 404, or a daemon not yet serving became *permission*. Only the seeded assertion had an accidental backstop (it expects `true`); the app-shell call site that gates the restored core lane had none. [Full reply.](https://github.com/nexu-io/open-design/pull/6481#discussion_r3725812395)

The probe now reports failure structurally — `{ ok: false, status, error }` for a non-2xx, a body without `config`, or a rejected fetch — and `packagedOnboardingCompletedFromProbe` raises `PackagedOnboardingConfigError` (its own type, so no caller can read it as `false`) unless `ok === true` **and** `status === 200` **and** a boolean reading is present. `status` gates the reading and is named in every failure message. There is deliberately no default and no retry: `waitForHealthyDesktop` already proved the same renderer gets 200 from `/api/health` immediately before both call sites, so a failure is a real fault, and a retry would only add the exhaustion-into-the-permissive-branch path.

`42f28bcf8c` moves the probe and its reading into the pure module verbatim and drives the shipped expression against a fake `fetch`:

```
 ❯ tests/packaged/app-shell.test.ts (27 tests | 6 failed) 7ms
     × refuses to answer when the daemon returns a server error 2ms
     × refuses to answer when the route is missing 0ms
     × refuses to answer when the daemon is not reachable at all 0ms
     × refuses to answer when the response carries no config 0ms
     × names the status so a failure says what could not be established 0ms
     × never lets a failed probe become permission to accept the landing 0ms

AssertionError: expected function to throw an error, but it didn't

 Test Files  1 failed (1)
      Tests  6 failed | 21 passed (27)
```

`46fa6eab29` hardens both halves:

```
 Test Files  1 passed (1)
      Tests  27 passed (27)
```

### Round 2 red -> green

Same discipline for the review fix. `a20b0c8ee6` names the decision as `packagedAppShellPolicy` and leaves it keyed off the smoke profile, exactly as round 1 left the behaviour, so the cases encoding the reviewer's point fail:

```
 ❯ tests/packaged/app-shell.test.ts (18 tests | 2 failed) 7ms
     × requires home once the daemon confirms onboarding is completed 3ms
     × keeps a seeded run failing when the app ignores completed onboarding 0ms

 FAIL  tests/packaged/app-shell.test.ts > packaged app-shell policy > requires home once the daemon confirms onboarding is completed
AssertionError: expected { acceptOnboardingLanding: true } to deeply equal { acceptOnboardingLanding: false }

- Expected
+ Received

  {
-   "acceptOnboardingLanding": false,
+   "acceptOnboardingLanding": true,
  }

 Test Files  1 failed (1)
      Tests  2 failed | 16 passed (18)
```

`a2da796482` makes the policy derive from the daemon:

```
 Test Files  1 passed (1)
      Tests  18 passed (18)
```

## Validation

Run from the repo root on macOS unless noted.

- `pnpm guard` — exit 0
- `pnpm typecheck` — exit 0
- `pnpm exec vitest run -c vitest.config.ts tests/packaged specs/win.spec.ts tests/win-installer-log.test.ts tests/packaged-win-identity.test.ts tests/packaged-smoke-workflow.test.ts` from `e2e/` — exit 0, `Test Files 9 passed | 1 skipped (10)`, `Tests 133 passed | 4 skipped (137)`. The skips are the Windows-only packaged cases; `specs/win.spec.ts` still loads cleanly with the new imports.

**Unverified from macOS:** the packaged Windows smoke cannot run here, so nothing below is confirmed end to end; it needs one Windows release run.

This change does **not** guarantee the stable lane goes green, and I would rather say so than imply otherwise. If the daemon on the cold-started process does report `onboardingCompleted: true` and the renderer still shows onboarding, the smoke now fails — correctly, because that is a real product bug. What it no longer does is hang for 45s on an unfalsifiable "did not reach main app shell" and force the lane onto `skip`. Either way the next Windows release run produces an attributed answer instead of a timeout.

One structurally suspicious thing I found but could not settle from macOS: in the `core` profile the app-shell check does not run against the seeded process at all. Lines 688-708 stop the app and relaunch it through the OS protocol handler (`Start-Process 'opendesign://…'`), and that cold start carries none of the test runner's environment — so no `OD_PACKAGED_CONFIG_PATH`, and `readRawPackagedConfig` falls back to the baked `resources/open-design-config.json`. Whether its baked `namespaceBaseRoot` still matches depends on the build-time `--dir` and the restored tools-pack cache, neither observable from here. It is a plausible reason this bites `core` specifically — `full` skips the cold-restart block — but I am not asserting it without a Windows run. The new direct seed assertion and the re-read at the app-shell step are what will distinguish it.

**Unrelated CI red:** `UI P0 (workspace-restoration)` failed on an earlier head — `app-restoration--P0-critic-…-poser-visible-on-that-route-chromium`, `locator.fill` timeout, red on retry too. It is a Playwright suite under `e2e/ui/` with no reference to any of the three files this PR touches, and five of the last twenty-five `ci` runs failed similarly today. Not touched, no timeout widened; a re-run should settle it.

**Left alone deliberately:**

- `packagedOnboardingExpression` (used by the `[P0]` smoke) overlaps with the new probe. Left unmerged: P0 asserts a different, larger field set and works today.
- `e2e/specs/mac.spec.ts` has no app-shell gate at all — it seeds onboarding and screenshots straight through. Not touched.





