### PR TITLE
fix(web): lazy-render design file grids and gate thumbnail fetches

### DIFF
--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAnalytics } from '../analytics/provider';
 import { trackFileManagerClick } from '../analytics/events';
 import { useT } from '../i18n';
@@ -138,6 +138,77 @@ const SECTION_ORDER: FileCategory[] = [
 
 const STYLESHEET_EXTENSIONS = new Set(['css', 'scss', 'sass', 'less']);
 const HTML_THUMBNAIL_INLINE_MAX_BYTES = 512 * 1024;
+
+// Incremental grid rendering: the page-card grid and the image masonry start
+// with this many entries and reveal the next batch when the invisible
+// end-of-grid sentinel nears the viewport. Root views intentionally list every
+// nested file (see dirsAtCurrentDir), so a web-clone project can put 4000+
+// HTML files in one section — rendering them all at once froze the client.
+const GRID_RENDER_BATCH = 48;
+
+// At most this many thumbnail content fetches run concurrently. Each visible
+// card fetches its HTML to build a srcDoc preview; without a cap, a large
+// section fires thousands of parallel fetches, exhausting local sockets
+// (net::ERR_INSUFFICIENT_RESOURCES) and starving the web<->daemon proxy.
+const MAX_CONCURRENT_HTML_THUMBNAIL_FETCHES = 6;
+
+let activeHtmlThumbnailFetches = 0;
+const queuedHtmlThumbnailFetches: Array<() => void> = [];
+
+// Start queued thumbnail fetches on a microtask, never synchronously from a
+// release. A synchronous pump would let one card's unmount cleanup start a
+// queued fetch for a sibling card that is being torn down in the same commit
+// (its own cleanup just hasn't run yet). Deferring to a microtask lets every
+// cleanup dequeue its task first; the pump then only starts live tasks.
+function pumpHtmlThumbnailFetchQueue(): void {
+  queueMicrotask(() => {
+    while (
+      activeHtmlThumbnailFetches < MAX_CONCURRENT_HTML_THUMBNAIL_FETCHES
+      && queuedHtmlThumbnailFetches.length > 0
+    ) {
+      queuedHtmlThumbnailFetches.shift()!();
+    }
+  });
+}
+
+/**
+ * FIFO concurrency gate for thumbnail content fetches. `start` runs once a
+ * slot is free (synchronously when one is available now) and receives the
+ * release function to call when the fetch settles. The returned release is
+ * the same function, for effect cleanup; it is idempotent, so settling and a
+ * later unmount may both call it:
+ * - released before starting → the queued task is removed and never runs;
+ * - released after starting → the slot frees and the queue pumps (async).
+ */
+function acquireHtmlThumbnailFetchSlot(
+  start: (release: () => void) => void,
+): () => void {
+  let started = false;
+  let released = false;
+  const release = () => {
+    if (released) return;
+    released = true;
+    if (!started) {
+      const index = queuedHtmlThumbnailFetches.indexOf(run);
+      if (index >= 0) queuedHtmlThumbnailFetches.splice(index, 1);
+      return;
+    }
+    activeHtmlThumbnailFetches -= 1;
+    pumpHtmlThumbnailFetchQueue();
+  };
+  const run = () => {
+    if (released) return;
+    started = true;
+    activeHtmlThumbnailFetches += 1;
+    start(release);
+  };
+  if (activeHtmlThumbnailFetches < MAX_CONCURRENT_HTML_THUMBNAIL_FETCHES) {
+    run();
+  } else {
+    queuedHtmlThumbnailFetches.push(run);
+  }
+  return release;
+}
 
 function fileCategory(file: ProjectFile): FileCategory {
   const dot = file.name.lastIndexOf('.');
@@ -564,6 +635,39 @@ export function DesignFilesPanel({
     const pages = availableTabs.find((tab) => tab.id === 'cat:html');
     return (pages ?? availableTabs[0])?.id ?? null;
   }, [activeTab, availableTabs]);
+
+  // Incremental grid rendering (see GRID_RENDER_BATCH). Only one card grid is
+  // on screen at a time (one active tab), so a single revealed-count state
+  // serves both the page-card grid and the image masonry. Environments
+  // without IntersectionObserver (jsdom) render every entry at once, matching
+  // the previous behavior.
+  const canLazyRenderGrids = typeof IntersectionObserver !== 'undefined';
+  const [gridRenderLimit, setGridRenderLimit] = useState(GRID_RENDER_BATCH);
+  const gridScopeKey = `${currentDir}\u0000${resolvedTab ?? ''}`;
+  const [gridScope, setGridScope] = useState(gridScopeKey);
+  if (gridScope !== gridScopeKey) {
+    // Adjust-during-render reset: navigating directories or switching tabs
+    // must drop the revealed count back to the initial batch BEFORE the new
+    // list paints, or one throwaway frame would render it at the old count.
+    setGridScope(gridScopeKey);
+    setGridRenderLimit(GRID_RENDER_BATCH);
+  }
+  const revealNextGridBatch = useCallback(() => {
+    setGridRenderLimit((limit) => limit + GRID_RENDER_BATCH);
+  }, []);
+  const limitGridEntries = (sectionFiles: ProjectFile[]): ProjectFile[] =>
+    canLazyRenderGrids ? sectionFiles.slice(0, gridRenderLimit) : sectionFiles;
+  const renderGridSentinel = (sectionFiles: ProjectFile[]) =>
+    canLazyRenderGrids && sectionFiles.length > gridRenderLimit ? (
+      <GridRenderSentinel
+        // Keyed by the revealed count so each batch re-observes from scratch:
+        // a fresh observation always reports the current intersection state,
+        // so a sentinel still inside the extended viewport after a batch
+        // keeps revealing until it leaves it or the list is exhausted.
+        key={`grid-sentinel:${gridRenderLimit}`}
+        onReveal={revealNextGridBatch}
+      />
+    ) : null;
 
   // Prune selections that no longer exist in the current file list
   // (e.g. after a refresh or delete within the same project).
@@ -1638,13 +1742,15 @@ export function DesignFilesPanel({
                       // Page cards are self-describing — a straight grid
                       // under the tab bar.
                       <div className="df-card-grid">
-                        {sectionFiles.map((f) => renderPageCard(f, category))}
+                        {limitGridEntries(sectionFiles).map((f) => renderPageCard(f, category))}
+                        {renderGridSentinel(sectionFiles)}
                       </div>
                     ) : category === 'image' ? (
                       // Images read as their own preview — a masonry waterfall
                       // of natural-aspect thumbnails instead of list rows.
                       <div className="df-image-masonry" data-testid="design-files-image-masonry">
-                        {sectionFiles.map((f) => renderImageCard(f, category))}
+                        {limitGridEntries(sectionFiles).map((f) => renderImageCard(f, category))}
+                        {renderGridSentinel(sectionFiles)}
                       </div>
                     ) : (
                       sectionFiles.map((f) => renderFileRow(f, category))
@@ -1744,6 +1850,55 @@ export function DesignFilesPanel({
   );
 }
 
+// Invisible end-of-grid marker that reveals the next render batch when it
+// nears the viewport. Deliberately renders no visible UI — no button, no
+// loading copy — so an incrementally rendered grid reads exactly like a fully
+// rendered one. The 1200px bottom rootMargin reveals the next batch well
+// before the user reaches the end of the rendered cards.
+function GridRenderSentinel({ onReveal }: { onReveal: () => void }) {
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const node = sentinelRef.current;
+    // The parent only renders the sentinel when IntersectionObserver exists
+    // (environments without it fall back to rendering the full grid), so this
+    // guard is for safety, not a jsdom fallback path.
+    if (!node || typeof IntersectionObserver === 'undefined') return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            onReveal();
+            observer.disconnect();
+            break;
+          }
+        }
+      },
+      { rootMargin: '0px 0px 1200px 0px' },
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [onReveal]);
+
+  return (
+    <div
+      ref={sentinelRef}
+      data-testid="design-files-grid-sentinel"
+      aria-hidden
+      // Spans the card grid's full row (gridColumn) and avoids splitting
+      // across masonry columns (breakInside) while staying visually absent.
+      style={{
+        gridColumn: '1 / -1',
+        breakInside: 'avoid',
+        blockSize: 1,
+        margin: 0,
+        padding: 0,
+        border: 0,
+      }}
+    />
+  );
+}
+
 // Pages are laid out at a desktop-ish width and scaled down to the card, so
 // the thumbnail reads as a zoomed-out page preview instead of the page's
 // narrow mobile layout cropped to the card's top-left corner.
@@ -1804,6 +1959,36 @@ function HtmlCardThumbnail({
   const hostRef = useRef<HTMLDivElement | null>(null);
   const [scale, setScale] = useState<number | null>(null);
 
+  // Content fetches wait until the card scrolls near the viewport; the 800px
+  // bottom rootMargin prefetches cards about to be scrolled into view, and a
+  // card that has intersected once stays "near" for good (same pattern as
+  // ExampleCard in ExamplesTab). Environments without IntersectionObserver
+  // (jsdom) fall back to treating every card as immediately visible.
+  const [nearViewport, setNearViewport] = useState(false);
+  useEffect(() => {
+    if (nearViewport) return;
+    const host = hostRef.current;
+    if (!host) return;
+    if (typeof IntersectionObserver === 'undefined') {
+      setNearViewport(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setNearViewport(true);
+            observer.disconnect();
+            break;
+          }
+        }
+      },
+      { rootMargin: '0px 0px 800px 0px' },
+    );
+    observer.observe(host);
+    return () => observer.disconnect();
+  }, [nearViewport]);
+
   useEffect(() => {
     setSrcDoc(null);
     if (tooLargeForThumbnail || !thumbnailIdentity) return;
@@ -1819,30 +2004,42 @@ function HtmlCardThumbnail({
       setSrcDoc(buildSrcdoc(cachedSource, { baseHref }));
       return;
     }
+    // Only an actual network load waits for viewport proximity (cached
+    // sources above render immediately) and for a free fetch slot — the
+    // gate + pool that keep a huge grid from firing thousands of fetches.
+    if (!nearViewport) return;
     let cancelled = false;
-    void loadHtmlThumbnailSource(
-      thumbnailIdentity,
-      async () => {
-        const response = await fetch(
-          appendResourceQuery(url, `v=${Math.round(file.mtime)}`),
-          {},
-        );
-        return response?.ok ? response.text() : null;
-      },
-    ).then((html) => {
-        if (cancelled || html === null) return;
-        const nextSrcDoc = buildSrcdoc(html, { baseHref });
-        if (!cancelled) setSrcDoc(nextSrcDoc);
-      })
-      .catch((err) => {
-        if (!cancelled) setSrcDoc(null);
-      });
+    const releaseSlot = acquireHtmlThumbnailFetchSlot((release) => {
+      void loadHtmlThumbnailSource(
+        thumbnailIdentity,
+        async () => {
+          const response = await fetch(
+            appendResourceQuery(url, `v=${Math.round(file.mtime)}`),
+            {},
+          );
+          return response?.ok ? response.text() : null;
+        },
+      ).then((html) => {
+          if (cancelled || html === null) return;
+          const nextSrcDoc = buildSrcdoc(html, { baseHref });
+          if (!cancelled) setSrcDoc(nextSrcDoc);
+        })
+        .catch(() => {
+          if (!cancelled) setSrcDoc(null);
+        })
+        // Success, failure, and abandonment all pass through here exactly
+        // once per acquired slot; release itself is idempotent, so the
+        // unmount cleanup below calling it again is safe.
+        .finally(release);
+    });
     return () => {
       cancelled = true;
+      releaseSlot();
     };
   }, [
     authorizationScopeKey,
     baseHref,
+    nearViewport,
     refreshKey,
     tooLargeForThumbnail,
     url,

--- a/apps/web/src/components/DesignFilesPanel.tsx
+++ b/apps/web/src/components/DesignFilesPanel.tsx
@@ -174,11 +174,16 @@ function pumpHtmlThumbnailFetchQueue(): void {
 /**
  * FIFO concurrency gate for thumbnail content fetches. `start` runs once a
  * slot is free (synchronously when one is available now) and receives the
- * release function to call when the fetch settles. The returned release is
- * the same function, for effect cleanup; it is idempotent, so settling and a
- * later unmount may both call it:
- * - released before starting → the queued task is removed and never runs;
- * - released after starting → the slot frees and the queue pumps (async).
+ * release function to call when the fetch settles. The returned function
+ * abandons the reservation, for effect cleanup:
+ * - abandoned before starting → the queued task is removed and never runs;
+ * - abandoned after starting → the slot stays held until the underlying
+ *   request settles and the settle path calls `release`. Cleanup must never
+ *   free a slot whose request is still on the network: releasing early would
+ *   let the queue pump start replacement fetches while the abandoned ones are
+ *   still in flight, pushing real connection concurrency above the cap during
+ *   directory/project navigation — the exact socket-exhaustion path this pool
+ *   exists to prevent.
  */
 function acquireHtmlThumbnailFetchSlot(
   start: (release: () => void) => void,
@@ -188,26 +193,27 @@ function acquireHtmlThumbnailFetchSlot(
   const release = () => {
     if (released) return;
     released = true;
-    if (!started) {
-      const index = queuedHtmlThumbnailFetches.indexOf(run);
-      if (index >= 0) queuedHtmlThumbnailFetches.splice(index, 1);
-      return;
-    }
     activeHtmlThumbnailFetches -= 1;
     pumpHtmlThumbnailFetchQueue();
   };
   const run = () => {
-    if (released) return;
     started = true;
     activeHtmlThumbnailFetches += 1;
     start(release);
+  };
+  let abandoned = false;
+  const abandon = () => {
+    if (abandoned || started) return;
+    abandoned = true;
+    const index = queuedHtmlThumbnailFetches.indexOf(run);
+    if (index >= 0) queuedHtmlThumbnailFetches.splice(index, 1);
   };
   if (activeHtmlThumbnailFetches < MAX_CONCURRENT_HTML_THUMBNAIL_FETCHES) {
     run();
   } else {
     queuedHtmlThumbnailFetches.push(run);
   }
-  return release;
+  return abandon;
 }
 
 function fileCategory(file: ProjectFile): FileCategory {
@@ -2009,7 +2015,7 @@ function HtmlCardThumbnail({
     // gate + pool that keep a huge grid from firing thousands of fetches.
     if (!nearViewport) return;
     let cancelled = false;
-    const releaseSlot = acquireHtmlThumbnailFetchSlot((release) => {
+    const abandonSlot = acquireHtmlThumbnailFetchSlot((release) => {
       void loadHtmlThumbnailSource(
         thumbnailIdentity,
         async () => {
@@ -2027,14 +2033,16 @@ function HtmlCardThumbnail({
         .catch(() => {
           if (!cancelled) setSrcDoc(null);
         })
-        // Success, failure, and abandonment all pass through here exactly
-        // once per acquired slot; release itself is idempotent, so the
-        // unmount cleanup below calling it again is safe.
+        // Success and failure both pass through here exactly once per
+        // started fetch — the ONLY place a started fetch's slot is freed.
+        // Cleanup below abandons the reservation without freeing the slot,
+        // so a fetch abandoned mid-flight keeps its slot until the network
+        // actually settles it and real concurrency stays within the cap.
         .finally(release);
     });
     return () => {
       cancelled = true;
-      releaseSlot();
+      abandonSlot();
     };
   }, [
     authorizationScopeKey,

--- a/apps/web/tests/design-files-lazy-render.test.tsx
+++ b/apps/web/tests/design-files-lazy-render.test.tsx
@@ -6,8 +6,10 @@
 // fetches exhausted local sockets (net::ERR_INSUFFICIENT_RESOURCES) and
 // 502'd the web<->daemon proxy. The contract under test:
 //   1. thumbnail content fetches start only once a card nears the viewport;
-//   2. at most 6 thumbnail fetches are in flight at once (FIFO queue), and
-//      slots return on completion AND on unmount;
+//   2. at most 6 thumbnail fetches are in flight at once (FIFO queue);
+//      unmount drops queued tasks, but a slot whose request already started
+//      stays held until the request settles — real network concurrency must
+//      never exceed the cap, even across unmount/remount navigation churn;
 //   3. the page-card grid and image masonry render incrementally behind an
 //      invisible end-of-grid sentinel (no visible UI change);
 //   4. the root directory still lists every nested file (semantics guard).
@@ -154,13 +156,22 @@ function renderPanel(
   );
 }
 
-/** fetch stub whose responses stay pending until the test releases them. */
+/**
+ * fetch stub whose responses stay pending until the test releases them.
+ * Every release is also registered module-wide so afterEach can settle
+ * whatever a test left pending: an in-flight request holds its pool slot
+ * until it settles (slots are NOT freed by unmount), so an unsettled mock
+ * fetch would leak its slot into the next test. Firing a release twice is
+ * harmless — resolving an already-resolved promise is a no-op.
+ */
+const outstandingReleases: Array<() => void> = [];
+
 function pendingFetchMock() {
   const releases: Array<() => void> = [];
   const fetchMock = vi.fn(
     () =>
       new Promise<Response>((resolve) => {
-        releases.push(() =>
+        const release = () =>
           resolve(
             new Response(
               "<!doctype html><html><body><main>page</main></body></html>",
@@ -169,8 +180,9 @@ function pendingFetchMock() {
                 headers: { "Content-Type": "text/html; charset=utf-8" },
               },
             ),
-          ),
-        );
+          );
+        releases.push(release);
+        outstandingReleases.push(release);
       }),
   );
   return { fetchMock, releases };
@@ -195,8 +207,13 @@ beforeEach(() => {
   vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver);
 });
 
-afterEach(() => {
+afterEach(async () => {
   cleanup();
+  // Settle every request the test left pending so retained slots return to
+  // the pool before the next test starts (see pendingFetchMock docblock).
+  await act(async () => {
+    for (const release of outstandingReleases.splice(0)) release();
+  });
   vi.unstubAllGlobals();
 });
 
@@ -234,23 +251,41 @@ describe("DesignFilesPanel thumbnail fetch viewport gating", () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(9));
   });
 
-  it("returns slots on unmount so later cards can still start fetching", () => {
-    const { fetchMock } = pendingFetchMock();
+  it("keeps unmounted in-flight requests counted against the cap and drops their queued siblings", async () => {
+    const { fetchMock, releases } = pendingFetchMock();
     vi.stubGlobal("fetch", fetchMock);
 
     const first = renderPanel(nestedHtmlFiles(10, "ja"));
     intersectAll(".df-thumb-scale-host");
     expect(fetchMock).toHaveBeenCalledTimes(6);
 
-    // Unmounting with 6 fetches in flight and 4 queued must release every
-    // slot AND drop the queued tasks — without starting them mid-teardown.
+    // Unmounting with 6 fetches in flight and 4 queued must drop the queued
+    // tasks without starting them. The 6 in-flight requests are still on the
+    // network — cleanup must NOT free their slots early.
     first.unmount();
     expect(fetchMock).toHaveBeenCalledTimes(6);
 
+    // A replacement grid mounts while the abandoned requests are still in
+    // flight (the directory-switch scenario from the incident). Its cards
+    // must queue behind them: releasing slots at unmount would start 6 new
+    // fetches here and push real network concurrency to 12.
     const second = renderPanel(nestedHtmlFiles(10, "de"));
     intersectAll(".df-thumb-scale-host");
-    // A leaked pool would leave 0 free slots and start nothing here.
-    expect(fetchMock).toHaveBeenCalledTimes(12);
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+
+    // Only as the abandoned requests actually settle do their slots return
+    // and the queued replacement cards start, FIFO, still capped at 6.
+    await act(async () => {
+      for (const release of releases.splice(0, 6)) release();
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(12));
+
+    // Settling the replacement wave starts the remaining 4 queued cards:
+    // 6 abandoned + 10 replacement requests total, never more than 6 live.
+    await act(async () => {
+      for (const release of releases.splice(0, 6)) release();
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(16));
     second.unmount();
   });
 });

--- a/apps/web/tests/design-files-lazy-render.test.tsx
+++ b/apps/web/tests/design-files-lazy-render.test.tsx
@@ -1,0 +1,333 @@
+// @vitest-environment jsdom
+
+// Regression suite for the 0.18.0 client meltdown: a 7442-file web-clone
+// project rendered EVERY nested HTML file as a thumbnail card at the project
+// root, and every card fetched its content on mount. 4000+ concurrent
+// fetches exhausted local sockets (net::ERR_INSUFFICIENT_RESOURCES) and
+// 502'd the web<->daemon proxy. The contract under test:
+//   1. thumbnail content fetches start only once a card nears the viewport;
+//   2. at most 6 thumbnail fetches are in flight at once (FIFO queue), and
+//      slots return on completion AND on unmount;
+//   3. the page-card grid and image masonry render incrementally behind an
+//      invisible end-of-grid sentinel (no visible UI change);
+//   4. the root directory still lists every nested file (semantics guard).
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ComponentProps } from "react";
+
+import { DesignFilesPanel } from "../src/components/DesignFilesPanel";
+import { resetHtmlThumbnailSourceCache } from "../src/components/html-thumbnail-source-cache";
+import type { ProjectFile } from "../src/types";
+
+// Stub localStorage with an in-memory store so no test bleeds view state into
+// the next (same convention as tests/components/DesignFilesPanel.test.tsx).
+const lsStore = new Map<string, string>();
+
+// Manually triggerable IntersectionObserver stand-in. jsdom ships no
+// IntersectionObserver, and the component treats that as "everything is
+// immediately visible" — so lazy behavior can only be asserted by installing
+// a fake whose intersections the test fires explicitly.
+type IntersectionCallback = (
+  entries: IntersectionObserverEntry[],
+  observer: IntersectionObserver,
+) => void;
+
+class FakeIntersectionObserver {
+  static instances: FakeIntersectionObserver[] = [];
+
+  static reset(): void {
+    FakeIntersectionObserver.instances = [];
+  }
+
+  readonly observed = new Set<Element>();
+
+  constructor(
+    readonly callback: IntersectionCallback,
+    readonly options?: IntersectionObserverInit,
+  ) {
+    FakeIntersectionObserver.instances.push(this);
+  }
+
+  observe(target: Element): void {
+    this.observed.add(target);
+  }
+
+  unobserve(target: Element): void {
+    this.observed.delete(target);
+  }
+
+  disconnect(): void {
+    this.observed.clear();
+  }
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
+function fireIntersection(target: Element): void {
+  for (const instance of [...FakeIntersectionObserver.instances]) {
+    if (!instance.observed.has(target)) continue;
+    instance.callback(
+      [{ isIntersecting: true, target } as unknown as IntersectionObserverEntry],
+      instance as unknown as IntersectionObserver,
+    );
+  }
+}
+
+/** Fire intersection for every element currently matching `selector`. */
+function intersectAll(selector: string): void {
+  act(() => {
+    for (const el of Array.from(document.querySelectorAll(selector))) {
+      fireIntersection(el);
+    }
+  });
+}
+
+/** Reveal grid batches until the sentinel disappears (list fully rendered). */
+function drainGridSentinel(maxRounds = 30): void {
+  for (let round = 0; round < maxRounds; round += 1) {
+    const sentinel = screen.queryByTestId("design-files-grid-sentinel");
+    if (!sentinel) return;
+    act(() => fireIntersection(sentinel));
+  }
+  throw new Error("grid sentinel never drained");
+}
+
+const BASE_MTIME = 1700000000000;
+
+function htmlFile(name: string, index: number): ProjectFile {
+  return {
+    name,
+    path: name,
+    type: "file",
+    size: 4096,
+    mtime: BASE_MTIME - index * 1000,
+    kind: "html",
+    mime: "text/html",
+  };
+}
+
+/**
+ * Nested pages shaped like the web-clone incident project: every file lives
+ * several directories deep (`ja/plugins/p1/index.html`), none at the root.
+ */
+function nestedHtmlFiles(count: number, localeRoot = "ja"): ProjectFile[] {
+  return Array.from({ length: count }, (_, i) =>
+    htmlFile(`${localeRoot}/plugins/p${i + 1}/index.html`, i),
+  );
+}
+
+function imageFile(name: string, index: number): ProjectFile {
+  return {
+    name,
+    path: name,
+    type: "file",
+    size: 2048,
+    mtime: BASE_MTIME - index * 1000,
+    kind: "image",
+    mime: "image/png",
+  };
+}
+
+function renderPanel(
+  files: ProjectFile[],
+  overrides: Partial<ComponentProps<typeof DesignFilesPanel>> = {},
+) {
+  return render(
+    <DesignFilesPanel
+      projectId="lazy-render-project"
+      files={files}
+      liveArtifacts={[]}
+      onRefreshFiles={vi.fn()}
+      onOpenFile={vi.fn()}
+      onOpenLiveArtifact={vi.fn()}
+      onRenameFile={vi.fn()}
+      onDeleteFile={vi.fn()}
+      onDeleteFiles={vi.fn()}
+      onUpload={vi.fn()}
+      onUploadFiles={vi.fn()}
+      onPaste={vi.fn()}
+      onNewSketch={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+/** fetch stub whose responses stay pending until the test releases them. */
+function pendingFetchMock() {
+  const releases: Array<() => void> = [];
+  const fetchMock = vi.fn(
+    () =>
+      new Promise<Response>((resolve) => {
+        releases.push(() =>
+          resolve(
+            new Response(
+              "<!doctype html><html><body><main>page</main></body></html>",
+              {
+                status: 200,
+                headers: { "Content-Type": "text/html; charset=utf-8" },
+              },
+            ),
+          ),
+        );
+      }),
+  );
+  return { fetchMock, releases };
+}
+
+beforeEach(() => {
+  lsStore.clear();
+  resetHtmlThumbnailSourceCache();
+  FakeIntersectionObserver.reset();
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => lsStore.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      lsStore.set(key, value);
+    },
+    removeItem: (key: string) => {
+      lsStore.delete(key);
+    },
+    clear: () => {
+      lsStore.clear();
+    },
+  });
+  vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("DesignFilesPanel thumbnail fetch viewport gating", () => {
+  it("fetches no thumbnail content on mount before any card nears the viewport", () => {
+    const { fetchMock } = pendingFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderPanel(nestedHtmlFiles(200));
+
+    // The root view lists all 200 nested pages, but not a single content
+    // fetch may start until a card actually intersects the viewport.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps at most 6 thumbnail fetches in flight and drains the FIFO queue as slots free up", async () => {
+    const { fetchMock, releases } = pendingFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderPanel(nestedHtmlFiles(50));
+
+    // Reveal every card: the initial batch plus the sentinel (which appends
+    // the remaining cards), then the freshly appended cards' hosts.
+    intersectAll("[data-testid='design-files-grid-sentinel'], .df-thumb-scale-host");
+    intersectAll(".df-thumb-scale-host");
+    expect(container.querySelectorAll(".df-card-grid .df-card").length).toBe(50);
+
+    // 50 visible cards, none resolved yet: exactly 6 fetches in flight.
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+
+    // Settling fetches returns their slots and starts queued cards, FIFO.
+    await act(async () => {
+      for (const release of releases.splice(0, 3)) release();
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(9));
+  });
+
+  it("returns slots on unmount so later cards can still start fetching", () => {
+    const { fetchMock } = pendingFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const first = renderPanel(nestedHtmlFiles(10, "ja"));
+    intersectAll(".df-thumb-scale-host");
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+
+    // Unmounting with 6 fetches in flight and 4 queued must release every
+    // slot AND drop the queued tasks — without starting them mid-teardown.
+    first.unmount();
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+
+    const second = renderPanel(nestedHtmlFiles(10, "de"));
+    intersectAll(".df-thumb-scale-host");
+    // A leaked pool would leave 0 free slots and start nothing here.
+    expect(fetchMock).toHaveBeenCalledTimes(12);
+    second.unmount();
+  });
+});
+
+describe("DesignFilesPanel incremental grid rendering", () => {
+  it("renders at most 48 page cards initially for 500 files and grows on sentinel intersection", () => {
+    const { fetchMock } = pendingFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderPanel(nestedHtmlFiles(500));
+
+    expect(container.querySelectorAll(".df-card-grid .df-card").length).toBe(48);
+
+    const sentinel = screen.getByTestId("design-files-grid-sentinel");
+    act(() => fireIntersection(sentinel));
+    expect(container.querySelectorAll(".df-card-grid .df-card").length).toBe(96);
+  });
+
+  it("renders the image masonry incrementally behind the same sentinel", () => {
+    // Root-level names: with no folders and no pages, Images is the sole tab
+    // and the masonry is the default view.
+    const { container } = renderPanel(
+      Array.from({ length: 120 }, (_, i) => imageFile(`img-${i + 1}.png`, i)),
+    );
+
+    expect(
+      container.querySelectorAll(".df-image-masonry .df-card--image").length,
+    ).toBe(48);
+
+    const sentinel = screen.getByTestId("design-files-grid-sentinel");
+    act(() => fireIntersection(sentinel));
+    expect(
+      container.querySelectorAll(".df-image-masonry .df-card--image").length,
+    ).toBe(96);
+  });
+
+  it("adds no visible chrome: no load-more button and no loading copy", () => {
+    const { fetchMock } = pendingFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderPanel(nestedHtmlFiles(500));
+
+    const sentinel = screen.getByTestId("design-files-grid-sentinel");
+    expect(sentinel.textContent).toBe("");
+    // Every button inside the grid belongs to a card, not to pagination.
+    const grid = container.querySelector(".df-card-grid")!;
+    for (const button of Array.from(grid.querySelectorAll("button"))) {
+      expect(button.closest(".df-card")).not.toBeNull();
+    }
+  });
+});
+
+// Semantics guard: the root view's recursive flat listing is intentional
+// (#see dirsAtCurrentDir derivation) — the lazy-render fix must not silently
+// turn it into an immediate-children-only listing. Green before AND after.
+describe("DesignFilesPanel root recursive listing (guard)", () => {
+  it("still lists every nested file at the root and can reveal them all", () => {
+    const { fetchMock } = pendingFetchMock();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderPanel(nestedHtmlFiles(200));
+
+    // The Pages tab counts every nested page, not just the rendered batch.
+    expect(
+      document.querySelector(
+        "[data-testid='design-files-tab-cat:html'] .df-tab-count",
+      )?.textContent,
+    ).toBe("200");
+
+    // Scrolling through the whole grid eventually renders every card.
+    drainGridSentinel();
+    expect(container.querySelectorAll(".df-card-grid .df-card").length).toBe(200);
+    expect(
+      screen.getByTestId("design-file-row-ja/plugins/p1/index.html"),
+    ).toBeTruthy();
+    expect(
+      screen.getByTestId("design-file-row-ja/plugins/p200/index.html"),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Fixes #6512

## Why

A 0.18.0 stable user's diagnostics bundle showed the client melting down on a 7,442-file project (a web-clone agent produced a full 19-locale static mirror of a website). The design files panel root view mounts every nested HTML file as a page card at once, and every `HtmlCardThumbnail` fetches its content on mount — the bundle shows 8,705 raw-file requests across 4,042 distinct files in 23 seconds, 7,889 × `net::ERR_INSUFFICIENT_RESOURCES`, machine-wide socket exhaustion (the daemon's own outbound calls failed with `EADDRNOTAVAIL`), 30 minutes of `projects 502` (project list / workspace switching dead until restart), and a renderer SIGTRAP crash. See #6512 for the full incident analysis.

## What users will see

No visual or interaction change. The design files grids look and scroll exactly as before; thumbnails now appear as cards approach the viewport instead of all at once. On huge projects (thousands of files), the panel stays responsive and no longer takes the rest of the app down with it.

## Surface area

- [ ] **UI** — no new page / dialog / panel / menu item / setting; rendering behavior only
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — thumbnail content loads lazily (viewport-gated, max 6 concurrent fetches) and card grids render incrementally (48 per batch behind an invisible scroll sentinel). Perceptible only as thumbnails fading in near the viewport; no new chrome, buttons, or copy.
- [ ] **None**

## Screenshots

Not applicable: the fix is deliberately invisible — the grid renders identically to the eager version (a test asserts no visible chrome is added). Behavior is verified by the red/green spec below and by request-count evidence in #6512.

## Bug fix verification

- Test path: `apps/web/tests/design-files-lazy-render.test.tsx`
- Red on `main`, green on this branch: **yes** — with the spec present and the source change reverted (origin/main component), 6 of 7 tests fail exactly on the incident behaviors:
  - `expected "vi.fn()" to not be called at all, but actually been called 200 times` (mount-time fetch flood)
  - `expected "vi.fn()" to be called 6 times, but got 50 times` (no concurrency cap)
  - `expected 500 to be 48` (grid renders every card at once)
  - the 7th (root recursive listing semantics guard) is green before and after, by design.

## Validation

- `pnpm --filter @open-design/web test` — 598 files / 6,228 tests passed, 11 skipped (full suite, includes the new spec)
- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm guard` — exit 0
- `pnpm typecheck` — exit 0 (full workspace)

## Design notes

- **Fetch gating**: `HtmlCardThumbnail` starts its content fetch only after the card host first intersects an 800px-extended viewport (same pattern as `ExamplesTab`); cached sources render immediately. A module-level FIFO pool caps concurrent thumbnail fetches at 6; slot release is idempotent and covers settle, unmount mid-flight, and unmount while still queued. The queue pump defers to a microtask so one card's unmount cleanup can't start a fetch for a sibling being torn down in the same commit.
- **Incremental grids**: the page-card grid and image masonry render 48 entries per batch behind an invisible end-of-grid sentinel (1200px rootMargin, keyed per batch so a sentinel still inside the extended viewport keeps revealing until the list is exhausted). Directory/tab changes reset the revealed count via an adjust-during-render reset. The root view's intentional recursive flat listing is unchanged and guarded by a test.
- **Fallback**: environments without `IntersectionObserver` (jsdom) keep the previous eager behavior.

## Adjacent issues (tracked in #6512, not in this PR)

- `od://` proxy retry + undici fallback amplify resource-exhaustion errors (packaged shell, separate PR).
- Thumbnail iframes execute artifact scripts (`allow-scripts`) — pending product decision.
- Daemon resilience under local socket exhaustion; diagnostics export losing the pre-restart daemon log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
