### PR TITLE
fix(amr): scope Vela model list by selected workspace

### DIFF
--- a/apps/daemon/src/routes/vela.ts
+++ b/apps/daemon/src/routes/vela.ts
@@ -483,7 +483,9 @@ export function registerVelaRoutes(app: Express, deps: RegisterVelaRoutesDeps): 
         inFlightVelaAccountInvalidations.has(accountCacheKey) &&
         (!previousAccount || previousAccount.plan !== account.plan)
       ) {
-        amrModelLoadingCache.invalidate(probe.cacheKey);
+        // Plan changes affect every workspace-scoped catalog for this
+        // credential, not only the unscoped probe used by /status.
+        amrModelLoadingCache.invalidateAll();
       }
       setVelaLiveAccount(accountCacheKey, account);
       return account;
@@ -604,8 +606,10 @@ export function registerVelaRoutes(app: Express, deps: RegisterVelaRoutesDeps): 
       });
       if (refresh) {
         try {
-          const modelProbe = resolveAmrModelProbeForEnv(configuredEnv);
-          amrModelLoadingCache.invalidate(modelProbe.cacheKey);
+          // Wallet refresh is an explicit "entitlements may have changed"
+          // signal. Catalogs are workspace-partitioned, so drop every entry
+          // rather than only the unscoped personal key.
+          amrModelLoadingCache.invalidateAll();
         } catch (err) {
           console.warn('[amr] model cache invalidation after wallet refresh failed', err);
         }

--- a/apps/daemon/src/routes/vela.ts
+++ b/apps/daemon/src/routes/vela.ts
@@ -47,12 +47,16 @@ import {
   velaWalletSnapshotReader,
 } from '../integrations/vela-wallet.js';
 import { amrModelLoadingCache } from '../runtimes/amr-model-cache.js';
-import { buildAmrModelCacheKey } from '../runtimes/amr-model-probe.js';
+import {
+  buildAmrModelCacheKey,
+  withVelaModelListWorkspaceScope,
+} from '../runtimes/amr-model-probe.js';
 import {
   fetchVelaBillingSummary,
   fetchVelaPresetModels,
   fetchVelaRemoteModelsWithRetry,
 } from '../runtimes/defs/amr.js';
+import { headerValue } from '../collab/workspace-resource-mutation.js';
 
 const AMR_API_PROXY_PREFIX = '/api/integrations/vela/api-proxy';
 const VELA_MESSAGE_CENTER_PREFIX = '/api/integrations/vela/message-center';
@@ -408,23 +412,29 @@ export function registerVelaRoutes(app: Express, deps: RegisterVelaRoutesDeps): 
     return host ? `${proto}://${host}` : 'http://localhost:7456';
   });
 
-  function resolveAmrModelProbeForEnv(configuredEnv: Record<string, string>): AmrModelProbe {
+  function resolveAmrModelProbeForEnv(
+    configuredEnv: Record<string, string>,
+    workspaceId?: string | null,
+  ): AmrModelProbe {
     const def = getAgentDef('amr');
     if (!def) throw new Error('AMR runtime definition is missing');
     const agentLaunch = resolveAgentLaunch(def, configuredEnv);
     const launchPath = agentLaunch.launchPath ?? agentLaunch.selectedPath;
     if (!launchPath) throw new Error('AMR vela binary could not be resolved');
-    const spawnEnv = applyAgentLaunchEnv(
-      spawnEnvForAgent(
-        def.id,
-        {
-          ...env,
-          ...(def.env || {}),
-        },
-        configuredEnv,
-        undefined,
+    const spawnEnv = withVelaModelListWorkspaceScope(
+      applyAgentLaunchEnv(
+        spawnEnvForAgent(
+          def.id,
+          {
+            ...env,
+            ...(def.env || {}),
+          },
+          configuredEnv,
+          undefined,
+        ),
+        agentLaunch,
       ),
-      agentLaunch,
+      workspaceId,
     );
     const credentialRevision = readVelaCredentialRevision(env, configuredEnv);
     const cacheKey = buildAmrModelCacheKey({
@@ -435,10 +445,12 @@ export function registerVelaRoutes(app: Express, deps: RegisterVelaRoutesDeps): 
     return { launchPath, env: spawnEnv, configuredEnv, cacheKey };
   }
 
-  async function resolveAmrModelProbe(): Promise<AmrModelProbe> {
+  async function resolveAmrModelProbe(
+    workspaceId?: string | null,
+  ): Promise<AmrModelProbe> {
     const appConfig = await readAppConfig(RUNTIME_DATA_DIR);
     const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'amr');
-    return resolveAmrModelProbeForEnv(configuredEnv);
+    return resolveAmrModelProbeForEnv(configuredEnv, workspaceId);
   }
 
   // Single-flight the live billing fetch per credential revision. Treating
@@ -491,9 +503,13 @@ export function registerVelaRoutes(app: Express, deps: RegisterVelaRoutesDeps): 
     return pending;
   }
 
-  app.get('/api/amr/models', async (_req, res) => {
+  app.get('/api/amr/models', async (req, res) => {
     try {
-      const probe = await resolveAmrModelProbe();
+      // Prefer the UI-selected workspace from the same shell headers every
+      // other workspace surface uses. Fall back to no scope only for legacy
+      // headerless callers; that keeps personal-default Link behavior.
+      const workspaceId = headerValue(req, 'x-od-workspace-id');
+      const probe = await resolveAmrModelProbe(workspaceId);
       const response = await amrModelLoadingCache.get(probe.cacheKey, {
         fetchPreset: () => fetchVelaPresetModels(probe.launchPath, probe.env),
         fetchRemote: () => fetchVelaRemoteModelsWithRetry(probe.launchPath, probe.env),

--- a/apps/daemon/src/routes/vela.ts
+++ b/apps/daemon/src/routes/vela.ts
@@ -511,6 +511,14 @@ export function registerVelaRoutes(app: Express, deps: RegisterVelaRoutesDeps): 
       // other workspace surface uses. Fall back to no scope only for legacy
       // headerless callers; that keeps personal-default Link behavior.
       const workspaceId = headerValue(req, 'x-od-workspace-id');
+      // Reject malformed workspace ids before they enter AmrModelLoadingCache
+      // or spawn `vela model list`. Per-key cache states have no age eviction;
+      // unbounded header values would otherwise create persistent entries and
+      // subprocess work. Same pattern as the AMR API proxy boundary above.
+      if (workspaceId !== null && !VELA_WORKSPACE_ID_PATTERN.test(workspaceId)) {
+        res.status(400).json({ error: 'invalid_workspace_id' });
+        return;
+      }
       const probe = await resolveAmrModelProbe(workspaceId);
       const response = await amrModelLoadingCache.get(probe.cacheKey, {
         fetchPreset: () => fetchVelaPresetModels(probe.launchPath, probe.env),

--- a/apps/daemon/src/runtimes/amr-model-cache.ts
+++ b/apps/daemon/src/runtimes/amr-model-cache.ts
@@ -68,6 +68,19 @@ export class AmrModelLoadingCache {
     this.states.delete(cacheKey);
   }
 
+  /**
+   * Drop every cached catalog entry.
+   *
+   * Path A discovery is workspace-partitioned (`velaWorkspaceId` is part of
+   * the cache key). Plan and wallet refreshes can change Link entitlements for
+   * every workspace that shares the active credential, so invalidating only
+   * the unscoped personal key would leave Team-scoped catalogs serving stale
+   * locks for up to the refresh TTL.
+   */
+  invalidateAll(): void {
+    this.states.clear();
+  }
+
   resetForTests(): void {
     this.states.clear();
   }

--- a/apps/daemon/src/runtimes/amr-model-probe.ts
+++ b/apps/daemon/src/runtimes/amr-model-probe.ts
@@ -67,6 +67,69 @@ export function buildAmrModelCacheKey({
   });
 }
 
+export interface BuildAmrRememberedLiveModelScopeInput {
+  /** Resolved Vela / OPEN_DESIGN_AMR profile (e.g. prod, local, test). */
+  profile: string;
+  /**
+   * Run-pinned or UI-selected workspace id. Empty/null means the personal
+   * (unscoped) catalog partition — never shared with Team workspaces.
+   */
+  workspaceId?: string | null;
+  /**
+   * Optional credential identity so account switches under the same profile
+   * do not reuse another user's remembered catalog. Prefer
+   * `userId` (file auth) or `credentialFingerprint` (env auth).
+   */
+  credentialIdentity?: string | null;
+}
+
+/**
+ * Scope key for `rememberLiveModels` / `getRememberedLiveModels` on AMR runs.
+ *
+ * Path A probes are workspace-scoped; the remembered-catalog fallback used
+ * when those probes fail must partition the same way. Profile-only keys let a
+ * workspace-A run rewrite an omitted/default model request to workspace B's
+ * last default under the same Vela profile.
+ */
+export function buildAmrRememberedLiveModelScope(
+  input: BuildAmrRememberedLiveModelScopeInput,
+): string {
+  const profile = (typeof input.profile === 'string' ? input.profile.trim() : '') || 'prod';
+  const workspaceId =
+    typeof input.workspaceId === 'string' ? input.workspaceId.trim() : '';
+  const credentialIdentity =
+    typeof input.credentialIdentity === 'string'
+      ? input.credentialIdentity.trim()
+      : '';
+  // Always emit the workspace segment (even when empty) so personal and Team
+  // partitions never collide, and so profile-only legacy keys cannot be
+  // mistaken for an intentional unscoped remember from this helper.
+  const parts = [profile, `ws=${workspaceId}`];
+  if (credentialIdentity) parts.push(`cred=${credentialIdentity}`);
+  return parts.join('|');
+}
+
+/**
+ * Compact non-secret identity for remembered-model partitioning.
+ * Empty when no account is attached yet (unsigned-in personal).
+ */
+export function amrCredentialIdentityFromRevision(
+  revision: Pick<
+    VelaCredentialRevision,
+    'userId' | 'credentialFingerprint' | 'authSource'
+  > | null | undefined,
+): string {
+  if (!revision) return '';
+  const userId = typeof revision.userId === 'string' ? revision.userId.trim() : '';
+  if (userId) return `user:${userId}`;
+  const fingerprint =
+    typeof revision.credentialFingerprint === 'string'
+      ? revision.credentialFingerprint.trim()
+      : '';
+  if (fingerprint) return `env:${fingerprint}`;
+  return revision.authSource === 'none' ? '' : `auth:${revision.authSource}`;
+}
+
 export async function resolveAmrModelProbe({
   dataDir,
   env: baseEnv,

--- a/apps/daemon/src/runtimes/amr-model-probe.ts
+++ b/apps/daemon/src/runtimes/amr-model-probe.ts
@@ -112,11 +112,16 @@ export function buildAmrRememberedLiveModelScope(
 /**
  * Compact non-secret identity for remembered-model partitioning.
  * Empty when no account is attached yet (unsigned-in personal).
+ *
+ * File-backed auth may omit `user.id` (config `user` is optional). Without a
+ * stable user/env identity, include `configMtimeMs` so a rewritten
+ * `~/.amr/config.json` under the same profile/workspace cannot reuse the
+ * previous account's remembered catalog after a failed scoped probe.
  */
 export function amrCredentialIdentityFromRevision(
   revision: Pick<
     VelaCredentialRevision,
-    'userId' | 'credentialFingerprint' | 'authSource'
+    'userId' | 'credentialFingerprint' | 'authSource' | 'configMtimeMs'
   > | null | undefined,
 ): string {
   if (!revision) return '';
@@ -127,7 +132,16 @@ export function amrCredentialIdentityFromRevision(
       ? revision.credentialFingerprint.trim()
       : '';
   if (fingerprint) return `env:${fingerprint}`;
-  return revision.authSource === 'none' ? '' : `auth:${revision.authSource}`;
+  if (revision.authSource === 'none') return '';
+  if (revision.authSource === 'file') {
+    const mtime =
+      typeof revision.configMtimeMs === 'number' &&
+      Number.isFinite(revision.configMtimeMs)
+        ? String(revision.configMtimeMs)
+        : '';
+    return mtime ? `auth:file:mtime=${mtime}` : 'auth:file';
+  }
+  return `auth:${revision.authSource}`;
 }
 
 export async function resolveAmrModelProbe({

--- a/apps/daemon/src/runtimes/amr-model-probe.ts
+++ b/apps/daemon/src/runtimes/amr-model-probe.ts
@@ -12,12 +12,39 @@ export interface ResolveAmrModelProbeDeps {
   dataDir: string;
   env: NodeJS.ProcessEnv;
   readAppConfig: typeof readAppConfig;
+  /**
+   * UI-selected / run-pinned Workspace id for Path A discovery
+   * (`vela model list`). Injected as `VELA_WORKSPACE_ID` so Link evaluates
+   * Team entitlements instead of the personal free allowlist. Omitted only
+   * for legacy unscoped hosts.
+   */
+  workspaceId?: string | null;
 }
 
 export interface BuildAmrModelCacheKeyInput {
   launchPath: string;
   env: NodeJS.ProcessEnv;
   credentialRevision: VelaCredentialRevision;
+}
+
+/**
+ * Apply Path A workspace scope for `vela model list`.
+ *
+ * Precedence mirrors Vela CLI #1372: an explicit host workspace becomes
+ * `VELA_WORKSPACE_ID`. Empty/blank values leave the env unset so Link keeps
+ * its personal-default behavior for legacy callers.
+ */
+export function withVelaModelListWorkspaceScope(
+  env: NodeJS.ProcessEnv,
+  workspaceId?: string | null,
+): NodeJS.ProcessEnv {
+  const scopedWorkspaceId =
+    typeof workspaceId === 'string' ? workspaceId.trim() : '';
+  if (!scopedWorkspaceId) return env;
+  return {
+    ...env,
+    VELA_WORKSPACE_ID: scopedWorkspaceId,
+  };
 }
 
 export function buildAmrModelCacheKey({
@@ -33,6 +60,9 @@ export function buildAmrModelCacheKey({
     velaLinkUrl: env.VELA_LINK_URL ?? '',
     velaRuntimeKey: env.VELA_RUNTIME_KEY ?? '',
     velaOpencodeBin: env.VELA_OPENCODE_BIN ?? '',
+    // Team entitlements are workspace-scoped. Without this key, a personal
+    // free catalog can stick after the UI switches to a paid Team workspace.
+    velaWorkspaceId: env.VELA_WORKSPACE_ID ?? '',
     credentialRevision,
   });
 }
@@ -41,6 +71,7 @@ export async function resolveAmrModelProbe({
   dataDir,
   env: baseEnv,
   readAppConfig,
+  workspaceId,
 }: ResolveAmrModelProbeDeps) {
   const appConfig = await readAppConfig(dataDir);
   const configuredEnv = agentCliEnvForAgent(appConfig.agentCliEnv, 'amr');
@@ -49,17 +80,20 @@ export async function resolveAmrModelProbe({
   const agentLaunch = resolveAgentLaunch(def, configuredEnv);
   const launchPath = agentLaunch.launchPath ?? agentLaunch.selectedPath;
   if (!launchPath) throw new Error('AMR vela binary could not be resolved');
-  const env = applyAgentLaunchEnv(
-    spawnEnvForAgent(
-      def.id,
-      {
-        ...baseEnv,
-        ...(def.env || {}),
-      },
-      configuredEnv,
-      undefined,
+  const env = withVelaModelListWorkspaceScope(
+    applyAgentLaunchEnv(
+      spawnEnvForAgent(
+        def.id,
+        {
+          ...baseEnv,
+          ...(def.env || {}),
+        },
+        configuredEnv,
+        undefined,
+      ),
+      agentLaunch,
     ),
-    agentLaunch,
+    workspaceId,
   );
   const credentialRevision = readVelaCredentialRevision(baseEnv, configuredEnv);
   const cacheKey = buildAmrModelCacheKey({

--- a/apps/daemon/src/runtimes/env.ts
+++ b/apps/daemon/src/runtimes/env.ts
@@ -231,7 +231,15 @@ export function openDesignAmrTraceEnv(input: {
     OPEN_DESIGN_RUN_ID: runId,
     OPEN_DESIGN_RUN_ATTEMPT: String(Math.floor(input.runAttempt)),
     ...(conversationId ? { OPEN_DESIGN_SESSION_ID: conversationId } : {}),
-    ...(workspaceId ? { OPEN_DESIGN_WORKSPACE_ID: workspaceId } : {}),
+    ...(workspaceId
+      ? {
+          OPEN_DESIGN_WORKSPACE_ID: workspaceId,
+          // Belt-and-suspenders for any nested Path A `vela model list` spawn
+          // inside the agent tree. Agent auth still requires the Open Design
+          // run trace above; this only scopes plain model discovery.
+          VELA_WORKSPACE_ID: workspaceId,
+        }
+      : {}),
     ...(bounded('pluginWorkflowId')
       ? { OPEN_DESIGN_PLUGIN_WORKFLOW_ID: bounded('pluginWorkflowId')! }
       : {}),

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -230,6 +230,7 @@ import {
   plainStdoutFromRunEvents,
 } from './runtimes/plain-stream.js';
 import {
+  readVelaCredentialRevision,
   readVelaLoginStatus,
   resolveAmrProfile,
 } from './integrations/vela.js';
@@ -887,7 +888,11 @@ import {
   bindProjectToPersistedAutomationWorkspace,
   normalizePersistedAutomationWorkspaceScope,
 } from './automations/workspace-scope.js';
-import { resolveAmrModelProbe } from './runtimes/amr-model-probe.js';
+import {
+  amrCredentialIdentityFromRevision,
+  buildAmrRememberedLiveModelScope,
+  resolveAmrModelProbe,
+} from './runtimes/amr-model-probe.js';
 import { createPluginInstallationHelpers, normalizeProjectPluginFolderPath, resolveProjectChildDirectory } from './services/plugin-installation.js';
 import { createPluginShareTaskStore } from './services/plugin-share-tasks.js';
 import { getRouteRegistrationInventory, installRouteRegistrationGuard } from './route-registration-guard.js';
@@ -9515,11 +9520,20 @@ export async function startServer({
     } catch {
       configuredAgentEnv = {};
     }
+    // AMR remembered-model validation must partition by workspace + credential,
+    // not only the Vela profile. Otherwise a failed workspace-scoped probe can
+    // reuse another workspace's last catalog under the same profile.
     const requestedLiveModelScope = def.id === 'amr'
-      ? resolveAmrProfile({
-          ...process.env,
-          ...(def.env || {}),
-          ...configuredAgentEnv,
+      ? buildAmrRememberedLiveModelScope({
+          profile: resolveAmrProfile({
+            ...process.env,
+            ...(def.env || {}),
+            ...configuredAgentEnv,
+          }),
+          workspaceId: run.workspaceScope?.workspaceId ?? null,
+          credentialIdentity: amrCredentialIdentityFromRevision(
+            readVelaCredentialRevision(process.env, configuredAgentEnv),
+          ),
         })
       : null;
     const configuredModel =
@@ -10551,7 +10565,16 @@ export async function startServer({
             agentLaunch,
           )
         : null;
-      const amrModelScope = resolveAmrProfile(modelProbeEnv ?? process.env);
+      const amrModelScope = buildAmrRememberedLiveModelScope({
+        profile: resolveAmrProfile(modelProbeEnv ?? process.env),
+        workspaceId: run.workspaceScope?.workspaceId ?? null,
+        credentialIdentity: amrCredentialIdentityFromRevision(
+          readVelaCredentialRevision(
+            modelProbeEnv ?? process.env,
+            configuredAgentEnv,
+          ),
+        ),
+      });
       // Resolve the AMR model catalog through the SAME shared cache the UI's
       // `/api/amr/models` endpoint serves (AmrModelLoadingCache): a cached
       // authoritative `vela model list` when it is hot, otherwise the offline

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -9569,7 +9569,12 @@ export async function startServer({
       // same rewrite before spawn; keeping this earlier copy aligned prevents
       // stored concrete session models from comparing against raw `default`.
       try {
-        const resumeProbe = await resolveAmrModelProbe({ dataDir: RUNTIME_DATA_DIR, env: process.env, readAppConfig });
+        const resumeProbe = await resolveAmrModelProbe({
+          dataDir: RUNTIME_DATA_DIR,
+          env: process.env,
+          readAppConfig,
+          workspaceId: run.workspaceScope?.workspaceId ?? null,
+        });
         const resumeCatalog = await amrModelLoadingCache.get(resumeProbe.cacheKey, {
           fetchPreset: () => fetchVelaPresetModels(resumeProbe.launchPath, resumeProbe.env),
           fetchRemote: () => fetchVelaRemoteModelsWithRetry(resumeProbe.launchPath, resumeProbe.env),
@@ -10565,7 +10570,12 @@ export async function startServer({
       // of fail-closing; vela's own `session/set_model` remains the final gate.
       let liveModels = [];
       try {
-        const probe = await resolveAmrModelProbe({ dataDir: RUNTIME_DATA_DIR, env: process.env, readAppConfig });
+        const probe = await resolveAmrModelProbe({
+          dataDir: RUNTIME_DATA_DIR,
+          env: process.env,
+          readAppConfig,
+          workspaceId: run.workspaceScope?.workspaceId ?? null,
+        });
         const catalog = await amrModelLoadingCache.get(probe.cacheKey, {
           fetchPreset: () => fetchVelaPresetModels(probe.launchPath, probe.env),
           fetchRemote: () => fetchVelaRemoteModelsWithRetry(probe.launchPath, probe.env),

--- a/apps/daemon/tests/amr-acp-integration.test.ts
+++ b/apps/daemon/tests/amr-acp-integration.test.ts
@@ -658,6 +658,39 @@ describe('AMR model loading cache', () => {
       models: [{ id: 'remote-prod', label: 'remote-prod' }],
     });
   });
+
+  it('drops every workspace-partitioned catalog when invalidateAll runs', async () => {
+    const cache = new AmrModelLoadingCache(60_000);
+    cache.warm('vela:personal', async () => [
+      { id: 'locked-personal', label: 'locked-personal', enabled: false },
+    ]);
+    cache.warm('vela:ws-team', async () => [
+      { id: 'unlocked-team', label: 'unlocked-team', enabled: true },
+    ]);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    cache.invalidateAll();
+
+    const personal = await cache.get('vela:personal', {
+      fetchPreset: async () => [{ id: 'preset-personal', label: 'preset-personal' }],
+      fetchRemote: async () => [{ id: 'remote-personal-new', label: 'remote-personal-new' }],
+    });
+    const team = await cache.get('vela:ws-team', {
+      fetchPreset: async () => [{ id: 'preset-team', label: 'preset-team' }],
+      fetchRemote: async () => [{ id: 'remote-team-new', label: 'remote-team-new' }],
+    });
+
+    expect(personal).toMatchObject({
+      source: 'preset',
+      models: [{ id: 'preset-personal', label: 'preset-personal' }],
+      refreshing: true,
+    });
+    expect(team).toMatchObject({
+      source: 'preset',
+      models: [{ id: 'preset-team', label: 'preset-team' }],
+      refreshing: true,
+    });
+  });
 });
 
 describe('AMR ACP transport — end-to-end against fake vela stub', () => {

--- a/apps/daemon/tests/fixtures/fake-vela.mjs
+++ b/apps/daemon/tests/fixtures/fake-vela.mjs
@@ -589,6 +589,20 @@ if (argv[2] === 'model' && argv.includes('--format') && argv.includes('json')) {
     exit(0);
   }
   if (argv[3] === 'list') {
+    // Optional Path A scope dump: OD hosts must pass VELA_WORKSPACE_ID (or
+    // --workspace-id) for Team entitlements. Tests assert the spawn env by
+    // pointing FAKE_VELA_MODEL_LIST_ENV_DUMP at a temp file.
+    if (env.FAKE_VELA_MODEL_LIST_ENV_DUMP) {
+      writeFileSync(
+        env.FAKE_VELA_MODEL_LIST_ENV_DUMP,
+        JSON.stringify({
+          VELA_WORKSPACE_ID: env.VELA_WORKSPACE_ID || null,
+          OPEN_DESIGN_WORKSPACE_ID: env.OPEN_DESIGN_WORKSPACE_ID || null,
+          args: argv.slice(2),
+        }),
+        'utf8',
+      );
+    }
     stdout.write(`${env.FAKE_VELA_MODEL_LIST_JSON || DEFAULT_MODEL_LIST_JSON}\n`);
     exit(0);
   }

--- a/apps/daemon/tests/integrations/vela.routes.test.ts
+++ b/apps/daemon/tests/integrations/vela.routes.test.ts
@@ -37,6 +37,7 @@ import {
   velaLiveAccountCacheKey,
 } from '../../src/integrations/vela.js';
 import { registerVelaRoutes } from '../../src/routes/vela.js';
+import { amrModelLoadingCache } from '../../src/runtimes/amr-model-cache.js';
 
 interface StartedServer {
   url: string;
@@ -51,8 +52,11 @@ let server: http.Server;
 let originalHome: string | undefined;
 let tmpHome: string;
 
-async function getJson<T = unknown>(url: string): Promise<{ status: number; body: T }> {
-  const resp = await fetch(url);
+async function getJson<T = unknown>(
+  url: string,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; body: T }> {
+  const resp = await fetch(url, Object.keys(headers).length > 0 ? { headers } : undefined);
   const parsedBody = (await resp.json()) as T;
   return { status: resp.status, body: parsedBody };
 }
@@ -72,16 +76,22 @@ async function postJson<T = unknown>(
   return { status: resp.status, body: parsedBody };
 }
 
+
+function amrModelLoadingCacheReset(): void {
+  amrModelLoadingCache.resetForTests();
+}
+
 async function waitForAmrModels(
   expectedSource: 'preset' | 'remote',
   timeoutMs = 5_000,
+  headers: Record<string, string> = {},
 ): Promise<{ status: number; body: { source: 'preset' | 'remote'; models: Array<{ id: string }> } }> {
   const deadline = Date.now() + timeoutMs;
   for (;;) {
     const response = await getJson<{
       source: 'preset' | 'remote';
       models: Array<{ id: string }>;
-    }>(`${baseUrl}/api/amr/models`);
+    }>(`${baseUrl}/api/amr/models`, headers);
     if (response.body.source === expectedSource) return response;
     if (Date.now() >= deadline) {
       throw new Error(`timed out waiting for /api/amr/models source=${expectedSource}`);
@@ -261,6 +271,7 @@ afterEach(async () => {
     delete process.env.FAKE_VELA_BILLING_UNKNOWN_COMMAND;
     delete process.env.FAKE_VELA_MODEL_LIST_JSON;
     delete process.env.FAKE_VELA_MODEL_PRESET_JSON;
+    delete process.env.FAKE_VELA_MODEL_LIST_ENV_DUMP;
     delete process.env.FAKE_VELA_ENV_DUMP_PATH;
     delete process.env.FAKE_VELA_LOGIN_INVOCATION_LOG;
     delete process.env.FAKE_VELA_LOGIN_ACTIVATION_AFTER_PARENT_EXIT_MS;
@@ -280,6 +291,29 @@ afterEach(async () => {
       retryDelay: 50,
     });
   }
+});
+
+describe('GET /api/amr/models workspace scope', () => {
+  it('forwards the selected workspace as VELA_WORKSPACE_ID to vela model list', async () => {
+    seedLogin('local');
+    const dumpPath = path.join(tmpHome, 'model-list-env.json');
+    process.env.FAKE_VELA_MODEL_LIST_ENV_DUMP = dumpPath;
+    // Force a remote refresh path by waiting for remote source.
+    amrModelLoadingCacheReset();
+    const response = await waitForAmrModels('remote', 8_000, {
+      'x-od-workspace-id': 'ws-team-pro',
+      'x-od-workspace-member-id': 'member-1',
+    });
+    expect(response.status).toBe(200);
+    expect(response.body.source).toBe('remote');
+    expect(existsSync(dumpPath)).toBe(true);
+    const dump = JSON.parse(readFileSync(dumpPath, 'utf8')) as {
+      VELA_WORKSPACE_ID: string | null;
+      args: string[];
+    };
+    expect(dump.VELA_WORKSPACE_ID).toBe('ws-team-pro');
+    expect(dump.args.slice(0, 2)).toEqual(['model', 'list']);
+  });
 });
 
 describe('GET /api/integrations/vela/wallet', () => {

--- a/apps/daemon/tests/integrations/vela.routes.test.ts
+++ b/apps/daemon/tests/integrations/vela.routes.test.ts
@@ -432,6 +432,54 @@ describe('GET /api/integrations/vela/wallet', () => {
     }
   });
 
+  it('invalidates workspace-scoped AMR model catalogs on wallet refresh', async () => {
+    const walletApi = await startWalletApi((_req, res) => {
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({
+        balanceUsd: '20.0000',
+        updatedAt: '2026-07-09T07:30:00.000Z',
+      }));
+    });
+    process.env.FAKE_VELA_MODEL_LIST_JSON = JSON.stringify({
+      source: 'remote',
+      data: [
+        { id: 'public_model_deepseek_v4_flash', enabled: false },
+      ],
+    });
+    seedLogin('local', {
+      apiUrl: walletApi.url,
+      controlKey: 'ck-wallet-refresh-ws',
+      runtimeKey: 'rt-wallet-refresh-ws',
+      user: { id: 'wallet-user', email: 'wallet@example.com', plan: 'free' },
+    });
+    const workspaceHeaders = {
+      'x-od-workspace-id': 'ws-team-pro',
+      'x-od-workspace-member-id': 'member-1',
+    };
+    try {
+      const warmed = await waitForAmrModels('remote', 8_000, workspaceHeaders);
+      expect(warmed.body.models).toEqual([
+        { id: 'deepseek-v4-flash', label: 'deepseek-v4-flash', enabled: false },
+      ]);
+
+      const refresh = await getJson<{ status: string }>(
+        `${baseUrl}/api/integrations/vela/wallet?refresh=1`,
+      );
+      expect(refresh.status).toBe(200);
+      expect(refresh.body.status).toBe('available');
+
+      const afterRefresh = await getJson<{
+        source: 'preset' | 'remote';
+        refreshing?: boolean;
+      }>(`${baseUrl}/api/amr/models`, workspaceHeaders);
+      expect(afterRefresh.status).toBe(200);
+      expect(afterRefresh.body.source).toBe('preset');
+      expect(afterRefresh.body.refreshing).toBe(true);
+    } finally {
+      await walletApi.close();
+    }
+  });
+
   it('invalidates the AMR model catalog cache when a forced status refresh observes a plan change', async () => {
     process.env.FAKE_VELA_BILLING_TIER = 'free';
     process.env.FAKE_VELA_BILLING_BALANCE_USD = '1.00';
@@ -470,6 +518,52 @@ describe('GET /api/integrations/vela/wallet', () => {
       refreshing?: boolean;
       models: Array<{ id: string }>;
     }>(`${baseUrl}/api/amr/models`);
+    expect(afterPlanChange.status).toBe(200);
+    expect(afterPlanChange.body.source).toBe('preset');
+    expect(afterPlanChange.body.refreshing).toBe(true);
+  });
+
+  it('invalidates workspace-scoped AMR model catalogs when a status refresh observes a plan change', async () => {
+    process.env.FAKE_VELA_BILLING_TIER = 'free';
+    process.env.FAKE_VELA_BILLING_BALANCE_USD = '1.00';
+    process.env.FAKE_VELA_MODEL_LIST_JSON = JSON.stringify({
+      source: 'remote',
+      data: [
+        { id: 'public_model_deepseek_v4_flash', enabled: false },
+      ],
+    });
+    seedLogin('local', {
+      controlKey: 'ck-status-refresh-ws',
+      runtimeKey: 'rt-status-refresh-ws',
+      user: { id: 'status-user', email: 'status@example.com', plan: 'free' },
+    });
+    const workspaceHeaders = {
+      'x-od-workspace-id': 'ws-team-pro',
+      'x-od-workspace-member-id': 'member-1',
+    };
+
+    const firstStatus = await getJson<{ account?: { plan?: string } }>(
+      `${baseUrl}/api/integrations/vela/status?refresh=1`,
+    );
+    expect(firstStatus.status).toBe(200);
+    expect(firstStatus.body.account?.plan).toBe('free');
+
+    const warmed = await waitForAmrModels('remote', 8_000, workspaceHeaders);
+    expect(warmed.body.models).toEqual([
+      { id: 'deepseek-v4-flash', label: 'deepseek-v4-flash', enabled: false },
+    ]);
+
+    process.env.FAKE_VELA_BILLING_TIER = 'pro';
+    const upgradedStatus = await getJson<{ account?: { plan?: string } }>(
+      `${baseUrl}/api/integrations/vela/status?refresh=1`,
+    );
+    expect(upgradedStatus.status).toBe(200);
+    expect(upgradedStatus.body.account?.plan).toBe('pro');
+
+    const afterPlanChange = await getJson<{
+      source: 'preset' | 'remote';
+      refreshing?: boolean;
+    }>(`${baseUrl}/api/amr/models`, workspaceHeaders);
     expect(afterPlanChange.status).toBe(200);
     expect(afterPlanChange.body.source).toBe('preset');
     expect(afterPlanChange.body.refreshing).toBe(true);

--- a/apps/daemon/tests/integrations/vela.routes.test.ts
+++ b/apps/daemon/tests/integrations/vela.routes.test.ts
@@ -314,6 +314,19 @@ describe('GET /api/amr/models workspace scope', () => {
     expect(dump.VELA_WORKSPACE_ID).toBe('ws-team-pro');
     expect(dump.args.slice(0, 2)).toEqual(['model', 'list']);
   });
+
+  it('rejects malformed x-od-workspace-id before probing or caching', async () => {
+    seedLogin('local');
+    amrModelLoadingCacheReset();
+    const dumpPath = path.join(tmpHome, 'model-list-invalid-env.json');
+    process.env.FAKE_VELA_MODEL_LIST_ENV_DUMP = dumpPath;
+    const response = await getJson<{ error: string }>(`${baseUrl}/api/amr/models`, {
+      'x-od-workspace-id': '../not a workspace!',
+    });
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: 'invalid_workspace_id' });
+    expect(existsSync(dumpPath)).toBe(false);
+  });
 });
 
 describe('GET /api/integrations/vela/wallet', () => {

--- a/apps/daemon/tests/runtimes/amr-model-probe-workspace-scope.test.ts
+++ b/apps/daemon/tests/runtimes/amr-model-probe-workspace-scope.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+
+import type { VelaCredentialRevision } from '../../src/integrations/vela.js';
+import {
+  buildAmrModelCacheKey,
+  withVelaModelListWorkspaceScope,
+} from '../../src/runtimes/amr-model-probe.js';
+
+const CREDENTIAL_REVISION: VelaCredentialRevision = {
+  authSource: 'file',
+  profile: 'test',
+  loggedIn: true,
+  userId: 'user-1',
+  userEmail: 'user@example.com',
+  configMtimeMs: 1,
+  credentialFingerprint: '',
+};
+
+test('withVelaModelListWorkspaceScope sets VELA_WORKSPACE_ID for Path A discovery', () => {
+  const env = withVelaModelListWorkspaceScope(
+    { HOME: '/tmp/home', VELA_PROFILE: 'test' },
+    '  ws-team-pro  ',
+  );
+  assert.equal(env.VELA_WORKSPACE_ID, 'ws-team-pro');
+  assert.equal(env.HOME, '/tmp/home');
+});
+
+test('withVelaModelListWorkspaceScope leaves env unscoped for blank workspace ids', () => {
+  const env = withVelaModelListWorkspaceScope(
+    { HOME: '/tmp/home' },
+    '   ',
+  );
+  assert.equal('VELA_WORKSPACE_ID' in env, false);
+});
+
+test('buildAmrModelCacheKey partitions catalogs by workspace id', () => {
+  const base = {
+    launchPath: '/bin/vela',
+    credentialRevision: CREDENTIAL_REVISION,
+  };
+  const personal = buildAmrModelCacheKey({
+    ...base,
+    env: { HOME: '/tmp/home', VELA_PROFILE: 'test' },
+  });
+  const team = buildAmrModelCacheKey({
+    ...base,
+    env: {
+      HOME: '/tmp/home',
+      VELA_PROFILE: 'test',
+      VELA_WORKSPACE_ID: 'ws-team-pro',
+    },
+  });
+  const teamAgain = buildAmrModelCacheKey({
+    ...base,
+    env: {
+      HOME: '/tmp/home',
+      VELA_PROFILE: 'test',
+      VELA_WORKSPACE_ID: 'ws-team-pro',
+    },
+  });
+
+  assert.notEqual(personal, team);
+  assert.equal(team, teamAgain);
+  assert.match(team, /ws-team-pro/);
+});

--- a/apps/daemon/tests/runtimes/amr-model-probe-workspace-scope.test.ts
+++ b/apps/daemon/tests/runtimes/amr-model-probe-workspace-scope.test.ts
@@ -3,9 +3,16 @@ import { test } from 'vitest';
 
 import type { VelaCredentialRevision } from '../../src/integrations/vela.js';
 import {
+  amrCredentialIdentityFromRevision,
   buildAmrModelCacheKey,
+  buildAmrRememberedLiveModelScope,
   withVelaModelListWorkspaceScope,
 } from '../../src/runtimes/amr-model-probe.js';
+import {
+  getRememberedLiveModels,
+  preferFreshLiveModels,
+  rememberLiveModels,
+} from '../../src/runtimes/models.js';
 
 const CREDENTIAL_REVISION: VelaCredentialRevision = {
   authSource: 'file',
@@ -63,4 +70,110 @@ test('buildAmrModelCacheKey partitions catalogs by workspace id', () => {
   assert.notEqual(personal, team);
   assert.equal(team, teamAgain);
   assert.match(team, /ws-team-pro/);
+});
+
+test('buildAmrRememberedLiveModelScope partitions by workspace and credential', () => {
+  const personal = buildAmrRememberedLiveModelScope({
+    profile: 'prod',
+    workspaceId: null,
+    credentialIdentity: 'user:alice',
+  });
+  const teamA = buildAmrRememberedLiveModelScope({
+    profile: 'prod',
+    workspaceId: 'ws-team-a',
+    credentialIdentity: 'user:alice',
+  });
+  const teamB = buildAmrRememberedLiveModelScope({
+    profile: 'prod',
+    workspaceId: 'ws-team-b',
+    credentialIdentity: 'user:alice',
+  });
+  const teamAOtherUser = buildAmrRememberedLiveModelScope({
+    profile: 'prod',
+    workspaceId: 'ws-team-a',
+    credentialIdentity: 'user:bob',
+  });
+
+  assert.notEqual(personal, teamA);
+  assert.notEqual(teamA, teamB);
+  assert.notEqual(teamA, teamAOtherUser);
+  assert.match(teamA, /ws=ws-team-a/);
+  assert.match(teamA, /cred=user:alice/);
+  assert.equal(
+    buildAmrRememberedLiveModelScope({
+      profile: 'prod',
+      workspaceId: '  ws-team-a  ',
+      credentialIdentity: ' user:alice ',
+    }),
+    teamA,
+  );
+});
+
+test('amrCredentialIdentityFromRevision prefers userId then env fingerprint', () => {
+  assert.equal(
+    amrCredentialIdentityFromRevision({
+      authSource: 'file',
+      userId: 'user-1',
+      credentialFingerprint: 'fp-ignored',
+    }),
+    'user:user-1',
+  );
+  assert.equal(
+    amrCredentialIdentityFromRevision({
+      authSource: 'env',
+      userId: '',
+      credentialFingerprint: 'abc123',
+    }),
+    'env:abc123',
+  );
+  assert.equal(
+    amrCredentialIdentityFromRevision({
+      authSource: 'none',
+      userId: '',
+      credentialFingerprint: '',
+    }),
+    '',
+  );
+});
+
+test('remembered AMR live models do not fall back across workspaces', () => {
+  const scopeA = buildAmrRememberedLiveModelScope({
+    profile: 'prod',
+    workspaceId: 'ws-a',
+    credentialIdentity: 'user:alice',
+  });
+  const scopeB = buildAmrRememberedLiveModelScope({
+    profile: 'prod',
+    workspaceId: 'ws-b',
+    credentialIdentity: 'user:alice',
+  });
+
+  rememberLiveModels('amr', [
+    { id: 'model-from-a', label: 'A default', enabled: true, default: true },
+  ], scopeA);
+  rememberLiveModels('amr', [
+    { id: 'model-from-b', label: 'B default', enabled: true, default: true },
+  ], scopeB);
+
+  // Probe failure path: empty fresh catalog must only reuse the same-workspace
+  // remembered list, never the sibling workspace under the same profile.
+  assert.deepEqual(
+    preferFreshLiveModels([], getRememberedLiveModels('amr', scopeA)),
+    [{ id: 'model-from-a', label: 'A default', enabled: true, default: true }],
+  );
+  assert.deepEqual(
+    preferFreshLiveModels([], getRememberedLiveModels('amr', scopeB)),
+    [{ id: 'model-from-b', label: 'B default', enabled: true, default: true }],
+  );
+  assert.deepEqual(
+    getRememberedLiveModels(
+      'amr',
+      buildAmrRememberedLiveModelScope({
+        profile: 'prod',
+        workspaceId: 'ws-c',
+        credentialIdentity: 'user:alice',
+      }),
+    ),
+    [],
+  );
 });

--- a/apps/daemon/tests/runtimes/amr-model-probe-workspace-scope.test.ts
+++ b/apps/daemon/tests/runtimes/amr-model-probe-workspace-scope.test.ts
@@ -115,6 +115,7 @@ test('amrCredentialIdentityFromRevision prefers userId then env fingerprint', ()
       authSource: 'file',
       userId: 'user-1',
       credentialFingerprint: 'fp-ignored',
+      configMtimeMs: 1,
     }),
     'user:user-1',
   );
@@ -123,6 +124,7 @@ test('amrCredentialIdentityFromRevision prefers userId then env fingerprint', ()
       authSource: 'env',
       userId: '',
       credentialFingerprint: 'abc123',
+      configMtimeMs: 1,
     }),
     'env:abc123',
   );
@@ -131,9 +133,51 @@ test('amrCredentialIdentityFromRevision prefers userId then env fingerprint', ()
       authSource: 'none',
       userId: '',
       credentialFingerprint: '',
+      configMtimeMs: null,
     }),
     '',
   );
+});
+
+test('amrCredentialIdentityFromRevision partitions file auth by config mtime when user is absent', () => {
+  // Supported file config makes `user` optional. Without mtime in the
+  // identity, every such account collapses to `auth:file` and a later
+  // rewrite under the same profile/workspace can reuse the prior catalog.
+  const beforeRewrite = amrCredentialIdentityFromRevision({
+    authSource: 'file',
+    userId: '',
+    credentialFingerprint: '',
+    configMtimeMs: 100,
+  });
+  const afterRewrite = amrCredentialIdentityFromRevision({
+    authSource: 'file',
+    userId: '',
+    credentialFingerprint: '',
+    configMtimeMs: 200,
+  });
+  const missingMtime = amrCredentialIdentityFromRevision({
+    authSource: 'file',
+    userId: '',
+    credentialFingerprint: '',
+    configMtimeMs: null,
+  });
+
+  assert.equal(beforeRewrite, 'auth:file:mtime=100');
+  assert.equal(afterRewrite, 'auth:file:mtime=200');
+  assert.notEqual(beforeRewrite, afterRewrite);
+  assert.equal(missingMtime, 'auth:file');
+
+  const scopeBefore = buildAmrRememberedLiveModelScope({
+    profile: 'prod',
+    workspaceId: 'ws-team',
+    credentialIdentity: beforeRewrite,
+  });
+  const scopeAfter = buildAmrRememberedLiveModelScope({
+    profile: 'prod',
+    workspaceId: 'ws-team',
+    credentialIdentity: afterRewrite,
+  });
+  assert.notEqual(scopeBefore, scopeAfter);
 });
 
 test('remembered AMR live models do not fall back across workspaces', () => {

--- a/apps/daemon/tests/runtimes/open-design-amr-trace-env.test.ts
+++ b/apps/daemon/tests/runtimes/open-design-amr-trace-env.test.ts
@@ -79,6 +79,7 @@ test('openDesignAmrTraceEnv forwards an exact persisted workspace id for AMR run
   });
 
   assert.equal(env.OPEN_DESIGN_WORKSPACE_ID, 'workspace_team_123');
+  assert.equal(env.VELA_WORKSPACE_ID, 'workspace_team_123');
 });
 
 test('openDesignAmrTraceEnv forwards a persisted Personal workspace id too', () => {
@@ -89,6 +90,7 @@ test('openDesignAmrTraceEnv forwards a persisted Personal workspace id too', () 
     workspaceId: ' workspace_personal_123 ',
   });
   assert.equal(env.OPEN_DESIGN_WORKSPACE_ID, 'workspace_personal_123');
+  assert.equal(env.VELA_WORKSPACE_ID, 'workspace_personal_123');
 });
 
 // Null/undefined/blank means the caller found no persisted binding at all.
@@ -101,6 +103,7 @@ test('openDesignAmrTraceEnv omits OPEN_DESIGN_WORKSPACE_ID only without a persis
     workspaceId: null,
   });
   assert.equal('OPEN_DESIGN_WORKSPACE_ID' in withNull, false);
+  assert.equal('VELA_WORKSPACE_ID' in withNull, false);
 
   const withUndefined = openDesignAmrTraceEnv({
     agentId: 'amr',
@@ -108,6 +111,7 @@ test('openDesignAmrTraceEnv omits OPEN_DESIGN_WORKSPACE_ID only without a persis
     runAttempt: 0,
   });
   assert.equal('OPEN_DESIGN_WORKSPACE_ID' in withUndefined, false);
+  assert.equal('VELA_WORKSPACE_ID' in withUndefined, false);
 
   const withBlank = openDesignAmrTraceEnv({
     agentId: 'amr',
@@ -116,6 +120,7 @@ test('openDesignAmrTraceEnv omits OPEN_DESIGN_WORKSPACE_ID only without a persis
     workspaceId: '   ',
   });
   assert.equal('OPEN_DESIGN_WORKSPACE_ID' in withBlank, false);
+  assert.equal('VELA_WORKSPACE_ID' in withBlank, false);
 });
 
 test('openDesignAmrTraceEnv never forwards workspaceId for non-AMR agents', () => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -477,6 +477,25 @@ function mergeAmrModelsIntoAgents(
   });
 }
 
+/**
+ * Drop the workspace-scoped live AMR catalog from the agents list.
+ *
+ * Path A models are merged into `agents` for the picker. Clearing only the
+ * `amrModelsRef` on workspace switch leaves the prior catalog rendered; if
+ * the replacement fetch fails or returns empty, those stale locks stick.
+ * Call this before the scoped refetch so the picker never keeps another
+ * workspace's entitlement map.
+ */
+export function clearAmrLiveModelsFromAgents(agents: AgentInfo[]): AgentInfo[] {
+  let changed = false;
+  const next = agents.map((agent) => {
+    if (agent.id !== 'amr' || agent.modelsSource !== 'live') return agent;
+    changed = true;
+    return { ...agent, models: [], modelsSource: undefined };
+  });
+  return changed ? next : agents;
+}
+
 const CANONICAL_AGENT_ORDER = [
   'amr',
   'claude',
@@ -1308,10 +1327,12 @@ function AppInner() {
 
   // Team entitlements are workspace-scoped. Drop the previous catalog as soon
   // as the shell identity changes so the picker cannot keep free locks (or a
-  // prior Team unlock map) while the scoped refetch is in flight. The AMR
-  // poll effect already depends on `currentWorkspaceIdentity`.
+  // prior Team unlock map) while the scoped refetch is in flight — including
+  // the live models already merged into `agents`. The AMR poll effect already
+  // depends on `currentWorkspaceIdentity`.
   useEffect(() => {
     amrModelsRef.current = null;
+    setAgents((current) => clearAmrLiveModelsFromAgents(current));
   }, [currentWorkspaceIdentity]);
 
   // v2 schema removed the standalone `app_launch` event; the initial

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -908,6 +908,10 @@ function AppInner() {
   const workspaceContextStateRef = useRef(workspaceContextState);
   const projectRouteWorkspaceContextRef = useRef<WorkspaceCollabContext | null>(null);
   const amrModelsCatalogContextRef = useRef<WorkspaceCollabContext | null>(null);
+  // Keep pending/identity in refs so refreshAgents (stable callback) can share
+  // the same Path A authority gate as the main catalog poll effect.
+  const amrModelsCatalogPendingRef = useRef(false);
+  const amrModelsCatalogIdentityRef = useRef('');
   const projectOpenWorkspaceWitnessRef = useRef<{
     projectId: string;
     projectWorkspaceId: string;
@@ -2796,19 +2800,33 @@ function AppInner() {
           // this call's return value can carry the scoped catalog as soon as
           // it becomes available — and so we do not race a caller's own
           // restartAmrPolling with a second generation bump.
-          const scoped = await fetchAmrModels(amrModelsCatalogContextRef.current);
-          if (!isCurrentAgentStreamRequest(agentRequestId)) {
-            return mergeAmrModelsIntoAgents(ordered, amrModelsRef.current);
-          }
-          if (scoped && Array.isArray(scoped.models) && scoped.models.length > 0) {
-            amrModelsRef.current = scoped;
-            pathACatalog = scoped;
-          } else {
-            // Prefer a concurrent Path A win over stomping a just-landed catalog.
-            pathACatalog = amrModelsRef.current;
-            if (!pathACatalog || pathACatalog.models.length === 0) {
-              amrModelsRef.current = null;
-              pathACatalog = null;
+          //
+          // Match the main poll effect: never re-probe while catalog authority
+          // is pending (account transition or unresolved bound-project
+          // workspace). The context ref may still hold a retained prior-account
+          // context or null, and committing that catalog would bypass the
+          // pending sentinel. Also discard responses after identity changes
+          // mid-flight (same intent as the poll generation guard).
+          if (!amrModelsCatalogPendingRef.current) {
+            const issuedIdentity = amrModelsCatalogIdentityRef.current;
+            const issuedWorkspaceContext = amrModelsCatalogContextRef.current;
+            const scoped = await fetchAmrModels(issuedWorkspaceContext);
+            if (
+              !isCurrentAgentStreamRequest(agentRequestId)
+              || amrModelsCatalogIdentityRef.current !== issuedIdentity
+            ) {
+              return mergeAmrModelsIntoAgents(ordered, amrModelsRef.current);
+            }
+            if (scoped && Array.isArray(scoped.models) && scoped.models.length > 0) {
+              amrModelsRef.current = scoped;
+              pathACatalog = scoped;
+            } else {
+              // Prefer a concurrent Path A win over stomping a just-landed catalog.
+              pathACatalog = amrModelsRef.current;
+              if (!pathACatalog || pathACatalog.models.length === 0) {
+                amrModelsRef.current = null;
+                pathACatalog = null;
+              }
             }
           }
         }
@@ -4232,6 +4250,8 @@ function AppInner() {
     accountGeneration: workspaceAccountGeneration,
   });
   amrModelsCatalogContextRef.current = amrModelsCatalogContext;
+  amrModelsCatalogPendingRef.current = amrModelsCatalogPending;
+  amrModelsCatalogIdentityRef.current = amrModelsCatalogIdentity;
 
   // Team entitlements are workspace- and account-scoped. Drop the previous
   // catalog as soon as that catalog identity changes so the picker cannot keep

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -496,6 +496,62 @@ export function clearAmrLiveModelsFromAgents(agents: AgentInfo[]): AgentInfo[] {
   return changed ? next : agents;
 }
 
+/**
+ * Choose the Path A AMR model-catalog scope for the shell picker.
+ *
+ * Invariant: catalog scope must match the authority that owns the next run.
+ * On project routes that is the open project's resolved workspace context, not
+ * the ambient navigation-rail selection (which may diverge while the project
+ * stays open). During account transitions the ambient context is intentionally
+ * retained with identityChangePending; treat that as pending and refuse to
+ * scope a fetch from the retained prior-account context.
+ */
+export function resolveAmrModelsCatalogScope(input: {
+  routeKind: string;
+  projectId?: string | null;
+  activeProject: { id: string; workspaceId?: string | null } | null;
+  activeProjectWorkspaceContext: WorkspaceCollabContext | null;
+  projectRouteLoading: boolean;
+  ambientWorkspaceContext: WorkspaceCollabContext | null;
+  identityChangePending: boolean;
+  accountGeneration: number;
+}): {
+  context: WorkspaceCollabContext | null;
+  pending: boolean;
+  identity: string;
+} {
+  const onProjectRoute = input.routeKind === 'project';
+  const context = onProjectRoute
+    ? input.activeProjectWorkspaceContext
+    : input.ambientWorkspaceContext;
+  const pending =
+    input.identityChangePending
+    || (onProjectRoute && input.activeProject == null)
+    || (
+      onProjectRoute
+      && Boolean(input.activeProject?.workspaceId?.trim())
+      && input.activeProjectWorkspaceContext == null
+      && input.projectRouteLoading
+    );
+  const identity = JSON.stringify(
+    pending
+      ? [
+          input.identityChangePending
+            ? 'pending-account'
+            : 'pending-project-workspace',
+          input.accountGeneration,
+          onProjectRoute ? input.projectId ?? null : null,
+          onProjectRoute ? input.activeProject?.workspaceId ?? null : null,
+        ]
+      : [
+          'workspace-account',
+          input.accountGeneration,
+          workspaceIdentityCacheKey(context),
+        ],
+  );
+  return { context, pending, identity };
+}
+
 const CANONICAL_AGENT_ORDER = [
   'amr',
   'claude',
@@ -840,6 +896,7 @@ function AppInner() {
   const workspaceContextRef = useRef<WorkspaceCollabContext | null>(null);
   const workspaceContextStateRef = useRef(workspaceContextState);
   const projectRouteWorkspaceContextRef = useRef<WorkspaceCollabContext | null>(null);
+  const amrModelsCatalogContextRef = useRef<WorkspaceCollabContext | null>(null);
   const projectOpenWorkspaceWitnessRef = useRef<{
     projectId: string;
     projectWorkspaceId: string;
@@ -1325,15 +1382,10 @@ function AppInner() {
     setAmrPollRestartToken((current) => current + 1);
   }, []);
 
-  // Team entitlements are workspace-scoped. Drop the previous catalog as soon
-  // as the shell identity changes so the picker cannot keep free locks (or a
-  // prior Team unlock map) while the scoped refetch is in flight — including
-  // the live models already merged into `agents`. The AMR poll effect already
-  // depends on `currentWorkspaceIdentity`.
-  useEffect(() => {
-    amrModelsRef.current = null;
-    setAgents((current) => clearAmrLiveModelsFromAgents(current));
-  }, [currentWorkspaceIdentity]);
+  // AMR model catalog clear/poll lives after `activeProjectWorkspaceContext`
+  // so Path A discovery can follow the open project's workspace authority
+  // (not only the ambient navigation-rail selection) and the account-generation
+  // pending sentinel.
 
   // v2 schema removed the standalone `app_launch` event; the initial
   // page_view fires from each top-level page surface (home / projects /
@@ -1810,52 +1862,6 @@ function AppInner() {
       // Daemon down or transient network — not worth surfacing.
     });
   }, [activeProjectId, activeFileName]);
-
-  useEffect(() => {
-    if (!daemonLive) return;
-    let cancelled = false;
-    let timer: number | null = null;
-    const pollGeneration = amrPollGenerationRef.current + 1;
-    amrPollGenerationRef.current = pollGeneration;
-    const pollDelayMs = 1_000;
-    const maxPresetPolls = 10;
-    let presetPolls = 0;
-    // Capture the workspace identity this poll generation was issued for.
-    // Path A model discovery is workspace-scoped; a later switch must not
-    // commit an older personal/team catalog into the new shell.
-    const issuedWorkspaceContext = workspaceContextRef.current;
-
-    const applyAmrModels = async () => {
-      const result = await fetchAmrModels(issuedWorkspaceContext);
-      if (
-        cancelled ||
-        amrPollGenerationRef.current !== pollGeneration ||
-        !result ||
-        !Array.isArray(result.models) ||
-        result.models.length === 0
-      ) {
-        return;
-      }
-      amrModelsRef.current = result;
-      setAgents((current) => mergeAmrModelsIntoAgents(current, result));
-      const shouldPollPreset =
-        result.source === 'preset' &&
-        !result.remoteError &&
-        presetPolls < maxPresetPolls;
-      if (shouldPollPreset) {
-        presetPolls += 1;
-        timer = window.setTimeout(() => {
-          void applyAmrModels();
-        }, pollDelayMs);
-      }
-    };
-
-    void applyAmrModels();
-    return () => {
-      cancelled = true;
-      if (timer !== null) window.clearTimeout(timer);
-    };
-  }, [amrPollRestartToken, currentWorkspaceIdentity, daemonLive]);
 
   // App-level AMR sign-in state. Feeds two analytics globals: the
   // `amr` configure_type bucket (deriveConfigureGlobals below) and the
@@ -4172,6 +4178,87 @@ function AppInner() {
     ? projectRouteWorkspaceContext.context
     : null;
   projectRouteWorkspaceContextRef.current = activeProjectWorkspaceContext;
+
+  const {
+    context: amrModelsCatalogContext,
+    pending: amrModelsCatalogPending,
+    identity: amrModelsCatalogIdentity,
+  } = resolveAmrModelsCatalogScope({
+    routeKind: route.kind,
+    projectId: route.kind === 'project' ? route.projectId : null,
+    activeProject,
+    activeProjectWorkspaceContext,
+    projectRouteLoading: projectRouteWorkspaceContext.loading,
+    ambientWorkspaceContext: workspaceContext,
+    identityChangePending: workspaceContextState.identityChangePending === true,
+    accountGeneration: workspaceAccountGeneration,
+  });
+  amrModelsCatalogContextRef.current = amrModelsCatalogContext;
+
+  // Team entitlements are workspace- and account-scoped. Drop the previous
+  // catalog as soon as that catalog identity changes so the picker cannot keep
+  // free locks (or a prior Team unlock map) while the scoped refetch is in
+  // flight — including the live models already merged into `agents`.
+  useEffect(() => {
+    amrModelsRef.current = null;
+    setAgents((current) => clearAmrLiveModelsFromAgents(current));
+  }, [amrModelsCatalogIdentity]);
+
+  useEffect(() => {
+    if (!daemonLive) return;
+    // Do not issue a scoped fetch from a retained ambient context during an
+    // account transition, or from ambient B while a project-A route is still
+    // resolving its own workspace authority.
+    if (amrModelsCatalogPending) return;
+    let cancelled = false;
+    let timer: number | null = null;
+    const pollGeneration = amrPollGenerationRef.current + 1;
+    amrPollGenerationRef.current = pollGeneration;
+    const pollDelayMs = 1_000;
+    const maxPresetPolls = 10;
+    let presetPolls = 0;
+    // Capture the workspace identity this poll generation was issued for.
+    // Path A model discovery is workspace-scoped; a later switch must not
+    // commit an older personal/team catalog into the new shell.
+    const issuedWorkspaceContext = amrModelsCatalogContextRef.current;
+
+    const applyAmrModels = async () => {
+      const result = await fetchAmrModels(issuedWorkspaceContext);
+      if (
+        cancelled ||
+        amrPollGenerationRef.current !== pollGeneration ||
+        !result ||
+        !Array.isArray(result.models) ||
+        result.models.length === 0
+      ) {
+        return;
+      }
+      amrModelsRef.current = result;
+      setAgents((current) => mergeAmrModelsIntoAgents(current, result));
+      const shouldPollPreset =
+        result.source === 'preset' &&
+        !result.remoteError &&
+        presetPolls < maxPresetPolls;
+      if (shouldPollPreset) {
+        presetPolls += 1;
+        timer = window.setTimeout(() => {
+          void applyAmrModels();
+        }, pollDelayMs);
+      }
+    };
+
+    void applyAmrModels();
+    return () => {
+      cancelled = true;
+      if (timer !== null) window.clearTimeout(timer);
+    };
+  }, [
+    amrModelsCatalogIdentity,
+    amrModelsCatalogPending,
+    amrPollRestartToken,
+    daemonLive,
+  ]);
+
   useEffect(() => {
     const pending = amrAuthRetryContinuationRef.current;
     if (!pending) return;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -461,18 +461,22 @@ export function resolveSettingsCloseConfig(
   return base.onboardingCompleted ? base : { ...base, onboardingCompleted: true };
 }
 
-function mergeAmrModelsIntoAgents(
+/**
+ * Merge Path A (`GET /api/amr/models`) catalog into the AMR agent for the picker.
+ *
+ * Invariant: Path A is the workspace-scoped entitlement authority. Prefer its
+ * models even when `source === "preset"` (remote refresh still pending or
+ * unavailable). Headerless `/api/agents` discovery can return a non-empty
+ * personal catalog for AMR; keeping those agent models on preset would let the
+ * unscoped free/lock shape win on Team workspaces and undo workspace scoping.
+ */
+export function mergeAmrModelsIntoAgents(
   agents: AgentInfo[],
   amrModels: AmrModelsResponse | null,
 ): AgentInfo[] {
   if (!amrModels || amrModels.models.length === 0) return agents;
   return agents.map((agent) => {
     if (agent.id !== 'amr') return agent;
-    const shouldPreferAgentModels =
-      amrModels.source === 'preset' &&
-      Array.isArray(agent.models) &&
-      agent.models.length > 0;
-    if (shouldPreferAgentModels) return agent;
     return { ...agent, models: amrModels.models, modelsSource: 'live' };
   });
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -462,42 +462,46 @@ export function resolveSettingsCloseConfig(
 }
 
 /**
+ * Drop AMR picker models from the agents list (live Path A or agent fallback).
+ *
+ * Path A is the workspace-scoped entitlement authority. Headerless
+ * `/api/agents` discovery can still emit a personal free/lock shape; those
+ * models must not survive a workspace/account identity change or a failed
+ * scoped refetch, or the picker keeps the wrong locks indefinitely.
+ */
+export function clearAmrLiveModelsFromAgents(agents: AgentInfo[]): AgentInfo[] {
+  let changed = false;
+  const next = agents.map((agent) => {
+    if (agent.id !== 'amr') return agent;
+    const hasModels = Array.isArray(agent.models) && agent.models.length > 0;
+    if (!hasModels && agent.modelsSource === undefined) return agent;
+    changed = true;
+    return { ...agent, models: [], modelsSource: undefined };
+  });
+  return changed ? next : agents;
+}
+
+/**
  * Merge Path A (`GET /api/amr/models`) catalog into the AMR agent for the picker.
  *
  * Invariant: Path A is the workspace-scoped entitlement authority. Prefer its
  * models even when `source === "preset"` (remote refresh still pending or
- * unavailable). Headerless `/api/agents` discovery can return a non-empty
- * personal catalog for AMR; keeping those agent models on preset would let the
- * unscoped free/lock shape win on Team workspaces and undo workspace scoping.
+ * unavailable). When Path A is unresolved, empty, or failed, fail closed:
+ * strip AMR models rather than keeping headerless `/api/agents` discovery,
+ * so concurrent boot/focus agent streams cannot repopulate unscoped locks
+ * after a catalog clear.
  */
 export function mergeAmrModelsIntoAgents(
   agents: AgentInfo[],
   amrModels: AmrModelsResponse | null,
 ): AgentInfo[] {
-  if (!amrModels || amrModels.models.length === 0) return agents;
+  if (!amrModels || amrModels.models.length === 0) {
+    return clearAmrLiveModelsFromAgents(agents);
+  }
   return agents.map((agent) => {
     if (agent.id !== 'amr') return agent;
     return { ...agent, models: amrModels.models, modelsSource: 'live' };
   });
-}
-
-/**
- * Drop the workspace-scoped live AMR catalog from the agents list.
- *
- * Path A models are merged into `agents` for the picker. Clearing only the
- * `amrModelsRef` on workspace switch leaves the prior catalog rendered; if
- * the replacement fetch fails or returns empty, those stale locks stick.
- * Call this before the scoped refetch so the picker never keeps another
- * workspace's entitlement map.
- */
-export function clearAmrLiveModelsFromAgents(agents: AgentInfo[]): AgentInfo[] {
-  let changed = false;
-  const next = agents.map((agent) => {
-    if (agent.id !== 'amr' || agent.modelsSource !== 'live') return agent;
-    changed = true;
-    return { ...agent, models: [], modelsSource: undefined };
-  });
-  return changed ? next : agents;
 }
 
 /**
@@ -4228,13 +4232,19 @@ function AppInner() {
 
     const applyAmrModels = async () => {
       const result = await fetchAmrModels(issuedWorkspaceContext);
+      if (cancelled || amrPollGenerationRef.current !== pollGeneration) {
+        return;
+      }
       if (
-        cancelled ||
-        amrPollGenerationRef.current !== pollGeneration ||
         !result ||
         !Array.isArray(result.models) ||
         result.models.length === 0
       ) {
+        // Fail closed: keep the picker free of unscoped agent models when the
+        // workspace-scoped catalog errors or returns empty (including after a
+        // concurrent fetchAgentsStream upsert while amrModelsRef was null).
+        amrModelsRef.current = null;
+        setAgents((current) => clearAmrLiveModelsFromAgents(current));
         return;
       }
       amrModelsRef.current = result;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2785,11 +2785,39 @@ function AppInner() {
           },
         });
         const ordered = orderAgentsByRegistry(next);
+        // Settings credential-propagation retries inspect this return value,
+        // not React state. Keep it aligned with the scoped Path A merge
+        // committed to state so headerless `/api/agents` fallback models
+        // cannot stop the loop while the workspace catalog is empty/cleared.
+        let pathACatalog = amrModelsRef.current;
+        if (!pathACatalog || pathACatalog.models.length === 0) {
+          // Path A may have stopped after an empty/error poll during credential
+          // propagation. Re-probe here (do not only bump the poll token) so
+          // this call's return value can carry the scoped catalog as soon as
+          // it becomes available — and so we do not race a caller's own
+          // restartAmrPolling with a second generation bump.
+          const scoped = await fetchAmrModels(amrModelsCatalogContextRef.current);
+          if (!isCurrentAgentStreamRequest(agentRequestId)) {
+            return mergeAmrModelsIntoAgents(ordered, amrModelsRef.current);
+          }
+          if (scoped && Array.isArray(scoped.models) && scoped.models.length > 0) {
+            amrModelsRef.current = scoped;
+            pathACatalog = scoped;
+          } else {
+            // Prefer a concurrent Path A win over stomping a just-landed catalog.
+            pathACatalog = amrModelsRef.current;
+            if (!pathACatalog || pathACatalog.models.length === 0) {
+              amrModelsRef.current = null;
+              pathACatalog = null;
+            }
+          }
+        }
+        const merged = mergeAmrModelsIntoAgents(ordered, pathACatalog);
         if (isCurrentAgentStreamRequest(agentRequestId)) {
-          setAgents(mergeAmrModelsIntoAgents(ordered, amrModelsRef.current));
+          setAgents(merged);
           setAgentsLoading(false);
         }
-        return ordered;
+        return merged;
       } catch (err) {
         if (!isCurrentAgentStreamRequest(agentRequestId)) return [];
         setAgentsLoading(false);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -519,7 +519,6 @@ export function resolveAmrModelsCatalogScope(input: {
   projectId?: string | null;
   activeProject: { id: string; workspaceId?: string | null } | null;
   activeProjectWorkspaceContext: WorkspaceCollabContext | null;
-  projectRouteLoading: boolean;
   ambientWorkspaceContext: WorkspaceCollabContext | null;
   identityChangePending: boolean;
   accountGeneration: number;
@@ -532,6 +531,11 @@ export function resolveAmrModelsCatalogScope(input: {
   const context = onProjectRoute
     ? input.activeProjectWorkspaceContext
     : input.ambientWorkspaceContext;
+  // Fail closed for workspace-bound projects: a null exact context is always
+  // unresolved (still loading, forbidden, or unavailable). Never fall through
+  // to a headerless personal-catalog fetch while the pinned workspace is
+  // unknown — that would let Settings show/persist models the project cannot
+  // use once authority recovers.
   const pending =
     input.identityChangePending
     || (onProjectRoute && input.activeProject == null)
@@ -539,7 +543,6 @@ export function resolveAmrModelsCatalogScope(input: {
       onProjectRoute
       && Boolean(input.activeProject?.workspaceId?.trim())
       && input.activeProjectWorkspaceContext == null
-      && input.projectRouteLoading
     );
   const identity = JSON.stringify(
     pending
@@ -4196,7 +4199,6 @@ function AppInner() {
     projectId: route.kind === 'project' ? route.projectId : null,
     activeProject,
     activeProjectWorkspaceContext,
-    projectRouteLoading: projectRouteWorkspaceContext.loading,
     ambientWorkspaceContext: workspaceContext,
     identityChangePending: workspaceContextState.identityChangePending === true,
     accountGeneration: workspaceAccountGeneration,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1306,6 +1306,14 @@ function AppInner() {
     setAmrPollRestartToken((current) => current + 1);
   }, []);
 
+  // Team entitlements are workspace-scoped. Drop the previous catalog as soon
+  // as the shell identity changes so the picker cannot keep free locks (or a
+  // prior Team unlock map) while the scoped refetch is in flight. The AMR
+  // poll effect already depends on `currentWorkspaceIdentity`.
+  useEffect(() => {
+    amrModelsRef.current = null;
+  }, [currentWorkspaceIdentity]);
+
   // v2 schema removed the standalone `app_launch` event; the initial
   // page_view fires from each top-level page surface (home / projects /
   // automations / plugins / design_systems / integrations) instead.
@@ -1791,9 +1799,13 @@ function AppInner() {
     const pollDelayMs = 1_000;
     const maxPresetPolls = 10;
     let presetPolls = 0;
+    // Capture the workspace identity this poll generation was issued for.
+    // Path A model discovery is workspace-scoped; a later switch must not
+    // commit an older personal/team catalog into the new shell.
+    const issuedWorkspaceContext = workspaceContextRef.current;
 
     const applyAmrModels = async () => {
-      const result = await fetchAmrModels();
+      const result = await fetchAmrModels(issuedWorkspaceContext);
       if (
         cancelled ||
         amrPollGenerationRef.current !== pollGeneration ||
@@ -1822,7 +1834,7 @@ function AppInner() {
       cancelled = true;
       if (timer !== null) window.clearTimeout(timer);
     };
-  }, [amrPollRestartToken, daemonLive]);
+  }, [amrPollRestartToken, currentWorkspaceIdentity, daemonLive]);
 
   // App-level AMR sign-in state. Feeds two analytics globals: the
   // `amr` configure_type bucket (deriveConfigureGlobals below) and the

--- a/apps/web/src/providers/daemon.ts
+++ b/apps/web/src/providers/daemon.ts
@@ -973,9 +973,16 @@ export async function fetchAmrWalletSnapshot(options: { refresh?: boolean } = {}
   }
 }
 
-export async function fetchAmrModels(): Promise<AmrModelsResponse | null> {
+export async function fetchAmrModels(
+  workspaceContext?: WorkspaceCollabContext | null,
+): Promise<AmrModelsResponse | null> {
   try {
-    const resp = await fetch('/api/amr/models', { cache: 'no-store' });
+    const resp = await fetch('/api/amr/models', {
+      cache: 'no-store',
+      ...(workspaceContext
+        ? { headers: workspaceProjectHeaders(workspaceContext) }
+        : {}),
+    });
     if (!resp.ok) return null;
     return (await resp.json()) as AmrModelsResponse;
   } catch {

--- a/apps/web/tests/App.test.ts
+++ b/apps/web/tests/App.test.ts
@@ -9,6 +9,7 @@ import {
   persistComposioConfigChange,
   projectViewAuthorizationLifetimeKey,
   projectRouteSurfaceState,
+  resolveAmrModelsCatalogScope,
   resolveDeepLinkedTeamSharedProject,
   resolveSettingsCloseConfig,
   shouldRouteToFirstRunOnboarding,
@@ -19,6 +20,7 @@ import type {
   WorkspaceCollabContext,
   WorkspaceProjectSummary,
 } from '@open-design/contracts';
+import { workspaceIdentityCacheKey } from '../src/collab/workspace-identity';
 
 describe('projectRouteSurfaceState', () => {
   it('only shows an unbounded loader while the initial project list is loading', () => {
@@ -560,5 +562,110 @@ describe('clearAmrLiveModelsFromAgents', () => {
       },
     ];
     expect(clearAmrLiveModelsFromAgents(fallbackAgents)).toBe(fallbackAgents);
+  });
+});
+
+describe('resolveAmrModelsCatalogScope', () => {
+  const workspaceA: WorkspaceCollabContext = {
+    workspaceId: 'ws-a',
+    workspaceType: 'team',
+    workspaceMemberId: 'member-a',
+    role: 'member',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+    billingState: 'active',
+    planId: 'team_pro',
+    providerMode: 'platform_credits',
+    seatSummary: { seatLimit: 5, usedSeats: 1, availableSeats: 4, isSeatFull: false },
+    permissions: {
+      canManageMembers: false,
+      canManageBilling: false,
+      canInviteMembers: false,
+      canManageAutoRecharge: false,
+      canShareProjects: true,
+      canWriteSyncedFiles: true,
+      canViewWorkspaceSettings: false,
+      canManageSharedResources: false,
+    },
+  };
+  const workspaceB: WorkspaceCollabContext = {
+    ...workspaceA,
+    workspaceId: 'ws-b',
+    workspaceMemberId: 'member-b',
+  };
+
+  it('uses the open project workspace on project routes even when ambient rail is B', () => {
+    const scope = resolveAmrModelsCatalogScope({
+      routeKind: 'project',
+      projectId: 'proj-a',
+      activeProject: { id: 'proj-a', workspaceId: 'ws-a' },
+      activeProjectWorkspaceContext: workspaceA,
+      projectRouteLoading: false,
+      ambientWorkspaceContext: workspaceB,
+      identityChangePending: false,
+      accountGeneration: 3,
+    });
+    expect(scope.pending).toBe(false);
+    expect(scope.context).toBe(workspaceA);
+    expect(scope.identity).toBe(JSON.stringify([
+      'workspace-account',
+      3,
+      workspaceIdentityCacheKey(workspaceA),
+    ]));
+  });
+
+  it('falls back to ambient workspace context off project routes', () => {
+    const scope = resolveAmrModelsCatalogScope({
+      routeKind: 'home',
+      activeProject: null,
+      activeProjectWorkspaceContext: null,
+      projectRouteLoading: false,
+      ambientWorkspaceContext: workspaceB,
+      identityChangePending: false,
+      accountGeneration: 1,
+    });
+    expect(scope.pending).toBe(false);
+    expect(scope.context).toBe(workspaceB);
+  });
+
+  it('marks account transitions pending so retained ambient context is not fetched', () => {
+    const scope = resolveAmrModelsCatalogScope({
+      routeKind: 'home',
+      activeProject: null,
+      activeProjectWorkspaceContext: null,
+      projectRouteLoading: false,
+      ambientWorkspaceContext: workspaceA,
+      identityChangePending: true,
+      accountGeneration: 4,
+    });
+    expect(scope.pending).toBe(true);
+    expect(scope.context).toBe(workspaceA);
+    expect(scope.identity).toBe(JSON.stringify([
+      'pending-account',
+      4,
+      null,
+      null,
+    ]));
+  });
+
+  it('stays pending while a project-bound workspace authority is still loading', () => {
+    const scope = resolveAmrModelsCatalogScope({
+      routeKind: 'project',
+      projectId: 'proj-a',
+      activeProject: { id: 'proj-a', workspaceId: 'ws-a' },
+      activeProjectWorkspaceContext: null,
+      projectRouteLoading: true,
+      ambientWorkspaceContext: workspaceB,
+      identityChangePending: false,
+      accountGeneration: 2,
+    });
+    expect(scope.pending).toBe(true);
+    expect(scope.context).toBeNull();
+    expect(scope.identity).toBe(JSON.stringify([
+      'pending-project-workspace',
+      2,
+      'proj-a',
+      'ws-a',
+    ]));
   });
 });

--- a/apps/web/tests/App.test.ts
+++ b/apps/web/tests/App.test.ts
@@ -661,6 +661,20 @@ describe('mergeAmrModelsIntoAgents', () => {
       modelsSource: undefined,
     });
   });
+
+  it('is the catalog refreshAgents must return so Settings retries stay on Path A', () => {
+    // Settings stops its signed-in empty-models retry loop when the returned
+    // AMR agent has models. Returning raw headerless `/api/agents` agents
+    // (non-empty personal fallback) while state was fail-closed empty made
+    // that loop exit early and left the picker loading until an unrelated
+    // focus refresh. refreshAgents must return this same merge result.
+    const headerlessAgents = agents;
+    const returned = mergeAmrModelsIntoAgents(headerlessAgents, null);
+    const amr = returned.find((agent) => agent.id === 'amr');
+    expect(amr?.models ?? []).toEqual([]);
+    // Non-empty fallback would have stopped Settings; empty keeps it retrying.
+    expect((amr?.models?.length ?? 0) > 0).toBe(false);
+  });
 });
 
 describe('resolveAmrModelsCatalogScope', () => {

--- a/apps/web/tests/App.test.ts
+++ b/apps/web/tests/App.test.ts
@@ -542,7 +542,7 @@ describe('clearAmrLiveModelsFromAgents', () => {
     },
   ];
 
-  it('clears only the AMR live catalog so a workspace switch cannot keep stale locks', () => {
+  it('clears the AMR catalog so a workspace switch cannot keep stale locks', () => {
     const next = clearAmrLiveModelsFromAgents(agents);
     expect(next[0]).toMatchObject({
       id: 'amr',
@@ -552,7 +552,7 @@ describe('clearAmrLiveModelsFromAgents', () => {
     expect(next[1]).toEqual(agents[1]);
   });
 
-  it('leaves non-live AMR agent models untouched', () => {
+  it('also strips headerless /api/agents fallback AMR models', () => {
     const fallbackAgents: AgentInfo[] = [
       {
         id: 'amr',
@@ -563,7 +563,25 @@ describe('clearAmrLiveModelsFromAgents', () => {
         modelsSource: 'fallback',
       },
     ];
-    expect(clearAmrLiveModelsFromAgents(fallbackAgents)).toBe(fallbackAgents);
+    const next = clearAmrLiveModelsFromAgents(fallbackAgents);
+    expect(next[0]).toMatchObject({
+      id: 'amr',
+      models: [],
+      modelsSource: undefined,
+    });
+  });
+
+  it('is a no-op when AMR already has no models', () => {
+    const empty: AgentInfo[] = [
+      {
+        id: 'amr',
+        name: 'AMR',
+        bin: 'vela',
+        available: true,
+        models: [],
+      },
+    ];
+    expect(clearAmrLiveModelsFromAgents(empty)).toBe(empty);
   });
 });
 
@@ -621,13 +639,27 @@ describe('mergeAmrModelsIntoAgents', () => {
     expect(next[0]?.modelsSource).toBe('live');
   });
 
-  it('leaves agents unchanged when Path A returns no models', () => {
-    expect(mergeAmrModelsIntoAgents(agents, null)).toBe(agents);
-    expect(mergeAmrModelsIntoAgents(agents, {
+  it('strips unscoped AMR models when Path A is unresolved or empty', () => {
+    // Concurrent fetchAgentsStream callbacks merge with amrModelsRef=null after
+    // an identity clear; fail closed so personal free/lock shape cannot stick.
+    const clearedNull = mergeAmrModelsIntoAgents(agents, null);
+    expect(clearedNull[0]).toMatchObject({
+      id: 'amr',
+      models: [],
+      modelsSource: undefined,
+    });
+    expect(clearedNull[1]).toEqual(agents[1]);
+
+    const clearedEmpty = mergeAmrModelsIntoAgents(agents, {
       source: 'preset',
       models: [],
       refreshing: true,
-    })).toBe(agents);
+    });
+    expect(clearedEmpty[0]).toMatchObject({
+      id: 'amr',
+      models: [],
+      modelsSource: undefined,
+    });
   });
 });
 

--- a/apps/web/tests/App.test.ts
+++ b/apps/web/tests/App.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   buildPersistedConfig,
+  clearAmrLiveModelsFromAgents,
   isAutosaveDraftOnlyChange,
   hydrateReadyTeamProject,
   mergeAgentModelChoice,
@@ -13,7 +14,7 @@ import {
   shouldRouteToFirstRunOnboarding,
   shouldSyncMediaProvidersOnSave,
 } from '../src/App';
-import type { AppConfig, Project } from '../src/types';
+import type { AgentInfo, AppConfig, Project } from '../src/types';
 import type {
   WorkspaceCollabContext,
   WorkspaceProjectSummary,
@@ -512,5 +513,52 @@ describe('resolveDeepLinkedTeamSharedProject', () => {
     expect(resolution).toEqual({ kind: 'still-materializing' });
     expect(getProject).toHaveBeenCalledTimes(1);
     expect(pullTeamSharedProjectIfAvailable).not.toHaveBeenCalled();
+  });
+});
+
+describe('clearAmrLiveModelsFromAgents', () => {
+  const agents: AgentInfo[] = [
+    {
+      id: 'amr',
+      name: 'AMR',
+      bin: 'vela',
+      available: true,
+      models: [
+        { id: 'locked-model', label: 'locked-model', enabled: false },
+      ],
+      modelsSource: 'live',
+    },
+    {
+      id: 'claude',
+      name: 'Claude',
+      bin: 'claude',
+      available: true,
+      models: [{ id: 'claude-sonnet', label: 'claude-sonnet' }],
+      modelsSource: 'live',
+    },
+  ];
+
+  it('clears only the AMR live catalog so a workspace switch cannot keep stale locks', () => {
+    const next = clearAmrLiveModelsFromAgents(agents);
+    expect(next[0]).toMatchObject({
+      id: 'amr',
+      models: [],
+      modelsSource: undefined,
+    });
+    expect(next[1]).toEqual(agents[1]);
+  });
+
+  it('leaves non-live AMR agent models untouched', () => {
+    const fallbackAgents: AgentInfo[] = [
+      {
+        id: 'amr',
+        name: 'AMR',
+        bin: 'vela',
+        available: true,
+        models: [{ id: 'preset-model', label: 'preset-model' }],
+        modelsSource: 'fallback',
+      },
+    ];
+    expect(clearAmrLiveModelsFromAgents(fallbackAgents)).toBe(fallbackAgents);
   });
 });

--- a/apps/web/tests/App.test.ts
+++ b/apps/web/tests/App.test.ts
@@ -6,6 +6,7 @@ import {
   isAutosaveDraftOnlyChange,
   hydrateReadyTeamProject,
   mergeAgentModelChoice,
+  mergeAmrModelsIntoAgents,
   persistComposioConfigChange,
   projectViewAuthorizationLifetimeKey,
   projectRouteSurfaceState,
@@ -17,6 +18,7 @@ import {
 } from '../src/App';
 import type { AgentInfo, AppConfig, Project } from '../src/types';
 import type {
+  AmrModelsResponse,
   WorkspaceCollabContext,
   WorkspaceProjectSummary,
 } from '@open-design/contracts';
@@ -562,6 +564,70 @@ describe('clearAmrLiveModelsFromAgents', () => {
       },
     ];
     expect(clearAmrLiveModelsFromAgents(fallbackAgents)).toBe(fallbackAgents);
+  });
+});
+
+describe('mergeAmrModelsIntoAgents', () => {
+  const unscopedAgentModels = [
+    { id: 'personal-free-model', label: 'personal-free-model', enabled: true },
+    { id: 'team-only-model', label: 'team-only-model', enabled: false },
+  ];
+  const scopedPresetModels = [
+    { id: 'personal-free-model', label: 'personal-free-model', enabled: true },
+    { id: 'team-only-model', label: 'team-only-model', enabled: true },
+  ];
+  const agents: AgentInfo[] = [
+    {
+      id: 'amr',
+      name: 'AMR',
+      bin: 'vela',
+      available: true,
+      // Non-empty models from headerless `/api/agents` discovery (personal shape).
+      models: unscopedAgentModels,
+      modelsSource: 'fallback',
+    },
+    {
+      id: 'claude',
+      name: 'Claude',
+      bin: 'claude',
+      available: true,
+      models: [{ id: 'claude-sonnet', label: 'claude-sonnet' }],
+    },
+  ];
+
+  it('applies a scoped Path A preset over non-empty unscoped agent models', () => {
+    const scopedPreset: AmrModelsResponse = {
+      source: 'preset',
+      models: scopedPresetModels,
+      refreshing: true,
+    };
+    const next = mergeAmrModelsIntoAgents(agents, scopedPreset);
+    expect(next[0]).toMatchObject({
+      id: 'amr',
+      models: scopedPresetModels,
+      modelsSource: 'live',
+    });
+    expect(next[1]).toEqual(agents[1]);
+  });
+
+  it('applies a remote Path A catalog the same way', () => {
+    const remote: AmrModelsResponse = {
+      source: 'remote',
+      models: scopedPresetModels,
+      refreshing: false,
+    };
+    const next = mergeAmrModelsIntoAgents(agents, remote);
+    expect(next[0]?.models).toEqual(scopedPresetModels);
+    expect(next[0]?.modelsSource).toBe('live');
+  });
+
+  it('leaves agents unchanged when Path A returns no models', () => {
+    expect(mergeAmrModelsIntoAgents(agents, null)).toBe(agents);
+    expect(mergeAmrModelsIntoAgents(agents, {
+      source: 'preset',
+      models: [],
+      refreshing: true,
+    })).toBe(agents);
   });
 });
 

--- a/apps/web/tests/App.test.ts
+++ b/apps/web/tests/App.test.ts
@@ -698,7 +698,6 @@ describe('resolveAmrModelsCatalogScope', () => {
       projectId: 'proj-a',
       activeProject: { id: 'proj-a', workspaceId: 'ws-a' },
       activeProjectWorkspaceContext: workspaceA,
-      projectRouteLoading: false,
       ambientWorkspaceContext: workspaceB,
       identityChangePending: false,
       accountGeneration: 3,
@@ -717,7 +716,6 @@ describe('resolveAmrModelsCatalogScope', () => {
       routeKind: 'home',
       activeProject: null,
       activeProjectWorkspaceContext: null,
-      projectRouteLoading: false,
       ambientWorkspaceContext: workspaceB,
       identityChangePending: false,
       accountGeneration: 1,
@@ -731,7 +729,6 @@ describe('resolveAmrModelsCatalogScope', () => {
       routeKind: 'home',
       activeProject: null,
       activeProjectWorkspaceContext: null,
-      projectRouteLoading: false,
       ambientWorkspaceContext: workspaceA,
       identityChangePending: true,
       accountGeneration: 4,
@@ -746,13 +743,12 @@ describe('resolveAmrModelsCatalogScope', () => {
     ]));
   });
 
-  it('stays pending while a project-bound workspace authority is still loading', () => {
+  it('stays pending while a project-bound workspace authority is still unresolved', () => {
     const scope = resolveAmrModelsCatalogScope({
       routeKind: 'project',
       projectId: 'proj-a',
       activeProject: { id: 'proj-a', workspaceId: 'ws-a' },
       activeProjectWorkspaceContext: null,
-      projectRouteLoading: true,
       ambientWorkspaceContext: workspaceB,
       identityChangePending: false,
       accountGeneration: 2,
@@ -765,5 +761,35 @@ describe('resolveAmrModelsCatalogScope', () => {
       'proj-a',
       'ws-a',
     ]));
+  });
+
+  it('stays pending when a bound project workspace lookup settles without exact context', () => {
+    // forbidden / unavailable leave context null after loading finishes.
+    // Catalog must not fall through to a headerless personal fetch.
+    const scope = resolveAmrModelsCatalogScope({
+      routeKind: 'project',
+      projectId: 'proj-a',
+      activeProject: { id: 'proj-a', workspaceId: 'ws-a' },
+      activeProjectWorkspaceContext: null,
+      ambientWorkspaceContext: workspaceB,
+      identityChangePending: false,
+      accountGeneration: 2,
+    });
+    expect(scope.pending).toBe(true);
+    expect(scope.context).toBeNull();
+  });
+
+  it('allows unscoped personal catalog for projects without a pinned workspace', () => {
+    const scope = resolveAmrModelsCatalogScope({
+      routeKind: 'project',
+      projectId: 'proj-personal',
+      activeProject: { id: 'proj-personal', workspaceId: null },
+      activeProjectWorkspaceContext: null,
+      ambientWorkspaceContext: workspaceB,
+      identityChangePending: false,
+      accountGeneration: 1,
+    });
+    expect(scope.pending).toBe(false);
+    expect(scope.context).toBeNull();
   });
 });

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -3,6 +3,7 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useSyncExternalStore } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceCollabContext } from '@open-design/contracts';
 
 import { App } from '../../src/App';
 import type { AppConfig } from '../../src/types';
@@ -18,6 +19,43 @@ import {
 import { fetchAmrModels, fetchVelaLoginStatus } from '../../src/providers/daemon';
 import { listProjects, listTemplates } from '../../src/state/projects';
 
+// Drive catalog authority (pending account / workspace identity) without
+// spinning the real workspace context network stack.
+const workspaceContextHarness = vi.hoisted(() => {
+  type Snapshot = {
+    context: WorkspaceCollabContext | null;
+    loading: boolean;
+    identityChangePending: boolean;
+  };
+  let snapshot: Snapshot = {
+    context: null,
+    loading: false,
+    identityChangePending: false,
+  };
+  const listeners = new Set<() => void>();
+  return {
+    getSnapshot: (): Snapshot => snapshot,
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    set: (next: Partial<Snapshot>) => {
+      snapshot = { ...snapshot, ...next };
+      listeners.forEach((listener) => listener());
+    },
+    reset: () => {
+      snapshot = {
+        context: null,
+        loading: false,
+        identityChangePending: false,
+      };
+      listeners.forEach((listener) => listener());
+    },
+  };
+});
+
 // Settings is now a full-page route (`/settings`): App.openSettings navigates
 // instead of toggling a modal flag, so the router mock must feed navigate()
 // calls back into useRoute() (like the production useSyncExternalStore router)
@@ -25,6 +63,22 @@ import { listProjects, listTemplates } from '../../src/state/projects';
 const homeRouteMock = { kind: 'home' as const, view: 'home' as const };
 const routeListeners = new Set<() => void>();
 const useRouteMock = vi.fn(() => homeRouteMock);
+
+vi.mock('../../src/collab/useWorkspaceContext', async () => {
+  const actual = await vi.importActual<typeof import('../../src/collab/useWorkspaceContext')>(
+    '../../src/collab/useWorkspaceContext',
+  );
+  const React = await import('react');
+  return {
+    ...actual,
+    useWorkspaceContext: () =>
+      React.useSyncExternalStore(
+        workspaceContextHarness.subscribe,
+        workspaceContextHarness.getSnapshot,
+        workspaceContextHarness.getSnapshot,
+      ),
+  };
+});
 
 vi.mock('../../src/router', async () => {
   const actual = await vi.importActual<typeof import('../../src/router')>('../../src/router');
@@ -254,9 +308,33 @@ async function advanceTestClock(ms: number): Promise<void> {
   });
 }
 
+const retainedTeamWorkspace: WorkspaceCollabContext = {
+  workspaceId: 'ws-retained',
+  workspaceType: 'team',
+  workspaceMemberId: 'member-retained',
+  role: 'member',
+  memberStatus: 'active',
+  lifecycleState: 'active',
+  billingState: 'active',
+  planId: 'team_pro',
+  providerMode: 'platform_credits',
+  seatSummary: { seatLimit: 5, usedSeats: 1, availableSeats: 4, isSeatFull: false },
+  permissions: {
+    canManageMembers: false,
+    canManageBilling: false,
+    canInviteMembers: false,
+    canManageAutoRecharge: false,
+    canShareProjects: true,
+    canWriteSyncedFiles: true,
+    canViewWorkspaceSettings: false,
+    canManageSharedResources: false,
+  },
+};
+
 describe('App AMR polling', () => {
   beforeEach(() => {
     window.localStorage.clear();
+    workspaceContextHarness.reset();
     useRouteMock.mockReturnValue(homeRouteMock);
     mockedDaemonIsLive.mockResolvedValue(true);
     mockedFetchAgentsStream.mockResolvedValue([
@@ -670,6 +748,127 @@ describe('App AMR polling', () => {
     await waitFor(() => {
       expect(mockedFetchAmrModels.mock.calls.length).toBeGreaterThanOrEqual(2);
     });
+  });
+
+  it('skips refreshAgents Path A re-probe while catalog authority is pending', async () => {
+    // Account transitions retain the prior workspace context while pending.
+    // Main poll already skips; refreshAgents must not re-probe that retained
+    // context (or a headerless personal catalog) and commit stale models.
+    workspaceContextHarness.set({
+      context: retainedTeamWorkspace,
+      loading: false,
+      identityChangePending: true,
+    });
+    mockedFetchAmrModels.mockReset();
+    mockedFetchAmrModels.mockResolvedValue({
+      source: 'remote',
+      refreshing: false,
+      models: [{ id: 'stale-retained-workspace', label: 'stale-retained-workspace' }],
+    });
+    mockedFetchAgentsStream.mockResolvedValue([
+      {
+        id: 'amr',
+        name: 'AMR',
+        bin: 'vela',
+        available: true,
+        version: '1.0.0',
+        models: [{ id: 'headerless-fallback', label: 'headerless-fallback' }],
+      },
+    ]);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('amr-model').textContent).toBe('none');
+    });
+    // Pending catalog identity must not issue Path A discovery at all.
+    expect(mockedFetchAmrModels).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText('open settings'));
+    await waitFor(() => {
+      expect(screen.getByText('rescan agents bare')).toBeTruthy();
+    });
+    fireEvent.click(screen.getByText('rescan agents bare'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('refresh-agents-amr-model').textContent).toBe('none');
+    });
+    // Settings retries must stay empty/fail-closed; no retained-catalog probe.
+    expect(mockedFetchAmrModels).not.toHaveBeenCalled();
+  });
+
+  it('discards refreshAgents Path A re-probe results after catalog identity changes', async () => {
+    workspaceContextHarness.set({
+      context: retainedTeamWorkspace,
+      loading: false,
+      identityChangePending: false,
+    });
+    const firstPoll = deferred<Awaited<ReturnType<typeof fetchAmrModels>>>();
+    const reProbe = deferred<Awaited<ReturnType<typeof fetchAmrModels>>>();
+    let amrModelCalls = 0;
+    mockedFetchAmrModels.mockReset();
+    mockedFetchAmrModels.mockImplementation(() => {
+      amrModelCalls += 1;
+      // First call is the initial Path A poll (empty so the rescan re-probe
+      // path is taken). The second call is the in-flight refreshAgents re-probe.
+      if (amrModelCalls === 1) return firstPoll.promise;
+      return reProbe.promise;
+    });
+    mockedFetchAgentsStream.mockResolvedValue([
+      {
+        id: 'amr',
+        name: 'AMR',
+        bin: 'vela',
+        available: true,
+        version: '1.0.0',
+        models: [{ id: 'headerless-fallback', label: 'headerless-fallback' }],
+      },
+    ]);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockedFetchAmrModels).toHaveBeenCalledTimes(1);
+    });
+
+    // Leave the initial poll empty so amrModelsRef stays null and rescan re-probes.
+    firstPoll.resolve(null);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('amr-model').textContent).toBe('none');
+    });
+
+    fireEvent.click(screen.getByText('open settings'));
+    await waitFor(() => {
+      expect(screen.getByText('rescan agents bare')).toBeTruthy();
+    });
+    fireEvent.click(screen.getByText('rescan agents bare'));
+
+    await waitFor(() => {
+      expect(amrModelCalls).toBe(2);
+    });
+    const callsBeforeIdentityFlip = amrModelCalls;
+
+    // Enter pending while the re-probe is in flight: identity changes and the
+    // main poll skips, so only the discard path can apply this response.
+    act(() => {
+      workspaceContextHarness.set({
+        identityChangePending: true,
+      });
+    });
+
+    reProbe.resolve({
+      source: 'remote',
+      refreshing: false,
+      models: [{ id: 'stale-pre-switch-catalog', label: 'stale-pre-switch-catalog' }],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('refresh-agents-amr-model').textContent).toBe('none');
+    });
+    // Pending gate must not start a replacement Path A probe for the discarded
+    // response either.
+    expect(amrModelCalls).toBe(callsBeforeIdentityFlip);
   });
 
   it('refreshes renderer config and clears stale AMR models after a desktop app-config change event', async () => {

--- a/apps/web/tests/components/App.amr-polling.test.tsx
+++ b/apps/web/tests/components/App.amr-polling.test.tsx
@@ -91,7 +91,9 @@ vi.mock('../../src/components/SettingsDialog', () => ({
     onAmrLoginStatusChange,
     onClose,
   }: {
-    onRefreshAgents: (options?: { agentCliEnv?: AppConfig['agentCliEnv'] }) => void | Promise<void>;
+    onRefreshAgents: (
+      options?: { agentCliEnv?: AppConfig['agentCliEnv'] },
+    ) => void | Promise<Array<{ id: string; models?: Array<{ id: string }> }>>;
     onAmrLoginStatusChange?: (status: {
       loggedIn: boolean;
       loginInFlight?: boolean;
@@ -112,6 +114,21 @@ vi.mock('../../src/components/SettingsDialog', () => ({
       >
         rescan agents
       </button>
+      <button
+        onClick={() => {
+          void Promise.resolve(onRefreshAgents()).then((agents) => {
+            const list = Array.isArray(agents) ? agents : [];
+            const amr = list.find((agent) => agent.id === 'amr');
+            const el = document.querySelector('[data-testid="refresh-agents-amr-model"]');
+            if (el) {
+              el.textContent = amr?.models?.[0]?.id ?? 'none';
+            }
+          });
+        }}
+      >
+        rescan agents bare
+      </button>
+      <div data-testid="refresh-agents-amr-model">unset</div>
       <button
         onClick={() => {
           window.dispatchEvent(new CustomEvent('od:amr-login-status-change'));
@@ -554,13 +571,19 @@ describe('App AMR polling', () => {
     expect(mockedFetchAmrModels).toHaveBeenCalledTimes(11);
   });
 
-  it('does not merge stale AMR remote models over a rescan with new agent env', async () => {
+  it('does not keep a stale Path A catalog after a rescan with new agent env', async () => {
     mockedFetchAmrModels.mockReset();
-    mockedFetchAmrModels.mockResolvedValue({
-      source: 'remote',
-      refreshing: false,
-      models: [{ id: 'old-remote', label: 'old-remote' }],
-    });
+    mockedFetchAmrModels
+      .mockResolvedValueOnce({
+        source: 'remote',
+        refreshing: false,
+        models: [{ id: 'old-remote', label: 'old-remote' }],
+      })
+      .mockResolvedValueOnce({
+        source: 'remote',
+        refreshing: false,
+        models: [{ id: 'profile-remote', label: 'profile-remote' }],
+      });
     mockedFetchAgentsStream
       .mockResolvedValueOnce([
         {
@@ -579,6 +602,7 @@ describe('App AMR polling', () => {
           bin: 'vela',
           available: true,
           version: '1.0.0',
+          // Headerless agent discovery must not win over Path A authority.
           models: [{ id: 'new-probe', label: 'new-probe' }],
         },
       ]);
@@ -600,10 +624,52 @@ describe('App AMR polling', () => {
     // mock (which renders the amr-model probe) is mounted again.
     fireEvent.click(screen.getByText('close settings'));
 
+    // Profile change clears Path A and re-arms the scoped poll. Fail-closed
+    // merge strips the headerless new-probe; the restarted Path A catalog
+    // is what the picker must show.
     await waitFor(() => {
-      expect(screen.getByTestId('amr-model').textContent).toBe('new-probe');
+      expect(screen.getByTestId('amr-model').textContent).toBe('profile-remote');
     });
-    expect(mockedFetchAmrModels).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('amr-model').textContent).not.toBe('new-probe');
+    expect(mockedFetchAmrModels).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns fail-closed AMR models from refreshAgents when Path A is empty', async () => {
+    // Settings retries stop when the returned AMR agent has models. If
+    // refreshAgents returned raw headerless `/api/agents` models while
+    // state was cleared, the loop exited early and the picker stayed loading.
+    mockedFetchAmrModels.mockReset();
+    mockedFetchAmrModels.mockResolvedValue(null);
+    mockedFetchAgentsStream.mockResolvedValue([
+      {
+        id: 'amr',
+        name: 'AMR',
+        bin: 'vela',
+        available: true,
+        version: '1.0.0',
+        models: [{ id: 'headerless-fallback', label: 'headerless-fallback' }],
+      },
+    ]);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('amr-model').textContent).toBe('none');
+    });
+
+    fireEvent.click(screen.getByText('open settings'));
+    await waitFor(() => {
+      expect(screen.getByText('rescan agents bare')).toBeTruthy();
+    });
+    fireEvent.click(screen.getByText('rescan agents bare'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('refresh-agents-amr-model').textContent).toBe('none');
+    });
+    // Path A empty after rescan re-arms the scoped poll (not only state merge).
+    await waitFor(() => {
+      expect(mockedFetchAmrModels.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
   });
 
   it('refreshes renderer config and clears stale AMR models after a desktop app-config change event', async () => {
@@ -615,13 +681,17 @@ describe('App AMR polling', () => {
       },
     });
     mockedFetchAmrModels.mockReset();
+    // Config change both restarts the Path A poll and re-probes inside
+    // refreshAgents when the catalog was cleared. Keep post-change answers
+    // durable so concurrent probes cannot exhaust a one-shot mock and clear
+    // the picker back to empty.
     mockedFetchAmrModels
       .mockResolvedValueOnce({
         source: 'remote',
         refreshing: false,
         models: [{ id: 'old-remote', label: 'old-remote' }],
       })
-      .mockResolvedValueOnce({
+      .mockResolvedValue({
         source: 'remote',
         refreshing: false,
         models: [{ id: 'local-remote', label: 'local-remote' }],
@@ -685,7 +755,7 @@ describe('App AMR polling', () => {
     await waitFor(() => {
       expect(mockedFetchAgentsStream).toHaveBeenCalledTimes(2);
     });
-    expect(mockedFetchAmrModels).toHaveBeenCalledTimes(2);
+    expect(mockedFetchAmrModels.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 
   it('ignores stale in-flight AMR model polls after a desktop app-config change restarts polling', async () => {
@@ -709,9 +779,14 @@ describe('App AMR polling', () => {
       agentCliEnv: daemon?.agentCliEnv ?? local.agentCliEnv,
     }));
     mockedFetchAmrModels.mockReset();
-    mockedFetchAmrModels
-      .mockReturnValueOnce(oldRemotePoll.promise)
-      .mockReturnValueOnce(localRemotePoll.promise);
+    let amrModelCalls = 0;
+    mockedFetchAmrModels.mockImplementation(() => {
+      amrModelCalls += 1;
+      // First (pre-change) poll stays in flight; every post-change probe
+      // shares the local catalog deferred so refreshAgents re-probe and the
+      // restarted poll effect do not diverge.
+      return amrModelCalls === 1 ? oldRemotePoll.promise : localRemotePoll.promise;
+    });
     mockedFetchAgentsStream
       .mockResolvedValueOnce([
         {
@@ -743,7 +818,7 @@ describe('App AMR polling', () => {
     fireEvent(window, new CustomEvent('open-design:app-config-changed'));
 
     await waitFor(() => {
-      expect(mockedFetchAmrModels).toHaveBeenCalledTimes(2);
+      expect(mockedFetchAmrModels.mock.calls.length).toBeGreaterThanOrEqual(2);
     });
 
     localRemotePoll.resolve({

--- a/apps/web/tests/providers/daemon-amr-models.test.ts
+++ b/apps/web/tests/providers/daemon-amr-models.test.ts
@@ -52,6 +52,44 @@ describe('fetchAmrModels', () => {
     expect(fetch).toHaveBeenCalledWith('/api/amr/models', { cache: 'no-store' });
   });
 
+  it('forwards the selected workspace identity on model discovery', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({
+        source: 'remote',
+        models: [{ id: 'gpt-5.5', label: 'gpt-5.5' }],
+        refreshing: false,
+      }), { status: 200 })),
+    );
+
+    await expect(fetchAmrModels({
+      workspaceId: 'ws-team-pro',
+      workspaceType: 'team',
+      workspaceMemberId: 'member-1',
+      role: 'member',
+      memberStatus: 'active',
+      lifecycleState: 'active',
+      permissions: {
+        canShareProjects: true,
+        canWriteSyncedFiles: true,
+      },
+    } as any)).resolves.toMatchObject({ source: 'remote' });
+
+    expect(fetch).toHaveBeenCalledWith('/api/amr/models', {
+      cache: 'no-store',
+      headers: {
+        'x-od-workspace-id': 'ws-team-pro',
+        'x-od-workspace-type': 'team',
+        'x-od-workspace-member-id': 'member-1',
+        'x-od-workspace-role': 'member',
+        'x-od-workspace-lifecycle-state': 'active',
+        'x-od-workspace-member-status': 'active',
+        'x-od-workspace-can-share-projects': 'true',
+        'x-od-workspace-can-write-synced-files': 'true',
+      },
+    });
+  });
+
   it('returns null when the daemon does not return AMR models', async () => {
     vi.stubGlobal(
       'fetch',

--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -9,6 +9,6 @@
   # 1. Temporarily set the consuming `hash = lib.fakeHash;`
   # 2. Run the relevant nix build/flake check
   # 3. Copy the expected hash printed by Nix into the matching field below
-  daemonHash = "sha256-YQvGfoSFGgSqdCezSTNrTBIlEpnPFPH04vUzZf5RJc0=";
-  webHash = "sha256-T6z+ZjG/+KOD9qBqO/WguX6F9C+Z1mGdQlDxw/5Ddq0=";
+  daemonHash = "sha256-z4YqG5NsG6elcZy+icWLT291FezUCGzCEBhHiikNOQY=";
+  webHash = "sha256-sKwMrVhcRt4DOaFjUdpi4ysKLKGXMzeY1mqRv/s29XU=";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -810,8 +810,8 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       '@powerformer/vela-cli':
-        specifier: 0.0.28
-        version: 0.0.28
+        specifier: 0.0.29
+        version: 0.0.29
 
   tools/release:
     dependencies:
@@ -2053,33 +2053,33 @@ packages:
   '@posthog/types@1.374.2':
     resolution: {integrity: sha512-ZghQSFMi+HFJNPvPjBoyY/jWQ+q6mSQVtWQxOHMSbBidUZjsyYbxYxBFbHy2qWLNe4mEpX+Wqir2Q4I/4AVvJQ==}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.28':
-    resolution: {integrity: sha512-CFJfjaG12xZ8Uw24irvYEe+rRPZiX2I+6MSP/5HN70gcHWz/bJLIuNBU0pVSMK27FETUwdk6r4vki6Wolb9RHQ==}
+  '@powerformer/vela-cli-darwin-arm64@0.0.29':
+    resolution: {integrity: sha512-Dw5HCTULtcGapjS8G/We6+mjJWEimqm/Z+pEFeajFvI3SuJRS8D5lkNoQEzWeJIy1HoZQsrzbWubXH+bI1NJ5w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@powerformer/vela-cli-darwin-x64@0.0.28':
-    resolution: {integrity: sha512-tAQi3i7w7j0U30XuOeTC7nt6vjfXUK12Uq++7KSL0PxNAtJTbF/Oe5OydsVKS9MHEFw/s1AnuHc2DG0RWcpEwg==}
+  '@powerformer/vela-cli-darwin-x64@0.0.29':
+    resolution: {integrity: sha512-9sIfZcXj9mpAdM6BeI5DYjirJwmqvK2IH77wdq44rguIudr184Wih+jkanEW1yQ/4C7NvVmRz0cfuxpyGNqv5A==}
     cpu: [x64]
     os: [darwin]
 
-  '@powerformer/vela-cli-linux-arm64@0.0.28':
-    resolution: {integrity: sha512-cRo4iIWBYRx9LYD2v5MdccgyU0Pqa0uNrdfGqgGsPqznY+CQPEuxOkpQiFOomH8l8waHYBsbkpUE/JtkqVWBUA==}
+  '@powerformer/vela-cli-linux-arm64@0.0.29':
+    resolution: {integrity: sha512-A8spGqw46LhbHmj3oGPAqXB9Fw0DnsoviYycq4A3lf29bq1QXq8q3hWGrbk/tP4CvwHLTRIL2ujUTLmQB2tNNw==}
     cpu: [arm64]
     os: [linux]
 
-  '@powerformer/vela-cli-linux-x64@0.0.28':
-    resolution: {integrity: sha512-+b6CykVp82WIAC7vkQTEmcU5cQ8Am9C1cZh7CblHHTTD7Y7C+JTYEEQgoPlD2iu59UJr9RjIkWF9PsDcgaMR/A==}
+  '@powerformer/vela-cli-linux-x64@0.0.29':
+    resolution: {integrity: sha512-xxIBTFR5wwAPxeHenCB4lQMWkVUK8oqa79XV1kvcdRamqITqVv9glrdhFV5yMMsUwgvHoXfU+mjbYO+mf9bceA==}
     cpu: [x64]
     os: [linux]
 
-  '@powerformer/vela-cli-win32-x64@0.0.28':
-    resolution: {integrity: sha512-jc/SCPViA4Uiktzae2XboHCl77V5FKbMzCIf2Dt0o7K0zlz3Kl2kbWVvBzm/0QDUKtzzrNIPliC9Wa+vVUQplA==}
+  '@powerformer/vela-cli-win32-x64@0.0.29':
+    resolution: {integrity: sha512-KuVmwa5pWr9yZBvnRgv3MxEy044gXK1e9D/WVamxtUfavhSXehEwZ0/MElK+1DsL+6+LvjWVO5N1qhGDgDo33g==}
     cpu: [x64]
     os: [win32]
 
-  '@powerformer/vela-cli@0.0.28':
-    resolution: {integrity: sha512-CZRKK/e/jm63cxM/DqxiegmzWil2od6q1aNmTRq3WCjDz8vTSby72qzD9R4akILLK7oOMXe99t7mOfzySTKlCQ==}
+  '@powerformer/vela-cli@0.0.29':
+    resolution: {integrity: sha512-J61aj11pbBzoT8XN6LKP/WN8ZWgmGNJgSQy+PWC9eZ9nA5dic0FYg2qSM1Tcmhrijtn6OPeLwuoaIwOCW0Embw==}
     hasBin: true
 
   '@preact/signals-core@1.14.2':
@@ -7911,28 +7911,28 @@ snapshots:
 
   '@posthog/types@1.374.2': {}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.28':
+  '@powerformer/vela-cli-darwin-arm64@0.0.29':
     optional: true
 
-  '@powerformer/vela-cli-darwin-x64@0.0.28':
+  '@powerformer/vela-cli-darwin-x64@0.0.29':
     optional: true
 
-  '@powerformer/vela-cli-linux-arm64@0.0.28':
+  '@powerformer/vela-cli-linux-arm64@0.0.29':
     optional: true
 
-  '@powerformer/vela-cli-linux-x64@0.0.28':
+  '@powerformer/vela-cli-linux-x64@0.0.29':
     optional: true
 
-  '@powerformer/vela-cli-win32-x64@0.0.28':
+  '@powerformer/vela-cli-win32-x64@0.0.29':
     optional: true
 
-  '@powerformer/vela-cli@0.0.28':
+  '@powerformer/vela-cli@0.0.29':
     optionalDependencies:
-      '@powerformer/vela-cli-darwin-arm64': 0.0.28
-      '@powerformer/vela-cli-darwin-x64': 0.0.28
-      '@powerformer/vela-cli-linux-arm64': 0.0.28
-      '@powerformer/vela-cli-linux-x64': 0.0.28
-      '@powerformer/vela-cli-win32-x64': 0.0.28
+      '@powerformer/vela-cli-darwin-arm64': 0.0.29
+      '@powerformer/vela-cli-darwin-x64': 0.0.29
+      '@powerformer/vela-cli-linux-arm64': 0.0.29
+      '@powerformer/vela-cli-linux-x64': 0.0.29
+      '@powerformer/vela-cli-win32-x64': 0.0.29
     optional: true
 
   '@preact/signals-core@1.14.2': {}

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -25,7 +25,7 @@
     "resedit": "1.7.2"
   },
   "optionalDependencies": {
-    "@powerformer/vela-cli": "0.0.28"
+    "@powerformer/vela-cli": "0.0.29"
   },
   "devDependencies": {
     "@types/node": "24.12.2",


### PR DESCRIPTION
## Why

Team workspace users (`team_pro` / `team_max`) still saw free-shaped model locks in the AMR picker even after Vela entitlement mapping landed.

Root cause on the Open Design host side: `GET /api/amr/models` spawned `vela model list` without the UI-selected workspace, so Link evaluated the personal free allowlist. Vela CLI #1372 / `@powerformer/vela-cli@0.0.29` can accept workspace scope, but OD was not passing it.

This unblocks Team paid unlock in the model picker and keeps agent runs on the same workspace identity.

## What users will see

- Selecting a Team workspace refreshes the AMR model catalog for that workspace's entitlements (paid unlock shape instead of free ~8-model locks).
- Switching workspace re-fetches models; the previous workspace catalog is dropped instead of sticking.
- Agent runs continue to attribute spend to the project's pinned workspace; nested model discovery also carries that scope.

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

Notes:
- UI surface is the existing AMR model picker path (`fetchAmrModels` now sends workspace headers). No new page/control.
- Default behavior change: model discovery is now workspace-scoped when the shell has a selected workspace; legacy headerless callers still omit scope (personal default).
- Bundled packaged dependency pin: `@powerformer/vela-cli` `0.0.28` → `0.0.29` in `tools/pack` (not root `package.json`).

## Screenshots

No visual chrome change; behavior-only model catalog scoping. Focused automated coverage asserts the selected workspace is forwarded on discovery.

## Bug fix verification

- Test paths:
  - `apps/daemon/tests/runtimes/amr-model-probe-workspace-scope.test.ts`
  - `apps/daemon/tests/integrations/vela.routes.test.ts` (`GET /api/amr/models workspace scope`)
  - `apps/daemon/tests/runtimes/open-design-amr-trace-env.test.ts`
  - `apps/web/tests/providers/daemon-amr-models.test.ts`
- Did the tests go red on `main` and green on this branch? Focused green-spec coverage added with the host wiring; the route test asserts `VELA_WORKSPACE_ID` on the fake `vela model list` spawn.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/runtimes/amr-model-probe-workspace-scope.test.ts tests/runtimes/open-design-amr-trace-env.test.ts tests/integrations/vela.routes.test.ts -t "workspace scope|OPEN_DESIGN_WORKSPACE_ID|forwards an exact|forwards a persisted|omits OPEN_DESIGN|partitions catalogs|sets VELA_WORKSPACE_ID|leaves env unscoped"`
- `pnpm --filter @open-design/web exec vitest run tests/providers/daemon-amr-models.test.ts`
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm --filter @open-design/web typecheck`
- `pnpm --filter @open-design/tools-pack typecheck`

## Implementation notes

- Path A (`vela model list`): web sends `x-od-workspace-*`; daemon injects `VELA_WORKSPACE_ID`; cache key includes workspace id.
- Path B (agent run): existing `OPEN_DESIGN_WORKSPACE_ID` kept; also set `VELA_WORKSPACE_ID` for nested discovery; run preflight/resume probes use pinned `run.workspaceScope.workspaceId`.
- Packaged CLI pin bumped to `0.0.29` so Path A scope is available in bundled builds.