### PR TITLE
docs(deploy): document Vela CLI setup for Linux Docker

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -111,22 +111,52 @@ docker compose -f docker-compose.yml -f docker-compose.linux.yml up -d --no-buil
 
 Common install paths:
 
-| CLI | Default path |
-|-----|-------------|
+| CLI | Install / default path |
+|-----|------------------------|
 | Claude Code | `~/.local/bin/claude` (symlink) + `~/.local/share/claude` (binaries) |
 | opencode | `~/.opencode/bin/opencode` |
 | Codex | `~/.local/bin/codex` |
+| Vela / AMR | npm package `@powerformer/vela-cli`; [Open Design AMR](https://open-design.ai/amr) is the browser account/wallet page |
 
-The daemon auto-detects any CLI that is visible in `PATH` at startup — no extra
-configuration needed. For a CLI installed in a non-standard path, add a volume
-and prepend its directory to `PATH` in `docker-compose.linux.yml`, then restart:
+Vela is published as the `@powerformer/vela-cli` npm package. The Open Design
+AMR URL above is not a shell installer. For Linux Docker, install Vela under a
+dedicated prefix so its launcher and platform package can be mounted together:
+
+```bash
+VELA_PREFIX="$HOME/.local/share/vela"
+npm install --global --prefix "$VELA_PREFIX" @powerformer/vela-cli
+export PATH="$VELA_PREFIX/bin:$PATH"
+which vela
+vela --version
+```
+
+Mount that complete prefix into the container, then expose its `bin` directory
+through `PATH` (or set `VELA_BIN` to the container-visible launcher):
 
 ```yaml
 environment:
-  PATH: /mnt/host-mycli:/mnt/host-local-bin:/mnt/host-opencode:/usr/local/bin:/usr/bin:/bin
+  PATH: /mnt/host-vela/bin:/mnt/host-local-bin:/mnt/host-opencode:/usr/local/bin:/usr/bin:/bin
+  VELA_BIN: /mnt/host-vela/bin/vela
 volumes:
-  - /opt/mycli/bin:/mnt/host-mycli:ro
+  - ${HOME}/.local/share/vela:/mnt/host-vela:ro
 ```
+
+Once the container is running, inspect both `PATH` discovery and any explicit
+Vela override:
+
+```bash
+docker compose exec open-design sh -lc 'which vela; echo "$VELA_BIN"'
+```
+
+Use either a `vela` launcher discoverable on `PATH` or a `VELA_BIN` path that
+exists inside the container. `VELA_BIN` is optional when `vela` is discoverable
+on `PATH`.
+
+The daemon auto-detects any CLI that is visible in `PATH` at startup — no extra
+configuration needed. For another CLI installed in a non-standard path, mount
+its complete install prefix read-only and prepend its binary directory to
+`PATH` in `docker-compose.linux.yml`, then restart. When a launcher is a symlink,
+mounting only the directory that contains the symlink may omit its target.
 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.linux.yml up -d --no-build


### PR DESCRIPTION
Fixes #5700

## Why

Linux Docker users can reach the AMR onboarding flow without knowing that the Vela CLI must be installed on the host and exposed inside the container. The current deployment guide explains the generic host-CLI mount pattern, but it does not name Vela/AMR, identify its published CLI package, distinguish the browser-only AMR account page from a shell installer, or provide the checks needed to distinguish a missing host installation from a missing container mount.

This PR follows the accepted docs scope in #5700 and keeps the separate Linux ARM64/runtime behavior tracked in #6567 out of scope.

## What users will see

The Linux Docker CLI section now lists Vela/AMR, identifies `@powerformer/vela-cli` as the installable npm package, and labels the AMR URL accurately as the browser account/wallet page rather than a shell installer. It installs Vela under a dedicated prefix so the npm launcher and its target stay together when mounted read-only, then verifies that `vela` is visible both on the host and inside the Open Design container. It also explains that `VELA_BIN` must point to the container-visible launcher when used.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [ ] **Default behavior change** — changes what existing users experience without opting in
- [x] **None** — documentation update only

## Screenshots

Not applicable — documentation-only change with no UI modification.

## Bug fix verification

Not a code bug fix. This closes the accepted documentation gap in #5700; the separate runtime behavior in #6567 is intentionally unchanged.

## Validation

- Direct URL probe — `https://open-design.ai/amr` resolves to the HTML account/wallet page at `https://open-design.ai/cloud/wallet`, confirming it is not a shell installer
- `npm view @powerformer/vela-cli version bin optionalDependencies --json` — verified the `vela` launcher and published Linux x64/arm64 packages
- Isolated `npm install --global --prefix <temp> @powerformer/vela-cli`, prefix relocation, and `<relocated-prefix>/bin/vela --version` — `0.0.32`; relative launcher target remained valid
- `docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.linux.yml -f <documented-override> config --quiet`
- `pnpm guard` (Node 24.11.1 / pnpm 10.33.2)
- `pnpm typecheck` (Node 24.11.1 / pnpm 10.33.2; 0 errors)
- `git diff --check`
- One-file final-scope and stale-installer-wording probes

