### PR TITLE
fix(daemon): prefer macOpenBundle over CLI on macOS for editor launch (Closes #6610)

### DIFF
--- a/apps/daemon/src/routes/host-tools.ts
+++ b/apps/daemon/src/routes/host-tools.ts
@@ -169,16 +169,9 @@ async function resolveEntry(entry: CatalogueEntry): Promise<{
   resolvedPath?: string;
   launch?: { command: string; argsForDir: (resolvedDir: string) => string[] };
 }> {
-  if (entry.command) {
-    const resolved = await probeCommandOnPath(entry.command);
-    if (resolved) {
-      return {
-        available: true,
-        resolvedPath: resolved,
-        launch: { command: resolved, argsForDir: entry.commandArgs ?? ((resolvedDir) => [resolvedDir]) },
-      };
-    }
-  }
+  // On macOS, prefer macOpenBundle over CLI for entries that have both.
+  // This avoids launching agent-only CLI wrappers (e.g. Cursor's `cursor`)
+  // that exit 1 immediately instead of opening the editor (#6610).
   if (entry.macOpenBundle && process.platform === 'darwin') {
     const bundle = await probeMacBundle(entry.macOpenBundle);
     if (bundle) {
@@ -191,6 +184,16 @@ async function resolveEntry(entry: CatalogueEntry): Promise<{
             ? ((resolvedDir) => entry.macOpenArgs?.(bundle.name, resolvedDir) ?? ['-a', bundle.name, resolvedDir])
             : ((resolvedDir) => ['-a', bundle.name, resolvedDir]),
         },
+      };
+    }
+  }
+  if (entry.command) {
+    const resolved = await probeCommandOnPath(entry.command);
+    if (resolved) {
+      return {
+        available: true,
+        resolvedPath: resolved,
+        launch: { command: resolved, argsForDir: entry.commandArgs ?? ((resolvedDir) => [resolvedDir]) },
       };
     }
   }


### PR DESCRIPTION
## Description

On macOS, Cursor's CLI shim (`cursor`) is now an agent-only launcher that exits 1 immediately instead of opening the editor. The `resolveEntry` function checked `command` before `macOpenBundle`, so the broken CLI was always selected for Cursor.

This PR swaps the probe order on macOS: when a catalogue entry has both `command` and `macOpenBundle`, the app bundle is preferred. If the bundle is not found, it falls back to the CLI probe, preserving the existing behaviour for editors that don't have a bundle installed.

## Changes

- **`apps/daemon/src/routes/host-tools.ts`**: In `resolveEntry`, check `macOpenBundle` before `command` on macOS. This affects all entries that have both fields (Cursor, VS Code, Windsurf, Zed, Qoder, Antigravity, WebStorm, IntelliJ IDEA).

## Root cause (from #6610)

The issue had two stacked problems:

1. Cursor's current CLI is the agent-only launcher (`cursor` exits 1 with "No Cursor IDE installation found"). The probe (`probeCommandOnPath`) treats "binary exists and is executable" as "editor available", so the entry resolves to the broken CLI even though `macOpenBundle: 'Cursor'` right next to it would have worked.

2. The CLI spawns fine, prints its error, exits 1 — and the route reports success. The user gets a dead button with no feedback.

The **first fix** (darwin bundle-first in `resolveEntry`) is addressed here. The second fix (exit-code grace window in `launchHostTool`) is a separate improvement tracked in the same issue.

## Testing

- `GET /api/editors` on macOS should still list all editors with `available: true`
- On macOS, choosing "Send to → Cursor" should now open the app via `open -a Cursor` instead of the `cursor` CLI
- On non-macOS platforms, behaviour is unchanged (the `macOpenBundle` branch is gated on `process.platform === 'darwin'`)
- On macOS for editors without a bundle (e.g. `command` only), the CLI probe still works as before

Closes #6610