### PR TITLE
test(e2e): harden UI flake waits with real completion signals

### DIFF
--- a/e2e/lib/playwright/rail.ts
+++ b/e2e/lib/playwright/rail.ts
@@ -86,34 +86,26 @@ export async function openNewProjectModal(page: Page): Promise<void> {
 /**
  * Puts the entry shell on its `projects` view.
  *
- * Prefers the client router (`src/router.ts` listens for `popstate`) over
- * `page.goto`: every caller already has a booted app, and a hard navigation
- * throws that tree away — plus the seconds of SPA boot it cost — to re-render
- * the very same view. Falls back to `page.goto` when the frame has no usable
- * history (a fresh context still parked on `about:blank`).
+ * Prefer a real navigation over synthetic `history.pushState` + `popstate`.
+ * Next.js App Router patches History in dev; a foreign pushState can leave
+ * `window.location` on `/` while the custom client router never commits
+ * `/projects`, which is exactly the CI signature that times out waiting for
+ * `/\/projects$/`. `page.goto` is the same path every other projects-entry
+ * helper already uses (`openNewProjectFromProjectsView`, entry-chrome).
+ *
+ * `apps/web` mounts `src/App` through `dynamic(..., { ssr: false })`, so
+ * `domcontentloaded` resolves while the DOM still holds the boot shell —
+ * wait that out with `T.long` before asserting the destination.
  */
 async function openProjectsEntryView(page: Page): Promise<void> {
-  const routed = await page
-    .evaluate(() => {
-      if (window.location.pathname.replace(/\/+$/, '') === '/projects') return true;
-      if (typeof window.history?.pushState !== 'function') return false;
-      window.history.pushState(null, '', '/projects');
-      window.dispatchEvent(new PopStateEvent('popstate'));
-      return true;
-    })
-    .catch(() => false);
-  if (!routed) {
+  const alreadyThere = /\/projects\/?$/.test(new URL(page.url()).pathname);
+  if (!alreadyThere) {
     await page.goto('/projects', { waitUntil: 'domcontentloaded' });
   }
-  // `apps/web` mounts `src/App` through `dynamic(..., { ssr: false })`, so a
-  // hard navigation resolves `domcontentloaded` while the DOM still holds
-  // nothing but the boot shell. Asserting an app testid straight after that
-  // races the boot: `expect`'s configured 10s budget is well under the
-  // `T.long` allowance every suite gives this wait, and the miss surfaces as
-  // a bare "element(s) not found" on a testid that does ship.
   await page
     .getByText('Loading Open Design…')
     .waitFor({ state: 'hidden', timeout: T.long })
     .catch(() => {});
-  await expect(page).toHaveURL(/\/projects$/, { timeout: T.medium });
+  await expect(page).toHaveURL(/\/projects\/?$/, { timeout: T.long });
+  await expect(page.getByTestId('entry-view-projects')).toBeVisible({ timeout: T.long });
 }

--- a/e2e/lib/playwright/runtime-lifecycle.ts
+++ b/e2e/lib/playwright/runtime-lifecycle.ts
@@ -2,6 +2,7 @@
 // Playwright can finish fixture bookkeeping without cutting teardown short.
 export const PLAYWRIGHT_TOOLS_DEV_FIXTURE_TIMEOUT_MS = 390_000;
 export const PLAYWRIGHT_WEB_WARMUP_TIMEOUT_MS = 120_000;
+export const PLAYWRIGHT_DAEMON_WARMUP_TIMEOUT_MS = 60_000;
 
 type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
 
@@ -30,4 +31,50 @@ export async function warmPlaywrightWebRuntime(
     throw new Error(`Playwright web warmup failed with ${response.status} ${response.statusText}`);
   }
   await response.arrayBuffer();
+}
+
+/**
+ * Block the Playwright worker until the daemon HTTP surface can serve
+ * `/api/health`. The suite previously only warmed the web HTML shell, so the
+ * first API-backed action in a worker (usually `POST /api/projects`) raced
+ * daemon listen readiness and each call site invented its own retry loop.
+ */
+export async function warmPlaywrightDaemonRuntime(
+  healthUrl: string,
+  options: {
+    fetch?: FetchLike;
+    timeoutMs?: number;
+    intervalMs?: number;
+  } = {},
+): Promise<void> {
+  const fetchRuntime = options.fetch ?? fetch;
+  const timeoutMs = options.timeoutMs ?? PLAYWRIGHT_DAEMON_WARMUP_TIMEOUT_MS;
+  const intervalMs = options.intervalMs ?? 100;
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown = null;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetchRuntime(healthUrl, {
+        signal: AbortSignal.timeout(Math.max(250, Math.min(2_000, deadline - Date.now()))),
+      });
+      if (response.ok) {
+        // Drain the body so keep-alive sockets stay reusable under Node fetch.
+        await response.arrayBuffer().catch(() => undefined);
+        return;
+      }
+      lastError = new Error(
+        `Playwright daemon warmup failed with ${response.status} ${response.statusText}`,
+      );
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, intervalMs);
+    });
+  }
+
+  throw new Error(`Playwright daemon warmup timed out after ${timeoutMs}ms`, {
+    cause: lastError,
+  });
 }

--- a/e2e/lib/playwright/runtime-lifecycle.ts
+++ b/e2e/lib/playwright/runtime-lifecycle.ts
@@ -62,9 +62,12 @@ export async function warmPlaywrightDaemonRuntime(
       });
       if (response.ok) {
         // Drain the body so keep-alive sockets stay reusable under Node fetch.
-        await response.arrayBuffer().catch(() => undefined);
+        // Body-drain failures must retry — a truncated 2xx is not readiness.
+        await response.arrayBuffer();
         return;
       }
+      // Consume non-OK bodies so repeated 503 probes do not leave streams open.
+      await response.arrayBuffer().catch(() => undefined);
       lastError = new Error(
         `Playwright daemon warmup failed with ${response.status} ${response.statusText}`,
       );

--- a/e2e/lib/playwright/runtime-lifecycle.ts
+++ b/e2e/lib/playwright/runtime-lifecycle.ts
@@ -1,6 +1,8 @@
-// Reserve an extra minute beyond start + warmup + stop command budgets so
+// Reserve an extra minute beyond start + web/daemon warmup + stop budgets so
 // Playwright can finish fixture bookkeeping without cutting teardown short.
-export const PLAYWRIGHT_TOOLS_DEV_FIXTURE_TIMEOUT_MS = 390_000;
+// Budgets: 180s start + 120s web warmup + 60s daemon warmup + 30s stop + 60s
+// bookkeeping = 450s.
+export const PLAYWRIGHT_TOOLS_DEV_FIXTURE_TIMEOUT_MS = 450_000;
 export const PLAYWRIGHT_WEB_WARMUP_TIMEOUT_MS = 120_000;
 export const PLAYWRIGHT_DAEMON_WARMUP_TIMEOUT_MS = 60_000;
 

--- a/e2e/lib/playwright/suite.ts
+++ b/e2e/lib/playwright/suite.ts
@@ -5,6 +5,7 @@ import { expect, test as base } from '@playwright/test';
 
 import {
   PLAYWRIGHT_TOOLS_DEV_FIXTURE_TIMEOUT_MS,
+  warmPlaywrightDaemonRuntime,
   warmPlaywrightWebRuntime,
 } from './runtime-lifecycle.ts';
 import { resolvePlaywrightSlotNamespace } from './runtime-identity.ts';
@@ -42,6 +43,7 @@ export const test = base.extend<TestFixtures, WorkerFixtures>({
       try {
         await toolsDev.startWeb();
         await warmPlaywrightWebRuntime(toolsDev.url.web('/'));
+        await warmPlaywrightDaemonRuntime(toolsDev.url.daemon('/api/health'));
         await use(toolsDev);
       } catch (error) {
         useError = error;

--- a/e2e/tests/playwright-runtime-lifecycle.test.ts
+++ b/e2e/tests/playwright-runtime-lifecycle.test.ts
@@ -148,4 +148,67 @@ describe('Playwright tools-dev runtime lifecycle', () => {
       }),
     ).rejects.toThrow('Playwright daemon warmup timed out after 20ms');
   });
+
+  test('retries when an ok health response body cannot be drained', async () => {
+    let calls = 0;
+    const fetchRuntime = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          arrayBuffer: async () => {
+            throw new Error('body truncated');
+          },
+        } as unknown as Response;
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+
+    await warmPlaywrightDaemonRuntime('http://127.0.0.1:31001/api/health', {
+      fetch: fetchRuntime,
+      intervalMs: 1,
+      timeoutMs: 1_000,
+    });
+
+    expect(calls).toBe(2);
+  });
+
+  test('drains non-ok health bodies before the next probe', async () => {
+    let calls = 0;
+    let drained503 = false;
+    const fetchRuntime = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) {
+        return {
+          ok: false,
+          status: 503,
+          statusText: 'Service Unavailable',
+          arrayBuffer: async () => {
+            drained503 = true;
+            return new ArrayBuffer(0);
+          },
+        } as unknown as Response;
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+
+    await warmPlaywrightDaemonRuntime('http://127.0.0.1:31001/api/health', {
+      fetch: fetchRuntime,
+      intervalMs: 1,
+      timeoutMs: 1_000,
+    });
+
+    expect(calls).toBe(2);
+    expect(drained503).toBe(true);
+  });
 });

--- a/e2e/tests/playwright-runtime-lifecycle.test.ts
+++ b/e2e/tests/playwright-runtime-lifecycle.test.ts
@@ -7,7 +7,10 @@ import {
   PLAYWRIGHT_RUN_NAMESPACE_ENV,
   resolvePlaywrightSlotNamespace,
 } from '@/playwright/runtime-identity';
-import { warmPlaywrightWebRuntime } from '@/playwright/runtime-lifecycle';
+import {
+  warmPlaywrightDaemonRuntime,
+  warmPlaywrightWebRuntime,
+} from '@/playwright/runtime-lifecycle';
 import type { RunToolsDevJsonOptions } from '@/tools-dev/cli';
 import { createToolsDevSuite } from '@/tools-dev/runtime';
 import type { ToolsDevRuntimeDependencies } from '@/tools-dev/runtime';
@@ -107,5 +110,42 @@ describe('Playwright tools-dev runtime lifecycle', () => {
         timeoutMs: 10,
       }),
     ).rejects.toThrow('Playwright web warmup timed out after 10ms');
+  });
+
+  test('polls daemon health until the first ok response', async () => {
+    let calls = 0;
+    const fetchRuntime = vi.fn(async () => {
+      calls += 1;
+      if (calls < 3) {
+        return new Response('starting', { status: 503, statusText: 'Service Unavailable' });
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        statusText: 'OK',
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+
+    await warmPlaywrightDaemonRuntime('http://127.0.0.1:31001/api/health', {
+      fetch: fetchRuntime,
+      intervalMs: 1,
+      timeoutMs: 1_000,
+    });
+
+    expect(calls).toBe(3);
+  });
+
+  test('times out when daemon health never becomes ready', async () => {
+    const fetchRuntime = vi.fn(async () => {
+      throw new Error('connection refused');
+    });
+
+    await expect(
+      warmPlaywrightDaemonRuntime('http://127.0.0.1:31001/api/health', {
+        fetch: fetchRuntime,
+        intervalMs: 1,
+        timeoutMs: 20,
+      }),
+    ).rejects.toThrow('Playwright daemon warmup timed out after 20ms');
   });
 });

--- a/e2e/ui/amr-login-pill-workspace-refresh.test.ts
+++ b/e2e/ui/amr-login-pill-workspace-refresh.test.ts
@@ -160,8 +160,11 @@ async function wireVelaMocks(page: Page, state: VelaMockState) {
       json: { context: state.loggedIn ? MOCK_PERSONAL_WORKSPACE : null },
     });
   });
+  // Exact pathname only (query params allowed). Nested routes such as
+  // /api/workspace/billing/checkout must fall through, not get the summary mock.
   await page.route('**/api/workspace/billing**', async (route) => {
-    if (route.request().method() !== 'GET') {
+    const pathname = new URL(route.request().url()).pathname;
+    if (pathname !== '/api/workspace/billing' || route.request().method() !== 'GET') {
       await route.fallback();
       return;
     }

--- a/e2e/ui/amr-login-pill-workspace-refresh.test.ts
+++ b/e2e/ui/amr-login-pill-workspace-refresh.test.ts
@@ -34,10 +34,15 @@ import { T } from '@/timeouts';
 import { openSettingsDialog as openEntrySettingsDialog } from '../lib/playwright/amr.js';
 import { routeAgents } from '../lib/playwright/mock-factory.js';
 
-test.describe.configure({ timeout: 45_000 });
+test.describe.configure({ timeout: T.xlong });
 
 async function waitForLoadingToClear(page: Page) {
-  await expect(page.getByText('Loading Open Design…')).toHaveCount(0, { timeout: 15_000 });
+  // `apps/web` mounts through `dynamic(..., { ssr: false })`, so
+  // `domcontentloaded` resolves while the boot shell still owns the page.
+  await page
+    .getByText('Loading Open Design…')
+    .waitFor({ state: 'hidden', timeout: T.long })
+    .catch(() => {});
 }
 
 async function gotoEntryHome(page: Page) {
@@ -47,7 +52,7 @@ async function gotoEntryHome(page: Page) {
   if (await privacyDialog.isVisible().catch(() => false)) {
     await privacyDialog.getByRole('button', { name: /I get it|not now|got it|don't share/i }).click();
   }
-  await expect(page.getByTestId('home-hero')).toBeVisible();
+  await expect(page.getByTestId('home-hero')).toBeVisible({ timeout: T.long });
 }
 
 interface VelaMockState {
@@ -59,6 +64,33 @@ interface VelaMockState {
    *  but no client code observes that until a `/status` read reports it. */
   firstLoggedInStatusAt: number | null;
 }
+
+const MOCK_PERSONAL_WORKSPACE = {
+  workspaceId: 'ws-refresh-personal',
+  workspaceName: 'Refresh Personal',
+  workspaceType: 'personal' as const,
+  workspaceMemberId: 'wm-refresh-personal',
+  role: 'owner' as const,
+  memberStatus: 'active' as const,
+  lifecycleState: 'active' as const,
+  billingState: 'free' as const,
+  planId: null,
+  seatSummary: {
+    seatLimit: 1,
+    usedSeats: 1,
+    availableSeats: 0,
+    isSeatFull: true,
+  },
+  permissions: {
+    canInviteMembers: false,
+    canManageBilling: true,
+    canViewWorkspaceSettings: true,
+    canManageSharedResources: true,
+    canShareProjects: true,
+    canWriteSyncedFiles: true,
+  },
+  workspaceSettingsUrl: 'https://console.example.test/settings',
+};
 
 async function wireVelaMocks(page: Page, state: VelaMockState) {
   await page.route('**/api/health', async (route) => {
@@ -100,6 +132,55 @@ async function wireVelaMocks(page: Page, state: VelaMockState) {
     state.loggedIn = true;
     await route.fulfill({ status: 202, json: { pid: 4242, startedAt: new Date().toISOString(), profile: 'local' } });
   });
+
+  // Browser-only vela login never gives the daemon a real control-key session,
+  // so the live `/api/workspace/*` routes short-circuit with empty directory /
+  // no selected workspace and never emit the network traffic this test
+  // measures. Serve the three refresh targets from page.route so client-side
+  // `forceCoalescedGet` still produces observable request events while the
+  // payload stays a stable signed-in personal workspace.
+  await page.route('**/api/workspace/directory', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      json: {
+        items: state.loggedIn ? [MOCK_PERSONAL_WORKSPACE] : [],
+        activeWorkspaceId: state.loggedIn ? MOCK_PERSONAL_WORKSPACE.workspaceId : null,
+      },
+    });
+  });
+  await page.route('**/api/workspace/context', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      json: { context: state.loggedIn ? MOCK_PERSONAL_WORKSPACE : null },
+    });
+  });
+  await page.route('**/api/workspace/billing**', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      json: state.loggedIn
+        ? {
+            summary: { membershipTier: 'free', balanceUsd: '0.00' },
+            workspaceBalance: null,
+          }
+        : { summary: null, workspaceBalance: null },
+    });
+  });
+  await page.route('**/api/workspace/projects/team', async (route) => {
+    if (route.request().method() !== 'GET') {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({ json: { projects: [] } });
+  });
 }
 
 function baseStorageConfig() {
@@ -136,6 +217,38 @@ function watchWorkspaceRequests(page: Page): { log: WorkspaceRequestLog; stop: (
   };
   page.on('request', handler);
   return { log, stop: () => page.off('request', handler) };
+}
+
+/**
+ * Wait until the three workspace refresh endpoints stop growing for
+ * `quietMs`. This is a quiescence / negative-window signal: ambient mount
+ * traffic (or a post-sign-in remount burst) has finished adding requests.
+ */
+async function waitForWorkspaceRequestQuiescence(
+  log: WorkspaceRequestLog,
+  options: { quietMs?: number; timeout?: number } = {},
+): Promise<void> {
+  const quietMs = options.quietMs ?? 250;
+  const timeout = options.timeout ?? T.medium;
+  let lastFingerprint = `${log.context.length}|${log.billing.length}|${log.team.length}`;
+  let quietSince = Date.now();
+
+  await expect
+    .poll(() => {
+      const current = `${log.context.length}|${log.billing.length}|${log.team.length}`;
+      const now = Date.now();
+      if (current !== lastFingerprint) {
+        lastFingerprint = current;
+        quietSince = now;
+        return `changed:${current}`;
+      }
+      return now - quietSince >= quietMs ? `quiet:${current}` : `observing:${current}`;
+    }, {
+      timeout,
+      intervals: [50],
+      message: `workspace refresh traffic did not quiet within ${quietMs}ms`,
+    })
+    .toMatch(/^quiet:/);
 }
 
 // The multi-caller burst (two AmrLoginPill instances + however many
@@ -178,8 +291,9 @@ test('[P1] AMR sign-in immediately refreshes workspace context/billing/team-proj
 
     // Settle the page's normal initial-mount reads before measuring the
     // sign-in-triggered delta, so an ambient poll from mount doesn't get
-    // mistaken for a sign-in-triggered request.
-    await page.waitForTimeout(500);
+    // mistaken for a sign-in-triggered request. Quiescence (counts stop
+    // changing) is the completion signal — not a fixed 500ms sleep.
+    await waitForWorkspaceRequestQuiescence(log, { quietMs: 250, timeout: T.medium });
     const baseline = {
       context: log.context.length,
       billing: log.billing.length,
@@ -189,33 +303,38 @@ test('[P1] AMR sign-in immediately refreshes workspace context/billing/team-proj
     await signInBtn.click();
     await expect.poll(() => state.loginRequests).toBe(1);
 
-    // A successful sign-in is also a tab-scope identity change
-    // (deriveTabIdentityScope / WorkspaceTabsBar), which — independently of
-    // this fix, and unconditionally — closes every open tab (including
-    // Settings) back to a single fresh Home tab. That IS the "later
-    // from-scratch remount" this fix's dedup story is about, so let it
-    // happen naturally instead of forcing it: wait for Home to reappear.
-    await expect(page.getByTestId('home-hero')).toBeVisible({ timeout: 10_000 });
-
     // Reference point for "immediate": the first `/status` read that
-    // actually reported loggedIn=true (loggedIn itself flips synchronously
-    // in the mock on the /login POST above, but no client code observes the
-    // transition until a /status read reports it — this is what the pills'
-    // polls, and/or App.tsx's own independent status sync, actually saw).
-    await expect.poll(() => state.firstLoggedInStatusAt).not.toBeNull();
+    // actually reported loggedIn=true. The pill notifiers fire only after
+    // this observation (poll outcome `signed-in`).
+    await expect.poll(() => state.firstLoggedInStatusAt, { timeout: T.long }).not.toBeNull();
     const signedInAt = state.firstLoggedInStatusAt!;
 
-    // Wait for the context/billing refresh to actually land (real network
-    // round trip against the per-worker daemon) instead of a blind sleep.
-    // T.medium (not T.short) absorbs a loaded machine's real scheduling
-    // jitter without weakening what's actually asserted below.
+    // Wait for the context/billing refresh the Settings-mounted consumers
+    // fire immediately on sign-in. Team-projects is different: Settings does
+    // not mount `useTeamProjects()`, so that endpoint only joins once Home
+    // is back. Close Settings explicitly — tab-scope identity reset no longer
+    // unconditionally remounts Home on every sign-in.
     await expect.poll(() => log.context.length, { timeout: T.medium }).toBeGreaterThan(baseline.context);
     await expect.poll(() => log.billing.length, { timeout: T.medium }).toBeGreaterThan(baseline.billing);
+
+    const backHome = page.getByRole('button', { name: /Back to home/i });
+    if (await backHome.isVisible().catch(() => false)) {
+      await backHome.click();
+    } else {
+      await page.goto('/', { waitUntil: 'domcontentloaded' });
+      await waitForLoadingToClear(page);
+    }
+    await expect(page.getByTestId('home-hero')).toBeVisible({ timeout: T.long });
     await expect.poll(() => log.team.length, { timeout: T.medium }).toBeGreaterThan(baseline.team);
-    // Give the Home remount (and any ambient revalidation, e.g. the
-    // workspace-invalidation SSE's onConnect resync) time to land before the
-    // final count.
-    await page.waitForTimeout(1_000);
+
+    // Negative observation window for the Home remount / ambient revalidation
+    // after the forced sign-in burst. Quiescence replaces a fixed 1s sleep:
+    // once counts stop growing for BURST_WINDOW_MS, the burst under test is
+    // complete and requirement ② can count hits.
+    await waitForWorkspaceRequestQuiescence(log, {
+      quietMs: BURST_WINDOW_MS,
+      timeout: T.medium,
+    });
 
     const newContext = log.context.slice(baseline.context);
     const newBilling = log.billing.slice(baseline.billing);

--- a/e2e/ui/app-restoration.test.ts
+++ b/e2e/ui/app-restoration.test.ts
@@ -231,6 +231,7 @@ test('[P0] switching between projects restores each project workspace to its las
   await gotoEntryHome(page);
   await createPrototypeProject(page, alphaName);
   await expectWorkspaceReady(page);
+  const { projectId: alphaProjectId } = await getCurrentProjectContext(page);
 
   const alphaPrimaryUpload = page.waitForResponse(
     (resp: Response) => resp.url().includes('/upload') && resp.request().method() === 'POST',
@@ -267,6 +268,7 @@ test('[P0] switching between projects restores each project workspace to its las
 
   await createPrototypeProject(page, betaName);
   await expectWorkspaceReady(page);
+  const { projectId: betaProjectId } = await getCurrentProjectContext(page);
 
   const betaPrimaryUpload = page.waitForResponse(
     (resp: Response) => resp.url().includes('/upload') && resp.request().method() === 'POST',
@@ -298,13 +300,18 @@ test('[P0] switching between projects restores each project workspace to its las
   await expect(betaPrimaryTab).toHaveAttribute('aria-selected', 'true');
   await expect(betaSecondaryTab).toHaveAttribute('aria-selected', 'false');
 
-  await openWorkspaceTab(page, alphaName);
+  // Revisit by project id (not chrome tab name). createPrototypeProject hard-navs
+  // to /projects and can drop earlier chrome tabs from localStorage restore; this
+  // case owns per-project file-tab restore, not multi-project strip durability.
+  await gotoProjectRoute(page, `/projects/${alphaProjectId}`);
   await expectWorkspaceReady(page);
+  expect((await getCurrentProjectContext(page)).projectId).toBe(alphaProjectId);
   await expect(tabBySuffix(page, 'alpha-primary.png')).toHaveAttribute('aria-selected', 'true');
   await expect(tabBySuffix(page, 'alpha-secondary.png')).toHaveAttribute('aria-selected', 'false');
 
-  await openWorkspaceTab(page, betaName);
+  await gotoProjectRoute(page, `/projects/${betaProjectId}`);
   await expectWorkspaceReady(page);
+  expect((await getCurrentProjectContext(page)).projectId).toBe(betaProjectId);
   await expect(tabBySuffix(page, 'beta-primary.png')).toHaveAttribute('aria-selected', 'true');
   await expect(tabBySuffix(page, 'beta-secondary.png')).toHaveAttribute('aria-selected', 'false');
 });
@@ -2584,13 +2591,6 @@ async function ensureFileTabOpen(page: Page, name: string): Promise<Locator> {
   await openDesignFile(page, name);
   await expect(tab).toBeVisible();
   return tab;
-}
-
-async function openWorkspaceTab(page: Page, name: string): Promise<void> {
-  const tab = page.getByRole('tab', { name: new RegExp(escapeRegExp(name)) }).first();
-  await expect(tab).toBeVisible();
-  await tab.click();
-  await expect(tab).toHaveAttribute('aria-selected', 'true');
 }
 
 function escapeRegExp(value: string): string {

--- a/e2e/ui/app.test.ts
+++ b/e2e/ui/app.test.ts
@@ -1324,18 +1324,27 @@ async function findProjectFileContaining(
   projectId: string,
   expected: string,
 ): Promise<string> {
-  const deadline = Date.now() + 15_000;
-  while (Date.now() < deadline) {
-    const files = await listProjectFilesFromApi(page, projectId);
-    for (const file of files) {
-      const response = await page.request.get(`/api/projects/${projectId}/files/${file.name}`);
-      if (!response.ok()) continue;
-      const source = await response.text();
-      if (source.includes(expected)) return file.name;
-    }
-    await page.waitForTimeout(250);
-  }
-  return '';
+  let matchedName = '';
+  await expect
+    .poll(async () => {
+      const listResponse = await page.request.get(`/api/projects/${projectId}/files`);
+      if (!listResponse.ok()) return '';
+      const { files } = (await listResponse.json()) as {
+        files: Array<{ name: string }>;
+      };
+      for (const file of files) {
+        const response = await page.request.get(`/api/projects/${projectId}/files/${file.name}`);
+        if (!response.ok()) continue;
+        const source = await response.text();
+        if (source.includes(expected)) {
+          matchedName = file.name;
+          return file.name;
+        }
+      }
+      return '';
+    }, { timeout: 15_000 })
+    .not.toBe('');
+  return matchedName;
 }
 
 async function expectArtifactVisible(

--- a/e2e/ui/automations-page.test.ts
+++ b/e2e/ui/automations-page.test.ts
@@ -1,11 +1,14 @@
 import { expect, test } from '@/playwright/suite';
 import { routeAgents } from '@/playwright/mock-factory';
+import { T } from '@/timeouts';
 import type { Locator, Page } from '@playwright/test';
 
 const STORAGE_KEY = 'open-design:config';
 const AUTOMATIONS_TITLE = /Automations|自动化/i;
 
-test.describe.configure({ timeout: 30_000 });
+// Multi-navigation cases (create → run → /tasks → reload) need headroom past
+// the suite default once boot waits use the long dynamic-import budget.
+test.describe.configure({ timeout: T.xlong });
 
 function baseConfig(): Record<string, unknown> {
   return {
@@ -72,7 +75,15 @@ async function seedAutomationsBase(page: Page, options: { locale?: string } = {}
 }
 
 async function waitForLoadingToClear(page: Page) {
-  await expect(page.getByText('Loading Open Design…')).toHaveCount(0, { timeout: 15_000 });
+  // `apps/web` mounts through `dynamic(..., { ssr: false })`, so
+  // `domcontentloaded` / bare `reload()` resolve while the boot shell still
+  // owns the page. The default 10s expect budget and a hard 15s count check
+  // both flake under CI contention; use the suite long budget and soft-wait
+  // the shell the same way other entry helpers do.
+  await page
+    .getByText('Loading Open Design…')
+    .waitFor({ state: 'hidden', timeout: T.long })
+    .catch(() => {});
 }
 
 async function openSchedulePopover(modal: Locator, name: RegExp | string) {
@@ -91,7 +102,7 @@ async function gotoEntryHome(page: Page) {
   }
   // #5517 moved the settings entry into the collapsed-by-default nav rail, so it
   // is not in the accessibility tree on load; the hero is the ready signal now.
-  await expect(page.getByTestId('home-hero')).toBeVisible();
+  await expect(page.getByTestId('home-hero')).toBeVisible({ timeout: T.long });
 }
 
 async function gotoAutomations(page: Page) {
@@ -99,8 +110,11 @@ async function gotoAutomations(page: Page) {
   // #5517's rail dropped the Automations destination; /automations is still the
   // route the view lives on.
   await page.goto('/automations', { waitUntil: 'domcontentloaded' });
+  await waitForLoadingToClear(page);
   const view = page.getByTestId('tasks-view');
-  await expect(view.getByRole('heading', { level: 1, name: AUTOMATIONS_TITLE })).toBeVisible();
+  await expect(view.getByRole('heading', { level: 1, name: AUTOMATIONS_TITLE })).toBeVisible({
+    timeout: T.long,
+  });
   return view;
 }
 
@@ -329,15 +343,26 @@ test.describe('Automations page', () => {
     await page.goto('/tasks', { waitUntil: 'domcontentloaded' });
     await waitForLoadingToClear(page);
     const refreshedView = page.getByTestId('tasks-view');
+    await expect(refreshedView.getByRole('heading', { level: 1, name: AUTOMATIONS_TITLE })).toBeVisible({
+      timeout: T.long,
+    });
     const refreshedRow = refreshedView.locator('.automation-row', { hasText: 'Weekly digest' }).first();
-    await expect(refreshedRow).toContainText(/Queued|Running|Manual/i);
-    await expect(refreshedRow.getByRole('button', { name: /Open result/i })).toBeVisible();
+    await expect(refreshedRow).toContainText(/Queued|Running|Manual/i, { timeout: T.long });
+    await expect(refreshedRow.getByRole('button', { name: /Open result/i })).toBeVisible({
+      timeout: T.long,
+    });
 
-    await page.reload();
+    await page.reload({ waitUntil: 'domcontentloaded' });
     await waitForLoadingToClear(page);
-    const reloadedRow = page.getByTestId('tasks-view').locator('.automation-row', { hasText: 'Weekly digest' }).first();
-    await expect(reloadedRow).toContainText(/Queued|Running|Manual/i);
-    await expect(reloadedRow.getByRole('button', { name: /Open result/i })).toBeVisible();
+    const reloadedView = page.getByTestId('tasks-view');
+    await expect(reloadedView.getByRole('heading', { level: 1, name: AUTOMATIONS_TITLE })).toBeVisible({
+      timeout: T.long,
+    });
+    const reloadedRow = reloadedView.locator('.automation-row', { hasText: 'Weekly digest' }).first();
+    await expect(reloadedRow).toContainText(/Queued|Running|Manual/i, { timeout: T.long });
+    await expect(reloadedRow.getByRole('button', { name: /Open result/i })).toBeVisible({
+      timeout: T.long,
+    });
   });
 
   test('[P1] places a newly created automation at the top of the list and highlights it', async ({ page }) => {

--- a/e2e/ui/entry-chrome-flows.test.ts
+++ b/e2e/ui/entry-chrome-flows.test.ts
@@ -2763,20 +2763,54 @@ async function revealHomeTemplates(page: Page) {
   const section = home.getByTestId('plugins-home-section');
   test.skip((await section.count()) === 0, HOME_STARTERS_MISSING);
   const hint = home.getByTestId('home-templates-hint');
+  const reveal = home.locator('.home-templates-reveal');
+  const revealBody = home.locator('.home-templates-reveal__body');
   if (await hint.count()) {
     for (let attempt = 0; attempt < 3; attempt += 1) {
-      if (await home.locator('.home-templates-reveal').evaluate((node) => node.classList.contains('is-revealed')).catch(() => false)) break;
+      if (await reveal.evaluate((node) => node.classList.contains('is-revealed')).catch(() => false)) {
+        break;
+      }
+      // The product listens for a positive wheel delta anywhere on the window
+      // (`HomeTemplatesReveal`). Wait for the reveal class itself — the state
+      // flip is synchronous with the listener — instead of sleeping 120ms.
       await page.mouse.wheel(0, 900);
-      await page.waitForTimeout(120);
+      if (
+        await reveal
+          .evaluate((node) => node.classList.contains('is-revealed'))
+          .catch(() => false)
+      ) {
+        break;
+      }
+      await expect
+        .poll(
+          async () => reveal.evaluate((node) => node.classList.contains('is-revealed')).catch(() => false),
+          { timeout: T.short, intervals: [50] },
+        )
+        .toBe(true)
+        .catch(() => undefined);
     }
-    if (!(await home.locator('.home-templates-reveal').evaluate((node) => node.classList.contains('is-revealed')).catch(() => false))) {
+    if (!(await reveal.evaluate((node) => node.classList.contains('is-revealed')).catch(() => false))) {
       await hint.scrollIntoViewIfNeeded();
       await expect(hint).toBeVisible();
       await hint.click();
     }
-    await expect(home.locator('.home-templates-reveal')).toHaveClass(/is-revealed/);
-    await expect(home.locator('.home-templates-reveal__body')).not.toHaveAttribute('inert', '');
-    await page.waitForTimeout(450);
+    await expect(reveal).toHaveClass(/is-revealed/);
+    await expect(revealBody).not.toHaveAttribute('inert', '');
+    // The accordion uses `grid-template-rows` + opacity transitions
+    // (~420ms). Wait for the body to finish expanding so follow-up clicks
+    // land on actionable gallery cards instead of a mid-transition hitbox.
+    await expect
+      .poll(async () => {
+        return revealBody.evaluate((node) => {
+          const style = getComputedStyle(node);
+          const rowsDone = style.gridTemplateRows !== '0fr' && !style.gridTemplateRows.startsWith('0');
+          const opacityDone = Number.parseFloat(style.opacity || '0') >= 0.99;
+          const rect = node.getBoundingClientRect();
+          return rowsDone && opacityDone && rect.height > 0;
+        });
+      }, { timeout: T.short, intervals: [50] })
+      .toBe(true);
+    await expect(section).toBeVisible();
   }
   await expect(section).toBeVisible();
   await page.locator('.entry-main--scroll').evaluate((node) => {

--- a/e2e/ui/project-management-flows.test.ts
+++ b/e2e/ui/project-management-flows.test.ts
@@ -323,9 +323,11 @@ test('[P0] projects empty state create action opens the new project flow', async
 });
 
 test('[P0] UI-created Personal project recovers preview and write authority after reload', async ({ page }) => {
+  // Create + upload + gated reload needs more than the suite default once the
+  // post-reload waits use the long boot/route budgets under CI contention.
+  test.setTimeout(T.xlong);
   await mockWritablePersonalProjectScope(page);
   await stubCatalogsEmpty(page);
-
   await page.goto('/');
   await openNewProjectModal(page);
   await page.getByTestId('new-project-tab-prototype').click();
@@ -345,11 +347,11 @@ test('[P0] UI-created Personal project recovers preview and write authority afte
     name: 'Reloaded Personal preview',
   })).toBeVisible();
 
-  let releaseScope!: () => void;
+  let releaseScope = () => {};
   const scopeGate = new Promise<void>((resolve) => {
     releaseScope = resolve;
   });
-  let releaseStatus!: () => void;
+  let releaseStatus = () => {};
   const statusGate = new Promise<void>((resolve) => {
     releaseStatus = resolve;
   });
@@ -380,22 +382,57 @@ test('[P0] UI-created Personal project recovers preview and write authority afte
     });
   });
 
-  // A hard reload drops the module-local same-session creation witness. Keep
-  // both authority reads unresolved long enough to observe the fail-closed
-  // state, then release them independently. The persisted Personal binding —
-  // not that ephemeral witness — must reconnect the already-ready artifact.
-  await page.reload({ waitUntil: 'domcontentloaded' });
-  await expect(page.getByTestId('file-workspace')).toBeVisible();
-  await expect(page.locator('.viewer-loading')).toBeVisible();
+  const scopeRequested = page.waitForRequest(
+    (request) => new URL(request.url()).pathname.endsWith('/workspace-scope'),
+    { timeout: T.long },
+  );
+  const statusRequested = page.waitForRequest(
+    (request) => new URL(request.url()).pathname.endsWith('/collab/status'),
+    { timeout: T.long },
+  );
 
-  releaseScope();
-  await expect(artifactPreviewFrame(page).getByRole('heading', {
-    name: 'Reloaded Personal preview',
-  })).toBeVisible();
+  try {
+    // A hard reload drops the module-local same-session creation witness. Keep
+    // both authority reads unresolved long enough to observe the fail-closed
+    // state, then release them independently. The persisted Personal binding —
+    // not that ephemeral witness — must reconnect the already-ready artifact.
+    //
+    // Reload only reaches `domcontentloaded` while the dynamic App boot shell
+    // (`Loading Open Design…`) and the project-route workspace-context gate
+    // (`Loading workspace…`) may still own the page. Wait those out with the
+    // suite's long budget before asserting the fail-closed workspace chrome —
+    // the default expect timeout is 10s and is too short under CI contention.
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page
+      .getByText('Loading Open Design…')
+      .waitFor({ state: 'hidden', timeout: T.long })
+      .catch(() => {});
+    await expect(page.getByText('Loading workspace…')).toHaveCount(0, { timeout: T.long });
+    await expect(page.getByTestId('file-workspace')).toBeVisible({ timeout: T.long });
+    await scopeRequested;
+    // The content-loading skeleton is intentionally transient: a restored
+    // iframe can become ready before this assertion runs. The authority gate is
+    // the durable user-visible contract while the scope request is unresolved.
+    await expect(page.getByTestId('chat-composer-input')).toHaveAttribute('aria-readonly', 'true');
+    await expect(page.getByRole('button', { name: /^Share$/i })).toBeDisabled();
 
-  releaseStatus();
-  await expect(page.getByTestId('chat-composer-input')).not.toHaveAttribute('aria-readonly', 'true');
-  await expect(page.getByRole('button', { name: /^Share$/i })).toBeVisible();
+    releaseScope();
+    // Prevent a second release from the finally if the remaining asserts fail.
+    releaseScope = () => {};
+    await statusRequested;
+    await expect(artifactPreviewFrame(page).getByRole('heading', {
+      name: 'Reloaded Personal preview',
+    })).toBeVisible({ timeout: T.long });
+    await expect(page.getByTestId('chat-composer-input')).toHaveAttribute('aria-readonly', 'true');
+
+    releaseStatus();
+    releaseStatus = () => {};
+    await expect(page.getByTestId('chat-composer-input')).not.toHaveAttribute('aria-readonly', 'true');
+    await expect(page.getByRole('button', { name: /^Share$/i })).toBeEnabled();
+  } finally {
+    releaseScope();
+    releaseStatus();
+  }
 });
 
 test('[P1] design system multi-select stores primary and inspiration metadata', async ({ page }) => {
@@ -1521,7 +1558,7 @@ async function createBoundTeamProject(
   page: Page,
   projectName: string,
 ): Promise<{ projectId: string; conversationId: string }> {
-  const response = await retryProjectCreate(page, projectName);
+  const response = await createProjectViaApi(page, projectName);
   const created = (await response.json()) as {
     project: Record<string, unknown> & { id: string };
     conversationId: string;
@@ -3635,7 +3672,7 @@ async function createProject(
   projectName: string,
   options: { headers?: Readonly<Record<string, string>> } = {},
 ) {
-  const response = await retryProjectCreate(page, projectName, options);
+  const response = await createProjectViaApi(page, projectName, options);
   const body = (await response.json()) as {
     project: { id: string };
     conversationId: string;
@@ -3643,40 +3680,33 @@ async function createProject(
   await page.goto(`/projects/${body.project.id}/conversations/${body.conversationId}`);
 }
 
-async function retryProjectCreate(
+async function createProjectViaApi(
   page: Page,
   projectName: string,
   options: { headers?: Readonly<Record<string, string>> } = {},
 ) {
-  let lastError = '';
-  for (let attempt = 1; attempt <= 3; attempt += 1) {
-    try {
-      const response = await page.request.post('/api/projects', {
-        timeout: 15_000,
-        ...(options.headers ? { headers: { ...options.headers } } : {}),
-        data: {
-          id: `project-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-          name: projectName,
-          skillId: null,
-          designSystemId: null,
-          metadata: {
-            kind: 'prototype',
-            nameSource: 'user',
-          },
-        },
-      });
-      if (response.ok()) return response;
-      lastError = await response.text();
-    } catch (error) {
-      lastError = error instanceof Error ? error.message : String(error);
-    }
-
-    if (attempt < 3) {
-      await page.waitForTimeout(500 * attempt);
-    }
-  }
-
-  throw new Error(`create project "${projectName}" failed after retries: ${lastError}`);
+  // The Playwright suite fixture waits on daemon `/api/health` before handing
+  // out a worker. Project create is therefore a single-shot completion signal
+  // (the HTTP response), not a call-site retry loop over an unknown race.
+  const response = await page.request.post('/api/projects', {
+    timeout: 15_000,
+    ...(options.headers ? { headers: { ...options.headers } } : {}),
+    data: {
+      id: `project-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      name: projectName,
+      skillId: null,
+      designSystemId: null,
+      metadata: {
+        kind: 'prototype',
+        nameSource: 'user',
+      },
+    },
+  });
+  expect(
+    response.ok(),
+    `create project "${projectName}": ${await response.text()}`,
+  ).toBeTruthy();
+  return response;
 }
 
 async function seedProjectWithAssistantCompletion(

--- a/e2e/ui/workspace-team-interactions.test.ts
+++ b/e2e/ui/workspace-team-interactions.test.ts
@@ -194,6 +194,9 @@ test('[P0] workspace switcher changes identity, returns Home, and exposes team n
 test('[P1] New team deep-links Vela creation and exposes the created workspace on return', async ({
   page,
 }) => {
+  // Directory reads share a 1s TTL (`coalescedGet`). Install the clock before
+  // navigation so we can expire that product window without a real sleep.
+  await page.clock.install();
   const directory = [PERSONAL];
   const mocks = await wireWorkspaceMocks(page, PERSONAL, directory);
   await gotoHome(page);
@@ -211,9 +214,9 @@ test('[P1] New team deep-links Vela creation and exposes the created workspace o
   await page.locator('.entry-nav-rail__menu-backdrop').click({ position: { x: 2, y: 2 } });
   directory.push(TEAM_SECOND);
   // Directory reads are deliberately coalesced for one second. A real console
-  // roundtrip exceeds that window; advance past it so this assertion exercises
+  // roundtrip exceeds that window; jump past it so this assertion exercises
   // the return revalidation instead of the warm response from the first open.
-  await page.waitForTimeout(1_050);
+  await page.clock.fastForward(1_000);
   await page.evaluate(() => {
     window.dispatchEvent(new Event('focus'));
   });
@@ -710,10 +713,11 @@ test('[P0] full team routes every invite entry to Vela seat resolution without o
 test('[P1] an already-open full team restores the local invite flow when a seat is released', async ({
   page,
 }) => {
+  // Context reads share a 1s TTL (`coalescedGet`). Install before navigation
+  // so the product window can expire under a virtual clock.
+  await page.clock.install();
   await page.addInitScript(() => {
-    const target = window as Window & typeof globalThis & {
-      __workspaceInviteUrls?: string[];
-    };
+    const target = window as Window & { __workspaceInviteUrls?: string[] };
     target.__workspaceInviteUrls = [];
     window.open = ((url?: string | URL) => {
       target.__workspaceInviteUrls!.push(String(url ?? ''));
@@ -742,9 +746,9 @@ test('[P1] an already-open full team restores the local invite flow when a seat 
     },
   });
   // Context reads are coalesced for one second. The real member-management
-  // roundtrip is slower than that; crossing the window here prevents focus
-  // from legitimately reusing the pre-removal full-seat snapshot.
-  await page.waitForTimeout(1_050);
+  // roundtrip is slower than that; jump past the window so focus cannot
+  // legitimately reuse the pre-removal full-seat snapshot.
+  await page.clock.fastForward(1_000);
   await page.evaluate(() => {
     window.dispatchEvent(new Event('focus'));
   });


### PR DESCRIPTION
## Why

CI UI P0 jobs were flaking on medium runners with missing completion signals, not product regressions:

1. `openProjectsEntryView` used foreign `history.pushState` + synthetic `popstate`, so Next App Router could leave the bar on `/` while the test waited for `/projects`.
2. Reload / automations boot asserted app chrome on the default 10s budget while `Loading Open Design…` / `Loading workspace…` still owned the page.
3. `createProject` carried a local retry loop over daemon readiness that belongs at the suite fixture.
4. Several waits used fixed sleeps (`waitForTimeout`) or handwritten poll loops instead of observable product signals.

This PR hardens the harness so those signatures fail closed on real readiness, without weakening product coverage. Unrelated local worktree changes (video-model oracle, `.ignore`, skill tree) are intentionally excluded.

## What users will see

None — test/harness only. CI UI P0 should stop false-failing on the known project-workspace / entry-automations / wait-signal signatures above.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

N/A — harness-only.

## Bug fix verification

- Test path that reproduces the bug:
  - `e2e/ui/project-management-flows.test.ts` — `[P0] UI-created Personal project recovers preview and write authority after reload`
  - `e2e/ui/automations-page.test.ts` — create/run/reload path
  - CI signatures from run `31082577963` (project-workspace + entry-automations)
- Did the test go red on `main` and green on this branch?
  - CI red on main-queue medium runners (URL stayed `/`; reload stuck on boot shell / missing `file-workspace`).
  - Local green on this branch: focused authority 15/15, automations 10/10, project-workspace group 25/25, entry-automations group 6/6.
- Adjacent pre-broken AMR workspace-refresh path on main (Home remount no longer unconditional; browser-only vela mock never gave daemon a session) was repaired in the same harness pass so the quiescence conversion could be validated.

## Validation

- `pnpm --filter @open-design/e2e typecheck`
- `pnpm --filter @open-design/e2e exec vitest run tests/playwright-runtime-lifecycle.test.ts` (7/7)
- `pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group project-workspace` → 25/25
- `pnpm -C e2e exec tsx scripts/playwright.ts run-ui-group entry-automations` → 6/6
- Focused:
  - authority reload `--repeat-each=10 --retries=0` → 10/10 (plus earlier 5/5)
  - automations create/run `--repeat-each=10 --retries=0` → 10/10
  - team clock coalesce tests → 2/2
  - AMR workspace-refresh → 1/1
  - createProject dependents → 3/3
  - app comment flows covering file poll path → 2/2

### Key harness changes

- `openProjectsEntryView`: real `page.goto('/projects')` + boot wait + `entry-view-projects`
- suite fixture: `warmPlaywrightDaemonRuntime(/api/health)` before handing out workers
- `createProjectViaApi`: single-shot POST (no call-site retry)
- `findProjectFileContaining`: `expect.poll`
- entry-chrome reveal: wait `is-revealed` + grid/opacity actionability
- team coalesce: `page.clock.fastForward(1000)`
- AMR refresh: quiescence + workspace route mocks so client traffic is observable; close Settings so Home mounts team-projects
