### PR TITLE
ci: add Blacksmith runner mode

### DIFF
--- a/.github/scripts/runners.py
+++ b/.github/scripts/runners.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 GITHUB_HOSTED = ["ubuntu-24.04"]
 WINDOWS_HOSTED = ["windows-latest"]
+BLACKSMITH_4VCPU = ["blacksmith-4vcpu-ubuntu-2404"]
+BLACKSMITH_8VCPU = ["blacksmith-8vcpu-ubuntu-2404"]
 NEXU_SMALL = ["nexu-runners-small"]
 NEXU_MEDIUM = ["nexu-runners-medium"]
 NEXU_LARGE = ["nexu-runners-large"]
@@ -19,18 +21,29 @@ def compact_json(value):
 
 def normalize_mode(raw_mode):
     mode = raw_mode or "default"
-    if mode in {"default", "performance", "economic"}:
+    if mode in {"default", "performance", "economic", "blacksmith"}:
         return mode
     return "default"
 
 
 def resolve_contract(mode):
-    control = GITHUB_HOSTED if mode == "economic" else NEXU_SMALL
-    workload = GITHUB_HOSTED if mode == "economic" else NEXU_MEDIUM
-    browser_workload = GITHUB_HOSTED if mode == "economic" else NEXU_LARGE
-    # UI P0 is the memory-heavy Playwright domain suite; prefer the dedicated
-    # xlarge class once available so large remains headroom for lighter UI jobs.
-    ui_p0_workload = GITHUB_HOSTED if mode == "economic" else NEXU_XLARGE
+    if mode == "economic":
+        control = GITHUB_HOSTED
+        workload = GITHUB_HOSTED
+        browser_workload = GITHUB_HOSTED
+        ui_p0_workload = GITHUB_HOSTED
+    elif mode == "blacksmith":
+        control = BLACKSMITH_4VCPU
+        workload = BLACKSMITH_4VCPU
+        browser_workload = BLACKSMITH_8VCPU
+        ui_p0_workload = BLACKSMITH_8VCPU
+    else:
+        control = NEXU_SMALL
+        workload = NEXU_MEDIUM
+        browser_workload = NEXU_LARGE
+        # UI P0 is the memory-heavy Playwright domain suite; prefer the
+        # dedicated xlarge class so large remains headroom for lighter UI jobs.
+        ui_p0_workload = NEXU_XLARGE
 
     return {
         "runs_on": {

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1385,6 +1385,18 @@ process.stdin.on("end", () => {
     expect(performanceRunsOn.ui_p0).toEqual(["nexu-runners-xlarge"]);
     expect(performanceRunsOn.visual_hot).toEqual(["nexu-runners-large"]);
 
+    const blacksmithProfiles = await runRunners("blacksmith");
+    const blacksmithRunsOn = runnerRunsOn(blacksmithProfiles);
+    expect(runnerDecision(blacksmithProfiles)).toEqual({ schema_version: 1, mode: "blacksmith" });
+    expect(blacksmithRunsOn.control).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
+    expect(blacksmithRunsOn.general_medium).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
+    expect(blacksmithRunsOn.workspace_unit).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
+    expect(blacksmithRunsOn.windows_tools).toEqual(["windows-latest"]);
+    expect(blacksmithRunsOn.js_hot).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
+    expect(blacksmithRunsOn.ui_hot).toEqual(["blacksmith-8vcpu-ubuntu-2404"]);
+    expect(blacksmithRunsOn.ui_p0).toEqual(["blacksmith-8vcpu-ubuntu-2404"]);
+    expect(blacksmithRunsOn.visual_hot).toEqual(["blacksmith-8vcpu-ubuntu-2404"]);
+
     const economicProfiles = await runRunners("economic");
     const economicRunsOn = runnerRunsOn(economicProfiles);
     expect(runnerDecision(economicProfiles)).toEqual({ schema_version: 1, mode: "economic" });


### PR DESCRIPTION
## Why

CI maintainers need an explicit way to route the primary Linux workload to Blacksmith without overloading the existing `performance` mode, which remains the Nexu ARC self-hosted profile. Keeping these provider-oriented names separate lets the team switch capacity pragmatically now while leaving broader runner-policy normalization for later.

Previously, `performance` was the only non-economic alternate mode and could not express a Blacksmith-backed workload without changing its ARC semantics.

## What users will see

No product UI or runtime behavior changes. CI maintainers can set `OD_CI_RUNNER_MODE=blacksmith` to select Blacksmith 4-vCPU runners for control/general/JS work and 8-vCPU runners for browser, UI P0, and visual work. Windows remains GitHub-hosted, and the runner-resolution bootstrap remains on its existing path.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this changes internal CI runner selection only.

## Bug fix verification

Not applicable; this is an additive CI mode.

## Validation

- `pnpm --filter @open-design/e2e test tests/packaged-smoke-workflow.test.ts` (58 tests)
- `pnpm guard`
- `pnpm typecheck`
- `actionlint -color`
- `git diff --check`
