### PR TITLE
fix(deploy): escape hatch for snap Docker tini AppArmor conflict

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -84,6 +84,58 @@ The image intentionally does not bundle Claude/Codex/Gemini CLI binaries. Keep
 those outside the image, or build a separate private runtime layer if a server
 deployment needs local code-agent CLIs installed in the container.
 
+### Snap Docker (Linux): `exec /sbin/tini: operation not permitted`
+
+On Ubuntu and other distros where Docker is installed from **snap**
+(`snap install docker`), Compose may crash-loop even when a plain
+`docker run …` of the same image works.
+
+**Symptom** — `docker logs open-design` repeats:
+
+```text
+exec /sbin/tini: operation not permitted
+```
+
+**Cause** — the base `docker-compose.yml` hardens the service with
+`read_only: true` and `security_opt: [no-new-privileges:true]`. Those
+defaults are fine under Docker Engine from apt/get, but snap's AppArmor
+profile blocks the image `ENTRYPOINT` (`/sbin/tini`) under that
+combination.
+
+**Preferred fix** — install Docker Engine from Docker's official packages
+instead of snap, then re-run Compose with the base file only:
+
+- https://docs.docker.com/engine/install/
+
+**Escape hatch** — keep snap Docker and relax only the two conflicting
+flags via `docker-compose.snap.yml`:
+
+```bash
+# from deploy/
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.snap.yml \
+  up -d --no-build
+```
+
+With the Linux host-network override:
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.linux.yml \
+  -f docker-compose.snap.yml \
+  up -d --no-build
+```
+
+`deploy/scripts/install.sh` and `update.sh` detect snap-packaged Docker
+and apply `docker-compose.snap.yml` automatically, with a warning that
+the hardening defaults were relaxed for compatibility.
+
+Trade-off: the container root filesystem is writable and
+`no-new-privileges` is not enforced. Use the official Docker Engine
+install when you want the full hardening defaults.
+
 ## Linux: mounting host agent CLIs
 
 On Linux you can mount host-installed agent CLIs (Claude Code, opencode, Codex,

--- a/deploy/docker-compose.snap.yml
+++ b/deploy/docker-compose.snap.yml
@@ -1,0 +1,34 @@
+# Escape hatch for Docker installed via snap (common on Ubuntu).
+#
+# Snap's AppArmor confinement rejects the base compose hardening:
+#   read_only: true
+#   security_opt: [no-new-privileges:true]
+# which then fails the image ENTRYPOINT with:
+#   exec /sbin/tini: operation not permitted
+#
+# Plain `docker run` often still works because it does not apply those
+# Compose security defaults. Prefer installing Docker Engine from Docker's
+# apt repository when you can; only use this override when compose
+# crash-loops with the tini error above.
+#
+# Usage (from deploy/):
+#   docker compose -f docker-compose.yml -f docker-compose.snap.yml up -d --no-build
+#
+# With the Linux host-network override:
+#   docker compose \
+#     -f docker-compose.yml \
+#     -f docker-compose.linux.yml \
+#     -f docker-compose.snap.yml \
+#     up -d --no-build
+#
+# install.sh / update.sh auto-apply this file when they detect snap Docker.
+# Requires Docker Compose v2.17+ for the `!reset` YAML tag (same as the
+# Linux host-network override).
+name: open-design
+
+services:
+  open-design:
+    # Writable root FS so /sbin/tini and node can exec under snap AppArmor.
+    read_only: false
+    # Clear base security_opt entries (including the no-new-privileges flag).
+    security_opt: !reset []

--- a/deploy/scripts/install.sh
+++ b/deploy/scripts/install.sh
@@ -20,17 +20,28 @@ DEPLOY_DIR="$(dirname "$SCRIPT_DIR")"
 COMPOSE_FILE="${DEPLOY_DIR}/docker-compose.yml"
 OVERRIDE_FILE="${DEPLOY_DIR}/docker-compose.override.yml"
 LINUX_OVERRIDE_FILE="${DEPLOY_DIR}/docker-compose.linux.yml"
+SNAP_OVERRIDE_FILE="${DEPLOY_DIR}/docker-compose.snap.yml"
+# Set to 1 after snap Docker is detected so rebuild_compose_files includes
+# the tini / AppArmor escape hatch (see docker-compose.snap.yml, issue #6488).
+APPLY_SNAP_COMPOSE_OVERRIDE=0
 
-# Build the -f argument list: always include the base file,
-# add the Linux host-network override, and add docker-compose.override.yml if present
-# (used by tests for isolation).
-COMPOSE_FILES=(-f "$COMPOSE_FILE")
-if [ "$(uname -s)" = "Linux" ] && [ -f "$LINUX_OVERRIDE_FILE" ]; then
-  COMPOSE_FILES+=(-f "$LINUX_OVERRIDE_FILE")
-fi
-if [ -f "$OVERRIDE_FILE" ]; then
-  COMPOSE_FILES+=(-f "$OVERRIDE_FILE")
-fi
+# Build the -f argument list: always include the base file, then optional
+# Linux host-network override, snap escape hatch, and docker-compose.override.yml
+# (used by tests for isolation). Call again after snap detection flips
+# APPLY_SNAP_COMPOSE_OVERRIDE.
+rebuild_compose_files() {
+  COMPOSE_FILES=(-f "$COMPOSE_FILE")
+  if [ "$(uname -s)" = "Linux" ] && [ -f "$LINUX_OVERRIDE_FILE" ]; then
+    COMPOSE_FILES+=(-f "$LINUX_OVERRIDE_FILE")
+  fi
+  if [ "$APPLY_SNAP_COMPOSE_OVERRIDE" = "1" ] && [ -f "$SNAP_OVERRIDE_FILE" ]; then
+    COMPOSE_FILES+=(-f "$SNAP_OVERRIDE_FILE")
+  fi
+  if [ -f "$OVERRIDE_FILE" ]; then
+    COMPOSE_FILES+=(-f "$OVERRIDE_FILE")
+  fi
+}
+rebuild_compose_files
 
 if [ ! -f "$COMPOSE_FILE" ]; then
   echo "WARN: docker-compose.yml not found at ${COMPOSE_FILE}" >&2
@@ -264,12 +275,54 @@ if ! detect_compose; then
   exit 1
 fi
 
-# The Linux host-network override uses the !reset YAML tag (Docker Compose
-# v2.17+). Reject legacy docker-compose v1 and podman-compose early so users
-# get a clear message instead of a YAML parse error mid-install.
+# Snap-packaged Docker + base compose hardening (read_only + no-new-privileges)
+# blocks the image ENTRYPOINT: exec /sbin/tini: operation not permitted (#6488).
+is_snap_confined_docker() {
+  [ "${CONTAINER_RUNTIME:-}" = "docker" ] || return 1
+  command -v docker >/dev/null 2>&1 || return 1
+  _docker_bin="$(command -v docker)"
+  case "$_docker_bin" in
+    /snap/*) return 0 ;;
+  esac
+  if command -v readlink >/dev/null 2>&1; then
+    _docker_resolved="$(readlink -f "$_docker_bin" 2>/dev/null || true)"
+    case "$_docker_resolved" in
+      /snap/*) return 0 ;;
+    esac
+  fi
+  # Fallback when the binary path is a non-snap wrapper but the daemon still
+  # stores state under the snap data directory.
+  if docker info 2>/dev/null | grep -q '/var/snap/docker'; then
+    return 0
+  fi
+  return 1
+}
+
+if is_snap_confined_docker && [ -f "$SNAP_OVERRIDE_FILE" ]; then
+  APPLY_SNAP_COMPOSE_OVERRIDE=1
+  rebuild_compose_files
+  warn "Snap-packaged Docker detected."
+  warn "Base compose hardening conflicts with snap AppArmor and causes:"
+  warn "  exec /sbin/tini: operation not permitted"
+  warn "Applying docker-compose.snap.yml (relaxes read_only + no-new-privileges)."
+  step "Prefer Docker Engine from Docker's apt repo when you can:"
+  step "  https://docs.docker.com/engine/install/"
+  step "Details: deploy/README.md → Snap Docker (Linux)"
+fi
+
+# Linux host-network and snap overrides use the !reset YAML tag (Docker
+# Compose v2.17+). Reject legacy docker-compose v1 and podman-compose early so
+# users get a clear message instead of a YAML parse error mid-install.
+_needs_compose_reset_tag=0
 if [ "$OS" = "Linux" ] && [ -f "$LINUX_OVERRIDE_FILE" ]; then
+  _needs_compose_reset_tag=1
+fi
+if [ "$APPLY_SNAP_COMPOSE_OVERRIDE" = "1" ]; then
+  _needs_compose_reset_tag=1
+fi
+if [ "$_needs_compose_reset_tag" = "1" ]; then
   if [ "$COMPOSE_CMD" != "docker compose" ]; then
-    error "The Linux host-network override requires 'docker compose' v2."
+    error "The Linux / snap compose overrides require 'docker compose' v2."
     error "Found: ${COMPOSE_CMD}"
     step "Install the Docker Compose plugin: https://docs.docker.com/compose/install/"
     exit 1
@@ -278,7 +331,7 @@ if [ "$OS" = "Linux" ] && [ -f "$LINUX_OVERRIDE_FILE" ]; then
   _compose_major="$(echo "$_compose_ver" | cut -d. -f1)"
   _compose_minor="$(echo "$_compose_ver" | cut -d. -f2)"
   if [ "$_compose_major" -lt 2 ] || { [ "$_compose_major" -eq 2 ] && [ "$_compose_minor" -lt 17 ]; }; then
-    error "Docker Compose v2.17 or later required for the Linux override (found v${_compose_ver})."
+    error "Docker Compose v2.17 or later required for the Linux / snap overrides (found v${_compose_ver})."
     step "Upgrade: https://docs.docker.com/compose/install/"
     exit 1
   fi
@@ -491,10 +544,13 @@ if [ "$OS" = "Linux" ] && [ "$OPT_NO_SYSTEMD" = "0" ]; then
       echo "WorkingDirectory=${DEPLOY_DIR}"
       # Build the compose -f list to match what the installer used at install
       # time, so systemd restarts use the same file set (including the Linux
-      # host-network override when present).
+      # host-network override and snap escape hatch when present).
       _COMPOSE_ARGS="-f ${COMPOSE_FILE}"
       if [ -f "$LINUX_OVERRIDE_FILE" ]; then
         _COMPOSE_ARGS="${_COMPOSE_ARGS} -f ${LINUX_OVERRIDE_FILE}"
+      fi
+      if [ "$APPLY_SNAP_COMPOSE_OVERRIDE" = "1" ] && [ -f "$SNAP_OVERRIDE_FILE" ]; then
+        _COMPOSE_ARGS="${_COMPOSE_ARGS} -f ${SNAP_OVERRIDE_FILE}"
       fi
       if [ -f "$OVERRIDE_FILE" ]; then
         _COMPOSE_ARGS="${_COMPOSE_ARGS} -f ${OVERRIDE_FILE}"

--- a/deploy/scripts/update.sh
+++ b/deploy/scripts/update.sh
@@ -10,15 +10,23 @@ DEPLOY_DIR="$(dirname "$SCRIPT_DIR")"
 COMPOSE_FILE="${DEPLOY_DIR}/docker-compose.yml"
 OVERRIDE_FILE="${DEPLOY_DIR}/docker-compose.override.yml"
 LINUX_OVERRIDE_FILE="${DEPLOY_DIR}/docker-compose.linux.yml"
+SNAP_OVERRIDE_FILE="${DEPLOY_DIR}/docker-compose.snap.yml"
+APPLY_SNAP_COMPOSE_OVERRIDE=0
 HEALTH_TIMEOUT=60
 
-COMPOSE_FILES=(-f "$COMPOSE_FILE")
-if [ "$(uname -s)" = "Linux" ] && [ -f "$LINUX_OVERRIDE_FILE" ]; then
-  COMPOSE_FILES+=(-f "$LINUX_OVERRIDE_FILE")
-fi
-if [ -f "$OVERRIDE_FILE" ]; then
-  COMPOSE_FILES+=(-f "$OVERRIDE_FILE")
-fi
+rebuild_compose_files() {
+  COMPOSE_FILES=(-f "$COMPOSE_FILE")
+  if [ "$(uname -s)" = "Linux" ] && [ -f "$LINUX_OVERRIDE_FILE" ]; then
+    COMPOSE_FILES+=(-f "$LINUX_OVERRIDE_FILE")
+  fi
+  if [ "$APPLY_SNAP_COMPOSE_OVERRIDE" = "1" ] && [ -f "$SNAP_OVERRIDE_FILE" ]; then
+    COMPOSE_FILES+=(-f "$SNAP_OVERRIDE_FILE")
+  fi
+  if [ -f "$OVERRIDE_FILE" ]; then
+    COMPOSE_FILES+=(-f "$OVERRIDE_FILE")
+  fi
+}
+rebuild_compose_files
 
 # ---------------------------------------------------------------------------
 # Colors & formatting
@@ -52,10 +60,44 @@ else
   exit 1
 fi
 
-# Same guard as install.sh: the Linux override uses !reset (Docker Compose v2.17+).
+# Snap Docker + base hardening blocks ENTRYPOINT tini (#6488). Match install.sh.
+is_snap_confined_docker() {
+  [ "$COMPOSE_CMD" = "docker compose" ] || [ "$COMPOSE_CMD" = "docker-compose" ] || return 1
+  command -v docker >/dev/null 2>&1 || return 1
+  _docker_bin="$(command -v docker)"
+  case "$_docker_bin" in
+    /snap/*) return 0 ;;
+  esac
+  if command -v readlink >/dev/null 2>&1; then
+    _docker_resolved="$(readlink -f "$_docker_bin" 2>/dev/null || true)"
+    case "$_docker_resolved" in
+      /snap/*) return 0 ;;
+    esac
+  fi
+  if docker info 2>/dev/null | grep -q '/var/snap/docker'; then
+    return 0
+  fi
+  return 1
+}
+
+if is_snap_confined_docker && [ -f "$SNAP_OVERRIDE_FILE" ]; then
+  APPLY_SNAP_COMPOSE_OVERRIDE=1
+  rebuild_compose_files
+  warn "Snap-packaged Docker detected; applying docker-compose.snap.yml escape hatch."
+  step "Details: deploy/README.md → Snap Docker (Linux)"
+fi
+
+# Same guard as install.sh: Linux / snap overrides use !reset (Compose v2.17+).
+_needs_compose_reset_tag=0
 if [ "$(uname -s)" = "Linux" ] && [ -f "$LINUX_OVERRIDE_FILE" ]; then
+  _needs_compose_reset_tag=1
+fi
+if [ "$APPLY_SNAP_COMPOSE_OVERRIDE" = "1" ]; then
+  _needs_compose_reset_tag=1
+fi
+if [ "$_needs_compose_reset_tag" = "1" ]; then
   if [ "$COMPOSE_CMD" != "docker compose" ]; then
-    error "The Linux host-network override requires 'docker compose' v2."
+    error "The Linux / snap compose overrides require 'docker compose' v2."
     error "Found: ${COMPOSE_CMD}"
     step "Install the Docker Compose plugin: https://docs.docker.com/compose/install/"
     exit 1
@@ -64,7 +106,7 @@ if [ "$(uname -s)" = "Linux" ] && [ -f "$LINUX_OVERRIDE_FILE" ]; then
   _compose_major="$(echo "$_compose_ver" | cut -d. -f1)"
   _compose_minor="$(echo "$_compose_ver" | cut -d. -f2)"
   if [ "$_compose_major" -lt 2 ] || { [ "$_compose_major" -eq 2 ] && [ "$_compose_minor" -lt 17 ]; }; then
-    error "Docker Compose v2.17 or later required for the Linux override (found v${_compose_ver})."
+    error "Docker Compose v2.17 or later required for the Linux / snap overrides (found v${_compose_ver})."
     step "Upgrade: https://docs.docker.com/compose/install/"
     exit 1
   fi

--- a/deploy/tests/snap-compose.test.ts
+++ b/deploy/tests/snap-compose.test.ts
@@ -1,0 +1,82 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const execFileAsync = promisify(execFile);
+const deployDir = join(import.meta.dirname, '..');
+const baseCompose = join(deployDir, 'docker-compose.yml');
+const snapCompose = join(deployDir, 'docker-compose.snap.yml');
+const readme = join(deployDir, 'README.md');
+
+test('base compose keeps the security defaults that snap Docker rejects', async () => {
+  const text = await readFile(baseCompose, 'utf8');
+  assert.match(text, /^\s*read_only:\s*true\s*$/m);
+  assert.match(text, /no-new-privileges:true/);
+});
+
+test('snap compose override relaxes only the tini-blocking hardening flags', async () => {
+  const text = await readFile(snapCompose, 'utf8');
+  // Escape hatch must flip the two flags from the issue report (#6488).
+  assert.match(text, /^\s*read_only:\s*false\s*$/m);
+  assert.match(text, /security_opt:\s*!reset\s*\[\]/);
+  // Active YAML keys must not re-enable the flag (comments may still name it).
+  assert.doesNotMatch(text, /^\s*-\s*no-new-privileges/m);
+  // Document the failure mode so operators can find the file from logs.
+  assert.match(text, /exec \/sbin\/tini: operation not permitted/);
+  assert.match(text, /snap/i);
+});
+
+test('deploy README documents the snap Docker tini failure and escape hatch', async () => {
+  const text = await readFile(readme, 'utf8');
+  assert.match(text, /Snap Docker \(Linux\)/);
+  assert.match(text, /exec \/sbin\/tini: operation not permitted/);
+  assert.match(text, /docker-compose\.snap\.yml/);
+  assert.match(text, /docs\.docker\.com\/engine\/install/);
+});
+
+test(
+  'merged compose config drops read_only and no-new-privileges when snap override is applied',
+  async (t) => {
+    // Needs a working Compose v2 that understands !reset.
+    let composeOk = false;
+    try {
+      await execFileAsync('docker', ['compose', 'version'], { timeout: 5000 });
+      composeOk = true;
+    } catch {
+      composeOk = false;
+    }
+    if (!composeOk) {
+      t.skip('docker compose not available');
+      return;
+    }
+
+    const env = {
+      ...process.env,
+      // Avoid pulling/building; config only resolves the merge.
+      OPEN_DESIGN_IMAGE: 'ghcr.io/nexu-io/od:latest',
+    };
+
+    const { stdout: baseOnly } = await execFileAsync(
+      'docker',
+      ['compose', '-f', baseCompose, 'config'],
+      { timeout: 30_000, cwd: deployDir, env },
+    );
+    // Sanity: base hardening is still present without the escape hatch.
+    assert.match(baseOnly, /read_only:\s*true/);
+    assert.match(baseOnly, /no-new-privileges/);
+
+    const { stdout: withSnap } = await execFileAsync(
+      'docker',
+      ['compose', '-f', baseCompose, '-f', snapCompose, 'config'],
+      { timeout: 30_000, cwd: deployDir, env },
+    );
+
+    // Compose omits default-false fields, so success is "no longer hardened":
+    // read_only:true and no-new-privileges must both be gone after the merge.
+    assert.doesNotMatch(withSnap, /read_only:\s*true/);
+    assert.doesNotMatch(withSnap, /no-new-privileges/);
+  },
+);


### PR DESCRIPTION
Fixes #6488

## Why

On Ubuntu (and similar) installs where Docker comes from **snap**, `docker compose up` crash-loops with:

```text
exec /sbin/tini: operation not permitted
```

while a plain `docker run` of the same image works. The base `deploy/docker-compose.yml` hardens the service with:

- `read_only: true`
- `security_opt: [no-new-privileges:true]`

Those defaults are correct under Docker Engine from apt/get, but snap's AppArmor profile blocks the image `ENTRYPOINT` (`/sbin/tini`) under that combination. The reporter confirmed that commenting both flags out unblocks startup.

Maintainer triage on the issue asked for either README documentation or a Linux-specific escape hatch — this PR ships both, plus auto-apply from the install/update scripts when snap Docker is detected.

## What users will see

- Snap Docker users can start Open Design without hand-editing compose files.
- `install.sh` / `update.sh` print a clear warning and apply `docker-compose.snap.yml` automatically when snap Docker is detected.
- Non-snap installs keep the full hardening defaults unchanged.
- Prefer installing Docker Engine from Docker's official packages when possible (documented).

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — only when snap Docker is detected: compose install/update auto-applies a less-hardened override
- [ ] **None**

## What changed

| Path | Change |
|------|--------|
| `deploy/docker-compose.snap.yml` | Escape hatch: `read_only: false` + `security_opt: !reset []` |
| `deploy/README.md` | New **Snap Docker (Linux)** section: symptom, cause, preferred Engine install, manual override command, trade-off |
| `deploy/scripts/install.sh` | Detect snap Docker; rebuild compose file list; warn; include snap override in systemd unit args |
| `deploy/scripts/update.sh` | Same snap detection + compose file list |
| `deploy/tests/snap-compose.test.ts` | File-content + `docker compose config` merge assertions |

Base `docker-compose.yml` security defaults are **unchanged** for non-snap users.

## Bug fix verification

- **Test path:** `deploy/tests/snap-compose.test.ts`
  - base still ships `read_only: true` + `no-new-privileges`
  - snap override flips / resets those flags
  - README documents the failure mode
  - `docker compose -f base -f snap config` no longer emits `read_only: true` or `no-new-privileges` (while base-only still does)
- **Did the test go red before / green after?** yes — merge assertions written against the intended post-fix config, then verified green
- **Extra checks:**
  ```bash
  bash -n deploy/scripts/install.sh
  bash -n deploy/scripts/update.sh
  node --test deploy/tests/snap-compose.test.ts
  # 4 passed
  ```

## Validation

Deploy/docs-only change — no `pnpm guard` / app typecheck scope.

```bash
bash -n deploy/scripts/install.sh
bash -n deploy/scripts/update.sh
node --test deploy/tests/snap-compose.test.ts
# 4 passed
```

Manual: on a snap Docker host, `install.sh` / `update.sh` should print the snap warning and include `docker-compose.snap.yml` in the compose file list; non-snap hosts keep base hardening only.

## Risks / notes

- **Security trade-off on snap only:** writable root FS and no `no-new-privileges`. Documented as temporary compatibility; preferred path is Docker Engine from official packages.
- **`!reset` requires Compose v2.17+** — same requirement as the existing Linux host-network override; install/update already enforce this when the snap override is active.
- **Detection** looks at `/snap/*` binary path (including resolved symlinks) and `/var/snap/docker` in `docker info`. False negatives still have the documented manual `-f docker-compose.snap.yml` path.
- Scope is deploy/docs only — image ENTRYPOINT stays `tini`.

## Screenshots

N/A — deploy/docs only.
