### PR TITLE
ci(backport): label conflicted backports so the release pre-flight check has a signal

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -2,7 +2,8 @@ name: backport
 # When a PR merged into main carries a "backport release/vX.Y.Z" label, cherry-pick it onto
 # the matching release branch and open a PR. The App token (not GITHUB_TOKEN) opens the PR so
 # it triggers ci.yml. On conflict it opens a draft PR (conflict markers committed) so nothing
-# is silently lost and a human resolves it.
+# is silently lost and a human resolves it. That draft is also labelled `backport-failed`, which
+# is the signal the release owner's pre-flight check looks for (see open-design-release skill).
 
 on:
   pull_request_target:
@@ -65,6 +66,7 @@ jobs:
           token: ${{ steps.app.outputs.token }}
 
       - name: Backport
+        id: backport
         if: steps.authz.outputs.ok == 'true'
         uses: korthout/backport-action@v3
         with:
@@ -83,3 +85,37 @@ jobs:
           # (triggered by ci.yml completing on the backport-* branch). release/v* has no merge
           # queue and no required status check, so GitHub auto-merge / enqueuePullRequest don't
           # apply here; that workflow gates on ci.yml's own success instead.
+
+      - name: Label conflicted backports
+        # A conflicted backport is opened as a draft with the conflict markers committed
+        # (conflict_resolution: draft_commit_conflicts). Nothing else distinguishes it: its title
+        # is byte-identical to a clean pick's, so in a PR list it is indistinguishable from one
+        # that is ready to merge. Draft is the only tell, and a draft can be flipped to ready by
+        # anyone. Label it so the signal survives that flip -- and so the release owner's
+        # pre-flight check, `gh pr list --label backport-failed --state open`, is actually wired
+        # to something instead of always returning empty.
+        if: >-
+          steps.authz.outputs.ok == 'true'
+          && steps.backport.outputs.created_pull_numbers != ''
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          REPO: ${{ github.repository }}
+          CREATED: ${{ steps.backport.outputs.created_pull_numbers }}
+          BY_TARGET: ${{ steps.backport.outputs.was_successful_by_target }}
+        run: |
+          set -euo pipefail
+          echo "backport results by target: ${BY_TARGET:-<none>}"
+
+          # Idempotent: --force updates the label if it already exists, creates it otherwise.
+          gh label create backport-failed \
+            --repo "$REPO" \
+            --color B60205 \
+            --description 'Backport hit conflicts; markers are committed and a human must resolve them' \
+            --force
+
+          for pr in $CREATED; do
+            if [ "$(gh api "repos/$REPO/pulls/$pr" --jq '.draft')" = "true" ]; then
+              gh pr edit "$pr" --repo "$REPO" --add-label backport-failed
+              echo "::warning::#$pr is a conflicted backport -- conflict markers are committed, do not merge until resolved"
+            fi
+          done


### PR DESCRIPTION
## Why

`docs/AGENTS.md` and the `open-design-release` skill both describe a `backport-failed` label as the marker for a backport that hit conflicts, and the skill's release pre-flight step tells the release owner to run:

```bash
gh pr list --repo nexu-io/open-design --label backport-failed --state open
```

That label has never existed. It is not defined in the repo's label set, `git grep backport-failed .github/` returns nothing, and zero PRs have ever carried it. So the pre-flight check returns empty every single time — not because there are no stuck backports, but because nothing ever emits the signal. **That is worse than having no check at all: it reads as "verified clean".**

This bit today. #6570 (`[backport release/v0.18.1] feat(web): localize DeepSeek V4 Flash campaign`) hit conflicts, so `conflict_resolution: draft_commit_conflicts` committed the markers and opened it as a draft — working as designed. But nothing else set it apart: its title is byte-identical to a clean pick's, and draft was the only tell. Once the draft was flipped to ready, it merged into `release/v0.18.1` carrying live conflict markers in `apps/web/src/components/EntryShell.tsx` (4 blocks) and `apps/web/src/styles/home/entry-layout.css`. CI caught it correctly — `Validate workspace` failed in 3 seconds, along with Preflight, both web workspace shards, three UI P0 jobs and two Playwright visual jobs — but `release/v*` carries no required status check, so a red CI could not stop the merge.

`backport-automerge.yml` does gate on ci.yml succeeding, and that path stayed safe. The gap is that it only guards *automatic* merges; a human merge bypasses the only gatekeeper the release branch has.

## What users will see

Nothing directly — this is repository automation. Indirectly: a conflicted backport can no longer reach a release branch disguised as a clean one, so a release is less likely to ship from a branch that does not build.

For maintainers, a conflicted backport now arrives labelled `backport-failed` (red), and the release pre-flight command finally has something to find.

## What changed

- `Backport` step gains `id: backport` so its outputs are addressable.
- New `Label conflicted backports` step: for every PR in `created_pull_numbers`, if the PR is a draft (which under `draft_commit_conflicts` means the cherry-pick conflicted), create the label if missing (`gh label create --force`, idempotent) and apply it, plus emit a `::warning::` naming the PR. `was_successful_by_target` is echoed for the run log.
- Header comment documents the label and points at the skill's pre-flight check.

Draft is the right predicate rather than `was_successful`: it maps 1:1 to "a human must resolve this before merge", and it is per-PR rather than per-target. The label also **survives the draft being flipped to ready** — which is exactly the transition that let #6570 through.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — one workflow file under `.github/workflows/`

## Screenshots

Not applicable — repository automation.

## Bug fix verification

Not a product bug; this closes a missing-signal gap in release tooling. The triggering incident is #6570 merging conflict markers into `release/v0.18.1`.

## Validation

- `ruby -ryaml` parses the workflow; the five steps resolve with `Backport` carrying `id: backport`.
- The step's `run` block passes `bash -n`.
- Output names verified against `korthout/backport-action@v3`'s own `action.yml`: `created_pull_numbers` (space-separated, empty when no PRs were created), `was_successful`, `was_successful_by_target`.
- `gh label create --force` is idempotent, so the first conflicted backport after this merges creates the label and every later one reuses it.

## Adjacent issues (not fixed here)

1. **`release/v*` has no required status check.** `CI enforcement` (which carries `Validate workspace` and, importantly, an empty `bypass_actors`) applies only to `~DEFAULT_BRANCH`. `Protected branches (preview/*, release/v*)` has no status-check rule and does let admins bypass. So protection is inverted today: a two-markdown-file PR is blocked on `main`, while a PR full of conflict markers merges into the branch that ships to users. Widening the CI enforcement ruleset to `refs/heads/release/v*` would close it — a ruleset change, deliberately not bundled into a code PR, and worth weighing against the fact that an empty `bypass_actors` also locks the release branch whenever Actions is down (as during today's `qcvjkzcs7j74` outage).
2. **`AGENTS.md` overstates the current flow** by describing the label as existing behaviour. Once this merges the description becomes accurate, so no doc change is needed — but if this is rejected, the doc should lose the claim instead.
