### PR TITLE
[backport release/v0.18.1] ci: add Blacksmith runner mode

### DIFF
--- a/.github/scripts/runners.py
+++ b/.github/scripts/runners.py
@@ -7,6 +7,8 @@ from pathlib import Path
 
 GITHUB_HOSTED = ["ubuntu-24.04"]
 WINDOWS_HOSTED = ["windows-latest"]
+BLACKSMITH_4VCPU = ["blacksmith-4vcpu-ubuntu-2404"]
+BLACKSMITH_8VCPU = ["blacksmith-8vcpu-ubuntu-2404"]
 NEXU_SMALL = ["nexu-runners-small"]
 NEXU_MEDIUM = ["nexu-runners-medium"]
 NEXU_LARGE = ["nexu-runners-large"]
@@ -19,18 +21,29 @@ def compact_json(value):
 
 def normalize_mode(raw_mode):
     mode = raw_mode or "default"
-    if mode in {"default", "performance", "economic"}:
+    if mode in {"default", "performance", "economic", "blacksmith"}:
         return mode
     return "default"
 
 
 def resolve_contract(mode):
-    control = GITHUB_HOSTED if mode == "economic" else NEXU_SMALL
-    workload = GITHUB_HOSTED if mode == "economic" else NEXU_MEDIUM
-    browser_workload = GITHUB_HOSTED if mode == "economic" else NEXU_LARGE
-    # UI P0 is the memory-heavy Playwright domain suite; prefer the dedicated
-    # xlarge class once available so large remains headroom for lighter UI jobs.
-    ui_p0_workload = GITHUB_HOSTED if mode == "economic" else NEXU_XLARGE
+    if mode == "economic":
+        control = GITHUB_HOSTED
+        workload = GITHUB_HOSTED
+        browser_workload = GITHUB_HOSTED
+        ui_p0_workload = GITHUB_HOSTED
+    elif mode == "blacksmith":
+        control = BLACKSMITH_4VCPU
+        workload = BLACKSMITH_4VCPU
+        browser_workload = BLACKSMITH_8VCPU
+        ui_p0_workload = BLACKSMITH_8VCPU
+    else:
+        control = NEXU_SMALL
+        workload = NEXU_MEDIUM
+        browser_workload = NEXU_LARGE
+        # UI P0 is the memory-heavy Playwright domain suite; prefer the
+        # dedicated xlarge class so large remains headroom for lighter UI jobs.
+        ui_p0_workload = NEXU_XLARGE
 
     return {
         "runs_on": {

--- a/e2e/tests/packaged-smoke-workflow.test.ts
+++ b/e2e/tests/packaged-smoke-workflow.test.ts
@@ -1325,6 +1325,18 @@ process.stdin.on("end", () => {
     expect(performanceRunsOn.ui_p0).toEqual(["nexu-runners-xlarge"]);
     expect(performanceRunsOn.visual_hot).toEqual(["nexu-runners-large"]);
 
+    const blacksmithProfiles = await runRunners("blacksmith");
+    const blacksmithRunsOn = runnerRunsOn(blacksmithProfiles);
+    expect(runnerDecision(blacksmithProfiles)).toEqual({ schema_version: 1, mode: "blacksmith" });
+    expect(blacksmithRunsOn.control).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
+    expect(blacksmithRunsOn.general_medium).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
+    expect(blacksmithRunsOn.workspace_unit).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
+    expect(blacksmithRunsOn.windows_tools).toEqual(["windows-latest"]);
+    expect(blacksmithRunsOn.js_hot).toEqual(["blacksmith-4vcpu-ubuntu-2404"]);
+    expect(blacksmithRunsOn.ui_hot).toEqual(["blacksmith-8vcpu-ubuntu-2404"]);
+    expect(blacksmithRunsOn.ui_p0).toEqual(["blacksmith-8vcpu-ubuntu-2404"]);
+    expect(blacksmithRunsOn.visual_hot).toEqual(["blacksmith-8vcpu-ubuntu-2404"]);
+
     const economicProfiles = await runRunners("economic");
     const economicRunsOn = runnerRunsOn(economicProfiles);
     expect(runnerDecision(economicProfiles)).toEqual({ schema_version: 1, mode: "economic" });


### PR DESCRIPTION
## Why

The active `release/v0.18.1` branch predates the explicit Blacksmith runner mode from #6533. The repository variable is already set to `OD_CI_RUNNER_MODE=blacksmith`, but this release branch currently normalizes that value back to `default`, so its CI cannot use the intended Blacksmith capacity profile.

This manual backport keeps release validation aligned with `main` without merging unrelated mainline changes into the release branch.

## What users will see

No product UI or runtime behavior changes. CI maintainers can use `OD_CI_RUNNER_MODE=blacksmith` on `release/v0.18.1`: control, general, workspace, and JS jobs use Blacksmith 4-vCPU runners; browser, UI P0, and visual jobs use Blacksmith 8-vCPU runners; Windows remains GitHub-hosted.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope.
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — internal CI and test change only

## Screenshots

Not applicable; this changes internal CI runner selection only.

## Bug fix verification

Not applicable; this is a manual backport of the additive runner mode from #6533.

## Validation

- `corepack pnpm --filter @open-design/e2e test tests/packaged-smoke-workflow.test.ts -t 'resolves CI runner profiles by mode'` (1 passed)
- `actionlint -color`
- direct resolver checks for `default`, `performance`, `economic`, `blacksmith`, and invalid fallback modes
- `git diff --check origin/release/v0.18.1...HEAD`

The full `packaged-smoke-workflow.test.ts` file was also attempted using dependencies reused from the main checkout: 46 tests passed and 10 unrelated release-metadata tests could not resolve the worktree-local `@open-design/release` package. The focused runner-profile test above passed on the release branch.

Cherry-picked from `2522094c825aee3bc4b262a4c4de3cb676183822` (#6533).
