### PR TITLE
Add Source Project Context plugin

### DIFF
--- a/plugins/community/source-project-context-msim9xgh/SKILL.md
+++ b/plugins/community/source-project-context-msim9xgh/SKILL.md
@@ -1,0 +1,49 @@
+# Source Project Context
+
+This design-system workspace was created from an existing Open Design project. Treat the copied project files as the primary source evidence for the generated design system.
+
+## Source project
+
+- Source project id: 959cbb13-fa8d-40f9-b379-4e6a9883f9af
+- Source project name: Web Prototype
+- New design-system project id: ea3a9a48-086a-425e-8dd2-1809ea495dd4
+- New design-system id: user:web-prototype-design-system
+- Source skill id: (none)
+- Source design system id: airbnb
+
+## Source metadata
+
+```json
+{
+  "kind": "prototype",
+  "platform": "auto",
+  "platformTargets": [
+    "mobile-ios",
+    "mobile-android"
+  ],
+  "nameSource": "prompt",
+  "linkedDirs": [
+    "/Users/aphilack/Documents/sunha-pos"
+  ]
+}
+```
+
+## Copied files
+
+- (none)
+
+## Skipped files
+
+- (none)
+
+## Generation contract
+
+- Read this file before editing design-system outputs.
+- Read the copied files directly from the project workspace; they are source evidence, not generated design-system output.
+- Preserve high-signal assets, source examples, UI surfaces, copy, tokens, typography, and interaction patterns from the copied project.
+- Generate a reusable Open Design design-system package in this same project: DESIGN.md, README.md, SKILL.md, colors_and_type.css, context/provenance, focused preview cards, preserved assets/build/fonts when available, and ui_kits/app/.
+- Before final response, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every actionable issue.
+
+## Provenance
+
+Formalized by Open Design from candidate 48d28549-7ba5-4096-9200-9308ed32621b.

--- a/plugins/community/source-project-context-msim9xgh/open-design.json
+++ b/plugins/community/source-project-context-msim9xgh/open-design.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://open-design.ai/schemas/plugin.v1.json",
+  "specVersion": "1.0.0",
+  "name": "source-project-context-msim9xgh",
+  "title": "Source Project Context",
+  "version": "0.1.0",
+  "description": "This design-system workspace was created from an existing Open Design project. Treat the copied project files as the primary source evidence for the generated design system.",
+  "od": {
+    "kind": "skill",
+    "taskKind": "new-generation",
+    "context": {
+      "skills": [
+        {
+          "path": "./SKILL.md"
+        }
+      ]
+    },
+    "capabilities": [
+      "prompt:inject"
+    ]
+  }
+}

--- a/plugins/community/source-project-context-msim9xgh/references/provenance.json
+++ b/plugins/community/source-project-context-msim9xgh/references/provenance.json
@@ -1,0 +1,19 @@
+{
+  "candidateId": "48d28549-7ba5-4096-9200-9308ed32621b",
+  "projectId": "ea3a9a48-086a-425e-8dd2-1809ea495dd4",
+  "runId": "62b03173-aabf-4f68-b840-fdf4828b86b6",
+  "conversationId": "a8bf1464-025f-4138-b0f2-36ee0fea8416",
+  "provenance": {
+    "summary": "Detected from context/source-context.md after a successful run.",
+    "detectedAt": 1786087159875
+  },
+  "sourceRefs": [
+    {
+      "kind": "file",
+      "value": "context/source-context.md",
+      "label": "context/source-context.md",
+      "size": 1533,
+      "copied": true
+    }
+  ]
+}

--- a/plugins/community/source-project-context-msim9xgh/references/source-1-source-context.md
+++ b/plugins/community/source-project-context-msim9xgh/references/source-1-source-context.md
@@ -1,0 +1,45 @@
+# Source Project Context
+
+This design-system workspace was created from an existing Open Design project. Treat the copied project files as the primary source evidence for the generated design system.
+
+## Source project
+
+- Source project id: 959cbb13-fa8d-40f9-b379-4e6a9883f9af
+- Source project name: Web Prototype
+- New design-system project id: ea3a9a48-086a-425e-8dd2-1809ea495dd4
+- New design-system id: user:web-prototype-design-system
+- Source skill id: (none)
+- Source design system id: airbnb
+
+## Source metadata
+
+```json
+{
+  "kind": "prototype",
+  "platform": "auto",
+  "platformTargets": [
+    "mobile-ios",
+    "mobile-android"
+  ],
+  "nameSource": "prompt",
+  "linkedDirs": [
+    "/Users/aphilack/Documents/sunha-pos"
+  ]
+}
+```
+
+## Copied files
+
+- (none)
+
+## Skipped files
+
+- (none)
+
+## Generation contract
+
+- Read this file before editing design-system outputs.
+- Read the copied files directly from the project workspace; they are source evidence, not generated design-system output.
+- Preserve high-signal assets, source examples, UI surfaces, copy, tokens, typography, and interaction patterns from the copied project.
+- Generate a reusable Open Design design-system package in this same project: DESIGN.md, README.md, SKILL.md, colors_and_type.css, context/provenance, focused preview cards, preserved assets/build/fonts when available, and ui_kits/app/.
+- Before final response, run `"$OD_NODE_BIN" "$OD_BIN" tools connectors design-system-package-audit --path . --fail-on-warnings` and fix every actionable issue.


### PR DESCRIPTION
Add Source Project Context (source-project-context-msim9xgh) plugin.
Version: 0.1.0
Description: This design-system workspace was created from an existing Open Design project. Treat the copied project files as the primary source evidence for the generated design system.