### PR TITLE
fix(web): surface the blocked-origin guard instead of an empty project list

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -172,6 +172,7 @@ import {
   importFolderProject,
   invalidatePluginCatalogCache,
   invalidateWorkspaceProjectLists,
+  isBlockedOriginError,
   listWorkspaceProjectSummaries,
   listProjects,
   listTemplates,
@@ -1192,6 +1193,11 @@ function AppInner() {
   }, []);
   const [dsLoading, setDsLoading] = useState(true);
   const [projectsLoading, setProjectsLoading] = useState(true);
+  // Set only when the daemon's powered-preview origin guard rejected the
+  // project list. Holds the loopback address the user should switch to, so
+  // the projects tab can say why it is empty instead of claiming there are
+  // no projects.
+  const [blockedOriginUrl, setBlockedOriginUrl] = useState<string | null>(null);
   const [promptTemplatesLoading, setPromptTemplatesLoading] = useState(true);
   // Goes true once the daemon-persisted config (agentId/designSystemId/etc.)
   // has merged into local state. Auto-selection effects below wait on this
@@ -2009,13 +2015,28 @@ function AppInner() {
       }
 
       const request = beginProjectListRequest(workspaceProjectViewRef.current);
+      // Startup asks for the strict variant only to inspect the failure, then
+      // reproduces the fail-soft behaviour itself: a daemon that is still
+      // coming up or briefly unreachable must keep leaving the UI rendered.
+      // The one exception is the powered-preview origin guard, which will
+      // keep rejecting until the user changes the address — reconciling []
+      // there would render a persistent misconfiguration as an empty
+      // workspace.
       void listCurrentWorkspaceProjects({
         workspaceView: workspaceProjectViewRef.current,
-      }).then((list) => {
-        if (cancelled) return;
-        reconcileFetchedProjects(list, request);
-        setProjectsLoading(false);
-      });
+        throwOnError: true,
+      })
+        .then((list) => {
+          if (cancelled) return;
+          reconcileFetchedProjects(list, request);
+          setProjectsLoading(false);
+        })
+        .catch((err: unknown) => {
+          if (cancelled) return;
+          if (isBlockedOriginError(err)) setBlockedOriginUrl(loopbackWorkaroundUrl());
+          else reconcileFetchedProjects([], request);
+          setProjectsLoading(false);
+        });
 
       void listTemplates().then((list) => {
         if (cancelled) return;
@@ -4980,6 +5001,7 @@ function AppInner() {
           workspaceDesignSystems.identity !== currentWorkspaceCatalogIdentity || dsLoading
         }
         projectsLoading={projectsLoading}
+        blockedOriginUrl={blockedOriginUrl}
         promptTemplatesLoading={promptTemplatesLoading}
         onCreateProject={handleCreateProject}
         onCreatePluginShareProject={handleCreatePluginShareProject}
@@ -5167,6 +5189,13 @@ function AppInner() {
       </AnimatePresence>
     </>
   );
+}
+
+// The address that reaches the daemon directly. Keeps the current port so
+// the guidance stays correct for non-default `--port` runs.
+function loopbackWorkaroundUrl(): string {
+  const { protocol, port } = window.location;
+  return `${protocol}//127.0.0.1${port ? `:${port}` : ''}`;
 }
 
 function generateInstallationIdSafe(): string {

--- a/apps/web/src/components/DesignsTab.tsx
+++ b/apps/web/src/components/DesignsTab.tsx
@@ -89,6 +89,10 @@ interface Props {
 	onRename?: (id: string, name: string) => void;
 	onNewProject?: () => void;
 	onRefresh?: () => Promise<void> | void;
+	/** Loopback address to recommend when the daemon's origin guard blocked the
+	 *  project list. Non-null means the list is empty because of the address,
+	 *  not because there are no projects. */
+	blockedOriginUrl?: string | null;
 	isActive?: boolean;
 }
 
@@ -103,6 +107,7 @@ export function DesignsTab({
 	onRename,
 	onNewProject,
 	onRefresh,
+	blockedOriginUrl = null,
 	isActive = true,
 }: Props) {
 	const renameTitleId = useId();
@@ -681,7 +686,17 @@ export function DesignsTab({
 			</div>
 			{filtered.length === 0 ? (
 				<div className="tab-empty">
-					{projects.length === 0 ? (
+					{projects.length === 0 && blockedOriginUrl ? (
+						// The list is empty because the daemon refused the request,
+						// not because the workspace is. Saying "No projects yet"
+						// here sends the user looking for lost work instead of at
+						// the address bar, so name the cause and the fix.
+						<div className="designs-empty-state" role="alert">
+							<h2 className="designs-empty-title">
+								{t("designs.blockedOrigin", { url: blockedOriginUrl })}
+							</h2>
+						</div>
+					) : projects.length === 0 ? (
 						<div className="designs-empty-state">
 							<h2 className="designs-empty-title">
 								{t("designs.emptyNoProjects")}

--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -423,6 +423,10 @@ interface Props {
   skillsLoading?: boolean;
   designSystemsLoading?: boolean;
   projectsLoading?: boolean;
+  /** Loopback address to recommend when the daemon's origin guard blocked the
+   *  project list. Non-null means the list is empty because of the address,
+   *  not because there are no projects. */
+  blockedOriginUrl?: string | null;
   // Execution / model-switching context. Threaded down from `App` so the
   // top-bar `InlineModelSwitcher` can render the active mode/agent/model
   // and persist changes through the same callbacks the project view uses.
@@ -560,6 +564,7 @@ export function EntryShell({
   skillsLoading = false,
   designSystemsLoading = false,
   projectsLoading = false,
+  blockedOriginUrl = null,
   config,
   providerModelsCache: sharedProviderModelsCache,
   onProviderModelsCacheChange,
@@ -1642,6 +1647,7 @@ export function EntryShell({
                     onDuplicate={onDuplicateProject}
                     onRename={onRenameProject}
                     onRefresh={onProjectsRefresh}
+                    blockedOriginUrl={blockedOriginUrl}
                     isActive={view === 'projects'}
                     onNewProject={() => {
                       openNewProject();

--- a/apps/web/src/components/EntryView.tsx
+++ b/apps/web/src/components/EntryView.tsx
@@ -111,6 +111,10 @@ interface Props {
   skillsLoading?: boolean;
   designSystemsLoading?: boolean;
   projectsLoading?: boolean;
+  /** Loopback address to recommend when the daemon's origin guard blocked the
+   *  project list. Non-null means the list is empty because of the address,
+   *  not because there are no projects. */
+  blockedOriginUrl?: string | null;
   promptTemplatesLoading?: boolean;
   onCreateProject: (input: EntryCreateProjectInput) => Promise<boolean> | boolean | void;
   onCreatePluginShareProject: (
@@ -273,6 +277,7 @@ export function EntryView({
   skillsLoading = false,
   designSystemsLoading = false,
   projectsLoading = false,
+  blockedOriginUrl = null,
   promptTemplatesLoading: _promptTemplatesLoading = false,
   onCreateProject,
   onCreatePluginShareProject,
@@ -377,6 +382,7 @@ export function EntryView({
       skillsLoading={skillsLoading}
       designSystemsLoading={designSystemsLoading}
       projectsLoading={projectsLoading}
+      blockedOriginUrl={blockedOriginUrl}
       config={config}
       providerModelsCache={providerModelsCache}
       onProviderModelsCacheChange={onProviderModelsCacheChange}

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -1894,6 +1894,7 @@ export const ar: Dict = {
   'designs.filterAria': 'تصفية المشاريع',
   'designs.searchPlaceholder': 'بحث...',
   'designs.emptyNoProjects': 'لا توجد مشاريع بعد.',
+  'designs.blockedOrigin': 'تعذّر تحميل المشاريع: حظر الـ daemon هذا العنوان. افتح {url} بدلاً منه.',
   'designs.emptyNoMatch': 'لا توجد مشاريع تطابق بحثك.',
   'designs.deleteTitle': 'حذف المشروع',
   'designs.deleteConfirm': 'هل تريد حذف "{name}"؟',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -1894,6 +1894,7 @@ export const de: Dict = {
   'designs.filterAria': 'Projekte filtern',
   'designs.searchPlaceholder': 'Suchen…',
   'designs.emptyNoProjects': 'Noch keine Projekte.',
+  'designs.blockedOrigin': 'Projekte konnten nicht geladen werden: Der Daemon hat diese Adresse blockiert. Öffne stattdessen {url}.',
   'designs.emptyNoMatch': 'Keine Projekte passen zu Ihrer Suche.',
   'designs.deleteTitle': 'Projekt löschen',
   'designs.deleteConfirm': '„{name}“ löschen?',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -1894,6 +1894,7 @@ export const en: Dict = {
   'designs.filterAria': 'Filter projects',
   'designs.searchPlaceholder': 'Search…',
   'designs.emptyNoProjects': 'No projects yet.',
+  'designs.blockedOrigin': 'Projects could not load: the daemon blocked this address. Open {url} instead.',
   'designs.emptyNoMatch': 'No projects match your search.',
   'designs.deleteTitle': 'Delete project',
   'designs.deleteConfirm': 'Delete "{name}"?',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -1894,6 +1894,7 @@ export const esES: Dict = {
   'designs.filterAria': 'Filtrar proyectos',
   'designs.searchPlaceholder': 'Buscar…',
   'designs.emptyNoProjects': 'Aún no hay proyectos.',
+  'designs.blockedOrigin': 'No se pudieron cargar los proyectos: el daemon bloqueó esta dirección. Abre {url} en su lugar.',
   'designs.emptyNoMatch': 'Ningún proyecto coincide con tu búsqueda.',
   'designs.deleteTitle': 'Eliminar proyecto',
   'designs.deleteConfirm': '¿Eliminar «{name}»?',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -1894,6 +1894,7 @@ export const fa: Dict = {
   'designs.filterAria': 'فیلتر پروژه‌ها',
   'designs.searchPlaceholder': 'جستجو…',
   'designs.emptyNoProjects': 'هنوز هیچ پروژه‌ای وجود ندارد.',
+  'designs.blockedOrigin': 'پروژه‌ها بارگذاری نشدند: دیمن این نشانی را مسدود کرد. به‌جای آن {url} را باز کنید.',
   'designs.emptyNoMatch': 'هیچ پروژه‌ای با جستجوی شما مطابقت ندارد.',
   'designs.deleteTitle': 'حذف پروژه',
   'designs.deleteConfirm': 'آیا «{name}» حذف شود؟',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -1894,6 +1894,7 @@ export const fr: Dict = {
   'designs.filterAria': 'Filtrer les projets',
   'designs.searchPlaceholder': 'Rechercher…',
   'designs.emptyNoProjects': 'Aucun projet pour l\'instant.',
+  'designs.blockedOrigin': 'Impossible de charger les projets : le daemon a bloqué cette adresse. Ouvrez plutôt {url}.',
   'designs.emptyNoMatch': 'Aucun projet ne correspond à votre recherche.',
   'designs.deleteTitle': 'Supprimer le projet',
   'designs.deleteConfirm': 'Supprimer « {name} » ?',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -1894,6 +1894,7 @@ export const hu: Dict = {
   'designs.filterAria': 'Projektek szűrése',
   'designs.searchPlaceholder': 'Keresés…',
   'designs.emptyNoProjects': 'Még nincs projekt.',
+  'designs.blockedOrigin': 'A projekteket nem sikerült betölteni: a daemon blokkolta ezt a címet. Nyisd meg helyette ezt: {url}.',
   'designs.emptyNoMatch': 'Egy projekt sem felel meg a keresésnek.',
   'designs.deleteTitle': 'Projekt törlése',
   'designs.deleteConfirm': 'Törlöd a(z) „{name}" projektet?',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -1894,6 +1894,7 @@ export const id: Dict = {
   'designs.filterAria': 'Filter proyek',
   'designs.searchPlaceholder': 'Cari...',
   'designs.emptyNoProjects': 'Belum ada proyek.',
+  'designs.blockedOrigin': 'Proyek tidak dapat dimuat: daemon memblokir alamat ini. Buka {url} sebagai gantinya.',
   'designs.emptyNoMatch': 'Tidak ada proyek yang cocok dengan pencarianmu.',
   'designs.deleteTitle': 'Hapus proyek',
   'designs.deleteConfirm': 'Hapus "{name}"?',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -1894,6 +1894,7 @@ export const it: Dict = {
   'designs.filterAria': 'Filtra progetti',
   'designs.searchPlaceholder': 'Cerca…',
   'designs.emptyNoProjects': 'Nessun progetto per ora.',
+  'designs.blockedOrigin': 'Impossibile caricare i progetti: il daemon ha bloccato questo indirizzo. Apri invece {url}.',
   'designs.emptyNoMatch': 'Nessun progetto corrisponde alla tua ricerca.',
   'designs.deleteTitle': 'Elimina progetto',
   'designs.deleteConfirm': 'Eliminare « {name} » ?',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -1894,6 +1894,7 @@ export const ja: Dict = {
   'designs.filterAria': 'プロジェクトをフィルター',
   'designs.searchPlaceholder': '検索…',
   'designs.emptyNoProjects': 'プロジェクトがまだありません。',
+  'designs.blockedOrigin': 'プロジェクトを読み込めませんでした: デーモンがこのアドレスをブロックしました。代わりに {url} を開いてください。',
   'designs.emptyNoMatch': '検索に一致するプロジェクトがありません。',
   'designs.deleteTitle': 'プロジェクトを削除',
   'designs.deleteConfirm': '"{name}" を削除しますか？',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -1894,6 +1894,7 @@ export const ko: Dict = {
   'designs.filterAria': '프로젝트 필터링',
   'designs.searchPlaceholder': '검색…',
   'designs.emptyNoProjects': '아직 프로젝트가 없습니다.',
+  'designs.blockedOrigin': '프로젝트를 불러오지 못했습니다: 데몬이 이 주소를 차단했습니다. 대신 {url}을 여세요.',
   'designs.emptyNoMatch': '검색어와 일치하는 프로젝트가 없습니다.',
   'designs.deleteTitle': '프로젝트 삭제',
   'designs.deleteConfirm': '"{name}" 프로젝트를 삭제하시겠습니까?',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -1894,6 +1894,7 @@ export const pl: Dict = {
   'designs.filterAria': 'Filtruj projekty',
   'designs.searchPlaceholder': 'Szukaj…',
   'designs.emptyNoProjects': 'Brak projektów.',
+  'designs.blockedOrigin': 'Nie można załadować projektów: demon zablokował ten adres. Otwórz zamiast tego {url}.',
   'designs.emptyNoMatch': 'Brak projektów pasujących do wyszukiwania.',
   'designs.deleteTitle': 'Usuń projekt',
   'designs.deleteConfirm': 'Usunąć „{name}”?',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -1894,6 +1894,7 @@ export const ptBR: Dict = {
   'designs.filterAria': 'Filtrar projetos',
   'designs.searchPlaceholder': 'Buscar…',
   'designs.emptyNoProjects': 'Ainda não há projetos.',
+  'designs.blockedOrigin': 'Não foi possível carregar os projetos: o daemon bloqueou este endereço. Abra {url} em vez disso.',
   'designs.emptyNoMatch': 'Nenhum projeto corresponde à sua busca.',
   'designs.deleteTitle': 'Excluir projeto',
   'designs.deleteConfirm': 'Excluir "{name}"?',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -1894,6 +1894,7 @@ export const ru: Dict = {
   'designs.filterAria': 'Фильтр проектов',
   'designs.searchPlaceholder': 'Поиск…',
   'designs.emptyNoProjects': 'Проектов пока нет.',
+  'designs.blockedOrigin': 'Не удалось загрузить проекты: демон заблокировал этот адрес. Откройте вместо этого {url}.',
   'designs.emptyNoMatch': 'Нет проектов, соответствующих вашему поиску.',
   'designs.deleteTitle': 'Удалить проект',
   'designs.deleteConfirm': 'Удалить «{name}»?',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -1894,6 +1894,7 @@ export const th: Dict = {
   'designs.filterAria': 'ตัวกรอง',
   'designs.searchPlaceholder': 'ค้นหา…',
   'designs.emptyNoProjects': 'ยังไม่มีโปรเจกต์',
+  'designs.blockedOrigin': 'โหลดโปรเจกต์ไม่ได้: daemon บล็อกที่อยู่นี้ เปิด {url} แทน',
   'designs.emptyNoMatch': 'ไม่พบโปรเจกต์',
   'designs.deleteTitle': 'ลบโปรเจกต์',
   'designs.deleteConfirm': 'ลบ "{name}"?',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -1894,6 +1894,7 @@ export const tr: Dict = {
   'designs.filterAria': 'Projeleri filtrele',
   'designs.searchPlaceholder': 'Ara…',
   'designs.emptyNoProjects': 'Henüz proje yok.',
+  'designs.blockedOrigin': 'Projeler yüklenemedi: daemon bu adresi engelledi. Bunun yerine {url} adresini açın.',
   'designs.emptyNoMatch': 'Hiçbir proje aramanızla örtüşmedi.',
   'designs.deleteTitle': 'Projeyi sil',
   'designs.deleteConfirm': '"{name}"’i sil?',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -1894,6 +1894,7 @@ export const uk: Dict = {
   'designs.filterAria': 'Фільтрувати проекти',
   'designs.searchPlaceholder': 'Пошук…',
   'designs.emptyNoProjects': 'Проектів ще немає.',
+  'designs.blockedOrigin': 'Не вдалося завантажити проєкти: демон заблокував цю адресу. Відкрийте натомість {url}.',
   'designs.emptyNoMatch': 'Проектів, що відповідають пошуку, не знайдено.',
   'designs.deleteTitle': 'Видалити проект',
   'designs.deleteConfirm': 'Видалити "{name}"?',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -1985,6 +1985,7 @@ export const zhCN: Dict = {
   "designs.filterAria": "筛选项目",
   "designs.searchPlaceholder": "搜索…",
   "designs.emptyNoProjects": "还没有项目。",
+  "designs.blockedOrigin": "无法加载项目：daemon 阻止了此地址。请改为打开 {url}。",
   "designs.emptyNoMatch": "没有匹配的项目。",
   "designs.deleteTitle": "删除项目",
   "designs.deleteConfirm": "确定删除「{name}」？",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -1993,6 +1993,7 @@ export const zhTW: Dict = {
   "designs.filterAria": "篩選專案",
   "designs.searchPlaceholder": "搜尋…",
   "designs.emptyNoProjects": "還沒有專案。",
+  "designs.blockedOrigin": "無法載入專案：daemon 已封鎖此位址。請改為開啟 {url}。",
   "designs.emptyNoMatch": "沒有符合的專案。",
   "designs.deleteTitle": "刪除專案",
   "designs.deleteConfirm": "確定刪除「{name}」？",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -2477,6 +2477,7 @@ export interface Dict {
   'designs.filterAria': string;
   'designs.searchPlaceholder': string;
   'designs.emptyNoProjects': string;
+  'designs.blockedOrigin': string;
   'designs.emptyNoMatch': string;
   'designs.deleteTitle': string;
   'designs.deleteConfirm': string;

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -203,6 +203,47 @@ function omitWorkspaceContext<T extends { workspaceContext?: WorkspaceCollabCont
   return rest;
 }
 
+// The daemon rejects every non-preview API route when the page was loaded
+// from the powered-preview host — the Linux/Docker case where the daemon
+// binds 127.0.0.1 and the user opens `localhost`. Unlike the transport
+// failures this module deliberately swallows, it never heals on its own:
+// the address has to change. Callers discriminate on it via
+// `isBlockedOriginError` so they can keep failing soft for everything else.
+const BLOCKED_ORIGIN_DAEMON_ERROR = 'Powered preview origin cannot access this API route';
+
+export class ProjectsRequestError extends Error {
+  readonly status: number;
+  readonly daemonError: string | null;
+
+  constructor(status: number, daemonError: string | null) {
+    super(`projects ${status}`);
+    this.name = 'ProjectsRequestError';
+    this.status = status;
+    this.daemonError = daemonError;
+  }
+}
+
+export function isBlockedOriginError(err: unknown): boolean {
+  return (
+    err instanceof ProjectsRequestError &&
+    err.status === 403 &&
+    err.daemonError === BLOCKED_ORIGIN_DAEMON_ERROR
+  );
+}
+
+// Every daemon guard answers with a structured `{ error }` envelope, so the
+// permanent origin rejection is distinguishable from transient 403s such as
+// `Server initializing`. A body that is absent or unparseable is simply not
+// one of those guards.
+async function readDaemonError(resp: Response): Promise<string | null> {
+  try {
+    const json = (await resp.json()) as { error?: unknown };
+    return typeof json.error === 'string' ? json.error : null;
+  } catch {
+    return null;
+  }
+}
+
 export async function listProjects(options?: {
   throwOnError?: boolean;
   workspaceContext?: WorkspaceCollabContext | null;
@@ -248,7 +289,7 @@ export async function listProjects(options?: {
       const resp = await fetch('/api/projects');
       // Throw inside the coalesced run so a failed read is not cached — the next
       // caller/poll retries immediately (see coalesced-get.ts).
-      if (!resp.ok) throw new Error(`projects ${resp.status}`);
+      if (!resp.ok) throw new ProjectsRequestError(resp.status, await readDaemonError(resp));
       const json = (await resp.json()) as { projects: Project[] };
       return json.projects ?? [];
     });

--- a/apps/web/tests/components/DesignsTab.empty.test.tsx
+++ b/apps/web/tests/components/DesignsTab.empty.test.tsx
@@ -147,6 +147,52 @@ describe('DesignsTab empty state', () => {
     expect(src).toContain('workspaceMemberId=member-designs');
   });
 
+  // #6263: on Linux/Docker the daemon binds 127.0.0.1 and a browser visit to
+  // `localhost` is rejected by the powered-preview origin guard. The list came
+  // back empty because the request was refused, so the empty state must not
+  // claim there are no projects.
+  it('names the blocked address instead of claiming there are no projects', () => {
+    const onNewProject = vi.fn();
+    render(
+      <DesignsTab
+        projects={[]}
+        skills={[]}
+        designSystems={[]}
+        onOpen={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDelete={vi.fn()}
+        onRename={vi.fn()}
+        onNewProject={onNewProject}
+        blockedOriginUrl="http://127.0.0.1:7456"
+      />,
+    );
+
+    expect(screen.queryByText('No projects yet.')).toBeNull();
+    const alert = screen.getByRole('alert');
+    expect(alert.textContent).toContain('http://127.0.0.1:7456');
+    // The CTA would create a project through the same blocked API.
+    expect(screen.queryByRole('button', { name: 'New project' })).toBeNull();
+  });
+
+  it('keeps the ordinary empty state when nothing is blocked', () => {
+    render(
+      <DesignsTab
+        projects={[]}
+        skills={[]}
+        designSystems={[]}
+        onOpen={vi.fn()}
+        onOpenLiveArtifact={vi.fn()}
+        onDelete={vi.fn()}
+        onRename={vi.fn()}
+        onNewProject={vi.fn()}
+        blockedOriginUrl={null}
+      />,
+    );
+
+    expect(screen.getByText('No projects yet.')).toBeTruthy();
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
   it('renders No projects match your search when projects exist but query filters them out', () => {
     render(
       <DesignsTab

--- a/apps/web/tests/state/projects.test.ts
+++ b/apps/web/tests/state/projects.test.ts
@@ -15,6 +15,7 @@ import {
   importFolderProject,
   invalidateWorkspaceProjectLists,
   installGeneratedPluginFolder,
+  isBlockedOriginError,
   listPlugins,
   listPluginsFresh,
   invalidatePluginCatalogCache,
@@ -470,6 +471,48 @@ describe('listProjects', () => {
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
     release();
     await Promise.all([first, second]);
+  });
+
+  it('flags the powered-preview origin guard so startup can surface it (#6263)', async () => {
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(
+      JSON.stringify({ error: 'Powered preview origin cannot access this API route' }),
+      { status: 403, headers: { 'content-type': 'application/json' } },
+    )));
+
+    const err = await listProjects({ throwOnError: true }).catch((e: unknown) => e);
+
+    expect(isBlockedOriginError(err)).toBe(true);
+  });
+
+  // Control arm: `Server initializing` is also a 403, but the daemon is merely
+  // still coming up and the next attempt succeeds. Keying on the status alone
+  // would turn a self-healing startup race into a permanent error screen.
+  it('does not flag transient 403s such as the daemon still initializing', async () => {
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(
+      JSON.stringify({ error: 'Server initializing' }),
+      { status: 403, headers: { 'content-type': 'application/json' } },
+    )));
+
+    const err = await listProjects({ throwOnError: true }).catch((e: unknown) => e);
+
+    expect(isBlockedOriginError(err)).toBe(false);
+  });
+
+  it('does not flag a 403 that carries no daemon error envelope', async () => {
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(null, { status: 403 })));
+
+    const err = await listProjects({ throwOnError: true }).catch((e: unknown) => e);
+
+    expect(isBlockedOriginError(err)).toBe(false);
+  });
+
+  it('leaves the blocked origin fail-soft for callers that did not opt into errors', async () => {
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>(async () => new Response(
+      JSON.stringify({ error: 'Powered preview origin cannot access this API route' }),
+      { status: 403, headers: { 'content-type': 'application/json' } },
+    )));
+
+    await expect(listProjects()).resolves.toEqual([]);
   });
 });
 


### PR DESCRIPTION
> **Reopening #6302 under a new number.** That PR was closed by the queue bot on Aug 5 ("waiting on author action (merge conflict, failing CI), no human activity for more than 5 days") — correctly, it had gone `CONFLICTING`. I've rebased it onto current `main`, but GitHub refuses to reopen a closed PR whose head commit no longer exists after a force-push, so this supersedes it. Same branch, same scope, no review had been left on the old one.
>
> Flagging it because @lefarcen said on #6263 that the issue stays open until **#6302 and #6325 both land** — that tracking reference now points here.

---

Part of #6263

## Why

I picked this up from the issue queue after @lefarcen confirmed it and posted acceptance criteria. It is a small bug with an outsized cost: a **permanent misconfiguration is rendered as an empty workspace**, so the user goes looking for lost projects instead of at the address bar.

Tracing it turned up a mechanism that already exists and an asymmetry that does not make sense:

- `listProjects(options?: { throwOnError?: boolean })` already models "this caller cannot tolerate a failure", and `ProjectReferenceModal.tsx` plus `refreshProjectsStrict` (`App.tsx`) already opt in.
- The **initial** load in `App.tsx` still used the bare call. So a manual refresh reports the error correctly, while opening the page silently renders the empty state.

The fail-soft default is deliberate and documented in two places (`state/projects.ts` file header — *"so the UI can stay rendered when the daemon is briefly unreachable"* — and the test name *"keeps the default fail-soft behavior for background app startup"*), so this PR does **not** make startup strict. The real axis is **transient vs permanent**, not startup vs refresh: a daemon that is still coming up heals itself; the powered-preview origin guard never will until the user changes the address.

Per @lefarcen's refinement, the exception is keyed to the **structured origin-guard error body**, not the raw `403` — `Server initializing` is also a `403` and is exactly the self-healing case that must stay soft.

## What users will see

On Linux/Docker host networking, opening `http://localhost:7456` while the daemon is bound to `127.0.0.1` no longer shows **"No projects yet."** in the Projects tab. It now shows an inline error naming the cause and the workaround:

> Projects could not load: the daemon blocked this address. Open http://127.0.0.1:7456 instead.

The address in the message is built from the live port, so it stays correct for non-default `--port` runs. The "New project" CTA is hidden in this state — it would go through the same blocked API.

Everything else is unchanged: a genuinely empty workspace still gets the normal empty state and CTA, and a daemon that is briefly unreachable at startup still leaves the UI rendered.

## Surface area

- [x] **UI** — Projects tab empty state in `apps/web`
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [x] **i18n keys** — one new key `designs.blockedOrigin`, translated in all 19 locales
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

## Screenshots

Both captured end-to-end against a real daemon + web build (Playwright with `/api/projects` fulfilled by the actual guard response), not from a component harness. The port shown is the dev server's.

**Blocked origin — `/api/projects` returns `403 {"error":"Powered preview origin cannot access this API route"}`**

![blocked origin](https://raw.githubusercontent.com/maxmilian/open-design/assets/pr-6263/6263-after.png)

**Control — genuinely empty workspace (`200 {"projects":[]}`), unchanged**

![empty workspace](https://raw.githubusercontent.com/maxmilian/open-design/assets/pr-6263/6263-empty.png)

## Bug fix verification

- Test paths that reproduce the bug:
  - `apps/web/tests/state/projects.test.ts` — the origin guard is flagged; **control arms** assert that a transient `403 Server initializing` and a bodyless `403` are *not* flagged, and that the default fail-soft path still resolves `[]`.
  - `apps/web/tests/components/DesignsTab.empty.test.tsx` — the blocked state names the address and does not claim there are no projects; a second case locks the ordinary empty state.
- Did the tests go red before the source change? **Yes.** With `state/projects.ts` and `DesignsTab.tsx` reverted and the specs kept, 4 of the new cases fail (`isBlockedOriginError is not a function` ×3, and `expected <h2 class="designs-empty-title"></h2> to be null`); the rest of the file stays green.

## Validation

- `pnpm guard` — exit 0
- `pnpm typecheck` — clean across every package
- `pnpm --filter @open-design/web test` — **443 files / 4907 passed, 7 skipped**, including `tests/i18n/locales.test.ts` (the tier-1 zh-CN/ja parity locks and the all-locale key/placeholder alignment for the new key).
  - The run reports 2 uncaught async errors attributed to `tests/components/FileViewer.test.tsx` (`window is not defined` from a timer firing after teardown). Running that file on its own passes **207/207 with no errors**, on this branch and on unmodified `main` — parallel-teardown noise, not a regression from this change.
- Screenshots above produced with a throwaway Playwright spec (not committed) driving the real daemon + web build.

Kept as `Part of #6263` rather than `Fixes`: the Linux Docker quickstart wording (`127.0.0.1` vs `localhost`) is the second half of the issue and is not in this PR.

---

## Rebase notes (Aug 6)

Not a mechanical rebase — `main` moved under two of the touched files, so here is what changed and why.

**`state/projects.ts`** — `listProjects` is now wrapped in `coalescedGet`, so the throw site moved inside the coalesced run. The patch applies there instead:

```ts
if (!resp.ok) throw new ProjectsRequestError(resp.status, await readDaemonError(resp));
```

The outer `catch` already rethrows when `throwOnError` is set, so the fail-soft default is untouched.

**`App.tsx`** — startup now reads through `listCurrentWorkspaceProjects` rather than `listProjects` directly. I kept the new call and moved the error handling onto it rather than reverting to the old one. It forwards `throwOnError` straight through, so the behaviour is preserved: with a workspace context the read goes through `listWorkspaceProjectSummaries`, `isBlockedOriginError` is false, and it fails soft exactly as `main` does today. The Docker/`localhost` case this issue is about has no workspace context, so it still goes through `/api/projects` and is still detected.

**One thing I found but did not fix.** The workspace-scoped path added since this branch's base has the same hole:

```ts
// listWorkspaceProjectSummaries
if (!resp.ok) throw new Error(`projects ${resp.status}`);
```

The origin guard rejects *every* non-preview route, so a Workspace user on the blocked address gets the same silent empty list this PR exists to prevent. Extending `ProjectsRequestError` there is a two-line change, but it widens the scope of a PR that was already reviewed as-is, so I've left it out — happy to add it here or file it separately, whichever you prefer.

## Verification on the rebased head

- `tests/state/projects.test.ts` + `tests/components/DesignsTab.empty.test.tsx` — **72 passed**, with the four `#6263` cases running alongside the new workspace tests `main` added
- full `apps/web/tests/state/` + `apps/web/tests/components/` — **3939 passed, 0 failed**
- `tsc --noEmit` clean across every touched file

