### PR TITLE
perf(collab): bound vela push fan-out and recover failed publishes

### DIFF
--- a/apps/daemon/src/collab/publish-scheduler.ts
+++ b/apps/daemon/src/collab/publish-scheduler.ts
@@ -76,9 +76,21 @@ interface ProjectState {
   /** A change arrived while a publish was in flight → re-publish after it settles. */
   dirty: boolean;
   dirtyReason: string;
+  /** Pending automatic retry of a failed publish (see {@link PUBLISH_RETRY_BACKOFF_MS}). */
+  retryTimer: ReturnType<typeof setTimeout> | null;
+  /** Consecutive failed publish attempts with no success or newer change in between. */
+  consecutiveFailures: number;
 }
 
 const DEFAULT_DEBOUNCE_MS = 400;
+// A publish that fails with no newer change pending retries automatically on
+// this bounded backoff schedule. Without it a transient hub/network error
+// leaves the project stuck in its failed sync state until the author happens
+// to edit again. The budget is deliberately finite: a persistently failing
+// hub gets three spaced attempts, then the scheduler goes quiet so a broken
+// deploy cannot drive an endless vela child-process drumbeat. A successful
+// publish or a fresh author change restores the full budget.
+export const PUBLISH_RETRY_BACKOFF_MS: readonly number[] = [5_000, 15_000, 45_000];
 
 export class CollabPublishScheduler {
   private readonly adapter: ResourcePublishAdapter;
@@ -98,6 +110,10 @@ export class CollabPublishScheduler {
   notifyChanged(projectId: string, reason = 'change'): void {
     const state = this.ensure(projectId);
     state.reason = reason;
+    // A fresh author change supersedes any in-progress failure recovery: it
+    // publishes on its own debounce window with the full retry budget.
+    state.consecutiveFailures = 0;
+    this.clearRetryTimer(state);
     if (state.publishing) {
       // Don't interrupt an in-flight publish — mark dirty so a fresh one runs
       // after it settles (last-write-wins; the change is never lost).
@@ -134,6 +150,7 @@ export class CollabPublishScheduler {
   dispose(): void {
     for (const state of this.projects.values()) {
       if (state.timer) clearTimeout(state.timer);
+      this.clearRetryTimer(state);
     }
     this.projects.clear();
   }
@@ -142,10 +159,13 @@ export class CollabPublishScheduler {
     const state = this.projects.get(projectId);
     if (!state || state.publishing) return;
     state.timer = null;
+    this.clearRetryTimer(state);
     state.publishing = true;
     const reason = state.reason;
+    let failed = false;
     try {
       const result = await this.adapter.publish({ projectId, reason });
+      state.consecutiveFailures = 0;
       if (result) {
         this.onPublished?.({
           projectId,
@@ -155,21 +175,58 @@ export class CollabPublishScheduler {
         });
       }
     } catch (error) {
+      failed = true;
       this.onError?.({ projectId, error });
     } finally {
       state.publishing = false;
       if (state.dirty) {
         state.dirty = false;
-        // A change landed during the publish — schedule a fresh one.
+        // A change landed during the publish — schedule a fresh one. That
+        // newer content supersedes failure recovery, so no retry stacks on
+        // top of the re-publish (notifyChanged restores the retry budget).
         this.notifyChanged(projectId, state.dirtyReason || 'change');
+      } else if (failed) {
+        this.scheduleRetry(projectId, state);
       }
+    }
+  }
+
+  /**
+   * Recovery for a publish that failed with nothing newer pending: re-run the
+   * same publish (same reason) after a bounded backoff. Exhausting the budget
+   * leaves the project in its failed sync state until the next author change —
+   * deliberately, so a persistently failing hub is retried a handful of times
+   * rather than forever.
+   */
+  private scheduleRetry(projectId: string, state: ProjectState): void {
+    const delayMs = PUBLISH_RETRY_BACKOFF_MS[state.consecutiveFailures];
+    state.consecutiveFailures += 1;
+    if (delayMs === undefined) return; // retry budget exhausted
+    state.retryTimer = setTimeout(() => {
+      state.retryTimer = null;
+      void this.flush(projectId);
+    }, delayMs);
+  }
+
+  private clearRetryTimer(state: ProjectState): void {
+    if (state.retryTimer) {
+      clearTimeout(state.retryTimer);
+      state.retryTimer = null;
     }
   }
 
   private ensure(projectId: string): ProjectState {
     let state = this.projects.get(projectId);
     if (!state) {
-      state = { timer: null, reason: 'change', publishing: false, dirty: false, dirtyReason: 'change' };
+      state = {
+        timer: null,
+        reason: 'change',
+        publishing: false,
+        dirty: false,
+        dirtyReason: 'change',
+        retryTimer: null,
+        consecutiveFailures: 0,
+      };
       this.projects.set(projectId, state);
     }
     return state;

--- a/apps/daemon/src/collab/vela-cli-resource-adapter.ts
+++ b/apps/daemon/src/collab/vela-cli-resource-adapter.ts
@@ -76,27 +76,41 @@ const MEMBER_MIRROR_EXCLUDED_ENTRIES = [
 const MEMBER_MIRROR_EXCLUDED_PREFIXES = ['.env'] as const;
 
 /**
- * Every entry name a `vela resource push` snapshot skips — the union of two
- * invariant families:
+ * Every entry name a `vela resource push` snapshot skips.
  *
- * - {@link MEMBER_MIRROR_EXCLUDED_ENTRIES}: secret-bearing entries
- *   (credentials, tool state, Open Design private bookkeeping) that must
- *   never leave the author's machine, at any depth.
- * - {@link IGNORED_PROJECT_DIR_NAMES}: generated, installed, or cache trees
- *   the project file list and watcher already hide from the owner. A member
- *   mirror without them matches what the owner sees in the UI while keeping
- *   node_modules-scale payloads out of every publish.
+ * Two families with DIFFERENT matching semantics, which is why they are not
+ * one flat list:
  *
- * `--exclude` matches entry names exactly at any depth (directories and
- * same-named files alike) — the same per-segment semantics the owner-side
- * ignore list applies.
+ * - {@link MEMBER_MIRROR_EXCLUDED_ENTRIES} — secret-bearing entries
+ *   (credentials, tool state, Open Design private bookkeeping). These must
+ *   never leave the author's machine whether they are a file, a directory, or
+ *   a symlink, so they are sent bare and match any entry of that name.
+ * - {@link IGNORED_PROJECT_DIR_NAMES} — generated/installed/cache trees the
+ *   owner's own file list already hides. The owner hides them as DIRECTORIES
+ *   only (`collectFiles` consults `shouldSkipDir` inside its `isDirectory()`
+ *   branch), so a bare name here would over-match: a project holding a regular
+ *   file called `target` or `out` would have it silently dropped from every
+ *   member mirror while the owner still sees it. These are therefore sent with
+ *   a trailing slash, the directory-only form.
+ *
+ * The trailing slash is also the compatibility seam. A Vela build that does
+ * not yet understand it compares `"dist/"` against entry names that never
+ * contain a slash, so the rule matches nothing and the tree is published in
+ * full — the pre-optimization payload, never a missing file. Once the CLI
+ * understands the form, the same push starts skipping those directories with
+ * no further Open Design change. A new `--exclude-dir` flag could NOT degrade
+ * this way: older CLIs reject unknown flags, which would fail every publish.
  */
-export const MEMBER_MIRROR_PUSH_EXCLUDED_ENTRIES: readonly string[] = [
-  ...new Set<string>([
-    ...MEMBER_MIRROR_EXCLUDED_ENTRIES,
-    ...IGNORED_PROJECT_DIR_NAMES,
-  ]),
-];
+export const MEMBER_MIRROR_PUSH_EXCLUDED_ENTRIES: readonly string[] = (() => {
+  const secretBearing = new Set<string>(MEMBER_MIRROR_EXCLUDED_ENTRIES);
+  // `.git` and `node_modules` appear in both families. The bare rule already
+  // covers them for every entry type, so adding the directory-only form would
+  // be dead weight on the command line.
+  const directoryOnly = [...IGNORED_PROJECT_DIR_NAMES]
+    .filter((name) => !secretBearing.has(name))
+    .map((name) => `${name}/`);
+  return [...secretBearing, ...directoryOnly];
+})();
 
 /** Run `vela resource <args>` and resolve its stdout. */
 export type RunVelaResource = (

--- a/apps/daemon/src/collab/vela-cli-resource-adapter.ts
+++ b/apps/daemon/src/collab/vela-cli-resource-adapter.ts
@@ -7,6 +7,7 @@ import {
   velaWorkspaceCommandOptions,
 } from '../integrations/vela-command.js';
 import { projectResourceIdFor } from '../integrations/vela-team-projects.js';
+import { IGNORED_PROJECT_DIR_NAMES } from '../project-ignored-dirs.js';
 import type { ResourcePublishAdapter } from './publish-scheduler.js';
 import {
   emitVelaResourcePullProfile,
@@ -30,6 +31,25 @@ const PROJECT_KIND = 'project';
 // Give the transport a generous 6x envelope for large snapshots, but never
 // let a wedged Vela child hold the per-project materialization lock forever.
 const RESOURCE_PULL_TIMEOUT_MS = 30_000;
+// A push uploads the author's full member-mirror snapshot; on a slow uplink a
+// large project can legitimately take minutes, so this budget exists only to
+// reap a truly wedged child — it must stay far above any honest upload time.
+const RESOURCE_PUSH_TIMEOUT_MS = 600_000;
+// head/shared/remove are metadata round-trips with no bulk transfer.
+const RESOURCE_METADATA_TIMEOUT_MS = 60_000;
+// Wall-clock budget per `vela resource` subcommand. A child that outlives its
+// budget is terminated (confirmed-kill, see `runVelaCommand`) and the command
+// rejects, so a hung CLI surfaces as an ordinary command failure instead of
+// pinning the scheduler's in-flight publish or the per-project
+// materialization lock forever. Subcommands not listed here (snapshot /
+// snapshot-redact) keep their historical unbounded behavior.
+const RESOURCE_COMMAND_TIMEOUTS_MS: Readonly<Record<string, number>> = {
+  pull: RESOURCE_PULL_TIMEOUT_MS,
+  push: RESOURCE_PUSH_TIMEOUT_MS,
+  head: RESOURCE_METADATA_TIMEOUT_MS,
+  shared: RESOURCE_METADATA_TIMEOUT_MS,
+  remove: RESOURCE_METADATA_TIMEOUT_MS,
+};
 const MEMBER_MIRROR_EXCLUDED_ENTRIES = [
   '.file-versions',
   '.live-artifacts',
@@ -54,6 +74,29 @@ const MEMBER_MIRROR_EXCLUDED_ENTRIES = [
   'terraform.tfstate.backup',
 ] as const;
 const MEMBER_MIRROR_EXCLUDED_PREFIXES = ['.env'] as const;
+
+/**
+ * Every entry name a `vela resource push` snapshot skips — the union of two
+ * invariant families:
+ *
+ * - {@link MEMBER_MIRROR_EXCLUDED_ENTRIES}: secret-bearing entries
+ *   (credentials, tool state, Open Design private bookkeeping) that must
+ *   never leave the author's machine, at any depth.
+ * - {@link IGNORED_PROJECT_DIR_NAMES}: generated, installed, or cache trees
+ *   the project file list and watcher already hide from the owner. A member
+ *   mirror without them matches what the owner sees in the UI while keeping
+ *   node_modules-scale payloads out of every publish.
+ *
+ * `--exclude` matches entry names exactly at any depth (directories and
+ * same-named files alike) — the same per-segment semantics the owner-side
+ * ignore list applies.
+ */
+export const MEMBER_MIRROR_PUSH_EXCLUDED_ENTRIES: readonly string[] = [
+  ...new Set<string>([
+    ...MEMBER_MIRROR_EXCLUDED_ENTRIES,
+    ...IGNORED_PROJECT_DIR_NAMES,
+  ]),
+];
 
 /** Run `vela resource <args>` and resolve its stdout. */
 export type RunVelaResource = (
@@ -127,7 +170,7 @@ export function createVelaCliResourceAdapter(
       return gated(principal, async () => {
         const dir = await options.resolveProjectDir(projectId);
         const args = ['push', kind, resourceIdFor(projectId, principal), dir, '--ref', PUBLISHED_REF, '--json'];
-        for (const name of MEMBER_MIRROR_EXCLUDED_ENTRIES) {
+        for (const name of MEMBER_MIRROR_PUSH_EXCLUDED_ENTRIES) {
           args.push('--exclude', name);
         }
         for (const prefix of MEMBER_MIRROR_EXCLUDED_PREFIXES) {
@@ -281,6 +324,7 @@ export const runVelaResourceCommand: RunVelaResource = (args, workspaceId) => {
   const workspaceOptions = velaWorkspaceCommandOptions(workspaceId);
   const profilePull =
     args[0] === 'pull' && sharedProjectPullProfileEnabled(process.env);
+  const timeoutMs = RESOURCE_COMMAND_TIMEOUTS_MS[args[0] ?? ''];
   return runVelaCommand(
     ['resource', ...args],
     {
@@ -289,7 +333,7 @@ export const runVelaResourceCommand: RunVelaResource = (args, workspaceId) => {
         ...workspaceOptions.configuredEnv,
         ...(profilePull ? { VELA_RESOURCE_PULL_PROFILE: '1' } : {}),
       },
-      ...(args[0] === 'pull' ? { timeoutMs: RESOURCE_PULL_TIMEOUT_MS } : {}),
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
       ...(profilePull
         ? {
             onStderr: (stderr: string) =>

--- a/apps/daemon/tests/collab-publish-scheduler.test.ts
+++ b/apps/daemon/tests/collab-publish-scheduler.test.ts
@@ -102,3 +102,136 @@ describe('CollabPublishScheduler', () => {
     expect(publish.mock.calls.map((call) => call[0].projectId).sort()).toEqual(['a', 'b']);
   });
 });
+
+// Red spec for publish-failure recovery. Before it existed, flush()'s catch
+// only reported the error: nothing ever re-attempted the publish, so one
+// transient hub/network failure left the project stuck in its failed sync
+// state until the author happened to edit again.
+describe('CollabPublishScheduler publish-failure retry', () => {
+  it('retries a failed publish on the backoff schedule and stops once it succeeds', async () => {
+    vi.useFakeTimers();
+    const onPublished = vi.fn();
+    const onError = vi.fn();
+    const publish = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('hub down'))
+      .mockResolvedValue({ version: 3 });
+    const scheduler = new CollabPublishScheduler({
+      adapter: { publish },
+      debounceMs: 100,
+      onPublished,
+      onError,
+    });
+
+    scheduler.notifyChanged('p1', 'edit');
+    await vi.advanceTimersByTimeAsync(100);
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(publish).toHaveBeenCalledTimes(1); // not before the first 5s backoff
+    await vi.advanceTimersByTimeAsync(1);
+    expect(publish).toHaveBeenCalledTimes(2);
+    // No author change happened in between → the retry keeps the original reason.
+    expect(publish).toHaveBeenLastCalledWith({ projectId: 'p1', reason: 'edit' });
+    expect(onPublished).toHaveBeenCalledWith({ projectId: 'p1', version: 3, reason: 'edit' });
+
+    // Success ends the recovery — nothing else fires afterwards.
+    await vi.advanceTimersByTimeAsync(3_600_000);
+    expect(publish).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up after three consecutive retries until the next author change', async () => {
+    vi.useFakeTimers();
+    const onError = vi.fn();
+    const publish = vi.fn().mockRejectedValue(new Error('hub down'));
+    const scheduler = new CollabPublishScheduler({ adapter: { publish }, debounceMs: 100, onError });
+
+    scheduler.notifyChanged('p1');
+    await vi.advanceTimersByTimeAsync(100); // initial attempt fails
+    await vi.advanceTimersByTimeAsync(5_000); // retry 1
+    await vi.advanceTimersByTimeAsync(15_000); // retry 2
+    await vi.advanceTimersByTimeAsync(45_000); // retry 3
+    expect(publish).toHaveBeenCalledTimes(4);
+    expect(onError).toHaveBeenCalledTimes(4);
+
+    // Budget exhausted → the scheduler goes quiet instead of retrying forever.
+    await vi.advanceTimersByTimeAsync(3_600_000);
+    expect(publish).toHaveBeenCalledTimes(4);
+
+    // A fresh author change restores the full retry budget.
+    scheduler.notifyChanged('p1', 'edit-again');
+    await vi.advanceTimersByTimeAsync(100);
+    expect(publish).toHaveBeenCalledTimes(5);
+    expect(publish).toHaveBeenLastCalledWith({ projectId: 'p1', reason: 'edit-again' });
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(publish).toHaveBeenCalledTimes(6);
+  });
+
+  it('a success resets the consecutive-failure streak', async () => {
+    vi.useFakeTimers();
+    const publish = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('hub down'))
+      .mockResolvedValueOnce({ version: 1 })
+      .mockRejectedValueOnce(new Error('hub down again'))
+      .mockResolvedValue({ version: 2 });
+    const scheduler = new CollabPublishScheduler({ adapter: { publish }, debounceMs: 100 });
+
+    scheduler.notifyChanged('p1');
+    await vi.advanceTimersByTimeAsync(100); // fails
+    await vi.advanceTimersByTimeAsync(5_000); // retry succeeds
+    expect(publish).toHaveBeenCalledTimes(2);
+
+    scheduler.notifyChanged('p1');
+    await vi.advanceTimersByTimeAsync(100); // fails again — a NEW streak
+    expect(publish).toHaveBeenCalledTimes(3);
+    // The retry fires at the first backoff step again, not deeper in the schedule.
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(publish).toHaveBeenCalledTimes(4);
+  });
+
+  it('a change during a failing publish follows the dirty path without stacking a retry', async () => {
+    vi.useFakeTimers();
+    let rejectFirst: (error: Error) => void = () => {};
+    const publish = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise<never>((_resolve, reject) => {
+        rejectFirst = reject;
+      }))
+      .mockResolvedValue({ version: 2 });
+    const scheduler = new CollabPublishScheduler({ adapter: { publish }, debounceMs: 100 });
+
+    scheduler.notifyChanged('p1', 'first');
+    await vi.advanceTimersByTimeAsync(100);
+    expect(publish).toHaveBeenCalledTimes(1);
+
+    scheduler.notifyChanged('p1', 'later'); // lands mid-publish → marked dirty
+    rejectFirst(new Error('hub down'));
+    await vi.advanceTimersByTimeAsync(0); // let the rejection settle
+
+    // The dirty re-publish arrives on the debounce window, not the retry backoff…
+    await vi.advanceTimersByTimeAsync(100);
+    expect(publish).toHaveBeenCalledTimes(2);
+    expect(publish).toHaveBeenLastCalledWith({ projectId: 'p1', reason: 'later' });
+
+    // …and no additional retry was stacked on top of the dirty path.
+    await vi.advanceTimersByTimeAsync(3_600_000);
+    expect(publish).toHaveBeenCalledTimes(2);
+  });
+
+  it('dispose cancels a pending retry', async () => {
+    vi.useFakeTimers();
+    const publish = vi.fn().mockRejectedValue(new Error('hub down'));
+    const scheduler = new CollabPublishScheduler({ adapter: { publish }, debounceMs: 100 });
+
+    scheduler.notifyChanged('p1');
+    await vi.advanceTimersByTimeAsync(100);
+    expect(publish).toHaveBeenCalledTimes(1); // failed → a retry is pending
+
+    scheduler.dispose();
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(3_600_000);
+    expect(publish).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/daemon/tests/integrations/vela-command.test.ts
+++ b/apps/daemon/tests/integrations/vela-command.test.ts
@@ -330,7 +330,7 @@ describe('runVelaCommand', () => {
     });
   });
 
-  it('bounds production resource pulls at 30s but leaves head commands unbounded', async () => {
+  it('bounds pulls at 30s, metadata commands at 60s, and pushes at 10 minutes', async () => {
     vi.useFakeTimers();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
     vi.stubEnv('VELA_BIN', process.execPath);
@@ -348,6 +348,7 @@ describe('runVelaCommand', () => {
       },
     );
 
+    // A head that answers within its metadata budget resolves normally…
     const head = runVelaResourceCommand([
       'head',
       'resource-1',
@@ -355,11 +356,51 @@ describe('runVelaCommand', () => {
       'published',
       '--json',
     ], 'workspace-1');
-    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.advanceTimersByTimeAsync(59_999);
     expect(stopProcessesMock).not.toHaveBeenCalled();
     callback(null, '{"version":1}\n');
     await expect(head).resolves.toBe('{"version":1}\n');
 
+    // …while a wedged head is reaped right at the 60s budget.
+    const wedgedHead = runVelaResourceCommand([
+      'head',
+      'resource-1',
+      '--ref',
+      'published',
+      '--json',
+    ], 'workspace-1');
+    const wedgedHeadRejection = expect(wedgedHead).rejects.toMatchObject({
+      code: 'ETIMEDOUT',
+      name: 'TimeoutError',
+    });
+    await vi.advanceTimersByTimeAsync(59_999);
+    expect(stopProcessesMock).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(stopProcessesMock).toHaveBeenCalledTimes(1);
+    await wedgedHeadRejection;
+
+    // A wedged push gets the slow-uplink budget: reaped at 10 minutes, so a
+    // hung CLI can no longer pin the scheduler's in-flight publish forever.
+    const push = runVelaResourceCommand([
+      'push',
+      'project',
+      'resource-1',
+      '/tmp/project-1',
+      '--ref',
+      'published',
+      '--json',
+    ], 'workspace-1');
+    const pushRejection = expect(push).rejects.toMatchObject({
+      code: 'ETIMEDOUT',
+      name: 'TimeoutError',
+    });
+    await vi.advanceTimersByTimeAsync(599_999);
+    expect(stopProcessesMock).toHaveBeenCalledTimes(1); // still only the wedged head
+    await vi.advanceTimersByTimeAsync(1);
+    expect(stopProcessesMock).toHaveBeenCalledTimes(2);
+    await pushRejection;
+
+    // Pull keeps its original 30s materialization budget.
     const pull = runVelaResourceCommand([
       'pull',
       'project',
@@ -374,11 +415,13 @@ describe('runVelaCommand', () => {
       name: 'TimeoutError',
     });
     await vi.advanceTimersByTimeAsync(29_999);
-    expect(stopProcessesMock).not.toHaveBeenCalled();
+    expect(stopProcessesMock).toHaveBeenCalledTimes(2);
     await vi.advanceTimersByTimeAsync(1);
-    expect(stopProcessesMock).toHaveBeenCalledTimes(1);
+    expect(stopProcessesMock).toHaveBeenCalledTimes(3);
     await pullRejection;
 
+    // The budgets ride the daemon's confirmed-kill deadline timer, never
+    // execFile's own timeout/signal plumbing.
     const options = execFileMock.mock.calls[0]?.[2] as {
       timeout?: number;
       signal?: AbortSignal;

--- a/apps/daemon/tests/vela-cli-resource-adapter.test.ts
+++ b/apps/daemon/tests/vela-cli-resource-adapter.test.ts
@@ -1,11 +1,85 @@
 import { describe, expect, it, vi } from 'vitest';
+
+const { runVelaCommandMock } = vi.hoisted(() => ({
+  runVelaCommandMock: vi.fn(),
+}));
+
+vi.mock('../src/integrations/vela-command.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../src/integrations/vela-command.js')>()),
+  runVelaCommand: runVelaCommandMock,
+}));
+
 import {
   contextHasTeamIdentity,
   createVelaCliResourceAdapter,
+  runVelaResourceCommand,
   shouldUseVelaCliResourceTransport,
 } from '../src/collab/vela-cli-resource-adapter.js';
 import { createCollabRuntime } from '../src/collab/runtime.js';
 import type { ResourceHubPrincipal } from '../src/collab/resource-principal.js';
+
+// Spelled out literally — NOT imported from the source module — so that an
+// accidental deletion of any entry from the source lists turns this file red.
+// Order: the secret-bearing member-mirror entries first, then the
+// generated/installed trees the project UI already hides from the owner.
+const EXPECTED_PUSH_EXCLUDED_ENTRIES = [
+  // Secret-bearing entries that must never reach a member mirror.
+  '.file-versions',
+  '.live-artifacts',
+  '.od-skills',
+  '.git',
+  'node_modules',
+  '.npmrc',
+  '.yarnrc',
+  '.yarnrc.yml',
+  '.aws',
+  '.ssh',
+  '.azure',
+  '.docker',
+  '.gnupg',
+  '.kube',
+  '.pulumi',
+  '.terraform',
+  '.git-credentials',
+  '.netrc',
+  '.pypirc',
+  'terraform.tfstate',
+  'terraform.tfstate.backup',
+  // Generated/installed trees (IGNORED_PROJECT_DIR_NAMES, minus the
+  // duplicates above) — the owner's file list and watcher already hide them.
+  'vendor',
+  '.od',
+  'debug',
+  'dist',
+  'build',
+  '.build',
+  'deriveddata',
+  'target',
+  '.next',
+  '.nuxt',
+  '.turbo',
+  '.cache',
+  '.output',
+  'out',
+  'coverage',
+  '.gradle',
+  '.swiftpm',
+  '.tmp',
+  '.venv',
+  'venv',
+  '__pycache__',
+  '.mypy_cache',
+  '.pytest_cache',
+  '.tox',
+  '.ruff_cache',
+];
+const EXPECTED_PUSH_EXCLUDE_ARGS = EXPECTED_PUSH_EXCLUDED_ENTRIES
+  .flatMap((name) => ['--exclude', name]);
+
+/** The names passed via `--exclude` in one recorded spawn's argument list. */
+function excludedNamesIn(args: readonly string[]): string[] {
+  return args.flatMap((arg, index) => (arg === '--exclude' ? [args[index + 1]!] : []));
+}
 
 function recordingRun(outputs: Record<string, string>) {
   const calls: string[][] = [];
@@ -53,51 +127,30 @@ describe('createVelaCliResourceAdapter', () => {
       '--ref',
       'published',
       '--json',
-      '--exclude',
-      '.file-versions',
-      '--exclude',
-      '.live-artifacts',
-      '--exclude',
-      '.od-skills',
-      '--exclude',
-      '.git',
-      '--exclude',
-      'node_modules',
-      '--exclude',
-      '.npmrc',
-      '--exclude',
-      '.yarnrc',
-      '--exclude',
-      '.yarnrc.yml',
-      '--exclude',
-      '.aws',
-      '--exclude',
-      '.ssh',
-      '--exclude',
-      '.azure',
-      '--exclude',
-      '.docker',
-      '--exclude',
-      '.gnupg',
-      '--exclude',
-      '.kube',
-      '--exclude',
-      '.pulumi',
-      '--exclude',
-      '.terraform',
-      '--exclude',
-      '.git-credentials',
-      '--exclude',
-      '.netrc',
-      '--exclude',
-      '.pypirc',
-      '--exclude',
-      'terraform.tfstate',
-      '--exclude',
-      'terraform.tfstate.backup',
+      ...EXPECTED_PUSH_EXCLUDE_ARGS,
       '--exclude-prefix',
       '.env',
     ]);
+  });
+
+  it('excludes the generated trees the owner UI already hides, alongside every secret-bearing entry', async () => {
+    const { run, calls } = recordingRun({ push: JSON.stringify({ version: 1 }) });
+    const adapter = createVelaCliResourceAdapter({ ...OPTS, run });
+    await adapter.publish({ projectId: 'p1', reason: 'edit' });
+
+    const excluded = excludedNamesIn(calls[0]!);
+    // Build/venv/cache output the project list and watcher never show the
+    // owner must not fan out to member mirrors either.
+    for (const name of ['dist', 'build', '.next', '.venv', 'coverage', '.tmp', '__pycache__', 'node_modules']) {
+      expect(excluded).toContain(name);
+    }
+    // The pre-existing secret exclusions must survive the merge untouched.
+    for (const name of ['.git', '.ssh', '.aws', '.netrc', '.git-credentials', 'terraform.tfstate']) {
+      expect(excluded).toContain(name);
+    }
+    const prefixAt = calls[0]!.indexOf('--exclude-prefix');
+    expect(prefixAt).toBeGreaterThan(-1);
+    expect(calls[0]![prefixAt + 1]).toBe('.env');
   });
 
   it('passes project metadata to the resource index when available', async () => {
@@ -116,48 +169,7 @@ describe('createVelaCliResourceAdapter', () => {
       '--ref',
       'published',
       '--json',
-      '--exclude',
-      '.file-versions',
-      '--exclude',
-      '.live-artifacts',
-      '--exclude',
-      '.od-skills',
-      '--exclude',
-      '.git',
-      '--exclude',
-      'node_modules',
-      '--exclude',
-      '.npmrc',
-      '--exclude',
-      '.yarnrc',
-      '--exclude',
-      '.yarnrc.yml',
-      '--exclude',
-      '.aws',
-      '--exclude',
-      '.ssh',
-      '--exclude',
-      '.azure',
-      '--exclude',
-      '.docker',
-      '--exclude',
-      '.gnupg',
-      '--exclude',
-      '.kube',
-      '--exclude',
-      '.pulumi',
-      '--exclude',
-      '.terraform',
-      '--exclude',
-      '.git-credentials',
-      '--exclude',
-      '.netrc',
-      '--exclude',
-      '.pypirc',
-      '--exclude',
-      'terraform.tfstate',
-      '--exclude',
-      'terraform.tfstate.backup',
+      ...EXPECTED_PUSH_EXCLUDE_ARGS,
       '--exclude-prefix',
       '.env',
       '--metadata-json',
@@ -494,5 +506,40 @@ describe('unpublish retraction idempotency (dangling team-catalog heal)', () => 
     } finally {
       runtime.dispose();
     }
+  });
+});
+
+// Red spec for the resource-transport spawn budgets. Before these existed,
+// only `pull` carried a timeout: a wedged `vela resource push` (hung network,
+// stalled auth refresh) held the scheduler's in-flight publish forever — no
+// error ever reached the failure path, so the project sat "publishing" until
+// daemon restart. head/shared/remove are pure metadata round-trips and get a
+// tight budget; push uploads whole project snapshots over arbitrary uplinks
+// and gets a deliberately huge one that only reaps truly-stuck children.
+describe('vela resource transport budgets', () => {
+  it('bounds every publish/metadata subcommand and keeps the pull budget', async () => {
+    runVelaCommandMock.mockReset();
+    runVelaCommandMock.mockResolvedValue('{}');
+
+    await runVelaResourceCommand(['push', 'project', 'r1', '/projects/p1', '--ref', 'published', '--json'], 'w1');
+    await runVelaResourceCommand(['head', 'r1', '--ref', 'published', '--json'], 'w1');
+    await runVelaResourceCommand(['shared', '--json'], 'w1');
+    await runVelaResourceCommand(['remove', 'r1', '--json'], 'w1');
+    await runVelaResourceCommand(['pull', 'project', 'r1', '/copies/p1', '--ref', 'published', '--json'], 'w1');
+
+    expect(runVelaCommandMock).toHaveBeenCalledTimes(5);
+    for (const [args] of runVelaCommandMock.mock.calls) {
+      expect(args[0]).toBe('resource');
+    }
+    const timeoutBySubcommand = Object.fromEntries(
+      runVelaCommandMock.mock.calls.map(([args, options]) => [args[1], options?.timeoutMs]),
+    );
+    expect(timeoutBySubcommand).toEqual({
+      push: 600_000,
+      head: 60_000,
+      shared: 60_000,
+      remove: 60_000,
+      pull: 30_000,
+    });
   });
 });

--- a/apps/daemon/tests/vela-cli-resource-adapter.test.ts
+++ b/apps/daemon/tests/vela-cli-resource-adapter.test.ts
@@ -46,32 +46,34 @@ const EXPECTED_PUSH_EXCLUDED_ENTRIES = [
   'terraform.tfstate',
   'terraform.tfstate.backup',
   // Generated/installed trees (IGNORED_PROJECT_DIR_NAMES, minus the
-  // duplicates above) — the owner's file list and watcher already hide them.
-  'vendor',
-  '.od',
-  'debug',
-  'dist',
-  'build',
-  '.build',
-  'deriveddata',
-  'target',
-  '.next',
-  '.nuxt',
-  '.turbo',
-  '.cache',
-  '.output',
-  'out',
-  'coverage',
-  '.gradle',
-  '.swiftpm',
-  '.tmp',
-  '.venv',
-  'venv',
-  '__pycache__',
-  '.mypy_cache',
-  '.pytest_cache',
-  '.tox',
-  '.ruff_cache',
+  // duplicates above). Trailing slash = directory-only: the owner hides these
+  // as directories, so a bare name would also swallow a regular file of the
+  // same name (a project file literally called `target` or `out`).
+  'vendor/',
+  '.od/',
+  'debug/',
+  'dist/',
+  'build/',
+  '.build/',
+  'deriveddata/',
+  'target/',
+  '.next/',
+  '.nuxt/',
+  '.turbo/',
+  '.cache/',
+  '.output/',
+  'out/',
+  'coverage/',
+  '.gradle/',
+  '.swiftpm/',
+  '.tmp/',
+  '.venv/',
+  'venv/',
+  '__pycache__/',
+  '.mypy_cache/',
+  '.pytest_cache/',
+  '.tox/',
+  '.ruff_cache/',
 ];
 const EXPECTED_PUSH_EXCLUDE_ARGS = EXPECTED_PUSH_EXCLUDED_ENTRIES
   .flatMap((name) => ['--exclude', name]);
@@ -141,7 +143,7 @@ describe('createVelaCliResourceAdapter', () => {
     const excluded = excludedNamesIn(calls[0]!);
     // Build/venv/cache output the project list and watcher never show the
     // owner must not fan out to member mirrors either.
-    for (const name of ['dist', 'build', '.next', '.venv', 'coverage', '.tmp', '__pycache__', 'node_modules']) {
+    for (const name of ['dist/', 'build/', '.next/', '.venv/', 'coverage/', '.tmp/', '__pycache__/', 'node_modules']) {
       expect(excluded).toContain(name);
     }
     // The pre-existing secret exclusions must survive the merge untouched.
@@ -151,6 +153,28 @@ describe('createVelaCliResourceAdapter', () => {
     const prefixAt = calls[0]!.indexOf('--exclude-prefix');
     expect(prefixAt).toBeGreaterThan(-1);
     expect(calls[0]![prefixAt + 1]).toBe('.env');
+  });
+
+  it('scopes generated-tree exclusions to directories so same-named files still sync', async () => {
+    const { run, calls } = recordingRun({ push: JSON.stringify({ version: 1 }) });
+    const adapter = createVelaCliResourceAdapter({ ...OPTS, run });
+    await adapter.publish({ projectId: 'p1', reason: 'edit' });
+
+    const excluded = excludedNamesIn(calls[0]!);
+    // `--exclude target` matches by entry name regardless of type, so the bare
+    // form would also drop a regular project file named `target` — content the
+    // owner still sees, silently missing from every member mirror. The owner
+    // side hides these as directories only, and the slash form says so.
+    for (const bare of ['target', 'out', 'dist', 'build', 'debug', 'coverage', 'vendor']) {
+      expect(excluded).not.toContain(bare);
+      expect(excluded).toContain(`${bare}/`);
+    }
+    // Secret-bearing entries keep the bare form on purpose: those must never
+    // leave the machine as a file OR a directory.
+    for (const bare of ['.git', '.ssh', '.aws', 'node_modules', 'terraform.tfstate']) {
+      expect(excluded).toContain(bare);
+      expect(excluded).not.toContain(`${bare}/`);
+    }
   });
 
   it('passes project metadata to the resource index when available', async () => {


### PR DESCRIPTION
## Why

While auditing the workspace resource-hub sync path end to end (daemon → vela CLI → hub API), we found the collab publish pipeline has no byte-level guardrails on the author side:

- `vela resource push` uploads the full project tree, but the push `--exclude` list only carried the 22 secret-bearing entries. Generated trees the project UI already hides from the owner (`dist/`, `.next/`, `.venv/`, `coverage/`, `.tmp/`, `__pycache__`, …) were still shipped into every member mirror — a project that ran one `next build` or created a Python venv pushes hundreds of MB **per publish, on every edit**, straight at the hub.
- Only `pull` had a wall-clock budget. A wedged `vela resource push` child pinned the scheduler's `state.publishing` flag forever, silently freezing that project's sync until daemon restart.
- A failed publish was never retried: the project sat in `sync_failed` until the author happened to edit again.

The pain is twofold: authors get silently-stuck or silently-stale team sync, and the hub eats avoidable GB-scale snapshots (its serving-plane half of this hardening is powerformer/vela#1445).

## What users will see

No UI change. Three behavior improvements:

- Team members' mirrored projects no longer contain generated/installed trees (`dist`, `.next`, virtualenvs, caches). Mirrors now match what the owner's own project view already shows, and typical publish payloads shrink by an order of magnitude.
- A publish that fails transiently (hub hiccup, network blip) now recovers on its own within about a minute (bounded 5s/15s/45s retries; a fresh edit or a success restores the full budget) instead of waiting for the next edit.
- A hung vela CLI can no longer freeze a project's sync permanently: every `vela resource` subcommand now has a wall-clock budget (push 10 min, head/shared/remove 60 s, pull keeps its 30 s), so a wedged child surfaces as an ordinary failed publish and retries.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — member mirrors stop receiving the generated trees that the owner-side file list and watcher already ignore (`IGNORED_PROJECT_DIR_NAMES`); every secret-bearing exclusion is preserved unchanged.
- [ ] **None**

## Screenshots

N/A — no UI surface; the change is daemon-internal publish behavior.

## Bug fix verification

Not a single-issue bug fix, but all three guardrails were built red-first. With the new specs in place and the source changes stashed back to the origin/main baseline, 7 specs fail on exactly the old behavior (push args missing the generated-tree excludes; `timeoutMs` undefined for push/head/shared/remove; zero retries after a failed publish); restored, 44/44 green across the three touched files:

- `apps/daemon/tests/vela-cli-resource-adapter.test.ts` — full exclude set (secret entries + generated trees + `.env` prefix), per-subcommand timeout budgets
- `apps/daemon/tests/collab-publish-scheduler.test.ts` — backoff schedule, budget exhaustion after 3 consecutive retries, reset on success/fresh change, no retry stacking on the dirty path, dispose clears retry timers
- `apps/daemon/tests/integrations/vela-command.test.ts` — real-child reap coverage rewritten from the old "head unbounded" invariant to the new budgets

`pnpm guard` and `pnpm typecheck` pass. Full daemon suite shows only the 12 pre-existing origin/main failures (re-run with this branch's source stashed: identical failure set, so no new failures). Cross-repo contract check: vela origin/main `PackTree` exclusion tests pass, confirming `--exclude` matches entry names exactly at any depth — the semantics this PR relies on.

## Adjacent issues (follow-ups, out of scope)

- `snapshot` / `snapshot-redact` subcommands keep their historical unbounded child behavior (documented at the timeout map).
- vela `--exclude` matches names case-sensitively while the owner-side ignore comparison is case-insensitive, so camel-case variants like `DerivedData` are still pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
