### PR TITLE
fix(daemon): serve SPA fallback from hidden static roots

### DIFF
--- a/apps/daemon/src/static-spa.ts
+++ b/apps/daemon/src/static-spa.ts
@@ -29,6 +29,6 @@ export function registerStaticSpaFallback(app: Express, staticDir: string): void
   app.get('/*splat', (req, res, next) => {
     const indexPath = resolveStaticSpaFallbackPath(req, staticDir);
     if (indexPath == null) return next();
-    res.sendFile(indexPath);
+    res.sendFile('index.html', { root: staticDir });
   });
 }

--- a/apps/daemon/tests/routes/static-spa-fallback.test.ts
+++ b/apps/daemon/tests/routes/static-spa-fallback.test.ts
@@ -1,8 +1,11 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import http from 'node:http';
 import os from 'node:os';
 import path from 'node:path';
+import express from 'express';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { registerStaticSpaFallback } from '../../src/static-spa.js';
 import { resolveStaticSpaFallbackPath } from '../../src/server.js';
 
 describe('static SPA fallback', () => {
@@ -33,6 +36,46 @@ describe('static SPA fallback', () => {
       .toBe(path.join(tempDir, 'index.html'));
     expect(resolveStaticSpaFallbackPath(request('/projects/proj-1/files/index.html'), tempDir))
       .toBe(path.join(tempDir, 'index.html'));
+  });
+
+  it('serves deep routes when the static root contains a hidden directory', async () => {
+    const rootDir = mkdtempSync(path.join(os.tmpdir(), 'od-static-spa-hidden-'));
+    const staticDir = path.join(rootDir, '.hermes', 'apps', 'web', 'out');
+    mkdirSync(staticDir, { recursive: true });
+    writeFileSync(path.join(staticDir, 'index.html'), '<!doctype html><div id="root">SPA</div>');
+
+    const app = express();
+    registerStaticSpaFallback(app, staticDir);
+    const server = app.listen(0, '127.0.0.1');
+    await new Promise<void>((resolve, reject) => {
+      server.once('listening', resolve);
+      server.once('error', reject);
+    });
+
+    try {
+      const address = server.address();
+      if (address == null || typeof address === 'string') throw new Error('server did not bind');
+      const response = await new Promise<{ body: string; statusCode: number | undefined }>((resolve, reject) => {
+        const request = http.get({
+          host: '127.0.0.1',
+          path: '/projects/project-1/conversations/conversation-1/files/docs/task.md',
+          port: address.port,
+          headers: { Accept: 'text/html' },
+        }, (res) => {
+          let body = '';
+          res.setEncoding('utf8');
+          res.on('data', (chunk) => { body += chunk; });
+          res.on('end', () => resolve({ body, statusCode: res.statusCode }));
+        });
+        request.on('error', reject);
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toContain('<div id="root">SPA</div>');
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      rmSync(rootDir, { force: true, recursive: true });
+    }
   });
 
   it('leaves API and framework asset misses to downstream 404 handling', () => {


### PR DESCRIPTION
Fixes #6613

## Why

This fixes the reported deep-route 404 when the built static root is below a hidden directory such as `.hermes/apps/web/out`. The existing fallback resolved the correct absolute `index.html` path, but Express's `sendFile(path)` security handling treated the hidden path segment as a dotfile and returned 404.

## What users will see

Deep SPA routes continue to load the app shell even when the static build lives under a hidden directory. API, artifact, and framework-asset misses remain delegated to downstream 404 handling.

## Surface area

- [ ] **UI** — no UI code or design change
- [ ] **Keyboard shortcut**
- [ ] **CLI / env var**
- [ ] **API / contract**
- [ ] **Extension point**
- [ ] **i18n keys**
- [ ] **New top-level dependency**
- [ ] **Default behavior change** — bug fix for an existing fallback only
- [x] **None** — internal daemon route behavior and regression test only

## Bug fix verification

- Test path that reproduces the bug: `apps/daemon/tests/routes/static-spa-fallback.test.ts`
- The test went red on `main`: yes — the real Express request returned 404 for a deep route under `.hermes/apps/web/out`.
- The test is green on this branch: yes — `4/4` tests passed.
- The regression test uses a real Express server and HTTP request, not only path-resolution unit behavior.

## Implementation

- Keep the existing path-resolution and route guards.
- Use `res.sendFile('index.html', { root: staticDir })`, which preserves the intended static root while avoiding the hidden-directory rejection for the resolved relative file.

## Validation

- `corepack pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/routes/static-spa-fallback.test.ts` — PASS, 4 tests.
- `corepack pnpm --filter @open-design/daemon typecheck` — PASS.
- `corepack pnpm --filter @open-design/daemon build` — PASS.
- `git diff --check` — PASS.
- The full daemon suite was attempted. It exposed unrelated baseline failures in multiple existing suites and did not reach a final Vitest summary before the runner hung after later CLI tests; the focused regression, typecheck, and build all pass independently.
