### PR TITLE
fix(daemon): read Qwen Code's configured models instead of two hardcoded ids

### DIFF
--- a/apps/daemon/src/runtimes/defs/qwen.ts
+++ b/apps/daemon/src/runtimes/defs/qwen.ts
@@ -1,16 +1,25 @@
 import { DEFAULT_MODEL_OPTION } from './shared.js';
+import { loadQwenSettingsModels } from '../qwen-settings.js';
 import type { RuntimeAgentDef } from '../types.js';
+
+// Static safety net only. Qwen Code has no `--list-models`, so the live list
+// comes from the CLI's own `~/.qwen/settings.json` via `fetchModels` below;
+// these are used when that file is absent or unreadable.
+const QWEN_FALLBACK_MODELS = [
+  DEFAULT_MODEL_OPTION,
+  { id: 'qwen3-coder-plus', label: 'qwen3-coder-plus' },
+  { id: 'qwen3-coder-flash', label: 'qwen3-coder-flash' },
+];
 
 export const qwenAgentDef = {
     id: 'qwen',
     name: 'Qwen Code',
     bin: 'qwen',
     versionArgs: ['--version'],
-    fallbackModels: [
-      DEFAULT_MODEL_OPTION,
-      { id: 'qwen3-coder-plus', label: 'qwen3-coder-plus' },
-      { id: 'qwen3-coder-flash', label: 'qwen3-coder-flash' },
-    ],
+    fallbackModels: QWEN_FALLBACK_MODELS,
+    // Surface the models the user already configured in Qwen Code itself,
+    // instead of pinning the picker to the two hardcoded coder ids.
+    fetchModels: async (_resolvedBin, env) => loadQwenSettingsModels(env, QWEN_FALLBACK_MODELS),
     // Prompt delivered via stdin (gated by `promptViaStdin: true`) to avoid Windows
     // `spawn ENAMETOOLONG` for large composed prompts. Qwen Code is a
     // Gemini-CLI fork and supports the same `--yolo` non-interactive mode.

--- a/apps/daemon/src/runtimes/qwen-settings.ts
+++ b/apps/daemon/src/runtimes/qwen-settings.ts
@@ -1,0 +1,153 @@
+// Qwen Code keeps its configured models in `~/.qwen/settings.json`, not behind
+// a `--list-models` flag. The picker was therefore stuck on a two-entry
+// hardcoded fallback (`qwen3-coder-plus` / `qwen3-coder-flash`) while the CLI
+// itself was configured with newer ones, so users could not select the model
+// they had already set up without typing it as a custom string.
+//
+// Mirrors `mmd-routes.ts` (the same problem for Claude Code) in shape: read
+// the CLI's own config, merge the discovered ids ahead of the static
+// fallbacks, and degrade to the fallbacks whenever the file is missing or
+// unreadable.
+
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { DEFAULT_MODEL_OPTION, sanitizeCustomModel } from './models.js';
+import type { RuntimeEnv, RuntimeModelOption } from './types.js';
+
+const DEFAULT_QWEN_SETTINGS_FILE = join('.qwen', 'settings.json');
+const QWEN_SETTINGS_FILE_ENV = 'QWEN_SETTINGS_FILE';
+
+function stringEnv(env: RuntimeEnv, key: string): string | null {
+  const value = env[key];
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function resolveHome(env: RuntimeEnv): string | null {
+  return stringEnv(env, 'HOME') ?? homedir() ?? null;
+}
+
+function expandSettingsFileOverride(raw: string, env: RuntimeEnv): string | null {
+  if (raw === '~') return resolveHome(env);
+  if (raw.startsWith('~/') || raw.startsWith('~\\')) {
+    const home = resolveHome(env);
+    return home ? join(home, raw.slice(2)) : null;
+  }
+  return raw;
+}
+
+export function resolveQwenSettingsFile(env: RuntimeEnv): string | null {
+  const override = stringEnv(env, QWEN_SETTINGS_FILE_ENV);
+  if (override) return expandSettingsFileOverride(override, env);
+
+  const home = resolveHome(env);
+  if (!home) return null;
+  return join(home, DEFAULT_QWEN_SETTINGS_FILE);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Collect model ids from a parsed `settings.json`.
+ *
+ * Two sources, in priority order:
+ * - `modelProviders.<provider>[].id` — every provider entry the user
+ *   configured. The shape is `{ openai: [{ id, name, baseUrl, … }], … }`;
+ *   provider keys are not enumerated against an allowlist so a Qwen release
+ *   that adds one keeps working.
+ * - `model` — the currently selected model, which may be a bare string or a
+ *   `{ name }`/`{ id }` record depending on Qwen version.
+ *
+ * Ids are sanitized and de-duplicated; anything unparseable is skipped rather
+ * than failing the whole read.
+ */
+export function parseQwenSettingsModelIds(raw: unknown): string[] {
+  if (!isRecord(raw)) return [];
+
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  const push = (candidate: unknown): void => {
+    if (typeof candidate !== 'string') return;
+    const id = sanitizeCustomModel(candidate);
+    if (!id || seen.has(id)) return;
+    seen.add(id);
+    ids.push(id);
+  };
+
+  const providers = raw.modelProviders;
+  if (isRecord(providers)) {
+    for (const entries of Object.values(providers)) {
+      if (!Array.isArray(entries)) continue;
+      for (const entry of entries) {
+        if (isRecord(entry)) push(entry.id);
+      }
+    }
+  }
+
+  const selected = raw.model;
+  if (typeof selected === 'string') push(selected);
+  else if (isRecord(selected)) {
+    push(selected.id);
+    push(selected.name);
+  }
+
+  return ids;
+}
+
+function addModel(
+  out: RuntimeModelOption[],
+  seen: Set<string>,
+  option: RuntimeModelOption,
+): void {
+  const id = sanitizeCustomModel(option.id);
+  if (!id || seen.has(id)) return;
+  seen.add(id);
+  const label = typeof option.label === 'string' && option.label.trim().length > 0
+    ? option.label
+    : id;
+  out.push({ id, label });
+}
+
+export function mergeQwenSettingsModels(
+  settingsIds: readonly string[],
+  fallbackModels: readonly RuntimeModelOption[],
+): RuntimeModelOption[] {
+  const out: RuntimeModelOption[] = [];
+  const seen = new Set<string>();
+
+  addModel(out, seen, DEFAULT_MODEL_OPTION);
+  for (const id of settingsIds) addModel(out, seen, { id, label: id });
+  for (const model of fallbackModels) addModel(out, seen, model);
+
+  return out;
+}
+
+export async function loadQwenSettingsModels(
+  env: RuntimeEnv,
+  fallbackModels: readonly RuntimeModelOption[],
+): Promise<RuntimeModelOption[] | null> {
+  const settingsFile = resolveQwenSettingsFile(env);
+  if (!settingsFile) return null;
+
+  let text: string;
+  try {
+    text = await readFile(settingsFile, 'utf8');
+  } catch {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+
+  const ids = parseQwenSettingsModelIds(parsed);
+  if (ids.length === 0) return null;
+  return mergeQwenSettingsModels(ids, fallbackModels);
+}

--- a/apps/daemon/tests/runtimes/qwen-settings.test.ts
+++ b/apps/daemon/tests/runtimes/qwen-settings.test.ts
@@ -1,0 +1,137 @@
+import { test } from 'vitest';
+import {
+  assert,
+  join,
+  mkdtempSync,
+  qwen,
+  rmSync,
+  tmpdir,
+  writeFileSync,
+} from './helpers/test-helpers.js';
+import {
+  loadQwenSettingsModels,
+  mergeQwenSettingsModels,
+  parseQwenSettingsModelIds,
+  resolveQwenSettingsFile,
+} from '../../src/runtimes/qwen-settings.js';
+
+test('qwen settings parser collects provider ids without exposing secrets', () => {
+  const ids = parseQwenSettingsModelIds({
+    env: { DASHSCOPE_API_KEY: 'sk-secret-must-not-leak' },
+    modelProviders: {
+      openai: [
+        { id: 'qwen3.8-max', name: '[ModelStudio] qwen3.8-max', envKey: 'DASHSCOPE_API_KEY' },
+        { id: 'qwen3.7-plus', baseUrl: 'https://dashscope.example.test/v1' },
+        // A provider entry that a future Qwen release could add.
+        { id: 'glm-5.1' },
+        { name: 'no id at all' },
+        { id: '-bad-flag-shaped-id' },
+        { id: 'bad id with spaces' },
+        { id: '' },
+      ],
+      // Unknown provider keys must not be dropped: no allowlist.
+      anthropicCompatible: [{ id: 'deepseek-v4-pro' }],
+      notAnArray: { id: 'ignored' },
+    },
+    model: 'qwen3.6-plus',
+  });
+
+  assert.deepEqual(ids, [
+    'qwen3.8-max',
+    'qwen3.7-plus',
+    'glm-5.1',
+    'deepseek-v4-pro',
+    'qwen3.6-plus',
+  ]);
+  assert.equal(JSON.stringify(ids).includes('secret'), false);
+});
+
+test('qwen settings parser accepts a record-shaped selected model and de-duplicates', () => {
+  assert.deepEqual(
+    parseQwenSettingsModelIds({
+      modelProviders: { openai: [{ id: 'qwen3.8-max' }] },
+      model: { name: 'qwen3.8-max' },
+    }),
+    ['qwen3.8-max'],
+  );
+  assert.deepEqual(
+    parseQwenSettingsModelIds({ model: { id: 'qwen3-coder-next' } }),
+    ['qwen3-coder-next'],
+  );
+  assert.deepEqual(parseQwenSettingsModelIds(null), []);
+  assert.deepEqual(parseQwenSettingsModelIds({}), []);
+});
+
+test('qwen merge keeps default first, settings ids ahead of static fallbacks', () => {
+  const merged = mergeQwenSettingsModels(
+    ['qwen3.8-max', 'qwen3-coder-plus'],
+    [{ id: 'default', label: 'CLI default' }, { id: 'qwen3-coder-plus', label: 'qwen3-coder-plus' }, { id: 'qwen3-coder-flash', label: 'qwen3-coder-flash' }],
+  );
+
+  assert.deepEqual(merged.map((m) => m.id), [
+    'default',
+    'qwen3.8-max',
+    'qwen3-coder-plus',
+    'qwen3-coder-flash',
+  ]);
+});
+
+test('qwen settings file honours the env override and falls back to ~/.qwen', () => {
+  assert.equal(
+    resolveQwenSettingsFile({ QWEN_SETTINGS_FILE: '/tmp/custom-qwen.json' }),
+    '/tmp/custom-qwen.json',
+  );
+  assert.equal(
+    resolveQwenSettingsFile({ HOME: '/home/tester', QWEN_SETTINGS_FILE: '~/nested/qwen.json' }),
+    join('/home/tester', 'nested/qwen.json'),
+  );
+  assert.equal(
+    resolveQwenSettingsFile({ HOME: '/home/tester' }),
+    join('/home/tester', '.qwen', 'settings.json'),
+  );
+});
+
+test('qwen agent def surfaces configured models and degrades to fallbacks', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'od-qwen-settings-'));
+  try {
+    const settingsFile = join(dir, 'settings.json');
+    writeFileSync(
+      settingsFile,
+      JSON.stringify({
+        env: { DASHSCOPE_API_KEY: 'sk-secret-must-not-leak' },
+        modelProviders: {
+          openai: [{ id: 'qwen3.8-max' }, { id: 'qwen3.7-plus' }],
+        },
+      }),
+    );
+
+    const fallbacks = [
+      { id: 'default', label: 'CLI default' },
+      { id: 'qwen3-coder-plus', label: 'qwen3-coder-plus' },
+    ];
+    const models = await loadQwenSettingsModels({ QWEN_SETTINGS_FILE: settingsFile }, fallbacks);
+    assert.deepEqual(models?.map((m) => m.id), [
+      'default',
+      'qwen3.8-max',
+      'qwen3.7-plus',
+      'qwen3-coder-plus',
+    ]);
+    assert.equal(JSON.stringify(models).includes('secret'), false);
+
+    // Missing and malformed files fall through to the static fallback list.
+    assert.equal(
+      await loadQwenSettingsModels({ QWEN_SETTINGS_FILE: join(dir, 'absent.json') }, fallbacks),
+      null,
+    );
+    const malformed = join(dir, 'malformed.json');
+    writeFileSync(malformed, '{ not json');
+    assert.equal(await loadQwenSettingsModels({ QWEN_SETTINGS_FILE: malformed }, fallbacks), null);
+
+    // And the def itself is wired to the loader.
+    assert.equal(typeof qwen.fetchModels, 'function');
+    const viaDef = await qwen.fetchModels?.('qwen', { QWEN_SETTINGS_FILE: settingsFile });
+    assert.deepEqual(viaDef?.map((m) => m.id).slice(0, 3), ['default', 'qwen3.8-max', 'qwen3.7-plus']);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

`qwenAgentDef` declares `fallbackModels` with no `fetchModels`, so the Qwen Code picker only ever offers `qwen3-coder-plus` and `qwen3-coder-flash`. Anything newer has to be retyped through "Custom (type below)…" every time.

Qwen Code has no `--list-models` flag, but it does persist its configured models in `~/.qwen/settings.json`:

```json
{
  "modelProviders": {
    "openai": [
      { "id": "qwen3.8-max", "name": "[ModelStudio Standard] qwen3.8-max", "baseUrl": "…" },
      { "id": "qwen3.7-plus", "…": "…" }
    ]
  },
  "model": "qwen3.6-plus"
}
```

On a current install (Qwen Code 0.21.6) that file lists `qwen3.8-max`, `qwen3.7-max`, `qwen3.7-plus`, `qwen3.6-plus` and more — none reachable from the picker.

## Fix

New `runtimes/qwen-settings.ts`, deliberately shaped like `mmd-routes.ts` (the same problem already solved for Claude Code): read the CLI's own config, merge the discovered ids ahead of the static fallbacks, degrade to the fallbacks when the file is absent or malformed. `qwen.ts` gains `fetchModels: (…) => loadQwenSettingsModels(env, QWEN_FALLBACK_MODELS)` and keeps the existing two ids as the safety net.

Notes:

- Provider keys under `modelProviders` are **not** allowlisted, so a Qwen release that adds a provider keeps working without a code change.
- `model` is accepted as a bare string or a `{ id }` / `{ name }` record, since the shape varies by Qwen version.
- `QWEN_SETTINGS_FILE` overrides the path, matching `MMD_MODEL_ROUTES_FILE`.
- **Secrets:** `settings.json` also holds `env.DASHSCOPE_API_KEY`. Only model ids are read, and two tests assert that nothing containing `secret` reaches the returned list — same guarantee `mmd-routes.test.ts` makes for `api_key`.

## Checks

5 new tests in `tests/runtimes/qwen-settings.test.ts` (parser, unknown providers, record-shaped selected model, merge ordering, env override, missing/malformed degradation, and the def wiring end-to-end). `tests/runtimes`: **694 passed, 1 skipped, 47 files**. `tsc --noEmit` clean for `tsconfig.json` and `tsconfig.tests.json`.