### PR TITLE
fix: add missing sandbox permissions for interactive HTML previews (allow-forms, allow-popups, allow-modals)

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -3730,7 +3730,7 @@ function FileVersionManagerModal({
                         <iframe
                           ref={versionPreviewIframeRef}
                           title={selectedVersion ? `${file.name} v${selectedVersion.version}` : file.name}
-                          sandbox="allow-scripts allow-downloads"
+                          sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
                           srcDoc={srcDoc}
                           onLoad={() => setLoadedSrcDoc(srcDoc)}
                         />
@@ -5857,7 +5857,7 @@ function ReactComponentViewer({
             <iframe
               data-testid="react-component-preview-frame"
               title={file.name}
-              sandbox="allow-scripts allow-downloads"
+              sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
               srcDoc={srcDoc}
               style={{ width: '100%', height: '100%', border: 0 }}
             />
@@ -13445,7 +13445,7 @@ function HtmlViewer({
                         aria-hidden={useUrlLoadPreview ? true : undefined}
                         tabIndex={useUrlLoadPreview ? -1 : 0}
                         title={file.name}
-                        sandbox="allow-scripts allow-downloads"
+                        sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
                         srcDoc={srcDocTransportContent}
                         onLoad={() => {
                           const frame = srcDocPreviewIframeRef.current;
@@ -13771,7 +13771,7 @@ function HtmlViewer({
           {effectiveDeck || !useUrlLoadPreview ? (
             <iframe
               title="present"
-              sandbox="allow-scripts allow-downloads"
+              sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
               data-od-render-mode="srcdoc"
               srcDoc={effectiveDeck ? presentationSrcDoc : srcDoc}
             />


### PR DESCRIPTION
## Summary

The `srcDoc` iframe sandbox was too restrictive (`allow-scripts allow-downloads` only), which prevented interactive HTML prototypes from working properly — buttons, forms, popups, and modal dialogs were non-responsive after the v0.18.0 update.

## Root Cause

As discussed in the issue, PR #5469 (redirect-loop guard) routes HTML files that match navigation patterns to the `srcDoc` inline path. The `srcDoc` path uses `sandbox="allow-scripts allow-downloads"` which is missing `allow-forms`, `allow-popups`, and `allow-modals` — all needed for interactive prototypes to function.

The reporter confirmed:
- No redirect-loop messages in console
- Buttons do not work from the first click
- The same HTML file works in a regular browser
- No JavaScript errors

## Changes

Updated all 4 `srcDoc` iframe sandbox attributes in `FileViewer.tsx`:

| Location | Previous | New |
|:---|:---|:---|
| Version preview (line 3733) | `allow-scripts allow-downloads` | `allow-scripts allow-forms allow-popups allow-modals allow-downloads` |
| React component preview (line 5860) | `allow-scripts allow-downloads` | `allow-scripts allow-forms allow-popups allow-modals allow-downloads` |
| Main artifact preview (line 13448) | `allow-scripts allow-downloads` | `allow-scripts allow-forms allow-popups allow-modals allow-downloads` |
| Present overlay (line 13774) | `allow-scripts allow-downloads` | `allow-scripts allow-forms allow-popups allow-modals allow-downloads` |

URL-load path iframes (lines 1929, 13781, 13392, 13420) are not affected by this issue and remain unchanged.

Fixes #6563