### PR TITLE
fix(daemon): scope MCP project tools to the signed-in workspace

### DIFF
--- a/apps/daemon/src/artifacts/create.ts
+++ b/apps/daemon/src/artifacts/create.ts
@@ -88,6 +88,7 @@ export async function postCreateArtifactRequest(args: {
   baseUrl: string;
   projectId: string;
   input: CreateProjectArtifactInput;
+  headers?: Record<string, string>;
 }): Promise<unknown> {
   const response = await fetch(
     `${args.baseUrl.replace(/\/$/, '')}/api/projects/${encodeURIComponent(args.projectId)}/files`,
@@ -96,6 +97,7 @@ export async function postCreateArtifactRequest(args: {
       headers: {
         accept: 'application/json',
         'content-type': 'application/json',
+        ...args.headers,
       },
       body: JSON.stringify(buildCreateArtifactRequestBody(args.input)),
     },

--- a/apps/daemon/src/mcp-workspace-context.ts
+++ b/apps/daemon/src/mcp-workspace-context.ts
@@ -1,0 +1,130 @@
+import type {
+  WorkspaceDirectoryItem,
+  WorkspaceDirectoryResponse,
+} from '@open-design/contracts';
+
+/**
+ * Workspace-aware request context for the MCP stdio bridge (#6569).
+ *
+ * 0.18.0 introduced workspace isolation: projects are lazy-adopted into the
+ * signed-in user's workspace (`bindUnboundProjectsToPersonalWorkspace`), so the
+ * NO-SCOPE catalog (`GET /api/projects`) returns empty to a headerless caller
+ * and bound-project reads 400 with `WORKSPACE_CONTEXT_REQUIRED`. The MCP bridge
+ * therefore resolves the daemon's signed-in workspace once via the headerless
+ * `GET /api/workspace/directory` and sends the resulting `x-od-workspace-*`
+ * headers on every project/run call.
+ *
+ * Selection mirrors the daemon's own `selectDefaultCandidate`
+ * (collab/vela-workspace-context.ts): active memberships only, then the
+ * personal workspace, then the first remaining candidate.
+ */
+
+export interface McpWorkspaceContext {
+  workspaceId: string;
+  workspaceMemberId: string;
+  workspaceType: 'personal' | 'team';
+  headers: { 'x-od-workspace-id': string; 'x-od-workspace-member-id': string };
+}
+
+/** Keep the bridge's view fresh at the same cadence as the daemon's directory cache. */
+export const MCP_WORKSPACE_CONTEXT_TTL_MS = 15_000;
+/** Back off after a directory outage instead of hammering the daemon. */
+export const MCP_WORKSPACE_FAILURE_COOLDOWN_MS = 60_000;
+
+const DIRECTORY_TIMEOUT_MS = 8_000;
+
+/**
+ * Pick the best default membership out of an already-fetched directory list.
+ * Verbatim port of `selectDefaultCandidate` in vela-workspace-context.ts so the
+ * bridge and the UI pick the same workspace for a multi-workspace user.
+ */
+export function selectDefaultMcpCandidate(
+  items: WorkspaceDirectoryItem[],
+  preferredId?: string,
+): WorkspaceDirectoryItem | undefined {
+  const candidates = items.filter(
+    (item) => item.memberStatus === 'active' && item.lifecycleState === 'active',
+  );
+  return (
+    (preferredId ? candidates.find((item) => item.workspaceId === preferredId) : undefined) ??
+    candidates.find((item) => item.workspaceType === 'personal') ??
+    candidates[0]
+  );
+}
+
+interface CacheEntry {
+  context: McpWorkspaceContext;
+  fetchedAt: number;
+}
+
+// Keyed by daemon base URL so a daemon URL change naturally re-bootstraps.
+const cache = new Map<string, CacheEntry>();
+const lastFailureAt = new Map<string, number>();
+
+/**
+ * Resolve the signed-in workspace to scope MCP project/run calls, or null for a
+ * headerless fallback (non-vela, signed-out, or a directory outage). Results are
+ * cached per base URL for MCP_WORKSPACE_CONTEXT_TTL_MS; failures suppress
+ * re-fetch for MCP_WORKSPACE_FAILURE_COOLDOWN_MS. `force` bypasses both.
+ */
+export async function resolveMcpWorkspaceContext(
+  baseUrl: string,
+  options: { force?: boolean } = {},
+): Promise<McpWorkspaceContext | null> {
+  const now = Date.now();
+  const cached = cache.get(baseUrl);
+  if (!options.force && cached && now - cached.fetchedAt < MCP_WORKSPACE_CONTEXT_TTL_MS) {
+    return cached.context;
+  }
+  const failedAt = lastFailureAt.get(baseUrl);
+  if (
+    !options.force &&
+    failedAt !== undefined &&
+    now - failedAt < MCP_WORKSPACE_FAILURE_COOLDOWN_MS
+  ) {
+    return null;
+  }
+
+  try {
+    const resp = await fetch(`${baseUrl}/api/workspace/directory`, {
+      signal: AbortSignal.timeout(DIRECTORY_TIMEOUT_MS),
+    });
+    if (!resp.ok) {
+      recordFailure(baseUrl);
+      return null;
+    }
+    const data = (await resp.json()) as WorkspaceDirectoryResponse;
+    const selected = selectDefaultMcpCandidate(data.items);
+    if (!selected) {
+      // 200 with empty items — non-vela (dev provider) or no live membership.
+      recordFailure(baseUrl);
+      return null;
+    }
+    const context: McpWorkspaceContext = {
+      workspaceId: selected.workspaceId,
+      workspaceMemberId: selected.workspaceMemberId,
+      workspaceType: selected.workspaceType,
+      headers: {
+        'x-od-workspace-id': selected.workspaceId,
+        'x-od-workspace-member-id': selected.workspaceMemberId,
+      },
+    };
+    cache.set(baseUrl, { context, fetchedAt: Date.now() });
+    lastFailureAt.delete(baseUrl);
+    return context;
+  } catch {
+    recordFailure(baseUrl);
+    return null;
+  }
+}
+
+function recordFailure(baseUrl: string): void {
+  cache.delete(baseUrl);
+  lastFailureAt.set(baseUrl, Date.now());
+}
+
+/** Test-only reset. */
+export function _resetMcpWorkspaceContextCacheForTests(): void {
+  cache.clear();
+  lastFailureAt.clear();
+}

--- a/apps/daemon/src/mcp.ts
+++ b/apps/daemon/src/mcp.ts
@@ -34,10 +34,12 @@ import {
   ANALYTICS_HEADER_SESSION_ID,
   buildProjectRawFileUrl,
   type McpAnalyticsContextResponse,
+  type WorkspaceProjectsResponse,
 } from '@open-design/contracts';
 import { randomUUID } from 'node:crypto';
 
 import { postCreateArtifactRequest } from './artifacts/create.js';
+import { resolveMcpWorkspaceContext } from './mcp-workspace-context.js';
 import {
   createLocalMcpBriefStore as createBriefStore,
   localMcpBriefResponseCopy,
@@ -1983,6 +1985,27 @@ function publicVelaLoginStatus(status: unknown): unknown {
   return publicStatus;
 }
 
+// Tools that address projects or runs are workspace-scoped after 0.18.0:
+// bound projects are invisible to a headerless caller and bound-project reads
+// 400 with WORKSPACE_CONTEXT_REQUIRED (#6569). These resolve the signed-in
+// workspace and send x-od-workspace-* headers on every daemon call.
+const PROJECT_OR_RUN_TOOLS = new Set([
+  'list_projects',
+  'get_project',
+  'get_file',
+  'list_files',
+  'search_files',
+  'get_artifact',
+  'write_file',
+  'delete_file',
+  'delete_project',
+  'create_project',
+  'create_artifact',
+  'start_run',
+  'get_run',
+  'cancel_run',
+]);
+
 async function handleMcpToolCall(
   baseUrl: string,
   name: unknown,
@@ -1990,6 +2013,11 @@ async function handleMcpToolCall(
   options: HandleMcpToolCallOptions = {},
 ): Promise<McpToolCallResult> {
   try {
+    const workspaceContext = PROJECT_OR_RUN_TOOLS.has(String(name))
+      ? await resolveMcpWorkspaceContext(baseUrl)
+      : null;
+    const headers = workspaceContext?.headers;
+    const workspaceId = workspaceContext?.workspaceId;
     switch (name) {
       case 'collect_brief': {
         const collected = (options.briefStore ?? createLocalMcpBriefStore())
@@ -2030,6 +2058,20 @@ async function handleMcpToolCall(
         };
       }
       case 'list_projects':
+        if (workspaceId && headers) {
+          const data = await getJson<WorkspaceProjectsResponse>(
+            `${baseUrl}/api/workspaces/${encodeURIComponent(workspaceId)}/projects`,
+            headers,
+          );
+          return ok({
+            projects: (data?.projects ?? []).map((p) => ({
+              id: p.id,
+              name: p.name,
+              ...(p.metadata ? { metadata: p.metadata as unknown as JsonObject } : {}),
+              workspaceId: p.workspaceId,
+            })),
+          });
+        }
         return ok(await getJson<ProjectsPayload>(`${baseUrl}/api/projects`));
       case 'get_active_context': {
         const data = await getJson<ActiveContext>(`${baseUrl}/api/active`);
@@ -2042,18 +2084,21 @@ async function handleMcpToolCall(
         return ok(data);
       }
       case 'get_project': {
-        const { id, resolved, active } = await resolveProjectArg(baseUrl, args.project);
-        const data = await getJson<ProjectPayload>(`${baseUrl}/api/projects/${encodeURIComponent(id)}`);
+        const { id, resolved, active } = await resolveProjectArg(baseUrl, args.project, headers);
+        const data = await getJson<ProjectPayload>(
+          `${baseUrl}/api/projects/${encodeURIComponent(id)}`,
+          headers,
+        );
         const project = data?.project ?? data;
         const resolvedDir = typeof data?.resolvedDir === 'string' ? data.resolvedDir : null;
         const declaredEntry = project?.metadata?.entryFile ?? null;
-        const entryFile = await resolveProjectEntry(baseUrl, id, declaredEntry);
+        const entryFile = await resolveProjectEntry(baseUrl, id, declaredEntry, headers);
         const previewUrl = rawPreviewUrl(baseUrl, id, entryFile);
         // Build the studio deep link too — needs the project's
         // default conversation, which we look up once. Cheap to skip
         // when the daemon has no webBaseUrl configured.
         const webBase = await getWebBaseUrl(baseUrl);
-        const conversationId = webBase ? await getDefaultConversationId(baseUrl, id) : null;
+        const conversationId = webBase ? await getDefaultConversationId(baseUrl, id, headers) : null;
         const studioUrl = buildStudioUrl(webBase, id, conversationId, entryFile);
         return ok(
           withActiveEcho(
@@ -2088,15 +2133,15 @@ async function handleMcpToolCall(
         );
       }
       case 'list_files': {
-        const { id, resolved, active } = await resolveProjectArg(baseUrl, args.project);
+        const { id, resolved, active } = await resolveProjectArg(baseUrl, args.project, headers);
         const params = new URLSearchParams();
         if (typeof args.since === 'number' && Number.isFinite(args.since)) params.set('since', String(args.since));
         const qs = params.toString();
         const url = `${baseUrl}/api/projects/${encodeURIComponent(id)}/files${qs ? `?${qs}` : ''}`;
-        return ok(withActiveEcho(await getJson(url), active, resolved));
+        return ok(withActiveEcho(await getJson(url, headers), active, resolved));
       }
       case 'get_file': {
-        const { id, resolved, active } = await resolveProjectArg(baseUrl, args.project);
+        const { id, resolved, active } = await resolveProjectArg(baseUrl, args.project, headers);
         let path = typeof args.path === 'string' ? args.path : '';
         if (!path && active && active.fileName) {
           path = active.fileName;
@@ -2104,7 +2149,7 @@ async function handleMcpToolCall(
         requireString(path, 'path');
         const offset = typeof args.offset === 'number' && Number.isFinite(args.offset) ? Math.max(0, Math.floor(args.offset)) : 0;
         const limit = typeof args.limit === 'number' && Number.isFinite(args.limit) ? Math.max(1, Math.floor(args.limit)) : 2000;
-        return await getFile(baseUrl, id, path, active, resolved, offset, limit);
+        return await getFile(baseUrl, id, path, active, resolved, offset, limit, headers);
       }
       case 'get_artifact':
         return await getArtifact(
@@ -2113,9 +2158,10 @@ async function handleMcpToolCall(
           args.entry,
           args.include,
           args.maxBytes,
+          headers,
         );
       case 'search_files': {
-        const { id, resolved, active } = await resolveProjectArg(baseUrl, args.project);
+        const { id, resolved, active } = await resolveProjectArg(baseUrl, args.project, headers);
         requireString(args.query, 'query');
         const params = new URLSearchParams({ q: String(args.query) });
         if (args.pattern) params.set('pattern', String(args.pattern));
@@ -2124,6 +2170,7 @@ async function handleMcpToolCall(
           withActiveEcho(
             await getJson(
               `${baseUrl}/api/projects/${encodeURIComponent(id)}/search?${params.toString()}`,
+              headers,
             ),
             active,
             resolved,
@@ -2131,15 +2178,15 @@ async function handleMcpToolCall(
         );
       }
       case 'create_artifact':
-        return await createArtifact(baseUrl, args);
+        return await createArtifact(baseUrl, args, headers);
       case 'write_file':
-        return await writeFile(baseUrl, args);
+        return await writeFile(baseUrl, args, headers);
       case 'delete_file':
-        return await deleteFile(baseUrl, args);
+        return await deleteFile(baseUrl, args, headers);
       case 'delete_project':
-        return await deleteProject(baseUrl, args);
+        return await deleteProject(baseUrl, args, headers);
       case 'create_project':
-        return await createProject(baseUrl, args);
+        return await createProject(baseUrl, args, headers);
       case 'list_skills':
         return ok(await getJson<SkillsPayload>(`${baseUrl}/api/skills`));
       case 'list_plugins':
@@ -2166,15 +2213,16 @@ async function handleMcpToolCall(
           ),
         );
       case 'start_run':
-        return await startRun(baseUrl, args, options);
+        return await startRun(baseUrl, args, options, headers);
       case 'get_run':
-        return await getRun(baseUrl, args);
+        return await getRun(baseUrl, args, headers);
       case 'cancel_run': {
         requireString(args.runId, 'runId');
         return ok(
           await postJson<JsonObject>(
             `${baseUrl}/api/runs/${encodeURIComponent(args.runId)}/cancel`,
             {},
+            headers ?? {},
           ),
         );
       }
@@ -2186,8 +2234,12 @@ async function handleMcpToolCall(
   }
 }
 
-async function writeFile(baseUrl: string, args: McpArgs) {
-  const { id, resolved, active } = await resolveProjectArg(baseUrl, args.project);
+async function writeFile(
+  baseUrl: string,
+  args: McpArgs,
+  headers?: Record<string, string>,
+) {
+  const { id, resolved, active } = await resolveProjectArg(baseUrl, args.project, headers);
   // The daemon route requires its argv field to be called `name`; the
   // MCP-facing surface uses `path` to match the rest of the file tools.
   requireString(args.path, 'path');
@@ -2199,7 +2251,7 @@ async function writeFile(baseUrl: string, args: McpArgs) {
   const url = `${baseUrl}/api/projects/${encodeURIComponent(id)}/files`;
   const resp = await fetch(url, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...headers },
     body: JSON.stringify({ name: args.path, content: args.content, encoding }),
   });
   if (!resp.ok) {
@@ -2209,8 +2261,12 @@ async function writeFile(baseUrl: string, args: McpArgs) {
   return ok(withActiveEcho(json, active, resolved));
 }
 
-async function deleteFile(baseUrl: string, args: McpArgs) {
-  const { id, resolved, active } = await resolveProjectArg(baseUrl, args.project);
+async function deleteFile(
+  baseUrl: string,
+  args: McpArgs,
+  headers?: Record<string, string>,
+) {
+  const { id, resolved, active } = await resolveProjectArg(baseUrl, args.project, headers);
   requireString(args.path, 'path');
   // /api/projects/:id/raw/* accepts nested paths; /api/projects/:id/files/:name
   // does not. Mirror the create_artifact surface, which already lets agents
@@ -2220,7 +2276,7 @@ async function deleteFile(baseUrl: string, args: McpArgs) {
     .filter((s) => s.length > 0)
     .map(encodeURIComponent);
   const url = `${baseUrl}/api/projects/${encodeURIComponent(id)}/raw/${segments.join('/')}`;
-  const resp = await fetch(url, { method: 'DELETE' });
+  const resp = await fetch(url, headers ? { method: 'DELETE', headers } : { method: 'DELETE' });
   if (!resp.ok) {
     return errorResult(await formatDaemonError(resp, url));
   }
@@ -2228,7 +2284,11 @@ async function deleteFile(baseUrl: string, args: McpArgs) {
   return ok(withActiveEcho(json, active, resolved));
 }
 
-async function deleteProject(baseUrl: string, args: McpArgs) {
+async function deleteProject(
+  baseUrl: string,
+  args: McpArgs,
+  headers?: Record<string, string>,
+) {
   // Active-context fallback is intentionally disabled: the daemon's
   // DELETE /api/projects/:id is irreversible (purges the row and the
   // on-disk project directory), so we never want it to fire against the
@@ -2240,9 +2300,9 @@ async function deleteProject(baseUrl: string, args: McpArgs) {
   if (args.confirm !== true) {
     return errorResult('confirm:true is required to delete a project (this cannot be undone).');
   }
-  const { id, resolved } = await resolveProjectArg(baseUrl, args.project);
+  const { id, resolved } = await resolveProjectArg(baseUrl, args.project, headers);
   const url = `${baseUrl}/api/projects/${encodeURIComponent(id)}`;
-  const resp = await fetch(url, { method: 'DELETE' });
+  const resp = await fetch(url, headers ? { method: 'DELETE', headers } : { method: 'DELETE' });
   if (!resp.ok) {
     return errorResult(await formatDaemonError(resp, url));
   }
@@ -2295,7 +2355,11 @@ async function postJson<T>(
 // <question-form> output ends up dropped from the MCP response because
 // no project file is produced. Better to let the outer agent gather
 // requirements directly and pass a precise prompt to start_run.
-async function createProject(baseUrl: string, args: McpArgs) {
+async function createProject(
+  baseUrl: string,
+  args: McpArgs,
+  headers?: Record<string, string>,
+) {
   requireString(args.name, 'name');
   const id =
     typeof args.id === 'string' && args.id.length > 0
@@ -2308,7 +2372,17 @@ async function createProject(baseUrl: string, args: McpArgs) {
   if (typeof args.skill === 'string' && args.skill.length > 0) {
     body.skillId = args.skill;
   }
-  return ok(await postJson<JsonObject>(`${baseUrl}/api/projects`, body));
+  // Send the workspace pair so the daemon binds the project to the
+  // workspace immediately. If workspace authority fails (e.g. the cached
+  // membership went stale between refreshes), retry headerless once — a
+  // headerless create is always legal and the project is lazy-adopted on
+  // the next workspace list.
+  try {
+    return ok(await postJson<JsonObject>(`${baseUrl}/api/projects`, body, headers ?? {}));
+  } catch (err) {
+    if (!headers || !String(err).includes('WORKSPACE_')) throw err;
+    return ok(await postJson<JsonObject>(`${baseUrl}/api/projects`, body));
+  }
 }
 
 // Flatten daemon's plugin record into the few fields an external agent
@@ -2387,6 +2461,7 @@ async function startRun(
   baseUrl: string,
   args: McpArgs,
   options: HandleMcpToolCallOptions = {},
+  headers?: Record<string, string>,
 ) {
   if (
     Object.prototype.hasOwnProperty.call(args, 'apiKey')
@@ -2397,7 +2472,7 @@ async function startRun(
       'raw API keys are not accepted by Open Design MCP. Configure Local BYOK in the Open Design UI and start that run from the local product instead.',
     );
   }
-  const { id, resolved, active } = await resolveProjectArg(baseUrl, args.project);
+  const { id, resolved, active } = await resolveProjectArg(baseUrl, args.project, headers);
   if (args.requestId !== undefined) requireString(args.requestId, 'requestId');
   if (
     options.pluginAttribution
@@ -2459,7 +2534,7 @@ async function startRun(
   const created = await postJson<JsonObject>(
     `${baseUrl}/api/runs`,
     body,
-    options.analyticsHeaders,
+    { ...options.analyticsHeaders, ...headers },
   );
   // Build studioUrl (conversation-level — no entry file yet) so the
   // outer agent has a URL to give the user right away. The daemon
@@ -2502,10 +2577,15 @@ async function startRun(
 //     relay it to the user (without this, the run looks like a
 //     "succeeded with empty output" mystery), and
 // (3) a hint that tells the outer agent how to surface both.
-async function getRun(baseUrl: string, args: McpArgs) {
+async function getRun(
+  baseUrl: string,
+  args: McpArgs,
+  headers?: Record<string, string>,
+) {
   requireString(args.runId, 'runId');
   const status = await getJson<JsonObject>(
     `${baseUrl}/api/runs/${encodeURIComponent(args.runId)}`,
+    headers,
   );
   if (status.status !== 'succeeded' || typeof status.projectId !== 'string' || !status.projectId) {
     // Non-terminal (or terminal-but-failed) status. Surface
@@ -2547,10 +2627,11 @@ async function getRun(baseUrl: string, args: McpArgs) {
     entryFile = await resolveLegacyRunEntry(
       baseUrl,
       status.projectId,
+      headers,
     );
   }
   const [agentMessage, webBase] = await Promise.all([
-    fetchRunAgentMessage(baseUrl, String(status.id ?? args.runId)),
+    fetchRunAgentMessage(baseUrl, String(status.id ?? args.runId), headers),
     getWebBaseUrl(baseUrl),
   ]);
   const previewUrl = entryFile
@@ -2580,9 +2661,15 @@ async function getRun(baseUrl: string, args: McpArgs) {
 // for terminal runs and closes), parse out text_delta deltas, and
 // concatenate. Best-effort: any HTTP / parse error returns null so the
 // caller just omits the field.
-async function fetchRunAgentMessage(baseUrl: string, runId: string): Promise<string | null> {
+async function fetchRunAgentMessage(
+  baseUrl: string,
+  runId: string,
+  headers?: Record<string, string>,
+): Promise<string | null> {
   try {
-    const resp = await fetch(`${baseUrl}/api/runs/${encodeURIComponent(runId)}/events`);
+    const resp = await fetch(`${baseUrl}/api/runs/${encodeURIComponent(runId)}/events`, {
+      ...(headers ? { headers } : {}),
+    });
     if (!resp.ok) return null;
     const body = await resp.text();
     const parts: string[] = [];
@@ -2662,10 +2749,15 @@ function buildStudioUrl(
 // create_project seeds a default conversation per project; this just
 // reads the same one back. Returns null on any lookup failure — caller
 // omits studioUrl.
-async function getDefaultConversationId(baseUrl: string, projectId: string): Promise<string | null> {
+async function getDefaultConversationId(
+  baseUrl: string,
+  projectId: string,
+  headers?: Record<string, string>,
+): Promise<string | null> {
   try {
     const data = await getJson<{ conversations?: Array<{ id?: string }> }>(
       `${baseUrl}/api/projects/${encodeURIComponent(projectId)}/conversations`,
+      headers,
     );
     const first = Array.isArray(data?.conversations) ? data.conversations[0] : null;
     return typeof first?.id === 'string' && first.id.length > 0 ? first.id : null;
@@ -2681,11 +2773,17 @@ async function getDefaultConversationId(baseUrl: string, projectId: string): Pro
 // index.html exists at the project root — without the fallback,
 // get_project/get_run would silently omit previewUrl and force the
 // outer agent to guess a file:// path.
-async function resolveProjectEntry(baseUrl: string, projectId: string, declared: unknown): Promise<string | null> {
+async function resolveProjectEntry(
+  baseUrl: string,
+  projectId: string,
+  declared: unknown,
+  headers?: Record<string, string>,
+): Promise<string | null> {
   if (typeof declared === 'string' && declared.length > 0) return declared;
   try {
     const data = await getJson<{ files?: Array<{ path?: string; name?: string; kind?: string }> }>(
       `${baseUrl}/api/projects/${encodeURIComponent(projectId)}/files`,
+      headers,
     );
     const files = data?.files ?? [];
     // index.html wins at any level — the conventional entry signal.
@@ -2717,22 +2815,28 @@ function rawPreviewUrl(baseUrl: string, projectId: string, entry: unknown): stri
 async function resolveLegacyRunEntry(
   baseUrl: string,
   projectId: string,
+  headers?: Record<string, string>,
 ): Promise<string | null> {
   try {
     const data = await getJson<ProjectPayload>(
       `${baseUrl}/api/projects/${encodeURIComponent(projectId)}`,
+      headers,
     );
     const project = data?.project ?? data;
     const declared = (project as { metadata?: JsonObject } | undefined)
       ?.metadata?.entryFile;
-    return resolveProjectEntry(baseUrl, projectId, declared);
+    return resolveProjectEntry(baseUrl, projectId, declared, headers);
   } catch {
     return null;
   }
 }
 
-async function createArtifact(baseUrl: string, args: McpArgs) {
-  const { id, resolved, active } = await resolveProjectArg(baseUrl, args.project);
+async function createArtifact(
+  baseUrl: string,
+  args: McpArgs,
+  headers?: Record<string, string>,
+) {
+  const { id, resolved, active } = await resolveProjectArg(baseUrl, args.project, headers);
   requireString(args.name, 'name');
   requireString(args.content, 'content');
   if (
@@ -2750,6 +2854,7 @@ async function createArtifact(baseUrl: string, args: McpArgs) {
   const payload = await postCreateArtifactRequest({
     baseUrl,
     projectId: id,
+    ...(headers ? { headers } : {}),
     input: {
       name: args.name,
       content: args.content,
@@ -2780,18 +2885,37 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 const PROJECT_LIST_TTL_MS = 5000;
 let projectListCache: ProjectListCache | null = null;
 
-async function fetchProjectList(baseUrl: string): Promise<ProjectSummary[]> {
+async function fetchProjectList(
+  baseUrl: string,
+  headers?: Record<string, string>,
+): Promise<ProjectSummary[]> {
+  const workspaceId = headers?.['x-od-workspace-id'] ?? '';
+  // Cache key includes the workspace so a scoped and an unbound list never mix.
+  const cacheKey = workspaceId ? `${baseUrl}|${workspaceId}` : baseUrl;
   const now = Date.now();
   if (
     projectListCache &&
-    projectListCache.baseUrl === baseUrl &&
+    projectListCache.baseUrl === cacheKey &&
     now - projectListCache.t < PROJECT_LIST_TTL_MS
   ) {
     return projectListCache.list;
   }
-  const data = await getJson<ProjectsPayload>(`${baseUrl}/api/projects`);
-  const list = Array.isArray(data?.projects) ? data.projects : [];
-  projectListCache = { baseUrl, t: now, list };
+  let list: ProjectSummary[];
+  if (workspaceId && headers) {
+    const data = await getJson<WorkspaceProjectsResponse>(
+      `${baseUrl}/api/workspaces/${encodeURIComponent(workspaceId)}/projects`,
+      headers,
+    );
+    list = (data?.projects ?? []).map((p) => ({
+      id: p.id,
+      name: p.name,
+      ...(p.metadata ? { metadata: p.metadata as unknown as JsonObject } : {}),
+    }));
+  } else {
+    const data = await getJson<ProjectsPayload>(`${baseUrl}/api/projects`);
+    list = Array.isArray(data?.projects) ? data.projects : [];
+  }
+  projectListCache = { baseUrl: cacheKey, t: now, list };
   return list;
 }
 
@@ -2800,9 +2924,13 @@ async function fetchProjectList(baseUrl: string): Promise<ProjectSummary[]> {
 // caller, the active-context payload that was used. Throws a clear
 // error when neither is available so the agent can prompt the user
 // rather than guessing.
-async function resolveProjectArg(baseUrl: string, arg: unknown): Promise<{ id: string; resolved: ResolvedProject | null; active: ActiveContext | null }> {
+async function resolveProjectArg(
+  baseUrl: string,
+  arg: unknown,
+  headers?: Record<string, string>,
+): Promise<{ id: string; resolved: ResolvedProject | null; active: ActiveContext | null }> {
   if (typeof arg === 'string' && arg.length > 0) {
-    const resolved = await resolveProjectId(baseUrl, arg);
+    const resolved = await resolveProjectId(baseUrl, arg, headers);
     return { id: resolved.id, resolved, active: null };
   }
   let active: ActiveContext;
@@ -2821,13 +2949,17 @@ async function resolveProjectArg(baseUrl: string, arg: unknown): Promise<{ id: s
   return { id: active.projectId, resolved: null, active };
 }
 
-async function resolveProjectId(baseUrl: string, arg: unknown): Promise<ResolvedProject> {
+async function resolveProjectId(
+  baseUrl: string,
+  arg: unknown,
+  headers?: Record<string, string>,
+): Promise<ResolvedProject> {
   if (typeof arg !== 'string' || !arg) {
     throw new Error('project is required (string).');
   }
   if (UUID_RE.test(arg)) return { id: arg, name: arg, source: 'uuid' as const };
 
-  const list = await fetchProjectList(baseUrl);
+  const list = await fetchProjectList(baseUrl, headers);
   if (list.length === 0) {
     throw new Error('no projects on this daemon');
   }
@@ -2862,8 +2994,8 @@ async function resolveProjectId(baseUrl: string, arg: unknown): Promise<Resolved
   throw new Error(`no project matches "${arg}"`);
 }
 
-async function getJson<T>(url: string): Promise<T> {
-  const resp = await fetch(url);
+async function getJson<T>(url: string, headers?: Record<string, string>): Promise<T> {
+  const resp = await fetch(url, headers ? { headers } : undefined);
   if (!resp.ok) {
     const body = await safeText(resp);
     throw new Error(`daemon ${resp.status} on ${url}: ${body || resp.statusText}`);
@@ -2871,13 +3003,22 @@ async function getJson<T>(url: string): Promise<T> {
   return (await resp.json()) as T;
 }
 
-async function getFile(baseUrl: string, project: string, relPath: string, active: ActiveContext | null, resolved?: ResolvedProject | null, offset = 0, limit = 2000) {
+async function getFile(
+  baseUrl: string,
+  project: string,
+  relPath: string,
+  active: ActiveContext | null,
+  resolved?: ResolvedProject | null,
+  offset = 0,
+  limit = 2000,
+  headers?: Record<string, string>,
+) {
   const segments = String(relPath)
     .split('/')
     .filter((s) => s.length > 0)
     .map(encodeURIComponent);
   const url = `${baseUrl}/api/projects/${encodeURIComponent(project)}/raw/${segments.join('/')}`;
-  const resp = await fetch(url);
+  const resp = await fetch(url, headers ? { headers } : undefined);
   if (!resp.ok) {
     const body = await safeText(resp);
     return errorResult(
@@ -2964,7 +3105,14 @@ function totalTextBytes(files: ProjectFileBundleEntry[]): number {
   return n;
 }
 
-async function getArtifact(baseUrl: string, projectArg: unknown, entryArg: unknown, includeMode: unknown, maxBytesArg: unknown) {
+async function getArtifact(
+  baseUrl: string,
+  projectArg: unknown,
+  entryArg: unknown,
+  includeMode: unknown,
+  maxBytesArg: unknown,
+  headers?: Record<string, string>,
+) {
   const include = includeMode == null || includeMode === '' ? 'auto' : includeMode;
   if (typeof include !== 'string' || !VALID_INCLUDE_MODES.has(include)) {
     return errorResult(
@@ -2974,8 +3122,11 @@ async function getArtifact(baseUrl: string, projectArg: unknown, entryArg: unkno
   const maxBytes =
     typeof maxBytesArg === 'number' && Number.isFinite(maxBytesArg) && maxBytesArg > 0 ? maxBytesArg : DEFAULT_MAX_BYTES;
 
-  const { id, active, resolved } = await resolveProjectArg(baseUrl, projectArg);
-  const data = await getJson<ProjectPayload>(`${baseUrl}/api/projects/${encodeURIComponent(id)}`);
+  const { id, active, resolved } = await resolveProjectArg(baseUrl, projectArg, headers);
+  const data = await getJson<ProjectPayload>(
+    `${baseUrl}/api/projects/${encodeURIComponent(id)}`,
+    headers,
+  );
   const project = (data.project ?? data) as ProjectSummary;
   // Active-file beats project default entry when project also came
   // from active context - if the user is on landing.html and asks
@@ -2995,7 +3146,7 @@ async function getArtifact(baseUrl: string, projectArg: unknown, entryArg: unkno
   if (include === 'shallow') {
     let file;
     try {
-      file = await fetchProjectFile(baseUrl, id, entry);
+      file = await fetchProjectFile(baseUrl, id, entry, undefined, headers);
     } catch (err) {
       return errorResult(errorMessage(err));
     }
@@ -3003,7 +3154,10 @@ async function getArtifact(baseUrl: string, projectArg: unknown, entryArg: unkno
   }
 
   if (include === 'all') {
-    const meta = await getJson<{ files?: Array<{ name: string }> }>(`${baseUrl}/api/projects/${encodeURIComponent(id)}/files`);
+    const meta = await getJson<{ files?: Array<{ name: string }> }>(
+      `${baseUrl}/api/projects/${encodeURIComponent(id)}/files`,
+      headers,
+    );
     const allFiles = Array.isArray(meta?.files) ? meta.files : [];
     const fetched: ProjectFileBundleEntry[] = [];
     let truncated = false;
@@ -3015,7 +3169,7 @@ async function getArtifact(baseUrl: string, projectArg: unknown, entryArg: unkno
       }
       try {
         const remaining = maxBytes - totalTextBytes(fetched);
-        fetched.push(await fetchProjectFile(baseUrl, id, f.name, remaining));
+        fetched.push(await fetchProjectFile(baseUrl, id, f.name, remaining, headers));
       } catch (err) {
         if (err instanceof BudgetExceededError) truncated = true;
         else skippedFileCount += 1;
@@ -3030,7 +3184,7 @@ async function getArtifact(baseUrl: string, projectArg: unknown, entryArg: unkno
   // returning an empty bundle would hide that.
   let entryFile;
   try {
-    entryFile = await fetchProjectFile(baseUrl, id, entry);
+    entryFile = await fetchProjectFile(baseUrl, id, entry, undefined, headers);
   } catch (err) {
     return errorResult(errorMessage(err));
   }
@@ -3057,7 +3211,7 @@ async function getArtifact(baseUrl: string, projectArg: unknown, entryArg: unkno
       let file;
       try {
         const remaining = maxBytes - totalTextBytes(fetched);
-        file = await fetchProjectFile(baseUrl, id, refPath, remaining);
+        file = await fetchProjectFile(baseUrl, id, refPath, remaining, headers);
       } catch (err) {
         if (err instanceof BudgetExceededError) truncated = true;
         else skippedFileCount += 1;
@@ -3081,13 +3235,19 @@ async function getArtifact(baseUrl: string, projectArg: unknown, entryArg: unkno
 // failure of the whole bundle.
 class BudgetExceededError extends Error {}
 
-async function fetchProjectFile(baseUrl: string, projectId: string, relPath: string, remainingBytes = Infinity): Promise<ProjectFileBundleEntry> {
+async function fetchProjectFile(
+  baseUrl: string,
+  projectId: string,
+  relPath: string,
+  remainingBytes = Infinity,
+  headers?: Record<string, string>,
+): Promise<ProjectFileBundleEntry> {
   const segments = String(relPath)
     .split('/')
     .filter((s) => s.length > 0)
     .map(encodeURIComponent);
   const url = `${baseUrl}/api/projects/${encodeURIComponent(projectId)}/raw/${segments.join('/')}`;
-  const resp = await fetch(url);
+  const resp = await fetch(url, headers ? { headers } : undefined);
   if (!resp.ok) {
     const body = await safeText(resp);
     throw new Error(`daemon ${resp.status} on ${url}: ${body || resp.statusText}`);

--- a/apps/daemon/tests/mcp-create-artifact.test.ts
+++ b/apps/daemon/tests/mcp-create-artifact.test.ts
@@ -1,8 +1,22 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { handleMcpToolCall } from '../src/mcp.js';
+import { _resetMcpWorkspaceContextCacheForTests } from '../src/mcp-workspace-context.js';
 
 const originalFetch = globalThis.fetch;
+
+// Non-vela directory: the bridge falls back to headerless behavior, which is
+// what this suite exercised before #6569.
+function withDirectory(
+  fn: (url: string, init?: RequestInit) => Promise<Response>,
+): (url: string, init?: RequestInit) => Promise<Response> {
+  return async (url: string, init?: RequestInit) => {
+    if (String(url).endsWith('/api/workspace/directory')) {
+      return new Response(JSON.stringify({ items: [], activeWorkspaceId: null }), { status: 200 });
+    }
+    return fn(url, init);
+  };
+}
 
 function firstText(result: { content: Array<{ text: string }> }): string {
   const item = result.content[0];
@@ -12,6 +26,7 @@ function firstText(result: { content: Array<{ text: string }> }): string {
 
 describe('public MCP create_artifact', () => {
   afterEach(() => {
+    _resetMcpWorkspaceContextCacheForTests();
     vi.unstubAllGlobals();
     globalThis.fetch = originalFetch;
   });
@@ -31,7 +46,7 @@ describe('public MCP create_artifact', () => {
         { status: 200 },
       );
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'create_artifact', {
       project: 'Demo',
@@ -63,7 +78,7 @@ describe('public MCP create_artifact', () => {
       }
       return new Response(JSON.stringify({ file: { name: 'index.html' } }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'create_artifact', {
       name: 'index.html',
@@ -83,7 +98,7 @@ describe('public MCP create_artifact', () => {
       }
       return new Response(JSON.stringify({ file: { name: 'index.html' } }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17457', 'create_artifact', {
       project: 'custom-project-id',
@@ -102,7 +117,7 @@ describe('public MCP create_artifact', () => {
       }
       return new Response(JSON.stringify({ file: { name: 'unused.html' } }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'create_artifact', {
       project: 'Demo',
@@ -121,7 +136,7 @@ describe('public MCP create_artifact', () => {
       }
       return new Response(JSON.stringify({ file: { name: 'unused.html' } }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'create_artifact', {
       project: 'Demo',

--- a/apps/daemon/tests/mcp-get-project.test.ts
+++ b/apps/daemon/tests/mcp-get-project.test.ts
@@ -1,8 +1,15 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { handleMcpToolCall } from '../src/mcp.js';
+import { _resetMcpWorkspaceContextCacheForTests } from '../src/mcp-workspace-context.js';
 
 const originalFetch = globalThis.fetch;
+
+// Non-vela directory: the bridge falls back to headerless behavior, which is
+// what this suite exercised before #6569.
+function emptyDirectory(): Response {
+  return new Response(JSON.stringify({ items: [], activeWorkspaceId: null }), { status: 200 });
+}
 
 function firstJson<T>(result: { content: Array<{ text: string }> }): T {
   const item = result.content[0];
@@ -12,6 +19,7 @@ function firstJson<T>(result: { content: Array<{ text: string }> }): T {
 
 describe('public MCP get_project', () => {
   afterEach(() => {
+    _resetMcpWorkspaceContextCacheForTests();
     vi.unstubAllGlobals();
     globalThis.fetch = originalFetch;
   });
@@ -21,6 +29,7 @@ describe('public MCP get_project', () => {
     const projectId = '11111111-1111-1111-1111-111111111111';
     const resolvedDir = '/tmp/open-design/projects/demo';
     const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith('/api/workspace/directory')) return emptyDirectory();
       if (url.endsWith('/api/mcp/install-info')) {
         return new Response(JSON.stringify({ webBaseUrl: null }), { status: 200 });
       }
@@ -43,7 +52,7 @@ describe('public MCP get_project', () => {
       project: projectId,
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(firstJson(result)).toMatchObject({
       id: projectId,
       name: 'Demo',

--- a/apps/daemon/tests/mcp-runs.test.ts
+++ b/apps/daemon/tests/mcp-runs.test.ts
@@ -2,8 +2,22 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { buildProjectRawFileUrl } from '@open-design/contracts';
 
 import { handleMcpToolCall, localMcpToolDefinitions } from '../src/mcp.js';
+import { _resetMcpWorkspaceContextCacheForTests } from '../src/mcp-workspace-context.js';
 
 const originalFetch = globalThis.fetch;
+
+// Non-vela directory: the bridge falls back to headerless behavior, which is
+// what this suite exercised before #6569.
+function withDirectory(
+  fn: (url: string, init?: RequestInit) => Promise<Response>,
+): (url: string, init?: RequestInit) => Promise<Response> {
+  return async (url: string, init?: RequestInit) => {
+    if (String(url).endsWith('/api/workspace/directory')) {
+      return new Response(JSON.stringify({ items: [], activeWorkspaceId: null }), { status: 200 });
+    }
+    return fn(url, init);
+  };
+}
 
 function firstText(result: { content: Array<{ text: string }> }): string {
   const item = result.content[0];
@@ -17,6 +31,7 @@ function firstText(result: { content: Array<{ text: string }> }): string {
 // itself — it asks the daemon to, and the daemon spawns its own agent.
 describe('public MCP discovery + generation tools', () => {
   afterEach(() => {
+    _resetMcpWorkspaceContextCacheForTests();
     vi.unstubAllGlobals();
     globalThis.fetch = originalFetch;
   });
@@ -26,7 +41,7 @@ describe('public MCP discovery + generation tools', () => {
       expect(url).toBe('http://127.0.0.1:17456/api/skills');
       return new Response(JSON.stringify({ skills: [{ id: 'deck', name: 'Deck' }] }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'list_skills', {});
     expect(JSON.parse(firstText(result))).toEqual({ skills: [{ id: 'deck', name: 'Deck' }] });
@@ -43,7 +58,7 @@ describe('public MCP discovery + generation tools', () => {
     const fetchMock = vi.fn(async () =>
       new Response(JSON.stringify({ runId: 'must-not-run' }), { status: 200 }),
     );
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall(
       'http://127.0.0.1:17456',
@@ -69,7 +84,7 @@ describe('public MCP discovery + generation tools', () => {
       expect(init?.method).toBe('POST');
       return new Response(JSON.stringify({ runId: 'run-42', pluginId: 'pitch-deck' }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'start_run', {
       project: 'Demo',
@@ -107,7 +122,7 @@ describe('public MCP discovery + generation tools', () => {
       }
       return new Response(JSON.stringify({ runId: 'run-7' }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'start_run', { prompt: 'iterate' });
 
@@ -133,7 +148,7 @@ describe('public MCP discovery + generation tools', () => {
       }
       return new Response(JSON.stringify({ runId: 'run-55', skillId: 'brand-identity' }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'start_run', {
       project: 'Demo',
@@ -163,7 +178,7 @@ describe('public MCP discovery + generation tools', () => {
       }
       return new Response(JSON.stringify({ runId: 'run-no-agent' }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'start_run', {
       prompt: 'make a banner',
@@ -188,7 +203,7 @@ describe('public MCP discovery + generation tools', () => {
       }
       return new Response(JSON.stringify({ runId: 'unused' }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'start_run', {
       project: 'Demo',
@@ -210,7 +225,7 @@ describe('public MCP discovery + generation tools', () => {
       }
       throw new Error(`unexpected url ${url}`);
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'get_run', { runId: 'run-42' });
     const parsed = JSON.parse(firstText(result));
@@ -225,7 +240,7 @@ describe('public MCP discovery + generation tools', () => {
       }
       return new Response(JSON.stringify({ id: 'run-99', status: 'running', projectId: 'project-1' }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'get_run', { runId: 'run-99' });
     const parsed = JSON.parse(firstText(result));
@@ -248,7 +263,7 @@ describe('public MCP discovery + generation tools', () => {
         failureAction: 'recharge',
       }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall(
       'http://127.0.0.1:17456',
@@ -299,7 +314,7 @@ describe('public MCP discovery + generation tools', () => {
       }
       throw new Error('unexpected url ' + url);
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'get_run', { runId: 'run-42' });
     const parsed = JSON.parse(firstText(result));
@@ -329,7 +344,7 @@ describe('public MCP discovery + generation tools', () => {
       }
       throw new Error('unexpected url ' + url);
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'get_run', { runId: 'run-42' });
     const parsed = JSON.parse(firstText(result));
@@ -375,7 +390,7 @@ describe('public MCP discovery + generation tools', () => {
       }
       throw new Error(`unexpected url ${url}`);
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const first = await handleMcpToolCall(
       'http://127.0.0.1:17456',
@@ -416,7 +431,7 @@ describe('public MCP discovery + generation tools', () => {
       }
       throw new Error('unexpected url ' + url);
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'get_run', { runId: 'run-42' });
     const parsed = JSON.parse(firstText(result));
@@ -440,7 +455,7 @@ describe('public MCP discovery + generation tools', () => {
       }
       throw new Error('unexpected url ' + url);
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'start_run', {
       project: 'Demo',
@@ -468,7 +483,7 @@ describe('public MCP discovery + generation tools', () => {
       }
       throw new Error('unexpected url ' + url);
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'get_project', { project: PROJECT_UUID });
     const parsed = JSON.parse(firstText(result));
@@ -484,7 +499,7 @@ describe('public MCP discovery + generation tools', () => {
       projectId: 'project-1',
       eventsLogPath: '/Users/x/.od/runs/run-99/events.jsonl',
     }), { status: 200 }));
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'get_run', { runId: 'run-99' });
     const parsed = JSON.parse(firstText(result));
@@ -506,7 +521,7 @@ describe('public MCP discovery + generation tools', () => {
       expect(init?.method).toBe('POST');
       return new Response(JSON.stringify({ ok: true }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'cancel_run', { runId: 'run-42' });
     expect(JSON.parse(firstText(result))).toEqual({ ok: true });
@@ -519,7 +534,7 @@ describe('public MCP discovery + generation tools', () => {
       const body = JSON.parse(String(init?.body));
       return new Response(JSON.stringify({ project: { id: body.id, name: body.name }, conversationId: 'c1' }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'create_project', {
       name: 'Demo Deck',
@@ -538,7 +553,7 @@ describe('public MCP discovery + generation tools', () => {
       const body = JSON.parse(String(init?.body));
       return new Response(JSON.stringify({ project: { id: body.id, name: body.name }, conversationId: 'c1' }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     await handleMcpToolCall('http://127.0.0.1:17456', 'create_project', { name: 'My Site', id: 'fixed-id' });
     const postBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
@@ -547,7 +562,7 @@ describe('public MCP discovery + generation tools', () => {
 
   it('create_project requires a name before posting', async () => {
     const fetchMock = vi.fn(async () => new Response('{}', { status: 200 }));
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'create_project', {});
     expect(result).toMatchObject({ isError: true });
@@ -565,7 +580,7 @@ describe('public MCP discovery + generation tools', () => {
         { status: 200 },
       );
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'get_project', { project: PROJECT_UUID });
     const parsed = JSON.parse(firstText(result));
@@ -581,7 +596,7 @@ describe('public MCP discovery + generation tools', () => {
       }
       return new Response(JSON.stringify({ project: { id: PROJECT_UUID, name: 'P1', metadata: {} } }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'get_project', { project: PROJECT_UUID });
     const parsed = JSON.parse(firstText(result));
@@ -606,7 +621,7 @@ describe('public MCP discovery + generation tools', () => {
       }
       return new Response(JSON.stringify({ project: { id: PROJECT_UUID, name: 'P1', metadata: { skipDiscoveryBrief: true } } }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'get_project', { project: PROJECT_UUID });
     const parsed = JSON.parse(firstText(result));
@@ -625,7 +640,7 @@ describe('public MCP discovery + generation tools', () => {
       }
       return new Response(JSON.stringify({ project: { id: PROJECT_UUID, metadata: {} } }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'get_project', { project: PROJECT_UUID });
     const parsed = JSON.parse(firstText(result));
@@ -644,7 +659,7 @@ describe('public MCP discovery + generation tools', () => {
       }
       return new Response(JSON.stringify({ project: { id: PROJECT_UUID, metadata: {} } }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'get_project', { project: PROJECT_UUID });
     const parsed = JSON.parse(firstText(result));
@@ -686,7 +701,7 @@ describe('public MCP discovery + generation tools', () => {
       }
       throw new Error(`unexpected url ${url}`);
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'get_run', { runId: 'run-42' });
     const parsed = JSON.parse(firstText(result));
@@ -712,7 +727,7 @@ describe('public MCP discovery + generation tools', () => {
       }
       throw new Error(`unexpected url ${url}`);
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'get_run', { runId: 'run-42' });
     const parsed = JSON.parse(firstText(result));
@@ -733,7 +748,7 @@ describe('public MCP discovery + generation tools', () => {
       }
       throw new Error(`unexpected url ${url}`);
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'get_run', { runId: 'run-42' });
     const parsed = JSON.parse(firstText(result));
@@ -761,7 +776,7 @@ describe('public MCP discovery + generation tools', () => {
       }
       throw new Error(`unexpected url ${url}`);
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'get_run', { runId: 'run-42' });
     const parsed = JSON.parse(firstText(result));
@@ -790,7 +805,7 @@ describe('public MCP discovery + generation tools', () => {
       const body = JSON.parse(String(init?.body));
       return new Response(JSON.stringify({ project: { id: body.id, name: body.name }, conversationId: 'c1' }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     await handleMcpToolCall('http://127.0.0.1:17456', 'create_project', { name: 'X' });
     const postBody = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
@@ -824,7 +839,7 @@ describe('public MCP discovery + generation tools', () => {
       }),
       { status: 200 },
     ));
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'list_plugins', {});
     const parsed = JSON.parse(firstText(result));
@@ -879,7 +894,7 @@ describe('public MCP discovery + generation tools', () => {
         },
       ],
     }), { status: 200 }));
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'list_agents', {});
     const parsed = JSON.parse(firstText(result));
@@ -906,7 +921,7 @@ describe('public MCP discovery + generation tools', () => {
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({
       agents: [{ id: 'opencode', name: 'OpenCode', available: true, models: longModels }],
     }), { status: 200 }));
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'list_agents', {});
     const parsed = JSON.parse(firstText(result));
@@ -921,7 +936,7 @@ describe('public MCP discovery + generation tools', () => {
         { id: 'devin', name: 'Devin', available: false, installUrl: 'https://cli.devin.ai', models: [] },
       ],
     }), { status: 200 }));
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall('http://127.0.0.1:17456', 'list_agents', { includeUnavailable: true });
     const parsed = JSON.parse(firstText(result));

--- a/apps/daemon/tests/mcp-workspace-context.test.ts
+++ b/apps/daemon/tests/mcp-workspace-context.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { WorkspaceDirectoryItem } from '@open-design/contracts';
+
+import {
+  _resetMcpWorkspaceContextCacheForTests,
+  resolveMcpWorkspaceContext,
+  selectDefaultMcpCandidate,
+} from '../src/mcp-workspace-context.js';
+
+const originalFetch = globalThis.fetch;
+
+function item(overrides: Partial<WorkspaceDirectoryItem> = {}): WorkspaceDirectoryItem {
+  return {
+    workspaceId: 'ws-personal',
+    workspaceName: 'Personal',
+    workspaceType: 'personal',
+    workspaceMemberId: 'mem-1',
+    role: 'owner',
+    memberStatus: 'active',
+    lifecycleState: 'active',
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  _resetMcpWorkspaceContextCacheForTests();
+  vi.unstubAllGlobals();
+  globalThis.fetch = originalFetch;
+});
+
+describe('selectDefaultMcpCandidate', () => {
+  it('only considers active, live memberships', () => {
+    const removed = item({ workspaceId: 'ws-removed', memberStatus: 'removed' });
+    const deleted = item({ workspaceId: 'ws-deleted', lifecycleState: 'deleted' });
+    const active = item({ workspaceId: 'ws-active' });
+    expect(selectDefaultMcpCandidate([removed, deleted, active])).toBe(active);
+  });
+
+  it('prefers the preferred workspace when it is an active candidate', () => {
+    const team = item({ workspaceId: 'ws-team', workspaceType: 'team' });
+    const personal = item({ workspaceId: 'ws-personal' });
+    expect(selectDefaultMcpCandidate([team, personal], 'ws-team')).toBe(team);
+    expect(selectDefaultMcpCandidate([team, personal], 'missing')).toBe(personal);
+  });
+
+  it('prefers a personal workspace over a team workspace, then first candidate', () => {
+    const teamA = item({ workspaceId: 'ws-a', workspaceType: 'team' });
+    const personal = item({ workspaceId: 'ws-personal' });
+    const teamB = item({ workspaceId: 'ws-b', workspaceType: 'team' });
+    expect(selectDefaultMcpCandidate([teamA, personal, teamB])).toBe(personal);
+    expect(selectDefaultMcpCandidate([teamA, teamB])).toBe(teamA);
+  });
+
+  it('returns undefined for empty or fully-inactive lists', () => {
+    expect(selectDefaultMcpCandidate([])).toBeUndefined();
+    expect(
+      selectDefaultMcpCandidate([
+        item({ memberStatus: 'removed' }),
+        item({ lifecycleState: 'deleted' }),
+      ]),
+    ).toBeUndefined();
+  });
+});
+
+describe('resolveMcpWorkspaceContext', () => {
+  it('bootstraps the personal workspace and returns both headers', async () => {
+    const base = 'http://127.0.0.1:19001';
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          items: [item()],
+          activeWorkspaceId: null,
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const ctx = await resolveMcpWorkspaceContext(base);
+    expect(ctx).toEqual({
+      workspaceId: 'ws-personal',
+      workspaceMemberId: 'mem-1',
+      workspaceType: 'personal',
+      headers: {
+        'x-od-workspace-id': 'ws-personal',
+        'x-od-workspace-member-id': 'mem-1',
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(`${base}/api/workspace/directory`, expect.anything());
+  });
+
+  it('returns null on a directory outage (non-200)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('unavailable', { status: 503 })),
+    );
+    expect(await resolveMcpWorkspaceContext('http://x')).toBeNull();
+  });
+
+  it('returns null when the directory has no active membership (non-vela)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify({ items: [], activeWorkspaceId: null }), { status: 200 })),
+    );
+    expect(await resolveMcpWorkspaceContext('http://x')).toBeNull();
+  });
+
+  it('caches per baseUrl within the TTL', async () => {
+    const base = 'http://127.0.0.1:19001';
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ items: [item()], activeWorkspaceId: null }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await resolveMcpWorkspaceContext(base);
+    await resolveMcpWorkspaceContext(base);
+    await resolveMcpWorkspaceContext(base);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Different baseUrl re-bootstraps independently.
+    await resolveMcpWorkspaceContext('http://127.0.0.1:19002');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('force bypasses the cache and refetches', async () => {
+    const base = 'http://127.0.0.1:19001';
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ items: [item()], activeWorkspaceId: null }), { status: 200 }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await resolveMcpWorkspaceContext(base);
+    await resolveMcpWorkspaceContext(base, { force: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('backs off for the failure cooldown after an outage', async () => {
+    const base = 'http://127.0.0.1:19001';
+    let calls = 0;
+    const fetchMock = vi.fn(async () => {
+      calls += 1;
+      return new Response('unavailable', { status: 503 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    expect(await resolveMcpWorkspaceContext(base)).toBeNull();
+    expect(await resolveMcpWorkspaceContext(base)).toBeNull();
+    expect(await resolveMcpWorkspaceContext(base)).toBeNull();
+    expect(calls).toBe(1);
+
+    // force breaks the cooldown.
+    expect(await resolveMcpWorkspaceContext(base, { force: true })).toBeNull();
+    expect(calls).toBe(2);
+  });
+});

--- a/apps/daemon/tests/mcp-workspace-projects.test.ts
+++ b/apps/daemon/tests/mcp-workspace-projects.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { handleMcpToolCall } from '../src/mcp.js';
+import { _resetMcpWorkspaceContextCacheForTests } from '../src/mcp-workspace-context.js';
+
+const originalFetch = globalThis.fetch;
+const BASE = 'http://127.0.0.1:19001';
+
+const DIRECTORY = {
+  items: [
+    {
+      workspaceId: 'ws-personal',
+      workspaceName: 'Personal',
+      workspaceType: 'personal',
+      workspaceMemberId: 'mem-1',
+      role: 'owner',
+      memberStatus: 'active',
+      lifecycleState: 'active',
+    },
+  ],
+  activeWorkspaceId: null,
+};
+
+function directoryResponse(): Response {
+  return new Response(JSON.stringify(DIRECTORY), { status: 200 });
+}
+
+function firstJson<T>(result: { content: Array<{ text: string }> }): T {
+  const item = result.content[0];
+  if (!item) throw new Error('expected MCP text content');
+  return JSON.parse(item.text) as T;
+}
+
+afterEach(() => {
+  _resetMcpWorkspaceContextCacheForTests();
+  vi.unstubAllGlobals();
+  globalThis.fetch = originalFetch;
+});
+
+describe('MCP workspace-scoped project tools (#6569)', () => {
+  it('list_projects calls the workspace-scoped catalog with workspace headers', async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      if (url.endsWith('/api/workspace/directory')) return directoryResponse();
+      if (url.includes('/api/workspaces/ws-personal/projects')) {
+        return new Response(
+          JSON.stringify({
+            projects: [
+              {
+                id: '22222222-2222-2222-2222-222222222222',
+                name: 'Bound Demo',
+                workspaceId: 'ws-personal',
+                metadata: { kind: 'prototype' },
+              },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ projects: [] }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handleMcpToolCall(BASE, 'list_projects', {});
+
+    expect(calls[0]?.url).toBe(`${BASE}/api/workspace/directory`);
+    const scoped = calls.find((c) => c.url.includes('/api/workspaces/ws-personal/projects'));
+    expect(scoped).toBeTruthy();
+    expect((scoped?.init?.headers as Record<string, string>)['x-od-workspace-id']).toBe('ws-personal');
+    expect((scoped?.init?.headers as Record<string, string>)['x-od-workspace-member-id']).toBe('mem-1');
+    const body = firstJson<{ projects: Array<{ id: string; name: string }> }>(result);
+    expect(body.projects).toHaveLength(1);
+    expect(body.projects[0]?.name).toBe('Bound Demo');
+  });
+
+  it('get_project sends workspace headers on the bound-project read', async () => {
+    const projectId = '11111111-1111-1111-1111-111111111111';
+    const seen: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      seen.push({ url, init });
+      if (url.endsWith('/api/workspace/directory')) return directoryResponse();
+      if (url.endsWith('/api/mcp/install-info')) {
+        return new Response(JSON.stringify({ webBaseUrl: null }), { status: 200 });
+      }
+      if (url.includes(`/api/projects/${projectId}/conversations`)) {
+        return new Response(JSON.stringify({ conversations: [] }), { status: 200 });
+      }
+      if (url.includes(`/api/projects/${projectId}`)) {
+        return new Response(
+          JSON.stringify({
+            project: { id: projectId, name: 'Demo', metadata: { entryFile: 'index.html' } },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response('{}', { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await handleMcpToolCall(BASE, 'get_project', { project: projectId });
+
+    const projectCall = seen.find((c) => c.url.includes(`/api/projects/${projectId}`) && !c.url.includes('conversations'));
+    expect(projectCall).toBeTruthy();
+    expect((projectCall?.init?.headers as Record<string, string>)['x-od-workspace-id']).toBe('ws-personal');
+    expect((projectCall?.init?.headers as Record<string, string>)['x-od-workspace-member-id']).toBe('mem-1');
+  });
+
+  it('write_file sends workspace headers on the project-file write', async () => {
+    const projectId = '11111111-1111-1111-1111-111111111111';
+    const seen: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      seen.push({ url, init });
+      if (url.endsWith('/api/workspace/directory')) return directoryResponse();
+      if (url.includes(`/api/projects/${projectId}/files`) && init?.method === 'POST') {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await handleMcpToolCall(BASE, 'write_file', {
+      project: projectId,
+      path: 'index.html',
+      content: '<h1>hi</h1>',
+    });
+
+    const writeCall = seen.find((c) => c.url.includes(`/api/projects/${projectId}/files`) && c.init?.method === 'POST');
+    expect(writeCall).toBeTruthy();
+    expect((writeCall?.init?.headers as Record<string, string>)['x-od-workspace-id']).toBe('ws-personal');
+  });
+
+  it('create_project sends workspace headers and falls back headerless on workspace denial', async () => {
+    let createCalls = 0;
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith('/api/workspace/directory')) return directoryResponse();
+      if (url.endsWith('/api/projects') && init?.method === 'POST') {
+        createCalls += 1;
+        if (createCalls === 1) {
+          // Workspace-bound create rejected (stale membership).
+          return new Response(
+            JSON.stringify({ error: { code: 'WORKSPACE_PROJECT_PERMISSION_DENIED', message: 'denied' } }),
+            { status: 403 },
+          );
+        }
+        return new Response(JSON.stringify({ id: 'new-project', name: 'New' }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handleMcpToolCall(BASE, 'create_project', { name: 'New' });
+
+    expect(createCalls).toBe(2);
+    expect(firstJson<{ id: string }>(result).id).toBe('new-project');
+  });
+
+  it('name resolution uses the workspace-scoped catalog', async () => {
+    const seen: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      seen.push({ url, init });
+      if (url.endsWith('/api/workspace/directory')) return directoryResponse();
+      if (url.includes('/api/workspaces/ws-personal/projects')) {
+        return new Response(
+          JSON.stringify({
+            projects: [
+              { id: '33333333-3333-3333-3333-333333333333', name: 'Bound Demo', workspaceId: 'ws-personal' },
+            ],
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.endsWith('/api/mcp/install-info')) {
+        return new Response(JSON.stringify({ webBaseUrl: null }), { status: 200 });
+      }
+      if (url.includes('/api/projects/33333333-3333-3333-3333-333333333333')) {
+        return new Response(
+          JSON.stringify({
+            project: { id: '33333333-3333-3333-3333-333333333333', name: 'Bound Demo' },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(JSON.stringify({ projects: [] }), { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handleMcpToolCall(BASE, 'get_project', { project: 'Bound Demo' });
+
+    const catalogCall = seen.find((c) => c.url.includes('/api/workspaces/ws-personal/projects'));
+    expect(catalogCall).toBeTruthy();
+    const body = firstJson<{ id: string }>(result);
+    expect(body.id).toBe('33333333-3333-3333-3333-333333333333');
+  });
+});
+
+describe('MCP headerless fallback (#6569)', () => {
+  it('list_projects stays headerless when the directory has no membership', async () => {
+    const seen: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      seen.push({ url, init });
+      if (url.endsWith('/api/workspace/directory')) {
+        return new Response(JSON.stringify({ items: [], activeWorkspaceId: null }), { status: 200 });
+      }
+      if (url.endsWith('/api/projects')) {
+        return new Response(JSON.stringify({ projects: [{ id: 'u1', name: 'Unbound' }] }), { status: 200 });
+      }
+      return new Response('{}', { status: 200 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await handleMcpToolCall(BASE, 'list_projects', {});
+
+    const catalog = seen.find((c) => c.url.endsWith('/api/projects'));
+    expect(catalog).toBeTruthy();
+    expect(catalog?.init).toBeUndefined();
+    const body = firstJson<{ projects: Array<{ name: string }> }>(result);
+    expect(body.projects[0]?.name).toBe('Unbound');
+  });
+});

--- a/apps/daemon/tests/mcp-workspace-projects.test.ts
+++ b/apps/daemon/tests/mcp-workspace-projects.test.ts
@@ -39,7 +39,7 @@ afterEach(() => {
 
 describe('MCP workspace-scoped project tools (#6569)', () => {
   it('list_projects calls the workspace-scoped catalog with workspace headers', async () => {
-    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const calls: Array<{ url: string; init?: RequestInit | undefined }> = [];
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
       calls.push({ url, init });
       if (url.endsWith('/api/workspace/directory')) return directoryResponse();
@@ -76,7 +76,7 @@ describe('MCP workspace-scoped project tools (#6569)', () => {
 
   it('get_project sends workspace headers on the bound-project read', async () => {
     const projectId = '11111111-1111-1111-1111-111111111111';
-    const seen: Array<{ url: string; init?: RequestInit }> = [];
+    const seen: Array<{ url: string; init?: RequestInit | undefined }> = [];
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
       seen.push({ url, init });
       if (url.endsWith('/api/workspace/directory')) return directoryResponse();
@@ -108,7 +108,7 @@ describe('MCP workspace-scoped project tools (#6569)', () => {
 
   it('write_file sends workspace headers on the project-file write', async () => {
     const projectId = '11111111-1111-1111-1111-111111111111';
-    const seen: Array<{ url: string; init?: RequestInit }> = [];
+    const seen: Array<{ url: string; init?: RequestInit | undefined }> = [];
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
       seen.push({ url, init });
       if (url.endsWith('/api/workspace/directory')) return directoryResponse();
@@ -156,7 +156,7 @@ describe('MCP workspace-scoped project tools (#6569)', () => {
   });
 
   it('name resolution uses the workspace-scoped catalog', async () => {
-    const seen: Array<{ url: string; init?: RequestInit }> = [];
+    const seen: Array<{ url: string; init?: RequestInit | undefined }> = [];
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
       seen.push({ url, init });
       if (url.endsWith('/api/workspace/directory')) return directoryResponse();
@@ -196,7 +196,7 @@ describe('MCP workspace-scoped project tools (#6569)', () => {
 
 describe('MCP headerless fallback (#6569)', () => {
   it('list_projects stays headerless when the directory has no membership', async () => {
-    const seen: Array<{ url: string; init?: RequestInit }> = [];
+    const seen: Array<{ url: string; init?: RequestInit | undefined }> = [];
     const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
       seen.push({ url, init });
       if (url.endsWith('/api/workspace/directory')) {

--- a/apps/daemon/tests/mcp-write-tools.test.ts
+++ b/apps/daemon/tests/mcp-write-tools.test.ts
@@ -1,8 +1,24 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { handleMcpToolCall } from '../src/mcp.js';
+import { _resetMcpWorkspaceContextCacheForTests } from '../src/mcp-workspace-context.js';
 
 const originalFetch = globalThis.fetch;
+
+// Non-vela directory: the bridge falls back to headerless behavior, which is
+// what this suite exercised before #6569. Wrapping the per-test fetch mock
+// keeps the directory bootstrap out of each test's call-count/index
+// assertions while still exercising the real resolveMcpWorkspaceContext path.
+function withDirectory(
+  fn: (url: string, init?: RequestInit) => Promise<Response>,
+): (url: string, init?: RequestInit) => Promise<Response> {
+  return async (url: string, init?: RequestInit) => {
+    if (String(url).endsWith('/api/workspace/directory')) {
+      return new Response(JSON.stringify({ items: [], activeWorkspaceId: null }), { status: 200 });
+    }
+    return fn(url, init);
+  };
+}
 
 function firstText(result: { content: Array<{ text: string }> }): string {
   const item = result.content[0];
@@ -30,6 +46,7 @@ function nextBaseUrl(): string {
 
 describe('public MCP write_file', () => {
   afterEach(() => {
+    _resetMcpWorkspaceContextCacheForTests();
     vi.unstubAllGlobals();
     globalThis.fetch = originalFetch;
   });
@@ -48,7 +65,7 @@ describe('public MCP write_file', () => {
         { status: 200 },
       );
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall(base, 'write_file', {
       project: 'Demo',
@@ -87,7 +104,7 @@ describe('public MCP write_file', () => {
       }
       return new Response(JSON.stringify({ file: { name: 'logo.png' } }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     await handleMcpToolCall(base, 'write_file', {
       project: 'P',
@@ -111,7 +128,7 @@ describe('public MCP write_file', () => {
       }
       return new Response(JSON.stringify({ file: { name: 'index.html' } }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall(base, 'write_file', {
       path: 'index.html',
@@ -135,7 +152,7 @@ describe('public MCP write_file', () => {
       }
       return new Response('{}', { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const missingPath = await handleMcpToolCall(base, 'write_file', {
       project: 'P',
@@ -159,6 +176,7 @@ describe('public MCP write_file', () => {
 
 describe('public MCP delete_file', () => {
   afterEach(() => {
+    _resetMcpWorkspaceContextCacheForTests();
     vi.unstubAllGlobals();
     globalThis.fetch = originalFetch;
   });
@@ -175,7 +193,7 @@ describe('public MCP delete_file', () => {
       expect(init?.method).toBe('DELETE');
       return new Response(JSON.stringify({ ok: true }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall(base, 'delete_file', {
       project: 'Demo',
@@ -195,7 +213,7 @@ describe('public MCP delete_file', () => {
         ? new Response(JSON.stringify({ projects: [{ id: 'p1', name: 'Demo' }] }), { status: 200 })
         : new Response('{}', { status: 200 }),
     );
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall(base, 'delete_file', {
       project: 'Demo',
@@ -209,6 +227,7 @@ describe('public MCP delete_file', () => {
 
 describe('public MCP delete_project', () => {
   afterEach(() => {
+    _resetMcpWorkspaceContextCacheForTests();
     vi.unstubAllGlobals();
     globalThis.fetch = originalFetch;
   });
@@ -225,7 +244,7 @@ describe('public MCP delete_project', () => {
       expect(init?.method).toBe('DELETE');
       return new Response(JSON.stringify({ ok: true }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall(base, 'delete_project', {
       project: 'Demo',
@@ -243,7 +262,7 @@ describe('public MCP delete_project', () => {
         ? new Response(JSON.stringify({ projects: [{ id: 'p1', name: 'Demo' }] }), { status: 200 })
         : new Response('{}', { status: 200 }),
     );
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const missing = await handleMcpToolCall(base, 'delete_project', {
       project: 'Demo',
@@ -275,7 +294,7 @@ describe('public MCP delete_project', () => {
     const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) =>
       new Response('{}', { status: 200 }),
     );
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall(base, 'delete_project', {
       confirm: true,
@@ -297,7 +316,7 @@ describe('public MCP delete_project', () => {
       expect(init?.method).toBe('DELETE');
       return new Response(JSON.stringify({ ok: true }), { status: 200 });
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     // 'throwaway' is a substring of 'Throwaway demo' — the tool accepts
     // substrings per inputSchema, so the response must carry
@@ -317,6 +336,7 @@ describe('public MCP delete_project', () => {
 
 describe('formatDaemonError (shared error mapper)', () => {
   afterEach(() => {
+    _resetMcpWorkspaceContextCacheForTests();
     vi.unstubAllGlobals();
     globalThis.fetch = originalFetch;
   });
@@ -331,7 +351,7 @@ describe('formatDaemonError (shared error mapper)', () => {
             { status: 404 },
           ),
     );
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall(base, 'delete_file', {
       project: 'Demo',
@@ -353,7 +373,7 @@ describe('formatDaemonError (shared error mapper)', () => {
         ? new Response(JSON.stringify({ projects: [{ id: 'p1', name: 'Demo' }] }), { status: 200 })
         : new Response('upstream boom', { status: 502 }),
     );
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall(base, 'delete_file', {
       project: 'Demo',
@@ -384,7 +404,7 @@ describe('formatDaemonError (shared error mapper)', () => {
         { status: 409 },
       );
     });
-    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('fetch', withDirectory(fetchMock));
 
     const result = await handleMcpToolCall(base, 'delete_project', {
       project: 'Demo',


### PR DESCRIPTION
Fixes #6569

## Why

After 0.18.0's workspace isolation, projects are lazy-adopted into the
signed-in user's workspace (`bindUnboundProjectsToPersonalWorkspace`), so the
NO-SCOPE catalog (`GET /api/projects`) returns only unbound rows to a
headerless caller — and 0.18.0-bound projects are all claimed, so it returns
**empty**. The MCP stdio bridge sent no `x-od-workspace-*` headers, so every
MCP integration (Claude Code, Codex, Cursor, Hermes, …) silently saw an empty
project list after upgrading. Bound-project reads (`get_project`, `write_file`,
…) also 400'd with `WORKSPACE_CONTEXT_REQUIRED`.

I hit this while reproducing #6569's stdio-MCP scenario against `main`.

## What users will see

MCP-driven agents (`od mcp`) now see the same project list as the desktop UI:
`list_projects` returns the signed-in user's workspace projects, and
`get_project` / `get_file` / `write_file` / `create_project` / `start_run` /
`get_run` work against them. In non-vela, signed-out, or directory-outage
situations the bridge falls back to the previous headerless behavior (unbound
projects), so nothing regresses for local/dev setups.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var** — behavior of the existing `od mcp` bridge; no new subcommand/flag
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change**
- [x] **None** — internal MCP bridge request layer + tests in `apps/daemon`

## Screenshots

Not applicable — no UI surface changed.

## Bug fix verification

- Red spec: `apps/daemon/tests/mcp-workspace-projects.test.ts` — `list_projects`
  must call the workspace-scoped catalog with `x-od-workspace-id` /
  `x-od-workspace-member-id` (currently it calls headerless `GET /api/projects`).
- Red on `main`: the bridge had no workspace headers anywhere (mcp.ts `getJson`/
  `postJson`), so the assertion that `list_projects` hits
  `/api/workspaces/:id/projects` with headers fails.
- Green on this branch: yes.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run tests/mcp-` — 332 passed
  (incl. new `mcp-workspace-context.test.ts` + `mcp-workspace-projects.test.ts`)
- `pnpm --filter @open-design/daemon exec vitest run tests/artifacts/` — 88 passed
- `pnpm --filter @open-design/daemon typecheck` + `pnpm typecheck` — clean
- `pnpm guard` — blocked by a pre-existing failure unrelated to this change:
  `apps/telemetry-worker/package.json` is referenced by the cross-app-imports
  check but the app was extracted from the monorepo in #5565 (only a stale
  local `node_modules/` remains).

Note: the full local daemon suite shows 41 pre-existing failures that also fail
on `main` (e.g. `project-move-owner-conflict.test.ts` expects the team hub);
none touch the changed modules (all mcp-* and artifact tests pass).