### PR TITLE
fix(pack): use runtime path for portable NSIS logs

### DIFF
--- a/tools/pack/src/win/custom-installer.ts
+++ b/tools/pack/src/win/custom-installer.ts
@@ -423,7 +423,12 @@ async function writeInstallerScript(config: ToolPackConfig, paths: WinPaths, pac
   const localUpdateDownloadsRoot = `${localDataRoot}\\updates\\downloads`;
   const localUpdateReleasesRoot = `${localDataRoot}\\updates\\releases`;
   const localUpdateStagingRoot = `${localDataRoot}\\updates\\staging`;
-  const nsisLogPath = escapeNsisString(paths.nsisLogPath);
+  const nsisLogDirectory = config.portable
+    ? `$TEMP\\${escapeNsisString(PRODUCT_NAME)}\\${escapeNsisString(sanitizeNamespace(config.namespace))}`
+    : escapeNsisString(dirname(paths.nsisLogPath));
+  const nsisLogPath = config.portable
+    ? `${nsisLogDirectory}\\nsis.log`
+    : escapeNsisString(paths.nsisLogPath);
   const runningInstancesScriptPath = join(dirname(paths.installerScriptPath), "running-instances.ps1");
   const launcherRuntimeSyncScriptPath = join(dirname(paths.installerScriptPath), "sync-launcher-runtime.ps1");
 
@@ -537,7 +542,7 @@ Var LX
 Function LogInstallerEvent
   Exch $0
   Push $1
-  CreateDirectory "${escapeNsisString(dirname(paths.nsisLogPath))}"
+  CreateDirectory "${nsisLogDirectory}"
   FileOpen $1 "${nsisLogPath}" a
   IfErrors done
   FileSeek $1 0 END
@@ -572,7 +577,7 @@ ${createLauncherRuntimeSyncScript(
 Function un.LogInstallerEvent
   Exch $0
   Push $1
-  CreateDirectory "${escapeNsisString(dirname(paths.nsisLogPath))}"
+  CreateDirectory "${nsisLogDirectory}"
   FileOpen $1 "${nsisLogPath}" a
   IfErrors done
   FileSeek $1 0 END

--- a/tools/pack/tests/win-custom-installer.test.ts
+++ b/tools/pack/tests/win-custom-installer.test.ts
@@ -1,0 +1,134 @@
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { ToolPackConfig } from "../src/config.js";
+import { buildCustomWinNsisInstaller } from "../src/win/custom-installer.js";
+import { resolveWinPaths } from "../src/win/paths.js";
+
+const BUILD_HOST_NSIS_LOG_PATH = "D:\\a\\_temp\\tools-pack\\logs\\nsis.log";
+const PORTABLE_NSIS_LOG_DIR = "$TEMP\\Open Design\\test-namespace";
+const PORTABLE_NSIS_LOG_PATH = `${PORTABLE_NSIS_LOG_DIR}\\nsis.log`;
+
+function createConfig(root: string, portable: boolean): ToolPackConfig {
+  return {
+    appVersion: "1.2.3",
+    containerized: false,
+    electronBuilderCliPath: "/unused/electron-builder",
+    electronDistPath: "/unused/electron",
+    electronVersion: "0.0.0",
+    macCompression: "normal",
+    namespace: "test-namespace",
+    platform: "win",
+    portable,
+    removeData: false,
+    removeLogs: false,
+    removeProductUserData: false,
+    removeSidecars: false,
+    requireVelaCli: false,
+    roots: {
+      cacheRoot: join(root, "cache"),
+      output: {
+        appBuilderRoot: join(root, "out", "builder"),
+        namespaceRoot: join(root, "out", "win", "namespaces", "test-namespace"),
+        platformRoot: join(root, "out", "win"),
+        root: join(root, "out"),
+      },
+      runtime: {
+        namespaceBaseRoot: join(root, "runtime", "win", "namespaces"),
+        namespaceRoot: join(root, "runtime", "win", "namespaces", "test-namespace"),
+      },
+      toolPackRoot: join(root, "tools-pack"),
+    },
+    signed: false,
+    silent: true,
+    to: "nsis",
+    webOutputMode: "standalone",
+    workspaceRoot: root,
+  };
+}
+
+function nsisFunction(script: string, name: string): string {
+  const start = script.indexOf(`Function ${name}\n`);
+  if (start < 0) throw new Error(`missing NSIS function: ${name}`);
+  const end = script.indexOf("\nFunctionEnd", start);
+  if (end < 0) throw new Error(`unterminated NSIS function: ${name}`);
+  return script.slice(start, end);
+}
+
+async function writeFakeMakensis(root: string): Promise<void> {
+  const command = join(
+    root,
+    "node_modules",
+    ".cache",
+    "electron-builder",
+    "nsis",
+    "nsis-3.0.4.1-nsis-3.0.4.1",
+    "makensis.exe",
+  );
+  await mkdir(dirname(command), { recursive: true });
+  await writeFile(
+    command,
+    `#!/bin/sh
+output=""
+for arg in "$@"; do
+  case "$arg" in
+    /DOUTPUT_EXE=*) output="\${arg#/DOUTPUT_EXE=}" ;;
+  esac
+done
+test -n "$output" || exit 2
+: > "$output"
+`,
+    "utf8",
+  );
+  await chmod(command, 0o755);
+}
+
+async function generateInstallerScript(root: string, portable: boolean): Promise<string> {
+  await writeFakeMakensis(root);
+  const config = createConfig(root, portable);
+  const paths = { ...resolveWinPaths(config), nsisLogPath: BUILD_HOST_NSIS_LOG_PATH };
+  const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+  if (platformDescriptor == null) throw new Error("process.platform descriptor is unavailable");
+
+  Object.defineProperty(process, "platform", { ...platformDescriptor, value: "win32" });
+  try {
+    await buildCustomWinNsisInstaller(config, paths);
+  } finally {
+    Object.defineProperty(process, "platform", platformDescriptor);
+  }
+  return readFile(paths.installerScriptPath, "utf8");
+}
+
+describe("buildCustomWinNsisInstaller logging", () => {
+  it("uses the same runtime-writable log path for portable install and uninstall", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-custom-installer-"));
+    try {
+      const script = await generateInstallerScript(root, true);
+      const installerLogger = nsisFunction(script, "LogInstallerEvent");
+      const uninstallerLogger = nsisFunction(script, "un.LogInstallerEvent");
+
+      for (const logger of [installerLogger, uninstallerLogger]) {
+        expect(logger).toContain(`CreateDirectory "${PORTABLE_NSIS_LOG_DIR}"`);
+        expect(logger).toContain(`FileOpen $1 "${PORTABLE_NSIS_LOG_PATH}" a`);
+      }
+      expect(script).not.toContain(BUILD_HOST_NSIS_LOG_PATH);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("retains tools-pack log readback for non-portable install and uninstall", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-win-custom-installer-"));
+    try {
+      const script = await generateInstallerScript(root, false);
+
+      expect(nsisFunction(script, "LogInstallerEvent")).toContain(`FileOpen $1 "${BUILD_HOST_NSIS_LOG_PATH}" a`);
+      expect(nsisFunction(script, "un.LogInstallerEvent")).toContain(`FileOpen $1 "${BUILD_HOST_NSIS_LOG_PATH}" a`);
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes #6554

## Why

The published Windows NSIS installer embedded the CI build machine's absolute `tools-pack` log path. Running that installer on another machine could therefore create a stray `D:\a\_temp\...` directory tree while trying to write installer diagnostics.

This keeps public/portable installer diagnostics on the end user's machine without breaking the existing non-portable `tools-pack` lifecycle log readback.

## What users will see

Portable Windows installs and uninstalls write NSIS diagnostics to `%TEMP%\Open Design\<namespace>\nsis.log` instead of a path copied from the build host. Non-portable local `tools-pack` builds continue using their configured `nsisLogPath`.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; there is no UI change.

## Bug fix verification

- Test path: `tools/pack/tests/win-custom-installer.test.ts`
- Yes. On `main`, the portable generated-script assertion went red because both logger functions contained `D:\a\_temp\tools-pack\logs\nsis.log`; it is green after the change. The same test also pins the unchanged non-portable log path.

## Validation

- `pnpm --filter @open-design/tools-pack exec vitest run tests/win-custom-installer.test.ts` — 2 passed
- `pnpm --filter @open-design/tools-pack exec vitest run tests/win-custom-installer.test.ts tests/win-nsis.test.ts tests/win-builder.test.ts tests/win-lifecycle.test.ts` — 16 passed, 1 existing skip
- `pnpm --filter @open-design/tools-pack test` — 273 passed, 8 existing skips
- `pnpm --filter @open-design/tools-pack typecheck`
- `pnpm --filter @open-design/tools-pack build`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
