### PR TITLE
fix(web): restore undo/redo buttons and keyboard shortcuts in manual edit mode (Fixes #6609)

### DIFF
--- a/apps/web/src/components/ManualEditPanel.tsx
+++ b/apps/web/src/components/ManualEditPanel.tsx
@@ -3,6 +3,7 @@ import type { ProjectDesignTokenSuggestion, ProjectDesignTokenSuggestionProp } f
 import { useT } from '../i18n';
 import { emptyManualEditStyles, type ManualEditHistoryEntry, type ManualEditPatch, type ManualEditStyles, type ManualEditTarget } from '../edit-mode/types';
 import { Icon } from './Icon';
+import { isMacPlatform } from '../utils/platform';
 
 export interface ManualEditDraft {
   text: string;
@@ -49,6 +50,8 @@ export function ManualEditPanel({
   onFloatingPositionChange,
   locked = false,
   onToggleLock,
+  canUndo,
+  canRedo,
 }: {
   targets: ManualEditTarget[];
   selectedTarget: ManualEditTarget | null;
@@ -99,6 +102,24 @@ export function ManualEditPanel({
   useEffect(() => {
     selectedTargetRef.current = selectedTarget;
   }, [selectedTarget]);
+
+  // Keyboard shortcut: Ctrl+Z / Cmd+Z for undo, Ctrl+Shift+Z / Cmd+Shift+Z for redo
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const primary = (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey;
+      const primaryShift = (e.metaKey || e.ctrlKey) && e.shiftKey && !e.altKey;
+      if (e.isComposing) return;
+      if (primary && e.key.toLowerCase() === 'z') {
+        e.preventDefault();
+        onUndo();
+      } else if (primaryShift && e.key.toLowerCase() === 'z') {
+        e.preventDefault();
+        onRedo();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown, { capture: true });
+    return () => window.removeEventListener('keydown', onKeyDown, { capture: true });
+  }, [onUndo, onRedo]);
 
   const changeTargetStyle = (key: keyof ManualEditStyles, value: string) => {
     const nextStyles = { ...draft.styles, [key]: value };
@@ -303,6 +324,26 @@ export function ManualEditPanel({
         <div className="manual-edit-footer">
           <div className="manual-edit-footer-actions">
             <div className="manual-edit-footer-left">
+              <button
+                type="button"
+                className="manual-edit-delete-btn"
+                aria-label={t('manualEdit.undo')}
+                title={`${t('manualEdit.undo')} (${isMacPlatform() ? '⌘Z' : 'Ctrl+Z'})`}
+                disabled={busy || !canUndo}
+                onClick={onUndo}
+              >
+                <Icon name="undo" size={15} />
+              </button>
+              <button
+                type="button"
+                className="manual-edit-delete-btn"
+                aria-label={t('manualEdit.redo')}
+                title={`${t('manualEdit.redo')} (${isMacPlatform() ? '⇧⌘Z' : 'Ctrl+Shift+Z'})`}
+                disabled={busy || !canRedo}
+                onClick={onRedo}
+              >
+                <Icon name="redo" size={15} />
+              </button>
               {targetForInspector ? (
                 <button
                   type="button"


### PR DESCRIPTION
## Summary

Fixes #6609 — the undo/redo functionality in manual edit mode was broken in 0.18.1.

## Why

The manual edit v2 refactor (PR #5890) reworked the history mechanism but dropped the undo/redo **UI buttons** and **keyboard shortcut handlers** from the `ManualEditPanel`. As a result, both Ctrl+Z and the toolbar undo button stopped working for delete-element and edit-text operations — a regression from 0.17.x, confirmed by the maintainer and matching #2866.

## What users will see

- The undo/redo buttons reappear in the manual edit panel footer (left side, beside the delete button).
- Ctrl+Z / Cmd+Z now undoes the last manual edit, and Ctrl+Shift+Z / Cmd+Shift+Z redoes it.
- Buttons are disabled (greyed out) when there is nothing to undo/redo, and while a save is in progress.
- Button tooltips show the keyboard shortcut for the current platform.

## Surface area checklist

- [x] Web UI (manual edit panel)
- [ ] CLI
- [ ] i18n keys (uses existing `manualEdit.undo`/`manualEdit.redo`)
- [ ] skills / design-systems / craft
- [ ] env vars / config
- [ ] new dependencies

## Validation

The change is a pure UI/UX restoration in `apps/web/src/components/ManualEditPanel.tsx`:
- Undo/redo buttons render in the footer and call the existing `onUndo`/`onRedo` props (wired to `undoManualEdit`/`redoManualEdit` in `FileViewer.tsx`, whose behavior is already covered by `FileViewer.manual-edit-history.test.tsx`).
- Keyboard shortcut handler added via `useEffect` with capture-phase keydown.
- `canUndo`/`canRedo` already flow from `FileViewer` (`manualEditHistory.length > 0` / `manualEditUndone.length > 0`).

Fixes #6609