### PR TITLE
fix(release): resolve #6570 leftover conflict markers

### DIFF
--- a/apps/web/src/components/EntryShell.tsx
+++ b/apps/web/src/components/EntryShell.tsx
@@ -422,11 +422,8 @@ interface Props {
    * vela login-status account/user plan (ACCOUNT-scoped). Used for personal
    * workspaces so a confirmed free account is not stuck as campaign audience
    * `unknown` while billing summary leaves `membershipTier` empty.
-<<<<<<< HEAD
    * Must not be applied to team workspaces — team plan comes from workspace
    * billing/snapshot (see App `resolvedAmrPlan`).
-=======
->>>>>>> caae6a373 (feat(web): localize DeepSeek V4 Flash campaign (19 locales) (#6561))
    */
   amrAccountPlan?: string | null;
   daemonLive: boolean;
@@ -630,16 +627,12 @@ export function EntryShell({
     workspaceContext,
   );
   const deepSeekCampaignVisibility = useDeepSeekV4FlashCampaignVisibility();
-<<<<<<< HEAD
   // Same personal-vs-team accountPlan rule as App's `resolvedAmrPlan`: team
   // entitlements live on the workspace snapshot, not the login projection.
   // Without personal `accountPlan: free`, a no-subscription user keeps
   // plan=null after billing settles (empty membershipTier + context
   // billingState "active" from lifecycle), audience stays unknown, and the
   // home campaign modal never opens — matching product unpaid free users.
-=======
-  // Same personal-vs-team accountPlan rule as App's `resolvedAmrPlan`.
->>>>>>> caae6a373 (feat(web): localize DeepSeek V4 Flash campaign (19 locales) (#6561))
   const deepSeekCampaignPlan = resolvePlanLabelTier({
     billing: workspaceBilling,
     context: workspaceContext,
@@ -1573,13 +1566,10 @@ export function EntryShell({
               lives in the rail footer, and everything below is fixed-position
               or portalled so it occupies no layout space here. */}
           <WhatsNewPopup active={view === 'home'} />
-<<<<<<< HEAD
           {/* Portal to body so the pill is not trapped under
               .workspace-tabs-chrome (z-index 120) — the tabs strip is a
               full-width hit target in that header and was swallowing
               clicks on the top-right badge even after raising its own z-index. */}
-=======
->>>>>>> caae6a373 (feat(web): localize DeepSeek V4 Flash campaign (19 locales) (#6561))
           {view === 'home'
             && deepSeekV4FlashCampaignAudience !== 'unknown'
             && typeof document !== 'undefined'
@@ -1588,17 +1578,10 @@ export function EntryShell({
                 type="button"
                 className="entry-deepseek-campaign-badge"
                 onClick={openDeepSeekCampaignPricing}
-<<<<<<< HEAD
-                aria-label="DeepSeek V4 无限免费用，查看官网 Pricing"
-                data-testid="deepseek-campaign-pricing-badge"
-              >
-                <span>DeepSeek V4无限免费用</span>
-=======
                 aria-label={t('campaign.deepseekV4Flash.workbenchBadgeAria')}
                 data-testid="deepseek-campaign-pricing-badge"
               >
                 <span>{t('campaign.deepseekV4Flash.workbenchBadge')}</span>
->>>>>>> caae6a373 (feat(web): localize DeepSeek V4 Flash campaign (19 locales) (#6561))
                 <Icon name="arrow-right" size={13} />
               </button>,
               document.body,

--- a/apps/web/src/styles/home/entry-layout.css
+++ b/apps/web/src/styles/home/entry-layout.css
@@ -1054,12 +1054,8 @@
 
 .entry-deepseek-campaign-badge {
   position: fixed;
-<<<<<<< HEAD
   /* Portaled to document.body (EntryShell). Must clear .workspace-tabs-chrome
      (z-index: 120) and stay under campaign modal / dialogs (~1700). */
-=======
-  /* Portaled to document.body. Must clear .workspace-tabs-chrome (z-index: 120). */
->>>>>>> caae6a373 (feat(web): localize DeepSeek V4 Flash campaign (19 locales) (#6561))
   z-index: 150;
   top: 18px;
   right: 22px;
@@ -1082,10 +1078,7 @@
   text-decoration: none;
   cursor: pointer;
   pointer-events: auto;
-<<<<<<< HEAD
   /* Header chrome is -webkit-app-region: drag; keep the pill clickable on desktop. */
-=======
->>>>>>> caae6a373 (feat(web): localize DeepSeek V4 Flash campaign (19 locales) (#6561))
   -webkit-app-region: no-drag;
   transition: border-color 140ms ease, background 140ms ease, transform 140ms ease;
 }


### PR DESCRIPTION
## Why

#6570 (`BACKPORT-CONFLICT`) was merged into `release/v0.18.1` with **unresolved git conflict markers** still in source. That breaks `next build` / prerelease packaging (e.g. run 31134967017 mac arm64).

## What users will see

No product change. Unblocks prerelease builds on `release/v0.18.1`.

## Resolution

- `EntryShell.tsx`: keep release-side docs on `amrAccountPlan` / audience; keep portal comment; **use i18n keys** for badge copy (not hardcoded Chinese).
- `entry-layout.css`: keep portal z-index / `no-drag` comments and styles; drop markers only.

## Surface area

- [x] **UI** — no visible change (conflict cleanup)
- [ ] **None** — packaging blocker

## Validation

- Confirmed no `<<<<<<<` / `>>>>>>>` / bare `=======` markers remain under `apps/web`.
- Typecheck running in parallel after install.

**Do not ship 0.18.1 until this lands.**