### PR TITLE
fix(release): treat an empty windows smoke mode as core

### DIFF
--- a/.github/workflows/notify-release-feishu.yml
+++ b/.github/workflows/notify-release-feishu.yml
@@ -86,12 +86,21 @@ jobs:
       # existed only while prod's resource-hub storage was unconfigured.)
       amr_profile: ${{ inputs.amr_profile || 'prod' }}
       # Windows packaged smoke is a hard publish gate (publish needs build_win
-      # success) but currently flakes on release/v0.18.0 ("did not reach main app
-      # shell"), skip-blocking EVERY platform's publish + the Feishu card. TEMPORARY:
+      # success) but flaked on release/v0.18.0 ("did not reach main app shell"),
+      # skip-blocking EVERY platform's publish + the Feishu card. TEMPORARY:
       # skip it on release/v0.18.0 so the workspace-team prerelease can actually
       # ship its mac/win/linux packages + post its card. Manual dispatch overrides.
-      # Remove this branch default once the win smoke flake root cause is fixed.
-      win_x64_smoke_mode: ${{ inputs.win_x64_smoke_mode || (github.ref_name == 'release/v0.18.0' && 'skip') || '' }}
+      # The root cause is fixed on main (#6481); remove this branch default once
+      # release/v0.18.0 no longer builds.
+      #
+      # The final arm must name a real profile, NOT ''. A workflow_call
+      # `default:` applies only when an input is omitted, so forwarding an empty
+      # string defeats the callee's declared `core` default; the empty value
+      # then reaches the spec, reads as "not core", and selects the updater path
+      # — which demands a fixture only a genuine `full` request wires up, so the
+      # job dies before the smoke starts. That is how release/v0.18.1's first
+      # prerelease failed on its branch-cut commit.
+      win_x64_smoke_mode: ${{ inputs.win_x64_smoke_mode || (github.ref_name == 'release/v0.18.0' && 'skip') || 'core' }}
 
   notify:
     name: Notify Feishu (release)

--- a/e2e/lib/vitest/packaged-smoke-profile.ts
+++ b/e2e/lib/vitest/packaged-smoke-profile.ts
@@ -7,9 +7,40 @@
  */
 export type PackagedSmokeProfile = 'core' | 'full' | 'skip';
 
-/** Resolve the profile from the value the release workflows hand down. */
+/**
+ * Resolve the profile from the value the release workflows hand down.
+ *
+ * The subtlety this exists for: **an empty string is "nothing was chosen", not
+ * a profile.** The value crosses three layers that each treat emptiness
+ * differently, and all three have to agree or a release lane silently runs the
+ * wrong coverage:
+ *
+ * 1. `notify-release-feishu.yml` computes the mode with a `||` chain whose last
+ *    arm yields `''` for any branch its special cases do not name.
+ * 2. A `workflow_call` `default:` applies only when an input is **omitted**.
+ *    Passing `''` is not omission, so the declared `core` default never fires.
+ * 3. `??` falls back only on `null`/`undefined`, so an empty environment
+ *    variable survives it intact.
+ *
+ * On `release/v0.18.1` that produced `smokeProfile === ''`, so
+ * `verifyCoreOnly` was false, the run took the `full` path, demanded the
+ * updater fixture only a genuine `full` request configures, and died before the
+ * smoke started. `release/v0.18.0` never showed it: its branch name matched a
+ * special case that produced `skip`, so the smoke never ran at all.
+ *
+ * Hence: empty (unset, or whitespace) means unset means `core`, and an
+ * unrecognised value is an error rather than a silent "not core" — a typo must
+ * not select the updater path the way `''` did.
+ */
 export function resolvePackagedSmokeProfile(
   raw: string | undefined | null,
 ): PackagedSmokeProfile {
-  return (raw ?? 'core') as PackagedSmokeProfile;
+  const normalized = raw?.trim() ?? '';
+  if (normalized.length === 0) return 'core';
+  if (normalized === 'core' || normalized === 'full' || normalized === 'skip') {
+    return normalized;
+  }
+  throw new Error(
+    `unsupported packaged smoke profile ${JSON.stringify(raw)}; expected core, full, skip, or empty for the core default`,
+  );
 }

--- a/e2e/lib/vitest/packaged-smoke-profile.ts
+++ b/e2e/lib/vitest/packaged-smoke-profile.ts
@@ -1,0 +1,15 @@
+/**
+ * Which coverage profile a packaged smoke run should execute.
+ *
+ * `core` installs, starts, inspects and uninstalls. `full` additionally drives
+ * the updater, which is why it demands an explicitly wired update fixture and
+ * refuses to run without one. `skip` does not run the smoke at all.
+ */
+export type PackagedSmokeProfile = 'core' | 'full' | 'skip';
+
+/** Resolve the profile from the value the release workflows hand down. */
+export function resolvePackagedSmokeProfile(
+  raw: string | undefined | null,
+): PackagedSmokeProfile {
+  return (raw ?? 'core') as PackagedSmokeProfile;
+}

--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -19,6 +19,7 @@ import {
   type PackagedAppShellState,
 } from '@/vitest/packaged-app-shell';
 import { createPackagedSmokeReport } from '@/vitest/packaged-report';
+import { resolvePackagedSmokeProfile } from '@/vitest/packaged-smoke-profile';
 import {
   assertPackagedPtySmokeResult,
   packagedPtySmokeExpression,
@@ -39,7 +40,11 @@ const toolsPackDir = resolveFromWorkspace(process.env.OD_PACKAGED_E2E_TOOLS_PACK
 const namespace = resolvePackagedSmokeNamespace('win');
 const toolsPackBin = join(workspaceRoot, 'tools', 'pack', 'bin', 'tools-pack.mjs');
 const maxInstallDurationMs = Number.parseInt(process.env.OD_PACKAGED_E2E_WIN_MAX_INSTALL_MS ?? '120000', 10);
-const smokeProfile = process.env.OD_PACKAGED_E2E_WIN_SMOKE_PROFILE ?? 'core';
+// `??` would keep an EMPTY value, and the release workflows can hand one down
+// — see `resolvePackagedSmokeProfile` for why all three layers have to agree
+// that empty means unset. An empty value surviving here reads as "not core"
+// and silently selects the updater path.
+const smokeProfile = resolvePackagedSmokeProfile(process.env.OD_PACKAGED_E2E_WIN_SMOKE_PROFILE);
 const verifyCoreOnly = smokeProfile === 'core';
 const verifyReinstallWhileRunning = !verifyCoreOnly && process.env.OD_PACKAGED_E2E_WIN_VERIFY_REINSTALL !== '0';
 const verifyUpgradePersistence =

--- a/e2e/tests/packaged/smoke-profile.test.ts
+++ b/e2e/tests/packaged/smoke-profile.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolvePackagedSmokeProfile } from '@/vitest/packaged-smoke-profile';
+
+// The packaged smoke's coverage profile reaches `win.spec.ts` through three
+// layers, and every one of them handles "nothing was chosen" differently:
+//
+//   1. `notify-release-feishu.yml` computes the mode with a `||` chain whose
+//      last arm yields `''` for any branch its special cases do not name.
+//   2. A `workflow_call` `default:` only applies when the input is *omitted*.
+//      Passing `''` is not omission, so the declared `core` default never
+//      fires.
+//   3. `??` falls back only on `null`/`undefined`, so an empty environment
+//      variable survives it.
+//
+// On `release/v0.18.1` that produced `verifyCoreOnly === ('' === 'core')`,
+// i.e. `false`: the run took the `full` path, demanded the updater fixture that
+// only a genuine `full` request wires up, and died before the smoke started —
+// on the branch-cut commit, before anything else had landed there.
+// `release/v0.18.0` hid it because its branch name matched a special case that
+// produced `skip`, so the smoke never ran at all.
+//
+// The invariant these pin: an absent value must never read as a *different*
+// profile. Empty means unset means `core`; anything unrecognised is an error,
+// not a silent "not core".
+describe('packaged smoke profile', () => {
+  it('defaults to core when the workflow passes an empty string', () => {
+    expect(resolvePackagedSmokeProfile('')).toBe('core');
+  });
+
+  it('defaults to core when the variable is unset', () => {
+    expect(resolvePackagedSmokeProfile(undefined)).toBe('core');
+    expect(resolvePackagedSmokeProfile(null)).toBe('core');
+  });
+
+  it('defaults to core when the value is only whitespace', () => {
+    expect(resolvePackagedSmokeProfile('   ')).toBe('core');
+  });
+
+  it('keeps each explicitly requested profile', () => {
+    expect(resolvePackagedSmokeProfile('core')).toBe('core');
+    expect(resolvePackagedSmokeProfile('full')).toBe('full');
+    expect(resolvePackagedSmokeProfile('skip')).toBe('skip');
+  });
+
+  it('trims an accidentally padded value rather than treating it as unknown', () => {
+    expect(resolvePackagedSmokeProfile(' full ')).toBe('full');
+  });
+
+  it('rejects an unrecognised profile instead of letting it read as not-core', () => {
+    // A typo must not quietly select the updater path the way `''` did.
+    expect(() => resolvePackagedSmokeProfile('fulll')).toThrow(/unsupported packaged smoke profile/);
+    expect(() => resolvePackagedSmokeProfile('CORE')).toThrow(/unsupported packaged smoke profile/);
+  });
+
+  it('never resolves an empty value to something that is not core', () => {
+    // The failure mode stated as an invariant: whatever emptiness looks like,
+    // it must not end up selecting a profile that changes what the smoke does.
+    for (const empty of ['', '  ', '\t', '\n', undefined, null]) {
+      expect(resolvePackagedSmokeProfile(empty as string | undefined | null)).toBe('core');
+    }
+  });
+});

--- a/tools/pack/tests/release-workflows.test.ts
+++ b/tools/pack/tests/release-workflows.test.ts
@@ -394,6 +394,28 @@ describe("release workflows", () => {
     expect(stablePrepare).toContain('setOutput("publish_side_effects_enabled"');
   });
 
+  it("never hands a shipping lane an empty windows smoke mode", async () => {
+    const notify = await readFile(
+      new URL("../../../.github/workflows/notify-release-feishu.yml", import.meta.url),
+      "utf8",
+    );
+
+    // A `workflow_call` `default:` applies only when an input is OMITTED, so
+    // forwarding an empty string defeats the declared `core` default. The empty
+    // value then survives `??` in the spec, `smokeProfile === 'core'` is false,
+    // and the run takes the `full` path — which demands an updater fixture only
+    // a genuine `full` request wires up, and dies before the smoke starts.
+    // That is how release/v0.18.1's first prerelease failed on its branch-cut
+    // commit; release/v0.18.0 stayed hidden behind a branch-name special case
+    // that produced `skip`, so its smoke never ran at all.
+    const modeLine = notify
+      .split("\n")
+      .find((line) => line.includes("win_x64_smoke_mode:") && line.includes("inputs.win_x64_smoke_mode"));
+    expect(modeLine, "notify-release-feishu must forward win_x64_smoke_mode").toBeDefined();
+    expect(modeLine).not.toMatch(/\|\|\s*''\s*\}\}/);
+    expect(modeLine).toMatch(/\|\|\s*'core'\s*\}\}/);
+  });
+
   it("bakes both halves of the workspace-team gate into every shipping lane", async () => {
     const [beta, preview, prerelease, stable] = await Promise.all([
       readFile(new URL("../../../.github/workflows/release-beta.yml", import.meta.url), "utf8"),


### PR DESCRIPTION
## Why

`release/v0.18.1`'s first prerelease **failed on its branch-cut commit**, before any other work had landed there — and again on every push since. `release/v0.18.0` never showed it, so this only surfaced once a second release branch existed.

```
Error: full packaged Windows payload smoke requires explicit tools-serve fixture;
       set OD_PACKAGED_E2E_WIN_UPDATE_FIXTURE=tools-serve or provide ...METADATA_URL
```

Nothing asked for the `full` profile. An **empty** value became one, across three layers that each handle emptiness differently:

1. `notify-release-feishu.yml` computes the mode with a `||` chain whose final arm is `''` for any branch its special cases do not name. `release/v0.18.0` matches one and gets `skip`; `release/v0.18.1` matches none and gets `''`.
2. A `workflow_call` `default:` applies only when an input is **omitted**. Passing `''` is not omission, so `release-prerelease.yml`'s declared `default: core` never fired.
3. `??` falls back only on `null`/`undefined`, so the empty environment variable survived into `win.spec.ts`.

Result: `smokeProfile === ''`, so `verifyCoreOnly` was `false`, so the run took the `full` path, demanded the updater fixture that only a genuine `full` request wires up, and died before the smoke started. The Windows job is a hard publish gate, so this blocked **every** platform's publish and the Feishu card.

This is the same defect family as the review chain on #6481: **something absent silently becoming something meaningful.**

## What users will see

Nothing directly — this is release tooling. Indirectly: `0.18.1` (and every future release branch) can produce prereleases again, and its Windows smoke runs the coverage it was configured for instead of a profile nobody selected.

## How

In `notify-release-feishu.yml`, the final arm now names a real profile instead of the empty string. In `win.spec.ts`, the profile is resolved through a new `resolvePackagedSmokeProfile` helper instead of `?? 'core'`.

Either change alone unblocks 0.18.1; they guard different holes, so both land — one stops an empty value being produced, the other stops one being misread.

The helper also **rejects** an unrecognised profile rather than letting it read as "not core": a typo must not select the updater path the way `''` did.

## Validation

Red-first, on both layers.

`84fc73419b` pins the invariants with the resolver mirroring main's `?? 'core'` verbatim:

```
 × defaults to core when the workflow passes an empty string
 × defaults to core when the value is only whitespace
 × trims an accidentally padded value rather than treating it as unknown
 × rejects an unrecognised profile instead of letting it read as not-core
 × never resolves an empty value to something that is not core
 Tests  5 failed | 2 passed (7)

 × never hands a shipping lane an empty windows smoke mode
 AssertionError: expected '      win_x64_smoke_mode: …' not to match /\|\|\s*''\s*\}\}/
```

`07571e0f5f` → e2e resolver **7 passed**, workflow assertions **5 passed**.

- `pnpm guard` — **0**
- `pnpm typecheck` — **0**
- `pnpm -C e2e typecheck` — **0**
- `win.spec.ts` still loads cleanly with the new import (4 skipped — Windows-only cases)
- `notify-release-feishu.yml` parsed with a YAML loader; job count unchanged

## Adjacent issues

Not fixed here:

- The `release/v0.18.0` skip special-case stays. Its root cause is fixed on `main` (#6481), so it should go once that branch stops building — but removing it here would change 0.18.0's behaviour while it can still cut patches.
- Once this lands, `release/v0.18.1` will run the Windows smoke at `core` for the first time. That is the first real exercise of #6481's work, including the open question about whether the protocol cold launch preserves the packaged data root. If it fails there it now fails with a named cause instead of a 45-second hang, and the fix would belong in the packaged runtime.

## Surface area

- [x] CI / GitHub Actions workflows
- [x] Tests

Needs backport to `release/v0.18.1` — that branch cannot produce a prerelease without it.
