### PR TITLE
fix(daemon): forward images for BYOK OpenCode multimodal models

### DIFF
--- a/apps/daemon/src/runtimes/byok-opencode.ts
+++ b/apps/daemon/src/runtimes/byok-opencode.ts
@@ -79,6 +79,18 @@ export function buildOpenCodeByokProviderConfig(
         models: {
           [rawModel]: {
             name: rawModel,
+            // OpenCode treats custom provider models as text-only unless the
+            // entry declares image input. BYOK users pick models for design
+            // work that routinely includes screenshots / pasted images, so
+            // advertise multimodal input here; without it OpenCode rewrites
+            // image tool results to "this model does not support image input"
+            // even when the upstream endpoint accepts image_url payloads
+            // (issue #6482).
+            attachment: true,
+            modalities: {
+              input: ['text', 'image'],
+              output: ['text'],
+            },
             limit: {
               context: DEFAULT_CONTEXT_TOKEN_LIMIT,
               output: DEFAULT_OUTPUT_TOKEN_LIMIT,

--- a/apps/daemon/src/runtimes/chat-prompt-inputs.ts
+++ b/apps/daemon/src/runtimes/chat-prompt-inputs.ts
@@ -848,6 +848,97 @@ export function resolveSafeProjectAttachments(
   return out;
 }
 
+/**
+ * Image extensions accepted for CLI file-path image handoff (`-f` / ACP
+ * resources). Matches OpenCode attachment formats and the pi image allowlist.
+ */
+export const CHAT_IMAGE_ATTACHMENT_EXTENSIONS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+]);
+
+/**
+ * Resolve project-relative chat `attachments` that are image files into
+ * absolute paths under `cwd`.
+ *
+ * The web UI uploads pasted/dropped images into the project and sends only
+ * `attachments` (project-relative paths) on `/api/runs` — not `imagePaths`
+ * (which is the separate upload-dir channel). Adapters that load pixels via
+ * absolute file flags (e.g. byok-opencode `-f`) need this handoff, or the
+ * model never sees the uploaded image (#6482 review).
+ */
+export function resolveAbsoluteProjectImageAttachments(
+  cwd: string | null | undefined,
+  attachments: readonly string[] | null | undefined,
+  opts: {
+    pathImpl?: typeof path;
+    existsSync?: (path: string) => boolean;
+    statSync?: (path: string) => { isFile(): boolean; size?: number };
+    maxBytes?: number;
+  } = {},
+): string[] {
+  if (!cwd || !Array.isArray(attachments) || attachments.length === 0) return [];
+  const pathImpl = opts.pathImpl ?? path;
+  const existsSync = opts.existsSync ?? fs.existsSync;
+  const statSync = opts.statSync ?? fs.statSync;
+  const maxBytes = Number.isFinite(opts.maxBytes)
+    ? Number(opts.maxBytes)
+    : MAX_CHAT_IMAGE_BYTES;
+  const root = pathImpl.resolve(cwd);
+  const out: string[] = [];
+  const seen = new Set<string>();
+
+  for (const attachment of attachments) {
+    if (typeof attachment !== 'string' || attachment.length === 0) continue;
+    let abs: string;
+    try {
+      abs = pathImpl.resolve(root, attachment);
+    } catch {
+      continue;
+    }
+    const relativePath = pathImpl.relative(root, abs);
+    const withinRoot =
+      relativePath === '' ||
+      (relativePath.length > 0 &&
+        !relativePath.startsWith('..') &&
+        !pathImpl.isAbsolute(relativePath));
+    if (!withinRoot || !existsSync(abs)) continue;
+    const ext = pathImpl.extname(abs).toLowerCase();
+    if (!CHAT_IMAGE_ATTACHMENT_EXTENSIONS.has(ext)) continue;
+    try {
+      const st = statSync(abs);
+      if (!st.isFile()) continue;
+      if (typeof st.size === 'number' && st.size > maxBytes) continue;
+    } catch {
+      continue;
+    }
+    if (seen.has(abs)) continue;
+    seen.add(abs);
+    out.push(abs);
+  }
+
+  return out;
+}
+
+/** Stable de-dupe merge of upload-dir imagePaths and project image attachments. */
+export function mergePromptImagePaths(
+  imagePaths: readonly string[] | null | undefined,
+  projectImageAbsPaths: readonly string[] | null | undefined,
+): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const p of [...(imagePaths || []), ...(projectImageAbsPaths || [])]) {
+    if (typeof p !== 'string' || p.length === 0) continue;
+    if (seen.has(p)) continue;
+    seen.add(p);
+    out.push(p);
+  }
+  return out;
+}
+
 export function formatProjectAttachmentHint(attachments: readonly string[] | null | undefined) {
   if (!Array.isArray(attachments) || attachments.length === 0) return '';
   return [

--- a/apps/daemon/src/runtimes/defs/byok-opencode.ts
+++ b/apps/daemon/src/runtimes/defs/byok-opencode.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import { opencodeByokModelId } from '../byok-opencode.js';
 import {
   OPENCODE_PERMISSION_CAPABILITY,
@@ -14,7 +16,7 @@ export const byokOpenCodeAgentDef = {
   versionArgs: ['--version'],
   ...OPENCODE_PERMISSION_CAPABILITY,
   fallbackModels: [DEFAULT_MODEL_OPTION],
-  buildArgs: (_prompt, _imagePaths, _extra, options = {}, runtimeContext = {}) => {
+  buildArgs: (_prompt, imagePaths, _extra, options = {}, runtimeContext = {}) => {
     const args = ['run', '--format', 'json'];
     if (typeof runtimeContext.cwd === 'string' && runtimeContext.cwd.length > 0) {
       // OpenCode promotes nested directories to the enclosing Git worktree
@@ -27,6 +29,17 @@ export const byokOpenCodeAgentDef = {
     appendOpenCodePermissionBypass(args, 'byok-opencode');
     const model = opencodeByokModelId(options.model);
     if (model) args.push('-m', model);
+    // Chat runs resolve uploads to absolute paths under the upload dir and
+    // pass them here. OpenCode accepts attachments via repeated `-f`/`--file`
+    // flags (see `opencode run --help`). The prompt itself stays on stdin —
+    // never as a trailing positional after `-f` — because OpenCode's yargs
+    // array option would otherwise treat the message as another file path
+    // (issue #6482; also documented in memory-llm OpenCode extraction).
+    for (const imagePath of imagePaths || []) {
+      if (typeof imagePath === 'string' && path.isAbsolute(imagePath)) {
+        args.push('-f', imagePath);
+      }
+    }
     return args;
   },
   promptViaStdin: true,

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -99,6 +99,8 @@ import {
   resolveEffectiveDesignSystemSelection,
   resolveGrantedCodexImagegenOverride,
   resolveResearchCommandContract,
+  mergePromptImagePaths,
+  resolveAbsoluteProjectImageAttachments,
   resolveSafeProjectAttachments,
   resolveSafePromptImagePaths,
   selectPromptImagePaths,
@@ -155,6 +157,8 @@ export {
   resolveEffectiveDesignSystemSelection,
   resolveGrantedCodexImagegenOverride,
   resolveResearchCommandContract,
+  mergePromptImagePaths,
+  resolveAbsoluteProjectImageAttachments,
   resolveSafeProjectAttachments,
   resolveSafePromptImagePaths,
   selectPromptImagePaths,
@@ -9049,6 +9053,16 @@ export async function startServer({
       : [];
     run.projectAttachmentPaths = safeAttachments;
 
+    // Web chat uploads images into the project and sends them only as
+    // `attachments` (relative paths), not `imagePaths` (upload-dir channel).
+    // Adapters that need absolute file handoff (byok-opencode `-f`, etc.)
+    // must receive those image attachments here (#6482).
+    const projectImageAbsPaths = resolveAbsoluteProjectImageAttachments(
+      cwd,
+      safeAttachments,
+    );
+    const agentImagePaths = mergePromptImagePaths(safeImages, projectImageAbsPaths);
+
     // Local code agents don't accept a separate "system" channel the way the
     // Messages API does — we fold the skill + design-system prompt into the
     // user message. The <artifact> wrapping instruction comes from
@@ -10811,7 +10825,7 @@ export async function startServer({
     try {
       args = def.buildArgs(
         composed,
-        safeImages,
+        agentImagePaths,
         extraAllowedDirs,
         agentOptions,
         {

--- a/apps/daemon/tests/chat-attachments.test.ts
+++ b/apps/daemon/tests/chat-attachments.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 import {
   formatDesignFilesWorkspaceHint,
   formatProjectAttachmentHint,
+  mergePromptImagePaths,
+  resolveAbsoluteProjectImageAttachments,
   resolveSafeProjectAttachments,
 } from '../src/server.js';
 
@@ -43,6 +45,57 @@ describe('resolveSafeProjectAttachments', () => {
         'When the user says "first attachment", "second file", or similar, map those references to the numbered list above.',
       ].join('\n'),
     );
+  });
+});
+
+describe('resolveAbsoluteProjectImageAttachments (#6482 web attachments path)', () => {
+  it('returns absolute paths for image attachments under cwd and drops non-images / escapes', () => {
+    const root = '/projects/demo';
+    const files = new Map<string, number>([
+      ['/projects/demo/shot.png', 12_000],
+      ['/projects/demo/assets/mark.JPG', 8_000],
+      ['/projects/demo/notes.md', 400],
+      ['/projects/demo/huge.png', 2_000_000],
+    ]);
+
+    const abs = resolveAbsoluteProjectImageAttachments(
+      root,
+      [
+        'shot.png',
+        'assets/mark.JPG',
+        'notes.md',
+        'huge.png',
+        '../escape.png',
+        'missing.png',
+      ],
+      {
+        pathImpl: path.posix,
+        existsSync: (target) => files.has(target),
+        statSync: (target) => ({
+          isFile: () => true,
+          size: files.get(target) ?? 0,
+        }),
+        maxBytes: 1_024_000,
+      },
+    );
+
+    expect(abs).toEqual([
+      '/projects/demo/shot.png',
+      '/projects/demo/assets/mark.JPG',
+    ]);
+  });
+
+  it('mergePromptImagePaths de-dupes upload-dir and project image paths', () => {
+    expect(
+      mergePromptImagePaths(
+        ['/tmp/od-uploads/a.png', '/projects/demo/shot.png'],
+        ['/projects/demo/shot.png', '/projects/demo/b.webp'],
+      ),
+    ).toEqual([
+      '/tmp/od-uploads/a.png',
+      '/projects/demo/shot.png',
+      '/projects/demo/b.webp',
+    ]);
   });
 });
 

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -557,6 +557,93 @@ process.stdin.on('end', () => {
     );
   });
 
+  // Regression for #6482 review: web chat sends uploaded images as project
+  // `attachments` (relative paths), not `imagePaths`. The daemon must resolve
+  // those image attachments to absolute paths and pass them as OpenCode `-f`.
+  it('forwards project image attachments as OpenCode -f flags on the BYOK path', async () => {
+    if (!process.env.OD_DATA_DIR) {
+      throw new Error('OD_DATA_DIR is required for BYOK OpenCode attachment tests');
+    }
+
+    const projectId = `proj-${randomUUID()}`;
+    const markerDir = await fsp.mkdtemp(join(tmpdir(), 'od-byok-opencode-attach-'));
+    tempDirs.push(markerDir);
+    const argsFile = join(markerDir, 'args.json');
+
+    const createProjectResponse = await fetch(`${baseUrl}/api/projects`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: projectId, name: 'BYOK OpenCode attachment fixture' }),
+    });
+    expect(createProjectResponse.ok).toBe(true);
+
+    // Match the live UI path: image lives in the project, request carries only
+    // the relative path under `attachments`.
+    const projectDir = resolve(process.env.OD_DATA_DIR, 'projects', projectId);
+    await fsp.mkdir(projectDir, { recursive: true });
+    // Minimal valid 1×1 PNG.
+    const png = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+      'base64',
+    );
+    const relImage = 'uploads/shot.png';
+    await fsp.mkdir(join(projectDir, 'uploads'), { recursive: true });
+    await fsp.writeFile(join(projectDir, relImage), png);
+    const absImage = resolve(projectDir, relImage);
+
+    await withFakeAgent(
+      'opencode',
+      `
+const fs = require('node:fs');
+process.stdin.resume();
+process.stdin.on('end', () => {
+  fs.writeFileSync(${JSON.stringify(argsFile)}, JSON.stringify(process.argv.slice(2)));
+  console.log(JSON.stringify({ type: 'step_start' }));
+  console.log(JSON.stringify({ type: 'text', part: { text: 'byok-attach-ok' } }));
+  console.log(JSON.stringify({ type: 'step_finish', part: { tokens: { input: 1, output: 1 } } }));
+  process.exit(0);
+});
+`,
+      async () => {
+        const response = await fetch(`${baseUrl}/api/chat`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            agentId: 'byok-opencode',
+            projectId,
+            message: 'What is in this screenshot?',
+            // No imagePaths — only the web attachment shape.
+            attachments: [relImage],
+            model: 'gpt-5.6-terra',
+            byokProvider: {
+              protocol: 'openai',
+              apiKey: 'sk-test-byok',
+              baseUrl: 'https://api.openai.com/v1',
+              model: 'gpt-5.6-terra',
+              requiresApiKey: true,
+            },
+          }),
+        });
+        const body = await response.text();
+        expect(response.ok).toBe(true);
+        expect(body).toContain('byok-attach-ok');
+
+        const args = JSON.parse(await fsp.readFile(argsFile, 'utf8')) as string[];
+        expect(args).toEqual([
+          'run',
+          '--format',
+          'json',
+          '--dir',
+          expect.stringContaining(projectId),
+          '-m',
+          'open-design-byok/gpt-5.6-terra',
+          '-f',
+          absImage,
+        ]);
+      },
+    );
+  });
+
   it('passes keyless BYOK provider config without auth fields to OpenCode', async () => {
     if (!process.env.OD_DATA_DIR) {
       throw new Error('OD_DATA_DIR is required for BYOK OpenCode config tests');

--- a/apps/daemon/tests/chat-route.test.ts
+++ b/apps/daemon/tests/chat-route.test.ts
@@ -541,6 +541,12 @@ process.stdin.on('end', () => {
         });
         expect(provider?.models?.['deepseek-v4-flash']).toEqual({
           name: 'deepseek-v4-flash',
+          // Multimodal metadata so OpenCode accepts image attachments (#6482).
+          attachment: true,
+          modalities: {
+            input: ['text', 'image'],
+            output: ['text'],
+          },
           limit: {
             context: 128_000,
             output: 16_384,

--- a/apps/daemon/tests/runtimes/byok-opencode.test.ts
+++ b/apps/daemon/tests/runtimes/byok-opencode.test.ts
@@ -37,6 +37,45 @@ describe('byok-opencode runtime config', () => {
     }
   });
 
+  // Regression for #6482: OpenCode only loads image attachments when they are
+  // passed as absolute `-f`/`--file` paths. Relative tokens and empty values
+  // must not be forwarded (and must not be treated as yargs array greed).
+  it('forwards absolute image attachments as repeated -f flags after model selection', () => {
+    agentCapabilities.delete('byok-opencode');
+    const absA = '/tmp/od-uploads/shot-a.png';
+    const absB = '/var/folders/xx/od-uploads/shot-b.jpg';
+    expect(
+      byokOpenCodeAgentDef.buildArgs(
+        '',
+        [absA, 'relative/skip.png', '', absB, null as unknown as string],
+        [],
+        { model: 'gpt-5.6-terra' },
+        { cwd: '/projects/demo' },
+      ),
+    ).toEqual([
+      'run',
+      '--format',
+      'json',
+      '--dir',
+      '/projects/demo',
+      '-m',
+      'open-design-byok/gpt-5.6-terra',
+      '-f',
+      absA,
+      '-f',
+      absB,
+    ]);
+  });
+
+  it('omits -f when no absolute image paths are supplied', () => {
+    agentCapabilities.delete('byok-opencode');
+    expect(
+      byokOpenCodeAgentDef.buildArgs('', ['relative.png', 'assets/foo.png'], [], {
+        model: 'gpt-4o-mini',
+      }),
+    ).toEqual(['run', '--format', 'json', '-m', 'open-design-byok/gpt-4o-mini']);
+  });
+
   it('prefixes raw BYOK models with the run-scoped OpenCode provider id', () => {
     expect(opencodeByokModelId('gpt-4o-mini')).toBe('open-design-byok/gpt-4o-mini');
     expect(opencodeByokModelId('open-design-byok/gpt-4o-mini')).toBe('open-design-byok/gpt-4o-mini');
@@ -67,6 +106,13 @@ describe('byok-opencode runtime config', () => {
           models: {
             'deepseek-v4-flash': {
               name: 'deepseek-v4-flash',
+              // #6482 — custom BYOK models default to text-only in OpenCode
+              // unless the provider entry advertises image input.
+              attachment: true,
+              modalities: {
+                input: ['text', 'image'],
+                output: ['text'],
+              },
               limit: {
                 context: 128_000,
                 output: 16_384,
@@ -74,6 +120,38 @@ describe('byok-opencode runtime config', () => {
             },
           },
         },
+      },
+    });
+  });
+
+  // Regression for #6482: without attachment/modalities OpenCode resolves the
+  // custom model as capabilities.input.image=false and rewrites image tool
+  // results to "this model does not support image input".
+  it('declares multimodal image input on every BYOK model entry', () => {
+    const out = buildOpenCodeByokProviderConfig(
+      {
+        protocol: 'openai',
+        apiKey: 'sk-openai',
+        baseUrl: 'https://api.openai.com/v1',
+      },
+      'gpt-5.6-terra',
+    );
+
+    const models = (
+      out?.config.provider as
+        | Record<string, { models?: Record<string, Record<string, unknown>> }>
+        | undefined
+    )?.[BYOK_OPENCODE_PROVIDER_ID]?.models;
+    expect(models?.['gpt-5.6-terra']).toEqual({
+      name: 'gpt-5.6-terra',
+      attachment: true,
+      modalities: {
+        input: ['text', 'image'],
+        output: ['text'],
+      },
+      limit: {
+        context: 128_000,
+        output: 16_384,
       },
     });
   });


### PR DESCRIPTION
Fixes #6482

## Why

BYOK OpenCode users who configure a multimodal custom model (OpenAI-compatible or similar) can upload/paste images into a project, and OpenCode's `read` tool even reports "Image read successfully". The upstream model still never sees the pixels.

Two adapter gaps on the packaged `byok-opencode` path caused this:

1. **Custom model metadata was text-only.** `buildOpenCodeByokProviderConfig` registered each model with only `name` + token `limit`. OpenCode therefore resolved `attachment: false` / `capabilities.input.image: false` and rewrote image tool results to `ERROR: Cannot read image (this model does not support image input)`.
2. **`buildArgs` ignored `imagePaths`.** OpenCode's CLI expects attachments via repeated `-f` / `--file` flags.
3. **(Review follow-up)** Web chat does not populate `imagePaths`. The live UI uploads images into the project and sends only project-relative `attachments`. The daemon must resolve image attachments to absolute paths before `buildArgs`, or `-f` is never emitted for the desktop repro.

## What users will see

- Custom BYOK OpenCode models can receive pasted/uploaded images again.
- Multimodal design workflows (screenshot → edit / critique) no longer fail with "this model does not support image input" when the upstream endpoint actually accepts image input.
- No UI change; adapter + chat-run handoff only.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — BYOK OpenCode model entries advertise image input; absolute image attachments (upload-dir `imagePaths` **and** project `attachments`) are forwarded as `-f` flags
- [ ] **None**

## What changed

1. `apps/daemon/src/runtimes/byok-opencode.ts`  
   Model entry includes `attachment: true` + `modalities.input: [text, image]`.
2. `apps/daemon/src/runtimes/defs/byok-opencode.ts`  
   Absolute `imagePaths` become repeated `-f` flags (prompt stays on stdin).
3. `apps/daemon/src/runtimes/chat-prompt-inputs.ts` + `server.ts`  
   `resolveAbsoluteProjectImageAttachments` + `mergePromptImagePaths` turn web `attachments` (image files under the project) into absolute paths merged into the list passed to `buildArgs`.

## Validation

```bash
# Unit: multimodal model metadata + -f argv shape
pnpm --filter @open-design/daemon exec vitest run tests/runtimes/byok-opencode.test.ts
# 23 passed

# Unit: project attachment → absolute image path handoff
pnpm --filter @open-design/daemon exec vitest run tests/chat-attachments.test.ts
# 5 passed

# Route: BYOK provider config + web attachments path emits -f <abs>
pnpm --filter @open-design/daemon exec vitest run tests/chat-route.test.ts \
  -t "passes BYOK provider config to the daemon-backed OpenCode runtime|forwards project image attachments as OpenCode"
# 2 passed

# Related runtime suites (earlier on branch)
pnpm --filter @open-design/daemon exec vitest run \
  tests/runtimes/byok-opencode.test.ts \
  tests/runtimes/agent-args.test.ts \
  tests/runtimes/registry-and-args.test.ts \
  tests/runtimes/opencode-resume-args.test.ts
# 106 passed
```

## Bug fix verification

- **Test path that reproduces the bug:**
  - `apps/daemon/tests/runtimes/byok-opencode.test.ts` — metadata + `-f` filtering
  - `apps/daemon/tests/chat-attachments.test.ts` — relative attachments → absolute image paths
  - `apps/daemon/tests/chat-route.test.ts` — **live web shape**: only `attachments: ['uploads/shot.png']`, no `imagePaths`, asserts argv contains `-f` + absolute path
- **Did the test go red on `main` and green on this branch?** yes  
  - First commit: adapter-only tests red→green  
  - Review follow-up: route-level attachments test would fail without the handoff; green after wiring

## Risks / notes

- **All BYOK models are advertised as multimodal.** Design workflows routinely attach images; without the metadata, multimodal endpoints still fail. A pure text model that rejects image payloads will still fail at the provider.
- **Project image attachments** are size-capped at `MAX_CHAT_IMAGE_BYTES` (1 MB), same as the upload-dir channel.
- Relative / non-image / path-escape attachments are not forwarded as `-f`.
- Scope is limited to the BYOK OpenCode CLI spawn path (plus shared chat-run image merge). Non-BYOK `opencode` still ignores imagePaths in `buildArgs`.

## Screenshots

N/A — daemon adapter only.