### PR TITLE
fix(e2e): align packaged onboarding smoke selector

### DIFF
--- a/e2e/lib/vitest/packaged-app-shell.ts
+++ b/e2e/lib/vitest/packaged-app-shell.ts
@@ -20,7 +20,7 @@ const PACKAGED_APP_SHELL_PROBE = `
     const home = doc.querySelector('[data-testid="entry-nav-home"]');
     const onboardingShell = doc.querySelector('.entry-shell--onboarding, .entry-onboarding-modal');
     const cloudSignIn = doc.querySelector('.onboarding-cloud__primary');
-    const secondaryLinks = Array.from(doc.querySelectorAll('.onboarding-cloud__secondary'));
+    const secondaryLinks = Array.from(doc.querySelectorAll('.onboarding-cloud__alt-btn'));
     return {
       byokLinkVisible: secondaryLinks[1] instanceof ElementCtor,
       cloudSignInVisible: cloudSignIn instanceof ElementCtor,

--- a/e2e/lib/vitest/packaged-app-shell.ts
+++ b/e2e/lib/vitest/packaged-app-shell.ts
@@ -15,12 +15,14 @@
  * fixture document (see `evaluatePackagedAppShellProbe`); in the renderer both
  * arguments are the ordinary globals.
  */
+export const packagedOnboardingRuntimeSelector = '.onboarding-cloud__alt-btn';
+
 const PACKAGED_APP_SHELL_PROBE = `
   (doc, ElementCtor) => {
     const home = doc.querySelector('[data-testid="entry-nav-home"]');
     const onboardingShell = doc.querySelector('.entry-shell--onboarding, .entry-onboarding-modal');
     const cloudSignIn = doc.querySelector('.onboarding-cloud__primary');
-    const secondaryLinks = Array.from(doc.querySelectorAll('.onboarding-cloud__alt-btn'));
+    const secondaryLinks = Array.from(doc.querySelectorAll('${packagedOnboardingRuntimeSelector}'));
     return {
       byokLinkVisible: secondaryLinks[1] instanceof ElementCtor,
       cloudSignInVisible: cloudSignIn instanceof ElementCtor,

--- a/e2e/tests/packaged/app-shell.test.ts
+++ b/e2e/tests/packaged/app-shell.test.ts
@@ -51,7 +51,7 @@ type FixtureNode = {
  * Enough of `querySelector` for the four selectors the probe uses: class
  * selectors, `[attr="value"]` selectors, and comma-separated groups. Document
  * order is the fixture array order, which is what makes the "second
- * `.onboarding-cloud__secondary` is the BYOK link" reading testable.
+ * `.onboarding-cloud__alt-btn` is the BYOK link" reading testable.
  */
 function matchesSelector(element: FixtureElement, selector: string): boolean {
   return selector
@@ -106,8 +106,8 @@ const CLOUD_SIGN_IN_LANDING: readonly FixtureNode[] = [
   { classes: ['entry-onboarding-modal'] },
   { classes: ['onboarding-view', 'onboarding-view--cloud'] },
   { classes: ['onboarding-cloud__primary'] },
-  { classes: ['onboarding-cloud__secondary'] },
-  { classes: ['onboarding-cloud__secondary'] },
+  { classes: ['onboarding-cloud__alt-btn'] },
+  { classes: ['onboarding-cloud__alt-btn'] },
 ];
 
 describe('packaged app-shell probe', () => {
@@ -216,7 +216,7 @@ describe('packaged app-shell terminal state', () => {
         { classes: ['entry-shell', 'entry-shell--onboarding'] },
         { classes: ['entry-onboarding-modal'] },
         { classes: ['onboarding-cloud__primary'] },
-        { classes: ['onboarding-cloud__secondary'] },
+        { classes: ['onboarding-cloud__alt-btn'] },
       ]),
     );
 

--- a/e2e/tests/packaged/app-shell.test.ts
+++ b/e2e/tests/packaged/app-shell.test.ts
@@ -1,3 +1,5 @@
+import { readFile } from 'node:fs/promises';
+
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -8,6 +10,7 @@ import {
   evaluatePackagedOnboardingConfigProbe,
   PackagedOnboardingConfigError,
   packagedAppShellExpression,
+  packagedOnboardingRuntimeSelector,
   packagedOnboardingCompletedFromProbe,
   packagedOnboardingCompletedForScenario,
   packagedOnboardingConfigExpression,
@@ -115,6 +118,17 @@ describe('packaged app-shell probe', () => {
     expect(packagedAppShellExpression).toContain('(document, HTMLElement)');
     expect(packagedAppShellExpression).toContain('[data-testid="entry-nav-home"]');
     expect(packagedAppShellExpression).toContain('.onboarding-cloud__primary');
+  });
+
+  it('tracks the runtime alternatives rendered by the current onboarding shell', async () => {
+    const entryShellSource = await readFile(
+      new URL('../../../apps/web/src/components/EntryShell.tsx', import.meta.url),
+      'utf8',
+    );
+    const runtimeClassName = packagedOnboardingRuntimeSelector.slice(1);
+
+    expect(packagedAppShellExpression).toContain(packagedOnboardingRuntimeSelector);
+    expect(entryShellSource.split(`className="${runtimeClassName}"`)).toHaveLength(3);
   });
 
   it('reports home for the main shell', () => {


### PR DESCRIPTION
## Why

The prerelease Windows x64 packaging job in Actions run 31089813744 installed and launched the application successfully, but its packaged-runtime smoke timed out while checking the first-run onboarding landing. The onboarding redesign changed the Local CLI and BYOK controls from `.onboarding-cloud__secondary` to `.onboarding-cloud__alt-btn`, while the packaged smoke probe still queried the retired class. That stale oracle blocked the prerelease workflow even though the current onboarding controls were rendered.

## What users will see

No user-facing product change. The prerelease Windows packaged smoke now recognizes the current Local CLI and BYOK onboarding controls instead of reporting a false failure.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this changes only the packaged E2E oracle.

## Bug fix verification

- Test path: `e2e/tests/packaged/app-shell.test.ts`
- The added source/probe contract is red with the retired selector and green with the current selector.
- Original failing evidence: Windows x64 job `92581215144` in Actions run `31089813744`.

## Validation

- `pnpm --filter @open-design/e2e test tests/packaged/app-shell.test.ts` — 46 passed
- `pnpm --filter @open-design/e2e typecheck` — passed
- `pnpm typecheck` — passed
- `git diff --check` — passed
- `pnpm guard` — blocked by pre-existing release-branch issues: unallowlisted landing-page vendor JavaScript and a missing `apps/telemetry-worker/package.json`; neither is touched by this PR.
