### PR TITLE
fix daemon retry generation terminal fencing

### DIFF
--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -12495,6 +12495,12 @@ export async function startServer({
       emitVisibleAgentStderr(chunk);
     });
 
+    // A retry reuses the same run object but replaces run.child. Treat that
+    // exact child identity as the attempt generation token: once ownership has
+    // moved, this attempt may still receive a late error/close event, but it
+    // must not emit errors, unregister the new sink, or make a terminal retry
+    // decision for the new attempt.
+    const attemptStillOwnsRun = () => run.child === child;
     const finishCanceledIfRequested = (
       code: number | null,
       signal: NodeJS.Signals | null,
@@ -12513,6 +12519,7 @@ export async function startServer({
       cleanupPromptFile();
       flushVisibleAgentStderr();
       revokeToolToken('child_exit');
+      if (!attemptStillOwnsRun()) return;
       unregisterChatAgentEventSink();
       if (finishCanceledIfRequested(1, null)) return;
       send('error', createSseErrorPayload('AGENT_EXECUTION_FAILED', err.message));
@@ -12524,12 +12531,10 @@ export async function startServer({
       clearFirstOutputWatchdog();
       clearForcedChildShutdown();
       flushVisibleAgentStderr();
-      if (watchdogRetryRestarted) {
-        // The inactivity watchdog already failed this attempt and the same-run
-        // retry restarted on a fresh child. Finalization and event-sink / run-
-        // handle ownership (keyed by the shared runId) now belong to the new
-        // attempt, so this stalled child's close must not re-run them — doing
-        // so would re-finalize the run and delete the new attempt's sink.
+      if (!attemptStillOwnsRun() || watchdogRetryRestarted) {
+        // Finalization and event-sink / run-handle ownership (keyed by the
+        // shared runId) now belong to another retry generation, so this
+        // child's late close must not re-run them.
         // Revoke only THIS attempt's tool token (idempotent, keyed by its own
         // token string) and bail; the `finally` block still cleans up logs.
         revokeToolToken('child_exit');

--- a/apps/daemon/tests/retry-generation-terminal-fence.test.ts
+++ b/apps/daemon/tests/retry-generation-terminal-fence.test.ts
@@ -1,0 +1,222 @@
+import type { Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import type { EventEmitter as EventEmitterType } from 'node:events';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import type { PassThrough as PassThroughType } from 'node:stream';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const spawnState = vi.hoisted(() => ({
+  target: '',
+  targetSpawnCount: 0,
+  staleCloseAfterRetrySpawn: false,
+}));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  const { EventEmitter } = await import('node:events');
+  const { PassThrough } = await import('node:stream');
+
+  return {
+    ...actual,
+    spawn: vi.fn((command, args, options) => {
+      if (command !== spawnState.target) {
+        return actual.spawn(command, args, options);
+      }
+
+      spawnState.targetSpawnCount += 1;
+      if (spawnState.targetSpawnCount > 1) {
+        return actual.spawn(command, args, options);
+      }
+
+      const child = new EventEmitter() as EventEmitterType & {
+        pid: number;
+        stdin: PassThroughType;
+        stdout: PassThroughType;
+        stderr: PassThroughType;
+        exitCode: number | null;
+        signalCode: NodeJS.Signals | null;
+        killed: boolean;
+        kill: (signal?: NodeJS.Signals) => boolean;
+      };
+      child.pid = 2_000_000_000;
+      child.stdin = new PassThrough();
+      child.stdout = new PassThrough();
+      child.stderr = new PassThrough();
+      child.exitCode = null;
+      child.signalCode = null;
+      child.killed = false;
+      child.kill = () => {
+        child.killed = true;
+        return true;
+      };
+
+      setImmediate(() => {
+        child.emit('error', new Error('HTTP 503 Service Unavailable before first token'));
+      });
+      setTimeout(() => {
+        child.exitCode = 1;
+        spawnState.staleCloseAfterRetrySpawn = spawnState.targetSpawnCount > 1;
+        child.emit('close', 1, null);
+      }, 1_200).unref();
+
+      return child;
+    }),
+  };
+});
+
+import { startServer } from '../src/server.js';
+
+type StartedServer = {
+  url: string;
+  server: Server;
+  shutdown?: () => Promise<void> | void;
+};
+
+describe('same-run retry generation terminal fence', () => {
+  const originalEnv = snapshotEnv();
+  let started: StartedServer | null = null;
+  let binDir: string | null = null;
+
+  afterEach(async () => {
+    await Promise.resolve(started?.shutdown?.());
+    if (started?.server) {
+      await new Promise<void>((resolve) => started?.server.close(() => resolve()));
+    }
+    started = null;
+    if (binDir) await rm(binDir, { recursive: true, force: true });
+    binDir = null;
+    spawnState.target = '';
+    spawnState.targetSpawnCount = 0;
+    spawnState.staleCloseAfterRetrySpawn = false;
+    restoreEnv(originalEnv);
+  });
+
+  it('ignores a previous attempt close after the retry child owns the run', async () => {
+    binDir = await mkdtemp(path.join(os.tmpdir(), 'od-retry-generation-fence-'));
+    spawnState.target = await writeDelayedSuccessfulClaude(binDir, 'claude-generation-fence');
+
+    delete process.env.POSTHOG_KEY;
+    delete process.env.POSTHOG_HOST;
+    delete process.env.LANGFUSE_PUBLIC_KEY;
+    delete process.env.LANGFUSE_SECRET_KEY;
+    delete process.env.LANGFUSE_BASE_URL;
+    delete process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL;
+
+    started = await startServer({ port: 0, returnServer: true }) as StartedServer;
+    await putConfig(started.url, {
+      agentId: 'claude',
+      agentCliEnv: { claude: { CLAUDE_BIN: spawnState.target } },
+      telemetry: { metrics: true, content: false, artifactManifest: false },
+      privacyDecisionAt: Date.now(),
+    });
+
+    const run = await createAndWaitForRun(started.url);
+
+    expect(spawnState.targetSpawnCount).toBe(2);
+    expect(spawnState.staleCloseAfterRetrySpawn).toBe(true);
+    expect(run.status).toBe('succeeded');
+  });
+});
+
+async function writeDelayedSuccessfulClaude(dir: string, name: string): Promise<string> {
+  const bin = path.join(dir, name);
+  await writeFile(bin, `#!/usr/bin/env node
+if (process.argv.includes('--version')) {
+  console.log('claude-code 1.0.0-generation-fence');
+  process.exit(0);
+}
+if (process.argv.includes('--help')) {
+  console.log('Usage: claude -p [--include-partial-messages] [--add-dir DIR]');
+  process.exit(0);
+}
+console.log(JSON.stringify({ type: 'system', subtype: 'init', model: 'claude-generation-fence' }));
+setTimeout(() => {
+  console.log(JSON.stringify({
+    type: 'assistant',
+    message: {
+      id: 'msg-generation-fence',
+      content: [{ type: 'text', text: 'The current retry completed.' }],
+      stop_reason: 'end_turn'
+    }
+  }));
+  setTimeout(() => process.exit(0), 20);
+}, 1800);
+`, 'utf8');
+  await chmod(bin, 0o755);
+  return bin;
+}
+
+async function putConfig(url: string, patch: Record<string, unknown>): Promise<void> {
+  const response = await fetch(`${url}/api/app-config`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(patch),
+  });
+  expect(response.status).toBe(200);
+}
+
+function snapshotEnv(): Record<string, string | undefined> {
+  return {
+    POSTHOG_KEY: process.env.POSTHOG_KEY,
+    POSTHOG_HOST: process.env.POSTHOG_HOST,
+    LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
+    LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
+    LANGFUSE_BASE_URL: process.env.LANGFUSE_BASE_URL,
+    OPEN_DESIGN_TELEMETRY_RELAY_URL: process.env.OPEN_DESIGN_TELEMETRY_RELAY_URL,
+  };
+}
+
+function restoreEnv(env: Record<string, string | undefined>): void {
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+}
+
+async function createAndWaitForRun(url: string): Promise<{ status: string }> {
+  const projectId = `retry_generation_fence_${randomUUID()}`;
+  const projectResponse = await fetch(`${url}/api/projects`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      id: projectId,
+      name: 'Retry generation terminal fence',
+      metadata: { kind: 'prototype' },
+      skipDiscoveryBrief: true,
+    }),
+  });
+  expect(projectResponse.status).toBe(200);
+  const project = await projectResponse.json() as { conversationId: string };
+
+  const prompt = 'reproduce a stale retry generation close';
+  const runResponse = await fetch(`${url}/api/runs`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-od-analytics-device-id': 'retry-generation-fence-test',
+      'x-od-analytics-session-id': 'retry-generation-fence-session',
+      'x-od-analytics-client-type': 'web',
+    },
+    body: JSON.stringify({
+      projectId,
+      conversationId: project.conversationId,
+      assistantMessageId: `assistant_retry_generation_${randomUUID()}`,
+      clientRequestId: `client_retry_generation_${randomUUID()}`,
+      agentId: 'claude',
+      message: prompt,
+      currentPrompt: prompt,
+    }),
+  });
+  expect(runResponse.status).toBe(202);
+  const { runId } = await runResponse.json() as { runId: string };
+
+  const eventsResponse = await fetch(`${url}/api/runs/${encodeURIComponent(runId)}/events`);
+  expect(eventsResponse.status).toBe(200);
+  await eventsResponse.text();
+
+  const statusResponse = await fetch(`${url}/api/runs/${encodeURIComponent(runId)}`);
+  expect(statusResponse.status).toBe(200);
+  return await statusResponse.json() as { status: string };
+}


### PR DESCRIPTION
## Why

The AMR reliability follow-up exposed a same-run retry race: a child can emit an `error` that safely schedules a retry, then emit its delayed `close` after the replacement child has started. Because both attempts share one run object, the old callback could unregister the replacement attempt's sink and finalize the run as failed.

This caused a healthy automatic retry to be cut off by terminal state from the previous attempt.

## What users will see

Transient failures that enter the existing same-run retry path no longer flip to a terminal failure when the previous child closes late. The replacement attempt remains authoritative and can complete normally.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — a late callback from a superseded retry attempt can no longer terminate the active attempt
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable; this changes daemon lifecycle behavior and has no UI surface.

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/retry-generation-terminal-fence.test.ts`
- Did the test go red on `main` and green on this branch? **yes**
- Red result: the replacement child had started, but the prior child's delayed `close` finalized the shared run as `failed`.
- Green result: child identity acts as the attempt-generation fence, so the active retry completes as `succeeded`.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/retry-generation-terminal-fence.test.ts tests/retry-orphan-process-group.test.ts tests/retry-stale-turn-completed-flag.test.ts tests/run-retry-runtime.test.ts -t "previous attempt close|kills the failed attempt|crashed retry attempt|forced-shutdown timers"` — 4 passed
- `pnpm --filter @open-design/daemon typecheck`
- `pnpm guard`
- `pnpm typecheck`
- `git diff --check`

Baseline note: the broader `run-retry-runtime.test.ts` file intermittently observes one persisted `start` event instead of two in its first case. Removing this patch and rerunning produced the same failure, so that event-log persistence timing issue is not introduced here.