### PR TITLE
fix(web): remount deck srcdoc preview after a hidden-tab load [stacked on #6519]

### DIFF
--- a/apps/web/src/components/FileViewer.tsx
+++ b/apps/web/src/components/FileViewer.tsx
@@ -7070,6 +7070,26 @@ export function fileViewerSourceAuthorizationScopeKey(
   return null;
 }
 
+/**
+ * A srcdoc document whose `load` completed while the browser tab was hidden
+ * has never experienced a real layout pass: Chrome keeps the hidden iframe's
+ * child viewport at 0x0, so a fixed-canvas deck's one-shot fit resolves to
+ * `transform: scale(0)`, and the in-frame recovery loop (`chaseFirstLayout`
+ * in runtime/srcdoc.ts) is exhausted by background-timer throttling before
+ * the user returns — leaving the main stage permanently white (issue #6583).
+ * Such a document must be given a fresh srcdoc parse on the first return to
+ * a visible document. Scoped to decks, which always render through the
+ * srcdoc transport and carry the one-shot fit; other srcdoc artifacts
+ * re-layout on their own.
+ */
+function srcDocLoadRequiresFreshParseOnReturnToVisible(state: {
+  loadedWhileDocumentHidden: boolean;
+  srcDocIsActiveTransport: boolean;
+  isDeck: boolean;
+}): boolean {
+  return state.loadedWhileDocumentHidden && state.srcDocIsActiveTransport && state.isDeck;
+}
+
 function HtmlViewer({
   projectId,
   projectKind,
@@ -8069,6 +8089,10 @@ function HtmlViewer({
   const previewFileIdentityRef = useRef(`${projectId}\u0000${file.name}`);
   previewFileIdentityRef.current = `${projectId}\u0000${file.name}`;
   const activatedSrcDocTransportHtmlRef = useRef<string | null>(null);
+  // Latched by the srcDoc onLoad handler when a load completes in a hidden
+  // browser tab; consumed (one-shot) by the visibilitychange recovery effect.
+  // See srcDocLoadRequiresFreshParseOnReturnToVisible.
+  const srcDocLoadedWhileDocumentHiddenRef = useRef(false);
   // Tracks the iframe DOM node whose dedupe ref was last reset by the
   // srcDoc onLoad handler. We reset the dedupe exactly once per freshly
   // mounted iframe (the first load is the shell HTML), and skip every
@@ -10266,7 +10290,29 @@ function HtmlViewer({
     wasUrlLoadPreviewRef.current = false;
     activateSrcDocTransport();
   }, [activateSrcDocTransport, useUrlLoadPreview, useLazySrcDocTransport]);
-  
+  // Recovery for a deck that parsed into the srcdoc iframe while the browser
+  // tab was hidden: on the first return to a visible document, remount the
+  // iframe for a fresh srcdoc parse (the mechanism Comment re-activation
+  // already relies on) and clear the latch so visibility round-trips after a
+  // healthy load never remount. Only the active viewer owns recovery —
+  // retained viewers keep their #6519 activation contract untouched.
+  useEffect(() => {
+    if (!workspaceActive || typeof document === 'undefined') return;
+    function onVisibilityChange() {
+      if (document.visibilityState !== 'visible') return;
+      if (!srcDocLoadRequiresFreshParseOnReturnToVisible({
+        loadedWhileDocumentHidden: srcDocLoadedWhileDocumentHiddenRef.current,
+        srcDocIsActiveTransport: !useUrlLoadPreview,
+        isDeck: effectiveDeck,
+      })) return;
+      srcDocLoadedWhileDocumentHiddenRef.current = false;
+      activatedSrcDocTransportHtmlRef.current = null;
+      setSrcDocTransportResetKey((key) => key + 1);
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', onVisibilityChange);
+  }, [workspaceActive, useUrlLoadPreview, effectiveDeck]);
+
   useEffect(() => {
     if (!workspaceActive) return;
     restorePreviewScrollPosition();
@@ -15416,6 +15462,13 @@ function HtmlViewer({
                         srcDoc={srcDocTransportContent}
                         onLoad={() => {
                           const frame = srcDocPreviewIframeRef.current;
+                          // Record whether this load ever saw a real layout
+                          // pass — a load completing in a hidden browser tab
+                          // did not, and decks then need a fresh parse on
+                          // return to visible (#6583). See
+                          // srcDocLoadRequiresFreshParseOnReturnToVisible.
+                          srcDocLoadedWhileDocumentHiddenRef.current =
+                            document.visibilityState === 'hidden';
                           if (!useUrlLoadPreview) iframeRef.current = frame;
                           if (frame) {
                             frame.dataset.odLoadedPreviewEpoch =

--- a/apps/web/tests/components/FileViewer.deck-preview-hidden-tab-mount.test.tsx
+++ b/apps/web/tests/components/FileViewer.deck-preview-hidden-tab-mount.test.tsx
@@ -1,0 +1,269 @@
+// @vitest-environment jsdom
+// Red spec for issue #6583: a deck preview that mounts while the browser tab
+// is HIDDEN stays permanently white after the user returns to the tab.
+//
+// Mechanism under test:
+//
+//   1. Decks always render through the srcDoc transport
+//      (`file-viewer-render-mode.ts`: `if (d.isDeck) return false`), so the
+//      deck HTML is parsed the moment the srcdoc iframe mounts — even when
+//      the whole browser tab is hidden (e.g. the project finished generating
+//      in a background tab).
+//
+//   2. While the tab is hidden Chrome never runs layout for the iframe, so
+//      the deck's one-shot fit computes against a 0x0 child viewport and
+//      resolves to `transform: scale(0)`. The srcdoc bridge's only recovery,
+//      `chaseFirstLayout` (30 x 50ms resize nudges), is exhausted by
+//      background-timer throttling long before the user returns; neither the
+//      host nor the bridge listens for `visibilitychange`, so nothing ever
+//      re-runs the fit. The main stage stays white forever while the
+//      thumbnail rail (host-rendered) stays healthy.
+//
+// The spec freezes the invariant: a srcdoc document whose load completed
+// while `document.visibilityState === 'hidden'` has never experienced a real
+// layout pass, so on the FIRST return to a visible document the deck's
+// srcdoc iframe must be remounted (fresh srcdoc parse — the only recovery
+// path that reliably re-runs the deck's fit). Loads that complete while
+// visible must NOT trigger a remount on later visibility round-trips (no
+// flicker), and a retained viewer (`workspaceActive === false`) must not
+// react at all.
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { CollabProvider, type CollabContextValue } from '../../src/collab/collab-context';
+import { FileViewer } from '../../src/components/FileViewer';
+import { resetSharedCancellableGet } from '../../src/lib/shared-cancellable-get';
+import type { ProjectFile } from '../../src/types';
+import { workspaceContextFixture } from '../helpers/workspace-context';
+
+const WORKSPACE_CONTEXT = workspaceContextFixture({
+  workspaceId: 'ws-deck-hidden-mount',
+  workspaceMemberId: 'member-deck-hidden-mount',
+});
+
+function collabValue(): CollabContextValue {
+  return {
+    workspaceContext: WORKSPACE_CONTEXT,
+    workspaceContextLoading: false,
+    projectResourceAuthority: 'workspace',
+    enabled: false,
+    member: null,
+    present: [],
+    publishedVersion: null,
+    syncState: null,
+    viewerOnly: false,
+    writerAuthority: 'pending',
+    isOwner: false,
+    isEffectiveOwner: false,
+    isSharedNonOwner: false,
+    ownerDisplayName: null,
+    ownerRole: null,
+    downloadPending: false,
+    reportChange: () => {},
+    requestPublish: () => {},
+    refreshPresence: () => {},
+    checkStatusNow: () => {},
+  };
+}
+
+function Wrap({ children }: { children: ReactNode }) {
+  return <CollabProvider value={collabValue()}>{children}</CollabProvider>;
+}
+
+function deckFile(overrides: Partial<ProjectFile> = {}): ProjectFile {
+  return {
+    name: 'deck.html',
+    path: 'deck.html',
+    type: 'file',
+    size: 2048,
+    mtime: 1710000000,
+    kind: 'html',
+    mime: 'text/html',
+    artifactManifest: {
+      version: 1,
+      kind: 'deck',
+      title: 'Deck',
+      entry: 'deck.html',
+      renderer: 'deck-html',
+      exports: ['html'],
+    },
+    ...overrides,
+  };
+}
+
+// Two-slide deck with NO relative project asset refs, so the #6142
+// scoped-asset preview hold never arms and the srcdoc fills as soon as the
+// raw source resolves. This spec is about visibility, not the hold (#6519).
+const DECK_HTML =
+  '<html><body>'
+  + '<section class="slide"><h1>slide-one</h1></section>'
+  + '<section class="slide"><p>slide-two</p></section>'
+  + '</body></html>';
+
+/**
+ * Fetch mock for one workspace-scoped deck project where every request
+ * settles immediately: the file list and raw deck HTML resolve, everything
+ * else 404s (preview-url probe, etc. — all null-safe).
+ */
+function installFetchMock(projectId: string) {
+  const filesUrl = `/api/projects/${encodeURIComponent(projectId)}/files`;
+  const rawUrl = `/api/projects/${encodeURIComponent(projectId)}/raw/deck.html`;
+  const isFilesListUrl = (url: string) => url.split('?')[0] === filesUrl;
+  vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+    if (isFilesListUrl(url)) {
+      return new Response(
+        JSON.stringify({ files: [deckFile()] }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }
+    if (url.startsWith(rawUrl)) {
+      return new Response(DECK_HTML, { status: 200 });
+    }
+    return new Response('', { status: 404 });
+  }));
+}
+
+let documentVisibility: DocumentVisibilityState = 'visible';
+
+function setDocumentVisibility(state: DocumentVisibilityState) {
+  documentVisibility = state;
+}
+
+function dispatchVisibilityChange() {
+  act(() => {
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+}
+
+function activeSrcDocFrame(): HTMLIFrameElement {
+  return screen.getByTestId('artifact-preview-frame') as HTMLIFrameElement;
+}
+
+function retainedSrcDocFrame(): HTMLIFrameElement {
+  return screen.getByTestId('artifact-preview-frame-srcdoc-retained-deck.html') as HTMLIFrameElement;
+}
+
+beforeEach(() => {
+  resetSharedCancellableGet();
+  documentVisibility = 'visible';
+  vi.spyOn(document, 'visibilityState', 'get').mockImplementation(() => documentVisibility);
+  vi.spyOn(document, 'hidden', 'get').mockImplementation(() => documentVisibility === 'hidden');
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('deck preview mounted while the browser tab is hidden (#6583)', () => {
+  it('remounts the srcdoc iframe on first return to visible after a hidden-tab load (fresh parse)', async () => {
+    const projectId = 'proj-deck-hidden-mount-recover';
+    installFetchMock(projectId);
+    setDocumentVisibility('hidden');
+
+    render(
+      <Wrap>
+        <FileViewer projectId={projectId} projectKind="prototype" file={deckFile()} isDeck />
+      </Wrap>,
+    );
+
+    // The deck parses into the srcdoc iframe while the tab is hidden…
+    await waitFor(() => {
+      expect(activeSrcDocFrame().getAttribute('data-od-render-mode')).toBe('srcdoc');
+      expect(activeSrcDocFrame().getAttribute('srcdoc') ?? '').toContain('slide-one');
+    });
+
+    // …and its load completes with the document still hidden: this document
+    // never experienced a real layout pass (0x0 viewport → fit = scale(0)).
+    const hiddenLoadedFrame = activeSrcDocFrame();
+    fireEvent.load(hiddenLoadedFrame);
+
+    // User returns to the tab. The host must give the deck a fresh srcdoc
+    // parse: a NEW iframe DOM node (explicit identity check — the old node
+    // is gone from the document), still carrying the deck HTML.
+    setDocumentVisibility('visible');
+    dispatchVisibilityChange();
+
+    await waitFor(() => {
+      const remounted = activeSrcDocFrame();
+      expect(remounted).not.toBe(hiddenLoadedFrame);
+      expect(remounted.getAttribute('srcdoc') ?? '').toContain('slide-one');
+    });
+    expect(hiddenLoadedFrame.isConnected).toBe(false);
+  });
+
+  it('does NOT remount when the load completed while visible (visibility round-trip is flicker-free)', async () => {
+    const projectId = 'proj-deck-visible-load-stable';
+    installFetchMock(projectId);
+
+    render(
+      <Wrap>
+        <FileViewer projectId={projectId} projectKind="prototype" file={deckFile()} isDeck />
+      </Wrap>,
+    );
+
+    await waitFor(() => {
+      expect(activeSrcDocFrame().getAttribute('data-od-render-mode')).toBe('srcdoc');
+      expect(activeSrcDocFrame().getAttribute('srcdoc') ?? '').toContain('slide-one');
+    });
+
+    // Load completes while the document is visible: layout was real.
+    const visibleLoadedFrame = activeSrcDocFrame();
+    fireEvent.load(visibleLoadedFrame);
+
+    // Tab goes to background and comes back — no remount, same DOM node.
+    setDocumentVisibility('hidden');
+    dispatchVisibilityChange();
+    setDocumentVisibility('visible');
+    dispatchVisibilityChange();
+
+    expect(activeSrcDocFrame()).toBe(visibleLoadedFrame);
+    expect(visibleLoadedFrame.isConnected).toBe(true);
+  });
+
+  it('does NOT remount a retained viewer (workspaceActive=false) on return to visible', async () => {
+    const projectId = 'proj-deck-hidden-mount-retained';
+    installFetchMock(projectId);
+
+    // A viewer becomes retained after being active: mount active first so the
+    // deck parses into the srcdoc iframe, then park it offscreen.
+    const view = render(
+      <Wrap>
+        <FileViewer projectId={projectId} projectKind="prototype" file={deckFile()} isDeck />
+      </Wrap>,
+    );
+
+    await waitFor(() => {
+      expect(activeSrcDocFrame().getAttribute('srcdoc') ?? '').toContain('slide-one');
+    });
+
+    view.rerender(
+      <Wrap>
+        <FileViewer
+          projectId={projectId}
+          projectKind="prototype"
+          file={deckFile()}
+          isDeck
+          workspaceActive={false}
+        />
+      </Wrap>,
+    );
+
+    // The retained srcdoc iframe's load completes while the document is
+    // hidden (e.g. its content refreshed in a background browser tab).
+    setDocumentVisibility('hidden');
+    const retainedFrame = retainedSrcDocFrame();
+    fireEvent.load(retainedFrame);
+
+    // Returning to visible must not touch a retained viewer at all — only
+    // the active viewer owns recovery.
+    setDocumentVisibility('visible');
+    dispatchVisibilityChange();
+
+    expect(retainedSrcDocFrame()).toBe(retainedFrame);
+    expect(retainedFrame.isConnected).toBe(true);
+  });
+});


### PR DESCRIPTION
> **Stacked on #6519** (`fix/deck-preview-blank-on-tab-return`): this PR's base branch is #6519's head branch because it reuses that branch's deck-preview test harness and complements its fix (see division of labor below). Once #6519 merges, this PR will be rebased onto `main` (`git rebase --onto origin/main origin/fix/deck-preview-blank-on-tab-return`) and retargeted to `main` before entering the queue.

Fixes #6583

## Why

Dogfood reports kept describing a deck (PPT) preview whose main stage comes back **pure white** after switching browser tabs, and only "cycling tabs a few times" eventually brings it back. While running local E2E verification of #6519 we found a deterministic recipe (issue #6583): whenever the deck's srcdoc iframe finishes loading **while the browser tab is hidden**, the stage stays white indefinitely — slide navigation doesn't recover it, more tab cycles don't either; only a remount performed while the tab is visible does.

The mechanism: decks always render through the srcdoc transport, so the deck HTML parses even in a hidden tab. Chrome runs no layout for hidden iframes, so the deck's one-shot fit computes against a 0×0 child viewport and resolves to `transform: scale(0)`. The srcdoc bridge's only recovery loop (`chaseFirstLayout`, 30 × 50 ms resize nudges) is exhausted by background-timer throttling long before the user returns, and neither the host nor the bridge listened for `visibilitychange` — so nothing ever re-ran the fit. The srcdoc document is fully populated; it just never painted.

Division of labor with #6519: that PR fixes the **empty-document** class (the scoped-asset file-list hold pinning `srcDoc` at `''`); this PR fixes the **populated-but-never-painted** class (hidden-tab load → `scale(0)` with no recovery path). Issue #6583 documents console evidence separating the two.

## What users will see

If a deck preview loads while its browser tab is in the background (e.g. generation finishes while you're on another tab), the deck now appears correctly the moment you come back to the tab — no more permanently white main stage next to healthy thumbnails and speaker notes, and no more "cycle tabs until it heals" ritual. Decks that loaded normally in a visible tab are untouched: switching tabs back and forth causes no reload or flicker.

## Surface area

- [x] **UI** — behavior fix in the existing deck preview pane (`apps/web`); no new page/dialog/panel/setting
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [ ] **None**

## Screenshots

The white-stage repro and the visible-remount recovery are captured in issue #6583's evidence set (`deck-13-hiddenmount-front-112407.jpg` → repro; `deck-16-visible-tabcycle-112555.jpg` → recovery). A live before/after comparison in a real Chrome session (open-browser-use, isolated runtime) is the planned human-verification step and will be posted as a follow-up comment on this PR; it does not block review of the state-machine fix below.

## Bug fix verification

- Test path: `apps/web/tests/components/FileViewer.deck-preview-hidden-tab-mount.test.tsx`
- Red on the unmodified base (`fca1d4bddb`, the #6519 branch head this PR stacks on — the defect also exists on `main`, which has neither PR) and green on this branch: **yes**.

Red (base, no fix):

```
× remounts the srcdoc iframe on first return to visible after a hidden-tab load (fresh parse) 1083ms
AssertionError: expected <iframe …(8)></iframe> not to be <iframe …(8)></iframe> // Object.is equality
Test Files  1 failed (1)
     Tests  1 failed | 2 passed (3)
```

Green (this branch):

```
Test Files  1 passed (1)
     Tests  3 passed (3)
```

The spec pins the invariant with explicit DOM-node identity comparisons: a hidden-tab load must be followed by a fresh srcdoc parse (new iframe node, old node disconnected) on the first return to visible; a visible-tab load must survive visibility round-trips with the **same** node (no flicker); a retained viewer (`workspaceActive === false`) must not react at all. jsdom cannot observe real paint — the unit specs anchor the host state machine; pixel-level acceptance is the obu real-Chrome comparison noted above.

## Validation

- `pnpm guard` — pass
- `pnpm typecheck` — pass
- `pnpm --filter @open-design/web test` — full suite green (598 files / 6226 passed, 11 skipped), including #6519's `FileViewer.deck-preview-blank-on-return.test.tsx`; baseline run on the unmodified branch head was also fully green, so no pre-existing failures are being absorbed
- No backport — 0.18.1 has already shipped; this fix targets `main` only and rides the next regular release

## Adjacent issues

- Non-deck srcdoc artifacts share the same hidden-tab family (a `scale(0)`-style one-shot fit is deck-specific, but other srcdoc content could mis-layout after a hidden load). This PR deliberately scopes recovery to decks (`effectiveDeck`) to match the reported defect; the wider family stays with issue #6583's notes for its own spec if it materializes.
- The retained-viewer (`workspaceActive === false`) activation contract flagged in #6519's Adjacent-issues section remains untouched and still needs its own spec; the new recovery path explicitly excludes retained viewers.
