### PR TITLE
fix(collab): mirror the owner's deriveddata- prefix rule

### DIFF
--- a/apps/daemon/src/collab/vela-cli-resource-adapter.ts
+++ b/apps/daemon/src/collab/vela-cli-resource-adapter.ts
@@ -73,7 +73,21 @@ const MEMBER_MIRROR_EXCLUDED_ENTRIES = [
   'terraform.tfstate',
   'terraform.tfstate.backup',
 ] as const;
-const MEMBER_MIRROR_EXCLUDED_PREFIXES = ['.env'] as const;
+/**
+ * Name prefixes a snapshot skips.
+ *
+ * `.env` is secret-bearing, so it is bare and matches any entry type — a
+ * `.env.local` file and a stray `.envrc` directory are equally unwelcome in a
+ * member mirror.
+ *
+ * `deriveddata-` mirrors the owner-side rule (`isIgnoredProjectDirName` treats
+ * any `deriveddata-*` name as hidden) and is directory-scoped for the same
+ * reason the generated-tree names are: a regular file starting with that
+ * prefix is ordinary project content. See
+ * {@link MEMBER_MIRROR_PUSH_EXCLUDED_ENTRIES} for the trailing-slash contract
+ * and why it degrades safely on a Vela that predates it.
+ */
+const MEMBER_MIRROR_EXCLUDED_PREFIXES = ['.env', 'deriveddata-/'] as const;
 
 /**
  * Every entry name a `vela resource push` snapshot skips.

--- a/apps/daemon/tests/vela-cli-resource-adapter.test.ts
+++ b/apps/daemon/tests/vela-cli-resource-adapter.test.ts
@@ -132,6 +132,8 @@ describe('createVelaCliResourceAdapter', () => {
       ...EXPECTED_PUSH_EXCLUDE_ARGS,
       '--exclude-prefix',
       '.env',
+      '--exclude-prefix',
+      'deriveddata-/',
     ]);
   });
 
@@ -153,6 +155,21 @@ describe('createVelaCliResourceAdapter', () => {
     const prefixAt = calls[0]!.indexOf('--exclude-prefix');
     expect(prefixAt).toBeGreaterThan(-1);
     expect(calls[0]![prefixAt + 1]).toBe('.env');
+  });
+
+  it('carries the owner-side deriveddata- prefix rule, directory-scoped', async () => {
+    const { run, calls } = recordingRun({ push: JSON.stringify({ version: 1 }) });
+    const adapter = createVelaCliResourceAdapter({ ...OPTS, run });
+    await adapter.publish({ projectId: 'p1', reason: 'edit' });
+
+    const prefixes = calls[0]!.flatMap((arg, i) =>
+      arg === '--exclude-prefix' ? [calls[0]![i + 1]!] : []);
+    // The owner hides any `deriveddata-*` DIRECTORY; a regular file starting
+    // with that prefix is ordinary content and must still reach members.
+    expect(prefixes).toContain('deriveddata-/');
+    expect(prefixes).not.toContain('deriveddata-');
+    // `.env` stays bare: a secret is unwelcome as a file or a directory.
+    expect(prefixes).toContain('.env');
   });
 
   it('scopes generated-tree exclusions to directories so same-named files still sync', async () => {
@@ -196,6 +213,8 @@ describe('createVelaCliResourceAdapter', () => {
       ...EXPECTED_PUSH_EXCLUDE_ARGS,
       '--exclude-prefix',
       '.env',
+      '--exclude-prefix',
+      'deriveddata-/',
       '--metadata-json',
       JSON.stringify({ name: 'Launch Deck', metadata: { kind: 'deck' } }),
     ]);


### PR DESCRIPTION
## Why

The owner side hides any `deriveddata-*` name — `isIgnoredProjectDirName` falls back to a `startsWith` check after its exact-name lookup — but the publish command only ever carried the `.env` prefix. So Xcode's prefixed derived-data directories (`deriveddata-Foo/`) still fanned out to every member mirror, while the plain `DerivedData/` name was handled. QA flagged the gap while validating #6564 (P1 in that report).

## What users will see

No visible change. Member mirrors of a team project stop receiving Xcode's prefixed derived-data directories, which the project owner's own file list already hides. Continues shrinking publish payloads for iOS/macOS projects.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change** — one more generated-directory family stops reaching member mirrors, matching what the owner already sees
- [ ] **None**

## Directory-scoped, like the rest

The rule is sent as `deriveddata-/`, not bare. The trailing slash is the directory-only form introduced in #6564: a regular project file whose name merely starts with that prefix is ordinary content and must still reach members. Same compatibility seam as well — a Vela older than powerformer/vela#1466 sees a prefix that no base name can start with, matches nothing, and publishes as before.

## Validation

`carries the owner-side deriveddata- prefix rule, directory-scoped` asserts the directory-scoped form is present and the bare form is not, and that `.env` stays bare (a secret is unwelcome as a file or a directory). Adapter suite 24/24 on top of current main.

End-to-end against the real Vela packer with the daemon's actual runtime lists: `deriveddata-cache/` is excluded while `deriveddata-notes.md` is published.

Follow-up to #6564; needs powerformer/vela#1466 (shipped in Vela CLI 0.0.31, bundled by #6603) to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)