### PR TITLE
fix(daemon): serve SPA fallback from static root

### DIFF
--- a/apps/daemon/src/static-spa.ts
+++ b/apps/daemon/src/static-spa.ts
@@ -29,6 +29,6 @@ export function registerStaticSpaFallback(app: Express, staticDir: string): void
   app.get('/*splat', (req, res, next) => {
     const indexPath = resolveStaticSpaFallbackPath(req, staticDir);
     if (indexPath == null) return next();
-    res.sendFile(indexPath);
+    res.sendFile('index.html', { root: staticDir });
   });
 }

--- a/apps/daemon/tests/routes/static-spa-fallback.test.ts
+++ b/apps/daemon/tests/routes/static-spa-fallback.test.ts
@@ -1,9 +1,12 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { resolveStaticSpaFallbackPath } from '../../src/server.js';
+import {
+  registerStaticSpaFallback,
+  resolveStaticSpaFallbackPath,
+} from '../../src/static-spa.js';
 
 describe('static SPA fallback', () => {
   let tempDir: string;
@@ -52,5 +55,24 @@ describe('static SPA fallback', () => {
     } finally {
       rmSync(emptyDir, { force: true, recursive: true });
     }
+  });
+
+  it('serves the shell relative to a hidden static root', () => {
+    const staticDir = path.join(tempDir, '.hermes', 'apps', 'web', 'out');
+    const indexPath = path.join(staticDir, 'index.html');
+    const app = { get: vi.fn() };
+    const response = { sendFile: vi.fn() };
+    const next = vi.fn();
+
+    expect(() => registerStaticSpaFallback(app as never, staticDir)).not.toThrow();
+    const handler = app.get.mock.calls[0]?.[1];
+    expect(handler).toBeTypeOf('function');
+
+    mkdirSync(staticDir, { recursive: true });
+    writeFileSync(indexPath, '<!doctype html>');
+    handler(request('/projects/proj-1'), response, next);
+
+    expect(response.sendFile).toHaveBeenCalledWith('index.html', { root: staticDir });
+    expect(next).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Fixes #6613

## Why

I found this while following the issue's reproducible deep-route failure. When Open Design is installed below a hidden directory such as `.hermes`, Express's `sendFile` dotfile handling rejects the absolute SPA shell path and returns a 404 for valid browser routes.

## What users will see

Reloading a valid deep project, conversation, or file route serves the SPA shell instead of an Express 404 page, including installations whose static directory is under a dot-prefixed path. API and asset misses keep their existing downstream handling.

## Surface area

- [ ] **UI**
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [x] **Default behavior change**
- [ ] **None**

## Screenshots

Not applicable. This is a daemon static-file response fix with no visual UI change.

## Bug fix verification

- Test path: `apps/daemon/tests/routes/static-spa-fallback.test.ts`
- The new hidden-static-root test was red against `main`: the handler passed the absolute `.hermes/.../index.html` path to `sendFile`.
- It is green on this branch after the handler uses `sendFile('index.html', { root: staticDir })`.

## Validation

- `pnpm --filter @open-design/daemon exec vitest run --config .tmp-vitest.config.ts` (4 tests passed; the temporary config only bypassed the repository's full-build setup because this sparse checkout does not contain the unrelated workspace packages)
- `git diff --check`
- Direct TypeScript harness confirmed the handler now passes the relative filename and static root.

## AI assistance

I used an AI agent to help inspect the reported failure, draft the focused regression test, and prepare the patch. I reviewed and understand the complete change, and I can revise it directly in response to feedback. The change adds no dependencies and is licensed under the repository's Apache-2.0 terms.

## Adjacent issues

None. API, artifact, frame, and framework-asset routing remain out of scope and are covered by the existing tests.
