### PR TITLE
fix(web): stop replaying stale succeeded Design runs on reload

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -126,6 +126,7 @@ import {
 } from '../runtime/chat-events';
 import type { RunFailureClassificationFields } from '../runtime/chat-events';
 import {
+  designDeliveryReconciliationStale,
   designDeliveryVerificationPending,
   isRetryableAssistantTerminalFailure,
   resolveDesignDeliveryOutcome,
@@ -11367,7 +11368,14 @@ export function shouldReplayTerminalRunMessage(message: ChatMessage): boolean {
   // A daemon can persist terminal success before the browser finishes its
   // project-file refresh. Reattach once even when prose already exists so the
   // delivery invariant can confirm a file or downgrade the turn after reload.
-  if (designDeliveryVerificationPending(message)) return true;
+  if (designDeliveryVerificationPending(message)) {
+    // #6505: a historical succeeded Design row whose delivery metadata never
+    // materialized must not be replayed/reattached on every reload. Bound
+    // reconciliation to a short window after the run's terminal time; past it,
+    // the row renders as a terminal outcome instead of looping through replay.
+    if (designDeliveryReconciliationStale(message)) return false;
+    return true;
+  }
   if (message.content.trim().length > 0) return false;
   if (
     message.startedAt == null

--- a/apps/web/src/runtime/design-delivery.ts
+++ b/apps/web/src/runtime/design-delivery.ts
@@ -117,3 +117,35 @@ export function designDeliveryVerificationPending(
   if (isIntermediateDesignTurn(message.content, message.events)) return false;
   return message.producedFiles === undefined || message.traceObjectFiles === undefined;
 }
+
+/**
+ * A succeeded Design message that still lacks delivery metadata long after its
+ * run finished is a historical row whose delivery never materialized (e.g. a
+ * row persisted by an older build before the final project-file refresh, or an
+ * interrupted persistence path). Auto-replaying such a row on every reload is
+ * the #6505 loop — the metadata will never appear, so each reload re-enters the
+ * reattach path and the chat stays visually loading.
+ *
+ * Reconcile only within a short window after the run's terminal time (enough
+ * for the run-status event to race ahead of the project-file refresh the
+ * `designDeliveryVerificationPending` gap exists to absorb); past that window
+ * the row is treated as a terminal outcome instead of being replayed.
+ */
+export function designDeliveryReconciliationStale(
+  message: Pick<
+    ChatMessage,
+    'sessionMode' | 'runStatus' | 'resultDeliveryState' | 'endedAt'
+  >,
+  now: number = Date.now(),
+): boolean {
+  if (message.sessionMode !== 'design' || message.runStatus !== 'succeeded') return false;
+  if (message.resultDeliveryState) return false;
+  const terminalAt = message.endedAt;
+  // No terminal timestamp (legacy row) — defer to the existing verification
+  // logic rather than guessing an age.
+  if (terminalAt == null) return false;
+  return now - terminalAt > DESIGN_DELIVERY_RECONCILIATION_WINDOW_MS;
+}
+
+/** How long after a run's `endedAt` a Design-mode delivery may be reconciled. */
+export const DESIGN_DELIVERY_RECONCILIATION_WINDOW_MS = 5 * 60 * 1000;

--- a/apps/web/src/runtime/design-delivery.ts
+++ b/apps/web/src/runtime/design-delivery.ts
@@ -134,18 +134,25 @@ export function designDeliveryVerificationPending(
 export function designDeliveryReconciliationStale(
   message: Pick<
     ChatMessage,
-    'sessionMode' | 'runStatus' | 'resultDeliveryState' | 'endedAt'
+    | 'sessionMode'
+    | 'runStatus'
+    | 'resultDeliveryState'
+    | 'endedAt'
+    | 'startedAt'
+    | 'createdAt'
   >,
   now: number = Date.now(),
 ): boolean {
   if (message.sessionMode !== 'design' || message.runStatus !== 'succeeded') return false;
   if (message.resultDeliveryState) return false;
-  const terminalAt = message.endedAt;
-  // No terminal timestamp (legacy row) — defer to the existing verification
-  // logic rather than guessing an age.
+  // The #6505 legacy shape can lack `endedAt` entirely (rows persisted before
+  // `endedAt` existed), so bound the reconciliation age from any persisted
+  // terminal timestamp — `endedAt` first, then the run/message start time. A
+  // row with no timestamp at all defers to the existing verification logic.
+  const terminalAt = message.endedAt ?? message.startedAt ?? message.createdAt;
   if (terminalAt == null) return false;
   return now - terminalAt > DESIGN_DELIVERY_RECONCILIATION_WINDOW_MS;
 }
 
-/** How long after a run's `endedAt` a Design-mode delivery may be reconciled. */
+/** How long after a run's terminal time a Design-mode delivery may be reconciled. */
 export const DESIGN_DELIVERY_RECONCILIATION_WINDOW_MS = 5 * 60 * 1000;

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -677,6 +677,26 @@ describe('ProjectView daemon cleanup', () => {
     ).toBe(false);
   });
 
+  it('does not auto-replay a historical succeeded Design message whose delivery never materialized', () => {
+    // #6505: a Design-mode success persisted days ago with delivery metadata
+    // absent must not be replayed/reattached on every reload — only a freshly
+    // completed run gets the one bounded reconciliation. Without an age bound,
+    // `designDeliveryVerificationPending` stays true forever and ProjectView
+    // re-enters the replay path on each recovery tick.
+    expect(
+      shouldReplayTerminalRunMessage({
+        id: 'msg-historical-delivery',
+        role: 'assistant',
+        content: 'I finished the design.',
+        runId: 'run-historical-delivery',
+        runStatus: 'succeeded',
+        sessionMode: 'design',
+        startedAt: 1,
+        endedAt: Date.now() - 24 * 60 * 60 * 1000,
+      }),
+    ).toBe(false);
+  });
+
   // Regression: a phantom 'running' row in DB (no runId, no matching active
   // daemon run) used to stick the UI on "Waiting for first output —
   // Working 24m+" forever. The reattach loop now self-heals by marking

--- a/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-cleanup.test.tsx
@@ -661,7 +661,8 @@ describe('ProjectView daemon cleanup', () => {
         runId: 'run-unverified-delivery',
         runStatus: 'succeeded',
         sessionMode: 'design',
-        startedAt: 1,
+        // Realistic start time so the reconciliation age bound sees a fresh run.
+        startedAt: Date.now(),
       }),
     ).toBe(true);
     expect(
@@ -693,6 +694,22 @@ describe('ProjectView daemon cleanup', () => {
         sessionMode: 'design',
         startedAt: 1,
         endedAt: Date.now() - 24 * 60 * 60 * 1000,
+      }),
+    ).toBe(false);
+  });
+
+  it('does not auto-replay a legacy succeeded Design row that has no endedAt', () => {
+    // #6505 rows persisted before `endedAt` existed carry only `startedAt`; the
+    // age bound must still flag them stale so a reload stops auto-replaying.
+    expect(
+      shouldReplayTerminalRunMessage({
+        id: 'msg-legacy-no-ended-at',
+        role: 'assistant',
+        content: 'I finished the design.',
+        runId: 'run-legacy-no-ended-at',
+        runStatus: 'succeeded',
+        sessionMode: 'design',
+        startedAt: Date.now() - 24 * 60 * 60 * 1000,
       }),
     ).toBe(false);
   });

--- a/apps/web/tests/components/ProjectView.run-isolation.test.tsx
+++ b/apps/web/tests/components/ProjectView.run-isolation.test.tsx
@@ -679,7 +679,10 @@ const succeededAssistant: ChatMessage = {
   ...runningAssistant,
   content: 'done',
   runStatus: 'succeeded',
-  endedAt: 2,
+  // Realistic terminal timestamp: a synthetic epoch value would read as years
+  // old to designDeliveryReconciliationStale's age bound and suppress the
+  // reload reconciliation these suites exercise.
+  endedAt: Date.now(),
 };
 
 const previewComment: PreviewComment = {

--- a/apps/web/tests/runtime/design-delivery.test.ts
+++ b/apps/web/tests/runtime/design-delivery.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  designDeliveryReconciliationStale,
   designDeliveryVerificationPending,
   resolveDesignDeliveryOutcome,
 } from '../../src/runtime/design-delivery';
@@ -235,6 +236,66 @@ describe('resolveDesignDeliveryOutcome', () => {
         content: '<question-form id="brief">{"questions":[]}</question-form>',
         events: [],
       }),
+    ).toBe(false);
+  });
+});
+
+describe('designDeliveryReconciliationStale', () => {
+  const now = 1_000_000;
+
+  it('treats a run that finished long ago as stale (no more auto-replay)', () => {
+    expect(
+      designDeliveryReconciliationStale(
+        {
+          sessionMode: 'design',
+          runStatus: 'succeeded',
+          endedAt: now - 24 * 60 * 60 * 1000,
+        },
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps a freshly completed run reconcilable', () => {
+    expect(
+      designDeliveryReconciliationStale(
+        {
+          sessionMode: 'design',
+          runStatus: 'succeeded',
+          endedAt: now - 30_000,
+        },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it('does not mark a row without a terminal timestamp as stale', () => {
+    expect(
+      designDeliveryReconciliationStale(
+        { sessionMode: 'design', runStatus: 'succeeded', startedAt: 1 },
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  it('ignores already-resolved deliveries and non-design/non-succeeded rows', () => {
+    expect(
+      designDeliveryReconciliationStale(
+        { sessionMode: 'design', runStatus: 'succeeded', resultDeliveryState: 'delivered', endedAt: 1 },
+        now,
+      ),
+    ).toBe(false);
+    expect(
+      designDeliveryReconciliationStale(
+        { sessionMode: 'chat', runStatus: 'succeeded', endedAt: 1 },
+        now,
+      ),
+    ).toBe(false);
+    expect(
+      designDeliveryReconciliationStale(
+        { sessionMode: 'design', runStatus: 'failed', endedAt: 1 },
+        now,
+      ),
     ).toBe(false);
   });
 });

--- a/apps/web/tests/runtime/design-delivery.test.ts
+++ b/apps/web/tests/runtime/design-delivery.test.ts
@@ -269,13 +269,24 @@ describe('designDeliveryReconciliationStale', () => {
     ).toBe(false);
   });
 
-  it('does not mark a row without a terminal timestamp as stale', () => {
+  it('does not mark a row with no timestamp at all as stale', () => {
     expect(
       designDeliveryReconciliationStale(
-        { sessionMode: 'design', runStatus: 'succeeded', startedAt: 1 },
+        { sessionMode: 'design', runStatus: 'succeeded' },
         now,
       ),
     ).toBe(false);
+  });
+
+  it('treats a legacy row without endedAt as stale when its start time is old', () => {
+    // #6505 rows persisted before `endedAt` existed carry only `startedAt`;
+    // the age bound falls back to it so reloads stop auto-replaying.
+    expect(
+      designDeliveryReconciliationStale(
+        { sessionMode: 'design', runStatus: 'succeeded', startedAt: now - 24 * 60 * 60 * 1000 },
+        now,
+      ),
+    ).toBe(true);
   });
 
   it('ignores already-resolved deliveries and non-design/non-succeeded rows', () => {


### PR DESCRIPTION
Fixes #6505

## Why

A Design-mode assistant message can be persisted as `succeeded` while its
delivery metadata (`resultDeliveryState` / `producedFiles` /
`traceObjectFiles`) is absent — historical rows created before a final
project-file refresh, or after an interrupted persistence path. On reload,
`designDeliveryVerificationPending` has no age bound, so
`shouldReplayTerminalRunMessage` returns true for such rows **forever**:
each reload re-enters the reattach path. Worse, when the SSE replay drops
mid-stream, the generic-disconnect `onError` path reverts the message to
`succeeded` *without* sealing `completedReattachRunsRef` and resets the
retry budget, so the loop never settles — the chat stays visually loading
and reopening the conversation can repeat the run's work.

I hit this while reproducing #6505's minimal scenario against `main`.

## What users will see

A conversation that reloads with a historically `succeeded` Design run whose
delivery never materialized now renders that run as a terminal outcome
(normal succeeded message, no automatic replay) instead of entering an
infinite replay/loading loop. Freshly completed runs still get the existing
one-shot reconciliation after reload, and runs with a resolved delivery
state are untouched.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — internal replay/reconcile logic + tests in `apps/web`

## Screenshots

Not applicable — no UI surface changed. The change affects reload recovery
behavior of persisted chat rows.

## Bug fix verification

- Test path: `apps/web/tests/components/ProjectView.run-cleanup.test.tsx`
  (`does not auto-replay a historical succeeded Design message whose delivery
  never materialized`) + `apps/web/tests/runtime/design-delivery.test.ts`
  (`designDeliveryReconciliationStale` cases).
- Red on `main`: the new `shouldReplayTerminalRunMessage` assertion for a
  row with `endedAt` a day old fails (returns `true` → expected `false`),
  reproducing the infinite replay.
- Green on this branch: yes.

## Adjacent issues (out of scope)

- The generic-disconnect `onError` path (ProjectView.tsx:5807-5868) does not
  add `completedReattachRunsRef` when its status probe returns `succeeded`,
  which is what makes a *recently* completed run's SSE drop loop. The
  age-bound here covers the historical-row case; sealing that path is a
  separate follow-up.
- Rows with no `endedAt` at all (legacy persistence) are conservatively left
  on the existing path; a broader fix could derive a staleness signal from
  other persisted timestamps.

## Validation

- `pnpm --filter @open-design/web exec vitest run tests/components/ProjectView.run-cleanup.test.tsx tests/runtime/design-delivery.test.ts` — 81 passed
- `pnpm --filter @open-design/web typecheck` — clean