### PR TITLE
test(e2e): red-spec for RTL chrome row mirroring (#5549)

### DIFF
--- a/apps/web/src/styles/shell.css
+++ b/apps/web/src/styles/shell.css
@@ -73,16 +73,21 @@
   z-index: 120;
 }
 .workspace-tabs-chrome .workspace-tabs-traffic {
-  margin-right: var(--app-chrome-traffic-margin);
+  /* Logical property: in LTR `margin-inline-end` is the right edge (traffic
+     sits on the left, the margin opens the gap toward the tab strip); in RTL
+     it flips to the left edge, so traffic mirrors to the right side of the
+     chrome row. See #5549. */
+  margin-inline-end: var(--app-chrome-traffic-margin);
 }
 .workspace-tabs-new-btn {
   width: 30px;
   height: 30px;
-  /* Always pinned to the strip's right edge: auto margin absorbs the free
-     space when tabs don't fill the row; the sticky rule below takes over
-     once the strip overflows and scrolls. */
-  margin-left: auto;
-  margin-right: 0;
+  /* Always pinned to the strip's inline-end edge: auto margin absorbs the
+     free space when tabs don't fill the row; the sticky rule below takes
+     over once the strip overflows and scrolls. Using logical properties so
+     the button mirrors to the visual left under `dir=rtl`. See #5549. */
+  margin-inline-start: auto;
+  margin-inline-end: 0;
   padding: 0;
   border: 0;
   border-radius: var(--radius-sm);
@@ -97,7 +102,7 @@
 }
 .workspace-tabs-strip.is-overflowing .workspace-tabs-new-btn {
   position: sticky;
-  right: 0;
+  inset-inline-end: 0;
   z-index: 2;
   background: var(--bg-panel);
   box-shadow: -8px 0 10px -9px color-mix(in srgb, var(--text) 30%, transparent);
@@ -247,7 +252,10 @@ html.od-radial-open .workspace-shell {
   display: flex;
   align-items: end;
   gap: 2px;
-  padding-left: var(--workspace-tabs-edge-inset);
+  /* Logical property: in LTR this is the left edge (tabs start from the
+     left); in RTL it flips to the right edge so the tab strip's leading
+     inset mirrors with the chrome row. See #5549. */
+  padding-inline-start: var(--workspace-tabs-edge-inset);
   position: relative;
   z-index: 1;
   /* Horizontal scroll inside the strip — tabs keep their natural width

--- a/apps/web/tests/styles/workspace-tabs-chrome.test.ts
+++ b/apps/web/tests/styles/workspace-tabs-chrome.test.ts
@@ -37,7 +37,9 @@ describe('workspace tabs chrome styles', () => {
     const projectStrip = cssDeclarations(routinesCss, '.workspace-shell .workspace-tabs-strip');
 
     expect(ruleValue(chrome, 'padding')).toBe('0 10px 0 8px');
-    expect(ruleValue(traffic, 'margin-right')).toBe('var(--app-chrome-traffic-margin)');
+    // Logical property (margin-inline-end) so the traffic/window-controls
+    // region mirrors under dir=rtl. See #5549.
+    expect(ruleValue(traffic, 'margin-inline-end')).toBe('var(--app-chrome-traffic-margin)');
     expect(ruleValue(projectChrome, 'padding')).toBe('0 8px 0 0');
     expect(ruleValue(projectStrip, 'align-items')).toBe('center');
   });

--- a/e2e/ui/rtl-chrome-mirroring.test.ts
+++ b/e2e/ui/rtl-chrome-mirroring.test.ts
@@ -1,0 +1,138 @@
+import { expect, test } from '@/playwright/suite';
+import { openNewProjectModal } from '@/playwright/rail';
+import type { Page } from '@playwright/test';
+import { applyStandardMocks } from '@/playwright/mock-factory';
+
+// Red spec for issue #5549: the workspace chrome row (tab strip + new-tab
+// button + traffic/window controls) must mirror under `dir=rtl` (Arabic,
+// Persian). On `main` the chrome is laid out with physical `left`/`right`
+// rules (`margin-left: auto`, `margin-right: var(--app-chrome-traffic-margin)`,
+// `padding-left: var(--workspace-tabs-edge-inset)`) that do not flip under
+// RTL, so the new-tab button stays pinned to the visual right and the window
+// controls / traffic stay on the visual left — the opposite of the mirrored
+// layout an RTL user expects. This spec goes red on `main` and green once the
+// chrome row adopts logical properties (`margin-inline-start`, `padding-
+// inline-start`) or `[dir='rtl']` overrides for the affected rules.
+//
+// Scope per the agreement on #5549: chrome-mirroring only (top nav / tab
+// strip / new-tab button / traffic). Workspace toolbar + empty-state alignment
+// are tracked as a follow-up.
+
+test.beforeEach(async ({ page }) => {
+  await applyStandardMocks(page);
+});
+
+async function gotoEntryHome(page: Page) {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.getByText('Loading Open Design…').waitFor({ state: 'detached', timeout: 10_000 }).catch(() => {});
+  const privacyDialog = page.getByRole('dialog').filter({ hasText: 'Help us improve Open Design' });
+  if (await privacyDialog.isVisible()) {
+    await privacyDialog.getByRole('button', { name: /I get it|not now|got it|don't share/i }).click();
+    await expect(privacyDialog).toHaveCount(0);
+  }
+  await expect(page.getByTestId('home-hero')).toBeVisible();
+}
+
+async function createPrototypeProject(page: Page, projectName: string) {
+  await openNewProjectModal(page);
+  await page.getByTestId('new-project-tab-prototype').click();
+  await page.getByTestId('new-project-name').fill(projectName);
+  await page.getByTestId('create-project').click();
+}
+
+async function expectWorkspaceReady(page: Page) {
+  await expect(page).toHaveURL(/\/projects\//);
+  await expect(page.getByText('Loading Open Design…')).toHaveCount(0);
+  await expect(page.getByTestId('chat-composer')).toBeVisible();
+}
+
+async function switchLocaleToArabic(page: Page) {
+  await page.locator('.avatar-agent-trigger').click();
+  await page.locator('.avatar-item--execution-settings').click();
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await dialog.locator('.settings-nav-item', { hasText: 'General' }).click();
+  await dialog.locator('.settings-general-select select').selectOption('ar');
+  await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+  await page.keyboard.press('Escape');
+  await expect(dialog).toBeHidden();
+}
+
+test('[P1] RTL: workspace chrome row mirrors — new-tab button lands on the visual left, traffic on the visual right', async ({ page }) => {
+  await gotoEntryHome(page);
+  await createPrototypeProject(page, 'RTL chrome mirroring red spec');
+  await expectWorkspaceReady(page);
+
+  // Switch to Arabic through the in-project settings UI. Seeding the locale
+  // via localStorage before navigation is unreliable here (the initial-locale
+  // detection can transiently lose a persisted manual locale during the hard
+  // navigation that project creation performs). setLocale from the settings
+  // dialog applies synchronously. Mirrors split-resize-scrollbar-hitbox.test.ts.
+  await switchLocaleToArabic(page);
+  await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+
+  const chrome = page.locator('.workspace-tabs-chrome').first();
+  await expect(chrome).toBeVisible();
+  const chromeBox = await chrome.boundingBox();
+  expect(chromeBox).not.toBeNull();
+
+  // The new-tab button uses `margin-left: auto` on main, which pins it to the
+  // physical right edge regardless of `dir`. Under RTL it must land on the
+  // visual LEFT (i.e. the chrome's left edge). On `main` it stays on the right
+  // — that's the red.
+  const newBtn = chrome.locator('.workspace-tabs-new-btn').first();
+  await expect(newBtn).toBeVisible();
+  const newBtnBox = await newBtn.boundingBox();
+  expect(newBtnBox).not.toBeNull();
+
+  const chromeCenterX = chromeBox!.x + chromeBox!.width / 2;
+  const newBtnCenterX = newBtnBox!.x + newBtnBox!.width / 2;
+
+  // Green condition: under dir=rtl, the new-tab button must sit in the visual
+  // LEFT half of the chrome row (mirrored from its LTR right-edge pin).
+  expect(
+    newBtnCenterX,
+    `expected new-tab button on the visual LEFT under dir=rtl (mirrored), got center x=${newBtnCenterX} vs chrome center x=${chromeCenterX}`,
+  ).toBeLessThan(chromeCenterX);
+
+  // The traffic / window-controls region uses `margin-right: var(--app-chrome-
+  // traffic-margin)` on main, which keeps it on the visual LEFT even under
+  // RTL. Under RTL it must sit in the visual RIGHT half (mirrored).
+  const traffic = chrome.locator('.workspace-tabs-traffic').first();
+  if (await traffic.isVisible().catch(() => false)) {
+    const trafficBox = await traffic.boundingBox();
+    expect(trafficBox).not.toBeNull();
+    const trafficCenterX = trafficBox!.x + trafficBox!.width / 2;
+    expect(
+      trafficCenterX,
+      `expected traffic/window-controls on the visual RIGHT under dir=rtl (mirrored), got center x=${trafficCenterX} vs chrome center x=${chromeCenterX}`,
+    ).toBeGreaterThan(chromeCenterX);
+  }
+});
+
+test('[P1] LTR control: workspace chrome row keeps new-tab on the right, traffic on the left', async ({ page }) => {
+  // Control case — pins the LTR behaviour so the RTL assertion can't be
+  // satisfied by a symmetric layout that happens to place both elements on
+  // the same side. Guards against the fix over-mirroring.
+  await gotoEntryHome(page);
+  await createPrototypeProject(page, 'LTR chrome control');
+  await expectWorkspaceReady(page);
+  await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+
+  const chrome = page.locator('.workspace-tabs-chrome').first();
+  await expect(chrome).toBeVisible();
+  const chromeBox = await chrome.boundingBox();
+  expect(chromeBox).not.toBeNull();
+
+  const newBtn = chrome.locator('.workspace-tabs-new-btn').first();
+  await expect(newBtn).toBeVisible();
+  const newBtnBox = await newBtn.boundingBox();
+  expect(newBtnBox).not.toBeNull();
+
+  const chromeCenterX = chromeBox!.x + chromeBox!.width / 2;
+  const newBtnCenterX = newBtnBox!.x + newBtnBox!.width / 2;
+  expect(
+    newBtnCenterX,
+    `expected new-tab button on the visual RIGHT under dir=ltr (control), got center x=${newBtnCenterX} vs chrome center x=${chromeCenterX}`,
+  ).toBeGreaterThan(chromeCenterX);
+});


### PR DESCRIPTION
## Why

Closes #5549. Under `dir=rtl` (Arabic / Persian) the workspace chrome row — tab strip, new-tab button, traffic / window controls — does not mirror. On `main` these surfaces are laid out with physical `left`/`right` rules:

- `.workspace-tabs-new-btn` uses `margin-left: auto` (pinned to the physical right edge regardless of `dir`)
- `.workspace-tabs-traffic` uses `margin-right: var(--app-chrome-traffic-margin)` (kept on the physical left)
- `.workspace-tabs-strip` uses `padding-left: var(--workspace-tabs-edge-inset)`

so an RTL user gets the LTR chrome layout: new-tab on the visual right, window controls on the visual left — the opposite of what a mirrored chrome should look like.

## What users will see

**Before (red, this PR's spec on `main`):** new-tab button stays pinned to the visual right under `dir=rtl`; window controls / traffic stay on the visual left.

**After (green, once the fix is layered into this PR):** new-tab button mirrors to the visual left; window controls mirror to the visual right — matching the rest of the RTL shell.

## Reproduced-vs-not-reproduced breakdown

Per the agreement on #5549, calling out which bullets from the original issue reproduced in my run and which did not:

**Reproduced on `main` under `dir=rtl` (in scope for this PR):**
- Top navigation row mixes LTR/RTL ordering — **reproduced.** The chrome row (`.workspace-tabs-chrome`) keeps the new-tab button on the visual right and the traffic/window controls on the visual left instead of mirroring.
- Tab strip edge inset (`padding-left`) does not flip — **reproduced.**

**Not reproduced in my run (out of scope; follow-up per #5549 agreement):**
- Workspace toolbar alignment — not covered by this slice; tracked as follow-up.
- Empty-state card alignment — not covered by this slice; tracked as follow-up.

## What this PR contains

**Red spec only** (this commit). Playwright test `e2e/ui/rtl-chrome-mirroring.test.ts`:

- `[P1] RTL: workspace chrome row mirrors` — asserts that under `dir=rtl` the `.workspace-tabs-new-btn` lands in the visual LEFT half of the chrome row (mirrored from its LTR right-edge pin) and the `.workspace-tabs-traffic` lands in the visual RIGHT half. Goes **red on `main`** today.
- `[P1] LTR control: workspace chrome row keeps new-tab on the right, traffic on the left` — paired control that pins the LTR behaviour so the RTL assertion can't be satisfied by a symmetric layout that happens to place both elements on the same side.

Setup mirrors `e2e/ui/split-resize-scrollbar-hitbox.test.ts`: `switchLocaleToArabic` through the in-project settings dialog (localStorage seeding is unreliable across the hard navigation project creation performs), then assert against `html[dir=rtl]`.

## Next (before marking ready for review)

Layer the fix on top of the red spec in this same PR — migrate the physical `left`/`right` rules on the chrome row to logical properties (`margin-inline-start`, `padding-inline-start`) or add `[dir='rtl']` overrides, then confirm the spec flips green and the LTR control stays green. Draft until that lands.

## Surface area checklist

- [x] UI — `apps/web/src/styles/shell.css` (fix, upcoming commit)
- [x] Tests — `e2e/ui/rtl-chrome-mirroring.test.ts` (this commit)
- [ ] CLI — N/A (CSS/test-only)
- [ ] i18n keys — N/A
- [ ] Skills / design-systems / design-templates / craft — N/A
- [ ] Env vars — N/A
- [ ] Root `package.json` deps — N/A