### PR TITLE
fix(collab): quell the packaged-client cloud 502 storm (heartbeat backoff, upstream error relay, proxy replay)

### DIFF
--- a/apps/daemon/src/collab/collab-cloud-error.ts
+++ b/apps/daemon/src/collab/collab-cloud-error.ts
@@ -1,0 +1,85 @@
+/**
+ * Classification for collab cloud-transport failures.
+ *
+ * The vela-cli transport surfaces upstream HTTP failures as a child-process
+ * error whose message embeds the spawned command line plus the CLI's stderr
+ * (`Command failed: …vela collab …\nError: API request failed with status
+ * NNN: code`). Routes must not flatten that into an unconditional 502: an
+ * upstream 401/403/404 is an authoritative rejection the web client should
+ * see as such, while only genuine infrastructure failures stay 502/503. The
+ * raw error (command line, stderr) belongs in the daemon log only — never in
+ * an HTTP response body.
+ */
+
+export type CollabCloudErrorKind =
+  | 'denied'
+  | 'not_found'
+  | 'timeout'
+  | 'infrastructure';
+
+export interface ClassifiedCollabCloudError {
+  kind: CollabCloudErrorKind;
+  /** HTTP status the daemon should answer with. */
+  status: 403 | 404 | 502 | 503;
+  /** Whether a client retry can plausibly change the outcome. */
+  retryable: boolean;
+  /** The upstream HTTP status parsed from the CLI error output, if any. */
+  upstreamStatus: number | null;
+}
+
+const VELA_API_STATUS_PATTERN = /API request failed with status (\d{3})\b/;
+
+/** Extract the upstream HTTP status from a vela CLI failure, if present. */
+export function parseVelaApiStatus(error: unknown): number | null {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : '';
+  const match = VELA_API_STATUS_PATTERN.exec(message);
+  if (!match) return null;
+  const status = Number(match[1]);
+  return Number.isInteger(status) && status >= 100 && status <= 599
+    ? status
+    : null;
+}
+
+function isTimeoutError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  return error.name === 'TimeoutError' || code === 'ETIMEDOUT';
+}
+
+export function classifyCollabCloudError(
+  error: unknown,
+): ClassifiedCollabCloudError {
+  const upstreamStatus = parseVelaApiStatus(error);
+  if (upstreamStatus === 401 || upstreamStatus === 403) {
+    return { kind: 'denied', status: 403, retryable: false, upstreamStatus };
+  }
+  if (upstreamStatus === 404) {
+    return { kind: 'not_found', status: 404, retryable: false, upstreamStatus };
+  }
+  if (isTimeoutError(error)) {
+    return { kind: 'timeout', status: 503, retryable: true, upstreamStatus };
+  }
+  return {
+    kind: 'infrastructure',
+    status: 502,
+    retryable: true,
+    upstreamStatus,
+  };
+}
+
+/**
+ * Raised in place of a cloud-transport call while a project's upstream is in
+ * a failure cooldown (see the presence negative cache): the stored
+ * classification is replayed without spawning another transport process.
+ */
+export class CollabCloudUpstreamBlockedError extends Error {
+  constructor(readonly classified: ClassifiedCollabCloudError) {
+    super('collab cloud upstream is cooling down after repeated failures');
+    this.name = 'CollabCloudUpstreamBlockedError';
+  }
+}

--- a/apps/daemon/src/collab/vela-cli-collab-client.ts
+++ b/apps/daemon/src/collab/vela-cli-collab-client.ts
@@ -221,10 +221,26 @@ function isRole(value: unknown): value is CollabMemberRole {
   return value === 'owner' || value === 'admin' || value === 'member';
 }
 
+/**
+ * Wall-clock budget for presence spawns. Presence heartbeat/list/leave are
+ * high-frequency lease traffic (the web client beats every 10s and every beat
+ * spawns a CLI process); without a budget a wedged CLI piles up unbounded
+ * children while the client keeps beating. Presence data is disposable — the
+ * next beat re-establishes it — so a hung spawn is terminated rather than
+ * awaited. Lower-frequency member/comment commands keep their existing
+ * unbounded behavior.
+ */
+const PRESENCE_COMMAND_TIMEOUT_MS = 10_000;
+
 const defaultRunVelaCollab: RunVelaCollab = (args, workspaceId) =>
   runVelaCommand(
     ['collab', ...args],
-    velaWorkspaceCommandOptions(workspaceId),
+    {
+      ...velaWorkspaceCommandOptions(workspaceId),
+      ...(args[0] === 'presence'
+        ? { timeoutMs: PRESENCE_COMMAND_TIMEOUT_MS }
+        : {}),
+    },
   );
 
 export function shouldUseVelaCliCollabTransport(

--- a/apps/daemon/src/routes/collab-presence.ts
+++ b/apps/daemon/src/routes/collab-presence.ts
@@ -12,6 +12,11 @@ import type {
 import type {
   VerifiedWorkspaceRequestContextResult,
 } from '../collab/request-workspace-context.js';
+import {
+  classifyCollabCloudError,
+  CollabCloudUpstreamBlockedError,
+  type ClassifiedCollabCloudError,
+} from '../collab/collab-cloud-error.js';
 
 type PresenceActivity = Exclude<PresenceMember['activity'], undefined>;
 
@@ -61,6 +66,14 @@ export interface RegisterCollabPresenceRoutesDeps {
    * requested workspace, so a separate remote team-project lookup is redundant.
    */
   cloudAuthorizesProjectPresence?: (projectId: string) => boolean;
+  /**
+   * Cooldown for the upstream negative cache: after repeated consecutive
+   * cloud-transport failures for one project, presence stops spawning the
+   * transport for this long and replays the classified failure instead.
+   */
+  presenceUpstreamCooldownMs?: number;
+  /** Virtual clock seam for deterministic negative-cache coverage. */
+  presenceUpstreamNow?: () => number;
 }
 
 export interface CollabPresenceRoutesControl {
@@ -380,9 +393,137 @@ function readPresenceSequence(
     : null;
 }
 
+/**
+ * Answer a classified cloud-transport failure. Authoritative upstream
+ * rejections keep their meaning (403/404) so the web client's existing
+ * forbidden-request handling applies; only genuine infrastructure failures
+ * stay 502/503. The response body is intentionally free of transport
+ * internals — the spawned command line and stderr stay in the daemon log
+ * (see {@link cloudError}).
+ */
+function sendClassifiedCloudError(
+  res: Response,
+  classified: ClassifiedCollabCloudError,
+) {
+  const upstreamSuffix =
+    classified.upstreamStatus == null
+      ? ''
+      : ` (upstream status ${classified.upstreamStatus})`;
+  const responseByKind = {
+    denied: {
+      error: 'collab_presence_denied',
+      message: `the collab cloud rejected this presence request${upstreamSuffix}`,
+    },
+    not_found: {
+      error: 'collab_presence_not_found',
+      message: `the collab cloud has no record of this project${upstreamSuffix}`,
+    },
+    timeout: {
+      error: 'collab_presence_unavailable',
+      message: 'the collab cloud transport timed out',
+    },
+    infrastructure: {
+      error: 'collab_presence_unavailable',
+      message: `the collab cloud transport failed${upstreamSuffix}`,
+    },
+  } as const;
+  return res.status(classified.status).json({
+    ...responseByKind[classified.kind],
+    ...(classified.retryable ? { retryable: true } : {}),
+  });
+}
+
 function cloudError(res: Response, error: unknown) {
-  const message = error instanceof Error ? error.message : String(error);
-  return res.status(502).json({ error: 'collab_presence_unavailable', message });
+  if (error instanceof CollabCloudUpstreamBlockedError) {
+    return sendClassifiedCloudError(res, error.classified);
+  }
+  const classified = classifyCollabCloudError(error);
+  // The full failure — command line, stderr — is diagnostic gold but must not
+  // reach the renderer; keep it daemon-side.
+  console.warn(
+    `[od] collab_presence_upstream_failure kind=${classified.kind} status=${classified.status} `
+      + `detail=${JSON.stringify(error instanceof Error ? error.message : String(error))}`,
+  );
+  return sendClassifiedCloudError(res, classified);
+}
+
+const DEFAULT_PRESENCE_UPSTREAM_COOLDOWN_MS = 20_000;
+/** Failures must be consecutive — one transient blip never opens the cache. */
+const PRESENCE_UPSTREAM_FAILURE_THRESHOLD = 2;
+const MAX_PRESENCE_UPSTREAM_FAILURE_ENTRIES = 256;
+
+interface PresenceUpstreamFailureState {
+  consecutiveFailures: number;
+  blockedUntil: number;
+  classified: ClassifiedCollabCloudError;
+}
+
+/**
+ * Negative cache for a persistently failing collab cloud upstream.
+ *
+ * Every presence heartbeat/list over the vela-cli transport spawns a child
+ * process. When the upstream keeps rejecting the same project (the packaged
+ * 502-storm incident: hours of one CLI spawn per 10s beat against a dead
+ * upstream), repeated consecutive failures open a cooldown during which the
+ * stored classification is replayed without spawning; the first attempt after
+ * the cooldown probes the upstream again. Any success closes the entry.
+ */
+function createPresenceUpstreamFailureCache(options: {
+  cooldownMs: number;
+  now: () => number;
+}) {
+  const states = new Map<string, PresenceUpstreamFailureState>();
+  const keyFor = (
+    projectId: string,
+    context: WorkspaceCollabContext | null,
+  ): string => `${context?.workspaceId?.trim() ?? ''}\0${projectId}`;
+  const touch = (key: string, state: PresenceUpstreamFailureState) => {
+    states.delete(key);
+    states.set(key, state);
+    while (states.size > MAX_PRESENCE_UPSTREAM_FAILURE_ENTRIES) {
+      const oldestKey = states.keys().next().value;
+      if (oldestKey === undefined) break;
+      states.delete(oldestKey);
+    }
+  };
+
+  return {
+    /** The classification to replay while the cooldown is active, else null. */
+    active(
+      projectId: string,
+      context: WorkspaceCollabContext | null,
+    ): ClassifiedCollabCloudError | null {
+      const state = states.get(keyFor(projectId, context));
+      if (!state) return null;
+      return options.now() < state.blockedUntil ? state.classified : null;
+    },
+
+    recordFailure(
+      projectId: string,
+      context: WorkspaceCollabContext | null,
+      classified: ClassifiedCollabCloudError,
+    ): void {
+      const key = keyFor(projectId, context);
+      const state = states.get(key) ?? {
+        consecutiveFailures: 0,
+        blockedUntil: 0,
+        classified,
+      };
+      state.consecutiveFailures += 1;
+      state.classified = classified;
+      if (state.consecutiveFailures >= PRESENCE_UPSTREAM_FAILURE_THRESHOLD) {
+        state.blockedUntil = options.now() + options.cooldownMs;
+      }
+      touch(key, state);
+    },
+
+    recordSuccess(
+      projectId: string,
+      context: WorkspaceCollabContext | null,
+    ): void {
+      states.delete(keyFor(projectId, context));
+    },
+  };
 }
 
 type PresenceWorkspaceVerification =
@@ -564,6 +705,13 @@ export function registerCollabPresenceRoutes(
     now: deps.presenceListCacheNow ?? Date.now,
   });
   const presenceSessions = createPresenceSessionFence();
+  const upstreamFailures = createPresenceUpstreamFailureCache({
+    cooldownMs: Math.max(
+      0,
+      deps.presenceUpstreamCooldownMs ?? DEFAULT_PRESENCE_UPSTREAM_COOLDOWN_MS,
+    ),
+    now: deps.presenceUpstreamNow ?? Date.now,
+  });
 
   async function projectIsShared(
     projectId: string,
@@ -640,7 +788,20 @@ export function registerCollabPresenceRoutes(
               ) {
                 return [];
               }
-              return cloud.listPresence(req.params.id, context);
+              const blocked = upstreamFailures.active(req.params.id, context);
+              if (blocked) throw new CollabCloudUpstreamBlockedError(blocked);
+              try {
+                const present = await cloud.listPresence(req.params.id, context);
+                upstreamFailures.recordSuccess(req.params.id, context);
+                return present;
+              } catch (error) {
+                upstreamFailures.recordFailure(
+                  req.params.id,
+                  context,
+                  classifyCollabCloudError(error),
+                );
+                throw error;
+              }
             },
             { waitForFresh: req.query.fresh === '1' },
           ),
@@ -698,6 +859,13 @@ export function registerCollabPresenceRoutes(
         return res.json({ present: [] });
       }
       if (cloud) {
+        // A project whose upstream keeps failing must not spawn another
+        // transport process on every 10s beat — replay the classified failure
+        // until the cooldown lets the next probe through.
+        const blocked = upstreamFailures.active(req.params.id, context);
+        if (blocked && !presenceSessions.isClosed(heartbeatFence)) {
+          return sendClassifiedCloudError(res, blocked);
+        }
         let present: CollabPresenceMember[] | null = null;
         let heartbeatError: unknown = null;
         try {
@@ -706,7 +874,13 @@ export function registerCollabPresenceRoutes(
             heartbeat,
             context,
           );
+          upstreamFailures.recordSuccess(req.params.id, context);
         } catch (error) {
+          upstreamFailures.recordFailure(
+            req.params.id,
+            context,
+            classifyCollabCloudError(error),
+          );
           heartbeatError = error;
         }
         if (presenceSessions.isClosed(heartbeatFence)) {
@@ -770,11 +944,14 @@ export function registerCollabPresenceRoutes(
     }
     if (cloud) {
       try {
+        // Leave is deliberately never gated by the upstream negative cache: a
+        // closing session must always try to release its remote lease.
         const present = await cloud.leavePresence(
           req.params.id,
           leave,
           context,
         );
+        upstreamFailures.recordSuccess(req.params.id, context);
         presenceLists.publish(req.params.id, context, present);
         return res.json({
           ok: true,

--- a/apps/daemon/tests/collab-presence-upstream.test.ts
+++ b/apps/daemon/tests/collab-presence-upstream.test.ts
@@ -1,0 +1,218 @@
+// Red spec for the packaged-client presence 502 storm (daemon half).
+//
+// With the vela-cli collab transport, every presence heartbeat spawns a
+// `vela collab presence heartbeat` child process. The CLI exits 1 on any
+// non-2xx API response and printed `API request failed with status NNN`, but
+// the daemon flattened every failure into a 502 `collab_presence_unavailable`
+// whose message embedded the full spawned command line. A project the
+// upstream persistently rejects (404/403) therefore looked like an infra
+// outage, kept spawning a CLI process per beat, and leaked spawn internals to
+// the renderer.
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import express from 'express';
+import http from 'node:http';
+import {
+  buildWorkspacePermissions,
+  buildWorkspaceSeatSummary,
+  type WorkspaceCollabContext,
+} from '@open-design/contracts';
+import { createCollabRuntime } from '../src/collab/runtime.js';
+import type {
+  CollabPresenceCloudClient,
+  RegisterCollabPresenceRoutesDeps,
+} from '../src/routes/collab-presence.js';
+import { registerCollabPresenceRoutes } from '../src/routes/collab-presence.js';
+
+let server: http.Server | null = null;
+
+afterEach(async () => {
+  if (server) {
+    const toClose = server;
+    server = null;
+    await new Promise<void>((resolve) => toClose.close(() => resolve()));
+  }
+});
+
+function teamContext(
+  workspaceId = 'w1',
+  workspaceMemberId = 'm1',
+): WorkspaceCollabContext {
+  return {
+    workspaceId,
+    workspaceName: `Workspace ${workspaceId}`,
+    workspaceType: 'team',
+    teamId: workspaceId,
+    workspaceMemberId,
+    role: 'member',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+    billingState: 'active',
+    planId: null,
+    providerMode: 'platform_credits',
+    seatSummary: buildWorkspaceSeatSummary({ seatLimit: 5, usedSeats: 1 }),
+    permissions: buildWorkspacePermissions({
+      role: 'member',
+      lifecycleState: 'active',
+    }),
+  };
+}
+
+async function startPresenceServer(
+  cloud: CollabPresenceCloudClient,
+  options: {
+    verifyWorkspaceRequest?: RegisterCollabPresenceRoutesDeps['verifyWorkspaceRequest'];
+    presenceUpstreamCooldownMs?: number;
+    presenceUpstreamNow?: () => number;
+  } = {},
+) {
+  const app = express();
+  app.use(express.json());
+  registerCollabPresenceRoutes(app, {
+    collab: createCollabRuntime(),
+    cloud,
+    cloudAuthorizesProjectPresence: () => true,
+    ...(options.verifyWorkspaceRequest
+      ? { verifyWorkspaceRequest: options.verifyWorkspaceRequest }
+      : {}),
+    ...(options.presenceUpstreamCooldownMs !== undefined
+      ? { presenceUpstreamCooldownMs: options.presenceUpstreamCooldownMs }
+      : {}),
+    ...(options.presenceUpstreamNow
+      ? { presenceUpstreamNow: options.presenceUpstreamNow }
+      : {}),
+  } as RegisterCollabPresenceRoutesDeps);
+  server = http.createServer(app);
+  await new Promise<void>((resolve) => server!.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('server did not bind to a TCP port');
+  }
+  const base = `http://127.0.0.1:${address.port}`;
+  return {
+    async heartbeat(projectId = 'p1') {
+      const response = await fetch(
+        `${base}/api/projects/${projectId}/presence/heartbeat`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ memberId: 'm1' }),
+        },
+      );
+      return {
+        status: response.status,
+        body: (await response.json()) as Record<string, unknown>,
+      };
+    },
+  };
+}
+
+/** The exact failure shape execFile produces for a vela CLI non-2xx exit. */
+function velaCliFailure(upstreamStatus: number, code: string): Error {
+  return new Error(
+    'Command failed: /opt/homebrew/bin/vela collab presence heartbeat p1 --client-id m1'
+      + `\nError: API request failed with status ${upstreamStatus}: ${code}`,
+  );
+}
+
+describe('collab presence upstream error relay', () => {
+  it('relays a persistent upstream 404 as 404 without leaking the spawned command line', async () => {
+    const heartbeatPresence = vi
+      .fn()
+      .mockRejectedValue(velaCliFailure(404, 'record not found'));
+    const api = await startPresenceServer(
+      {
+        heartbeatPresence,
+        listPresence: vi.fn(async () => []),
+        leavePresence: vi.fn(async () => []),
+      },
+      {
+        verifyWorkspaceRequest: async () => ({ ok: true, context: teamContext() }),
+      },
+    );
+
+    const { status, body } = await api.heartbeat();
+
+    expect(status).toBe(404);
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain('Command failed');
+    expect(serialized).not.toContain('--client-id');
+    expect(serialized).not.toContain('/opt/homebrew');
+  });
+
+  it('relays an upstream 403 rejection as 403 so the web client sees revoked authority', async () => {
+    const heartbeatPresence = vi
+      .fn()
+      .mockRejectedValue(velaCliFailure(403, 'presence denied'));
+    const api = await startPresenceServer(
+      {
+        heartbeatPresence,
+        listPresence: vi.fn(async () => []),
+        leavePresence: vi.fn(async () => []),
+      },
+      {
+        verifyWorkspaceRequest: async () => ({ ok: true, context: teamContext() }),
+      },
+    );
+
+    const { status } = await api.heartbeat();
+
+    expect(status).toBe(403);
+  });
+
+  it('keeps genuine infrastructure failures on 502', async () => {
+    const heartbeatPresence = vi
+      .fn()
+      .mockRejectedValue(new Error('vela binary not found; install vela or configure VELA_BIN'));
+    const api = await startPresenceServer(
+      {
+        heartbeatPresence,
+        listPresence: vi.fn(async () => []),
+        leavePresence: vi.fn(async () => []),
+      },
+      {
+        verifyWorkspaceRequest: async () => ({ ok: true, context: teamContext() }),
+      },
+    );
+
+    const { status, body } = await api.heartbeat();
+
+    expect(status).toBe(502);
+    expect(body.error).toBe('collab_presence_unavailable');
+  });
+
+  it('stops spawning the upstream transport for a project that keeps failing', async () => {
+    let now = 1_000_000;
+    const heartbeatPresence = vi
+      .fn()
+      .mockRejectedValue(velaCliFailure(503, 'relay overloaded'));
+    const api = await startPresenceServer(
+      {
+        heartbeatPresence,
+        listPresence: vi.fn(async () => []),
+        leavePresence: vi.fn(async () => []),
+      },
+      {
+        verifyWorkspaceRequest: async () => ({ ok: true, context: teamContext() }),
+        presenceUpstreamCooldownMs: 20_000,
+        presenceUpstreamNow: () => now,
+      },
+    );
+
+    // Two consecutive failures arm the negative cache…
+    await api.heartbeat();
+    await api.heartbeat();
+    expect(heartbeatPresence).toHaveBeenCalledTimes(2);
+
+    // …so within the cooldown window the daemon answers from the cached
+    // classification without spawning another CLI process.
+    const blocked = await api.heartbeat();
+    expect(heartbeatPresence).toHaveBeenCalledTimes(2);
+    expect(blocked.status).toBeGreaterThanOrEqual(500);
+
+    // After the cooldown the upstream is probed again.
+    now += 21_000;
+    await api.heartbeat();
+    expect(heartbeatPresence).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/daemon/tests/vela-cli-collab-presence-timeout.test.ts
+++ b/apps/daemon/tests/vela-cli-collab-presence-timeout.test.ts
@@ -1,0 +1,42 @@
+// Red spec for the presence CLI spawn budget.
+//
+// Presence heartbeat/list/leave are high-frequency lease traffic: the web
+// client beats every 10 seconds and every beat spawns a `vela collab presence
+// …` child process. Without a wall-clock budget a wedged CLI (hung network,
+// stalled auth refresh) piles up unbounded child processes while the client
+// keeps beating. Presence spawns must carry an explicit `timeoutMs`; the
+// lower-frequency member/comment commands keep their existing unbounded
+// behavior.
+
+import { describe, expect, it, vi } from 'vitest';
+
+const { runVelaCommandMock } = vi.hoisted(() => ({
+  runVelaCommandMock: vi.fn(),
+}));
+
+vi.mock('../src/integrations/vela-command.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/integrations/vela-command.js')>()),
+  runVelaCommand: runVelaCommandMock,
+}));
+
+import { createVelaCliCollabClient } from '../src/collab/vela-cli-collab-client.js';
+
+describe('vela CLI presence command timeout', () => {
+  it('bounds every presence spawn with a positive timeoutMs', async () => {
+    runVelaCommandMock.mockReset();
+    runVelaCommandMock.mockResolvedValue('{"viewers":[]}');
+    const client = createVelaCliCollabClient();
+
+    await client.heartbeatPresence('p1', { member: { memberId: 'm1' } }, 'w1');
+    await client.listPresence('p1', 'w1');
+    await client.leavePresence('p1', { memberId: 'm1' }, 'w1');
+
+    expect(runVelaCommandMock).toHaveBeenCalledTimes(3);
+    for (const [args, options] of runVelaCommandMock.mock.calls) {
+      expect(args[0]).toBe('collab');
+      expect(args[1]).toBe('presence');
+      expect(options?.timeoutMs).toBeGreaterThan(0);
+      expect(options?.timeoutMs).toBeLessThanOrEqual(30_000);
+    }
+  });
+});

--- a/apps/web/sidecar/server.ts
+++ b/apps/web/sidecar/server.ts
@@ -876,7 +876,7 @@ async function createWebSidecarHandle(
   };
 }
 
-function createDaemonProxyHandler(
+export function createDaemonProxyHandler(
   daemonOrigin: string | null,
   fallback: (request: IncomingMessage, response: ServerResponse) => Promise<void>,
 ): (request: IncomingMessage, response: ServerResponse) => void {

--- a/apps/web/sidecar/server.ts
+++ b/apps/web/sidecar/server.ts
@@ -1,12 +1,13 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import {
+  Agent as HttpAgent,
   createServer as createHttpServer,
   request as createHttpRequest,
   type IncomingMessage,
   type Server as HttpServer,
   type ServerResponse,
 } from "node:http";
-import { request as createHttpsRequest } from "node:https";
+import { Agent as HttpsAgent, request as createHttpsRequest } from "node:https";
 import { existsSync, readFileSync } from "node:fs";
 import { readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
@@ -400,13 +401,115 @@ function isSameBrowserHostOrigin(options: {
   return isLoopbackOrPrivateLanHost(originHost) || isAllowedDevHost(originHost, allowedDevHosts);
 }
 
+/**
+ * Explicit keep-alive pool for proxied upstream requests.
+ *
+ * Invariant: a pooled idle socket must be destroyed strictly before either
+ * upstream's server-side keep-alive window can close it — the daemon holds
+ * kept-alive sockets for 120s (`apps/daemon/src/server.ts`) and a standalone
+ * Next.js backend uses Node's 5s default — so the proxy should not pick up an
+ * idle socket its upstream is concurrently closing. On a keep-alive Agent the
+ * `timeout` option destroys pooled sockets after that idle period; sockets
+ * with an in-flight request only emit an (unobserved) `timeout` event, so
+ * long-lived streams such as SSE are unaffected.
+ */
+const PROXY_FREE_SOCKET_IDLE_MS = 3_000;
+const proxyHttpAgent = new HttpAgent({
+  keepAlive: true,
+  scheduling: "lifo",
+  timeout: PROXY_FREE_SOCKET_IDLE_MS,
+});
+const proxyHttpsAgent = new HttpsAgent({
+  keepAlive: true,
+  scheduling: "lifo",
+  timeout: PROXY_FREE_SOCKET_IDLE_MS,
+});
+
+/**
+ * Requests whose body is fully buffered under this cap AND whose method is
+ * idempotent may be replayed once after a reused-socket connection reset.
+ * Larger bodies and non-idempotent methods keep the streaming pass-through
+ * path and are never replayed.
+ */
+const PROXY_REPLAY_BODY_LIMIT_BYTES = 512 * 1024;
+const IDEMPOTENT_PROXY_METHODS = new Set(["GET", "HEAD", "PUT", "DELETE", "OPTIONS"]);
+
+type ProxyRequestBody =
+  | { replayable: true; body: Buffer }
+  | { replayable: false; prefix: Buffer[]; stream: IncomingMessage };
+
+function captureProxyRequestBody(request: IncomingMessage): Promise<ProxyRequestBody> {
+  const method = (request.method ?? "GET").toUpperCase();
+  if (!IDEMPOTENT_PROXY_METHODS.has(method)) {
+    return Promise.resolve({ replayable: false, prefix: [], stream: request });
+  }
+  return new Promise((resolveBody) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    let settled = false;
+    const settle = (body: ProxyRequestBody) => {
+      if (settled) return;
+      settled = true;
+      request.off("data", onData);
+      request.off("end", onEnd);
+      request.off("error", onError);
+      request.off("close", onError);
+      resolveBody(body);
+    };
+    const onData = (chunk: Buffer) => {
+      chunks.push(chunk);
+      size += chunk.length;
+      if (size > PROXY_REPLAY_BODY_LIMIT_BYTES) {
+        request.pause();
+        settle({ replayable: false, prefix: [...chunks], stream: request });
+      }
+    };
+    const onEnd = () => settle({ replayable: true, body: Buffer.concat(chunks) });
+    // A client that aborts mid-body gets the same truncated-stream behavior
+    // as the previous pipe-through implementation (and is never replayed).
+    const onError = () => settle({ replayable: false, prefix: [...chunks], stream: request });
+    request.on("data", onData);
+    request.on("end", onEnd);
+    request.on("error", onError);
+    // A disconnect can surface as a bare "close" with neither "end" nor
+    // "error"; "end" always fires first on complete bodies, so this only
+    // catches genuinely truncated requests.
+    request.on("close", onError);
+  });
+}
+
+/**
+ * The daemon can close a kept-alive socket at the same moment the proxy
+ * reuses it (keep-alive window expiry, restart) — the write then fails with a
+ * connection reset and, before this guard, surfaced to the browser as a 502
+ * the daemon never sent. Replaying is safe exactly when the request is
+ * idempotent with a fully buffered body, no response bytes have arrived, and
+ * the failed attempt ran on a REUSED pooled socket; the retry takes a fresh
+ * connection so it cannot hit another stale pool entry.
+ */
+function shouldReplayProxyRequest(input: {
+  attempt: number;
+  body: ProxyRequestBody;
+  error: unknown;
+  reusedSocket: boolean;
+  response: ServerResponse;
+}): boolean {
+  if (input.attempt > 0 || !input.body.replayable) return false;
+  if (input.response.headersSent || !input.reusedSocket) return false;
+  const code = input.error instanceof Error
+    ? (input.error as NodeJS.ErrnoException).code
+    : undefined;
+  return code === "ECONNRESET" || code === "EPIPE";
+}
+
 async function proxyHttpRequest(
   target: URL,
   request: IncomingMessage,
   response: ServerResponse,
   options: { daemonWebPort?: number } = {},
 ): Promise<void> {
-  const proxyRequestFactory = target.protocol === "https:" ? createHttpsRequest : createHttpRequest;
+  const secure = target.protocol === "https:";
+  const proxyRequestFactory = secure ? createHttpsRequest : createHttpRequest;
   const headers = { ...request.headers, host: target.host };
   if (options.daemonWebPort != null) {
     const origin = normalizeDaemonProxyOriginHeader({
@@ -422,30 +525,55 @@ async function proxyHttpRequest(
     }
   }
 
+  const body = await captureProxyRequestBody(request);
+
   await new Promise<void>((resolveProxy) => {
-    const proxyRequest = proxyRequestFactory(
-      target,
-      {
-        headers,
-        method: request.method,
-      },
-      (proxyResponse) => {
-        response.writeHead(proxyResponse.statusCode ?? 502, proxyResponse.headers);
-        proxyResponse.pipe(response);
-        proxyResponse.on("end", resolveProxy);
-      },
-    );
+    const sendAttempt = (attempt: number): void => {
+      const proxyRequest = proxyRequestFactory(
+        target,
+        {
+          headers,
+          method: request.method,
+          // The replay must prove the failure was a stale pooled socket, so
+          // it bypasses the pool and dials a fresh connection.
+          agent: attempt === 0 ? (secure ? proxyHttpsAgent : proxyHttpAgent) : false,
+        },
+        (proxyResponse) => {
+          response.writeHead(proxyResponse.statusCode ?? 502, proxyResponse.headers);
+          proxyResponse.pipe(response);
+          proxyResponse.on("end", resolveProxy);
+        },
+      );
 
-    proxyRequest.on("error", (error) => {
-      if (!response.headersSent) {
-        response.statusCode = 502;
-        response.setHeader("content-type", "text/plain; charset=utf-8");
+      proxyRequest.on("error", (error) => {
+        if (
+          shouldReplayProxyRequest({
+            attempt,
+            body,
+            error,
+            reusedSocket: proxyRequest.reusedSocket === true,
+            response,
+          })
+        ) {
+          sendAttempt(attempt + 1);
+          return;
+        }
+        if (!response.headersSent) {
+          response.statusCode = 502;
+          response.setHeader("content-type", "text/plain; charset=utf-8");
+        }
+        response.end(error instanceof Error ? error.message : String(error));
+        resolveProxy();
+      });
+
+      if (body.replayable) {
+        proxyRequest.end(body.body);
+      } else {
+        for (const chunk of body.prefix) proxyRequest.write(chunk);
+        body.stream.pipe(proxyRequest);
       }
-      response.end(error instanceof Error ? error.message : String(error));
-      resolveProxy();
-    });
-
-    request.pipe(proxyRequest);
+    };
+    sendAttempt(0);
   });
 }
 

--- a/apps/web/src/collab/collab-client.ts
+++ b/apps/web/src/collab/collab-client.ts
@@ -73,6 +73,15 @@ export interface CollabClientOptions {
 
 const DEFAULT_HEARTBEAT_MS = 10_000;
 const DEFAULT_STATUS_POLL_MS = 5_000;
+/**
+ * Ceiling for the failure-widened heartbeat interval. Presence retries
+ * forever (the upstream can recover at any moment), but a packaged client
+ * left open against a persistently rejecting upstream must degrade to a slow
+ * probe — not an error every 10 seconds for hours (the 502 storm).
+ */
+const HEARTBEAT_BACKOFF_CAP_MS = 300_000;
+/** ±10% jitter so many open clients do not re-probe in lockstep. */
+const HEARTBEAT_BACKOFF_JITTER = 0.2;
 // Vela's authoritative project-presence lease is 30 seconds from the
 // server-recorded heartbeatAt, not from when this client happens to observe
 // the roster. Using observation time can nearly double a stale lease.
@@ -154,6 +163,14 @@ export class CollabClient {
   private presenceSessionSequence = 0;
   /** A leave is necessary only after a heartbeat request could have made a lease. */
   private presenceLeaseMemberId: string | null = null;
+  /**
+   * Self-scheduling heartbeat chain (single pending timer). A fixed interval
+   * cannot express failure backoff, so each settled heartbeat schedules the
+   * next one at {@link nextHeartbeatDelayMs}.
+   */
+  private heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Consecutive failed heartbeat requests; any success resets it. */
+  private heartbeatFailureStreak = 0;
   private running = false;
   private onVisibilityChange: (() => void) | null = null;
 
@@ -193,6 +210,9 @@ export class CollabClient {
       this.presenceAppliedRequestGeneration = this.presenceRequestGeneration;
       this.clearPresenceRoster();
       this.presenceAttemptedForMember = false;
+      // A new identity is a new presence session: probe it promptly instead
+      // of inheriting the previous identity's widened failure interval.
+      this.heartbeatFailureStreak = 0;
     }
     if (
       this.running
@@ -248,9 +268,6 @@ export class CollabClient {
     this.timers.push(setInterval(() => {
       if (visible()) void this.pollStatus();
     }, this.statusPollMs));
-    this.timers.push(setInterval(() => {
-      void this.heartbeat();
-    }, this.heartbeatMs));
     if (typeof document !== 'undefined') {
       this.onVisibilityChange = () => {
         if (!visible()) return;
@@ -275,6 +292,10 @@ export class CollabClient {
     this.presenceFallbackMissingSince.clear();
     for (const timer of this.timers) clearInterval(timer);
     this.timers.length = 0;
+    if (this.heartbeatTimer) {
+      clearTimeout(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
     if (this.onVisibilityChange && typeof document !== 'undefined') {
       document.removeEventListener('visibilitychange', this.onVisibilityChange);
       this.onVisibilityChange = null;
@@ -307,6 +328,17 @@ export class CollabClient {
     // still resolve and reach the "newly shared" heartbeat below. Stopped
     // clients no longer own a presence loop and must never write to it.
     if (!this.running) return;
+    try {
+      await this.heartbeatOnce();
+    } finally {
+      // Every heartbeat attempt — including the identity-less and unshared
+      // early returns — keeps the presence loop alive by scheduling the next
+      // beat. stop() is the only exit from the chain.
+      this.scheduleNextHeartbeat();
+    }
+  }
+
+  private async heartbeatOnce(): Promise<void> {
     // No identity yet (status polling can be running well before `member`
     // resolves — see setMember) — presence has nothing to announce.
     if (!this.member) return;
@@ -337,6 +369,7 @@ export class CollabClient {
         clientId: this.clientId,
         sequence,
       });
+      this.heartbeatFailureStreak = 0;
       if (Array.isArray(body?.present)) {
         this.applyPresenceResponse(
           requestGeneration,
@@ -344,12 +377,45 @@ export class CollabClient {
         );
       }
     } catch (error) {
+      this.heartbeatFailureStreak += 1;
       if (isForbiddenCollabRequest(error)) {
         this.applyPresenceAuthorityRevocation(requestGeneration);
       }
       this.presenceAttemptedForMember = false;
       this.onError?.(error);
     }
+  }
+
+  /**
+   * Reschedule the single pending heartbeat. Out-of-band beats (setMember's
+   * immediate announce, the shared-transition beat in pollStatus) land here
+   * too, so the loop never accumulates parallel timers.
+   */
+  private scheduleNextHeartbeat(): void {
+    if (!this.running) return;
+    if (this.heartbeatTimer) clearTimeout(this.heartbeatTimer);
+    this.heartbeatTimer = setTimeout(() => {
+      this.heartbeatTimer = null;
+      void this.heartbeat();
+    }, this.nextHeartbeatDelayMs());
+  }
+
+  /**
+   * The invariant behind the 502-storm fix: consecutive heartbeat failures
+   * double the interval (base → 2× → 4× → …) up to
+   * {@link HEARTBEAT_BACKOFF_CAP_MS}, with jitter; one success — or a new
+   * presence identity — restores the base cadence.
+   */
+  private nextHeartbeatDelayMs(): number {
+    if (this.heartbeatFailureStreak === 0) return this.heartbeatMs;
+    const exponent = Math.min(this.heartbeatFailureStreak - 1, 10);
+    const widened = Math.min(
+      this.heartbeatMs * 2 ** exponent,
+      HEARTBEAT_BACKOFF_CAP_MS,
+    );
+    const jitter =
+      1 - HEARTBEAT_BACKOFF_JITTER / 2 + HEARTBEAT_BACKOFF_JITTER * Math.random();
+    return Math.round(widened * jitter);
   }
 
   /**

--- a/apps/web/tests/collab-client.heartbeat-backoff.test.ts
+++ b/apps/web/tests/collab-client.heartbeat-backoff.test.ts
@@ -1,0 +1,116 @@
+// Red spec for the packaged-client presence 502 storm (heartbeat half).
+//
+// A packaged client left open on a shared project whose collab upstream is in
+// a persistent rejection state used to fire a heartbeat POST every 10 seconds
+// forever — several hours of that is ~2050 DevTools errors plus a spawned CLI
+// process per beat on the daemon side. Presence heartbeats must keep retrying
+// (the upstream can recover at any time), but consecutive failures have to
+// widen the interval instead of hammering a dead endpoint at full cadence.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CollabClient } from '../src/collab/collab-client.js';
+import { workspaceContextFixture } from './helpers/workspace-context';
+
+const TEAM_CONTEXT = workspaceContextFixture({
+  workspaceId: 'workspace-team',
+  workspaceMemberId: 'member-viewer',
+});
+
+const TEST_NOW = Date.parse('2026-08-05T00:00:00.000Z');
+
+interface HeartbeatFetchState {
+  /** Heartbeat responses fail while callCount < failFirst (Infinity = always). */
+  failFirst: number;
+  heartbeatTimes: number[];
+}
+
+function makeHeartbeatFetch(failFirst: number) {
+  const state: HeartbeatFetchState = { failFirst, heartbeatTimes: [] };
+  const fetchImpl = (async (input: RequestInfo | URL) => {
+    const pathname = new URL(String(input), 'http://daemon.local').pathname;
+    if (pathname.endsWith('/presence/heartbeat')) {
+      state.heartbeatTimes.push(Date.now() - TEST_NOW);
+      if (state.heartbeatTimes.length <= state.failFirst) {
+        return {
+          ok: false,
+          status: 502,
+          json: async () => ({ error: 'collab_presence_unavailable' }),
+        } as unknown as Response;
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ present: [{ memberId: 'member-viewer' }] }),
+      } as unknown as Response;
+    }
+    if (pathname.endsWith('/collab/status')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ publishedVersion: 1, syncState: 'synced' }),
+      } as unknown as Response;
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, present: [] }),
+    } as unknown as Response;
+  }) as typeof fetch;
+  return { fetchImpl, state };
+}
+
+function startClient(fetchImpl: typeof fetch): CollabClient {
+  const client = new CollabClient({
+    projectId: 'p1',
+    member: { memberId: 'member-viewer', name: 'Viewer' },
+    workspaceContext: TEAM_CONTEXT,
+    fetch: fetchImpl,
+  });
+  client.start();
+  return client;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(TEST_NOW);
+  // Pin backoff jitter to its midpoint so scheduled beats are deterministic.
+  vi.spyOn(Math, 'random').mockReturnValue(0.5);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('CollabClient heartbeat backoff', () => {
+  it('backs off instead of heartbeating every 10s against a persistently failing upstream', async () => {
+    const { fetchImpl, state } = makeHeartbeatFetch(Number.POSITIVE_INFINITY);
+    const client = startClient(fetchImpl);
+
+    // Ten minutes of a persistently failing upstream. The fixed 10s interval
+    // produced ~61 failed heartbeats here; exponential backoff capped at five
+    // minutes must keep it to a handful.
+    await vi.advanceTimersByTimeAsync(600_000);
+    client.stop();
+
+    expect(state.heartbeatTimes.length).toBeLessThanOrEqual(12);
+  });
+
+  it('returns to the base cadence after one successful heartbeat', async () => {
+    const { fetchImpl, state } = makeHeartbeatFetch(3);
+    const client = startClient(fetchImpl);
+
+    await vi.advanceTimersByTimeAsync(600_000);
+    client.stop();
+
+    // Recovery must not stay stuck at the backed-off interval: once a beat
+    // succeeds, the next beats run at (roughly) the 10s base again.
+    const firstSuccessIndex = 3; // the fourth beat succeeds by construction
+    const afterRecovery = state.heartbeatTimes.slice(firstSuccessIndex);
+    expect(afterRecovery.length).toBeGreaterThanOrEqual(2);
+    for (let i = 1; i < Math.min(afterRecovery.length, 4); i += 1) {
+      const gap = afterRecovery[i]! - afterRecovery[i - 1]!;
+      expect(gap).toBeLessThanOrEqual(12_000);
+    }
+  });
+});

--- a/apps/web/tests/sidecar-proxy-keepalive.test.ts
+++ b/apps/web/tests/sidecar-proxy-keepalive.test.ts
@@ -1,0 +1,167 @@
+// Red spec for the packaged-client 502 storm (proxy half).
+//
+// The web sidecar proxies every /api request to the daemon over pooled
+// keep-alive sockets. When the daemon side of one of those sockets goes away
+// between requests — its 120s keep-alive window closing while the pooled
+// socket is being picked up, a daemon restart, any server-side close racing
+// the proxy's write — the proxied request dies with ECONNRESET and the proxy
+// synthesizes a 502 the daemon never sent. In the packaged client this
+// surfaced as recurring `PUT /api/workspace/billing/interests/:clientId` 502s
+// even though that daemon route has no 502 path at all.
+//
+// The spec: an idempotent request with a small replayable body that fails
+// with a connection reset on a REUSED pooled socket, before any response
+// bytes arrived, must be retried once on a fresh connection instead of
+// surfacing a synthesized 502. Non-idempotent methods must never be replayed.
+
+import { createServer as createNetServer, type Server as NetServer, type Socket } from 'node:net';
+import { createServer as createHttpServer, type Server as HttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createDaemonProxyHandler } from '../sidecar/server';
+
+/**
+ * A daemon stand-in that serves exactly one request per kept-alive socket on
+ * its first connection, then hard-closes that socket as soon as the next
+ * request has been fully written into it — the deterministic equivalent of
+ * the daemon closing a pooled connection the proxy just reused. Every later
+ * connection behaves normally, so a single fresh-socket retry succeeds.
+ */
+function startFlakyDaemon(): Promise<{
+  port: number;
+  requestLog: string[];
+  close: () => Promise<void>;
+}> {
+  const requestLog: string[] = [];
+  let connectionIndex = 0;
+  const sockets = new Set<Socket>();
+
+  const server: NetServer = createNetServer((socket) => {
+    connectionIndex += 1;
+    const connection = connectionIndex;
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+    let pending = Buffer.alloc(0);
+    let served = 0;
+
+    socket.on('data', (chunk) => {
+      pending = Buffer.concat([pending, chunk]);
+      for (;;) {
+        const headerEnd = pending.indexOf('\r\n\r\n');
+        if (headerEnd === -1) return;
+        const header = pending.subarray(0, headerEnd).toString('utf8');
+        const contentLength = Number(
+          /content-length:\s*(\d+)/i.exec(header)?.[1] ?? '0',
+        );
+        const total = headerEnd + 4 + contentLength;
+        if (pending.length < total) return;
+        pending = pending.subarray(total);
+        served += 1;
+        const requestLine = header.split('\r\n')[0] ?? '';
+        requestLog.push(`conn${connection} ${requestLine}`);
+        if (connection === 1 && served > 1) {
+          // The daemon closed this kept-alive socket right after the proxy
+          // reused it: the request was fully written, no response will come.
+          socket.destroy();
+          return;
+        }
+        const body = JSON.stringify({ ok: true, connection, served });
+        socket.write(
+          'HTTP/1.1 200 OK\r\n'
+            + 'content-type: application/json\r\n'
+            + `content-length: ${Buffer.byteLength(body)}\r\n`
+            + 'connection: keep-alive\r\n'
+            + '\r\n'
+            + body,
+        );
+      }
+    });
+  });
+
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({
+        port: (server.address() as AddressInfo).port,
+        requestLog,
+        close: async () => {
+          for (const socket of sockets) socket.destroy();
+          await new Promise<void>((resolveClose) => {
+            server.close(() => resolveClose());
+          });
+        },
+      });
+    });
+  });
+}
+
+const cleanups: (() => Promise<void>)[] = [];
+
+afterEach(async () => {
+  while (cleanups.length > 0) await cleanups.pop()!();
+});
+
+async function startProxy(daemonPort: number): Promise<number> {
+  const proxy: HttpServer = createHttpServer(
+    createDaemonProxyHandler(`http://127.0.0.1:${daemonPort}`, async (_request, response) => {
+      response.statusCode = 404;
+      response.end('fallback');
+    }),
+  );
+  await new Promise<void>((resolve) => {
+    proxy.listen(0, '127.0.0.1', () => resolve());
+  });
+  cleanups.push(async () => {
+    await new Promise<void>((resolve) => {
+      proxy.close(() => resolve());
+    });
+    proxy.closeAllConnections();
+  });
+  return (proxy.address() as AddressInfo).port;
+}
+
+describe('sidecar daemon proxy keep-alive resilience', () => {
+  it('replays an idempotent request once when the daemon resets a reused pooled socket', async () => {
+    const daemon = await startFlakyDaemon();
+    cleanups.push(daemon.close);
+    const proxyPort = await startProxy(daemon.port);
+    const url = `http://127.0.0.1:${proxyPort}/api/workspace/billing/interests/c1`;
+    const init = {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ generation: '1', interests: [] }),
+    } as const;
+
+    const first = await fetch(url, init);
+    expect(first.status).toBe(200);
+
+    // Give the proxy time to release the daemon socket back into its pool.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const second = await fetch(url, init);
+    expect(second.status).toBe(200);
+    expect(daemon.requestLog.some((line) => line.startsWith('conn2 '))).toBe(true);
+  });
+
+  it('never replays a non-idempotent request', async () => {
+    const daemon = await startFlakyDaemon();
+    cleanups.push(daemon.close);
+    const proxyPort = await startProxy(daemon.port);
+    const url = `http://127.0.0.1:${proxyPort}/api/projects/p1/presence/heartbeat`;
+    const init = {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ memberId: 'm1' }),
+    } as const;
+
+    const first = await fetch(url, init);
+    expect(first.status).toBe(200);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const second = await fetch(url, init);
+    expect(second.status).toBe(502);
+    expect(daemon.requestLog.some((line) => line.startsWith('conn2 '))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

A packaged production client left open for a few hours accumulated **~2050 DevTools errors**: `POST /api/projects/:id/presence/heartbeat` and `PUT /api/workspace/billing/interests/:clientId` failing with 502 every few seconds, burning a spawned `vela` CLI child process per beat on the daemon while the collab upstream was in a persistent rejection state for that project. Three client-side amplifiers turned one upstream problem into an hours-long error storm:

1. **Web heartbeat had no backoff.** `CollabClient` heartbeated on a fixed 10s interval forever; failures only invoked an `onError` nobody wires. 6 errors/minute, indefinitely.
2. **The daemon flattened every upstream failure into 502.** The vela CLI exits 1 on any non-2xx and prints `API request failed with status NNN`, but `collab-presence.ts` wrapped everything as 502 `collab_presence_unavailable` — with the full spawned command line embedded in the response message — and re-spawned the CLI on every beat with no timeout and no cooldown.
3. **The sidecar proxy synthesized 502s the daemon never sent.** The interests route has no 502 path at all (200/400/403/409/429/503 only); the observed `PUT … interests` 502s were minted by the web sidecar's `/api` proxy when a proxied request died with a connection reset on a reused pooled keep-alive socket (daemon-side close racing the proxy's write — keep-alive window expiry, daemon restart).

The upstream's sticky rejection state itself is a Vela server-side issue owned by backend (see Adjacent issues); this PR removes the client-side amplification and mislabeling.

## What users will see

- The multi-hour 502 error storm in the packaged client disappears. When the collab upstream rejects a project, the console shows a handful of correctly-labeled errors (403/404) whose frequency decays to one probe every ~5 minutes — and presence recovers by itself on the next successful beat when the upstream comes back.
- Presence/billing requests no longer intermittently fail with bogus 502s when the daemon closes an idle keep-alive connection; the proxy replays safe requests once on a fresh connection and users see the daemon's real answer.
- Error payloads no longer leak the daemon's spawned CLI command line to the renderer (full detail stays in the daemon log).
- A wedged `vela` CLI can no longer pile up presence child processes: presence spawns are bounded at 10s, and a persistently failing project stops spawning entirely for 20s windows.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [x] **API / contract** — no new endpoint and no `packages/contracts` change, but the daemon presence routes' *error statuses* change: upstream 401/403 now relay as 403 (`collab_presence_denied`), upstream 404 as 404 (`collab_presence_not_found`), transport timeouts as 503; only genuine infrastructure failures keep 502 `collab_presence_unavailable`. The web client already treats 403 as authority revocation, so it benefits without changes.
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency** — none; the proxy fix uses Node's built-in `http.Agent` only.
- [x] **Default behavior change** — failing presence heartbeats now back off exponentially (10s → 20s → 40s → … capped at 5 min, ±10% jitter; any success or identity switch restores the 10s cadence). Healthy-path behavior is unchanged.
- [ ] **None**

## Bug fix verification

All three surfaces were encoded as red specs first, on this branch's first commit (4f655989c3, tests only), then fixed in the second commit. Red output on unmodified `main` code:

```
### apps/web collab-client heartbeat backoff (A)
 × backs off instead of heartbeating every 10s against a persistently failing upstream
AssertionError: expected 62 to be less than or equal to 12        # 62 heartbeats in 10 simulated minutes

### apps/daemon presence upstream relay + negative cache + CLI timeout (B)
 × relays a persistent upstream 404 as 404 without leaking the spawned command line
AssertionError: expected 502 to be 404
 × relays an upstream 403 rejection as 403 so the web client sees revoked authority
AssertionError: expected 502 to be 403
 × stops spawning the upstream transport for a project that keeps failing
AssertionError: expected "vi.fn()" to be called 2 times, but got 3 times
 × bounds every presence spawn with a positive timeoutMs
TypeError: actual value must be number or bigint, received "undefined"

### apps/web sidecar proxy keep-alive retry (C)
 × replays an idempotent request once when the daemon resets a reused pooled socket
AssertionError: expected 502 to be 200
```

- Test paths:
  - `apps/web/tests/collab-client.heartbeat-backoff.test.ts`
  - `apps/daemon/tests/collab-presence-upstream.test.ts`
  - `apps/daemon/tests/vela-cli-collab-presence-timeout.test.ts`
  - `apps/web/tests/sidecar-proxy-keepalive.test.ts`
- Red on `main`, green on this branch: **yes** (6 red assertions above; all green after the fix commit).
- The proxy race is asserted behaviorally: a net-level daemon stand-in serves one request per kept-alive socket, then hard-closes the socket the moment the proxy writes a reused-socket request into it — the deterministic equivalent of the daemon closing a pooled connection mid-reuse. A companion spec pins the safety boundary: non-idempotent (POST) requests are never replayed.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass (all workspaces)
- `pnpm --filter @open-design/web test` — full suite pass (599 files / 6225 tests). One run showed a single unrelated load-timing flake in `tests/components/ProjectView.run-workspace-identity.test.tsx` (a `waitFor`-then-assert race on the send button); that file mocks out `useProjectCollab` entirely so none of this diff executes in it, and it passes consistently in isolation and on the full-suite rerun.
- `pnpm --filter @open-design/daemon test` — collab subset (full daemon suite is slow): `collab-presence-upstream`, `vela-cli-collab-presence-timeout`, `collab-presence-routes`, `collab-presence-transport-off`, `collab-presence-tracker`, `collab-cloud`, `collab-cli`, `collab-context-routes`, `collab-sync-routes`, `collab-workspace-events-route`, `collab-workspace-invalidation-poller`, `collab-team-projects-routes` — 269 tests, all pass

## Adjacent issues (out of scope)

- **Vela server-side sticky rejection state**: the storm's root trigger was the upstream persistently answering 404/503 for one project's presence writes. That is a Vela backend issue and is being tracked by backend colleagues; this PR only removes the client-side amplification, mislabeling, and process-spawn waste around it.
- **Investigation nuance worth recording**: on Node ≥ 19 the global agent already destroys pooled idle sockets after 5s, so the pure "daemon 120s keep-alive expiry vs. idle pool" race window is narrower than the incident write-up assumed. The proxy fix therefore targets the whole reused-socket reset class (close/reuse races regardless of cause, daemon restarts) with an explicit agent invariant plus a single safe replay, rather than only re-tuning idle windows.
- `apps/web/src/collab/workspace-billing-interests.ts` retry ceiling stays at 20s; with the proxy no longer minting 502s its residual failure traffic is genuine 503s at a modest rate, so the ladder was left untouched to keep this PR scoped.
