### PR TITLE
fix Codebuddy model discovery from CLI help

### DIFF
--- a/apps/daemon/src/runtimes/defs/codebuddy.ts
+++ b/apps/daemon/src/runtimes/defs/codebuddy.ts
@@ -13,36 +13,30 @@ import type { RuntimeAgentDef } from '../types.js';
 // Key differences from the claude adapter:
 //   • Binary names: `codebuddy` / `cbc` (not `claude` / `openclaude`).
 //   • `--effort` flag for reasoning control (minimal/low/medium/high/xhigh/max).
-//   • Richer multi-provider model list (GLM, Kimi, MiniMax, Claude, GPT,
-//     Gemini, DeepSeek) exposed through `--model <id>`.
+//   • A multi-provider model list advertised in `--help` and selected through
+//     `--model <id>`.
 //   • `--mcp-config <fileOrString>` for MCP server injection (the daemon can
 //     also write `.mcp.json` to the project cwd, same as Claude Code).
 
-const CODEBUDDY_FALLBACK_MODELS = [
-  DEFAULT_MODEL_OPTION,
-  // GLM family (Zhipu AI)
-  { id: 'glm-5.1-ioa', label: 'glm-5.1-ioa' },
-  { id: 'glm-5v-turbo-ioa', label: 'glm-5v-turbo-ioa' },
-  // Claude family (via Codebuddy proxy)
-  { id: 'claude-opus-4.8-1m', label: 'claude-opus-4.8-1m' },
-  { id: 'claude-opus-4.8', label: 'claude-opus-4.8' },
-  { id: 'claude-sonnet-4.6-1m', label: 'claude-sonnet-4.6-1m' },
-  { id: 'claude-haiku-4.5', label: 'claude-haiku-4.5' },
-  // GPT family
-  { id: 'gpt-5.5', label: 'gpt-5.5' },
-  { id: 'gpt-5.4', label: 'gpt-5.4' },
-  { id: 'gpt-5.3-codex', label: 'gpt-5.3-codex' },
-  // Gemini family
-  { id: 'gemini-3.5-flash', label: 'gemini-3.5-flash' },
-  // DeepSeek family
-  { id: 'deepseek-v4-pro-ioa', label: 'deepseek-v4-pro-ioa' },
-  { id: 'deepseek-v4-flash-ioa', label: 'deepseek-v4-flash-ioa' },
-  // Kimi family
-  { id: 'kimi-k2.6-ioa', label: 'kimi-k2.6-ioa' },
-  // MiniMax family
-  { id: 'minimax-m3-ioa', label: 'minimax-m3-ioa' },
-  { id: 'minimax-m2.7-ioa', label: 'minimax-m2.7-ioa' },
-];
+function parseCodebuddyHelpModels(stdout: string) {
+  const advertised = stdout.match(
+    /--model <model>[\s\S]*?Currently supported:\s*\(([^)]*)\)/i,
+  )?.[1];
+  if (!advertised) return null;
+
+  const modelIds = [...new Set(
+    advertised
+      .split(',')
+      .map((modelId) => modelId.trim())
+      .filter((modelId) => modelId.length > 0 && modelId !== DEFAULT_MODEL_OPTION.id),
+  )];
+  if (modelIds.length === 0) return null;
+
+  return [
+    DEFAULT_MODEL_OPTION,
+    ...modelIds.map((modelId) => ({ id: modelId, label: modelId })),
+  ];
+}
 
 export const codebuddyAgentDef = {
     id: 'codebuddy',
@@ -59,10 +53,17 @@ export const codebuddyAgentDef = {
       '--include-partial-messages': 'partialMessages',
       '--add-dir': 'addDir',
     },
-    fallbackModels: CODEBUDDY_FALLBACK_MODELS,
-    // Codebuddy CLI does not ship a `models` subcommand; the supported model
-    // ids are advertised in `--help` output. Fallback list above covers the
-    // current set; users can type custom ids through the "Custom" input.
+    // Codebuddy has no `models` subcommand, but the installed build advertises
+    // its supported ids in root help. Parse that version-local catalog instead
+    // of surfacing a static list that drifts as Codebuddy updates.
+    listModels: {
+      args: ['--help'],
+      parse: parseCodebuddyHelpModels,
+      timeoutMs: 10_000,
+    },
+    // If an older build omits the catalog or help changes shape, fail closed to
+    // Codebuddy's configured default rather than offering unverified ids.
+    fallbackModels: [DEFAULT_MODEL_OPTION],
     // Codebuddy CLI --effort supports exactly 6 levels:
     //   minimal, low, medium, high, xhigh, max
     // We additionally expose a synthetic `default` sentinel as the FIRST

--- a/apps/daemon/tests/runtimes/codebuddy.test.ts
+++ b/apps/daemon/tests/runtimes/codebuddy.test.ts
@@ -124,16 +124,10 @@ describe('codebuddy definition metadata', () => {
     expect(codebuddyAgentDef.externalMcpInjection).toBe('claude-mcp-json');
   });
 
-  it('exposes fallback models with multi-provider coverage', () => {
-    const modelIds = codebuddyAgentDef.fallbackModels.map((m) => m.id);
-    expect(modelIds).toContain('default');
-    expect(modelIds).toContain('glm-5.1-ioa');
-    expect(modelIds).toContain('claude-opus-4.8');
-    expect(modelIds).toContain('gpt-5.5');
-    expect(modelIds).toContain('gemini-3.5-flash');
-    expect(modelIds).toContain('deepseek-v4-pro-ioa');
-    expect(modelIds).toContain('kimi-k2.6-ioa');
-    expect(modelIds).toContain('minimax-m3-ioa');
+  it('fails closed to the CLI-configured default when live model discovery is unavailable', () => {
+    expect(codebuddyAgentDef.fallbackModels).toEqual([
+      { id: 'default', label: 'Default (CLI config)' },
+    ]);
   });
 
   it('probes -p subcommand for capability flags', () => {
@@ -145,6 +139,44 @@ describe('codebuddy definition metadata', () => {
   it('provides install and docs URLs', () => {
     expect(codebuddyAgentDef.installUrl).toBe('https://www.codebuddy.cn');
     expect(codebuddyAgentDef.docsUrl).toBe('https://www.codebuddy.cn/docs/workbuddy/Overview');
+  });
+});
+
+describe('codebuddy model discovery', () => {
+  it('parses the model ids advertised by the installed CLI help', () => {
+    const help = `
+Options:
+  --model <model>  Model for the current session. Please provide the model ID. Currently supported: (hy3, glm-5.2, glm-5.1,
+                     glm-5v-turbo, minimax-m3, kimi-k3-1, deepseek-v4-pro)
+  --text-to-image-model <model>  Model for text-to-image generation
+`;
+
+    expect(codebuddyAgentDef.listModels?.args).toEqual(['--help']);
+    expect(codebuddyAgentDef.listModels?.parse(help)).toEqual([
+      { id: 'default', label: 'Default (CLI config)' },
+      { id: 'hy3', label: 'hy3' },
+      { id: 'glm-5.2', label: 'glm-5.2' },
+      { id: 'glm-5.1', label: 'glm-5.1' },
+      { id: 'glm-5v-turbo', label: 'glm-5v-turbo' },
+      { id: 'minimax-m3', label: 'minimax-m3' },
+      { id: 'kimi-k3-1', label: 'kimi-k3-1' },
+      { id: 'deepseek-v4-pro', label: 'deepseek-v4-pro' },
+    ]);
+  });
+
+  it('deduplicates advertised model ids while preserving CLI order', () => {
+    const help = '--model <model> Currently supported: (hy3, glm-5.2, hy3)';
+
+    expect(codebuddyAgentDef.listModels?.parse(help)?.map((model) => model.id)).toEqual([
+      'default',
+      'hy3',
+      'glm-5.2',
+    ]);
+  });
+
+  it('returns null when the CLI does not advertise a usable model catalog', () => {
+    expect(codebuddyAgentDef.listModels?.parse('--model <model> Model for the session')).toBeNull();
+    expect(codebuddyAgentDef.listModels?.parse('--model <model> Currently supported: ()')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Why

I hit this while running Open Design with Codebuddy Code 2.121.1. The model picker reported a hard-coded fallback catalog whose IDs did not overlap the models advertised by the installed CLI, so users could select stale or unsupported model IDs.

Codebuddy does not expose a `models` subcommand, but its root `--help` output includes the version-local supported model IDs. The adapter already probed the binary but never parsed that catalog.

## What users will see

When Codebuddy is installed, the model picker now reflects the model IDs advertised by that local Codebuddy version and reports the catalog as live. If an older build does not advertise a usable catalog, Open Design offers only `Default (CLI config)` instead of stale guesses.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys
- [ ] **New top-level dependency** — adding any new entry to the root `package.json`
- [x] **Default behavior change** — Codebuddy model options now come from the installed CLI
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Screenshots

Not applicable: this changes daemon-provided model data without adding or changing UI controls.

## Bug fix verification

- Test path: `apps/daemon/tests/runtimes/codebuddy.test.ts`
- Red on `main`: yes — 4 new assertions failed because `listModels` was absent and stale fallback IDs remained.
- Green on this branch: yes — 29/29 focused tests pass.
- Runtime verification: Codebuddy 2.121.1 changed from `modelsSource: fallback` to `modelsSource: live`; the returned IDs matched `codebuddy --help`.

## Validation

- ✅ `pnpm --filter @open-design/daemon exec vitest run -c vitest.config.ts tests/runtimes/codebuddy.test.ts`
- ✅ `pnpm --filter @open-design/daemon typecheck`
- ✅ `pnpm --filter @open-design/daemon build`
- ✅ Live systemd runtime probe against `GET /api/agents`
- ⚠️ `pnpm guard` is blocked on this checkout because `scripts/scopes.ts` imports the absent `e2e/lib/playwright/suites.ts`.
- ⚠️ Root `pnpm typecheck` reaches the unrelated desktop package, then fails because `@open-design/download` declarations are unavailable in this checkout; daemon typecheck passes.
- ⚠️ Full daemon tests hit the existing proxy connection test failure `reports malformed proxy env without leaking the connection-test timer`; the focused runtime suite passes.
