### PR TITLE
Codex/codex integration

### DIFF
--- a/open-design-local.cmd
+++ b/open-design-local.cmd
@@ -2,23 +2,58 @@
 setlocal
 
 set "OD_ROOT=%~dp0"
-set "OD_NODE=C:\Users\jvale\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe"
-set "OD_PNPM=%OD_ROOT%.tmp\pnpm10\node_modules\pnpm\bin\pnpm.cjs"
-set "PATH=%OD_ROOT%.tmp\pnpm10\node_modules\.bin;C:\Users\jvale\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin;%PATH%"
 
-if not exist "%OD_NODE%" (
+rem Windows cannot create pnpm workspace links through a UNC current directory.
+rem Use one stable drive mapping when the repository is reached through tsclient;
+rem local-drive checkouts on the older PC continue to use their native path.
+if "%OD_ROOT:~0,2%"=="\\" (
+  if exist "%USERPROFILE%\OpenDesignRuntime\open-design-local.cmd" (
+    call "%USERPROFILE%\OpenDesignRuntime\open-design-local.cmd" %*
+    exit /b %ERRORLEVEL%
+  )
+  net use O: \\tsclient\D /persistent:no >nul 2>nul
+  if errorlevel 1 (
+    echo Unable to map the shared D drive to O: for Open Design.
+    exit /b 1
+  )
+  set "OD_ROOT=O:\full-stack\P Projects\Open Design\"
+)
+
+set "OD_CODEX_DEPS=%USERPROFILE%\.cache\codex-runtimes\codex-primary-runtime\dependencies"
+set "OD_NODE=%OD_CODEX_DEPS%\node\bin\node.exe"
+set "OD_PNPM=%OD_CODEX_DEPS%\node\node_modules\pnpm\bin\pnpm.cjs"
+set "PATH=%OD_CODEX_DEPS%\bin\override;%OD_CODEX_DEPS%\bin\fallback;%OD_CODEX_DEPS%\node\bin;%PATH%"
+
+if not exist "%OD_NODE%" set "OD_NODE=node"
+if not exist "%OD_PNPM%" set "OD_PNPM=%OD_ROOT%.tmp\pnpm10\node_modules\pnpm\bin\pnpm.cjs"
+
+if /i "%OD_NODE%"=="node" (
+  where node >nul 2>nul
+  if errorlevel 1 (
+    echo Open Design requires Node 24. Neither the bundled Codex runtime nor system Node was found.
+    exit /b 1
+  )
+) else if not exist "%OD_NODE%" (
   echo Open Design requires Node 24. The bundled Codex Node runtime was not found:
   echo   %OD_NODE%
   exit /b 1
 )
 
 if not exist "%OD_PNPM%" (
-  echo Open Design's local pnpm 10.33.2 installation was not found:
+  echo The bundled Codex pnpm installation was not found:
   echo   %OD_PNPM%
   exit /b 1
 )
 
-cd /d "%OD_ROOT%"
+if not exist "%OD_ROOT%node_modules\.bin\tools-dev.CMD" (
+  echo Preparing Open Design dependencies for this PC...
+  pushd "%OD_ROOT%" || exit /b 1
+  "%OD_NODE%" "%OD_PNPM%" install
+  if errorlevel 1 exit /b %errorlevel%
+  popd
+)
+
+pushd "%OD_ROOT%" || exit /b 1
 
 if "%~1"=="" (
   "%OD_NODE%" "%OD_PNPM%" tools-dev start web --daemon-port 7456 --web-port 7457

--- a/open-design-local.cmd
+++ b/open-design-local.cmd
@@ -1,0 +1,30 @@
+@echo off
+setlocal
+
+set "OD_ROOT=%~dp0"
+set "OD_NODE=C:\Users\jvale\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin\node.exe"
+set "OD_PNPM=%OD_ROOT%.tmp\pnpm10\node_modules\pnpm\bin\pnpm.cjs"
+set "PATH=%OD_ROOT%.tmp\pnpm10\node_modules\.bin;C:\Users\jvale\.cache\codex-runtimes\codex-primary-runtime\dependencies\node\bin;%PATH%"
+
+if not exist "%OD_NODE%" (
+  echo Open Design requires Node 24. The bundled Codex Node runtime was not found:
+  echo   %OD_NODE%
+  exit /b 1
+)
+
+if not exist "%OD_PNPM%" (
+  echo Open Design's local pnpm 10.33.2 installation was not found:
+  echo   %OD_PNPM%
+  exit /b 1
+)
+
+cd /d "%OD_ROOT%"
+
+if "%~1"=="" (
+  "%OD_NODE%" "%OD_PNPM%" tools-dev start web --daemon-port 7456 --web-port 7457
+  if errorlevel 1 exit /b %errorlevel%
+  echo Open Design is available at http://127.0.0.1:7457
+  exit /b 0
+)
+
+"%OD_NODE%" "%OD_PNPM%" tools-dev %*


### PR DESCRIPTION
<!-- Required for issue/PR auto-link. Use Fixes / Closes / Resolves so the
     linked issue closes on merge and release-time reverse lookup works.
     Delete this whole block if the PR genuinely doesn't close any issue. -->
Fixes #

## Why

<!-- Why are you opening this PR? Cover two things:
       - Your use case — what made you write this today? Did you hit it yourself
         while building on top of OD, are you scratching an itch for a team, or
         are you speculatively adding for others? All are fine, but say which.
       - The pain being addressed — user-facing problem, technical debt, a prod
         issue, or unblocking another change.
     For non-trivial features, please open a discussion or issue first to align
     on scope and UX before writing code. -->


## What users will see

<!-- Describe the change from a user's perspective, not in code terms. Examples:
       - "Settings → AI Providers has a new 'Custom endpoint' field, off by default"
       - "Right-clicking a design file shows a new 'Duplicate' option"
       - "Default model changed from X to Y — existing users will notice on first launch"
       - "New `od skills install <name>` subcommand"
     Skip this section only if you check "None" below. -->


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only


## Screenshots

<!-- If you checked "UI" above, attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->


## Bug fix verification

<!-- Skip if this PR isn't a bug fix.

     Per AGENTS.md → "Bug follow-up workflow", bugs should be encoded as a
     falsifiable test that goes red before the source change. Confirm:
       - Test path that reproduces the bug:
       - Did the test go red on `main` and green on this branch? (yes / no)
       - If a red spec wasn't cheap to write, explain why and what verification
         you did instead. -->

-


## Validation

<!-- What you actually ran. Default minimum: `pnpm guard` + `pnpm typecheck`,
     plus the package-scoped tests/build for the files you changed
     (e.g. `pnpm --filter @open-design/web test`). -->

-
