### PR TITLE
fix(release): treat an empty windows smoke mode as core

### DIFF
--- a/.github/workflows/notify-release-feishu.yml
+++ b/.github/workflows/notify-release-feishu.yml
@@ -86,12 +86,21 @@ jobs:
       # existed only while prod's resource-hub storage was unconfigured.)
       amr_profile: ${{ inputs.amr_profile || 'prod' }}
       # Windows packaged smoke is a hard publish gate (publish needs build_win
-      # success) but currently flakes on release/v0.18.0 ("did not reach main app
-      # shell"), skip-blocking EVERY platform's publish + the Feishu card. TEMPORARY:
+      # success) but flaked on release/v0.18.0 ("did not reach main app shell"),
+      # skip-blocking EVERY platform's publish + the Feishu card. TEMPORARY:
       # skip it on release/v0.18.0 so the workspace-team prerelease can actually
       # ship its mac/win/linux packages + post its card. Manual dispatch overrides.
-      # Remove this branch default once the win smoke flake root cause is fixed.
-      win_x64_smoke_mode: ${{ inputs.win_x64_smoke_mode || (github.ref_name == 'release/v0.18.0' && 'skip') || '' }}
+      # The root cause is fixed on main (#6481); remove this branch default once
+      # release/v0.18.0 no longer builds.
+      #
+      # The final arm must name a real profile, NOT ''. A workflow_call
+      # `default:` applies only when an input is omitted, so forwarding an empty
+      # string defeats the callee's declared `core` default; the empty value
+      # then reaches the spec, reads as "not core", and selects the updater path
+      # — which demands a fixture only a genuine `full` request wires up, so the
+      # job dies before the smoke starts. That is how release/v0.18.1's first
+      # prerelease failed on its branch-cut commit.
+      win_x64_smoke_mode: ${{ inputs.win_x64_smoke_mode || (github.ref_name == 'release/v0.18.0' && 'skip') || 'core' }}
 
   notify:
     name: Notify Feishu (release)

--- a/e2e/lib/vitest/packaged-smoke-profile.ts
+++ b/e2e/lib/vitest/packaged-smoke-profile.ts
@@ -7,9 +7,40 @@
  */
 export type PackagedSmokeProfile = 'core' | 'full' | 'skip';
 
-/** Resolve the profile from the value the release workflows hand down. */
+/**
+ * Resolve the profile from the value the release workflows hand down.
+ *
+ * The subtlety this exists for: **an empty string is "nothing was chosen", not
+ * a profile.** The value crosses three layers that each treat emptiness
+ * differently, and all three have to agree or a release lane silently runs the
+ * wrong coverage:
+ *
+ * 1. `notify-release-feishu.yml` computes the mode with a `||` chain whose last
+ *    arm yields `''` for any branch its special cases do not name.
+ * 2. A `workflow_call` `default:` applies only when an input is **omitted**.
+ *    Passing `''` is not omission, so the declared `core` default never fires.
+ * 3. `??` falls back only on `null`/`undefined`, so an empty environment
+ *    variable survives it intact.
+ *
+ * On `release/v0.18.1` that produced `smokeProfile === ''`, so
+ * `verifyCoreOnly` was false, the run took the `full` path, demanded the
+ * updater fixture only a genuine `full` request configures, and died before the
+ * smoke started. `release/v0.18.0` never showed it: its branch name matched a
+ * special case that produced `skip`, so the smoke never ran at all.
+ *
+ * Hence: empty (unset, or whitespace) means unset means `core`, and an
+ * unrecognised value is an error rather than a silent "not core" — a typo must
+ * not select the updater path the way `''` did.
+ */
 export function resolvePackagedSmokeProfile(
   raw: string | undefined | null,
 ): PackagedSmokeProfile {
-  return (raw ?? 'core') as PackagedSmokeProfile;
+  const normalized = raw?.trim() ?? '';
+  if (normalized.length === 0) return 'core';
+  if (normalized === 'core' || normalized === 'full' || normalized === 'skip') {
+    return normalized;
+  }
+  throw new Error(
+    `unsupported packaged smoke profile ${JSON.stringify(raw)}; expected core, full, skip, or empty for the core default`,
+  );
 }

--- a/e2e/lib/vitest/packaged-smoke-profile.ts
+++ b/e2e/lib/vitest/packaged-smoke-profile.ts
@@ -1,0 +1,15 @@
+/**
+ * Which coverage profile a packaged smoke run should execute.
+ *
+ * `core` installs, starts, inspects and uninstalls. `full` additionally drives
+ * the updater, which is why it demands an explicitly wired update fixture and
+ * refuses to run without one. `skip` does not run the smoke at all.
+ */
+export type PackagedSmokeProfile = 'core' | 'full' | 'skip';
+
+/** Resolve the profile from the value the release workflows hand down. */
+export function resolvePackagedSmokeProfile(
+  raw: string | undefined | null,
+): PackagedSmokeProfile {
+  return (raw ?? 'core') as PackagedSmokeProfile;
+}

--- a/e2e/specs/win.spec.ts
+++ b/e2e/specs/win.spec.ts
@@ -19,6 +19,7 @@ import {
   type PackagedAppShellState,
 } from '@/vitest/packaged-app-shell';
 import { createPackagedSmokeReport } from '@/vitest/packaged-report';
+import { resolvePackagedSmokeProfile } from '@/vitest/packaged-smoke-profile';
 import {
   assertPackagedPtySmokeResult,
   packagedPtySmokeExpression,
@@ -39,7 +40,11 @@ const toolsPackDir = resolveFromWorkspace(process.env.OD_PACKAGED_E2E_TOOLS_PACK
 const namespace = resolvePackagedSmokeNamespace('win');
 const toolsPackBin = join(workspaceRoot, 'tools', 'pack', 'bin', 'tools-pack.mjs');
 const maxInstallDurationMs = Number.parseInt(process.env.OD_PACKAGED_E2E_WIN_MAX_INSTALL_MS ?? '120000', 10);
-const smokeProfile = process.env.OD_PACKAGED_E2E_WIN_SMOKE_PROFILE ?? 'core';
+// `??` would keep an EMPTY value, and the release workflows can hand one down
+// — see `resolvePackagedSmokeProfile` for why all three layers have to agree
+// that empty means unset. An empty value surviving here reads as "not core"
+// and silently selects the updater path.
+const smokeProfile = resolvePackagedSmokeProfile(process.env.OD_PACKAGED_E2E_WIN_SMOKE_PROFILE);
 const verifyCoreOnly = smokeProfile === 'core';
 const verifyReinstallWhileRunning = !verifyCoreOnly && process.env.OD_PACKAGED_E2E_WIN_VERIFY_REINSTALL !== '0';
 const verifyUpgradePersistence =

--- a/e2e/tests/packaged/smoke-profile.test.ts
+++ b/e2e/tests/packaged/smoke-profile.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolvePackagedSmokeProfile } from '@/vitest/packaged-smoke-profile';
+
+// The packaged smoke's coverage profile reaches `win.spec.ts` through three
+// layers, and every one of them handles "nothing was chosen" differently:
+//
+//   1. `notify-release-feishu.yml` computes the mode with a `||` chain whose
+//      last arm yields `''` for any branch its special cases do not name.
+//   2. A `workflow_call` `default:` only applies when the input is *omitted*.
+//      Passing `''` is not omission, so the declared `core` default never
+//      fires.
+//   3. `??` falls back only on `null`/`undefined`, so an empty environment
+//      variable survives it.
+//
+// On `release/v0.18.1` that produced `verifyCoreOnly === ('' === 'core')`,
+// i.e. `false`: the run took the `full` path, demanded the updater fixture that
+// only a genuine `full` request wires up, and died before the smoke started —
+// on the branch-cut commit, before anything else had landed there.
+// `release/v0.18.0` hid it because its branch name matched a special case that
+// produced `skip`, so the smoke never ran at all.
+//
+// The invariant these pin: an absent value must never read as a *different*
+// profile. Empty means unset means `core`; anything unrecognised is an error,
+// not a silent "not core".
+describe('packaged smoke profile', () => {
+  it('defaults to core when the workflow passes an empty string', () => {
+    expect(resolvePackagedSmokeProfile('')).toBe('core');
+  });
+
+  it('defaults to core when the variable is unset', () => {
+    expect(resolvePackagedSmokeProfile(undefined)).toBe('core');
+    expect(resolvePackagedSmokeProfile(null)).toBe('core');
+  });
+
+  it('defaults to core when the value is only whitespace', () => {
+    expect(resolvePackagedSmokeProfile('   ')).toBe('core');
+  });
+
+  it('keeps each explicitly requested profile', () => {
+    expect(resolvePackagedSmokeProfile('core')).toBe('core');
+    expect(resolvePackagedSmokeProfile('full')).toBe('full');
+    expect(resolvePackagedSmokeProfile('skip')).toBe('skip');
+  });
+
+  it('trims an accidentally padded value rather than treating it as unknown', () => {
+    expect(resolvePackagedSmokeProfile(' full ')).toBe('full');
+  });
+
+  it('rejects an unrecognised profile instead of letting it read as not-core', () => {
+    // A typo must not quietly select the updater path the way `''` did.
+    expect(() => resolvePackagedSmokeProfile('fulll')).toThrow(/unsupported packaged smoke profile/);
+    expect(() => resolvePackagedSmokeProfile('CORE')).toThrow(/unsupported packaged smoke profile/);
+  });
+
+  it('never resolves an empty value to something that is not core', () => {
+    // The failure mode stated as an invariant: whatever emptiness looks like,
+    // it must not end up selecting a profile that changes what the smoke does.
+    for (const empty of ['', '  ', '\t', '\n', undefined, null]) {
+      expect(resolvePackagedSmokeProfile(empty as string | undefined | null)).toBe('core');
+    }
+  });
+});

--- a/tools/pack/tests/release-workflows.test.ts
+++ b/tools/pack/tests/release-workflows.test.ts
@@ -394,6 +394,28 @@ describe("release workflows", () => {
     expect(stablePrepare).toContain('setOutput("publish_side_effects_enabled"');
   });
 
+  it("never hands a shipping lane an empty windows smoke mode", async () => {
+    const notify = await readFile(
+      new URL("../../../.github/workflows/notify-release-feishu.yml", import.meta.url),
+      "utf8",
+    );
+
+    // A `workflow_call` `default:` applies only when an input is OMITTED, so
+    // forwarding an empty string defeats the declared `core` default. The empty
+    // value then survives `??` in the spec, `smokeProfile === 'core'` is false,
+    // and the run takes the `full` path — which demands an updater fixture only
+    // a genuine `full` request wires up, and dies before the smoke starts.
+    // That is how release/v0.18.1's first prerelease failed on its branch-cut
+    // commit; release/v0.18.0 stayed hidden behind a branch-name special case
+    // that produced `skip`, so its smoke never ran at all.
+    const modeLine = notify
+      .split("\n")
+      .find((line) => line.includes("win_x64_smoke_mode:") && line.includes("inputs.win_x64_smoke_mode"));
+    expect(modeLine, "notify-release-feishu must forward win_x64_smoke_mode").toBeDefined();
+    expect(modeLine).not.toMatch(/\|\|\s*''\s*\}\}/);
+    expect(modeLine).toMatch(/\|\|\s*'core'\s*\}\}/);
+  });
+
   it("bakes both halves of the workspace-team gate into every shipping lane", async () => {
     const [beta, preview, prerelease, stable] = await Promise.all([
       readFile(new URL("../../../.github/workflows/release-beta.yml", import.meta.url), "utf8"),


### PR DESCRIPTION
Direct fix to `release/v0.18.1` because that branch **cannot produce a prerelease at all** without it — three consecutive runs have failed, starting with the branch-cut commit itself, before any other work had landed there.

The same fix is on `main` as #6524 (approved, in CI). This lands here directly rather than waiting for that to merge and backport, following the precedent of #6480 on `release/v0.18.0`.

## The failure

```
Error: full packaged Windows payload smoke requires explicit tools-serve fixture;
       set OD_PACKAGED_E2E_WIN_UPDATE_FIXTURE=tools-serve or provide ...METADATA_URL
```

Nothing requested `full`. An **empty** value became one, across three layers that each treat emptiness differently:

1. `notify-release-feishu.yml` computes the mode with a `||` chain whose last arm is `''` for any branch its special cases do not name. `release/v0.18.0` matches one and gets `skip`; this branch matches none and gets `''`.
2. A `workflow_call` `default:` applies only when an input is **omitted** — passing `''` is not omission, so `release-prerelease.yml`'s declared `default: core` never fired.
3. `??` falls back only on `null`/`undefined`, so the empty environment variable survived into `win.spec.ts`.

`smokeProfile === ''` → `verifyCoreOnly` false → the `full` path → demands the updater fixture only a genuine `full` request wires up → dies before the smoke starts. The Windows job is a hard publish gate, so this blocked every platform's publish and the Feishu card.

Failed on `9d4343e` (branch cut), `dcfb456` (after the win-smoke fix) and `16de575` (after the workspace-scope fix) — identically each time, which is what identifies it as the branch's own defect rather than anything those commits introduced.

## What changed

The workflow's final arm names `core` instead of `''`, and `win.spec.ts` resolves the profile through a new `resolvePackagedSmokeProfile` that treats empty, whitespace and unset alike as `core` and rejects anything unrecognised — a typo must not select the updater path the way `''` did.

Either change alone unblocks the branch; both land because they guard different holes — one stops an empty value being produced, the other stops one being misread.

## Validation

Cherry-picked from the `main` PR, and all five touched files are **byte-identical** to the revision validated there (`sha256` compared per file). On that revision:

- Red first, both layers. The resolver mirrored the old `?? 'core'` verbatim: `5 failed | 2 passed`, the first being *"defaults to core when the workflow passes an empty string"* — the exact production failure. The workflow assertion failed with `expected '…win_x64_smoke_mode: …' not to match /\|\|\s*''\s*\}\}/`.
- Green after: resolver **7 passed**, workflow assertions **5 passed**.
- `pnpm guard` **0** · `pnpm typecheck` **0** · `pnpm -C e2e typecheck` **0**
- `win.spec.ts` loads cleanly with the new import (4 skipped — Windows-only cases)

On this branch: `notify-release-feishu.yml` re-parsed with a YAML loader (valid, job count unchanged), and the resolved line verified to contain `|| 'core' }}` with no `|| '' }}` remaining. The package-scoped test run was not repeated here — the local disk could not hold another `node_modules` — but the inputs are byte-identical to the validated revision.

## After this lands

`release/v0.18.1` will run the Windows smoke at `core` for the first time. That is also the first real exercise of #6481's work, including the open question of whether the protocol cold launch preserves the packaged data root. If it fails there, it now fails with a named cause instead of a 45-second hang, and the fix would belong in the packaged runtime rather than in loosening this check.

## Surface area

- [x] CI / GitHub Actions workflows
- [x] Tests
