### PR TITLE
chore(pack): bundle Vela CLI 0.0.31

### DIFF
--- a/nix/pnpm-deps.nix
+++ b/nix/pnpm-deps.nix
@@ -9,6 +9,6 @@
   # 1. Temporarily set the consuming `hash = lib.fakeHash;`
   # 2. Run the relevant nix build/flake check
   # 3. Copy the expected hash printed by Nix into the matching field below
-  daemonHash = "sha256-YQvGfoSFGgSqdCezSTNrTBIlEpnPFPH04vUzZf5RJc0=";
-  webHash = "sha256-T6z+ZjG/+KOD9qBqO/WguX6F9C+Z1mGdQlDxw/5Ddq0=";
+  daemonHash = "sha256-LZeGYpjxKgDwqbY/1XZLiaHBawIZM68i9oUju7XU6PI=";
+  webHash = "sha256-+kvUsQ9gNVaGIO2aF0z3dSPrNi4Nbp2z/B4gkWUZXyo=";
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -810,8 +810,8 @@ importers:
         version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.2)(jsdom@29.1.1)(vite@7.3.3(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       '@powerformer/vela-cli':
-        specifier: 0.0.28
-        version: 0.0.28
+        specifier: 0.0.31
+        version: 0.0.31
 
   tools/release:
     dependencies:
@@ -2053,33 +2053,33 @@ packages:
   '@posthog/types@1.374.2':
     resolution: {integrity: sha512-ZghQSFMi+HFJNPvPjBoyY/jWQ+q6mSQVtWQxOHMSbBidUZjsyYbxYxBFbHy2qWLNe4mEpX+Wqir2Q4I/4AVvJQ==}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.28':
-    resolution: {integrity: sha512-CFJfjaG12xZ8Uw24irvYEe+rRPZiX2I+6MSP/5HN70gcHWz/bJLIuNBU0pVSMK27FETUwdk6r4vki6Wolb9RHQ==}
+  '@powerformer/vela-cli-darwin-arm64@0.0.31':
+    resolution: {integrity: sha512-Qp2E++ELUhs4W7nJ9RlAHbGO1X3rkdrkZ1ru/G4rg3gZP/MIiZLgzSAsrmF2cp7esy64QODsq2uhU9UsHz/I9w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@powerformer/vela-cli-darwin-x64@0.0.28':
-    resolution: {integrity: sha512-tAQi3i7w7j0U30XuOeTC7nt6vjfXUK12Uq++7KSL0PxNAtJTbF/Oe5OydsVKS9MHEFw/s1AnuHc2DG0RWcpEwg==}
+  '@powerformer/vela-cli-darwin-x64@0.0.31':
+    resolution: {integrity: sha512-rSqPd253JXXJIcr7S/hGXwn+jKW2tj2tsul3vMSICO/iYek5RrNZ76fmNL2lacVzWoQkVShIbLcmkiu2NcUfnA==}
     cpu: [x64]
     os: [darwin]
 
-  '@powerformer/vela-cli-linux-arm64@0.0.28':
-    resolution: {integrity: sha512-cRo4iIWBYRx9LYD2v5MdccgyU0Pqa0uNrdfGqgGsPqznY+CQPEuxOkpQiFOomH8l8waHYBsbkpUE/JtkqVWBUA==}
+  '@powerformer/vela-cli-linux-arm64@0.0.31':
+    resolution: {integrity: sha512-/JMbdZii+JyJGC5cZBM69XMqvQyg58TlmMgVLKwnflflVtPOqO+qQcjcKFa/6Y9bdlAdXGFN9r7GQ6e82/5xZA==}
     cpu: [arm64]
     os: [linux]
 
-  '@powerformer/vela-cli-linux-x64@0.0.28':
-    resolution: {integrity: sha512-+b6CykVp82WIAC7vkQTEmcU5cQ8Am9C1cZh7CblHHTTD7Y7C+JTYEEQgoPlD2iu59UJr9RjIkWF9PsDcgaMR/A==}
+  '@powerformer/vela-cli-linux-x64@0.0.31':
+    resolution: {integrity: sha512-/OK19sB6vVzRx/buH9ALyqBrponkIB6jf9oxNZDktHU5xIYtGBe/47wguZEPkMrfn8xHSkaMDb31ZFqC4aeGrQ==}
     cpu: [x64]
     os: [linux]
 
-  '@powerformer/vela-cli-win32-x64@0.0.28':
-    resolution: {integrity: sha512-jc/SCPViA4Uiktzae2XboHCl77V5FKbMzCIf2Dt0o7K0zlz3Kl2kbWVvBzm/0QDUKtzzrNIPliC9Wa+vVUQplA==}
+  '@powerformer/vela-cli-win32-x64@0.0.31':
+    resolution: {integrity: sha512-9B9Y0nzD/TAEur94EqpDKNqjbbAKkKV0X65Y9ANcj8KJ1UFATFdsvJb1tesgCssxFBU40zjt/p+HQoqdBy6sfg==}
     cpu: [x64]
     os: [win32]
 
-  '@powerformer/vela-cli@0.0.28':
-    resolution: {integrity: sha512-CZRKK/e/jm63cxM/DqxiegmzWil2od6q1aNmTRq3WCjDz8vTSby72qzD9R4akILLK7oOMXe99t7mOfzySTKlCQ==}
+  '@powerformer/vela-cli@0.0.31':
+    resolution: {integrity: sha512-/mMa/IwR//BJ+ClWhQf+bbYNUf+Op3CUPlOQX6IwSk7PdRjlFcD8mMourwTfP2JDTny123nw/UW9mMD5GyBbVg==}
     hasBin: true
 
   '@preact/signals-core@1.14.2':
@@ -7911,28 +7911,28 @@ snapshots:
 
   '@posthog/types@1.374.2': {}
 
-  '@powerformer/vela-cli-darwin-arm64@0.0.28':
+  '@powerformer/vela-cli-darwin-arm64@0.0.31':
     optional: true
 
-  '@powerformer/vela-cli-darwin-x64@0.0.28':
+  '@powerformer/vela-cli-darwin-x64@0.0.31':
     optional: true
 
-  '@powerformer/vela-cli-linux-arm64@0.0.28':
+  '@powerformer/vela-cli-linux-arm64@0.0.31':
     optional: true
 
-  '@powerformer/vela-cli-linux-x64@0.0.28':
+  '@powerformer/vela-cli-linux-x64@0.0.31':
     optional: true
 
-  '@powerformer/vela-cli-win32-x64@0.0.28':
+  '@powerformer/vela-cli-win32-x64@0.0.31':
     optional: true
 
-  '@powerformer/vela-cli@0.0.28':
+  '@powerformer/vela-cli@0.0.31':
     optionalDependencies:
-      '@powerformer/vela-cli-darwin-arm64': 0.0.28
-      '@powerformer/vela-cli-darwin-x64': 0.0.28
-      '@powerformer/vela-cli-linux-arm64': 0.0.28
-      '@powerformer/vela-cli-linux-x64': 0.0.28
-      '@powerformer/vela-cli-win32-x64': 0.0.28
+      '@powerformer/vela-cli-darwin-arm64': 0.0.31
+      '@powerformer/vela-cli-darwin-x64': 0.0.31
+      '@powerformer/vela-cli-linux-arm64': 0.0.31
+      '@powerformer/vela-cli-linux-x64': 0.0.31
+      '@powerformer/vela-cli-win32-x64': 0.0.31
     optional: true
 
   '@preact/signals-core@1.14.2': {}

--- a/tools/pack/package.json
+++ b/tools/pack/package.json
@@ -25,7 +25,7 @@
     "resedit": "1.7.2"
   },
   "optionalDependencies": {
-    "@powerformer/vela-cli": "0.0.28"
+    "@powerformer/vela-cli": "0.0.31"
   },
   "devDependencies": {
     "@types/node": "24.12.2",

--- a/tools/pack/src/vela-cli.ts
+++ b/tools/pack/src/vela-cli.ts
@@ -5,8 +5,15 @@ import { dirname, join } from "node:path";
 export const VELA_CLI_BIN_ENV = "OPEN_DESIGN_VELA_CLI_BIN";
 const OPEN_CODE_COMPANION_RELATIVE_PATH = ["libexec", "opencode"] as const;
 const AUTHORIZED_PULL_HELP_ARGS = ["team-projects", "pull", "--help"] as const;
+// What the bundle needs from `team-projects pull` is the authorized staged
+// pull CAPABILITY: the subcommand exists, takes a project id, and accepts the
+// flags the daemon drives it with. Deliberately not asserted: whether
+// `stageDir` is required or optional. Vela made it optional when it added
+// `--authorize-only` (a size probe that stages nothing), which changed the
+// usage line from `<stageDir>` to `[stageDir]` without removing anything the
+// daemon uses — a shape change, not a capability change.
 const AUTHORIZED_PULL_HELP_MARKERS = [
-  "pull <projectId> <stageDir>",
+  "pull <projectId>",
   "--expected-version",
   "--live-dir",
   "--ref",

--- a/tools/pack/src/vela-cli.ts
+++ b/tools/pack/src/vela-cli.ts
@@ -5,15 +5,19 @@ import { dirname, join } from "node:path";
 export const VELA_CLI_BIN_ENV = "OPEN_DESIGN_VELA_CLI_BIN";
 const OPEN_CODE_COMPANION_RELATIVE_PATH = ["libexec", "opencode"] as const;
 const AUTHORIZED_PULL_HELP_ARGS = ["team-projects", "pull", "--help"] as const;
-// What the bundle needs from `team-projects pull` is the authorized staged
-// pull CAPABILITY: the subcommand exists, takes a project id, and accepts the
-// flags the daemon drives it with. Deliberately not asserted: whether
-// `stageDir` is required or optional. Vela made it optional when it added
-// `--authorize-only` (a size probe that stages nothing), which changed the
-// usage line from `<stageDir>` to `[stageDir]` without removing anything the
-// daemon uses — a shape change, not a capability change.
+// The daemon always invokes `pull <projectId> <stageDir> --live-dir …`
+// (`stageAuthorizedTeamProjectPull`), so the staging-directory positional is
+// part of the capability, not decoration: a CLI whose usage dropped it would
+// pass a laxer gate here and then reject the shipped invocation at runtime.
+//
+// What is NOT part of the capability is whether that positional reads as
+// required or optional. Vela made it optional when it added `--authorize-only`
+// (a size probe that stages nothing), turning `<stageDir>` into `[stageDir]`
+// without removing anything the daemon relies on. Accept both spellings and
+// nothing else, so the gate stays fail-closed on a genuinely missing argument.
+const AUTHORIZED_PULL_USAGE_PATTERN =
+  /pull <projectId> (?:<stageDir>|\[stageDir\])/u;
 const AUTHORIZED_PULL_HELP_MARKERS = [
-  "pull <projectId>",
   "--expected-version",
   "--live-dir",
   "--ref",
@@ -125,6 +129,11 @@ async function validateBundledVelaCliBinary(
     );
   }
   const help = `${helpResult.stdout}\n${helpResult.stderr}`;
+  if (!AUTHORIZED_PULL_USAGE_PATTERN.test(help)) {
+    throw strictResolutionError(
+      "bundled Vela CLI lacks the authorized staged pull capability markers: pull <projectId> <stageDir>",
+    );
+  }
   const missingMarkers = AUTHORIZED_PULL_HELP_MARKERS.filter(
     (marker) => !help.includes(marker),
   );

--- a/tools/pack/tests/resources.test.ts
+++ b/tools/pack/tests/resources.test.ts
@@ -40,6 +40,43 @@ async function pinnedVelaCliVersion(): Promise<string> {
   return version;
 }
 
+/**
+ * Help output as current Vela prints it: `--authorize-only` made `stageDir`
+ * optional, so the usage line reads `[stageDir]`. Every flag the daemon drives
+ * is still there — the capability is unchanged, only the usage shape moved.
+ */
+async function velaCliCommandWithOptionalStageDir(
+  _source: string,
+  args: readonly string[],
+): Promise<{ stderr: string; stdout: string }> {
+  if (args[0] === "--version") {
+    return { stderr: "", stdout: `${await pinnedVelaCliVersion()}\n` };
+  }
+  if (args[0] === "billing") {
+    return {
+      stderr: "",
+      stdout: [
+        "Usage:",
+        "  vela billing workspace-snapshot [flags]",
+        "      --workspace-id string",
+        "      --format string",
+      ].join("\n"),
+    };
+  }
+  return {
+    stderr: "",
+    stdout: [
+      "Usage:",
+      "  vela team-projects pull <projectId> [stageDir] [flags]",
+      "      --authorize-only",
+      "      --expected-version int",
+      "      --live-dir string",
+      "      --ref string",
+      "      --json",
+    ].join("\n"),
+  };
+}
+
 async function matchingVelaCliCommand(
   _binary: string,
   args: readonly string[],
@@ -333,6 +370,33 @@ describe("copyOptionalVelaCliBinary", () => {
       await expect(access(target)).resolves.toBeUndefined();
       const openCodeName = process.platform === "win32" ? "opencode.exe" : "opencode";
       await expect(access(join(resourceRoot, "bin", "libexec", "opencode", openCodeName))).resolves.toBeUndefined();
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("accepts a Vela CLI whose pull usage line marks stageDir optional", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-tools-pack-vela-optional-stage-"));
+    const source = join(root, "source", "vela");
+    const resourceRoot = join(root, "resources", "open-design");
+
+    try {
+      await mkdir(join(root, "source"), { recursive: true });
+      await writeFile(source, "#!/bin/sh\nexit 0\n", "utf8");
+      await writeFakeOpenCodeCompanion(source, "#!/bin/sh\necho opencode\n");
+
+      // Validation must gate on the capability, not on whether an argument is
+      // spelled <required> or [optional]; otherwise a purely cosmetic usage
+      // change in Vela blocks packaging for no reason.
+      const copied = await copyOptionalVelaCliBinary({
+        env: { OPEN_DESIGN_VELA_CLI_BIN: source },
+        platform: "mac",
+        requireBundled: true,
+        resourceRoot,
+        runCommand: velaCliCommandWithOptionalStageDir,
+      });
+
+      expect(copied?.target).toBe(join(resourceRoot, "bin", "vela"));
     } finally {
       await rm(root, { force: true, recursive: true });
     }

--- a/tools/pack/tests/resources.test.ts
+++ b/tools/pack/tests/resources.test.ts
@@ -77,6 +77,42 @@ async function velaCliCommandWithOptionalStageDir(
   };
 }
 
+/**
+ * A CLI whose pull usage dropped the staging-directory positional entirely.
+ * The daemon always passes it, so packaging must refuse this binary rather
+ * than ship one that rejects the invocation at runtime.
+ */
+async function velaCliCommandWithoutStageDir(
+  _source: string,
+  args: readonly string[],
+): Promise<{ stderr: string; stdout: string }> {
+  if (args[0] === "--version") {
+    return { stderr: "", stdout: `${await pinnedVelaCliVersion()}\n` };
+  }
+  if (args[0] === "billing") {
+    return {
+      stderr: "",
+      stdout: [
+        "Usage:",
+        "  vela billing workspace-snapshot [flags]",
+        "      --workspace-id string",
+        "      --format string",
+      ].join("\n"),
+    };
+  }
+  return {
+    stderr: "",
+    stdout: [
+      "Usage:",
+      "  vela team-projects pull <projectId> [flags]",
+      "      --expected-version int",
+      "      --live-dir string",
+      "      --ref string",
+      "      --json",
+    ].join("\n"),
+  };
+}
+
 async function matchingVelaCliCommand(
   _binary: string,
   args: readonly string[],
@@ -397,6 +433,33 @@ describe("copyOptionalVelaCliBinary", () => {
       });
 
       expect(copied?.target).toBe(join(resourceRoot, "bin", "vela"));
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("refuses a Vela CLI whose pull usage dropped the staging directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "open-design-tools-pack-vela-no-stage-"));
+    const source = join(root, "source", "vela");
+    const resourceRoot = join(root, "resources", "open-design");
+
+    try {
+      await mkdir(join(root, "source"), { recursive: true });
+      await writeFile(source, "#!/bin/sh\nexit 0\n", "utf8");
+      await writeFakeOpenCodeCompanion(source, "#!/bin/sh\necho opencode\n");
+
+      // The daemon invokes `pull <projectId> <stageDir> --live-dir …`, so a CLI
+      // that no longer takes the positional must fail packaging rather than
+      // ship and reject that invocation at runtime.
+      await expect(
+        copyOptionalVelaCliBinary({
+          env: { OPEN_DESIGN_VELA_CLI_BIN: source },
+          platform: "mac",
+          requireBundled: true,
+          resourceRoot,
+          runCommand: velaCliCommandWithoutStageDir,
+        }),
+      ).rejects.toThrow(/staged pull capability markers/u);
     } finally {
       await rm(root, { force: true, recursive: true });
     }


### PR DESCRIPTION
## Why

Packaged builds bundle a pinned Vela CLI, and that pin (`0.0.28`) predates the directory-scoped exclude semantics `apps/daemon` now depends on.

nexu-io/open-design#6564 sends generated-tree names in the directory-only form (`dist/`) instead of bare (`dist`), because the bare form also swallowed a regular project file named `dist`, `out` or `target` — content the owner still saw, silently absent from every member mirror. powerformer/vela#1466 taught the CLI that form; this bump is what turns it on for packaged users. Until the bundled CLI understands it, those rules match nothing and packaged builds publish the full tree — correct, just not yet optimized.

## What users will see

No visible change. Packaged builds start skipping generated directories (`dist`, `.next`, `.venv`, `coverage`, `target`, `DerivedData`, `deriveddata-*`) when publishing a team project, so a member mirror carries the author's actual content instead of their build output. On a mixed 15-file fixture that is 3 blobs instead of 10.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency** — `@powerformer/vela-cli` is an existing `tools/pack` optional dependency, version-bumped only
- [x] **Default behavior change** — packaged publishes stop shipping generated directories to member mirrors
- [ ] **None**

## The capability marker change

Packaging validates the bundled CLI by matching markers in its `--help` output. One marker asserted the usage line `pull <projectId> <stageDir>`. Vela made `stageDir` optional when it added `--authorize-only` (a size probe that stages nothing), so the line now reads `pull <projectId> [stageDir]` and the exact-string match fails — packaging would refuse the new CLI.

Every flag the daemon actually drives (`--expected-version`, `--live-dir`, `--ref`, `--json`) is still present. The usage shape moved; the capability did not. The marker now covers the subcommand plus its flags, which is what "authorized staged pull" means, and deliberately says nothing about whether an argument is spelled `<required>` or `[optional]` — pinning packaging to that would block future bumps for cosmetic reasons.

## Validation

Red-first: the new spec (`accepts a Vela CLI whose pull usage line marks stageDir optional`) fails against the old marker with the exact packaging error, and passes after. `tools-pack` suite 17/17, including the test that resolves and validates the **real installed 0.0.31 binary** through the default npm resolver. `pnpm guard` and `pnpm typecheck` both exit 0.

Verified against the shipped binary directly: reports `0.0.31`, prints the `[stageDir]` usage line, and its `--exclude` help documents the new trailing-slash directory semantics.

Pairs with nexu-io/open-design#6564 and powerformer/vela#1466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
