### PR TITLE
fix(web): bound terminal Design delivery replay (#6505)

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5512,9 +5512,24 @@ export function ProjectView({
           && designDeliveryVerificationPending(message);
         let terminalDeliveryVerificationExpired = false;
         let terminalDeliveryVerificationTimer: ReturnType<typeof setTimeout> | null = null;
-        const settleTerminalDeliveryVerification = () => {
+        const settleTerminalDeliveryVerification = async (preserveReplayProgress = false) => {
           if (terminalDeliveryVerificationExpired) return;
           terminalDeliveryVerificationExpired = true;
+          const deliveryContent = preserveReplayProgress ? replayedContent : message.content;
+          const deliveryEvents = preserveReplayProgress
+            ? [...(message.events ?? []), ...replayedEvents]
+            : message.events;
+          let recoveredProducedFiles: ProjectFile[] = [];
+          let recoveredTraceObjectFiles: ProjectFile[] = [];
+          if (preserveReplayProgress) {
+            const nextFiles = await refreshProjectFiles();
+            const beforeFileNames = new Set(message.preTurnFileNames ?? nextFiles.map((file) => file.name));
+            const touchedFilePaths = extractTouchedFilePathsFromEvents(deliveryEvents);
+            recoveredProducedFiles = computeProducedFiles(beforeFileNames, nextFiles) ?? [];
+            recoveredTraceObjectFiles = computeTraceObjectFiles(
+              beforeFileNames, nextFiles, touchedFilePaths, project.id, projectDetail.resolvedDir,
+            ) ?? [];
+          }
           if (terminalDeliveryVerificationTimer) {
             clearProjectTimeout(terminalDeliveryVerificationTimer);
             terminalDeliveryVerificationTimer = null;
@@ -5527,10 +5542,10 @@ export function ProjectView({
           const timeoutOutcome = resolveDesignDeliveryOutcome({
             sessionMode: message.sessionMode,
             runStatus: message.runStatus,
-            content: message.content,
-            events: message.events,
-            producedFileCount: 0,
-            traceObjectFileCount: 0,
+            content: deliveryContent,
+            events: deliveryEvents,
+            producedFileCount: recoveredProducedFiles.length,
+            traceObjectFileCount: recoveredTraceObjectFiles.length,
           });
           updateMessageById(
             message.id,
@@ -5540,10 +5555,12 @@ export function ProjectView({
               }
               const settled = {
                 ...prev,
-                content: prev.content || message.content,
-                events: [...(message.events ?? []), ...(prev.events ?? [])],
-                producedFiles: prev.producedFiles ?? [],
-                traceObjectFiles: prev.traceObjectFiles ?? [],
+                content: deliveryContent || prev.content || message.content,
+                events: preserveReplayProgress
+                  ? deliveryEvents
+                  : [...(message.events ?? []), ...(prev.events ?? [])],
+                producedFiles: prev.producedFiles ?? recoveredProducedFiles,
+                traceObjectFiles: prev.traceObjectFiles ?? recoveredTraceObjectFiles,
               };
               return applyDesignDeliveryOutcome(
                 settled,
@@ -5567,7 +5584,7 @@ export function ProjectView({
         if (boundedTerminalDeliveryVerification) {
           terminalDeliveryVerificationTimer = scheduleProjectTimeout(() => {
             if (reattachControllersRef.current.get(runId) !== controller) return;
-            settleTerminalDeliveryVerification();
+            void settleTerminalDeliveryVerification();
           }, TERMINAL_DELIVERY_VERIFICATION_TIMEOUT_MS);
         }
         void reattachDaemonRun({
@@ -5791,9 +5808,9 @@ export function ProjectView({
             onError: async (err) => {
               const genericDisconnect = isGenericDaemonDisconnect(err);
               if (boundedTerminalDeliveryVerification && genericDisconnect) {
-                textBuffer.cancel();
+                textBuffer.flush();
                 unregisterTextBuffer();
-                settleTerminalDeliveryVerification();
+                await settleTerminalDeliveryVerification(true);
                 return;
               }
               if (terminalDeliveryVerificationTimer) {

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -6031,6 +6031,7 @@ export function ProjectView({
             },
           },
           onRunStatus: (runStatus) => {
+            if (terminalDeliveryVerificationExpired) return;
             textBuffer.flush();
             updateMessageById(
               message.id,

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -11360,14 +11360,22 @@ function artifactFromRecoverableSourceText(sourceText: string): Artifact | null 
   };
 }
 
+const TERMINAL_DELIVERY_REPLAY_WINDOW_MS = 60_000;
+
 export function shouldReplayTerminalRunMessage(message: ChatMessage): boolean {
   if (message.role !== 'assistant') return false;
   if (!message.runId) return false;
   if (message.runStatus !== 'succeeded') return false;
   // A daemon can persist terminal success before the browser finishes its
-  // project-file refresh. Reattach once even when prose already exists so the
-  // delivery invariant can confirm a file or downgrade the turn after reload.
-  if (designDeliveryVerificationPending(message)) return true;
+  // project-file refresh. Reattach only during that bounded handoff window;
+  // replaying historical terminal rows with incomplete delivery metadata can
+  // otherwise keep a conversation loading forever after reload. Timestamp-less
+  // legacy rows retain the established recovery path because their age cannot
+  // be distinguished safely here.
+  if (designDeliveryVerificationPending(message)) {
+    const terminalAt = message.endedAt ?? message.createdAt ?? message.startedAt;
+    return terminalAt == null || Date.now() - terminalAt <= TERMINAL_DELIVERY_REPLAY_WINDOW_MS;
+  }
   if (message.content.trim().length > 0) return false;
   if (
     message.startedAt == null

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -6131,6 +6131,7 @@ export function ProjectView({
             }
           },
           onRunEventId: (lastRunEventId) => {
+            if (terminalDeliveryVerificationExpired) return;
             textBuffer.flush();
             updateMessageById(message.id, (prev) => ({ ...prev, lastRunEventId }));
             persistSoon();

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -6110,6 +6110,9 @@ export function ProjectView({
           },
           onRunStatus: (runStatus) => {
             if (terminalDeliveryVerificationExpired) return;
+            if (boundedTerminalDeliveryVerification && (runStatus === 'queued' || runStatus === 'running')) {
+              return;
+            }
             textBuffer.flush();
             updateMessageById(
               message.id,

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5586,7 +5586,7 @@ export function ProjectView({
         if (boundedTerminalDeliveryVerification) {
           terminalDeliveryVerificationTimer = scheduleProjectTimeout(() => {
             if (reattachControllersRef.current.get(runId) !== controller) return;
-            void settleTerminalDeliveryVerification();
+            void settleTerminalDeliveryVerification(true);
           }, TERMINAL_DELIVERY_VERIFICATION_TIMEOUT_MS);
         }
         void reattachDaemonRun({

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5512,54 +5512,62 @@ export function ProjectView({
           && designDeliveryVerificationPending(message);
         let terminalDeliveryVerificationExpired = false;
         let terminalDeliveryVerificationTimer: ReturnType<typeof setTimeout> | null = null;
+        const settleTerminalDeliveryVerification = () => {
+          if (terminalDeliveryVerificationExpired) return;
+          terminalDeliveryVerificationExpired = true;
+          if (terminalDeliveryVerificationTimer) {
+            clearProjectTimeout(terminalDeliveryVerificationTimer);
+            terminalDeliveryVerificationTimer = null;
+          }
+          completedReattachRunsRef.current.add(runId);
+          reattachControllersRef.current.delete(runId);
+          reattachCancelControllersRef.current.delete(runId);
+          clearCurrentRunStreamingMarker(reattachConversationId, controller, cancelController);
+          controller.abort();
+          const timeoutOutcome = resolveDesignDeliveryOutcome({
+            sessionMode: message.sessionMode,
+            runStatus: message.runStatus,
+            content: message.content,
+            events: message.events,
+            producedFileCount: 0,
+            traceObjectFileCount: 0,
+          });
+          updateMessageById(
+            message.id,
+            (prev) => {
+              if (prev.runStatus !== 'succeeded' || !designDeliveryVerificationPending(prev)) {
+                return prev;
+              }
+              const settled = {
+                ...prev,
+                content: prev.content || message.content,
+                events: [...(message.events ?? []), ...(prev.events ?? [])],
+                producedFiles: prev.producedFiles ?? [],
+                traceObjectFiles: prev.traceObjectFiles ?? [],
+              };
+              return applyDesignDeliveryOutcome(
+                settled,
+                resolveDesignDeliveryOutcome({
+                  sessionMode: settled.sessionMode,
+                  runStatus: settled.runStatus,
+                  content: settled.content,
+                  events: settled.events,
+                  producedFileCount: settled.producedFiles.length,
+                  traceObjectFileCount: settled.traceObjectFiles.length,
+                }),
+              );
+            },
+            true,
+            { telemetryFinalized: true },
+          );
+          if (timeoutOutcome === 'no_result' || timeoutOutcome === 'delivery_failed') {
+            setError(DESIGN_RESULT_MISSING_DETAIL);
+          }
+        };
         if (boundedTerminalDeliveryVerification) {
           terminalDeliveryVerificationTimer = scheduleProjectTimeout(() => {
             if (reattachControllersRef.current.get(runId) !== controller) return;
-            terminalDeliveryVerificationExpired = true;
-            completedReattachRunsRef.current.add(runId);
-            reattachControllersRef.current.delete(runId);
-            reattachCancelControllersRef.current.delete(runId);
-            clearCurrentRunStreamingMarker(reattachConversationId, controller, cancelController);
-            controller.abort();
-            const timeoutOutcome = resolveDesignDeliveryOutcome({
-              sessionMode: message.sessionMode,
-              runStatus: message.runStatus,
-              content: message.content,
-              events: message.events,
-              producedFileCount: 0,
-              traceObjectFileCount: 0,
-            });
-            updateMessageById(
-              message.id,
-              (prev) => {
-                if (prev.runStatus !== 'succeeded' || !designDeliveryVerificationPending(prev)) {
-                  return prev;
-                }
-                const settled = {
-                  ...prev,
-                  content: prev.content || message.content,
-                  events: [...(message.events ?? []), ...(prev.events ?? [])],
-                  producedFiles: prev.producedFiles ?? [],
-                  traceObjectFiles: prev.traceObjectFiles ?? [],
-                };
-                return applyDesignDeliveryOutcome(
-                  settled,
-                  resolveDesignDeliveryOutcome({
-                    sessionMode: settled.sessionMode,
-                    runStatus: settled.runStatus,
-                    content: settled.content,
-                    events: settled.events,
-                    producedFileCount: settled.producedFiles.length,
-                    traceObjectFileCount: settled.traceObjectFiles.length,
-                  }),
-                );
-              },
-              true,
-              { telemetryFinalized: true },
-            );
-            if (timeoutOutcome === 'no_result' || timeoutOutcome === 'delivery_failed') {
-              setError(DESIGN_RESULT_MISSING_DETAIL);
-            }
+            settleTerminalDeliveryVerification();
           }, TERMINAL_DELIVERY_VERIFICATION_TIMEOUT_MS);
         }
         void reattachDaemonRun({
@@ -5781,6 +5789,13 @@ export function ProjectView({
               onProjectsRefresh();
             },
             onError: async (err) => {
+              const genericDisconnect = isGenericDaemonDisconnect(err);
+              if (boundedTerminalDeliveryVerification && genericDisconnect) {
+                textBuffer.cancel();
+                unregisterTextBuffer();
+                settleTerminalDeliveryVerification();
+                return;
+              }
               if (terminalDeliveryVerificationTimer) {
                 clearProjectTimeout(terminalDeliveryVerificationTimer);
                 terminalDeliveryVerificationTimer = null;
@@ -5794,7 +5809,6 @@ export function ProjectView({
               const resumable = (err as Error & { resumable?: boolean }).resumable === true;
               let skipFinalPersistNow = false;
               let retryFullReplayAfterCleanup = false;
-              const genericDisconnect = isGenericDaemonDisconnect(err);
               const failure = runFailureFieldsFromError(err);
               // A superseded reattached run must not paint a global failure
               // banner or re-finalize its message over the replacement run.

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5148,6 +5148,47 @@ export function ProjectView({
           );
         }
 
+        const terminalDeliveryReplayNeedsAuthoritativeAge =
+          replayingTerminalRun
+          && message.runStatus === 'succeeded'
+          && designDeliveryVerificationPending(message)
+          && message.endedAt == null;
+        if (
+          terminalDeliveryReplayNeedsAuthoritativeAge
+          && status.status === 'succeeded'
+          && !isFreshTerminalDeliveryReplayTimestamp(status.updatedAt)
+        ) {
+          const deliveryOutcome = resolveDesignDeliveryOutcome({
+            sessionMode: message.sessionMode,
+            runStatus: 'succeeded',
+            content: message.content,
+            events: message.events,
+            producedFileCount: 0,
+            traceObjectFileCount: 0,
+          });
+          const endedAt = isSafeTerminalTimestamp(status.updatedAt)
+            ? status.updatedAt
+            : undefined;
+          updateMessageById(
+            message.id,
+            (prev) => applyDesignDeliveryOutcome(
+              {
+                ...prev,
+                producedFiles: [],
+                traceObjectFiles: [],
+                ...(prev.endedAt == null && endedAt !== undefined ? { endedAt } : {}),
+              },
+              deliveryOutcome,
+            ),
+            true,
+            { telemetryFinalized: true },
+          );
+          completedReattachRunsRef.current.add(runId);
+          genericDisconnectRetriesRef.current.delete(runId);
+          genericDisconnectBackoffUntilRef.current.delete(runId);
+          continue;
+        }
+
         if (shouldReplayTerminalRunMessage(message)) {
           const replayedContent = textContentFromAgentEvents(message.events);
           if (replayedContent.trim().length > 0) {
@@ -11443,19 +11484,24 @@ function artifactFromRecoverableSourceText(sourceText: string): Artifact | null 
 
 const TERMINAL_DELIVERY_REPLAY_WINDOW_MS = 60_000;
 
+function isSafeTerminalTimestamp(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value <= Date.now();
+}
+
+function isFreshTerminalDeliveryReplayTimestamp(value: unknown): boolean {
+  return isSafeTerminalTimestamp(value) && Date.now() - value <= TERMINAL_DELIVERY_REPLAY_WINDOW_MS;
+}
+
 export function shouldReplayTerminalRunMessage(message: ChatMessage): boolean {
   if (message.role !== 'assistant') return false;
   if (!message.runId) return false;
   if (message.runStatus !== 'succeeded') return false;
-  // A daemon can persist terminal success before the browser finishes its
-  // project-file refresh. Reattach only during that bounded handoff window;
-  // replaying historical terminal rows with incomplete delivery metadata can
-  // otherwise keep a conversation loading forever after reload. Timestamp-less
-  // legacy rows retain the established recovery path because their age cannot
-  // be distinguished safely here.
+  // With a stored terminal timestamp, the browser can make a local bounded
+  // decision. Without it, createdAt/startedAt describe run start rather than
+  // completion, so leave the row eligible solely for an authoritative daemon
+  // status probe below.
   if (designDeliveryVerificationPending(message)) {
-    const terminalAt = message.endedAt ?? message.createdAt ?? message.startedAt;
-    return terminalAt == null || Date.now() - terminalAt <= TERMINAL_DELIVERY_REPLAY_WINDOW_MS;
+    return message.endedAt == null || isFreshTerminalDeliveryReplayTimestamp(message.endedAt);
   }
   if (message.content.trim().length > 0) return false;
   if (

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -4992,6 +4992,36 @@ export function ProjectView({
           hasGenericDisconnectFailureEvent(message);
         const replayingTerminalRun =
           shouldReplayTerminalRunMessage(message) || spuriouslyFailedPending;
+        const terminalDeliveryReplayIsIneligible =
+          message.runStatus === 'succeeded'
+          && designDeliveryVerificationPending(message)
+          && message.endedAt != null
+          && !isFreshTerminalDeliveryReplayTimestamp(message.endedAt);
+        if (terminalDeliveryReplayIsIneligible) {
+          const deliveryOutcome = resolveDesignDeliveryOutcome({
+            sessionMode: message.sessionMode,
+            runStatus: 'succeeded',
+            content: message.content,
+            events: message.events,
+            producedFileCount: 0,
+            traceObjectFileCount: 0,
+          });
+          updateMessageById(
+            message.id,
+            (prev) => applyDesignDeliveryOutcome(
+              { ...prev, producedFiles: [], traceObjectFiles: [] },
+              deliveryOutcome,
+            ),
+            true,
+            { telemetryFinalized: true },
+          );
+          if (message.runId) {
+            completedReattachRunsRef.current.add(message.runId);
+            genericDisconnectRetriesRef.current.delete(message.runId);
+            genericDisconnectBackoffUntilRef.current.delete(message.runId);
+          }
+          continue;
+        }
         const needsFullReplay =
           isActiveRunStatus(message.runStatus) ||
           replayingTerminalRun ||
@@ -5183,6 +5213,16 @@ export function ProjectView({
             true,
             { telemetryFinalized: true },
           );
+          completedReattachRunsRef.current.add(runId);
+          genericDisconnectRetriesRef.current.delete(runId);
+          genericDisconnectBackoffUntilRef.current.delete(runId);
+          continue;
+        }
+
+        if (
+          terminalDeliveryReplayNeedsAuthoritativeAge
+          && (status.status === 'failed' || status.status === 'canceled')
+        ) {
           completedReattachRunsRef.current.add(runId);
           genericDisconnectRetriesRef.current.delete(runId);
           genericDisconnectBackoffUntilRef.current.delete(runId);

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -6024,6 +6024,7 @@ export function ProjectView({
           },
         })
           .catch((err) => {
+            if (terminalDeliveryVerificationExpired) return;
             // Skip AbortError (expected on interrupt) and any error from a run
             // that was tagged superseded by a send-now interrupt — it must not
             // surface a global failure over the replacement.

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -5515,6 +5515,8 @@ export function ProjectView({
         const settleTerminalDeliveryVerification = async (preserveReplayProgress = false) => {
           if (terminalDeliveryVerificationExpired) return;
           terminalDeliveryVerificationExpired = true;
+          textBuffer.cancel();
+          unregisterTextBuffer();
           const deliveryContent = preserveReplayProgress ? replayedContent : message.content;
           const deliveryEvents = preserveReplayProgress
             ? [...(message.events ?? []), ...replayedEvents]
@@ -5806,6 +5808,11 @@ export function ProjectView({
               onProjectsRefresh();
             },
             onError: async (err) => {
+              if (terminalDeliveryVerificationExpired) {
+                textBuffer.cancel();
+                unregisterTextBuffer();
+                return;
+              }
               const genericDisconnect = isGenericDaemonDisconnect(err);
               if (boundedTerminalDeliveryVerification && genericDisconnect) {
                 textBuffer.flush();
@@ -6157,7 +6164,9 @@ export function ProjectView({
             }
           })
           .finally(() => {
-            textBuffer.flush();
+            if (!terminalDeliveryVerificationExpired) {
+              textBuffer.flush();
+            }
             textBuffer.cancel();
             unregisterTextBuffer();
             if (persistTimer) clearProjectTimeout(persistTimer);

--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -4913,6 +4913,9 @@ export function ProjectView({
   // completion.  Transient null-status retries are bounded; after
   // MAX_TRANSIENT_RETRIES we add to completedReattachRunsRef to avoid spinning.
   const MAX_TRANSIENT_RETRIES = 2;
+  // A terminal Design run may need one short stream reattach to reconcile files,
+  // but that supplemental verification must never keep the chat loading forever.
+  const TERMINAL_DELIVERY_VERIFICATION_TIMEOUT_MS = 5_000;
 
   // Reset transient retry counts when the conversation or daemon connection
   // changes so stale counts from a previous session do not bleed in.  This
@@ -5421,6 +5424,63 @@ export function ProjectView({
           isActiveRunStatus(message.runStatus)
           || spuriouslyFailedPending
           || recoverableGenericDisconnectFailed;
+        const boundedTerminalDeliveryVerification =
+          replayingTerminalRun
+          && message.runStatus === 'succeeded'
+          && status.status === 'succeeded'
+          && designDeliveryVerificationPending(message);
+        let terminalDeliveryVerificationExpired = false;
+        let terminalDeliveryVerificationTimer: ReturnType<typeof setTimeout> | null = null;
+        if (boundedTerminalDeliveryVerification) {
+          terminalDeliveryVerificationTimer = scheduleProjectTimeout(() => {
+            if (reattachControllersRef.current.get(runId) !== controller) return;
+            terminalDeliveryVerificationExpired = true;
+            completedReattachRunsRef.current.add(runId);
+            reattachControllersRef.current.delete(runId);
+            reattachCancelControllersRef.current.delete(runId);
+            clearCurrentRunStreamingMarker(reattachConversationId, controller, cancelController);
+            controller.abort();
+            const timeoutOutcome = resolveDesignDeliveryOutcome({
+              sessionMode: message.sessionMode,
+              runStatus: message.runStatus,
+              content: message.content,
+              events: message.events,
+              producedFileCount: 0,
+              traceObjectFileCount: 0,
+            });
+            updateMessageById(
+              message.id,
+              (prev) => {
+                if (prev.runStatus !== 'succeeded' || !designDeliveryVerificationPending(prev)) {
+                  return prev;
+                }
+                const settled = {
+                  ...prev,
+                  content: prev.content || message.content,
+                  events: [...(message.events ?? []), ...(prev.events ?? [])],
+                  producedFiles: prev.producedFiles ?? [],
+                  traceObjectFiles: prev.traceObjectFiles ?? [],
+                };
+                return applyDesignDeliveryOutcome(
+                  settled,
+                  resolveDesignDeliveryOutcome({
+                    sessionMode: settled.sessionMode,
+                    runStatus: settled.runStatus,
+                    content: settled.content,
+                    events: settled.events,
+                    producedFileCount: settled.producedFiles.length,
+                    traceObjectFileCount: settled.traceObjectFiles.length,
+                  }),
+                );
+              },
+              true,
+              { telemetryFinalized: true },
+            );
+            if (timeoutOutcome === 'no_result' || timeoutOutcome === 'delivery_failed') {
+              setError(DESIGN_RESULT_MISSING_DETAIL);
+            }
+          }, TERMINAL_DELIVERY_VERIFICATION_TIMEOUT_MS);
+        }
         void reattachDaemonRun({
           runId,
           projectId: project.id,
@@ -5432,6 +5492,7 @@ export function ProjectView({
           publishRunFinishedEvent: shouldPublishRunFinishedEvent,
           handlers: {
             onDelta: (delta) => {
+              if (terminalDeliveryVerificationExpired) return;
               // First payload from the resumed stream is real recovery — the daemon is
               // sending data, not just answering REST status probes.  Reset the
               // transient retry budgets so a future disconnect starts from zero, but
@@ -5450,6 +5511,7 @@ export function ProjectView({
               textBuffer.appendContent(delta);
             },
             onAgentEvent: (ev) => {
+              if (terminalDeliveryVerificationExpired) return;
               transientFailedRetriesRef.current.delete(runId);
               if (!(replayingTerminalRun && !(message.producedFiles?.length))) {
                 genericDisconnectRetriesRef.current.delete(runId);
@@ -5459,6 +5521,15 @@ export function ProjectView({
               textBuffer.appendEvent(ev);
             },
             onDone: async () => {
+              if (terminalDeliveryVerificationTimer) {
+                clearProjectTimeout(terminalDeliveryVerificationTimer);
+                terminalDeliveryVerificationTimer = null;
+              }
+              if (terminalDeliveryVerificationExpired) {
+                textBuffer.cancel();
+                unregisterTextBuffer();
+                return;
+              }
               // A reattached run interrupted by a "send now" still receives a
               // late onDone from the daemon. Decide ownership first, then bail
               // BEFORE any current-run side effect (committing buffered text,
@@ -5629,6 +5700,15 @@ export function ProjectView({
               onProjectsRefresh();
             },
             onError: async (err) => {
+              if (terminalDeliveryVerificationTimer) {
+                clearProjectTimeout(terminalDeliveryVerificationTimer);
+                terminalDeliveryVerificationTimer = null;
+              }
+              if (terminalDeliveryVerificationExpired) {
+                textBuffer.cancel();
+                unregisterTextBuffer();
+                return;
+              }
               const errorCode = (err as Error & { code?: string }).code;
               const resumable = (err as Error & { resumable?: boolean }).resumable === true;
               let skipFinalPersistNow = false;

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -838,6 +838,7 @@ describe('ProjectView daemon reattach restore', () => {
     vi.useFakeTimers();
     const endedAt = Date.now();
     let terminalOnError: ((error: Error & { code?: string }) => Promise<void>) | null = null;
+    let terminalOnDelta: ((delta: string) => void) | null = null;
     listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
     listMessages.mockResolvedValue([
       {
@@ -866,8 +867,12 @@ describe('ProjectView daemon reattach restore', () => {
       updatedAt: endedAt, exitCode: 0, signal: null,
     });
     reattachDaemonRun.mockImplementation(async (options: {
-      handlers: { onError: (error: Error & { code?: string }) => Promise<void> };
+      handlers: {
+        onDelta: (delta: string) => void;
+        onError: (error: Error & { code?: string }) => Promise<void>;
+      };
     }) => {
+      terminalOnDelta = options.handlers.onDelta;
       terminalOnError = options.handlers.onError;
       return new Promise<void>(() => {});
     });
@@ -879,6 +884,10 @@ describe('ProjectView daemon reattach restore', () => {
       });
     }
     expect(terminalOnError).toBeTypeOf('function');
+    expect(terminalOnDelta).toBeTypeOf('function');
+    await act(async () => {
+      (terminalOnDelta as (delta: string) => void)('Recovered terminal delivery.');
+    });
     const genericDisconnect = Object.assign(
       new Error('daemon stream disconnected before run completed'),
       { code: 'GENERIC_DAEMON_DISCONNECT' },
@@ -896,6 +905,7 @@ describe('ProjectView daemon reattach restore', () => {
     expect(saveMessage.mock.calls.map((call) => call[2] as ChatMessage)).toContainEqual(expect.objectContaining({
       id: 'msg-terminal-generic-disconnect',
       runStatus: 'succeeded',
+      content: 'Recovered terminal delivery.',
       producedFiles: [],
       traceObjectFiles: [],
       resultDeliveryState: 'no_result',

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -805,6 +805,8 @@ describe('ProjectView daemon reattach restore', () => {
       });
     }
     expect(reattachDaemonRun).toHaveBeenCalledTimes(1);
+    expect(lateOnRunStatus).toBeTypeOf('function');
+    lateOnRunStatus!('running');
     expect(lateOnDelta).toBeTypeOf('function');
     lateOnDelta!('late buffered delta');
 

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -658,6 +658,7 @@ describe('ProjectView daemon reattach restore', () => {
     vi.useFakeTimers();
     const endedAt = Date.now();
     let lateOnDone: (() => void) | null = null;
+    let lateOnRunStatus: ((status: 'queued' | 'running' | 'succeeded' | 'failed' | 'canceled') => void) | null = null;
     listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
     listMessages.mockResolvedValue([
       {
@@ -687,8 +688,12 @@ describe('ProjectView daemon reattach restore', () => {
       id: 'run-stalled-terminal-delivery', status: 'succeeded', createdAt: endedAt - 1_000,
       updatedAt: endedAt, exitCode: 0, signal: null,
     });
-    reattachDaemonRun.mockImplementation(async (options: { handlers: { onDone: () => void } }) => {
+    reattachDaemonRun.mockImplementation(async (options: {
+      handlers: { onDone: () => void };
+      onRunStatus?: (status: 'queued' | 'running' | 'succeeded' | 'failed' | 'canceled') => void;
+    }) => {
       lateOnDone = options.handlers.onDone;
+      lateOnRunStatus = options.onRunStatus ?? null;
       return new Promise<void>(() => {});
     });
 
@@ -723,6 +728,11 @@ describe('ProjectView daemon reattach restore', () => {
     expect(lateOnDone).not.toBeNull();
     await act(async () => {
       await (lateOnDone as unknown as () => void)();
+    });
+    expect(saveMessage).toHaveBeenCalledTimes(savesAtTimeout);
+    expect(lateOnRunStatus).toBeTypeOf('function');
+    await act(async () => {
+      (lateOnRunStatus as unknown as (status: 'running') => void)('running');
     });
     expect(saveMessage).toHaveBeenCalledTimes(savesAtTimeout);
     const reattachOptions = reattachDaemonRun.mock.calls[0]?.[0] as { signal: AbortSignal } | undefined;

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -834,6 +834,78 @@ describe('ProjectView daemon reattach restore', () => {
     expect(reattachDaemonRun).toHaveBeenCalledTimes(1);
   });
 
+  it('settles a terminal Design verification on generic disconnect without retrying', async () => {
+    vi.useFakeTimers();
+    const endedAt = Date.now();
+    let terminalOnError: ((error: Error & { code?: string }) => Promise<void>) | null = null;
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([
+      {
+        id: 'msg-terminal-generic-disconnect',
+        role: 'assistant',
+        content: 'I finished the design.',
+        createdAt: endedAt - 1_000,
+        startedAt: endedAt - 1_000,
+        endedAt,
+        runId: 'run-terminal-generic-disconnect',
+        runStatus: 'succeeded',
+        sessionMode: 'design',
+        preTurnFileNames: [],
+        events: [{ kind: 'tool_use', id: 'write-generic-disconnect', name: 'Write', input: { file_path: 'index.html' } }],
+      } satisfies ChatMessage,
+    ]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-terminal-generic-disconnect', status: 'succeeded', createdAt: endedAt - 1_000,
+      updatedAt: endedAt, exitCode: 0, signal: null,
+    });
+    reattachDaemonRun.mockImplementation(async (options: {
+      handlers: { onError: (error: Error & { code?: string }) => Promise<void> };
+    }) => {
+      terminalOnError = options.handlers.onError;
+      return new Promise<void>(() => {});
+    });
+
+    renderProjectView();
+    for (let attempt = 0; attempt < 20 && terminalOnError === null; attempt += 1) {
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+    expect(terminalOnError).toBeTypeOf('function');
+    const genericDisconnect = Object.assign(
+      new Error('daemon stream disconnected before run completed'),
+      { code: 'GENERIC_DAEMON_DISCONNECT' },
+    );
+    await act(async () => {
+      await (terminalOnError as (error: typeof genericDisconnect) => Promise<void>)(genericDisconnect);
+    });
+    for (let attempt = 0; attempt < 20 && !saveMessage.mock.calls.some((call) =>
+      (call[2] as ChatMessage).resultDeliveryState === 'no_result'); attempt += 1) {
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+
+    expect(saveMessage.mock.calls.map((call) => call[2] as ChatMessage)).toContainEqual(expect.objectContaining({
+      id: 'msg-terminal-generic-disconnect',
+      runStatus: 'succeeded',
+      producedFiles: [],
+      traceObjectFiles: [],
+      resultDeliveryState: 'no_result',
+    }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6_000);
+    });
+    expect(reattachDaemonRun).toHaveBeenCalledTimes(1);
+  });
+
   it('does not publish a run-finished event while replaying a historical success', async () => {
     const startedAt = Date.now() - 10_000;
     listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -562,6 +562,100 @@ describe('ProjectView daemon reattach restore', () => {
     });
   });
 
+  it('settles a stale observed terminal Design timestamp without status probing or reattach', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2030-01-01T00:00:00.000Z'));
+    const now = Date.now();
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([
+      {
+        id: 'msg-stale-observed-terminal-delivery',
+        role: 'assistant',
+        content: 'I finished the design.',
+        createdAt: now - 120_000,
+        startedAt: now - 120_000,
+        endedAt: now - 60_001,
+        runId: 'run-stale-observed-terminal-delivery',
+        runStatus: 'succeeded',
+        sessionMode: 'design',
+        preTurnFileNames: [],
+        events: [{ kind: 'tool_use', id: 'write-stale', name: 'Write', input: { file_path: 'index.html' } }],
+      } satisfies ChatMessage,
+    ]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+
+    renderProjectView();
+    for (let attempt = 0; attempt < 20 && saveMessage.mock.calls.length === 0; attempt += 1) {
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+
+    expect(fetchChatRunStatus).not.toHaveBeenCalled();
+    expect(reattachDaemonRun).not.toHaveBeenCalled();
+    expect(saveMessage.mock.calls.map((call) => call[2] as ChatMessage)).toContainEqual(expect.objectContaining({
+      id: 'msg-stale-observed-terminal-delivery',
+      runStatus: 'succeeded',
+      endedAt: now - 60_001,
+      producedFiles: [],
+      traceObjectFiles: [],
+      resultDeliveryState: 'no_result',
+    }));
+  });
+
+  it('does not reattach a missing-endedAt Design snapshot when daemon status is failed', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2030-01-01T00:00:00.000Z'));
+    const now = Date.now();
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([
+      {
+        id: 'msg-daemon-failed-terminal-delivery',
+        role: 'assistant',
+        content: 'I finished the design.',
+        createdAt: now - 61_000,
+        startedAt: now - 61_000,
+        runId: 'run-daemon-failed-terminal-delivery',
+        runStatus: 'succeeded',
+        sessionMode: 'design',
+        preTurnFileNames: [],
+        events: [{ kind: 'tool_use', id: 'write-failed', name: 'Write', input: { file_path: 'index.html' } }],
+      } satisfies ChatMessage,
+    ]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-daemon-failed-terminal-delivery', status: 'failed', createdAt: now - 61_000,
+      updatedAt: now, exitCode: 1, signal: null,
+    });
+    reattachDaemonRun.mockResolvedValue(undefined);
+
+    renderProjectView();
+    for (let attempt = 0; attempt < 20 && saveMessage.mock.calls.length === 0; attempt += 1) {
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+
+    expect(fetchChatRunStatus).toHaveBeenCalledWith('run-daemon-failed-terminal-delivery', null);
+    expect(reattachDaemonRun).not.toHaveBeenCalled();
+    expect(saveMessage.mock.calls.map((call) => call[2] as ChatMessage)).toContainEqual(expect.objectContaining({
+      id: 'msg-daemon-failed-terminal-delivery',
+      runStatus: 'failed',
+    }));
+  });
+
   it('probes a long terminal Design run without endedAt and reattaches when daemon completion is fresh', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2030-01-01T00:00:00.000Z'));

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, waitFor } from '@testing-library/react';
+import { act, cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   ProjectView,
@@ -446,6 +446,7 @@ describe('same-turn dedup for recovered prose-only artifacts (#4318)', () => {
 
 describe('ProjectView daemon reattach restore', () => {
   afterEach(() => {
+    vi.useRealTimers();
     cleanup();
     vi.clearAllMocks();
     chatPaneHarness.onSend = null;
@@ -559,6 +560,82 @@ describe('ProjectView daemon reattach restore', () => {
       expect(lastWithProduced?.producedFiles?.map((f) => f.name)).toEqual(['new.pptx']);
       expect(lastWithProduced?.runStatus).toBe('succeeded');
     });
+  });
+
+  it('settles one stalled terminal Design delivery verification without reattaching again', async () => {
+    vi.useFakeTimers();
+    const endedAt = Date.now();
+    let lateOnDone: (() => void) | null = null;
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([
+      {
+        id: 'msg-stalled-terminal-delivery',
+        role: 'assistant',
+        content: 'I finished the design.',
+        createdAt: endedAt - 1_000,
+        startedAt: endedAt - 1_000,
+        endedAt,
+        runId: 'run-stalled-terminal-delivery',
+        runStatus: 'succeeded',
+        sessionMode: 'design',
+        preTurnFileNames: [],
+        producedFiles: undefined,
+        traceObjectFiles: undefined,
+        events: [{ kind: 'tool_use', id: 'write-1', name: 'Write', input: { file_path: 'index.html' } }],
+      } satisfies ChatMessage,
+    ]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-stalled-terminal-delivery', status: 'succeeded', createdAt: endedAt - 1_000,
+      updatedAt: endedAt, exitCode: 0, signal: null,
+    });
+    reattachDaemonRun.mockImplementation(async (options: { handlers: { onDone: () => void } }) => {
+      lateOnDone = options.handlers.onDone;
+      return new Promise<void>(() => {});
+    });
+
+    renderProjectView();
+    for (let attempt = 0; attempt < 20 && reattachDaemonRun.mock.calls.length === 0; attempt += 1) {
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+    expect(reattachDaemonRun).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_001);
+    });
+    for (let attempt = 0; attempt < 20 && saveMessage.mock.calls.length === 0; attempt += 1) {
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+
+    const settled = saveMessage.mock.calls
+      .map((call) => call[2] as ChatMessage)
+      .find((message) => message.id === 'msg-stalled-terminal-delivery'
+        && message.resultDeliveryState === 'no_result');
+    expect(settled).toMatchObject({
+      runStatus: 'succeeded',
+      producedFiles: [],
+      traceObjectFiles: [],
+      resultDeliveryState: 'no_result',
+    });
+    const savesAtTimeout = saveMessage.mock.calls.length;
+    expect(lateOnDone).not.toBeNull();
+    await act(async () => {
+      await (lateOnDone as unknown as () => void)();
+    });
+    expect(saveMessage).toHaveBeenCalledTimes(savesAtTimeout);
+    const reattachOptions = reattachDaemonRun.mock.calls[0]?.[0] as { signal: AbortSignal } | undefined;
+    expect(reattachOptions?.signal.aborted).toBe(true);
+    expect(reattachDaemonRun).toHaveBeenCalledTimes(1);
   });
 
   it('does not publish a run-finished event while replaying a historical success', async () => {

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -753,6 +753,7 @@ describe('ProjectView daemon reattach restore', () => {
     const endedAt = Date.now();
     let lateOnDone: (() => void) | null = null;
     let lateOnRunStatus: ((status: 'queued' | 'running' | 'succeeded' | 'failed' | 'canceled') => void) | null = null;
+    let lateOnRunEventId: ((eventId: string) => void) | null = null;
     listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
     listMessages.mockResolvedValue([
       {
@@ -785,9 +786,11 @@ describe('ProjectView daemon reattach restore', () => {
     reattachDaemonRun.mockImplementation(async (options: {
       handlers: { onDone: () => void };
       onRunStatus?: (status: 'queued' | 'running' | 'succeeded' | 'failed' | 'canceled') => void;
+      onRunEventId?: (eventId: string) => void;
     }) => {
       lateOnDone = options.handlers.onDone;
       lateOnRunStatus = options.onRunStatus ?? null;
+      lateOnRunEventId = options.onRunEventId ?? null;
       return new Promise<void>(() => {});
     });
 
@@ -828,6 +831,9 @@ describe('ProjectView daemon reattach restore', () => {
     await act(async () => {
       (lateOnRunStatus as unknown as (status: 'running') => void)('running');
     });
+    expect(saveMessage).toHaveBeenCalledTimes(savesAtTimeout);
+    expect(lateOnRunEventId).toBeTypeOf('function');
+    await act(async () => { (lateOnRunEventId as (eventId: string) => void)('late-event'); });
     expect(saveMessage).toHaveBeenCalledTimes(savesAtTimeout);
     const reattachOptions = reattachDaemonRun.mock.calls[0]?.[0] as { signal: AbortSignal } | undefined;
     expect(reattachOptions?.signal.aborted).toBe(true);

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -776,7 +776,7 @@ describe('ProjectView daemon reattach restore', () => {
     ]);
     fetchPreviewComments.mockResolvedValue([]);
     loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
-    fetchProjectFiles.mockResolvedValue([]);
+    fetchProjectFiles.mockResolvedValue([{ name: 'index.html', path: 'index.html', size: 23, mtime: endedAt, kind: 'html', mime: 'text/html' }]);
     fetchLiveArtifacts.mockResolvedValue([]);
     fetchSkill.mockResolvedValue(null);
     fetchDesignSystem.mockResolvedValue(null);
@@ -822,12 +822,12 @@ describe('ProjectView daemon reattach restore', () => {
     const settled = saveMessage.mock.calls
       .map((call) => call[2] as ChatMessage)
       .find((message) => message.id === 'msg-stalled-terminal-delivery'
-        && message.resultDeliveryState === 'no_result');
+        && message.resultDeliveryState !== undefined);
     expect(settled).toMatchObject({
       runStatus: 'succeeded',
-      producedFiles: [],
-      traceObjectFiles: [],
-      resultDeliveryState: 'no_result',
+      content: 'late buffered delta',
+      producedFiles: [expect.objectContaining({ name: 'index.html' })],
+      traceObjectFiles: [expect.objectContaining({ name: 'index.html' })],
     });
     const savesAtTimeout = saveMessage.mock.calls.length;
     expect(lateOnDone).not.toBeNull();

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -754,6 +754,8 @@ describe('ProjectView daemon reattach restore', () => {
     let lateOnDone: (() => void) | null = null;
     let lateOnRunStatus: ((status: 'queued' | 'running' | 'succeeded' | 'failed' | 'canceled') => void) | null = null;
     let lateOnRunEventId: ((eventId: string) => void) | null = null;
+    let lateOnError: ((error: Error & { code?: string }) => Promise<void>) | null = null;
+    let lateOnDelta: ((delta: string) => void) | null = null;
     listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
     listMessages.mockResolvedValue([
       {
@@ -784,11 +786,13 @@ describe('ProjectView daemon reattach restore', () => {
       updatedAt: endedAt, exitCode: 0, signal: null,
     });
     reattachDaemonRun.mockImplementation(async (options: {
-      handlers: { onDone: () => void };
+      handlers: { onDone: () => void; onDelta: (delta: string) => void; onError: (error: Error & { code?: string }) => Promise<void> };
       onRunStatus?: (status: 'queued' | 'running' | 'succeeded' | 'failed' | 'canceled') => void;
       onRunEventId?: (eventId: string) => void;
     }) => {
       lateOnDone = options.handlers.onDone;
+      lateOnDelta = options.handlers.onDelta;
+      lateOnError = options.handlers.onError;
       lateOnRunStatus = options.onRunStatus ?? null;
       lateOnRunEventId = options.onRunEventId ?? null;
       return new Promise<void>(() => {});
@@ -801,6 +805,8 @@ describe('ProjectView daemon reattach restore', () => {
       });
     }
     expect(reattachDaemonRun).toHaveBeenCalledTimes(1);
+    expect(lateOnDelta).toBeTypeOf('function');
+    lateOnDelta!('late buffered delta');
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(5_001);
@@ -834,6 +840,9 @@ describe('ProjectView daemon reattach restore', () => {
     expect(saveMessage).toHaveBeenCalledTimes(savesAtTimeout);
     expect(lateOnRunEventId).toBeTypeOf('function');
     await act(async () => { (lateOnRunEventId as (eventId: string) => void)('late-event'); });
+    expect(saveMessage).toHaveBeenCalledTimes(savesAtTimeout);
+    expect(lateOnError).toBeTypeOf('function');
+    await act(async () => { await (lateOnError as (error: Error & { code?: string }) => Promise<void>)(Object.assign(new Error('late disconnect'), { code: 'GENERIC_DAEMON_DISCONNECT' })); });
     expect(saveMessage).toHaveBeenCalledTimes(savesAtTimeout);
     const reattachOptions = reattachDaemonRun.mock.calls[0]?.[0] as { signal: AbortSignal } | undefined;
     expect(reattachOptions?.signal.aborted).toBe(true);

--- a/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
+++ b/apps/web/tests/components/ProjectView.reattach-restore.test.tsx
@@ -562,6 +562,98 @@ describe('ProjectView daemon reattach restore', () => {
     });
   });
 
+  it('probes a long terminal Design run without endedAt and reattaches when daemon completion is fresh', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2030-01-01T00:00:00.000Z'));
+    const now = Date.now();
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([
+      {
+        id: 'msg-long-terminal-delivery',
+        role: 'assistant',
+        content: 'I finished the design.',
+        createdAt: now - 61_000,
+        startedAt: now - 61_000,
+        runId: 'run-long-terminal-delivery',
+        runStatus: 'succeeded',
+        sessionMode: 'design',
+        preTurnFileNames: [],
+        events: [{ kind: 'tool_use', id: 'write-long', name: 'Write', input: { file_path: 'index.html' } }],
+      } satisfies ChatMessage,
+    ]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-long-terminal-delivery', status: 'succeeded', createdAt: now - 61_000,
+      updatedAt: now, exitCode: 0, signal: null,
+    });
+    reattachDaemonRun.mockImplementation(async () => new Promise<void>(() => {}));
+
+    renderProjectView();
+    for (let attempt = 0; attempt < 20 && reattachDaemonRun.mock.calls.length === 0; attempt += 1) {
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+
+    expect(fetchChatRunStatus).toHaveBeenCalledWith('run-long-terminal-delivery', null);
+    expect(reattachDaemonRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('settles a missing-endedAt Design row when the daemon completion is historical', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2030-01-01T00:00:00.000Z'));
+    const now = Date.now();
+    listConversations.mockResolvedValue([{ id: 'conv-1', title: 'Conversation' }]);
+    listMessages.mockResolvedValue([
+      {
+        id: 'msg-historical-terminal-delivery',
+        role: 'assistant',
+        content: 'I finished the design.',
+        createdAt: now - 120_000,
+        startedAt: now - 120_000,
+        runId: 'run-historical-terminal-delivery',
+        runStatus: 'succeeded',
+        sessionMode: 'design',
+        preTurnFileNames: [],
+        events: [{ kind: 'tool_use', id: 'write-historical', name: 'Write', input: { file_path: 'index.html' } }],
+      } satisfies ChatMessage,
+    ]);
+    fetchPreviewComments.mockResolvedValue([]);
+    loadTabs.mockResolvedValue({ tabs: [], activeTabId: null });
+    fetchProjectFiles.mockResolvedValue([]);
+    fetchLiveArtifacts.mockResolvedValue([]);
+    fetchSkill.mockResolvedValue(null);
+    fetchDesignSystem.mockResolvedValue(null);
+    getTemplate.mockResolvedValue(null);
+    fetchChatRunStatus.mockResolvedValue({
+      id: 'run-historical-terminal-delivery', status: 'succeeded', createdAt: now - 120_000,
+      updatedAt: now - 60_001, exitCode: 0, signal: null,
+    });
+
+    renderProjectView();
+    for (let attempt = 0; attempt < 20 && saveMessage.mock.calls.length === 0; attempt += 1) {
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+
+    expect(fetchChatRunStatus).toHaveBeenCalledWith('run-historical-terminal-delivery', null);
+    expect(reattachDaemonRun).not.toHaveBeenCalled();
+    expect(saveMessage.mock.calls.map((call) => call[2] as ChatMessage)).toContainEqual(expect.objectContaining({
+      id: 'msg-historical-terminal-delivery',
+      runStatus: 'succeeded',
+      endedAt: now - 60_001,
+      producedFiles: [],
+      traceObjectFiles: [],
+    }));
+  });
+
   it('settles one stalled terminal Design delivery verification without reattaching again', async () => {
     vi.useFakeTimers();
     const endedAt = Date.now();

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -652,16 +652,52 @@ describe('ProjectView daemon cleanup', () => {
     expect(resolveSucceededRunStatus('canceled')).toBe('canceled');
   });
 
-  it('replays an unverified terminal Design-mode result after reload', () => {
+  it('only replays a freshly completed unverified terminal Design-mode result', () => {
+    const now = Date.now();
     expect(
       shouldReplayTerminalRunMessage({
-        id: 'msg-unverified-delivery',
+        id: 'msg-fresh-unverified-delivery',
         role: 'assistant',
         content: 'I finished the design.',
-        runId: 'run-unverified-delivery',
+        runId: 'run-fresh-unverified-delivery',
+        runStatus: 'succeeded',
+        sessionMode: 'design',
+        startedAt: now - 1_000,
+        endedAt: now,
+      }),
+    ).toBe(true);
+    expect(
+      shouldReplayTerminalRunMessage({
+        id: 'msg-historical-unverified-delivery',
+        role: 'assistant',
+        content: 'I finished the design.',
+        runId: 'run-historical-unverified-delivery',
         runStatus: 'succeeded',
         sessionMode: 'design',
         startedAt: 1,
+        endedAt: 1,
+      }),
+    ).toBe(false);
+    expect(
+      shouldReplayTerminalRunMessage({
+        id: 'msg-stale-unverified-delivery',
+        role: 'assistant',
+        content: 'I finished the design.',
+        runId: 'run-stale-unverified-delivery',
+        runStatus: 'succeeded',
+        sessionMode: 'design',
+        startedAt: now - 60_001,
+        endedAt: now - 60_001,
+      }),
+    ).toBe(false);
+    expect(
+      shouldReplayTerminalRunMessage({
+        id: 'msg-legacy-unverified-delivery',
+        role: 'assistant',
+        content: 'I finished the design.',
+        runId: 'run-legacy-unverified-delivery',
+        runStatus: 'succeeded',
+        sessionMode: 'design',
       }),
     ).toBe(true);
     expect(

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -652,65 +652,29 @@ describe('ProjectView daemon cleanup', () => {
     expect(resolveSucceededRunStatus('canceled')).toBe('canceled');
   });
 
-  it('only replays a freshly completed unverified terminal Design-mode result', () => {
+  it('uses only a valid terminal timestamp to bound unverified Design replay', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2030-01-01T00:00:00.000Z'));
     const now = Date.now();
-    expect(
-      shouldReplayTerminalRunMessage({
-        id: 'msg-fresh-unverified-delivery',
-        role: 'assistant',
-        content: 'I finished the design.',
-        runId: 'run-fresh-unverified-delivery',
-        runStatus: 'succeeded',
-        sessionMode: 'design',
-        startedAt: now - 1_000,
-        endedAt: now,
-      }),
-    ).toBe(true);
-    expect(
-      shouldReplayTerminalRunMessage({
-        id: 'msg-historical-unverified-delivery',
-        role: 'assistant',
-        content: 'I finished the design.',
-        runId: 'run-historical-unverified-delivery',
-        runStatus: 'succeeded',
-        sessionMode: 'design',
-        startedAt: 1,
-        endedAt: 1,
-      }),
-    ).toBe(false);
-    expect(
-      shouldReplayTerminalRunMessage({
-        id: 'msg-stale-unverified-delivery',
-        role: 'assistant',
-        content: 'I finished the design.',
-        runId: 'run-stale-unverified-delivery',
-        runStatus: 'succeeded',
-        sessionMode: 'design',
-        startedAt: now - 60_001,
-        endedAt: now - 60_001,
-      }),
-    ).toBe(false);
-    expect(
-      shouldReplayTerminalRunMessage({
-        id: 'msg-legacy-unverified-delivery',
-        role: 'assistant',
-        content: 'I finished the design.',
-        runId: 'run-legacy-unverified-delivery',
-        runStatus: 'succeeded',
-        sessionMode: 'design',
-      }),
-    ).toBe(true);
-    expect(
-      shouldReplayTerminalRunMessage({
-        id: 'msg-chat-answer',
-        role: 'assistant',
-        content: 'Here is the answer.',
-        runId: 'run-chat-answer',
-        runStatus: 'succeeded',
-        sessionMode: 'chat',
-        startedAt: 1,
-      }),
-    ).toBe(false);
+    const message = (id: string, endedAt?: number): ChatMessage => ({
+      id,
+      role: 'assistant',
+      content: 'I finished the design.',
+      runId: `run-${id}`,
+      runStatus: 'succeeded',
+      sessionMode: 'design',
+      createdAt: now - 61_000,
+      startedAt: now - 61_000,
+      ...(endedAt === undefined ? {} : { endedAt }),
+    });
+
+    expect(shouldReplayTerminalRunMessage(message('fresh', now))).toBe(true);
+    expect(shouldReplayTerminalRunMessage(message('boundary', now - 60_000))).toBe(true);
+    expect(shouldReplayTerminalRunMessage(message('stale', now - 60_001))).toBe(false);
+    expect(shouldReplayTerminalRunMessage(message('future', now + 1))).toBe(false);
+    // No stored terminal timestamp means the effect must consult daemon updatedAt,
+    // not infer completion age from the much older run start timestamps.
+    expect(shouldReplayTerminalRunMessage(message('missing-ended-at'))).toBe(true);
   });
 
   // Regression: a phantom 'running' row in DB (no runId, no matching active

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -1767,6 +1767,7 @@ describe('ProjectView conversation run isolation', () => {
       {
         ...succeededAssistant,
         content: '',
+        endedAt: Date.now(),
         sessionMode: 'design',
         events: [
           { kind: 'text', text: 'I finished the design.' },
@@ -1826,6 +1827,7 @@ describe('ProjectView conversation run isolation', () => {
       {
         ...succeededAssistant,
         content: '',
+        endedAt: Date.now(),
         sessionMode: 'design',
         events: [{ kind: 'text', text: 'The hero image contrast is too low.' }],
         preTurnFileNames: [],


### PR DESCRIPTION
## Summary
- bound automatic Design delivery reconciliation to a 60-second terminal handoff window
- use persisted `endedAt` only when finite, non-future, and fresh; otherwise settle canonically
- when `endedAt` is absent, probe daemon status; only fresh `succeeded` `updatedAt` can use one bounded local verification
- preserve active `queued`/`running` recovery and prevent failed/canceled snapshots from opening a terminal stream
- the one terminal verification settles on five-second expiry or generic SSE disconnect, aborting only the local stream with no retry
- partial reconnect progress is preserved and reconciled against existing project files before terminal classification
- all late callbacks are fenced after settlement, including `onError`, `onRunStatus`, and `onRunEventId`; terminal settlement cancels buffered writes and `finally` cannot flush after expiry

## Verification
- focused regression suite: 183/183 passed (`reattach-restore`, `run-cleanup`, `run-isolation`)
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/web build`
- `git diff --check`

## Scope
No runtime release, database, service, migration, data row, or production configuration was changed. This remains a draft pending upstream review and separately authorized local promotion.

- ignore historical `queued`/`running` SSE status frames during bounded terminal verification so they cannot downgrade `succeeded` before canonical settlement
