### PR TITLE
fix(byok): restore BYOK model switching in the home and composer pickers

### DIFF
--- a/apps/web/src/components/AvatarMenu.tsx
+++ b/apps/web/src/components/AvatarMenu.tsx
@@ -13,6 +13,13 @@ import {
   effectiveAgentModelChoice,
 } from './agentModelSelection';
 import { orderModelOptionsByAvailability } from './modelOptions';
+import {
+  mergeProviderModelOptions,
+  providerModelsCacheKey,
+} from './providerModelsCache';
+import { KNOWN_PROVIDERS } from '../state/config';
+import { SUGGESTED_MODELS_BY_PROTOCOL } from '../state/apiProtocols';
+import { fetchProviderModels } from '../providers/provider-models';
 import type { AgentInfo, AppConfig, ExecMode, ProviderModelOption } from '../types';
 import {
   canUpgradeVelaPlan,
@@ -71,6 +78,8 @@ export function AvatarMenu({
   agents,
   onAgentChange,
   onAgentModelChange,
+  onApiModelChange,
+  providerModelsCache,
   onOpenSettings,
   onBack,
   placement = 'down',
@@ -317,6 +326,86 @@ export function AvatarMenu({
     currentAgent?.reasoningOptions?.find((option) => option.id === currentReasoningId)?.label ??
     currentReasoningId;
   const apiModelLabel = config.model?.trim() || null;
+
+  // BYOK catalogue for the composer popover. The popover is the model picker
+  // for the ACTIVE execution mode, so BYOK mode offers a selectable provider
+  // catalogue writing through `onApiModelChange`, exactly like daemon mode
+  // offers the agent catalogue through `onAgentModelChange` (regression
+  // #6142 collapsed this into a read-only readout). Models come from the
+  // shared Settings cache when the host passes one, with a local discovery
+  // fetch as fallback so surfaces without cache wiring still get the live
+  // catalogue; the curated suggested list seeds the merge either way.
+  const apiProtocol = config.apiProtocol ?? 'anthropic';
+  const byokProvider = useMemo(
+    () =>
+      KNOWN_PROVIDERS.find(
+        (provider) =>
+          provider.protocol === apiProtocol &&
+          (config.apiProviderBaseUrl
+            ? provider.baseUrl === config.apiProviderBaseUrl
+            : false),
+      ) ?? KNOWN_PROVIDERS.find((provider) => provider.protocol === apiProtocol),
+    [apiProtocol, config.apiProviderBaseUrl],
+  );
+  const byokModelsKey = providerModelsCacheKey(
+    apiProtocol,
+    config.baseUrl ?? '',
+    config.apiKey ?? '',
+    config.apiVersion ?? '',
+  );
+  const [discoveredByokModels, setDiscoveredByokModels] = useState<
+    Record<string, ProviderModelOption[]>
+  >({});
+  const fetchedByokModels =
+    providerModelsCache?.[byokModelsKey] ??
+    discoveredByokModels[byokModelsKey] ??
+    [];
+
+  useEffect(() => {
+    if (!open || config.mode !== 'api') return;
+    if (fetchedByokModels.length > 0) return;
+    if (apiProtocol === 'azure' || apiProtocol === 'ollama') return;
+    const baseUrl = config.baseUrl?.trim() ?? '';
+    if (!/^https?:\/\//i.test(baseUrl)) return;
+    // AIHubMix's catalogue is public; every other protocol needs a key.
+    if (apiProtocol !== 'aihubmix' && !(config.apiKey ?? '').trim()) return;
+    const key = byokModelsKey;
+    let cancelled = false;
+    void fetchProviderModels({
+      protocol: apiProtocol,
+      baseUrl,
+      apiKey: config.apiKey ?? '',
+    })
+      .then((result) => {
+        if (cancelled || !result.ok || !result.models?.length) return;
+        setDiscoveredByokModels((current) => ({
+          ...current,
+          [key]: result.models ?? [],
+        }));
+      })
+      .catch(() => {
+        // Non-fatal: the list falls back to the suggested seed models.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    open,
+    config.mode,
+    apiProtocol,
+    config.baseUrl,
+    config.apiKey,
+    byokModelsKey,
+    fetchedByokModels.length,
+  ]);
+
+  const byokModelOptions = mergeProviderModelOptions(
+    fetchedByokModels,
+    byokProvider?.preferredModels.length
+      ? byokProvider.preferredModels
+      : SUGGESTED_MODELS_BY_PROTOCOL[apiProtocol] ?? [],
+  );
+
   // Selected-model readout shown inside the trigger (left of the Send button).
   // Hidden by default in CSS; composer-row contexts opt it in.
   const triggerModelLabel =
@@ -559,15 +648,87 @@ export function AvatarMenu({
             </>
           ) : null}
 
-          {config.mode === 'api' && apiModelLabel ? (
-            <div className="avatar-model-section">
-              <div className="avatar-select-row">
-                <span className="avatar-select-label">
-                  {t('avatar.modelLabel')}
-                </span>
-                <div className="avatar-static-value">{apiModelLabel}</div>
+          {config.mode === 'api' ? (
+            byokModelOptions.length > 0 ? (
+              <div className="avatar-model-section">
+                <div className="avatar-select-row">
+                  <span className="avatar-select-label">
+                    {t('avatar.modelLabel')}
+                  </span>
+                  <div
+                    className="avatar-model-list"
+                    role="radiogroup"
+                    aria-label={t('avatar.modelLabel')}
+                    data-testid="avatar-model-list"
+                  >
+                    {(config.model &&
+                    !byokModelOptions.some((m) => m.id === config.model)
+                      ? [
+                          ...byokModelOptions,
+                          {
+                            id: config.model,
+                            label: `${config.model} ${t('avatar.customSuffix')}`,
+                          },
+                        ]
+                      : byokModelOptions
+                    ).map((model) => {
+                      const active = model.id === config.model;
+                      return (
+                        <button
+                          key={model.id}
+                          type="button"
+                          role="radio"
+                          aria-checked={active}
+                          className={`avatar-model-option${active ? ' is-active' : ''}`}
+                          data-testid={`avatar-model-option-${model.id}`}
+                          onClick={() => {
+                            onApiModelChange?.(model.id);
+                            // Selection made — dismiss the popover right away.
+                            setOpen(false);
+                          }}
+                        >
+                          <span
+                            className="avatar-model-option-logo"
+                            aria-hidden="true"
+                          >
+                            {(() => {
+                              const src = modelProviderIconSrc(model.id);
+                              return src ? (
+                                <img src={src} alt="" width={16} height={16} />
+                              ) : (
+                                <RemixIcon name="link" size={16} />
+                              );
+                            })()}
+                          </span>
+                          <span className="avatar-model-option-label">
+                            {model.label}
+                          </span>
+                          {active ? (
+                            <RemixIcon
+                              name="check-line"
+                              size={14}
+                              className="avatar-model-option-check"
+                            />
+                          ) : null}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
               </div>
-            </div>
+            ) : apiModelLabel ? (
+              // Never an empty shell: with no catalogue to offer (e.g. Azure
+              // deployments are free-form names), keep the current model
+              // visible as a readout.
+              <div className="avatar-model-section">
+                <div className="avatar-select-row">
+                  <span className="avatar-select-label">
+                    {t('avatar.modelLabel')}
+                  </span>
+                  <div className="avatar-static-value">{apiModelLabel}</div>
+                </div>
+              </div>
+            ) : null
           ) : null}
 
           {/* The one link out to 设置 → 执行. #5517's popover has no such entry,

--- a/apps/web/src/components/InlineModelSwitcher.tsx
+++ b/apps/web/src/components/InlineModelSwitcher.tsx
@@ -1190,7 +1190,108 @@ export function InlineModelSwitcher({
           </div>
           )}
 
-          {compact ? (
+          {/* The popover body always reflects the ACTIVE execution mode:
+              `compact` only chooses layout density, never which catalogue is
+              on offer. A BYOK chip therefore always opens onto the BYOK
+              provider's model list (regression: the compact home popover kept
+              listing the local CLI agent's cloud models while the chip showed
+              the BYOK model). */}
+          {config.mode === 'api' ? (
+            <>
+              {compact ? null : (
+              <div className="inline-switcher__row">
+                <span className="inline-switcher__label">
+                  {t('inlineSwitcher.providerLabel')}
+                </span>
+                <div className="inline-switcher__chips" role="tablist">
+                  {API_PROTOCOL_TABS.map((tab) => {
+                    const active = apiProtocol === tab.id;
+                    return (
+                      <button
+                        key={tab.id}
+                        type="button"
+                        role="tab"
+                        aria-selected={active}
+                        className={
+                          'inline-switcher__chip-tab' +
+                          (active ? ' is-active' : '')
+                        }
+                        data-testid={`inline-model-switcher-provider-${tab.id}`}
+                        onClick={() => {
+                          // Unlike Settings (which skips unmapped protocols),
+                          // report the click even when the protocol has no v2
+                          // provider_id (e.g. aihubmix) — just omit the field.
+                          trackExecutionSettingsPopoverClick(analytics.track, {
+                            page_name: 'home',
+                            area: 'execution_settings_popover',
+                            element: 'byok_provider_tab',
+                            provider_id:
+                              byokProtocolToTracking(tab.id) ?? undefined,
+                          });
+                          onApiProtocolChange?.(tab.id);
+                        }}
+                      >
+                        {tab.title}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+              )}
+
+              <div className="inline-switcher__row">
+                <span className="inline-switcher__label">
+                  {t('inlineSwitcher.modelLabel')}
+                </span>
+                {apiModelOptions.length > 0 ? (
+                  <SearchableModelSelect
+                    className="inline-switcher__select"
+                    popoverClassName="inline-model-popover"
+                    data-testid="inline-model-switcher-api-model"
+                    searchInputTestId="inline-model-switcher-api-model-search"
+                    popoverTestId="inline-model-switcher-api-model-popover"
+                    searchPlaceholder={t('designs.searchPlaceholder')}
+                    getPopoverBoundary={getModelPopoverBoundary}
+                    aria-label={t('inlineSwitcher.modelLabel')}
+                    models={apiModelChoices}
+                    value={config.model}
+                    onChange={(nextValue) => {
+                      trackExecutionSettingsPopoverClick(analytics.track, {
+                        page_name: 'home',
+                        area: 'execution_settings_popover',
+                        element: 'model_dropdown',
+                        execution_mode: 'byok',
+                        provider_id:
+                          byokProtocolToTracking(apiProtocol) ?? undefined,
+                        model_id: modelIdForTracking(nextValue),
+                      });
+                      onApiModelChange?.(nextValue);
+                    }}
+                    additionalOptions={
+                      config.model && !apiModelIds.includes(config.model)
+                        ? [
+                            {
+                              value: config.model,
+                              label: `${config.model} ${t('inlineSwitcher.customSuffix')}`,
+                            },
+                          ]
+                        : undefined
+                    }
+                  />
+                ) : (
+                  <span className="inline-switcher__hint">
+                    {t('inlineSwitcher.openSettingsForModel')}
+                  </span>
+                )}
+              </div>
+
+              {!config.apiKey ? (
+                <div className="inline-switcher__warn" role="status">
+                  {t('inlineSwitcher.missingApiKey')}
+                </div>
+              ) : null}
+            </>
+          ) : compact ? (
             // Compact home popover: a plain list of the CURRENT agent's model
             // names (no header, no agent icons) — switching agents lives in
             // the execution settings entry below.
@@ -1279,7 +1380,7 @@ export function InlineModelSwitcher({
                 </span>
               )}
             </div>
-          ) : config.mode === 'daemon' ? (
+          ) : (
             <>
               <div className="inline-switcher__row">
                 <span className="inline-switcher__label">
@@ -1538,99 +1639,6 @@ export function InlineModelSwitcher({
                         : undefined
                     }
                   />
-                </div>
-              ) : null}
-            </>
-          ) : (
-            <>
-              <div className="inline-switcher__row">
-                <span className="inline-switcher__label">
-                  {t('inlineSwitcher.providerLabel')}
-                </span>
-                <div className="inline-switcher__chips" role="tablist">
-                  {API_PROTOCOL_TABS.map((tab) => {
-                    const active = apiProtocol === tab.id;
-                    return (
-                      <button
-                        key={tab.id}
-                        type="button"
-                        role="tab"
-                        aria-selected={active}
-                        className={
-                          'inline-switcher__chip-tab' +
-                          (active ? ' is-active' : '')
-                        }
-                        data-testid={`inline-model-switcher-provider-${tab.id}`}
-                        onClick={() => {
-                          // Unlike Settings (which skips unmapped protocols),
-                          // report the click even when the protocol has no v2
-                          // provider_id (e.g. aihubmix) — just omit the field.
-                          trackExecutionSettingsPopoverClick(analytics.track, {
-                            page_name: 'home',
-                            area: 'execution_settings_popover',
-                            element: 'byok_provider_tab',
-                            provider_id:
-                              byokProtocolToTracking(tab.id) ?? undefined,
-                          });
-                          onApiProtocolChange?.(tab.id);
-                        }}
-                      >
-                        {tab.title}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-
-              <div className="inline-switcher__row">
-                <span className="inline-switcher__label">
-                  {t('inlineSwitcher.modelLabel')}
-                </span>
-                {apiModelOptions.length > 0 ? (
-                  <SearchableModelSelect
-                    className="inline-switcher__select"
-                    popoverClassName="inline-model-popover"
-                    data-testid="inline-model-switcher-api-model"
-                    searchInputTestId="inline-model-switcher-api-model-search"
-                    popoverTestId="inline-model-switcher-api-model-popover"
-                    searchPlaceholder={t('designs.searchPlaceholder')}
-                    getPopoverBoundary={getModelPopoverBoundary}
-                    aria-label={t('inlineSwitcher.modelLabel')}
-                    models={apiModelChoices}
-                    value={config.model}
-                    onChange={(nextValue) => {
-                      trackExecutionSettingsPopoverClick(analytics.track, {
-                        page_name: 'home',
-                        area: 'execution_settings_popover',
-                        element: 'model_dropdown',
-                        execution_mode: 'byok',
-                        provider_id:
-                          byokProtocolToTracking(apiProtocol) ?? undefined,
-                        model_id: modelIdForTracking(nextValue),
-                      });
-                      onApiModelChange?.(nextValue);
-                    }}
-                    additionalOptions={
-                      config.model && !apiModelIds.includes(config.model)
-                        ? [
-                            {
-                              value: config.model,
-                              label: `${config.model} ${t('inlineSwitcher.customSuffix')}`,
-                            },
-                          ]
-                        : undefined
-                    }
-                  />
-                ) : (
-                  <span className="inline-switcher__hint">
-                    {t('inlineSwitcher.openSettingsForModel')}
-                  </span>
-                )}
-              </div>
-
-              {!config.apiKey ? (
-                <div className="inline-switcher__warn" role="status">
-                  {t('inlineSwitcher.missingApiKey')}
                 </div>
               ) : null}
             </>

--- a/apps/web/tests/components/AvatarMenu.test.tsx
+++ b/apps/web/tests/components/AvatarMenu.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { WorkspaceCollabContext } from '@open-design/contracts';
 
 import { AvatarMenu } from '../../src/components/AvatarMenu';
+import { providerModelsCacheKey } from '../../src/components/providerModelsCache';
 import type { ProjectWorkspaceScopeState } from '../../src/collab/useProjectWorkspaceScope';
 import type { AgentInfo, AppConfig, ExecMode } from '../../src/types';
 
@@ -523,6 +524,53 @@ describe('AvatarMenu', () => {
     expect(screen.queryByRole('link', {
       name: 'settings.amrUpgrade',
     })).toBeNull();
+  });
+
+  it('lets the user switch the BYOK model from the composer popover', () => {
+    // Regression (#6142): in BYOK mode the composer popover collapsed the
+    // model area into a read-only box showing the current model, so switching
+    // BYOK models from the composer became impossible. The popover is the
+    // model picker for the ACTIVE execution mode — in BYOK mode that means a
+    // selectable provider-catalogue list writing through onApiModelChange,
+    // exactly like the daemon-mode list writes through onAgentModelChange.
+    const onApiModelChange = vi.fn<(model: string) => void>();
+    render(
+      <AvatarMenu
+        config={{
+          ...baseConfig,
+          mode: 'api',
+          apiProtocol: 'openai',
+          baseUrl: 'https://api.openai.com/v1',
+          apiProviderBaseUrl: 'https://api.openai.com/v1',
+          apiKey: 'sk-test',
+          model: 'gpt-4o',
+        }}
+        agents={[codexAgent, claudeAgent]}
+        daemonLive={true}
+        onModeChange={vi.fn()}
+        onAgentChange={vi.fn()}
+        onAgentModelChange={vi.fn()}
+        onApiModelChange={onApiModelChange}
+        providerModelsCache={{
+          [providerModelsCacheKey('openai', 'https://api.openai.com/v1', 'sk-test', '')]: [
+            { id: 'gpt-4o', label: 'gpt-4o' },
+            { id: 'gpt-4o-mini', label: 'gpt-4o-mini' },
+            { id: 'gpt-5.5', label: 'gpt-5.5' },
+          ],
+        }}
+        onOpenSettings={vi.fn()}
+        onRefreshAgents={vi.fn()}
+      />,
+    );
+
+    const menu = openMenu();
+    // The current model reads as the checked option, not as a dead-end box.
+    const current = within(menu).getByRole('radio', { name: 'gpt-4o' });
+    expect(current.getAttribute('aria-checked')).toBe('true');
+
+    fireEvent.click(within(menu).getByRole('radio', { name: 'gpt-5.5' }));
+    expect(onApiModelChange).toHaveBeenCalledWith('gpt-5.5');
+    expect(screen.queryByRole('dialog', { name: 'avatar.title' })).toBeNull();
   });
 
   it('routes a locked model only when the exact project member can upgrade', async () => {

--- a/apps/web/tests/components/InlineModelSwitcher.test.tsx
+++ b/apps/web/tests/components/InlineModelSwitcher.test.tsx
@@ -1539,6 +1539,62 @@ describe('InlineModelSwitcher AMR row', () => {
     });
   });
 
+  it('offers the BYOK provider catalogue, not the CLI agent catalogue, in the compact home popover', () => {
+    // Bug: with BYOK active, the compact home-hero chip correctly showed the
+    // BYOK model (e.g. gpt-4o), but opening the popover listed the local CLI
+    // agent's models (the Open Design cloud catalogue) instead of the BYOK
+    // provider's catalogue. The popover body must always reflect the active
+    // execution mode; `compact` only affects layout density.
+    const onApiModelChange = vi.fn();
+    render(
+      <InlineModelSwitcher
+        config={{
+          ...baseConfig,
+          mode: 'api',
+          apiProtocol: 'openai',
+          baseUrl: 'https://api.openai.com/v1',
+          apiProviderBaseUrl: 'https://api.openai.com/v1',
+          apiKey: 'sk-test',
+          model: 'gpt-4o',
+        }}
+        agents={[amrAgent, codexAgent]}
+        compact
+        daemonLive={true}
+        onModeChange={vi.fn()}
+        onAgentChange={vi.fn()}
+        onAgentModelChange={vi.fn()}
+        onApiProtocolChange={vi.fn()}
+        onApiModelChange={onApiModelChange}
+        providerModelsCache={{
+          [providerModelsCacheKey('openai', 'https://api.openai.com/v1', 'sk-test', '')]: [
+            { id: 'gpt-4o', label: 'gpt-4o' },
+            { id: 'gpt-4o-mini', label: 'gpt-4o-mini' },
+            { id: 'gpt-5.5', label: 'gpt-5.5' },
+          ],
+        }}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('inline-model-switcher-chip'));
+    const popover = screen.getByTestId('inline-model-switcher-popover');
+
+    // The CLI agent's catalogue must not leak into a BYOK popover.
+    expect(within(popover).queryByText('AMR Cloud Latest')).toBeNull();
+
+    // The BYOK provider's catalogue is on offer and picking a model writes
+    // through the BYOK sink.
+    fireEvent.click(within(popover).getByTestId('inline-model-switcher-api-model'));
+    const modelPopover = screen.getByTestId(
+      'inline-model-switcher-api-model-popover',
+    );
+    expect(optionNames(modelPopover)).toEqual(
+      expect.arrayContaining(['gpt-4o', 'gpt-4o-mini', 'gpt-5.5']),
+    );
+    fireEvent.click(within(modelPopover).getByRole('option', { name: 'gpt-5.5' }));
+    expect(onApiModelChange).toHaveBeenCalledWith('gpt-5.5');
+  });
+
   it('lists fetched BYOK provider models from the shared cache', () => {
     const cacheKey = providerModelsCacheKey(
       'anthropic',

--- a/e2e/ui/visual-workspace.test.ts
+++ b/e2e/ui/visual-workspace.test.ts
@@ -205,12 +205,9 @@ test('[P2] captures the topbar BYOK execution switcher surface', async ({ page }
   await configureVisualPage(page, {
     // No local agent, which is the premise the popover assertions below already
     // state ("a BYOK config has no local agent"). `configureVisualPage`
-    // otherwise serves `[MOCK_AGENT]` from `/api/agents`, and an installed
-    // agent wins the popover: it renders that agent's model radiogroup
-    // (`radio "Default"`) instead of the BYOK provider/model rows, so the
-    // `.inline-switcher__hint` this case waits for never exists. The chip still
-    // showed the BYOK glyph and `gpt-4o`, which is why the earlier assertions
-    // passed and only the popover shape disagreed.
+    // otherwise serves `[MOCK_AGENT]` from `/api/agents`; the popover body must
+    // derive from `config.mode` either way, so the leanest fixture is the one
+    // with nothing else to draw.
     agents: [],
     config: {
       mode: 'api',
@@ -220,6 +217,25 @@ test('[P2] captures the topbar BYOK execution switcher surface', async ({ page }
       model: 'gpt-4o',
       agentId: null,
     },
+  });
+  // Deterministic BYOK catalogue: opening the popover warms the shared
+  // provider-models cache through the daemon (`/api/provider/models`), which
+  // would otherwise forward the fixture key to the real provider endpoint.
+  // The fulfilled list is what the capture and the option assertions render.
+  await page.route('**/api/provider/models', async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        kind: 'success',
+        latencyMs: 1,
+        models: [
+          { id: 'gpt-4o', label: 'gpt-4o' },
+          { id: 'gpt-4o-mini', label: 'gpt-4o-mini' },
+          { id: 'o3', label: 'o3' },
+        ],
+      }),
+    });
   });
   await gotoVisualHome(page);
 
@@ -232,18 +248,19 @@ test('[P2] captures the topbar BYOK execution switcher surface', async ({ page }
   await chip.click();
   const popover = page.getByTestId('inline-model-switcher-popover');
   await expect(popover).toBeVisible();
-  // ef9c8cd8b's compact popover carries neither the mode segmented control nor
-  // an in-place BYOK model dropdown — a BYOK config has no local agent, so the
-  // popover is the "configure the provider in Settings" hint plus the route
-  // there. Both moved to Settings → Execution and are captured in this same
-  // lane by visual-settings.test.ts ("settings BYOK" and "settings BYOK model
-  // dropdown"), which is also why the old separate
-  // `visual-topbar-byok-model-dropdown` case is gone rather than recast: on
-  // this surface it would have re-captured exactly this popover. Its guard —
-  // no in-place dropdown in the top bar — is folded in below.
+  // The compact popover body derives from the ACTIVE execution mode: with BYOK
+  // active it offers the provider's own model catalogue in place (#6515
+  // restored this after #6142 left BYOK with only a Settings hint — or, with a
+  // CLI agent installed, that agent's cloud models). Execution configuration
+  // stays folded into Settings → Execution: neither the mode segmented control
+  // nor the provider tabs mount in the top bar, and both remain captured in
+  // this same lane by visual-settings.test.ts ("settings BYOK" and "settings
+  // BYOK model dropdown").
   await expect(popover.getByTestId('inline-model-switcher-mode-api')).toHaveCount(0);
-  await expect(popover.getByTestId('inline-model-switcher-api-model')).toHaveCount(0);
-  await expect(popover.locator('.inline-switcher__hint')).toContainText(/Settings/i);
+  await expect(popover.getByTestId('inline-model-switcher-provider-openai')).toHaveCount(0);
+  const modelPicker = popover.getByTestId('inline-model-switcher-api-model');
+  await expect(modelPicker).toBeVisible();
+  await expect(modelPicker).toContainText('gpt-4o');
   await expect(popover.getByTestId('inline-model-switcher-open-settings')).toBeVisible();
 
   await captureVisual(page, 'visual-topbar-byok-switcher');
@@ -252,6 +269,12 @@ test('[P2] captures the topbar BYOK execution switcher surface', async ({ page }
     'visual-topbar-byok-switcher-popover',
     page.getByTestId('inline-model-switcher-popover'),
   );
+
+  // The catalogue is genuinely selectable, not a readout: the dropdown opens
+  // with the provider's models on offer.
+  await modelPicker.click();
+  const modelPopover = page.getByTestId('inline-model-switcher-api-model-popover');
+  await expect(modelPopover.getByRole('option', { name: 'gpt-4o-mini' })).toBeVisible();
 });
 
 test('[P2] captures the avatar menu surface', async ({ page }) => {


### PR DESCRIPTION
## Why

Reported from a packaged-client dogfooding session with a BYOK (custom provider) setup. Two model-picker surfaces regressed in #6142 (356c8c364f, the workspace-team redesign), with the same root shape — the picker stopped deriving its catalogue from the active execution mode:

- **Home page**: with BYOK active, the composer chip correctly shows the BYOK model (e.g. `gpt-4o` with the link glyph + connected dot), but opening the dropdown lists the Open Design Cloud models (deepseek-v4-flash, claude-opus-4.x, …) instead of the BYOK provider's models. #6142 introduced a compact-only popover body that unconditionally renders the local CLI agent's model rows, ignoring `config.mode === 'api'`.
- **Project detail page**: the chat composer's model popover used to offer a selectable BYOK model list (`SearchableModelSelect` writing through `onApiModelChange`). #6142 replaced it with a read-only box showing the current model, so switching BYOK models from the composer became impossible — the `onApiModelChange` / `providerModelsCache` props were left declared on `AvatarMenu` but no longer consumed.

The pain: a BYOK user can no longer see or switch their own provider's models from either everyday surface; the home popover actively misleads by offering cloud models that a BYOK run will never use.

## What users will see

- **Home page (BYOK active)**: the model chip's dropdown now lists the connected provider's models (fetched live from the provider, seeded with the curated suggestions), searchable, with the current model selected. The "Open execution settings" entry stays at the bottom. When a CLI agent is active, the dropdown is unchanged.
- **Project detail composer (BYOK active)**: the model popover shows a selectable model list again — the current model is checked, clicking another model switches to it immediately and closes the popover, matching how the CLI-mode model list already behaves. When no catalogue can be offered (e.g. Azure's free-form deployment names), the current model stays visible as a readout instead of an empty panel.

## Surface area

- [x] **UI** — restores model-list behavior in the home model chip popover and the project composer model popover in `apps/web`
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — no defaults change; this restores pre-#6142 behavior for BYOK users
- [ ] **None**

(No CLI surface: this is a web-UI regression fix for existing pickers; the underlying config write path `PUT /api/config` and `od` config handling are unchanged.)

## Screenshots

UI screenshots to be attached after manual verification in a local runtime (the fix restores pre-#6142 behavior; before/after will show the BYOK provider list replacing the cloud list in the home popover, and the selectable list replacing the static box in the composer popover).

## Bug fix verification

- Test paths that reproduce the bugs:
  - `apps/web/tests/components/InlineModelSwitcher.test.tsx` — "offers the BYOK provider catalogue, not the CLI agent catalogue, in the compact home popover"
  - `apps/web/tests/components/AvatarMenu.test.tsx` — "lets the user switch the BYOK model from the composer popover"
- Did the tests go red on `main` and green on this branch? **Yes.** Both were run against the unmodified `origin/main` source first: the InlineModelSwitcher spec fails with `AMR Cloud Latest` present in a BYOK popover, and the AvatarMenu spec fails with no selectable model radio (only the static readout). With the fix applied, both files pass fully (39/39).

Regression commit: 356c8c364f (#6142) — verified via `git show 356c8c364f~1:apps/web/src/components/AvatarMenu.tsx` (BYOK `SearchableModelSelect` present before, static box after) and the pre-#6142 `InlineModelSwitcher`, whose popover body was mode-aware for both layouts.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/web test` — 597 files, 6223 passed / 11 skipped, 0 failed

## Adjacent issues (not fixed here)

- `ProjectView` does not pass the shared `providerModelsCache` into `AvatarMenu`; the composer popover therefore warms its own local discovery cache per mount (same as pre-#6142). Wiring the App-level cache through `ProjectView` would deduplicate fetches across surfaces but touches an unrelated prop chain, so it is left out of this fix.
