### PR TITLE
fix(web): recover deck preview after returning to a project tab

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -7070,6 +7070,26 @@ export function fileViewerSourceAuthorizationScopeKey(
   return null;
 }
 
+/**
+ * A srcdoc document whose `load` completed while the browser tab was hidden
+ * has never experienced a real layout pass: Chrome keeps the hidden iframe's
+ * child viewport at 0x0, so a fixed-canvas deck's one-shot fit resolves to
+ * `transform: scale(0)`, and the in-frame recovery loop (`chaseFirstLayout`
+ * in runtime/srcdoc.ts) is exhausted by background-timer throttling before
+ * the user returns — leaving the main stage permanently white (issue #6583).
+ * Such a document must be given a fresh srcdoc parse on the first return to
+ * a visible document. Scoped to decks, which always render through the
+ * srcdoc transport and carry the one-shot fit; other srcdoc artifacts
+ * re-layout on their own.
+ */
+function srcDocLoadRequiresFreshParseOnReturnToVisible(state: {
+  loadedWhileDocumentHidden: boolean;
+  srcDocIsActiveTransport: boolean;
+  isDeck: boolean;
+}): boolean {
+  return state.loadedWhileDocumentHidden && state.srcDocIsActiveTransport && state.isDeck;
+}
+
 function HtmlViewer({
   projectId,
   projectKind,
@@ -8069,6 +8089,10 @@ function HtmlViewer({
   const previewFileIdentityRef = useRef(`${projectId}\u0000${file.name}`);
   previewFileIdentityRef.current = `${projectId}\u0000${file.name}`;
   const activatedSrcDocTransportHtmlRef = useRef<string | null>(null);
+  // Latched by the srcDoc onLoad handler when a load completes in a hidden
+  // browser tab; consumed (one-shot) by the visibilitychange recovery effect.
+  // See srcDocLoadRequiresFreshParseOnReturnToVisible.
+  const srcDocLoadedWhileDocumentHiddenRef = useRef(false);
   // Tracks the iframe DOM node whose dedupe ref was last reset by the
   // srcDoc onLoad handler. We reset the dedupe exactly once per freshly
   // mounted iframe (the first load is the shell HTML), and skip every
@@ -10266,7 +10290,29 @@ function HtmlViewer({
     wasUrlLoadPreviewRef.current = false;
     activateSrcDocTransport();
   }, [activateSrcDocTransport, useUrlLoadPreview, useLazySrcDocTransport]);
-  
+  // Recovery for a deck that parsed into the srcdoc iframe while the browser
+  // tab was hidden: on the first return to a visible document, remount the
+  // iframe for a fresh srcdoc parse (the mechanism Comment re-activation
+  // already relies on) and clear the latch so visibility round-trips after a
+  // healthy load never remount. Only the active viewer owns recovery —
+  // retained viewers keep their #6519 activation contract untouched.
+  useEffect(() => {
+    if (!workspaceActive || typeof document === 'undefined') return;
+    function onVisibilityChange() {
+      if (document.visibilityState !== 'visible') return;
+      if (!srcDocLoadRequiresFreshParseOnReturnToVisible({
+        loadedWhileDocumentHidden: srcDocLoadedWhileDocumentHiddenRef.current,
+        srcDocIsActiveTransport: !useUrlLoadPreview,
+        isDeck: effectiveDeck,
+      })) return;
+      srcDocLoadedWhileDocumentHiddenRef.current = false;
+      activatedSrcDocTransportHtmlRef.current = null;
+      setSrcDocTransportResetKey((key) => key + 1);
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', onVisibilityChange);
+  }, [workspaceActive, useUrlLoadPreview, effectiveDeck]);
+
   useEffect(() => {
     if (!workspaceActive) return;
     restorePreviewScrollPosition();
@@ -15416,6 +15462,13 @@ function HtmlViewer({
                         srcDoc={srcDocTransportContent}
                         onLoad={() => {
                           const frame = srcDocPreviewIframeRef.current;
+                          // Record whether this load ever saw a real layout
+                          // pass — a load completing in a hidden browser tab
+                          // did not, and decks then need a fresh parse on
+                          // return to visible (#6583). See
+                          // srcDocLoadRequiresFreshParseOnReturnToVisible.
+                          srcDocLoadedWhileDocumentHiddenRef.current =
+                            document.visibilityState === 'hidden';
                           if (!useUrlLoadPreview) iframeRef.current = frame;
                           if (frame) {
                             frame.dataset.odLoadedPreviewEpoch =

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -10310,6 +10310,15 @@ function HtmlViewer({
       setSrcDocTransportResetKey((key) => key + 1);
     }
     document.addEventListener('visibilitychange', onVisibilityChange);
+    // Run one check immediately: this effect only listens while the viewer is
+    // ACTIVE, so when the hidden-tab load happened in a retained viewer and
+    // the browser returned to visible before the user clicked back into the
+    // project, the visibilitychange event fired with no listener armed and
+    // will not replay. The latch would dangle (0x0-parsed deck, permanently
+    // white) exactly on the "switch back to the project tab" flow. The
+    // handler's own guards (visible + latch + srcdoc active + deck) make this
+    // a one-shot no-op everywhere else.
+    onVisibilityChange();
     return () => document.removeEventListener('visibilitychange', onVisibilityChange);
   }, [workspaceActive, useUrlLoadPreview, effectiveDeck]);
 

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -15542,14 +15542,19 @@ function HtmlViewer({
                           <CenteredLoader label={t('fileViewer.loading')} />
                         </div>
                       ) : null}
-                      {!useUrlLoadPreview && !srcDocTransportContent ? (
+                      {!useUrlLoadPreview && !srcDocTransportContent && previewSource === null ? (
                         // srcDoc-path twin of the cover above: while the
-                        // srcdoc document is still empty — the scoped-asset
+                        // preview content is still PENDING — the scoped-asset
                         // rewrite waiting on the project file list (deck on a
                         // workspace-scoped project), or a Reload's synchronous
                         // clear before its re-fetch lands — the active iframe
                         // is a blank document and the pane reads as a dead
-                        // white screen without this cover.
+                        // white screen without this cover. Both hold states
+                        // are exactly `previewSource === null`; a loaded
+                        // zero-byte file is `previewSource === ''` (empty
+                        // srcDoc with nothing in flight), so keying on srcDoc
+                        // emptiness alone would pin this loader forever over
+                        // a legitimately empty document.
                         <div
                           className="artifact-preview-first-load"
                           role="status"

--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -9406,18 +9406,29 @@ function HtmlViewer({
     // while a file-watch token accumulated during inactivity changes
     // filesRefreshKey and therefore still runs this effect on activation.
     if (!workspaceActiveRef.current) return;
-    let cancelled = false;
+    // This viewer's pending file-list read must die with the viewer. Without
+    // an AbortSignal, `fetchProjectFiles` PINS the shared single-flight entry
+    // (`sharedCancellableGet`): a read that stalls (a request queued behind
+    // saturated connections neither resolves nor rejects — every failure path
+    // resolves `[]`) then survives unmount forever, and every later viewer
+    // mount for the same project + workspace identity silently rejoins the
+    // same dead promise. For a workspace-scoped deck that hold keeps
+    // `previewSource` at null, i.e. a bare white stage on every return to the
+    // project. Aborting on cleanup lets a fresh mount issue a fresh read.
+    const controller = new AbortController();
     setProjectFilePathSet(null);
-    void fetchProjectFiles(projectId, { workspaceContext })
+    void fetchProjectFiles(projectId, { workspaceContext, signal: controller.signal })
       .then((files) => {
-        if (!cancelled) setProjectFilePathSet(new Set(files.map((entry) => entry.name)));
+        if (!controller.signal.aborted) {
+          setProjectFilePathSet(new Set(files.map((entry) => entry.name)));
+        }
       })
       .catch(() => {
         // Keep the conservative `null` state: a failed read is not proof that
         // the project has no root-relative assets.
       });
     return () => {
-      cancelled = true;
+      controller.abort();
     };
   }, [projectId, file.mtime, filesRefreshKey, reloadKey, workspaceContext]);
   const projectRootAssetRefs = useMemo(
@@ -15468,6 +15479,24 @@ function HtmlViewer({
                         // navigation may still be queued behind heavy same-origin
                         // traffic (drafts/all-projects cover iframes) — without
                         // this cover the pane reads as a dead white screen.
+                        <div
+                          className="artifact-preview-first-load"
+                          role="status"
+                          aria-busy="true"
+                          aria-label={t('fileViewer.loading')}
+                          data-testid="artifact-preview-first-load"
+                        >
+                          <CenteredLoader label={t('fileViewer.loading')} />
+                        </div>
+                      ) : null}
+                      {!useUrlLoadPreview && !srcDocTransportContent ? (
+                        // srcDoc-path twin of the cover above: while the
+                        // srcdoc document is still empty — the scoped-asset
+                        // rewrite waiting on the project file list (deck on a
+                        // workspace-scoped project), or a Reload's synchronous
+                        // clear before its re-fetch lands — the active iframe
+                        // is a blank document and the pane reads as a dead
+                        // white screen without this cover.
                         <div
                           className="artifact-preview-first-load"
                           role="status"

--- a/apps/web/tests/components/FileViewer.deck-preview-blank-on-return.test.tsx
+++ b/apps/web/tests/components/FileViewer.deck-preview-blank-on-return.test.tsx
@@ -161,6 +161,34 @@ function installFetchMock(projectId: string, filesRequests: FilesRequestLog) {
   }));
 }
 
+/**
+ * Fetch mock for a project whose deck HTML file is a legitimate ZERO-BYTE
+ * file: `GET .../raw/deck.html` resolves 200 with an empty body, the project
+ * file list resolves immediately (no stall, no relative assets — nothing arms
+ * the scoped-asset hold), everything else 404s.
+ */
+function installEmptyFileFetchMock(projectId: string) {
+  const filesUrl = `/api/projects/${encodeURIComponent(projectId)}/files`;
+  const rawUrl = `/api/projects/${encodeURIComponent(projectId)}/raw/deck.html`;
+  const isFilesListUrl = (url: string) => url.split('?')[0] === filesUrl;
+  const rawRequests: FilesRequestLog = [];
+  vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+    if (isFilesListUrl(url)) {
+      return new Response(
+        JSON.stringify({ files: [deckFile({ size: 0 })] }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }
+    if (url.startsWith(rawUrl)) {
+      rawRequests.push({ url });
+      return new Response('', { status: 200 });
+    }
+    return new Response('', { status: 404 });
+  }));
+  return rawRequests;
+}
+
 function srcDocFrame(): HTMLIFrameElement {
   return screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
 }
@@ -245,5 +273,34 @@ describe('deck preview blank after leaving and returning to the project', () => 
     await waitFor(() => {
       expect(screen.getByTestId('artifact-preview-first-load')).toBeTruthy();
     });
+  });
+
+  it('drops the loading cover once a legitimately empty file has loaded, instead of pinning it forever', async () => {
+    // Guards the other side of the cover condition: `previewSource` uses ''
+    // for "loaded, zero bytes" and null for "not ready yet". A cover keyed on
+    // srcDoc emptiness cannot tell those apart and would announce a permanent
+    // `role="status"` / aria-busy loader over a file that finished loading
+    // with no request in flight.
+    const projectId = 'proj-deck-empty-file';
+    const rawRequests = installEmptyFileFetchMock(projectId);
+
+    render(
+      <Wrap>
+        <FileViewer projectId={projectId} projectKind="prototype" file={deckFile({ size: 0 })} isDeck />
+      </Wrap>,
+    );
+
+    // The zero-byte source load resolves on the srcDoc path…
+    await waitFor(() => {
+      expect(srcDocFrame().getAttribute('data-od-render-mode')).toBe('srcdoc');
+      expect(rawRequests.length).toBeGreaterThanOrEqual(1);
+    });
+
+    // …and the loading cover must clear: the file IS loaded, nothing is in
+    // flight, and the truthful render of an empty file is an empty document.
+    await waitFor(() => {
+      expect(screen.queryByTestId('artifact-preview-first-load')).toBeNull();
+    });
+    expect(srcDocFrame().getAttribute('srcdoc') ?? '').toBe('');
   });
 });

--- a/apps/web/tests/components/FileViewer.deck-preview-blank-on-return.test.tsx
+++ b/apps/web/tests/components/FileViewer.deck-preview-blank-on-return.test.tsx
@@ -1,0 +1,249 @@
+// @vitest-environment jsdom
+// Red spec for the "deck preview goes blank after leaving and returning to the
+// project" report (packaged client, multiple project tabs open).
+//
+// Mechanism under test — all three observed facts reproduce from it:
+//
+//   1. For a workspace-scoped project whose deck HTML references a relative
+//      project asset, PR #6142 holds the srcDoc preview at `''` (a bare white
+//      iframe, no loading cover) until `GET /api/projects/:id/files` and the
+//      scoped asset rewrite complete (`scopedRelativeAssetRefs &&
+//      inlinedSource === null` → `previewSource = null` → `srcDoc = ''`).
+//      The thumbnail rail and speaker notes render from `source` directly, so
+//      they stay healthy while the main stage is a white empty document.
+//
+//   2. FileViewer's project-file-list effect calls `fetchProjectFiles`
+//      WITHOUT an AbortSignal. `sharedCancellableGet` therefore marks the
+//      shared single-flight entry as *pinned*: it can never be aborted and it
+//      stays in the shared map until it settles. `fetchProjectFiles` resolves
+//      `[]` on every failure path — the only way it can stay unsettled is a
+//      request that neither resolves nor rejects (a stalled/queued
+//      connection). When that happens, every later viewer mount for the same
+//      project + workspace identity silently REJOINS the same dead promise
+//      instead of issuing its own read, so switching away and back to the
+//      project keeps showing the white stage forever.
+//
+// The spec freezes the invariant: a freshly mounted viewer must not be wedged
+// by a stalled read that a previous (now unmounted) viewer started — its own
+// mount re-issues the project-files read, and the preview hold releases.
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { CollabProvider, type CollabContextValue } from '../../src/collab/collab-context';
+import { FileViewer } from '../../src/components/FileViewer';
+import { resetSharedCancellableGet } from '../../src/lib/shared-cancellable-get';
+import type { ProjectFile } from '../../src/types';
+import { workspaceContextFixture } from '../helpers/workspace-context';
+
+const WORKSPACE_CONTEXT = workspaceContextFixture({
+  workspaceId: 'ws-deck-blank',
+  workspaceMemberId: 'member-deck-blank',
+});
+
+// Full context value: a team-workspace project that is not live-shared.
+// `workspaceContext` + `projectResourceAuthority: 'workspace'` is what arms
+// the scoped-asset preview hold in FileViewer.
+function collabValue(): CollabContextValue {
+  return {
+    workspaceContext: WORKSPACE_CONTEXT,
+    workspaceContextLoading: false,
+    projectResourceAuthority: 'workspace',
+    enabled: false,
+    member: null,
+    present: [],
+    publishedVersion: null,
+    syncState: null,
+    viewerOnly: false,
+    writerAuthority: 'pending',
+    isOwner: false,
+    isEffectiveOwner: false,
+    isSharedNonOwner: false,
+    ownerDisplayName: null,
+    ownerRole: null,
+    downloadPending: false,
+    reportChange: () => {},
+    requestPublish: () => {},
+    refreshPresence: () => {},
+    checkStatusNow: () => {},
+  };
+}
+
+function Wrap({ children }: { children: ReactNode }) {
+  return <CollabProvider value={collabValue()}>{children}</CollabProvider>;
+}
+
+function deckFile(overrides: Partial<ProjectFile> = {}): ProjectFile {
+  return {
+    name: 'deck.html',
+    path: 'deck.html',
+    type: 'file',
+    size: 2048,
+    mtime: 1710000000,
+    kind: 'html',
+    mime: 'text/html',
+    artifactManifest: {
+      version: 1,
+      kind: 'deck',
+      title: 'Deck',
+      entry: 'deck.html',
+      renderer: 'deck-html',
+      exports: ['html'],
+    },
+    ...overrides,
+  };
+}
+
+// Two-slide deck whose first slide carries a RELATIVE project asset ref —
+// that ref is what arms `scopedRelativeAssetRefs` and the preview hold.
+const DECK_HTML =
+  '<html><body>'
+  + '<section class="slide"><h1>slide-one</h1><img src="assets/cover.png" alt="" /></section>'
+  + '<section class="slide"><p>slide-two</p></section>'
+  + '</body></html>';
+
+type FilesRequestLog = { url: string }[];
+
+/**
+ * Fetch mock for one workspace-scoped deck project:
+ *  - `GET .../raw/deck.html` resolves with the deck HTML,
+ *  - `GET .../files` — the first request STALLS forever (neither resolves nor
+ *    rejects, like a request queued behind saturated connections); every
+ *    later request resolves with the real file list,
+ *  - everything else 404s (preview-url probe, etc. — all null-safe).
+ */
+function installFetchMock(projectId: string, filesRequests: FilesRequestLog) {
+  const filesUrl = `/api/projects/${encodeURIComponent(projectId)}/files`;
+  const rawUrl = `/api/projects/${encodeURIComponent(projectId)}/raw/deck.html`;
+  // Exact-path match: `/files/<name>/publish-public` (the public-publication
+  // probe) must not be mistaken for the project file LIST read.
+  const isFilesListUrl = (url: string) => url.split('?')[0] === filesUrl;
+  vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+    if (isFilesListUrl(url)) {
+      filesRequests.push({ url });
+      if (filesRequests.length === 1) {
+        // Stalled read: keep the promise pending forever, but honor an abort
+        // like real fetch would so an aborted joiner can settle.
+        return new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          if (signal) {
+            signal.addEventListener(
+              'abort',
+              () => reject(new DOMException('Aborted', 'AbortError')),
+              { once: true },
+            );
+          }
+        });
+      }
+      return new Response(
+        JSON.stringify({
+          files: [
+            deckFile(),
+            {
+              name: 'assets/cover.png',
+              path: 'assets/cover.png',
+              type: 'file',
+              size: 10,
+              mtime: 1710000000,
+              kind: 'image',
+              mime: 'image/png',
+            },
+          ],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }
+    if (url.startsWith(rawUrl)) {
+      return new Response(DECK_HTML, { status: 200 });
+    }
+    return new Response('', { status: 404 });
+  }));
+}
+
+function srcDocFrame(): HTMLIFrameElement {
+  return screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+}
+
+beforeEach(() => {
+  resetSharedCancellableGet();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('deck preview blank after leaving and returning to the project', () => {
+  it('re-issues the project-files read on remount instead of rejoining a stalled shared read, releasing the preview hold', async () => {
+    const projectId = 'proj-deck-blank-return';
+    const filesRequests: FilesRequestLog = [];
+    installFetchMock(projectId, filesRequests);
+
+    // --- Phase 1: open the deck project; the files read stalls ---
+    const first = render(
+      <Wrap>
+        <FileViewer projectId={projectId} projectKind="prototype" file={deckFile()} isDeck />
+      </Wrap>,
+    );
+
+    // Deck source arrives and the deck chrome renders (thumbnail rail up)…
+    await waitFor(() => {
+      expect(srcDocFrame().getAttribute('data-od-render-mode')).toBe('srcdoc');
+      expect(document.querySelector('.deck-thumbnail-rail')).toBeTruthy();
+    });
+    expect(filesRequests.length).toBe(1);
+
+    // …while the main stage is held at an EMPTY document (bare white iframe):
+    // the scoped-asset hold is waiting on the stalled project-files read.
+    expect(srcDocFrame().getAttribute('srcdoc') ?? '').toBe('');
+
+    // --- Phase 2: switch to another project (viewer unmounts) ---
+    first.unmount();
+
+    // --- Phase 3: switch back (fresh viewer mounts) ---
+    render(
+      <Wrap>
+        <FileViewer projectId={projectId} projectKind="prototype" file={deckFile()} isDeck />
+      </Wrap>,
+    );
+
+    // The remounted viewer must perform ITS OWN project-files read — not
+    // silently rejoin the previous viewer's stalled, pinned request.
+    await waitFor(() => {
+      expect(filesRequests.length).toBeGreaterThanOrEqual(2);
+    });
+
+    // With the read answered, the hold releases and the deck actually renders.
+    await waitFor(() => {
+      expect(srcDocFrame().getAttribute('srcdoc') ?? '').toContain('slide-one');
+    });
+  });
+
+  it('covers the held srcDoc preview with the loading indicator instead of a bare white iframe', async () => {
+    const projectId = 'proj-deck-blank-cover';
+    const filesRequests: FilesRequestLog = [];
+    installFetchMock(projectId, filesRequests);
+
+    render(
+      <Wrap>
+        <FileViewer projectId={projectId} projectKind="prototype" file={deckFile()} isDeck />
+      </Wrap>,
+    );
+
+    // Deck data is on screen, the main stage is still held empty…
+    await waitFor(() => {
+      expect(srcDocFrame().getAttribute('data-od-render-mode')).toBe('srcdoc');
+      expect(document.querySelector('.deck-thumbnail-rail')).toBeTruthy();
+    });
+    expect(srcDocFrame().getAttribute('srcdoc') ?? '').toBe('');
+
+    // …so the user must see the loading cover, not a dead white pane. The
+    // URL-load path already has exactly this cover for its own first-load
+    // white-pane case; the srcDoc hold needs the same treatment.
+    await waitFor(() => {
+      expect(screen.getByTestId('artifact-preview-first-load')).toBeTruthy();
+    });
+  });
+});

--- a/apps/web/tests/components/FileViewer.deck-preview-hidden-tab-mount.test.tsx
+++ b/apps/web/tests/components/FileViewer.deck-preview-hidden-tab-mount.test.tsx
@@ -1,0 +1,269 @@
+// @vitest-environment jsdom
+// Red spec for issue #6583: a deck preview that mounts while the browser tab
+// is HIDDEN stays permanently white after the user returns to the tab.
+//
+// Mechanism under test:
+//
+//   1. Decks always render through the srcDoc transport
+//      (`file-viewer-render-mode.ts`: `if (d.isDeck) return false`), so the
+//      deck HTML is parsed the moment the srcdoc iframe mounts — even when
+//      the whole browser tab is hidden (e.g. the project finished generating
+//      in a background tab).
+//
+//   2. While the tab is hidden Chrome never runs layout for the iframe, so
+//      the deck's one-shot fit computes against a 0x0 child viewport and
+//      resolves to `transform: scale(0)`. The srcdoc bridge's only recovery,
+//      `chaseFirstLayout` (30 x 50ms resize nudges), is exhausted by
+//      background-timer throttling long before the user returns; neither the
+//      host nor the bridge listens for `visibilitychange`, so nothing ever
+//      re-runs the fit. The main stage stays white forever while the
+//      thumbnail rail (host-rendered) stays healthy.
+//
+// The spec freezes the invariant: a srcdoc document whose load completed
+// while `document.visibilityState === 'hidden'` has never experienced a real
+// layout pass, so on the FIRST return to a visible document the deck's
+// srcdoc iframe must be remounted (fresh srcdoc parse — the only recovery
+// path that reliably re-runs the deck's fit). Loads that complete while
+// visible must NOT trigger a remount on later visibility round-trips (no
+// flicker), and a retained viewer (`workspaceActive === false`) must not
+// react at all.
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { CollabProvider, type CollabContextValue } from '../../src/collab/collab-context';
+import { FileViewer } from '../../src/components/FileViewer';
+import { resetSharedCancellableGet } from '../../src/lib/shared-cancellable-get';
+import type { ProjectFile } from '../../src/types';
+import { workspaceContextFixture } from '../helpers/workspace-context';
+
+const WORKSPACE_CONTEXT = workspaceContextFixture({
+  workspaceId: 'ws-deck-hidden-mount',
+  workspaceMemberId: 'member-deck-hidden-mount',
+});
+
+function collabValue(): CollabContextValue {
+  return {
+    workspaceContext: WORKSPACE_CONTEXT,
+    workspaceContextLoading: false,
+    projectResourceAuthority: 'workspace',
+    enabled: false,
+    member: null,
+    present: [],
+    publishedVersion: null,
+    syncState: null,
+    viewerOnly: false,
+    writerAuthority: 'pending',
+    isOwner: false,
+    isEffectiveOwner: false,
+    isSharedNonOwner: false,
+    ownerDisplayName: null,
+    ownerRole: null,
+    downloadPending: false,
+    reportChange: () => {},
+    requestPublish: () => {},
+    refreshPresence: () => {},
+    checkStatusNow: () => {},
+  };
+}
+
+function Wrap({ children }: { children: ReactNode }) {
+  return <CollabProvider value={collabValue()}>{children}</CollabProvider>;
+}
+
+function deckFile(overrides: Partial<ProjectFile> = {}): ProjectFile {
+  return {
+    name: 'deck.html',
+    path: 'deck.html',
+    type: 'file',
+    size: 2048,
+    mtime: 1710000000,
+    kind: 'html',
+    mime: 'text/html',
+    artifactManifest: {
+      version: 1,
+      kind: 'deck',
+      title: 'Deck',
+      entry: 'deck.html',
+      renderer: 'deck-html',
+      exports: ['html'],
+    },
+    ...overrides,
+  };
+}
+
+// Two-slide deck with NO relative project asset refs, so the #6142
+// scoped-asset preview hold never arms and the srcdoc fills as soon as the
+// raw source resolves. This spec is about visibility, not the hold (#6519).
+const DECK_HTML =
+  '<html><body>'
+  + '<section class="slide"><h1>slide-one</h1></section>'
+  + '<section class="slide"><p>slide-two</p></section>'
+  + '</body></html>';
+
+/**
+ * Fetch mock for one workspace-scoped deck project where every request
+ * settles immediately: the file list and raw deck HTML resolve, everything
+ * else 404s (preview-url probe, etc. — all null-safe).
+ */
+function installFetchMock(projectId: string) {
+  const filesUrl = `/api/projects/${encodeURIComponent(projectId)}/files`;
+  const rawUrl = `/api/projects/${encodeURIComponent(projectId)}/raw/deck.html`;
+  const isFilesListUrl = (url: string) => url.split('?')[0] === filesUrl;
+  vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+    if (isFilesListUrl(url)) {
+      return new Response(
+        JSON.stringify({ files: [deckFile()] }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }
+    if (url.startsWith(rawUrl)) {
+      return new Response(DECK_HTML, { status: 200 });
+    }
+    return new Response('', { status: 404 });
+  }));
+}
+
+let documentVisibility: DocumentVisibilityState = 'visible';
+
+function setDocumentVisibility(state: DocumentVisibilityState) {
+  documentVisibility = state;
+}
+
+function dispatchVisibilityChange() {
+  act(() => {
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+}
+
+function activeSrcDocFrame(): HTMLIFrameElement {
+  return screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+}
+
+function retainedSrcDocFrame(): HTMLIFrameElement {
+  return screen.getByTestId('artifact-preview-frame-srcdoc-retained-deck.html') as HTMLIFrameElement;
+}
+
+beforeEach(() => {
+  resetSharedCancellableGet();
+  documentVisibility = 'visible';
+  vi.spyOn(document, 'visibilityState', 'get').mockImplementation(() => documentVisibility);
+  vi.spyOn(document, 'hidden', 'get').mockImplementation(() => documentVisibility === 'hidden');
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('deck preview mounted while the browser tab is hidden (#6583)', () => {
+  it('remounts the srcdoc iframe on first return to visible after a hidden-tab load (fresh parse)', async () => {
+    const projectId = 'proj-deck-hidden-mount-recover';
+    installFetchMock(projectId);
+    setDocumentVisibility('hidden');
+
+    render(
+      <Wrap>
+        <FileViewer projectId={projectId} projectKind="prototype" file={deckFile()} isDeck />
+      </Wrap>,
+    );
+
+    // The deck parses into the srcdoc iframe while the tab is hidden…
+    await waitFor(() => {
+      expect(activeSrcDocFrame().getAttribute('data-od-render-mode')).toBe('srcdoc');
+      expect(activeSrcDocFrame().getAttribute('srcdoc') ?? '').toContain('slide-one');
+    });
+
+    // …and its load completes with the document still hidden: this document
+    // never experienced a real layout pass (0x0 viewport → fit = scale(0)).
+    const hiddenLoadedFrame = activeSrcDocFrame();
+    fireEvent.load(hiddenLoadedFrame);
+
+    // User returns to the tab. The host must give the deck a fresh srcdoc
+    // parse: a NEW iframe DOM node (explicit identity check — the old node
+    // is gone from the document), still carrying the deck HTML.
+    setDocumentVisibility('visible');
+    dispatchVisibilityChange();
+
+    await waitFor(() => {
+      const remounted = activeSrcDocFrame();
+      expect(remounted).not.toBe(hiddenLoadedFrame);
+      expect(remounted.getAttribute('srcdoc') ?? '').toContain('slide-one');
+    });
+    expect(hiddenLoadedFrame.isConnected).toBe(false);
+  });
+
+  it('does NOT remount when the load completed while visible (visibility round-trip is flicker-free)', async () => {
+    const projectId = 'proj-deck-visible-load-stable';
+    installFetchMock(projectId);
+
+    render(
+      <Wrap>
+        <FileViewer projectId={projectId} projectKind="prototype" file={deckFile()} isDeck />
+      </Wrap>,
+    );
+
+    await waitFor(() => {
+      expect(activeSrcDocFrame().getAttribute('data-od-render-mode')).toBe('srcdoc');
+      expect(activeSrcDocFrame().getAttribute('srcdoc') ?? '').toContain('slide-one');
+    });
+
+    // Load completes while the document is visible: layout was real.
+    const visibleLoadedFrame = activeSrcDocFrame();
+    fireEvent.load(visibleLoadedFrame);
+
+    // Tab goes to background and comes back — no remount, same DOM node.
+    setDocumentVisibility('hidden');
+    dispatchVisibilityChange();
+    setDocumentVisibility('visible');
+    dispatchVisibilityChange();
+
+    expect(activeSrcDocFrame()).toBe(visibleLoadedFrame);
+    expect(visibleLoadedFrame.isConnected).toBe(true);
+  });
+
+  it('does NOT remount a retained viewer (workspaceActive=false) on return to visible', async () => {
+    const projectId = 'proj-deck-hidden-mount-retained';
+    installFetchMock(projectId);
+
+    // A viewer becomes retained after being active: mount active first so the
+    // deck parses into the srcdoc iframe, then park it offscreen.
+    const view = render(
+      <Wrap>
+        <FileViewer projectId={projectId} projectKind="prototype" file={deckFile()} isDeck />
+      </Wrap>,
+    );
+
+    await waitFor(() => {
+      expect(activeSrcDocFrame().getAttribute('srcdoc') ?? '').toContain('slide-one');
+    });
+
+    view.rerender(
+      <Wrap>
+        <FileViewer
+          projectId={projectId}
+          projectKind="prototype"
+          file={deckFile()}
+          isDeck
+          workspaceActive={false}
+        />
+      </Wrap>,
+    );
+
+    // The retained srcdoc iframe's load completes while the document is
+    // hidden (e.g. its content refreshed in a background browser tab).
+    setDocumentVisibility('hidden');
+    const retainedFrame = retainedSrcDocFrame();
+    fireEvent.load(retainedFrame);
+
+    // Returning to visible must not touch a retained viewer at all — only
+    // the active viewer owns recovery.
+    setDocumentVisibility('visible');
+    dispatchVisibilityChange();
+
+    expect(retainedSrcDocFrame()).toBe(retainedFrame);
+    expect(retainedFrame.isConnected).toBe(true);
+  });
+});

--- a/apps/web/tests/components/FileViewer.deck-preview-hidden-tab-mount.test.tsx
+++ b/apps/web/tests/components/FileViewer.deck-preview-hidden-tab-mount.test.tsx
@@ -266,4 +266,127 @@ describe('deck preview mounted while the browser tab is hidden (#6583)', () => {
     expect(retainedSrcDocFrame()).toBe(retainedFrame);
     expect(retainedFrame.isConnected).toBe(true);
   });
+
+  it('recovers on ACTIVATION when the visibility flip happened while the viewer was retained (missed event, latch pending)', async () => {
+    // Escape sequence past the listener: the latch arms during a hidden-tab
+    // load while the viewer is RETAINED (no listener — correct, see the case
+    // above), the browser returns to visible while still retained (the
+    // visibilitychange event fires with no listener armed), and only THEN
+    // does the user click the project tab. The event will not replay, so
+    // activation itself must run the pending-latch check.
+    const projectId = 'proj-deck-retained-hidden-load-activate';
+    installFetchMock(projectId);
+
+    const view = render(
+      <Wrap>
+        <FileViewer projectId={projectId} projectKind="prototype" file={deckFile()} isDeck />
+      </Wrap>,
+    );
+
+    await waitFor(() => {
+      expect(activeSrcDocFrame().getAttribute('srcdoc') ?? '').toContain('slide-one');
+    });
+
+    view.rerender(
+      <Wrap>
+        <FileViewer
+          projectId={projectId}
+          projectKind="prototype"
+          file={deckFile()}
+          isDeck
+          workspaceActive={false}
+        />
+      </Wrap>,
+    );
+
+    // Hidden-tab load while retained: the latch arms (0x0 layout, scale(0)).
+    setDocumentVisibility('hidden');
+    const retainedFrame = retainedSrcDocFrame();
+    fireEvent.load(retainedFrame);
+
+    // Browser becomes visible while STILL retained — no action (the case
+    // above), and no listener was armed to see this event.
+    setDocumentVisibility('visible');
+    dispatchVisibilityChange();
+    expect(retainedSrcDocFrame()).toBe(retainedFrame);
+
+    // User clicks the project tab: activation happens AFTER the visibility
+    // flip. The host must notice the dangling latch now and give the deck a
+    // fresh srcdoc parse — a NEW iframe DOM node still carrying the deck.
+    view.rerender(
+      <Wrap>
+        <FileViewer projectId={projectId} projectKind="prototype" file={deckFile()} isDeck />
+      </Wrap>,
+    );
+
+    await waitFor(() => {
+      const activated = activeSrcDocFrame();
+      expect(activated).not.toBe(retainedFrame);
+      expect(activated.getAttribute('srcdoc') ?? '').toContain('slide-one');
+    });
+    expect(retainedFrame.isConnected).toBe(false);
+
+    // Exactly once: the latch cleared with the remount, so a later visibility
+    // round-trip (healthy visible load) must not remount again.
+    const recoveredFrame = activeSrcDocFrame();
+    fireEvent.load(recoveredFrame);
+    setDocumentVisibility('hidden');
+    dispatchVisibilityChange();
+    setDocumentVisibility('visible');
+    dispatchVisibilityChange();
+    expect(activeSrcDocFrame()).toBe(recoveredFrame);
+    expect(recoveredFrame.isConnected).toBe(true);
+  });
+
+  it('does NOT remount on activation when the retained load completed while visible (no latch)', async () => {
+    // Guard against over-triggering: activation alone is not a recovery
+    // signal. If the retained document loaded with real layout (visible),
+    // clicking back into the project must be a pure visibility swap.
+    const projectId = 'proj-deck-retained-visible-load-activate';
+    installFetchMock(projectId);
+
+    const view = render(
+      <Wrap>
+        <FileViewer projectId={projectId} projectKind="prototype" file={deckFile()} isDeck />
+      </Wrap>,
+    );
+
+    await waitFor(() => {
+      expect(activeSrcDocFrame().getAttribute('srcdoc') ?? '').toContain('slide-one');
+    });
+
+    view.rerender(
+      <Wrap>
+        <FileViewer
+          projectId={projectId}
+          projectKind="prototype"
+          file={deckFile()}
+          isDeck
+          workspaceActive={false}
+        />
+      </Wrap>,
+    );
+
+    // Load completes while the document is VISIBLE: layout was real, no latch.
+    const retainedFrame = retainedSrcDocFrame();
+    fireEvent.load(retainedFrame);
+
+    // A background round-trip happens while retained (no load during hidden).
+    setDocumentVisibility('hidden');
+    dispatchVisibilityChange();
+    setDocumentVisibility('visible');
+    dispatchVisibilityChange();
+
+    // Activation must keep the same iframe DOM node.
+    view.rerender(
+      <Wrap>
+        <FileViewer projectId={projectId} projectKind="prototype" file={deckFile()} isDeck />
+      </Wrap>,
+    );
+
+    await waitFor(() => {
+      expect(activeSrcDocFrame()).toBe(retainedFrame);
+    });
+    expect(retainedFrame.isConnected).toBe(true);
+  });
 });


### PR DESCRIPTION
## Why

Dogfooding report from the packaged client (multiple project tabs open): open a deck (PPT) project, switch to another project tab, come back a while later — the main preview stage is a solid white pane. The slide thumbnail rail (all 10 slides) and the speaker-notes bar still render, so the data is clearly there; only the main iframe is dead. Re-opening the project or cycling tabs a few times eventually brings it back.

Traced root cause (two cooperating defects, both on the srcDoc preview path):

1. **A stalled project-files read wedges every later mount.** Since #6142, a workspace-scoped deck whose HTML references a relative project asset holds its srcDoc preview at an empty document (`previewSource = null` → `srcdoc=""`) until `GET /api/projects/:id/files` answers and the scoped asset rewrite runs (`scopedRelativeAssetRefs && inlinedSource === null` in `HtmlViewer`). The viewer's file-list effect calls `fetchProjectFiles` **without an AbortSignal**, which makes `sharedCancellableGet` **pin** the shared single-flight entry: it can never be aborted and stays in the shared map until it settles. `fetchProjectFiles` resolves `[]` on every failure path, so the only way the entry stays unsettled is a request that neither resolves nor rejects — exactly what a request queued behind saturated connections does (the packaged client multiplexes SSE streams + preview iframes + cover fetches over HTTP/1.1's six connections per origin). Once that happens, every later viewer mount for the same project + workspace identity **silently rejoins the same dead promise** instead of issuing its own read — switching away and back can never recover.

2. **The held state renders as a dead white pane.** While the hold is active the srcDoc iframe carries an empty document with no loading indicator — unlike the URL-load path, which has the `artifact-preview-first-load` cover for exactly this "navigation queued behind heavy traffic" situation. So even the *transient* hold (every return to a workspace-scoped deck) reads as a broken white screen, and the wedged case reads as a permanently broken one. The thumbnail rail and speaker notes render from `source` directly, which is why they stay healthy — matching the report exactly.

## What users will see

- Coming back to a deck project tab no longer risks a permanently white main preview: a fresh viewer mount always issues its own project-files read instead of inheriting a previous mount's stalled one.
- While a deck (or any srcDoc-path artifact) preview is still being prepared — or a Reload is re-fetching — the stage shows the standard centered loading indicator instead of a bare white pane.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

CLI note: no CLI surface — this is a web-preview rendering/recovery fix inside `FileViewer`; there is no corresponding `od` capability to mirror.

## Screenshots

The loading-cover state needs a stalled network to capture; screenshots from a manual packaged-client verification will be added by a human follow-up (bug reproduces only under connection saturation, which a local screenshot session doesn't show on demand).

## Bug fix verification

- Test path that reproduces the bug: `apps/web/tests/components/FileViewer.deck-preview-blank-on-return.test.tsx`
  - spec 1: a viewer whose project-files read stalls is unmounted (project tab switch) and a fresh viewer mounts — on `main` the fresh mount performs **no** new `/files` request (it rejoins the pinned stalled entry, `expected 1 to be greater than or equal to 2`) and the srcdoc stays empty; on this branch it re-issues the read and the deck renders.
  - spec 2: while the hold is active, the stage must show the `artifact-preview-first-load` cover — red on `main` (`Unable to find an element by: [data-testid="artifact-preview-first-load"]`), green here.
- Did the test go red on `main` and green on this branch? **yes** (both specs)

## Validation

- `pnpm --filter @open-design/web test` — full suite green
- `pnpm --filter @open-design/web typecheck`
- `pnpm guard` (exit 0), `pnpm typecheck` (root)

## Adjacent issues (not fixed here)

- The file-list effect intentionally omits `workspaceActive` from its deps ("first mounted while active" assumption). A retained viewer first mounted while *hidden* keeps `projectFilePathSet === null` after activation until an unrelated dep bump, which can reproduce the same white-hold without any network stall. Left untouched because changing that dependency contract needs its own spec around the retained-viewer activation flow.
- The scoped-asset hold itself (holding first paint until the file list lands) still adds one round trip of covered latency to every workspace-scoped deck (re)mount; deciding whether a deadline fallback is acceptable trades against #6142's "never leak an unscoped subresource request" invariant and needs a product/maintainer call.


## Update 2026-08-07: absorbed stacked PR #6587 (hidden-tab-mount white screen)

Fixes #6583

The stacked PR #6587 was merged into this branch (5d4bdede11), so this PR now carries **both** white-screen fixes for the "deck goes blank" symptom family:

1. **Original scope (unchanged)** — empty-document hold: fresh mounts re-issue the project-files read and the hold window shows the `artifact-preview-first-load` cover instead of a blank stage.
2. **Absorbed from #6587** — hidden-tab mount (#6583): a srcdoc deck that finishes loading while the browser tab is hidden never runs layout (0×0 → `scale(0)`), and the in-frame `chaseFirstLayout` rescue exhausts its attempts under background-timer throttling, leaving the stage permanently white with a fully populated srcdoc. The fix latches "load completed while `document.visibilityState === 'hidden'`" on the srcdoc iframe's `onLoad` and, on the first return to visible (gated on `workspaceActive`, srcdoc transport active, deck only), forces a one-shot fresh parse via the existing `srcDocTransportResetKey` remount path. Healthy visible loads and retained viewers are untouched (covered by negative specs).

Verification for the absorbed fix (details and evidence in #6587):

- Red spec on the pre-fix branch head, green after: `apps/web/tests/components/FileViewer.deck-preview-hidden-tab-mount.test.tsx` (3 specs: remount-on-return red→green; visible-load no-remount and retained-viewer no-action both green before and after, guarding the no-flicker contract).
- Full `@open-design/web` suite green (6226 passed / 0 failed), `pnpm guard`, root `pnpm typecheck`.
- Real-Chrome buggy-vs-fix acceptance on two isolated runtimes: identical hidden-mount recipe reproduces a permanent white stage without the fix and renders correctly with it, with host-side state identical on both sides — see https://github.com/nexu-io/open-design/pull/6587#issuecomment-5212383828.

No backport: 0.18.1 has already shipped; this lands on `main` only.
