### PR TITLE
feat(daemon): resume cursor-agent CLI session across chat turns

### DIFF
--- a/apps/daemon/src/agent-session-resume.ts
+++ b/apps/daemon/src/agent-session-resume.ts
@@ -290,6 +290,65 @@ export function isOpencodeResumeFailure(text: string): boolean {
   return OPENCODE_RESUME_FAILURE_PATTERNS.some((re) => re.test(text));
 }
 
+// Signature cursor-agent prints when `--resume <chatId>` targets a chat that
+// no longer exists in Cursor's local chat store. Cursor owns the chat id and
+// the daemon captures/replays it, so a stale handle must clear the row and
+// re-seed from the full transcript instead of retrying the dead `--resume`.
+const CURSOR_AGENT_RESUME_FAILURE_PATTERNS: RegExp[] = [
+  /chat not found/i,
+  /no chat found/i,
+  /chat .* not found/i,
+  /could not find chat/i,
+  /chat .* does not exist/i,
+];
+
+function hasCursorAgentResumeFailurePattern(text: string): boolean {
+  if (!text) return false;
+  return CURSOR_AGENT_RESUME_FAILURE_PATTERNS.some((re) => re.test(text));
+}
+
+function hasCursorAgentResumeFailureErrorEvent(stdout: string): boolean {
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('{')) continue;
+    let event: {
+      type?: unknown;
+      is_error?: unknown;
+      message?: unknown;
+      error?: unknown;
+      detail?: unknown;
+      errors?: unknown;
+    };
+    try {
+      event = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    const errorLike =
+      event.type === 'error' ||
+      event.is_error === true ||
+      (typeof event.error === 'string' && event.error.length > 0) ||
+      (Array.isArray(event.errors) && event.errors.length > 0);
+    if (!errorLike) continue;
+    const parts = [
+      event.message,
+      event.error,
+      event.detail,
+      ...(Array.isArray(event.errors) ? event.errors : []),
+    ]
+      .filter((value): value is string => typeof value === 'string' && value.length > 0)
+      .join('\n');
+    if (hasCursorAgentResumeFailurePattern(parts)) return true;
+  }
+  return false;
+}
+
+/** True when cursor-agent output indicates a resume target chat is missing. */
+export function isCursorAgentResumeFailure(stderr: string, stdout = ''): boolean {
+  if (hasCursorAgentResumeFailurePattern(stderr)) return true;
+  return stdout ? hasCursorAgentResumeFailureErrorEvent(stdout) : false;
+}
+
 /**
  * Per-agent dispatch for "the session/thread I asked to resume is gone".
  * Generalizes the resume-fallback so every `resumesSessionViaCli` adapter
@@ -309,6 +368,7 @@ export function isAgentResumeFailure(
 ): boolean {
   if (agentId === 'codex') return isCodexResumeFailure(stderr);
   if (agentId === 'opencode') return isOpencodeResumeFailure(stderr);
+  if (agentId === 'cursor-agent') return isCursorAgentResumeFailure(stderr, stdout);
   if (agentId === 'amr') {
     return (
       isAmrResumeFailure(stdout) ||

--- a/apps/daemon/src/runtimes/defs/cursor-agent.ts
+++ b/apps/daemon/src/runtimes/defs/cursor-agent.ts
@@ -94,11 +94,27 @@ export const cursorAgentDef = {
       if (options.model && options.model !== 'default') {
         args.push('--model', options.model);
       }
+      // Resume the CLI's own chat across turns so it keeps working memory and
+      // the daemon can skip resending the full transcript (resumesSessionViaCli
+      // gate in server.ts). cursor-agent has no `--session-id`: it mints its
+      // own id on the create turn (captured from the event stream and stored by
+      // the daemon), so we only pass `--resume <chatId>` when a stored id
+      // exists — never the daemon-minted `newSessionId`, which the CLI would
+      // silently treat as a fresh chat.
+      if (typeof runtimeContext.resumeSessionId === 'string' && runtimeContext.resumeSessionId) {
+        args.push('--resume', runtimeContext.resumeSessionId);
+      }
       return args;
     },
     promptViaStdin: true,
     streamFormat: 'json-event-stream',
     eventParser: 'cursor-agent',
+    // cursor-agent's CLI carries multi-turn memory via `--resume <chatId>`.
+    // The daemon captures the emitted `session_id` from status events and
+    // replays it next turn, which lets the prompt path skip the transcript on
+    // follow-ups.
+    resumesSessionViaCli: true,
+    capturesSessionIdFromStream: true,
     // `cursor-agent status` is a cheap, side-effect-free auth check. Declaring
     // it here is what makes detection surface an "auth required" badge for
     // Cursor Agent (the generalized probe only runs for adapters that opt in).

--- a/apps/daemon/src/runtimes/json-event-stream.ts
+++ b/apps/daemon/src/runtimes/json-event-stream.ts
@@ -6,6 +6,9 @@ type ParserKind = string;
 type ParserState = {
   cursorTextSoFar: string;
   cursorTurnStart: number;
+  // Last cursor-agent session id surfaced as a status event for capture-style
+  // resume persistence.
+  cursorSessionId: string | null;
   openCodeToolUses: Set<string>;
   codexToolUses: Set<string>;
   codexErrorEmitted: boolean;
@@ -606,13 +609,25 @@ function reconcileCursorTurnReplay(text: string, onEvent: StreamEventHandler, st
 function handleCursorEvent(obj: unknown, onEvent: StreamEventHandler, state: ParserState): boolean {
   if (!isRecord(obj)) return false;
 
+  const sessionId =
+    typeof obj.session_id === 'string' && obj.session_id.length > 0
+      ? obj.session_id
+      : null;
+
   if (obj.type === 'system' && obj.subtype === 'init') {
+    if (sessionId) state.cursorSessionId = sessionId;
     onEvent({
       type: 'status',
       label: 'initializing',
       model: typeof obj.model === 'string' ? obj.model : undefined,
+      sessionId,
     });
     return true;
+  }
+
+  if (sessionId && state.cursorSessionId !== sessionId) {
+    state.cursorSessionId = sessionId;
+    onEvent({ type: 'status', label: 'running', sessionId });
   }
 
   if (obj.type === 'assistant' && obj.message) {
@@ -875,6 +890,7 @@ export function createJsonEventStreamHandler(kind: ParserKind, onEvent: StreamEv
   const state: ParserState = {
     cursorTextSoFar: '',
     cursorTurnStart: 0,
+    cursorSessionId: null,
     openCodeToolUses: new Set<string>(),
     codexToolUses: new Set<string>(),
     codexErrorEmitted: false,

--- a/apps/daemon/tests/agent-session-resume.test.ts
+++ b/apps/daemon/tests/agent-session-resume.test.ts
@@ -20,6 +20,7 @@ import {
   isAmrResumeFailure,
   isClaudeResumeFailure,
   isCodexResumeFailure,
+  isCursorAgentResumeFailure,
   isOpencodeResumeFailure,
   persistCapturedAgentSession,
   resolveAgentResumeContext,
@@ -454,6 +455,41 @@ describe('isOpencodeResumeFailure', () => {
   });
 });
 
+describe('isCursorAgentResumeFailure', () => {
+  it('matches cursor-agent stale chat errors from stderr', () => {
+    expect(isCursorAgentResumeFailure('Error: chat not found')).toBe(true);
+    expect(isCursorAgentResumeFailure('Chat cursor-chat-123 not found')).toBe(true);
+    expect(isCursorAgentResumeFailure('could not find chat cursor-chat-123')).toBe(true);
+  });
+
+  it('matches structured cursor-agent error events from stdout', () => {
+    expect(
+      isCursorAgentResumeFailure('', JSON.stringify({
+        type: 'error',
+        message: 'Chat cursor-chat-123 not found',
+      })),
+    ).toBe(true);
+    expect(
+      isCursorAgentResumeFailure('', JSON.stringify({
+        type: 'result',
+        is_error: true,
+        errors: ['chat not found'],
+      })),
+    ).toBe(true);
+  });
+
+  it('ignores unrelated cursor-agent errors and assistant output', () => {
+    expect(isCursorAgentResumeFailure('rate limit exceeded')).toBe(false);
+    expect(
+      isCursorAgentResumeFailure('', JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'The phrase chat not found appears in docs.' }] },
+      })),
+    ).toBe(false);
+    expect(isCursorAgentResumeFailure('')).toBe(false);
+  });
+});
+
 describe('isAmrResumeFailure', () => {
   it('matches vela\'s structured resume_failed ACP error on stdout', () => {
     expect(
@@ -525,6 +561,15 @@ describe('isAgentResumeFailure dispatch', () => {
     ).toBe(false);
   });
 
+  it('routes cursor-agent to the chat-not-found detector', () => {
+    expect(
+      isAgentResumeFailure('cursor-agent', 'Error: chat not found', ''),
+    ).toBe(true);
+    expect(
+      isAgentResumeFailure('cursor-agent', 'No conversation found with session ID: abc', ''),
+    ).toBe(false);
+  });
+
   it('does NOT treat a generic phrase in successful assistant stdout as a resume miss (#4629 nettee)', () => {
     // A turn that SUCCEEDS but whose model output literally says "session not
     // found" must not be failed + have its session cleared — the phrase is only
@@ -534,6 +579,12 @@ describe('isAgentResumeFailure dispatch', () => {
     ).toBe(false);
     expect(
       isAgentResumeFailure('codex', '', 'The logs mention "no rollout found for thread id" as an example.'),
+    ).toBe(false);
+    expect(
+      isAgentResumeFailure('cursor-agent', '', JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'The old chat was not found.' }] },
+      })),
     ).toBe(false);
   });
 

--- a/apps/daemon/tests/runtimes/agent-args.test.ts
+++ b/apps/daemon/tests/runtimes/agent-args.test.ts
@@ -67,6 +67,35 @@ test('cursor-agent passes --trust once the --help probe detects it', () => {
   }
 });
 
+test('cursor-agent resumes with the captured CLI chat id', () => {
+  agentCapabilities.delete('cursor-agent');
+  const args = cursorAgent.buildArgs(
+    '',
+    [],
+    [],
+    {},
+    {
+      cwd: '/tmp/od-project',
+      resumeSessionId: 'cursor-chat-123',
+      newSessionId: 'daemon-minted-id',
+    },
+  );
+
+  assert.deepEqual(args, [
+    '--print',
+    '--output-format',
+    'stream-json',
+    '--stream-partial-output',
+    '--force',
+    '--workspace',
+    '/tmp/od-project',
+    '--resume',
+    'cursor-chat-123',
+  ]);
+  assert.equal(cursorAgent.resumesSessionViaCli, true);
+  assert.equal(cursorAgent.capturesSessionIdFromStream, true);
+});
+
 test('cursor-agent declares the --trust capability probe (issue #4461 root cause)', () => {
   assert.deepEqual(cursorAgent.helpArgs, ['--help']);
   assert.equal(cursorAgent.capabilityFlags?.['--trust'], 'trust');

--- a/apps/daemon/tests/runtimes/json-event-stream.test.ts
+++ b/apps/daemon/tests/runtimes/json-event-stream.test.ts
@@ -692,7 +692,13 @@ test('cursor stream emits partial text once and usage events', () => {
   const { events, handler } = collectEvents('cursor-agent');
 
   handler.feed(
-    JSON.stringify({ type: 'system', subtype: 'init', model: 'GPT-5 Mini' }) + '\n' +
+    JSON.stringify({
+      type: 'system',
+      subtype: 'init',
+      model: 'GPT-5 Mini',
+      session_id: 'cursor-chat-1',
+    }) +
+    '\n' +
     JSON.stringify({
       type: 'assistant',
       timestamp_ms: 1,
@@ -719,7 +725,12 @@ test('cursor stream emits partial text once and usage events', () => {
   );
 
   assert.deepEqual(events, [
-    { type: 'status', label: 'initializing', model: 'GPT-5 Mini' },
+    {
+      type: 'status',
+      label: 'initializing',
+      model: 'GPT-5 Mini',
+      sessionId: 'cursor-chat-1',
+    },
     { type: 'text_delta', delta: 'OD' },
     { type: 'text_delta', delta: '_OK' },
     {
@@ -727,6 +738,33 @@ test('cursor stream emits partial text once and usage events', () => {
       usage: { input_tokens: 5, output_tokens: 2, cached_read_tokens: 1, cached_write_tokens: 0 },
       durationMs: 120,
     },
+  ]);
+});
+
+test('cursor stream surfaces a late session id as a status sessionId', () => {
+  const { events, handler } = collectEvents('cursor-agent');
+
+  handler.feed(
+    JSON.stringify({
+      type: 'assistant',
+      session_id: 'cursor-chat-late',
+      timestamp_ms: 1,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] },
+    }) +
+    '\n' +
+    JSON.stringify({
+      type: 'assistant',
+      session_id: 'cursor-chat-late',
+      timestamp_ms: 2,
+      message: { role: 'assistant', content: [{ type: 'text', text: ' again' }] },
+    }) +
+    '\n',
+  );
+
+  assert.deepEqual(events, [
+    { type: 'status', label: 'running', sessionId: 'cursor-chat-late' },
+    { type: 'text_delta', delta: 'hello' },
+    { type: 'text_delta', delta: ' again' },
   ]);
 });
 


### PR DESCRIPTION
Closes #4790
Refs #744

## Why

This picks up the stale draft cursor-agent session-resume work from #4790 and rebases it onto current `main`. The original PR branch is on a contributor fork that this account cannot push to, so this ready PR carries the finished change from an updateable branch.

cursor-agent can resume a prior chat with `--resume <chatId>`, but it mints that chat id itself and emits it as `session_id` in the stream. Persisting the daemon-minted `newSessionId` would make follow-up turns look resumable while cursor-agent actually starts a fresh chat, risking silent context loss.

## What users will see

cursor-agent follow-up turns in the same conversation can continue the CLI's captured chat session instead of re-sending the full transcript every turn. First turns and turns without a captured cursor session id still seed from the full transcript.

## Surface area

- [ ] **UI** - new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** - new or changed
- [ ] **CLI / env var** - new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** - new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** - new entry under `skills/`, `design-systems/`, `design-templates`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** - added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** - adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` -> Code style)
- [x] **Default behavior change** - changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** - internal refactor, docs, tests, or translation update only

## Screenshots

N/A - daemon runtime behavior only.

## Bug fix verification

N/A - feature/performance follow-up to the cursor-agent resume work from #4790.

## Validation

- `pnpm exec vitest run -c vitest.config.ts tests/runtimes/json-event-stream.test.ts tests/runtimes/agent-args.test.ts tests/chat-run-artifact-quiet-period.test.ts tests/agent-session-resume.test.ts tests/native-session-recovery.test.ts tests/run-diagnostics.test.ts tests/runtimes/runs.test.ts` from `apps/daemon`: 7 files / 240 tests passed
- `pnpm --filter @open-design/daemon typecheck`: passed