### PR TITLE
docs(spec): update collab realtime current-state summary

### DIFF
--- a/specs/current/collab-sse-vela-push.md
+++ b/specs/current/collab-sse-vela-push.md
@@ -1,6 +1,26 @@
-# Collab realtime — vela → daemon push channel (Hop 1 design)
+# Collab realtime — current implementation and hop 1 design history
 
-Status: draft for vela-backend review. Owner: workspace-team.
+Status: implemented on `main`. Owner: workspace-team.
+
+## Implemented state
+
+Collaboration invalidations now travel over two implemented SSE hops:
+
+- **Hop 1 (vela → daemon):** the daemon opens an exact-workspace cloud-hub
+  subscription at `/api/v1/collab/events`. It verifies that the `ready` event
+  names the requested workspace, uses heartbeats to monitor stream health,
+  reconnects after interruptions, and performs source-gap catch-up.
+- **Hop 2 (daemon → web):** the daemon publishes thin invalidations at
+  `/api/projects/:id/events` and `/api/workspace/events`; web clients re-fetch
+  the affected state rather than receiving full resource payloads.
+- **Polling floor:** polling remains as a slower recovery floor so missed or
+  unavailable push events still converge.
+
+## Historical design context — July 15 proposal
+
+The remainder of this document preserves the original July 15 design snapshot
+and rationale. Its proposed endpoint, event catalogue, status statements, and
+sequencing are historical context, not the current wire contract.
 
 ## Why this exists
 
@@ -31,7 +51,7 @@ interval (~5s for comments; on-demand for members/context).
 change made by one user reaches other members' daemons in near-real-time,
 replacing the daemon's polling of vela.
 
-## Verified current state (as of this branch)
+## Historical implementation snapshot (July 15)
 
 - `apps/daemon/src/collab/collab-cloud-service.ts` runs an internal `setInterval`
   poll (~5s) that calls `client.pullComments(...)`. This is the only self-driven


### PR DESCRIPTION
Fixes #6589

## Why

`specs/current/collab-sse-vela-push.md` was imported by #6142 with its July 15 design status unchanged even though `main` already contained both SSE hops. Because the file lives under `specs/current`, its opening can send contributors to the wrong endpoint and make polling look like the current primary path.

This is a source/spec correction discovered while auditing current collaboration architecture. It does not change runtime behavior.

## What users will see

No product behavior changes. Contributors reading the spec will see the implemented two-hop contract first under `Implemented state`, while the original July 15 proposal and rationale remain available under explicit historical-design and historical-snapshot headings.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — documentation-only change.

## Bug fix verification

- Disposable source/spec contract probe: RED on unchanged `main` while the July 15 draft assertions are normative; GREEN after adding the implemented-state summary, historical boundary, and non-misleading historical snapshot heading.
- No runtime code or test behavior changed.

## Validation

- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`
- Disposable source/spec contract probe (GREEN)
