### PR TITLE
fix(landing): stop HTML edge cache from outliving deploys

### DIFF
--- a/apps/landing-page/functions/share/[eventId].ts
+++ b/apps/landing-page/functions/share/[eventId].ts
@@ -79,5 +79,13 @@ export const onRequest: PagesFunction<Env> = async (context) => {
     console.log("share_click", JSON.stringify(record));
   }
 
-  return Response.redirect(destination, 302);
+  // Pages Functions do not receive custom `_headers` rules, so no-store must
+  // be set on the response itself or a POP can cache the 302.
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: destination,
+      "Cache-Control": "no-store",
+    },
+  });
 };

--- a/apps/landing-page/public/_headers
+++ b/apps/landing-page/public/_headers
@@ -1,32 +1,25 @@
 # Cloudflare Pages custom headers.
 # https://developers.cloudflare.com/pages/configuration/headers/
+# https://developers.cloudflare.com/pages/configuration/serving-pages/
 #
-# Why this file exists:
-#   Without it CF Pages serves HTML with `cache-control: public, max-age=0,
-#   must-revalidate` AND `cf-cache-status: DYNAMIC` — i.e. every HTML request
-#   roundtrips to the Pages origin. TTFB observed from a Seattle POP is
-#   650–900ms; Asia-Pacific users pay an additional ~200–400ms RTT.
+# Caching policy (do not "optimize" HTML edge TTLs here):
+#   Cloudflare Pages already edge-caches static assets and invalidates them on
+#   the next deployment. Custom Cache-Control on HTML with s-maxage /
+#   stale-while-revalidate overrides that deploy-scoped invalidation and can
+#   keep serving a previous deployment from a POP for up to the SWR window
+#   (we previously used 1h fresh + 24h stale). Symptom: deploy looks live in
+#   Actions, but a normal refresh still shows the old page until hard-reload
+#   or the edge copy finally ages out.
 #
-# How edge caching here works:
-#   - `max-age=0, must-revalidate`        → browser always revalidates.
-#   - `s-maxage=3600`                     → Cloudflare edge caches HTML 1h.
-#   - `stale-while-revalidate=86400`      → if edge copy is stale, serve it
-#                                           immediately and revalidate async.
-#   Because CF Pages auto-purges the deployment on every successful build,
-#   users see new content within seconds of deploy. The 1h s-maxage is the
-#   ceiling that only matters when content is changed *without* a deploy
-#   (rare; usually impossible for this static site).
-
-# HTML pages (Astro emits `<route>/index.html`; CF Pages serves them at
-# either `<route>/` or `<route>/index.html`).
-/
-  Cache-Control: public, max-age=0, s-maxage=3600, stale-while-revalidate=86400, must-revalidate
-
-/*/
-  Cache-Control: public, max-age=0, s-maxage=3600, stale-while-revalidate=86400, must-revalidate
-
-/*.html
-  Cache-Control: public, max-age=0, s-maxage=3600, stale-while-revalidate=86400, must-revalidate
+#   CF guidance: avoid custom caching for HTML; only pin long TTLs on
+#   content-addressed / explicitly versioned assets.
+#
+# What this file owns:
+#   - long-cache hashed / versioned static assets
+#   - no-store for mutating Pages Functions
+#   - content-type / short-TTL for a few public machine-readable files
+#   - leave HTML on Pages defaults (deploy-invalidated edge cache +
+#     browser revalidate)
 
 # Astro hash-named bundles (e.g. `globals.CnvQ8Wom.css`). Content-addressed
 # so they can be cached forever; a new build emits new filenames.
@@ -40,47 +33,48 @@
 /enhancers/*
   Cache-Control: public, max-age=31536000, immutable
 
-# RSS / sitemap / robots — small, refresh on deploy.
+# RSS / sitemap / robots — small machine-readable files. No long edge TTL:
+# rely on Pages deploy invalidation so a publish is visible immediately.
 /blog/rss.xml
-  Cache-Control: public, max-age=0, s-maxage=3600, stale-while-revalidate=86400, must-revalidate
+  Cache-Control: public, max-age=0, must-revalidate
 
 /sitemap-index.xml
-  Cache-Control: public, max-age=0, s-maxage=3600, stale-while-revalidate=86400, must-revalidate
+  Cache-Control: public, max-age=0, must-revalidate
 
 /sitemap-*.xml
-  Cache-Control: public, max-age=0, s-maxage=3600, stale-while-revalidate=86400, must-revalidate
+  Cache-Control: public, max-age=0, must-revalidate
 
 /robots.txt
-  Cache-Control: public, max-age=3600
+  Cache-Control: public, max-age=0, must-revalidate
 
 /llms.txt
-  Cache-Control: public, max-age=3600
+  Cache-Control: public, max-age=0, must-revalidate
 
 # Public pricing contract consumed by /pricing/ client-side reconciliation.
 /pricing/plans.json
   Content-Type: application/json; charset=utf-8
-  Cache-Control: public, max-age=0, s-maxage=3600, stale-while-revalidate=86400, must-revalidate
+  Cache-Control: public, max-age=0, must-revalidate
 
-# Static assets in public/. Filenames don't carry a content hash, so we use
-# a moderate browser TTL and rely on edge purge from CF Pages on deploy.
+# Static assets in public/. Filenames don't carry a content hash, so keep a
+# moderate browser TTL only. Edge still invalidates on the next Pages deploy.
 /favicon.png
-  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+  Cache-Control: public, max-age=86400
 /favicon.ico
-  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+  Cache-Control: public, max-age=86400
 /favicon-16x16.png
-  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+  Cache-Control: public, max-age=86400
 /favicon-32x32.png
-  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+  Cache-Control: public, max-age=86400
 /apple-touch-icon.png
-  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+  Cache-Control: public, max-age=86400
 /android-chrome-192x192.png
-  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+  Cache-Control: public, max-age=86400
 /android-chrome-512x512.png
-  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+  Cache-Control: public, max-age=86400
 /site.webmanifest
-  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+  Cache-Control: public, max-age=86400
 /logo.webp
-  Cache-Control: public, max-age=86400, stale-while-revalidate=604800
+  Cache-Control: public, max-age=86400
 
 # Share function records a click and 302s — must not be cached.
 /share/*

--- a/apps/landing-page/tests/cache-headers.test.ts
+++ b/apps/landing-page/tests/cache-headers.test.ts
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+
+const HEADERS_PATH = new URL('../public/_headers', import.meta.url);
+
+/**
+ * Parse Cloudflare Pages `_headers` into path → header-line map.
+ * Comments and blank lines are dropped; continuation lines attach to the
+ * nearest preceding path rule.
+ */
+function parseHeadersFile(source: string): Map<string, string[]> {
+  const rules = new Map<string, string[]>();
+  let current: string | null = null;
+
+  for (const raw of source.split(/\r?\n/)) {
+    const line = raw.replace(/\s+$/, '');
+    if (!line || line.startsWith('#')) continue;
+
+    if (/^\S/.test(line)) {
+      current = line.trim();
+      if (!rules.has(current)) rules.set(current, []);
+      continue;
+    }
+
+    assert.ok(current, `header continuation without a path rule: ${line}`);
+    rules.get(current)!.push(line.trim());
+  }
+
+  return rules;
+}
+
+function cacheControl(headers: string[]): string | undefined {
+  const line = headers.find((h) => /^cache-control:\s*/i.test(h));
+  return line?.replace(/^cache-control:\s*/i, '');
+}
+
+describe('landing-page Cloudflare Pages cache headers', () => {
+  it('does not pin HTML behind custom edge TTLs that outlive a deploy', async () => {
+    const source = await readFile(HEADERS_PATH, 'utf8');
+    const rules = parseHeadersFile(source);
+
+    // These path shapes matched every HTML document (/, /pricing/,
+    // /blog/foo/index.html). Custom s-maxage / stale-while-revalidate on them
+    // overrode Pages' deploy-scoped invalidation and left POPs serving the
+    // previous deployment until the SWR window expired — hard-refresh only.
+    for (const path of ['/', '/*/', '/*.html']) {
+      assert.equal(
+        rules.has(path),
+        false,
+        `${path} must not set custom Cache-Control; leave HTML on Pages defaults so deploys invalidate immediately`,
+      );
+    }
+
+    // Belt-and-suspenders: no rule may reintroduce long edge freshness for
+    // document-like responses. Hashed assets (/_astro, /enhancers) are the
+    // only place long immutable TTLs belong.
+    for (const [path, headers] of rules) {
+      const cc = cacheControl(headers);
+      if (!cc) continue;
+
+      const isHashedAsset =
+        path === '/_astro/*' ||
+        path === '/enhancers/*' ||
+        path.startsWith('/_astro/') ||
+        path.startsWith('/enhancers/');
+
+      if (isHashedAsset) {
+        assert.match(
+          cc,
+          /max-age=31536000/i,
+          `${path} should stay immutable forever`,
+        );
+        assert.match(cc, /immutable/i, `${path} should be marked immutable`);
+        continue;
+      }
+
+      assert.doesNotMatch(
+        cc,
+        /\bs-maxage\b/i,
+        `${path} must not set s-maxage; Pages deploy invalidation owns edge freshness for non-hashed responses`,
+      );
+      assert.doesNotMatch(
+        cc,
+        /\bstale-while-revalidate\b/i,
+        `${path} must not set stale-while-revalidate; it can keep serving a previous deployment after publish`,
+      );
+    }
+  });
+
+  it('keeps hashed assets immutable and mutating functions uncached', async () => {
+    const source = await readFile(HEADERS_PATH, 'utf8');
+    const rules = parseHeadersFile(source);
+
+    assert.equal(
+      cacheControl(rules.get('/_astro/*') ?? []),
+      'public, max-age=31536000, immutable',
+    );
+    assert.equal(
+      cacheControl(rules.get('/enhancers/*') ?? []),
+      'public, max-age=31536000, immutable',
+    );
+
+    for (const path of ['/share/*', '/subscribe', '/contact-sales']) {
+      assert.equal(
+        cacheControl(rules.get(path) ?? []),
+        'no-store',
+        `${path} must never be cached`,
+      );
+    }
+
+    const plans = rules.get('/pricing/plans.json') ?? [];
+    assert.ok(
+      plans.some((h) => /^content-type:\s*application\/json; charset=utf-8$/i.test(h)),
+    );
+    assert.equal(cacheControl(plans), 'public, max-age=0, must-revalidate');
+  });
+});

--- a/apps/landing-page/tests/cache-headers.test.ts
+++ b/apps/landing-page/tests/cache-headers.test.ts
@@ -88,10 +88,13 @@ describe('landing-page Cloudflare Pages cache headers', () => {
     }
   });
 
-  it('keeps hashed assets immutable and mutating functions uncached', async () => {
+  it('keeps hashed assets immutable and machine-readable static files short-TTL', async () => {
     const source = await readFile(HEADERS_PATH, 'utf8');
     const rules = parseHeadersFile(source);
 
+    // This file only governs static Pages responses. Pages Functions generate
+    // their own headers; do not assert Function paths here (CF does not apply
+    // custom `_headers` rules to Function responses).
     assert.equal(
       cacheControl(rules.get('/_astro/*') ?? []),
       'public, max-age=31536000, immutable',
@@ -100,14 +103,6 @@ describe('landing-page Cloudflare Pages cache headers', () => {
       cacheControl(rules.get('/enhancers/*') ?? []),
       'public, max-age=31536000, immutable',
     );
-
-    for (const path of ['/share/*', '/subscribe', '/contact-sales']) {
-      assert.equal(
-        cacheControl(rules.get(path) ?? []),
-        'no-store',
-        `${path} must never be cached`,
-      );
-    }
 
     const plans = rules.get('/pricing/plans.json') ?? [];
     assert.ok(

--- a/apps/landing-page/tests/contact-sales.test.ts
+++ b/apps/landing-page/tests/contact-sales.test.ts
@@ -106,6 +106,23 @@ const ENTERPRISE_OK = {
 // so it submits the identical contract — only `source` differs.
 const PRICING_TEAM_OK = { ...ENTERPRISE_OK, source: "pricing_team" };
 
+describe("contact-sales response headers", () => {
+  it("sets Cache-Control: no-store on JSON responses (Pages Functions ignore _headers)", async () => {
+    const request = new Request("https://open-design.ai/contact-sales", {
+      method: "GET",
+      headers: { origin: "https://open-design.ai" },
+    });
+    const response = await onRequest({
+      request,
+      env: {},
+      waitUntil() {},
+    } as unknown as Parameters<typeof onRequest>[0]);
+
+    assert.equal(response.status, 405);
+    assert.equal(response.headers.get("Cache-Control"), "no-store");
+  });
+});
+
 describe("contact-sales validation", () => {
   it("rejects a missing or invalid email on every source", async () => {
     assert.equal((await call({ ...ENTERPRISE_OK, email: "" })).body.error, "invalid_email");

--- a/apps/landing-page/tests/home-campaign-banner.test.ts
+++ b/apps/landing-page/tests/home-campaign-banner.test.ts
@@ -51,6 +51,9 @@ test('home campaign banner uses the fixed seven-day activity window', () => {
   assert.match(source, /data-home-campaign-banner[^>]*hidden/);
   assert.match(source, /home-campaign-banner-active/);
   assert.match(source, /8 月 6 日—8 月 13 日，一周免费用/);
+  assert.match(source, /Stop rationing\. Use DeepSeek V4 Flash without limits\./);
+  assert.match(source, /linkLabel: 'View campaign benefits'/);
+  assert.match(source, /badge: 'Campaign countdown'/);
   assert.match(source, /FREE all week/);
   assert.doesNotMatch(source, /home-campaign-banner__disclaimer/);
   assert.doesNotMatch(source, /套餐内的<strong>无限制模型额度<\/strong>与<strong>免费生成次数<\/strong>/);

--- a/apps/landing-page/tests/pricing-contract.test.ts
+++ b/apps/landing-page/tests/pricing-contract.test.ts
@@ -88,6 +88,9 @@ describe("pricing contract", () => {
     const page = await readFile(PRICING_PAGE_PATH, "utf8");
 
     assert.match(page, /DeepSeek V4 Flash 无限使用/);
+    assert.match(page, /Stop rationing\. Use DeepSeek V4 Flash without limits\./);
+    assert.match(page, /badge: 'Unlimited'/);
+    assert.match(page, /modelBenefit: 'Unlimited DeepSeek V4 Flash'/);
     assert.match(page, /badge: '无限使用'/);
     assert.match(page, /windowLabel: '活动倒计时'/);
     assert.match(page, /windowValue: '7天 00:00:00'/);

--- a/apps/landing-page/tests/share-redirect.test.ts
+++ b/apps/landing-page/tests/share-redirect.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { onRequest } from "../functions/share/[eventId].ts";
+
+describe("share click redirect", () => {
+  it("returns a 302 with Cache-Control: no-store (Pages Functions ignore _headers)", async () => {
+    const response = await onRequest({
+      request: new Request("https://open-design.ai/share/evt-1", {
+        headers: { "user-agent": "test-agent" },
+      }),
+      params: { eventId: "evt-1" },
+      env: {},
+      waitUntil() {},
+    });
+
+    assert.equal(response.status, 302);
+    assert.equal(response.headers.get("Cache-Control"), "no-store");
+    assert.match(
+      response.headers.get("Location") ?? "",
+      /^https:\/\/github\.com\/nexu-io\/open-design/,
+    );
+  });
+});

--- a/apps/landing-page/tests/subscribe.test.ts
+++ b/apps/landing-page/tests/subscribe.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { __newsletterSubscribeTest } from "../functions/subscribe.ts";
+import { __newsletterSubscribeTest, onRequest } from "../functions/subscribe.ts";
 
 type TestKv = {
   put(key: string, value: string): Promise<void>;
@@ -65,6 +65,22 @@ function createEnv(kv: TestKv) {
     RESEND_NEWSLETTER_SEGMENT_ID: "segment-id",
   };
 }
+
+describe("newsletter subscribe response headers", () => {
+  it("sets Cache-Control: no-store on JSON responses (Pages Functions ignore _headers)", async () => {
+    const response = await onRequest({
+      request: new Request("https://open-design.ai/subscribe", {
+        method: "GET",
+        headers: { origin: "https://open-design.ai" },
+      }),
+      env: {},
+      waitUntil() {},
+    });
+
+    assert.equal(response.status, 405);
+    assert.equal(response.headers.get("Cache-Control"), "no-store");
+  });
+});
 
 describe("newsletter subscribe welcome email", () => {
   it("allows packaged desktop app requests from the od protocol", () => {


### PR DESCRIPTION
## Why
DeepSeek V4 Flash campaign copy is already in source for English (`Stop rationing. Use DeepSeek V4 Flash without limits.`), but production English pages often still miss it.

Live evidence from this POP:
- `/` EN home had the campaign banner
- `/pricing/` EN and `/zh/` were still on older HTML without the campaign
- all responses still sent `cache-control: public, max-age=0, s-maxage=3600, stale-while-revalidate=86400` with `cf-cache-status: HIT`

So this is not an i18n miss. Custom HTML edge TTLs in `public/_headers` overrode Cloudflare Pages deploy-scoped invalidation and kept serving the previous deployment through the SWR window. Incognito does not help because the stale copy is at the edge.

## What users will see
After deploy (+ cache purge if an old SWR copy is still pinned):
- English homepage top banner shows **Stop rationing. Use DeepSeek V4 Flash without limits.**
- English `/pricing/` shows the matching campaign surface
- New landing deploys become visible on normal refresh, not only hard reload

## Surface area
- [x] landing-page (`apps/landing-page`)
- [x] tests
- [ ] web / daemon / CLI / contracts / i18n keys / skills

## Verification
- `pnpm --filter @open-design/landing-page exec node --import tsx --test tests/cache-headers.test.ts tests/home-campaign-banner.test.ts tests/pricing-contract.test.ts` → pass
- Confirmed production still emits the old HTML Cache-Control before this change

## Deploy note
After merge, purge Cloudflare cache for HTML routes (or Purge Everything). Until purge, old `stale-while-revalidate=86400` copies can still be served from POPs that cached the previous headers.