### PR TITLE
fix(packaged): fail od:// proxy fast on local resource exhaustion

### DIFF
--- a/apps/packaged/src/protocol.ts
+++ b/apps/packaged/src/protocol.ts
@@ -64,6 +64,47 @@ function toWebRuntimeUrl(webRuntimeUrl: OdProtocolTarget, requestUrl: string): s
 }
 
 const OD_PROXY_RETRYABLE_METHODS = new Set(["GET", "HEAD"]);
+
+/**
+ * Error tokens that mean the LOCAL machine is out of network resources —
+ * sockets, file descriptors, ephemeral ports, kernel buffers. Kept as an
+ * explicit whitelist: everything not listed here retains the proxy's normal
+ * resilience behavior (undici fallback, transient retry).
+ */
+const OD_RESOURCE_EXHAUSTION_ERROR_TOKENS: readonly string[] = [
+  "ERR_INSUFFICIENT_RESOURCES",
+  "EMFILE",
+  "ENFILE",
+  "EADDRNOTAVAIL",
+  "ENOBUFS",
+];
+
+/**
+ * Is this failure the local machine running out of network resources?
+ *
+ * INVARIANT: a request that fails because this machine is out of
+ * sockets/file descriptors must cost exactly ONE upstream attempt. Both of
+ * the proxy's resilience layers amplify load, and when the failure is
+ * exhaustion, amplification is precisely the wrong medicine: in the incident
+ * that motivated this classifier, the undici fallback re-issued every failed
+ * net.fetch (7890 doubled requests measured) and the linear-backoff transient
+ * retry stacked another 1334 attempts on top — each new attempt consuming
+ * exactly the resource the machine had already run out of, and prolonging the
+ * outage it was trying to ride through.
+ *
+ * Matching looks at BOTH `Error.code` and the message because the two fetch
+ * transports report differently: Electron's net.fetch surfaces Chromium
+ * network-stack failures as plain Errors whose message carries the
+ * `net::ERR_...` token while `code` stays unset, whereas Node/undici throws
+ * ErrnoExceptions that carry the token in `code`.
+ */
+function isLocalResourceExhaustionError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  return OD_RESOURCE_EXHAUSTION_ERROR_TOKENS.some(
+    (token) => code === token || error.message.includes(token),
+  );
+}
 const OD_PROXY_RETRY_ATTEMPTS = 3;
 const OD_PROXY_RETRY_BACKOFF_MS = 150; // 150ms, 300ms — throw path only, ~450ms worst-case added
 
@@ -285,6 +326,11 @@ async function fetchOdTargetWithTransientRetry(
       // Retrying a request the client abandoned can only fail again, and each
       // extra attempt is a misleading "proxy fetch failed" line in the log.
       if (isClientCancelled(request)) break;
+      // Resource exhaustion fails fast: every extra attempt consumes exactly
+      // the resource the machine has run out of. ECONNREFUSED is deliberately
+      // NOT in that whitelist — this retry budget is what bridges the daemon
+      // startup race. See isLocalResourceExhaustionError.
+      if (isLocalResourceExhaustionError(error)) break;
       if (attempt === attempts) break;
       const waitMs = backoffMs * attempt;
       // Main-process console output lands in the packaged desktop logs, so
@@ -405,6 +451,12 @@ function resolveOdProxyFetch(): OdProtocolFetch {
       if (!OD_PROXY_RETRYABLE_METHODS.has(request.method) || isClientCancelled(request)) {
         throw error;
       }
+      // The fallback exists to rescue Electron-specific transport rejections
+      // (net::ERR_FAILED on CSS-mask GETs) that undici serves fine. Local
+      // resource exhaustion is not that: undici draws on the same exhausted
+      // machine, so replaying there only doubles the failing load. Rethrow and
+      // let the handler answer 502 at once. See isLocalResourceExhaustionError.
+      if (isLocalResourceExhaustionError(error)) throw error;
       console.warn("[open-design packaged] net.fetch failed; falling back to undici", {
         message: error instanceof Error ? error.message : String(error),
         method: request.method,

--- a/apps/packaged/tests/protocol.test.ts
+++ b/apps/packaged/tests/protocol.test.ts
@@ -500,6 +500,160 @@ describe('od:// proxy client-cancellation is not an upstream failure', () => {
 });
 
 /**
+ * Local resource exhaustion must FAIL FAST — the proxy's two resilience
+ * layers (undici fallback after a net.fetch rejection, linear-backoff
+ * transient retry) both amplify load, and when the failure IS "this machine
+ * is out of sockets/file descriptors", amplification is exactly wrong:
+ * during the incident that motivated this, the undici fallback doubled every
+ * failing request (7890 fallback fetches measured) and the retry loop added
+ * another 1334 attempts on top, each consuming precisely the resource the
+ * machine had run out of.
+ *
+ * Electron's net.fetch surfaces these as plain Errors whose MESSAGE carries
+ * the `net::ERR_...` token while `code` stays unset; Node/undici surfaces
+ * them as ErrnoExceptions with a `code`. Both shapes must be recognized.
+ *
+ * Errors outside the explicit exhaustion whitelist must keep today's
+ * behavior: ECONNREFUSED still buys the full retry budget (it covers the
+ * daemon startup race) and generic net.fetch rejections still fall back to
+ * undici (that fallback rescues real Electron transport regressions such as
+ * CSS-mask GETs).
+ */
+describe('od:// proxy fails fast on local resource exhaustion', () => {
+  beforeEach(() => {
+    vi.mocked(protocol.handle).mockClear();
+    vi.mocked(net.fetch).mockReset();
+  });
+
+  const registeredHandler = (): ((request: Request) => Promise<Response>) => {
+    const calls = vi.mocked(protocol.handle).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    return calls.at(-1)![1] as (request: Request) => Promise<Response>;
+  };
+
+  /** Electron net.fetch shape: token in the message, `code` unset. */
+  const exhaustionByMessage = (): Error => new Error('net::ERR_INSUFFICIENT_RESOURCES');
+
+  /** Node/undici shape: token in `code`. */
+  const exhaustionByCode = (code: string): Error => {
+    const error = new Error(`connect ${code} 127.0.0.1:17579`) as NodeJS.ErrnoException;
+    error.code = code;
+    return error;
+  };
+
+  it('does not double a net::ERR_INSUFFICIENT_RESOURCES failure through the undici fallback', async () => {
+    vi.mocked(net.fetch).mockRejectedValue(exhaustionByMessage());
+    const undiciFetch = vi.fn(async (_input: Request | string | URL) =>
+      new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', undiciFetch);
+
+    registerOdProtocol(() => 'http://127.0.0.1:61424/');
+    const handler = registeredHandler();
+    const response = await handler(new Request('od://app/agent-icons/opencode.svg'));
+
+    // Exhaustion must cost exactly one upstream attempt: no undici double,
+    // no retry amplification, an honest 502 to the renderer.
+    expect(undiciFetch).not.toHaveBeenCalled();
+    expect(vi.mocked(net.fetch)).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(502);
+    const body = (await response.json()) as { error: string; message: string };
+    expect(body.error).toBe('OD_PROTOCOL_PROXY_FAILED');
+    expect(body.message).toContain('ERR_INSUFFICIENT_RESOURCES');
+  });
+
+  it('does not burn the retry budget when only the message carries net::ERR_INSUFFICIENT_RESOURCES', async () => {
+    let calls = 0;
+    const waits: number[] = [];
+    const fetchImpl: typeof fetch = async () => {
+      calls += 1;
+      throw exhaustionByMessage();
+    };
+
+    const response = await handleOdRequest(
+      new Request('od://app/'),
+      'http://127.0.0.1:17579/',
+      fetchImpl,
+      {
+        delay: async (ms: number) => {
+          waits.push(ms);
+        },
+      },
+    );
+
+    expect(calls).toBe(1);
+    expect(waits).toEqual([]);
+    expect(response.status).toBe(502);
+  });
+
+  it.each(['EMFILE', 'ENFILE', 'EADDRNOTAVAIL', 'ENOBUFS'])(
+    'does not burn the retry budget on %s',
+    async (code) => {
+      let calls = 0;
+      const waits: number[] = [];
+      const fetchImpl: typeof fetch = async () => {
+        calls += 1;
+        throw exhaustionByCode(code);
+      };
+
+      const response = await handleOdRequest(
+        new Request('od://app/'),
+        'http://127.0.0.1:17579/',
+        fetchImpl,
+        {
+          delay: async (ms: number) => {
+            waits.push(ms);
+          },
+        },
+      );
+
+      expect(calls).toBe(1);
+      expect(waits).toEqual([]);
+      expect(response.status).toBe(502);
+      const body = (await response.json()) as { code?: string };
+      expect(body.code).toBe(code);
+    },
+  );
+
+  // Guard: ECONNREFUSED is NOT exhaustion — it is the daemon/web sidecar not
+  // being up yet, and the retry budget is exactly what bridges that startup
+  // race. Fast-failing it would regress packaged first-launch.
+  it('still spends the full retry budget on ECONNREFUSED', async () => {
+    let calls = 0;
+    const fetchImpl: typeof fetch = async () => {
+      calls += 1;
+      throw exhaustionByCode('ECONNREFUSED');
+    };
+
+    const response = await handleOdRequest(
+      new Request('od://app/'),
+      'http://127.0.0.1:17579/',
+      fetchImpl,
+      { delay: async () => {} },
+    );
+
+    expect(calls).toBe(3);
+    expect(response.status).toBe(502);
+  });
+
+  // Guard: a generic net.fetch rejection still gets the undici fallback —
+  // that fallback exists because Electron can reject specific renderer-owned
+  // subresource requests (CSS-mask GETs) that undici serves fine.
+  it('still falls back to undici on a generic net::ERR_FAILED', async () => {
+    vi.mocked(net.fetch).mockRejectedValue(new Error('net::ERR_FAILED'));
+    const undiciFetch = vi.fn(async (_input: Request | string | URL) =>
+      new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', undiciFetch);
+
+    registerOdProtocol(() => 'http://127.0.0.1:61424/');
+    const handler = registeredHandler();
+    const response = await handler(new Request('od://app/agent-icons/opencode.svg'));
+
+    expect(response.status).toBe(200);
+    expect(undiciFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
  * The od:// proxy target must be RESOLVED PER REQUEST, never captured as a
  * constant at registration time.
  *


### PR DESCRIPTION
## Why

Follow-up from the #6512 incident (the client meltdown on a 7,442-file project). The diagnostics bundle showed the packaged shell's `od://` proxy actively amplifying the request flood once the machine ran out of sockets: the undici fallback re-issued every failed `net.fetch` (7,890 doubled requests in 23 seconds), and the transient-retry loop burned full linear-backoff budgets on the same dead requests (1,334 more). Local resource exhaustion is not a transient network blip — retrying and double-transporting it makes the exhaustion worse.

## What users will see

Nothing under normal operation. Under local socket/file-descriptor exhaustion, previews now fail fast instead of stacking doubled requests and retries — which keeps the rest of the app (project list, workspace switching) responsive and lets the machine drain sooner.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — failure handling only: errors matching a narrow local-resource-exhaustion allowlist (`ERR_INSUFFICIENT_RESOURCES` / `EMFILE` / `ENFILE` / `EADDRNOTAVAIL` / `ENOBUFS`, matched on both `Error.code` and message to cover Electron's `net::ERR_…` message-only shape) no longer fall back to undici and no longer consume retry budget. Every other error keeps the existing rescue paths untouched — including `ECONNREFUSED`, which deliberately stays retryable because it papers over the daemon-startup race.
- [ ] **None**

## Screenshots

Not applicable — no UI change.

## Bug fix verification

- Test path: `apps/packaged/tests/protocol.test.ts`
- Red on `main`, green on this branch: **yes** — with the spec present and source unmodified, 6 tests fail on the incident behaviors (`expect(undiciFetch).not.toHaveBeenCalled()` → called; `expected 3 to be 1` retry counts for all five exhaustion shapes). Two guard tests (ECONNREFUSED still retries; generic `net::ERR_FAILED` still falls back to undici) are green before and after, by design.

## Validation

- `apps/packaged` protocol tests: 33/33 (exit 0, re-run independently by the reviewer-side check)
- `pnpm --filter @open-design/packaged test`: 22 files / 294 tests green (exit 0)
- packaged typecheck, `pnpm guard`, root `pnpm typecheck`: all exit 0

Refs #6512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
