### PR TITLE
fix(web): unify Settings connection Test button chrome

### DIFF
--- a/apps/web/src/components/SettingsDialog.tsx
+++ b/apps/web/src/components/SettingsDialog.tsx
@@ -4950,7 +4950,7 @@ export function SettingsDialog({
                                   <button
                                     type="button"
                                     className={
-                                      'ghost icon-btn settings-test-btn agent-card-test-btn' +
+                                      'ghost settings-test-btn agent-card-test-btn' +
                                       (running ? ' loading' : '')
                                     }
                                     onClick={() => void handleTestAgent()}
@@ -5025,7 +5025,7 @@ export function SettingsDialog({
                                         <div className="settings-test-actions-row">
                                           <button
                                             type="button"
-                                            className="ghost icon-btn settings-test-btn"
+                                            className="ghost settings-test-btn"
                                             onClick={() => void handleTestAgent()}
                                           >
                                             <Icon name="reload" size={13} />

--- a/apps/web/src/components/byok/ByokConnectionTestControl.tsx
+++ b/apps/web/src/components/byok/ByokConnectionTestControl.tsx
@@ -76,7 +76,7 @@ export function ByokConnectionTestControl({
         <button
           type="button"
           className={
-            'ghost icon-btn settings-test-btn' +
+            'settings-test-btn' +
             (providerTestState.status === 'running' ? ' loading' : '')
           }
           onClick={() => void onTestProvider()}

--- a/apps/web/src/styles/workspace/artifacts.css
+++ b/apps/web/src/styles/workspace/artifacts.css
@@ -2619,24 +2619,10 @@ button.agent-group-rescan-btn:hover:not(:disabled) {
 .settings-byok-ready {
   color: var(--text-muted);
 }
-.settings-section-byok .settings-test-btn,
-.settings-section-byok .settings-test-btn.loading {
-  border-color: var(--selected);
-  background: var(--selected);
-  color: #fff;
-  box-shadow:
-    0 0 0 3px var(--selected-soft),
-    0 1px 2px color-mix(in srgb, var(--selected) 22%, transparent);
-}
-.settings-section-byok .settings-test-btn:hover:not(:disabled),
-.settings-section-byok .settings-test-btn:focus-visible:not(:disabled) {
-  border-color: color-mix(in srgb, var(--selected) 82%, var(--text-strong));
-  background: color-mix(in srgb, var(--selected) 88%, var(--text-strong));
-  color: #fff;
-}
+/* BYOK "测试" uses the shared outline-pill `.settings-test-btn` chrome
+   (same as Local CLI agent cards). Do not restyle it as a filled primary. */
 .settings-section-byok .settings-test-btn:disabled {
   opacity: 0.72;
-  color: #fff;
 }
 .settings-memory-summary-value {
   color: var(--text-muted);

--- a/apps/web/src/styles/workspace/mention-home.css
+++ b/apps/web/src/styles/workspace/mention-home.css
@@ -2036,12 +2036,29 @@
   flex-wrap: wrap;
   gap: 8px;
 }
-.settings-test-btn {
+/* Text CTA (测试 / 重新测试): outline pill — same chrome as
+   `.agent-card-test-btn` (CLI cards). Not a square `icon-btn`. */
+button.settings-test-btn {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   min-width: 64px;
+  height: 36px;
+  padding: 0 18px;
   justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill, 999px);
+  background: var(--bg-panel);
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 500;
+  box-shadow: none;
+}
+button.settings-test-btn:hover:not(:disabled),
+button.settings-test-btn:focus-visible:not(:disabled) {
+  background: color-mix(in srgb, var(--accent-tint) 58%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+  color: var(--accent-strong);
 }
 .settings-test-btn.loading {
   border-color: var(--accent-soft);


### PR DESCRIPTION
## Why

Settings → Local CLI agent cards and Settings → BYOK both expose a connection **Test** control (`settings.test`), but BYOK was styled as a filled `--selected` primary while CLI cards use the intentional outline pill from the #5517 redesign. After aligning radius, the color mismatch was obvious.

I hit this while reviewing Settings after other home/execution work and wanted the two Test actions to read as one control family.

## What users will see

- BYOK **测试 / Test** matches Local CLI agent-card **Test**: outline pill (panel background, border, 13px/500 weight, same hover tint).
- Dropped the filled selected fill + soft glow on the BYOK Test button.
- Removed the mistaken `icon-btn` class from these text Test buttons (it forced a squarer radius).

## Surface area

- [x] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Compare Settings → execution Local CLI agent card Test vs Settings → BYOK Test after this change — both should be outline pills.

## Bug fix verification

Visual consistency fix (CSS + class cleanup). Verified by inspecting shared semantics (`settings.test` / connection probe) and aligning BYOK to the documented CLI outline-pill spec rather than the older filled override from the artifacts CSS split.

## Validation

- Manual: Settings Local CLI Test + BYOK Test side-by-side on local `tools-dev`
- Style-only change; no new unit tests


Made with [Cursor](https://cursor.com)