### PR TITLE
fix(web): settle project workspace scope when bootstrap arrives late

### DIFF
--- a/apps/web/src/collab/useProjectWorkspaceScope.ts
+++ b/apps/web/src/collab/useProjectWorkspaceScope.ts
@@ -377,6 +377,19 @@ export function useProjectWorkspaceScope(
     resolvedCallerIdentityKey: initialScopeCanSeed ? callerIdentityKey : 'none',
   }));
   const skipFirstActiveRevalidationRef = useRef(initialScopeCanSeed);
+  /**
+   * Whether this hook's state was actually seeded from `initialScope` at mount.
+   *
+   * Only a seeded mount already holds the answer the initial read would fetch.
+   * A route bootstrap that resolves AFTER the hook mounted flips
+   * `initialScopeCanSeed` on an already-running hook, but cannot retroactively
+   * seed state — the state initializer ran once, without it. Skipping the
+   * initial read on that late flip therefore cancels the in-flight scope GET
+   * that is the only thing able to settle `loading`, and strands the hook at
+   * `{ loading: true, scope: null }` forever (no scope also means the workspace
+   * invalidation SSE never subscribes, so no later event can re-trigger it).
+   */
+  const seededFromInitialScopeRef = useRef(initialScopeCanSeed);
 
   const scheduleDeferredRevalidation = useCallback(() => {
     // The daemon shares a short successful directory cache between the scope
@@ -467,7 +480,7 @@ export function useProjectWorkspaceScope(
     let firstAttempt = true;
     const refreshRevision = refreshRequest.revision;
 
-    if (refreshRevision === 0 && initialScopeCanSeed) {
+    if (refreshRevision === 0 && initialScopeCanSeed && seededFromInitialScopeRef.current) {
       return () => controller.abort();
     }
 

--- a/apps/web/tests/useProjectWorkspaceScope.test.tsx
+++ b/apps/web/tests/useProjectWorkspaceScope.test.tsx
@@ -590,4 +590,68 @@ describe('useProjectWorkspaceScope', () => {
     });
     expect(scopeCalls).toHaveLength(2);
   });
+
+  // A route bootstrap that answers AFTER ProjectView mounted flips
+  // `initialScope` from absent to present on an already-mounted hook. That must
+  // not strand the hook: the mount-time read is still the only thing that can
+  // settle state, because state was never seeded from the late prop.
+  //
+  // Regression: the initial-read skip keyed off the CURRENT render's
+  // "can seed" answer, so the late prop aborted the in-flight scope GET and
+  // returned without ever seeding a scope or clearing `loading`. `loading`
+  // then pinned `true` forever — and because the workspace invalidation SSE is
+  // only subscribed once a scope resolves, no later event could re-trigger the
+  // read either. ProjectView reads that stuck `loading` as
+  // `workspaceContextReadOnly`, so the whole workspace fell into the
+  // "This is a shared project — you can view and comment" read-only mode with a
+  // permanently non-editable composer.
+  it('settles when a bootstrap scope arrives after the initial read started', async () => {
+    vi.stubGlobal('EventSource', OpeningEventSource as unknown as typeof EventSource);
+    const bootstrapScope = {
+      kind: 'unbound',
+      projectId: 'project-late-bootstrap',
+      workspaceId: null,
+      context: null,
+    } as const;
+    const inFlight = deferred<Response>();
+    const scopeCalls: string[] = [];
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/workspace/context')) {
+        return Promise.resolve(new Response(JSON.stringify({ context: null }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }));
+      }
+      if (!url.includes('/workspace-scope')) {
+        throw new Error(`Unexpected fetch: ${url}`);
+      }
+      scopeCalls.push(url);
+      // The mount-time read is still in flight when the bootstrap prop lands.
+      if (scopeCalls.length === 1) return inFlight.promise;
+      return Promise.resolve(new Response(
+        JSON.stringify({ scope: bootstrapScope }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      ));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const hook = renderHook(
+      ({ initialScope }: { initialScope?: typeof bootstrapScope }) =>
+        useProjectWorkspaceScope('project-late-bootstrap', null, null, initialScope),
+      { initialProps: {} as { initialScope?: typeof bootstrapScope } },
+    );
+    await waitFor(() => expect(scopeCalls).toHaveLength(1));
+    expect(hook.result.current.loading).toBe(true);
+
+    // The route bootstrap answers now, after the hook already mounted.
+    hook.rerender({ initialScope: bootstrapScope });
+
+    await waitFor(() => {
+      expect(hook.result.current).toMatchObject({
+        loading: false,
+        scope: bootstrapScope,
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Why

The merge-gating `UI P0 (workspace-restoration)` shard went red on an **unrelated** PR
([job](https://github.com/nexu-io/open-design/actions/runs/31069183404/job/92513505149)), forcing a
re-run and blocking that author for no reason of their own. I picked it up as a flake triage, but the
shard was not lying: it caught a real product deadlock that leaves a project permanently read-only.

The pain is twofold:

- **Product** — `useProjectWorkspaceScope` can strand itself at `{ loading: true, scope: null }`
  forever. `ProjectView` reads that stuck `loading` as `workspaceContextReadOnly`, so the entire
  workspace drops into "This is a shared project — you can view and comment, but not change
  artifacts through Chat or the editing tools." mode: dead composer, disabled New sketch / New
  document / Upload / Create new design system. The user's own private project. Only a reload
  escapes it.
- **Process** — a P0 that can go red without the product being broken trains everyone to reflexively
  re-run red checks. This one *was* the product being broken, which is exactly the outcome that
  habit costs us.

## What users will see

Opening a project by URL — a deep link, a shared link, a browser reload, or any full page load
straight onto `/projects/:id/...` — no longer risks landing in a bogus read-only workspace. Before
this fix, when the route bootstrap answered a moment *after* the project view mounted, the workspace
could come up permanently locked with the "This is a shared project" banner and a composer that
could not be typed into, on a project the user owns. It stayed stuck until a manual reload.

## Surface area

- [x] **UI** — fixes a stuck read-only state in the project workspace (`apps/web`)
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

The CI failure screenshot (`test-failed-1.png`, from the run above) is the bug exactly as a user
would hit it — note the read-only banner in Design Files, the greyed-out create actions, and the
composer showing the read-only notice as its placeholder:

`ui/reports/test-results/app-restoration--P0-critic-6abe3-poser-visible-on-that-route-chromium/test-failed-1.png`

## Root cause

`useProjectWorkspaceScope` skips its mount-time scope read when the caller already handed it a
usable bootstrap scope:

```ts
if (refreshRevision === 0 && initialScopeCanSeed) {
  return () => controller.abort();
}
```

`initialScopeCanSeed` is recomputed **every render**, but the state it refers to is only ever seeded
**once**, in the `useState` initializer. `App.tsx` fills `routeProjectSnapshotRef` asynchronously
(`await bootstrapProjectRoute(...)`, `App.tsx:4276-4291`) and then forces a re-render. When that
lands *after* `ProjectView` mounted, `initialWorkspaceScope` flips `undefined -> scope`,
`initialScopeCanSeed` flips `false -> true`, and — since it is in the effect's dependency array —
the effect re-runs, **aborts the in-flight `GET /api/projects/:id/workspace-scope`, and returns
without fetching or setting state**. State keeps the `loading: true` written by the first attempt.

It is a closed deadlock: no scope means `projectWorkspaceContext(state.scope)` is null, so
`useWorkspaceInvalidation` never subscribes the workspace SSE (`workspace-events.ts:51-55`), so no
`onActive` / invalidation event can ever bump the revision and retry. Nothing re-triggers the read.

The stuck `loading` then propagates:
`ProjectView.tsx:1911` (`workspaceContextLoading: projectWorkspaceScopeState.loading`) ->
`useProjectCollab.ts:332-335` (`workspaceContextReadOnly`) ->
`useProjectCollab.ts:428` (`viewerOnly`) ->
`ProjectView.tsx:10573-10574` (`sendDisabled` + `viewerOnly` on `ChatPane`) ->
`ChatComposer` renders `contenteditable="false"`.

The Playwright trace confirms every step: the last two `workspace-scope` requests are aborted
(status `-1`, 03:52:36.103 and .112) and **no further request is ever issued** for the remaining ~50s
of the 90s budget, while the composer keeps reporting `element is not enabled` 134 times.

The fix makes the skip depend on whether state was *actually* seeded at mount, which is what the
early return always assumed. A bootstrap scope that arrives late is simply ignored — the mount-time
read it would have replaced is already in flight and now settles normally.

## Adjacent issues found and deliberately left alone

- `GET /api/projects/:id/collab/status` answers `400 WORKSPACE_CONTEXT_REQUIRED` when
  `projectIsSharedWithWorkspace` calls it with no workspace context
  (`apps/web/src/collab/project-shared-status.ts`). It is caught and falls through, so it is
  harmless today, but it is an avoidable guaranteed-400 on every project open while signed out.
- If `callerIdentityKey` changes while a hook mounted *with* a seeded scope and the seed still
  validates, `state.resolvedCallerIdentityKey` can lag the request key and the render guard returns
  `{ loading: true }`. Pre-existing and unchanged by this PR; out of scope for this fix.

Both belong in their own red spec and their own PR.

## Bug fix verification

- Test path that reproduces the bug:
  `apps/web/tests/useProjectWorkspaceScope.test.tsx` ->
  `settles when a bootstrap scope arrives after the initial read started`
- Did the test go red on `main` and green on this branch? **yes**

Red, on `origin/main` with only the test applied:

```
FAIL  tests/useProjectWorkspaceScope.test.tsx > useProjectWorkspaceScope >
      settles when a bootstrap scope arrives after the initial read started
- Expected
+ Received
  {
-   "loading": false,
-   "scope": { "context": null, "kind": "unbound",
-              "projectId": "project-late-bootstrap", "workspaceId": null },
+   "loading": true,
+   "scope": null,
  }
 Test Files  1 failed (1)
      Tests  1 failed | 10 passed (11)
```

`{ loading: true, scope: null }` is precisely the state that renders the read-only workspace in the
CI screenshot.

Green, with the fix:

```
Test Files  5 passed (5)
      Tests  63 passed (63)
```

(`useProjectWorkspaceScope`, `useProjectWorkspaceScope.workspace-identity`,
`single-flight-project-reads`, `use-project-collab.created-by-viewer`, `run-workspace-identity`.)

The e2e case that caught this — `e2e/ui/app-restoration.test.ts:536` — is deliberately **unchanged**.
It was correct; no timeout was widened and nothing was skipped.

## Validation

- `pnpm typecheck` — exit **0**
- `pnpm --filter @open-design/web test` — exit **0**, `597 passed (597)` files,
  `6220 passed | 11 skipped` tests
- `pnpm guard` — exit **1**, but **identical byte-for-byte on pristine `origin/main`** in this
  worktree (verified by stashing the change and re-running; both logs end after the design-system
  checks with no error line). Pre-existing environment failure, unrelated to this change.
- Playwright was **not** run locally — this machine has no browser cache and installing one is
  prohibited. The CI trace + screenshot from the linked job are the evidence for the e2e symptom;
  the deterministic reproduction is the vitest spec above.
