### PR TITLE
chore(pack): bump Vela CLI to 0.0.30

### DIFF
--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -9,6 +9,6 @@
   # 1. Temporarily set the consuming `hash = lib.fakeHash;`
   # 2. Run the relevant nix build/flake check
   # 3. Copy the expected hash printed by Nix into the matching field below
-  daemonHash = "sha256-YQvGfoSFGgSqdCezSTNrTBIlEpnPFPH04vUzZf5RJc0=";
-  webHash = "sha256-T6z+ZjG/+KOD9qBqO/WguX6F9C+Z1mGdQlDxw/5Ddq0=";
+  daemonHash = "sha256-K3RhFxXga0Lv8trjmYIQo9jdN5jjbJqGCWTjUfrNgZo=";
+  webHash = "sha256-++h2dXIGLZNI9goJjV5mjZAw088M5A8ie9hI8s0KNf4=";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -810,8 +810,8 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       '@powerformer/vela-cli':
-        specifier: 0.0.28
-        version: 0.0.28
+        specifier: 0.0.30
+        version: 0.0.30
 
   tools/release:
     dependencies:
@@ -2053,33 +2053,33 @@ packages:
   '@posthog/types@1.374.2':
     resolution: {integrity: sha512-ZghQSFMi+HFJNPvPjBoyY/jWQ+q6mSQVtWQxOHMSbBidUZjsyYbxYxBFbHy2qWLNe4mEpX+Wqir2Q4I/4AVvJQ==}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.28':
-    resolution: {integrity: sha512-CFJfjaG12xZ8Uw24irvYEe+rRPZiX2I+6MSP/5HN70gcHWz/bJLIuNBU0pVSMK27FETUwdk6r4vki6Wolb9RHQ==}
+  '@powerformer/vela-cli-darwin-arm64@0.0.30':
+    resolution: {integrity: sha512-gL/QyxTXlCffryb2kxb/NA959BSY5RkN6RTrADwA78gUtf8XY5CX5ZiUqnhBudax9HE/UhCNX3u/oAnztO81ZQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@powerformer/vela-cli-darwin-x64@0.0.28':
-    resolution: {integrity: sha512-tAQi3i7w7j0U30XuOeTC7nt6vjfXUK12Uq++7KSL0PxNAtJTbF/Oe5OydsVKS9MHEFw/s1AnuHc2DG0RWcpEwg==}
+  '@powerformer/vela-cli-darwin-x64@0.0.30':
+    resolution: {integrity: sha512-w/sXJQfTzUe9er6jjA1EhFprExFD5tWr/hsCP6ypytRmj2pZ74lL4GX+4xn4tpKYt1IECD7qwPTEtZmLtSJm/w==}
     cpu: [x64]
     os: [darwin]
 
-  '@powerformer/vela-cli-linux-arm64@0.0.28':
-    resolution: {integrity: sha512-cRo4iIWBYRx9LYD2v5MdccgyU0Pqa0uNrdfGqgGsPqznY+CQPEuxOkpQiFOomH8l8waHYBsbkpUE/JtkqVWBUA==}
+  '@powerformer/vela-cli-linux-arm64@0.0.30':
+    resolution: {integrity: sha512-j5cq+oEQmx4pH27GSDEcfEcXkuJN9btoR8gAmvlzdRpbOvO880nfe7CnhOy4AeuauWzEo2OshtF0jhQz6nSe7g==}
     cpu: [arm64]
     os: [linux]
 
-  '@powerformer/vela-cli-linux-x64@0.0.28':
-    resolution: {integrity: sha512-+b6CykVp82WIAC7vkQTEmcU5cQ8Am9C1cZh7CblHHTTD7Y7C+JTYEEQgoPlD2iu59UJr9RjIkWF9PsDcgaMR/A==}
+  '@powerformer/vela-cli-linux-x64@0.0.30':
+    resolution: {integrity: sha512-3ToVOdrfyktPWorwzqhJW+WssivVsjaz2Q0Lw5v78JwayBDC8uV8AsW+aTTlN88ZZ6QohcnjFhCAJaIDDeNySw==}
     cpu: [x64]
     os: [linux]
 
-  '@powerformer/vela-cli-win32-x64@0.0.28':
-    resolution: {integrity: sha512-jc/SCPViA4Uiktzae2XboHCl77V5FKbMzCIf2Dt0o7K0zlz3Kl2kbWVvBzm/0QDUKtzzrNIPliC9Wa+vVUQplA==}
+  '@powerformer/vela-cli-win32-x64@0.0.30':
+    resolution: {integrity: sha512-dGbCa1B3VIvr+izqmQ96J8Em7K/UX5XEGyiY/TG6xVSuKWJrypclNLp3IJVKuItWm8TnUMHchxpUm8RObJ77hw==}
     cpu: [x64]
     os: [win32]
 
-  '@powerformer/vela-cli@0.0.28':
-    resolution: {integrity: sha512-CZRKK/e/jm63cxM/DqxiegmzWil2od6q1aNmTRq3WCjDz8vTSby72qzD9R4akILLK7oOMXe99t7mOfzySTKlCQ==}
+  '@powerformer/vela-cli@0.0.30':
+    resolution: {integrity: sha512-m27DcfZ4GsDzmh7/rL/btZ56kydfVUrYoy5qqcdL3Z0trVu3HxhvFrlR2kd0pDb6fS10FaVix7YESxgpubkwMg==}
     hasBin: true
 
   '@preact/signals-core@1.14.2':
@@ -7911,28 +7911,28 @@ snapshots:
 
   '@posthog/types@1.374.2': {}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.28':
+  '@powerformer/vela-cli-darwin-arm64@0.0.30':
     optional: true
 
-  '@powerformer/vela-cli-darwin-x64@0.0.28':
+  '@powerformer/vela-cli-darwin-x64@0.0.30':
     optional: true
 
-  '@powerformer/vela-cli-linux-arm64@0.0.28':
+  '@powerformer/vela-cli-linux-arm64@0.0.30':
     optional: true
 
-  '@powerformer/vela-cli-linux-x64@0.0.28':
+  '@powerformer/vela-cli-linux-x64@0.0.30':
     optional: true
 
-  '@powerformer/vela-cli-win32-x64@0.0.28':
+  '@powerformer/vela-cli-win32-x64@0.0.30':
     optional: true
 
-  '@powerformer/vela-cli@0.0.28':
+  '@powerformer/vela-cli@0.0.30':
     optionalDependencies:
-      '@powerformer/vela-cli-darwin-arm64': 0.0.28
-      '@powerformer/vela-cli-darwin-x64': 0.0.28
-      '@powerformer/vela-cli-linux-arm64': 0.0.28
-      '@powerformer/vela-cli-linux-x64': 0.0.28
-      '@powerformer/vela-cli-win32-x64': 0.0.28
+      '@powerformer/vela-cli-darwin-arm64': 0.0.30
+      '@powerformer/vela-cli-darwin-x64': 0.0.30
+      '@powerformer/vela-cli-linux-arm64': 0.0.30
+      '@powerformer/vela-cli-linux-x64': 0.0.30
+      '@powerformer/vela-cli-win32-x64': 0.0.30
     optional: true
 
   '@preact/signals-core@1.14.2': {}

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -25,7 +25,7 @@
     "resedit": "1.7.2"
   },
   "optionalDependencies": {
-    "@powerformer/vela-cli": "0.0.28"
+    "@powerformer/vela-cli": "0.0.30"
   },
   "devDependencies": {
     "@types/node": "24.12.2",


### PR DESCRIPTION
## Why

The Vela CLI release workflow [31089265752](https://github.com/powerformer/vela/actions/runs/31089265752) completed successfully and published `0.0.30`. Update the packaged tools dependency to consume that release.

## What users will see

Packaged Open Design builds resolve Vela CLI `0.0.30`.

## Surface area

- [x] **None** — dependency metadata and lockfile only.

## Validation

- `pnpm install`
- `pnpm --dir tools/pack exec vitest run tests/resources.test.ts tests/release-workflows.test.ts tests/config.test.ts tests/win-resources.test.ts` — 48 passed
- `pnpm --filter @open-design/tools-pack typecheck`
- `pnpm --filter @open-design/tools-pack build`
- `pnpm --dir tools/pack exec vela --version` — `0.0.30`
- `pnpm typecheck`
- `pnpm guard` — pre-existing failure: missing `apps/telemetry-worker/package.json` and residual landing-page JavaScript allowlist findings.