### PR TITLE
fix(packaged): refresh install.json launchPath on payload launches

### DIFF
--- a/apps/packaged/src/launcher-runtime.ts
+++ b/apps/packaged/src/launcher-runtime.ts
@@ -485,7 +485,11 @@ export async function resolvePackagedLauncherRuntime(
     runtime: descriptor,
   });
   const persistedInstall = await readLauncherInstallDescriptor(launcherPaths, channel, config.namespace).catch(() => null);
-  const currentPackageLaunchPath = stableAppLaunchPathFromExecutable(process.execPath);
+  // Track the stable launch path of the CURRENT launcher executable (the
+  // `currentExecutablePath` option, defaulting to process.execPath), so the
+  // payload branch can refresh install.json when an update moved the launcher
+  // (issue #6494) instead of keeping a stale persisted launchPath forever.
+  const currentPackageLaunchPath = stableAppLaunchPathFromExecutable(currentExecutablePath);
 
   if (selection.selected) {
     const versionPaths = resolveLauncherVersionPaths({
@@ -522,12 +526,34 @@ export async function resolvePackagedLauncherRuntime(
           version: selection.pointer.version,
         } satisfies LauncherAttemptDescriptor);
       }
+      // Issue #6494: the payload branch previously only READ the persisted
+      // install.json launchPath (written by the cold-start current-package
+      // branch) and never refreshed it, so after an update that moved the
+      // launcher executable (0.17.0 Local\Programs\... → 0.18.0 launcher
+      // payload), the stale path kept flowing into the MCP bootstrap
+      // command published by /api/mcp/install-info, making MCP clients
+      // relaunch the old executable on the same sidecar pipe until the
+      // launcher's stale-sidecar sweep killed the fresh daemon. Refresh
+      // install.json so launchPath tracks the current launcher executable
+      // across updates. Only the launcher process owns the descriptor: a
+      // delegated payload desktop runs from the versioned payload exe and
+      // must keep the stable launch path the launcher persisted.
+      const installedLaunchPath = !payloadDesktopProcess
+        && (persistedInstall == null
+          || !sameExecutablePath(persistedInstall.launchPath, currentPackageLaunchPath))
+        ? (await writeLauncherInstallDescriptor(
+          launcherPaths,
+          channel,
+          config.namespace,
+          currentPackageLaunchPath,
+        )).launchPath
+        : (persistedInstall?.launchPath ?? currentPackageLaunchPath);
       return {
         config: payloadConfig.config,
         desktopExecutablePath: payloadConfig.desktopExecutablePath,
         descriptor,
         electronNodeCommand: payloadConfig.electronNodeCommand,
-        installedLaunchPath: persistedInstall?.launchPath ?? currentPackageLaunchPath,
+        installedLaunchPath,
         launcherPaths,
         paths: { ...paths, resourceRoot: payloadConfig.config.resourceRoot },
         payloadDesktopProcess,

--- a/apps/packaged/tests/launcher-runtime.test.ts
+++ b/apps/packaged/tests/launcher-runtime.test.ts
@@ -145,7 +145,12 @@ describe("resolvePackagedLauncherRuntime", () => {
         })}\n`,
       );
 
-      const runtime = await resolvePackagedLauncherRuntime(config, paths);
+      const runtime = await resolvePackagedLauncherRuntime(config, paths, {
+        // The launcher process runs from the stable installed app bundle, so
+        // its stable launch path matches the persisted install descriptor and
+        // the payload branch keeps the persisted entry untouched.
+        currentExecutablePath: "/Applications/Open Design Beta.app",
+      });
 
       expect(runtime.source).toBe("payload");
       expect(runtime.desktopExecutablePath).toBe(payloadExecutablePath);
@@ -208,6 +213,106 @@ describe("resolvePackagedLauncherRuntime", () => {
       expect(JSON.parse(await readFile(resumedRuntime.launcherPaths.runtimePath, "utf8"))).toMatchObject({
         active: { generation: 1, version: "1.2.3-beta.5" },
         lastSuccessful: { generation: 1, version: "1.2.3-beta.5" },
+      });
+    } finally {
+      await rm(root, { force: true, recursive: true });
+    }
+  });
+
+  it("refreshes install.json launchPath to the current launcher executable when the persisted path is stale", async () => {
+    // Issue #6494: the payload branch only READ the persisted install.json
+    // launchPath (written by the cold-start current-package branch) and never
+    // refreshed it, so after an update that moved the launcher executable
+    // (0.17.0 Local\Programs\... → 0.18.0 launcher payload), the stale path
+    // kept flowing into OD_MCP_BOOTSTRAP_COMMAND and /api/mcp/install-info.
+    const root = await mkdtemp(join(tmpdir(), "od-packaged-launcher-install-refresh-"));
+    try {
+      const config = fakeConfig(root, "1.2.3-beta.4");
+      const paths = resolvePackagedNamespacePaths(config);
+      const versionPaths = resolveLauncherVersionPaths({
+        channel: "beta",
+        namespace: config.namespace,
+        root,
+        version: "1.2.3-beta.5",
+      });
+      const resourcesPath = join(versionPaths.payloadRoot, "Open Design Beta.app", "Contents", "Resources");
+      const payloadExecutablePath = join(
+        versionPaths.payloadRoot,
+        "Open Design Beta.app",
+        "Contents",
+        "MacOS",
+        "Open Design Beta",
+      );
+      await mkdir(join(resourcesPath, "open-design", "bin"), { recursive: true });
+      await mkdir(join(versionPaths.payloadRoot, "Open Design Beta.app", "Contents", "MacOS"), { recursive: true });
+      await mkdir(join(resourcesPath, "prebundled", "daemon"), { recursive: true });
+      await mkdir(join(resourcesPath, "prebundled", "web"), { recursive: true });
+      await writeFile(join(resourcesPath, "open-design", "bin", "node"), "");
+      await writeFile(payloadExecutablePath, "");
+      await writeFile(join(resourcesPath, "prebundled", "daemon", "daemon-sidecar.mjs"), "");
+      await writeFile(join(resourcesPath, "prebundled", "web", "web-sidecar.mjs"), "");
+      await writeFile(
+        join(resourcesPath, "open-design-config.json"),
+        `${JSON.stringify({
+          appVersion: "1.2.3-beta.5",
+          daemonSidecarEntryRelative: "prebundled/daemon/daemon-sidecar.mjs",
+          nodeCommandRelative: "open-design/bin/node",
+          webOutputMode: "standalone",
+          webSidecarEntryRelative: "prebundled/web/web-sidecar.mjs",
+        })}\n`,
+      );
+      await writeFile(
+        versionPaths.manifestPath,
+        `${JSON.stringify({
+          channel: "beta",
+          entry: {
+            cwd: "payload/Open Design Beta.app",
+            executable: "payload/Open Design Beta.app/Contents/MacOS/Open Design Beta",
+          },
+          namespace: config.namespace,
+          payloadRoot: "payload",
+          platform: "darwin",
+          schemaVersion: LAUNCHER_SCHEMA_VERSION,
+          version: "1.2.3-beta.5",
+        })}\n`,
+      );
+      await mkdir(join(paths.installationRoot, "launcher", "channels", "beta", "namespaces", config.namespace), { recursive: true });
+      await writeFile(
+        join(paths.installationRoot, "launcher", "channels", "beta", "namespaces", config.namespace, "runtime.json"),
+        `${JSON.stringify({
+          active: { generation: 1, version: "1.2.3-beta.5" },
+          channel: "beta",
+          lastSuccessful: { generation: 0, version: "1.2.3-beta.4" },
+          namespace: config.namespace,
+          schemaVersion: LAUNCHER_SCHEMA_VERSION,
+        })}\n`,
+      );
+      // The persisted descriptor points at the previous install location
+      // (e.g. the 0.17.0 Local\Programs\... exe), which no longer matches
+      // the launcher executable that resolved this payload.
+      const installPath = join(paths.installationRoot, "launcher", "channels", "beta", "namespaces", config.namespace, "install.json");
+      await writeFile(
+        installPath,
+        `${JSON.stringify({
+          channel: "beta",
+          launchPath: "/Applications/Open Design Legacy.app",
+          namespace: config.namespace,
+          schemaVersion: LAUNCHER_SCHEMA_VERSION,
+        })}\n`,
+      );
+
+      const runtime = await resolvePackagedLauncherRuntime(config, paths, {
+        currentExecutablePath: "/Applications/Open Design Beta.app",
+      });
+
+      expect(runtime.source).toBe("payload");
+      expect(runtime.payloadDesktopProcess).toBe(false);
+      expect(runtime.installedLaunchPath).toBe("/Applications/Open Design Beta.app");
+      expect(JSON.parse(await readFile(installPath, "utf8"))).toMatchObject({
+        channel: "beta",
+        launchPath: "/Applications/Open Design Beta.app",
+        namespace: config.namespace,
+        schemaVersion: LAUNCHER_SCHEMA_VERSION,
       });
     } finally {
       await rm(root, { force: true, recursive: true });


### PR DESCRIPTION
Fixes #6494

## Why

I hit this myself on Windows: after 0.17.0 → 0.18.0, the desktop app launched but its daemon-sidecar was killed within seconds — `/api/*` unreachable, MCP bootstrap timing out with "daemon did not become ready within 60000ms", and the launcher stuck in a `stale-sidecar` restart loop. The issue thread (and lefarcen's analysis) pinned the root cause: `writeLauncherInstallDescriptor` is only called on the cold-start `current-package` path, while the payload branch at `launcher-runtime.ts:530` reads the persisted `install.json` `launchPath` and **never overwrites it**. So the 0.17.0-era `launchPath` (`Local\Programs\Open Design\Open Design.exe`) survived the update and flowed into the MCP bootstrap command (`OD_MCP_BOOTSTRAP_COMMAND` → `/api/mcp/install-info`), making every MCP client relaunch the **old 0.17.0 executable** on the same sidecar IPC pipe — which the launcher's `stale-sidecar` sweep then mistook for a foreign daemon and killed, restart-looping the desktop.

## What users will see

Windows users who update from 0.17.x to 0.18.0 no longer get a desktop that opens but has a dead daemon (broken workspace/project views, unreachable `/api/*`, MCP install timing out). The daemon-sidecar now survives launch, exactly as in 0.17.0.

## Surface area

- [ ] **UI** — new page / dialog / panel / menu item / setting / empty state in `apps/web` or `apps/desktop` (including Electron menu bar)
- [ ] **Keyboard shortcut** — new or changed
- [ ] **CLI / env var** — new `od` subcommand or flag, new `tools-dev` / `tools-pack` flag, or new `OD_*` env var
- [ ] **API / contract** — new `/api/*` endpoint, new SSE event, or changed shape in `packages/contracts`
- [ ] **Extension point** — new entry under `skills/`, `design-systems/`, `design-templates/`, or `craft/`, or change to the skills protocol
- [ ] **i18n keys** — added new translation keys (see `TRANSLATIONS.md` for the locale workflow)
- [ ] **New top-level dependency** — adding any new entry to the **root** `package.json` (`dependencies` or `devDependencies`); workspace-package `package.json` files are out of scope. Include a paragraph on what we get vs. what bytes we ship (see `CONTRIBUTING.md` → Code style)
- [x] **Default behavior change** — the payload branch now refreshes a persisted descriptor it previously left stale
- [ ] **None** — internal refactor, docs, tests, or translation update only

## Bug fix verification

- Test path that reproduces the bug: `apps/packaged/tests/launcher-runtime.test.ts` → "refreshes install.json launchPath to the current launcher executable when the persisted path is stale"
- Did the test go red on `main` and green on this branch? **yes** — verified by stashing only the source change: 1 failed / 6 passed on `main`, 7 passed on this branch.
- Full `apps/packaged` suite: 292 passed, 5 failed — the 5 failures are pre-existing FUSE/AppImage mount tests in `prewarm.test.ts` that fail identically on a clean `main` checkout on this Windows host (Linux-only feature).

## How the fix works

In `resolvePackagedLauncherRuntime`'s payload branch, when the persisted `install.json` `launchPath` no longer matches the current launcher executable's stable launch path (`stableAppLaunchPathFromExecutable(currentExecutablePath)`), the branch now rewrites `install.json` via `writeLauncherInstallDescriptor` and returns the refreshed path. That breaks the stale-exe chain: `OD_MCP_BOOTSTRAP_COMMAND` (and thus `/api/mcp/install-info`) now publishes the current launcher executable, so MCP clients stop spawning a rival 0.17.0 daemon on the sidecar pipe. Only the launcher process (payload desktop not yet spawned, `payloadDesktopProcess === false`) refreshes the descriptor — a delegated payload desktop runs from the versioned payload exe and must keep the stable launch path the launcher persisted.

## Validation

- `pnpm --filter @open-design/launcher-proto --filter @open-design/sidecar-proto --filter @open-design/release --filter @open-design/sidecar --filter @open-design/platform --filter @open-design/desktop build` — passed
- `pnpm --filter @open-design/packaged test` — launcher-runtime suite 7/7 green; full suite green except pre-existing FUSE tests (verified pre-existing on clean `main`)
- `tsc -p tsconfig.json --noEmit` and `tsc -p tsconfig.tests.json --noEmit` — clean
