### PR TITLE
fix(web): auto-refresh file preview when tab becomes visible (#6630)

### DIFF
--- a/apps/web/src/components/ProjectView.tsx
+++ b/apps/web/src/components/ProjectView.tsx
@@ -3886,6 +3886,23 @@ export function ProjectView({
     },
   }, projectRunWorkspaceContext);
 
+  // Auto-refresh file list when the tab becomes visible (e.g., after
+  // editing a file externally). This provides a fallback for environments
+  // where the chokidar file watcher cannot detect external changes (Docker,
+  // certain filesystem mounts). The coalesced callback already debounces
+  // rapid visibility toggles. Fixes #6630.
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') {
+        coalescedFileChangedRefresh();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisible);
+    };
+  }, [coalescedFileChangedRefresh]);
+
   const activePromptContextSignature = useMemo(() => {
     const skill = project.skillId
       ? (skills.find((s) => s.id === project.skillId) ??


### PR DESCRIPTION
## Summary

Fixes #6630: the built-in HTML preview does not refresh after a file is edited and saved by an external process.

## Root cause

The preview refresh depends on the daemon's chokidar file watcher firing a `file-changed` SSE event, which bumps `filesRefresh` and propagates new mtimes through to the FileViewer iframes (`?v=${mtime}` cache-bust). In environments where chokidar cannot observe external filesystem changes (Docker/Coolify containers, certain filesystem mounts), that event never fires, so the preview keeps rendering the stale HTML — even though the file on disk and the daemon's file endpoints already contain the latest content.

## Fix

Add a `visibilitychange` listener in `ProjectView` that triggers the same `coalescedFileChangedRefresh()` pipeline when the user returns to the Open Design tab (e.g. after editing the file in an external editor). This is a reliable fallback that works regardless of whether the OS file watcher works.

- Reuses the existing debounced `coalescedFileChangedRefresh()` (wait 80ms / maxWait 250ms), so rapid visibility toggles coalesce into a single refresh.
- Mirrors the existing pattern already used for preview comments (which refresh on visibilitychange).
- No new endpoints, no new dependencies.

## Test plan

- Open an HTML file in the built-in preview.
- Modify and save the same file in an external editor.
- Switch back to Open Design — the preview now auto-reloads with the latest content.
