### PR TITLE
fix(landing): lock downloads to stable R2 metadata

### DIFF
--- a/apps/landing-page/app/_lib/github.ts
+++ b/apps/landing-page/app/_lib/github.ts
@@ -203,6 +203,90 @@ export function buildMatrixFromStableMetadata(metadata: unknown): ReleaseMatrix 
   };
 }
 
+type ReleaseMetadataFetch = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+/**
+ * Resolve the canonical public stable release from one complete R2 manifest.
+ * Download-page version labels and artifacts must never be assembled from
+ * independent GitHub and R2 snapshots.
+ */
+export async function fetchLatestStableRelease(
+  fetchImpl: ReleaseMetadataFetch = fetch,
+): Promise<LatestRelease> {
+  const response = await fetchImpl(RELEASE_METADATA_UPSTREAM_URL, {
+    headers: { Accept: 'application/json' },
+  });
+  if (!response.ok) {
+    throw new Error(`Request returned ${response.status}: ${RELEASE_METADATA_UPSTREAM_URL}`);
+  }
+
+  const metadata: unknown = await response.json();
+  if (!isRecord(metadata) || metadata.channel !== 'stable' || metadata.releaseState !== 'complete') {
+    throw new Error('Stable release metadata is not complete');
+  }
+
+  const versionLabel = formatStableReleaseVersion(metadata);
+  if (!versionLabel) throw new Error('Stable release metadata has no valid version');
+
+  const matrix = buildMatrixFromStableMetadata(metadata);
+  if (!matrix.macArm64Dmg || !matrix.macX64Dmg || !matrix.winSetup) {
+    throw new Error('Stable release metadata is missing required desktop installers');
+  }
+  const releaseVersion = cleanVersion(versionLabel);
+  const versionPrefix = `/stable/versions/${releaseVersion}`;
+  const mismatchedArtifact = Object.values(matrix).find((asset) => {
+    if (!asset) return false;
+    try {
+      const url = new URL(asset.url);
+      return (
+        url.origin !== 'https://releases.open-design.ai' ||
+        (url.pathname !== versionPrefix &&
+          !url.pathname.startsWith(`${versionPrefix}/`) &&
+          !url.pathname.startsWith(`${versionPrefix}.`))
+      );
+    } catch {
+      return true;
+    }
+  });
+  if (mismatchedArtifact) {
+    throw new Error(
+      `Stable release artifact ${mismatchedArtifact.name} does not match release version ${releaseVersion}`,
+    );
+  }
+  const expectedTagName = `open-design-v${releaseVersion}`;
+  if (metadata.versionTag !== expectedTagName) {
+    throw new Error(`Stable release tag does not match version ${releaseVersion}`);
+  }
+  const tagName = expectedTagName;
+
+  return {
+    version: releaseVersion,
+    versionLabel,
+    tagName,
+    publishedAt:
+      typeof metadata.publishedAt === 'string'
+        ? metadata.publishedAt
+        : typeof metadata.generatedAt === 'string'
+          ? metadata.generatedAt
+          : null,
+    releaseUrl: tagName
+      ? `${REPO_RELEASES}/tag/${encodeURIComponent(tagName)}`
+      : REPO_RELEASES,
+    matrix,
+    resolved: Object.values(matrix).some((asset) => asset !== null),
+  };
+}
+
+let latestStableReleasePromise: Promise<LatestRelease> | null = null;
+
+export function getLatestStableRelease(): Promise<LatestRelease> {
+  latestStableReleasePromise ??= fetchLatestStableRelease();
+  return latestStableReleasePromise;
+}
+
 function mergeMatrices(preferred: ReleaseMatrix, fallback: ReleaseMatrix): ReleaseMatrix {
   return {
     macArm64Dmg: preferred.macArm64Dmg ?? fallback.macArm64Dmg,

--- a/apps/landing-page/app/info-page-i18n.ts
+++ b/apps/landing-page/app/info-page-i18n.ts
@@ -364,7 +364,6 @@ export interface InfoPageCopy {
     portable: string;
     dmg: string;
     zip: string;
-    checksum: string;
     downloadVerb: string; // "Download"
     requirementsTitle: string;
     requirements: LinkText[];
@@ -3357,7 +3356,6 @@ const INFO_PAGE_COPY: Partial<Record<LandingLocaleCode, InfoPageCopy>> = {
       portable: 'Portable',
       dmg: 'DMG',
       zip: 'ZIP',
-      checksum: 'SHA-256',
       downloadVerb: 'Download',
       requirementsTitle: 'System requirements',
       requirements: [
@@ -3367,7 +3365,7 @@ const INFO_PAGE_COPY: Partial<Record<LandingLocaleCode, InfoPageCopy>> = {
       ],
       allReleasesTitle: 'All releases',
       allReleasesBody:
-        'Every build, checksum, and past version lives on GitHub Releases and releases.open-design.ai.',
+        'Every build and past version lives on GitHub Releases and releases.open-design.ai.',
       ctaTitle: 'Prefer the terminal?',
       ctaBody:
         'Install from source in three commands, or drive Open Design headlessly from your existing coding agent.',
@@ -3378,7 +3376,7 @@ const INFO_PAGE_COPY: Partial<Record<LandingLocaleCode, InfoPageCopy>> = {
 /*
  * Localized /download copy for the compact locales (everything outside the
  * full en/zh/zh-tw blocks above). Brand/technical tokens — mac/windows/linux,
- * DMG/ZIP, SHA-256, Apple Silicon, Intel — intentionally stay as the English
+ * DMG/ZIP, Apple Silicon, Intel — intentionally stay as the English
  * defaults via the spread, matching how the zh block keeps them. zh-CN is
  * hand-checked; the rest are machine-translated and welcome native review.
  */
@@ -3414,9 +3412,9 @@ const COMPACT_DOWNLOAD_COPY: Partial<Record<LandingLocaleCode, DownloadCopy>> = 
       { label: 'Windows', body: '10 または 11（x64）— インストーラーまたはポータブル zip。' },
       { label: 'Linux', body: 'AppImage、または Docker / Podman Compose のワンクリック構築。' },
     ],
-    allReleasesTitle: 'すべてのリリースとチェックサム',
+    allReleasesTitle: 'すべてのリリース',
     allReleasesBody:
-      'すべてのビルド、チェックサム、過去のバージョンは GitHub Releases と releases.open-design.ai にあります。',
+      'すべてのビルドと過去のバージョンは GitHub Releases と releases.open-design.ai にあります。',
     ctaTitle: 'ターミナル派ですか？',
     ctaBody:
       '3 つのコマンドでソースからインストール、または既存のコーディングエージェントから Open Design をヘッドレスで動かせます。',
@@ -3451,9 +3449,9 @@ const COMPACT_DOWNLOAD_COPY: Partial<Record<LandingLocaleCode, DownloadCopy>> = 
       { label: 'Windows', body: '10 또는 11(x64) — 설치 버전 또는 포터블 zip.' },
       { label: 'Linux', body: 'AppImage, 또는 Docker / Podman Compose 원클릭 설치.' },
     ],
-    allReleasesTitle: '모든 릴리스 및 체크섬',
+    allReleasesTitle: '모든 릴리스',
     allReleasesBody:
-      '모든 빌드, 체크섬, 이전 버전은 GitHub Releases와 releases.open-design.ai에 있습니다.',
+      '모든 빌드와 이전 버전은 GitHub Releases와 releases.open-design.ai에 있습니다.',
     ctaTitle: '터미널이 더 편하세요?',
     ctaBody:
       '세 개의 명령으로 소스에서 설치하거나, 기존 코딩 에이전트에서 Open Design을 헤드리스로 구동하세요.',
@@ -3488,9 +3486,9 @@ const COMPACT_DOWNLOAD_COPY: Partial<Record<LandingLocaleCode, DownloadCopy>> = 
       { label: 'Windows', body: '10 oder 11 (x64) — Installer oder portables ZIP.' },
       { label: 'Linux', body: 'AppImage oder Docker / Podman Compose mit Ein-Klick-Setup.' },
     ],
-    allReleasesTitle: 'Alle Releases & Prüfsummen',
+    allReleasesTitle: 'Alle Releases',
     allReleasesBody:
-      'Jeder Build, jede Prüfsumme und alle früheren Versionen liegen auf GitHub Releases und releases.open-design.ai.',
+      'Jeder Build und alle früheren Versionen liegen auf GitHub Releases und releases.open-design.ai.',
     ctaTitle: 'Lieber das Terminal?',
     ctaBody:
       'Installiere aus dem Quellcode mit drei Befehlen oder steuere Open Design headless aus deinem bestehenden Coding-Agent.',
@@ -3525,9 +3523,9 @@ const COMPACT_DOWNLOAD_COPY: Partial<Record<LandingLocaleCode, DownloadCopy>> = 
       { label: 'Windows', body: '10 ou 11 (x64) — installateur ou zip portable.' },
       { label: 'Linux', body: 'AppImage, ou installation en un clic via Docker / Podman Compose.' },
     ],
-    allReleasesTitle: 'Toutes les versions et sommes de contrôle',
+    allReleasesTitle: 'Toutes les versions',
     allReleasesBody:
-      'Chaque build, somme de contrôle et version passée se trouve sur GitHub Releases et releases.open-design.ai.',
+      'Chaque build et chaque version passée se trouvent sur GitHub Releases et releases.open-design.ai.',
     ctaTitle: 'Vous préférez le terminal ?',
     ctaBody:
       'Installez depuis les sources en trois commandes, ou pilotez Open Design en mode headless depuis votre agent de code existant.',
@@ -3562,9 +3560,9 @@ const COMPACT_DOWNLOAD_COPY: Partial<Record<LandingLocaleCode, DownloadCopy>> = 
       { label: 'Windows', body: '10 или 11 (x64) — установщик или портативный zip.' },
       { label: 'Linux', body: 'AppImage или установка в один клик через Docker / Podman Compose.' },
     ],
-    allReleasesTitle: 'Все релизы и контрольные суммы',
+    allReleasesTitle: 'Все релизы',
     allReleasesBody:
-      'Каждая сборка, контрольная сумма и прошлые версии — на GitHub Releases и releases.open-design.ai.',
+      'Все сборки и прошлые версии — на GitHub Releases и releases.open-design.ai.',
     ctaTitle: 'Предпочитаете терминал?',
     ctaBody:
       'Установите из исходников тремя командами или управляйте Open Design в headless-режиме из вашего существующего агента для кода.',
@@ -3599,9 +3597,9 @@ const COMPACT_DOWNLOAD_COPY: Partial<Record<LandingLocaleCode, DownloadCopy>> = 
       { label: 'Windows', body: '10 u 11 (x64) — instalador o zip portable.' },
       { label: 'Linux', body: 'AppImage, o instalación con un clic vía Docker / Podman Compose.' },
     ],
-    allReleasesTitle: 'Todas las versiones y sumas de verificación',
+    allReleasesTitle: 'Todas las versiones',
     allReleasesBody:
-      'Cada compilación, suma de verificación y versión anterior está en GitHub Releases y releases.open-design.ai.',
+      'Cada compilación y versión anterior está en GitHub Releases y releases.open-design.ai.',
     ctaTitle: '¿Prefieres la terminal?',
     ctaBody:
       'Instala desde el código fuente con tres comandos, o controla Open Design en modo headless desde tu agente de código actual.',
@@ -3636,9 +3634,9 @@ const COMPACT_DOWNLOAD_COPY: Partial<Record<LandingLocaleCode, DownloadCopy>> = 
       { label: 'Windows', body: '10 ou 11 (x64) — instalador ou zip portátil.' },
       { label: 'Linux', body: 'AppImage, ou instalação com um clique via Docker / Podman Compose.' },
     ],
-    allReleasesTitle: 'Todas as versões e somas de verificação',
+    allReleasesTitle: 'Todas as versões',
     allReleasesBody:
-      'Cada build, soma de verificação e versão anterior fica no GitHub Releases e em releases.open-design.ai.',
+      'Cada build e versão anterior fica no GitHub Releases e em releases.open-design.ai.',
     ctaTitle: 'Prefere o terminal?',
     ctaBody:
       'Instale a partir do código-fonte com três comandos, ou controle o Open Design em modo headless pelo seu agente de código atual.',
@@ -3673,9 +3671,9 @@ const COMPACT_DOWNLOAD_COPY: Partial<Record<LandingLocaleCode, DownloadCopy>> = 
       { label: 'Windows', body: '10 o 11 (x64) — installer o zip portatile.' },
       { label: 'Linux', body: 'AppImage, o installazione con un clic tramite Docker / Podman Compose.' },
     ],
-    allReleasesTitle: 'Tutte le release e i checksum',
+    allReleasesTitle: 'Tutte le release',
     allReleasesBody:
-      'Ogni build, checksum e versione precedente si trova su GitHub Releases e releases.open-design.ai.',
+      'Ogni build e versione precedente si trova su GitHub Releases e releases.open-design.ai.',
     ctaTitle: 'Preferisci il terminale?',
     ctaBody:
       'Installa dai sorgenti con tre comandi, oppure pilota Open Design in modalità headless dal tuo agente di coding esistente.',
@@ -3708,9 +3706,9 @@ const COMPACT_DOWNLOAD_COPY: Partial<Record<LandingLocaleCode, DownloadCopy>> = 
       { label: 'Windows', body: '10 hoặc 11 (x64) — bản cài đặt hoặc zip di động.' },
       { label: 'Linux', body: 'AppImage, hoặc cài đặt một chạm qua Docker / Podman Compose.' },
     ],
-    allReleasesTitle: 'Tất cả bản phát hành và checksum',
+    allReleasesTitle: 'Tất cả bản phát hành',
     allReleasesBody:
-      'Mọi bản dựng, checksum và phiên bản trước đều có trên GitHub Releases và releases.open-design.ai.',
+      'Mọi bản dựng và phiên bản trước đều có trên GitHub Releases và releases.open-design.ai.',
     ctaTitle: 'Thích dùng terminal hơn?',
     ctaBody:
       'Cài đặt từ mã nguồn bằng ba lệnh, hoặc điều khiển Open Design ở chế độ headless từ agent lập trình hiện có của bạn.',
@@ -3743,9 +3741,9 @@ const COMPACT_DOWNLOAD_COPY: Partial<Record<LandingLocaleCode, DownloadCopy>> = 
       { label: 'Windows', body: '10 lub 11 (x64) — instalator albo przenośny zip.' },
       { label: 'Linux', body: 'AppImage lub instalacja jednym kliknięciem przez Docker / Podman Compose.' },
     ],
-    allReleasesTitle: 'Wszystkie wydania i sumy kontrolne',
+    allReleasesTitle: 'Wszystkie wydania',
     allReleasesBody:
-      'Każda kompilacja, suma kontrolna i poprzednia wersja są na GitHub Releases i releases.open-design.ai.',
+      'Każda kompilacja i poprzednia wersja są na GitHub Releases i releases.open-design.ai.',
     ctaTitle: 'Wolisz terminal?',
     ctaBody:
       'Zainstaluj ze źródeł trzema poleceniami albo steruj Open Design w trybie headless ze swojego agenta do kodowania.',
@@ -3778,9 +3776,9 @@ const COMPACT_DOWNLOAD_COPY: Partial<Record<LandingLocaleCode, DownloadCopy>> = 
       { label: 'Windows', body: '10 atau 11 (x64) — penginstal atau zip portabel.' },
       { label: 'Linux', body: 'AppImage, atau penyiapan satu klik via Docker / Podman Compose.' },
     ],
-    allReleasesTitle: 'Semua rilis & checksum',
+    allReleasesTitle: 'Semua rilis',
     allReleasesBody:
-      'Setiap build, checksum, dan versi lampau ada di GitHub Releases dan releases.open-design.ai.',
+      'Setiap build dan versi lampau ada di GitHub Releases dan releases.open-design.ai.',
     ctaTitle: 'Lebih suka terminal?',
     ctaBody:
       'Pasang dari sumber dengan tiga perintah, atau jalankan Open Design secara headless dari agen coding Anda yang sudah ada.',
@@ -3813,9 +3811,9 @@ const COMPACT_DOWNLOAD_COPY: Partial<Record<LandingLocaleCode, DownloadCopy>> = 
       { label: 'Windows', body: '10 of 11 (x64) — installatieprogramma of portable zip.' },
       { label: 'Linux', body: 'AppImage, of installatie met één klik via Docker / Podman Compose.' },
     ],
-    allReleasesTitle: 'Alle releases en checksums',
+    allReleasesTitle: 'Alle releases',
     allReleasesBody:
-      'Elke build, checksum en eerdere versie staat op GitHub Releases en releases.open-design.ai.',
+      'Elke build en eerdere versie staat op GitHub Releases en releases.open-design.ai.',
     ctaTitle: 'Liever de terminal?',
     ctaBody:
       'Installeer vanuit de broncode met drie commando’s, of stuur Open Design headless aan vanuit je bestaande coding-agent.',
@@ -3848,9 +3846,9 @@ const COMPACT_DOWNLOAD_COPY: Partial<Record<LandingLocaleCode, DownloadCopy>> = 
       { label: 'Windows', body: '10 أو 11 (x64) — برنامج تثبيت أو ملف zip محمول.' },
       { label: 'Linux', body: 'AppImage، أو إعداد بنقرة واحدة عبر Docker / Podman Compose.' },
     ],
-    allReleasesTitle: 'جميع الإصدارات وقيم التحقق',
+    allReleasesTitle: 'جميع الإصدارات',
     allReleasesBody:
-      'كل بناء وقيمة تحقق وإصدار سابق موجود على GitHub Releases وعلى releases.open-design.ai.',
+      'كل بناء وإصدار سابق موجود على GitHub Releases وعلى releases.open-design.ai.',
     ctaTitle: 'تفضّل الطرفية؟',
     ctaBody:
       'ثبّت من المصدر بثلاثة أوامر، أو شغّل Open Design بوضع headless من وكيل البرمجة الحالي لديك.',
@@ -3885,9 +3883,9 @@ const COMPACT_DOWNLOAD_COPY: Partial<Record<LandingLocaleCode, DownloadCopy>> = 
       { label: 'Windows', body: '10 veya 11 (x64) — yükleyici veya taşınabilir zip.' },
       { label: 'Linux', body: 'AppImage veya Docker / Podman Compose ile tek tıkla kurulum.' },
     ],
-    allReleasesTitle: 'Tüm sürümler ve sağlama toplamları',
+    allReleasesTitle: 'Tüm sürümler',
     allReleasesBody:
-      'Her derleme, sağlama toplamı ve geçmiş sürüm GitHub Releases ve releases.open-design.ai üzerindedir.',
+      'Her derleme ve geçmiş sürüm GitHub Releases ve releases.open-design.ai üzerindedir.',
     ctaTitle: 'Terminali mi tercih edersiniz?',
     ctaBody:
       'Kaynaktan üç komutla kurun veya Open Design’i mevcut kodlama aracınızdan headless olarak çalıştırın.',
@@ -3920,9 +3918,9 @@ const COMPACT_DOWNLOAD_COPY: Partial<Record<LandingLocaleCode, DownloadCopy>> = 
       { label: 'Windows', body: '10 або 11 (x64) — інсталятор або портативний zip.' },
       { label: 'Linux', body: 'AppImage або встановлення в один клік через Docker / Podman Compose.' },
     ],
-    allReleasesTitle: 'Усі випуски та контрольні суми',
+    allReleasesTitle: 'Усі випуски',
     allReleasesBody:
-      'Кожна збірка, контрольна сума й попередня версія — на GitHub Releases і releases.open-design.ai.',
+      'Кожна збірка й попередня версія — на GitHub Releases і releases.open-design.ai.',
     ctaTitle: 'Надаєте перевагу терміналу?',
     ctaBody:
       'Встановіть із джерел трьома командами або керуйте Open Design у headless-режимі з наявного агента для кодування.',
@@ -4205,7 +4203,6 @@ INFO_PAGE_COPY.zh = {
     linuxBody: 'AppImage 以及 Docker / Podman Compose 一键搭建，见 release 页面。',
     installer: '安装版',
     portable: '便携版',
-    checksum: 'SHA-256',
     downloadVerb: '下载',
     requirementsTitle: '系统要求',
     requirements: [
@@ -4214,7 +4211,7 @@ INFO_PAGE_COPY.zh = {
       { label: 'Linux', body: 'AppImage，或 Docker / Podman Compose 一键搭建。' },
     ],
     allReleasesTitle: '全部版本',
-    allReleasesBody: '每个构建、校验和与历史版本都在 GitHub Releases 与 releases.open-design.ai 上。',
+    allReleasesBody: '每个构建与历史版本都在 GitHub Releases 与 releases.open-design.ai 上。',
     ctaTitle: '更喜欢用终端？',
     ctaBody: '三条命令从源码安装，或用你现有的编码 agent 以 headless 方式驱动 Open Design。',
   },

--- a/apps/landing-page/app/pages/download/index.astro
+++ b/apps/landing-page/app/pages/download/index.astro
@@ -2,14 +2,15 @@
 /*
  * /download/ — dedicated download center.
  *
- * Auto-reflects the latest GitHub release. The platform matrix is
- * rendered at build time from `getLatestRelease()` (SEO-friendly, works
+ * Auto-reflects the latest stable release. The platform matrix is
+ * rendered at build time from `getLatestStableRelease()` (SEO-friendly, works
  * without JS); an inline enhancer detects the visitor's OS, highlights
- * the matching row, and refetches `releases/latest` to keep hrefs live
- * between rebuilds. Asset-name conventions mirror header-enhancer.astro.
+ * the matching row, and refetches the canonical R2 metadata to keep the
+ * complete visible release snapshot current between rebuilds.
  */
 import Layout from '../../_components/sub-page-layout.astro';
-import { getLatestRelease, type ReleaseAsset } from '../../_lib/github';
+import { getLatestStableRelease, type ReleaseAsset } from '../../_lib/github';
+import { RELEASE_METADATA_URL } from '../../_lib/release-metadata';
 import { getInfoPageCopy } from '../../info-page-i18n';
 import { localeFromPath, localizedHref } from '../../i18n';
 
@@ -19,7 +20,7 @@ const copy = getInfoPageCopy(locale);
 const page = copy.download;
 const common = copy.common;
 
-const release = await getLatestRelease();
+const release = await getLatestStableRelease();
 const m = release.matrix;
 const directAssets = {
   macArm64: m.macArm64Dmg?.url ?? '',
@@ -189,15 +190,19 @@ const jsonLd = [
             <span data-dl-auto-label>{page.autoCtaFallback}</span>
             <span class="dl-auto-os" data-dl-auto-os hidden></span>
           </a>
-          <a class="dl-hero-release-link" href={release.releaseUrl} target="_blank" rel="noreferrer noopener">
+          <a class="dl-hero-release-link" href={release.releaseUrl} data-release-notes-link target="_blank" rel="noreferrer noopener">
             {page.releaseNotes} ↗
           </a>
         </div>
         <p class="dl-hero-meta">
-          <a class="inline-link" href={release.releaseUrl} target="_blank" rel="noreferrer noopener">
-            {release.versionLabel}
+          <a class="inline-link" href={release.releaseUrl} data-release-notes-link target="_blank" rel="noreferrer noopener">
+            <span data-release-version>{release.versionLabel}</span>
           </a>
-          {publishedLabel && <span class="dl-version-date"> · {page.publishedPrefix} {publishedLabel}</span>}
+          {publishedLabel && (
+            <span class="dl-version-date">
+              {' · '}{page.publishedPrefix} <span data-release-date>{publishedLabel}</span>
+            </span>
+          )}
         </p>
       </div>
 
@@ -225,7 +230,7 @@ const jsonLd = [
             <h2 class="dl-os">{card.osLabel}</h2>
             <p class="dl-card-sub">
               {card.arch && <span class="dl-arch">{card.arch}</span>}
-              <span class="dl-card-version">{release.versionLabel}</span>
+              <span class="dl-card-version" data-release-version>{release.versionLabel}</span>
             </p>
 
             {card.rows.length > 0 && (
@@ -237,11 +242,8 @@ const jsonLd = [
                         <a class="dl-link" href={row.asset.url} data-dl-key={row.key}>
                           <span class="dl-dl-icon" aria-hidden="true">{ICON_DOWNLOAD}</span>
                           {page.downloadVerb} <strong>{row.variant}</strong>
-                          {fmtSize(row.asset.size) && <span class="dl-size">{fmtSize(row.asset.size)}</span>}
+                          {fmtSize(row.asset.size) && <span class="dl-size" data-dl-size>{fmtSize(row.asset.size)}</span>}
                         </a>
-                        {row.asset.sha256Url && (
-                          <a class="dl-sha" href={row.asset.sha256Url} target="_blank" rel="noreferrer noopener">{page.checksum}</a>
-                        )}
                       </>
                     ) : (
                       <a class="dl-link dl-link-fallback" href={release.releaseUrl} target="_blank" rel="noreferrer noopener">
@@ -260,7 +262,7 @@ const jsonLd = [
              */}
             {card.note && (
               <p class="dl-note">
-                <a class="inline-link" href={release.releaseUrl} target="_blank" rel="noreferrer noopener">{card.note}</a>
+                <a class="inline-link" href={release.releaseUrl} data-release-notes-link target="_blank" rel="noreferrer noopener">{card.note}</a>
               </p>
             )}
           </div>
@@ -291,13 +293,20 @@ const jsonLd = [
       </div>
       <div class="info-cta-meta">
         <span class="stamp">● {common.live}</span>
-        <span>{release.versionLabel} · Apache-2.0</span>
+        <span><span data-release-version>{release.versionLabel}</span> · Apache-2.0</span>
         <span>{common.macWinLinux}</span>
       </div>
     </section>
   </article>
 
-  <script is:inline define:vars={{ autoPrefix: page.autoCtaPrefix, directAssets }}>
+  <script
+    is:inline
+    define:vars={{
+      autoPrefix: page.autoCtaPrefix,
+      directAssets,
+      releaseMetadataUrl: RELEASE_METADATA_URL,
+    }}
+  >
     (() => {
       // Download-intent analytics: capture clicks on the hero auto-CTA and on
       // every platform card link so the /download/ funnel is measurable. PostHog
@@ -325,8 +334,6 @@ const jsonLd = [
           if (auto) { fire('auto-detected', auto); return; }
         });
       })();
-
-      const REPO_API = 'https://api.github.com/repos/nexu-io/open-design';
 
       const ua = (navigator.userAgent || '').toLowerCase();
       const devicePlatform = (
@@ -380,25 +387,26 @@ const jsonLd = [
       };
 
       const platform = detect();
-      if (!platform) return;
 
       // Highlight the recommended card + set the hero CTA OS label.
-      for (const card of document.querySelectorAll('[data-dl-card]')) {
-        if (card.getAttribute('data-dl-match') === platform.matchKey) {
-          card.setAttribute('data-dl-recommended', 'true');
-          const rec = card.querySelector('[data-dl-rec]');
-          if (rec) rec.hidden = false;
+      if (platform) {
+        for (const card of document.querySelectorAll('[data-dl-card]')) {
+          if (card.getAttribute('data-dl-match') === platform.matchKey) {
+            card.setAttribute('data-dl-recommended', 'true');
+            const rec = card.querySelector('[data-dl-rec]');
+            if (rec) rec.hidden = false;
+          }
         }
+        const osSlot = document.querySelector('[data-dl-auto-os]');
+        const labelSlot = document.querySelector('[data-dl-auto-label]');
+        if (osSlot) { osSlot.textContent = ` ${platform.os}`; osSlot.hidden = false; }
+        if (labelSlot) labelSlot.textContent = autoPrefix;
       }
-      const osSlot = document.querySelector('[data-dl-auto-os]');
-      const labelSlot = document.querySelector('[data-dl-auto-label]');
-      if (osSlot) { osSlot.textContent = ` ${platform.os}`; osSlot.hidden = false; }
-      if (labelSlot) labelSlot.textContent = autoPrefix;
 
       // Use the build-time latest asset immediately, closing the short window
       // where the primary CTA could still route through the download page.
       const hero = document.querySelector('[data-dl-auto]');
-      const staticAsset = directAssets[platform.assetKey];
+      const staticAsset = platform ? directAssets[platform.assetKey] : null;
       if (hero && staticAsset) {
         hero.href = staticAsset;
         hero.setAttribute('download', '');
@@ -406,36 +414,95 @@ const jsonLd = [
         hero.removeAttribute('rel');
       }
 
-      // Live refetch: keep the hero CTA + matrix links current between rebuilds.
-      fetch(`${REPO_API}/releases/latest`, { headers: { Accept: 'application/vnd.github+json' } })
+      // Live refetch: replace the complete visible release snapshot from the
+      // canonical stable R2 metadata, so labels and links cannot drift apart.
+      fetch(releaseMetadataUrl, { headers: { Accept: 'application/json' } })
         .then((r) => (r.ok ? r.json() : null))
-        .then((release) => {
-          const assets = Array.isArray(release && release.assets) ? release.assets : [];
-          if (assets.length === 0) return;
-          const byName = (re) =>
-            assets.find((a) => a && typeof a.name === 'string' && typeof a.browser_download_url === 'string' && re(a.name));
-          const map = {
-            'mac-arm64-dmg': (n) => n.endsWith('mac-arm64.dmg'),
-            'mac-arm64-zip': (n) => n.endsWith('mac-arm64.zip'),
-            'mac-x64-dmg': (n) => n.endsWith('mac-x64.dmg'),
-            'mac-x64-zip': (n) => n.endsWith('mac-x64.zip'),
-            'win-setup': (n) => /win.*setup\.exe$/.test(n),
-            'win-portable': (n) => /win.*portable\.zip$/.test(n),
-            'linux-appimage': (n) => /\.appimage$/i.test(n),
+        .then((metadata) => {
+          if (!metadata || metadata.channel !== 'stable' || metadata.releaseState !== 'complete') return;
+          const versionMatch = typeof metadata.releaseVersion === 'string'
+            ? metadata.releaseVersion.match(/^v?(\d+\.\d+\.\d+(?:[-+][\w.-]+)?)$/)
+            : null;
+          if (!versionMatch || !metadata.platforms || typeof metadata.platforms !== 'object') return;
+          const releaseVersion = versionMatch[1];
+          const expectedTag = `open-design-v${releaseVersion}`;
+          if (metadata.versionTag !== expectedTag) return;
+          const versionPrefix = `/stable/versions/${releaseVersion}`;
+
+          const artifact = (platformKey, artifactKey) => {
+            const value = metadata.platforms?.[platformKey]?.artifacts?.[artifactKey];
+            if (!value || typeof value.url !== 'string' || !Number.isFinite(value.size) || value.size <= 0) return null;
+            try {
+              const url = new URL(value.url);
+              if (
+                url.origin !== 'https://releases.open-design.ai' ||
+                (url.pathname !== versionPrefix &&
+                  !url.pathname.startsWith(`${versionPrefix}/`) &&
+                  !url.pathname.startsWith(`${versionPrefix}.`))
+              ) return null;
+            } catch {
+              return null;
+            }
+            return { url: value.url, size: value.size };
           };
-          for (const [key, re] of Object.entries(map)) {
-            const asset = byName(re);
-            if (!asset) continue;
-            for (const link of document.querySelectorAll(`[data-dl-key="${key}"]`)) {
-              link.href = asset.browser_download_url;
+          const assets = {
+            'mac-arm64-dmg': artifact('mac', 'dmg'),
+            'mac-x64-dmg': artifact('macIntel', 'dmg'),
+            'win-setup': artifact('win', 'installer'),
+            'linux-appimage': artifact('linux', 'appImage') || artifact('linux', 'appimage'),
+          };
+          const linkUpdates = [];
+          for (const link of document.querySelectorAll('[data-dl-key]')) {
+            const key = link.getAttribute('data-dl-key');
+            const asset = key ? assets[key] : null;
+            if (!key || !asset) return;
+            linkUpdates.push({ link, asset });
+          }
+          const versionLabel = `v${releaseVersion}`;
+          const releaseDate = typeof metadata.generatedAt === 'string'
+            ? metadata.generatedAt.slice(0, 10)
+            : null;
+          const releaseUrl = `https://github.com/nexu-io/open-design/releases/tag/${encodeURIComponent(expectedTag)}`;
+          const formatSize = (bytes) => {
+            const mb = bytes / (1024 * 1024);
+            return mb >= 1 ? `${mb.toFixed(0)} MB` : `${(bytes / 1024).toFixed(0)} KB`;
+          };
+
+          for (const slot of document.querySelectorAll('[data-release-version]')) {
+            slot.textContent = versionLabel;
+          }
+          if (releaseDate) {
+            for (const slot of document.querySelectorAll('[data-release-date]')) {
+              slot.textContent = releaseDate;
             }
           }
-          const heroAsset = byName(platform.match);
+          if (releaseUrl) {
+            for (const link of document.querySelectorAll('[data-release-notes-link]')) {
+              link.href = releaseUrl;
+            }
+          }
+          for (const { link, asset } of linkUpdates) {
+            link.href = asset.url;
+            const size = link.querySelector('[data-dl-size]');
+            if (size) size.textContent = formatSize(asset.size);
+          }
+          const heroAssetKey = platform && {
+            macArm64: 'mac-arm64-dmg',
+            macX64: 'mac-x64-dmg',
+            windows: 'win-setup',
+            linux: 'linux-appimage',
+          }[platform.assetKey];
+          const heroAsset = heroAssetKey ? assets[heroAssetKey] : null;
           if (heroAsset && hero) {
-            hero.href = heroAsset.browser_download_url;
+            hero.href = heroAsset.url;
             hero.setAttribute('download', '');
             hero.removeAttribute('target');
             hero.removeAttribute('rel');
+          } else if (releaseUrl && hero) {
+            hero.href = releaseUrl;
+            hero.removeAttribute('download');
+            hero.setAttribute('target', '_blank');
+            hero.setAttribute('rel', 'noreferrer noopener');
           }
         })
         .catch(() => {});
@@ -813,8 +880,6 @@ const jsonLd = [
   .dl-link:hover .dl-dl-icon { transform: translateY(2px); }
   .dl-size { font-size: 0.74rem; opacity: 0.55; }
   /* Skill link color (颜色.md 链接/信息) instead of the UA default blue. */
-  .dl-sha { font-size: 0.68rem; opacity: 0.5; text-decoration: none; color: #1a74ff; }
-  .dl-sha:hover { opacity: 1; text-decoration: underline; }
   .dl-note {
     font-size: 0.82rem;
     opacity: 0.78;

--- a/apps/landing-page/functions/release-metadata.ts
+++ b/apps/landing-page/functions/release-metadata.ts
@@ -7,7 +7,7 @@ type PagesFunctionContext<Env> = {
 
 type PagesFunction<Env> = (context: PagesFunctionContext<Env>) => Response | Promise<Response>;
 
-const CACHE_CONTROL = 'public, max-age=300, s-maxage=300, stale-while-revalidate=3600';
+const CACHE_CONTROL = 'public, max-age=60, s-maxage=60, stale-while-revalidate=300';
 
 export const onRequest: PagesFunction<Record<string, never>> = async () => {
   const response = await fetch(RELEASE_METADATA_UPSTREAM_URL, {

--- a/apps/landing-page/package.json
+++ b/apps/landing-page/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "tsx scripts/vendor-enhancers.ts && astro dev --host 127.0.0.1 --port 17574",
     "build": "astro check && pnpm run build:static",
-    "build:static": "tsx scripts/vendor-enhancers.ts && astro build && tsx scripts/verify-localized-template-routes.ts && tsx scripts/copy-example-html.ts",
+    "build:static": "pnpm test && tsx scripts/vendor-enhancers.ts && astro build && tsx scripts/verify-localized-template-routes.ts && tsx scripts/copy-example-html.ts",
     "vendor:enhancers": "tsx scripts/vendor-enhancers.ts",
     "preview": "astro preview --host 127.0.0.1 --port 17574",
     "previews": "tsx scripts/generate-previews.ts",

--- a/apps/landing-page/tests/download-release-refresh.test.ts
+++ b/apps/landing-page/tests/download-release-refresh.test.ts
@@ -1,0 +1,422 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+
+import { getInfoPageCopy } from '../app/info-page-i18n.ts';
+import { LANDING_LOCALES } from '../app/i18n.ts';
+
+const downloadPagePath = new URL('../app/pages/download/index.astro', import.meta.url);
+
+type FakeElement = {
+  href: string;
+  hidden: boolean;
+  textContent: string;
+  attributes: Map<string, string>;
+  getAttribute(name: string): string | null;
+  setAttribute(name: string, value: string): void;
+  removeAttribute(name: string): void;
+  querySelector(selector: string): FakeElement | null;
+};
+
+function element(options: Partial<Pick<FakeElement, 'href' | 'hidden' | 'textContent'>> = {}): FakeElement {
+  const children = new Map<string, FakeElement>();
+  const attributes = new Map<string, string>();
+  return {
+    href: options.href ?? '',
+    hidden: options.hidden ?? false,
+    textContent: options.textContent ?? '',
+    attributes,
+    getAttribute(name) {
+      if (name === 'href') return this.href;
+      return attributes.get(name) ?? null;
+    },
+    setAttribute(name, value) {
+      attributes.set(name, String(value));
+    },
+    removeAttribute(name) {
+      attributes.delete(name);
+    },
+    querySelector(selector) {
+      return children.get(selector) ?? null;
+    },
+  };
+}
+
+function extractEnhancer(page: string): string {
+  const scriptTag = page.indexOf('<script', page.indexOf('</article>'));
+  const start = page.indexOf('    (() => {', scriptTag);
+  const scriptEnd = page.indexOf('  </script>', start);
+  const endMarker = '    })();';
+  const end = page.lastIndexOf(endMarker, scriptEnd);
+  assert.ok(scriptTag >= 0 && start >= 0 && end > start, 'download release enhancer not found');
+  return page.slice(start, end + endMarker.length);
+}
+
+test('download page refreshes the complete stable release snapshot on entry', async () => {
+  const page = await readFile(downloadPagePath, 'utf8');
+  const enhancer = extractEnhancer(page);
+
+  const hero = element({ href: 'https://releases.open-design.ai/stable/versions/0.17.0/open-design-0.17.0-mac-arm64.dmg' });
+  const notice = element({ hidden: true });
+  const osSlot = element({ hidden: true });
+  const labelSlot = element({ textContent: 'Download' });
+  const versionSlots = [element({ textContent: 'v0.17.0' }), element({ textContent: 'v0.17.0' })];
+  const dateSlot = element({ textContent: '2026-08-03' });
+  const releaseLink = element({ href: 'https://github.com/nexu-io/open-design/releases/tag/open-design-v0.17.0' });
+  const sizeSlot = element({ textContent: '280 MB' });
+  const macDownload = element({
+    href: 'https://releases.open-design.ai/stable/versions/0.17.0/open-design-0.17.0-mac-arm64.dmg',
+  });
+  macDownload.setAttribute('data-dl-key', 'mac-arm64-dmg');
+  macDownload.querySelector = (selector) => (selector === '[data-dl-size]' ? sizeSlot : null);
+
+  const cardRecommendation = element({ hidden: true });
+  const card = element();
+  card.setAttribute('data-dl-match', 'mac-arm64');
+  card.querySelector = (selector) => (selector === '[data-dl-rec]' ? cardRecommendation : null);
+
+  const selectors = new Map<string, FakeElement[]>([
+    ['[data-dl-card]', [card]],
+    ['[data-release-version]', versionSlots],
+    ['[data-release-date]', [dateSlot]],
+    ['[data-release-notes-link]', [releaseLink]],
+    ['[data-dl-key]', [macDownload]],
+    ['[data-dl-key="mac-arm64-dmg"]', [macDownload]],
+    ['[data-dl-key="mac-x64-dmg"]', []],
+    ['[data-dl-key="win-setup"]', []],
+    ['[data-dl-key="linux-appimage"]', []],
+  ]);
+  const document = {
+    addEventListener() {},
+    querySelector(selector: string) {
+      if (selector === '[data-dl-mobile-notice]') return notice;
+      if (selector === '[data-dl-auto]') return hero;
+      if (selector === '[data-dl-auto-os]') return osSlot;
+      if (selector === '[data-dl-auto-label]') return labelSlot;
+      return null;
+    },
+    querySelectorAll(selector: string) {
+      return selectors.get(selector) ?? [];
+    },
+    createElement() {
+      return {
+        getContext: () => ({
+          getExtension: () => ({ UNMASKED_RENDERER_WEBGL: 1 }),
+          getParameter: () => 'Apple GPU',
+        }),
+      };
+    },
+  };
+  const window = {
+    matchMedia: () => ({ matches: false, addEventListener() {} }),
+    __odTrack: undefined,
+    posthog: undefined,
+  };
+  const navigator = {
+    userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+    platform: 'MacIntel',
+    maxTouchPoints: 0,
+  };
+  const requestedUrls: string[] = [];
+  let responseMetadata = {
+    channel: 'stable',
+    releaseState: 'complete',
+    releaseVersion: '0.18.0',
+    versionTag: 'open-design-v0.18.0',
+    generatedAt: '2026-08-05T17:31:11.878Z',
+    platforms: {
+      mac: {
+        artifacts: {
+          dmg: {
+            name: 'open-design-0.18.0-mac-arm64.dmg',
+            size: 300_329_080,
+            url: 'https://releases.open-design.ai/stable/versions/0.18.0/open-design-0.18.0-mac-arm64.dmg',
+          },
+        },
+      },
+    },
+  };
+  const fetch = async (url: string) => {
+    requestedUrls.push(url);
+    return {
+      ok: true,
+      async json() {
+        return responseMetadata;
+      },
+    };
+  };
+
+  const runEnhancer = () => {
+    // Execute the production inline enhancer against the current static snapshot.
+    // eslint-disable-next-line no-new-func
+    new Function(
+      'window',
+      'navigator',
+      'document',
+      'fetch',
+      'autoPrefix',
+      'directAssets',
+      'releaseMetadataUrl',
+      enhancer,
+    )(
+      window,
+      navigator,
+      document,
+      fetch,
+      'Download for',
+      { macArm64: hero.href },
+      '/release-metadata',
+    );
+  };
+
+  runEnhancer();
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(requestedUrls, ['/release-metadata']);
+  assert.deepEqual(versionSlots.map((slot) => slot.textContent), ['v0.18.0', 'v0.18.0']);
+  assert.equal(dateSlot.textContent, '2026-08-05');
+  assert.match(releaseLink.href, /open-design-v0\.18\.0$/);
+  assert.match(macDownload.href, /stable\/versions\/0\.18\.0\/open-design-0\.18\.0-mac-arm64\.dmg$/);
+  assert.equal(sizeSlot.textContent, '286 MB');
+  assert.equal(hero.href, macDownload.href);
+
+  responseMetadata = {
+    ...responseMetadata,
+    releaseVersion: '0.19.0',
+    versionTag: 'open-design-v0.18.0',
+    platforms: {
+      mac: {
+        artifacts: {
+          dmg: {
+            name: 'open-design-0.19.0-mac-arm64.dmg',
+            size: 310_000_000,
+            url: 'https://releases.open-design.ai/stable/versions/0.19.0/open-design-0.19.0-mac-arm64.dmg',
+          },
+        },
+      },
+    },
+  };
+  runEnhancer();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(versionSlots.map((slot) => slot.textContent), ['v0.18.0', 'v0.18.0']);
+  assert.match(macDownload.href, /stable\/versions\/0\.18\.0\//);
+
+  responseMetadata = {
+    ...responseMetadata,
+    versionTag: 'open-design-v0.19.0',
+    platforms: {
+      mac: {
+        artifacts: {
+          dmg: {
+            name: 'open-design-0.18.0-mac-arm64.dmg',
+            size: 300_329_080,
+            url: 'https://releases.open-design.ai/stable/versions/0.18.0/open-design-0.18.0-mac-arm64.dmg',
+          },
+        },
+      },
+    },
+  };
+  runEnhancer();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.equal(requestedUrls.length, 3);
+  assert.deepEqual(versionSlots.map((slot) => slot.textContent), ['v0.18.0', 'v0.18.0']);
+  assert.match(macDownload.href, /stable\/versions\/0\.18\.0\//);
+});
+
+test('download page keeps the static snapshot when stable metadata is incomplete', async () => {
+  const page = await readFile(downloadPagePath, 'utf8');
+  const enhancer = extractEnhancer(page);
+
+  const hero = element({ href: 'https://releases.open-design.ai/stable/versions/0.17.0/open-design-0.17.0-mac-arm64.dmg' });
+  const versionSlot = element({ textContent: 'v0.17.0' });
+  const dateSlot = element({ textContent: '2026-08-03' });
+  const releaseLink = element({ href: 'https://github.com/nexu-io/open-design/releases/tag/open-design-v0.17.0' });
+  const sizeSlot = element({ textContent: '280 MB' });
+  const macDownload = element({ href: hero.href });
+  macDownload.setAttribute('data-dl-key', 'mac-arm64-dmg');
+  macDownload.querySelector = (selector) => (selector === '[data-dl-size]' ? sizeSlot : null);
+
+  const selectors = new Map<string, FakeElement[]>([
+    ['[data-dl-card]', []],
+    ['[data-release-version]', [versionSlot]],
+    ['[data-release-date]', [dateSlot]],
+    ['[data-release-notes-link]', [releaseLink]],
+    ['[data-dl-key]', [macDownload]],
+    ['[data-dl-key="mac-arm64-dmg"]', [macDownload]],
+    ['[data-dl-key="mac-x64-dmg"]', []],
+    ['[data-dl-key="win-setup"]', []],
+    ['[data-dl-key="linux-appimage"]', []],
+  ]);
+  const document = {
+    addEventListener() {},
+    querySelector(selector: string) {
+      if (selector === '[data-dl-auto]') return hero;
+      return null;
+    },
+    querySelectorAll(selector: string) {
+      return selectors.get(selector) ?? [];
+    },
+    createElement() {
+      return {
+        getContext: () => ({
+          getExtension: () => ({ UNMASKED_RENDERER_WEBGL: 1 }),
+          getParameter: () => 'Apple GPU',
+        }),
+      };
+    },
+  };
+  const window = {
+    matchMedia: () => ({ matches: false, addEventListener() {} }),
+    __odTrack: undefined,
+    posthog: undefined,
+  };
+  const navigator = {
+    userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+    platform: 'MacIntel',
+    maxTouchPoints: 0,
+  };
+  const fetch = async () => ({
+    ok: true,
+    async json() {
+      return {
+        channel: 'stable',
+        releaseState: 'complete',
+        releaseVersion: '0.18.0',
+        versionTag: 'open-design-v0.18.0',
+        generatedAt: '2026-08-05T17:31:11.878Z',
+        platforms: { mac: { artifacts: {} } },
+      };
+    },
+  });
+
+  // eslint-disable-next-line no-new-func
+  new Function(
+    'window',
+    'navigator',
+    'document',
+    'fetch',
+    'autoPrefix',
+    'directAssets',
+    'releaseMetadataUrl',
+    enhancer,
+  )(
+    window,
+    navigator,
+    document,
+    fetch,
+    'Download for',
+    { macArm64: hero.href },
+    '/release-metadata',
+  );
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.equal(versionSlot.textContent, 'v0.17.0');
+  assert.equal(dateSlot.textContent, '2026-08-03');
+  assert.match(releaseLink.href, /open-design-v0\.17\.0$/);
+  assert.match(macDownload.href, /stable\/versions\/0\.17\.0\//);
+  assert.equal(sizeSlot.textContent, '280 MB');
+  assert.equal(hero.href, macDownload.href);
+});
+
+test('download page does not expose checksum actions', async () => {
+  const page = await readFile(downloadPagePath, 'utf8');
+
+  assert.doesNotMatch(page, /class="dl-sha"/);
+  assert.doesNotMatch(page, /row\.asset\.sha256Url/);
+  assert.doesNotMatch(page, /page\.checksum/);
+});
+
+test('localized download links do not advertise checksums', () => {
+  const checksumTerms =
+    /checksum|チェックサム|체크섬|prüfsumm|sommes? de contrôle|контрольн|sumas? de verificación|somas? de verificação|sağlama toplam/iu;
+
+  for (const locale of LANDING_LOCALES) {
+    assert.doesNotMatch(
+      [
+        getInfoPageCopy(locale.code).download.allReleasesTitle,
+        getInfoPageCopy(locale.code).download.allReleasesBody,
+      ].join(' '),
+      checksumTerms,
+      `download release copy exposes checksums for ${locale.code}`,
+    );
+  }
+});
+
+test('download page refreshes the neutral release link when no desktop platform is detected', async () => {
+  const page = await readFile(downloadPagePath, 'utf8');
+  const enhancer = extractEnhancer(page);
+  const hero = element({ href: 'https://github.com/nexu-io/open-design/releases/tag/open-design-v0.17.0' });
+  const versionSlot = element({ textContent: 'v0.17.0' });
+  const requestedUrls: string[] = [];
+  const document = {
+    addEventListener() {},
+    querySelector(selector: string) {
+      if (selector === '[data-dl-auto]') return hero;
+      return null;
+    },
+    querySelectorAll(selector: string) {
+      if (selector === '[data-release-version]') return [versionSlot];
+      return [];
+    },
+    createElement() {
+      throw new Error('mobile platform detection must not probe WebGL');
+    },
+  };
+  const window = {
+    matchMedia: () => ({ matches: true, addEventListener() {} }),
+    __odTrack: undefined,
+    posthog: undefined,
+  };
+  const navigator = {
+    userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) Mobile',
+    platform: 'iPhone',
+    maxTouchPoints: 5,
+  };
+  const fetch = async (url: string) => {
+    requestedUrls.push(url);
+    return {
+      ok: true,
+      async json() {
+        return {
+          channel: 'stable',
+          releaseState: 'complete',
+          releaseVersion: '0.18.0',
+          versionTag: 'open-design-v0.18.0',
+          generatedAt: '2026-08-05T17:31:11.878Z',
+          platforms: {},
+        };
+      },
+    };
+  };
+
+  // eslint-disable-next-line no-new-func
+  new Function(
+    'window',
+    'navigator',
+    'document',
+    'fetch',
+    'autoPrefix',
+    'directAssets',
+    'releaseMetadataUrl',
+    enhancer,
+  )(
+    window,
+    navigator,
+    document,
+    fetch,
+    'Download for',
+    {},
+    '/release-metadata',
+  );
+
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(requestedUrls, ['/release-metadata']);
+  assert.equal(versionSlot.textContent, 'v0.18.0');
+  assert.match(hero.href, /open-design-v0\.18\.0$/);
+  assert.equal(hero.attributes.has('download'), false);
+});

--- a/apps/landing-page/tests/header-download-cta.test.ts
+++ b/apps/landing-page/tests/header-download-cta.test.ts
@@ -52,7 +52,7 @@ function runDownloadDirectAssetGate(
   options: { userAgent: string; platform: string; maxTouchPoints: number },
 ) {
   const start = page.indexOf("      const ua = (navigator.userAgent || '').toLowerCase();");
-  const endMarker = '      // Live refetch: keep the hero CTA + matrix links current between rebuilds.';
+  const endMarker = '      // Live refetch: replace the complete visible release snapshot from the';
   const end = page.indexOf(endMarker, start);
   assert.ok(start >= 0 && end > start, 'download direct-asset enhancer not found');
   const script = page.slice(start, end);

--- a/apps/landing-page/tests/release-metadata.test.ts
+++ b/apps/landing-page/tests/release-metadata.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { onRequest } from '../functions/release-metadata.ts';
+
+test('release metadata proxy keeps the stable snapshot fresh within one minute', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response('{"releaseVersion":"0.18.0"}', {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  try {
+    const response = await onRequest({
+      request: new Request('https://open-design.ai/release-metadata'),
+      env: {},
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(
+      response.headers.get('Cache-Control'),
+      'public, max-age=60, s-maxage=60, stale-while-revalidate=300',
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/apps/landing-page/tests/stable-release-contract.test.ts
+++ b/apps/landing-page/tests/stable-release-contract.test.ts
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { fetchLatestStableRelease } from '../app/_lib/github.ts';
+import { RELEASE_METADATA_UPSTREAM_URL } from '../app/_lib/release-metadata.ts';
+
+function completeStableMetadata() {
+  return {
+    channel: 'stable',
+    releaseState: 'complete',
+    releaseVersion: '0.18.0',
+    versionTag: 'open-design-v0.18.0',
+    generatedAt: '2026-08-05T17:31:11.878Z',
+    platforms: {
+      mac: {
+        artifacts: {
+          dmg: {
+            name: 'open-design-0.18.0-mac-arm64.dmg',
+            size: 300_329_080,
+            url: 'https://releases.open-design.ai/stable/versions/0.18.0/open-design-0.18.0-mac-arm64.dmg',
+          },
+        },
+      },
+      macIntel: {
+        artifacts: {
+          dmg: {
+            name: 'open-design-0.18.0-mac-x64.dmg',
+            size: 310_378_496,
+            url: 'https://releases.open-design.ai/stable/versions/0.18.0/open-design-0.18.0-mac-x64.dmg',
+          },
+        },
+      },
+      win: {
+        artifacts: {
+          installer: {
+            name: 'open-design-0.18.0-win-x64-setup.exe',
+            size: 326_107_136,
+            url: 'https://releases.open-design.ai/stable/versions/0.18.0/open-design-0.18.0-win-x64-setup.exe',
+          },
+        },
+      },
+    },
+  };
+}
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+test('download build snapshot comes from one complete stable R2 manifest', async () => {
+  const requestedUrls: string[] = [];
+  const release = await fetchLatestStableRelease(async (input) => {
+    requestedUrls.push(String(input));
+    return jsonResponse(completeStableMetadata());
+  });
+
+  assert.deepEqual(requestedUrls, [RELEASE_METADATA_UPSTREAM_URL]);
+  assert.equal(release.versionLabel, 'v0.18.0');
+  assert.equal(release.tagName, 'open-design-v0.18.0');
+  assert.equal(release.publishedAt, '2026-08-05T17:31:11.878Z');
+  assert.match(release.matrix.macArm64Dmg?.url ?? '', /stable\/versions\/0\.18\.0\//);
+  assert.match(release.matrix.macX64Dmg?.url ?? '', /stable\/versions\/0\.18\.0\//);
+  assert.match(release.matrix.winSetup?.url ?? '', /stable\/versions\/0\.18\.0\//);
+});
+
+test('download build rejects a partial stable R2 manifest', async () => {
+  await assert.rejects(
+    fetchLatestStableRelease(async () => new Response(JSON.stringify({
+      channel: 'stable',
+      releaseState: 'partial',
+      releaseVersion: '0.19.0',
+      platforms: {},
+    }), { status: 200 })),
+    /not complete/,
+  );
+});
+
+test('download build rejects a complete manifest without the required desktop installers', async () => {
+  await assert.rejects(
+    fetchLatestStableRelease(async () => new Response(JSON.stringify({
+      channel: 'stable',
+      releaseState: 'complete',
+      releaseVersion: '0.19.0',
+      versionTag: 'open-design-v0.19.0',
+      platforms: {},
+    }), { status: 200 })),
+    /required desktop installers/,
+  );
+});
+
+test('download build rejects installer URLs from a different stable version', async () => {
+  const metadata = completeStableMetadata();
+  metadata.platforms.mac.artifacts.dmg.url =
+    'https://releases.open-design.ai/stable/versions/0.17.0/open-design-0.17.0-mac-arm64.dmg';
+
+  await assert.rejects(
+    fetchLatestStableRelease(async () => jsonResponse(metadata)),
+    /does not match release version 0\.18\.0/,
+  );
+});
+
+test('download build rejects a release tag from a different stable version', async () => {
+  const metadata = completeStableMetadata();
+  metadata.versionTag = 'open-design-v0.17.0';
+
+  await assert.rejects(
+    fetchLatestStableRelease(async () => jsonResponse(metadata)),
+    /release tag does not match version 0\.18\.0/,
+  );
+});


### PR DESCRIPTION
## Why

The public `/download/` page could render an old version label (for example, v0.17.0) while its client-side link refresh already pointed at the v0.18.0 installer. The page assembled visible release state from different GitHub/R2 snapshots, so version, date, links, and sizes could drift apart. A prior regression also restored SHA-256 actions that had intentionally been removed.

This change makes the stable R2 manifest the single release truth and adds executable guards so the split-source behavior and checksum UI cannot be reintroduced silently.

## What users will see

On page entry, `/download/` now validates one complete stable R2 snapshot and atomically refreshes the visible version, release date, release links, installer URLs, file sizes, and platform CTA. Incomplete metadata, a mismatched release tag, or an artifact URL from another version leaves the build-time snapshot unchanged. SHA-256 links and checksum copy are no longer shown.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this fixes release data synchronization and removes checksum actions without changing the page layout or styling.

## Bug fix verification

- Test paths: `apps/landing-page/tests/download-release-refresh.test.ts`, `apps/landing-page/tests/stable-release-contract.test.ts`, and `apps/landing-page/tests/release-metadata.test.ts`
- Red on the previous implementation and green on this branch: yes. The runtime test reproduced both a stale-label/new-link split and acceptance of mismatched tag/artifact versions.
- `build:static` now runs the landing package tests first, so PR, staging, and production builds all enforce these guards.

## Validation

- `pnpm install`
- `pnpm --filter @open-design/landing-page build:static` — 112 tests passed; 6,420 pages built
- `pnpm --filter @open-design/landing-page typecheck` — 0 errors
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
