### PR TITLE
fix(daemon): allow workspace-less design system deletion

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -7289,6 +7289,11 @@ export async function startServer({
       // and `syncSharedTeamDesignSystem` kept re-stamping `markTeamSynced()`
       // onto every teammate forever.
       unshareTeamDesignSystemIfShared: async (id, req) => {
+        const requestContext = workspaceResourceContextFromRequest(req);
+        const hasWorkspaceContextHeaders = Object.keys(req.headers ?? {}).some(
+          (name) => name.startsWith('x-od-workspace-') || name === 'x-od-app-user-id',
+        );
+        if (requestContext === null && !hasWorkspaceContextHeaders) return false;
         const verified = await verifyExplicitWorkspaceRequestContext({
           req,
           requireTeam: false,

--- a/apps/daemon/tests/design-system-workspaceless-delete.test.ts
+++ b/apps/daemon/tests/design-system-workspaceless-delete.test.ts
@@ -1,0 +1,101 @@
+import type { Server } from 'node:http';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, expect, it, vi } from 'vitest';
+
+type StartedServer = {
+  url: string;
+  server: Server;
+  shutdown?: () => Promise<void> | void;
+};
+
+const originalDataDir = process.env.OD_DATA_DIR;
+const originalWorkspaceContextSource = process.env.OD_WORKSPACE_CONTEXT_SOURCE;
+let dataDir: string | null = null;
+let started: StartedServer | null = null;
+
+afterEach(async () => {
+  const current = started;
+  started = null;
+  if (current) {
+    await Promise.resolve(current.shutdown?.());
+    current.server.closeAllConnections?.();
+    current.server.closeIdleConnections?.();
+    if (current.server.listening) {
+      await new Promise<void>((resolve) => current.server.close(() => resolve()));
+    }
+  }
+  const { closeDatabase } = await import('../src/db.js');
+  closeDatabase();
+  if (dataDir) await rm(dataDir, { recursive: true, force: true });
+  dataDir = null;
+  if (originalDataDir === undefined) delete process.env.OD_DATA_DIR;
+  else process.env.OD_DATA_DIR = originalDataDir;
+  if (originalWorkspaceContextSource === undefined) {
+    delete process.env.OD_WORKSPACE_CONTEXT_SOURCE;
+  } else {
+    process.env.OD_WORKSPACE_CONTEXT_SOURCE = originalWorkspaceContextSource;
+  }
+  vi.resetModules();
+}, 30_000);
+
+it('allows headerless deletion but rejects malformed workspace metadata in workspace-less local mode', async () => {
+  // Given a workspace-less local daemon with a user-created design system
+  dataDir = await mkdtemp(join(tmpdir(), 'od-design-system-workspaceless-delete-'));
+  process.env.OD_DATA_DIR = dataDir;
+  delete process.env.OD_WORKSPACE_CONTEXT_SOURCE;
+  vi.resetModules();
+  const { startServer } = await import('../src/server.js');
+  started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+
+  const createResponse = await fetch(`${started.url}/api/design-systems`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ title: 'Workspace-less Delete' }),
+  });
+  expect(createResponse.status).toBe(201);
+  const created = await createResponse.json() as {
+    designSystem: { id: string };
+  };
+  const designSystemUrl = `${started.url}/api/design-systems/${encodeURIComponent(created.designSystem.id)}`;
+
+  const getResponse = await fetch(designSystemUrl);
+  expect(getResponse.status).toBe(200);
+  await expect(getResponse.json()).resolves.toMatchObject({ canMutate: true });
+
+  // When the mutable design system is deleted without workspace headers
+  const deleteResponse = await fetch(designSystemUrl, { method: 'DELETE' });
+  const deleteBody: unknown = deleteResponse.status === 204
+    ? null
+    : await deleteResponse.json();
+
+  // Then the local delete proceeds instead of requiring Team workspace context
+  expect({ status: deleteResponse.status, body: deleteBody }).toEqual({
+    status: 204,
+    body: null,
+  });
+
+  const malformedCreateResponse = await fetch(`${started.url}/api/design-systems`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ title: 'Malformed Workspace Delete' }),
+  });
+  expect(malformedCreateResponse.status).toBe(201);
+  const malformedCreated = await malformedCreateResponse.json() as {
+    designSystem: { id: string };
+  };
+
+  const malformedDeleteResponse = await fetch(
+    `${started.url}/api/design-systems/${encodeURIComponent(malformedCreated.designSystem.id)}`,
+    {
+      method: 'DELETE',
+      headers: { 'x-od-workspace-type': 'team' },
+    },
+  );
+
+  expect(malformedDeleteResponse.status).toBe(400);
+  await expect(malformedDeleteResponse.json()).resolves.toMatchObject({
+    error: 'WORKSPACE_CONTEXT_REQUIRED',
+  });
+}, 60_000);


### PR DESCRIPTION
Fixes #6575

## Why

Issue #6575 reports that a workspace-less local install can expose a user-created design system as `canMutate: true` while rejecting its DELETE request with `400 WORKSPACE_CONTEXT_REQUIRED`.

The failure occurs after the normal mutation checks: `unshareTeamDesignSystemIfShared` always verifies explicit workspace authority even when the request carries no workspace context and the install therefore has no Team share to retract. This change lets that truly headerless local path continue to deletion while keeping malformed, Personal, and Team workspace requests on the existing verification path.

## What users will see

Users on workspace-less local installs can delete their own user-created design systems normally instead of seeing a generic error and leaving the design system in place.

Requests that provide workspace metadata still require valid workspace identity and retain the existing Team unshare and authority checks.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — workspace-less local design-system DELETE now proceeds instead of requiring impossible workspace context
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not attached. This is a daemon-side authorization-path fix with no UI or layout changes; the user-visible behavior is covered through the real HTTP server.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/design-system-workspaceless-delete.test.ts`
- Did the test go red on `main` and green on this branch? yes
  - RED before the source change: DELETE returned `400` with `WORKSPACE_CONTEXT_REQUIRED` instead of `204` (reproduced twice).
  - GREEN after the source change: the same production-wiring test passes.
  - A follow-up RED/GREEN boundary check proved that standalone workspace metadata such as `x-od-workspace-type: team` still receives `400 WORKSPACE_CONTEXT_REQUIRED` rather than bypassing verification.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/design-system-workspaceless-delete.test.ts tests/routes/design-system-delete-unshares-team-share.test.ts tests/routes/design-systems-team-mutation-guard.test.ts` — 3 files, 19 tests passed after rebasing onto current `origin/main`
- `pnpm --filter @open-design/daemon typecheck` — passed
- `pnpm guard` — passed
- `git diff HEAD^ --check` — passed
