### PR TITLE
fix(web): describe MCP slash commands

### DIFF
--- a/apps/web/src/components/ChatComposer.tsx
+++ b/apps/web/src/components/ChatComposer.tsx
@@ -989,7 +989,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
           id: 'mcp',
           label: '/mcp',
           insert: '/mcp ',
-          descKey: 'pet.slashPet',
+          descKey: 'pet.slashMcp',
           icon: 'sliders',
           argHint: 'open settings · <server-id> to insert hint',
         });
@@ -999,7 +999,7 @@ export const ChatComposer = forwardRef<ChatComposerHandle, Props>(
           id: `mcp-${s.id}`,
           label: `/mcp ${s.id}`,
           insert: `Use the \`${s.id}\` MCP server tools. `,
-          descKey: 'pet.slashPet',
+          descKey: 'pet.slashMcp',
           icon: 'sparkles',
           argHint: s.label || s.transport,
         });

--- a/apps/web/src/i18n/locales/ar.ts
+++ b/apps/web/src/i18n/locales/ar.ts
@@ -3731,6 +3731,7 @@ export const ar: Dict = {
   'pet.slashPopoverTitle': 'الأوامر',
   'pet.slashPopoverHint': '↑↓ للتنقل · enter للاختيار · esc للتجاهل',
   'pet.slashPet': 'تبديل، تبني، أو الانتقال لإعدادات الحيوانات الأليفة.',
+  'pet.slashMcp': 'Open MCP server settings or insert a server tool hint.',
   'pet.slashPetWake': 'إيقاظ طبقة الحيوان الأليف العائمة.',
   'pet.slashPetTuck': 'إخفاء الحيوان الأليف حالياً.',
   'pet.slashHatch': 'توليد حيوان Codex عبر مهارة hatch-pet.',

--- a/apps/web/src/i18n/locales/de.ts
+++ b/apps/web/src/i18n/locales/de.ts
@@ -3731,6 +3731,7 @@ export const de: Dict = {
   'pet.slashPopoverTitle': 'Befehle',
   'pet.slashPopoverHint': '↑↓ navigieren · enter auswählen · esc schließen',
   'pet.slashPet': 'Pet umschalten, adoptieren oder Einstellungen öffnen.',
+  'pet.slashMcp': 'Open MCP server settings or insert a server tool hint.',
   'pet.slashPetWake': 'Schwebende Pet-Anzeige aufwecken.',
   'pet.slashPetTuck': 'Pet vorerst wegstecken.',
   'pet.slashHatch': 'Codex-Pet mit dem hatch-pet-Skill erzeugen.',

--- a/apps/web/src/i18n/locales/en.ts
+++ b/apps/web/src/i18n/locales/en.ts
@@ -3769,6 +3769,7 @@ export const en: Dict = {
   'pet.slashPopoverTitle': 'Commands',
   'pet.slashPopoverHint': '↑↓ navigate · enter to pick · esc to dismiss',
   'pet.slashPet': 'Toggle, adopt, or jump to pet settings.',
+  'pet.slashMcp': 'Open MCP server settings or insert a server tool hint.',
   'pet.slashPetWake': 'Wake the floating pet overlay.',
   'pet.slashPetTuck': 'Tuck the pet away for now.',
   'pet.slashHatch': 'Generate a Codex pet via the hatch-pet skill.',

--- a/apps/web/src/i18n/locales/es-ES.ts
+++ b/apps/web/src/i18n/locales/es-ES.ts
@@ -3731,6 +3731,7 @@ export const esES: Dict = {
   'pet.slashPopoverTitle': 'Comandos',
   'pet.slashPopoverHint': '↑↓ navegar · enter elegir · esc cerrar',
   'pet.slashPet': 'Alternar, adoptar o ir a ajustes de mascota.',
+  'pet.slashMcp': 'Open MCP server settings or insert a server tool hint.',
   'pet.slashPetWake': 'Despertar la mascota flotante.',
   'pet.slashPetTuck': 'Guardar la mascota por ahora.',
   'pet.slashHatch': 'Genera una mascota Codex con la skill hatch-pet.',

--- a/apps/web/src/i18n/locales/fa.ts
+++ b/apps/web/src/i18n/locales/fa.ts
@@ -3731,6 +3731,7 @@ export const fa: Dict = {
   'pet.slashPopoverTitle': 'دستورها',
   'pet.slashPopoverHint': '↑↓ پیمایش · enter انتخاب · esc بستن',
   'pet.slashPet': 'پت را روشن/خاموش کنید، انتخاب کنید یا تنظیمات را باز کنید.',
+  'pet.slashMcp': 'Open MCP server settings or insert a server tool hint.',
   'pet.slashPetWake': 'پت شناور را بیدار کنید.',
   'pet.slashPetTuck': 'پت را فعلاً جمع کنید.',
   'pet.slashHatch': 'با مهارت hatch-pet یک پت Codex بسازید.',

--- a/apps/web/src/i18n/locales/fr.ts
+++ b/apps/web/src/i18n/locales/fr.ts
@@ -3731,6 +3731,7 @@ export const fr: Dict = {
   'pet.slashPopoverTitle': 'Commandes',
   'pet.slashPopoverHint': '↑↓ naviguer · entrée pour choisir · échap pour fermer',
   'pet.slashPet': 'Basculer, adopter ou aller aux paramètres du compagnon.',
+  'pet.slashMcp': 'Open MCP server settings or insert a server tool hint.',
   'pet.slashPetWake': 'Réveiller l\'overlay flottant du compagnon.',
   'pet.slashPetTuck': 'Cacher le compagnon pour l\'instant.',
   'pet.slashHatch': 'Générer un pet Codex via le Skill hatch-pet.',

--- a/apps/web/src/i18n/locales/hu.ts
+++ b/apps/web/src/i18n/locales/hu.ts
@@ -3731,6 +3731,7 @@ export const hu: Dict = {
   'pet.slashPopoverTitle': 'Parancsok',
   'pet.slashPopoverHint': '↑↓ navigáció · enter választás · esc kilépés',
   'pet.slashPet': 'Háziállat váltása, befogadása vagy a beállítások megnyitása.',
+  'pet.slashMcp': 'Open MCP server settings or insert a server tool hint.',
   'pet.slashPetWake': 'Lebegő háziállat-réteg ébresztése.',
   'pet.slashPetTuck': 'Háziállat elrejtése egy időre.',
   'pet.slashHatch': 'Codex háziállat generálása a hatch-pet skill-lel.',

--- a/apps/web/src/i18n/locales/id.ts
+++ b/apps/web/src/i18n/locales/id.ts
@@ -3731,6 +3731,7 @@ export const id: Dict = {
   'pet.slashPopoverTitle': 'Perintah',
   'pet.slashPopoverHint': 'atas/bawah untuk navigasi - enter untuk pilih - esc untuk tutup',
   'pet.slashPet': 'Toggle, adopsi, atau buka pengaturan pet.',
+  'pet.slashMcp': 'Open MCP server settings or insert a server tool hint.',
   'pet.slashPetWake': 'Bangunkan overlay pet melayang.',
   'pet.slashPetTuck': 'Sembunyikan pet untuk sekarang.',
   'pet.slashHatch': 'Buat pet Codex lewat skill hatch-pet.',

--- a/apps/web/src/i18n/locales/it.ts
+++ b/apps/web/src/i18n/locales/it.ts
@@ -3731,6 +3731,7 @@ export const it: Dict = {
   'pet.slashPopoverTitle': 'Comandi',
   'pet.slashPopoverHint': '↑↓ naviga · invio per scegliere · esc per chiudere',
   'pet.slashPet': 'Alterna, adotta o vai alle impostazioni del compagno.',
+  'pet.slashMcp': 'Open MCP server settings or insert a server tool hint.',
   'pet.slashPetWake': 'Sveglia l\'overlay fluttuante del compagno.',
   'pet.slashPetTuck': 'Nascondi il compagno per ora.',
   'pet.slashHatch': 'Genera un pet Codex tramite la competenza hatch-pet.',

--- a/apps/web/src/i18n/locales/ja.ts
+++ b/apps/web/src/i18n/locales/ja.ts
@@ -3731,6 +3731,7 @@ export const ja: Dict = {
   'pet.slashPopoverTitle': 'コマンド',
   'pet.slashPopoverHint': '↑↓ で移動 · enter で選択 · esc で閉じる',
   'pet.slashPet': 'ペットを切替・採用、または設定を開く。',
+  'pet.slashMcp': 'Open MCP server settings or insert a server tool hint.',
   'pet.slashPetWake': '浮遊ペットを起こす。',
   'pet.slashPetTuck': 'ペットを一旦しまう。',
   'pet.slashHatch': 'hatch-pet スキルで Codex ペットを生成。',

--- a/apps/web/src/i18n/locales/ko.ts
+++ b/apps/web/src/i18n/locales/ko.ts
@@ -3731,6 +3731,7 @@ export const ko: Dict = {
   'pet.slashPopoverTitle': '명령',
   'pet.slashPopoverHint': '↑↓ 이동 · enter 선택 · esc 닫기',
   'pet.slashPet': '펫을 토글하거나 입양 또는 설정으로 이동.',
+  'pet.slashMcp': 'Open MCP server settings or insert a server tool hint.',
   'pet.slashPetWake': '플로팅 펫을 깨우기.',
   'pet.slashPetTuck': '펫을 잠시 치우기.',
   'pet.slashHatch': 'hatch-pet 스킬로 Codex 펫 생성.',

--- a/apps/web/src/i18n/locales/pl.ts
+++ b/apps/web/src/i18n/locales/pl.ts
@@ -3731,6 +3731,7 @@ export const pl: Dict = {
   'pet.slashPopoverTitle': 'Polecenia',
   'pet.slashPopoverHint': '↑↓ nawigacja · enter wybierz · esc zamknij',
   'pet.slashPet': 'Przełącz, adoptuj lub otwórz ustawienia peta.',
+  'pet.slashMcp': 'Open MCP server settings or insert a server tool hint.',
   'pet.slashPetWake': 'Obudź pływającego peta.',
   'pet.slashPetTuck': 'Schowaj peta na razie.',
   'pet.slashHatch': 'Wygeneruj peta Codex skillem hatch-pet.',

--- a/apps/web/src/i18n/locales/pt-BR.ts
+++ b/apps/web/src/i18n/locales/pt-BR.ts
@@ -3731,6 +3731,7 @@ export const ptBR: Dict = {
   'pet.slashPopoverTitle': 'Comandos',
   'pet.slashPopoverHint': '↑↓ navegar · enter escolher · esc fechar',
   'pet.slashPet': 'Alternar, adotar ou abrir as configurações do pet.',
+  'pet.slashMcp': 'Open MCP server settings or insert a server tool hint.',
   'pet.slashPetWake': 'Acordar o pet flutuante.',
   'pet.slashPetTuck': 'Guardar o pet por agora.',
   'pet.slashHatch': 'Gere um pet Codex com a skill hatch-pet.',

--- a/apps/web/src/i18n/locales/ru.ts
+++ b/apps/web/src/i18n/locales/ru.ts
@@ -3731,6 +3731,7 @@ export const ru: Dict = {
   'pet.slashPopoverTitle': 'Команды',
   'pet.slashPopoverHint': '↑↓ навигация · enter выбрать · esc закрыть',
   'pet.slashPet': 'Переключить, выбрать или открыть настройки пета.',
+  'pet.slashMcp': 'Open MCP server settings or insert a server tool hint.',
   'pet.slashPetWake': 'Разбудить плавающего пета.',
   'pet.slashPetTuck': 'Спрятать пета на время.',
   'pet.slashHatch': 'Создать Codex-пета через навык hatch-pet.',

--- a/apps/web/src/i18n/locales/th.ts
+++ b/apps/web/src/i18n/locales/th.ts
@@ -3731,6 +3731,7 @@ export const th: Dict = {
   'pet.slashPopoverTitle': 'สั่งทำงานตามคำพูดตรง',
   'pet.slashPopoverHint': 'ไล่ชี้จากทิศทาง ↑↓ นำเอา enter เข้าจับสั่ง · esc ไม่เอาหน้าต่างแล้วออกไป',
   'pet.slashPet': 'โหมดตั้งกลับแบบ เปิดเอา/ปิดรับ พร้อมการเข้าจัดระบบตัวของสัตว์เลยทันใจ',
+  'pet.slashMcp': 'Open MCP server settings or insert a server tool hint.',
   'pet.slashPetWake': 'เรียกตัวที่เตรียมลอยมาโชว์รับในจอ',
   'pet.slashPetTuck': 'เอากลับพับโชว์เข้าที่ไปตอนนี้นี่แหล่ะ',
   'pet.slashHatch': 'ก่อแบบเสกตัวของจากแบบฉบับ Codex ทำเข้าจากตรงระบบความสามารถ hatch-pet เสียด้วย',

--- a/apps/web/src/i18n/locales/tr.ts
+++ b/apps/web/src/i18n/locales/tr.ts
@@ -3731,6 +3731,7 @@ export const tr: Dict = {
   'pet.slashPopoverTitle': 'Komutlar',
   'pet.slashPopoverHint': '↑↓ gez · enter seç · esc kapat',
   'pet.slashPet': 'Peti aç/kapat, evlat edin veya ayarları aç.',
+  'pet.slashMcp': 'Open MCP server settings or insert a server tool hint.',
   'pet.slashPetWake': 'Yüzen peti uyandır.',
   'pet.slashPetTuck': 'Peti şimdilik sakla.',
   'pet.slashHatch': 'hatch-pet skill\'i ile bir Codex peti üret.',

--- a/apps/web/src/i18n/locales/uk.ts
+++ b/apps/web/src/i18n/locales/uk.ts
@@ -3731,6 +3731,7 @@ export const uk: Dict = {
   'pet.slashPopoverTitle': 'Команди',
   'pet.slashPopoverHint': '↑↓ навігація · enter для вибору · esc для закриття',
   'pet.slashPet': 'Перемикання, встановлення або перехід до параметрів домашної тварини.',
+  'pet.slashMcp': 'Open MCP server settings or insert a server tool hint.',
   'pet.slashPetWake': 'Розбудити накладку плаваючої домашної тварини.',
   'pet.slashPetTuck': 'Сховати домашну тварину на цей час.',
   'pet.slashHatch': 'Створити домашну тварину Codex через навичку hatch-pet.',

--- a/apps/web/src/i18n/locales/zh-CN.ts
+++ b/apps/web/src/i18n/locales/zh-CN.ts
@@ -3937,6 +3937,7 @@ export const zhCN: Dict = {
   "pet.slashPopoverTitle": "命令",
   "pet.slashPopoverHint": "↑↓ 切换 · 回车选择 · esc 关闭",
   "pet.slashPet": "切换、领养或跳转到宠物设置。",
+  "pet.slashMcp": "打开 MCP 服务器设置，或插入服务器工具提示。",
   "pet.slashPetWake": "唤醒漂浮的宠物。",
   "pet.slashPetTuck": "把宠物收起来。",
   "pet.slashHatch": "调用 hatch-pet 技能生成一只 Codex 宠物。",

--- a/apps/web/src/i18n/locales/zh-TW.ts
+++ b/apps/web/src/i18n/locales/zh-TW.ts
@@ -3945,6 +3945,7 @@ export const zhTW: Dict = {
   "pet.slashPopoverTitle": "命令",
   "pet.slashPopoverHint": "↑↓ 切換 · enter 選擇 · esc 關閉",
   "pet.slashPet": "切換、領養或跳到寵物設定。",
+  "pet.slashMcp": "開啟 MCP 伺服器設定，或插入伺服器工具提示。",
   "pet.slashPetWake": "喚醒漂浮的寵物。",
   "pet.slashPetTuck": "把寵物收起來。",
   "pet.slashHatch": "呼叫 hatch-pet 技能生成一隻 Codex 寵物。",

--- a/apps/web/src/i18n/types.ts
+++ b/apps/web/src/i18n/types.ts
@@ -4578,6 +4578,7 @@ export interface Dict {
   'pet.slashPopoverTitle': string;
   'pet.slashPopoverHint': string;
   'pet.slashPet': string;
+  'pet.slashMcp': string;
   'pet.slashPetWake': string;
   'pet.slashPetTuck': string;
   'pet.slashHatch': string;

--- a/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
+++ b/apps/web/tests/components/ChatComposer.context-pickers.test.tsx
@@ -410,6 +410,23 @@ describe('ChatComposer context pickers', () => {
     expect(screen.queryByText('No results for “missing”.')).toBeNull();
   });
 
+  it('describes /mcp slash commands as MCP actions instead of pet actions', async () => {
+    renderComposer();
+    await flushMounts();
+
+    await typeAndSettle('/');
+
+    const popover = await screen.findByTestId('slash-popover');
+    const settingsRow = within(popover).getByText('/mcp').closest('button');
+    const mcpRow = within(popover).getByText('/mcp slack').closest('button');
+    expect(settingsRow).toBeTruthy();
+    expect(mcpRow).toBeTruthy();
+    expect(settingsRow?.textContent).toContain('Open MCP server settings or insert a server tool hint.');
+    expect(settingsRow?.textContent).not.toContain('Toggle, adopt, or jump to pet settings.');
+    expect(mcpRow?.textContent).toContain('Open MCP server settings or insert a server tool hint.');
+    expect(mcpRow?.textContent).not.toContain('Toggle, adopt, or jump to pet settings.');
+  });
+
   it('lists Design Files first in All and picks the first file with Enter', async () => {
     renderComposer({
       projectFiles: [


### PR DESCRIPTION
## Summary

The slash-command popover currently shows the pet command description for every `/mcp` row. That makes the MCP entries look unrelated to the server tools they insert.

This PR gives `/mcp` and `/mcp <server-id>` their own MCP-specific description key, so the command list explains that these entries open MCP settings or insert a server tool hint instead of talking about pet settings.

Fixes #6541

## Implementation

- Switch the `/mcp` slash command rows from `pet.slashPet` to a new `pet.slashMcp` i18n key.
- Add the key to `Dict` and every bundled locale.
- Add regression coverage for both the base `/mcp` row and a server-specific `/mcp slack` row.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [x] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [ ] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [x] **None** — copy/i18n correction only; no layout, interaction, or new UI surface is introduced.

## Verification

Bug-fix verification note:

- Before the patch, both the base `/mcp` row and a server-specific row such as `/mcp slack` reused the pet command description, so the slash-command popover described pet settings instead of MCP settings or server tool insertion.
- After the patch, `/mcp` and `/mcp slack` both resolve the dedicated `pet.slashMcp` copy while keeping the existing command labels and interaction flow unchanged.

Commands run:

- `git diff --check`
- `pnpm --filter @open-design/web test tests/components/ChatComposer.context-pickers.test.tsx`
- `pnpm --filter @open-design/web typecheck`