### PR TITLE
fix(web): cancel stale invite dialog close timer

### DIFF
--- a/apps/web/src/components/InviteDialog.tsx
+++ b/apps/web/src/components/InviteDialog.tsx
@@ -111,6 +111,7 @@ export function InviteDialog({
   const rowsRef = useRef<HTMLDivElement | null>(null);
   const roleTriggerRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const roleMenuRef = useRef<HTMLDivElement | null>(null);
+  const autoCloseTimerRef = useRef<number | null>(null);
   const [roleMenuPos, setRoleMenuPos] = useState<CSSProperties | null>(null);
   const roleListboxId = useId();
 
@@ -161,6 +162,12 @@ export function InviteDialog({
 
   useEffect(() => {
     if (!open) setOpenRoleIndex(null);
+  }, [open]);
+
+  useEffect(() => () => {
+    if (autoCloseTimerRef.current === null) return;
+    window.clearTimeout(autoCloseTimerRef.current);
+    autoCloseTimerRef.current = null;
   }, [open]);
 
   // Reset the submit lifecycle each time the dialog opens so a prior error /
@@ -337,7 +344,8 @@ export function InviteDialog({
       }, { requestId });
       setSuccess(true);
       onSubmit?.(valid);
-      window.setTimeout(() => {
+      autoCloseTimerRef.current = window.setTimeout(() => {
+        autoCloseTimerRef.current = null;
         onClose();
         setRows([{ email: '', role: DEFAULT_ROLE }]);
         setSuccess(false);

--- a/e2e/ui/workspace-team-interactions.test.ts
+++ b/e2e/ui/workspace-team-interactions.test.ts
@@ -670,6 +670,50 @@ test('[P0] team owner completes a multi-row invite with explicit roles', async (
   await expect(dialog).toHaveCount(0, { timeout: 5_000 });
 });
 
+test('[P1] stale invite success timer does not close a reopened dialog', async ({ page }) => {
+  await page.addInitScript(
+    ({ workspaceId, workspaceMemberId }) => {
+      window.sessionStorage.setItem(
+        'od.workspaceSelection.v1',
+        JSON.stringify({ workspaceId, workspaceMemberId }),
+      );
+    },
+    {
+      workspaceId: TEAM_OWNER.workspaceId,
+      workspaceMemberId: TEAM_OWNER.workspaceMemberId,
+    },
+  );
+  await wireWorkspaceMocks(page, TEAM_OWNER, [PERSONAL, TEAM_OWNER]);
+  await gotoHome(page);
+  await ensureRailOpen(page);
+  await page.clock.install();
+  await page.clock.pauseAt((await page.evaluate(() => Date.now())) + 60_000);
+
+  await page.getByTestId('workspace-switcher').click();
+  await page.getByRole('menu').getByRole('menuitem', { name: 'Invite colleague' }).click();
+
+  const dialog = page.getByRole('dialog', { name: 'Invite members' });
+  const emailInput = dialog.getByPlaceholder('Enter email address…').first();
+  await emailInput.fill('first@example.com');
+  await dialog.getByRole('button', { name: 'Confirm and invite' }).click();
+  await expect(dialog.getByRole('button', { name: 'Invitation sent' })).toBeVisible();
+
+  await dialog.getByRole('button', { name: 'Close' }).click();
+  await page.getByTestId('workspace-switcher').click();
+  await page.getByRole('menu').getByRole('menuitem', { name: 'Invite colleague' }).click();
+  await expect(dialog).toBeVisible();
+  await emailInput.fill('second@example.com');
+
+  await page.clock.fastForward(999);
+  await expect(dialog).toBeVisible();
+  await expect(emailInput).toHaveValue('second@example.com');
+
+  await page.clock.fastForward(1);
+
+  await expect(dialog).toBeVisible();
+  await expect(emailInput).toHaveValue('second@example.com');
+});
+
 test('[P0] full team routes every invite entry to Vela seat resolution without opening the local dialog', async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- retain the pending invite-success close timer so it has an explicit lifecycle owner
- cancel that timer when the dialog session changes or the component unmounts
- add a Chromium regression proving an old deadline cannot close a reopened dialog or erase its new email input

## Linked issue
Closes #6556

## Change type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore / build / CI

## Surface areas

- [ ] Native shell / desktop
- [x] Web app
- [ ] Daemon / API / MCP
- [ ] Plugins
- [ ] Design systems
- [ ] Documentation / website
- [ ] Release tooling / CI
- [ ] UI — new page, dialog, panel, menu, or user-facing setting
- [ ] i18n — user-facing copy changed or added
- [ ] Architecture — new package, cross-boundary dependency, or reusable subsystem

## Validation

- [x] `pnpm guard`
- [x] Unit / integration tests
- [x] Web app checked
- [ ] Native app checked
- [ ] Documentation links checked

## Test evidence

- `pnpm guard`
- `pnpm --filter @open-design/e2e exec playwright test -c playwright.config.ts ui/workspace-team-interactions.test.ts --grep "stale invite success timer does not close a reopened dialog" --workers=1` — 1 passed after rebasing onto latest `main`
- the regression was repeated twice before the rebase — 2 passed
- combined existing invite auto-close + reopen regression run — 2 passed
- `pnpm --filter @open-design/web test tests/components/InviteDialog.analytics.test.tsx tests/components/InviteDialog.role-menu.test.tsx tests/components/InviteDialog.seat-gate.test.tsx` — 3 files, 13 tests passed
- `pnpm --filter @open-design/web typecheck`

## UI screenshots

Not applicable — this changes only timer lifecycle behavior and adds no layout, copy, styling, or new UI surface. The regression is exercised in real Chromium.

## Native screenshots

Not applicable — no native shell or desktop surface changes.

## Breaking changes

None.
