### PR TITLE
fix(pack): bundle Vela retry exhaustion bridge

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -810,8 +810,8 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       '@powerformer/vela-cli':
-        specifier: 0.0.28
-        version: 0.0.28
+        specifier: 0.0.29
+        version: 0.0.29
 
   tools/release:
     dependencies:
@@ -2053,33 +2053,33 @@ packages:
   '@posthog/types@1.374.2':
     resolution: {integrity: sha512-ZghQSFMi+HFJNPvPjBoyY/jWQ+q6mSQVtWQxOHMSbBidUZjsyYbxYxBFbHy2qWLNe4mEpX+Wqir2Q4I/4AVvJQ==}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.28':
-    resolution: {integrity: sha512-CFJfjaG12xZ8Uw24irvYEe+rRPZiX2I+6MSP/5HN70gcHWz/bJLIuNBU0pVSMK27FETUwdk6r4vki6Wolb9RHQ==}
+  '@powerformer/vela-cli-darwin-arm64@0.0.29':
+    resolution: {integrity: sha512-Dw5HCTULtcGapjS8G/We6+mjJWEimqm/Z+pEFeajFvI3SuJRS8D5lkNoQEzWeJIy1HoZQsrzbWubXH+bI1NJ5w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@powerformer/vela-cli-darwin-x64@0.0.28':
-    resolution: {integrity: sha512-tAQi3i7w7j0U30XuOeTC7nt6vjfXUK12Uq++7KSL0PxNAtJTbF/Oe5OydsVKS9MHEFw/s1AnuHc2DG0RWcpEwg==}
+  '@powerformer/vela-cli-darwin-x64@0.0.29':
+    resolution: {integrity: sha512-9sIfZcXj9mpAdM6BeI5DYjirJwmqvK2IH77wdq44rguIudr184Wih+jkanEW1yQ/4C7NvVmRz0cfuxpyGNqv5A==}
     cpu: [x64]
     os: [darwin]
 
-  '@powerformer/vela-cli-linux-arm64@0.0.28':
-    resolution: {integrity: sha512-cRo4iIWBYRx9LYD2v5MdccgyU0Pqa0uNrdfGqgGsPqznY+CQPEuxOkpQiFOomH8l8waHYBsbkpUE/JtkqVWBUA==}
+  '@powerformer/vela-cli-linux-arm64@0.0.29':
+    resolution: {integrity: sha512-A8spGqw46LhbHmj3oGPAqXB9Fw0DnsoviYycq4A3lf29bq1QXq8q3hWGrbk/tP4CvwHLTRIL2ujUTLmQB2tNNw==}
     cpu: [arm64]
     os: [linux]
 
-  '@powerformer/vela-cli-linux-x64@0.0.28':
-    resolution: {integrity: sha512-+b6CykVp82WIAC7vkQTEmcU5cQ8Am9C1cZh7CblHHTTD7Y7C+JTYEEQgoPlD2iu59UJr9RjIkWF9PsDcgaMR/A==}
+  '@powerformer/vela-cli-linux-x64@0.0.29':
+    resolution: {integrity: sha512-xxIBTFR5wwAPxeHenCB4lQMWkVUK8oqa79XV1kvcdRamqITqVv9glrdhFV5yMMsUwgvHoXfU+mjbYO+mf9bceA==}
     cpu: [x64]
     os: [linux]
 
-  '@powerformer/vela-cli-win32-x64@0.0.28':
-    resolution: {integrity: sha512-jc/SCPViA4Uiktzae2XboHCl77V5FKbMzCIf2Dt0o7K0zlz3Kl2kbWVvBzm/0QDUKtzzrNIPliC9Wa+vVUQplA==}
+  '@powerformer/vela-cli-win32-x64@0.0.29':
+    resolution: {integrity: sha512-KuVmwa5pWr9yZBvnRgv3MxEy044gXK1e9D/WVamxtUfavhSXehEwZ0/MElK+1DsL+6+LvjWVO5N1qhGDgDo33g==}
     cpu: [x64]
     os: [win32]
 
-  '@powerformer/vela-cli@0.0.28':
-    resolution: {integrity: sha512-CZRKK/e/jm63cxM/DqxiegmzWil2od6q1aNmTRq3WCjDz8vTSby72qzD9R4akILLK7oOMXe99t7mOfzySTKlCQ==}
+  '@powerformer/vela-cli@0.0.29':
+    resolution: {integrity: sha512-J61aj11pbBzoT8XN6LKP/WN8ZWgmGNJgSQy+PWC9eZ9nA5dic0FYg2qSM1Tcmhrijtn6OPeLwuoaIwOCW0Embw==}
     hasBin: true
 
   '@preact/signals-core@1.14.2':
@@ -7911,28 +7911,28 @@ snapshots:
 
   '@posthog/types@1.374.2': {}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.28':
+  '@powerformer/vela-cli-darwin-arm64@0.0.29':
     optional: true
 
-  '@powerformer/vela-cli-darwin-x64@0.0.28':
+  '@powerformer/vela-cli-darwin-x64@0.0.29':
     optional: true
 
-  '@powerformer/vela-cli-linux-arm64@0.0.28':
+  '@powerformer/vela-cli-linux-arm64@0.0.29':
     optional: true
 
-  '@powerformer/vela-cli-linux-x64@0.0.28':
+  '@powerformer/vela-cli-linux-x64@0.0.29':
     optional: true
 
-  '@powerformer/vela-cli-win32-x64@0.0.28':
+  '@powerformer/vela-cli-win32-x64@0.0.29':
     optional: true
 
-  '@powerformer/vela-cli@0.0.28':
+  '@powerformer/vela-cli@0.0.29':
     optionalDependencies:
-      '@powerformer/vela-cli-darwin-arm64': 0.0.28
-      '@powerformer/vela-cli-darwin-x64': 0.0.28
-      '@powerformer/vela-cli-linux-arm64': 0.0.28
-      '@powerformer/vela-cli-linux-x64': 0.0.28
-      '@powerformer/vela-cli-win32-x64': 0.0.28
+      '@powerformer/vela-cli-darwin-arm64': 0.0.29
+      '@powerformer/vela-cli-darwin-x64': 0.0.29
+      '@powerformer/vela-cli-linux-arm64': 0.0.29
+      '@powerformer/vela-cli-linux-x64': 0.0.29
+      '@powerformer/vela-cli-win32-x64': 0.0.29
     optional: true
 
   '@preact/signals-core@1.14.2': {}

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -25,7 +25,7 @@
     "resedit": "1.7.2"
   },
   "optionalDependencies": {
-    "@powerformer/vela-cli": "0.0.28"
+    "@powerformer/vela-cli": "0.0.29"
   },
   "devDependencies": {
     "@types/node": "24.12.2",

--- a/tools/pack/tests/resources.test.ts
+++ b/tools/pack/tests/resources.test.ts
@@ -40,6 +40,16 @@ async function pinnedVelaCliVersion(): Promise<string> {
   return version;
 }
 
+function compareNumericVersions(left: string, right: string): number {
+  const leftParts = left.split(".").map(Number);
+  const rightParts = right.split(".").map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    const difference = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+    if (difference !== 0) return difference;
+  }
+  return 0;
+}
+
 async function matchingVelaCliCommand(
   _binary: string,
   args: readonly string[],
@@ -225,6 +235,12 @@ describe("copyBundledResourceTrees", () => {
 });
 
 describe("copyOptionalVelaCliBinary", () => {
+  it("pins a Vela CLI release that forwards OpenCode retry exhaustion to ACP hosts", async () => {
+    expect(
+      compareNumericVersions(await pinnedVelaCliVersion(), "0.0.29"),
+    ).toBeGreaterThanOrEqual(0);
+  });
+
   it("rejects a strict build when the Vela CLI version does not match the package pin", async () => {
     const root = await mkdtemp(join(tmpdir(), "open-design-tools-pack-vela-version-"));
     const source = join(root, "source", "vela");


### PR DESCRIPTION
## Why

While investigating the Open Design 0.18.0 AMR first-token failure cluster, a frozen UTC cohort contained 29 `first_token_wait` inactivity timeouts. Twenty-two of those runs produced 318 Link `503 model_limit_state_unavailable` / `unresolved permit` errors, but packaged Vela 0.0.28 did not forward OpenCode retry exhaustion through ACP. Open Design therefore kept waiting for first output and reported a generic inactivity timeout instead of the terminal retry failure.

Upstream Vela [#1310](https://github.com/powerformer/vela/pull/1310) adds the structured retry-exhaustion bridge. Vela [0.0.29](https://github.com/powerformer/vela/releases/tag/vela-cli/v0.0.29) is the first release that contains it, so this PR moves the packaged pin to that minimal fixed version.

This intentionally does not change Open Design's first-output timeout. Two cohort runs were large requests cancelled by the existing watchdog, and five runs had no Link request evidence; those are separate investigation/fix lanes.

## What users will see

When OpenCode exhausts its retries before producing the first output, packaged AMR runs can receive the structured terminal ACP failure instead of waiting until Open Design reports a generic first-token inactivity timeout. No UI, setting, or timeout default changes.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — changes what existing users experience without opting in (default model, default setting, file/SQLite schema, auto-network on startup, auto-install)
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable — no UI surface changed.

## Bug fix verification

- Test path: `tools/pack/tests/resources.test.ts` — `pins a Vela CLI release that forwards OpenCode retry exhaustion to ACP hosts`
- The test went red against the `main` pin (0.0.28) and green on this branch (0.0.29).
- The focused upstream regression also passes: `TestACPBridgePromptReturnsStructuredRetryExhaustionData`.

## Validation

- `pnpm --filter @open-design/tools-pack exec vitest run tests/resources.test.ts` (17 passed)
- `pnpm --filter @open-design/tools-pack exec vela --version` (`0.0.29`)
- `pnpm --filter @open-design/tools-pack test` (272 passed, 8 skipped)
- `pnpm --filter @open-design/tools-pack typecheck`
- `pnpm --filter @open-design/tools-pack build`
- `pnpm guard`
- `pnpm typecheck`
- `go test ./internal/agent -run '^TestACPBridgePromptReturnsStructuredRetryExhaustionData$' -count=1` in the Vela CLI workspace
