### PR TITLE
fix(web): stop provisional comment pin numbers colliding after deletion

### DIFF
--- a/apps/web/src/comments.ts
+++ b/apps/web/src/comments.ts
@@ -423,18 +423,20 @@ export function commentsToAttachments(comments: PreviewComment[]): ChatCommentAt
 /**
  * Provisional canvas pin number for a comment that has not been saved yet.
  *
- * Invariant: a new pin gets one past the HIGHEST number currently rendered on
- * the canvas — mirroring the daemon's `MAX(pin_seq)+1` assignment rule
- * (`upsertPreviewComment` in apps/daemon/src/db.ts) — never `count + 1`.
- * Pin numbers are permanent: deleting a comment retires its number instead of
- * recycling it, so after a deletion the open-comment count can sit below the
- * highest surviving number and a count-based guess would collide with a pin
- * that is still on screen.
+ * Invariant: a new pin gets one past the HIGHEST pin number the daemon could
+ * already have handed out for this file — mirroring its `MAX(pin_seq)+1`
+ * assignment rule (`upsertPreviewComment` in apps/daemon/src/db.ts), which
+ * scans every row for the project/file regardless of status — never
+ * `count + 1`. Pin numbers are permanent: deleting a comment retires its
+ * number, and a non-open comment (resolved / attached / applying /
+ * needs_review / failed) keeps its row — and therefore its number — even
+ * though the canvas renders no marker for it. Callers must therefore pass
+ * the file's comments across ALL statuses, not just the open ones on screen.
  *
  * A comment without a server-assigned `pinSeq` yet (legacy row / test
- * fixture) contributes the same creation-order fallback number the canvas
- * renders for it (`index + 1` — callers pass `comments` in creation order,
- * see FileViewer's `creationSortedSideComments`).
+ * fixture) contributes its creation rank (`index + 1` — callers pass
+ * `comments` in creation order), matching the daemon's creation-ordered
+ * `pin_seq` backfill for pre-`pin_seq` rows.
  */
 export function provisionalNextPinNumber(comments: readonly PreviewComment[]): number {
   let highest = 0;

--- a/apps/web/src/comments.ts
+++ b/apps/web/src/comments.ts
@@ -420,6 +420,31 @@ export function commentsToAttachments(comments: PreviewComment[]): ChatCommentAt
   return comments.map((comment, index) => commentToAttachment(comment, index + 1));
 }
 
+/**
+ * Provisional canvas pin number for a comment that has not been saved yet.
+ *
+ * Invariant: a new pin gets one past the HIGHEST number currently rendered on
+ * the canvas — mirroring the daemon's `MAX(pin_seq)+1` assignment rule
+ * (`upsertPreviewComment` in apps/daemon/src/db.ts) — never `count + 1`.
+ * Pin numbers are permanent: deleting a comment retires its number instead of
+ * recycling it, so after a deletion the open-comment count can sit below the
+ * highest surviving number and a count-based guess would collide with a pin
+ * that is still on screen.
+ *
+ * A comment without a server-assigned `pinSeq` yet (legacy row / test
+ * fixture) contributes the same creation-order fallback number the canvas
+ * renders for it (`index + 1` — callers pass `comments` in creation order,
+ * see FileViewer's `creationSortedSideComments`).
+ */
+export function provisionalNextPinNumber(comments: readonly PreviewComment[]): number {
+  let highest = 0;
+  comments.forEach((comment, index) => {
+    const rendered = typeof comment.pinSeq === 'number' ? comment.pinSeq : index + 1;
+    if (rendered > highest) highest = rendered;
+  });
+  return highest + 1;
+}
+
 export function buildBoardCommentAttachments(input: {
   target: PreviewCommentTarget;
   notes: string[];

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -5669,6 +5669,7 @@ function anchorStateLabel(state: PreviewCommentAnchorState): string {
 
 function CommentPreviewOverlays({
   comments,
+  provisionalPinNumber,
   liveTargets,
   hoveredTarget,
   hoveredPodMemberId,
@@ -5687,6 +5688,10 @@ function CommentPreviewOverlays({
   onOpenComment,
 }: {
   comments: PreviewComment[];
+  /** Next pin number for a brand-new comment. Computed by the caller over the
+   *  file's comments across ALL statuses (see `provisionalNextPinNumber`) —
+   *  wider than `comments`, which carries only the open ones the canvas pins. */
+  provisionalPinNumber: number;
   liveTargets: Map<string, PreviewCommentSnapshot>;
   hoveredTarget: PreviewCommentSnapshot | null;
   hoveredPodMemberId: string | null;
@@ -5824,10 +5829,11 @@ function CommentPreviewOverlays({
   const activePinNumber = activeSavedComment
     ? (typeof activeSavedComment.pinSeq === 'number' ? activeSavedComment.pinSeq : activeSavedIndex + 1)
     // A brand-new, not-yet-saved comment: provisional guess at what the
-    // daemon will assign on create — `MAX(pin_seq)+1`, never `count+1`
-    // (pin numbers are permanent; a deletion retires its number, so a
-    // count-based guess would collide with a surviving pin).
-    : provisionalNextPinNumber(comments);
+    // daemon will assign on create — `MAX(pin_seq)+1` across ALL of the
+    // file's comments regardless of status, never open-count+1 (pin
+    // numbers are permanent; deletion or resolution retires them, so a
+    // count-based guess would collide with or resurrect a taken number).
+    : provisionalPinNumber;
   const targetOverlay = activeTarget ?? hoveredTarget;
   return (
     <div className="comment-overlay-layer" aria-hidden={false}>
@@ -13571,6 +13577,18 @@ function HtmlViewer({
       .sort((a, b) => commentCreatedAt(a) - commentCreatedAt(b)),
     [file.name, previewComments],
   );
+  // Provisional number for the next (not-yet-saved) pin. Computed over the
+  // file's comments across ALL statuses — a resolved/attached/failed comment
+  // keeps its pin_seq row in the daemon DB, so its number stays retired even
+  // though the canvas renders no marker for it (see provisionalNextPinNumber).
+  const nextProvisionalPinNumber = useMemo(
+    () => provisionalNextPinNumber(
+      previewComments
+        .filter((comment) => comment.filePath === file.name)
+        .sort((a, b) => commentCreatedAt(a) - commentCreatedAt(b)),
+    ),
+    [file.name, previewComments],
+  );
   // Sidebar display order: descending by `sortKey` (a fresh comment gets the
   // largest sortKey, so it shows first by default — "newest at the front").
   // A legacy/un-migrated row without a sortKey falls back to its createdAt,
@@ -15495,6 +15513,7 @@ function HtmlViewer({
               {boardMode ? (
                 <CommentPreviewOverlays
                   comments={commentCreateMode ? creationSortedSideComments : []}
+                  provisionalPinNumber={nextProvisionalPinNumber}
                   driftLadder={collab.enabled}
                   currentVersion={collab.publishedVersion ?? undefined}
                   {...(collab.onLostAnchors ? { onLostAnchors: collab.onLostAnchors } : {})}

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -228,6 +228,7 @@ import {
   liveSnapshotForComment,
   overlayBoundsFromSnapshot,
   planLostAnchorWriteBacks,
+  provisionalNextPinNumber,
   resolveCommentAnchor,
   selectionKindLabel,
   targetFromSnapshot,
@@ -5822,10 +5823,11 @@ function CommentPreviewOverlays({
   const activeSavedComment = activeSavedIndex >= 0 ? comments[activeSavedIndex] : undefined;
   const activePinNumber = activeSavedComment
     ? (typeof activeSavedComment.pinSeq === 'number' ? activeSavedComment.pinSeq : activeSavedIndex + 1)
-    // A brand-new, not-yet-saved comment: `comments.length + 1` is a
-    // provisional guess at what the daemon will assign — matches the
-    // "provisional local pin_seq" the server itself computes on create.
-    : comments.length + 1;
+    // A brand-new, not-yet-saved comment: provisional guess at what the
+    // daemon will assign on create — `MAX(pin_seq)+1`, never `count+1`
+    // (pin numbers are permanent; a deletion retires its number, so a
+    // count-based guess would collide with a surviving pin).
+    : provisionalNextPinNumber(comments);
   const targetOverlay = activeTarget ?? hoveredTarget;
   return (
     <div className="comment-overlay-layer" aria-hidden={false}>

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -8773,6 +8773,61 @@ describe('FileViewer tweaks toolbar', () => {
     expect(screen.getByTestId('comment-saved-marker-hero').textContent).toBe('2');
   });
 
+  it('does not reuse a retired pin number held by a non-open comment', async () => {
+    // A resolved comment keeps its pin_seq row in the daemon DB, so the
+    // daemon's MAX(pin_seq)+1 counts it even though the canvas renders no
+    // marker for it. The provisional pin for a brand-new comment must skip
+    // that retired number (here: resolved pinSeq 2 -> new pin reads 3, not 1).
+    const resolvedComment: PreviewComment = {
+      id: 'comment-resolved',
+      projectId: 'project-1',
+      conversationId: 'conversation-1',
+      filePath: 'preview.html',
+      elementId: 'hero',
+      selector: '[data-od-id="hero"]',
+      label: 'Hero',
+      text: 'Hero',
+      htmlHint: '<main data-od-id="hero">Hero</main>',
+      position: { x: 8, y: 12, width: 120, height: 48 },
+      note: 'Resolved note',
+      status: 'resolved',
+      createdAt: 10,
+      updatedAt: 10,
+      pinSeq: 2,
+    };
+
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlPreviewFile()}
+        liveHtml='<html><body><main data-od-id="hero">Hero</main><button data-od-id="mood">Mood</button></body></html>'
+        previewComments={[resolvedComment]}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('comment-panel-toggle'));
+
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: {
+        type: 'od:comment-target',
+        elementId: 'mood',
+        selector: '[data-od-id="mood"]',
+        label: 'Mood',
+        text: 'Mood',
+        position: { x: 8, y: 80, width: 90, height: 32 },
+        hoverPoint: { x: 12, y: 84 },
+        htmlHint: '<button data-od-id="mood">Mood</button>',
+      },
+    }));
+
+    expect((await screen.findByTestId('comment-active-pin')).textContent).toBe('3');
+    // Resolved comments render no saved marker — their number is simply retired.
+    expect(screen.queryByTestId('comment-saved-marker-hero')).toBeNull();
+  });
+
   it('keeps comment marker numbers global across deck slides', async () => {
     const slideOneComment: PreviewComment = {
       id: 'comment-slide-one',

--- a/apps/web/tests/components/FileViewer.test.tsx
+++ b/apps/web/tests/components/FileViewer.test.tsx
@@ -8699,6 +8699,80 @@ describe('FileViewer tweaks toolbar', () => {
     expect(screen.getByTestId('comment-active-pin').textContent).toBe('1');
   });
 
+  it('does not reuse a surviving pin number for a new comment after a deletion', async () => {
+    // One comment left whose server-assigned pinSeq is 2 (pin 1 was deleted).
+    // Pin numbers are permanent — the daemon assigns MAX(pin_seq)+1, never
+    // count+1 — so the provisional pin for a brand-new comment must read 3,
+    // not collide with the surviving marker 2.
+    const survivingComment: PreviewComment = {
+      id: 'comment-surviving',
+      projectId: 'project-1',
+      conversationId: 'conversation-1',
+      filePath: 'preview.html',
+      elementId: 'hero',
+      selector: '[data-od-id="hero"]',
+      label: 'Hero',
+      text: 'Hero',
+      htmlHint: '<main data-od-id="hero">Hero</main>',
+      position: { x: 8, y: 12, width: 120, height: 48 },
+      note: 'Surviving note',
+      status: 'open',
+      createdAt: 10,
+      updatedAt: 10,
+      pinSeq: 2,
+    };
+
+    render(
+      <FileViewer
+        projectId="project-1"
+        projectKind="prototype"
+        file={htmlPreviewFile()}
+        liveHtml='<html><body><main data-od-id="hero">Hero</main><button data-od-id="mood">Mood</button></body></html>'
+        previewComments={[survivingComment]}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('comment-panel-toggle'));
+
+    const frame = screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: {
+        type: 'od:comment-targets',
+        targets: [{
+          elementId: 'hero',
+          selector: '[data-od-id="hero"]',
+          label: 'Hero',
+          text: 'Hero',
+          position: { x: 8, y: 12, width: 120, height: 48 },
+          htmlHint: '<main data-od-id="hero">Hero</main>',
+        }],
+      },
+    }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('comment-saved-marker-hero').textContent).toBe('2');
+    });
+
+    window.dispatchEvent(new MessageEvent('message', {
+      source: frame.contentWindow,
+      data: {
+        type: 'od:comment-target',
+        elementId: 'mood',
+        selector: '[data-od-id="mood"]',
+        label: 'Mood',
+        text: 'Mood',
+        position: { x: 8, y: 80, width: 90, height: 32 },
+        hoverPoint: { x: 12, y: 84 },
+        htmlHint: '<button data-od-id="mood">Mood</button>',
+      },
+    }));
+
+    expect((await screen.findByTestId('comment-active-pin')).textContent).toBe('3');
+    // The surviving marker keeps its permanent number.
+    expect(screen.getByTestId('comment-saved-marker-hero').textContent).toBe('2');
+  });
+
   it('keeps comment marker numbers global across deck slides', async () => {
     const slideOneComment: PreviewComment = {
       id: 'comment-slide-one',


### PR DESCRIPTION
## Why

Reported from dogfooding a shared (read-only + comment) project in the packaged client: a project had one surviving comment whose canvas pin was numbered **2** (the comment that used to be #1 had been deleted). When the viewer selected another element to add a new comment, the new pin bubble also showed **2** — a duplicate of the pin already on the canvas.

Root cause: the provisional number for a brand-new, not-yet-saved comment pin was computed as `comments.length + 1`. The daemon's authoritative assignment (`upsertPreviewComment` in `apps/daemon/src/db.ts`) is `MAX(pin_seq) + 1` — pin numbers are permanent and a deletion retires its number rather than recycling it. So whenever the open-comment count sits below the highest surviving pin number (i.e. after any deletion), the count-based guess collides with a pin still on screen.

## What users will see

While composing a new comment on the canvas, the in-progress pin bubble now shows the next unused pin number (e.g. **3** when the only existing comment is numbered **2**), instead of duplicating a number already visible on another pin. Saved comments are unaffected — their numbers were already server-assigned and correct.

## Surface area

- [x] **UI** — behavior fix to the comment pin overlay in `apps/web` (no new page/dialog/setting)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [ ] **None**

CLI note: this is a display-only fix inside the web comment overlay; the persisted `pin_seq` (shared by both surfaces via `/api/*` and rendered by `od` consumers through the same contract field) is unchanged, so there is no CLI counterpart to this change.

## Screenshots

UI screenshots (before/after of the duplicate pin bubble) to be attached manually by a human — this fix was authored in a headless environment. The reproduction is: create two comments, delete the first, start a new comment → before: new pin shows the same number as the surviving pin; after: new pin shows the next number.

## Bug fix verification

- Test paths that reproduce the bug (both in `apps/web/tests/components/FileViewer.test.tsx`):
  - `"does not reuse a surviving pin number for a new comment after a deletion"` — the reported collision (deleted comment retires its number).
  - `"does not reuse a retired pin number held by a non-open comment"` — review follow-up (resolved/attached rows keep their `pin_seq` and count toward the daemon's MAX).
- Did the tests go red before their fix and green on this branch? **yes**
  - Red before the first fix (`main` code):
    ```
    FAIL  tests/components/FileViewer.test.tsx > FileViewer tweaks toolbar > does not reuse a surviving pin number for a new comment after a deletion
    AssertionError: expected '2' to be '3' // Object.is equality
    ```
  - Red before the second fix (branch code prior to cdc86ab62f):
    ```
    FAIL  tests/components/FileViewer.test.tsx > FileViewer tweaks toolbar > does not reuse a retired pin number held by a non-open comment
    AssertionError: expected '1' to be '3' // Object.is equality
    ```
  - Green on this branch: `Test Files 1 passed (1) / Tests 261 passed (261)` for `tests/components/FileViewer.test.tsx`.

## Validation

- `pnpm guard` — exit 0
- `pnpm typecheck` — exit 0 (full), plus `pnpm --filter @open-design/web typecheck` after the review follow-up — exit 0
- `pnpm --filter @open-design/web test tests/components/FileViewer.test.tsx` — 261/261 passed
- `pnpm --filter @open-design/web test tests/comments.test.ts` — 28/28 passed

## Adjacent issues (not fixed here)

- The saved-marker fallback for comments **without** a server-assigned `pinSeq` (legacy rows / test fixtures) is creation-order `index + 1`; two legacy rows surviving a deletion could in principle still render colliding fallback numbers with a `pinSeq`-bearing row. All production rows are backfilled with `pin_seq` (see `apps/daemon/src/db.ts` backfill), so this is fixture-only surface; left untouched to keep this fix scoped to the reported collision.
- For single-user local projects the client comment list is conversation-scoped (`listPreviewComments` filters on `conversation_id`), so a same-file comment from a different local conversation is invisible to the client and can still skew the provisional guess low. Closing that fully needs a server-authoritative next-seq (or project-wide list) API; the daemon-assigned `pin_seq` remains the source of truth after save either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
