### PR TITLE
fix(web): resilient retry for workspace-context writes

### DIFF
--- a/apps/web/src/collab/useWorkspaceContext.ts
+++ b/apps/web/src/collab/useWorkspaceContext.ts
@@ -16,6 +16,7 @@ import {
   buildWorkspaceSeatSummary,
 } from '@open-design/contracts';
 import { coalescedGet, forceCoalescedGet } from '../lib/coalesced-get';
+import { BackoffController, type BackoffOptions } from '../lib/backoff';
 import {
   markProjectDisplaySnapshotsDirty,
   patchProjectDisplaySnapshots,
@@ -229,6 +230,18 @@ function advanceWorkspaceContextRequestToken(sharedToken?: string | null): void 
  *  by the identity generation above. */
 function workspaceContextCoalesceKey(): string {
   return `workspace-context:${workspaceContextRequestToken}`;
+}
+
+/**
+ * The LIVE identity generation token. A cached workspace context is stamped
+ * with the token it was resolved under (see `resourceReadIdentity.generation`);
+ * a write path compares that stamp against this live value to decide whether a
+ * retained (last-good) context still belongs to the current identity, rather
+ * than trusting a possibly-stale `identityChangePending` snapshot. See
+ * `resolvedWorkspaceContextForWrite` in `state/projects.ts`.
+ */
+export function currentWorkspaceContextRequestToken(): string {
+  return workspaceContextRequestToken;
 }
 
 async function fetchWorkspaceDirectory(): Promise<WorkspaceDirectoryResponse> {
@@ -476,6 +489,7 @@ export function resetWorkspaceContextCache(): void {
   workspaceContextIdentityChangePending = false;
   workspaceAccountGeneration = 0;
   workspaceAccountGenerationStamp = 'initial';
+  resetWorkspaceContextRetrySchedules();
   writeWorkspaceSelection(null);
 }
 
@@ -701,6 +715,9 @@ export function useWorkspaceContext(): WorkspaceContextState {
       cachedWorkspaceContext = nextContext;
       cachedWorkspaceContextGeneration = requestGeneration;
       workspaceContextIdentityChangePending = false;
+      // A successful read is the only thing that rewinds the failure-retry
+      // backoff for this generation.
+      clearWorkspaceContextRetryFailures(requestGeneration);
       setState({
         context: cachedWorkspaceContext,
         resourceReadIdentity: cachedWorkspaceContext
@@ -719,6 +736,7 @@ export function useWorkspaceContext(): WorkspaceContextState {
       // last-known context instead of flashing the signed-out state. A never-
       // signed-in / personal user has a null cache, so this still shows the local
       // state for them.
+      const unsupported = (error as { status?: unknown })?.status === 404;
       setState({
         context: cachedWorkspaceContext,
         resourceReadIdentity:
@@ -730,11 +748,13 @@ export function useWorkspaceContext(): WorkspaceContextState {
             : null,
         loading: false,
         identityChangePending: workspaceContextIdentityChangePending,
-        failure:
-          (error as { status?: unknown })?.status === 404
-            ? 'unsupported'
-            : 'unavailable',
+        failure: unsupported ? 'unsupported' : 'unavailable',
       });
+      // An `unsupported` daemon has no workspace endpoint — retrying is
+      // pointless. A transient `unavailable` outage arms the shared jittered
+      // backoff so the shell recovers on its own without waiting for the 30s
+      // poll or a focus event.
+      if (!unsupported) scheduleWorkspaceContextRetry(requestGeneration);
     }
   }, []);
 
@@ -815,15 +835,26 @@ export function useWorkspaceContext(): WorkspaceContextState {
       advanceWorkspaceAccountGeneration(event.newValue ?? 'storage');
       refreshAfterIdentityChange();
     };
+    // A scheduled failure-retry (see `scheduleWorkspaceContextRetry`) fires this
+    // event for a specific identity generation. Re-read only when it still names
+    // the current generation — a retry armed for an identity the user has since
+    // left must not spend a request.
+    const onContextRetry = (event: Event) => {
+      const detail = (event as CustomEvent<{ requestKey?: string }>).detail;
+      if (detail?.requestKey !== workspaceContextRequestToken) return;
+      void loadContext();
+    };
     window.addEventListener('focus', refresh);
     window.addEventListener('pageshow', refresh);
     window.addEventListener(WORKSPACE_CONTEXT_REFRESH_EVENT, refreshAfterIdentityChange);
+    window.addEventListener(WORKSPACE_CONTEXT_RETRY_EVENT, onContextRetry);
     window.addEventListener('storage', onStorage);
     document.addEventListener('visibilitychange', onVisibilityChange);
     return () => {
       window.removeEventListener('focus', refresh);
       window.removeEventListener('pageshow', refresh);
       window.removeEventListener(WORKSPACE_CONTEXT_REFRESH_EVENT, refreshAfterIdentityChange);
+      window.removeEventListener(WORKSPACE_CONTEXT_RETRY_EVENT, onContextRetry);
       window.removeEventListener('storage', onStorage);
       document.removeEventListener('visibilitychange', onVisibilityChange);
     };
@@ -1607,7 +1638,7 @@ const WORKSPACE_BILLING_RETRY_EVENT = 'od:workspace-billing-retry';
  * within the share window costs zero network requests).
  */
 type WorkspaceBillingRetrySchedule = {
-  consecutiveFailures: number;
+  backoff: BackoffController;
   timer: ReturnType<typeof setTimeout> | null;
 };
 const workspaceBillingRetrySchedules = new Map<string, WorkspaceBillingRetrySchedule>();
@@ -1616,15 +1647,23 @@ function scheduleWorkspaceBillingRetry(requestKey: string): void {
   if (typeof window === 'undefined') return;
   let schedule = workspaceBillingRetrySchedules.get(requestKey);
   if (!schedule) {
-    schedule = { consecutiveFailures: 0, timer: null };
+    schedule = {
+      backoff: new BackoffController({
+        initialMs: WORKSPACE_BILLING_RETRY_BASE_MS,
+        maxMs: WORKSPACE_BILLING_RETRY_MAX_MS,
+        factor: 2,
+        // Jitter stays OFF for billing: its exponential schedule predates this
+        // change and is pinned by an exact-cadence regression test (the od://
+        // 502-storm). Only the arithmetic moves onto the shared controller;
+        // the observable 5s→10s→20s→40s→60s timing is unchanged.
+        jitter: false,
+      }),
+      timer: null,
+    };
     workspaceBillingRetrySchedules.set(requestKey, schedule);
   }
   if (schedule.timer != null) return;
-  const delay = Math.min(
-    WORKSPACE_BILLING_RETRY_BASE_MS * 2 ** schedule.consecutiveFailures,
-    WORKSPACE_BILLING_RETRY_MAX_MS,
-  );
-  schedule.consecutiveFailures += 1;
+  const delay = schedule.backoff.nextDelay();
   schedule.timer = setTimeout(() => {
     schedule.timer = null;
     // Dispatch unconditionally: listeners filter on their own active
@@ -1636,8 +1675,7 @@ function scheduleWorkspaceBillingRetry(requestKey: string): void {
 }
 
 function clearWorkspaceBillingRetryFailures(requestKey: string): void {
-  const schedule = workspaceBillingRetrySchedules.get(requestKey);
-  if (schedule) schedule.consecutiveFailures = 0;
+  workspaceBillingRetrySchedules.get(requestKey)?.backoff.reset();
 }
 
 function resetWorkspaceBillingRetrySchedules(): void {
@@ -1646,6 +1684,82 @@ function resetWorkspaceBillingRetrySchedules(): void {
   }
   workspaceBillingRetrySchedules.clear();
 }
+
+// ---------- workspace context failure retry ----------
+//
+// `GET /api/workspace/context` (and its directory prerequisite) previously had
+// NO failure retry: a read that failed just sat on the last-good context until
+// the next 30s poll or a focus event. During a multi-hour vela authority outage
+// that left the shell stale far longer than necessary and, combined with the
+// old fail-closed write gate, drove the create-retry storm this PR fixes.
+//
+// The failure path now arms a jittered exponential-backoff retry (1s → 30s),
+// module-level and keyed by identity generation — one timer shared by every
+// mounted consumer, exactly like the billing schedule above (a per-hook timer
+// would arm a dozen for the dozen-plus mounted `useWorkspaceContext`s). Success
+// resets the depth; an ambient trigger (SSE `workspace-context-changed`, focus,
+// the poll floor) fetches immediately WITHOUT rewinding the depth, so unrelated
+// foreground activity cannot keep kicking a flaky transport back to a 1s cadence.
+const WORKSPACE_CONTEXT_RETRY_BASE_MS = 1_000;
+const WORKSPACE_CONTEXT_RETRY_MAX_MS = 30_000;
+const WORKSPACE_CONTEXT_RETRY_EVENT = 'od:workspace-context-retry';
+
+function defaultWorkspaceContextRetryBackoff(): BackoffOptions {
+  return {
+    initialMs: WORKSPACE_CONTEXT_RETRY_BASE_MS,
+    maxMs: WORKSPACE_CONTEXT_RETRY_MAX_MS,
+    factor: 2,
+    jitter: true,
+  };
+}
+
+// Test seam: production uses jittered backoff; a test pins the schedule to a
+// deterministic sequence (jitter off) to assert the exact 1s→2s→4s…→30s growth.
+let workspaceContextRetryBackoffOptions: BackoffOptions = defaultWorkspaceContextRetryBackoff();
+
+export function __setWorkspaceContextRetryBackoffForTests(
+  options: BackoffOptions | null,
+): void {
+  workspaceContextRetryBackoffOptions = options ?? defaultWorkspaceContextRetryBackoff();
+}
+
+type WorkspaceContextRetrySchedule = {
+  backoff: BackoffController;
+  timer: ReturnType<typeof setTimeout> | null;
+};
+const workspaceContextRetrySchedules = new Map<string, WorkspaceContextRetrySchedule>();
+
+function scheduleWorkspaceContextRetry(requestKey: string): void {
+  if (typeof window === 'undefined') return;
+  let schedule = workspaceContextRetrySchedules.get(requestKey);
+  if (!schedule) {
+    schedule = {
+      backoff: new BackoffController(workspaceContextRetryBackoffOptions),
+      timer: null,
+    };
+    workspaceContextRetrySchedules.set(requestKey, schedule);
+  }
+  if (schedule.timer != null) return;
+  const delay = schedule.backoff.nextDelay();
+  schedule.timer = setTimeout(() => {
+    schedule.timer = null;
+    window.dispatchEvent(
+      new CustomEvent(WORKSPACE_CONTEXT_RETRY_EVENT, { detail: { requestKey } }),
+    );
+  }, delay);
+}
+
+function clearWorkspaceContextRetryFailures(requestKey: string): void {
+  workspaceContextRetrySchedules.get(requestKey)?.backoff.reset();
+}
+
+function resetWorkspaceContextRetrySchedules(): void {
+  for (const schedule of workspaceContextRetrySchedules.values()) {
+    if (schedule.timer != null) clearTimeout(schedule.timer);
+  }
+  workspaceContextRetrySchedules.clear();
+}
+
 export const WORKSPACE_BILLING_REFRESH_EVENT = 'od:workspace-billing-refresh';
 const WORKSPACE_BILLING_REFRESH_STORAGE_KEY = 'od.workspaceBilling.refreshAt';
 

--- a/apps/web/src/components/Theater/state/sse.ts
+++ b/apps/web/src/components/Theater/state/sse.ts
@@ -9,6 +9,7 @@ import type { WorkspaceCollabContext } from '@open-design/contracts';
 
 import type { CritiqueAction } from './reducer';
 import { workspaceResourceUrl } from '../../../collab/workspace-identity';
+import { BackoffController } from '../../../lib/backoff';
 
 export interface CritiqueEventsConnection {
   close(): void;
@@ -24,6 +25,8 @@ export interface CritiqueEventsConnectionOptions {
   /** Test seam: setTimeout substitutes for fake timers. */
   setTimeoutFn?: typeof setTimeout;
   clearTimeoutFn?: typeof clearTimeout;
+  /** Test seam: deterministic jitter source for the reconnect backoff. */
+  randomFn?: () => number;
   /** Persisted project authority encoded into the EventSource URL. */
   workspaceContext?: WorkspaceCollabContext | null;
 }
@@ -114,13 +117,17 @@ export function createCritiqueEventsConnection(
     ?? (typeof EventSource === 'undefined' ? null : EventSource);
   if (!Ctor) return { close() { /* noop */ } };
 
-  const initialBackoff = options.initialBackoffMs ?? DEFAULT_INITIAL_BACKOFF;
-  const maxBackoff = options.maxBackoffMs ?? DEFAULT_MAX_BACKOFF;
   const setT = options.setTimeoutFn ?? setTimeout;
   const clearT = options.clearTimeoutFn ?? clearTimeout;
+  const backoff = new BackoffController({
+    initialMs: options.initialBackoffMs ?? DEFAULT_INITIAL_BACKOFF,
+    maxMs: options.maxBackoffMs ?? DEFAULT_MAX_BACKOFF,
+    factor: 2,
+    jitter: true,
+    random: options.randomFn,
+  });
 
   let cancelled = false;
-  let backoff = initialBackoff;
   let source: EventSource | null = null;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -145,7 +152,7 @@ export function createCritiqueEventsConnection(
     const es = new Ctor(critiqueEventsUrl(projectId, options.workspaceContext));
     source = es;
     es.addEventListener('ready', () => {
-      backoff = initialBackoff;
+      backoff.reset();
     });
     for (const name of CRITIQUE_SSE_EVENT_NAMES) {
       es.addEventListener(name, handleCritiqueFrame(name));
@@ -154,9 +161,7 @@ export function createCritiqueEventsConnection(
       if (cancelled) return;
       es.close();
       if (source === es) source = null;
-      const delay = backoff;
-      backoff = Math.min(backoff * 2, maxBackoff);
-      reconnectTimer = setT(connect, delay) as ReturnType<typeof setTimeout>;
+      reconnectTimer = setT(connect, backoff.nextDelay()) as ReturnType<typeof setTimeout>;
     });
   };
 

--- a/apps/web/src/hooks/useEventStream.ts
+++ b/apps/web/src/hooks/useEventStream.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { BackoffController } from '../lib/backoff';
 
 // Collab realtime hop-2 — the reusable daemon→web SSE client.
 //
@@ -77,7 +78,14 @@ class EventStreamManager {
   private readonly subscribers = new Set<InternalSubscriber>();
   private source: EventSource | null = null;
   private connected = false;
-  private backoff = INITIAL_BACKOFF_MS;
+  // Jittered exponential reconnect backoff (1s → 30s), shared with every other
+  // SSE surface via the common controller.
+  private readonly backoff = new BackoffController({
+    initialMs: INITIAL_BACKOFF_MS,
+    maxMs: MAX_BACKOFF_MS,
+    factor: 2,
+    jitter: true,
+  });
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private hiddenTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly attachedNames = new Set<string>();
@@ -137,7 +145,7 @@ class EventStreamManager {
     this.source = es;
     this.attachedNames.clear();
     es.onopen = () => {
-      this.backoff = INITIAL_BACKOFF_MS;
+      this.backoff.reset();
       this.setConnected(true);
       // Snapshot catch-up on (re)connect — the thin-event model relies on this
       // instead of replaying buffered events.
@@ -154,7 +162,7 @@ class EventStreamManager {
     // too (covers transports where `onopen` is unreliable).
     this.listen('ready', () => {
       if (!this.connected) {
-        this.backoff = INITIAL_BACKOFF_MS;
+        this.backoff.reset();
         this.setConnected(true);
         for (const sub of Array.from(this.subscribers)) sub.onActive?.();
       }
@@ -192,13 +200,10 @@ class EventStreamManager {
 
   private scheduleReconnect(): void {
     if (this.reconnectTimer || this.subscribers.size === 0) return;
-    const jitter = Math.floor(Math.random() * 500);
-    const delay = this.backoff + jitter;
-    this.backoff = Math.min(this.backoff * 2, MAX_BACKOFF_MS);
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null;
       this.ensureOpen();
-    }, delay);
+    }, this.backoff.nextDelay());
   }
 
   private closeSource(): void {

--- a/apps/web/src/lib/backoff.ts
+++ b/apps/web/src/lib/backoff.ts
@@ -1,0 +1,84 @@
+// Shared exponential-backoff primitive for the web runtime.
+//
+// This is pure logic — no React, no DOM, no timers. It only decides HOW LONG
+// the next wait should be; the caller owns the single timer that actually
+// sleeps. Keeping the arithmetic here (instead of re-deriving `backoff =
+// Math.min(backoff * 2, cap)` inline in every SSE reconnect / failure-retry
+// loop) means the "1s → 30s, ×2, jittered, reset-on-success" contract has ONE
+// definition that can be unit-tested exhaustively.
+//
+// Full jitter matters under a struggling transport: when N clients all fail at
+// the same instant (a vela outage, a packaged-client proxy 502 storm), an
+// un-jittered schedule reconnects them in lockstep and re-creates the very
+// thundering herd that produced the failure. Multiplying each delay by a
+// random factor in [0.5, 1.0) spreads the retries out.
+
+export interface BackoffOptions {
+  /** Delay for the first retry, before any exponential growth. Default 1000ms. */
+  initialMs?: number;
+  /** Ceiling the (un-jittered) delay is clamped to. Default 30000ms. */
+  maxMs?: number;
+  /** Growth factor applied after each `nextDelay()`. Default 2. */
+  factor?: number;
+  /** When true (default) each delay is multiplied by random(0.5, 1.0). */
+  jitter?: boolean;
+  /**
+   * Randomness seam. Defaults to `Math.random` (available in every browser and
+   * in Node test envs). Tests inject a deterministic function so the jittered
+   * delay is predictable.
+   */
+  random?: () => number;
+}
+
+/**
+ * A mutable exponential-backoff cursor.
+ *
+ * `nextDelay()` returns the delay to wait NOW and advances the internal cursor
+ * for next time. `reset()` returns to the initial delay — the only thing that
+ * should clear accumulated depth is an actual success. `attempt` counts how
+ * many delays have been handed out since the last reset.
+ */
+export class BackoffController {
+  private readonly initialMs: number;
+  private readonly maxMs: number;
+  private readonly factor: number;
+  private readonly jitter: boolean;
+  private readonly random: () => number;
+
+  /** The next un-jittered delay `nextDelay()` will draw from. */
+  private currentMs: number;
+
+  /** Delays handed out since the last `reset()`. */
+  attempt = 0;
+
+  constructor(options: BackoffOptions = {}) {
+    this.initialMs = Math.max(0, options.initialMs ?? 1000);
+    this.maxMs = Math.max(this.initialMs, options.maxMs ?? 30_000);
+    this.factor = options.factor ?? 2;
+    this.jitter = options.jitter ?? true;
+    this.random = options.random ?? Math.random;
+    this.currentMs = this.initialMs;
+  }
+
+  /**
+   * The delay (in ms) to wait before the next attempt. Reads the current
+   * (un-jittered) base, applies jitter if enabled, then grows the base toward
+   * the cap for the following call. The returned value is the jittered delay;
+   * the internal base is what doubles, so the base sequence stays a clean
+   * 1s → 2s → 4s → … → cap regardless of the random draws.
+   */
+  nextDelay(): number {
+    const base = this.currentMs;
+    this.attempt += 1;
+    this.currentMs = Math.min(this.currentMs * this.factor, this.maxMs);
+    if (!this.jitter) return base;
+    // random() ∈ [0, 1) → multiplier ∈ [0.5, 1.0).
+    return base * (0.5 + this.random() * 0.5);
+  }
+
+  /** Return to the initial delay. Call this only after a genuine success. */
+  reset(): void {
+    this.currentMs = this.initialMs;
+    this.attempt = 0;
+  }
+}

--- a/apps/web/src/providers/project-events.ts
+++ b/apps/web/src/providers/project-events.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { BackoffController } from '../lib/backoff';
 import {
   COLLAB_PROJECT_INVALIDATION_EVENTS,
   PROJECT_CONTENT_TRANSFER_STATE_EVENT,
@@ -50,6 +51,8 @@ export interface ProjectEventsConnectionOptions {
   /** Test seam: setTimeout/clearTimeout substitutes for fake timers. */
   setTimeoutFn?: typeof setTimeout;
   clearTimeoutFn?: typeof clearTimeout;
+  /** Test seam: deterministic jitter source for the reconnect backoff. */
+  randomFn?: () => number;
   /**
    * Collab realtime hop-2 poll-as-floor signal. Fires `true` when the stream is
    * live (the daemon's `ready` handshake) and `false` on error/disconnect, so a
@@ -101,13 +104,17 @@ export function createProjectEventsConnection(
     ?? (typeof EventSource === 'undefined' ? null : EventSource);
   if (!Ctor) return { close() { /* noop */ } };
 
-  const initialBackoff = options.initialBackoffMs ?? DEFAULT_INITIAL_BACKOFF;
-  const maxBackoff = options.maxBackoffMs ?? DEFAULT_MAX_BACKOFF;
   const setT = options.setTimeoutFn ?? setTimeout;
   const clearT = options.clearTimeoutFn ?? clearTimeout;
+  const backoff = new BackoffController({
+    initialMs: options.initialBackoffMs ?? DEFAULT_INITIAL_BACKOFF,
+    maxMs: options.maxBackoffMs ?? DEFAULT_MAX_BACKOFF,
+    factor: 2,
+    jitter: true,
+    random: options.randomFn,
+  });
 
   let cancelled = false;
-  let backoff = initialBackoff;
   let source: EventSource | null = null;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -116,7 +123,7 @@ export function createProjectEventsConnection(
     const es = new Ctor(projectEventsUrl(projectId, workspaceContext));
     source = es;
     es.addEventListener('ready', () => {
-      backoff = initialBackoff;
+      backoff.reset();
       options.onConnectedChange?.(true);
       options.onReady?.();
     });
@@ -215,9 +222,7 @@ export function createProjectEventsConnection(
       options.onConnectedChange?.(false);
       es.close();
       if (source === es) source = null;
-      const delay = backoff;
-      backoff = Math.min(backoff * 2, maxBackoff);
-      reconnectTimer = setT(connect, delay) as ReturnType<typeof setTimeout>;
+      reconnectTimer = setT(connect, backoff.nextDelay()) as ReturnType<typeof setTimeout>;
     });
   };
 

--- a/apps/web/src/state/projects.ts
+++ b/apps/web/src/state/projects.ts
@@ -6,6 +6,7 @@
 // the UI can stay rendered when the daemon is briefly unreachable.
 
 import { coalescedGet, evictCoalescedGet } from '../lib/coalesced-get';
+import { BackoffController, type BackoffOptions } from '../lib/backoff';
 import { markProjectCreatedByViewer } from '../collab/useProjectCollab';
 import { API_ERROR_CODES, type ApiErrorCode } from '@open-design/contracts';
 import type {
@@ -38,7 +39,11 @@ import {
   workspaceProjectHeaders,
   workspaceResourceUrl,
 } from '../collab/workspace-identity';
-import { currentWorkspaceAccountGeneration } from '../collab/useWorkspaceContext';
+import {
+  currentWorkspaceAccountGeneration,
+  currentWorkspaceContextRequestToken,
+} from '../collab/useWorkspaceContext';
+import type { WorkspaceResourceReadIdentity } from '../collab/workspace-identity';
 import type {
   ChatMessage,
   Conversation,
@@ -88,7 +93,34 @@ export type WorkspaceContextForWrite = {
   loading: boolean;
   identityChangePending?: boolean;
   failure?: 'unsupported' | 'unavailable';
+  /**
+   * The directory-verified identity the retained `context` was resolved under,
+   * carrying the generation token it belongs to. Present on production state
+   * (`useWorkspaceContext`) whenever a last-good context is held. Used by
+   * {@link resolvedWorkspaceContextForWrite} to decide whether that retained
+   * context still belongs to the CURRENT identity generation.
+   */
+  resourceReadIdentity?: WorkspaceResourceReadIdentity | null;
 };
+
+/**
+ * Whether the retained `context` still belongs to the current identity
+ * generation — the signal that lets a write proceed on a last-good context
+ * during a transient outage without ever letting one account's cached context
+ * authorize a write after the identity changed.
+ *
+ * True only when the state carries a directory-verified `resourceReadIdentity`
+ * whose generation matches the LIVE request token AND whose context is the same
+ * identity as `state.context`. A snapshot from a retired generation (an account
+ * switch bumped the token) fails this check even if `identityChangePending` in
+ * the snapshot has not caught up.
+ */
+function writeContextBelongsToCurrentGeneration(state: WorkspaceContextForWrite): boolean {
+  const identity = state.resourceReadIdentity;
+  if (!identity || state.context === null) return false;
+  if (identity.generation !== currentWorkspaceContextRequestToken()) return false;
+  return workspaceIdentityCacheKey(identity.context) === workspaceIdentityCacheKey(state.context);
+}
 
 export type WorkspaceContextWriteResolutionOptions = {
   /**
@@ -102,6 +134,17 @@ export type WorkspaceContextWriteResolutionOptions = {
 /**
  * Preserve headerless old-daemon/anonymous compatibility, but never collapse
  * an unresolved or unavailable modern workspace authority into "anonymous".
+ *
+ * When the read is momentarily blocked (loading, a pending identity change, or
+ * a transient `unavailable` outage) but the shell still holds a directory-
+ * verified last-good context that belongs to the CURRENT identity generation,
+ * that context is honored instead of throwing. The daemon re-verifies the
+ * claimed identity on the write (`authorizeCreatedProjectWorkspace`: valid →
+ * allow, cross-workspace → 403, authority down → 503 retryable), so a
+ * client-side fail-closed here is a redundant second lock that, under a flaky
+ * network, only turns a create the server would have honored into a dead
+ * button + retry storm. A context from a RETIRED generation (an account switch
+ * bumped the token) still fails closed — that is the cross-account guard.
  */
 export function resolvedWorkspaceContextForWrite(
   state: WorkspaceContextForWrite,
@@ -112,6 +155,7 @@ export function resolvedWorkspaceContextForWrite(
     || state.identityChangePending === true
     || state.failure === 'unavailable'
   ) {
+    if (writeContextBelongsToCurrentGeneration(state)) return state.context;
     if (options.unavailablePolicy === 'unscoped') return null;
     throw new Error('Workspace context is unavailable. Try again when workspace sync finishes.');
   }
@@ -475,22 +519,87 @@ export async function getProjectDetail(
   }
 }
 
-export async function createProject(input: {
-  name: string;
-  projectLocationId?: string;
-  skillId: string | null;
-  designSystemId: string | null;
-  pendingPrompt?: string;
-  metadata?: ProjectMetadata;
-  conversationMode?: ChatSessionMode;
-  // Plan §3.A1 / spec §11.5 — POST /api/projects accepts a pluginId
-  // (or pre-applied snapshot id) to resolve and pin a plugin to the new
-  // project. Used by the PluginLoopHome flow on Home.
-  pluginId?: string;
-  appliedPluginSnapshotId?: string;
-  pluginInputs?: Record<string, unknown>;
-  workspaceContext?: WorkspaceCollabContext | null;
-}): Promise<{ project: Project; conversationId: string; appliedPluginSnapshotId?: string }> {
+/**
+ * Bounded-retry knobs for {@link createProject}. Production callers omit this
+ * and get the default 1s→…-jittered backoff; tests inject a no-op `sleep` (and
+ * usually a small `maxRetries`) so the schedule is instant and deterministic.
+ */
+export interface CreateProjectRetryOptions {
+  /** Additional attempts after the first. Default 3 (so up to 4 requests). */
+  maxRetries?: number;
+  /** Backoff shape between retries. Defaults to 500ms→4s ×2 jittered. */
+  backoff?: BackoffOptions;
+  /** Test seam for the inter-retry wait. Defaults to a real `setTimeout` sleep. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const DEFAULT_CREATE_PROJECT_RETRY_BACKOFF: BackoffOptions = {
+  initialMs: 500,
+  maxMs: 4_000,
+  factor: 2,
+  jitter: true,
+};
+
+function defaultRetrySleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Parse a create/write error body into a UI message + the retryable flag. */
+async function readWorkspaceWriteError(
+  resp: Response,
+  fallbackMessage: string,
+): Promise<{ message: string; retryable: boolean }> {
+  let message = fallbackMessage;
+  let retryable = false;
+  try {
+    const body = (await resp.json()) as { error?: unknown };
+    if (body.error && typeof body.error === 'object') {
+      const error = body.error as { message?: unknown; retryable?: unknown };
+      if (typeof error.message === 'string' && error.message.trim()) {
+        message = error.message;
+      }
+      if (error.retryable === true) retryable = true;
+    }
+  } catch {
+    // Keep the generic fallback when the error body is absent or invalid.
+  }
+  return { message, retryable };
+}
+
+/**
+ * Whether a failed workspace-scoped write should be retried. The daemon marks
+ * `WORKSPACE_AUTHORITY_UNAVAILABLE` (vela membership authority momentarily down)
+ * as a 503 `retryable: true`; a cross-workspace 403 or a validation 4xx is
+ * permanent and must surface immediately.
+ */
+function isRetryableWorkspaceWriteFailure(status: number, retryable: boolean): boolean {
+  return status === 503 && retryable;
+}
+
+export async function createProject(
+  input: {
+    name: string;
+    projectLocationId?: string;
+    skillId: string | null;
+    designSystemId: string | null;
+    pendingPrompt?: string;
+    metadata?: ProjectMetadata;
+    conversationMode?: ChatSessionMode;
+    // Plan §3.A1 / spec §11.5 — POST /api/projects accepts a pluginId
+    // (or pre-applied snapshot id) to resolve and pin a plugin to the new
+    // project. Used by the PluginLoopHome flow on Home.
+    pluginId?: string;
+    appliedPluginSnapshotId?: string;
+    pluginInputs?: Record<string, unknown>;
+    workspaceContext?: WorkspaceCollabContext | null;
+  },
+  retryOptions: CreateProjectRetryOptions = {},
+): Promise<{ project: Project; conversationId: string; appliedPluginSnapshotId?: string }> {
+  const maxRetries = retryOptions.maxRetries ?? 3;
+  const sleep = retryOptions.sleep ?? defaultRetrySleep;
+  const backoff = new BackoffController(
+    retryOptions.backoff ?? DEFAULT_CREATE_PROJECT_RETRY_BACKOFF,
+  );
   try {
     // `randomUUID` falls back to `crypto.getRandomValues` / `Math.random`
     // when `crypto.randomUUID` is unavailable. Open Design served over
@@ -498,44 +607,43 @@ export async function createProject(input: {
     // non-secure context, where `crypto.randomUUID` is undefined and
     // calling it directly throws — the surrounding try/catch then turns
     // the Create button into a silent no-op (issue #849).
+    //
+    // The id is minted ONCE and reused across retries: a retryable 503 fails
+    // vela's authority check before any row is inserted, so replaying the same
+    // client-provided id is idempotent, never a duplicate project.
     const id = randomUUID();
-    const resp = await fetch('/api/projects', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        ...(input.workspaceContext ? workspaceProjectHeaders(input.workspaceContext) : {}),
-      },
-      body: JSON.stringify({ id, ...omitWorkspaceContext(input) }),
-    });
-    if (!resp.ok) {
-      let message = 'Could not create project';
-      try {
-        const body = await resp.json() as { error?: unknown };
-        if (
-          body.error &&
-          typeof body.error === 'object' &&
-          'message' in body.error &&
-          typeof body.error.message === 'string' &&
-          body.error.message.trim()
-        ) {
-          message = body.error.message;
-        }
-      } catch {
-        // Keep the generic fallback when the error body is absent or invalid.
+    for (let attempt = 0; ; attempt += 1) {
+      const resp = await fetch('/api/projects', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(input.workspaceContext ? workspaceProjectHeaders(input.workspaceContext) : {}),
+        },
+        body: JSON.stringify({ id, ...omitWorkspaceContext(input) }),
+      });
+      if (resp.ok) {
+        const created = (await resp.json()) as {
+          project: Project;
+          conversationId: string;
+          appliedPluginSnapshotId?: string;
+        };
+        // Preserve the exact Workspace authority used by this create request.
+        // `useProjectCollab` may use this only to skip the initial status-unknown
+        // read-only window; another Workspace with the same project id must not
+        // inherit the signal.
+        markProjectCreatedByViewer(created.project.id, input.workspaceContext ?? null);
+        return created;
+      }
+      const { message, retryable } = await readWorkspaceWriteError(
+        resp,
+        'Could not create project',
+      );
+      if (isRetryableWorkspaceWriteFailure(resp.status, retryable) && attempt < maxRetries) {
+        await sleep(backoff.nextDelay());
+        continue;
       }
       throw new Error(message);
     }
-    const created = (await resp.json()) as {
-      project: Project;
-      conversationId: string;
-      appliedPluginSnapshotId?: string;
-    };
-    // Preserve the exact Workspace authority used by this create request.
-    // `useProjectCollab` may use this only to skip the initial status-unknown
-    // read-only window; another Workspace with the same project id must not
-    // inherit the signal.
-    markProjectCreatedByViewer(created.project.id, input.workspaceContext ?? null);
-    return created;
   } catch (err) {
     throw err instanceof Error ? err : new Error('Could not create project');
   }

--- a/apps/web/tests/components/Theater/state/sse.test.ts
+++ b/apps/web/tests/components/Theater/state/sse.test.ts
@@ -241,6 +241,8 @@ describe('critique SSE connection manager (Phase 7.2)', () => {
       EventSourceCtor: StubEventSource as unknown as typeof EventSource,
       initialBackoffMs: 1000,
       maxBackoffMs: 30_000,
+      // Pin jitter to its high edge (multiplier 1.0) so the base sequence shows.
+      randomFn: () => 1,
       setTimeoutFn,
     });
     expect(StubEventSource.instances).toHaveLength(1);
@@ -262,6 +264,28 @@ describe('critique SSE connection manager (Phase 7.2)', () => {
     StubEventSource.instances[1]!.fireError();
     expect(queue).toHaveLength(1);
     expect(queue[0]!.at - now).toBe(1000);
+  });
+
+  it('jitters each reconnect delay within [0.5, 1.0) of the base', () => {
+    const delays: number[] = [];
+    const setTimeoutFn = ((_fn: () => void, delay: number) => {
+      delays.push(delay);
+      // Do not fire: observe the scheduled delay per error only.
+      return delays.length as unknown as ReturnType<typeof setTimeout>;
+    }) as typeof setTimeout;
+
+    createCritiqueEventsConnection('proj-1', () => undefined, {
+      EventSourceCtor: StubEventSource as unknown as typeof EventSource,
+      initialBackoffMs: 1000,
+      maxBackoffMs: 30_000,
+      // random() = 0 → multiplier 0.5 (the low edge of the jitter window).
+      randomFn: () => 0,
+      setTimeoutFn,
+    });
+    const es = StubEventSource.instances[0]!;
+    for (let i = 0; i < 4; i += 1) es.fireError();
+    // Base 1000, 2000, 4000, 8000 → all halved by the low-edge jitter.
+    expect(delays).toEqual([500, 1000, 2000, 4000]);
   });
 
   it('close() cancels pending reconnects and stops the live source', () => {

--- a/apps/web/tests/lib/backoff.test.ts
+++ b/apps/web/tests/lib/backoff.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { BackoffController } from '../../src/lib/backoff';
+
+describe('BackoffController', () => {
+  it('produces a doubling sequence capped at maxMs (jitter off)', () => {
+    const backoff = new BackoffController({
+      initialMs: 1000,
+      maxMs: 30_000,
+      factor: 2,
+      jitter: false,
+    });
+    const delays = Array.from({ length: 8 }, () => backoff.nextDelay());
+    expect(delays).toEqual([1000, 2000, 4000, 8000, 16_000, 30_000, 30_000, 30_000]);
+  });
+
+  it('honors a custom growth factor', () => {
+    const backoff = new BackoffController({
+      initialMs: 100,
+      maxMs: 10_000,
+      factor: 3,
+      jitter: false,
+    });
+    expect([backoff.nextDelay(), backoff.nextDelay(), backoff.nextDelay()]).toEqual([
+      100, 300, 900,
+    ]);
+  });
+
+  it('counts attempts and resets both depth and attempt count on reset()', () => {
+    const backoff = new BackoffController({ initialMs: 1000, jitter: false });
+    expect(backoff.attempt).toBe(0);
+    backoff.nextDelay();
+    backoff.nextDelay();
+    expect(backoff.attempt).toBe(2);
+    // Depth advanced: the third delay would be 4000.
+    expect(backoff.nextDelay()).toBe(4000);
+
+    backoff.reset();
+    expect(backoff.attempt).toBe(0);
+    // Depth returned to the initial delay.
+    expect(backoff.nextDelay()).toBe(1000);
+  });
+
+  it('applies jitter as a multiplier in [0.5, 1.0) over the base sequence', () => {
+    // random() = 0 → multiplier 0.5 (the low edge).
+    const low = new BackoffController({ initialMs: 1000, jitter: true, random: () => 0 });
+    expect(low.nextDelay()).toBe(500); // 1000 * 0.5
+    expect(low.nextDelay()).toBe(1000); // base advanced to 2000, * 0.5
+
+    // random() ≈ 1 → multiplier ≈ 1.0 (the high edge, exclusive of the base).
+    const high = new BackoffController({
+      initialMs: 1000,
+      jitter: true,
+      random: () => 0.9999,
+    });
+    const first = high.nextDelay();
+    expect(first).toBeGreaterThan(999);
+    expect(first).toBeLessThan(1000);
+
+    // random() = 0.5 → multiplier 0.75.
+    const mid = new BackoffController({ initialMs: 1000, jitter: true, random: () => 0.5 });
+    expect(mid.nextDelay()).toBe(750);
+  });
+
+  it('keeps every jittered delay within [0.5, 1.0) of its base across random draws', () => {
+    let seed = 0;
+    // A deterministic pseudo-random walk over [0, 1) so the assertion is stable.
+    const backoff = new BackoffController({
+      initialMs: 1000,
+      maxMs: 8000,
+      jitter: true,
+      random: () => {
+        seed = (seed + 0.37) % 1;
+        return seed;
+      },
+    });
+    const bases = [1000, 2000, 4000, 8000, 8000];
+    for (const base of bases) {
+      const delay = backoff.nextDelay();
+      expect(delay).toBeGreaterThanOrEqual(base * 0.5);
+      expect(delay).toBeLessThan(base);
+    }
+  });
+
+  it('clamps maxMs up to initialMs when misconfigured', () => {
+    const backoff = new BackoffController({ initialMs: 5000, maxMs: 1000, jitter: false });
+    // maxMs cannot be below initialMs, so the sequence pins at 5000.
+    expect([backoff.nextDelay(), backoff.nextDelay()]).toEqual([5000, 5000]);
+  });
+});

--- a/apps/web/tests/providers/project-events.test.ts
+++ b/apps/web/tests/providers/project-events.test.ts
@@ -336,6 +336,9 @@ describe('createProjectEventsConnection', () => {
         EventSourceCtor: MockEventSource as unknown as typeof EventSource,
         initialBackoffMs: 100,
         maxBackoffMs: 800,
+        // Pin jitter to its high edge (multiplier 1.0) so the base doubling
+        // sequence is observable; the jitter range is covered separately.
+        randomFn: () => 1,
         setTimeoutFn: setTimeoutFn as unknown as typeof setTimeout,
         clearTimeoutFn: clearTimeoutFn as unknown as typeof clearTimeout,
       },
@@ -374,6 +377,7 @@ describe('createProjectEventsConnection', () => {
       {
         EventSourceCtor: MockEventSource as unknown as typeof EventSource,
         initialBackoffMs: 100,
+        randomFn: () => 1,
         setTimeoutFn: setTimeoutFn as unknown as typeof setTimeout,
       },
     );
@@ -387,6 +391,34 @@ describe('createProjectEventsConnection', () => {
     MockEventSource.instances[2]!.dispatch('error', {});
     expect(nextDelay).toBe(100);
 
+    conn.close();
+  });
+
+  it('jitters each reconnect delay within [0.5, 1.0) of the base', () => {
+    const delays: number[] = [];
+    const setTimeoutFn = vi.fn((_cb: () => void, ms: number) => {
+      delays.push(ms);
+      // Do NOT auto-fire: we only want to observe the scheduled delay per error.
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    });
+    const conn = createProjectEventsConnection(
+      'p1',
+      () => {},
+      {
+        EventSourceCtor: MockEventSource as unknown as typeof EventSource,
+        initialBackoffMs: 1000,
+        maxBackoffMs: 30_000,
+        // random() = 0 → multiplier 0.5 (the low edge of the jitter window).
+        randomFn: () => 0,
+        setTimeoutFn: setTimeoutFn as unknown as typeof setTimeout,
+      },
+    );
+    // Only one source exists (auto-fire disabled), so re-dispatch error on it to
+    // walk the backoff cursor without opening new connections.
+    const es = MockEventSource.instances[0]!;
+    for (let i = 0; i < 4; i += 1) es.dispatch('error', {});
+    // Base sequence 1000, 2000, 4000, 8000 → all halved by the low-edge jitter.
+    expect(delays).toEqual([500, 1000, 2000, 4000]);
     conn.close();
   });
 

--- a/apps/web/tests/state/projects.test.ts
+++ b/apps/web/tests/state/projects.test.ts
@@ -45,6 +45,10 @@ import {
   designBrowserHistoryStorageKey,
   designBrowserViewportStorageKey,
 } from '../../src/components/design-browser-storage';
+import {
+  currentWorkspaceContextRequestToken,
+  resetWorkspaceContextCache,
+} from '../../src/collab/useWorkspaceContext';
 
 function personalWorkspaceContext(): WorkspaceCollabContext {
   return {
@@ -557,6 +561,57 @@ describe('createProject', () => {
     })).toThrow('Workspace context is unavailable');
   });
 
+  it('passes a retained last-good context through a transient outage when it belongs to the current generation', () => {
+    // Task#5: a vela authority outage set `failure: 'unavailable'`, but the
+    // shell still holds a directory-verified context resolved under the CURRENT
+    // identity generation. The old fail-closed behavior threw here, which turned
+    // every create click during the outage into a dead button + retry storm.
+    // The backend re-verifies the claimed identity, so honor the cache.
+    resetWorkspaceContextCache();
+    const context = teamWorkspaceContext();
+    expect(resolvedWorkspaceContextForWrite({
+      context,
+      loading: false,
+      failure: 'unavailable',
+      resourceReadIdentity: {
+        context,
+        generation: currentWorkspaceContextRequestToken(),
+      },
+    })).toBe(context);
+  });
+
+  it('still fails closed when the retained context belongs to a RETIRED generation (account switch)', () => {
+    // An account switch advanced the request token; the state still carries the
+    // previous account's cached context stamped with the OLD generation. Passing
+    // it through would authorize a write under the wrong account (cross-account
+    // write). The generation mismatch must keep this fail-closed.
+    resetWorkspaceContextCache();
+    const previousAccountContext = teamWorkspaceContext();
+    expect(() => resolvedWorkspaceContextForWrite({
+      context: previousAccountContext,
+      loading: false,
+      failure: 'unavailable',
+      resourceReadIdentity: {
+        context: previousAccountContext,
+        generation: 'retired-generation',
+      },
+    })).toThrow('Workspace context is unavailable');
+
+    // And the unscoped policy yields null (not the stale context) in that case.
+    expect(resolvedWorkspaceContextForWrite(
+      {
+        context: previousAccountContext,
+        loading: false,
+        failure: 'unavailable',
+        resourceReadIdentity: {
+          context: previousAccountContext,
+          generation: 'retired-generation',
+        },
+      },
+      { unavailablePolicy: 'unscoped' },
+    )).toBeNull();
+  });
+
   it('allows an explicitly local project-create caller to remain unscoped while workspace sync is unresolved', () => {
     expect(resolvedWorkspaceContextForWrite(
       { context: null, loading: true },
@@ -588,6 +643,80 @@ describe('createProject', () => {
       loading: false,
       failure: 'unsupported',
     })).toBeNull();
+  });
+
+  // P1.C: the daemon returns 503 WORKSPACE_AUTHORITY_UNAVAILABLE (retryable) when
+  // vela's membership authority is momentarily down. Before this change the very
+  // first 503 threw straight through, so a create during a vela blip failed with
+  // zero retries and the user re-clicked into a storm. The write must ride out a
+  // transient authority outage with bounded backoff before surfacing an error.
+  it('retries a retryable 503 authority-unavailable response and then succeeds', async () => {
+    let calls = 0;
+    const fetchMock = vi.fn<typeof fetch>(async () => {
+      calls += 1;
+      if (calls === 1) {
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: 'WORKSPACE_AUTHORITY_UNAVAILABLE',
+              message: 'workspace membership authority is temporarily unavailable',
+              retryable: true,
+            },
+          }),
+          { status: 503, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      return new Response(
+        JSON.stringify({ project: { id: 'p1' }, conversationId: 'c1' }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const created = await createProject(
+      { name: 'Retry me', skillId: null, designSystemId: null },
+      { sleep: async () => {} },
+    );
+    expect(created.project.id).toBe('p1');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // The retry reuses the SAME client-provided project id (idempotent): the
+    // 503 fails the authority check before any row is written.
+    const firstBody = JSON.parse(
+      (fetchMock.mock.calls[0]![1] as RequestInit).body as string,
+    ) as { id: string };
+    const secondBody = JSON.parse(
+      (fetchMock.mock.calls[1]![1] as RequestInit).body as string,
+    ) as { id: string };
+    expect(secondBody.id).toBe(firstBody.id);
+  });
+
+  it('does not retry a 503 that is not marked retryable', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(
+      JSON.stringify({ error: { code: 'INTERNAL_ERROR', message: 'nope' } }),
+      { status: 503, headers: { 'content-type': 'application/json' } },
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(createProject(
+      { name: 'x', skillId: null, designSystemId: null },
+      { sleep: async () => {} },
+    )).rejects.toThrow('nope');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up after the retry budget when a retryable 503 persists', async () => {
+    const fetchMock = vi.fn<typeof fetch>(async () => new Response(
+      JSON.stringify({ error: { message: 'still down', retryable: true } }),
+      { status: 503, headers: { 'content-type': 'application/json' } },
+    ));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(createProject(
+      { name: 'x', skillId: null, designSystemId: null },
+      { maxRetries: 2, sleep: async () => {} },
+    )).rejects.toThrow('still down');
+    // Initial attempt + 2 retries.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/apps/web/tests/useWorkspaceContext.retry.test.tsx
+++ b/apps/web/tests/useWorkspaceContext.retry.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resetCoalescedGet } from '../src/lib/coalesced-get';
+import {
+  __setWorkspaceContextRetryBackoffForTests,
+  resetWorkspaceContextCache,
+  useWorkspaceContext,
+} from '../src/collab/useWorkspaceContext';
+import {
+  workspaceContextFixture,
+  workspaceDirectoryFixture,
+} from './helpers/workspace-context';
+
+const TEAM_CONTEXT = workspaceContextFixture({
+  workspaceId: 'workspace-team',
+  workspaceMemberId: 'member-team',
+  workspaceName: 'Team workspace',
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+// Silence the 30s compatibility poll / SSE floor so the ONLY re-reads a test
+// observes come from the failure-retry schedule under test.
+function makeDocumentHidden(): void {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => 'hidden',
+  });
+}
+
+describe('useWorkspaceContext failure retry (P1.B)', () => {
+  beforeEach(() => {
+    resetCoalescedGet();
+    resetWorkspaceContextCache();
+    makeDocumentHidden();
+    // Deterministic (jitter-off) schedule so the 1s→2s→4s growth is exact.
+    __setWorkspaceContextRetryBackoffForTests({
+      initialMs: 1000,
+      maxMs: 30_000,
+      factor: 2,
+      jitter: false,
+    });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+    vi.unstubAllGlobals();
+    __setWorkspaceContextRetryBackoffForTests(null);
+    resetCoalescedGet();
+    resetWorkspaceContextCache();
+  });
+
+  it('retries a failed context read with exponential backoff and resets after a success', async () => {
+    let failContext = true;
+    let contextReads = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === '/api/workspace/directory') {
+          return jsonResponse(workspaceDirectoryFixture([TEAM_CONTEXT]));
+        }
+        if (url === '/api/workspace/context') {
+          contextReads += 1;
+          if (failContext) {
+            return new Response(JSON.stringify({ error: 'boom' }), {
+              status: 500,
+              headers: { 'content-type': 'application/json' },
+            });
+          }
+          return jsonResponse({ context: TEAM_CONTEXT });
+        }
+        throw new Error(`unexpected fetch ${url}`);
+      }),
+    );
+
+    const flush = async (ms: number) => {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(ms);
+      });
+    };
+
+    const hook = renderHook(() => useWorkspaceContext());
+    await flush(0);
+    await flush(0);
+    // The mount read failed: exactly one attempt so far, marked unavailable.
+    expect(contextReads).toBe(1);
+    expect(hook.result.current.failure).toBe('unavailable');
+
+    // First retry lands at the base 1s delay.
+    await flush(1000);
+    expect(contextReads).toBe(2);
+
+    // Backed off: the second retry is 2s out, NOT another 1s.
+    await flush(1999);
+    expect(contextReads).toBe(2);
+    await flush(1);
+    expect(contextReads).toBe(3);
+
+    // Third retry is 4s out.
+    await flush(3999);
+    expect(contextReads).toBe(3);
+    await flush(1);
+    expect(contextReads).toBe(4);
+
+    // Recover: the next retry succeeds and the failure clears.
+    failContext = false;
+    await flush(8000); // fourth retry is 8s out
+    expect(contextReads).toBe(5);
+    expect(hook.result.current.context?.workspaceId).toBe(TEAM_CONTEXT.workspaceId);
+    expect(hook.result.current.failure).toBeUndefined();
+
+    // A later failure starts over at the base 1s delay — success reset the depth.
+    failContext = true;
+    // Drop the coalesced-read cache so the ambient focus refresh actually hits
+    // the network (and fails) instead of replaying the cached success.
+    resetCoalescedGet();
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'));
+    });
+    await flush(0);
+    const readsBeforeReset = contextReads; // the focus read failed → +1
+    // The retry is armed at the BASE 1s delay again, proving the depth reset.
+    await flush(999);
+    expect(contextReads).toBe(readsBeforeReset);
+    await flush(1);
+    expect(contextReads).toBe(readsBeforeReset + 1);
+  });
+});


### PR DESCRIPTION
## Why

**Use case:** while investigating yesterday's spike in project-creation failures (+1102% on 08-06, ~98 devices hitting it 885 times), I traced the root cause to the web client.

**Pain:** during a ~2h vela authority outage, the write gate (`resolvedWorkspaceContextForWrite`) threw `Workspace context is unavailable` the moment the workspace-context read reported a transient `unavailable` — **ignoring a perfectly good last-good context it was already holding**. Users saw "try again", clicked repeatedly, and produced a retry storm; a weak-network blip triggers the exact same self-inflicted failure. Auditing the area, the same "retry + backoff" concern is reimplemented several times across `apps/web` (three separate SSE reconnect loops, billing's fixed 5s, context with no retry at all, and **zero jitter anywhere**), so this also extracts a shared primitive that those sites now share.

## What users will see

- On a weak-network blip or a brief backend authority hiccup, **creating a project (and every other workspace write) no longer suddenly errors with "Workspace context is unavailable"** and no longer needs frantic retrying — the client proceeds on the identity it already resolved, and the daemon's directory check stays the authority (a permanent cross-workspace 403 or a validation 4xx still surfaces immediately).
- **After switching accounts**, a write never rides on the previous account's cached identity — a retired-generation cache still fails closed.
- A brief backend `503 WORKSPACE_AUTHORITY_UNAVAILABLE` during create now **auto-retries and succeeds**, invisibly to the user.

## Surface area

- [x] **Default behavior change** — workspace-context-dependent writes now proceed on a generation-matched cached identity during a transient outage instead of failing closed, and create/write auto-retries a retryable 503. No new UI element.

(No UI / keyboard / CLI / API-contract / extension-point / i18n / new-dependency surface.)

## Screenshots

No new UI element — behavior change only. Verified in a real browser; see Validation.

## Bug fix verification

- Test paths (red→green):
  - `apps/web/tests/state/projects.test.ts` — **A**: a retained last-good context is used while the read is `unavailable` (was RED with `Error: Workspace context is unavailable`); and a cache from a **retired generation** (account switch) still fails closed.
  - `apps/web/tests/state/projects.test.ts` — **C**: `retries a retryable 503 … succeeds` and `gives up after the retry budget` (was RED: one fetch, threw on the first 503; id minted once so the replay is idempotent).
  - `apps/web/tests/useWorkspaceContext.retry.test.tsx` — **B**: context retry fires at 1s→2s→4s, a recovering attempt clears `failure`, and a later failure re-arms at the base depth (no reset from an SSE early-trigger).
- Red on `main`, green on this branch? **yes** — each red spec was confirmed failing before the source change and green after.

## Validation

- `pnpm --filter @open-design/web typecheck` — pass
- `pnpm --filter @open-design/web test` — 6290 passed (+15 new), exit 0
- `pnpm typecheck` (repo-wide) — pass
- `pnpm guard` — pass
- **Real-Chrome E2E** (isolated runtime + a real signed-in workspace): composer project creation succeeds end-to-end (the change doesn't break the create/generate flow); injecting a first-attempt `503 retryable` on the create request still lands a created project → confirms **C**'s auto-retry fires. The weak-network `failure` state for **A** couldn't be forced from outside the browser (the client's context cache is intentionally resilient and didn't flip to `failure`), so that boundary is covered by the red→green unit specs above.
