### PR TITLE
fix(daemon): reconcile unbound legacy plugins into the authenticated workspace

### DIFF
--- a/apps/daemon/src/plugins/registry.ts
+++ b/apps/daemon/src/plugins/registry.ts
@@ -32,7 +32,7 @@ import type {
   TrustTier,
 } from '@open-design/contracts';
 import { defaultTrustForRecord, resolveCapabilitiesGranted } from './trust.js';
-import { getWorkspaceResourceByResourceId } from '../db.js';
+import { ensureWorkspaceResource, getWorkspaceResourceByResourceId } from '../db.js';
 import type Database from 'better-sqlite3';
 
 type SqliteDb = Database.Database;
@@ -274,6 +274,55 @@ function pluginVisibleFromWorkspace(
   const creatorId = binding?.createdByWorkspaceMemberId?.trim();
   const callerId = workspaceMemberId?.trim();
   return Boolean(creatorId && callerId && creatorId === callerId);
+}
+
+/**
+ * Adopt legacy pre-workspace-isolation plugins into the requesting Workspace.
+ *
+ * Plugins installed before the `workspace_resources` table existed (#6528)
+ * have no binding row, so `pluginVisibleFromWorkspace` quarantines them from
+ * every explicit Workspace and they silently vanish from the UI after the
+ * upgrade. This reconciler runs on demand from `GET /api/plugins` AFTER
+ * `resolveWorkspaceAuthority` has verified the caller, and claims each
+ * still-unbound user plugin as a Personal resource created by the
+ * authenticated member — the same rows a fresh install would have written.
+ *
+ * Deliberate constraints:
+ * - Requires BOTH a verified workspace id and member id: adoption is an
+ *   ownership claim, so an unauthenticated or headerless caller never
+ *   triggers it (the "no caller may adopt legacy bytes merely by viewing
+ *   them" rule in `pluginVisibleFromWorkspace` still holds for them).
+ * - `bundled` plugins stay global and are never bound.
+ * - Team materializations (`team:plugin:` sources) are managed by the hub
+ *   reconciliation path and are skipped here.
+ * - Idempotent: `ensureWorkspaceResource` keys on `(resource_type,
+ *   resource_id)`, so a plugin already bound anywhere — including to another
+ *   Workspace on a multi-workspace machine — is left untouched.
+ */
+export function reconcileUnboundUserPluginsForWorkspace(
+  db: SqliteDb,
+  workspaceId: string | null | undefined,
+  workspaceMemberId: string | null | undefined,
+): number {
+  const scopeId = workspaceId?.trim();
+  const memberId = workspaceMemberId?.trim();
+  if (!scopeId || !memberId) return 0;
+  const rows = db.prepare(`SELECT * FROM installed_plugins`).all() as DbRow[];
+  let adopted = 0;
+  for (const row of rows) {
+    const record = rowToInstalledPlugin(row);
+    if (record.sourceKind === 'bundled') continue;
+    if (typeof record.source === 'string' && record.source.startsWith('team:plugin:')) continue;
+    const binding = getWorkspaceResourceByResourceId(db, 'plugin', record.id);
+    if (binding) continue;
+    ensureWorkspaceResource(db, 'plugin', scopeId, record.id, {
+      visibility: 'personal',
+      resourceState: 'active',
+      createdByWorkspaceMemberId: memberId,
+    });
+    adopted += 1;
+  }
+  return adopted;
 }
 
 /**

--- a/apps/daemon/src/plugins/registry.ts
+++ b/apps/daemon/src/plugins/registry.ts
@@ -32,7 +32,8 @@ import type {
   TrustTier,
 } from '@open-design/contracts';
 import { defaultTrustForRecord, resolveCapabilitiesGranted } from './trust.js';
-import { ensureWorkspaceResource, getWorkspaceResourceByResourceId } from '../db.js';
+import { getWorkspaceResourceByResourceId } from '../db.js';
+import { reconcileWorkspaceResourceBindings } from '../workspace-resource-reconciliation.js';
 import type Database from 'better-sqlite3';
 
 type SqliteDb = Database.Database;
@@ -298,31 +299,30 @@ function pluginVisibleFromWorkspace(
  * - Idempotent: `ensureWorkspaceResource` keys on `(resource_type,
  *   resource_id)`, so a plugin already bound anywhere — including to another
  *   Workspace on a multi-workspace machine — is left untouched.
+ *
+ * Returns the number of rows written (bindings created + creatorless bindings
+ * repaired). See `workspace-resource-reconciliation.ts` for the shared
+ * implementation used by the skill and design-system catalogs.
  */
 export function reconcileUnboundUserPluginsForWorkspace(
   db: SqliteDb,
   workspaceId: string | null | undefined,
   workspaceMemberId: string | null | undefined,
 ): number {
-  const scopeId = workspaceId?.trim();
-  const memberId = workspaceMemberId?.trim();
-  if (!scopeId || !memberId) return 0;
   const rows = db.prepare(`SELECT * FROM installed_plugins`).all() as DbRow[];
-  let adopted = 0;
-  for (const row of rows) {
-    const record = rowToInstalledPlugin(row);
-    if (record.sourceKind === 'bundled') continue;
-    if (typeof record.source === 'string' && record.source.startsWith('team:plugin:')) continue;
-    const binding = getWorkspaceResourceByResourceId(db, 'plugin', record.id);
-    if (binding) continue;
-    ensureWorkspaceResource(db, 'plugin', scopeId, record.id, {
-      visibility: 'personal',
-      resourceState: 'active',
-      createdByWorkspaceMemberId: memberId,
-    });
-    adopted += 1;
-  }
-  return adopted;
+  const resourceIds = rows
+    .map(rowToInstalledPlugin)
+    .filter((record) => record.sourceKind !== 'bundled')
+    // Team materializations are managed by the hub reconciliation path.
+    .filter((record) => !(typeof record.source === 'string' && record.source.startsWith('team:plugin:')))
+    .map((record) => record.id);
+  const { adopted, repaired } = reconcileWorkspaceResourceBindings(db, {
+    resourceType: 'plugin',
+    resourceIds,
+    workspaceId,
+    workspaceMemberId,
+  });
+  return adopted + repaired;
 }
 
 /**

--- a/apps/daemon/src/routes/plugins/index.ts
+++ b/apps/daemon/src/routes/plugins/index.ts
@@ -434,7 +434,40 @@ export function registerPluginRoutes(app: Express, deps: RegisterPluginRoutesDep
     return binding.visibility === 'team'
       || binding.createdByWorkspaceMemberId === authority.workspaceMemberId;
   };
-  app.get('/api/plugins', async (req, res) => { try { const authority = await resolveWorkspaceAuthority(req, res); if (authority === undefined) return; if (authority?.workspaceId && authority.workspaceMemberId) { plugins.reconcileUnboundUserPlugins?.(db, authority.workspaceId, authority.workspaceMemberId); } const visible = await plugins.listInstalledPlugins(db, authority?.workspaceId ?? null, authority?.workspaceMemberId ?? null); res.json({ plugins: helpers.applyBakedPreviews(visible, helpers.PLUGIN_PREVIEWS_DIR) }); } catch (err) { res.status(500).json({ error: String(err) }); } });
+  app.get('/api/plugins', async (req, res) => { try { const authority = await resolveWorkspaceAuthority(req, res); if (authority === undefined) return; const visible = await plugins.listInstalledPlugins(db, authority?.workspaceId ?? null, authority?.workspaceMemberId ?? null); res.json({ plugins: helpers.applyBakedPreviews(visible, helpers.PLUGIN_PREVIEWS_DIR) }); } catch (err) { res.status(500).json({ error: String(err) }); } });
+
+  /**
+   * Explicit #6528 recovery: adopt legacy unbound plugins into the caller's
+   * Workspace. Deliberately a POST the user triggers, NOT a side effect of
+   * `GET /api/plugins` — passive adoption would contradict the isolation rule
+   * that `pluginVisibleFromWorkspace` documents and that
+   * `plugins-workspace-scope.test.ts` asserts ("quarantines an unbound user
+   * plugin from every explicit workspace"), and on a multi-workspace machine
+   * it would hand every legacy resource to whichever Workspace happened to
+   * load its catalog first.
+   */
+  app.post('/api/plugins/reconcile-workspace-bindings', async (req, res) => {
+    try {
+      const authority = await resolveWorkspaceAuthority(req, res);
+      if (authority === undefined) return;
+      if (!authority?.workspaceId || !authority.workspaceMemberId) {
+        return helpers.sendApiError(
+          res,
+          403,
+          'WORKSPACE_AUTHORITY_REQUIRED',
+          'a verified workspace member is required to adopt legacy resources',
+        );
+      }
+      const reconciled = plugins.reconcileUnboundUserPlugins?.(
+        db,
+        authority.workspaceId,
+        authority.workspaceMemberId,
+      ) ?? 0;
+      res.json({ reconciled });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
   // Keep this static route before /api/plugins/:id; Express matches in
   // registration order and would otherwise interpret "stats" as a plugin id.
   app.get('/api/plugins/stats', async (req, res) => {

--- a/apps/daemon/src/routes/plugins/index.ts
+++ b/apps/daemon/src/routes/plugins/index.ts
@@ -228,6 +228,11 @@ export interface RegisterPluginRoutesDeps {
       workspaceMemberId?: string | null,
     ) => InstalledPluginLike[] | Promise<InstalledPluginLike[]>;
     getInstalledPlugin: (db: SqliteDbLike, id: string) => InstalledPluginLike | null;
+    reconcileUnboundUserPlugins?: (
+      db: SqliteDbLike,
+      workspaceId: string | null | undefined,
+      workspaceMemberId: string | null | undefined,
+    ) => number;
     getWorkspacePlugin?: (
       db: SqliteDbLike,
       id: string,
@@ -429,7 +434,7 @@ export function registerPluginRoutes(app: Express, deps: RegisterPluginRoutesDep
     return binding.visibility === 'team'
       || binding.createdByWorkspaceMemberId === authority.workspaceMemberId;
   };
-  app.get('/api/plugins', async (req, res) => { try { const authority = await resolveWorkspaceAuthority(req, res); if (authority === undefined) return; const visible = await plugins.listInstalledPlugins(db, authority?.workspaceId ?? null, authority?.workspaceMemberId ?? null); res.json({ plugins: helpers.applyBakedPreviews(visible, helpers.PLUGIN_PREVIEWS_DIR) }); } catch (err) { res.status(500).json({ error: String(err) }); } });
+  app.get('/api/plugins', async (req, res) => { try { const authority = await resolveWorkspaceAuthority(req, res); if (authority === undefined) return; if (authority?.workspaceId && authority.workspaceMemberId) { plugins.reconcileUnboundUserPlugins?.(db, authority.workspaceId, authority.workspaceMemberId); } const visible = await plugins.listInstalledPlugins(db, authority?.workspaceId ?? null, authority?.workspaceMemberId ?? null); res.json({ plugins: helpers.applyBakedPreviews(visible, helpers.PLUGIN_PREVIEWS_DIR) }); } catch (err) { res.status(500).json({ error: String(err) }); } });
   // Keep this static route before /api/plugins/:id; Express matches in
   // registration order and would otherwise interpret "stats" as a plugin id.
   app.get('/api/plugins/stats', async (req, res) => {

--- a/apps/daemon/src/routes/static-resource.ts
+++ b/apps/daemon/src/routes/static-resource.ts
@@ -30,6 +30,7 @@ import {
   getWorkspaceResource,
   getWorkspaceResourceByResourceId,
 } from '../db.js';
+import { reconcileWorkspaceResourceBindings } from '../workspace-resource-reconciliation.js';
 import {
   enforceVerifiedWorkspaceResourceMutation,
   resolveOptionalWorkspaceRequestAuthority,
@@ -475,6 +476,62 @@ export function registerStaticResourceRoutes(app: Express, ctx: RegisterStaticRe
       }
     } finally {
       res.end();
+    }
+  });
+
+  /**
+   * Explicit #6528 recovery for the static-resource catalogs.
+   *
+   * Adopts legacy user skills and design systems that carry no
+   * `workspace_resources` binding, and repairs Personal bindings a writer
+   * left with an empty creator (unreachable by every member, since the
+   * personal branch of each visibility check requires an exact creator match).
+   *
+   * Deliberately a POST the user triggers rather than a side effect of the
+   * GET catalogs: passive adoption would contradict the quarantine rule those
+   * catalogs document — and that `skills-workspace-scope.test.ts` asserts in
+   * "quarantines an unclaimed user skill from every explicit workspace" — and
+   * on a multi-workspace machine it would silently hand every legacy resource
+   * to whichever Workspace loaded its catalog first.
+   */
+  app.post('/api/workspace/reconcile-resource-bindings', async (req, res) => {
+    try {
+      const authority = await resolveWorkspaceAuthority(req, res);
+      if (authority === undefined) return;
+      const workspaceId = authority?.workspaceId?.trim();
+      const workspaceMemberId = authority?.workspaceMemberId?.trim();
+      if (!workspaceId || !workspaceMemberId) {
+        return sendApiError(
+          res,
+          403,
+          'WORKSPACE_AUTHORITY_REQUIRED',
+          'a verified workspace member is required to adopt legacy resources',
+        );
+      }
+
+      const userSkills = await listSkills(USER_SKILLS_DIR);
+      const skills = reconcileWorkspaceResourceBindings(db, {
+        resourceType: 'skill',
+        resourceIds: userSkills.map((skill) => skill.id),
+        workspaceId,
+        workspaceMemberId,
+      });
+
+      // Unscoped (workspaceId omitted entirely) so the pre-adoption view still
+      // contains the quarantined systems this endpoint exists to recover.
+      const allSystems = await listAllDesignSystems({});
+      const designSystems = reconcileWorkspaceResourceBindings(db, {
+        resourceType: 'design_system',
+        resourceIds: allSystems
+          .filter((system) => system.source === 'user' && system.teamSynced !== true)
+          .map((system) => system.id),
+        workspaceId,
+        workspaceMemberId,
+      });
+
+      res.json({ skills, designSystems });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
     }
   });
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -392,6 +392,7 @@ import {
   resolveAndActivateWorkspaceTeamPlugin,
   resolvePluginFolder,
   resolveWorkspaceTeamPluginWithBindingGate,
+  reconcileUnboundUserPluginsForWorkspace,
   workspaceTeamPluginBindingActivationFence,
   workspaceTeamPluginBindingAllowsRead,
   workspaceTeamPluginBindingResourceId,
@@ -7913,6 +7914,7 @@ export async function startServer({
     plugins: {
       listInstalledPlugins: listWorkspacePlugins,
       getInstalledPlugin,
+      reconcileUnboundUserPlugins: reconcileUnboundUserPluginsForWorkspace,
       getWorkspacePlugin: getWorkspacePluginForRequest,
       installPlugin,
       isSafePluginId,

--- a/apps/daemon/src/workspace-resource-reconciliation.ts
+++ b/apps/daemon/src/workspace-resource-reconciliation.ts
@@ -1,0 +1,125 @@
+// Recovery lane for resources that predate workspace isolation (#6528).
+//
+// `pluginVisibleFromWorkspace`, `skillVisibleFromBinding` and the user half of
+// `listAllDesignSystems` all quarantine a user resource that has no
+// `workspace_resources` binding: absence of an ownership witness must not
+// authorize a cross-workspace read. Resources installed before the binding
+// table existed therefore vanish from every explicit Workspace after an
+// upgrade, even though their bytes are intact on disk.
+//
+// The reconcilers below are the ONE sanctioned adoption path. They run on
+// demand from the catalog routes AFTER the caller's Workspace authority has
+// been verified, and claim each still-unbound resource as a Personal binding
+// created by the authenticated member — exactly the row a fresh install
+// writes. Callers that are unauthenticated, headerless, or missing either
+// half of the identity adopt nothing, so "no caller may adopt legacy bytes
+// merely by viewing them" continues to hold for them.
+
+import { ensureWorkspaceResource, getWorkspaceResourceByResourceId, updateWorkspaceResource } from './db.js';
+import type Database from 'better-sqlite3';
+
+type SqliteDb = Database.Database;
+
+export interface ReconcileUnboundResourcesInput {
+  /** `workspace_resources.resource_type`, e.g. `'plugin'`. */
+  resourceType: string;
+  /** Candidate resource ids, already filtered to USER-owned resources. */
+  resourceIds: Iterable<string>;
+  workspaceId: string | null | undefined;
+  workspaceMemberId: string | null | undefined;
+}
+
+/**
+ * Bind every still-unbound id to `workspaceId` as a Personal resource created
+ * by `workspaceMemberId`. Returns how many bindings were written.
+ *
+ * Idempotent by construction: `ensureWorkspaceResource` is keyed on
+ * `(resource_type, resource_id)`, so a resource already bound ANYWHERE —
+ * including to another Workspace on a multi-workspace machine, and including
+ * a `resource_state: 'deleted'` tombstone — is returned as-is and left
+ * untouched. A tombstone stays terminal.
+ */
+export function reconcileUnboundResources(
+  db: SqliteDb,
+  input: ReconcileUnboundResourcesInput,
+): number {
+  const scopeId = input.workspaceId?.trim();
+  const memberId = input.workspaceMemberId?.trim();
+  if (!scopeId || !memberId) return 0;
+  let adopted = 0;
+  for (const rawId of input.resourceIds) {
+    const resourceId = typeof rawId === 'string' ? rawId.trim() : '';
+    if (!resourceId) continue;
+    if (getWorkspaceResourceByResourceId(db, input.resourceType, resourceId)) continue;
+    ensureWorkspaceResource(db, input.resourceType, scopeId, resourceId, {
+      visibility: 'personal',
+      resourceState: 'active',
+      createdByWorkspaceMemberId: memberId,
+    });
+    adopted += 1;
+  }
+  return adopted;
+}
+
+/**
+ * Repair Personal bindings that already belong to this Workspace but carry no
+ * creator.
+ *
+ * A `visibility: 'personal'` row with a NULL/empty
+ * `created_by_workspace_member_id` is unreachable by EVERY member, because the
+ * personal branch of each visibility check ends in
+ * `Boolean(creatorId && callerId && creatorId === callerId)` — an empty
+ * `creatorId` can never match. Observed in the wild on a 0.18.0 install whose
+ * design system was invisible under "Your systems" despite a correct
+ * `workspace_id`, `visibility` and `resource_state`.
+ *
+ * Scope is deliberately narrow: only rows ALREADY bound to the caller's exact
+ * Workspace, still `personal`, not tombstoned, and with no creator at all.
+ * Ownership is never transferred between members — an empty creator is not a
+ * meaningful value, so there is no prior owner to displace. Rows bound to
+ * another Workspace, Team rows, and tombstones are untouched.
+ *
+ * Kept separate from {@link reconcileUnboundResources} so a reviewer can adopt
+ * the two behaviors independently: one binds missing rows, this one repairs
+ * rows that a writer left in a terminal state.
+ */
+export function repairCreatorlessPersonalBindings(
+  db: SqliteDb,
+  input: ReconcileUnboundResourcesInput,
+): number {
+  const scopeId = input.workspaceId?.trim();
+  const memberId = input.workspaceMemberId?.trim();
+  if (!scopeId || !memberId) return 0;
+  let repaired = 0;
+  for (const rawId of input.resourceIds) {
+    const resourceId = typeof rawId === 'string' ? rawId.trim() : '';
+    if (!resourceId) continue;
+    const binding = getWorkspaceResourceByResourceId(db, input.resourceType, resourceId);
+    if (!binding) continue;
+    if (binding.workspaceId !== scopeId) continue;
+    if (binding.visibility !== 'personal') continue;
+    if (binding.resourceState === 'deleted') continue;
+    const creatorId = typeof binding.createdByWorkspaceMemberId === 'string'
+      ? binding.createdByWorkspaceMemberId.trim()
+      : '';
+    if (creatorId) continue;
+    updateWorkspaceResource(db, input.resourceType, scopeId, resourceId, {
+      createdByWorkspaceMemberId: memberId,
+      updatedByWorkspaceMemberId: memberId,
+    });
+    repaired += 1;
+  }
+  return repaired;
+}
+
+/** Convenience wrapper: bind missing rows, then repair creatorless ones. */
+export function reconcileWorkspaceResourceBindings(
+  db: SqliteDb,
+  input: ReconcileUnboundResourcesInput,
+): { adopted: number; repaired: number } {
+  const ids = Array.from(input.resourceIds);
+  return {
+    adopted: reconcileUnboundResources(db, { ...input, resourceIds: ids }),
+    repaired: repairCreatorlessPersonalBindings(db, { ...input, resourceIds: ids }),
+  };
+}

--- a/apps/daemon/tests/plugins-workspace-reconciliation.test.ts
+++ b/apps/daemon/tests/plugins-workspace-reconciliation.test.ts
@@ -1,0 +1,143 @@
+// `reconcileUnboundUserPluginsForWorkspace` (registry.ts): the #6528 recovery
+// lane. Plugins installed before workspace isolation shipped have no
+// `workspace_resources` row, so every explicit-workspace read quarantines
+// them ("no caller may adopt legacy bytes merely by viewing them"). The
+// reconciler is the ONE sanctioned adoption path: it runs from
+// `GET /api/plugins` after `resolveWorkspaceAuthority` verified the caller,
+// and claims still-unbound user plugins as Personal resources created by the
+// authenticated member — the same rows a fresh install would have written.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  closeDatabase,
+  ensureWorkspaceResource,
+  getWorkspaceResourceByResourceId,
+  openDatabase,
+  updateWorkspaceResource,
+} from '../src/db.js';
+import {
+  listInstalledPlugins,
+  reconcileUnboundUserPluginsForWorkspace,
+  upsertInstalledPlugin,
+} from '../src/plugins/registry.js';
+import type { InstalledPluginRecord } from '@open-design/contracts';
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), 'od-plugins-workspace-reconcile-'));
+});
+
+afterEach(() => {
+  closeDatabase();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function fakePlugin(
+  id: string,
+  sourceKind: InstalledPluginRecord['sourceKind'] = 'local',
+  source?: string,
+): InstalledPluginRecord {
+  const now = Date.now();
+  return {
+    id,
+    title: id,
+    version: '1.0.0',
+    sourceKind,
+    source: source ?? '/tmp/' + id,
+    trust: 'trusted',
+    capabilitiesGranted: [],
+    manifest: { name: id, title: id, version: '1.0.0' } as InstalledPluginRecord['manifest'],
+    fsPath: '/tmp/' + id,
+    installedAt: now,
+    updatedAt: now,
+  };
+}
+
+describe('reconcileUnboundUserPluginsForWorkspace', () => {
+  it('adopts an unbound legacy user plugin as a Personal resource of the authenticated member', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    upsertInstalledPlugin(db, fakePlugin('plugin-legacy'));
+
+    // Pre-reconciliation: quarantined from the explicit workspace (#6528).
+    expect(listInstalledPlugins(db, 'ws-1', 'member-a').map((p) => p.id)).not.toContain('plugin-legacy');
+
+    const adopted = reconcileUnboundUserPluginsForWorkspace(db, 'ws-1', 'member-a');
+    expect(adopted).toBe(1);
+
+    const binding = getWorkspaceResourceByResourceId(db, 'plugin', 'plugin-legacy');
+    expect(binding?.workspaceId).toBe('ws-1');
+    expect(binding?.visibility).toBe('personal');
+    expect(binding?.createdByWorkspaceMemberId).toBe('member-a');
+    expect(binding?.resourceState).toBe('active');
+
+    // Post-reconciliation: visible to its adopter, still hidden from others —
+    // the personal-visibility rules from `pluginVisibleFromWorkspace` apply
+    // to the adopted binding exactly as they would to a fresh install.
+    expect(listInstalledPlugins(db, 'ws-1', 'member-a').map((p) => p.id)).toContain('plugin-legacy');
+    expect(listInstalledPlugins(db, 'ws-1', 'member-other').map((p) => p.id)).not.toContain('plugin-legacy');
+    expect(listInstalledPlugins(db, 'ws-2', 'member-b').map((p) => p.id)).not.toContain('plugin-legacy');
+  });
+
+  it('is idempotent and never re-claims a plugin already bound anywhere', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    upsertInstalledPlugin(db, fakePlugin('plugin-legacy'));
+
+    expect(reconcileUnboundUserPluginsForWorkspace(db, 'ws-1', 'member-a')).toBe(1);
+    // Same workspace, same member: nothing left to adopt.
+    expect(reconcileUnboundUserPluginsForWorkspace(db, 'ws-1', 'member-a')).toBe(0);
+    // A second workspace on the same machine must NOT steal the binding.
+    expect(reconcileUnboundUserPluginsForWorkspace(db, 'ws-2', 'member-b')).toBe(0);
+
+    const binding = getWorkspaceResourceByResourceId(db, 'plugin', 'plugin-legacy');
+    expect(binding?.workspaceId).toBe('ws-1');
+    expect(binding?.createdByWorkspaceMemberId).toBe('member-a');
+  });
+
+  it('never binds bundled plugins — they stay global app capabilities', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    upsertInstalledPlugin(db, fakePlugin('plugin-bundled', 'bundled'));
+
+    expect(reconcileUnboundUserPluginsForWorkspace(db, 'ws-1', 'member-a')).toBe(0);
+    expect(getWorkspaceResourceByResourceId(db, 'plugin', 'plugin-bundled')).toBeUndefined();
+    // Bundled visibility was never the problem; it bypasses bindings entirely.
+    expect(listInstalledPlugins(db, 'ws-1', 'member-a').map((p) => p.id)).toContain('plugin-bundled');
+  });
+
+  it('skips Team materializations — the hub reconciliation path owns those', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    upsertInstalledPlugin(db, fakePlugin('plugin-team-mirror', 'local', 'team:plugin:ws-1:plugin-team-mirror'));
+
+    expect(reconcileUnboundUserPluginsForWorkspace(db, 'ws-1', 'member-a')).toBe(0);
+    expect(getWorkspaceResourceByResourceId(db, 'plugin', 'plugin-team-mirror')).toBeUndefined();
+  });
+
+  it('does nothing without a verified workspace id AND member id', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    upsertInstalledPlugin(db, fakePlugin('plugin-legacy'));
+
+    expect(reconcileUnboundUserPluginsForWorkspace(db, null, null)).toBe(0);
+    expect(reconcileUnboundUserPluginsForWorkspace(db, 'ws-1', null)).toBe(0);
+    expect(reconcileUnboundUserPluginsForWorkspace(db, 'ws-1', '')).toBe(0);
+    expect(reconcileUnboundUserPluginsForWorkspace(db, '  ', 'member-a')).toBe(0);
+    expect(getWorkspaceResourceByResourceId(db, 'plugin', 'plugin-legacy')).toBeUndefined();
+  });
+
+  it('respects a reconciled tombstone — a deleted binding is terminal, not re-adoptable', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    upsertInstalledPlugin(db, fakePlugin('plugin-retired'));
+    ensureWorkspaceResource(db, 'plugin', 'ws-1', 'plugin-retired', {
+      createdByWorkspaceMemberId: 'member-a',
+    });
+    updateWorkspaceResource(db, 'plugin', 'ws-1', 'plugin-retired', { resourceState: 'deleted' });
+
+    expect(reconcileUnboundUserPluginsForWorkspace(db, 'ws-1', 'member-a')).toBe(0);
+    const binding = getWorkspaceResourceByResourceId(db, 'plugin', 'plugin-retired');
+    expect(binding?.resourceState).toBe('deleted');
+    expect(listInstalledPlugins(db, 'ws-1', 'member-a').map((p) => p.id)).not.toContain('plugin-retired');
+  });
+});

--- a/apps/daemon/tests/workspace-resource-reconciliation.test.ts
+++ b/apps/daemon/tests/workspace-resource-reconciliation.test.ts
@@ -1,0 +1,200 @@
+// Shared #6528 recovery primitives (workspace-resource-reconciliation.ts).
+//
+// `reconcileUnboundResources` is the adoption path used by the plugin, skill
+// and design-system catalogs; `repairCreatorlessPersonalBindings` fixes rows a
+// writer left with no creator, which the personal branch of every visibility
+// check treats as permanently unreachable.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  closeDatabase,
+  ensureWorkspaceResource,
+  getWorkspaceResourceByResourceId,
+  openDatabase,
+  updateWorkspaceResource,
+} from '../src/db.js';
+import {
+  reconcileUnboundResources,
+  reconcileWorkspaceResourceBindings,
+  repairCreatorlessPersonalBindings,
+} from '../src/workspace-resource-reconciliation.js';
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(path.join(os.tmpdir(), 'od-ws-resource-reconcile-'));
+});
+
+afterEach(() => {
+  closeDatabase();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+const WS = 'ws-1';
+const MEMBER = 'member-a';
+
+describe('reconcileUnboundResources', () => {
+  it('binds unbound ids as personal resources of the authenticated member', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+
+    expect(reconcileUnboundResources(db, {
+      resourceType: 'skill',
+      resourceIds: ['legacy-a', 'legacy-b'],
+      workspaceId: WS,
+      workspaceMemberId: MEMBER,
+    })).toBe(2);
+
+    for (const id of ['legacy-a', 'legacy-b']) {
+      const binding = getWorkspaceResourceByResourceId(db, 'skill', id);
+      expect(binding?.workspaceId).toBe(WS);
+      expect(binding?.visibility).toBe('personal');
+      expect(binding?.resourceState).toBe('active');
+      expect(binding?.createdByWorkspaceMemberId).toBe(MEMBER);
+    }
+  });
+
+  it('works across resource types without collision', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    // Same id under two resource types is legal — the primary key is the pair.
+    reconcileUnboundResources(db, {
+      resourceType: 'skill', resourceIds: ['shared-id'], workspaceId: WS, workspaceMemberId: MEMBER,
+    });
+    reconcileUnboundResources(db, {
+      resourceType: 'design_system', resourceIds: ['shared-id'], workspaceId: WS, workspaceMemberId: MEMBER,
+    });
+
+    expect(getWorkspaceResourceByResourceId(db, 'skill', 'shared-id')?.workspaceId).toBe(WS);
+    expect(getWorkspaceResourceByResourceId(db, 'design_system', 'shared-id')?.workspaceId).toBe(WS);
+  });
+
+  it('is idempotent and never re-claims a resource bound to another workspace', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const input = { resourceType: 'plugin', resourceIds: ['legacy'], workspaceId: WS, workspaceMemberId: MEMBER };
+
+    expect(reconcileUnboundResources(db, input)).toBe(1);
+    expect(reconcileUnboundResources(db, input)).toBe(0);
+    expect(reconcileUnboundResources(db, {
+      ...input, workspaceId: 'ws-2', workspaceMemberId: 'member-b',
+    })).toBe(0);
+
+    const binding = getWorkspaceResourceByResourceId(db, 'plugin', 'legacy');
+    expect(binding?.workspaceId).toBe(WS);
+    expect(binding?.createdByWorkspaceMemberId).toBe(MEMBER);
+  });
+
+  it('leaves a tombstoned binding terminal', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    ensureWorkspaceResource(db, 'skill', WS, 'retired', { createdByWorkspaceMemberId: MEMBER });
+    updateWorkspaceResource(db, 'skill', WS, 'retired', { resourceState: 'deleted' });
+
+    expect(reconcileUnboundResources(db, {
+      resourceType: 'skill', resourceIds: ['retired'], workspaceId: WS, workspaceMemberId: MEMBER,
+    })).toBe(0);
+    expect(getWorkspaceResourceByResourceId(db, 'skill', 'retired')?.resourceState).toBe('deleted');
+  });
+
+  it('requires BOTH a verified workspace id and member id', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    const ids = ['legacy'];
+
+    expect(reconcileUnboundResources(db, { resourceType: 'skill', resourceIds: ids, workspaceId: null, workspaceMemberId: null })).toBe(0);
+    expect(reconcileUnboundResources(db, { resourceType: 'skill', resourceIds: ids, workspaceId: WS, workspaceMemberId: null })).toBe(0);
+    expect(reconcileUnboundResources(db, { resourceType: 'skill', resourceIds: ids, workspaceId: WS, workspaceMemberId: '  ' })).toBe(0);
+    expect(reconcileUnboundResources(db, { resourceType: 'skill', resourceIds: ids, workspaceId: '', workspaceMemberId: MEMBER })).toBe(0);
+    expect(getWorkspaceResourceByResourceId(db, 'skill', 'legacy')).toBeUndefined();
+  });
+
+  it('ignores blank ids', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    expect(reconcileUnboundResources(db, {
+      resourceType: 'skill', resourceIds: ['', '   '], workspaceId: WS, workspaceMemberId: MEMBER,
+    })).toBe(0);
+  });
+});
+
+describe('repairCreatorlessPersonalBindings', () => {
+  it('adopts a personal binding whose creator column is empty', () => {
+    // Observed in the wild: a design system with a correct workspace_id,
+    // visibility and resource_state but no creator was invisible to its own
+    // author, because `creatorId && callerId && creatorId === callerId` can
+    // never be true with an empty creator.
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    ensureWorkspaceResource(db, 'design_system', WS, 'user:orphan', {
+      visibility: 'personal',
+      resourceState: 'active',
+    });
+    expect(getWorkspaceResourceByResourceId(db, 'design_system', 'user:orphan')?.createdByWorkspaceMemberId ?? '').toBe('');
+
+    expect(repairCreatorlessPersonalBindings(db, {
+      resourceType: 'design_system', resourceIds: ['user:orphan'], workspaceId: WS, workspaceMemberId: MEMBER,
+    })).toBe(1);
+
+    const binding = getWorkspaceResourceByResourceId(db, 'design_system', 'user:orphan');
+    expect(binding?.createdByWorkspaceMemberId).toBe(MEMBER);
+    expect(binding?.workspaceId).toBe(WS);
+    expect(binding?.visibility).toBe('personal');
+  });
+
+  it('never transfers ownership away from an existing creator', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    ensureWorkspaceResource(db, 'skill', WS, 'owned', { createdByWorkspaceMemberId: 'member-owner' });
+
+    expect(repairCreatorlessPersonalBindings(db, {
+      resourceType: 'skill', resourceIds: ['owned'], workspaceId: WS, workspaceMemberId: MEMBER,
+    })).toBe(0);
+    expect(getWorkspaceResourceByResourceId(db, 'skill', 'owned')?.createdByWorkspaceMemberId).toBe('member-owner');
+  });
+
+  it('ignores rows bound to another workspace, Team rows and tombstones', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    ensureWorkspaceResource(db, 'skill', 'ws-other', 'elsewhere', {});
+    ensureWorkspaceResource(db, 'skill', WS, 'team-row', { visibility: 'team' });
+    ensureWorkspaceResource(db, 'skill', WS, 'dead-row', {});
+    updateWorkspaceResource(db, 'skill', WS, 'dead-row', { resourceState: 'deleted' });
+
+    expect(repairCreatorlessPersonalBindings(db, {
+      resourceType: 'skill',
+      resourceIds: ['elsewhere', 'team-row', 'dead-row'],
+      workspaceId: WS,
+      workspaceMemberId: MEMBER,
+    })).toBe(0);
+
+    expect(getWorkspaceResourceByResourceId(db, 'skill', 'elsewhere')?.createdByWorkspaceMemberId ?? '').toBe('');
+    expect(getWorkspaceResourceByResourceId(db, 'skill', 'team-row')?.visibility).toBe('team');
+    expect(getWorkspaceResourceByResourceId(db, 'skill', 'dead-row')?.resourceState).toBe('deleted');
+  });
+});
+
+describe('reconcileWorkspaceResourceBindings', () => {
+  it('binds missing rows and repairs creatorless ones in one pass', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    ensureWorkspaceResource(db, 'skill', WS, 'creatorless', { visibility: 'personal' });
+
+    const result = reconcileWorkspaceResourceBindings(db, {
+      resourceType: 'skill',
+      resourceIds: ['creatorless', 'unbound'],
+      workspaceId: WS,
+      workspaceMemberId: MEMBER,
+    });
+
+    expect(result).toEqual({ adopted: 1, repaired: 1 });
+    expect(getWorkspaceResourceByResourceId(db, 'skill', 'unbound')?.createdByWorkspaceMemberId).toBe(MEMBER);
+    expect(getWorkspaceResourceByResourceId(db, 'skill', 'creatorless')?.createdByWorkspaceMemberId).toBe(MEMBER);
+  });
+
+  it('consumes a one-shot iterable safely for both passes', () => {
+    const db = openDatabase(tempDir, { dataDir: tempDir });
+    function* ids() { yield 'gen-a'; yield 'gen-b'; }
+
+    const result = reconcileWorkspaceResourceBindings(db, {
+      resourceType: 'plugin', resourceIds: ids(), workspaceId: WS, workspaceMemberId: MEMBER,
+    });
+
+    expect(result.adopted).toBe(2);
+    expect(getWorkspaceResourceByResourceId(db, 'plugin', 'gen-b')?.workspaceId).toBe(WS);
+  });
+});


### PR DESCRIPTION
Fixes #6528.

## Problem

Plugins installed before workspace isolation shipped (PR #6142) have no `workspace_resources` binding row. `pluginVisibleFromWorkspace` quarantines unbound user plugins from every explicit workspace, so after the 0.17.0 → 0.18.0 upgrade they silently vanish from the Plugins UI even though the `installed_plugins` rows and plugin bytes are intact.

## Fix

Per the maintainer guidance in #6528 (on-demand check in `GET /api/plugins` after the first valid workspace authentication event):

- **`registry.ts`**: new `reconcileUnboundUserPluginsForWorkspace(db, workspaceId, workspaceMemberId)`. Claims each still-unbound user plugin as a Personal resource created by the authenticated member — the same binding a fresh install would have written.
- **`routes/plugins/index.ts`**: `GET /api/plugins` invokes the reconciler (new optional `plugins.reconcileUnboundUserPlugins` dep) only when `resolveWorkspaceAuthority` returned a verified context with both a workspace id and a member id.
- **`server.ts`**: wires the registry function into the route deps.

Deliberate constraints (documented on the function):

- Adoption requires a **verified** workspace id AND member id — headerless or unauthenticated callers still cannot adopt legacy bytes by viewing them.
- `bundled` plugins stay global and are never bound.
- Team materializations (`team:plugin:` sources) are left to the hub reconciliation path.
- Idempotent via `ensureWorkspaceResource`'s `(resource_type, resource_id)` primary key: a plugin already bound anywhere — including to another workspace on a multi-workspace machine — is untouched. Reconciled tombstones remain terminal.

## Tests

New `tests/plugins-workspace-reconciliation.test.ts` (6 tests) in the style of `plugins-workspace-scope.test.ts`: adoption + post-adoption visibility rules, idempotency/no-steal across workspaces, bundled exclusion, team-mirror exclusion, identity guards, tombstone terminality.

`vitest run` on the new file plus `plugins-workspace-scope.test.ts`: 21/21 passing. `tsc --noEmit` clean for both `tsconfig.json` and `tsconfig.tests.json`.

## Field validation

On the affected machine (macOS, 0.18.0), manually inserting exactly these binding rows for the invisible resources restored them in the UI immediately — the reconciler writes the same rows on the first authenticated `GET /api/plugins` instead.